### PR TITLE
feat(bin): make CLAUDE.md -> AGENTS.md promotion opt-in via --promote

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -454,6 +454,7 @@ $RULE1
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.
+The default run leaves a real \`CLAUDE.md\` untouched; pass \`--promote\` only when you intend to rename an existing \`CLAUDE.md\` into the \`AGENTS.md\` convention in this task.
 Record only project knowledge useful to almost every future session.
 For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
 If you touch a project \`AGENTS.md\` that lacks \`## Maintaining this file\`, add that short self-governance section from \`$FM_ROOT/bin/fm-ensure-agents-md.sh\` in the same pass.

--- a/bin/fm-ensure-agents-md.sh
+++ b/bin/fm-ensure-agents-md.sh
@@ -2,27 +2,36 @@
 # Ensure a project worktree follows the agent-memory file convention.
 # AGENTS.md is the real project-intrinsic knowledge file; CLAUDE.md is a
 # relative symlink to it for compatibility. Creates a minimal AGENTS.md skeleton
-# when neither file exists, promotes a real CLAUDE.md file when it is the only
-# file present, and refuses to clobber distinct real files or wrong symlinks.
+# when neither file exists, and refuses to clobber distinct real files or wrong
+# symlinks. By default a project whose only memory file is a real CLAUDE.md is
+# left untouched: a crewmate running this as a routine step must not rewrite a
+# project that is already in a perfectly valid state. Promotion of a real
+# CLAUDE.md into the AGENTS.md convention is explicit and opt-in via --promote,
+# which keeps the rename, symlink, and self-governance injection in one step.
 # Owns the canonical "## Maintaining this file" self-governance wording for
 # project AGENTS.md files, injecting it idempotently into created skeletons,
-# promoted CLAUDE.md files, and any existing AGENTS.md that still lacks it.
+# --promoted CLAUDE.md files, and any existing AGENTS.md that still lacks it.
 # Refuses a case-variant real memory file such as a lowercase agents.md, whose
 # CLAUDE.md symlink would carry an uppercase literal target that dangles on a
 # case-sensitive filesystem (issue #389).
 # This is a worktree utility for crewmates, not a supervision script, so it does
 # not call fm-guard.sh.
-# Usage: fm-ensure-agents-md.sh [repo-or-worktree-dir]
+# Usage: fm-ensure-agents-md.sh [--promote] [repo-or-worktree-dir]
 set -eu
 
 usage() {
-  echo "usage: fm-ensure-agents-md.sh [repo-or-worktree-dir]" >&2
+  echo "usage: fm-ensure-agents-md.sh [--promote] [repo-or-worktree-dir]" >&2
 }
 
+PROMOTE=0
 case "${1:-}" in
   -h|--help)
     usage
     exit 0
+    ;;
+  --promote)
+    PROMOTE=1
+    shift
     ;;
 esac
 [ "$#" -le 1 ] || { usage; exit 1; }
@@ -183,6 +192,10 @@ fi
 
 if [ -e "$CLAUDE" ]; then
   if [ -f "$CLAUDE" ]; then
+    if [ "$PROMOTE" -ne 1 ]; then
+      echo "unchanged: project already has agent memory at CLAUDE.md in $DIR; pass --promote to adopt the AGENTS.md convention"
+      exit 0
+    fi
     mv "$CLAUDE" "$AGENTS"
     ensure_maintenance_section
     ln -s "$AGENTS" "$CLAUDE"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -278,7 +278,7 @@ The [Relay configuration reference](configuration.md#promised-public-replies-sta
 
 Durable project-intrinsic agent knowledge lives in each project's committed `AGENTS.md`, with `CLAUDE.md` as a symlink.
 Ship briefs prompt crewmates to create or update those files through the normal delivery path; `data/projects.md` stays a thin private registry.
-Each project `AGENTS.md` carries a short `## Maintaining this file` self-governance section; `bin/fm-ensure-agents-md.sh` owns the canonical wording and injects it idempotently when creating the skeleton, promoting an existing `CLAUDE.md`, or reconciling an existing `AGENTS.md` that still lacks it.
+Each project `AGENTS.md` carries a short `## Maintaining this file` self-governance section; `bin/fm-ensure-agents-md.sh` owns the canonical wording and injects it idempotently when creating the skeleton, when --promote renames an existing `CLAUDE.md` into the convention, or when reconciling an existing `AGENTS.md` that still lacks it.
 It refuses a case-variant real memory file such as a lowercase `agents.md`, whose `CLAUDE.md` symlink would carry an uppercase literal target that dangles on a case-sensitive filesystem, and surfaces the mismatch for manual reconciliation.
 The full ownership rule - what is project-intrinsic versus fleet-private, and how firstmate keeps the two apart without writing into project clones - is owned by [`AGENTS.md`](../AGENTS.md) (project and knowledge management).
 

--- a/tests/fm-ensure-agents-md.test.sh
+++ b/tests/fm-ensure-agents-md.test.sh
@@ -37,7 +37,8 @@ test_promoted_claude_md_includes_self_governance() {
 
 Run tests with `make test`.
 EOF
-  "$ROOT/bin/fm-ensure-agents-md.sh" "$repo" >/dev/null 2>&1 || fail "fm-ensure-agents-md.sh failed for CLAUDE.md promotion"
+  "$ROOT/bin/fm-ensure-agents-md.sh" --promote "$repo" >/dev/null 2>&1 \
+    || fail "fm-ensure-agents-md.sh --promote failed for CLAUDE.md promotion"
   agents="$repo/AGENTS.md"
   assert_present "$agents" "AGENTS.md was not created during promotion"
   [ -L "$repo/CLAUDE.md" ] || fail "CLAUDE.md is not a symlink after promotion"
@@ -47,7 +48,7 @@ EOF
   [ "$count" -eq 1 ] || fail "promotion wrote $count self-governance sections"
   assert_grep "Keep this file for knowledge useful to almost every future agent session in this project." "$agents" \
     "promoted AGENTS.md missing self-governance wording"
-  pass "fm-ensure-agents-md.sh: promoted CLAUDE.md includes self-governance section"
+  pass "fm-ensure-agents-md.sh: --promote on CLAUDE.md includes self-governance section"
 }
 
 test_promoted_claude_md_without_trailing_newline_keeps_blank_separator() {
@@ -55,7 +56,8 @@ test_promoted_claude_md_without_trailing_newline_keeps_blank_separator() {
   repo="$TMP_ROOT/no-trailing-newline-project"
   mkdir -p "$repo"
   printf '# Existing agent memory\n\nRun tests with make test.' > "$repo/CLAUDE.md"
-  "$ROOT/bin/fm-ensure-agents-md.sh" "$repo" >/dev/null 2>&1 || fail "fm-ensure-agents-md.sh failed for newline-less CLAUDE.md promotion"
+  "$ROOT/bin/fm-ensure-agents-md.sh" --promote "$repo" >/dev/null 2>&1 \
+    || fail "fm-ensure-agents-md.sh --promote failed for newline-less CLAUDE.md promotion"
   agents="$repo/AGENTS.md"
   assert_grep "Run tests with make test." "$agents" \
     "newline-less promotion lost or mangled the last content line"
@@ -63,7 +65,49 @@ test_promoted_claude_md_without_trailing_newline_keeps_blank_separator() {
     "newline-less promotion did not append the self-governance section"
   before=$(grep -B1 -Fx '## Maintaining this file' "$agents" | head -n 1)
   [ -z "$before" ] || fail "self-governance heading not preceded by a blank line (got: $before)"
-  pass "fm-ensure-agents-md.sh: newline-less promotion keeps a blank separator line"
+  pass "fm-ensure-agents-md.sh: --promote on newline-less CLAUDE.md keeps a blank separator line"
+}
+
+test_default_run_leaves_real_claude_md_untouched() {
+  local repo rc out snapshot
+  repo="$TMP_ROOT/default-claude-project"
+  mkdir -p "$repo"
+  cat > "$repo/CLAUDE.md" <<'EOF'
+# Existing agent memory
+
+Run tests with `make test`.
+EOF
+  snapshot="$repo/.claude-snapshot"
+  cp "$repo/CLAUDE.md" "$snapshot"
+  out=$("$ROOT/bin/fm-ensure-agents-md.sh" "$repo" 2>&1)
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "default run exited non-zero ($rc) on a project with real CLAUDE.md: $out"
+  assert_absent "$repo/AGENTS.md" "default run created AGENTS.md on a project with only CLAUDE.md"
+  [ -f "$repo/CLAUDE.md" ] || fail "default run no longer leaves CLAUDE.md as a regular file"
+  [ ! -L "$repo/CLAUDE.md" ] || fail "default run replaced CLAUDE.md with a symlink"
+  cmp -s "$snapshot" "$repo/CLAUDE.md" \
+    || fail "default run modified the bytes of the project's CLAUDE.md"
+  assert_contains "$out" "--promote" "default-run output did not mention --promote"
+  pass "fm-ensure-agents-md.sh: default run leaves real CLAUDE.md untouched and exits 0"
+}
+
+test_default_run_does_not_inject_self_governance_into_claude_md() {
+  local repo rc out
+  repo="$TMP_ROOT/default-no-inject-project"
+  mkdir -p "$repo"
+  cat > "$repo/CLAUDE.md" <<'EOF'
+# Existing agent memory
+
+Run tests with `make test`.
+EOF
+  out=$("$ROOT/bin/fm-ensure-agents-md.sh" "$repo" 2>&1)
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "default run exited non-zero ($rc): $out"
+  assert_no_grep "## Maintaining this file" "$repo/CLAUDE.md" \
+    "default run injected the self-governance section into the project's CLAUDE.md"
+  assert_no_grep "Keep this file for knowledge useful to almost every future agent session in this project." "$repo/CLAUDE.md" \
+    "default run injected self-governance wording into the project's CLAUDE.md"
+  pass "fm-ensure-agents-md.sh: default run does not inject self-governance into a real CLAUDE.md"
 }
 
 test_existing_agents_md_with_symlink_gains_self_governance() {
@@ -203,6 +247,8 @@ test_lowercase_agents_md_refuses_case_fragile_symlink() {
 test_created_agents_md_includes_self_governance
 test_promoted_claude_md_includes_self_governance
 test_promoted_claude_md_without_trailing_newline_keeps_blank_separator
+test_default_run_leaves_real_claude_md_untouched
+test_default_run_does_not_inject_self_governance_into_claude_md
 test_existing_agents_md_with_symlink_gains_self_governance
 test_existing_agents_md_without_claude_gains_section_and_symlink
 test_existing_agents_md_with_section_reports_unchanged


### PR DESCRIPTION
## Summary

`bin/fm-ensure-agents-md.sh` used to silently rewrite a project's real `CLAUDE.md` into `AGENTS.md` and inject the canonical self-governance section whenever the only memory file present was a real `CLAUDE.md`. Crewmates run this script as a routine step on every ship task, so an unrelated task on a project whose `CLAUDE.md` is its own working agreement would land a PR that renamed and edited the project's memory file, leaving the `CLAUDE.md` type change uncommitted and the repo with two near-identical drifting copies.

Make promotion explicit. The default run leaves a real `CLAUDE.md` untouched, prints one line naming the project memory file and pointing at `--promote`, and exits 0. `--promote` keeps today's rename, symlink, and self-governance injection byte-for-byte. Every other branch (skeleton creation, existing `AGENTS.md`, correct symlink, case-variant refusal, conflict paths) is unchanged.

`bin/fm-brief.sh`'s Project memory wording now reflects the default. The two existing promote tests pass `--promote` and keep their assertions. Two new tests cover the default path: the project's `CLAUDE.md` keeps its type and bytes, no `AGENTS.md` is created, and the self-governance section is not injected into the project's `CLAUDE.md`. `docs/architecture.md` is patched to keep its single sentence accurate without duplicating the script's contract.

## Test plan

- `bin/fm-lint.sh` is clean (single owner of the lint definition).
- `shellcheck` is clean for `bin/fm-ensure-agents-md.sh`, `bin/fm-brief.sh`, and `tests/fm-ensure-agents-md.test.sh`.
- `tests/fm-ensure-agents-md.test.sh` runs all 11 cases green: the 9 existing tests plus 2 new ones (`test_default_run_leaves_real_claude_md_untouched` and `test_default_run_does_not_inject_self_governance_into_claude_md`).
