### PR TITLE
feat(bin): add fail-closed shadow and replicante backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Firstmate's skills live in two separate places with different audiences:
 ## Documentation
 
 - [docs/shadow.md](docs/shadow.md) - the fail-closed WSL replica for Windows-visible Firstmate inspection.
+- [docs/replicante.md](docs/replicante.md) - the incremental, content-addressed WSL backup for H:\Firstmate-Backup.
 - [docs/architecture.md](docs/architecture.md) - maintainer architecture for the crew, supervision, worktrees, secondmates, and project modes.
 - [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, runtime backend selection, optional Relay and its X and Discord setup steps, the files you set, and harness support.
 - [docs/remote-secondmates.md](docs/remote-secondmates.md) - current setup, routing, transfer, recovery, and safety behavior for whole-home remote second mates.

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Firstmate's skills live in two separate places with different audiences:
 
 ## Documentation
 
+- [docs/shadow.md](docs/shadow.md) - the fail-closed WSL replica for Windows-visible Firstmate inspection.
 - [docs/architecture.md](docs/architecture.md) - maintainer architecture for the crew, supervision, worktrees, secondmates, and project modes.
 - [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, runtime backend selection, optional Relay and its X and Discord setup steps, the files you set, and harness support.
 - [docs/remote-secondmates.md](docs/remote-secondmates.md) - current setup, routing, transfer, recovery, and safety behavior for whole-home remote second mates.

--- a/bin/fm-replicante.py
+++ b/bin/fm-replicante.py
@@ -291,7 +291,10 @@ def load_root(source: Path, destination: Path, allow_initialize: bool) -> tuple[
         for child in (destination / "objects", destination / "snapshots"):
             if not child.is_dir() or child.is_symlink():
                 fail(f"backup layout is incomplete or unsafe: {child}")
-        if not (destination / LATEST_MARKER).is_file():
+        latest = destination / LATEST_MARKER
+        if latest.is_symlink():
+            fail("latest snapshot marker must not be a symbolic link")
+        if not latest.is_file():
             fail("backup destination has no latest snapshot marker")
     return initialized, destination / "objects", destination / "snapshots"
 
@@ -392,7 +395,7 @@ def read_snapshot_manifest(
 ) -> dict[str, Any]:
     snapshot = snapshot_path(snapshots, identifier)
     manifest_path = snapshot / "manifest.json"
-    if not snapshot.is_dir() or snapshot.is_symlink() or not manifest_path.is_file():
+    if snapshot.is_symlink() or not snapshot.is_dir() or manifest_path.is_symlink() or not manifest_path.is_file():
         fail(f"snapshot is missing its manifest: {identifier}")
     try:
         extra = [child for child in snapshot.iterdir() if child.name != "manifest.json"]
@@ -445,7 +448,10 @@ def read_snapshot_manifest(
 
 
 def latest_id(destination: Path) -> str:
-    value = read_bytes(destination / LATEST_MARKER).decode("ascii").strip()
+    marker = destination / LATEST_MARKER
+    if marker.is_symlink() or not marker.is_file():
+        fail("latest snapshot marker is missing or a symbolic link")
+    value = read_bytes(marker).decode("ascii").strip()
     if not SNAPSHOT_ID_RE.fullmatch(value):
         fail("latest snapshot marker is malformed")
     return value
@@ -579,8 +585,14 @@ def prune_snapshots(
     if len(verified) <= retain:
         return
     current = latest_id(destination)
-    for _, identifier in sorted(verified)[: len(verified) - retain]:
-        if identifier == current:
+    ordered = sorted(verified)
+    retained = {current}
+    for _, identifier in reversed(ordered):
+        if len(retained) >= retain:
+            break
+        retained.add(identifier)
+    for _, identifier in ordered:
+        if identifier in retained:
             continue
         target = snapshot_path(snapshots, identifier)
         try:

--- a/bin/fm-replicante.py
+++ b/bin/fm-replicante.py
@@ -1,0 +1,816 @@
+#!/usr/bin/env python3
+"""Incremental, content-addressed backup for the canonical Firstmate tree."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+
+CANONICAL_SOURCE = Path("/home/ale/firstmate")
+CANONICAL_DESTINATION = Path("/mnt/h/Firstmate-Backup")
+ROOT_MARKER = ".replicante-root.json"
+LATEST_MARKER = "latest"
+SNAPSHOT_FORMAT = "replicante-snapshot-v1"
+ROOT_FORMAT = "replicante-root-v1"
+SNAPSHOT_ID_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def fail(message: str) -> None:
+    print(f"fm-replicante: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def canonical_json(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def read_bytes(path: Path) -> bytes:
+    try:
+        with path.open("rb") as handle:
+            return handle.read()
+    except OSError as exc:
+        fail(f"cannot read {path}: {exc}")
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(read_bytes(path).decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        fail(f"invalid JSON in {path}: {exc}")
+    if not isinstance(value, dict):
+        fail(f"JSON root is not an object: {path}")
+    return value
+
+
+def atomic_write(path: Path, content: bytes) -> None:
+    temporary = None
+    try:
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{path.name}.tmp-",
+            dir=path.parent,
+        )
+        temporary = Path(temporary_name)
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(content)
+        os.replace(temporary, path)
+        temporary = None
+    except OSError as exc:
+        fail(f"cannot atomically write {path}: {exc}")
+    finally:
+        if temporary is not None:
+            try:
+                temporary.unlink()
+            except OSError:
+                pass
+
+
+def ensure_directory(path: Path) -> None:
+    if path.is_symlink():
+        fail(f"path must not be a symbolic link: {path}")
+    if path.exists():
+        if not path.is_dir():
+            fail(f"path is not a directory: {path}")
+        return
+    try:
+        path.mkdir()
+    except OSError as exc:
+        fail(f"cannot create directory {path}: {exc}")
+
+
+def is_under(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def resolve_paths(command: str) -> tuple[Path, Path, bool]:
+    test_mode = os.environ.get("REPLICANTE_TEST_MODE") == "1"
+    test_source = os.environ.get("REPLICANTE_TEST_SOURCE")
+    test_destination = os.environ.get("REPLICANTE_TEST_DESTINATION")
+    if test_mode:
+        if not test_source or not test_destination:
+            fail("fixture mode requires REPLICANTE_TEST_SOURCE and REPLICANTE_TEST_DESTINATION")
+        source = Path(test_source)
+        destination = Path(test_destination)
+    else:
+        if test_source or test_destination:
+            fail("test source or destination overrides require REPLICANTE_TEST_MODE=1")
+        source = CANONICAL_SOURCE
+        destination = CANONICAL_DESTINATION
+
+    source_text = os.path.realpath(source)
+    destination_text = os.path.realpath(destination)
+    if not test_mode:
+        if source_text != str(CANONICAL_SOURCE) or destination_text != str(CANONICAL_DESTINATION):
+            fail("operational paths are not the canonical source and destination")
+        if not Path("/mnt/h").is_dir() or Path("/mnt/h").is_symlink():
+            fail("H: volume is unavailable at /mnt/h")
+        if not os.path.ismount("/mnt/h"):
+            fail("H: volume is not mounted at /mnt/h")
+
+    if source_text == destination_text:
+        fail("source and backup destination are the same path")
+    source_absolute = Path(source_text)
+    destination_absolute = Path(destination_text)
+    if is_under(destination_absolute, source_absolute) or is_under(source_absolute, destination_absolute):
+        fail("source and backup destination must not contain one another")
+    if not test_mode and is_under(destination_absolute, Path("/mnt/d")):
+        fail("backup destination must not touch the D: tree")
+    if command == "run" and not source_absolute.is_dir():
+        fail(f"canonical source is not an existing directory: {source_absolute}")
+    return source_absolute, destination_absolute, test_mode
+
+
+def git_output(root: Path, arguments: list[str], allow_failure: bool = False) -> str:
+    command = [
+        "git",
+        "-c",
+        f"safe.directory={root}",
+        "-C",
+        str(root),
+        *arguments,
+    ]
+    result = subprocess.run(command, capture_output=True, text=True)
+    if result.returncode != 0:
+        if allow_failure:
+            return ""
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        fail(f"Git command failed for {root}: {detail}")
+    return result.stdout.strip()
+
+
+def source_identity(source: Path) -> dict[str, str]:
+    root = Path(git_output(source, ["rev-parse", "--show-toplevel"])).resolve()
+    if root != source.resolve():
+        fail(f"source is not the root of its Git worktree: {source}")
+    commit = git_output(source, ["rev-parse", "--verify", "HEAD"])
+    if not re.fullmatch(r"[0-9a-f]{40,64}", commit):
+        fail("source HEAD is not a valid commit identity")
+    branch = git_output(source, ["symbolic-ref", "--quiet", "--short", "HEAD"], allow_failure=True)
+    return {"source_branch": branch or "DETACHED", "source_commit": commit}
+
+
+def hash_file(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    try:
+        with path.open("rb") as handle:
+            while chunk := handle.read(1024 * 1024):
+                digest.update(chunk)
+                size += len(chunk)
+    except OSError as exc:
+        fail(f"cannot hash {path}: {exc}")
+    return digest.hexdigest(), size
+
+
+def scan_tree(root: Path) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+
+    def visit(path: Path, relative: str) -> None:
+        try:
+            metadata = os.lstat(path)
+        except OSError as exc:
+            fail(f"cannot inspect source path {path}: {exc}")
+        mode = metadata.st_mode
+        if stat.S_ISLNK(mode):
+            try:
+                target = os.readlink(path)
+            except OSError as exc:
+                fail(f"cannot read symbolic link {path}: {exc}")
+            entries.append({"kind": "symlink", "path": relative, "target": target})
+            return
+        if stat.S_ISREG(mode):
+            digest, size = hash_file(path)
+            entries.append(
+                {
+                    "kind": "file",
+                    "mode": stat.S_IMODE(mode),
+                    "path": relative,
+                    "sha256": digest,
+                    "size": size,
+                }
+            )
+            return
+        if not stat.S_ISDIR(mode):
+            fail(f"special file is not supported in the canonical tree: {relative}")
+        entries.append({"kind": "dir", "mode": stat.S_IMODE(mode), "path": relative})
+        try:
+            with os.scandir(path) as iterator:
+                children = sorted(iterator, key=lambda entry: entry.name)
+        except OSError as exc:
+            fail(f"cannot enumerate source path {path}: {exc}")
+        for child in children:
+            child_path = Path(child.path)
+            child_relative = child.name if relative == "." else f"{relative}/{child.name}"
+            visit(child_path, child_relative)
+
+    visit(root, ".")
+    return sorted(entries, key=lambda entry: entry["path"])
+
+
+def identity_payload(source: Path, identity: dict[str, str], entries: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "entries": entries,
+        "format": SNAPSHOT_FORMAT,
+        "source": str(source),
+        **identity,
+    }
+
+
+def snapshot_id(source: Path, identity: dict[str, str], entries: list[dict[str, Any]]) -> str:
+    return hashlib.sha256(canonical_json(identity_payload(source, identity, entries))).hexdigest()
+
+
+def backup_root_marker(source: Path, destination: Path) -> dict[str, str]:
+    return {
+        "destination": str(destination),
+        "format": ROOT_FORMAT,
+        "policy": "content-addressed-incremental",
+        "source": str(source),
+    }
+
+
+def load_root(source: Path, destination: Path, allow_initialize: bool) -> tuple[bool, Path, Path]:
+    if destination.is_symlink():
+        fail(f"backup destination must not be a symbolic link: {destination}")
+    initialized = False
+    if destination.exists():
+        if not destination.is_dir():
+            fail(f"backup destination is not a directory: {destination}")
+        marker = destination / ROOT_MARKER
+        if marker.is_symlink():
+            fail(f"backup identity marker must not be a symbolic link: {marker}")
+        if not marker.exists():
+            try:
+                nonempty = any(destination.iterdir())
+            except OSError as exc:
+                fail(f"cannot inspect backup destination: {exc}")
+            if nonempty:
+                fail("backup destination has no matching replicante identity marker")
+            if not allow_initialize:
+                fail("backup destination is uninitialized")
+            initialized = True
+    else:
+        if not allow_initialize:
+            fail(f"backup destination is unavailable: {destination}")
+        try:
+            destination.mkdir()
+        except OSError as exc:
+            fail(f"cannot create backup destination: {exc}")
+        initialized = True
+
+    marker_path = destination / ROOT_MARKER
+    if initialized:
+        atomic_write(marker_path, canonical_json(backup_root_marker(source, destination)) + b"\n")
+        ensure_directory(destination / "objects")
+        ensure_directory(destination / "snapshots")
+    else:
+        marker = read_json(marker_path)
+        expected = backup_root_marker(source, destination)
+        if marker != expected:
+            fail("backup destination identity marker does not match the canonical source and destination")
+        for child in (destination / "objects", destination / "snapshots"):
+            if not child.is_dir() or child.is_symlink():
+                fail(f"backup layout is incomplete or unsafe: {child}")
+        if not (destination / LATEST_MARKER).is_file():
+            fail("backup destination has no latest snapshot marker")
+    return initialized, destination / "objects", destination / "snapshots"
+
+
+class BackupLock:
+    def __init__(self, destination: Path) -> None:
+        self.destination = destination
+        self.path = destination.parent / f".{destination.name}.replicante.lock"
+        self.held = False
+
+    def __enter__(self) -> "BackupLock":
+        try:
+            self.path.mkdir()
+            self.held = True
+            atomic_write(
+                self.path / "owner",
+                f"pid={os.getpid()}\ndestination={self.destination}\n".encode(),
+            )
+        except FileExistsError:
+            fail(f"another replicante execution holds the lock: {self.path}")
+        except OSError as exc:
+            if self.held:
+                try:
+                    self.path.rmdir()
+                except OSError:
+                    pass
+            fail(f"cannot acquire replicante lock {self.path}: {exc}")
+        return self
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        if not self.held:
+            return
+        try:
+            owner = self.path / "owner"
+            if owner.exists():
+                owner.unlink()
+            self.path.rmdir()
+        except OSError as exc:
+            fail(f"cannot release replicante lock {self.path}: {exc}")
+        self.held = False
+
+
+def snapshot_path(snapshots: Path, identifier: str) -> Path:
+    if not SNAPSHOT_ID_RE.fullmatch(identifier):
+        fail(f"invalid snapshot identifier: {identifier}")
+    return snapshots / identifier
+
+
+def validate_entry(entry: Any, seen: set[str]) -> None:
+    if not isinstance(entry, dict):
+        fail("snapshot contains a non-object entry")
+    kind = entry.get("kind")
+    relative = entry.get("path")
+    if kind not in {"dir", "file", "symlink"} or not isinstance(relative, str):
+        fail("snapshot contains a malformed entry")
+    if not relative or relative.startswith("/") or "\\" in relative or "\x00" in relative:
+        fail(f"snapshot contains an unsafe path: {relative!r}")
+    if relative != "." and ".." in PurePosixPath(relative).parts:
+        fail(f"snapshot contains a traversal path: {relative}")
+    if relative in seen:
+        fail(f"snapshot contains a duplicate path: {relative}")
+    seen.add(relative)
+    if kind in {"dir", "file"}:
+        mode = entry.get("mode")
+        if not isinstance(mode, int) or mode < 0 or mode > 0o7777:
+            fail(f"snapshot contains an invalid mode: {relative}")
+    if kind == "file":
+        if not isinstance(entry.get("size"), int) or entry["size"] < 0:
+            fail(f"snapshot contains an invalid file size: {relative}")
+        if not isinstance(entry.get("sha256"), str) or not re.fullmatch(r"[0-9a-f]{64}", entry["sha256"]):
+            fail(f"snapshot contains an invalid file hash: {relative}")
+    if kind == "symlink" and not isinstance(entry.get("target"), str):
+        fail(f"snapshot contains an invalid symbolic-link target: {relative}")
+
+
+def validate_entry_tree(entries: list[dict[str, Any]]) -> None:
+    kinds = {entry["path"]: entry["kind"] for entry in entries}
+    if kinds.get(".") != "dir":
+        fail("snapshot has no directory root entry")
+    for entry in entries:
+        relative = entry["path"]
+        if relative == ".":
+            continue
+        parts = PurePosixPath(relative).parts
+        for index in range(1, len(parts)):
+            parent = "/".join(parts[:index])
+            if kinds.get(parent) != "dir":
+                fail(f"snapshot path has a non-directory parent: {relative}")
+
+
+def read_snapshot_manifest(
+    source: Path,
+    destination: Path,
+    snapshots: Path,
+    objects: Path,
+    identifier: str,
+    verify_objects: bool,
+) -> dict[str, Any]:
+    snapshot = snapshot_path(snapshots, identifier)
+    manifest_path = snapshot / "manifest.json"
+    if not snapshot.is_dir() or snapshot.is_symlink() or not manifest_path.is_file():
+        fail(f"snapshot is missing its manifest: {identifier}")
+    try:
+        extra = [child for child in snapshot.iterdir() if child.name != "manifest.json"]
+    except OSError as exc:
+        fail(f"cannot inspect snapshot {identifier}: {exc}")
+    if extra:
+        fail(f"snapshot contains unexpected files: {extra[0]}")
+    manifest = read_json(manifest_path)
+    if manifest.get("format") != SNAPSHOT_FORMAT:
+        fail(f"snapshot has an unsupported format: {identifier}")
+    if manifest.get("source") != str(source) or manifest.get("destination") != str(destination):
+        fail(f"snapshot identity does not match this backup: {identifier}")
+    if manifest.get("snapshot_id") != identifier:
+        fail(f"snapshot identifier does not match its manifest: {identifier}")
+    if not isinstance(manifest.get("source_branch"), str) or not isinstance(manifest.get("source_commit"), str):
+        fail(f"snapshot source identity is malformed: {identifier}")
+    if not re.fullmatch(r"[0-9a-f]{40,64}", manifest["source_commit"]):
+        fail(f"snapshot source commit is malformed: {identifier}")
+    entries = manifest.get("entries")
+    if not isinstance(entries, list) or not entries:
+        fail(f"snapshot has no entries: {identifier}")
+    seen: set[str] = set()
+    for entry in entries:
+        validate_entry(entry, seen)
+    if entries != sorted(entries, key=lambda entry: entry["path"]):
+        fail(f"snapshot entries are not canonically ordered: {identifier}")
+    validate_entry_tree(entries)
+    expected_id = snapshot_id(source, {
+        "source_branch": manifest.get("source_branch", ""),
+        "source_commit": manifest.get("source_commit", ""),
+    }, entries)
+    if expected_id != identifier:
+        fail(f"snapshot identity hash does not match its manifest: {identifier}")
+    manifest_hash = manifest.get("manifest_sha256")
+    unsigned = dict(manifest)
+    unsigned.pop("manifest_sha256", None)
+    if not isinstance(manifest_hash, str) or hashlib.sha256(canonical_json(unsigned)).hexdigest() != manifest_hash:
+        fail(f"snapshot manifest hash does not match its contents: {identifier}")
+    if verify_objects:
+        for entry in entries:
+            if entry["kind"] != "file":
+                continue
+            object_path = objects / entry["sha256"]
+            if not object_path.is_file() or object_path.is_symlink():
+                fail(f"snapshot object is missing: {entry['sha256']}")
+            digest, size = hash_file(object_path)
+            if digest != entry["sha256"] or size != entry["size"]:
+                fail(f"snapshot object hash or size is corrupt: {entry['path']}")
+    return manifest
+
+
+def latest_id(destination: Path) -> str:
+    value = read_bytes(destination / LATEST_MARKER).decode("ascii").strip()
+    if not SNAPSHOT_ID_RE.fullmatch(value):
+        fail("latest snapshot marker is malformed")
+    return value
+
+
+def source_path(root: Path, relative: str) -> Path:
+    if relative == ".":
+        return root
+    return root.joinpath(*PurePosixPath(relative).parts)
+
+
+def copy_file_contents(source: Path, destination: Path) -> None:
+    try:
+        with source.open("rb") as source_handle, destination.open("wb") as destination_handle:
+            while chunk := source_handle.read(1024 * 1024):
+                destination_handle.write(chunk)
+    except OSError as exc:
+        fail(f"cannot copy backup content from {source}: {exc}")
+
+
+def ensure_object(source: Path, objects: Path, digest: str, size: int) -> bool:
+    object_path = objects / digest
+    if object_path.exists():
+        if object_path.is_symlink() or not object_path.is_file():
+            fail(f"backup object path is not a regular file: {digest}")
+        actual_digest, actual_size = hash_file(object_path)
+        if actual_digest != digest or actual_size != size:
+            fail(f"existing backup object is corrupt: {digest}")
+        return False
+    temporary = None
+    try:
+        descriptor, temporary_name = tempfile.mkstemp(prefix=".object.tmp-", dir=objects)
+        temporary = Path(temporary_name)
+        with os.fdopen(descriptor, "wb") as handle:
+            with source.open("rb") as source_handle:
+                while chunk := source_handle.read(1024 * 1024):
+                    handle.write(chunk)
+        actual_digest, actual_size = hash_file(temporary)
+        if actual_digest != digest or actual_size != size:
+            fail(f"source changed while copying backup object: {source}")
+        os.replace(temporary, object_path)
+        temporary = None
+        return True
+    except OSError as exc:
+        fail(f"cannot create backup object {digest}: {exc}")
+    finally:
+        if temporary is not None:
+            try:
+                temporary.unlink()
+            except OSError:
+                pass
+    return False
+
+
+def write_snapshot(
+    source: Path,
+    destination: Path,
+    snapshots: Path,
+    identifier: str,
+    identity: dict[str, str],
+    entries: list[dict[str, Any]],
+) -> None:
+    final_path = snapshot_path(snapshots, identifier)
+    if final_path.exists():
+        fail(f"snapshot path already exists but was not accepted: {identifier}")
+    temporary = snapshots / f".{identifier}.tmp-{os.getpid()}"
+    if temporary.exists():
+        fail(f"stale snapshot staging path exists: {temporary}")
+    try:
+        temporary.mkdir()
+        body: dict[str, Any] = {
+            "created_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+            "destination": str(destination),
+            "entries": entries,
+            "format": SNAPSHOT_FORMAT,
+            "snapshot_id": identifier,
+            "source": str(source),
+            **identity,
+        }
+        manifest = dict(body)
+        manifest["manifest_sha256"] = hashlib.sha256(canonical_json(body)).hexdigest()
+        atomic_write(temporary / "manifest.json", canonical_json(manifest) + b"\n")
+        os.replace(temporary, final_path)
+    except OSError as exc:
+        fail(f"cannot install snapshot {identifier}: {exc}")
+    finally:
+        if temporary.exists():
+            shutil.rmtree(temporary, ignore_errors=True)
+
+
+def source_state(source: Path) -> tuple[dict[str, str], list[dict[str, Any]]]:
+    identity = source_identity(source)
+    entries = scan_tree(source)
+    return identity, entries
+
+
+def assert_source_stable(
+    source: Path,
+    identity: dict[str, str],
+    entries: list[dict[str, Any]],
+) -> None:
+    current_identity, current_entries = source_state(source)
+    if current_identity != identity or current_entries != entries:
+        fail("canonical source changed while the backup was being built")
+
+
+def snapshot_ids(snapshots: Path) -> list[str]:
+    try:
+        values = [child.name for child in snapshots.iterdir() if child.is_dir() and SNAPSHOT_ID_RE.fullmatch(child.name)]
+    except OSError as exc:
+        fail(f"cannot enumerate snapshots: {exc}")
+    return sorted(values)
+
+
+def prune_snapshots(
+    source: Path,
+    destination: Path,
+    objects: Path,
+    snapshots: Path,
+    retain: int,
+) -> None:
+    if retain < 1:
+        fail("snapshot retention must be at least 1")
+    verified: list[tuple[str, str]] = []
+    for identifier in snapshot_ids(snapshots):
+        manifest = read_snapshot_manifest(source, destination, snapshots, objects, identifier, True)
+        created = manifest.get("created_at")
+        if not isinstance(created, str):
+            fail(f"snapshot has no creation time: {identifier}")
+        verified.append((created, identifier))
+    if len(verified) <= retain:
+        return
+    current = latest_id(destination)
+    for _, identifier in sorted(verified)[: len(verified) - retain]:
+        if identifier == current:
+            continue
+        target = snapshot_path(snapshots, identifier)
+        try:
+            shutil.rmtree(target)
+        except OSError as exc:
+            fail(f"cannot prune snapshot {identifier}: {exc}")
+
+
+def destination_needs_initialization(destination: Path) -> bool:
+    if not destination.exists():
+        return True
+    if destination.is_symlink() or not destination.is_dir():
+        return False
+    try:
+        return not any(destination.iterdir())
+    except OSError as exc:
+        fail(f"cannot inspect backup destination: {exc}")
+
+
+def run_backup(source: Path, destination: Path, retain: int) -> None:
+    if retain < 1:
+        fail("snapshot retention must be at least 1")
+    with BackupLock(destination):
+        initial_backup = destination_needs_initialization(destination)
+        if initial_backup:
+            identity, entries = source_state(source)
+            assert_source_stable(source, identity, entries)
+            _, objects, snapshots = load_root(source, destination, allow_initialize=True)
+            previous = None
+        else:
+            _, objects, snapshots = load_root(source, destination, allow_initialize=False)
+            previous = latest_id(destination)
+            read_snapshot_manifest(source, destination, snapshots, objects, previous, True)
+            identity, entries = source_state(source)
+        identifier = snapshot_id(source, identity, entries)
+        if identifier == previous:
+            assert_source_stable(source, identity, entries)
+            prune_snapshots(source, destination, objects, snapshots, retain)
+            print(f"already current: snapshot={identifier} destination={destination}")
+            return
+        for entry in entries:
+            if entry["kind"] == "file":
+                ensure_object(
+                    source_path(source, entry["path"]),
+                    objects,
+                    entry["sha256"],
+                    entry["size"],
+                )
+        assert_source_stable(source, identity, entries)
+        if snapshot_path(snapshots, identifier).exists():
+            read_snapshot_manifest(source, destination, snapshots, objects, identifier, True)
+        else:
+            write_snapshot(source, destination, snapshots, identifier, identity, entries)
+            read_snapshot_manifest(source, destination, snapshots, objects, identifier, True)
+        atomic_write(destination / LATEST_MARKER, f"{identifier}\n".encode("ascii"))
+        prune_snapshots(source, destination, objects, snapshots, retain)
+        print(f"replicated: snapshot={identifier} destination={destination}")
+
+
+def restore_tree(
+    manifest: dict[str, Any],
+    objects: Path,
+    output: Path,
+    apply_modes: bool,
+) -> None:
+    entries = manifest["entries"]
+    try:
+        output.mkdir()
+        for entry in entries:
+            target = source_path(output, entry["path"])
+            if entry["path"] == ".":
+                continue
+            if entry["kind"] == "dir":
+                target.mkdir()
+            elif entry["kind"] == "symlink":
+                os.symlink(entry["target"], target)
+            else:
+                copy_file_contents(objects / entry["sha256"], target)
+        if apply_modes:
+            for entry in sorted(entries, key=lambda value: value["path"].count("/"), reverse=True):
+                if entry["kind"] in {"dir", "file"}:
+                    os.chmod(source_path(output, entry["path"]), entry["mode"])
+    except OSError as exc:
+        fail(f"cannot restore snapshot to {output}: {exc}")
+
+
+def projected_entries(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            key: value
+            for key, value in entry.items()
+            if key in {"kind", "path", "sha256", "size", "target"}
+        }
+        for entry in entries
+    ]
+
+
+def verify_restore_test(manifest: dict[str, Any], objects: Path) -> None:
+    temporary = Path(tempfile.mkdtemp(prefix="replicante-verify-"))
+    temporary.rmdir()
+    try:
+        restore_tree(manifest, objects, temporary, apply_modes=False)
+        restored = scan_tree(temporary)
+        if projected_entries(restored) != projected_entries(manifest["entries"]):
+            fail("restore verification produced a tree different from the snapshot")
+    finally:
+        shutil.rmtree(temporary, ignore_errors=True)
+
+
+def verify_backup(
+    source: Path,
+    destination: Path,
+    identifier: str | None,
+    verify_all: bool,
+    restore_test: bool,
+) -> None:
+    with BackupLock(destination):
+        initialized, objects, snapshots = load_root(source, destination, allow_initialize=False)
+        if initialized:
+            fail("backup destination is initialized but has no snapshot to verify")
+        selected = snapshot_ids(snapshots) if verify_all else [identifier or latest_id(destination)]
+        if not selected:
+            fail("backup destination contains no snapshots")
+        for value in selected:
+            manifest = read_snapshot_manifest(source, destination, snapshots, objects, value, True)
+            if restore_test:
+                if verify_all or len(selected) != 1:
+                    fail("restore test requires one selected snapshot")
+                verify_restore_test(manifest, objects)
+        suffix = " with restore test" if restore_test else ""
+        print(f"verified: snapshots={len(selected)} destination={destination}{suffix}")
+
+
+def restore_backup(
+    source: Path,
+    destination: Path,
+    identifier: str,
+    output: Path,
+    test_mode: bool,
+    apply_modes: bool,
+) -> None:
+    if output.exists() or output.is_symlink():
+        fail(f"restore output already exists: {output}")
+    output_parent = output.parent.resolve()
+    output_absolute = Path(os.path.realpath(output))
+    if not output_parent.is_dir():
+        fail(f"restore output parent is unavailable: {output_parent}")
+    if not test_mode:
+        if is_under(output_absolute, Path("/mnt/d")) or is_under(output_absolute, source):
+            fail("restore output must not touch the source or D: trees")
+        if is_under(output_absolute, destination):
+            fail("restore output must not be inside the backup store")
+        if not is_under(output_absolute, Path("/mnt/h")):
+            fail("restore output must be on H: or use fixture mode")
+    with BackupLock(destination):
+        initialized, objects, snapshots = load_root(source, destination, allow_initialize=False)
+        if initialized:
+            fail("backup destination is initialized but has no snapshot to restore")
+        manifest = read_snapshot_manifest(source, destination, snapshots, objects, identifier, True)
+        temporary = output_parent / f".{output.name}.replicante-restore-{os.getpid()}"
+        if temporary.exists():
+            fail(f"stale restore staging path exists: {temporary}")
+        try:
+            restore_tree(manifest, objects, temporary, apply_modes)
+            os.replace(temporary, output)
+        except OSError as exc:
+            fail(f"cannot install restored snapshot: {exc}")
+        finally:
+            if temporary.exists():
+                shutil.rmtree(temporary, ignore_errors=True)
+        print(f"restored: snapshot={identifier} output={output}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Incremental content-addressed backup to /mnt/h/Firstmate-Backup."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    run_parser = subparsers.add_parser("run", help="create or advance the incremental backup")
+    retention_default = os.environ.get("REPLICANTE_RETENTION", "30")
+    try:
+        retention_default_value = int(retention_default)
+    except ValueError:
+        parser.error("REPLICANTE_RETENTION must be an integer")
+    run_parser.add_argument(
+        "--retain",
+        type=int,
+        default=retention_default_value,
+        help="number of historical snapshots to retain (default: 30)",
+    )
+    verify_parser = subparsers.add_parser("verify", help="verify one or all snapshots")
+    verify_parser.add_argument("--snapshot", help="snapshot identifier; defaults to latest")
+    verify_parser.add_argument("--all", action="store_true", help="verify every retained snapshot")
+    verify_parser.add_argument(
+        "--restore-test",
+        action="store_true",
+        help="restore the selected snapshot to a temporary directory and compare its tree",
+    )
+    restore_parser = subparsers.add_parser("restore", help="restore one snapshot to a new output directory")
+    restore_parser.add_argument("--snapshot", required=True, help="snapshot identifier")
+    restore_parser.add_argument("--output", required=True, help="new recovery output directory")
+    restore_parser.add_argument(
+        "--apply-modes",
+        action="store_true",
+        help="apply recorded source modes where the recovery filesystem permits it",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    arguments = parse_args()
+    source, destination, test_mode = resolve_paths(arguments.command)
+    if arguments.command == "run":
+        run_backup(source, destination, arguments.retain)
+    elif arguments.command == "verify":
+        if arguments.snapshot and arguments.all:
+            fail("--snapshot and --all cannot be combined")
+        if arguments.restore_test and arguments.all:
+            fail("--restore-test requires one selected snapshot")
+        verify_backup(source, destination, arguments.snapshot, arguments.all, arguments.restore_test)
+    else:
+        restore_backup(
+            source,
+            destination,
+            arguments.snapshot,
+            Path(arguments.output).absolute(),
+            test_mode,
+            arguments.apply_modes,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/fm-replicante.py
+++ b/bin/fm-replicante.py
@@ -352,6 +352,8 @@ def validate_entry(entry: Any, seen: set[str]) -> None:
         fail("snapshot contains a malformed entry")
     if not relative or relative.startswith("/") or "\\" in relative or "\x00" in relative:
         fail(f"snapshot contains an unsafe path: {relative!r}")
+    if relative != PurePosixPath(relative).as_posix():
+        fail(f"snapshot contains a non-canonical path: {relative}")
     if relative != "." and ".." in PurePosixPath(relative).parts:
         fail(f"snapshot contains a traversal path: {relative}")
     if relative in seen:

--- a/bin/fm-replicante.sh
+++ b/bin/fm-replicante.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# fm-replicante.sh - maintain the incremental Firstmate backup on H:.
+#
+# The normal destination is exactly /mnt/h/Firstmate-Backup.
+# The source is exactly /home/ale/firstmate.
+# run creates content-addressed objects and immutable full-tree snapshot
+# manifests, so changed bytes are copied once and deleted source paths remain
+# available through older snapshots.
+# verify checks snapshot and object hashes; --restore-test also reconstructs a
+# temporary tree and compares its content and symbolic links.
+# restore writes one selected snapshot to a new H: recovery directory.
+#
+# Normal operation does not accept source or destination overrides.
+# Tests use REPLICANTE_TEST_MODE=1 with explicit temporary fixture paths.
+#
+# Usage:
+#   fm-replicante.sh run [--retain <count>]
+#   fm-replicante.sh verify [--snapshot <id>] [--all] [--restore-test]
+#   fm-replicante.sh restore --snapshot <id> --output <directory> [--apply-modes]
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec python3 "$SCRIPT_DIR/fm-replicante.py" "$@"

--- a/bin/fm-shadow.py
+++ b/bin/fm-shadow.py
@@ -132,6 +132,8 @@ def read_manifest(
     expected_branch: str,
     expected_commit: str,
 ) -> dict[str, tuple[str, str, str]]:
+    if manifest_path.is_symlink() or policy_path.is_symlink():
+        fail("destination manifest and policy must not be symbolic links")
     if not manifest_path.is_file() or not policy_path.is_file():
         fail("destination requires its manifest and policy sidecars")
     try:

--- a/bin/fm-shadow.py
+++ b/bin/fm-shadow.py
@@ -228,7 +228,17 @@ def validate_command(args: argparse.Namespace) -> None:
             fail(f"destination content differs from manifest: {rel}")
     try:
         branch = subprocess.check_output(
-            ["git", "-C", str(root), "symbolic-ref", "--quiet", "--short", "HEAD"],
+            [
+                "git",
+                "-c",
+                f"safe.directory={root}",
+                "-C",
+                str(root),
+                "symbolic-ref",
+                "--quiet",
+                "--short",
+                "HEAD",
+            ],
             text=True,
             stderr=subprocess.DEVNULL,
         ).strip()

--- a/bin/fm-shadow.py
+++ b/bin/fm-shadow.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import os
-import shutil
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -37,12 +37,37 @@ def link_target(path: Path, rel: str) -> str:
     return target
 
 
+def copy_file_contents(source: Path, destination: Path) -> None:
+    with source.open("rb") as source_handle, destination.open("wb") as destination_handle:
+        while chunk := source_handle.read(1024 * 1024):
+            destination_handle.write(chunk)
+
+
+def copy_entry(source: Path, destination: Path, relative: str) -> None:
+    mode = os.lstat(source).st_mode
+    if stat.S_ISLNK(mode):
+        os.symlink(os.readlink(source), destination)
+        return
+    if stat.S_ISDIR(mode):
+        os.mkdir(destination)
+        with os.scandir(source) as iterator:
+            children = sorted(iterator, key=lambda entry: entry.name)
+        for child in children:
+            child_relative = f"{relative}/{child.name}" if relative else child.name
+            copy_entry(Path(child.path), destination / child.name, child_relative)
+        return
+    if stat.S_ISREG(mode):
+        copy_file_contents(source, destination)
+        return
+    fail(f"special file is not allowed in source tree: {relative}")
+
+
 def copy_tree(source: Path, destination: Path) -> None:
-    if not source.is_dir() or source.is_symlink():
+    if not stat.S_ISDIR(os.lstat(source).st_mode) or source.is_symlink():
         fail(f"source tree is not a directory: {source}")
     try:
-        shutil.copytree(source, destination, symlinks=True, copy_function=shutil.copy2)
-    except (OSError, shutil.Error) as exc:
+        copy_entry(source, destination, "")
+    except OSError as exc:
         fail(f"cannot mirror source tree: {exc}")
 
 

--- a/bin/fm-shadow.py
+++ b/bin/fm-shadow.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Private implementation helpers for bin/fm-shadow.sh."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def fail(message: str) -> None:
+    print(f"fm-shadow: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def hash_file(path: Path) -> tuple[str, str]:
+    digest = hashlib.sha256()
+    size = 0
+    try:
+        with path.open("rb") as handle:
+            while chunk := handle.read(1024 * 1024):
+                digest.update(chunk)
+                size += len(chunk)
+    except OSError as exc:
+        fail(f"cannot hash {path}: {exc}")
+    return digest.hexdigest(), str(size)
+
+
+def link_target(path: Path, rel: str) -> str:
+    target = os.readlink(path)
+    if any(char in target for char in "\x00\r\n\t"):
+        fail(f"symbolic-link target contains a control character: {rel}")
+    return target
+
+
+def copy_tree(source: Path, destination: Path) -> None:
+    if not source.is_dir() or source.is_symlink():
+        fail(f"source tree is not a directory: {source}")
+    try:
+        shutil.copytree(source, destination, symlinks=True, copy_function=shutil.copy2)
+    except (OSError, shutil.Error) as exc:
+        fail(f"cannot mirror source tree: {exc}")
+
+
+def copy_command(args: argparse.Namespace) -> None:
+    copy_tree(Path(args.source), Path(args.stage))
+
+
+def staged_entries(root: Path) -> list[tuple[str, str, str, str]]:
+    entries: list[tuple[str, str, str, str]] = []
+    for current, dirnames, filenames in os.walk(root, topdown=True, followlinks=False):
+        current_path = Path(current)
+        kept_dirs = []
+        for name in sorted(dirnames):
+            path = current_path / name
+            rel = path.relative_to(root).as_posix()
+            if path.is_symlink():
+                entries.append(("symlink", link_target(path, rel), "-", rel))
+            else:
+                entries.append(("dir", "-", "-", rel))
+                kept_dirs.append(name)
+        dirnames[:] = kept_dirs
+        for name in sorted(filenames):
+            path = current_path / name
+            rel = path.relative_to(root).as_posix()
+            if path.is_symlink():
+                entries.append(("symlink", link_target(path, rel), "-", rel))
+                continue
+            if not path.is_file():
+                fail(f"special file is not allowed in staged output: {rel}")
+            digest, size = hash_file(path)
+            entries.append(("file", digest, size, rel))
+    return sorted(entries, key=lambda entry: entry[3])
+
+
+def manifest_command(args: argparse.Namespace) -> None:
+    values = (args.source, args.branch, args.commit)
+    if any(any(char in value for char in "\x00\r\n\t") for value in values):
+        fail("manifest metadata contains a control character")
+    entries = staged_entries(Path(args.root))
+    if not entries:
+        fail("staged output is empty")
+    lines = [
+        "shadow-manifest-v1",
+        f"source={args.source}",
+        f"source_branch={args.branch}",
+        f"source_commit={args.commit}",
+        f"policy_sha256={hash_file(Path(args.policy))[0]}",
+    ]
+    lines.extend("entry\t%s\t%s\t%s\t%s" % entry for entry in entries)
+    body = ("\n".join(lines) + "\n").encode("utf-8")
+    output = body + f"manifest_sha256={hashlib.sha256(body).hexdigest()}\n".encode("ascii")
+    try:
+        Path(args.output).write_bytes(output)
+    except OSError as exc:
+        fail(f"cannot write manifest: {exc}")
+
+
+def read_manifest(
+    root: Path,
+    manifest_path: Path,
+    policy_path: Path,
+    expected_branch: str,
+    expected_commit: str,
+) -> dict[str, tuple[str, str, str]]:
+    if not manifest_path.is_file() or not policy_path.is_file():
+        fail("destination requires its manifest and policy sidecars")
+    try:
+        raw = manifest_path.read_bytes()
+        lines = raw.decode("utf-8").splitlines()
+    except (OSError, UnicodeDecodeError) as exc:
+        fail(f"cannot read manifest: {exc}")
+    if len(lines) < 5 or lines[0] != "shadow-manifest-v1":
+        fail("unsupported manifest format")
+    if not raw.endswith(b"\n") or not lines[-1].startswith("manifest_sha256="):
+        fail("manifest hash footer is missing")
+    body = ("\n".join(lines[:-1]) + "\n").encode("utf-8")
+    if hashlib.sha256(body).hexdigest() != lines[-1].split("=", 1)[1]:
+        fail("manifest hash does not match its contents")
+    fields: dict[str, str] = {}
+    entries: dict[str, tuple[str, str, str]] = {}
+    for line in lines[1:-1]:
+        if line.startswith("entry\t"):
+            parts = line.split("\t")
+            if len(parts) != 5:
+                fail("malformed manifest entry")
+            _, kind, digest, size, rel = parts
+            if not rel or rel.startswith("/") or "\\" in rel or "\x00" in rel:
+                fail(f"unsafe manifest path: {rel!r}")
+            if rel in entries:
+                fail(f"duplicate manifest path: {rel}")
+            if ".." in Path(rel).parts:
+                fail(f"relative traversal in manifest path: {rel}")
+            entries[rel] = kind, digest, size
+        elif "=" in line:
+            key, value = line.split("=", 1)
+            if key in fields:
+                fail(f"duplicate manifest field: {key}")
+            fields[key] = value
+        else:
+            fail("malformed manifest line")
+    if fields.get("source_branch") != expected_branch:
+        fail("manifest source branch is not the configured default branch")
+    if fields.get("source_commit") != expected_commit:
+        fail("manifest source commit is not the current source commit")
+    if fields.get("policy_sha256") != hash_file(policy_path)[0]:
+        fail("policy hash does not match the generated policy")
+    if not entries:
+        fail("manifest contains no output entries")
+    return entries
+
+
+def actual_entries(root: Path) -> dict[str, tuple[str, str, str]]:
+    result: dict[str, tuple[str, str, str]] = {}
+    for current, dirnames, filenames in os.walk(root, topdown=True, followlinks=False):
+        current_path = Path(current)
+        kept_dirs = []
+        for name in sorted(dirnames):
+            path = current_path / name
+            rel = path.relative_to(root).as_posix()
+            if path.is_symlink():
+                result[rel] = "symlink", os.readlink(path), "-"
+            else:
+                result[rel] = "dir", "-", "-"
+                kept_dirs.append(name)
+        dirnames[:] = kept_dirs
+        for name in sorted(filenames):
+            path = current_path / name
+            rel = path.relative_to(root).as_posix()
+            if path.is_symlink():
+                result[rel] = "symlink", os.readlink(path), "-"
+            elif path.is_file():
+                digest, size = hash_file(path)
+                result[rel] = "file", digest, size
+            else:
+                fail(f"special file is present in destination: {rel}")
+    return result
+
+
+def validate_command(args: argparse.Namespace) -> None:
+    root = Path(args.root)
+    entries = read_manifest(
+        root,
+        Path(args.manifest),
+        Path(args.policy),
+        args.branch,
+        args.commit,
+    )
+    actual = actual_entries(root)
+    if set(entries) != set(actual):
+        missing = sorted(set(entries) - set(actual))
+        extra = sorted(set(actual) - set(entries))
+        if missing:
+            fail(f"manifest file is missing from destination: {missing[0]}")
+        fail(f"destination contains an unmanifested path: {extra[0]}")
+    for rel, expected in entries.items():
+        path = root / rel
+        if actual[rel] != expected:
+            fail(f"destination content differs from manifest: {rel}")
+    try:
+        branch = subprocess.check_output(
+            ["git", "-C", str(root), "symbolic-ref", "--quiet", "--short", "HEAD"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except subprocess.CalledProcessError:
+        fail("destination is detached")
+    if branch != args.branch:
+        fail(f"destination branch is {branch!r}, expected {args.branch!r}")
+
+
+def compare_command(args: argparse.Namespace) -> None:
+    source_entries = staged_entries(Path(args.source))
+    replica_entries = staged_entries(Path(args.replica))
+    if source_entries != replica_entries:
+        fail("source tree changed while the replica was being built")
+
+
+parser = argparse.ArgumentParser()
+subparsers = parser.add_subparsers(dest="command", required=True)
+copy_parser = subparsers.add_parser("copy")
+copy_parser.add_argument("--source", required=True)
+copy_parser.add_argument("--stage", required=True)
+manifest_parser = subparsers.add_parser("manifest")
+manifest_parser.add_argument("--root", required=True)
+manifest_parser.add_argument("--source", required=True)
+manifest_parser.add_argument("--branch", required=True)
+manifest_parser.add_argument("--commit", required=True)
+manifest_parser.add_argument("--policy", required=True)
+manifest_parser.add_argument("--output", required=True)
+validate_parser = subparsers.add_parser("validate")
+validate_parser.add_argument("--root", required=True)
+validate_parser.add_argument("--branch", required=True)
+validate_parser.add_argument("--commit", required=True)
+validate_parser.add_argument("--manifest", required=True)
+validate_parser.add_argument("--policy", required=True)
+compare_parser = subparsers.add_parser("compare")
+compare_parser.add_argument("--source", required=True)
+compare_parser.add_argument("--replica", required=True)
+args = parser.parse_args()
+if args.command == "copy":
+    copy_command(args)
+elif args.command == "manifest":
+    manifest_command(args)
+elif args.command == "compare":
+    compare_command(args)
+else:
+    validate_command(args)

--- a/bin/fm-shadow.sh
+++ b/bin/fm-shadow.sh
@@ -39,6 +39,7 @@ LOCK_DIR=
 LOCK_HELD=0
 STAGE=
 STAGE_MOVED=0
+SOURCE_SNAPSHOT=
 CONTROL_DIR=
 CONTROL_STAGE=
 CONTROL_STAGE_MOVED=0
@@ -60,6 +61,9 @@ die() {
 }
 
 cleanup() {
+  if [ -n "$SOURCE_SNAPSHOT" ] && [ -d "$SOURCE_SNAPSHOT" ]; then
+    rm -rf -- "$SOURCE_SNAPSHOT"
+  fi
   if [ -n "$STAGE" ] && [ -d "$STAGE" ] && [ "$STAGE_MOVED" -eq 0 ]; then
     rm -rf -- "$STAGE"
   fi
@@ -93,6 +97,10 @@ git_status_at() {
   local repo=$1
   shift
   git -c "safe.directory=$repo" -c core.filemode=false -C "$repo" "$@"
+}
+
+source_status_output() {
+  GIT_OPTIONAL_LOCKS=0 git_at "$SOURCE" status --porcelain=v1 --untracked-files=all
 }
 
 lowercase() {
@@ -168,7 +176,7 @@ default_branch() {
 }
 
 check_source() {
-  local root branch
+  local root branch status
   require_command git
   require_command python3
   root=$(git_at "$SOURCE" rev-parse --show-toplevel 2>/dev/null) \
@@ -181,7 +189,10 @@ check_source() {
     || die "cannot determine source default branch from origin/HEAD, main, or master"
   [ "$branch" = "$DEFAULT_BRANCH" ] \
     || die "source branch '$branch' is not the default branch '$DEFAULT_BRANCH'"
-  [ -z "$(GIT_OPTIONAL_LOCKS=0 git_at "$SOURCE" status --porcelain=v1 --untracked-files=all)" ] \
+  if ! status=$(source_status_output); then
+    die "cannot inspect source working tree"
+  fi
+  [ -z "$status" ] \
     || die "source working tree is dirty; refusing to publish"
   SOURCE_COMMIT=$(git_at "$SOURCE" rev-parse --verify HEAD 2>/dev/null) \
     || die "cannot resolve source HEAD"
@@ -242,13 +253,20 @@ check_existing_destination() {
 
 build_stage() {
   local clone_head
+  SOURCE_SNAPSHOT=$(mktemp -d "$DEST_PARENT/.shadow-source-snapshot.XXXXXX") \
+    || die "cannot create the source snapshot beside destination"
+  rmdir -- "$SOURCE_SNAPSHOT"
+  python3 "$SCRIPT_DIR/fm-shadow.py" copy --source "$SOURCE" --stage "$SOURCE_SNAPSHOT" \
+    || die "cannot capture the source snapshot"
+  source_snapshot_is_stable \
+    || die "source changed while the source snapshot was being captured; no destination update was made"
   STAGE=$(mktemp -d "$DEST_PARENT/.shadow-stage.XXXXXX") \
     || die "cannot create staging directory beside destination"
   rmdir -- "$STAGE"
   CONTROL_STAGE=$(mktemp -d "$DEST_PARENT/.shadow-control-stage.XXXXXX") \
     || die "cannot create replica control staging directory"
-  python3 "$SCRIPT_DIR/fm-shadow.py" copy --source "$SOURCE" --stage "$STAGE" \
-    || die "cannot mirror source into the temporary replica"
+  python3 "$SCRIPT_DIR/fm-shadow.py" copy --source "$SOURCE_SNAPSHOT" --stage "$STAGE" \
+    || die "cannot build the temporary replica from the source snapshot"
   clone_head=$(git_at "$STAGE" rev-parse --verify HEAD 2>/dev/null) \
     || die "staged replica has no commit"
   [ "$clone_head" = "$SOURCE_COMMIT" ] \
@@ -272,16 +290,26 @@ EOF
     || die "cannot write the replica manifest"
 }
 
-recheck_source() {
-  local branch commit
+source_snapshot_is_stable() {
+  local branch commit status
   branch=$(git_at "$SOURCE" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
   commit=$(git_at "$SOURCE" rev-parse --verify HEAD 2>/dev/null || true)
-  [ "$branch" = "$DEFAULT_BRANCH" ] && [ "$commit" = "$SOURCE_COMMIT" ] \
+  [ "$branch" = "$DEFAULT_BRANCH" ] && [ "$commit" = "$SOURCE_COMMIT" ] || return 1
+  if ! status=$(source_status_output); then
+    return 1
+  fi
+  [ -z "$status" ] || return 1
+  python3 "$SCRIPT_DIR/fm-shadow.py" compare --source "$SOURCE" --replica "$SOURCE_SNAPSHOT" \
+    >/dev/null 2>&1 || return 1
+  if [ -n "$STAGE" ]; then
+    python3 "$SCRIPT_DIR/fm-shadow.py" compare --source "$SOURCE_SNAPSHOT" --replica "$STAGE" \
+      >/dev/null 2>&1 || return 1
+  fi
+}
+
+recheck_source() {
+  source_snapshot_is_stable \
     || die "source changed while the replica was being built; no destination update was made"
-  [ -z "$(GIT_OPTIONAL_LOCKS=0 git_at "$SOURCE" status --porcelain=v1 --untracked-files=all)" ] \
-    || die "source became dirty while the replica was being built; no destination update was made"
-  python3 "$SCRIPT_DIR/fm-shadow.py" compare --source "$SOURCE" --replica "$STAGE" \
-    || die "source tree changed while the replica was being built; no destination update was made"
 }
 
 same_output() {
@@ -291,14 +319,16 @@ same_output() {
 }
 
 source_matches_replica() {
-  local branch commit replica_commit
+  local branch commit replica_commit status
   branch=$(git_at "$SOURCE" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
   commit=$(git_at "$SOURCE" rev-parse --verify HEAD 2>/dev/null || true)
   replica_commit=$(git_at "$DEST" rev-parse --verify HEAD 2>/dev/null || true)
   [ "$branch" = "$DEFAULT_BRANCH" ] && [ "$commit" = "$replica_commit" ] \
     || return 1
-  [ -z "$(GIT_OPTIONAL_LOCKS=0 git_at "$SOURCE" status --porcelain=v1 --untracked-files=all)" ] \
-    || return 1
+  if ! status=$(source_status_output); then
+    return 1
+  fi
+  [ -z "$status" ] || return 1
   python3 "$SCRIPT_DIR/fm-shadow.py" compare --source "$SOURCE" --replica "$DEST" \
     >/dev/null 2>&1
 }
@@ -449,9 +479,12 @@ begin_transaction() {
 }
 
 swap_replica() {
-  recheck_source
   check_existing_destination
   begin_transaction
+  if ! source_snapshot_is_stable; then
+    clear_transaction
+    die "source changed before shadow installation; no destination update was made"
+  fi
   if [ "$(transaction_field destination-present)" -eq 1 ]; then
     mv -- "$DEST" "$TRANSACTION_DIR/old-destination" \
       || { recover_transaction; die "cannot move the validated destination into the shadow transaction"; }
@@ -524,8 +557,8 @@ check_existing_destination
 build_stage
 recheck_source
 if [ -d "$DEST" ] && same_output; then
-  recheck_source
   check_existing_destination
+  recheck_source
   printf 'already current: %s at %s\n' "$SOURCE_COMMIT" "$DEST"
   exit 0
 fi

--- a/bin/fm-shadow.sh
+++ b/bin/fm-shadow.sh
@@ -30,8 +30,11 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SOURCE_INPUT=$(printenv FM_SHADOW_SOURCE 2>/dev/null || printf '%s\n' /home/ale/firstmate)
 DEST_INPUT=$(printenv FM_SHADOW_DESTINATION 2>/dev/null || printf '%s\n' /mnt/d/Workspace/shadow)
 SOURCE=
+SOURCE_PARENT=
 DEST=
 DEST_PARENT=
+SOURCE_LOCK_DIR=
+SOURCE_LOCK_HELD=0
 LOCK_DIR=
 LOCK_HELD=0
 STAGE=
@@ -67,6 +70,10 @@ cleanup() {
     rm -f -- "$LOCK_DIR/owner"
     rmdir -- "$LOCK_DIR" 2>/dev/null || true
   fi
+  if [ "$SOURCE_LOCK_HELD" -eq 1 ] && [ -d "$SOURCE_LOCK_DIR" ]; then
+    rm -f -- "$SOURCE_LOCK_DIR/owner"
+    rmdir -- "$SOURCE_LOCK_DIR" 2>/dev/null || true
+  fi
 }
 
 trap 'exit 1' HUP INT TERM
@@ -95,6 +102,7 @@ lowercase() {
 resolve_paths() {
   [ -d "$SOURCE_INPUT" ] || die "source is not an existing directory: $SOURCE_INPUT"
   SOURCE=$(cd "$SOURCE_INPUT" && pwd -P) || die "cannot resolve source: $SOURCE_INPUT"
+  SOURCE_PARENT=$(dirname -- "$SOURCE")
 
   local parent name
   parent=$(dirname -- "$DEST_INPUT")
@@ -106,6 +114,7 @@ resolve_paths() {
   DEST="$DEST_PARENT/$name"
   CONTROL_DIR="$DEST_PARENT/.shadow-control.$name"
   TRANSACTION_DIR="$DEST_PARENT/.shadow-transaction.$name"
+  SOURCE_LOCK_DIR="$SOURCE_PARENT/.shadow-source-lock.$(basename -- "$SOURCE")"
 
   [ "$SOURCE" != "$DEST" ] || die "source and destination are the same path"
   case "$DEST/" in
@@ -135,6 +144,10 @@ resolve_paths() {
   [ ! -L "$TRANSACTION_DIR" ] || die "shadow transaction marker must not be a symbolic link: $TRANSACTION_DIR"
   if [ -e "$TRANSACTION_DIR" ] && [ ! -d "$TRANSACTION_DIR" ]; then
     die "shadow transaction marker is not a directory: $TRANSACTION_DIR"
+  fi
+  [ ! -L "$SOURCE_LOCK_DIR" ] || die "source lock must not be a symbolic link: $SOURCE_LOCK_DIR"
+  if [ -e "$SOURCE_LOCK_DIR" ] && [ ! -d "$SOURCE_LOCK_DIR" ]; then
+    die "source lock is not a directory: $SOURCE_LOCK_DIR"
   fi
 }
 
@@ -177,6 +190,14 @@ check_source() {
 }
 
 acquire_lock() {
+  mkdir -- "$SOURCE_LOCK_DIR" 2>/dev/null \
+    || die "another fm-shadow execution holds the source lock: $SOURCE_LOCK_DIR"
+  SOURCE_LOCK_HELD=1
+  {
+    printf 'pid=%s\n' "$$"
+    printf 'source=%s\n' "$SOURCE"
+    printf 'destination=%s\n' "$DEST"
+  } >"$SOURCE_LOCK_DIR/owner" || die "cannot record source lock owner: $SOURCE_LOCK_DIR"
   LOCK_DIR="$DEST_PARENT/.shadow.lock"
   mkdir -- "$LOCK_DIR" 2>/dev/null \
     || die "another fm-shadow execution holds the lock: $LOCK_DIR"
@@ -269,6 +290,19 @@ same_output() {
     && cmp -s "$CONTROL_STAGE/policy" "$CONTROL_DIR/policy"
 }
 
+source_matches_replica() {
+  local branch commit replica_commit
+  branch=$(git_at "$SOURCE" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+  commit=$(git_at "$SOURCE" rev-parse --verify HEAD 2>/dev/null || true)
+  replica_commit=$(git_at "$DEST" rev-parse --verify HEAD 2>/dev/null || true)
+  [ "$branch" = "$DEFAULT_BRANCH" ] && [ "$commit" = "$replica_commit" ] \
+    || return 1
+  [ -z "$(GIT_OPTIONAL_LOCKS=0 git_at "$SOURCE" status --porcelain=v1 --untracked-files=all)" ] \
+    || return 1
+  python3 "$SCRIPT_DIR/fm-shadow.py" compare --source "$SOURCE" --replica "$DEST" \
+    >/dev/null 2>&1
+}
+
 transaction_child_is_safe() {
   local child=$1
   [ ! -L "$TRANSACTION_DIR/$child" ] || die "shadow transaction contains a symbolic link: $child"
@@ -305,6 +339,22 @@ park_transaction_output() {
   fi
 }
 
+preserve_failed_transaction() {
+  local preserved
+  preserved=$(mktemp -d "$DEST_PARENT/.shadow-recovery-failed.XXXXXX") \
+    || die "cannot preserve the failed shadow output"
+  if [ -e "$TRANSACTION_DIR/failed-destination" ] || [ -L "$TRANSACTION_DIR/failed-destination" ]; then
+    mv -- "$TRANSACTION_DIR/failed-destination" "$preserved/destination" \
+      || die "cannot preserve the failed shadow destination at $preserved"
+  fi
+  if [ -e "$TRANSACTION_DIR/failed-control" ] || [ -L "$TRANSACTION_DIR/failed-control" ]; then
+    mv -- "$TRANSACTION_DIR/failed-control" "$preserved/control" \
+      || die "cannot preserve the failed shadow control metadata at $preserved"
+  fi
+  clear_transaction
+  die "shadow transaction was rolled back; failed output was preserved at $preserved"
+}
+
 recover_transaction() {
   local branch commit destination_present control_present
   [ -e "$TRANSACTION_DIR" ] || return 0
@@ -320,6 +370,10 @@ recover_transaction() {
   transaction_child_is_safe new-control
   transaction_child_is_safe failed-destination
   transaction_child_is_safe failed-control
+  if [ -e "$TRANSACTION_DIR/failed-destination" ] || [ -L "$TRANSACTION_DIR/failed-destination" ] \
+    || [ -e "$TRANSACTION_DIR/failed-control" ] || [ -L "$TRANSACTION_DIR/failed-control" ]; then
+    preserve_failed_transaction
+  fi
   if [ ! -f "$TRANSACTION_DIR/ready" ]; then
     [ ! -e "$TRANSACTION_DIR/old-destination" ] \
       && [ ! -e "$TRANSACTION_DIR/old-control" ] \
@@ -344,7 +398,8 @@ recover_transaction() {
   if [ ! -L "$DEST" ] && [ -d "$DEST" ] && [ ! -L "$CONTROL_DIR" ] && [ -d "$CONTROL_DIR" ] \
     && python3 "$SCRIPT_DIR/fm-shadow.py" validate \
       --root "$DEST" --manifest "$CONTROL_DIR/manifest" --policy "$CONTROL_DIR/policy" \
-      --branch "$branch" --commit "$commit" >/dev/null 2>&1; then
+      --branch "$branch" --commit "$commit" >/dev/null 2>&1 \
+    && source_matches_replica; then
     clear_transaction
     return 0
   fi
@@ -371,6 +426,10 @@ recover_transaction() {
   else
     park_transaction_output "$CONTROL_DIR" failed-control
   fi
+  if [ -e "$TRANSACTION_DIR/failed-destination" ] || [ -L "$TRANSACTION_DIR/failed-destination" ] \
+    || [ -e "$TRANSACTION_DIR/failed-control" ] || [ -L "$TRANSACTION_DIR/failed-control" ]; then
+    preserve_failed_transaction
+  fi
   clear_transaction
 }
 
@@ -390,6 +449,7 @@ begin_transaction() {
 }
 
 swap_replica() {
+  recheck_source
   check_existing_destination
   begin_transaction
   if [ "$(transaction_field destination-present)" -eq 1 ]; then
@@ -418,6 +478,10 @@ swap_replica() {
     --branch "$DEFAULT_BRANCH" --commit "$SOURCE_COMMIT"; then
     recover_transaction
     die "post-install validation failed; old destination was restored"
+  fi
+  if ! source_matches_replica; then
+    recover_transaction
+    die "source changed during shadow installation; old destination was restored"
   fi
   clear_transaction
 }
@@ -460,6 +524,7 @@ check_existing_destination
 build_stage
 recheck_source
 if [ -d "$DEST" ] && same_output; then
+  recheck_source
   check_existing_destination
   printf 'already current: %s at %s\n' "$SOURCE_COMMIT" "$DEST"
   exit 0

--- a/bin/fm-shadow.sh
+++ b/bin/fm-shadow.sh
@@ -13,6 +13,7 @@
 # Existing destination output is removed only after a clean replacement is
 # validated and installed.
 # Every Git invocation binds safe.directory to the exact checkout path for that invocation.
+# Destination status additionally disables filemode comparison only for that invocation.
 #
 # Usage:
 #   fm-shadow.sh [--source <path>] [--destination <path>]
@@ -80,6 +81,12 @@ git_at() {
   local repo=$1
   shift
   git -c "safe.directory=$repo" -C "$repo" "$@"
+}
+
+git_status_at() {
+  local repo=$1
+  shift
+  git -c "safe.directory=$repo" -c core.filemode=false -C "$repo" "$@"
 }
 
 lowercase() {
@@ -179,7 +186,7 @@ acquire_lock() {
 
 check_destination_git_clean() {
   local status line
-  status=$(GIT_OPTIONAL_LOCKS=0 git_at "$DEST" status --porcelain=v1 --untracked-files=all) \
+  status=$(GIT_OPTIONAL_LOCKS=0 git_status_at "$DEST" status --porcelain=v1 --untracked-files=all) \
     || die "cannot inspect destination status"
   while IFS= read -r line; do
     [ -n "$line" ] || continue

--- a/bin/fm-shadow.sh
+++ b/bin/fm-shadow.sh
@@ -220,6 +220,18 @@ acquire_lock() {
   } >"$LOCK_DIR/owner" || die "cannot record lock owner: $LOCK_DIR"
 }
 
+cleanup_stale_source_snapshots() {
+  local snapshot
+  for snapshot in "$DEST_PARENT"/.shadow-source-snapshot.*; do
+    if [ ! -e "$snapshot" ] && [ ! -L "$snapshot" ]; then
+      continue
+    fi
+    [ ! -L "$snapshot" ] || die "source snapshot must not be a symbolic link: $snapshot"
+    [ -d "$snapshot" ] || die "source snapshot is not a directory: $snapshot"
+    rm -rf -- "$snapshot" || die "cannot remove stale source snapshot: $snapshot"
+  done
+}
+
 check_destination_git_clean() {
   local status line
   status=$(GIT_OPTIONAL_LOCKS=0 git_status_at "$DEST" status --porcelain=v1 --untracked-files=all) \
@@ -330,6 +342,11 @@ source_matches_replica() {
   fi
   [ -z "$status" ] || return 1
   python3 "$SCRIPT_DIR/fm-shadow.py" compare --source "$SOURCE" --replica "$DEST" \
+    >/dev/null 2>&1
+}
+
+snapshot_matches_replica() {
+  python3 "$SCRIPT_DIR/fm-shadow.py" compare --source "$SOURCE_SNAPSHOT" --replica "$DEST" \
     >/dev/null 2>&1
 }
 
@@ -512,9 +529,9 @@ swap_replica() {
     recover_transaction
     die "post-install validation failed; old destination was restored"
   fi
-  if ! source_matches_replica; then
+  if ! snapshot_matches_replica; then
     recover_transaction
-    die "source changed during shadow installation; old destination was restored"
+    die "published shadow snapshot failed its final comparison; old destination was restored"
   fi
   clear_transaction
 }
@@ -551,6 +568,7 @@ done
 
 resolve_paths
 acquire_lock
+cleanup_stale_source_snapshots
 check_source
 recover_transaction
 check_existing_destination

--- a/bin/fm-shadow.sh
+++ b/bin/fm-shadow.sh
@@ -1,0 +1,379 @@
+#!/usr/bin/env bash
+# fm-shadow.sh - publish a fail-closed, one-way snapshot of canonical Firstmate.
+#
+# The source must be a clean checkout on its default branch.
+# The destination contains an exact copy of the source tree, including ignored
+# files, project clones, operational directories, and Git metadata.
+# Every run builds a complete temporary output beside the destination and
+# swaps it into place only after source, scope, manifest, and fast-forward
+# checks pass.
+#
+# A dirty, divergent, malformed, or unavailable destination is never repaired.
+# The command never uses a forced Git operation, a stash, or a hard reset.
+# Existing destination output is removed only after a clean replacement is
+# validated and installed.
+#
+# Usage:
+#   fm-shadow.sh [--source <path>] [--destination <path>]
+#
+# Defaults:
+#   source      FM_SHADOW_SOURCE or /home/ale/firstmate
+#   destination FM_SHADOW_DESTINATION or /mnt/d/Workspace/shadow
+#
+# The destination parent must already exist.
+# The first run accepts a missing destination or an empty directory.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SOURCE_INPUT=$(printenv FM_SHADOW_SOURCE 2>/dev/null || printf '%s\n' /home/ale/firstmate)
+DEST_INPUT=$(printenv FM_SHADOW_DESTINATION 2>/dev/null || printf '%s\n' /mnt/d/Workspace/shadow)
+SOURCE=
+DEST=
+DEST_PARENT=
+LOCK_DIR=
+LOCK_HELD=0
+STAGE=
+STAGE_MOVED=0
+CONTROL_DIR=
+CONTROL_STAGE=
+CONTROL_STAGE_MOVED=0
+CONTROL_BACKUP=
+BACKUP=
+DEFAULT_BRANCH=
+SOURCE_COMMIT=
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0" >&2
+}
+
+die() {
+  printf 'fm-shadow: %s\n' "$*" >&2
+  exit 1
+}
+
+cleanup() {
+  if [ -n "$STAGE" ] && [ -d "$STAGE" ] && [ "$STAGE_MOVED" -eq 0 ]; then
+    rm -rf -- "$STAGE"
+  fi
+  if [ -n "$CONTROL_STAGE" ] && [ -d "$CONTROL_STAGE" ] && [ "$CONTROL_STAGE_MOVED" -eq 0 ]; then
+    rm -rf -- "$CONTROL_STAGE"
+  fi
+  if [ "$LOCK_HELD" -eq 1 ] && [ -d "$LOCK_DIR" ]; then
+    rm -f -- "$LOCK_DIR/owner"
+    rmdir -- "$LOCK_DIR" 2>/dev/null || true
+  fi
+}
+
+trap 'exit 1' HUP INT TERM
+trap cleanup EXIT
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "required command is missing: $1"
+}
+
+lowercase() {
+  LC_ALL=C tr '[:upper:]' '[:lower:]'
+}
+
+resolve_paths() {
+  [ -d "$SOURCE_INPUT" ] || die "source is not an existing directory: $SOURCE_INPUT"
+  SOURCE=$(cd "$SOURCE_INPUT" && pwd -P) || die "cannot resolve source: $SOURCE_INPUT"
+
+  local parent name
+  parent=$(dirname -- "$DEST_INPUT")
+  name=$(basename -- "$DEST_INPUT")
+  [ -n "$name" ] && [ "$name" != . ] && [ "$name" != / ] \
+    || die "destination must name a directory: $DEST_INPUT"
+  [ -d "$parent" ] || die "destination parent is not an existing directory: $parent"
+  DEST_PARENT=$(cd "$parent" && pwd -P) || die "cannot resolve destination parent: $parent"
+  DEST="$DEST_PARENT/$name"
+  CONTROL_DIR="$DEST_PARENT/.shadow-control.$name"
+
+  [ "$SOURCE" != "$DEST" ] || die "source and destination are the same path"
+  case "$DEST/" in
+    "$SOURCE/"*) die "destination is inside source: $DEST" ;;
+  esac
+  case "$SOURCE/" in
+    "$DEST/"*) die "source is inside destination: $SOURCE" ;;
+  esac
+  case "$(printf '%s' "$SOURCE" | lowercase)" in
+    /mnt/d/rocodata|/mnt/d/rocodata/*)
+      die "external /mnt/d/RocoData is outside the mirror source and is not handled by fm-shadow"
+      ;;
+  esac
+  case "$(printf '%s' "$DEST" | lowercase)" in
+    /mnt/d/rocodata|/mnt/d/rocodata/*)
+      die "external /mnt/d/RocoData is protected and cannot be a mirror destination"
+      ;;
+  esac
+  [ ! -L "$DEST" ] || die "destination must not be a symbolic link: $DEST"
+  if [ -e "$DEST" ] && [ ! -d "$DEST" ]; then
+    die "destination exists but is not a directory: $DEST"
+  fi
+  [ ! -L "$CONTROL_DIR" ] || die "replica control metadata must not be a symbolic link: $CONTROL_DIR"
+  if [ -e "$CONTROL_DIR" ] && [ ! -d "$CONTROL_DIR" ]; then
+    die "replica control metadata is not a directory: $CONTROL_DIR"
+  fi
+}
+
+default_branch() {
+  local repo=$1 ref branch
+  ref=$(git -C "$repo" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+  if [ -n "$ref" ]; then
+    printf '%s\n' "$(printf '%s' "$ref" | sed 's#^origin/##')"
+    return 0
+  fi
+  for branch in main master; do
+    if git -C "$repo" show-ref --verify --quiet "refs/heads/$branch"; then
+      printf '%s\n' "$branch"
+      return 0
+    fi
+  done
+  return 1
+}
+
+check_source() {
+  local root branch
+  require_command git
+  require_command python3
+  root=$(git -C "$SOURCE" rev-parse --show-toplevel 2>/dev/null) \
+    || die "source is not a Git worktree: $SOURCE"
+  root=$(cd "$root" && pwd -P) || die "cannot resolve source Git root: $SOURCE"
+  [ "$root" = "$SOURCE" ] || die "source must be the Git worktree root: $SOURCE"
+  branch=$(git -C "$SOURCE" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+  [ -n "$branch" ] || die "source must be checked out on a named branch"
+  DEFAULT_BRANCH=$(default_branch "$SOURCE") \
+    || die "cannot determine source default branch from origin/HEAD, main, or master"
+  [ "$branch" = "$DEFAULT_BRANCH" ] \
+    || die "source branch '$branch' is not the default branch '$DEFAULT_BRANCH'"
+  [ -z "$(GIT_OPTIONAL_LOCKS=0 git -C "$SOURCE" status --porcelain=v1 --untracked-files=all)" ] \
+    || die "source working tree is dirty; refusing to publish"
+  SOURCE_COMMIT=$(git -C "$SOURCE" rev-parse --verify HEAD 2>/dev/null) \
+    || die "cannot resolve source HEAD"
+  git -C "$SOURCE" cat-file -e "$SOURCE_COMMIT^{commit}" \
+    || die "source HEAD is not a commit: $SOURCE_COMMIT"
+}
+
+acquire_lock() {
+  LOCK_DIR="$DEST_PARENT/.shadow.lock"
+  mkdir -- "$LOCK_DIR" 2>/dev/null \
+    || die "another fm-shadow execution holds the lock: $LOCK_DIR"
+  LOCK_HELD=1
+  {
+    printf 'pid=%s\n' "$$"
+    printf 'source=%s\n' "$SOURCE"
+    printf 'destination=%s\n' "$DEST"
+  } >"$LOCK_DIR/owner" || die "cannot record lock owner: $LOCK_DIR"
+}
+
+check_destination_git_clean() {
+  local status line
+  status=$(GIT_OPTIONAL_LOCKS=0 git -C "$DEST" status --porcelain=v1 --untracked-files=all) \
+    || die "cannot inspect destination status"
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    die "destination has changes: $line"
+  done <<<"$status"
+}
+
+check_existing_destination() {
+  local root head
+  if [ ! -d "$DEST" ] || [ -z "$(find "$DEST" -mindepth 1 -print -quit 2>/dev/null)" ]; then
+    [ ! -e "$CONTROL_DIR" ] || die "replica control metadata exists without a complete destination: $CONTROL_DIR"
+    return 0
+  fi
+  root=$(git -C "$DEST" rev-parse --show-toplevel 2>/dev/null) \
+    || die "existing destination is not a Git worktree: $DEST"
+  root=$(cd "$root" && pwd -P) || die "cannot resolve destination Git root: $DEST"
+  [ "$root" = "$DEST" ] || die "destination must be the Git worktree root: $DEST"
+  head=$(git -C "$DEST" rev-parse --verify HEAD 2>/dev/null) \
+    || die "destination has no commit"
+  git -C "$SOURCE" merge-base --is-ancestor "$head" "$SOURCE_COMMIT" \
+    || die "destination commit $head diverges from source commit $SOURCE_COMMIT"
+  python3 "$SCRIPT_DIR/fm-shadow.py" validate \
+    --root "$DEST" --manifest "$CONTROL_DIR/manifest" --policy "$CONTROL_DIR/policy" \
+    --branch "$DEFAULT_BRANCH" --commit "$head" \
+    || die "destination manifest validation failed"
+  check_destination_git_clean
+}
+
+build_stage() {
+  local clone_head
+  STAGE=$(mktemp -d "$DEST_PARENT/.shadow-stage.XXXXXX") \
+    || die "cannot create staging directory beside destination"
+  rmdir -- "$STAGE"
+  CONTROL_STAGE=$(mktemp -d "$DEST_PARENT/.shadow-control-stage.XXXXXX") \
+    || die "cannot create replica control staging directory"
+  python3 "$SCRIPT_DIR/fm-shadow.py" copy --source "$SOURCE" --stage "$STAGE" \
+    || die "cannot mirror source into the temporary replica"
+  clone_head=$(git -C "$STAGE" rev-parse --verify HEAD 2>/dev/null) \
+    || die "staged replica has no commit"
+  [ "$clone_head" = "$SOURCE_COMMIT" ] \
+    || die "staged commit $clone_head differs from source commit $SOURCE_COMMIT"
+  [ "$(git -C "$STAGE" symbolic-ref --quiet --short HEAD 2>/dev/null || true)" = "$DEFAULT_BRANCH" ] \
+    || die "staged replica is not on default branch $DEFAULT_BRANCH"
+  cat >"$CONTROL_STAGE/policy" <<EOF
+shadow-policy-v1
+direction=source-to-destination
+source=$SOURCE
+source_branch=$DEFAULT_BRANCH
+source_commit=$SOURCE_COMMIT
+mirror=every-path-under-source-root
+destination_is_output_only=true
+manual_destination_edits=refuse-next-replication
+external_rocodata=outside-source-refused
+EOF
+  python3 "$SCRIPT_DIR/fm-shadow.py" manifest \
+    --root "$STAGE" --source "$SOURCE" --branch "$DEFAULT_BRANCH" --commit "$SOURCE_COMMIT" \
+    --policy "$CONTROL_STAGE/policy" --output "$CONTROL_STAGE/manifest" \
+    || die "cannot write the replica manifest"
+}
+
+recheck_source() {
+  local branch commit
+  branch=$(git -C "$SOURCE" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+  commit=$(git -C "$SOURCE" rev-parse --verify HEAD 2>/dev/null || true)
+  [ "$branch" = "$DEFAULT_BRANCH" ] && [ "$commit" = "$SOURCE_COMMIT" ] \
+    || die "source changed while the replica was being built; no destination update was made"
+  [ -z "$(GIT_OPTIONAL_LOCKS=0 git -C "$SOURCE" status --porcelain=v1 --untracked-files=all)" ] \
+    || die "source became dirty while the replica was being built; no destination update was made"
+  python3 "$SCRIPT_DIR/fm-shadow.py" compare --source "$SOURCE" --replica "$STAGE" \
+    || die "source tree changed while the replica was being built; no destination update was made"
+}
+
+same_output() {
+  [ -f "$CONTROL_DIR/manifest" ] && [ -f "$CONTROL_DIR/policy" ] \
+    && cmp -s "$CONTROL_STAGE/manifest" "$CONTROL_DIR/manifest" \
+    && cmp -s "$CONTROL_STAGE/policy" "$CONTROL_DIR/policy"
+}
+
+swap_replica() {
+  local failed failed_control old_backup old_control_backup
+
+  restore_old() {
+    if [ -n "$CONTROL_BACKUP" ] && [ -d "$CONTROL_BACKUP" ]; then
+      mv -- "$CONTROL_BACKUP" "$CONTROL_DIR" \
+        || die "replacement failed and restoring replica control metadata also failed; old metadata is at $CONTROL_BACKUP"
+      CONTROL_BACKUP=
+    fi
+    if [ -n "$BACKUP" ] && [ -d "$BACKUP" ]; then
+      mv -- "$BACKUP" "$DEST" \
+        || die "replacement failed and restoring the old destination also failed; old output is at $BACKUP"
+      BACKUP=
+    fi
+  }
+
+  if [ -d "$DEST" ]; then
+    if [ -n "$(find "$DEST" -mindepth 1 -print -quit 2>/dev/null)" ]; then
+      old_backup=$(mktemp -d "$DEST_PARENT/.shadow-backup.XXXXXX") \
+        || die "cannot create replacement backup"
+      rmdir -- "$old_backup"
+      mv -- "$DEST" "$old_backup" \
+        || {
+          rmdir -- "$old_backup" 2>/dev/null || true
+          die "cannot move the validated destination aside; no update was made"
+        }
+      BACKUP=$old_backup
+    else
+      rmdir -- "$DEST" || die "cannot remove the empty destination directory for first replica"
+    fi
+  fi
+  if [ -e "$CONTROL_DIR" ]; then
+    old_control_backup=$(mktemp -d "$DEST_PARENT/.shadow-control-backup.XXXXXX") \
+      || die "cannot create replica control backup"
+    rmdir -- "$old_control_backup"
+    if ! mv -- "$CONTROL_DIR" "$old_control_backup"; then
+      rmdir -- "$old_control_backup" 2>/dev/null || true
+      restore_old
+      die "cannot move the validated replica control metadata aside; no update was made"
+    fi
+    CONTROL_BACKUP=$old_control_backup
+  fi
+  if ! mv -- "$STAGE" "$DEST"; then
+    restore_old
+    die "cannot install the complete staged replica; no destination update was made"
+  fi
+  STAGE_MOVED=1
+  if ! mv -- "$CONTROL_STAGE" "$CONTROL_DIR"; then
+    failed=$(mktemp -d "$DEST_PARENT/.shadow-failed.XXXXXX") \
+      || die "replica control installation failed and recovery storage is unavailable"
+    rmdir -- "$failed"
+    mv -- "$DEST" "$failed" \
+      || die "replica control installation failed; failed output is at $DEST"
+    restore_old
+    die "cannot install replica control metadata; failed output is at $failed after restoring the old replica"
+  fi
+  CONTROL_STAGE_MOVED=1
+  if ! python3 "$SCRIPT_DIR/fm-shadow.py" validate \
+    --root "$DEST" --manifest "$CONTROL_DIR/manifest" --policy "$CONTROL_DIR/policy" \
+    --branch "$DEFAULT_BRANCH" --commit "$SOURCE_COMMIT"; then
+    failed=$(mktemp -d "$DEST_PARENT/.shadow-failed.XXXXXX") || die "post-install validation failed and recovery storage is unavailable"
+    rmdir -- "$failed"
+    mv -- "$DEST" "$failed" \
+      || die "post-install validation failed; failed output is at $DEST"
+    failed_control=$(mktemp -d "$DEST_PARENT/.shadow-failed-control.XXXXXX") \
+      || die "post-install validation failed and control recovery storage is unavailable"
+    rmdir -- "$failed_control"
+    mv -- "$CONTROL_DIR" "$failed_control" \
+      || die "post-install validation failed; failed control metadata is at $CONTROL_DIR"
+    restore_old
+    rm -rf -- "$failed"
+    rm -rf -- "$failed_control"
+    die "post-install validation failed; old destination was restored"
+  fi
+  if [ -n "$BACKUP" ] && [ -d "$BACKUP" ]; then
+    rm -rf -- "$BACKUP"
+    BACKUP=
+  fi
+  if [ -n "$CONTROL_BACKUP" ] && [ -d "$CONTROL_BACKUP" ]; then
+    rm -rf -- "$CONTROL_BACKUP"
+    CONTROL_BACKUP=
+  fi
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --source)
+      [ "$#" -gt 1 ] || die "--source requires a path"
+      SOURCE_INPUT=$2
+      shift 2
+      ;;
+    --source=*)
+      SOURCE_INPUT=$(printf '%s' "$1" | sed 's/^--source=//')
+      shift
+      ;;
+    --destination)
+      [ "$#" -gt 1 ] || die "--destination requires a path"
+      DEST_INPUT=$2
+      shift 2
+      ;;
+    --destination=*)
+      DEST_INPUT=$(printf '%s' "$1" | sed 's/^--destination=//')
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument '$1' (see --help)"
+      ;;
+  esac
+done
+
+resolve_paths
+acquire_lock
+check_source
+check_existing_destination
+build_stage
+recheck_source
+if [ -d "$DEST" ] && same_output; then
+  printf 'already current: %s at %s\n' "$SOURCE_COMMIT" "$DEST"
+  exit 0
+fi
+swap_replica
+printf 'replicated: %s -> %s (%s)\n' "$SOURCE" "$DEST" "$SOURCE_COMMIT"

--- a/bin/fm-shadow.sh
+++ b/bin/fm-shadow.sh
@@ -12,6 +12,7 @@
 # The command never uses a forced Git operation, a stash, or a hard reset.
 # Existing destination output is removed only after a clean replacement is
 # validated and installed.
+# Every Git invocation binds safe.directory to the exact checkout path for that invocation.
 #
 # Usage:
 #   fm-shadow.sh [--source <path>] [--destination <path>]
@@ -75,6 +76,12 @@ require_command() {
   command -v "$1" >/dev/null 2>&1 || die "required command is missing: $1"
 }
 
+git_at() {
+  local repo=$1
+  shift
+  git -c "safe.directory=$repo" -C "$repo" "$@"
+}
+
 lowercase() {
   LC_ALL=C tr '[:upper:]' '[:lower:]'
 }
@@ -122,13 +129,13 @@ resolve_paths() {
 
 default_branch() {
   local repo=$1 ref branch
-  ref=$(git -C "$repo" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+  ref=$(git_at "$repo" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
   if [ -n "$ref" ]; then
     printf '%s\n' "$(printf '%s' "$ref" | sed 's#^origin/##')"
     return 0
   fi
   for branch in main master; do
-    if git -C "$repo" show-ref --verify --quiet "refs/heads/$branch"; then
+    if git_at "$repo" show-ref --verify --quiet "refs/heads/$branch"; then
       printf '%s\n' "$branch"
       return 0
     fi
@@ -140,21 +147,21 @@ check_source() {
   local root branch
   require_command git
   require_command python3
-  root=$(git -C "$SOURCE" rev-parse --show-toplevel 2>/dev/null) \
+  root=$(git_at "$SOURCE" rev-parse --show-toplevel 2>/dev/null) \
     || die "source is not a Git worktree: $SOURCE"
   root=$(cd "$root" && pwd -P) || die "cannot resolve source Git root: $SOURCE"
   [ "$root" = "$SOURCE" ] || die "source must be the Git worktree root: $SOURCE"
-  branch=$(git -C "$SOURCE" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+  branch=$(git_at "$SOURCE" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
   [ -n "$branch" ] || die "source must be checked out on a named branch"
   DEFAULT_BRANCH=$(default_branch "$SOURCE") \
     || die "cannot determine source default branch from origin/HEAD, main, or master"
   [ "$branch" = "$DEFAULT_BRANCH" ] \
     || die "source branch '$branch' is not the default branch '$DEFAULT_BRANCH'"
-  [ -z "$(GIT_OPTIONAL_LOCKS=0 git -C "$SOURCE" status --porcelain=v1 --untracked-files=all)" ] \
+  [ -z "$(GIT_OPTIONAL_LOCKS=0 git_at "$SOURCE" status --porcelain=v1 --untracked-files=all)" ] \
     || die "source working tree is dirty; refusing to publish"
-  SOURCE_COMMIT=$(git -C "$SOURCE" rev-parse --verify HEAD 2>/dev/null) \
+  SOURCE_COMMIT=$(git_at "$SOURCE" rev-parse --verify HEAD 2>/dev/null) \
     || die "cannot resolve source HEAD"
-  git -C "$SOURCE" cat-file -e "$SOURCE_COMMIT^{commit}" \
+  git_at "$SOURCE" cat-file -e "$SOURCE_COMMIT^{commit}" \
     || die "source HEAD is not a commit: $SOURCE_COMMIT"
 }
 
@@ -172,7 +179,7 @@ acquire_lock() {
 
 check_destination_git_clean() {
   local status line
-  status=$(GIT_OPTIONAL_LOCKS=0 git -C "$DEST" status --porcelain=v1 --untracked-files=all) \
+  status=$(GIT_OPTIONAL_LOCKS=0 git_at "$DEST" status --porcelain=v1 --untracked-files=all) \
     || die "cannot inspect destination status"
   while IFS= read -r line; do
     [ -n "$line" ] || continue
@@ -186,13 +193,13 @@ check_existing_destination() {
     [ ! -e "$CONTROL_DIR" ] || die "replica control metadata exists without a complete destination: $CONTROL_DIR"
     return 0
   fi
-  root=$(git -C "$DEST" rev-parse --show-toplevel 2>/dev/null) \
+  root=$(git_at "$DEST" rev-parse --show-toplevel 2>/dev/null) \
     || die "existing destination is not a Git worktree: $DEST"
   root=$(cd "$root" && pwd -P) || die "cannot resolve destination Git root: $DEST"
   [ "$root" = "$DEST" ] || die "destination must be the Git worktree root: $DEST"
-  head=$(git -C "$DEST" rev-parse --verify HEAD 2>/dev/null) \
+  head=$(git_at "$DEST" rev-parse --verify HEAD 2>/dev/null) \
     || die "destination has no commit"
-  git -C "$SOURCE" merge-base --is-ancestor "$head" "$SOURCE_COMMIT" \
+  git_at "$SOURCE" merge-base --is-ancestor "$head" "$SOURCE_COMMIT" \
     || die "destination commit $head diverges from source commit $SOURCE_COMMIT"
   python3 "$SCRIPT_DIR/fm-shadow.py" validate \
     --root "$DEST" --manifest "$CONTROL_DIR/manifest" --policy "$CONTROL_DIR/policy" \
@@ -210,11 +217,11 @@ build_stage() {
     || die "cannot create replica control staging directory"
   python3 "$SCRIPT_DIR/fm-shadow.py" copy --source "$SOURCE" --stage "$STAGE" \
     || die "cannot mirror source into the temporary replica"
-  clone_head=$(git -C "$STAGE" rev-parse --verify HEAD 2>/dev/null) \
+  clone_head=$(git_at "$STAGE" rev-parse --verify HEAD 2>/dev/null) \
     || die "staged replica has no commit"
   [ "$clone_head" = "$SOURCE_COMMIT" ] \
     || die "staged commit $clone_head differs from source commit $SOURCE_COMMIT"
-  [ "$(git -C "$STAGE" symbolic-ref --quiet --short HEAD 2>/dev/null || true)" = "$DEFAULT_BRANCH" ] \
+  [ "$(git_at "$STAGE" symbolic-ref --quiet --short HEAD 2>/dev/null || true)" = "$DEFAULT_BRANCH" ] \
     || die "staged replica is not on default branch $DEFAULT_BRANCH"
   cat >"$CONTROL_STAGE/policy" <<EOF
 shadow-policy-v1
@@ -235,11 +242,11 @@ EOF
 
 recheck_source() {
   local branch commit
-  branch=$(git -C "$SOURCE" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
-  commit=$(git -C "$SOURCE" rev-parse --verify HEAD 2>/dev/null || true)
+  branch=$(git_at "$SOURCE" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+  commit=$(git_at "$SOURCE" rev-parse --verify HEAD 2>/dev/null || true)
   [ "$branch" = "$DEFAULT_BRANCH" ] && [ "$commit" = "$SOURCE_COMMIT" ] \
     || die "source changed while the replica was being built; no destination update was made"
-  [ -z "$(GIT_OPTIONAL_LOCKS=0 git -C "$SOURCE" status --porcelain=v1 --untracked-files=all)" ] \
+  [ -z "$(GIT_OPTIONAL_LOCKS=0 git_at "$SOURCE" status --porcelain=v1 --untracked-files=all)" ] \
     || die "source became dirty while the replica was being built; no destination update was made"
   python3 "$SCRIPT_DIR/fm-shadow.py" compare --source "$SOURCE" --replica "$STAGE" \
     || die "source tree changed while the replica was being built; no destination update was made"

--- a/bin/fm-shadow.sh
+++ b/bin/fm-shadow.sh
@@ -39,8 +39,7 @@ STAGE_MOVED=0
 CONTROL_DIR=
 CONTROL_STAGE=
 CONTROL_STAGE_MOVED=0
-CONTROL_BACKUP=
-BACKUP=
+TRANSACTION_DIR=
 DEFAULT_BRANCH=
 SOURCE_COMMIT=
 
@@ -100,12 +99,13 @@ resolve_paths() {
   local parent name
   parent=$(dirname -- "$DEST_INPUT")
   name=$(basename -- "$DEST_INPUT")
-  [ -n "$name" ] && [ "$name" != . ] && [ "$name" != / ] \
+  [ -n "$name" ] && [ "$name" != . ] && [ "$name" != .. ] && [ "$name" != / ] \
     || die "destination must name a directory: $DEST_INPUT"
   [ -d "$parent" ] || die "destination parent is not an existing directory: $parent"
   DEST_PARENT=$(cd "$parent" && pwd -P) || die "cannot resolve destination parent: $parent"
   DEST="$DEST_PARENT/$name"
   CONTROL_DIR="$DEST_PARENT/.shadow-control.$name"
+  TRANSACTION_DIR="$DEST_PARENT/.shadow-transaction.$name"
 
   [ "$SOURCE" != "$DEST" ] || die "source and destination are the same path"
   case "$DEST/" in
@@ -131,6 +131,10 @@ resolve_paths() {
   [ ! -L "$CONTROL_DIR" ] || die "replica control metadata must not be a symbolic link: $CONTROL_DIR"
   if [ -e "$CONTROL_DIR" ] && [ ! -d "$CONTROL_DIR" ]; then
     die "replica control metadata is not a directory: $CONTROL_DIR"
+  fi
+  [ ! -L "$TRANSACTION_DIR" ] || die "shadow transaction marker must not be a symbolic link: $TRANSACTION_DIR"
+  if [ -e "$TRANSACTION_DIR" ] && [ ! -d "$TRANSACTION_DIR" ]; then
+    die "shadow transaction marker is not a directory: $TRANSACTION_DIR"
   fi
 }
 
@@ -265,88 +269,157 @@ same_output() {
     && cmp -s "$CONTROL_STAGE/policy" "$CONTROL_DIR/policy"
 }
 
+transaction_child_is_safe() {
+  local child=$1
+  [ ! -L "$TRANSACTION_DIR/$child" ] || die "shadow transaction contains a symbolic link: $child"
+}
+
+transaction_field() {
+  local field=$1 value
+  transaction_child_is_safe "$field"
+  [ -f "$TRANSACTION_DIR/$field" ] || die "shadow transaction is missing its $field field"
+  value=$(cat -- "$TRANSACTION_DIR/$field") || die "cannot read shadow transaction field: $field"
+  printf '%s\n' "$value"
+}
+
+clear_transaction() {
+  rm -rf -- "$TRANSACTION_DIR/old-destination" "$TRANSACTION_DIR/old-control" \
+    "$TRANSACTION_DIR/new-destination" "$TRANSACTION_DIR/new-control" \
+    "$TRANSACTION_DIR/failed-destination" "$TRANSACTION_DIR/failed-control" \
+    || die "cannot clear the completed shadow transaction: $TRANSACTION_DIR"
+  rm -f -- "$TRANSACTION_DIR/source-branch" "$TRANSACTION_DIR/source-commit" \
+    "$TRANSACTION_DIR/destination-present" "$TRANSACTION_DIR/control-present" \
+    "$TRANSACTION_DIR/ready" \
+    || die "cannot clear the completed shadow transaction marker: $TRANSACTION_DIR"
+  rmdir -- "$TRANSACTION_DIR" \
+    || die "cannot remove the completed shadow transaction marker: $TRANSACTION_DIR"
+}
+
+park_transaction_output() {
+  local path=$1 name=$2
+  if [ -e "$path" ] || [ -L "$path" ]; then
+    transaction_child_is_safe "$name"
+    [ ! -e "$TRANSACTION_DIR/$name" ] || die "shadow transaction recovery path already exists: $name"
+    mv -- "$path" "$TRANSACTION_DIR/$name" \
+      || die "cannot preserve the incomplete shadow output during recovery: $path"
+  fi
+}
+
+recover_transaction() {
+  local branch commit destination_present control_present
+  [ -e "$TRANSACTION_DIR" ] || return 0
+  [ -d "$TRANSACTION_DIR" ] || die "shadow transaction marker is not a directory: $TRANSACTION_DIR"
+  transaction_child_is_safe ready
+  transaction_child_is_safe source-branch
+  transaction_child_is_safe source-commit
+  transaction_child_is_safe destination-present
+  transaction_child_is_safe control-present
+  transaction_child_is_safe old-destination
+  transaction_child_is_safe old-control
+  transaction_child_is_safe new-destination
+  transaction_child_is_safe new-control
+  transaction_child_is_safe failed-destination
+  transaction_child_is_safe failed-control
+  if [ ! -f "$TRANSACTION_DIR/ready" ]; then
+    [ ! -e "$TRANSACTION_DIR/old-destination" ] \
+      && [ ! -e "$TRANSACTION_DIR/old-control" ] \
+      && [ ! -e "$TRANSACTION_DIR/new-destination" ] \
+      && [ ! -e "$TRANSACTION_DIR/new-control" ] \
+      || die "shadow transaction marker is incomplete: $TRANSACTION_DIR"
+    rm -rf -- "$TRANSACTION_DIR" \
+      || die "cannot remove the incomplete shadow transaction marker: $TRANSACTION_DIR"
+    return 0
+  fi
+  branch=$(transaction_field source-branch)
+  commit=$(transaction_field source-commit)
+  destination_present=$(transaction_field destination-present)
+  control_present=$(transaction_field control-present)
+  [ "$branch" = "$DEFAULT_BRANCH" ] || die "shadow transaction branch does not match the source default branch"
+  case "$destination_present:$control_present" in
+    0:0|0:1|1:0|1:1) ;;
+    *) die "shadow transaction presence fields are malformed" ;;
+  esac
+  git_at "$SOURCE" cat-file -e "$commit^{commit}" \
+    || die "shadow transaction source commit is unavailable: $commit"
+  if [ ! -L "$DEST" ] && [ -d "$DEST" ] && [ ! -L "$CONTROL_DIR" ] && [ -d "$CONTROL_DIR" ] \
+    && python3 "$SCRIPT_DIR/fm-shadow.py" validate \
+      --root "$DEST" --manifest "$CONTROL_DIR/manifest" --policy "$CONTROL_DIR/policy" \
+      --branch "$branch" --commit "$commit" >/dev/null 2>&1; then
+    clear_transaction
+    return 0
+  fi
+
+  if [ "$destination_present" -eq 1 ]; then
+    if [ -d "$TRANSACTION_DIR/old-destination" ]; then
+      park_transaction_output "$DEST" failed-destination
+      mv -- "$TRANSACTION_DIR/old-destination" "$DEST" \
+        || die "cannot restore the previous shadow destination: $DEST"
+    elif [ ! -e "$DEST" ] && [ ! -L "$DEST" ]; then
+      die "previous shadow destination is missing from the transaction: $TRANSACTION_DIR"
+    fi
+  else
+    park_transaction_output "$DEST" failed-destination
+  fi
+  if [ "$control_present" -eq 1 ]; then
+    if [ -d "$TRANSACTION_DIR/old-control" ]; then
+      park_transaction_output "$CONTROL_DIR" failed-control
+      mv -- "$TRANSACTION_DIR/old-control" "$CONTROL_DIR" \
+        || die "cannot restore the previous shadow control metadata: $CONTROL_DIR"
+    elif [ ! -e "$CONTROL_DIR" ] && [ ! -L "$CONTROL_DIR" ]; then
+      die "previous shadow control metadata is missing from the transaction: $TRANSACTION_DIR"
+    fi
+  else
+    park_transaction_output "$CONTROL_DIR" failed-control
+  fi
+  clear_transaction
+}
+
+begin_transaction() {
+  local destination_present=0 control_present=0
+  if [ -d "$DEST" ] && [ -n "$(find "$DEST" -mindepth 1 -print -quit 2>/dev/null)" ]; then
+    destination_present=1
+  fi
+  [ -e "$CONTROL_DIR" ] && control_present=1
+  mkdir -- "$TRANSACTION_DIR" \
+    || die "cannot create the shadow transaction marker: $TRANSACTION_DIR"
+  printf '%s\n' "$DEFAULT_BRANCH" >"$TRANSACTION_DIR/source-branch"
+  printf '%s\n' "$SOURCE_COMMIT" >"$TRANSACTION_DIR/source-commit"
+  printf '%s\n' "$destination_present" >"$TRANSACTION_DIR/destination-present"
+  printf '%s\n' "$control_present" >"$TRANSACTION_DIR/control-present"
+  : >"$TRANSACTION_DIR/ready"
+}
+
 swap_replica() {
-  local failed failed_control old_backup old_control_backup
-
-  restore_old() {
-    if [ -n "$CONTROL_BACKUP" ] && [ -d "$CONTROL_BACKUP" ]; then
-      mv -- "$CONTROL_BACKUP" "$CONTROL_DIR" \
-        || die "replacement failed and restoring replica control metadata also failed; old metadata is at $CONTROL_BACKUP"
-      CONTROL_BACKUP=
-    fi
-    if [ -n "$BACKUP" ] && [ -d "$BACKUP" ]; then
-      mv -- "$BACKUP" "$DEST" \
-        || die "replacement failed and restoring the old destination also failed; old output is at $BACKUP"
-      BACKUP=
-    fi
-  }
-
-  if [ -d "$DEST" ]; then
-    if [ -n "$(find "$DEST" -mindepth 1 -print -quit 2>/dev/null)" ]; then
-      old_backup=$(mktemp -d "$DEST_PARENT/.shadow-backup.XXXXXX") \
-        || die "cannot create replacement backup"
-      rmdir -- "$old_backup"
-      mv -- "$DEST" "$old_backup" \
-        || {
-          rmdir -- "$old_backup" 2>/dev/null || true
-          die "cannot move the validated destination aside; no update was made"
-        }
-      BACKUP=$old_backup
-    else
-      rmdir -- "$DEST" || die "cannot remove the empty destination directory for first replica"
-    fi
+  check_existing_destination
+  begin_transaction
+  if [ "$(transaction_field destination-present)" -eq 1 ]; then
+    mv -- "$DEST" "$TRANSACTION_DIR/old-destination" \
+      || { recover_transaction; die "cannot move the validated destination into the shadow transaction"; }
+  elif [ -d "$DEST" ]; then
+    rmdir -- "$DEST" \
+      || { recover_transaction; die "cannot remove the empty destination for the shadow transaction"; }
   fi
-  if [ -e "$CONTROL_DIR" ]; then
-    old_control_backup=$(mktemp -d "$DEST_PARENT/.shadow-control-backup.XXXXXX") \
-      || die "cannot create replica control backup"
-    rmdir -- "$old_control_backup"
-    if ! mv -- "$CONTROL_DIR" "$old_control_backup"; then
-      rmdir -- "$old_control_backup" 2>/dev/null || true
-      restore_old
-      die "cannot move the validated replica control metadata aside; no update was made"
-    fi
-    CONTROL_BACKUP=$old_control_backup
+  if [ "$(transaction_field control-present)" -eq 1 ]; then
+    mv -- "$CONTROL_DIR" "$TRANSACTION_DIR/old-control" \
+      || { recover_transaction; die "cannot move the validated control metadata into the shadow transaction"; }
   fi
-  if ! mv -- "$STAGE" "$DEST"; then
-    restore_old
-    die "cannot install the complete staged replica; no destination update was made"
-  fi
+  mv -- "$STAGE" "$TRANSACTION_DIR/new-destination" \
+    || { recover_transaction; die "cannot move the staged destination into the shadow transaction"; }
   STAGE_MOVED=1
-  if ! mv -- "$CONTROL_STAGE" "$CONTROL_DIR"; then
-    failed=$(mktemp -d "$DEST_PARENT/.shadow-failed.XXXXXX") \
-      || die "replica control installation failed and recovery storage is unavailable"
-    rmdir -- "$failed"
-    mv -- "$DEST" "$failed" \
-      || die "replica control installation failed; failed output is at $DEST"
-    restore_old
-    die "cannot install replica control metadata; failed output is at $failed after restoring the old replica"
-  fi
+  mv -- "$CONTROL_STAGE" "$TRANSACTION_DIR/new-control" \
+    || { recover_transaction; die "cannot move the staged control metadata into the shadow transaction"; }
   CONTROL_STAGE_MOVED=1
+  mv -- "$TRANSACTION_DIR/new-destination" "$DEST" \
+    || { recover_transaction; die "cannot install the complete staged replica"; }
+  mv -- "$TRANSACTION_DIR/new-control" "$CONTROL_DIR" \
+    || { recover_transaction; die "cannot install the staged control metadata"; }
   if ! python3 "$SCRIPT_DIR/fm-shadow.py" validate \
     --root "$DEST" --manifest "$CONTROL_DIR/manifest" --policy "$CONTROL_DIR/policy" \
     --branch "$DEFAULT_BRANCH" --commit "$SOURCE_COMMIT"; then
-    failed=$(mktemp -d "$DEST_PARENT/.shadow-failed.XXXXXX") || die "post-install validation failed and recovery storage is unavailable"
-    rmdir -- "$failed"
-    mv -- "$DEST" "$failed" \
-      || die "post-install validation failed; failed output is at $DEST"
-    failed_control=$(mktemp -d "$DEST_PARENT/.shadow-failed-control.XXXXXX") \
-      || die "post-install validation failed and control recovery storage is unavailable"
-    rmdir -- "$failed_control"
-    mv -- "$CONTROL_DIR" "$failed_control" \
-      || die "post-install validation failed; failed control metadata is at $CONTROL_DIR"
-    restore_old
-    rm -rf -- "$failed"
-    rm -rf -- "$failed_control"
+    recover_transaction
     die "post-install validation failed; old destination was restored"
   fi
-  if [ -n "$BACKUP" ] && [ -d "$BACKUP" ]; then
-    rm -rf -- "$BACKUP"
-    BACKUP=
-  fi
-  if [ -n "$CONTROL_BACKUP" ] && [ -d "$CONTROL_BACKUP" ]; then
-    rm -rf -- "$CONTROL_BACKUP"
-    CONTROL_BACKUP=
-  fi
+  clear_transaction
 }
 
 while [ "$#" -gt 0 ]; do
@@ -382,10 +455,12 @@ done
 resolve_paths
 acquire_lock
 check_source
+recover_transaction
 check_existing_destination
 build_stage
 recheck_source
 if [ -d "$DEST" ] && same_output; then
+  check_existing_destination
   printf 'already current: %s at %s\n' "$SOURCE_COMMIT" "$DEST"
   exit 0
 fi

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -141,7 +141,7 @@ family_for_basename() {
     fm-kimi-harness.test.sh|fm-muse-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
     fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|\
-    fm-shadow.test.sh|\
+    fm-shadow.test.sh|fm-replicante.test.sh|\
     fm-subagent-pretool-check.test.sh|\
     fm-supervision-instructions.test.sh|fm-task-delivery.test.sh|\
     fm-tmux-submit-busy.test.sh|fm-trace-context-lib.test.sh|\
@@ -947,6 +947,7 @@ families_for_changed_path() {
       printf '%s\n' real-herdr-gated
       ;;
     bin/fm-lint.sh|bin/fm-install-shellcheck.sh|bin/fm-shadow.sh|bin/fm-shadow.py|\
+    bin/fm-replicante.sh|bin/fm-replicante.py|\
     bin/fm-brief.sh|bin/fm-ensure-agents-md.sh|bin/fm-crew-state.sh|\
     bin/fm-decision-hold.sh|bin/fm-supervision*|bin/fm-transition-lib.sh|\
     bin/fm-tmux-lib.sh|bin/fm-marker-lib.sh|bin/fm-operational-input.sh|bin/fm-tasks-axi-lib.sh|\

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -141,6 +141,7 @@ family_for_basename() {
     fm-kimi-harness.test.sh|fm-muse-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
     fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|\
+    fm-shadow.test.sh|\
     fm-subagent-pretool-check.test.sh|\
     fm-supervision-instructions.test.sh|fm-task-delivery.test.sh|\
     fm-tmux-submit-busy.test.sh|fm-trace-context-lib.test.sh|\
@@ -945,7 +946,7 @@ families_for_changed_path() {
       # lane's contract coverage re-runs.
       printf '%s\n' real-herdr-gated
       ;;
-    bin/fm-lint.sh|bin/fm-install-shellcheck.sh|\
+    bin/fm-lint.sh|bin/fm-install-shellcheck.sh|bin/fm-shadow.sh|bin/fm-shadow.py|\
     bin/fm-brief.sh|bin/fm-ensure-agents-md.sh|bin/fm-crew-state.sh|\
     bin/fm-decision-hold.sh|bin/fm-supervision*|bin/fm-transition-lib.sh|\
     bin/fm-tmux-lib.sh|bin/fm-marker-lib.sh|bin/fm-operational-input.sh|bin/fm-tasks-axi-lib.sh|\

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -285,6 +285,10 @@
       "audience": "operator-current"
     },
     {
+      "path": "docs/replicante.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/shadow.md",
       "audience": "operator-current"
     },

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -285,6 +285,10 @@
       "audience": "operator-current"
     },
     {
+      "path": "docs/shadow.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/sessionstart-nudge.md",
       "audience": "operator-current"
     },

--- a/docs/replicante.md
+++ b/docs/replicante.md
@@ -12,11 +12,13 @@ The worker does not accept normal source or destination overrides.
 
 ## Operation
 
-The H: volume must be mounted at /mnt/h before every run.
+The H: volume must be mounted at /mnt/h before every operational command.
 
 Run the first complete backup with /home/ale/firstmate/bin/fm-replicante.sh run.
 
-Set retention explicitly when the default of 30 snapshots is not appropriate, for example /home/ale/firstmate/bin/fm-replicante.sh run --retain 60.
+Set retention explicitly when the built-in default of 30 snapshots is not appropriate, for example /home/ale/firstmate/bin/fm-replicante.sh run --retain 60.
+
+The REPLICANTE_RETENTION environment variable changes the default for run, and an explicit --retain value takes precedence for that invocation.
 
 Each snapshot has a complete manifest of the source paths and points regular-file content at SHA-256 objects.
 
@@ -52,13 +54,15 @@ Restore never overwrites an existing output, the canonical source, the backup st
 
 Source modes are recorded in snapshot manifests.
 
-The 9p object store uses content operations, and --apply-modes requests mode restoration only when the recovery filesystem supports it.
+The --apply-modes option attempts to apply the recorded modes during restoration; omit it when the recovery filesystem does not support those mode updates.
 
 Inspect a restored tree before any separate operator-owned replacement or import procedure.
 
 ## Scheduling
 
 Create one Windows Task Scheduler action for the WSL command, such as wsl.exe -d Ubuntu -- /home/ale/firstmate/bin/fm-replicante.sh run --retain 30.
+
+Run the task in the WSL distribution where /mnt/h is mounted and /home/ale/firstmate is the canonical source.
 
 Use one scheduled replicante action rather than parallel backup writers.
 
@@ -71,5 +75,7 @@ Do not schedule a command that points at /mnt/h generally or at a different back
 ## Tests
 
 Run the fixture suite with bash tests/fm-replicante.test.sh.
+
+The fixture suite enables REPLICANTE_TEST_MODE=1 with temporary paths and never accesses /home/ale/firstmate or /mnt/h/Firstmate-Backup.
 
 The suite covers first backup, idempotent repetition, incremental changes, deletion history, retention, destination identity, concurrent locking, unsupported source entries, corruption refusal, verification, and restoration.

--- a/docs/replicante.md
+++ b/docs/replicante.md
@@ -1,0 +1,75 @@
+# Replicante backup
+
+bin/fm-replicante.sh is the incremental recovery backup for the canonical Firstmate tree.
+
+It is separate from bin/fm-shadow.sh: shadow publishes an exact visual mirror to D:\Workspace\shadow, while replicante keeps historical recovery snapshots on H:\Firstmate-Backup.
+
+The only operational source is /home/ale/firstmate.
+
+The only operational destination is /mnt/h/Firstmate-Backup, which is the WSL spelling of H:\Firstmate-Backup.
+
+The worker does not accept normal source or destination overrides.
+
+## Operation
+
+The H: volume must be mounted at /mnt/h before every run.
+
+Run the first complete backup with /home/ale/firstmate/bin/fm-replicante.sh run.
+
+Set retention explicitly when the default of 30 snapshots is not appropriate, for example /home/ale/firstmate/bin/fm-replicante.sh run --retain 60.
+
+Each snapshot has a complete manifest of the source paths and points regular-file content at SHA-256 objects.
+
+Only objects whose content hash is not already present are copied on later runs.
+
+An unchanged source returns already current without creating a snapshot.
+
+Deleted source paths disappear from later manifests but remain available through retained earlier snapshots.
+
+The backup root records its exact source and destination identity and refuses an unrelated nonempty directory.
+
+The backup also refuses an unavailable H: volume, a concurrent lock, a corrupt snapshot or object, and unsupported special files in the source tree.
+
+Special files cannot be represented by this content-addressed 9p-compatible store and are refused rather than excluded; supporting one requires a separate captain decision.
+
+The command never writes D:\Workspace\firstmate, D:\RocoData, or another external source tree.
+
+## Verification and recovery
+
+Verify the latest snapshot and every referenced object with /home/ale/firstmate/bin/fm-replicante.sh verify.
+
+Verify every retained historical snapshot with /home/ale/firstmate/bin/fm-replicante.sh verify --all.
+
+Run a temporary reconstruction check with /home/ale/firstmate/bin/fm-replicante.sh verify --restore-test.
+
+The restore test compares every restored path, regular-file hash, size, and symbolic-link target before removing its temporary output.
+
+Choose a snapshot identifier from the latest marker or a verified manifest, then restore it to a new H: directory outside the backup store.
+
+Use /home/ale/firstmate/bin/fm-replicante.sh restore --snapshot <snapshot-id> --output /mnt/h/Firstmate-Backup-recovery-<date> --apply-modes for a recovery reconstruction.
+
+Restore never overwrites an existing output, the canonical source, the backup store, or a D: tree.
+
+Source modes are recorded in snapshot manifests.
+
+The 9p object store uses content operations, and --apply-modes requests mode restoration only when the recovery filesystem supports it.
+
+Inspect a restored tree before any separate operator-owned replacement or import procedure.
+
+## Scheduling
+
+Create one Windows Task Scheduler action for the WSL command, such as wsl.exe -d Ubuntu -- /home/ale/firstmate/bin/fm-replicante.sh run --retain 30.
+
+Use one scheduled replicante action rather than parallel backup writers.
+
+The destination-parent lock rejects an overlapping run and never clears an existing lock automatically.
+
+Scheduling shadow and replicante separately is safe because they have different destinations and independent locks.
+
+Do not schedule a command that points at /mnt/h generally or at a different backup folder.
+
+## Tests
+
+Run the fixture suite with bash tests/fm-replicante.test.sh.
+
+The suite covers first backup, idempotent repetition, incremental changes, deletion history, retention, destination identity, concurrent locking, unsupported source entries, corruption refusal, verification, and restoration.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -7,6 +7,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 
 | Script                   | Purpose                                                                              |
 | ------------------------ | ------------------------------------------------------------------------------------ |
+| fm-shadow.sh             | Publish a one-way, manifest-verified WSL snapshot of canonical Firstmate              |
 | `fm-session-start.sh`    | Compose lock, bootstrap, and wake drain into the single ordered session-start digest |
 | `fm-sessionstart-nudge.sh` | Print the native session-start hook nudge when the primary has not already run the digest |
 | `fm-sessionstart-run.sh` | Route a native session-open hook to the full digest, a context re-emit, or the nudge |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -8,6 +8,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | Script                   | Purpose                                                                              |
 | ------------------------ | ------------------------------------------------------------------------------------ |
 | fm-shadow.sh             | Publish a one-way, manifest-verified WSL snapshot of canonical Firstmate              |
+| fm-replicante.sh         | Maintain the incremental, verified H: recovery backup of canonical Firstmate           |
 | `fm-session-start.sh`    | Compose lock, bootstrap, and wake drain into the single ordered session-start digest |
 | `fm-sessionstart-nudge.sh` | Print the native session-start hook nudge when the primary has not already run the digest |
 | `fm-sessionstart-run.sh` | Route a native session-open hook to the full digest, a context re-emit, or the nudge |

--- a/docs/shadow.md
+++ b/docs/shadow.md
@@ -8,6 +8,8 @@ The default destination is /mnt/d/Workspace/shadow, which is the WSL spelling of
 
 The destination is an output surface for Windows inspection and is not part of the agent workflow.
 
+The separate bin/fm-replicante.sh backup keeps historical recovery snapshots on H:\Firstmate-Backup and never changes this visual mirror's contract.
+
 Manual destination edits are preserved on disk but make the next replication stop safely.
 
 ## Operation

--- a/docs/shadow.md
+++ b/docs/shadow.md
@@ -24,6 +24,10 @@ The first run accepts a missing destination or an empty directory.
 
 The command creates an atomic lock at the destination parent's .shadow.lock.
 
+The command also creates a source-side lock at the source parent's .shadow-source-lock.<source-name>.
+
+Both locks are persistent markers, and the source-side lock coordinates shadow executions while the source snapshot is the sealed source tree for that run.
+
 An existing lock is treated as active and is never removed automatically.
 
 The source must be the root of a Git worktree on the default branch with a clean tracked and untracked tree.
@@ -38,7 +42,9 @@ Git's ownership trust is granted only per invocation for the exact absolute sour
 
 The destination status check also disables Git filemode comparison only for that invocation because 9p can normalize modes; the manifest still detects content, type, size, and hash changes.
 
-Each run stages the complete output beside the destination, validates its content, and swaps it into place only after the source is rechecked.
+Each run captures a complete source snapshot, stages the output beside the destination from that snapshot, validates its content, and swaps it into place only after the source is rechecked.
+
+The source is checked again at the transaction boundary and after installation, and any detected source change aborts the run and restores the prior validated destination.
 
 The staging copier uses 9p-compatible content and symbolic-link operations and does not request POSIX metadata updates from the destination filesystem.
 
@@ -70,7 +76,9 @@ It never uses a forced Git operation, a stash, a hard reset, a partial destinati
 
 If staging or the final atomic installation fails, the previous validated destination remains the recovery point.
 
-Investigate and clear a stale .shadow.lock only after verifying that no fm-shadow.sh process is running.
+Inspect the owner file in a stale .shadow.lock or .shadow-source-lock.<source-name> only after verifying that no fm-shadow.sh process is running.
+
+Remove only the exact stale lock directory for that source and destination after confirming that its recorded process is no longer active.
 
 Do not repair the destination by hand and retry after an integrity refusal unless the manual change is intentionally removed through the separate operating procedure that owns the Windows output.
 

--- a/docs/shadow.md
+++ b/docs/shadow.md
@@ -34,6 +34,8 @@ The final destination commit must have exactly the same identity as the source c
 
 Git's ownership trust is granted only per invocation for the exact absolute source, stage, or destination path.
 
+The destination status check also disables Git filemode comparison only for that invocation because 9p can normalize modes; the manifest still detects content, type, size, and hash changes.
+
 Each run stages the complete output beside the destination, validates its content, and swaps it into place only after the source is rechecked.
 
 The staging copier uses 9p-compatible content and symbolic-link operations and does not request POSIX metadata updates from the destination filesystem.

--- a/docs/shadow.md
+++ b/docs/shadow.md
@@ -34,6 +34,8 @@ The final destination commit must have exactly the same identity as the source c
 
 Each run stages the complete output beside the destination, validates its content, and swaps it into place only after the source is rechecked.
 
+The staging copier uses 9p-compatible content and symbolic-link operations and does not request POSIX metadata updates from the destination filesystem.
+
 An unchanged source and unchanged complete tree returns already current without replacing the destination.
 
 ## Mirrored contents

--- a/docs/shadow.md
+++ b/docs/shadow.md
@@ -14,7 +14,7 @@ Manual destination edits are preserved on disk but make the next replication sto
 
 ## Operation
 
-Run the replicator from WSL with bin/fm-shadow.sh.
+Run the mirror from WSL with bin/fm-shadow.sh.
 
 Override either path for a controlled fixture or another installation with bin/fm-shadow.sh --source <source> --destination <destination>.
 
@@ -26,13 +26,13 @@ The command creates an atomic lock at the destination parent's .shadow.lock.
 
 The command also creates a source-side lock at the source parent's .shadow-source-lock.<source-name>.
 
-Both locks are persistent markers, and the source-side lock coordinates shadow executions while the source snapshot is the sealed source tree for that run.
+The two locks are atomic run markers that a normal exit releases, and the source-side lock coordinates shadow executions while the source snapshot is the sealed source tree for that run.
 
 An existing lock is treated as active and is never removed automatically.
 
 The source must be the root of a Git worktree on the default branch with a clean tracked and untracked tree.
 
-The destination must be the root of a Git worktree on the same default branch with a valid prior manifest and no local changes.
+An existing destination must be the root of a Git worktree on the same default branch with a valid prior manifest and no local changes.
 
 The destination commit must be an ancestor of the source commit in the source repository.
 
@@ -51,6 +51,14 @@ An interrupted run's source snapshot is removed by the next invocation after bot
 The staging copier uses 9p-compatible content and symbolic-link operations and does not request POSIX metadata updates from the destination filesystem.
 
 An unchanged source and unchanged complete tree returns already current without replacing the destination.
+
+## Scheduling
+
+Create one Windows Task Scheduler action for the WSL command, such as wsl.exe -d Ubuntu -- /home/ale/firstmate/bin/fm-shadow.sh.
+
+Run the task in the WSL distribution where /home/ale/firstmate is the canonical source.
+
+Schedule shadow separately from replicante; the commands have different destinations and independent locks.
 
 ## Mirrored contents
 
@@ -76,17 +84,17 @@ The command refuses a dirty source, a dirty destination, a detached or wrong bra
 
 It never uses a forced Git operation, a stash, a hard reset, a partial destination copy, or a deletion of destination changes.
 
-If staging or the final atomic installation fails, the previous validated destination remains the recovery point.
+If staging or the final atomic installation fails, an existing validated destination remains the recovery point.
 
 Inspect the owner file in a stale .shadow.lock or .shadow-source-lock.<source-name> only after verifying that no fm-shadow.sh process is running.
 
-Remove only the exact stale lock directory for that source and destination after confirming that its recorded process is no longer active.
-
-Do not repair the destination by hand and retry after an integrity refusal unless the manual change is intentionally removed through the separate operating procedure that owns the Windows output.
+Remove only the exact stale .shadow.lock or .shadow-source-lock.<source-name> directory after confirming that its recorded process is no longer active.
 
 ## Tests
 
-The fixture suite covers first publication, repeated idempotent publication, complete working-tree content, destination dirtiness, destination divergence, concurrent locking, external-source protection, and recovery from an unsupported source entry.
+The fixture suite covers first publication, repeated idempotent publication, complete working-tree content, destination dirtiness, destination divergence, concurrent locking, external symlink-target protection, and recovery from an unsupported source entry.
+
+The fixture suite uses temporary source and destination paths and never accesses the live Firstmate home or Windows destination.
 
 Run the focused suite with bash tests/fm-shadow.test.sh.
 

--- a/docs/shadow.md
+++ b/docs/shadow.md
@@ -44,7 +44,9 @@ The destination status check also disables Git filemode comparison only for that
 
 Each run captures a complete source snapshot, stages the output beside the destination from that snapshot, validates its content, and swaps it into place only after the source is rechecked.
 
-The source is checked again at the transaction boundary and after installation, and any detected source change aborts the run and restores the prior validated destination.
+The source is checked again at the transaction boundary, and the installed output is compared with the sealed snapshot before the transaction is cleared.
+
+An interrupted run's source snapshot is removed by the next invocation after both locks are acquired.
 
 The staging copier uses 9p-compatible content and symbolic-link operations and does not request POSIX metadata updates from the destination filesystem.
 

--- a/docs/shadow.md
+++ b/docs/shadow.md
@@ -32,6 +32,8 @@ The destination commit must be an ancestor of the source commit in the source re
 
 The final destination commit must have exactly the same identity as the source commit.
 
+Git's ownership trust is granted only per invocation for the exact absolute source, stage, or destination path.
+
 Each run stages the complete output beside the destination, validates its content, and swaps it into place only after the source is rechecked.
 
 The staging copier uses 9p-compatible content and symbolic-link operations and does not request POSIX metadata updates from the destination filesystem.

--- a/docs/shadow.md
+++ b/docs/shadow.md
@@ -1,0 +1,77 @@
+# Shadow replica
+
+bin/fm-shadow.sh publishes the complete canonical Linux Firstmate tree to a Windows-visible WSL destination in one direction.
+
+The default source is /home/ale/firstmate.
+
+The default destination is /mnt/d/Workspace/shadow, which is the WSL spelling of D:\Workspace\shadow.
+
+The destination is an output surface for Windows inspection and is not part of the agent workflow.
+
+Manual destination edits are preserved on disk but make the next replication stop safely.
+
+## Operation
+
+Run the replicator from WSL with bin/fm-shadow.sh.
+
+Override either path for a controlled fixture or another installation with bin/fm-shadow.sh --source <source> --destination <destination>.
+
+The destination parent must already exist.
+
+The first run accepts a missing destination or an empty directory.
+
+The command creates an atomic lock at the destination parent's .shadow.lock.
+
+An existing lock is treated as active and is never removed automatically.
+
+The source must be the root of a Git worktree on the default branch with a clean tracked and untracked tree.
+
+The destination must be the root of a Git worktree on the same default branch with a valid prior manifest and no local changes.
+
+The destination commit must be an ancestor of the source commit in the source repository.
+
+The final destination commit must have exactly the same identity as the source commit.
+
+Each run stages the complete output beside the destination, validates its content, and swaps it into place only after the source is rechecked.
+
+An unchanged source and unchanged complete tree returns already current without replacing the destination.
+
+## Mirrored contents
+
+Every path rooted under /home/ale/firstmate is mirrored, including ignored files, project clones, operational directories, Git metadata, empty directories, regular files, and symbolic links.
+
+The generated manifest and policy live in the destination parent's .shadow-control.<destination-name> sidecar directory.
+
+Keeping controls outside the destination preserves source paths named .shadow-manifest or .shadow-policy exactly.
+
+The manifest records every mirrored path, its type, and the SHA-256 hash of every regular file.
+
+The policy records the one-way output boundary and the source identity.
+
+The copier never follows a symbolic link target, so content outside the source root is not traversed.
+
+An external /mnt/d/RocoData source or destination is protected and is refused.
+
+RocoData under the source root is mirrored because the captain's current scope is the complete source tree.
+
+## Refusal and recovery
+
+The command refuses a dirty source, a dirty destination, a detached or wrong branch, a divergent destination commit, a malformed manifest, an unavailable path, an unsupported special file, or a concurrent lock.
+
+It never uses a forced Git operation, a stash, a hard reset, a partial destination copy, or a deletion of destination changes.
+
+If staging or the final atomic installation fails, the previous validated destination remains the recovery point.
+
+Investigate and clear a stale .shadow.lock only after verifying that no fm-shadow.sh process is running.
+
+Do not repair the destination by hand and retry after an integrity refusal unless the manual change is intentionally removed through the separate operating procedure that owns the Windows output.
+
+## Tests
+
+The fixture suite covers first publication, repeated idempotent publication, complete working-tree content, destination dirtiness, destination divergence, concurrent locking, external-source protection, and recovery from an unsupported source entry.
+
+Run the focused suite with bash tests/fm-shadow.test.sh.
+
+Run shell lint with bin/fm-lint.sh.
+
+Run documentation structure checks with bin/fm-doc-audience-check.sh.

--- a/tests/fm-replicante.test.sh
+++ b/tests/fm-replicante.test.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# Behavioral tests for the incremental, content-addressed replicante backup.
+#
+# Every case uses a temporary source Git worktree and backup destination.
+# Fixture mode is the only path override and never reaches the real H: volume.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "$0")/lib.sh"
+
+REPLICANTE="$ROOT/bin/fm-replicante.sh"
+
+make_source() {
+  local source=$1
+  mkdir -p "$source"
+  git init -q -b main "$source"
+  git -C "$source" config user.name 'Replicante Tests'
+  git -C "$source" config user.email 'replicante-tests@example.invalid'
+  printf 'canonical Firstmate backup fixture\n' >"$source/README.md"
+  printf '%s\n' 'projects/' 'data/' 'config/' 'state/' '.no-mistakes/' >"$source/.gitignore"
+  printf 'source secret\n' >"$source/.env"
+  printf 'source-owned policy\n' >"$source/.shadow-policy"
+  mkdir -p "$source/projects/alpha/src" \
+    "$source/projects/alpha/config" \
+    "$source/data/decisions" \
+    "$source/config" \
+    "$source/state" \
+    "$source/.no-mistakes"
+  printf 'project source\n' >"$source/projects/alpha/src/app.txt"
+  printf 'project private config\n' >"$source/projects/alpha/config/private.txt"
+  printf 'durable decision\n' >"$source/data/decisions/choice.md"
+  printf 'local config\n' >"$source/config/local"
+  printf 'local state\n' >"$source/state/live"
+  printf 'local no-mistakes\n' >"$source/.no-mistakes/live"
+  ln -s ../src/app.txt "$source/projects/alpha/config/app-link"
+  chmod 0400 "$source/projects/alpha/config/private.txt"
+  git -C "$source" add README.md .gitignore .env .shadow-policy
+  git -C "$source" commit -qm initial
+}
+
+new_fixture() {
+  local root=$1
+  mkdir -p "$root/destination-parent"
+  make_source "$root/source"
+}
+
+run_replicante() {
+  local source=$1 destination=$2
+  shift 2
+  REPLICANTE_TEST_MODE=1 \
+    REPLICANTE_TEST_SOURCE="$source" \
+    REPLICANTE_TEST_DESTINATION="$destination" \
+    "$REPLICANTE" "$@"
+}
+
+snapshot_count() {
+  find "$1/snapshots" -mindepth 1 -maxdepth 1 -type d -print | wc -l
+}
+
+object_count() {
+  find "$1/objects" -mindepth 1 -maxdepth 1 -type f -print | wc -l
+}
+
+test_first_backup_and_verify() {
+  local root source destination out snapshot
+  root=$(fm_test_tmproot replicante-first)
+  new_fixture "$root"
+  source="$root/source"
+  destination="$root/destination-parent/Firstmate-Backup"
+
+  out=$(run_replicante "$source" "$destination" run)
+  assert_contains "$out" 'replicated: snapshot=' 'first backup did not publish a snapshot'
+  assert_present "$destination/.replicante-root.json" 'backup identity marker was not created'
+  assert_present "$destination/latest" 'latest snapshot marker was not created'
+  assert_present "$destination/objects" 'backup object store was not created'
+  assert_present "$destination/snapshots" 'backup snapshot store was not created'
+  [ "$(snapshot_count "$destination")" = 1 ] || fail 'first backup did not create exactly one snapshot'
+  snapshot=$(cat "$destination/latest")
+  assert_present "$destination/snapshots/$snapshot/manifest.json" 'snapshot manifest was not created'
+
+  out=$(run_replicante "$source" "$destination" verify --restore-test)
+  assert_contains "$out" 'with restore test' \
+    'first snapshot restore verification did not pass'
+  pass 'first backup creates a complete verifiable snapshot'
+}
+
+test_repeat_is_idempotent() {
+  local root source destination out objects_before
+  root=$(fm_test_tmproot replicante-repeat)
+  new_fixture "$root"
+  source="$root/source"
+  destination="$root/destination-parent/Firstmate-Backup"
+  run_replicante "$source" "$destination" run >/dev/null
+  objects_before=$(object_count "$destination")
+
+  out=$(run_replicante "$source" "$destination" run)
+  assert_contains "$out" 'already current: snapshot=' 'repeated backup was not idempotent'
+  [ "$(snapshot_count "$destination")" = 1 ] || fail 'repeated backup created a duplicate snapshot'
+  [ "$(object_count "$destination")" = "$objects_before" ] || fail 'repeated backup recopied unchanged objects'
+  pass 'repeated backup is idempotent'
+}
+
+test_incremental_changes_and_deletion_history() {
+  local root source destination old_snapshot changed_snapshot deleted_snapshot out
+  root=$(fm_test_tmproot replicante-incremental)
+  new_fixture "$root"
+  source="$root/source"
+  destination="$root/destination-parent/Firstmate-Backup"
+  run_replicante "$source" "$destination" run >/dev/null
+  old_snapshot=$(cat "$destination/latest")
+
+  printf 'updated project source\n' >"$source/projects/alpha/src/app.txt"
+  printf 'new incremental file\n' >"$source/projects/alpha/src/new.txt"
+  out=$(run_replicante "$source" "$destination" run)
+  assert_contains "$out" 'replicated: snapshot=' 'incremental content change was not published'
+  changed_snapshot=$(cat "$destination/latest")
+  [ "$changed_snapshot" != "$old_snapshot" ] || fail 'content change reused the old snapshot'
+  [ "$(snapshot_count "$destination")" = 2 ] || fail 'incremental change did not preserve both snapshots'
+
+  rm "$source/projects/alpha/src/app.txt"
+  out=$(run_replicante "$source" "$destination" run)
+  assert_contains "$out" 'replicated: snapshot=' 'source deletion was not published'
+  deleted_snapshot=$(cat "$destination/latest")
+  [ "$deleted_snapshot" != "$changed_snapshot" ] || fail 'source deletion reused the old snapshot'
+
+  run_replicante "$source" "$destination" restore \
+    --snapshot "$changed_snapshot" --output "$root/restored-before-delete" --apply-modes >/dev/null
+  assert_present "$root/restored-before-delete/projects/alpha/src/app.txt" \
+    'historical snapshot did not preserve the deleted source file'
+  assert_grep 'updated project source' "$root/restored-before-delete/projects/alpha/src/app.txt" \
+    'historical snapshot restored the wrong file content'
+  [ "$(stat -c '%a' "$root/restored-before-delete/projects/alpha/config/private.txt")" = 400 ] \
+    || fail 'restoration did not apply the recorded source mode'
+  run_replicante "$source" "$destination" restore \
+    --snapshot "$deleted_snapshot" --output "$root/restored-after-delete" >/dev/null
+  assert_absent "$root/restored-after-delete/projects/alpha/src/app.txt" \
+    'latest snapshot resurrected a deleted source file'
+  assert_present "$root/restored-after-delete/projects/alpha/src/new.txt" \
+    'latest snapshot lost an incremental file'
+  out=$(run_replicante "$source" "$destination" verify --all)
+  assert_contains "$out" 'verified: snapshots=3' 'historical snapshots did not verify'
+  pass 'incremental changes and deletions preserve historical restoration'
+}
+
+test_retention_is_configurable() {
+  local root source destination
+  root=$(fm_test_tmproot replicante-retention)
+  new_fixture "$root"
+  source="$root/source"
+  destination="$root/destination-parent/Firstmate-Backup"
+  run_replicante "$source" "$destination" run --retain 2 >/dev/null
+  printf 'retention one\n' >"$source/README.md"
+  run_replicante "$source" "$destination" run --retain 2 >/dev/null
+  printf 'retention two\n' >"$source/README.md"
+  run_replicante "$source" "$destination" run --retain 2 >/dev/null
+  [ "$(snapshot_count "$destination")" = 2 ] || fail 'configured retention did not prune old snapshots'
+  run_replicante "$source" "$destination" verify --all >/dev/null
+  pass 'snapshot retention is configurable and retained snapshots remain verifiable'
+}
+
+test_wrong_destination_is_refused() {
+  local root source destination out
+  root=$(fm_test_tmproot replicante-wrong-destination)
+  new_fixture "$root"
+  source="$root/source"
+  destination="$root/destination-parent/Firstmate-Backup"
+  mkdir "$destination"
+  printf 'unrelated destination\n' >"$destination/unrelated.txt"
+
+  if out=$(run_replicante "$source" "$destination" run 2>&1); then
+    fail 'uninitialized nonempty destination was accepted'
+  fi
+  assert_contains "$out" 'no matching replicante identity marker' \
+    'wrong destination refusal did not identify the identity boundary'
+  assert_grep 'unrelated destination' "$destination/unrelated.txt" \
+    'wrong destination content was changed'
+  pass 'wrong destination identity is refused without touching its content'
+}
+
+test_concurrent_lock_is_refused() {
+  local root source destination lock out
+  root=$(fm_test_tmproot replicante-lock)
+  new_fixture "$root"
+  source="$root/source"
+  destination="$root/destination-parent/Firstmate-Backup"
+  lock="$root/destination-parent/.Firstmate-Backup.replicante.lock"
+  mkdir "$lock"
+  printf 'other process\n' >"$lock/owner"
+
+  if out=$(run_replicante "$source" "$destination" run 2>&1); then
+    fail 'concurrent backup was accepted'
+  fi
+  assert_contains "$out" 'holds the lock' 'concurrent backup refusal did not identify the lock'
+  assert_absent "$destination" 'locked backup created a destination'
+  pass 'concurrent backup execution is serialized by an atomic lock'
+}
+
+test_unsupported_source_preserves_absent_destination() {
+  local root source destination out
+  root=$(fm_test_tmproot replicante-special)
+  new_fixture "$root"
+  source="$root/source"
+  destination="$root/destination-parent/Firstmate-Backup"
+  mkfifo "$source/projects/alpha/unsupported-fifo"
+
+  if out=$(run_replicante "$source" "$destination" run 2>&1); then
+    fail 'unsupported source entry was accepted'
+  fi
+  assert_contains "$out" 'special file is not supported' \
+    'unsupported source refusal did not identify the source limitation'
+  assert_absent "$destination" 'unsupported source entry left a partial first backup'
+  pass 'unsupported source entry fails closed before creating a first backup'
+}
+
+test_corruption_is_refused() {
+  local root source destination object latest out
+  root=$(fm_test_tmproot replicante-corrupt)
+  new_fixture "$root"
+  source="$root/source"
+  destination="$root/destination-parent/Firstmate-Backup"
+  run_replicante "$source" "$destination" run >/dev/null
+  latest=$(cat "$destination/latest")
+  object=$(find "$destination/objects" -type f -print -quit)
+  printf 'corrupt object\n' >"$object"
+
+  if out=$(run_replicante "$source" "$destination" verify 2>&1); then
+    fail 'corrupt object passed verification'
+  fi
+  assert_contains "$out" 'object hash or size is corrupt' \
+    'corruption refusal did not identify the object integrity failure'
+  if out=$(run_replicante "$source" "$destination" run 2>&1); then
+    fail 'corrupt prior backup was accepted for incremental run'
+  fi
+  assert_contains "$out" 'object hash or size is corrupt' \
+    'incremental corruption refusal did not preserve the integrity boundary'
+  [ "$(cat "$destination/latest")" = "$latest" ] || fail 'corruption changed latest snapshot'
+  pass 'corrupt backup objects are refused without advancing the backup'
+}
+
+test_first_backup_and_verify
+test_repeat_is_idempotent
+test_incremental_changes_and_deletion_history
+test_retention_is_configurable
+test_wrong_destination_is_refused
+test_concurrent_lock_is_refused
+test_unsupported_source_preserves_absent_destination
+test_corruption_is_refused

--- a/tests/fm-replicante.test.sh
+++ b/tests/fm-replicante.test.sh
@@ -158,6 +158,65 @@ test_retention_is_configurable() {
   pass 'snapshot retention is configurable and retained snapshots remain verifiable'
 }
 
+test_retention_keeps_current_after_rollback() {
+  local root source destination first_snapshot out
+  root=$(fm_test_tmproot replicante-retention-rollback)
+  new_fixture "$root"
+  source="$root/source"
+  destination="$root/destination-parent/Firstmate-Backup"
+
+  run_replicante "$source" "$destination" run --retain 3 >/dev/null
+  first_snapshot=$(cat "$destination/latest")
+  printf 'rollback state one\n' >"$source/README.md"
+  run_replicante "$source" "$destination" run --retain 3 >/dev/null
+  printf 'rollback state two\n' >"$source/README.md"
+  run_replicante "$source" "$destination" run --retain 3 >/dev/null
+  printf 'canonical Firstmate backup fixture\n' >"$source/README.md"
+  out=$(run_replicante "$source" "$destination" run --retain 2)
+
+  assert_contains "$out" 'replicated: snapshot=' 'rollback to an existing snapshot was not published'
+  [ "$(cat "$destination/latest")" = "$first_snapshot" ] \
+    || fail 'rollback did not make the historical snapshot current'
+  [ "$(snapshot_count "$destination")" = 2 ] \
+    || fail 'retention skipped the current rollback snapshot'
+  run_replicante "$source" "$destination" verify --all >/dev/null
+  pass 'retention keeps the current snapshot when source state rolls back'
+}
+
+test_metadata_symlinks_are_refused() {
+  local root source destination snapshot manifest external latest_target out
+  root=$(fm_test_tmproot replicante-metadata-symlinks)
+  new_fixture "$root"
+  source="$root/source"
+  destination="$root/destination-parent/Firstmate-Backup"
+  run_replicante "$source" "$destination" run >/dev/null
+  snapshot=$(cat "$destination/latest")
+  manifest="$destination/snapshots/$snapshot/manifest.json"
+  external="$root/external-manifest.json"
+  cp "$manifest" "$external"
+  rm "$manifest"
+  ln -s "$external" "$manifest"
+
+  if out=$(run_replicante "$source" "$destination" verify 2>&1); then
+    fail 'manifest symlink was accepted'
+  fi
+  assert_contains "$out" 'snapshot is missing its manifest' \
+    'manifest symlink refusal did not identify the unsafe metadata'
+
+  rm "$manifest"
+  cp "$external" "$manifest"
+  latest_target="$root/external-latest"
+  printf '%s\n' "$snapshot" >"$latest_target"
+  rm "$destination/latest"
+  ln -s "$latest_target" "$destination/latest"
+  if out=$(run_replicante "$source" "$destination" verify 2>&1); then
+    fail 'latest marker symlink was accepted'
+  fi
+  assert_contains "$out" 'latest snapshot marker must not be a symbolic link' \
+    'latest marker symlink refusal did not identify the unsafe metadata'
+  pass 'manifest and latest metadata symlinks are refused'
+}
+
 test_wrong_destination_is_refused() {
   local root source destination out
   root=$(fm_test_tmproot replicante-wrong-destination)
@@ -241,6 +300,8 @@ test_first_backup_and_verify
 test_repeat_is_idempotent
 test_incremental_changes_and_deletion_history
 test_retention_is_configurable
+test_retention_keeps_current_after_rollback
+test_metadata_symlinks_are_refused
 test_wrong_destination_is_refused
 test_concurrent_lock_is_refused
 test_unsupported_source_preserves_absent_destination

--- a/tests/fm-shadow.test.sh
+++ b/tests/fm-shadow.test.sh
@@ -106,6 +106,24 @@ test_first_replica_copies_identity_and_complete_tree() {
   pass 'first replica preserves commit identity and mirrors the complete source tree'
 }
 
+test_9p_content_fixture_ignores_source_metadata_restrictions() {
+  local root source destination out
+  root=$(fm_test_tmproot shadow-9p-content)
+  new_fixture "$root"
+  source="$root/source"
+  destination="$root/destination-parent/shadow"
+  chmod 0444 "$source/projects/alpha/config/private.txt"
+  ln -s ../src/app.txt "$source/projects/alpha/config/app-link"
+
+  out=$(run_shadow "$source" "$destination")
+  assert_contains "$out" 'replicated:' '9p content fixture was not published'
+  assert_grep 'private project config' "$destination/projects/alpha/config/private.txt" \
+    'content copy failed for a metadata-restricted source file'
+  [ -L "$destination/projects/alpha/config/app-link" ] \
+    || fail 'content fixture did not preserve the source symlink'
+  pass '9p content fixture copies bytes and symlinks without source metadata updates'
+}
+
 test_repeated_replica_is_idempotent_and_tracks_complete_working_tree() {
   local root source destination controls out manifest_before
   root=$(fm_test_tmproot shadow-repeat)
@@ -226,7 +244,7 @@ test_staging_failure_preserves_previous_replica() {
   if out=$(run_shadow "$source" "$destination" 2>&1); then
     fail 'unsupported source entry was accepted'
   fi
-  assert_contains "$out" 'cannot mirror source tree' \
+  assert_contains "$out" 'special file is not allowed in source tree' \
     'unsupported source entry did not stop the mirror'
   [ "$(git -C "$destination" rev-parse HEAD)" = "$before" ] \
     || fail 'staging failure changed destination history'
@@ -259,6 +277,7 @@ test_manifest_tamper_is_refused() {
 }
 
 test_first_replica_copies_identity_and_complete_tree
+test_9p_content_fixture_ignores_source_metadata_restrictions
 test_repeated_replica_is_idempotent_and_tracks_complete_working_tree
 test_dirty_destination_is_preserved
 test_divergent_destination_is_preserved

--- a/tests/fm-shadow.test.sh
+++ b/tests/fm-shadow.test.sh
@@ -243,6 +243,22 @@ test_source_lock_is_fail_closed() {
   pass 'concurrent source replication is serialized by a source-side lock'
 }
 
+test_stale_source_snapshot_is_reclaimed() {
+  local root source destination stale out
+  root=$(fm_test_tmproot shadow-stale-source-snapshot)
+  new_fixture "$root"
+  source="$root/source"
+  destination="$root/destination-parent/shadow"
+  stale="$root/destination-parent/.shadow-source-snapshot.stale"
+  mkdir "$stale"
+  printf 'stale snapshot\n' >"$stale/README.md"
+
+  out=$(run_shadow "$source" "$destination")
+  assert_contains "$out" 'replicated:' 'stale source snapshot blocked publication'
+  assert_absent "$stale" 'stale source snapshot was not reclaimed'
+  pass 'interrupted source snapshots are reclaimed before the next publication'
+}
+
 test_destination_parent_traversal_is_refused() {
   local root source destination out
   root=$(fm_test_tmproot shadow-normalization)
@@ -372,6 +388,27 @@ test_manifest_tamper_is_refused() {
   pass 'manifest hash tamper is refused without touching destination output'
 }
 
+test_control_metadata_symlinks_are_refused() {
+  local root source destination controls external out
+  root=$(fm_test_tmproot shadow-control-symlinks)
+  new_fixture "$root"
+  source="$root/source"
+  destination="$root/destination-parent/shadow"
+  controls="$root/destination-parent/.shadow-control.shadow"
+  run_shadow "$source" "$destination" >/dev/null
+  external="$root/external-manifest"
+  cp "$controls/manifest" "$external"
+  rm "$controls/manifest"
+  ln -s "$external" "$controls/manifest"
+
+  if out=$(run_shadow "$source" "$destination" 2>&1); then
+    fail 'control metadata symlink was accepted'
+  fi
+  assert_contains "$out" 'must not be symbolic links' \
+    'control metadata symlink refusal did not identify the unsafe metadata'
+  pass 'shadow control metadata symlinks are refused'
+}
+
 test_first_replica_copies_identity_and_complete_tree
 test_9p_content_fixture_ignores_source_metadata_restrictions
 test_mode_only_destination_drift_is_ignored_on_9p
@@ -380,8 +417,10 @@ test_dirty_destination_is_preserved
 test_divergent_destination_is_preserved
 test_concurrent_lock_is_fail_closed
 test_source_lock_is_fail_closed
+test_stale_source_snapshot_is_reclaimed
 test_destination_parent_traversal_is_refused
 test_external_symlink_target_is_not_traversed
 test_staging_failure_preserves_previous_replica
 test_interrupted_recovery_preserves_failed_output
 test_manifest_tamper_is_refused
+test_control_metadata_symlinks_are_refused

--- a/tests/fm-shadow.test.sh
+++ b/tests/fm-shadow.test.sh
@@ -226,6 +226,23 @@ test_concurrent_lock_is_fail_closed() {
   pass 'concurrent execution is serialized by an atomic lock directory'
 }
 
+test_source_lock_is_fail_closed() {
+  local root source destination lock out
+  root=$(fm_test_tmproot shadow-source-lock)
+  new_fixture "$root"
+  source="$root/source"
+  destination="$root/destination-parent/shadow"
+  lock="$root/.shadow-source-lock.source"
+  mkdir "$lock"
+
+  if out=$(run_shadow "$source" "$destination" 2>&1); then
+    fail 'source lock was not enforced'
+  fi
+  assert_contains "$out" 'holds the source lock' 'source lock refusal did not identify the active lock'
+  assert_absent "$destination" 'source-locked first replica created destination output'
+  pass 'concurrent source replication is serialized by a source-side lock'
+}
+
 test_destination_parent_traversal_is_refused() {
   local root source destination out
   root=$(fm_test_tmproot shadow-normalization)
@@ -289,6 +306,51 @@ test_staging_failure_preserves_previous_replica() {
   pass 'unsupported source entry leaves the prior replica intact and cleans temporary output'
 }
 
+test_interrupted_recovery_preserves_failed_output() {
+  local root source destination controls transaction saved_destination saved_control commit out preserved
+  root=$(fm_test_tmproot shadow-recovery-edit)
+  new_fixture "$root"
+  source="$root/source"
+  destination="$root/destination-parent/shadow"
+  controls="$root/destination-parent/.shadow-control.shadow"
+  run_shadow "$source" "$destination" >/dev/null
+  saved_destination="$root/saved-destination"
+  saved_control="$root/saved-control"
+  cp -a "$destination" "$saved_destination"
+  cp -a "$controls" "$saved_control"
+  printf 'new staged source content\n' >"$source/projects/alpha/src/app.txt"
+  run_shadow "$source" "$destination" >/dev/null
+
+  transaction="$root/destination-parent/.shadow-transaction.shadow"
+  mkdir "$transaction"
+  mv "$saved_destination" "$transaction/old-destination"
+  mv "$saved_control" "$transaction/old-control"
+  commit=$(git -C "$source" rev-parse HEAD)
+  printf 'main\n' >"$transaction/source-branch"
+  printf '%s\n' "$commit" >"$transaction/source-commit"
+  printf '1\n' >"$transaction/destination-present"
+  printf '1\n' >"$transaction/control-present"
+  : >"$transaction/ready"
+  printf 'operator edit during recovery\n' >"$destination/README.md"
+
+  if out=$(run_shadow "$source" "$destination" 2>&1); then
+    fail 'interrupted recovery accepted an edited destination'
+  fi
+  assert_contains "$out" 'failed output was preserved' \
+    'interrupted recovery did not report the preserved failed output'
+  assert_grep 'canonical Firstmate fixture' "$destination/README.md" \
+    'interrupted recovery did not restore the previous destination'
+  preserved=$(find "$root/destination-parent" -maxdepth 1 -type d \
+    -name '.shadow-recovery-failed.*' -print -quit)
+  [ -n "$preserved" ] || fail 'interrupted recovery did not create preserved output storage'
+  assert_grep 'operator edit during recovery' "$preserved/destination/README.md" \
+    'interrupted recovery deleted the edited failed output'
+  assert_present "$preserved/control/manifest" \
+    'interrupted recovery did not preserve the failed control metadata'
+  assert_absent "$transaction" 'interrupted recovery left a completed transaction marker'
+  pass 'interrupted recovery restores the old output and preserves failed edits'
+}
+
 test_manifest_tamper_is_refused() {
   local root source destination controls before out
   root=$(fm_test_tmproot shadow-manifest)
@@ -317,7 +379,9 @@ test_repeated_replica_is_idempotent_and_tracks_complete_working_tree
 test_dirty_destination_is_preserved
 test_divergent_destination_is_preserved
 test_concurrent_lock_is_fail_closed
+test_source_lock_is_fail_closed
 test_destination_parent_traversal_is_refused
 test_external_symlink_target_is_not_traversed
 test_staging_failure_preserves_previous_replica
+test_interrupted_recovery_preserves_failed_output
 test_manifest_tamper_is_refused

--- a/tests/fm-shadow.test.sh
+++ b/tests/fm-shadow.test.sh
@@ -125,6 +125,23 @@ test_9p_content_fixture_ignores_source_metadata_restrictions() {
   pass '9p content fixture copies bytes and symlinks without source metadata updates'
 }
 
+test_mode_only_destination_drift_is_ignored_on_9p() {
+  local root source destination out
+  root=$(fm_test_tmproot shadow-mode-drift)
+  new_fixture "$root"
+  source="$root/source"
+  destination="$root/destination-parent/shadow"
+  run_shadow "$source" "$destination" >/dev/null
+  chmod 0777 "$destination/README.md"
+
+  out=$(run_shadow "$source" "$destination")
+  assert_contains "$out" 'already current:' \
+    '9p mode-only destination drift was treated as content drift'
+  assert_grep 'canonical Firstmate fixture' "$destination/README.md" \
+    'mode-only destination validation changed file content'
+  pass '9p mode-only destination drift is ignored while content remains validated'
+}
+
 test_repeated_replica_is_idempotent_and_tracks_complete_working_tree() {
   local root source destination controls out manifest_before
   root=$(fm_test_tmproot shadow-repeat)
@@ -279,6 +296,7 @@ test_manifest_tamper_is_refused() {
 
 test_first_replica_copies_identity_and_complete_tree
 test_9p_content_fixture_ignores_source_metadata_restrictions
+test_mode_only_destination_drift_is_ignored_on_9p
 test_repeated_replica_is_idempotent_and_tracks_complete_working_tree
 test_dirty_destination_is_preserved
 test_divergent_destination_is_preserved

--- a/tests/fm-shadow.test.sh
+++ b/tests/fm-shadow.test.sh
@@ -54,7 +54,8 @@ new_fixture() {
 }
 
 run_shadow() {
-  "$SHADOW" --source "$1" --destination "$2"
+  # Git's test hook emulates a foreign-owned checkout without changing fixture ownership.
+  GIT_TEST_ASSUME_DIFFERENT_OWNER=1 "$SHADOW" --source "$1" --destination "$2"
 }
 
 test_first_replica_copies_identity_and_complete_tree() {

--- a/tests/fm-shadow.test.sh
+++ b/tests/fm-shadow.test.sh
@@ -226,6 +226,22 @@ test_concurrent_lock_is_fail_closed() {
   pass 'concurrent execution is serialized by an atomic lock directory'
 }
 
+test_destination_parent_traversal_is_refused() {
+  local root source destination out
+  root=$(fm_test_tmproot shadow-normalization)
+  new_fixture "$root"
+  source="$root/source"
+  mkdir -p "$root/destination-parent/shadow"
+  destination="$root/destination-parent/shadow/.."
+
+  if out=$(run_shadow "$source" "$destination" 2>&1); then
+    fail 'destination parent traversal was accepted'
+  fi
+  assert_contains "$out" 'destination must name a directory' \
+    'destination parent traversal refusal did not identify the invalid path'
+  pass 'destination parent traversal is refused before path identity checks'
+}
+
 test_external_symlink_target_is_not_traversed() {
   local root source destination controls external out
   root=$(fm_test_tmproot shadow-external)
@@ -301,6 +317,7 @@ test_repeated_replica_is_idempotent_and_tracks_complete_working_tree
 test_dirty_destination_is_preserved
 test_divergent_destination_is_preserved
 test_concurrent_lock_is_fail_closed
+test_destination_parent_traversal_is_refused
 test_external_symlink_target_is_not_traversed
 test_staging_failure_preserves_previous_replica
 test_manifest_tamper_is_refused

--- a/tests/fm-shadow.test.sh
+++ b/tests/fm-shadow.test.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+# Behavioral tests for the fail-closed fm-shadow replica command.
+#
+# Every case uses a temporary source Git worktree and destination parent.
+# No test reaches the configured Windows destination or the live Firstmate home.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "$0")/lib.sh"
+
+SHADOW="$ROOT/bin/fm-shadow.sh"
+
+make_source() {
+  local source=$1
+  mkdir -p "$source"
+  git init -q -b main "$source"
+  git -C "$source" config user.name 'Firstmate Shadow Tests'
+  git -C "$source" config user.email 'shadow-tests@example.invalid'
+  printf 'canonical Firstmate fixture\n' >"$source/README.md"
+  printf 'source-owned manifest name\n' >"$source/.shadow-manifest"
+  printf 'source-owned policy name\n' >"$source/.shadow-policy"
+  printf '%s\n' 'projects/' 'data/' 'config/' 'state/' '.no-mistakes/' '.env' >"$source/.gitignore"
+  git -C "$source" add README.md .gitignore .shadow-manifest .shadow-policy
+  git -C "$source" commit -qm initial
+
+  mkdir -p "$source/projects/alpha/src" \
+    "$source/projects/alpha/config" \
+    "$source/projects/alpha/.treehouse" \
+    "$source/projects/alpha/logs" \
+    "$source/projects/RocoData" \
+    "$source/data/decisions" \
+    "$source/config" \
+    "$source/state" \
+    "$source/.no-mistakes"
+  printf 'visible project file\n' >"$source/projects/alpha/src/app.txt"
+  printf 'private project config\n' >"$source/projects/alpha/config/private.txt"
+  mkdir -p "$source/projects/alpha/.git"
+  printf 'nested project Git metadata\n' >"$source/projects/alpha/.git/config"
+  printf 'agent worktree\n' >"$source/projects/alpha/.treehouse/agent.txt"
+  printf 'volatile log\n' >"$source/projects/alpha/logs/run.log"
+  printf 'live RocoData\n' >"$source/projects/RocoData/live.sqlite"
+  printf 'durable decision\n' >"$source/data/decisions/choice.md"
+  printf 'non-document data\n' >"$source/data/decisions/private.txt"
+  printf 'local config\n' >"$source/config/local"
+  printf 'local state\n' >"$source/state/live"
+  printf 'local no-mistakes state\n' >"$source/.no-mistakes/live"
+  printf 'local secret\n' >"$source/.env"
+}
+
+new_fixture() {
+  local root=$1
+  mkdir -p "$root/destination-parent"
+  make_source "$root/source"
+}
+
+run_shadow() {
+  "$SHADOW" --source "$1" --destination "$2"
+}
+
+test_first_replica_copies_identity_and_complete_tree() {
+  local root source destination controls out source_head
+  root=$(fm_test_tmproot shadow-first)
+  new_fixture "$root"
+  source="$root/source"
+  destination="$root/destination-parent/shadow"
+  controls="$root/destination-parent/.shadow-control.shadow"
+  source_head=$(git -C "$source" rev-parse HEAD)
+
+  out=$(run_shadow "$source" "$destination")
+  assert_contains "$out" 'replicated:' 'first replica reports a completed publish'
+  [ "$(git -C "$destination" rev-parse HEAD)" = "$source_head" ] \
+    || fail 'first replica commit identity differs from source HEAD'
+  [ "$(git -C "$destination" symbolic-ref --short HEAD)" = main ] \
+    || fail 'first replica is not checked out on the default branch'
+  assert_present "$destination/projects/alpha/src/app.txt" \
+    'project working-tree content was not mirrored'
+  assert_present "$destination/projects/alpha/config/private.txt" \
+    'project config was not mirrored'
+  assert_present "$destination/projects/alpha/.treehouse/agent.txt" \
+    'project .treehouse content was not mirrored'
+  assert_present "$destination/projects/alpha/logs/run.log" \
+    'project log was not mirrored'
+  assert_present "$destination/projects/alpha/.git/config" \
+    'nested project Git metadata was not mirrored'
+  assert_present "$destination/projects/RocoData/live.sqlite" \
+    'RocoData content inside the source root was not mirrored'
+  assert_present "$destination/data/decisions/choice.md" \
+    'durable Markdown decision was not mirrored'
+  assert_present "$destination/data/decisions/private.txt" \
+    'non-Markdown data was not mirrored'
+  assert_present "$destination/config/local" 'config content was not mirrored'
+  assert_present "$destination/state/live" 'state content was not mirrored'
+  assert_present "$destination/.no-mistakes/live" '.no-mistakes content was not mirrored'
+  assert_present "$destination/.env" '.env content was not mirrored'
+  assert_grep 'source-owned manifest name' "$destination/.shadow-manifest" \
+    'source-owned manifest path was not preserved'
+  assert_grep 'source-owned policy name' "$destination/.shadow-policy" \
+    'source-owned policy path was not preserved'
+  assert_present "$controls/manifest" 'replica manifest sidecar was not written'
+  assert_present "$controls/policy" 'replica policy sidecar was not written'
+  assert_grep '.shadow-manifest' "$controls/manifest" \
+    'manifest did not enumerate the source-owned manifest path'
+  assert_grep '.shadow-policy' "$controls/manifest" \
+    'manifest did not enumerate the source-owned policy path'
+  assert_present "$destination/.git/index" 'source Git metadata was not mirrored'
+  pass 'first replica preserves commit identity and mirrors the complete source tree'
+}
+
+test_repeated_replica_is_idempotent_and_tracks_complete_working_tree() {
+  local root source destination controls out manifest_before
+  root=$(fm_test_tmproot shadow-repeat)
+  new_fixture "$root"
+  source="$root/source"
+  destination="$root/destination-parent/shadow"
+  controls="$root/destination-parent/.shadow-control.shadow"
+  run_shadow "$source" "$destination" >/dev/null
+  manifest_before=$(cat "$controls/manifest")
+
+  out=$(run_shadow "$source" "$destination")
+  assert_contains "$out" 'already current:' 'repeated replica was not idempotent'
+  [ "$(cat "$controls/manifest")" = "$manifest_before" ] \
+    || fail 'idempotent replica changed its manifest'
+
+  printf 'updated project snapshot\n' >"$source/projects/alpha/src/app.txt"
+  out=$(run_shadow "$source" "$destination")
+  assert_contains "$out" 'replicated:' 'changed source content was not published'
+  assert_grep 'updated project snapshot' "$destination/projects/alpha/src/app.txt" \
+    'changed source content did not reach destination'
+  pass 'repeated replica is stable and refreshes complete source content'
+}
+
+test_dirty_destination_is_preserved() {
+  local root source destination before out
+  root=$(fm_test_tmproot shadow-dirty)
+  new_fixture "$root"
+  source="$root/source"
+  destination="$root/destination-parent/shadow"
+  run_shadow "$source" "$destination" >/dev/null
+  before=$(git -C "$destination" rev-parse HEAD)
+  printf 'captain changed the output\n' >"$destination/README.md"
+
+  if out=$(run_shadow "$source" "$destination" 2>&1); then
+    fail 'dirty destination was accepted'
+  fi
+  assert_contains "$out" 'destination content differs from manifest' \
+    'dirty destination refusal did not explain the safety boundary'
+  assert_grep 'captain changed the output' "$destination/README.md" \
+    'dirty destination content was overwritten'
+  [ "$(git -C "$destination" rev-parse HEAD)" = "$before" ] \
+    || fail 'dirty destination commit changed during refusal'
+  pass 'dirty destination is refused and preserved byte-for-byte'
+}
+
+test_divergent_destination_is_preserved() {
+  local root source destination before out
+  root=$(fm_test_tmproot shadow-divergent)
+  new_fixture "$root"
+  source="$root/source"
+  destination="$root/destination-parent/shadow"
+  run_shadow "$source" "$destination" >/dev/null
+  git -C "$destination" -c user.name='Shadow Test' \
+    -c user.email='shadow-tests@example.invalid' commit --allow-empty -qm divergent
+  before=$(git -C "$destination" rev-parse HEAD)
+
+  if out=$(run_shadow "$source" "$destination" 2>&1); then
+    fail 'divergent destination was accepted'
+  fi
+  assert_contains "$out" 'diverges from source commit' \
+    'divergent destination refusal did not identify the ancestry failure'
+  [ "$(git -C "$destination" rev-parse HEAD)" = "$before" ] \
+    || fail 'divergent destination commit changed during refusal'
+  pass 'divergent destination is refused without rewriting its history'
+}
+
+test_concurrent_lock_is_fail_closed() {
+  local root source destination lock out
+  root=$(fm_test_tmproot shadow-lock)
+  new_fixture "$root"
+  source="$root/source"
+  destination="$root/destination-parent/shadow"
+  lock="$root/destination-parent/.shadow.lock"
+  mkdir "$lock"
+  printf 'other process\n' >"$lock/owner"
+
+  if out=$(run_shadow "$source" "$destination" 2>&1); then
+    fail 'concurrent lock was not enforced'
+  fi
+  assert_contains "$out" 'holds the lock' 'lock refusal did not identify the active lock'
+  assert_absent "$destination" 'locked first replica created destination output'
+  pass 'concurrent execution is serialized by an atomic lock directory'
+}
+
+test_external_symlink_target_is_not_traversed() {
+  local root source destination controls external out
+  root=$(fm_test_tmproot shadow-external)
+  new_fixture "$root"
+  source="$root/source"
+  destination="$root/destination-parent/shadow"
+  controls="$root/destination-parent/.shadow-control.shadow"
+  external="$root/external-RocoData"
+  mkdir "$external"
+  printf 'outside source root\n' >"$external/outside.sqlite"
+  ln -s "$external" "$source/projects/alpha/external-roco-data"
+
+  out=$(run_shadow "$source" "$destination")
+  assert_contains "$out" 'replicated:' 'external symlink fixture was not published'
+  [ -L "$destination/projects/alpha/external-roco-data" ] \
+    || fail 'external symlink was followed instead of mirrored as a link'
+  assert_grep 'external-roco-data' "$controls/manifest" \
+    'external symlink path was not recorded in the manifest'
+  assert_no_grep 'outside.sqlite' "$controls/manifest" \
+    'content outside the source root was traversed into the manifest'
+  pass 'symlink targets outside the source root are not traversed'
+}
+
+test_staging_failure_preserves_previous_replica() {
+  local root source destination before out
+  root=$(fm_test_tmproot shadow-recovery)
+  new_fixture "$root"
+  source="$root/source"
+  destination="$root/destination-parent/shadow"
+  run_shadow "$source" "$destination" >/dev/null
+  before=$(git -C "$destination" rev-parse HEAD)
+  mkfifo "$source/projects/alpha/unsupported-fifo"
+
+  if out=$(run_shadow "$source" "$destination" 2>&1); then
+    fail 'unsupported source entry was accepted'
+  fi
+  assert_contains "$out" 'cannot mirror source tree' \
+    'unsupported source entry did not stop the mirror'
+  [ "$(git -C "$destination" rev-parse HEAD)" = "$before" ] \
+    || fail 'staging failure changed destination history'
+  assert_grep 'canonical Firstmate fixture' "$destination/README.md" \
+    'staging failure changed destination content'
+  [ -z "$(find "$root/destination-parent" -maxdepth 1 -name '.shadow-stage.*' -print -quit)" ] \
+    || fail 'staging failure left a partial staging directory'
+  pass 'unsupported source entry leaves the prior replica intact and cleans temporary output'
+}
+
+test_manifest_tamper_is_refused() {
+  local root source destination controls before out
+  root=$(fm_test_tmproot shadow-manifest)
+  new_fixture "$root"
+  source="$root/source"
+  destination="$root/destination-parent/shadow"
+  controls="$root/destination-parent/.shadow-control.shadow"
+  run_shadow "$source" "$destination" >/dev/null
+  before=$(git -C "$destination" rev-parse HEAD)
+  sed -i '2s/$/tampered/' "$controls/manifest"
+
+  if out=$(run_shadow "$source" "$destination" 2>&1); then
+    fail 'tampered manifest was accepted'
+  fi
+  assert_contains "$out" 'manifest hash does not match' \
+    'manifest tamper refusal did not identify the integrity failure'
+  [ "$(git -C "$destination" rev-parse HEAD)" = "$before" ] \
+    || fail 'manifest tamper changed destination history'
+  pass 'manifest hash tamper is refused without touching destination output'
+}
+
+test_first_replica_copies_identity_and_complete_tree
+test_repeated_replica_is_idempotent_and_tracks_complete_working_tree
+test_dirty_destination_is_preserved
+test_divergent_destination_is_preserved
+test_concurrent_lock_is_fail_closed
+test_external_symlink_target_is_not_traversed
+test_staging_failure_preserves_previous_replica
+test_manifest_tamper_is_refused


### PR DESCRIPTION
## Intent

Implement and validate the complete authorized Firstmate replication change: keep shadow as an exact one-way mirror of /home/ale/firstmate to /mnt/d/Workspace/shadow, add replicante as a separate fail-closed incremental content-addressed backup from exactly /home/ale/firstmate to exactly /mnt/h/Firstmate-Backup with historical snapshots, deletion retention, integrity verification, restore testing, configurable retention, exact identity and lock checks, WSL/Windows scheduling documentation, fixture-only tests, and do not execute a real copy against H: or D:; leave the pull request open and never merge it.

## What Changed

- Added `fm-shadow` as a fail-closed exact one-way mirror with path/trust validation, locking, recovery, staged publication, and fixture-only tests.
- Added `fm-replicante` as an incremental content-addressed backup with historical snapshots, retention, integrity verification, restore testing, and a shell entrypoint.
- Documented replication contracts and WSL/Windows scheduling, with supporting documentation metadata and test-runner integration.

## Risk Assessment

⚠️ Medium: The latest changes address the previously identified integrity, cleanup, and canonicalization issues; the remaining implementation is operationally sensitive but no material source defect is substantiated in this review.

## Testing

All targeted tests passed. Manual fixture-only CLI verification demonstrated the requested mirror and backup behavior; no real H: or D: copy was executed, and the worktree remained clean.

<details>
<summary>Evidence: Fixture-only replication CLI transcript</summary>

```text
fixture_mode=only
source=/tmp/fm-replication-evidence.CGtEBk/source
shadow_destination=/tmp/fm-replication-evidence.CGtEBk/shadow-parent/shadow
backup_destination=/tmp/fm-replication-evidence.CGtEBk/backup-parent/Firstmate-Backup
source_head=483507793fa0c04e01488b75768a6766aa73515b
shadow.first=replicated: /tmp/fm-replication-evidence.CGtEBk/source -> /tmp/fm-replication-evidence.CGtEBk/shadow-parent/shadow (483507793fa0c04e01488b75768a6766aa73515b)
shadow.commit_identity=exact
shadow.tree=exact
shadow.repeat=already current: 483507793fa0c04e01488b75768a6766aa73515b at /tmp/fm-replication-evidence.CGtEBk/shadow-parent/shadow
shadow.symlink_target=current.txt
shadow_manifest=manifest policy
shadow.changed=replicated: /tmp/fm-replication-evidence.CGtEBk/source -> /tmp/fm-replication-evidence.CGtEBk/shadow-parent/shadow (75e8cabe6f54315d1f981c0d8243859db41fa489)
shadow.deleted_path_present=no
shadow.updated_content=updated mirror content
replicante.first=replicated: snapshot=7ef5e4b930f581c38d44d3f1845ceda8026675b48dd5c901c1d3d0a8ed605dbb destination=/tmp/fm-replication-evidence.CGtEBk/backup-parent/Firstmate-Backup
replicante.first_snapshot=7ef5e4b930f581c38d44d3f1845ceda8026675b48dd5c901c1d3d0a8ed605dbb
replicante.objects=32 snapshots=1
replicante.changed=replicated: snapshot=0f72287aca1e96c8832784633bb7fff9720a7b3bc96f0046d2138f267ff4f3b9 destination=/tmp/fm-replication-evidence.CGtEBk/backup-parent/Firstmate-Backup
replicante.changed_snapshot=0f72287aca1e96c8832784633bb7fff9720a7b3bc96f0046d2138f267ff4f3b9
replicante.historical_snapshot_distinct=yes
replicante.added=replicated: snapshot=5aa9080a52ad334c482de16745ec95d7b922418163008f3c7e6878e436f93a90 destination=/tmp/fm-replication-evidence.CGtEBk/backup-parent/Firstmate-Backup
replicante.deletion=replicated: snapshot=0f72287aca1e96c8832784633bb7fff9720a7b3bc96f0046d2138f267ff4f3b9 destination=/tmp/fm-replication-evidence.CGtEBk/backup-parent/Firstmate-Backup
replicante.restore=restored: snapshot=5aa9080a52ad334c482de16745ec95d7b922418163008f3c7e6878e436f93a90 output=/tmp/fm-replication-evidence.CGtEBk/restored-historical
historical_restore.deleted_later=deleted later
current_snapshot.deleted_later_present=no
replicante.verify_all=verified: snapshots=3 destination=/tmp/fm-replication-evidence.CGtEBk/backup-parent/Firstmate-Backup
replicante.restore_test=verified: snapshots=1 destination=/tmp/fm-replication-evidence.CGtEBk/backup-parent/Firstmate-Backup with restore test
real_H_or_D_copy=not_run
```
</details>
<details>
<summary>Evidence: Replicante override safety transcript</summary>

```text
non_fixture_override_exit=1
fm-replicante: test source or destination overrides require REPLICANTE_TEST_MODE=1
real_H_or_D_copy=not_run
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 7 issues found → auto-fixed (4) ✅</summary>

- 🚨 `bin/fm-shadow.sh:30` - The required criterion says shadow must mirror exactly `/home/ale/firstmate` to `/mnt/d/Workspace/shadow`, but normal operation accepts `FM_SHADOW_SOURCE`, `FM_SHADOW_DESTINATION`, `--source`, and `--destination`, including arbitrary installations. Please confirm whether these overrides must be restricted to explicit fixture mode.
- 🚨 `bin/fm-shadow.sh:262` - Destination validation occurs before staging, but `same_output` only compares sidecar files. If a user edits the destination during staging, an unchanged-source run returns `already current` without detecting the edit; a changed-source run can overwrite it. Revalidate the destination immediately before the no-op or swap boundary.
- 🚨 `bin/fm-replicante.py:395` - `is_file()` follows symbolic links, so a tampered backup can use an external symlink for `manifest.json` (and similarly for `latest` at line 294). Verification and restore then accept metadata outside the backup store, bypassing the self-contained integrity boundary. Explicitly reject symlinks before accepting these files.
- 🚨 `bin/fm-shadow.sh:102` - The final destination is built from a canonicalized parent plus an unchecked basename, so a destination ending in `..` can refer to an ancestor while containment checks use the uncanonicalized string. Reject `..` or canonicalize the complete destination before all identity and containment checks.
- 🚨 `docs/shadow.md:17` - The required criterion includes WSL/Windows scheduling documentation. `docs/replicante.md` documents a Windows Task Scheduler action only for replicante, while `docs/shadow.md` only says to run shadow from WSL and provides no Windows scheduling action or equivalent guidance. Please confirm the intended scheduling contract for shadow.
- ⚠️ `bin/fm-shadow.sh:310` - The advertised atomic swap is not crash-safe: after the old destination/control are moved aside, installing the new destination and control are separate operations. A kill or power loss between lines 310 and 315 leaves an unusable destination with the prior replica only in hidden backup directories, and the next run refuses before recovery. Add a durable transaction/recovery marker or make the two artifacts recoverable as one transaction.
- ⚠️ `bin/fm-replicante.py:582` - Retention is computed by creation time and skips the current snapshot if it falls in the deletion set. If the source returns to a previously retained state, that snapshot can be the oldest; the prune loop then skips it and leaves more than the configured retention count. Select the retained set while always including the current snapshot.

🔧 Fix: Captain: harden shadow recovery and replicante integrity
2 errors still open:
- 🚨 `bin/fm-shadow.sh:354` - If an interrupted transaction leaves a new destination in place, an operator edit made before retry is moved to `failed-destination` and then deleted by `clear_transaction` after restoring the old replica. This violates the fail-closed contract that manual destination edits are preserved; preserve the failed output and stop safely instead of removing it.
- 🚨 `bin/fm-shadow.sh:461` - `recheck_source` is the last source check before `same_output` or `swap_replica`. A source file changed immediately afterward—especially an ignored operational file that Git does not mark dirty—can leave the destination stale while the command reports success, or publish a stale stage. Hold a source-side lock or enforce a final source/stage transaction boundary before installation.

🔧 Fix: Captain: preserve recovery edits and close shadow races
3 issues (2 errors, 1 warning) still open:
- 🚨 `bin/fm-shadow.sh:527` - The new source lock only serializes other `fm-shadow.sh` processes; no source mutation path acquires or honors it. A normal writer can change an ignored operational file after `recheck_source` and before the success path completes, leaving a stale destination while reporting success. Use a shared source mutation boundary or a filesystem snapshot if exact mirroring is required.
- 🚨 `bin/fm-shadow.sh:171` - The source cleanliness checks use `[ -z &#34;$(git ... status ...)&#34; ]`, which discards Git&#39;s exit status. If `git status` fails with empty stdout, the source is treated as clean and replication can continue despite an unknown source state. Capture and check the command status explicitly in `check_source`, `recheck_source`, and `source_matches_replica`.
- ⚠️ `docs/shadow.md:25` - The new source lock is persistent and never cleared automatically, but the operator documentation only describes `.shadow.lock` at the destination parent. After an interrupted run, scheduled executions can remain blocked by `.shadow-source-lock.&lt;source-name&gt;` with no documented safe inspection and cleanup procedure.

🔧 Fix: Captain: seal shadow snapshots and document stale-lock recovery
4 issues (2 errors, 2 warnings) still open:
- 🚨 `bin/fm-shadow.sh:515` - After `source_matches_replica` returns, an external writer can change an ignored source file before transaction cleanup, so the command succeeds with a stale destination. The source lock only serializes shadow processes; enforce a shared source-writer lock or immutable publication boundary.
- 🚨 `bin/fm-shadow.py:135` - Manifest and policy sidecars are accepted through `is_file()` and reads that follow symlinks. A tampered control directory can therefore point metadata outside the self-contained integrity boundary; reject symlinks before reading either file.
- ⚠️ `bin/fm-shadow.sh:256` - A complete source snapshot is created for every run, but only the current process cleanup removes it. Interrupted runs leave `.shadow-source-snapshot.*` directories permanently, allowing repeated interruptions to exhaust the destination parent&#39;s disk.
- ⚠️ `bin/fm-replicante.py:353` - Snapshot paths such as `a//b` or `./a` pass validation but normalize to different filesystem paths during restore. Verification can accept such a manifest while restore materializes a different path; require canonical relative POSIX paths.

🔧 Fix: Captain: seal snapshots, reclaim leaks, and canonicalize backup paths
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-shadow.test.sh`
- `bash tests/fm-replicante.test.sh`
- `bash tests/fm-test-run.test.sh`
- `bash tests/fm-documentation-audiences.test.sh`
- `Fixture-only shadow publish, exact comparison, idempotency, symlink preservation, update, and deletion flow`
- `Fixture-only replicante incremental snapshots, historical restore, deletion retention, verification, and restore testing`
- `Non-fixture override refusal check`
- `git status --short --branch`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
