### PR TITLE
feat(bin): guide documentation-only follow-ups in no-mistakes briefs

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -394,7 +394,7 @@ When starting no-mistakes, make \`--intent\` preserve all relevant content from 
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 
 Prefer folding documentation-only follow-up changes into the next known code round - review findings, a queued fix, or anything else - instead of starting a separate validation run.
-When a documentation-only change is genuinely the last thing standing, use \`--skip test\` with \`no-mistakes axi run\` or top-level \`no-mistakes\` so the pipeline skips the \`test\` step, and confirm the current flag and accepted step names with \`no-mistakes axi run --help\` in this worktree.
+When a documentation-only change is genuinely the last thing standing, use \`--skip test\` with \`no-mistakes axi run\` or top-level \`no-mistakes\` so the pipeline skips the \`test\` step - the step is named \`test\`, and \`no-mistakes axi status\` lists every step name if you need another; confirm the current \`--skip\` flag with \`no-mistakes axi run --help\` in this worktree.
 Documentation-only means no change to any source, test, configuration, dependency, or build file - documentation and comments only; anything else is an ordinary code round.
 
 Two firstmate-specific rules layer on top of that guidance:

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -393,6 +393,10 @@ Follow the guidance no-mistakes itself provides for the mechanics: it loads when
 When starting no-mistakes, make \`--intent\` preserve all relevant content from this brief's \`# Task\` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 
+Prefer folding documentation-only follow-up changes into the next known code round - review findings, a queued fix, or anything else - instead of starting a separate validation run.
+When a documentation-only change is genuinely the last thing standing, use \`--skip test\` with \`no-mistakes axi run\` or top-level \`no-mistakes\` so the pipeline skips the \`test\` step, and confirm the current flag and accepted step names with \`no-mistakes axi run --help\` in this worktree.
+Documentation-only means no change to any source, test, configuration, dependency, or build file - documentation and comments only; anything else is an ordinary code round.
+
 Two firstmate-specific rules layer on top of that guidance:
 - ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
   Firstmate applies the authority contract in its \`AGENTS.md\` and obtains any required captain decision.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -355,33 +355,45 @@ test_no_mistakes_dod_wording() {
 }
 
 test_docs_only_pipeline_guidance_is_no_mistakes_only() {
-  local home id brief
+  local home id brief fold_line skip_line definition_line help_line
   home="$TMP_ROOT/docs-only-guidance-home"
   mkdir -p "$home/data"
+
+  # Every fragment below is asserted present in the no-mistakes brief and absent
+  # from the other modes, so a negative assertion can never drift into a string
+  # the generator does not emit (a case-sensitive `grep -F` miss would otherwise
+  # pass vacuously).
+  fold_line="Prefer folding documentation-only follow-up changes into the next known code round"
+  # shellcheck disable=SC2016 # Literal backticks must stay unexpanded.
+  skip_line='use `--skip test` with `no-mistakes axi run` or top-level `no-mistakes`'
+  definition_line="Documentation-only means no change to any source, test, configuration, dependency, or build file"
+  # shellcheck disable=SC2016 # Literal backticks must stay unexpanded.
+  help_line='confirm the current flag and accepted step names with `no-mistakes axi run --help`'
 
   id="brief-docs-only-no-mistakes"
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
   brief="$home/data/$id/brief.md"
-  assert_grep "Prefer folding documentation-only follow-up changes into the next known code round" "$brief" \
+  assert_grep "$fold_line" "$brief" \
     "no-mistakes brief lost the documentation-only folding guidance"
-  # shellcheck disable=SC2016 # Literal backticks must stay unexpanded.
-  assert_grep 'use `--skip test` with `no-mistakes axi run` or top-level `no-mistakes`' "$brief" \
+  assert_grep "$skip_line" "$brief" \
     "no-mistakes brief lost the verified pipeline skip guidance"
-  assert_grep "Documentation-only means no change to any source, test, configuration, dependency, or build file" "$brief" \
+  assert_grep "$definition_line" "$brief" \
     "no-mistakes brief lost the concrete documentation-only definition"
-  # shellcheck disable=SC2016 # Literal backticks must stay unexpanded.
-  assert_grep 'confirm the current flag and accepted step names with `no-mistakes axi run --help`' "$brief" \
+  assert_grep "$help_line" "$brief" \
     "no-mistakes brief lost the version-matched help instruction"
 
   for mode in direct-PR local-only; do
     id="brief-docs-only-$mode"
     FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1
     brief="$home/data/$id/brief.md"
-    assert_no_grep "Prefer folding documentation-only follow-up changes" "$brief" \
+    assert_no_grep "$fold_line" "$brief" \
       "$mode brief unexpectedly gained no-mistakes documentation-only guidance"
-    # shellcheck disable=SC2016 # Literal backticks must stay unexpanded.
-    assert_no_grep 'Use `--skip test` with `no-mistakes axi run`' "$brief" \
+    assert_no_grep "$skip_line" "$brief" \
       "$mode brief unexpectedly gained the no-mistakes pipeline skip guidance"
+    assert_no_grep "$definition_line" "$brief" \
+      "$mode brief unexpectedly gained the documentation-only definition"
+    assert_no_grep "$help_line" "$brief" \
+      "$mode brief unexpectedly gained the version-matched help instruction"
   done
 
   pass "fm-brief.sh: documentation-only pipeline guidance is limited to no-mistakes briefs"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -354,6 +354,39 @@ test_no_mistakes_dod_wording() {
   pass "fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe"
 }
 
+test_docs_only_pipeline_guidance_is_no_mistakes_only() {
+  local home id brief
+  home="$TMP_ROOT/docs-only-guidance-home"
+  mkdir -p "$home/data"
+
+  id="brief-docs-only-no-mistakes"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep "Prefer folding documentation-only follow-up changes into the next known code round" "$brief" \
+    "no-mistakes brief lost the documentation-only folding guidance"
+  # shellcheck disable=SC2016 # Literal backticks must stay unexpanded.
+  assert_grep 'use `--skip test` with `no-mistakes axi run` or top-level `no-mistakes`' "$brief" \
+    "no-mistakes brief lost the verified pipeline skip guidance"
+  assert_grep "Documentation-only means no change to any source, test, configuration, dependency, or build file" "$brief" \
+    "no-mistakes brief lost the concrete documentation-only definition"
+  # shellcheck disable=SC2016 # Literal backticks must stay unexpanded.
+  assert_grep 'confirm the current flag and accepted step names with `no-mistakes axi run --help`' "$brief" \
+    "no-mistakes brief lost the version-matched help instruction"
+
+  for mode in direct-PR local-only; do
+    id="brief-docs-only-$mode"
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1
+    brief="$home/data/$id/brief.md"
+    assert_no_grep "Prefer folding documentation-only follow-up changes" "$brief" \
+      "$mode brief unexpectedly gained no-mistakes documentation-only guidance"
+    # shellcheck disable=SC2016 # Literal backticks must stay unexpanded.
+    assert_no_grep 'Use `--skip test` with `no-mistakes axi run`' "$brief" \
+      "$mode brief unexpectedly gained the no-mistakes pipeline skip guidance"
+  done
+
+  pass "fm-brief.sh: documentation-only pipeline guidance is limited to no-mistakes briefs"
+}
+
 test_ship_project_memory_wording() {
   local home id brief
   home="$TMP_ROOT/project-memory-home"
@@ -719,6 +752,7 @@ test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
+test_docs_only_pipeline_guidance_is_no_mistakes_only
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -355,45 +355,55 @@ test_no_mistakes_dod_wording() {
 }
 
 test_docs_only_pipeline_guidance_is_no_mistakes_only() {
-  local home id brief fold_line skip_line definition_line help_line
+  local home id brief fold_line skip_line definition_line steps_line help_line
   home="$TMP_ROOT/docs-only-guidance-home"
   mkdir -p "$home/data"
 
   # Every fragment below is asserted present in the no-mistakes brief and absent
   # from the other modes, so a negative assertion can never drift into a string
   # the generator does not emit (a case-sensitive `grep -F` miss would otherwise
-  # pass vacuously).
+  # pass vacuously). `assert_present` closes the other vacuous-pass channel:
+  # `grep -F` exits 2 on a missing file and `assert_no_grep` negates that into a
+  # pass, so each brief must be proven scaffolded before it is asserted against.
   fold_line="Prefer folding documentation-only follow-up changes into the next known code round"
   # shellcheck disable=SC2016 # Literal backticks must stay unexpanded.
   skip_line='use `--skip test` with `no-mistakes axi run` or top-level `no-mistakes`'
   definition_line="Documentation-only means no change to any source, test, configuration, dependency, or build file"
   # shellcheck disable=SC2016 # Literal backticks must stay unexpanded.
-  help_line='confirm the current flag and accepted step names with `no-mistakes axi run --help`'
+  steps_line='the step is named `test`, and `no-mistakes axi status` lists every step name'
+  # shellcheck disable=SC2016 # Literal backticks must stay unexpanded.
+  help_line='confirm the current `--skip` flag with `no-mistakes axi run --help`'
 
   id="brief-docs-only-no-mistakes"
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
   brief="$home/data/$id/brief.md"
+  assert_present "$brief" "no-mistakes brief was not scaffolded"
   assert_grep "$fold_line" "$brief" \
     "no-mistakes brief lost the documentation-only folding guidance"
   assert_grep "$skip_line" "$brief" \
     "no-mistakes brief lost the verified pipeline skip guidance"
   assert_grep "$definition_line" "$brief" \
     "no-mistakes brief lost the concrete documentation-only definition"
+  assert_grep "$steps_line" "$brief" \
+    "no-mistakes brief must name the test step and point step names at the run status listing"
   assert_grep "$help_line" "$brief" \
-    "no-mistakes brief lost the version-matched help instruction"
+    "no-mistakes brief lost the version-matched flag check against the installed tool"
 
   for mode in direct-PR local-only; do
     id="brief-docs-only-$mode"
     FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1
     brief="$home/data/$id/brief.md"
+    assert_present "$brief" "$mode brief was not scaffolded"
     assert_no_grep "$fold_line" "$brief" \
       "$mode brief unexpectedly gained no-mistakes documentation-only guidance"
     assert_no_grep "$skip_line" "$brief" \
       "$mode brief unexpectedly gained the no-mistakes pipeline skip guidance"
     assert_no_grep "$definition_line" "$brief" \
       "$mode brief unexpectedly gained the documentation-only definition"
+    assert_no_grep "$steps_line" "$brief" \
+      "$mode brief unexpectedly gained the pipeline step-name guidance"
     assert_no_grep "$help_line" "$brief" \
-      "$mode brief unexpectedly gained the version-matched help instruction"
+      "$mode brief unexpectedly gained the version-matched flag check"
   done
 
   pass "fm-brief.sh: documentation-only pipeline guidance is limited to no-mistakes briefs"


### PR DESCRIPTION
## Intent

Update bin/fm-brief.sh so generated --mode no-mistakes ship briefs contain short guidance for documentation-only follow-up commits: prefer folding documentation-only changes into a known upcoming code round; when a documentation-only change is genuinely the last thing standing, use the pipeline --skip test flag so the test step is skipped, with the current flag and accepted step names verified from no-mistakes axi run --help; define documentation-only concretely as documentation and comments only, with no changes to source, test, configuration, dependency, or build files. Keep the guidance inside the existing no-mistakes contract, keep all other generated mode contracts unchanged, and add or retain generated-content tests. Do not add automatic diff classification machinery or touch ~/.no-mistakes/config.yaml. Push only to robotkad/firstmate and never push or open a pull request against kunchenguid/firstmate; any pull request base repository must be robotkad/firstmate.

## What Changed

- `bin/fm-brief.sh` now emits three extra lines inside the existing no-mistakes contract of generated ship briefs: prefer folding documentation-only follow-ups into the next known code round; when one is genuinely last, run `--skip test` via `no-mistakes axi run` or top-level `no-mistakes` (step names listed by `no-mistakes axi status`, current flag confirmed with `no-mistakes axi run --help`); and a concrete definition of documentation-only as documentation and comments with no source, test, configuration, dependency, or build file changes.
- Added `test_docs_only_pipeline_guidance_is_no_mistakes_only` to `tests/fm-brief.test.sh`, asserting all five guidance fragments are present in a generated `--mode no-mistakes` brief and absent from `direct-PR` and `local-only` briefs, with each brief proven scaffolded first so a missing file cannot make a negative assertion pass vacuously.
- Other generated mode contracts are unchanged, and no diff-classification machinery was added — the Test step verified this by generating every scaffold from both base and target and diffing them path-normalized, plus two mutation checks that each fail the new test.

## Risk Assessment

✅ Low: The change remains a bounded three-line prose addition to a single mode branch plus its generated-content test, both round-1 findings are fully closed, and every factual claim the new guidance makes (the `--skip` flag on `axi run` and top-level, and the `test` step name) was verified read-only against the installed no-mistakes binary.

## Testing

I exercised this as an end user would: generated the actual crewmate brief files from the target generator and diffed them against briefs from the base generator, which shows the three guidance lines appearing inside the existing no-mistakes Definition-of-done block while the direct-PR, local-only, scout, and secondmate scaffolds come out byte-identical to the base contract. I then verified every factual claim the new guidance makes against the installed no-mistakes CLI rather than trusting the prose: `--skip` is the current flag on both `no-mistakes axi run` and the top-level command, and the binary's own validation string lists `test` among the valid step names; the `axi status` step-name claim is backed by that command's help text and the installed skill doc, since this isolated gate worktree is not gate-initialized and running init is outside this phase. The targeted `tests/fm-brief.test.sh` suite and the neighbouring ask-user authority test both pass, and two mutation runs confirm the new test actually bites — it fails when the guidance is deleted and fails again when the guidance leaks into the direct-PR contract. No screenshot applies: this change generates a markdown brief, so the generated brief file itself is the reviewer-visible end-user surface and is attached. The worktree is clean and all scratch fixtures were removed.

<details>
<summary>Evidence: Generated --mode no-mistakes crewmate brief (the end-user surface, with the new guidance in context)</summary>

<code>Delivery contract: mode=no-mistakes&#10;...&#10;Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.&#10;&#10;Prefer folding documentation-only follow-up changes into the next known code round - review findings, a queued fix, or anything else - instead of starting a separate validation run.&#10;When a documentation-only change is genuinely the last thing standing, use `--skip test` with `no-mistakes axi run` or top-level `no-mistakes` so the pipeline skips the `test` step - the step is named `test`, and `no-mistakes axi status` lists every step name if you need another; confirm the current `--skip` flag with `no-mistakes axi run --help` in this worktree.&#10;Documentation-only means no change to any source, test, configuration, dependency, or build file - documentation and comments only; anything else is an ordinary code round.&#10;&#10;Two firstmate-specific rules layer on top of that guidance:</code>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of acme-api, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/ship-no-mistakes`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '<FM_HOME>/state/ship-no-mistakes.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `<REPO>/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `<REPO>/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Prefer folding documentation-only follow-up changes into the next known code round - review findings, a queued fix, or anything else - instead of starting a separate validation run.
When a documentation-only change is genuinely the last thing standing, use `--skip test` with `no-mistakes axi run` or top-level `no-mistakes` so the pipeline skips the `test` step - the step is named `test`, and `no-mistakes axi status` lists every step name if you need another; confirm the current `--skip` flag with `no-mistakes axi run --help` in this worktree.
Documentation-only means no change to any source, test, configuration, dependency, or build file - documentation and comments only; anything else is an ordinary code round.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Base-vs-target generated contract diff for every scaffold (only no-mistakes changes)</summary>

<code>=== --mode direct-PR ===&#10;UNCHANGED - generated brief is byte-identical to the base contract&#10;&#10;=== --mode local-only ===&#10;UNCHANGED - generated brief is byte-identical to the base contract&#10;&#10;=== --mode no-mistakes ===&#10;@@ -62,6 +62,10 @@&#10;Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.&#10;&#10;+Prefer folding documentation-only follow-up changes into the next known code round - review findings, a queued fix, or anything else - instead of starting a separate validation run.&#10;+When a documentation-only change is genuinely the last thing standing, use `--skip test` with `no-mistakes axi run` or top-level `no-mistakes` so the pipeline skips the `test` step - the step is named `test`, and `no-mistakes axi status` lists every step name if you need another; confirm the current `--skip` flag with `no-mistakes axi run --help` in this worktree.&#10;+Documentation-only means no change to any source, test, configuration, dependency, or build file - documentation and comments only; anything else is an ordinary code round.&#10;+&#10;Two firstmate-specific rules layer on top of that guidance:&#10;&#10;=== scout-x (scout / secondmate scaffold) ===&#10;UNCHANGED - generated scaffold is byte-identical to the base contract&#10;&#10;=== sm-x (scout / secondmate scaffold) ===&#10;UNCHANGED - generated scaffold is byte-identical to the base contract</code>

```text
Generated crewmate brief contracts: base 85e750a vs target 915ba94
(FM_HOME and repo root paths normalized; briefs generated with:
   bin/fm-brief.sh ship-<mode> acme-api --mode <mode>)

=== --mode direct-PR ===
UNCHANGED - generated brief is byte-identical to the base contract

=== --mode local-only ===
UNCHANGED - generated brief is byte-identical to the base contract

=== --mode no-mistakes ===
@@ -62,6 +62,10 @@
 When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 
+Prefer folding documentation-only follow-up changes into the next known code round - review findings, a queued fix, or anything else - instead of starting a separate validation run.
+When a documentation-only change is genuinely the last thing standing, use `--skip test` with `no-mistakes axi run` or top-level `no-mistakes` so the pipeline skips the `test` step - the step is named `test`, and `no-mistakes axi status` lists every step name if you need another; confirm the current `--skip` flag with `no-mistakes axi run --help` in this worktree.
+Documentation-only means no change to any source, test, configuration, dependency, or build file - documentation and comments only; anything else is an ordinary code round.
+
 Two firstmate-specific rules layer on top of that guidance:
 - ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
   Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.

=== scout-x (scout / secondmate scaffold) ===
UNCHANGED - generated scaffold is byte-identical to the base contract

=== sm-x (scout / secondmate scaffold) ===
UNCHANGED - generated scaffold is byte-identical to the base contract
```
</details>
<details>
<summary>Evidence: Guidance claims verified against installed no-mistakes CLI v1.41.2</summary>

<code>installed version: no-mistakes version v1.41.2 (867d64d)&#10;&#10;$ no-mistakes axi run --help&#10;--skip string comma-separated pipeline steps to skip&#10;&#10;$ no-mistakes --help&#10;--skip string comma-separated pipeline steps to skip for a new run&#10;&#10;$ strings ~/.no-mistakes/bin/no-mistakes | grep &#34;Valid steps&#34;&#10;Valid steps: intent, rebase, review, test, document, lint, push, pr, ci&#10;&#10;$ no-mistakes axi status --help&#10;Show the active (or most recent) run in detail</code>

```text
Verifying the generated guidance's factual claims against the installed no-mistakes CLI
installed version: no-mistakes version v1.41.2 (867d64d) 2026-07-24T06:16:23Z

$ no-mistakes axi run --help   (claim: the current flag is `--skip`)
      --intent string   what the user set out to accomplish (not a description of the diff); used instead of inferring from transcripts (required to start a run)
      --skip string     comma-separated pipeline steps to skip
  -y, --yes             auto-resolve every gate (fix findings, then accept) until a decision point or outcome

$ no-mistakes --help           (claim: top-level `no-mistakes` also takes --skip)
  -h, --help          help for no-mistakes
      --skip string   comma-separated pipeline steps to skip for a new run
  -v, --version       version for no-mistakes

$ strings ~/.no-mistakes/bin/no-mistakes | grep "Valid steps"   (claim: the step is named `test`)
Valid steps: intent, rebase, review, test, document, lint, push, pr, cijson

$ grep -n "axi status" ~/.claude/skills/no-mistakes/SKILL.md   (claim: axi status lists the run step names)
268:no-mistakes axi status        # full detail plus cached branch_sync when relevant
Show the active (or most recent) run in detail

Usage:
```
</details>
<details>
<summary>Evidence: Mutation checks proving the new test is not a vacuous pass</summary>

<code>1. Guidance removed from the no-mistakes contract:&#10;not ok - no-mistakes brief lost the documentation-only folding guidance&#10;&#10;2. Guidance leaked into the direct-PR contract:&#10;not ok - direct-PR brief unexpectedly gained no-mistakes documentation-only guidance&#10;&#10;3. Unmutated tree:&#10;ok - fm-brief.sh: documentation-only pipeline guidance is limited to no-mistakes briefs</code>

```text
Mutation checks proving tests/fm-brief.test.sh guards this behavior in both directions

1. Guidance removed from the no-mistakes contract:
   not ok - no-mistakes brief lost the documentation-only folding guidance

2. Guidance leaked into the direct-PR contract:
   not ok - direct-PR brief unexpectedly gained no-mistakes documentation-only guidance

3. Unmutated tree:
   ok - fm-brief.sh: documentation-only pipeline guidance is limited to no-mistakes briefs
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ℹ️ `tests/fm-brief.test.sh:387` - The negative-assertion loop can pass vacuously if brief generation fails. `assert_no_grep` is `! grep -F -- &#34;$1&#34; &#34;$2&#34;`, and grep exits 2 (not 1) when the file does not exist, so `!` makes that a pass. The generator call on line 387 discards both stderr and its exit status, so if `fm-brief.sh` ever stopped scaffolding `direct-PR`/`local-only` briefs from this bare `mkdir -p &#34;$home/data&#34;` home (the test does not call `write_registry`, unlike `test_faster_paths_use_configured_authority_without_stacked_review`), all four `assert_no_grep` calls would succeed against a nonexistent file and the test would report pass. The header comment claims the fragments are bound so negatives &#34;can never drift into a string the generator does not emit&#34; - that closes the string-drift channel but not the missing-file one. Fix: add `assert_present &#34;$brief&#34; &#34;$mode brief was not scaffolded&#34;` after line 388 (or `|| fail ...` on line 387), matching what `test_no_mistakes_dod_wording` already does.
- ℹ️ `bin/fm-brief.sh:397` - The generated guidance tells the worker to &#34;confirm the current flag and accepted step names with `no-mistakes axi run --help`&#34;, but that help output does not enumerate step names. Verified against the installed binary (v1.41.2): `no-mistakes help axi run` prints only `--skip string   comma-separated pipeline steps to skip`, with no list of accepted steps. The flag half of the instruction is verifiable there; the step-name half is not, so a worker following it literally finds nothing and may loop or guess. Step names are discoverable elsewhere (`no-mistakes axi status` output, the pipeline listing in the no-mistakes skill). Line 392 of the same DOD already establishes `axi run --help` plus the `help` lines in each `axi` response as authoritative - pointing the step-name half at the `axi` response `help` lines would make the instruction actually satisfiable. Flagging rather than fixing because the intent explicitly specified this verification source, so the wording is the author&#39;s call.

🔧 Fix: Point step names at run status; guard brief negatives
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-brief.test.sh` — full fm-brief generated-content suite including the new `test_docs_only_pipeline_guidance_is_no_mistakes_only`</code>
- <code>`bash tests/fm-ask-user-authority.test.sh` — neighbouring assertion on the same no-mistakes DOD block</code>
- <code>Generated real briefs for every scaffold from both base 85e750a and target 915ba94 (`bin/fm-brief.sh ship-&lt;mode&gt; acme-api --mode no-mistakes|direct-PR|local-only`, `--scout`, `--secondmate`) and diffed them path-normalized to prove only the no-mistakes contract changed</code>
- <code>`no-mistakes axi run --help` — confirmed the current flag is `--skip string` (comma-separated pipeline steps to skip)</code>
- <code>`no-mistakes --help` — confirmed top-level `no-mistakes` also accepts `--skip`</code>
- <code>`strings ~/.no-mistakes/bin/no-mistakes | grep &#39;Valid steps&#39;` — confirmed `test` is an accepted step name (`intent, rebase, review, test, document, lint, push, pr, ci`)</code>
- <code>`no-mistakes axi status --help` — confirmed it shows the active/most-recent run in detail (step-name listing claim; could not execute a live run in this uninitialized gate worktree)</code>
- <code>Mutation check 1: removed the guidance from a copy of `bin/fm-brief.sh` → `not ok - no-mistakes brief lost the documentation-only folding guidance`</code>
- <code>Mutation check 2: injected the guidance into the direct-PR contract in a copy → `not ok - direct-PR brief unexpectedly gained no-mistakes documentation-only guidance`</code>
- <code>`ls -l ~/.no-mistakes/config.yaml` — untouched (mtime still the Aug 6 install time)</code>
- <code>`git status --porcelain` — worktree clean, all scratch fixtures removed</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
