### PR TITLE
fix(brief): pin decision key placement in generated briefs

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -244,6 +244,7 @@ A marked request requires one correlated answer after the work; it does not requ
 Never append \`working:\` merely to acknowledge receipt or announce that a marked request has started.
 When a routed-work phase has a supervisor-actionable material change worth reporting under the rule above, give that reported phase a stable key.
 When you use a key, put it between the verb and the colon, as in \`blocked [key=<work-slug>]: {why}\`; never put it after the note.
+Replace the placeholder with a real slug of letters, digits, \`.\`, \`_\`, or \`-\` only - no spaces and no angle brackets.
 For a decision on that phase, append \`needs-decision [key=<slug>]: {summary}\`.
 If its first reportable event is \`working [key=<work-slug>]: {material phase}\`, use the same key on its later \`$PAUSED_VERB\`, \`done\`, \`failed\`, \`needs-decision\`, or \`blocked\` event so the earlier working phase is superseded.
 When a keyed phase ends without another reportable state, append \`resolved [key=<work-slug>]: {why it is no longer active}\`.
@@ -332,6 +333,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs to a human (product choices, destructive actions), append \`needs-decision [key=<slug>]: {summary of options}\` and stop. Firstmate will reply with the decision.
    When you use a key, put it between the verb and the colon, as in \`blocked [key=<work-slug>]: {why}\`; never put it after the note.
+   Replace the placeholder with a real slug of letters, digits, \`.\`, \`_\`, or \`-\` only - no spaces and no angle brackets.
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
    Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append the closing line yourself as you resume: \`resolved: {how it cleared}\`, or \`resolved [key=<slug>]: {how it cleared}\` if you opened it with a key.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
@@ -448,6 +450,7 @@ $RULE1
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings), append \`needs-decision [key=<slug>]: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
    When you use a key, put it between the verb and the colon, as in \`blocked [key=<work-slug>]: {why}\`; never put it after the note.
+   Replace the placeholder with a real slug of letters, digits, \`.\`, \`_\`, or \`-\` only - no spaces and no angle brackets.
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
    Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append the closing line yourself as you resume: \`resolved: {how it cleared}\`, or \`resolved [key=<slug>]: {how it cleared}\` if you opened it with a key.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -243,12 +243,12 @@ This is also how you return the answer to a marked from-firstmate request above.
 A marked request requires one correlated answer after the work; it does not require a separate receipt or start acknowledgement.
 Never append \`working:\` merely to acknowledge receipt or announce that a marked request has started.
 When a routed-work phase has a supervisor-actionable material change worth reporting under the rule above, give that reported phase a stable key.
-Put a key between the verb and the colon, as in \`blocked [key=<work-slug>]: {why}\`; never put it after the note.
-For a decision, append \`needs-decision [key=<slug>]: {summary}\`.
+When you use a key, put it between the verb and the colon, as in \`blocked [key=<work-slug>]: {why}\`; never put it after the note.
+For a decision on that phase, append \`needs-decision [key=<slug>]: {summary}\`.
 If its first reportable event is \`working [key=<work-slug>]: {material phase}\`, use the same key on its later \`$PAUSED_VERB\`, \`done\`, \`failed\`, \`needs-decision\`, or \`blocked\` event so the earlier working phase is superseded.
 When a keyed phase ends without another reportable state, append \`resolved [key=<work-slug>]: {why it is no longer active}\`.
 \`resolved\` separately closes an escalated decision or blocker, and only a \`resolved\` line carrying that decision's exact key closes it: a later \`done\` or \`working\` event never does, even when the answer is what started that work.
-The main firstmate's answer normally writes that closing line at answer time; when a blocker or wait clears WITHOUT an answer from the main firstmate, append \`resolved [key=<slug>]: {how it cleared}\` yourself if you opened it with a key, as your domain resumes.
+The main firstmate's answer normally writes that closing line at answer time; when a blocker or wait clears WITHOUT an answer from the main firstmate, append the closing line yourself as your domain resumes: \`resolved: {how it cleared}\`, or \`resolved [key=<slug>]: {how it cleared}\` if you opened it with a key.
 Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.
 
 # Definition of done
@@ -330,10 +330,10 @@ The report is the only thing that survives, so anything worth keeping must be in
    firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
    treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
-Put a key between the verb and the colon, as in \`blocked [key=<work-slug>]: {why}\`; never put it after the note.
 6. If a decision belongs to a human (product choices, destructive actions), append \`needs-decision [key=<slug>]: {summary of options}\` and stop. Firstmate will reply with the decision.
+   When you use a key, put it between the verb and the colon, as in \`blocked [key=<work-slug>]: {why}\`; never put it after the note.
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
-   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved [key=<slug>]: {how it cleared}\` yourself if you opened it with a key, as you resume.
+   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append the closing line yourself as you resume: \`resolved: {how it cleared}\`, or \`resolved [key=<slug>]: {how it cleared}\` if you opened it with a key.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
@@ -446,10 +446,10 @@ $RULE1
    a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
    cadence instead of treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
-Put a key between the verb and the colon, as in \`blocked [key=<work-slug>]: {why}\`; never put it after the note.
 6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings), append \`needs-decision [key=<slug>]: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
+   When you use a key, put it between the verb and the colon, as in \`blocked [key=<work-slug>]: {why}\`; never put it after the note.
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
-   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved [key=<slug>]: {how it cleared}\` yourself if you opened it with a key, as you resume.
+   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append the closing line yourself as you resume: \`resolved: {how it cleared}\`, or \`resolved [key=<slug>]: {how it cleared}\` if you opened it with a key.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -243,10 +243,12 @@ This is also how you return the answer to a marked from-firstmate request above.
 A marked request requires one correlated answer after the work; it does not require a separate receipt or start acknowledgement.
 Never append \`working:\` merely to acknowledge receipt or announce that a marked request has started.
 When a routed-work phase has a supervisor-actionable material change worth reporting under the rule above, give that reported phase a stable key.
+Put a key between the verb and the colon, as in \`blocked [key=<work-slug>]: {why}\`; never put it after the note.
+For a decision, append \`needs-decision [key=<slug>]: {summary}\`.
 If its first reportable event is \`working [key=<work-slug>]: {material phase}\`, use the same key on its later \`$PAUSED_VERB\`, \`done\`, \`failed\`, \`needs-decision\`, or \`blocked\` event so the earlier working phase is superseded.
 When a keyed phase ends without another reportable state, append \`resolved [key=<work-slug>]: {why it is no longer active}\`.
 \`resolved\` separately closes an escalated decision or blocker, and only a \`resolved\` line carrying that decision's exact key closes it: a later \`done\` or \`working\` event never does, even when the answer is what started that work.
-The main firstmate's answer normally writes that closing line at answer time; when a blocker or wait clears WITHOUT an answer from the main firstmate, append \`resolved: {how it cleared}\` yourself (keyed with \`[key=<slug>]\` if you opened it with one) as your domain resumes.
+The main firstmate's answer normally writes that closing line at answer time; when a blocker or wait clears WITHOUT an answer from the main firstmate, append \`resolved [key=<slug>]: {how it cleared}\` yourself if you opened it with a key, as your domain resumes.
 Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.
 
 # Definition of done
@@ -328,10 +330,10 @@ The report is the only thing that survives, so anything worth keeping must be in
    firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
    treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
-6. If a decision belongs to a human (product choices, destructive actions),
-   append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
+Put a key between the verb and the colon, as in \`blocked [key=<work-slug>]: {why}\`; never put it after the note.
+6. If a decision belongs to a human (product choices, destructive actions), append \`needs-decision [key=<slug>]: {summary of options}\` and stop. Firstmate will reply with the decision.
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
-   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
+   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved [key=<slug>]: {how it cleared}\` yourself if you opened it with a key, as you resume.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
@@ -444,10 +446,10 @@ $RULE1
    a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
    cadence instead of treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
-6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
-   append \`needs-decision: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
+Put a key between the verb and the colon, as in \`blocked [key=<work-slug>]: {why}\`; never put it after the note.
+6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings), append \`needs-decision [key=<slug>]: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
-   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
+   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved [key=<slug>]: {how it cleared}\` yourself if you opened it with a key, as you resume.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -390,7 +390,7 @@ _fm_open_decisions_cursor_path() {  # <status-file>
   printf '%s/.%s.open-decisions-cursor' "$dir" "${base%.status}"
 }
 
-FM_OPEN_DECISIONS_FOLD_VERSION=2
+FM_OPEN_DECISIONS_FOLD_VERSION=3
 
 # Portable device:inode identity for the rotation/recreation check below.
 _fm_open_decisions_file_ident() {  # <file> -> "dev:inode", empty on I/O failure

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -390,6 +390,10 @@ _fm_open_decisions_cursor_path() {  # <status-file>
   printf '%s/.%s.open-decisions-cursor' "$dir" "${base%.status}"
 }
 
+# Bump this on ANY change to _fm_decision_fold_line's open/close semantics: a
+# cursor persisted under older semantics carries an open set that folder would
+# no longer produce, and only a version mismatch forces the full re-fold that
+# discards it. Forgetting the bump silently serves a wrong open set forever.
 FM_OPEN_DECISIONS_FOLD_VERSION=3
 
 # Portable device:inode identity for the rotation/recreation check below.

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -261,22 +261,19 @@ _fm_decision_fold_line() {  # <open-set> <status-line> <resolve-verb> <held-verb
   stripped=${line//[[:space:]]/}
   [ -n "$stripped" ] || { printf '%s' "$open"; return 0; }
   verb=$(status_line_verb "$line")
-  if ! key=$(_fm_decision_key "$line"); then
-    case "$verb" in
-      needs-decision|blocked) key=default ;;
-      *) printf '%s' "$open"; return 0 ;;
-    esac
-  fi
+  key=$(_fm_decision_key "$line") || key=''
   _fm_decision_key_transition_allowed "$key" "$(status_line_note "$line")" \
     || { printf '%s' "$open"; return 0; }
   case "$verb" in
     needs-decision|blocked)
+      key=${key:-default}
       note=$(status_line_note "$line")
       open=$(_fm_decision_drop "$open" "$key")
       [ -n "$open" ] && open="${open}"$'\n'
       open="${open}${key}"$'\t'"${verb}"$'\t'"${note}"$'\n'
       ;;
     "$resolve"|"$held")
+      [ -n "$key" ] || { printf '%s' "$open"; return 0; }
       open=$(_fm_decision_drop "$open" "$key")
       [ -n "$open" ] && open="${open}"$'\n'
       ;;

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -165,6 +165,10 @@ status_is_paused_or_captain_held() {  # <status-line>
 #   resolved       [key=api-shape]: <how it was decided>
 # A line with no token uses the key "default", preserving the historical
 # one-open-decision-per-task behavior (a bare "resolved:" closes "default").
+# A malformed slug is not a valid key, so it never names a record: an OPENING
+# needs-decision/blocked line falls back to "default" rather than vanishing from
+# the open set, while a CLOSING resolve/held line is ignored outright so a typo
+# can never silently close a decision it does not name.
 # The three parsers are pure reads of a single line; the verb parser strips any
 # key token before the colon so the leading word is recovered cleanly.
 status_line_verb() {  # <status-line> -> leading verb word
@@ -257,7 +261,12 @@ _fm_decision_fold_line() {  # <open-set> <status-line> <resolve-verb> <held-verb
   stripped=${line//[[:space:]]/}
   [ -n "$stripped" ] || { printf '%s' "$open"; return 0; }
   verb=$(status_line_verb "$line")
-  key=$(_fm_decision_key "$line") || { printf '%s' "$open"; return 0; }
+  if ! key=$(_fm_decision_key "$line"); then
+    case "$verb" in
+      needs-decision|blocked) key=default ;;
+      *) printf '%s' "$open"; return 0 ;;
+    esac
+  fi
   _fm_decision_key_transition_allowed "$key" "$(status_line_note "$line")" \
     || { printf '%s' "$open"; return 0; }
   case "$verb" in

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -668,6 +668,9 @@ test_pause_verb_override_renders_all_brief_scaffolds() {
     # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
     assert_grep 'When you use a key, put it between the verb and the colon, as in `blocked [key=<work-slug>]: {why}`' "$brief" \
       "$kind brief did not pin decision-key placement between the verb and colon"
+    # shellcheck disable=SC2016 # Literal backticks must remain unexpanded.
+    assert_grep 'Replace the placeholder with a real slug of letters, digits, `.`, `_`, or `-` only' "$brief" \
+      "$kind brief did not state the key slug grammar it now routes every escalation through"
     assert_grep 'needs-decision [key=<slug>]:' "$brief" \
       "$kind brief did not show correctly placed decision-key syntax"
     # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -666,12 +666,16 @@ test_pause_verb_override_renders_all_brief_scaffolds() {
     assert_grep 'a blocker or wait clears' "$brief" \
       "$kind brief did not require durable resolution when a blocker clears"
     # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
-    assert_grep 'Put a key between the verb and the colon, as in `blocked [key=<work-slug>]: {why}`' "$brief" \
+    assert_grep 'When you use a key, put it between the verb and the colon, as in `blocked [key=<work-slug>]: {why}`' "$brief" \
       "$kind brief did not pin decision-key placement between the verb and colon"
     assert_grep 'needs-decision [key=<slug>]:' "$brief" \
       "$kind brief did not show correctly placed decision-key syntax"
-    assert_grep 'resolved [key=<slug>]: {how it cleared}' "$brief" \
-      "$kind brief did not show correctly placed resolution-key syntax"
+    # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
+    assert_grep 'append the closing line yourself as you' "$brief" \
+      "$kind brief made the worker self-close duty conditional on having used a key"
+    # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
+    assert_grep '`resolved: {how it cleared}`, or `resolved [key=<slug>]: {how it cleared}` if you opened it with a key' "$brief" \
+      "$kind brief did not show both the bare and keyed self-close forms"
     # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
     assert_no_grep 'resolved: {how it cleared}` yourself (same `[key=<slug>]`' "$brief" \
       "$kind brief retained the ambiguous trailing-key resolution syntax"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -665,6 +665,16 @@ test_pause_verb_override_renders_all_brief_scaffolds() {
       "$kind brief still instructs the default paused status"
     assert_grep 'a blocker or wait clears' "$brief" \
       "$kind brief did not require durable resolution when a blocker clears"
+    # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
+    assert_grep 'Put a key between the verb and the colon, as in `blocked [key=<work-slug>]: {why}`' "$brief" \
+      "$kind brief did not pin decision-key placement between the verb and colon"
+    assert_grep 'needs-decision [key=<slug>]:' "$brief" \
+      "$kind brief did not show correctly placed decision-key syntax"
+    assert_grep 'resolved [key=<slug>]: {how it cleared}' "$brief" \
+      "$kind brief did not show correctly placed resolution-key syntax"
+    # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
+    assert_no_grep 'resolved: {how it cleared}` yourself (same `[key=<slug>]`' "$brief" \
+      "$kind brief retained the ambiguous trailing-key resolution syntax"
     assert_grep 'even when the answer is what started that work' "$brief" \
       "$kind brief did not warn that an answer-started done/working never closes a decision"
   done

--- a/tests/fm-wake-drain-open-decisions-cursor.test.sh
+++ b/tests/fm-wake-drain-open-decisions-cursor.test.sh
@@ -311,6 +311,37 @@ test_previous_fold_cache_is_refolded_under_current_semantics() {
   pass "an old fold cache is rebuilt once before same-version incremental reads resume"
 }
 
+test_fold_version_2_cursor_is_never_trusted() {
+  local dir state status cursor out ident status_bytes
+  dir=$(make_case cursor-fold-version-2)
+  state="$dir/state"
+  status="$state/task7.status"
+  cursor="$state/.task7.open-decisions-cursor"
+  out="$dir/drain.out"
+
+  printf 'needs-decision [key=bad key]: choose A or B\n' > "$status"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" \
+    || fail "bootstrap drain over a malformed-key escalation failed"
+  grep -F 'task7' "$out" | grep -F 'choose A or B' >/dev/null \
+    || fail "a malformed-key escalation did not surface through the incremental drain"
+
+  ident=$(sed -n 's/^ident=//p' "$cursor")
+  status_bytes=$(LC_ALL=C wc -c < "$status" | tr -d '[:space:]')
+  {
+    printf 'version=2\n'
+    printf 'offset=%s\n' "$status_bytes"
+    printf 'ident=%s\n' "$ident"
+  } > "$cursor"
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" \
+    || fail "drain failed over a fold-version-2 cursor"
+  grep -F 'task7' "$out" | grep -F 'choose A or B' >/dev/null \
+    || fail "a fold-version-2 cursor's empty open set was trusted under current fold semantics"
+
+  pass "a cursor persisted under fold version 2 is refolded, not trusted"
+}
+
+test_fold_version_2_cursor_is_never_trusted
 test_truncated_log_falls_back_to_a_full_refold_not_a_dropped_decision
 test_same_size_rewrite_is_detected_via_inode_identity
 test_read_failure_never_silently_returns_empty

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -191,6 +191,17 @@ test_classifier_primitives() {
     && fail "FM_CAPTAIN_RE override bypassed paused: suppression"
   FM_CAPTAIN_RE='custom-verb:' status_is_captain_relevant "custom-verb: x" \
     || fail "nonterminal suppression weakened custom bare-line behavior"
+  incident_line='blocked: report complete; decision-hold gate needs tasks-axi>=0.2.4 [key=decision-hold-gate]'
+  printf '%s\n' "$incident_line" > "$state/incident.status"
+  open=$(status_open_decisions "$state/incident.status")
+  printf '%s' "$open" | grep -F $'default\tblocked\treport complete; decision-hold gate needs tasks-axi>=0.2.4 [key=decision-hold-gate]' >/dev/null \
+    || fail "the exact trailing-key incident line no longer documents its compatibility behavior"
+  printf '%s' "$open" | grep -F $'decision-hold-gate\t' >/dev/null \
+    && fail "a trailing key token was unexpectedly accepted despite ambiguous note prose"
+  printf 'blocked [key=decision-hold-gate]: report complete; decision-hold gate needs tasks-axi>=0.2.4\n' > "$state/incident-correct.status"
+  open=$(status_open_decisions "$state/incident-correct.status")
+  printf '%s' "$open" | grep -F $'decision-hold-gate\tblocked\treport complete; decision-hold gate needs tasks-axi>=0.2.4' >/dev/null \
+    || fail "a correctly placed decision key was not read"
   printf 'needs-decision: should docs mention [key=prose]?\nneeds-decision [key=q1]: real choice\nresolved: docs still mention [key=q1]\nneeds-decision [key=bad key]: malformed\n' > "$state/keys.status"
   open=$(status_open_decisions "$state/keys.status")
   printf '%s' "$open" | grep -F $'q1\t' >/dev/null \

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -210,6 +210,12 @@ test_classifier_primitives() {
     && fail "a key token in note prose changed the decision key"
   printf '%s' "$open" | grep -F $'bad key\t' >/dev/null \
     && fail "an invalid key slug entered the open-decision set"
+  printf '%s' "$open" | grep -F $'default\tneeds-decision\tmalformed' >/dev/null \
+    || fail "an escalation with a malformed key slug vanished from the open-decision set"
+  printf 'needs-decision [key=<slug>]: pick option A or B\nresolved [key=bad key]: typo\n' > "$state/malformed-keys.status"
+  open=$(status_open_decisions "$state/malformed-keys.status")
+  printf '%s' "$open" | grep -F $'default\tneeds-decision\tpick option A or B' >/dev/null \
+    || fail "a copied key placeholder either voided the escalation or let a malformed resolve close it"
   cat > "$state/activity.status" <<'EOF'
 working [key=phase7]: Phase 7 started
 working [key=phase6]: Phase 6 started


### PR DESCRIPTION
## Problem
`bin/fm-classify-lib.sh` requires `[key=<slug>]` between the status verb and the colon, but the generated scaffolds did not say so. Workers therefore wrote keys at the end of status lines, and the key never registered.

## Changes
- Clarified parser-accepted key placement in ship, scout, and secondmate briefs.
- Added regression coverage for the incident line and correctly placed keys.
- Kept the parser strict because trailing bracketed prose is ambiguous.

Validation: `tests/fm-brief.test.sh`, focused classifier coverage, `tests/fm-send-resolve-key.test.sh`, and `bin/fm-lint.sh` pass.