### PR TITLE
fix(bin): skip non-git fleet-sync candidates

### DIFF
--- a/bin/fm-fleet-sync.sh
+++ b/bin/fm-fleet-sync.sh
@@ -12,7 +12,10 @@
 # ... - needs attention" warning rather than a quiet drift. Nothing is ever forced,
 # stashed, or discarded.
 # Still skips (benignly) local-only/no-origin projects, missing remotes/branches,
-# and fetch failures.
+# and fetch failures. A plain directory under projects/ with no own .git entry
+# (dir or gitfile) is skipped before any git command runs, so git never walks up
+# into the firstmate home checkout; the skip names whether the label is a
+# registered project.
 # Pruning never deletes the checked-out branch or a branch that still has a
 # worktree, so it cannot discard unlanded work; set FM_FLEET_PRUNE=0 to disable it.
 # When the fetch fails on an orphaned .git/packed-refs.lock (left by a ref rewrite
@@ -292,12 +295,38 @@ report_stuck() {
   echo "$label: STUCK: on $state, $behind commits behind $BASE - needs attention"
 }
 
+# True when $1 is itself a repository root: it has its own .git entry (a directory
+# for a normal clone, or a gitfile for a linked worktree). A plain container under
+# projects/ fails this check so later git -C never walks up into a parent checkout.
+is_repo_root() {
+  [ -e "$1/.git" ]
+}
+
+# True when $1 is a name listed in this home's data/projects.md registry.
+project_registered() {
+  local name=$1 reg
+  reg="${FM_DATA_OVERRIDE:-$FM_HOME/data}/projects.md"
+  [ -f "$reg" ] || return 1
+  awk -v n="$name" 'BEGIN { f = 0 } $1 == "-" && $2 == n { f = 1; exit } END { exit !f }' "$reg"
+}
+
 sync_project() {
   PROJ=$1
   label=$(project_label)
 
   if [ ! -d "$PROJ" ]; then
     echo "$label: skipped: not a directory"
+    return 0
+  fi
+  # Require an own .git before any git command. Without this, git -C on a plain
+  # projects/<name> container discovers the firstmate home checkout above it and
+  # can emit a false STUCK: for the home, not the candidate.
+  if ! is_repo_root "$PROJ"; then
+    if project_registered "$label"; then
+      echo "$label: skipped: not a git clone (no .git); registered project"
+    else
+      echo "$label: skipped: not a git clone (no .git); not a registered project"
+    fi
     return 0
   fi
   if ! git -C "$PROJ" rev-parse --is-inside-work-tree >/dev/null 2>&1; then

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -302,6 +302,7 @@ Invoked in a primary home, `/stow` then cascades the same sweep to every registe
 The locked session-start deferred network stage, PR-based teardown, and merged-PR wake handling refresh remote-backed project clones when the clone is safe to move.
 Wake-time refreshes can target a single clone by project name, so the primary home also catches up when a secondmate reports a merge from its own home.
 Clean default-branch clones fast-forward to `origin/<default>`, and a clean detached HEAD that holds no unique commits is re-attached to the default branch before the same fast-forward path runs.
+Fleet sync invokes Git only after a candidate resolves to a clone root with its own `.git` directory or gitfile, preventing a plain directory under `projects/` from resolving upward into the Firstmate home checkout.
 Dirty clones, non-default branches, detached HEADs with unique commits, diverged defaults, and default branches checked out in another worktree are reported as `STUCK:` with their behind count and left untouched.
 Fetches blocked by an orphaned `.git/packed-refs.lock` use bounded retries and remove the lock only when the shared staleness proof can prove it abandoned; [configuration.md](configuration.md#toolchain) owns the recovery details and tuning knobs.
 Local-only projects, clones without an origin remote, and fetch failures remain benign skips.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -310,6 +310,8 @@ Bootstrap also reports a `TANGLE:` line when `FM_ROOT` is on a named non-default
 In a read-only session that did not get the fleet lock, the same line is advisory and omits the checkout command.
 The locked session-start deferred network stage runs bootstrap's best-effort project clone refresh through `fm-fleet-sync.sh`.
 It emits `FLEET_SYNC:` for skipped refreshes that may matter, recovered self-heals, and `STUCK:` alarms.
+An entry without its own `.git` directory or gitfile is reported as `skipped: not a git clone (no .git)` before any Git command, with the message also stating whether its name is registered in `data/projects.md`.
+A symlink under `projects/` remains eligible when its target is a clone with that `.git` entry.
 Normal completed runs keep local-only and no-origin skips silent.
 If bootstrap kills a timed-out refresh, it replays any completed `fm-fleet-sync.sh` output before the aggregate timeout skip so no finished result is lost.
 A killed refresh (or a teardown process kill) can leave an orphaned `.git/packed-refs.lock` in a clone, which makes the next refresh's fetch fail with Git's `Unable to create '...packed-refs.lock': File exists`.

--- a/tests/fm-fleet-sync.test.sh
+++ b/tests/fm-fleet-sync.test.sh
@@ -538,6 +538,28 @@ test_symlinked_clone_still_syncs() {
   pass "symlinked project clone keeps working"
 }
 
+test_linked_worktree_gitfile_still_syncs() {
+  local home source linked out line
+  home=$(new_home)
+  source=$(build_pair "$home" gitfile-source)
+  mv "$source" "$home/gitfile-source"
+  source="$home/gitfile-source"
+  git -C "$source" checkout --detach --quiet
+  linked="$home/projects/linked-gitfile"
+  git -C "$source" worktree add --quiet "$linked" main
+  [ -f "$linked/.git" ] || fail "fixture: linked worktree must have a .git file"
+  advance_origin "$home" gitfile-source C1
+
+  out=$(run_sync "$home")
+  line=$(printf '%s\n' "$out" | grep -E '^linked-gitfile:' || true)
+
+  assert_contains "$line" "linked-gitfile: synced" "linked worktree with .git file must sync"
+  assert_not_contains "$line" "not a git clone" "linked worktree must not be treated as non-git"
+  [ "$(head_sha "$linked")" = "$(git -C "$linked" rev-parse origin/main)" ] \
+    || fail "linked worktree was not fast-forwarded"
+  pass "linked worktree with a .git file keeps working"
+}
+
 test_whole_fleet_form() {
   local home behind current out
   home=$(new_home)
@@ -725,6 +747,7 @@ test_single_project_unresolvable_name_still_skips
 test_plain_nongit_dir_skips_without_parent_walkup
 test_plain_nongit_dir_registered_still_reports_skip
 test_symlinked_clone_still_syncs
+test_linked_worktree_gitfile_still_syncs
 test_whole_fleet_form
 test_bootstrap_relays_recovered_and_stuck
 test_orphaned_stale_packed_refs_lock_recovers

--- a/tests/fm-fleet-sync.test.sh
+++ b/tests/fm-fleet-sync.test.sh
@@ -21,6 +21,9 @@
 # worktree dir as its cwd also blocks removal (the clone-dir liveness check); a
 # transient lock that self-clears is retried without a force-remove; and any
 # non-packed-refs.lock fetch failure keeps today's behavior with no retry.
+#
+# Plain non-git directories under projects/ must skip before any git command so
+# discovery never walks into a parent checkout (the firstmate home itself).
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -434,6 +437,107 @@ test_single_project_unresolvable_name_still_skips() {
   pass "single-project form leaves a genuinely bad name unresolved"
 }
 
+# plant_parent_checkout <home>: make $home itself a dirty, origin-backed git
+# checkout on main (projects/ already exists and is preserved). Models the real
+# firstmate home so a plain projects/<name> without its own .git would otherwise
+# make git walk up and report the home as STUCK. Idempotent when home is already
+# that checkout (new_home reuses home-1 across tests in this suite).
+plant_parent_checkout() {
+  local home=$1 work remote remote_abs
+  work="$home/parent-work"
+  remote="$home/remotes/parent-home.git"
+  mkdir -p "$home/remotes"
+  if [ ! -e "$home/.git" ]; then
+    git init -q "$work"
+    git -C "$work" symbolic-ref HEAD refs/heads/main
+    commit_file "$work" home.txt v0 C0
+    git clone --quiet --bare "$work" "$remote"
+    remote_abs=$(cd "$remote" && pwd)
+    git -C "$work" remote add origin "file://$remote_abs"
+    git -C "$work" push -q -u origin main
+    # Init home in place so projects/ stays put.
+    git -C "$home" init -q
+    git -C "$home" symbolic-ref HEAD refs/heads/main
+    git -C "$home" remote add origin "file://$remote_abs"
+    git -C "$home" fetch -q origin
+    git -C "$home" checkout -q -B main origin/main
+    # Advance origin and leave home dirty so a walk-up false positive is STUCK.
+    commit_file "$work" home.txt v1 C1
+    git -C "$work" push -q origin main
+    printf 'dirty-home\n' > "$home/uncommitted.txt"
+  fi
+  git -C "$home" rev-parse --is-inside-work-tree >/dev/null
+}
+
+test_plain_nongit_dir_skips_without_parent_walkup() {
+  local home plain name out parent_head line
+  home=$(new_home)
+  plant_parent_checkout "$home"
+  parent_head=$(head_sha "$home")
+  name=nongit-plain
+  plain="$home/projects/$name"
+  mkdir -p "$plain"
+  # Sanity: git discovery from the plain dir WOULD see the parent checkout.
+  [ "$(git -C "$plain" rev-parse --show-toplevel 2>/dev/null)" = "$(git -C "$home" rev-parse --show-toplevel)" ] \
+    || fail "fixture: git -C on plain dir should discover the parent home checkout"
+
+  out=$(run_sync "$home")
+  line=$(printf '%s\n' "$out" | grep -E "^${name}:" || true)
+
+  assert_contains "$line" "${name}: skipped: not a git clone (no .git); not a registered project" \
+    "plain projects/ dir must skip as a non-clone"
+  assert_not_contains "$line" "STUCK" "plain projects/ dir must never be reported as STUCK"
+  # Without the .git gate, git would report the parent home as STUCK (dirty, behind).
+  assert_not_contains "$out" "${name}: STUCK" "plain dir must not emit a walk-up STUCK for the home"
+  [ "$(head_sha "$home")" = "$parent_head" ] || fail "parent home checkout was mutated by fleet-sync"
+  pass "plain non-git projects/ dir skips without git walk-up into the home"
+}
+
+test_plain_nongit_dir_registered_still_reports_skip() {
+  local home plain name out line
+  home=$(new_home)
+  plant_parent_checkout "$home"
+  name=nongit-registered
+  plain="$home/projects/$name"
+  mkdir -p "$plain"
+  mkdir -p "$home/data"
+  # Append so earlier local-only registry rows (iota) stay intact.
+  if [ -f "$home/data/projects.md" ]; then
+    printf -- '- %s [no-mistakes] - plain container (added 2026-08-09)\n' "$name" \
+      >> "$home/data/projects.md"
+  else
+    printf -- '- %s [no-mistakes] - plain container (added 2026-08-09)\n' "$name" \
+      > "$home/data/projects.md"
+  fi
+
+  out=$(run_sync "$home")
+  line=$(printf '%s\n' "$out" | grep -E "^${name}:" || true)
+
+  assert_contains "$line" "${name}: skipped: not a git clone (no .git); registered project" \
+    "registered name without .git must still report a skip (not silent)"
+  assert_not_contains "$line" "STUCK" "registered non-clone must not be STUCK"
+  pass "registered plain projects/ dir reports a non-silent skip"
+}
+
+test_symlinked_clone_still_syncs() {
+  local home real_clone link_name out line
+  home=$(new_home)
+  real_clone=$(build_pair "$home" link-real)
+  advance_origin "$home" link-real C1
+  # Relocate the clone out of projects/ and put a symlink back under the name
+  # the fleet sweep iterates (e.g. projects/mother-clucker -> real path).
+  link_name="$home/projects/mother-clucker"
+  mv "$real_clone" "$home/real-mother-clucker"
+  ln -s "$home/real-mother-clucker" "$link_name"
+
+  out=$(run_sync "$home")
+  line=$(printf '%s\n' "$out" | grep -E '^mother-clucker:' || true)
+
+  assert_contains "$line" "mother-clucker: synced" "symlinked clone under projects/ must still sync"
+  assert_not_contains "$line" "not a git clone" "symlinked clone must not be treated as non-git"
+  pass "symlinked project clone keeps working"
+}
+
 test_whole_fleet_form() {
   local home behind current out
   home=$(new_home)
@@ -618,6 +722,9 @@ test_single_project_by_bare_name_ignores_cwd_shadow
 test_single_project_by_projects_relative_name_resolves
 test_single_project_by_projects_relative_name_ignores_cwd_shadow
 test_single_project_unresolvable_name_still_skips
+test_plain_nongit_dir_skips_without_parent_walkup
+test_plain_nongit_dir_registered_still_reports_skip
+test_symlinked_clone_still_syncs
 test_whole_fleet_form
 test_bootstrap_relays_recovered_and_stuck
 test_orphaned_stale_packed_refs_lock_recovers


### PR DESCRIPTION
## Intent

Make fleet-sync skip non-git directories under projects/ so the clone sweep cannot walk git discovery up into the firstmate home checkout and emit a false STUCK diagnostic (reproduced with projects/worktrees as a plain container). Require each candidate to be a repo root via its own .git entry (dir or gitfile) before any git command; report a clear skip that notes whether the name is registered; keep symlinked clones working. Ship through no-mistakes so the PR satisfies the repo enforcement that rejects hand-opened PRs (prior hand-opened PR https://github.com/kunchenguid/firstmate/pull/2044 is red for that reason).

## What Changed

- Require fleet-sync candidates to have their own `.git` directory or gitfile before running Git, preventing parent-repository discovery and false `STUCK` diagnostics.
- Report skipped non-git directories with their project-registration status while preserving support for symlinked clones.
- Document the candidate checks and add regression coverage for registered and unregistered plain directories, parent-checkout isolation, and symlinked clones.

## Risk Assessment

✅ Low: The change is narrowly scoped, gates candidate-specific git commands behind an own .git entry, reports registry status, and preserves symlinked clones with focused regression coverage.

## Testing

The focused fleet-sync suite passed, and end-to-end CLI evidence confirmed correct registered/unregistered skips, no parent walk-up or false STUCK, unchanged parent HEAD, and successful symlinked and gitfile-backed clone syncing; however, PR #2044 at the target commit still fails the required no-mistakes provenance check, so the overall acceptance result is failed.

<details>
<summary>Evidence: End-to-end fleet-sync CLI transcript</summary>

```text
Scenario: a dirty, one-commit-behind firstmate home contains two plain project containers.
Git discovery from plain-unregistered before fleet-sync resolves to parent: /private/var/folders/vx/kq2w6_xj1sq82jh1gtsjl0_m0000gn/T/no-mistakes-evidence/01KZRPNDW4G4JE903TBN6ARA0R/fleet-sync-e2e-fixture.JcWqx1/firstmate-home

Fleet-sync user-visible output:
gitfile-worktree: synced 5e6e71a..7cccb98
plain-registered: skipped: not a git clone (no .git); registered project
plain-unregistered: skipped: not a git clone (no .git); not a registered project
symlinked-clone: synced 5e6e71a..df62852

Postconditions:
parent HEAD unchanged: yes
plain candidate emitted STUCK: no
symlinked clone reached origin/main: yes
linked worktree .git entry type: file
gitfile-backed worktree reached origin/main: yes
```
</details>
<details>
<summary>Evidence: Pre-git gate evidence</summary>

<code>Single-candidate output: plain-unregistered: skipped: not a git clone (no .git); not a registered project&#10;Git trace events whose argv mention the plain candidate path: 0</code>

```text
Single-candidate output: plain-unregistered: skipped: not a git clone (no .git); not a registered project
Git trace events whose argv mention the plain candidate path: 0
```
</details>
<details>
<summary>Evidence: Raw Git trace</summary>

```text
{"event":"version","sid":"20260811T153134.322827Z-Hc39e1fa7-P000101be","thread":"main","time":"2026-08-11T15:31:34.323341Z","file":"common-init.c","line":57,"evt":"4","exe":"2.50.1 (Apple Git-155)"}
{"event":"start","sid":"20260811T153134.322827Z-Hc39e1fa7-P000101be","thread":"main","time":"2026-08-11T15:31:34.323410Z","file":"common-init.c","line":58,"t_abs":0.001207,"argv":["/Applications/Xcode.app/Contents/Developer/usr/bin/git","-C","/Users/josephkim/.no-mistakes/worktrees/9ffe04aa3c01/01KZRPNDW4G4JE903TBN6ARA0R","rev-parse","--is-inside-work-tree"]}
{"event":"cmd_name","sid":"20260811T153134.322827Z-Hc39e1fa7-P000101be","thread":"main","time":"2026-08-11T15:31:34.323542Z","file":"git.c","line":477,"name":"rev-parse","hierarchy":"rev-parse"}
{"event":"def_repo","sid":"20260811T153134.322827Z-Hc39e1fa7-P000101be","thread":"main","time":"2026-08-11T15:31:34.324878Z","file":"repository.c","line":241,"repo":1,"worktree":"/Users/josephkim/.no-mistakes/worktrees/9ffe04aa3c01/01KZRPNDW4G4JE903TBN6ARA0R"}
{"event":"exit","sid":"20260811T153134.322827Z-Hc39e1fa7-P000101be","thread":"main","time":"2026-08-11T15:31:34.325435Z","file":"git.c","line":747,"t_abs":0.003234,"code":0}
{"event":"atexit","sid":"20260811T153134.322827Z-Hc39e1fa7-P000101be","thread":"main","time":"2026-08-11T15:31:34.325452Z","file":"trace2/tr2_tgt_event.c","line":207,"t_abs":0.003252,"code":0}
{"event":"version","sid":"20260811T153134.346645Z-Hc39e1fa7-P000101c8","thread":"main","time":"2026-08-11T15:31:34.347355Z","file":"common-init.c","line":57,"evt":"4","exe":"2.50.1 (Apple Git-155)"}
{"event":"start","sid":"20260811T153134.346645Z-Hc39e1fa7-P000101c8","thread":"main","time":"2026-08-11T15:31:34.347392Z","file":"common-init.c","line":58,"t_abs":0.001529,"argv":["/Applications/Xcode.app/Contents/Developer/usr/bin/git","-C","/Users/josephkim/.no-mistakes/worktrees/9ffe04aa3c01/01KZRPNDW4G4JE903TBN6ARA0R","symbolic-ref","--quiet","--short","HEAD"]}
{"event":"def_repo","sid":"20260811T153134.346645Z-Hc39e1fa7-P000101c8","thread":"main","time":"2026-08-11T15:31:34.348193Z","file":"repository.c","line":241,"repo":1,"worktree":"/Users/josephkim/.no-mistakes/worktrees/9ffe04aa3c01/01KZRPNDW4G4JE903TBN6ARA0R"}
{"event":"cmd_name","sid":"20260811T153134.346645Z-Hc39e1fa7-P000101c8","thread":"main","time":"2026-08-11T15:31:34.348812Z","file":"git.c","line":477,"name":"symbolic-ref","hierarchy":"symbolic-ref"}
{"event":"exit","sid":"20260811T153134.346645Z-Hc39e1fa7-P000101c8","thread":"main","time":"2026-08-11T15:31:34.350014Z","file":"git.c","line":747,"t_abs":0.004152,"code":1}
{"event":"atexit","sid":"20260811T153134.346645Z-Hc39e1fa7-P000101c8","thread":"main","time":"2026-08-11T15:31:34.350040Z","file":"trace2/tr2_tgt_event.c","line":207,"t_abs":0.004178,"code":1}
```
</details>
<details>
<summary>Evidence: Focused test results</summary>

```text
{
  "families": [
    {
      "count": 1,
      "duration_ms": 65762,
      "failed": 0,
      "name": "session-bootstrap"
    }
  ],
  "finished_at": "2026-08-11T15:29:20Z",
  "run_id": "fm-test-run-1786462095033-42013",
  "scripts": [
    {
      "duration_ms": 65762,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "session-bootstrap",
      "gate_skip": false,
      "path": "tests/fm-fleet-sync.test.sh"
    }
  ],
  "selection": "scripts",
  "started_at": "2026-08-11T15:28:15Z",
  "summary": {
    "duration_ms": 65833,
    "failed": 0,
    "skipped_gate": 0,
    "total": 1
  }
}
```
</details>
<details>
<summary>Evidence: PR 2044 delivery check</summary>

Source: [PR 2044 delivery check](https://github.com/kunchenguid/firstmate/pull/2044)

```text
PR checks: 12 passed, 1 failed. Failing check: `PR must be raised via no-mistakes`.
```
</details>
- Outcome: ⚠️ 1 error across 1 run (8m58s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 Target commit 8905284126968a0a284818e55e3783f975699d94 is still the head of hand-opened PR #2044, whose required `PR must be raised via no-mistakes` check fails. The behavioral change works, but the authoritative delivery requirement is not satisfied. This isolated worktree also lacks no-mistakes initialization, so I could not repair the PR provenance within this testing-only run.
- <code>`no-mistakes axi` - preflight reported that this isolated worktree is not initialized</code>
- `bin/fm-test-run.sh tests/fm-fleet-sync.test.sh --json /var/folders/vx/kq2w6_xj1sq82jh1gtsjl0_m0000gn/T/no-mistakes-evidence/01KZRPNDW4G4JE903TBN6ARA0R/fleet-sync-test-results.json`
- `Manual whole-fleet CLI sweep with a dirty, one-commit-behind parent checkout; registered and unregistered plain directories; a symlinked clone; and a gitfile-backed linked worktree`
- <code>`GIT_TRACE2_EVENT=... bin/fm-fleet-sync.sh &lt;plain-candidate&gt;` - verified zero Git trace events referenced the candidate before its skip</code>
- <code>`gh-axi pr checks 2044` and `git ls-remote origin refs/heads/fm/fm-fleet-sync-skip-nongit` - verified the target commit is on PR #2044 and its no-mistakes enforcement check fails</code>
- <code>`git status --short` - verified testing left the worktree clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
