### PR TITLE
feat(bin): let crews use documented AGENTS.md bypasses for pipeline anomalies

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -178,6 +178,13 @@ shell_quote() {
 
 STATUS_FILE=$(shell_quote "$STATE/$ID.status")
 
+IFS= read -r -d '' NO_MISTAKES_ANOMALY_RULE <<'EOF' || true
+   Before appending `blocked:` for a no-mistakes pipeline anomaly that is not a real code defect or shared-daemon error, check the current project's own `AGENTS.md` for an exact, approved, worker-safe bypass that does not touch the shared no-mistakes daemon, edit product code, or require captain authorization.
+   If one exists, apply it directly and independently verify the expected outcome (for example with `gh-axi` or `gh pr checks`) before continuing.
+   Never invent a bypass; if the symptom is not already documented there, append `blocked: {the anomaly}` and stop.
+EOF
+NO_MISTAKES_ANOMALY_RULE=${NO_MISTAKES_ANOMALY_RULE%$'\n'}
+
 if [ "$KIND" = secondmate ]; then
 SECONDMATE_PROJECTS=""
 idx=1
@@ -335,6 +342,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+$NO_MISTAKES_ANOMALY_RULE
 
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
@@ -451,6 +459,7 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+$NO_MISTAKES_ANOMALY_RULE
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -371,6 +371,44 @@ test_ship_project_memory_wording() {
   pass "fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar"
 }
 
+# The no-mistakes anomaly-bypass rule must render identically (same source
+# variable, not a duplicated literal) right after the daemon rule in both
+# crewmate briefs that carry that rule - ship (no-mistakes mode) and scout -
+# so crews never invent a bypass and never touch the shared daemon or product
+# code without an AGENTS.md-documented, worker-safe escape hatch.
+test_no_mistakes_anomaly_bypass_rule() {
+  local home id brief scout_id scout
+  home="$TMP_ROOT/anomaly-bypass-home"
+  mkdir -p "$home/data"
+
+  id="brief-anomaly-e1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "brief was not scaffolded"
+  assert_grep "check the current project's own \`AGENTS.md\` for an exact, approved, worker-safe bypass" "$brief" \
+    "ship DOD must point workers at the project's own AGENTS.md before blocking on an anomaly"
+  assert_grep "does not touch the shared no-mistakes daemon, edit product code, or require captain authorization" "$brief" \
+    "ship DOD must scope the documented bypass to worker-safe, daemon-untouched, captain-free actions"
+  assert_grep "apply it directly and independently verify the expected outcome (for example with \`gh-axi\` or \`gh pr checks\`)" "$brief" \
+    "ship DOD must require independent verification of a documented bypass, not blind trust"
+  assert_grep "Never invent a bypass; if the symptom is not already documented there, append \`blocked: {the anomaly}\` and stop." "$brief" \
+    "ship DOD must still block undocumented anomaly symptoms instead of improvising"
+  awk '/Never stop, restart, or update the shared `no-mistakes` daemon/{found=1} found && /check the current project.s own/{print "adjacent"; exit}' "$brief" \
+    | grep -q adjacent \
+    || fail "ship DOD anomaly-bypass rule must immediately follow the daemon-preservation rule"
+
+  scout_id="brief-anomaly-e2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$scout_id" some-proj --scout >/dev/null 2>&1
+  scout="$home/data/$scout_id/brief.md"
+  assert_present "$scout" "scout brief was not scaffolded"
+  assert_grep "check the current project's own \`AGENTS.md\` for an exact, approved, worker-safe bypass" "$scout" \
+    "scout brief lost the AGENTS.md anomaly-bypass instruction"
+  assert_grep "Never invent a bypass; if the symptom is not already documented there, append \`blocked: {the anomaly}\` and stop." "$scout" \
+    "scout brief must still block undocumented anomaly symptoms instead of improvising"
+
+  pass "fm-brief.sh: no-mistakes anomaly-bypass rule sends workers to AGENTS.md, requires verification, and still blocks undocumented symptoms"
+}
+
 test_herdr_lab_contract_is_explicit_and_complete() {
   local home id brief
   home="$TMP_ROOT/herdr-lab-home"
@@ -720,6 +758,7 @@ test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording
+test_no_mistakes_anomaly_bypass_rule
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path
 test_herdr_lab_omission_is_loud_for_ship_and_scout


### PR DESCRIPTION
## Intent

Update bin/fm-brief.sh so every generated crewmate brief tells workers, before appending blocked for a no-mistakes pipeline anomaly that is not a real code defect or shared-daemon error, to check the current project’s own AGENTS.md for an exact, approved, worker-safe bypass that does not touch the shared no-mistakes daemon, edit product code, or require captain authorization. When such a bypass is already documented, the worker must apply it directly and independently verify the expected outcome, for example with gh-axi or gh pr checks; workers must never invent a bypass and must still block undocumented symptoms. Preserve the existing rule that workers never stop, restart, or update the shared no-mistakes daemon and that only firstmate manages it. Keep the change generic and proportionate, with no project-specific terapeuta or GitHub Free detail hardcoded in bin/fm-brief.sh, keep the bypass detail owned by each project AGENTS.md, avoid duplicating the new instruction source across scaffold variants, and ensure bin/fm-lint.sh passes.

## What Changed
- `bin/fm-brief.sh`: adds a shared `NO_MISTAKES_ANOMALY_RULE` block, appended immediately after the existing "never touch the shared no-mistakes daemon" rule in both the ship (no-mistakes mode) and scout crewmate briefs, instructing workers to check the project's own `AGENTS.md` for an exact, approved, worker-safe bypass before appending `blocked:` for a pipeline anomaly that isn't a real code defect or daemon error.
- The rule requires workers to apply a documented bypass directly and independently verify the outcome (e.g. with `gh-axi` or `gh pr checks`), while still forbidding invented bypasses and still requiring `blocked:` for undocumented symptoms; it stays generic with no project-specific bypass detail hardcoded, and the daemon-preservation rule is unchanged.
- `tests/fm-brief.test.sh`: adds `test_no_mistakes_anomaly_bypass_rule`, verifying the rule text appears verbatim (via the shared source variable, not a duplicated literal) in both the ship and scout briefs, sits immediately after the daemon-preservation rule, and still enforces blocking on undocumented anomalies.

## Risk Assessment

✅ Low: Small, well-scoped addition of one shared static rule string interpolated into two existing brief templates, fully consistent with the stated intent and covered by a behavioral test against the generated brief output.

## Testing

Targeted test suite tests/fm-brief.test.sh passes fully (21/21) including the new anomaly-bypass test, and a manually generated real crewmate brief confirms the AGENTS.md bypass instruction renders end-to-end immediately after the daemon-preservation rule as intended; bin/fm-lint.sh could not be executed due to missing ShellCheck in this sandboxed test phase, which is flagged as a warning since the user intent requires lint to pass.

<details>
<summary>Evidence: fm-brief.test.sh run (21/21 passing, including new anomaly-bypass test)</summary>

```text
ok - fm-brief.sh: bash -n succeeds
/tmp/fm-brief.emnZds/heredoc-in-substitution.sh:2
ok - fm-brief.sh: no heredoc is nested inside a command substitution (Bash 3.2 parse-safe)
ok - fm-brief.sh: --help renders the complete header
ok - fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly
ok - fm-brief.sh: ship --mode is required and closed-set validated
ok - fm-brief.sh: the explicit ship mode wins over the registered posture
ok - fm-brief.sh: --yolo and scout/secondmate --mode are refused, never silently dropped
ok - fm-brief.sh: faster paths use configured authority without stacked review
ok - fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe
ok - fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar
ok - fm-brief.sh: no-mistakes anomaly-bypass rule sends workers to AGENTS.md, requires verification, and still blocks undocumented symptoms
ok - fm-brief.sh: --herdr-lab emits the complete hard safety contract
ok - fm-brief.sh: --herdr-lab uses its quoted Firstmate-owned helper path
ok - fm-brief.sh: ship and scout scaffolds make omitted Herdr intent fail-visible
ok - fm-brief.sh: Herdr lab contract covers scouts and rejects secondmate misuse
ok - fm-brief.sh: --no-projects scaffolds a project-less charter and guards misuse
ok - fm-brief.sh: marked requests avoid generic acknowledgements and preserve material reporting
ok - fm-brief.sh: relative directory inputs ignore CDPATH, render stable absolute charter paths, or fail loudly
ok - fm-brief.sh: custom pause verb renders in every scaffold
ok - fm-brief.sh: investigation and visual-review completions load the shared decision policy
ok - fm-brief: scout and secondmate code paths still scaffold well-formed briefs
```
</details>
<details>
<summary>Evidence: Actual generated ship-mode crewmate brief showing the new AGENTS.md anomaly-bypass rule rendered immediately after the daemon-preservation rule</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of some-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/demo-brief`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/tmp.BBduBzdVAC/state/demo-brief.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.
   Before appending `blocked:` for a no-mistakes pipeline anomaly that is not a real code defect or shared-daemon error, check the current project's own `AGENTS.md` for an exact, approved, worker-safe bypass that does not touch the shared no-mistakes daemon, edit product code, or require captain authorization.
   If one exists, apply it directly and independently verify the expected outcome (for example with `gh-axi` or `gh pr checks`) before continuing.
   Never invent a bypass; if the symptom is not already documented there, append `blocked: {the anomaly}` and stop.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/luizh/.no-mistakes/worktrees/f4c597359d80/01KZNXHFBH6AWTMXY88C0CV0MT/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/luizh/.no-mistakes/worktrees/f4c597359d80/01KZNXHFBH6AWTMXY88C0CV0MT/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (2m1s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `bin/fm-lint.sh` - bin/fm-lint.sh could not be run: ShellCheck 0.11.0 is not installed in this sandbox, and installing system packages is outside this test phase&#39;s allowed boundary. The user intent explicitly requires &#39;ensure bin/fm-lint.sh passes&#39;, which could not be directly verified here. Mitigating evidence: `bash -n bin/fm-brief.sh` passes (via the test suite), and the diff is a small, straightforward heredoc/variable addition consistent with existing patterns already linted elsewhere in the file. A phase with ShellCheck available (e.g. CI) should confirm fm-lint.sh passes before this is considered fully verified.
- `bash tests/fm-brief.test.sh (21/21 passing, including new test_no_mistakes_anomaly_bypass_rule)`
- `Manual: FM_HOME=<tmp> bin/fm-brief.sh demo-brief some-proj --mode no-mistakes, then inspected generated data/demo-brief/brief.md for the anomaly-bypass rule placement`
- `bin/fm-lint.sh (could not run: shellcheck not installed in this environment)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
