### PR TITLE
feat(supervision): enqueue idempotent fleet refill wake on capacity-freeing transitions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -389,6 +389,7 @@ Handle actionable wakes as follows:
 2. For `stale:`, inspect the recorded endpoint and load `stuck-crewmate-recovery` for a stopped, looping, confused, or unresponsive worker; a deep-inspection reason also requires current-state and validation-log inspection.
 3. For `check:`, act on the named poll result, including merges, Relay events, and process-to-event source results.
 4. For `heartbeat:`, review the whole fleet from the structured fleet view, reconcile suspicious tasks and PR state, update the backlog, and never report an unchanged fleet as progress.
+5. For `refill:`, re-evaluate ready work against free capacity using the structured fleet view; the wake is advisory only and never itself a spawn or task recommendation (enqueue owners: `bin/fm-wake-lib.sh`, lifecycle hooks in `bin/fm-watch.sh` and `bin/fm-teardown.sh`).
 
 When any wake reports a merged PR for a project cloned in this home, refresh that clone through the guarded fleet-sync path.
 When Relay-linked work reaches a milestone or terminal state, load `fmx-respond`; before terminal teardown, use its promised-final reconciliation when a typed public commitment exists, otherwise post the final completion follow-up so the link clears even if earlier follow-ups were spent.

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -97,6 +97,22 @@ status_is_terminal_verb() {
   esac
 }
 
+# 0 if a status line's leading verb frees compute capacity and should enqueue
+# one advisory fleet refill wake (bin/fm-wake-lib.sh's fm_wake_enqueue_refill).
+# Covers completion and failure, blocked/paused/needs-decision, and decision
+# resolution. Working and other nonterminal progress never free capacity.
+# Distinct from status_is_captain_relevant: paused and resolved free capacity
+# without being captain-relevant signal verbs.
+status_frees_capacity() {
+  local line=$1 verb
+  [ -n "$line" ] || return 1
+  verb=$(status_line_verb "$line")
+  case "$verb" in
+    done|failed|blocked|paused|needs-decision|resolved) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # 0 if the given (last) status line matches a captain-relevant verb.
 # Verb-aware by default: terminal verbs always match; nonterminal progress verbs
 # (working, resolved, captain-held) and paused never match from free-text prose;

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -420,6 +420,13 @@ classify_heartbeat() {
   printf 'self|heartbeat (catch-all scan runs in housekeeping)'
 }
 
+# Advisory fleet refill: firstmate (or the away-mode primary injection) must
+# re-evaluate ready work against free capacity. The daemon never selects or
+# spawns from this wake itself.
+classify_refill() {
+  printf 'escalate|refill: re-evaluate ready work against free capacity'
+}
+
 # Anything unrecognized is escalated (fail-safe).
 classify_unknown() {  # <reason>
   printf 'escalate|unknown wake: %s' "$1"
@@ -1192,7 +1199,7 @@ should_force_self() {  # <reason>
 is_wake_reason() {  # <reason>
   local reason=$1
   case "$reason" in
-    signal:*|stale:*|check:*|heartbeat|heartbeat:*) return 0 ;;
+    signal:*|stale:*|check:*|heartbeat|heartbeat:*|refill|refill:*) return 0 ;;
   esac
   return 1
 }
@@ -1218,6 +1225,7 @@ handle_wake() {  # <reason> <state>
               esac ;;
     check:*)  decision=$(classify_check "$reason") ;;
     heartbeat|heartbeat:*) decision=$(classify_heartbeat) ;;
+    refill|refill:*) decision=$(classify_refill) ;;
     *)        decision=$(classify_unknown "$reason") ;;
   esac
   action=${decision%%|*}

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -58,6 +58,9 @@
 #   --force skips ordinary-task dirty and landed-work checks, skips scout report
 #   checks, and discards secondmate child work for kind=secondmate. Only use it
 #   when the captain has explicitly said to discard the work.
+# After a successful teardown (local or remote), enqueue one advisory fleet
+# refill wake (bin/fm-wake-lib.sh's fm_wake_enqueue_refill) so firstmate
+# re-evaluates ready work against free capacity. Refill never selects or spawns.
 #
 # Transient / stale worktree git lock recovery (teardown-lock-race): a crew process
 # killed mid-git-operation can leave a .git/worktrees/<wt>/index.lock (or, for a
@@ -395,6 +398,9 @@ remote_secondmate_teardown() {
   rm -f -- "$STATE/$ID.status" "$STATE/$ID.meta" "$STATE/$ID.turn-ended" \
     "$STATE/.$ID.open-decisions-cursor"
   printf 'teardown %s complete (remote %s:%s)\n' "$ID" "$remote_host" "$remote_home"
+  # Capacity free: advisory refill so firstmate re-evaluates ready work.
+  fm_wake_enqueue_refill || \
+    echo "warning: could not enqueue fleet refill after remote teardown of $ID" >&2
   return 0
 }
 
@@ -2546,4 +2552,8 @@ if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only 
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
 fi
 echo "teardown $ID complete (window $T, worktree $WT)"
+# Capacity free: advisory refill so firstmate re-evaluates ready work.
+# Multiple teardowns before drain collapse to one refill record (dedupe by kind).
+fm_wake_enqueue_refill || \
+  echo "warning: could not enqueue fleet refill after teardown of $ID" >&2
 backlog_refresh_reminder

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -558,7 +558,7 @@ fm_wake_clean_field() {
 fm_wake_append() {
   local kind=$1 key=$2 payload=$3 clean_key clean_payload epoch seq seq_file status
   case "$kind" in
-    signal|stale|check|heartbeat) ;;
+    signal|stale|check|heartbeat|refill) ;;
     *) printf 'fm_wake_append: invalid wake kind: %s\n' "$kind" >&2; return 2 ;;
   esac
 
@@ -582,6 +582,19 @@ fm_wake_append() {
   return "$status"
 }
 
+# fm_wake_enqueue_refill
+# Enqueue one advisory fleet-refill wake after a capacity-freeing lifecycle
+# transition. Multiple transitions before drain collapse into ONE queued record
+# (dedupe by kind, like heartbeat). The payload tells firstmate to re-evaluate
+# ready work against free capacity using the structured fleet view; this helper
+# never selects, recommends, or spawns tasks. Provider-reset and Playbot-settled
+# triggers are deliberate follow-ups, not owned here.
+# Payload text is stable so drains and tests can match it exactly.
+FM_WAKE_REFILL_PAYLOAD='refill: re-evaluate ready work against free capacity'
+fm_wake_enqueue_refill() {
+  fm_wake_append refill refill "$FM_WAKE_REFILL_PAYLOAD"
+}
+
 # fm_wake_queued_keys <kind>
 # Print the distinct keys currently queued for <kind>, oldest first. Read under
 # the append lock so a concurrent append is never observed half-written. The
@@ -590,7 +603,7 @@ fm_wake_append() {
 fm_wake_queued_keys() {
   local kind=$1
   case "$kind" in
-    signal|stale|check|heartbeat) ;;
+    signal|stale|check|heartbeat|refill) ;;
     *) printf 'fm_wake_queued_keys: invalid wake kind: %s\n' "$kind" >&2; return 2 ;;
   esac
   fm_lock_acquire_wait "$FM_WAKE_QUEUE_LOCK"
@@ -619,8 +632,10 @@ fm_wake_print_deduped() {
   awk -F '\t' '
     NF >= 5 {
       dedupe = $3 SUBSEP $4
-      if ($3 == "heartbeat") {
-        dedupe = "heartbeat"
+      # heartbeat and refill collapse by kind alone: many capacity-freeing
+      # transitions before drain must still leave exactly one refill record.
+      if ($3 == "heartbeat" || $3 == "refill") {
+        dedupe = $3
       }
       if (!(dedupe in seen)) {
         order[++count] = dedupe

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -53,6 +53,13 @@
 #                          running a check or removing poll artifacts
 #   heartbeat              fleet-scan backstop found an unsurfaced captain-relevant
 #                          status, unless afk is active
+#   refill: ...            advisory fleet refill after a capacity-freeing lifecycle
+#                          transition (status done/failed/blocked/paused/
+#                          needs-decision/resolved, merged PR poll, or teardown);
+#                          enqueued as kind=refill and drained for firstmate to
+#                          re-evaluate ready work against free capacity. Never
+#                          selects or spawns tasks itself. Multiple transitions
+#                          collapse to one queued refill record (dedupe by kind).
 # For normal supervision, resume the session-start primary-harness protocol
 # after each printed reason. Direct duplicate invocations of this script still
 # no-op through the watcher singleton lock.
@@ -842,6 +849,8 @@ while :; do
         reason="check: $c: $out"
         fm_wake_append check "$c" "$reason" || exit 1
         if [ "$is_pr_poll" -eq 1 ] && [ "$out" = merged ]; then
+          # Capacity free after a merged PR: one advisory refill wake.
+          fm_wake_enqueue_refill || exit 1
           if fm_pr_poll_retirement_publish "$STATE" "$id" "$SCRIPT_DIR/fm-pr-poll.sh" "$out"; then
             fm_pr_poll_retirement_recover_one "$STATE" "$id" "$SCRIPT_DIR/fm-pr-poll.sh" \
               || triage_log "merged PR poll retirement remains recoverable for $id"
@@ -879,6 +888,24 @@ while :; do
 $pending
 EOF
     reason="signal:$files"
+    # Capacity-freeing status transitions enqueue ONE advisory refill wake
+    # (deduped by kind at drain). Paused and resolved free capacity without
+    # being captain-relevant, so detect them here before the absorb decision.
+    # Working notes never free capacity and never enqueue refill.
+    need_refill=0
+    while IFS=$(printf '\t') read -r sf sig f; do
+      [ -n "$sf" ] || continue
+      case "$f" in *.status) ;; *) continue ;; esac
+      if status_frees_capacity "$(last_status_line "$f")"; then
+        need_refill=1
+        break
+      fi
+    done <<EOF
+$pending
+EOF
+    if [ "$need_refill" -eq 1 ]; then
+      fm_wake_enqueue_refill || exit 1
+    fi
     # Triage: a signal is ACTIONABLE when any of these holds (cheapest first):
     #   - the away-mode daemon owns triage (afk) and wants every wake;
     #   - any status file carries a captain-relevant verb;
@@ -892,6 +919,9 @@ EOF
     # will not re-fire, log, and keep blocking without enqueuing. The provably-working
     # check is the only costly one (it may run a bounded no-mistakes call), so the ||
     # ordering evaluates it ONLY for a non-afk, no-captain-verb signal.
+    # A refill-only path (e.g. resolved: while the crew is still working) advances
+    # markers and exits with the refill reason so firstmate re-evaluates capacity
+    # without treating the wake as a spawn recommendation.
     # shellcheck disable=SC2086  # $files is a space-separated status-path list (ids carry no spaces)
     if afk_present || signal_reason_is_actionable $files || ! signal_crew_provably_working $files; then
       while IFS=$(printf '\t') read -r sf sig f; do
@@ -908,6 +938,14 @@ EOF
 $pending
 EOF
       wake "$reason"
+    elif [ "$need_refill" -eq 1 ]; then
+      while IFS=$(printf '\t') read -r sf sig f; do
+        [ -n "$sf" ] || continue
+        printf '%s' "$sig" > "$sf"
+      done <<EOF
+$pending
+EOF
+      wake "$FM_WAKE_REFILL_PAYLOAD"
     else
       while IFS=$(printf '\t') read -r sf sig f; do
         [ -n "$sf" ] || continue

--- a/docs/supervision-protocols/claude.md
+++ b/docs/supervision-protocols/claude.md
@@ -5,7 +5,7 @@ When this session owns supervision and away mode is not active:
 2. Routine watcher arm and re-arm are owned by the Stop `asyncRewake` hook (`bin/fm-claude-stop-autoarm.sh`), never by you.
    Every turn end while supervision is needed launches or attaches one home-scoped watcher cycle with no model command and no model tokens.
    An actionable close wakes you through the hook's exit-2 rewake, delivered as a `Stop hook feedback` message.
-3. On a `Stop hook feedback` wake (`signal:`, `stale:`, `check:`, or `heartbeat`), run `bin/fm-wake-drain.sh` first and handle the wake.
+3. On a `Stop hook feedback` wake (`signal:`, `stale:`, `check:`, `heartbeat`, or `refill:`), run `bin/fm-wake-drain.sh` first and handle the wake.
    Do not run `bin/fm-watch-arm.sh` after an ordinary wake; the next turn end re-arms automatically when supervision is still needed.
    Do not invent a wake from an attach-status line alone; drain and act only on real wake records, the drain's `OPEN DECISIONS` entries, or a real watcher reason line.
 4. On the one `Stop hook feedback` automatic-mechanism failure notice (`firstmate watcher auto-arm FAILED ...`), drain, inspect the automatic mechanism failure, and do not turn the notice into a repeating manual-arm loop.

--- a/docs/supervision-protocols/codex.md
+++ b/docs/supervision-protocols/codex.md
@@ -4,7 +4,7 @@ When this session owns supervision and away mode is not active:
 1. Drain first with `bin/fm-wake-drain.sh`.
 2. Source `__FM_X_MODE_ENV__` first when Relay is active.
 3. First cycle: run one foreground watcher checkpoint with `bin/fm-watch-checkpoint.sh --seconds "${FM_CODEX_WATCH_CHECKPOINT:-180}"`.
-4. Ordinary wake: if the command prints `signal:`, `stale:`, `check:`, or `heartbeat`, drain queued wakes, handle that wake, then start the next checkpoint.
+4. Ordinary wake: if the command prints `signal:`, `stale:`, `check:`, `heartbeat`, or `refill:`, drain queued wakes, handle that wake, then start the next checkpoint.
 5. If the command prints `checkpoint:` or exits 124 with no wake, drain queued wakes anyway, process any queued user message now visible to Codex, then start the next checkpoint.
 6. Never use shell `&` or Codex background tasks for firstmate watcher supervision.
 7. Do not run `bin/fm-watch-arm.sh` as Codex's normal supervision command.

--- a/docs/supervision-protocols/grok.md
+++ b/docs/supervision-protocols/grok.md
@@ -23,7 +23,7 @@ Grok injects a synthetic user message with `synthetic_reason: task_completed` wh
 When you see a background-task-completed system reminder for the arm:
 1. Run `bin/fm-wake-drain.sh` first.
 2. Optionally fetch arm output with `get_command_or_subagent_output(<task_id>)` for the reason line.
-3. Handle `signal`, `stale`, `check`, or `heartbeat` using the harness-neutral contract in `AGENTS.md`.
+3. Handle `signal`, `stale`, `check`, `heartbeat`, or `refill` using the harness-neutral contract in `AGENTS.md`.
 4. Ordinary wake: re-arm the next cycle with the same background `bin/fm-watch-arm.sh` call if work remains in flight or Relay still needs polling.
 5. Do not invent a wake from an attach-status line alone.
    Drain the queue and act only on real wake records, the drain's `OPEN DECISIONS` entries, or a real watcher reason line.

--- a/docs/supervision-protocols/pi.md
+++ b/docs/supervision-protocols/pi.md
@@ -11,7 +11,7 @@ When this session owns supervision and away mode is not active:
 6. Ordinary same-process session replacement (`/new`, `/resume`, `/fork`, reload) retires only the prior generation; call `fm_watch_arm_pi` once for the first cycle of the replacement session without restarting Pi.
    The generation-owner contract lives in `.pi/extensions/fm-primary-pi-watch.ts`.
 7. After an actionable child close, the extension rechecks session-lock ownership and verifies one successor before it delivers the follow-up wake; its bounded fallback is defined in `docs/watcher-continuity.md`.
-8. Ordinary work, turn completion, and ordinary signal, stale, check, heartbeat, or other wake handling: do not call `fm_watch_arm_pi` again because continuity is extension-owned rather than model-memory-owned.
+8. Ordinary work, turn completion, and ordinary signal, stale, check, heartbeat, refill, or other wake handling: do not call `fm_watch_arm_pi` again because continuity is extension-owned rather than model-memory-owned.
 9. An unexpected child close enters bounded exponential retry, and an exhausted retry or lost session lock is surfaced as a watcher failure instead of disappearing.
 10. Missing, failed, or unhealthy cycle only: if a later notification explicitly reports one of those repair conditions, drain queued wakes, inspect the failure text, call `fm_watch_arm_pi`, and restart the selected Pi-family executable with both extensions loaded if needed.
    A redundant call while the extension owns an arm child or scheduled retry is an ownership-based `watcher: unchanged` no-op, not an independent health claim.

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -1326,6 +1326,29 @@ test_teardown_missing_busy_sidecar_completes() {
   pass "teardown completes when an exact busy-state sidecar is already absent"
 }
 
+# Phase 2: successful teardown enqueues one advisory fleet refill wake so
+# firstmate re-evaluates ready work against free capacity. Drain clears it.
+test_teardown_enqueues_refill_wake() {
+  local case_dir drain_out refill_n leftover
+  case_dir=$(make_case teardown-refill)
+  write_meta "$case_dir" local-only ship
+  run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr" \
+    || fail "teardown-refill: teardown failed: $(cat "$case_dir/stderr")"
+  grep -F 'teardown task-x1 complete' "$case_dir/stdout" >/dev/null \
+    || fail "teardown-refill: teardown did not complete"
+  drain_out="$case_dir/drain.out"
+  FM_STATE_OVERRIDE="$case_dir/state" "$ROOT/bin/fm-wake-drain.sh" > "$drain_out" 2>/dev/null \
+    || fail "teardown-refill: drain failed"
+  refill_n=$(awk -F '\t' '$3 == "refill" { n++ } END { print n + 0 }' "$drain_out")
+  [ "$refill_n" -eq 1 ] || fail "teardown-refill: expected one refill, got $refill_n: $(cat "$drain_out")"
+  grep -F 'refill: re-evaluate ready work against free capacity' "$drain_out" >/dev/null \
+    || fail "teardown-refill: refill payload missing"
+  leftover=$(FM_STATE_OVERRIDE="$case_dir/state" "$ROOT/bin/fm-wake-drain.sh" \
+    | awk -F '\t' 'NF == 5 { count++ } END { print count + 0 }')
+  [ "$leftover" -eq 0 ] || fail "teardown-refill: queue not empty after drain"
+  pass "successful teardown enqueues one refill wake that drain clears"
+}
+
 test_herdr_teardown_clears_escalation_marker() {
   local case_dir marker
   case_dir=$(make_case herdr-marker-cleanup)
@@ -2600,6 +2623,7 @@ test_no_mistakes_origin_remote_allows
 test_no_mistakes_truly_unpushed_refuses
 test_local_only_force_overrides_unpushed
 test_teardown_missing_busy_sidecar_completes
+test_teardown_enqueues_refill_wake
 test_herdr_teardown_clears_escalation_marker
 test_herdr_flat_teardown_refuses_orphaning_records_then_retry_completes
 test_herdr_flat_teardown_refuses_records_on_unparseable_presence

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -168,6 +168,10 @@ SH
   FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" || fail "drain after check wake failed"
   grep "$(printf '\tcheck\t')" "$drain_out" | grep -F "$check_file" | grep -F 'merged: https://example.test/pr/1' >/dev/null || fail "check wake was not queued"
   [ -e "$state/.last-check" ] || fail "check cadence marker was not written after queue append"
+  # Custom checks are not PR-poll artifacts: only exact PR-poll "merged" enqueues refill.
+  if awk -F '\t' '$3 == "refill" { found=1 } END { exit found ? 0 : 1 }' "$drain_out"; then
+    fail "custom check must not enqueue a refill wake: $(cat "$drain_out")"
+  fi
   pass "registered custom check output is queued before cadence suppression"
 }
 
@@ -210,6 +214,65 @@ test_drain_dedupes_obvious_duplicates() {
   grep "$(printf '\theartbeat\theartbeat\theartbeat')" "$out" >/dev/null || fail "heartbeat was not preserved"
   grep "$(printf '\tsignal\ttask.status\t')" "$out" | grep -F "$state/task.turn-ended" >/dev/null || fail "latest signal payload was not preserved"
   pass "drain collapses obvious duplicate heartbeat and signal records"
+}
+
+# Phase 2 refill: N capacity-freeing transitions before drain collapse to ONE
+# refill record; drain clears it; refill never replaces or reorders other kinds.
+test_drain_dedupes_refill_by_kind() {
+  local dir state out count refill_count leftover
+  dir=$(make_case refill-dedupe)
+  state="$dir/state"
+  out="$dir/drain.out"
+  append_wake "$state" refill refill "refill: re-evaluate ready work against free capacity" \
+    || fail "first refill append failed"
+  append_wake "$state" signal task.status "signal: $state/task.status" \
+    || fail "signal append failed"
+  append_wake "$state" refill refill "refill: re-evaluate ready work against free capacity" \
+    || fail "second refill append failed"
+  append_wake "$state" refill refill "refill: re-evaluate ready work against free capacity" \
+    || fail "third refill append failed"
+  append_wake "$state" stale 's:fm-task' 'stale: s:fm-task' \
+    || fail "stale append failed"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" || fail "refill dedupe drain failed"
+  count=$(awk -F '\t' 'NF == 5 { count++ } END { print count + 0 }' "$out")
+  [ "$count" -eq 3 ] || fail "expected 3 records (signal, one refill, stale), got $count"
+  refill_count=$(awk -F '\t' '$3 == "refill" { n++ } END { print n + 0 }' "$out")
+  [ "$refill_count" -eq 1 ] || fail "expected exactly one refill after dedupe, got $refill_count"
+  grep "$(printf '\tsignal\ttask.status\t')" "$out" >/dev/null || fail "signal was dropped by refill dedupe"
+  grep "$(printf '\tstale\t')" "$out" >/dev/null || fail "stale was dropped by refill dedupe"
+  # First non-refill kinds keep their relative order; refill sits where first seen.
+  awk -F '\t' '
+    NF == 5 {
+      order[++n] = $3
+    }
+    END {
+      if (n != 3) exit 1
+      # order of first occurrence: refill, signal, stale
+      if (order[1] != "refill" || order[2] != "signal" || order[3] != "stale") exit 2
+    }
+  ' "$out" || fail "refill reordered or replaced other wake kinds: $(cat "$out")"
+  leftover=$(FM_STATE_OVERRIDE="$state" "$DRAIN" | awk -F '\t' 'NF == 5 { count++ } END { print count + 0 }')
+  [ "$leftover" -eq 0 ] || fail "queue was not empty after draining refill"
+  pass "drain collapses N refill records to one and preserves other kinds"
+}
+
+test_refill_enqueue_helper_is_valid_kind() {
+  local dir state out count
+  dir=$(make_case refill-helper)
+  state="$dir/state"
+  out="$dir/drain.out"
+  FM_STATE_OVERRIDE="$state" bash -c '
+    # shellcheck disable=SC1090,SC1091
+    . "$1"
+    fm_wake_enqueue_refill
+    fm_wake_enqueue_refill
+  ' _ "$ROOT/bin/fm-wake-lib.sh" || fail "fm_wake_enqueue_refill failed"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" || fail "drain after helper failed"
+  count=$(awk -F '\t' '$3 == "refill" { n++ } END { print n + 0 }' "$out")
+  [ "$count" -eq 1 ] || fail "helper should leave one drained refill, got $count"
+  grep -F 'refill: re-evaluate ready work against free capacity' "$out" >/dev/null \
+    || fail "helper payload missing from drained refill"
+  pass "fm_wake_enqueue_refill is a valid kind and collapses on drain"
 }
 
 # The drain runs at the top of every wake-handling turn, so it also asserts
@@ -444,6 +507,8 @@ test_not_working_stale_enqueue_before_suppressor
 test_check_output_is_queued
 test_atomic_double_drain
 test_drain_dedupes_obvious_duplicates
+test_drain_dedupes_refill_by_kind
+test_refill_enqueue_helper_is_valid_kind
 test_drain_asserts_watcher_liveness
 test_structural_signal_enrichment_preserves_raw_rows
 test_enrichment_caps_and_status_file_failures

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -177,6 +177,15 @@ test_classifier_primitives() {
     || fail "done: not a terminal verb"
   status_is_terminal_verb "working: rebased onto merged #76" \
     && fail "working: wrongly classed as terminal verb"
+  # Capacity-freeing verbs for the Phase 2 refill wake: terminal + paused + resolved.
+  status_frees_capacity "done: ready in branch" || fail "done: does not free capacity"
+  status_frees_capacity "failed: tests red" || fail "failed: does not free capacity"
+  status_frees_capacity "blocked: needs credential" || fail "blocked: does not free capacity"
+  status_frees_capacity "paused: rate limit" || fail "paused: does not free capacity"
+  status_frees_capacity "needs-decision: pick A" || fail "needs-decision: does not free capacity"
+  status_frees_capacity "resolved [key=q1]: answered: use A" || fail "resolved: does not free capacity"
+  status_frees_capacity "working: implementing" && fail "working: wrongly frees capacity"
+  status_frees_capacity "captain-held [key=q1]: parked" && fail "captain-held: wrongly frees capacity"
   status_is_captain_relevant "merged" || fail "legacy bare merged free-text not captain-relevant"
   status_is_captain_relevant "PR ready https://x/pull/2" \
     || fail "legacy bare PR ready free-text not captain-relevant"
@@ -430,7 +439,105 @@ test_actionable_signal_surfaced() {
   FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain after the actionable signal failed"
   grep "$(printf '\tsignal\t')" "$drain_out" | grep -F "$status_file" >/dev/null || fail "actionable signal was not queued"
   [ -s "$state/.hb-surfaced-task" ] || fail "actionable signal did not record the surfaced marker"
+  # Capacity-freeing needs-decision also enqueues exactly one refill wake.
+  refill_n=$(awk -F '\t' '$3 == "refill" { n++ } END { print n + 0 }' "$drain_out")
+  [ "$refill_n" -eq 1 ] || fail "needs-decision signal should enqueue exactly one refill, got $refill_n"
   pass "captain-relevant signal is surfaced (queue + exit) and marked surfaced"
+}
+
+# Phase 2: capacity-freeing status transitions enqueue one refill; working does not.
+test_capacity_freeing_status_enqueues_refill() {
+  local dir state fakebin out drain_out status_file pid verb refill_n
+  # paused: is not captain-relevant; force not-provably-working so the path surfaces.
+  export FM_FAKE_CREW_STATE='state: unknown · source: none · fake default'
+  for verb in 'done: ready' 'failed: boom' 'blocked: wait' 'paused: external'; do
+    dir=$(make_case "refill-${verb%%:*}"); state="$dir/state"; fakebin="$dir/fakebin"
+    out="$dir/watch.out"; drain_out="$dir/drain.out"
+    status_file="$state/task.status"
+    printf '%s\n' "$verb" > "$status_file"
+    watch_bg "$state" "$fakebin" "$out"
+    pid=$!
+    wait_for_exit "$pid" 40 || fail "watcher did not exit for capacity-freeing status: $verb"
+    FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null \
+      || fail "drain failed after capacity-freeing status: $verb"
+    refill_n=$(awk -F '\t' '$3 == "refill" { n++ } END { print n + 0 }' "$drain_out")
+    [ "$refill_n" -eq 1 ] || fail "expected one refill for '$verb', got $refill_n: $(cat "$drain_out")"
+    grep -F 'refill: re-evaluate ready work against free capacity' "$drain_out" >/dev/null \
+      || fail "refill payload missing for '$verb'"
+  done
+  unset FM_FAKE_CREW_STATE
+  pass "capacity-freeing status verbs enqueue exactly one refill each"
+}
+
+test_working_status_does_not_enqueue_refill() {
+  local dir state fakebin out drain_out status_file pid
+  dir=$(make_case refill-working); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; drain_out="$dir/drain.out"
+  status_file="$state/task.status"
+  printf 'working: implementing the fix\n' > "$status_file"
+  # Not provably working so the signal surfaces (not absorbed) - still no refill.
+  export FM_FAKE_CREW_STATE='state: unknown · source: none · fake default'
+  watch_bg "$state" "$fakebin" "$out"
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "watcher did not exit for non-working working: note"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null \
+    || fail "drain after working: note failed"
+  if awk -F '\t' '$3 == "refill" { found=1 } END { exit found ? 0 : 1 }' "$drain_out"; then
+    fail "working: status must not enqueue a refill: $(cat "$drain_out")"
+  fi
+  unset FM_FAKE_CREW_STATE
+  pass "working status does not enqueue a refill wake"
+}
+
+test_resolved_while_working_enqueues_refill_only() {
+  local dir state fakebin out drain_out status_file pid refill_n signal_n
+  dir=$(make_case refill-resolved); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; drain_out="$dir/drain.out"
+  status_file="$state/task.status"
+  printf 'needs-decision [key=q1]: pick A\nresolved [key=q1]: answered: use A\n' > "$status_file"
+  # Crew is still working after the decision was closed - signal is absorbed,
+  # but refill must still surface so firstmate re-evaluates capacity.
+  export FM_FAKE_CREW_STATE='state: working · source: run-step · running'
+  watch_bg "$state" "$fakebin" "$out"
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "watcher did not exit for resolved-while-working refill"
+  grep -F 'refill: re-evaluate ready work against free capacity' "$out" >/dev/null \
+    || fail "watcher did not print the refill reason for resolved-while-working"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null \
+    || fail "drain after resolved-while-working failed"
+  refill_n=$(awk -F '\t' '$3 == "refill" { n++ } END { print n + 0 }' "$drain_out")
+  [ "$refill_n" -eq 1 ] || fail "expected one refill for resolved-while-working, got $refill_n"
+  signal_n=$(awk -F '\t' '$3 == "signal" { n++ } END { print n + 0 }' "$drain_out")
+  [ "$signal_n" -eq 0 ] || fail "resolved-while-working should absorb signal and surface refill only, got $signal_n signals"
+  unset FM_FAKE_CREW_STATE
+  pass "resolved while working enqueues refill without a signal wake"
+}
+
+test_n_capacity_transitions_collapse_to_one_refill() {
+  local dir state fakebin out drain_out pid refill_n i
+  dir=$(make_case refill-collapse); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; drain_out="$dir/drain.out"
+  # Three tasks free capacity before any drain: watcher exits on the first, but
+  # append three refills directly then drain to pin the queue-side collapse.
+  # Behavioral watcher path: first done: wakes with signal+refill; remaining
+  # transitions are simulated via the production enqueue helper while the first
+  # refill is still queued.
+  printf 'done: first\n' > "$state/a.status"
+  watch_bg "$state" "$fakebin" "$out"
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "watcher did not exit for first capacity-freeing transition"
+  # Two more capacity-freeing transitions land before firstmate drains.
+  i=0
+  while [ "$i" -lt 2 ]; do
+    FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_wake_enqueue_refill' _ "$ROOT/bin/fm-wake-lib.sh" \
+      || fail "extra refill enqueue failed"
+    i=$((i + 1))
+  done
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null \
+    || fail "drain after N capacity transitions failed"
+  refill_n=$(awk -F '\t' '$3 == "refill" { n++ } END { print n + 0 }' "$drain_out")
+  [ "$refill_n" -eq 1 ] || fail "N transitions before drain must collapse to one refill, got $refill_n"
+  pass "N capacity-freeing transitions before drain collapse to one refill"
 }
 
 test_terminal_stale_surfaced() {
@@ -1812,6 +1919,10 @@ test_turn_ended_provably_working_absorbed
 test_turn_ended_not_working_surfaced
 test_working_note_not_working_surfaced
 test_actionable_signal_surfaced
+test_capacity_freeing_status_enqueues_refill
+test_working_status_does_not_enqueue_refill
+test_resolved_while_working_enqueues_refill_only
+test_n_capacity_transitions_collapse_to_one_refill
 test_terminal_stale_surfaced
 test_stale_terminal_status_overridden_by_active_run
 test_nonterminal_stale_provably_working_absorbed_then_escalated


### PR DESCRIPTION
## Summary

Phase 2 of the staged parallelism fix (see `data/fm-parallelism-root-cause/report.md` §11, §13, §17).

After capacity-freeing lifecycle transitions, the fleet now enqueues **one idempotent advisory `refill` wake** so firstmate re-evaluates ready work against free capacity - without the captain having to introduce work or challenge an idle lane.

This does **not** spawn, select, or recommend specific tasks. Firstmate remains the decision-maker and continues to dispatch through existing lifecycle owners. Phase 0 (focus lifecycle) is intentionally not built.

## What changed

### New wake kind: `refill`

- Owned by `bin/fm-wake-lib.sh`:
  - Valid kind in `fm_wake_append` / `fm_wake_queued_keys`
  - `fm_wake_enqueue_refill` helper with stable payload: `refill: re-evaluate ready work against free capacity`
  - Drain dedupes by kind (like `heartbeat`): N transitions before drain collapse to **one** queued refill record
  - Refill never replaces or reorders other wake kinds

### Capacity-freeing detection

- `status_frees_capacity` in `bin/fm-classify-lib.sh` matches:
  - `done` / `failed` / `blocked` / `paused` / `needs-decision` / `resolved`
  - Explicitly **not** `working` or other nonterminal progress

### Enqueue sites (deliberately minimal)

1. **Status transitions** (`bin/fm-watch.sh` signal path) - capacity-freeing last line enqueues refill; resolved-while-working still wakes with refill even when the signal is absorbed
2. **Merged PR poll** (`bin/fm-watch.sh` check path) - exact PR-poll `merged` result enqueues refill
3. **Teardown completion** (`bin/fm-teardown.sh` local and remote success paths)

**Follow-ups (explicitly skipped):** provider-reset and Playbot-settled triggers.

### Supervision contract

- `AGENTS.md` §8: one new handling line for `refill:` (re-evaluate ready work against free capacity via structured fleet view; advisory only)
- Away-mode daemon recognizes `refill:` and escalates it to the primary for re-evaluation (never spawns itself)
- Supervision protocol lists updated to include the kind

## Tests

Extended existing suites (no new runners):

- `tests/fm-wake-queue.test.sh` - N refills collapse to one; helper valid; other kinds preserved; custom checks do not enqueue refill
- `tests/fm-watch-triage.test.sh` - capacity-freeing verbs enqueue one refill; working does not; resolved-while-working surfaces refill only; N transitions collapse
- `tests/fm-teardown.test.sh` - successful teardown enqueues one refill; drain clears it

## Verification

```bash
bin/fm-lint.sh
tests/fm-wake-queue.test.sh
tests/fm-watch-triage.test.sh
# teardown suite: test_teardown_enqueues_refill_wake (and full suite)
```

## Delivery notes

- Branch: `fm/fm-refill-wake-phase2`
- Phase 1 already shipped as `bin/fm-fleet-snapshot.sh` (`fm-fleet-snapshot.v1`); Phase 3 is effectively the heartbeat/bearings structured fleet view
