### PR TITLE
docs: name capacity-limited shared build/test infra as a serializing condition

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,7 +277,7 @@ An unregistered project or absent registry resolves to `no-mistakes` with yolo o
 Record the resulting mode, yolo, and the one-line reason for any deviation in the backlog item note.
 
 Treat file or subsystem overlap as a risk signal rather than an automatic reason to wait, and dispatch isolated work immediately with no concurrency cap when each change can be independently implemented and validated and the selected delivery path can reconcile ordinary rebases or conflicts.
-Serialize only for a true semantic dependency, shared mutable external state, incompatible concurrent migration, or another concrete condition that makes independent progress or reconciliation unsafe; same-file editing alone is insufficient, and genuine blockers remain durable.
+Serialize only for a true semantic dependency, shared mutable external state - including capacity-limited shared build or test infrastructure such as a device simulator or emulator, a device farm, or a single machine's build capacity - incompatible concurrent migration, or another concrete condition that makes independent progress or reconciliation unsafe; same-file editing alone is insufficient, partition a partitionable shared resource per worker rather than serializing it, and genuine blockers remain durable.
 Write the task-specific brief under section 11 before spawning.
 
 ### Dispatch and supervision handoff

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,7 +277,7 @@ An unregistered project or absent registry resolves to `no-mistakes` with yolo o
 Record the resulting mode, yolo, and the one-line reason for any deviation in the backlog item note.
 
 Treat file or subsystem overlap as a risk signal rather than an automatic reason to wait, and dispatch isolated work immediately with no concurrency cap when each change can be independently implemented and validated and the selected delivery path can reconcile ordinary rebases or conflicts.
-Serialize only for a true semantic dependency, shared mutable external state - including capacity-limited shared build or test infrastructure such as a device simulator or emulator, a device farm, or a single machine's build capacity - incompatible concurrent migration, or another concrete condition that makes independent progress or reconciliation unsafe; same-file editing alone is insufficient, partition a partitionable shared resource per worker rather than serializing it, and genuine blockers remain durable.
+Serialize only for a true semantic dependency, shared mutable external state, incompatible concurrent migration, or another concrete condition that makes independent progress or reconciliation unsafe - shared mutable external state includes capacity-limited shared build or test infrastructure such as a device simulator or emulator, a device farm, or a single machine's build capacity; same-file editing alone is insufficient, partition a partitionable shared resource per worker rather than serializing it, and genuine blockers remain durable.
 Write the task-specific brief under section 11 before spawning.
 
 ### Dispatch and supervision handoff


### PR DESCRIPTION
## Summary
- Patches AGENTS.md section 7's existing serialize-only-for sentence (~line 280) to name capacity-limited shared build or test infrastructure (a device simulator or emulator, a device farm, a single machine's build capacity) as a concrete shared-mutable-external-state condition that requires serializing concurrent work.
- States that partitioning such a resource per worker is the cheaper answer than serializing, wherever it can be partitioned.

## Why
Three same-day failures on one machine came from dispatching two iOS workers concurrently: a validation test-step failure initially misdiagnosed as a code defect (actually another worker's xcodebuild holding the same simulator), two workers driving the same named simulator, and 22 orphaned simulator clones (52GB) from abnormal exits stalling unrelated work. The existing rule already covered this case as "shared mutable external state" but was never read that way, so this patches the existing sentence rather than adding new prose.

## Test plan
- [x] `bin/fm-doc-audience-check.sh` passes
- [x] no-mistakes pipeline: intent, rebase, review, test, document steps all passed (lint skipped: ShellCheck unavailable in this environment, no scripts changed)