### PR TITLE
chore: ignore playwright-cli cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__/
 *.pyc
 .env
 config/
+/.playwright-cli/


### PR DESCRIPTION
## Intent

Ship a single small change to the firstmate repo: add one line /.playwright-cli/ to the root .gitignore, so the playwright-cli tool log cache that pollutes the working tree is ignored (the files are kept, just untracked). The automating-dia-browser skill that was originally part of this PR was dropped by explicit captain decision: it is captain-private and was relocated to the global user-level skills directory, so it does not belong in this repo's public template surface. Touch nothing else in the repo. Run the full no-mistakes pipeline to a PR on the firstmate repo with green CI and report the PR URL.

## What Changed
- Add `/.playwright-cli/` to the root `.gitignore` so the playwright-cli tool's local log cache stops being tracked as untracked dirty entries in the working tree (files remain on disk, just untracked).

## Risk Assessment

✅ Low: The change is a single, minimal `.gitignore` entry that is correctly anchored to the repo root, matches the stated user intent exactly, and touches no other files in the repository.

## Testing

`Targeted validation of the .gitignore change at commit c3790c5. Used git itself as the real consumer of the declarative artifact: created .playwright-cli/ and subdir/.playwright-cli/ in the worktree, asserted via git check-ignore -v that files and the directory under <root>/.playwright-cli/ are matched by line 13, nested paths are not (root anchoring works), and git status --ignored reports the directory as Ignored rather than Untracked. Parsed .gitignore into a normalized semantic model rather than relying on raw substring matches. Confirmed via the existing tests/fm-gitignore-config.test.sh that the new entry does not break the pre-existing config/ rule. Verified the diff touches only .gitignore (+1 line), no files were deleted, and no skills/automating-dia-browser/ was reintroduced. All cleanup performed; worktree is clean.`

<details>
<summary>Evidence: gitignore behavior evidence (semantic parse + git check-ignore output + acceptance checklist)</summary>

```text
Targeted validation evidence for /playwright-cli/ .gitignore entry
=================================================================

Repo path: /Users/msoup/.no-mistakes/worktrees/9820a5ae57e6/01KZN2D7P1EFRHA2GVGAK2QCZE
Base commit:    85e750ab9b76df275c1f6b9e2bc95b671955bae9
Target commit:  c3790c58bc38eafd8e971e9793ed42e431b66aa4
Diffstat:       M .gitignore  (+1 line, no other files touched)

Parsed .gitignore semantic model
--------------------------------
line=1  anchored=no  dir-only=yes  pattern=projects
line=2  anchored=no  dir-only=yes  pattern=state
line=3  anchored=no  dir-only=yes  pattern=data
line=4  anchored=no  dir-only=yes  pattern=.no-mistakes
line=5  anchored=no  dir-only=yes  pattern=.lavish
line=6  anchored=no  dir-only=no  pattern=.fm-secondmate-home
line=7  anchored=no  dir-only=no  pattern=.fm-secondmate-parent
line=8  anchored=no  dir-only=no  pattern=.DS_Store
line=9  anchored=no  dir-only=yes  pattern=__pycache__
line=10 anchored=no  dir-only=no  pattern=*.pyc
line=11 anchored=no  dir-only=no  pattern=.env
line=12 anchored=no  dir-only=yes  pattern=config
line=13 anchored=yes  dir-only=yes  pattern=.playwright-cli   <-- NEW

Real-consumer test (git check-ignore)
-------------------------------------
$ mkdir -p .playwright-cli subdir/.playwright-cli
$ touch .playwright-cli/some-cache.log .playwright-cli/screenshot.png subdir/.playwright-cli/cache.log

$ git check-ignore -v .playwright-cli/some-cache.log
.gitignore:13:/.playwright-cli/    .playwright-cli/some-cache.log

$ git check-ignore -v .playwright-cli/screenshot.png
.gitignore:13:/.playwright-cli/    .playwright-cli/screenshot.png

$ git check-ignore -v .playwright-cli
.gitignore:13:/.playwright-cli/    .playwright-cli

$ git check-ignore -v subdir/.playwright-cli/cache.log
$ echo $?
1                       <-- exit=1 means NOT ignored (anchored to root, not nested)

$ git status --ignored
Ignored files:
  (use "git add -f <file>..." to include in what will be committed)
        .playwright-cli/

$ rm -rf .playwright-cli subdir/.playwright-cli

Acceptance-criteria checklist
-----------------------------
[done] ONLY .gitignore is modified (git diff --name-only reports 1 file)
[done] Pattern is /.playwright-cli/ (anchored to repo root, trailing / makes it dir-only)
[done] Files at <root>/.playwright-cli/ are reported as ignored by git
[done] Directory <root>/.playwright-cli/ is reported as ignored by git
[done] Nested paths like subdir/.playwright-cli/ are NOT ignored (anchoring works)
[done] "git status --ignored" lists .playwright-cli/ under Ignored files, not as untracked
[done] No files were deleted (intake intent: "files are kept, just untracked")
[done] NO skills/, no automating-dia-browser/, no other files added or modified
[done] Existing .gitignore test still passes:
        ok - config/ is ignored as a directory, covering unlisted and nested paths
        ok - an unrelated path outside config/ remains visible to git
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c3790c58bc38eafd8e971e9793ed42e431b66aa4","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --name-only 85e750ab..c3790c5 (single file changed: .gitignore)`
- `git diff 85e750ab..c3790c5 (one-line addition at line 13 of .gitignore)`
- `awk-based semantic parser of .gitignore showing line 13 = anchored=yes, dir-only=yes, pattern=.playwright-cli`
- `git check-ignore -v .playwright-cli/some-cache.log (matched by .gitignore:13:/.playwright-cli/)`
- `git check-ignore -v .playwright-cli/screenshot.png (matched)`
- `git check-ignore -v .playwright-cli (directory itself matched)`
- `git check-ignore -v subdir/.playwright-cli/cache.log (NOT matched, exit=1, confirming root anchoring)`
- `git status --ignored on a tree with .playwright-cli/ created (.playwright-cli/ listed under Ignored files)`
- `ls skills/ before/after to confirm automating-dia-browser was not added`
- `bash tests/fm-gitignore-config.test.sh (existing config/ regression still green)`
- `Cleanup: rm -rf .playwright-cli subdir/.playwright-cli; git status clean`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
