### PR TITLE
fix(spawn): force regular Pi TUI for crews

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -276,6 +276,7 @@ The follow-up was verified in the interactive TUI; `opencode run` can exit befor
 | Interrupt | single Escape |
 
 Pi has no permission system, so crewmates are always autonomous.
+Pi's `packages/coding-agent/docs/settings.md` UI and display section documents `regular` as the `tuiMode` default, `fullscreen` as experimental, and `--tui-mode` as its startup override; fullscreen can bury steers by rewriting scrollback, so `fm-spawn` always passes `--tui-mode regular` for Pi-family crews.
 `pi-signed` is the signed wrapper identity verified on version 0.82.0 and exposes the same CLI and TUI behavior as Pi.
 Firstmate launches the selected executable name from `PATH`, records `pi-signed` without normalization, and refuses rather than falling back to `pi` when that wrapper is unavailable.
 The observed signed process tree is an exact `pi-signed` wrapper parent with the Pi application as its child, while tmux reports the foreground command as the exact `pi-launcher` name for both selected executables.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1071,9 +1071,9 @@ launch_template() {
     opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     pi|pi-signed)
       if [ "$kind" = secondmate ]; then
-        printf '%s%s' "$harness" ' __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s%s' "$harness" ' --tui-mode regular __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       else
-        printf '%s%s' "$harness" ' __MODELFLAG____EFFORTFLAG__-e __PIEXT__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s%s' "$harness" ' --tui-mode regular __MODELFLAG____EFFORTFLAG__-e __PIEXT__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       fi
       ;;
     # grok (Grok Build TUI): a positional prompt starts the supervised interactive

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -213,6 +213,7 @@ New harnesses get verified through a supervised trial task before joining the se
 The verified adapter evidence - each harness's busy-state source, interrupt and exit behavior, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 The executable interrupt and exit mechanics live in [`bin/fm-control-lib.sh`](../bin/fm-control-lib.sh), and [`docs/agent-control.md`](agent-control.md) owns their lifecycle-control architecture.
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
+Pi and pi-signed crew launches explicitly pass `--tui-mode regular` so fullscreen mode cannot rewrite scrollback and bury steers.
 Enabled primary-session turn-end guard integrations are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).
 Kimi remains outside the primary turn-end guard integrations; [`docs/turnend-guard.md`](turnend-guard.md#compatibility-limits) owns its separate captain-approved crew wake hook.
 Primary-session watcher wake protocols are rendered at session start by [`bin/fm-supervision-instructions.sh`](../bin/fm-supervision-instructions.sh) from [`docs/supervision-protocols/`](supervision-protocols/).

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -379,6 +379,7 @@ test_claude_threads_model_and_effort() {
   launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "claude --dangerously-skip-permissions --model 'sonnet' --effort 'high'" \
     "claude launch did not thread model and effort flags"
+  assert_not_contains "$launch" "--tui-mode" "non-Pi launches must not receive Pi's TUI mode override"
   pass "claude receives --model and --effort profile flags"
 }
 
@@ -500,8 +501,8 @@ test_pi_threads_model_and_max_effort() {
   expect_code 0 "$status" "pi spawn with max effort should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" pi openai-codex/gpt-5.6-sol max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "FM_PI_HARNESS=pi pi --model 'openai-codex/gpt-5.6-sol' --thinking 'max' -e" \
-    "pi launch did not thread the requested model and max thinking level"
+  assert_contains "$launch" "FM_PI_HARNESS=pi pi --tui-mode regular --model 'openai-codex/gpt-5.6-sol' --thinking 'max' -e" \
+    "pi launch did not force the regular TUI while threading the requested model and max thinking level"
   assert_not_contains "$launch" "FM_FIRSTMATE_PI_LAUNCH_BRIEF=" \
     "pi launch still exports the removed Calm input-reroute binding"
   assert_contains "$launch" "fm-operational-input.sh' encode launch-brief" \
@@ -522,8 +523,8 @@ test_pi_signed_threads_shared_pi_profile_and_preserves_identity() {
   assert_contains "$out" "spawned $id harness=pi-signed" "pi-signed spawn did not preserve its visible identity"
   assert_meta_profile "$HOME_DIR/state/$id.meta" pi-signed openai-codex/gpt-5.6-sol max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "FM_PI_HARNESS=pi-signed pi-signed --model 'openai-codex/gpt-5.6-sol' --thinking 'max' -e" \
-    "pi-signed launch did not share Pi's model, thinking, and extension semantics"
+  assert_contains "$launch" "FM_PI_HARNESS=pi-signed pi-signed --tui-mode regular --model 'openai-codex/gpt-5.6-sol' --thinking 'max' -e" \
+    "pi-signed launch did not force the regular TUI with Pi's model, thinking, and extension semantics"
   assert_contains "$launch" "fm-operational-input.sh' encode launch-brief" \
     "pi-signed launch lost the canonical typed launch-brief envelope"
   assert_present "$HOME_DIR/state/$id.pi-ext.ts" "pi-signed launch did not install Pi's turn-end extension"
@@ -582,8 +583,8 @@ test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity() {
     "pi-signed secondmate spawn did not preserve its runtime identity"
   assert_meta_profile "$HOME_DIR/state/$id.meta" pi-signed default default
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "FM_PI_HARNESS=pi-signed pi-signed -e '$sm/.pi/extensions/fm-primary-turnend-guard.ts' -e '$sm/.pi/extensions/fm-primary-pi-watch.ts'" \
-    "pi-signed secondmate did not share Pi's primary extension launch shape"
+  assert_contains "$launch" "FM_PI_HARNESS=pi-signed pi-signed --tui-mode regular -e '$sm/.pi/extensions/fm-primary-turnend-guard.ts' -e '$sm/.pi/extensions/fm-primary-pi-watch.ts'" \
+    "pi-signed secondmate did not force the regular TUI with Pi's primary extension launch shape"
   pass "pi-signed is a distinct persistent secondmate runtime with shared Pi supervision semantics"
 }
 


### PR DESCRIPTION
## What Changed

- Force Pi and pi-signed crew launches to use `--tui-mode regular`.
- Document the regular TUI requirement and update dispatch-profile tests to verify it.

## Risk Assessment

✅ Low: The change is narrowly scoped to verified Pi-family launch templates and preserves existing model, effort, extension, and supervision arguments.

## Testing

The focused spawn suite passed, covering pi, pi-signed, and pi-signed secondmate launch paths. Pi 0.84.1 supports `--tui-mode regular`; launch transcripts were captured as evidence.

<details>
<summary>Evidence: Pi launch transcript</summary>

```text
+ launch='FM_PI_HARNESS=pi pi --tui-mode regular -e '\''/private/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T/fm-spawn-dispatch-profile.ewv0PT/profile-relative-paths/home/state/profile-relative-paths-z1b.pi-ext.ts'\'' "$('\''/Users/rblom/.no-mistakes/worktrees/da21ab8c5308/01KZJXMDP160VXBNVVSVD100QY/bin/fm-operational-input.sh'\'' encode launch-brief < '\''/private/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T/fm-spawn-dispatch-profile.ewv0PT/profile-relative-paths/home/data/profile-relative-paths-z1b/brief.md'\'')"'
+ assert_contains 'FM_PI_HARNESS=pi pi --tui-mode regular -e '\''/private/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T/fm-spawn-dispatch-profile.ewv0PT/profile-relative-paths/home/state/profile-relative-paths-z1b.pi-ext.ts'\'' "$('\''/Users/rblom/.no-mistakes/worktrees/da21ab8c5308/01KZJXMDP160VXBNVVSVD100QY/bin/fm-operational-input.sh'\'' encode launch-brief < '\''/private/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T/fm-spawn-dispatch-profile.ewv0PT/profile-relative-paths/home/data/profile-relative-paths-z1b/brief.md'\'')"' '-e '\''/private/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T/fm-spawn-dispatch-profile.ewv0PT/profile-relative-paths/home/state/profile-relative-paths-z1b.pi-ext.ts'\''' 'relative FM_STATE_OVERRIDE leaked into Pi'\''s cross-process extension path'
+ assert_contains 'FM_PI_HARNESS=pi pi --tui-mode regular -e '\''/private/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T/fm-spawn-dispatch-profile.ewv0PT/profile-relative-paths/home/state/profile-relative-paths-z1b.pi-ext.ts'\'' "$('\''/Users/rblom/.no-mistakes/worktrees/da21ab8c5308/01KZJXMDP160VXBNVVSVD100QY/bin/fm-operational-input.sh'\'' encode launch-brief < '\''/private/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T/fm-spawn-dispatch-profile.ewv0PT/profile-relative-paths/home/data/profile-relative-paths-z1b/brief.md'\'')"' '< '\''/private/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T/fm-spawn-dispatch-profile.ewv0PT/profile-relative-paths/home/data/profile-relative-paths-z1b/brief.md'\''' 'relative FM_DATA_OVERRIDE leaked into the cross-process brief path'
+ launch='FM_PI_HARNESS=pi pi --tui-mode regular -e '\''/private/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T/fm-spawn-dispatch-profile.ewv0PT/profile-home-defaults/home/state/profile-relative-home-defaults-z1c.pi-ext.ts'\'' "$('\''/Users/rblom/.no-mistakes/worktrees/da21ab8c5308/01KZJXMDP160VXBNVVSVD100QY/bin/fm-operational-input.sh'\'' encode launch-brief < '\''/private/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T/fm-spawn-dispatch-profile.ewv0PT/profile-home-defaults/home/data/profile-relative-home-defaults-z1c/brief.md'\'')"'
+ assert_contains 'FM_PI_HARNESS=pi pi --tui-mode regular -e '\''/private/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T/fm-spawn-dispatch-profile.ewv0PT/profile-home-defaults/home/state/profile-relative-home-defaults-z1c.pi-ext.ts'\'' "$('\''/Users/rblom/.no-mistakes/worktrees/da21ab8c5308/01KZJXMDP160VXBNVVSVD100QY/bin/fm-operational-input.sh'\'' encode launch-brief < '\''/private/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T/fm-spawn-dispatch-profile.ewv0PT/profile-home-defaults/home/data/profile-relative-home-defaults-z1c/brief.md'\'')"' '-e '\''/private/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T/fm-spawn-dispatch-profile.ewv0PT/profile-home-defaults/home/state/profile-relative-home-defaults-z1c.pi-ext.ts'\''' 'relative FM_HOME leaked into Pi'\''s default cross-process extension path'
+ assert_contains 'FM_PI_HARNESS=pi pi --tui-mode regular -e '\''/private/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T/fm-spawn-dispatch-profile.ewv0PT/profile-home-defaults/home/state/profile-relative-home-defaults-z1c.pi-ext.ts'\'' "$('\''/Users/rblom/.no-mistakes/worktrees/da21ab8c5308/01KZJXMDP160VXBNVVSVD100QY/bin/fm-operational-input.sh'\'' encode launch-brief < '\''/private/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T/fm-spawn-dispatch-profile.ewv0PT/profile-home-defaults/home/data/profile-relative-home-defaults-z1c/brief.md'\'')"' '< '\''/private/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T/fm-spawn-dispatch-profile.ewv0PT/profile-home-defaults/home/data/profile-relative-home-defaults-z1c/brief.md'\''' 'relative FM_HOME leaked into the default cross-process brief path'
+ launch='FM_PI_HARNESS=pi pi --tui-mode regular -e '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-home-defaults/home-link/state/profile-absolute-home-defaults-z1d.pi-ext.ts'\'' "$('\''/Users/rblom/.no-mistakes/worktrees/da21ab8c5308/01KZJXMDP160VXBNVVSVD100QY/bin/fm-operational-input.sh'\'' encode launch-brief < '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-home-defaults/home-link/data/profile-absolute-home-defaults-z1d/brief.md'\'')"'
+ assert_contains 'FM_PI_HARNESS=pi pi --tui-mode regular -e '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-home-defaults/home-link/state/profile-absolute-home-defaults-z1d.pi-ext.ts'\'' "$('\''/Users/rblom/.no-mistakes/worktrees/da21ab8c5308/01KZJXMDP160VXBNVVSVD100QY/bin/fm-operational-input.sh'\'' encode launch-brief < '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-home-defaults/home-link/data/profile-absolute-home-defaults-z1d/brief.md'\'')"' '-e '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-home-defaults/home-link/state/profile-absolute-home-defaults-z1d.pi-ext.ts'\''' 'absolute FM_HOME spelling changed in Pi'\''s default cross-process extension path'
+ assert_contains 'FM_PI_HARNESS=pi pi --tui-mode regular -e '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-home-defaults/home-link/state/profile-absolute-home-defaults-z1d.pi-ext.ts'\'' "$('\''/Users/rblom/.no-mistakes/worktrees/da21ab8c5308/01KZJXMDP160VXBNVVSVD100QY/bin/fm-operational-input.sh'\'' encode launch-brief < '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-home-defaults/home-link/data/profile-absolute-home-defaults-z1d/brief.md'\'')"' '< '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-home-defaults/home-link/data/profile-absolute-home-defaults-z1d/brief.md'\''' 'absolute FM_HOME spelling changed in the default cross-process brief path'
+ launch='FM_PI_HARNESS=pi pi --tui-mode regular -e '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-absolute-paths/home-link/state/profile-absolute-paths-z1c.pi-ext.ts'\'' "$('\''/Users/rblom/.no-mistakes/worktrees/da21ab8c5308/01KZJXMDP160VXBNVVSVD100QY/bin/fm-operational-input.sh'\'' encode launch-brief < '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-absolute-paths/home-link/data/profile-absolute-paths-z1c/brief.md'\'')"'
+ assert_contains 'FM_PI_HARNESS=pi pi --tui-mode regular -e '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-absolute-paths/home-link/state/profile-absolute-paths-z1c.pi-ext.ts'\'' "$('\''/Users/rblom/.no-mistakes/worktrees/da21ab8c5308/01KZJXMDP160VXBNVVSVD100QY/bin/fm-operational-input.sh'\'' encode launch-brief < '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-absolute-paths/home-link/data/profile-absolute-paths-z1c/brief.md'\'')"' '-e '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-absolute-paths/home-link/state/profile-absolute-paths-z1c.pi-ext.ts'\''' 'absolute FM_STATE_OVERRIDE spelling changed in Pi'\''s cross-process extension path'
+ assert_contains 'FM_PI_HARNESS=pi pi --tui-mode regular -e '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-absolute-paths/home-link/state/profile-absolute-paths-z1c.pi-ext.ts'\'' "$('\''/Users/rblom/.no-mistakes/worktrees/da21ab8c5308/01KZJXMDP160VXBNVVSVD100QY/bin/fm-operational-input.sh'\'' encode launch-brief < '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-absolute-paths/home-link/data/profile-absolute-paths-z1c/brief.md'\'')"' '< '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-absolute-paths/home-link/data/profile-absolute-paths-z1c/brief.md'\''' 'absolute FM_DATA_OVERRIDE spelling changed in the cross-process brief path'
+ launch='FM_PI_HARNESS=pi pi --tui-mode regular --model '\''openai-codex/gpt-5.6-sol'\'' --thinking '\''max'\'' -e '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-pi/home/state/profile-pi-z8.pi-ext.ts'\'' "$('\''/Users/rblom/.no-mistakes/worktrees/da21ab8c5308/01KZJXMDP160VXBNVVSVD100QY/bin/fm-operational-input.sh'\'' encode launch-brief < '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-pi/home/data/profile-pi-z8/brief.md'\'')"'
+ assert_contains 'FM_PI_HARNESS=pi pi --tui-mode regular --model '\''openai-codex/gpt-5.6-sol'\'' --thinking '\''max'\'' -e '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-pi/home/state/profile-pi-z8.pi-ext.ts'\'' "$('\''/Users/rblom/.no-mistakes/worktrees/da21ab8c5308/01KZJXMDP160VXBNVVSVD100QY/bin/fm-operational-input.sh'\'' encode launch-brief < '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-pi/home/data/profile-pi-z8/brief.md'\'')"' 'FM_PI_HARNESS=pi pi --tui-mode regular --model '\''openai-codex/gpt-5.6-sol'\'' --thinking '\''max'\'' -e' 'pi launch did not force the regular TUI while threading the requested model and max thinking level'
+ assert_not_contains 'FM_PI_HARNESS=pi pi --tui-mode regular --model '\''openai-codex/gpt-5.6-sol'\'' --thinking '\''max'\'' -e '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-pi/home/state/profile-pi-z8.pi-ext.ts'\'' "$('\''/Users/rblom/.no-mistakes/worktrees/da21ab8c5308/01KZJXMDP160VXBNVVSVD100QY/bin/fm-operational-input.sh'\'' encode launch-brief < '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-pi/home/data/profile-pi-z8/brief.md'\'')"' FM_FIRSTMATE_PI_LAUNCH_BRIEF= 'pi launch still exports the removed Calm input-reroute binding'
+ assert_contains 'FM_PI_HARNESS=pi pi --tui-mode regular --model '\''openai-codex/gpt-5.6-sol'\'' --thinking '\''max'\'' -e '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-pi/home/state/profile-pi-z8.pi-ext.ts'\'' "$('\''/Users/rblom/.no-mistakes/worktrees/da21ab8c5308/01KZJXMDP160VXBNVVSVD100QY/bin/fm-operational-input.sh'\'' encode launch-brief < '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-pi/home/data/profile-pi-z8/brief.md'\'')"' 'fm-operational-input.sh'\'' encode launch-brief' 'pi launch lost the canonical typed launch-brief envelope'
+ launch='FM_PI_HARNESS=pi-signed pi-signed --tui-mode regular --model '\''openai-codex/gpt-5.6-sol'\'' --thinking '\''max'\'' -e '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-pi-signed/home/state/profile-pi-signed-z8b.pi-ext.ts'\'' "$('\''/Users/rblom/.no-mistakes/worktrees/da21ab8c5308/01KZJXMDP160VXBNVVSVD100QY/bin/fm-operational-input.sh'\'' encode launch-brief < '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-pi-signed/home/data/profile-pi-signed-z8b/brief.md'\'')"'
+ assert_contains 'FM_PI_HARNESS=pi-signed pi-signed --tui-mode regular --model '\''openai-codex/gpt-5.6-sol'\'' --thinking '\''max'\'' -e '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-pi-signed/home/state/profile-pi-signed-z8b.pi-ext.ts'\'' "$('\''/Users/rblom/.no-mistakes/worktrees/da21ab8c5308/01KZJXMDP160VXBNVVSVD100QY/bin/fm-operational-input.sh'\'' encode launch-brief < '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-pi-signed/home/data/profile-pi-signed-z8b/brief.md'\'')"' 'FM_PI_HARNESS=pi-signed pi-signed --tui-mode regular --model '\''openai-codex/gpt-5.6-sol'\'' --thinking '\''max'\'' -e' 'pi-signed launch did not force the regular TUI with Pi'\''s model, thinking, and extension semantics'
+ assert_contains 'FM_PI_HARNESS=pi-signed pi-signed --tui-mode regular --model '\''openai-codex/gpt-5.6-sol'\'' --thinking '\''max'\'' -e '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-pi-signed/home/state/profile-pi-signed-z8b.pi-ext.ts'\'' "$('\''/Users/rblom/.no-mistakes/worktrees/da21ab8c5308/01KZJXMDP160VXBNVVSVD100QY/bin/fm-operational-input.sh'\'' encode launch-brief < '\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-pi-signed/home/data/profile-pi-signed-z8b/brief.md'\'')"' 'fm-operational-input.sh'\'' encode launch-brief' 'pi-signed launch lost the canonical typed launch-brief envelope'
+ launch='FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_PUBLIC_FOLLOWUP_PRIMARY_HOME='\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-pi-signed-secondmate/home'\'' FM_HOME='\''/private/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T/fm-spawn-dispatch-profile.ewv0PT/profile-pi-signed-secondmate/secondmate-home'\'' FM_TRACE_CONTEXT=off FM_SUPERVISION_MODEL=persistent FM_PI_HARNESS=pi-signed pi-signed --tui-mode regular -e '\''/private/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T/fm-spawn-dispatch-profile.ewv0PT/profile-pi-signed-secondmate/secondmate-home/.pi/extensions/fm-primary-turnend-guard.ts'\'' -e '\''/private/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T/fm-spawn-dispatch-profile.ewv0PT/profile-pi-signed-secondmate/secondmate-home/.pi/extensions/fm-primary-pi-watch.ts'\'' "$('\''/Users/rblom/.no-mistakes/worktrees/da21ab8c5308/01KZJXMDP160VXBNVVSVD100QY/bin/fm-operational-input.sh'\'' encode launch-brief < '\''/private/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T/fm-spawn-dispatch-profile.ewv0PT/profile-pi-signed-secondmate/secondmate-home/data/charter.md'\'')"'
+ assert_contains 'FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_PUBLIC_FOLLOWUP_PRIMARY_HOME='\''/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T//fm-spawn-dispatch-profile.ewv0PT/profile-pi-signed-secondmate/home'\'' FM_HOME='\''/private/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T/fm-spawn-dispatch-profile.ewv0PT/profile-pi-signed-secondmate/secondmate-home'\'' FM_TRACE_CONTEXT=off FM_SUPERVISION_MODEL=persistent FM_PI_HARNESS=pi-signed pi-signed --tui-mode regular -e '\''/private/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T/fm-spawn-dispatch-profile.ewv0PT/profile-pi-signed-secondmate/secondmate-home/.pi/extensions/fm-primary-turnend-guard.ts'\'' -e '\''/private/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T/fm-spawn-dispatch-profile.ewv0PT/profile-pi-signed-secondmate/secondmate-home/.pi/extensions/fm-primary-pi-watch.ts'\'' "$('\''/Users/rblom/.no-mistakes/worktrees/da21ab8c5308/01KZJXMDP160VXBNVVSVD100QY/bin/fm-operational-input.sh'\'' encode launch-brief < '\''/private/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T/fm-spawn-dispatch-profile.ewv0PT/profile-pi-signed-secondmate/secondmate-home/data/charter.md'\'')"' 'FM_PI_HARNESS=pi-signed pi-signed --tui-mode regular -e '\''/private/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T/fm-spawn-dispatch-profile.ewv0PT/profile-pi-signed-secondmate/secondmate-home/.pi/extensions/fm-primary-turnend-guard.ts'\'' -e '\''/private/var/folders/jx/qt_gfrgs2tbgs40myz32d6280000gn/T/fm-spawn-dispatch-profile.ewv0PT/profile-pi-signed-secondmate/secondmate-home/.pi/extensions/fm-primary-pi-watch.ts'\''' 'pi-signed secondmate did not force the regular TUI with Pi'\''s primary extension launch shape'
+ echo '# all fm-spawn-dispatch-profile tests passed'
# all fm-spawn-dispatch-profile tests passed
```
</details>
<details>
<summary>Evidence: Focused test output</summary>

```text
ok - no --model/--effort records defaults and types the claude launch instructions
ok - relative home overrides ignore CDPATH and become absolute before spawn launch construction
ok - FM_HOME defaults resolve relative paths and preserve absolute spellings
ok - absolute override spellings are preserved in spawn launch paths
ok - unresolvable relative spawn overrides fail with named diagnostics
ok - active crew-dispatch profile requires an explicit harness for ship spawns
ok - active crew-dispatch profile requires an explicit harness for scout spawns
ok - active crew-dispatch profile allows an explicit resolved harness
ok - active crew-dispatch profile allows the legacy positional harness form
ok - active crew-dispatch profile allows the raw launch-command escape hatch
ok - claude receives --model and --effort profile flags
ok - codex receives --model and model_reasoning_effort profile flags
ok - codex omits unsupported max effort instead of passing a bad config value
ok - grok receives --model and --reasoning-effort profile flags
ok - grok omits unsupported max reasoning effort
ok - grok omits unsupported xhigh reasoning effort
ok - opencode receives --model and omits the unsupported effort axis
ok - pi receives --model and --thinking max profile flags
ok - pi-signed shares Pi launch semantics while preserving its configured and recorded identity
ok - pi-signed refuses safely and actionably when the selected executable is unavailable
ok - pi-signed is a distinct persistent secondmate runtime with shared Pi supervision semantics
ok - batch dispatch forwards shared --harness, --model, and --effort to every pair
ok - claude forwards firstmate's CLAUDE_CONFIG_DIR so the crewmate uses the same credential store
ok - claude omits the config-dir prefix when firstmate runs with the single-store default
ok - non-claude harnesses do not receive the claude CLAUDE_CONFIG_DIR prefix
ok - active crew-dispatch profile does not block secondmate launches
# all fm-spawn-dispatch-profile tests passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-spawn-dispatch-profile.test.sh`
- `pi --version`
- `pi --help | rg -- '--tui-mode|tui-mode|regular'`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
