### PR TITLE
fix(bin): accept a decision key on either side of the status colon

### DIFF
--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -170,7 +170,8 @@ status_is_paused_or_captain_held() {  # <status-line>
 # line}" shape naturally puts the token at the head of the note. Accepting one
 # placement only silently folds every line of the other shape onto "default",
 # colliding unrelated decisions and re-surfacing answered ones.
-# A line with no token uses the key "default", preserving the historical
+# A line with no token - or one whose slug is malformed, which is not a token
+# this grammar recognises - uses the key "default", preserving the historical
 # one-open-decision-per-task behavior (a bare "resolved:" closes "default").
 # The three parsers are pure reads of a single line; the verb parser strips any
 # key token before the colon so the leading word is recovered cleanly, and the
@@ -184,15 +185,20 @@ status_line_verb() {  # <status-line> -> leading verb word
   v=${v%"${v##*[![:space:]]}"}
   printf '%s' "$v"
 }
-# <text> -> the raw slug of a leading "[key=<slug>]" token, unvalidated; 1 when
-# the text carries no such token. The ONE place the post-colon token's shape is
-# recognised, shared by the note and key parsers so they cannot disagree about
-# what counts as a token.
+# <text> -> sets _FM_KEY_TOKEN to the raw slug of a leading "[key=<slug>]" token,
+# unvalidated; returns 1 when the text carries no such token. The ONE place the
+# post-colon token's shape is recognised, shared by the note and key parsers so
+# they cannot disagree about what counts as a token. It reports through a caller
+# read variable rather than stdout because both callers run once per status line
+# over the whole stream, where a command substitution's fork is a real cost;
+# every caller declares _FM_KEY_TOKEN local, so nothing escapes the call.
 _fm_leading_key_token() {  # <text>
-  local t=$1 k
-  case "$t" in
-    \[key=*\]*) k=${t#\[key=}; printf '%s' "${k%%\]*}" ;;
-    *) return 1 ;;
+  case "$1" in
+    \[key=*\]*)
+      _FM_KEY_TOKEN=${1#\[key=}
+      _FM_KEY_TOKEN=${_FM_KEY_TOKEN%%\]*}
+      ;;
+    *) _FM_KEY_TOKEN=''; return 1 ;;
   esac
 }
 # 0 when <slug> is a usable decision key.
@@ -205,17 +211,24 @@ _fm_decision_key_is_valid() {  # <slug>
 # <status-line> -> text after the first colon, trimmed, minus a leading
 # "[key=<slug>]" token so the note is the same text under either key placement.
 status_line_note() {
-  local n=$1 k
+  local n=$1 _FM_KEY_TOKEN=''
   case "$n" in *:*) n=${n#*:} ;; esac
   n=${n#"${n%%[![:space:]]*}"}
-  if k=$(_fm_leading_key_token "$n") && _fm_decision_key_is_valid "$k"; then
+  if _fm_leading_key_token "$n" && _fm_decision_key_is_valid "$_FM_KEY_TOKEN"; then
     n=${n#*\]}
     n=${n#"${n%%[![:space:]]*}"}
   fi
   printf '%s' "$n"
 }
-_fm_decision_key() {  # <status-line> -> key slug, or "default" when no token
-  local prefix=${1%%:*} rest k
+# <status-line> -> key slug, or "default" when the line carries no usable token.
+# A malformed slug falls back to "default" exactly as a missing token does, under
+# BOTH placements: this parser is the gate on whether a line is a decision
+# transition at all, so returning a failure here would make a typo'd key silently
+# delete a needs-decision from the open set - the one thing the fold above must
+# never do. Falling back also keeps this parser agreeing with status_line_note,
+# which leaves an unrecognised token in the note as ordinary text.
+_fm_decision_key() {
+  local prefix=${1%%:*} rest k _FM_KEY_TOKEN=''
   case "$prefix" in
     *\[key=*\]*)
       k=${prefix#*\[key=}
@@ -226,10 +239,11 @@ _fm_decision_key() {  # <status-line> -> key slug, or "default" when no token
       # puts it at the head of the note instead.
       case "$1" in *:*) rest=${1#*:} ;; *) printf 'default'; return 0 ;; esac
       rest=${rest#"${rest%%[![:space:]]*}"}
-      k=$(_fm_leading_key_token "$rest") || { printf 'default'; return 0; }
+      _fm_leading_key_token "$rest" || { printf 'default'; return 0; }
+      k=$_FM_KEY_TOKEN
       ;;
   esac
-  _fm_decision_key_is_valid "$k" || return 1
+  _fm_decision_key_is_valid "$k" || { printf 'default'; return 0; }
   printf '%s' "$k"
 }
 # Drop the record for <key> from a newline-terminated "<key>\t<verb>\t<note>" set.
@@ -295,12 +309,12 @@ _fm_decision_fold_line() {  # <open-set> <status-line> <resolve-verb> <held-verb
   stripped=${line//[[:space:]]/}
   [ -n "$stripped" ] || { printf '%s' "$open"; return 0; }
   verb=$(status_line_verb "$line")
-  key=$(_fm_decision_key "$line") || { printf '%s' "$open"; return 0; }
-  _fm_decision_key_transition_allowed "$key" "$(status_line_note "$line")" \
+  key=$(_fm_decision_key "$line")
+  note=$(status_line_note "$line")
+  _fm_decision_key_transition_allowed "$key" "$note" \
     || { printf '%s' "$open"; return 0; }
   case "$verb" in
     needs-decision|blocked)
-      note=$(status_line_note "$line")
       open=$(_fm_decision_drop "$open" "$key")
       [ -n "$open" ] && open="${open}"$'\n'
       open="${open}${key}"$'\t'"${verb}"$'\t'"${note}"$'\n'
@@ -422,7 +436,7 @@ _fm_open_decisions_cursor_path() {  # <status-file>
   printf '%s/.%s.open-decisions-cursor' "$dir" "${base%.status}"
 }
 
-FM_OPEN_DECISIONS_FOLD_VERSION=3
+FM_OPEN_DECISIONS_FOLD_VERSION=4
 
 # Portable device:inode identity for the rotation/recreation check below.
 _fm_open_decisions_file_ident() {  # <file> -> "dev:inode", empty on I/O failure

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -160,13 +160,23 @@ status_is_paused_or_captain_held() {  # <status-line>
 # rule 6), so closure never depends on a busy worker's discipline.
 #
 # Decision key grammar (backward-compatible with the existing "<verb>: <note>"
-# format): an OPTIONAL "[key=<slug>]" token sits between the verb and the colon,
+# format): an OPTIONAL "[key=<slug>]" token sits either between the verb and the
+# colon or at the head of the note, and the two placements name the SAME key,
 #   needs-decision [key=api-shape]: <summary>
-#   resolved       [key=api-shape]: <how it was decided>
+#   needs-decision: [key=api-shape] <summary>
+# Both are accepted because both are written in practice: firstmate's own writers
+# (bin/fm-send.sh, bin/fm-decision-hold.sh, bin/fm-pending-reply-lib.sh) emit the
+# pre-colon form, while a crewmate following the brief's "{state}: {one short
+# line}" shape naturally puts the token at the head of the note. Accepting one
+# placement only silently folds every line of the other shape onto "default",
+# colliding unrelated decisions and re-surfacing answered ones.
 # A line with no token uses the key "default", preserving the historical
 # one-open-decision-per-task behavior (a bare "resolved:" closes "default").
 # The three parsers are pure reads of a single line; the verb parser strips any
-# key token before the colon so the leading word is recovered cleanly.
+# key token before the colon so the leading word is recovered cleanly, and the
+# note parser strips a leading key token so a note reads identically - and is
+# matched identically, including by the reserved-namespace vocabulary rule
+# below - under either placement.
 status_line_verb() {  # <status-line> -> leading verb word
   local v=${1%%:*}
   v=${v%%\[key=*}
@@ -174,25 +184,53 @@ status_line_verb() {  # <status-line> -> leading verb word
   v=${v%"${v##*[![:space:]]}"}
   printf '%s' "$v"
 }
-status_line_note() {  # <status-line> -> text after the first colon, trimmed
-  case "$1" in
-    *:*) local n=${1#*:}; printf '%s' "${n#"${n%%[![:space:]]*}"}" ;;
-    *) printf '%s' "$1" ;;
+# <text> -> the raw slug of a leading "[key=<slug>]" token, unvalidated; 1 when
+# the text carries no such token. The ONE place the post-colon token's shape is
+# recognised, shared by the note and key parsers so they cannot disagree about
+# what counts as a token.
+_fm_leading_key_token() {  # <text>
+  local t=$1 k
+  case "$t" in
+    \[key=*\]*) k=${t#\[key=}; printf '%s' "${k%%\]*}" ;;
+    *) return 1 ;;
   esac
 }
+# 0 when <slug> is a usable decision key.
+_fm_decision_key_is_valid() {  # <slug>
+  case "$1" in
+    ''|*[!A-Za-z0-9._-]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+# <status-line> -> text after the first colon, trimmed, minus a leading
+# "[key=<slug>]" token so the note is the same text under either key placement.
+status_line_note() {
+  local n=$1 k
+  case "$n" in *:*) n=${n#*:} ;; esac
+  n=${n#"${n%%[![:space:]]*}"}
+  if k=$(_fm_leading_key_token "$n") && _fm_decision_key_is_valid "$k"; then
+    n=${n#*\]}
+    n=${n#"${n%%[![:space:]]*}"}
+  fi
+  printf '%s' "$n"
+}
 _fm_decision_key() {  # <status-line> -> key slug, or "default" when no token
-  local prefix=${1%%:*} k
+  local prefix=${1%%:*} rest k
   case "$prefix" in
     *\[key=*\]*)
       k=${prefix#*\[key=}
       k=${k%%\]*}
-      case "$k" in
-        ''|*[!A-Za-z0-9._-]*) return 1 ;;
-        *) printf '%s' "$k" ;;
-      esac
       ;;
-    *) printf 'default' ;;
+    *)
+      # No token before the colon: the brief's "{state}: {one short line}" shape
+      # puts it at the head of the note instead.
+      case "$1" in *:*) rest=${1#*:} ;; *) printf 'default'; return 0 ;; esac
+      rest=${rest#"${rest%%[![:space:]]*}"}
+      k=$(_fm_leading_key_token "$rest") || { printf 'default'; return 0; }
+      ;;
   esac
+  _fm_decision_key_is_valid "$k" || return 1
+  printf '%s' "$k"
 }
 # Drop the record for <key> from a newline-terminated "<key>\t<verb>\t<note>" set.
 # Portable (no associative arrays) so the fold runs on bash 3.2 as well as 4+.
@@ -384,7 +422,7 @@ _fm_open_decisions_cursor_path() {  # <status-file>
   printf '%s/.%s.open-decisions-cursor' "$dir" "${base%.status}"
 }
 
-FM_OPEN_DECISIONS_FOLD_VERSION=2
+FM_OPEN_DECISIONS_FOLD_VERSION=3
 
 # Portable device:inode identity for the rotation/recreation check below.
 _fm_open_decisions_file_ident() {  # <file> -> "dev:inode", empty on I/O failure

--- a/tests/fm-wake-drain-open-decisions.test.sh
+++ b/tests/fm-wake-drain-open-decisions.test.sh
@@ -85,6 +85,84 @@ test_reserved_key_namespace_is_owned_by_its_library() {
   pass "a reserved decision key can only be opened or closed by its owning library"
 }
 
+test_key_after_the_colon_names_the_same_decision() {
+  local dir state out
+  dir=$(make_case key-after-colon)
+  state="$dir/state"
+  out="$dir/drain.out"
+  # The crewmate brief tells workers to append "{state}: {one short line}", so a
+  # keyed decision is naturally written with the token leading the note, AFTER
+  # the first colon. Both placements must name the same decision, or distinct
+  # decisions collide under "default" and an answered one keeps resurfacing.
+  printf 'needs-decision: [key=api-shape] pick REST or RPC\n' > "$state/taskA.status"
+  printf 'needs-decision: [key=rollout] pick the rollout plan\n' >> "$state/taskA.status"
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" || fail "drain failed on post-colon keys"
+
+  grep -F 'taskA [key=api-shape] needs-decision: pick REST or RPC' "$out" >/dev/null \
+    || fail "a post-colon key did not name its own decision: $(cat "$out")"
+  grep -F 'taskA [key=rollout] needs-decision: pick the rollout plan' "$out" >/dev/null \
+    || fail "a second post-colon key collided with the first: $(cat "$out")"
+  if grep -F '[key=default]' "$out" >/dev/null; then
+    fail "a post-colon keyed decision folded to the default key: $(cat "$out")"
+  fi
+  pass "a [key=<slug>] token after the colon names its own decision"
+}
+
+test_both_key_placements_pair_open_and_resolved() {
+  local dir state out
+  dir=$(make_case key-placement-pairing)
+  state="$dir/state"
+  out="$dir/drain.out"
+  # Same-shape pairing, and both cross-shape pairings: whichever placement the
+  # opening line used, a resolution carrying that key in either placement closes
+  # it, and neither placement closes an unrelated key.
+  printf 'needs-decision: [key=post-post] a\n' > "$state/taskB.status"
+  printf 'resolved: [key=post-post] answered a\n' >> "$state/taskB.status"
+  printf 'needs-decision: [key=post-pre] b\n' >> "$state/taskB.status"
+  printf 'resolved [key=post-pre]: answered b\n' >> "$state/taskB.status"
+  printf 'needs-decision [key=pre-post]: c\n' >> "$state/taskB.status"
+  printf 'resolved: [key=pre-post] answered c\n' >> "$state/taskB.status"
+  printf 'needs-decision: [key=still-open] d\n' >> "$state/taskB.status"
+  printf 'resolved: answered something else\n' >> "$state/taskB.status"
+  printf 'done: unrelated later milestone\n' >> "$state/taskB.status"
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" || fail "drain failed on mixed key placements"
+
+  grep -F 'taskB [key=still-open] needs-decision: d' "$out" >/dev/null \
+    || fail "an unanswered post-colon decision stopped surfacing: $(cat "$out")"
+  local key
+  for key in post-post post-pre pre-post; do
+    if grep -F "[key=$key]" "$out" >/dev/null; then
+      fail "a resolution did not close the '$key' decision it answers: $(cat "$out")"
+    fi
+  done
+  pass "open and resolved lines pair on the same key under both placements"
+}
+
+test_reserved_key_namespace_holds_after_the_colon() {
+  local dir state out
+  dir=$(make_case reserved-key-after-colon)
+  state="$dir/state"
+  out="$dir/drain.out"
+  # The reserved-namespace rule reads the note's own vocabulary, so it must see
+  # the same note whichever placement the key token used.
+  printf 'blocked: [key=pending-reply-abcdef0123456789] pending-reply-missed: task=ios pending-reply-id=abcdef0123456789 request=ship it\n' > "$state/taskC.status"
+  printf 'resolved: [key=pending-reply-abcdef0123456789] all good now\n' >> "$state/taskC.status"
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" || fail "drain failed on post-colon reserved keys"
+
+  grep -F 'pending-reply-id=abcdef0123456789' "$out" >/dev/null \
+    || fail "a foreign resolution cleared a reserved decision it does not own: $(cat "$out")"
+
+  printf 'resolved: [key=pending-reply-abcdef0123456789] pending-reply-resolved: task=ios pending-reply-id=abcdef0123456789 via=status\n' >> "$state/taskC.status"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" || fail "drain failed after the owner closed its decision"
+  if grep -F 'OPEN DECISIONS' "$out" >/dev/null; then
+    fail "the owner's own post-colon resolution did not close its decision: $(cat "$out")"
+  fi
+  pass "the reserved-key rule applies identically to a post-colon key token"
+}
+
 test_later_unrelated_terminal_line_does_not_close_it() {
   local dir state out
   dir=$(make_case unrelated-terminal)
@@ -218,6 +296,9 @@ test_over_long_decision_note_is_capped_with_a_marker() {
 test_buried_decision_still_surfaces
 test_over_long_decision_note_is_capped_with_a_marker
 test_explicit_resolution_closes_it
+test_key_after_the_colon_names_the_same_decision
+test_both_key_placements_pair_open_and_resolved
+test_reserved_key_namespace_holds_after_the_colon
 test_later_unrelated_terminal_line_does_not_close_it
 test_reserved_key_namespace_is_owned_by_its_library
 test_no_open_decisions_prints_nothing

--- a/tests/fm-wake-drain-open-decisions.test.sh
+++ b/tests/fm-wake-drain-open-decisions.test.sh
@@ -163,6 +163,39 @@ test_reserved_key_namespace_holds_after_the_colon() {
   pass "the reserved-key rule applies identically to a post-colon key token"
 }
 
+test_malformed_key_slug_still_surfaces_under_default() {
+  local dir state out
+  dir=$(make_case malformed-key-slug)
+  state="$dir/state"
+  out="$dir/drain.out"
+  # A typo'd slug is not a key this grammar recognises, under either placement.
+  # It must degrade to the historical unkeyed decision, never make the line stop
+  # being a decision at all - a lost needs-decision is the one failure the whole
+  # open-decision fold exists to prevent.
+  printf 'needs-decision: [key=oauth token] pick one\n' > "$state/taskD.status"
+  printf 'working: continuing other work\n' >> "$state/taskD.status"
+  printf 'needs-decision [key=payment/refund]: waiting on refunds\n' > "$state/taskE.status"
+  printf 'done: unrelated later milestone\n' >> "$state/taskE.status"
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" || fail "drain failed on a malformed key slug"
+
+  grep -F 'OPEN DECISIONS' "$out" >/dev/null \
+    || fail "a malformed key slug suppressed the whole OPEN DECISIONS section: $(cat "$out")"
+  grep -F 'taskD' "$out" | grep -F 'pick one' >/dev/null \
+    || fail "a post-colon malformed slug made the decision vanish: $(cat "$out")"
+  grep -F 'taskE' "$out" | grep -F 'waiting on refunds' >/dev/null \
+    || fail "a pre-colon malformed slug made the decision vanish: $(cat "$out")"
+
+  # And it stays closable the way an unkeyed decision always was.
+  printf 'resolved: answered it\n' >> "$state/taskD.status"
+  printf 'resolved: answered it\n' >> "$state/taskE.status"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" || fail "drain failed after resolving a malformed-key decision"
+  if grep -F 'OPEN DECISIONS' "$out" >/dev/null; then
+    fail "a bare resolution did not close a malformed-key decision: $(cat "$out")"
+  fi
+  pass "a malformed key slug falls back to the default key instead of dropping the decision"
+}
+
 test_later_unrelated_terminal_line_does_not_close_it() {
   local dir state out
   dir=$(make_case unrelated-terminal)
@@ -299,6 +332,7 @@ test_explicit_resolution_closes_it
 test_key_after_the_colon_names_the_same_decision
 test_both_key_placements_pair_open_and_resolved
 test_reserved_key_namespace_holds_after_the_colon
+test_malformed_key_slug_still_surfaces_under_default
 test_later_unrelated_terminal_line_does_not_close_it
 test_reserved_key_namespace_is_owned_by_its_library
 test_no_open_decisions_prints_nothing


### PR DESCRIPTION
## The defect

`_fm_decision_key()` in `bin/fm-classify-lib.sh` looked for the optional `[key=<slug>]` token only in the text *before* a status line's first colon.

The standard crewmate brief tells workers to append `{state}: {one short line}`, so a keyed decision is naturally written with the token leading the note, *after* the colon:

```
needs-decision: [key=api-shape] pick REST or RPC
```

Every line of that shape folded to `key=default`. Distinct decisions collided under one key, and an already-answered decision kept looking open, which produced repeated false-positive stale wakes in live supervision.

## Where the fix belongs, and why

The fix is in the **parser**, not in the brief scaffold.

- Status files already written on disk carry the post-colon shape. A scaffold-only fix would only change what *future* workers write, leaving every existing task's decision history broken.
- Firstmate's own writers - `bin/fm-send.sh`, `bin/fm-decision-hold.sh`, `bin/fm-pending-reply-lib.sh` - emit the pre-colon shape, which must keep working exactly as before.

So both placements now resolve to the same key. Neither shape was fixed by breaking the other, and the brief scaffold's wording is deliberately unchanged.

`status_line_note()` now strips a leading key token as well. That is required rather than cosmetic: the reserved-key namespace rule (`_fm_decision_key_transition_allowed`) decides whether a transition is allowed by matching the note's own leading vocabulary token, so without stripping, a post-colon reserved-key line could not open or close its own decision.

## Malformed slugs fall back to `default`

Review caught a real regression in the first version of this change: a post-colon token with a malformed slug (`[key=oauth token]`) made `_fm_decision_key()` return non-zero, so `_fm_decision_fold_line()` dropped the line entirely and the `needs-decision` never opened at all. On the base commit that same line folded under `default` and did surface.

`_fm_decision_key()` is the gate on whether a line is a decision transition at all, so a failure return there means a typo'd key silently deletes a decision from the open set - the one thing this fold exists to prevent. A malformed slug now falls back to `default` exactly as a missing token does, under **both** placements. That restores the base behaviour and aligns the key parser with `status_line_note()`, which already leaves an unrecognised token in the note as ordinary text.

## Other changes

- `FM_OPEN_DECISIONS_FOLD_VERSION` 2 -> 3, as the library's own contract requires when fold semantics change, so persisted cursors from the old interpretation are discarded and rebuilt.
- The shared token-recognition helper reports through a caller-declared local variable instead of stdout, so the whole-file fold does not pay an extra subshell fork per status line - it runs once per task on every fleet snapshot.

## Tests

All in `tests/fm-wake-drain-open-decisions.test.sh`, driving the real `bin/fm-wake-drain.sh` over crafted status logs and asserting on its printed output, never on implementation source text:

- The reproduction: two distinct post-colon keyed decisions must name their own keys. Written first and confirmed failing against the unfixed parser, where both collapsed into a single unkeyed entry.
- Open/resolved pairing under both placements and both cross-shape combinations, plus an unrelated bare resolution that must not close a keyed decision.
- The reserved-key namespace rule under the post-colon shape.
- A malformed slug under either placement still surfaces under `default`, and stays closable by a bare resolution.

## Scope

One parsing defect. No classifier restructuring, no generalised status grammar, no status-line schema, and no change to the brief scaffold's wording.
