### PR TITLE
fix(bin): isolate spawned harness identity markers

### DIFF
--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -31,10 +31,11 @@ detect_own() {
   # Layer 1: environment markers for verified harnesses.
   # Keep marker detection before ancestry detection as an explicit precedence rule.
   # Only claude, pi, and grok set verified markers of their own; codex, opencode,
-  # kimi, and muse are markerless, so a foreign marker retained in a terminal
-  # multiplexer's stored environment can silently misidentify one of them before
-  # ancestry is consulted. This is a precedence hazard, not evidence that
-  # CLAUDECODE inheritance into a kimi child was observed; it was not observed.
+  # kimi, and muse are markerless. bin/fm-spawn.sh removes foreign identity markers
+  # at its verified-adapter launch boundary, but callers that bypass that boundary
+  # can still let a retained marker win before ancestry is consulted. This is a
+  # precedence hazard, not evidence that CLAUDECODE inheritance into a kimi child
+  # was observed; it was not observed.
   [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
   if [ "${PI_CODING_AGENT:-}" = "true" ]; then
     if [ "${FM_PI_HARNESS:-}" = pi-signed ]; then echo pi-signed; else echo pi; fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -149,6 +149,10 @@
 #     __PITURNEND__ absolute path to .pi/extensions/fm-primary-turnend-guard.ts in a pi secondmate home
 #     __PIWATCH__   absolute path to .pi/extensions/fm-primary-pi-watch.ts in a pi secondmate home
 #     __OPINPUT__   absolute path to the canonical operational-input encoder
+#   Every verified-adapter launch is prefixed at the common construction boundary
+#   with an environment scrub that removes the other harnesses' identity markers.
+#   A selected marker-bearing harness keeps its own legitimate marker inputs;
+#   unrelated configuration and credential variables are never part of the scrub.
 # Verified per-harness turn-end hooks are installed automatically where enabled; some live outside the worktree.
 # Kimi uses one surgically installed Firstmate region in $HOME/.kimi-code/config.toml,
 # a firstmate-owned global hook and registry, and a gitignored per-task pointer.
@@ -1109,8 +1113,21 @@ launch_template() {
     # plugin engine is off in the default build, so firstmate folds muse's own
     # session event log instead (bin/fm-busy-lib.sh), bound by the sidecar
     # written below. Nothing to place in the template for it.
-    # codex, opencode, and kimi are also markerless and share this inherited-marker hazard; changing their verified launch boundaries belongs in follow-up work.
-    muse) printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS XDG_CONFIG_HOME=__MUSECONFIG__ XDG_DATA_HOME=__MUSEDATA__ MUSE_EXPERIMENTAL_FOREIGN_PERSONAL_CONTEXT_KILL=on __MUSEBIN__ --yolo __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    muse) printf '%s' 'XDG_CONFIG_HOME=__MUSECONFIG__ XDG_DATA_HOME=__MUSEDATA__ MUSE_EXPERIMENTAL_FOREIGN_PERSONAL_CONTEXT_KILL=on __MUSEBIN__ --yolo __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    *) return 1 ;;
+  esac
+}
+
+# Print the launch prefix that keeps fm-harness.sh's verified marker precedence
+# target-local. A marker-bearing target retains only its own identity family;
+# markerless targets retain none. FM_PI_HARNESS is part of Pi's family and is
+# normalized to the selected pi/pi-signed adapter immediately after this prefix.
+launch_identity_env_prefix() {
+  case "$1" in
+    claude) printf '%s' 'env -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT' ;;
+    pi|pi-signed) printf '%s' 'env -u CLAUDECODE -u GROK_AGENT' ;;
+    grok) printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS' ;;
+    codex|opencode|kimi|muse) printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT' ;;
     *) return 1 ;;
   esac
 }
@@ -2589,6 +2606,9 @@ if [ "$KIND" = secondmate ]; then
   # Reuse the single frozen decision from the carrier resolution above so the
   # injected carrier and this on/off snapshot are guaranteed to agree.
   LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_PUBLIC_FOLLOWUP_PRIMARY_HOME=$sq_primary_home FM_HOME=$sq_home FM_TRACE_CONTEXT=$SPAWN_TRACE_EFFECTIVE FM_SUPERVISION_MODEL=$supervision_model $LAUNCH"
+fi
+if identity_env_prefix=$(launch_identity_env_prefix "$HARNESS"); then
+  LAUNCH="$identity_env_prefix $LAUNCH"
 fi
 if [ -z "$SPAWN_TRACEPARENT" ] && [ "$RELAUNCH" -eq 1 ]; then
   LAUNCH="unset TRACEPARENT; $LAUNCH"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -214,6 +214,7 @@ The verified adapter evidence - each harness's busy-state source, interrupt and 
 The executable interrupt and exit mechanics live in [`bin/fm-control-lib.sh`](../bin/fm-control-lib.sh), and [`docs/agent-control.md`](agent-control.md) owns their lifecycle-control architecture.
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
 Pi and pi-signed crew launches explicitly pass `--tui-mode regular` so fullscreen mode cannot rewrite scrollback and bury steers.
+That launch boundary removes identity markers belonging to other verified harnesses before the selected worker starts, while retaining the selected harness's own marker inputs and unrelated configuration or credentials.
 Enabled primary-session turn-end guard integrations are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).
 Kimi remains outside the primary turn-end guard integrations; [`docs/turnend-guard.md`](turnend-guard.md#compatibility-limits) owns its separate captain-approved crew wake hook.
 Primary-session watcher wake protocols are rendered at session start by [`bin/fm-supervision-instructions.sh`](../bin/fm-supervision-instructions.sh) from [`docs/supervision-protocols/`](supervision-protocols/).

--- a/docs/verification/muse.md
+++ b/docs/verification/muse.md
@@ -48,7 +48,7 @@ $ grep -nE 'muse-bin|exec ' launcher.sh
 
 `ps -o comm= -p <pid>` returns the full executable path, whose basename is `muse-bin-<version>`.
 That is why both `bin/fm-harness.sh` and `bin/backends/tmux.sh` match the anchored prefix `muse-bin-*` rather than an exact name, and why neither can rely on an install-path component: `~/.local/bin/muse-bin-<version>` contains no `muse` path component.
-The Muse launch clears `CLAUDECODE`, `PI_CODING_AGENT`, `GROK_AGENT`, and `FM_PI_HARNESS` before the worker starts so foreign primary markers cannot override the versioned ancestry.
+The common verified-adapter launch boundary clears `CLAUDECODE`, `PI_CODING_AGENT`, `GROK_AGENT`, and `FM_PI_HARNESS` for markerless targets such as Muse before the worker starts, so foreign primary markers cannot override the versioned ancestry.
 
 [`runtime-backends.md`](runtime-backends.md#agent-liveness-name-sources) owns the resulting tmux liveness verdict and its relationship to the portable decoy regression.
 

--- a/docs/verification/muse.md
+++ b/docs/verification/muse.md
@@ -48,7 +48,7 @@ $ grep -nE 'muse-bin|exec ' launcher.sh
 
 `ps -o comm= -p <pid>` returns the full executable path, whose basename is `muse-bin-<version>`.
 That is why both `bin/fm-harness.sh` and `bin/backends/tmux.sh` match the anchored prefix `muse-bin-*` rather than an exact name, and why neither can rely on an install-path component: `~/.local/bin/muse-bin-<version>` contains no `muse` path component.
-The common verified-adapter launch boundary clears `CLAUDECODE`, `PI_CODING_AGENT`, `GROK_AGENT`, and `FM_PI_HARNESS` for markerless targets such as Muse before the worker starts, so foreign primary markers cannot override the versioned ancestry.
+[`configuration.md`](../configuration.md#harness-support) owns the current verified-adapter launch-boundary identity isolation that protects this ancestry signal.
 
 [`runtime-backends.md`](runtime-backends.md#agent-liveness-name-sources) owns the resulting tmux liveness verdict and its relationship to the portable decoy regression.
 

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -192,7 +192,7 @@ test_kimi_launch_then_send_is_verified() {
   assert_contains "$out" "spawned $id harness=kimi" "kimi spawn did not report success"
 
   launch=$(cat "$CASE_DIR/launch.log")
-  [ "$launch" = "'$FAKEBIN_DIR/kimi' --model 'kimi-code/k3' --auto" ] \
+  [ "$launch" = "env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT '$FAKEBIN_DIR/kimi' --model 'kimi-code/k3' --auto" ] \
     || fail "kimi launch did not use the absolute binary, model, and --auto only: $launch"
   assert_not_contains "$launch" "--effort" "kimi launch emitted a nonexistent effort flag"
   assert_not_contains "$launch" "turn-ended" "kimi launch embedded a turn-end path"
@@ -449,7 +449,7 @@ test_kimi_falls_back_to_expanded_home_binary() {
   rc=$?
   expect_code 0 "$rc" "Kimi HOME fallback spawn should succeed"
   launch=$(cat "$CASE_DIR/launch.log")
-  [ "$launch" = "'$fallback' --auto" ] \
+  [ "$launch" = "env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT '$fallback' --auto" ] \
     || fail "Kimi fallback did not expand HOME into an absolute executable: $launch"
   pass "fm-spawn: Kimi fallback expands the active HOME"
 }

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -832,8 +832,30 @@ test_spawn_explicit_harness_uses_explicit_profile_axes() {
   pass "C8 spawn: an explicit --harness still honors explicit model/effort flags"
 }
 
+install_harness_identity_probe() {  # <fakebin> <harness>
+  local fakebin=$1 harness=$2
+  cp "$(command -v bash)" "$fakebin/$harness-runtime"
+  cat > "$fakebin/$harness" <<'SH'
+#!/usr/bin/env bash
+set -u
+exec "$FM_FAKE_HARNESS_RUNTIME" -c '
+  detected=$($FM_FAKE_HARNESS_PROBE)
+  {
+    printf "detected=%s\n" "$detected"
+    printf "CLAUDECODE=%s\n" "${CLAUDECODE:-}"
+    printf "PI_CODING_AGENT=%s\n" "${PI_CODING_AGENT:-}"
+    printf "FM_PI_HARNESS=%s\n" "${FM_PI_HARNESS:-}"
+    printf "GROK_AGENT=%s\n" "${GROK_AGENT:-}"
+    printf "CLAUDE_CONFIG_DIR=%s\n" "${CLAUDE_CONFIG_DIR:-}"
+    "$FM_FAKE_SUPERVISION_PROBE"
+  } > "$FM_FAKE_HARNESS_RESULT"
+'
+SH
+  chmod +x "$fakebin/$harness"
+}
+
 test_spawned_secondmate_uses_its_harness_supervision_model() {
-  local harness expected w sm launchlog launch fakebin out
+  local harness expected w sm launchlog launch fakebin out result clean_result runtime
   for harness in codex claude; do
     w="$TMP_ROOT/spawn-supervision-model-$harness"
     sm="$w/sm"
@@ -841,7 +863,7 @@ test_spawned_secondmate_uses_its_harness_supervision_model() {
     mkdir -p "$w/home/config"
     printf '%s\n' "$harness" > "$w/home/config/secondmate-harness"
     make_seeded_home "$sm" sm
-    spawn_secondmate_capture "$w" sm "$sm" "$launchlog" >/dev/null 2>&1
+    spawn_secondmate_capture "$w" sm "$sm" "$launchlog" --harness "$harness" >/dev/null 2>&1
     fm_write_meta "$sm/state/task.meta" "window=firstmate:fm-task" "kind=ship"
     touch "$sm/state/.last-watcher-beat"
     fakebin="$w/tmux-sm/fakebin"
@@ -867,8 +889,62 @@ SH
           || fail "Claude secondmate with a fresh beacon should use auto-arm supervision, got: $out"
         ;;
     esac
+
+    install_harness_identity_probe "$fakebin" "$harness"
+    runtime="$fakebin/$harness-runtime"
+    if [ "$harness" = codex ]; then
+      # Hold the generated launch tuple constant and remove only the inherited
+      # identity markers. An ancestry-selected Codex result here proves the
+      # executable fixture itself is valid and rules out ancestry as the cause.
+      clean_result="$w/$harness-clean.result"
+      env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
+        FM_FAKE_HARNESS_RUNTIME="$runtime" \
+        FM_FAKE_HARNESS_PROBE="$ROOT/bin/fm-harness.sh" \
+        FM_FAKE_SUPERVISION_PROBE="$ROOT/bin/fm-supervision-instructions.sh" \
+        FM_FAKE_HARNESS_RESULT="$clean_result" \
+        PATH="$fakebin:$BASE_PATH" CLAUDE_CONFIG_DIR="$w/claude-config" \
+        bash -c "$launch"
+      assert_grep 'detected=codex' "$clean_result" \
+        "clean-environment Codex launch did not detect its executable ancestry: $(cat "$clean_result")"
+      assert_grep 'primary harness: codex' "$clean_result" \
+        "clean-environment Codex launch did not render its bounded protocol"
+    fi
+    result="$w/$harness-marked.result"
+    FM_FAKE_HARNESS_RUNTIME="$runtime" \
+      FM_FAKE_HARNESS_PROBE="$ROOT/bin/fm-harness.sh" \
+      FM_FAKE_SUPERVISION_PROBE="$ROOT/bin/fm-supervision-instructions.sh" \
+      FM_FAKE_HARNESS_RESULT="$result" \
+      PATH="$fakebin:$BASE_PATH" CLAUDECODE=1 PI_CODING_AGENT=true \
+      FM_PI_HARNESS=pi-signed GROK_AGENT=1 CLAUDE_CONFIG_DIR="$w/claude-config" \
+      bash -c "$launch"
+    assert_grep "detected=$harness" "$result" \
+      "$harness child selected the wrong harness under inherited primary markers"
+    assert_grep "primary harness: $harness" "$result" \
+      "$harness child rendered the wrong primary supervision protocol"
+    case "$harness" in
+      codex)
+        assert_grep 'foreground watcher checkpoint' "$result" \
+          "Codex child did not render its bounded checkpoint protocol"
+        for expected in CLAUDECODE PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT; do
+          [ "$(grep "^$expected=" "$result")" = "$expected=" ] \
+            || fail "Codex child retained conflicting harness marker $expected"
+        done
+        ;;
+      claude)
+        assert_grep 'CLAUDECODE=1' "$result" \
+          "matching Claude launch discarded its legitimate identity marker"
+        assert_grep "CLAUDE_CONFIG_DIR=$w/claude-config" "$result" \
+          "matching Claude launch discarded its selected config store"
+        assert_grep 'Stop-owned auto-arm' "$result" \
+          "Claude child did not render its Stop-owned protocol"
+        for expected in PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT; do
+          [ "$(grep "^$expected=" "$result")" = "$expected=" ] \
+            || fail "Claude child retained conflicting harness marker $expected"
+        done
+        ;;
+    esac
   done
-  pass "C9 spawn: secondmate launch pins supervision to its own harness"
+  pass "C9 spawn: secondmate launch pins supervision and child identity to its own harness"
 }
 
 # The harness fallback chain (secondmate-harness -> crew-harness -> own) still

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -129,7 +129,7 @@ test_no_profile_keeps_claude_profile_defaults() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
+  expected="env -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch did not use the canonical launch kind"$'\n'"expected: $expected"$'\n'"actual:   $launch"
   pass "no --model/--effort records defaults and types the claude launch instructions"
 }


### PR DESCRIPTION
## What Changed

- Scrub foreign harness identity markers at the shared verified-adapter launch boundary while preserving the selected harness’s markers, configuration, and credentials.
- Add regression coverage for marked and clean child environments, including secondmate supervision and Claude/Kimi launch construction.
- Document launch-boundary identity isolation and its ownership across harness configuration and verification guidance.

## Risk Assessment

✅ Low: The change is narrowly scoped to target-specific environment cleanup at the shared launch boundary, preserves selected-harness variables, and introduces no substantiated correctness or compatibility issues.

## Testing

The corrected end-to-end spawn-boundary run and affected Kimi, Muse, and dispatch suites passed. Evidence records generated CLI launches, conflicting inherited markers, child detection, marker removal/preservation, and rendered supervision protocols. This is a CLI/runtime change with no rendered UI surface, so screenshots are not applicable.

<details>
<summary>Evidence: End-to-end identity and supervision transcript</summary>

```text
+ fm-secondmate-harness.test.sh:879: launch='env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_PUBLIC_FOLLOWUP_PRIMARY_HOME='\''<fixture>/spawn-supervision-model-codex/home'\'' FM_HOME='\''<fixture>/spawn-supervision-model-codex/sm'\'' FM_TRACE_CONTEXT=off FM_SUPERVISION_MODEL=persistent codex --dangerously-bypass-approvals-and-sandbox "$('\''<repo>/bin/fm-operational-input.sh'\'' encode launch-brief < '\''<fixture>/spawn-supervision-model-codex/sm/data/charter.md'\'')"'
+ fm-secondmate-harness.test.sh:913: CLAUDECODE=1
+ fm-secondmate-harness.test.sh:913: PI_CODING_AGENT=true
+ fm-secondmate-harness.test.sh:913: FM_PI_HARNESS=pi-signed
+ fm-secondmate-harness.test.sh:913: GROK_AGENT=1
+ fm-secondmate-harness.test.sh:913: CLAUDE_CONFIG_DIR=<fixture>/spawn-supervision-model-codex/claude-config
+ fm-secondmate-harness.test.sh:920: assert_grep detected=codex <fixture>/spawn-supervision-model-codex/codex-marked.result 'codex child selected the wrong harness under inherited primary markers'
+ fm-secondmate-harness.test.sh:922: assert_grep 'primary harness: codex' <fixture>/spawn-supervision-model-codex/codex-marked.result 'codex child rendered the wrong primary supervision protocol'
+ fm-secondmate-harness.test.sh:926: assert_grep 'foreground watcher checkpoint' <fixture>/spawn-supervision-model-codex/codex-marked.result 'Codex child did not render its bounded checkpoint protocol'
++ fm-secondmate-harness.test.sh:929: grep '^CLAUDECODE=' <fixture>/spawn-supervision-model-codex/codex-marked.result
+ fm-secondmate-harness.test.sh:929: '[' CLAUDECODE= = CLAUDECODE= ']'
++ fm-secondmate-harness.test.sh:929: grep '^PI_CODING_AGENT=' <fixture>/spawn-supervision-model-codex/codex-marked.result
+ fm-secondmate-harness.test.sh:929: '[' PI_CODING_AGENT= = PI_CODING_AGENT= ']'
++ fm-secondmate-harness.test.sh:929: grep '^FM_PI_HARNESS=' <fixture>/spawn-supervision-model-codex/codex-marked.result
+ fm-secondmate-harness.test.sh:929: '[' FM_PI_HARNESS= = FM_PI_HARNESS= ']'
++ fm-secondmate-harness.test.sh:929: grep '^GROK_AGENT=' <fixture>/spawn-supervision-model-codex/codex-marked.result
+ fm-secondmate-harness.test.sh:929: '[' GROK_AGENT= = GROK_AGENT= ']'
+ fm-secondmate-harness.test.sh:879: launch='env -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_PUBLIC_FOLLOWUP_PRIMARY_HOME='\''<fixture>/spawn-supervision-model-claude/home'\'' FM_HOME='\''<fixture>/spawn-supervision-model-claude/sm'\'' FM_TRACE_CONTEXT=off FM_SUPERVISION_MODEL=autoarm CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "$('\''<repo>/bin/fm-operational-input.sh'\'' encode launch-brief < '\''<fixture>/spawn-supervision-model-claude/sm/data/charter.md'\'')"'
+ fm-secondmate-harness.test.sh:913: CLAUDECODE=1
+ fm-secondmate-harness.test.sh:913: PI_CODING_AGENT=true
+ fm-secondmate-harness.test.sh:913: FM_PI_HARNESS=pi-signed
+ fm-secondmate-harness.test.sh:913: GROK_AGENT=1
+ fm-secondmate-harness.test.sh:913: CLAUDE_CONFIG_DIR=<fixture>/spawn-supervision-model-claude/claude-config
+ fm-secondmate-harness.test.sh:920: assert_grep detected=claude <fixture>/spawn-supervision-model-claude/claude-marked.result 'claude child selected the wrong harness under inherited primary markers'
+ fm-secondmate-harness.test.sh:922: assert_grep 'primary harness: claude' <fixture>/spawn-supervision-model-claude/claude-marked.result 'claude child rendered the wrong primary supervision protocol'
+ fm-secondmate-harness.test.sh:934: assert_grep CLAUDECODE=1 <fixture>/spawn-supervision-model-claude/claude-marked.result 'matching Claude launch discarded its legitimate identity marker'
+ fm-secondmate-harness.test.sh:936: assert_grep CLAUDE_CONFIG_DIR=<fixture>/spawn-supervision-model-claude/claude-config <fixture>/spawn-supervision-model-claude/claude-marked.result 'matching Claude launch discarded its selected config store'
+ fm-secondmate-harness.test.sh:938: assert_grep 'Stop-owned auto-arm' <fixture>/spawn-supervision-model-claude/claude-marked.result 'Claude child did not render its Stop-owned protocol'
++ fm-secondmate-harness.test.sh:941: grep '^PI_CODING_AGENT=' <fixture>/spawn-supervision-model-claude/claude-marked.result
+ fm-secondmate-harness.test.sh:941: '[' PI_CODING_AGENT= = PI_CODING_AGENT= ']'
++ fm-secondmate-harness.test.sh:941: grep '^FM_PI_HARNESS=' <fixture>/spawn-supervision-model-claude/claude-marked.result
+ fm-secondmate-harness.test.sh:941: '[' FM_PI_HARNESS= = FM_PI_HARNESS= ']'
++ fm-secondmate-harness.test.sh:941: grep '^GROK_AGENT=' <fixture>/spawn-supervision-model-claude/claude-marked.result
+ fm-secondmate-harness.test.sh:941: '[' GROK_AGENT= = GROK_AGENT= ']'
+ fm-secondmate-harness.test.sh:947: pass 'C9 spawn: secondmate launch pins supervision and child identity to its own harness'
```
</details>
<details>
<summary>Evidence: Secondmate harness suite output</summary>

```text
ok - A1 fm-harness.sh secondmate resolves the fallback chain; crew mode unchanged
ok - C1 fm-harness.sh secondmate-model/secondmate-effort resolve the optional tokens; bare harness stays empty (backward-compat)
ok - pi-signed identity: authoritative launch selection distinguishes shared wrapper ancestry
ok - harness identity: dash-leading ps command names are basename operands, not options
ok - B1 propagate_inheritable_config: copy, idempotence, convergence, absence-mirror, exclusion, no-op, skip diagnostics
ok - B2 spawn: secondmate runs the secondmate harness; its home inherits declared config
ok - B3 spawn: an absent secondmate-harness falls back to the crew harness (backward-compat)
ok - B4 spawn: no config at all -> own harness and no propagation side effects
ok - B5 spawn: an explicit per-spawn harness arg overrides config/secondmate-harness
ok - B6 spawn: an unverified resolved secondmate harness is refused (guard intact)
ok - B5b spawn: FM_BACKEND wins over inherited config/backend
ok - B5c spawn: explicit --backend wins over FM_BACKEND and inherited config/backend
ok - C2 spawn: a bare harness-only secondmate-harness file launches with no model/effort flag (backward-compat)
ok - C3 spawn: config/secondmate-harness's model token threads --model into the launch and meta
ok - C4 spawn: config/secondmate-harness's model+effort tokens thread into the launch and meta
ok - C5 spawn: an explicit --model overrides config/secondmate-harness's model token; the file's effort token still applies
ok - C6 spawn: an explicit --effort overrides config/secondmate-harness's effort token; the file's model token still applies
ok - C7 spawn: an explicit --harness starts with clean model/effort defaults
ok - C8 spawn: an explicit --harness still honors explicit model/effort flags
ok - C9 spawn: secondmate launch pins supervision and child identity to its own harness
ok - C9 spawn: the harness fallback chain still resolves with no tokens; crew/scout launches are unaffected by this feature
ok - B7 bootstrap sweep pushes, re-converges, and mirrors absence; never inherits secondmate-harness
ok - B8 bootstrap sweep propagates config even when the home's tracked files are already current
ok - B9 bootstrap sweep defers new inherited config until the home ignores it
ok - B10 bootstrap sweep materializes and inherits the startup-memory default while fast-forwarding
ok - B12b backend inheritance: present values and primary absence converge exactly
ok - B12c presentation inheritance: the primary default converges on, and only an explicit opt-out propagates off
ok - B11 bootstrap sweep surfaces config propagation failures
ok - B11 bootstrap rereads completed config writes after partial propagation
ok - B12 config-push propagates via shared live discovery, reports items, rereads on change only, and does not fast-forward
ok - B13 config-push reports dirty, non-allowing, and invalid homes without failing warnings-only runs
ok - B14 config-push exits nonzero on real propagation errors
ok - B14 config-push rereads completed config writes after partial propagation
ok - B15 config reread is per-home, exact-byte, ordered, and pointer-only
ok - B16 config reread isolation, ABSENT, generation safety, send failure, and retry
ok - B20 config reread publication failures retain exact generations for retry
ok - B21 config reread instruction-write failures retain exact retry generations
ok - B21 config reread preserves exact bytes when temporary adoption also fails
ok - B21 config reread serializes concurrent propagation and delivery
ok - B22 full config reread retry queues drain before new publication
ok - B23 mixed config reread delivery failures still bound sent history
ok - B26 config reread delivery stops after the oldest failed generation
ok - B17 config reread skips unchanged homes and reads destination post-write bytes
ok - B18 bootstrap config reread path works; spawn flexibility remains defaults-only
ok - B19 bootstrap respawns before inherited-config reread
ok - B25 spawn quarantines stale rereads without blocking relaunch
ok - B24 bootstrap detect-only mode remains filesystem read-only
# all fm-secondmate-harness tests passed
```
</details>
<details>
<summary>Evidence: Kimi harness suite output</summary>

```text
ok - Kimi hook install is idempotent and removal restores every foreign config byte
ok - Kimi hook removal preserves owned newline boundaries and pristine bytes
ok - Kimi hook install refuses missing, malformed, and surprising config without writing
ok - Kimi hook install refuses without jq before any config write
ok - fm-spawn: kimi launches, delivers its brief, and registers a guarded turn-end token
ok - Kimi hook stays silent and inert without a Firstmate registry token
ok - fm-spawn: unsafe Kimi global config refuses before pane creation
ok - fm-teardown: Kimi task pointer and registry token are removed
ok - fm-spawn: Kimi fallback expands the active HOME
ok - fm-spawn: missing Kimi executable refuses before pane creation
ok - fm-spawn: kimi treats a silent pointer drop as a failed spawn
ok - fm-spawn: kimi never sends the brief pointer before an observable ready signal
ok - fm-harness: markerless kimi is detected by ancestry after env-marker precedence
lock acquired: harness pid 37880
ok - fm-lock recognizes Kimi ancestry and live lock holders
ok - busy detection: real Kimi moon-plus-middot captures require its harness while idle labels stay idle
ok - fm-watch classifies Kimi as unknown rather than from its spinner, and Grok's fallback stays isolated
ok - composer classifier: kimi's existing bordered > shape is already safe without an override
```
</details>
<details>
<summary>Evidence: Muse harness suite output</summary>

```text
ok - muse is detected through any versioned muse-bin ancestor
ok - muse detection does not claim unrelated muse-containing commands
ok - muse launch clears foreign harness markers before ancestry detection
ok - muse spawn launches with autonomy, privacy control, and a positional brief
ok - muse maps the shared effort vocabulary and reaches ultra only via explicit max
ok - muse spawn refuses when no credential can reach the provider
ok - muse spawn refuses a META_API_KEY that cannot reach the worker
ok - muse spawn accepts a stored credential without META_API_KEY
ok - muse resolves relative XDG roots before preflight and launch
ok - muse is refused as a secondmate harness
ok - muse spawn writes a session binding that teardown removes
ok - every accepted muse Escape alias clears the restored composer
ok - the composer clear is scoped to muse and does not touch other adapters
ok - a failed muse composer clear fails loudly instead of leaving stale input
ok - the run fold tracks open, settled, interrupted, reopened, and run-free logs
ok - a nested terminal record never settles an in-flight run
ok - the session binding folds only the log matching this task's worktree
ok - workspace bindings compare decoded paths literally
ok - spawn-time exclusions select the current session across equal mtimes
ok - the Muse session cache avoids rescans and refreshes safely across incarnations
ok - a changed Muse namespace revalidates cached session uniqueness
ok - sub-agent session logs are excluded from the parent's busy fold
ok - every unproven muse binding classifies unknown rather than idle
ok - a settled session log reads idle for both completed and interrupted turns
ok - muse trusts no busy record source
```
</details>
<details>
<summary>Evidence: Spawn dispatch suite output</summary>

```text
ok - no --model/--effort records defaults and types the claude launch instructions
ok - relative home overrides ignore CDPATH and become absolute before spawn launch construction
ok - FM_HOME defaults resolve relative paths and preserve absolute spellings
ok - absolute override spellings are preserved in spawn launch paths
ok - unresolvable relative spawn overrides fail with named diagnostics
ok - active crew-dispatch profile requires an explicit harness for ship spawns
ok - active crew-dispatch profile requires an explicit harness for scout spawns
ok - active crew-dispatch profile allows an explicit resolved harness
ok - active crew-dispatch profile allows the legacy positional harness form
ok - active crew-dispatch profile allows the raw launch-command escape hatch
ok - claude receives --model and --effort profile flags
ok - codex receives --model and model_reasoning_effort profile flags
ok - codex omits unsupported max effort instead of passing a bad config value
ok - grok receives --model and --reasoning-effort profile flags
ok - grok omits unsupported max reasoning effort
ok - grok omits unsupported xhigh reasoning effort
ok - opencode receives --model and omits the unsupported effort axis
ok - pi receives --model and --thinking max profile flags
ok - pi-signed shares Pi launch semantics while preserving its configured and recorded identity
ok - pi-signed refuses safely and actionably when the selected executable is unavailable
ok - pi-signed is a distinct persistent secondmate runtime with shared Pi supervision semantics
ok - batch dispatch forwards shared --harness, --model, and --effort to every pair
ok - claude forwards firstmate's CLAUDE_CONFIG_DIR so the crewmate uses the same credential store
ok - claude omits the config-dir prefix when firstmate runs with the single-store default
ok - non-claude harnesses do not receive the claude CLAUDE_CONFIG_DIR prefix
ok - active crew-dispatch profile does not block secondmate launches
# all fm-spawn-dispatch-profile tests passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Baseline inspection: `git status --short --branch`, `git rev-parse HEAD`, and `git diff 85e750ab9b76df275c1f6b9e2bc95b671955bae9..a641d970502d8eda780ef4f10f7c44440a409eff`</code>
- <code>Invalid instrumentation attempt: `PS4=... bash -x tests/fm-secondmate-harness.test.sh` (xtrace polluted an stderr-sensitive fixture; discarded as test evidence)</code>
- `PS4=... BASH_XTRACEFD=9 bash -x tests/fm-secondmate-harness.test.sh`
- <code>`bash tests/fm-kimi-harness.test.sh` (including an isolated retry confirming exit 0)</code>
- `bash tests/fm-spawn-dispatch-profile.test.sh`
- `bash tests/fm-muse-harness.test.sh`
- <code>Extracted the C9 behavior trace into `harness-identity-e2e-transcript.log`</code>
- <code>Cleanup verification: `git rev-parse HEAD; git status --short`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
