### PR TITLE
feat(bin): add a token-efficiency work policy to the owner contract and ship briefs

### DIFF
--- a/.agents/skills/quota-array-dispatch/SKILL.md
+++ b/.agents/skills/quota-array-dispatch/SKILL.md
@@ -89,7 +89,7 @@ Never use headroom, runway, pace, or reserve to silently replace that reasoning 
 2. Honor any explicit captain instruction that sets a floor for that candidate before the generic comparison.
    Do not invent a generic percentage floor or treat a low percentage as an automatic failure.
 3. Keep the strongest-reasoning class when every candidate is tight or completion evidence is poor.
-   Dispatch inside that class when a candidate can proceed, or report that its strongest-class choice cannot proceed.
+   Dispatch inside that class when a candidate can proceed, or report that its strongest-class choice cannot proceed rather than downgrading it to conserve quota.
 4. Compare comparable-fit candidates on their applicable effective headroom and usable runway.
    Eliminate a candidate only when another candidate Pareto-dominates it on both dimensions, with at least one dimension strictly better.
    Establish dominance only from comparable known evidence, never by treating absent, `unknown`, or unmeasurable headroom or runway as zero or as a healthy value.

--- a/.agents/skills/quota-array-dispatch/SKILL.md
+++ b/.agents/skills/quota-array-dispatch/SKILL.md
@@ -89,7 +89,7 @@ Never use headroom, runway, pace, or reserve to silently replace that reasoning 
 2. Honor any explicit captain instruction that sets a floor for that candidate before the generic comparison.
    Do not invent a generic percentage floor or treat a low percentage as an automatic failure.
 3. Keep the strongest-reasoning class when every candidate is tight or completion evidence is poor.
-   Dispatch inside that class when a candidate can proceed, or report that its strongest-class choice cannot proceed rather than downgrading it to conserve quota.
+   Dispatch inside that class when a candidate can proceed, or report that its strongest-class choice cannot proceed.
 4. Compare comparable-fit candidates on their applicable effective headroom and usable runway.
    Eliminate a candidate only when another candidate Pareto-dominates it on both dimensions, with at least one dimension strictly better.
    Establish dominance only from comparable known evidence, never by treating absent, `unknown`, or unmeasurable headroom or runway as zero or as a healthy value.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -326,7 +326,7 @@ Within each delivery-path owner's implementation and correction loops, group rel
 For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
 The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
-Never restart, duplicate, or supersede an active validation run to save tokens; preserve its fixes and drive its current gate.
+Token or quota savings alone never authorize restarting, duplicating, or superseding an active validation run; apart from the supersession sequence below, preserve that run's own pipeline fixes and drive its current gate.
 Once validation starts, prefer routing new requirements to follow-up work rather than expanding the current task, unless a new requirement completely invalidates the work being validated; however, the smallest downstream changes needed to keep already accepted product or engineering behavior correct, add behavioral tests where an executable contract exists, or keep documentation accurate remain within the current task even when they touch files not named at intake, and corrections required to satisfy already accepted intent are not new requirements.
 
 Only a current, explicit captain instruction that completely invalidates the work being validated keeps the task with the same worker instead of routing it to follow-up work or handing it to a replacement.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,6 +261,7 @@ Do not build wrappers, control planes, policy layers, custom verifiers, or autom
 
 Save tokens by eliminating duplicated work, irrelevant raw context, and repeated evidence collection, never by weakening accepted scope, necessary reasoning, evidence, validation, or safety.
 Preserve direct user requirements, authoritative source material, and durable decisions, and perform necessary targeted rereads; never substitute a lossy summary when the exact source is required to act safely or correctly.
+When firstmate or a secondmate implements or corrects work directly, group related fixes and run the smallest focused checks that establish the changed behavior before rerunning broader suites; that ordering applies only before validation begins and never narrows the delivery path's required final checks.
 Before commissioning an investigation, consult existing reports and established evidence.
 Classify the deliverable:
 
@@ -278,8 +279,7 @@ On a `no-mistakes-prod-only` project, classify the task's surface: internal-only
 An unregistered project or absent registry resolves to `no-mistakes` with yolo off, and the registration gap goes to the captain.
 Record the resulting mode, yolo, and the one-line reason for any deviation in the backlog item note.
 
-Keep independent ready work moving, but never dispatch redundant parallel work for the same deliverable.
-Treat file or subsystem overlap as a risk signal rather than an automatic reason to wait, and dispatch isolated work immediately with no concurrency cap when each change can be independently implemented and validated and the selected delivery path can reconcile ordinary rebases or conflicts.
+Treat file or subsystem overlap as a risk signal rather than an automatic reason to wait, and dispatch isolated work immediately with no concurrency cap when each change can be independently implemented and validated and the selected delivery path can reconcile ordinary rebases or conflicts, but never dispatch redundant parallel work for the same deliverable.
 Serialize only for a true semantic dependency, shared mutable external state, incompatible concurrent migration, or another concrete condition that makes independent progress or reconciliation unsafe; same-file editing alone is insufficient, and genuine blockers remain durable.
 Write the task-specific brief under section 11 before spawning.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,7 @@ Establish model support and provider family from that harness's own authoritativ
 Missing model-level quota, a missing authentication source, unmeasurable headroom, or unmodeled authentication is disclosed uncertainty that keeps a candidate eligible, never a credential or login escalation.
 Only concrete contradictory evidence blocks a candidate, such as an authoritative catalog proving the model unsupported or proof that the credential selected for that surface is unusable; never infer a credential store, provider family, or quota mapping from a harness, model, or source name, and never launch another harness's CLI to judge a candidate.
 Preserve malformed profile configuration as an actionable error rather than selecting around it.
+Choose the task-appropriate model and effort from the accepted work and dispatch evidence; never lower either solely to conserve tokens or quota.
 When every candidate is tight, preserve the captain's strongest-reasoning class rather than silently downgrading it solely to conserve quota; stop and report the tight choice if that class cannot proceed.
 Break genuine evidence ties without array-order or harness bias.
 `quota-axi` owns how model or product windows relate to bounding account windows and remains data-only.
@@ -259,7 +260,9 @@ If no secondmate scope fits, use the main home or discuss creating an appropriat
 For one-off or infrequent operational work, start with the simplest direct end-to-end path.
 Do not build wrappers, control planes, policy layers, custom verifiers, or automation unless the direct path exposes a concrete blocker or repeated need that justifies the added machinery.
 
-Before commissioning an investigation, consult existing reports and established evidence.
+Save tokens by eliminating duplicated work, irrelevant raw context, and repeated evidence collection, never by weakening accepted scope, necessary reasoning, evidence, validation, or safety.
+Preserve direct user requirements, authoritative source material, and durable decisions, and perform necessary targeted rereads; never substitute a lossy summary when the exact source is required to act safely or correctly.
+Before commissioning an investigation, consult existing reports and established evidence, and do not repeat one already answered unless the captain explicitly requested that deliverable or new evidence could materially change the outcome.
 Classify the deliverable:
 
 - **Ship** is the default and produces a project change through the selected delivery mode; once implementation is authorized, dispatch a ship and keep any remaining bounded research inside it unless unresolved uncertainty could materially change whether or what to build.
@@ -276,6 +279,7 @@ On a `no-mistakes-prod-only` project, classify the task's surface: internal-only
 An unregistered project or absent registry resolves to `no-mistakes` with yolo off, and the registration gap goes to the captain.
 Record the resulting mode, yolo, and the one-line reason for any deviation in the backlog item note.
 
+Keep independent ready work moving, but never dispatch redundant parallel work for the same deliverable.
 Treat file or subsystem overlap as a risk signal rather than an automatic reason to wait, and dispatch isolated work immediately with no concurrency cap when each change can be independently implemented and validated and the selected delivery path can reconcile ordinary rebases or conflicts.
 Serialize only for a true semantic dependency, shared mutable external state, incompatible concurrent migration, or another concrete condition that makes independent progress or reconciliation unsafe; same-file editing alone is insufficient, and genuine blockers remain durable.
 Write the task-specific brief under section 11 before spawning.
@@ -295,9 +299,9 @@ Supervise all live work under section 8.
 
 ### Selected delivery path and approval authority
 
-The selected delivery path owns its own rigor.
+The selected delivery path owns its own rigor; token savings never skip, narrow, or replace its required final tests, documentation, review, no-mistakes gates, PR checks, or CI.
 When no-mistakes is selected, no-mistakes alone owns review, fixes, tests, documentation, push, PR, and CI; otherwise follow the faster path without adding an independent reviewer.
-Never hold work outside no-mistakes for a manual clean verdict, stack serial manual reviews, or infer authority for one from security, architecture, or risk alone.
+Never commission an optional duplicate reviewer, hold work outside no-mistakes for a manual clean verdict, stack serial manual reviews, or infer authority for one from security, architecture, or risk alone.
 A separate review or audit is allowed only when the captain explicitly requests that deliverable or the authorized task is a knowledge-only review; one named question remains scoped to that question.
 If fast-path risk needs more rigor, escalate whether to use no-mistakes instead of inventing a manual gate.
 The path's worker, automated gates, and captain approval remain authoritative:
@@ -319,9 +323,11 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 
 ### Validate
 
+Within each delivery-path owner's implementation and correction loops, group related fixes and run the smallest focused checks that establish the changed behavior before rerunning broader suites.
 For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
 The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
+Never restart, duplicate, or supersede an active validation run to save tokens; preserve its fixes and drive its current gate.
 Once validation starts, prefer routing new requirements to follow-up work rather than expanding the current task, unless a new requirement completely invalidates the work being validated; however, the smallest downstream changes needed to keep already accepted product or engineering behavior correct, add behavioral tests where an executable contract exists, or keep documentation accurate remain within the current task even when they touch files not named at intake, and corrections required to satisfy already accepted intent are not new requirements.
 
 Only a current, explicit captain instruction that completely invalidates the work being validated keeps the task with the same worker instead of routing it to follow-up work or handing it to a replacement.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -322,7 +322,6 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 
 ### Validate
 
-Within each delivery-path owner's implementation and correction loops, group related fixes and run the smallest focused checks that establish the changed behavior before rerunning broader suites.
 For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
 The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,7 +261,7 @@ Do not build wrappers, control planes, policy layers, custom verifiers, or autom
 
 Save tokens by eliminating duplicated work, irrelevant raw context, and repeated evidence collection, never by weakening accepted scope, necessary reasoning, evidence, validation, or safety.
 Preserve direct user requirements, authoritative source material, and durable decisions, and perform necessary targeted rereads; never substitute a lossy summary when the exact source is required to act safely or correctly.
-When firstmate or a secondmate implements or corrects work directly, group related fixes and run the smallest focused checks that establish the changed behavior before rerunning broader suites; that ordering applies only before validation begins and never narrows the delivery path's required final checks.
+When firstmate or a secondmate implements or corrects work directly under section 1's existing exceptions, group related fixes and run the smallest focused checks that establish the changed behavior before rerunning broader suites; that ordering applies only before validation begins and never narrows the delivery path's required final checks.
 Before commissioning an investigation, consult existing reports and established evidence.
 Classify the deliverable:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,8 +187,7 @@ Establish model support and provider family from that harness's own authoritativ
 Missing model-level quota, a missing authentication source, unmeasurable headroom, or unmodeled authentication is disclosed uncertainty that keeps a candidate eligible, never a credential or login escalation.
 Only concrete contradictory evidence blocks a candidate, such as an authoritative catalog proving the model unsupported or proof that the credential selected for that surface is unusable; never infer a credential store, provider family, or quota mapping from a harness, model, or source name, and never launch another harness's CLI to judge a candidate.
 Preserve malformed profile configuration as an actionable error rather than selecting around it.
-Choose the task-appropriate model and effort from the accepted work and dispatch evidence; never lower either solely to conserve tokens or quota.
-When every candidate is tight, preserve the captain's strongest-reasoning class rather than silently downgrading it solely to conserve quota; stop and report the tight choice if that class cannot proceed.
+When every candidate is tight, preserve the captain's strongest-reasoning class and the task-appropriate effort rather than silently downgrading either solely to conserve tokens or quota; stop and report the tight choice if that class cannot proceed.
 Break genuine evidence ties without array-order or harness bias.
 `quota-axi` owns how model or product windows relate to bounding account windows and remains data-only.
 Load `quota-array-dispatch` before choosing among a matched profile array; that skill is the single owner of the completion-aware selection procedure.
@@ -262,7 +261,7 @@ Do not build wrappers, control planes, policy layers, custom verifiers, or autom
 
 Save tokens by eliminating duplicated work, irrelevant raw context, and repeated evidence collection, never by weakening accepted scope, necessary reasoning, evidence, validation, or safety.
 Preserve direct user requirements, authoritative source material, and durable decisions, and perform necessary targeted rereads; never substitute a lossy summary when the exact source is required to act safely or correctly.
-Before commissioning an investigation, consult existing reports and established evidence, and do not repeat one already answered unless the captain explicitly requested that deliverable or new evidence could materially change the outcome.
+Before commissioning an investigation, consult existing reports and established evidence.
 Classify the deliverable:
 
 - **Ship** is the default and produces a project change through the selected delivery mode; once implementation is authorized, dispatch a ship and keep any remaining bounded research inside it unless unresolved uncertainty could materially change whether or what to build.
@@ -301,7 +300,7 @@ Supervise all live work under section 8.
 
 The selected delivery path owns its own rigor; token savings never skip, narrow, or replace its required final tests, documentation, review, no-mistakes gates, PR checks, or CI.
 When no-mistakes is selected, no-mistakes alone owns review, fixes, tests, documentation, push, PR, and CI; otherwise follow the faster path without adding an independent reviewer.
-Never commission an optional duplicate reviewer, hold work outside no-mistakes for a manual clean verdict, stack serial manual reviews, or infer authority for one from security, architecture, or risk alone.
+Never hold work outside no-mistakes for a manual clean verdict, stack serial manual reviews, or infer authority for one from security, architecture, or risk alone.
 A separate review or audit is allowed only when the captain explicitly requests that deliverable or the authorized task is a knowledge-only review; one named question remains scoped to that question.
 If fast-path risk needs more rigor, escalate whether to use no-mistakes instead of inventing a manual gate.
 The path's worker, automated gates, and captain approval remain authoritative:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,7 +187,8 @@ Establish model support and provider family from that harness's own authoritativ
 Missing model-level quota, a missing authentication source, unmeasurable headroom, or unmodeled authentication is disclosed uncertainty that keeps a candidate eligible, never a credential or login escalation.
 Only concrete contradictory evidence blocks a candidate, such as an authoritative catalog proving the model unsupported or proof that the credential selected for that surface is unusable; never infer a credential store, provider family, or quota mapping from a harness, model, or source name, and never launch another harness's CLI to judge a candidate.
 Preserve malformed profile configuration as an actionable error rather than selecting around it.
-When every candidate is tight, preserve the captain's strongest-reasoning class and the task-appropriate effort rather than silently downgrading either solely to conserve tokens or quota; stop and report the tight choice if that class cannot proceed.
+Choose the task-appropriate model and effort from the accepted work and dispatch evidence; never lower either solely to conserve tokens or quota.
+When every candidate is tight, preserve the captain's strongest-reasoning class rather than silently downgrading it solely to conserve quota; stop and report the tight choice if that class cannot proceed.
 Break genuine evidence ties without array-order or harness bias.
 `quota-axi` owns how model or product windows relate to bounding account windows and remains data-only.
 Load `quota-array-dispatch` before choosing among a matched profile array; that skill is the single owner of the completion-aware selection procedure.
@@ -261,7 +262,7 @@ Do not build wrappers, control planes, policy layers, custom verifiers, or autom
 
 Save tokens by eliminating duplicated work, irrelevant raw context, and repeated evidence collection, never by weakening accepted scope, necessary reasoning, evidence, validation, or safety.
 Preserve direct user requirements, authoritative source material, and durable decisions, and perform necessary targeted rereads; never substitute a lossy summary when the exact source is required to act safely or correctly.
-When firstmate or a secondmate implements or corrects work directly under section 1's existing exceptions, group related fixes and run the smallest focused checks that establish the changed behavior before rerunning broader suites; that ordering applies only before validation begins and never narrows the delivery path's required final checks.
+When firstmate or a secondmate implements or corrects work directly under section 1's existing exceptions, group related fixes and run the smallest focused checks that establish the changed behavior before rerunning broader suites; that ordering ends when the delivery path's required final checks begin and never narrows them.
 Before commissioning an investigation, consult existing reports and established evidence.
 Classify the deliverable:
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -451,9 +451,9 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
-8. Before validation starts, group related fixes and run the smallest focused checks that establish the
-   changed behavior before rerunning broader suites. This orders your own implementation and correction
-   loop only - it never narrows what your Definition of done requires.
+8. While the change is still yours to edit, group related fixes and run the smallest focused checks that
+   establish the changed behavior before rerunning broader suites. This ordering ends when this mode's
+   required final checks begin, and it never narrows what your Definition of done requires.
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -451,6 +451,9 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+8. While implementing and correcting your own work, group related fixes and run the smallest focused
+   checks that establish the changed behavior before rerunning broader suites. This orders your own
+   iteration only - it never narrows what your Definition of done requires.
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -451,9 +451,9 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
-8. While implementing and correcting your own work, group related fixes and run the smallest focused
-   checks that establish the changed behavior before rerunning broader suites. This orders your own
-   iteration only - it never narrows what your Definition of done requires.
+8. Before validation starts, group related fixes and run the smallest focused checks that establish the
+   changed behavior before rerunning broader suites. This orders your own implementation and correction
+   loop only - it never narrows what your Definition of done requires.
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -41,6 +41,10 @@
 # to launch a ship task whose explicit --mode disagrees, so an adjusted brief and the
 # recorded task metadata cannot drift apart.
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
+# Ship briefs also carry a worker-owned iteration rule: while the change is still the
+# worker's to edit, related fixes are grouped behind the smallest focused checks that
+# establish the changed behavior. That ordering ends when this mode's required final
+# checks begin and never narrows the definition of done it generates.
 # --mode is refused on scout and secondmate scaffolds: a scout's deliverable is a
 # report rather than a merge, and a charter is not a delivery contract.
 # There is no --yolo flag here. The worker never owns approval decisions, so yolo is

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -5,8 +5,8 @@
 # again. After promoting, send the crewmate its ship instructions via fm-send.sh
 # (inventory scratch state, reset to a clean default-branch base, carry over only
 # intended fix changes, create branch fm/<task-id>, implement with related fixes
-# grouped behind the smallest focused checks, then report done according to this
-# task's delivery mode).
+# grouped behind the smallest focused checks until validation starts, then report
+# done according to this task's delivery mode).
 # A scout records no delivery posture, so promotion is where this task's delivery
 # contract is decided: --mode and --yolo are REQUIRED and written into the meta
 # alongside the kind= flip. Firstmate resolves both at promotion time, having just
@@ -86,4 +86,4 @@ mv "$TMP" "$META"
 
 HOME_Q=$(printf '%q' "$FM_HOME")
 echo "promoted $ID to ship mode=$MODE yolo=$YOLO (teardown protection restored)"
-echo "next: FM_HOME=$HOME_Q bin/fm-send.sh fm-$ID '<ship instructions for mode=$MODE: review scratch state with git status and git log; reset to a clean default-branch base; carry over only intended fix changes; create branch fm/$ID; implement, grouping related fixes and running the smallest focused checks that establish the changed behavior before rerunning broader suites; those interim checks never narrow the definition of done or final checks this delivery mode requires; report done>'"
+echo "next: FM_HOME=$HOME_Q bin/fm-send.sh fm-$ID '<ship instructions for mode=$MODE: review scratch state with git status and git log; reset to a clean default-branch base; carry over only intended fix changes; create branch fm/$ID; implement, grouping related fixes and running the smallest focused checks that establish the changed behavior before rerunning broader suites; those interim checks apply only before validation starts and never narrow the definition of done or final checks this delivery mode requires; report done>'"

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -4,8 +4,9 @@
 # state/<task-id>.meta so fm-teardown.sh applies the full ship-task teardown protection
 # again. After promoting, send the crewmate its ship instructions via fm-send.sh
 # (inventory scratch state, reset to a clean default-branch base, carry over only
-# intended fix changes, create branch fm/<task-id>, implement, then report done
-# according to this task's delivery mode).
+# intended fix changes, create branch fm/<task-id>, implement with related fixes
+# grouped behind the smallest focused checks, then report done according to this
+# task's delivery mode).
 # A scout records no delivery posture, so promotion is where this task's delivery
 # contract is decided: --mode and --yolo are REQUIRED and written into the meta
 # alongside the kind= flip. Firstmate resolves both at promotion time, having just
@@ -85,4 +86,4 @@ mv "$TMP" "$META"
 
 HOME_Q=$(printf '%q' "$FM_HOME")
 echo "promoted $ID to ship mode=$MODE yolo=$YOLO (teardown protection restored)"
-echo "next: FM_HOME=$HOME_Q bin/fm-send.sh fm-$ID '<ship instructions for mode=$MODE: review scratch state with git status and git log; reset to a clean default-branch base; carry over only intended fix changes; create branch fm/$ID; implement; report done>'"
+echo "next: FM_HOME=$HOME_Q bin/fm-send.sh fm-$ID '<ship instructions for mode=$MODE: review scratch state with git status and git log; reset to a clean default-branch base; carry over only intended fix changes; create branch fm/$ID; implement, grouping related fixes and running the smallest focused checks that establish the changed behavior before rerunning broader suites; report done>'"

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -86,4 +86,4 @@ mv "$TMP" "$META"
 
 HOME_Q=$(printf '%q' "$FM_HOME")
 echo "promoted $ID to ship mode=$MODE yolo=$YOLO (teardown protection restored)"
-echo "next: FM_HOME=$HOME_Q bin/fm-send.sh fm-$ID '<ship instructions for mode=$MODE: review scratch state with git status and git log; reset to a clean default-branch base; carry over only intended fix changes; create branch fm/$ID; implement, grouping related fixes and running the smallest focused checks that establish the changed behavior before rerunning broader suites; report done>'"
+echo "next: FM_HOME=$HOME_Q bin/fm-send.sh fm-$ID '<ship instructions for mode=$MODE: review scratch state with git status and git log; reset to a clean default-branch base; carry over only intended fix changes; create branch fm/$ID; implement, grouping related fixes and running the smallest focused checks that establish the changed behavior before rerunning broader suites; those interim checks never narrow the definition of done or final checks this delivery mode requires; report done>'"

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -5,8 +5,8 @@
 # again. After promoting, send the crewmate its ship instructions via fm-send.sh
 # (inventory scratch state, reset to a clean default-branch base, carry over only
 # intended fix changes, create branch fm/<task-id>, implement with related fixes
-# grouped behind the smallest focused checks until validation starts, then report
-# done according to this task's delivery mode).
+# grouped behind the smallest focused checks until this mode's required final
+# checks begin, then report done according to this task's delivery mode).
 # A scout records no delivery posture, so promotion is where this task's delivery
 # contract is decided: --mode and --yolo are REQUIRED and written into the meta
 # alongside the kind= flip. Firstmate resolves both at promotion time, having just
@@ -86,4 +86,4 @@ mv "$TMP" "$META"
 
 HOME_Q=$(printf '%q' "$FM_HOME")
 echo "promoted $ID to ship mode=$MODE yolo=$YOLO (teardown protection restored)"
-echo "next: FM_HOME=$HOME_Q bin/fm-send.sh fm-$ID '<ship instructions for mode=$MODE: review scratch state with git status and git log; reset to a clean default-branch base; carry over only intended fix changes; create branch fm/$ID; implement, grouping related fixes and running the smallest focused checks that establish the changed behavior before rerunning broader suites; those interim checks apply only before validation starts and never narrow the definition of done or final checks this delivery mode requires; report done>'"
+echo "next: FM_HOME=$HOME_Q bin/fm-send.sh fm-$ID '<ship instructions for mode=$MODE: review scratch state with git status and git log; reset to a clean default-branch base; carry over only intended fix changes; create branch fm/$ID; implement, grouping related fixes and running the smallest focused checks that establish the changed behavior before rerunning broader suites; that ordering ends when the final checks this delivery mode requires begin, and never narrows the definition of done; report done>'"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -212,8 +212,8 @@ test_ship_modes_generate_clean_briefs() {
     assert_grep "{TASK}" "$brief" "$id: brief missing the {TASK} placeholder"
     assert_grep "mid-task \`working:\` line (including setup complete) is nonterminal" "$brief" \
       "$id: brief missing nonterminal working:/setup-complete gate protection"
-    assert_grep "group related fixes and run the smallest focused" "$brief" \
-      "$id: brief missing the grouped-fix/focused-check iteration guidance"
+    assert_grep "Before validation starts, group related fixes and run the smallest focused" "$brief" \
+      "$id: brief missing the pre-validation grouped-fix/focused-check iteration guidance"
     assert_grep "never narrows what your Definition of done requires" "$brief" \
       "$id: iteration guidance is not scoped away from the mode's required final checks"
     assert_no_grep "EOF" "$brief" "$id: brief leaked a heredoc EOF marker (unterminated heredoc)"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -212,10 +212,10 @@ test_ship_modes_generate_clean_briefs() {
     assert_grep "{TASK}" "$brief" "$id: brief missing the {TASK} placeholder"
     assert_grep "mid-task \`working:\` line (including setup complete) is nonterminal" "$brief" \
       "$id: brief missing nonterminal working:/setup-complete gate protection"
-    assert_grep "Before validation starts, group related fixes and run the smallest focused" "$brief" \
-      "$id: brief missing the pre-validation grouped-fix/focused-check iteration guidance"
-    assert_grep "never narrows what your Definition of done requires" "$brief" \
-      "$id: iteration guidance is not scoped away from the mode's required final checks"
+    assert_grep "While the change is still yours to edit, group related fixes" "$brief" \
+      "$id: brief missing the worker-owned grouped-fix/focused-check iteration guidance"
+    assert_grep "required final checks begin, and it never narrows what your Definition of done requires" "$brief" \
+      "$id: iteration guidance is not bounded by this mode's required final checks"
     assert_no_grep "EOF" "$brief" "$id: brief leaked a heredoc EOF marker (unterminated heredoc)"
   done
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -212,34 +212,13 @@ test_ship_modes_generate_clean_briefs() {
     assert_grep "{TASK}" "$brief" "$id: brief missing the {TASK} placeholder"
     assert_grep "mid-task \`working:\` line (including setup complete) is nonterminal" "$brief" \
       "$id: brief missing nonterminal working:/setup-complete gate protection"
+    assert_grep "group related fixes and run the smallest focused" "$brief" \
+      "$id: brief missing the grouped-fix/focused-check iteration guidance"
+    assert_grep "never narrows what your Definition of done requires" "$brief" \
+      "$id: iteration guidance is not scoped away from the mode's required final checks"
     assert_no_grep "EOF" "$brief" "$id: brief leaked a heredoc EOF marker (unterminated heredoc)"
   done
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"
-}
-
-# The grouped-fix/focused-check policy binds whoever actually runs implementation
-# and correction loops, and that is the crewmate - which never loads firstmate's
-# own AGENTS.md, only the generated brief. Assert the emitted brief (the
-# generated interface delivered to the agent) carries the guidance for every ship
-# mode, and that it stays scoped so no worker can read it as license to narrow
-# the final checks its delivery mode requires.
-test_ship_briefs_carry_focused_check_guidance() {
-  local home id mode brief
-  home="$TMP_ROOT/focused-check-home"
-  mkdir -p "$home/data"
-
-  for id_mode in "brief-focus-c1:no-mistakes" "brief-focus-c2:direct-PR" "brief-focus-c3:local-only"; do
-    id=${id_mode%%:*}
-    mode=${id_mode##*:}
-    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1 \
-      || fail "$id: fm-brief.sh --mode $mode should exit 0"
-    brief="$home/data/$id/brief.md"
-    assert_grep "group related fixes and run the smallest focused" "$brief" \
-      "$id ($mode): brief missing the grouped-fix/focused-check iteration guidance"
-    assert_grep "never narrows what your Definition of done requires" "$brief" \
-      "$id ($mode): iteration guidance is not scoped away from the mode's required final checks"
-  done
-  pass "fm-brief.sh: every ship mode's brief carries scoped focused-check iteration guidance"
 }
 
 # A ship task's delivery mode is firstmate's per-task decision, so a missing or
@@ -739,7 +718,6 @@ test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
-test_ship_briefs_carry_focused_check_guidance
 test_ship_mode_is_required_and_closed_set
 test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -217,6 +217,31 @@ test_ship_modes_generate_clean_briefs() {
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"
 }
 
+# The grouped-fix/focused-check policy binds whoever actually runs implementation
+# and correction loops, and that is the crewmate - which never loads firstmate's
+# own AGENTS.md, only the generated brief. Assert the emitted brief (the
+# generated interface delivered to the agent) carries the guidance for every ship
+# mode, and that it stays scoped so no worker can read it as license to narrow
+# the final checks its delivery mode requires.
+test_ship_briefs_carry_focused_check_guidance() {
+  local home id mode brief
+  home="$TMP_ROOT/focused-check-home"
+  mkdir -p "$home/data"
+
+  for id_mode in "brief-focus-c1:no-mistakes" "brief-focus-c2:direct-PR" "brief-focus-c3:local-only"; do
+    id=${id_mode%%:*}
+    mode=${id_mode##*:}
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1 \
+      || fail "$id: fm-brief.sh --mode $mode should exit 0"
+    brief="$home/data/$id/brief.md"
+    assert_grep "group related fixes and run the smallest focused" "$brief" \
+      "$id ($mode): brief missing the grouped-fix/focused-check iteration guidance"
+    assert_grep "never narrows what your Definition of done requires" "$brief" \
+      "$id ($mode): iteration guidance is not scoped away from the mode's required final checks"
+  done
+  pass "fm-brief.sh: every ship mode's brief carries scoped focused-check iteration guidance"
+}
+
 # A ship task's delivery mode is firstmate's per-task decision, so a missing or
 # unusable value must stop the scaffold instead of silently defaulting. The
 # no-mistakes-prod-only row is the conditional registry policy: it is never a task
@@ -714,6 +739,7 @@ test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
+test_ship_briefs_carry_focused_check_guidance
 test_ship_mode_is_required_and_closed_set
 test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -236,8 +236,8 @@ test_promote_requires_and_records_the_delivery_contract() {
   assert_contains "$out" "ship instructions for mode=direct-PR" "promotion hint did not carry the decided mode"
   assert_contains "$out" "grouping related fixes and running the smallest focused checks" \
     "promotion handoff dropped the loop guidance the promoted scout's brief never carried"
-  assert_contains "$out" "never narrow the definition of done or final checks" \
-    "promotion handoff dropped the safeguard keeping interim checks from narrowing the delivery mode"
+  assert_contains "$out" "apply only before validation starts and never narrow the definition of done or final checks" \
+    "promotion handoff dropped the pre-validation scoping keeping interim checks from narrowing the delivery mode"
   case "$out" in
     *"bin/fm-send.sh fm-promote-d1 '<"*"'"*) ;;
     *) fail "promotion hint no longer emits a single-quoted fm-send payload" ;;

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -234,6 +234,8 @@ test_promote_requires_and_records_the_delivery_contract() {
   assert_grep 'mode=direct-PR' "$meta" "promotion did not record the decided delivery mode"
   assert_grep 'yolo=on' "$meta" "promotion did not record the decided approval posture"
   assert_contains "$out" "ship instructions for mode=direct-PR" "promotion hint did not carry the decided mode"
+  assert_contains "$out" "grouping related fixes and running the smallest focused checks" \
+    "promotion handoff dropped the loop guidance the promoted scout's brief never carried"
   [ "$(grep -c '^mode=' "$meta")" = 1 ] || fail "promotion left more than one mode= line in the task record"
   pass "fm-promote: promotion requires the delivery contract and records it exactly once"
 }

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -236,8 +236,8 @@ test_promote_requires_and_records_the_delivery_contract() {
   assert_contains "$out" "ship instructions for mode=direct-PR" "promotion hint did not carry the decided mode"
   assert_contains "$out" "grouping related fixes and running the smallest focused checks" \
     "promotion handoff dropped the loop guidance the promoted scout's brief never carried"
-  assert_contains "$out" "apply only before validation starts and never narrow the definition of done or final checks" \
-    "promotion handoff dropped the pre-validation scoping keeping interim checks from narrowing the delivery mode"
+  assert_contains "$out" "ends when the final checks this delivery mode requires begin, and never narrows the definition of done" \
+    "promotion handoff dropped the mode-neutral boundary keeping interim checks from narrowing the delivery mode"
   case "$out" in
     *"bin/fm-send.sh fm-promote-d1 '<"*"'"*) ;;
     *) fail "promotion hint no longer emits a single-quoted fm-send payload" ;;

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -236,6 +236,15 @@ test_promote_requires_and_records_the_delivery_contract() {
   assert_contains "$out" "ship instructions for mode=direct-PR" "promotion hint did not carry the decided mode"
   assert_contains "$out" "grouping related fixes and running the smallest focused checks" \
     "promotion handoff dropped the loop guidance the promoted scout's brief never carried"
+  assert_contains "$out" "never narrow the definition of done or final checks" \
+    "promotion handoff dropped the safeguard keeping interim checks from narrowing the delivery mode"
+  case "$out" in
+    *"bin/fm-send.sh fm-promote-d1 '<"*"'"*) ;;
+    *) fail "promotion hint no longer emits a single-quoted fm-send payload" ;;
+  esac
+  case "${out#*fm-send.sh fm-promote-d1 }" in
+    *"'"*"'"*"'"*) fail "promotion hint payload contains an apostrophe that breaks its own single quoting" ;;
+  esac
   [ "$(grep -c '^mode=' "$meta")" = 1 ] || fail "promotion left more than one mode= line in the task record"
   pass "fm-promote: promotion requires the delivery contract and records it exactly once"
 }


### PR DESCRIPTION
## Intent

Codify a small, durable Firstmate policy for token-efficient work that never weakens intelligence, reasoning, accepted scope, evidence, validation, or safety. Inspect existing authoritative contracts first and patch their owner language rather than appending a parallel policy or duplicating rules already present. The policy must apply across project tasks and supported worker runtimes without depending on one model vendor or an optional plugin. Save tokens by eliminating duplicated work, irrelevant raw context, and repeated evidence collection, not by lowering the task-appropriate model or effort solely to conserve quota. Preserve direct user requirements, authoritative source material, durable decisions, and necessary targeted rereads; never rely on a lossy summary when an exact source is required to act safely or correctly. During implementation and correction loops, group related fixes and prefer the smallest focused checks that establish changed behavior before rerunning broader suites. The selected delivery path remains authoritative: required final tests, documentation, review, no-mistakes gates, PR checks, and CI may never be skipped, narrowed, or replaced for token savings. Do not commission optional duplicate reviewers or repeat an already-answered investigation unless the captain explicitly requested that deliverable or new evidence could materially change the outcome. Do not restart, duplicate, or supersede an active validation run to save tokens; preserve its fixes and drive its current gate. Keep independent ready work moving, but do not create redundant parallel work on the same deliverable. This is an instruction-policy change, not new machinery: do not add wrappers, hooks, daemons, background processes, model routers, token counters, custom verifiers, or new runtime state. Do not change watcher, supervision, dispatch, no-mistakes, merge-authority, approval, worktree, recovery, destructive-action, or security-sensitive contracts. Preserve automatic no-mistakes and green-merge behavior, routine yolo decision authority, required captain boundaries, and true semantic dependency handling. Keep the always-loaded addition concise. Use the documentation audience inventory and one-owner rule to place supporting prose; do not create a new skill without a genuine conditional trigger. Validate the complete final diff for contradictory or duplicate rules. Run bin/fm-doc-audience-check.sh and every existing relevant documentation/instruction check. Do not add source-text assertion tests. Commit the minimal coherent change, run the full no-mistakes path, and report the green PR URL. Do not create a standalone HTML summary.

## What Changed

- `AGENTS.md`: folded token-efficiency rules into the existing owner clauses instead of a parallel section — savings must come from eliminating duplicated work, irrelevant raw context, and repeated evidence collection, never from weakening accepted scope, reasoning, evidence, validation, or safety; model and effort are chosen from the accepted work and dispatch evidence and never lowered to conserve quota; the selected delivery path's required final tests, docs, review, no-mistakes gates, PR checks, and CI can't be skipped, narrowed, or replaced; an active validation run can't be restarted, duplicated, or superseded for token savings; and dispatch may not create redundant parallel work on the same deliverable.
- `bin/fm-brief.sh`: generated ship briefs now carry a worker-owned iteration rule (rule 8) to group related fixes behind the smallest focused checks that establish the changed behavior before rerunning broader suites, explicitly bounded so it ends when the mode's required final checks begin and never narrows the Definition of done; the script header documents the same rule.
- `bin/fm-promote.sh`: the promotion handoff hint relays that mode-neutral loop guidance to a promoted scout, whose original brief never contained it. Tests assert the guidance appears in all three ship-mode briefs and in the promotion hint, and that the hint's payload stays safe under its own single quoting.

## Risk Assessment

✅ Low: Instruction-policy-only change: five net lines of always-loaded prose plus mode-neutral guidance in two generated interfaces, with no new machinery, no runtime state, every intent criterion traceable to a specific line, the earlier out-of-scope quota-array-dispatch edit fully reverted to base, and new assertions that exercise emitted output rather than implementation source.

## Testing

Ran the documentation-audience check and the targeted tests covering both changed scripts (fm-brief, fm-task-delivery, fm-documentation-audiences, fm-ask-user-authority, fm-tangle-guard, fm-secondmate-safety, fm-subagent-pretool-check) — all pass — then went past the unit assertions and exercised the real surfaces: generated actual ship briefs for all three delivery modes plus a scout, confirming the new grouped-fix/focused-check rule renders with its "never narrows your Definition of done" boundary in every ship mode and is absent from the scout brief, and ran the scout-to-ship promotion end-to-end, shell-parsing and executing its emitted handoff command against a stub fm-send.sh to prove the relayed instructions reach the promoted crewmate as one intact argument. No rendered UI exists in this change (it edits AGENTS.md prose and two bash scripts that emit agent instruction text), so evidence is the generated brief and executed CLI transcripts rather than screenshots. Transient temp state was removed and the worktree is clean; no findings.

<details>
<summary>Evidence: Generated crewmate ship brief (no-mistakes mode) carrying the new rule 8</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of some-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/demo-no-mistakes`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/rc/mqjhh21s1zs8j8l54gtwm7c40000gn/T//fm-evidence.ENSbgL/home/state/demo-no-mistakes.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.
8. While the change is still yours to edit, group related fixes and run the smallest focused checks that
   establish the changed behavior before rerunning broader suites. This ordering ends when this mode's
   required final checks begin, and it never narrows what your Definition of done requires.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/johndoe/.no-mistakes/worktrees/49d49de89cf6/01KZHG6P67N6CP1MBKZ3XD99NK/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/johndoe/.no-mistakes/worktrees/49d49de89cf6/01KZHG6P67N6CP1MBKZ3XD99NK/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: New brief rule as rendered in all three ship modes (and absent from the scout brief)</summary>

<code>===== mode=no-mistakes : tail of the # Rules section =====&#10;8. While the change is still yours to edit, group related fixes and run the smallest focused checks that&#10;establish the changed behavior before rerunning broader suites. This ordering ends when this mode&#39;s&#10;required final checks begin, and it never narrows what your Definition of done requires.&#10;&#10;(identical rule 8 renders for mode=direct-PR and mode=local-only)&#10;&#10;===== --scout =====&#10;rule-8 lines in scout brief: 0</code>

```text
Generated crewmate ship briefs - bin/fm-brief.sh <id> some-proj --mode <mode>
The new worker-loop rule is what an implementation crewmate actually receives.

===== mode=no-mistakes : tail of the # Rules section =====
8. While the change is still yours to edit, group related fixes and run the smallest focused checks that
   establish the changed behavior before rerunning broader suites. This ordering ends when this mode's
   required final checks begin, and it never narrows what your Definition of done requires.


===== mode=direct-PR : tail of the # Rules section =====
8. While the change is still yours to edit, group related fixes and run the smallest focused checks that
   establish the changed behavior before rerunning broader suites. This ordering ends when this mode's
   required final checks begin, and it never narrows what your Definition of done requires.


===== mode=local-only : tail of the # Rules section =====
8. While the change is still yours to edit, group related fixes and run the smallest focused checks that
   establish the changed behavior before rerunning broader suites. This ordering ends when this mode's
   required final checks begin, and it never narrows what your Definition of done requires.


===== --scout : no rule 8 (a scout has no delivery contract yet) =====
rule-8 lines in scout brief: 0
```
</details>
<details>
<summary>Evidence: Scout to ship promotion handoff executed end-to-end</summary>

<code>$ FM_HOME=&lt;home&gt; bin/fm-promote.sh demo-scout --mode no-mistakes --yolo on&#10;promoted demo-scout to ship mode=no-mistakes yolo=on (teardown protection restored)&#10;next: FM_HOME=&lt;home&gt; bin/fm-send.sh fm-demo-scout &#39;&lt;ship instructions for mode=no-mistakes: ... implement, grouping related fixes and running the smallest focused checks that establish the changed behavior before rerunning broader suites; that ordering ends when the final checks this delivery mode requires begin, and never narrows the definition of done; report done&gt;&#39;&#10;&#10;task record after promotion:&#10;window=fm-demo-scout / kind=ship / mode=no-mistakes / yolo=on&#10;&#10;The captain runs that emitted command. Executed here against a stub fm-send.sh:&#10;fm-send.sh received argc=2&#10;arg1 (window) = fm-demo-scout&#10;arg2 = the full ship instructions above, delivered intact as a single argument</code>

```text
Scout -> ship promotion handoff, end to end (bin/fm-promote.sh)

$ FM_HOME=<home> bin/fm-promote.sh demo-scout --mode no-mistakes --yolo on
promoted demo-scout to ship mode=no-mistakes yolo=on (teardown protection restored)
next: FM_HOME=/var/folders/rc/mqjhh21s1zs8j8l54gtwm7c40000gn/T//fm-evidence.ENSbgL/promote-home bin/fm-send.sh fm-demo-scout '<ship instructions for mode=no-mistakes: review scratch state with git status and git log; reset to a clean default-branch base; carry over only intended fix changes; create branch fm/demo-scout; implement, grouping related fixes and running the smallest focused checks that establish the changed behavior before rerunning broader suites; that ordering ends when the final checks this delivery mode requires begin, and never narrows the definition of done; report done>'

task record after promotion:
  window=fm-demo-scout
  worktree=/tmp/wt
  kind=ship
  mode=no-mistakes
  yolo=on

The captain runs that emitted command. Executed here against a stub fm-send.sh:
fm-send.sh received argc=2
  arg1 (window) = fm-demo-scout
  arg2 (message delivered to the promoted crewmate):
    | <ship instructions for mode=no-mistakes: review scratch state with git status and git log; 
    | reset to a clean default-branch base; carry over only intended fix changes; create branch 
    | fm/demo-scout; implement, grouping related fixes and running the smallest focused checks that 
    | establish the changed behavior before rerunning broader suites; that ordering ends when the 
    | final checks this delivery mode requires begin, and never narrows the definition of done; 
    | report done>
  FM_HOME seen by fm-send = /var/folders/rc/mqjhh21s1zs8j8l54gtwm7c40000gn/T//fm-evidence.ENSbgL/promote-home
```
</details>
<details>
<summary>Evidence: AGENTS.md policy sentences shown under the owner sections they were patched into</summary>

<code>[## 4. Harness and runtime dispatch] AGENTS.md:190 - task-appropriate model/effort, never lowered solely to conserve tokens or quota&#10;[### Intake and authority] AGENTS.md:263-265 - save tokens by removing duplicated work/irrelevant context/repeated evidence; preserve requirements, sources, durable decisions, targeted rereads; grouped fixes behind smallest focused checks for direct work&#10;[### Intake and authority] AGENTS.md:283 - no redundant parallel work for the same deliverable&#10;[### Selected delivery path and approval authority] AGENTS.md:302 - token savings never skip/narrow/replace required final tests, docs, review, gates, PR checks, or CI&#10;[### Validate] AGENTS.md:329 - token savings never authorize restarting/duplicating/superseding an active validation run&#10;AGENTS.md total lines: 562 (net +7)</code>

```text
AGENTS.md is the always-loaded firstmate instruction surface (CLAUDE.md is a symlink to it).
Each policy sentence this change adds, shown under the owner section it was patched into:

[## 4. Harness and runtime dispatch]  AGENTS.md:190
  Choose the task-appropriate model and effort from the accepted work and dispatch evidence; never lower either solely to conserve tokens or quota.

[### Intake and authority]  AGENTS.md:263
  Save tokens by eliminating duplicated work, irrelevant raw context, and repeated evidence collection, never by weakening accepted scope, necessary reasoning, evidence, validation, or safety.

[### Intake and authority]  AGENTS.md:264
  Preserve direct user requirements, authoritative source material, and durable decisions, and perform necessary targeted rereads; never substitute a lossy summary when the exact source is required to act safely or correctly.

[### Intake and authority]  AGENTS.md:265
  When firstmate or a secondmate implements or corrects work directly under section 1's existing exceptions, group related fixes and run the smallest focused checks that establish the changed behavior before rerunning broader suites; that ordering ends when the delivery path's required final checks begin and never narrows them.

[### Intake and authority]  AGENTS.md:283
  Treat file or subsystem overlap as a risk signal rather than an automatic reason to wait, and dispatch isolated work immediately with no concurrency cap when each change can be independently implemented and validated and the selected delivery path can reconcile ordinary rebases or conflicts, but never dispatch redundant parallel work for the same deliverable.

[### Selected delivery path and approval authority]  AGENTS.md:302
  The selected delivery path owns its own rigor; token savings never skip, narrow, or replace its required final tests, documentation, review, no-mistakes gates, PR checks, or CI.

[### Validate]  AGENTS.md:329
  Token or quota savings alone never authorize restarting, duplicating, or superseding an active validation run; apart from the supersession sequence below, preserve that run's own pipeline fixes and drive its current gate.

AGENTS.md total lines: 562 (net +7 from this change)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (3) ✅</summary>

- ℹ️ `AGENTS.md:325` - Commit 71bb97d removed the always-loaded copy of the focused-check loop rule (&#34;Within each delivery-path owner&#39;s implementation and correction loops, group related fixes and run the smallest focused checks...&#34;) from the Validate section, leaving it only in generated ship briefs (bin/fm-brief.sh:454) and the scout-promotion hint (bin/fm-promote.sh:89). That covers crewmates doing project tasks, which is what the intent&#39;s &#34;across project tasks and supported worker runtimes&#34; asks for, but AGENTS.md:40 explicitly authorizes firstmate to change shared tracked material directly when the fleet is empty, and secondmates read AGENTS.md rather than a generated brief. Those actors run their own implementation and correction loops and no longer see the rule anywhere. Confirm the narrowing to crewmate briefs is intended, or restore a one-clause owner sentence for the firstmate/secondmate path.
- ℹ️ `bin/fm-brief.sh:454` - Ship-brief rule 8 says &#34;While implementing and correcting your own work, group related fixes and run the smallest focused checks...&#34; with no scoping to the pre-validation phase. In no-mistakes mode the same brief later states &#34;Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix&#34; (bin/fm-brief.sh:394), and AGENTS.md:345 treats a worker fixing/committing during an active run as duplicated pipeline ownership. Rule 8&#39;s guard only protects the Definition of done from being narrowed; it does not say when the loop applies, so a worker mid-pipeline could read a prominent numbered rule as sanction to batch its own fixes. The promotion handoff has the same gap. Scoping the clause (e.g. &#34;while implementing, before validation starts&#34;) would close it.
- ℹ️ `AGENTS.md:281` - &#34;Keep independent ready work moving&#34; restates the rule stated in full on the very next line (&#34;dispatch isolated work immediately with no concurrency cap when each change can be independently implemented and validated...&#34;). The only new normative content in the added line is &#34;never dispatch redundant parallel work for the same deliverable,&#34; which could be appended to the existing owner sentence instead of adding a line. Given the intent&#39;s &#34;Keep the always-loaded addition concise&#34; and &#34;patch their owner language rather than appending a parallel policy or duplicating rules already present,&#34; the duplicated clause is worth folding in.

🔧 Fix: Restore owner loop clause and scope pre-validation guidance
2 issues (1 warning, 1 info) still open:
- ⚠️ `.agents/skills/quota-array-dispatch/SKILL.md:92` - Fix round 71bb97d deleted &#34;rather than downgrading it to conserve quota&#34; from selection-order step 3 of the quota-array-dispatch skill. The intent says &#34;Do not change watcher, supervision, dispatch, no-mistakes, ... contracts,&#34; and AGENTS.md:193 names this skill &#34;the single owner of the completion-aware selection procedure&#34; - so this is an edit to a dispatch contract. It is also out of scope for the change: the author&#39;s own commit (44cf86a) never touched this file, and the duplication being removed was pre-existing, not introduced here. The behavior has a dedicated eval case named for it (tests/fm-quota-array-dispatch-live-e2e.test.sh:103, &#34;required strongest reasoning class is not downgraded for quota&#34;), and docs/verification/dispatch-auth.md:178 lists &#34;the strongest-reasoning constraint&#34; as covered regression surface; removing the only clause in the step that names the quota motive weakens the signal that case exercises. Mitigating: the prohibition is still implied by SKILL.md:89 (&#34;Never use headroom, runway, pace, or reserve to silently replace that reasoning class&#34;), step 3&#39;s first sentence, and AGENTS.md:190. Either restore the clause or confirm the dispatch-contract edit is intended.
- ℹ️ `AGENTS.md:264` - The restored owner clause opens &#34;When firstmate or a secondmate implements or corrects work directly, ...&#34; without naming the narrow authority that makes that premise legal. Every other place in this file that contemplates firstmate touching code anchors it explicitly - AGENTS.md:54, :88, and :221 all say &#34;hard rule 1&#39;s concrete captain-approved project operation exception,&#34; and AGENTS.md:40 scopes the other case to &#34;when the fleet is empty, firstmate may change [shared tracked material] directly.&#34; AGENTS.md:16-17 and hard rule 1 (&#34;Never write to a project&#34;) are the top-priority rules of the document. A conditional clause is not an authority grant, so this is not a contradiction, but in an always-loaded rule file read by an agent it normalizes the premise without the guardrail the rest of the file consistently attaches. Anchoring it (e.g. &#34;When firstmate or a secondmate implements or corrects work directly under section 1&#39;s exceptions, ...&#34;) costs a few words and matches the established convention.

🔧 Fix: Restore dispatch clause and anchor direct-work loop guidance
2 infos still open:
- ℹ️ `AGENTS.md:190` - The intent requires token savings &#34;not by lowering the task-appropriate model or effort solely to conserve quota&#34; as an unconditional rule. The author&#39;s commit 44cf86a wrote it that way (&#34;Choose the task-appropriate model and effort from the accepted work and dispatch evidence; never lower either solely to conserve tokens or quota&#34;), but the pipeline&#39;s consolidation commit 5bd2921 deleted that sentence and folded its content into the pre-existing tight-candidate sentence, which is guarded by &#34;When every candidate is tight&#34;. As a result the concrete model/effort anti-downgrade rule now only fires inside a tight quota-array selection; an ordinary dispatch that picks a cheaper model or lower effort while quota is plentiful is no longer covered by section 4 language. AGENTS.md:194 selects effort by task nature but never forbids a token-motivated downgrade, and AGENTS.md:262&#39;s &#34;never by weakening ... necessary reasoning&#34; is the only remaining general coverage. Confirm the tight-candidate scoping is intended, or restore the unconditional phrasing (e.g. drop the tight-case guard from the model/effort half, or name model and effort in AGENTS.md:262).
- ℹ️ `bin/fm-brief.sh:454` - Rule 8 is emitted into the shared ship-brief rules block, so it reaches all three delivery modes, but its scoping term &#34;Before validation starts&#34; only has a referent in no-mistakes mode. The direct-PR Definition of done (bin/fm-brief.sh:364) says &#34;Do NOT run /no-mistakes&#34; and the local-only one (bin/fm-brief.sh:373) says &#34;no remote, no PR, no pipeline&#34;, and neither block uses the word validation - so for those workers the condition never becomes false and the clause reads as standing guidance right through their final pre-push checks. bin/fm-promote.sh:89 carries the same phrasing (&#34;apply only before validation starts&#34;) into a hint whose --mode may be direct-PR or local-only. Mitigating: the clause is an ordering rule that presumes &#34;rerunning broader suites&#34;, and the second sentence still protects the Definition of done, so nothing is authorized to be skipped. Consider a mode-neutral phrasing (e.g. &#34;while implementing, before you hand the change to this mode&#39;s final checks&#34;) or omitting rule 8 from the non-pipeline modes.

🔧 Fix: Restore unconditional model/effort rule, make loop boundary mode-neutral
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-doc-audience-check.sh` (ok surfaces=65 local_links=214)</code>
- `bin/fm-test-run.sh tests/fm-brief.test.sh tests/fm-task-delivery.test.sh tests/fm-documentation-audiences.test.sh`
- <code>`bin/fm-test-run.sh tests/fm-ask-user-authority.test.sh tests/fm-tangle-guard.test.sh tests/fm-secondmate-safety.test.sh tests/fm-subagent-pretool-check.test.sh` (all remaining consumers of bin/fm-brief.sh and bin/fm-promote.sh)</code>
- <code>Manual: generated real briefs with `FM_HOME=&lt;tmp&gt; bin/fm-brief.sh demo-&lt;mode&gt; some-proj --mode no-mistakes|direct-PR|local-only` and `--scout`, then read the rendered `# Rules` section a crewmate receives</code>
- <code>Manual: `FM_HOME=&lt;tmp&gt; FM_STATE_OVERRIDE=&lt;tmp&gt;/state bin/fm-promote.sh demo-scout --mode no-mistakes --yolo on` end-to-end, inspecting the resulting `.meta` record</code>
- <code>Manual: `bash -n` on the emitted `next:` command, then executed it via `eval` against a stub `bin/fm-send.sh` to confirm the ship instructions arrive as one intact argument (argc=2)</code>
- `Manual: extracted each new AGENTS.md sentence with its enclosing section heading to confirm owner-section placement instead of a parallel policy block`
- <code>`bin/fm-test-run.sh --list --changed --base 833a9a2` to scope the relevant test set</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `AGENTS.md:265` - Duplicate-rule validation over the final diff: AGENTS.md:265 ends the interim grouped-fix ordering at &#34;the delivery path&#39;s required final checks&#34; and AGENTS.md:302 states the delivery path&#39;s own rigor rule enumerating those gates. I judged this a deliberate boundary clause at the intake owner rather than a second copy of the delivery-path contract (each is operative in its own section, and the loop rule is unsafe without its boundary), so I left both. Flagging it as the one near-overlap the diff contains, in case a later consolidation pass wants the boundary reduced to a bare cross-reference to the delivery-path section.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
