### PR TITLE
fix: preserve valid UTF-8 in remote replies

### DIFF
--- a/bin/fm-procevent-remote-reply.sh
+++ b/bin/fm-procevent-remote-reply.sh
@@ -281,12 +281,12 @@ validate_utf8_payload() { # <source>
   ' < "$1"
 }
 
-# The one adaptation a machine boundary forces on valid UTF-8 bytes: NUL and
-# every other C0 control except tab and newline, plus DEL, become '?'. Printable
-# ASCII and valid UTF-8 pass through untouched, so ordinary notes mirror exactly
-# as a local secondmate would have written them. Newlines remain framing rather
-# than payload bytes, and blank separators are not carried into the parent status
-# stream.
+# The one adaptation a machine boundary forces on a valid UTF-8 payload: NUL and
+# every other C0 control except tab and newline, plus DEL, become '?'. Within a
+# content-bearing line, printable ASCII, tabs, and all non-ASCII bytes pass
+# through untouched, so ordinary notes mirror exactly as a local secondmate
+# would have written them. Newlines remain framing rather than payload bytes,
+# and blank separators are not carried into the parent status stream.
 normalize_payload() { # <source> <destination>
   LC_ALL=C tr '\000-\010\013-\037\177' '?' < "$1" > "$2"
 }

--- a/bin/fm-procevent-remote-reply.sh
+++ b/bin/fm-procevent-remote-reply.sh
@@ -35,7 +35,7 @@
 # on the stream. Gating on it here made a remote mate's own progress lines and
 # newly raised decisions - which carry no corr= by contract - unrepresentable,
 # and rejecting one line failed the whole delta, so the cursor could never
-# advance past it. No single line can stop or wedge the stream.
+# advance past it. A missing correlation token never stops or wedges the stream.
 #
 # What remains here is only what crossing a machine boundary genuinely adds:
 #   - cursor continuity and identity (offset plus prefix digest)
@@ -269,12 +269,24 @@ fetch_document() { # <id> <remote-relative> <result-var>
   printf -v "$result_var" '%s' "$local_rel"
 }
 
-# The one adaptation a machine boundary forces on the mirrored bytes: NUL and
+# Validate the complete captured payload before shell line processing. Perl's
+# core Encode module gives macOS and Linux the same strict UTF-8 boundary while
+# leaving the original bytes untouched for the subsequent mirror.
+validate_utf8_payload() { # <source>
+  perl -MEncode=decode,FB_CROAK -e '
+    binmode STDIN;
+    local $/;
+    my $bytes = <STDIN>;
+    eval { decode("UTF-8", $bytes, FB_CROAK); 1 } or exit 1;
+  ' < "$1"
+}
+
+# The one adaptation a machine boundary forces on valid UTF-8 bytes: NUL and
 # every other C0 control except tab and newline, plus DEL, become '?'. Printable
-# ASCII and every high byte pass through untouched, so ordinary UTF-8 notes
-# mirror exactly as a local secondmate would have written them. Newlines remain
-# framing rather than payload bytes, and blank separators are not carried into
-# the parent status stream.
+# ASCII and valid UTF-8 pass through untouched, so ordinary notes mirror exactly
+# as a local secondmate would have written them. Newlines remain framing rather
+# than payload bytes, and blank separators are not carried into the parent status
+# stream.
 normalize_payload() { # <source> <destination>
   LC_ALL=C tr '\000-\010\013-\037\177' '?' < "$1" > "$2"
 }
@@ -323,6 +335,7 @@ cmd_ingest() {
   actual_hash=$(sha256_file "$payload")
   [ "$actual_bytes" -eq "$payload_bytes" ] && [ "$actual_hash" = "$payload_hash" ] \
     || die "result payload bytes do not match its committed digest"
+  validate_utf8_payload "$payload" || die "remote reply payload is not valid UTF-8"
   normalized_payload="$tmp/normalized-payload"
   normalize_payload "$payload" "$normalized_payload" || die "cannot normalize remote reply payload"
   status_file="$STATE/$id.status"

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -174,7 +174,7 @@ A process-event source performs a non-destructive, cursor-anchored delta read, f
 The channel carries the mate's status and decision model: an uncorrelated progress line and a newly raised `needs-decision` travel the same path as a correlated answer, and reach the parent's open-decision fold identically.
 Correlation is a per-line property that settles a pending request; it is never a gate on the stream, so a missing correlation token cannot stop or wedge the relay or hold the cursor back.
 The adapter rejects malformed UTF-8 before any payload line reaches the primary status channel.
-Transport normalization rewrites NUL, every other C0 control except tab and newline, and DEL to `?`, while printable ASCII and valid UTF-8 pass through unchanged.
+Transport normalization rewrites NUL, every other C0 control except tab and newline, and DEL to `?`; within a content-bearing line, printable ASCII, tabs, and all non-ASCII bytes from the validated UTF-8 payload pass through unchanged.
 If the confined remote reader permanently refuses a referenced document, the mate's line is mirrored with its original pointer and the adapter appends one keyed escalation naming the gap instead of stalling the stream.
 An SSH exit status of 255 while fetching a referenced document leaves the delta uncommitted for the process-event runner's normal retry because remote completion is unknown.
 The process-event runner applies each captured delta through this adapter as soon as it is captured, so a mirrored reply reaches the primary status channel without depending on the wake handler running the adapter itself.

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -172,8 +172,9 @@ Marked requests keep the existing correlation contract.
 The remote charter appends replies to `state/parent-replies.status` in the remote home.
 A process-event source performs a non-destructive, cursor-anchored delta read, fetches only referenced `data/*.md` documents through the confined reader, mirrors every content-bearing line at most once into the primary status channel, and does not carry blank separators.
 The channel carries the mate's status and decision model: an uncorrelated progress line and a newly raised `needs-decision` travel the same path as a correlated answer, and reach the parent's open-decision fold identically.
-Correlation is a per-line property that settles a pending request; it is never a gate on the stream, so no single line can stop or wedge the relay or hold the cursor back.
-Transport normalization rewrites NUL, every other C0 control except tab and newline, and DEL to `?`, while printable ASCII and all high bytes, including UTF-8, pass through unchanged.
+Correlation is a per-line property that settles a pending request; it is never a gate on the stream, so a missing correlation token cannot stop or wedge the relay or hold the cursor back.
+The adapter rejects malformed UTF-8 before any payload line reaches the primary status channel.
+Transport normalization rewrites NUL, every other C0 control except tab and newline, and DEL to `?`, while printable ASCII and valid UTF-8 pass through unchanged.
 If the confined remote reader permanently refuses a referenced document, the mate's line is mirrored with its original pointer and the adapter appends one keyed escalation naming the gap instead of stalling the stream.
 An SSH exit status of 255 while fetching a referenced document leaves the delta uncommitted for the process-event runner's normal retry because remote completion is unknown.
 The process-event runner applies each captured delta through this adapter as soon as it is captured, so a mirrored reply reaches the primary status channel without depending on the wake handler running the adapter itself.

--- a/tests/fm-remote-reply.test.sh
+++ b/tests/fm-remote-reply.test.sh
@@ -206,7 +206,7 @@ fm_pending_reply_mark_delivered "$PARENT/state" "$PENDING_CORR" \
 {
   printf 'working [key=version-audit]: family --version audit complete (data/reply/report.md)\n'
   printf 'needs-decision [key=rough-cut-version]: implement --version or retire the tool\n'
-  printf 'done [corr=%s]: release chain audited\n' "$PENDING_CORR"
+  printf 'done: login refreshed; ad-racers home authenticated, healthy, and idle \342\200\224 ready for routed work [corr=%s]\n' "$PENDING_CORR"
 } >> "$REMOTE/state/parent-replies.status"
 remote_env "$ROOT/bin/fm-procevent.sh" start "$SID" >/dev/null \
   || fail "the mirrored status stream was not captured"
@@ -215,7 +215,12 @@ remote_env "$ADAPTER" handle ios 4 "$RESULT_FOUR" > "$TMP_ROOT/handle-mirror.out
   || fail "an uncorrelated status line stopped the delta: $(cat "$TMP_ROOT/handle-mirror.out")"
 assert_grep 'working [key=version-audit]' "$PARENT/state/ios.status" "an uncorrelated progress line never reached the parent stream"
 assert_grep 'needs-decision [key=rough-cut-version]' "$PARENT/state/ios.status" "a newly raised remote decision never reached the parent stream"
-assert_grep "done [corr=$PENDING_CORR]" "$PARENT/state/ios.status" "the correlated answer sharing the delta was lost"
+EXPECTED_UNICODE_REPLY=$(printf 'done: login refreshed; ad-racers home authenticated, healthy, and idle \342\200\224 ready for routed work [corr=%s]' "$PENDING_CORR")
+assert_grep "$EXPECTED_UNICODE_REPLY" "$PARENT/state/ios.status" "the UTF-8 correlated answer sharing the delta was lost"
+printf '%s\n' "$EXPECTED_UNICODE_REPLY" > "$TMP_ROOT/expected-unicode-reply"
+grep -F "$EXPECTED_UNICODE_REPLY" "$PARENT/state/ios.status" > "$TMP_ROOT/actual-unicode-reply"
+cmp -s "$TMP_ROOT/expected-unicode-reply" "$TMP_ROOT/actual-unicode-reply" \
+  || fail "the relayed UTF-8 answer did not preserve its original bytes"
 mirror_offset=$(LC_ALL=C wc -c < "$REMOTE/state/parent-replies.status" | tr -d ' ')
 assert_grep "offset=$mirror_offset" "$PARENT/state/remote-replies/ios.cursor" \
   "the cursor did not advance past an uncorrelated line"
@@ -231,6 +236,33 @@ printf '%s' "$OPEN" | grep -q '^rough-cut-version	needs-decision	' \
 [ "$(fm_pending_reply_get "$PARENT/state/pending-replies/$PENDING_CORR" phase)" = resolved ] \
   || fail "the correlated answer in the same delta did not settle its pending-reply record"
 pass "a remote mate's new decision folds open exactly as a local mate's does"
+
+# A digest-valid payload still has to be valid UTF-8 before any line can enter
+# the parent status stream. Replace the three-byte Unicode punctuation above
+# with an invalid two-byte overlong sequence plus one ASCII byte, retaining the
+# payload size while recomputing its digest so this exercises the public ingest
+# boundary rather than the transport commitment.
+MALFORMED_RESULT="$TMP_ROOT/malformed-utf8.result"
+MALFORMED_PAYLOAD="$TMP_ROOT/malformed-utf8.payload"
+malformed_boundary=$(LC_ALL=C awk '$0 == "" { print NR; exit }' "$RESULT_FOUR")
+tail -n "+$((malformed_boundary + 1))" "$RESULT_FOUR" \
+  | perl -0pe 's/\xE2\x80\x94/\xC0\xAFX/' > "$MALFORMED_PAYLOAD"
+malformed_hash=$(sha256_file "$MALFORMED_PAYLOAD")
+head -n "$malformed_boundary" "$RESULT_FOUR" \
+  | sed "s/^payload_sha256=.*/payload_sha256=$malformed_hash/" > "$TMP_ROOT/malformed-utf8.header"
+cat "$TMP_ROOT/malformed-utf8.header" "$MALFORMED_PAYLOAD" > "$MALFORMED_RESULT"
+cp "$PARENT/state/ios.status" "$TMP_ROOT/status-before-malformed-utf8"
+cp "$PARENT/state/remote-replies/ios.cursor" "$TMP_ROOT/cursor-before-malformed-utf8"
+if remote_env "$ADAPTER" ingest ios "$MALFORMED_RESULT" > "$TMP_ROOT/malformed-utf8.out" 2>&1; then
+  fail "ingest accepted a digest-valid malformed UTF-8 payload"
+fi
+assert_grep 'remote reply payload is not valid UTF-8' "$TMP_ROOT/malformed-utf8.out" \
+  "malformed UTF-8 was rejected for an unrelated reason"
+cmp -s "$TMP_ROOT/status-before-malformed-utf8" "$PARENT/state/ios.status" \
+  || fail "malformed UTF-8 changed the parent status stream"
+cmp -s "$TMP_ROOT/cursor-before-malformed-utf8" "$PARENT/state/remote-replies/ios.cursor" \
+  || fail "malformed UTF-8 changed the committed cursor"
+pass "digest-valid malformed UTF-8 is rejected without changing status or cursor state"
 
 # Ingesting the same generation again is idempotent: no duplicated lines and no
 # cursor movement, so a replay can never wedge or double-count the stream.


### PR DESCRIPTION
## Intent

Fix the production remote second-mate reply relay bug exposed by the first real Mac mini pilot so a valid correlated lifecycle line may contain bounded safe UTF-8 human text, including the observed Unicode punctuation, without rejection, while preserving accepted bytes exactly and relaying once. Reproduce through the closest executable boundary, compare a proven ASCII reply, separate the initiating trigger, masking condition, and visible symptom, inspect relevant history, test the smallest counterfactual, and seek disconfirming evidence before fixing. Turn the exact Unicode failure into regression coverage through the executable public interface, add negative coverage proving malformed UTF-8 and unsafe controls do not enter parent status state, and preserve all existing size, correlation, lifecycle semantics, document path safety, cursor continuity, digest, deduplication, acknowledgement, and re-arming guarantees. Prefer a small portable validation boundary with one clear owner, review supported macOS and Linux shells, keep shellcheck and bin/fm-lint.sh clean, run focused end-to-end tests, and update maintained documentation only where the current contract changes. The current branch base already includes the newer full status-stream mirror contract, so retain that later design where correlation and lifecycle semantics are handled by their existing owners rather than reintroducing obsolete ingestion gates, while strictly rejecting malformed UTF-8 before append and retaining existing control-byte normalization.

## What Changed

- Validate remote reply payloads as strict UTF-8 before ingestion while preserving valid Unicode bytes through relay and existing control-byte normalization.
- Add regression coverage for byte-exact Unicode punctuation relay and rejection of malformed UTF-8 without changing parent status or cursor state.
- Document the remote reply transport contract for UTF-8 validation and normalization.

## Risk Assessment

✅ Low: The change adds a narrow strict UTF-8 validation boundary before any status or cursor mutation while preserving the established normalization, correlation, deduplication, acknowledgement, and re-arming semantics.

## Testing

The focused remote-reply E2E test and byte-level public `ingest` check passed, covering the ASCII comparison, exact Unicode punctuation reply, byte preservation, once-only replay, malformed UTF-8 rejection without status or cursor mutation, control normalization, and existing capture, digest, cursor, deduplication, acknowledgement, re-arm, document, and fold guarantees. No visual artifact applies because the end-user surface is a shell relay and persisted status stream.

<details>
<summary>Evidence: Remote reply UTF-8 public-interface transcript</summary>

<code>ASCII accepted: done: ASCII reply ready [corr=0123456789abcdef]&#10;Unicode accepted: done: login refreshed; ad-racers home authenticated, healthy, and idle — ready for routed work [corr=3600c09c1d4fe2b1]&#10;Unicode bytes preserved: yes (sha256=40d6e300a8ebd8e826012cd5d8e7edbd56299ec197b4b7321778da367e262b26)&#10;Unicode relay count after replay: 1&#10;Malformed UTF-8 exit: 1&#10;Malformed UTF-8 response: error: remote reply payload is not valid UTF-8&#10;Malformed UTF-8 state unchanged: yes&#10;Control-byte normalized: blocked [key=ctl]: escape ?[31mhere?[0m bell ? café end&#10;Unsafe control bytes in parent status: 0</code>

```text
Command:
bash verify-remote-reply-utf8.sh /Users/metygl/.no-mistakes/worktrees/4b28d26566d4/01KZFM3T1TVP1XVYAJK9ESDVWJ

ASCII accepted: done: ASCII reply ready [corr=0123456789abcdef]
Unicode accepted: done: login refreshed; ad-racers home authenticated, healthy, and idle — ready for routed work [corr=3600c09c1d4fe2b1]
Unicode bytes preserved: yes (sha256=40d6e300a8ebd8e826012cd5d8e7edbd56299ec197b4b7321778da367e262b26)
Unicode relay count after replay: 1
Malformed UTF-8 exit: 1
Malformed UTF-8 response: error: remote reply payload is not valid UTF-8
Malformed UTF-8 state unchanged: yes
Control-byte normalized: blocked [key=ctl]: escape ?[31mhere?[0m bell ? café end
Unsafe control bytes in parent status: 0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-test-run.sh tests/fm-remote-reply.test.sh` (exit 0)</code>
- <code>`bash /var/folders/d3/ws90r07556gchkj6sk_6v6380000gn/T/no-mistakes-evidence/01KZFM3T1TVP1XVYAJK9ESDVWJ/verify-remote-reply-utf8.sh &#34;$PWD&#34;` (exit 0)</code>
- <code>Inspected `git log` and `git blame` for the adapter to verify ownership history for stream mirroring, correlation, normalization, automatic apply, and re-arming.</code>
- <code>Verified `git status --short` remained empty after testing.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
