### PR TITLE
fix(skills): use a subshell for no-mistakes init in project-management

### DIFF
--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -72,10 +72,11 @@ The captain's request to create that local project authorizes this local initial
 
 ## Initialize
 
-Run no-mistakes initialization only for `no-mistakes` and `no-mistakes-prod-only` projects:
+Run no-mistakes initialization only for `no-mistakes` and `no-mistakes-prod-only` projects.
+Use a subshell so the primary session directory never changes, satisfying the cd guard (`docs/cd-guard.md`):
 
 ```sh
-cd projects/<name> && no-mistakes init && no-mistakes doctor
+(cd projects/<name> && no-mistakes init && no-mistakes doctor)
 ```
 
 Initialization configures the local gate and does not vendor a no-mistakes skill into the project.


### PR DESCRIPTION
## Summary
- The project-management skill's no-mistakes-initialization example used a bare top-level `cd projects/<name> && no-mistakes init && no-mistakes doctor`, which the repo's own cd-guard PreToolUse policy denies (a persistent cd into a project clone from the primary firstmate shell risks silently relocating later firstmate-owned commands).
- Wraps the example in a subshell, `(cd projects/<name> && no-mistakes init && no-mistakes doctor)`, so the primary shell's directory never changes, and references docs/cd-guard.md.

## Test plan
- Documentation-only change to an internal agent-only skill file; no script behavior changed.
- Validated through the no-mistakes pipeline: intent, rebase, review, test, and document steps all passed with zero findings. Lint was skipped (ShellCheck not installed in this environment; no shell scripts were touched by this change).