### PR TITLE
fix(bin): honor shutdown after remote job worker ownership loss

### DIFF
--- a/bin/fm-remote-job-worker.sh
+++ b/bin/fm-remote-job-worker.sh
@@ -295,8 +295,9 @@ worker_shutdown() {
   trap - HUP INT TERM
   worker_publish_quarantine || {
     worker_error "cannot guard worker ownership for shutdown"
-    trap worker_shutdown HUP INT TERM
-    return 0
+    # Returning would resume service even when the ownership directory is gone.
+    # Exit cleanup still stops active execution before releasing any ownership.
+    exit 125
   }
   worker_stop_active_execution || {
     worker_error "could not stop the active command tree"

--- a/tests/fm-remote-job-orphan-reap.test.sh
+++ b/tests/fm-remote-job-orphan-reap.test.sh
@@ -1,11 +1,19 @@
 #!/usr/bin/env bash
-# Behavior tests for remote job workers abandoned by a pruned code root.
+# Behavior tests for remote job worker teardown: workers abandoned by a pruned
+# code root, and workers whose ownership state was removed underneath them.
 #
 # The leak this pins: a worker launched from a worktree's own bin/ outlives that
 # worktree. Its restart supervisor sits above the serving child, so killing the
 # recorded worker pid only makes the supervisor respawn, and nothing else ever
 # stops it. Observed 2026-08-07 as 29 workers at ppid 1, 1-2 days old, each
 # still appending to a log in a pruned no-mistakes gate worktree.
+#
+# The second leak this pins comes out of the same teardown: removing the state
+# root under a live serving child does not stop it, and its stale-job sweep
+# recreates the state root, jobs, and logs without ever recreating worker.lock.
+# A shutdown signal must still stop that now unowned child, because a swallowed
+# TERM leaves it serving and publishing ready heartbeats that make the account
+# look like it still has a healthy worker.
 #
 # bin/fm-remote-job-reap-orphans.sh is a machine-wide sweep by design, so these
 # cases assert only about their own fixture processes. Any other worker it

--- a/tests/fm-remote-job-orphan-reap.test.sh
+++ b/tests/fm-remote-job-orphan-reap.test.sh
@@ -41,13 +41,15 @@ pgid_of() { ps -p "$1" -o pgid= 2>/dev/null | tr -d '[:space:]'; }
 
 ppid_of() { ps -p "$1" -o ppid= 2>/dev/null | tr -d '[:space:]'; }
 
-inode_of() {
-  if [ "$(uname -s 2>/dev/null || true)" = Darwin ]; then
-    stat -f %i "$1" 2>/dev/null
-  else
-    stat -c %i "$1" 2>/dev/null
-  fi
-}
+# stat's inode selector differs by platform, so resolve it once here rather than
+# paying a uname fork inside anything that watches a file.
+if [ "$(uname -s 2>/dev/null || true)" = Darwin ]; then
+  STAT_INODE=(-f %i)
+else
+  STAT_INODE=(-c %i)
+fi
+
+inode_of() { stat "${STAT_INODE[@]}" "$1" 2>/dev/null; }
 
 # Wait up to <seconds> for <pid> to exit; 0 when it did.
 wait_gone() { # <pid> <seconds>
@@ -64,6 +66,28 @@ wait_child() { # <pid> <seconds>
   local pid=$1 deadline=$(( $(date +%s) + $2 ))
   while [ "$(date +%s)" -lt "$deadline" ]; do
     [ -n "$(pgrep -P "$pid" 2>/dev/null || true)" ] && return 0
+    sleep 0.1
+  done
+  return 1
+}
+
+# A supervisor's genuine serving child - never the sleep it forks for restart
+# backoff, and never a transient subshell of its own state preparation.
+serving_child() { # <supervisor-pid>
+  pgrep -P "$1" -f 'fm-remote-job-worker\.sh --serve' 2>/dev/null | head -n 1
+}
+
+# Wait up to <seconds> for <supervisor> to be serving through a child other than
+# <previous>, and echo it. Retrying against the pid that just died would prove
+# nothing, so the previous one never satisfies this.
+next_serving_child() { # <supervisor-pid> <previous-serving-pid> <seconds>
+  local worker=$1 previous=$2 deadline=$(( $(date +%s) + $3 )) candidate
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    candidate=$(serving_child "$worker")
+    if [ -n "$candidate" ] && [ "$candidate" != "$previous" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
     sleep 0.1
   done
   return 1
@@ -109,8 +133,8 @@ build_remote_root "$CASE1/remote-root"
 WORKER=$(start_worker "$CASE1/remote-root" "$CASE1/account" "$CASE1/remote-jobs") ||
   fail "could not start the fixture remote job worker"
 track "$WORKER"
-wait_child "$WORKER" 10 || fail "the fixture worker never started its serving child"
-SERVE=$(pgrep -P "$WORKER" | head -n 1)
+SERVE=$(next_serving_child "$WORKER" '' 10) ||
+  fail "the fixture worker never started its serving child"
 
 [ "$(pgid_of "$WORKER")" = "$WORKER" ] ||
   fail "the started worker is not its own process group leader, so its tree cannot be signalled as one group"
@@ -127,53 +151,86 @@ pass "the Linux start path puts the whole worker tree in its own process group"
 # after its atomic heartbeat replaces the ready inode. It then cannot execute
 # while the state root is removed, and CONT resumes the real loop immediately
 # before its stale-job sweep recreates the root without the ownership lock.
+#
+# The STOP has only the few milliseconds between that rename and the sweep's
+# re-creation of the state root to land in, so the watcher must not fork: a hard
+# link pins the published inode (which also stops the kernel recycling it into
+# the next heartbeat's temp file), and `[ -ef ]`, `kill` and `SECONDS` are all
+# bash builtins, so the loop polls at syscall speed with no sleep at all. A
+# loaded host can still deschedule the watcher past the window; that attempt
+# proves it missed by the serving child dying on its next heartbeat against the
+# removed state root, and the whole construction is retried against the next
+# genuine serving child the supervisor spawns.
 READY="$CASE1/remote-jobs/worker.ready"
-for _ in $(seq 1 200); do
-  READY_INODE=$(inode_of "$READY" 2>/dev/null || true)
-  [ -n "$READY_INODE" ] && break
-  sleep 0.01
-done
-[ -n "${READY_INODE:-}" ] || fail "the serving child did not publish its initial heartbeat"
-for _ in $(seq 1 1000); do
-  NEXT_READY_INODE=$(inode_of "$READY" 2>/dev/null || true)
-  if [ -n "$NEXT_READY_INODE" ] && [ "$NEXT_READY_INODE" != "$READY_INODE" ]; then
-    kill -STOP "$SERVE" || fail "could not stop the serving child after its heartbeat publication"
-    break
+READY_WITNESS="$CASE1/ready.witness"
+
+stopped() { # <pid>
+  case "$(ps -p "$1" -o state= 2>/dev/null | tr -d '[:space:]')" in T*) return 0 ;; esac
+  return 1
+}
+
+lock_free_state_present() {
+  [ -d "$CASE1/remote-jobs/jobs" ] && [ -d "$CASE1/remote-jobs/logs" ] &&
+    [ ! -e "$CASE1/remote-jobs/worker.lock" ] && [ ! -L "$CASE1/remote-jobs/worker.lock" ] &&
+    [ -f "$READY" ]
+}
+
+# 0 once this attempt has observed both the lock-free state and the TERM
+# outcome; 1 when its STOP landed after the sweep had already recreated the
+# state root, which the serving child proves by dying before recreating it.
+construct_lock_free_serving_child() { # <serving-pid>
+  local serve=$1 deadline ready_inode next_ready_inode
+  deadline=$((SECONDS + 30))
+  while [ ! -f "$READY" ]; do
+    [ "$SECONDS" -lt "$deadline" ] || fail "the serving child did not publish its initial heartbeat"
+    sleep 0.01
+  done
+  rm -f -- "$READY_WITNESS"
+  ln "$READY" "$READY_WITNESS" || fail "could not pin the published heartbeat inode"
+  while [ "$READY" -ef "$READY_WITNESS" ]; do
+    alive "$serve" || fail "the serving child died before replacing its heartbeat inode"
+    [ "$SECONDS" -lt "$deadline" ] ||
+      fail "the serving child did not atomically replace its heartbeat inode"
+  done
+  kill -STOP "$serve" || fail "could not stop the serving child after its heartbeat publication"
+  [ -f "$READY" ] && [ ! "$READY" -ef "$READY_WITNESS" ] ||
+    fail "the serving child did not atomically replace its heartbeat inode"
+  deadline=$((SECONDS + 30))
+  until stopped "$serve"; do
+    [ "$SECONDS" -lt "$deadline" ] || fail "the serving child was not stopped before state removal"
+    sleep 0.01
+  done
+  rm -rf "$CASE1/remote-jobs"
+  assert_absent "$CASE1/remote-jobs" "the serving child mutated state while stopped"
+  kill -CONT "$serve" || fail "could not resume the serving child after state removal"
+  deadline=$((SECONDS + 30))
+  until lock_free_state_present; do
+    alive "$serve" || return 1
+    [ "$SECONDS" -lt "$deadline" ] ||
+      fail "the stale-job sweep did not recreate state without the ownership lock"
+    sleep 0.01
+  done
+  ready_inode=$(inode_of "$READY") || fail "the recreated heartbeat has no inode"
+  kill -TERM "$serve" || fail "could not TERM the lock-free serving child"
+  if ! wait_gone "$serve" 6; then
+    next_ready_inode=$(inode_of "$READY" 2>/dev/null || true)
+    fail "the lock-free serving child survived TERM and advanced heartbeat $ready_inode->$next_ready_inode"
   fi
-  sleep 0.001
+}
+
+ATTEMPT=1
+until construct_lock_free_serving_child "$SERVE"; do
+  ATTEMPT=$((ATTEMPT + 1))
+  [ "$ATTEMPT" -le 8 ] ||
+    fail "the STOP never landed between the heartbeat and the stale-job sweep in $((ATTEMPT - 1)) attempts"
+  alive "$WORKER" ||
+    fail "the fixture supervisor stopped before the construction could be retried"
+  SERVE=$(next_serving_child "$WORKER" "$SERVE" 30) ||
+    fail "the supervisor did not respawn a serving child to retry the construction against"
 done
-[ -n "${NEXT_READY_INODE:-}" ] && [ "$NEXT_READY_INODE" != "$READY_INODE" ] \
-  || fail "the serving child did not atomically replace its heartbeat inode"
-for _ in $(seq 1 200); do
-  case "$(ps -p "$SERVE" -o state= 2>/dev/null | tr -d '[:space:]')" in T*) break ;; esac
-  sleep 0.01
-done
-case "$(ps -p "$SERVE" -o state= 2>/dev/null | tr -d '[:space:]')" in
-  T*) ;;
-  *) fail "the serving child was not stopped before state removal" ;;
-esac
-rm -rf "$CASE1/remote-jobs"
-assert_absent "$CASE1/remote-jobs" "the serving child mutated state while stopped"
-kill -CONT "$SERVE" || fail "could not resume the serving child after state removal"
-for _ in $(seq 1 1000); do
-  if [ -d "$CASE1/remote-jobs/jobs" ] && [ -d "$CASE1/remote-jobs/logs" ] &&
-    [ ! -e "$CASE1/remote-jobs/worker.lock" ] && [ -f "$READY" ]; then
-    break
-  fi
-  alive "$SERVE" || fail "the serving child exited before recreating the lock-free state"
-  sleep 0.01
-done
-[ -d "$CASE1/remote-jobs/jobs" ] && [ -d "$CASE1/remote-jobs/logs" ] &&
-  [ ! -e "$CASE1/remote-jobs/worker.lock" ] && [ -f "$READY" ] \
-  || fail "the stale-job sweep did not recreate state without the ownership lock"
-READY_INODE=$(inode_of "$READY") || fail "the recreated heartbeat has no inode"
-kill -TERM "$SERVE" || fail "could not TERM the lock-free serving child"
-if ! wait_gone "$SERVE" 6; then
-  NEXT_READY_INODE=$(inode_of "$READY" 2>/dev/null || true)
-  fail "the lock-free serving child survived TERM and advanced heartbeat $READY_INODE->$NEXT_READY_INODE"
-fi
 alive "$WORKER" || fail "the fixture supervisor did not survive a lone child kill, so this case no longer covers the leak"
-wait_child "$WORKER" 15 || fail "the supervisor did not respawn after its recorded child pid was killed"
+SERVE=$(next_serving_child "$WORKER" "$SERVE" 15) ||
+  fail "the supervisor did not respawn after its recorded child pid was killed"
 pass "a serving child honors TERM after its state root is recreated without the ownership lock"
 
 # A worker whose code root is intact is never a reap candidate, which is what
@@ -184,7 +241,8 @@ alive "$WORKER" || fail "the reaper stopped a worker whose code root still exist
 pass "a worker whose code root still exists is never reaped"
 
 # Prune the code root the way a returned worktree does.
-SURVIVOR=$(pgrep -P "$WORKER" | head -n 1)
+SURVIVOR=$(serving_child "$WORKER")
+[ -n "$SURVIVOR" ] || fail "the worker had no serving child left to outlive its pruned code root"
 rm -rf "$CASE1/remote-root"
 wait_gone "$WORKER" 60 || fail "the worker survived its code root being pruned"
 wait_gone "$SURVIVOR" 60 || fail "a serving child outlived the abandoned supervisor"

--- a/tests/fm-remote-job-orphan-reap.test.sh
+++ b/tests/fm-remote-job-orphan-reap.test.sh
@@ -41,6 +41,14 @@ pgid_of() { ps -p "$1" -o pgid= 2>/dev/null | tr -d '[:space:]'; }
 
 ppid_of() { ps -p "$1" -o ppid= 2>/dev/null | tr -d '[:space:]'; }
 
+inode_of() {
+  if [ "$(uname -s 2>/dev/null || true)" = Darwin ]; then
+    stat -f %i "$1" 2>/dev/null
+  else
+    stat -c %i "$1" 2>/dev/null
+  fi
+}
+
 # Wait up to <seconds> for <pid> to exit; 0 when it did.
 wait_gone() { # <pid> <seconds>
   local pid=$1 deadline=$(( $(date +%s) + $2 ))
@@ -115,14 +123,58 @@ pass "the Linux start path puts the whole worker tree in its own process group"
 
 # The exact teardown shape that leaked in production: a fixture cleanup removes
 # the worker's state root and then TERMs the single recorded worker pid - which
-# is the serving child, not the supervisor. The supervisor respawns, so the tree
-# survives a teardown that looks complete.
+# is the serving child, not the supervisor. Stop the serving child immediately
+# after its atomic heartbeat replaces the ready inode. It then cannot execute
+# while the state root is removed, and CONT resumes the real loop immediately
+# before its stale-job sweep recreates the root without the ownership lock.
+READY="$CASE1/remote-jobs/worker.ready"
+for _ in $(seq 1 200); do
+  READY_INODE=$(inode_of "$READY" 2>/dev/null || true)
+  [ -n "$READY_INODE" ] && break
+  sleep 0.01
+done
+[ -n "${READY_INODE:-}" ] || fail "the serving child did not publish its initial heartbeat"
+for _ in $(seq 1 1000); do
+  NEXT_READY_INODE=$(inode_of "$READY" 2>/dev/null || true)
+  if [ -n "$NEXT_READY_INODE" ] && [ "$NEXT_READY_INODE" != "$READY_INODE" ]; then
+    kill -STOP "$SERVE" || fail "could not stop the serving child after its heartbeat publication"
+    break
+  fi
+  sleep 0.001
+done
+[ -n "${NEXT_READY_INODE:-}" ] && [ "$NEXT_READY_INODE" != "$READY_INODE" ] \
+  || fail "the serving child did not atomically replace its heartbeat inode"
+for _ in $(seq 1 200); do
+  case "$(ps -p "$SERVE" -o state= 2>/dev/null | tr -d '[:space:]')" in T*) break ;; esac
+  sleep 0.01
+done
+case "$(ps -p "$SERVE" -o state= 2>/dev/null | tr -d '[:space:]')" in
+  T*) ;;
+  *) fail "the serving child was not stopped before state removal" ;;
+esac
 rm -rf "$CASE1/remote-jobs"
-kill -TERM "$SERVE" 2>/dev/null || true
-wait_gone "$SERVE" 10 || fail "the serving child ignored TERM"
+assert_absent "$CASE1/remote-jobs" "the serving child mutated state while stopped"
+kill -CONT "$SERVE" || fail "could not resume the serving child after state removal"
+for _ in $(seq 1 1000); do
+  if [ -d "$CASE1/remote-jobs/jobs" ] && [ -d "$CASE1/remote-jobs/logs" ] &&
+    [ ! -e "$CASE1/remote-jobs/worker.lock" ] && [ -f "$READY" ]; then
+    break
+  fi
+  alive "$SERVE" || fail "the serving child exited before recreating the lock-free state"
+  sleep 0.01
+done
+[ -d "$CASE1/remote-jobs/jobs" ] && [ -d "$CASE1/remote-jobs/logs" ] &&
+  [ ! -e "$CASE1/remote-jobs/worker.lock" ] && [ -f "$READY" ] \
+  || fail "the stale-job sweep did not recreate state without the ownership lock"
+READY_INODE=$(inode_of "$READY") || fail "the recreated heartbeat has no inode"
+kill -TERM "$SERVE" || fail "could not TERM the lock-free serving child"
+if ! wait_gone "$SERVE" 6; then
+  NEXT_READY_INODE=$(inode_of "$READY" 2>/dev/null || true)
+  fail "the lock-free serving child survived TERM and advanced heartbeat $READY_INODE->$NEXT_READY_INODE"
+fi
 alive "$WORKER" || fail "the fixture supervisor did not survive a lone child kill, so this case no longer covers the leak"
 wait_child "$WORKER" 15 || fail "the supervisor did not respawn after its recorded child pid was killed"
-pass "removing the state root and killing the recorded worker pid leaves the tree running at ppid 1"
+pass "a serving child honors TERM after its state root is recreated without the ownership lock"
 
 # A worker whose code root is intact is never a reap candidate, which is what
 # keeps the account's healthy LaunchAgent worker out of scope.


### PR DESCRIPTION
## Intent

Fix the pre-existing remote job worker ownership-loss shutdown defect as its own focused change and pull request, separate from unrelated PR 1716. The worker's stale-job sweep can recreate the state root, jobs, and logs without worker.lock; quarantine publication then has no ownership directory, and TERM must not be swallowed so the same unowned serving worker continues publishing ready heartbeats. Choose the safe ownership or shutdown behavior from the existing code rather than guessing, keep the product change small, and preserve existing active-execution cleanup. The regression must first fail against the unfixed product and then pass with the fix, and must deterministically construct the state by watching the atomic heartbeat inode replacement, immediately sending STOP, removing the state root while stopped, sending CONT so the stale-job sweep recreates lock-free state, then sending TERM and observing the serving process. Do not replace that synchronization with timing luck or weaken the regression. Publish this branch with one upstream push and one pull request body publication because each extra push or body edit spends another approval round-trip.

## What Changed

- `worker_shutdown` no longer swallows the signal when `worker_publish_quarantine` fails. Previously it re-armed the `HUP INT TERM` trap and returned 0, so a worker whose ownership directory was gone resumed serving and kept publishing ready heartbeats; it now exits 125, and because the EXIT cleanup trap is registered before the shutdown trap, active-execution cleanup still stops the command tree first.
- Rewrote the teardown case in `tests/fm-remote-job-orphan-reap.test.sh` to construct the unowned state deterministically instead of by timing: a hard link pins the published `worker.ready` inode, a fork-free builtin-only loop watches for the atomic replacement and STOPs the serving child in that window, the state root is removed while it is stopped, CONT lets the stale-job sweep recreate `jobs`/`logs`/`worker.ready` without `worker.lock`, and TERM must then kill the child rather than let it advance the heartbeat. If a loaded host deschedules the watcher past the window, the child dies on its next heartbeat and the whole construction retries (bounded at 8) against the next serving child the supervisor spawns.
- Added test helpers behind that: `serving_child`/`next_serving_child` match on `fm-remote-job-worker.sh --serve` so a supervisor's restart-backoff `sleep` or a transient state-preparation subshell is never mistaken for the serving child, and `inode_of` resolves the platform-specific `stat` selector once at startup instead of forking `uname` on every poll. The file header now documents this second leak alongside the pruned-code-root one.

## Risk Assessment

✅ Low: The round-2 commit is test-only and well-bounded: it replaces the racy fork-based watcher with a fork-free hard-link/`-ef` loop plus a retry that can only trigger on a proven miss, preserving every assertion and the fail-against-unfixed-product property, while the reviewed three-line product fix is unchanged.

## Testing

I confirmed the regression is a real first-fail/then-pass one by reverting only the product hunk to base 833a9a2 - the test then fails deterministically with the serving child surviving TERM and advancing its heartbeat inode - and restoring the fix, after which it passes 5/5 and also 3/3 under 2x CPU oversubscription, so the STOP-in-the-heartbeat-window construction and its retry are not relying on timing luck. Because a passing assertion does not show what an operator sees, I drove the real worker through the same construction and captured `ps` and heartbeat state on both sides: before the fix the TERMed pid stays in `ps` with no worker.lock and its heartbeat inode keeps advancing, after the fix that pid is gone and the supervisor's replacement holds genuine ownership with worker.lock/pid and worker.ready naming the new pid. I separately exercised the changed exit-125 path with a real in-flight job to check the intent's preserve-active-execution-cleanup constraint: on the fix the recorded command group is killed and its side effect never lands, while on the base the worker ignores TERM and the job runs to completion and mutates. tests/fm-remote-job.test.sh passes in full, covering the unchanged shutdown and quarantine paths. No product failures; the only note is pre-existing gpg-signing noise in the fixture's git commit that does not affect any assertion. Transient scratch roots and worker processes were cleaned up and the worktree is clean.

<details>
<summary>Evidence: Operator transcript - BEFORE the fix: unowned worker swallows TERM and keeps publishing ready heartbeats</summary>

<code>--- the worker&#39;s own state root, recreated by its stale-job sweep -------&#10;$ ls -la .../remote-jobs&#10;drwx------ jobs&#10;drwx------ logs&#10;-rw------- worker.ready&#10;&#10;worker.lock (the ownership directory) is absent:&#10;ls: .../remote-jobs/worker.lock: No such file or directory&#10;&#10;--- the serving process before TERM ------------------------------------&#10;$ ps -o pid,ppid,state,command -p 12346&#10;PID PPID STAT COMMAND&#10;12346 12299 S /bin/bash .../bin/fm-remote-job-worker.sh --serve&#10;&#10;published heartbeat: inode 194257032 contents: 12346&#10;&#10;--- operator sends TERM to the unowned serving worker -------------------&#10;$ kill -TERM 12346&#10;&#10;--- six seconds later --------------------------------------------------&#10;RESULT: the process is STILL RUNNING and still owns no lock.&#10;PID PPID STAT COMMAND&#10;12346 12299 S /bin/bash .../bin/fm-remote-job-worker.sh --serve&#10;&#10;heartbeat inode 194257032 -&gt; 194257110&#10;it is STILL PUBLISHING ready heartbeats: the fleet believes an&#10;unowned worker is healthy and will hand it jobs.&#10;&#10;VERDICT: DEFECT REPRODUCED - TERM was swallowed.</code>

```text
==============================================================
worker under test: BEFORE the fix (base commit 833a9a2)
==============================================================

--- the worker's own state root, recreated by its stale-job sweep -------
$ ls -la /private/tmp/repro-worker2.enyDG9/before/remote-jobs
    total 8
    drwx------@ 5 tiago  wheel  160 Aug  8 21:28 .
    drwxr-xr-x@ 6 tiago  wheel  192 Aug  8 21:28 ..
    drwx------@ 2 tiago  wheel   64 Aug  8 21:28 jobs
    drwx------@ 2 tiago  wheel   64 Aug  8 21:28 logs
    -rw-------@ 1 tiago  wheel    6 Aug  8 21:28 worker.ready

    worker.lock (the ownership directory) is absent:
    $ ls -d /private/tmp/repro-worker2.enyDG9/before/remote-jobs/worker.lock
    ls: /private/tmp/repro-worker2.enyDG9/before/remote-jobs/worker.lock: No such file or directory

--- the serving process before TERM ------------------------------------
$ ps -o pid,ppid,state,command -p 12346
      PID  PPID STAT COMMAND
    12346 12299 S    /bin/bash /private/tmp/repro-worker2.enyDG9/before/remote-root/bin/fm-remote-job-worker.sh --serve

    published heartbeat: inode 194257032  contents: 12346

--- operator sends TERM to the unowned serving worker -------------------
$ kill -TERM 12346

--- six seconds later --------------------------------------------------
    RESULT: the process is STILL RUNNING and still owns no lock.
$ ps -o pid,ppid,state,command -p 12346
      PID  PPID STAT COMMAND
    12346 12299 S    /bin/bash /private/tmp/repro-worker2.enyDG9/before/remote-root/bin/fm-remote-job-worker.sh --serve

    heartbeat inode 194257032 -> 194257110
    it is STILL PUBLISHING ready heartbeats: the fleet believes an
    unowned worker is healthy and will hand it jobs.

    VERDICT: DEFECT REPRODUCED - TERM was swallowed.
```
</details>
<details>
<summary>Evidence: Operator transcript - AFTER the fix: unowned worker honors TERM, replacement reacquires real ownership</summary>

<code>--- the serving process before TERM ------------------------------------&#10;$ ps -o pid,ppid,state,command -p 63757&#10;PID PPID STAT COMMAND&#10;63757 63324 R /bin/bash .../bin/fm-remote-job-worker.sh --serve&#10;&#10;published heartbeat: inode 194234270 contents: 63757&#10;&#10;--- operator sends TERM to the unowned serving worker -------------------&#10;$ kill -TERM 63757&#10;&#10;--- six seconds later --------------------------------------------------&#10;RESULT: the process is GONE.&#10;$ ps -o pid,ppid,state,command -p 63757&#10;PID PPID STAT COMMAND&#10;&#10;VERDICT: FIXED - the unowned worker honored TERM and stopped serving.&#10;&#10;--- what the supervisor put in its place --------------------------------&#10;$ ps -o pid,ppid,state,command -p 66573&#10;PID PPID STAT COMMAND&#10;66573 63324 S /bin/bash .../bin/fm-remote-job-worker.sh --serve&#10;&#10;$ ls -la .../remote-jobs&#10;drwx------ jobs&#10;drwx------ logs&#10;-rw------- worker.identity&#10;drwx------ worker.lock&#10;-rw------- worker.pid&#10;-rw------- worker.ready&#10;&#10;ownership is genuine again - worker.lock/pid says 66573&#10;heartbeat says 66573, and the TERMed pid 63757 is not either of them.</code>

```text
==============================================================
worker under test: AFTER the fix (e9f378b)
==============================================================

--- the worker's own state root, recreated by its stale-job sweep -------
$ ls -la /private/tmp/repro-worker2.enyDG9/after/remote-jobs
    total 8
    drwx------@ 5 tiago  wheel  160 Aug  8 21:26 .
    drwxr-xr-x@ 6 tiago  wheel  192 Aug  8 21:26 ..
    drwx------@ 2 tiago  wheel   64 Aug  8 21:26 jobs
    drwx------@ 2 tiago  wheel   64 Aug  8 21:26 logs
    -rw-------@ 1 tiago  wheel    6 Aug  8 21:26 worker.ready

    worker.lock (the ownership directory) is absent:
    $ ls -d /private/tmp/repro-worker2.enyDG9/after/remote-jobs/worker.lock
    ls: /private/tmp/repro-worker2.enyDG9/after/remote-jobs/worker.lock: No such file or directory

--- the serving process before TERM ------------------------------------
$ ps -o pid,ppid,state,command -p 63757
      PID  PPID STAT COMMAND
    63757 63324 R    /bin/bash /private/tmp/repro-worker2.enyDG9/after/remote-root/bin/fm-remote-job-worker.sh --serve

    published heartbeat: inode 194234270  contents: 63757

--- operator sends TERM to the unowned serving worker -------------------
$ kill -TERM 63757

--- six seconds later --------------------------------------------------
    RESULT: the process is GONE.
$ ps -o pid,ppid,state,command -p 63757
      PID  PPID STAT COMMAND

    VERDICT: FIXED - the unowned worker honored TERM and stopped serving.

--- what the supervisor put in its place --------------------------------
$ ps -o pid,ppid,state,command -p 66573
      PID  PPID STAT COMMAND
    66573 63324 S    /bin/bash /private/tmp/repro-worker2.enyDG9/after/remote-root/bin/fm-remote-job-worker.sh --serve

$ ls -la /private/tmp/repro-worker2.enyDG9/after/remote-jobs
    total 24
    drwx------@ 8 tiago  wheel  256 Aug  8 21:27 .
    drwxr-xr-x@ 6 tiago  wheel  192 Aug  8 21:26 ..
    drwx------@ 2 tiago  wheel   64 Aug  8 21:26 jobs
    drwx------@ 2 tiago  wheel   64 Aug  8 21:26 logs
    -rw-------@ 1 tiago  wheel  123 Aug  8 21:27 worker.identity
    drwx------@ 5 tiago  wheel  160 Aug  8 21:27 worker.lock
    -rw-------@ 1 tiago  wheel    6 Aug  8 21:27 worker.pid
    -rw-------@ 1 tiago  wheel    6 Aug  8 21:27 worker.ready

    ownership is genuine again - worker.lock/pid says 66573
    heartbeat says 66573, and the TERMed pid 63757 is not either of them.
```
</details>
<details>
<summary>Evidence: Active-execution cleanup on the changed exit-125 path - AFTER the fix (mid-flight job stopped, no side effect)</summary>

<code>--- a real job is mid-flight on an owned worker -------------------------&#10;PID PPID PGID STAT COMMAND&#10;2963 2647 2647 S .../fm-remote-job-worker.sh --serve&#10;4291 2963 4291 S .../fm-shutdown-job.sh .../job-started .../job-side-effect&#10;&#10;job job-pjUJVn state: running&#10;its command tree is recorded at jobs/job-pjUJVn/.claim/group = 4291&#10;&#10;--- remove the ownership directory, so shutdown cannot quarantine -------&#10;$ rm -rf .../remote-jobs/worker.lock&#10;&#10;--- TERM the serving worker --------------------------------------------&#10;$ kill -TERM 2963&#10;the serving worker honored TERM and exited.&#10;&#10;--- did exit cleanup still stop the active command tree? ----------------&#10;$ ps -o pid,ppid,pgid,state,command -p 4291&#10;PID PPID PGID STAT COMMAND&#10;&#10;the recorded command tree and the job command itself are both gone.&#10;waiting past the job&#39;s own sleep to prove it never completed its work...&#10;$ ls .../job-side-effect&#10;ls: .../job-side-effect: No such file or directory&#10;&#10;VERDICT: active execution cleanup PRESERVED - the mid-flight command&#10;tree was stopped and never mutated anything after shutdown.</code>

```text
==============================================================
worker under test: AFTER the fix (e9f378b)
==============================================================

--- a real job is mid-flight on an owned worker -------------------------
$ ps -o pid,ppid,pgid,state,command -p 2963 -p 4291 -p 4291
      PID  PPID  PGID STAT COMMAND
     2963  2647  2647 S    /bin/bash /private/tmp/repro-active2.aucAKp/after/remote-root/bin/fm-remote-job-worker.sh --serve
     4291  2963  4291 S    /bin/bash /private/tmp/repro-active2.aucAKp/after/remote-root/bin/fm-shutdown-job.sh /private/tmp/repro-active2.aucAKp/after/job-started /private/tmp/repro-active2.aucAKp/after/job-side-effect

    job job-pjUJVn state: running
    its command tree is recorded at jobs/job-pjUJVn/.claim/group = 4291

--- remove the ownership directory, so shutdown cannot quarantine -------
$ rm -rf /private/tmp/repro-active2.aucAKp/after/remote-jobs/worker.lock
    total 24
    drwx------@ 7 tiago  wheel  224 Aug  8 21:32 .
    drwxr-xr-x@ 7 tiago  wheel  224 Aug  8 21:32 ..
    drwx------@ 3 tiago  wheel   96 Aug  8 21:32 jobs
    drwx------@ 3 tiago  wheel   96 Aug  8 21:32 logs
    -rw-------@ 1 tiago  wheel  123 Aug  8 21:32 worker.identity
    -rw-------@ 1 tiago  wheel    5 Aug  8 21:32 worker.pid
    -rw-------@ 1 tiago  wheel    5 Aug  8 21:32 worker.ready

--- TERM the serving worker --------------------------------------------
$ kill -TERM 2963

    the serving worker honored TERM and exited.

--- did exit cleanup still stop the active command tree? ----------------
$ ps -o pid,ppid,pgid,state,command -p 4291 -p 4291
      PID  PPID  PGID STAT COMMAND


    the recorded command tree and the job command itself are both gone.
    waiting past the job's own sleep to prove it never completed its work...
$ ls /private/tmp/repro-active2.aucAKp/after/job-side-effect
    ls: /private/tmp/repro-active2.aucAKp/after/job-side-effect: No such file or directory

    VERDICT: active execution cleanup PRESERVED - the mid-flight command
    tree was stopped and never mutated anything after shutdown.
```
</details>
<details>
<summary>Evidence: Active-execution cleanup - BEFORE the fix (worker ignores TERM, job runs on and mutates)</summary>

<code>--- TERM the serving worker --------------------------------------------&#10;$ kill -TERM 18787&#10;&#10;the serving worker IGNORED TERM and is still running:&#10;PID PPID STAT COMMAND&#10;18787 18701 S /bin/bash .../fm-remote-job-worker.sh --serve&#10;&#10;--- did exit cleanup still stop the active command tree? ----------------&#10;VERDICT: the job still produced its side effect at .../job-side-effect - cleanup failed.</code>

```text
==============================================================
worker under test: BEFORE the fix (base commit 833a9a2)
==============================================================

--- a real job is mid-flight on an owned worker -------------------------
$ ps -o pid,ppid,pgid,state,command -p 18787 -p 19303 -p 19303
      PID  PPID  PGID STAT COMMAND
    18787 18701 18701 S    /bin/bash /private/tmp/repro-active2.aucAKp/before/remote-root/bin/fm-remote-job-worker.sh --serve
    19303 18787 19303 S    /bin/bash /private/tmp/repro-active2.aucAKp/before/remote-root/bin/fm-shutdown-job.sh /private/tmp/repro-active2.aucAKp/before/job-started /private/tmp/repro-active2.aucAKp/before/job-side-effect

    job job-M7DAzC state: running
    its command tree is recorded at jobs/job-M7DAzC/.claim/group = 19303

--- remove the ownership directory, so shutdown cannot quarantine -------
$ rm -rf /private/tmp/repro-active2.aucAKp/before/remote-jobs/worker.lock
    total 24
    drwx------@ 7 tiago  wheel  224 Aug  8 21:33 .
    drwxr-xr-x@ 7 tiago  wheel  224 Aug  8 21:33 ..
    drwx------@ 3 tiago  wheel   96 Aug  8 21:33 jobs
    drwx------@ 3 tiago  wheel   96 Aug  8 21:33 logs
    -rw-------@ 1 tiago  wheel  123 Aug  8 21:33 worker.identity
    -rw-------@ 1 tiago  wheel    6 Aug  8 21:33 worker.pid
    -rw-------@ 1 tiago  wheel    6 Aug  8 21:33 worker.ready

--- TERM the serving worker --------------------------------------------
$ kill -TERM 18787

    the serving worker IGNORED TERM and is still running:
      PID  PPID STAT COMMAND
    18787 18701 S    /bin/bash /private/tmp/repro-active2.aucAKp/before/remote-root/bin/fm-remote-job-worker.sh --serve

--- did exit cleanup still stop the active command tree? ----------------
$ ps -o pid,ppid,pgid,state,command -p 19303 -p 19303
      PID  PPID  PGID STAT COMMAND


    the recorded command tree and the job command itself are both gone.
    waiting past the job's own sleep to prove it never completed its work...
    VERDICT: the job still produced its side effect at /private/tmp/repro-active2.aucAKp/before/job-side-effect - cleanup failed.
```
</details>
<details>
<summary>Evidence: First-fail proof: regression against the unfixed worker (product hunk reverted to base 833a9a2)</summary>

```text
$ bash tests/fm-remote-job-orphan-reap.test.sh; echo "exit=$?"
exit=1

ok - the Linux start path puts the whole worker tree in its own process group
not ok - the lock-free serving child survived TERM and advanced heartbeat 194129551->194133103

(4 runs, identical failure each time; with the fix restored, 5/5 runs exit 0 and report
"ok - a serving child honors TERM after its state root is recreated without the ownership lock")
```
</details>
<details>
<summary>Evidence: Repro harness: unowned-worker TERM construction (heartbeat-inode watch -&gt; STOP -&gt; state removal -&gt; CONT -&gt; TERM)</summary>

```text
#!/usr/bin/env bash
# Manual end-to-end reproduction of the remote job worker ownership-loss
# shutdown defect, run against one worker binary and printed as an operator
# would observe it: `ps` for the serving process and the published heartbeat
# it keeps advancing.
#
# usage: repro-unowned-worker-term.sh <repo-root> <worker-script> <label> <scratch-dir>
set -u

ROOT=$1
WORKER_SRC=$2
LABEL=$3
# The worker refuses a non-physical account home, and /tmp is a symlink on
# macOS, so resolve the scratch root the way the real test fixture does.
mkdir -p "$4"
SCRATCH=$(cd "$4" && pwd -P)

STATE="$SCRATCH/remote-jobs"
ACCOUNT="$SCRATCH/account"
CODE="$SCRATCH/remote-root"
READY="$STATE/worker.ready"
WITNESS="$SCRATCH/ready.witness"

case "$(uname -s)" in Darwin) STAT_INODE=(-f %i) ;; *) STAT_INODE=(-c %i) ;; esac
inode_of() { stat "${STAT_INODE[@]}" "$1" 2>/dev/null; }
alive() { kill -0 "$1" 2>/dev/null; }
stopped() { case "$(ps -p "$1" -o state= 2>/dev/null | tr -d '[:space:]')" in T*) return 0 ;; esac; return 1; }
serving_child() { pgrep -P "$1" -f 'fm-remote-job-worker\.sh --serve' 2>/dev/null | head -n 1; }
say() { printf '%s\n' "$*"; }

cleanup() {
  [ -n "${SUPERVISOR:-}" ] && { kill -KILL -- "-$SUPERVISOR" 2>/dev/null; kill -KILL "$SUPERVISOR" 2>/dev/null; }
  return 0
}
trap cleanup EXIT

mkdir -p "$ACCOUNT" "$CODE/bin"
cp "$ROOT/bin/fm-remote-job-lib.sh" "$CODE/bin/"
cp "$WORKER_SRC" "$CODE/bin/fm-remote-job-worker.sh"
chmod +x "$CODE/bin"/*.sh
printf 'fixture\n' > "$CODE/AGENTS.md"
git -C "$CODE" init -q -b main
git -C "$CODE" config user.email test@example.com
git -C "$CODE" config user.name Test
git -C "$CODE" config commit.gpgsign false
git -C "$CODE" add AGENTS.md bin
git -C "$CODE" commit -qm 'remote job fixture'

SUPERVISOR=$(
  export FM_REMOTE_JOB_STATE_ROOT="$STATE"
  export FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux
  export FM_REMOTE_JOB_ORPHAN_GRACE_SECONDS=1
  . "$ROOT/bin/fm-remote-job-lib.sh"
  fm_remote_job_start_linux_worker "$CODE" "$ACCOUNT" >/dev/null 2>&1 || exit 1
  pgrep -f "^/bin/bash $CODE/bin/fm-remote-job-worker.sh\$" | head -n 1
) || { say "FATAL: could not start the fixture worker"; exit 1; }

say "=============================================================="
say "worker under test: $LABEL"
say "=============================================================="
say ""

# Build the unowned-but-serving state: STOP the serving child the instant its
# atomic heartbeat replaces the published inode, remove the state root while it
# cannot run, CONT so its stale-job sweep recreates jobs/ logs/ and the
# heartbeat without ever recreating worker.lock.
attempt=0
while :; do
  attempt=$((attempt + 1))
  [ "$attempt" -le 8 ] || { say "FATAL: STOP never landed in the heartbeat window"; exit 1; }
  SERVE=$(serving_child "$SUPERVISOR")
  [ -n "$SERVE" ] || { sleep 0.2; attempt=$((attempt - 1)); continue; }

  deadline=$((SECONDS + 30))
  while [ ! -f "$READY" ]; do
    [ "$SECONDS" -lt "$deadline" ] || { say "FATAL: no initial heartbeat"; exit 1; }
    sleep 0.01
  done
  rm -f -- "$WITNESS"; ln "$READY" "$WITNESS" || exit 1
  while [ "$READY" -ef "$WITNESS" ]; do
    alive "$SERVE" || break
    [ "$SECONDS" -lt "$deadline" ] || { say "FATAL: heartbeat never replaced"; exit 1; }
  done
  kill -STOP "$SERVE" 2>/dev/null || continue
  until stopped "$SERVE"; do
    alive "$SERVE" || break
    [ "$SECONDS" -lt "$deadline" ] || break
    sleep 0.01
  done
  alive "$SERVE" || { kill -CONT "$SERVE" 2>/dev/null; sleep 0.5; continue; }

  rm -rf "$STATE"
  kill -CONT "$SERVE" 2>/dev/null || continue

  deadline=$((SECONDS + 30))
  recreated=0
  while [ "$SECONDS" -lt "$deadline" ]; do
    if [ -d "$STATE/jobs" ] && [ -d "$STATE/logs" ] && [ ! -e "$STATE/worker.lock" ] && [ -f "$READY" ]; then
      recreated=1; break
    fi
    alive "$SERVE" || break
    sleep 0.01
  done
  [ "$recreated" -eq 1 ] && break
  say "(retry $attempt: the STOP landed after the sweep had already recreated state)"
  sleep 0.5
done

say "--- the worker's own state root, recreated by its stale-job sweep -------"
say "\$ ls -la $STATE"
ls -la "$STATE" | sed 's/^/    /'
say ""
say "    worker.lock (the ownership directory) is absent:"
say "    \$ ls -d $STATE/worker.lock"
ls -d "$STATE/worker.lock" 2>&1 | sed 's/^/    /'
say ""
say "--- the serving process before TERM ------------------------------------"
say "\$ ps -o pid,ppid,state,command -p $SERVE"
ps -o pid,ppid,state,command -p "$SERVE" | sed 's/^/    /'
say ""
say "    published heartbeat: inode $(inode_of "$READY")  contents: $(tr -d '\n' < "$READY" 2>/dev/null)"
say ""
say "--- operator sends TERM to the unowned serving worker -------------------"
say "\$ kill -TERM $SERVE"
kill -TERM "$SERVE"
before_inode=$(inode_of "$READY")

deadline=$(( $(date +%s) + 6 ))
while [ "$(date +%s)" -lt "$deadline" ]; do
  alive "$SERVE" || break
  sleep 0.1
done
say ""
say "--- six seconds later --------------------------------------------------"
if alive "$SERVE"; then
  say "    RESULT: the process is STILL RUNNING and still owns no lock."
  say "\$ ps -o pid,ppid,state,command -p $SERVE"
  ps -o pid,ppid,state,command -p "$SERVE" | sed 's/^/    /'
  sleep 2
  after_inode=$(inode_of "$READY")
  say ""
  say "    heartbeat inode $before_inode -> $after_inode"
  if [ "$before_inode" != "$after_inode" ]; then
    say "    it is STILL PUBLISHING ready heartbeats: the fleet believes an"
    say "    unowned worker is healthy and will hand it jobs."
  fi
  say ""
  say "    VERDICT: DEFECT REPRODUCED - TERM was swallowed."
else
  say "    RESULT: the process is GONE."
  say "\$ ps -o pid,ppid,state,command -p $SERVE"
  ps -o pid,ppid,state,command -p "$SERVE" 2>&1 | sed 's/^/    /'
  say ""
  say "    VERDICT: FIXED - the unowned worker honored TERM and stopped serving."
  say ""
  say "--- what the supervisor put in its place --------------------------------"
  # The supervisor legitimately restarts a worker, and that replacement goes
  # through the normal startup path, so it holds real ownership again. Any
  # heartbeat published from here on belongs to that owned worker, not to the
  # unowned one TERM just stopped.
  deadline=$(( $(date +%s) + 15 ))
  while [ "$(date +%s)" -lt "$deadline" ]; do
    [ -d "$STATE/worker.lock" ] && [ -n "$(serving_child "$SUPERVISOR")" ] && break
    sleep 0.1
  done
  REPLACEMENT=$(serving_child "$SUPERVISOR")
  say "\$ ps -o pid,ppid,state,command -p ${REPLACEMENT:-0}"
  ps -o pid,ppid,state,command -p "${REPLACEMENT:-0}" 2>&1 | sed 's/^/    /'
  say ""
  say "\$ ls -la $STATE"
  ls -la "$STATE" | sed 's/^/    /'
  say ""
  say "    ownership is genuine again - worker.lock/pid says $(tr -d '\n' < "$STATE/worker.lock/pid" 2>/dev/null)"
  say "    heartbeat says $(tr -d '\n' < "$READY" 2>/dev/null), and the TERMed pid $SERVE is not either of them."
fi
say ""
```
</details>
<details>
<summary>Evidence: Repro harness: active-execution cleanup on the exit-125 shutdown path</summary>

```text
#!/usr/bin/env bash
# The intent requires the new exit-125 shutdown path to preserve active
# execution cleanup. This drives the changed path directly - the ownership
# directory is removed so worker_publish_quarantine fails - while a real job is
# mid-flight, and shows whether the job's command tree is still stopped.
#
# usage: repro-active-execution-cleanup.sh <repo-root> <worker-script> <label> <scratch-dir>
set -u

ROOT=$1
WORKER_SRC=$2
LABEL=$3
mkdir -p "$4"
SCRATCH=$(cd "$4" && pwd -P)

STATE="$SCRATCH/remote-jobs"
ACCOUNT="$SCRATCH/account"
HOME_DIR="$SCRATCH/remote-home"
CODE="$SCRATCH/remote-root"
STARTED="$SCRATCH/job-started"
SIDE_EFFECT="$SCRATCH/job-side-effect"

alive() { kill -0 "$1" 2>/dev/null; }
say() { printf '%s\n' "$*"; }

cleanup() {
  [ -n "${SUPERVISOR:-}" ] && { kill -KILL -- "-$SUPERVISOR" 2>/dev/null; kill -KILL "$SUPERVISOR" 2>/dev/null; }
  [ -n "${JOB_TREE:-}" ] && { kill -KILL -- "-$JOB_TREE" 2>/dev/null; kill -KILL "$JOB_TREE" 2>/dev/null; }
  return 0
}
trap cleanup EXIT

mkdir -p "$ACCOUNT" "$HOME_DIR" "$CODE/bin"
cp "$ROOT/bin/fm-remote-job-lib.sh" "$CODE/bin/"
cp "$WORKER_SRC" "$CODE/bin/fm-remote-job-worker.sh"
# The same shape the suite's shutdown fixture uses: it ignores TERM itself, so
# only a real stop of the command tree can prevent the later side effect.
cat > "$CODE/bin/fm-shutdown-job.sh" <<'SH'
#!/bin/bash
trap '' HUP INT TERM
printf 'started\n' > "$1"
sleep 5
printf 'ran\n' > "$2"
SH
chmod +x "$CODE/bin"/*.sh
printf 'fixture\n' > "$CODE/AGENTS.md"
git -C "$CODE" init -q -b main
git -C "$CODE" config user.email test@example.com
git -C "$CODE" config user.name Test
git -C "$CODE" config commit.gpgsign false
git -C "$CODE" add AGENTS.md bin
git -C "$CODE" commit -qm 'remote job fixture'

export FM_REMOTE_JOB_STATE_ROOT="$STATE"
export FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux
export FM_REMOTE_JOB_TIMEOUT=120
export FM_REMOTE_JOB_QUEUE_TIMEOUT=60
# shellcheck source=bin/fm-remote-job-lib.sh
. "$ROOT/bin/fm-remote-job-lib.sh"

say "=============================================================="
say "worker under test: $LABEL"
say "=============================================================="
say ""

fm_remote_job_start_linux_worker "$CODE" "$ACCOUNT" >/dev/null 2>&1 ||
  { say "FATAL: could not start the fixture worker: ${FM_REMOTE_JOB_ERROR:-}"; exit 1; }
SUPERVISOR=$(pgrep -f "^/bin/bash $CODE/bin/fm-remote-job-worker.sh\$" | head -n 1)
deadline=$(( $(date +%s) + 20 ))
while [ ! -f "$STATE/worker.ready" ]; do
  [ "$(date +%s)" -lt "$deadline" ] || { say "FATAL: worker never became ready"; exit 1; }
  sleep 0.05
done

fm_remote_job_stage "$ACCOUNT" "$CODE" "$HOME_DIR" fm-shutdown-job.sh "$STARTED" "$SIDE_EFFECT" \
  < /dev/null > /dev/null || { say "FATAL: could not stage the job"; exit 1; }
JOB_ID=$FM_REMOTE_JOB_ID
deadline=$(( $(date +%s) + 30 ))
while [ ! -f "$STARTED" ]; do
  [ "$(date +%s)" -lt "$deadline" ] || { say "FATAL: the job never began executing"; exit 1; }
  sleep 0.05
done

SERVE=$(tr -d '\n' < "$STATE/worker.pid")
# The worker records the command tree as a process group in .claim/group.
JOB_TREE=$(tr -d '\n' < "$STATE/jobs/$JOB_ID/.claim/group" 2>/dev/null)
JOB_CMD=$(pgrep -f "fm-shutdown-job\.sh $STARTED" | head -n 1)

say "--- a real job is mid-flight on an owned worker -------------------------"
say "\$ ps -o pid,ppid,pgid,state,command -p $SERVE -p $JOB_TREE -p $JOB_CMD"
ps -o pid,ppid,pgid,state,command -p "$SERVE" -p "$JOB_TREE" -p "$JOB_CMD" | sed 's/^/    /'
say ""
say "    job $JOB_ID state: $(cat "$STATE/jobs/$JOB_ID/state" 2>/dev/null)"
say "    its command tree is recorded at jobs/$JOB_ID/.claim/group = $JOB_TREE"
say ""

say "--- remove the ownership directory, so shutdown cannot quarantine -------"
say "\$ rm -rf $STATE/worker.lock"
rm -rf "$STATE/worker.lock"
ls -la "$STATE" | sed 's/^/    /'
say ""

say "--- TERM the serving worker --------------------------------------------"
say "\$ kill -TERM $SERVE"
kill -TERM "$SERVE"
deadline=$(( $(date +%s) + 10 ))
while [ "$(date +%s)" -lt "$deadline" ]; do
  alive "$SERVE" || break
  sleep 0.1
done
say ""
if alive "$SERVE"; then
  say "    the serving worker IGNORED TERM and is still running:"
  ps -o pid,ppid,state,command -p "$SERVE" | sed 's/^/    /'
else
  say "    the serving worker honored TERM and exited."
fi
say ""

say "--- did exit cleanup still stop the active command tree? ----------------"
say "\$ ps -o pid,ppid,pgid,state,command -p $JOB_TREE -p $JOB_CMD"
ps -o pid,ppid,pgid,state,command -p "$JOB_TREE" -p "$JOB_CMD" 2>&1 | sed 's/^/    /'
if alive "$JOB_TREE" || alive "$JOB_CMD" || kill -0 -- "-$JOB_TREE" 2>/dev/null; then
  say ""
  say "    VERDICT: the job's command tree SURVIVED - active execution cleanup was lost."
else
  say ""
  say ""
  say "    the recorded command tree and the job command itself are both gone."
  say "    waiting past the job's own sleep to prove it never completed its work..."
  sleep 10
  if [ -e "$SIDE_EFFECT" ]; then
    say "    VERDICT: the job still produced its side effect at $SIDE_EFFECT - cleanup failed."
  else
    say "\$ ls $SIDE_EFFECT"
    ls "$SIDE_EFFECT" 2>&1 | sed 's/^/    /'
    say ""
    say "    VERDICT: active execution cleanup PRESERVED - the mid-flight command"
    say "    tree was stopped and never mutated anything after shutdown."
  fi
fi
say ""
```
</details>
- Outcome: ⚠️ 1 info across 1 run (12m50s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- 🚨 `tests/fm-remote-job-orphan-reap.test.sh:137` - The STOP has to land in the ~7.4ms between the heartbeat mv and prepare_state re-creating the state root, but the detection loop&#39;s granularity is ~14ms, so the regression fails roughly half the time. main() writes the heartbeat and then immediately runs fm_remote_job_reap_stale -&gt; fm_remote_job_prepare_state; I measured that prefix (validate_settings, canonical_existing_dir on the account home, normalize/dirname/basename, canonical_existing_dir on the parent) at ~7.4ms, and one iteration of this loop (inode_of subshell + uname fork + stat fork + sleep 0.001) at ~14ms. A synthetic replay of the same cadence detected the inode change within 7.4ms in only 54% of heartbeats, with p90 at 294ms. When the STOP lands late, `rm -rf` + CONT leaves prepare_state to chmod/mkdir a removed root, it returns 1, and the next worker_write_heartbeat mktemp fails, so main() exits 1 and line 163 fails with &#34;the serving child exited before recreating the lock-free state&#34;. Fix additively rather than by weakening the sync: wrap the whole construct-and-TERM sequence in a retry that, when the serving child dies before recreating the lock-free state, waits for the supervisor to respawn a new child (pgrep -P &#34;$WORKER&#34;) and tries again; and hoist the `uname -s` check out of inode_of (compute the stat flag once at line 44) so each poll costs one fork instead of three.
- ℹ️ `bin/fm-remote-job-worker.sh:300` - The fix makes TERM authoritative for a worker that lost its ownership directory, which is the defect the intent scopes. The adjacent exposure remains and is reachable: an unowned worker that is never signalled keeps publishing worker.ready and processing jobs from a state root it no longer owns, and because worker.lock is gone a second worker can mkdir it and serve the same queue concurrently. The serving loop never re-validates that it still holds the lock. Noting as the natural follow-up; closing it would need a per-iteration ownership check in main(), which is outside the intent&#39;s explicit &#34;keep the product change small&#34;.
- ℹ️ `bin/fm-remote-job-worker.sh:300` - Exiting 125 rather than 0 makes worker_supervise_linux treat this shutdown as a child failure: it increments `failures`, applies backoff, and counts toward FM_REMOTE_JOB_SUPERVISOR_MAX_RESTARTS. That is the right semantic here (the respawned child re-acquires ownership cleanly, and the test asserts the respawn), and a child that stayed up FM_REMOTE_JOB_SUPERVISOR_HEALTHY_SECONDS resets the counter, so it is self-limiting. Recording the tradeoff, not asking for a change.

🔧 Fix: make heartbeat-window watcher fork-free and retryable
2 infos still open:
- ℹ️ `tests/fm-remote-job-orphan-reap.test.sh:190` - The inode watcher spins with no sleep and no yield, which is the point (it is what shrinks detection latency to syscall speed) but is worth recording as a tradeoff: in the normal case it burns one core for the ~65ms between heartbeats, and on the pathological path where the heartbeat stops advancing it burns one core for the full 30s deadline before failing. Under a cgroup CPU quota the spin can get throttled, which makes a miss more likely - but that is exactly what the bounded retry at line 222 covers, so the outcome is a slower test rather than a wrong one. No action; noting it so the cost is a known property rather than a surprise.
- ℹ️ `tests/fm-remote-job-orphan-reap.test.sh:225` - The retry-exhaustion message says &#34;the STOP never landed between the heartbeat and the stale-job sweep in N attempts&#34;, but the only condition that consumes an attempt is line 208 - the serving child died before recreating the lock-free state. Eight consecutive deaths are far more likely to mean the product started dying on a lock-free sweep than that scheduling missed the window eight times in a row, so the message points a maintainer at a scheduling ghost. Appending the observed cause (&#34;the serving child died before recreating the lock-free state on every attempt&#34;) keeps the diagnosis honest without touching the contract.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `tests/fm-remote-job-orphan-reap.test.sh:110` - tests/fm-remote-job-orphan-reap.test.sh (and tests/fm-remote-job.test.sh) build their fixture code root with `git commit` but never set `commit.gpgsign false`, so on a machine with global commit signing enabled the fixture commit fails and prints `gpg: signing failed: No secret key` / `fatal: failed to write commit object` into the test output. The assertions still pass because the worker only needs the git index, not a commit, so this is cosmetic - but it makes passing runs look broken and could hide a genuine failure. Pre-existing on the base commit, not introduced by this change.
- <code>`bash tests/fm-remote-job-orphan-reap.test.sh` with the fix - 5 consecutive runs, exit 0 each</code>
- <code>`bash tests/fm-remote-job-orphan-reap.test.sh` with bin/fm-remote-job-worker.sh reverted to base 833a9a2 - 4 runs, all `not ok - the lock-free serving child survived TERM and advanced heartbeat ...`, exit 1</code>
- <code>`bash tests/fm-remote-job-orphan-reap.test.sh` under 2x CPU oversubscription (28 spinner processes on 14 cores) - 3 runs, exit 0, retry construction never exhausted its 8 attempts</code>
- <code>`bash tests/fm-remote-job.test.sh` - 22 assertions pass, covering `worker shutdown terminates the active command tree before replacement`, `failed shutdown quarantines ownership against replacement workers`, `quarantine clears only after recorded execution has stopped`</code>
- <code>Manual end-to-end repro `repro-unowned-worker-term.sh` run against both the base and fixed worker: starts a real worker via fm_remote_job_start_linux_worker, pins the published heartbeat inode with a hard link, STOPs the serving child on atomic inode replacement, removes the state root while stopped, CONTs so the stale-job sweep recreates jobs/logs/worker.ready without worker.lock, then TERMs and records `ps` plus heartbeat inode movement</code>
- <code>Manual verification `repro-active-execution-cleanup.sh` against both workers: stages a real job whose command ignores TERM, removes only worker.lock so worker_publish_quarantine fails, TERMs the serving worker, then checks the recorded `.claim/group` command tree and whether the job&#39;s post-sleep side effect ever appears</code>
- <code>Code trace confirming `trap worker_exit_cleanup EXIT` (bin/fm-remote-job-worker.sh:678) is registered before `trap worker_shutdown HUP INT TERM` (line 687), so the new `exit 125` still runs active-execution cleanup</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `bin/fm-remote-job-worker.sh:18` - The remote job worker&#39;s ownership state machine has no authoritative owner document: worker.lock, its quarantine marker, and the distinct shutdown outcomes (exit 75 when ownership is quarantined after an unconfirmed shutdown, exit 125 for a shutdown that could not guard or stop cleanly, and how the Linux supervisor treats each) exist only as scattered code in bin/fm-remote-job-worker.sh and bin/fm-remote-job-lib.sh. This change&#39;s own invariant is correctly captured as a call-site comment, so nothing here is stale or wrong today. A follow-up consolidating that state machine into the bin/fm-remote-job-worker.sh header (the tier-7 mechanics owner, alongside the abandonment and supervisor-backoff paragraphs already there) would give the contract one owner, but writing it means restating behaviour this change did not touch and is out of scope for a focused fix.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
