### PR TITLE
feat: support OMP as a verified harness

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -84,7 +84,7 @@ The daemon constructs every current injection as the `away-supervisor` kind owne
 The bare `FM_INJECT_MARK` form remains accepted for legacy daemon escalations during rollout.
 U+2063 has no normal keyboard keystroke and survives terminal transport as UTF-8 text.
 This is how firstmate tells a daemon escalation apart from a real message in the same pane.
-The operational prefix travels with the message text; it does not rely on harness-level typed-vs-injected detection, which is not portable across claude, codex, opencode, pi, pi-signed, grok, and kimi.
+The operational prefix travels with the message text; it does not rely on harness-level typed-vs-injected detection, which is not portable across claude, codex, opencode, pi, pi-signed, omp, grok, and kimi.
 
 ## Busy-guard and composer guard
 

--- a/.agents/skills/firstmate-orca/SKILL.md
+++ b/.agents/skills/firstmate-orca/SKILL.md
@@ -13,7 +13,7 @@ It does not replace `AGENTS.md`, `docs/orca-backend.md`, or `harness-adapters`.
 
 Orca is a runtime backend, not an agent harness.
 The runtime backend owns the task endpoint and, for Orca, the task worktree.
-The harness is the agent process launched inside that endpoint, such as `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, or `kimi`.
+The harness is the agent process launched inside that endpoint, such as `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `omp`, `grok`, or `kimi`.
 Load `harness-adapters` for harness-specific launch, interrupt, resume, trust-dialog, and skill-invocation facts.
 
 Implementation details, metadata fields, teardown guarantees, and limitations live in `docs/orca-backend.md`.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -320,7 +320,7 @@ When a secondmate is launched on Pi or pi-signed, `fm-spawn.sh --secondmate` lau
 OMP is distributed as a Bun script.
 Detection accepts only the positive `OMPCODE=1` marker, the exact `omp` executable, or Bun whose script argv is an exact `omp` path component; later prompt text never counts.
 A Firstmate-launched OMP worker inherited `CLAUDECODE`, so `OMPCODE=1` must precede foreign markers and the launch template removes known foreign harness markers.
-Because that precedence outranks every other marker, the reciprocal also holds: `fm-spawn.sh` strips an inherited `OMPCODE` from every launch whose resolved harness is not `omp`, raw escape-hatch commands included, so no other adapter's worker can report `omp` against its own recorded harness.
+Because that precedence outranks every other marker, the reciprocal also holds: `fm-spawn.sh` prefixes `unset OMPCODE;` to every launch whose resolved harness is not `omp`, raw escape-hatch commands included, so no other adapter's worker can report `omp` against its own recorded harness.
 Launch keeps the encoded brief as one positional message, loads one per-task extension from `state/`, and starts with no observed trust or permission dialog.
 Herdr reports native `working` and `idle` states for OMP.
 OMP 17.2.12 leaves its Herdr registration at `idle` after `/exit` returns to the nested worktree shell, so the Herdr backend treats only the separately proven one-process shell shape as agent-free.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-adapters
-description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, kimi, and muse.
+description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, kimi, muse, and OMP.
 user-invocable: false
 metadata:
   internal: true
@@ -43,6 +43,7 @@ If the captain asks for a new harness, propose verifying it first: spawn a trivi
 ## Detection
 
 `bin/fm-harness.sh` prints firstmate's own harness, using verified env markers first and then process ancestry.
+OMP 17.2.12 exports `OMPCODE=1`; that positive marker wins over inherited foreign markers, and its exact Bun-script process is recognized by ancestry and may own the session lock.
 Within the Pi family, only the exact launch-boundary marker `FM_PI_HARNESS=pi-signed` alongside `PI_CODING_AGENT=true` selects the signed identity; unmarked shared launcher ancestry remains `pi`.
 `bin/fm-harness.sh crew` resolves the effective crewmate harness from `config/crew-harness` (absent or `default` -> own).
 `bin/fm-harness.sh secondmate` resolves the secondmate-launch harness through the chain `config/secondmate-harness` -> `config/crew-harness` -> own, so an unset `config/secondmate-harness` matches the crew harness.
@@ -56,9 +57,9 @@ Use that value for interrupt, exit, resume, and skill-invocation facts.
 
 ## Primary turn-end guard
 
-The primary integrations for `claude`, `codex`, `opencode`, `pi`, `pi-signed`, and `grok` have empirically validated hook paths for the "no turn ends blind" guard.
+The primary integrations for `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, and `omp` have empirically validated hook paths for the "no turn ends blind" guard.
 `claude` and `codex` block directly through Stop hooks that preserve exit status 2 and stderr from `bin/fm-turnend-guard.sh`.
-`opencode`, `pi`, and `pi-signed` expose passive lifecycle callbacks and force one bounded follow-up when the shared predicate blocks.
+`opencode`, `pi`, `pi-signed`, and `omp` expose passive lifecycle callbacks and force one bounded follow-up when the shared predicate blocks.
 Grok selects native blocking or its pre-native bounded resume fallback from the exact running Stop payload; [`docs/turnend-guard.md`](../../../docs/turnend-guard.md) owns that contract.
 Kimi is outside the primary turn-end guard scope, while `docs/turnend-guard.md` owns its separate guarded global hook for crew wake signals.
 muse is CREWMATE/SCOUT ONLY and has no primary integration at all: its plugin engine (its only hook surface) is disabled in the default build, and its Claude-compatible hook dialect names `asyncRewake` and model reawakening as explicitly unsupported, which is exactly what a firstmate primary's turn-end supervision needs.
@@ -69,9 +70,9 @@ When changing any primary turn-end hook, validate the real harness behavior in a
 
 ## Primary pre-arm (PreToolUse) seatbelt
 
-The primary integrations for `claude`, `codex`, `opencode`, `pi`, `pi-signed`, and `grok` also have wired PreToolUse-equivalent hooks that deny a watcher-arm anti-pattern (shell `&`, truncating pipe, bundling, broad `pkill -f fm-watch`) before it runs.
+The primary integrations for `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, and `omp` also have wired PreToolUse-equivalent hooks that deny a watcher-arm anti-pattern (shell `&`, truncating pipe, bundling, broad `pkill -f fm-watch`) before it runs.
 `claude` and `codex` block directly through PreToolUse hooks; `grok` blocks the same way but requires every `$VAR` reference in its hook `command` string to carry an inline `:-default` or it fails to launch the hook entirely.
-`opencode`, `pi`, and `pi-signed` block by throwing from `tool.execute.before` / returning `{block: true}` from `tool_call`.
+`opencode`, `pi`, `pi-signed`, and `omp` block by throwing from `tool.execute.before` / returning `{block: true}` from `tool_call`.
 The exact hook files, commands, output-shaping quirks (Claude Code only honors the deny when stdout is empty), and validation transcripts are owned by `docs/arm-pretool-check.md`.
 When changing any watcher-arm PreToolUse hook, validate the real harness behavior in a scratch project before trusting it, then update that doc.
 ## Primary delegation-shape guard
@@ -99,7 +100,8 @@ Do not substitute another harness's wait shape when resuming supervision.
 Claude's Stop `asyncRewake` hook (`bin/fm-claude-stop-autoarm.sh`) owns tokenless re-arm around `bin/fm-watch-arm.sh`, and Grok uses tracked background-notify cycles around `bin/fm-watch-arm.sh`.
 Codex uses bounded foreground checkpoints through `bin/fm-watch-checkpoint.sh` because Codex cannot reason while a foreground tool call is running.
 OpenCode uses `.opencode/plugins/fm-primary-watch-arm.js`, which coordinates with the turn-end guard plugin and wakes the TUI with `client.session.promptAsync`.
-Pi and pi-signed use the tracked `.pi/extensions/fm-primary-turnend-guard.ts` plus the tracked `.pi/extensions/fm-primary-pi-watch.ts`, both project-local extensions the Pi engine auto-discovers once trusted.
+Pi and pi-signed use the tracked `.pi/extensions/fm-primary-turnend-guard.ts` plus `.pi/extensions/fm-primary-pi-watch.ts`.
+OMP auto-loads tracked `.omp/extensions/` entrypoints that reuse the same Pi-family core while selecting OMP's `agent_end`, session-switch, marker, and watcher-tool vocabulary.
 When changing any primary watcher adapter, update `docs/supervision-protocols/`, `docs/turnend-guard.md` if a shared idle or turn-end hook changed, and the relevant concise fact below.
 
 ## Launch profile axes
@@ -123,6 +125,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'` | Verified on codex-cli 0.142.1. The installed binary schema contains `model_reasoning_effort`, the active config uses it, and the bundled model catalog advertises only low/medium/high/xhigh. `max` is omitted. |
 | grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
 | pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
+| omp | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-08-09 on OMP 17.2.12. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
 | kimi | `--model <model>` | none | Verified 2026-07-25 on Kimi Code CLI 0.29.1. |
 | muse | `--model <model>` | `--reasoning-effort <low\|medium\|high\|xhigh>`, and `ultra` only for an explicit `max` | Verified 2026-08-05 on Muse Code 0.1.0-R708.1. The flag accepts `none\|minimal\|low\|medium\|high\|xhigh\|ultra` and defaults to `high`. `ultra` is muse's max-class level, so it is reachable only through an explicit captain `max`, never from the generic fallback; `none` and `minimal` sit below the shared vocabulary and stay unreachable. |
@@ -141,6 +144,7 @@ Use the discovery surface in the current authenticated environment because suppo
 | codex | Open the current interactive session's `/model` picker. |
 | opencode | Run `opencode models [provider]`, which lists available provider/model identifiers. |
 | pi / pi-signed | Run the selected executable as `<executable> --list-models [search]`; Pi's installed `docs/models.md` owns how built-in, extension-registered, and custom provider/model entries reach that list. |
+| omp | Run `omp --list-models [search]`; the current CLI help owns how built-in and configured model entries reach that list. |
 | grok | Run `grok models`, which lists the models available to the current Grok installation and account. |
 | kimi | Run `kimi provider list --json`, which lists the current provider and model configuration. |
 
@@ -160,6 +164,7 @@ Natural language is acceptable if uncertain.
 - codex: `$<skill>`, for example `$no-mistakes`; `/<skill>` is claude-only and codex rejects it as "Unrecognized command".
 - opencode: no separate verified skill invocation beyond normal slash-command behavior; use natural language if the exact skill command is uncertain.
 - pi and pi-signed: no separate verified skill invocation beyond normal command behavior; use natural language if the exact skill command is uncertain.
+- omp: no separate verified skill invocation beyond normal command behavior; use natural language if the exact skill command is uncertain.
 - grok: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified end to end: grok discovers the user-level `no-mistakes` skill, `/no-mistakes` invokes it, and grok drives a real `no-mistakes axi run`. Like codex's `$`/`/` popups, typing `/<skill>` opens grok's slash-autocomplete, so a too-fast Enter selects the popup entry instead of sending, and for an argument-taking command (like `/no-mistakes`'s optional task-first argument) that first Enter only expands the popup selection into an argument-hint placeholder rather than submitting - a genuine second Enter is required (see the grok section below for the 2026-07-03 incident and fix). `fm_tmux_submit_core`'s retried Enter (used by `fm-send` on the tmux backend) handles this through the structural composer reader; the herdr backend needed a dedicated fix (`fm_backend_herdr_composer_state`, docs/herdr-backend.md) because its prior delta-based verification false-positived on that same popup-close content change.
 - kimi: `/<skill>`, for example `/no-mistakes`.
 
@@ -300,6 +305,31 @@ Pi's primary watcher protocol also requires the tracked `.pi/extensions/fm-prima
 The model arms through `fm_watch_arm_pi`, never a foreground bash arm; the watcher tool result and clean-exit fallback are owned by `docs/supervision-protocols/pi.md`.
 `bin/fm-session-start.sh` reports when the live Pi-family session has not loaded both the turn-end guard and watcher extensions, and points at the selected executable after project trust as the fix, with `-e` as a trust-free fallback.
 When a secondmate is launched on Pi or pi-signed, `fm-spawn.sh --secondmate` launches the selected executable with both `-e .pi/extensions/fm-primary-turnend-guard.ts` and `-e .pi/extensions/fm-primary-pi-watch.ts`, both already present in the secondmate home's git worktree.
+
+## OMP (VERIFIED 2026-08-09, OMP 17.2.12)
+
+| Fact | Value |
+|---|---|
+| Busy state | Per-task extension events: `agent_start` opens a run and `agent_end` closes it after `session_stop`; `agent_end` also publishes the turn-end notification. |
+| Exit command | `/exit` |
+| Interrupt | single Escape; the cancelled tool reports `[Command cancelled]`, the agent returns idle, and the composer is empty. |
+| Autonomy | `--approval-mode yolo` |
+| Env marker | `OMPCODE=1`, verified in tool subprocesses. |
+| Skill invocation | No separate verified command; use natural language. |
+
+OMP is distributed as a Bun script.
+Detection accepts only the positive `OMPCODE=1` marker, the exact `omp` executable, or Bun whose script argv is an exact `omp` path component; later prompt text never counts.
+A Firstmate-launched OMP worker inherited `CLAUDECODE`, so `OMPCODE=1` must precede foreign markers and the launch template removes known foreign harness markers.
+Launch keeps the encoded brief as one positional message, loads one per-task extension from `state/`, and starts with no observed trust or permission dialog.
+Herdr reports native `working` and `idle` states for OMP.
+OMP 17.2.12 leaves its Herdr registration at `idle` after `/exit` returns to the nested worktree shell, so the Herdr backend treats only the separately proven one-process shell shape as agent-free.
+Relaunch uses Firstmate's deterministic brief-based replacement; no private-session resume contract is required.
+
+**Primary-session guard fact.**
+OMP auto-loads `.omp/extensions/fm-primary-turnend-guard.ts` and `.omp/extensions/fm-primary-omp-watch.ts`.
+The wrappers reuse the Pi-family implementations, which select OMP's `agent_end`, `session_switch`, `.omp-*` marker, and `fm_watch_arm_omp` vocabulary from `OMPCODE=1`.
+The primary supervision contract is `docs/supervision-protocols/omp.md`.
+An OMP secondmate launch passes both primary extensions explicitly with `-e`.
 
 ## grok (VERIFIED 2026-06-29, grok 0.2.73; slash-submit re-verified 2026-07-03 on 0.2.82; reasoning-effort ceiling re-verified 2026-07-13 on 0.2.99; exit paths re-verified 2026-07-19 on grok 0.2.103)
 

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -328,7 +328,8 @@ Relaunch uses Firstmate's deterministic brief-based replacement; no private-sess
 
 **Primary-session guard fact.**
 OMP auto-loads `.omp/extensions/fm-primary-turnend-guard.ts` and `.omp/extensions/fm-primary-omp-watch.ts`.
-The wrappers reuse the Pi-family implementations, which select OMP's `agent_end`, `session_switch`, `.omp-*` marker, and `fm_watch_arm_omp` vocabulary from `OMPCODE=1`.
+The wrappers reuse the Pi-family implementations and pass the harness as an argument, which is what selects OMP's `agent_end`, `session_switch`, `.omp-*` marker, and `fm_watch_arm_omp` vocabulary.
+Loading a `.omp/extensions/` wrapper is the authoritative OMP signal because only OMP discovers that directory; the shared core never reads `OMPCODE` for this, so a Pi primary that inherited the marker still gets Pi's `agent_settled`, `.pi-*` markers, and `fm_watch_arm_pi`.
 The primary supervision contract is `docs/supervision-protocols/omp.md`.
 An OMP secondmate launch passes both primary extensions explicitly with `-e`.
 

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -320,6 +320,7 @@ When a secondmate is launched on Pi or pi-signed, `fm-spawn.sh --secondmate` lau
 OMP is distributed as a Bun script.
 Detection accepts only the positive `OMPCODE=1` marker, the exact `omp` executable, or Bun whose script argv is an exact `omp` path component; later prompt text never counts.
 A Firstmate-launched OMP worker inherited `CLAUDECODE`, so `OMPCODE=1` must precede foreign markers and the launch template removes known foreign harness markers.
+Because that precedence outranks every other marker, the reciprocal also holds: `fm-spawn.sh` strips an inherited `OMPCODE` from every launch whose resolved harness is not `omp`, raw escape-hatch commands included, so no other adapter's worker can report `omp` against its own recorded harness.
 Launch keeps the encoded brief as one positional message, loads one per-task extension from `state/`, and starts with no observed trust or permission dialog.
 Herdr reports native `working` and `idle` states for OMP.
 OMP 17.2.12 leaves its Herdr registration at `idle` after `/exit` returns to the nested worktree shell, so the Herdr backend treats only the separately proven one-process shell shape as agent-free.

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ __pycache__/
 *.pyc
 .env
 config/
+
+.pi-subagents/

--- a/.omp/extensions/fm-primary-omp-watch.ts
+++ b/.omp/extensions/fm-primary-omp-watch.ts
@@ -1,0 +1,6 @@
+// OMP entrypoint for Firstmate's shared Pi-family watcher bridge.
+import registerPiFamilyPrimaryWatch from "../../.pi/extensions/fm-primary-pi-watch.ts";
+
+export default function (omp: any): void {
+  registerPiFamilyPrimaryWatch(omp);
+}

--- a/.omp/extensions/fm-primary-omp-watch.ts
+++ b/.omp/extensions/fm-primary-omp-watch.ts
@@ -1,6 +1,8 @@
-// OMP entrypoint for Firstmate's shared Pi-family watcher bridge.
+// OMP entrypoint for Firstmate's shared Pi-family watcher bridge. Loading THIS
+// file is the authoritative OMP signal - only OMP discovers .omp/extensions/ -
+// so the harness travels as an argument rather than an inheritable env marker.
 import registerPiFamilyPrimaryWatch from "../../.pi/extensions/fm-primary-pi-watch.ts";
 
 export default function (omp: any): void {
-  registerPiFamilyPrimaryWatch(omp);
+  registerPiFamilyPrimaryWatch(omp, "omp");
 }

--- a/.omp/extensions/fm-primary-turnend-guard.ts
+++ b/.omp/extensions/fm-primary-turnend-guard.ts
@@ -1,0 +1,6 @@
+// OMP entrypoint for Firstmate's shared Pi-family turn-end guard.
+import registerPiFamilyPrimaryTurnendGuard from "../../.pi/extensions/fm-primary-turnend-guard.ts";
+
+export default function (omp: any): void {
+  registerPiFamilyPrimaryTurnendGuard(omp);
+}

--- a/.omp/extensions/fm-primary-turnend-guard.ts
+++ b/.omp/extensions/fm-primary-turnend-guard.ts
@@ -1,6 +1,8 @@
-// OMP entrypoint for Firstmate's shared Pi-family turn-end guard.
+// OMP entrypoint for Firstmate's shared Pi-family turn-end guard. Loading THIS
+// file is the authoritative OMP signal - only OMP discovers .omp/extensions/ -
+// so the harness travels as an argument rather than an inheritable env marker.
 import registerPiFamilyPrimaryTurnendGuard from "../../.pi/extensions/fm-primary-turnend-guard.ts";
 
 export default function (omp: any): void {
-  registerPiFamilyPrimaryTurnendGuard(omp);
+  registerPiFamilyPrimaryTurnendGuard(omp, "omp");
 }

--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -83,8 +83,27 @@ const fmRoot = process.env.FM_ROOT_OVERRIDE || root;
 const state = process.env.FM_STATE_OVERRIDE || `${fmHome}/state`;
 const config = process.env.FM_CONFIG_OVERRIDE || `${fmHome}/config`;
 const armScript = `${fmRoot}/bin/fm-watch-arm.sh`;
-const marker = `${state}/.pi-watch-extension-loaded`;
-const extensionVersion = `sha256:${createHash("sha256").update(readFileSync(extensionFile)).digest("hex")}`;
+type PrimaryHarness = "pi" | "omp";
+let primaryHarnessSlug: PrimaryHarness = "pi";
+let primaryHarnessLabel = "Pi";
+let watchToolName = "fm_watch_arm_pi";
+let watchCommandName = "fm-watch-arm-pi";
+let marker = `${state}/.pi-watch-extension-loaded`;
+let extensionVersion = `sha256:${createHash("sha256").update(readFileSync(extensionFile)).digest("hex")}`;
+
+function selectPrimaryHarness(harness: PrimaryHarness): void {
+  primaryHarnessSlug = harness;
+  primaryHarnessLabel = harness === "omp" ? "OMP" : "Pi";
+  watchToolName = `fm_watch_arm_${harness}`;
+  watchCommandName = `fm-watch-arm-${harness}`;
+  repairOnlyHint = `call ${watchToolName} again only after a later notification says the cycle is missing, failed, or unhealthy`;
+  shuttingDownMessage = `watcher: not armed - ${primaryHarnessLabel} session is shutting down`;
+  marker = `${state}/.${harness}-watch-extension-loaded`;
+  const identityFile = harness === "omp"
+    ? `${root}/.omp/extensions/fm-primary-omp-watch.ts`
+    : extensionFile;
+  extensionVersion = `sha256:${createHash("sha256").update(readFileSync(identityFile)).digest("hex")}`;
+}
 const retryBaseMs = positiveInteger("FM_WATCH_REARM_RETRY_BASE_MS", 250);
 const retryMaxMs = positiveInteger("FM_WATCH_REARM_RETRY_MAX_MS", 4000);
 const retryLimit = positiveInteger("FM_WATCH_REARM_RETRY_LIMIT", 5);
@@ -96,8 +115,8 @@ const armReadyTimeoutMs = positiveInteger(
   process.platform === "win32" ? 35000 : 12000,
 );
 const armRetireTimeoutMs = positiveInteger("FM_WATCH_ARM_RETIRE_TIMEOUT_MS", 1000);
-const repairOnlyHint = "call fm_watch_arm_pi again only after a later notification says the cycle is missing, failed, or unhealthy";
-const shuttingDownMessage = "watcher: not armed - Pi session is shutting down";
+let repairOnlyHint = `call ${watchToolName} again only after a later notification says the cycle is missing, failed, or unhealthy`;
+let shuttingDownMessage = `watcher: not armed - ${primaryHarnessLabel} session is shutting down`;
 
 let nextGenerationId = 0;
 let activeGeneration: SessionGeneration | null = null;
@@ -161,7 +180,7 @@ function classifyClose(stdout: string, stderr: string, code: number | null, sign
   if (healthy) {
     return {
       kind: "failure",
-      message: `watcher: FAILED - Pi extension arm child found an external healthy watcher instead of owning wake delivery\n${healthy}`,
+      message: `watcher: FAILED - ${primaryHarnessLabel} extension arm child found an external healthy watcher instead of owning wake delivery\n${healthy}`,
     };
   }
   const failed = combined.split(/\r?\n/).find((line) => /^watcher: FAILED/.test(line));
@@ -169,7 +188,7 @@ function classifyClose(stdout: string, stderr: string, code: number | null, sign
   if (signal) {
     return {
       kind: "failure",
-      message: `watcher: FAILED - Pi extension arm child ended from ${signal}${combined ? `\n${combined}` : ""}`,
+      message: `watcher: FAILED - ${primaryHarnessLabel} extension arm child ended from ${signal}${combined ? `\n${combined}` : ""}`,
     };
   }
   if (code && code !== 0) {
@@ -180,7 +199,7 @@ function classifyClose(stdout: string, stderr: string, code: number | null, sign
   }
   return {
     kind: "failure",
-    message: "watcher: FAILED - Pi extension arm cycle ended without an actionable reason",
+    message: `watcher: FAILED - ${primaryHarnessLabel} extension arm cycle ended without an actionable reason`,
   };
 }
 
@@ -217,7 +236,7 @@ const cleanupOnProcessExit = () => {
 };
 process.once("exit", cleanupOnProcessExit);
 
-export default function (pi: ExtensionAPI) {
+function registerPrimaryWatchExtension(pi: ExtensionAPI) {
   let generation = createGeneration();
   activateGeneration(generation);
 
@@ -299,32 +318,32 @@ export default function (pi: ExtensionAPI) {
       const successorChild = owner.child;
       if (replacement.ok && successorChild && await waitForReadiness(successorChild)) return "";
       if (replacement.ok) {
-        failure = "watcher: FAILED - Pi extension could not verify a ready successor watcher";
+        failure = `watcher: FAILED - ${primaryHarnessLabel} extension could not verify a ready successor watcher`;
         if (!(await retireArm(successorChild))) {
-          return `${failure}\nwatcher: FAILED - Pi extension could not restore watcher continuity because the unready successor arm did not exit within ${armRetireTimeoutMs}ms`;
+          return `${failure}\nwatcher: FAILED - ${primaryHarnessLabel} extension could not restore watcher continuity because the unready successor arm did not exit within ${armRetireTimeoutMs}ms`;
         }
       } else {
         failure = /(?:read-only|no live session)/.test(replacement.message)
-          ? `watcher: FAILED - Pi extension cannot restore continuity because this session no longer owns the lock\n${replacement.message}`
-          : `watcher: FAILED - Pi extension could not start the successor watcher cycle\n${replacement.message}`;
+          ? `watcher: FAILED - ${primaryHarnessLabel} extension cannot restore continuity because this session no longer owns the lock\n${replacement.message}`
+          : `watcher: FAILED - ${primaryHarnessLabel} extension could not start the successor watcher cycle\n${replacement.message}`;
         if (/(?:read-only|no live session)/.test(replacement.message)) break;
       }
       if (attempt === retryLimit) break;
       await waitForRetry(attempt + 1);
     }
-    return `${failure}\nwatcher: FAILED - Pi extension could not restore watcher continuity after ${retryLimit} retries`;
+    return `${failure}\nwatcher: FAILED - ${primaryHarnessLabel} extension could not restore watcher continuity after ${retryLimit} retries`;
   }
 
   function scheduleRetry(owner: SessionGeneration, message: string, predecessorArmPid: string): void {
     if (!generationIsLive(owner) || owner.child || owner.retryTimer) return;
     const ownership = lockOwnership();
     if (ownership !== "owned") {
-      surfaceFailure(owner, `watcher: FAILED - Pi extension cannot restore continuity because this session no longer owns the lock\n${message}`);
+      surfaceFailure(owner, `watcher: FAILED - ${primaryHarnessLabel} extension cannot restore continuity because this session no longer owns the lock\n${message}`);
       return;
     }
     owner.retryFailures += 1;
     if (owner.retryFailures > retryLimit) {
-      surfaceFailure(owner, `watcher: FAILED - Pi extension could not restore watcher continuity after ${retryLimit} retries\n${message}`);
+      surfaceFailure(owner, `watcher: FAILED - ${primaryHarnessLabel} extension could not restore watcher continuity after ${retryLimit} retries\n${message}`);
       return;
     }
     const timer = setTimeout(() => {
@@ -332,7 +351,7 @@ export default function (pi: ExtensionAPI) {
       if (!generationIsLive(owner)) return;
       const result = startArm(owner, predecessorArmPid);
       if (!result.ok) {
-        surfaceFailure(owner, `watcher: FAILED - Pi extension could not launch a continuity retry\n${result.message}`);
+        surfaceFailure(owner, `watcher: FAILED - ${primaryHarnessLabel} extension could not launch a continuity retry\n${result.message}`);
       }
     }, retryDelay(owner.retryFailures));
     timer.unref();
@@ -346,20 +365,20 @@ export default function (pi: ExtensionAPI) {
     if (ownership === "missing") {
       return {
         ok: false,
-        message: "watcher: not armed - no live session holds the lock; run bin/fm-session-start.sh to reclaim it, then call fm_watch_arm_pi to re-arm",
+        message: `watcher: not armed - no live session holds the lock; run bin/fm-session-start.sh to reclaim it, then call ${watchToolName} to re-arm`,
       };
     }
     markLoaded();
     if (owner.child) {
       return {
         ok: true,
-        message: `watcher: unchanged - Pi extension already owns an arm child; no manual re-arm needed; ${repairOnlyHint}`,
+        message: `watcher: unchanged - ${primaryHarnessLabel} extension already owns an arm child; no manual re-arm needed; ${repairOnlyHint}`,
       };
     }
     if (owner.retryTimer) {
       return {
         ok: true,
-        message: `watcher: unchanged - Pi extension already owns a scheduled continuity retry; no manual re-arm needed; ${repairOnlyHint}`,
+        message: `watcher: unchanged - ${primaryHarnessLabel} extension already owns a scheduled continuity retry; no manual re-arm needed; ${repairOnlyHint}`,
       };
     }
     const id = ++owner.seq;
@@ -445,25 +464,34 @@ export default function (pi: ExtensionAPI) {
       releaseChild();
       if (!generationIsLive(owner)) return;
       if (owner.restoring) return;
-      scheduleRetry(owner, `watcher: FAILED - Pi extension arm child ${id} failed: ${error.message}`, String(armChild.pid ?? ""));
+      scheduleRetry(owner, `watcher: FAILED - ${primaryHarnessLabel} extension arm child ${id} failed: ${error.message}`, String(armChild.pid ?? ""));
     });
     return {
       ok: true,
-      message: `watcher: started Pi extension arm child ${id}; future ordinary re-arms are automatic; ${repairOnlyHint}`,
+      message: `watcher: started ${primaryHarnessLabel} extension arm child ${id}; future ordinary re-arms are automatic; ${repairOnlyHint}`,
     };
   }
 
-  pi.on?.("session_start", () => {
+  const activateCurrentGeneration = () => {
     if (generation.stopping) generation = createGeneration();
     activateGeneration(generation);
     markLoaded();
-  });
+  };
+  pi.on?.("session_start", activateCurrentGeneration);
+  if (primaryHarnessSlug === "omp") {
+    // OMP emits session_switch, not another session_start, for same-process replacement.
+    const onSessionSwitch = pi.on as unknown as (
+      event: "session_switch",
+      handler: () => void,
+    ) => void;
+    onSessionSwitch.call(pi, "session_switch", activateCurrentGeneration);
+  }
   pi.on?.("session_shutdown", () => {
     stopGeneration(generation);
   });
 
-  pi.registerCommand?.("fm-watch-arm-pi", {
-    description: "Arm firstmate watcher supervision through the Pi extension instead of foreground bash.",
+  pi.registerCommand?.(watchCommandName, {
+    description: `Arm firstmate watcher supervision through the ${primaryHarnessLabel} extension instead of foreground bash.`,
     handler: async (_args, ctx) => {
       const result = startArm(generation);
       ctx.ui.notify(result.message, result.ok ? "info" : "warning");
@@ -471,22 +499,22 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.registerTool?.({
-    name: "fm_watch_arm_pi",
+    name: watchToolName,
     label: "Arm firstmate watcher",
-    description: "Start the first required Pi watcher cycle, or repair one only after a notification says the cycle is missing, failed, or unhealthy. Do not call after ordinary work or ordinary notifications; the Pi extension re-arms automatically. Never run bin/fm-watch-arm.sh through bash.",
-    promptSnippet: "Start the first required Pi watcher cycle or repair a cycle reported missing, failed, or unhealthy; ordinary re-arming is automatic.",
+    description: `Start the first required ${primaryHarnessLabel} watcher cycle, or repair one only after a notification says the cycle is missing, failed, or unhealthy. Do not call after ordinary work or ordinary notifications; the ${primaryHarnessLabel} extension re-arms automatically. Never run bin/fm-watch-arm.sh through bash.`,
+    promptSnippet: `Start the first required ${primaryHarnessLabel} watcher cycle or repair one reported missing, failed, or unhealthy; ordinary re-arming is automatic.`,
     promptGuidelines: [
-      "Call fm_watch_arm_pi only for the first required cycle or after a notification says the cycle is missing, failed, or unhealthy. Do not call it after ordinary work, turn completion, or ordinary signal, stale, check, or heartbeat handling because the Pi extension owns re-arming. Never run bin/fm-watch-arm.sh through bash.",
+      `Call ${watchToolName} only for the first required cycle or after a notification says the cycle is missing, failed, or unhealthy. Do not call it after ordinary work, turn completion, or ordinary signal, stale, check, or heartbeat handling because the ${primaryHarnessLabel} extension owns re-arming. Never run bin/fm-watch-arm.sh through bash.`,
     ],
     parameters: Type.Object({}),
     renderShell: "self",
     renderCall: (_args, theme, context) => {
       if (calmHides("assistant-tool-call")) return new Container();
       if (calmPresentation.stockExportRendering) {
-        return new Text(theme.fg("toolTitle", theme.bold("fm_watch_arm_pi")), 0, 0);
+        return new Text(theme.fg("toolTitle", theme.bold(watchToolName)), 0, 0);
       }
       const state = context.state as WatchToolShellState;
-      state.call = new Text(theme.fg("toolTitle", theme.bold("fm_watch_arm_pi")), 0, 0);
+      state.call = new Text(theme.fg("toolTitle", theme.bold(watchToolName)), 0, 0);
       return refreshWatchToolShell(state, theme, context);
     },
     renderResult: (result, _options, theme, context) => {
@@ -515,4 +543,10 @@ export default function (pi: ExtensionAPI) {
   });
 
   markLoaded();
+}
+
+
+export default function registerPiFamilyPrimaryWatch(pi: ExtensionAPI): void {
+  selectPrimaryHarness(process.env.OMPCODE === "1" ? "omp" : "pi");
+  registerPrimaryWatchExtension(pi);
 }

--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -99,10 +99,16 @@ function selectPrimaryHarness(harness: PrimaryHarness): void {
   repairOnlyHint = `call ${watchToolName} again only after a later notification says the cycle is missing, failed, or unhealthy`;
   shuttingDownMessage = `watcher: not armed - ${primaryHarnessLabel} session is shutting down`;
   marker = `${state}/.${harness}-watch-extension-loaded`;
-  const identityFile = harness === "omp"
-    ? `${root}/.omp/extensions/fm-primary-omp-watch.ts`
-    : extensionFile;
-  extensionVersion = `sha256:${createHash("sha256").update(readFileSync(identityFile)).digest("hex")}`;
+  // The entrypoint alone is a thin re-export, so its bytes never move when the
+  // shared implementation below it changes. Hash the whole load chain, in the
+  // same order bin/fm-session-start.sh hashes it, or a stale in-memory watcher
+  // would keep reporting itself current.
+  const identityFiles = harness === "omp"
+    ? [`${root}/.omp/extensions/fm-primary-omp-watch.ts`, extensionFile]
+    : [extensionFile];
+  const digest = createHash("sha256");
+  for (const file of identityFiles) digest.update(readFileSync(file));
+  extensionVersion = `sha256:${digest.digest("hex")}`;
 }
 const retryBaseMs = positiveInteger("FM_WATCH_REARM_RETRY_BASE_MS", 250);
 const retryMaxMs = positiveInteger("FM_WATCH_REARM_RETRY_MAX_MS", 4000);

--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -552,7 +552,14 @@ function registerPrimaryWatchExtension(pi: ExtensionAPI) {
 }
 
 
-export default function registerPiFamilyPrimaryWatch(pi: ExtensionAPI): void {
-  selectPrimaryHarness(process.env.OMPCODE === "1" ? "omp" : "pi");
+// The LOADED ENTRYPOINT selects the protocol, never an environment marker: a
+// marker is inheritable, so a Pi primary started under a retained OMPCODE would
+// otherwise register OMP's event vocabulary against a runtime that never emits
+// it. Pi auto-loads this file and gets Pi; only .omp/extensions/ passes "omp".
+export default function registerPiFamilyPrimaryWatch(
+  pi: ExtensionAPI,
+  harness: PrimaryHarness = "pi",
+): void {
+  selectPrimaryHarness(harness);
   registerPrimaryWatchExtension(pi);
 }

--- a/.pi/extensions/fm-primary-turnend-guard.ts
+++ b/.pi/extensions/fm-primary-turnend-guard.ts
@@ -18,8 +18,19 @@ const extensionDir = dirname(extensionFile);
 const root = resolve(extensionDir, "../..");
 const fmHome = process.env.FM_HOME || process.env.FM_ROOT_OVERRIDE || root;
 const state = process.env.FM_STATE_OVERRIDE || `${fmHome}/state`;
-const marker = `${state}/.pi-turnend-extension-loaded`;
-const extensionVersion = `sha256:${createHash("sha256").update(readFileSync(extensionFile)).digest("hex")}`;
+type PrimaryHarness = "pi" | "omp";
+let primaryHarness: PrimaryHarness = "pi";
+let marker = `${state}/.pi-turnend-extension-loaded`;
+let extensionVersion = `sha256:${createHash("sha256").update(readFileSync(extensionFile)).digest("hex")}`;
+
+function selectPrimaryHarness(harness: PrimaryHarness): void {
+  primaryHarness = harness;
+  marker = `${state}/.${harness}-turnend-extension-loaded`;
+  const identityFile = harness === "omp"
+    ? `${root}/.omp/extensions/fm-primary-turnend-guard.ts`
+    : extensionFile;
+  extensionVersion = `sha256:${createHash("sha256").update(readFileSync(identityFile)).digest("hex")}`;
+}
 
 function parentPid(pid: string): string {
   const result = spawnSync("ps", ["-o", "ppid=", "-p", pid], { encoding: "utf8" });
@@ -58,16 +69,15 @@ function markLoaded(): void {
   writeFileSync(marker, `${extensionVersion}\n${process.pid}\n`);
 }
 
-// Pi's session_start reasons are startup | reload | new | resume | fork, and a
-// separate session_compact event fires after a compaction. "new" is Pi's /clear
-// (a fresh session in the SAME process, so the fleet lock is still ours), while
-// reload, resume, and fork all keep prior context. bin/fm-sessionstart-run.sh
-// owns what each source means; this maps Pi's vocabulary onto its --source
-// names and injects whatever it prints.
+// Pi's session_start and OMP's session_switch reasons map onto the sources
+// owned by bin/fm-sessionstart-run.sh. "new" is the same-process clear path,
+// while reload, resume, and fork keep prior context.
 const sessionstartDeliveryBytes = 512 * 1024;
-const sessionstartTruncatedMarker =
-  "\n\nPI SESSION-START DELIVERY TRUNCATED - the digest exceeded 512 KiB. " +
-  "Treat omitted context as unread and inspect the named files directly before acting on it.";
+function sessionstartTruncatedMarker(): string {
+  return `\n\n${primaryHarness === "omp" ? "OMP" : "PI"} SESSION-START DELIVERY TRUNCATED - ` +
+    "the digest exceeded 512 KiB. " +
+    "Treat omitted context as unread and inspect the named files directly before acting on it.";
+}
 
 function runSessionstartHook(source: string): Promise<string> {
   return new Promise((resolveResult) => {
@@ -95,7 +105,7 @@ function runSessionstartHook(source: string): Promise<string> {
         return;
       }
       const raw = Buffer.concat(chunks).toString("utf8").trim();
-      resolveResult(truncated ? `${raw}${sessionstartTruncatedMarker}` : raw);
+      resolveResult(truncated ? `${raw}${sessionstartTruncatedMarker()}` : raw);
     });
   });
 }
@@ -166,17 +176,45 @@ function runCdCheck(command: string): Promise<{ code: number; stderr: string }> 
   return runChecker("fm-cd-pretool-check.sh", command);
 }
 
-export default function (pi: ExtensionAPI) {
+function sessionReason(event: unknown): string {
+  if (!event || typeof event !== "object" || !("reason" in event)) return "";
+  return typeof event.reason === "string" ? event.reason : "";
+}
+
+function sessionSource(reason: string): string | undefined {
+  switch (reason) {
+    case "startup": return "startup";
+    case "new": return "clear";
+    case "resume":
+    case "handoff": return "resume";
+    case "fork": return "fork";
+    default: return undefined;
+  }
+}
+
+type CrossHarnessEvent = "session_switch" | "agent_end";
+type CrossHarnessOn = (event: CrossHarnessEvent, handler: (event: unknown) => unknown) => void;
+
+function registerPrimaryTurnendGuard(pi: ExtensionAPI) {
   pi.on?.("session_start", async (event) => {
-    const reason = String((event as { reason?: unknown }).reason ?? "");
-    const source = { startup: "startup", new: "clear", resume: "resume", fork: "fork" }[reason];
+    const source = primaryHarness === "omp"
+      ? "startup"
+      : sessionSource(sessionReason(event));
     markLoaded();
     if (!source) return;
     await injectSessionstart(pi, source);
   });
 
-  // Pi's compaction equivalent. The digest is what a compacted session has just
-  // lost, so re-emitting it here is the point rather than a side effect.
+  if (primaryHarness === "omp") {
+    // OMP's API is a strict event superset of the legacy Pi ExtensionAPI type.
+    const onCrossHarnessEvent = pi.on as unknown as CrossHarnessOn;
+    onCrossHarnessEvent.call(pi, "session_switch", async (event) => {
+      const source = sessionSource(sessionReason(event));
+      if (source) await injectSessionstart(pi, source);
+    });
+  }
+
+  // Pi and OMP share session_compact as the post-compaction notification.
   pi.on?.("session_compact", async () => {
     await injectSessionstart(pi, "compact");
   });
@@ -194,7 +232,7 @@ export default function (pi: ExtensionAPI) {
     return { block: true, reason: result.stderr.trim() || "denied by the watcher-arm PreToolUse seatbelt" };
   });
 
-  pi.on("agent_settled", async () => {
+  const runSettledGuard = async () => {
     if (guardFollowupActive) {
       guardFollowupActive = false;
       return;
@@ -215,7 +253,21 @@ export default function (pi: ExtensionAPI) {
     } catch {
       guardFollowupActive = false;
     }
-  });
+  };
+
+  if (primaryHarness === "omp") {
+    // OMP settles the main loop with agent_end; Pi uses agent_settled.
+    const onCrossHarnessEvent = pi.on as unknown as CrossHarnessOn;
+    onCrossHarnessEvent.call(pi, "agent_end", runSettledGuard);
+  } else {
+    pi.on("agent_settled", runSettledGuard);
+  }
 
   markLoaded();
+}
+
+
+export default function registerPiFamilyPrimaryTurnendGuard(pi: ExtensionAPI): void {
+  selectPrimaryHarness(process.env.OMPCODE === "1" ? "omp" : "pi");
+  registerPrimaryTurnendGuard(pi);
 }

--- a/.pi/extensions/fm-primary-turnend-guard.ts
+++ b/.pi/extensions/fm-primary-turnend-guard.ts
@@ -26,10 +26,16 @@ let extensionVersion = `sha256:${createHash("sha256").update(readFileSync(extens
 function selectPrimaryHarness(harness: PrimaryHarness): void {
   primaryHarness = harness;
   marker = `${state}/.${harness}-turnend-extension-loaded`;
-  const identityFile = harness === "omp"
-    ? `${root}/.omp/extensions/fm-primary-turnend-guard.ts`
-    : extensionFile;
-  extensionVersion = `sha256:${createHash("sha256").update(readFileSync(identityFile)).digest("hex")}`;
+  // The entrypoint alone is a thin re-export, so its bytes never move when the
+  // shared implementation below it changes. Hash the whole load chain, in the
+  // same order bin/fm-session-start.sh hashes it, or a stale in-memory guard
+  // would keep reporting itself current.
+  const identityFiles = harness === "omp"
+    ? [`${root}/.omp/extensions/fm-primary-turnend-guard.ts`, extensionFile]
+    : [extensionFile];
+  const digest = createHash("sha256");
+  for (const file of identityFiles) digest.update(readFileSync(file));
+  extensionVersion = `sha256:${digest.digest("hex")}`;
 }
 
 function parentPid(pid: string): string {
@@ -210,6 +216,7 @@ function registerPrimaryTurnendGuard(pi: ExtensionAPI) {
     const onCrossHarnessEvent = pi.on as unknown as CrossHarnessOn;
     onCrossHarnessEvent.call(pi, "session_switch", async (event) => {
       const source = sessionSource(sessionReason(event));
+      markLoaded();
       if (source) await injectSessionstart(pi, source);
     });
   }

--- a/.pi/extensions/fm-primary-turnend-guard.ts
+++ b/.pi/extensions/fm-primary-turnend-guard.ts
@@ -274,7 +274,15 @@ function registerPrimaryTurnendGuard(pi: ExtensionAPI) {
 }
 
 
-export default function registerPiFamilyPrimaryTurnendGuard(pi: ExtensionAPI): void {
-  selectPrimaryHarness(process.env.OMPCODE === "1" ? "omp" : "pi");
+// The LOADED ENTRYPOINT selects the protocol, never an environment marker: a
+// marker is inheritable, so a Pi primary started under a retained OMPCODE would
+// otherwise bind the guard to agent_end, which Pi never emits, and every turn
+// would end blind. Pi auto-loads this file and gets Pi; only .omp/extensions/
+// passes "omp".
+export default function registerPiFamilyPrimaryTurnendGuard(
+  pi: ExtensionAPI,
+  harness: PrimaryHarness = "pi",
+): void {
+  selectPrimaryHarness(harness);
   registerPrimaryTurnendGuard(pi);
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,7 +175,7 @@ A silent bootstrap section needs no action; for any printed actionable diagnosti
 ## 4. Harness and runtime dispatch
 
 Load `harness-adapters` before every spawn or recovery and before trust handling, skill invocation, interrupt, exit, resume, or adapter verification.
-The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, and `kimi`, plus `muse` for crewmates and scouts only; never dispatch on an unverified adapter.
+The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `omp`, `grok`, and `kimi`, plus `muse` for crewmates and scouts only; never dispatch on an unverified adapter.
 If static `config/crew-harness` or `config/secondmate-harness` names an unverified adapter, report it and fall back only to a verified adapter rather than launching it.
 
 `docs/configuration.md` owns dispatch-profile and runtime-backend schemas, `bin/fm-harness.sh` owns static resolution, and `bin/fm-spawn.sh` owns launch flags and fail-closed validation.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ omp
 
 For Grok, `--trust` is needed once per clone so project hooks and the turn-end guard load; `/hooks-trust` inside Grok works too.
 For Pi, approve the project trust prompt once per clone on first launch so the tracked `.pi/extensions/*.ts` files auto-load.
-OMP auto-loads the tracked `.omp/extensions/*.ts` files and uses `OMPCODE=1` to keep its identity distinct from inherited foreign harness markers.
+OMP auto-loads the tracked `.omp/extensions/*.ts` files. Firstmate-launched OMP workers carry `OMPCODE=1`; primary OMP sessions are also identified by their exact Bun `/omp` script ancestry, which takes precedence over inherited foreign harness markers.
 Pi's `/calm` toggle hides supported transcript chrome, including canonically classified Firstmate operational user rows, and uses a Calm-only animated working boat during active runs while preserving all model context and session data.
 The hidden operational inputs remain ordinary user-role messages with unchanged delivery, ordering, authority, persistence, and exports.
 The preference persists for the effective Firstmate home, and toggling it off restores ordinary rendering.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Full detail on every feature lives in [docs/architecture.md](docs/architecture.m
 
 ### Requirements
 
-- A verified primary agent harness: Claude Code, Grok, Pi, `pi-signed`, Codex, or OpenCode.
+- A verified primary agent harness: Claude Code, Grok, Pi, `pi-signed`, OMP, Codex, or OpenCode.
 - Git and the GitHub CLI, authenticated through `gh auth login`.
 - The CLI and dependencies for your selected runtime backend; tmux is the reference default.
 
@@ -72,7 +72,7 @@ Claude Code uses a tracked Stop hook for tokenless watcher re-arm and rewake, Gr
 All three have verified turn-end guard paths when launched with their documented setup.
 Pick whichever one matches your subscription and workflow.
 
-Codex and OpenCode are also verified and supported as primary harnesses; Codex uses bounded foreground checkpoints, and OpenCode uses a TUI plugin, so both carry more harness-specific supervision tradeoffs than the three co-primaries.
+OMP, Codex, and OpenCode are also verified and supported as primary harnesses; OMP shares the Pi-family extension core with OMP-specific lifecycle events, Codex uses bounded foreground checkpoints, and OpenCode uses a TUI plugin.
 
 ### Install and launch
 
@@ -104,8 +104,15 @@ pi
 FM_PI_HARNESS=pi-signed pi-signed
 ```
 
+**OMP**
+
+```sh
+omp
+```
+
 For Grok, `--trust` is needed once per clone so project hooks and the turn-end guard load; `/hooks-trust` inside Grok works too.
 For Pi, approve the project trust prompt once per clone on first launch so the tracked `.pi/extensions/*.ts` files auto-load.
+OMP auto-loads the tracked `.omp/extensions/*.ts` files and uses `OMPCODE=1` to keep its identity distinct from inherited foreign harness markers.
 Pi's `/calm` toggle hides supported transcript chrome, including canonically classified Firstmate operational user rows, and uses a Calm-only animated working boat during active runs while preserving all model context and session data.
 The hidden operational inputs remain ordinary user-role messages with unchanged delivery, ordering, authority, persistence, and exports.
 The preference persists for the effective Firstmate home, and toggling it off restores ordinary rendering.
@@ -211,7 +218,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/gitlab-merge-watch.md](docs/gitlab-merge-watch.md) - maintainer verification for GitLab merge watching on arbitrary instances.
 - [docs/turnend-guard.md](docs/turnend-guard.md) - the primary session's current "no turn ends blind" backstop, scope, loop safety, and compatibility limits.
 - [docs/verification/supervision.md](docs/verification/supervision.md) - active maintainer verification for session-start, guard, continuity, and wedge integrations.
-- [docs/supervision-protocols/](docs/supervision-protocols/) - rendered primary-harness watcher protocols for Claude, Codex, OpenCode, Pi and `pi-signed`, Grok, and unknown harness fallback.
+- [docs/supervision-protocols/](docs/supervision-protocols/) - rendered primary-harness watcher protocols for Claude, Codex, OpenCode, Pi and `pi-signed`, OMP, Grok, and unknown harness fallback.
 - [docs/scripts.md](docs/scripts.md) - the `bin/` toolbelt reference.
 - [docs/documentation-audiences.md](docs/documentation-audiences.md) - documentation audiences and the machine-checked placement boundary.
 - [`AGENTS.md`](AGENTS.md) - the distro's always-loaded operating contract and routing index for conditional procedures.

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1855,6 +1855,49 @@ fm_backend_herdr_explicit_close_pane_confirmed() {  # <session> <pane_id>
   [ "$presence" = dead ]
 }
 
+# OMP 17.2.12 leaves its Herdr agent registration at `idle` after `/exit` has
+# returned to the task's nested worktree shell. This proof recognizes only that
+# adapter's exact stale-registration shape: one foreground process, its pid is
+# the foreground process group, both reported names are the same recognized
+# shell, and the OS process has no child. Any transient prompt helper or
+# unreadable field keeps the registration live/unknown for the next poll.
+fm_backend_herdr_omp_exited_to_shell() {  # <session> <pane-id>
+  local session=$1 pane=$2 info pid pgid name argv0 shell rows ps_bin
+  info=$(fm_backend_herdr_cli "$session" pane process-info --pane "$pane" 2>/dev/null) || return 1
+  printf '%s' "$info" | jq -e --arg pane "$pane" '
+    .result.type == "pane_process_info"
+    and .result.process_info.pane_id == $pane
+    and (.result.process_info.foreground_processes | type) == "array"
+    and (.result.process_info.foreground_processes | length) == 1
+  ' >/dev/null 2>&1 || return 1
+  pid=$(printf '%s' "$info" | jq -er \
+    '.result.process_info.foreground_processes[0].pid | select(type == "number" and . > 1) | floor' 2>/dev/null) || return 1
+  pgid=$(printf '%s' "$info" | jq -er \
+    '.result.process_info.foreground_process_group_id | select(type == "number" and . > 1) | floor' 2>/dev/null) || return 1
+  [ "$pid" = "$pgid" ] || return 1
+  name=$(printf '%s' "$info" | jq -er \
+    '.result.process_info.foreground_processes[0].name | select(type == "string" and length > 0)' 2>/dev/null) || return 1
+  argv0=$(printf '%s' "$info" | jq -er '
+    .result.process_info.foreground_processes[0] as $process
+    | ($process.argv0 // $process.argv[0])
+    | select(type == "string" and length > 0)
+  ' 2>/dev/null) || return 1
+  shell=${name##*/}
+  argv0=${argv0#-}
+  argv0=${argv0##*/}
+  [ "$argv0" = "$shell" ] || return 1
+  case "$shell" in sh|bash|zsh|dash|ksh|fish) ;; *) return 1 ;; esac
+  ps_bin=${FM_HERDR_PS_BIN:-ps}
+  command -v "$ps_bin" >/dev/null 2>&1 || return 1
+  fm_backend_herdr_pid_is_bare_shell "$ps_bin" "$pid" || return 1
+  rows=$("$ps_bin" -axo pid=,ppid= 2>/dev/null) || return 1
+  printf '%s\n' "$rows" | awk -v shell="$pid" '
+    $1 == shell { found++ }
+    $2 == shell { child++ }
+    END { exit(found == 1 && child == 0 ? 0 : 1) }
+  ' || return 1
+}
+
 # fm_backend_herdr_pane_agent_state: classify <pane_id> in <session> as one of
 # dead|no-agent|live|unknown, purely from the JSON body of two read-only
 # calls - never from process exit status, since a business-logic "not found"
@@ -1877,9 +1920,9 @@ fm_backend_herdr_explicit_close_pane_confirmed() {  # <session> <pane_id>
 #              `resume_agents_on_restore = false` restore would produce too
 #              (a plain shell, never an agent).
 #   live     - `agent get` succeeds and reports a real agent_status (working,
-#              idle, done, or blocked - any registered value). An idle or
-#              blocked agent is still a genuine, still-registered agent, not
-#              a restored husk, so it is never a close-and-replace candidate.
+#              idle, done, or blocked - any registered value), except that an
+#              idle/done OMP registration with the separately proven lone-shell
+#              exit shape above is `no-agent`.
 #   unknown  - anything else: an unparseable/unexpected response from either
 #              call, or a `pane get` success whose own echoed pane_id does not
 #              round-trip (guards against misreading a herdr response shape
@@ -1887,7 +1930,7 @@ fm_backend_herdr_explicit_close_pane_confirmed() {  # <session> <pane_id>
 #              refusal here, never toward closing - this is the conservative
 #              backstop the husk check depends on.
 fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
-  local session=$1 pane_id=$2 out code presence status
+  local session=$1 pane_id=$2 out code presence status agent
   presence=$(fm_backend_herdr_pane_presence_state "$session" "$pane_id")
   if [ "$presence" != present ]; then
     case "$presence" in
@@ -1902,7 +1945,16 @@ fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
     [ "$code" = "agent_not_found" ] && printf 'no-agent' || printf 'unknown'
     return 0
   fi
+  agent=$(printf '%s' "$out" | jq -r '.result.agent.agent // empty' 2>/dev/null)
   status=$(printf '%s' "$out" | jq -r '.result.agent.agent_status // empty' 2>/dev/null)
+  case "$agent:$status" in
+    omp:idle|omp:done)
+      if fm_backend_herdr_omp_exited_to_shell "$session" "$pane_id"; then
+        printf 'no-agent'
+        return 0
+      fi
+      ;;
+  esac
   case "$status" in
     working|idle|done|blocked) printf 'live' ;;
     *) printf 'unknown' ;;
@@ -2799,10 +2851,10 @@ fm_backend_herdr_composer_state() {  # <target> -> empty|pending|unknown
         ;;
     esac
   done < <(printf '%s\n' "$cap")
-  # Pi has no prompt glyph or side border. Compare its bottom-most complete
-  # separator pair with the last generic match so an earlier bordered transcript
-  # row can never suppress the live Pi composer. Identity is consulted only when
-  # a lower separator pair could change the verdict.
+  # Pi-family TUIs have no prompt glyph or side border. Compare the bottom-most
+  # complete separator pair with the last generic match so an earlier bordered
+  # transcript row can never suppress the live composer. Identity is consulted
+  # only when a lower separator pair could change the verdict.
   fm_backend_herdr_pi_composer_find "$cap"
   if [ "$FM_BACKEND_HERDR_PI_PAIR_FOUND" -eq 1 ] \
      && [ "$FM_BACKEND_HERDR_PI_PAIR_LINE" -gt "$generic_line" ] \
@@ -2812,7 +2864,7 @@ fm_backend_herdr_composer_state() {  # <target> -> empty|pending|unknown
 $identity
 EOF
     case "$agent:$agent_status" in
-      pi:idle|pi:done|pi:blocked)
+      pi:idle|pi:done|pi:blocked|omp:idle|omp:done|omp:blocked)
         if [ "$FM_BACKEND_HERDR_PI_PAIR_VALID" -eq 1 ]; then
           shape=separated
           raw_match=$FM_BACKEND_HERDR_PI_CONTENT
@@ -2821,12 +2873,13 @@ EOF
           found=0
         fi
         ;;
-      pi:*|:*)
-        # A working Pi or unreadable identity cannot authorize injection, and
-        # the lower separator pair proves any generic row above is not current.
+      pi:*|omp:*|:*)
+        # A working Pi-family agent or unreadable identity cannot authorize
+        # injection, and the lower separator pair proves any generic row above
+        # is not current.
         found=0
         ;;
-      *) : ;; # A known non-Pi agent keeps its established generic verdict.
+      *) : ;; # A known non-Pi-family agent keeps its established generic verdict.
     esac
   elif [ "$FM_BACKEND_HERDR_PI_PAIR_FOUND" -eq 0 ] \
        && [ "$FM_BACKEND_HERDR_PI_LAST_SEPARATOR_LINE" -gt "$generic_line" ]; then

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -218,7 +218,7 @@ fm_backend_tmux_foreground_comms() {  # <target>
 }
 
 fm_backend_tmux_foreground_argv0s() {  # <target>
-  local target=$1 tty pid pgid tpgid comm args argv0
+  local target=$1 tty pid pgid tpgid comm args argv0 rest script
   tty=$(tmux display-message -p -t "$target" '#{pane_tty}' 2>/dev/null) || return 0
   [ -n "$tty" ] || return 0
   LC_ALL=C ps -t "${tty#/dev/}" -o pid=,pgid=,tpgid=,comm= 2>/dev/null \
@@ -229,6 +229,18 @@ fm_backend_tmux_foreground_argv0s() {  # <target>
         args=${args#"${args%%[![:space:]]*}"}
         argv0=${args%%[[:space:]]*}
         [ -n "$argv0" ] && printf '%s\n' "$argv0"
+        # OMP's long-lived process is Bun with the exact `omp` script as argv[1].
+        # Export that one verified identity candidate, never later prompt text.
+        case "${comm##*/}" in
+          bun)
+            rest=${args#"$argv0"}
+            rest=${rest#"${rest%%[![:space:]]*}"}
+            script=${rest%%[[:space:]]*}
+            if [ "$(fm_harness_path_name "$script" 2>/dev/null || true)" = omp ]; then
+              printf '%s\n' "$script"
+            fi
+            ;;
+        esac
       done
 }
 

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -598,40 +598,40 @@ fm_backend_source() {  # <name>
   case "$name" in
     tmux)
       if [ -z "${_FM_BACKEND_TMUX_SOURCED:-}" ]; then
-        # shellcheck source=/dev/null
         [ -f "$FM_BACKEND_LIB_DIR/backends/tmux.sh" ] || return 1
+        # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/tmux.sh" || return 1
         _FM_BACKEND_TMUX_SOURCED=1
       fi
       ;;
     herdr)
       if [ -z "${_FM_BACKEND_HERDR_SOURCED:-}" ]; then
-        # shellcheck source=/dev/null
         [ -f "$FM_BACKEND_LIB_DIR/backends/herdr.sh" ] || return 1
+        # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/herdr.sh" || return 1
         _FM_BACKEND_HERDR_SOURCED=1
       fi
       ;;
     zellij)
       if [ -z "${_FM_BACKEND_ZELLIJ_SOURCED:-}" ]; then
-        # shellcheck source=/dev/null
         [ -f "$FM_BACKEND_LIB_DIR/backends/zellij.sh" ] || return 1
+        # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/zellij.sh" || return 1
         _FM_BACKEND_ZELLIJ_SOURCED=1
       fi
       ;;
     orca)
       if [ -z "${_FM_BACKEND_ORCA_SOURCED:-}" ]; then
-        # shellcheck source=/dev/null
         [ -f "$FM_BACKEND_LIB_DIR/backends/orca.sh" ] || return 1
+        # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/orca.sh" || return 1
         _FM_BACKEND_ORCA_SOURCED=1
       fi
       ;;
     cmux)
       if [ -z "${_FM_BACKEND_CMUX_SOURCED:-}" ]; then
-        # shellcheck source=/dev/null
         [ -f "$FM_BACKEND_LIB_DIR/backends/cmux.sh" ] || return 1
+        # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/cmux.sh" || return 1
         _FM_BACKEND_CMUX_SOURCED=1
       fi

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -599,6 +599,7 @@ fm_backend_source() {  # <name>
     tmux)
       if [ -z "${_FM_BACKEND_TMUX_SOURCED:-}" ]; then
         # shellcheck source=/dev/null
+        [ -f "$FM_BACKEND_LIB_DIR/backends/tmux.sh" ] || return 1
         . "$FM_BACKEND_LIB_DIR/backends/tmux.sh" || return 1
         _FM_BACKEND_TMUX_SOURCED=1
       fi
@@ -606,6 +607,7 @@ fm_backend_source() {  # <name>
     herdr)
       if [ -z "${_FM_BACKEND_HERDR_SOURCED:-}" ]; then
         # shellcheck source=/dev/null
+        [ -f "$FM_BACKEND_LIB_DIR/backends/herdr.sh" ] || return 1
         . "$FM_BACKEND_LIB_DIR/backends/herdr.sh" || return 1
         _FM_BACKEND_HERDR_SOURCED=1
       fi
@@ -613,6 +615,7 @@ fm_backend_source() {  # <name>
     zellij)
       if [ -z "${_FM_BACKEND_ZELLIJ_SOURCED:-}" ]; then
         # shellcheck source=/dev/null
+        [ -f "$FM_BACKEND_LIB_DIR/backends/zellij.sh" ] || return 1
         . "$FM_BACKEND_LIB_DIR/backends/zellij.sh" || return 1
         _FM_BACKEND_ZELLIJ_SOURCED=1
       fi
@@ -620,6 +623,7 @@ fm_backend_source() {  # <name>
     orca)
       if [ -z "${_FM_BACKEND_ORCA_SOURCED:-}" ]; then
         # shellcheck source=/dev/null
+        [ -f "$FM_BACKEND_LIB_DIR/backends/orca.sh" ] || return 1
         . "$FM_BACKEND_LIB_DIR/backends/orca.sh" || return 1
         _FM_BACKEND_ORCA_SOURCED=1
       fi
@@ -627,6 +631,7 @@ fm_backend_source() {  # <name>
     cmux)
       if [ -z "${_FM_BACKEND_CMUX_SOURCED:-}" ]; then
         # shellcheck source=/dev/null
+        [ -f "$FM_BACKEND_LIB_DIR/backends/cmux.sh" ] || return 1
         . "$FM_BACKEND_LIB_DIR/backends/cmux.sh" || return 1
         _FM_BACKEND_CMUX_SOURCED=1
       fi

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -997,7 +997,7 @@ crew_dispatch_validate() {
     return 0
   fi
   err=$(jq -r '
-    def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi","muse"] | index($h);
+    def verified($h): ["claude","codex","opencode","pi","pi-signed","omp","grok","kimi","muse"] | index($h);
     def effort_ok($h; $e):
       if $e == null then true
       elif ($e | type) != "string" then false
@@ -1005,6 +1005,7 @@ crew_dispatch_validate() {
       elif $h == "codex" then (["low","medium","high","xhigh"] | index($e))
       elif $h == "grok" then (["low","medium","high"] | index($e))
       elif $h == "pi" or $h == "pi-signed" then (["low","medium","high","xhigh","max"] | index($e))
+      elif $h == "omp" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "muse" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "opencode" or $h == "kimi" then false
       else true

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1001,12 +1001,9 @@ crew_dispatch_validate() {
     def effort_ok($h; $e):
       if $e == null then true
       elif ($e | type) != "string" then false
-      elif $h == "claude" then (["low","medium","high","xhigh","max"] | index($e))
+      elif $h == "claude" or $h == "pi" or $h == "pi-signed" or $h == "omp" or $h == "muse" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "codex" then (["low","medium","high","xhigh"] | index($e))
       elif $h == "grok" then (["low","medium","high"] | index($e))
-      elif $h == "pi" or $h == "pi-signed" then (["low","medium","high","xhigh","max"] | index($e))
-      elif $h == "omp" then (["low","medium","high","xhigh","max"] | index($e))
-      elif $h == "muse" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "opencode" or $h == "kimi" then false
       else true
       end;

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -686,7 +686,7 @@ secondmate_liveness_one() {  # <meta> <id>
   [ -n "$target" ] || target="$window"
   agent_state=$(fm_backend_agent_state "$backend" "$target" 2>/dev/null) || agent_state=unreadable
   case "$harness" in
-    claude|codex|opencode|pi|pi-signed|grok|kimi) ;;
+    claude|codex|opencode|pi|pi-signed|omp|grok|kimi) ;;
     *)
       case "$agent_state" in dead|missing) agent_state=unverified-harness ;; esac
       ;;

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -30,6 +30,7 @@
 # never classify another adapter):
 #   pi-ext           Pi/pi-signed per-task extension (agent_start/agent_settled)
 #   omp-ext          OMP per-task extension (agent_start/agent_end)
+#   opencode-plugin  OpenCode per-task plugin (session.status)
 #   claude-hook      Claude lifecycle hooks (UserPromptSubmit/Stop/StopFailure/SessionEnd)
 #   codex-hook, codex-appserver  reserved: Codex, gated by
 #                    fm_busy_codex_semantic_source

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -29,7 +29,7 @@
 # task's recorded harness classifies unknown, so one adapter's writer can
 # never classify another adapter):
 #   pi-ext           Pi/pi-signed per-task extension (agent_start/agent_settled)
-#   opencode-plugin  OpenCode per-task plugin (session.status)
+#   omp-ext          OMP per-task extension (agent_start/agent_end)
 #   claude-hook      Claude lifecycle hooks (UserPromptSubmit/Stop/StopFailure/SessionEnd)
 #   codex-hook, codex-appserver  reserved: Codex, gated by
 #                    fm_busy_codex_semantic_source
@@ -184,6 +184,7 @@ fm_busy_sources_for_harness() {  # <harness>
       ;;
     opencode*) adapter=opencode-plugin ;;
     pi|pi-signed) adapter=pi-ext ;;
+    omp*) adapter=omp-ext ;;
     kimi*)
       fm_busy_kimi_verified || { printf ''; return 0; }
       adapter='kimi-wire kimi-hook'

--- a/bin/fm-control-lib.sh
+++ b/bin/fm-control-lib.sh
@@ -63,7 +63,7 @@ fm_control_verb_allowed() {  # <verb>
 # than guessed at, exactly as a spawn on it would be.
 fm_control_harness_supported() {  # <harness>
   case "${1-}" in
-    claude|codex|opencode|pi|pi-signed|grok|kimi|muse) return 0 ;;
+    claude|codex|opencode|pi|pi-signed|grok|kimi|muse|omp) return 0 ;;
   esac
   return 1
 }
@@ -86,6 +86,7 @@ fm_control_harness_family() {  # <recorded-harness>
     grok*) printf 'grok' ;;
     kimi*) printf 'kimi' ;;
     muse*) printf 'muse' ;;
+    omp*) printf 'omp' ;;
     *) return 1 ;;
   esac
 }
@@ -108,7 +109,7 @@ fm_control_harness_supports_kind() {  # <harness> <kind>
 # whose Esc only moves focus to the scrollback; grok cancels on Ctrl+C.
 fm_control_interrupt_key() {  # <harness>
   case "${1-}" in
-    claude|codex|opencode|pi|pi-signed|kimi|muse) printf 'Escape' ;;
+    claude|codex|opencode|pi|pi-signed|kimi|muse|omp) printf 'Escape' ;;
     grok) printf 'C-c' ;;
     *) return 1 ;;
   esac
@@ -119,7 +120,7 @@ fm_control_interrupt_key() {  # <harness>
 fm_control_interrupt_repeat() {  # <harness>
   case "${1-}" in
     opencode) printf '2' ;;
-    claude|codex|pi|pi-signed|grok|kimi|muse) printf '1' ;;
+    claude|codex|pi|pi-signed|grok|kimi|muse|omp) printf '1' ;;
     *) return 1 ;;
   esac
 }
@@ -134,7 +135,7 @@ fm_control_interrupt_repeat() {  # <harness>
 fm_control_interrupt_clear_key() {  # <harness>
   case "${1-}" in
     muse) printf 'C-u' ;;
-    claude|codex|opencode|pi|pi-signed|grok|kimi) ;;
+    claude|codex|opencode|pi|pi-signed|grok|kimi|omp) ;;
     *) return 1 ;;
   esac
 }
@@ -142,7 +143,7 @@ fm_control_interrupt_clear_key() {  # <harness>
 fm_control_interrupt_ack_source() {  # <harness>
   case "${1-}" in
     muse) printf 'muse-session-terminal' ;;
-    claude|codex|opencode|pi|pi-signed|grok|kimi) printf 'none' ;;
+    claude|codex|opencode|pi|pi-signed|grok|kimi|omp) printf 'none' ;;
     *) return 1 ;;
   esac
 }
@@ -150,7 +151,7 @@ fm_control_interrupt_ack_source() {  # <harness>
 # The command that exits the agent from its own composer.
 fm_control_exit_command() {  # <harness>
   case "${1-}" in
-    claude|opencode|grok|kimi|muse) printf '/exit' ;;
+    claude|opencode|grok|kimi|muse|omp) printf '/exit' ;;
     codex|pi|pi-signed) printf '/quit' ;;
     *) return 1 ;;
   esac
@@ -198,6 +199,7 @@ fm_control_harness_wiring_paths() {  # <harness> <worktree> <state-dir> <id>
     claude) printf '%s\n' "$wt/.claude/settings.local.json" ;;
     opencode) printf '%s\n' "$wt/.opencode/plugins/fm-busy-state.js" ;;
     pi|pi-signed) printf '%s\n' "$state/$id.pi-ext.ts" ;;
+    omp) printf '%s\n' "$state/$id.omp-ext.ts" ;;
     grok)
       printf '%s\n' "$wt/.fm-grok-turnend"
       printf '%s\n' "$state/$id.grok-turnend-token"

--- a/bin/fm-control-lib.sh
+++ b/bin/fm-control-lib.sh
@@ -37,8 +37,8 @@
 # `resume` is deliberately NOT a verb. It is not deterministic across the
 # verified adapters: codex and grok resume only from a session id printed at
 # exit, opencode resumes the most recent session for the cwd with --continue,
-# and claude, pi, pi-signed, and kimi have no verified pane-resume contract at
-# all. `relaunch` covers the same need deterministically for every adapter,
+# and claude, pi, pi-signed, omp, kimi, and muse have no verified pane-resume
+# contract at all. `relaunch` covers the same need deterministically for every adapter,
 # because the brief on disk - not a harness-private session - is the durable
 # instruction.
 

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -174,7 +174,7 @@ shift 2
 if ! fm_control_verb_allowed "$VERB"; then
   {
     if [ "$VERB" = resume ]; then
-      echo "error: 'resume' is not a control verb: resuming an exited agent is not deterministic across the verified adapters (codex and grok need a session id printed at exit, opencode continues the most recent session for the cwd, and claude, pi, pi-signed, and kimi have no verified pane-resume contract). Use 'relaunch', which carries the brief plus a progress note into a fresh agent on any adapter."
+      echo "error: 'resume' is not a control verb: resuming an exited agent is not deterministic across the verified adapters (codex and grok need a session id printed at exit, opencode continues the most recent session for the cwd, and claude, pi, pi-signed, omp, kimi, and muse have no verified pane-resume contract). Use 'relaunch', which carries the brief plus a progress note into a fresh agent on any adapter."
     else
       echo "error: '$VERB' is not a control verb"
     fi

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -28,15 +28,55 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 
 
+fm_harness_omp_process_matches() {  # <comm> <args>
+  local comm=$1 args=$2 script
+  case "$(basename -- "$comm")" in
+    omp) return 0 ;;
+    bun*)
+      # OMP is distributed as a Bun script. Match only argv[1]'s exact `omp`
+      # path component; later prompt arguments may mention OMP and are not
+      # process identity. A bare `bun` with no script argument is not OMP even
+      # when its own install path has an `omp` component, so the guard below
+      # mirrors bin/fm-session-lock-lib.sh: judge only a real argv[1].
+      script=${args#* }
+      if [ "$script" != "$args" ]; then
+        script=${script%% *}
+        case "/$script/" in
+          */omp/*) return 0 ;;
+        esac
+      fi ;;
+  esac
+  return 1
+}
+
+fm_harness_omp_ancestry_matches() {
+  local pid=$$ comm args
+  for _ in 1 2 3 4 5 6 7 8; do
+    comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
+    args=$(ps -o args= -p "$pid" 2>/dev/null)
+    fm_harness_omp_process_matches "$comm" "$args" && return 0
+    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    if [ -z "$pid" ] || [ "$pid" -le 1 ]; then
+      break
+    fi
+  done
+  return 1
+}
+
+
 detect_own() {
-  # OMP exports OMPCODE=1 to tool subprocesses (verified: omp 17.2.12).
-  # Check it before foreign markers retained by the surrounding terminal: a
-  # firstmate-launched OMP worker inherited CLAUDECODE=1 while preserving this
-  # positive OMP marker.
+  # OMP workers launched by Firstmate carry OMPCODE=1. A primary OMP 17.2.12
+  # session may omit it, so its exact Bun ancestry must also outrank an
+  # inherited foreign Claude marker.
   [ "${OMPCODE:-}" = "1" ] && { echo omp; return; }
+  if [ "${CLAUDECODE:-}" = "1" ] && fm_harness_omp_ancestry_matches; then
+    echo omp
+    return
+  fi
   # Layer 1: environment markers for verified harnesses.
   # Keep marker detection before ancestry detection as an explicit precedence rule.
-  # Only OMP, claude, pi, and grok set verified adapter markers of their own; codex,
+  # OMP's exact ancestry exception is checked above because its primary session
+  # may be markerless. Only OMP, claude, pi, and grok set verified adapter markers of their own; codex,
   # opencode, kimi, and muse are markerless, so a foreign marker retained in a
   # terminal multiplexer's stored environment can silently misidentify one of
   # them before ancestry is consulted. This is a precedence hazard, not evidence
@@ -64,7 +104,7 @@ detect_own() {
   # without verifying it reaches children AND that it cannot survive in a
   # multiplexer's stored environment, which is the precedence hazard above.
   # Layer 2: walk the parent chain and match the command name.
-  local pid=$$ comm args script
+  local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
     case "$(basename -- "$comm")" in
@@ -73,7 +113,6 @@ detect_own() {
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
       kimi) echo kimi; return ;;
-      omp) echo omp; return ;;
       # muse's installed launcher ~/.local/bin/muse execs ~/.local/bin/muse-bin-<version>
       # (verified in the published launcher, muse 0.1.0-R708.1), so the live process
       # name carries the version and CHANGES on every auto-update. Match the stable
@@ -82,20 +121,9 @@ detect_own() {
       muse|muse-bin-*) echo muse; return ;;
       pi-signed) echo pi; return ;;
       pi) echo pi; return ;;
-      bun*)
-        # OMP is distributed as a Bun script. Match only argv[1]'s exact `omp`
-        # path component; later prompt arguments may mention OMP and are not
-        # process identity. A bare `bun` with no script argument is not OMP even
-        # when its own install path has an `omp` component, so the guard below
-        # mirrors bin/fm-session-lock-lib.sh: judge only a real argv[1].
+      omp|bun*)
         args=$(ps -o args= -p "$pid" 2>/dev/null)
-        script=${args#* }
-        if [ "$script" != "$args" ]; then
-          script=${script%% *}
-          case "/$script/" in
-            */omp/*) echo omp; return ;;
-          esac
-        fi ;;
+        fm_harness_omp_process_matches "$comm" "$args" && { echo omp; return; } ;;
       node*|python*)
         # Bare interpreter: match the harness name in its script path.
         args=$(ps -o args= -p "$pid" 2>/dev/null)

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -64,7 +64,7 @@ detect_own() {
   # without verifying it reaches children AND that it cannot survive in a
   # multiplexer's stored environment, which is the precedence hazard above.
   # Layer 2: walk the parent chain and match the command name.
-  local pid=$$ comm args
+  local pid=$$ comm args script
   for _ in 1 2 3 4 5 6 7 8; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
     case "$(basename -- "$comm")" in
@@ -85,13 +85,17 @@ detect_own() {
       bun*)
         # OMP is distributed as a Bun script. Match only argv[1]'s exact `omp`
         # path component; later prompt arguments may mention OMP and are not
-        # process identity.
+        # process identity. A bare `bun` with no script argument is not OMP even
+        # when its own install path has an `omp` component, so the guard below
+        # mirrors bin/fm-session-lock-lib.sh: judge only a real argv[1].
         args=$(ps -o args= -p "$pid" 2>/dev/null)
-        args=${args#* }
-        args=${args%% *}
-        case "/$args/" in
-          */omp/*) echo omp; return ;;
-        esac ;;
+        script=${args#* }
+        if [ "$script" != "$args" ]; then
+          script=${script%% *}
+          case "/$script/" in
+            */omp/*) echo omp; return ;;
+          esac
+        fi ;;
       node*|python*)
         # Bare interpreter: match the harness name in its script path.
         args=$(ps -o args= -p "$pid" 2>/dev/null)

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|muse|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|muse|omp|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -27,14 +27,20 @@ FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 
+
 detect_own() {
+  # OMP exports OMPCODE=1 to tool subprocesses (verified: omp 17.2.12).
+  # Check it before foreign markers retained by the surrounding terminal: a
+  # firstmate-launched OMP worker inherited CLAUDECODE=1 while preserving this
+  # positive OMP marker.
+  [ "${OMPCODE:-}" = "1" ] && { echo omp; return; }
   # Layer 1: environment markers for verified harnesses.
   # Keep marker detection before ancestry detection as an explicit precedence rule.
-  # Only claude, pi, and grok set verified markers of their own; codex, opencode,
-  # kimi, and muse are markerless, so a foreign marker retained in a terminal
-  # multiplexer's stored environment can silently misidentify one of them before
-  # ancestry is consulted. This is a precedence hazard, not evidence that
-  # CLAUDECODE inheritance into a kimi child was observed; it was not observed.
+  # Only OMP, claude, pi, and grok set verified adapter markers of their own; codex,
+  # opencode, kimi, and muse are markerless, so a foreign marker retained in a
+  # terminal multiplexer's stored environment can silently misidentify one of
+  # them before ancestry is consulted. This is a precedence hazard, not evidence
+  # that CLAUDECODE inheritance into a kimi child was observed; it was not.
   [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
   if [ "${PI_CODING_AGENT:-}" = "true" ]; then
     if [ "${FM_PI_HARNESS:-}" = pi-signed ]; then echo pi-signed; else echo pi; fi
@@ -67,6 +73,7 @@ detect_own() {
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
       kimi) echo kimi; return ;;
+      omp) echo omp; return ;;
       # muse's installed launcher ~/.local/bin/muse execs ~/.local/bin/muse-bin-<version>
       # (verified in the published launcher, muse 0.1.0-R708.1), so the live process
       # name carries the version and CHANGES on every auto-update. Match the stable
@@ -75,6 +82,16 @@ detect_own() {
       muse|muse-bin-*) echo muse; return ;;
       pi-signed) echo pi; return ;;
       pi) echo pi; return ;;
+      bun*)
+        # OMP is distributed as a Bun script. Match only argv[1]'s exact `omp`
+        # path component; later prompt arguments may mention OMP and are not
+        # process identity.
+        args=$(ps -o args= -p "$pid" 2>/dev/null)
+        args=${args#* }
+        args=${args%% *}
+        case "/$args/" in
+          */omp/*) echo omp; return ;;
+        esac ;;
       node*|python*)
         # Bare interpreter: match the harness name in its script path.
         args=$(ps -o args= -p "$pid" 2>/dev/null)

--- a/bin/fm-remote-doctor.sh
+++ b/bin/fm-remote-doctor.sh
@@ -57,7 +57,7 @@ FM_ROOT="${FM_ROOT_OVERRIDE:-$(CDPATH='' cd "$SCRIPT_DIR/.." && pwd -P)}"
 # shellcheck source=bin/fm-tasks-axi-lib.sh
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
 REQUIRED_TOOLS=(git jq herdr tasks-axi treehouse)
-HARNESS_TOOLS=(claude codex opencode pi pi-signed grok kimi)
+HARNESS_TOOLS=(claude codex opencode pi pi-signed omp grok kimi)
 OPTIONAL_TOOLS=(tmux no-mistakes gh)
 LAUNCH_AGENT_LABEL=dev.firstmate.herdr.fm-remote
 # The dedicated remote-secondmate session. The user's interactive Herdr work

--- a/bin/fm-remote-secondmate-control.sh
+++ b/bin/fm-remote-secondmate-control.sh
@@ -138,7 +138,7 @@ cmd_launch() {
 
   validate_id "$id"
   validate_home "$id"
-  case "$harness" in claude|codex|opencode|pi|pi-signed|grok|kimi) ;; *) die "unverified remote secondmate harness: $harness" ;; esac
+  case "$harness" in claude|codex|opencode|pi|pi-signed|omp|grok|kimi) ;; *) die "unverified remote secondmate harness: $harness" ;; esac
   case "$effort" in -|low|medium|high|xhigh|max) ;; *) die "invalid remote secondmate effort: $effort" ;; esac
   # Herdr is required on this host, not merely preferred: its server belongs to
   # the GUI login session, so the endpoint survives every SSH disconnection that

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -8,14 +8,14 @@
 # lock-owning primary session before it may arm or rewake.
 # This file is sourced by scripts and has no side effects on source.
 
-# Known harness command names; extend when a new adapter is verified.
-FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$'
+# Long-lived process names that may own a firstmate session lock. OMP's exact
+# Bun-script shape is verified alongside its primary and worker adapter.
+FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$|^omp$'
 
-# The same harnesses as exact executable names. Keep in sync with
-# FM_HARNESS_RE. Used only for the stricter path evidence below, where the
-# loose regex would also match ordinary firstmate paths such as
-# bin/fm-claude-stop-autoarm.sh.
-FM_HARNESS_NAMES=(claude codex opencode grok kimi pi-signed pi)
+# Exact executable names for the stricter path evidence below. Keep in sync
+# with FM_HARNESS_RE. The exact-component check avoids treating ordinary
+# firstmate paths such as bin/fm-claude-stop-autoarm.sh as harness processes.
+FM_HARNESS_NAMES=(claude codex opencode grok kimi pi-signed pi omp)
 
 # Print the exact harness name carried by executable path $1 - its own basename
 # or any directory component - or return 1.
@@ -47,7 +47,7 @@ fm_harness_path_name() {  # <path>
 #      argv[0] in `ps -o comm=`, while procps on Linux reports the kernel exec
 #      name and ignores argv[0] entirely, so a version-named Claude Code binary
 #      is identified by its install path on macOS and by argv[0] on Linux.
-#   3. a bare interpreter (node, python) running a harness script path.
+#   3. a bare interpreter (node, python, bun) running a harness script path.
 FM_HARNESS_IS_CLAUDE=0
 fm_harness_process_matches() {  # <comm> <args>
   local comm=$1 args=$2 base argv0 name
@@ -62,7 +62,21 @@ fm_harness_process_matches() {  # <comm> <args>
     case "$name" in claude) FM_HARNESS_IS_CLAUDE=1 ;; esac
     return 0
   fi
-  # Bare interpreter (e.g. node): match the harness name in its script path.
+  # OMP is distributed as a Bun script. Require its script argv to be the exact
+  # `omp` path component; matching arbitrary Bun arguments would let an unrelated
+  # process whose prompt merely mentions OMP claim a firstmate home.
+  case "$comm" in
+    *bun*)
+      local script=${args#* }
+      if [ "$script" != "$args" ]; then
+        script=${script%% *}
+        if name=$(fm_harness_path_name "$script") && [ "$name" = omp ]; then
+          return 0
+        fi
+      fi
+      ;;
+  esac
+  # Bare Node or Python interpreter: match the harness name in its script path.
   case "$comm" in
     *node*|*python*)
       if printf '%s' "$args" | grep -qE "$FM_HARNESS_RE"; then

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -94,9 +94,9 @@
 # The LOCK/BOOTSTRAP/WAKE-QUEUE safety preamble keeps its order: it establishes
 # mutation authority and this turn's work queue before anything else is read.
 #
-# On a Pi primary, the supervision-block step also checks whether Pi's two
-# tracked primary extensions are loaded and prints a PI_WATCH_EXTENSION
-# reminder line when one is missing.
+# On a Pi or OMP primary, the supervision-block step also checks whether that
+# harness's two tracked primary extensions are loaded and prints a
+# PI_WATCH_EXTENSION or OMP_WATCH_EXTENSION reminder line when one is missing.
 #
 # Why lock first: the old documented order (bootstrap, THEN lock) let a
 # SECOND concurrent session run bootstrap's mutating sweeps - converging

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -630,6 +630,18 @@ if [ "$PRIMARY_HARNESS" = pi ] || [ "$PRIMARY_HARNESS" = pi-signed ]; then
     || ! pi_extension_loaded "$PI_TURNEND_MARKER" "$PI_TURNEND_VERSION" "$PI_LOCK"; then
     printf 'PI_WATCH_EXTENSION: not loaded - approve Pi project trust once per clone, then restart %s so %s and %s auto-load for turn-end guard and background wake coverage; use -e %s -e %s only if project hooks are not trusted\n' "$PI_RESTART_COMMAND" "$PI_TURNEND_EXT" "$PI_EXT" "$PI_TURNEND_EXT" "$PI_EXT"
   fi
+elif [ "$PRIMARY_HARNESS" = omp ]; then
+  OMP_EXT="$FM_ROOT/.omp/extensions/fm-primary-omp-watch.ts"
+  OMP_TURNEND_EXT="$FM_ROOT/.omp/extensions/fm-primary-turnend-guard.ts"
+  OMP_WATCH_MARKER="$STATE/.omp-watch-extension-loaded"
+  OMP_TURNEND_MARKER="$STATE/.omp-turnend-extension-loaded"
+  OMP_LOCK="$STATE/.lock"
+  OMP_WATCH_VERSION=$(hash_file "$OMP_EXT" || printf '')
+  OMP_TURNEND_VERSION=$(hash_file "$OMP_TURNEND_EXT" || printf '')
+  if ! pi_extension_loaded "$OMP_WATCH_MARKER" "$OMP_WATCH_VERSION" "$OMP_LOCK" \
+    || ! pi_extension_loaded "$OMP_TURNEND_MARKER" "$OMP_TURNEND_VERSION" "$OMP_LOCK"; then
+    printf 'OMP_WATCH_EXTENSION: not loaded - restart OMP so %s and %s auto-load for turn-end guard and background wake coverage; use -e %s -e %s as an explicit fallback\n' "$OMP_TURNEND_EXT" "$OMP_EXT" "$OMP_TURNEND_EXT" "$OMP_EXT"
+  fi
 fi
 "$SCRIPT_DIR/fm-supervision-instructions.sh" \
   --harness "$PRIMARY_HARNESS" \

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -482,15 +482,21 @@ print_status_tail() {
   done < <(tail -n "$STATUS_TAIL" "$status")
 }
 
+# One version token over an extension's whole load chain, in argument order:
+# an entrypoint that only re-exports a shared implementation cannot prove the
+# loaded code is current on its own bytes. The extensions hash the same files
+# in the same order, so a single-file call still matches a plain file digest.
 hash_file() {
-  local file=$1
-  [ -f "$file" ] || return 1
+  local file
+  for file in "$@"; do
+    [ -f "$file" ] || return 1
+  done
   if command -v shasum >/dev/null 2>&1; then
-    shasum -a 256 "$file" | awk '{print "sha256:" $1}'
+    cat -- "$@" | shasum -a 256 | awk '{print "sha256:" $1}'
   elif command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "$file" | awk '{print "sha256:" $1}'
+    cat -- "$@" | sha256sum | awk '{print "sha256:" $1}'
   else
-    cksum "$file" | awk '{print "cksum:" $1 ":" $2}'
+    cat -- "$@" | cksum | awk '{print "cksum:" $1 ":" $2}'
   fi
 }
 
@@ -636,8 +642,8 @@ elif [ "$PRIMARY_HARNESS" = omp ]; then
   OMP_WATCH_MARKER="$STATE/.omp-watch-extension-loaded"
   OMP_TURNEND_MARKER="$STATE/.omp-turnend-extension-loaded"
   OMP_LOCK="$STATE/.lock"
-  OMP_WATCH_VERSION=$(hash_file "$OMP_EXT" || printf '')
-  OMP_TURNEND_VERSION=$(hash_file "$OMP_TURNEND_EXT" || printf '')
+  OMP_WATCH_VERSION=$(hash_file "$OMP_EXT" "$FM_ROOT/.pi/extensions/fm-primary-pi-watch.ts" || printf '')
+  OMP_TURNEND_VERSION=$(hash_file "$OMP_TURNEND_EXT" "$FM_ROOT/.pi/extensions/fm-primary-turnend-guard.ts" || printf '')
   if ! pi_extension_loaded "$OMP_WATCH_MARKER" "$OMP_WATCH_VERSION" "$OMP_LOCK" \
     || ! pi_extension_loaded "$OMP_TURNEND_MARKER" "$OMP_TURNEND_VERSION" "$OMP_LOCK"; then
     printf 'OMP_WATCH_EXTENSION: not loaded - restart OMP so %s and %s auto-load for turn-end guard and background wake coverage; use -e %s -e %s as an explicit fallback\n' "$OMP_TURNEND_EXT" "$OMP_EXT" "$OMP_TURNEND_EXT" "$OMP_EXT"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1125,7 +1125,6 @@ launch_template() {
   esac
 }
 
-TEMPLATE_LAUNCH=0
 case "$ARG3" in
   *' '*)  # raw launch command (unverified-adapter escape hatch)
     LAUNCH=$ARG3
@@ -1155,12 +1154,10 @@ case "$ARG3" in
       harness_src='config/crew-harness'
     fi
     LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: no launch template for harness '$HARNESS' (from $harness_src or detection); pass a raw launch command to use an unverified adapter" >&2; exit 1; }
-    TEMPLATE_LAUNCH=1
     ;;
   *)
     HARNESS=$ARG3
     LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: unknown harness '$HARNESS'; pass a raw launch command to use an unverified adapter" >&2; exit 1; }
-    TEMPLATE_LAUNCH=1
     ;;
 esac
 
@@ -1173,13 +1170,17 @@ case "$HARNESS" in
   pi|pi-signed) PI_MARKER="FM_PI_HARNESS=$HARNESS " ;;
   *) PI_MARKER= ;;
 esac
-# OMPCODE is OMP's own positive identity marker, so every other verified
-# template strips an inherited one instead of letting its worker self-identify
-# as OMP. A raw launch command stays the operator's verbatim command line.
-if [ "$TEMPLATE_LAUNCH" -eq 1 ] && [ "$HARNESS" != omp ]; then
-  LAUNCH="env -u OMPCODE $PI_MARKER$LAUNCH"
-else
+# OMPCODE is OMP's own positive identity marker and bin/fm-harness.sh detect_own
+# reads it ahead of every other marker, so a worker that is not OMP must not
+# inherit one from the session or multiplexer daemon that launched it - it would
+# report a harness its own task meta contradicts. This binds to the RESOLVED
+# harness, not to the launch kind: a raw escape-hatch command names its adapter
+# too, and leaving that one pane unstripped is exactly the case that breaks the
+# FM_PI_HARNESS marker set above.
+if [ "$HARNESS" = omp ]; then
   LAUNCH="$PI_MARKER$LAUNCH"
+else
+  LAUNCH="env -u OMPCODE $PI_MARKER$LAUNCH"
 fi
 
 # muse is verified as a CREWMATE/SCOUT adapter only. A secondmate is a firstmate

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -104,7 +104,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi|muse)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi|muse|omp)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters. pi-signed launches that exact executable name from PATH and
@@ -148,6 +148,9 @@
 #                  written by this script; outside the worktree to avoid pi's trust gate)
 #     __PITURNEND__ absolute path to .pi/extensions/fm-primary-turnend-guard.ts in a pi secondmate home
 #     __PIWATCH__   absolute path to .pi/extensions/fm-primary-pi-watch.ts in a pi secondmate home
+#     __OMPEXT__    absolute path to state/<task-id>.omp-ext.ts (OMP busy/turn-end extension)
+#     __OMPTURNEND__ absolute path to .omp/extensions/fm-primary-turnend-guard.ts in an OMP secondmate home
+#     __OMPWATCH__   absolute path to .omp/extensions/fm-primary-omp-watch.ts in an OMP secondmate home
 #     __OPINPUT__   absolute path to the canonical operational-input encoder
 # Verified per-harness turn-end hooks are installed automatically where enabled; some live outside the worktree.
 # Kimi uses one surgically installed Firstmate region in $HOME/.kimi-code/config.toml,
@@ -416,7 +419,7 @@ spawn_remote_secondmate() {
     harness=$("$FM_ROOT/bin/fm-harness.sh" secondmate)
   fi
   case "$harness" in
-    claude|codex|opencode|pi|pi-signed|grok|kimi) ;;
+    claude|codex|opencode|pi|pi-signed|grok|kimi|omp) ;;
     *)
       fm_lock_release "$registry_lock" || true
       fm_lock_release "$SPAWN_TASK_LOCK" || true
@@ -1023,7 +1026,7 @@ if [ "$RELAUNCH" -eq 1 ]; then
   }
 elif [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|pi-signed|grok|kimi|muse)
+    ''|claude|codex|opencode|pi|pi-signed|grok|kimi|muse|omp)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -1076,6 +1079,13 @@ launch_template() {
         printf '%s%s' "$harness" ' --tui-mode regular __MODELFLAG____EFFORTFLAG__-e __PIEXT__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       fi
       ;;
+    omp)
+      if [ "$kind" = secondmate ]; then
+        printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT -u GROK_HOOK_EVENT OMPCODE=1 omp __MODELFLAG____EFFORTFLAG__--approval-mode yolo -e __OMPTURNEND__ -e __OMPWATCH__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+      else
+        printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT -u GROK_HOOK_EVENT OMPCODE=1 omp __MODELFLAG____EFFORTFLAG__--approval-mode yolo -e __OMPEXT__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+      fi
+      ;;
     # grok (Grok Build TUI): a positional prompt starts the supervised interactive
     # session. --always-approve auto-approves every tool execution (verified: the
     # crewmate runs fully autonomously, no permission gate), which an unattended
@@ -1115,6 +1125,7 @@ launch_template() {
   esac
 }
 
+TEMPLATE_LAUNCH=0
 case "$ARG3" in
   *' '*)  # raw launch command (unverified-adapter escape hatch)
     LAUNCH=$ARG3
@@ -1144,16 +1155,22 @@ case "$ARG3" in
       harness_src='config/crew-harness'
     fi
     LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: no launch template for harness '$HARNESS' (from $harness_src or detection); pass a raw launch command to use an unverified adapter" >&2; exit 1; }
+    TEMPLATE_LAUNCH=1
     ;;
   *)
     HARNESS=$ARG3
     LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: unknown harness '$HARNESS'; pass a raw launch command to use an unverified adapter" >&2; exit 1; }
+    TEMPLATE_LAUNCH=1
     ;;
 esac
 
-case "$HARNESS" in
-  pi|pi-signed) LAUNCH="FM_PI_HARNESS=$HARNESS $LAUNCH" ;;
-esac
+if [ "$TEMPLATE_LAUNCH" -eq 1 ]; then
+  case "$HARNESS" in
+    omp) ;;
+    pi|pi-signed) LAUNCH="env -u OMPCODE FM_PI_HARNESS=$HARNESS $LAUNCH" ;;
+    *) LAUNCH="env -u OMPCODE $LAUNCH" ;;
+  esac
+fi
 
 # muse is verified as a CREWMATE/SCOUT adapter only. A secondmate is a firstmate
 # instance, so it needs a primary supervision protocol; muse has none, and its
@@ -1171,6 +1188,13 @@ fi
 # retain the literal name in the launch command and task metadata.
 if [ "$HARNESS" = pi-signed ] && ! command -v pi-signed >/dev/null 2>&1; then
   echo "error: pi-signed executable not found on PATH; install the signed Pi wrapper or select a different verified harness" >&2
+  exit 1
+fi
+
+# OMP is an exact executable identity. Resolve it before endpoint creation so a
+# configured adapter cannot fall through to a shell error in an unattended pane.
+if [ "$HARNESS" = omp ] && ! command -v omp >/dev/null 2>&1; then
+  echo "error: omp executable not found on PATH; install OMP or select a different verified harness" >&2
   exit 1
 fi
 
@@ -1283,7 +1307,7 @@ model_flag_for_harness() {
   local harness=$1 model=$2
   [ -n "$model" ] && [ "$model" != default ] || return 0
   case "$harness" in
-    claude|codex|opencode|pi|pi-signed|grok|kimi|muse)
+    claude|codex|opencode|pi|pi-signed|grok|kimi|muse|omp)
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
   esac
@@ -1318,6 +1342,12 @@ effort_flag_for_harness() {
     pi|pi-signed)
       # Pi 0.80.6 accepts the full shared effort vocabulary, including max, through
       # its --thinking flag.
+      case "$effort" in
+        low|medium|high|xhigh|max) printf -- '--thinking %s ' "$(shell_quote "$effort")" ;;
+      esac
+      ;;
+    omp)
+      # OMP 17.2.12 accepts the shared effort vocabulary through --thinking.
       case "$effort" in
         low|medium|high|xhigh|max) printf -- '--thinking %s ' "$(shell_quote "$effort")" ;;
       esac
@@ -2187,7 +2217,7 @@ if [ "$KIND" != secondmate ]; then
       ;;
   esac
   case "$HARNESS" in
-    claude*|opencode*|pi|pi-signed)
+    claude*|opencode*|pi|pi-signed|omp)
       BUSY_GEN=$("$FM_ROOT/bin/fm-busy-event.sh" arm "$STATE_REAL" "$ID") || {
         echo "error: failed to arm the busy-state contract for $ID" >&2
         exit 1
@@ -2311,6 +2341,34 @@ export default function (pi: any) {
     return busyEvent("idle", "agent-settled");
   });
   pi.on("turn_end", () => execFile("touch", ["$TURNEND"]));
+}
+EOF
+      ;;
+    omp)
+      # OMP exposes a verified semantic lifecycle extension API. agent_start
+      # brackets the submitted run; agent_end fires once after session_stop and
+      # the final turn, so it clears busy state and publishes the wake marker
+      # without the inner-turn false idle possible from turn_end.
+      cat > "$STATE/$ID.omp-ext.ts" <<EOF
+// Firstmate semantic busy-state events + turn-end notification; written by
+// fm-spawn under the contract owned by bin/fm-busy-lib.sh.
+import { execFile } from "node:child_process";
+const busyEvent = (state: string, event: string) =>
+  new Promise<void>((resolve) => {
+    execFile("$FM_ROOT/bin/fm-busy-event.sh", [
+      "apply", "$STATE_REAL", "$ID", state,
+      "--gen", "$BUSY_GEN", "--source", "omp-ext", "--event", event,
+    ], () => resolve());
+  });
+export default function (omp: any) {
+  omp.on("agent_start", () => busyEvent("busy", "agent-start"));
+  omp.on("agent_end", async () => {
+    await busyEvent("idle", "agent-end");
+    await new Promise<void>((resolve) => {
+      execFile("touch", ["$TURNEND"], () => resolve());
+    });
+  });
+  omp.on("session_shutdown", () => busyEvent("idle", "session-shutdown"));
 }
 EOF
       ;;
@@ -2553,6 +2611,9 @@ sq_turnend=$(shell_quote "$TURNEND")
 sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
 sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts")
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
+sq_ompext=$(shell_quote "$STATE/$ID.omp-ext.ts")
+sq_ompturnend=$(shell_quote "$PROJ_ABS/.omp/extensions/fm-primary-turnend-guard.ts")
+sq_ompwatch=$(shell_quote "$PROJ_ABS/.omp/extensions/fm-primary-omp-watch.ts")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
@@ -2563,6 +2624,9 @@ LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
+LAUNCH=${LAUNCH//__OMPEXT__/$sq_ompext}
+LAUNCH=${LAUNCH//__OMPTURNEND__/$sq_ompturnend}
+LAUNCH=${LAUNCH//__OMPWATCH__/$sq_ompwatch}
 LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}
 # Crewmate panes are created by a long-lived tmux/herdr daemon that does not
 # inherit firstmate's current environment, so a bare `claude` in the pane falls

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1167,21 +1167,8 @@ esac
 # `pi-signed ...` escape-hatch worker would self-identify as plain pi and
 # contradict the harness recorded in its own task meta.
 case "$HARNESS" in
-  pi|pi-signed) PI_MARKER="FM_PI_HARNESS=$HARNESS " ;;
-  *) PI_MARKER= ;;
+  pi|pi-signed) LAUNCH="FM_PI_HARNESS=$HARNESS $LAUNCH" ;;
 esac
-# OMPCODE is OMP's own positive identity marker and bin/fm-harness.sh detect_own
-# reads it ahead of every other marker, so a worker that is not OMP must not
-# inherit one from the session or multiplexer daemon that launched it - it would
-# report a harness its own task meta contradicts. This binds to the RESOLVED
-# harness, not to the launch kind: a raw escape-hatch command names its adapter
-# too, and leaving that one pane unstripped is exactly the case that breaks the
-# FM_PI_HARNESS marker set above.
-if [ "$HARNESS" = omp ]; then
-  LAUNCH="$PI_MARKER$LAUNCH"
-else
-  LAUNCH="env -u OMPCODE $PI_MARKER$LAUNCH"
-fi
 
 # muse is verified as a CREWMATE/SCOUT adapter only. A secondmate is a firstmate
 # instance, so it needs a primary supervision protocol; muse has none, and its
@@ -2664,6 +2651,17 @@ if [ "$KIND" = secondmate ]; then
   # Reuse the single frozen decision from the carrier resolution above so the
   # injected carrier and this on/off snapshot are guaranteed to agree.
   LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_PUBLIC_FOLLOWUP_PRIMARY_HOME=$sq_primary_home FM_HOME=$sq_home FM_TRACE_CONTEXT=$SPAWN_TRACE_EFFECTIVE FM_SUPERVISION_MODEL=$supervision_model $LAUNCH"
+fi
+# OMPCODE is OMP's own positive identity marker and bin/fm-harness.sh detect_own
+# reads it ahead of every other marker, so a worker that is not OMP must not
+# inherit one from the session or multiplexer daemon that launched it: it would
+# report a harness its own task meta contradicts. This binds to the RESOLVED
+# harness, not to the launch kind, because a raw escape-hatch command names its
+# adapter too. It is a pane-shell statement rather than an `env` prefix so that
+# the escape hatch keeps accepting the shell forms it exists for - `cd x && ...`,
+# a sourced launcher, a shell function - which an `env` prefix would break.
+if [ "$HARNESS" != omp ]; then
+  LAUNCH="unset OMPCODE; $LAUNCH"
 fi
 if [ -z "$SPAWN_TRACEPARENT" ] && [ "$RELAUNCH" -eq 1 ]; then
   LAUNCH="unset TRACEPARENT; $LAUNCH"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1164,12 +1164,22 @@ case "$ARG3" in
     ;;
 esac
 
-if [ "$TEMPLATE_LAUNCH" -eq 1 ]; then
-  case "$HARNESS" in
-    omp) ;;
-    pi|pi-signed) LAUNCH="env -u OMPCODE FM_PI_HARNESS=$HARNESS $LAUNCH" ;;
-    *) LAUNCH="env -u OMPCODE $LAUNCH" ;;
-  esac
+# FM_PI_HARNESS is the identity the WORKER reports back through
+# bin/fm-harness.sh detect_own, which cannot tell pi-signed from pi without it.
+# It binds to the resolved harness for a raw launch command too, or a
+# `pi-signed ...` escape-hatch worker would self-identify as plain pi and
+# contradict the harness recorded in its own task meta.
+case "$HARNESS" in
+  pi|pi-signed) PI_MARKER="FM_PI_HARNESS=$HARNESS " ;;
+  *) PI_MARKER= ;;
+esac
+# OMPCODE is OMP's own positive identity marker, so every other verified
+# template strips an inherited one instead of letting its worker self-identify
+# as OMP. A raw launch command stays the operator's verbatim command line.
+if [ "$TEMPLATE_LAUNCH" -eq 1 ] && [ "$HARNESS" != omp ]; then
+  LAUNCH="env -u OMPCODE $PI_MARKER$LAUNCH"
+else
+  LAUNCH="$PI_MARKER$LAUNCH"
 fi
 
 # muse is verified as a CREWMATE/SCOUT adapter only. A secondmate is a firstmate

--- a/bin/fm-supervision-instructions.sh
+++ b/bin/fm-supervision-instructions.sh
@@ -81,7 +81,7 @@ if [ -z "$HARNESS" ]; then
 fi
 
 case "$HARNESS" in
-  claude|codex|opencode|pi|grok) SNIPPET="$DOC_DIR/$HARNESS.md" ;;
+  claude|codex|opencode|pi|grok|omp) SNIPPET="$DOC_DIR/$HARNESS.md" ;;
   pi-signed) SNIPPET="$DOC_DIR/pi.md" ;;
   *) HARNESS=unknown; SNIPPET="$DOC_DIR/unknown.md" ;;
 esac
@@ -90,6 +90,8 @@ esac
 checkpoint_seconds=${FM_CODEX_WATCH_CHECKPOINT:-180}
 pi_ext="$FM_ROOT/.pi/extensions/fm-primary-pi-watch.ts"
 pi_turnend_ext="$FM_ROOT/.pi/extensions/fm-primary-turnend-guard.ts"
+omp_ext="$FM_ROOT/.omp/extensions/fm-primary-omp-watch.ts"
+omp_turnend_ext="$FM_ROOT/.omp/extensions/fm-primary-turnend-guard.ts"
 x_mode_env="$CONFIG/x-mode.env"
 
 shell_quote() {
@@ -109,6 +111,8 @@ render_snippet() {
   while IFS= read -r line || [ -n "$line" ]; do
     line=${line//__FM_PI_EXT__/$pi_ext}
     line=${line//__FM_PI_TURNEND_EXT__/$pi_turnend_ext}
+    line=${line//__FM_OMP_EXT__/$omp_ext}
+    line=${line//__FM_OMP_TURNEND_EXT__/$omp_turnend_ext}
     line=${line//__FM_X_MODE_ENV_SH__/$x_mode_env_sh}
     line=${line//__FM_X_MODE_ENV__/$x_mode_env}
     printf '%s\n' "$line"
@@ -143,6 +147,9 @@ repair_line() {
     pi|pi-signed)
       printf '%s%s%s%s%s%s\n' "$prefix" 'repair a missing or failed watcher cycle with the Pi tool fm_watch_arm_pi, or restart Pi with -e ' "$pi_turnend_ext" ' -e ' "$pi_ext" ' if the extensions are not loaded.'
       ;;
+    omp)
+      printf '%s%s%s%s%s%s\n' "$prefix" 'repair a missing or failed watcher cycle with the OMP tool fm_watch_arm_omp, or restart OMP with -e ' "$omp_turnend_ext" ' -e ' "$omp_ext" ' if the extensions are not loaded.'
+      ;;
     opencode)
       printf '%s%s\n' "$prefix" 'repair missing watcher supervision by letting the OpenCode TUI plugin arm after idle; use bin/fm-watch-arm.sh only as a manual recovery probe if the plugin reports failure.'
       ;;
@@ -165,6 +172,9 @@ ordinary_wake_line() {
       ;;
     pi|pi-signed)
       printf '%s\n' '- Ordinary wake: the Pi extension already owns watcher continuity; do not arm another cycle.'
+      ;;
+    omp)
+      printf '%s\n' '- Ordinary wake: the OMP extension already owns watcher continuity; do not arm another cycle.'
       ;;
     opencode)
       printf '%s\n' '- Ordinary wake: the OpenCode TUI plugin already owns watcher continuity; do not arm manually.'

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2257,6 +2257,7 @@ cleanup_firstmate_home_children() {
     retire_busy_state "$sub_state" "$child_id" "$child_busy_gen" || return 1
     rm -f "$sub_state/$child_id.status" "$sub_state/$child_id.turn-ended" \
       "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" \
+      "$sub_state/$child_id.omp-ext.ts" \
       "$sub_state/$child_id.grok-turnend-token" "$sub_state/$child_id.kimi-turnend-token" \
       "$sub_state/$child_id.muse-session" "$sub_state/$child_id.muse-session-current"
   done
@@ -2534,7 +2535,7 @@ fm_backend_clear_transition "$BACKEND" "$STATE" "$T" || true
 remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
 retire_busy_state "$STATE" "$ID" "$BUSY_GEN" || exit 1
 rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
-  "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
+  "$STATE/$ID.pi-ext.ts" "$STATE/$ID.omp-ext.ts" "$STATE/$ID.grok-turnend-token" \
   "$STATE/$ID.kimi-turnend-token" "$STATE/$ID.muse-session" \
   "$STATE/$ID.muse-session-current" \
   "$STATE/.$ID.open-decisions-cursor" \

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -67,7 +67,8 @@
 . "$(dirname -- "${BASH_SOURCE[0]}")/fm-composer-lib.sh"
 
 # Delivery-only rendered busy footers per harness. claude/codex: "esc to
-# interrupt"; opencode: "esc interrupt"; pi: "Working..."; grok: "Ctrl+c:cancel".
+# interrupt"; opencode: "esc interrupt"; pi: "Working..."; OMP: "Working…";
+# grok: "Ctrl+c:cancel".
 # Claude's current spinner has a rotating glyph and word, but every active-turn
 # line has an ellipsis followed by a parenthesized elapsed duration. Keep this
 # signature separate from the shared default because that shape is not generic
@@ -87,6 +88,7 @@ FM_TMUX_CLAUDE_BUSY_REGEX_DEFAULT='esc to interrupt|…[[:space:]]+\([0-9]+[smh]
 FM_TMUX_CODEX_BUSY_REGEX_DEFAULT='esc to interrupt'
 FM_TMUX_OPENCODE_BUSY_REGEX_DEFAULT='esc interrupt'
 FM_TMUX_PI_BUSY_REGEX_DEFAULT='Working\.\.\.'
+FM_TMUX_OMP_BUSY_REGEX_DEFAULT='Working(\.\.\.|…)'
 FM_TMUX_GROK_BUSY_REGEX_DEFAULT='Ctrl\+c:cancel'
 FM_TMUX_KIMI_BUSY_REGEX_DEFAULT='^[[:space:]]*(🌑|🌒|🌓|🌔|🌕|🌖|🌗|🌘)[[:space:]]+·[[:space:]]+'
 
@@ -101,6 +103,7 @@ fm_busy_lines_match() {  # [harness]
       codex) regex=$FM_TMUX_CODEX_BUSY_REGEX_DEFAULT ;;
       opencode) regex=$FM_TMUX_OPENCODE_BUSY_REGEX_DEFAULT ;;
       pi|pi-signed) regex=$FM_TMUX_PI_BUSY_REGEX_DEFAULT ;;
+      omp) regex=$FM_TMUX_OMP_BUSY_REGEX_DEFAULT ;;
       grok) regex=$FM_TMUX_GROK_BUSY_REGEX_DEFAULT ;;
       kimi) regex=$FM_TMUX_KIMI_BUSY_REGEX_DEFAULT ;;
       '') regex=$FM_TMUX_BUSY_REGEX_DEFAULT ;;

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -48,7 +48,7 @@ The clear is refused before anything is sent when the recorded backend cannot de
 Removing a worktree, closing an endpoint, or discarding work stays with [`bin/fm-teardown.sh`](../bin/fm-teardown.sh), which owns the landed-work test.
 
 **`resume` is not a verb.**
-It is not deterministic across the verified adapters: codex and grok resume only from a session id printed at exit, opencode continues the most recent session for the cwd, and claude, pi, pi-signed, and kimi have no verified pane-resume contract.
+It is not deterministic across the verified adapters: codex and grok resume only from a session id printed at exit, opencode continues the most recent session for the cwd, and claude, pi, pi-signed, OMP, kimi, and muse have no verified pane-resume contract.
 `relaunch` covers the same need on every adapter, because the brief on disk - not a harness-private session - is the durable instruction.
 
 ## Transactional relaunch

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,7 +57,7 @@ The default path remains local-only; live GitHub enrichment exists only behind t
 Optional Relay integrates with the watcher only after explicit opt-in; [configuration.md](configuration.md#relay-env) owns its generated-artifact and dispatch mechanics.
 
 At session start, `bin/fm-session-start.sh` emits exactly one primary-harness supervision block rendered by `bin/fm-supervision-instructions.sh` from `docs/supervision-protocols/`.
-That block owns the live wait shape for the running primary harness: Claude's Stop `asyncRewake` hook owns tokenless re-arm cycles, Grok uses background-notify cycles, Codex uses bounded foreground checkpoints, Pi and pi-signed use the same two tracked primary extensions, and OpenCode uses its TUI plugin.
+That block owns the live wait shape for the running primary harness: Claude's Stop `asyncRewake` hook owns tokenless re-arm cycles, Grok uses background-notify cycles, Codex uses bounded foreground checkpoints, Pi and pi-signed share two tracked Pi extensions, OMP uses two tracked OMP entrypoints over the same Pi-family core, and OpenCode uses its TUI plugin.
 `bin/fm-watch-arm.sh` remains the verified arm wrapper for protocols that call it; it forks the watcher as a tracked child, verifies it is genuinely alive with a fresh liveness beacon, and prints an honest `started`, `attached`, or nonzero `FAILED` status.
 [`watcher-continuity.md`](watcher-continuity.md#arm-layer-cycle-contract) owns the arm layer's successor, terminal-delivery, and typed clean-close failure contract.
 The arm layer records one bounded lifecycle row per observed cycle in `state/.watch-cycle-exits.log`; `state/.watch-triage.log` remains exclusively the absorbed-wake debug log.
@@ -65,7 +65,7 @@ Pi and OpenCode verify session-lock ownership and launch one singleton successor
 Claude's `bin/fm-claude-stop-autoarm.sh` hook fires on every Stop and, when the home is eligible and still needs supervision, claims one home-scoped cycle, foregrounds the arm wrapper, and translates actionable closes into exit-2 rewakes.
 It suppresses failed-looking closes when the same identity-matched watcher is healthy, retries genuine failures within a bound, and coordinates exhausted failure episodes with the Claude turn-end guard as documented in [`turnend-guard.md`](turnend-guard.md).
 [`watcher-continuity.md`](watcher-continuity.md) owns Claude's residual active-turn coverage and watcher-status command-gating boundary.
-The existing turn-end guard remains the final backstop for all five harness-engine protocols, with pi-signed sharing Pi's protocol and the `--claude` mode cooperating with the auto-arm claim.
+The existing turn-end guard remains the final backstop for every verified primary protocol, with pi-signed sharing Pi's protocol, OMP selecting its own lifecycle events through the shared extension core, and the `--claude` mode cooperating with the auto-arm claim.
 Its `--restart` mode signals only the watcher recorded in the current home's `state/.watch.lock`, so restarting one home cannot kill sibling secondmate watchers.
 A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if the primary checkout is tangled, if work, process-event sources, or Relay polling has an unhealthy model-aware supervision verdict, or if queued wakes are waiting to be drained.
 The drain script calls that guard after emptying the queue, which avoids repeating the queued-wakes warning for records it just consumed while still warning on unhealthy supervision.
@@ -99,7 +99,7 @@ Text for a worker to read and commands that drive a worker's process are separat
 `bin/fm-busy-lib.sh` is the single owner of what "this worker is busy" means, and `bin/fm-busy-event.sh` is the only writer of the per-task records it reads.
 Every classification returns a verdict of busy, idle, unknown, or dead together with the source that produced it, so a consumer or a diagnostic can never confuse semantic state with a fallback.
 
-Each converted adapter reports its own turn lifecycle through a machine-readable contract the vendor already exposes, rather than through rendered footer text: Pi and pi-signed through the Firstmate-owned extension's `agent_start` and `agent_settled` confirmed by `ctx.isIdle()`, OpenCode through its plugin's semantic `session.status`, and Claude through owned `UserPromptSubmit`, `Stop`, `StopFailure`, and `SessionEnd` hooks.
+Each converted adapter reports its own turn lifecycle through a machine-readable contract the vendor already exposes, rather than through rendered footer text: Pi and pi-signed through the Firstmate-owned extension's `agent_start` and `agent_settled` confirmed by `ctx.isIdle()`, OMP through `agent_start` and `agent_end`, OpenCode through its plugin's semantic `session.status`, and Claude through owned `UserPromptSubmit`, `Stop`, `StopFailure`, and `SessionEnd` hooks.
 Kimi behind Pi inherits Pi's lifecycle.
 Codex and standalone Kimi classify unknown behind explicit probes until a semantic source is live-verified for them, and Grok keeps one clearly isolated rendered-tail fallback that can only ever classify a Grok task.
 
@@ -175,7 +175,7 @@ The session-start bootstrap step keeps valid dispatch configuration silent unles
 When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
 Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
-That keeps spawn launch compatible across claude, codex, opencode, pi, pi-signed, grok, kimi, and muse while preserving the requested profile for later audit.
+That keeps spawn launch compatible across claude, codex, opencode, pi, pi-signed, omp, grok, kimi, and muse while preserving the requested profile for later audit.
 
 ## Optional secondmates
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,7 +61,7 @@ That block owns the live wait shape for the running primary harness: Claude's St
 `bin/fm-watch-arm.sh` remains the verified arm wrapper for protocols that call it; it forks the watcher as a tracked child, verifies it is genuinely alive with a fresh liveness beacon, and prints an honest `started`, `attached`, or nonzero `FAILED` status.
 [`watcher-continuity.md`](watcher-continuity.md#arm-layer-cycle-contract) owns the arm layer's successor, terminal-delivery, and typed clean-close failure contract.
 The arm layer records one bounded lifecycle row per observed cycle in `state/.watch-cycle-exits.log`; `state/.watch-triage.log` remains exclusively the absorbed-wake debug log.
-Pi and OpenCode verify session-lock ownership and launch one singleton successor from their child-close handlers before delivering an actionable wake prompt, with bounded exponential retry for failed restoration.
+Pi-family adapters and OpenCode verify session-lock ownership and launch one singleton successor from their child-close handlers before delivering an actionable wake prompt, with bounded exponential retry for failed restoration.
 Claude's `bin/fm-claude-stop-autoarm.sh` hook fires on every Stop and, when the home is eligible and still needs supervision, claims one home-scoped cycle, foregrounds the arm wrapper, and translates actionable closes into exit-2 rewakes.
 It suppresses failed-looking closes when the same identity-matched watcher is healthy, retries genuine failures within a bound, and coordinates exhausted failure episodes with the Claude turn-end guard as documented in [`turnend-guard.md`](turnend-guard.md).
 [`watcher-continuity.md`](watcher-continuity.md) owns Claude's residual active-turn coverage and watcher-status command-gating boundary.

--- a/docs/arm-pretool-check.md
+++ b/docs/arm-pretool-check.md
@@ -211,7 +211,7 @@ Observed output for the four allowed calls was `UNRELATED_EXECUTED`, a successfu
 Each harness blocked the final command with exit 2 mapped through its native adapter behavior.
 The stable reason was `[watcher-background] a protected watcher command cannot run in an asynchronous shell list or through nohup/disown`.
 The dummy arm body would have created `<harness>.sentinel` if the denied command executed.
-All five sentinel files remained absent.
+All six sentinel files remained absent.
 
 The Codex transcript showed `PreToolUse Completed` for all three originally reported false-positive shapes and `PreToolUse Blocked` only for the backgrounded arm.
 The Grok debug transcript showed four exit-0 results from `project/fm-primary-pretool-check`, then exit 2 with 145 stdout bytes, 214 stderr bytes, and `hook denied` for the backgrounded arm.

--- a/docs/arm-pretool-check.md
+++ b/docs/arm-pretool-check.md
@@ -24,7 +24,7 @@ It tokenizes the bytes and classifies lexical execution positions only.
 
 - Stdin JSON at `.tool_input.command` for Claude and Codex.
 - Stdin JSON at `.toolInput.command` for Grok.
-- `--command <exact string>` for OpenCode, Pi, and pi-signed.
+- `--command <exact string>` for OpenCode, Pi, pi-signed, and OMP.
 - `--background` as a compatibility-only field that never changes the decision.
 - `--claude` to preserve Claude's stderr-only deny requirement.
 
@@ -151,7 +151,7 @@ Prose may improve without changing adapter behavior.
 - `--claude` suppresses stdout completely because Claude ignores a PreToolUse deny when stdout is nonempty.
 - Codex blocks on exit 2 and displays stderr.
 - OpenCode throws only when the checker exits 2.
-- Pi and pi-signed return `{block: true}` only when the checker exits 2.
+- Pi, pi-signed, and OMP return `{block: true}` only when the checker exits 2.
 
 ## Harness wiring
 
@@ -162,6 +162,7 @@ Prose may improve without changing adapter behavior.
 | Grok | `.toolInput.command` | `.grok/hooks/fm-primary-pretool-check.json` forwards stdin and Grok consumes the stdout `decision=deny` object. |
 | OpenCode | `output.args.command` | `.opencode/plugins/fm-primary-pretool-check.js` passes one `--command` argument and throws only for exit 2. |
 | Pi / pi-signed | `event.input.command` | `.pi/extensions/fm-primary-turnend-guard.ts` passes one `--command` argument and returns `{block: true}` only for exit 2. |
+| OMP | `event.input.command` | `.omp/extensions/fm-primary-turnend-guard.ts` reuses the Pi-family core, passes one `--command` argument, and returns `{block: true}` only for exit 2. |
 
 Grok project hooks require folder trust.
 Every shell variable reference in a Grok hook command must carry an inline default such as `${GROK_WORKSPACE_ROOT:-}` because Grok expands the raw hook command before `bash -lc` runs it.
@@ -203,6 +204,7 @@ codex exec --dangerously-bypass-hook-trust --dangerously-bypass-approvals-and-sa
 GROK_HOME="$SCRATCH_GROK_HOME" RUST_LOG=xai_grok_hooks=debug GROK_LOG_FILE="$SCRATCH_LOG" grok --trust -p "$PROMPT" --permission-mode bypassPermissions --output-format plain
 OPENCODE_CONFIG_CONTENT='{"permission":{"*":"allow"}}' opencode run --print-logs --log-level INFO "$PROMPT"
 pi -p -e .pi/extensions/fm-primary-turnend-guard.ts --no-context-files --no-session "$PROMPT"
+OMPCODE=1 omp -p -e .omp/extensions/fm-primary-turnend-guard.ts --no-context-files --no-session --no-tools "$PROMPT"
 ```
 
 Observed output for the four allowed calls was `UNRELATED_EXECUTED`, a successful read-only `pgrep`, `CHECKPOINT_EXECUTED`, and two `TMUX_ARGS:` lines that preserved the watcher text as data.

--- a/docs/cd-guard.md
+++ b/docs/cd-guard.md
@@ -74,13 +74,13 @@ It does not permit `cd /home/project`, because an absolute-path `cd` remains a p
 
 ## Transport and fail-open behavior
 
-`bin/fm-cd-pretool-check.sh` supports all five harness-engine entry shapes used by the tracked adapters, with pi-signed sharing Pi's shape:
+`bin/fm-cd-pretool-check.sh` supports all five harness-engine entry shapes used by the tracked adapters, with pi-signed and OMP sharing Pi's shape:
 
 - Claude sends stdin JSON at `.tool_input.command` and adds `--claude` to preserve Claude's stderr-only deny requirement.
 - Codex sends stdin JSON at `.tool_input.command` without `--claude`.
 - Grok sends stdin JSON at `.toolInput.command`.
 - OpenCode sends the exact command string through `--command <exact string>`.
-- Pi and pi-signed send the exact command string through `--command <exact string>`.
+- Pi, pi-signed, and OMP send the exact command string through `--command <exact string>`.
 
 Processing order is cheapest-first: a strict-superset prefilter, then the primary-checkout scope, then the Node policy owner.
 The prefilter removes ordinary single quotes, double quotes, backslashes, carriage returns, and newlines before fast-allowing any command that carries no `cd`, `pushd`, or `popd` substring and no quoting-decoder marker (`$'` ANSI-C or `$"` locale), so quoted or escaped command-word fragments delegate to the policy while most commands never pay for the git scoping calls or the Node process.
@@ -99,7 +99,7 @@ Identical in shape to `docs/arm-pretool-check.md`:
 - `--claude` suppresses stdout completely because Claude ignores a PreToolUse deny when stdout is nonempty.
 - Codex blocks on exit 2 and displays stderr.
 - OpenCode throws only when the checker exits 2.
-- Pi and pi-signed return `{block: true}` only when the checker exits 2.
+- Pi, pi-signed, and OMP return `{block: true}` only when the checker exits 2.
 
 ## Shared classifier ownership
 
@@ -117,6 +117,7 @@ The cd-guard never duplicates shell lexing; it adds only the cd-specific decisio
 | Grok | `.grok/hooks/fm-primary-cd-check.json` PreToolUse hook anchored on `${GROK_WORKSPACE_ROOT:-}` | Consumes the stdout `decision=deny` object. |
 | OpenCode | `.opencode/plugins/fm-primary-cd-check.js` `tool.execute.before` | Throws, which surfaces as the failed tool result. |
 | Pi | `.pi/extensions/fm-primary-turnend-guard.ts` `tool_call` handler | Returns `{block: true}`; piggybacks on the already-loaded primary extension so no extra `-e` flag is needed. |
+| OMP | `.omp/extensions/fm-primary-turnend-guard.ts` `tool_call` handler, reusing the Pi-family core | Returns `{block: true}`; piggybacks on the auto-loaded primary extension so no extra `-e` flag is needed. |
 
 Each harness runs the cd-guard alongside the watcher-arm seatbelt; the two are independent checks, and either deny blocks the command.
 Every shell variable reference in the Grok hook command carries an inline default (`${GROK_WORKSPACE_ROOT:-}`) because Grok expands the raw hook command before `bash -lc` runs it, the same requirement documented in `docs/arm-pretool-check.md`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -217,7 +217,7 @@ Pi and pi-signed crew launches explicitly pass `--tui-mode regular` so fullscree
 Enabled primary-session turn-end guard integrations are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).
 Kimi remains outside the primary turn-end guard integrations; [`docs/turnend-guard.md`](turnend-guard.md#compatibility-limits) owns its separate captain-approved crew wake hook.
 Primary-session watcher wake protocols are rendered at session start by [`bin/fm-supervision-instructions.sh`](../bin/fm-supervision-instructions.sh) from [`docs/supervision-protocols/`](supervision-protocols/).
-Claude's Stop `asyncRewake` hook owns tokenless re-arm cycles, Grok uses background-notify cycles, Codex uses bounded foreground checkpoints, Pi and pi-signed use the same two tracked primary extensions, and OpenCode uses its TUI plugin.
+[`docs/architecture.md`](architecture.md#event-driven-supervision) owns the per-harness live wait shape those protocols describe.
 `config/crew-harness` is a local, gitignored file containing one adapter name for crewmate and scout launches.
 When pi-signed is selected, Firstmate launches the executable named `pi-signed` from `PATH` with `FM_PI_HARNESS=pi-signed` and refuses the launch if it is unavailable rather than falling back to pi.
 Plain Pi launches set `FM_PI_HARNESS=pi`, so a signed primary's environment cannot relabel a plain Pi worker.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -206,7 +206,7 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 
 ## Harness support
 
-claude, codex, opencode, pi, pi-signed, grok, and kimi are empirically verified for crewmate and secondmate launches; [README requirements](../README.md#requirements) own the set supported for the primary session.
+claude, codex, opencode, pi, pi-signed, omp, grok, and kimi are empirically verified for crewmate and secondmate launches; [README requirements](../README.md#requirements) own the set supported for the primary session.
 muse is verified for crewmate and scout launches ONLY, and `fm-spawn.sh` refuses it for a secondmate, because muse ships no usable hook surface for a primary session's turn-end supervision; [`docs/verification/muse.md`](verification/muse.md) owns that evidence.
 muse also needs a worker-reachable credential before spawning, and the portable fleet path is the `<config>/muse/auth.json` credential stored by `muse login`, because a caller-only `META_API_KEY` does not cross a long-lived backend daemon.
 New harnesses get verified through a supervised trial task before joining the set.
@@ -241,6 +241,7 @@ Kimi continues to use the captain's normal Kimi home, including the existing con
 The Kimi installer requires an existing regular non-symlink `~/.kimi-code/config.toml`, `python3` with `tomllib`, and `jq`; it validates but never serializes the captain's TOML and refuses before writing when the config is missing, malformed, or surprising or when either tool requirement is unavailable.
 Its `remove` action excises only the marker-delimited Firstmate region and removes Firstmate's hook files.
 For Pi and pi-signed secondmate launches, `fm-spawn.sh` starts the selected executable with `-e` pointed at the secondmate home's own tracked `.pi/extensions/fm-primary-pi-watch.ts` and `.pi/extensions/fm-primary-turnend-guard.ts`, both already present from the secondmate home's git worktree.
+For OMP secondmate launches, `fm-spawn.sh` uses the same contract with the secondmate home's `.omp/extensions/fm-primary-omp-watch.ts` and `.omp/extensions/fm-primary-turnend-guard.ts`.
 
 ## Crew dispatch profiles (config/crew-dispatch.json)
 
@@ -510,7 +511,7 @@ HERDR_SESSION=default  # herdr-only: named session for normal backend ops; not e
 FM_BACKEND_HERDR_COMPOSER_LINES=20  # herdr-only: tail lines scanned by composer-state guard/fallback paths; idle-baseline submit confirmation uses agent-state
 FM_BACKEND_HERDR_IDLE_RE='^Type a message\.\.\.$'  # herdr-only: empty-composer placeholder regex after shared ghost extraction plus border and prompt stripping
 FM_BACKEND_HERDR_BARE_PROMPT_RE='^(❯|›)'  # herdr-only: verified agent glyphs recognized as an UNBORDERED (bare) composer row, e.g. Claude's ❯ or Codex's ›; an alternation, not a `[...]` bracket expression, so a C-locale byte-decomposed match can never misfire on an unrelated multibyte glyph; shell glyphs remain unknown rather than empty, and de-emphasised ghost/placeholder text reads empty through shared fm_composer_strip_ghost (docs/herdr-backend.md "Composer and injection safety")
-FM_BACKEND_HERDR_PI_COMPOSER_MAX_LINES=8  # herdr-only: maximum rows admitted between Pi's native-identity-corroborated separator pair; taller or ambiguous candidates stay unknown (docs/herdr-backend.md "Composer and injection safety")
+FM_BACKEND_HERDR_PI_COMPOSER_MAX_LINES=8  # herdr-only: maximum rows admitted between a Pi-family separator pair corroborated by native Pi or OMP identity; taller or ambiguous candidates stay unknown (docs/herdr-backend.md "Composer and injection safety")
 FM_BACKEND_HERDR_SUBMIT_POLLS=6  # herdr-only: agent-state samples spread across each Enter attempt's budget when confirming a submit (docs/herdr-backend.md "Current transport behavior")
 FM_BACKEND_HERDR_SUBMIT_MIN_SLEEP=0.6  # herdr-only: minimum per-Enter confirmation budget before polling agent-state after an idle baseline
 FM_BACKEND_ORCA_COMPOSER_LINES=200  # orca-only: terminal-read lines scanned to locate the composer row for submit verification

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -305,6 +305,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": "docs/supervision-protocols/omp.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": "docs/supervision-protocols/opencode.md",
       "audience": "agent-runtime"
     },

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -223,13 +223,14 @@ This generous floor is required for small composer and peek reads.
 
 Herdr's native agent state can read idle while a harness waits on its own long foreground tool.
 The shared crew-state path therefore accepts a native `busy` as evidence of activity but never a native `idle` as evidence that a worker has stopped; the task's own semantic busy state (`bin/fm-busy-lib.sh`) decides that.
+OMP 17.2.12 also leaves its native agent registration at `idle` after `/exit` returns to the pane's nested worktree shell, so the backend recognizes stopped OMP only when Herdr process metadata and the OS process table prove the same lone idle shell with no child.
 A human-blocked permission dialog has no busy banner and still surfaces.
 
 ## Composer and injection safety
 
 Herdr has no direct cursor-row primitive.
-The adapter locates the bottom-most recognized bordered row, Claude `❯` row, Codex `›` row, or a Pi separator region admitted only when native identity is exactly Pi and state is idle, done, or blocked.
-A working Pi, pending middle row, missing identity, incomplete separator pair, or over-tall candidate remains pending or unknown.
+The adapter locates the bottom-most recognized bordered row, Claude `❯` row, Codex `›` row, or a Pi-family separator region admitted only when native identity is exactly Pi or OMP and state is idle, done, or blocked.
+A working Pi-family agent, pending middle row, missing identity, incomplete separator pair, or over-tall candidate remains pending or unknown.
 
 ANSI capture preserves de-emphasized placeholder style.
 `bin/fm-composer-lib.sh` is the fleet-wide owner that strips dim or faint runs and dark truecolor placeholders while retaining bright typed input.

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -105,7 +105,7 @@ These steps are never automated and are always reported rather than silently att
 - The first console login on that Mac, and automatic login in System Settings > Users & Groups when the machine runs headless and must come back on its own after a reboot.
 - FileVault, which holds a reboot at pre-boot authentication before any login session exists.
 - Installing any missing required tool that no safe wrapper can resolve.
-- The required remote tool set is `git`, `jq`, `herdr`, compatible `tasks-axi`, `treehouse`, and at least one of `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, or `kimi`.
+- The required remote tool set is `git`, `jq`, `herdr`, compatible `tasks-axi`, `treehouse`, and at least one of `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `omp`, `grok`, or `kimi`.
 - Each worker runtime's own `/login`, and any keychain password prompt that login needs.
 
 Firstmate never writes an auto-login password, never changes FileVault, and never stores an account password.

--- a/docs/sessionstart-nudge.md
+++ b/docs/sessionstart-nudge.md
@@ -7,7 +7,7 @@ Firstmate ships two session-open tiers, and the tier is a property of the harnes
 
 | Tier | What the adapter does | Used by |
 | --- | --- | --- |
-| Run | Executes `bin/fm-session-start.sh` in the hook and lets its ordered digest land in model context before the first turn. | Claude, `codex exec`, Pi / pi-signed |
+| Run | Executes `bin/fm-session-start.sh` in the hook and lets its ordered digest land in model context before the first turn. | Claude, `codex exec`, Pi / pi-signed, OMP |
 | Nudge | Asks the agent to run the digest through the native adapter or the tracked session-start instruction. | Grok, OpenCode, Codex interactive TUI, and run-tier sources routed to the nudge |
 
 The run tier exists because the nudge can only ask.
@@ -70,12 +70,13 @@ A lock another session holds and a truncated digest therefore surface as digest 
 | Codex exec | Run | `.codex/hooks.json` anchors to the hook process working directory, verifies a Firstmate-shaped hook-bearing root, and pipes the hook payload into the wrapper with a 180s timeout. | Native stdout context injection is supported under `codex exec`. |
 | Codex interactive TUI | Nudge | The tracked `AGENTS.md` session-start instruction and Ahoy step-zero fallback remain visible when the project hook does not fire. | Codex 0.146.0 does not fire the tracked project `SessionStart` hook in its interactive TUI. Firstmate ships no global hook and does not depend on one. |
 | Pi / pi-signed | Run | `.pi/extensions/fm-primary-turnend-guard.ts` maps `session_start` reasons `startup`, `new`, `resume`, and `fork` onto wrapper sources, handles `session_compact` as the compaction equivalent, and injects the output with `pi.sendMessage`. | The custom message reaches model context without racing an initial positional prompt. Pi's `reload` reason is deliberately unmapped, as it always was. |
+| OMP | Run | `.omp/extensions/fm-primary-turnend-guard.ts` reuses the Pi-family delivery core, maps initial `session_start` to `startup`, maps `session_switch` reasons `new`, `resume`, and `fork`, and handles `session_compact`; it injects output with `pi.sendMessage`. | OMP's extension API is a strict event superset of Pi's compatibility type; `agent_end` replaces Pi's `agent_settled` for the turn-end path. |
 | OpenCode | Nudge | `.opencode/plugins/fm-primary-sessionstart-nudge.js` listens for `session.created`, runs once per session id, and calls `client.session.promptAsync` only when the wrapper prints a nudge. | Interactive TUI delivery is supported; headless `opencode run` is intentionally fail-open because the process can exit before the queued turn. That early exit is also why OpenCode cannot use the run tier. |
 | Grok | Nudge | `.grok/hooks/fm-primary-sessionstart-nudge.json` registers a project `SessionStart` hook and invokes the wrapper through inline-defaulted `${GROK_WORKSPACE_ROOT:-}`. | The project hook runs when the checkout is trusted, but Grok currently discards hook stdout from model context, so this path is intentionally fail-open and cannot use the run tier. |
 
-Pi is the only adapter that injects a message rather than hook stdout, so whatever it injects must carry operational provenance or the Ahoy skill would have to guess whether it was captain-authored.
-The extension therefore encodes an unencoded digest as `session-start` operational input before sending it, and leaves the already-encoded nudge alone.
-It streams the hook to completion and retains at most 512 KiB for message delivery; this approved containment keeps the prefix and appends a loud `PI SESSION-START DELIVERY TRUNCATED` marker with direct-inspection guidance whenever the digest is incomplete.
+Pi-family adapters are the only adapters that inject a message rather than hook stdout, so whatever they inject must carry operational provenance or the Ahoy skill would have to guess whether it was captain-authored.
+The shared extension core therefore encodes an unencoded digest as `session-start` operational input before sending it, and leaves the already-encoded nudge alone.
+It streams the hook to completion and retains at most 512 KiB for message delivery; this approved containment keeps the prefix and appends a loud harness-named `SESSION-START DELIVERY TRUNCATED` marker with direct-inspection guidance whenever the digest is incomplete.
 
 The OpenCode nudge runs only on `session.created`.
 The watcher-arm and turn-end plugins run later on `session.idle`, and the guard lets the watcher coordinator act first, so the plugins do not race for one lifecycle event.

--- a/docs/supervision-protocols/omp.md
+++ b/docs/supervision-protocols/omp.md
@@ -1,0 +1,22 @@
+Mode: OMP extension background wake.
+
+When this session owns supervision and away mode is not active:
+1. Drain first with `bin/fm-wake-drain.sh`.
+2. Confirm OMP auto-loaded both project extensions; if not, restart `omp` with `-e __FM_OMP_TURNEND_EXT__ -e __FM_OMP_EXT__` as an explicit fallback.
+3. First cycle only: make the one required `fm_watch_arm_omp` call.
+   Use `/fm-watch-arm-omp` only as a human-entered fallback.
+   Never run `bin/fm-watch-arm.sh` through OMP's bash tool because that foreground arm can wedge the agent and bypass extension-owned cleanup.
+4. If the extension says no live session holds the lock, run `bin/fm-session-start.sh` to reclaim the session lock, then call `fm_watch_arm_omp` again.
+5. The extension starts `bin/fm-watch-arm.sh --restart`, keeps the child attached to the live OMP process, and owns every later successor launch.
+6. Ordinary same-process session replacement keeps one live generation; a terminal `session_shutdown` retires it.
+7. After an actionable child close, the extension rechecks session-lock ownership and verifies one successor before it delivers the follow-up notification; its bounded fallback is defined in `docs/watcher-continuity.md`.
+8. Ordinary work, turn completion, and ordinary notification handling: do not call `fm_watch_arm_omp` again because continuity is extension-owned rather than model-memory-owned.
+9. An unexpected child close enters bounded exponential retry, and an exhausted retry or lost session lock is surfaced as a watcher failure instead of disappearing.
+10. Missing, failed, or unhealthy cycle only: drain queued notifications, inspect the failure text, call `fm_watch_arm_omp`, and restart OMP with both extensions loaded if needed.
+    A redundant call while the extension owns an arm child or scheduled retry is an ownership-based `watcher: unchanged` no-op, not an independent health claim.
+11. Never use shell `&` for watcher supervision.
+    The manual recovery seatbelt is wired into the turn-end guard at `__FM_OMP_TURNEND_EXT__`.
+
+The turn-end guard extension lives at `__FM_OMP_TURNEND_EXT__`.
+The watcher extension lives at `__FM_OMP_EXT__`.
+Both are tracked project-local `.omp/extensions/*.ts` files that OMP auto-discovers; `bin/fm-session-start.sh` reports when the running OMP session has not loaded both required extensions.

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -60,6 +60,7 @@ Scoping the second source to the foreground process group rather than to the pan
 The same scoping covers multi-process launchers without a special case, so the Pi Launcher path is attributed through its `pi-signed` wrapper and `pi` engine even though its title is the exact foreground command `pi-launcher`.
 Direct executable identities `pi`, `pi-signed`, and `Pi` remain accepted exactly, and similar or prefixed process names are not accepted through those exact Pi-family entries.
 Muse is likewise anchored to the exact `muse` launcher identity or the installed `muse-bin-<version>` prefix, so unrelated names such as `musescore` and `amuse` remain ambiguous.
+OMP runs as a Bun script, so the foreground probe exports only its script argument as an identity candidate and accepts it only when that path carries an exact `omp` component; later prompt arguments that merely mention OMP are never process identity.
 
 The CI-enforced portable regression and opt-in real-harness drift guard follow the split owned by `.agents/skills/firstmate-coding-guidelines/SKILL.md`.
 Run the real-harness guard after any harness upgrade and before trusting refreshed evidence.

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -48,7 +48,7 @@ Verify setup by spawning a small task and confirming its `fm-<id>` window appear
 
 A target-existence check proves only that the pane exists.
 The deeper tmux agent-liveness probe first verifies exact window membership, then reads process names to distinguish a running harness from a bare idle shell.
-It classifies recognized Claude, Codex, OpenCode, Pi, pi-signed, Grok, Kimi, and Muse process names as `alive`, common shells as `dead`, an authoritatively absent window as `missing`, unreadable state as `unreadable`, and every other process as `ambiguous`.
+It classifies recognized Claude, Codex, OpenCode, Pi, pi-signed, OMP, Grok, Kimi, and Muse process names as `alive`, common shells as `dead`, an authoritatively absent window as `missing`, unreadable state as `unreadable`, and every other process as `ambiguous`.
 Only `dead` and `missing` authorize recovery because a false dead result could launch a duplicate agent.
 
 For positive attribution, the probe combines two independent name sources rather than making either one load-bearing.

--- a/docs/trace-context.md
+++ b/docs/trace-context.md
@@ -23,7 +23,7 @@ When enabled, for each spawn Firstmate resolves one W3C `traceparent` carrier fo
 This feature parents no SDK span by itself.
 
 Because the injected carrier and the recorded carrier are the same string, an observer that reads the metadata reconstructs exactly the identity the child received.
-The injection sits at the unconditional pre-launch export site, so it covers ship and scout spawns across `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, `kimi`, and `muse`, plus Secondmate spawns across that same set except the deliberately crewmate-only `muse` adapter.
+The injection sits at the unconditional pre-launch export site, so it covers ship and scout spawns across `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `omp`, `grok`, `kimi`, and `muse`, plus Secondmate spawns across that same set except the deliberately crewmate-only `muse` adapter.
 This is the same coverage `GOTMPDIR` already has and requires no trace-specific `launch_template()` behavior.
 Ship and scout spawns reach that site on every spawn backend (`tmux`, `herdr`, `zellij`, `orca`, `cmux`); a Secondmate reaches it on every backend that accepts a Secondmate spawn (`tmux`, `herdr`, `zellij`), because `bin/fm-spawn.sh` rejects a Secondmate on `orca` and `cmux`.
 

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -47,6 +47,7 @@ If `jq` is missing or hook stdin is empty, the guard exits 0 because it cannot s
 - Codex registers a `Stop` hook in `.codex/hooks.json`, anchors the executable to the hook process working directory, verifies a Firstmate-shaped hook-bearing root, and passes the original payload to the shared guard.
 - OpenCode listens for `session.idle` in `.opencode/plugins/fm-primary-turnend-guard.js`, lets the watcher coordinator act first, and calls `client.session.promptAsync` once when the guard returns 2.
 - Pi listens for `agent_settled` in `.pi/extensions/fm-primary-turnend-guard.ts`, runs once per logical agent run, and calls `pi.sendUserMessage(..., { deliverAs: "followUp" })` once when the guard returns 2.
+- OMP auto-loads `.omp/extensions/fm-primary-turnend-guard.ts`, reuses the Pi-family core, listens for OMP's logical-run `agent_end`, and calls `pi.sendUserMessage(..., { deliverAs: "followUp" })` once when the guard returns 2.
 - Grok registers a `Stop` hook in `.grok/hooks/fm-primary-turnend-guard.json` and delegates capability selection to `bin/fm-turnend-guard-grok.sh`.
   The tracked Claude Stop entries are inert when `GROK_AGENT` or `GROK_HOOK_EVENT` is present, so Grok's Claude-compatible settings loading cannot create a second continuation path.
   Both markers are required because Grok does not inject the same variables into every process kind: grok 0.2.73 set `GROK_AGENT` for child and tool processes, while grok 1.0.0 hook processes carry `GROK_HOOK_EVENT`, `GROK_HOOK_NAME`, `GROK_SESSION_ID`, and `GROK_WORKSPACE_ROOT` but no `GROK_AGENT`.
@@ -75,11 +76,11 @@ The alarm cannot repeat during that failure episode, and a later unhealthy stop 
 A positively verified healthy watcher clears the failure notice, alarm, and block budget for a future independent episode.
 A Claude failure notice describes the automatic mechanism as broken and does not direct a routine manual background arm.
 
-OpenCode, Pi, and pi-signed expose passive callbacks for this purpose.
-Their adapters fail open at the hook boundary to protect the user session but schedule one bounded follow-up when the predicate blocks.
+OpenCode, Pi, pi-signed, and OMP expose passive callbacks for this purpose.
+Their adapters step aside at the hook boundary to protect the user session but schedule one bounded follow-up when the predicate blocks.
 The generated prompts use the canonical `turn-end-guard` kind after the U+2063 `FIRSTMATE_OP: ` prefix, so Ahoy does not treat them as captain messages.
 Each passive adapter owns a loop latch.
-Pi keeps the latch across internal tool turns and clears it only when the generated follow-up settles or delivery fails.
+Pi-family adapters keep the latch across internal tool turns and clear it only when the generated follow-up settles or delivery fails.
 OpenCode's forced follow-up is supported for persistent TUI sessions and remains fail-open in headless `opencode run`.
 
 Grok makes exactly one typed capability decision from each running Stop payload.
@@ -110,9 +111,9 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 
 ## Regression coverage
 
-`tests/fm-turnend-guard.test.sh` covers the predicate, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the live-lock and fresh-beacon guard predicate, the cooperative `--claude` claim wait, monotonic failed-epoch progression, bounded attended fail-open, post-alarm continuation suppression, positive recovery reset, Pi logical-run latching, missing-`jq` behavior, all five primary registrations, Grok native and legacy selection, typed field precedence, malformed input, and exactly-one-path safety.
+`tests/fm-turnend-guard.test.sh` covers the predicate, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the live-lock and fresh-beacon guard predicate, the cooperative `--claude` claim wait, monotonic failed-epoch progression, bounded attended fail-open, post-alarm continuation suppression, positive recovery reset, Pi-family logical-run latching, missing-`jq` behavior, all verified primary registrations, Grok native and legacy selection, typed field precedence, malformed input, and exactly-one-path safety.
 `tests/fm-guard-stale-banner.test.sh` covers the pull-guard predicate, including the persistent-model fresh-leftover-beacon negative control, the auto-arm model's healthy fresh-beacon-without-a-watcher case and its stale-beacon alarm, the true-reason banner wording, and the reason-keyed episode dedup surviving a beacon mtime change.
 `tests/fm-kimi-harness.test.sh` covers the separate Kimi crew hook's format preservation, idempotence, refusal cases, token guard, spawn registration, and teardown cleanup.
-`tests/fm-supervision-instructions.test.sh` covers recovery-line ownership and pi-signed's identity-preserving reuse of Pi's protocol.
+`tests/fm-supervision-instructions.test.sh` covers recovery-line ownership, pi-signed's identity-preserving reuse of Pi's protocol, and OMP's distinct tracked extension paths.
 `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` is the opt-in isolated Pi path.
-[`verification/supervision.md`](verification/supervision.md#turn-end-guard) records the active cross-harness empirical evidence, including the 2026-07-24 Claude `asyncRewake` revalidation.
+[`verification/supervision.md`](verification/supervision.md#turn-end-guard) records the active cross-harness empirical evidence, including the 2026-08-09 OMP primary extension smoke.

--- a/docs/verification/public-followup.md
+++ b/docs/verification/public-followup.md
@@ -73,7 +73,7 @@ Roughly 0.07 ms per session start, from a single `[ -f "$FM_HOME/.env" ]` test t
 
 ## Compatibility axes reviewed
 
-Primary harnesses (`claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, `kimi`): not applicable after inspection.
+Primary harnesses (`claude`, `codex`, `opencode`, `pi`, `pi-signed`, `omp`, `grok`, `kimi`): not applicable after inspection.
 Nothing here reads or renders harness-specific state.
 The only supervision surfaces touched are the session-start digest, which `bin/fm-supervision-instructions.sh` already renders per harness without knowing this section exists, and the wake payload produced by the existing relay poll, which every harness protocol consumes identically.
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -6,6 +6,28 @@ This record contains reusable version-scoped evidence for active runtime guarant
 The backend guides own current setup, safety boundaries, and limitations.
 Exact task chronology, branch names, temporary homes, local paths, process ids, thread ids, and delivery transcripts remain in private reports or PR evidence.
 
+## OMP primary session identity
+
+OMP 17.2.12 was verified on 2026-08-09 as a primary-session lock identity, not as a dispatch or watcher adapter.
+The live OMP tool environment exported `OMPCODE=1` while also inheriting `CLAUDECODE=1`, and its long-lived process had the shape `bun <home>/.bun/bin/omp`.
+The marker therefore selects the unknown supervision protocol before the foreign Claude marker, while the exact Bun script ancestry supplies the stable process id that owns the home lock.
+An unrelated Bun script whose later arguments merely mention OMP remains outside that identity.
+
+Portable and live verification:
+
+```sh
+tests/fm-secondmate-harness.test.sh
+FM_HARNESS_LIVENESS_DRIFT=1 tests/fm-harness-liveness-drift-live-e2e.test.sh
+```
+
+Observed relevant output:
+
+```text
+ok - OMP primary identity: exact Bun script owns the session lock without claiming a verified supervision adapter
+# OMP omp/17.2.12: OMP_IDENTITY marker=1 harness=unknown lock=<pid> process=<same-pid>
+ok - OMP session identity: omp/17.2.12 owns the lock without claiming a verified supervision adapter
+```
+
 ## tmux
 
 Foreground-process behavior was verified on 2026-07-07 with tmux 3.6a on macOS.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -8,10 +8,10 @@ Exact task chronology, branch names, temporary homes, local paths, process ids, 
 
 ## OMP primary session identity
 
-OMP 17.2.12 was verified on 2026-08-09 as a primary-session lock identity, not as a dispatch or watcher adapter.
+OMP 17.2.12 was verified on 2026-08-09 as a primary-session identity: the marker that selects its own supervision adapter, and the process shape that owns the home lock.
 The live OMP tool environment exported `OMPCODE=1` while also inheriting `CLAUDECODE=1`, and its long-lived process had the shape `bun <home>/.bun/bin/omp`.
-The marker therefore selects the unknown supervision protocol before the foreign Claude marker, while the exact Bun script ancestry supplies the stable process id that owns the home lock.
-An unrelated Bun script whose later arguments merely mention OMP remains outside that identity.
+The marker therefore resolves the harness as `omp` before the foreign Claude marker, so supervision instructions select the verified `omp` protocol, while the exact Bun script ancestry supplies the stable process id that owns the home lock.
+An unrelated Bun script whose later arguments merely mention OMP remains outside that identity, and a bare Bun with no script argument stays unattributed even when its install path carries an `omp` component.
 
 Portable and live verification:
 
@@ -23,9 +23,9 @@ FM_HARNESS_LIVENESS_DRIFT=1 tests/fm-harness-liveness-drift-live-e2e.test.sh
 Observed relevant output:
 
 ```text
-ok - OMP primary identity: exact Bun script owns the session lock without claiming a verified supervision adapter
-# OMP omp/17.2.12: OMP_IDENTITY marker=1 harness=unknown lock=<pid> process=<same-pid>
-ok - OMP session identity: omp/17.2.12 owns the lock without claiming a verified supervision adapter
+ok - OMP identity: positive marker and exact Bun script select the verified adapter and session-lock owner
+# OMP omp/17.2.12: OMP_IDENTITY marker=1 harness=omp lock=<pid> process=<same-pid>
+ok - OMP session identity: omp/17.2.12 selects the verified adapter and owns the lock
 ```
 
 ## tmux

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -57,7 +57,7 @@ Pi and pi-signed 0.82.0 were reverified on 2026-07-27 through real isolated `fm-
 The earlier record that every harness is observed under its own `#{pane_current_command}` no longer holds and has been replaced by the per-harness evidence below.
 In this macOS run that reading reflected a rewritable process title rather than stable executable identity, so it is now one of two independent name sources rather than the sole basis of a verdict.
 
-The seven primary-capable adapters were relaunched on 2026-08-03 with tmux 3.6a on macOS 26.5.2 arm64, each on a private socket in an isolated lab.
+The seven primary-capable adapters verified at that point were relaunched on 2026-08-03 with tmux 3.6a on macOS 26.5.2 arm64, each on a private socket in an isolated lab.
 
 ```sh
 tmux -L "$socket" new-window -d -t "$session:" -n "$harness" -c "$wt" -- "$bin"
@@ -84,6 +84,8 @@ That is the evidence for treating any single process name as a surface under ven
 The crewmate-only Muse Code 0.1.0-R708.1 adapter was verified separately on 2026-08-05 against tmux on macOS arm64.
 Its installed `muse-bin-0.1.0-R708.1` foreground identity classified `alive`, while `musescore`, `amuse`, `muse-binary`, and `muse-bind` remained ambiguous in the portable regression.
 [`muse.md`](muse.md#process-identity) owns the artifact identity and launcher evidence for that verification.
+
+OMP carries no harness name in either process-name source, so its foreground attribution rests on the Bun script argument recorded in [OMP primary session identity](#omp-primary-session-identity) above; the drift guard's per-harness relaunch loop now includes `omp`.
 
 Bounded observed output:
 
@@ -200,7 +202,7 @@ ok - fm-teardown: dedicated-socket invalid cleanup preserves target/control and 
 The dedicated tmux cell removed ambient tmux variables, required a socket-bound wrapper, kept one target and one independent control window, and proved the wrapper was not called for invalid metadata or a direct empty target.
 Valid cleanup removed only the exact task-bound target and left the control window live.
 The metadata-only validation covers tmux, Herdr, Zellij, Orca, and cmux before backend dispatch.
-Claude, Codex, OpenCode, Pi, pi-signed, Grok, Kimi, and Muse share that backend cleanup boundary; their harness-specific hook files, tokens, and session-log sidecars are cleaned only after it, so no harness needs a separate endpoint parser.
+Claude, Codex, OpenCode, Pi, pi-signed, OMP, Grok, Kimi, and Muse share that backend cleanup boundary; their harness-specific hook files, tokens, and session-log sidecars are cleaned only after it, so no harness needs a separate endpoint parser.
 
 ## Herdr
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -8,9 +8,9 @@ Exact task chronology, branch names, temporary homes, local paths, process ids, 
 
 ## OMP primary session identity
 
-OMP 17.2.12 was verified on 2026-08-09 as a primary-session identity: the marker that selects its own supervision adapter, and the process shape that owns the home lock.
-The live OMP tool environment exported `OMPCODE=1` while also inheriting `CLAUDECODE=1`, and its long-lived process had the shape `bun <home>/.bun/bin/omp`.
-The marker therefore resolves the harness as `omp` before the foreign Claude marker, so supervision instructions select the verified `omp` protocol, while the exact Bun script ancestry supplies the stable process id that owns the home lock.
+OMP 17.2.12 was verified on 2026-08-09 as a primary-session identity: the exact Bun script ancestry that selects its supervision adapter and the process shape that owns the home lock.
+The live OMP tool environment did not export `OMPCODE=1`, inherited `CLAUDECODE=1`, and its long-lived process had the shape `bun <home>/.bun/bin/omp`.
+The exact Bun argv[1] therefore resolves the harness as `omp` before the foreign Claude marker, so supervision instructions select the verified `omp` protocol, while the same ancestry supplies the stable process id that owns the home lock.
 An unrelated Bun script whose later arguments merely mention OMP remains outside that identity on both surfaces, because each judges argv[1] alone.
 The two surfaces deliberately differ for a bare Bun carrying no script argument at all: harness detection leaves it unattributed, while the session-lock owner check reaches it through the same whole-path-component rule that identifies a version-named Claude Code binary, so a Bun installed under an `omp` path component still reads as a possible lock owner there.
 That asymmetry is the conservative direction - a recycled lock pid can only keep a session read-only, never hand two sessions the same lock - and it is not narrowed by the `omp` identity above.
@@ -25,9 +25,9 @@ FM_HARNESS_LIVENESS_DRIFT=1 tests/fm-harness-liveness-drift-live-e2e.test.sh
 Observed relevant output:
 
 ```text
-ok - OMP identity: positive marker and exact Bun script select the verified adapter and session-lock owner
-# OMP omp/17.2.12: OMP_IDENTITY marker=1 harness=omp lock=<pid> process=<same-pid>
-ok - OMP session identity: omp/17.2.12 selects the verified adapter and owns the lock
+ok - OMP identity: positive marker and exact Bun script defeat inherited foreign markers
+# OMP omp/17.2.12: OMP_IDENTITY marker= harness=omp lock=<pid> process=<same-pid>
+ok - OMP session identity: omp/17.2.12 selects the adapter and owns the lock under an inherited marker
 ```
 
 ## tmux

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -11,7 +11,9 @@ Exact task chronology, branch names, temporary homes, local paths, process ids, 
 OMP 17.2.12 was verified on 2026-08-09 as a primary-session identity: the marker that selects its own supervision adapter, and the process shape that owns the home lock.
 The live OMP tool environment exported `OMPCODE=1` while also inheriting `CLAUDECODE=1`, and its long-lived process had the shape `bun <home>/.bun/bin/omp`.
 The marker therefore resolves the harness as `omp` before the foreign Claude marker, so supervision instructions select the verified `omp` protocol, while the exact Bun script ancestry supplies the stable process id that owns the home lock.
-An unrelated Bun script whose later arguments merely mention OMP remains outside that identity, and a bare Bun with no script argument stays unattributed even when its install path carries an `omp` component.
+An unrelated Bun script whose later arguments merely mention OMP remains outside that identity on both surfaces, because each judges argv[1] alone.
+The two surfaces deliberately differ for a bare Bun carrying no script argument at all: harness detection leaves it unattributed, while the session-lock owner check reaches it through the same whole-path-component rule that identifies a version-named Claude Code binary, so a Bun installed under an `omp` path component still reads as a possible lock owner there.
+That asymmetry is the conservative direction - a recycled lock pid can only keep a session read-only, never hand two sessions the same lock - and it is not narrowed by the `omp` identity above.
 
 Portable and live verification:
 

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -82,6 +82,9 @@ compact
 Pi disagrees with Claude and Codex on `resume`: a NEW Pi process continuing a session reports `startup`, and Pi's `resume` reason is reserved for an in-process session switch.
 That is correct for the run tier rather than a problem, because a new process holds no lock and must take the helm; the routing table in [`../sessionstart-nudge.md`](../sessionstart-nudge.md#source-routing) is written to whichever source each harness actually reports.
 
+OMP 17.2.12 joined the run tier on 2026-08-09 through the same tracked guard extension, and the live event probe recorded under [Watcher continuity](#watcher-continuity) is its current source evidence: initial `session_start` plus same-process `session_switch` for replacement.
+It is not yet one of the harnesses the lab below drives, so its cold-open, context-reset, and reopen rows are absent from the table above rather than measured and omitted.
+
 ### Detached session-open workers survive the hook
 
 Session start composes its digest from local reads and runs every external-network call in a worker detached by the hook (`bin/fm-startup-network.sh`), so a harness that reaped the hook's process tree would silently stop running the sweeps rather than merely delaying them.
@@ -121,7 +124,7 @@ SECONDMATE_SYNC: secondmate ios: skipped: remote inheritance failed on remote-ma
 
 The unreachable route was preserved rather than relaunched in both runs, and the result surfaced durably as a queued `check: startup-network` wake once the worker finished.
 
-Codex and Pi were not installed as run-tier labs in this measurement, so their evidence for this fact is NOT refreshed; `tests/fm-sessionstart-hook-live-e2e.test.sh` asserts it for every installed run-tier harness and is the command that refreshes this record.
+Codex and Pi were not installed as run-tier labs in this measurement, so their evidence for this fact is NOT refreshed; `tests/fm-sessionstart-hook-live-e2e.test.sh` asserts it for every installed harness that lab drives - currently Claude, Codex, and Pi, not OMP - and is the command that refreshes this record.
 A harness that did reap the worker degrades loudly rather than silently: the leftover record reads as an abandoned run needing a rerun, and the next session start re-derives every finding, because these sweeps are idempotent detectors.
 
 Current deterministic and live entry points:

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -156,6 +156,10 @@ Each pass polled `state/<id>.busy-state` while a real turn ran.
 | Kimi (standalone) | not installed | None usable | No binary on `PATH`, so the gate stays closed and it classifies `unknown kimi-unverified`. |
 | Grok | 0.2.112 | Isolated rendered-tail fallback | Retained unconverted; the approved audit could not credit a live structured-lifecycle run. |
 
+
+OMP 17.2.12 was verified on 2026-08-09 with a live extension event probe and the tracked OMP primary entrypoints.
+The runtime emitted `agent_start`, `session_stop`, `turn_end`, and one final `agent_end` for a completed run, and emitted `session_switch` for same-process replacement.
+`tests/fm-busy-state.test.sh` and `tests/fm-secondmate-harness.test.sh` pin the generated `omp-ext` mapping from `agent_start` to busy and from `agent_end` to idle plus the turn-end marker.
 Codex was probed two ways, both refused:
 
 ```sh
@@ -178,7 +182,7 @@ tests/fm-crew-state.test.sh
 
 ## Turn-end guard
 
-The direct and passive mechanisms were validated across all five harnesses on 2026-07-08 through 2026-07-12, with Claude's replacement Stop-owned path revalidated on 2026-07-24.
+The direct and passive mechanisms were validated across the supported harnesses on 2026-07-08 through 2026-08-09, with Claude's replacement Stop-owned path revalidated on 2026-07-24.
 
 | Harness | Version verified | Mechanism | Observed result |
 | --- | --- | --- | --- |
@@ -186,6 +190,7 @@ The direct and passive mechanisms were validated across all five harnesses on 20
 | Codex | 0.142.1 | Blocking `Stop` hook | Hook process root stayed anchored to the trusted checkout and one continuation ran. |
 | OpenCode | 1.17.6 | Passive `session.idle` callback | Throwing could not block, while `promptAsync` scheduled one TUI follow-up; headless remained fail-open. |
 | Pi | 0.80.5 | Passive `agent_settled` callback | Exactly one guard follow-up ran for an unhealthy cycle, with no recursion across tool turns. |
+| OMP | 17.2.12 | Passive `agent_end` callback | A live run emitted one final `agent_end`; the tracked entrypoint's deterministic integration test injected exactly one recovery follow-up per logical run without registering Pi's `agent_settled` event. |
 | Grok | 0.2.112 native and 0.2.73 pre-native | Running-payload adaptive `Stop` | Native false-to-true continuation stayed in one process with two model turns and zero resume launches; the field-absent pre-native process launched exactly one guarded resume. |
 
 The Grok adaptive matrix ran on 2026-07-28 with separate scratch repositories and homes, dedicated tmux sockets, one target plus one control window, ambient tmux variables removed, and a socket-bound wrapper first in `PATH`.
@@ -328,7 +333,14 @@ tests/fm-pi-primary-types.test.sh
 
 Observed guarantee: after ordinary `session_shutdown` for `/new`, `/resume`, and `/fork`, plus same-instance shutdown-plus-start, the replacement generation armed again without a Pi restart and without the `watcher: not armed - Pi session is shutting down` refusal.
 Stale prior-generation tool callbacks could not mutate the active child, repeated transitions kept exactly one live arm cycle, and terminal `quit` still refused late rearm.
-Plain Pi and pi-signed share the same tracked `.pi/extensions/fm-primary-pi-watch.ts` path, so both inherit the generation owner; other primary harnesses are not applicable because they do not use this Pi extension lifecycle.
+Plain Pi and pi-signed share the tracked `.pi/extensions/fm-primary-pi-watch.ts` entrypoint.
+OMP loads its tracked `.omp/extensions/` entrypoints over that same core, selecting OMP-specific events, tool names, markers, and session-switch behavior; other primary harnesses do not use this Pi-family extension lifecycle.
+
+OMP 17.2.12 primary supervision was live-verified on 2026-08-09 from the tracked project root with an isolated Firstmate home.
+Project-local `.omp/extensions/` discovery loaded both tracked entrypoints without explicit `-e` flags.
+The `session_start` hook acquired the isolated home lock and wrote `.omp-watch-extension-loaded` and `.omp-turnend-extension-loaded`; both recorded SHA-256 values matched the current tracked entrypoint bytes and named the live OMP process.
+The model then called `fm_watch_arm_omp` exactly once, returned `OMP_TOOL_OK`, and the watcher published a fresh `.last-watcher-beat` plus an owned watcher lock before process-exit cleanup.
+An independent live event probe observed `session_start`, `agent_start`, `session_stop`, `turn_end`, `agent_end`, and same-process `session_switch`; the tracked deterministic tests pin the event-to-generation and guard contracts.
 
 Deterministic entry points:
 

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -338,7 +338,7 @@ OMP loads its tracked `.omp/extensions/` entrypoints over that same core, select
 
 OMP 17.2.12 primary supervision was live-verified on 2026-08-09 from the tracked project root with an isolated Firstmate home.
 Project-local `.omp/extensions/` discovery loaded both tracked entrypoints without explicit `-e` flags.
-The `session_start` hook acquired the isolated home lock and wrote `.omp-watch-extension-loaded` and `.omp-turnend-extension-loaded`; both recorded SHA-256 values matched the current tracked entrypoint bytes and named the live OMP process.
+The `session_start` hook acquired the isolated home lock and wrote `.omp-watch-extension-loaded` and `.omp-turnend-extension-loaded`; both recorded SHA-256 values matched the current bytes of the tracked entrypoint together with the shared Pi-family implementation it re-exports, and named the live OMP process.
 The model then called `fm_watch_arm_omp` exactly once, returned `OMP_TOOL_OK`, and the watcher published a fresh `.last-watcher-beat` plus an owned watcher lock before process-exit cleanup.
 An independent live event probe observed `session_start`, `agent_start`, `session_stop`, `turn_end`, `agent_end`, and same-process `session_switch`; the tracked deterministic tests pin the event-to-generation and guard contracts.
 

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -159,7 +159,8 @@ Each pass polled `state/<id>.busy-state` while a real turn ran.
 
 OMP 17.2.12 was verified on 2026-08-09 with a live extension event probe and the tracked OMP primary entrypoints.
 The runtime emitted `agent_start`, `session_stop`, `turn_end`, and one final `agent_end` for a completed run, and emitted `session_switch` for same-process replacement.
-`tests/fm-busy-state.test.sh` and `tests/fm-secondmate-harness.test.sh` pin the generated `omp-ext` mapping from `agent_start` to busy and from `agent_end` to idle plus the turn-end marker.
+`tests/fm-busy-adapter-wiring.test.sh` loads the generated `omp-ext` extension in a plain Node host and pins that mapping through the real writer and classifier: `agent_start` to busy, `agent_end` to idle plus the turn-end marker, `session_shutdown` to idle, and a superseded generation's events rejected as stale.
+`tests/fm-busy-state.test.sh` pins `omp-ext` source isolation and `tests/fm-secondmate-harness.test.sh` pins the launch that installs it.
 Codex was probed two ways, both refused:
 
 ```sh

--- a/docs/watcher-continuity.md
+++ b/docs/watcher-continuity.md
@@ -5,10 +5,10 @@ Must-work continuity now lives above that process boundary instead of depending 
 
 ## Ownership
 
-Pi's `.pi/extensions/fm-primary-pi-watch.ts` and OpenCode's `.opencode/plugins/fm-primary-watch-arm.js` own continuous re-arm after an actionable child close.
+Pi's `.pi/extensions/fm-primary-pi-watch.ts`, which OMP loads through its own `.omp/extensions/fm-primary-omp-watch.ts` entrypoint, and OpenCode's `.opencode/plugins/fm-primary-watch-arm.js` own continuous re-arm after an actionable child close.
 Each adapter starts the next arm before delivering the wake prompt, checks current session-lock ownership at launch, preserves one child or scheduled retry at a time, and applies bounded exponential retry after an unexpected or failed close.
 A failed follow-up never cancels continuity restoration.
-Pi same-process session replacement follows the generation-owner contract in `.pi/extensions/fm-primary-pi-watch.ts`.
+Pi-family same-process session replacement follows the generation-owner contract in `.pi/extensions/fm-primary-pi-watch.ts`, reached through Pi's `session_start` and OMP's `session_switch`.
 Claude's `.claude/settings.json` Stop `asyncRewake` hook (`bin/fm-claude-stop-autoarm.sh`) owns routine tokenless re-arm.
 The hook fires on every Stop, and an eligible primary with supervision need admits one home-scoped owner that foregrounds `bin/fm-watch-arm.sh` inside the hook-owned process tree.
 A numeric session-lock owner that fails the shared `fm_harness_pid_alive` predicate is reclaimed through `bin/fm-lock.sh` before auto-arm state changes, while a live owner, absent lock, or malformed lock keeps the competing hook inert.
@@ -21,14 +21,14 @@ While supervision is still needed and away mode remains inactive, an actionable 
 
 ## Actionable wake ordering
 
-After an actionable Pi or OpenCode child close, the adapter starts and verifies one singleton successor before it delivers the original wake.
+After an actionable Pi-family or OpenCode child close, the adapter starts and verifies one singleton successor before it delivers the original wake.
 It waits at most one readiness timeout per attempt, then sends TERM and waits a bounded retirement confirmation before the next lock-verified exponential retry.
 If the unready arm does not retire within that bound, the adapter keeps ownership, starts no overlapping retry, and delivers the typed fallback immediately.
 When that retained arm later closes, its actual close is classified as a new supervised event without replaying the earlier fallback.
 After the configured retry bound is exhausted, it delivers the original wake with a typed continuity-restoration failure even if every successor arm hung without reporting readiness.
 This is deliberate Option B ordering: the fleet is protected before the model handles the wake whenever restoration succeeds, but the model is never left blind when it does not.
 
-Claude's Stop hook starts the successor arm at the next Stop after the handling turn, rather than before notification as Pi and OpenCode do.
+Claude's Stop hook starts the successor arm at the next Stop after the handling turn, rather than before notification as the Pi-family and OpenCode adapters do.
 The durable wake queue preserves actionable events during the residual active-turn window, and the bounded turn-end guard enforces recovery at Stop when no watcher or auto-arm claim is present.
 The model no longer re-arms after ordinary wakes.
 No PreToolUse hook denies fleet commands based on watcher status.
@@ -62,6 +62,7 @@ Only the watcher process touches `state/.last-watcher-beat`; no helper process c
 
 `tests/fm-pi-watch-extension.test.sh` checks Pi's first-cycle-or-explicit-repair tool metadata and ownership-based redundant-call no-ops, then simulates actionable and empty child closes against the actual Pi and OpenCode close handlers, blocks prompt delivery to prove the successor launches first, verifies single-flight behavior, changes the session lock before close to prove ownership is rechecked, and hangs each successor arm to prove bounded fallback delivery includes the typed restoration failure.
 The same suite covers ordinary same-process session replacement for `/new`, `/resume`, and `/fork`, same-instance shutdown-plus-start, stale prior-generation callbacks, repeated transitions with exactly one live cycle, disappearance of the shutting-down refusal after a valid replacement activates, and terminal quit still refusing late rearm.
+It also pins that the loaded entrypoint alone selects the Pi-family vocabulary: the OMP entrypoint takes OMP's lifecycle, tool, command, and marker names, while a Pi session that inherited `OMPCODE` keeps Pi's.
 `tests/fm-watcher-lock.test.sh` covers verified-successor attach, the typed self-eviction failure, bounded and successor-linked lifecycle rows, and a SIGSTOP counterfactual that distinguishes a live PID from a stale beacon before classifying termination.
 `tests/fm-subagent-pretool-check.test.sh` proves Claude retains only the non-status Bash seatbelts.
 `tests/fm-claude-stop-autoarm.test.sh` covers the auto-arm's scope, stale and live session owners, unchanged AFK and need boundaries, single-flight, bounded failure retries, benign live-watcher cycle ends, one-notice failure episodes, and exit-2 translation.
@@ -70,9 +71,9 @@ The same suite covers ordinary same-process session replacement for `/new`, `/re
 
 ## Active limits and verification
 
-The goal is continuity without a Pi or OpenCode model-memory re-arm step.
+The goal is continuity without a Pi-family or OpenCode model-memory re-arm step.
 No zero-latency guarantee is claimed because lock verification, watcher startup, and bounded retry delays remain deliberate safety work.
 OpenCode support targets persistent TUI sessions rather than headless `opencode run`.
 Claude depends on the Stop `asyncRewake` rewake, Grok retains native background-completion notifications, and Codex retains bounded foreground checkpoints.
 
-[`verification/supervision.md`](verification/supervision.md#watcher-continuity) records the current five-harness live evidence, the 2026-07-24 Stop-owned Claude auto-arm results, and exact opt-in commands.
+[`verification/supervision.md`](verification/supervision.md#watcher-continuity) records the current cross-harness live evidence, the 2026-07-24 Stop-owned Claude auto-arm results, the 2026-08-09 OMP primary pass, and exact opt-in commands.

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -3095,6 +3095,103 @@ test_composer_state_omp_separator_idle_is_empty() {
   pass "fm_backend_herdr_composer_state: a native idle OMP separator composer reads empty"
 }
 
+# --- OMP's stale idle agent registration after /exit ------------------------
+#
+# OMP 17.2.12 leaves its Herdr agent registration at `idle` once /exit has
+# returned the pane to the task's nested worktree shell, so the registration
+# alone cannot distinguish a working OMP worker from a husk. The verdict these
+# cases pin is load-bearing in both directions: `no-agent` maps to `dead` and
+# licenses close-and-replace on a live worktree, while a missed husk leaves a
+# reclaimable tab stranded forever.
+
+# omp_agent_state_verdict <dir> <agent> <status> <process-info-json> [ps-rows]:
+# drive fm_backend_herdr_pane_agent_state over a canned presence read, agent
+# registration, and pane process-info, backed by a fake operating-system
+# process table. ps-rows is the `-axo pid=,ppid=` table (default: pid 4242 as a
+# lone child of init); every pid in it answers `-o comm=` as a login zsh except
+# 5150, the Bun runtime a live OMP worker keeps in its pane.
+omp_agent_state_verdict() {  # <dir> <agent> <status> <process-info> [ps-rows]
+  local dir=$1 agent=$2 status=$3 info=$4 rows=${5:-'1 0
+4242 1'} log resp fb
+  mkdir -p "$dir/responses"
+  log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '%s\n' '{"result":{"pane":{"pane_id":"w1:p1","tab_id":"w1:t1","workspace_id":"w1"}}}' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent":"%s","agent_status":"%s"}}}\n' "$agent" "$status" > "$resp/2.out"
+  printf '%s\n' "$info" > "$resp/3.out"
+  printf '%s\n' "$rows" > "$dir/ps-rows"
+  cat > "$dir/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  "-axo pid=,ppid=") cat "${FM_FAKE_PS_ROWS:?}" ;;
+  *"-o comm=")
+    pid=
+    while [ "$#" -gt 0 ]; do
+      case "$1" in -p) pid=$2; shift 2 ;; *) shift ;; esac
+    done
+    grep -q "^$pid " "${FM_FAKE_PS_ROWS:?}" || exit 1
+    case "$pid" in
+      5150) printf 'bun\n' ;;
+      *) printf -- '-zsh\n' ;;
+    esac
+    ;;
+  *) exit 1 ;;
+esac
+SH
+  chmod +x "$dir/ps"
+  fb=$(make_herdr_fakebin "$dir")
+  PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_PS_BIN="$dir/ps" \
+    FM_FAKE_PS_ROWS="$dir/ps-rows" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_pane_agent_state lab w1:p1' "$ROOT"
+}
+
+omp_lone_shell_process_info() {  # <pid>
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p1","shell_pid":%s,"foreground_process_group_id":%s,"foreground_processes":[{"pid":%s,"name":"zsh","argv0":"zsh"}]}}}' "$1" "$1" "$1"
+}
+
+test_omp_idle_registration_over_a_lone_shell_is_no_agent() {
+  local out
+  out=$(omp_agent_state_verdict "$TMP_ROOT/omp-husk-idle" omp idle "$(omp_lone_shell_process_info 4242)")
+  [ "$out" = no-agent ] \
+    || fail "an OMP registration left idle over the bare worktree shell must be a reclaimable husk, got '$out'"
+  out=$(omp_agent_state_verdict "$TMP_ROOT/omp-husk-done" omp done "$(omp_lone_shell_process_info 4242)")
+  [ "$out" = no-agent ] \
+    || fail "the same stale OMP registration reported done must also be a husk, got '$out'"
+  pass "herdr agent state: a stale OMP registration over the bare worktree shell classifies no-agent"
+}
+
+test_omp_idle_registration_over_a_running_bun_stays_live() {
+  local out info
+  info='{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p1","shell_pid":4242,"foreground_process_group_id":5150,"foreground_processes":[{"pid":5150,"name":"bun","argv0":"bun"}]}}}'
+  out=$(omp_agent_state_verdict "$TMP_ROOT/omp-live-bun" omp idle "$info" '1 0
+4242 1
+5150 4242')
+  [ "$out" = live ] \
+    || fail "an OMP worker between turns is still running Bun in its pane and must stay live, got '$out'"
+  pass "herdr agent state: an idle OMP registration backed by a running Bun process stays live"
+}
+
+# The shape a husk read must never claim: the pane's foreground process looks
+# like the shell, but the operating system still shows a child under it, so the
+# agent has not actually exited.
+test_omp_idle_registration_over_a_shell_with_a_child_stays_live() {
+  local out
+  out=$(omp_agent_state_verdict "$TMP_ROOT/omp-live-child" omp idle "$(omp_lone_shell_process_info 4242)" '1 0
+4242 1
+5150 4242')
+  [ "$out" = live ] \
+    || fail "a pane shell that still has a child process must not be declared agent-free, got '$out'"
+  pass "herdr agent state: a pane shell with a surviving child stays live rather than reclaimable"
+}
+
+test_omp_husk_proof_does_not_widen_to_other_adapters() {
+  local out
+  out=$(omp_agent_state_verdict "$TMP_ROOT/omp-scope-claude" claude idle "$(omp_lone_shell_process_info 4242)")
+  [ "$out" = live ] \
+    || fail "the OMP-only stale-registration proof widened to another adapter, got '$out'"
+  pass "herdr agent state: the OMP stale-registration proof is scoped to the OMP adapter alone"
+}
+
 test_composer_state_pi_separator_real_text_is_pending() {
   local dir log resp fb out
   dir="$TMP_ROOT/composer-pi-separated-pending"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
@@ -4334,6 +4431,10 @@ test_composer_state_unknown_on_capture_failure
 test_composer_state_unknown_when_no_composer_row_found
 test_composer_state_pi_separator_idle_is_empty
 test_composer_state_omp_separator_idle_is_empty
+test_omp_idle_registration_over_a_lone_shell_is_no_agent
+test_omp_idle_registration_over_a_running_bun_stays_live
+test_omp_idle_registration_over_a_shell_with_a_child_stays_live
+test_omp_husk_proof_does_not_widen_to_other_adapters
 test_composer_state_pi_separator_real_text_is_pending
 test_composer_state_pi_incomplete_separator_below_stale_generic_is_unknown
 test_composer_state_pi_separator_requires_safe_native_identity

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -3083,6 +3083,18 @@ test_composer_state_pi_separator_idle_is_empty() {
   pass "fm_backend_herdr_composer_state: a native idle Pi separator composer reads empty"
 }
 
+test_composer_state_omp_separator_idle_is_empty() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/composer-omp-separated-idle"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '│ stale bordered transcript row │\n\x1b[0m\x1b[38;2;129;162;190m─────────────────────────────────────────────────────\x1b[0m\n\x1b[0m\x1b[7m \x1b[0m                                                    \n\x1b[0m\x1b[38;2;129;162;190m─────────────────────────────────────────────────────\x1b[0m\n' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent":"omp","agent_status":"idle"}}}\n' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state lab:w1:p2' "$ROOT" )
+  [ "$out" = empty ] || fail "an idle native OMP separator composer should read empty, got '$out'"
+  pass "fm_backend_herdr_composer_state: a native idle OMP separator composer reads empty"
+}
+
 test_composer_state_pi_separator_real_text_is_pending() {
   local dir log resp fb out
   dir="$TMP_ROOT/composer-pi-separated-pending"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
@@ -4321,6 +4333,7 @@ test_composer_state_popup_placeholder_fill_is_pending
 test_composer_state_unknown_on_capture_failure
 test_composer_state_unknown_when_no_composer_row_found
 test_composer_state_pi_separator_idle_is_empty
+test_composer_state_omp_separator_idle_is_empty
 test_composer_state_pi_separator_real_text_is_pending
 test_composer_state_pi_incomplete_separator_below_stale_generic_is_unknown
 test_composer_state_pi_separator_requires_safe_native_identity

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -3154,7 +3154,7 @@ test_omp_idle_registration_over_a_lone_shell_is_no_agent() {
   out=$(omp_agent_state_verdict "$TMP_ROOT/omp-husk-idle" omp idle "$(omp_lone_shell_process_info 4242)")
   [ "$out" = no-agent ] \
     || fail "an OMP registration left idle over the bare worktree shell must be a reclaimable husk, got '$out'"
-  out=$(omp_agent_state_verdict "$TMP_ROOT/omp-husk-done" omp done "$(omp_lone_shell_process_info 4242)")
+  out=$(omp_agent_state_verdict "$TMP_ROOT/omp-husk-done" omp "done" "$(omp_lone_shell_process_info 4242)")
   [ "$out" = no-agent ] \
     || fail "the same stale OMP registration reported done must also be a husk, got '$out'"
   pass "herdr agent state: a stale OMP registration over the bare worktree shell classifies no-agent"

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -1123,6 +1123,8 @@ unsupported grok max effort is flagged^{"rules":[{"when":"deep current work","us
 unsupported grok xhigh effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"xhigh"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:xhigh
 pi max effort is accepted^{"rules":[{"when":"deep coding","use":{"harness":"pi","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
 pi-signed max effort is accepted^{"rules":[{"when":"signed coding","use":{"harness":"pi-signed","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
+omp max effort is accepted^{"rules":[{"when":"omp deep coding","use":{"harness":"omp","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
+unsupported omp ultra effort is flagged^{"rules":[{"when":"omp ultra","use":{"harness":"omp","effort":"ultra"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: omp:ultra
 muse shared efforts are accepted^{"rules":[{"when":"muse low","use":{"harness":"muse","effort":"low"}},{"when":"muse medium","use":{"harness":"muse","effort":"medium"}},{"when":"muse high","use":{"harness":"muse","effort":"high"}},{"when":"muse xhigh","use":{"harness":"muse","effort":"xhigh"}},{"when":"muse max","use":{"harness":"muse","effort":"max"}}]}^empty^
 unsupported muse ultra effort is flagged^{"rules":[{"when":"muse ultra","use":{"harness":"muse","effort":"ultra"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: muse:ultra
 unsupported opencode effort is flagged^{"rules":[{"when":"opencode work","use":{"harness":"opencode","model":"anthropic/claude-sonnet-4-5","effort":"high"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: opencode:high

--- a/tests/fm-busy-adapter-wiring.test.sh
+++ b/tests/fm-busy-adapter-wiring.test.sh
@@ -35,7 +35,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse pi opencode claude codex
+  fm_fake_exit0 "$fakebin" treehouse pi opencode claude codex omp
   printf '%s\n' "$fakebin"
 }
 
@@ -175,6 +175,74 @@ test_pi_extension_stale_incarnation_rejected() {
   out=$(classify pi "$id" "$state")
   [ "$out" = "busy fm-spawn" ] || fail "a stale extension event must not change state, got '$out'"
   pass "pi extension events from a superseded incarnation are rejected as stale"
+}
+
+# drive_omp_ext <ext-path> <mode>: load the generated OMP extension in a plain
+# Node host and fire one lifecycle handler. Modes: agent-start, agent-end,
+# session-shutdown. OMP has no ctx.isIdle(): agent_end fires once after the
+# final turn, so it is the whole idle edge and it also publishes the turn-end
+# notification.
+drive_omp_ext() {
+  EXT_PATH="$1" MODE="$2" node --input-type=module 2>&1 <<'EOF'
+import { pathToFileURL } from "node:url";
+const mod = await import(pathToFileURL(process.env.EXT_PATH).href);
+const handlers = {};
+mod.default({ on: (name, fn) => { handlers[name] = fn; } });
+switch (process.env.MODE) {
+  case "agent-start": await handlers["agent_start"]({}, {}); break;
+  case "agent-end": await handlers["agent_end"]({}, {}); break;
+  case "session-shutdown": await handlers["session_shutdown"]({}, {}); break;
+  default: throw new Error("unknown mode " + process.env.MODE);
+}
+EOF
+}
+
+test_omp_extension_semantic_lifecycle() {
+  local rec id=busy-omp-1 out state ext
+  rec=$(make_spawn_case omp-lifecycle omp "$id")
+  read_case_record "$rec"
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" "$PROJ_DIR")
+  expect_code 0 $? "omp spawn should succeed: $out"
+  state="$HOME_DIR/state"
+  ext="$state/$id.omp-ext.ts"
+  assert_present "$ext" "omp spawn did not write the per-task extension"
+
+  out=$(classify omp "$id" "$state")
+  [ "$out" = "busy fm-spawn" ] || fail "seed after spawn must be 'busy fm-spawn', got '$out'"
+
+  out=$(drive_omp_ext "$ext" agent-start) || fail "agent_start drive failed: $out"
+  out=$(classify omp "$id" "$state")
+  [ "$out" = "busy omp-ext" ] || fail "agent_start must classify 'busy omp-ext', got '$out'"
+
+  rm -f "$state/$id.turn-ended"
+  out=$(drive_omp_ext "$ext" agent-end) || fail "agent_end drive failed: $out"
+  out=$(classify omp "$id" "$state")
+  [ "$out" = "idle omp-ext" ] || fail "agent_end must classify 'idle omp-ext', got '$out'"
+  [ -f "$state/$id.turn-ended" ] || fail "agent_end no longer publishes the turn-end notification marker"
+
+  out=$(drive_omp_ext "$ext" agent-start) || fail "second agent_start drive failed: $out"
+  out=$(classify omp "$id" "$state")
+  [ "$out" = "busy omp-ext" ] || fail "a fresh run must reopen busy, got '$out'"
+
+  out=$(drive_omp_ext "$ext" session-shutdown) || fail "session_shutdown drive failed: $out"
+  out=$(classify omp "$id" "$state")
+  [ "$out" = "idle omp-ext" ] || fail "session_shutdown must settle the worker idle, got '$out'"
+  pass "omp extension opens busy on agent_start, settles idle on agent_end with the turn-end marker, and settles on shutdown"
+}
+
+test_omp_extension_stale_incarnation_rejected() {
+  local rec id=busy-omp-2 out state ext
+  rec=$(make_spawn_case omp-stale omp "$id")
+  read_case_record "$rec"
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" "$PROJ_DIR")
+  expect_code 0 $? "omp spawn should succeed: $out"
+  state="$HOME_DIR/state"
+  ext="$state/$id.omp-ext.ts"
+  "$ROOT/bin/fm-busy-event.sh" arm "$state" "$id" >/dev/null
+  out=$(drive_omp_ext "$ext" agent-end) || fail "stale agent_end drive failed: $out"
+  out=$(classify omp "$id" "$state")
+  [ "$out" = "busy fm-spawn" ] || fail "a stale extension event must not change state, got '$out'"
+  pass "omp extension events from a superseded incarnation are rejected as stale"
 }
 
 # drive_oc_plugin <plugin-path> <events-json-lines...>: load the generated
@@ -345,6 +413,8 @@ test_kimi_and_grok_install_no_unverified_wiring() {
 test_pi_extension_semantic_lifecycle
 test_pi_extension_serializes_settle_before_next_start
 test_pi_extension_stale_incarnation_rejected
+test_omp_extension_semantic_lifecycle
+test_omp_extension_stale_incarnation_rejected
 test_kimi_and_grok_install_no_unverified_wiring
 test_opencode_plugin_semantic_lifecycle
 test_claude_hooks_semantic_lifecycle

--- a/tests/fm-busy-state.test.sh
+++ b/tests/fm-busy-state.test.sh
@@ -160,7 +160,7 @@ test_stale_gen_record_unknown() {
 test_missing_record_unknown_not_idle() {
   local state out h
   state=$(new_state_dir missing)
-  for h in claude opencode pi pi-signed; do
+  for h in claude opencode pi pi-signed omp; do
     out=$(fm_busy_classify tmux w1 "$h" t1 "$state")
     [ "$out" = "unknown missing" ] || fail "$h with no record must be 'unknown missing', got '$out'"
   done
@@ -215,6 +215,21 @@ test_source_mismatch_cross_adapter() {
   pass "a record is trusted only by the adapter whose source wrote it"
 }
 
+test_omp_source_isolation() {
+  local state gen out
+  state=$(new_state_dir omp-source)
+  gen=$("$EV" arm "$state" t1)
+  "$EV" apply "$state" t1 busy --gen "$gen" --source omp-ext --event agent-start
+  out=$(fm_busy_classify tmux w1 omp t1 "$state")
+  [ "$out" = "busy omp-ext" ] || fail "omp-ext record on an OMP task must classify, got '$out'"
+  out=$(fm_busy_classify tmux w1 pi t1 "$state")
+  [ "$out" = "unknown source-mismatch" ] || fail "Pi must not trust an OMP extension record, got '$out'"
+  "$EV" apply "$state" t1 idle --gen "$gen" --source omp-ext --event agent-end
+  out=$(fm_busy_classify tmux w1 omp t1 "$state")
+  [ "$out" = "idle omp-ext" ] || fail "OMP agent-end must classify idle, got '$out'"
+  pass "OMP trusts only its per-task extension lifecycle source"
+}
+
 test_converted_adapters_ignore_footer_text() {
   local state out h
   state=$(new_state_dir no-footer)
@@ -222,7 +237,7 @@ test_converted_adapters_ignore_footer_text() {
    ■■■■⬝⬝⬝⬝  esc interrupt
 Working...
 Ctrl+c:cancel'
-  for h in claude opencode pi pi-signed; do
+  for h in claude opencode pi pi-signed omp; do
     out=$(fm_busy_classify tmux w1 "$h" t1 "$state" "$tail")
     [ "$out" = "unknown missing" ] || fail "$h must never classify from footer text, got '$out'"
   done
@@ -368,6 +383,7 @@ test_missing_record_unknown_not_idle
 test_malformed_record_unknown
 test_record_without_sidecar_unknown
 test_source_mismatch_cross_adapter
+test_omp_source_isolation
 test_converted_adapters_ignore_footer_text
 test_grok_regex_isolated
 test_codex_unverified_gate

--- a/tests/fm-composer-ghost.test.sh
+++ b/tests/fm-composer-ghost.test.sh
@@ -501,12 +501,12 @@ test_all_tmux_harness_composers_share_classification() {
   dir="$TMP_ROOT/all-harness-composers"; mkdir -p "$dir"
   fb=$(make_fake_tmux "$dir")
   capture="$dir/styled.txt"
-  for harness in claude codex opencode pi pi-signed grok; do
+  for harness in claude codex opencode pi pi-signed omp grok; do
     case "$harness" in
       claude) printf '╭────────────╮\n│ ❯ \033[2mtry\033[0m      │\n╰────────────╯\n' > "$capture" ;;
       codex) printf '╭────────────╮\n│ › \033[2mtip\033[0m      │\n╰────────────╯\n' > "$capture" ;;
       opencode) printf '╭────────────╮\n│ >          │\n╰────────────╯\n' > "$capture" ;;
-      pi|pi-signed) printf '╭────────────╮\n│            │\n╰────────────╯\n' > "$capture" ;;
+      pi|pi-signed|omp) printf '╭────────────╮\n│            │\n╰────────────╯\n' > "$capture" ;;
       grok) printf '╭────────────╮\n│ ❯ \033[38;2;50;47;70mType\033[0m     │\n╰────────────╯\n' > "$capture" ;;
     esac
     out=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=1 \
@@ -516,7 +516,7 @@ test_all_tmux_harness_composers_share_classification() {
     case "$harness" in
       claude|grok) printf '╭────────────╮\n│ ❯ fix      │\n╰────────────╯\n' > "$capture" ;;
       codex) printf '╭────────────╮\n│ › fix      │\n╰────────────╯\n' > "$capture" ;;
-      opencode|pi|pi-signed) printf '╭────────────╮\n│ > fix      │\n╰────────────╯\n' > "$capture" ;;
+      opencode|pi|pi-signed|omp) printf '╭────────────╮\n│ > fix      │\n╰────────────╯\n' > "$capture" ;;
     esac
     out=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=1 \
       fm_tmux_composer_state "fakepane")

--- a/tests/fm-control.test.sh
+++ b/tests/fm-control.test.sh
@@ -35,7 +35,7 @@ mkdir -p "$TMP_ROOT"
 TMP_ROOT=$(cd "$TMP_ROOT" && pwd)
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
-VERIFIED_HARNESSES="claude codex opencode pi pi-signed grok kimi muse"
+VERIFIED_HARNESSES="claude codex opencode pi pi-signed omp grok kimi muse"
 
 # The expectation table, written out independently of the implementation so a
 # silent change to either side shows up here. The fourth field is the composer
@@ -48,6 +48,7 @@ verified_adapter_contract() {  # <harness> -> exit command, interrupt key, repea
     opencode) printf '/exit\tEscape\t2\t\n' ;;
     pi) printf '/quit\tEscape\t1\t\n' ;;
     pi-signed) printf '/quit\tEscape\t1\t\n' ;;
+    omp) printf '/exit\tEscape\t1\t\n' ;;
     grok) printf '/exit\tC-c\t1\t\n' ;;
     kimi) printf '/exit\tEscape\t1\t\n' ;;
     muse) printf '/exit\tEscape\t1\tC-u\n' ;;
@@ -256,7 +257,7 @@ test_interrupt_sends_each_harness_verified_key() {
 test_harness_family_resolution() {
   local pair recorded want got
   for pair in claude:claude claude-latest:claude codex:codex codex-cli:codex \
-      opencode:opencode grok:grok grok-2:grok kimi:kimi muse:muse \
+      opencode:opencode omp:omp omp-17:omp grok:grok grok-2:grok kimi:kimi muse:muse \
       muse-bin-0.1.0:muse pi:pi pi-signed:pi-signed; do
     recorded=${pair%%:*}
     want=${pair#*:}
@@ -365,7 +366,7 @@ test_harness_kind_capability() {
   done
   fm_control_harness_supports_kind muse secondmate \
     && fail "muse has no primary supervision protocol and must not claim a secondmate"
-  for harness in claude codex opencode pi pi-signed grok kimi; do
+  for harness in claude codex opencode pi pi-signed omp grok kimi; do
     fm_control_harness_supports_kind "$harness" secondmate \
       || fail "$harness should be able to run a secondmate"
   done

--- a/tests/fm-harness-liveness-drift-live-e2e.test.sh
+++ b/tests/fm-harness-liveness-drift-live-e2e.test.sh
@@ -86,7 +86,7 @@ SKIPPED=
 # so the live process name changes on every auto-update and its install path
 # carries no `muse` component to fall back on. That is precisely the drift this
 # guard exists to catch, and only a real muse release can produce it.
-for harness in claude codex opencode pi pi-signed grok kimi muse; do
+for harness in claude codex opencode pi pi-signed omp grok kimi muse; do
   if ! bin_path=$(resolve_harness_binary "$harness"); then
     SKIPPED="$SKIPPED $harness"
     note "skip: $harness is not installed on this machine, so its classification is unverified here"
@@ -118,6 +118,50 @@ for harness in claude codex opencode pi pi-signed grok kimi muse; do
   pass "harness liveness: $harness $version classifies alive"
   CHECKED=$((CHECKED + 1))
 done
+
+# OMP's verified adapter identity has two independent vendor-controlled surfaces:
+# the positive child-process marker and exact Bun-script ancestry used for the
+# home lock. Probe from inside the real OMP process so a stub cannot restate them.
+if omp_path=$(resolve_harness_binary omp); then
+  omp_version=$("$omp_path" --version 2>/dev/null | head -1 | tr -d '\r') || omp_version=
+  [ -n "$omp_version" ] || omp_version=unknown
+  cat > "$LAB/omp-session-identity.ts" <<'TS'
+import { spawnSync } from "node:child_process";
+
+export default function (pi: { on?: (event: string, handler: () => void) => void }) {
+  pi.on?.("session_start", () => {
+    const root = process.env.FM_LIVE_ROOT || "";
+    const harness = spawnSync(`${root}/bin/fm-harness.sh`, { encoding: "utf8" }).stdout.trim();
+    const lock = spawnSync(
+      "bash",
+      ["-c", `. '${root}/bin/fm-session-lock-lib.sh'; fm_harness_ancestry_pid`],
+      { encoding: "utf8" },
+    ).stdout.trim();
+    const line =
+      `OMP_IDENTITY marker=${process.env.OMPCODE || ""} ` +
+      `harness=${harness} lock=${lock} process=${process.pid}\n`;
+    const ok =
+      process.env.OMPCODE === "1" &&
+      harness === "omp" &&
+      lock === String(process.pid);
+    process.stdout.write(line, () => process.exit(ok ? 0 : 1));
+  });
+}
+TS
+  omp_out=$(FM_LIVE_ROOT="$ROOT" "$omp_path" -p --no-session --no-tools \
+    -e "$LAB/omp-session-identity.ts" probe 2>&1)
+  omp_status=$?
+  [ "$omp_status" -eq 0 ] || fail \
+    "OMP SESSION-IDENTITY DRIFT: $omp_version no longer exports OMPCODE=1, selects the OMP adapter, and resolves its Bun process as the session-lock owner. Observed: $omp_out"
+  case "$omp_out" in
+    *"OMP_IDENTITY marker=1 harness=omp "*) ;;
+    *) fail "OMP session-identity probe returned an unrecognized success payload: $omp_out" ;;
+  esac
+  note "OMP $omp_version: $omp_out"
+  pass "OMP session identity: $omp_version selects the verified adapter and owns the lock"
+else
+  note "skip: OMP is not installed on this machine, so its primary session identity is unverified here"
+fi
 
 [ "$CHECKED" -gt 0 ] || fail \
   "no verified harness is installed here, so this run proved nothing; install at least one harness before trusting a pass"

--- a/tests/fm-harness-liveness-drift-live-e2e.test.sh
+++ b/tests/fm-harness-liveness-drift-live-e2e.test.sh
@@ -148,7 +148,7 @@ export default function (pi: { on?: (event: string, handler: () => void) => void
   });
 }
 TS
-  omp_out=$(OMPCODE= CLAUDECODE=1 FM_LIVE_ROOT="$ROOT" "$omp_path" -p --no-session --no-tools \
+  omp_out=$(OMPCODE='' CLAUDECODE=1 FM_LIVE_ROOT="$ROOT" "$omp_path" -p --no-session --no-tools \
     -e "$LAB/omp-session-identity.ts" probe 2>&1)
   omp_status=$?
   [ "$omp_status" -eq 0 ] || fail \

--- a/tests/fm-harness-liveness-drift-live-e2e.test.sh
+++ b/tests/fm-harness-liveness-drift-live-e2e.test.sh
@@ -119,9 +119,10 @@ for harness in claude codex opencode pi pi-signed omp grok kimi muse; do
   CHECKED=$((CHECKED + 1))
 done
 
-# OMP's verified adapter identity has two independent vendor-controlled surfaces:
-# the positive child-process marker and exact Bun-script ancestry used for the
-# home lock. Probe from inside the real OMP process so a stub cannot restate them.
+# OMP's verified primary identity has an exact Bun-script ancestry surface. The
+# installed release may omit OMPCODE and inherit a foreign CLAUDECODE marker, so
+# probe from inside the real OMP process with both conditions present; a stub
+# cannot restate the process shape or the home-lock owner.
 if omp_path=$(resolve_harness_binary omp); then
   omp_version=$("$omp_path" --version 2>/dev/null | head -1 | tr -d '\r') || omp_version=
   [ -n "$omp_version" ] || omp_version=unknown
@@ -141,24 +142,23 @@ export default function (pi: { on?: (event: string, handler: () => void) => void
       `OMP_IDENTITY marker=${process.env.OMPCODE || ""} ` +
       `harness=${harness} lock=${lock} process=${process.pid}\n`;
     const ok =
-      process.env.OMPCODE === "1" &&
       harness === "omp" &&
       lock === String(process.pid);
     process.stdout.write(line, () => process.exit(ok ? 0 : 1));
   });
 }
 TS
-  omp_out=$(FM_LIVE_ROOT="$ROOT" "$omp_path" -p --no-session --no-tools \
+  omp_out=$(OMPCODE= CLAUDECODE=1 FM_LIVE_ROOT="$ROOT" "$omp_path" -p --no-session --no-tools \
     -e "$LAB/omp-session-identity.ts" probe 2>&1)
   omp_status=$?
   [ "$omp_status" -eq 0 ] || fail \
-    "OMP SESSION-IDENTITY DRIFT: $omp_version no longer exports OMPCODE=1, selects the OMP adapter, and resolves its Bun process as the session-lock owner. Observed: $omp_out"
+    "OMP SESSION-IDENTITY DRIFT: $omp_version did not select the OMP adapter and its Bun process as the session-lock owner under an inherited Claude marker. Observed: $omp_out"
   case "$omp_out" in
-    *"OMP_IDENTITY marker=1 harness=omp "*) ;;
+    *"OMP_IDENTITY marker="*" harness=omp lock="*) ;;
     *) fail "OMP session-identity probe returned an unrecognized success payload: $omp_out" ;;
   esac
   note "OMP $omp_version: $omp_out"
-  pass "OMP session identity: $omp_version selects the verified adapter and owns the lock"
+  pass "OMP session identity: $omp_version selects the adapter and owns the lock under an inherited marker"
 else
   note "skip: OMP is not installed on this machine, so its primary session identity is unverified here"
 fi

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -192,7 +192,7 @@ test_kimi_launch_then_send_is_verified() {
   assert_contains "$out" "spawned $id harness=kimi" "kimi spawn did not report success"
 
   launch=$(cat "$CASE_DIR/launch.log")
-  [ "$launch" = "'$FAKEBIN_DIR/kimi' --model 'kimi-code/k3' --auto" ] \
+  [ "$launch" = "env -u OMPCODE '$FAKEBIN_DIR/kimi' --model 'kimi-code/k3' --auto" ] \
     || fail "kimi launch did not use the absolute binary, model, and --auto only: $launch"
   assert_not_contains "$launch" "--effort" "kimi launch emitted a nonexistent effort flag"
   assert_not_contains "$launch" "turn-ended" "kimi launch embedded a turn-end path"
@@ -449,7 +449,7 @@ test_kimi_falls_back_to_expanded_home_binary() {
   rc=$?
   expect_code 0 "$rc" "Kimi HOME fallback spawn should succeed"
   launch=$(cat "$CASE_DIR/launch.log")
-  [ "$launch" = "'$fallback' --auto" ] \
+  [ "$launch" = "env -u OMPCODE '$fallback' --auto" ] \
     || fail "Kimi fallback did not expand HOME into an absolute executable: $launch"
   pass "fm-spawn: Kimi fallback expands the active HOME"
 }

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -530,10 +530,10 @@ esac
 SH
   chmod +x "$fakebin/ps"
 
-  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+  out=$(env -u OMPCODE -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
     PATH="$fakebin:$BASE_PATH" FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh")
   [ "$out" = kimi ] || fail "kimi ancestry detection returned '$out'"
-  out=$(CLAUDECODE=1 PATH="$fakebin:$BASE_PATH" FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh")
+  out=$(env -u OMPCODE CLAUDECODE=1 PATH="$fakebin:$BASE_PATH" FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh")
   [ "$out" = claude ] || fail "verified env-marker precedence changed, got '$out'"
   pass "fm-harness: markerless kimi is detected by ancestry after env-marker precedence"
 }

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -192,7 +192,7 @@ test_kimi_launch_then_send_is_verified() {
   assert_contains "$out" "spawned $id harness=kimi" "kimi spawn did not report success"
 
   launch=$(cat "$CASE_DIR/launch.log")
-  [ "$launch" = "env -u OMPCODE '$FAKEBIN_DIR/kimi' --model 'kimi-code/k3' --auto" ] \
+  [ "$launch" = "unset OMPCODE; '$FAKEBIN_DIR/kimi' --model 'kimi-code/k3' --auto" ] \
     || fail "kimi launch did not use the absolute binary, model, and --auto only: $launch"
   assert_not_contains "$launch" "--effort" "kimi launch emitted a nonexistent effort flag"
   assert_not_contains "$launch" "turn-ended" "kimi launch embedded a turn-end path"
@@ -449,7 +449,7 @@ test_kimi_falls_back_to_expanded_home_binary() {
   rc=$?
   expect_code 0 "$rc" "Kimi HOME fallback spawn should succeed"
   launch=$(cat "$CASE_DIR/launch.log")
-  [ "$launch" = "env -u OMPCODE '$fallback' --auto" ] \
+  [ "$launch" = "unset OMPCODE; '$fallback' --auto" ] \
     || fail "Kimi fallback did not expand HOME into an absolute executable: $launch"
   pass "fm-spawn: Kimi fallback expands the active HOME"
 }

--- a/tests/fm-muse-harness.test.sh
+++ b/tests/fm-muse-harness.test.sh
@@ -167,7 +167,7 @@ test_detects_versioned_process_ancestor() {
   mkdir -p "$dir"
   for bin in muse-bin-0.1.0-R708.1 muse-bin-9.9.9-RZZZ.9 muse; do
     cp "$(command -v bash)" "$dir/$bin"
-    out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    out=$(env -u OMPCODE -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
       "$dir/$bin" -c "r=\$(\"$HARNESS\"); printf '%s' \"\$r\"")
     [ "$out" = muse ] || fail "fm-harness.sh under process '$bin' reported '$out', expected muse"
   done
@@ -182,7 +182,7 @@ test_detection_is_anchored() {
   mkdir -p "$dir"
   for bin in musescore amuse notmuse-bin muse-binary muse-bind; do
     cp "$(command -v bash)" "$dir/$bin"
-    out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    out=$(env -u OMPCODE -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
       "$dir/$bin" -c "r=\$(\"$HARNESS\"); printf '%s' \"\$r\"")
     [ "$out" != muse ] || fail "fm-harness.sh misdetected unrelated process '$bin' as muse"
   done

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -120,6 +120,65 @@ EOF
   pass "OMP watcher entrypoint selects OMP lifecycle, command, tool, and marker names"
 }
 
+# OMPCODE is inheritable: a Pi primary started from an OMP session's shell, or
+# in a pane whose multiplexer server stored that environment, carries it. The
+# entrypoint Pi auto-loads is the authoritative signal, so the marker must not
+# be able to switch this session onto OMP's vocabulary behind its back.
+test_pi_watcher_entrypoint_ignores_an_inherited_omp_marker() {
+  local repo home plugin out status
+  repo="$TMP_ROOT/pi-entrypoint-inherited-omp-root"
+  home="$TMP_ROOT/pi-entrypoint-inherited-omp-home"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(OMPCODE=1 PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" node --input-type=module 2>&1 <<'EOF'
+import { existsSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const events = new Map();
+const commands = [];
+const tools = [];
+const pi = {
+  on(name, handler) {
+    events.set(name, handler);
+  },
+  registerCommand(name) {
+    commands.push(name);
+  },
+  registerTool(tool) {
+    tools.push(tool.name);
+  },
+  sendUserMessage: async () => {},
+};
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+if (events.has("session_switch")) {
+  throw new Error("the Pi entrypoint bound OMP's session_switch under an inherited marker");
+}
+if (!commands.includes("fm-watch-arm-pi")) throw new Error(`Pi command missing: ${commands}`);
+if (!tools.includes("fm_watch_arm_pi")) throw new Error(`Pi tool missing: ${tools}`);
+await events.get("session_start")();
+if (!existsSync(`${process.env.FM_HOME}/state/.pi-watch-extension-loaded`)) {
+  throw new Error("the Pi entrypoint did not write Pi's loaded marker");
+}
+if (existsSync(`${process.env.FM_HOME}/state/.omp-watch-extension-loaded`)) {
+  throw new Error("the Pi entrypoint wrote OMP's loaded marker under an inherited marker");
+}
+await events.get("session_shutdown")();
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "an inherited OMPCODE must not switch the Pi entrypoint onto OMP's contract"
+  [ -z "$out" ] || fail "Pi entrypoint inherited-marker test printed output: $out"
+  pass "Pi watcher entrypoint keeps Pi's lifecycle, tool, and marker under an inherited OMP marker"
+}
+
 test_pi_extension_reports_external_healthy_watcher() {
   local repo home plugin out status
   repo="$TMP_ROOT/pi-external-healthy-root"
@@ -2187,6 +2246,7 @@ EOF
 
 test_pi_extension_reports_external_healthy_watcher
 test_omp_watcher_entrypoint_selects_omp_contract
+test_pi_watcher_entrypoint_ignores_an_inherited_omp_marker
 test_pi_tool_returns_agent_tool_result
 test_pi_redundant_tool_call_is_owned_noop
 test_pi_scheduled_retry_call_is_owned_noop

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -59,6 +59,67 @@ export const Type = {
 JS
 }
 
+test_omp_watcher_entrypoint_selects_omp_contract() {
+  local repo home plugin out status
+  repo="$TMP_ROOT/omp-entrypoint-root"
+  home="$TMP_ROOT/omp-entrypoint-home"
+  mkdir -p "$repo/bin" "$repo/.omp/extensions" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  cp "$ROOT/.omp/extensions/fm-primary-omp-watch.ts" "$repo/.omp/extensions/fm-primary-omp-watch.ts"
+  plugin="$repo/.omp/extensions/fm-primary-omp-watch.ts"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(OMPCODE=1 PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" node --input-type=module 2>&1 <<'EOF'
+import { existsSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const events = new Map();
+const commands = [];
+const tools = [];
+let commandDescription = "";
+let toolDescription = "";
+const pi = {
+  on(name, handler) {
+    events.set(name, handler);
+  },
+  registerCommand(name, definition) {
+    commands.push(name);
+    commandDescription = definition.description;
+  },
+  registerTool(tool) {
+    tools.push(tool.name);
+    toolDescription = tool.description;
+  },
+  sendUserMessage: async () => {},
+};
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+for (const name of ["session_start", "session_switch", "session_shutdown"]) {
+  if (!events.has(name)) throw new Error(`OMP watcher omitted ${name}`);
+}
+if (events.has("agent_settled")) throw new Error("OMP watcher registered Pi's agent_settled event");
+if (!commands.includes("fm-watch-arm-omp")) throw new Error(`OMP command missing: ${commands}`);
+if (!tools.includes("fm_watch_arm_omp")) throw new Error(`OMP tool missing: ${tools}`);
+if (!commandDescription.includes("OMP extension")) throw new Error(`OMP command description wrong: ${commandDescription}`);
+if (!toolDescription.includes("OMP watcher cycle")) throw new Error(`OMP tool description wrong: ${toolDescription}`);
+await events.get("session_start")();
+if (!existsSync(`${process.env.FM_HOME}/state/.omp-watch-extension-loaded`)) {
+  throw new Error("OMP watcher did not write its loaded marker");
+}
+await events.get("session_shutdown")();
+await events.get("session_switch")();
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "OMP watcher entrypoint must select OMP events, names, and marker"
+  [ -z "$out" ] || fail "OMP watcher entrypoint test printed output: $out"
+  pass "OMP watcher entrypoint selects OMP lifecycle, command, tool, and marker names"
+}
+
 test_pi_extension_reports_external_healthy_watcher() {
   local repo home plugin out status
   repo="$TMP_ROOT/pi-external-healthy-root"
@@ -2125,6 +2186,7 @@ EOF
 }
 
 test_pi_extension_reports_external_healthy_watcher
+test_omp_watcher_entrypoint_selects_omp_contract
 test_pi_tool_returns_agent_tool_result
 test_pi_redundant_tool_call_is_owned_noop
 test_pi_scheduled_retry_call_is_owned_noop

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -51,13 +51,12 @@ set -u
 . "$ROOT/bin/fm-config-inherit-lib.sh"
 
 # The harness-detection cases below fake `ps` so process ancestry is fully
-# controlled, but bin/fm-harness.sh checks verified ENV markers before ancestry.
-# A suite run from inside one of those harnesses inherits its marker, and the
-# highest-precedence one wins over everything these cases set up: with an
-# ambient CLAUDECODE=1, the pi-signed ancestry case resolves "claude". Drop the
-# ambient markers so what this suite asserts does not depend on which harness it
-# was launched from; every case states the marker it means to test.
-unset CLAUDECODE PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT
+# controlled, but bin/fm-harness.sh checks environment markers before ancestry.
+# A suite run from inside a harness inherits its marker, and the highest-
+# precedence one wins over everything these cases set up. Drop all ambient
+# markers, including OMP's lock-only identity marker, so every case states the
+# marker it means to test.
+unset OMPCODE CLAUDECODE PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT
 
 BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
 fm_git_identity fmtest fmtest@example.com
@@ -93,6 +92,7 @@ crew set, secondmate absent -> crew (backward-compat)^codex^-^codex^codex
 crew set, secondmate set -> secondmate wins, crew untouched^codex^grok^grok^codex
 crew absent, secondmate set -> secondmate value, crew own^-^grok^grok^claude
 signed Pi wrapper remains a distinct secondmate value^codex^pi-signed^pi-signed^codex
+OMP remains a distinct secondmate value^codex^omp^omp^codex
 secondmate=default defers to crew^codex^default^codex^codex
 crew=default resolves to own, secondmate follows^default^-^claude^claude
 secondmate=default with crew absent -> own^-^default^claude^claude
@@ -131,6 +131,7 @@ bare harness only -> empty model/effort (backward-compat)^claude^claude^^
 harness + model -> model only^claude opus^claude^opus^
 harness + model + effort -> both^claude opus high^claude^opus^high
 signed Pi wrapper + model + effort preserves every token^pi-signed openai-codex/gpt-5.6-sol max^pi-signed^openai-codex/gpt-5.6-sol^max
+OMP model and effort preserve every token^omp openai-codex/gpt-5.6-sol high^omp^openai-codex/gpt-5.6-sol^high
 default harness token -> falls back to crew, empty model/effort^default^claude^^
 extra whitespace between tokens is tolerated^grok   grok-4    xhigh^grok^grok-4^xhigh
 leading/trailing blank lines and a comment are skipped^# a comment\n\nclaude opus low\n^claude^opus^low
@@ -201,6 +202,56 @@ SH
   fi
 
   pass "pi-signed identity: authoritative launch selection distinguishes shared wrapper ancestry"
+}
+
+test_omp_primary_and_worker_identity() {
+  local dir fakebin got
+  dir="$TMP_ROOT/omp-primary-worker-identity"
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field= pid=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) pid=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$field:${FM_TEST_OMP_SHAPE:-omp}" in
+  comm=:*) printf '%s\n' '/opt/homebrew/bin/bun' ;;
+  args=:omp) printf '%s\n' 'bun /Users/u/.bun/bin/omp --model openai/test' ;;
+  args=:unrelated) printf '%s\n' 'bun /opt/tools/compiler.js --prompt omp' ;;
+  ppid=:*) printf '%s\n' 1 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+
+  got=$(OMPCODE=1 CLAUDECODE=1 PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-harness.sh")
+  [ "$got" = omp ] \
+    || fail "OMP under an inherited Claude marker selected '$got', expected omp"
+  got=$(FM_TEST_OMP_SHAPE=omp PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-harness.sh")
+  [ "$got" = omp ] \
+    || fail "exact Bun/OMP ancestry selected '$got', expected omp"
+  got=$(FM_TEST_OMP_SHAPE=unrelated CLAUDECODE=1 PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-harness.sh")
+  [ "$got" = claude ] \
+    || fail "an unrelated Bun process suppressed the verified Claude marker, got '$got'"
+
+  got=$(PATH="$fakebin:$BASE_PATH" bash -c \
+    '. "$0/bin/fm-session-lock-lib.sh"; fm_harness_ancestry_pid' "$ROOT")
+  case "$got" in
+    ''|*[!0-9]*) fail "OMP session-lock ancestry returned nonnumeric identity '$got'" ;;
+  esac
+  PATH="$fakebin:$BASE_PATH" bash -c \
+    '. "$0/bin/fm-session-lock-lib.sh"; kill() { return 0; }; fm_harness_pid_alive 777' "$ROOT" \
+    || fail "session-lock liveness rejected the exact Bun/OMP process"
+  if FM_TEST_OMP_SHAPE=unrelated PATH="$fakebin:$BASE_PATH" bash -c \
+    '. "$0/bin/fm-session-lock-lib.sh"; kill() { return 0; }; fm_harness_pid_alive 777' "$ROOT"; then
+    fail "session-lock liveness accepted an unrelated Bun process that merely mentioned OMP"
+  fi
+
+  pass "OMP identity: positive marker and exact Bun script select the verified adapter and session-lock owner"
 }
 
 test_dash_leading_process_names_are_basename_operands() {
@@ -690,6 +741,50 @@ test_spawn_bare_harness_no_model_effort_flag() {
   assert_not_contains "$launch" "--model" "bare-tokens: launch must not carry a --model flag"
   assert_not_contains "$launch" "--effort" "bare-tokens: launch must not carry an --effort flag"
   pass "C2 spawn: a bare harness-only secondmate-harness file launches with no model/effort flag (backward-compat)"
+}
+
+test_spawn_omp_secondmate_contract() {
+  local w sm sm_real meta launchlog launch out status
+  w="$TMP_ROOT/spawn-omp-secondmate"
+  sm="$w/sm"
+  launchlog="$w/launch.log"
+  mkdir -p "$w/home/config"
+  printf 'omp openai-codex/gpt-5.6-sol high\n' > "$w/home/config/secondmate-harness"
+  make_seeded_home "$sm" sm
+  sm_real=$(cd "$sm" && pwd -P)
+  mkdir -p "$w/tmux-sm/fakebin"
+  cat > "$w/tmux-sm/fakebin/omp" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$w/tmux-sm/fakebin/omp"
+
+  out=$(spawn_secondmate_capture "$w" sm "$sm" "$launchlog" 2>&1); status=$?
+  expect_code 0 "$status" "OMP secondmate spawn should succeed"$'\n'"$out"
+
+  meta="$w/home/state/sm.meta"
+  [ "$(meta_field "$meta" harness)" = omp ] \
+    || fail "OMP secondmate meta did not preserve harness=omp"
+  [ "$(meta_field "$meta" model)" = openai-codex/gpt-5.6-sol ] \
+    || fail "OMP secondmate meta did not preserve the selected model"
+  [ "$(meta_field "$meta" effort)" = high ] \
+    || fail "OMP secondmate meta did not preserve the selected effort"
+  launch=$(cat "$launchlog")
+  assert_contains "$launch" "OMPCODE=1" \
+    "OMP secondmate launch did not establish its positive identity marker"
+  assert_contains "$launch" "env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT -u GROK_HOOK_EVENT" \
+    "OMP secondmate launch did not remove inherited foreign harness markers"
+  assert_contains "$launch" "-e '$sm_real/.omp/extensions/fm-primary-turnend-guard.ts'" \
+    "OMP secondmate launch did not load its primary turn-end guard"
+  assert_contains "$launch" "-e '$sm_real/.omp/extensions/fm-primary-omp-watch.ts'" \
+    "OMP secondmate launch did not load its primary watcher"
+  assert_contains "$launch" "--approval-mode yolo" \
+    "OMP secondmate launch did not apply yolo approval mode"
+  assert_contains "$launch" "--model 'openai-codex/gpt-5.6-sol'" \
+    "OMP secondmate launch did not apply the selected model"
+  assert_contains "$launch" "--thinking 'high'" \
+    "OMP secondmate launch did not apply the selected effort"
+  pass "OMP spawn: secondmate launch carries identity, primary extensions, autonomy, model, and effort"
 }
 
 # "<harness> <model>" durably threads --model into the secondmate launch and
@@ -2466,6 +2561,7 @@ SH
 test_harness_resolution
 test_secondmate_model_effort_tokens
 test_pi_signed_detection_and_session_lock_identity
+test_omp_primary_and_worker_identity
 test_dash_leading_process_names_are_basename_operands
 test_propagate_lib
 test_spawn_split_and_inherit
@@ -2476,6 +2572,7 @@ test_spawn_unverified_secondmate_harness_refused
 test_spawn_backend_precedence_over_inherited_config
 test_spawn_explicit_backend_precedence_over_env_and_inherited_config
 test_spawn_bare_harness_no_model_effort_flag
+test_spawn_omp_secondmate_contract
 test_spawn_secondmate_harness_model_token
 test_spawn_secondmate_harness_model_and_effort_tokens
 test_spawn_explicit_model_overrides_secondmate_harness_token

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -237,6 +237,12 @@ SH
   got=$(FM_TEST_OMP_SHAPE=unrelated CLAUDECODE=1 PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-harness.sh")
   [ "$got" = claude ] \
     || fail "an unrelated Bun process suppressed the verified Claude marker, got '$got'"
+  # No marker at all, so this reaches the Bun ancestry branch itself: a script
+  # path that merely MENTIONS omp in a later argument is not an identity, and
+  # widening the anchored argv[1] match has to fail here.
+  got=$(FM_TEST_OMP_SHAPE=unrelated PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-harness.sh")
+  [ "$got" = unknown ] \
+    || fail "an unrelated Bun script whose later argument mentions omp resolved '$got', expected unknown"
 
   got=$(PATH="$fakebin:$BASE_PATH" bash -c \
     '. "$0/bin/fm-session-lock-lib.sh"; fm_harness_ancestry_pid' "$ROOT")

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -220,9 +220,11 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 case "$field:${FM_TEST_OMP_SHAPE:-omp}" in
+  comm=:bare) printf '%s\n' '/opt/omp/bin/bun' ;;
   comm=:*) printf '%s\n' '/opt/homebrew/bin/bun' ;;
   args=:omp) printf '%s\n' 'bun /Users/u/.bun/bin/omp --model openai/test' ;;
   args=:unrelated) printf '%s\n' 'bun /opt/tools/compiler.js --prompt omp' ;;
+  args=:bare) printf '%s\n' '/opt/omp/bin/bun' ;;
   ppid=:*) printf '%s\n' 1 ;;
 esac
 SH
@@ -243,6 +245,13 @@ SH
   got=$(FM_TEST_OMP_SHAPE=unrelated PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-harness.sh")
   [ "$got" = unknown ] \
     || fail "an unrelated Bun script whose later argument mentions omp resolved '$got', expected unknown"
+  # detect_own attributes an ancestor by process NAME only - it has no install-
+  # path rule - so a bare Bun with no script argument must stay unattributed
+  # even when Bun's own path carries an omp component. The identity Bun can
+  # carry is argv[1], never argv[0].
+  got=$(FM_TEST_OMP_SHAPE=bare PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-harness.sh")
+  [ "$got" = unknown ] \
+    || fail "a bare Bun installed under an omp path component resolved '$got', expected unknown"
 
   got=$(PATH="$fakebin:$BASE_PATH" bash -c \
     '. "$0/bin/fm-session-lock-lib.sh"; fm_harness_ancestry_pid' "$ROOT")

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -51,9 +51,9 @@ set -u
 . "$ROOT/bin/fm-config-inherit-lib.sh"
 
 # The harness-detection cases below fake `ps` so process ancestry is fully
-# controlled, but bin/fm-harness.sh checks environment markers before ancestry.
-# A suite run from inside a harness inherits its marker, and the highest-
-# precedence one wins over everything these cases set up. Drop all ambient
+# controlled. bin/fm-harness.sh checks verified environment markers before
+# general ancestry, while exact OMP ancestry also outranks an inherited Claude
+# marker because a live primary OMP release may omit OMPCODE. Drop all ambient
 # markers, including OMP's lock-only identity marker, so every case states the
 # marker it means to test.
 unset OMPCODE CLAUDECODE PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT
@@ -233,9 +233,9 @@ SH
   got=$(OMPCODE=1 CLAUDECODE=1 PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-harness.sh")
   [ "$got" = omp ] \
     || fail "OMP under an inherited Claude marker selected '$got', expected omp"
-  got=$(FM_TEST_OMP_SHAPE=omp PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-harness.sh")
+  got=$(FM_TEST_OMP_SHAPE=omp CLAUDECODE=1 PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-harness.sh")
   [ "$got" = omp ] \
-    || fail "exact Bun/OMP ancestry selected '$got', expected omp"
+    || fail "exact Bun/OMP ancestry under an inherited Claude marker selected '$got', expected omp"
   got=$(FM_TEST_OMP_SHAPE=unrelated CLAUDECODE=1 PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-harness.sh")
   [ "$got" = claude ] \
     || fail "an unrelated Bun process suppressed the verified Claude marker, got '$got'"
@@ -266,7 +266,7 @@ SH
     fail "session-lock liveness accepted an unrelated Bun process that merely mentioned OMP"
   fi
 
-  pass "OMP identity: positive marker and exact Bun script select the verified adapter and session-lock owner"
+  pass "OMP identity: positive marker and exact Bun script defeat inherited foreign markers"
 }
 
 test_dash_leading_process_names_are_basename_operands() {

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -675,13 +675,12 @@ network_stage_report() {
 }
 
 hash_file_for_test() {
-  local file=$1
   if command -v shasum >/dev/null 2>&1; then
-    shasum -a 256 "$file" | awk '{print "sha256:" $1}'
+    cat -- "$@" | shasum -a 256 | awk '{print "sha256:" $1}'
   elif command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "$file" | awk '{print "sha256:" $1}'
+    cat -- "$@" | sha256sum | awk '{print "sha256:" $1}'
   else
-    cksum "$file" | awk '{print "cksum:" $1 ":" $2}'
+    cat -- "$@" | cksum | awk '{print "cksum:" $1 ":" $2}'
   fi
 }
 
@@ -720,13 +719,19 @@ install_omp_extensions_fixture() {
   mkdir -p "$root/.omp/extensions"
   cp "$ROOT/.omp/extensions/fm-primary-omp-watch.ts" "$root/.omp/extensions/fm-primary-omp-watch.ts"
   cp "$ROOT/.omp/extensions/fm-primary-turnend-guard.ts" "$root/.omp/extensions/fm-primary-turnend-guard.ts"
+  install_pi_watch_extension_fixture "$root"
+  install_pi_turnend_extension_fixture "$root"
 }
 
+# The OMP entrypoints only re-export the shared Pi-family implementation, so a
+# loaded marker records the digest of the whole load chain, entrypoint first.
 write_omp_loaded_markers() {
   local home=$1 root=$2 pid=$3 version
-  version=$(hash_file_for_test "$root/.omp/extensions/fm-primary-omp-watch.ts")
+  version=$(hash_file_for_test "$root/.omp/extensions/fm-primary-omp-watch.ts" \
+    "$root/.pi/extensions/fm-primary-pi-watch.ts")
   printf '%s\n%s\n' "$version" "$pid" > "$home/state/.omp-watch-extension-loaded"
-  version=$(hash_file_for_test "$root/.omp/extensions/fm-primary-turnend-guard.ts")
+  version=$(hash_file_for_test "$root/.omp/extensions/fm-primary-turnend-guard.ts" \
+    "$root/.pi/extensions/fm-primary-turnend-guard.ts")
   printf '%s\n%s\n' "$version" "$pid" > "$home/state/.omp-turnend-extension-loaded"
 }
 
@@ -2179,6 +2184,36 @@ EOF
 
   pass "session start accepts current OMP watcher and turn-end markers"
 }
+
+# OMP's tracked entrypoints are re-export shims: every line of watcher and
+# turn-end logic lives in the shared Pi-family core they import. An update that
+# only touches that core must still make the session running the OLD code in
+# memory report itself stale, exactly as it does for a Pi primary.
+test_omp_diagnostic_rejects_shared_core_drift() {
+  local rec root home fakebin out holder_pid
+  rec=$(new_world omp-shared-core-drift)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_toolchain "$fakebin"
+
+  sleep 300 &
+  holder_pid=$!
+  make_fake_ps_omp_holder "$fakebin" "$holder_pid"
+  install_omp_extensions_fixture "$root"
+  write_omp_loaded_markers "$home" "$root" "$holder_pid"
+  printf '\n// shared-core update delivered after this session loaded it\n' \
+    >> "$root/.pi/extensions/fm-primary-pi-watch.ts"
+  out=$(FM_FAKE_HARNESS=omp run_session_start "$home" "$root" "$fakebin:$BASE_PATH" omp)
+  kill "$holder_pid" 2>/dev/null || true
+  wait "$holder_pid" 2>/dev/null || true
+
+  assert_contains "$out" "OMP_WATCH_EXTENSION: not loaded" \
+    "an update to the shared Pi-family watcher core left the OMP session reporting itself current"
+
+  pass "session start reports OMP extensions stale when only the shared core changed"
+}
+
 test_pi_diagnostic_rejects_stale_loaded_marker() {
   local rec root home fakebin out marker holder_pid
   rec=$(new_world pi-stale-loaded-marker)
@@ -2318,6 +2353,7 @@ test_supervision_block_exactly_one_and_pi_diagnostic
 test_pi_signed_primary_uses_pi_extensions_without_identity_normalization
 test_omp_primary_uses_verified_supervision_extensions
 test_omp_diagnostic_accepts_current_loaded_markers
+test_omp_diagnostic_rejects_shared_core_drift
 test_pi_diagnostic_rejects_stale_loaded_marker
 test_pi_diagnostic_accepts_prelock_loaded_marker
 test_pi_diagnostic_rejects_missing_turnend_guard_marker

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -287,6 +287,41 @@ SH
   chmod +x "$fakebin/ps"
 }
 
+make_fake_ps_omp_holder() {
+  local fakebin=$1 holder_pid=$2
+  cat > "$fakebin/ps" <<SH
+#!/usr/bin/env bash
+set -u
+pid=""
+prev=""
+for arg in "\$@"; do
+  [ "\$prev" = "-p" ] && pid="\$arg"
+  prev="\$arg"
+done
+case "\$*" in
+  *"comm="*)
+    if [ "\$pid" = "$holder_pid" ]; then
+      printf '/Users/test/.bun/bin/omp\n'
+    else
+      printf '/bin/zsh\n'
+    fi
+    exit 0
+    ;;
+  *"args="*)
+    if [ "\$pid" = "$holder_pid" ]; then
+      printf '/Users/test/.bun/bin/omp --model openai-codex/gpt-5.6-sol\n'
+    else
+      printf 'zsh\n'
+    fi
+    exit 0
+    ;;
+  *"ppid="*) printf '%s\n' "$holder_pid"; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+}
+
 # make_fake_tmux <fakebin> <live-target>: display-message succeeds only for
 # the given "session:window" target - the exact primitive
 # fm_backend_target_exists uses for a tmux endpoint liveness read.
@@ -498,25 +533,31 @@ SH
   chmod +x "$fakebin/herdr"
 }
 
-# run_session_start <home> <root> <path>
-# Drop every harness env marker from bin/fm-harness.sh detect_own so the
-# surrounding interactive shell cannot leak past the suite's fake ps harness.
-# Markers today: CLAUDECODE (claude), PI_CODING_AGENT plus FM_PI_HARNESS
-# (Pi family), GROK_AGENT (grok).
-# codex and opencode have no env markers (ancestry only). Without this, a local
-# claude/pi/grok session fails cases that pin a different fake harness while CI
-# (no ambient markers) still passes.
+# run_session_start <home> <root> <path> [selected-harness]
+# Drop every harness environment marker from bin/fm-harness.sh detect_own so
+# the surrounding interactive shell cannot leak past the suite's fake ps
+# harness. A selected Pi-family or OMP harness then receives only its own
+# positive marker; ancestry-only fixtures receive none.
 run_session_start() {
-  local home=$1 root=$2 path=$3 pi_harness=${4:-}
-  if [ -n "$pi_harness" ]; then
-    env -u CLAUDECODE -u GROK_AGENT PI_CODING_AGENT=true FM_PI_HARNESS="$pi_harness" \
-      FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$path" \
-      "$SESSION_START"
-  else
-    env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
-      FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$path" \
-      "$SESSION_START"
-  fi
+  local home=$1 root=$2 path=$3 selected_harness=${4:-}
+  case "$selected_harness" in
+    omp)
+      env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
+        OMPCODE=1 FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$path" \
+        "$SESSION_START"
+      ;;
+    pi|pi-signed)
+      env -u OMPCODE -u CLAUDECODE -u GROK_AGENT \
+        PI_CODING_AGENT=true FM_PI_HARNESS="$selected_harness" \
+        FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$path" \
+        "$SESSION_START"
+      ;;
+    *)
+      env -u OMPCODE -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
+        FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$path" \
+        "$SESSION_START"
+      ;;
+  esac
 }
 
 # prepare_session_start_secondmate <name>: a throwaway main home and Pi
@@ -672,6 +713,21 @@ write_pi_loaded_markers() {
   local home=$1 root=$2 pid=$3
   write_pi_watch_loaded_marker "$home" "$root" "$pid"
   write_pi_turnend_loaded_marker "$home" "$root" "$pid"
+}
+
+install_omp_extensions_fixture() {
+  local root=$1
+  mkdir -p "$root/.omp/extensions"
+  cp "$ROOT/.omp/extensions/fm-primary-omp-watch.ts" "$root/.omp/extensions/fm-primary-omp-watch.ts"
+  cp "$ROOT/.omp/extensions/fm-primary-turnend-guard.ts" "$root/.omp/extensions/fm-primary-turnend-guard.ts"
+}
+
+write_omp_loaded_markers() {
+  local home=$1 root=$2 pid=$3 version
+  version=$(hash_file_for_test "$root/.omp/extensions/fm-primary-omp-watch.ts")
+  printf '%s\n%s\n' "$version" "$pid" > "$home/state/.omp-watch-extension-loaded"
+  version=$(hash_file_for_test "$root/.omp/extensions/fm-primary-turnend-guard.ts")
+  printf '%s\n%s\n' "$version" "$pid" > "$home/state/.omp-turnend-extension-loaded"
 }
 
 # --- context digest: absent vs empty vs present -----------------------------
@@ -1877,7 +1933,7 @@ SH
   chmod +x "$nest"
 
   # shellcheck disable=SC2016 # $$ must expand in the launched shell, not here.
-  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
+  out=$(env -u OMPCODE -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
     FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$fakebin:$BASE_PATH" \
     bash -c 'export FM_FAKE_HARNESS_PID=$$; exec "$1" 8 "$2"' _ "$nest" "$SESSION_START")
 
@@ -1913,7 +1969,7 @@ EOF
 
   append_wake "$home/state" signal task-r "done: queued after the re-emit too" || fail "seed second wake failed"
   reemit=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$root" FM_FAKE_HARNESS_PID=$$ PATH="$fakebin:$BASE_PATH" \
-    env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
+    env -u OMPCODE -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
     "$SESSION_START" --reemit)
 
   assert_contains "$reemit" "SESSION START (CONTEXT RE-EMIT) - $home" "--reemit did not label itself"
@@ -1938,7 +1994,7 @@ EOF
   git -C "$root" checkout -q -B fm/reemit-tangle
 
   reemit=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$fakebin:$BASE_PATH" \
-    env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
+    env -u OMPCODE -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
     "$SESSION_START" --reemit)
 
   # A re-emit skips the sweeps because it ALREADY ran them, not because it lacks
@@ -1953,7 +2009,7 @@ EOF
   holder_pid=$!
   printf '%s\n' "$holder_pid" > "$home/state/.lock"
   readonly_out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$fakebin:$BASE_PATH" \
-    env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
+    env -u OMPCODE -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
     "$SESSION_START" --reemit)
   kill "$holder_pid" 2>/dev/null || true
   wait "$holder_pid" 2>/dev/null || true
@@ -2076,6 +2132,53 @@ EOF
   pass "session start preserves pi-signed primary identity while applying Pi extension guarantees"
 }
 
+test_omp_primary_uses_verified_supervision_extensions() {
+  local rec root home fakebin out
+  rec=$(new_world omp-supervision-block)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_toolchain "$fakebin"
+  make_fake_ps_harness "$fakebin" omp
+
+  out=$(FM_FAKE_HARNESS=omp run_session_start "$home" "$root" "$fakebin:$BASE_PATH" omp)
+
+  assert_contains "$out" "SUPERVISION OPERATING INSTRUCTIONS - primary harness: omp" \
+    "session start did not select OMP's verified supervision protocol"
+  assert_contains "$out" "Mode: OMP extension background wake." \
+    "OMP primary did not render its extension-owned supervision protocol"
+  assert_contains "$out" "OMP_WATCH_EXTENSION: not loaded" \
+    "OMP primary skipped extension validation"
+  assert_contains "$out" "restart OMP so $root/.omp/extensions/fm-primary-turnend-guard.ts and $root/.omp/extensions/fm-primary-omp-watch.ts auto-load" \
+    "OMP extension diagnostic did not name both required entrypoints"
+  assert_not_contains "$out" "Mode: Unknown harness fallback." \
+    "OMP primary still received the unknown fallback"
+
+  pass "session start selects OMP's verified supervision protocol and validates both extensions"
+}
+
+
+test_omp_diagnostic_accepts_current_loaded_markers() {
+  local rec root home fakebin out holder_pid
+  rec=$(new_world omp-current-loaded-markers)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_toolchain "$fakebin"
+
+  sleep 300 &
+  holder_pid=$!
+  make_fake_ps_omp_holder "$fakebin" "$holder_pid"
+  install_omp_extensions_fixture "$root"
+  write_omp_loaded_markers "$home" "$root" "$holder_pid"
+  out=$(FM_FAKE_HARNESS=omp run_session_start "$home" "$root" "$fakebin:$BASE_PATH" omp)
+  kill "$holder_pid" 2>/dev/null || true
+  wait "$holder_pid" 2>/dev/null || true
+
+  assert_not_contains "$out" "OMP_WATCH_EXTENSION: not loaded" "OMP diagnostic rejected current loaded markers"
+
+  pass "session start accepts current OMP watcher and turn-end markers"
+}
 test_pi_diagnostic_rejects_stale_loaded_marker() {
   local rec root home fakebin out marker holder_pid
   rec=$(new_world pi-stale-loaded-marker)
@@ -2213,6 +2316,8 @@ test_next_step_sources_x_mode_cadence
 test_next_step_afk_delegates_to_daemon
 test_supervision_block_exactly_one_and_pi_diagnostic
 test_pi_signed_primary_uses_pi_extensions_without_identity_normalization
+test_omp_primary_uses_verified_supervision_extensions
+test_omp_diagnostic_accepts_current_loaded_markers
 test_pi_diagnostic_rejects_stale_loaded_marker
 test_pi_diagnostic_accepts_prelock_loaded_marker
 test_pi_diagnostic_rejects_missing_turnend_guard_marker

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -362,7 +362,7 @@ test_active_dispatch_profile_allows_raw_launch_command() {
   assert_contains "$out" "spawned $id harness=custom-agent" "spawn did not report raw command harness"
   assert_meta_profile "$HOME_DIR/state/$id.meta" custom-agent default default
   launch=$(cat "$LAUNCH_LOG")
-  [ "$launch" = "custom-agent --flag" ] || fail "raw launch command changed"$'\n'"actual: $launch"
+  [ "$launch" = "env -u OMPCODE custom-agent --flag" ] || fail "raw launch command changed"$'\n'"actual: $launch"
   pass "active crew-dispatch profile allows the raw launch-command escape hatch"
 }
 
@@ -544,14 +544,22 @@ test_pi_signed_threads_shared_pi_profile_and_preserves_identity() {
 }
 
 # A raw launch command still resolves a harness identity, and that identity is
-# what the worker must report back. Without FM_PI_HARNESS a raw `pi-signed ...`
-# worker sees only PI_CODING_AGENT and calls itself plain pi, contradicting the
-# harness recorded in its own meta.
-test_raw_pi_signed_launch_keeps_the_self_identification_marker() {
-  local rec id out status launch own
+# what the worker must report back. The composed command line is therefore RUN
+# here, in a pane environment that reproduces a spawn from an OMP primary: OMP's
+# own OMPCODE marker is inherited, and detect_own reads it ahead of every other
+# marker. The invariant under test is worker self-identity == recorded harness,
+# so a leaked marker and a missing FM_PI_HARNESS both have to fail this.
+test_raw_launch_worker_identity_matches_its_recorded_harness() {
+  local rec id out status launch probe
   id=profile-raw-pi-signed-z8e
   rec=$(make_spawn_case profile-raw-pi-signed claude "$id")
   read_case_record "$rec"
+  probe="$CASE_DIR/raw-harness-probe"
+  cat > "$FAKEBIN_DIR/pi-signed" <<SH
+#!/usr/bin/env bash
+"$ROOT/bin/fm-harness.sh" > "$probe"
+SH
+  chmod +x "$FAKEBIN_DIR/pi-signed"
 
   out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
     "$id" "$PROJ_DIR" "pi-signed --model openai-codex/gpt-5.6-sol")
@@ -559,16 +567,14 @@ test_raw_pi_signed_launch_keeps_the_self_identification_marker() {
   expect_code 0 "$status" "a raw pi-signed launch command should spawn"
   assert_contains "$out" "spawned $id harness=pi-signed" "raw pi-signed launch did not record its harness identity"
   assert_grep "harness=pi-signed" "$HOME_DIR/state/$id.meta" "raw pi-signed launch meta lost harness=pi-signed"
-  launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "FM_PI_HARNESS=pi-signed pi-signed --model openai-codex/gpt-5.6-sol" \
-    "raw pi-signed launch dropped the marker its worker self-identifies with"
-  assert_not_contains "$launch" "env -u OMPCODE" \
-    "raw launch command must stay the operator's verbatim command line"
 
-  own=$(env -u CLAUDECODE -u GROK_AGENT -u OMPCODE \
-    PI_CODING_AGENT=true FM_PI_HARNESS=pi-signed "$ROOT/bin/fm-harness.sh")
-  [ "$own" = pi-signed ] || fail "a worker launched with that marker self-identified as '$own', not pi-signed"
-  pass "a raw pi-signed launch keeps the identity marker its worker reports back"
+  launch=$(cat "$LAUNCH_LOG")
+  env -u CLAUDECODE -u GROK_AGENT OMPCODE=1 PI_CODING_AGENT=true \
+    PATH="$FAKEBIN_DIR:$PATH" bash -c "$launch"
+  [ -f "$probe" ] || fail "the raw launch command did not run its harness probe"
+  [ "$(cat "$probe")" = pi-signed ] \
+    || fail "a raw worker spawned under an inherited OMPCODE self-identified as '$(cat "$probe")', not pi-signed"
+  pass "a raw launch worker self-identifies as its recorded harness even under an inherited OMP marker"
 }
 
 test_pi_signed_missing_binary_refuses_before_endpoint_or_metadata() {
@@ -721,7 +727,7 @@ test_grok_omits_invalid_xhigh_reasoning_effort
 test_opencode_threads_model_and_ignores_effort_axis
 test_pi_threads_model_and_max_effort
 test_pi_signed_threads_shared_pi_profile_and_preserves_identity
-test_raw_pi_signed_launch_keeps_the_self_identification_marker
+test_raw_launch_worker_identity_matches_its_recorded_harness
 test_pi_signed_missing_binary_refuses_before_endpoint_or_metadata
 test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity
 test_batch_forwards_shared_profile_flags

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -129,7 +129,7 @@ test_no_profile_keeps_claude_profile_defaults() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
+  expected="env -u OMPCODE CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch did not use the canonical launch kind"$'\n'"expected: $expected"$'\n'"actual:   $launch"
   pass "no --model/--effort records defaults and types the claude launch instructions"
 }
@@ -543,6 +543,34 @@ test_pi_signed_threads_shared_pi_profile_and_preserves_identity() {
   pass "pi-signed shares Pi launch semantics while preserving its configured and recorded identity"
 }
 
+# A raw launch command still resolves a harness identity, and that identity is
+# what the worker must report back. Without FM_PI_HARNESS a raw `pi-signed ...`
+# worker sees only PI_CODING_AGENT and calls itself plain pi, contradicting the
+# harness recorded in its own meta.
+test_raw_pi_signed_launch_keeps_the_self_identification_marker() {
+  local rec id out status launch own
+  id=profile-raw-pi-signed-z8e
+  rec=$(make_spawn_case profile-raw-pi-signed claude "$id")
+  read_case_record "$rec"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" "pi-signed --model openai-codex/gpt-5.6-sol")
+  status=$?
+  expect_code 0 "$status" "a raw pi-signed launch command should spawn"
+  assert_contains "$out" "spawned $id harness=pi-signed" "raw pi-signed launch did not record its harness identity"
+  assert_grep "harness=pi-signed" "$HOME_DIR/state/$id.meta" "raw pi-signed launch meta lost harness=pi-signed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "FM_PI_HARNESS=pi-signed pi-signed --model openai-codex/gpt-5.6-sol" \
+    "raw pi-signed launch dropped the marker its worker self-identifies with"
+  assert_not_contains "$launch" "env -u OMPCODE" \
+    "raw launch command must stay the operator's verbatim command line"
+
+  own=$(env -u CLAUDECODE -u GROK_AGENT -u OMPCODE \
+    PI_CODING_AGENT=true FM_PI_HARNESS=pi-signed "$ROOT/bin/fm-harness.sh")
+  [ "$own" = pi-signed ] || fail "a worker launched with that marker self-identified as '$own', not pi-signed"
+  pass "a raw pi-signed launch keeps the identity marker its worker reports back"
+}
+
 test_pi_signed_missing_binary_refuses_before_endpoint_or_metadata() {
   local rec id out status
   id=profile-pi-signed-missing-z8c
@@ -618,7 +646,7 @@ test_claude_forwards_firstmate_config_dir_when_set() {
   status=$?
   expect_code 0 "$status" "claude spawn with CLAUDE_CONFIG_DIR set should succeed"
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "CLAUDE_CONFIG_DIR='/opt/test/claude-work' CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude" \
+  assert_contains "$launch" "CLAUDE_CONFIG_DIR='/opt/test/claude-work' env -u OMPCODE CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude" \
     "claude launch did not forward firstmate's CLAUDE_CONFIG_DIR to the crewmate pane"
   pass "claude forwards firstmate's CLAUDE_CONFIG_DIR so the crewmate uses the same credential store"
 }
@@ -693,6 +721,7 @@ test_grok_omits_invalid_xhigh_reasoning_effort
 test_opencode_threads_model_and_ignores_effort_axis
 test_pi_threads_model_and_max_effort
 test_pi_signed_threads_shared_pi_profile_and_preserves_identity
+test_raw_pi_signed_launch_keeps_the_self_identification_marker
 test_pi_signed_missing_binary_refuses_before_endpoint_or_metadata
 test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity
 test_batch_forwards_shared_profile_flags

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -129,7 +129,7 @@ test_no_profile_keeps_claude_profile_defaults() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="env -u OMPCODE CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
+  expected="unset OMPCODE; CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch did not use the canonical launch kind"$'\n'"expected: $expected"$'\n'"actual:   $launch"
   pass "no --model/--effort records defaults and types the claude launch instructions"
 }
@@ -362,7 +362,7 @@ test_active_dispatch_profile_allows_raw_launch_command() {
   assert_contains "$out" "spawned $id harness=custom-agent" "spawn did not report raw command harness"
   assert_meta_profile "$HOME_DIR/state/$id.meta" custom-agent default default
   launch=$(cat "$LAUNCH_LOG")
-  [ "$launch" = "env -u OMPCODE custom-agent --flag" ] || fail "raw launch command changed"$'\n'"actual: $launch"
+  [ "$launch" = "unset OMPCODE; custom-agent --flag" ] || fail "raw launch command changed"$'\n'"actual: $launch"
   pass "active crew-dispatch profile allows the raw launch-command escape hatch"
 }
 
@@ -577,6 +577,38 @@ SH
   pass "a raw launch worker self-identifies as its recorded harness even under an inherited OMP marker"
 }
 
+# The raw path is the escape hatch for verifying a new adapter, so it has to keep
+# accepting the shell forms an experimental launcher takes. A command-prefix
+# strip (`env -u OMPCODE cd sub && agent`) would make this pane die at the first
+# word while still looking like a launch, so the composed line is run for real.
+test_raw_launch_preserves_compound_shell_command_forms() {
+  local rec id out status launch probe sub sub_pwd
+  id=profile-raw-shellform-z8g
+  rec=$(make_spawn_case profile-raw-shellform claude "$id")
+  read_case_record "$rec"
+  probe="$CASE_DIR/raw-shellform-probe"
+  sub="$CASE_DIR/subdir"
+  mkdir -p "$sub"
+  sub_pwd=$(cd "$sub" && pwd)
+  cat > "$FAKEBIN_DIR/myagent" <<SH
+#!/usr/bin/env bash
+printf '%s %s\n' "\$PWD" "\${OMPCODE-stripped}" > "$probe"
+SH
+  chmod +x "$FAKEBIN_DIR/myagent"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" "cd $sub && myagent --x")
+  status=$?
+  expect_code 0 "$status" "a raw compound-shell launch command should spawn"
+
+  launch=$(cat "$LAUNCH_LOG")
+  env OMPCODE=1 PATH="$FAKEBIN_DIR:$PATH" bash -c "$launch"
+  [ -f "$probe" ] || fail "the raw compound-shell launch command never reached its agent"$'\n'"launch: $launch"
+  [ "$(cat "$probe")" = "$sub_pwd stripped" ] \
+    || fail "raw compound-shell launch produced '$(cat "$probe")', want '$sub_pwd stripped'"
+  pass "a raw launch keeps compound shell forms runnable while still stripping the OMP marker"
+}
+
 test_pi_signed_missing_binary_refuses_before_endpoint_or_metadata() {
   local rec id out status
   id=profile-pi-signed-missing-z8c
@@ -652,7 +684,7 @@ test_claude_forwards_firstmate_config_dir_when_set() {
   status=$?
   expect_code 0 "$status" "claude spawn with CLAUDE_CONFIG_DIR set should succeed"
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "CLAUDE_CONFIG_DIR='/opt/test/claude-work' env -u OMPCODE CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude" \
+  assert_contains "$launch" "unset OMPCODE; CLAUDE_CONFIG_DIR='/opt/test/claude-work' CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude" \
     "claude launch did not forward firstmate's CLAUDE_CONFIG_DIR to the crewmate pane"
   pass "claude forwards firstmate's CLAUDE_CONFIG_DIR so the crewmate uses the same credential store"
 }
@@ -728,6 +760,7 @@ test_opencode_threads_model_and_ignores_effort_axis
 test_pi_threads_model_and_max_effort
 test_pi_signed_threads_shared_pi_profile_and_preserves_identity
 test_raw_launch_worker_identity_matches_its_recorded_harness
+test_raw_launch_preserves_compound_shell_command_forms
 test_pi_signed_missing_binary_refuses_before_endpoint_or_metadata
 test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity
 test_batch_forwards_shared_profile_flags

--- a/tests/fm-supervision-instructions.test.sh
+++ b/tests/fm-supervision-instructions.test.sh
@@ -81,6 +81,13 @@ test_cross_harness_ordinary_continuation_and_repair_matrix() {
   out=$("$RENDER" --harness pi --repair-line)
   assert_contains "$out" "fm_watch_arm_pi" "pi recovery line lost the extension-owned repair tool"
 
+  out=$("$RENDER" --harness omp)
+  ordinary=$(printf '%s\n' "$out" | grep -F -- '- Ordinary wake:')
+  assert_contains "$ordinary" "OMP extension already owns watcher continuity" "OMP ordinary-wake line does not leave continuity to the extension"
+  assert_not_contains "$ordinary" "fm_watch_arm_omp" "OMP ordinary-wake line incorrectly calls the recovery tool"
+  out=$("$RENDER" --harness omp --repair-line)
+  assert_contains "$out" "fm_watch_arm_omp" "OMP recovery line lost the extension-owned repair tool"
+
   out=$("$RENDER" --harness opencode)
   ordinary=$(printf '%s\n' "$out" | grep -F -- '- Ordinary wake:')
   assert_contains "$ordinary" "plugin already owns watcher continuity" "opencode ordinary-wake line does not leave continuity to the plugin"
@@ -176,6 +183,24 @@ test_pi_snippet_uses_effective_extension_path() {
   pass "pi supervision snippet renders the effective extension path"
 }
 
+test_omp_snippet_uses_effective_extension_path() {
+  local home out turnend watch
+  home="$TMP_ROOT/omp-home"
+  turnend="$ROOT/.omp/extensions/fm-primary-turnend-guard.ts"
+  watch="$ROOT/.omp/extensions/fm-primary-omp-watch.ts"
+  mkdir -p "$home/state" "$home/config"
+  out=$(FM_HOME="$home" "$RENDER" --harness omp)
+  assert_contains "$out" "primary harness: omp" "OMP supervision heading missing"
+  assert_contains "$out" "Mode: OMP extension background wake." "OMP snippet missing"
+  assert_contains "$out" "-e $turnend -e $watch" "OMP snippet did not render both effective extension launch paths"
+  assert_contains "$out" "The turn-end guard extension lives at \`$turnend\`" "OMP snippet did not render the turn-end guard extension path"
+  assert_contains "$out" "The watcher extension lives at \`$watch\`" "OMP snippet did not render the watcher extension path"
+  assert_not_contains "$out" "__FM_OMP_EXT__" "renderer leaked the OMP extension path placeholder"
+  assert_not_contains "$out" "__FM_OMP_TURNEND_EXT__" "renderer leaked the OMP turn-end extension path placeholder"
+  assert_not_contains "$out" "Mode: Unknown harness fallback." "OMP still received the unknown supervision protocol"
+  pass "OMP supervision snippet renders the effective extension paths and verified protocol"
+}
+
 test_selected_harness_block_only
 test_unknown_fallback
 test_conditional_stanzas
@@ -185,3 +210,4 @@ test_pi_signed_preserves_identity_with_pi_supervision_protocol
 test_grok_is_background_notify
 test_grok_command_sources_effective_config
 test_pi_snippet_uses_effective_extension_path
+test_omp_snippet_uses_effective_extension_path

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -1326,6 +1326,30 @@ test_teardown_missing_busy_sidecar_completes() {
   pass "teardown completes when an exact busy-state sidecar is already absent"
 }
 
+# The per-task extension a Pi-family spawn writes into state/ is an executable
+# artifact firstmate owns, and task ids are never reused, so anything teardown
+# forgets accumulates in state/ forever.
+test_teardown_removes_per_task_adapter_extensions() {
+  local case_dir rc
+  case_dir=$(make_case adapter-extensions)
+  write_meta "$case_dir" local-only ship
+  printf 'harness=omp\n' >> "$case_dir/state/task-x1.meta"
+  printf '// generated pi extension\n' > "$case_dir/state/task-x1.pi-ext.ts"
+  printf '// generated omp extension\n' > "$case_dir/state/task-x1.omp-ext.ts"
+
+  set +e
+  run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "adapter-extensions: teardown should complete: $(cat "$case_dir/stderr")"
+  assert_absent "$case_dir/state/task-x1.pi-ext.ts" \
+    "adapter-extensions: teardown left the generated Pi extension behind"
+  assert_absent "$case_dir/state/task-x1.omp-ext.ts" \
+    "adapter-extensions: teardown left the generated OMP extension behind"
+  pass "teardown removes the generated per-task adapter extensions from state"
+}
+
 test_herdr_teardown_clears_escalation_marker() {
   local case_dir marker
   case_dir=$(make_case herdr-marker-cleanup)
@@ -2600,6 +2624,7 @@ test_no_mistakes_origin_remote_allows
 test_no_mistakes_truly_unpushed_refuses
 test_local_only_force_overrides_unpushed
 test_teardown_missing_busy_sidecar_completes
+test_teardown_removes_per_task_adapter_extensions
 test_herdr_teardown_clears_escalation_marker
 test_herdr_flat_teardown_refuses_orphaning_records_then_retry_completes
 test_herdr_flat_teardown_refuses_records_on_unparseable_presence

--- a/tests/fm-tmux-agent-liveness.test.sh
+++ b/tests/fm-tmux-agent-liveness.test.sh
@@ -24,6 +24,7 @@ pass() { printf 'ok - %s\n' "$1"; }
 
 command -v tmux >/dev/null 2>&1 || { echo "skip: tmux not found"; exit 0; }
 SLEEP_BIN=$(command -v sleep) || { echo "skip: sleep not found"; exit 0; }
+SH_BIN=$(command -v sh) || { echo "skip: sh not found"; exit 0; }
 
 REAL_TMUX=$(command -v tmux)
 SOCKET="fm-liveness-$$"
@@ -160,6 +161,37 @@ new_window omp "$LAB/bin/omp" 900
 wait_for_state "$SESSION:omp" alive \
   || fail "a running exact OMP process must classify alive"
 pass "tmux liveness: an exact OMP process classifies alive"
+
+# --- OMP's real shape: a Bun runtime whose script argument is the identity ----
+# The installed OMP is a Bun script, so nothing in the process NAME says omp -
+# the only identity is argv[1]. A pane misread here reads as a dead endpoint,
+# which is the verdict that tears down or duplicates a live OMP worker. The
+# decoy pins the same anchoring rule the muse cases pin: a script path that
+# merely contains "omp" is a different program.
+
+mkdir -p "$LAB/bunroot" "$LAB/decoyroot"
+ln -s "$SH_BIN" "$LAB/bin/bun"
+cat > "$LAB/bunroot/omp" <<SH
+#!/bin/sh
+"$SLEEP_BIN" 900
+SH
+cat > "$LAB/decoyroot/ompanion" <<SH
+#!/bin/sh
+"$SLEEP_BIN" 900
+SH
+chmod +x "$LAB/bunroot/omp" "$LAB/decoyroot/ompanion"
+
+new_window ompbun "$LAB/bin/bun" "$LAB/bunroot/omp"
+wait_for_state "$SESSION:ompbun" alive \
+  || fail "Bun running the exact omp script must classify alive"
+title_classifies_agent "$SESSION:ompbun" \
+  && fail "the Bun case went vacuous: the process name alone already named a harness"
+pass "tmux liveness: a Bun process whose script argument is the exact omp path classifies alive"
+
+new_window ompbun-decoy "$LAB/bin/bun" "$LAB/decoyroot/ompanion"
+wait_for_state "$SESSION:ompbun-decoy" ambiguous \
+  || fail "a Bun script path that merely contains 'omp' must not classify as a live agent pane"
+pass "tmux liveness: a Bun script path that only contains 'omp' stays ambiguous"
 
 # --- muse's version-suffixed binary name ------------------------------------
 # A muse crewmate pane misclassified here reads as a dead endpoint, so a healthy

--- a/tests/fm-tmux-agent-liveness.test.sh
+++ b/tests/fm-tmux-agent-liveness.test.sh
@@ -53,6 +53,7 @@ export PATH
 # the executable identity, which is exactly the signal under test.
 ln -s "$SLEEP_BIN" "$LAB/bin/claude-link"
 ln -s "$SLEEP_BIN" "$LAB/bin/pi"
+ln -s "$SLEEP_BIN" "$LAB/bin/omp"
 ln -s "$SLEEP_BIN" "$LAB/bin/notaharness"
 # muse's installed binary is muse-bin-<version>: the launcher execs it, so the
 # version is the LIVE process name and it changes on every auto-update. Unlike
@@ -154,6 +155,11 @@ new_window agent "$LAB/bin/claude-link" 900
 wait_for_state "$SESSION:agent" alive \
   || fail "a running harness-named foreground process must classify alive"
 pass "tmux liveness: a harness-named foreground process classifies alive"
+
+new_window omp "$LAB/bin/omp" 900
+wait_for_state "$SESSION:omp" alive \
+  || fail "a running exact OMP process must classify alive"
+pass "tmux liveness: an exact OMP process classifies alive"
 
 # --- muse's version-suffixed binary name ------------------------------------
 # A muse crewmate pane misclassified here reads as a dead endpoint, so a healthy

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -1096,6 +1096,60 @@ EOF
   pass ".omp primary extension: agent_end drives one guard follow-up per logical run"
 }
 
+# The loaded marker is what bin/fm-session-start.sh reads to decide whether the
+# running session carries current guard code. OMP replaces a session in the same
+# process with session_switch, so that path has to restore the marker the way
+# session_start does, and the recorded version has to cover the shared core the
+# thin .omp entrypoint re-exports - otherwise a core-only update stays invisible.
+test_omp_session_switch_restores_a_current_loaded_marker() {
+  local repo home ext out status
+  repo="$TMP_ROOT/omp-switch-marker-root"
+  home="$TMP_ROOT/omp-switch-marker-home"
+  ext="$repo/.omp/extensions/fm-primary-turnend-guard.ts"
+  mkdir -p "$repo/.omp/extensions" "$repo/.pi/extensions/lib" "$repo/bin" "$home/state"
+  cp "$ROOT/.omp/extensions/fm-primary-turnend-guard.ts" "$ext"
+  cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$repo/.pi/extensions/fm-primary-turnend-guard.ts"
+  cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$repo/.pi/extensions/lib/fm-operational-input.ts"
+  out=$(OMPCODE=1 PLUGIN="$ext" FM_HOME="$home" node --input-type=module 2>&1 <<'EOF'
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const entrypoint = process.env.PLUGIN;
+const repo = resolve(dirname(entrypoint), "../..");
+const shared = `${repo}/.pi/extensions/fm-primary-turnend-guard.ts`;
+const marker = `${process.env.FM_HOME}/state/.omp-turnend-extension-loaded`;
+const expected = `sha256:${createHash("sha256")
+  .update(readFileSync(entrypoint))
+  .update(readFileSync(shared))
+  .digest("hex")}`;
+
+const handlers = new Map();
+const pi = { on(event, handler) { handlers.set(event, handler); } };
+const mod = await import(pathToFileURL(entrypoint).href);
+mod.default(pi);
+
+if (readFileSync(marker, "utf8").split("\n")[0] !== expected) {
+  throw new Error(`registration recorded ${readFileSync(marker, "utf8").split("\n")[0]}, want ${expected}`);
+}
+
+rmSync(marker);
+const switched = handlers.get("session_switch");
+if (!switched) throw new Error("OMP session_switch handler was not registered");
+await switched({ type: "session_switch", reason: "new" }, {});
+if (!existsSync(marker)) throw new Error("session_switch did not restore the loaded marker");
+const [version, pid] = readFileSync(marker, "utf8").split("\n");
+if (version !== expected) throw new Error(`session_switch recorded ${version}, want ${expected}`);
+if (Number(pid) !== process.pid) throw new Error(`session_switch recorded pid ${pid}, want ${process.pid}`);
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "OMP session_switch must restore a marker versioned over the whole load chain"
+  [ -z "$out" ] || fail "OMP session_switch marker test printed output: $out"
+  pass ".omp primary extension: session_switch restores the loaded marker over the whole load chain"
+}
+
 test_pi_extension_retries_after_followup_delivery_failure() {
   local repo home ext out status
   repo="$TMP_ROOT/pi-delivery-failure-root"
@@ -1706,6 +1760,7 @@ test_codex_hook_ignores_nested_git_root_guard
 test_opencode_plugin_anchors_guard_to_worktree
 test_pi_extension_injects_once_per_logical_agent_run
 test_omp_extension_uses_agent_end_for_logical_runs
+test_omp_session_switch_restores_a_current_loaded_marker
 test_pi_extension_retries_after_followup_delivery_failure
 test_hook_claude_mode_reblocks_stop_hook_active_when_unhealthy
 test_hook_claude_mode_reblocks_x_mode_without_tasks

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -1150,6 +1150,70 @@ EOF
   pass ".omp primary extension: session_switch restores the loaded marker over the whole load chain"
 }
 
+# OMPCODE is inheritable, so a Pi primary launched from an OMP session's shell
+# carries it. Binding the guard to OMP's agent_end there would be silent and
+# total: Pi never emits agent_end, so every turn would end with no guard at all.
+# The entrypoint Pi auto-loads decides the protocol, and this pins that.
+test_pi_guard_entrypoint_ignores_an_inherited_omp_marker() {
+  local repo home ext log out status
+  repo="$TMP_ROOT/pi-guard-inherited-omp-root"
+  home="$TMP_ROOT/pi-guard-inherited-omp-home"
+  ext="$repo/.pi/extensions/fm-primary-turnend-guard.ts"
+  log="$TMP_ROOT/pi-guard-inherited-omp.log"
+  mkdir -p "$repo/.pi/extensions/lib" "$repo/bin" "$home/state"
+  cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$ext"
+  cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$repo/.pi/extensions/lib/fm-operational-input.ts"
+  cp "$ROOT/bin/fm-operational-input.sh" "$repo/bin/fm-operational-input.sh"
+  cat > "$repo/bin/fm-turnend-guard.sh" <<'SH'
+#!/usr/bin/env bash
+cat >/dev/null
+printf 'guard\n' >> "${FM_GUARD_LOG:?}"
+printf 'inherited-marker guard fired\n' >&2
+exit 2
+SH
+  cat > "$repo/bin/fm-arm-pretool-check.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$repo/bin/fm-turnend-guard.sh" "$repo/bin/fm-arm-pretool-check.sh"
+  out=$(OMPCODE=1 PLUGIN="$ext" FM_HOME="$home" FM_GUARD_LOG="$log" node --input-type=module 2>&1 <<'EOF'
+import { existsSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const handlers = new Map();
+let prompts = 0;
+const pi = {
+  on(event, handler) { handlers.set(event, handler); },
+  async sendUserMessage(message, options) {
+    prompts += 1;
+    if (!message.includes("TURN WOULD END BLIND")) throw new Error(`unexpected prompt: ${message}`);
+    if (options?.deliverAs !== "followUp") throw new Error("guard prompt was not a follow-up");
+    await handlers.get("agent_settled")?.({ type: "agent_settled" }, {});
+  },
+};
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+if (handlers.has("agent_end")) {
+  throw new Error("the Pi entrypoint bound OMP's agent_end under an inherited marker");
+}
+const settled = handlers.get("agent_settled");
+if (!settled) throw new Error("Pi's agent_settled handler was not registered");
+await settled({ type: "agent_settled" }, {});
+if (prompts !== 1) throw new Error(`Pi's logical run injected ${prompts} guard follow-ups`);
+if (!existsSync(`${process.env.FM_HOME}/state/.pi-turnend-extension-loaded`)) {
+  throw new Error("the Pi entrypoint did not write Pi's loaded marker");
+}
+if (existsSync(`${process.env.FM_HOME}/state/.omp-turnend-extension-loaded`)) {
+  throw new Error("the Pi entrypoint wrote OMP's loaded marker under an inherited marker");
+}
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "an inherited OMPCODE must not bind the Pi guard to an event Pi never emits"
+  [ -z "$out" ] || fail "Pi guard inherited-marker test printed output: $out"
+  pass ".pi primary extension: an inherited OMP marker cannot rebind the guard away from agent_settled"
+}
+
 test_pi_extension_retries_after_followup_delivery_failure() {
   local repo home ext out status
   repo="$TMP_ROOT/pi-delivery-failure-root"
@@ -1761,6 +1825,7 @@ test_opencode_plugin_anchors_guard_to_worktree
 test_pi_extension_injects_once_per_logical_agent_run
 test_omp_extension_uses_agent_end_for_logical_runs
 test_omp_session_switch_restores_a_current_loaded_marker
+test_pi_guard_entrypoint_ignores_an_inherited_omp_marker
 test_pi_extension_retries_after_followup_delivery_failure
 test_hook_claude_mode_reblocks_stop_hook_active_when_unhealthy
 test_hook_claude_mode_reblocks_x_mode_without_tasks

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -1034,6 +1034,68 @@ EOF
   pass ".pi primary extension: no-tool and multi-tool runs each inject exactly one guard follow-up"
 }
 
+test_omp_extension_uses_agent_end_for_logical_runs() {
+  local repo home ext log out status
+  repo="$TMP_ROOT/omp-logical-run-root"
+  home="$TMP_ROOT/omp-logical-run-home"
+  ext="$repo/.omp/extensions/fm-primary-turnend-guard.ts"
+  log="$TMP_ROOT/omp-logical-run-guard.log"
+  mkdir -p "$repo/.omp/extensions" "$repo/.pi/extensions/lib" "$repo/bin" "$home/state"
+  cp "$ROOT/.omp/extensions/fm-primary-turnend-guard.ts" "$ext"
+  cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$repo/.pi/extensions/fm-primary-turnend-guard.ts"
+  cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$repo/.pi/extensions/lib/fm-operational-input.ts"
+  cp "$ROOT/bin/fm-operational-input.sh" "$repo/bin/fm-operational-input.sh"
+  cat > "$repo/bin/fm-turnend-guard.sh" <<'SH'
+#!/usr/bin/env bash
+cat >/dev/null
+printf 'guard\n' >> "${FM_GUARD_LOG:?}"
+printf 'OMP logical-run guard fired\n' >&2
+exit 2
+SH
+  cat > "$repo/bin/fm-arm-pretool-check.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$repo/bin/fm-turnend-guard.sh" "$repo/bin/fm-arm-pretool-check.sh"
+  out=$(OMPCODE=1 PLUGIN="$ext" FM_HOME="$home" FM_GUARD_LOG="$log" node --input-type=module 2>&1 <<'EOF'
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const handlers = new Map();
+let prompts = 0;
+const pi = {
+  on(event, handler) {
+    handlers.set(event, handler);
+  },
+  async sendUserMessage(message, options) {
+    prompts += 1;
+    if (!message.startsWith("\u2063FIRSTMATE_OP: v1 turn-end-guard: ")) throw new Error(`untyped operational prompt: ${message}`);
+    if (!message.includes("TURN WOULD END BLIND")) throw new Error(`unexpected prompt: ${message}`);
+    if (options?.deliverAs !== "followUp") throw new Error("OMP guard prompt was not a follow-up");
+    await handlers.get("agent_end")?.({ type: "agent_end" }, {});
+  },
+};
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+if (handlers.has("agent_settled")) throw new Error("OMP registered Pi's agent_settled event");
+const ended = handlers.get("agent_end");
+if (!ended) throw new Error("OMP agent_end handler was not registered");
+
+await ended({ type: "agent_end" }, {});
+if (prompts !== 1) throw new Error(`OMP run injected ${prompts} follow-ups`);
+await ended({ type: "agent_end" }, {});
+if (prompts !== 2) throw new Error(`second OMP run injected ${prompts - 1} follow-ups`);
+
+const guardRuns = readFileSync(process.env.FM_GUARD_LOG, "utf8").trim().split("\n").length;
+if (guardRuns !== 2) throw new Error(`OMP guard predicate ran ${guardRuns} times for two logical runs`);
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "OMP guard must use agent_end and inject once per logical run"
+  [ -z "$out" ] || fail "OMP logical-run guard test printed output: $out"
+  pass ".omp primary extension: agent_end drives one guard follow-up per logical run"
+}
+
 test_pi_extension_retries_after_followup_delivery_failure() {
   local repo home ext out status
   repo="$TMP_ROOT/pi-delivery-failure-root"
@@ -1643,6 +1705,7 @@ test_codex_hook_uses_process_pwd_when_payload_cwd_is_outside_root
 test_codex_hook_ignores_nested_git_root_guard
 test_opencode_plugin_anchors_guard_to_worktree
 test_pi_extension_injects_once_per_logical_agent_run
+test_omp_extension_uses_agent_end_for_logical_runs
 test_pi_extension_retries_after_followup_delivery_failure
 test_hook_claude_mode_reblocks_stop_hook_active_when_unhealthy
 test_hook_claude_mode_reblocks_x_mode_without_tasks

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -34,6 +34,12 @@ FM_TEST_LIB_SOURCED=1
 # strips this to verify real refusal.
 export FM_GATE_REFUSE_BYPASS=1
 
+# The suite must not inherit OMP's positive process marker when it runs from an
+# OMP primary session. OMP-specific cases set OMPCODE=1 explicitly; every other
+# fixture would otherwise be misidentified before its deterministic fake
+# ancestry is consulted.
+unset OMPCODE
+
 # Resolve the repo root from this library's own location. Consumed by sourcing
 # test files, not by this library, so it reads as "unused" here.
 # shellcheck disable=SC2034


### PR DESCRIPTION
## Intent

Make OMP a first-class verified Firstmate harness for primary sessions, crewmates, and secondmates, including identity detection, spawn and control, semantic busy and liveness, tracked supervision extensions, documentation, and regression coverage without changing backend selection or weakening safety.

## What Changed

- Added OMP identity detection and validated launch/control support across primary, crewmate, secondmate, and remote secondmate paths, including dispatch profiles, model/effort flags, marker isolation, and teardown cleanup.
- Added OMP semantic busy/liveness handling and tracked `.omp/extensions/` watcher and turn-end entrypoints using the Pi-family supervision core with OMP-specific lifecycle events and session switching.
- Documented OMP’s verified harness and supervision contracts, with regression coverage for identity, spawning/control, busy state, liveness, extension continuity, backend behavior, and teardown.

## Risk Assessment

🚨 High: Both safety-sensitive OMP terminal paths ignore the verified `session_stop` event, leaving stale busy state and supervision arms reachable after session termination.

## Testing

Ran the focused harness, spawn/control, busy/liveness, supervision, documentation, bootstrap, teardown, and Herdr tests; fixed the missing-adapter preflight failure and verified the affected suites. The live OMP 17.2.12 liveness and inherited-marker identity checks passed, with reviewer-visible CLI evidence captured. One OpenCode watch test showed a parallel-load timing flake but passed repeated serial runs. No full suite, lint, formatter, or static-analysis commands were run.

<details>
<summary>Evidence: OMP end-to-end CLI transcript</summary>

```text
OMP verified harness evidence
===========================

$ OMPCODE=1 CLAUDECODE=1 FM_CONFIG_OVERRIDE=.../config bin/fm-harness.sh
omp
$ ... bin/fm-harness.sh crew
claude
$ ... bin/fm-harness.sh secondmate
omp
$ ... bin/fm-harness.sh secondmate-model
openai-codex/gpt-5.6-sol
$ ... bin/fm-harness.sh secondmate-effort
high

$ FM_HOME=... bin/fm-supervision-instructions.sh --harness omp --repair-line
repair a missing or failed watcher cycle with the OMP tool fm_watch_arm_omp, or restart OMP with -e /Users/chsong/.no-mistakes/worktrees/567426cc743b/01KZM6PM35QRZ86SD6JW0SDJYP/.omp/extensions/fm-primary-turnend-guard.ts -e /Users/chsong/.no-mistakes/worktrees/567426cc743b/01KZM6PM35QRZ86SD6JW0SDJYP/.omp/extensions/fm-primary-omp-watch.ts if the extensions are not loaded.

$ OMP semantic lifecycle through fm-busy-event.sh and fm-busy-lib.sh
busy=busy omp-ext
idle=idle omp-ext

$ OMP control contract from fm-control-lib.sh
interrupt=Escape repeat=1 exit=/exit secondmate-kind=allowed
```
</details>
<details>
<summary>Evidence: Live OMP liveness and identity evidence</summary>

```text
ok - harness liveness: omp omp/17.2.12 classifies alive
ok - OMP session identity: omp/17.2.12 selects the adapter and owns the lock under an inherited marker
```
</details>
- Outcome: ⚠️ 1 warning across 2 runs (44m58s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2a2bb88ecdbdfdaaaf4b692161a9e032b2249c09","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 errors</summary>

- 🚨 `bin/fm-spawn.sh:2369` - The intent requires “semantic busy and liveness”, but the generated OMP extension handles `session_shutdown` while the verification record says OMP emits `session_stop`. A stop without a final `agent_end` leaves `busy-state` at `busy omp-ext`, so the live shell cannot settle the task. Confirm handling the verified terminal event and update the regression to exercise it.
- 🚨 `.pi/extensions/fm-primary-pi-watch.ts:487` - The intent requires “tracked supervision extensions”. The new OMP path adds `session_switch`, but shared watcher cleanup still listens only for `session_shutdown`; verified OMP behavior uses `session_stop`. An OMP session can therefore leave its watcher generation armed after termination. Confirm OMP-specific cleanup for `session_stop` and align the protocol documentation and behavioral test.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- 🚨 `bin/fm-harness.sh:44` - Live OMP 17.2.12 does not export `OMPCODE=1` to its extension process. With inherited `CLAUDECODE=1`, `bin/fm-harness.sh` returns `claude` before checking exact Bun `/omp` ancestry, so a real primary OMP session can select the wrong identity. Preserve the exact Bun-path safety check while correcting precedence or the verified identity contract; do not weaken matching to arbitrary Bun arguments.
- `bash tests/fm-secondmate-harness.test.sh`
- `bash tests/fm-busy-adapter-wiring.test.sh`
- `bash tests/fm-busy-state.test.sh`
- `bash tests/fm-control.test.sh`
- `bash tests/fm-pi-watch-extension.test.sh`
- `bash tests/fm-turnend-guard.test.sh`
- `bash tests/fm-supervision-instructions.test.sh`
- `bash tests/fm-spawn-dispatch-profile.test.sh`
- `bash tests/fm-session-start.test.sh`
- `bash tests/fm-backend-herdr.test.sh`
- `bash tests/fm-tmux-agent-liveness.test.sh`
- `FM_HARNESS_LIVENESS_DRIFT=1 bash tests/fm-harness-liveness-drift-live-e2e.test.sh`
- `CLAUDECODE=1 FM_HARNESS_LIVENESS_DRIFT=1 bash tests/fm-harness-liveness-drift-live-e2e.test.sh`
- `bash tests/fm-teardown.test.sh`
- <code>Manual `fm-harness.sh`, `fm-busy-event.sh`, and `fm-supervision-instructions.sh --harness omp` product transcript</code>
- <code>Final `git status --short --untracked-files=all`</code>

🔧 Fix: Fixed OMP identity precedence; focused tests pass
1 warning still open:
- ⚠️ `tests/fm-pi-watch-extension.test.sh` - The OpenCode watch-extension test failed once when many focused suites ran concurrently, then passed in isolated and repeated serial runs. This appears to be a timing-sensitive test flake under parallel load.
- `bash tests/fm-secondmate-harness.test.sh`
- `bash tests/fm-spawn-dispatch-profile.test.sh`
- `bash tests/fm-busy-adapter-wiring.test.sh`
- `bash tests/fm-busy-state.test.sh`
- `bash tests/fm-session-start.test.sh`
- `bash tests/fm-supervision-instructions.test.sh`
- `bash tests/fm-turnend-guard.test.sh`
- `bash tests/fm-control.test.sh`
- `bash tests/fm-tmux-agent-liveness.test.sh`
- `bash tests/fm-documentation-audiences.test.sh`
- `bash tests/fm-bootstrap.test.sh`
- <code>`bash tests/fm-teardown.test.sh` after the adapter-loader fix</code>
- <code>`bash tests/fm-backend-herdr.test.sh` after the adapter-loader fix</code>
- `for iteration in 1 2; do bash tests/fm-pi-watch-extension.test.sh >/dev/null || exit $?; done`
- `FM_HARNESS_LIVENESS_DRIFT=1 bash tests/fm-harness-liveness-drift-live-e2e.test.sh`
- `Isolated OMP CLI identity, supervision-repair, busy-lifecycle, and control-contract checks captured in the evidence transcript`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Fix ShellCheck source directives and empty OMP assignment
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
