### PR TITLE
fix(codex): route delegated agents through FirstMate

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -76,7 +76,7 @@ The exact hook files, commands, output-shaping quirks (Claude Code only honors t
 When changing any watcher-arm PreToolUse hook, validate the real harness behavior in a scratch project before trusting it, then update that doc.
 ## Primary delegation-shape guard
 
-Claude exposes built-in delegation, scheduling, and worktree tools that a primary session can use to create work with no `state/<id>.meta`, which makes the whole guard stack inert because every guard counts that metadata.
+Claude exposes built-in delegation, scheduling, and worktree tools, and Codex exposes built-in agent delegation; either primary session can create work with no `state/<id>.meta`, which makes the whole guard stack inert because every guard counts that metadata.
 The shipped mechanism is `bin/fm-subagent-pretool-check.sh`, a primary-home PreToolUse guard that denies a delegation-SHAPED tool name.
 Claude primaries should also use an untracked per-home local `permissions.deny` list as hardening for known Claude delegation tools, because it removes them from the model's schema so they are never offered.
 That deny list must not ship in tracked `.claude/settings.json` because it is Claude-only rather than harness-agnostic, and because tracked project settings propagate into linked worktrees where they disarm legitimate crewmates.

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-subagent-pretool-check.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.PreToolUse[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-subagent-pretool-check.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-subagent-pretool-check.sh\" --claude'",
+            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-subagent-pretool-check.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; \"$root/bin/fm-subagent-pretool-check.sh\" --validate-codex-hook-config \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-subagent-pretool-check.sh\" --claude'",
             "timeout": 10
           }
         ]

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -26,6 +26,16 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-subagent-pretool-check.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.PreToolUse[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-subagent-pretool-check.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-subagent-pretool-check.sh\" --claude'",
+            "timeout": 10
+          }
+        ]
       }
     ],
     "Stop": [

--- a/bin/fm-subagent-pretool-check.sh
+++ b/bin/fm-subagent-pretool-check.sh
@@ -17,10 +17,10 @@
 # That deny list must not be tracked: it is Claude-only rather than
 # harness-agnostic, and tracked project settings propagate into linked
 # worktrees where they disarm legitimate crewmates.
-# The tracked Claude matcher is deliberately `.*`: a stem-enumerating matcher
-# would reintroduce the fail-open-by-enumeration problem this guard exists to
-# solve, because any future tool name outside the matcher would never reach this
-# script.
+# The tracked Claude and Codex matchers are deliberately `.*`: a
+# stem-enumerating matcher would reintroduce the fail-open-by-enumeration
+# problem this guard exists to solve, because any future tool name outside the
+# matcher would never reach this script.
 # This script is therefore the single owner of classification.
 # It matches a delegation-SHAPED tool name rather than a fixed list, so a future
 # tool that ships before anyone updates a local deny list is still refused.

--- a/bin/fm-subagent-pretool-check.sh
+++ b/bin/fm-subagent-pretool-check.sh
@@ -63,7 +63,7 @@ DELEGATION_STEMS='agent subagent task workflow cron schedul worktree delegate sp
 # or end it. A local Claude deny list may still remove these from the
 # schema; this shipped guard deliberately stays narrower so it can never be the
 # reason a runaway task cannot be stopped.
-OBSERVE_ONLY_TOOLS='taskoutput taskstop taskget tasklist cronlist bashoutput killshell listagents waitagent interruptagent collaborationlistagents collaborationwaitagent collaborationinterruptagent'
+OBSERVE_ONLY_TOOLS='taskoutput taskstop taskget tasklist cronlist bashoutput killshell listagents waitagent interruptagent collaborationlistagents collaborationwaitagent collaborationinterruptagent multiagentv1waitagent multiagentv1closeagent'
 
 # Exact lowercase tool names that match a stem above but create no RUNNABLE
 # work. These write only the harness's session-local todo list, which has no

--- a/bin/fm-subagent-pretool-check.sh
+++ b/bin/fm-subagent-pretool-check.sh
@@ -44,7 +44,7 @@
 #   INERT - not a genuine primary home (a crewmate/scout task worktree or a
 #           non-firstmate repo): exit 0 with no output, exactly like ALLOW.
 #   ESCAPE - FM_ALLOW_SUBAGENT=1 in the environment allows deliberately.
-#   FAIL OPEN - malformed or empty stdin, or missing jq for stdin transport.
+#   FAIL OPEN - malformed or empty stdin, or an unavailable Node runtime.
 #
 # Claude requires stdout to remain empty on deny.
 # Codex blocks on exit 2 and displays stderr.
@@ -81,10 +81,31 @@ PLAN_ONLY_TOOLS='taskcreate taskupdate'
 TOOL=""
 TOOL_SET=0
 CLAUDE_MODE=0
+CODEX_HOOK_CONFIG=""
+
+validate_codex_hook_config() {
+  command -v node >/dev/null 2>&1 || return 1
+  node -e '
+    const fs = require("node:fs");
+    try {
+      const config = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+      const entries = config?.hooks?.PreToolUse;
+      const present = Array.isArray(entries) && entries.some((entry) =>
+        Array.isArray(entry?.hooks) && entry.hooks.some((hook) =>
+          typeof hook?.command === "string" && hook.command.includes("fm-subagent-pretool-check.sh")
+        )
+      );
+      process.exit(present ? 0 : 1);
+    } catch {
+      process.exit(1);
+    }
+  ' "$1"
+}
 
 usage() {
   cat <<'EOF'
 Usage: fm-subagent-pretool-check.sh [--tool <tool-name>] [--claude]
+       fm-subagent-pretool-check.sh --validate-codex-hook-config <path>
 
 With no --tool, reads a PreToolUse-style JSON payload on stdin (Claude/Codex
 tool_name, or Grok toolName).
@@ -121,6 +142,11 @@ while [ "$#" -gt 0 ]; do
       CLAUDE_MODE=1
       shift
       ;;
+    --validate-codex-hook-config)
+      [ "$#" -gt 1 ] || { echo "error: --validate-codex-hook-config requires a value" >&2; exit 2; }
+      CODEX_HOOK_CONFIG=$2
+      shift 2
+      ;;
     -h|--help)
       usage
       exit 0
@@ -133,11 +159,27 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
+if [ -n "$CODEX_HOOK_CONFIG" ]; then
+  validate_codex_hook_config "$CODEX_HOOK_CONFIG"
+  exit $?
+fi
+
 if [ "$TOOL_SET" -eq 0 ]; then
   PAYLOAD=$(cat 2>/dev/null || true)
   [ -n "$PAYLOAD" ] || exit 0
-  command -v jq >/dev/null 2>&1 || exit 0
-  TOOL=$(printf '%s' "$PAYLOAD" | jq -r '(.tool_name // .toolName // empty)' 2>/dev/null) || exit 0
+  command -v node >/dev/null 2>&1 || exit 0
+  TOOL=$(printf '%s' "$PAYLOAD" | node -e '
+    const fs = require("node:fs");
+    try {
+      const payload = JSON.parse(fs.readFileSync(0, "utf8"));
+      const tool = typeof payload?.tool_name === "string"
+        ? payload.tool_name
+        : typeof payload?.toolName === "string" ? payload.toolName : "";
+      process.stdout.write(tool);
+    } catch {
+      process.exit(1);
+    }
+  ' 2>/dev/null) || exit 0
 fi
 
 [ -n "$TOOL" ] || exit 0

--- a/bin/fm-subagent-pretool-check.sh
+++ b/bin/fm-subagent-pretool-check.sh
@@ -63,7 +63,7 @@ DELEGATION_STEMS='agent subagent task workflow cron schedul worktree delegate sp
 # or end it. A local Claude deny list may still remove these from the
 # schema; this shipped guard deliberately stays narrower so it can never be the
 # reason a runaway task cannot be stopped.
-OBSERVE_ONLY_TOOLS='taskoutput taskstop taskget tasklist cronlist bashoutput killshell'
+OBSERVE_ONLY_TOOLS='taskoutput taskstop taskget tasklist cronlist bashoutput killshell listagents waitagent interruptagent collaborationlistagents collaborationwaitagent collaborationinterruptagent'
 
 # Exact lowercase tool names that match a stem above but create no RUNNABLE
 # work. These write only the harness's session-local todo list, which has no

--- a/docs/subagent-guard.md
+++ b/docs/subagent-guard.md
@@ -38,7 +38,7 @@ It says nothing about whether the resulting brief, project, or delivery mode is 
 
 `bin/fm-subagent-pretool-check.sh` is the shipped layer.
 It classifies the tool NAME by shape rather than against a fixed list.
-The tracked Claude PreToolUse matcher is `.*`, so every Claude tool name reaches the script and the script is the single owner of classification.
+The tracked Claude and Codex PreToolUse matchers are `.*`, so every tool name from either harness reaches the script and the script is the single owner of classification.
 A stem-enumerating matcher would reintroduce the fail-open-by-enumeration problem this guard exists to solve, because any future tool name outside the matcher would be silently missed before the script could inspect it.
 A tool is delegation-shaped when its normalized lowercase name contains one of these stems:
 
@@ -181,45 +181,22 @@ Applicability turns on one question: does the harness expose built-in delegation
 | Harness | Delegation surface | Status |
 | --- | --- | --- |
 | Claude | 16 known tools, listed above | Scoped guard wired and live-verified; untracked local deny list verified and recommended. |
-| Codex | none | Not applicable, verified empirically below. Codex 0.144.1 exposes no subagent, sub-task, or delegated-agent tool, so there is nothing to remove or intercept. `.codex/hooks.json` is unchanged. |
+| Codex | `collaboration.spawn_agent`, delivered to hooks as `collaborationspawn_agent` | Scoped match-all guard wired and live-verified on Codex 0.147.0. |
 | Grok | present, exact tokens unconfirmed | Not wired pending live verification. See below. |
 | OpenCode | present, exact tokens unconfirmed | Not wired pending live verification. See below. |
 | Pi | none reported | Not wired pending live verification. See below. |
 
-### Codex, verified not applicable
+### Codex
 
-Codex 0.144.1 was asked to enumerate its own tools in a scratch git repo on 2026-07-22.
+Codex 0.147.0 exposes `collaboration.spawn_agent` to a primary session and delivers its call to the real project `PreToolUse` hook as `tool_name: "collaborationspawn_agent"`.
+The existing classifier needs no Codex-specific exception because normalization preserves that token and the established `agent` and `spawn` stems both classify it as delegation-shaped.
+The tracked `.codex/hooks.json` keeps the watcher-arm and directory-change checkers on their existing `Bash`-only entry and adds a separate `.*` entry for `bin/fm-subagent-pretool-check.sh`.
+That separation lets the delegation checker see current normalized `spawn_agent` spellings and future delegation-shaped names without widening either Bash checker.
 
-```sh
-codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check \
-  "List the exact names of every tool available to you in this session, one per line, nothing else. Then state on a final line whether you have any tool that spawns a subagent, sub-task, or delegated agent: answer SUBAGENT_TOOL=yes or SUBAGENT_TOOL=no."
-```
-
-Exact reported tool set and verdict:
-
-```text
-web.run
-functions.exec_command
-functions.write_stdin
-functions.list_mcp_resources
-functions.list_mcp_resource_templates
-functions.read_mcp_resource
-functions.update_plan
-functions.request_user_input
-functions.request_plugin_install
-functions.view_image
-functions.get_goal
-functions.create_goal
-functions.update_goal
-functions.apply_patch
-image_gen.imagegen
-tool_search.tool_search_tool
-multi_tool_use.parallel
-SUBAGENT_TOOL=no
-```
-
-`multi_tool_use.parallel` batches calls to the tools above; it does not spawn an agent.
-Codex is therefore not applicable today, and this table row is the tripwire: if a future Codex release adds a delegated-agent tool, wire `.codex/hooks.json` the same way its `Bash` PreToolUse entries already forward stdin to a checker.
+The Codex project hook is the enforceable boundary.
+On 0.147.0 the CLI collaboration call reached that boundary and was refused with the route to `bin/fm-brief.sh` and `bin/fm-spawn.sh`; it did not bypass local hooks.
+A collaboration implementation executed outside Codex's project-hook lifecycle would remain outside this mechanism, so the guarantee is deliberately limited to delegation calls that the supported Codex `PreToolUse` surface can observe.
+The dated payload and live-deny evidence is recorded in [`verification/supervision.md`](verification/supervision.md#codex-delegated-agent-pretooluse).
 
 ### Grok, OpenCode, and Pi, inspected but not wired
 
@@ -233,7 +210,7 @@ The integration surface of each was inspected and each is structurally wireable 
 - Pi's tracked extension gates on `event.toolName !== "bash"` inside `pi.on("tool_call", ...)` and blocks by returning `{block: true}`.
   The same change applies. A parallel evaluation reports that Pi exposes no delegation tool at all, which would make it not applicable, but that was not verified here.
 
-None of the three is wired in this change because none of the three binaries is installed on the host where this work was done, so the exact tool-name tokens could not be confirmed and the wiring could not be validated against the real harness.
+None of the three is wired because the exact tool-name tokens have not been confirmed and the wiring has not been validated against the real harness.
 This repo's rule in the `firstmate-coding-guidelines` skill is that a harness hook must be validated in a scratch project before it is trusted, and `arm-pretool-check.md` records the concrete cost of guessing: a Grok hook whose `command` string is even slightly wrong fails to launch the hook at all.
 Wiring an unvalidated matcher would trade a known gap for an unknown breakage.
 
@@ -353,7 +330,8 @@ The live consequence is confirmed by the shipped-guard result above: Claude hono
 ## Automated validation
 
 `tests/fm-subagent-pretool-check.test.sh` owns the acceptance matrix and is registered in the `pure-contract-unit` family in `bin/fm-test-run.sh`.
-It covers the tracked Claude settings boundary that forbids a `permissions` key; the match-all Claude hook registration; denial of every work-creating delegation tool by shape; denial of twelve hypothetical future tool names that appear on no list; the observe-or-stop, plan-only, and MCP exclusions; the exactness of the plan-only exclusion against six near-miss names a substring or shorter-stem widening would release; the scout-present and scout-absent message variants; the escape hatch including its fail-closed values; inertness in a linked task worktree and in a non-firstmate repo; in-scope enforcement for a marked secondmate home; both stdin transports; the empty-stdout requirement; fail-open transport behavior; and the preserved `Bash` seatbelts and `Stop` guard.
+It covers the tracked Claude settings boundary that forbids a `permissions` key; the match-all Claude and Codex hook registrations; denial of every work-creating delegation tool by shape; denial of twelve hypothetical future tool names that appear on no list; the observe-or-stop, plan-only, and MCP exclusions; the exactness of the plan-only exclusion against six near-miss names a substring or shorter-stem widening would release; the scout-present and scout-absent message variants; the escape hatch including its fail-closed values; inertness in a linked task worktree and in a non-firstmate repo; in-scope enforcement for a marked secondmate home; both stdin transports; the empty-stdout requirement; fail-open transport behavior; and the preserved `Bash` seatbelts and `Stop` guard.
+Its Codex hook runner executes the commands selected by the tracked matcher against a FirstMate-shaped primary and linked worktree, proving the current `collaborationspawn_agent` token and normalized `spawn_agent` spelling are denied only in the primary while safe Bash stays allowed.
 
 Run:
 
@@ -377,5 +355,5 @@ Without an independent Relay need, unaccounted primary work therefore reads as i
 
 The durable fix for that class is to make the guards treat "the primary is doing project-shaped work with zero `state/*.meta` files" as a suspicious state rather than an idle one.
 That would catch this class on any harness, including work created through `Bash`.
-This change fences only the Claude tool surface.
+This mechanism fences the Claude tool surface and the Codex delegation calls observable through project `PreToolUse`.
 That is a separate change to `bin/fm-supervision-lib.sh` and `bin/fm-turnend-guard.sh` and is out of scope here.

--- a/docs/subagent-guard.md
+++ b/docs/subagent-guard.md
@@ -51,8 +51,9 @@ Three exclusions keep the shape test from producing false positives.
 
 - A name beginning `mcp__` is never classified.
   An MCP server chooses its own tool names, a task or agent noun there is common, and it has no bearing on fleet dispatch.
-- `OBSERVE_ONLY_TOOLS`: the exact names `taskoutput`, `taskstop`, `taskget`, `tasklist`, `cronlist`, `bashoutput`, and `killshell` are allowed.
+- `OBSERVE_ONLY_TOOLS`: the exact names `taskoutput`, `taskstop`, `taskget`, `tasklist`, `cronlist`, `bashoutput`, `killshell`, `listagents`, `waitagent`, `interruptagent`, `collaborationlistagents`, `collaborationwaitagent`, and `collaborationinterruptagent` are allowed.
   These observe or stop work that already exists rather than creating it, and denying them at this layer could strand already-running work with no way to inspect or end it.
+  The bare and `collaboration`-prefixed variants cover Codex's direct tool spellings and the namespace-normalized spellings delivered to project hooks.
   A Claude primary's optional local deny list may still remove them from the schema.
   The shipped guard stays narrower on purpose so it can never be the reason a runaway task cannot be stopped.
 - `PLAN_ONLY_TOOLS`: the exact names `taskcreate` and `taskupdate` are allowed.
@@ -331,7 +332,7 @@ The live consequence is confirmed by the shipped-guard result above: Claude hono
 
 `tests/fm-subagent-pretool-check.test.sh` owns the acceptance matrix and is registered in the `pure-contract-unit` family in `bin/fm-test-run.sh`.
 It covers the tracked Claude settings boundary that forbids a `permissions` key; the match-all Claude and Codex hook registrations; denial of every work-creating delegation tool by shape; denial of twelve hypothetical future tool names that appear on no list; the observe-or-stop, plan-only, and MCP exclusions; the exactness of the plan-only exclusion against six near-miss names a substring or shorter-stem widening would release; the scout-present and scout-absent message variants; the escape hatch including its fail-closed values; inertness in a linked task worktree and in a non-firstmate repo; in-scope enforcement for a marked secondmate home; both stdin transports; the empty-stdout requirement; fail-open transport behavior; and the preserved `Bash` seatbelts and `Stop` guard.
-Its Codex hook runner executes the commands selected by the tracked matcher against a FirstMate-shaped primary and linked worktree, proving the current `collaborationspawn_agent` token and normalized `spawn_agent` spelling are denied only in the primary while safe Bash stays allowed.
+Its Codex hook runner executes the commands selected by the tracked matcher against a FirstMate-shaped primary and linked worktree, proving the current `collaborationspawn_agent` token and normalized `spawn_agent` spelling are denied only in the primary while exact `list_agents`, `wait_agent`, and `interrupt_agent` controls and safe Bash stay allowed.
 
 Run:
 

--- a/docs/subagent-guard.md
+++ b/docs/subagent-guard.md
@@ -51,9 +51,10 @@ Three exclusions keep the shape test from producing false positives.
 
 - A name beginning `mcp__` is never classified.
   An MCP server chooses its own tool names, a task or agent noun there is common, and it has no bearing on fleet dispatch.
-- `OBSERVE_ONLY_TOOLS`: the exact names `taskoutput`, `taskstop`, `taskget`, `tasklist`, `cronlist`, `bashoutput`, `killshell`, `listagents`, `waitagent`, `interruptagent`, `collaborationlistagents`, `collaborationwaitagent`, and `collaborationinterruptagent` are allowed.
+- `OBSERVE_ONLY_TOOLS`: the exact names `taskoutput`, `taskstop`, `taskget`, `tasklist`, `cronlist`, `bashoutput`, `killshell`, `listagents`, `waitagent`, `interruptagent`, `collaborationlistagents`, `collaborationwaitagent`, `collaborationinterruptagent`, `multiagentv1waitagent`, and `multiagentv1closeagent` are allowed.
   These observe or stop work that already exists rather than creating it, and denying them at this layer could strand already-running work with no way to inspect or end it.
   The bare and `collaboration`-prefixed variants cover Codex's direct tool spellings and the namespace-normalized spellings delivered to project hooks.
+  The `multiagentv1` variants cover Codex 0.147.0's V1 namespaced wait and close controls.
   A Claude primary's optional local deny list may still remove them from the schema.
   The shipped guard stays narrower on purpose so it can never be the reason a runaway task cannot be stopped.
 - `PLAN_ONLY_TOOLS`: the exact names `taskcreate` and `taskupdate` are allowed.
@@ -182,7 +183,7 @@ Applicability turns on one question: does the harness expose built-in delegation
 | Harness | Delegation surface | Status |
 | --- | --- | --- |
 | Claude | 16 known tools, listed above | Scoped guard wired and live-verified; untracked local deny list verified and recommended. |
-| Codex | `collaboration.spawn_agent`, delivered to hooks as `collaborationspawn_agent` | Scoped match-all guard wired and live-verified on Codex 0.147.0. |
+| Codex | `collaboration.spawn_agent`, delivered to hooks as `collaborationspawn_agent`; V1 `multi_agent_v1.spawn_agent`, serialized as `multi_agent_v1spawn_agent` | Scoped match-all guard wired; the V2 call was live-verified and the V1 serialization is behavior-covered on Codex 0.147.0. |
 | Grok | present, exact tokens unconfirmed | Not wired pending live verification. See below. |
 | OpenCode | present, exact tokens unconfirmed | Not wired pending live verification. See below. |
 | Pi | none reported | Not wired pending live verification. See below. |
@@ -332,7 +333,7 @@ The live consequence is confirmed by the shipped-guard result above: Claude hono
 
 `tests/fm-subagent-pretool-check.test.sh` owns the acceptance matrix and is registered in the `pure-contract-unit` family in `bin/fm-test-run.sh`.
 It covers the tracked Claude settings boundary that forbids a `permissions` key; the match-all Claude and Codex hook registrations; denial of every work-creating delegation tool by shape; denial of twelve hypothetical future tool names that appear on no list; the observe-or-stop, plan-only, and MCP exclusions; the exactness of the plan-only exclusion against six near-miss names a substring or shorter-stem widening would release; the scout-present and scout-absent message variants; the escape hatch including its fail-closed values; inertness in a linked task worktree and in a non-firstmate repo; in-scope enforcement for a marked secondmate home; both stdin transports; the empty-stdout requirement; fail-open transport behavior; and the preserved `Bash` seatbelts and `Stop` guard.
-Its Codex hook runner executes the commands selected by the tracked matcher against a FirstMate-shaped primary and linked worktree, proving the current `collaborationspawn_agent` token and normalized `spawn_agent` spelling are denied only in the primary while exact `list_agents`, `wait_agent`, and `interrupt_agent` controls and safe Bash stay allowed.
+Its Codex hook runner executes the commands selected by the tracked matcher against a FirstMate-shaped primary and linked worktree, proving the current `collaborationspawn_agent`, normalized `spawn_agent`, and V1 `multi_agent_v1spawn_agent` spellings are denied only in the primary while exact V2 list, wait, and interrupt controls, V1 wait and close controls, and safe Bash stay allowed.
 
 Run:
 

--- a/docs/subagent-guard.md
+++ b/docs/subagent-guard.md
@@ -169,7 +169,7 @@ A tool removed from the schema stays removed, so a genuinely intended use of a l
 - Default deny mode also writes `{"decision":"deny","reason":"[subagent-dispatch] ..."}` to stdout for Grok.
 - `--claude` suppresses stdout completely, because Claude Code ignores a PreToolUse deny when stdout is nonempty.
   This is the same verified quirk recorded in [`arm-pretool-check.md`](arm-pretool-check.md), and the tracked Claude hook therefore passes `--claude`.
-- Malformed or empty stdin, invalid JSON, a payload with no tool name, and missing `jq` for stdin transport all fail open with exit 0 and no output.
+- Malformed or empty stdin, invalid JSON, a payload with no tool name, and an unavailable universal Node runtime all fail open with exit 0 and no output.
 
 The deny message names the real dispatch path.
 When `bin/fm-scout.sh` exists in the home the message first defers to the `AGENTS.md` intake classification, then routes work already classified as a scout there and authorized ship work with its bounded research to `bin/fm-brief.sh` then `bin/fm-spawn.sh`.
@@ -194,6 +194,7 @@ Codex 0.147.0 exposes `collaboration.spawn_agent` to a primary session and deliv
 The existing classifier needs no Codex-specific exception because normalization preserves that token and the established `agent` and `spawn` stems both classify it as delegation-shaped.
 The tracked `.codex/hooks.json` keeps the watcher-arm and directory-change checkers on their existing `Bash`-only entry and adds a separate `.*` entry for `bin/fm-subagent-pretool-check.sh`.
 That separation lets the delegation checker see current normalized `spawn_agent` spellings and future delegation-shaped names without widening either Bash checker.
+The delegation entry uses the universal Node runtime for its registration validation and payload extraction, so it does not depend on optional `jq` in a default tmux home.
 
 The Codex project hook is the enforceable boundary.
 On 0.147.0 the CLI collaboration call reached that boundary and was refused with the route to `bin/fm-brief.sh` and `bin/fm-spawn.sh`; it did not bypass local hooks.
@@ -332,7 +333,7 @@ The live consequence is confirmed by the shipped-guard result above: Claude hono
 ## Automated validation
 
 `tests/fm-subagent-pretool-check.test.sh` owns the acceptance matrix and is registered in the `pure-contract-unit` family in `bin/fm-test-run.sh`.
-It covers the tracked Claude settings boundary that forbids a `permissions` key; the match-all Claude and Codex hook registrations; denial of every work-creating delegation tool by shape; denial of twelve hypothetical future tool names that appear on no list; the observe-or-stop, plan-only, and MCP exclusions; the exactness of the plan-only exclusion against six near-miss names a substring or shorter-stem widening would release; the scout-present and scout-absent message variants; the escape hatch including its fail-closed values; inertness in a linked task worktree and in a non-firstmate repo; in-scope enforcement for a marked secondmate home; both stdin transports; the empty-stdout requirement; fail-open transport behavior; and the preserved `Bash` seatbelts and `Stop` guard.
+It covers the tracked Claude settings boundary that forbids a `permissions` key; the match-all Claude and Codex hook registrations; denial of every work-creating delegation tool by shape; denial of twelve hypothetical future tool names that appear on no list; the observe-or-stop, plan-only, and MCP exclusions; the exactness of the plan-only exclusion against six near-miss names a substring or shorter-stem widening would release; the scout-present and scout-absent message variants; the escape hatch including its fail-closed values; inertness in a linked task worktree and in a non-firstmate repo; in-scope enforcement for a marked secondmate home; both stdin transports; the empty-stdout requirement; jq-free Codex hook and checker enforcement; fail-open malformed transport behavior; and the preserved `Bash` seatbelts and `Stop` guard.
 Its Codex hook runner executes the commands selected by the tracked matcher against a FirstMate-shaped primary and linked worktree, proving the current `collaborationspawn_agent`, normalized `spawn_agent`, and V1 `multi_agent_v1spawn_agent` spellings are denied only in the primary while exact V2 list, wait, and interrupt controls, V1 wait and close controls, and safe Bash stay allowed.
 
 Run:

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -95,7 +95,7 @@ The portable regression runs the commands selected by the tracked Codex matchers
 tests/fm-subagent-pretool-check.test.sh
 ```
 
-Observed result: the real hook/checker interface denied `collaborationspawn_agent`, `spawn_agent`, and V1 `multi_agent_v1spawn_agent` in a genuine FirstMate primary, allowed the exact bare and namespace-normalized `list_agents`, `wait_agent`, and `interrupt_agent` controls plus V1 `multi_agent_v1wait_agent` and `multi_agent_v1close_agent`, denied delegation-shaped near misses of those controls, allowed `collaborationspawn_agent` in a linked worker worktree, and left safe Bash allowed through all matching hooks.
+Observed result: the real hook/checker interface denied `collaborationspawn_agent`, `spawn_agent`, and V1 `multi_agent_v1spawn_agent` in a genuine FirstMate primary, still denied `collaborationspawn_agent` with `jq` unavailable, allowed the exact bare and namespace-normalized `list_agents`, `wait_agent`, and `interrupt_agent` controls plus V1 `multi_agent_v1wait_agent` and `multi_agent_v1close_agent`, denied delegation-shaped near misses of those controls, allowed `collaborationspawn_agent` in a linked worker worktree, and left safe Bash allowed through all matching hooks.
 
 ### Run-tier source vocabulary and context-reset injection
 

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -95,7 +95,7 @@ The portable regression runs the commands selected by the tracked Codex matchers
 tests/fm-subagent-pretool-check.test.sh
 ```
 
-Observed result: the real hook/checker interface denied both `collaborationspawn_agent` and `spawn_agent` in a genuine FirstMate primary, allowed the exact bare and namespace-normalized `list_agents`, `wait_agent`, and `interrupt_agent` controls, denied delegation-shaped near misses of those controls, allowed `collaborationspawn_agent` in a linked worker worktree, and left safe Bash allowed through all matching hooks.
+Observed result: the real hook/checker interface denied `collaborationspawn_agent`, `spawn_agent`, and V1 `multi_agent_v1spawn_agent` in a genuine FirstMate primary, allowed the exact bare and namespace-normalized `list_agents`, `wait_agent`, and `interrupt_agent` controls plus V1 `multi_agent_v1wait_agent` and `multi_agent_v1close_agent`, denied delegation-shaped near misses of those controls, allowed `collaborationspawn_agent` in a linked worker worktree, and left safe Bash allowed through all matching hooks.
 
 ### Run-tier source vocabulary and context-reset injection
 

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -95,7 +95,7 @@ The portable regression runs the commands selected by the tracked Codex matchers
 tests/fm-subagent-pretool-check.test.sh
 ```
 
-Observed result: the real hook/checker interface denied both `collaborationspawn_agent` and `spawn_agent` in a genuine FirstMate primary, allowed `collaborationspawn_agent` in a linked worker worktree, and left safe Bash allowed through all matching hooks.
+Observed result: the real hook/checker interface denied both `collaborationspawn_agent` and `spawn_agent` in a genuine FirstMate primary, allowed the exact bare and namespace-normalized `list_agents`, `wait_agent`, and `interrupt_agent` controls, denied delegation-shaped near misses of those controls, allowed `collaborationspawn_agent` in a linked worker worktree, and left safe Bash allowed through all matching hooks.
 
 ### Run-tier source vocabulary and context-reset injection
 

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -48,6 +48,55 @@ The earlier `sendUserMessage` counterfactual raced the positional prompt; the cu
 The installed pi-signed 0.82.0 wrapper repeated the Pi primary extension and session-start path on 2026-07-27.
 [`runtime-backends.md`](runtime-backends.md#tmux) owns the shared-ancestry evidence and authoritative selection-marker boundary.
 
+## Codex delegated-agent PreToolUse
+
+The Codex delegation payload and guard path were verified on 2026-08-09 with `codex-cli 0.147.0` in a throwaway FirstMate-shaped git project.
+The first run used a match-all `PreToolUse` recorder and this prompt:
+
+```sh
+codex exec --dangerously-bypass-approvals-and-sandbox \
+  --dangerously-bypass-hook-trust --skip-git-repo-check \
+  'Call collaboration.spawn_agent exactly once with task_name probe and a tiny message. Do not use any shell command or any other tool. Then report whether the call succeeded.'
+```
+
+The tool succeeded in the recorder control and the hook received this structural payload:
+
+```json
+{
+  "hook_event_name": "PreToolUse",
+  "tool_name": "collaborationspawn_agent",
+  "tool_input": {
+    "task_name": "probe",
+    "fork_turns": "all"
+  }
+}
+```
+
+The payload's opaque message value and per-run identifiers are omitted because they do not participate in classification.
+The load-bearing fact is that Codex normalizes `collaboration.spawn_agent` to `collaborationspawn_agent` before the project hook sees it.
+
+The recorder was then replaced with the tracked `.codex/hooks.json`, `bin/fm-subagent-pretool-check.sh`, and `bin/fm-primary-scope-lib.sh` from this change, and the same command was repeated with `task_name blocked_probe`.
+Relevant output, with the long deny JSON body elided:
+
+```text
+hook: PreToolUse
+error=Tool call blocked by PreToolUse hook: ...
+(blocked tool: collaborationspawn_agent, delegation-shaped on "agent")
+hook: PreToolUse Blocked
+The call did not succeed. A `PreToolUse` hook denied it, requiring delegation through the project's fleet workflow instead.
+```
+
+This proves Codex 0.147.0's CLI collaboration surface reaches the project hook and honors its exit-2 deny.
+It does not prove interception for a future host or service that executes collaboration outside Codex's project-hook lifecycle; [`../subagent-guard.md`](../subagent-guard.md#codex) owns that current boundary.
+
+The portable regression runs the commands selected by the tracked Codex matchers rather than inspecting source bytes:
+
+```sh
+tests/fm-subagent-pretool-check.test.sh
+```
+
+Observed result: the real hook/checker interface denied both `collaborationspawn_agent` and `spawn_agent` in a genuine FirstMate primary, allowed `collaborationspawn_agent` in a linked worker worktree, and left safe Bash allowed through all matching hooks.
+
 ### Run-tier source vocabulary and context-reset injection
 
 The run tier depends on three facts only the vendor can supply: the session-open source it reports, whether hook stdout reaches model context on a context-RESET open rather than only a cold one, and whether a worker the hook detaches survives the hook returning.

--- a/tests/fm-subagent-pretool-check.test.sh
+++ b/tests/fm-subagent-pretool-check.test.sh
@@ -77,7 +77,7 @@ expect_deny() {
 }
 
 run_codex_pretool_hooks() {
-  local dir=$1 tool=$2 submitted_command=${3:-} payload command hook_rc=0 overall_rc=0 matched=0
+  local dir=$1 tool=$2 submitted_command=${3:-} hook_bash_env=${4:-} payload command hook_rc=0 overall_rc=0 matched=0
   payload=$(jq -nc --arg tool "$tool" --arg command "$submitted_command" \
     '{hook_event_name:"PreToolUse",tool_name:$tool,tool_input:{command:$command}}') \
     || fail "could not build Codex PreToolUse fixture payload"
@@ -87,7 +87,11 @@ run_codex_pretool_hooks() {
     [ -n "$command" ] || continue
     matched=$((matched + 1))
     hook_rc=0
-    printf '%s' "$payload" | (cd "$dir" && bash -c "$command") >> "$OUT" 2>> "$ERR" || hook_rc=$?
+    if [ -n "$hook_bash_env" ]; then
+      printf '%s' "$payload" | (cd "$dir" && env BASH_ENV="$hook_bash_env" bash -c "$command") >> "$OUT" 2>> "$ERR" || hook_rc=$?
+    else
+      printf '%s' "$payload" | (cd "$dir" && bash -c "$command") >> "$OUT" 2>> "$ERR" || hook_rc=$?
+    fi
     case "$hook_rc" in
       0) ;;
       2) overall_rc=2 ;;
@@ -308,25 +312,26 @@ test_malformed_transport_fails_open() {
   pass "malformed, empty, and tool-name-less payloads fail open rather than blocking every tool call"
 }
 
-test_missing_jq_stdin_transport_fails_open() {
-  local fakebin="$TMP_ROOT/no-jq-bin" bash_bin cat_bin rc=0
-  bash_bin=$(command -v bash) || fail "test needs bash to simulate the hook shebang"
-  cat_bin=$(command -v cat) || fail "test needs cat to feed stdin without jq"
+test_node_stdin_transport_does_not_require_jq() {
+  local fakebin="$TMP_ROOT/no-jq-bin" tool tool_bin rc=0
   mkdir -p "$fakebin"
-  ln -sf "$bash_bin" "$fakebin/bash"
-  ln -sf "$cat_bin" "$fakebin/cat"
+  for tool in bash cat node tr dirname git sed; do
+    tool_bin=$(command -v "$tool") || fail "test needs $tool for the jq-free stdin path"
+    ln -sf "$tool_bin" "$fakebin/$tool"
+  done
   : > "$OUT"; : > "$ERR"
   printf '%s' '{"tool_name":"Agent"}' \
     | env PATH="$fakebin" FM_ROOT_OVERRIDE="$PRIMARY" FM_HOME="$PRIMARY" FM_STATE_OVERRIDE="$STATE" \
       "$CHECK" --claude > "$OUT" 2> "$ERR" || rc=$?
-  [ "$rc" -eq 0 ] || fail "missing jq transport must fail open, got exit $rc: $(cat "$ERR")"
-  [ ! -s "$OUT" ] || fail "missing jq fail-open path wrote stdout: $(cat "$OUT")"
-  [ ! -s "$ERR" ] || fail "missing jq fail-open path wrote stderr: $(cat "$ERR")"
-  pass "missing jq for stdin transport fails open rather than denying every tool call"
+  [ "$rc" -eq 2 ] || fail "Node stdin transport must deny without jq, got exit $rc: $(cat "$ERR")"
+  [ ! -s "$OUT" ] || fail "jq-free Node stdin deny wrote stdout: $(cat "$OUT")"
+  jq -e '.hookSpecificOutput.permissionDecision == "deny"' "$ERR" >/dev/null 2>&1 \
+    || fail "jq-free Node stdin deny lost its permission decision: $(cat "$ERR")"
+  pass "the Node stdin transport denies delegation without jq"
 }
 
 test_codex_real_hook_surface_routes_delegation_and_preserves_scope() {
-  local tool child="$TMP_ROOT/codex-child" rc=0
+  local tool child="$TMP_ROOT/codex-child" no_jq_env="$TMP_ROOT/no-jq.bash" no_jq_loaded="$TMP_ROOT/no-jq.loaded" no_jq_called="$TMP_ROOT/no-jq.called" rc=0
   setup_codex_hook_fixture
 
   for tool in collaborationspawn_agent spawn_agent multi_agent_v1spawn_agent; do
@@ -338,6 +343,29 @@ test_codex_real_hook_surface_routes_delegation_and_preserves_scope() {
       "$ERR" >/dev/null 2>&1 \
       || fail "Codex primary deny for $tool lost the route-to-FirstMate decision: $(cat "$ERR")"
   done
+
+  cat > "$no_jq_env" <<'SH'
+printf 'loaded\n' >> "${FM_TEST_NO_JQ_LOADED:?}"
+command() {
+  if [ "${1:-}" = -v ] && [ "${2:-}" = jq ]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+jq() {
+  printf 'called\n' >> "${FM_TEST_NO_JQ_CALLED:?}"
+  return 127
+}
+SH
+  export FM_TEST_NO_JQ_LOADED="$no_jq_loaded" FM_TEST_NO_JQ_CALLED="$no_jq_called"
+  rc=0
+  run_codex_pretool_hooks "$CODEX_PRIMARY" collaborationspawn_agent '' "$no_jq_env" || rc=$?
+  unset FM_TEST_NO_JQ_LOADED FM_TEST_NO_JQ_CALLED
+  [ -s "$no_jq_loaded" ] || fail "jq-free Codex hook fixture did not load its dependency mask"
+  [ ! -e "$no_jq_called" ] || fail "jq-free Codex delegation hook still invoked jq"
+  [ "$rc" -eq 2 ] || fail "Codex delegation hook must deny without jq, got exit $rc: $(cat "$ERR")"
+  jq -e '.hookSpecificOutput.permissionDecision == "deny"' "$ERR" >/dev/null 2>&1 \
+    || fail "jq-free Codex hook deny lost its permission decision: $(cat "$ERR")"
 
   for tool in $CODEX_OBSERVE_ONLY_TOOLS; do
     rc=0
@@ -378,5 +406,5 @@ test_task_worktree_and_non_firstmate_repo_are_inert
 test_secondmate_home_is_in_scope
 test_stdin_transports_and_output_shapes
 test_malformed_transport_fails_open
-test_missing_jq_stdin_transport_fails_open
+test_node_stdin_transport_does_not_require_jq
 test_codex_real_hook_surface_routes_delegation_and_preserves_scope

--- a/tests/fm-subagent-pretool-check.test.sh
+++ b/tests/fm-subagent-pretool-check.test.sh
@@ -42,6 +42,10 @@ PLAN_ONLY_TOOLS='TaskCreate TaskUpdate'
 # assumed.
 PLAN_ONLY_NEAR_MISSES='TaskCreateAgent TaskCreateWorktree TaskUpdateAgent RemoteTaskCreate Task TaskCreator'
 
+CODEX_OBSERVE_ONLY_TOOLS='collaborationlist_agents collaborationwait_agent collaborationinterrupt_agent list_agents wait_agent interrupt_agent'
+
+CODEX_OBSERVE_NEAR_MISSES='collaborationlist_agents_spawn collaborationwait_agent_task collaborationinterrupt_agent_worktree'
+
 run_tool() {
   local tool=$1 rc=0
   shift
@@ -335,6 +339,19 @@ test_codex_real_hook_surface_routes_delegation_and_preserves_scope() {
       || fail "Codex primary deny for $tool lost the route-to-FirstMate decision: $(cat "$ERR")"
   done
 
+  for tool in $CODEX_OBSERVE_ONLY_TOOLS; do
+    rc=0
+    run_codex_pretool_hooks "$CODEX_PRIMARY" "$tool" || rc=$?
+    [ "$rc" -eq 0 ] || fail "Codex observe-or-stop control $tool must remain allowed, got exit $rc: $(cat "$ERR")"
+    [ ! -s "$OUT" ] && [ ! -s "$ERR" ] || fail "Codex observe-or-stop control $tool wrote output"
+  done
+
+  for tool in $CODEX_OBSERVE_NEAR_MISSES; do
+    rc=0
+    run_codex_pretool_hooks "$CODEX_PRIMARY" "$tool" || rc=$?
+    [ "$rc" -eq 2 ] || fail "Codex observe-or-stop near miss $tool must remain denied, got exit $rc"
+  done
+
   git -C "$CODEX_PRIMARY" worktree add -q -b fixture-codex-child "$child"
   mkdir -p "$child/state"
   rc=0
@@ -346,7 +363,7 @@ test_codex_real_hook_surface_routes_delegation_and_preserves_scope() {
   run_codex_pretool_hooks "$CODEX_PRIMARY" Bash 'printf safe' || rc=$?
   [ "$rc" -eq 0 ] || fail "safe Bash must remain allowed through all matching Codex hooks, got exit $rc: $(cat "$ERR")"
   [ ! -s "$OUT" ] && [ ! -s "$ERR" ] || fail "safe Bash through Codex hooks wrote output"
-  pass "the real Codex hook surface denies current and normalized delegation names only in FirstMate primaries"
+  pass "the real Codex hook surface denies delegation while preserving exact observe-or-stop controls"
 }
 
 test_guard_denies_every_currently_known_delegation_tool

--- a/tests/fm-subagent-pretool-check.test.sh
+++ b/tests/fm-subagent-pretool-check.test.sh
@@ -42,7 +42,7 @@ PLAN_ONLY_TOOLS='TaskCreate TaskUpdate'
 # assumed.
 PLAN_ONLY_NEAR_MISSES='TaskCreateAgent TaskCreateWorktree TaskUpdateAgent RemoteTaskCreate Task TaskCreator'
 
-CODEX_OBSERVE_ONLY_TOOLS='collaborationlist_agents collaborationwait_agent collaborationinterrupt_agent list_agents wait_agent interrupt_agent'
+CODEX_OBSERVE_ONLY_TOOLS='collaborationlist_agents collaborationwait_agent collaborationinterrupt_agent list_agents wait_agent interrupt_agent multi_agent_v1wait_agent multi_agent_v1close_agent'
 
 CODEX_OBSERVE_NEAR_MISSES='collaborationlist_agents_spawn collaborationwait_agent_task collaborationinterrupt_agent_worktree'
 
@@ -329,7 +329,7 @@ test_codex_real_hook_surface_routes_delegation_and_preserves_scope() {
   local tool child="$TMP_ROOT/codex-child" rc=0
   setup_codex_hook_fixture
 
-  for tool in collaborationspawn_agent spawn_agent; do
+  for tool in collaborationspawn_agent spawn_agent multi_agent_v1spawn_agent; do
     rc=0
     run_codex_pretool_hooks "$CODEX_PRIMARY" "$tool" || rc=$?
     [ "$rc" -eq 2 ] || fail "Codex primary hook surface must deny $tool, got exit $rc"

--- a/tests/fm-subagent-pretool-check.test.sh
+++ b/tests/fm-subagent-pretool-check.test.sh
@@ -12,6 +12,7 @@ PRIMARY="$TMP_ROOT/primary"
 STATE="$PRIMARY/state"
 OUT="$TMP_ROOT/out"
 ERR="$TMP_ROOT/err"
+CODEX_PRIMARY="$TMP_ROOT/codex-primary"
 
 mkdir -p "$PRIMARY/bin" "$STATE"
 printf '# fixture\n' > "$PRIMARY/AGENTS.md"
@@ -69,6 +70,50 @@ expect_deny() {
     || fail "$label ($tool) deny omitted Claude's permission decision: $(cat "$ERR")"
   jq -e --arg tool "$tool" '.systemMessage | startswith("[subagent-dispatch]") and contains("blocked tool: " + $tool)' "$ERR" >/dev/null 2>&1 \
     || fail "$label ($tool) deny message lost its code or tool name: $(jq -r '.systemMessage' "$ERR")"
+}
+
+run_codex_pretool_hooks() {
+  local dir=$1 tool=$2 submitted_command=${3:-} payload command hook_rc=0 overall_rc=0 matched=0
+  payload=$(jq -nc --arg tool "$tool" --arg command "$submitted_command" \
+    '{hook_event_name:"PreToolUse",tool_name:$tool,tool_input:{command:$command}}') \
+    || fail "could not build Codex PreToolUse fixture payload"
+  : > "$OUT"
+  : > "$ERR"
+  while IFS= read -r command; do
+    [ -n "$command" ] || continue
+    matched=$((matched + 1))
+    hook_rc=0
+    printf '%s' "$payload" | (cd "$dir" && bash -c "$command") >> "$OUT" 2>> "$ERR" || hook_rc=$?
+    case "$hook_rc" in
+      0) ;;
+      2) overall_rc=2 ;;
+      *) fail "Codex PreToolUse hook for $tool failed with unexpected exit $hook_rc: $(cat "$ERR")" ;;
+    esac
+  done < <(jq -r --arg tool "$tool" '
+    .hooks.PreToolUse[]
+    | select((.matcher // ".*") as $matcher | ($tool | test($matcher)))
+    | .hooks[].command
+  ' "$dir/.codex/hooks.json")
+  [ "$matched" -gt 0 ] || fail "Codex PreToolUse matcher reached no hook for $tool"
+  return "$overall_rc"
+}
+
+setup_codex_hook_fixture() {
+  mkdir -p "$CODEX_PRIMARY/bin" "$CODEX_PRIMARY/state" "$CODEX_PRIMARY/.codex"
+  cp "$ROOT/AGENTS.md" "$CODEX_PRIMARY/AGENTS.md"
+  cp "$ROOT/.codex/hooks.json" "$CODEX_PRIMARY/.codex/hooks.json"
+  cp "$ROOT/bin/fm-subagent-pretool-check.sh" \
+    "$ROOT/bin/fm-primary-scope-lib.sh" \
+    "$ROOT/bin/fm-arm-pretool-check.sh" \
+    "$ROOT/bin/fm-cd-pretool-check.sh" \
+    "$ROOT/bin/fm-arm-command-policy.mjs" \
+    "$ROOT/bin/fm-cd-command-policy.mjs" \
+    "$CODEX_PRIMARY/bin/"
+  git -C "$CODEX_PRIMARY" init -q
+  git -C "$CODEX_PRIMARY" config user.name fixture
+  git -C "$CODEX_PRIMARY" config user.email fixture@example.test
+  git -C "$CODEX_PRIMARY" add AGENTS.md .codex bin
+  git -C "$CODEX_PRIMARY" commit -qm fixture
 }
 
 # ---------------------------------------------------------------------------
@@ -276,6 +321,34 @@ test_missing_jq_stdin_transport_fails_open() {
   pass "missing jq for stdin transport fails open rather than denying every tool call"
 }
 
+test_codex_real_hook_surface_routes_delegation_and_preserves_scope() {
+  local tool child="$TMP_ROOT/codex-child" rc=0
+  setup_codex_hook_fixture
+
+  for tool in collaborationspawn_agent spawn_agent; do
+    rc=0
+    run_codex_pretool_hooks "$CODEX_PRIMARY" "$tool" || rc=$?
+    [ "$rc" -eq 2 ] || fail "Codex primary hook surface must deny $tool, got exit $rc"
+    jq -e --arg tool "$tool" \
+      '.hookSpecificOutput.permissionDecision == "deny" and (.systemMessage | contains("blocked tool: " + $tool))' \
+      "$ERR" >/dev/null 2>&1 \
+      || fail "Codex primary deny for $tool lost the route-to-FirstMate decision: $(cat "$ERR")"
+  done
+
+  git -C "$CODEX_PRIMARY" worktree add -q -b fixture-codex-child "$child"
+  mkdir -p "$child/state"
+  rc=0
+  run_codex_pretool_hooks "$child" collaborationspawn_agent || rc=$?
+  [ "$rc" -eq 0 ] || fail "Codex delegation must remain allowed in a linked worker worktree, got exit $rc: $(cat "$ERR")"
+  [ ! -s "$OUT" ] && [ ! -s "$ERR" ] || fail "linked worker Codex hook allow wrote output"
+
+  rc=0
+  run_codex_pretool_hooks "$CODEX_PRIMARY" Bash 'printf safe' || rc=$?
+  [ "$rc" -eq 0 ] || fail "safe Bash must remain allowed through all matching Codex hooks, got exit $rc: $(cat "$ERR")"
+  [ ! -s "$OUT" ] && [ ! -s "$ERR" ] || fail "safe Bash through Codex hooks wrote output"
+  pass "the real Codex hook surface denies current and normalized delegation names only in FirstMate primaries"
+}
+
 test_guard_denies_every_currently_known_delegation_tool
 test_guard_denies_hypothetical_future_tools
 test_guard_allows_ordinary_and_observe_only_tools
@@ -289,3 +362,4 @@ test_secondmate_home_is_in_scope
 test_stdin_transports_and_output_shapes
 test_malformed_transport_fails_open
 test_missing_jq_stdin_transport_fails_open
+test_codex_real_hook_surface_routes_delegation_and_preserves_scope


### PR DESCRIPTION
## Summary
- register Codex PreToolUse delegation interception through the existing FirstMate subagent guard
- deny current and normalized delegation-shaped tool names in genuine primary sessions while preserving linked-worker collaboration and existing exclusions
- remove the optional jq fail-open by using the universal Node boundary
- document verified Codex 0.147.0 behavior and the residual service-level hook limitation

## Validation
- focused subagent guard behavior tests
- isolated Herdr presentation suite, including contiguous owner blocks and no focus drift
- documentation audience check
- FirstMate lint (local ShellCheck unavailable; CI provides parity)
- no-mistakes review, test, and documentation stages green

No merge requested.