### PR TITLE
fix(spawn): allow no-mistakes socket access

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -218,6 +218,15 @@ Directory trust dialog on first run per repo root: "Do you trust the contents of
 Accept with Enter.
 The decision persists for the repo, so later worktrees of the same project skip it.
 
+Firstmate non-secondmate Codex workers retain the full-access autonomy flag and also receive explicit additional writable roots for the active home's state directory and the linked worktree's physical Git common directory.
+Scouts additionally receive only their task-local report directory, while secondmates receive none of these parent-home roots.
+This defense in depth preserves normal branch, commit, status, notification, and report operations when an outer policy reduces the effective worker sandbox to workspace-write.
+The static launch contract is covered by `tests/fm-spawn-dispatch-profile.test.sh`, and the opt-in credentialed control plus success path is `tests/fm-codex-writable-roots-live-e2e.test.sh`.
+The complete status, report, branch, and commit path was live-verified on 2026-08-04 with Codex 0.146.0 under an explicit workspace-write control.
+A Codex ship whose resolved mode is exactly `no-mistakes` additionally receives the physical root selected by `NM_HOME` or `HOME/.no-mistakes`, and the launch freezes that same root in `NM_HOME`.
+Direct-PR, local-only, scouts, secondmates, and every non-Codex harness receive no no-mistakes root.
+The 2026-08-05 socket control and refresh command are recorded in `docs/verification/runtime-backends.md`.
+
 Resume after exit with `codex resume <session-id>`.
 The session id is printed on quit.
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1252,7 +1252,9 @@ codex_writable_root_flags() {  # <kind> <worktree> <state-dir> <report-dir> [<no
     printf -- '--add-dir %s ' "$(shell_quote "$report_dir")"
   fi
   if [ -n "$no_mistakes_root" ]; then
-    printf -- '--add-dir %s ' "$(shell_quote "$no_mistakes_root")"
+    printf -- '--add-dir %s -c %s ' \
+      "$(shell_quote "$no_mistakes_root")" \
+      "$(shell_quote 'sandbox_workspace_write.network_access=true')"
   fi
 }
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1118,8 +1118,10 @@ launch_template() {
   esac
 }
 
+RAW_LAUNCH=0
 case "$ARG3" in
   *' '*)  # raw launch command (unverified-adapter escape hatch)
+    RAW_LAUNCH=1
     LAUNCH=$ARG3
     HARNESS=""
     for word in $LAUNCH; do
@@ -1153,6 +1155,11 @@ case "$ARG3" in
     LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: unknown harness '$HARNESS'; pass a raw launch command to use an unverified adapter" >&2; exit 1; }
     ;;
 esac
+
+if [ "$RAW_LAUNCH" -eq 1 ] && [ "$HARNESS" = codex ] && [ "$KIND" = ship ] && [ "$MODE" = no-mistakes ]; then
+  echo "error: raw Codex launch commands cannot satisfy the no-mistakes writable-root contract; select the verified codex harness instead" >&2
+  exit 1
+fi
 
 case "$HARNESS" in
   pi|pi-signed) LAUNCH="FM_PI_HARNESS=$HARNESS $LAUNCH" ;;
@@ -1396,15 +1403,7 @@ effort_flag_for_harness() {
   esac
 }
 
-# no-mistakes selects NM_HOME when non-empty and otherwise uses
-# $HOME/.no-mistakes, with its Unix socket directly under that root. Resolve
-# and freeze the physical directory before endpoint creation, then forward the
-# same value into the worker because long-lived session backends need not share
-# firstmate's current environment. No other mode, kind, or harness receives it.
 CODEX_NO_MISTAKES_ROOT=
-if [ "$HARNESS" = codex ] && [ "$KIND" = ship ] && [ "$MODE" = no-mistakes ]; then
-  CODEX_NO_MISTAKES_ROOT=$(resolve_no_mistakes_root) || exit 1
-fi
 
 case "$LAUNCH" in
   *__MUSEBIN__*)
@@ -1466,6 +1465,51 @@ path_is_ancestor_of() {
     "$ancestor"/*) return 0 ;;
   esac
   return 1
+}
+
+paths_overlap() {
+  local left=$1 right=$2
+  [ "$left" = "$right" ] || path_is_ancestor_of "$left" "$right" || path_is_ancestor_of "$right" "$left"
+}
+
+validate_no_mistakes_root() {
+  local root=$1 project=$2 home_real fm_home_real fm_root_real name path real
+  [ "$root" != / ] || {
+    echo "error: refusing broad or overlapping no-mistakes root: filesystem root" >&2
+    return 1
+  }
+  home_real=$(CDPATH='' cd -- "${HOME:-}" 2>/dev/null && pwd -P) || home_real=
+  if [ -n "$home_real" ] && { [ "$root" = "$home_real" ] || path_is_ancestor_of "$root" "$home_real"; }; then
+    echo "error: refusing broad or overlapping no-mistakes root: user home" >&2
+    return 1
+  fi
+  fm_home_real=$(CDPATH='' cd -- "$FM_HOME" 2>/dev/null && pwd -P) || fm_home_real=
+  if [ -n "$fm_home_real" ] && { [ "$root" = "$fm_home_real" ] || path_is_ancestor_of "$root" "$fm_home_real"; }; then
+    echo "error: refusing broad or overlapping no-mistakes root: active Firstmate home" >&2
+    return 1
+  fi
+  fm_root_real=$(CDPATH='' cd -- "$FM_ROOT" 2>/dev/null && pwd -P) || fm_root_real=
+  if [ -n "$fm_root_real" ] && paths_overlap "$root" "$fm_root_real"; then
+    echo "error: refusing broad or overlapping no-mistakes root: Firstmate repository" >&2
+    return 1
+  fi
+  for name in data state config projects; do
+    case "$name" in
+      data) path=$DATA ;;
+      state) path=$STATE ;;
+      config) path=$CONFIG ;;
+      projects) path=$PROJECTS ;;
+    esac
+    real=$(CDPATH='' cd -- "$path" 2>/dev/null && pwd -P) || continue
+    if paths_overlap "$root" "$real"; then
+      echo "error: refusing broad or overlapping no-mistakes root: Firstmate $name directory" >&2
+      return 1
+    fi
+  done
+  if paths_overlap "$root" "$project"; then
+    echo "error: refusing broad or overlapping no-mistakes root: primary project directory" >&2
+    return 1
+  fi
 }
 
 validate_firstmate_home_for_spawn() {
@@ -1673,6 +1717,16 @@ BRIEF_REAL="$BRIEF_DIR_REAL/$(basename "$BRIEF")"
 # once here so every downstream comparison uses the same physical form
 # (docs/herdr-backend.md "Known gaps").
 PROJ_ABS_REAL=$(cd "$PROJ_ABS" 2>/dev/null && pwd -P) || PROJ_ABS_REAL="$PROJ_ABS"
+
+# no-mistakes selects NM_HOME when non-empty and otherwise uses
+# $HOME/.no-mistakes, with its Unix socket directly under that root. Resolve
+# and freeze the physical directory before endpoint creation, then forward the
+# same value into the worker because long-lived session backends need not share
+# firstmate's current environment. No other mode, kind, or harness receives it.
+if [ "$HARNESS" = codex ] && [ "$KIND" = ship ] && [ "$MODE" = no-mistakes ]; then
+  CODEX_NO_MISTAKES_ROOT=$(resolve_no_mistakes_root) || exit 1
+  validate_no_mistakes_root "$CODEX_NO_MISTAKES_ROOT" "$PROJ_ABS_REAL" || exit 1
+fi
 
 real_path_or_raw() {  # <path>
   local path=$1 real

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -144,6 +144,9 @@
 #     __BRIEF__    absolute path to data/<task-id>/brief.md
 #     __TURNEND__  absolute path to state/<task-id>.turn-ended (for harnesses whose
 #                  turn-end signal rides the launch command, e.g. codex -c notify=[...])
+#     __CODEXWRITEROOTS__ task-scoped additional writable roots for a non-secondmate
+#                  Codex worker's state, linked-worktree Git metadata, scout report,
+#                  and exact no-mistakes root when that ship's mode requires the gate
 #     __PIEXT__    absolute path to state/<task-id>.pi-ext.ts (pi turn-end extension,
 #                  written by this script; outside the worktree to avoid pi's trust gate)
 #     __PITURNEND__ absolute path to .pi/extensions/fm-primary-turnend-guard.ts in a pi secondmate home
@@ -1065,7 +1068,7 @@ launch_template() {
       if [ "$kind" = secondmate ]; then
         printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       else
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox __CODEXWRITEROOTS__-c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       fi
       ;;
     opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
@@ -1206,6 +1209,53 @@ shell_quote() {
   printf "'"
 }
 
+resolve_no_mistakes_root() {
+  local candidate source resolved
+  if [ -n "${NM_HOME:-}" ]; then
+    candidate=$NM_HOME
+    source=NM_HOME
+  elif [ -n "${HOME:-}" ]; then
+    candidate="$HOME/.no-mistakes"
+    source='HOME default'
+  else
+    echo "error: no-mistakes root cannot be resolved because neither NM_HOME nor HOME is set" >&2
+    return 1
+  fi
+  resolved=$(CDPATH='' cd -- "$candidate" 2>/dev/null && pwd -P) || {
+    echo "error: no-mistakes root from $source is not an existing directory: $candidate" >&2
+    return 1
+  }
+  printf '%s\n' "$resolved"
+}
+
+codex_writable_root_flags() {  # <kind> <worktree> <state-dir> <report-dir> [<no-mistakes-root>]
+  local kind=$1 worktree=$2 state_dir=$3 report_dir=$4 no_mistakes_root=${5:-}
+  local git_common_raw git_common_path git_common_real
+  [ "$kind" != secondmate ] || return 0
+
+  git_common_raw=$(git -C "$worktree" rev-parse --git-common-dir 2>/dev/null) || {
+    echo "error: could not resolve Codex worker Git metadata root for $worktree" >&2
+    return 1
+  }
+  case "$git_common_raw" in
+    /*) git_common_path=$git_common_raw ;;
+    *) git_common_path="$worktree/$git_common_raw" ;;
+  esac
+  git_common_real=$(cd "$git_common_path" 2>/dev/null && pwd -P) || {
+    echo "error: Codex worker Git metadata root is not a directory: $git_common_path" >&2
+    return 1
+  }
+
+  printf -- '--add-dir %s --add-dir %s ' \
+    "$(shell_quote "$state_dir")" "$(shell_quote "$git_common_real")"
+  if [ "$kind" = scout ]; then
+    printf -- '--add-dir %s ' "$(shell_quote "$report_dir")"
+  fi
+  if [ -n "$no_mistakes_root" ]; then
+    printf -- '--add-dir %s ' "$(shell_quote "$no_mistakes_root")"
+  fi
+}
+
 resolve_kimi_binary() {
   local candidate dir fallback
   candidate=$(command -v kimi 2>/dev/null || true)
@@ -1343,6 +1393,16 @@ effort_flag_for_harness() {
     # task metadata but never reaches the launch command.
   esac
 }
+
+# no-mistakes selects NM_HOME when non-empty and otherwise uses
+# $HOME/.no-mistakes, with its Unix socket directly under that root. Resolve
+# and freeze the physical directory before endpoint creation, then forward the
+# same value into the worker because long-lived session backends need not share
+# firstmate's current environment. No other mode, kind, or harness receives it.
+CODEX_NO_MISTAKES_ROOT=
+if [ "$HARNESS" = codex ] && [ "$KIND" = ship ] && [ "$MODE" = no-mistakes ]; then
+  CODEX_NO_MISTAKES_ROOT=$(resolve_no_mistakes_root) || exit 1
+fi
 
 case "$LAUNCH" in
   *__MUSEBIN__*)
@@ -2556,14 +2616,23 @@ sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
+CODEXWRITEROOTS=
+if [ "$HARNESS" = codex ] && [ "$KIND" != secondmate ]; then
+  CODEXWRITEROOTS=$(codex_writable_root_flags \
+    "$KIND" "$WT" "$STATE_REAL" "$BRIEF_DIR_REAL" "$CODEX_NO_MISTAKES_ROOT") || exit 1
+fi
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
 LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
+LAUNCH=${LAUNCH//__CODEXWRITEROOTS__/$CODEXWRITEROOTS}
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}
 LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
 LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}
+if [ -n "$CODEX_NO_MISTAKES_ROOT" ]; then
+  LAUNCH="NM_HOME=$(shell_quote "$CODEX_NO_MISTAKES_ROOT") $LAUNCH"
+fi
 # Crewmate panes are created by a long-lived tmux/herdr daemon that does not
 # inherit firstmate's current environment, so a bare `claude` in the pane falls
 # back to the default ~/.claude store even when firstmate itself runs under a

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1470,7 +1470,7 @@ paths_overlap() {
 }
 
 validate_no_mistakes_root() {
-  local root=$1 project=$2 home_real fm_home_real fm_root_real name path real
+  local root=$1 project=$2 home_real fm_home_real fm_root_real name path real daemon_status
   [ "$root" != / ] || {
     echo "error: refusing broad or overlapping no-mistakes root: filesystem root" >&2
     return 1
@@ -1507,8 +1507,12 @@ validate_no_mistakes_root() {
     echo "error: refusing broad or overlapping no-mistakes root: primary project directory" >&2
     return 1
   fi
-  if ! (cd "$project" && env NM_HOME="$root" NO_MISTAKES_TELEMETRY=off \
-    NO_MISTAKES_NO_UPDATE_CHECK=1 no-mistakes axi >/dev/null 2>&1); then
+  daemon_status=$(cd "$project" && env NM_HOME="$root" NO_MISTAKES_TELEMETRY=off \
+    NO_MISTAKES_NO_UPDATE_CHECK=1 NO_COLOR=1 no-mistakes daemon status 2>&1) || {
+    echo "error: selected root cannot be verified as an active no-mistakes home: $root" >&2
+    return 1
+  }
+  if ! [[ "$daemon_status" =~ ^[[:space:]]*([^[:alnum:][:space:]]+[[:space:]]+)?daemon[[:space:]]+running[[:space:]]+\(pid[[:space:]]+[1-9][0-9]*\)[[:space:]]*$ ]]; then
     echo "error: selected root cannot be verified as an active no-mistakes home: $root" >&2
     return 1
   fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -107,8 +107,11 @@
 #   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi|muse)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
-#   new adapters. pi-signed launches that exact executable name from PATH and
-#   refuses before endpoint creation when it is unavailable; it never falls back to pi.
+#   new adapters outside no-mistakes ship mode. A no-mistakes ship refuses a raw
+#   launch before endpoint creation because only a verified adapter can construct
+#   its required writable-root boundary. pi-signed launches that exact executable
+#   name from PATH and refuses before endpoint creation when it is unavailable;
+#   it never falls back to pi.
 #   config/secondmate-harness may also carry an optional model and effort as extra
 #   whitespace-separated tokens ("<harness> [<model>] [<effort>]"). For a
 #   --secondmate spawn, those tokens apply only when this spawn also resolves its

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1118,10 +1118,12 @@ launch_template() {
   esac
 }
 
-RAW_LAUNCH=0
 case "$ARG3" in
   *' '*)  # raw launch command (unverified-adapter escape hatch)
-    RAW_LAUNCH=1
+    if [ "$KIND" = ship ] && [ "$MODE" = no-mistakes ]; then
+      echo "error: raw launch commands cannot satisfy the no-mistakes writable-root contract; select a verified harness adapter instead" >&2
+      exit 1
+    fi
     LAUNCH=$ARG3
     HARNESS=""
     for word in $LAUNCH; do
@@ -1155,11 +1157,6 @@ case "$ARG3" in
     LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: unknown harness '$HARNESS'; pass a raw launch command to use an unverified adapter" >&2; exit 1; }
     ;;
 esac
-
-if [ "$RAW_LAUNCH" -eq 1 ] && [ "$HARNESS" = codex ] && [ "$KIND" = ship ] && [ "$MODE" = no-mistakes ]; then
-  echo "error: raw Codex launch commands cannot satisfy the no-mistakes writable-root contract; select the verified codex harness instead" >&2
-  exit 1
-fi
 
 case "$HARNESS" in
   pi|pi-signed) LAUNCH="FM_PI_HARNESS=$HARNESS $LAUNCH" ;;
@@ -1508,6 +1505,11 @@ validate_no_mistakes_root() {
   done
   if paths_overlap "$root" "$project"; then
     echo "error: refusing broad or overlapping no-mistakes root: primary project directory" >&2
+    return 1
+  fi
+  if ! env NM_HOME="$root" NO_MISTAKES_NO_UPDATE_CHECK=1 \
+    no-mistakes daemon status >/dev/null 2>&1; then
+    echo "error: selected root cannot be verified as an active no-mistakes home: $root" >&2
     return 1
   fi
 }

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1507,8 +1507,8 @@ validate_no_mistakes_root() {
     echo "error: refusing broad or overlapping no-mistakes root: primary project directory" >&2
     return 1
   fi
-  if ! env NM_HOME="$root" NO_MISTAKES_NO_UPDATE_CHECK=1 \
-    no-mistakes daemon status >/dev/null 2>&1; then
+  if ! (cd "$project" && env NM_HOME="$root" NO_MISTAKES_TELEMETRY=off \
+    NO_MISTAKES_NO_UPDATE_CHECK=1 no-mistakes axi >/dev/null 2>&1); then
     echo "error: selected root cannot be verified as an active no-mistakes home: $root" >&2
     return 1
   fi

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -180,7 +180,8 @@ family_for_basename() {
       printf '%s\n' session-bootstrap
       ;;
     fm-afk-pi-herdr-return-e2e.test.sh|\
-    fm-codex-continuity-live-e2e.test.sh|fm-grok-continuity-live-e2e.test.sh|\
+    fm-codex-continuity-live-e2e.test.sh|fm-codex-writable-roots-live-e2e.test.sh|\
+    fm-grok-continuity-live-e2e.test.sh|\
     fm-grok-stop-live-e2e.test.sh|fm-harness-liveness-drift-live-e2e.test.sh|\
     fm-muse-signals-live-e2e.test.sh|\
     fm-herdr-version-floor-live-e2e.test.sh|\

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -204,7 +204,7 @@ Bounded output from the successful run:
 ok - codex-cli 0.146.0 live E2E proved narrow Codex worker writable roots
 ```
 
-The 2026-08-07 static extension adds no-mistakes ship inclusion, direct-PR and local-only exclusion, non-Codex exclusion, preserved existing roots, the `NM_HOME` and default `HOME/.no-mistakes` selection contract, unresolved and protected-overlap root refusal, raw Codex gate-launch refusal before endpoint creation, and workspace-write network access only for the verified no-mistakes Codex ship.
+The 2026-08-07 static extension adds no-mistakes ship inclusion, direct-PR and local-only exclusion, non-Codex exclusion, preserved existing roots, the `NM_HOME` and default `HOME/.no-mistakes` selection contract, active-daemon home verification, unresolved and protected-overlap root refusal, all opaque gate-launch refusal before endpoint creation, and workspace-write network access only for the verified no-mistakes Codex ship.
 
 The no-mistakes socket control ran on 2026-08-05 with no-mistakes v1.41.2 and codex-cli 0.146.0 in a Firstmate Codex worker whose effective sandbox was workspace-write and whose launch lacked the no-mistakes root.
 The installed matching v1.41.2 module source established that `NM_HOME` selects the root when non-empty, otherwise `HOME/.no-mistakes` does, and the Unix socket is `<root>/socket`.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -189,22 +189,10 @@ It checks ship and scout construction, physical path and symlink normalization, 
 tests/fm-spawn-dispatch-profile.test.sh
 ```
 
-The credentialed live control ran on 2026-08-04 with codex-cli 0.146.0 under an explicit workspace-write sandbox.
+The credentialed live control first ran on 2026-08-04 with codex-cli 0.146.0 under an explicit workspace-write sandbox.
 Without additional roots, the control proved that the active home's state directory remained denied.
 With the narrow roots, the worker appended status, wrote its task-local report, created a linked-worktree branch and commit, and remained unable to write sibling-task data.
-
-```sh
-FM_CODEX_WRITABLE_ROOTS_LIVE_E2E=1 \
-  bin/fm-test-run.sh tests/fm-codex-writable-roots-live-e2e.test.sh
-```
-
-Bounded output from the successful run:
-
-```text
-ok - codex-cli 0.146.0 live E2E proved narrow Codex worker writable roots
-```
-
-The 2026-08-07 static extension adds no-mistakes ship inclusion, direct-PR and local-only exclusion, non-Codex exclusion, preserved existing roots, the `NM_HOME` and default `HOME/.no-mistakes` selection contract, direct AF_UNIX connectivity and captured daemon-status verification, unresolved and protected-overlap root refusal, stopped-daemon and unrelated-directory refusal, all opaque gate-launch refusal before endpoint creation, and workspace-write network access only for the verified no-mistakes Codex ship.
+The 2026-08-07 static extension exercises the inclusion and exclusion contract documented in the [harness-adapters skill](../../.agents/skills/harness-adapters/SKILL.md), plus unresolved, unsafe-overlap, unverified-home, and raw-launch refusals.
 
 The no-mistakes socket control ran on 2026-08-05 with no-mistakes v1.41.2 and codex-cli 0.146.0 in a Firstmate Codex worker whose effective sandbox was workspace-write and whose launch lacked the no-mistakes root.
 The installed matching v1.41.2 module source established that `NM_HOME` selects the root when non-empty, otherwise `HOME/.no-mistakes` does, and the Unix socket is `<root>/socket`.
@@ -223,9 +211,12 @@ connect to daemon socket: dial ipc: dial unix <home>/.no-mistakes/socket: connec
 The refreshed opt-in guard keeps telemetry and update checks disabled, suppresses the captured daemon-status payload, requires the control's exact AF_UNIX socket denial, and then requires both a direct AF_UNIX connection and explicit `daemon running (pid N)` status after the selected no-mistakes root and workspace-write network access are added.
 It never starts a no-mistakes pipeline or invokes another state-mutating no-mistakes command.
 
-Its additional bounded success marker is:
+```sh
+FM_CODEX_WRITABLE_ROOTS_LIVE_E2E=1 \
+  bin/fm-test-run.sh tests/fm-codex-writable-roots-live-e2e.test.sh
+```
 
-The credentialed guard produced this marker on 2026-08-07 with no-mistakes v1.41.2 and codex-cli 0.146.0 after the workspace-write network correction.
+The credentialed guard produced the bounded marker below on 2026-08-07 with no-mistakes v1.41.2 and codex-cli 0.146.0 after the workspace-write network correction.
 
 ```text
 ok - codex-cli 0.146.0 live E2E proved narrow Codex worker writable roots and read-only no-mistakes socket access

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -204,7 +204,7 @@ Bounded output from the successful run:
 ok - codex-cli 0.146.0 live E2E proved narrow Codex worker writable roots
 ```
 
-The 2026-08-07 static extension adds no-mistakes ship inclusion, direct-PR and local-only exclusion, non-Codex exclusion, preserved existing roots, the `NM_HOME` and default `HOME/.no-mistakes` selection contract, read-only AXI socket verification, unresolved and protected-overlap root refusal, stopped-daemon and unrelated-directory refusal, all opaque gate-launch refusal before endpoint creation, and workspace-write network access only for the verified no-mistakes Codex ship.
+The 2026-08-07 static extension adds no-mistakes ship inclusion, direct-PR and local-only exclusion, non-Codex exclusion, preserved existing roots, the `NM_HOME` and default `HOME/.no-mistakes` selection contract, direct AF_UNIX connectivity and captured daemon-status verification, unresolved and protected-overlap root refusal, stopped-daemon and unrelated-directory refusal, all opaque gate-launch refusal before endpoint creation, and workspace-write network access only for the verified no-mistakes Codex ship.
 
 The no-mistakes socket control ran on 2026-08-05 with no-mistakes v1.41.2 and codex-cli 0.146.0 in a Firstmate Codex worker whose effective sandbox was workspace-write and whose launch lacked the no-mistakes root.
 The installed matching v1.41.2 module source established that `NM_HOME` selects the root when non-empty, otherwise `HOME/.no-mistakes` does, and the Unix socket is `<root>/socket`.
@@ -220,8 +220,8 @@ no-mistakes daemon status
 connect to daemon socket: dial ipc: dial unix <home>/.no-mistakes/socket: connect: operation not permitted
 ```
 
-The refreshed opt-in guard keeps telemetry and update checks disabled, suppresses the AXI home payload, requires the control's exact socket denial, and then requires the same read-only AXI home command to connect after the selected no-mistakes root and workspace-write network access are added.
-It never invokes `no-mistakes axi run` or another pipeline-starting command.
+The refreshed opt-in guard keeps telemetry and update checks disabled, suppresses the captured daemon-status payload, requires the control's exact AF_UNIX socket denial, and then requires both a direct AF_UNIX connection and explicit `daemon running (pid N)` status after the selected no-mistakes root and workspace-write network access are added.
+It never starts a no-mistakes pipeline or invokes another state-mutating no-mistakes command.
 
 Its additional bounded success marker is:
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -204,7 +204,7 @@ Bounded output from the successful run:
 ok - codex-cli 0.146.0 live E2E proved narrow Codex worker writable roots
 ```
 
-The 2026-08-07 static extension adds no-mistakes ship inclusion, direct-PR and local-only exclusion, non-Codex exclusion, preserved existing roots, the `NM_HOME` and default `HOME/.no-mistakes` selection contract, active-daemon home verification, unresolved and protected-overlap root refusal, all opaque gate-launch refusal before endpoint creation, and workspace-write network access only for the verified no-mistakes Codex ship.
+The 2026-08-07 static extension adds no-mistakes ship inclusion, direct-PR and local-only exclusion, non-Codex exclusion, preserved existing roots, the `NM_HOME` and default `HOME/.no-mistakes` selection contract, read-only AXI socket verification, unresolved and protected-overlap root refusal, stopped-daemon and unrelated-directory refusal, all opaque gate-launch refusal before endpoint creation, and workspace-write network access only for the verified no-mistakes Codex ship.
 
 The no-mistakes socket control ran on 2026-08-05 with no-mistakes v1.41.2 and codex-cli 0.146.0 in a Firstmate Codex worker whose effective sandbox was workspace-write and whose launch lacked the no-mistakes root.
 The installed matching v1.41.2 module source established that `NM_HOME` selects the root when non-empty, otherwise `HOME/.no-mistakes` does, and the Unix socket is `<root>/socket`.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -204,7 +204,7 @@ Bounded output from the successful run:
 ok - codex-cli 0.146.0 live E2E proved narrow Codex worker writable roots
 ```
 
-The 2026-08-05 static extension adds no-mistakes ship inclusion, direct-PR and local-only exclusion, non-Codex exclusion, preserved existing roots, the `NM_HOME` and default `HOME/.no-mistakes` selection contract, and unresolved-root refusal.
+The 2026-08-07 static extension adds no-mistakes ship inclusion, direct-PR and local-only exclusion, non-Codex exclusion, preserved existing roots, the `NM_HOME` and default `HOME/.no-mistakes` selection contract, unresolved-root refusal, and workspace-write network access only for the no-mistakes Codex ship.
 
 The no-mistakes socket control ran on 2026-08-05 with no-mistakes v1.41.2 and codex-cli 0.146.0 in a Firstmate Codex worker whose effective sandbox was workspace-write and whose launch lacked the no-mistakes root.
 The installed matching v1.41.2 module source established that `NM_HOME` selects the root when non-empty, otherwise `HOME/.no-mistakes` does, and the Unix socket is `<root>/socket`.
@@ -220,10 +220,12 @@ no-mistakes daemon status
 connect to daemon socket: dial ipc: dial unix <home>/.no-mistakes/socket: connect: operation not permitted
 ```
 
-The refreshed opt-in guard keeps telemetry and update checks disabled, suppresses the AXI home payload, requires the control's exact socket denial, and then requires the same read-only AXI home command to connect after the selected no-mistakes root is added.
+The refreshed opt-in guard keeps telemetry and update checks disabled, suppresses the AXI home payload, requires the control's exact socket denial, and then requires the same read-only AXI home command to connect after the selected no-mistakes root and workspace-write network access are added.
 It never invokes `no-mistakes axi run` or another pipeline-starting command.
 
 Its additional bounded success marker is:
+
+The credentialed guard produced this marker on 2026-08-07 with no-mistakes v1.41.2 and codex-cli 0.146.0 after the workspace-write network correction.
 
 ```text
 ok - codex-cli 0.146.0 live E2E proved narrow Codex worker writable roots and read-only no-mistakes socket access

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -180,6 +180,55 @@ Valid cleanup removed only the exact task-bound target and left the control wind
 The metadata-only validation covers tmux, Herdr, Zellij, Orca, and cmux before backend dispatch.
 Claude, Codex, OpenCode, Pi, pi-signed, Grok, Kimi, and Muse share that backend cleanup boundary; their harness-specific hook files, tokens, and session-log sidecars are cleaned only after it, so no harness needs a separate endpoint parser.
 
+## Codex worker writable roots
+
+The shared backend-neutral launch path is covered by the portable spawn regression below.
+It checks ship and scout construction, physical path and symlink normalization, shell quoting for spaces, the task-local scout report boundary, and secondmate exclusion.
+
+```sh
+tests/fm-spawn-dispatch-profile.test.sh
+```
+
+The credentialed live control ran on 2026-08-04 with codex-cli 0.146.0 under an explicit workspace-write sandbox.
+Without additional roots, the control proved that the active home's state directory remained denied.
+With the narrow roots, the worker appended status, wrote its task-local report, created a linked-worktree branch and commit, and remained unable to write sibling-task data.
+
+```sh
+FM_CODEX_WRITABLE_ROOTS_LIVE_E2E=1 \
+  bin/fm-test-run.sh tests/fm-codex-writable-roots-live-e2e.test.sh
+```
+
+Bounded output from the successful run:
+
+```text
+ok - codex-cli 0.146.0 live E2E proved narrow Codex worker writable roots
+```
+
+The 2026-08-05 static extension adds no-mistakes ship inclusion, direct-PR and local-only exclusion, non-Codex exclusion, preserved existing roots, the `NM_HOME` and default `HOME/.no-mistakes` selection contract, and unresolved-root refusal.
+
+The no-mistakes socket control ran on 2026-08-05 with no-mistakes v1.41.2 and codex-cli 0.146.0 in a Firstmate Codex worker whose effective sandbox was workspace-write and whose launch lacked the no-mistakes root.
+The installed matching v1.41.2 module source established that `NM_HOME` selects the root when non-empty, otherwise `HOME/.no-mistakes` does, and the Unix socket is `<root>/socket`.
+The read-only commands produced the bounded evidence below without starting a pipeline.
+
+```sh
+no-mistakes doctor
+no-mistakes daemon status
+```
+
+```text
+✓ data directory  <home>/.no-mistakes
+connect to daemon socket: dial ipc: dial unix <home>/.no-mistakes/socket: connect: operation not permitted
+```
+
+The refreshed opt-in guard keeps telemetry and update checks disabled, suppresses the AXI home payload, requires the control's exact socket denial, and then requires the same read-only AXI home command to connect after the selected no-mistakes root is added.
+It never invokes `no-mistakes axi run` or another pipeline-starting command.
+
+Its additional bounded success marker is:
+
+```text
+ok - codex-cli 0.146.0 live E2E proved narrow Codex worker writable roots and read-only no-mistakes socket access
+```
+
 ## Herdr
 
 The compatibility floor is protocol 14.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -204,7 +204,7 @@ Bounded output from the successful run:
 ok - codex-cli 0.146.0 live E2E proved narrow Codex worker writable roots
 ```
 
-The 2026-08-07 static extension adds no-mistakes ship inclusion, direct-PR and local-only exclusion, non-Codex exclusion, preserved existing roots, the `NM_HOME` and default `HOME/.no-mistakes` selection contract, unresolved-root refusal, and workspace-write network access only for the no-mistakes Codex ship.
+The 2026-08-07 static extension adds no-mistakes ship inclusion, direct-PR and local-only exclusion, non-Codex exclusion, preserved existing roots, the `NM_HOME` and default `HOME/.no-mistakes` selection contract, unresolved and protected-overlap root refusal, raw Codex gate-launch refusal before endpoint creation, and workspace-write network access only for the verified no-mistakes Codex ship.
 
 The no-mistakes socket control ran on 2026-08-05 with no-mistakes v1.41.2 and codex-cli 0.146.0 in a Firstmate Codex worker whose effective sandbox was workspace-write and whose launch lacked the no-mistakes root.
 The installed matching v1.41.2 module source established that `NM_HOME` selects the root when non-empty, otherwise `HOME/.no-mistakes` does, and the Unix socket is `<root>/socket`.

--- a/tests/fm-backend-autodetect-smoke.test.sh
+++ b/tests/fm-backend-autodetect-smoke.test.sh
@@ -106,7 +106,7 @@ env -u TMUX -u FM_BACKEND PATH="$PATH" HERDR_ENV=1 \
   FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
   FM_CONFIG_OVERRIDE="$CONFIG" FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" \
   FM_SPAWN_NO_GUARD=1 \
-  "$ROOT/bin/fm-spawn.sh" "$ID" "$PROJ" "sh -c 'echo autodetect-smoke-ok'" --mode no-mistakes --yolo off \
+  "$ROOT/bin/fm-spawn.sh" "$ID" "$PROJ" "sh -c 'echo autodetect-smoke-ok'" --mode local-only --yolo off \
   >"$OUT_FILE" 2>"$ERR_FILE"
 status=$?
 [ "$status" -eq 0 ] || fail "fm-spawn.sh did not succeed auto-detecting herdr"$'\n'"--- stdout ---"$'\n'"$(cat "$OUT_FILE")"$'\n'"--- stderr ---"$'\n'"$(cat "$ERR_FILE")"

--- a/tests/fm-backend-herdr-launcher-workspace-e2e.test.sh
+++ b/tests/fm-backend-herdr-launcher-workspace-e2e.test.sh
@@ -207,7 +207,7 @@ focused_workspace() {
 
 # --- 1. unique label, no herdr ancestry: the per-home container still works --
 
-spawn_from_launcher "" "$PRIMARY_HOME" uniqA "$PROJ" --mode no-mistakes --yolo off
+spawn_from_launcher "" "$PRIMARY_HOME" uniqA "$PROJ" --mode local-only --yolo off
 [ "$SPAWN_RC" -eq 0 ] || fail "a primary-shaped spawn with no herdr parent failed"$'\n'"$(cat "$SPAWN_ERR")"
 UNIQA_META="$PRIMARY_HOME/state/uniqA.meta"
 record_worktree "$UNIQA_META"
@@ -227,7 +227,7 @@ $(lab tab create --workspace "$WS_PRIMARY" --cwd "$TMP_ROOT" --label captain-she
 EOF
 [ -n "$LAUNCH_PRIMARY_PANE" ] || fail "could not create a launcher pane inside the 'firstmate' workspace"
 
-spawn_from_launcher "$LAUNCH_PRIMARY_PANE" "$PRIMARY_HOME" uniqB "$PROJ" --mode no-mistakes --yolo off
+spawn_from_launcher "$LAUNCH_PRIMARY_PANE" "$PRIMARY_HOME" uniqB "$PROJ" --mode local-only --yolo off
 [ "$SPAWN_RC" -eq 0 ] || fail "a primary spawn from a launcher pane failed"$'\n'"$(cat "$SPAWN_ERR")"
 UNIQB_META="$PRIMARY_HOME/state/uniqB.meta"
 record_worktree "$UNIQB_META"
@@ -239,7 +239,7 @@ pass "real herdr E2E: the normal unique-label path is unchanged when the launche
 # --- 2b. presentation spaces ON: the projected child is created and bound
 #         UNDER the launcher's exact workspace, not collapsed into it ---------
 
-spawn_from_launcher "$LAUNCH_PRIMARY_PANE" "$PRES_HOME" presU "$PROJ" --mode no-mistakes --yolo off
+spawn_from_launcher "$LAUNCH_PRIMARY_PANE" "$PRES_HOME" presU "$PROJ" --mode local-only --yolo off
 [ "$SPAWN_RC" -eq 0 ] || fail "a presentation-enabled spawn from a launcher pane failed"$'\n'"$(cat "$SPAWN_ERR")"
 PRESU_META="$PRES_HOME/state/presU.meta"
 record_worktree "$PRESU_META"
@@ -279,7 +279,7 @@ cat > "$TMP_ROOT/spawn-in-pane.sh" <<SPAWN
 #!/usr/bin/env bash
 set -u
 FM_SPAWN_NO_GUARD=1 FM_HOME="$PRIMARY_HOME" FM_ROOT_OVERRIDE="$ROOT" \\
-  "$ROOT/bin/fm-spawn.sh" dupC "$PROJ" "sh -c 'echo launcher-ws-ok'" --mode no-mistakes --yolo off --backend herdr \\
+  "$ROOT/bin/fm-spawn.sh" dupC "$PROJ" "sh -c 'echo launcher-ws-ok'" --mode local-only --yolo off --backend herdr \\
   > "$TMP_ROOT/dupC.out" 2> "$TMP_ROOT/dupC.err"
 echo \$? > "$TMP_ROOT/dupC.rc"
 SPAWN
@@ -314,7 +314,7 @@ pass "real herdr E2E: the duplicate-labeled sibling workspace is left entirely u
 # --- 3b. presentation spaces ON with a duplicated parent label: the projection
 #         still hangs off the launcher's exact workspace ---------------------
 
-spawn_from_launcher "$LAUNCH_DUP_PANE" "$PRES_HOME" presD "$PROJ" --mode no-mistakes --yolo off
+spawn_from_launcher "$LAUNCH_DUP_PANE" "$PRES_HOME" presD "$PROJ" --mode local-only --yolo off
 [ "$SPAWN_RC" -eq 0 ] || fail "a projected spawn under a duplicated parent label failed"$'\n'"$(cat "$SPAWN_ERR")"
 PRESD_META="$PRES_HOME/state/presD.meta"
 record_worktree "$PRESD_META"
@@ -341,7 +341,7 @@ pass "real herdr E2E: with a duplicated home label, a projected worker still han
 
 # --- 4. duplicate label with NO launcher identity refuses before publishing --
 
-spawn_from_launcher "" "$PRIMARY_HOME" dupD "$PROJ" --mode no-mistakes --yolo off
+spawn_from_launcher "" "$PRIMARY_HOME" dupD "$PROJ" --mode local-only --yolo off
 [ "$SPAWN_RC" -ne 0 ] || fail "a duplicate-labeled home workspace with no herdr parent must refuse, not guess"
 assert_contains_local "$(cat "$SPAWN_ERR")" "labeled 'firstmate'" \
   "the refusal did not name the duplicated home label"
@@ -365,7 +365,7 @@ if lab pane get "$STALE_PANE" >/dev/null 2>&1; then
   fail "the launcher pane did not actually go away"
 fi
 
-spawn_from_launcher "$STALE_PANE" "$PRIMARY_HOME" staleF "$PROJ" --mode no-mistakes --yolo off
+spawn_from_launcher "$STALE_PANE" "$PRIMARY_HOME" staleF "$PROJ" --mode local-only --yolo off
 [ "$SPAWN_RC" -ne 0 ] || fail "a launcher pane that no longer exists must refuse, not fall back to a label search"
 assert_contains_local "$(cat "$SPAWN_ERR")" "$STALE_PANE" \
   "the stale-identity refusal did not name the launcher pane it could not resolve"
@@ -385,7 +385,7 @@ EOF
 [ -n "$WS_SM_DECOY" ] && [ -n "$WS_SM_LAUNCH" ] || fail "could not create the two secondmate-labeled workspaces"
 WS_SM_DECOY_TABS_BEFORE=$(tab_labels_of_workspace "$WS_SM_DECOY")
 
-spawn_from_launcher "$LAUNCH_SM_PANE" "$SM_HOME" smE "$PROJ" --mode no-mistakes --yolo off
+spawn_from_launcher "$LAUNCH_SM_PANE" "$SM_HOME" smE "$PROJ" --mode local-only --yolo off
 [ "$SPAWN_RC" -eq 0 ] || fail "a secondmate-owned crewmate spawn failed"$'\n'"$(cat "$SPAWN_ERR")"
 SME_META="$SM_HOME/state/smE.meta"
 record_worktree "$SME_META"

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -383,7 +383,7 @@ make_project() {  # <dir>
 spawn_task() {  # <id> <home> <project>
   local id=$1 home=$2 project=$3
   FM_GATE_REFUSE_BYPASS=1 FM_SPAWN_NO_GUARD=1 FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
-    "$ROOT/bin/fm-spawn.sh" "$id" "$project" "sh -c 'sleep 120'" --mode no-mistakes --yolo off --backend herdr
+    "$ROOT/bin/fm-spawn.sh" "$id" "$project" "sh -c 'sleep 120'" --mode local-only --yolo off --backend herdr
 }
 
 finish_concurrent_spawn() {  # <id> <status> <stdout> <stderr>

--- a/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
+++ b/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
@@ -115,7 +115,7 @@ PROJ2="$TMP_ROOT/scratch-project-2"; make_scratch_project "$PROJ2"
 
 CM1_OUT="$TMP_ROOT/cm1.out"; CM1_ERR="$TMP_ROOT/cm1.err"
 FM_SPAWN_NO_GUARD=1 FM_HOME="$PRIMARY_HOME" FM_ROOT_OVERRIDE="$ROOT" \
-  "$ROOT/bin/fm-spawn.sh" cm1 "$PROJ1" "sh -c 'echo primary-crew-ok'" --mode no-mistakes --yolo off --backend herdr \
+  "$ROOT/bin/fm-spawn.sh" cm1 "$PROJ1" "sh -c 'echo primary-crew-ok'" --mode local-only --yolo off --backend herdr \
   >"$CM1_OUT" 2>"$CM1_ERR"
 rc=$?
 [ "$rc" -eq 0 ] || fail "primary-shaped crewmate spawn failed"$'\n'"--- stdout ---"$'\n'"$(cat "$CM1_OUT")"$'\n'"--- stderr ---"$'\n'"$(cat "$CM1_ERR")"
@@ -170,7 +170,7 @@ pass "real herdr E2E: a --secondmate spawn by the PRIMARY lands in the SECONDMAT
 
 CM2_OUT="$TMP_ROOT/cm2.out"; CM2_ERR="$TMP_ROOT/cm2.err"
 FM_SPAWN_NO_GUARD=1 FM_HOME="$SM_HOME" FM_ROOT_OVERRIDE="$ROOT" \
-  "$ROOT/bin/fm-spawn.sh" cm2 "$PROJ2" "sh -c 'echo sm-crew-ok'" --mode no-mistakes --yolo off --backend herdr \
+  "$ROOT/bin/fm-spawn.sh" cm2 "$PROJ2" "sh -c 'echo sm-crew-ok'" --mode local-only --yolo off --backend herdr \
   >"$CM2_OUT" 2>"$CM2_ERR"
 rc=$?
 [ "$rc" -eq 0 ] || fail "a crewmate spawned FROM the secondmate-shaped home failed"$'\n'"--- stdout ---"$'\n'"$(cat "$CM2_OUT")"$'\n'"--- stderr ---"$'\n'"$(cat "$CM2_ERR")"

--- a/tests/fm-busy-adapter-wiring.test.sh
+++ b/tests/fm-busy-adapter-wiring.test.sh
@@ -58,10 +58,10 @@ make_spawn_case() {  # <name> <harness> <id>
 run_spawn() {  # <home> <wt> <fakebin> <spawn-args...>
   # Every case here is a ship spawn, which carries an explicit delivery contract
   # (AGENTS.md section 7); these tests are about busy-state wiring, so they pass a
-  # fixed valid one.
+  # fixed valid local-only one.
   local home=$1 wt=$2 fakebin=$3
   shift 3
-  set -- "$@" --mode no-mistakes --yolo off
+  set -- "$@" --mode local-only --yolo off
   FM_ROOT_OVERRIDE='' FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \

--- a/tests/fm-codex-writable-roots-live-e2e.test.sh
+++ b/tests/fm-codex-writable-roots-live-e2e.test.sh
@@ -62,14 +62,13 @@ git -C "$PROJECT" worktree add -q --detach "$WORKTREE"
 cat > "$WORKTREE/control.sh" <<SH
 #!/usr/bin/env bash
 socket_out=; socket_status=0
-socket_out=\$(NO_MISTAKES_TELEMETRY=off \
-  NO_MISTAKES_NO_UPDATE_CHECK=1 no-mistakes axi 2>&1) || socket_status=\$?
+socket_out=\$(python3 -c 'import socket; s=socket.socket(socket.AF_UNIX); s.connect("$NO_MISTAKES_ROOT/socket"); s.close()' 2>&1) || socket_status=\$?
 if [ "\$socket_status" -eq 0 ]; then
   echo CONTROL_SOCKET_UNEXPECTED_CONNECT
   exit 90
 fi
 case "\$socket_out" in
-  *'connect: operation not permitted'*) ;;
+  *'Operation not permitted'*) ;;
   *) echo CONTROL_SOCKET_WRONG_ERROR; exit 90 ;;
 esac
 if printf 'unexpected\n' >> '$STATE/proof.status'; then
@@ -93,14 +92,15 @@ chmod +x "$WORKTREE/control.sh"
 ) > "$CONTROL_TRANSCRIPT" 2>&1 || fail "Codex control turn failed: $(tail -20 "$CONTROL_TRANSCRIPT")"
 
 grep -F 'CONTROL_DENIED' "$CONTROL_TRANSCRIPT" >/dev/null \
-  || fail "control without additional roots did not prove the parent-home write denial"
+  || fail "control without additional roots did not prove the parent-home write denial: $(tail -20 "$CONTROL_TRANSCRIPT")"
 [ ! -e "$STATE/proof.status" ] || fail "control unexpectedly wrote the parent-home status file"
 
 cat > "$WORKTREE/probe.sh" <<SH
 #!/usr/bin/env bash
 set -eu
-if ! NO_MISTAKES_TELEMETRY=off \
-  NO_MISTAKES_NO_UPDATE_CHECK=1 no-mistakes axi >/dev/null 2>&1; then
+python3 -c 'import socket; s=socket.socket(socket.AF_UNIX); s.connect("$NO_MISTAKES_ROOT/socket"); s.close()'
+if ! (cd '$ROOT' && NO_MISTAKES_TELEMETRY=off \
+  NO_MISTAKES_NO_UPDATE_CHECK=1 no-mistakes axi >/dev/null 2>&1); then
   echo NO_MISTAKES_SOCKET_CONNECT_FAILED
   exit 93
 fi
@@ -127,6 +127,7 @@ chmod +x "$WORKTREE/probe.sh"
     --add-dir "$PROJECT/.git" \
     --add-dir "$REPORT" \
     --add-dir "$NO_MISTAKES_ROOT" \
+    -c 'sandbox_workspace_write.network_access=true' \
     --skip-git-repo-check \
     -c 'approval_policy="never"' \
     -c 'model_reasoning_effort="low"' \

--- a/tests/fm-codex-writable-roots-live-e2e.test.sh
+++ b/tests/fm-codex-writable-roots-live-e2e.test.sh
@@ -99,8 +99,14 @@ cat > "$WORKTREE/probe.sh" <<SH
 #!/usr/bin/env bash
 set -eu
 python3 -c 'import socket; s=socket.socket(socket.AF_UNIX); s.connect("$NO_MISTAKES_ROOT/socket"); s.close()'
-if ! (cd '$ROOT' && NO_MISTAKES_TELEMETRY=off \
-  NO_MISTAKES_NO_UPDATE_CHECK=1 no-mistakes axi >/dev/null 2>&1); then
+no_mistakes_status=
+if ! no_mistakes_status=\$(cd '$ROOT' && env NM_HOME='$NO_MISTAKES_ROOT' \
+  NO_MISTAKES_TELEMETRY=off NO_MISTAKES_NO_UPDATE_CHECK=1 NO_COLOR=1 \
+  no-mistakes daemon status 2>&1); then
+  echo NO_MISTAKES_SOCKET_CONNECT_FAILED
+  exit 93
+fi
+if ! [[ "\$no_mistakes_status" =~ ^[[:space:]]*([^[:alnum:][:space:]]+[[:space:]]+)?daemon[[:space:]]+running[[:space:]]+\(pid[[:space:]]+[1-9][0-9]*\)[[:space:]]*\$ ]]; then
   echo NO_MISTAKES_SOCKET_CONNECT_FAILED
   exit 93
 fi

--- a/tests/fm-codex-writable-roots-live-e2e.test.sh
+++ b/tests/fm-codex-writable-roots-live-e2e.test.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Opt-in credentialed Codex regression proving explicit writable roots preserve
+# the narrow worker boundary while enabling Firstmate status, report, linked
+# worktree Git operations, and a read-only no-mistakes socket connection under
+# an effective workspace-write sandbox.
+set -u
+
+if [ "${FM_CODEX_WRITABLE_ROOTS_LIVE_E2E:-0}" != 1 ]; then
+  echo "skip: set FM_CODEX_WRITABLE_ROOTS_LIVE_E2E=1 to run the Codex writable-roots regression"
+  exit 0
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  exit 1
+}
+
+command -v codex >/dev/null 2>&1 || fail "codex not found"
+command -v no-mistakes >/dev/null 2>&1 || fail "no-mistakes not found"
+
+if [ -n "${NM_HOME:-}" ]; then
+  NO_MISTAKES_CANDIDATE=$NM_HOME
+elif [ -n "${HOME:-}" ]; then
+  NO_MISTAKES_CANDIDATE="$HOME/.no-mistakes"
+else
+  fail "neither NM_HOME nor HOME can select the no-mistakes root"
+fi
+NO_MISTAKES_ROOT=$(CDPATH='' cd -- "$NO_MISTAKES_CANDIDATE" 2>/dev/null && pwd -P) \
+  || fail "the selected no-mistakes root is not an existing directory"
+[ -S "$NO_MISTAKES_ROOT/socket" ] || fail "the selected no-mistakes root has no live Unix socket"
+export NM_HOME=$NO_MISTAKES_ROOT
+
+LAB="${TMPDIR:-/tmp}/fm-codex-writable-roots-live-e2e.$$"
+HOME_LAB="$ROOT/.codex-writable-roots-live-e2e-home.$$"
+PROJECT="$LAB/project"
+WORKTREE="$LAB/worktree"
+STATE="$HOME_LAB/state"
+REPORT="$HOME_LAB/data/proof-task"
+SIBLING="$HOME_LAB/data/sibling-task"
+CONTROL_TRANSCRIPT="$LAB/control.jsonl"
+PROOF_TRANSCRIPT="$LAB/proof.jsonl"
+CODEX_VERSION=$(codex --version)
+# shellcheck disable=SC2016 # Backticks are literal prompt markup.
+CONTROL_PROMPT='Run exactly `./control.sh`. Do not alter it. Reply with its final output marker.'
+# shellcheck disable=SC2016 # Backticks are literal prompt markup.
+PROOF_PROMPT='Run exactly `./probe.sh`. Do not alter it. Reply with its final output marker.'
+
+cleanup() {
+  rm -rf "$LAB" "$HOME_LAB"
+}
+trap cleanup EXIT
+
+mkdir -p "$PROJECT" "$STATE" "$REPORT" "$SIBLING"
+git -C "$PROJECT" init -q -b main
+printf 'fixture\n' > "$PROJECT/README.md"
+git -C "$PROJECT" add README.md
+git -C "$PROJECT" commit -q -m "Initialize writable-roots fixture"
+git -C "$PROJECT" worktree add -q --detach "$WORKTREE"
+
+cat > "$WORKTREE/control.sh" <<SH
+#!/usr/bin/env bash
+socket_out=; socket_status=0
+socket_out=\$(NO_MISTAKES_TELEMETRY=off \
+  NO_MISTAKES_NO_UPDATE_CHECK=1 no-mistakes axi 2>&1) || socket_status=\$?
+if [ "\$socket_status" -eq 0 ]; then
+  echo CONTROL_SOCKET_UNEXPECTED_CONNECT
+  exit 90
+fi
+case "\$socket_out" in
+  *'connect: operation not permitted'*) ;;
+  *) echo CONTROL_SOCKET_WRONG_ERROR; exit 90 ;;
+esac
+if printf 'unexpected\n' >> '$STATE/proof.status'; then
+  echo CONTROL_UNEXPECTED_WRITE
+  exit 91
+fi
+echo CONTROL_DENIED
+SH
+chmod +x "$WORKTREE/control.sh"
+
+(
+  cd "$WORKTREE" || exit 1
+  codex exec \
+    --dangerously-bypass-hook-trust \
+    --sandbox workspace-write \
+    --skip-git-repo-check \
+    -c 'approval_policy="never"' \
+    -c 'model_reasoning_effort="low"' \
+    --json \
+    "$CONTROL_PROMPT"
+) > "$CONTROL_TRANSCRIPT" 2>&1 || fail "Codex control turn failed: $(tail -20 "$CONTROL_TRANSCRIPT")"
+
+grep -F 'CONTROL_DENIED' "$CONTROL_TRANSCRIPT" >/dev/null \
+  || fail "control without additional roots did not prove the parent-home write denial"
+[ ! -e "$STATE/proof.status" ] || fail "control unexpectedly wrote the parent-home status file"
+
+cat > "$WORKTREE/probe.sh" <<SH
+#!/usr/bin/env bash
+set -eu
+if ! NO_MISTAKES_TELEMETRY=off \
+  NO_MISTAKES_NO_UPDATE_CHECK=1 no-mistakes axi >/dev/null 2>&1; then
+  echo NO_MISTAKES_SOCKET_CONNECT_FAILED
+  exit 93
+fi
+git switch -c fm/codex-writable-roots-live-proof
+printf 'proof\n' > proof.txt
+git add proof.txt
+git commit -q -m 'Prove Codex writable roots'
+printf 'running: proof\n' >> '$STATE/proof.status'
+printf 'report: proof\n' > '$REPORT/report.md'
+if printf 'unexpected\n' > '$SIBLING/escape.txt'; then
+  echo SIBLING_WRITE_UNEXPECTED
+  exit 92
+fi
+echo WRITABLE_ROOTS_AND_SOCKET_PROOF_OK
+SH
+chmod +x "$WORKTREE/probe.sh"
+
+(
+  cd "$WORKTREE" || exit 1
+  codex exec \
+    --dangerously-bypass-hook-trust \
+    --sandbox workspace-write \
+    --add-dir "$STATE" \
+    --add-dir "$PROJECT/.git" \
+    --add-dir "$REPORT" \
+    --add-dir "$NO_MISTAKES_ROOT" \
+    --skip-git-repo-check \
+    -c 'approval_policy="never"' \
+    -c 'model_reasoning_effort="low"' \
+    --json \
+    "$PROOF_PROMPT"
+) > "$PROOF_TRANSCRIPT" 2>&1 || fail "Codex writable-roots turn failed: $(tail -20 "$PROOF_TRANSCRIPT")"
+
+grep -F 'WRITABLE_ROOTS_AND_SOCKET_PROOF_OK' "$PROOF_TRANSCRIPT" >/dev/null \
+  || fail "Codex transcript omitted the writable-roots and socket success marker"
+grep -Fqx 'running: proof' "$STATE/proof.status" \
+  || fail "Codex did not append the authorized status file"
+grep -Fqx 'report: proof' "$REPORT/report.md" \
+  || fail "Codex did not write the task-local report"
+[ ! -e "$SIBLING/escape.txt" ] \
+  || fail "Codex escaped the task-local report root into sibling data"
+[ "$(git -C "$WORKTREE" branch --show-current)" = fm/codex-writable-roots-live-proof ] \
+  || fail "Codex did not create the linked-worktree branch"
+[ "$(git -C "$WORKTREE" log -1 --format=%s)" = 'Prove Codex writable roots' ] \
+  || fail "Codex did not create the linked-worktree commit"
+
+printf 'ok - %s live E2E proved narrow Codex worker writable roots and read-only no-mistakes socket access\n' "$CODEX_VERSION"

--- a/tests/fm-gate-refuse.test.sh
+++ b/tests/fm-gate-refuse.test.sh
@@ -167,7 +167,7 @@ run_spawn() {
       "FM_PROJECTS_OVERRIDE=$home/projects" "FM_CONFIG_OVERRIDE=$home/config" \
       "FM_SPAWN_NO_GUARD=1" "FM_FAKE_PANE_PATH=$pane" "TMUX=fake,1,0" \
       "PATH=$fakebin:$PATH" "$@" \
-      "$SPAWN" "$id" "$proj" codex --mode no-mistakes --yolo off ) 2>&1
+      "$SPAWN" "$id" "$proj" codex --mode local-only --yolo off ) 2>&1
 }
 
 test_spawn_refuses_and_admits() {

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -909,7 +909,7 @@ test_spawn_fallback_chain_and_crew_scout_unaffected() {
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" FM_FAKE_LAUNCH_LOG="$launchlog" \
-    "$ROOT/bin/fm-spawn.sh" "$id" "$proj" --mode no-mistakes --yolo off >/dev/null 2>&1
+    "$ROOT/bin/fm-spawn.sh" "$id" "$proj" --mode local-only --yolo off >/dev/null 2>&1
   meta="$home/state/$id.meta"
   [ "$(meta_field "$meta" kind)" = ship ] || fail "crew-unaffected: expected an ordinary ship task"
   [ "$(meta_field "$meta" harness)" = codex ] || fail "crew-unaffected: crew harness resolution changed"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -25,7 +25,11 @@ esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;
-  has-session|new-session|new-window|kill-window) exit 0 ;;
+  has-session|kill-window) exit 0 ;;
+  new-session|new-window)
+    [ -z "${FM_FAKE_ENDPOINT_LOG:-}" ] || printf '%s\n' "$1" >> "$FM_FAKE_ENDPOINT_LOG"
+    exit 0
+    ;;
   send-keys)
     if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
       prev=
@@ -85,6 +89,7 @@ run_spawn() {
   local home=$1 wt=$2 fakebin=$3 launchlog=$4
   shift 4
   : > "$launchlog"
+  : > "$launchlog.endpoint"
   # CLAUDE_CONFIG_DIR is forwarded onto claude launches by fm-spawn, so pin it
   # explicitly (empty by default) instead of leaking the invoking shell's value,
   # which would make launch assertions depend on the developer's environment.
@@ -96,7 +101,8 @@ run_spawn() {
     HOME="${FM_TEST_HOME-$home/user-home}" \
     NM_HOME="${FM_TEST_NM_HOME-$home/no-mistakes-home}" \
     CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
-    FM_FAKE_LAUNCH_LOG="$launchlog" GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
+    FM_FAKE_LAUNCH_LOG="$launchlog" FM_FAKE_ENDPOINT_LOG="$launchlog.endpoint" \
+    GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
     "$SPAWN" "$@" 2>&1
 }
 
@@ -606,6 +612,50 @@ test_codex_no_mistakes_root_resolution_fails_closed() {
   pass "Codex no-mistakes spawn fails closed before endpoint publication when its root is unresolved"
 }
 
+test_codex_no_mistakes_root_rejects_broad_or_overlapping_paths() {
+  local rec base_id labels candidates i id out status
+  base_id=profile-codex-roots-refused-z3h
+  rec=$(make_spawn_case profile-codex-roots-refused codex \
+    "$base_id-root" "$base_id-home" "$base_id-firstmate" "$base_id-data" "$base_id-project")
+  read_case_record "$rec"
+  labels=(root home firstmate data project)
+  candidates=(/ "$HOME_DIR/user-home" "$HOME_DIR" "$HOME_DIR/data" "$PROJ_DIR")
+
+  for i in "${!labels[@]}"; do
+    id="$base_id-${labels[$i]}"
+    out=$(FM_TEST_NM_HOME="${candidates[$i]}" \
+      run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+    status=$?
+    expect_code 1 "$status" "Codex no-mistakes spawn with ${labels[$i]} as its root should fail"
+    assert_contains "$out" "refusing broad or overlapping no-mistakes root" \
+      "Codex no-mistakes refusal did not name the unsafe root boundary"
+    assert_absent "$HOME_DIR/state/$id.meta" \
+      "Codex no-mistakes unsafe-root refusal wrote task metadata"
+    [ ! -s "$LAUNCH_LOG.endpoint" ] || fail "Codex no-mistakes unsafe-root refusal created an endpoint"
+    [ ! -s "$LAUNCH_LOG" ] || fail "Codex no-mistakes unsafe-root refusal typed a launch command"
+  done
+  pass "Codex no-mistakes spawn rejects broad and protected overlapping roots"
+}
+
+test_raw_codex_no_mistakes_launch_fails_closed() {
+  local rec id out status
+  id=profile-raw-codex-no-mistakes-z3i
+  rec=$(make_spawn_case profile-raw-codex-no-mistakes claude "$id")
+  read_case_record "$rec"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" "codex --profile isolated")
+  status=$?
+  expect_code 1 "$status" "raw Codex no-mistakes launch should fail"
+  assert_contains "$out" "raw Codex launch commands cannot satisfy the no-mistakes writable-root contract" \
+    "raw Codex no-mistakes refusal did not name the unsupported access contract"
+  assert_absent "$HOME_DIR/state/$id.meta" \
+    "raw Codex no-mistakes refusal wrote task metadata"
+  [ ! -s "$LAUNCH_LOG.endpoint" ] || fail "raw Codex no-mistakes refusal created an endpoint"
+  [ ! -s "$LAUNCH_LOG" ] || fail "raw Codex no-mistakes refusal typed a launch command"
+  pass "raw Codex no-mistakes launch fails before endpoint creation"
+}
+
 test_codex_omits_invalid_max_effort() {
   local rec id out status launch
   id=profile-codex-max-z4
@@ -907,6 +957,8 @@ test_codex_writable_roots_are_physical_and_shell_quoted
 test_codex_no_mistakes_root_is_physical_and_shell_quoted
 test_codex_no_mistakes_root_uses_home_default_when_nm_home_is_empty
 test_codex_no_mistakes_root_resolution_fails_closed
+test_codex_no_mistakes_root_rejects_broad_or_overlapping_paths
+test_raw_codex_no_mistakes_launch_fails_closed
 test_codex_omits_invalid_max_effort
 test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -423,6 +423,8 @@ test_codex_no_mistakes_ship_receives_gate_state_and_git_writable_roots() {
     "Codex ship launch omitted the state or linked-worktree Git metadata root"
   assert_contains "$launch" "--add-dir '$no_mistakes_real'" \
     "Codex no-mistakes ship launch omitted the selected no-mistakes root"
+  assert_contains "$launch" "-c 'sandbox_workspace_write.network_access=true'" \
+    "Codex no-mistakes ship launch omitted workspace-write network access"
   assert_contains "$launch" "NM_HOME='$no_mistakes_real' codex" \
     "Codex no-mistakes ship launch did not freeze the same selected root for the worker"
   assert_not_contains "$launch" "--add-dir '$data_real'" \
@@ -455,6 +457,8 @@ test_codex_non_gate_ship_modes_exclude_no_mistakes_root() {
       "Codex $mode ship unexpectedly received the no-mistakes root"
     assert_not_contains "$launch" "NM_HOME=" \
       "Codex $mode ship unexpectedly received the no-mistakes environment"
+    assert_not_contains "$launch" "sandbox_workspace_write.network_access=true" \
+      "Codex $mode ship unexpectedly received workspace-write network access"
   done
   pass "Codex direct-PR and local-only ships preserve existing roots without gate access"
 }
@@ -483,6 +487,8 @@ test_codex_scout_receives_task_local_report_root_without_no_mistakes_root() {
     "Codex scout launch unexpectedly received the no-mistakes root"
   assert_not_contains "$launch" "NM_HOME=" \
     "Codex scout launch unexpectedly received the no-mistakes environment"
+  assert_not_contains "$launch" "sandbox_workspace_write.network_access=true" \
+    "Codex scout launch unexpectedly received workspace-write network access"
   pass "Codex scout keeps its report root without sibling data or gate access"
 }
 
@@ -554,6 +560,8 @@ test_codex_no_mistakes_root_is_physical_and_shell_quoted() {
   no_mistakes_real=$(CDPATH='' cd -- "$no_mistakes_real" && pwd -P)
   assert_contains "$launch" "--add-dir '$no_mistakes_real'" \
     "Codex no-mistakes root was not physically resolved and shell quoted"
+  assert_contains "$launch" "-c 'sandbox_workspace_write.network_access=true'" \
+    "Codex no-mistakes launch omitted workspace-write network access"
   assert_contains "$launch" "NM_HOME='$no_mistakes_real' codex" \
     "Codex no-mistakes environment did not use the physical shell-quoted root"
   assert_not_contains "$launch" "$no_mistakes_link" \
@@ -875,6 +883,8 @@ test_active_dispatch_profile_does_not_block_secondmate_launch() {
     "Codex secondmate launch must not receive parent-home worker writable roots"
   assert_not_contains "$launch" "NM_HOME=" \
     "Codex secondmate launch must not receive the parent no-mistakes environment"
+  assert_not_contains "$launch" "sandbox_workspace_write.network_access=true" \
+    "Codex secondmate launch must not receive parent no-mistakes network access"
   pass "active crew-dispatch profile does not block secondmate launches"
 }
 

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -48,8 +48,21 @@ SH
   cat > "$fakebin/no-mistakes" <<'SH'
 #!/usr/bin/env bash
 set -u
-[ "${1:-}" = daemon ] && [ "${2:-}" = status ] || exit 2
-[ -f "${NM_HOME:-}/.fm-test-no-mistakes-home" ]
+if [ "$#" -eq 2 ] && [ "$1" = daemon ] && [ "$2" = status ]; then
+  if [ -f "${NM_HOME:-}/.fm-test-no-mistakes-daemon-running" ]; then
+    printf 'daemon running\n'
+  else
+    printf 'daemon not running\n'
+  fi
+  exit 0
+fi
+if [ "$#" -eq 1 ] && [ "$1" = axi ]; then
+  [ "${NO_MISTAKES_TELEMETRY:-}" = off ] || exit 3
+  [ "${NO_MISTAKES_NO_UPDATE_CHECK:-}" = 1 ] || exit 3
+  [ -f "${NM_HOME:-}/.fm-test-no-mistakes-daemon-running" ]
+  exit
+fi
+exit 2
 SH
   chmod +x "$fakebin/tmux" "$fakebin/no-mistakes"
   fm_fake_exit0 "$fakebin" treehouse pi-signed
@@ -67,8 +80,8 @@ make_spawn_case() {
   fakebin=$(make_spawn_fakebin "$case_dir/fake")
   mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config" \
     "$home/no-mistakes-home" "$home/user-home/.no-mistakes"
-  touch "$home/no-mistakes-home/.fm-test-no-mistakes-home" \
-    "$home/user-home/.no-mistakes/.fm-test-no-mistakes-home"
+  touch "$home/no-mistakes-home/.fm-test-no-mistakes-daemon-running" \
+    "$home/user-home/.no-mistakes/.fm-test-no-mistakes-daemon-running"
   printf '%s\n' "$harness" > "$home/config/crew-harness"
   fm_git_worktree "$proj" "$wt" "wt-$name"
   touch "$home/state/.last-watcher-beat"
@@ -559,7 +572,7 @@ test_codex_no_mistakes_root_is_physical_and_shell_quoted() {
   fakebin=$(make_spawn_fakebin "$case_dir/fake")
   mkdir -p "$home_real/data/$id" "$home_real/projects" "$home_real/state" \
     "$home_real/config" "$home_real/user-home" "$no_mistakes_real"
-  touch "$no_mistakes_real/.fm-test-no-mistakes-home"
+  touch "$no_mistakes_real/.fm-test-no-mistakes-daemon-running"
   printf '%s\n' codex > "$home_real/config/crew-harness"
   printf 'brief for %s\n' "$id" > "$home_real/data/$id/brief.md"
   touch "$home_real/state/.last-watcher-beat"
@@ -650,12 +663,14 @@ test_codex_no_mistakes_root_rejects_unverified_homes() {
   local rec base_id labels candidates i id out status
   base_id=profile-codex-roots-unverified-z3j
   rec=$(make_spawn_case profile-codex-roots-unverified codex \
-    "$base_id-credentials" "$base_id-repository")
+    "$base_id-stopped-daemon" "$base_id-credentials" "$base_id-repository")
   read_case_record "$rec"
-  mkdir -p "$HOME_DIR/user-home/.ssh" "$CASE_DIR/unrelated-repository"
+  mkdir -p "$CASE_DIR/stopped-no-mistakes-home" \
+    "$HOME_DIR/user-home/.ssh" "$CASE_DIR/unrelated-repository"
   git -C "$CASE_DIR/unrelated-repository" init -q
-  labels=(credentials repository)
-  candidates=("$HOME_DIR/user-home/.ssh" "$CASE_DIR/unrelated-repository")
+  labels=(stopped-daemon credentials repository)
+  candidates=("$CASE_DIR/stopped-no-mistakes-home" \
+    "$HOME_DIR/user-home/.ssh" "$CASE_DIR/unrelated-repository")
 
   for i in "${!labels[@]}"; do
     id="$base_id-${labels[$i]}"
@@ -670,7 +685,7 @@ test_codex_no_mistakes_root_rejects_unverified_homes() {
     [ ! -s "$LAUNCH_LOG.endpoint" ] || fail "Codex no-mistakes unverified-root refusal created an endpoint"
     [ ! -s "$LAUNCH_LOG" ] || fail "Codex no-mistakes unverified-root refusal typed a launch command"
   done
-  pass "Codex no-mistakes spawn rejects credential and unrelated repository roots without runtime identity"
+  pass "Codex no-mistakes spawn rejects stopped, credential, and repository roots without a socket connection"
 }
 
 test_raw_no_mistakes_launches_fail_closed() {

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -45,7 +45,13 @@ case "${1:-}" in
 esac
 exit 0
 SH
-  chmod +x "$fakebin/tmux"
+  cat > "$fakebin/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+set -u
+[ "${1:-}" = daemon ] && [ "${2:-}" = status ] || exit 2
+[ -f "${NM_HOME:-}/.fm-test-no-mistakes-home" ]
+SH
+  chmod +x "$fakebin/tmux" "$fakebin/no-mistakes"
   fm_fake_exit0 "$fakebin" treehouse pi-signed
   printf '%s\n' "$fakebin"
 }
@@ -61,6 +67,8 @@ make_spawn_case() {
   fakebin=$(make_spawn_fakebin "$case_dir/fake")
   mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config" \
     "$home/no-mistakes-home" "$home/user-home/.no-mistakes"
+  touch "$home/no-mistakes-home/.fm-test-no-mistakes-home" \
+    "$home/user-home/.no-mistakes/.fm-test-no-mistakes-home"
   printf '%s\n' "$harness" > "$home/config/crew-harness"
   fm_git_worktree "$proj" "$wt" "wt-$name"
   touch "$home/state/.last-watcher-beat"
@@ -361,22 +369,22 @@ test_active_dispatch_profile_allows_positional_harness() {
   pass "active crew-dispatch profile allows the legacy positional harness form"
 }
 
-test_active_dispatch_profile_allows_raw_launch_command() {
+test_active_dispatch_profile_allows_raw_non_gate_launch_command() {
   local rec id out status launch
   id=profile-raw-z15
   rec=$(make_spawn_case profile-raw claude "$id")
   read_case_record "$rec"
   enable_dispatch_profile "$HOME_DIR"
 
-  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
-    "$id" "$PROJ_DIR" "custom-agent --flag")
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" "custom-agent --flag" --mode local-only --yolo off)
   status=$?
   expect_code 0 "$status" "raw launch command should satisfy active dispatch-profile requirement"
   assert_contains "$out" "spawned $id harness=custom-agent" "spawn did not report raw command harness"
   assert_meta_profile "$HOME_DIR/state/$id.meta" custom-agent default default
   launch=$(cat "$LAUNCH_LOG")
   [ "$launch" = "custom-agent --flag" ] || fail "raw launch command changed"$'\n'"actual: $launch"
-  pass "active crew-dispatch profile allows the raw launch-command escape hatch"
+  pass "active crew-dispatch profile allows the raw launch-command escape hatch outside no-mistakes mode"
 }
 
 test_claude_threads_model_and_effort() {
@@ -551,6 +559,7 @@ test_codex_no_mistakes_root_is_physical_and_shell_quoted() {
   fakebin=$(make_spawn_fakebin "$case_dir/fake")
   mkdir -p "$home_real/data/$id" "$home_real/projects" "$home_real/state" \
     "$home_real/config" "$home_real/user-home" "$no_mistakes_real"
+  touch "$no_mistakes_real/.fm-test-no-mistakes-home"
   printf '%s\n' codex > "$home_real/config/crew-harness"
   printf 'brief for %s\n' "$id" > "$home_real/data/$id/brief.md"
   touch "$home_real/state/.last-watcher-beat"
@@ -637,23 +646,60 @@ test_codex_no_mistakes_root_rejects_broad_or_overlapping_paths() {
   pass "Codex no-mistakes spawn rejects broad and protected overlapping roots"
 }
 
-test_raw_codex_no_mistakes_launch_fails_closed() {
-  local rec id out status
-  id=profile-raw-codex-no-mistakes-z3i
-  rec=$(make_spawn_case profile-raw-codex-no-mistakes claude "$id")
+test_codex_no_mistakes_root_rejects_unverified_homes() {
+  local rec base_id labels candidates i id out status
+  base_id=profile-codex-roots-unverified-z3j
+  rec=$(make_spawn_case profile-codex-roots-unverified codex \
+    "$base_id-credentials" "$base_id-repository")
   read_case_record "$rec"
+  mkdir -p "$HOME_DIR/user-home/.ssh" "$CASE_DIR/unrelated-repository"
+  git -C "$CASE_DIR/unrelated-repository" init -q
+  labels=(credentials repository)
+  candidates=("$HOME_DIR/user-home/.ssh" "$CASE_DIR/unrelated-repository")
 
-  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
-    "$id" "$PROJ_DIR" "codex --profile isolated")
-  status=$?
-  expect_code 1 "$status" "raw Codex no-mistakes launch should fail"
-  assert_contains "$out" "raw Codex launch commands cannot satisfy the no-mistakes writable-root contract" \
-    "raw Codex no-mistakes refusal did not name the unsupported access contract"
-  assert_absent "$HOME_DIR/state/$id.meta" \
-    "raw Codex no-mistakes refusal wrote task metadata"
-  [ ! -s "$LAUNCH_LOG.endpoint" ] || fail "raw Codex no-mistakes refusal created an endpoint"
-  [ ! -s "$LAUNCH_LOG" ] || fail "raw Codex no-mistakes refusal typed a launch command"
-  pass "raw Codex no-mistakes launch fails before endpoint creation"
+  for i in "${!labels[@]}"; do
+    id="$base_id-${labels[$i]}"
+    out=$(FM_TEST_NM_HOME="${candidates[$i]}" \
+      run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+    status=$?
+    expect_code 1 "$status" "Codex no-mistakes spawn with an unverified ${labels[$i]} root should fail"
+    assert_contains "$out" "selected root cannot be verified as an active no-mistakes home" \
+      "Codex no-mistakes refusal did not require positive runtime identity"
+    assert_absent "$HOME_DIR/state/$id.meta" \
+      "Codex no-mistakes unverified-root refusal wrote task metadata"
+    [ ! -s "$LAUNCH_LOG.endpoint" ] || fail "Codex no-mistakes unverified-root refusal created an endpoint"
+    [ ! -s "$LAUNCH_LOG" ] || fail "Codex no-mistakes unverified-root refusal typed a launch command"
+  done
+  pass "Codex no-mistakes spawn rejects credential and unrelated repository roots without runtime identity"
+}
+
+test_raw_no_mistakes_launches_fail_closed() {
+  local rec base_id labels commands i id out status
+  base_id=profile-raw-no-mistakes-z3i
+  rec=$(make_spawn_case profile-raw-no-mistakes claude \
+    "$base_id-codex" "$base_id-env-codex" "$base_id-opaque")
+  read_case_record "$rec"
+  labels=(codex env-codex opaque)
+  commands=(
+    "codex --profile isolated"
+    "env NM_HOME=$HOME_DIR/no-mistakes-home codex --profile isolated"
+    "custom-agent --flag"
+  )
+
+  for i in "${!labels[@]}"; do
+    id="$base_id-${labels[$i]}"
+    out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+      "$id" "$PROJ_DIR" "${commands[$i]}")
+    status=$?
+    expect_code 1 "$status" "raw ${labels[$i]} no-mistakes launch should fail"
+    assert_contains "$out" "raw launch commands cannot satisfy the no-mistakes writable-root contract" \
+      "raw no-mistakes refusal did not name the unsupported access contract"
+    assert_absent "$HOME_DIR/state/$id.meta" \
+      "raw no-mistakes refusal wrote task metadata"
+    [ ! -s "$LAUNCH_LOG.endpoint" ] || fail "raw no-mistakes refusal created an endpoint"
+    [ ! -s "$LAUNCH_LOG" ] || fail "raw no-mistakes refusal typed a launch command"
+  done
+  pass "all opaque no-mistakes launches fail before endpoint creation"
 }
 
 test_codex_omits_invalid_max_effort() {
@@ -947,7 +993,7 @@ test_active_dispatch_profile_requires_explicit_harness_for_ship
 test_active_dispatch_profile_requires_explicit_harness_for_scout
 test_active_dispatch_profile_allows_explicit_harness
 test_active_dispatch_profile_allows_positional_harness
-test_active_dispatch_profile_allows_raw_launch_command
+test_active_dispatch_profile_allows_raw_non_gate_launch_command
 test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
 test_codex_no_mistakes_ship_receives_gate_state_and_git_writable_roots
@@ -958,7 +1004,8 @@ test_codex_no_mistakes_root_is_physical_and_shell_quoted
 test_codex_no_mistakes_root_uses_home_default_when_nm_home_is_empty
 test_codex_no_mistakes_root_resolution_fails_closed
 test_codex_no_mistakes_root_rejects_broad_or_overlapping_paths
-test_raw_codex_no_mistakes_launch_fails_closed
+test_codex_no_mistakes_root_rejects_unverified_homes
+test_raw_no_mistakes_launches_fail_closed
 test_codex_omits_invalid_max_effort
 test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -55,7 +55,8 @@ make_spawn_case() {
   wt="$case_dir/wt"
   launchlog="$case_dir/launch.log"
   fakebin=$(make_spawn_fakebin "$case_dir/fake")
-  mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
+  mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config" \
+    "$home/no-mistakes-home" "$home/user-home/.no-mistakes"
   printf '%s\n' "$harness" > "$home/config/crew-harness"
   fm_git_worktree "$proj" "$wt" "wt-$name"
   touch "$home/state/.last-watcher-beat"
@@ -92,6 +93,8 @@ run_spawn() {
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    HOME="${FM_TEST_HOME-$home/user-home}" \
+    NM_HOME="${FM_TEST_NM_HOME-$home/no-mistakes-home}" \
     CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
     FM_FAKE_LAUNCH_LOG="$launchlog" GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
     "$SPAWN" "$@" 2>&1
@@ -131,7 +134,11 @@ test_no_profile_keeps_claude_profile_defaults() {
   launch=$(cat "$LAUNCH_LOG")
   expected="CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch did not use the canonical launch kind"$'\n'"expected: $expected"$'\n'"actual:   $launch"
-  pass "no --model/--effort records defaults and types the claude launch instructions"
+  assert_not_contains "$launch" "NM_HOME=" \
+    "non-Codex no-mistakes ship unexpectedly received the no-mistakes environment"
+  assert_not_contains "$launch" "--add-dir" \
+    "non-Codex no-mistakes ship unexpectedly received a Codex writable root"
+  pass "non-Codex launch excludes Codex roots while preserving default profile instructions"
 }
 
 test_relative_home_overrides_launch_with_absolute_cross_process_paths() {
@@ -398,6 +405,199 @@ test_codex_threads_model_and_effort() {
   pass "codex receives --model and model_reasoning_effort profile flags"
 }
 
+test_codex_no_mistakes_ship_receives_gate_state_and_git_writable_roots() {
+  local rec id out status launch state_real git_common_real data_real no_mistakes_real
+  id=profile-codex-roots-ship-z3a
+  rec=$(make_spawn_case profile-codex-roots-ship codex "$id")
+  read_case_record "$rec"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "Codex ship spawn with writable roots should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  state_real=$(cd "$HOME_DIR/state" && pwd -P)
+  git_common_real=$(cd "$(git -C "$WT_DIR" rev-parse --git-common-dir)" && pwd -P)
+  data_real=$(cd "$HOME_DIR/data/$id" && pwd -P)
+  no_mistakes_real=$(cd "$HOME_DIR/no-mistakes-home" && pwd -P)
+  assert_contains "$launch" "--add-dir '$state_real' --add-dir '$git_common_real'" \
+    "Codex ship launch omitted the state or linked-worktree Git metadata root"
+  assert_contains "$launch" "--add-dir '$no_mistakes_real'" \
+    "Codex no-mistakes ship launch omitted the selected no-mistakes root"
+  assert_contains "$launch" "NM_HOME='$no_mistakes_real' codex" \
+    "Codex no-mistakes ship launch did not freeze the same selected root for the worker"
+  assert_not_contains "$launch" "--add-dir '$data_real'" \
+    "Codex ship launch must not receive a scout report directory"
+  pass "Codex no-mistakes ship receives only its gate, state, and Git metadata roots"
+}
+
+test_codex_non_gate_ship_modes_exclude_no_mistakes_root() {
+  local mode mode_slug rec id out status launch no_mistakes_real state_real git_common_real
+  for mode in direct-PR local-only; do
+    case "$mode" in
+      direct-PR) mode_slug=direct-pr ;;
+      local-only) mode_slug=local-only ;;
+    esac
+    id="profile-codex-roots-${mode_slug}-z3d"
+    rec=$(make_spawn_case "profile-codex-roots-$mode_slug" codex "$id")
+    read_case_record "$rec"
+
+    out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+      "$id" "$PROJ_DIR" --mode "$mode" --yolo off)
+    status=$?
+    expect_code 0 "$status" "Codex $mode ship spawn should succeed"
+    launch=$(cat "$LAUNCH_LOG")
+    no_mistakes_real=$(cd "$HOME_DIR/no-mistakes-home" && pwd -P)
+    state_real=$(cd "$HOME_DIR/state" && pwd -P)
+    git_common_real=$(cd "$(git -C "$WT_DIR" rev-parse --git-common-dir)" && pwd -P)
+    assert_contains "$launch" "--add-dir '$state_real' --add-dir '$git_common_real'" \
+      "Codex $mode ship lost its existing state or Git metadata root"
+    assert_not_contains "$launch" "--add-dir '$no_mistakes_real'" \
+      "Codex $mode ship unexpectedly received the no-mistakes root"
+    assert_not_contains "$launch" "NM_HOME=" \
+      "Codex $mode ship unexpectedly received the no-mistakes environment"
+  done
+  pass "Codex direct-PR and local-only ships preserve existing roots without gate access"
+}
+
+test_codex_scout_receives_task_local_report_root_without_no_mistakes_root() {
+  local rec id out status launch report_real no_mistakes_real state_real git_common_real
+  id=profile-codex-roots-scout-z3b
+  rec=$(make_spawn_case profile-codex-roots-scout codex "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --scout)
+  status=$?
+  expect_code 0 "$status" "Codex scout spawn with writable roots should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  report_real=$(cd "$HOME_DIR/data/$id" && pwd -P)
+  no_mistakes_real=$(cd "$HOME_DIR/no-mistakes-home" && pwd -P)
+  state_real=$(cd "$HOME_DIR/state" && pwd -P)
+  git_common_real=$(cd "$(git -C "$WT_DIR" rev-parse --git-common-dir)" && pwd -P)
+  assert_contains "$launch" "--add-dir '$state_real' --add-dir '$git_common_real'" \
+    "Codex scout lost its existing state or Git metadata root"
+  assert_contains "$launch" "--add-dir '$report_real'" \
+    "Codex scout launch omitted its task-local report directory"
+  assert_not_contains "$launch" "--add-dir '$HOME_DIR/data' " \
+    "Codex scout launch must not receive the whole data directory"
+  assert_not_contains "$launch" "--add-dir '$no_mistakes_real'" \
+    "Codex scout launch unexpectedly received the no-mistakes root"
+  assert_not_contains "$launch" "NM_HOME=" \
+    "Codex scout launch unexpectedly received the no-mistakes environment"
+  pass "Codex scout keeps its report root without sibling data or gate access"
+}
+
+test_codex_writable_roots_are_physical_and_shell_quoted() {
+  local case_dir paths home_real home_link proj wt fakebin launchlog id out status launch
+  local state_real report_real git_common_real
+  id=profile-codex-roots-spaces-z3c
+  case_dir="$TMP_ROOT/profile-codex-roots-spaces"
+  paths="$case_dir/paths with spaces"
+  home_real="$paths/home"
+  home_link="$case_dir/home-link"
+  proj="$paths/project"
+  wt="$paths/worktree"
+  launchlog="$case_dir/launch.log"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  mkdir -p "$home_real/data/$id" "$home_real/projects" "$home_real/state" "$home_real/config"
+  printf '%s\n' codex > "$home_real/config/crew-harness"
+  printf 'brief for %s\n' "$id" > "$home_real/data/$id/brief.md"
+  touch "$home_real/state/.last-watcher-beat"
+  ln -s "$home_real" "$home_link"
+  fm_git_worktree "$proj" "$wt" wt-codex-roots-spaces
+
+  out=$(run_spawn "$home_link" "$wt" "$fakebin" "$launchlog" "$id" "$proj" --scout)
+  status=$?
+  expect_code 0 "$status" "Codex scout spawn with spaced and symlinked paths should succeed"
+  launch=$(cat "$launchlog")
+  state_real=$(cd "$home_real/state" && pwd -P)
+  report_real=$(cd "$home_real/data/$id" && pwd -P)
+  git_common_real=$(cd "$(git -C "$wt" rev-parse --git-common-dir)" && pwd -P)
+  assert_contains "$launch" "--add-dir '$state_real'" \
+    "Codex state writable root was not physically resolved and shell quoted"
+  assert_contains "$launch" "--add-dir '$git_common_real'" \
+    "Codex Git metadata writable root was not physically resolved and shell quoted"
+  assert_contains "$launch" "--add-dir '$report_real'" \
+    "Codex report writable root was not physically resolved and shell quoted"
+  assert_not_contains "$launch" "$home_link/state" \
+    "Codex launch leaked the symlink spelling instead of the physical state path"
+  pass "Codex writable roots are physical paths and remain one shell argument with spaces"
+}
+
+test_codex_no_mistakes_root_is_physical_and_shell_quoted() {
+  local case_dir paths home_real home_link proj wt fakebin launchlog id out status launch
+  local no_mistakes_real no_mistakes_link
+  id=profile-codex-no-mistakes-spaces-z3g
+  case_dir="$TMP_ROOT/profile-codex-no-mistakes-spaces"
+  paths="$case_dir/paths with spaces"
+  home_real="$paths/home"
+  home_link="$case_dir/home-link"
+  proj="$paths/project"
+  wt="$paths/worktree"
+  no_mistakes_real="$paths/no mistakes"
+  no_mistakes_link="$case_dir/no-mistakes-link"
+  launchlog="$case_dir/launch.log"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  mkdir -p "$home_real/data/$id" "$home_real/projects" "$home_real/state" \
+    "$home_real/config" "$home_real/user-home" "$no_mistakes_real"
+  printf '%s\n' codex > "$home_real/config/crew-harness"
+  printf 'brief for %s\n' "$id" > "$home_real/data/$id/brief.md"
+  touch "$home_real/state/.last-watcher-beat"
+  ln -s "$home_real" "$home_link"
+  ln -s "$no_mistakes_real" "$no_mistakes_link"
+  fm_git_worktree "$proj" "$wt" wt-codex-no-mistakes-spaces
+
+  out=$(FM_TEST_NM_HOME="$no_mistakes_link" \
+    run_ship_spawn "$home_link" "$wt" "$fakebin" "$launchlog" "$id" "$proj")
+  status=$?
+  expect_code 0 "$status" "Codex no-mistakes spawn with spaced and symlinked paths should succeed"
+  launch=$(cat "$launchlog")
+  no_mistakes_real=$(CDPATH='' cd -- "$no_mistakes_real" && pwd -P)
+  assert_contains "$launch" "--add-dir '$no_mistakes_real'" \
+    "Codex no-mistakes root was not physically resolved and shell quoted"
+  assert_contains "$launch" "NM_HOME='$no_mistakes_real' codex" \
+    "Codex no-mistakes environment did not use the physical shell-quoted root"
+  assert_not_contains "$launch" "$no_mistakes_link" \
+    "Codex launch leaked the no-mistakes symlink spelling instead of its physical path"
+  pass "Codex no-mistakes root is physical and remains one shell argument with spaces"
+}
+
+test_codex_no_mistakes_root_uses_home_default_when_nm_home_is_empty() {
+  local rec id out status launch expected
+  id=profile-codex-roots-home-default-z3e
+  rec=$(make_spawn_case profile-codex-roots-home-default codex "$id")
+  read_case_record "$rec"
+
+  out=$(FM_TEST_NM_HOME='' \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "Codex no-mistakes spawn with the HOME default should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  expected=$(cd "$HOME_DIR/user-home/.no-mistakes" && pwd -P)
+  assert_contains "$launch" "--add-dir '$expected'" \
+    "Codex no-mistakes launch did not select HOME/.no-mistakes when NM_HOME was empty"
+  assert_contains "$launch" "NM_HOME='$expected' codex" \
+    "Codex no-mistakes launch did not freeze the HOME-derived root"
+  pass "Codex no-mistakes root follows the authoritative HOME default"
+}
+
+test_codex_no_mistakes_root_resolution_fails_closed() {
+  local rec id out status
+  id=profile-codex-roots-missing-z3f
+  rec=$(make_spawn_case profile-codex-roots-missing codex "$id")
+  read_case_record "$rec"
+
+  out=$(FM_TEST_NM_HOME="$CASE_DIR/missing-no-mistakes-home" \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 1 "$status" "Codex no-mistakes spawn with an unresolved root should fail"
+  assert_contains "$out" "no-mistakes root from NM_HOME is not an existing directory" \
+    "Codex no-mistakes refusal did not name the unresolved configured root"
+  assert_absent "$HOME_DIR/state/$id.meta" \
+    "Codex no-mistakes root refusal wrote task metadata"
+  [ ! -s "$LAUNCH_LOG" ] || fail "Codex no-mistakes root refusal typed a launch command"
+  pass "Codex no-mistakes spawn fails closed before endpoint publication when its root is unresolved"
+}
+
 test_codex_omits_invalid_max_effort() {
   local rec id out status launch
   id=profile-codex-max-z4
@@ -656,7 +856,7 @@ test_non_claude_harness_ignores_config_dir() {
 }
 
 test_active_dispatch_profile_does_not_block_secondmate_launch() {
-  local rec id sm out status
+  local rec id sm out status launch
   id=profile-secondmate-z16
   rec=$(make_spawn_case profile-secondmate codex "$id")
   read_case_record "$rec"
@@ -670,6 +870,11 @@ test_active_dispatch_profile_does_not_block_secondmate_launch() {
   assert_contains "$out" "spawned $id harness=codex kind=secondmate" "secondmate launch did not use secondmate harness resolution"
   assert_grep "kind=secondmate" "$HOME_DIR/state/$id.meta" "secondmate meta missing kind=secondmate"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex default default
+  launch=$(cat "$LAUNCH_LOG")
+  assert_not_contains "$launch" "--add-dir" \
+    "Codex secondmate launch must not receive parent-home worker writable roots"
+  assert_not_contains "$launch" "NM_HOME=" \
+    "Codex secondmate launch must not receive the parent no-mistakes environment"
   pass "active crew-dispatch profile does not block secondmate launches"
 }
 
@@ -685,6 +890,13 @@ test_active_dispatch_profile_allows_positional_harness
 test_active_dispatch_profile_allows_raw_launch_command
 test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
+test_codex_no_mistakes_ship_receives_gate_state_and_git_writable_roots
+test_codex_non_gate_ship_modes_exclude_no_mistakes_root
+test_codex_scout_receives_task_local_report_root_without_no_mistakes_root
+test_codex_writable_roots_are_physical_and_shell_quoted
+test_codex_no_mistakes_root_is_physical_and_shell_quoted
+test_codex_no_mistakes_root_uses_home_default_when_nm_home_is_empty
+test_codex_no_mistakes_root_resolution_fails_closed
 test_codex_omits_invalid_max_effort
 test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -49,18 +49,24 @@ SH
 #!/usr/bin/env bash
 set -u
 if [ "$#" -eq 2 ] && [ "$1" = daemon ] && [ "$2" = status ]; then
+  [ "${NO_MISTAKES_TELEMETRY:-}" = off ] || exit 3
+  [ "${NO_MISTAKES_NO_UPDATE_CHECK:-}" = 1 ] || exit 3
   if [ -f "${NM_HOME:-}/.fm-test-no-mistakes-daemon-running" ]; then
-    printf 'daemon running\n'
+    printf '  ✓ daemon running (pid 4242)\n'
   else
-    printf 'daemon not running\n'
+    printf '  ○ daemon not running\n'
   fi
   exit 0
 fi
 if [ "$#" -eq 1 ] && [ "$1" = axi ]; then
   [ "${NO_MISTAKES_TELEMETRY:-}" = off ] || exit 3
   [ "${NO_MISTAKES_NO_UPDATE_CHECK:-}" = 1 ] || exit 3
-  [ -f "${NM_HOME:-}/.fm-test-no-mistakes-daemon-running" ]
-  exit
+  if [ -f "${NM_HOME:-}/.fm-test-no-mistakes-daemon-running" ]; then
+    printf 'daemon: running\n'
+  else
+    printf 'daemon: stopped\n'
+  fi
+  exit 0
 fi
 exit 2
 SH

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -97,7 +97,7 @@ run_settle_spawn() {
     FM_FAKE_PANE_PATH="$WT_DIR" FM_FAKE_PANE_STALE="$STALE_DIR" \
     FM_FAKE_PANE_STALE_READS="$STALE_READS" FM_FAKE_PANE_COUNTFILE="$COUNTFILE" \
     PATH="$FAKEBIN_DIR:$PATH" \
-    "$SPAWN" "$id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1
+    "$SPAWN" "$id" "$PROJ_DIR" --mode local-only --yolo off 2>&1
 }
 
 # A single stale first read (the exact incident) must not be accepted: the

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -182,7 +182,7 @@ run_spawn() {
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$pane" TMUX="fake,1,0" \
     PATH="$fakebin:$PATH" \
-    "$ROOT/bin/fm-spawn.sh" "$id" "$proj" codex --mode no-mistakes --yolo off 2>&1
+    "$ROOT/bin/fm-spawn.sh" "$id" "$proj" codex --mode local-only --yolo off 2>&1
 }
 
 test_spawn_isolation_abort() {
@@ -262,7 +262,7 @@ run_spawn_record() {
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$pane" TMUX="fake,1,0" \
     FM_TMUX_REC="$rec" \
     PATH="$fakebin:$PATH" \
-    "$ROOT/bin/fm-spawn.sh" "$id" "$proj" codex --mode no-mistakes --yolo off 2>&1
+    "$ROOT/bin/fm-spawn.sh" "$id" "$proj" codex --mode local-only --yolo off 2>&1
 }
 
 test_spawn_tmux_window_construction() {


### PR DESCRIPTION
## What Changed

- Expanded `bin/fm-spawn.sh` to support and verify no-mistakes socket access, including writable-root launch contracts and portable spawn modes.
- Added runtime-backend verification guidance and updated harness/test-runner documentation for the no-mistakes writable-root boundary.
- Added and updated deterministic dispatch, launch, workspace, gate, backend, and live writable-root end-to-end coverage; deterministic tests passed, while live socket/worker writes remain sandbox-blocked.

## Risk Assessment

⚠️ Medium: The implementation is bounded and internally consistent, but it changes a security-sensitive sandbox boundary by granting selected Codex workers access to shared Git metadata and the verified no-mistakes root.

## Testing

Launch root selection, quoting, mode restrictions, network access, fail-closed validation, and raw-launch refusal passed. The live Codex/no-mistakes E2E could not initialize due to sandbox permissions.

<details>
<summary>Evidence: Codex writable-roots live E2E</summary>

<code>Credentialed live E2E blocked by sandbox: Codex PATH-alias/app-server initialization returned `Operation not permitted`.</code>

```text
WARNING: proceeding, even though we could not create PATH aliases: Operation not permitted (os error 1)
not ok - Codex control turn failed: WARNING: proceeding, even though we could not create PATH aliases: Operation not permitted (os error 1)
Reading additional input from stdin...
Error: failed to initialize in-process app-server client: Operation not permitted (os error 1)
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (3m33s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - medium risk</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `tests/fm-codex-writable-roots-live-e2e.test.sh` - Live socket access and worker-side writes remain unverified because the sandbox blocked Codex initialization. Deterministic launch-contract tests passed.
- `PATH="$PWD/.test-fakebin:$PATH" bin/fm-test-run.sh tests/fm-spawn-dispatch-profile.test.sh`
- `FM_CODEX_WRITABLE_ROOTS_LIVE_E2E=1 bash tests/fm-codex-writable-roots-live-e2e.test.sh`

</details>

<details>
<summary>⚠️ **Document** - 1 warning</summary>

- ⚠️ `.agents/skills/harness-adapters/SKILL.md:226` - The authoritative harness contract omits that no-mistakes roots must pass a read-only daemon-running check before endpoint creation. The verification record documents this, but the skill could not be edited because .agents is read-only in this phase.

🔧 Fix: Reviewed Codex writable-root documentation
1 warning still open:
- ⚠️ `.agents/skills/harness-adapters/SKILL.md:226` - The authoritative harness contract still omits the required read-only daemon-running check before endpoint creation; .agents is read-only in this phase.

🔧 Fix: Reviewed Codex writable-root documentation
1 warning still open:
- ⚠️ `.agents/skills/harness-adapters/SKILL.md:226` - The authoritative contract still omits the required read-only `no-mistakes daemon status` check requiring `daemon running (pid N)` before endpoint creation. The edit is blocked because `.agents/skills/harness-adapters/SKILL.md` is read-only in this phase.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
