### PR TITLE
feat(bin): bake validation ladder into no-mistakes DOD scaffold

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -38,7 +38,7 @@
 # the three concrete modes at intake before calling this script.
 # The no-mistakes DOD carries the captain's standing validation ladder as fixed
 # scaffold text; briefs add task-specific scenarios on top but never restate or
-# trim the ladder itself. Scout and direct-PR scaffolds do not carry it.
+# trim the ladder itself. Scout, direct-PR, and local-only scaffolds do not carry it.
 # The generated ship brief records the chosen mode as a fixed machine-readable
 # "Delivery contract: mode=<mode>" line. bin/fm-spawn.sh reads that line and refuses
 # to launch a ship task whose explicit --mode disagrees, so an adjusted brief and the

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -36,6 +36,9 @@
 #                the configured merge authority approves, firstmate merges to local main
 # no-mistakes-prod-only is a registry policy, not a task mode; resolve it to one of
 # the three concrete modes at intake before calling this script.
+# The no-mistakes DOD carries the captain's standing validation ladder as fixed
+# scaffold text; briefs add task-specific scenarios on top but never restate or
+# trim the ladder itself. Scout and direct-PR scaffolds do not carry it.
 # The generated ship brief records the chosen mode as a fixed machine-readable
 # "Delivery contract: mode=<mode>" line. bin/fm-spawn.sh reads that line and refuses
 # to launch a ship task whose explicit --mode disagrees, so an adjusted brief and the
@@ -384,6 +387,14 @@ EOF
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 Delivery contract: mode=no-mistakes
+
+## Validation ladder (captain standing policy — part of definition of done)
+- The no-mistakes test round must execute the repo's exact fail-closed validation entrypoint (the full script, not a subset). Non-zero from that script is red, always.
+- PR-scoped agent-driven checks against a stood-up local app are mandatory for the surfaces this diff actually touches (happy path + obvious regressions). Any surface a browser can reach (page, form, redirect target, emailed link) must be exercised by a real browser through the full post-action journey, asserting the final URL stays on the app's public origin and renders the intended page; API-only evidence suffices only for surfaces no browser reaches. Stand the app up as deployed (production build + deployment bind, seeded fixtures), not the dev server.
+- Keep the evidence — commands, output, and the commit each check ran at — in the run log or PR description. A later commit that touches a checked surface (pipeline fix rounds included) voids that surface's evidence until re-run; the last run before the PR is merge-ready must hold current evidence for every touched surface.
+- Local e2e uses fixture/seeded paths only — no paid AI keys.
+- If GitHub Actions schedules no checks or is flaky, run the exact CI unit entrypoint locally and record the exit code in your evidence; never claim GitHub-green when only the local substitute ran.
+
 The task is complete only when committed on your branch.
 When you believe it is complete, append \`done: {summary}\` to the status file and stop.
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -354,6 +354,45 @@ test_no_mistakes_dod_wording() {
   pass "fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe"
 }
 
+# The captain's standing validation ladder is baked into the no-mistakes DOD as
+# fixed scaffold text (post-mortem P4), so briefs can no longer hand-paraphrase
+# or drop words from it. It is no-mistakes-mode policy: scout, direct-PR, and
+# local-only scaffolds must not carry it.
+test_no_mistakes_dod_validation_ladder() {
+  local home id brief
+  home="$TMP_ROOT/ladder-home"
+  mkdir -p "$home/data"
+  id="brief-ladder-e1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "brief was not scaffolded"
+  assert_grep "## Validation ladder (captain standing policy — part of definition of done)" "$brief" \
+    "no-mistakes DOD lost the validation ladder heading"
+  assert_grep "exact fail-closed validation entrypoint (the full script, not a subset)" "$brief" \
+    "validation ladder lost the full-entrypoint bullet"
+  assert_grep "asserting the final URL stays on the app's public origin and renders the intended page" "$brief" \
+    "validation ladder lost the real-browser journey origin assertion"
+  assert_grep "Stand the app up as deployed (production build + deployment bind, seeded fixtures), not the dev server." "$brief" \
+    "validation ladder lost the as-deployed stand-up requirement"
+  assert_grep "voids that surface's evidence until re-run" "$brief" \
+    "validation ladder lost per-head evidence freshness"
+  assert_grep "Local e2e uses fixture/seeded paths only — no paid AI keys." "$brief" \
+    "validation ladder lost the no-paid-keys bullet"
+  assert_grep "never claim GitHub-green when only the local substitute ran" "$brief" \
+    "validation ladder lost the CI-substitute honesty bullet"
+
+  for id_args in "brief-ladder-e2:some-proj --mode direct-PR" "brief-ladder-e3:some-proj --mode local-only" "brief-ladder-e4:some-proj --scout"; do
+    id=${id_args%%:*}
+    # shellcheck disable=SC2086  # args is an intentional word-split arg list
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" ${id_args##*:} >/dev/null 2>&1
+    brief="$home/data/$id/brief.md"
+    assert_present "$brief" "$id: brief was not scaffolded"
+    assert_no_grep "## Validation ladder" "$brief" \
+      "$id: ladder is no-mistakes-mode policy and must not appear in this scaffold"
+  done
+  pass "fm-brief.sh: validation ladder is fixed no-mistakes DOD text and absent elsewhere"
+}
+
 test_ship_project_memory_wording() {
   local home id brief
   home="$TMP_ROOT/project-memory-home"
@@ -719,6 +758,7 @@ test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
+test_no_mistakes_dod_validation_ladder
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -174,6 +174,8 @@ test_help_includes_entire_header() {
   local help
   help=$("$ROOT/bin/fm-brief.sh" --help)
   assert_contains "$help" "Refuses to overwrite an existing brief." "fm-brief.sh --help omitted its header terminator"
+  assert_contains "$help" "Scout, direct-PR, and local-only scaffolds do not carry it." \
+    "fm-brief.sh --help omitted the no-mistakes-only validation ladder note"
   pass "fm-brief.sh: --help renders the complete header"
 }
 

--- a/tests/fm-remote-job-orphan-reap.test.sh
+++ b/tests/fm-remote-job-orphan-reap.test.sh
@@ -41,6 +41,30 @@ pgid_of() { ps -p "$1" -o pgid= 2>/dev/null | tr -d '[:space:]'; }
 
 ppid_of() { ps -p "$1" -o ppid= 2>/dev/null | tr -d '[:space:]'; }
 
+# Wait up to <seconds> for the asynchronous Linux start path to publish its
+# supervisor process, then echo that process id.
+wait_worker() { # <root> <seconds>
+  local root=$1 deadline=$(( $(date +%s) + $2 )) pid
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    pid=$(pgrep -f "^/bin/bash $root/bin/fm-remote-job-worker.sh\$" | head -n 1 || true)
+    case "$pid" in
+      ''|*[!0-9]*) sleep 0.1 ;;
+      *) printf '%s\n' "$pid"; return 0 ;;
+    esac
+  done
+  return 1
+}
+
+# Wait up to <seconds> for a process to reach the requested parent.
+wait_for_ppid() { # <pid> <expected-ppid> <seconds>
+  local pid=$1 expected=$2 deadline=$(( $(date +%s) + $3 ))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    [ "$(ppid_of "$pid")" = "$expected" ] && return 0
+    sleep 0.1
+  done
+  return 1
+}
+
 # Wait up to <seconds> for <pid> to exit; 0 when it did.
 wait_gone() { # <pid> <seconds>
   local pid=$1 deadline=$(( $(date +%s) + $2 ))
@@ -89,7 +113,7 @@ start_worker() {
     # shellcheck source=bin/fm-remote-job-lib.sh
     . "$ROOT/bin/fm-remote-job-lib.sh"
     fm_remote_job_start_linux_worker "$root" "$account_home" >&2 || exit 1
-    pgrep -f "^/bin/bash $root/bin/fm-remote-job-worker.sh\$" | head -n 1
+    wait_worker "$root" 10
   ) || return 1
   case "$pid" in ''|*[!0-9]*) return 1 ;; esac
   printf '%s\n' "$pid"
@@ -110,7 +134,7 @@ SERVE=$(pgrep -P "$WORKER" | head -n 1)
   fail "the serving child is outside the worker's process group"
 pass "the Linux start path puts the whole worker tree in its own process group"
 
-[ "$(ppid_of "$WORKER")" = 1 ] ||
+wait_for_ppid "$WORKER" 1 10 ||
   fail "the fixture worker is not orphaned to init, so this case does not reproduce the leak"
 
 # The exact teardown shape that leaked in production: a fixture cleanup removes


### PR DESCRIPTION
## Intent

Implement post-mortem proposal P4, captain-authorized verbatim: bake the captain's standing validation ladder into bin/fm-brief.sh's no-mistakes Definition-of-done scaffold so task briefs stop hand-paraphrasing it and can no longer drop words from it. The exact text and location are specified in data/ladder-local-e2e-postmortem/report.md section P4: the five-bullet '## Validation ladder (captain standing policy — part of definition of done)' block must be inserted into the DOD heredoc of the no-mistakes mode branch, after the 'Delivery contract: mode=no-mistakes' line, VERBATIM as the report specifies — rewording is explicitly forbidden. The em dashes inside the block are part of the captain-authorized verbatim text and are deliberate; the repo's plain-dash style rule governs tracked Markdown prose, and this block lives in a shell heredoc reproducing authorized text exactly. The ladder is no-mistakes-mode policy only: scout, direct-PR, and local-only scaffolds must NOT carry it. Also required: update the script's usage header where it describes the DOD contents (done as a short fixed-block note near the mode list), keep shellcheck clean per bin/fm-lint.sh (verified locally with the pinned ShellCheck 0.11.0), and extend the colocated tests/fm-brief.test.sh to assert the ladder block's presence in a generated no-mistakes brief and its absence in scout and direct-PR scaffolds (absence in local-only is additionally asserted for the same reason). Task briefs may still add surface-specific scenarios on top; they just no longer carry the ladder itself. Contribution path: this home's origin is the upstream template that cannot be pushed to directly - the fork flow per CONTRIBUTING.md is in use (no-mistakes init --fork-url, push through the gate), and the pipeline opens the cross-repo PR against the upstream repo; the PR then awaits upstream review, which is expected.

## What Changed

- Bake the captain-authorized five-bullet validation ladder verbatim into the no-mistakes Definition-of-done scaffold after the delivery-contract line.
- Document the fixed ladder in the usage header and test its presence in no-mistakes briefs and absence from scout, direct-PR, and local-only scaffolds.

## Risk Assessment

✅ Low: The change is bounded and satisfies the requested no-mistakes-only verbatim ladder insertion with coverage for its presence and absence in other scaffolds.

## Testing

The focused behavior test and end-user CLI scaffold checks succeeded. Evidence shows the verbatim ladder appears only in no-mistakes briefs and is absent from direct-PR, local-only, and scout briefs; the worktree stayed clean. ShellCheck was not rerun because this prompt explicitly prohibited linters/static analysis.

<details>
<summary>Evidence: Generated no-mistakes brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of demo, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/evidence-no-mistakes`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/14/9jywyxlx31v7rrm2dz9b7j6r0000gn/T/no-mistakes-evidence/01KZKN03FC22PJ35VRZJV8EFFS/brief-home/state/evidence-no-mistakes.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/alejandroarias/.no-mistakes/worktrees/9985daa35c87/01KZKN03FC22PJ35VRZJV8EFFS/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/alejandroarias/.no-mistakes/worktrees/9985daa35c87/01KZKN03FC22PJ35VRZJV8EFFS/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes

## Validation ladder (captain standing policy — part of definition of done)
- The no-mistakes test round must execute the repo's exact fail-closed validation entrypoint (the full script, not a subset). Non-zero from that script is red, always.
- PR-scoped agent-driven checks against a stood-up local app are mandatory for the surfaces this diff actually touches (happy path + obvious regressions). Any surface a browser can reach (page, form, redirect target, emailed link) must be exercised by a real browser through the full post-action journey, asserting the final URL stays on the app's public origin and renders the intended page; API-only evidence suffices only for surfaces no browser reaches. Stand the app up as deployed (production build + deployment bind, seeded fixtures), not the dev server.
- Keep the evidence — commands, output, and the commit each check ran at — in the run log or PR description. A later commit that touches a checked surface (pipeline fix rounds included) voids that surface's evidence until re-run; the last run before the PR is merge-ready must hold current evidence for every touched surface.
- Local e2e uses fixture/seeded paths only — no paid AI keys.
- If GitHub Actions schedules no checks or is flaky, run the exact CI unit entrypoint locally and record the exit code in your evidence; never claim GitHub-green when only the local substitute ran.

The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Generated direct-PR brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of demo, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/evidence-direct-pr`

# Rules
1. Never push to the default branch (push only your `fm/evidence-direct-pr` branch). Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/14/9jywyxlx31v7rrm2dz9b7j6r0000gn/T/no-mistakes-evidence/01KZKN03FC22PJ35VRZJV8EFFS/brief-home/state/evidence-direct-pr.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/alejandroarias/.no-mistakes/worktrees/9985daa35c87/01KZKN03FC22PJ35VRZJV8EFFS/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/alejandroarias/.no-mistakes/worktrees/9985daa35c87/01KZKN03FC22PJ35VRZJV8EFFS/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=direct-PR
This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
```
</details>
<details>
<summary>Evidence: Generated local-only brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of demo, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/evidence-local-only`

# Rules
1. Never push to any remote and never open a PR. Work only on your `fm/evidence-local-only` branch; firstmate handles the merge into local `main`.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/14/9jywyxlx31v7rrm2dz9b7j6r0000gn/T/no-mistakes-evidence/01KZKN03FC22PJ35VRZJV8EFFS/brief-home/state/evidence-local-only.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/alejandroarias/.no-mistakes/worktrees/9985daa35c87/01KZKN03FC22PJ35VRZJV8EFFS/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/alejandroarias/.no-mistakes/worktrees/9985daa35c87/01KZKN03FC22PJ35VRZJV8EFFS/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=local-only
This task ships **local-only**: no remote, no PR, no pipeline.
The task is complete only when committed on your branch `fm/evidence-local-only`. Do NOT push, do NOT open a PR, do NOT merge.
Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
When it is implemented and committed, append `done: ready in branch fm/evidence-local-only` to the status file and stop.
The configured merge authority approves the ready branch, then firstmate merges it into local `main` through the guarded fast-forward path.
```
</details>
<details>
<summary>Evidence: Generated scout brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of demo, at a detached HEAD on a clean default branch.
This is a SCOUT task: the deliverable is a written report, not a PR.
The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
The report is the only thing that survives, so anything worth keeping must be in it.

# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/14/9jywyxlx31v7rrm2dz9b7j6r0000gn/T/no-mistakes-evidence/01KZKN03FC22PJ35VRZJV8EFFS/brief-home/state/evidence-scout.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
   FYI progress lines; firstmate reads your pane for that.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
   firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
   treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Definition of done
Write your findings to `/var/folders/14/9jywyxlx31v7rrm2dz9b7j6r0000gn/T/no-mistakes-evidence/01KZKN03FC22PJ35VRZJV8EFFS/brief-home/data/evidence-scout/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
Before reporting done, read and follow `/Users/alejandroarias/.no-mistakes/worktrees/9985daa35c87/01KZKN03FC22PJ35VRZJV8EFFS/.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
```
</details>
<details>
<summary>Evidence: Verbatim ladder and mode-isolation check</summary>

```text
exact ladder: PASS
location: PASS (contract line 55, heading line 57)
mode isolation: PASS (direct-PR, local-only, scout absent)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh tests/fm-brief.test.sh`
- <code>Generated no-mistakes, direct-PR, local-only, and scout briefs with `bin/fm-brief.sh`</code>
- `Compared the generated ladder exactly against the supplied five-bullet intent and checked its placement after the delivery-contract line`
- <code>Ran `bin/fm-brief.sh --help` and verified the usage-header note</code>

</details>

<details>
<summary>⚠️ **Document** - 1 warning</summary>

- ⚠️ `bin/fm-lint.sh` - ShellCheck 0.11.0 is unavailable, so bin/fm-lint.sh could not complete.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
