### PR TITLE
fix(composer): classify a Unicode-space-separated prompt glyph as an empty composer

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -421,6 +421,10 @@ Muse Code is a CREWMATE and SCOUT adapter only.
 | Effort | `--reasoning-effort`, default `high`; see the launch-profile table above for the mapping. |
 | Resume | `muse resume --last` or `muse resume <session-uuid>`; bare `muse resume` opens a picker. |
 
+That bordered-box composer is a DESCRIPTION, and it disagrees with the border-free row CAPTURED in `docs/verification/muse.md` "Composer rendering"; task `fm-muse-herdr-bare-glyph` settles which is true against real muse.
+It decides which shape in `bin/fm-composer-lib.sh`'s catalogue an idle muse composer actually exercises - `bordered` or `bare` - and therefore which one a future shape change may break without any test noticing.
+The per-adapter divergence this used to cause is gone: every backend now reaches the same shared classifier, which recognises `⟩` on both shapes, so muse no longer reads `empty` on one backend and `unknown` on another.
+
 ### Credentials are a spawn preflight, not a screen check
 
 muse reads `META_API_KEY` (which always wins) or a stored credential at `${XDG_CONFIG_HOME:-$HOME/.config}/muse/auth.json`, written by `muse login` (an OIDC device-code flow) or `muse auth set --api-key-stdin`.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -188,6 +188,8 @@ Firstmate launches every claude crewmate and secondmate with `CLAUDE_CODE_ENABLE
 The CLI's `--prompt-suggestions` flag is print/SDK-mode only and does not suppress the interactive composer ghost text, verified empirically on v2.1.186.
 As defense in depth for any pane that flag cannot reach, including the captain's own firstmate composer that away-mode reads, the shared `fm_composer_strip_ghost` extractor in `bin/fm-composer-lib.sh` removes dim/faint SGR 2 ghost runs before pending-input classification on every styled reader (tmux, herdr, and Zellij).
 Its broader dark-TRUECOLOR placeholder handling and dark-theme tradeoff are documented in `docs/herdr-backend.md` "Composer and injection safety", with active captures in `docs/verification/runtime-backends.md`.
+Claude also separates that prompt glyph from the composer's content with U+00A0 NO-BREAK SPACE rather than an ASCII space, so the same owner normalizes every code point carrying the Unicode `White_Space=Yes` property before classifying.
+A newly verified harness therefore needs no separator enumerated unless the one it draws falls outside that property, which `FM_COMPOSER_HARNESS_DRIFT=1 tests/fm-composer-harness-drift-live-e2e.test.sh` is what detects.
 That styled capture is internal to the boolean detector only.
 `fm-peek` and every other human or LLM-facing capture path stays plain `tmux capture-pane` with no escape codes.
 

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -182,6 +182,7 @@ family_for_basename() {
     fm-afk-pi-herdr-return-e2e.test.sh|\
     fm-cmux-claude-composer-live-e2e.test.sh|\
     fm-composer-matrix-live-e2e.test.sh|\
+    fm-composer-harness-drift-live-e2e.test.sh|\
     fm-codex-continuity-live-e2e.test.sh|fm-grok-continuity-live-e2e.test.sh|\
     fm-grok-stop-live-e2e.test.sh|fm-harness-liveness-drift-live-e2e.test.sh|\
     fm-muse-signals-live-e2e.test.sh|\
@@ -935,8 +936,8 @@ families_for_changed_path() {
       ;;
     bin/fm-composer-lib.sh)
       # The shared shape catalogue is vendor-rendered signal; a change to it
-      # re-selects the live guard (fm-composer-matrix-live-e2e) alongside the
-      # portable families.
+      # re-selects the live guards (fm-composer-matrix-live-e2e and
+      # fm-composer-harness-drift-live-e2e) alongside the portable families.
       printf '%s\n' backend-dispatch
       printf '%s\n' pure-contract-unit
       printf '%s\n' live-harness-optin

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -236,6 +236,11 @@ ANSI capture preserves de-emphasized placeholder style.
 `bin/fm-composer-lib.sh` is the fleet-wide owner that strips dim or faint runs and dark truecolor placeholders while retaining bright typed input.
 If the ANSI capture ever fails, the plain fallback declares itself unstyled and the classifier degrades a glyph row carrying trailing text to `unknown` instead of misreading ghost suggestions as typed input, which safely defers injection and eventually raises the wedge alarm.
 
+Separator whitespace is normalized rather than enumerated per harness.
+The shared owner's structural row scan and its content classifier alike map each code point carrying the Unicode property `White_Space=Yes` onto an ASCII space before trimming, border stripping, and glyph comparison, so a prompt glyph followed only by a non-ASCII space - claude draws U+00A0 NO-BREAK SPACE - is an affirmatively empty composer instead of pending input.
+The predicate is not otherwise relaxed: any non-whitespace character anywhere is still pending, and U+200B ZERO WIDTH SPACE carries `White_Space=No`, so it stays pending.
+[`verification/runtime-backends.md`](verification/runtime-backends.md#composer-separator-rendering) owns the per-harness captured rows and the refresh command.
+
 A bare shell prompt is never an empty agent composer.
 Away-mode injection proceeds only on an affirmative `empty` result, never on unknown.
 This prevents a dead agent pane from receiving and possibly executing an escalation as shell input.

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -70,6 +70,8 @@ Agent liveness and composer safety are separate checks.
 The tmux reader is a thin adapter over the fleet-wide classifier in `bin/fm-composer-lib.sh`: it contributes one styled full-pane capture, the `#{cursor_y}` cursor row, and a Pi foreground-process identity probe, and the shape containing the cursor - a complete bordered box (titled bottom borders tolerated), a bare agent-glyph row with its wrapped input, opencode's left bar, or Pi's identity-corroborated separator pair - decides the verdict.
 Real text in an identified shape is pending, while only positively proven emptiness reads empty.
 A blank or otherwise unidentified cursor row is `unknown` and every consumer defers: this strict container-proof rule replaced the earlier permissive blank-row reading, so a modal dialog, a dead shell between stale rules, or a mid-redraw pane is never an injection target.
+The box-geometry probe that proves a row blank to the border's own width uses that same owner's Unicode-whitespace normalization and its single prompt-glyph declarations, so a non-ASCII separator or an accepted prompt glyph can no longer leave the content classifier reading empty while the structure reads ambiguous.
+[herdr-backend.md](herdr-backend.md#composer-and-injection-safety) owns the shared content contract, including the whitespace boundary.
 The shared classifier accepts a shell glyph as an empty agent composer only inside a bordered container.
 A bare shell prompt is `unknown`, so away-mode escalation is never injected into a dead shell.
 
@@ -103,6 +105,7 @@ tests/fm-backend-tmux-smoke.test.sh
 tests/fm-tmux-agent-liveness.test.sh
 tests/fm-harness-liveness-drift-live-e2e.test.sh
 tests/fm-composer-ghost.test.sh
+tests/fm-composer-harness-drift-live-e2e.test.sh
 tests/fm-kimi-harness.test.sh
 tests/fm-muse-harness.test.sh
 tests/fm-tmux-submit-busy.test.sh

--- a/docs/verification/muse.md
+++ b/docs/verification/muse.md
@@ -154,6 +154,9 @@ Captured with `tmux capture-pane -p -e`:
 Prompt glyph `⟩` (U+27E9) at luminance ~149.9 against the 128 default ghost threshold; typed text at ~209.8.
 After a single Escape the interrupted prompt is restored into the composer at the same bright ~209.8, and `C-u` clears it.
 
+The rows above carry no box-drawing border, while `.agents/skills/harness-adapters/SKILL.md`'s muse `Composer` row describes a bordered box; this page holds an observed capture and that row holds a claim, so they are not equal evidence.
+That does not settle it, because these rows do not record when in the session they were taken and a capture made at launch would not show what an IDLE composer draws; task `fm-muse-herdr-bare-glyph` resolves it against real muse, and the SKILL.md row states which shape in the shared catalogue it decides muse exercises.
+
 ## The credentialed multi-step smoke (verified 2026-08-06)
 
 This was the one item deferred until a `META_API_KEY` was available, because it is what decides whether a settled log may classify `idle`.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -174,7 +174,8 @@ Every harness absent from this machine is recorded as unverified rather than pas
 
 Before the fix in `bin/fm-composer-lib.sh`, that exact `e2 9d af c2 a0` row classified `pending`, meaning "a human's unsubmitted text is sitting there", so every caller that must not overwrite unsubmitted input refused to act (upstream `kunchenguid/firstmate#1988`).
 `fm_composer_normalize_trim_var` now maps every code point with the Unicode property `White_Space=Yes` onto an ASCII space before any trim or glyph comparison, so the classifier follows a standards property instead of a separator observed in one release.
-`tests/fm-composer-lib.test.sh` and `tests/fm-composer-ghost.test.sh` pin the same bytes in CI.
+The same shared mapping runs inside the shared owner's own structural row scan, where the separator produced a different symptom with the identical consequence: the box geometry could not be proven blank and an empty bordered composer read `unknown`.
+`tests/fm-composer-lib.test.sh` and `tests/fm-composer-ghost.test.sh` pin the same bytes in CI, on the bordered and unbordered shapes alike, asserting the exact `empty` / `pending` / `unknown` verdict in each case.
 
 ### Cleanup endpoint identity
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -144,6 +144,38 @@ Zellij has no verified recovery-grade agent process probe, while Orca and cmux d
 The current classifier matrix and its refresh guard are recorded in [Composer classification matrix](#composer-classification-matrix), with portable shape coverage in `tests/fm-composer-lib.test.sh` and `tests/fm-composer-ghost.test.sh`.
 Kimi pointer delivery and OpenCode 1.18.4 busy-queue behavior remain pinned by `tests/fm-kimi-harness.test.sh` and `tests/fm-tmux-submit-busy.test.sh`.
 
+### Composer separator rendering
+
+This is the per-harness record of what an EMPTY composer actually renders, and it is the owner the Herdr "Composer and operational input" section below refers to.
+The verdict a composer read produces is taken from the harness's own input row, so the separator that row draws is a vendor surface under no contract.
+Claude Code separates its prompt glyph from the composer's content with U+00A0 NO-BREAK SPACE rather than an ASCII space, which is invisible in any rendered capture and only appears when the bytes are decoded.
+
+Refresh this table with the opt-in guard, which drives each installed harness for real, types a marker, clears it, and decodes the resulting empty row:
+
+```sh
+FM_COMPOSER_HARNESS_DRIFT=1 tests/fm-composer-harness-drift-live-e2e.test.sh
+```
+
+Run on 2026-08-09 with tmux 3.5a on Debian GNU/Linux 13 x86_64, each harness on a private socket in an isolated lab.
+The composer is emptied by the guard itself - it types a marker, confirms the harness rendered it, sends `C-u`, and confirms the marker is gone from the pane - so the row below is affirmatively empty rather than assumed empty.
+
+| Harness | Version | Empty composer row bytes | Separator | Verdict |
+| --- | --- | --- | --- | --- |
+| claude | 2.1.226 | `e2 9d af c2 a0` | U+00A0 | empty |
+| codex | not installed | - | - | unverified here |
+| opencode | not installed | - | - | unverified here |
+| pi | not installed | - | - | unverified here |
+| pi-signed | not installed | - | - | unverified here |
+| grok | not installed | - | - | unverified here |
+| kimi | not installed | - | - | unverified here |
+| muse | not installed | - | - | unverified here |
+
+Every harness absent from this machine is recorded as unverified rather than passed over, and the guard refuses to report a pass when no installed harness reached a readable composer.
+
+Before the fix in `bin/fm-composer-lib.sh`, that exact `e2 9d af c2 a0` row classified `pending`, meaning "a human's unsubmitted text is sitting there", so every caller that must not overwrite unsubmitted input refused to act (upstream `kunchenguid/firstmate#1988`).
+`fm_composer_normalize_trim_var` now maps every code point with the Unicode property `White_Space=Yes` onto an ASCII space before any trim or glyph comparison, so the classifier follows a standards property instead of a separator observed in one release.
+`tests/fm-composer-lib.test.sh` and `tests/fm-composer-ghost.test.sh` pin the same bytes in CI.
+
 ### Cleanup endpoint identity
 
 The cleanup identity boundary was validated on 2026-07-28 with tmux 3.6a and metadata fixtures for every supported backend.
@@ -521,7 +553,7 @@ ok - forced teardown retains a nested secondmate home and its grandchild's Herdr
 
 Real captures verified these active distinctions:
 
-- Claude and Codex use bare `❯` and `›` agent composers.
+- Claude and Codex use bare `❯` and `›` agent composers; the tmux "Composer separator rendering" section above owns the per-harness record of the whitespace each one draws after that glyph.
 - Pi uses content between complete separator rows and requires exact native Pi identity.
 - Dim or faint suggestion text is ghost content, while normally styled text is pending input.
 - Grok dark truecolor placeholders are ghost content, while bright truecolor typed input remains pending.

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -3095,6 +3095,42 @@ test_composer_state_pi_separator_real_text_is_pending() {
   pass "fm_backend_herdr_composer_state: real Pi composer text remains pending"
 }
 
+# The herdr adapter's STRUCTURAL half. The row scan above was taught the shared
+# normalizing trim, but the Pi separator recogniser kept an ASCII-only one and
+# then required the remainder be nothing but `─`, so a rule terminated with a
+# non-ASCII space left residue, no complete separator pair was found, the
+# `separated` shape was never established, and the verdict degraded to
+# `unknown` - the same refuse-to-act outcome by a different route. Both rules
+# below carry a trailing U+00A0, and the fixture asserts it is still there
+# because it is invisible in any capture.
+test_composer_state_pi_separator_padded_with_nbsp_is_empty() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/composer-pi-separated-nbsp"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '\x1b[0m\x1b[38;2;129;162;190m─────────────────────────────────────────────────────\302\240\x1b[0m\n\x1b[0m\x1b[7m \x1b[0m                                                    \n\x1b[0m\x1b[38;2;129;162;190m─────────────────────────────────────────────────────\302\240\x1b[0m\n' > "$resp/1.out"
+  herdr_nbsp_fixture_check "$resp/1.out" "U+00A0-padded Pi separator"
+  printf '{"result":{"agent":{"agent":"pi","agent_status":"idle"}}}\n' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state lab:w1:p2' "$ROOT" )
+  [ "$out" = empty ] || fail "an idle Pi composer whose rules are padded with U+00A0 should read empty, got '$out'"
+  pass "fm_backend_herdr_composer_state: a Pi separator pair padded with U+00A0 still establishes the composer shape"
+}
+
+# And the negative half on that same structural path: recognising the padded
+# rules must not make the content inside them read empty when it is real text.
+test_composer_state_pi_separator_padded_with_nbsp_real_text_is_pending() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/composer-pi-separated-nbsp-pending"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '\x1b[38;2;129;162;190m─────────────────────────────────────────────────────\302\240\x1b[0m\nprivacy safe human draft\x1b[7m \x1b[0m\n\x1b[38;2;129;162;190m─────────────────────────────────────────────────────\302\240\x1b[0m\n' > "$resp/1.out"
+  herdr_nbsp_fixture_check "$resp/1.out" "U+00A0-padded Pi separator with text"
+  printf '{"result":{"agent":{"agent":"pi","agent_status":"done"}}}\n' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state lab:w1:p2' "$ROOT" )
+  [ "$out" = pending ] || fail "real text between U+00A0-padded Pi rules must stay pending, got '$out'"
+  pass "fm_backend_herdr_composer_state: real text between U+00A0-padded Pi rules remains pending"
+}
+
 test_composer_state_pi_incomplete_separator_below_stale_generic_is_unknown() {
   local dir log resp fb out
   dir="$TMP_ROOT/composer-pi-separated-incomplete"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
@@ -4369,6 +4405,8 @@ test_composer_state_unknown_on_capture_failure
 test_composer_state_unknown_when_no_composer_row_found
 test_composer_state_pi_separator_idle_is_empty
 test_composer_state_pi_separator_real_text_is_pending
+test_composer_state_pi_separator_padded_with_nbsp_is_empty
+test_composer_state_pi_separator_padded_with_nbsp_real_text_is_pending
 test_composer_state_pi_incomplete_separator_below_stale_generic_is_unknown
 test_composer_state_pi_separator_requires_safe_native_identity
 test_composer_state_claude_nbsp_prompt_is_empty

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -3158,6 +3158,51 @@ test_composer_state_claude_unbordered_prompt_is_empty() {
   pass "fm_backend_herdr_composer_state: a real-claude unbordered '❯' prompt row (no border box in view) reads empty"
 }
 
+# THE U+00A0 SEPARATOR regression (task fm-composer-read-unreliable, upstream
+# kunchenguid/firstmate#1988). Captured read-only from a live claude-on-herdr
+# pane on 2026-08-09: claude separates its prompt glyph from the composer's
+# content with U+00A0 NO-BREAK SPACE, not an ASCII space, so an AFFIRMATIVELY
+# EMPTY composer renders as exactly `❯\302\240`. The composer row below is
+# byte-for-byte that capture, dim suggestion and all; the horizontal rules
+# around it are the same 38;2;136;136;136 rules the real pane draws, shortened
+# only in width. Before the fix this read `pending` - "a human has half-typed
+# something here" - so bin/fm-supervise-daemon.sh refused every injection and
+# deferred 2105 escalations over 8.3 hours against an idle pane.
+#
+# U+00A0 is invisible in any plain capture, which is why the emptiness looked
+# correct to the eye the whole time, so both cases assert the fixture still
+# carries the separator rather than trusting it to stay put.
+herdr_nbsp_fixture_check() {  # <file> <what>
+  LC_ALL=C grep -q "$(printf '\302\240')" "$1" \
+    || fail "$2 fixture no longer contains U+00A0; this case would pass vacuously"
+}
+
+test_composer_state_claude_nbsp_prompt_is_empty() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/composer-claude-nbsp-empty"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '\033[0m\033[38;2;153;153;153m\xe2\x9c\xbb\033[0m \033[0m\033[38;2;153;153;153mBaked for 3m 48s\033[0m\r\n\r\n\033[0m\033[38;2;136;136;136m\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\033[0m\r\n\xe2\x9d\xaf\302\240\033[0m\033[2mkeep going, dont stop until the four tracks are landed\033[0m\r\n\033[0m\033[38;2;136;136;136m\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\033[0m\r\n' > "$resp/1.out"
+  herdr_nbsp_fixture_check "$resp/1.out" "empty herdr composer"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+  [ "$out" = empty ] || fail "a real claude composer row of '\xe2\x9d\xaf'+U+00A0 plus a dim suggestion is EMPTY and must read empty, got '$out' (the 8.3-hour away-mode wedge: 2105 escalations deferred against an idle pane)"
+  pass "fm_backend_herdr_composer_state: a real claude '❯'+U+00A0 empty composer reads empty"
+}
+
+# The negative half, and the one that matters more: the fix must not have
+# bought that `empty` by becoming permissive about real input.
+test_composer_state_claude_nbsp_prompt_with_text_is_pending() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/composer-claude-nbsp-pending"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '\033[0m\033[38;2;136;136;136m\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\033[0m\r\n\xe2\x9d\xaf\302\240captain hold on, still typing\r\n\033[0m\033[38;2;136;136;136m\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\033[0m\r\n' > "$resp/1.out"
+  herdr_nbsp_fixture_check "$resp/1.out" "typed-into herdr composer"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+  [ "$out" = pending ] || fail "real unsubmitted text after the U+00A0 separator MUST stay pending, got '$out' (a false empty types over the captain's half-written message)"
+  pass "fm_backend_herdr_composer_state: real text after a '❯'+U+00A0 separator still reads pending"
+}
+
 test_composer_state_claude_unbordered_prompt_is_pending() {
   local dir log resp fb out
   dir="$TMP_ROOT/composer-claude-bare-pending"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
@@ -4326,6 +4371,8 @@ test_composer_state_pi_separator_idle_is_empty
 test_composer_state_pi_separator_real_text_is_pending
 test_composer_state_pi_incomplete_separator_below_stale_generic_is_unknown
 test_composer_state_pi_separator_requires_safe_native_identity
+test_composer_state_claude_nbsp_prompt_is_empty
+test_composer_state_claude_nbsp_prompt_with_text_is_pending
 test_composer_state_claude_unbordered_prompt_is_empty
 test_composer_state_claude_unbordered_prompt_is_pending
 test_composer_state_bare_prompt_below_stale_bordered_banner_wins

--- a/tests/fm-composer-ghost.test.sh
+++ b/tests/fm-composer-ghost.test.sh
@@ -681,6 +681,98 @@ test_peek_output_is_escape_free() {
   pass "fm-peek output is escape-free (no raw -e bytes reach firstmate context)"
 }
 
+# --- Unicode whitespace between the prompt glyph and the content -------------
+# Regression coverage for task fm-composer-read-unreliable (upstream
+# kunchenguid/firstmate#1988). Claude 2.x separates its prompt glyph from the
+# composer's content with U+00A0 NO-BREAK SPACE rather than an ASCII space, so
+# an AFFIRMATIVELY EMPTY composer renders as exactly `❯` U+00A0. Every trim and
+# glyph comparison in the shared owner tested only POSIX `[[:space:]]`, which
+# bash excludes U+00A0 from under the C and UTF-8 locales alike, so that lone
+# separator survived as apparent typed content and the row classified
+# `pending` - the verdict meaning "a human's unsubmitted text is sitting
+# there", which stops every caller that must not type over it. The rows below
+# are the real bytes captured read-only from live claude panes on 2026-08-09:
+# tmux paints the glyph `\033[38;5;246m❯\302\240\033[39m`, herdr's ANSI read of
+# the same harness gives `❯\302\240\033[0m\033[2m<suggestion>\033[0m`.
+#
+# NBSP is invisible in any plain capture, so each case first asserts the
+# fixture still CONTAINS the separator. Without that a later edit could replace
+# it with an ASCII space and leave these passing vacuously against the very
+# shape they exist to pin.
+NBSP=$(printf '\302\240')
+
+assert_fixture_has_nbsp() {  # <fixture-text> <what>
+  case "$1" in
+    *"$NBSP"*) return 0 ;;
+  esac
+  fail "$2 fixture no longer contains U+00A0; this case would pass vacuously"
+}
+
+# nbsp_row_state <styled-row>: the tmux verdict for one bare claude composer
+# row, read through the real capture path (fake tmux serves the row, the cursor
+# sits on it) so the fixture travels the same capture -> caps -> classifier
+# route a live pane does.
+nbsp_row_state() {  # <styled-row>
+  local row=$1 dir fb capture
+  dir="$TMP_ROOT/nbsp-$RANDOM"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+  capture="$dir/styled.txt"
+  printf '%s\n' "$row" > "$capture"
+  PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+    fm_tmux_composer_state "fakepane"
+}
+
+test_nbsp_separated_prompt_is_empty() {
+  local row out
+  # The live tmux row, byte for byte: a 256-colour prompt glyph and the NBSP,
+  # with no other content whatsoever. 38;5;246 is a PALETTE colour, which the
+  # ghost stripper deliberately never luminance-tests, so the glyph survives
+  # stripping and the whole verdict rests on how the separator is read.
+  row=$(printf '\033[38;5;246m\xe2\x9d\xaf\302\240\033[39m')
+  assert_fixture_has_nbsp "$row" "empty tmux composer"
+  out=$(nbsp_row_state "$row")
+  [ "$out" = empty ] || fail "the real empty claude composer row (glyph + U+00A0) must read empty, got '$out' (this is the 8.3-hour away-mode wedge)"
+  pass "fm_tmux_composer_state: a real claude '❯'+U+00A0 empty composer row reads empty"
+}
+
+# The case that matters most: the fix must not have bought `empty` by becoming
+# permissive. Real typed text after the same NBSP separator must still be
+# pending, or firstmate would type over a captain's half-written message.
+test_nbsp_separated_prompt_with_real_text_is_pending() {
+  local row out
+  row=$(printf '\033[38;5;246m\xe2\x9d\xaf\302\240\033[39mcaptain I am half way through')
+  assert_fixture_has_nbsp "$row" "typed-into tmux composer"
+  out=$(nbsp_row_state "$row")
+  [ "$out" = pending ] || fail "real unsubmitted text after a U+00A0 separator MUST stay pending, got '$out' (a false empty types over the captain's input)"
+  # Content that is ONLY non-ASCII whitespace is not text to protect, but a
+  # single real character anywhere in it is.
+  out=$(nbsp_row_state "$(printf '\xe2\x9d\xaf\302\240\302\240\302\240x')")
+  [ "$out" = pending ] || fail "one real character behind several U+00A0 separators must still read pending, got '$out'"
+  pass "fm_tmux_composer_state: real text behind a U+00A0 separator still reads pending"
+}
+
+# Drive the two independent signals apart. The ghost stripper (de-emphasis) and
+# the whitespace normalization answer different halves of "is anything typed
+# here", and the empty verdict must survive losing either one: the live rows
+# carry both a dim suggestion AND the NBSP, but a row with the NBSP alone still
+# has to read empty, and a row whose ONLY content is a bright dim-free
+# suggestion still has to read pending.
+test_nbsp_composer_verdict_survives_losing_the_ghost_signal() {
+  local out
+  # Both signals present (herdr's live shape: NBSP + a dim suggestion).
+  out=$(nbsp_row_state "$(printf '\xe2\x9d\xaf\302\240\033[0m\033[2mkeep going, dont stop\033[0m')")
+  [ "$out" = empty ] || fail "NBSP + dim ghost should read empty, got '$out'"
+  # Ghost signal removed - the NBSP alone must still carry the empty verdict.
+  out=$(nbsp_row_state "$(printf '\xe2\x9d\xaf\302\240')")
+  [ "$out" = empty ] || fail "the NBSP separator alone must still read empty with no ghost run present, got '$out'"
+  # Whitespace signal removed - a bright, dim-free body must still be pending,
+  # proving normalization did not start swallowing real content.
+  out=$(nbsp_row_state "$(printf '\xe2\x9d\xaf \033[38;2;224;222;244mbright typed\033[0m')")
+  [ "$out" = pending ] || fail "bright dim-free text must remain pending, got '$out'"
+  pass "fm_tmux_composer_state: the empty verdict survives losing the ghost signal, and pending survives losing the whitespace one"
+}
+
+
 test_strip_ghost_drops_dim_keeps_normal
 test_strip_ghost_handles_combined_and_boundary_codes
 test_strip_ghost_keeps_colored_text_with_2_payloads
@@ -714,3 +806,6 @@ test_legitimate_empty_routes_remain_empty
 test_non_bordered_composer_uses_compatibility_fallback
 test_non_bordered_interior_edges_are_pending
 test_peek_output_is_escape_free
+test_nbsp_separated_prompt_is_empty
+test_nbsp_separated_prompt_with_real_text_is_pending
+test_nbsp_composer_verdict_survives_losing_the_ghost_signal

--- a/tests/fm-composer-ghost.test.sh
+++ b/tests/fm-composer-ghost.test.sh
@@ -772,6 +772,146 @@ test_nbsp_composer_verdict_survives_losing_the_ghost_signal() {
   pass "fm_tmux_composer_state: the empty verdict survives losing the ghost signal, and pending survives losing the whitespace one"
 }
 
+# --- The BORDERED tmux path, which reaches the verdict a different way -------
+# fm_tmux_composer_row_state above is only half of the tmux reader. When the
+# harness draws a box, fm_tmux_find_composer_box also has to agree the box's
+# GEOMETRY is unambiguous, by blanking every character an empty content row is
+# allowed to hold and comparing the result against the border's own width. That
+# scan trimmed with ASCII whitespace only and respelled the prompt glyphs
+# inline, so a non-ASCII separator (and muse's `⟩`, which it never listed) left
+# residue, marked the geometry ambiguous, and fm_tmux_composer_state turned that
+# into `unknown` - a DIFFERENT verdict from the unbordered path's `pending` with
+# the identical consequence: the guard refuses to act. Both paths are therefore
+# pinned end to end through the same public entry point, and every case asserts
+# its exact verdict rather than merely "not pending", which `unknown` would pass.
+
+# Write a bordered composer box whose content row is padded to the border's own
+# width. <inner-columns> is passed rather than derived, because the row's bytes
+# and its columns differ: an SGR run is zero columns wide, and the prompt glyph
+# and U+00A0 are multibyte but one column each.
+write_bordered_box() {  # <file> <inner> <inner-columns> [width]
+  local file=$1 inner=$2 cols=$3 width=${4:-24} rule='' pad='' i=0
+  while [ "$i" -lt "$width" ]; do rule="$rule─"; i=$((i + 1)); done
+  i=$cols
+  while [ "$i" -lt "$width" ]; do pad="$pad "; i=$((i + 1)); done
+  printf '╭%s╮\n│%s%s│\n╰%s╯\n' "$rule" "$inner" "$pad" "$rule" > "$file"
+}
+
+read_composer_state() {  # <dir> <capture> <cursor-y>
+  local fb
+  fb=$(make_fake_tmux "$1")
+  PATH="$fb:$PATH" FM_FAKE_STYLED="$2" FM_FAKE_CY="$3" \
+    fm_tmux_composer_state "fakepane"
+}
+
+test_bordered_nbsp_composer_is_empty() {
+  local dir capture out
+  dir="$TMP_ROOT/bordered-nbsp-empty"; mkdir -p "$dir"
+  capture="$dir/styled.txt"
+  # The live claude row bytes, wrapped in the box a bordered harness draws.
+  write_bordered_box "$capture" "$(printf ' \033[38;5;246m\xe2\x9d\xaf\302\240\033[39m')" 3
+  assert_fixture_has_nbsp "$(cat "$capture")" "empty bordered tmux composer"
+  out=$(read_composer_state "$dir" "$capture" 1)
+  [ "$out" = empty ] \
+    || fail "a bordered composer holding only '❯'+U+00A0 is affirmatively empty and must read empty, got '$out' (the ambiguous-geometry route to the same refuse-to-act wedge)"
+  # And with the cursor parked on the bottom border, the other real tmux shape.
+  out=$(read_composer_state "$dir" "$capture" 2)
+  [ "$out" = empty ] \
+    || fail "the same bordered '❯'+U+00A0 box with the cursor on its bottom border must read empty, got '$out'"
+  pass "fm_tmux_composer_state: a bordered '❯'+U+00A0 composer box reads empty"
+}
+
+# The negative half on the bordered path, and the one that matters more: a false
+# `empty` here makes firstmate type over a captain's half-written message.
+test_bordered_nbsp_composer_with_real_text_is_pending() {
+  local dir capture out
+  dir="$TMP_ROOT/bordered-nbsp-pending"; mkdir -p "$dir"
+  capture="$dir/styled.txt"
+  write_bordered_box "$capture" \
+    "$(printf ' \033[38;5;246m\xe2\x9d\xaf\302\240\033[39mhalf typed')" 13
+  assert_fixture_has_nbsp "$(cat "$capture")" "typed-into bordered tmux composer"
+  out=$(read_composer_state "$dir" "$capture" 1)
+  [ "$out" = pending ] \
+    || fail "real unsubmitted text behind a U+00A0 separator inside a BORDERED box must stay pending, got '$out'"
+  # A single character behind several separators is still text to protect.
+  write_bordered_box "$capture" "$(printf ' \xe2\x9d\xaf\302\240\302\240x')" 5
+  assert_fixture_has_nbsp "$(cat "$capture")" "single-character bordered tmux composer"
+  out=$(read_composer_state "$dir" "$capture" 1)
+  [ "$out" = pending ] \
+    || fail "one real character behind U+00A0 separators inside a bordered box must read pending, got '$out'"
+  pass "fm_tmux_composer_state: real text behind a U+00A0 separator in a bordered box stays pending"
+}
+
+# muse's `⟩` (U+27E9) is an agent prompt glyph the shared classifier recognises,
+# but the box scan's inline glyph list had drifted and omitted it, so an
+# otherwise-empty muse box read `unknown`. The scan now reaches the one shared
+# declaration instead of keeping a fourth copy.
+test_bordered_muse_glyph_composer_is_empty() {
+  local dir capture out
+  dir="$TMP_ROOT/bordered-muse"; mkdir -p "$dir"
+  capture="$dir/styled.txt"
+  # muse's real composer colours (38;2;90;160;255 glyph, 38;2;204;211;219 text).
+  write_bordered_box "$capture" "$(printf ' \033[38;2;90;160;255m\xe2\x9f\xa9 \033[39m')" 3
+  out=$(read_composer_state "$dir" "$capture" 1)
+  [ "$out" = empty ] \
+    || fail "an empty muse composer box ('⟩') must read empty, got '$out' (the glyph the box scan's inline list omitted)"
+  # The same glyph with a non-ASCII separator, the two drifts compounded.
+  write_bordered_box "$capture" "$(printf ' \033[38;2;90;160;255m\xe2\x9f\xa9\302\240\033[39m')" 3
+  assert_fixture_has_nbsp "$(cat "$capture")" "empty bordered muse composer"
+  out=$(read_composer_state "$dir" "$capture" 1)
+  [ "$out" = empty ] \
+    || fail "an empty muse composer box separated with U+00A0 must read empty, got '$out'"
+  # And muse's real typed text in the same box is still pending.
+  write_bordered_box "$capture" \
+    "$(printf ' \033[38;2;90;160;255m\xe2\x9f\xa9\302\240\033[38;2;204;211;219mhello\033[39m')" 8
+  out=$(read_composer_state "$dir" "$capture" 1)
+  [ "$out" = pending ] \
+    || fail "muse's real typed text in a bordered box must read pending, got '$out'"
+  pass "fm_tmux_composer_state: a bordered muse '⟩' composer reads empty, and its typed text pending"
+}
+
+# The unbordered path through the same public entry point, so the two are pinned
+# side by side rather than one through a row helper and one end to end.
+test_unbordered_nbsp_composer_state_is_empty_and_typed_is_pending() {
+  local dir capture out
+  dir="$TMP_ROOT/unbordered-nbsp"; mkdir -p "$dir"
+  capture="$dir/styled.txt"
+  printf '\033[38;5;246m\xe2\x9d\xaf\302\240\033[39m\n' > "$capture"
+  assert_fixture_has_nbsp "$(cat "$capture")" "empty unbordered tmux composer"
+  out=$(read_composer_state "$dir" "$capture" 0)
+  [ "$out" = empty ] \
+    || fail "the real unbordered claude composer row ('❯'+U+00A0) must read empty, got '$out'"
+  printf '\033[38;5;246m\xe2\x9d\xaf\302\240\033[39mhalf typed\n' > "$capture"
+  assert_fixture_has_nbsp "$(cat "$capture")" "typed-into unbordered tmux composer"
+  out=$(read_composer_state "$dir" "$capture" 0)
+  [ "$out" = pending ] \
+    || fail "real text after a U+00A0 separator on an unbordered row must read pending, got '$out'"
+  pass "fm_tmux_composer_state: the unbordered '❯'+U+00A0 row reads empty, and typed text pending"
+}
+
+# Normalization must not have bought those verdicts by making the box scan
+# credulous: genuinely unreadable geometry still has to reach `unknown`, and a
+# bare dead-shell prompt still must never become an injection target.
+test_nbsp_does_not_make_the_box_scan_credulous() {
+  local dir capture out
+  dir="$TMP_ROOT/nbsp-still-unknown"; mkdir -p "$dir"
+  capture="$dir/styled.txt"
+  # A content row one column WIDER than its border, padded with U+00A0 so the
+  # excess is invisible: still ambiguous geometry, still unknown.
+  printf '╭────────╮\n│ \xe2\x9d\xaf\302\240\302\240\302\240\302\240\302\240\302\240\302\240│\n╰────────╯\n' > "$capture"
+  assert_fixture_has_nbsp "$(cat "$capture")" "over-wide bordered tmux composer"
+  out=$(read_composer_state "$dir" "$capture" 1)
+  [ "$out" = unknown ] \
+    || fail "a content row wider than its border stays ambiguous geometry and must read unknown, got '$out'"
+  # A bare dead-shell prompt separated with U+00A0 is not an empty composer.
+  printf '$\302\240\n' > "$capture"
+  assert_fixture_has_nbsp "$(cat "$capture")" "bare dead-shell prompt"
+  out=$(read_composer_state "$dir" "$capture" 0)
+  [ "$out" = unknown ] \
+    || fail "a bare dead-shell '\$' prompt followed by U+00A0 must stay unknown, got '$out'"
+  pass "fm_tmux_composer_state: ambiguous geometry and bare dead-shell prompts still read unknown with U+00A0"
+}
+
 
 test_strip_ghost_drops_dim_keeps_normal
 test_strip_ghost_handles_combined_and_boundary_codes
@@ -809,3 +949,8 @@ test_peek_output_is_escape_free
 test_nbsp_separated_prompt_is_empty
 test_nbsp_separated_prompt_with_real_text_is_pending
 test_nbsp_composer_verdict_survives_losing_the_ghost_signal
+test_bordered_nbsp_composer_is_empty
+test_bordered_nbsp_composer_with_real_text_is_pending
+test_bordered_muse_glyph_composer_is_empty
+test_unbordered_nbsp_composer_state_is_empty_and_typed_is_pending
+test_nbsp_does_not_make_the_box_scan_credulous

--- a/tests/fm-composer-harness-drift-live-e2e.test.sh
+++ b/tests/fm-composer-harness-drift-live-e2e.test.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# tests/fm-composer-harness-drift-live-e2e.test.sh - opt-in drift guard proving
+# every INSTALLED harness's real, genuinely EMPTY composer still classifies
+# `empty`, and that real typed text in it still classifies `pending`.
+#
+# Why this file exists: the composer verdict is read off the harness's own
+# rendered input row, which the vendor controls and changes without notice.
+# Claude Code began separating its prompt glyph from the composer's content with
+# U+00A0 NO-BREAK SPACE instead of an ASCII space, and the shared classifier -
+# which tested only POSIX `[[:space:]]` - read that lone separator as a human's
+# half-typed text. Every caller that must not type over unsubmitted input then
+# refused to act: away-mode escalation delivery deferred 2105 times across 8.3
+# hours against an idle pane, `bin/fm-send.sh` reported landed messages as
+# unconfirmed, and the away-mode wedge alarm was itself undeliverable because it
+# shares the blocked channel (upstream kunchenguid/firstmate#1988).
+#
+# That class of regression is invisible from the output: the composer LOOKS
+# empty in any plain capture, and only decoding the code points reveals the
+# separator. A stubbed agent cannot see it either - a fixture can only confirm
+# the separator that was already written into it. So this guard drives real
+# harnesses and decodes what they actually draw, and prints those bytes on
+# success too, because that decoded row is the evidence
+# docs/verification/runtime-backends.md records.
+#
+# Both directions are checked for every harness, because the fix for a false
+# `pending` would be trivially "achievable" by making the predicate permissive,
+# and a false `empty` is the strictly worse failure: it types over a captain's
+# half-written message, silently.
+#
+# Backend scope: this drives the tmux adapter, the verified reference backend.
+# The verdict itself comes from the ONE shared owner (bin/fm-composer-lib.sh's
+# fm_composer_classify_content) that the tmux, herdr, orca, and cmux adapters
+# all delegate to, and the drift being guarded is what the HARNESS renders, not
+# what a backend captures - the same claude build was observed drawing the same
+# `❯`+U+00A0 row through both tmux and herdr. Per-backend structural row-finding
+# is covered by each adapter's own portable suite.
+#
+# Each harness is launched bare, with no prompt, and text is only ever TYPED,
+# never submitted, so this consumes no model tokens. An unauthenticated harness
+# that never reaches a composer is reported as unverified rather than passed
+# over silently.
+#
+# Standard CI has no harness binaries or credentials, so this real-harness guard
+# is opt-in and on-demand. Its portable counterparts pin the classifier logic in
+# CI: tests/fm-composer-ghost.test.sh and the composer cases in
+# tests/fm-backend-herdr.test.sh. Run this guard after any harness upgrade and
+# before trusting refreshed per-harness evidence.
+set -u
+
+if [ "${FM_COMPOSER_HARNESS_DRIFT:-0}" != 1 ]; then
+  echo "skip: set FM_COMPOSER_HARNESS_DRIFT=1 to run the installed-harness composer drift guard"
+  exit 0
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fail() { printf 'not ok - %s\n' "$1" >&2; cleanup_all; exit 1; }
+pass() { printf 'ok - %s\n' "$1"; }
+note() { printf '# %s\n' "$1"; }
+
+command -v tmux >/dev/null 2>&1 || fail "tmux not found"
+REAL_TMUX=$(command -v tmux)
+SOCKET="fm-composer-drift-$$"
+LAB=$(mktemp -d "${TMPDIR:-/tmp}/fm-composer-drift.XXXXXX")
+SESSION=drift
+
+cleanup_all() {
+  "$REAL_TMUX" -L "$SOCKET" kill-server >/dev/null 2>&1 || true
+  [ -n "${LAB:-}" ] && rm -rf "$LAB"
+}
+trap cleanup_all EXIT
+
+mkdir -p "$LAB/shim" "$LAB/wt"
+cat > "$LAB/shim/tmux" <<SH
+#!/usr/bin/env bash
+exec "$REAL_TMUX" -L "$SOCKET" "\$@"
+SH
+chmod +x "$LAB/shim/tmux"
+PATH="$LAB/shim:$PATH"
+export PATH
+
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-backend.sh"
+fm_backend_source tmux || fail "fm_backend_source tmux failed"
+
+"$REAL_TMUX" -L "$SOCKET" new-session -d -s "$SESSION" -n control -c "$LAB/wt" \
+  || fail "could not start the private tmux server"
+
+# Mirror bin/fm-spawn.sh's own resolution order so this guard covers the same
+# binary firstmate would actually launch (kimi is not required to be on PATH).
+resolve_harness_binary() {  # <harness>
+  local harness=$1 candidate
+  candidate=$(command -v "$harness" 2>/dev/null || true)
+  if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+  if [ "$harness" = kimi ] && [ -n "${HOME:-}" ] && [ -x "$HOME/.kimi-code/bin/kimi" ]; then
+    printf '%s\n' "$HOME/.kimi-code/bin/kimi"
+    return 0
+  fi
+  return 1
+}
+
+# The composer row as raw bytes, hex-dumped. A separator change is invisible in
+# rendered text and only shows up here (U+00A0 reads as the byte pair c2 a0), so
+# every verdict this guard reports - pass or fail - carries it.
+composer_row_bytes() {  # <target>
+  local row
+  row=$("$REAL_TMUX" -L "$SOCKET" capture-pane -p -t "$1" 2>/dev/null \
+    | grep -a -e "$(printf '\xe2\x9d\xaf')" -e "$(printf '\xe2\x80\xba')" -e "$(printf '\xe2\x9f\xa9')" \
+    | tail -1)
+  [ -n "$row" ] || { printf '(no prompt-glyph row found in the capture)'; return 0; }
+  printf '%s' "$row" | LC_ALL=C od -An -tx1 | tr -s ' \n' ' '
+}
+
+# Read the verdict twice so a mid-redraw frame cannot be mistaken for a settled
+# one; an unstable pair reports empty, which the callers below treat as not yet
+# settled rather than as a verdict.
+stable_composer_state() {  # <target>
+  local first second
+  first=$(fm_backend_composer_state tmux "$1")
+  sleep 1
+  second=$(fm_backend_composer_state tmux "$1")
+  [ "$first" = "$second" ] || return 0
+  printf '%s' "$first"
+}
+
+# Poll until <target>'s settled verdict is one of <wanted...>, or the bound
+# expires; echo whatever the last settled verdict was.
+await_composer_state() {  # <target> <deadline-iterations> <wanted...>
+  local target=$1 tries=$2 state='' want
+  shift 2
+  while [ "$tries" -gt 0 ]; do
+    state=$(stable_composer_state "$target")
+    for want in "$@"; do
+      [ "$state" = "$want" ] && { printf '%s' "$state"; return 0; }
+    done
+    tries=$((tries - 1))
+  done
+  printf '%s' "$state"
+}
+
+# A marker this guard types itself. Establishing "this pane is really sitting at
+# a composer" from our OWN input is what makes the empty verdict affirmative
+# rather than assumed: a harness parked on a startup dialog (claude's "1. Yes, I
+# trust this folder" menu row even begins with the `❯` glyph) never takes the
+# marker, and is reported unverified instead of being read as a composer.
+# Letters only - no `/` or `$`, which would open a completion popup.
+PROBE_MARKER=zqxfmcomposerprobe
+
+pane_has_marker() {  # <target>
+  "$REAL_TMUX" -L "$SOCKET" capture-pane -p -t "$1" 2>/dev/null \
+    | LC_ALL=C grep -qa "$PROBE_MARKER"
+}
+
+await_marker() {  # <target> <present|absent> <tries>
+  local target=$1 want=$2 tries=$3
+  while [ "$tries" -gt 0 ]; do
+    if pane_has_marker "$target"; then
+      [ "$want" = present ] && return 0
+    else
+      [ "$want" = absent ] && return 0
+    fi
+    sleep 0.5
+    tries=$((tries - 1))
+  done
+  return 1
+}
+
+CHECKED=0
+SKIPPED=
+UNVERIFIED=
+
+# The verified adapters, in the order .agents/skills/harness-adapters/SKILL.md
+# records them. An adapter that gains a verified launch path belongs here too.
+for harness in claude codex opencode pi pi-signed grok kimi muse; do
+  if ! bin_path=$(resolve_harness_binary "$harness"); then
+    SKIPPED="$SKIPPED $harness"
+    note "skip: $harness is not installed on this machine, so its composer rendering is unverified here"
+    continue
+  fi
+
+  version=$("$bin_path" --version 2>/dev/null | head -1 | tr -d '\r') || version=
+  [ -n "$version" ] || version="unknown"
+
+  target="$SESSION:$harness"
+  "$REAL_TMUX" -L "$SOCKET" new-window -d -t "$SESSION:" -n "$harness" -c "$LAB/wt" -- "$bin_path" \
+    || fail "$harness ($version): could not launch a window for the composer probe"
+
+  state=
+  for _ in $(seq 1 150); do
+    state=$(fm_backend_agent_state tmux "$target")
+    [ "$state" = alive ] && break
+    sleep 0.2
+  done
+  [ "$state" = alive ] || {
+    UNVERIFIED="$UNVERIFIED $harness"
+    note "unverified: $harness $version never reached an 'alive' process, so its composer was never read"
+    "$REAL_TMUX" -L "$SOCKET" kill-window -t "$target" >/dev/null 2>&1 || true
+    continue
+  }
+
+  # Let the harness paint its first full frame, then record what it starts on
+  # purely as evidence - the startup frame is NOT asserted on, because a trust
+  # or login dialog is a legitimate thing to start on and is not a composer.
+  sleep 3
+  note "$harness $version: startup row bytes $(composer_row_bytes "$target")"
+
+  # Step 1, the pending direction, which also PROVES this pane is at a composer:
+  # type a marker literally, never submitted, and require the harness to render
+  # it back.
+  #
+  # A first launch in a fresh directory can sit on a trust or bypass-permissions
+  # confirmation instead (.agents/skills/harness-adapters/SKILL.md: accept with
+  # Enter, or the choice the dialog requires). Enter is sent ONLY after the pane
+  # has demonstrably NOT reflected typed input, so it can never submit a real
+  # composer and start a billed turn; two rounds cover a trust dialog followed
+  # by a permissions one.
+  at_composer=0
+  for _ in 1 2 3; do
+    "$REAL_TMUX" -L "$SOCKET" send-keys -l -t "$target" "$PROBE_MARKER" \
+      || fail "$harness ($version): could not type into the pane"
+    if await_marker "$target" present 20; then at_composer=1; break; fi
+    note "$harness $version: typed input was not rendered back; accepting a startup confirmation with Enter and retrying"
+    "$REAL_TMUX" -L "$SOCKET" send-keys -t "$target" C-u >/dev/null 2>&1 || true
+    "$REAL_TMUX" -L "$SOCKET" send-keys -t "$target" Enter >/dev/null 2>&1 || true
+    sleep 3
+  done
+  if [ "$at_composer" -ne 1 ]; then
+    UNVERIFIED="$UNVERIFIED $harness"
+    note "unverified: $harness $version never rendered typed input back, so it is not sitting at a composer (a login or trust dialog it does not accept with Enter, or it needs credentials). Row bytes: $(composer_row_bytes "$target")"
+    "$REAL_TMUX" -L "$SOCKET" kill-window -t "$target" >/dev/null 2>&1 || true
+    continue
+  fi
+
+  typed=$(await_composer_state "$target" 20 pending)
+  [ "$typed" = pending ] || fail \
+    "COMPOSER DRIFT: $harness $version is rendering real unsubmitted text in its composer, yet it classifies '$typed' instead of 'pending'. This is the DANGEROUS direction: firstmate will type over a captain's half-written message, and the loss is silent. Decoded composer row: $(composer_row_bytes "$target")."
+
+  # Step 2, the empty direction. Clearing our own marker is what makes the
+  # composer AFFIRMATIVELY empty: the row is empty because this guard just
+  # emptied it and confirmed the marker is gone from the rendered pane, not
+  # because the verdict said so.
+  "$REAL_TMUX" -L "$SOCKET" send-keys -t "$target" C-u >/dev/null 2>&1 || true
+  if ! await_marker "$target" absent 40; then
+    UNVERIFIED="$UNVERIFIED $harness"
+    note "unverified: $harness $version did not clear its composer on C-u, so no affirmatively empty composer could be produced to read. Row bytes: $(composer_row_bytes "$target")"
+    "$REAL_TMUX" -L "$SOCKET" kill-window -t "$target" >/dev/null 2>&1 || true
+    continue
+  fi
+
+  cleared=$(await_composer_state "$target" 20 empty)
+  [ "$cleared" = empty ] || fail \
+    "COMPOSER DRIFT: $harness $version has a composer this guard just emptied - the typed marker is gone from the rendered pane - yet it classifies '$cleared' instead of 'empty'. Every caller that must not overwrite unsubmitted input now refuses to act against this harness: away-mode escalations stop being delivered and steer confirmations report landed messages as unconfirmed. The separator or prompt glyph this release renders is not one bin/fm-composer-lib.sh recognises. Decoded composer row: $(composer_row_bytes "$target") (U+00A0 NO-BREAK SPACE is the byte pair c2 a0; fm_composer_normalize_trim_var maps every Unicode White_Space=Yes code point, so a byte run outside that property is the thing to add)."
+
+  note "$harness $version: EMPTY composer row bytes $(composer_row_bytes "$target")"
+
+  pass "composer drift: $harness $version reads pending with real typed text and empty once cleared"
+  CHECKED=$((CHECKED + 1))
+  "$REAL_TMUX" -L "$SOCKET" kill-window -t "$target" >/dev/null 2>&1 || true
+done
+
+[ "$CHECKED" -gt 0 ] || fail \
+  "no installed harness reached a readable composer, so this run proved nothing; install and authenticate at least one harness before trusting a pass"
+
+[ -n "$SKIPPED" ] && note "not installed on this machine:$SKIPPED"
+[ -n "$UNVERIFIED" ] && note "installed but composer unverified (no readable composer reached):$UNVERIFIED"
+note "checked $CHECKED installed harness(es) end to end"
+
+cleanup_all
+trap - EXIT

--- a/tests/fm-composer-harness-drift-live-e2e.test.sh
+++ b/tests/fm-composer-harness-drift-live-e2e.test.sh
@@ -27,6 +27,14 @@
 # and a false `empty` is the strictly worse failure: it types over a captain's
 # half-written message, silently.
 #
+# The shared owner recognises several composer SHAPES on the way to that
+# verdict, and they have failed independently - an unbordered row misreads as
+# `pending`, a bordered box whose geometry cannot be proven blank misreads as
+# `unknown`, and both make every caller refuse to act. Which shape a harness
+# draws is the harness's own choice, so this guard reports the shape each one
+# exercised (and says plainly when a run saw only one of them) rather than
+# pretending a single-shape run covered the others.
+#
 # Backend scope: this drives the tmux adapter, the verified reference backend.
 # The verdict itself comes from the ONE shared owner (bin/fm-composer-lib.sh's
 # fm_composer_classify_content) that the tmux, herdr, orca, and cmux adapters
@@ -114,6 +122,36 @@ composer_row_bytes() {  # <target>
   printf '%s' "$row" | LC_ALL=C od -An -tx1 | tr -s ' \n' ' '
 }
 
+# Which shape from the shared owner's catalogue this harness's composer takes.
+# The shapes reach the same verdict by different routes and have failed
+# independently: an unbordered row misreads as `pending`, while a bordered box
+# whose geometry cannot be proven blank misreads as `unknown`. Both refuse to
+# act, so a fix for one is not evidence for the other, and every verdict below
+# names the path it was reached through. The shape comes from the SAME row scan
+# the verdict does (bin/fm-composer-lib.sh's _fm_composer_scan_screen), so this
+# label can never disagree with the classification it is describing.
+composer_structural_path() {  # <target>
+  local cy pane plain
+  cy=$("$REAL_TMUX" -L "$SOCKET" display-message -p -t "$1" '#{cursor_y}' 2>/dev/null) || cy=
+  case "$cy" in ''|*[!0-9]*) printf 'unreadable'; return 0 ;; esac
+  pane=$("$REAL_TMUX" -L "$SOCKET" capture-pane -p -t "$1" -S 0 -E - 2>/dev/null) || {
+    printf 'unreadable'; return 0
+  }
+  plain=$(printf '%s\n' "$pane" | fm_composer_strip_ansi)
+  _fm_composer_scan_screen "$plain" "$cy"
+  if [ "$FM_COMPOSER_SCAN_BOX_TOP" -ge 0 ]; then
+    printf 'bordered-box'
+  elif [ "$FM_COMPOSER_SCAN_LEFTBAR_START" -ge 0 ]; then
+    printf 'left-bar'
+  elif [ "$FM_COMPOSER_SCAN_PI_PAIR_VALID" = 1 ]; then
+    printf 'separated'
+  elif [ "$FM_COMPOSER_SCAN_BARE_ROW" -ge 0 ]; then
+    printf 'bare-row'
+  else
+    printf 'unrecognised'
+  fi
+}
+
 # Read the verdict twice so a mid-redraw frame cannot be mistaken for a settled
 # one; an unstable pair reports empty, which the callers below treat as not yet
 # settled rather than as a verdict.
@@ -171,6 +209,7 @@ await_marker() {  # <target> <present|absent> <tries>
 CHECKED=0
 SKIPPED=
 UNVERIFIED=
+PATHS_SEEN=
 
 # The verified adapters, in the order .agents/skills/harness-adapters/SKILL.md
 # records them. An adapter that gains a verified launch path belongs here too.
@@ -234,9 +273,12 @@ for harness in claude codex opencode pi pi-signed grok kimi muse; do
     continue
   fi
 
+  structural_path=$(composer_structural_path "$target")
+  note "$harness $version: composer reached through the $structural_path path"
+
   typed=$(await_composer_state "$target" 20 pending)
   [ "$typed" = pending ] || fail \
-    "COMPOSER DRIFT: $harness $version is rendering real unsubmitted text in its composer, yet it classifies '$typed' instead of 'pending'. This is the DANGEROUS direction: firstmate will type over a captain's half-written message, and the loss is silent. Decoded composer row: $(composer_row_bytes "$target")."
+    "COMPOSER DRIFT: $harness $version is rendering real unsubmitted text in its composer (reached through the $structural_path path), yet it classifies '$typed' instead of 'pending'. This is the DANGEROUS direction: firstmate will type over a captain's half-written message, and the loss is silent. Decoded composer row: $(composer_row_bytes "$target")."
 
   # Step 2, the empty direction. Clearing our own marker is what makes the
   # composer AFFIRMATIVELY empty: the row is empty because this guard just
@@ -250,13 +292,18 @@ for harness in claude codex opencode pi pi-signed grok kimi muse; do
     continue
   fi
 
+  empty_path=$(composer_structural_path "$target")
   cleared=$(await_composer_state "$target" 20 empty)
   [ "$cleared" = empty ] || fail \
-    "COMPOSER DRIFT: $harness $version has a composer this guard just emptied - the typed marker is gone from the rendered pane - yet it classifies '$cleared' instead of 'empty'. Every caller that must not overwrite unsubmitted input now refuses to act against this harness: away-mode escalations stop being delivered and steer confirmations report landed messages as unconfirmed. The separator or prompt glyph this release renders is not one bin/fm-composer-lib.sh recognises. Decoded composer row: $(composer_row_bytes "$target") (U+00A0 NO-BREAK SPACE is the byte pair c2 a0; fm_composer_normalize_trim_var maps every Unicode White_Space=Yes code point, so a byte run outside that property is the thing to add)."
+    "COMPOSER DRIFT: $harness $version has a composer this guard just emptied - the typed marker is gone from the rendered pane - yet it classifies '$cleared' instead of 'empty', reached through the $empty_path path. Every caller that must not overwrite unsubmitted input now refuses to act against this harness: away-mode escalations stop being delivered and steer confirmations report landed messages as unconfirmed. On the $empty_path path a '$cleared' verdict means the separator or prompt glyph this release renders is not one bin/fm-composer-lib.sh recognises (bare-row drift usually reads 'pending'; a bordered box whose blanked geometry no longer matches its border reads 'unknown'). Decoded composer row: $(composer_row_bytes "$target") (U+00A0 NO-BREAK SPACE is the byte pair c2 a0; fm_composer_normalize_trim_var maps every Unicode White_Space=Yes code point, so a byte run outside that property is the thing to add)."
 
   note "$harness $version: EMPTY composer row bytes $(composer_row_bytes "$target")"
 
-  pass "composer drift: $harness $version reads pending with real typed text and empty once cleared"
+  case " $PATHS_SEEN " in
+    *" $empty_path "*) : ;;
+    *) PATHS_SEEN="$PATHS_SEEN $empty_path" ;;
+  esac
+  pass "composer drift: $harness $version reads pending with real typed text and empty once cleared (via the $empty_path path)"
   CHECKED=$((CHECKED + 1))
   "$REAL_TMUX" -L "$SOCKET" kill-window -t "$target" >/dev/null 2>&1 || true
 done
@@ -267,6 +314,20 @@ done
 [ -n "$SKIPPED" ] && note "not installed on this machine:$SKIPPED"
 [ -n "$UNVERIFIED" ] && note "installed but composer unverified (no readable composer reached):$UNVERIFIED"
 note "checked $CHECKED installed harness(es) end to end"
+# Which structural paths this run actually covered. Which one a harness takes is
+# the HARNESS's choice, not this guard's, so a machine with only bare-row
+# harnesses installed cannot be failed for it - but a run that saw only one path
+# is not evidence about the other, and says so rather than reading as full
+# coverage. The portable suites pin both paths unconditionally.
+note "structural paths exercised:$PATHS_SEEN"
+case " $PATHS_SEEN " in
+  *" bordered-box "*) : ;;
+  *) note "no installed harness drew a BORDERED composer box, so the bordered structural path is unverified by this run (tests/fm-composer-ghost.test.sh pins it portably)" ;;
+esac
+case " $PATHS_SEEN " in
+  *" bare-row "*) : ;;
+  *) note "no installed harness drew a BARE composer row, so the unbordered structural path is unverified by this run (tests/fm-composer-ghost.test.sh pins it portably)" ;;
+esac
 
 cleanup_all
 trap - EXIT

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -531,6 +531,78 @@ test_selected_content_is_composer_scoped_and_wrap_normalized() {
   pass "fm_composer_extract_selected_content: scopes user content and excludes furniture"
 }
 
+# --- Unicode whitespace between the prompt glyph and the content ------------
+# Task fm-composer-read-unreliable (upstream kunchenguid/firstmate#1988).
+# Claude 2.x separates its prompt glyph from the composer's content with U+00A0
+# NO-BREAK SPACE, so an affirmatively EMPTY composer is exactly `❯\302\240`.
+# Every trim and glyph comparison here tested only POSIX `[[:space:]]`, which
+# bash excludes U+00A0 from under the C and UTF-8 locales alike, so that lone
+# separator survived as apparent typed content and the row read `pending` - the
+# verdict that stops every caller which must not overwrite unsubmitted input.
+# The owner now follows the Unicode White_Space property instead of a list of
+# separators observed in one release. The screen-level matrix above pins the
+# real captured rows; these cases pin the property itself at the content
+# classifier, where every adapter's verdict ultimately lands.
+
+# The classifier follows the Unicode White_Space property rather than a list of
+# separators observed in one harness release, so the next space-like character a
+# harness picks is already covered. U+200B ZERO WIDTH SPACE pins the deliberate
+# boundary: Unicode gives it White_Space=No, so it is NOT normalized and still
+# reads as content.
+test_unicode_whitespace_property_set_is_covered() {
+  local sep ws glyph out
+  glyph=$(printf '\xe2\x9d\xaf')
+  for sep in '\302\205' '\302\240' '\341\232\200' '\342\200\200' '\342\200\207' \
+             '\342\200\212' '\342\200\250' '\342\200\251' '\342\200\257' \
+             '\342\201\237' '\343\200\200'; do
+    ws=$(printf '%b' "$sep")
+    out=$(fm_composer_classify_content 1 "$glyph$ws")
+    [ "$out" = empty ] || fail "a glyph followed by Unicode whitespace ${sep} should read empty, got '$out'"
+    out=$(fm_composer_classify_content 1 "${glyph}${ws}typed")
+    [ "$out" = pending ] || fail "real text behind Unicode whitespace ${sep} should read pending, got '$out'"
+  done
+  # U+200B is a format character, not whitespace - it stays content.
+  out=$(fm_composer_classify_content 1 "$(printf '\xe2\x9d\xaf\342\200\213')")
+  [ "$out" = pending ] || fail "U+200B ZERO WIDTH SPACE is White_Space=No and must NOT be normalized away, got '$out'"
+  pass "fm_composer_classify_content: the Unicode White_Space property set normalizes, U+200B deliberately does not"
+}
+
+# The leading-glyph strip used `${content#?}`, which drops one BYTE under
+# LC_ALL=C (the fleet default) and one CHARACTER under a UTF-8 locale, so a
+# multibyte glyph left locale-dependent trailing bytes that read as content.
+# The verdict must not depend on the ambient locale in either direction.
+test_composer_verdict_is_locale_independent() {
+  local loc out checked=0
+  for loc in C C.utf8 en_US.utf8; do
+    locale -a 2>/dev/null | grep -qx "$loc" || continue
+    out=$(LC_ALL="$loc" bash -c '. "$1"; fm_composer_classify_content 1 "$(printf "\xe2\x9d\xaf\302\240")"' _ "$ROOT/bin/fm-composer-lib.sh")
+    [ "$out" = empty ] || fail "glyph + U+00A0 must read empty under LC_ALL=$loc, got '$out'"
+    out=$(LC_ALL="$loc" bash -c '. "$1"; fm_composer_classify_content 1 "$(printf "\xe2\x9d\xaf\302\240still typing")"' _ "$ROOT/bin/fm-composer-lib.sh")
+    [ "$out" = pending ] || fail "glyph + U+00A0 + real text must read pending under LC_ALL=$loc, got '$out'"
+    out=$(LC_ALL="$loc" bash -c '. "$1"; fm_composer_classify_content 1 "$(printf "\xe2\x9d\xaf hello")"' _ "$ROOT/bin/fm-composer-lib.sh")
+    [ "$out" = pending ] || fail "glyph + ASCII space + real text must read pending under LC_ALL=$loc, got '$out'"
+    checked=$((checked + 1))
+  done
+  # LC_ALL=C is the fleet default and is guaranteed present, so checking nothing
+  # here means the locale probe itself broke rather than that the case passed.
+  [ "$checked" -gt 0 ] || fail "no installed locale was exercised; this case checked nothing"
+  pass "fm_composer_classify_content: the verdict is identical under every installed locale ($checked checked)"
+}
+
+# The dead-shell refusal is the reason this classifier exists at all, and a
+# Unicode separator must not become a way around it: a bare shell prompt is
+# still never a safe injection target, with or without one.
+test_nbsp_does_not_weaken_the_dead_shell_refusal() {
+  local out glyph
+  for glyph in '>' '$' '%' '#'; do
+    out=$(fm_composer_classify_content 0 "$glyph$NBSP")
+    [ "$out" = unknown ] || fail "a bare dead-shell '$glyph' followed by U+00A0 must stay unknown, got '$out'"
+    out=$(fm_composer_classify_content 1 "$glyph$NBSP")
+    [ "$out" = empty ] || fail "a bordered composer's own '$glyph' prompt with U+00A0 should read empty, got '$out'"
+  done
+  pass "fm_composer_classify_content: U+00A0 never turns a bare dead-shell prompt into an injection target"
+}
+
 test_bare_shell_glyphs_are_unknown
 test_stripped_unbordered_content_uses_plain_content
 test_bare_shell_prompt_with_command_is_not_empty
@@ -559,3 +631,6 @@ test_incomplete_lower_box_invalidates_stale_candidate
 test_titled_bottom_requires_matching_width
 test_cursor_on_proven_box_bottom_classifies_content
 test_selected_content_is_composer_scoped_and_wrap_normalized
+test_unicode_whitespace_property_set_is_covered
+test_composer_verdict_is_locale_independent
+test_nbsp_does_not_weaken_the_dead_shell_refusal

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -603,6 +603,42 @@ test_nbsp_does_not_weaken_the_dead_shell_refusal() {
   pass "fm_composer_classify_content: U+00A0 never turns a bare dead-shell prompt into an injection target"
 }
 
+# The structural geometry probe asks "is this row blank to the same width as its
+# border", and an empty composer row is allowed to hold its prompt glyph. That
+# probe used to respell the glyphs and had already drifted (it never listed
+# muse's `⟩`), so it must reach the SAME declarations the content classifier
+# reaches. Driving both against every declared glyph is what pins them together:
+# a glyph added to either list without the probe following is a failure here.
+# Every glyph occupies one column, so blanking rather than deleting is what
+# keeps the width comparison honest.
+test_every_declared_prompt_glyph_is_blankable_and_classified() {
+  local glyph blanked verdict seen=0
+  while IFS= read -r glyph; do
+    [ -n "$glyph" ] || continue
+    seen=$((seen + 1))
+    blanked=$(fm_composer_geometry_spaces " $glyph$NBSP ") \
+      || fail "the geometry probe cannot prove a row blank that holds only the declared prompt glyph '$glyph'"
+    [ "$blanked" = "    " ] \
+      || fail "the geometry probe must blank the declared prompt glyph '$glyph' to exactly one column: got '$blanked'"
+    # And the same glyph reads as an empty composer inside a container, which is
+    # the verdict the blanked-geometry row is about to be combined with.
+    verdict=$(fm_composer_classify_content 1 "$glyph$NBSP")
+    [ "$verdict" = empty ] \
+      || fail "declared prompt glyph '$glyph' should classify empty inside a container, got '$verdict'"
+  done <<EOF
+$FM_COMPOSER_AGENT_PROMPT_GLYPHS
+$FM_COMPOSER_SHELL_PROMPT_GLYPHS
+EOF
+  [ "$seen" -ge 7 ] || fail "only $seen prompt glyphs were exercised; the declarations look empty and this case checked nothing"
+  # Exactly ONE leading glyph is blanked. A second non-ASCII character is
+  # residue the width proof cannot account for, so the row fails it rather than
+  # being silently absorbed into the border's own width.
+  if blanked=$(fm_composer_geometry_spaces "❯ ❯"); then
+    fail "only the ONE leading prompt glyph may be blanked; a second must fail the proof, got '$blanked'"
+  fi
+  pass "fm_composer_geometry_spaces: every declared prompt glyph blanks to one column and classifies empty ($seen glyphs)"
+}
+
 test_bare_shell_glyphs_are_unknown
 test_stripped_unbordered_content_uses_plain_content
 test_bare_shell_prompt_with_command_is_not_empty
@@ -634,3 +670,4 @@ test_selected_content_is_composer_scoped_and_wrap_normalized
 test_unicode_whitespace_property_set_is_covered
 test_composer_verdict_is_locale_independent
 test_nbsp_does_not_weaken_the_dead_shell_refusal
+test_every_declared_prompt_glyph_is_blankable_and_classified


### PR DESCRIPTION
## Intent

Fix a deterministic composer misclassification: fm_backend_composer_state returns `pending` for a claude composer that is affirmatively empty. `pending` means "real unsubmitted text is sitting there", so every caller that must not type over the captain's half-written message refuses to act. Observed cost: bin/fm-supervise-daemon.sh deferred every away-mode escalation for 8.3 hours overnight (2105 deferrals reading "composer not confirmed-empty" against only 3 genuine "pane busy"), leaving two finished pieces of work unshipped; bin/fm-send.sh reported "text not submitted (delivery unconfirmed; verdict=pending)" for a message that had visibly landed, inviting a duplicate steer.

ROOT CAUSE (accepted, and it SUPERSEDES the two hypotheses the original task brief proposed - the brief blamed either the prompt glyph's truecolor luminance sitting above the 128 ghost threshold, or the input area being drawn with horizontal rules instead of a boxed border; firstmate later instructed me to discard both). Claude renders the idle composer as U+276F followed by U+00A0 NO-BREAK SPACE. fm_composer_classify_content accepted a bare glyph and glyph+ASCII-space as empty, but not glyph+U+00A0, which fell through to pending.

The brief required establishing the cause by counterfactual rather than by reading the code and forming an opinion, changing one condition at a time and recording whether the verdict moved. I did that against the live panes and both original hypotheses were falsified: recolouring the glyph (including to the exact truecolor luminance suspected) did NOT move the verdict, and deleting the horizontal rules did NOT move it, while changing ONLY the separator did. It reproduces identically on tmux and herdr; on tmux the row is nothing but the glyph and the separator, and there the glyph is a 256-colour foreground that is never luminance-tested at all. Upstream filed the same finding as kunchenguid/firstmate#1988 with the same proof; the fix is shaped to close it, and its "Suggested directions" 1 and 2 (normalise Unicode spaces generally rather than enumerating glyph+separator pairs; add a regression pinning glyph+U+00A0 to empty) are implemented.

REQUIRED APPROACH. Prefer normalising Unicode whitespace generally over enumerating more glyph+separator pairs, and fix the single-character strip too: `${content#??}`/`${content#?}` assumed a one-character separator, which breaks on any multi-byte separator independently of the match (measured: it drops one BYTE under LC_ALL=C and one CHARACTER under a UTF-8 locale, leaving locale-dependent trailing bytes on a multibyte glyph). Distinguish the composer's own decoration from user content using the most structural signal available rather than another brightness number, and do not let a single vendor string be load-bearing - a rendered glyph and its colour are exactly what a harness release can change without warning.

HARD CONSTRAINT, deliberately chosen and central to review: do NOT weaken the predicate. This guard's entire purpose is to never type over text a human has half-written. `empty` must remain an affirmative verdict, real typed text MUST still read `pending`, and `unknown` must stay available for genuinely unreadable panes. Making it too permissive would make firstmate silently destroy the captain's unsent input, which is a worse and silent failure than the one being fixed. So the fix follows the Unicode White_Space=Yes property (a standards fact) rather than a brightness threshold or another observed string; whitespace-only content already classified `empty` when the whitespace was ASCII, and any non-whitespace character anywhere still classifies `pending`. The bare dead-shell-prompt refusal is unchanged with or without a separator.

DELIBERATE DECISIONS a reviewer reading only the diff would not know:
- U+200B ZERO WIDTH SPACE is deliberately EXCLUDED from normalization because Unicode gives it White_Space=No; including it would substitute my own guess for the property the owner claims to follow. This boundary is pinned by a test asserting U+200B still reads pending.
- The prompt glyphs were spelled out in three separate places, which bin/fm-composer-lib.sh's own header already flagged as a drift hazard ("must be listed in ALL THREE places"); they are now declared exactly once each and reached through helpers. This is behaviour-preserving.
- The shared normalizing trim is applied in all four adapters (tmux, herdr, orca, cmux) so a non-ASCII space cannot defeat one adapter's structural row scan while another's still matches.
- Normalization substitutes a space rather than deleting, so "foo<NBSP>bar" is not silently joined into one token.
- The live guard types its OWN marker, confirms the harness rendered it, clears it with C-u, and confirms it is gone before reading the empty composer - so `empty` is affirmative rather than assumed. It accepts a startup trust dialog with Enter ONLY after the pane has demonstrably not reflected typed input, so it can never submit a real composer or consume model tokens. It reports an absent harness explicitly and refuses a pass that checked nothing.

TESTS, both required by .agents/skills/firstmate-coding-guidelines "Harness-dependent checks":
- A portable regression under tests/ extending existing scripts rather than adding a runner, pinning the real captured row shapes: the empty composer that must read `empty`, and a genuinely-typed-into one that must still read `pending` (the second matters more than the first). Because U+00A0 is invisible in any capture, the fixtures assert they still contain the separator so no case can pass vacuously. Also pins the whole White_Space property set and locale independence.
- The env-gated, self-skipping live guard in the live-harness-optin family exercising every INSTALLED harness for real and failing by name and version, since a stub can only confirm the assumption written into it.
Verified against real claude 2.1.226 on tmux 3.5a: the empty row is `e2 9d af c2 a0`, and both the portable regression and the live guard fail on that exact row when the fix is reverted. The dated per-harness result is recorded in docs/verification/runtime-backends.md as required.

SCOPE, explicitly bounded by the brief and reaffirmed by firstmate: the composer-state read and its callers only. Do NOT restructure away mode, do NOT change the wake queue, and do NOT touch the Stop-hook watcher path (that path works and is currently the only reliable way firstmate gets woken). Upstream issue 1988's directions 3 and 4 are away-mode changes and are deliberately NOT implemented here.

A third reported symptom - `fm-send.sh --resolve-key <key>` refusing with "no open decision or blocker with that key" while the wake drain listed that key open - was to be treated as possibly a SEPARATE defect and not folded in silently. I established it IS separate: a status line written as `needs-decision: [key=slug] ...` puts the key token AFTER the colon, while _fm_decision_key only parses it BEFORE the colon, so the decision silently degrades to key `default`. Different subsystem and different mechanism from the composer bug, and it already has its own task and branch (fm/fm-decision-key-position). It is deliberately excluded from this change.

Known pre-existing failures NOT caused by this change, each verified to reproduce on the unmodified tree: tests/fm-afk-inject-herdr-e2e.test.sh fails under LC_ALL=C with the fix reverted too; tests/fm-lint.test.sh needs the pinned shellcheck on PATH; tests/fm-test-run.test.sh needs LC_ALL=C collation. With the pinned shellcheck and LC_ALL=C, the full changed-selection suite is 71 scripts with only that pre-existing away-mode E2E failing.

## What Changed

- Added `fm_composer_normalize_spaces_var` / `fm_composer_normalize_trim_var` to `bin/fm-composer-lib.sh`, mapping every non-ASCII code point with the Unicode `White_Space=Yes` property (U+0085, U+00A0, U+1680, U+2000–U+200A, U+2028, U+2029, U+202F, U+205F, U+3000 — deliberately not U+200B, which is `White_Space=No`) onto an ASCII space before every trim, border strip, and glyph comparison, so claude's empty row `❯` + U+00A0 now classifies `empty` instead of `pending`. The predicate is not otherwise loosened: any non-whitespace character still reads `pending`, and a bare shell glyph still reads `unknown`. The same shared trim replaces the open-coded ASCII-only trims in the tmux, herdr, orca, and cmux structural row scans, where the same separator made a bordered composer read `unknown`.
- Consolidated the prompt glyphs into single declarations (`FM_COMPOSER_AGENT_PROMPT_GLYPHS`, `FM_COMPOSER_SHELL_PROMPT_GLYPHS`) reached via `fm_composer_leading_prompt_glyph_var` / `fm_composer_blank_leading_prompt_var`, replacing the three inline copies in the classifier plus the drifted copy in `fm_tmux_composer_geometry_spaces` (which omitted muse's `⟩`). The glyph strip now removes the matched literal instead of `${content#?}`/`${content#??}`, which dropped one byte under `LC_ALL=C` and one character under a UTF-8 locale.
- Added regression coverage pinning the captured `e2 9d af c2 a0` row to `empty` and typed input to `pending` (`tests/fm-composer-lib.test.sh`, `tests/fm-composer-ghost.test.sh`, `tests/fm-backend-herdr.test.sh`, with fixtures asserting the separator is present so no case passes vacuously), plus a new env-gated live guard `tests/fm-composer-harness-drift-live-e2e.test.sh` that types and clears its own marker before reading each installed harness; `bin/fm-test-run.sh` routes `bin/fm-composer*` and `bin/fm-tmux-lib.sh` changes to the `live-harness-optin` family. Backend docs, the harness-adapters skill, and `docs/verification/runtime-backends.md` record the whitespace boundary and the dated per-harness table (claude 2.1.226 on tmux 3.5a; every uninstalled harness listed as unverified).

## Risk Assessment

✅ Low: The change is well-bounded to the composer-state read and its four adapters, the predicate is verifiably not weakened in the dangerous direction (bare dead-shell prompts, ZWSP, and real typed text all still refuse), the Unicode table matches the standard property exactly, both fix rounds' claims check out against the current code, and the only outstanding item is a test-enumeration gap over data I verified correct.

## Testing

I proved the intent end-to-end against the real harness rather than only in fixtures: driving `bin/fm-supervise-daemon.sh`'s actual away-mode escalation guard against a live claude 2.1.226 composer on tmux 3.5a reproduced the reported "composer not confirmed-empty (state=pending)" deferral on the reverted classifier and showed the escalation accepted on the fix, against a composer the demo had itself emptied and whose bytes decode to `e2 9d af c2 a0`; the hard constraint holds on the same live pane, since real unsubmitted text still reads `pending` and still defers. The opt-in live drift guard passes on the fix and fails by name and version when reverted, and reports the seven uninstalled harnesses and the uncovered bordered path rather than reading as full coverage. All portable suites for the changed classifier and the four adapters pass, each new regression fails on base sources in both C and UTF-8 locales, and the test-runner change correctly selects 71 scripts including the new live guard. The one failure seen, the away-mode herdr E2E under `LC_ALL=C`, reproduces identically on the unmodified base tree and passes here in a UTF-8 locale, so it is pre-existing and not caused by this change. No visual artifact applies: the affected surface is a terminal composer read and a daemon log line, both captured as CLI transcripts, and the defect is invisible in any rendered capture because U+00A0 only appears once the bytes are decoded.

<details>
<summary>Evidence: Away-mode escalation guard against a live claude composer: before/after the fix, plus the safety half</summary>

<code>== BEFORE THE FIX (composer classifier reverted to base commit 2d2be63) ==&#10;-- claude version: 2.1.226 (Claude Code)&#10;-- marker cleared; the composer is now affirmatively EMPTY. Its raw bytes:&#10;e2 9d af c2 a0&#10;(e2 9d af = U+276F &#39;\xe2\x9d\xaf&#39; ; c2 a0 = U+00A0 NO-BREAK SPACE)&#10;-- what fm_backend_composer_state reads off that live pane:&#10;pending&#10;-- running the real inject_msg() away-mode escalation guard:&#10;inject_msg -&gt; DEFERRED (escalation withheld)&#10;-- daemon log:&#10;[2026-08-09T06:40:02+0000] inject deferred: supervisor composer not confirmed-empty (state=pending: pending input, dead-shell prompt, or unreadable pane)&#10;&#10;== AFTER THE FIX (worktree at deb3692) ==&#10;-- what fm_backend_composer_state reads off that live pane:&#10;empty&#10;-- running the real inject_msg() away-mode escalation guard:&#10;inject_msg -&gt; ACCEPTED (escalation would be delivered to the captain)&#10;-- daemon log:&#10;&#10;== AFTER THE FIX - SAFETY HALF: real unsubmitted text still blocks injection ==&#10;-- marker deliberately LEFT in the composer (unsubmitted human text). Its raw bytes:&#10;e2 9d af c2 a0 7a 71 78 66 6d 67 75 61 72 64 64 65 6d 6f&#10;-- what fm_backend_composer_state reads off that live pane:&#10;pending&#10;-- running the real inject_msg() away-mode escalation guard:&#10;inject_msg -&gt; DEFERRED (escalation withheld)&#10;-- daemon log:&#10;[2026-08-09T06:41:09+0000] inject deferred: supervisor composer not confirmed-empty (state=pending: pending input, dead-shell prompt, or unreadable pane)</code>

```text
### Away-mode escalation guard against a REAL claude 2.1.226 composer on tmux 3.5a
### (bin/fm-supervise-daemon.sh inject_msg; only the final send is stubbed, so no tokens are spent)

== BEFORE THE FIX (composer classifier reverted to base commit 2d2be63) ==
-- claude version: 2.1.226 (Claude Code)
-- pane with our typed marker still in the composer (the 'human is half-way through' case):
     ❯ zqxfmguarddemo
-- marker cleared; the composer is now affirmatively EMPTY. Its raw bytes:
      e2 9d af c2 a0 
     (e2 9d af = U+276F '\xe2\x9d\xaf' ; c2 a0 = U+00A0 NO-BREAK SPACE)
-- what fm_backend_composer_state reads off that live pane:
     pending
-- running the real inject_msg() away-mode escalation guard:
     inject_msg -> DEFERRED (escalation withheld)
-- daemon log:
     [2026-08-09T06:40:02+0000] inject deferred: supervisor composer not confirmed-empty (state=pending: pending input, dead-shell prompt, or unreadable pane)

== AFTER THE FIX (worktree at deb3692) ==
-- claude version: 2.1.226 (Claude Code)
-- pane with our typed marker still in the composer (the 'human is half-way through' case):
     ❯ zqxfmguarddemo
-- marker cleared; the composer is now affirmatively EMPTY. Its raw bytes:
      e2 9d af c2 a0 
     (e2 9d af = U+276F '\xe2\x9d\xaf' ; c2 a0 = U+00A0 NO-BREAK SPACE)
-- what fm_backend_composer_state reads off that live pane:
     empty
-- running the real inject_msg() away-mode escalation guard:
     inject_msg -> ACCEPTED (escalation would be delivered to the captain)
-- daemon log:

== AFTER THE FIX - SAFETY HALF: real unsubmitted text still blocks injection ==
-- claude version: 2.1.226 (Claude Code)
-- pane with our typed marker still in the composer (the 'human is half-way through' case):
     ❯ zqxfmguarddemo
-- marker deliberately LEFT in the composer (unsubmitted human text). Its raw bytes:
      e2 9d af c2 a0 7a 71 78 66 6d 67 75 61 72 64 64 65 6d 6f 
     (e2 9d af = U+276F '\xe2\x9d\xaf' ; c2 a0 = U+00A0 NO-BREAK SPACE)
-- what fm_backend_composer_state reads off that live pane:
     pending
-- running the real inject_msg() away-mode escalation guard:
     inject_msg -> DEFERRED (escalation withheld)
-- daemon log:
     [2026-08-09T06:41:09+0000] inject deferred: supervisor composer not confirmed-empty (state=pending: pending input, dead-shell prompt, or unreadable pane)
```
</details>
<details>
<summary>Evidence: Live harness drift guard on the fix (real claude 2.1.226, tmux 3.5a)</summary>

<code># claude 2.1.226 (Claude Code): startup row bytes 20 e2 9d af 20 31 2e 20 59 65 73 2c 20 49 20 74 72 75 73 74 20 74 68 69 73 20 66 6f 6c 64 65 72&#10;# claude 2.1.226 (Claude Code): typed input was not rendered back; accepting a startup confirmation with Enter and retrying&#10;# claude 2.1.226 (Claude Code): composer reached through the bare-row path&#10;# claude 2.1.226 (Claude Code): EMPTY composer row bytes e2 9d af c2 a0&#10;ok - composer drift: claude 2.1.226 (Claude Code) reads pending with real typed text and empty once cleared (via the bare-row path)&#10;# not installed on this machine: codex opencode pi pi-signed grok kimi muse&#10;# checked 1 installed harness(es) end to end&#10;# structural paths exercised: bare-row&#10;# no installed harness drew a BORDERED composer box, so the bordered structural path is unverified by this run (tests/fm-composer-ghost.test.sh pins it portably)</code>

```text
# claude 2.1.226 (Claude Code): startup row bytes  20 e2 9d af 20 31 2e 20 59 65 73 2c 20 49 20 74 72 75 73 74 20 74 68 69 73 20 66 6f 6c 64 65 72 
# claude 2.1.226 (Claude Code): typed input was not rendered back; accepting a startup confirmation with Enter and retrying
# claude 2.1.226 (Claude Code): composer reached through the bare-row path
# claude 2.1.226 (Claude Code): EMPTY composer row bytes  e2 9d af c2 a0 
ok - composer drift: claude 2.1.226 (Claude Code) reads pending with real typed text and empty once cleared (via the bare-row path)
# skip: codex is not installed on this machine, so its composer rendering is unverified here
# skip: opencode is not installed on this machine, so its composer rendering is unverified here
# skip: pi is not installed on this machine, so its composer rendering is unverified here
# skip: pi-signed is not installed on this machine, so its composer rendering is unverified here
# skip: grok is not installed on this machine, so its composer rendering is unverified here
# skip: kimi is not installed on this machine, so its composer rendering is unverified here
# skip: muse is not installed on this machine, so its composer rendering is unverified here
# not installed on this machine: codex opencode pi pi-signed grok kimi muse
# checked 1 installed harness(es) end to end
# structural paths exercised: bare-row
# no installed harness drew a BORDERED composer box, so the bordered structural path is unverified by this run (tests/fm-composer-ghost.test.sh pins it portably)
```
</details>
<details>
<summary>Evidence: Same live guard against base-commit sources — fails by name and version</summary>

`not ok - COMPOSER DRIFT: claude 2.1.226 (Claude Code) has a composer this guard just emptied - the typed marker is gone from the rendered pane - yet it classifies 'pending' instead of 'empty', reached through the bare-row path. ... Decoded composer row: e2 9d af c2 a0 (U+00A0 NO-BREAK SPACE is the byte pair c2 a0 ...)`

```text
# claude 2.1.226 (Claude Code): startup row bytes  20 e2 9d af 20 31 2e 20 59 65 73 2c 20 49 20 74 72 75 73 74 20 74 68 69 73 20 66 6f 6c 64 65 72 
# claude 2.1.226 (Claude Code): typed input was not rendered back; accepting a startup confirmation with Enter and retrying
# claude 2.1.226 (Claude Code): composer reached through the bare-row path
not ok - COMPOSER DRIFT: claude 2.1.226 (Claude Code) has a composer this guard just emptied - the typed marker is gone from the rendered pane - yet it classifies 'pending' instead of 'empty', reached through the bare-row path. Every caller that must not overwrite unsubmitted input now refuses to act against this harness: away-mode escalations stop being delivered and steer confirmations report landed messages as unconfirmed. On the bare-row path a 'pending' verdict means the separator or prompt glyph this release renders is not one bin/fm-composer-lib.sh recognises (bare-row drift usually reads 'pending'; a bordered box whose blanked geometry no longer matches its border reads 'unknown'). Decoded composer row:  e2 9d af c2 a0  (U+00A0 NO-BREAK SPACE is the byte pair c2 a0; fm_composer_normalize_trim_var maps every Unicode White_Space=Yes code point, so a byte run outside that property is the thing to add).
```
</details>
<details>
<summary>Evidence: Harness script used for the live away-mode guard demo (evidence-only, outside the worktree)</summary>

```text
#!/usr/bin/env bash
# Product-level demo: drive bin/fm-supervise-daemon.sh's real away-mode
# escalation guard (inject_msg) against a REAL, live, affirmatively-empty
# claude composer in a private tmux server, and show the daemon log line the
# captain would actually read.
#
# The only thing stubbed is the final send (fm_backend_send_text_submit), so no
# text is ever typed into or submitted to the real harness and no model tokens
# are consumed. Everything before it - pane-exists, busy-guard, composer-guard -
# is the real product code reading the real pane.
#
# usage: daemon-guard-demo.sh <tree-root> <label>
set -u
ROOT=$1
LABEL=$2

REAL_TMUX=$(command -v tmux)
SOCKET="fm-guard-demo-$$"
LAB=$(mktemp -d "${TMPDIR:-/tmp}/fm-guard-demo.XXXXXX")
SESSION=demo
cleanup() { "$REAL_TMUX" -L "$SOCKET" kill-server >/dev/null 2>&1 || true; rm -rf "$LAB"; }
trap cleanup EXIT

mkdir -p "$LAB/shim" "$LAB/wt" "$LAB/state"
cat > "$LAB/shim/tmux" <<SH
#!/usr/bin/env bash
exec "$REAL_TMUX" -L "$SOCKET" "\$@"
SH
chmod +x "$LAB/shim/tmux"
PATH="$LAB/shim:$PATH"; export PATH

MARKER=zqxfmguarddemo
TARGET="$SESSION:claude"

"$REAL_TMUX" -L "$SOCKET" new-session -d -s "$SESSION" -n control -c "$LAB/wt"
"$REAL_TMUX" -L "$SOCKET" new-window -d -t "$SESSION:" -n claude -c "$LAB/wt" -- "$(command -v claude)"
sleep 6

pane_has() { "$REAL_TMUX" -L "$SOCKET" capture-pane -p -t "$TARGET" 2>/dev/null | LC_ALL=C grep -qa "$MARKER"; }

# Prove the pane is really at a composer by typing our OWN marker and seeing the
# harness render it back; a startup trust dialog never takes it.
at_composer=0
for _ in 1 2 3; do
  "$REAL_TMUX" -L "$SOCKET" send-keys -l -t "$TARGET" "$MARKER"
  for _ in $(seq 1 20); do pane_has && { at_composer=1; break; }; sleep 0.5; done
  [ "$at_composer" = 1 ] && break
  "$REAL_TMUX" -L "$SOCKET" send-keys -t "$TARGET" C-u >/dev/null 2>&1 || true
  "$REAL_TMUX" -L "$SOCKET" send-keys -t "$TARGET" Enter >/dev/null 2>&1 || true
  sleep 4
done
[ "$at_composer" = 1 ] || { echo "ABORT: never reached a real claude composer"; exit 2; }

echo "== $LABEL =="
echo "-- claude version: $(claude --version 2>/dev/null | head -1)"
echo "-- pane with our typed marker still in the composer (the 'human is half-way through' case):"
"$REAL_TMUX" -L "$SOCKET" capture-pane -p -t "$TARGET" | grep -a "$MARKER" | tail -1 | sed 's/^/     /'

# Clear it, and confirm it is GONE from the rendered pane: the composer is now
# affirmatively empty, because we just emptied it. With CLEAR=0 the marker is
# deliberately LEFT in place, standing in for a captain's half-written message:
# the guard must still refuse, or firstmate would type over it.
if [ "${CLEAR:-1}" = 1 ]; then
  "$REAL_TMUX" -L "$SOCKET" send-keys -t "$TARGET" C-u >/dev/null 2>&1 || true
  cleared=0
  for _ in $(seq 1 40); do pane_has || { cleared=1; break; }; sleep 0.5; done
  [ "$cleared" = 1 ] || { echo "ABORT: composer did not clear"; exit 2; }
  sleep 2
  echo "-- marker cleared; the composer is now affirmatively EMPTY. Its raw bytes:"
else
  pane_has || { echo "ABORT: the marker vanished on its own"; exit 2; }
  echo "-- marker deliberately LEFT in the composer (unsubmitted human text). Its raw bytes:"
fi

row=$("$REAL_TMUX" -L "$SOCKET" capture-pane -p -t "$TARGET" | grep -a "$(printf '\xe2\x9d\xaf')" | tail -1)
printf '%s' "$row" | LC_ALL=C od -An -tx1 | tr -s ' \n' ' ' | sed 's/^/     /'
echo ""
echo "     (e2 9d af = U+276F '\xe2\x9d\xaf' ; c2 a0 = U+00A0 NO-BREAK SPACE)"

# Now the real daemon guard.
# shellcheck source=/dev/null
. "$ROOT/bin/fm-supervise-daemon.sh"
LOG="$LAB/daemon.log"; : > "$LOG"
FM_STATE_OVERRIDE="$LAB/state"; export FM_STATE_OVERRIDE
afk_enter "$LAB/state"
FM_SUPERVISOR_BACKEND=tmux
FM_SUPERVISOR_TARGET="$TARGET"
# Stub ONLY the final send so the demo never types into or submits to the real
# harness. Reaching this stub at all means every guard ahead of it passed.
fm_backend_send_text_submit() { echo "STUBBED-SEND" >&2; printf 'empty'; }

echo "-- what fm_backend_composer_state reads off that live pane:"
echo "     $(fm_backend_composer_state tmux "$TARGET")"
echo "-- running the real inject_msg() away-mode escalation guard:"
if inject_msg "two finished pieces of work are unshipped, come look" 2>/dev/null; then
  echo "     inject_msg -> ACCEPTED (escalation would be delivered to the captain)"
else
  echo "     inject_msg -> DEFERRED (escalation withheld)"
fi
echo "-- daemon log:"
sed 's/^/     /' "$LOG"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-tmux-lib.sh:190` - Intent conformance: the criteria state &#34;The shared normalizing trim is applied in all four adapters (tmux, herdr, orca, cmux) so a non-ASCII space cannot defeat one adapter&#39;s structural row scan while another&#39;s still matches.&#34; For tmux that is not the case. The trim was applied to fm_tmux_composer_row_state (lines 132/134/141), but tmux&#39;s structural row scan - which bin/fm-composer-lib.sh&#39;s own header names as &#34;tmux&#39;s visible-pane box scan&#34; - still uses the raw ASCII-only trim at fm-tmux-lib.sh:190-192, and fm_tmux_composer_geometry_spaces:166/172-175 still tests the leftover bytes with [![:space:]]. Verified read-only against the changed code: fm_tmux_find_composer_box 1 with pane rows &#39;╭────────╮&#39; / &#39;│ ❯&lt;U+00A0&gt;     │&#39; / &#39;╰────────╯&#39; returns &#34;0 2 1&#34; (geometry_ambiguous=1), while the identical pane with an ASCII space returns &#34;0 2 0&#34;. fm_tmux_composer_state:342 converts that flag into &#39;unknown&#39; even though fm_tmux_composer_row_state classifies the row &#39;empty&#39; - so a bordered tmux composer separated with U+00A0 still never reads confirmed-empty, and every caller that must not overwrite unsubmitted input still refuses to act. That is the exact authorized failure this change fixes, surviving on the sibling path in the same file. herdr&#39;s ANSI tail scan and orca/cmux&#39;s read-screen scans were normalized, so tmux is precisely the &#34;one adapter defeated while another matches&#34; case the criterion says cannot happen. Earliest supported shared boundary: run each captured line through fm_composer_normalize_trim inside fm_tmux_find_composer_box&#39;s loop (and in fm_tmux_composer_geometry_spaces&#39; probe) instead of the open-coded ${line#&#34;${line%%[![:space:]]*}&#34;} pair. Not proven live-reachable for claude today (its tmux composer is a bare glyph row, not a box), which is why this is a warning rather than an error - but it contradicts a stated deliberate coverage claim, so it is the author&#39;s call whether to close it here or as a follow-up.
- ℹ️ `bin/fm-composer-lib.sh:140` - _fm_composer_normalize_space_var is documented as replacing in place &#34;so the wrapper below adds no subshell&#34;, but fm_composer_normalize_trim prints to stdout and all 12 call sites consume it via command substitution, so every call forks anyway - plus one heredoc temp file per call for the 19-entry mapping loop. The row loops are the cost: bin/backends/orca.sh:276 runs this once per captured line with FM_BACKEND_ORCA_COMPOSER_LINES defaulting to 200, where the previous code was pure parameter expansion with zero forks. Measured on this worktree: 200 command substitutions of fm_composer_normalize_trim take ~72ms versus ~1ms for the parameter-expansion form, per composer read, and composer_state is polled by bin/fm-supervise-daemon.sh and re-read inside the send-submit retry loops. Absolute cost is small, so this is informational: exposing the existing in-place form as a public fm_composer_normalize_trim_var &lt;varname&gt; and using it in the orca/cmux/herdr row loops would deliver the design the comment already describes.
- ℹ️ `bin/fm-tmux-lib.sh:169` - The change&#39;s stated deliberate decision is that the prompt glyphs &#34;are now declared exactly once each and reached through helpers&#34;, and FM_COMPOSER_AGENT_PROMPT_GLYPHS does that for the classifier. fm_tmux_composer_geometry_spaces is a fourth place that still spells them out inline (&#39;&gt;&#39; , &#39;❯&#39;, &#39;›&#39;) and is already drifted: it omits &#39;⟩&#39; (muse, U+27E9), which the classifier does recognise. Consequence on the bordered tmux path: a muse composer&#39;s content row keeps its multibyte glyph, sed &#39;s/[!-~]/ /g&#39; cannot flatten it, the *[![:space:]]* test at line 174 fires, geometry_spaces returns 1, and fm_tmux_find_composer_box sets geometry_ambiguous=1 - so an otherwise-empty muse box reads &#39;unknown&#39; rather than &#39;empty&#39;. Pre-existing rather than introduced here, and it is the same drift hazard the header comment was rewritten to eliminate; reaching FM_COMPOSER_AGENT_PROMPT_GLYPHS from this helper would close it.
- ℹ️ `bin/backends/herdr.sh:2708` - fm_backend_herdr_pi_separator_row still uses the open-coded ASCII-only trim and then requires the remainder be nothing but &#39;─&#39; ([ -z &#34;${row//─/}&#34; ]). A Pi rule padded or terminated with any non-ASCII space fails that test, so no complete separator pair is found, fm_backend_herdr_composer_state&#39;s &#39;separated&#39; shape is never established, and the verdict degrades to &#39;unknown&#39; - the same refuse-to-act outcome, reached through the structural half of the herdr adapter that the row loop at line 2782 normalized but this helper did not. No evidence any Pi release pads its rules that way today, so this is informational; routing this trim through fm_composer_normalize_trim like its sibling would make the herdr adapter internally consistent.

🔧 Fix: normalize Unicode spaces and glyphs in tmux/herdr structural scans
3 infos still open:
- ℹ️ `bin/fm-composer-lib.sh:31` - The fix round added a header claim that is not accurate: &#34;An ADAPTER that needs to recognise a prompt glyph in its own structural scan - tmux&#39;s box-geometry probe is the one such caller - reaches the same declarations ... rather than becoming a fourth copy&#34; (bin/fm-composer-lib.sh:30-35). herdr&#39;s adapter has a second such scan: FM_BACKEND_HERDR_BARE_PROMPT_RE at bin/backends/herdr.sh:2700 is &#39;^(❯|›)&#39;, spelling out two of the three agent glyphs inline and omitting muse&#39;s &#39;⟩&#39;. It is the sole gate for the `bare` shape in fm_backend_herdr_composer_state (herdr.sh:2793-2799): a row that is neither &#39;│&#39;*&#39;│&#39; nor matched by that regex leaves found=0 and the verdict is `unknown`. So this is a second declaration of ❯ and ›, which also contradicts the accepted intent&#39;s deliberate decision that the glyphs &#34;are now declared exactly once each and reached through helpers&#34;. I could NOT establish that the failure is live-reachable, and I am reporting that honestly rather than asserting it: the repo&#39;s two records disagree on muse&#39;s composer shape. .agents/skills/harness-adapters/SKILL.md:419 says &#34;Bordered box whose prompt glyph is `⟩`&#34;, in which case herdr&#39;s &#39;│&#39;*&#39;│&#39; case matches first and this regex never matters; docs/verification/muse.md:150-151 shows the actual `tmux capture-pane -p -e` rows as a border-free `⟩ ` line, in which case an empty muse composer on herdr never establishes a shape and reads `unknown` while the same pane on tmux reads `empty`. The code is pre-existing and unchanged by this diff (its alternation form has a documented locale rationale at herdr.sh:2691-2699, so it cannot simply become a bracket class), and it was not in the round-1 findings or the fix instructions. Author&#39;s call: either reach FM_COMPOSER_AGENT_PROMPT_GLYPHS when building that regex and reconcile the two muse records, or narrow the new header claim so it does not assert a uniqueness the tree does not have.
- ℹ️ `bin/fm-composer-lib.sh:169` - fm_composer_normalize_trim (the value-returning form) has zero callers after the fix round converted all twelve call sites to fm_composer_normalize_trim_var - I grepped every *.sh and *.md in the tree and the only hits are its own definition and the doc line in docs/verification/runtime-backends.md:184, which names the _var form. It is a public, untested function in a shared library, so nothing would catch it drifting from the _var form it wraps. Either drop it, or keep it and note it is currently unused; the comment at :165-168 already explains it is deliberately not the default, so a reader has no way to tell &#34;reserved for future callers&#34; from &#34;leftover&#34;.
- ℹ️ `bin/fm-composer-lib.sh:403` - fm_composer_classify_content still does `content=$(_fm_composer_strip_leading_prompt &#34;$content&#34;)`, a command substitution, immediately after the same file&#39;s comment at :165-168 argues the value-returning form is not the default precisely because &#34;consuming it costs a subshell per call&#34;. _fm_composer_strip_leading_prompt is now a thin wrapper over fm_composer_leading_prompt_glyph_var, so the fork is removable in place with no new mapping and no behavior change: `if fm_composer_leading_prompt_glyph_var glyph &#34;$content&#34;; then content=${content#*&#34;$glyph&#34;}; fi`. Cost is small and bounded - the early returns above mean this line is only reached for rows that carry real content, and a tmux content row already forks three times (strip_ansi, strip_ghost, and the per-row `sed -n Np` in fm_tmux_composer_state:338) - so this is efficiency tidying, not a regression. Verified equivalence of the substitution while reviewing: fm_composer_leading_prompt_glyph_var only matches a glyph at the first non-whitespace position and classify_content trims before this line, so `#*&#34;$glyph&#34;` can never strip past the intended glyph.

🔧 Fix: drop dead trim wrapper, inline glyph strip, correct header claim
1 info still open:
- ℹ️ `tests/fm-composer-lib.test.sh:163` - test_unicode_whitespace_property_set_is_covered independently spells out 11 separators (&#39;\302\205&#39; 00A0 1680 2000 2007 200A 2028 2029 202F 205F 3000) but the implementation&#39;s FM_COMPOSER_UNICODE_SPACES holds 19. The eight unpinned entries are U+2001-U+2006, U+2008 and U+2009 - the interior of the one contiguous run in the table, and the run most exposed to a single-digit slip because the table is hand-transcribed octal (&#39;\0342\0200\0201&#39; .. &#39;\0342\0200\0212&#39; at bin/fm-composer-lib.sh:141-143). I decoded all 19 entries at runtime and they are byte-correct today, so this is a coverage gap and not a live defect; the point is that a future edit dropping or mistyping U+2003 would not fail anything, because the only other test that touches the set (test_every_declared_prompt_glyph_is_blankable_and_classified) iterates the glyph declarations, not the space table, and iterating the table against itself would pass with a wrong byte sequence in it. The intent states the portable regression &#39;pins the whole White_Space property set&#39;; extending the existing literal loop to all 19 escapes (the assertions already in the test body need no change) is what makes that true. Independent literal spelling is the right shape here - do not replace it with a loop over FM_COMPOSER_UNICODE_SPACES, which would be self-referential.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`FM_COMPOSER_HARNESS_DRIFT=1 bash tests/fm-composer-harness-drift-live-e2e.test.sh` — live guard, real claude 2.1.226 on tmux 3.5a: passes (empty row `e2 9d af c2 a0`, bare-row path); same guard against base-commit sources fails with a named COMPOSER DRIFT error</code>
- <code>Manual end-to-end: drove the real `inject_msg()` away-mode escalation guard in `bin/fm-supervise-daemon.sh` against a live claude composer emptied by the harness itself (marker typed, rendered back, cleared with C-u, confirmed gone), with only `fm_backend_send_text_submit` stubbed so no text was submitted and no model tokens spent — reproduced the reported `inject deferred: supervisor composer not confirmed-empty (state=pending...)` on reverted sources and ACCEPTED on the fix</code>
- <code>Manual end-to-end safety half: same live pane with real unsubmitted text left in the composer — `fm_backend_composer_state` reads `pending` and `inject_msg` still DEFERS</code>
- <code>`LC_ALL=C bash tests/fm-composer-lib.test.sh` (13 ok; White_Space property set, U+200B stays `pending`, locale independence across C/C.utf8/en_US.utf8, dead-shell refusal, all 7 declared glyphs blankable)</code>
- <code>`LC_ALL=C bash tests/fm-composer-ghost.test.sh` (bordered + unbordered tmux paths, muse `⟩`, ambiguous geometry still `unknown`)</code>
- <code>`LC_ALL=C bash tests/fm-backend-herdr.test.sh` (new `❯`+U+00A0 empty/pending cases and U+00A0-padded Pi separator cases)</code>
- <code>Revert proof: ran `tests/fm-composer-lib.test.sh` and `tests/fm-composer-ghost.test.sh` against a tree with `bin/fm-composer-lib.sh`, `bin/fm-tmux-lib.sh` and the three adapters restored to 2d2be63 — both fail (`got &#39;pending&#39;`) in `C` and `C.UTF-8`</code>
- <code>`LC_ALL=C bash tests/fm-backend-orca.test.sh`, `tests/fm-backend-cmux.test.sh`, `tests/fm-backend.test.sh`, `tests/fm-test-run.test.sh` — all pass</code>
- <code>`LC_ALL=C bash bin/fm-test-run.sh --changed --base 2d2be63 --list` — selects 71 scripts and includes `tests/fm-composer-harness-drift-live-e2e.test.sh`, confirming the changed-file map wiring</code>
- <code>`LC_ALL=C bash tests/fm-afk-inject-herdr-e2e.test.sh` on this tree and on a clean 2d2be63 checkout — fails identically on both (pre-existing); passes on this tree in the default UTF-8 locale</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `.agents/skills/harness-adapters/SKILL.md:419` - Two doc surfaces still contradict each other on muse&#39;s composer shape, and I could not resolve it here because muse is not installed on this machine. `.agents/skills/harness-adapters/SKILL.md:419` records muse&#39;s composer as a &#34;Bordered box whose prompt glyph is `⟩` (U+27E9)&#34;, while `docs/verification/muse.md:150-151` shows a captured row with no box-drawing border - just `⟩` plus an ASCII space with a background fill. Which one is true decides whether herdr&#39;s `FM_BACKEND_HERDR_BARE_PROMPT_RE` (which spells out `❯` and `›` and omits `⟩`) is reachable at all: if muse draws a bare row, an empty muse composer reads `unknown` on herdr while the same pane reads `empty` on tmux. This change&#39;s new comment in `bin/fm-composer-lib.sh` names the contradiction and defers the permissive regex fix to its own task; the doc side needs one live muse capture to settle which surface is stale, then a correction in the wrong one. Follow-up, not fixable in this change.

🔧 Fix: cross-reference muse composer shape contradiction on both surfaces
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
