### PR TITLE
fix: surface local secondmate watcher lapses

### DIFF
--- a/bin/fm-guard.sh
+++ b/bin/fm-guard.sh
@@ -30,9 +30,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 WATCH="$SCRIPT_DIR/fm-watch.sh"
 GRACE=${FM_GUARD_GRACE:-300}
+SECOND_MATE_WATCHER_GRACE=${FM_SECOND_MATE_WATCHER_GRACE:-900}
+case "$SECOND_MATE_WATCHER_GRACE" in ''|*[!0-9]*|0) SECOND_MATE_WATCHER_GRACE=900 ;; esac
 queue_pending=false
 READ_ONLY=${FM_GUARD_READ_ONLY:-0}
 case "$READ_ONLY" in 1|true|TRUE|yes|YES) READ_ONLY=1 ;; *) READ_ONLY=0 ;; esac
@@ -117,6 +120,27 @@ fm_guard_clear_stale_banner() {
   rm -f "$STALE_BANNER_MARKER" 2>/dev/null || true
 }
 
+fm_guard_report_secondmate_watchers() {
+  local id status age _token
+  while IFS=$(printf '\t') read -r id status age _token; do
+    [ -n "$id" ] || continue
+    case "$status" in
+      stale)
+        printf '●  SUPERVISION ALARM - SECONDMATE WATCHER STALE - %s: last beat %ss ago (threshold %ss).\n' \
+          "$id" "$age" "$SECOND_MATE_WATCHER_GRACE"
+        ;;
+      missing)
+        printf '●  SUPERVISION ALARM - SECONDMATE WATCHER MISSING - %s: no heartbeat exists (threshold %ss).\n' \
+          "$id" "$SECOND_MATE_WATCHER_GRACE"
+        ;;
+      unreadable)
+        printf '●  SUPERVISION ALARM - SECONDMATE WATCHER UNREADABLE - %s: heartbeat age is unavailable (threshold %ss).\n' \
+          "$id" "$SECOND_MATE_WATCHER_GRACE"
+        ;;
+    esac
+  done < <(fm_secondmate_watcher_statuses "$DATA/secondmates.md" "$SECOND_MATE_WATCHER_GRACE")
+}
+
 # Worktree-tangle alarm, checked FIRST and independent of in-flight tasks: the
 # firstmate PRIMARY checkout (FM_ROOT) must stay on its default branch. If a
 # crewmate's branch/commits landed here instead of in its own isolated worktree,
@@ -147,6 +171,7 @@ fi
 # Compute supervision need and watcher-beacon freshness via the shared
 # grace-based predicate (bin/fm-supervision-lib.sh). Act when work, an event
 # source, or an X-mode relay poll needs supervision.
+fm_guard_report_secondmate_watchers >&2
 fm_supervision_status "$STATE" "$GRACE"
 in_flight=$FM_SUP_IN_FLIGHT
 sources=$FM_SUP_SOURCES

--- a/bin/fm-guard.sh
+++ b/bin/fm-guard.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# Watcher liveness and worktree-tangle guard, called by supervision scripts, by
-# fm-wake-drain.sh after it empties queued wakes, and by fm-session-start.sh in
-# read-only advisory mode whenever session-lock ownership was not verified.
+# Primary and registered-local-secondmate watcher liveness plus worktree-tangle
+# guard, called by supervision scripts, by fm-wake-drain.sh after it empties
+# queued wakes, and by fm-session-start.sh in read-only advisory mode whenever
+# session-lock ownership was not verified.
 # First, always warn if the firstmate primary checkout (FM_ROOT) is on a named
 # non-default branch, because that means firstmate-on-itself work landed in the
 # primary instead of an isolated worktree.
@@ -21,9 +22,12 @@
 # later guarded commands in the same episode print a one-line reminder instead.
 # Episode state lives only under state/.guard-watcher-stale-banner (volatile,
 # bounded). Independent alarms (queued wakes, worktree tangle) are never
-# suppressed by that dedup. Normal wake handling (watcher briefly down between a
-# wake and the next supervision resume) stays inside the grace window and stays
-# silent. Always exits 0: the guard warns, it never blocks.
+# suppressed by that dedup. Registered local secondmate homes are also scanned
+# for a stale, missing, or unreadable watcher beat under their separate grace;
+# remote routes are skipped so this guard remains network-free. Normal wake
+# handling (watcher briefly down between a wake and the next supervision resume)
+# stays inside the grace window and stays silent. Always exits 0: the guard
+# warns, it never blocks.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/bin/fm-supervision-lib.sh
+++ b/bin/fm-supervision-lib.sh
@@ -14,11 +14,6 @@
 # identity-matched watcher is still required. The status fields here retain the
 # beacon-age details used in their messages.
 
-FM_SUPERVISION_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-# shellcheck source=bin/fm-secondmate-registry-lib.sh
-. "$FM_SUPERVISION_LIB_DIR/fm-secondmate-registry-lib.sh"
-
 # Portable mtime; Linux stat lacks -f, macOS stat lacks -c.
 fm_sup_stat_mtime() {
   if [ "$(uname)" = Darwin ]; then
@@ -106,10 +101,13 @@ fm_supervision_unhealthy() {
 # skipped here rather than guessed around. The default grace is 900 seconds.
 fm_secondmate_watcher_statuses() {
   local registry=$1 grace=${2:-${FM_SECOND_MATE_WATCHER_GRACE:-900}}
-  local now line id home beat reference m age
+  local supervision_lib_dir now line id home beat reference m age
 
   case "$grace" in ''|*[!0-9]*|0) grace=900 ;; esac
   [ -f "$registry" ] && [ ! -L "$registry" ] || return 0
+  supervision_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # shellcheck source=bin/fm-secondmate-registry-lib.sh
+  . "$supervision_lib_dir/fm-secondmate-registry-lib.sh"
   now=$(date +%s)
 
   while IFS= read -r line || [ -n "$line" ]; do

--- a/bin/fm-supervision-lib.sh
+++ b/bin/fm-supervision-lib.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-# Shared "supervision missing" predicate.
+# Shared home and registered-secondmate watcher-liveness predicates.
 # Usage: . bin/fm-supervision-lib.sh
 #
 # Reports whether a firstmate home needs supervision because it has in-flight
@@ -13,6 +13,11 @@
 # with no live watcher is healthy; under persistent-watcher harnesses a live
 # identity-matched watcher is still required. The status fields here retain the
 # beacon-age details used in their messages.
+
+FM_SUPERVISION_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=bin/fm-secondmate-registry-lib.sh
+. "$FM_SUPERVISION_LIB_DIR/fm-secondmate-registry-lib.sh"
 
 # Portable mtime; Linux stat lacks -f, macOS stat lacks -c.
 fm_sup_stat_mtime() {
@@ -89,4 +94,67 @@ fm_supervision_needed() {
 fm_supervision_unhealthy() {
   fm_supervision_status "$@"
   [ "$FM_SUP_NEEDED" = true ] && [ "$FM_SUP_WATCHER_FRESH" = false ]
+}
+
+# fm_secondmate_watcher_statuses <registry> [grace-seconds]
+# Prints one tab-separated row for each registered LOCAL secondmate:
+#   <id><TAB><fresh|starting|stale|missing|unreadable><TAB><age|unknown><TAB><episode-token>
+# Remote homes are deliberately skipped: watcher/session-start liveness checks
+# stay local and never add an SSH/network call to the supervision loop or the
+# session-start blocking path. Invalid registry records are already diagnosed by
+# bootstrap's registry validation and cannot safely name a home, so they are
+# skipped here rather than guessed around. The default grace is 900 seconds.
+fm_secondmate_watcher_statuses() {
+  local registry=$1 grace=${2:-${FM_SECOND_MATE_WATCHER_GRACE:-900}}
+  local now line id home beat reference m age
+
+  case "$grace" in ''|*[!0-9]*|0) grace=900 ;; esac
+  [ -f "$registry" ] && [ ! -L "$registry" ] || return 0
+  now=$(date +%s)
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in '- '*) ;; *) continue ;; esac
+    secondmate_registry_parse_line "$line" || continue
+    [ "$SECONDMATE_REGISTRY_REMOTE" -eq 0 ] || continue
+    id=$SECONDMATE_REGISTRY_ID
+    home=$SECONDMATE_REGISTRY_HOME
+    case "$home" in /*) ;; *) continue ;; esac
+
+    beat="$home/state/.last-watcher-beat"
+    if [ ! -e "$beat" ]; then
+      reference="$home/.fm-secondmate-home"
+      if [ ! -f "$reference" ] || [ -L "$reference" ]; then
+        reference=$registry
+      fi
+      m=$(fm_sup_stat_mtime "$reference")
+      case "$m" in
+        ''|*[!0-9]*)
+          printf '%s\tunreadable\tunknown\tunreadable\n' "$id"
+          continue
+          ;;
+      esac
+      age=$((now - m))
+      [ "$age" -ge 0 ] || age=0
+      if [ "$age" -ge "$grace" ]; then
+        printf '%s\tmissing\t%s\tmissing-%s\n' "$id" "$age" "$m"
+      else
+        printf '%s\tstarting\t%s\tmissing-%s\n' "$id" "$age" "$m"
+      fi
+      continue
+    fi
+    m=$(fm_sup_stat_mtime "$beat")
+    case "$m" in
+      ''|*[!0-9]*)
+        printf '%s\tunreadable\tunknown\tunreadable\n' "$id"
+        continue
+        ;;
+    esac
+    age=$((now - m))
+    [ "$age" -ge 0 ] || age=0
+    if [ "$age" -ge "$grace" ]; then
+      printf '%s\tstale\t%s\tmtime-%s\n' "$id" "$age" "$m"
+    else
+      printf '%s\tfresh\t%s\tmtime-%s\n' "$id" "$age" "$m"
+    fi
+  done < "$registry"
 }

--- a/bin/fm-wake-drain.sh
+++ b/bin/fm-wake-drain.sh
@@ -38,11 +38,12 @@ esac
 # every wake-handling and recovery turn, so assert supervision health here too. A
 # lapsed supervision chain then surfaces on a plain drain-and-handle turn, not
 # only when a guarded supervision script (fm-peek/fm-send/...) happens to run.
-# Reuse fm-guard.sh's model-aware alarm and FM_GUARD_GRACE instead of duplicating
-# its supervision verdict. Under Claude's between-turns auto-arm model, a normal
-# fire leaves a recent beacon well inside grace and stays silent mid-turn. Under
-# persistent-watcher models, the guard also requires the live identity-matched
-# watcher. Never let a guard hiccup change the drain's exit status.
+# Reuse fm-guard.sh's model-aware primary verdict and registered-secondmate
+# liveness scan instead of duplicating either predicate. Under Claude's
+# between-turns auto-arm model, a normal fire leaves a recent primary beacon well
+# inside FM_GUARD_GRACE and stays silent mid-turn. Under persistent-watcher
+# models, the primary verdict also requires the live identity-matched watcher.
+# Never let a guard hiccup change the drain's exit status.
 assert_watcher_liveness() {
   "$SCRIPT_DIR/fm-guard.sh" || true
 }

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -46,6 +46,9 @@
 #                          and has not been surfaced yet; reported once per
 #                          captured generation, never again while that record
 #                          stays queued and never once it is acknowledged
+#   check: secondmate watcher <state>: <id> (...)
+#                          a registered local secondmate's watcher heartbeat is
+#                          stale, missing, or unreadable; one wake per lapse
 #   check: rejected unauthenticated state checks: <paths>
 #                          unsafe state checks were refused without execution
 #   check: rejected unauthenticated PR poll retirement receipts: <paths>
@@ -62,6 +65,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 mkdir -p "$STATE"
 
 # The native event fast-path and only its true dependencies have one narrow
@@ -85,6 +89,10 @@ mkdir -p "$STATE"
 . "$SCRIPT_DIR/fm-pending-reply-lib.sh"
 # shellcheck source=bin/fm-busy-lib.sh
 . "$SCRIPT_DIR/fm-busy-lib.sh"
+# Shared registered-secondmate heartbeat scan. This is independent of ordinary
+# worker status/pane classification and performs no remote/network probes.
+# shellcheck source=bin/fm-supervision-lib.sh
+. "$SCRIPT_DIR/fm-supervision-lib.sh"
 
 WATCH_LOCK="$STATE/.watch.lock"
 WATCH_PATH="$SCRIPT_DIR/fm-watch.sh"
@@ -117,6 +125,8 @@ HEARTBEAT=${FM_HEARTBEAT:-600}        # base seconds between heartbeat scans
 HEARTBEAT_MAX=${FM_HEARTBEAT_MAX:-7200}  # heartbeat backoff cap
 CHECK_INTERVAL=${FM_CHECK_INTERVAL:-300}  # seconds between *.check.sh sweeps
 CHECK_TIMEOUT=${FM_CHECK_TIMEOUT:-30}     # seconds allowed per *.check.sh
+SECOND_MATE_WATCHER_GRACE=${FM_SECOND_MATE_WATCHER_GRACE:-900}
+case "$SECOND_MATE_WATCHER_GRACE" in ''|*[!0-9]*|0) SECOND_MATE_WATCHER_GRACE=900 ;; esac
 SIGNAL_GRACE=${FM_SIGNAL_GRACE:-30}   # seconds to linger after a signal so trailing
                                       # signals (a status write, then the same turn's
                                       # turn-end hook) coalesce into one wake
@@ -513,6 +523,42 @@ procevent_surface_queued() {
   wake "$reason"
 }
 
+# Parent-side liveness for persistent local secondmates. A .seen-* marker keeps
+# one unchanged stale/missing episode from making every re-arm exit immediately;
+# a fresh heartbeat clears it so the next lapse surfaces again. Enqueue precedes
+# suppression, preserving the watcher rule that a crash may duplicate an alarm
+# but cannot silently lose it. Remote homes remain on their existing registered
+# status/reply and startup-network paths because this poll is strictly local.
+scan_secondmate_watchers() {
+  local id status age token marker seen reason
+  while IFS=$(printf '\t') read -r id status age token; do
+    [ -n "$id" ] || continue
+    marker="$STATE/.seen-secondmate-watcher-$id"
+    if [ "$status" = fresh ] || [ "$status" = starting ]; then
+      rm -f "$marker" 2>/dev/null || true
+      continue
+    fi
+    seen=$(cat "$marker" 2>/dev/null || true)
+    [ "$seen" != "$token" ] || continue
+    case "$status" in
+      stale)
+        reason="check: secondmate watcher stale: $id (last beat ${age}s ago; threshold ${SECOND_MATE_WATCHER_GRACE}s)"
+        ;;
+      missing)
+        reason="check: secondmate watcher missing: $id (no heartbeat for ${age}s; threshold ${SECOND_MATE_WATCHER_GRACE}s)"
+        ;;
+      unreadable)
+        reason="check: secondmate watcher unreadable: $id (heartbeat age unavailable; threshold ${SECOND_MATE_WATCHER_GRACE}s)"
+        ;;
+      *) continue ;;
+    esac
+    fm_wake_append check "secondmate-watcher:$id" "$reason" || exit 1
+    printf '%s\n' "$token" > "$marker" 2>/dev/null \
+      || triage_log "could not record secondmate watcher alarm suppression for $id"
+    wake "$reason"
+  done < <(fm_secondmate_watcher_statuses "$DATA/secondmates.md" "$SECOND_MATE_WATCHER_GRACE")
+}
+
 run_check_process() {
   local c=$1
   shift
@@ -834,6 +880,11 @@ while :; do
   # Liveness beacon for fm-guard.sh: a fresh mtime here means a watcher is
   # alive. Supervision scripts warn when this goes stale with tasks in flight.
   touch "$STATE/.last-watcher-beat"
+
+  # A persistent secondmate can remain process-alive while its own watcher has
+  # stopped. Its local heartbeat is the parent-visible supervision signal; this
+  # check is separate from and does not alter ordinary worker classification.
+  scan_secondmate_watchers
 
   # Parent-owned secondmate pending-reply reconciliation: resolve correlated
   # parent reports, observe backend busy/idle turn completion, send one recovery

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,6 +21,10 @@ No-verb wakes, such as `working:` notes and bare turn-ended signals, are benign 
 A crew that declares `paused:` for a known external wait is separately absorbed while idle and re-surfaced only on the longer pause cadence, rather than being treated as a possible wedge.
 For an ordinary crew that has stopped, the normal-mode watcher first surfaces one stale wake, then applies that same cadence to an unchanged `paused:` or durable `captain-held` endpoint only when the backend confidently reports its agent dead.
 Live or inconclusive liveness remains fail-open at that initial surface, and the secondmate idle-endpoint exemption is unchanged.
+Independently of ordinary worker and idle-secondmate pane classification, the parent watcher scans each registered local secondmate home's `state/.last-watcher-beat`.
+Newly seeded homes receive a 900-second first-heartbeat grace, existing beats become stale at the same threshold, and an unreadable heartbeat age alarms instead of being treated as fresh.
+The watcher queues one named `check: secondmate watcher ...` wake per unchanged lapse, clears that suppression after a fresh or startup-grace state, and skips remote routes so the local poll never performs network I/O.
+The pull guard runs the shared scan during locked wake drain and read-only session start, printing the current named alarm independently of ordinary primary-watcher health.
 Its initial normal-mode status signal still surfaces through the no-verb path, while away mode self-handles that routine signal and owns the later recheck.
 Fresh stale panes use the same current-state read before trusting the status log, so an active run or a proven busy worker outranks an old captain-relevant status-log line left behind before validation.
 No-change heartbeats are also benign.
@@ -67,7 +71,7 @@ It suppresses failed-looking closes when the same identity-matched watcher is he
 [`watcher-continuity.md`](watcher-continuity.md) owns Claude's residual active-turn coverage and watcher-status command-gating boundary.
 The existing turn-end guard remains the final backstop for all five harness-engine protocols, with pi-signed sharing Pi's protocol and the `--claude` mode cooperating with the auto-arm claim.
 Its `--restart` mode signals only the watcher recorded in the current home's `state/.watch.lock`, so restarting one home cannot kill sibling secondmate watchers.
-A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if the primary checkout is tangled, if work, process-event sources, or Relay polling has an unhealthy model-aware supervision verdict, or if queued wakes are waiting to be drained.
+A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if the primary checkout is tangled, if work, process-event sources, or Relay polling has an unhealthy model-aware supervision verdict, if a registered local secondmate watcher is unhealthy, or if queued wakes are waiting to be drained.
 The drain script calls that guard after presenting the queue; records remain durable, and may keep the queued-wakes warning visible, until the exact generation-bound acknowledgement printed by the drain succeeds after handling.
 It leads with a prominent bordered tangle banner, while `bin/fm-guard.sh` owns the watcher-down banner and reminder policy so repeated guarded commands stay noisy without reprinting the full banner in the same episode.
 On every verified primary harness, tracked hook integration gives the primary session a push-based backstop: when work, a process-event source, or Relay polling needs supervision and no identity-matched watcher lock with a fresh beacon is live, direct Stop hooks block and passive turn-end hooks force one bounded follow-up.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -551,6 +551,7 @@ FMX_FOLLOWUP_MAX_COUNT=3   # local cap on Relay completion follow-ups per linked
 FM_PF_RETRY_BACKOFF_SECS=900   # seconds before the next attempt after a retryable promised-public-reply delivery error
 FM_LOCK_STALE_AFTER=2   # seconds before dead-pid lock records can be reclaimed; mid-acquire locks keep at least 2s grace
 FM_GUARD_GRACE=300      # seconds before guard warnings, arm health checks, and the primary turn-end guard treat a watcher beacon as stale
+FM_SECOND_MATE_WATCHER_GRACE=900   # seconds before a registered local secondmate beat is stale or its first missing beat alarms; remote routes are not polled
 FM_CLAUDE_AUTOARM_ATTEMPTS=2   # bounded Stop-owned arm attempts per Claude auto-arm cycle; accepted values are 1, 2, or 3
 FM_CLAUDE_AUTOARM_SYNC_WAIT_MS=800   # milliseconds the --claude turn-end guard waits for watcher health, a role-verified Stop auto-arm claim, or a fresh epoch before deciding recovery ownership or failure progression
 FM_CLAUDE_AUTOARM_EPOCH_FRESH=15   # seconds a recorded auto-arm outcome remains eligible for the current event epoch's recovery or failure decision

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -80,7 +80,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification          |
 | `fm-timeout-lib.sh`      | Single owner of hard-bounded command execution and its fallback watchdog |
 | `fm-timing-lib.sh`       | Single owner of the deferred network stage's per-step elapsed-time records, inert unless a run asks for them |
-| `fm-supervision-lib.sh`  | Shared in-flight-work-without-fresh-watcher-beacon predicate                         |
+| `fm-supervision-lib.sh`  | Compute home and registered-local-secondmate watcher-liveness predicates             |
 | `fm-ff-lib.sh`           | Shared guarded fast-forward helper for origin pulls and local secondmate syncs       |
 | `fm-lock-lib.sh`         | Shared "is this git lock provably abandoned?" proof used by teardown and fleet-sync   |
 | `fm-config-inherit-lib.sh` | Shared primary-to-secondmate inherited local-material propagation and config-reread delivery |

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -12,6 +12,7 @@ Do not infer this guard's scope, loop safety, or compatibility tradeoffs for tho
 ## Current invariant
 
 `bin/fm-guard.sh` is a pull-based warning that runs only when another supervision command invokes it.
+Separately from the primary turn-end predicate, that pull guard also prints registered-local-secondmate watcher alarms through locked wake drain and read-only session start; [`architecture.md`](architecture.md#event-driven-supervision) owns the shared scan contract, and [`configuration.md`](configuration.md#environment-variables) owns its separate grace setting.
 The turn-end guard closes the remaining gap at the primary's own turn boundary.
 When work, a process-event source, or Relay polling needs supervision at that boundary and no identity-matched watcher has a fresh beacon, the harness integration must either block the turn end or force one bounded follow-up that uses the recovery instruction from the emitted session-start protocol.
 The mid-turn pull warning uses the model-aware supervision verdict described below, while the turn-end guard keeps the PID-strict watcher predicate.
@@ -97,6 +98,7 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 
 - Child crewmate and scout worktrees are outside scope.
 - A valid secondmate home is in scope; an idle secondmate endpoint with no Relay poll remains healthy because it has no supervision need.
+- That endpoint-idle verdict does not suppress the parent home's separate registered-local watcher scan; [`architecture.md`](architecture.md#event-driven-supervision) owns that boundary.
 - The direct-blocking and bounded passive-follow-up split is limited to the primary integrations listed above.
 - OpenCode headless mode and untrusted Grok project hooks remain fail-open at the host boundary.
 - Kimi Code CLI 0.29.1 exposes only global `[[hooks]]` configuration in `~/.kimi-code/config.toml`, including a `Stop` event with snake_case payload fields `hook_event_name`, `session_id`, `cwd`, and `stop_hook_active`.
@@ -111,7 +113,7 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 ## Regression coverage
 
 `tests/fm-turnend-guard.test.sh` covers the predicate, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the live-lock and fresh-beacon guard predicate, the cooperative `--claude` claim wait, monotonic failed-epoch progression, bounded attended fail-open, post-alarm continuation suppression, positive recovery reset, Pi logical-run latching, missing-`jq` behavior, all five primary registrations, Grok native and legacy selection, typed field precedence, malformed input, and exactly-one-path safety.
-`tests/fm-guard-stale-banner.test.sh` covers the pull-guard predicate, including the persistent-model fresh-leftover-beacon negative control, the auto-arm model's healthy fresh-beacon-without-a-watcher case and its stale-beacon alarm, the true-reason banner wording, and the reason-keyed episode dedup surviving a beacon mtime change.
+`tests/fm-guard-stale-banner.test.sh` covers the pull-guard predicate, including the persistent-model fresh-leftover-beacon negative control, the auto-arm model's healthy fresh-beacon-without-a-watcher case and its stale-beacon alarm, the true-reason banner wording, the reason-keyed episode dedup surviving a beacon mtime change, and a named stale registered-secondmate alarm that does not misclassify the healthy parent watcher.
 `tests/fm-kimi-harness.test.sh` covers the separate Kimi crew hook's format preservation, idempotence, refusal cases, token guard, spawn registration, and teardown cleanup.
 `tests/fm-supervision-instructions.test.sh` covers recovery-line ownership and pi-signed's identity-preserving reuse of Pi's protocol.
 `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` is the opt-in isolated Pi path.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -337,9 +337,11 @@ Deterministic entry points:
 ```sh
 tests/fm-pi-watch-extension.test.sh
 tests/fm-pi-primary-types.test.sh
+tests/fm-watch-triage.test.sh
 tests/fm-watcher-lock.test.sh
 tests/fm-watch-arm.test.sh
 tests/fm-wake-queue.test.sh
+tests/fm-guard-stale-banner.test.sh
 tests/fm-subagent-pretool-check.test.sh
 tests/fm-claude-stop-autoarm.test.sh
 tests/fm-turnend-guard.test.sh

--- a/docs/watcher-continuity.md
+++ b/docs/watcher-continuity.md
@@ -57,8 +57,9 @@ Each record includes arm and watcher PIDs, start and end timestamps, exit code a
 The file is size-capped through `FM_WATCH_CYCLE_LOG_MAX_BYTES` and `FM_WATCH_CYCLE_LOG_KEEP_LINES`.
 `state/.watch-triage.log` remains only the watcher's bounded absorbed-wake debug log and carries no lifecycle semantics.
 
-The default 300-second grace is unchanged.
-Only the watcher process touches `state/.last-watcher-beat`; no helper process can make a wedged watcher appear healthy.
+A home's own arm and guard freshness grace remains 300 seconds.
+Parent-side registered-secondmate liveness uses the separate `FM_SECOND_MATE_WATCHER_GRACE` setting in [`configuration.md`](configuration.md#environment-variables), while [`architecture.md`](architecture.md#event-driven-supervision) owns the scan and suppression contract.
+Only the watcher process within each home touches that home's `state/.last-watcher-beat`; no helper process can make a wedged watcher appear healthy.
 
 ## Regression coverage
 
@@ -66,6 +67,7 @@ Only the watcher process touches `state/.last-watcher-beat`; no helper process c
 The same suite covers ordinary same-process session replacement for `/new`, `/resume`, and `/fork`, same-instance shutdown-plus-start, stale prior-generation callbacks, repeated transitions with exactly one live cycle, disappearance of the shutting-down refusal after a valid replacement activates, and terminal quit still refusing late rearm.
 `tests/fm-watch-arm.test.sh` covers durable queue replay, real remote parent-replies ingestion into the authoritative status log, decision-only OPEN DECISIONS recovery, interrupted handling replay, generation-bound acknowledgement, and a persistent live successor after recovery.
 `tests/fm-watcher-lock.test.sh` covers verified-successor attach, recovery publication before stale-lock removal, the typed self-eviction failure, bounded and successor-linked lifecycle rows, and a SIGSTOP counterfactual that distinguishes a live PID from a stale beacon before classifying termination.
+`tests/fm-watch-triage.test.sh` and `tests/fm-guard-stale-banner.test.sh` cover the registered local secondmate scan, first-heartbeat grace, named alarms, once-per-lapse watcher suppression, recovery re-arm, and healthy-parent negative control.
 `tests/fm-subagent-pretool-check.test.sh` proves Claude retains only the non-status Bash seatbelts.
 `tests/fm-claude-stop-autoarm.test.sh` covers the auto-arm's scope, stale and live session owners, unchanged AFK and need boundaries, single-flight, bounded failure retries, benign live-watcher cycle ends, one-notice failure episodes, and exit-2 translation.
 `FM_CLAUDE_LIVE_E2E=1 tests/fm-claude-stop-autoarm-live-e2e.test.sh` starts with the reproduced stale-lock state, runs session start first, completes two tokenless cycles, and checks the competing-live-owner negative control.

--- a/tests/fm-guard-stale-banner.test.sh
+++ b/tests/fm-guard-stale-banner.test.sh
@@ -17,9 +17,18 @@ make_guard_case() {
   dir="$TMP_ROOT/$name"
   home="$dir/home"
   root="$dir/root"
-  mkdir -p "$home/state" "$home/config" "$root"
+  mkdir -p "$home/state" "$home/data" "$home/config" "$root"
   fm_write_meta "$home/state/task.meta" "window=firstmate:fm-task" "kind=ship"
   printf '%s\n' "$dir"
+}
+
+register_local_secondmate() {  # <dir> <id> <mate-home>
+  local dir=$1 id=$2 mate_home=$3 home
+  home=$(case_home "$dir")
+  mkdir -p "$mate_home/state"
+  printf '%s\n' \
+    "- $id - Test secondmate (home: $mate_home; scope: test work; projects: test; added 2026-08-10)" \
+    > "$home/data/secondmates.md"
 }
 
 case_home() {
@@ -373,6 +382,35 @@ test_persistent_no_watcher_episode_survives_beacon_touch() {
   pass "fm-guard stale banner: a no-watcher episode survives a beacon mtime change"
 }
 
+test_parent_guard_names_stale_secondmate_watcher() {
+  local dir home mate out pid back
+  dir=$(make_guard_case secondmate-watcher-stale)
+  home=$(case_home "$dir")
+  mate="$dir/secondmate-home"
+  register_local_secondmate "$dir" agentepos "$mate"
+  touch "$mate/state/.last-watcher-beat"
+  back=$(( $(date +%s) - 901 ))
+  if [ "$(uname)" = Darwin ]; then
+    touch -mt "$(date -r "$back" '+%Y%m%d%H%M.%S')" "$mate/state/.last-watcher-beat"
+  else
+    touch -m -d "@$back" "$mate/state/.last-watcher-beat"
+  fi
+
+  sleep 60 &
+  pid=$!
+  record_live_watcher "$dir" "$pid" || fail "could not record healthy parent watcher"
+  touch "$home/state/.last-watcher-beat"
+  out=$(run_guard_case "$dir")
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+
+  assert_contains "$out" "SECONDMATE WATCHER STALE - agentepos" \
+    "parent guard did not name the stale registered secondmate"
+  assert_not_contains "$out" "WATCHER DOWN - SUPERVISION IS OFF" \
+    "healthy parent watcher was misclassified while reporting its secondmate"
+  pass "fm-guard surfaces a parent-side alarm naming a stale registered secondmate watcher"
+}
+
 test_first_stale_call_prints_full_banner
 test_repeated_same_episode_prints_reminder_only
 test_autoarm_fresh_beacon_without_watcher_is_healthy
@@ -380,6 +418,7 @@ test_autoarm_stale_beacon_alarms_with_correct_reason
 test_autoarm_stale_episode_is_stable
 test_persistent_no_watcher_banner_names_missing_process
 test_persistent_no_watcher_episode_survives_beacon_touch
+test_parent_guard_names_stale_secondmate_watcher
 test_fresh_beacon_without_live_watcher_stays_alarm
 test_x_mode_without_live_watcher_stays_alarm
 test_healthy_recovery_rearms_next_stale_episode

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -1448,6 +1448,111 @@ SH
   pass "triage log capping handles wc byte counts with leading spaces"
 }
 
+# --- registered secondmate watcher liveness ---------------------------------
+
+write_local_secondmate_registry() {  # <data-dir> <id> <home>
+  local data=$1 id=$2 home=$3
+  mkdir -p "$data"
+  printf '%s\n' \
+    "- $id - Test secondmate (home: $home; scope: test work; projects: test; added 2026-08-10)" \
+    > "$data/secondmates.md"
+}
+
+start_secondmate_liveness_watch() {  # <dir> <out>
+  local dir=$1 out=$2
+  PATH="$dir/fakebin:$PATH" FM_HOME="$dir" FM_STATE_OVERRIDE="$dir/state" \
+    FM_DATA_OVERRIDE="$dir/data" FM_CREW_STATE_BIN="$dir/fakebin/fm-crew-state.sh" \
+    FM_SECOND_MATE_WATCHER_GRACE=900 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+}
+
+# Current main drains a delivered wake in one call. PR #2055 retains it until
+# the generation-bound acknowledgement printed by that drain. Honor either
+# contract so this regression composes with the open recovery work instead of
+# bypassing its durable queue boundary.
+settle_secondmate_liveness_cycle() {  # <dir>
+  local dir=$1 err sequence generation
+  err="$dir/secondmate-liveness-drain.err"
+  FM_HOME="$dir" FM_STATE_OVERRIDE="$dir/state" FM_DATA_OVERRIDE="$dir/data" \
+    "$DRAIN" >/dev/null 2> "$err" || return 1
+  sequence=$(sed -n 's/^WAKE_ACK_REQUIRED:.*--ack-through \([0-9][0-9]*\) --recovery-generation [A-Za-z0-9._-][A-Za-z0-9._-]*$/\1/p' "$err" | tail -1)
+  generation=$(sed -n 's/^WAKE_ACK_REQUIRED:.*--ack-through [0-9][0-9]* --recovery-generation \([A-Za-z0-9._-][A-Za-z0-9._-]*\)$/\1/p' "$err" | tail -1)
+  rm -f "$err"
+  if [ -n "$sequence" ] || [ -n "$generation" ]; then
+    [ -n "$sequence" ] && [ -n "$generation" ] || return 1
+    FM_HOME="$dir" FM_STATE_OVERRIDE="$dir/state" FM_DATA_OVERRIDE="$dir/data" \
+      "$DRAIN" --ack-through "$sequence" --recovery-generation "$generation" >/dev/null
+  fi
+}
+
+test_stale_secondmate_watcher_surfaces_once_and_rearms_after_recovery() {
+  local dir state mate out pid back marker i
+  dir=$(make_case secondmate-watcher-stale); state="$dir/state"; mate="$dir/mate"
+  out="$dir/watch.out"
+  mkdir -p "$mate/state"
+  write_local_secondmate_registry "$dir/data" agentepos "$mate"
+  touch "$mate/state/.last-watcher-beat"
+  back=$(( $(date +%s) - 901 ))
+  set_mtime "$back" "$mate/state/.last-watcher-beat"
+
+  start_secondmate_liveness_watch "$dir" "$out"
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "stale registered secondmate watcher did not surface"
+  grep -F 'check: secondmate watcher stale: agentepos' "$out" >/dev/null \
+    || fail "stale secondmate wake did not name agentepos: $(cat "$out")"
+  grep "$(printf '\tcheck\tsecondmate-watcher:agentepos\t')" "$state/.wake-queue" >/dev/null \
+    || fail "stale secondmate watcher alarm was not queued with its own check key"
+  marker="$state/.seen-secondmate-watcher-agentepos"
+  [ -s "$marker" ] || fail "stale secondmate watcher alarm did not record episode suppression"
+
+  settle_secondmate_liveness_cycle "$dir" || fail "could not settle the first secondmate watcher alarm"
+  : > "$out"
+  start_secondmate_liveness_watch "$dir" "$out"
+  pid=$!
+  wait_live "$pid" 20 || fail "unchanged stale secondmate watcher re-fired immediately: $(cat "$out")"
+  [ ! -s "$state/.wake-queue" ] || { reap "$pid"; fail "unchanged stale secondmate watcher queued a duplicate alarm"; }
+
+  touch "$mate/state/.last-watcher-beat"
+  i=0
+  while [ "$i" -lt 30 ] && [ -e "$marker" ]; do sleep 0.1; i=$((i + 1)); done
+  [ ! -e "$marker" ] || { reap "$pid"; fail "fresh secondmate heartbeat did not clear stale-episode suppression"; }
+
+  back=$(( $(date +%s) - 901 ))
+  set_mtime "$back" "$mate/state/.last-watcher-beat"
+  wait_for_exit "$pid" 40 || fail "second secondmate watcher lapse did not re-arm after recovery"
+  grep -F 'check: secondmate watcher stale: agentepos' "$out" >/dev/null \
+    || fail "re-armed secondmate watcher alarm did not name agentepos"
+  pass "registered stale secondmate watcher surfaces once per lapse and re-arms after recovery"
+}
+
+test_missing_secondmate_watcher_heartbeat_surfaces_by_name() {
+  local dir state mate out pid back
+  dir=$(make_case secondmate-watcher-missing); state="$dir/state"; mate="$dir/mate"
+  out="$dir/watch.out"
+  mkdir -p "$mate/state"
+  printf '%s\n' docs-mate > "$mate/.fm-secondmate-home"
+  write_local_secondmate_registry "$dir/data" docs-mate "$mate"
+
+  start_secondmate_liveness_watch "$dir" "$out"
+  pid=$!
+  wait_live "$pid" 20 || fail "newly seeded secondmate alarmed before its first-heartbeat grace elapsed: $(cat "$out")"
+  [ ! -s "$state/.wake-queue" ] || { reap "$pid"; fail "newly seeded secondmate queued a premature missing-heartbeat alarm"; }
+  reap "$pid"
+  settle_secondmate_liveness_cycle "$dir" || fail "could not settle the intentionally stopped startup-grace watcher"
+
+  back=$(( $(date +%s) - 901 ))
+  set_mtime "$back" "$mate/.fm-secondmate-home"
+  : > "$out"
+  start_secondmate_liveness_watch "$dir" "$out"
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "registered secondmate with no watcher heartbeat did not surface"
+  grep -F 'check: secondmate watcher missing: docs-mate' "$out" >/dev/null \
+    || fail "missing secondmate watcher heartbeat alarm did not name docs-mate: $(cat "$out")"
+  grep "$(printf '\tcheck\tsecondmate-watcher:docs-mate\t')" "$state/.wake-queue" >/dev/null \
+    || fail "missing secondmate watcher heartbeat was not queued as a check"
+  pass "registered secondmate with no watcher heartbeat surfaces by name"
+}
+
 # --- process-event delivery -------------------------------------------------
 # A durably captured process-event result publishes an ordinary `check` wake on
 # the durable queue. The watcher must deliver that queued wake proactively -
@@ -1880,6 +1985,8 @@ test_nonterminal_paused_rechecks_authoritative_state
 test_paused_authoritative_working_preserves_wedge_timer
 test_nonterminal_stale_repairs_missing_or_corrupt_timer
 test_triage_log_size_cap_accepts_spaced_wc_counts
+test_stale_secondmate_watcher_surfaces_once_and_rearms_after_recovery
+test_missing_secondmate_watcher_heartbeat_surfaces_by_name
 test_procevent_captured_result_surfaces_proactively
 test_procevent_unacknowledged_result_redrains_until_handled
 test_procevent_marker_keys_are_injective


### PR DESCRIPTION
## Intent

Ship scout recommendation 1 from data/firstmate-wake-gap-diagnosis/report.md: add a parent-side second-mate watcher-liveness check so a registered local second mate whose state/.last-watcher-beat is stale beyond 10 to 15 minutes surfaces a supervision alarm naming that second mate through the watcher and session-start guard path. Use a 900-second default, keep newly seeded homes quiet during the same first-heartbeat grace, and suppress unchanged lapses until recovery so this does not create issue 2028-style re-arm thrash. Keep the change additive and do not alter ordinary-worker classification. Extend fm-watch tests. Reconcile and compose with open PR 2055 durable re-arm recovery rather than duplicating or bypassing its wake acknowledgement contract. Keep remote second-mate routes network-free in the local poll. Do not switch harnesses; secondmate-harness is already configured to Pi for future launches. A separate watch-cycle ledger change is optional only if cheap and necessary.

## What Changed

- Add a network-free liveness scan for registered local secondmate watcher heartbeats, with a configurable 900-second threshold and first-heartbeat grace.
- Queue named stale, missing, or unreadable alarms once per unchanged lapse, then re-arm them after heartbeat recovery.
- Surface secondmate alarms through the watcher and session-start guard paths without changing primary watcher or ordinary-worker classification, with accompanying tests and documentation.

## Risk Assessment

✅ Low: Captain, the additive local-heartbeat scan satisfies the required grace, suppression, guard integration, remote-route exclusion, and PR 2055 compatibility without altering ordinary-worker classification.

## Testing

No prior baseline output was supplied; focused watcher and guard suites plus end-to-end CLI/session-start checks passed, demonstrating the 900-second default, first-heartbeat grace, named persisted alarm, suppression until recovery, recovery re-arm, and network-free remote handling.

<details>
<summary>Evidence: Watcher liveness end-to-end transcript</summary>

<code>Newly seeded home: watcher stayed alive; 0 alarms queued.&#10;Stale local heartbeat: check: secondmate watcher stale: agentepos (last beat 901s ago; threshold 900s)&#10;Unchanged lapse after drain: watcher running; 0 alarms queued.&#10;Recovery cleared suppression; a subsequent lapse emitted a new alarm.&#10;Remote route: 0 SSH calls.</code>

```text
SECOND-MATE WATCHER LIVENESS END-TO-END
Remote-route probe: a fake ssh wrapper records every attempted call.

1. Newly seeded local home, no first heartbeat, default grace (FM_SECOND_MATE_WATCHER_GRACE unset)
after three poll cycles: watcher_alive=1 stopped_for_test_exit=1
queued alarms=0
watcher output=

2. Local heartbeat is 901 seconds old; remote route remains present
watcher exit=0
output: check: secondmate watcher stale: agentepos (last beat 901s ago; threshold 900s)
persisted queue: kind=check key=secondmate-watcher:agentepos payload=check: secondmate watcher stale: agentepos (last beat 901s ago; threshold 900s)
ssh wrapper calls=0

3. Drain the delivered wake, then re-arm against the unchanged lapse
drained: 1786352137	1	check	secondmate-watcher:agentepos	check: secondmate watcher stale: agentepos (last beat 901s ago; threshold 900s)
after two unchanged poll cycles: watcher=running queued alarms=0
after fresh recovery beat: suppression marker=cleared watcher=running
after a new 901-second lapse: watcher exit=0
output: check: secondmate watcher stale: agentepos (last beat 902s ago; threshold 900s)

4. Real session-start wake-queue guard path (network namespace disabled)
session-start exit=0
session: 3:SESSION START - /tmp/fm-secondmate-liveness-e2e.KxyECM/home
session: 22:WAKE QUEUE
session: 25:●  SUPERVISION ALARM - SECONDMATE WATCHER STALE - agentepos: last beat 903s ago (threshold 900s).
ssh wrapper calls after session-start=0
```
</details>
<details>
<summary>Evidence: Real session-start named alarm</summary>

<code>WAKE QUEUE&#10;● SUPERVISION ALARM - SECONDMATE WATCHER STALE - agentepos: last beat 903s ago (threshold 900s).</code>

```text

================================================================================
SESSION START - /tmp/fm-secondmate-liveness-e2e.KxyECM/home
================================================================================

LOCK
--------------------------------------------------------------------------------
lock acquired: harness pid 2272147

BOOTSTRAP
--------------------------------------------------------------------------------
MISSING: tmux (install: brew install tmux  # or the platform's package manager)
MISSING: treehouse (install: curl -fsSL https://kunchenguid.github.io/treehouse/install.sh | sh)
MISSING: gh (install: brew install gh  # or the platform's package manager)
MISSING: no-mistakes (install: curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh)
MISSING: gh-axi (install: npm install -g gh-axi && gh-axi setup hooks)
MISSING: chrome-devtools-axi (install: npm install -g chrome-devtools-axi && chrome-devtools-axi setup hooks)
MISSING: lavish-axi (install: npm install -g lavish-axi && lavish-axi setup hooks)
MISSING: tasks-axi (install: npm install -g tasks-axi)
MISSING: quota-axi (install: npm install -g quota-axi)

WAKE QUEUE
--------------------------------------------------------------------------------
1786352141	2	check	secondmate-watcher:agentepos	check: secondmate watcher stale: agentepos (last beat 902s ago; threshold 900s)
●  SUPERVISION ALARM - SECONDMATE WATCHER STALE - agentepos: last beat 903s ago (threshold 900s).
================================================================================
SUPERVISION OPERATING INSTRUCTIONS - primary harness: unknown
================================================================================
Current state:
- Lock: held by this session; this session owns normal supervision unless away mode says otherwise.
- Away mode: inactive.
- X mode: inactive; use the default watcher cadence.
- Ordinary wake: follow the continuation in the harness protocol below; do not use shell &.

Mode: Unknown harness fallback.

This primary harness does not have a verified watcher wake adapter.
Follow the generic supervision contract in `AGENTS.md`.
First cycle: drain queued wakes, then choose a supervision wait that the harness can actually wake from.
Ordinary wake: drain and handle the wake, then repeat that verified wait while supervision is still required.
Use `bin/fm-watch-arm.sh` only when the harness has a tracked background mechanism that survives the tool call and notifies the model on process exit.
Use a bounded foreground wait over `bin/fm-watch.sh` when that wake mechanism is not verified.
Never use shell `&` for watcher supervision.
Failure or missing cycle only: inspect the failure and restore the same verified wait shape.

Record new verification evidence before promoting an unknown harness to a named snippet.


================================================================================
READ-ONCE CONTRACT
================================================================================
Everything below is printed in full for this session start: every state/*.meta,
a compact data/backlog.md listing, a bounded tail of every state/*.status,
data/projects.md, data/secondmates.md, data/captain.md, data/captain-shared.md,
and data/learnings.md.
Do NOT re-read any of them after reading this digest, and do NOT bulk-read
data/backlog.md or state/*.status: re-reading everything defeats the entire
point of this command.

Go to a source directly only when:
  - this digest flagged it ABSENT (then rebuild or create it per AGENTS.md),
  - its contents looked unparseable or corrupt,
  - an individual full status log is needed for older wake-event history, or a
    status line was capped and its tail matters (each task's full log path is
    printed with its tail),
  - a full task body is needed (tasks-axi show <id> --full, or data/backlog.md),
  - the backlog listing disclosed omitted queued items and this turn needs them,
  - the NETWORK CHECKS section reported its checks still IN PROGRESS and this
    turn needs their verdict (bin/fm-startup-network.sh report),
  - or a STARTUP TRUNCATED banner named the stage that would have printed it, in
    which case that stage's sources were never emitted and must be reconciled.

================================================================================
FLEET STATE
================================================================================

data/backlog.md
--------------------------------------------------------------------------------
ABSENT

Work under way (state/*.meta)
--------------------------------------------------------------------------------
(none)

Orphan status logs (state/*.status without matching .meta)
--------------------------------------------------------------------------------
(none)

AFK
--------------------------------------------------------------------------------
absent

================================================================================
NETWORK CHECKS
================================================================================
completed off the startup path in 0s: GitHub authentication, dead-secondmate relaunch, secondmate convergence, pending handoff delivery, and project clone refresh with its drift reporting.
NEEDS_GH_AUTH
fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
These ran AFTER the sections above were composed, so re-read any record a line here names.

================================================================================
CONTEXT
================================================================================

data/projects.md
--------------------------------------------------------------------------------
ABSENT

data/secondmates.md
--------------------------------------------------------------------------------
- agentepos - Local secondmate (home: /tmp/fm-secondmate-liveness-e2e.KxyECM/agentepos-home; scope: coding; projects: test; added 2026-08-10)
- docs-mate - Newly seeded local secondmate (home: /tmp/fm-secondmate-liveness-e2e.KxyECM/docs-mate-home; scope: docs; projects: test; added 2026-08-10)
- remote-mate - Remote secondmate (host: remote.invalid; root: /srv/firstmate; home: /srv/remote-home; scope: remote; projects: test; added 2026-08-10)

data/captain.md
--------------------------------------------------------------------------------
ABSENT

data/captain-shared.md (shared, main-authoritative, read-only in secondmate homes)
--------------------------------------------------------------------------------
ABSENT

data/learnings.md
--------------------------------------------------------------------------------
ABSENT

================================================================================
NEXT STEP
================================================================================
Follow the supervision operating instructions block above for harness 'unknown'.
This script never starts supervision itself.

The digest above is complete for this session start. The READ-ONCE CONTRACT
section near the top of it governs what may still be read from disk.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"28b869ef47404c592d83ae1a4a8b790a021c30b4","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `tests/fm-watch-triage.test.sh`
- `tests/fm-guard-stale-banner.test.sh`
- <code>Executed `bin/fm-watch.sh` with throwaway new, stale-local, and remote second-mate registrations while leaving `FM_SECOND_MATE_WATCHER_GRACE` unset; inspected CLI output and persisted wake-queue state across startup grace, first lapse, unchanged re-arm, recovery, and re-lapse.</code>
- <code>Executed `bin/fm-session-start.sh` in a network-disabled fixture and verified its real wake-queue guard path named only the stale local second mate while a fake `ssh` recorder observed zero calls.</code>
- <code>Verified `git status --short` was empty and no evidence-fixture watcher processes remained.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
