### PR TITLE
feat: support Gitea-hosted PRs alongside GitHub in the PR lifecycle scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ state/               volatile runtime signals; gitignored
   <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth
   <id>.turn-ended    touched by turn-end hooks
   <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
-  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; kind=secondmate also records home= and projects=; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, appends pr= and GitHub's pr_head= when available; fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for an X-mode-originated task (section 14)
+  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; kind=secondmate also records home= and projects=; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, appends pr= and the forge's pr_head= when available; fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for an X-mode-originated task (section 14)
   <id>.check.sh      optional slow poll you write per task (e.g. merged-PR check)
   x-watch.check.sh   generated X-mode relay poll shim; present only when opted in (section 14)
   x-inbox/           generated X-mode pending mention payloads; fmx-respond drains it (section 14)
@@ -459,9 +459,9 @@ Firstmate's own repo is the exception: its `.no-mistakes/` stays gitignored, unt
 This do-not-fight rule does not license evidence commits in firstmate's own repo.
 
 **yolo (orthogonal).** With `yolo=off` (default) every approval is the captain's: ask-user findings, PR merges, the local-only merge.
-With `yolo=on`, firstmate makes those calls itself without asking - resolve ask-user findings on your judgment, and run `bin/fm-pr-merge.sh <id> <full GitHub PR URL>` / `bin/fm-merge-local.sh` once the work is green/approved - EXCEPT anything destructive, irreversible, or security-sensitive, which still escalates to the captain.
+With `yolo=on`, firstmate makes those calls itself without asking - resolve ask-user findings on your judgment, and run `bin/fm-pr-merge.sh <id> <full PR URL>` / `bin/fm-merge-local.sh` once the work is green/approved - EXCEPT anything destructive, irreversible, or security-sensitive, which still escalates to the captain.
 Never merge a red PR even under yolo.
-`bin/fm-pr-merge.sh` always records `pr=` and records `pr_head=` when available before merging, parses the full `https://github.com/<owner>/<repo>/pull/<n>` URL into `gh-axi pr merge <n> --repo <owner>/<repo>`, and defaults to `--squash` unless an explicit merge method is forwarded after `--`; this holds even on a repo with no PR CI where the "checks green" signal that normally triggers `bin/fm-pr-check.sh` never fires - do not call `gh-axi pr merge` directly for a task's PR, or the recording step can be silently skipped and a later `fm-teardown.sh` has nothing to verify a squash merge against.
+`bin/fm-pr-merge.sh` always records `pr=` and records `pr_head=` when available before merging; it detects the forge from the PR URL's shape alone (`bin/fm-pr-url-lib.sh`: singular `https://github.com/<owner>/<repo>/pull/<n>` is GitHub, plural `https://<any-host>/<owner>/<repo>/pulls/<n>` is Gitea), never a hardcoded hostname. A GitHub URL parses into `gh-axi pr merge <n> --repo <owner>/<repo>` and defaults to `--squash` unless an explicit merge method is forwarded after `--`. A Gitea URL parses into `tea pulls merge <n> --repo <owner>/<repo>` (run with cwd inside the task's worktree so tea resolves login/host from its origin remote) and defaults to `--style squash` unless the caller passes an explicit `--style`; this holds even on a repo with no PR CI where the "checks green" signal that normally triggers `bin/fm-pr-check.sh` never fires - do not call `gh-axi pr merge` or `tea pulls merge` directly for a task's PR, or the recording step can be silently skipped and a later `fm-teardown.sh` has nothing to verify a squash merge against.
 After any merge you perform without asking the captain, post a one-line "merged <full PR URL or local main> after checks passed" FYI so the captain keeps a trail.
 
 ### Validate
@@ -494,13 +494,13 @@ During the `ci` monitor phase, `bin/fm-crew-state.sh` also reads the ci step log
 ### PR ready
 
 For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
-Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and GitHub's `pr_head=` when available in the task's meta and arms the watcher's merge poll.
+Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the watcher's merge poll (GitHub via `gh`, Gitea via `tea`, detected from the URL's shape).
 Tell the captain: the PR's full URL (always the complete `https://...` link, never a bare `#number` - the captain's terminal makes a full URL clickable), a one-paragraph summary, and, for `no-mistakes`, the risk level it emitted.
 (The check contract, for any custom `state/<id>.check.sh` you write yourself: print one line only when firstmate should wake, print nothing otherwise, and finish before `FM_CHECK_TIMEOUT`.)
 
-If the captain says "merge it", run `bin/fm-pr-merge.sh <id> <full GitHub PR URL>` yourself; that instruction is the explicit approval.
+If the captain says "merge it", run `bin/fm-pr-merge.sh <id> <full PR URL>` yourself; that instruction is the explicit approval.
 If `yolo=on`, merge a green/approved PR yourself the same way and post the required FYI.
-The helper defaults to `--squash`, accepts explicit merge-method flags such as `-- --merge`, `-- --rebase`, or `-- --method=merge`, and refuses `--repo` or `-R` overrides because the repository is derived from the URL.
+For a GitHub PR the helper defaults to `--squash` and accepts explicit merge-method flags such as `-- --merge`, `-- --rebase`, or `-- --method=merge`; for a Gitea PR it defaults to `--style squash` and accepts an explicit `-- --style <merge|rebase|squash|rebase-merge>`. Either way it refuses `--repo` or `-R` overrides because the repository is derived from the URL.
 
 ### Ship teardown (only after merge is confirmed)
 
@@ -701,7 +701,7 @@ If the primary leaves the file absent, each home uses the default tasks-axi back
 Keep Done to the 10 most recent entries.
 With the active compatible tasks-axi backend, `tasks-axi done` auto-prunes Done and archives pruned entries to `data/done-archive.md`, so do not hand-prune.
 When hand-editing, prune older Done entries manually whenever you add to the section.
-Pruning loses nothing: finished PR-based ship tasks live on as GitHub PRs, local-only ship tasks live on in local `main`, and scout tasks live on as report files.
+Pruning loses nothing: finished PR-based ship tasks live on as GitHub or Gitea PRs, local-only ship tasks live on in local `main`, and scout tasks live on as report files.
 Map firstmate's real backlog operations to the approved commands:
 
 - File an item: `tasks-axi add <id> "<one line>" --kind <ship|scout> --repo <name>`, plus `--start` for immediate dispatch (In flight) or the default queue placement, and `--blocked-by <id>` (repeatable) when it waits on another task.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Full detail on every feature lives in [docs/architecture.md](docs/architecture.m
 ### Requirements
 
 - A verified agent harness: Claude Code, Grok, Pi, Codex, or OpenCode.
-- Git and the GitHub CLI, authenticated through `gh auth login`.
+- Git and the GitHub CLI, authenticated through `gh auth login`. A project hosted on a self-managed Gitea instead needs the `tea` CLI, authenticated for that host.
 - tmux, for the reference session backend.
 
 The first mate detects and offers to install everything else.

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
-# Record a PR-ready task: appends pr=<url> and GitHub's pr_head=<sha> to
+# Record a PR-ready task: appends pr=<url> and the forge's pr_head=<sha> to
 # state/<id>.meta when available, then arms the watcher's merge poll by writing
 # state/<id>.check.sh, which prints one line iff the PR is merged (the watcher's
 # check contract: output = wake firstmate, silence = keep sleeping).
+# The PR URL's shape (fm-pr-url-lib.sh) picks the forge: a GitHub URL uses gh; a
+# Gitea URL (any host, plural "pulls") uses tea, run with cwd inside the task's
+# worktree so tea auto-discovers the right login/host from its origin remote.
 # Usage: fm-pr-check.sh <task-id> <pr-url>
 set -eu
 
@@ -10,18 +13,32 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+# shellcheck source=bin/fm-pr-url-lib.sh
+. "$SCRIPT_DIR/fm-pr-url-lib.sh"
 "$FM_ROOT/bin/fm-guard.sh" || true
 ID=$1
 URL=$2
+
+WT=
+fm_parse_pr_url "$URL" || true
+FORGE=$FM_PR_FORGE
 
 META="$STATE/$ID.meta"
 if [ -f "$META" ]; then
   WT=$(grep '^worktree=' "$META" | tail -1 | cut -d= -f2- || true)
   PR_HEAD=
   if [ -n "$WT" ] && [ -d "$WT" ]; then
-    if command -v gh >/dev/null 2>&1; then
-      if REMOTE_HEAD=$(cd "$WT" && gh pr view "$URL" --json headRefOid -q .headRefOid 2>/dev/null); then
-        PR_HEAD=$REMOTE_HEAD
+    if [ "$FORGE" = gitea ]; then
+      if command -v tea >/dev/null 2>&1; then
+        if REMOTE_HEAD=$(cd "$WT" && tea pulls "$FM_PR_NUMBER" --repo "$FM_PR_OWNER/$FM_PR_REPO" -o json 2>/dev/null | jq -r '.headSha // empty'); then
+          [ -n "$REMOTE_HEAD" ] && PR_HEAD=$REMOTE_HEAD
+        fi
+      fi
+    else
+      if command -v gh >/dev/null 2>&1; then
+        if REMOTE_HEAD=$(cd "$WT" && gh pr view "$URL" --json headRefOid -q .headRefOid 2>/dev/null); then
+          PR_HEAD=$REMOTE_HEAD
+        fi
       fi
     fi
   fi
@@ -33,8 +50,15 @@ if [ -f "$META" ]; then
   fi
 fi
 
-cat > "$STATE/$ID.check.sh" <<EOF
+if [ "$FORGE" = gitea ]; then
+  cat > "$STATE/$ID.check.sh" <<EOF
+state=\$(cd "$WT" 2>/dev/null && tea pulls "$FM_PR_NUMBER" --repo "$FM_PR_OWNER/$FM_PR_REPO" -o json 2>/dev/null | jq -r '.hasMerged // false')
+[ "\$state" = "true" ] && echo "merged"
+EOF
+else
+  cat > "$STATE/$ID.check.sh" <<EOF
 state=\$(gh pr view "$URL" --json state -q .state 2>/dev/null)
 [ "\$state" = "MERGED" ] && echo "merged"
 EOF
+fi
 echo "armed: state/$ID.check.sh polls $URL"

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -52,8 +52,11 @@ fi
 
 if [ "$FORGE" = gitea ]; then
   cat > "$STATE/$ID.check.sh" <<EOF
-state=\$(cd "$WT" 2>/dev/null && tea pulls "$FM_PR_NUMBER" --repo "$FM_PR_OWNER/$FM_PR_REPO" -o json 2>/dev/null | jq -r '.hasMerged // false')
-[ "\$state" = "true" ] && echo "merged"
+WT=\$(grep '^worktree=' "$META" | tail -1 | cut -d= -f2- || true)
+if [ -n "\$WT" ] && [ -d "\$WT" ]; then
+  state=\$(cd "\$WT" 2>/dev/null && tea pulls "$FM_PR_NUMBER" --repo "$FM_PR_OWNER/$FM_PR_REPO" -o json 2>/dev/null | jq -r '.hasMerged // false')
+  [ "\$state" = "true" ] && echo "merged"
+fi
 EOF
 else
   cat > "$STATE/$ID.check.sh" <<EOF

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -18,24 +18,32 @@
 # parse a full https://github.com/<owner>/<repo>/pull/<n> URL. This script
 # parses the URL and invokes gh-axi in the form it accepts.
 #
-# Merge method: defaults to --squash when the caller passes none of --squash,
-# --merge, --rebase, or --method after the optional -- separator. An explicit
-# caller method is never overridden.
+# A Gitea PR URL (fm-pr-url-lib.sh: any host, plural "pulls") is merged with
+# `tea pulls merge` instead, run with cwd inside the task's worktree so tea
+# auto-discovers the right login/host from its origin remote.
+#
+# Merge method: defaults to --squash (gh-axi) / --style squash (tea) when the
+# caller passes no explicit method after the optional -- separator. An explicit
+# caller method is never overridden. For a Gitea PR the caller passes tea's own
+# `--style <merge|rebase|squash|rebase-merge>` flag; gh-axi's --squash/--merge/
+# --rebase/--method flags are gh-specific and are not translated.
 # Extra args must not include --repo or -R because the repo is parsed from the
 # PR URL.
 #
-# Usage: fm-pr-merge.sh <task-id> <pr-url> [-- <extra gh-axi pr merge args>]
+# Usage: fm-pr-merge.sh <task-id> <pr-url> [-- <extra gh-axi/tea merge args>]
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ID=${1:?usage: fm-pr-merge.sh <task-id> <pr-url> [-- <extra gh-axi pr merge args>]}
-URL=${2:?usage: fm-pr-merge.sh <task-id> <pr-url> [-- <extra gh-axi pr merge args>]}
+ID=${1:?usage: fm-pr-merge.sh <task-id> <pr-url> [-- <extra gh-axi/tea merge args>]}
+URL=${2:?usage: fm-pr-merge.sh <task-id> <pr-url> [-- <extra gh-axi/tea merge args>]}
 shift 2
 [ "${1:-}" = "--" ] && shift
 
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+# shellcheck source=bin/fm-pr-url-lib.sh
+. "$SCRIPT_DIR/fm-pr-url-lib.sh"
 META="$STATE/$ID.meta"
 [ -f "$META" ] || { echo "error: no meta for task $ID at $META; refusing to merge without recording pr=" >&2; exit 1; }
 
@@ -49,17 +57,26 @@ caller_has_merge_method() {
   return 1
 }
 
+caller_has_style_arg() {
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      --style|--style=*) return 0 ;;
+    esac
+  done
+  return 1
+}
+
 parse_pr_url() {
   local url=$1
-  if [[ "$url" =~ ^https://github\.com/([A-Za-z0-9][A-Za-z0-9-]{0,38})/([A-Za-z0-9._-]+)/pull/([0-9]+)/?$ ]]; then
-    PR_OWNER="${BASH_REMATCH[1]}"
-    PR_REPO="${BASH_REMATCH[2]}"
-    PR_NUMBER="${BASH_REMATCH[3]}"
-    if [[ "$PR_OWNER" != *- ]]; then
-      return 0
-    fi
+  if fm_parse_pr_url "$url"; then
+    PR_FORGE=$FM_PR_FORGE
+    PR_OWNER=$FM_PR_OWNER
+    PR_REPO=$FM_PR_REPO
+    PR_NUMBER=$FM_PR_NUMBER
+    return 0
   fi
-  echo "error: PR URL must match https://github.com/<owner>/<repo>/pull/<number> (got: $url)" >&2
+  echo "error: PR URL must match https://github.com/<owner>/<repo>/pull/<number> or a Gitea https://<host>/<owner>/<repo>/pulls/<number> URL (got: $url)" >&2
   return 1
 }
 
@@ -83,8 +100,16 @@ reject_repo_overrides "$@" || exit 1
 grep -qxF "pr=$URL" "$META" || { echo "error: fm-pr-check did not record pr=$URL in $META; refusing to merge" >&2; exit 1; }
 
 merge_args=()
-if ! caller_has_merge_method "$@"; then
-  merge_args=(--squash)
+if [ "$PR_FORGE" = gitea ]; then
+  if ! caller_has_style_arg "$@"; then
+    merge_args=(--style squash)
+  fi
+  WT=$(grep '^worktree=' "$META" | tail -1 | cut -d= -f2- || true)
+  [ -n "$WT" ] && [ -d "$WT" ] || { echo "error: no worktree recorded for task $ID; cannot resolve Gitea login context for tea" >&2; exit 1; }
+  ( cd "$WT" && tea pulls merge "$PR_NUMBER" --repo "$PR_OWNER/$PR_REPO" ${merge_args[@]+"${merge_args[@]}"} "$@" )
+else
+  if ! caller_has_merge_method "$@"; then
+    merge_args=(--squash)
+  fi
+  gh-axi pr merge "$PR_NUMBER" --repo "$PR_OWNER/$PR_REPO" ${merge_args[@]+"${merge_args[@]}"} "$@"
 fi
-
-gh-axi pr merge "$PR_NUMBER" --repo "$PR_OWNER/$PR_REPO" ${merge_args[@]+"${merge_args[@]}"} "$@"

--- a/bin/fm-pr-url-lib.sh
+++ b/bin/fm-pr-url-lib.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# fm-pr-url-lib.sh - parses a PR URL into forge, host, owner, repo, and number.
+#
+# Two forges are recognized by URL shape alone, never by a hostname allowlist:
+#   GitHub - https://github.com/<owner>/<repo>/pull/<number>   (singular "pull")
+#   Gitea  - https://<host>/<owner>/<repo>/pulls/<number>      (plural "pulls",
+#            any self-hosted host)
+# This is the shared recognition point so fm-pr-check.sh, fm-pr-merge.sh, and
+# fm-teardown.sh dispatch to gh or tea consistently instead of each duplicating
+# the regex.
+#
+# fm_parse_pr_url <url>: on a match, sets FM_PR_FORGE (github|gitea), FM_PR_HOST,
+# FM_PR_OWNER, FM_PR_REPO, FM_PR_NUMBER and returns 0. On no match, clears all
+# five and returns 1; the caller reports its own error message.
+#
+# Sourced by fm-pr-check.sh, fm-pr-merge.sh, fm-teardown.sh, and their tests. No
+# side effects on source. set -u / set -e safe.
+
+# shellcheck disable=SC2034 # FM_PR_* are read by callers (fm-pr-check.sh, fm-pr-merge.sh, fm-teardown.sh) after sourcing.
+fm_parse_pr_url() {
+  local url=$1
+  FM_PR_FORGE=
+  FM_PR_HOST=
+  FM_PR_OWNER=
+  FM_PR_REPO=
+  FM_PR_NUMBER=
+  if [[ "$url" =~ ^https://github\.com/([A-Za-z0-9][A-Za-z0-9-]{0,38})/([A-Za-z0-9._-]+)/pull/([0-9]+)/?$ ]]; then
+    [[ "${BASH_REMATCH[1]}" == *- ]] && return 1
+    FM_PR_FORGE=github
+    FM_PR_HOST=github.com
+    FM_PR_OWNER=${BASH_REMATCH[1]}
+    FM_PR_REPO=${BASH_REMATCH[2]}
+    FM_PR_NUMBER=${BASH_REMATCH[3]}
+    return 0
+  fi
+  if [[ "$url" =~ ^https://([A-Za-z0-9.-]+(:[0-9]+)?)/([A-Za-z0-9][A-Za-z0-9._-]{0,38})/([A-Za-z0-9._-]+)/pulls/([0-9]+)/?$ ]]; then
+    FM_PR_FORGE=gitea
+    FM_PR_HOST=${BASH_REMATCH[1]}
+    FM_PR_OWNER=${BASH_REMATCH[3]}
+    FM_PR_REPO=${BASH_REMATCH[4]}
+    FM_PR_NUMBER=${BASH_REMATCH[5]}
+    return 0
+  fi
+  return 1
+}

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -88,6 +88,8 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-backend.sh"
 # shellcheck source=bin/fm-lock-lib.sh
 . "$SCRIPT_DIR/fm-lock-lib.sh"
+# shellcheck source=bin/fm-pr-url-lib.sh
+. "$SCRIPT_DIR/fm-pr-url-lib.sh"
 FM_LOCK_LOG_PREFIX=teardown
 "$FM_ROOT/bin/fm-guard.sh" || true
 ID=$1
@@ -191,6 +193,10 @@ pr_number_from_target() {
       n=${target##*/pull/}
       n=${n%%[!0-9]*}
       ;;
+    *"/pulls/"*)
+      n=${target##*/pulls/}
+      n=${n%%[!0-9]*}
+      ;;
     [0-9]*)
       n=${target%%[!0-9]*}
       ;;
@@ -242,10 +248,14 @@ EOF
 }
 
 # Is the worktree's PR merged for local work contained in that PR? Resolves the
-# PR from the recorded pr= URL first, then from the branch name, and asks GitHub
-# for both the PR state and head. Returns non-zero when the PR is not merged, the
-# current work is not contained in the PR head, no PR is found, or any gh error
-# occurs - the caller then falls back to the content check.
+# PR from the recorded pr= URL first, then from the branch name. A recorded
+# Gitea PR URL (fm-pr-url-lib.sh: any host, plural "pulls") is looked up via
+# `tea pulls` (cwd inside $WT so tea auto-discovers the login/host); anything
+# else (a GitHub URL, or a bare number from pr_number_from_branch, which is
+# always gh-axi-sourced) is looked up via `gh pr view` exactly as before.
+# Returns non-zero when the PR is not merged, the current work is not contained
+# in the PR head, no PR is found, or any lookup error occurs - the caller then
+# falls back to the content check.
 pr_is_merged() {
   local branch=$1 target view state head current
   if [ -n "$PR_URL" ]; then
@@ -254,14 +264,26 @@ pr_is_merged() {
     target=$(pr_number_from_branch "$branch") || return 1
   fi
   [ -n "$target" ] || return 1
-  view=$(cd "$WT" && gh pr view "$target" --json state,headRefOid -q '.state + "\t" + .headRefOid' 2>/dev/null) || return 1
-  state=${view%%$'\t'*}
-  head=${view#*$'\t'}
-  [ "$state" != "$view" ] || return 1
-  case "$state" in
-    MERGED|merged) ;;
-    *) return 1 ;;
-  esac
+  if fm_parse_pr_url "$target" && [ "$FM_PR_FORGE" = gitea ]; then
+    view=$(cd "$WT" && tea pulls "$FM_PR_NUMBER" --repo "$FM_PR_OWNER/$FM_PR_REPO" -o json 2>/dev/null \
+      | jq -r '(.hasMerged | tostring) + "\t" + (.headSha // "")') || return 1
+    state=${view%%$'\t'*}
+    head=${view#*$'\t'}
+    [ "$state" != "$view" ] || return 1
+    case "$state" in
+      true) ;;
+      *) return 1 ;;
+    esac
+  else
+    view=$(cd "$WT" && gh pr view "$target" --json state,headRefOid -q '.state + "\t" + .headRefOid' 2>/dev/null) || return 1
+    state=${view%%$'\t'*}
+    head=${view#*$'\t'}
+    [ "$state" != "$view" ] || return 1
+    case "$state" in
+      MERGED|merged) ;;
+      *) return 1 ;;
+    esac
+  fi
   [ -n "$head" ] || return 1
   ensure_commit_object "$target" "$head" || return 1
   current=$(git -C "$WT" rev-parse --verify HEAD 2>/dev/null) || return 1

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -150,8 +150,11 @@ The `data/secondmates.md` line schema and the secondmate environment variables a
 Review diffs go through `bin/fm-review-diff.sh`, which refreshes the authoritative base and, when task meta records `pr=`, compares against the reachable recorded `pr_head=` or a freshly fetched `refs/pull/<n>/head` before falling back to the local branch with a warning.
 For target project repos shipped through their own no-mistakes pipeline, commits under `.no-mistakes/evidence/` are the pipeline's PR-viewable validation evidence and are expected to stay in the crew branch until the evidence-hosting design changes.
 The firstmate repo itself is the exception: its `.no-mistakes/` directory is local state, stays gitignored, and is rejected by CI if tracked.
-PR-based task merges go through `bin/fm-pr-merge.sh`, which records `pr=` and any available `pr_head=` through `bin/fm-pr-check.sh` before calling `gh-axi pr merge`.
-The helper requires a full `https://github.com/<owner>/<repo>/pull/<n>` URL, invokes `gh-axi pr merge <n> --repo <owner>/<repo>`, defaults to `--squash`, preserves explicit merge-method flags, and rejects malformed URLs or repo override flags before recording merge state.
+PR-based task merges go through `bin/fm-pr-merge.sh`, which records `pr=` and any available `pr_head=` through `bin/fm-pr-check.sh` before merging.
+[`bin/fm-pr-url-lib.sh`](../bin/fm-pr-url-lib.sh) parses the PR URL's shape to pick the forge, never a hostname allowlist: a singular `https://github.com/<owner>/<repo>/pull/<n>` URL is GitHub, and a plural `https://<any-host>/<owner>/<repo>/pulls/<n>` URL is Gitea.
+A GitHub URL invokes `gh-axi pr merge <n> --repo <owner>/<repo>`, defaults to `--squash`, and preserves explicit merge-method flags.
+A Gitea URL invokes `tea pulls merge <n> --repo <owner>/<repo>` with cwd inside the task's worktree so `tea` auto-discovers the login and host from its origin remote, defaults to `--style squash`, and preserves an explicit caller `--style` flag; it refuses when the task's worktree is missing.
+Either path rejects malformed URLs or repo override flags before recording merge state.
 Teardown is fail-closed for ship worktrees: dirty worktrees refuse, and committed work must be landed before the worktree is returned.
 [`bin/fm-teardown.sh`](../bin/fm-teardown.sh)'s header owns the landed-work proofs, PR-discovery fallback, and stale-lock recovery procedure.
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -59,8 +59,9 @@ If you have changed away from the firstmate home in an interactive shell, invoke
 | `fm-send.sh`             | Send one verified literal line or supported key through the target's recorded backend |
 | `fm-tmux-lib.sh`         | Shared tmux pane primitives for busy detection, composer capture, and verified submit |
 | `fm-peek.sh`             | Print a bounded tail of a crewmate endpoint                                          |
+| `fm-pr-url-lib.sh`       | Shared PR URL parser dispatching GitHub and Gitea URLs by shape into forge, owner, repo, number |
 | `fm-pr-check.sh`         | Record `pr=` and `pr_head=` for a PR-ready task, then arm the watcher's merge poll   |
-| `fm-pr-merge.sh`         | Record PR metadata, then merge a task's PR from its full GitHub URL                  |
+| `fm-pr-merge.sh`         | Record PR metadata, then merge a task's GitHub or Gitea PR from its full URL         |
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task                               |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require scout reports, retire secondmate homes |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -52,6 +52,8 @@ make_fake_root() {
   ln -s "$ROOT/bin/fm-backend.sh" "$fake/bin/fm-backend.sh"
   ln -s "$ROOT/bin/backends/tmux.sh" "$fake/bin/backends/tmux.sh"
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
+  # fm-composer-lib.sh: fm-tmux-lib.sh sources it unconditionally.
+  ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
   # fm-lock-lib.sh: teardown sources it for the shared lock-staleness proof.
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
   # fm-pr-url-lib.sh: teardown sources it to dispatch a recorded pr= URL to gh
@@ -151,7 +153,9 @@ test_teardown_skips_gracefully_without_tasktmp() {
   ln -s "$ROOT/bin/fm-backend.sh" "$fake/bin/fm-backend.sh"
   ln -s "$ROOT/bin/backends/tmux.sh" "$fake/bin/backends/tmux.sh"
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
+  ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
+  ln -s "$ROOT/bin/fm-pr-url-lib.sh" "$fake/bin/fm-pr-url-lib.sh"
   cat > "$fake/bin/fm-guard.sh" <<'SH'
 #!/usr/bin/env bash
 exit 0

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -54,6 +54,9 @@ make_fake_root() {
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
   # fm-lock-lib.sh: teardown sources it for the shared lock-staleness proof.
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
+  # fm-pr-url-lib.sh: teardown sources it to dispatch a recorded pr= URL to gh
+  # or tea; unused by this suite's nonexistent-worktree fixture but must exist.
+  ln -s "$ROOT/bin/fm-pr-url-lib.sh" "$fake/bin/fm-pr-url-lib.sh"
   # fm-guard.sh: stub (teardown calls it with `|| true`).
   cat > "$fake/bin/fm-guard.sh" <<'SH'
 #!/usr/bin/env bash

--- a/tests/fm-pr-check.test.sh
+++ b/tests/fm-pr-check.test.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Tests for bin/fm-pr-check.sh: records pr= and the forge's pr_head= into
+# state/<id>.meta, then arms state/<id>.check.sh to poll for merge. The PR
+# URL's shape (bin/fm-pr-url-lib.sh) picks the forge: a GitHub URL
+# (.../pull/<n>) uses gh; a Gitea URL (any host, plural .../pulls/<n>) uses tea,
+# run with cwd inside the task's worktree so tea auto-discovers the login/host
+# from its origin remote.
+#
+# Matrix:
+#   (a) GitHub URL records pr= and pr_head= via gh; arms a gh-based check.sh
+#   (b) GitHub check.sh reports "merged" when gh reports state MERGED
+#   (c) Gitea URL records pr= and pr_head= via tea; arms a tea-based check.sh
+#   (d) Gitea check.sh reports "merged" when tea reports hasMerged true
+#   (e) Gitea check.sh stays silent when tea reports hasMerged false
+#   (f) no worktree on disk: pr= is still recorded, pr_head= is skipped (both forges)
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+fm_git_identity fmtest fmtest@example.invalid
+
+PR_CHECK="$ROOT/bin/fm-pr-check.sh"
+TMP_ROOT=$(fm_test_tmproot fm-pr-check-tests)
+
+# Build a fresh sandbox for one test case: a state dir with a task meta (whose
+# worktree exists on disk unless the caller skips mkdir) and a fakebin. Echoes
+# the case dir.
+make_case() {
+  local name=$1 case_dir fakebin
+  case_dir="$TMP_ROOT/$name"
+  fakebin="$case_dir/fakebin"
+  mkdir -p "$case_dir/state" "$fakebin"
+  fm_write_meta "$case_dir/state/task-x1.meta" \
+    "window=fm-task-x1" \
+    "worktree=$case_dir/wt" \
+    "project=$case_dir/project" \
+    "kind=ship" \
+    "mode=no-mistakes"
+  printf '%s\n' "$case_dir"
+}
+
+add_gh_mock() {
+  local case_dir=$1 head=$2
+  cat > "$case_dir/fakebin/gh" <<SH
+#!/usr/bin/env bash
+case "\${1:-} \${2:-}" in
+  "pr view")
+    case " \$* " in
+      *"headRefOid"*) printf '%s\n' '$head' ; exit 0 ;;
+      *"state"*) printf '%s\n' 'MERGED' ; exit 0 ;;
+    esac
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/gh"
+}
+
+# tea mock: `tea pulls <n> --repo <owner/repo> -o json` prints headSha/hasMerged.
+add_tea_mock() {
+  local case_dir=$1 head=$2 merged=$3
+  cat > "$case_dir/fakebin/tea" <<SH
+#!/usr/bin/env bash
+case "\${1:-} \${2:-}" in
+  "pulls "*)
+    printf '{"headSha":"%s","hasMerged":%s}\n' '$head' '$merged' ; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/tea"
+}
+
+run_pr_check() {
+  local case_dir=$1; shift
+  FM_ROOT_OVERRIDE="$ROOT" \
+  FM_STATE_OVERRIDE="$case_dir/state" \
+  PATH="$case_dir/fakebin:$PATH" \
+    "$PR_CHECK" "$@"
+}
+
+test_github_records_pr_head_and_arms_check() {
+  local case_dir rc
+  case_dir=$(make_case github-record)
+  mkdir -p "$case_dir/wt"
+  add_gh_mock "$case_dir" cafefeeddeadbeef0000000000000000cafefeed
+
+  set +e
+  run_pr_check "$case_dir" task-x1 https://github.com/example/repo/pull/9 \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "github-record: fm-pr-check should succeed"
+  assert_grep 'pr=https://github.com/example/repo/pull/9' "$case_dir/state/task-x1.meta" \
+    "github-record: pr= was not recorded"
+  assert_grep 'pr_head=cafefeeddeadbeef0000000000000000cafefeed' "$case_dir/state/task-x1.meta" \
+    "github-record: pr_head= was not recorded"
+  assert_grep 'gh pr view' "$case_dir/state/task-x1.check.sh" \
+    "github-record: check.sh was not armed with a gh-based poll"
+  pass "fm-pr-check records pr= and pr_head= via gh and arms a gh-based check.sh"
+}
+
+test_github_check_reports_merged() {
+  local case_dir out
+  case_dir=$(make_case github-merged)
+  mkdir -p "$case_dir/wt"
+  add_gh_mock "$case_dir" 1111111111111111111111111111111111111111
+
+  run_pr_check "$case_dir" task-x1 https://github.com/example/repo/pull/11 \
+    > "$case_dir/stdout" 2> "$case_dir/stderr" || fail "github-merged: fm-pr-check failed"
+
+  out=$(PATH="$case_dir/fakebin:$PATH" bash "$case_dir/state/task-x1.check.sh") || true
+  assert_contains "$out" "merged" "github-merged: armed check.sh did not report merged"
+  pass "fm-pr-check's armed check.sh reports merged when gh reports state MERGED"
+}
+
+test_gitea_records_pr_head_and_arms_check() {
+  local case_dir rc
+  case_dir=$(make_case gitea-record)
+  mkdir -p "$case_dir/wt"
+  add_tea_mock "$case_dir" beefcafedeadbeef0000000000000000beefcafe false
+
+  set +e
+  run_pr_check "$case_dir" task-x1 https://git.example.com/example/repo/pulls/9 \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "gitea-record: fm-pr-check should succeed"
+  assert_grep 'pr=https://git.example.com/example/repo/pulls/9' "$case_dir/state/task-x1.meta" \
+    "gitea-record: pr= was not recorded"
+  assert_grep 'pr_head=beefcafedeadbeef0000000000000000beefcafe' "$case_dir/state/task-x1.meta" \
+    "gitea-record: pr_head= was not recorded"
+  assert_grep 'tea pulls' "$case_dir/state/task-x1.check.sh" \
+    "gitea-record: check.sh was not armed with a tea-based poll"
+  pass "fm-pr-check records pr= and pr_head= via tea for a Gitea PR URL and arms a tea-based check.sh"
+}
+
+test_gitea_check_reports_merged() {
+  local case_dir out
+  case_dir=$(make_case gitea-merged)
+  mkdir -p "$case_dir/wt"
+  add_tea_mock "$case_dir" 2222222222222222222222222222222222222222 true
+
+  run_pr_check "$case_dir" task-x1 https://git.example.com/example/repo/pulls/12 \
+    > "$case_dir/stdout" 2> "$case_dir/stderr" || fail "gitea-merged: fm-pr-check failed"
+
+  out=$(PATH="$case_dir/fakebin:$PATH" bash "$case_dir/state/task-x1.check.sh") || true
+  assert_contains "$out" "merged" "gitea-merged: armed check.sh did not report merged"
+  pass "fm-pr-check's armed check.sh reports merged when tea reports hasMerged true"
+}
+
+test_gitea_check_stays_silent_when_not_merged() {
+  local case_dir out
+  case_dir=$(make_case gitea-not-merged)
+  mkdir -p "$case_dir/wt"
+  add_tea_mock "$case_dir" 3333333333333333333333333333333333333333 false
+
+  run_pr_check "$case_dir" task-x1 https://git.example.com/example/repo/pulls/13 \
+    > "$case_dir/stdout" 2> "$case_dir/stderr" || fail "gitea-not-merged: fm-pr-check failed"
+
+  out=$(PATH="$case_dir/fakebin:$PATH" bash "$case_dir/state/task-x1.check.sh") || true
+  [ -z "$out" ] || fail "gitea-not-merged: armed check.sh should stay silent (got: $out)"
+  pass "fm-pr-check's armed check.sh stays silent when tea reports hasMerged false"
+}
+
+test_no_worktree_records_pr_without_head() {
+  local case_dir rc
+  case_dir=$(make_case no-worktree)
+  add_tea_mock "$case_dir" 4444444444444444444444444444444444444444 false
+
+  set +e
+  run_pr_check "$case_dir" task-x1 https://git.example.com/example/repo/pulls/14 \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "no-worktree: fm-pr-check should succeed"
+  assert_grep 'pr=https://git.example.com/example/repo/pulls/14' "$case_dir/state/task-x1.meta" \
+    "no-worktree: pr= was not recorded"
+  assert_no_grep 'pr_head=' "$case_dir/state/task-x1.meta" \
+    "no-worktree: pr_head= should not be recorded without a worktree to resolve tea's login from"
+  pass "fm-pr-check records pr= without pr_head= when the task's worktree is missing"
+}
+
+test_github_records_pr_head_and_arms_check
+test_github_check_reports_merged
+test_gitea_records_pr_head_and_arms_check
+test_gitea_check_reports_merged
+test_gitea_check_stays_silent_when_not_merged
+test_no_worktree_records_pr_without_head

--- a/tests/fm-pr-check.test.sh
+++ b/tests/fm-pr-check.test.sh
@@ -13,6 +13,9 @@
 #   (d) Gitea check.sh reports "merged" when tea reports hasMerged true
 #   (e) Gitea check.sh stays silent when tea reports hasMerged false
 #   (f) no worktree on disk: pr= is still recorded, pr_head= is skipped (both forges)
+#   (g) Gitea check.sh re-reads the worktree from meta at poll time, so a
+#       worktree that appears after arming (not just at arm time) still lets
+#       the merge poll succeed instead of silently failing forever
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -183,9 +186,49 @@ test_no_worktree_records_pr_without_head() {
   pass "fm-pr-check records pr= without pr_head= when the task's worktree is missing"
 }
 
+test_gitea_check_polls_worktree_recorded_after_arming() {
+  local case_dir out
+  case_dir="$TMP_ROOT/gitea-late-worktree"
+  mkdir -p "$case_dir/state" "$case_dir/fakebin"
+  fm_write_meta "$case_dir/state/task-x1.meta" \
+    "window=fm-task-x1" \
+    "project=$case_dir/project" \
+    "kind=ship" \
+    "mode=no-mistakes"
+
+  # Mirrors real tea: only succeeds when invoked with cwd inside the recorded
+  # worktree (tea auto-discovers login/host from the worktree's origin
+  # remote), so this fails unless the generated check.sh actually cd's there.
+  local expected_wt
+  expected_wt=$(cd "$case_dir" && mkdir -p wt && cd wt && pwd -P)
+  cat > "$case_dir/fakebin/tea" <<SH
+#!/usr/bin/env bash
+case "\${1:-} \${2:-}" in
+  "pulls "*)
+    [ "\$(pwd -P)" = "$expected_wt" ] || exit 1
+    printf '{"headSha":"%s","hasMerged":%s}\n' '5555555555555555555555555555555555555555' 'true' ; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/tea"
+
+  run_pr_check "$case_dir" task-x1 https://git.example.com/example/repo/pulls/15 \
+    > "$case_dir/stdout" 2> "$case_dir/stderr" || fail "gitea-late-worktree: fm-pr-check failed"
+  assert_no_grep 'pr_head=' "$case_dir/state/task-x1.meta" \
+    "gitea-late-worktree: pr_head= should not be recorded before the worktree is known"
+
+  mkdir -p "$case_dir/wt"
+  echo "worktree=$case_dir/wt" >> "$case_dir/state/task-x1.meta"
+  out=$(PATH="$case_dir/fakebin:$PATH" bash "$case_dir/state/task-x1.check.sh") || true
+  assert_contains "$out" "merged" \
+    "gitea-late-worktree: armed check.sh should poll a worktree recorded after arming, not stay silent forever"
+  pass "fm-pr-check's armed check.sh re-reads the worktree from meta at poll time and still detects merge"
+}
+
 test_github_records_pr_head_and_arms_check
 test_github_check_reports_merged
 test_gitea_records_pr_head_and_arms_check
 test_gitea_check_reports_merged
 test_gitea_check_stays_silent_when_not_merged
 test_no_worktree_records_pr_without_head
+test_gitea_check_polls_worktree_recorded_after_arming

--- a/tests/fm-pr-merge.test.sh
+++ b/tests/fm-pr-merge.test.sh
@@ -14,6 +14,12 @@
 #   (f) malformed PR URL fails fast without calling gh-axi
 #   (g) explicit merge method is not overridden by the default --squash
 #   (h) repo override args fail fast because the repo comes from the URL
+#
+# A Gitea PR URL (any host, plural "pulls") dispatches to `tea pulls merge`
+# instead of gh-axi (bin/fm-pr-url-lib.sh):
+#   (i) Gitea URL merges via tea with default --style squash
+#   (j) explicit --style is not overridden by the default
+#   (k) merge refuses when the task has no worktree to resolve tea's login from
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -89,8 +95,26 @@ run_pr_merge() {
   FM_ROOT_OVERRIDE="$ROOT" \
   FM_STATE_OVERRIDE="$case_dir/state" \
   FM_TEST_GH_AXI_LOG="$case_dir/gh-axi.log" \
+  FM_TEST_TEA_LOG="$case_dir/tea.log" \
   PATH="$case_dir/fakebin:$PATH" \
     "$PR_MERGE" "$@"
+}
+
+# tea mock recording every invocation to a log file, and answering `tea pulls
+# <n>` (fm-pr-check.sh's pr_head lookup) with the given head sha; `tea pulls
+# merge` always succeeds. Args: case_dir head
+add_tea_mocks() {
+  local case_dir=$1 head=$2
+  cat > "$case_dir/fakebin/tea" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "\$FM_TEST_TEA_LOG"
+case "\${1:-} \${2:-}" in
+  "pulls merge") exit 0 ;;
+  "pulls "*) printf '{"headSha":"%s","hasMerged":false}\n' '$head' ; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/tea"
 }
 
 test_records_pr_and_head_before_merging() {
@@ -295,6 +319,65 @@ test_parses_pr_url_for_gh_axi() {
   pass "fm-pr-merge parses a GitHub PR URL into gh-axi number and --repo arguments"
 }
 
+test_gitea_merge_uses_tea_with_default_style() {
+  local case_dir rc
+  case_dir=$(make_case gitea-merge)
+  mkdir -p "$case_dir/wt"
+  add_tea_mocks "$case_dir" abcdef0123456789abcdef0123456789abcdef01
+  : > "$case_dir/tea.log"
+
+  set +e
+  run_pr_merge "$case_dir" task-x1 https://git.example.com/example/repo/pulls/9 \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "gitea-merge: fm-pr-merge should succeed"
+  assert_grep 'pr=https://git.example.com/example/repo/pulls/9' "$case_dir/state/task-x1.meta" \
+    "gitea-merge: pr= was not recorded"
+  assert_grep 'pr_head=abcdef0123456789abcdef0123456789abcdef01' "$case_dir/state/task-x1.meta" \
+    "gitea-merge: pr_head= was not recorded"
+  grep -qxF 'pulls merge 9 --repo example/repo --style squash' "$case_dir/tea.log" \
+    || fail "gitea-merge: tea pulls merge was not invoked with number, --repo, and default --style squash"
+  [ ! -s "$case_dir/gh-axi.log" ] || fail "gitea-merge: gh-axi was invoked for a Gitea PR"
+  pass "fm-pr-merge merges a Gitea PR via tea pulls merge with the default --style squash"
+}
+
+test_gitea_explicit_style_not_overridden() {
+  local case_dir
+  case_dir=$(make_case gitea-explicit-style)
+  mkdir -p "$case_dir/wt"
+  add_tea_mocks "$case_dir" 1234567890abcdef1234567890abcdef12345678
+  : > "$case_dir/tea.log"
+
+  run_pr_merge "$case_dir" task-x1 https://git.example.com/example/repo/pulls/22 -- --style rebase \
+    > "$case_dir/stdout" 2> "$case_dir/stderr" || fail "gitea-explicit-style: fm-pr-merge failed"
+
+  grep -qxF 'pulls merge 22 --repo example/repo --style rebase' "$case_dir/tea.log" \
+    || fail "gitea-explicit-style: caller --style rebase was not forwarded without an extra default --style squash"
+  pass "fm-pr-merge does not add a default --style squash when the caller passes an explicit tea --style"
+}
+
+test_gitea_merge_refuses_without_worktree() {
+  local case_dir rc
+  case_dir=$(make_case gitea-no-worktree)
+  add_tea_mocks "$case_dir" 2468135790abcdef2468135790abcdef24681357
+  : > "$case_dir/tea.log"
+
+  set +e
+  run_pr_merge "$case_dir" task-x1 https://git.example.com/example/repo/pulls/30 \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "gitea-no-worktree: fm-pr-merge should refuse without a resolvable worktree"
+  assert_grep 'cannot resolve Gitea login context for tea' "$case_dir/stderr" \
+    "gitea-no-worktree: refusal did not explain the missing worktree"
+  assert_no_grep 'pulls merge' "$case_dir/tea.log" \
+    "gitea-no-worktree: tea pulls merge was invoked despite the missing worktree"
+  pass "fm-pr-merge refuses a Gitea merge when the task has no worktree to resolve tea's login from"
+}
+
 test_records_pr_and_head_before_merging
 test_merge_failure_propagates_after_recording
 test_extra_merge_args_forwarded
@@ -305,3 +388,6 @@ test_repo_override_args_refuse_before_recording
 test_explicit_merge_method_not_overridden
 test_method_equals_merge_method_not_overridden
 test_parses_pr_url_for_gh_axi
+test_gitea_merge_uses_tea_with_default_style
+test_gitea_explicit_style_not_overridden
+test_gitea_merge_refuses_without_worktree

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -49,6 +49,11 @@
 #   (w) index.lock mtime read failure                         -> lock kept, REFUSE
 #   (x) transient lock cleared after first failed return      -> retry ALLOW
 #   (y) persistent lock (never clears, not provably stale)    -> REFUSE loudly
+#
+# Also covers Gitea PR dispatch (bin/fm-pr-url-lib.sh: any host, plural "pulls"
+# in the recorded pr= URL routes the containment check through `tea` instead of
+# `gh`):
+#   (z) no-mistakes + Gitea squash-merged PR, deleted branch  -> ALLOW (tea dispatch)
 set -u
 
 # shellcheck source=tests/lib.sh disable=SC1091
@@ -242,6 +247,32 @@ append_pr_meta_for_current_head() {
   printf '%s\n' \
     'pr=https://github.com/example/repo/pull/7' \
     "pr_head=$head" >> "$case_dir/state/task-x1.meta"
+}
+
+# Gitea equivalent of append_pr_meta_for_current_head: a plural "pulls" URL
+# (any host) so fm-teardown.sh's containment check dispatches to tea.
+append_gitea_pr_meta_for_current_head() {
+  local case_dir=$1 head
+  head=$(git -C "$case_dir/wt" rev-parse HEAD)
+  printf '%s\n' \
+    'pr=https://git.example.com/example/repo/pulls/7' \
+    "pr_head=$head" >> "$case_dir/state/task-x1.meta"
+}
+
+# Override tea to report PR 7 as merged with the supplied head, via
+# `tea pulls <n> --repo <owner>/<repo> -o json`. Gitea equivalent of
+# add_gh_pr_merged_for_head.
+add_tea_pr_merged_for_head() {
+  local case_dir=$1 head=$2
+  cat > "$case_dir/fakebin/tea" <<SH
+#!/usr/bin/env bash
+case "\${1:-} \${2:-}" in
+  "pulls "*)
+    printf '{"headSha":"%s","hasMerged":true}\n' '$head' ; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$case_dir/fakebin/tea"
 }
 
 append_pr_meta_url() {
@@ -648,6 +679,28 @@ test_squash_merged_branch_deleted_allows() {
   expect_code 0 "$rc" "squash-merged: teardown should succeed when the PR is merged"
   ! grep -q REFUSED "$case_dir/stderr" || fail "squash-merged: teardown printed a REFUSED line"
   pass "squash-merged + deleted-branch worktree (PR merged) is torn down (the fix)"
+}
+
+test_gitea_squash_merged_branch_deleted_allows() {
+  local case_dir rc pr_head
+  case_dir=$(make_case gitea-squash-merged)
+  write_meta "$case_dir" no-mistakes ship
+  # Same scenario as test_squash_merged_branch_deleted_allows, but the recorded
+  # pr= is a Gitea URL (plural "pulls"), so the containment check must dispatch
+  # to tea instead of gh.
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  append_gitea_pr_meta_for_current_head "$case_dir"
+  pr_head=$(git -C "$case_dir/wt" rev-parse HEAD)
+  add_tea_pr_merged_for_head "$case_dir" "$pr_head"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "gitea-squash-merged: teardown should succeed when the Gitea PR is merged"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "gitea-squash-merged: teardown printed a REFUSED line"
+  pass "Gitea squash-merged + deleted-branch worktree (PR merged via tea) is torn down"
 }
 
 test_squash_merged_pr_allows_when_head_ancestor_of_pr_head() {
@@ -1273,6 +1326,7 @@ test_no_mistakes_truly_unpushed_refuses
 test_local_only_force_overrides_unpushed
 test_herdr_teardown_clears_escalation_marker
 test_squash_merged_branch_deleted_allows
+test_gitea_squash_merged_branch_deleted_allows
 test_squash_merged_pr_allows_when_head_ancestor_of_pr_head
 test_no_pr_recorded_discovers_merged_pr_by_branch_allows
 test_squash_merged_pr_allows_replayed_unpushed_patch


### PR DESCRIPTION
Teaches `fm-pr-check.sh`, `fm-pr-merge.sh`, and `fm-teardown.sh` to handle Gitea-hosted PRs via `tea`, alongside the existing GitHub (`gh-axi`) path.

- Adds a shared `fm-pr-url-lib.sh` to parse both GitHub and Gitea PR URLs.
- `fm-pr-check`/`fm-pr-merge` dispatch on the URL host: Gitea resolves through `tea`, GitHub through `gh-axi`.
- `fm-teardown` can discover a merged PR by branch name for Gitea too.
- Docs updated (`AGENTS.md`, `README.md`, `docs/architecture.md`, `docs/scripts.md`).
- Test fixture fixed: `tests/fm-gotmp.test.sh` needed the new symlinks (`fm-composer-lib.sh`, `fm-pr-url-lib.sh`) added at a second call site.

All Gitea tests pass; shellcheck clean.