### PR TITLE
fix(classify): align status decision key formats

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -246,7 +246,7 @@ When a routed-work phase has a supervisor-actionable material change worth repor
 If its first reportable event is \`working [key=<work-slug>]: {material phase}\`, use the same key on its later \`$PAUSED_VERB\`, \`done\`, \`failed\`, \`needs-decision\`, or \`blocked\` event so the earlier working phase is superseded.
 When a keyed phase ends without another reportable state, append \`resolved [key=<work-slug>]: {why it is no longer active}\`.
 \`resolved\` separately closes an escalated decision or blocker, and only a \`resolved\` line carrying that decision's exact key closes it: a later \`done\` or \`working\` event never does, even when the answer is what started that work.
-The main firstmate's answer normally writes that closing line at answer time; when a blocker or wait clears WITHOUT an answer from the main firstmate, append \`resolved: {how it cleared}\` yourself (keyed with \`[key=<slug>]\` if you opened it with one) as your domain resumes.
+The main firstmate's answer normally writes that closing line at answer time; when a blocker or wait clears WITHOUT an answer from the main firstmate, append \`resolved [key=<slug>]: {how it cleared}\` yourself (same key you opened with, or bare \`resolved:\` if you opened keyless) as your domain resumes.
 Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.
 
 # Definition of done

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -330,8 +330,9 @@ The report is the only thing that survives, so anything worth keeping must be in
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs to a human (product choices, destructive actions),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
+   To key a decision or blocker, put the token between the verb and the colon - \`needs-decision [key=<slug>]: {summary}\` - the canonical spelling firstmate's own tools write.
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
-   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
+   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved [key=<slug>]: {how it cleared}\` yourself (same key you opened with, or bare \`resolved:\` if you opened keyless) as you resume.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
@@ -446,8 +447,9 @@ $RULE1
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
+   To key a decision or blocker, put the token between the verb and the colon - \`needs-decision [key=<slug>]: {summary}\` - the canonical spelling firstmate's own tools write.
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
-   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
+   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved [key=<slug>]: {how it cleared}\` yourself (same key you opened with, or bare \`resolved:\` if you opened keyless) as you resume.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -163,9 +163,14 @@ status_is_paused_or_captain_held() {  # <status-line>
 # format): an OPTIONAL "[key=<slug>]" token sits between the verb and the colon,
 #   needs-decision [key=api-shape]: <summary>
 #   resolved       [key=api-shape]: <how it was decided>
-# A line with no token uses the key "default", preserving the historical
+# Crews in the wild also write the token as the FIRST token of the body,
+#   needs-decision: [key=api-shape] <summary>
+# and both spellings name the SAME key, so an open in one spelling closes
+# against a resolution in the other; the note excludes the token either way.
+# A "[key=...]" anywhere later in the body is prose, never a key. A line with
+# no token in either position uses the key "default", preserving the historical
 # one-open-decision-per-task behavior (a bare "resolved:" closes "default").
-# The three parsers are pure reads of a single line; the verb parser strips any
+# The parsers are pure reads of a single line; the verb parser strips any
 # key token before the colon so the leading word is recovered cleanly.
 status_line_verb() {  # <status-line> -> leading verb word
   local v=${1%%:*}
@@ -180,6 +185,22 @@ status_line_note() {  # <status-line> -> text after the first colon, trimmed
     *) printf '%s' "$1" ;;
   esac
 }
+# Body-position key parser: succeeds only when the body's FIRST token is a
+# well-formed "[key=<slug>]" (closing bracket present, valid slug charset, and
+# nothing but whitespace or end-of-line after the bracket). A malformed leading
+# token fails here and the line folds under "default" - exactly how such lines
+# have always folded - unlike the between-verb-and-colon form, whose malformed
+# token rejects the whole line (preserved below, unchanged).
+_fm_decision_body_key() {  # <body-text> -> key slug, or fail when the body does not lead with one
+  local body=$1 k after
+  case "$body" in \[key=*) ;; *) return 1 ;; esac
+  k=${body#\[key=}
+  k=${k%%\]*}
+  case "$k" in ''|*[!A-Za-z0-9._-]*) return 1 ;; esac
+  after=${body#"[key=$k]"}
+  [ "$after" != "$body" ] || return 1
+  case "$after" in ''|[[:space:]]*) printf '%s' "$k" ;; *) return 1 ;; esac
+}
 _fm_decision_key() {  # <status-line> -> key slug, or "default" when no token
   local prefix=${1%%:*} k
   case "$prefix" in
@@ -191,8 +212,30 @@ _fm_decision_key() {  # <status-line> -> key slug, or "default" when no token
         *) printf '%s' "$k" ;;
       esac
       ;;
-    *) printf 'default' ;;
+    *)
+      case "$1" in
+        *:*) k=$(_fm_decision_body_key "$(status_line_note "$1")") || k=default ;;
+        *) k=default ;;
+      esac
+      printf '%s' "$k"
+      ;;
   esac
+}
+# Decision-note parser: the note as the folds record it, i.e. the after-colon
+# text minus a leading body-position key token. For a canonical keyed line or
+# a token-free line this is exactly status_line_note; keeping that public
+# parser untouched preserves every non-decision consumer of raw note text.
+_fm_decision_note() {  # <status-line> -> note text, minus a leading body key token
+  local note k
+  note=$(status_line_note "$1")
+  case "${1%%:*}" in
+    *\[key=*\]*) printf '%s' "$note"; return 0 ;;
+  esac
+  if k=$(_fm_decision_body_key "$note"); then
+    note=${note#"[key=$k]"}
+    note=${note#"${note%%[![:space:]]*}"}
+  fi
+  printf '%s' "$note"
 }
 # Drop the record for <key> from a newline-terminated "<key>\t<verb>\t<note>" set.
 # Portable (no associative arrays) so the fold runs on bash 3.2 as well as 4+.
@@ -258,11 +301,11 @@ _fm_decision_fold_line() {  # <open-set> <status-line> <resolve-verb> <held-verb
   [ -n "$stripped" ] || { printf '%s' "$open"; return 0; }
   verb=$(status_line_verb "$line")
   key=$(_fm_decision_key "$line") || { printf '%s' "$open"; return 0; }
-  _fm_decision_key_transition_allowed "$key" "$(status_line_note "$line")" \
+  note=$(_fm_decision_note "$line")
+  _fm_decision_key_transition_allowed "$key" "$note" \
     || { printf '%s' "$open"; return 0; }
   case "$verb" in
     needs-decision|blocked)
-      note=$(status_line_note "$line")
       open=$(_fm_decision_drop "$open" "$key")
       [ -n "$open" ] && open="${open}"$'\n'
       open="${open}${key}"$'\t'"${verb}"$'\t'"${note}"$'\n'
@@ -384,7 +427,10 @@ _fm_open_decisions_cursor_path() {  # <status-file>
   printf '%s/.%s.open-decisions-cursor' "$dir" "${base%.status}"
 }
 
-FM_OPEN_DECISIONS_FOLD_VERSION=2
+# Version 3: body-position "[key=<slug>]" tokens (first token after the colon)
+# now key the line, so persisted version-2 open-sets folded under the
+# prefix-only interpretation are discarded and rebuilt from byte 0.
+FM_OPEN_DECISIONS_FOLD_VERSION=3
 
 # Portable device:inode identity for the rotation/recreation check below.
 _fm_open_decisions_file_ident() {  # <file> -> "dev:inode", empty on I/O failure
@@ -543,7 +589,7 @@ _fm_status_open_activities_stream() {
     key=$(_fm_decision_key "$line") || continue
     case "$verb" in
       working|"$pause")
-        note=$(status_line_note "$line")
+        note=$(_fm_decision_note "$line")
         open=$(_fm_decision_drop "$open" "$key")
         [ -n "$open" ] && open="${open}"$'\n'
         open="${open}${key}"$'\t'"${verb}"$'\t'"${note}"$'\n'

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -202,7 +202,7 @@ _fm_decision_body_key() {  # <body-text> -> key slug, or fail when the body does
   case "$after" in ''|[[:space:]]*) printf '%s' "$k" ;; *) return 1 ;; esac
 }
 _fm_decision_parse_line() {
-  local line=$1 key_var=$2 note_var=$3 prefix=${1%%:*} body_note k parsed_key= parsed_note=
+  local line=$1 key_var=$2 note_var=$3 prefix=${1%%:*} body_note k parsed_key='' parsed_note=''
   case "$prefix" in
     *\[key=*\]*)
       k=${prefix#*\[key=}

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -201,41 +201,52 @@ _fm_decision_body_key() {  # <body-text> -> key slug, or fail when the body does
   [ "$after" != "$body" ] || return 1
   case "$after" in ''|[[:space:]]*) printf '%s' "$k" ;; *) return 1 ;; esac
 }
-_fm_decision_key() {  # <status-line> -> key slug, or "default" when no token
-  local prefix=${1%%:*} k
+_fm_decision_parse_line() {
+  local line=$1 key_var=$2 note_var=$3 prefix=${1%%:*} body_note k parsed_key= parsed_note=
   case "$prefix" in
     *\[key=*\]*)
       k=${prefix#*\[key=}
       k=${k%%\]*}
       case "$k" in
         ''|*[!A-Za-z0-9._-]*) return 1 ;;
-        *) printf '%s' "$k" ;;
+        *) parsed_key=$k ;;
       esac
+      parsed_note=$(status_line_note "$line")
       ;;
     *)
+      parsed_key=default
+      parsed_note=$(status_line_note "$line")
       case "$1" in
-        *:*) k=$(_fm_decision_body_key "$(status_line_note "$1")") || k=default ;;
-        *) k=default ;;
+        *:*)
+          if k=$(_fm_decision_body_key "$parsed_note"); then
+            parsed_key=$k
+            body_note=${parsed_note#"[key=$k]"}
+            parsed_note=${body_note#"${body_note%%[![:space:]]*}"}
+          fi
+          ;;
       esac
-      printf '%s' "$k"
       ;;
   esac
+  printf -v "$key_var" '%s' "$parsed_key"
+  printf -v "$note_var" '%s' "$parsed_note"
+}
+_fm_decision_key() {  # <status-line> -> key slug, or "default" when no token
+  local key note
+  _fm_decision_parse_line "$1" key note || return 1
+  printf '%s' "$key"
 }
 # Decision-note parser: the note as the folds record it, i.e. the after-colon
 # text minus a leading body-position key token. For a canonical keyed line or
 # a token-free line this is exactly status_line_note; keeping that public
 # parser untouched preserves every non-decision consumer of raw note text.
 _fm_decision_note() {  # <status-line> -> note text, minus a leading body key token
-  local note k
-  note=$(status_line_note "$1")
-  case "${1%%:*}" in
-    *\[key=*\]*) printf '%s' "$note"; return 0 ;;
-  esac
-  if k=$(_fm_decision_body_key "$note"); then
-    note=${note#"[key=$k]"}
-    note=${note#"${note%%[![:space:]]*}"}
+  local parsed_key parsed_note
+  if [ "$#" -eq 3 ]; then
+    _fm_decision_parse_line "$1" "$2" "$3"
+    return $?
   fi
-  printf '%s' "$note"
+  _fm_decision_parse_line "$1" parsed_key parsed_note || return 1
+  printf '%s' "$parsed_note"
 }
 # Drop the record for <key> from a newline-terminated "<key>\t<verb>\t<note>" set.
 # Portable (no associative arrays) so the fold runs on bash 3.2 as well as 4+.
@@ -300,8 +311,7 @@ _fm_decision_fold_line() {  # <open-set> <status-line> <resolve-verb> <held-verb
   stripped=${line//[[:space:]]/}
   [ -n "$stripped" ] || { printf '%s' "$open"; return 0; }
   verb=$(status_line_verb "$line")
-  key=$(_fm_decision_key "$line") || { printf '%s' "$open"; return 0; }
-  note=$(_fm_decision_note "$line")
+  _fm_decision_note "$line" key note || { printf '%s' "$open"; return 0; }
   _fm_decision_key_transition_allowed "$key" "$note" \
     || { printf '%s' "$open"; return 0; }
   case "$verb" in
@@ -586,10 +596,9 @@ _fm_status_open_activities_stream() {
     stripped=${line//[[:space:]]/}
     [ -n "$stripped" ] || continue
     verb=$(status_line_verb "$line")
-    key=$(_fm_decision_key "$line") || continue
+    _fm_decision_note "$line" key note || continue
     case "$verb" in
       working|"$pause")
-        note=$(_fm_decision_note "$line")
         open=$(_fm_decision_drop "$open" "$key")
         [ -n "$open" ] && open="${open}"$'\n'
         open="${open}${key}"$'\t'"${verb}"$'\t'"${note}"$'\n'

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -665,6 +665,8 @@ test_pause_verb_override_renders_all_brief_scaffolds() {
       "$kind brief still instructs the default paused status"
     assert_grep 'a blocker or wait clears' "$brief" \
       "$kind brief did not require durable resolution when a blocker clears"
+    assert_grep 'resolved [key=<slug>]: {how it cleared}' "$brief" \
+      "$kind brief did not show canonical keyed resolution syntax"
     assert_grep 'even when the answer is what started that work' "$brief" \
       "$kind brief did not warn that an answer-started done/working never closes a decision"
   done

--- a/tests/fm-send-resolve-key.test.sh
+++ b/tests/fm-send-resolve-key.test.sh
@@ -132,6 +132,32 @@ test_answer_send_closes_open_decision() {
   pass "fm-send --resolve-key: the answer send itself closes the open decision"
 }
 
+# Crews in the wild open decisions with the key as the body's first token
+# ("needs-decision: [key=x] summary") rather than the canonical
+# between-verb-and-colon spelling. --resolve-key must bind against such an
+# open record identically: same refuse-before-send safety, same canonical
+# closing line, same drained result.
+test_body_position_keyed_open_binds() {
+  local dir fb log home rc out
+  dir="$TMP_ROOT/body-key"; mkdir -p "$dir"
+  fb=$(make_stubs "$dir"); log="$dir/send.log"
+  home=$(setup_home body-key)
+  fm_write_meta "$home/state/t8.meta" "window=sess:fm-t8" "kind=ship"
+  printf 'needs-decision: [key=api-shape] pick REST or RPC\n' > "$home/state/t8.status"
+
+  run_send "$fb" "$home" "$log" t8 --resolve-key api-shape "go with REST"; rc=$?
+  expect_code 0 "$rc" "an answer should bind against a body-position keyed open record"
+  assert_contains "$(cat "$log")" "go with REST" "the answer text should reach the worker"
+  grep -F 'resolved [key=api-shape]: answered: go with REST' "$home/state/t8.status" >/dev/null \
+    || fail "fm-send did not append the canonical closing line:"$'\n'"$(cat "$home/state/t8.status")"
+
+  out=$(drain_out "$home")
+  if printf '%s' "$out" | grep -F 'OPEN DECISIONS' >/dev/null; then
+    fail "the body-position keyed decision still lists as open after the answer: $out"
+  fi
+  pass "fm-send --resolve-key: binds and closes a body-position keyed open record"
+}
+
 test_answer_starts_work_never_orphans() {
   local dir fb log home rc out
   dir="$TMP_ROOT/starts-work"; mkdir -p "$dir"
@@ -396,6 +422,7 @@ test_flag_misuse_refuses() {
 }
 
 test_answer_send_closes_open_decision
+test_body_position_keyed_open_binds
 test_answer_starts_work_never_orphans
 test_routine_steer_never_closes
 test_not_open_key_refuses_before_send

--- a/tests/fm-wake-drain-open-decisions.test.sh
+++ b/tests/fm-wake-drain-open-decisions.test.sh
@@ -215,9 +215,100 @@ test_over_long_decision_note_is_capped_with_a_marker() {
   pass "an over-long open decision is cut to its per-item budget with the shared truncation marker"
 }
 
+# Crews in the wild write the key token as the FIRST token of the body
+# ("needs-decision: [key=x] summary") rather than the canonical
+# between-verb-and-colon position. Both spellings must name the SAME key, or
+# such decisions fold keyless and a later canonical "resolved [key=x]:" (the
+# spelling fm-send's --resolve-key writes) leaves a phantom open entry.
+test_body_position_key_closes_against_canonical_resolved() {
+  local dir state out
+  dir=$(make_case body-key-canonical-close)
+  state="$dir/state"
+  out="$dir/drain.out"
+  printf 'needs-decision: [key=api-shape] pick REST or RPC\n' > "$state/taskA.status"
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" || fail "drain failed on a body-position keyed open"
+  grep -F 'taskA [key=api-shape] needs-decision: pick REST or RPC' "$out" >/dev/null \
+    || fail "a body-position keyed needs-decision did not fold as keyed with its token-free note: $(cat "$out")"
+
+  printf 'resolved [key=api-shape]: went with REST\n' >> "$state/taskA.status"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" || fail "drain failed after the canonical resolution"
+  if grep -F 'OPEN DECISIONS' "$out" >/dev/null; then
+    fail "a canonical keyed resolved did not close the body-position keyed open: $(cat "$out")"
+  fi
+  pass "a body-position keyed open closes against a canonical keyed resolved"
+}
+
+test_body_position_resolved_closes_either_spelling() {
+  local dir state out
+  dir=$(make_case body-key-body-close)
+  state="$dir/state"
+  out="$dir/drain.out"
+  # taskB opens and closes entirely in the body-position spelling; taskC opens
+  # canonically and closes in the body-position spelling (the reverse interop).
+  printf 'blocked: [key=creds] need the deploy token\n' > "$state/taskB.status"
+  printf 'resolved: [key=creds] token landed in the vault\n' >> "$state/taskB.status"
+  printf 'needs-decision [key=rollout]: big-bang or phased\n' > "$state/taskC.status"
+  printf 'resolved: [key=rollout] phased\n' >> "$state/taskC.status"
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" || fail "drain failed on body-position resolutions"
+  if grep -F 'OPEN DECISIONS' "$out" >/dev/null; then
+    fail "a body-position keyed resolved left an open entry in either spelling: $(cat "$out")"
+  fi
+  pass "a body-position keyed resolved closes body-position and canonical opens alike"
+}
+
+test_canonical_spelling_folds_unchanged_next_to_body_spelling() {
+  local dir state out
+  dir=$(make_case canonical-unchanged)
+  state="$dir/state"
+  out="$dir/drain.out"
+  # The canonical pair must behave exactly as before the body-position parser
+  # existed, including when both spellings share one log: the canonical
+  # api-shape pair closes, the body-position migration open stays open.
+  printf 'needs-decision [key=api-shape]: pick REST or RPC\n' > "$state/taskD.status"
+  printf 'needs-decision: [key=migration] pick the rollout plan\n' >> "$state/taskD.status"
+  printf 'resolved [key=api-shape]: went with REST\n' >> "$state/taskD.status"
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" || fail "drain failed on a mixed-spelling log"
+  grep -F 'taskD [key=migration] needs-decision: pick the rollout plan' "$out" >/dev/null \
+    || fail "the still-open body-position decision vanished from a mixed-spelling log: $(cat "$out")"
+  if grep -F '[key=api-shape]' "$out" >/dev/null; then
+    fail "the canonically resolved decision stayed open next to a body-position line: $(cat "$out")"
+  fi
+  pass "canonical keyed lines fold unchanged alongside body-position keyed lines"
+}
+
+test_key_token_not_at_body_start_is_prose() {
+  local dir state out
+  dir=$(make_case body-key-prose)
+  state="$dir/state"
+  out="$dir/drain.out"
+  # A [key=...] mentioned mid-body is prose: the line folds under "default",
+  # a keyed resolved for the mentioned slug must NOT close it, and a bare
+  # keyless resolved (the historical default-key close) must.
+  printf 'blocked: waiting on the [key=infra] approval\n' > "$state/taskE.status"
+  printf 'resolved [key=infra]: not a close for that blocker\n' >> "$state/taskE.status"
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" || fail "drain failed on a mid-body key mention"
+  grep -F 'taskE blocked: waiting on the [key=infra] approval' "$out" >/dev/null \
+    || fail "a mid-body [key=...] mention was treated as a key: $(cat "$out")"
+
+  printf 'resolved: approval came through\n' >> "$state/taskE.status"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" || fail "drain failed after the keyless resolution"
+  if grep -F 'OPEN DECISIONS' "$out" >/dev/null; then
+    fail "a keyless resolved did not close the default-keyed blocker: $(cat "$out")"
+  fi
+  pass "a [key=...] token not at the start of the body is prose, never a key"
+}
+
 test_buried_decision_still_surfaces
 test_over_long_decision_note_is_capped_with_a_marker
 test_explicit_resolution_closes_it
+test_body_position_key_closes_against_canonical_resolved
+test_body_position_resolved_closes_either_spelling
+test_canonical_spelling_folds_unchanged_next_to_body_spelling
+test_key_token_not_at_body_start_is_prose
 test_later_unrelated_terminal_line_does_not_close_it
 test_reserved_key_namespace_is_owned_by_its_library
 test_no_open_decisions_prints_nothing


### PR DESCRIPTION
## What Changed

- Extended status parsing to support `[key=<slug>]` after the colon and between the verb and colon, with consistent decision/activity folding and incremental fold versioning.
- Updated generated crew briefs to document canonical keyed `resolved` syntax and closure behavior.
- Added regression coverage for mixed key formats, `fm-send --resolve-key`, wake-drain decision scans, and brief scaffolding.

## Risk Assessment

⚠️ Medium: The parser change is localized, but it changes interpretation of append-only historical status logs and can resurface stale captain decisions.

## Testing

Exercised focused behavior, persistence, downstream classifier, snapshot, and end-to-end CLI/send paths; captured two reviewer-visible transcripts and left the worktree clean. No linters, formatters, static analysis, or no-mistakes pipeline steps were run per the test-only constraints; the read-only preflight reported the repository is not initialized.

<details>
<summary>Evidence: Manual CLI evidence</summary>

```text
$ status-key-demo.status: needs-decision: [key=api-shape] pick REST or RPC
$ FM_STATE_OVERRIDE=... bin/fm-wake-drain.sh
OPEN DECISIONS (still open, folded from the durable status logs - not just the latest line):
status-key-demo [key=api-shape] needs-decision: pick REST or RPC
OPEN DECISIONS: close one by answering it: bin/fm-send.sh <task> --resolve-key <key> '<answer>'
$ printf "resolved [key=api-shape]: went with REST" >> status-key-demo.status
$ FM_STATE_OVERRIDE=... bin/fm-wake-drain.sh
(no OPEN DECISIONS section: the canonical keyed resolution closed the legacy body-position decision)
```
</details>
<details>
<summary>Evidence: fm-send evidence</summary>

```text
$ tests/fm-send-resolve-key.test.sh
ok - fm-send --resolve-key: the answer send itself closes the open decision
ok - fm-send --resolve-key: binds and closes a body-position keyed open record
ok - fm-send --resolve-key: an answer that starts a workstream leaves no orphaned decision
ok - fm-send: a send without --resolve-key never closes a decision, and working/done still cannot
ok - fm-send --resolve-key: a key that is not open refuses loudly before anything is sent
ok - fm-send --resolve-key: a failed send never closes the decision
ok - fm-send --resolve-key: one answer closes each named key and only those
ok - fm-send --resolve-key: a marked local-secondmate answer closes with the plain answer text
ok - fm-send --resolve-key: a remote-secondmate answer closes the same local ledger, transport-only difference
ok - fm-send --resolve-key: a failed remote transport never closes the decision
ok - fm-send --resolve-key: --key, empty message, explicit targets, and malformed keys refuse loudly
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

- ⚠️ `bin/fm-classify-lib.sh:217` - Historical `needs-decision: [key=x]` records were previously treated as `default`; after this parser and fold-version change, bare `resolved:` entries no longer close them, so stale decisions may reappear and break decision-hold inventory until manually resolved. Confirm a migration/compatibility policy or explicitly accept this behavior.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh tests/fm-brief.test.sh tests/fm-send-resolve-key.test.sh tests/fm-wake-drain-open-decisions.test.sh`
- `bin/fm-test-run.sh tests/fm-wake-drain-open-decisions-cursor.test.sh tests/fm-decision-hold-lifecycle.test.sh tests/fm-pending-reply.test.sh tests/fm-remote-reply.test.sh`
- `bin/fm-test-run.sh tests/fm-crew-state.test.sh tests/fm-watch-triage.test.sh tests/fm-fleet-snapshot-view.test.sh tests/fm-bearings-snapshot.test.sh`
- `Manual CLI flow: body-position decision → OPEN DECISIONS → canonical resolution → no open decision`
- <code>`git status --short --untracked-files=all` and target HEAD verification</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
