### PR TITLE
feat(bin): add fm-firefox isolated Firefox/Marionette session owner

### DIFF
--- a/.agents/skills/firefox-marionette/SKILL.md
+++ b/.agents/skills/firefox-marionette/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: firefox-marionette
+description: >-
+  Agent-only guide for driving an isolated, disposable Firefox over Marionette through bin/fm-firefox.sh.
+  Load before choosing or using this route for a task: installing a caller-supplied WebExtension the supported Mozilla way, or driving Firefox web content or extension/browser context without pixel automation, in a fresh profile that never touches the captain's live Firefox/Zen.
+  Covers when to prefer this over Playwright/CDP/FoxMCP, the browser-vs-OS boundary, the no-live-profile safety contract, dependency checks, receipts, cleanup, and the native-host cookie caveat.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# firefox-marionette
+
+`bin/fm-firefox.sh` owns the lifecycle of one isolated, disposable Firefox process driven over Marionette (the W3C WebDriver protocol Firefox speaks natively).
+It exists because Firefox extension work and Gecko-specific behavior cannot be reproduced by Chrome-based tools, and because the supported install/control path must never touch the captain's live browser.
+Read `bin/fm-firefox.sh --help` for the exact commands and flags; this skill is only the judgment layer around them, and never restates the flags.
+
+## When to choose this route
+
+Pick this route only when the task genuinely needs the Gecko engine or a Firefox WebExtension:
+
+- Installing or exercising a caller-supplied Firefox WebExtension through the supported Mozilla temporary-add-on route.
+- Reproducing or verifying Firefox-extension behavior, including extension background/browser context and native-messaging-adjacent flows.
+- Driving real web content in Firefox (DOM read/write, navigation, script) without any pixel automation.
+
+Prefer another tool when the task is not Firefox-specific:
+
+- `chrome-devtools-axi` (and Playwright when configured) own Chrome/Chromium/CDP work and disposable headless Chromium verification.
+- FoxMCP drives the captain's own live, logged-in Zen/Firefox and is only for reading that real session under high trust; never use it for disposable automation, and never point this tool at that live browser.
+- If the work does not need Firefox at all, do not launch Firefox.
+
+## Browser-vs-OS boundary
+
+This tool controls the browser, not the operating system.
+All control flows over Marionette's loopback TCP endpoint: content DOM, extension/browser context, and add-on install.
+It never synthesizes clicks or keystrokes and never needs macOS Accessibility, Screen Recording, or any TCC grant.
+If a task genuinely requires OS-level GUI interaction, this is the wrong tool; do not try to bolt pixel automation onto it.
+
+## No-live-profile safety contract
+
+The tool always creates a fresh, empty, task-owned profile and launches exactly one `-no-remote` Firefox it owns.
+It never attaches to, copies, or enumerates the captain's Firefox/Zen profiles, refuses the shared default endpoint `127.0.0.1:2828`, and applies privileged system access only to its own disposable process.
+`stop` tears down only the process, profile, and port it created, after proving the recorded PID is still our Firefox by its profile path; it refuses ambiguous PID/port/profile ownership rather than killing or deleting anything it cannot prove it created.
+Trust the tool's refusals: an ownership refusal is a stop-and-look signal, never an obstacle to force past.
+
+## Dependencies, receipts, and cleanup
+
+Run `doctor` first; it reports whether a Firefox binary and python3 (both required) resolve, and notes web-ext as an optional unmanaged alternative that this tool does not use.
+Every `start`, `receipt`, and `stop` prints a truthful machine-readable JSON receipt: the owned profile, the avoided shared port, the actual Marionette endpoint, whether the extension installed and its real add-on id, and exactly which resources were created or removed.
+Read the receipt as evidence rather than assuming success, and always `stop` the session when done so no Firefox child, profile, or port is left behind.
+A caller drives the browser by connecting its own WebDriver client to the Marionette endpoint the receipt reports; the tool owns lifecycle and install, not the caller's automation logic.
+
+## Native-host cookie caveat
+
+Profile isolation constrains only this tool's own Firefox profile.
+It does not and cannot constrain a project-specific native messaging host, which can independently discover unrelated Gecko cookie profiles (for example Zen) on the machine.
+When a task drives a project whose native host reads browser cookies and that privacy scope matters, the project must supply its own independently verified cookie-off contract; forward it with the tool's cookie-off/env hook, which passes it through without interpreting it and records it in the receipt as caller-asserted.
+Never claim that this tool's generic browser isolation controls a project native host's cookie behavior; state the boundary honestly and point at the receipt's caveat.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -525,6 +525,7 @@ These skills are not captain-invocable; load them only at their precise triggers
   Never run a registered source's blocking command yourself in a conversational turn.
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the Relay configuration blocker, on a `public-followup ...` `check:` wake or a startup-surfaced public commitment, and on any milestone or terminal wake for a Relay-linked task before posting its completion follow-up; relevant only when Relay is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
+- `firefox-marionette` - load before choosing or using an isolated, disposable Firefox/Marionette browser session through `bin/fm-firefox.sh` to install a supplied extension or drive Firefox web content or extension context without pixel automation.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
 
 ## 14. Relay

--- a/bin/fm-firefox.sh
+++ b/bin/fm-firefox.sh
@@ -389,6 +389,27 @@ PY
   return 0
 }
 
+# In-flight teardown for a start that is interrupted or fails before its session
+# is committed: kill the Firefox we launched (only when the recorded pid is still
+# our own, proven by profile path via ff_pid_is_our_firefox) and remove the fresh
+# profile we created under the state root. Bound to INT/TERM/ERR from just after
+# launch until the state file is written, then cleared, so an interrupted start
+# never orphans a process or leaves a profile/state behind, while a signal after
+# commit never tears down a live, recorded session.
+ff_start_abort() { # exit_code
+  trap - INT TERM ERR
+  local code=${1:-1}
+  if [ -n "${pid:-}" ] && ff_pid_is_our_firefox "$pid" "${profile:-}"; then
+    ff_kill_pid "$pid" || true
+  fi
+  if [ -n "${profile:-}" ] && [ -n "${state_dir:-}" ]; then
+    case "$profile" in
+      "$state_dir"/profile.*) rm -rf "$profile" ;;
+    esac
+  fi
+  exit "$code"
+}
+
 ff_cmd_start() {
   local session="" label="" extension="" system_access=0 headless=1 port="" timeout=$FM_FIREFOX_DEFAULT_TIMEOUT
   local -a env_pairs=() cookie_pairs=()
@@ -478,6 +499,12 @@ ff_cmd_start() {
   pid=$!
   disown 2>/dev/null || true
 
+  # Until the session is committed, any interruption or unexpected failure must
+  # tear down the process and profile we just created (ff_start_abort).
+  trap 'ff_start_abort 130' INT
+  trap 'ff_start_abort 143' TERM
+  trap 'ff_start_abort $?' ERR
+
   # Bounded readiness wait; on failure, clean up everything we created.
   local deadline waited=0 ready=0
   deadline=$((timeout * 4)) # 0.25s ticks
@@ -516,6 +543,8 @@ ff_cmd_start() {
     FF_EXT_PATH="$extension" FF_EXT_INSTALLED="$ext_installed" FF_EXT_ID="$ext_id" \
     FF_ENV_KEYS="$env_keys" FF_COOKIE_OFF_KEYS="$cookie_keys" \
     ff_emit_receipt "$py" | tee "$state_file" >/dev/null
+  # Session is committed; a later signal must not tear down a recorded session.
+  trap - INT TERM ERR
   chmod 600 "$state_file" 2>/dev/null || true
   cat "$state_file"
   return 0

--- a/bin/fm-firefox.sh
+++ b/bin/fm-firefox.sh
@@ -1,0 +1,629 @@
+#!/usr/bin/env bash
+# fm-firefox.sh - own the lifecycle of one isolated, disposable Firefox process
+# driven over Marionette (W3C WebDriver), so any Firstmate worker can install a
+# supplied extension and drive web content without pixel automation, TCC
+# prompts, or touching a live browser profile.
+#
+# Usage:
+#   fm-firefox.sh doctor [--json]
+#   fm-firefox.sh start [--extension <dir|xpi>] [--session <name>] [--label <l>]
+#                       [--system-access] [--headless|--no-headless]
+#                       [--port <n>] [--timeout <seconds>]
+#                       [--env KEY=VALUE ...] [--cookie-off KEY=VALUE ...]
+#   fm-firefox.sh receipt <session>
+#   fm-firefox.sh list
+#   fm-firefox.sh stop <session>
+#
+# What this owner guarantees, and what it refuses:
+#   - It always creates a fresh, empty, task-owned profile directory. It never
+#     attaches to, copies, or reuses a live Firefox/Zen profile, and never
+#     enumerates unrelated browser profiles.
+#   - It self-allocates a fresh loopback Marionette endpoint and refuses the
+#     shared default 127.0.0.1:2828 outright.
+#   - It launches exactly one -no-remote Firefox process it owns, and applies
+#     -remote-allow-system-access only to that disposable process, only when
+#     --system-access is requested.
+#   - stop tears down only the process, profile, and port this tool created for
+#     that session, after proving the recorded PID is still our own Firefox by
+#     its profile path. It refuses ambiguous PID/port/profile ownership rather
+#     than killing or deleting anything it cannot prove it created.
+#
+# Cookie / privacy scope (truthful boundary, not a guarantee this tool can make):
+#   This tool isolates only its own Firefox profile. It does NOT and CANNOT
+#   constrain a project-specific native messaging host, which can independently
+#   discover unrelated Gecko cookie profiles (e.g. Zen) on the machine. A project
+#   that needs its native host's cookie scanning disabled must supply its own
+#   verified cookie-off contract; forward it with --cookie-off KEY=VALUE (or the
+#   generic --env), which this tool passes into the launched process without
+#   interpreting it, and reports as a caller-asserted contract in the receipt.
+#
+# Dependencies: a Firefox binary (resolved from FM_FIREFOX_BIN, then PATH, then
+# the platform default) and python3 (the embedded Marionette client and receipt
+# serializer). web-ext is an optional, unmanaged alternative route, reported by
+# doctor but never required. Windows is unsupported.
+#
+# Test seams (never used in production paths): FM_FIREFOX_BIN overrides the
+# resolved binary, FM_FIREFOX_STATE_DIR overrides the per-user session/state root.
+set -u
+
+FM_FIREFOX_DEFAULT_TIMEOUT=45
+FM_FIREFOX_MARIONETTE_DEFAULT_PORT=2828
+
+ff_err() { printf 'fm-firefox: %s\n' "$*" >&2; }
+
+ff_python() {
+  if command -v python3 >/dev/null 2>&1; then
+    printf '%s\n' python3
+    return 0
+  fi
+  return 1
+}
+
+ff_state_dir() {
+  printf '%s' "${FM_FIREFOX_STATE_DIR:-${TMPDIR:-/tmp}/fm-firefox-${UID}}"
+}
+
+ff_state_file() { printf '%s/%s.json' "$(ff_state_dir)" "$1"; }
+
+# Resolve the Firefox binary without ever scanning a user's profiles. Order:
+# explicit override, PATH, then the well-known platform install location.
+ff_resolve_bin() {
+  local candidate
+  if [ -n "${FM_FIREFOX_BIN:-}" ]; then
+    if [ -x "$FM_FIREFOX_BIN" ] || command -v "$FM_FIREFOX_BIN" >/dev/null 2>&1; then
+      command -v "$FM_FIREFOX_BIN" 2>/dev/null || printf '%s\n' "$FM_FIREFOX_BIN"
+      return 0
+    fi
+    return 1
+  fi
+  if command -v firefox >/dev/null 2>&1; then
+    command -v firefox
+    return 0
+  fi
+  for candidate in \
+    /Applications/Firefox.app/Contents/MacOS/firefox \
+    /Applications/Firefox\ Developer\ Edition.app/Contents/MacOS/firefox \
+    /usr/bin/firefox \
+    /usr/local/bin/firefox \
+    /snap/bin/firefox; do
+    [ -x "$candidate" ] && { printf '%s\n' "$candidate"; return 0; }
+  done
+  return 1
+}
+
+ff_validate_session_name() {
+  case "$1" in
+    ff-[a-z0-9] | ff-[a-z0-9]*) : ;;
+    *) ff_err "session name must start with 'ff-' and contain only lowercase letters, digits, underscores, or dashes: $1"; return 1 ;;
+  esac
+  case "$1" in
+    *[!a-z0-9_-]*) ff_err "session name must contain only lowercase letters, digits, underscores, or dashes: $1"; return 1 ;;
+  esac
+  return 0
+}
+
+ff_sanitize_label() {
+  local raw=${1:-session} out
+  out=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '-' | sed 's/-\{2,\}/-/g; s/^-//; s/-$//')
+  out=${out:0:24}
+  [ -n "$out" ] || out=session
+  printf '%s' "$out"
+}
+
+# Allocate a free loopback TCP port and refuse the shared default. Bind :0, read
+# the assigned port, release it; Firefox (or a fake) then claims it.
+ff_alloc_port() {
+  local py port
+  py=$(ff_python) || { ff_err "python3 is required to allocate a loopback endpoint"; return 1; }
+  port=$("$py" - <<'PY'
+import socket
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+PY
+  ) || { ff_err "could not allocate a loopback endpoint"; return 1; }
+  case "$port" in
+    '' | *[!0-9]*) ff_err "loopback endpoint allocation returned a non-numeric port"; return 1 ;;
+  esac
+  if [ "$port" = "$FM_FIREFOX_MARIONETTE_DEFAULT_PORT" ]; then
+    ff_err "refusing the shared default Marionette endpoint 127.0.0.1:$FM_FIREFOX_MARIONETTE_DEFAULT_PORT"
+    return 1
+  fi
+  printf '%s\n' "$port"
+}
+
+ff_port_connectable() { # host port
+  local py=$1 host=$2 port=$3
+  FF_HOST="$host" FF_PORT="$port" "$py" - <<'PY'
+import os, socket, sys
+try:
+    s = socket.create_connection((os.environ["FF_HOST"], int(os.environ["FF_PORT"])), timeout=1)
+    s.close()
+    sys.exit(0)
+except OSError:
+    sys.exit(1)
+PY
+}
+
+# Minimal Marionette (protocol v3) client: connect, read the hello frame, create
+# a session, install the supplied add-on as a temporary extension, delete the
+# session. Prints the installed add-on id on success. No third-party client
+# needed - only python3's stdlib - so the tool stays dependency-light.
+ff_marionette_install() { # py host port ext_path
+  local py=$1 host=$2 port=$3 ext=$4
+  FF_HOST="$host" FF_PORT="$port" FF_EXT="$ext" "$py" - <<'PY'
+import json, os, socket, sys
+
+host = os.environ["FF_HOST"]
+port = int(os.environ["FF_PORT"])
+ext = os.environ["FF_EXT"]
+
+
+def recv_frame(sock, buf):
+    while b":" not in buf:
+        chunk = sock.recv(4096)
+        if not chunk:
+            raise IOError("marionette closed the connection during framing")
+        buf += chunk
+    length, _, rest = buf.partition(b":")
+    need = int(length)
+    body = rest
+    while len(body) < need:
+        chunk = sock.recv(4096)
+        if not chunk:
+            raise IOError("marionette closed the connection mid-frame")
+        body += chunk
+    return json.loads(body[:need].decode("utf-8")), body[need:]
+
+
+def send(sock, msg_id, name, params):
+    payload = json.dumps([0, msg_id, name, params]).encode("utf-8")
+    sock.sendall(str(len(payload)).encode("ascii") + b":" + payload)
+
+
+def command(sock, buf, msg_id, name, params):
+    send(sock, msg_id, name, params)
+    while True:
+        frame, buf = recv_frame(sock, buf)
+        if isinstance(frame, list) and len(frame) >= 4 and frame[0] == 1 and frame[1] == msg_id:
+            err, result = frame[2], frame[3]
+            if err is not None:
+                raise RuntimeError(json.dumps(err))
+            return result, buf
+
+
+try:
+    sock = socket.create_connection((host, port), timeout=30)
+    sock.settimeout(30)
+    _, buf = recv_frame(sock, b"")  # server hello
+    _, buf = command(sock, buf, 1, "WebDriver:NewSession", {"capabilities": {}})
+    result, buf = command(sock, buf, 2, "Addon:Install", {"path": ext, "temporary": True})
+except Exception as exc:  # noqa: BLE001 - surface any protocol failure verbatim
+    sys.stderr.write("marionette install failed: %s\n" % exc)
+    sys.exit(1)
+
+addon_id = result.get("value") if isinstance(result, dict) else result
+try:
+    command(sock, buf, 3, "WebDriver:DeleteSession", {})
+except Exception:  # noqa: BLE001 - best-effort teardown of the install session
+    pass
+finally:
+    sock.close()
+
+print(addon_id if addon_id is not None else "")
+PY
+}
+
+# Serialize a receipt object from environment-provided scalars plus the caller
+# env-key and cookie-off-key lists. python3 owns escaping so the JSON is always
+# valid.
+ff_emit_receipt() { # writes JSON to stdout
+  local py=$1
+  "$py" - <<'PY'
+import json, os
+
+def as_bool(name):
+    return os.environ.get(name, "") == "1"
+
+def key_list(name):
+    raw = os.environ.get(name, "")
+    return [k for k in raw.split("\x1f") if k]
+
+cookie_off_keys = key_list("FF_COOKIE_OFF_KEYS")
+receipt = {
+    "tool": "fm-firefox",
+    "schema": "fm-firefox.receipt.v1",
+    "session": os.environ.get("FF_SESSION", ""),
+    "state": os.environ.get("FF_STATE", ""),
+    "pid": int(os.environ["FF_PID"]) if os.environ.get("FF_PID", "").isdigit() else None,
+    "firefox": {
+        "binary": os.environ.get("FF_BIN", ""),
+        "no_remote": True,
+        "headless": as_bool("FF_HEADLESS"),
+        "system_access": as_bool("FF_SYSTEM_ACCESS"),
+    },
+    "profile": {
+        "path": os.environ.get("FF_PROFILE", ""),
+        "fresh": True,
+        "owned": True,
+    },
+    "marionette": {
+        "host": os.environ.get("FF_MHOST", "127.0.0.1"),
+        "port": int(os.environ["FF_PORT"]) if os.environ.get("FF_PORT", "").isdigit() else None,
+        "reserved_shared_port_avoided": 2828,
+    },
+    "extension": None,
+    "cookie": {
+        "profile_isolated": True,
+        "profile_owned": True,
+        "native_host_scope": "out-of-scope",
+        "caveat": (
+            "This tool isolates only its own Firefox profile. A project-specific "
+            "native messaging host can independently discover unrelated Gecko "
+            "cookie profiles (e.g. Zen); this tool does not and cannot constrain "
+            "that behavior. Supply a project cookie-off contract via "
+            "--cookie-off/--env to disable it."
+        ),
+        "project_contract": "caller-asserted" if cookie_off_keys else "absent",
+        "project_contract_env_keys": cookie_off_keys,
+    },
+    "caller_env_keys": key_list("FF_ENV_KEYS"),
+    "created_resources": {
+        "profile_dir": os.environ.get("FF_PROFILE", ""),
+        "marionette_port": int(os.environ["FF_PORT"]) if os.environ.get("FF_PORT", "").isdigit() else None,
+        "pid": int(os.environ["FF_PID"]) if os.environ.get("FF_PID", "").isdigit() else None,
+    },
+    "owner_token": os.environ.get("FF_TOKEN", ""),
+}
+ext_path = os.environ.get("FF_EXT_PATH", "")
+if ext_path:
+    receipt["extension"] = {
+        "path": ext_path,
+        "installed": as_bool("FF_EXT_INSTALLED"),
+        "id": os.environ.get("FF_EXT_ID", "") or None,
+        "route": "marionette:Addon:Install(temporary)",
+    }
+print(json.dumps(receipt, indent=2, sort_keys=True))
+PY
+}
+
+ff_write_profile_prefs() { # profile port
+  local profile=$1 port=$2
+  cat > "$profile/user.js" <<PREFS
+// Task-owned, disposable Firefox profile created by fm-firefox.sh.
+user_pref("marionette.port", $port);
+user_pref("browser.shell.checkDefaultBrowser", false);
+user_pref("browser.startup.homepage", "about:blank");
+user_pref("browser.startup.page", 0);
+user_pref("startup.homepage_welcome_url", "about:blank");
+user_pref("startup.homepage_welcome_url.additional", "");
+user_pref("browser.aboutwelcome.enabled", false);
+user_pref("datareporting.policy.dataSubmissionEnabled", false);
+user_pref("datareporting.healthreport.uploadEnabled", false);
+user_pref("toolkit.telemetry.enabled", false);
+user_pref("toolkit.telemetry.unified", false);
+user_pref("app.update.enabled", false);
+user_pref("app.update.auto", false);
+user_pref("extensions.update.enabled", false);
+user_pref("extensions.autoDisableScopes", 0);
+user_pref("extensions.enabledScopes", 15);
+user_pref("xpinstall.signatures.required", false);
+user_pref("browser.tabs.warnOnClose", false);
+user_pref("browser.sessionstore.resume_from_crash", false);
+PREFS
+}
+
+ff_kill_pid() { # pid
+  local pid=$1 i=0
+  kill -TERM "$pid" 2>/dev/null || true
+  while [ "$i" -lt 50 ]; do
+    kill -0 "$pid" 2>/dev/null || return 0
+    sleep 0.1
+    i=$((i + 1))
+  done
+  kill -KILL "$pid" 2>/dev/null || true
+  i=0
+  while [ "$i" -lt 30 ]; do
+    kill -0 "$pid" 2>/dev/null || return 0
+    sleep 0.1
+    i=$((i + 1))
+  done
+  return 1
+}
+
+# Ownership proof: the recorded PID must still be a live process whose command
+# line references the exact profile directory this tool created. Anything else
+# (dead PID, or a reused PID that is not our Firefox) is reported honestly and
+# never killed.
+ff_pid_is_our_firefox() { # pid profile
+  local pid=$1 profile=$2 command
+  kill -0 "$pid" 2>/dev/null || return 2 # dead
+  command=$(ps -p "$pid" -o command= 2>/dev/null || true)
+  case "$command" in
+    *"$profile"*) return 0 ;;
+    *) return 1 ;; # alive but not ours
+  esac
+}
+
+ff_cmd_doctor() {
+  local json=0 py bin webext webext_ver missing=0
+  [ "${1:-}" = "--json" ] && json=1
+  py=$(ff_python || true)
+  bin=$(ff_resolve_bin || true)
+  webext=$(command -v web-ext 2>/dev/null || true)
+  webext_ver=""
+  [ -n "$webext" ] && webext_ver=$(web-ext --version 2>/dev/null | head -1 || true)
+  [ -n "$bin" ] || missing=1
+  [ -n "$py" ] || missing=1
+  if [ "$json" = 1 ]; then
+    [ -n "$py" ] || { ff_err "python3 is required to render the doctor JSON"; return 1; }
+    FF_BIN="$bin" FF_WEBEXT="$webext" FF_WEBEXT_VER="$webext_ver" \
+      FF_MISSING="$missing" "$py" - <<'PY'
+import json, os
+ok = os.environ.get("FF_MISSING", "1") != "1"
+print(json.dumps({
+    "tool": "fm-firefox",
+    "schema": "fm-firefox.doctor.v1",
+    "ok": ok,
+    "firefox": {"resolved": bool(os.environ.get("FF_BIN")), "path": os.environ.get("FF_BIN", "") or None,
+                "required": True},
+    "python3": {"resolved": True, "path": None, "required": True},
+    "web_ext": {"resolved": bool(os.environ.get("FF_WEBEXT")), "path": os.environ.get("FF_WEBEXT", "") or None,
+                "version": os.environ.get("FF_WEBEXT_VER", "") or None, "required": False,
+                "note": "optional, unmanaged alternative install route; not used by this tool"},
+    "install_route": "marionette:Addon:Install(temporary)",
+    "platform_boundary": "macOS and Linux supported; Windows unsupported",
+}, indent=2, sort_keys=True))
+PY
+    [ "$missing" = 1 ] && return 1
+    return 0
+  fi
+  printf 'fm-firefox doctor\n'
+  if [ -n "$bin" ]; then printf '  [ok]      firefox        %s\n' "$bin"; else printf '  [MISSING] firefox        set FM_FIREFOX_BIN or install Firefox\n'; fi
+  if [ -n "$py" ]; then printf '  [ok]      python3        %s\n' "$(command -v python3)"; else printf '  [MISSING] python3        required for the Marionette client and receipts\n'; fi
+  if [ -n "$webext" ]; then printf '  [ok]      web-ext        %s (%s; optional, not used by this tool)\n' "$webext" "${webext_ver:-unknown}"; else printf '  [--]      web-ext        absent (optional alternative route)\n'; fi
+  printf '  install route  marionette:Addon:Install(temporary)\n'
+  printf '  platform       macOS and Linux supported; Windows unsupported\n'
+  [ "$missing" = 1 ] && { ff_err "required dependencies are missing"; return 1; }
+  return 0
+}
+
+ff_cmd_start() {
+  local session="" label="" extension="" system_access=0 headless=1 port="" timeout=$FM_FIREFOX_DEFAULT_TIMEOUT
+  local -a env_pairs=() cookie_pairs=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --session) session=${2:-}; shift 2 ;;
+      --label) label=${2:-}; shift 2 ;;
+      --extension) extension=${2:-}; shift 2 ;;
+      --system-access) system_access=1; shift ;;
+      --headless) headless=1; shift ;;
+      --no-headless) headless=0; shift ;;
+      --port) port=${2:-}; shift 2 ;;
+      --timeout) timeout=${2:-}; shift 2 ;;
+      --env) env_pairs+=("${2:-}"); shift 2 ;;
+      --cookie-off) cookie_pairs+=("${2:-}"); shift 2 ;;
+      *) ff_err "unknown start option: $1"; return 2 ;;
+    esac
+  done
+
+  local py bin
+  py=$(ff_python) || { ff_err "python3 is required"; return 1; }
+  bin=$(ff_resolve_bin) || { ff_err "no Firefox binary found (set FM_FIREFOX_BIN, add firefox to PATH, or install Firefox)"; return 1; }
+
+  case "$timeout" in '' | *[!0-9]*) ff_err "--timeout must be a positive integer of seconds"; return 2 ;; esac
+
+  if [ -n "$extension" ]; then
+    if [ -d "$extension" ]; then
+      [ -f "$extension/manifest.json" ] || { ff_err "extension directory has no manifest.json: $extension"; return 2; }
+    elif [ -f "$extension" ]; then
+      case "$extension" in *.xpi | *.zip) : ;; *) ff_err "extension file must be an .xpi/.zip: $extension"; return 2 ;; esac
+    else
+      ff_err "extension path does not exist: $extension"; return 2
+    fi
+    extension=$(cd "$(dirname "$extension")" && printf '%s/%s' "$(pwd)" "$(basename "$extension")")
+  fi
+
+  if [ -n "$port" ]; then
+    case "$port" in '' | *[!0-9]*) ff_err "--port must be numeric"; return 2 ;; esac
+    [ "$port" != "$FM_FIREFOX_MARIONETTE_DEFAULT_PORT" ] || { ff_err "refusing the shared default Marionette endpoint 127.0.0.1:$FM_FIREFOX_MARIONETTE_DEFAULT_PORT"; return 2; }
+  else
+    port=$(ff_alloc_port) || return 1
+  fi
+
+  if [ -z "$session" ]; then
+    session="ff-$(ff_sanitize_label "${label:-session}")-$$-${RANDOM}"
+  fi
+  ff_validate_session_name "$session" || return 2
+  local state_file
+  state_file=$(ff_state_file "$session")
+  [ -e "$state_file" ] && { ff_err "session already exists: $session"; return 2; }
+
+  local state_dir
+  state_dir=$(ff_state_dir)
+  mkdir -p "$state_dir" || { ff_err "cannot create state directory: $state_dir"; return 1; }
+  chmod 700 "$state_dir" 2>/dev/null || true
+
+  local profile
+  profile=$(mktemp -d "$state_dir/profile.$session.XXXXXX") || { ff_err "cannot create a fresh profile directory"; return 1; }
+  ff_write_profile_prefs "$profile" "$port"
+
+  local token
+  token=$("$py" -c 'import secrets;print(secrets.token_hex(16))')
+
+  # Build env-key manifests (keys only; values never recorded).
+  local env_keys="" cookie_keys="" pair
+  local -a launch_env=()
+  for pair in "${env_pairs[@]:-}"; do
+    [ -n "$pair" ] || continue
+    launch_env+=("$pair")
+    env_keys="${env_keys}${env_keys:+$'\x1f'}${pair%%=*}"
+  done
+  for pair in "${cookie_pairs[@]:-}"; do
+    [ -n "$pair" ] || continue
+    launch_env+=("$pair")
+    cookie_keys="${cookie_keys}${cookie_keys:+$'\x1f'}${pair%%=*}"
+  done
+
+  local -a args=(-no-remote -profile "$profile" -marionette)
+  [ "$headless" = 1 ] && args+=(-headless)
+  [ "$system_access" = 1 ] && args+=(-remote-allow-system-access)
+  args+=(about:blank)
+
+  local pid
+  # Launch exactly one -no-remote Firefox we own; detach it so it survives this
+  # command and the caller can drive the reported endpoint.
+  env "${launch_env[@]:+${launch_env[@]}}" "$bin" "${args[@]}" >"$profile/firefox.log" 2>&1 &
+  pid=$!
+  disown 2>/dev/null || true
+
+  # Bounded readiness wait; on failure, clean up everything we created.
+  local deadline waited=0 ready=0
+  deadline=$((timeout * 4)) # 0.25s ticks
+  while [ "$waited" -lt "$deadline" ]; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      ff_err "Firefox exited before its Marionette endpoint opened; see $profile/firefox.log"
+      rm -rf "$profile"
+      return 1
+    fi
+    if ff_port_connectable "$py" 127.0.0.1 "$port"; then ready=1; break; fi
+    sleep 0.25
+    waited=$((waited + 1))
+  done
+  if [ "$ready" != 1 ]; then
+    ff_err "Firefox Marionette endpoint 127.0.0.1:$port did not open within ${timeout}s"
+    ff_kill_pid "$pid" || true
+    rm -rf "$profile"
+    return 1
+  fi
+
+  local ext_installed=0 ext_id=""
+  if [ -n "$extension" ]; then
+    if ext_id=$(ff_marionette_install "$py" 127.0.0.1 "$port" "$extension"); then
+      ext_installed=1
+    else
+      ff_err "extension install over Marionette failed"
+      ff_kill_pid "$pid" || true
+      rm -rf "$profile"
+      return 1
+    fi
+  fi
+
+  FF_SESSION="$session" FF_STATE="running" FF_PID="$pid" FF_BIN="$bin" \
+    FF_HEADLESS="$headless" FF_SYSTEM_ACCESS="$system_access" FF_PROFILE="$profile" \
+    FF_MHOST="127.0.0.1" FF_PORT="$port" FF_TOKEN="$token" \
+    FF_EXT_PATH="$extension" FF_EXT_INSTALLED="$ext_installed" FF_EXT_ID="$ext_id" \
+    FF_ENV_KEYS="$env_keys" FF_COOKIE_OFF_KEYS="$cookie_keys" \
+    ff_emit_receipt "$py" | tee "$state_file" >/dev/null
+  chmod 600 "$state_file" 2>/dev/null || true
+  cat "$state_file"
+  return 0
+}
+
+ff_cmd_receipt() {
+  local session=${1:-} py state_file
+  [ -n "$session" ] || { ff_err "receipt requires a session id"; return 2; }
+  state_file=$(ff_state_file "$session")
+  [ -f "$state_file" ] || { ff_err "no such session: $session"; return 2; }
+  py=$(ff_python) || { ff_err "python3 is required"; return 1; }
+  local pid profile port live_state
+  pid=$(FF_FILE="$state_file" "$py" -c 'import json,os;print(json.load(open(os.environ["FF_FILE"])).get("pid") or "")')
+  profile=$(FF_FILE="$state_file" "$py" -c 'import json,os;print(json.load(open(os.environ["FF_FILE"]))["profile"]["path"])')
+  port=$(FF_FILE="$state_file" "$py" -c 'import json,os;print(json.load(open(os.environ["FF_FILE"]))["marionette"]["port"] or "")')
+  live_state="stopped"
+  if [ -n "$pid" ] && ff_pid_is_our_firefox "$pid" "$profile"; then
+    if ff_port_connectable "$py" 127.0.0.1 "$port"; then live_state="running"; else live_state="starting"; fi
+  fi
+  FF_FILE="$state_file" FF_LIVE="$live_state" "$py" - <<'PY'
+import json, os
+data = json.load(open(os.environ["FF_FILE"]))
+data["state"] = os.environ["FF_LIVE"]
+print(json.dumps(data, indent=2, sort_keys=True))
+PY
+}
+
+ff_cmd_list() {
+  local state_dir f
+  state_dir=$(ff_state_dir)
+  [ -d "$state_dir" ] || return 0
+  for f in "$state_dir"/*.json; do
+    [ -e "$f" ] || continue
+    basename "$f" .json
+  done
+}
+
+ff_cmd_stop() {
+  local session=${1:-} py state_file
+  [ -n "$session" ] || { ff_err "stop requires a session id"; return 2; }
+  state_file=$(ff_state_file "$session")
+  [ -f "$state_file" ] || { ff_err "no such session: $session"; return 2; }
+  py=$(ff_python) || { ff_err "python3 is required"; return 1; }
+  local pid profile state_dir
+  pid=$(FF_FILE="$state_file" "$py" -c 'import json,os;print(json.load(open(os.environ["FF_FILE"])).get("pid") or "")')
+  profile=$(FF_FILE="$state_file" "$py" -c 'import json,os;print(json.load(open(os.environ["FF_FILE"]))["profile"]["path"])')
+  state_dir=$(ff_state_dir)
+
+  # Refuse to delete a profile path outside the state root this tool owns.
+  case "$profile" in
+    "$state_dir"/profile.*) : ;;
+    *) ff_err "refusing to remove a profile outside the tool's state root: $profile"; return 1 ;;
+  esac
+
+  local killed="none"
+  if [ -n "$pid" ]; then
+    if ff_pid_is_our_firefox "$pid" "$profile"; then
+      if ff_kill_pid "$pid"; then
+        killed="terminated"
+      else
+        ff_err "could not terminate our Firefox pid $pid"
+        return 1
+      fi
+    else
+      local rc=$?
+      if [ "$rc" = 2 ]; then
+        killed="already-dead"
+      else
+        ff_err "refusing to kill pid $pid: it is alive but not the Firefox this tool started (profile ownership unproven)"
+        return 1
+      fi
+    fi
+  fi
+
+  [ -d "$profile" ] && rm -rf "$profile"
+  rm -f "$state_file"
+
+  FF_SESSION="$session" FF_KILLED="$killed" FF_PROFILE="$profile" FF_PID="$pid" "$py" - <<'PY'
+import json, os
+print(json.dumps({
+    "tool": "fm-firefox",
+    "schema": "fm-firefox.cleanup.v1",
+    "session": os.environ["FF_SESSION"],
+    "process": os.environ["FF_KILLED"],
+    "removed": {
+        "profile_dir": os.environ["FF_PROFILE"],
+        "state_file": True,
+        "pid": int(os.environ["FF_PID"]) if os.environ.get("FF_PID", "").isdigit() else None,
+    },
+    "touched_only_owned_resources": True,
+}, indent=2, sort_keys=True))
+PY
+}
+
+ff_usage() { awk 'NR==1{next} /^#/{sub(/^# ?/,"");print;next} {exit}' "$0"; }
+
+main() {
+  local cmd=${1:-}
+  [ $# -gt 0 ] && shift || true
+  case "$cmd" in
+    doctor) ff_cmd_doctor "$@" ;;
+    start) ff_cmd_start "$@" ;;
+    receipt) ff_cmd_receipt "$@" ;;
+    list) ff_cmd_list "$@" ;;
+    stop) ff_cmd_stop "$@" ;;
+    -h | --help | help | '') ff_usage ;;
+    *) ff_err "unknown command: $cmd"; ff_usage >&2; return 2 ;;
+  esac
+}
+
+main "$@"

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -137,7 +137,7 @@ family_for_basename() {
     fm-calm-pi-extension.test.sh|fm-cd-pretool-check.test.sh|\
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
     fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
-    fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
+    fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-firefox-marionette.test.sh|fm-grok-harness.test.sh|\
     fm-kimi-harness.test.sh|fm-muse-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
     fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|\
@@ -182,6 +182,7 @@ family_for_basename() {
     fm-afk-pi-herdr-return-e2e.test.sh|\
     fm-codex-continuity-live-e2e.test.sh|fm-grok-continuity-live-e2e.test.sh|\
     fm-grok-stop-live-e2e.test.sh|fm-harness-liveness-drift-live-e2e.test.sh|\
+    fm-firefox-marionette-live-e2e.test.sh|\
     fm-muse-signals-live-e2e.test.sh|\
     fm-herdr-version-floor-live-e2e.test.sh|\
     fm-opencode-primary-live-e2e.test.sh|fm-pi-primary-live-e2e.test.sh|\
@@ -396,6 +397,8 @@ tests/fm-daemon.test.sh 15140
 tests/fm-documentation-audiences.test.sh 572
 tests/fm-fleet-snapshot-view.test.sh 5902
 tests/fm-fleet-sync.test.sh 16417
+tests/fm-firefox-marionette-live-e2e.test.sh 20
+tests/fm-firefox-marionette.test.sh 5675
 tests/fm-gate-refuse.test.sh 2839
 tests/fm-gitignore-config.test.sh 28
 tests/fm-gotmp.test.sh 308

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -137,6 +137,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/firefox-marionette/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/firstmate-codexapp/SKILL.md",
       "audience": "agent-runtime"
     },
@@ -249,6 +253,10 @@
       "audience": "maintainer-architecture"
     },
     {
+      "path": "docs/firefox-marionette.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/examples/crew-dispatch.json",
       "audience": "operator-example"
     },
@@ -330,6 +338,10 @@
     },
     {
       "path": "docs/verification/dispatch-auth.md",
+      "audience": "maintainer-verification"
+    },
+    {
+      "path": "docs/verification/firefox-marionette.md",
       "audience": "maintainer-verification"
     },
     {

--- a/docs/firefox-marionette.md
+++ b/docs/firefox-marionette.md
@@ -1,0 +1,34 @@
+# Isolated Firefox over Marionette
+
+`bin/fm-firefox.sh` is a harness-agnostic CLI that owns the lifecycle of one isolated, disposable Firefox process driven over Marionette, the W3C WebDriver protocol Firefox speaks natively.
+Any Firstmate worker, on any harness, invokes it through the shell to install a caller-supplied WebExtension and drive Firefox web content or extension context without pixel automation, TCC prompts, or touching a live browser.
+The script header and `bin/fm-firefox.sh --help` own the exact commands and flags; this page is the operator overview and does not restate them.
+Agents choosing between this and other browser tools load the `firefox-marionette` skill; current verification evidence lives in [verification/firefox-marionette.md](verification/firefox-marionette.md).
+
+## What it does
+
+- `doctor` diagnoses dependencies: a Firefox binary and python3 are required, and web-ext is reported as an optional, unmanaged alternative this tool does not use.
+- `start` creates a fresh task-owned profile, self-allocates a loopback Marionette endpoint, launches exactly one `-no-remote` Firefox, optionally enables privileged system access for that process, installs a supplied extension through the supported Mozilla temporary-add-on route, and prints a machine-readable receipt.
+- `receipt` and `list` report owned sessions and their live state; `stop` tears down only what that session created.
+
+The one supported install route is Marionette's `Addon:Install` with `temporary` set, which is why the tool can own exactly one Firefox process rather than delegating the launch to an external runner.
+
+## Safety guarantees operators can rely on
+
+- It always creates a fresh, empty profile and never attaches to, copies, or enumerates the machine's real Firefox/Zen profiles.
+- It refuses the shared default endpoint `127.0.0.1:2828` and allocates its own loopback port instead.
+- It applies `-remote-allow-system-access` only to its own disposable process, only when asked.
+- `stop` proves ownership by the recorded PID's profile path before terminating anything, and refuses ambiguous PID/port/profile ownership rather than killing or deleting resources it cannot prove it created.
+
+## Platform boundary
+
+macOS and Linux are supported; Windows is unsupported.
+The tool needs a resolvable Firefox binary (`FM_FIREFOX_BIN`, then `PATH`, then the platform default install location) and python3.
+Control is entirely in-browser over a loopback TCP endpoint, so it never requires macOS Accessibility or Screen Recording permission.
+
+## Native-host cookie caveat
+
+Profile isolation here constrains only this tool's own Firefox profile.
+It does not and cannot constrain a project-specific native messaging host, which can independently discover unrelated Gecko cookie profiles such as Zen on the same machine.
+When a project's native host reads browser cookies and that scope matters, the project must supply its own independently verified cookie-off contract; forward it with the tool's cookie-off/env hook, which passes it through unchanged and records it in the receipt as caller-asserted.
+The receipt's cookie block carries the authoritative caveat wording; never describe generic browser isolation as controlling a project native host's cookie behavior.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -28,6 +28,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions                 |
 | `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs   |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
+| `fm-firefox.sh`          | Own the lifecycle of one isolated, disposable Firefox over Marionette: fresh profile, self-allocated loopback endpoint, single -no-remote launch, supported-route extension install, truthful receipts, owned-only cleanup (docs/firefox-marionette.md) |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |
 | `fm-install-treehouse.sh`| Install CI's exact-version Treehouse pin for real-Herdr E2E that needs spawn worktrees |
 | `fm-herdr-ci-cleanup.sh` | Snapshot and tear down only job-owned `fm-lab-*` sessions in the Herdr CI lane       |

--- a/docs/verification/firefox-marionette.md
+++ b/docs/verification/firefox-marionette.md
@@ -1,0 +1,95 @@
+# Verification: isolated Firefox over Marionette
+
+Active empirical evidence for `bin/fm-firefox.sh`.
+Operator overview is [../firefox-marionette.md](../firefox-marionette.md); refresh this record after a Firefox upgrade or a change to the tool's launch, install, or cleanup behavior by re-running the commands below.
+
+## Environment (2026-08-09)
+
+- Firefox: `Mozilla Firefox 153.0.3` at `/Applications/Firefox.app/Contents/MacOS/firefox` (macOS, Darwin 25.4.0).
+- python3: `Python 3.12.10`.
+- marionette_driver (WebDriver client used only by the live proof, not by the tool): `3.7.1`.
+- web-ext (optional, unmanaged, not used by the tool): `10.1.0`.
+
+An earlier Firefox `152.0.6` on the same machine proved the same route during the originating investigation (`data/scout-mg-firefox-deploy/report.md`).
+
+## Hermetic command-surface behavior (runs in standard CI)
+
+```
+$ bash tests/fm-firefox-marionette.test.sh
+ok - dependency failure is diagnosed and refused
+ok - start creates a clean owned profile, avoids 2828, and emits a truthful receipt
+ok - cookie caveat is truthful and the caller cookie-off contract is recorded by key only
+ok - stop removes exactly the profile, state, and process it created
+ok - extension is optional and absent cookie contract is reported honestly
+ok - extension paths are validated before any launch
+ok - the shared 127.0.0.1:2828 endpoint is refused
+ok - ambiguous pid ownership is refused instead of guessing
+ok - a profile path outside the state root is never removed
+ok - a Firefox that dies before readiness is cleaned up with no leftovers
+ok - a Firefox that never opens the endpoint is killed and cleaned up
+ok - an extension install failure is cleaned up with no leftovers
+ok - fm-firefox.sh hermetic command-surface behavior
+```
+
+This test drives the tool against a fake Firefox that speaks the real Marionette (protocol v3) wire format the tool's client emits, so it needs no real browser, no network, and no third-party WebDriver client.
+
+## Live proof (opt-in, self-skipping)
+
+`tests/fm-firefox-marionette-live-e2e.test.sh` self-skips unless `FM_FIREFOX_LIVE_E2E=1` and Firefox, python3, and marionette_driver are all present, so standard CI stays hermetic.
+Run it after a Firefox upgrade to refresh this record:
+
+```
+$ FM_FIREFOX_LIVE_E2E=1 bash tests/fm-firefox-marionette-live-e2e.test.sh
+ok - fm-firefox live E2E (Mozilla Firefox 153.0.3): real add-on install, web-content and extension-context control, no unrelated browser touched, no leftovers
+```
+
+It installs a synthetic local extension, serves a page over loopback HTTP (no external URL), and through an independent Marionette client proves: the add-on is installed and active, the extension is controllable in the browser context (its `WebExtensionPolicy` name), its content script ran on the page, and Marionette drives the page DOM directly - all without pixel clicks.
+It then proves `stop` left no Firefox child, profile, or port behind, and that every unrelated Firefox/Zen process and the shared `127.0.0.1:2828` endpoint were unchanged.
+
+## doctor
+
+```
+$ bin/fm-firefox.sh doctor
+fm-firefox doctor
+  [ok]      firefox        /Applications/Firefox.app/Contents/MacOS/firefox
+  [ok]      python3        /Library/Frameworks/Python.framework/Versions/3.12/bin/python3
+  [ok]      web-ext        /Users/pestly/.npm-global/bin/web-ext (10.1.0; optional, not used by this tool)
+  install route  marionette:Addon:Install(temporary)
+  platform       macOS and Linux supported; Windows unsupported
+```
+
+## Representative receipts
+
+`start` with a supplied extension, privileged system access, and a caller cookie-off contract (values elided by design; only keys are recorded):
+
+```
+"cookie": {
+  "native_host_scope": "out-of-scope",
+  "profile_isolated": true,
+  "project_contract": "caller-asserted",
+  "project_contract_env_keys": ["MG_COOKIE_SOURCE"]
+},
+"extension": {
+  "id": "fm-evidence@firstmate.local",
+  "installed": true,
+  "route": "marionette:Addon:Install(temporary)"
+},
+"firefox": {"headless": true, "no_remote": true, "system_access": true},
+"marionette": {"host": "127.0.0.1", "port": 50922, "reserved_shared_port_avoided": 2828}
+```
+
+`stop` teardown receipt:
+
+```
+{
+  "process": "terminated",
+  "removed": {"pid": 310, "profile_dir": ".../profile.ff-evidence.L0tay6", "state_file": true},
+  "schema": "fm-firefox.cleanup.v1",
+  "touched_only_owned_resources": true
+}
+```
+
+## What is proven live vs. documented
+
+- Proven live on this Mac: dependency diagnosis, fresh owned-profile creation, loopback endpoint allocation avoiding 2828, single `-no-remote` launch, temporary add-on install over Marionette, real web-content and extension-context control, and exact teardown that leaves unrelated browsers and the shared endpoint untouched.
+- Documented, not exercised here: Linux is a supported platform by binary resolution and the same Marionette route, but the live receipts above are macOS only. Windows is unsupported.

--- a/tests/fm-firefox-marionette-live-e2e.test.sh
+++ b/tests/fm-firefox-marionette-live-e2e.test.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Opt-in live proof for bin/fm-firefox.sh against a real Firefox. It installs a
+# synthetic local extension, drives a loopback-served page (no external URL) and
+# the extension's browser context over Marionette without pixel automation, and
+# proves it changed no existing Firefox/Zen process, profile, or endpoint and
+# left nothing behind. Standard CI stays hermetic because this self-skips unless
+# FM_FIREFOX_LIVE_E2E=1 and Firefox + python3 + a WebDriver (marionette_driver)
+# client are all present.
+set -u
+
+if [ "${FM_FIREFOX_LIVE_E2E:-0}" != 1 ]; then
+  echo "skip: set FM_FIREFOX_LIVE_E2E=1 to run the live isolated-Firefox proof"
+  exit 0
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TOOL="$ROOT/bin/fm-firefox.sh"
+
+skip() { echo "skip: $1"; exit 0; }
+fail() { printf 'not ok - %s\n' "$1" >&2; exit 1; }
+
+command -v python3 >/dev/null 2>&1 || skip "python3 is required for the live proof"
+python3 -c 'import marionette_driver' 2>/dev/null || skip "marionette_driver (WebDriver client) is not installed"
+"$TOOL" doctor >/dev/null 2>&1 || skip "no Firefox binary resolved for the live proof"
+
+LAB=$(mktemp -d "${TMPDIR:-/tmp}/fm-ff-live.XXXXXX")
+export FM_FIREFOX_STATE_DIR="$LAB/state"
+SESSION="ff-live-$$"
+HTTP_PID=""
+
+# Snapshot every unrelated Firefox/Zen main process so we can prove none of them
+# was restarted or killed. Our own disposable process lives under $LAB and is
+# excluded by path.
+snapshot_browsers() {
+  pgrep -lf 'Applications/(Firefox|Zen)\.app/Contents/MacOS/(firefox|zen)' 2>/dev/null |
+    grep -v "$LAB" | awk '{print $1}' | sort -n
+}
+BROWSERS_BEFORE=$(snapshot_browsers)
+PORT_2828_BEFORE=$(lsof -nP -iTCP:2828 -sTCP:LISTEN 2>/dev/null | tail -n +2 | awk '{print $2}' | sort -n)
+
+cleanup() {
+  [ -n "$HTTP_PID" ] && kill "$HTTP_PID" 2>/dev/null || true
+  "$TOOL" stop "$SESSION" >/dev/null 2>&1 || true
+  rm -rf "$LAB"
+}
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+
+# Synthetic local extension: a content script that marks any page it runs on,
+# plus a background message listener. No remote code, no external URL.
+EXT="$LAB/ext"
+mkdir -p "$EXT"
+cat > "$EXT/manifest.json" <<'JSON'
+{
+  "manifest_version": 2,
+  "name": "fm-firefox live-e2e probe",
+  "version": "0.0.1",
+  "browser_specific_settings": { "gecko": { "id": "fm-live-e2e-probe@firstmate.local" } },
+  "permissions": ["<all_urls>"],
+  "background": { "scripts": ["bg.js"] },
+  "content_scripts": [ { "matches": ["<all_urls>"], "js": ["cs.js"], "run_at": "document_idle" } ]
+}
+JSON
+printf '%s\n' 'browser.runtime.onMessage.addListener((m) => Promise.resolve({ pong: m && m.ping }));' > "$EXT/bg.js"
+printf '%s\n' 'document.documentElement.setAttribute("data-fm-firefox-probe", "content-script-ran");' > "$EXT/cs.js"
+
+# Loopback page server: a real page over http://127.0.0.1, never an external URL.
+WWW="$LAB/www"
+mkdir -p "$WWW"
+printf '%s\n' '<!doctype html><html><head><title>fm-firefox live probe</title></head><body><h1 id="marker">initial</h1></body></html>' > "$WWW/probe.html"
+HTTP_PORT=$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')
+( cd "$WWW" && exec python3 -m http.server "$HTTP_PORT" --bind 127.0.0.1 >/dev/null 2>&1 ) &
+HTTP_PID=$!
+sleep 0.5
+
+# --- launch the disposable Firefox and install the extension through the tool.
+RECEIPT=$("$TOOL" start --session "$SESSION" --extension "$EXT" --system-access) \
+  || fail "fm-firefox start failed"
+FF_PORT=$(FF_JSON="$RECEIPT" python3 -c 'import json,os;print(json.loads(os.environ["FF_JSON"])["marionette"]["port"])')
+FF_PROFILE=$(FF_JSON="$RECEIPT" python3 -c 'import json,os;print(json.loads(os.environ["FF_JSON"])["profile"]["path"])')
+FF_PID=$(FF_JSON="$RECEIPT" python3 -c 'import json,os;print(json.loads(os.environ["FF_JSON"])["pid"])')
+FF_EXT_ID=$(FF_JSON="$RECEIPT" python3 -c 'import json,os;print(json.loads(os.environ["FF_JSON"])["extension"]["id"])')
+
+[ "$FF_PORT" != 2828 ] || fail "the tool must never allocate the shared 2828 endpoint"
+[ "$FF_EXT_ID" = "fm-live-e2e-probe@firstmate.local" ] || fail "receipt add-on id did not match the synthetic extension"
+case "$FF_PROFILE" in "$LAB"/state/profile.*) : ;; *) fail "profile is not a task-owned disposable directory: $FF_PROFILE" ;; esac
+
+# --- independent verification over Marionette (no pixel clicks): a fresh
+# WebDriver client the tool did not use for install, proving real add-on install,
+# web-content control, and extension/browser-context control.
+VERIFY=$(FF_PORT="$FF_PORT" FF_URL="http://127.0.0.1:$HTTP_PORT/probe.html" FF_EXT_ID="$FF_EXT_ID" python3 - <<'PY'
+import os, time
+from marionette_driver.marionette import Marionette
+
+m = Marionette(host="127.0.0.1", port=int(os.environ["FF_PORT"]))
+m.start_session()
+out = {}
+try:
+    m.set_context("chrome")
+    addons = m.execute_async_script(
+        """
+        let wanted = arguments[0];
+        let cb = arguments[arguments.length-1];
+        const { AddonManager } = ChromeUtils.importESModule("resource://gre/modules/AddonManager.sys.mjs");
+        AddonManager.getAllAddons().then(list => cb(
+          list.filter(a => a.id === wanted).map(a => a.isActive)
+        ));
+        """,
+        script_args=[os.environ["FF_EXT_ID"]],
+    )
+    out["addon_active"] = bool(addons) and addons[0] is True
+    policy = m.execute_script(
+        "const p = WebExtensionPolicy.getByID(arguments[0]); return p ? p.name : null;",
+        script_args=[os.environ["FF_EXT_ID"]],
+    )
+    out["ext_context_name"] = policy
+
+    m.set_context("content")
+    m.navigate(os.environ["FF_URL"])
+    time.sleep(0.6)
+    out["content_script_effect"] = m.execute_script(
+        'return document.documentElement.getAttribute("data-fm-firefox-probe");'
+    )
+    m.execute_script('document.getElementById("marker").textContent = "driven-by-marionette";')
+    out["direct_dom_control"] = m.execute_script('return document.getElementById("marker").textContent;')
+finally:
+    m.delete_session()
+
+print("addon_active=%s" % out.get("addon_active"))
+print("ext_context_name=%s" % out.get("ext_context_name"))
+print("content_script_effect=%s" % out.get("content_script_effect"))
+print("direct_dom_control=%s" % out.get("direct_dom_control"))
+PY
+) || fail "Marionette verification failed"
+
+grep -q '^addon_active=True$' <<<"$VERIFY" || fail "the add-on was not installed and active: $VERIFY"
+grep -q '^ext_context_name=fm-firefox live-e2e probe$' <<<"$VERIFY" || fail "extension browser-context control failed: $VERIFY"
+grep -q '^content_script_effect=content-script-ran$' <<<"$VERIFY" || fail "the extension's content script did not run on the page: $VERIFY"
+grep -q '^direct_dom_control=driven-by-marionette$' <<<"$VERIFY" || fail "direct web-content control failed: $VERIFY"
+
+# --- tear down through the tool and prove exact cleanup.
+CLEAN=$("$TOOL" stop "$SESSION") || fail "fm-firefox stop failed"
+grep -q '"touched_only_owned_resources": true' <<<"$CLEAN" || fail "cleanup did not assert owned-only teardown"
+
+[ ! -d "$FF_PROFILE" ] || fail "the disposable profile was left behind: $FF_PROFILE"
+[ ! -f "$LAB/state/$SESSION.json" ] || fail "the session state file was left behind"
+kill -0 "$FF_PID" 2>/dev/null && fail "the disposable Firefox process was left running (pid $FF_PID)"
+pgrep -f "$LAB" >/dev/null 2>&1 && fail "a Firefox child referencing our lab was left behind"
+python3 -c "import socket,sys
+try:
+    s=socket.create_connection(('127.0.0.1',$FF_PORT),timeout=1); s.close(); sys.exit(1)
+except OSError:
+    sys.exit(0)" || fail "the Marionette port $FF_PORT was left bound after cleanup"
+
+# --- prove no unrelated browser or the shared endpoint changed.
+BROWSERS_AFTER=$(snapshot_browsers)
+[ "$BROWSERS_BEFORE" = "$BROWSERS_AFTER" ] || fail "an unrelated Firefox/Zen process changed:"$'\n'"before: $BROWSERS_BEFORE"$'\n'"after:  $BROWSERS_AFTER"
+PORT_2828_AFTER=$(lsof -nP -iTCP:2828 -sTCP:LISTEN 2>/dev/null | tail -n +2 | awk '{print $2}' | sort -n)
+[ "$PORT_2828_BEFORE" = "$PORT_2828_AFTER" ] || fail "the shared 127.0.0.1:2828 endpoint owner changed"
+
+FF_VERSION=$("$(FM_FIREFOX_BIN="${FM_FIREFOX_BIN:-}" bash -c 'command -v firefox 2>/dev/null || echo /Applications/Firefox.app/Contents/MacOS/firefox')" --version 2>/dev/null | head -1 || echo "Firefox")
+echo "ok - fm-firefox live E2E ($FF_VERSION): real add-on install, web-content and extension-context control, no unrelated browser touched, no leftovers"

--- a/tests/fm-firefox-marionette.test.sh
+++ b/tests/fm-firefox-marionette.test.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# Hermetic behavior tests for bin/fm-firefox.sh. A fake Firefox binary speaks the
+# real Marionette (protocol v3) wire format the tool's client emits, so these
+# tests exercise the tool's public command surface end to end with no real
+# browser, no network, and no third-party WebDriver client. They assert observed
+# behavior and receipt fields only, never implementation source bytes.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TOOL="$ROOT/bin/fm-firefox.sh"
+TMP_ROOT=$(fm_test_tmproot fm-firefox)
+FAKEBIN=$(fm_fakebin "$TMP_ROOT")
+STATE_DIR="$TMP_ROOT/state"
+ENV_ECHO="$TMP_ROOT/env-echo"
+EXT_DIR="$TMP_ROOT/ext"
+
+export FM_FIREFOX_STATE_DIR="$STATE_DIR"
+export FM_FIREFOX_BIN="$FAKEBIN/firefox"
+export FM_FAKE_FF_ENV_ECHO="$ENV_ECHO"
+
+# Track any real background pid a case starts, so a mid-test failure still leaves
+# no fake Firefox or stray sleep behind.
+STRAY_PIDS=()
+cleanup() {
+  local p
+  for p in "${STRAY_PIDS[@]:-}"; do
+    [ -n "$p" ] && kill -KILL "$p" 2>/dev/null || true
+  done
+  fm_test_cleanup
+}
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+
+# --- fake Firefox: reads marionette.port from the profile, serves the wire
+# protocol, honors FM_FAKE_FF_MODE for the failure paths.
+cat > "$FAKEBIN/firefox" <<'PY'
+#!/usr/bin/env python3
+import json, os, re, socket, sys, time
+
+mode = os.environ.get("FM_FAKE_FF_MODE", "serve")
+echo = os.environ.get("FM_FAKE_FF_ENV_ECHO")
+if echo:
+    with open(echo, "w") as fh:
+        fh.write(os.environ.get("FMFF_TEST_FWD", ""))
+
+if mode == "exit-immediately":
+    sys.stderr.write("fake firefox: exiting before marionette\n")
+    sys.exit(1)
+
+profile = None
+argv = sys.argv[1:]
+for i, a in enumerate(argv):
+    if a == "-profile" and i + 1 < len(argv):
+        profile = argv[i + 1]
+if not profile:
+    sys.exit(2)
+
+port = None
+try:
+    with open(os.path.join(profile, "user.js")) as fh:
+        m = re.search(r'marionette\.port"\s*,\s*(\d+)', fh.read())
+        if m:
+            port = int(m.group(1))
+except OSError:
+    pass
+if not port:
+    sys.exit(3)
+
+if mode == "stall":
+    # Alive but never opens the endpoint: exercises the readiness timeout.
+    time.sleep(600)
+    sys.exit(0)
+
+
+def read_frame(conn, buf):
+    while b":" not in buf:
+        chunk = conn.recv(4096)
+        if not chunk:
+            return None, buf
+        buf += chunk
+    length, _, rest = buf.partition(b":")
+    need = int(length)
+    body = rest
+    while len(body) < need:
+        chunk = conn.recv(4096)
+        if not chunk:
+            return None, body
+        body += chunk
+    return json.loads(body[:need].decode("utf-8")), body[need:]
+
+
+def send(conn, obj):
+    payload = json.dumps(obj).encode("utf-8")
+    conn.sendall(str(len(payload)).encode("ascii") + b":" + payload)
+
+
+def addon_id_for(path):
+    try:
+        with open(os.path.join(path, "manifest.json")) as fh:
+            data = json.load(fh)
+        return data["browser_specific_settings"]["gecko"]["id"]
+    except (OSError, KeyError, ValueError):
+        return "unknown@fake"
+
+
+srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+srv.bind(("127.0.0.1", port))
+srv.listen(8)
+
+while True:
+    try:
+        conn, _ = srv.accept()
+    except OSError:
+        continue
+    # A single dropped or reset connection (e.g. the tool's readiness probe that
+    # connects and closes) must never take down the whole fake server.
+    try:
+        send(conn, {"applicationType": "gecko", "marionetteProtocol": 3})
+        buf = b""
+        while True:
+            frame, buf = read_frame(conn, buf)
+            if frame is None:
+                break
+            _, msg_id, name, params = frame
+            if name == "Addon:Install" and mode == "install-fail":
+                send(conn, [1, msg_id, {"error": "unknown error", "message": "fake install refusal"}, None])
+            elif name == "Addon:Install":
+                send(conn, [1, msg_id, None, {"value": addon_id_for(params.get("path", ""))}])
+            else:
+                send(conn, [1, msg_id, None, {}])
+    except OSError:
+        pass
+    finally:
+        try:
+            conn.close()
+        except OSError:
+            pass
+PY
+chmod +x "$FAKEBIN/firefox"
+
+mkdir -p "$EXT_DIR"
+cat > "$EXT_DIR/manifest.json" <<'JSON'
+{
+  "manifest_version": 2,
+  "name": "fm-firefox hermetic probe",
+  "version": "0.0.1",
+  "browser_specific_settings": { "gecko": { "id": "fm-hermetic-probe@firstmate.local" } }
+}
+JSON
+
+json_field() { # <json> <python-expr on data>
+  FF_JSON="$1" python3 -c "import json,os;data=json.loads(os.environ['FF_JSON']);print($2)"
+}
+
+# --- 1) dependency failure ---------------------------------------------------
+out=$(FM_FIREFOX_BIN=/nonexistent/firefox "$TOOL" doctor --json 2>/dev/null); code=$?
+expect_code 1 "$code" "doctor --json must fail when Firefox is unresolved"
+[ "$(json_field "$out" 'data["ok"]')" = "False" ] || fail "doctor must report ok=false when Firefox is missing"
+[ "$(json_field "$out" 'data["firefox"]["resolved"]')" = "False" ] || fail "doctor must report firefox unresolved"
+out=$(FM_FIREFOX_BIN=/nonexistent/firefox "$TOOL" start --label dep 2>&1); code=$?
+expect_code 1 "$code" "start must refuse when no Firefox binary resolves"
+assert_contains "$out" "no Firefox binary found" "start must name the missing Firefox dependency"
+pass "dependency failure is diagnosed and refused"
+
+# --- 2) clean profile + 3) loopback allocation + 6) truthful receipt ---------
+recv=$("$TOOL" start --session ff-recv --extension "$EXT_DIR" --system-access --no-headless \
+  --env FMFF_TEST_FWD=forwarded-value --cookie-off MG_COOKIE_SOURCE=none) || fail "start with extension failed"
+port=$(json_field "$recv" 'data["marionette"]["port"]')
+pid=$(json_field "$recv" 'data["pid"]')
+profile=$(json_field "$recv" 'data["profile"]["path"]')
+STRAY_PIDS+=("$pid")
+
+[ -d "$profile" ] || fail "start must create the profile directory"
+case "$profile" in "$STATE_DIR"/profile.ff-recv.*) : ;; *) fail "profile must live under the task-owned state root: $profile" ;; esac
+[ -f "$profile/user.js" ] || fail "start must write a fresh profile user.js"
+# A fresh profile has no cookies/history the tool copied in.
+assert_absent "$profile/cookies.sqlite" "a fresh profile must not carry a copied cookie store"
+grep -Fq "marionette.port\", $port" "$profile/user.js" || fail "profile user.js must pin the allocated Marionette port"
+[ "$port" != 2828 ] || fail "allocated port must never be the shared default 2828"
+[ "$(json_field "$recv" 'data["marionette"]["reserved_shared_port_avoided"]')" = "2828" ] || fail "receipt must record the avoided shared port"
+[ "$(json_field "$recv" 'data["profile"]["fresh"]')" = "True" ] || fail "receipt must mark the profile fresh"
+[ "$(json_field "$recv" 'data["profile"]["owned"]')" = "True" ] || fail "receipt must mark the profile owned"
+[ "$(json_field "$recv" 'data["firefox"]["no_remote"]')" = "True" ] || fail "receipt must record -no-remote"
+[ "$(json_field "$recv" 'data["firefox"]["system_access"]')" = "True" ] || fail "receipt must reflect --system-access"
+[ "$(json_field "$recv" 'data["firefox"]["headless"]')" = "False" ] || fail "receipt must reflect --no-headless"
+[ "$(json_field "$recv" 'data["extension"]["installed"]')" = "True" ] || fail "receipt must record the extension as installed"
+[ "$(json_field "$recv" 'data["extension"]["id"]')" = "fm-hermetic-probe@firstmate.local" ] || fail "receipt must carry the real installed add-on id"
+[ "$(json_field "$recv" 'data["extension"]["route"]')" = "marionette:Addon:Install(temporary)" ] || fail "receipt must name the supported install route"
+[ "$(cat "$ENV_ECHO")" = "forwarded-value" ] || fail "--env values must be forwarded into the launched process"
+pass "start creates a clean owned profile, avoids 2828, and emits a truthful receipt"
+
+# --- 6b) receipt command re-reports live state -------------------------------
+rc=$("$TOOL" receipt ff-recv) || fail "receipt must succeed for a known session"
+[ "$(json_field "$rc" 'data["state"]')" = "running" ] || fail "receipt must show a live session as running"
+
+# --- 9) native-host cookie caveat + caller-hook contract ---------------------
+[ "$(json_field "$recv" 'data["cookie"]["native_host_scope"]')" = "out-of-scope" ] || fail "cookie scope must be truthfully out-of-scope"
+caveat=$(json_field "$recv" 'data["cookie"]["caveat"]')
+assert_contains "$caveat" "does not and cannot constrain" "caveat must not claim control over native-host cookies"
+assert_contains "$caveat" "native messaging host" "caveat must name the native host as the uncontrolled surface"
+[ "$(json_field "$recv" 'data["cookie"]["project_contract"]')" = "caller-asserted" ] || fail "supplying --cookie-off must mark the contract caller-asserted"
+[ "$(json_field "$recv" 'data["cookie"]["project_contract_env_keys"][0]')" = "MG_COOKIE_SOURCE" ] || fail "cookie contract must list the caller key"
+# Values are never recorded, only keys.
+assert_not_contains "$recv" "MG_COOKIE_SOURCE=none" "receipt must not echo cookie-off values"
+assert_not_contains "$recv" '"none"' "receipt must not echo cookie-off values"
+pass "cookie caveat is truthful and the caller cookie-off contract is recorded by key only"
+
+# --- 7) exact cleanup --------------------------------------------------------
+clean=$("$TOOL" stop ff-recv) || fail "stop must succeed for an owned session"
+[ "$(json_field "$clean" 'data["process"]')" = "terminated" ] || fail "stop must terminate the owned process"
+[ "$(json_field "$clean" 'data["touched_only_owned_resources"]')" = "True" ] || fail "cleanup receipt must assert only owned resources were touched"
+assert_absent "$profile" "stop must remove the owned profile directory"
+assert_absent "$(printf '%s/ff-recv.json' "$STATE_DIR")" "stop must remove the session state file"
+kill -0 "$pid" 2>/dev/null && fail "stop must terminate the fake Firefox process"
+pass "stop removes exactly the profile, state, and process it created"
+
+# --- 5) start with no extension is valid (extension optional) ----------------
+recv2=$("$TOOL" start --session ff-noext) || fail "start without an extension must succeed"
+pid2=$(json_field "$recv2" 'data["pid"]')
+STRAY_PIDS+=("$pid2")
+[ "$(json_field "$recv2" 'data["extension"]')" = "None" ] || fail "no-extension receipt must record extension=null"
+[ "$(json_field "$recv2" 'data["cookie"]["project_contract"]')" = "absent" ] || fail "without --cookie-off the contract must be absent"
+"$TOOL" stop ff-noext >/dev/null || fail "stop must clean up the no-extension session"
+pass "extension is optional and absent cookie contract is reported honestly"
+
+# --- 4) extension-path validation --------------------------------------------
+out=$("$TOOL" start --session ff-badext --extension "$TMP_ROOT/does-not-exist" 2>&1); code=$?
+expect_code 2 "$code" "start must reject a nonexistent extension path"
+assert_contains "$out" "does not exist" "start must explain the missing extension path"
+mkdir -p "$TMP_ROOT/empty-ext"
+out=$("$TOOL" start --session ff-badext2 --extension "$TMP_ROOT/empty-ext" 2>&1); code=$?
+expect_code 2 "$code" "start must reject an extension directory without manifest.json"
+assert_contains "$out" "no manifest.json" "start must explain the invalid extension directory"
+assert_absent "$(printf '%s/ff-badext.json' "$STATE_DIR")" "a rejected extension must leave no session state"
+pass "extension paths are validated before any launch"
+
+# --- 3b) refuse the shared default endpoint ----------------------------------
+out=$("$TOOL" start --session ff-2828 --port 2828 2>&1); code=$?
+expect_code 2 "$code" "start must refuse an explicit --port 2828"
+assert_contains "$out" "2828" "refusal must name the shared default endpoint"
+pass "the shared 127.0.0.1:2828 endpoint is refused"
+
+# --- 8) ownership refusal ----------------------------------------------------
+recv3=$("$TOOL" start --session ff-own) || fail "start for the ownership case failed"
+own_pid=$(json_field "$recv3" 'data["pid"]')
+own_profile=$(json_field "$recv3" 'data["profile"]["path"]')
+STRAY_PIDS+=("$own_pid")
+sleep 600 &
+stray=$!
+disown "$stray" 2>/dev/null || true
+STRAY_PIDS+=("$stray")
+# Rewrite the recorded pid to an unrelated live process the tool never created.
+python3 - "$STATE_DIR/ff-own.json" "$stray" <<'PY'
+import json, sys
+f = sys.argv[1]
+data = json.load(open(f))
+data["pid"] = int(sys.argv[2])
+json.dump(data, open(f, "w"))
+PY
+out=$("$TOOL" stop ff-own 2>&1); code=$?
+expect_code 1 "$code" "stop must refuse a pid it cannot prove it created"
+assert_contains "$out" "ownership unproven" "refusal must explain the unproven ownership"
+kill -0 "$stray" 2>/dev/null || fail "stop must never kill an unrelated live process"
+assert_present "$own_profile" "stop must not delete the profile when it refuses on ownership"
+# The refusal happened; tidy the real fake and stray directly.
+kill -KILL "$own_pid" 2>/dev/null || true
+kill -KILL "$stray" 2>/dev/null || true
+rm -rf "$own_profile" "$STATE_DIR/ff-own.json"
+pass "ambiguous pid ownership is refused instead of guessing"
+
+# --- 8b) refuse deleting a profile outside the state root --------------------
+cat > "$STATE_DIR/ff-foreign.json" <<JSON
+{"pid": null, "profile": {"path": "/tmp/not-a-fm-firefox-profile"}, "marionette": {"port": 40000}}
+JSON
+out=$("$TOOL" stop ff-foreign 2>&1); code=$?
+expect_code 1 "$code" "stop must refuse a profile outside its own state root"
+assert_contains "$out" "outside the tool's state root" "refusal must explain the foreign profile path"
+assert_present "$STATE_DIR/ff-foreign.json" "a refused foreign stop must not delete state it did not prove it owns"
+rm -f "$STATE_DIR/ff-foreign.json"
+pass "a profile path outside the state root is never removed"
+
+# --- 8c) interruption / error cleanup: Firefox never opens the endpoint -------
+out=$(FM_FAKE_FF_MODE=exit-immediately "$TOOL" start --session ff-earlyexit 2>&1); code=$?
+expect_code 1 "$code" "start must fail when Firefox exits before Marionette opens"
+assert_absent "$STATE_DIR/ff-earlyexit.json" "an aborted start must leave no session state"
+ls -d "$STATE_DIR"/profile.ff-earlyexit.* >/dev/null 2>&1 && fail "an aborted start must leave no profile directory"
+pass "a Firefox that dies before readiness is cleaned up with no leftovers"
+
+# --- 8d) readiness timeout cleanup -------------------------------------------
+out=$(FM_FAKE_FF_MODE=stall "$TOOL" start --session ff-stall --timeout 2 2>&1); code=$?
+expect_code 1 "$code" "start must fail when the Marionette endpoint never opens"
+assert_contains "$out" "did not open" "a readiness timeout must be reported"
+assert_absent "$STATE_DIR/ff-stall.json" "a timed-out start must leave no session state"
+ls -d "$STATE_DIR"/profile.ff-stall.* >/dev/null 2>&1 && fail "a timed-out start must leave no profile directory"
+pass "a Firefox that never opens the endpoint is killed and cleaned up"
+
+# --- 8e) install failure cleanup ---------------------------------------------
+out=$(FM_FAKE_FF_MODE=install-fail "$TOOL" start --session ff-instfail --extension "$EXT_DIR" 2>&1); code=$?
+expect_code 1 "$code" "start must fail when the extension install is refused"
+assert_contains "$out" "install over Marionette failed" "an install failure must be reported"
+assert_absent "$STATE_DIR/ff-instfail.json" "a failed install must leave no session state"
+ls -d "$STATE_DIR"/profile.ff-instfail.* >/dev/null 2>&1 && fail "a failed install must leave no profile directory"
+pass "an extension install failure is cleaned up with no leftovers"
+
+echo "ok - fm-firefox.sh hermetic command-surface behavior"

--- a/tests/fm-firefox-marionette.test.sh
+++ b/tests/fm-firefox-marionette.test.sh
@@ -306,4 +306,45 @@ assert_absent "$STATE_DIR/ff-instfail.json" "a failed install must leave no sess
 ls -d "$STATE_DIR"/profile.ff-instfail.* >/dev/null 2>&1 && fail "a failed install must leave no profile directory"
 pass "an extension install failure is cleaned up with no leftovers"
 
+# --- 8f) interruption cleanup: SIGTERM during the readiness window -----------
+# stall mode keeps the launched Firefox alive but never opens the endpoint, so
+# start sits in its readiness window with a fresh profile and a live child. A
+# SIGTERM to the start process (as a supervisor terminating a fleet worker would
+# send) must tear both down and commit nothing.
+FM_FAKE_FF_MODE=stall "$TOOL" start --session ff-sigterm --timeout 60 >/dev/null 2>&1 &
+sig_start_pid=$!
+STRAY_PIDS+=("$sig_start_pid")
+
+# Wait until the launched fake Firefox is actually running: its argv carries the
+# session profile path, which nothing else in this suite does, so its presence
+# proves we are inside the interruptible launch->commit window.
+waited=0
+sig_ff_up=0
+while [ "$waited" -lt 100 ]; do
+  if pgrep -f 'profile[.]ff-sigterm[.]' >/dev/null 2>&1; then sig_ff_up=1; break; fi
+  kill -0 "$sig_start_pid" 2>/dev/null || break
+  sleep 0.1
+  waited=$((waited + 1))
+done
+[ "$sig_ff_up" = 1 ] || fail "fake Firefox never entered the readiness window for the SIGTERM case"
+
+kill -TERM "$sig_start_pid" 2>/dev/null || true
+waited=0
+while kill -0 "$sig_start_pid" 2>/dev/null; do
+  [ "$waited" -lt 100 ] || fail "interrupted start did not exit after SIGTERM"
+  sleep 0.1
+  waited=$((waited + 1))
+done
+
+# The launched Firefox must be gone (give the in-flight teardown a beat to reap).
+waited=0
+while pgrep -f 'profile[.]ff-sigterm[.]' >/dev/null 2>&1; do
+  [ "$waited" -lt 100 ] || fail "an interrupted start left a Firefox process referencing the session profile"
+  sleep 0.1
+  waited=$((waited + 1))
+done
+ls -d "$STATE_DIR"/profile.ff-sigterm.* >/dev/null 2>&1 && fail "an interrupted start must leave no profile directory"
+assert_absent "$STATE_DIR/ff-sigterm.json" "an interrupted start must leave no session state file"
+pass "a SIGTERM during the readiness window orphans no process and leaves no profile or state"
+
 echo "ok - fm-firefox.sh hermetic command-surface behavior"


### PR DESCRIPTION
## Intent

Productize the already live-proven Firefox web-ext + Marionette/WebDriver route as a reusable, harness-agnostic Firstmate tool plus a just-in-time agent skill. The captain explicitly authorized adding this capability to the shared tool set.

Deliverable: one new shell CLI bin/fm-firefox.sh that owns the lifecycle of a single isolated, disposable Firefox process driven over Marionette. Deliberate architecture decisions (not mistakes): (1) chose a thin harness-agnostic shell CLI over a new MCP server, AXI daemon, or global service, because the tool-layer-placement scout established that harness-agnostic CLI surfaces take precedence and every Pi worker already inherits the same MCP config, so a daemon would add a second browser control plane with no reach benefit; (2) the single supported install route is Marionette Addon:Install(temporary) so the tool can own exactly one -no-remote Firefox process it launched, rather than delegating launch to web-ext (which spawns its own process); web-ext is intentionally only reported by doctor as an optional, unmanaged alternative, not used; (3) the Marionette client is a small raw-protocol python3 implementation embedded in the CLI, so the tool's only hard deps are a Firefox binary and python3 (no marionette_driver dependency); marionette_driver is used only by the opt-in live test as an independent verification client.

Safety contract implemented: always create a fresh, empty, task-owned profile (never attach to, copy, or enumerate a live Firefox/Zen profile); self-allocate a loopback Marionette endpoint and refuse the shared default 127.0.0.1:2828; launch exactly one -no-remote Firefox; apply -remote-allow-system-access only to that disposable process and only when --system-access is requested; expose truthful machine-readable JSON receipts; and on stop tear down only the process/profile/port it created after proving the recorded PID is still our Firefox by its profile path, refusing ambiguous PID/port/profile ownership rather than guessing or killing an unrelated process.

Cookie/privacy scope is deliberately truthful, not a guarantee the tool can make: the CLI proves its own Firefox profile is fresh and task-owned but states in its receipt/help that a project-specific native messaging host can still independently discover unrelated Gecko cookie profiles (e.g. Zen) unless the project supplies its own verified cookie-off contract. The tool provides a generic caller env/cookie-off hook (--env, --cookie-off KEY=VALUE) that it forwards into the launched process without interpreting it, recording only the keys (never values) as a caller-asserted contract, so no MediaGrabber business logic is baked into Firstmate. Constraints honored: does not depend on the still-open MediaGrabber PRs #8/#9; never claims generic browser isolation controls project native-host cookie behavior; does not modify any global Pi/MCP configuration; the tool is invoked purely through the shell and is harness-independent.

Also added: an agent-only .agents/skills/firefox-marionette skill (with one one-line AGENTS.md section 13 load trigger) teaching when to choose this route over Playwright/CDP/FoxMCP, the browser-vs-OS boundary, the no-live-profile safety contract, dependency checks, receipts, cleanup, and the native-host cookie caveat, pointing to the CLI --help rather than duplicating flags; operator documentation at docs/firefox-marionette.md and current verification evidence at docs/verification/firefox-marionette.md, both registered in docs/documentation-audiences.json, plus a docs/scripts.md toolbelt row; and registration of both new tests in bin/fm-test-run.sh (hermetic in pure-contract-unit, live in live-harness-optin) with shard weight hints. Two tests were added: a hermetic command-surface test (tests/fm-firefox-marionette.test.sh) that drives a fake Firefox speaking the real Marionette wire format and asserts observed behavior and receipt fields only (never implementation source bytes) - covering dependency failure, clean-profile creation, loopback allocation, ownership refusal, extension-path validation, truthful receipts, exact cleanup, interruption/error cleanup, and the native-host cookie caveat/caller-hook contract; and an opt-in live test (tests/fm-firefox-marionette-live-e2e.test.sh, gated by FM_FIREFOX_LIVE_E2E=1) that uses a synthetic local extension and a loopback HTTP page (no external URL) to prove real add-on install plus web-content and extension/browser-context control without pixel clicks, verifies no existing Firefox/Zen process or the shared endpoint changed, and leaves no Firefox child/profile/port behind, self-skipping when Firefox/python3/WebDriver deps are absent so standard CI stays hermetic. The live proof was run on this Mac against Firefox 153.0.3.

## What Changed

- Added `bin/fm-firefox.sh`, a harness-agnostic shell CLI that owns the full lifecycle of a single isolated, disposable Firefox driven over Marionette: it always creates a fresh task-owned profile, self-allocates a loopback Marionette endpoint (refusing the shared `127.0.0.1:2828`), launches exactly one `-no-remote` process, installs the addon via a small embedded raw-protocol python3 Marionette client (so hard deps are only a Firefox binary + python3), exposes truthful JSON receipts/`doctor` output, forwards an uninterpreted `--env`/`--cookie-off` caller hook (recording keys only), and on `stop` tears down only the process/profile/port it created after verifying the recorded PID is still our Firefox by profile path. A start-time INT/TERM/EXIT trap kills the launched pid and removes the fresh profile if interrupted before the session state file is committed, closing the orphaned-process/profile window.
- Added a just-in-time `.agents/skills/firefox-marionette` agent skill (with an AGENTS.md section 13 load trigger), operator docs at `docs/firefox-marionette.md`, verification evidence at `docs/verification/firefox-marionette.md`, both registered in `docs/documentation-audiences.json`, and a `docs/scripts.md` toolbelt row.
- Added two tests registered in `bin/fm-test-run.sh`: a hermetic command-surface test (`tests/fm-firefox-marionette.test.sh`) that drives a fake Firefox speaking the real Marionette wire format and asserts observed behavior plus receipt fields (dependency failure, clean-profile creation, loopback allocation, ownership refusal, extension-path validation, exact/interrupted cleanup, native-host cookie caveat), and an opt-in live e2e test (`tests/fm-firefox-marionette-live-e2e.test.sh`, gated by `FM_FIREFOX_LIVE_E2E=1`) that proves real add-on install and web/extension-context control against a loopback page, verifies no existing process or the shared endpoint changed, and self-skips when deps are absent so standard CI stays hermetic.

## Risk Assessment

✅ Low: Artımlı değişiklik, Round 1'deki tek uyarıyı (interrupt-penceresi süreç/profil sızıntısı) doğru bir INT/TERM/ERR trap + in-flight teardown ile kapatıyor; ampirik olarak trap'in sinyalde tetiklendiği, lokalleri dinamik kapsamla gördüğü ve açık hata yollarını bozmadığı doğrulandı, ayrıca doğrudan bir hermetik test eklendi.

## Testing

Ran the smallest intent-relevant tests: the hermetic fm-firefox-marionette test (14 checks, real Marionette wire protocol against a fake Firefox — dependency refusal, clean owned profile, loopback allocation + 2828 refusal, truthful receipts, ownership-proven refusal, extension-path validation, exact cleanup, interruption/error/SIGTERM teardown, native-host cookie caveat) and the opt-in live e2e against the real Firefox 153.0.3 named in the intent (real temporary add-on install, web-content + extension-context control over Marionette with no pixel clicks, proof that no unrelated Firefox/Zen process or the shared 2828 endpoint changed, and zero leftovers). Both exit 0. The doctor JSON surface was exercised directly and reports honestly. This is a shell CLI with no rendered UI surface, so product-level evidence is the live-e2e CLI transcript and JSON receipts rather than a screenshot. No transient artifacts remained (default state root empty, worktree clean).

<details>
<summary>Evidence: Live e2e transcript vs real Firefox 153.0.3</summary>

`ok - fm-firefox live E2E (Mozilla Firefox 153.0.3): real add-on install, web-content and extension-context control, no unrelated browser touched, no leftovers`

```text
ok - fm-firefox live E2E (Mozilla Firefox 153.0.3): real add-on install, web-content and extension-context control, no unrelated browser touched, no leftovers
```
</details>
<details>
<summary>Evidence: Hermetic command-surface test output (14 checks)</summary>

```text
ok - dependency failure is diagnosed and refused
ok - start creates a clean owned profile, avoids 2828, and emits a truthful receipt
ok - cookie caveat is truthful and the caller cookie-off contract is recorded by key only
ok - stop removes exactly the profile, state, and process it created
ok - extension is optional and absent cookie contract is reported honestly
ok - extension paths are validated before any launch
ok - the shared 127.0.0.1:2828 endpoint is refused
ok - ambiguous pid ownership is refused instead of guessing
ok - a profile path outside the state root is never removed
ok - a Firefox that dies before readiness is cleaned up with no leftovers
ok - a Firefox that never opens the endpoint is killed and cleaned up
ok - an extension install failure is cleaned up with no leftovers
ok - a SIGTERM during the readiness window orphans no process and leaves no profile or state
ok - fm-firefox.sh hermetic command-surface behavior
```
</details>
<details>
<summary>Evidence: doctor --json product surface</summary>

```text
{"firefox":{"path":"/Applications/Firefox.app/Contents/MacOS/firefox","required":true,"resolved":true},"install_route":"marionette:Addon:Install(temporary)","ok":true,"platform_boundary":"macOS and Linux supported; Windows unsupported","python3":{"required":true,"resolved":true},"schema":"fm-firefox.doctor.v1","tool":"fm-firefox","web_ext":{"note":"optional, unmanaged alternative install route; not used by this tool","required":false,"resolved":true,"version":"10.1.0"}}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-firefox.sh:477` - start komutunda sinyal (SIGTERM) kesinti penceresi için temizlik yok: 477. satırda arka planda (disown edilmiş) Firefox başlatıldıktan sonra, 518. satırda state dosyası yazılana kadar (--timeout kadar, varsayılan 45sn readiness + extension install süresi boyunca) script&#39;te hiçbir trap yok. Bu pencerede fm-firefox.sh PID&#39;ine SIGTERM gelirse (ör. çağıran fleet worker&#39;ını sonlandıran bir supervisor — bu araç tam olarak fleet worker&#39;ları tarafından çağrılmak üzere tasarlı), script ölür ama disown edilmiş Firefox yetim kalır ve profil dizini state root altında kalır; state dosyası hiç yazılmadığı için &#39;stop&#39; bunu asla geri alamaz. Bu, aracın merkezi &#39;disposable / no-leftovers / owned-only&#39; garantisini interrupt yolunda ihlal eder. Hermetik test 8c/8d/8e yalnızca Firefox-tarafı hata yollarını kapsıyor, gerçek bir sinyal kesintisini değil. Öneri: start süresince aktif bir INT/TERM/EXIT trap ekleyip, session commit edilene (state dosyası yazılana) kadar başlatılan pid&#39;i öldürüp taze profili silen bir in-flight cleanup ekleyin. Not: Ctrl-C (process group&#39;a SIGINT) senaryosunda Firefox aynı pgroup&#39;ta olduğu için zaten ölür; boşluk yalnızca script PID&#39;ine doğrudan SIGTERM gönderilen durumdadır.

🔧 Fix: trap interrupted fm-firefox start to prevent orphaned process/profile
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-firefox-marionette.test.sh` — hermetic command-surface, 14/14 checks pass, exit 0</code>
- <code>`FM_FIREFOX_LIVE_E2E=1 bash tests/fm-firefox-marionette-live-e2e.test.sh` — live proof vs real Firefox 153.0.3, exit 0</code>
- <code>`bin/fm-firefox.sh doctor` and `doctor --json` — truthful dependency/receipt product surface (firefox+python3 resolved, web-ext optional/unused)</code>
- `Manual before/after browser snapshot: pre-existing Zen (109 procs) and Firefox pid 890 untouched; no fm-firefox state/profile/port leftovers; worktree clean`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
