### PR TITLE
docs: adopt Firstmate ADLC as standing delivery process model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,6 +245,10 @@ When the captain invokes `/stow`, load the `stow` skill for the complete knowled
 ## 7. Task lifecycle
 
 The delivery lifecycle is an always-loaded operational contract; referenced scripts own exact commands, flags, and data mechanics.
+Firstmate's standing delivery process model is ADLC (agentic delivery lifecycle).
+Owner: [`docs/adlc-standard.md`](docs/adlc-standard.md) - do not restate stages here.
+Apply at intake when classifying ship vs scout, when scout is required, and when explaining outcomes to the captain.
+ADLC does not change hard rules in section 1 or delivery mode / yolo mechanics in this section.
 
 ### Intake and authority
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,7 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 ## Development
 
 Tracked changes to firstmate itself - `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, `.agents/skills/`, and `skills/` - ship through the `no-mistakes` pipeline on a feature branch and require an explicit merge approval.
+Firstmate's standing delivery process model is ADLC; see [`docs/adlc-standard.md`](docs/adlc-standard.md).
 Before making any such change, load the agent-only `firstmate-coding-guidelines` skill (`.agents/skills/firstmate-coding-guidelines/SKILL.md`).
 It has the knowledge-placement rules that keep `AGENTS.md` from regrowing after each diet pass.
 There is no reliable way for `bin/fm-brief.sh`'s scaffold to detect that a task's repo is firstmate itself, so firstmate adds this skill's load line to firstmate-repo briefs by hand.

--- a/docs/adlc-standard.md
+++ b/docs/adlc-standard.md
@@ -1,0 +1,115 @@
+# Firstmate ADLC
+
+Standing delivery process model for Firstmate fleets (captain-approved 2026-08-10).
+
+This document is the one owner of the ADLC stage map and scout-when-required rules.
+Task lifecycle mechanics stay in [`AGENTS.md`](../AGENTS.md) section 7.
+Supervision mechanics stay in [`AGENTS.md`](../AGENTS.md) section 8.
+Hard laws stay in [`AGENTS.md`](../AGENTS.md) section 1.
+
+## What ADLC means here
+
+ADLC is the **agentic delivery lifecycle** for Firstmate fleets.
+It serves the same goal as a traditional software delivery lifecycle: intent, build, review, land, and learn.
+It shortens cycles by pairing agents for implementation and checks with human gates for authority and product judgment.
+It is a process model only.
+It is not a second orchestration runtime, control plane, or rename of existing roles.
+
+## Stage table
+
+| Stage | Human/agent | Firstmate mechanism |
+| --- | --- | --- |
+| Goal | Captain | Intake, backlog item, acceptance criteria |
+| PRD / investigation | Scout when needed | `scout` → `data/<id>/report.md`; promote via `fm-promote` |
+| Architecture | Scout when multi-subsystem/greenfield | Report + constraints in ship brief |
+| Implementation | Agents | Ship crewmate, isolated worktree, `fm-spawn` |
+| Human review | Captain / configured authority | `needs-decision`, ask-user, **merge authority** |
+| Testing & eval | Agents + forge | `no-mistakes` when rigor selected; CI; PR-CI guardians |
+| Land / deploy | Merge authority + platform | `fm-pr-merge` / local merge after approval; deploy is platform (e.g. Vercel), not a firstmate universal auto-deploy |
+| Monitoring | Firstmate + optional project checks | Watcher, merge poll, guardians; prod APM only if project registers it |
+| Continuous iteration | Fleet | Backlog re-eval, open-work, interrupt-resume, secondmates |
+
+## Default path
+
+```text
+Goal
+  → [scout if uncertain]
+  → Ship
+  → human decisions (when required)
+  → automated checks
+  → green PR
+  → captain merge (or standing yolo for green routine merges)
+  → platform deploy (project-owned)
+  → supervise / loop
+```
+
+Ship is the default deliverable once implementation is authorized.
+Keep bounded research inside the ship unless a scout rule below fires.
+
+## When scout is required
+
+These cases are binding:
+
+- Unresolved uncertainty could change whether or what to build.
+- Multi-subsystem or greenfield architecture needs a design boundary before implementation.
+- The captain explicitly asks for investigation, design, or a report only.
+
+Otherwise ship is the default.
+Do not open a parallel design-only scout when established evidence already answers the question and implementation intent is clear.
+A scout report may recommend implementation.
+It does not authorize it.
+Promote with `fm-promote` when the captain authorizes the ship.
+
+## Delivery mode is rigor, not a different lifecycle
+
+Delivery modes (`no-mistakes`, `direct-PR`, `local-only`) choose how hard the path validates before a PR or local branch is ready.
+They are orthogonal to ADLC stages.
+ADLC does not force `no-mistakes` on every ship (for example a pure process-doc or internal tooling change may use `direct-PR` when the project's standing posture and task classification allow it).
+Resolve mode at intake per [`AGENTS.md`](../AGENTS.md) section 7.
+Do not invent a second lifecycle per mode.
+
+## Yolo is orthogonal
+
+Yolo is merge and gate authority posture, not a stage.
+
+- **Yolo off** (common standing default): the captain owns merges and captain-gated ask-user findings.
+- **Yolo on**: firstmate may decide routine gates within the captain's original request and accepted task criteria, and may merge only green work.
+- Never merge a red PR without a current explicit captain instruction that states that concrete merge.
+
+Standing yolo never authorizes destructive, irreversible, or security-sensitive choices.
+Those still need explicit captain word.
+Details: [`AGENTS.md`](../AGENTS.md) section 7 and the `ask-user-authority` skill.
+
+## Hard laws ADLC does not relax
+
+ADLC does not weaken section 1 hard rules.
+Full text lives in [`AGENTS.md`](../AGENTS.md) section 1.
+In short:
+
+- No firstmate project writes (crews change product code).
+- No merge without captain word (except standing yolo for green routine merges).
+- No discard of unlanded work without explicit authority.
+- Crews never address the captain.
+
+## Done means landed
+
+A ship is done when the change is on the default branch (or an approved local-only merge completed).
+A worker `done: PR <url>` line means the PR is ready for configured merge authority.
+It is not land.
+Teardown follows confirmed land, not the worker's PR-open or checks-green signal alone.
+See [`AGENTS.md`](../AGENTS.md) section 7 for teardown and merge owners.
+
+## Non-goals
+
+ADLC does not add:
+
+- A second control plane, workflow engine, or parallel task state machine.
+- Universal auto-deploy or auto-prod patch without captain and platform ownership.
+- Marketing renames of crewmates, scouts, or secondmates.
+- A restatement of full section 7 or section 8 contracts (point there instead).
+
+## Where this applies
+
+Apply ADLC at intake when classifying ship vs scout, when deciding whether scout is required, and when explaining outcomes to the captain in plain language.
+Keep operator-facing wording on project outcomes (investigation, fix, PR, merge, blocker), not internal stage marketing labels.
+Cross-reference this doc; do not copy the stage table into `AGENTS.md` or briefs.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -205,6 +205,10 @@
       "audience": "public-product"
     },
     {
+      "path": "docs/adlc-standard.md",
+      "audience": "maintainer-architecture"
+    },
+    {
       "path": "docs/agent-control.md",
       "audience": "maintainer-architecture"
     },


### PR DESCRIPTION
## Summary
- Adopt **Firstmate ADLC** (agentic delivery lifecycle) as the standing delivery process model (captain-approved 2026-08-10).
- Add one-owner standard at `docs/adlc-standard.md` (stage map, scout-when-required, delivery-mode/yolo orthogonality, hard laws, done=landed, non-goals).
- Thin pointer in `AGENTS.md` §7 and one-liner in `CONTRIBUTING.md`; register the surface in `docs/documentation-audiences.json`.

## Intentional delivery deviation
mode=`direct-PR` for this pure process-doc ship (standing firstmate posture is no-mistakes; docs-only exception per task).

## Test plan
- [x] `bin/fm-doc-audience-check.sh` → ok (surfaces=68)
- [x] Grep: full ADLC stage table only in `docs/adlc-standard.md`
- [ ] Human review of pointer size discipline (no stage table in AGENTS.md)

Never merge without captain word.