### PR TITLE
fix(bin): pin C collation for the test runner's coverage guard

### DIFF
--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -569,9 +569,24 @@ select_lane() {
   [ "$found" -eq 1 ] || die "lane '$want' selected no tests"
 }
 
+# Every set operation below sorts with LC_ALL=C and must COMPARE with LC_ALL=C
+# too. `comm` collates under the ambient locale, and en_US.UTF-8 orders
+# punctuation differently from C, so a C-sorted file reads as unsorted there:
+# `fm-pr-check-security.test.sh` sorts before `fm-pr-check.test.sh` under C
+# ('-' 0x2D < '.' 0x2E) and after it under en_US.UTF-8. That mismatch made the
+# guard fail on any developer machine with a UTF-8 locale while staying green in
+# CI's C locale, and it failed in the worst way: `comm` exits non-zero on a
+# sort-order complaint, so the unguarded overlap comparison below aborted the
+# whole script under `set -e` with no diagnostic beyond a bare
+# "comm: input is not in sorted order". Pinning the collation for the function
+# keeps the sorts and the comparisons in one order and restores the real
+# diagnostics.
 run_coverage_guard() {
   local tmp missing extra a b shard
   local -a saved_scripts=()
+  # -x so `comm`, `sort` and `uniq` in the subprocesses actually see it; bash
+  # restores the caller's value on return.
+  local -x LC_ALL=C
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-coverage.XXXXXX")
 
   all_repo_tests | LC_ALL=C sort -u >"$tmp/all"

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -571,11 +571,18 @@ select_lane() {
 
 # Every set operation below sorts with LC_ALL=C and must COMPARE with LC_ALL=C
 # too. `comm` collates under the ambient locale, and en_US.UTF-8 orders
-# punctuation differently from C, so a C-sorted file reads as unsorted there:
-# `fm-pr-check-security.test.sh` sorts before `fm-pr-check.test.sh` under C
-# ('-' 0x2D < '.' 0x2E) and after it under en_US.UTF-8. That mismatch made the
-# guard fail on any developer machine with a UTF-8 locale while staying green in
-# CI's C locale, and it failed in the worst way: `comm` exits non-zero on a
+# punctuation differently from C, so a C-sorted file reads as unsorted there.
+# This repo's own file set diverges: C compares byte by byte and puts
+# `fm-backend-herdr-workspace-per-home-e2e.test.sh` first because '-' (0x2D)
+# precedes '.' (0x2E), while glibc drops punctuation at the primary level and
+# then compares 't' against 'w', putting `fm-backend-herdr.test.sh` first.
+# Punctuation alone is not enough to diverge, so pick any replacement example by
+# running `sort` under both locales rather than by eye: `fm-pr-check-security`
+# versus `fm-pr-check` agrees in C and en_US.UTF-8, because there the characters
+# after the punctuation, 's' and 't', order the same way either way.
+# That mismatch made the guard fail on any developer machine with a UTF-8
+# locale while staying green in CI's C locale, and it failed in the worst way:
+# `comm` exits non-zero on a
 # sort-order complaint, so the unguarded overlap comparison below aborted the
 # whole script under `set -e` with no diagnostic beyond a bare
 # "comm: input is not in sorted order". Pinning the collation for the function

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -576,18 +576,19 @@ select_lane() {
 # `fm-backend-herdr-workspace-per-home-e2e.test.sh` first because '-' (0x2D)
 # precedes '.' (0x2E), while glibc drops punctuation at the primary level and
 # then compares 't' against 'w', putting `fm-backend-herdr.test.sh` first.
-# Punctuation alone is not enough to diverge, so pick any replacement example by
-# running `sort` under both locales rather than by eye: `fm-pr-check-security`
-# versus `fm-pr-check` agrees in C and en_US.UTF-8, because there the characters
-# after the punctuation, 's' and 't', order the same way either way.
 # That mismatch made the guard fail on any developer machine with a UTF-8
 # locale while staying green in CI's C locale, and it failed in the worst way:
-# `comm` exits non-zero on a
-# sort-order complaint, so the unguarded overlap comparison below aborted the
-# whole script under `set -e` with no diagnostic beyond a bare
-# "comm: input is not in sorted order". Pinning the collation for the function
-# keeps the sorts and the comparisons in one order and restores the real
-# diagnostics.
+# `comm` exits non-zero on a sort-order complaint, so the unguarded overlap
+# comparison below aborted the whole script under `set -e` with no diagnostic
+# beyond a bare "comm: input is not in sorted order". Pinning the collation for
+# the function keeps the sorts and the comparisons in one order and restores
+# the real diagnostics.
+#
+# Sharing a prefix is not enough to diverge, so check any replacement example
+# by running `sort` under both locales rather than by eye:
+# `fm-backend-herdr-smoke.test.sh` sorts before `fm-backend-herdr.test.sh`
+# under both, because there the characters that decide are 's' and 't', which
+# order the same way byte-wise and at the primary level alike.
 run_coverage_guard() {
   local tmp missing extra a b shard
   local -a saved_scripts=()

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -397,16 +397,19 @@ test_portable_shard_union_and_coverage_guard() {
 # "comm: input is not in sorted order". Pins the guard to be collation
 # independent: it must succeed identically under C and under a language locale.
 test_coverage_guard_is_locale_independent() {
-  local loc out rc probe
+  local loc out rc cand c_order
   # A language locale, not C.utf8 - C.utf8 collates by codepoint exactly like C,
   # so it cannot expose the mismatch and would make this case vacuous.
-  loc=$(locale -a 2>/dev/null | grep -iE '^[a-z][a-z]_[A-Z][A-Z]\.(utf-?8)$' | head -n 1 || true)
-  # A name is not proof. The filter above is name-based, and a name-based filter
-  # cannot see that a C library collates by byte regardless of the locale it
-  # names: on a musl-based image `locale -a` lists en_US.UTF-8 while every
-  # locale sorts in C order. Running there would prove nothing while reporting
-  # that it had, which is the exact vacuity excluding C.utf8 was meant to avoid.
-  # So probe the real behavior instead of the name.
+  #
+  # A name is not proof. A name-based filter cannot see that a C library
+  # collates by byte regardless of the locale it names: on a musl-based image
+  # `locale -a` lists en_US.UTF-8 while every locale sorts in C order. Running
+  # there would prove nothing while reporting that it had, which is the exact
+  # vacuity excluding C.utf8 was meant to avoid. So probe the real behavior
+  # instead of the name, and probe every name-matching candidate rather than
+  # just the first: a host can list both a byte-collating and a truly collating
+  # UTF-8 locale, and stopping at the first would skip the check while a later
+  # candidate would have exercised the guard for real.
   #
   # The probe pair matters. "a-b" vs "a.b" looks like the obvious test and is
   # useless: glibc ignores punctuation at the primary collation level, so both
@@ -418,10 +421,15 @@ test_coverage_guard_is_locale_independent() {
   # the real divergence in this repo's own file set, where
   # fm-backend-herdr-workspace-per-home-e2e.test.sh and
   # fm-backend-herdr.test.sh swap places.
-  if [ -n "$loc" ]; then
-    probe=$(printf 'a-b\na.a\n' | LC_ALL="$loc" sort)
-    [ "$probe" = "$(printf 'a-b\na.a\n' | LC_ALL=C sort)" ] && loc=""
-  fi
+  c_order=$(printf 'a-b\na.a\n' | LC_ALL=C sort)
+  loc=""
+  while read -r cand; do
+    [ -n "$cand" ] || continue
+    if [ "$(printf 'a-b\na.a\n' | LC_ALL="$cand" sort 2>/dev/null)" != "$c_order" ]; then
+      loc="$cand"
+      break
+    fi
+  done < <(locale -a 2>/dev/null | grep -iE '^[a-z][a-z]_[A-Z][A-Z]\.(utf-?8)$' || true)
   if [ -z "$loc" ]; then
     # Report the absent capability rather than passing over it silently.
     echo "note: no locale that collates differently from C; skipping the non-C collation check" >&2

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -25,8 +25,11 @@ test_list_all_exact_suite_coverage() {
     done | LC_ALL=C sort
   )
   [ -n "$listed" ] || fail "--list --all printed nothing"
-  missing=$(comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
-  extra=$(comm -13 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
+  # LC_ALL=C on comm too: its inputs are C-sorted and comm collates under the
+  # ambient locale, which reorders punctuation and makes a C-sorted list read as
+  # unsorted (see bin/fm-test-run.sh's run_coverage_guard comment).
+  missing=$(LC_ALL=C comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
+  extra=$(LC_ALL=C comm -13 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
   [ -z "$missing" ] || fail "--list --all missing scripts: $missing"
   [ -z "$extra" ] || fail "--list --all unexpected scripts: $extra"
   # No duplicates.
@@ -359,7 +362,7 @@ test_portable_shard_union_and_coverage_guard() {
   herdr=$("$RUNNER" --list --family real-herdr-gated)
   [ -n "$s1" ] && [ -n "$s2" ] || fail "portable parallel shards must be non-empty"
   # Shards disjoint.
-  overlap=$(comm -12 <(printf '%s\n' "$s1" | LC_ALL=C sort) <(printf '%s\n' "$s2" | LC_ALL=C sort) || true)
+  overlap=$(LC_ALL=C comm -12 <(printf '%s\n' "$s1" | LC_ALL=C sort) <(printf '%s\n' "$s2" | LC_ALL=C sort) || true)
   [ -z "$overlap" ] || fail "portable parallel shards overlap: $overlap"
   # Union of shards equals proven-isolated.
   [ "$(printf '%s\n' "$s1" "$s2" | LC_ALL=C sort -u)" = \
@@ -384,6 +387,31 @@ test_portable_shard_union_and_coverage_guard() {
   [ "$first" = "tests/fm-x-mode.test.sh" ] \
     || fail "shard 1 must start with the longest proven script, got $first"
   pass "portable shard union, disjointness, and coverage guard hold"
+}
+
+# The coverage guard sorts its set files with LC_ALL=C, so it must compare them
+# under LC_ALL=C as well. Under a language locale, `comm` collates punctuation
+# differently and reports a C-sorted file as unsorted, then exits non-zero, which
+# aborted the guard under `set -e` with no diagnostic at all. CI runs in the C
+# locale, so this failed only on developer machines and only ever printed
+# "comm: input is not in sorted order". Pins the guard to be collation
+# independent: it must succeed identically under C and under a language locale.
+test_coverage_guard_is_locale_independent() {
+  local loc out rc
+  # A language locale, not C.utf8 - C.utf8 collates by codepoint exactly like C,
+  # so it cannot expose the mismatch and would make this case vacuous.
+  loc=$(locale -a 2>/dev/null | grep -iE '^[a-z][a-z]_[A-Z][A-Z]\.(utf-?8)$' | head -n 1 || true)
+  if [ -z "$loc" ]; then
+    # Report the absent dependency rather than passing over it silently.
+    echo "note: no language UTF-8 locale installed; skipping the non-C collation check" >&2
+    pass "coverage guard collation check skipped (no language locale available)"
+    return 0
+  fi
+  out=$(LC_ALL="$loc" "$RUNNER" --check-coverage 2>&1) && rc=0 || rc=$?
+  [ "$rc" -eq 0 ] || fail "coverage guard failed under $loc (exit $rc): $out"
+  assert_contains "$out" "FM_TEST_COVERAGE ok" "guard reports success under $loc"
+  assert_not_contains "$out" "not in sorted order" "guard must not misread its own C-sorted files under $loc"
+  pass "coverage guard is collation independent (verified under $loc)"
 }
 
 test_portable_serial_shards_partition_the_serial_lane() {
@@ -681,6 +709,7 @@ test_gate_skip_accounting
 test_fail_on_gate_skip_token
 test_exclude_family
 test_portable_shard_union_and_coverage_guard
+test_coverage_guard_is_locale_independent
 test_portable_serial_shards_partition_the_serial_lane
 test_portable_serial_shard_lane_refusals
 test_jobs_requires_proven_isolated

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -397,14 +397,35 @@ test_portable_shard_union_and_coverage_guard() {
 # "comm: input is not in sorted order". Pins the guard to be collation
 # independent: it must succeed identically under C and under a language locale.
 test_coverage_guard_is_locale_independent() {
-  local loc out rc
+  local loc out rc probe
   # A language locale, not C.utf8 - C.utf8 collates by codepoint exactly like C,
   # so it cannot expose the mismatch and would make this case vacuous.
   loc=$(locale -a 2>/dev/null | grep -iE '^[a-z][a-z]_[A-Z][A-Z]\.(utf-?8)$' | head -n 1 || true)
+  # A name is not proof. The filter above is name-based, and a name-based filter
+  # cannot see that a C library collates by byte regardless of the locale it
+  # names: on a musl-based image `locale -a` lists en_US.UTF-8 while every
+  # locale sorts in C order. Running there would prove nothing while reporting
+  # that it had, which is the exact vacuity excluding C.utf8 was meant to avoid.
+  # So probe the real behavior instead of the name.
+  #
+  # The probe pair matters. "a-b" vs "a.b" looks like the obvious test and is
+  # useless: glibc ignores punctuation at the primary collation level, so both
+  # reduce to "ab", tie, and fall back to codepoint order - identical to C even
+  # on a fully collating locale. The pair below differs in the character AFTER
+  # the punctuation, so the primary keys themselves diverge ("ab" vs "aa"): C
+  # orders by '-' (0x2D) < '.' (0x2E) and puts a-b first, while a collating
+  # locale compares b against a and puts a.a first. That is the same shape as
+  # the real divergence in this repo's own file set, where
+  # fm-backend-herdr-workspace-per-home-e2e.test.sh and
+  # fm-backend-herdr.test.sh swap places.
+  if [ -n "$loc" ]; then
+    probe=$(printf 'a-b\na.a\n' | LC_ALL="$loc" sort)
+    [ "$probe" = "$(printf 'a-b\na.a\n' | LC_ALL=C sort)" ] && loc=""
+  fi
   if [ -z "$loc" ]; then
-    # Report the absent dependency rather than passing over it silently.
-    echo "note: no language UTF-8 locale installed; skipping the non-C collation check" >&2
-    pass "coverage guard collation check skipped (no language locale available)"
+    # Report the absent capability rather than passing over it silently.
+    echo "note: no locale that collates differently from C; skipping the non-C collation check" >&2
+    pass "coverage guard collation check skipped (no differently-collating locale available)"
     return 0
   fi
   out=$(LC_ALL="$loc" "$RUNNER" --check-coverage 2>&1) && rc=0 || rc=$?

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -432,8 +432,8 @@ test_coverage_guard_is_locale_independent() {
   done < <(locale -a 2>/dev/null | grep -iE '^[a-z][a-z]_[A-Z][A-Z]\.(utf-?8)$' || true)
   if [ -z "$loc" ]; then
     # Report the absent capability rather than passing over it silently.
+    echo "skip: no differently-collating locale"
     echo "note: no locale that collates differently from C; skipping the non-C collation check" >&2
-    pass "coverage guard collation check skipped (no differently-collating locale available)"
     return 0
   fi
   out=$(LC_ALL="$loc" "$RUNNER" --check-coverage 2>&1) && rc=0 || rc=$?


### PR DESCRIPTION
## Intent

Contribute an upstream bug fix to kunchenguid/firstmate: bin/fm-test-run.sh --check-coverage is broken on any developer machine whose locale is a language UTF-8 locale rather than C.

The guard sorts all of its set files with LC_ALL=C but compares them with comm under the ambient locale. A collating locale orders the repo's own test filenames differently from C, so comm rejects its own C-sorted input, exits non-zero on the sort-order complaint, and an unguarded overlap comparison aborts the whole runner under set -e printing nothing but 'comm: input is not in sorted order'. CI runs in the C locale so it stays green there and the breakage is invisible to CI. This matters upstream specifically because CONTRIBUTING.md instructs every contributor to run bin/fm-test-run.sh --check-coverage, so contributors hit it while following the documented workflow. Measured: the unfixed guard exits 1 under en_US.utf8 and 0 under C. The real diverging pair in this repo is fm-backend-herdr-workspace-per-home-e2e.test.sh versus fm-backend-herdr.test.sh.

The fix pins the collation for the duration of run_coverage_guard with a local -x LC_ALL=C so the sorts and comparisons agree, and fixes the same mismatch in tests/fm-test-run.test.sh's own comm calls.

The branch is two commits and that shape is deliberate; do not squash or rewrite either. The first is the fix. The second answers a review finding from an earlier run of this same branch: selecting a language locale BY NAME can pass vacuously on a musl image where en_US.UTF-8 still collates by byte, so the case now probes the real ordering and skips explicitly when no installed locale collates differently from C.

OUTSTANDING REVIEW FINDINGS from the immediately previous run, already decided and to be applied as a NEW commit on top. (1) comment-cites-non-diverging-pair, warning, bin/fm-test-run.sh: the rationale comment cites fm-pr-check-security.test.sh versus fm-pr-check.test.sh, but that pair does NOT diverge and tests/fm-pr-check.test.sh does not exist; replace it with the real diverging pair named above and state the mechanism (C orders by '-' 0x2D before '.' 0x2E; glibc ignores punctuation at the primary level and then compares 't' against 'w'), verifying whatever pair you write by actually running sort under both locales. (2) probe-only-first-locale, tests/fm-test-run.test.sh: drop head -n 1, iterate the name-matching candidates and select the first whose probe output differs from the C-sorted output, reaching the existing explicit-skip branch only after all candidates were probed. Keep the probe pair as 'a-b' versus 'a.a' and keep the comment explaining why 'a-b' versus 'a.b' is inert; that pair was measured inert on glibc and reverting to it would make the case skip where the guard genuinely fails. (3) probe-proxy-vs-real-fileset was classified no-op and is deliberately NOT actioned; leave the synthetic pair rather than switching to a real-file-set probe.

Other deliberate decisions. The export (-x) on the local LC_ALL is intentional so subprocesses see it while bash restores the caller's value on return. The inline LC_ALL=C prefixes inside the function are deliberately KEPT as defence in depth even though the function-level pin makes them redundant; that was raised as a no-op and explicitly left.

Constraints: public upstream repo conventions - one sentence per line in tracked Markdown, plain dash never an em dash, no agent as commit co-author, bin/*.sh shellcheck-clean via bin/fm-lint.sh, tests colocated in tests/ as <subject>.test.sh exercising behaviour not source bytes. Scope is the collation bug alone; an unrelated crew-state run-attribution fix ships as its own PR, so do not pull it in. Add every fix as a NEW commit on top; never amend or rewrite an existing commit on this branch - an earlier run of this branch died exactly that way.

## What Changed

- `run_coverage_guard` in `bin/fm-test-run.sh` now declares `local -x LC_ALL=C`, so the `comm`/`sort`/`uniq` subprocesses that compare its set files collate in the same order those files were sorted in. Previously the sets were sorted with `LC_ALL=C` but compared under the ambient locale, so under a language UTF-8 locale `comm` reported the C-sorted input as unsorted and exited non-zero, aborting the unguarded overlap comparison under `set -e` with nothing but `comm: input is not in sorted order`. A comment records the mechanism and names the pair in this repo's own file set that diverges (`fm-backend-herdr-workspace-per-home-e2e.test.sh` vs `fm-backend-herdr.test.sh`).
- The three bare `comm` calls in `tests/fm-test-run.test.sh` that consume `LC_ALL=C sort` output are now prefixed with `LC_ALL=C` for the same reason.
- Added `test_coverage_guard_is_locale_independent`, which runs `--check-coverage` under a non-C locale and asserts exit 0, a `FM_TEST_COVERAGE ok` report, and no sort-order complaint. It selects the locale by probing actual collation of `a-b` vs `a.a` (a pair whose primary keys diverge, unlike the inert `a-b` vs `a.b`) across every `xx_XX.utf8` candidate rather than trusting the locale name, and emits the repo's gate-skip token when no installed locale collates differently from C.

## Risk Assessment

✅ Low: The fix is a tightly scoped collation pin plus a genuine regression test that fails before the fix and passes after; every collation claim, the skip-token protocol, and the absence of guard/runtime partition divergence were verified against the source, leaving only two comment- and follow-up-level notes.

## Testing

I reproduced the reported failure end-to-end before testing the fix: on the base commit, the documented contributor command `bin/fm-test-run.sh --check-coverage` exits 1 under en_US.utf8 printing only `comm: input is not in sorted order`, while exiting 0 under C - which is why CI never saw it. At branch HEAD the same command succeeds identically under both locales. I ran the runner's own contract suite (the smallest relevant automated set), which passes with the new collation case exercised for real rather than skipped, and I proved the case is a true regression test by driving it against the unfixed runner, where it is the only failure. I independently measured every collation claim in the new comments with `sort` under both locales, including the non-diverging counterexample and the inert probe pair. I also exercised both no-collating-locale skip paths behind `locale` shims and confirmed the emitted gate-skip token is honored by the runner's own `--fail-on-gate-skip` consumer, and showed the fixed guard now reports genuine coverage defects under a language locale instead of dying on the `comm` complaint. This is a shell CLI change with no rendered surface, so the evidence is CLI transcripts rather than screenshots. All checks passed and the worktree was left clean.

<details>
<summary>Evidence: Contributor command before/after, both locales</summary>

<code>########## BEFORE (base 2d2be63, unfixed guard) ##########&#10;&#10;$ LC_ALL=C bin/fm-test-run.sh --check-coverage&#10;FM_TEST_COVERAGE ok total=135 parallel=24 serial=99 serial_shards=4 herdr=12&#10;exit=0&#10;&#10;$ LC_ALL=en_US.utf8 bin/fm-test-run.sh --check-coverage&#10;comm: file 2 is not in sorted order&#10;comm: input is not in sorted order&#10;exit=1&#10;&#10;########## AFTER (HEAD 54d79aa, fixed guard) ##########&#10;&#10;$ LC_ALL=C bin/fm-test-run.sh --check-coverage&#10;FM_TEST_COVERAGE ok total=135 parallel=24 serial=99 serial_shards=4 herdr=12&#10;exit=0&#10;&#10;$ LC_ALL=en_US.utf8 bin/fm-test-run.sh --check-coverage&#10;FM_TEST_COVERAGE ok total=135 parallel=24 serial=99 serial_shards=4 herdr=12&#10;exit=0</code>

```text
########## BEFORE (base 2d2be63, unfixed guard) ##########

$ LC_ALL=C bin/fm-test-run.sh --check-coverage
FM_TEST_COVERAGE ok total=135 parallel=24 serial=99 serial_shards=4 herdr=12
exit=0

$ LC_ALL=en_US.utf8 bin/fm-test-run.sh --check-coverage
comm: file 2 is not in sorted order
comm: input is not in sorted order
exit=1

########## AFTER (HEAD 54d79aa, fixed guard) ##########

$ LC_ALL=C bin/fm-test-run.sh --check-coverage
FM_TEST_COVERAGE ok total=135 parallel=24 serial=99 serial_shards=4 herdr=12
exit=0

$ LC_ALL=en_US.utf8 bin/fm-test-run.sh --check-coverage
FM_TEST_COVERAGE ok total=135 parallel=24 serial=99 serial_shards=4 herdr=12
exit=0
```
</details>
<details>
<summary>Evidence: New case fails against the unfixed guard (regression proof)</summary>

<code>$ bash tests/fm-test-run.test.sh # ROOT pinned to the unfixed runner&#10;ok - exact suite coverage: --all lists every tests/*.test.sh once&#10;...&#10;ok - portable shard union, disjointness, and coverage guard hold&#10;not ok - coverage guard failed under en_US.utf8 (exit 1): comm: file 2 is not in sorted order&#10;comm: input is not in sorted order&#10;exit=1</code>

```text
### New regression case run against the UNFIXED guard (base 2d2be63)
$ bash tests/fm-test-run.test.sh   # ROOT pinned to the unfixed runner
ok - exact suite coverage: --all lists every tests/*.test.sh once
ok - family selection returns a proper subset of the suite
ok - single-script selection lists exactly that path
ok - changed-file selection stays conservative (never silent full suite)
ok - changed selection covers dependents and fails closed for unmapped source
ok - empty changed selection emits deterministic text and JSON summaries
ok - timing markers and JSON artifact are valid
ok - aggregate exit reflects any script failure
ok - gate-skip accounting is honest and non-failing
ok - fail-on-gate-skip converts herdr-not-found into a hard failure
ok - exclude-family drops the named primary family after selection
ok - portable shard union, disjointness, and coverage guard hold
not ok - coverage guard failed under en_US.utf8 (exit 1): comm: file 2 is not in sorted order
comm: input is not in sorted order
exit=1
```
</details>
<details>
<summary>Evidence: Collation facts measured with sort under both locales</summary>

<code>=== Diverging pair cited in bin/fm-test-run.sh comment ===&#10;-- LC_ALL=C sort --&#10;fm-backend-herdr-workspace-per-home-e2e.test.sh&#10;fm-backend-herdr.test.sh&#10;-- LC_ALL=en_US.utf8 sort --&#10;fm-backend-herdr.test.sh&#10;fm-backend-herdr-workspace-per-home-e2e.test.sh&#10;&#10;=== Counterexample pair cited as NON-diverging ===&#10;-- LC_ALL=C sort --&#10;fm-backend-herdr-smoke.test.sh&#10;fm-backend-herdr.test.sh&#10;-- LC_ALL=en_US.utf8 sort --&#10;fm-backend-herdr-smoke.test.sh&#10;fm-backend-herdr.test.sh&#10;&#10;=== Probe pair used by the test (a-b vs a.a) ===&#10;-- LC_ALL=C sort --&#10;a-b&#10;a.a&#10;-- LC_ALL=en_US.utf8 sort --&#10;a.a&#10;a-b&#10;&#10;=== Inert pair the comment warns about (a-b vs a.b) ===&#10;-- LC_ALL=C sort --&#10;a-b&#10;a.b&#10;-- LC_ALL=en_US.utf8 sort --&#10;a-b&#10;a.b</code>

```text
=== Diverging pair cited in bin/fm-test-run.sh comment ===
-- LC_ALL=C sort --
fm-backend-herdr-workspace-per-home-e2e.test.sh
fm-backend-herdr.test.sh
-- LC_ALL=en_US.utf8 sort --
fm-backend-herdr.test.sh
fm-backend-herdr-workspace-per-home-e2e.test.sh

=== Counterexample pair cited as NON-diverging ===
-- LC_ALL=C sort --
fm-backend-herdr-smoke.test.sh
fm-backend-herdr.test.sh
-- LC_ALL=en_US.utf8 sort --
fm-backend-herdr-smoke.test.sh
fm-backend-herdr.test.sh

=== Probe pair used by the test (a-b vs a.a) ===
-- LC_ALL=C sort --
a-b
a.a
-- LC_ALL=en_US.utf8 sort --
a.a
a-b

=== Inert pair the comment warns about (a-b vs a.b) ===
-- LC_ALL=C sort --
a-b
a.b
-- LC_ALL=en_US.utf8 sort --
a-b
a.b
```
</details>
<details>
<summary>Evidence: Review finding (2): head -n 1 skipped vacuously, loop verifies</summary>

<code>=== First candidate byte-collates, a later one really collates ===&#10;&#10;--- BEFORE (commit 75d3e50, `head -n 1`): skips without exercising the guard ---&#10;note: no locale that collates differently from C; skipping the non-C collation check&#10;ok - coverage guard collation check skipped (no differently-collating locale available)&#10;&#10;--- AFTER (HEAD, iterates candidates): finds en_US.utf8 and verifies for real ---&#10;ok - coverage guard is collation independent (verified under en_US.utf8)</code>

```text
=== Review finding (2): first candidate byte-collates, a later one really collates ===

--- BEFORE (commit 75d3e50, `head -n 1`): skips without exercising the guard ---
note: no locale that collates differently from C; skipping the non-C collation check
ok - coverage guard collation check skipped (no differently-collating locale available)

--- AFTER (HEAD, iterates candidates): finds en_US.utf8 and verifies for real ---
ok - coverage guard is collation independent (verified under en_US.utf8)
```
</details>
<details>
<summary>Evidence: Gate-skip token honored by the runner&#39;s own --fail-on-gate-skip</summary>

<code>=== A. Host with no language locales listed (C/C.utf8/POSIX only) ===&#10;skip: no differently-collating locale&#10;note: no locale that collates differently from C; skipping the non-C collation check&#10;FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0&#10;&#10;=== B. musl-style host: names match the filter, every one collates by byte ===&#10;skip: no differently-collating locale&#10;FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0&#10;&#10;=== C. Real consumer: --fail-on-gate-skip &#39;no differently-collating locale&#39; ===&#10;fm-test-run: required gate skip token seen in tests/fm-test-run.test.sh: skip: no differently-collating locale&#10;FM_TEST_SUMMARY total=1 failed=1&#10;runner exit=1&#10;&#10;=== D. Same host, unrelated token: stays green ===&#10;FM_TEST_SUMMARY total=1 failed=0&#10;runner exit=0&#10;&#10;=== E. First candidate byte-collates, a LATER one really collates ===&#10;ok - coverage guard is collation independent (verified under en_US.utf8)</code>

```text
=== A. Host with no language locales listed (C/C.utf8/POSIX only) ===
skip: no differently-collating locale
note: no locale that collates differently from C; skipping the non-C collation check
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=6225

=== B. musl-style host: names match the filter, every one collates by byte ===
skip: no differently-collating locale
note: no locale that collates differently from C; skipping the non-C collation check
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=6166

=== C. Real consumer: --fail-on-gate-skip 'no differently-collating locale' on that host ===
fm-test-run: required gate skip token seen in tests/fm-test-run.test.sh: skip: no differently-collating locale
FM_TEST_SUMMARY total=1 failed=1 skipped_gate=0 duration_ms=6163
runner exit=1

=== D. Same host, unrelated token: stays green ===
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=6168
runner exit=0

=== E. First candidate byte-collates, a LATER one really collates ===
    (the case head -n 1 skipped; the loop must reach en_US.utf8)
ok - coverage guard is collation independent (verified under en_US.utf8)
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=7197
```
</details>
<details>
<summary>Evidence: Fix restores real guard diagnostics under a language locale</summary>

<code>=== A test file the lanes still claim has been removed from tests/ ===&#10;removed: tests/fm-x-mode.test.sh&#10;&#10;--- BEFORE (unfixed guard, LC_ALL=en_US.utf8): dies before it can say anything ---&#10;comm: file 2 is not in sorted order&#10;comm: input is not in sorted order&#10;exit=1&#10;&#10;--- AFTER (fixed guard, LC_ALL=en_US.utf8): reports the actual coverage defect ---&#10;fm-test-run: coverage guard: union of portable shards + portable serial + Herdr must equal tests/*.test.sh&#10;fm-test-run: extra beyond inventory:&#10;tests/fm-x-mode.test.sh&#10;exit=1</code>

```text
=== A test file the lanes still claim has been removed from tests/ ===
removed: tests/fm-x-mode.test.sh

--- BEFORE (unfixed guard, LC_ALL=en_US.utf8): dies before it can say anything ---
comm: file 2 is not in sorted order
comm: input is not in sorted order
exit=1

--- AFTER (fixed guard, LC_ALL=en_US.utf8): reports the actual coverage defect ---
fm-test-run: coverage guard: union of portable shards + portable serial + Herdr must equal tests/*.test.sh
fm-test-run: extra beyond inventory:
tests/fm-x-mode.test.sh
exit=1
```
</details>
<details>
<summary>Evidence: Runner contract suite at branch HEAD</summary>

<code>$ bin/fm-test-run.sh tests/fm-test-run.test.sh&#10;ok - portable shard union, disjointness, and coverage guard hold&#10;ok - coverage guard is collation independent (verified under en_US.utf8)&#10;FM_TEST_END tests/fm-test-run.test.sh exit=0 gate_skip=false&#10;FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0</code>

```text
$ bin/fm-test-run.sh tests/fm-test-run.test.sh
FM_TEST_BEGIN 2026-08-09T06:01:46Z tests/fm-test-run.test.sh family=pure-contract-unit expected_gate_skip=none
ok - exact suite coverage: --all lists every tests/*.test.sh once
ok - family selection returns a proper subset of the suite
ok - single-script selection lists exactly that path
ok - changed-file selection stays conservative (never silent full suite)
ok - changed selection covers dependents and fails closed for unmapped source
ok - empty changed selection emits deterministic text and JSON summaries
ok - timing markers and JSON artifact are valid
ok - aggregate exit reflects any script failure
ok - gate-skip accounting is honest and non-failing
ok - fail-on-gate-skip converts herdr-not-found into a hard failure
ok - exclude-family drops the named primary family after selection
ok - portable shard union, disjointness, and coverage guard hold
ok - coverage guard is collation independent (verified under en_US.utf8)
ok - portable serial shards are a deterministic disjoint cover of the serial lane
ok - portable serial shard lanes refuse mismatched, out-of-range, and countless names
ok - --jobs refuses non-proven / stateful selections
ok - jobs scheduler runs proven scripts; failure propagates; non-proven refused
ok - aggregate-json merges lane timing artifacts
FM_TEST_END 2026-08-09T06:01:53Z tests/fm-test-run.test.sh exit=0 duration_ms=7292 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=7311
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=1 duration_ms=7292 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-test-run.test.sh duration_ms=7292
exit=0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- 🚨 `bin/fm-test-run.sh:575` - The rationale comment still cites the pair the intent marks as wrong. Intent requires: &#34;replace it with the real diverging pair named above and state the mechanism (C orders by &#39;-&#39; 0x2D before &#39;.&#39; 0x2E; glibc ignores punctuation at the primary level and then compares &#39;t&#39; against &#39;w&#39;), verifying whatever pair you write by actually running sort under both locales.&#34; Verified by running sort under both locales: `printf &#39;fm-pr-check-security.test.sh\nfm-pr-check.test.sh\n&#39; | sort` yields the SAME order under LC_ALL=C and LC_ALL=en_US.utf8, and tests/fm-pr-check.test.sh does not exist in the repo. The real diverging pair does swap: fm-backend-herdr-workspace-per-home-e2e.test.sh sorts before fm-backend-herdr.test.sh under C and after it under en_US.utf8, because glibc drops the punctuation at the primary level and then compares &#39;w&#39; against &#39;t&#39;. As written, the comment documents the bug with an example that does not reproduce it, so a future reader who checks it will conclude the fix was unnecessary. This correction was already decided in the previous run and is required to land as a new commit on top; it is not present at 75d3e50 and the working tree is clean.
- 🚨 `tests/fm-test-run.test.sh:403` - The locale selection still ends in `head -n 1`, so exactly one candidate is ever probed. Intent requires: &#34;drop head -n 1, iterate the name-matching candidates and select the first whose probe output differs from the C-sorted output, reaching the existing explicit-skip branch only after all candidates were probed.&#34; Concrete failure: on a host where `locale -a` lists both a byte-collating and a truly collating UTF-8 locale (or where the alphabetically first match happens to collate by byte, e.g. a musl image listing en_US.UTF-8 first), the single probe at line 415 matches the C-sorted output, `loc` is cleared, and the case takes the skip branch and reports `pass` - even though a later candidate would have exercised the guard under a genuinely diverging collation. The regression then goes unverified on exactly the machines it was written to protect. This correction was already decided in the previous run and is required to land as a new commit on top; it is not present at 75d3e50 and the working tree is clean.

🔧 Fix: cite a pair that really diverges, probe every locale
2 issues (1 warning, 1 info) still open:
- ⚠️ `tests/fm-test-run.test.sh:435` - The no-diverging-locale branch reports the skip with a free-text `note:` line plus `pass`, bypassing the repo&#39;s own machine-readable skip protocol, so nothing can assert that this regression check actually ran. This repo already has that protocol: `detect_gate_skip_token` (bin/fm-test-run.sh:1107) greps the captured output for `skip: &lt;token&gt;` anywhere, and .github/workflows/ci.yml:261 already uses `--fail-on-gate-skip &#39;herdr not found&#39;` to turn a silent skip into a hard failure in a job that must not skip. Per-case skips inside a multi-case file already follow this convention - see tests/fm-afk-launch.test.sh:234, 829, 830, 891, which `echo &#34;skip: tmux not found (concurrent start)&#34;` then `return 0`. Concrete failure: a runner image ships only C, C.utf8 and POSIX (or a musl image where every locale collates by byte). The loop probes every candidate, finds none, prints the `note:` line and `pass`, and the suite reports `ok -` with exit 0. There is no token for `--fail-on-gate-skip` to match, so CI cannot distinguish &#34;the collation guard was verified&#34; from &#34;the collation guard was never exercised&#34; - the same class of invisible-to-CI gap this whole branch exists to close. Suggested fix: emit `skip: no differently-collating locale` on stdout in that branch (keeping the existing explanatory note), so a job that has locales installed can add `--fail-on-gate-skip &#39;no differently-collating locale&#39;` and fail if the check silently degraded. Marked ask-user because the skip wording and reporting shape were a deliberate authorial choice (the branch comment says &#34;Report the absent capability rather than passing over it silently&#34;).
- ℹ️ `bin/fm-test-run.sh:579` - The corrected rationale comment is factually right - I verified both orderings with `sort` under LC_ALL=C and LC_ALL=en_US.utf8, and the cited pair really does swap. Two small readability issues remain in how the new text was spliced in. (1) The counterexample cites `fm-pr-check-security` versus `fm-pr-check`, but tests/fm-pr-check.test.sh does not exist in the repo (only tests/fm-pr-check-security.test.sh does). The claim about those two strings is true either way, so nothing is wrong, but a reader who tries to reproduce the counterexample against the tree will find no such file - the same kind of trip hazard the previous round removed. (2) The counterexample paragraph was inserted between the divergence explanation and the consequence sentence, so &#34;That mismatch made the guard fail...&#34; at line 583 now reads as referring to the pair that does NOT diverge. Moving the counterexample to the end of the comment, or naming a non-diverging pair where both files exist, fixes both. Comment-only, no behavior change.

🔧 Fix: emit the repo&#39;s gate-skip token when no locale collates
2 infos still open:
- ℹ️ `bin/fm-test-run.sh:590` - The non-diverging counterexample states the wrong mechanism for the C half. It says fm-backend-herdr-smoke.test.sh sorts before fm-backend-herdr.test.sh under both locales &#34;because there the characters that decide are &#39;s&#39; and &#39;t&#39;, which order the same way byte-wise and at the primary level alike.&#34; Under C, &#39;s&#39; and &#39;t&#39; are never reached: the comparison terminates at position 17, where &#39;-&#39; (0x2D) beats &#39;.&#39; (0x2E) - exactly the same byte-level decision that puts the -workspace- name first in the diverging pair two paragraphs above. Only the glibc primary level compares &#39;s&#39; against &#39;t&#39;. I verified both orderings with sort; the conclusion (the pair agrees under both) is correct, so nothing is broken. The rule a reader would extract is what misleads: byte order ALWAYS puts the &#39;-&#39;-continued name first, and the locale agrees only when the letter after &#39;-&#39; sorts before the letter after &#39;.&#39;. That is &#39;s&#39; &lt; &#39;t&#39; here, and &#39;w&#39; &gt; &#39;t&#39; for the diverging pair - the actual variable is which way the letter comparison runs relative to &#39;-&#39; &lt; &#39;.&#39;, not whether two letters &#34;order the same way both ways.&#34; Suggested wording: under C, &#39;-&#39; &lt; &#39;.&#39; puts -smoke first; under glibc the primary keys compare &#39;s&#39; against &#39;t&#39; and reach the same answer, so the pair happens to agree. Comment-only, no behavior change.
- ℹ️ `tests/fm-test-run.test.sh:435` - The new `skip: no differently-collating locale` token is correct and matches the repo protocol, but no CI job consumes it yet, so the vacuity gap it was added to close is currently latent rather than closed. .github/workflows/ci.yml uses --fail-on-gate-skip only at line 261, on the real-herdr-gated family with the &#39;herdr not found&#39; token; fm-test-run.test.sh runs in the portable lanes (lines 64, 96, 156), none of which pass the flag. On a runner image whose `locale -a` lists no differently-collating UTF-8 locale, the loop probes every candidate, prints the token and the stderr note, returns 0, and the job stays green with the collation guard never exercised - exactly the state the token exists to make visible. No action needed in this change: the intent scopes it to the collation bug alone, and the round-2 instruction asked only that the token be emitted so a job CAN opt in. Recording it so the maintainer knows the CI-visibility win requires adding --fail-on-gate-skip &#39;no differently-collating locale&#39; to a lane job on an image known to have collating locales installed.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`LC_ALL=C bin/fm-test-run.sh --check-coverage` and `LC_ALL=en_US.utf8 bin/fm-test-run.sh --check-coverage` against both the base commit (2d2be63) runner and branch HEAD, via a symlink mirror repo so the worktree was never modified</code>
- <code>`bin/fm-test-run.sh tests/fm-test-run.test.sh` - the runner&#39;s own contract suite, including the new `test_coverage_guard_is_locale_independent` case (18 cases, all ok)</code>
- <code>Regression proof: ran `tests/fm-test-run.test.sh` with ROOT pinned to the unfixed base-commit runner; `test_coverage_guard_is_locale_independent` is the only case that fails</code>
- <code>`sort` under `LC_ALL=C` vs `LC_ALL=en_US.utf8` on the diverging pair `fm-backend-herdr-workspace-per-home-e2e.test.sh`/`fm-backend-herdr.test.sh`, the non-diverging counterexample `fm-backend-herdr-smoke.test.sh`/`fm-backend-herdr.test.sh`, the probe pair `a-b`/`a.a`, and the inert pair `a-b`/`a.b`</code>
- <code>Review finding (2): ran commit 75d3e50&#39;s `head -n 1` version and HEAD&#39;s iterating version behind a `locale` shim listing a byte-collating name first and a genuinely collating one second</code>
- <code>Skip path A - `locale` shim listing only C/C.utf8/POSIX: case emits `skip: no differently-collating locale`</code>
- `Skip path B - musl-style shim whose listed language locales all collate byte-wise: same skip token emitted`
- <code>Real consumer check: `bin/fm-test-run.sh tests/fm-test-run.test.sh --fail-on-gate-skip &#39;no differently-collating locale&#39;` (exit 1, failed=1) vs `--fail-on-gate-skip &#39;herdr not found&#39;` (exit 0) on that host, and no token emitted on this host where en_US.utf8 truly collates</code>
- <code>Diagnostics check: removed a lane-assigned test file in a mirror and compared unfixed vs fixed guard output under `LC_ALL=en_US.utf8`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
