### PR TITLE
fix(bin): reconcile Herdr-authoritative idle against stale Firstmate busy records

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2901,6 +2901,35 @@ fm_backend_herdr_busy_state() {  # <target>
     "$(fm_backend_herdr_agent_status_raw "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")"
 }
 
+# fm_backend_herdr_authoritative_state: the busy|idle|unknown verdict from
+# herdr's agent-state ONLY when it is owned by a verified full-lifecycle
+# integration (e.g. herdr:pi), where idle and blocked are turn-state
+# authoritative rather than a screen-detection guess. Herdr reports
+# screen_detection_skipped=true together with an agent_session.source that names
+# the lifecycle integration exactly when that integration holds full-lifecycle
+# authority; a screen-detected or generic agent has neither. Every other case -
+# a missing/unreadable read, screen-detected status, or an unknown source -
+# returns unknown, so the caller keeps the conservative rule that a generic idle
+# is NOT trusted (a long foreground tool call reads idle). This is the reader
+# side of the authoritative idle-vs-stale-busy reconciliation; the writer side
+# is the per-task Pi extension's session_start reconciliation. Verified against
+# herdr 0.8.0 + pi integration v8 (docs/verification/supervision.md).
+fm_backend_herdr_authoritative_state() {  # <target>
+  fm_backend_herdr_target_ready "$1" || { printf 'unknown'; return 0; }
+  local out skipped source status
+  out=$(fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" agent get "$FM_BACKEND_HERDR_PANE" 2>/dev/null) \
+    || { printf 'unknown'; return 0; }
+  skipped=$(printf '%s' "$out" | jq -r '.result.agent.screen_detection_skipped // empty' 2>/dev/null)
+  source=$(printf '%s' "$out" | jq -r '.result.agent.agent_session.source // empty' 2>/dev/null)
+  status=$(printf '%s' "$out" | jq -r '.result.agent.agent_status // empty' 2>/dev/null)
+  case "$source" in
+    herdr:*) : ;;
+    *) printf 'unknown'; return 0 ;;
+  esac
+  [ "$skipped" = true ] || { printf 'unknown'; return 0; }
+  fm_backend_herdr_classify_agent_status "$status"
+}
+
 # fm_backend_herdr_wait_for_working: poll <session>:<pane_id>'s NATIVE
 # agent-state (agent get) up to <polls> times spread evenly across
 # <budget-seconds>, returning on stdout the STRONGEST signal observed:

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -793,6 +793,22 @@ fm_backend_busy_state() {  # <backend> <target>
   esac
 }
 
+# fm_backend_authoritative_state: busy|idle|unknown from a backend's VERIFIED
+# full-lifecycle integration only (not screen detection or pane-regex). The
+# busy-state contract (bin/fm-busy-lib.sh) uses this to reconcile a stale
+# firstmate busy record against an authoritative live lifecycle observation.
+# Backends without such an integration return unknown, so their behavior is
+# unchanged.
+fm_backend_authoritative_state() {  # <backend> <target>
+  local backend=$1
+  shift
+  fm_backend_source "$backend" || { printf 'unknown'; return 0; }
+  case "$backend" in
+    herdr) fm_backend_herdr_authoritative_state "$@" ;;
+    *) printf 'unknown' ;;
+  esac
+}
+
 # fm_backend_composer_state: classify the composer/input area of <target> as
 # empty|pending|pending-unproven|unknown for callers that need a pre-submit
 # input guard, a submit acknowledgement, or a launch-readiness check. It is

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -41,18 +41,28 @@
 # Classifier-only sources (never written into a record):
 #   endpoint-gone, herdr-native, grok-regex, muse-session-log, missing,
 #   malformed, gen-mismatch, source-mismatch, kimi-unverified,
-#   codex-unverified, capture-failed, no-target
+#   codex-unverified, capture-failed, no-target,
+#   <backend>-idle-stale-busy (the conflict verdict below)
 #
-# Classification (fm_busy_classify): busy | idle | unknown | dead, always
-# with the producing source as the second token. Precedence:
+# Classification (fm_busy_classify): busy | idle | unknown | dead | conflict,
+# always with the producing source as the second token. Precedence:
 #   1. dead endpoint (fm_busy_classify_live only) -> dead endpoint-gone
 #   2. standalone Kimi before verification       -> unknown kimi-unverified
-#   3. a valid, gen-matching, source-trusted record -> its state and source
+#   3. a valid, gen-matching, source-trusted record; EXCEPT a busy record that a
+#      verified full-lifecycle backend integration contradicts with a live idle
+#      observation is stale and yields `conflict <backend>-idle-stale-busy`
+#      (fm_backend_authoritative_state; the reader never reports that as busy,
+#      it reconciles against the task's terminal result). Otherwise the record's
+#      own state and source.
 #   4. no record at all: herdr's native busy verdict is trusted as busy
 #      (generation state is sufficient for busy, not for idle), then the
 #      muse session-log pull source, then the Grok-only temporary regex fallback
 #      classifies a grok task from its rendered tail, then unknown missing
 #   5. malformed, stale, or untrusted records -> unknown, never a fallback
+# The conflict verdict is the ONLY place a valid record is overridden, and only
+# by an authoritative lifecycle idle - never by a fixed busy TTL, and never for
+# screen-detected / generic / non-lifecycle backends (they return unknown, so a
+# long foreground tool call that reads idle can never force a false conflict).
 # The Grok arm is the ONLY rendered-text classification that survives the
 # redesign, because Grok's structured lifecycle was not credited-live-verified
 # in the approved audit; it is scoped to harness=grok and can never classify
@@ -632,11 +642,30 @@ fm_busy_classify() {  # <backend> <target> <harness> <id> <state-dir> [tail40]
     r_state=${out%% *}
     out=${out#* }
     r_source=${out%% *}
-    if fm_busy_source_trusted "$harness" "$r_source"; then
-      printf '%s %s' "$r_state" "$r_source"
-    else
+    if ! fm_busy_source_trusted "$harness" "$r_source"; then
       printf 'unknown source-mismatch'
+      return 0
     fi
+    # Authoritative reconciliation: a valid busy record that a VERIFIED
+    # full-lifecycle backend integration contradicts with a live idle
+    # observation is stale (e.g. a Pi /reload replaced the per-task extension
+    # mid-run so the settle was never recorded). Never report that as busy:
+    # emit a deterministic conflict verdict so the current-state reader
+    # reconciles it against the task's terminal result instead of trusting the
+    # stale record. fm_backend_authoritative_state returns unknown for
+    # screen-detected / generic / non-lifecycle backends, so the conservative
+    # rule (a long foreground tool call can read idle) is preserved and no
+    # fixed busy TTL is used - only the authoritative lifecycle observation
+    # triggers the contradiction.
+    if [ "$r_state" = busy ] && command -v fm_backend_authoritative_state >/dev/null 2>&1; then
+      local auth
+      auth=$(fm_backend_authoritative_state "$backend" "$target" 2>/dev/null || true)
+      if [ "$auth" = idle ]; then
+        printf 'conflict %s-idle-stale-busy' "$backend"
+        return 0
+      fi
+    fi
+    printf '%s %s' "$r_state" "$r_source"
     return 0
   fi
   case "$out" in

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -445,9 +445,12 @@ do_exit() {
     missing) die "task $ID's recorded endpoint is gone, so there is no agent to stop; reconcile the task before any further control action" ;;
     *) die "task $ID's endpoint reads '$state' rather than a positively classified state; refusing to send a lifecycle command into an unattributed endpoint" ;;
   esac
-  # A busy agent is interrupted first before the exit command is submitted.
+  # A busy agent - or one whose still-busy record an authoritative live idle
+  # contradicts (a conflict verdict, e.g. a Pi worker blocked on a dialog whose
+  # stale busy seed never settled) - is interrupted first: the cancelling key
+  # must land before the exit command is typed, or an open modal can swallow it.
   case "$(busy_verdict)" in
-    busy*)
+    busy*|conflict*)
       cancel=$(deliver_interrupt) || return $?
       state=$(agent_state)
       case "$state" in

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -154,12 +154,15 @@ pane_readable() {  # <target>
   esac
 }
 # crew_busy_verdict: the crew's semantic busy state from the one contract
-# owner (bin/fm-busy-lib.sh), as "<busy|idle|unknown> <source>". A converted
-# adapter answers from its own lifecycle record; Grok answers from its
+# owner (bin/fm-busy-lib.sh), as "<busy|idle|unknown|conflict> <source>". A
+# converted adapter answers from its own lifecycle record; Grok answers from its
 # isolated rendered-tail fallback; a herdr crew's native `busy` is accepted
 # when no record exists, but its native `idle` is NOT, because agent.get
 # reports generation state (idle while a crew blocks on its own long-running
-# foreground tool call) rather than turn state.
+# foreground tool call) rather than turn state. The one exception is `conflict`:
+# a busy record that a verified full-lifecycle integration contradicts with a
+# live idle observation is stale, and the consumer below reconciles it against
+# the task's terminal result rather than reporting working.
 crew_busy_verdict() {  # <target>
   local tail40=''
   case "$HARNESS" in
@@ -549,6 +552,22 @@ if [ "$KIND" != secondmate ]; then
   case "${BUSY_VERDICT%% *}" in
     busy) emit working pane "harness busy (${BUSY_VERDICT#* })" ;;
     idle) ;;
+    conflict)
+      # An authoritative full-lifecycle idle observation contradicts a still-busy
+      # firstmate record: the crew has settled and the busy record is stale (see
+      # fm-busy-lib.sh). NEVER report working. An idle/done agent is not
+      # automatically a completed task, so reconcile against the durable terminal
+      # or external-wait status first; if the task carries none, surface a
+      # deterministic incomplete-idle so supervision continues or recovers it
+      # instead of trusting the stale busy record.
+      if [ -n "$LOG_VERB" ]; then
+        CONFLICT_LOG_STATE=$(map_log_state "$LOG_LINE")
+        case "$CONFLICT_LOG_STATE" in
+          done|failed|paused|parked|blocked)
+            emit "$CONFLICT_LOG_STATE" status-log "$(status_line_note "$LOG_LINE")${SEP}authoritative idle reconciled (${BUSY_VERDICT#* })" ;;
+        esac
+      fi
+      emit unknown pane "incomplete-idle: authoritative idle contradicts a stale busy record (${BUSY_VERDICT#* }); no terminal result - continue or recover" ;;
     *) emit unknown pane "harness state unavailable ($BUSY_VERDICT)" ;;
   esac
 fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2342,29 +2342,121 @@ EOF
       # loaded from inside the project (verified live), but an explicit -e path
       # elsewhere loads without a dialog. Lives in state/, cleaned by teardown.
       cat > "$STATE/$ID.pi-ext.ts" <<EOF
-// Firstmate semantic busy-state events + turn-end notification; written by
-// fm-spawn under the contract owned by bin/fm-busy-lib.sh.
-// Semantic state: "agent_start" -> busy when a low-level agent run begins;
-// "agent_settled" -> idle only when ctx.isIdle() confirms Pi will not
-// continue automatically - auto-retries, auto-compaction retries, tool
-// loops, and queued continuations all keep the run un-settled, and a settle
-// that raced another extension's fresh run keeps state busy via isIdle().
-// "turn_end" fires at every inner turn boundary (one LLM response plus its
-// tool calls) and stays a wake NOTIFICATION touch for the watcher, never
-// current-state truth.
+// Firstmate semantic busy-state events + turn-end notification + question wait
+// signal; written by fm-spawn under the contract owned by bin/fm-busy-lib.sh.
+//
+// Turn lifecycle (busy-state record via fm-busy-event.sh, source pi-ext):
+//   agent_start   -> busy   a low-level agent run began.
+//   agent_settled -> idle   only when ctx.isIdle() confirms Pi will not continue
+//                           automatically - auto-retries, auto-compaction retries,
+//                           tool loops, and queued continuations keep the run
+//                           un-settled, and a settle that raced another
+//                           extension's fresh run stays busy via isIdle().
+//   session_start(reason != "startup") -> reconcile from ctx.isIdle(). A /reload
+//                           or other session replacement re-loads this extension
+//                           WITHOUT a paired agent_start/agent_settled for the
+//                           pre-existing run (Pi 0.84.1 emits session_shutdown
+//                           then session_start reason=reload with no agent_settled),
+//                           so a reload that lands while the record is busy but the
+//                           agent is actually idle would otherwise leave a
+//                           permanently stale busy record. reason "startup" is
+//                           skipped: the arm already seeded busy for the launch
+//                           brief and agent_start follows. Mirrors the herdr:pi
+//                           integration's own session_start reconciliation.
+// Every apply is serialized through one in-process queue so two events firing
+// close together can never be applied to the record out of order.
+//
+// turn_end stays a wake NOTIFICATION touch for the watcher, never current state.
+//
+// herdr:blocked: Pi 0.84.1 exposes no generic dialog lifecycle event and no
+// installed package emits the shared herdr:blocked event the herdr pi integration
+// listens for, so an interactive question/approval wait (ctx.ui confirm/select/
+// input/editor/custom, including MCP tool approval and elicitation) is invisible
+// to both herdr and firstmate while full-lifecycle authority suppresses herdr
+// screen detection. ctx.ui is ONE shared object for every extension and tool in
+// the session, so wrapping its dialog methods is the single truthful integration
+// point: it emits herdr:blocked(active) exactly while a real dialog is open and
+// clears it when the dialog resolves, cancels, or throws. Only a non-sensitive
+// category label (the method name) ever leaves the worker UI - never the title,
+// body, arguments, or entered values. Detection and relay only; the question is
+// never answered here.
 import { execFile } from "node:child_process";
-const busyEvent = (state: string, event: string) =>
+const applyBusy = (state: string, event: string) =>
   new Promise<void>((resolve) => {
     execFile("$FM_ROOT/bin/fm-busy-event.sh", [
       "apply", "$STATE_REAL", "$ID", state,
       "--gen", "$BUSY_GEN", "--source", "pi-ext", "--event", event,
     ], () => resolve());
   });
+let busyInFlight = false;
+const busyQueue: Array<[string, string, () => void]> = [];
+async function drainBusyQueue(): Promise<void> {
+  if (busyInFlight) return;
+  busyInFlight = true;
+  try {
+    while (busyQueue.length) {
+      const next = busyQueue.shift();
+      if (next) { await applyBusy(next[0], next[1]); next[2](); }
+    }
+  } finally {
+    busyInFlight = false;
+    if (busyQueue.length) void drainBusyQueue();
+  }
+};
+// Serialize every apply through one queue so two events firing close together
+// can never be applied out of order; the returned promise resolves when THIS
+// event's apply has landed so a handler can await it.
+const busyEvent = (state: string, event: string): Promise<void> =>
+  new Promise<void>((resolve) => {
+    busyQueue.push([state, event, resolve]);
+    void drainBusyQueue();
+  });
+const paneIdle = (ctx: any): boolean | undefined => {
+  if (!ctx || typeof ctx.isIdle !== "function") return undefined;
+  try { return ctx.isIdle() === true; } catch { return undefined; }
+};
+const emitBlocked = (pi: any, active: boolean, label: string) => {
+  try { pi.events?.emit?.("herdr:blocked", { active, label }); } catch {}
+};
+const DIALOG_METHODS = ["confirm", "select", "input", "editor", "custom"];
+const wrapDialogs = (pi: any, ui: any) => {
+  if (!ui || ui.__fmBlockedWrapped) return;
+  for (const method of DIALOG_METHODS) {
+    const original = ui[method];
+    if (typeof original !== "function") continue;
+    ui[method] = function (this: any, ...args: any[]) {
+      emitBlocked(pi, true, method);
+      let cleared = false;
+      const clear = () => { if (!cleared) { cleared = true; emitBlocked(pi, false, method); } };
+      let result: any;
+      try {
+        result = original.apply(this, args);
+      } catch (err) {
+        clear();
+        throw err;
+      }
+      if (result && typeof result.then === "function") {
+        return result.then((v: any) => { clear(); return v; }, (e: any) => { clear(); throw e; });
+      }
+      clear();
+      return result;
+    };
+  }
+  try { Object.defineProperty(ui, "__fmBlockedWrapped", { value: true, enumerable: false }); }
+  catch { ui.__fmBlockedWrapped = true; }
+};
 export default function (pi: any) {
-  pi.on("agent_start", () => busyEvent("busy", "agent-start"));
+  pi.on("agent_start", (_event: any, ctx: any) => { wrapDialogs(pi, ctx?.ui); return busyEvent("busy", "agent-start"); });
   pi.on("agent_settled", (_event: any, ctx: any) => {
-    if (ctx && typeof ctx.isIdle === "function" && !ctx.isIdle()) return;
+    if (paneIdle(ctx) === false) return;
     return busyEvent("idle", "agent-settled");
+  });
+  pi.on("session_start", (event: any, ctx: any) => {
+    wrapDialogs(pi, ctx?.ui);
+    if (!event || event.reason === "startup") return;
+    const idle = paneIdle(ctx);
+    if (idle === true) return busyEvent("idle", "session-reconcile");
+    if (idle === false) return busyEvent("busy", "session-reconcile");
   });
   pi.on("turn_end", () => execFile("touch", ["$TURNEND"]));
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -101,7 +101,7 @@ Text for a worker to read and commands that drive a worker's process are separat
 ## Busy state is semantic, per adapter
 
 `bin/fm-busy-lib.sh` is the single owner of what "this worker is busy" means, and `bin/fm-busy-event.sh` is the only writer of the per-task records it reads.
-Every classification returns a verdict of busy, idle, unknown, or dead together with the source that produced it, so a consumer or a diagnostic can never confuse semantic state with a fallback.
+Every classification returns a verdict of busy, idle, unknown, dead, or conflict together with the source that produced it, so a consumer or a diagnostic can never confuse semantic state with a fallback.
 
 Each converted adapter reports its own turn lifecycle through a machine-readable contract the vendor already exposes, rather than through rendered footer text: Pi and pi-signed through the Firstmate-owned extension's `agent_start` and `agent_settled` confirmed by `ctx.isIdle()`, OpenCode through its plugin's semantic `session.status`, and Claude through owned `UserPromptSubmit`, `Stop`, `StopFailure`, and `SessionEnd` hooks.
 Kimi behind Pi inherits Pi's lifecycle.
@@ -127,6 +127,7 @@ Unknown backend names fail loudly.
 For compatibility, default tmux tasks do not write `backend=tmux`; every reader treats a missing `backend=` field as `tmux`.
 `fm-watch.sh` decides each window's busy state through the semantic contract above rather than by polling the backend for rendered text.
 Herdr's native `agent.get` verdict still participates, but only as evidence of activity: a native `busy` is accepted when the task has no record of its own, while a native `idle` is not, because `agent.get` reports generation state and reads idle while a worker blocks on its own long-running foreground tool call.
+A verified full-lifecycle integration (such as `herdr:pi`) is the one exception: its idle is turn-state authoritative and reconciles a stale busy record into a `conflict` verdict instead of being trusted as still-busy, as [herdr-backend.md](herdr-backend.md#current-transport-behavior) owns.
 tmux, zellij, orca, and cmux expose no native busy primitive at all, so a task on those backends is classified purely from its adapter's own lifecycle record.
 That poll loop is still the default event source for backends with no native push events, so this stays an extraction of the abstraction rather than a watcher rewrite.
 For capable Herdr sessions, the same watcher replaces its terminal sleep with a bounded native event wait that immediately surfaces `blocked`; [Push events and polling fallback](herdr-backend.md#push-events-and-polling-fallback) owns the current mechanism and capability gates, while [runtime backend verification](verification/runtime-backends.md#native-blocked-event) owns the active evidence.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -222,8 +222,16 @@ The capture owner requests at least 200 lines from Herdr and trims locally to th
 This generous floor is required for small composer and peek reads.
 
 Herdr's native agent state can read idle while a harness waits on its own long foreground tool.
-The shared crew-state path therefore accepts a native `busy` as evidence of activity but never a native `idle` as evidence that a worker has stopped; the task's own semantic busy state (`bin/fm-busy-lib.sh`) decides that.
-A human-blocked permission dialog has no busy banner and still surfaces.
+The shared crew-state path therefore accepts a generic or screen-detected native `busy` as evidence of activity but never such an `idle` as evidence that a worker has stopped; the task's own semantic busy state (`bin/fm-busy-lib.sh`) decides that.
+
+A verified full-lifecycle integration is the one authoritative exception.
+When Herdr reports `screen_detection_skipped` with an `agent_session.source` naming a lifecycle integration such as `herdr:pi` (verified against Herdr 0.8.0 plus Pi integration v8 in [`docs/verification/supervision.md`](verification/supervision.md)), its idle is turn-state authoritative, and `fm_backend_herdr_authoritative_state` exposes that verdict.
+`bin/fm-busy-lib.sh` uses it to reconcile a stale firstmate busy record: if the record still says busy while the full-lifecycle integration reports idle, the classifier returns a `conflict` verdict instead of busy, and `bin/fm-crew-state.sh` reconciles that against the task's terminal result or reports incomplete-idle so supervision continues or recovers it.
+No fixed busy TTL is used; only the authoritative lifecycle observation triggers the contradiction, and a long foreground tool reads busy from the same integration so it never becomes a false conflict.
+
+Full-lifecycle authority also suppresses Herdr screen detection, so a Pi interactive question or approval wait would otherwise be invisible.
+Pi 0.84.1 exposes no generic dialog lifecycle event and no installed package emits the shared `herdr:blocked` event the Pi integration listens for, so the per-task Pi extension `bin/fm-spawn.sh` installs wraps the one shared `ctx.ui` object and emits `herdr:blocked` with a non-sensitive method label while any `ctx.ui` dialog (confirm, select, input, editor, or custom, including MCP tool approval and elicitation) is open.
+Herdr's integration turns that into a `blocked` agent state and the transition policy (`bin/fm-transition-lib.sh`) treats it as immediately actionable; the extension only detects and relays the wait and never answers it.
 
 ## Composer and injection safety
 

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -176,6 +176,30 @@ tests/fm-busy-adapter-wiring.test.sh
 tests/fm-crew-state.test.sh
 ```
 
+### Herdr full-lifecycle idle reconciliation and Pi reload (2026-08-09)
+
+Verified against Pi `0.84.1` and Herdr `0.8.0` with its current official Pi integration v8 (`~/.pi/agent/extensions/herdr-agent-state.ts`, `HERDR_INTEGRATION_VERSION=8`), all in a named non-default Herdr lab session so the live `default` fleet was untouched (fleet-state tripwire equal before and after each run).
+
+Root cause of the stale busy record: on `/reload` Pi emits `session_shutdown` reason `reload`, re-loads the per-task extension, then emits `session_start` reason `reload` with `ctx.isIdle()` already `true` and no paired `agent_settled`.
+Captured in a pty-driven `pi -e <ext>` session:
+
+```
+session_shutdown reason=reload
+EXT_LOADED
+session_start reason=reload mode=tui isIdle=true
+```
+
+The previous generated extension had no `session_start` handler, so a reload that landed while the record was `busy source=pi-ext event=agent-start` left it stale forever while `herdr:pi` recovered to idle via its own `session_start` reconciliation.
+The current generated extension reconciles on any non-`startup` `session_start` from `ctx.isIdle()`; the lab observed the recovery event `state=idle source=pi-ext event=session-reconcile` and, on a clean turn, `working -> idle` in both `herdr agent get` and `state/<id>.busy-state`.
+
+Authority signal: `herdr agent get <pane>` for the lab's Pi worker returned `agent_status: idle`, `screen_detection_skipped: true`, and `agent_session.source: herdr:pi`, which `fm_backend_herdr_authoritative_state` requires before letting an idle observation override a busy record.
+A screen-detected or generic agent has neither field, so a long foreground tool call still classifies busy.
+
+Question/approval waits: Pi 0.84.1 exposes no generic dialog lifecycle event on the extension bus (its full event set has no `ui`/`dialog`/`tool_approval` event), and no installed Pi package emits the `herdr:blocked` event the Pi integration listens for.
+A lab dialog that blocks a turn on `ctx.ui.confirm` was invisible without the fix (`herdr agent get` read `idle` for the whole wait); with the per-task extension's `ctx.ui` wrapper loaded, the same dialog drove `herdr agent get` to `blocked`, which the transition policy escalates as actionable.
+Only the method-name label leaves the worker UI; the dialog title and body never appear in the emitted event.
+The robust upstream fix would be Pi (or `pi-mcp-adapter`) emitting `herdr:blocked` itself, or Pi exposing a generic dialog lifecycle event; wrapping the shared `ctx.ui` object is the strongest safe local detection until then and covers every `ctx.ui` dialog without patching installed packages or reading question wording.
+
 ## Turn-end guard
 
 The direct and passive mechanisms were validated across all five harnesses on 2026-07-08 through 2026-07-12, with Claude's replacement Stop-owned path revalidated on 2026-07-24.

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -2982,6 +2982,43 @@ test_busy_state_unknown_on_no_agent() {
   pass "fm_backend_herdr_busy_state: unparseable/absent agent state reports unknown, the regex-fallback cue"
 }
 
+# --- authoritative_state (full-lifecycle-only agent state) --------------------
+
+test_authoritative_state_full_lifecycle_idle() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/auth-idle"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"agent":{"agent_status":"idle","screen_detection_skipped":true,"agent_session":{"source":"herdr:pi"}}}}\n' > "$resp/1.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_authoritative_state default:w1:p2' "$ROOT" )
+  [ "$out" = idle ] || fail "full-lifecycle herdr:pi idle should be authoritative idle, got '$out'"
+  pass "fm_backend_herdr_authoritative_state: screen_detection_skipped + herdr:pi source -> authoritative idle"
+}
+
+test_authoritative_state_screen_detected_is_unknown() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/auth-screen"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  # Screen-detected agent: no lifecycle source and detection not skipped.
+  printf '{"result":{"agent":{"agent_status":"idle","screen_detection_skipped":false,"agent_session":{"source":""}}}}\n' > "$resp/1.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_authoritative_state default:w1:p2' "$ROOT" )
+  [ "$out" = unknown ] || fail "screen-detected idle must NOT be authoritative, got '$out'"
+  pass "fm_backend_herdr_authoritative_state: screen-detected idle is unknown (conservative rule preserved)"
+}
+
+test_authoritative_state_skipped_without_lifecycle_source_is_unknown() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/auth-nosource"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  # Detection skipped for a non-lifecycle reason (e.g. launch pending) with no source.
+  printf '{"result":{"agent":{"agent_status":"idle","screen_detection_skipped":true,"agent_session":{"source":""}}}}\n' > "$resp/1.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_authoritative_state default:w1:p2' "$ROOT" )
+  [ "$out" = unknown ] || fail "skipped detection without a lifecycle source must not be authoritative, got '$out'"
+  pass "fm_backend_herdr_authoritative_state: detection-skipped without a herdr lifecycle source is unknown"
+}
+
 # --- composer_state: structural border-row classification --------------------
 
 test_composer_state_bare_prompt_is_empty() {
@@ -4316,6 +4353,9 @@ test_current_path_reads_cwd
 test_busy_state_working_maps_to_busy
 test_busy_state_done_and_blocked_map_to_idle
 test_busy_state_unknown_on_no_agent
+test_authoritative_state_full_lifecycle_idle
+test_authoritative_state_screen_detected_is_unknown
+test_authoritative_state_skipped_without_lifecycle_source_is_unknown
 test_composer_state_bare_prompt_is_empty
 test_composer_state_styled_placeholder_draft_is_pending
 test_composer_state_real_text_is_pending

--- a/tests/fm-busy-adapter-wiring.test.sh
+++ b/tests/fm-busy-adapter-wiring.test.sh
@@ -100,6 +100,11 @@ switch (process.env.MODE) {
     await handlers["agent_start"]({}, ctx);
     break;
   case "turn-end": await handlers["turn_end"]({}, ctx); break;
+  case "session-start": {
+    const sctx = { isIdle: () => process.env.SESSION_IDLE === "1" };
+    await handlers["session_start"]({ reason: process.env.SESSION_REASON }, sctx);
+    break;
+  }
   default: throw new Error("unknown mode " + process.env.MODE);
 }
 if (process.env.MODE === "turn-end") {
@@ -158,6 +163,178 @@ test_pi_extension_serializes_settle_before_next_start() {
   out=$(classify pi "$id" "$state")
   [ "$out" = "busy pi-ext" ] || fail "a fresh agent_start after agent_settled must win, got '$out'"
   pass "pi extension awaits agent_settled before the next agent_start without a test delay"
+}
+
+# drive_pi_ext_ui <ext-path> <scenario>: load the generated Pi extension in a
+# plain Node host that provides pi.events (capturing every herdr:blocked emit)
+# and a shared ctx.ui whose dialog methods we control, then exercise a dialog
+# scenario. Prints one JSON line per herdr:blocked emit plus RESULT/ERROR lines,
+# so the test asserts the OBSERVABLE contract, never extension source bytes.
+drive_pi_ext_ui() {
+  EXT_PATH="$1" SCENARIO="$2" node --input-type=module 2>&1 <<'EOF'
+import { pathToFileURL } from "node:url";
+const mod = await import(pathToFileURL(process.env.EXT_PATH).href);
+const handlers = {};
+const log = [];
+const pi = {
+  on: (name, fn) => { handlers[name] = fn; },
+  events: { emit: (name, data) => { if (name === "herdr:blocked") log.push(data); } },
+};
+mod.default(pi);
+// A shared ctx.ui exactly as Pi hands the SAME object to every extension/tool.
+let resolvers = {};
+const mkDialog = (name) => (...args) => {
+  // Record the raw args so the test can prove only the method label leaks.
+  log.push({ call: name, args });
+  if (process.env.SCENARIO === "sync-throw" && name === "confirm") {
+    throw new Error("boom-" + JSON.stringify(args));
+  }
+  return new Promise((resolve, reject) => { resolvers[name] = { resolve, reject }; });
+};
+const ui = {};
+for (const m of ["confirm", "select", "input", "editor", "custom"]) ui[m] = mkDialog(m);
+const ctx = { isIdle: () => false, ui };
+// session_start installs the wrapper on the shared ui object.
+await handlers["session_start"]({ reason: "startup" }, ctx);
+// A reload re-runs the extension and re-enters session_start on the SAME ui
+// object: the wrapper must stay idempotent (no double emit per dialog).
+if (process.env.SCENARIO === "idempotent") {
+  await handlers["session_start"]({ reason: "reload" }, ctx);
+}
+
+const emit = () => log.filter((e) => e && typeof e.active === "boolean");
+const dump = () => { for (const e of emit()) process.stdout.write(JSON.stringify(e) + "\n"); };
+const calls = () => log.filter((e) => e && e.call);
+
+switch (process.env.SCENARIO) {
+  case "resolve": {
+    const p = ctx.ui.confirm("Delete production DB?", "secret-body-value");
+    process.stdout.write("AFTER_OPEN active_count=" + emit().filter(e=>e.active).length + "\n");
+    resolvers.confirm.resolve(true);
+    await p;
+    dump();
+    // Prove no sensitive text leaked into any emitted label.
+    const leaked = emit().some((e) => JSON.stringify(e).includes("secret-body-value") || JSON.stringify(e).includes("production"));
+    process.stdout.write("LEAKED=" + leaked + "\n");
+    break;
+  }
+  case "nested": {
+    const p1 = ctx.ui.confirm("outer");
+    const p2 = ctx.ui.select("inner", ["a", "b"]);
+    process.stdout.write("BOTH_OPEN actives=" + emit().filter(e=>e.active).length + "\n");
+    resolvers.select.resolve("a");
+    await p2;
+    process.stdout.write("AFTER_INNER inactives=" + emit().filter(e=>!e.active).length + "\n");
+    resolvers.confirm.resolve(true);
+    await p1;
+    dump();
+    break;
+  }
+  case "cancel-reject": {
+    const p = ctx.ui.input("name?");
+    resolvers.input.reject(new Error("cancelled"));
+    let threw = false;
+    try { await p; } catch { threw = true; }
+    process.stdout.write("REJECTED=" + threw + "\n");
+    dump();
+    break;
+  }
+  case "sync-throw": {
+    let threw = false;
+    try { ctx.ui.confirm("boom?"); } catch { threw = true; }
+    process.stdout.write("THREW=" + threw + "\n");
+    dump();
+    break;
+  }
+  case "idempotent": {
+    const p = ctx.ui.confirm("only once?");
+    resolvers.confirm.resolve(true);
+    await p;
+    process.stdout.write("ACTIVES=" + emit().filter(e=>e.active).length + " INACTIVES=" + emit().filter(e=>!e.active).length + "\n");
+    dump();
+    break;
+  }
+  default: throw new Error("unknown scenario " + process.env.SCENARIO);
+}
+EOF
+}
+
+test_pi_extension_session_start_reconciles_reload() {
+  local rec id=busy-pi-reload out state ext
+  rec=$(make_spawn_case pi-reload pi "$id")
+  read_case_record "$rec"
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" "$PROJ_DIR")
+  expect_code 0 $? "pi spawn should succeed: $out"
+  state="$HOME_DIR/state"
+  ext="$state/$id.pi-ext.ts"
+
+  # Drive a stale busy record (agent-start recorded, settle never delivered).
+  out=$(drive_pi_ext "$ext" agent-start) || fail "agent_start drive failed: $out"
+  [ "$(classify pi "$id" "$state")" = "busy pi-ext" ] || fail "precondition: record must be busy"
+
+  # A /reload while the agent is actually idle: session_start(reason=reload)
+  # with isIdle=true must reconcile the stale busy record to idle (the incident
+  # recovery herdr:pi v8 performs and our old extension did not).
+  out=$(SESSION_REASON=reload SESSION_IDLE=1 drive_pi_ext "$ext" session-start) \
+    || fail "session-start reload-idle drive failed: $out"
+  [ "$(classify pi "$id" "$state")" = "idle pi-ext" ] \
+    || fail "session_start(reload,isIdle) must reconcile a stale busy record to idle, got '$(classify pi "$id" "$state")'"
+
+  # A reload mid-run (isIdle=false) reconciles busy.
+  out=$(SESSION_REASON=reload SESSION_IDLE=0 drive_pi_ext "$ext" session-start) \
+    || fail "session-start reload-busy drive failed: $out"
+  [ "$(classify pi "$id" "$state")" = "busy pi-ext" ] \
+    || fail "session_start(reload,!isIdle) must reconcile to busy, got '$(classify pi "$id" "$state")'"
+
+  # A fresh startup session_start must NOT clobber the record: the arm seed and
+  # agent_start own the initial busy, so reason=startup is a no-op even at isIdle.
+  "$ROOT/bin/fm-busy-event.sh" apply "$state" "$id" busy --current-gen --source pi-ext --event agent-start
+  out=$(SESSION_REASON=startup SESSION_IDLE=1 drive_pi_ext "$ext" session-start) \
+    || fail "session-start startup drive failed: $out"
+  [ "$(classify pi "$id" "$state")" = "busy pi-ext" ] \
+    || fail "session_start(startup) must not reconcile away the launch-brief busy, got '$(classify pi "$id" "$state")'"
+  pass "pi extension reconciles a stale record on reload and leaves the startup launch-brief busy intact"
+}
+
+test_pi_extension_blocked_wrapper_emits_and_clears() {
+  command -v node >/dev/null 2>&1 || { pass "pi blocked wrapper skipped without node"; return; }
+  local rec id=busy-pi-block out ext state
+  rec=$(make_spawn_case pi-block pi "$id")
+  read_case_record "$rec"
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" "$PROJ_DIR")
+  expect_code 0 $? "pi spawn should succeed: $out"
+  state="$HOME_DIR/state"
+  ext="$state/$id.pi-ext.ts"
+
+  # A dialog that opens then resolves: exactly one active then one inactive,
+  # both labelled by the method only, with no title/body ever leaking.
+  out=$(drive_pi_ext_ui "$ext" resolve) || fail "resolve scenario failed: $out"
+  printf '%s\n' "$out" | grep -q 'AFTER_OPEN active_count=1' || fail "a dialog must emit exactly one herdr:blocked active on open: $out"
+  printf '%s\n' "$out" | grep -q '{"active":true,"label":"confirm"}' || fail "active emit must carry only the method label: $out"
+  printf '%s\n' "$out" | grep -q '{"active":false,"label":"confirm"}' || fail "a resolved dialog must clear blocked: $out"
+  printf '%s\n' "$out" | grep -q 'LEAKED=false' || fail "the dialog title/body must never leak into a herdr:blocked emit: $out"
+
+  # Nested / overlapping dialogs: two actives, two inactives (herdr's own
+  # blockedCount handles the nesting depth).
+  out=$(drive_pi_ext_ui "$ext" nested) || fail "nested scenario failed: $out"
+  printf '%s\n' "$out" | grep -q 'BOTH_OPEN actives=2' || fail "overlapping dialogs must each emit active: $out"
+  printf '%s\n' "$out" | grep -q 'AFTER_INNER inactives=1' || fail "resolving one dialog must clear exactly one: $out"
+
+  # A cancelled/rejected dialog still clears blocked exactly once and propagates.
+  out=$(drive_pi_ext_ui "$ext" cancel-reject) || fail "cancel-reject scenario failed: $out"
+  printf '%s\n' "$out" | grep -q 'REJECTED=true' || fail "a rejected dialog must still reject to the caller: $out"
+  printf '%s\n' "$out" | grep -q '{"active":false,"label":"input"}' || fail "a rejected dialog must clear blocked: $out"
+
+  # A synchronously-throwing dialog clears blocked and re-throws.
+  out=$(drive_pi_ext_ui "$ext" sync-throw) || fail "sync-throw scenario failed: $out"
+  printf '%s\n' "$out" | grep -q 'THREW=true' || fail "a throwing dialog must propagate its error: $out"
+  printf '%s\n' "$out" | grep -q '{"active":false,"label":"confirm"}' || fail "a throwing dialog must clear blocked: $out"
+
+  # Idempotent wrap: a reload re-enters session_start on the same ui object, but
+  # one dialog must still emit exactly one active and one inactive (no dup).
+  out=$(drive_pi_ext_ui "$ext" idempotent) || fail "idempotent scenario failed: $out"
+  printf '%s\n' "$out" | grep -q 'ACTIVES=1 INACTIVES=1' || fail "a re-wrapped ui must not double-emit per dialog: $out"
+  pass "pi extension emits herdr:blocked around ctx.ui dialogs, clears once on resolve/cancel/throw, stays idempotent across reload, and leaks only the method label"
 }
 
 test_pi_extension_stale_incarnation_rejected() {
@@ -344,6 +521,8 @@ test_kimi_and_grok_install_no_unverified_wiring() {
 
 test_pi_extension_semantic_lifecycle
 test_pi_extension_serializes_settle_before_next_start
+test_pi_extension_session_start_reconciles_reload
+test_pi_extension_blocked_wrapper_emits_and_clears
 test_pi_extension_stale_incarnation_rejected
 test_kimi_and_grok_install_no_unverified_wiring
 test_opencode_plugin_semantic_lifecycle

--- a/tests/fm-busy-state.test.sh
+++ b/tests/fm-busy-state.test.sh
@@ -314,6 +314,93 @@ test_herdr_native_busy_only() {
   pass "herdr's native verdict is trusted for busy only, and records outrank it"
 }
 
+# --- authoritative full-lifecycle idle vs stale busy record -------------------
+# The exact incident: a Pi /reload replaced the per-task extension mid-run so
+# the settle was never recorded, leaving a stale pi-ext busy record, while
+# herdr's full-lifecycle herdr:pi integration authoritatively reports idle.
+
+test_authoritative_idle_conflicts_stale_busy() {
+  local state gen out
+  state=$(new_state_dir auth-conflict)
+  gen=$("$EV" arm "$state" t1)
+  # Stale busy record exactly as the incident left it (seq=2 pi-ext agent-start).
+  "$EV" apply "$state" t1 busy --gen "$gen" --source pi-ext --event agent-start
+  # shellcheck disable=SC2329 # invoked indirectly through fm_busy_classify
+  fm_backend_authoritative_state() { printf 'idle'; }
+  out=$(fm_busy_classify herdr s:p pi t1 "$state")
+  [ "$out" = "conflict herdr-idle-stale-busy" ] \
+    || fail "authoritative idle over a stale busy record must yield the conflict verdict, got '$out'"
+  # The boolean view must never read the conflict as busy.
+  if fm_busy_is_busy herdr s:p pi t1 "$state"; then
+    fail "a conflict verdict must not read as busy"
+  fi
+  unset -f fm_backend_authoritative_state
+  pass "authoritative full-lifecycle idle over a stale busy record yields a conflict, never busy"
+}
+
+test_authoritative_working_keeps_busy() {
+  local state gen out
+  state=$(new_state_dir auth-working)
+  gen=$("$EV" arm "$state" t1)
+  "$EV" apply "$state" t1 busy --gen "$gen" --source pi-ext --event agent-start
+  # A long foreground tool: the record is busy and the full-lifecycle
+  # integration agrees the agent is still in a turn (busy). No conflict.
+  # shellcheck disable=SC2329 # invoked indirectly through fm_busy_classify
+  fm_backend_authoritative_state() { printf 'busy'; }
+  out=$(fm_busy_classify herdr s:p pi t1 "$state")
+  [ "$out" = "busy pi-ext" ] || fail "authoritative working must keep the busy record, got '$out'"
+  unset -f fm_backend_authoritative_state
+  pass "an authoritative working observation keeps the busy record (no false conflict)"
+}
+
+test_screen_detected_idle_keeps_busy() {
+  local state gen out
+  state=$(new_state_dir auth-screen)
+  gen=$("$EV" arm "$state" t1)
+  "$EV" apply "$state" t1 busy --gen "$gen" --source pi-ext --event agent-start
+  # Screen-detected / generic herdr idle is NOT authoritative: the backend
+  # returns unknown, so the conservative rule (a long foreground tool can read
+  # idle) is preserved and the busy record stands.
+  # shellcheck disable=SC2329 # invoked indirectly through fm_busy_classify
+  fm_backend_authoritative_state() { printf 'unknown'; }
+  out=$(fm_busy_classify herdr s:p pi t1 "$state")
+  [ "$out" = "busy pi-ext" ] || fail "non-authoritative idle must not override the busy record, got '$out'"
+  unset -f fm_backend_authoritative_state
+  pass "screen-detected / non-authoritative idle never forces a conflict (busy record preserved)"
+}
+
+test_authoritative_idle_only_overrides_busy() {
+  local state gen out
+  state=$(new_state_dir auth-idle-record)
+  gen=$("$EV" arm "$state" t1)
+  # An idle record with authoritative idle agrees: plain idle, not a conflict.
+  "$EV" apply "$state" t1 idle --gen "$gen" --source pi-ext --event agent-settled
+  # shellcheck disable=SC2329 # invoked indirectly through fm_busy_classify
+  fm_backend_authoritative_state() { printf 'idle'; }
+  out=$(fm_busy_classify herdr s:p pi t1 "$state")
+  [ "$out" = "idle pi-ext" ] || fail "an idle record must stay idle, got '$out'"
+  unset -f fm_backend_authoritative_state
+  pass "the conflict override applies only to a busy record, never to an agreeing idle record"
+}
+
+test_authoritative_reconcile_scoped_to_backends() {
+  local state gen out
+  state=$(new_state_dir auth-nonherdr)
+  gen=$("$EV" arm "$state" t1)
+  "$EV" apply "$state" t1 busy --gen "$gen" --source pi-ext --event agent-start
+  # A backend with no full-lifecycle integration returns unknown -> no conflict,
+  # so tmux/cmux/zellij/orca behavior is unchanged.
+  # shellcheck disable=SC2329 # invoked indirectly through fm_busy_classify
+  fm_backend_authoritative_state() { printf 'unknown'; }
+  out=$(fm_busy_classify tmux w1 pi t1 "$state")
+  [ "$out" = "busy pi-ext" ] || fail "a non-lifecycle backend must never conflict, got '$out'"
+  unset -f fm_backend_authoritative_state
+  # With the reconciler absent entirely, a busy record still classifies busy.
+  out=$(fm_busy_classify tmux w1 pi t1 "$state")
+  [ "$out" = "busy pi-ext" ] || fail "absent reconciler must leave the busy record intact, got '$out'"
+  pass "authoritative reconciliation is a no-op without a full-lifecycle backend integration"
+}
+
 # The record parser runs inside sourcing callers (the watcher, the daemon, the
 # crew-state reader), so it must not disturb their shell: no clobbered
 # positional parameters and no changed glob setting.
@@ -374,6 +461,11 @@ test_codex_unverified_gate
 test_kimi_unverified_gate
 test_dead_endpoint_overrides
 test_herdr_native_busy_only
+test_authoritative_idle_conflicts_stale_busy
+test_authoritative_working_keeps_busy
+test_screen_detected_idle_keeps_busy
+test_authoritative_idle_only_overrides_busy
+test_authoritative_reconcile_scoped_to_backends
 test_record_read_leaves_caller_shell_intact
 test_boolean_view_never_promotes_unknown
 

--- a/tests/fm-control.test.sh
+++ b/tests/fm-control.test.sh
@@ -147,6 +147,83 @@ SH
   printf '%s\n' "$fb"
 }
 
+# make_herdr_stub <dir>: add a fake `herdr` binary to the case's fakebin, so a
+# herdr-backed task can be driven without the real multiplexer. It models only
+# the four subcommands the exit path reads, as a small state machine over
+# $FM_FAKE_DIR: `status` reports a running server, `pane get` a present pane,
+# `agent get` an agent whose full-lifecycle (herdr:pi, screen_detection_skipped)
+# status is `blocked` - which the reader maps to authoritative idle - until an
+# interrupt key is delivered, after which it reports agent_not_found. Every key
+# is recorded to $FM_FAKE_DIR/keys exactly like the tmux stub, and
+# FM_FAKE_INTERRUPT_STOPS_AGENT makes the interrupt retire the agent.
+make_herdr_stub() {  # <dir>
+  local dir=$1 fb="$1/fakebin"
+  mkdir -p "$fb"
+  cat > "$fb/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+D=$FM_FAKE_DIR
+case "${1:-}" in
+  status) printf '{"server":{"running":true}}\n'; exit 0 ;;
+  pane)
+    case "${2:-}" in
+      get) printf '{"result":{"pane":{"pane_id":"%s"}}}\n' "${3:-}"; exit 0 ;;
+      send-keys)
+        key=${4:-}
+        printf '%s\n' "$key" >> "$D/keys"
+        if [ -n "${FM_FAKE_INTERRUPT_STOPS_AGENT:-}" ] \
+           && { [ "$key" = escape ] || [ "$key" = ctrl+c ]; }; then
+          : > "$D/herdr-agent-gone"
+        fi
+        exit 0 ;;
+    esac
+    exit 0 ;;
+  agent)
+    case "${2:-}" in
+      get)
+        if [ -e "$D/herdr-agent-gone" ]; then
+          printf '{"error":{"code":"agent_not_found"}}\n'
+        else
+          printf '{"result":{"agent":{"agent":"fm-agent","agent_status":"blocked","screen_detection_skipped":true,"agent_session":{"source":"herdr:pi"}}}}\n'
+        fi
+        exit 0 ;;
+    esac
+    exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/herdr"
+}
+
+# add_herdr_task <case-dir> <id> <harness>: like add_task, but records a herdr
+# endpoint (window=<session>:<pane>) so lifecycle verbs resolve the herdr
+# backend and drive the fake herdr binary.
+add_herdr_task() {  # <case-dir> <id> <harness>
+  local dir=$1 id=$2 harness=$3
+  local home="$dir/home" proj="$dir/proj-$id" wt="$dir/wt-$id"
+  local session=fmlab workspace=w1 tab=w1:t2 pane=w1:p2
+  fm_git_worktree "$proj" "$wt" "task-$id"
+  mkdir -p "$home/data/$id"
+  printf '# brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  {
+    echo "window=$session:$pane"
+    echo "endpoint_task_id=$id"
+    echo "worktree=$wt"
+    echo "project=$proj"
+    echo "harness=$harness"
+    echo "kind=ship"
+    echo "mode=no-mistakes"
+    echo "yolo=off"
+    echo "model=default"
+    echo "effort=default"
+    echo "backend=herdr"
+    echo "herdr_session=$session"
+    echo "herdr_workspace_id=$workspace"
+    echo "herdr_tab_id=$tab"
+    echo "herdr_pane_id=$pane"
+  } > "$home/state/$id.meta"
+}
+
 # new_case <name> -> echoes a case dir holding home/, fake/, and fakebin.
 new_case() {
   local dir="$TMP_ROOT/$1-$RANDOM"
@@ -767,6 +844,32 @@ test_exit_accepts_agent_stopped_by_busy_interrupt() {
   pass "fm-control exit: an interrupt-stopped agent satisfies the gone-state postcondition"
 }
 
+test_conflict_verdict_is_interrupted_before_the_exit_command() {
+  local dir out rc gen
+  dir=$(new_case conflict)
+  make_herdr_stub "$dir"
+  add_herdr_task "$dir" t1 pi
+  # The reconciliation incident: a Pi worker's stale busy record (an agent-start
+  # seed whose settle never landed, e.g. a /reload) that the herdr:pi
+  # full-lifecycle integration authoritatively contradicts as idle yields a
+  # `conflict` verdict, not `busy`. The exit gate must still interrupt first -
+  # the fake herdr retires the agent the instant the cancel key lands, proving
+  # the interrupt reached the pane before any exit command was typed.
+  gen=$("$ROOT/bin/fm-busy-event.sh" arm "$dir/home/state" t1)
+  "$ROOT/bin/fm-busy-event.sh" apply "$dir/home/state" t1 busy \
+    --gen "$gen" --source pi-ext --event agent-start
+  printf 'busy_gen=%s\n' "$gen" >> "$dir/home/state/t1.meta"
+  out=$(FM_FAKE_INTERRUPT_STOPS_AGENT=1 run_control "$dir" t1 exit); rc=$?
+  expect_code 0 "$rc" "exiting a conflict-verdict agent should succeed"$'\n'"$out"
+  [ "$(keys_sent "$dir")" = "escape" ] \
+    || fail "a conflict verdict must be interrupted before exit, got keys: $(keys_sent "$dir")"
+  [ -z "$(literals "$dir")" ] \
+    || fail "the interrupt already stopped the agent, so no exit command should be typed, got: $(literals "$dir")"
+  assert_contains "$out" "stopped t1 harness=pi backend=herdr" \
+    "a conflict-verdict agent stopped by the pre-exit interrupt completes exit"
+  pass "fm-control exit: a conflict verdict is interrupted before the exit command"
+}
+
 test_agent_that_does_not_stop_fails_closed() {
   local dir out rc gen
   dir=$(new_case stubborn)
@@ -890,6 +993,7 @@ test_interrupt_without_acknowledgement_preserves_busy_state
 test_muse_interrupt_confirms_adapter_acknowledgement
 test_interrupt_revalidates_agent_after_acknowledgement_wait
 test_exit_accepts_agent_stopped_by_busy_interrupt
+test_conflict_verdict_is_interrupted_before_the_exit_command
 test_agent_that_does_not_stop_fails_closed
 test_grok_interrupt_without_acknowledgement_reports_unconfirmed
 test_grok_idle_footer_does_not_confirm_cancellation

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -116,7 +116,11 @@ case "${1:-}" in
     case "${2:-}" in
       get)
         [ -n "${FM_FAKE_HERDR_AGENT_STATUS:-}" ] || exit 1
-        printf '{"result":{"agent":{"agent_status":"%s"}}}\n' "$FM_FAKE_HERDR_AGENT_STATUS"
+        # Optional full-lifecycle authority signals (screen_detection_skipped +
+        # agent_session.source). Absent by default so existing cases model a
+        # non-authoritative native verdict.
+        printf '{"result":{"agent":{"agent_status":"%s","screen_detection_skipped":%s,"agent_session":{"source":"%s"}}}}\n' \
+          "$FM_FAKE_HERDR_AGENT_STATUS" "${FM_FAKE_HERDR_SKIPPED:-false}" "${FM_FAKE_HERDR_SOURCE:-}"
         exit 0 ;;
     esac ;;
 esac
@@ -169,9 +173,11 @@ reset_fakes() {
   FM_FAKE_HERDR_BUSY=0
   FM_FAKE_HERDR_MISSING=0
   FM_FAKE_HERDR_AGENT_STATUS=""
+  FM_FAKE_HERDR_SKIPPED=false
+  FM_FAKE_HERDR_SOURCE=""
   FM_FAKE_CI_LOGS=""
   export FM_FAKE_AXI_STATUS FM_FAKE_AXI_STATUS_RUN FM_FAKE_RUNS_LIST FM_FAKE_BUSY FM_FAKE_BUSY_TEXT FM_FAKE_TMUX_MISSING
-  export FM_FAKE_HERDR_BUSY FM_FAKE_HERDR_MISSING FM_FAKE_HERDR_AGENT_STATUS FM_FAKE_CI_LOGS
+  export FM_FAKE_HERDR_BUSY FM_FAKE_HERDR_MISSING FM_FAKE_HERDR_AGENT_STATUS FM_FAKE_HERDR_SKIPPED FM_FAKE_HERDR_SOURCE FM_FAKE_CI_LOGS
 }
 
 # --- run-object fixtures (TOON, as `no-mistakes axi status` emits) -----------
@@ -923,6 +929,92 @@ test_no_run_herdr_idle_agent_status_and_idle_record_stays_idle() {
   pass "an idle record with idle agent_status stays not-busy (no regression for a human-blocked agent)"
 }
 
+# The exact 2026-08 incident: a stale pi-ext BUSY record (a Pi /reload replaced
+# the per-task extension mid-run so the settle was never recorded) while herdr's
+# full-lifecycle herdr:pi integration authoritatively reports idle. The crew must
+# NOT read working; with no terminal status it surfaces as incomplete-idle so
+# supervision continues or recovers it.
+test_conflict_stale_busy_vs_authoritative_idle_incomplete() {
+  command -v jq >/dev/null 2>&1 || { pass "conflict incomplete-idle skipped without jq"; return; }
+  reset_fakes
+  local d; d=$(new_case conflict-incomplete)
+  make_repo_on_branch "$d/wt" fm/feat-conflict
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-conflict.meta" "window=default:w1:p9" "worktree=$d/wt" "kind=ship" \
+    "backend=herdr" "harness=pi"
+  printf 'working: implementing the fix\n' > "$d/state/feat-conflict.status"
+  FM_FAKE_AXI_STATUS=""
+  FM_FAKE_RUNS_LIST=""
+  FM_FAKE_TMUX_MISSING=1
+  FM_FAKE_HERDR_AGENT_STATUS=idle
+  FM_FAKE_HERDR_SKIPPED=true
+  FM_FAKE_HERDR_SOURCE="herdr:pi"
+  local gen; gen=$("$ROOT/bin/fm-busy-event.sh" arm "$d/state" feat-conflict)
+  "$ROOT/bin/fm-busy-event.sh" apply "$d/state" feat-conflict busy --gen "$gen" \
+    --source pi-ext --event agent-start
+  local out; out=$(run_crew_state "$d" feat-conflict)
+  assert_not_contains "$out" "state: working" "authoritative idle over a stale busy record must never read working"
+  assert_contains "$out" "incomplete-idle" "a stale busy record + authoritative idle + no terminal -> incomplete-idle"
+  # crew_absorb_class must surface it (none), not absorb as provably working.
+  local cls; cls=$(FM_CREW_STATE_BIN="$CREW_STATE" FM_STATE_OVERRIDE="$d/state" PATH="$d/fakebin:$PATH" bash -c '. "'"$ROOT"'/bin/fm-classify-lib.sh"; crew_absorb_class feat-conflict')
+  [ "$cls" = none ] || fail "an incomplete-idle conflict must surface (crew_absorb_class none), got '$cls'"
+  pass "stale busy record + authoritative full-lifecycle idle + no terminal status surfaces as incomplete-idle"
+}
+
+# An idle/done herdr agent is not automatically a completed task: when the task
+# DOES carry a durable terminal result, the conflict reconciles to that terminal
+# state instead of incomplete-idle.
+test_conflict_reconciles_against_terminal_status() {
+  command -v jq >/dev/null 2>&1 || { pass "conflict terminal reconcile skipped without jq"; return; }
+  reset_fakes
+  local d; d=$(new_case conflict-terminal)
+  make_repo_on_branch "$d/wt" fm/feat-conflictterm
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-conflictterm.meta" "window=default:w1:p10" "worktree=$d/wt" "kind=ship" \
+    "backend=herdr" "harness=pi"
+  printf 'needs-decision: which database backend?\n' > "$d/state/feat-conflictterm.status"
+  FM_FAKE_AXI_STATUS=""
+  FM_FAKE_RUNS_LIST=""
+  FM_FAKE_TMUX_MISSING=1
+  FM_FAKE_HERDR_AGENT_STATUS=idle
+  FM_FAKE_HERDR_SKIPPED=true
+  FM_FAKE_HERDR_SOURCE="herdr:pi"
+  local gen; gen=$("$ROOT/bin/fm-busy-event.sh" arm "$d/state" feat-conflictterm)
+  "$ROOT/bin/fm-busy-event.sh" apply "$d/state" feat-conflictterm busy --gen "$gen" \
+    --source pi-ext --event agent-start
+  local out; out=$(run_crew_state "$d" feat-conflictterm)
+  assert_contains "$out" "state: parked" "a needs-decision status reconciles the authoritative idle to parked"
+  assert_contains "$out" "authoritative idle reconciled" "the parked reconciliation names the authoritative idle"
+  pass "an authoritative-idle conflict reconciles against a durable terminal/decision status"
+}
+
+# A long foreground tool call is a legitimate quiet turn: the full-lifecycle
+# integration reports WORKING for it (the agent run is still active), so a busy
+# record must stay working and never be misread as an idle conflict.
+test_conflict_not_triggered_by_authoritative_working() {
+  command -v jq >/dev/null 2>&1 || { pass "conflict working-guard skipped without jq"; return; }
+  reset_fakes
+  local d; d=$(new_case conflict-working)
+  make_repo_on_branch "$d/wt" fm/feat-conflictwork
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-conflictwork.meta" "window=default:w1:p11" "worktree=$d/wt" "kind=ship" \
+    "backend=herdr" "harness=pi"
+  printf 'working: running a long build\n' > "$d/state/feat-conflictwork.status"
+  FM_FAKE_AXI_STATUS=""
+  FM_FAKE_RUNS_LIST=""
+  FM_FAKE_TMUX_MISSING=1
+  FM_FAKE_HERDR_AGENT_STATUS=working
+  FM_FAKE_HERDR_SKIPPED=true
+  FM_FAKE_HERDR_SOURCE="herdr:pi"
+  local gen; gen=$("$ROOT/bin/fm-busy-event.sh" arm "$d/state" feat-conflictwork)
+  "$ROOT/bin/fm-busy-event.sh" apply "$d/state" feat-conflictwork busy --gen "$gen" \
+    --source pi-ext --event agent-start
+  local out; out=$(run_crew_state "$d" feat-conflictwork)
+  assert_contains "$out" "state: working" "an authoritative working observation keeps a busy record working"
+  assert_contains "$out" "source: pane" "the busy record reads through the pane source"
+  pass "a legitimate long foreground tool call (authoritative working) never becomes an idle conflict"
+}
+
 # (g) no run + idle pane -> the status-log verb, as-is
 test_no_run_idle_pane_uses_log() {
   reset_fakes
@@ -1339,6 +1431,9 @@ test_no_run_grok_uses_isolated_fallback
 test_no_run_herdr_unknown_uses_backend_capture
 test_no_run_herdr_idle_agent_status_outranked_by_record
 test_no_run_herdr_idle_agent_status_and_idle_record_stays_idle
+test_conflict_stale_busy_vs_authoritative_idle_incomplete
+test_conflict_reconciles_against_terminal_status
+test_conflict_not_triggered_by_authoritative_working
 test_no_run_idle_pane_uses_log
 test_no_run_idle_pane_uses_keyed_log
 test_no_run_idle_pane_paused


### PR DESCRIPTION
## Intent

Fix Firstmate supervision so a Herdr-backed Pi worker that has actually settled idle cannot stay falsely classified as working because an older Firstmate Pi busy record is stuck on agent-start, and make Pi interactive question/approval waits visible.

Root cause (reproduced live on Pi 0.84.1 + Herdr 0.8.0, Pi integration v8): on /reload or another session replacement Pi emits session_shutdown then session_start(reason=reload) with ctx.isIdle() already true and NO paired agent_settled. The generated per-task Pi extension had no session_start handler, so a reload landing while the record was busy left it permanently stale while herdr:pi recovered to idle via its own session_start reconciliation.

Writer fix (bin/fm-spawn.sh generated Pi extension): reconcile busy-state from ctx.isIdle() on any non-startup session_start (startup keeps the launch-brief busy seed, matching the arm); serialize every apply through one in-process queue so close-together events cannot be applied out of order (handlers still return an awaitable promise); wrap the ONE shared ctx.ui object to emit herdr:blocked with a non-sensitive method-name label around any dialog (confirm/select/input/editor/custom, incl MCP approval/elicitation). Pi 0.84.1 exposes no generic dialog event and nothing emits herdr:blocked, so ctx.ui wrapping is the strongest safe local detection; detection/relay only, the question is never answered, and title/body/args never leak.

Reader fix (defense in depth, one owner each): fm_backend_herdr_authoritative_state (bin/backends/herdr.sh) exposes herdr status only from a verified full-lifecycle integration (screen_detection_skipped plus a herdr: lifecycle source), never screen detection; fm_backend_authoritative_state dispatches it (bin/fm-backend.sh). fm_busy_classify (bin/fm-busy-lib.sh) returns a deterministic conflict verdict when a valid busy record is contradicted by an authoritative live idle, never plain busy - no fixed busy TTL, and a long foreground tool (authoritative working) never becomes a false conflict. fm-crew-state.sh maps the conflict: reconcile against the task's terminal/external-wait status, else report incomplete-idle so supervision continues/recovers it through the existing surface machinery; blocked stays in the transition-policy owner (fm-transition-lib.sh).

Deliberate decisions/constraints: keep every contract in its existing owner (no new state machine, skill, daemon, or control plane); preserve tmux/cmux/zellij/Orca/secondmate-idle/paused/blocked/long-foreground-tool/missing-integration/screen-detection behavior (all non-herdr backends return unknown -> unchanged); do not make the watcher invent work or send prompts; the ctx.ui wrapper is monkey-patching a live shared object from our own extension (not node_modules) and is fully defensive so it can never break a dialog. Added executable-interface regression tests (no source-byte assertions) for the stale-busy vs authoritative-idle incident, authoritative working, screen-detected idle, missing integration, terminal/no-terminal reconciliation, session_start reload/startup reconciliation, and the ctx.ui blocked wrapper (nested, cancel, throw, idempotent, redaction). Updated docs/herdr-backend.md and docs/verification/supervision.md. Verified in a named non-default Herdr lab with the live default fleet untouched. This is a reviewed PR only - do not merge.

## What Changed

- Generated Pi extension (`bin/fm-spawn.sh`) now reconciles busy-state from `ctx.isIdle()` on any non-startup `session_start` (startup keeps the launch-brief busy seed), serializes every handler apply through one in-process queue so close-together events cannot be applied out of order, and wraps the shared `ctx.ui` object to emit `herdr:blocked` with a non-sensitive method-name label around each dialog (confirm/select/input/editor/custom, incl. MCP approval/elicitation) — detection/relay only, never answering.
- Reader-side defense in depth: `fm_backend_herdr_authoritative_state` (`bin/backends/herdr.sh`) exposes herdr idle only from a verified full-lifecycle integration and never from screen detection, dispatched via `fm_backend_authoritative_state` (`bin/fm-backend.sh`); `fm_busy_classify` (`bin/fm-busy-lib.sh`) returns a deterministic `conflict` verdict when a valid busy record is contradicted by an authoritative live idle; `fm-crew-state.sh` maps `conflict` to reconcile against terminal/external-wait status or report incomplete-idle; `fm-control.sh` treats `conflict` like `busy` for the `do_exit` pre-exit interrupt.
- Added executable-interface regression tests for the stale-busy-vs-authoritative-idle incident, session_start reload/startup reconciliation, and the `ctx.ui` blocked wrapper, and updated `docs/architecture.md`, `docs/herdr-backend.md`, and `docs/verification/supervision.md`.

## Risk Assessment

✅ Low: The only delta since the prior review is a one-line, precisely-scoped fix that makes do_exit treat the new conflict verdict like busy for the pre-exit interrupt (resolving the sole round-1 finding) plus matching regression coverage, and the rest of the branch was already reviewed as solid and intent-conforming.

## Testing

Baseline: ran the five targeted regression suites that own this change (fm-busy-state, fm-busy-adapter-wiring, fm-crew-state, fm-backend-herdr, fm-control) — all green. Since passing tests alone are not sufficient evidence, I additionally authored and ran a product-level CLI demonstration that drives the actual generated Pi extension and the real classifier/backend chain end-to-end, reproducing the Pi 0.84.1 /reload incident and capturing the operator-visible verdicts: a stale busy record reconciles to `idle pi-ext` on reload-idle, stays `busy` on startup, the reader chain emits `conflict herdr-idle-stale-busy` for a verified live idle while screen-detected idle stays `unknown`, and the ctx.ui wrapper emits herdr:blocked with only the method label (LEAKED=false). This is a backend/shell supervision change with no rendered UI surface, so a CLI transcript (not a screenshot) is the correct reviewer-visible artifact. Worktree verified clean and temp dirs auto-cleaned; overall result: pass, no findings.

<details>
<summary>Evidence: End-to-end incident demonstration transcript (real product code)</summary>

<code>STEP 2 session_start(reload,isIdle=true) .. idle pi-ext ==&gt; FIXED: stale busy reconciled to idle&#10;STEP 3 session_start(startup,isIdle=true) . busy pi-ext (launch-brief busy preserved)&#10;STEP 4 herdr authoritative state (herdr:pi, skipped) .. idle&#10;classifier verdict .. conflict herdr-idle-stale-busy ==&gt; supervision recovers, never false-busy&#10;herdr authoritative state (screen-detected) .. unknown (conservative rule preserved)&#10;STEP 5 ctx.ui dialog -&gt; {&#34;active&#34;:true,&#34;label&#34;:&#34;confirm&#34;} / {&#34;active&#34;:false,&#34;label&#34;:&#34;confirm&#34;} / LEAKED=false</code>

```text

FIRSTMATE SUPERVISION — stale-busy vs authoritative-idle (live product code)
repo: /Users/pestly/.no-mistakes/worktrees/37d1398da5bd/01KZKDVGB6PWHS4D84QAY03SSX
node: v24.15.0
------------------------------------------------------------
STEP 1  fm-spawn generated the per-task Pi extension:
  /var/folders/p_/qhscbrm561d3rhlj3pv3yz780000gn/T//fm-demo-incident.zqDJjT/demo/home/state/demo-pi.pi-ext.ts
  record seed after arm ....... busy fm-spawn   (launch brief -> busy)
------------------------------------------------------------
STEP 2  Pi 0.84.1 /reload incident: session replaced, agent already idle,
        NO paired agent_settled. Old code left the busy record permanently stale.
        New writer: session_start(reason=reload) reconciles from ctx.isIdle().
  before reload (mid-run) ..... busy pi-ext
  after session_start(reload,isIdle=true) .. idle pi-ext
  ==> FIXED: the stale busy record was reconciled to idle by the reload handler.
------------------------------------------------------------
STEP 3  A fresh startup must NOT clobber the launch-brief busy seed
        (only the arm + agent_start own the initial busy).
  after session_start(startup,isIdle=true) . busy pi-ext   (busy preserved)
------------------------------------------------------------
STEP 4  Reader chain end-to-end — the REAL bin/backends/herdr.sh authoritative
        state feeds the REAL classifier. A stale busy record contradicted by a
        verified full-lifecycle live idle must return CONFLICT, never 'busy'.
  stale record present ............................ busy pi-ext
  herdr authoritative state (herdr:pi, skipped) .. idle   (trusted lifecycle idle)
  classifier verdict .............................. conflict herdr-idle-stale-busy
  ==> CONFLICT: supervision reconciles/recovers the task, never trusts false-busy
  herdr authoritative state (screen-detected) .... unknown   (conservative rule preserved)
------------------------------------------------------------
STEP 5  Interactive question/approval visibility: the ctx.ui wrapper emits
        herdr:blocked around any dialog, leaking ONLY the method label.

  scenario 'resolve' (confirm dialog opens then resolves):
    AFTER_OPEN active_count=1
    {"active":true,"label":"confirm"}
    {"active":false,"label":"confirm"}
    LEAKED=false

  scenario 'nested' (two overlapping dialogs):
    BOTH_OPEN actives=2
    AFTER_INNER inactives=1
    {"active":true,"label":"confirm"}
    {"active":true,"label":"select"}
    {"active":false,"label":"select"}
    {"active":false,"label":"confirm"}

  scenario 'cancel-reject' (dialog rejected — still cleared once):
    REJECTED=true
    {"active":true,"label":"input"}
    {"active":false,"label":"input"}
------------------------------------------------------------
DEMONSTRATION COMPLETE — all steps reflect live product-code behavior.
```
</details>
<details>
<summary>Evidence: Demonstration harness (drives real fm-spawn extension + real classifier)</summary>

```text
#!/usr/bin/env bash
# End-to-end demonstration of the Firstmate stale-busy-vs-authoritative-idle fix.
# Drives the REAL bin/fm-spawn.sh generated Pi extension + the REAL
# bin/fm-busy-lib.sh classifier, reproducing the Pi 0.84.1 /reload incident.
# No source-byte assertions: every line is an observable operator verdict.
set -u
ROOT="${ROOT:?ROOT must point at the repo}"
. "$ROOT/tests/lib.sh"
. "$ROOT/bin/fm-busy-lib.sh"
# Reuse the real test-harness helpers verbatim (fakebin, spawn-case, drivers),
# extracted line-for-line from tests/fm-busy-adapter-wiring.test.sh.
# shellcheck source=/dev/null
. "$(dirname "${BASH_SOURCE[0]}")/_helpers.sh"
SPAWN="$ROOT/bin/fm-spawn.sh"
TMP_ROOT=$(fm_test_tmproot fm-demo-incident)

hr(){ printf '%s\n' "------------------------------------------------------------"; }
say(){ printf '  %s\n' "$*"; }

echo
echo "FIRSTMATE SUPERVISION — stale-busy vs authoritative-idle (live product code)"
echo "repo: $ROOT"
echo "node: $(node --version)"
hr

# --- Reproduce the incident on a real generated Pi extension ------------------
id=demo-pi
rec=$(make_spawn_case demo pi "$id"); read_case_record "$rec"
run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" "$PROJ_DIR" >/dev/null \
  || { echo "SPAWN FAILED"; exit 1; }
state="$HOME_DIR/state"; ext="$state/$id.pi-ext.ts"
echo "STEP 1  fm-spawn generated the per-task Pi extension:"
say "$ext"
say "record seed after arm ....... $(classify pi "$id" "$state")   (launch brief -> busy)"
hr

echo "STEP 2  Pi 0.84.1 /reload incident: session replaced, agent already idle,"
echo "        NO paired agent_settled. Old code left the busy record permanently stale."
echo "        New writer: session_start(reason=reload) reconciles from ctx.isIdle()."
drive_pi_ext "$ext" agent-start >/dev/null   # make the record busy first
say "before reload (mid-run) ..... $(classify pi "$id" "$state")"
SESSION_REASON=reload SESSION_IDLE=1 drive_pi_ext "$ext" session-start >/dev/null
after=$(classify pi "$id" "$state")
say "after session_start(reload,isIdle=true) .. $after"
if [ "$after" = "idle pi-ext" ]; then
  say "==> FIXED: the stale busy record was reconciled to idle by the reload handler."
else
  say "==> REGRESSION: expected 'idle pi-ext', got '$after'"; exit 1
fi
hr

echo "STEP 3  A fresh startup must NOT clobber the launch-brief busy seed"
echo "        (only the arm + agent_start own the initial busy)."
drive_pi_ext "$ext" agent-start >/dev/null
SESSION_REASON=startup SESSION_IDLE=1 drive_pi_ext "$ext" session-start >/dev/null
say "after session_start(startup,isIdle=true) . $(classify pi "$id" "$state")   (busy preserved)"
hr

echo "STEP 4  Reader chain end-to-end — the REAL bin/backends/herdr.sh authoritative"
echo "        state feeds the REAL classifier. A stale busy record contradicted by a"
echo "        verified full-lifecycle live idle must return CONFLICT, never 'busy'."
. "$ROOT/bin/fm-backend.sh"   # real fm_backend_authoritative_state dispatcher
drive_pi_ext "$ext" agent-start >/dev/null   # leave a genuinely-busy stale record
say "stale record present ............................ $(classify pi "$id" "$state")"

hdir="$TMP_ROOT/herdr"; mkdir -p "$hdir/responses"
fb=$(make_herdr_fakebin "$hdir")

# 4a: verified full-lifecycle herdr:pi + screen_detection_skipped, agent idle.
printf '{"result":{"agent":{"agent_status":"idle","screen_detection_skipped":true,"agent_session":{"source":"herdr:pi"}}}}\n' > "$hdir/responses/1.out"
auth=$(PATH="$fb:$PATH" FM_HERDR_LOG="$hdir/log1" FM_HERDR_RESPONSES="$hdir/responses" \
  bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_authoritative_state default:w1:p2' "$ROOT")
say "herdr authoritative state (herdr:pi, skipped) .. $auth   (trusted lifecycle idle)"
verdict=$(PATH="$fb:$PATH" FM_HERDR_LOG="$hdir/log1" FM_HERDR_RESPONSES="$hdir/responses" \
  bash -c '. "$0/bin/fm-backend.sh"; . "$0/bin/fm-busy-lib.sh"; rm -f "$1/responses/.count"; fm_busy_classify herdr default:w1:p2 pi '"$id"' "'"$state"'"' "$ROOT" "$hdir")
say "classifier verdict .............................. $verdict"
case "$verdict" in
  conflict\ herdr-idle-stale-busy)
    say "==> CONFLICT: supervision reconciles/recovers the task, never trusts false-busy";;
  *) say "==> REGRESSION: expected conflict verdict, got '$verdict'"; exit 1;;
esac

# 4b: screen-detected idle (no lifecycle source) must NOT be authoritative.
printf '{"result":{"agent":{"agent_status":"idle","screen_detection_skipped":false,"agent_session":{"source":""}}}}\n' > "$hdir/responses/1.out"
rm -f "$hdir/responses/.count"
auth2=$(PATH="$fb:$PATH" FM_HERDR_LOG="$hdir/log2" FM_HERDR_RESPONSES="$hdir/responses" \
  bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_authoritative_state default:w1:p2' "$ROOT")
say "herdr authoritative state (screen-detected) .... $auth2   (conservative rule preserved)"
[ "$auth2" = unknown ] || { say "==> REGRESSION: screen detection must not be authoritative"; exit 1; }
hr

# --- ctx.ui blocked wrapper: interactive question/approval visibility ---------
echo "STEP 5  Interactive question/approval visibility: the ctx.ui wrapper emits"
echo "        herdr:blocked around any dialog, leaking ONLY the method label."
echo
echo "  scenario 'resolve' (confirm dialog opens then resolves):"
drive_pi_ext_ui "$ext" resolve | sed 's/^/    /'
echo
echo "  scenario 'nested' (two overlapping dialogs):"
drive_pi_ext_ui "$ext" nested | sed 's/^/    /'
echo
echo "  scenario 'cancel-reject' (dialog rejected — still cleared once):"
drive_pi_ext_ui "$ext" cancel-reject | sed 's/^/    /'
hr
echo "DEMONSTRATION COMPLETE — all steps reflect live product-code behavior."
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-control.sh:450` - fm-control.sh `do_exit` gates its pre-exit interrupt on `case &#34;$(busy_verdict)&#34; in busy*)` (bin/fm-control.sh:449-464). The new `conflict` verdict introduced by this change does not match `busy*`, so it skips the interrupt and sends the exit command directly. A Pi agent blocked on an interactive ctx.ui dialog is exactly a case that now yields `conflict`: herdr reports agent_status=blocked, `fm_backend_herdr_classify_agent_status` maps blocked-&gt;idle (bin/backends/herdr.sh:3068), so `fm_backend_authoritative_state` returns idle while the pi-ext record is still busy -&gt; `conflict herdr-idle-stale-busy`. Before this change that agent classified as `busy` and got the dialog-cancelling interrupt (Esc/Ctrl-C) before the exit command. Now the interrupt is skipped and the `/exit` command is typed into a pane with an open modal dialog, which can be swallowed so `wait_agent_state dead` times out and `do_exit` dies (&#34;the agent did not stop within ${EXIT_WAIT}s&#34;). It fails loud rather than silently, but stopping a dialog-blocked Pi worker is now less robust. Consider treating `conflict` like `busy` for the interrupt decision (or otherwise confirming the intended stop semantics for a blocked agent).

🔧 Fix: treat conflict like busy for do_exit pre-exit interrupt
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-busy-state.test.sh` (25 checks incl. authoritative-idle-conflicts-stale-busy)</code>
- <code>`bash tests/fm-busy-adapter-wiring.test.sh` (real fm-spawn Pi extension: reload/startup reconciliation + ctx.ui blocked wrapper)</code>
- <code>`bash tests/fm-crew-state.test.sh` (52 checks)</code>
- <code>`bash tests/fm-backend-herdr.test.sh` (174 checks incl. authoritative_state full-lifecycle vs screen-detected)</code>
- <code>`bash tests/fm-control.test.sh` (36 checks)</code>
- <code>`ROOT=$PWD bash demo-incident.sh` — end-to-end operator transcript over real generated Pi extension + real herdr backend + real classifier</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
