### PR TITLE
feat: roll out the feature-first focused validation operating model

### DIFF
--- a/.agents/skills/focused-validation/SKILL.md
+++ b/.agents/skills/focused-validation/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: focused-validation
+description: >-
+  Agent-only procedure for the feature-first validation operating model: the mapped focused validation slice that is the default preflight for every ship task, the stop rule that proves a changed surface isolated and proven, the file-to-test-family map, the internal-only fast-path boundary, and isolation-preserving test optimizations that keep per-run isolation. Load before classifying a ship task's surface at intake, before writing or adjusting a ship brief's focused-validation clause, and before running a ship task's focused preflight.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# focused-validation
+
+This skill is the single policy owner for the feature-first validation operating model's procedure.
+`AGENTS.md` section 7 owns the always-loaded contract: the preflight requirement, the stop rule, the fast-path boundary, the full-review retention, and the daemon-window scheduling rule.
+`bin/fm-brief.sh` generates the worker-facing focused-validation section in every ship brief and points here for the detail.
+This skill never duplicates those owners; it states the procedure they reference.
+
+## Load triggers
+
+Load before classifying a ship task's surface at intake, before writing or adjusting a ship brief's focused-validation clause, and before running a ship task's focused preflight.
+A worker running a ship brief that carries the focused-validation section loads this skill through the brief's `$FM_ROOT` pointer when it needs the ladder, the isolation proof, or the map.
+
+## The mapped focused validation slice
+
+Every ship task runs a mapped focused validation slice before the full review starts or before a direct-PR opens, and records the slice's timing.
+The slice is the cheapest test selection that can observe the change's contract, mapped from the touched files.
+
+- For firstmate-repo tasks, the map is `bin/fm-test-run.sh --changed` (the changed-file to family map owned by that script's header) or the touched `tests/<family>.test.sh` scripts directly.
+- For other projects, use the focused test families the project's committed `AGENTS.md` names.
+- When a project has no such pointer, choose the minimal test file or runner selection that asserts the contract, and record the choice with the timing.
+
+The preflight's purpose is that a trivial break fails in seconds here instead of after the full review.
+
+## The stop rule: isolated and proven
+
+A changed surface is isolated and proven when all four conditions hold:
+
+1. **File-to-surface map** - the touched files resolve to exactly one module and one test family, with no shared middleware, config, deploy, or edge file in the diff.
+2. **Contract expressibility** - the acceptance condition is writable as a pure function or a single API-level assertion, with no browser, scheduler, or external service required.
+3. **No external mutation** - the diff writes no database schema shared with other features, no deploy workflow, no secret, and no edge config.
+4. **Existing focused coverage** - the module's focused tests exist and pass on the base.
+
+Only an isolated and proven surface earns fast-path eligibility, and only inside the internal-only boundary: direct-PR with focused validation is limited to internal tooling, automation, scripts, and operator process.
+Product-facing, mixed, security-sensitive, edge, deployment, and uncertain work climbs to the full `no-mistakes` review regardless of focused-slice results.
+
+## Isolation-preserving optimizations
+
+Per-run test isolation is retained indefinitely; there is no shared warm test stack.
+Optimize startup inside isolated runs with deterministic fixtures, immutable dependency or image caches, focused health checks, and unique writable test artifacts such as per-worker database names and ephemeral ports.
+A shared warm stack is not part of this model, and no change here reintroduces it.
+
+## Scheduling around the gate daemon
+
+The full `no-mistakes` review stays the production correctness gate.
+Never schedule a no-mistakes run that would span a no-mistakes daemon-update window, because a daemon restart kills in-flight runs.
+Only firstmate manages the daemon.
+
+## Focused validation is not visual review
+
+The focused slice never substitutes for the separate vision-capable visual-review worker that `AGENTS.md` section 7 assigns to every UI-touching ship.

--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -39,9 +39,9 @@ The registry records the project's standing posture, which is the captain's defa
 Choose that posture when adding or creating the project:
 
 - `no-mistakes` runs the full validation pipeline before a PR.
-- `direct-PR` pushes and opens a PR without the no-mistakes pipeline.
+- `direct-PR` pushes and opens a PR without the no-mistakes pipeline but with the mapped focused-validation preflight.
 - `local-only` has no required remote or PR and lands only through the approved local fast-forward path.
-- `no-mistakes-prod-only` is a conditional policy rather than one flat mode: genuinely internal-only tooling, automation, contributor or operator process, and release or submission work ships `direct-PR`, while product-facing, mixed, and uncertain work ships `no-mistakes`.
+- `no-mistakes-prod-only` is a conditional policy rather than one flat mode: `AGENTS.md` section 7 owns the per-task surface boundary that decides between `direct-PR` with focused validation and the full `no-mistakes` review.
 
 `no-mistakes-prod-only` is the default for a newly added or created remote-backed project when the captain specifies nothing, and a project with no remote defaults to `local-only`.
 State that resolved default while confirming the source, local name, and posture instead of asking the captain to choose from scratch, and record a flat mode instead whenever they ask for one.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,6 +257,8 @@ Keep `local-only` work in the main home.
 Send in-scope work to the fitting secondmate unless it is blocked or the captain explicitly redirects it; do not read the secondmate's chat because marked routed replies return through its status or referenced document.
 If no secondmate scope fits, use the main home or discuss creating an appropriate persistent secondmate.
 For one-off or infrequent operational work, start with the simplest direct end-to-end path.
+Route visual work by capability at intake: a UI-touching ship - one whose deliverable is a visible UI change, screenshot, layout check, or visual review - gets a separate vision-capable (Luna) visual-review worker, while bounded non-visual implementation and test work defaults to the cheap non-vision (DeepSeek Flash) profile.
+The visual-review worker is the only authority on visual findings for that task and its evidence handoff is by file, never by chat; verify a model's vision capability in the harness's own catalog at dispatch rather than trusting a model name.
 Do not build wrappers, control planes, policy layers, custom verifiers, or automation unless the direct path exposes a concrete blocker or repeated need that justifies the added machinery.
 
 Before commissioning an investigation, consult existing reports and established evidence.
@@ -272,12 +274,16 @@ Load `diagnostic-reasoning` before scoping a reported bug and before acting on a
 
 Resolve every ship task's concrete delivery mode and yolo posture at intake, and pass both explicitly to the brief, the spawn, and any scout promotion, which all refuse to guess.
 A current explicit captain instruction wins; otherwise the project's registry entry is the captain's standing posture, and dropping below its rigor needs a reason you can state.
-On a `no-mistakes-prod-only` project, classify the task's surface: internal-only tooling, automation, contributor or operator process, and release or submission work ships `direct-PR`, while product-facing, mixed, and uncertain work ships `no-mistakes`; never infer internal-only from file location or project name.
+On a `no-mistakes-prod-only` project, classify the task's surface: internal-only tooling, automation, scripts, and operator process may ship `direct-PR` with focused validation, while product-facing, mixed, security-sensitive, edge, deployment, and uncertain work ships `no-mistakes`; never infer internal-only from file location or project name.
+Every ship runs a mapped focused validation slice as the default preflight before the full review or before opening a direct-PR, and records the slice's timing.
+The fast path's stop rule is an isolated and proven surface: the touched files resolve to one module and one test family, no shared middleware, config, deploy, or edge file, no external mutation, and existing focused tests cover the module and pass.
+An isolated and proven surface earns fast-path eligibility only inside the internal-only boundary above; product-facing, mixed, and uncertain work climbs to the full `no-mistakes` review regardless of focused-slice results.
+The `focused-validation` skill (section 13) owns the ladder, the isolation proof, and the file-to-test-family map.
 An unregistered project or absent registry resolves to `no-mistakes` with yolo off, and the registration gap goes to the captain.
 Record the resulting mode, yolo, and the one-line reason for any deviation in the backlog item note.
 
-Treat file or subsystem overlap as a risk signal rather than an automatic reason to wait, and dispatch isolated work immediately with no concurrency cap when each change can be independently implemented and validated and the selected delivery path can reconcile ordinary rebases or conflicts.
-Serialize only for a true semantic dependency, shared mutable external state, incompatible concurrent migration, or another concrete condition that makes independent progress or reconciliation unsafe; same-file editing alone is insufficient, and genuine blockers remain durable.
+Treat file or subsystem overlap as a risk signal rather than an automatic reason to wait, and dispatch isolated work immediately with no artificial concurrency cap when each change can be independently implemented and validated and the selected delivery path can reconcile ordinary rebases or conflicts.
+Serialize only for the same branch or head, a mutable database or schema, a fixed port or compose project, production or edge state, the shared no-mistakes gate daemon, firstmate's shared tracked surface, or another true semantic dependency or incompatible concurrent migration that makes independent progress or reconciliation unsafe; same-file editing alone is insufficient, and genuine blockers remain durable.
 Write the task-specific brief under section 11 before spawning.
 
 ### Dispatch and supervision handoff
@@ -305,7 +311,7 @@ If fast-path risk needs more rigor, escalate whether to use no-mistakes instead 
 The path's worker, automated gates, and captain approval remain authoritative:
 
 - **no-mistakes** runs the full pipeline through a PR, then waits for the configured merge authority.
-- **direct-PR** has the worker push and open a PR without the no-mistakes pipeline, then waits for the configured merge authority.
+- **direct-PR** has the worker push and open a PR with focused validation (the mapped preflight), without the no-mistakes pipeline, then waits for the configured merge authority.
 - **local-only** has the worker stop with a clean ready branch, then waits for the configured merge authority before firstmate uses the guarded fast-forward merge path.
 
 Delivery mode and `yolo` are orthogonal.
@@ -324,6 +330,8 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
 The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
+The full `no-mistakes` review stays the production correctness gate for product-facing, mixed, security-sensitive, edge, deployment, and uncertain work.
+Never schedule a no-mistakes run that would span a no-mistakes daemon-update window, because a daemon restart kills in-flight runs.
 Once validation starts, prefer routing new requirements to follow-up work rather than expanding the current task, unless a new requirement completely invalidates the work being validated; however, the smallest downstream changes needed to keep already accepted product or engineering behavior correct, add behavioral tests where an executable contract exists, or keep documentation accurate remain within the current task even when they touch files not named at intake, and corrections required to satisfy already accepted intent are not new requirements.
 
 Only a current, explicit captain instruction that completely invalidates the work being validated keeps the task with the same worker instead of routing it to follow-up work or handing it to a replacement.
@@ -491,6 +499,7 @@ Use its scaffold as the contract, then replace every `{TASK}` placeholder with a
 Keep additions task-specific rather than repeating lifecycle instructions, and alter generated sections only when the task genuinely differs from the standard shape.
 
 Every ship brief must retain the worktree-isolation assertion and stop if launched in the primary checkout.
+Every ship brief carries the scaffolded focused-validation preflight section and its stop rule; keep that section unless the task genuinely has no testable surface.
 If a ship task touches firstmate's shared tracked material, explicitly require `firstmate-coding-guidelines` before editing.
 If a task will drive Herdr lifecycle behavior, scaffold with `--herdr-lab`; if that need appears after an unguarded scaffold, stop and regenerate rather than adding commands by hand.
 The generated Herdr contract must use a named non-`default` isolated lab and its guarded helper for every lifecycle action.
@@ -526,6 +535,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the Relay configuration blocker, on a `public-followup ...` `check:` wake or a startup-surfaced public commitment, and on any milestone or terminal wake for a Relay-linked task before posting its completion follow-up; relevant only when Relay is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
+- `focused-validation` - load before classifying a ship task's surface at intake, before writing or adjusting a ship brief's focused-validation clause, and before running a ship task's focused preflight.
 
 ## 14. Relay
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -364,7 +364,7 @@ Delivery contract: mode=direct-PR
 This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
 Run the mapped focused validation slice from the Focused validation section and record its timing before pushing; it is the review for this fast path.
-If the changed surface is not isolated and proven under the stop rule, or the slice fails, fix within the task - or append \`needs-decision\` instead of pushing when the surface turns out to be product-facing, mixed, or uncertain.
+If the changed surface is not isolated and proven under the stop rule, or the slice fails, fix within the task - or append \`needs-decision\` instead of pushing when the surface turns out to fall outside the internal-only boundary defined in \`$FM_ROOT/.agents/skills/focused-validation/SKILL.md\`.
 When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
@@ -425,8 +425,8 @@ IFS= read -r -d '' FOCUSED_VALIDATION_SECTION <<EOF || true
 Run the mapped focused validation slice for this change before reporting done, and record its timing.
 Map the touched files to the project's test surface: for firstmate-repo tasks run \`bin/fm-test-run.sh --changed\` from the worktree root or the touched \`tests/<family>.test.sh\` scripts; for other projects use the focused test families that project's \`AGENTS.md\` names.
 The stop rule is an isolated and proven surface: the touched files resolve to one module and one test family, no shared middleware, config, deploy, or edge file, no external mutation, and existing focused tests cover the module and pass.
-An isolated and proven surface qualifies for the fast path only for \`direct-PR\` work inside the internal-only boundary; product-facing, mixed, and uncertain work still climbs to the full review.
-Follow \`$FM_ROOT/.agents/skills/focused-validation/SKILL.md\` for the ladder, the isolation proof, and the file-to-test-family map.
+An isolated and proven surface qualifies for the fast path only for \`direct-PR\` work inside the internal-only boundary; work outside that boundary still climbs to the full review.
+Follow \`$FM_ROOT/.agents/skills/focused-validation/SKILL.md\` for the internal-only boundary, the ladder, the isolation proof, and the file-to-test-family map.
 EOF
 FOCUSED_VALIDATION_SECTION=${FOCUSED_VALIDATION_SECTION%$'\n'}
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -423,7 +423,7 @@ DOD=${DOD%$'\n'}
 IFS= read -r -d '' FOCUSED_VALIDATION_SECTION <<EOF || true
 # Focused validation
 Run the mapped focused validation slice for this change before reporting done, and record its timing.
-Map the touched files to the project's test surface: for firstmate-repo tasks run \`$FM_ROOT/bin/fm-test-run.sh --changed\` or the touched \`tests/<family>.test.sh\` scripts; for other projects use the focused test families that project's \`AGENTS.md\` names.
+Map the touched files to the project's test surface: for firstmate-repo tasks run \`bin/fm-test-run.sh --changed\` from the worktree root or the touched \`tests/<family>.test.sh\` scripts; for other projects use the focused test families that project's \`AGENTS.md\` names.
 The stop rule is an isolated and proven surface: the touched files resolve to one module and one test family, no shared middleware, config, deploy, or edge file, no external mutation, and existing focused tests cover the module and pass.
 An isolated and proven surface qualifies for the fast path only for \`direct-PR\` work inside the internal-only boundary; product-facing, mixed, and uncertain work still climbs to the full review.
 Follow \`$FM_ROOT/.agents/skills/focused-validation/SKILL.md\` for the ladder, the isolation proof, and the file-to-test-family map.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -34,6 +34,9 @@
 #   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> configured merge authority
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                the configured merge authority approves, firstmate merges to local main
+# Every ship brief also carries the mapped focused-validation preflight section
+# (AGENTS.md section 7): the worker-facing step, the one-line stop rule, and the
+# pointer to the focused-validation skill that owns the full procedure.
 # no-mistakes-prod-only is a registry policy, not a task mode; resolve it to one of
 # the three concrete modes at intake before calling this script.
 # The generated ship brief records the chosen mode as a fixed machine-readable
@@ -360,6 +363,8 @@ case "$MODE" in
 Delivery contract: mode=direct-PR
 This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
+Run the mapped focused validation slice from the Focused validation section and record its timing before pushing; it is the review for this fast path.
+If the changed surface is not isolated and proven under the stop rule, or the slice fails, fix within the task - or append \`needs-decision\` instead of pushing when the surface turns out to be product-facing, mixed, or uncertain.
 When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
@@ -372,6 +377,7 @@ EOF
 Delivery contract: mode=local-only
 This task ships **local-only**: no remote, no PR, no pipeline.
 The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
+Run the mapped focused validation slice from the Focused validation section and record its timing before appending \`done: ready in branch\`.
 Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
 When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
 The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
@@ -385,6 +391,7 @@ EOF
 # Definition of done
 Delivery contract: mode=no-mistakes
 The task is complete only when committed on your branch.
+Run the mapped focused validation slice from the Focused validation section and record its timing before appending \`done: {summary}\`; a slice that fails must be fixed before the pipeline starts.
 When you believe it is complete, append \`done: {summary}\` to the status file and stop.
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 
@@ -408,6 +415,20 @@ esac
 # $(...) command substitution used to strip. Drop that one newline so generated
 # briefs stay byte-identical to the historical Bash 5 output.
 DOD=${DOD%$'\n'}
+
+# Every ship brief carries the mapped focused-validation preflight (AGENTS.md
+# section 7). The full procedure, isolation proof, and file-to-test-family map
+# live in the focused-validation skill; this section is the worker-facing step
+# plus the one-line stop rule, and each mode's DOD above references it.
+IFS= read -r -d '' FOCUSED_VALIDATION_SECTION <<EOF || true
+# Focused validation
+Run the mapped focused validation slice for this change before reporting done, and record its timing.
+Map the touched files to the project's test surface: for firstmate-repo tasks run \`$FM_ROOT/bin/fm-test-run.sh --changed\` or the touched \`tests/<family>.test.sh\` scripts; for other projects use the focused test families that project's \`AGENTS.md\` names.
+The stop rule is an isolated and proven surface: the touched files resolve to one module and one test family, no shared middleware, config, deploy, or edge file, no external mutation, and existing focused tests cover the module and pass.
+An isolated and proven surface qualifies for the fast path only for \`direct-PR\` work inside the internal-only boundary; product-facing, mixed, and uncertain work still climbs to the full review.
+Follow \`$FM_ROOT/.agents/skills/focused-validation/SKILL.md\` for the ladder, the isolation proof, and the file-to-test-family map.
+EOF
+FOCUSED_VALIDATION_SECTION=${FOCUSED_VALIDATION_SECTION%$'\n'}
 
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
@@ -458,6 +479,8 @@ Record only project knowledge useful to almost every future session.
 For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
 If you touch a project \`AGENTS.md\` that lacks \`## Maintaining this file\`, add that short self-governance section from \`$FM_ROOT/bin/fm-ensure-agents-md.sh\` in the same pass.
 Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
+
+$FOCUSED_VALIDATION_SECTION
 
 $DOD
 EOF

--- a/bin/fm-project-mode.sh
+++ b/bin/fm-project-mode.sh
@@ -21,8 +21,9 @@
 #   direct-PR              push + PR via gh-axi, no pipeline
 #   local-only             local branch, no remote/PR, guarded local merge
 #   no-mistakes-prod-only  a conditional policy, not a task mode: firstmate
-#                          classifies each task's surface at intake (the
-#                          project-management skill owns that classification).
+#                          classifies each task's surface at intake (AGENTS.md
+#                          section 7 owns the boundary; the focused-validation
+#                          skill owns the classification procedure).
 #                          Mechanical output maps it to its most rigorous leg,
 #                          no-mistakes, so sync, seeding, and init treat such a
 #                          project as the remote-backed pipeline project it is.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -221,7 +221,7 @@ The `data/secondmates.md` line contract is owned by the [`secondmate-provisionin
 
 ## Delivery modes are explicit per task
 
-`no-mistakes` tasks run the full validation pipeline, `direct-PR` tasks open PRs without that pipeline, and `local-only` tasks stay local until firstmate performs an approved fast-forward merge.
+`no-mistakes` tasks run the full validation pipeline, `direct-PR` tasks open PRs with the mapped focused-validation preflight but without that pipeline, and `local-only` tasks stay local until firstmate performs an approved fast-forward merge.
 Each task's mode and `yolo` posture are firstmate's decision at intake and are passed explicitly to `bin/fm-brief.sh`, `bin/fm-spawn.sh`, and `bin/fm-promote.sh`, which refuse a ship task that does not carry them.
 A ship brief records its mode as a fixed machine-readable line and the spawn refuses to launch on a different one, so the worker's instructions and the recorded task delivery cannot diverge.
 `data/projects.md` records each project's standing posture and optional `+yolo` flag as the captain's default and as context for that decision, including the conditional `no-mistakes-prod-only` policy; a ship spawn that drops below the registered rigor prints a deviation notice and continues.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -153,6 +153,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/focused-validation/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/harness-adapters/SKILL.md",
       "audience": "agent-runtime"
     },

--- a/docs/examples/crew-dispatch.json
+++ b/docs/examples/crew-dispatch.json
@@ -1,26 +1,34 @@
 {
   "rules": [
     {
-      "when": "The task depends on fresh news, current events, live public facts, or recent market and product changes.",
-      "use": { "harness": "grok" },
-      "why": "Grok is the preferred dispatch when current web-connected context is central to the work."
+      "when": "The task's deliverable is a visible UI change, screenshot, layout check, or visual review, or the ship touches a rendered surface.",
+      "use": {
+        "harness": "pi",
+        "model": "opencode-go/gpt-5.6-luna",
+        "effort": "max"
+      },
+      "why": "Vision-capable Luna owns the visual surface; a UI-touching ship also gets a separate Luna visual-review worker under AGENTS.md section 7."
     },
     {
-      "when": "The task is a trivial mechanical edit such as a rote rename, formatting sweep, targeted typo fix, or simple file gathering.",
-      "use": { "harness": "claude", "model": "haiku", "effort": "low" },
-      "why": "Use the cheapest fast profile when the task is narrow and low ambiguity."
+      "when": "The task is bounded non-visual implementation, tests, tooling, automation, a routine mechanical edit, or a well-understood operational check that can be verified without a rendered surface.",
+      "use": {
+        "harness": "pi",
+        "model": "opencode-go/deepseek-v4-flash",
+        "effort": "max"
+      },
+      "why": "DeepSeek Flash is the default for bounded non-visual work: cheap and no vision needed. Verify the current model name in the harness catalog at dispatch."
     },
     {
       "when": "The task is a big or ambiguous multi-file feature, a risky refactor, or work that requires holding many moving parts in mind.",
       "use": [
-        { "harness": "claude", "model": "claude-sonnet-5", "effort": "high" },
+        { "harness": "pi", "model": "opencode-go/gpt-5.6-luna", "effort": "max" },
         { "harness": "codex", "model": "gpt-5.5", "effort": "high" }
       ],
-      "why": "Use a strong coding profile for big, ambiguous work; resolve the alternatives through quota-array-dispatch."
+      "why": "Use a strong coding profile for big, ambiguous work; resolve the alternatives through quota-array-dispatch. Sol is explicit-only, never automatic."
     }
   ],
   "default": [
-    { "harness": "codex", "model": "gpt-5.5", "effort": "medium" },
-    { "harness": "pi", "model": "anthropic/claude-sonnet-5", "effort": "medium" }
+    { "harness": "pi", "model": "opencode-go/gpt-5.6-luna", "effort": "max" },
+    { "harness": "codex", "model": "gpt-5.5", "effort": "medium" }
   ]
 }

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -50,6 +50,8 @@ test_focused_validation_preflight_in_ship_briefs() {
       "$mode brief leaks a literal unexpanded FM_ROOT test-run path"
     assert_grep "tests/<family>.test.sh" "$brief" "$mode brief lost the direct test-script map"
     assert_grep "isolated and proven" "$brief" "$mode brief lost the stop rule"
+    assert_grep "work outside that boundary still climbs to the full review" "$brief" \
+      "$mode brief lost the outside-the-boundary full-review rule"
     assert_grep "$ROOT/.agents/skills/focused-validation/SKILL.md" "$brief" \
       "$mode brief lost the focused-validation skill pointer"
   done
@@ -58,8 +60,8 @@ test_focused_validation_preflight_in_ship_briefs() {
     "no-mistakes DOD lost the preflight-before-pipeline rule"
   assert_grep "it is the review for this fast path" "$home/data/fv-directpr/brief.md" \
     "direct-PR DOD lost the focused-validation-as-review rule"
-  assert_grep "product-facing, mixed, or uncertain" "$home/data/fv-directpr/brief.md" \
-    "direct-PR DOD lost the internal-only escalation boundary"
+  assert_grep "outside the internal-only boundary defined in" "$home/data/fv-directpr/brief.md" \
+    "direct-PR DOD lost the internal-only escalation boundary pointer"
   assert_grep "before appending \`done: ready in branch\`" "$home/data/fv-localonly/brief.md" \
     "local-only DOD lost the preflight-before-ready rule"
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -22,6 +22,50 @@ TMP_ROOT=$(fm_test_tmproot fm-brief)
 BRIEF_HOME="$TMP_ROOT/home"
 mkdir -p "$BRIEF_HOME/data"
 
+# Every ship brief carries the mapped focused-validation preflight (AGENTS.md
+# section 7) in all three delivery modes: the worker-facing step, the stop rule,
+# the file-to-test-family map, and the skill pointer. Each mode's DOD references
+# the shared section without restating it, and scout briefs never carry the
+# section because their deliverable is a report, not a ship.
+test_focused_validation_preflight_in_ship_briefs() {
+  local home id mode brief
+  home="$TMP_ROOT/focused-validation-home"
+  mkdir -p "$home/data"
+
+  for id_mode in "fv-nomistakes:no-mistakes" "fv-directpr:direct-PR" "fv-localonly:local-only"; do
+    id=${id_mode%%:*}
+    mode=${id_mode#*:}
+    FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+      "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1 \
+      || fail "fm-brief.sh $id --mode $mode should exit 0"
+    brief="$home/data/$id/brief.md"
+    assert_grep "# Focused validation" "$brief" "$mode brief missing the focused-validation section"
+    assert_grep "record its timing" "$brief" "$mode brief lost the timing record requirement"
+    assert_grep "$ROOT/bin/fm-test-run.sh --changed" "$brief" \
+      "$mode brief lost the firstmate-repo file-to-test-family map"
+    assert_grep "tests/<family>.test.sh" "$brief" "$mode brief lost the direct test-script map"
+    assert_grep "isolated and proven" "$brief" "$mode brief lost the stop rule"
+    assert_grep "$ROOT/.agents/skills/focused-validation/SKILL.md" "$brief" \
+      "$mode brief lost the focused-validation skill pointer"
+  done
+
+  assert_grep "before the pipeline starts" "$home/data/fv-nomistakes/brief.md" \
+    "no-mistakes DOD lost the preflight-before-pipeline rule"
+  assert_grep "it is the review for this fast path" "$home/data/fv-directpr/brief.md" \
+    "direct-PR DOD lost the focused-validation-as-review rule"
+  assert_grep "product-facing, mixed, or uncertain" "$home/data/fv-directpr/brief.md" \
+    "direct-PR DOD lost the internal-only escalation boundary"
+  assert_grep "before appending \`done: ready in branch\`" "$home/data/fv-localonly/brief.md" \
+    "local-only DOD lost the preflight-before-ready rule"
+
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    "$ROOT/bin/fm-brief.sh" fv-scout alpha --scout >/dev/null 2>&1 \
+    || fail "fm-brief.sh scout scaffold should exit 0"
+  assert_no_grep "# Focused validation" "$home/data/fv-scout/brief.md" \
+    "scout brief must not carry the ship-only focused-validation section"
+  pass "fm-brief.sh: ship briefs carry the mapped focused-validation preflight in every mode"
+}
+
 # The script itself must always parse under the ambient bash. That is Bash 5 in
 # CI and locally, where the issue #958/#1069 parser bug does not fire, so this
 # is a weak guard on its own; test_no_heredoc_in_command_substitution and the
@@ -714,6 +758,7 @@ test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
+test_focused_validation_preflight_in_ship_briefs
 test_ship_mode_is_required_and_closed_set
 test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -41,8 +41,13 @@ test_focused_validation_preflight_in_ship_briefs() {
     brief="$home/data/$id/brief.md"
     assert_grep "# Focused validation" "$brief" "$mode brief missing the focused-validation section"
     assert_grep "record its timing" "$brief" "$mode brief lost the timing record requirement"
-    assert_grep "$ROOT/bin/fm-test-run.sh --changed" "$brief" \
+    assert_grep "bin/fm-test-run.sh --changed" "$brief" \
       "$mode brief lost the firstmate-repo file-to-test-family map"
+    assert_no_grep "$ROOT/bin/fm-test-run.sh" "$brief" \
+      "$mode brief points firstmate-repo workers at the primary checkout's test runner"
+    # shellcheck disable=SC2016  # literal $FM_ROOT must stay unexpanded in the grep pattern
+    assert_no_grep '$FM_ROOT/bin/fm-test-run.sh' "$brief" \
+      "$mode brief leaks a literal unexpanded FM_ROOT test-run path"
     assert_grep "tests/<family>.test.sh" "$brief" "$mode brief lost the direct test-script map"
     assert_grep "isolated and proven" "$brief" "$mode brief lost the stop rule"
     assert_grep "$ROOT/.agents/skills/focused-validation/SKILL.md" "$brief" \


### PR DESCRIPTION
## Intent

Implement the approved feature-first validation operating model in Firstmate's shared tracked surface.

Acceptance criteria:
- Make a mapped focused validation slice the default preflight before a full review, with a clear stop rule when the changed surface is isolated and proven.
- Encode that independent workers have no artificial concurrency cap, while preserving explicit serialization for the same branch or head, mutable database, fixed port or compose project, production or edge state, shared gate daemon, and shared tracked surface.
- Encode that every UI-touching ship receives a separate Luna visual-review worker, while bounded non-visual implementation and test work defaults to DeepSeek Flash.
- Retain per-run test isolation indefinitely and replace the warm-stack recommendation with isolation-preserving optimizations such as deterministic fixtures, immutable dependency or image caches, focused health checks, and unique writable test artifacts.
- Keep the full no-mistakes review for production-facing, mixed, security-sensitive, edge, deployment, and uncertain work, and document scheduling around daemon-update windows rather than removing that gate.
- Preserve the approved ESIM boundary: direct-PR with focused validation is limited to internal tooling, automation, scripts, and operator process; product-facing or uncertain changes remain on the full path.
- Place each rule in its authoritative owner rather than duplicating contracts across AGENTS.md, skills, briefs, and docs.
- Add or update executable regression coverage for any changed script or enforceable behavior, following firstmate-coding-guidelines.
- Run the relevant focused tests, documentation audience checks, shell lint, and repository validation before handing the branch to the no-mistakes pipeline.

Constraints:
- Load firstmate-coding-guidelines before editing shared tracked material.
- Do not modify captain-private config files, projects/, or unrelated operational policy.
- Do not add a visual review worker for this non-UI policy task.
- Keep all implementation and evidence in this isolated Firstmate worktree and commit the result on the task branch.

## What Changed

- Adds `.agents/skills/focused-validation/SKILL.md` as the single procedure owner for the feature-first validation model (mapped focused-validation slice, isolated-and-proven stop rule, internal-only fast-path boundary, isolation-preserving optimizations) and makes `AGENTS.md` section 7 the always-loaded contract: every ship runs a mapped preflight with recorded timing, direct-PR stays limited to internal-only work, the full no-mistakes review remains the gate for product-facing, mixed, security-sensitive, edge, deployment, and uncertain work, daemon-update windows are avoided for scheduling, and UI-touching ships get a separate vision-capable (Luna) visual-review worker while bounded non-visual work defaults to DeepSeek Flash.
- `bin/fm-brief.sh` now emits a shared `# Focused validation` section (worker-facing step, `bin/fm-test-run.sh --changed` / `tests/<family>.test.sh` file-to-test-family map, stop rule, and skill pointer) in every ship brief for all three delivery modes, with each mode's definition-of-done requiring the slice and its timing before completion; `bin/fm-project-mode.sh`, `.agents/skills/project-management/SKILL.md`, `docs/architecture.md`, and `docs/examples/crew-dispatch.json` were updated to match the new boundary and dispatch semantics.
- Adds regression coverage in `tests/fm-brief.test.sh` asserting the focused-validation section, stop rule, map, and skill pointer appear in no-mistakes, direct-PR, and local-only briefs (with mode-specific DOD rules) and never in scout briefs, and registers the new skill in `docs/documentation-audiences.json`.

## Risk Assessment

✅ Low: The change is a policy-documentation and brief-scaffold rollout with the round-1 warning fixed exactly per the user's option-B instruction (boundary deferred to the authoritative skill, six-category list preserved in AGENTS.md and the skill), with matching regression coverage and no runtime code paths altered beyond generated brief text.

## Testing

Ran the two focused test files covering the changed executable surface (tests/fm-brief.test.sh with the new preflight test, and tests/fm-documentation-audiences.test.sh exercising the real audience-check consumer), plus the dispatch-profile plumbing test; all pass. Demonstrated end-to-end by generating real ship briefs in all three delivery modes (evidence: brief-directpr.md, generated-briefs-modes.txt), running bin/fm-test-run.sh --changed against this branch's base to show the mapped slice selecting the exact test families, confirming the new skill's frontmatter loads in the real harness consumer, parsing crew-dispatch.json, and grepping for stale warm-stack or contradictory text (none found). Worktree left clean; no failures or missing evidence.

<details>
<summary>Evidence: Generated direct-PR ship brief with focused-validation section and DOD</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of some-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/demo-directpr`

# Rules
1. Never push to the default branch (push only your `fm/demo-directpr` branch). Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/fv-demo-home.SUKw6C/state/demo-directpr.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/andrzej/.no-mistakes/worktrees/f17d52d226fc/01KZKA5M1N4KWHX693H5BVA048/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/andrzej/.no-mistakes/worktrees/f17d52d226fc/01KZKA5M1N4KWHX693H5BVA048/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Focused validation
Run the mapped focused validation slice for this change before reporting done, and record its timing.
Map the touched files to the project's test surface: for firstmate-repo tasks run `bin/fm-test-run.sh --changed` from the worktree root or the touched `tests/<family>.test.sh` scripts; for other projects use the focused test families that project's `AGENTS.md` names.
The stop rule is an isolated and proven surface: the touched files resolve to one module and one test family, no shared middleware, config, deploy, or edge file, no external mutation, and existing focused tests cover the module and pass.
An isolated and proven surface qualifies for the fast path only for `direct-PR` work inside the internal-only boundary; work outside that boundary still climbs to the full review.
Follow `/home/andrzej/.no-mistakes/worktrees/f17d52d226fc/01KZKA5M1N4KWHX693H5BVA048/.agents/skills/focused-validation/SKILL.md` for the internal-only boundary, the ladder, the isolation proof, and the file-to-test-family map.

# Definition of done
Delivery contract: mode=direct-PR
This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
Run the mapped focused validation slice from the Focused validation section and record its timing before pushing; it is the review for this fast path.
If the changed surface is not isolated and proven under the stop rule, or the slice fails, fix within the task - or append `needs-decision` instead of pushing when the surface turns out to fall outside the internal-only boundary defined in `/home/andrzej/.no-mistakes/worktrees/f17d52d226fc/01KZKA5M1N4KWHX693H5BVA048/.agents/skills/focused-validation/SKILL.md`.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
```
</details>
<details>
<summary>Evidence: no-mistakes and local-only DOD preflight rules + scout exclusion</summary>

```text
=== no-mistakes DOD ===
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
Run the mapped focused validation slice from the Focused validation section and record its timing before appending `done: {summary}`; a slice that fails must be fixed before the pipeline starts.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

=== local-only DOD ===
Delivery contract: mode=local-only
This task ships **local-only**: no remote, no PR, no pipeline.
The task is complete only when committed on your branch `fm/demo-localonly`. Do NOT push, do NOT open a PR, do NOT merge.
Run the mapped focused validation slice from the Focused validation section and record its timing before appending `done: ready in branch`.
Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
When it is implemented and committed, append `done: ready in branch fm/demo-localonly` to the status file and stop.
The configured merge authority approves the ready branch, then firstmate merges it into local `main` through the guarded fast-forward path.
=== scout: section absence ===
0
0 (absent, expected)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-brief.sh:367` - The direct-PR DOD&#39;s escalation clause and the brief&#39;s Focused validation section (line 428) name only &#34;product-facing, mixed, or uncertain&#34; as surfaces that must leave the fast path, while the accepted boundary (AGENTS.md:277, AGENTS.md:333, focused-validation SKILL.md:43) also requires the full no-mistakes review for security-sensitive, edge, and deployment work. A direct-PR worker whose surface turns out security-sensitive, edge, or deployment gets no escalation instruction — the DOD says to &#34;fix within the task&#34; and push, so a task misclassified at intake can ship without the full review the intent requires; the full list is only one pointer hop away in the skill, not in the operative DOD. Recommend naming the full six-category boundary in the DOD escalation clause (or explicitly deferring the list there).
- ℹ️ `docs/examples/crew-dispatch.json:7` - The example dispatch profiles name concrete model IDs (opencode-go/gpt-5.6-luna at line 7/24/31, opencode-go/deepseek-v4-flash at line 16) that are not verified against any in-repo harness catalog, and the third rule&#39;s why (line 27) asserts &#34;Sol is explicit-only, never automatic&#34; without defining Sol anywhere in the repository. Staleness is hedged in the why text (&#34;verify the current model name in the harness catalog at dispatch&#34;) and by AGENTS.md:261, and the example is not consumed by bootstrap validation, so a stale copy fails closed at the real config with a CREW_DISPATCH invalid error rather than silently dispatching. Informational.
- ℹ️ `AGENTS.md:502` - Section 11 now claims every ship brief carries the scaffolded focused-validation preflight section, but scout-promoted ships keep their scout brief (bin/fm-promote.sh only rewrites task meta; it never re-scaffolds the brief), and the promotion follow-up message template at bin/fm-promote.sh:125 does not mention the preflight. The always-loaded AGENTS.md section 7 requirement still covers firstmate when composing the steer, so the requirement is not lost, but the scaffolded reminder channel is absent on the promotion path; consider mentioning the mapped preflight in the promote follow-up template.

🔧 Fix: Defer brief escalation boundary to focused-validation skill
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-brief.test.sh` - full file incl. new test_focused_validation_preflight_in_ship_briefs (section present in all 3 ship modes, timing + map + stop rule + skill pointer, mode-specific DOD rules, scout brief excludes section, no primary-checkout path leak); 21 checks pass</code>
- <code>`bash tests/fm-documentation-audiences.test.sh` - real fm-doc-audience-check.sh consumer accepts docs/documentation-audiences.json with the new .agents/skills/focused-validation/SKILL.md entry; all pass</code>
- <code>`bash tests/fm-spawn-dispatch-profile.test.sh` - harness profile plumbing (pi receives --model/--thinking max; opencode model flags) underpinning the Luna/DeepSeek Flash example rules; all pass</code>
- <code>End-to-end brief generation: `bin/fm-brief.sh &lt;id&gt; some-proj --mode direct-PR|no-mistakes|local-only` and `--scout` under a demo FM_HOME - captured real generated brief sections as evidence (direct-PR DOD: preflight is &#39;the review for this fast path&#39; with needs-decision escalation; no-mistakes DOD: slice must pass &#39;before the pipeline starts&#39;; local-only DOD: preflight before `done: ready in branch`; scout brief has no section)</code>
- <code>`bin/fm-test-run.sh --changed --base 74230fcd --list` - the mapped focused slice resolves this branch&#39;s diff to tests/fm-brief.test.sh, tests/fm-documentation-audiences.test.sh, and related families (the exact families run here)</code>
- `Skill frontmatter validated by the real consumer: the pi harness parsed .agents/skills/focused-validation/SKILL.md at session start and exposed it as an available skill with its description (name/user-invocable/metadata.internal correct)`
- <code>`python3 json.load` on docs/examples/crew-dispatch.json - valid JSON; rules encode the separate Luna visual-review worker for UI-touching ships and DeepSeek Flash default for bounded non-visual work</code>
- `Repo-wide grep: no stale warm-stack recommendation anywhere; AGENTS.md section 7 text encodes the serialization list (same branch/head, mutable DB, fixed port/compose, prod/edge state, shared gate daemon, shared tracked surface), no-artificial-cap dispatch, internal-only ESIM boundary, and daemon-update-window scheduling rule`

</details>

<details>
<summary>⚠️ **Document** - 2 infos</summary>

- ℹ️ `docs/examples/crew-dispatch.json:31` - The big-ambiguous-work rule&#39;s `why` ends with &#34;Sol is explicit-only, never automatic&#34;, but no profile in the file names a Sol model and neither AGENTS.md section 7 nor the Luna/DeepSeek Flash routing contract mentions it; it reads as fleet-specific shorthand with no owner or pointer, so a future session cannot tell whether it is load-bearing guidance or a leftover note. This is fresh content of the change itself, not a fact the change made stale, so I left it untouched per scope discipline.
- ℹ️ `.agents/skills/focused-validation/SKILL.md:27` - The skill says the changed-file map is &#34;owned by that script&#39;s header&#34;, while bin/fm-test-run.sh&#39;s header declares ownership and the map implementation lives in families_for_changed_path() in the body; harmless shorthand, not stale, left as-is.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
