### PR TITLE
fix(remote-job): reap workers abandoned by a pruned code root

### DIFF
--- a/bin/fm-remote-job-lib.sh
+++ b/bin/fm-remote-job-lib.sh
@@ -37,6 +37,18 @@
 # with logs under ~/Library/Logs. Linux starts the same worker process without
 # an Aqua requirement. The launch-agent renderer and repair helpers here are
 # shared by the entrypoint and remote doctor so their ownership cannot drift.
+#
+# The Linux start path puts the worker tree in its own process group, so
+# stopping a worker signals its restart supervisor, its serving child, and any
+# job descendant together instead of leaving a supervisor to restart what was
+# just killed. fm_remote_job_stop_worker_tree owns that stop and refuses to
+# signal a group whose leader is not itself a worker, so a worker inherited
+# from an older build or from launchd's own session is still stopped safely as
+# a single process. fm_remote_job_root_is_live is the shared predicate for
+# whether a worker's code root still exists; bin/fm-remote-job-worker.sh uses
+# it to stop itself once its root is pruned, and
+# bin/fm-remote-job-reap-orphans.sh uses it to reap workers that were already
+# orphaned that way.
 
 FM_REMOTE_JOB_LABEL=dev.firstmate.remote-job
 FM_REMOTE_JOB_MAX_BYTES=${FM_REMOTE_JOB_MAX_BYTES:-1048576}
@@ -692,6 +704,65 @@ fm_remote_job_process_command() {
   printf '%s\n' "$value"
 }
 
+fm_remote_job_process_pgid() { # <pid>
+  local pid=$1 ps_bin value
+  if [ -x /bin/ps ]; then ps_bin=/bin/ps; elif [ -x /usr/bin/ps ]; then ps_bin=/usr/bin/ps; else return 1; fi
+  value=$("$ps_bin" -p "$pid" -o pgid= 2>/dev/null) || return 1
+  value=$(printf '%s' "$value" | tr -d '[:space:]')
+  case "$value" in ''|*[!0-9]*) return 1 ;; esac
+  printf '%s\n' "$value"
+}
+
+# The code root a worker serves is still a genuine Firstmate checkout. A worker
+# whose root fails this can never claim, validate, or execute another job, so
+# the same predicate decides both self-termination and orphan reaping.
+fm_remote_job_root_is_live() { # <remote-root>
+  local root=$1
+  [ -n "$root" ] || return 1
+  [ -d "$root" ] && [ ! -L "$root" ] || return 1
+  [ -f "$root/AGENTS.md" ] && [ ! -L "$root/AGENTS.md" ] || return 1
+  [ -f "$root/bin/fm-remote-job-worker.sh" ] && [ ! -L "$root/bin/fm-remote-job-worker.sh" ]
+}
+
+# The isolated process group that owns <pid>'s whole worker tree, echoed only
+# when signalling it is provably safe: the group is not this shell's own, not a
+# reserved id, and its leader is itself a remote job worker. A worker started
+# without group isolation (an older build, or launchd's own session) therefore
+# never yields a group, and callers fall back to signalling the single process.
+fm_remote_job_worker_process_group() { # <pid>
+  local pid=$1 pgid own_pgid leader_command
+  pgid=$(fm_remote_job_process_pgid "$pid") || return 1
+  case "$pgid" in 0|1) return 1 ;; esac
+  own_pgid=$(fm_remote_job_process_pgid "$$") || return 1
+  [ "$pgid" != "$own_pgid" ] || return 1
+  leader_command=$(fm_remote_job_process_command "$pgid" 2>/dev/null || true)
+  case "$leader_command" in *fm-remote-job-worker.sh*) ;; *) return 1 ;; esac
+  printf '%s\n' "$pgid"
+}
+
+# Stop a worker and every descendant it leaked, TERM first and KILL only for a
+# survivor. Signals the isolated worker group when one is provable and the lone
+# process otherwise. Returns non-zero when the worker is still alive afterwards.
+fm_remote_job_stop_worker_tree() { # <pid>
+  local pid=$1 pgid i=0
+  case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$pid" -gt 1 ] || return 1
+  pgid=$(fm_remote_job_worker_process_group "$pid" 2>/dev/null || true)
+  if [ -n "$pgid" ]; then kill -TERM -- "-$pgid" 2>/dev/null || true; else kill -TERM "$pid" 2>/dev/null || true; fi
+  while kill -0 "$pid" 2>/dev/null && [ "$i" -lt 50 ]; do
+    i=$((i + 1))
+    sleep 0.1
+  done
+  kill -0 "$pid" 2>/dev/null || return 0
+  if [ -n "$pgid" ]; then kill -KILL -- "-$pgid" 2>/dev/null || true; else kill -KILL "$pid" 2>/dev/null || true; fi
+  i=0
+  while kill -0 "$pid" 2>/dev/null && [ "$i" -lt 50 ]; do
+    i=$((i + 1))
+    sleep 0.1
+  done
+  ! kill -0 "$pid" 2>/dev/null
+}
+
 fm_remote_job_read_single_line() {
   local file=$1 max=$2 value extra
   fm_remote_job_regular_bounded "$file" "$max" || return 1
@@ -849,7 +920,7 @@ fm_remote_job_reload_launchagent() { # <account-home> <uid>
 }
 
 fm_remote_job_start_linux_worker() { # <remote-root> <account-home>
-  local root=$1 account_home=$2 worker pid i
+  local root=$1 account_home=$2 worker pid
   worker="$root/bin/fm-remote-job-worker.sh"
   [ -f "$worker" ] && [ ! -L "$worker" ] && [ -x "$worker" ] || {
     FM_REMOTE_JOB_ERROR="remote job worker is not a genuine executable in the configured code root"
@@ -858,23 +929,21 @@ fm_remote_job_start_linux_worker() { # <remote-root> <account-home>
   fm_remote_job_prepare_state "$account_home" || return 1
   if fm_remote_job_worker_owned_alive "$root" "$account_home"; then
     if fm_remote_job_worker_identity_matches "$root" "$account_home"; then return 0; fi
+    # The owner pid is the serving child; its restart supervisor sits above it
+    # and would immediately replace a lone process kill, so stop the whole
+    # worker tree through its isolated group.
     pid=$FM_REMOTE_JOB_OWNER_PID
-    kill -TERM "$pid" 2>/dev/null || {
-      FM_REMOTE_JOB_ERROR="could not stop the stale remote job worker"
+    fm_remote_job_stop_worker_tree "$pid" || {
+      FM_REMOTE_JOB_ERROR="stale remote job worker did not stop safely"
       return 1
     }
     wait "$pid" 2>/dev/null || true
-    i=0
-    while kill -0 "$pid" 2>/dev/null && [ "$i" -lt 100 ]; do
-      i=$((i + 1))
-      sleep 0.1
-    done
-    if kill -0 "$pid" 2>/dev/null; then
-      FM_REMOTE_JOB_ERROR="stale remote job worker did not stop safely"
-      return 1
-    fi
     FM_REMOTE_JOB_REPAIRED=1
   fi
+  # Job control puts the worker tree in its own process group, so a later stop
+  # can signal every descendant at once without ever reaching the caller's own
+  # group. Without this the group of a leaked worker is the launching command's.
+  set -m
   nohup env \
     HOME="$account_home" \
     FM_ROOT_OVERRIDE="$root" \
@@ -882,6 +951,7 @@ fm_remote_job_start_linux_worker() { # <remote-root> <account-home>
     FM_REMOTE_JOB_PLATFORM_OVERRIDE="${FM_REMOTE_JOB_PLATFORM_OVERRIDE:-}" \
     "$worker" >> "$FM_REMOTE_JOB_STATE/logs/$FM_REMOTE_JOB_LABEL.log" 2>&1 < /dev/null &
   pid=$!
+  set +m
   case "$pid" in ''|*[!0-9]*) FM_REMOTE_JOB_ERROR="could not start the remote job worker"; return 1 ;; esac
   FM_REMOTE_JOB_REPAIRED=1
 }

--- a/bin/fm-remote-job-reap-orphans.sh
+++ b/bin/fm-remote-job-reap-orphans.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Reap remote job workers whose code root no longer exists.
+#
+# Usage: fm-remote-job-reap-orphans.sh [--dry-run]
+#   --dry-run reports what would be reaped and signals nothing.
+#
+# A remote job worker (bin/fm-remote-job-worker.sh) is launched from a specific
+# Firstmate code root: the account's own checkout under the LaunchAgent, a
+# remote secondmate's checkout, a no-mistakes gate worktree, a pooled task
+# worktree, or a test fixture root. When that root is pruned while the worker is
+# running, the worker is reparented to init and, on older builds, keeps polling
+# and logging indefinitely. Current workers stop themselves once their root is
+# gone (bin/fm-remote-job-worker.sh); this sweep is the belt-and-suspenders pass
+# that clears workers already orphaned that way, including ones started before
+# self-termination shipped.
+#
+# The reap condition is exactly fm_remote_job_root_is_live failing for the root
+# named in the worker's own command line. That is deliberately the whole test:
+# a worker whose root is gone can never claim, validate, or execute another job,
+# and no healthy worker can present a missing root. The account's healthy
+# LaunchAgent worker, a live remote secondmate's worker, and any worker whose
+# checkout still exists are therefore never candidates, with no dependence on
+# log paths, process age, or which home is sweeping.
+#
+# Only this user's processes are inspected, and this process, its own process
+# group, and any ancestor are never signalled. Each candidate is stopped through
+# the shared fm_remote_job_stop_worker_tree, so the whole worker tree goes at
+# once (TERM first, KILL only for a survivor) and a group whose leader is not
+# itself a worker is stopped as a single process instead.
+#
+# Prints one line per reaped or surviving candidate and nothing when there is
+# nothing to do. Exits 0 unless the process scan itself could not run, so a
+# caller can sweep without risking its own outcome.
+set -u
+
+SCRIPT_DIR=$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+
+# shellcheck source=bin/fm-remote-job-lib.sh
+. "$SCRIPT_DIR/fm-remote-job-lib.sh"
+
+DRY_RUN=0
+REAP_SUFFIX=/bin/fm-remote-job-worker.sh
+
+reap_die() { printf 'fm-remote-job-reap-orphans: %s\n' "$1" >&2; exit 2; }
+
+reap_usage() {
+  cat <<'TXT'
+Usage: fm-remote-job-reap-orphans.sh [--dry-run]
+
+Stop every remote job worker whose Firstmate code root has been pruned. A
+worker whose root still exists - the account's LaunchAgent worker, a live
+remote secondmate's worker - is never a candidate. --dry-run reports the
+candidates and signals nothing. Read this script's header for the full rule.
+TXT
+}
+
+# The code root a worker command line was launched from, echoed only when the
+# command is unambiguously a worker invocation: an absolute script path ending
+# in the worker suffix, optionally preceded by the interpreter ps reports as
+# "/bin/bash <script>", with at most the --serve argument after it.
+reap_worker_root() { # <command>
+  local command=$1 path prefix leading
+  case "$command" in
+    *"$REAP_SUFFIX --serve") path=${command%" --serve"} ;;
+    *"$REAP_SUFFIX") path=$command ;;
+    *) return 1 ;;
+  esac
+  prefix=${path%"$REAP_SUFFIX"}
+  case "$prefix" in /*) ;; *) return 1 ;; esac
+  leading=${prefix%% *}
+  # Drop the leading token only when it really is the interpreter binary, so a
+  # code root that itself contains a space is read whole rather than split.
+  if [ "$leading" != "$prefix" ] && [ -f "$leading" ] && [ -x "$leading" ]; then
+    prefix=${prefix#"$leading" }
+  fi
+  case "$prefix" in /*) ;; *) return 1 ;; esac
+  printf '%s\n' "$prefix"
+}
+
+reap_is_self_or_ancestor() { # <pid>
+  local pid=$1 walk=$$ i=0
+  while [ "$walk" -gt 1 ] && [ "$i" -lt 64 ]; do
+    [ "$walk" != "$pid" ] || return 0
+    walk=$(ps -p "$walk" -o ppid= 2>/dev/null | tr -d '[:space:]') || return 0
+    case "$walk" in ''|*[!0-9]*) return 1 ;; esac
+    i=$((i + 1))
+  done
+  return 1
+}
+
+reap_orphans() {
+  local uid scan pid command live root own_pgid pgid
+  uid=$(id -u 2>/dev/null || true)
+  case "$uid" in ''|*[!0-9]*) reap_die "cannot resolve the current uid" ;; esac
+  scan=$(ps -u "$uid" -o pid=,command= 2>/dev/null) ||
+    reap_die "cannot scan this account's processes for remote job workers"
+  own_pgid=$(fm_remote_job_process_pgid "$$" 2>/dev/null || true)
+  # ps pads the pid column to the widest pid on the host, so the fields are read
+  # with default word splitting rather than by fixed offsets or a single space.
+  while read -r pid command; do
+    case "$pid" in ''|*[!0-9]*) continue ;; esac
+    [ -n "$command" ] || continue
+    root=$(reap_worker_root "$command") || continue
+    fm_remote_job_root_is_live "$root" && continue
+    [ "$pid" != "$$" ] || continue
+    reap_is_self_or_ancestor "$pid" && continue
+    if [ -n "$own_pgid" ]; then
+      pgid=$(fm_remote_job_process_pgid "$pid" 2>/dev/null || true)
+      [ "$pgid" != "$own_pgid" ] || continue
+    fi
+    # Re-read the command from the live process so a recycled pid cannot be
+    # signalled on the strength of a stale scan line.
+    live=$(fm_remote_job_process_command "$pid" 2>/dev/null || true)
+    read -r live <<< "$live"
+    [ "$live" = "$command" ] || continue
+    if [ "$DRY_RUN" -eq 1 ]; then
+      printf 'would reap abandoned remote job worker %s (pruned code root %s)\n' "$pid" "$root"
+      continue
+    fi
+    if fm_remote_job_stop_worker_tree "$pid"; then
+      printf 'reaped abandoned remote job worker %s (pruned code root %s)\n' "$pid" "$root"
+    else
+      printf 'warning: abandoned remote job worker %s survived reaping (pruned code root %s)\n' "$pid" "$root" >&2
+    fi
+  done <<EOF
+$scan
+EOF
+}
+
+case "${1:-}" in
+  '') ;;
+  --dry-run) DRY_RUN=1; [ "$#" -eq 1 ] || reap_die "unexpected arguments" ;;
+  -h|--help) reap_usage; exit 0 ;;
+  *) reap_die "unexpected argument: $1" ;;
+esac
+
+reap_orphans

--- a/bin/fm-remote-job-worker.sh
+++ b/bin/fm-remote-job-worker.sh
@@ -14,7 +14,32 @@
 # record is marked done only after its bounded outputs and numeric exit status
 # have been committed. The library header owns the exact record fields and
 # lifecycle.
+#
+# The worker is abandoned when its configured FM_ROOT stops being a genuine
+# Firstmate checkout - the state a pruned no-mistakes gate worktree, a returned
+# pooled worktree, or a removed test fixture root leaves behind. It can never
+# validate or execute another job from a root that is gone, so both the serving
+# loop and the Linux restart supervisor stop instead of polling forever
+# reparented to init. FM_REMOTE_JOB_ORPHAN_GRACE_SECONDS is how long the root
+# must stay missing before that counts, so an ordinary transient never stops a
+# healthy worker. The supervisor additionally refuses to restart a child that
+# keeps failing immediately: it backs off up to
+# FM_REMOTE_JOB_SUPERVISOR_MAX_BACKOFF_SECONDS and gives up after
+# FM_REMOTE_JOB_SUPERVISOR_MAX_RESTARTS consecutive failures, since a restart
+# loop that never stays up only burns CPU and grows its log without bound. A
+# child that stays up for FM_REMOTE_JOB_SUPERVISOR_HEALTHY_SECONDS clears that
+# count. fm-on's ensure path restarts a worker that gave up.
 set -u
+
+# A non-numeric override falls back to the default rather than crashing the
+# arithmetic that bounds these loops.
+worker_bounded_setting() { # <value> <default>
+  case "$1" in ''|*[!0-9]*) printf '%s\n' "$2" ;; *) printf '%s\n' "$1" ;; esac
+}
+FM_REMOTE_JOB_ORPHAN_GRACE_SECONDS=$(worker_bounded_setting "${FM_REMOTE_JOB_ORPHAN_GRACE_SECONDS:-}" 5)
+FM_REMOTE_JOB_SUPERVISOR_MAX_RESTARTS=$(worker_bounded_setting "${FM_REMOTE_JOB_SUPERVISOR_MAX_RESTARTS:-}" 20)
+FM_REMOTE_JOB_SUPERVISOR_MAX_BACKOFF_SECONDS=$(worker_bounded_setting "${FM_REMOTE_JOB_SUPERVISOR_MAX_BACKOFF_SECONDS:-}" 5)
+FM_REMOTE_JOB_SUPERVISOR_HEALTHY_SECONDS=$(worker_bounded_setting "${FM_REMOTE_JOB_SUPERVISOR_HEALTHY_SECONDS:-}" 10)
 
 SCRIPT_DIR=$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
 FM_ROOT=${FM_ROOT_OVERRIDE:-$(CDPATH='' cd "$SCRIPT_DIR/.." && pwd -P)}
@@ -179,6 +204,21 @@ worker_cleanup() {
   rm -f -- "$WORKER_LOCK/pid" "$WORKER_LOCK/start" "$WORKER_LOCK/command" 2>/dev/null || true
   rmdir "$WORKER_LOCK" 2>/dev/null || true
   WORKER_LOCK_HELD=0
+}
+
+# The configured code root is gone and stayed gone across the grace window, so
+# this worker has nothing left to serve. Confirming over the window keeps a
+# momentary read during an ordinary checkout operation from stopping a healthy
+# worker.
+worker_code_root_abandoned() {
+  local waited=0
+  fm_remote_job_root_is_live "$FM_ROOT" && return 1
+  while [ "$waited" -lt "$FM_REMOTE_JOB_ORPHAN_GRACE_SECONDS" ]; do
+    sleep 1
+    waited=$((waited + 1))
+    fm_remote_job_root_is_live "$FM_ROOT" && return 1
+  done
+  return 0
 }
 
 worker_read_process_id() { # <file>
@@ -648,6 +688,12 @@ main() {
   worker_publish_pid || { worker_error "cannot publish worker pid"; exit 1; }
   while :; do
     worker_write_heartbeat || { worker_error "cannot update worker heartbeat"; exit 1; }
+    # Checked right after a fresh heartbeat, so the grace window cannot make a
+    # still-healthy worker read as unready to a concurrent probe.
+    if worker_code_root_abandoned; then
+      worker_error "configured FM_ROOT $FM_ROOT no longer exists; stopping the abandoned worker"
+      exit 0
+    fi
     worker_reap=0
     if [ "$worker_reap" -eq 0 ]; then
       fm_remote_job_reap_stale "$account_home" || true
@@ -688,13 +734,18 @@ worker_supervisor_shutdown() {
 }
 
 worker_supervise_linux() {
-  local account_home child_status
+  local account_home child_status started failures=0 backoff
   account_home=$(worker_account_home) || { worker_error "cannot resolve account home"; return 1; }
   FM_ROOT=$(fm_remote_job_canonical_existing_dir "$FM_ROOT") || { worker_error "configured FM_ROOT is unsafe"; return 1; }
   [ -f "$FM_ROOT/AGENTS.md" ] && [ ! -L "$FM_ROOT/AGENTS.md" ] || { worker_error "FM_ROOT is not a Firstmate checkout"; return 1; }
   fm_remote_job_prepare_state "$account_home" || { worker_error "$FM_REMOTE_JOB_ERROR"; return 1; }
   trap worker_supervisor_shutdown HUP INT TERM
   while :; do
+    if worker_code_root_abandoned; then
+      worker_error "configured FM_ROOT $FM_ROOT no longer exists; stopping the abandoned worker supervisor"
+      return 0
+    fi
+    started=$SECONDS
     "$SCRIPT_DIR/fm-remote-job-worker.sh" --serve &
     WORKER_SUPERVISED_PID=$!
     wait "$WORKER_SUPERVISED_PID" 2>/dev/null
@@ -709,7 +760,20 @@ worker_supervise_linux() {
     fi
     worker_supervisor_cleanup_dead_child "$account_home" "$WORKER_SUPERVISED_PID" || true
     WORKER_SUPERVISED_PID=
-    sleep 0.1
+    if [ $((SECONDS - started)) -ge "$FM_REMOTE_JOB_SUPERVISOR_HEALTHY_SECONDS" ]; then
+      failures=0
+      sleep 0.1
+      continue
+    fi
+    failures=$((failures + 1))
+    if [ "$failures" -ge "$FM_REMOTE_JOB_SUPERVISOR_MAX_RESTARTS" ]; then
+      worker_error "remote job worker failed $failures times without staying up; stopping the supervisor"
+      return 1
+    fi
+    backoff=$failures
+    [ "$backoff" -le "$FM_REMOTE_JOB_SUPERVISOR_MAX_BACKOFF_SECONDS" ] ||
+      backoff=$FM_REMOTE_JOB_SUPERVISOR_MAX_BACKOFF_SECONDS
+    sleep "$backoff"
   done
 }
 

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -121,6 +121,16 @@
 #     roots are unique per task and never
 #     shared, so this can never reach another task's or the primary's
 #     processes. Idempotent: nothing left to find is a silent no-op.
+#   Fix 3 - sweep abandoned remote job workers. A remote job worker started
+#     from a worktree's own bin/ outlives that worktree's removal without
+#     being reachable by Fix 2, because its working directory is wherever it
+#     was launched rather than the task worktree (observed 2026-08-07: 29
+#     workers at ppid 1, 1-2 days old, each still polling and appending to a
+#     log in a pruned no-mistakes gate worktree). bin/fm-remote-job-reap-orphans.sh
+#     owns that sweep and its safety rule; it never touches a worker whose code
+#     root still exists, so the account's healthy LaunchAgent worker and every
+#     live remote secondmate worker are out of scope. Best effort: a sweep
+#     failure never blocks this teardown.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -2202,6 +2212,10 @@ if [ "$KIND" != secondmate ]; then
   conclude_task_no_mistakes_run "$WT"
   reap_task_worktree_processes worktree "$WT" "$TASK_TMP"
 fi
+
+# Fix 3 (see script header): sweep remote job workers abandoned by an already
+# pruned code root. Best effort - a sweep failure never blocks this teardown.
+"$SCRIPT_DIR/fm-remote-job-reap-orphans.sh" >&2 || true
 
 # A Herdr close may reposition shared workspace order, so the whole
 # destructive sequence below (worktree return, pane close, record removal)

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -164,7 +164,7 @@ family_for_basename() {
       printf '%s\n' real-herdr-gated
       ;;
     fm-backlog-handoff.test.sh|fm-on.test.sh|fm-remote-backlog-handoff.test.sh|\
-    fm-remote-doctor.test.sh|fm-remote-job.test.sh|\
+    fm-remote-doctor.test.sh|fm-remote-job.test.sh|fm-remote-job-orphan-reap.test.sh|\
     fm-remote-reply.test.sh|fm-remote-secondmate-lifecycle-e2e.test.sh|\
     fm-remote-secondmate-trace-context.test.sh|\
     fm-secondmate-harness.test.sh|fm-secondmate-lifecycle-e2e.test.sh|\

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -35,6 +35,7 @@ After that bootstrap every non-doctor `fm-on.sh` target runs through that worker
 The worker runs one staged job at a time and preempts a running reply long-poll as soon as any command other than another reply long-poll is queued, so interactive commands and startup checks are never serialized behind a poll window.
 `bin/fm-remote-job-lib.sh` owns that preemption contract, and a preempted poll is indistinguishable from one whose wait window closed with no data, so the re-armed poll loses nothing.
 Linux uses the same queue and worker protocol without the Aqua-session requirement.
+A worker stops itself once its configured code root stops being a Firstmate checkout, so a worker started from a worktree cannot outlive that worktree, and `bin/fm-remote-job-reap-orphans.sh` clears any worker already left behind that way without ever touching one whose checkout still exists.
 The remote account must provide the required toolchain, the selected worker runtime, the selected session backend, and credentials that work on that host.
 The origin URL named for each project must be reachable from the remote account because projects are cloned on that host rather than copied from the primary.
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -21,6 +21,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-on.sh`               | Execute one tracked Firstmate command in a configured remote secondmate home, using its job worker except for the doctor bootstrap |
 | `fm-remote-job-lib.sh`   | Shared bounded remote job queue, worker readiness, LaunchAgent contract, and filesystem-composed PATH |
 | `fm-remote-job-worker.sh` | Long-lived remote queue worker for tracked `fm-*.sh` commands in the account runtime |
+| `fm-remote-job-reap-orphans.sh` | Stop remote job workers left running by a pruned code root, never one whose checkout still exists |
 | `fm-remote-doctor.sh`    | Check, and with `--fix` repair, one remote account's second-mate readiness (remote job worker, Herdr, Aqua launch agents, PATH, and required tools) |
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-backlog-receive.sh`  | Idempotently ingest one confined remote handoff outbox through tasks-axi             |

--- a/tests/fm-remote-job-orphan-reap.test.sh
+++ b/tests/fm-remote-job-orphan-reap.test.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# Behavior tests for remote job workers abandoned by a pruned code root.
+#
+# The leak this pins: a worker launched from a worktree's own bin/ outlives that
+# worktree. Its restart supervisor sits above the serving child, so killing the
+# recorded worker pid only makes the supervisor respawn, and nothing else ever
+# stops it. Observed 2026-08-07 as 29 workers at ppid 1, 1-2 days old, each
+# still appending to a log in a pruned no-mistakes gate worktree.
+#
+# bin/fm-remote-job-reap-orphans.sh is a machine-wide sweep by design, so these
+# cases assert only about their own fixture processes. Any other worker it
+# stops during the run had a pruned code root too, which is exactly the
+# contract.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+TMP_ROOT=$(fm_test_tmproot fm-remote-job-orphan-reap)
+TMP_ROOT=$(cd "$TMP_ROOT" && pwd -P)
+REAPER="$ROOT/bin/fm-remote-job-reap-orphans.sh"
+
+TRACKED_PIDS=()
+orphan_cleanup() {
+  local pid
+  for pid in "${TRACKED_PIDS[@]:-}"; do
+    [ -n "$pid" ] || continue
+    kill -KILL -- "-$pid" 2>/dev/null || true
+    kill -KILL "$pid" 2>/dev/null || true
+  done
+  fm_test_cleanup
+}
+trap orphan_cleanup EXIT
+
+track() { TRACKED_PIDS+=("$1"); }
+
+alive() { kill -0 "$1" 2>/dev/null; }
+
+pgid_of() { ps -p "$1" -o pgid= 2>/dev/null | tr -d '[:space:]'; }
+
+ppid_of() { ps -p "$1" -o ppid= 2>/dev/null | tr -d '[:space:]'; }
+
+# Wait up to <seconds> for <pid> to exit; 0 when it did.
+wait_gone() { # <pid> <seconds>
+  local pid=$1 deadline=$(( $(date +%s) + $2 ))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    alive "$pid" || return 0
+    sleep 0.1
+  done
+  ! alive "$pid"
+}
+
+# Wait up to <seconds> for <pid> to have a live child; 0 when it does.
+wait_child() { # <pid> <seconds>
+  local pid=$1 deadline=$(( $(date +%s) + $2 ))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    [ -n "$(pgrep -P "$pid" 2>/dev/null || true)" ] && return 0
+    sleep 0.1
+  done
+  return 1
+}
+
+# --- a real worker fixture, launched exactly the way fm-on's Linux start does -
+
+# build_remote_root <dir>: a minimal but genuine Firstmate code root carrying
+# the real worker and job library.
+build_remote_root() {
+  local root=$1
+  mkdir -p "$root/bin"
+  cp "$ROOT/bin/fm-remote-job-lib.sh" "$ROOT/bin/fm-remote-job-worker.sh" "$root/bin/"
+  chmod +x "$root/bin"/*.sh
+  printf 'fixture\n' > "$root/AGENTS.md"
+  git -C "$root" init -q -b main
+  git -C "$root" config user.email test@example.com
+  git -C "$root" config user.name Test
+  git -C "$root" add AGENTS.md bin
+  git -C "$root" commit -qm 'remote job fixture'
+}
+
+# start_worker <remote-root> <account-home> <state-root>: start the worker
+# through the shared library start path and echo the supervisor pid.
+start_worker() {
+  local root=$1 account_home=$2 state_root=$3 pid
+  pid=$(
+    export FM_REMOTE_JOB_STATE_ROOT="$state_root"
+    export FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux
+    export FM_REMOTE_JOB_ORPHAN_GRACE_SECONDS=1
+    # shellcheck source=bin/fm-remote-job-lib.sh
+    . "$ROOT/bin/fm-remote-job-lib.sh"
+    fm_remote_job_start_linux_worker "$root" "$account_home" >&2 || exit 1
+    pgrep -f "^/bin/bash $root/bin/fm-remote-job-worker.sh\$" | head -n 1
+  ) || return 1
+  case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+  printf '%s\n' "$pid"
+}
+
+CASE1="$TMP_ROOT/case1"
+mkdir -p "$CASE1/account"
+build_remote_root "$CASE1/remote-root"
+WORKER=$(start_worker "$CASE1/remote-root" "$CASE1/account" "$CASE1/remote-jobs") ||
+  fail "could not start the fixture remote job worker"
+track "$WORKER"
+wait_child "$WORKER" 10 || fail "the fixture worker never started its serving child"
+SERVE=$(pgrep -P "$WORKER" | head -n 1)
+
+[ "$(pgid_of "$WORKER")" = "$WORKER" ] ||
+  fail "the started worker is not its own process group leader, so its tree cannot be signalled as one group"
+[ "$(pgid_of "$SERVE")" = "$WORKER" ] ||
+  fail "the serving child is outside the worker's process group"
+pass "the Linux start path puts the whole worker tree in its own process group"
+
+[ "$(ppid_of "$WORKER")" = 1 ] ||
+  fail "the fixture worker is not orphaned to init, so this case does not reproduce the leak"
+
+# The exact teardown shape that leaked in production: a fixture cleanup removes
+# the worker's state root and then TERMs the single recorded worker pid - which
+# is the serving child, not the supervisor. The supervisor respawns, so the tree
+# survives a teardown that looks complete.
+rm -rf "$CASE1/remote-jobs"
+kill -TERM "$SERVE" 2>/dev/null || true
+wait_gone "$SERVE" 10 || fail "the serving child ignored TERM"
+alive "$WORKER" || fail "the fixture supervisor did not survive a lone child kill, so this case no longer covers the leak"
+wait_child "$WORKER" 15 || fail "the supervisor did not respawn after its recorded child pid was killed"
+pass "removing the state root and killing the recorded worker pid leaves the tree running at ppid 1"
+
+# A worker whose code root is intact is never a reap candidate, which is what
+# keeps the account's healthy LaunchAgent worker out of scope.
+out=$("$REAPER" 2>&1) || fail "the reaper failed against a live code root: $out"
+assert_not_contains "$out" "$WORKER" "the reaper reported a worker whose code root still exists"
+alive "$WORKER" || fail "the reaper stopped a worker whose code root still exists"
+pass "a worker whose code root still exists is never reaped"
+
+# Prune the code root the way a returned worktree does.
+SURVIVOR=$(pgrep -P "$WORKER" | head -n 1)
+rm -rf "$CASE1/remote-root"
+wait_gone "$WORKER" 60 || fail "the worker survived its code root being pruned"
+wait_gone "$SURVIVOR" 60 || fail "a serving child outlived the abandoned supervisor"
+pass "a worker stops its whole tree once its code root is pruned"
+
+# --- the belt-and-suspenders sweep over already-orphaned workers -------------
+#
+# A current worker stops itself, so the sweep is exercised against a stand-in
+# that presents the same command line from a pruned root without that
+# self-termination - the shape of every worker started before it shipped.
+
+CASE2="$TMP_ROOT/case2"
+mkdir -p "$CASE2/remote-root/bin"
+cat > "$CASE2/remote-root/bin/fm-remote-job-worker.sh" <<'SH'
+#!/bin/bash
+# Stand-in for a worker predating self-termination: a supervisor that always
+# respawns its serving child and never inspects its own code root.
+set -u
+if [ "${1:-}" = --serve ]; then
+  while :; do sleep 0.2; done
+fi
+while :; do
+  "$0" --serve &
+  wait $! 2>/dev/null
+  sleep 0.2
+done
+SH
+chmod +x "$CASE2/remote-root/bin/fm-remote-job-worker.sh"
+printf 'fixture\n' > "$CASE2/remote-root/AGENTS.md"
+
+set -m
+"$CASE2/remote-root/bin/fm-remote-job-worker.sh" >/dev/null 2>&1 &
+STALE=$!
+set +m
+track "$STALE"
+wait_child "$STALE" 10 || fail "the stand-in worker never started its serving child"
+STALE_SERVE=$(pgrep -P "$STALE" | head -n 1)
+
+rm -rf "$CASE2/remote-root"
+
+out=$("$REAPER" --dry-run 2>&1) || fail "the reaper dry run failed: $out"
+assert_contains "$out" "$STALE" "the dry run did not report the abandoned worker"
+assert_contains "$out" "would reap" "the dry run did not mark its report as a preview"
+alive "$STALE" || fail "the dry run stopped the abandoned worker instead of only reporting it"
+pass "a dry run reports the abandoned worker and signals nothing"
+
+out=$("$REAPER" 2>&1) || fail "the reaper failed: $out"
+assert_contains "$out" "$STALE" "the reaper did not report stopping the abandoned worker"
+wait_gone "$STALE" 20 || fail "the abandoned worker survived the reaper"
+wait_gone "$STALE_SERVE" 20 || fail "the abandoned worker's serving child survived the reaper"
+pass "the reaper stops an abandoned worker's whole tree"
+
+out=$("$REAPER" 2>&1) || fail "a repeat reaper run failed: $out"
+assert_not_contains "$out" "$STALE" "the reaper reported an already-stopped worker"
+pass "the reaper is idempotent"

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -19,7 +19,18 @@ REAL_GIT=$(command -v git)
 OTHER_PID=
 RECOVERY_WORKER_PID=
 mkdir -p "$REMOTE_ROOT/bin" "$REMOTE_HOME" "$ACCOUNT_HOME" "$RUNTIME_BIN"
-trap 'if [ -n "$OTHER_PID" ]; then kill "$OTHER_PID" 2>/dev/null || true; fi; if [ -n "$RECOVERY_WORKER_PID" ]; then kill "$RECOVERY_WORKER_PID" 2>/dev/null || true; fi; if [ -f "$STATE_ROOT/worker.pid" ]; then kill "$(cat "$STATE_ROOT/worker.pid")" 2>/dev/null || true; fi; rm -rf -- "$TMP_ROOT"' EXIT
+# worker.pid records the serving child, not its restart supervisor, so stopping
+# that pid alone leaves the supervisor to respawn - the leak
+# tests/fm-remote-job-orphan-reap.test.sh pins. Stop the whole worker tree.
+cleanup_remote_job_fixture() {
+  [ -z "$OTHER_PID" ] || kill "$OTHER_PID" 2>/dev/null || true
+  [ -z "$RECOVERY_WORKER_PID" ] || kill "$RECOVERY_WORKER_PID" 2>/dev/null || true
+  if [ -f "$STATE_ROOT/worker.pid" ]; then
+    fm_remote_job_stop_worker_tree "$(cat "$STATE_ROOT/worker.pid")" || true
+  fi
+  rm -rf -- "$TMP_ROOT"
+}
+trap cleanup_remote_job_fixture EXIT
 
 cp "$ROOT/bin/fm-remote-job-lib.sh" "$ROOT/bin/fm-remote-job-worker.sh" \
   "$ROOT/bin/fm-remote-delta-read.sh" "$REMOTE_ROOT/bin/"

--- a/tests/fm-remote-reply.test.sh
+++ b/tests/fm-remote-reply.test.sh
@@ -14,17 +14,18 @@ REMOTE="$TMP_ROOT/remote"
 FAKEBIN=$(fm_fakebin "$TMP_ROOT/fake")
 CLAIMS="$TMP_ROOT/claims"
 mkdir -p "$PARENT/data" "$PARENT/state" "$REMOTE/state" "$REMOTE/data/reply" "$CLAIMS"
+# shellcheck source=bin/fm-remote-job-lib.sh
+. "$ROOT/bin/fm-remote-job-lib.sh"
+# The recorded worker pid is the serving child, not its restart supervisor, so
+# stopping that pid alone leaves the supervisor to respawn - the leak
+# tests/fm-remote-job-orphan-reap.test.sh pins. Stop the whole worker tree.
 cleanup() {
-  local worker_pid='' wait_attempt=0
+  local worker_pid=''
   FM_HOME="$PARENT" FM_PROCEVENT_CLAIM_ROOT="$CLAIMS" \
     "$ROOT/bin/fm-procevent.sh" sweep-home >/dev/null 2>&1 || true
   if [ -f "$TMP_ROOT/remote-jobs/worker.pid" ]; then
     worker_pid=$(cat "$TMP_ROOT/remote-jobs/worker.pid")
-    kill "$worker_pid" 2>/dev/null || true
-    while kill -0 "$worker_pid" 2>/dev/null && [ "$wait_attempt" -lt 100 ]; do
-      wait_attempt=$((wait_attempt + 1))
-      sleep 0.05
-    done
+    fm_remote_job_stop_worker_tree "$worker_pid" || true
   fi
   rm -rf -- "$TMP_ROOT"
 }


### PR DESCRIPTION
## Intent

Firstmate: reap orphaned fm-remote-job-worker processes via process-group teardown plus an idle reaper.

CAPTAIN INTENT (2026-08-07): 29 orphaned fm-remote-job-worker.sh bash workers were found on the firstmate machine at PPID 1, etime 1-2 days, each 1-2% CPU, logs 50-300MB at /private/var/folders/.../fm-remote-reply.*/remote-jobs/logs/dev.firstmate.remote-job.log and command /Users/kunchen/.no-mistakes/worktrees/016d88035d58/<ULID>/bin/fm-remote-job-worker.sh. Their worktrees had already been returned/pruned but the process held a cwd FD to the deleted dir - a classic orphan after a no-mistakes run was cancelled or completed without reaping. All 29 were TERM'd manually on 2026-08-07. This task is to PREVENT future leaks by improving firstmate's teardown/supervision logic to kill process groups.

REQUIRED WORK:
- Diagnose the exact launch paths that leak: (a) a no-mistakes worktree's bin/fm-remote-job-worker.sh launched during the pipeline for remote secondmate jobs, (b) a treehouse pooled worktree's bin/fm-remote-job-worker.sh from fmdev tasks, (c) e2e temp remote-root workers. Confirm via code in bin/fm-remote-job-worker.sh launch sites, bin/fm-teardown.sh, bin/fm-spawn.sh, bin/fm-remote-job-lib.sh.
- Fix minimally and fundamentally, and do NOT overfit to just remote-job workers: spawn the worker in its own process GROUP (setpgid) and kill the whole group on teardown/abort/cancel/daemon-cleanup (macOS: setpgid plus kill -pgid, not just the immediate child). Ensure fm-teardown.sh reaps descendant processes rooted in the worktree/tasktmp, not just the agent endpoint.
- Add a belt-and-suspenders idle reaper: at locked session start or via a bin/fm-teardown.sh sweep, kill any ppid=1 fm-remote-job-worker.sh whose owning task/worktree is gone and whose log path is under a stale root that no longer exists. It MUST NOT kill the healthy primary dev.firstmate.remote-job LaunchAgent worker - distinguish by FM_ROOT and lock ownership.
- Do not touch the shared no-mistakes daemon (one instance fleet-wide); never restart it with runs active. Tests must use isolated fixtures/mocks, never live remotes or the live daemon.

ACCEPTANCE:
- Repro: launch a fixture remote-job worker in a temp worktree, orphan it via a simulated teardown without a group kill, prove it survives with ppid 1; after the fix, the same teardown kills the whole group.
- After the fix, a cancelled no-mistakes run does not leave a ppid 1 fm-remote-job-worker.sh behind.
- Existing tests pass, no regression in remote secondmate transport.

COORDINATION CONSTRAINT: a sibling task nm-lingering-process-reap-r1 owns the no-mistakes PIPELINE side of process-group teardown, and separate queued tasks fm-teardown-reap-leaked-test-processes and nm-orphaned-test-process-reap-r1 own the general leaked-test-process reaper. This task is deliberately scoped to firstmate's worktree/teardown ownership and the worker itself; it must NOT duplicate the pipeline-side or general test-process-reaper work. Building a general leaked-test-process reaper here would be out of scope and is intentionally omitted. Do not touch the public stow skill.

WHAT I FOUND AND DECIDED WHILE DOING THE WORK:

Reproduction (done first, end-to-end, before any fix). I launched a real worker through the shared library's Linux start path from a parent shell that then exited, and confirmed the exact production signature: supervisor at PPID 1, still alive, hot-restarting its --serve child, with fd 1/2 pointing at a log inside a deleted directory growing ~23KB/30s (~66MB/day, matching the observed 50-300MB over 1-2 days). I then traced the leak source precisely: tests/fm-remote-reply.test.sh runs with FM_ROOT_OVERRIDE set to the repo checkout (which under CI is the no-mistakes gate worktree) and FM_REMOTE_JOB_STATE_ROOT under a /private/var/folders/.../fm-remote-reply.XXXXXX fixture - byte-for-byte the paths in the captain's evidence. 29 orphans equals 29 pipeline runs of that suite.

Root cause is three faults combining, and I fixed all three rather than only the symptom:
1. The recorded worker.pid is the SERVING CHILD, not the restart supervisor above it. A teardown that stops that single pid only makes the supervisor respawn. The Linux start path also left the worker tree in the LAUNCHING COMMAND's process group, so there was no isolated group to signal instead - group-killing it would have hit fm-on itself.
2. Neither the serving loop nor the Linux supervisor ever re-checked whether its configured FM_ROOT still existed, so a worker launched from a worktree outlived that worktree indefinitely.
3. The supervisor restarted a failing child with a fixed 0.1s delay and no bound, which is what grew the logs without limit.

Design decisions and tradeoffs:
- I deliberately chose 'the code root named in the worker's own command line no longer exists' as the SOLE reap condition, instead of the log-path/ppid/age heuristics the task text suggested. It is strictly stronger and simpler: a worker whose root is gone can never claim, validate, or execute another job, and no healthy worker can present a missing root. This satisfies the 'must not kill the healthy LaunchAgent worker' requirement structurally rather than by heuristic, and covers all three named leak classes (pruned nm gate worktree, returned pooled worktree, removed e2e temp root) with one rule.
- The most fundamental fix is SELF-TERMINATION in the worker itself, not just external reaping: a worker whose root is pruned now stops on its own. The reaper is explicitly belt-and-suspenders for workers already orphaned by older builds. Self-termination is confirmed across a grace window (FM_REMOTE_JOB_ORPHAN_GRACE_SECONDS, default 5) so an ordinary transient read cannot stop a healthy worker, and the check runs immediately after a fresh heartbeat so the grace window cannot make a healthy worker read as unready to a concurrent probe.
- Process-group isolation uses bash job control (set -m) around the existing nohup launch, matching the pattern already used by worker_run_with_timeout in the same file, rather than introducing a new setsid dependency.
- fm_remote_job_stop_worker_tree REFUSES to signal a process group whose leader is not itself a remote job worker, and never signals group 0, group 1, or the caller's own group. A worker inherited from an older build without isolation, or from launchd's own session, is therefore still stopped safely as a single process rather than taking out an unrelated group. This is the key safety property of the group kill.
- The supervisor now backs off and gives up after a bounded number of consecutive immediate failures rather than looping forever. Measured: 90 seconds and a 1.1KB log, versus never and 66MB/day. fm-on's ensure path restarts a worker that gave up, so this loses no availability.
- I wired the sweep into bin/fm-teardown.sh (documented as Fix 3 in its header, alongside the existing Fix 1 and Fix 2) rather than into bin/fm-bootstrap.sh's locked session-start sweeps. Rationale: teardown already owns leaked-process reaping, it runs frequently enough, and adding a seventh bootstrap MUTATING sweep would have required changing the AGENTS.md always-loaded contract for no added coverage. The sweep is best-effort and never blocks a teardown.
- The reaper parses ps with default word splitting rather than fixed offsets, because ps pads the pid column to the widest pid on the host; an earlier draft silently skipped any worker with a short pid. It also re-reads each candidate's command from the live process before signalling, so a recycled pid cannot be signalled on a stale scan line.
- I also fixed the two test suites that were leaking these in the first place (tests/fm-remote-reply.test.sh and tests/fm-remote-job.test.sh) to stop the whole worker tree instead of the recorded pid alone.

Verification performed: the new tests/fm-remote-job-orphan-reap.test.sh has 7 cases and I confirmed it FAILS against the pre-fix code in two independent places - once for the missing process-group isolation, once for the missing self-termination - so it is a genuine regression test and not vacuous. bin/fm-lint.sh, bin/fm-doc-audience-check.sh, and the affected suites (fm-remote-job, fm-remote-reply, fm-remote-doctor, fm-on, fm-remote-backlog-handoff, fm-teardown, fm-teardown-endpoint-safety, fm-test-run, fm-documentation-audiences) all pass, and no worker processes are left on the machine.

This is firstmate shared tracked material, so firstmate-coding-guidelines applies: knowledge was routed to its most specific owner (script headers for mechanics, docs/scripts.md and docs/remote-secondmates.md for reference) rather than added to AGENTS.md, which needed no change.

## What Changed

- Made the remote job worker stop itself once its configured `FM_ROOT` stops being a genuine Firstmate checkout, confirmed across a grace window (`FM_REMOTE_JOB_ORPHAN_GRACE_SECONDS`), in both the serving loop and the Linux restart supervisor; the supervisor also now backs off and gives up after bounded consecutive immediate failures instead of restarting a failing child forever.
- Isolated the Linux-launched worker tree in its own process group (`set -m`) and added `fm_remote_job_stop_worker_tree` / `fm_remote_job_root_is_live` helpers in `bin/fm-remote-job-lib.sh`, so a stop signals the supervisor, serving child, and job descendants together while refusing to signal a group whose leader is not itself a worker (or a reserved/own group).
- Added `bin/fm-remote-job-reap-orphans.sh`, a best-effort sweep of workers whose named code root no longer exists, wired into `bin/fm-teardown.sh` as Fix 3; updated the two leaking suites to stop the whole worker tree, added `tests/fm-remote-job-orphan-reap.test.sh`, registered it in `bin/fm-test-run.sh`, and documented the behavior in `docs/scripts.md` and `docs/remote-secondmates.md`.

## Risk Assessment

✅ Low: The change is well-bounded, matches established in-file patterns (unconditional set -m job control, non-symlink root invariant consistent with the existing start precondition), guards every kill path structurally against hitting the caller or the healthy LaunchAgent worker, and ships a genuine before/after behavioral regression test.

## Testing

Ran the smallest relevant set proving the intent. The new tests/fm-remote-job-orphan-reap.test.sh drives the actual shared library start path and the new reaper: it starts a genuine fixture worker, confirms the whole tree is in its own process group, reproduces the exact production leak (killing the recorded serving-child pid leaves the restart supervisor respawning at ppid 1), then confirms the fix - the worker self-terminates its whole tree once its code root is pruned, the reaper never touches a worker whose root still exists, dry-run signals nothing, and the reaper stops an already-orphaned tree and is idempotent (exit 0, 7/7). I confirmed the suite is a genuine behavioral regression by neutralizing each fix in a temp mirror and observing it fail in two independent places (process-group case, self-termination case). The modified existing teardowns and remote transport paths pass with no regression: fm-remote-job (22 ok), fm-remote-reply (16 ok), fm-teardown (57 ok, Fix 3 sweep), fm-teardown-endpoint-safety (5 ok). No residual worker processes remained; worktree is clean and the temp mirror was removed. Evidence is CLI transcripts (no UI surface in this change), so no screenshot applies.

<details>
<summary>Evidence: Orphan-reap E2E CLI transcript</summary>

<code>$ bash tests/fm-remote-job-orphan-reap.test.sh&#10;ok - the Linux start path puts the whole worker tree in its own process group&#10;ok - removing the state root and killing the recorded worker pid leaves the tree running at ppid 1&#10;ok - a worker whose code root still exists is never reaped&#10;ok - a worker stops its whole tree once its code root is pruned&#10;ok - a dry run reports the abandoned worker and signals nothing&#10;ok - the reaper stops an abandoned worker&#39;s whole tree&#10;ok - the reaper is idempotent&#10;exit=0</code>

```text
### E2E: orphaned remote-job worker reap (bash 5.3.9(1)-release, darwin)
$ bash tests/fm-remote-job-orphan-reap.test.sh
ok - the Linux start path puts the whole worker tree in its own process group
ok - removing the state root and killing the recorded worker pid leaves the tree running at ppid 1
ok - a worker whose code root still exists is never reaped
ok - a worker stops its whole tree once its code root is pruned
ok - a dry run reports the abandoned worker and signals nothing
ok - the reaper stops an abandoned worker's whole tree
ok - the reaper is idempotent
exit=0
```
</details>
<details>
<summary>Evidence: Genuine-regression proof (two-place failure against pre-fix behavior)</summary>

<code>Fix A removed (no `set -m`): not ok - the started worker is not its own process group leader&#10;Fix B removed (worker never self-terminates): not ok - the worker survived its code root being pruned</code>

```text
### Genuine-regression check for tests/fm-remote-job-orphan-reap.test.sh
Built a temp mirror of bin/ + tests/, neutralized each fix independently,
and confirmed the suite fails (non-zero) in two independent places.

--- Fix A removed: dropped `set -m`/`set +m` process-group isolation from
    fm_remote_job_start_linux_worker (bin/fm-remote-job-lib.sh) ---
$ bash <mirror>/tests/fm-remote-job-orphan-reap.test.sh
not ok - the started worker is not its own process group leader, so its tree cannot be signalled as one group
(suite aborts non-zero on the first case)

--- Fix B removed: made worker_code_root_abandoned() always return 1
    (never self-terminate) in bin/fm-remote-job-worker.sh ---
$ bash <mirror>/tests/fm-remote-job-orphan-reap.test.sh
ok - the Linux start path puts the whole worker tree in its own process group
ok - removing the state root and killing the recorded worker pid leaves the tree running at ppid 1
ok - a worker whose code root still exists is never reaped
not ok - the worker survived its code root being pruned

Both confirm the test is behavioral and not vacuous: it exercises the live
worker/reaper interfaces and asserts on ppid/pgid and process liveness.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"61a96e51813a85801aa64c8066d225860584dc74","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-remote-job-orphan-reap.test.sh` - new 7-case suite: reproduces the ppid-1 leak with a real worker, then proves group-kill self-termination and the reaper (dry-run/idempotent) - exit 0</code>
- <code>Genuine-regression check in a temp mirror: removed `set -m` group isolation in bin/fm-remote-job-lib.sh -&gt; `not ok - the started worker is not its own process group leader`; disabled worker_code_root_abandoned() in bin/fm-remote-job-worker.sh -&gt; `not ok - the worker survived its code root being pruned`</code>
- <code>`bash tests/fm-remote-job.test.sh` - 22 ok, modified group-stop teardown</code>
- <code>`bash tests/fm-remote-reply.test.sh` - 16 ok, remote secondmate transport + modified teardown</code>
- <code>`bash tests/fm-teardown.sh` - 57 ok, Fix 3 reaper sweep wiring</code>
- <code>`bash tests/fm-teardown-endpoint-safety.test.sh` - 5 ok</code>
- <code>`ps -u &lt;uid&gt;` scan confirmed no residual fm-remote-job-worker.sh processes after runs</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
