### PR TITLE
fix(spawn): refuse a worktree a live sibling already records

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,7 +283,7 @@ Write the task-specific brief under section 11 before spawning.
 ### Dispatch and supervision handoff
 
 Spawn only through `bin/fm-spawn.sh` after the profile and backend checks in section 4.
-The spawn must resolve a genuine isolated task worktree distinct from the primary checkout; a failed isolation assertion stops the task.
+The spawn must resolve a genuine isolated task worktree distinct from the primary checkout and unclaimed by another live task in this home; a failed isolation assertion stops the task.
 After spawning, confirm the worker is processing the brief, handle any trust dialog through `harness-adapters`, and record ship or scout work as under way.
 A persistent secondmate is recorded in the secondmate registry and runtime state, never as a backlog work item.
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -111,7 +111,10 @@
 #   Before a secondmate launch, the home is locally fast-forwarded to the primary
 #   default-branch commit when safe; skipped syncs warn and launch unchanged.
 #   Ship/scout spawns refuse to launch unless the resolved task path is a real
-#   git worktree root distinct from the primary project checkout.
+#   git worktree root distinct from the primary project checkout, and unless no
+#   other task in this home records that same path as its worktree with a
+#   still-live endpoint - the worktree pool cannot see an idle agent, so only
+#   an authoritatively dead or missing endpoint releases a recorded slot.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -1395,6 +1398,66 @@ real_path_or_raw() {  # <path>
 # herdr-sm-spaces-k4). Both branches converge on the same $T ("target") string
 # that every downstream operation (send/capture/kill) already treats as opaque
 # per-backend routing (fm_backend_resolve_selector).
+# validate_worktree_free_of_live_sibling: refuse a worktree that another live
+# task in this home already records as its own.
+#
+# The worktree pool decides a slot is in use by looking for live processes whose
+# working directory sits inside it. An agent that is thinking, waiting on the
+# network, or simply idle between commands has no such process, so its own
+# worktree reads as free and the next `treehouse get` hands the slot over. The
+# pool then resets it to a clean detached HEAD, destroying the running agent's
+# branch checkout. That detection is the pool's, not firstmate's, and it cannot
+# see an idle agent at all; firstmate owns the record that can, because every
+# task writes `worktree=` into state/<id>.meta. This is therefore the correct
+# layer for the guard, and it runs here - before the launched agent has been
+# handed its brief, let alone run `git checkout -b` - which is what keeps a
+# collision recoverable at zero cost.
+#
+# Liveness comes from bin/fm-backend.sh's fm_backend_agent_state rather than a
+# second notion of "is that worker still there". Only `dead` and `missing`
+# release the claim: stale metadata outlives its agent, worktrees are pooled and
+# reused, and a task whose endpoint is authoritatively gone has no claim on the
+# slot. Every other verdict - `alive`, `ambiguous`, `unreadable`, `unverified` -
+# refuses, matching this file's own duplicate-launch guard
+# (herdr_projection_existing_meta_allows_flat), which already treats an
+# unreadable endpoint exactly like a live one. The two errors are not
+# symmetric: wrongly refusing costs one spawn that names the record to clear,
+# while wrongly proceeding resets a live worker's branch checkout out from under
+# it. The refusal is also narrow - it fires only for a spawn that lands on that
+# one recorded path, so an unreadable record cannot stall the fleet, only the
+# reuse of its own slot, which `bin/fm-teardown.sh` releases.
+validate_worktree_free_of_live_sibling() {  # <source> <inspect-target> <worktree-real-path>
+  local source=$1 inspect_target=$2 wt_real=$3
+  local meta sib_id sib_wt sib_wt_real sib_backend sib_target sib_state
+  for meta in "$STATE"/*.meta; do
+    [ -f "$meta" ] || continue
+    sib_id=$(basename "$meta" .meta)
+    # A relaunch legitimately re-seats the same task into the worktree its own
+    # metadata already records (stuck-crewmate-recovery depends on it), so the
+    # task's own record can never be the sibling that refuses it.
+    [ "$sib_id" != "$ID" ] || continue
+    sib_wt=$(fm_meta_get "$meta" worktree)
+    [ -n "$sib_wt" ] || continue
+    # Compare physically resolved paths, exactly as the isolation check above
+    # does: a symlinked prefix or a trailing slash spells the same directory
+    # differently, and a raw string comparison would miss the collision.
+    sib_wt_real=$(real_path_or_raw "$sib_wt")
+    [ "$sib_wt_real" = "$wt_real" ] || continue
+    sib_backend=$(fm_backend_of_meta "$meta")
+    sib_target=$(fm_backend_target_of_meta "$meta")
+    if [ -n "$sib_target" ]; then
+      sib_state=$(fm_backend_agent_state "$sib_backend" "$sib_target")
+    else
+      sib_state=unreadable
+    fi
+    case "$sib_state" in
+      dead|missing) continue ;;
+    esac
+    echo "error: $source handed back a worktree that task $sib_id already records as its own, and $sib_id's endpoint is $sib_state (shared worktree '$wt_real'); refusing to launch to avoid resetting a live worker's checkout. If $sib_id is finished, release its record with bin/fm-teardown.sh $sib_id and spawn again. Inspect target $inspect_target" >&2
+    exit 1
+  done
+}
+
 validate_spawn_worktree() {  # <source> <inspect-target>
   local source=$1 inspect_target=$2 wt_real proj_real wt_top wt_top_real
   wt_real=
@@ -1411,6 +1474,7 @@ validate_spawn_worktree() {  # <source> <inspect-target>
     echo "error: $source did not yield an isolated worktree (resolved '$WT'; worktree root '${wt_top:-none}'; primary '$PROJ_ABS'); refusing to launch to avoid tangling the primary checkout. Inspect target $inspect_target" >&2
     exit 1
   fi
+  validate_worktree_free_of_live_sibling "$source" "$inspect_target" "$wt_real"
 }
 
 herdr_projection_meta_field_exact() {  # <meta> <key>

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -621,7 +621,9 @@ if [ "$BACKEND" = orca ]; then
   fm_backend_orca_runtime_check || exit 1
 fi
 ORCA_ABORT_CLEANUP=0
-ORCA_ABORT_KEEP_WORKTREE=0
+# Set when this abort is a live-sibling refusal, meaning the orca resources this
+# spawn is holding may belong to that sibling rather than to this spawn.
+ORCA_ABORT_SIBLING_OWNED=0
 ORCA_WORKTREE_ID=
 ORCA_TERMINAL=
 HERDR_PROJECTION_ABORT_CLEANUP=0
@@ -674,28 +676,38 @@ spawn_abort_cleanup() {
   fi
   if [ "$ORCA_ABORT_CLEANUP" = 1 ]; then
     ORCA_ABORT_CLEANUP=0
-    if [ -n "${ORCA_TERMINAL:-}" ]; then
-      fm_backend_kill orca "$ORCA_TERMINAL" 2>/dev/null || true
-    fi
-    if [ -n "${ORCA_WORKTREE_ID:-}" ] && [ "$ORCA_ABORT_KEEP_WORKTREE" != 1 ]; then
-      if ! fm_backend_remove_worktree orca "$ORCA_WORKTREE_ID" 2>/dev/null; then
-        mkdir -p "$STATE" 2>/dev/null || true
-        if [ -d "$STATE" ]; then
-          {
-            echo "window=$W"
-            echo "worktree=${WT:-}"
-            echo "project=$PROJ_ABS"
-            echo "harness=$HARNESS"
-            echo "kind=$KIND"
-            [ -z "${MODE:-}" ] || echo "mode=$MODE"
-            [ -z "${YOLO:-}" ] || echo "yolo=$YOLO"
-            echo "tasktmp=${TASK_TMP:-}"
-            echo "model=${MODEL:-default}"
-            echo "effort=${EFFORT:-default}"
-            echo "backend=orca"
-            echo "orca_worktree_id=$ORCA_WORKTREE_ID"
-            [ -z "${ORCA_TERMINAL:-}" ] || echo "terminal=$ORCA_TERMINAL"
-          } > "$STATE/$ID.meta" 2>/dev/null || true
+    # This abort must destroy nothing a live sibling owns, so one condition
+    # gates the whole block rather than each resource separately. Both are at
+    # risk: fm_backend_orca_worktree_create returns a worktree-terminal-handle
+    # alongside the worktree, and parse_orca_worktree_result stores it in
+    # ORCA_TERMINAL before this guard runs, so on a sibling refusal that handle
+    # can be the sibling's own terminal exactly as the path can be its worktree.
+    # Gating the block, not the two statements, means a third resource added
+    # here later is covered without rediscovering this.
+    if [ "$ORCA_ABORT_SIBLING_OWNED" != 1 ]; then
+      if [ -n "${ORCA_TERMINAL:-}" ]; then
+        fm_backend_kill orca "$ORCA_TERMINAL" 2>/dev/null || true
+      fi
+      if [ -n "${ORCA_WORKTREE_ID:-}" ]; then
+        if ! fm_backend_remove_worktree orca "$ORCA_WORKTREE_ID" 2>/dev/null; then
+          mkdir -p "$STATE" 2>/dev/null || true
+          if [ -d "$STATE" ]; then
+            {
+              echo "window=$W"
+              echo "worktree=${WT:-}"
+              echo "project=$PROJ_ABS"
+              echo "harness=$HARNESS"
+              echo "kind=$KIND"
+              [ -z "${MODE:-}" ] || echo "mode=$MODE"
+              [ -z "${YOLO:-}" ] || echo "yolo=$YOLO"
+              echo "tasktmp=${TASK_TMP:-}"
+              echo "model=${MODEL:-default}"
+              echo "effort=${EFFORT:-default}"
+              echo "backend=orca"
+              echo "orca_worktree_id=$ORCA_WORKTREE_ID"
+              [ -z "${ORCA_TERMINAL:-}" ] || echo "terminal=$ORCA_TERMINAL"
+            } > "$STATE/$ID.meta" 2>/dev/null || true
+          fi
         fi
       fi
     fi
@@ -1435,8 +1447,8 @@ real_path_or_raw() {  # <path>
 #
 # The refusal exits through the same path as the primary-checkout isolation
 # error above, which already leaves this spawn's own task endpoint behind:
-# spawn_abort_cleanup unwinds herdr projections and orca worktrees (except the
-# sibling-owned one this refusal names, see ORCA_ABORT_KEEP_WORKTREE) but never
+# spawn_abort_cleanup unwinds herdr projections and orca resources (except on a
+# sibling refusal, see ORCA_ABORT_SIBLING_OWNED) but never
 # a tmux window, so `firstmate:fm-<id>` survives and a bare retry then fails with
 # `window ... already exists`. That orphan is pre-existing behaviour shared by
 # both refusals rather than something this guard introduces, and cleaning it up
@@ -1477,14 +1489,14 @@ validate_worktree_free_of_live_sibling() {  # <source> <inspect-target> <worktre
     esac
     # Name the endpoint this refused spawn leaves behind, in the terms of the
     # backend that created it, so the retry sequence needs no source reading.
-    # An orca refusal names no removal step: spawn_abort_cleanup kills whatever
-    # terminal orca had already returned, and ORCA_ABORT_KEEP_WORKTREE holds it
-    # back from removing the worktree, because the path orca handed over is the
-    # one this refusal just proved a live sibling records. That suppression also
-    # keeps the cleanup's removal-failure fallback from writing $STATE/$ID.meta,
-    # so an orca refusal leaves no record of its own either.
+    # An orca refusal names no removal step: ORCA_ABORT_SIBLING_OWNED stops
+    # spawn_abort_cleanup destroying anything, because both the worktree and the
+    # terminal orca handed over can belong to the sibling this refusal just
+    # named. That suppression also keeps the cleanup's removal-failure fallback
+    # from writing $STATE/$ID.meta, so an orca refusal leaves no record of its
+    # own either.
     case "$BACKEND" in
-      orca) leftover=""; ORCA_ABORT_KEEP_WORKTREE=1 ;;
+      orca) leftover=""; ORCA_ABORT_SIBLING_OWNED=1 ;;
       tmux) leftover="remove this spawn's leftover task window with tmux kill-window -t '$inspect_target'; then " ;;
       *) leftover="remove this spawn's leftover $BACKEND task endpoint '$inspect_target'; then " ;;
     esac

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1470,13 +1470,13 @@ validate_worktree_free_of_live_sibling() {  # <source> <inspect-target> <worktre
     esac
     # Name the endpoint this refused spawn leaves behind, in the terms of the
     # backend that created it, so the retry sequence needs no source reading.
-    # An orca refusal is the one that leaves nothing: it fires before the
-    # terminal exists, and spawn_abort_cleanup unwinds the worktree orca did
-    # create, so that path skips the removal step entirely.
+    # An orca refusal is the one that leaves nothing: spawn_abort_cleanup kills
+    # whatever terminal orca had already returned and removes the worktree it
+    # created, so that path skips the removal step entirely.
     case "$BACKEND" in
       orca) leftover="" ;;
-      tmux) leftover="remove this spawn's leftover task window with tmux kill-window -t '$inspect_target', because a bare retry collides with it and bin/fm-teardown.sh $ID cannot clear it (this spawn recorded no metadata); then " ;;
-      *) leftover="remove this spawn's leftover $BACKEND task endpoint '$inspect_target' if it outlived the abort, because a bare retry collides with it and bin/fm-teardown.sh $ID cannot clear it (this spawn recorded no metadata); then " ;;
+      tmux) leftover="remove this spawn's leftover task window with tmux kill-window -t '$inspect_target'; then " ;;
+      *) leftover="remove this spawn's leftover $BACKEND task endpoint '$inspect_target'; then " ;;
     esac
     echo "error: $source handed back a worktree that task $sib_id already records as its own, and $sib_id's endpoint is $sib_state (shared worktree '$wt_real'); refusing to launch to avoid resetting a live worker's checkout. Recover in order: ${leftover}once $sib_id is finished, release its record with bin/fm-teardown.sh $sib_id; then spawn again. Inspect target $inspect_target" >&2
     exit 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -621,6 +621,7 @@ if [ "$BACKEND" = orca ]; then
   fm_backend_orca_runtime_check || exit 1
 fi
 ORCA_ABORT_CLEANUP=0
+ORCA_ABORT_KEEP_WORKTREE=0
 ORCA_WORKTREE_ID=
 ORCA_TERMINAL=
 HERDR_PROJECTION_ABORT_CLEANUP=0
@@ -676,7 +677,7 @@ spawn_abort_cleanup() {
     if [ -n "${ORCA_TERMINAL:-}" ]; then
       fm_backend_kill orca "$ORCA_TERMINAL" 2>/dev/null || true
     fi
-    if [ -n "${ORCA_WORKTREE_ID:-}" ]; then
+    if [ -n "${ORCA_WORKTREE_ID:-}" ] && [ "$ORCA_ABORT_KEEP_WORKTREE" != 1 ]; then
       if ! fm_backend_remove_worktree orca "$ORCA_WORKTREE_ID" 2>/dev/null; then
         mkdir -p "$STATE" 2>/dev/null || true
         if [ -d "$STATE" ]; then
@@ -1410,8 +1411,13 @@ real_path_or_raw() {  # <path>
 # see an idle agent at all; firstmate owns the record that can, because every
 # task writes `worktree=` into state/<id>.meta. This is therefore the correct
 # layer for the guard, and it runs here - before the launched agent has been
-# handed its brief, let alone run `git checkout -b` - which is what keeps a
-# collision recoverable at zero cost.
+# handed its brief, let alone run `git checkout -b` - so no second worker ever
+# starts inside the shared checkout. What it cannot do is prevent the handover
+# itself: on the pooled path `treehouse get` acquires AND resets the slot before
+# this runs, so a refusal means the sibling's uncommitted work must be inspected
+# rather than assumed intact. Holding a slot instead of catching the collision
+# after the fact needs a durable claim inside the pool:
+# https://github.com/kunchenguid/firstmate/issues/1924
 #
 # Liveness comes from bin/fm-backend.sh's fm_backend_agent_state rather than a
 # second notion of "is that worker still there". Only `dead` and `missing`
@@ -1429,8 +1435,9 @@ real_path_or_raw() {  # <path>
 #
 # The refusal exits through the same path as the primary-checkout isolation
 # error above, which already leaves this spawn's own task endpoint behind:
-# spawn_abort_cleanup unwinds herdr projections and orca worktrees but never a
-# tmux window, so `firstmate:fm-<id>` survives and a bare retry then fails with
+# spawn_abort_cleanup unwinds herdr projections and orca worktrees (except the
+# sibling-owned one this refusal names, see ORCA_ABORT_KEEP_WORKTREE) but never
+# a tmux window, so `firstmate:fm-<id>` survives and a bare retry then fails with
 # `window ... already exists`. That orphan is pre-existing behaviour shared by
 # both refusals rather than something this guard introduces, and cleaning it up
 # is deliberately out of scope here; the remedy clause below names the removal
@@ -1470,15 +1477,18 @@ validate_worktree_free_of_live_sibling() {  # <source> <inspect-target> <worktre
     esac
     # Name the endpoint this refused spawn leaves behind, in the terms of the
     # backend that created it, so the retry sequence needs no source reading.
-    # An orca refusal is the one that leaves nothing: spawn_abort_cleanup kills
-    # whatever terminal orca had already returned and removes the worktree it
-    # created, so that path skips the removal step entirely.
+    # An orca refusal names no removal step: spawn_abort_cleanup kills whatever
+    # terminal orca had already returned, and ORCA_ABORT_KEEP_WORKTREE holds it
+    # back from removing the worktree, because the path orca handed over is the
+    # one this refusal just proved a live sibling records. That suppression also
+    # keeps the cleanup's removal-failure fallback from writing $STATE/$ID.meta,
+    # so an orca refusal leaves no record of its own either.
     case "$BACKEND" in
-      orca) leftover="" ;;
+      orca) leftover=""; ORCA_ABORT_KEEP_WORKTREE=1 ;;
       tmux) leftover="remove this spawn's leftover task window with tmux kill-window -t '$inspect_target'; then " ;;
       *) leftover="remove this spawn's leftover $BACKEND task endpoint '$inspect_target'; then " ;;
     esac
-    echo "error: $source handed back a worktree that task $sib_id already records as its own, and $sib_id's endpoint is $sib_state (shared worktree '$wt_real'); refusing to launch to avoid resetting a live worker's checkout. Recover in order: ${leftover}once $sib_id is finished, release its record with bin/fm-teardown.sh $sib_id; then spawn again. Inspect target $inspect_target" >&2
+    echo "error: $source handed back a worktree that task $sib_id already records as its own, and $sib_id's endpoint is $sib_state (shared worktree '$wt_real'); refusing to launch a second worker into that checkout. The pool may already have reset it, so inspect $sib_id's uncommitted work rather than assuming it survived. Recover in order: ${leftover}once $sib_id is finished, release its record with bin/fm-teardown.sh $sib_id; then spawn again. Inspect target $inspect_target" >&2
     exit 1
   done
 }

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1426,9 +1426,19 @@ real_path_or_raw() {  # <path>
 # it. The refusal is also narrow - it fires only for a spawn that lands on that
 # one recorded path, so an unreadable record cannot stall the fleet, only the
 # reuse of its own slot, which `bin/fm-teardown.sh` releases.
+#
+# The refusal exits through the same path as the primary-checkout isolation
+# error above, which already leaves this spawn's own task endpoint behind:
+# spawn_abort_cleanup unwinds herdr projections and orca worktrees but never a
+# tmux window, so `firstmate:fm-<id>` survives and a bare retry then fails with
+# `window ... already exists`. That orphan is pre-existing behaviour shared by
+# both refusals rather than something this guard introduces, and cleaning it up
+# is deliberately out of scope here; the remedy clause below names the removal
+# step instead. Follow-up:
+# https://github.com/kunchenguid/firstmate/issues/1913
 validate_worktree_free_of_live_sibling() {  # <source> <inspect-target> <worktree-real-path>
   local source=$1 inspect_target=$2 wt_real=$3
-  local meta sib_id sib_wt sib_wt_real sib_backend sib_target sib_state
+  local meta sib_id sib_wt sib_wt_real sib_backend sib_target sib_state leftover
   for meta in "$STATE"/*.meta; do
     [ -f "$meta" ] || continue
     sib_id=$(basename "$meta" .meta)
@@ -1444,7 +1454,12 @@ validate_worktree_free_of_live_sibling() {  # <source> <inspect-target> <worktre
     sib_wt_real=$(real_path_or_raw "$sib_wt")
     [ "$sib_wt_real" = "$wt_real" ] || continue
     sib_backend=$(fm_backend_of_meta "$meta")
-    sib_target=$(fm_backend_target_of_meta "$meta")
+    # `|| true` because fm_backend_target_of_meta reports an absent endpoint by
+    # returning non-zero, and under this script's `set -eu` a bare assignment
+    # from it would abort the whole spawn with no diagnostic at all, leaving the
+    # unreadable verdict below unreachable. A record with no readable endpoint
+    # still refuses; it does not release the claim.
+    sib_target=$(fm_backend_target_of_meta "$meta" || true)
     if [ -n "$sib_target" ]; then
       sib_state=$(fm_backend_agent_state "$sib_backend" "$sib_target")
     else
@@ -1453,7 +1468,17 @@ validate_worktree_free_of_live_sibling() {  # <source> <inspect-target> <worktre
     case "$sib_state" in
       dead|missing) continue ;;
     esac
-    echo "error: $source handed back a worktree that task $sib_id already records as its own, and $sib_id's endpoint is $sib_state (shared worktree '$wt_real'); refusing to launch to avoid resetting a live worker's checkout. If $sib_id is finished, release its record with bin/fm-teardown.sh $sib_id and spawn again. Inspect target $inspect_target" >&2
+    # Name the endpoint this refused spawn leaves behind, in the terms of the
+    # backend that created it, so the retry sequence needs no source reading.
+    # An orca refusal is the one that leaves nothing: it fires before the
+    # terminal exists, and spawn_abort_cleanup unwinds the worktree orca did
+    # create, so that path skips the removal step entirely.
+    case "$BACKEND" in
+      orca) leftover="" ;;
+      tmux) leftover="remove this spawn's leftover task window with tmux kill-window -t '$inspect_target', because a bare retry collides with it and bin/fm-teardown.sh $ID cannot clear it (this spawn recorded no metadata); then " ;;
+      *) leftover="remove this spawn's leftover $BACKEND task endpoint '$inspect_target' if it outlived the abort, because a bare retry collides with it and bin/fm-teardown.sh $ID cannot clear it (this spawn recorded no metadata); then " ;;
+    esac
+    echo "error: $source handed back a worktree that task $sib_id already records as its own, and $sib_id's endpoint is $sib_state (shared worktree '$wt_real'); refusing to launch to avoid resetting a live worker's checkout. Recover in order: ${leftover}once $sib_id is finished, release its record with bin/fm-teardown.sh $sib_id; then spawn again. Inspect target $inspect_target" >&2
     exit 1
   done
 }

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -193,6 +193,7 @@ family_for_basename() {
     fm-herdr-session-cleanup.test.sh|fm-send-resolve-key.test.sh|fm-send-strict.test.sh|fm-spawn-batch.test.sh|\
     fm-spawn-dispatch-profile.test.sh|\
     fm-trace-context-spawn.test.sh|fm-spawn-worktree-settle.test.sh|\
+    fm-spawn-sibling-worktree.test.sh|\
     fm-teardown-endpoint-safety.test.sh)
       printf '%s\n' backend-dispatch
       ;;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -139,6 +139,8 @@ Crewmates never intentionally touch your project clone; [treehouse](https://gith
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout and unclaimed by another live task in this home.
 A worktree pool decides a slot is in use by finding live processes whose working directory sits inside it, so a thinking, waiting, or idle agent's own worktree can read as free and be handed out again, then reset to a clean detached HEAD under the running agent.
 The `worktree=` field every task records in `state/<id>.meta` is the only record that can see that claim, which is why the guard sits in the spawn path rather than in the pool, and why it refuses on any liveness verdict except an authoritatively dead or missing endpoint.
+The refusal stops a second worker from taking over that checkout, but on the pooled path `treehouse get` has already handed the slot over and reset it by the time the spawn can object, so the sibling's uncommitted work must be inspected rather than assumed intact.
+Closing that window needs a durable claim inside the pool itself and is tracked in [issue 1924](https://github.com/kunchenguid/firstmate/issues/1924).
 `bin/fm-spawn.sh`'s header owns the exact verdicts, the physical-path comparison, and the remedy the refusal prints.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -136,7 +136,10 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 ## Worktrees, not branches in your checkout
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
-For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
+For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout and unclaimed by another live task in this home.
+A worktree pool decides a slot is in use by finding live processes whose working directory sits inside it, so a thinking, waiting, or idle agent's own worktree can read as free and be handed out again, then reset to a clean detached HEAD under the running agent.
+The `worktree=` field every task records in `state/<id>.meta` is the only record that can see that claim, which is why the guard sits in the spawn path rather than in the pool, and why it refuses on any liveness verdict except an authoritatively dead or missing endpoint.
+`bin/fm-spawn.sh`'s header owns the exact verdicts, the physical-path comparison, and the remedy the refusal prints.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.
 Its operating checkout (`FM_ROOT`) and the disposable crewmate worktrees are all linked git worktrees of the same repository, so the valid discriminator is branch state, not whether the checkout is linked.

--- a/tests/fm-spawn-sibling-worktree.test.sh
+++ b/tests/fm-spawn-sibling-worktree.test.sh
@@ -16,7 +16,9 @@
 # inventory and foreground command name are the two signals
 # fm_backend_tmux_agent_state reads, so listing or omitting the sibling's window
 # and naming an agent or a shell as its foreground command selects `alive`,
-# `missing`, or `unreadable` deterministically.
+# `missing`, or `unreadable` deterministically. One case needs no fake at all:
+# a record carrying no window= line names no endpoint to probe, and reaches the
+# same `unreadable` verdict from the metadata alone.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -120,6 +122,22 @@ write_sibling() {
     "yolo=off"
 }
 
+# write_endpointless_sibling <id> <worktree-path>: the same durable record with
+# no window= line at all. fm_backend_target_of_meta reports that absent endpoint
+# by returning non-zero, so this shape is what proves the guard reads the
+# unreadable verdict instead of dying on it under the spawn's `set -eu`.
+write_endpointless_sibling() {
+  local id=$1 worktree=$2
+  fm_write_meta "$HOME_DIR/state/$id.meta" \
+    "endpoint_task_id=$id" \
+    "worktree=$worktree" \
+    "project=$PROJ_DIR" \
+    "harness=codex" \
+    "kind=crewmate" \
+    "mode=no-mistakes" \
+    "yolo=off"
+}
+
 run_spawn() {
   local id=$1
   seed_brief "$id"
@@ -180,6 +198,12 @@ test_live_sibling_refuses() {
   [ "$status" -ne 0 ] || fail "spawn succeeded onto a live sibling's worktree"
   assert_contains "$out" "sibling-idle-worker" "the refusal did not name the offending task"
   assert_contains "$out" "$WT_REAL" "the refusal did not name the shared worktree"
+  # The refused spawn's own task window outlives the refusal (spawn_abort_cleanup
+  # never removes one), so a bare retry collides with it and no teardown can
+  # clear it - the record it would need was never written. The diagnostic has to
+  # name that window itself rather than leave the operator to derive it.
+  assert_contains "$out" "tmux kill-window -t 'firstmate:fm-$id'" \
+    "the refusal did not name the leftover task window blocking a retry"
   assert_absent "$HOME_DIR/state/$id.meta" "the refused spawn still recorded metadata"
   assert_no_agent_launched "the refused spawn still launched an agent onto the shared worktree"
   pass "a worktree recorded by a live sibling refuses the spawn"
@@ -234,9 +258,31 @@ test_unreadable_sibling_refuses() {
   status=$?
   [ "$status" -ne 0 ] || fail "spawn succeeded onto a sibling whose liveness could not be read"
   assert_contains "$out" "sibling-unknown-worker" "the refusal did not name the offending task"
+  assert_contains "$out" "$WT_REAL" "the refusal did not name the shared worktree"
   assert_contains "$out" "unreadable" "the refusal did not report the endpoint verdict"
   assert_no_agent_launched "the refused spawn still launched an agent onto the shared worktree"
   pass "an unreadable sibling endpoint refuses rather than releasing the claim"
+}
+
+# A sibling record with no window= line at all names no endpoint to probe.
+# fm_backend_target_of_meta signals that by returning non-zero, so the guard has
+# to tolerate the failure explicitly: a bare assignment from it would trip the
+# spawn's `set -eu` and exit 1 with no diagnostic, silently skipping the refusal
+# this record must produce. The assertions below therefore check both halves -
+# that the spawn refuses, and that it refused out loud.
+test_endpointless_sibling_refuses_with_a_diagnostic() {
+  local id=sibling-endpointless-a7 out status
+  make_case sibling-endpointless
+  write_endpointless_sibling sibling-no-window-worker "$WT_DIR"
+  out=$(run_spawn "$id")
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn succeeded onto a sibling record naming no endpoint"
+  assert_contains "$out" "error:" "the spawn died without any diagnostic"
+  assert_contains "$out" "sibling-no-window-worker" "the refusal did not name the offending task"
+  assert_contains "$out" "$WT_REAL" "the refusal did not name the shared worktree"
+  assert_contains "$out" "unreadable" "the refusal did not report the endpoint verdict"
+  assert_no_agent_launched "the refused spawn still launched an agent onto the shared worktree"
+  pass "a sibling record with no endpoint refuses with a named diagnostic"
 }
 
 # A record written through a symlinked prefix and with a trailing slash spells
@@ -254,6 +300,7 @@ test_differently_spelled_path_is_caught() {
   status=$?
   [ "$status" -ne 0 ] || fail "spawn succeeded onto a differently-spelled path for a live sibling's worktree"
   assert_contains "$out" "sibling-symlinked-worker" "the refusal did not name the offending task"
+  assert_contains "$out" "$WT_REAL" "the refusal did not name the resolved shared worktree"
   assert_no_agent_launched "the refused spawn still launched an agent onto the shared worktree"
   pass "a symlinked, trailing-slash spelling of the same worktree is still caught"
 }
@@ -263,6 +310,7 @@ test_live_sibling_refuses
 test_dead_sibling_still_spawns
 test_own_record_does_not_refuse_itself
 test_unreadable_sibling_refuses
+test_endpointless_sibling_refuses_with_a_diagnostic
 test_differently_spelled_path_is_caught
 
 echo "# all fm-spawn-sibling-worktree tests passed"

--- a/tests/fm-spawn-sibling-worktree.test.sh
+++ b/tests/fm-spawn-sibling-worktree.test.sh
@@ -90,10 +90,19 @@ case "${1:-} ${2:-}" in
   "status "*) printf '{"ok":true,"result":{"runtime":{"reachable":true,"state":"ready"}}}\n' ;;
   "repo show"*) printf '{"ok":true,"result":{"repo":{"id":"repo-1"}}}\n' ;;
   "worktree create"*)
-    printf '{"ok":true,"result":{"worktree":{"id":"wt-1","path":"%s"}}}\n' "${FM_FAKE_ORCA_WT_PATH:-}"
+    if [ -n "${FM_FAKE_ORCA_CREATE_TERMINAL:-}" ]; then
+      printf '{"ok":true,"result":{"worktree":{"id":"wt-1","path":"%s"},"terminal":{"handle":"%s"}}}\n' \
+        "${FM_FAKE_ORCA_WT_PATH:-}" "$FM_FAKE_ORCA_CREATE_TERMINAL"
+    else
+      printf '{"ok":true,"result":{"worktree":{"id":"wt-1","path":"%s"}}}\n' "${FM_FAKE_ORCA_WT_PATH:-}"
+    fi
     ;;
   "worktree rm"*)
     rm -rf "${FM_FAKE_ORCA_WT_PATH:?orca worktree rm without a path}"
+    printf '{"ok":true,"result":{}}\n'
+    ;;
+  "terminal close"*)
+    [ -z "${FM_FAKE_ORCA_TERMINAL_FILE:-}" ] || rm -f "$FM_FAKE_ORCA_TERMINAL_FILE"
     printf '{"ok":true,"result":{}}\n'
     ;;
   "terminal create"*) printf '{"ok":true,"result":{"terminal":{"handle":"term-1"}}}\n' ;;
@@ -119,6 +128,8 @@ make_case() {
   FAKE_WINDOWS=''
   FAKE_LIST_FAIL=''
   FAKE_PANE_COMMAND=zsh
+  FAKE_ORCA_CREATE_TERMINAL=''
+  FAKE_ORCA_TERMINAL_FILE=''
   FAKEBIN_DIR=$(make_sibling_fakebin "$case_dir/fake")
   mkdir -p "$HOME_DIR/data" "$HOME_DIR/projects" "$HOME_DIR/state" "$HOME_DIR/config"
   printf 'codex\n' > "$HOME_DIR/config/crew-harness"
@@ -188,6 +199,8 @@ run_spawn() {
     FM_FAKE_TMUX_LOG="$LOG_FILE" \
     FM_FAKE_ORCA_WT_PATH="$WT_DIR" \
     FM_FAKE_ORCA_LOG="$ORCA_LOG" \
+    FM_FAKE_ORCA_CREATE_TERMINAL="${FAKE_ORCA_CREATE_TERMINAL:-}" \
+    FM_FAKE_ORCA_TERMINAL_FILE="${FAKE_ORCA_TERMINAL_FILE:-}" \
     PATH="$FAKEBIN_DIR:$PATH" \
     "$SPAWN" "$id" "$PROJ_DIR" --mode no-mistakes --yolo off "$@" 2>&1
 }
@@ -366,6 +379,33 @@ test_orca_refusal_keeps_the_siblings_worktree() {
   pass "an orca refusal leaves the live sibling's worktree in place"
 }
 
+# The worktree is not the only thing the abort trap destroys. Orca returns a
+# terminal handle alongside the worktree it hands back, and
+# parse_orca_worktree_result stores it before the guard runs, so on a refusal
+# that handle can be the live sibling's own terminal - closing it is the same
+# destruction the worktree case guards against, reached by the other statement
+# in the same block. The fake's `terminal close` really removes the sentinel, so
+# this cannot pass on an absent log line.
+test_orca_refusal_keeps_the_siblings_terminal() {
+  local id=sibling-orca-term-a9 out status
+  make_case sibling-orca-term
+  write_sibling sibling-orca-term-worker "$WT_DIR"
+  FAKE_WINDOWS='fm-sibling-orca-term-worker'
+  FAKE_PANE_COMMAND=claude
+  FAKE_ORCA_CREATE_TERMINAL=term-sibling
+  FAKE_ORCA_TERMINAL_FILE="$CASE_DIR/sibling-terminal-alive"
+  : > "$FAKE_ORCA_TERMINAL_FILE"
+  out=$(run_spawn "$id" --backend orca)
+  status=$?
+  [ "$status" -ne 0 ] || fail "orca spawn succeeded onto a live sibling's worktree"
+  assert_contains "$out" "sibling-orca-term-worker" "the refusal did not name the offending task"
+  [ -f "$FAKE_ORCA_TERMINAL_FILE" ] || fail "the orca refusal closed the live sibling's terminal"
+  [ -d "$WT_DIR" ] || fail "the orca refusal removed the live sibling's worktree"
+  assert_no_grep 'terminal close' "$ORCA_LOG" \
+    "the orca refusal asked orca to close the live sibling's terminal"
+  pass "an orca refusal leaves the live sibling's terminal open"
+}
+
 test_clean_spawn_still_succeeds
 test_live_sibling_refuses
 test_dead_sibling_still_spawns
@@ -374,5 +414,6 @@ test_unreadable_sibling_refuses
 test_endpointless_sibling_refuses_with_a_diagnostic
 test_differently_spelled_path_is_caught
 test_orca_refusal_keeps_the_siblings_worktree
+test_orca_refusal_keeps_the_siblings_terminal
 
 echo "# all fm-spawn-sibling-worktree tests passed"

--- a/tests/fm-spawn-sibling-worktree.test.sh
+++ b/tests/fm-spawn-sibling-worktree.test.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+# Regression test for fm-spawn.sh's live-sibling worktree guard
+# (validate_worktree_free_of_live_sibling, reached from validate_spawn_worktree).
+#
+# The worktree pool decides a slot is in use by looking for live processes whose
+# working directory sits inside it, so an agent that is thinking, waiting on the
+# network, or idle between commands reads as absent and the next `treehouse get`
+# hands its slot to the following spawn - which then resets it to a clean
+# detached HEAD, destroying the running agent's branch checkout. Firstmate holds
+# the record the pool cannot see: every task writes worktree= into
+# state/<id>.meta. These cases drive that record directly rather than trying to
+# race a real pool, because the live bug needs an IDLE agent to reproduce and a
+# test built around a raceable, non-idle worker would pass for the wrong reason.
+#
+# The fake tmux below is what makes each liveness verdict reachable: window
+# inventory and foreground command name are the two signals
+# fm_backend_tmux_agent_state reads, so listing or omitting the sibling's window
+# and naming an agent or a shell as its foreground command selects `alive`,
+# `missing`, or `unreadable` deterministically.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-sibling-worktree)
+
+# make_sibling_fakebin <dir> builds a fake tmux driven entirely by environment:
+#   FM_FAKE_PANE_PATH        the pane cwd `treehouse get` settles into
+#   FM_FAKE_WINDOWS          newline-separated window names `list-windows -t`
+#                            reports (empty = the session has no windows)
+#   FM_FAKE_LIST_FAIL        when non-empty, `list-windows -t` fails printing
+#                            this text - an inventory read that neither names
+#                            the window nor proves the session gone
+#   FM_FAKE_PANE_COMMAND     what `#{pane_current_command}` reports
+#   FM_FAKE_TMUX_LOG         file every invocation is appended to
+# pane_tty is deliberately answered empty so the foreground process-group half
+# of the liveness probe reports nothing and the verdict rests on the two signals
+# this fake can actually control.
+make_sibling_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+[ -z "${FM_FAKE_TMUX_LOG:-}" ] || printf '%s\n' "$*" >> "$FM_FAKE_TMUX_LOG"
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+  *"#{pane_tty}"*) exit 0 ;;
+  *"#{pane_current_command}"*) printf '%s\n' "${FM_FAKE_PANE_COMMAND:-zsh}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows)
+    if [ -n "${FM_FAKE_LIST_FAIL:-}" ]; then
+      printf '%s\n' "$FM_FAKE_LIST_FAIL" >&2
+      exit 1
+    fi
+    [ -z "${FM_FAKE_WINDOWS:-}" ] || printf '%s\n' "$FM_FAKE_WINDOWS"
+    exit 0
+    ;;
+  has-session|new-session|new-window|kill-window|set-window-option) exit 0 ;;
+  send-keys) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  printf '%s\n' "$fakebin"
+}
+
+# make_case <name> builds a home, a project with one real worktree standing in
+# for the pooled slot, and the fake tmux. The worktree is the path every case
+# below makes the spawn land on.
+make_case() {
+  local name=$1 case_dir
+  case_dir="$TMP_ROOT/$name"
+  CASE_DIR="$case_dir"
+  HOME_DIR="$case_dir/home"
+  PROJ_DIR="$case_dir/project"
+  WT_DIR="$case_dir/wt"
+  LOG_FILE="$case_dir/tmux.log"
+  FAKE_WINDOWS=''
+  FAKE_LIST_FAIL=''
+  FAKE_PANE_COMMAND=zsh
+  FAKEBIN_DIR=$(make_sibling_fakebin "$case_dir/fake")
+  mkdir -p "$HOME_DIR/data" "$HOME_DIR/projects" "$HOME_DIR/state" "$HOME_DIR/config"
+  printf 'codex\n' > "$HOME_DIR/config/crew-harness"
+  fm_git_worktree "$PROJ_DIR" "$WT_DIR" "wt-$name"
+  touch "$HOME_DIR/state/.last-watcher-beat"
+  # The diagnostic reports the physically resolved worktree, and on macOS the
+  # temp root is itself a symlinked, double-slashed spelling of that directory.
+  WT_REAL=$(cd "$WT_DIR" && pwd -P)
+  : > "$LOG_FILE"
+}
+
+seed_brief() {
+  local id=$1
+  mkdir -p "$HOME_DIR/data/$id"
+  printf 'brief for %s\n' "$id" > "$HOME_DIR/data/$id/brief.md"
+}
+
+# write_sibling <id> <worktree-path> [window-name]: the durable record one other
+# task in this home left behind, exactly as fm-spawn writes it.
+write_sibling() {
+  local id=$1 worktree=$2 window=${3:-}
+  # Default the window inside the body, not in the `local` word list: every word
+  # of a `local` command is expanded before the builtin runs, so ${3:-...$id}
+  # would interpolate the CALLER's `id`, quietly pointing the record at the
+  # spawning task's own endpoint and making the collision unreachable.
+  [ -n "$window" ] || window="firstmate:fm-$id"
+  fm_write_meta "$HOME_DIR/state/$id.meta" \
+    "window=$window" \
+    "endpoint_task_id=$id" \
+    "worktree=$worktree" \
+    "project=$PROJ_DIR" \
+    "harness=codex" \
+    "kind=crewmate" \
+    "mode=no-mistakes" \
+    "yolo=off"
+}
+
+run_spawn() {
+  local id=$1
+  seed_brief "$id"
+  FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
+    FM_FAKE_PANE_PATH="$WT_DIR" \
+    FM_FAKE_WINDOWS="${FAKE_WINDOWS:-}" \
+    FM_FAKE_LIST_FAIL="${FAKE_LIST_FAIL:-}" \
+    FM_FAKE_PANE_COMMAND="${FAKE_PANE_COMMAND:-zsh}" \
+    FM_FAKE_TMUX_LOG="$LOG_FILE" \
+    PATH="$FAKEBIN_DIR:$PATH" \
+    "$SPAWN" "$id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1
+}
+
+# assert_no_agent_launched: the refusal has to land before the incoming agent is
+# started, which is what keeps a collision recoverable at zero cost - the new
+# worker never reaches `git checkout -b` because it never runs at all. The pane
+# is allowed to have run `treehouse get` (that is how the collision is
+# discovered); it must not have been handed a harness launch command.
+assert_no_agent_launched() {
+  local msg=$1
+  assert_grep 'treehouse get' "$LOG_FILE" "the spawn never reached worktree acquisition"
+  assert_no_grep 'codex' "$LOG_FILE" "$msg"
+}
+
+# A worktree no other record claims still spawns normally. The sibling here is
+# real and live; it simply sits in a different slot, so the guard must ignore it
+# rather than refusing every spawn that finds any live task in the home.
+test_clean_spawn_still_succeeds() {
+  local id=sibling-clean-a1 out status other_wt
+  make_case sibling-clean
+  other_wt="$CASE_DIR/other-wt"
+  git -C "$PROJ_DIR" worktree add --quiet -b other-slot "$other_wt"
+  write_sibling sibling-live-elsewhere "$other_wt"
+  FAKE_WINDOWS='fm-sibling-live-elsewhere'
+  FAKE_PANE_COMMAND=claude
+  out=$(run_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "spawn should succeed when no record claims this worktree"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  assert_grep "worktree=$WT_DIR" "$HOME_DIR/state/$id.meta" \
+    "meta did not record the acquired worktree"
+  pass "a worktree claimed by nobody still spawns"
+}
+
+# The bug itself: the pool hands over a slot whose owner is idle. The owner's
+# record is what proves the claim, and its endpoint is alive.
+test_live_sibling_refuses() {
+  local id=sibling-collide-a2 out status
+  make_case sibling-collide
+  write_sibling sibling-idle-worker "$WT_DIR"
+  FAKE_WINDOWS='fm-sibling-idle-worker'
+  FAKE_PANE_COMMAND=claude
+  out=$(run_spawn "$id")
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn succeeded onto a live sibling's worktree"
+  assert_contains "$out" "sibling-idle-worker" "the refusal did not name the offending task"
+  assert_contains "$out" "$WT_REAL" "the refusal did not name the shared worktree"
+  assert_absent "$HOME_DIR/state/$id.meta" "the refused spawn still recorded metadata"
+  assert_no_agent_launched "the refused spawn still launched an agent onto the shared worktree"
+  pass "a worktree recorded by a live sibling refuses the spawn"
+}
+
+# Stale metadata outlives its agent and worktrees are pooled, so a record whose
+# endpoint is authoritatively gone must not poison the slot forever. The session
+# inventory here is readable and simply does not contain the recorded window.
+test_dead_sibling_still_spawns() {
+  local id=sibling-dead-a3 out status
+  make_case sibling-dead
+  write_sibling sibling-finished-worker "$WT_DIR"
+  out=$(run_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "a dead sibling's stale record must not block reuse"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  assert_grep "worktree=$WT_DIR" "$HOME_DIR/state/$id.meta" \
+    "meta did not record the reused worktree"
+  pass "a dead sibling's recorded worktree is reusable"
+}
+
+# Recovery re-seats the same task id into the worktree its own record already
+# names. An alive own endpoint is unreachable here - the window-name collision
+# check refuses that spawn earlier, before this guard runs - so the construction
+# that actually exercises the exclusion is an inventory read that fails without
+# proving the session gone. That verdict is `unreadable`, which this guard
+# refuses, and only the $ID exclusion lets the relaunch through.
+test_own_record_does_not_refuse_itself() {
+  local id=sibling-relaunch-a4 out status
+  make_case sibling-relaunch
+  write_sibling "$id" "$WT_DIR"
+  FAKE_LIST_FAIL='connection to server timed out'
+  FAKE_PANE_COMMAND=claude
+  out=$(run_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "a relaunch must not refuse against its own recorded worktree"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  pass "a task's own recorded worktree never refuses its relaunch"
+}
+
+# The divergence that keeps the case above from passing vacuously: the identical
+# unreadable-inventory construction, differing only in which id owns the record,
+# must refuse. Without that, the previous test would also pass if the guard
+# simply never fired on an unreadable endpoint.
+test_unreadable_sibling_refuses() {
+  local id=sibling-unreadable-a5 out status
+  make_case sibling-unreadable
+  write_sibling sibling-unknown-worker "$WT_DIR"
+  FAKE_LIST_FAIL='connection to server timed out'
+  FAKE_PANE_COMMAND=claude
+  out=$(run_spawn "$id")
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn succeeded onto a sibling whose liveness could not be read"
+  assert_contains "$out" "sibling-unknown-worker" "the refusal did not name the offending task"
+  assert_contains "$out" "unreadable" "the refusal did not report the endpoint verdict"
+  assert_no_agent_launched "the refused spawn still launched an agent onto the shared worktree"
+  pass "an unreadable sibling endpoint refuses rather than releasing the claim"
+}
+
+# A record written through a symlinked prefix and with a trailing slash spells
+# the same directory the pool just handed over. Raw string comparison would miss
+# it; both sides resolve physically, exactly as the isolation check already does.
+test_differently_spelled_path_is_caught() {
+  local id=sibling-spelling-a6 out status link
+  make_case sibling-spelling
+  link="$CASE_DIR/wt-link"
+  ln -s "$WT_DIR" "$link"
+  write_sibling sibling-symlinked-worker "$link/"
+  FAKE_WINDOWS='fm-sibling-symlinked-worker'
+  FAKE_PANE_COMMAND=claude
+  out=$(run_spawn "$id")
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn succeeded onto a differently-spelled path for a live sibling's worktree"
+  assert_contains "$out" "sibling-symlinked-worker" "the refusal did not name the offending task"
+  assert_no_agent_launched "the refused spawn still launched an agent onto the shared worktree"
+  pass "a symlinked, trailing-slash spelling of the same worktree is still caught"
+}
+
+test_clean_spawn_still_succeeds
+test_live_sibling_refuses
+test_dead_sibling_still_spawns
+test_own_record_does_not_refuse_itself
+test_unreadable_sibling_refuses
+test_differently_spelled_path_is_caught
+
+echo "# all fm-spawn-sibling-worktree tests passed"

--- a/tests/fm-spawn-sibling-worktree.test.sh
+++ b/tests/fm-spawn-sibling-worktree.test.sh
@@ -68,7 +68,40 @@ exit 0
 SH
   chmod +x "$fakebin/tmux"
   fm_fake_exit0 "$fakebin" treehouse
+  make_sibling_fake_orca "$fakebin"
   printf '%s\n' "$fakebin"
+}
+
+# make_sibling_fake_orca <fakebin> answers the JSON calls the orca spawn path
+# makes before the guard runs, so `--backend orca` reaches validate_spawn_worktree
+# with a worktree id armed for the EXIT trap - the shape the trap's removal
+# actually needs. `worktree rm` deletes the directory exactly as the real removal
+# would, so the assertion that the sibling's checkout survived cannot be
+# satisfied by a log line alone.
+#   FM_FAKE_ORCA_WT_PATH  the worktree path `orca worktree create` hands back
+#   FM_FAKE_ORCA_LOG      file every invocation is appended to
+make_sibling_fake_orca() {
+  local fakebin=$1
+  cat > "$fakebin/orca" <<'SH'
+#!/usr/bin/env bash
+set -u
+[ -z "${FM_FAKE_ORCA_LOG:-}" ] || printf '%s\n' "$*" >> "$FM_FAKE_ORCA_LOG"
+case "${1:-} ${2:-}" in
+  "status "*) printf '{"ok":true,"result":{"runtime":{"reachable":true,"state":"ready"}}}\n' ;;
+  "repo show"*) printf '{"ok":true,"result":{"repo":{"id":"repo-1"}}}\n' ;;
+  "worktree create"*)
+    printf '{"ok":true,"result":{"worktree":{"id":"wt-1","path":"%s"}}}\n' "${FM_FAKE_ORCA_WT_PATH:-}"
+    ;;
+  "worktree rm"*)
+    rm -rf "${FM_FAKE_ORCA_WT_PATH:?orca worktree rm without a path}"
+    printf '{"ok":true,"result":{}}\n'
+    ;;
+  "terminal create"*) printf '{"ok":true,"result":{"terminal":{"handle":"term-1"}}}\n' ;;
+  *) printf '{"ok":true,"result":{}}\n' ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/orca"
 }
 
 # make_case <name> builds a home, a project with one real worktree standing in
@@ -82,6 +115,7 @@ make_case() {
   PROJ_DIR="$case_dir/project"
   WT_DIR="$case_dir/wt"
   LOG_FILE="$case_dir/tmux.log"
+  ORCA_LOG="$case_dir/orca.log"
   FAKE_WINDOWS=''
   FAKE_LIST_FAIL=''
   FAKE_PANE_COMMAND=zsh
@@ -94,6 +128,7 @@ make_case() {
   # temp root is itself a symlinked, double-slashed spelling of that directory.
   WT_REAL=$(cd "$WT_DIR" && pwd -P)
   : > "$LOG_FILE"
+  : > "$ORCA_LOG"
 }
 
 seed_brief() {
@@ -140,6 +175,7 @@ write_endpointless_sibling() {
 
 run_spawn() {
   local id=$1
+  shift
   seed_brief "$id"
   FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
     FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
@@ -150,8 +186,10 @@ run_spawn() {
     FM_FAKE_LIST_FAIL="${FAKE_LIST_FAIL:-}" \
     FM_FAKE_PANE_COMMAND="${FAKE_PANE_COMMAND:-zsh}" \
     FM_FAKE_TMUX_LOG="$LOG_FILE" \
+    FM_FAKE_ORCA_WT_PATH="$WT_DIR" \
+    FM_FAKE_ORCA_LOG="$ORCA_LOG" \
     PATH="$FAKEBIN_DIR:$PATH" \
-    "$SPAWN" "$id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1
+    "$SPAWN" "$id" "$PROJ_DIR" --mode no-mistakes --yolo off "$@" 2>&1
 }
 
 # assert_no_agent_launched: the refusal has to land before the incoming agent is
@@ -305,6 +343,29 @@ test_differently_spelled_path_is_caught() {
   pass "a symlinked, trailing-slash spelling of the same worktree is still caught"
 }
 
+# The orca path is the one that reaches this guard with a worktree of its own
+# already created and ORCA_ABORT_CLEANUP armed, so the refusal's EXIT trap would
+# otherwise remove the very checkout the guard just proved a live sibling
+# records - the guard deleting what it exists to protect, while looking like it
+# worked. The refusal must leave that directory exactly where it is.
+test_orca_refusal_keeps_the_siblings_worktree() {
+  local id=sibling-orca-a8 out status
+  make_case sibling-orca
+  write_sibling sibling-orca-worker "$WT_DIR"
+  FAKE_WINDOWS='fm-sibling-orca-worker'
+  FAKE_PANE_COMMAND=claude
+  out=$(run_spawn "$id" --backend orca)
+  status=$?
+  [ "$status" -ne 0 ] || fail "orca spawn succeeded onto a live sibling's worktree"
+  assert_contains "$out" "sibling-orca-worker" "the refusal did not name the offending task"
+  assert_contains "$out" "$WT_REAL" "the refusal did not name the shared worktree"
+  [ -d "$WT_DIR" ] || fail "the orca refusal removed the live sibling's worktree"
+  assert_no_grep 'worktree rm' "$ORCA_LOG" \
+    "the orca refusal asked orca to remove the live sibling's worktree"
+  assert_absent "$HOME_DIR/state/$id.meta" "the refused orca spawn still recorded metadata"
+  pass "an orca refusal leaves the live sibling's worktree in place"
+}
+
 test_clean_spawn_still_succeeds
 test_live_sibling_refuses
 test_dead_sibling_still_spawns
@@ -312,5 +373,6 @@ test_own_record_does_not_refuse_itself
 test_unreadable_sibling_refuses
 test_endpointless_sibling_refuses_with_a_diagnostic
 test_differently_spelled_path_is_caught
+test_orca_refusal_keeps_the_siblings_worktree
 
 echo "# all fm-spawn-sibling-worktree tests passed"


### PR DESCRIPTION
## The bug

The worktree pool decides a slot is in use by detecting live processes whose working directory is inside it. An agent that is thinking, waiting on the network, or simply idle between commands has no such process, so its own worktree reads as free and the next `treehouse get` hands the slot over. The pool then resets it to a clean detached HEAD, destroying the running agent's branch checkout.

Reproduced twice on 2026-08-07 against `persea`: slot 2 was handed out on two consecutive spawns while a live worker owned it, while slot 6 sat available both times. Not load-related and not random - it recurs for any idle worker. Nothing was lost only because the collision was caught before the new agent ran `git checkout -b`.

## The change

`validate_spawn_worktree` already refused a worktree that is not isolated from the primary checkout. This extends that same validation point: a spawn now also refuses when the acquired worktree is already recorded by another live task in this home, which firstmate knows from each task's `worktree=` in `state/<id>.meta`.

The upstream in-use detection is not touched. This guard is the correct layer because firstmate owns the metadata that knows the truth, and the pool cannot see an idle agent at all.

- Physical paths are compared on both sides, so a symlinked, trailing-slash, or otherwise differently-spelled path still matches.
- The task's own record is excluded, so recovery and re-seating still relaunch into their own recorded worktree.
- Liveness comes from `fm_backend_agent_state` rather than a second liveness notion.

## What the guard does and does not prevent

On the treehouse path the guard runs after `treehouse get` returns, and the pool performs its reset inside that call. So by the time the guard can object, the slot has already been handed over and reset.

What it prevents is the second half of the damage, which is the half that hurt in both observed incidents: a second agent taking over a checkout that another worker is using, and the displaced worker ending up somewhere it should never be.

The refusal message says so plainly and tells the operator not to assume the sibling's uncommitted work is intact. The root cause lives in the pool and is tracked separately in kunchenguid/firstmate#1924.

## Ambiguous liveness: why anything other than dead or missing refuses

Only `dead` and `missing` release a claim. `alive`, `ambiguous`, `unreadable`, and `unverified` all refuse.

- It matches this file's existing duplicate-launch guard, which already treats an unreadable endpoint exactly like a live one.
- The errors are asymmetric. A wrong refusal costs one spawn, and the diagnostic names the exact record to clear. Wrongly proceeding resets a live worker's branch checkout out from under it, which is the bug being fixed.
- The refusal is narrow. It fires only for a spawn that lands on that one recorded path, so an unreadable record stalls reuse of its own slot rather than the fleet, and `bin/fm-teardown.sh` releases the record.

The operational consequence is that `zellij`, `cmux`, and `orca` siblings report `unverified`, so a stale record from one of those holds its pooled slot until an operator tears it down. That is the deliberate cost of the direction above.

## Orphan window on refusal

A refusal exits after the task window was created, and the abort cleanup does not remove a tmux window. The refusal diagnostic therefore names the manual `tmux kill-window` step so its stated remedy actually works.

The window itself is left alone on purpose. This is pre-existing behaviour: the primary-checkout isolation refusal exits on the same path and leaves the same orphan. Cleaning it up belongs in its own change scoped to every refusal on that path rather than to one caller, and is tracked in kunchenguid/firstmate#1913.

## Orca abort cleanup

The orca branch sets `ORCA_ABORT_CLEANUP=1` before validation runs, so a refusal used to reach `spawn_abort_cleanup` and destroy the very resources the guard had just proved a live sibling owns. That ordering was safe before this change, because the only previous refusal reason was a worktree identical to the primary checkout, which orca never creates. This change adds a refusal reason where those resources belong to somebody else.

The cleanup destroys two things: it closes `ORCA_TERMINAL` and it removes `ORCA_WORKTREE_ID`. Both are at risk on a refusal, because `fm_backend_orca_worktree_create` returns a `worktree-terminal-handle` alongside the worktree and `parse_orca_worktree_result` stores it before the guard runs, so that handle can be the sibling's own terminal exactly as the path can be its worktree.

One condition (`ORCA_ABORT_SIBLING_OWNED`) therefore gates the whole block rather than the two statements separately, so a resource added there later is covered without rediscovering this. Every other abort still destroys both resources exactly as before.

## Tests

Colocated in `tests/fm-spawn-sibling-worktree.test.sh`, following the existing `fm-spawn` conventions and the fake-backend plus real-git-worktree harness already used by `tests/fm-spawn-worktree-settle.test.sh`.

Covered: a clean spawn still succeeds; a live sibling refuses; a dead sibling still spawns; a task's own record does not refuse its relaunch; an endpointless sibling record refuses with a diagnostic instead of dying silently; an unreadable endpoint refuses; differently-spelled paths resolving to the same directory are caught; and an orca refusal leaves both the sibling's worktree and the sibling's terminal intact.

The two orca cases drive a real `--backend orca` refusal rather than asserting on source text. The fake `orca worktree rm` deletes the directory and the fake `orca terminal close` removes a sentinel file, so neither assertion can be satisfied by a missing log line alone.

Each guard case was mutation-checked: disabling the guard fails the refusal cases, disabling the own-id exclusion fails the relaunch case, reverting the errexit fix fails the endpointless case with the exact silent-death shape, and disabling the orca trap gate fails the worktree case and, checked in isolation, the terminal case with "the orca refusal closed the live sibling's terminal".

## What is not covered

- The real race is not staged. Reproducing it needs an idle agent, so the guard is tested against constructed `state/<id>.meta` records rather than by racing a live pool. Testing the pool directly would have meant a weaker test that passes for the wrong reason.
- Whether orca's `worktree create` can return an already-existing worktree was not confirmed against a live orca. The suppression does not depend on that question, since it gates on the refusal rather than on how the resource was obtained, but it is the reason the terminal case is stated as a real risk rather than a hypothetical: the handle reaches `ORCA_TERMINAL` from the create result either way.
