### PR TITLE
fix(bin): attest existing Captain's Call references

### DIFF
--- a/.agents/skills/decision-hold-lifecycle/SKILL.md
+++ b/.agents/skills/decision-hold-lifecycle/SKILL.md
@@ -16,8 +16,10 @@ This skill is the single policy owner for unresolved captain decisions discovere
 
 Every unresolved decision that belongs to the captain and is discovered while producing, reading, presenting, or ending an investigation or visual review must become a structured captain-held work item in the authoritative backlog of the home that owns the originating work before that work or review may be treated as complete.
 The agent performs the semantic inventory because scripts must not infer decisions from report prose, visual-review artifacts, terminal output, or chat.
-Give each distinct unresolved decision a stable privacy-safe key, register it through `bin/fm-decision-hold.sh hold`, and use the same key on retry so registration is idempotent while different decisions retain different durable identities.
-After inventorying the whole report and review surface, run `bin/fm-decision-hold.sh complete` with every unresolved key, or with `--none` only when the reviewed surface contains no unresolved captain decision.
+Give each distinct unresolved decision that lacks a durable item a stable privacy-safe key, register it through `bin/fm-decision-hold.sh hold`, and use the same key on retry so registration is idempotent while different decisions retain different durable identities.
+When the same unresolved choice is already an active structured Captain's Call item in the authoritative backlog, completion explicitly attests that existing task identity instead of duplicating or mutating it.
+Completed work, ordinary queued or parked work, external holds, and non-captain items are never eligible existing decision identities.
+After inventorying the whole report and review surface, run `bin/fm-decision-hold.sh complete` with every newly registered key and every eligible existing identity, or explicitly attest no decisions only when the reviewed surface contains no unresolved captain decision.
 A completed investigation and an ended visual review use this same owner and completion command; a visual tool, including Lavish, never owns a parallel completion policy.
 Run the command in the originating work's authoritative `FM_HOME`; main-home work creates main-home holds, and secondmate-owned work creates holds in that secondmate home's backlog rather than copying them into the main backlog.
 Do not close a hold merely because the originating investigation completed, its report was archived, its visual review ended, or its task was torn down.
@@ -29,8 +31,8 @@ Bearings reads the resulting structured state and must never compensate by scrap
 
 1. Read the complete investigation result and complete the visual review before declaring either complete.
 2. Inventory only genuine unresolved choices that require the captain.
-3. For each choice, choose a stable key and use the script's `hold` command with a concise title, reason, and repository.
-4. Run the script's `complete` command with the full unresolved-key inventory for that review pass.
+3. For each choice, either choose a stable key and use the script's `hold` command with a concise title, reason, and repository, or identify its eligible existing structured task identity.
+4. Run the script's `complete` command with the full new-key and existing-identity inventory for that review pass.
 5. Relay the choices to the captain as decisions from Bearings' Captain's Call section under `AGENTS.md` section 9; do not use the word hold in captain chat.
 6. After the captain decides, record dependent work with normal tasks-axi commands and block it by the hold identity.
 7. Put the captain's exact durable decision in a file and use the script's `resolve` command with every routed task.

--- a/.agents/skills/decision-hold-lifecycle/SKILL.md
+++ b/.agents/skills/decision-hold-lifecycle/SKILL.md
@@ -38,5 +38,5 @@ Bearings reads the resulting structured state and must never compensate by scrap
 7. Put the captain's exact durable decision in a file and use the script's `resolve` command with every routed task.
 8. Confirm Bearings no longer shows the closed hold and that routed work remains in structured backlog state.
 
-`bin/fm-decision-hold.sh --help` owns command syntax, identity construction, completion attestation, retry behavior, and close ordering.
+`bin/fm-decision-hold.sh --help` owns exact command syntax.
 `docs/decision-hold-lifecycle.md` records the mechanism and regression evidence without restating this policy.

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -20,7 +20,8 @@
 #   fm-decision-hold.sh id <origin-id> <decision-key>
 #   fm-decision-hold.sh hold <origin-id> <decision-key> \
 #     --title <title> --reason <reason> [--repo <repo>]
-#   fm-decision-hold.sh complete <origin-id> (--none | <decision-key>...)
+#   fm-decision-hold.sh complete <origin-id> \
+#     (--none | <decision-key>... | --existing <task-id> [--existing <task-id>]...)
 #   fm-decision-hold.sh verify <origin-id>
 #   fm-decision-hold.sh resolve <origin-id> <decision-key> \
 #     --decision-file <path> --routed-to <task-id> [--routed-to <task-id>...]
@@ -30,6 +31,13 @@
 # no unresolved captain decision. Later review passes may add keys; a live task's
 # metadata inventory is unioned idempotently. A post-teardown visual review can
 # complete against the surviving report and holds without recreating task state.
+# `--existing <task-id>` explicitly reuses an unresolved structured Captain's
+# Call item already present in the active backlog, may repeat, and may accompany
+# current-origin decision keys. Existing references require live origin metadata
+# so `decision_refs=` can durably attest their exact identities. Completion
+# validates every reference before writing the attestation and never creates,
+# closes, or mutates a referenced task. `--none` cannot accompany keys or
+# existing references.
 # `verify` is read-only and is called by scout teardown so teardown cannot erase a
 # source before this gate has succeeded.
 #
@@ -170,6 +178,31 @@ verify_hold_active() {  # <hold-id>
   [ "$hold_kind" = captain ] || fail "backlog item $id is not held for the captain"
 }
 
+verify_existing_captain_call() {  # <task-id>
+  local id=$1 show state blocked blocked_by held kind hold_kind
+  show=$(task_show "$id") \
+    || fail "existing Captain's Call task $id does not exist in the active backlog $FM_HOME/data/backlog.md"
+  state=$(show_field "$show" state)
+  blocked=$(show_field "$show" blocked)
+  blocked_by=$(show_field "$show" blocked_by)
+  held=$(show_field "$show" held)
+  kind=$(show_field "$show" kind)
+  hold_kind=$(show_field "$show" hold_kind)
+  [ "$state" != "done" ] || fail "existing Captain's Call task $id is already completed"
+  case "$hold_kind" in
+    parked) fail "existing reference $id is ordinary parked work, not a Captain's Call item" ;;
+    external) fail "existing reference $id is an external hold, not a Captain's Call item" ;;
+  esac
+  [ "$kind" = captain ] || fail "existing reference $id is not kind captain (kind=$kind)"
+  [ "$held" = yes ] || fail "existing captain item $id is not actively held"
+  [ "$hold_kind" = captain ] \
+    || fail "existing captain item $id is not held for the captain (hold_kind=$hold_kind)"
+  [ "$state" = queued ] \
+    || fail "existing captain item $id is not queued Captain's Call work (state=$state)"
+  [ "$blocked" = no ] \
+    || fail "existing captain item $id is blocked by $blocked_by and is not an actionable Captain's Call item"
+}
+
 verify_hold_resolved() {  # <hold-id>
   local id=$1 show state kind body
   show=$(task_show "$id") || return 1
@@ -275,7 +308,8 @@ command_hold() {
 }
 
 command_complete() {
-  local origin=${1:-} meta previous='' supplied='' keys='' key status_file open raw_open key_seen=0 has_meta=0
+  local origin=${1:-} meta previous='' previous_refs='' supplied='' supplied_refs=''
+  local keys='' refs='' new_refs='' key ref status_file open raw_open key_seen=0 has_meta=0 none_seen=0 detail=''
   [ "$#" -ge 2 ] || { usage >&2; exit 2; }
   validate_slug origin-id "$origin"
   shift
@@ -283,26 +317,59 @@ command_complete() {
   [ -f "$meta" ] && has_meta=1
   require_tasks_axi
   origin_exists_here "$origin" || fail "origin $origin is not owned by the active home $FM_HOME"
-  if [ "$#" -eq 1 ] && [ "$1" = --none ]; then
-    supplied=''
-  else
-    while [ "$#" -gt 0 ]; do
-      [ "$1" != --none ] || fail "--none cannot be combined with decision keys"
-      validate_slug decision-key "$1"
-      supplied="${supplied}${supplied:+ }$1"
-      shift
-    done
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --none)
+        [ "$none_seen" = 0 ] || fail "--none cannot be repeated"
+        none_seen=1
+        ;;
+      --existing)
+        shift
+        [ "$#" -gt 0 ] || fail "--existing requires a task identity"
+        case "$1" in
+          --none|--existing) fail "--existing requires a task identity before $1" ;;
+        esac
+        validate_slug existing-task-id "$1"
+        supplied_refs="${supplied_refs}${supplied_refs:+ }$1"
+        ;;
+      *)
+        validate_slug decision-key "$1"
+        supplied="${supplied}${supplied:+ }$1"
+        ;;
+    esac
+    shift
+  done
+  if [ "$none_seen" = 1 ] && { [ -n "$supplied" ] || [ -n "$supplied_refs" ]; }; then
+    fail "--none cannot be combined with decision keys or existing references"
+  fi
+  if [ -n "$supplied_refs" ] && [ "$has_meta" != 1 ]; then
+    fail "--existing requires live origin metadata so the reviewing origin can be durably attested: $meta"
   fi
   if [ "$has_meta" = 1 ]; then
     previous=$(meta_value "$meta" decision_keys)
+    previous_refs=$(meta_value "$meta" decision_refs)
   fi
   keys=$(sorted_key_union "$previous" "$supplied")
+  refs=$(sorted_key_union "$previous_refs" "$supplied_refs")
+  new_refs=$(sorted_key_union '' "$supplied_refs")
   if [ -n "$keys" ]; then
     while IFS= read -r key; do
       [ -n "$key" ] || continue
       verify_hold_durable "$(hold_id "$origin" "$key")"
     done <<EOF
 $(printf '%s\n' "$keys" | tr ',' '\n')
+EOF
+  fi
+  if [ -n "$refs" ]; then
+    while IFS= read -r ref; do
+      [ -n "$ref" ] || continue
+      if list_has_key "$new_refs" "$ref"; then
+        verify_existing_captain_call "$ref"
+      else
+        verify_hold_durable "$ref"
+      fi
+    done <<EOF
+$(printf '%s\n' "$refs" | tr ',' '\n')
 EOF
   fi
 
@@ -318,8 +385,12 @@ $open
 EOF
 
   if [ "$has_meta" = 1 ]; then
-    if [ "$(meta_value "$meta" decisions_reviewed)" != 1 ] || [ "$previous" != "$keys" ]; then
+    if [ "$(meta_value "$meta" decisions_reviewed)" != 1 ] \
+      || [ "$previous" != "$keys" ] || [ "$previous_refs" != "$refs" ]; then
       printf 'decisions_reviewed=1\ndecision_keys=%s\n' "$keys" >> "$meta"
+      if [ -n "$refs" ] || [ -n "$previous_refs" ]; then
+        printf 'decision_refs=%s\n' "$refs" >> "$meta"
+      fi
     fi
 
     # Transfer any still-open status decision to its durable backlog owner so the
@@ -334,11 +405,13 @@ $raw_open
 EOF
   fi
   : "$key_seen"
-  printf 'complete: %s decision inventory reviewed%s\n' "$origin" "${keys:+ ($keys)}"
+  detail=$keys
+  [ -z "$refs" ] || detail="${detail}${detail:+; }existing=$refs"
+  printf 'complete: %s decision inventory reviewed%s\n' "$origin" "${detail:+ ($detail)}"
 }
 
 command_verify() {
-  local origin=${1:-} meta reviewed keys key open
+  local origin=${1:-} meta reviewed keys refs key ref open
   [ "$#" -eq 1 ] || { usage >&2; exit 2; }
   validate_slug origin-id "$origin"
   meta="$STATE/$origin.meta"
@@ -347,12 +420,21 @@ command_verify() {
   reviewed=$(meta_value "$meta" decisions_reviewed)
   [ "$reviewed" = 1 ] || fail "origin $origin has no completed unresolved-decision inventory"
   keys=$(meta_value "$meta" decision_keys)
+  refs=$(meta_value "$meta" decision_refs)
   if [ -n "$keys" ]; then
     while IFS= read -r key; do
       [ -n "$key" ] || continue
       verify_hold_durable "$(hold_id "$origin" "$key")"
     done <<EOF
 $(printf '%s\n' "$keys" | tr ',' '\n')
+EOF
+  fi
+  if [ -n "$refs" ]; then
+    while IFS= read -r ref; do
+      [ -n "$ref" ] || continue
+      verify_hold_durable "$ref"
+    done <<EOF
+$(printf '%s\n' "$refs" | tr ',' '\n')
 EOF
   fi
   open=$(origin_open_decisions "$origin")

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -184,7 +184,7 @@ unresolved_blocker_ids() {
     esac
     if blocker_show=$(task_show "$blocker"); then
       blocker_state=$(show_field "$blocker_show" state)
-      [ "$blocker_state" = done ] && continue
+      [ "$blocker_state" = "done" ] && continue
     fi
     if ! list_has_key "$unresolved" "$blocker"; then
       unresolved="${unresolved}${unresolved:+,}$blocker"

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -21,7 +21,7 @@
 #   fm-decision-hold.sh hold <origin-id> <decision-key> \
 #     --title <title> --reason <reason> [--repo <repo>]
 #   fm-decision-hold.sh complete <origin-id> \
-#     (--none | <decision-key>... | --existing <task-id> [--existing <task-id>]...)
+#     (--none | (<decision-key> | --existing <task-id>)...)
 #   fm-decision-hold.sh verify <origin-id>
 #   fm-decision-hold.sh resolve <origin-id> <decision-key> \
 #     --decision-file <path> --routed-to <task-id> [--routed-to <task-id>...]
@@ -31,13 +31,6 @@
 # no unresolved captain decision. Later review passes may add keys; a live task's
 # metadata inventory is unioned idempotently. A post-teardown visual review can
 # complete against the surviving report and holds without recreating task state.
-# `--existing <task-id>` explicitly reuses an unresolved structured Captain's
-# Call item already present in the active backlog, may repeat, and may accompany
-# current-origin decision keys. Existing references require live origin metadata
-# so `decision_refs=` can durably attest their exact identities. Completion
-# validates every reference before writing the attestation and never creates,
-# closes, or mutates a referenced task. `--none` cannot accompany keys or
-# existing references.
 # `verify` is read-only and is called by scout teardown so teardown cannot erase a
 # source before this gate has succeeded.
 #

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -178,13 +178,36 @@ verify_hold_active() {  # <hold-id>
   [ "$hold_kind" = captain ] || fail "backlog item $id is not held for the captain"
 }
 
+unresolved_blocker_ids() {
+  local deps=$1 dep blocker blocker_show blocker_state unresolved=''
+  deps=$(printf '%s' "$deps" | tr -d '[:space:]')
+  deps=${deps#\"}
+  deps=${deps%\"}
+  [ "$deps" != none ] || return 0
+  while IFS= read -r dep; do
+    case "$dep" in
+      blocked-by:*) blocker=${dep#blocked-by:} ;;
+      *) continue ;;
+    esac
+    if blocker_show=$(task_show "$blocker"); then
+      blocker_state=$(show_field "$blocker_show" state)
+      [ "$blocker_state" = done ] && continue
+    fi
+    if ! list_has_key "$unresolved" "$blocker"; then
+      unresolved="${unresolved}${unresolved:+,}$blocker"
+    fi
+  done <<EOF
+$(printf '%s\n' "$deps" | tr ',' '\n')
+EOF
+  printf '%s' "$unresolved"
+}
+
 verify_existing_captain_call() {  # <task-id>
-  local id=$1 show state blocked blocked_by held kind hold_kind
+  local id=$1 show state deps unresolved held kind hold_kind
   show=$(task_show "$id") \
     || fail "existing Captain's Call task $id does not exist in the active backlog $FM_HOME/data/backlog.md"
   state=$(show_field "$show" state)
-  blocked=$(show_field "$show" blocked)
-  blocked_by=$(show_field "$show" blocked_by)
+  deps=$(show_field "$show" deps)
   held=$(show_field "$show" held)
   kind=$(show_field "$show" kind)
   hold_kind=$(show_field "$show" hold_kind)
@@ -199,8 +222,31 @@ verify_existing_captain_call() {  # <task-id>
     || fail "existing captain item $id is not held for the captain (hold_kind=$hold_kind)"
   [ "$state" = queued ] \
     || fail "existing captain item $id is not queued Captain's Call work (state=$state)"
-  [ "$blocked" = no ] \
-    || fail "existing captain item $id is blocked by $blocked_by and is not an actionable Captain's Call item"
+  unresolved=$(unresolved_blocker_ids "$deps")
+  [ -z "$unresolved" ] \
+    || fail "existing captain item $id is blocked by $unresolved and is not an actionable Captain's Call item"
+}
+
+publish_completion_attestation() {
+  local meta=$1 keys=$2 refs=$3 tmp
+  tmp=$(mktemp "${meta%/*}/.${meta##*/}.decision-hold.XXXXXX") \
+    || fail "could not prepare completion attestation for $meta"
+  if ! cp "$meta" "$tmp"; then
+    rm -f "$tmp"
+    fail "could not prepare completion attestation for $meta"
+  fi
+  if ! {
+    printf 'decision_keys=%s\n' "$keys"
+    [ -z "$refs" ] || printf 'decision_refs=%s\n' "$refs"
+    printf 'decisions_reviewed=1\n'
+  } >> "$tmp"; then
+    rm -f "$tmp"
+    fail "could not write completion attestation for $meta"
+  fi
+  if ! mv -f "$tmp" "$meta"; then
+    rm -f "$tmp"
+    fail "could not publish completion attestation for $meta"
+  fi
 }
 
 verify_hold_resolved() {  # <hold-id>
@@ -387,10 +433,7 @@ EOF
   if [ "$has_meta" = 1 ]; then
     if [ "$(meta_value "$meta" decisions_reviewed)" != 1 ] \
       || [ "$previous" != "$keys" ] || [ "$previous_refs" != "$refs" ]; then
-      printf 'decisions_reviewed=1\ndecision_keys=%s\n' "$keys" >> "$meta"
-      if [ -n "$refs" ] || [ -n "$previous_refs" ]; then
-        printf 'decision_refs=%s\n' "$refs" >> "$meta"
-      fi
+      publish_completion_attestation "$meta" "$keys" "$refs"
     fi
 
     # Transfer any still-open status decision to its durable backlog owner so the

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -13,11 +13,11 @@ The `hold` subcommand maps an originating work id and stable decision key to `<o
 It creates a kind `captain` backlog item when absent and invokes `tasks-axi hold <id> --reason <reason> --kind captain` on every retry.
 It rejects an identity collision, a changed title, and attempts to reopen an already resolved identity.
 
-The `complete` subcommand unions the reviewed keys into `decision_keys=` and appends `decisions_reviewed=1` while originating task metadata is live.
+The `complete` subcommand unions the reviewed keys into `decision_keys=` and publishes the complete attestation through a same-directory atomic metadata replacement while originating task metadata is live.
 A repeated `--existing <task-id>` option lets the reviewing origin attest an active structured Captain's Call item that already exists under a formal earlier identity or an arbitrary legacy structured identity.
-It validates every explicit identity from the active authoritative backlog before writing and unions exact identities into `decision_refs=` so retries are deterministic and idempotent.
+It validates every explicit identity and raw `blocked-by` edge from the active authoritative backlog before writing and unions exact identities into `decision_refs=` so retries are deterministic and idempotent.
 An existing reference must be queued, unblocked, actively held, kind `captain`, and hold-kind `captain`.
-Missing, malformed, completed, non-captain, ordinary parked, external-hold, blocked, and mixed invalid reference sets fail before attestation.
+Missing, malformed, completed, non-captain, inactive, non-queued, ordinary parked, external-hold, blocked, dangling-blocked, and mixed invalid reference sets fail before attestation.
 Existing-reference completion never invokes a backlog mutation, so each referenced task keeps its identity, title, body, dependencies, and open state and no duplicate task is created.
 The `config/backlog-backend=manual` setting retains the contract owned by `docs/configuration.md`; explicit reference validation reads the manually maintained structured backlog through compatible tasks-axi without mutating it.
 A post-teardown visual review can complete against the surviving report and durable holds without recreating volatile task metadata.
@@ -51,12 +51,13 @@ Verification date: 2026-07-14.
 Additional quoted `blocked_by` regression verification date: 2026-07-17.
 Plural blocker-readiness and mixed-home projection verification date: 2026-07-22.
 Existing Captain's Call reference verification date: 2026-08-08.
+Failure-atomic and complete rejection-class verification date: 2026-08-09.
 
 The focused end-to-end regression uses only synthetic `sample` identities and decision text.
 It begins with a completed investigation and visual review whose genuine unresolved choice exists only in the report.
 The initial Bearings snapshot correctly has no open decision, and the new teardown gate refuses to erase the source.
 A later regression covers tasks-axi's quoted multi-entry `blocked_by` output so `resolve` matches the first, middle, and last ids and rejects a genuinely absent id.
-The existing-reference regression covers a formal earlier hold, an arbitrary legacy structured identity, multiple references, manual-backend validation, idempotent retry, byte-identical referenced rows, verification, teardown gating, and fail-closed invalid reference sets.
+The existing-reference regression covers a formal earlier hold, an arbitrary legacy structured identity, multiple references, manual-backend validation, idempotent retry, byte-identical referenced rows, verification, teardown gating, every invalid state including a dangling blocker, and interrupted attestation publication.
 
 The final verification commands and their exact summarized outputs follow.
 
@@ -66,7 +67,8 @@ ok - report-only unresolved decision is reproduced and completion refuses before
 ok - non-forced scout teardown always requires durable inventory verification
 ok - captain holds are idempotent, distinct, teardown-safe, Bearings-visible, and durably routed before close
 ok - existing formal and legacy Captain's Call references attest idempotently without backlog mutation
-ok - missing, malformed, done, unrelated, parked, external, blocked, and mixed existing references fail closed
+ok - all invalid existing-reference states fail closed without metadata or backlog mutation
+ok - completion attestation publishes atomically after an interrupted write
 ok - completion and verification validate origins before constructing paths
 ok - ended visual review follows the same decision-hold completion owner
 ok - resolved findings and decision-like prose do not create false holds

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -14,14 +14,14 @@ It creates a kind `captain` backlog item when absent and invokes `tasks-axi hold
 It rejects an identity collision, a changed title, and attempts to reopen an already resolved identity.
 
 The `complete` subcommand unions the reviewed keys into `decision_keys=` and publishes the complete attestation through a same-directory atomic metadata replacement while originating task metadata is live.
-A repeated `--existing <task-id>` option lets the reviewing origin attest an active structured Captain's Call item that already exists under a formal earlier identity or an arbitrary legacy structured identity.
+Repeated explicit existing task references may accompany current-origin decision keys and let a reviewing origin with live metadata attest an active structured Captain's Call item that already exists under a formal earlier identity or an arbitrary legacy structured identity.
 It validates every explicit identity and raw `blocked-by` edge from the active authoritative backlog before writing and unions exact identities into `decision_refs=` so retries are deterministic and idempotent.
 An existing reference must be queued, unblocked, actively held, kind `captain`, and hold-kind `captain`.
 Missing, malformed, completed, non-captain, inactive, non-queued, ordinary parked, external-hold, blocked, dangling-blocked, and mixed invalid reference sets fail before attestation.
 Existing-reference completion never invokes a backlog mutation, so each referenced task keeps its identity, title, body, dependencies, and open state and no duplicate task is created.
 The `config/backlog-backend=manual` setting retains the contract owned by `docs/configuration.md`; explicit reference validation reads the manually maintained structured backlog through compatible tasks-axi without mutating it.
 A post-teardown visual review can complete against the surviving report and durable holds without recreating volatile task metadata.
-It accepts `--none` as an explicit semantic inventory result, not as inferred absence.
+The no-decisions form records an explicit semantic inventory result, cannot accompany keys or existing references, and is never inferred from absence.
 It verifies every listed identity against tasks-axi before recording completion.
 For an open keyed status decision, it appends a `captain-held [key=<key>]: ...` transfer event only after the matching backlog hold is durable.
 `bin/fm-classify-lib.sh` recognizes that transfer as closing the live status copy without claiming that the captain has answered it.

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -14,6 +14,12 @@ It creates a kind `captain` backlog item when absent and invokes `tasks-axi hold
 It rejects an identity collision, a changed title, and attempts to reopen an already resolved identity.
 
 The `complete` subcommand unions the reviewed keys into `decision_keys=` and appends `decisions_reviewed=1` while originating task metadata is live.
+A repeated `--existing <task-id>` option lets the reviewing origin attest an active structured Captain's Call item that already exists under a formal earlier identity or an arbitrary legacy structured identity.
+It validates every explicit identity from the active authoritative backlog before writing and unions exact identities into `decision_refs=` so retries are deterministic and idempotent.
+An existing reference must be queued, unblocked, actively held, kind `captain`, and hold-kind `captain`.
+Missing, malformed, completed, non-captain, ordinary parked, external-hold, blocked, and mixed invalid reference sets fail before attestation.
+Existing-reference completion never invokes a backlog mutation, so each referenced task keeps its identity, title, body, dependencies, and open state and no duplicate task is created.
+The `config/backlog-backend=manual` setting retains the contract owned by `docs/configuration.md`; explicit reference validation reads the manually maintained structured backlog through compatible tasks-axi without mutating it.
 A post-teardown visual review can complete against the surviving report and durable holds without recreating volatile task metadata.
 It accepts `--none` as an explicit semantic inventory result, not as inferred absence.
 It verifies every listed identity against tasks-axi before recording completion.
@@ -21,6 +27,7 @@ For an open keyed status decision, it appends a `captain-held [key=<key>]: ...` 
 `bin/fm-classify-lib.sh` recognizes that transfer as closing the live status copy without claiming that the captain has answered it.
 
 Scout teardown calls the script's read-only `verify` subcommand after checking for the report and before removing any source state.
+Verification checks both deterministic current-origin keys and exact existing task references against their durable structured state.
 The `--force` path remains the explicit captain-approved discard escape hatch.
 
 The `resolve` subcommand requires a decision file and at least one existing dependent task whose structured `blocked-by` edge points to the hold.
@@ -43,11 +50,13 @@ The projection remains read-only and does not inspect historical prose.
 Verification date: 2026-07-14.
 Additional quoted `blocked_by` regression verification date: 2026-07-17.
 Plural blocker-readiness and mixed-home projection verification date: 2026-07-22.
+Existing Captain's Call reference verification date: 2026-08-08.
 
 The focused end-to-end regression uses only synthetic `sample` identities and decision text.
 It begins with a completed investigation and visual review whose genuine unresolved choice exists only in the report.
 The initial Bearings snapshot correctly has no open decision, and the new teardown gate refuses to erase the source.
 A later regression covers tasks-axi's quoted multi-entry `blocked_by` output so `resolve` matches the first, middle, and last ids and rejects a genuinely absent id.
+The existing-reference regression covers a formal earlier hold, an arbitrary legacy structured identity, multiple references, manual-backend validation, idempotent retry, byte-identical referenced rows, verification, teardown gating, and fail-closed invalid reference sets.
 
 The final verification commands and their exact summarized outputs follow.
 
@@ -56,6 +65,8 @@ $ bash tests/fm-decision-hold-lifecycle.test.sh
 ok - report-only unresolved decision is reproduced and completion refuses before loss
 ok - non-forced scout teardown always requires durable inventory verification
 ok - captain holds are idempotent, distinct, teardown-safe, Bearings-visible, and durably routed before close
+ok - existing formal and legacy Captain's Call references attest idempotently without backlog mutation
+ok - missing, malformed, done, unrelated, parked, external, blocked, and mixed existing references fail closed
 ok - completion and verification validate origins before constructing paths
 ok - ended visual review follows the same decision-hold completion owner
 ok - resolved findings and decision-like prose do not create false holds

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -350,7 +350,8 @@ test_existing_captain_call_references_attest_without_mutation() {
 }
 
 test_existing_captain_call_reference_rejections_fail_closed() {
-  local home origin valid done_ref noncaptain parked external blocker blocked_ref backlog_before backlog_after
+  local home origin valid done_ref noncaptain parked external inactive nonqueued blocker blocked_ref
+  local dangling_blocker dangling_ref dangling_missing missing_meta_origin show meta_before meta_after backlog_before backlog_after
   home=$(make_home invalid-existing-captain-call-references)
   origin=sample-invalid-reference-review
   mkdir -p "$home/data/$origin"
@@ -375,14 +376,48 @@ test_existing_captain_call_reference_rejections_fail_closed() {
   external=sample-external-hold
   tasks_in "$home" add "$external" "External hold" --kind scout --repo sample >/dev/null
   tasks_in "$home" hold "$external" --reason "upstream release pending" --kind external >/dev/null
+  inactive=sample-inactive-captain-call
+  tasks_in "$home" add "$inactive" "Inactive captain call" --kind captain --repo sample >/dev/null
+  nonqueued=sample-nonqueued-captain-call
+  tasks_in "$home" add "$nonqueued" "Non-queued captain call" --kind captain --repo sample >/dev/null
+  tasks_in "$home" hold "$nonqueued" --reason "captain non-queued choice pending" --kind captain >/dev/null
+  tasks_in "$home" start "$nonqueued" >/dev/null
   blocker=sample-captain-call-prerequisite
   tasks_in "$home" add "$blocker" "Captain call prerequisite" --kind ship --repo sample >/dev/null
   blocked_ref=sample-blocked-captain-call
   tasks_in "$home" add "$blocked_ref" "Blocked captain call" --kind captain --repo sample >/dev/null
   tasks_in "$home" hold "$blocked_ref" --reason "captain blocked choice pending" --kind captain >/dev/null
   tasks_in "$home" block "$blocked_ref" --by "$blocker" >/dev/null
+  dangling_blocker=sample-dangling-prerequisite
+  tasks_in "$home" add "$dangling_blocker" "Dangling prerequisite source" --kind ship --repo sample >/dev/null
+  dangling_ref=sample-dangling-captain-call
+  tasks_in "$home" add "$dangling_ref" "Dangling-blocked captain call" --kind captain --repo sample >/dev/null
+  tasks_in "$home" hold "$dangling_ref" --reason "captain dangling choice pending" --kind captain >/dev/null
+  tasks_in "$home" block "$dangling_ref" --by "$dangling_blocker" >/dev/null
+  dangling_missing=sample-missing-prerequisite
+  sed "s/blocked-by: $dangling_blocker/blocked-by: $dangling_missing/" \
+    "$home/data/backlog.md" > "$home/data/backlog.next"
+  mv "$home/data/backlog.next" "$home/data/backlog.md"
+  show=$(tasks_in "$home" show "$dangling_ref" --full)
+  assert_contains "$show" "blocked: no" "dangling-blocker fixture must expose tasks-axi's resolved projection"
+  assert_contains "$show" "blocked-by:$dangling_missing" \
+    "dangling-blocker fixture must retain the authoritative dependency edge"
+  show=$(tasks_in "$home" show "$nonqueued" --full)
+  assert_contains "$show" "state: in_flight" "non-queued fixture must remain outside the queued section"
+  assert_contains "$show" "held: yes" "non-queued fixture must retain its active captain hold"
+  missing_meta_origin=sample-missing-metadata-review
+  tasks_in "$home" add "$missing_meta_origin" "Review without live metadata" --kind scout --repo sample >/dev/null
 
+  meta_before=$(shasum -a 256 "$home/state/$origin.meta" | awk '{print $1}')
   backlog_before=$(shasum -a 256 "$home/data/backlog.md" | awk '{print $1}')
+  if run_decisions "$home" complete "$missing_meta_origin" --existing "$valid" \
+    > "$home/missing-meta.out" 2> "$home/missing-meta.err"; then
+    fail "completion accepted an existing reference without live reviewing-origin metadata"
+  fi
+  assert_grep "requires live origin metadata" "$home/missing-meta.err" \
+    "missing live reviewing-origin metadata did not produce actionable output"
+  [ ! -e "$home/state/$missing_meta_origin.meta" ] \
+    || fail "missing-metadata rejection created reviewing-origin metadata"
   if run_decisions "$home" complete "$origin" --existing sample-missing-captain-call \
     > "$home/missing.out" 2> "$home/missing.err"; then
     fail "completion accepted a missing existing reference"
@@ -419,12 +454,30 @@ test_existing_captain_call_reference_rejections_fail_closed() {
   fi
   assert_grep "is an external hold" "$home/external.err" \
     "external-hold existing reference did not produce actionable output"
+  if run_decisions "$home" complete "$origin" --existing "$inactive" \
+    > "$home/inactive.out" 2> "$home/inactive.err"; then
+    fail "completion accepted an inactive captain item"
+  fi
+  assert_grep "is not actively held" "$home/inactive.err" \
+    "inactive captain item did not produce actionable output"
+  if run_decisions "$home" complete "$origin" --existing "$nonqueued" \
+    > "$home/nonqueued.out" 2> "$home/nonqueued.err"; then
+    fail "completion accepted non-queued captain work"
+  fi
+  assert_grep "is not queued Captain's Call work" "$home/nonqueued.err" \
+    "non-queued captain work did not produce actionable output"
   if run_decisions "$home" complete "$origin" --existing "$blocked_ref" \
     > "$home/blocked.out" 2> "$home/blocked.err"; then
     fail "completion accepted a blocked captain item outside Captain's Call"
   fi
   assert_grep "is blocked by $blocker" "$home/blocked.err" \
     "blocked captain item did not produce actionable output"
+  if run_decisions "$home" complete "$origin" --existing "$dangling_ref" \
+    > "$home/dangling.out" 2> "$home/dangling.err"; then
+    fail "completion accepted a captain item with a dangling blocker"
+  fi
+  assert_grep "is blocked by $dangling_missing" "$home/dangling.err" \
+    "dangling blocker did not follow canonical unresolved dependency semantics"
   if run_decisions "$home" complete "$origin" --existing "$valid" --existing "$external" \
     > "$home/mixed.out" 2> "$home/mixed.err"; then
     fail "completion accepted mixed valid and invalid existing references"
@@ -446,12 +499,80 @@ test_existing_captain_call_reference_rejections_fail_closed() {
 
   assert_no_grep "decisions_reviewed=1" "$home/state/$origin.meta" \
     "a rejected existing-reference set recorded completion"
+  meta_after=$(shasum -a 256 "$home/state/$origin.meta" | awk '{print $1}')
+  [ "$meta_before" = "$meta_after" ] \
+    || fail "rejected existing references changed reviewing-origin metadata"
   backlog_after=$(shasum -a 256 "$home/data/backlog.md" | awk '{print $1}')
   [ "$backlog_before" = "$backlog_after" ] \
     || fail "rejected existing references created or mutated backlog work"
   run_decisions "$home" verify "$origin" > "$home/unattested-verify.out" 2> "$home/unattested-verify.err" \
     && fail "verify accepted an origin after every existing-reference completion was rejected"
-  pass "missing, malformed, done, unrelated, parked, external, blocked, and mixed existing references fail closed"
+  pass "all invalid existing-reference states fail closed without metadata or backlog mutation"
+}
+
+test_completion_attestation_publication_is_failure_atomic() {
+  local home origin existing meta_before meta_after backlog_before backlog_after
+  home=$(make_home atomic-existing-reference-attestation)
+  origin=sample-atomic-reference-review
+  tasks_in "$home" add "$origin" "Review atomic reference publication" --kind scout --repo sample --start >/dev/null
+  write_origin_meta "$home" "$origin"
+  printf 'done: report complete\n' > "$home/state/$origin.status"
+  existing=sample-atomic-captain-call
+  tasks_in "$home" add "$existing" "Atomic captain call" --kind captain --repo sample >/dev/null
+  tasks_in "$home" hold "$existing" --reason "captain atomic choice pending" --kind captain >/dev/null
+  cat > "$home/fakebin/mv" <<'EOF'
+#!/usr/bin/env bash
+last=''
+for arg in "$@"; do last=$arg; done
+case "$last" in
+  */state/*.meta)
+    if [ ! -e "$FM_HOME/meta-publish-failed-once" ]; then
+      : > "$FM_HOME/meta-publish-failed-once"
+      exit 91
+    fi
+    ;;
+esac
+exec /bin/mv "$@"
+EOF
+  chmod +x "$home/fakebin/mv"
+
+  meta_before=$(shasum -a 256 "$home/state/$origin.meta" | awk '{print $1}')
+  backlog_before=$(shasum -a 256 "$home/data/backlog.md" | awk '{print $1}')
+  if run_decisions "$home" complete "$origin" --existing "$existing" \
+    > "$home/interrupted.out" 2> "$home/interrupted.err"; then
+    fail "completion succeeded after interrupted attestation publication"
+  fi
+  assert_grep "could not publish completion attestation" "$home/interrupted.err" \
+    "interrupted attestation publication did not fail actionably"
+  meta_after=$(shasum -a 256 "$home/state/$origin.meta" | awk '{print $1}')
+  [ "$meta_before" = "$meta_after" ] \
+    || fail "interrupted attestation publication exposed partial metadata"
+  assert_no_grep "decisions_reviewed=" "$home/state/$origin.meta" \
+    "interrupted attestation publication exposed the reviewed marker"
+  assert_no_grep "decision_refs=" "$home/state/$origin.meta" \
+    "interrupted attestation publication exposed references"
+  if find "$home/state" -name ".$origin.meta.decision-hold.*" -print | grep . >/dev/null; then
+    fail "interrupted attestation publication left a temporary metadata file"
+  fi
+  if run_decisions "$home" verify "$origin" \
+    > "$home/interrupted-verify.out" 2> "$home/interrupted-verify.err"; then
+    fail "verify accepted interrupted attestation publication"
+  fi
+  backlog_after=$(shasum -a 256 "$home/data/backlog.md" | awk '{print $1}')
+  [ "$backlog_before" = "$backlog_after" ] \
+    || fail "interrupted attestation publication mutated the backlog"
+
+  run_decisions "$home" complete "$origin" --existing "$existing" >/dev/null \
+    || fail "attestation publication did not recover on retry"
+  assert_grep "decision_keys=" "$home/state/$origin.meta" \
+    "successful retry omitted the current-origin key inventory"
+  assert_grep "decision_refs=$existing" "$home/state/$origin.meta" \
+    "successful retry omitted the existing reference"
+  assert_grep "decisions_reviewed=1" "$home/state/$origin.meta" \
+    "successful retry omitted the reviewed marker"
+  run_decisions "$home" verify "$origin" >/dev/null \
+    || fail "verify rejected the atomically published attestation"
+  pass "completion attestation publishes atomically after an interrupted write"
 }
 
 test_scout_teardown_always_requires_inventory_verification() {
@@ -734,6 +855,7 @@ test_scout_teardown_always_requires_inventory_verification
 test_structured_holds_survive_teardown_and_route_resolution
 test_existing_captain_call_references_attest_without_mutation
 test_existing_captain_call_reference_rejections_fail_closed
+test_completion_attestation_publication_is_failure_atomic
 test_origin_slug_validation_precedes_path_construction
 test_visual_review_uses_shared_completion_owner
 test_none_inventory_and_resolved_prose_do_not_create_holds

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -276,6 +276,184 @@ EOF
   pass "captain holds are idempotent, distinct, teardown-safe, Bearings-visible, and durably routed before close"
 }
 
+test_existing_captain_call_references_attest_without_mutation() {
+  local home origin formal legacy dependent backlog_before backlog_after
+  local formal_before formal_after legacy_before legacy_after meta_after_first meta_after_retry
+  home=$(make_home existing-captain-call-references)
+  origin=sample-followup-review
+  mkdir -p "$home/data/$origin"
+  tasks_in "$home" add "$origin" "Review earlier captain decisions" --kind scout --repo sample --start >/dev/null \
+    || fail "could not create existing-reference origin"
+  write_origin_meta "$home" "$origin"
+  printf 'done: report and visual review complete\n' > "$home/state/$origin.status"
+  printf '# Follow-up review\n\nTwo earlier captain decisions remain unresolved.\n' > "$home/data/$origin/report.md"
+
+  tasks_in "$home" add sample-earlier-review "Earlier formal review" --kind scout --repo sample --start >/dev/null \
+    || fail "could not create formal hold origin"
+  formal=$(run_decisions "$home" hold sample-earlier-review route \
+    --title "Choose the earlier sample route" --reason "captain earlier route pending" --repo sample) \
+    || fail "could not create formal earlier captain hold"
+  legacy='legacy-sample-captain-call'
+  tasks_in "$home" add "$legacy" "Choose the legacy sample route" --kind captain --repo sample \
+    --body "Legacy structured Captain's Call body." >/dev/null \
+    || fail "could not create legacy structured captain item"
+  tasks_in "$home" hold "$legacy" --reason "captain legacy route pending" --kind captain >/dev/null \
+    || fail "could not activate legacy structured captain item"
+  dependent=sample-existing-reference-dependent
+  tasks_in "$home" add "$dependent" "Use the earlier captain decision" --kind ship --repo sample \
+    --blocked-by "$formal" >/dev/null \
+    || fail "could not create existing-reference dependent"
+
+  printf 'manual\n' > "$home/config/backlog-backend"
+  backlog_before=$(shasum -a 256 "$home/data/backlog.md" | awk '{print $1}')
+  formal_before=$(tasks_in "$home" show "$formal" --full)
+  legacy_before=$(tasks_in "$home" show "$legacy" --full)
+  run_decisions "$home" complete "$origin" --existing "$formal" --existing "$legacy" >/dev/null \
+    || fail "could not attest formal and legacy existing captain references"
+  backlog_after=$(shasum -a 256 "$home/data/backlog.md" | awk '{print $1}')
+  formal_after=$(tasks_in "$home" show "$formal" --full)
+  legacy_after=$(tasks_in "$home" show "$legacy" --full)
+  [ "$backlog_before" = "$backlog_after" ] \
+    || fail "existing-reference completion mutated the authoritative backlog"
+  [ "$formal_before" = "$formal_after" ] \
+    || fail "existing-reference completion mutated the formal captain hold"
+  [ "$legacy_before" = "$legacy_after" ] \
+    || fail "existing-reference completion mutated the legacy captain hold"
+  assert_grep "decisions_reviewed=1" "$home/state/$origin.meta" \
+    "existing-reference completion attestation missing"
+  assert_grep "decision_keys=" "$home/state/$origin.meta" \
+    "existing-reference completion changed the current-origin key contract"
+  assert_grep "decision_refs=$legacy,$formal" "$home/state/$origin.meta" \
+    "existing-reference identities were not recorded deterministically"
+  [ "$(grep -cE "^- \[ \] $formal -" "$home/data/backlog.md")" = 1 ] \
+    || fail "existing-reference completion duplicated the formal captain hold"
+  [ "$(grep -cE "^- \[ \] $legacy -" "$home/data/backlog.md")" = 1 ] \
+    || fail "existing-reference completion duplicated the legacy captain hold"
+
+  meta_after_first=$(shasum -a 256 "$home/state/$origin.meta" | awk '{print $1}')
+  run_decisions "$home" complete "$origin" --existing "$legacy" --existing "$formal" --existing "$formal" >/dev/null \
+    || fail "idempotent existing-reference retry failed"
+  meta_after_retry=$(shasum -a 256 "$home/state/$origin.meta" | awk '{print $1}')
+  [ "$meta_after_first" = "$meta_after_retry" ] \
+    || fail "idempotent existing-reference retry appended a duplicate attestation"
+  run_decisions "$home" verify "$origin" >/dev/null \
+    || fail "verify rejected the existing-reference completion attestation"
+  run_teardown "$home" "$origin" >/dev/null 2> "$home/existing-reference-teardown.err" \
+    || fail "teardown rejected existing-reference completion: $(cat "$home/existing-reference-teardown.err")"
+  formal_after=$(tasks_in "$home" show "$formal" --full)
+  legacy_after=$(tasks_in "$home" show "$legacy" --full)
+  [ "$formal_before" = "$formal_after" ] \
+    || fail "teardown after existing-reference verification mutated the formal captain hold"
+  [ "$legacy_before" = "$legacy_after" ] \
+    || fail "teardown after existing-reference verification mutated the legacy captain hold"
+  pass "existing formal and legacy Captain's Call references attest idempotently without backlog mutation"
+}
+
+test_existing_captain_call_reference_rejections_fail_closed() {
+  local home origin valid done_ref noncaptain parked external blocker blocked_ref backlog_before backlog_after
+  home=$(make_home invalid-existing-captain-call-references)
+  origin=sample-invalid-reference-review
+  mkdir -p "$home/data/$origin"
+  tasks_in "$home" add "$origin" "Review invalid existing references" --kind scout --repo sample --start >/dev/null \
+    || fail "could not create invalid-reference origin"
+  write_origin_meta "$home" "$origin"
+  printf 'done: report complete\n' > "$home/state/$origin.status"
+  printf '# Invalid reference review\n\nOnly synthetic rejection controls.\n' > "$home/data/$origin/report.md"
+
+  tasks_in "$home" add sample-valid-earlier "Valid earlier origin" --kind scout --repo sample --start >/dev/null
+  valid=$(run_decisions "$home" hold sample-valid-earlier route \
+    --title "Choose a valid earlier route" --reason "captain valid route pending" --repo sample)
+  done_ref=sample-done-captain-call
+  tasks_in "$home" add "$done_ref" "Completed captain call" --kind captain --repo sample >/dev/null
+  tasks_in "$home" hold "$done_ref" --reason "captain completed choice" --kind captain >/dev/null
+  tasks_in "$home" "done" "$done_ref" >/dev/null
+  noncaptain=sample-ordinary-queued-work
+  tasks_in "$home" add "$noncaptain" "Ordinary queued work" --kind ship --repo sample >/dev/null
+  parked=sample-ordinary-parked-work
+  tasks_in "$home" add "$parked" "Ordinary parked work" --kind ship --repo sample --start >/dev/null
+  tasks_in "$home" hold "$parked" --reason "ordinary work parked" --kind parked >/dev/null
+  external=sample-external-hold
+  tasks_in "$home" add "$external" "External hold" --kind scout --repo sample >/dev/null
+  tasks_in "$home" hold "$external" --reason "upstream release pending" --kind external >/dev/null
+  blocker=sample-captain-call-prerequisite
+  tasks_in "$home" add "$blocker" "Captain call prerequisite" --kind ship --repo sample >/dev/null
+  blocked_ref=sample-blocked-captain-call
+  tasks_in "$home" add "$blocked_ref" "Blocked captain call" --kind captain --repo sample >/dev/null
+  tasks_in "$home" hold "$blocked_ref" --reason "captain blocked choice pending" --kind captain >/dev/null
+  tasks_in "$home" block "$blocked_ref" --by "$blocker" >/dev/null
+
+  backlog_before=$(shasum -a 256 "$home/data/backlog.md" | awk '{print $1}')
+  if run_decisions "$home" complete "$origin" --existing sample-missing-captain-call \
+    > "$home/missing.out" 2> "$home/missing.err"; then
+    fail "completion accepted a missing existing reference"
+  fi
+  assert_grep "does not exist in the active backlog" "$home/missing.err" \
+    "missing existing reference did not produce actionable output"
+  if run_decisions "$home" complete "$origin" --existing 'malformed/reference' \
+    > "$home/malformed.out" 2> "$home/malformed.err"; then
+    fail "completion accepted a malformed existing reference"
+  fi
+  assert_grep "existing-task-id must be a non-empty privacy-safe slug" "$home/malformed.err" \
+    "malformed existing reference did not produce actionable output"
+  if run_decisions "$home" complete "$origin" --existing "$done_ref" \
+    > "$home/done.out" 2> "$home/done.err"; then
+    fail "completion accepted a completed existing reference"
+  fi
+  assert_grep "is already completed" "$home/done.err" \
+    "completed existing reference did not produce actionable output"
+  if run_decisions "$home" complete "$origin" --existing "$noncaptain" \
+    > "$home/noncaptain.out" 2> "$home/noncaptain.err"; then
+    fail "completion accepted unrelated non-captain work"
+  fi
+  assert_grep "is not kind captain" "$home/noncaptain.err" \
+    "non-captain existing reference did not produce actionable output"
+  if run_decisions "$home" complete "$origin" --existing "$parked" \
+    > "$home/parked.out" 2> "$home/parked.err"; then
+    fail "completion accepted ordinary parked work"
+  fi
+  assert_grep "is ordinary parked work" "$home/parked.err" \
+    "parked existing reference did not produce actionable output"
+  if run_decisions "$home" complete "$origin" --existing "$external" \
+    > "$home/external.out" 2> "$home/external.err"; then
+    fail "completion accepted an external hold"
+  fi
+  assert_grep "is an external hold" "$home/external.err" \
+    "external-hold existing reference did not produce actionable output"
+  if run_decisions "$home" complete "$origin" --existing "$blocked_ref" \
+    > "$home/blocked.out" 2> "$home/blocked.err"; then
+    fail "completion accepted a blocked captain item outside Captain's Call"
+  fi
+  assert_grep "is blocked by $blocker" "$home/blocked.err" \
+    "blocked captain item did not produce actionable output"
+  if run_decisions "$home" complete "$origin" --existing "$valid" --existing "$external" \
+    > "$home/mixed.out" 2> "$home/mixed.err"; then
+    fail "completion accepted mixed valid and invalid existing references"
+  fi
+  assert_grep "is an external hold" "$home/mixed.err" \
+    "mixed existing references did not identify the invalid member"
+  if run_decisions "$home" complete "$origin" --none --existing "$valid" \
+    > "$home/none-mixed.out" 2> "$home/none-mixed.err"; then
+    fail "completion combined --none with an existing reference"
+  fi
+  assert_grep "--none cannot be combined" "$home/none-mixed.err" \
+    "mixed --none and existing reference did not produce actionable output"
+  if run_decisions "$home" complete "$origin" --existing \
+    > "$home/missing-value.out" 2> "$home/missing-value.err"; then
+    fail "completion accepted --existing without a task identity"
+  fi
+  assert_grep "--existing requires a task identity" "$home/missing-value.err" \
+    "missing --existing value did not produce actionable output"
+
+  assert_no_grep "decisions_reviewed=1" "$home/state/$origin.meta" \
+    "a rejected existing-reference set recorded completion"
+  backlog_after=$(shasum -a 256 "$home/data/backlog.md" | awk '{print $1}')
+  [ "$backlog_before" = "$backlog_after" ] \
+    || fail "rejected existing references created or mutated backlog work"
+  run_decisions "$home" verify "$origin" > "$home/unattested-verify.out" 2> "$home/unattested-verify.err" \
+    && fail "verify accepted an origin after every existing-reference completion was rejected"
+  pass "missing, malformed, done, unrelated, parked, external, blocked, and mixed existing references fail closed"
+}
+
 test_scout_teardown_always_requires_inventory_verification() {
   local home id
   home=$(make_home unconditional-teardown)
@@ -554,6 +732,8 @@ test_uninventoried_report_decision_refuses_completion
 
 test_scout_teardown_always_requires_inventory_verification
 test_structured_holds_survive_teardown_and_route_resolution
+test_existing_captain_call_references_attest_without_mutation
+test_existing_captain_call_reference_rejections_fail_closed
 test_origin_slug_validation_precedes_path_construction
 test_visual_review_uses_shared_completion_owner
 test_none_inventory_and_resolved_prose_do_not_create_holds


### PR DESCRIPTION
## Intent

Fix the decision-hold completion lifecycle so a completed investigation or visual review can explicitly attest unresolved captain decisions already registered under earlier formal or legacy structured task identities, without duplicating, closing, or mutating those Captain's Call rows. Extend bin/fm-decision-hold.sh complete narrowly and fail closed with repeated explicit existing task identities; require live reviewing-origin metadata for durable, sorted, idempotent attestation; verify every newly referenced identity exists in the active authoritative backlog and is queued, unblocked, actively captain-held kind captain work; reject mixed invalid sets, missing or malformed identities, completed work, non-captain work, ordinary parked work, external holds, and blocked items with actionable errors before any attestation. Preserve referenced identity, title, body, dependencies, and open state, create no task, and preserve complete --none plus deterministic current-origin-key behavior. Keep verify and scout teardown compatible, retain the default tasks-axi and manual-backend contracts, and never weaken the rule that decisions must already be durable before completion. Cover a pre-existing formal hold, an arbitrary legacy structured hold, idempotent retry, multiple holds, every rejection class, absence of duplicate creation or mutation, unchanged existing flows, successful verify, and teardown gating. Keep exact syntax in the script header and help, policy only in the decision-hold skill, mechanism and regression evidence in the decision-hold document, do not change AGENTS.md, use one sentence per Markdown line and plain dashes, and add no agent co-author. The local focused, documentation, lint, coverage, and lifecycle suites are green; an unrelated Muse detection test fails only in the outer Codex process environment, so classify or correct it within pipeline isolation. Use branch fm/decision-hold-existing-reference, push and open a PR, wait for green checks, and do not merge.

## What Changed

- Extend `complete` to accept repeated `--existing <task-id>` references alongside current-origin decision keys, recording sorted identities without creating or mutating referenced backlog items.
- Require live origin metadata and fail closed unless each new reference is queued, unblocked, actively captain-held work, then publish the completion attestation atomically and verify references during teardown.
- Update lifecycle policy, mechanism documentation, and regression coverage for formal and legacy references, retries, invalid states, verification, and teardown gating.

## Risk Assessment

✅ Low: The follow-up changes close all three previously identified source defects: blocker eligibility now follows raw dependency semantics, completion metadata is published by one same-directory atomic replacement, and the missing rejection and interrupted-publication regressions are covered without broadening behavior.

## Testing

The focused lifecycle E2E suite and an independent manual-backend CLI walkthrough passed, covering help syntax, formal and legacy attestation, sorted idempotent metadata, preservation without duplication or mutation, all rejection classes, successful verify, and teardown gating; this is CLI-only behavior, so no visual artifact applies.

<details>
<summary>Evidence: Decision-hold existing-reference CLI walkthrough</summary>

`Shows sorted formal/legacy attestation, unchanged referenced tasks and backlog, successful verification, idempotent retry, and atomic rejection of an external hold.`

```text
=== Complete with two earlier Captain Calls (reverse input order) ===
complete: demo-followup-review decision inventory reviewed (existing=demo-earlier-review-decision-route,legacy-demo-captain-call)
=== Persisted reviewing-origin attestation ===
decision_keys=
decision_refs=demo-earlier-review-decision-route,legacy-demo-captain-call
decisions_reviewed=1
=== Referenced formal task after completion ===
task:
  id: demo-earlier-review-decision-route
  title: Choose the earlier sample route
  state: queued
  blocked: no
  blocked_by: none
  held: yes
  hold_reason: captain earlier route pending
  hold_kind: captain
  hold_until: "-"
  kind: captain
  repo: sample
  priority: "-"
  created: 2026-08-09
=== Referenced legacy task after completion ===
task:
  id: legacy-demo-captain-call
  title: Choose the legacy sample route
  state: queued
  blocked: no
  blocked_by: none
  held: yes
  hold_reason: captain legacy route pending
  hold_kind: captain
  hold_until: "-"
  kind: captain
  repo: sample
  priority: "-"
  created: 2026-08-09
preservation: backlog_sha256_unchanged=yes formal_projection_unchanged=yes legacy_projection_unchanged=yes formal_row_count=1 legacy_row_count=1
=== Verify attestation ===
verified: demo-followup-review unresolved-decision inventory
=== Idempotent retry with duplicate/reordered identities ===
complete: demo-followup-review decision inventory reviewed (existing=demo-earlier-review-decision-route,legacy-demo-captain-call)
retry: metadata_sha256_unchanged=yes
=== Mixed valid + external-hold rejection ===
exit=1
fm-decision-hold: existing reference demo-external-hold is an external hold, not a Captain's Call item
rejection_atomicity: metadata_sha256_unchanged=yes backlog_sha256_unchanged=yes
artifact_path=/var/folders/s8/0_mzgfjj34v2wr0gvxxh64n80000gn/T/no-mistakes-evidence/01KZFGD9NNPNX0SR6T3SJQH7JA/decision-hold-existing-reference.XXXXXX.txt
fixture_path=/var/folders/s8/0_mzgfjj34v2wr0gvxxh64n80000gn/T/no-mistakes-evidence/01KZFGD9NNPNX0SR6T3SJQH7JA/manual-existing-reference.V8hiI5
=== Full preserved formal task projection (identity/title/state/dependencies/body) ===
task:
  id: demo-earlier-review-decision-route
  title: Choose the earlier sample route
  state: queued
  blocked: no
  blocked_by: none
  held: yes
  hold_reason: captain earlier route pending
  hold_kind: captain
  hold_until: "-"
  kind: captain
  repo: sample
  priority: "-"
  created: 2026-08-09
  closed: "-"
  deps: none
  links: none
  body: "Origin: demo-earlier-review\nDecision key: route\nState: awaiting captain decision."
=== Full preserved legacy task projection (identity/title/state/dependencies/body) ===
task:
  id: legacy-demo-captain-call
  title: Choose the legacy sample route
  state: queued
  blocked: no
  blocked_by: none
  held: yes
  hold_reason: captain legacy route pending
  hold_kind: captain
  hold_until: "-"
  kind: captain
  repo: sample
  priority: "-"
  created: 2026-08-09
  closed: "-"
  deps: none
  links: none
  body: Legacy structured Captain's Call body.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- 🚨 `bin/fm-decision-hold.sh:202` - The required criterion says every new reference must be “queued, unblocked, actively captain-held” and blocked items must be rejected, but this trusts tasks-axi’s derived `blocked` field. That field treats a dangling `blocked-by` identity as resolved, while Firstmate’s canonical fleet projection deliberately keeps missing blockers unresolved. A captain-held row with `blocked-by: missing` is therefore attested and teardown can proceed even though Bearings excludes it from Captain’s Call. Validate blocker readiness using the canonical Firstmate semantics and add the dangling-blocker regression.
- 🚨 `bin/fm-decision-hold.sh:390` - The durable attestation is published in two appends: `decisions_reviewed=1` and keys first, then `decision_refs`. If the second append fails or the process stops between them, `verify` sees a completed inventory with no references and teardown may remove the source. This contradicts the required “durable, sorted, idempotent attestation.” Publish keys, references, and the reviewed marker as one failure-atomic metadata update and cover an interrupted-write failure.
- 🚨 `tests/fm-decision-hold-lifecycle.test.sh:359` - The required “every rejection class” coverage is incomplete: this fixture always creates live origin metadata and never exercises a kind-captain item that is inactive (`held=no`) or non-queued. Thus the new live-metadata, active-hold, and queued-state rejection branches have no regression evidence. Add those exact cases and assert both metadata and backlog remain unchanged.

🔧 Fix: Fix atomic decision attestation and blocker validation
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-decision-hold-lifecycle.test.sh`
- `bin/fm-decision-hold.sh --help`
- <code>Manual-backend CLI walkthrough using `complete demo-followup-review --existing demo-earlier-review-decision-route --existing legacy-demo-captain-call`, followed by `verify`, duplicate/reordered retry, and mixed external-hold rejection</code>
- `Compared backlog hashes and full referenced-task projections before and after completion; compared metadata hashes across retry and rejected completion`
- <code>`git status --short` after testing</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Quote completed blocker state in lint-safe comparison
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
