### PR TITLE
fix(bin): verify resolved decision keys leave the fold

### DIFF
--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -52,12 +52,12 @@
 # ledger per status_open_decisions (bin/fm-classify-lib.sh) or fm-send refuses
 # before sending, so a mistyped key cannot deliver an answer while silently
 # orphaning the decision. A failed or unconfirmed send never closes a key; a
-# delivered answer whose closing append fails exits nonzero with the exact
-# manual close command, leaving the decision open to re-surface (the safe
-# direction). A send without the flag never closes anything: a routine steer,
-# working:, or done: event still cannot clear a captain decision. The flag is
-# refused with --key, with an explicit backend target (no task ledger in this
-# home), and with an empty message.
+# delivered answer whose closing append fails or does not close the folded key
+# exits nonzero with the manual or owner close path, leaving the decision open
+# to re-surface (the safe direction). A send without the flag never closes
+# anything: a routine steer, working:, or done: event still cannot clear a
+# captain decision. The flag is refused with --key, with an explicit backend
+# target (no task ledger in this home), and with an empty message.
 #
 # After a successful text submit fm-send pauses FM_SEND_SETTLE seconds (default 1,
 # 0 disables) before returning: submit confirmation only proves the text was
@@ -376,10 +376,10 @@ if [ -n "$RESOLVE_KEYS" ]; then
 fi
 
 # Close each answered decision in this home's ledger, only after delivery is
-# fully confirmed. An append failure exits nonzero with the manual close
-# command; the decision then stays open and re-surfaces, never silently lost.
+# fully confirmed. An append or folded-close failure exits nonzero with the
+# manual or owner close path; the decision then stays open and re-surfaces.
 fm_send_close_resolved_keys() {  # <answer-text>
-  local note=$1 k line
+  local note=$1 k line resolve_open_set
   note=$(printf '%s' "$note" | tr '\n\r\t' '   ' | LC_ALL=C tr -d '\000-\037\177')
   for k in $RESOLVE_KEYS; do
     line="resolved [key=$k]: answered: $note"
@@ -388,6 +388,13 @@ fm_send_close_resolved_keys() {  # <answer-text>
       echo "error: the answer was delivered to $T, but decision key '$k' could not be closed in $RESOLVE_STATUS_FILE. Close it manually with: echo 'resolved [key=$k]: <how it was answered>' >> $RESOLVE_STATUS_FILE - do not resend the answer." >&2
       return 1
     fi
+    resolve_open_set=$(status_open_decisions "$RESOLVE_STATUS_FILE")
+    case "$resolve_open_set" in
+      "$k"$'\t'*|*$'\n'"$k"$'\t'*)
+        echo "error: the answer was delivered to $T, but decision key '$k' could not be closed in $RESOLVE_STATUS_FILE. Close it through its owning workflow or manually with a fold-valid 'resolved [key=$k]: ...' line in $RESOLVE_STATUS_FILE - do not resend the answer." >&2
+        return 1
+        ;;
+    esac
   done
 }
 

--- a/tests/fm-send-resolve-key.test.sh
+++ b/tests/fm-send-resolve-key.test.sh
@@ -21,6 +21,8 @@
 #      message crosses the stubbed ssh transport while the close is the same
 #      local ledger append; a failed transport closes nothing.
 #   7. Flag misuse (--key, empty message, explicit backend target) refuses.
+#   8. A reserved key that rejects the generic closing note fails loudly after
+#      delivery and stays open, while an ordinary key still closes normally.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -130,6 +132,31 @@ test_answer_send_closes_open_decision() {
     fail "the answered decision still lists as open: $out"
   fi
   pass "fm-send --resolve-key: the answer send itself closes the open decision"
+}
+
+test_rejected_close_fails_after_delivery() {
+  local dir fb log home err rc out
+  dir="$TMP_ROOT/rejected-close"; mkdir -p "$dir"
+  fb=$(make_stubs "$dir"); log="$dir/send.log"; err="$dir/send.err"
+  home=$(setup_home rejected-close)
+  fm_write_meta "$home/state/t1-rejected.meta" "window=sess:fm-t1-rejected" "kind=ship"
+  printf 'blocked [key=pending-reply-abc]: pending-reply-abc: delivery missed\n' \
+    > "$home/state/t1-rejected.status"
+
+  : > "$log"
+  env PATH="$fb:$PATH" \
+    FM_ROOT_OVERRIDE="$home" FM_HOME="$home" FM_SEND_LOG="$log" FM_SEND_SETTLE=0 \
+    "$SEND" t1-rejected --resolve-key pending-reply-abc "done" >/dev/null 2>"$err"; rc=$?
+  [ "$rc" -ne 0 ] || fail "a reserved key whose close is rejected should exit nonzero"
+  assert_contains "$(cat "$log")" "done" "the answer should be delivered before close verification fails"
+  assert_contains "$(cat "$err")" "answer was delivered" "the error should confirm delivery"
+  assert_contains "$(cat "$err")" "could not be closed" "the error should name the close failure"
+  assert_contains "$(cat "$err")" "do not resend the answer" "the error should prevent duplicate delivery"
+
+  out=$(drain_out "$home")
+  printf '%s' "$out" | grep -F '[key=pending-reply-abc]' >/dev/null \
+    || fail "the rejected reserved-key close disappeared from OPEN DECISIONS: $out"
+  pass "fm-send --resolve-key: a fold-rejected close fails after delivery and stays open"
 }
 
 test_answer_starts_work_never_orphans() {
@@ -396,6 +423,7 @@ test_flag_misuse_refuses() {
 }
 
 test_answer_send_closes_open_decision
+test_rejected_close_fails_after_delivery
 test_answer_starts_work_never_orphans
 test_routine_steer_never_closes
 test_not_open_key_refuses_before_send


### PR DESCRIPTION
`fm-send --resolve-key` could deliver an answer and exit 0 while the decision stayed open: the closing `resolved [key=...]` append succeeds as a write, but reserved keys (e.g. pending-reply records) reject the generic closing note, so the key silently stayed in OPEN DECISIONS.

After the confirmed-delivery close append, fm-send now re-folds the ledger and exits nonzero when the key is still open, printing the owner/manual close path and warning not to resend the delivered answer. Regression test seeds a reserved key and proves: answer delivered exactly once, nonzero exit, key stays visible.