### PR TITLE
fix(relay): re-offer mentions after interrupted wakes

### DIFF
--- a/.agents/skills/fmx-respond/SKILL.md
+++ b/.agents/skills/fmx-respond/SKILL.md
@@ -156,6 +156,10 @@ Treat `state/x-inbox/` as the source of truth and process **every** file you fin
       ```
 
       (`bin/fm-x-reply.sh <request_id> -`, reading the reply on stdin, is equally fine.) It echoes the `request_id` and exits 0 on success; non-zero on a failed live post or failed dry-run record.
+      Exit 10 is not a failure to fix: it means a confirmed marker proves that request was already answered, so the reply was deliberately refused rather than posted twice.
+      Treat it as an answered request - clear the inbox file as in step 2f and move on, without composing another reply.
+      Exit 11 means the initial answer outcome is unresolved, either because this attempt was ambiguous or because it found an unconfirmed claim, so do not compose or retry a reply.
+      Leave the inbox file in place and escalate to firstmate immediately with the stderr detail; the durable answer claim stays held, and a later attempt remains exit 11 until the state is resolved.
       When the reply carries one real visual artifact, add `--image <path>`: the helper reads one local PNG, JPEG, GIF, WebP, BMP, or TIFF, detects the media type, base64-encodes it, and sends it in the relay's optional `image` object without ever inlining image bytes into the shell command.
       If the reply auto-splits into a thread, the image rides the first/opener message only.
    e-skip. **For a skip, dismiss it at the relay instead of replying.** A pure acknowledgment gets no reply, but clearing only the local inbox file is not enough: the relay keeps re-offering that request on every poll until it times out to a polite "offline" auto-reply. So before clearing the file, tell the relay to drop the request:
@@ -166,9 +170,10 @@ Treat `state/x-inbox/` as the source of truth and process **every** file you fin
 
       It posts nothing, stops the re-offer, and prevents the offline auto-reply; it echoes the `request_id` and exits 0 on success (it honors `FMX_DRY_RUN` like `bin/fm-x-reply.sh`, recording the would-be dismiss to `state/x-outbox/` instead of posting). Do **not** call `bin/fm-x-reply.sh` for a skip.
    f. **On success (a posted reply, or a relay dismiss for a skip), remove that inbox file:** `rm -f state/x-inbox/<request_id>.json` (and your temporary reply file).
-      This is the local idempotency guard - a cleared file is never answered twice.
+      This completes the local inbox drain; the durable initial-answer marker described in `docs/configuration.md` prevents a repeated wake from becoming a duplicate public reply.
       For an acknowledged actionable request that spawned a task, this cleanup comes **after** the step 2c link, never before, so the link can copy the reply platform and budget directly from the inbox payload.
-   g. **On failure** (a non-zero exit from `bin/fm-x-reply.sh` or `bin/fm-x-dismiss.sh`), leave that inbox file in place, move on to the next, and do not retry blindly.
+   g. **On failure** (a non-zero exit from `bin/fm-x-reply.sh` other than the confirmed-answer exit 10, or a non-zero exit from `bin/fm-x-dismiss.sh`), leave that inbox file in place, move on to the next, and do not retry blindly.
+      Exit 11 follows the immediate escalation rule in step 2e and must never be retried.
       If you had already acted on this mention in step 2c before the post failed, do **not** redo that work on a later drain - check whether it is already done (e.g. the backlog item exists, the crewmate is already running) and only retry the reply.
       If a reply or dismiss fails twice, surface it to the captain as a blocker with the stderr detail; for live post failures include the relay's HTTP status when available.
       The relay posts its own offline reply if no live answer lands in time, so a single miss is not a crisis.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ state/               volatile runtime signals; gitignored
   procevent/         registered process-to-event sources, one private record per canonical source id; written only by bin/fm-procevent.sh, and their presence alone keeps supervision required (section 13)
   procevent-inbox/   private captured results and their durable handled-acknowledgement markers; source output lives here and never in an event line
   x-inbox/           generated Relay pending mention payloads; fmx-respond drains it (section 14)
-  x-context/         generated Relay durable per-request reply context and one-wake offer markers, keyed by request_id; survives inbox cleanup and expires within seven days (section 14; bin/fm-x-lib.sh)
+  x-context/         generated Relay durable per-request reply context and delivery markers, keyed by request_id; survives inbox cleanup and expires within seven days (section 14; docs/configuration.md)
   x-outbox/          generated Relay dry-run reply and dismiss previews; inspect it when FMX_DRY_RUN is set (section 14)
   public-followup/   generated private transport for promised public replies: commitment registrations, typed terminal-result inbox, accepted/rejected ledgers (section 14; bin/fm-public-followup.sh)
   x-poll.error x-poll.claim-error  generated Relay and offer-claim diagnostic dedupe markers

--- a/bin/fm-x-lib.sh
+++ b/bin/fm-x-lib.sh
@@ -23,7 +23,20 @@
 #                                - persist the durable per-request reply context;
 #                                refresh=1 resets its retention timestamp
 #   fmx_offer_registry_claim <state> <request_id> - atomically claim the durable
-#                                one-wake offer marker; 0=new, 1=existing, 2=error
+#                                offer-delivery marker; 0=new, 1=existing, 2=error
+#   fmx_offer_registry_commit <state> <request_id> - record that the claimed
+#                                marker's wake was emitted
+#   fmx_offer_registry_emitted <state> <request_id> - true only for a marker
+#                                whose wake was emitted
+#   fmx_answer_registry_claim <state> <request_id> - atomically claim the right
+#                                to post one public answer; 0=claimed,
+#                                1=already answered or unresolved, 2=error
+#   fmx_answer_registry_confirm <state> <request_id> - record that the claimed
+#                                public answer received a 2xx response
+#   fmx_answer_registry_answered <state> <request_id> - true only for a marker
+#                                whose public answer is confirmed
+#   fmx_answer_registry_release <state> <request_id> - drop a claim whose post
+#                                definitely did not land
 #   fmx_context_registry_prune <state> - remove records older than seven days
 #   fmx_context_registry_get <state> <request_id> - read the durable per-request
 #                                reply context, or the empty shape when absent
@@ -535,11 +548,16 @@ fmx_context_registry_set() {
 }
 
 # fmx_offer_registry_claim <state> <request_id>: atomically claim the durable
-# one-wake marker at state/x-context/<request_id>.offered.json. The marker uses
+# offer-delivery marker at state/x-context/<request_id>.offered.json. It uses
 # the context registry's recorded_at retention contract, so its first claim
 # survives inbox cleanup and expires with the relay's bounded follow-up window.
 # Returns 0 only to the caller that created the marker, 1 when a valid marker
 # already exists, and 2 on invalid input or a publication failure.
+#
+# The claim records wake_emitted:false because claiming is not offering: the
+# offer only exists once the wake line is written. fmx_offer_registry_commit
+# flips that field afterwards, and only a committed marker suppresses a later
+# relay re-offer, so an interrupted claim cannot silence the mention.
 fmx_offer_registry_claim() {
   local state=$1 rid=$2 dir now record rc
   case "$rid" in
@@ -552,12 +570,137 @@ fmx_offer_registry_claim() {
   esac
   [ "${#now}" -le 18 ] || return 2
   record=$(jq -cn --arg rid "$rid" --argjson recorded_at "$now" \
-    '{request_id:$rid, recorded_at:$recorded_at}') || return 2
+    '{request_id:$rid, recorded_at:$recorded_at, wake_emitted:false}') || return 2
   dir="$state/x-context"
   printf '%s\n' "$record" \
     | fmx_private_artifact_publish_stdin_once "$dir" "$rid.offered.json" 600
   rc=$?
   return "$rc"
+}
+
+# fmx_offer_registry_commit <state> <request_id>: record that the claimed
+# marker's wake was emitted, preserving the claim's recorded_at so retention
+# still runs from the first claim. Callers commit only after the wake line is
+# written, so a failure here costs one repeated offer rather than a lost
+# mention. Returns non-zero when no valid marker exists or the write fails.
+fmx_offer_registry_commit() {
+  local state=$1 rid=$2 dir file now recorded_at
+  case "$rid" in
+    ''|.*|*[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+  dir="$state/x-context"
+  file="$dir/$rid.offered.json"
+  fmx_private_artifact_file_valid "$dir" "$rid.offered.json" 600 || return 1
+  now=${FMX_NOW_OVERRIDE:-$(date +%s)}
+  case "$now" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  [ "${#now}" -le 18 ] || return 1
+  recorded_at=$(fmx_context_registry_recorded_at "$file" "$now") || recorded_at=$now
+  (set -o pipefail; jq -cn --arg rid "$rid" --argjson recorded_at "$recorded_at" \
+    '{request_id:$rid, recorded_at:$recorded_at, wake_emitted:true}' \
+    | fmx_private_artifact_publish_stdin "$dir" "$rid.offered.json" 600) || return 1
+}
+
+# fmx_offer_registry_emitted <state> <request_id>: true only when a valid marker
+# records an emitted wake. A marker written before this field existed is treated
+# as emitted, so upgrading firstmate never replays a mention that was already
+# answered; an unreadable marker is treated as not emitted, which at worst
+# repeats one offer and lets the retention prune clear the record.
+fmx_offer_registry_emitted() {
+  local state=$1 rid=$2 dir emitted
+  case "$rid" in
+    ''|.*|*[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+  dir="$state/x-context"
+  fmx_private_artifact_file_valid "$dir" "$rid.offered.json" 600 || return 1
+  emitted=$(jq -r 'if has("wake_emitted") then (.wake_emitted == true) else true end' \
+    "$dir/$rid.offered.json" 2>/dev/null) || return 1
+  [ "$emitted" = true ]
+}
+
+# fmx_answer_registry_claim <state> <request_id>: atomically claim the durable
+# answered marker at state/x-context/<request_id>.answered.json before posting a
+# public answer. The poll offers a mention at least once - an interrupted offer
+# is deliberately re-offered rather than silenced - so exactly-once has to be
+# enforced where the public action happens, not where the wake is produced.
+# The initial marker records answered:false, which grants its creator permission
+# to post but does not claim the answer landed. Returns 0 only to the caller that
+# created the marker, 1 when a request has already been claimed, and 2 on invalid
+# input or a publication failure. Callers must refuse to post on anything but 0.
+# The marker shares the context registry's retention, so it covers the relay's
+# whole follow-up window.
+fmx_answer_registry_claim() {
+  local state=$1 rid=$2 dir now record rc
+  case "$rid" in
+    ''|.*|*[!A-Za-z0-9._-]*) return 2 ;;
+  esac
+  fmx_context_registry_prune "$state"
+  now=${FMX_NOW_OVERRIDE:-$(date +%s)}
+  case "$now" in
+    ''|*[!0-9]*) return 2 ;;
+  esac
+  [ "${#now}" -le 18 ] || return 2
+  record=$(jq -cn --arg rid "$rid" --argjson recorded_at "$now" \
+    '{request_id:$rid, recorded_at:$recorded_at, answered:false}') || return 2
+  dir="$state/x-context"
+  printf '%s\n' "$record" \
+    | fmx_private_artifact_publish_stdin_once "$dir" "$rid.answered.json" 600
+  rc=$?
+  return "$rc"
+}
+
+# fmx_answer_registry_confirm <state> <request_id>: record that the claimed
+# answer received a 2xx response, preserving the claim's recorded_at so
+# retention still runs from the first claim. Returns non-zero when no valid
+# marker exists or the write fails.
+fmx_answer_registry_confirm() {
+  local state=$1 rid=$2 dir file now recorded_at
+  case "$rid" in
+    ''|.*|*[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+  dir="$state/x-context"
+  file="$dir/$rid.answered.json"
+  fmx_private_artifact_file_valid "$dir" "$rid.answered.json" 600 || return 1
+  now=${FMX_NOW_OVERRIDE:-$(date +%s)}
+  case "$now" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  [ "${#now}" -le 18 ] || return 1
+  recorded_at=$(fmx_context_registry_recorded_at "$file" "$now") || recorded_at=$now
+  (set -o pipefail; jq -cn --arg rid "$rid" --argjson recorded_at "$recorded_at" \
+    '{request_id:$rid, recorded_at:$recorded_at, answered:true}' \
+    | fmx_private_artifact_publish_stdin "$dir" "$rid.answered.json" 600) || return 1
+}
+
+# fmx_answer_registry_answered <state> <request_id>: true only when a valid
+# marker records a confirmed answer. A missing answered field is unresolved,
+# because legacy claim markers cannot prove that their post landed.
+fmx_answer_registry_answered() {
+  local state=$1 rid=$2 dir answered
+  case "$rid" in
+    ''|.*|*[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+  dir="$state/x-context"
+  fmx_private_artifact_file_valid "$dir" "$rid.answered.json" 600 || return 1
+  answered=$(jq -r '.answered == true' "$dir/$rid.answered.json" 2>/dev/null) || return 1
+  [ "$answered" = true ]
+}
+
+# fmx_answer_registry_release <state> <request_id>: drop a claim whose post
+# definitely did not land, so the answer can be retried. Only a definite failure
+# releases it; an unknown outcome must keep the claim so the public surface
+# never gets a second post from an automatic retry. Idempotent when the marker is
+# absent and non-zero when the marker cannot be safely removed.
+fmx_answer_registry_release() {
+  local state=$1 rid=$2 dir
+  case "$rid" in
+    ''|.*|*[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+  dir="$state/x-context"
+  [ -e "$dir" ] || return 0
+  [ -d "$dir" ] && [ ! -L "$dir" ] || return 1
+  rm -f "$dir/$rid.answered.json" 2>/dev/null
 }
 
 # fmx_context_registry_get <state> <request_id>: print the durable per-request

--- a/bin/fm-x-poll.sh
+++ b/bin/fm-x-poll.sh
@@ -14,9 +14,10 @@
 #   a newly offered mention with non-empty text -> stash the full object to
 #       state/x-inbox/<request_id>.json, record the durable per-request reply
 #       context to state/x-context/<request_id>.json (best-effort), atomically
-#       claim state/x-context/<request_id>.offered.json, and print one compact
-#       line "x-mention <request_id>" (which becomes the watcher wake payload)
-#   an already offered request_id                -> print nothing, exit 0
+#       claim state/x-context/<request_id>.offered.json, print one compact line
+#       "x-mention <request_id>" (which becomes the watcher wake payload), and
+#       only then commit that marker as emitted
+#   a request_id with an emitted wake marker     -> print nothing, exit 0
 #   a new set of unreconciled public-followup terminal results -> print one
 #       "public-followup ..." line BEFORE the relay call, so a promised final
 #       reply is surfaced through this same wake path
@@ -147,7 +148,9 @@ esac
 # successful answer or dismiss. Checking it before the inbox stash keeps both a
 # still-pending request and the relay's brief post-answer re-offer silent without
 # recreating a drained inbox. The startup prune above bounds marker retention.
-if fmx_private_artifact_file_valid "$STATE/x-context" "$REQ.offered.json" 600; then
+# Only a marker whose wake was actually emitted suppresses the re-offer: a marker
+# left behind by an interrupted offer below must fall through to be re-offered.
+if fmx_offer_registry_emitted "$STATE" "$REQ"; then
   clear_error
   clear_claim_error
   exit 0
@@ -176,10 +179,27 @@ if [ -n "$POLL_CTX" ]; then
   fmx_context_registry_set "$STATE" "$REQ" "$POLL_PLATFORM" "$POLL_MAX" 2>/dev/null || true
 fi
 
+# Claim, emit, then commit. The claim stays first because it is the atomic gate
+# that stops two polls from offering one request, but it deliberately records an
+# UNEMITTED marker: committing before the wake is written would let any death in
+# that gap leave a marker that swallows every later relay re-offer above, losing
+# the mention for the rest of the retention window with no trace. In this order
+# an interrupted offer costs at most one repeated wake - the noise the marker
+# exists to trim - instead of a silently dropped mention.
 fmx_offer_registry_claim "$STATE" "$REQ"
 offer_rc=$?
 case "$offer_rc" in
-  0) clear_error; clear_claim_error; printf 'x-mention %s\n' "$REQ" ;;
-  1) clear_error; clear_claim_error; exit 0 ;;
+  # 1 is an unemitted marker from an interrupted earlier offer, because the check
+  # above already returned for an emitted one; re-offer it rather than exiting.
+  0|1) clear_error; clear_claim_error ;;
   *) emit_claim_error_once "cannot record mention offer"; exit 0 ;;
 esac
+# One line of output per poll is the watcher's wake-payload contract, so a failed
+# commit stays silent here: its only cost is the next cycle re-offering.
+# This closes the poll's own window, not every window: the watcher reads this
+# output, deletes the capture, and only then appends the durable wake record, so
+# a watcher that dies in that gap still loses the wake. Closing that one belongs
+# in the watcher's check dispatch, not here. Because a wake can also be repeated,
+# the single public answer per request is enforced in bin/fm-x-reply.sh.
+printf 'x-mention %s\n' "$REQ" || exit 0
+fmx_offer_registry_commit "$STATE" "$REQ" || true

--- a/bin/fm-x-reply.sh
+++ b/bin/fm-x-reply.sh
@@ -37,8 +37,21 @@
 # binds the reply to the exact post it recorded for that request_id, so this
 # client only ever echoes the relay-issued request_id and NEVER names a platform
 # message id.
-# On success it echoes ONLY that request_id; on a non-2xx (or transport failure)
-# it exits non-zero so the caller knows the post did not land. The confirmed
+# On success it echoes ONLY that request_id.
+# A relay non-2xx other than 409 proves the post did not land, but a 409,
+# transport failure, or unreadable HTTP status leaves the outcome unknown.
+#
+# One public answer per request_id is enforced here, because this is the only
+# place an answer is posted. The poll deliberately offers a mention AT LEAST
+# once (an interrupted offer is re-offered rather than silenced), so a repeated
+# wake can reach this client twice for one request. The initial answer path
+# atomically claims state/x-context/<request_id>.answered.json before posting and
+# confirms the marker only after a 2xx response. A confirmed duplicate REFUSES
+# with exit 10; an unconfirmed claim REFUSES with exit 11 because the earlier
+# attempt's outcome is unknown. The claim is released whenever the answer
+# definitely did not land, so an ordinary failure stays retryable; a 2xx and 409
+# keep it. Follow-ups are legitimately repeated and are governed by the relay's
+# cap instead. The confirmed
 # relay contract for an exhausted follow-up binding is HTTP 409 from
 # /connector/followup, optionally with {"error":"followup_unavailable"} in the
 # response body. This client always maps a follow-up 409 to exit code 9 so
@@ -47,6 +60,10 @@
 # relay-side 409 is secondary: after the relay's own cleanup sweep, a very-late
 # call can instead see a benign no-op 200, so fm-x-followup.sh's local
 # window/cap pruning remains the primary guard.
+# Exit 11 is reserved for an initial answer whose outcome is unknown after an
+# ambiguous transport failure, 409 response, unreadable HTTP status, or an
+# existing unconfirmed claim.
+# Its answer claim stays held, and a later attempt also refuses with exit 11.
 #
 # Reply platform + split budget are resolved per axis: an explicit
 # FMX_REPLY_PLATFORM / FMX_REPLY_MAX_CHARS env override wins (fm-x-followup passes
@@ -119,6 +136,12 @@ write_reply_receipt() {
       '{request_id:$r, endpoint:$e, chunks:$c, dry_run:($d == 1)}' > "$RECEIPT_FILE"); then
     echo "fm-x-reply: warning: posted but could not write the receipt to $RECEIPT_FILE" >&2
   fi
+}
+
+release_answer_claim() {
+  fmx_answer_registry_release "$STATE" "$REQ" && return 0
+  echo "fm-x-reply: the answer claim for $REQ could not be released; a later attempt for this request will refuse until it is cleared" >&2
+  return 1
 }
 
 usage() {
@@ -346,20 +369,77 @@ if [ -z "$FMX_TOKEN" ]; then
   echo "fm-x-reply: X mode not configured (no FMX_PAIRING_TOKEN)" >&2
   exit 1
 fi
+# One public answer per request_id, enforced here because this is the only place
+# a public answer is posted. The poll offers a mention AT LEAST once - an
+# interrupted offer is re-offered rather than silenced - so a repeated wake can
+# genuinely reach this script twice for one request. Claiming before the post
+# turns that into a refusal instead of a second public reply. Follow-ups are
+# legitimately repeated and keep their own relay-side cap, so the claim covers
+# the initial answer only.
+if [ "$FOLLOWUP" = 0 ]; then
+  fmx_answer_registry_claim "$STATE" "$REQ"
+  answer_claim_rc=$?
+  case "$answer_claim_rc" in
+    0) : ;;
+    1)
+      if fmx_answer_registry_answered "$STATE" "$REQ"; then
+        echo "fm-x-reply: $REQ was already answered; refusing to post again" >&2
+        exit 10
+      fi
+      echo "fm-x-reply: the answer's outcome is unknown for $REQ; its unconfirmed claim is deliberately held, and this attempt will not post" >&2
+      exit 11
+      ;;
+    *)
+      # Refuse rather than post what cannot be recorded: an unrecorded answer is
+      # exactly the state that lets a later repeated wake answer twice.
+      echo "fm-x-reply: cannot record the answer claim for $REQ; refusing to post" >&2
+      exit 1
+      ;;
+  esac
+fi
 reply_make_tmp_file RESPONSE_BODY_FILE || {
-  echo "fm-x-reply: cannot create relay response temp file" >&2; exit 1; }
+  echo "fm-x-reply: cannot create relay response temp file" >&2
+  [ "$FOLLOWUP" = 1 ] || release_answer_claim || true
+  exit 1
+}
 code=$(fmx_post_json "$ENDPOINT" "$PAYLOAD_FILE" "$RESPONSE_BODY_FILE")
 post_rc=$?
+# An answer claim is released only when the answer provably did not land.
+# Failures before transmission and a readable non-2xx other than 409 are
+# definite; transport failures and unreadable statuses are ambiguous and keep
+# the claim so a later wake cannot post a second public answer.
 case "$post_rc" in
   0) : ;;
-  127) echo "fm-x-reply: curl not found" >&2; exit 1 ;;
-  3) echo "fm-x-reply: invalid FMX_PAIRING_TOKEN" >&2; exit 1 ;;
-  *) echo "fm-x-reply: request to relay failed" >&2; exit 1 ;;
+  127)
+    echo "fm-x-reply: curl not found" >&2
+    [ "$FOLLOWUP" = 1 ] || release_answer_claim || true
+    exit 1
+    ;;
+  2)
+    echo "fm-x-reply: request payload is unreadable: $PAYLOAD_FILE" >&2
+    [ "$FOLLOWUP" = 1 ] || release_answer_claim || true
+    exit 1
+    ;;
+  3)
+    echo "fm-x-reply: invalid FMX_PAIRING_TOKEN" >&2
+    [ "$FOLLOWUP" = 1 ] || release_answer_claim || true
+    exit 1
+    ;;
+  *)
+    echo "fm-x-reply: request to relay failed" >&2
+    if [ "$FOLLOWUP" = 0 ]; then
+      echo "fm-x-reply: the answer's outcome is unknown; its claim is deliberately held, and a later attempt for this request will refuse with exit 11" >&2
+      exit 11
+    fi
+    exit 1
+    ;;
 esac
 
 case "$code" in
   2[0-9][0-9])
     if [ "$FOLLOWUP" = 0 ]; then
+      fmx_answer_registry_confirm "$STATE" "$REQ" \
+        || echo "fm-x-reply: warning: could not confirm the answer marker for $REQ" >&2
       fmx_context_registry_set "$STATE" "$REQ" "$REQ_PLATFORM" "$REQ_EXPLICIT_MAX" 1 2>/dev/null \
         || echo "fm-x-reply: warning: could not retain reply context for $REQ" >&2
     fi
@@ -379,7 +459,20 @@ case "$code" in
       exit 9
     fi
     echo "fm-x-reply: relay returned HTTP $code" >&2
+    echo "fm-x-reply: the answer's outcome is unknown; its claim is deliberately held, and a later attempt for this request will refuse with exit 11" >&2
+    exit 11
+    ;;
+  [1-5][0-9][0-9])
+    echo "fm-x-reply: relay returned HTTP $code" >&2
+    [ "$FOLLOWUP" = 1 ] || release_answer_claim || true
     exit 1
     ;;
-  *) echo "fm-x-reply: relay returned HTTP $code" >&2; exit 1 ;;
+  *)
+    echo "fm-x-reply: relay returned an unreadable HTTP status" >&2
+    if [ "$FOLLOWUP" = 0 ]; then
+      echo "fm-x-reply: the answer's outcome is unknown; its claim is deliberately held, and a later attempt for this request will refuse with exit 11" >&2
+      exit 11
+    fi
+    exit 1
+    ;;
 esac

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -243,7 +243,7 @@ Destructive, irreversible, or security-sensitive asks are escalated for trusted-
 The relay uses owner-only routing: a mention delivered to a home is from that home's owner, while parent-thread context may still include other public accounts.
 On the locked session-start bootstrap step, that token creates the local polling and watcher-cadence artifacts described in the [Relay configuration reference](configuration.md#relay-env).
 Without the token, the locked session-start bootstrap step removes those artifacts on opt-out and otherwise stays silent, so non-Relay users see no behavior change.
-Newly offered mentions are stored as `state/x-inbox/<request_id>.json` and wake firstmate once per retained request ID; the [Relay configuration reference](configuration.md#relay-env) owns the durable offer-marker and re-offer contract.
+Newly offered mentions are stored as `state/x-inbox/<request_id>.json`; the [Relay configuration reference](configuration.md#relay-env) owns the at-least-once wake, durable marker, re-offer, and initial-answer deduplication contracts.
 The `fmx-respond` agent-only skill drains that inbox, uses `in_reply_to` parent-post context for conversational continuity, classifies each mention as an actionable request, question, or pure acknowledgment, and submits public-safe replies through `bin/fm-x-reply.sh`.
 When a reply has a real visual artifact, `--image <path>` attaches one local PNG, JPEG, GIF, WebP, BMP, or TIFF to the relay's optional `{media_type,data_base64}` image object.
 Actionable reversible requests run through firstmate's normal intake, backlog, dispatch, investigation, or ship lifecycle.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -364,8 +364,16 @@ Its request handling remains in Relay-specific `bin/` scripts and the `fmx-respo
 
 `bin/fm-x-poll.sh` calls `GET /connector/poll` with `Authorization: Bearer <FMX_PAIRING_TOKEN>`.
 HTTP 204 is silent.
-A newly offered pending mention with non-empty `text` is stored at `state/x-inbox/<request_id>.json` and wakes firstmate exactly once with `x-mention <request_id>`.
-The poll atomically claims `state/x-context/<request_id>.offered.json` before emitting that wake, and subsequent offers of the same request stay silent even after the inbox is drained following an answer or dismiss.
+A newly offered pending mention with non-empty `text` is stored at `state/x-inbox/<request_id>.json` and wakes firstmate with `x-mention <request_id>`.
+The poll atomically claims `state/x-context/<request_id>.offered.json` before emitting that wake and marks the marker `wake_emitted` only after the wake line is written, and subsequent offers of the same request stay silent even after the inbox is drained following an answer or dismiss.
+Only an emitted marker suppresses a later offer, so a poll that dies between the claim and the wake re-offers the mention on its next cycle instead of silencing it; a marker written before this field existed counts as emitted.
+The wake is therefore at least once rather than exactly once, because a repeated wake is recoverable and a silenced mention is not.
+Exactly-once is enforced where the public action happens: `bin/fm-x-reply.sh` atomically writes `state/x-context/<request_id>.answered.json` with `answered:false` before posting an initial answer, then confirms it with `answered:true` only after a 2xx response.
+A repeated wake cannot become a second public reply: a confirmed marker refuses with exit 10, while an unconfirmed or legacy marker refuses with exit 11 and leaves the inbox in place for visible escalation because the earlier outcome cannot be proven.
+The claim is released only when the answer provably did not land, including failures before transmission and readable non-2xx responses other than 409.
+A 409, transport failure, or unreadable HTTP status holds the unconfirmed claim and exits 11, while a failed release emits a warning that later attempts will refuse until the claim is cleared.
+The answer claim does not apply to follow-ups, which the relay caps instead.
+A residual delivery window remains outside the poll: the watcher reads the poll's output, deletes the capture, and only then appends the durable wake record, so a watcher that dies in that gap still loses the wake.
 Offer markers share the context registry's bounded seven-day retention, so losing or expiring the local marker lets a relay offer wake firstmate again.
 The full relay object is preserved, including `in_reply_to: {author_handle, text}` when the mention is a reply in a conversation or `null` for fresh mentions.
 At the same time the poll records a durable per-request reply context at `state/x-context/<request_id>.json` (`{request_id, platform, reply_max_chars, recorded_at}`) from the same authoritative relay payload, best-effort and keyed by `request_id` so concurrent requests never overwrite each other; it survives the inbox cleanup that follows the acknowledgement, so a delayed follow-up can recover the original platform and split budget even with no task link.

--- a/tests/fm-x-mode.test.sh
+++ b/tests/fm-x-mode.test.sh
@@ -26,6 +26,8 @@ TMP_ROOT=$(fm_test_tmproot fm-x-mode-tests)
 # FAKE_REQCTX_CODE/FAKE_REQCTX_BODY for the request-context lookup), records each
 # call to FAKE_CURL_LOG, writes the poll/lookup body to the script's -o file, and
 # prints the HTTP code to stdout exactly as the real `-w '%{http_code}'` would.
+# FAKE_ANSWER_TRANSPORT_FAIL makes only the answer endpoint fail after recording
+# the request, without printing an HTTP status.
 make_fake_curl() {
   local dir=$1 fakebin
   fakebin=$(fm_fakebin "$dir")
@@ -69,6 +71,8 @@ case "$url" in
     ;;
   */connector/answer)
     [ -n "$ofile" ] && printf '%s' "${FAKE_ANSWER_BODY:-}" > "$ofile"
+    [ -n "${FAKE_ANSWER_CHMOD_DIR:-}" ] && chmod 500 "$FAKE_ANSWER_CHMOD_DIR"
+    [ -n "${FAKE_ANSWER_TRANSPORT_FAIL:-}" ] && exit 28
     printf '%s' "${FAKE_ANSWER_CODE:-200}"
     ;;
   */connector/followup)
@@ -344,6 +348,72 @@ test_poll_mentions_wake_once_per_durable_offer() {
   [ "$out" = "x-mention req-new" ] \
     || fail "a re-offer after the bounded marker expiry must wake once (got: $out)"
   pass "fm-x-poll wakes once per durable request offer across inbox cleanup"
+}
+
+# An uncommitted offer marker must not suppress a later relay re-offer.
+# Both halves pin the crash window: an offer whose wake could not be written,
+# and the durable state a poll killed at the same point leaves behind.
+test_poll_reoffers_a_mention_whose_wake_was_never_delivered() {
+  local home fakebin out rc body
+  home="$TMP_ROOT/poll-offer-crash-window"; mkdir -p "$home"
+  fakebin=$(make_fake_curl "$home")
+  printf 'FMX_PAIRING_TOKEN=tok-crash\n' > "$home/.env"
+  body='{"request_id":"req-lost","platform":"discord","reply_max_chars":1900,"text":"status?"}'
+  # Closing stdout makes the wake line undeliverable exactly where a killed poll
+  # would stop: after the marker exists, before firstmate ever hears the mention.
+  PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_NOW_OVERRIDE=1700000000 \
+    FMX_RELAY_URL="https://relay.test" FAKE_POLL_CODE=200 FAKE_POLL_BODY="$body" \
+    "$ROOT/bin/fm-x-poll.sh" >&- 2>/dev/null
+  assert_present "$home/state/x-inbox/req-lost.json" \
+    "an interrupted offer must still leave its stashed mention pending"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_NOW_OVERRIDE=1700000030 \
+    FMX_RELAY_URL="https://relay.test" FAKE_POLL_CODE=200 FAKE_POLL_BODY="$body" \
+    "$ROOT/bin/fm-x-poll.sh"); rc=$?
+  expect_code 0 "$rc" "re-offer after an undelivered wake exit"
+  [ "$out" = "x-mention req-lost" ] \
+    || fail "a mention whose wake was never delivered must be re-offered (got: $out)"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_NOW_OVERRIDE=1700000060 \
+    FMX_RELAY_URL="https://relay.test" FAKE_POLL_CODE=200 FAKE_POLL_BODY="$body" \
+    "$ROOT/bin/fm-x-poll.sh"); rc=$?
+  expect_code 0 "$rc" "recovered offer dedupe exit"
+  [ -z "$out" ] || fail "a recovered offer must still wake only once (got: $out)"
+  [ "$(jq -r .recorded_at "$home/state/x-context/req-lost.offered.json")" = 1700000000 ] \
+    || fail "a recovered offer must keep the first claim's retention timestamp"
+  # The same durable state a poll killed between the two steps leaves behind.
+  body='{"request_id":"req-killed","platform":"discord","reply_max_chars":1900,"text":"still there?"}'
+  FMX_NOW_OVERRIDE=1700000090 bash -c \
+    '. "$1/bin/fm-x-lib.sh"; fmx_offer_registry_claim "$2/state" req-killed' _ "$ROOT" "$home" \
+    || fail "the interrupted-offer fixture must claim its marker"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_NOW_OVERRIDE=1700000120 \
+    FMX_RELAY_URL="https://relay.test" FAKE_POLL_CODE=200 FAKE_POLL_BODY="$body" \
+    "$ROOT/bin/fm-x-poll.sh"); rc=$?
+  expect_code 0 "$rc" "re-offer after an interrupted claim exit"
+  [ "$out" = "x-mention req-killed" ] \
+    || fail "a claimed but never offered mention must be re-offered (got: $out)"
+  pass "fm-x-poll re-offers a mention whose wake never reached firstmate"
+}
+
+# A marker written before the emission field existed came from a path that
+# printed its wake immediately, so an upgraded poll must keep honoring it rather
+# than replaying an answered mention into a public reply.
+test_poll_treats_a_legacy_offer_marker_as_delivered() {
+  local home fakebin dir out rc body
+  home="$TMP_ROOT/poll-offer-legacy-marker"; mkdir -p "$home"
+  fakebin=$(make_fake_curl "$home")
+  printf 'FMX_PAIRING_TOKEN=tok-legacy\n' > "$home/.env"
+  dir="$home/state/x-context"
+  private_artifact_dir "$dir"
+  jq -cn '{request_id:"req-legacy-offer",recorded_at:1700000000}' > "$dir/req-legacy-offer.offered.json"
+  private_artifact_file "$dir/req-legacy-offer.offered.json"
+  body='{"request_id":"req-legacy-offer","platform":"discord","reply_max_chars":1900,"text":"status?"}'
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_NOW_OVERRIDE=1700000030 \
+    FMX_RELAY_URL="https://relay.test" FAKE_POLL_CODE=200 FAKE_POLL_BODY="$body" \
+    "$ROOT/bin/fm-x-poll.sh"); rc=$?
+  expect_code 0 "$rc" "legacy offer marker poll exit"
+  [ -z "$out" ] || fail "a legacy offer marker must keep suppressing the re-offer (got: $out)"
+  assert_absent "$home/state/x-inbox/req-legacy-offer.json" \
+    "a legacy offer marker must not recreate the drained inbox"
+  pass "fm-x-poll honors an offer marker written before the emission field"
 }
 
 test_poll_offer_claim_failure_reports_once() {
@@ -1465,7 +1535,7 @@ test_reply_followup_409_without_marker_still_exits_distinctly() {
   pass "fm-x-reply maps every follow-up 409 to exit 9 even without the marker"
 }
 
-test_reply_answer_409_is_generic_failure() {
+test_reply_answer_409_is_unresolved() {
   local home fakebin out rc err
   home="$TMP_ROOT/reply-answer-409"; mkdir -p "$home"
   fakebin=$(make_fake_curl "$home")
@@ -1474,10 +1544,207 @@ test_reply_answer_409_is_generic_failure() {
   out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_RELAY_URL="https://relay.test" \
     FAKE_ANSWER_CODE=409 FAKE_ANSWER_BODY='{"error":"followup_unavailable"}' \
     "$ROOT/bin/fm-x-reply.sh" "req-answer-409" "Normal answer." 2>"$err"); rc=$?
-  expect_code 1 "$rc" "answer 409 exit"
+  expect_code 11 "$rc" "answer 409 exit"
   [ -z "$out" ] || fail "answer 409 must not echo the request_id (got: $out)"
-  assert_grep "relay returned HTTP 409" "$err" "answer 409 must stay on the generic failure path"
-  pass "fm-x-reply treats answer-endpoint 409 as a generic failure"
+  assert_grep "relay returned HTTP 409" "$err" "answer 409 must report the relay response"
+  assert_grep "answer's outcome is unknown" "$err" "answer 409 must report the unresolved outcome"
+  assert_present "$home/state/x-context/req-answer-409.answered.json" \
+    "an answer 409 must hold its claim"
+  pass "fm-x-reply holds an answer-endpoint 409 as unresolved"
+}
+
+# The poll offers a mention at least once, so exactly-once has to hold where the
+# public action happens. A repeated wake for one request_id must never become a
+# second public answer.
+test_reply_answers_one_request_id_once() {
+  local home fakebin log out rc err posts
+  home="$TMP_ROOT/reply-answer-once"; mkdir -p "$home"
+  fakebin=$(make_fake_curl "$home")
+  log="$home/curl.log"
+  err="$home/err.txt"
+  printf 'FMX_PAIRING_TOKEN=tok-once\n' > "$home/.env"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_RELAY_URL="https://relay.test" \
+    FAKE_CURL_LOG="$log" FAKE_ANSWER_CODE=200 \
+    "$ROOT/bin/fm-x-reply.sh" "req-once" "First answer." 2>"$err"); rc=$?
+  expect_code 0 "$rc" "first answer exit"
+  [ "$out" = "req-once" ] || fail "the first answer must echo the request_id (got: $out)"
+  [ "$(jq -r '.answered' "$home/state/x-context/req-once.answered.json")" = true ] \
+    || fail "a successful answer must confirm its marker"
+  # The same request offered again: the answer must be refused, not re-posted.
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_RELAY_URL="https://relay.test" \
+    FAKE_CURL_LOG="$log" FAKE_ANSWER_CODE=200 \
+    "$ROOT/bin/fm-x-reply.sh" "req-once" "Second answer." 2>"$err"); rc=$?
+  expect_code 10 "$rc" "repeated answer exit"
+  [ -z "$out" ] || fail "a repeated answer must not echo the request_id (got: $out)"
+  assert_grep "already answered" "$err" "a repeated answer must say why it refused"
+  posts=$(grep -c 'url=https://relay.test/connector/answer' "$log")
+  [ "$posts" = 1 ] \
+    || fail "a repeated answer must not reach the relay (answer posts: $posts)"
+  pass "fm-x-reply posts one public answer per request_id"
+}
+
+# A claim only grants permission to post.
+# If its owner dies before confirming the answer, the next attempt must escalate
+# the unresolved outcome and must not post.
+test_reply_unconfirmed_answer_claim_refuses_as_unresolved() {
+  local home fakebin log out rc err
+  home="$TMP_ROOT/reply-answer-unconfirmed"; mkdir -p "$home"
+  fakebin=$(make_fake_curl "$home")
+  log="$home/curl.log"
+  err="$home/err.txt"
+  printf 'FMX_PAIRING_TOKEN=tok-unconfirmed\n' > "$home/.env"
+  # shellcheck disable=SC2016  # single quotes are deliberate: positional parameters must expand in the inner shell
+  FMX_NOW_OVERRIDE=1700000000 "$BASH" -c \
+    '. "$1"; fmx_answer_registry_claim "$2" "$3"' \
+    _ "$ROOT/bin/fm-x-lib.sh" "$home/state" "req-unconfirmed" \
+    || fail "the unconfirmed answer claim must be created"
+  [ "$(jq -r '.answered' "$home/state/x-context/req-unconfirmed.answered.json")" = false ] \
+    || fail "a fresh answer claim must remain unconfirmed"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_NOW_OVERRIDE=1700000001 \
+    FMX_RELAY_URL="https://relay.test" \
+    FAKE_CURL_LOG="$log" FAKE_ANSWER_CODE=200 \
+    "$ROOT/bin/fm-x-reply.sh" "req-unconfirmed" "Answer." 2>"$err"); rc=$?
+  expect_code 11 "$rc" "unconfirmed answer claim exit"
+  [ -z "$out" ] || fail "an unconfirmed claim must not echo the request_id (got: $out)"
+  assert_grep "outcome is unknown" "$err" "an unconfirmed claim must report the unresolved outcome"
+  [ ! -f "$log" ] || fail "an unconfirmed claim must not reach the relay"
+  pass "fm-x-reply escalates an unconfirmed answer claim without posting"
+}
+
+# Refusing a duplicate must not strand a genuine retry: an answer that did not
+# land has to stay postable.
+test_reply_failed_answer_stays_retryable() {
+  local home fakebin log out rc posts
+  home="$TMP_ROOT/reply-answer-retry"; mkdir -p "$home"
+  fakebin=$(make_fake_curl "$home")
+  log="$home/curl.log"
+  printf 'FMX_PAIRING_TOKEN=tok-retry\n' > "$home/.env"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_RELAY_URL="https://relay.test" \
+    FAKE_CURL_LOG="$log" FAKE_ANSWER_CODE=500 \
+    "$ROOT/bin/fm-x-reply.sh" "req-retry" "Answer." 2>/dev/null); rc=$?
+  expect_code 1 "$rc" "failed answer exit"
+  assert_absent "$home/state/x-context/req-retry.answered.json" \
+    "an answer that did not land must not keep its claim"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_RELAY_URL="https://relay.test" \
+    FAKE_CURL_LOG="$log" FAKE_ANSWER_CODE=200 \
+    "$ROOT/bin/fm-x-reply.sh" "req-retry" "Answer." 2>/dev/null); rc=$?
+  expect_code 0 "$rc" "retried answer exit"
+  [ "$out" = "req-retry" ] || fail "a retried answer must post (got: $out)"
+  posts=$(grep -c 'url=https://relay.test/connector/answer' "$log")
+  [ "$posts" = 2 ] || fail "the retry must reach the relay (answer posts: $posts)"
+  pass "fm-x-reply keeps a failed answer retryable"
+}
+
+# A timeout can happen after the relay accepted an answer.
+# Its claim must stay held because retrying could create a second public post.
+test_reply_ambiguous_transport_failure_holds_answer_claim() {
+  local home fakebin log out rc err posts marker
+  home="$TMP_ROOT/reply-answer-ambiguous"; mkdir -p "$home"
+  fakebin=$(make_fake_curl "$home")
+  log="$home/curl.log"
+  err="$home/err.txt"
+  marker="$home/state/x-context/req-ambiguous.answered.json"
+  printf 'FMX_PAIRING_TOKEN=tok-ambiguous\n' > "$home/.env"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_RELAY_URL="https://relay.test" \
+    FAKE_CURL_LOG="$log" FAKE_ANSWER_TRANSPORT_FAIL=1 \
+    "$ROOT/bin/fm-x-reply.sh" "req-ambiguous" "First answer." 2>"$err"); rc=$?
+  expect_code 11 "$rc" "ambiguous answer transport exit"
+  [ -z "$out" ] || fail "an ambiguous answer must not echo the request_id (got: $out)"
+  assert_present "$marker" "an ambiguous answer must keep its durable claim"
+  assert_grep "answer's outcome is unknown" "$err" \
+    "an ambiguous answer must report that its outcome is unknown"
+  assert_grep "claim is deliberately held" "$err" \
+    "an ambiguous answer must report that its claim remains held"
+  assert_grep "refuse with exit 11" "$err" \
+    "an ambiguous answer must explain how a later attempt is refused"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_RELAY_URL="https://relay.test" \
+    FAKE_CURL_LOG="$log" FAKE_ANSWER_CODE=200 \
+    "$ROOT/bin/fm-x-reply.sh" "req-ambiguous" "Second answer." 2>"$err"); rc=$?
+  expect_code 11 "$rc" "answer retry after ambiguous transport exit"
+  [ -z "$out" ] || fail "a refused answer retry must not echo the request_id (got: $out)"
+  posts=$(grep -c 'url=https://relay.test/connector/answer' "$log")
+  [ "$posts" = 1 ] \
+    || fail "an ambiguous answer must reach the relay only once (answer posts: $posts)"
+  assert_present "$marker" "a refused retry must keep the ambiguous answer claim"
+  pass "fm-x-reply holds ambiguous answer outcomes against duplicate posts"
+}
+
+# fmx_post_json return 2 is pinned at the library boundary because the reply
+# client creates its own readable payload and exposing that file would require a
+# production seam.
+# This proves curl is never invoked for that status; the reply client's release
+# classification remains inspection-covered.
+test_reply_unreadable_payload_is_pretransmission_failure() {
+  local home fakebin log payload response rc
+  home="$TMP_ROOT/reply-unreadable-payload"; mkdir -p "$home"
+  fakebin=$(make_fake_curl "$home")
+  log="$home/curl.log"
+  payload="$home/payload.json"
+  response="$home/response.json"
+  printf '{"request_id":"req-unreadable","text":"Answer."}\n' > "$payload"
+  chmod 000 "$payload"
+  # shellcheck disable=SC2016  # single quotes are deliberate: positional parameters must expand in the inner shell
+  PATH="$fakebin:$BASE_PATH" FMX_RELAY_URL="https://relay.test" FMX_TOKEN=tok \
+    FAKE_CURL_LOG="$log" "$BASH" -c \
+    '. "$1"; fmx_post_json answer "$2" "$3"' \
+    _ "$ROOT/bin/fm-x-lib.sh" "$payload" "$response" >/dev/null 2>&1; rc=$?
+  chmod 600 "$payload"
+  expect_code 2 "$rc" "unreadable payload library exit"
+  [ ! -f "$log" ] || fail "an unreadable payload must fail before curl runs"
+  pass "fmx_post_json classifies an unreadable payload before transmission"
+}
+
+# A definite non-post remains exit 1 even when its answer claim cannot be
+# released, but the stranded claim must be reported.
+test_reply_failed_answer_reports_unreleased_claim() {
+  local home fakebin context_dir out rc err
+  home="$TMP_ROOT/reply-unreleased-claim"; mkdir -p "$home"
+  fakebin=$(make_fake_curl "$home")
+  context_dir="$home/state/x-context"
+  err="$home/err.txt"
+  printf 'FMX_PAIRING_TOKEN=tok-unreleased\n' > "$home/.env"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_RELAY_URL="https://relay.test" \
+    FAKE_ANSWER_CODE=500 FAKE_ANSWER_CHMOD_DIR="$context_dir" \
+    "$ROOT/bin/fm-x-reply.sh" "req-unreleased" "Answer." 2>"$err"); rc=$?
+  chmod 700 "$context_dir"
+  expect_code 1 "$rc" "failed answer with unreleased claim exit"
+  [ -z "$out" ] || fail "a failed answer must not echo the request_id (got: $out)"
+  assert_grep "claim for req-unreleased could not be released" "$err" \
+    "a failed claim release must be reported"
+  assert_grep "later attempt for this request will refuse until it is cleared" "$err" \
+    "a failed claim release must explain the stranded claim"
+  assert_present "$context_dir/req-unreleased.answered.json" \
+    "a failed claim release must leave the marker visible"
+  pass "fm-x-reply reports a claim that could not be released"
+}
+
+# The claim covers the initial answer only: follow-ups are legitimately repeated
+# and keep the relay's own cap, and a preview must never consume a real answer.
+test_reply_answer_claim_spares_followups_and_dry_runs() {
+  local home fakebin log out rc posts
+  home="$TMP_ROOT/reply-answer-claim-scope"; mkdir -p "$home"
+  fakebin=$(make_fake_curl "$home")
+  log="$home/curl.log"
+  printf 'FMX_PAIRING_TOKEN=tok-scope\n' > "$home/.env"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_RELAY_URL="https://relay.test" \
+    FMX_DRY_RUN=1 "$ROOT/bin/fm-x-reply.sh" "req-scope" "Preview." 2>/dev/null); rc=$?
+  expect_code 0 "$rc" "dry-run answer exit"
+  assert_absent "$home/state/x-context/req-scope.answered.json" \
+    "a dry-run preview must not consume the answer claim"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_RELAY_URL="https://relay.test" \
+    FAKE_CURL_LOG="$log" FAKE_ANSWER_CODE=200 \
+    "$ROOT/bin/fm-x-reply.sh" "req-scope" "Real answer." 2>/dev/null); rc=$?
+  expect_code 0 "$rc" "answer after dry-run exit"
+  [ "$out" = "req-scope" ] || fail "a real answer must still post after a preview (got: $out)"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_RELAY_URL="https://relay.test" \
+    FMX_REPLY_PLATFORM=x FMX_REPLY_MAX_CHARS=280 \
+    FAKE_CURL_LOG="$log" FAKE_FOLLOWUP_CODE=200 \
+    "$ROOT/bin/fm-x-reply.sh" "req-scope" --followup "Progress." 2>/dev/null); rc=$?
+  expect_code 0 "$rc" "follow-up after answer exit"
+  [ "$out" = "req-scope" ] || fail "a follow-up must not be blocked by the answer claim (got: $out)"
+  posts=$(grep -c 'url=https://relay.test/connector/followup' "$log")
+  [ "$posts" = 1 ] || fail "the follow-up must reach the relay (follow-up posts: $posts)"
+  pass "fm-x-reply's answer claim spares follow-ups and dry-run previews"
 }
 
 test_reply_followup_image_live_posts_image_object() {
@@ -2802,6 +3069,8 @@ test_poll_auth_error_reports_once
 test_poll_error_private_publication_rejects_unsafe_paths
 test_poll_question_stashes_and_marks
 test_poll_mentions_wake_once_per_durable_offer
+test_poll_reoffers_a_mention_whose_wake_was_never_delivered
+test_poll_treats_a_legacy_offer_marker_as_delivered
 test_poll_offer_claim_failure_reports_once
 test_poll_preserves_conversation_context
 test_poll_inbox_commit_failure_reports_error
@@ -2838,7 +3107,14 @@ test_reply_image_path_errors_are_clear
 test_reply_followup_live_posts_to_followup_endpoint
 test_reply_followup_409_marker_exits_distinctly
 test_reply_followup_409_without_marker_still_exits_distinctly
-test_reply_answer_409_is_generic_failure
+test_reply_answer_409_is_unresolved
+test_reply_answers_one_request_id_once
+test_reply_unconfirmed_answer_claim_refuses_as_unresolved
+test_reply_failed_answer_stays_retryable
+test_reply_ambiguous_transport_failure_holds_answer_claim
+test_reply_unreadable_payload_is_pretransmission_failure
+test_reply_failed_answer_reports_unreleased_claim
+test_reply_answer_claim_spares_followups_and_dry_runs
 test_reply_followup_image_live_posts_image_object
 test_reply_followup_flag_position_is_flexible
 test_reply_followup_dry_run_marks_endpoint


### PR DESCRIPTION
## Summary

Makes relay mention delivery at least once instead of silently dropping a mention if the poll stops after claiming its marker but before the watcher receives its wake.

The poll now records an un-emitted claim, writes the wake, and only then marks delivery complete.
A later poll re-offers an un-emitted claim.

Because a repeated wake is now possible, the initial answer path records and confirms one durable answer claim per request ID.
This prevents a duplicate public answer while allowing definite failures to remain retryable.

## Validation

- `bin/fm-test-run.sh tests/fm-x-mode.test.sh`
- `bin/fm-lint.sh`
- `bin/fm-doc-audience-check.sh`
- `git diff --check upstream/main...HEAD`
