### PR TITLE
fix(bin): stop teardown rebuilding retired homes and bound e2e waits by wall clock

### DIFF
--- a/.agents/skills/firstmate-coding-guidelines/SKILL.md
+++ b/.agents/skills/firstmate-coding-guidelines/SKILL.md
@@ -121,6 +121,7 @@ Run `bin/fm-doc-audience-check.sh`; it enforces classification, README setup rou
 - Run `bin/fm-lint.sh` before treating a script change as done; it is the single owner of the lint definition (file set, config, and pinned shellcheck version) that CI and the no-mistakes pre-push gate both invoke, and it refuses to run under any other shellcheck version.
 - Colocate tests with the existing pattern in `tests/`, name them `<subject>.test.sh`, and extend an existing script rather than inventing a new runner.
 - Tests must exercise behavior through an executable or public interface and must never assert implementation-source bytes, including through parsers, regexes, snapshots, or indirect wrappers.
+- Bound every wait for a worker's marker file on wall-clock seconds with `fm_test_wait_file` in `tests/lib.sh`, never on an iteration count, because a poll budget silently shrinks exactly when a loaded runner makes the awaited work slowest.
 - A maintainer-verification record under `docs/verification/` records active empirical facts, not assumptions or task chronology.
 - Include the date, version, exact commands run, and exact output needed to support the current guarantee.
 - Keep incident chronology and delivery evidence in private task reports or PR evidence unless a concise rationale is required to maintain a current safety boundary.

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -417,7 +417,13 @@ trap 'exit 0' TERM INT
 while :; do sleep 0.02; done
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_PI_ARM_READY_TIMEOUT_MS=250 FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node --input-type=module 2>&1 <<'EOF'
+  # The ready timeout is also the window a spawned successor has to reach its
+  # arm= append before retirement SIGTERMs it: a successor killed while bash -l
+  # is still starting leaves no row, and the arm counts below misread the
+  # recovery (rows went missing at 250ms on a loaded CI runner). It must bound
+  # successor startup with margin, not model the expected duration, even though
+  # this hung recovery deliberately spends it in full three times.
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_PI_ARM_READY_TIMEOUT_MS=2000 FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node --input-type=module 2>&1 <<'EOF'
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -441,7 +447,8 @@ writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 const mod = await import(pathToFileURL(process.env.PLUGIN).href);
 mod.default(pi);
 await tool.execute("tool-call-hung-successor", {}, undefined, undefined, {});
-for (let i = 0; i < 500 && !prompt; i += 1) {
+const promptDeadline = Date.now() + 30000;
+while (!prompt && Date.now() < promptDeadline) {
   await new Promise((resolve) => setTimeout(resolve, 10));
 }
 const rows = existsSync(process.env.FM_ARM_LOG)
@@ -489,7 +496,7 @@ printf 'arm=%s\n' "$$" >> "${FM_ARM_LOG:?}"
 while [ ! -e "$FM_RELEASE_FILE" ]; do sleep 0.1; done
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_RELEASE_FILE="$release" FM_PI_ARM_READY_TIMEOUT_MS=250 FM_WATCH_ARM_RETIRE_TIMEOUT_MS=20 FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node --input-type=module 2>&1 <<'EOF'
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_RELEASE_FILE="$release" FM_PI_ARM_READY_TIMEOUT_MS=2000 FM_WATCH_ARM_RETIRE_TIMEOUT_MS=20 FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node --input-type=module 2>&1 <<'EOF'
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -513,7 +520,8 @@ writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 const mod = await import(pathToFileURL(process.env.PLUGIN).href);
 mod.default(pi);
 await tool.execute("tool-call-unretired-successor", {}, undefined, undefined, {});
-for (let i = 0; i < 500 && !prompt; i += 1) {
+const promptDeadline = Date.now() + 30000;
+while (!prompt && Date.now() < promptDeadline) {
   await new Promise((resolve) => setTimeout(resolve, 10));
 }
 const rows = existsSync(process.env.FM_ARM_LOG)
@@ -567,7 +575,7 @@ trap 'exit 0' TERM INT
 while [ ! -e "$FM_STOP_FILE" ]; do sleep 0.02; done
 SH
     chmod +x "$repo/bin/fm-watch-arm.sh"
-    out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_UNRETIRED_READY_FILE="$ready" FM_UNRETIRED_RETIRE_FILE="$retired" FM_RELEASE_FILE="$release" FM_STOP_FILE="$stop" FM_LATE_KIND="$kind" FM_PI_ARM_READY_TIMEOUT_MS=250 FM_WATCH_ARM_RETIRE_TIMEOUT_MS=20 FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node --input-type=module 2>&1 <<'EOF'
+    out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_UNRETIRED_READY_FILE="$ready" FM_UNRETIRED_RETIRE_FILE="$retired" FM_RELEASE_FILE="$release" FM_STOP_FILE="$stop" FM_LATE_KIND="$kind" FM_PI_ARM_READY_TIMEOUT_MS=2000 FM_WATCH_ARM_RETIRE_TIMEOUT_MS=20 FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node --input-type=module 2>&1 <<'EOF'
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -587,11 +595,11 @@ const rows = () => existsSync(process.env.FM_ARM_LOG)
   ? readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n")
   : [];
 async function waitFor(predicate, message) {
-  for (let i = 0; i < 500; i += 1) {
-    if (predicate()) return;
+  const deadline = Date.now() + 30000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(message);
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
-  throw new Error(message);
 }
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 const mod = await import(pathToFileURL(process.env.PLUGIN).href);
@@ -1579,7 +1587,11 @@ trap 'exit 0' TERM INT
 while :; do sleep 0.02; done
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" FM_OPENCODE_ARM_READY_TIMEOUT_MS=250 FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node 2>&1 <<'EOF'
+  # Same startup-window constraint as the Pi hung-successor test: the ready
+  # timeout must cover a loaded runner's bash -l spawn latency or retirement
+  # kills a successor before it logs its arm= row and the counts below misread
+  # the recovery.
+  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" FM_OPENCODE_ARM_READY_TIMEOUT_MS=2000 FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node 2>&1 <<'EOF'
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -1603,7 +1615,8 @@ const hooks = await mod.FmPrimaryWatchArm({
 });
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 await hooks.event({ event: { type: "session.idle", properties: { sessionID: "session-test" } } });
-for (let i = 0; i < 500 && !prompt; i += 1) {
+const promptDeadline = Date.now() + 30000;
+while (!prompt && Date.now() < promptDeadline) {
   await new Promise((resolve) => setTimeout(resolve, 10));
 }
 const rows = existsSync(process.env.FM_ARM_LOG)
@@ -1653,7 +1666,7 @@ printf 'arm=%s\n' "$$" >> "${FM_ARM_LOG:?}"
 while [ ! -e "$FM_RELEASE_FILE" ]; do sleep 0.1; done
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" FM_RELEASE_FILE="$release" FM_OPENCODE_ARM_READY_TIMEOUT_MS=250 FM_WATCH_ARM_RETIRE_TIMEOUT_MS=20 FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node 2>&1 <<'EOF'
+  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" FM_RELEASE_FILE="$release" FM_OPENCODE_ARM_READY_TIMEOUT_MS=2000 FM_WATCH_ARM_RETIRE_TIMEOUT_MS=20 FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node 2>&1 <<'EOF'
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -1677,7 +1690,8 @@ const hooks = await mod.FmPrimaryWatchArm({
 });
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 await hooks.event({ event: { type: "session.idle", properties: { sessionID: "session-test" } } });
-for (let i = 0; i < 500 && !prompt; i += 1) {
+const promptDeadline = Date.now() + 30000;
+while (!prompt && Date.now() < promptDeadline) {
   await new Promise((resolve) => setTimeout(resolve, 10));
 }
 const rows = existsSync(process.env.FM_ARM_LOG)
@@ -1733,7 +1747,7 @@ trap 'exit 0' TERM INT
 while [ ! -e "$FM_STOP_FILE" ]; do sleep 0.02; done
 SH
     chmod +x "$repo/bin/fm-watch-arm.sh"
-    out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" FM_UNRETIRED_READY_FILE="$ready" FM_UNRETIRED_RETIRE_FILE="$retired" FM_RELEASE_FILE="$release" FM_STOP_FILE="$stop" FM_LATE_KIND="$kind" FM_OPENCODE_ARM_READY_TIMEOUT_MS=250 FM_WATCH_ARM_RETIRE_TIMEOUT_MS=20 FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node 2>&1 <<'EOF'
+    out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" FM_UNRETIRED_READY_FILE="$ready" FM_UNRETIRED_RETIRE_FILE="$retired" FM_RELEASE_FILE="$release" FM_STOP_FILE="$stop" FM_LATE_KIND="$kind" FM_OPENCODE_ARM_READY_TIMEOUT_MS=2000 FM_WATCH_ARM_RETIRE_TIMEOUT_MS=20 FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node 2>&1 <<'EOF'
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -1750,11 +1764,11 @@ const rows = () => existsSync(process.env.FM_ARM_LOG)
   ? readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n")
   : [];
 async function waitFor(predicate, message) {
-  for (let i = 0; i < 500; i += 1) {
-    if (predicate()) return;
+  const deadline = Date.now() + 30000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(message);
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
-  throw new Error(message);
 }
 const hooks = await mod.FmPrimaryWatchArm({
   client,

--- a/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
@@ -24,6 +24,13 @@ HERDR_LOG="$TMP_ROOT/remote-herdr.log"
 TMUX_LOG="$TMP_ROOT/remote-tmux.log"
 TMUX_STATE="$TMP_ROOT/remote-tmux.state"
 CLAIMS="$TMP_ROOT/claims"
+# Wall-clock bounds for the deliberately blocked workers below (fm_test_wait_file).
+# A remote transaction traverses several SSH-boundary jobs before it reaches its
+# blocked write or launch, and a loaded runner has been measured taking 26s to get
+# there; a local marker is one process away. Both are hang tripwires with margin,
+# not expected durations - a healthy wait ends the moment its marker appears.
+WAIT_REMOTE_SECONDS=90
+WAIT_LOCAL_SECONDS=30
 mkdir -p "$PARENT/data" "$PARENT/state" "$PARENT/config" "$PARENT/projects" "$REMOTE_ROOT" "$CLAIMS"
 cleanup() {
   local worker_pid='' wait_attempt=0
@@ -322,13 +329,9 @@ PATH="$FAKEBIN:$PATH" FM_HOME="$TMP_ROOT/concurrent-home" FM_ROOT_OVERRIDE="$REM
   "$REMOTE_ROOT/bin/fm-remote-home-provision.sh" < "$TMP_ROOT/provision.manifest" \
   > "$TMP_ROOT/provision-one.out" 2>&1 &
 provision_one=$!
-provision_wait=0
-while [ ! -f "$TMP_ROOT/provision.entered" ]; do
-  kill -0 "$provision_one" 2>/dev/null || fail "first provisioning attempt exited before cloning"
-  provision_wait=$((provision_wait + 1))
-  [ "$provision_wait" -le 250 ] || fail "first provisioning attempt never reached cloning"
-  sleep 0.02
-done
+fm_test_wait_file "$TMP_ROOT/provision.entered" "$WAIT_LOCAL_SECONDS" "$provision_one" \
+  "first provisioning attempt exited before cloning" \
+  "first provisioning attempt never reached cloning"
 PATH="$FAKEBIN:$PATH" FM_HOME="$TMP_ROOT/concurrent-home" FM_ROOT_OVERRIDE="$REMOTE_ROOT" \
   "$REMOTE_ROOT/bin/fm-remote-home-provision.sh" < "$TMP_ROOT/provision.manifest" \
   > "$TMP_ROOT/provision-two.out" 2>&1 &
@@ -355,13 +358,9 @@ FM_SECONDMATE_CHARTER='Failing seed charter.' FM_SECONDMATE_SCOPE='failed seed' 
   seed-fail remote-mac "$REMOTE_ROOT" "$TMP_ROOT/seed-fail-home" --no-projects \
   > "$TMP_ROOT/seed-fail.out" 2>&1 &
 seed_fail_pid=$!
-seed_wait=0
-while [ ! -f "$TMP_ROOT/seed.entered" ]; do
-  kill -0 "$seed_fail_pid" 2>/dev/null || fail "failing seed exited before remote provisioning"
-  seed_wait=$((seed_wait + 1))
-  [ "$seed_wait" -le 250 ] || fail "failing seed never reached remote provisioning"
-  sleep 0.02
-done
+fm_test_wait_file "$TMP_ROOT/seed.entered" "$WAIT_LOCAL_SECONDS" "$seed_fail_pid" \
+  "failing seed exited before remote provisioning" \
+  "failing seed never reached remote provisioning"
 FM_SECONDMATE_CHARTER='Successful seed charter.' FM_SECONDMATE_SCOPE='successful seed' \
   seed_env "$ROOT/bin/fm-remote-home-seed.sh" seed-keep remote-mac "$REMOTE_ROOT" \
   "$TMP_ROOT/seed-keep-home" --no-projects > "$TMP_ROOT/seed-keep.out" 2>&1 &
@@ -826,15 +825,9 @@ EOF
 FM_FAKE_SSH_MODE=inherit-block remote_env "$ROOT/bin/fm-spawn.sh" ios --secondmate \
   > "$TMP_ROOT/spawn-concurrent.out" 2>&1 &
 spawn_concurrent=$!
-spawn_inherit_wait=0
-# Earlier inherited files traverse the worker before captain-shared.md, so give
-# a loaded portable runner 30 seconds to reach this deliberately blocked write.
-while [ ! -f "$TMP_ROOT/inherit.entered" ]; do
-  kill -0 "$spawn_concurrent" 2>/dev/null || fail "remote spawn exited before its blocked inheritance write"
-  spawn_inherit_wait=$((spawn_inherit_wait + 1))
-  [ "$spawn_inherit_wait" -le 1500 ] || fail "remote spawn never reached its blocked inheritance write"
-  sleep 0.02
-done
+fm_test_wait_file "$TMP_ROOT/inherit.entered" "$WAIT_REMOTE_SECONDS" "$spawn_concurrent" \
+  "remote spawn exited before its blocked inheritance write" \
+  "remote spawn never reached its blocked inheritance write"
 cat > "$PARENT/data/captain-shared.md" <<'EOF'
 # Shared captain preferences
 This file is main-authoritative and maintained by the main firstmate.
@@ -923,15 +916,9 @@ EOF
 FM_FAKE_SSH_MODE=inherit-block remote_env "$ROOT/bin/fm-config-push.sh" \
   > "$TMP_ROOT/config-concurrent-first.out" 2>&1 &
 config_first=$!
-inherit_wait=0
-while [ ! -f "$TMP_ROOT/inherit.entered" ]; do
-  kill -0 "$config_first" 2>/dev/null || fail "first inheritance transaction exited before its blocked write"
-  inherit_wait=$((inherit_wait + 1))
-  # Match the earlier spawn/inheritance wait: a loaded portable runner can
-  # spend several seconds in the remote entrypoint before reaching this write.
-  [ "$inherit_wait" -le 1500 ] || fail "first inheritance transaction never reached its blocked write"
-  sleep 0.02
-done
+fm_test_wait_file "$TMP_ROOT/inherit.entered" "$WAIT_REMOTE_SECONDS" "$config_first" \
+  "first inheritance transaction exited before its blocked write" \
+  "first inheritance transaction never reached its blocked write"
 cat > "$PARENT/data/captain-shared.md" <<'EOF'
 # Shared captain preferences
 This file is main-authoritative and maintained by the main firstmate.
@@ -1159,26 +1146,16 @@ FM_HOME="$PARENT" /bin/bash -c '
 ' _ "$ROOT/bin/fm-wake-lib.sh" "$handoff_lock" "$TMP_ROOT/handoff.entered" \
   "$TMP_ROOT/handoff.release" &
 handoff_holder_pid=$!
-handoff_wait=0
-while [ ! -f "$TMP_ROOT/handoff.entered" ]; do
-  kill -0 "$handoff_holder_pid" 2>/dev/null || fail "handoff lock holder exited before acquiring the route lock"
-  handoff_wait=$((handoff_wait + 1))
-  [ "$handoff_wait" -le 250 ] || fail "handoff lock holder never acquired the route lock"
-  sleep 0.02
-done
+fm_test_wait_file "$TMP_ROOT/handoff.entered" "$WAIT_LOCAL_SECONDS" "$handoff_holder_pid" \
+  "handoff lock holder exited before acquiring the route lock" \
+  "handoff lock holder never acquired the route lock"
 rm -f "$TMUX_STATE" "$TMP_ROOT/launch.entered" "$TMP_ROOT/launch.release"
 FM_FAKE_SSH_MODE=launch-block remote_env "$ROOT/bin/fm-spawn.sh" ios --secondmate \
   > "$TMP_ROOT/spawn-retirement.out" 2>&1 &
 spawn_retirement_pid=$!
-launch_wait=0
-# The respawn performs readiness and inheritance jobs before launch, so allow
-# the same 30-second loaded-runner bound as the earlier blocked worker path.
-while [ ! -f "$TMP_ROOT/launch.entered" ]; do
-  kill -0 "$spawn_retirement_pid" 2>/dev/null || fail "remote respawn exited before its blocked launch"
-  launch_wait=$((launch_wait + 1))
-  [ "$launch_wait" -le 1500 ] || fail "remote respawn never reached its blocked launch"
-  sleep 0.02
-done
+fm_test_wait_file "$TMP_ROOT/launch.entered" "$WAIT_REMOTE_SECONDS" "$spawn_retirement_pid" \
+  "remote respawn exited before its blocked launch" \
+  "remote respawn never reached its blocked launch"
 remote_env "$ROOT/bin/fm-teardown.sh" ios > "$TMP_ROOT/teardown-serialized.out" 2>&1 &
 teardown_pid=$!
 sleep 0.2

--- a/tests/fm-test-lib-wait.test.sh
+++ b/tests/fm-test-lib-wait.test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Behavior of the shared bounded wait in tests/lib.sh.
+#
+# Every suite that blocks a real worker at a fixture barrier polls for its
+# marker, and the bound those polls carry is what decides whether a slow runner
+# reports a hang. This pins the wait's contract: wall-clock bound, a distinct
+# verdict for a dead producer, and no false "exited" when the producer writes
+# its marker and exits in the same breath.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+LIB="$ROOT/tests/lib.sh"
+TMP_ROOT=$(fm_test_tmproot fm-test-lib-wait)
+mkdir -p "$TMP_ROOT"
+
+# Register every producer as soon as its pid is known, BEFORE the assertions
+# that could abort: a case that only kills on its happy path orphans that
+# producer on every failing or signalled path.
+PRODUCER_PIDS=()
+cleanup() {
+  local pid
+  for pid in "${PRODUCER_PIDS[@]:-}"; do
+    [ -n "$pid" ] && kill "$pid" 2>/dev/null
+  done
+  fm_test_cleanup
+}
+trap cleanup EXIT
+
+# Run one fm_test_wait_file call in its own shell so its fail() aborts only that
+# shell. Echoes the call's exit status; its output is captured by the caller.
+run_wait() { # <marker> <seconds> <pid|-> <out-file>
+  bash -c '
+    . "$1"
+    fm_test_wait_file "$2" "$3" "$4" "producer exited" "wait timed out"
+    printf "returned\n"
+  ' _ "$LIB" "$1" "$2" "$3" > "$4" 2>&1
+}
+
+test_returns_as_soon_as_the_marker_appears() {
+  local marker="$TMP_ROOT/appears.marker" out="$TMP_ROOT/appears.out" producer status
+  ( sleep 0.3; : > "$marker" ) &
+  producer=$!
+  PRODUCER_PIDS+=("$producer")
+  run_wait "$marker" 30 "$producer" "$out"
+  status=$?
+  wait "$producer" 2>/dev/null || true
+  expect_code 0 "$status" "wait aborted while its producer was still working"
+  assert_grep returned "$out" "wait did not return after the marker appeared"
+  pass "the wait returns once its marker appears"
+}
+
+# Time out one wait whose marker never appears; echo the seconds it spent.
+time_out_wait() { # <label> <seconds>
+  local label=$1 seconds=$2 marker="$TMP_ROOT/never-$1.marker" out="$TMP_ROOT/never-$1.out"
+  local producer status started elapsed
+  ( sleep 60 ) &
+  producer=$!
+  PRODUCER_PIDS+=("$producer")
+  started=$SECONDS
+  run_wait "$marker" "$seconds" "$producer" "$out"
+  status=$?
+  elapsed=$((SECONDS - started))
+  kill "$producer" 2>/dev/null || true
+  expect_code 1 "$status" "a wait whose marker never appears must fail ($label)"
+  assert_grep "wait timed out" "$out" "timeout did not report its own message ($label)"
+  printf '%s\n' "$elapsed"
+}
+
+test_bound_is_wall_clock_seconds_not_iterations() {
+  local short_elapsed long_elapsed
+  short_elapsed=$(time_out_wait short 1) || exit 1
+  long_elapsed=$(time_out_wait long 5) || exit 1
+  # Two independent failure modes, and a poll count catches neither. A count
+  # spends whatever its polls happen to cost on the day - too little on a loaded
+  # runner, which is what reports a slow worker as a hang - and it spends the
+  # same amount whatever bound the caller asked for.
+  [ "$short_elapsed" -ge 1 ] || fail "wait gave up after ${short_elapsed}s of a 1s bound"
+  [ "$long_elapsed" -ge 5 ] || fail "wait gave up after ${long_elapsed}s of a 5s bound"
+  [ "$((long_elapsed - short_elapsed))" -ge 2 ] \
+    || fail "a 5s bound outlasted a 1s bound by only $((long_elapsed - short_elapsed))s, so the bound is not the seconds asked for"
+  pass "the bound is wall-clock seconds, spent in full and scaled to the caller's request"
+}
+
+test_dead_producer_is_reported_apart_from_a_timeout() {
+  local marker="$TMP_ROOT/dead.marker" out="$TMP_ROOT/dead.out" producer status started elapsed
+  ( sleep 0.2; exit 3 ) &
+  producer=$!
+  PRODUCER_PIDS+=("$producer")
+  started=$SECONDS
+  run_wait "$marker" 60 "$producer" "$out"
+  status=$?
+  elapsed=$((SECONDS - started))
+  expect_code 1 "$status" "a wait whose producer died must fail"
+  assert_grep "producer exited" "$out" "dead producer was not reported as an exit"
+  assert_no_grep "wait timed out" "$out" "dead producer was reported as a timeout"
+  [ "$elapsed" -le 30 ] || fail "dead producer was not noticed until the bound expired"
+  pass "a producer that dies without its marker is reported apart from a timeout"
+}
+
+test_returns_as_soon_as_the_marker_appears
+test_bound_is_wall_clock_seconds_not_iterations
+test_dead_producer_is_reported_apart_from_a_timeout
+
+echo "ALL TESTS PASSED"

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -259,6 +259,34 @@ fm_write_secondmate_meta() {
     "projects=$projects"
 }
 
+# --- bounded waits ----------------------------------------------------------
+
+# fm_test_wait_file <path> <seconds> <pid|-> <exited-msg> <timeout-msg>: poll
+# until <path> exists, bounded by WALL-CLOCK seconds rather than an iteration
+# count. An iteration budget is not a duration: the same "250 iterations of
+# sleep 0.02" spends ~5s on an idle runner and ~20s on a loaded one, so a bound
+# written as a count silently shrinks exactly when the work it waits for is
+# slowest. bin/fm-remote-job-lib.sh bounds its own polls the same way.
+# Choose <seconds> as a hang tripwire with margin over the measured worst case,
+# never as the expected duration: a healthy wait returns the moment <path>
+# appears and costs nothing extra.
+# Fails with <exited-msg> when <pid> dies without producing <path>, or with
+# <timeout-msg> at the deadline. Pass - for <pid> when no process backs the wait.
+fm_test_wait_file() {
+  local path=$1 seconds=$2 pid=$3 exited_msg=$4 timeout_msg=$5 deadline
+  deadline=$((SECONDS + seconds))
+  while [ ! -e "$path" ]; do
+    if [ "$pid" != - ] && ! kill -0 "$pid" 2>/dev/null; then
+      # The process can create <path> and exit between the two checks, so a
+      # dead pid only proves failure once <path> is still absent afterwards.
+      [ ! -e "$path" ] || return 0
+      fail "$exited_msg"
+    fi
+    [ "$SECONDS" -lt "$deadline" ] || fail "$timeout_msg"
+    sleep 0.02
+  done
+}
+
 # --- common assertions ------------------------------------------------------
 
 # assert_contains <haystack> <needle> <msg>


### PR DESCRIPTION
## Intent

Fix the fork trunk's own red CI check "Behavior portable serial 2", which every open fork PR inherits and which therefore blocks the entire merge queue (nine parked fork PRs).

Measured evidence at intake: tests/fm-remote-secondmate-lifecycle-e2e.test.sh failed with "not ok - first inheritance transaction never reached its blocked write" on the base commit ed376cf itself; two independent lanes reproduced it, one proving its diff was a single doc file with bin/ and tests/ byte-identical to base and still red; the last ten fork-main CI runs all concluded failure. Required method: reproduce locally at the fork trunk first, diagnose the actual mechanism with disconfirming evidence for the losing hypothesis (test-side environment/timing/CI-skew versus shipped code), fix the real cause, prove a test-side fix with a witnessed-red control and ship a regression test with any code-side fix, and state exactly why the same run goes green in CI - pinning or neutralizing any load-bearing CI-environment difference rather than hoping. Two named hypotheses to check against the evidence: the CI treehouse v2.0.1 pin versus local v2.1.x, and the recorded serial lane running near its own timeout. Keep the change minimal and provable. This touches firstmate's shared tracked material, so the firstmate-coding-guidelines skill applies.

Findings and decisions made while doing the work:

DEFECT 1 (test-side). The config-push inheritance barrier bounded its wait by a poll count (250 iterations of sleep 0.02) rather than a duration. On the CI runner those iterations elapse in 5.3 seconds while the transaction needs longer to traverse its SSH-boundary jobs - the sibling spawn barrier in the same CI job took about 16 seconds. Git history shows upstream raised exactly this bound to 1500 in upstream #1727 (commit 30b18b9, 2026-08-04) and the fork reconciliation ad53e97 (2026-08-05) landed 250 at that one site while keeping 1500 at its sibling: a dropped upstream fix, not a code fault. Disconfirming evidence against a code-side defect: with an enlarged bound the transaction does reach its blocked write (measured 297-341 iterations / 19-26 seconds across three loaded runs) and every serialization assertion after it passes.

DELIBERATE CHOICE: rather than restoring upstream's literal 1500 (a one-line change that would minimize fork/upstream drift), the fix converts these waits to wall-clock bounds via a new shared tests/lib.sh helper, fm_test_wait_file. Rationale: a poll count is not a duration - it shrinks precisely when the work it waits for is slowest, so a restored count leaves the same defect one loaded runner away, and the same reconciliation could drop it again. The helper mirrors bin/fm-remote-job-lib.sh, which already bounds its own polls by wall clock. All six blocked-worker waits in that suite use it: 90 seconds for a remote transaction, 30 for a local marker, chosen as hang tripwires with margin over the measured 26-second worst case rather than expected durations, since a healthy wait ends the moment its marker appears. The helper also distinguishes a producer that died from a bound that expired, and re-checks the marker after observing a dead pid so a producer that writes and exits is not misreported.

DEFECT 2 (code-side), only reachable once the wait was fixed. The suite then failed at its final case: a remote secondmate retirement completed, reported success, and left the retired home behind as a stray tree containing data/.parent-route/wake-ledger.tsv. Mechanism: a remote secondmate is retired by a host-local teardown whose DATA is a private directory INSIDE the home being removed (bin/fm-remote-secondmate-control.sh), the terminal wake-ledger line is written after that removal, and bin/fm-wake-ledger.sh creates its ledger's directory - so the telemetry write rebuilt the tree the retirement had just deleted. Confirmed by a direct probe of the ledger writer against a non-existent destination, and isolated as fork-specific by running the upstream trunk on the same loaded machine, where the same suite passes (bin/fm-wake-ledger.sh does not exist upstream).

DELIBERATE CHOICE on the shape of that fix: an earlier version moved the ledger write ahead of the home removal, which also fixed a latent metadata-join degradation. That was rejected because it changed teardown's failure semantics - a teardown that refuses after the removal would then have already emitted a terminal "landed" line, and a retry would append a second one. The shipped fix instead leaves the write in place and skips only a destination inside a home this teardown just removed, tested both by path containment and by the vanished directory so neither spelling of the path resurrects it. The skipped line was unreachable evidence in that shape anyway: it lived only inside the deleted home, and the parent home exits before its own ledger write for a remote retirement.

Verification performed: every new guarantee was witnessed red under a matching defect before being accepted - a fixed poll count fails the wall-clock case, a wait ignoring a dead producer fails the exit case, a wait that refuses to poll fails the completion case, removing the teardown guard rebuilds the home, and applying that guard too broadly loses a terminal ledger line for a retirement whose ledger lives outside the home. A near-vacuous race case was deliberately deleted rather than kept, because no external control could force its interleaving. The full CI serial shard 2 lane now runs green locally (25 tests, 0 failed, the previously red test running for real with gate_skip=false); the cleanup suite passes with both new cases; lint, the coverage guard, and the documentation-audience check are clean.

Both named hypotheses are disconfirmed with evidence: treehouse is installed only in the Herdr CI job and never in the portable serial shard, and this suite never invokes it; and the serial lane is now four sharded jobs completing in about 9.5 minutes against a 15-minute cap, so it is not near its timeout.

## What Changed
- `tests/lib.sh` gains `fm_test_wait_file`, a wall-clock-bounded wait that also distinguishes a dead producer from an expired bound; the six blocked-worker waits in `tests/fm-remote-secondmate-lifecycle-e2e.test.sh` now use it (90s for remote transactions, 30s for local markers) instead of a 250-iteration poll count, fixing the "Behavior portable serial 2" check that was red on the fork trunk base itself — the pipeline's Test lane confirms the formerly failing suite now runs green for real (22 ok, `gate_skip=false`).
- `bin/fm-teardown.sh` now decides wake-ledger containment before removing a secondmate home and skips the terminal ledger write when the ledger lived inside the home it just removed (matched by path containment or the vanished directory), so a remote secondmate retirement no longer rebuilds the deleted home as a stray `data/.parent-route/wake-ledger.tsv` tree; covered by new retirement-guard cases in `tests/fm-teardown.test.sh`, with an SC1007 lint cleanup in the new path helper.
- The branch also carries the fork trunk's accumulated history not yet on origin/main — 46 commits spanning the fleet launcher menu, model registry and zero-budget spawn gate, wake-outcome ledger, fleet admission control, remote secondmate provisioning/doctor/job workers, LoopSpec, and the fork/upstream reconciliations — which is why the full delta spans ~204 files.

## Risk Assessment

✅ Low: The review-fix commit implements every element of the round-1 fix instructions exactly (pre-removal containment verdict, vanished-dir arm removed, write position and warning path preserved, all three test directions kept/added), and the new path-resolution helper verified correct across edge cases by static analysis and an isolated probe, leaving only one minor idiom-hardening nit.

## Testing

Ran the three targeted suites through the project's own runner — the previously red lifecycle e2e (now fully green with gate_skip=false), the teardown suite with its three new retirement-guard cases, and the new wait-helper contract test — plus a manual red/green control proving the base teardown rebuilds the retired home (stray wake-ledger.tsv tree) while the fixed teardown does not; all green, worktree left clean. No visual evidence applies: the change is shell-script and test behavior with no rendered surface, so CLI transcripts are the end-user-visible artifact.

<details>
<summary>Evidence: Previously red lifecycle e2e suite passing (22 ok, exit 0, gate_skip=false)</summary>

```text
FM_TEST_BEGIN 2026-08-09T00:55:48Z tests/fm-remote-secondmate-lifecycle-e2e.test.sh family=secondmate expected_gate_skip=none
ok - overlapping remote home provisioning serializes through publication and rollback
ok - remote seed rollback preserves serialized competing routes
ok - unknown readiness preserves its route and brief for reconciliation
ok - remote seeding checks, repairs, and re-checks readiness, then stops on a remaining gap
ok - remote seeding proceeds once the repair closes every gap
ok - remote seed registers the route and provisions the whole home and project clone on that host
ok - remote inheritance rejects incomplete and superseded payload generations
ok - mixed local and remote routes validate without migration
ok - remote spawn launches on the remote-local backend and records a host-qualified route
ok - legacy and mismatched remote endpoints fail closed before backend access
ok - non-herdr remote endpoints are refused without changing either route
ok - remote spawn serializes inheritance through launch publication
ok - marked send and routed reply complete through the existing parent correlation owner
PR_CHECK_MIGRATION: watcher ownership is ambiguous; review state/.watch.lock before rearming polls
ok - partial remote inheritance retains reread intent through bootstrap convergence
ok - config push and bootstrap serialize remote inheritance convergence
WARNING: queued wakes pending - drain them with bin/fm-wake-drain.sh before anything else.
ok - remote inherited config retains and retries a failed live reread nudge
ok - fleet snapshot projects mixed local and remote structured state
ok - remote update imports and fast-forwards the persistent home on its configured host
PR_CHECK_MIGRATION: watcher ownership is ambiguous; review state/.watch.lock before rearming polls
ok - startup repairs remote readiness before probing without relaunching
PR_CHECK_MIGRATION: watcher ownership is ambiguous; review state/.watch.lock before rearming polls
ok - startup reports alive legacy backends without changing their routes
ok - unreachable remote state remains unknown with no local respawn or failover
ok - remote retirement refuses child work, then removes only its own endpoint while a shared-session sibling survives
ALL TESTS PASSED
FM_TEST_END 2026-08-09T00:59:00Z tests/fm-remote-secondmate-lifecycle-e2e.test.sh exit=0 duration_ms=192732 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=192768
FM_TEST_SUMMARY_FAMILY family=secondmate count=1 duration_ms=192732 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-remote-secondmate-lifecycle-e2e.test.sh duration_ms=192732
```
</details>
<details>
<summary>Evidence: Red/green control: base ed376cf teardown rebuilds the removed home (wake-ledger.tsv stray tree listed, exit 1); fixed teardown green in the same environment</summary>

<code>not ok - secondmate-home-owned-data: retirement rebuilt the removed home&#10;.../secondmate-home/data/.parent-route/wake-ledger.tsv&#10;suite exit: 1&#10;=== GREEN: fixed (f1ac922) bin/fm-teardown.sh + same tests, same environment ===&#10;ok - secondmate retirement writes nothing back into the home it removed&#10;ok - secondmate retirement still records a terminal line in a ledger outside that home&#10;suite exit: 0</code>

```text
=== RED CONTROL: base (ed376cf) bin/fm-teardown.sh + new retirement tests ===
not ok - secondmate-home-owned-data: retirement rebuilt the removed home
/tmp/fm-teardown-tests.okgQhv/secondmate-home-owned-data/secondmate-home
/tmp/fm-teardown-tests.okgQhv/secondmate-home-owned-data/secondmate-home/data
/tmp/fm-teardown-tests.okgQhv/secondmate-home-owned-data/secondmate-home/data/.parent-route
/tmp/fm-teardown-tests.okgQhv/secondmate-home-owned-data/secondmate-home/data/.parent-route/wake-ledger.tsv
suite exit: 1
=== GREEN: fixed (f1ac922) bin/fm-teardown.sh + same tests, same environment ===
ok - secondmate retirement writes nothing back into the home it removed
ok - secondmate retirement still records a terminal line in a ledger outside that home
suite exit: 0
```
</details>
<details>
<summary>Evidence: Full teardown suite green including the three new retirement-guard cases</summary>

```text
FM_TEST_BEGIN 2026-08-09T00:56:01Z tests/fm-teardown.test.sh family=pr-forge expected_gate_skip=none
ok - local-only worktree with HEAD on a fork remote is torn down (fix holds)
ok - teardown prompts tasks-axi backlog refresh when compatible
ok - teardown honors config/backlog-backend=manual even when tasks-axi is compatible
ok - local-only worktree with truly unpushed work is refused (safety preserved)
ok - local-only worktree with work merged into local main is torn down (no regression)
ok - no-mistakes worktree with HEAD on origin is torn down (no regression)
ok - no-mistakes worktree with genuinely unlanded work is refused (safety preserved)
ok - local-only worktree with unpushed work is torn down under --force (escape hatch)
ok - teardown completes when an exact busy-state sidecar is already absent
ok - herdr teardown removes pane-owned escalation dedupe state
ok - herdr flat teardown refuses before returning the isolated copy under lock contention and the retry completes cleanly
ok - herdr flat teardown never erases records when pane presence is unparseable
ok - herdr flat teardown preflight refuses before every destructive change
ok - forced secondmate teardown preflights every Herdr child before cleanup mutation
ok - forced secondmate teardown retains Herdr child identity until exact pane disappearance
ok - forced teardown retains a nested secondmate home and its grandchild's Herdr identity when the grandchild close is unconfirmed
ok - secondmate retirement writes nothing back into the home it removed
ok - secondmate retirement still records a terminal line in a ledger outside that home
ok - secondmate retirement creates a missing external ledger directory and records its terminal line
ok - herdr projection teardown retires its journal only after confirming the exact recorded pane is gone
ok - herdr projection teardown retains every record when post-close presence is unknown
ok - squash-merged + deleted-branch worktree (PR merged) is torn down (the fix)
ok - releasing a task whose PR has not landed leaves a durable landing record
ok - releasing a task whose PR already merged leaves no landing record
ok - squash-merged PR accepts a local HEAD that is an ancestor of the final PR head
ok - teardown discovers a merged PR by branch name and tears down when no pr= was ever recorded
ok - squash-merged PR accepts replayed unpushed local patches contained in the PR head
ok - merged PR does not allow teardown after a later local commit
ok - fm-pr-check does not refresh PR head after HEAD moves
ok - fm-pr-check records the remote PR head when the local worktree lags
ok - worktree whose content already landed in the default branch is torn down (content fallback)
ok - content fallback refreshes origin default before comparing trees
ok - work squash-merged into the fork trunk is torn down though no tracking ref follows it
ok - genuinely unlanded work is still refused on a fetch/push split
ok - an unreadable landing target refuses rather than falling back to the upstream answer
ok - content landed on the upstream trunk is still accepted when the fork trunk is readable
ok - an ordinary single-remote repository names no landing ref and is unaffected
ok - dirty worktree is refused even when its committed work has landed (dirty always wins)
ok - spawn-written turn-end artifacts (claude, opencode, grok, kimi) do not read as uncommitted work
ok - untracked work beside a turn-end artifact still refuses (allowlist is per-path, not per-directory)
ok - gh lookup error with content not in default refuses (fail-safe)
ok - provably-stale worktree index.lock (old, no live holder) is cleared and teardown succeeds
ok - live-held worktree index.lock is never removed and teardown refuses
ok - lsof errors leave worktree index.lock in place and refuse teardown
ok - stale lock cleanup rechecks and refuses dirty worktree before return
ok - normal repo index.lock is resolved from the worktree and cleared when stale
ok - lock mtime read failures leave worktree index.lock in place and refuse teardown
ok - transient index.lock cleared after first failed return is retried successfully without force-remove
ok - persistent index.lock exhausts retries and refuses without force-removing the lock
ok - empty retry wait overrides use the default without aborting teardown
ok - fractional legacy retry wait remains supported without arithmetic
ok - teardown records the terminal ledger line with the meta's profile before deleting it
ok - a --force teardown records the task as abandoned rather than landed
ok - an unwritable ledger warns but never fails or halts a teardown
ok - a task's own parked no-mistakes run is aborted, not orphaned, before the worker is removed
ok - teardown refuses before reap or removal when a task-owned run remains parked
ok - a different run cannot confirm the targeted abort
ok - empty post-abort status is not accepted as confirmation
ok - the CLI's exact run-not-found signal confirms completion
ok - a parked run on another branch is never aborted by this task's teardown (ownership is precise)
ok - a task-owned autonomous running step is left alone rather than aborted
ok - a leaked descendant process rooted under the task's worktree is reaped by teardown, not left surviving
ok - a leaked descendant process rooted under the task's per-task tasktmp is reaped by teardown too
ok - missing lsof falls back to reaping the tmux pane process group
ok - an erroring lsof scan refuses teardown and preserves the task
ok - a reused pid with a different start time is never force-killed
ok - an exec change preserves birth identity and the process is reaped
ok - a process spawned during grace is reaped on a later pass
ok - persistent leaked processes refuse teardown after bounded retries
ok - a process exiting during identity lookup does not block teardown
ok - the run abort and the leaked-process reap both complete before the destructive worktree return
FM_TEST_END 2026-08-09T00:57:18Z tests/fm-teardown.test.sh exit=0 duration_ms=77577 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=77613
FM_TEST_SUMMARY_FAMILY family=pr-forge count=1 duration_ms=77577 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-teardown.test.sh duration_ms=77577
```
</details>
<details>
<summary>Evidence: fm_test_wait_file contract test: wall-clock bound, dead-producer verdict, immediate return on marker</summary>

```text
FM_TEST_BEGIN 2026-08-09T00:55:49Z tests/fm-test-lib-wait.test.sh family=unclassified expected_gate_skip=none
ok - the wait returns once its marker appears
ok - the bound is wall-clock seconds, spent in full and scaled to the caller's request
ok - a producer that dies without its marker is reported apart from a timeout
ALL TESTS PASSED
FM_TEST_END 2026-08-09T00:55:56Z tests/fm-test-lib-wait.test.sh exit=0 duration_ms=6414 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=6450
FM_TEST_SUMMARY_FAMILY family=unclassified count=1 duration_ms=6414 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-test-lib-wait.test.sh duration_ms=6414
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Rebase** - skipped</summary>

- ⚠️ `.agents/skills/afk/SKILL.md` - branch carries 46 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (212 file(s)) into the PR:
- ed376cf fix(bin): refuse merges without verified green checks (land of upstream #1614) (#48)
- 744f982 fix(bin): resolve the fork trunk as a landing target (#47)
- 561f0bb fix(bin): keep the fleet view working past the per-argument cap (#46)
- aef7a6d fix(bin): resolve the wake sequence instead of trusting a supplied one (#45)
- f90ed1d fix(bin): detect child-process work during supervision (land of upstream #1676) (#44)
- 3611e49 fix(bin): separate task read and contribution bases (land of upstream #1613) (#43)
- dda7f30 fix: stop rechecking captain-gated pauses in away mode (land of upstream #1621) (#42)
- 4bee9f1 fix(bin): escalate blocked-on-human transitions past status-line dedupe (#41)
- 27c7a2d fix(bin): stop wedge alarms on settled terminal tasks (#40)
- ad53e97 reconcile: one landable base from the diverged fork and upstream trunks (#39)
- 9f914d1 feat: add the canonical LoopSpec representation, schema and register (#38)
- cc242ae feat: add research-approved-work skill and deterministic corpus scanner (#37)
- 50adfce fix(bin): measure pool-slot safety against the landing target (#36)
- 631c248 feat(bin): wake-outcome ledger for measured coordinator attention cost (#35)
- 817ee8e CI mirror: refuse local merges only on genuine working-tree collisions (#1)
- ef74752 fix(bin): recognize kimi variants and pi launcher basenames in harness detection (#20)
- 5e6e90f fix(bin): let a released task land through the sanctioned merge path (#34)
- 1149178 Merge pull request #33 from sbracewell64/fm/fork-upstream-resync-conflicts
- 490a371 reconcile: fork trunk with upstream main (0 behind, queue intact, 7 conflicts resolved) (#32)
- a004e4c Merge upstream 33a4287 into the fork trunk queue
- ecbbe30 fork-landing: Windows-to-WSL launcher bridge reconciled onto trunk (#31)
- abc2e7b fix(bin): prevent treehouse allocation from detaching live work (#25)
- 61a5ce8 feat(bin): carry standing worker rules into every generated brief (#23)
- 1ba6ffe fix(bin): allowlist the opencode turn-end plugin in teardown&#39;s dirty check (#12)
- 988dd4b fix(composer): read an NBSP-padded empty composer as empty and fail unshown herdr wedge alarms (#14)
- 0c83af2 test: reap leaked background processes on every suite ending (#16)
- 8e1eb2d feat(bin): wake firstmate when a monitored PR goes conflicting (#21)
- 3edbc23 CI mirror: feat(bin): add fleet admission control stages 0 and 1 (#8)
- cf8f2c6 feat(bin): trigger the 70% compaction doctrine from Claude&#39;s host-computed context telemetry (#11)
- e960b84 feat(bin): enforce the zero-budget model rule with a model registry, spawn gate, and probe verification (#10)
- d965699 feat(bin): mark crewmate and scout steers as from-firstmate and teach briefs to read the marker (#9)
- 9dbaa00 Merge fm/fm-launch-menu: fleet launcher menu (upstream PR #1288)
- 06a6fbd no-mistakes(review): add launch lock, reject leading-zero input, refresh evidence anchors
- fa1dcc7 test: replace launch-lib one-owner source assertions with behavioral coverage
- 74be2a6 no-mistakes(review): fix glob split, enforce backend, guard reattach, probe pi-signed
- cca9d3a feat(bin): add the fleet launcher menu, Herdr gate, and reattach guard
- a083886 no-mistakes(document): point harness-adapters launch facts at fm-launch-lib owner
- 0f42855 no-mistakes(review): bind consumer obligation to every primary, fix pi rationale
- 1154677 no-mistakes(review): bind consumer obligation to any bypass flag, add grok
- bf87246 no-mistakes(review): record primary autonomy evidence and consumer obligation
- abe3c8d no-mistakes(review): add grok --trust, refuse kimi primary, pin every primary shape
- dbfd400 no-mistakes(document): point grok adapter launch line at fm-launch-lib owner
- e067656 no-mistakes(review): use verified opencode --auto primary shape and tighten launch-lib ownership
- 7fd8e55 no-mistakes(document): point launch-command docs at new fm-launch-lib.sh owner
- 6e65a07 no-mistakes(review): map fm-launch-lib.sh into test selection, fixture, and docs
- 2c93585 refactor(bin): give launch knowledge one owner in fm-launch-lib.sh

Push main to origin, or rebase your branch onto origin/main, before gating.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-teardown.sh:2375` - The vanished-directory arm of the new ledger guard (`|| [ ! -d &#34;$(dirname &#34;$LEDGER_PATH&#34;)&#34; ]`) skips the terminal wake-ledger line for ANY secondmate teardown whose ledger parent directory does not exist, not just for the removed home. Concrete regression: with FM_WAKE_LEDGER redirected outside the home to a not-yet-created directory, fm-wake-ledger.sh previously created the directory and recorded the line (and a failed write at least emitted the &#39;wake ledger terminal line not recorded&#39; warning); now the write is skipped entirely and silently, since the skip path bypasses the warning too. The shipped counter-test (test_secondmate_retirement_still_records_a_ledger_outside_the_home) only covers an external ledger whose directory already exists. The two-armed guard shape is documented as a deliberate choice, so this challenges intent rather than being auto-fixable; a minimal mitigation is to emit the existing warning when the vanished-dir arm fires without path containment matching.
- ℹ️ `tests/fm-remote-backlog-handoff.test.sh:234` - The same defect class fixed by this branch — blocked-worker waits bounded by a poll count (250 iterations of sleep 0.02) instead of wall clock — survives in tests/fm-remote-backlog-handoff.test.sh at lines 139, 234, and 309, waiting on the same SSH-boundary remote transactions (fm-backlog-handoff.sh behind FM_FAKE_SSH_MODE barriers). These sites are one loaded runner away from the identical &#39;never reached its blocked write&#39; flake. Leaving them unconverted is consistent with the intent&#39;s required minimality, so no action for this change; they are a natural follow-up now that tests/lib.sh owns fm_test_wait_file.

🔧 Fix: decide ledger containment before removing the secondmate home
1 info still open:
- ℹ️ `bin/fm-teardown.sh:889` - nearest_existing_abs_path resolves with a bare `cd &#34;$dir&#34;` while the same file&#39;s other containment/canonicalization helpers (lines 211, 239, 424-431) deliberately use `CDPATH=&#39;&#39; cd --`. If an operator exports CDPATH and a relative path component reaches the helper, cd can resolve through a CDPATH entry and also prints the destination into the command substitution, yielding a corrupted resolved path and therefore a wrong ledger-containment verdict. Exposure is minimal because HOME_PATH and LEDGER_PATH are effectively always absolute in this codebase; changing the line to `resolved=$(CDPATH=&#39;&#39; cd -- &#34;$dir&#34; 2&gt;/dev/null &amp;&amp; pwd -P)` matches the file&#39;s established defensive idiom.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-test-run.sh tests/fm-remote-secondmate-lifecycle-e2e.test.sh` — the suite behind the red CI check; 22 ok, exit 0, gate_skip=false, including the formerly failing &#34;first inheritance transaction&#34; barrier and the final retirement case</code>
- <code>`bin/fm-test-run.sh tests/fm-teardown.test.sh` — full cleanup suite green with all three new retirement-guard cases (nothing written into the removed home; external ledger still recorded; missing external ledger directory still created)</code>
- <code>`bin/fm-test-run.sh tests/fm-test-lib-wait.test.sh` — fm_test_wait_file contract: wall-clock bound scaled to the request, dead producer reported apart from timeout, immediate return on marker</code>
- `Manual red/green control in an ephemeral /tmp tree: base ed376cf bin/fm-teardown.sh under the new retirement tests fails with the home rebuilt as a stray tree containing data/.parent-route/wake-ledger.tsv (exit 1); restoring the f1ac922 teardown in the same environment turns both cases green (exit 0)`
- <code>`bin/fm-test-run.sh --list --lane portable-serial-2of4` — confirmed the lifecycle e2e suite is selected by the exact CI serial shard that was red</code>

</details>

<details>
<summary>⚠️ **Document** - 2 issues (1 error, 1 info)</summary>

- 🚨 `bin/fm-teardown.sh:880` - bin/fm-lint.sh fails at the target commit: shellcheck SC1007 at bin/fm-teardown.sh:880 (`local path=$1 dir=$1 suffix= resolved` in the new nearest_existing_abs_path helper; shellcheck wants `suffix=&#39;&#39;`). The failure is pre-existing in this change&#39;s own code (verified identical with my documentation edits stashed), CI&#39;s lint job runs bin/fm-lint.sh directly, so the lint lane is red at f1ac922 - contradicting the intent&#39;s claim that lint was clean and the goal of a green fork trunk. The fix is a one-character code edit, which this documentation-only pass is forbidden to make.
- ℹ️ `docs/fm-test-portable-shards.md:67` - Follow-up: docs/fm-test-portable-shards.md&#39;s dated shard-balance evidence (2026-08-02: 18 scripts in portable-serial-2of4, ~5-minute shards with ~3x timeout margin) has drifted - the intent measured 25 scripts in shard 2 and ~9.5 minutes against the 15-minute cap, and this change adds tests/fm-test-lib-wait.test.sh to the serial remainder. The doc&#39;s own refresh procedure needs per-shard timing artifacts from a green CI run, which can only exist after this change lands, so refresh the hints table then rather than hand-editing the dated evidence now.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: quiet SC1007 with explicit empty suffix initializer
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
