### PR TITLE
feat(bin): add read-only sweep for GitHub writes missing the attribution token

### DIFF
--- a/bin/fm-attribution-sweep.sh
+++ b/bin/fm-attribution-sweep.sh
@@ -41,7 +41,12 @@
 #   --repo <owner/name>  repository to sweep (repeatable; default: every repository
 #                        the account owns)
 #   --kind <kind>        comments | reviews | commits (repeatable; default: all three)
-#   --since <iso8601>    window start (default: FM_SWEEP_WINDOW_DAYS, itself 30, days back)
+#   --since <iso8601>    window start, spelled YYYY-MM-DDTHH:MM:SSZ (default:
+#                        FM_SWEEP_WINDOW_DAYS, itself 30, days back). Every window
+#                        filter is a string comparison against GitHub's own UTC
+#                        timestamps, so any other spelling is refused outright
+#                        rather than sorting below every record and quietly
+#                        examining nothing.
 #   --branch <name>      restrict the commits kind to this branch (repeatable)
 #   --budget <n>         maximum GitHub requests for the whole run (default 300).
 #                        There is no unlimited value: 0 permits no request at
@@ -64,7 +69,11 @@
 #   FM_SWEEP_SCOPE repo=<owner/name> kind=<kind> outcome=observed examined=<n> declared=<n> candidates=<n>
 #   FM_SWEEP_SCOPE repo=<owner/name> kind=<kind> outcome=could-not-observe reason=<slug> detail=<text>
 #   FM_SWEEP_CANDIDATE repo=<owner/name> kind=<kind> ref=<id> when=<iso> url=<url> evidence=<k=v,...>
-#   FM_SWEEP_SUMMARY scopes=<n> observed=<n> could_not_observe=<n> declared=<n> candidates=<n> outcome=<clean|candidates|could-not-observe>
+#   FM_SWEEP_SUMMARY scopes=<n> observed=<n> could_not_observe=<n> declared=<n> candidates=<n> requests=<n> outcome=<clean|candidates|could-not-observe>
+#
+# examined counts the records that survived the account and window filters, the
+# same way for all three kinds, so examined always equals declared plus
+# candidates and a gap between them is a bug rather than a reading of the field.
 #
 # Exit status:
 #   0   every scope was observed and no candidate was found
@@ -187,6 +196,19 @@ is_uint() {
   esac
 }
 
+# Every window filter - the pull request walk here and the jq selects sent to
+# GitHub - is a lexicographic comparison against GitHub's own UTC timestamps.
+# That is only sound for one exact spelling: a value like "30d" sorts below every
+# real timestamp, so it would drop every record and report an observed-clean
+# sweep of nothing. The window start is therefore checked to be that spelling
+# before it is ever compared against anything.
+is_iso8601() {
+  case $1 in
+    [0-9][0-9][0-9][0-9]-[0-1][0-9]-[0-3][0-9]T[0-2][0-9]:[0-5][0-9]:[0-6][0-9]Z) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 is_uint "$BUDGET" || die_usage "--budget must be a non-negative integer"
 is_uint "$MAX_PAGES" || die_usage "--max-pages must be a non-negative integer"
 is_uint "$PER_PAGE" || die_usage "--per-page must be a non-negative integer"
@@ -203,9 +225,11 @@ for kind in "${KINDS[@]}"; do
 done
 
 WINDOW_DAYS=${FM_SWEEP_WINDOW_DAYS:-30}
-if [ -z "$SINCE" ]; then
+if [ -n "$SINCE" ]; then
+  is_iso8601 "$SINCE" \
+    || die_usage "--since must be a UTC ISO-8601 timestamp spelled YYYY-MM-DDTHH:MM:SSZ, e.g. 2026-01-01T00:00:00Z"
+else
   is_uint "$WINDOW_DAYS" || die_usage "FM_SWEEP_WINDOW_DAYS must be a non-negative integer"
-  SINCE=$(days_ago_iso "$WINDOW_DAYS")
 fi
 
 NOW=$(now_iso)
@@ -330,10 +354,12 @@ JQ_ENVELOPE='| ([(.n|tostring)] + .r) | join("\n")'
 # "feat/a&b" would otherwise end the query early, and the sweep would report a
 # branch it never actually asked about as observed - a silent wrong answer of
 # exactly the kind this tool exists to prevent. Byte-wise under LC_ALL=C so a
-# non-ASCII name encodes correctly rather than per rendered character.
+# non-ASCII name encodes correctly rather than per rendered character. LC_ALL is
+# local so that byte-wise view stays inside this function: leaking it would
+# silently make sanitize's character bound a byte bound and change the collation
+# every other comparison in the script relies on.
 urlq() {
-  local s=$1 out='' i c
-  LC_ALL=C
+  local s=$1 out='' i c LC_ALL=C
   for ((i = 0; i < ${#s}; i++)); do
     c=${s:i:1}
     case $c in
@@ -419,6 +445,19 @@ unobserved scopes were not searched, so nothing is known about them either way.
 EOF
   fi
 }
+
+# The derived window start is resolved here rather than beside the other
+# argument checks because a system whose date understands neither form yields no
+# window at all. That is a could-not-observe, not a usage error, and reporting it
+# needs the markers above to exist.
+if [ -z "$SINCE" ]; then
+  SINCE=$(days_ago_iso "$WINDOW_DAYS")
+  if ! is_iso8601 "$SINCE"; then
+    SINCE=unresolved
+    run_blocked missing-tool \
+      "date could not compute a window start $WINDOW_DAYS days back, so there is no window to sweep"
+  fi
+fi
 
 if [ -z "$B64D" ]; then
   run_blocked missing-tool "base64 cannot decode on this system; no response could be read"
@@ -508,9 +547,9 @@ sweep_comments() {
       scope_unobserved "$repo" comments unparsable "comment page $page was not parsable" "$declared" "$candidates"
       return
     fi
-    examined=$((examined + raw))
     while IFS='|' read -r id issue when has_token assoc app; do
       [ -n "$id" ] || continue
+      examined=$((examined + 1))
       if [ "$(b64d "$has_token")" = "true" ]; then
         declared=$((declared + 1))
         continue
@@ -657,9 +696,9 @@ sweep_reviews() {
         scope_unobserved "$repo" reviews unparsable "reviews of pull request $number were not parsable" "$declared" "$candidates"
         return
       fi
-      examined=$((examined + raw))
       while IFS='|' read -r id when has_token assoc state; do
         [ -n "$id" ] || continue
+        examined=$((examined + 1))
         if [ "$(b64d "$has_token")" = "true" ]; then
           declared=$((declared + 1))
           continue
@@ -754,11 +793,21 @@ sweep_commits() {
   # filter, so the window and the account are applied here for every source.
   # The raw page count stays unfiltered above this, so pagination still ends on
   # the real page length rather than on how many records survived.
+  #
+  # The window is compared against the LATER of the committer and author dates.
+  # GitHub's own since= filters a branch listing on committer date, while a
+  # rebase or cherry-pick - the fleet's routine lane workflow - keeps an author
+  # date from before the window on a commit pushed inside it. Filtering on author
+  # date alone would let the API return such a commit and then silently drop it
+  # here, which is a write made invisible by a scope that still reads observed.
   commit_jq="{n: length, r: [ .[]
     | select(((.author.login) // \"\") == $ACCOUNT_JQ)
-    | select((((.commit.author.date) // \"\")) >= $SINCE_JQ)
+    | (((.commit.committer.date) // \"\")) as \$committed
+    | (((.commit.author.date) // \"\")) as \$authored
+    | (if \$committed >= \$authored then \$committed else \$authored end) as \$when
+    | select(\$when >= $SINCE_JQ)
     | [ (.sha|@base64),
-        (((.commit.author.date) // \"\")|@base64),
+        (\$when|@base64),
         (((((.commit.message) // \"\")|contains($TOKEN_JQ)))|tostring|@base64),
         ((((.commit.verification.verified) // false)|tostring)|@base64),
         (((.committer.login) // \"none\")|@base64) ]

--- a/bin/fm-attribution-sweep.sh
+++ b/bin/fm-attribution-sweep.sh
@@ -63,9 +63,9 @@
 #                        repository readable. Correctness never depends on the
 #                        value: an over-large page is refused, not silently cut.
 #
-# The window and every bound are printed in the begin and summary markers, and
-# hitting one is reported as could-not-observe rather than silently narrowing
-# what was examined.
+# The window and the request budget are printed in the begin marker and named
+# again in the summary; every other bound is named in the could-not-observe
+# detail when a run hits it, rather than silently narrowing what was examined.
 #
 # Output markers (stdout):
 #   FM_SWEEP_BEGIN <iso> account=<login> since=<iso> token=<token> repos=<n> budget=<n>

--- a/bin/fm-attribution-sweep.sh
+++ b/bin/fm-attribution-sweep.sh
@@ -205,11 +205,32 @@ is_uint() {
 # real timestamp, so it would drop every record and report an observed-clean
 # sweep of nothing. The window start is therefore checked to be that spelling
 # before it is ever compared against anything.
+#
+# The shape alone is not the check. An impossible date that still matches the
+# shape - month 13, day 32, hour 24 - sorts ABOVE every real timestamp, which
+# drops every record and reports the same observed-clean sweep of nothing from
+# the other side. Each component is therefore range-checked against the calendar,
+# so a value that cannot order sensibly against GitHub's timestamps is refused
+# exactly like "30d" is.
 is_iso8601() {
-  case $1 in
-    [0-9][0-9][0-9][0-9]-[0-1][0-9]-[0-3][0-9]T[0-2][0-9]:[0-5][0-9]:[0-6][0-9]Z) return 0 ;;
+  local v=$1 month day hour minute second
+  case $v in
+    [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9]Z) ;;
     *) return 1 ;;
   esac
+  # Base 10 explicitly: "08" and "09" are not octal numbers.
+  month=$((10#${v:5:2}))
+  day=$((10#${v:8:2}))
+  hour=$((10#${v:11:2}))
+  minute=$((10#${v:14:2}))
+  second=$((10#${v:17:2}))
+  { [ "$month" -ge 1 ] && [ "$month" -le 12 ]; } || return 1
+  { [ "$day" -ge 1 ] && [ "$day" -le 31 ]; } || return 1
+  [ "$hour" -le 23 ] || return 1
+  [ "$minute" -le 59 ] || return 1
+  # A leap second is spelled :60 and GitHub can print one, so it is accepted.
+  [ "$second" -le 60 ] || return 1
+  return 0
 }
 
 is_uint "$BUDGET" || die_usage "--budget must be a non-negative integer"
@@ -368,6 +389,20 @@ gh_get() {
 # line, then one "|"-joined record of base64 fields per surviving element.
 JQ_ENVELOPE='| ([(.n|tostring)] + .r) | join("\n")'
 
+# The two halves of that envelope, read back through one pair of helpers rather
+# than open-coded at every listing. The count line drives pagination and the
+# record lines drive the tallies, so a caller that took one from a stale body and
+# the other from a fresh one would page on a length that never described the
+# records it counted. Both halves come from the same GH_BODY here by
+# construction.
+page_count() {
+  printf '%s\n' "$GH_BODY" | head -1
+}
+
+page_records() {
+  printf '%s\n' "$GH_BODY" | tail -n +2
+}
+
 # Percent-encode a value going into a request path or query. A branch named
 # "feat/a&b" would otherwise end the query early, and the sweep would report a
 # branch it never actually asked about as observed - a silent wrong answer of
@@ -523,12 +558,12 @@ if [ "${#REPOS[@]}" -eq 0 ]; then
     if [ "$GH_STATUS" != "ok" ]; then
       run_blocked "$GH_STATUS" "could not enumerate the account's repositories: $GH_DETAIL"
     fi
-    raw=$(printf '%s\n' "$GH_BODY" | head -1)
+    raw=$(page_count)
     is_uint "$raw" || run_blocked unparsable "repository listing page $page was not parsable"
     while IFS= read -r line; do
       [ -n "$line" ] || continue
       REPOS+=("$(b64d "$line")")
-    done < <(printf '%s\n' "$GH_BODY" | tail -n +2)
+    done < <(page_records)
     [ "$raw" -eq "$PER_PAGE" ] || break
     page=$((page + 1))
   done
@@ -587,7 +622,7 @@ sweep_comments() {
       scope_unobserved "$repo" comments "$GH_STATUS" "$GH_DETAIL" "$declared" "$candidates"
       return
     fi
-    raw=$(printf '%s\n' "$GH_BODY" | head -1)
+    raw=$(page_count)
     if ! is_uint "$raw"; then
       scope_unobserved "$repo" comments unparsable "comment page $page was not parsable" "$declared" "$candidates"
       return
@@ -605,7 +640,7 @@ sweep_comments() {
       emit_candidate "$repo" comment "$id" "$(b64d "$when")" \
         "https://github.com/$repo/issues/$issue#issuecomment-$id" \
         "assoc=$(b64d "$assoc"),via_app=$(b64d "$app"),token=absent"
-    done < <(printf '%s\n' "$GH_BODY" | tail -n +2)
+    done < <(page_records)
     [ "$raw" -eq "$PER_PAGE" ] || break
     page=$((page + 1))
   done
@@ -671,7 +706,7 @@ collect_prs_uncached() {
       PR_DETAIL=$GH_DETAIL
       return 1
     fi
-    raw=$(printf '%s\n' "$GH_BODY" | head -1)
+    raw=$(page_count)
     if ! is_uint "$raw"; then
       PR_STATUS=unparsable
       PR_DETAIL="pull request page $page was not parsable"
@@ -685,7 +720,7 @@ collect_prs_uncached() {
         continue
       fi
       PR_NUMBERS+=("$(b64d "$number")")
-    done < <(printf '%s\n' "$GH_BODY" | tail -n +2)
+    done < <(page_records)
     [ "$exhausted" -eq 0 ] || break
     [ "$raw" -eq "$PER_PAGE" ] || break
     page=$((page + 1))
@@ -736,7 +771,7 @@ sweep_reviews() {
         scope_unobserved "$repo" reviews "$GH_STATUS" "pull request $number: $GH_DETAIL" "$declared" "$candidates"
         return
       fi
-      raw=$(printf '%s\n' "$GH_BODY" | head -1)
+      raw=$(page_count)
       if ! is_uint "$raw"; then
         scope_unobserved "$repo" reviews unparsable "reviews of pull request $number were not parsable" "$declared" "$candidates"
         return
@@ -753,7 +788,7 @@ sweep_reviews() {
         emit_candidate "$repo" review "$id" "$(b64d "$when")" \
           "https://github.com/$repo/pull/$number#pullrequestreview-$id" \
           "assoc=$(b64d "$assoc"),state=$(b64d "$state"),pr=$number,token=absent"
-      done < <(printf '%s\n' "$GH_BODY" | tail -n +2)
+      done < <(page_records)
       [ "$raw" -eq "$PER_PAGE" ] || break
       page=$((page + 1))
     done
@@ -797,7 +832,7 @@ sweep_commits() {
         scope_unobserved "$repo" commits "$GH_STATUS" "$GH_DETAIL" "$declared" "$candidates"
         return
       fi
-      raw=$(printf '%s\n' "$GH_BODY" | head -1)
+      raw=$(page_count)
       if ! is_uint "$raw"; then
         scope_unobserved "$repo" commits unparsable "branch page $page was not parsable" "$declared" "$candidates"
         return
@@ -805,7 +840,7 @@ sweep_commits() {
       while IFS= read -r name; do
         [ -n "$name" ] || continue
         branches+=("$(b64d "$name")")
-      done < <(printf '%s\n' "$GH_BODY" | tail -n +2)
+      done < <(page_records)
       [ "$raw" -eq "$PER_PAGE" ] || break
       page=$((page + 1))
     done
@@ -871,7 +906,7 @@ sweep_commits() {
         scope_unobserved "$repo" commits "$GH_STATUS" "$label: $GH_DETAIL" "$declared" "$candidates"
         return
       fi
-      raw=$(printf '%s\n' "$GH_BODY" | head -1)
+      raw=$(page_count)
       if ! is_uint "$raw"; then
         scope_unobserved "$repo" commits unparsable "commits of $label were not parsable" "$declared" "$candidates"
         return
@@ -893,7 +928,7 @@ sweep_commits() {
         emit_candidate "$repo" commit "$sha" "$(b64d "$when")" \
           "https://github.com/$repo/commit/$sha" \
           "$label,signed=$(b64d "$verified"),committer=$(b64d "$committer"),token=absent"
-      done < <(printf '%s\n' "$GH_BODY" | tail -n +2)
+      done < <(page_records)
       [ "$raw" -eq "$PER_PAGE" ] || break
       page=$((page + 1))
     done

--- a/bin/fm-attribution-sweep.sh
+++ b/bin/fm-attribution-sweep.sh
@@ -455,6 +455,12 @@ undeclared model session and the captain's own hand-typed comment look like in
 every field GitHub exposes. The evidence on each line is a signal, not an
 attribution; the captain judges.
 
+Some candidates are known permanent ones. A capability probe on 2026-08-02 left
+five deliberately unprefixed writes in place as this sweep's only real-world red
+control, and reporting them is correct behaviour rather than a finding. Before
+investigating any candidate dated 2026-08-02, check it against the table in
+docs/model-write-attribution.md under "The retained probe writes".
+
 This run covered ${WINDOW_DESCRIPTION}, and writes outside it
 were not examined at all - a clean result says nothing about them. Widen the
 window with --since <iso8601> or FM_SWEEP_WINDOW_DAYS=<days>, and raise --budget

--- a/bin/fm-attribution-sweep.sh
+++ b/bin/fm-attribution-sweep.sh
@@ -47,7 +47,10 @@
 #                        timestamps, so any other spelling is refused outright
 #                        rather than sorting below every record and quietly
 #                        examining nothing.
-#   --branch <name>      restrict the commits kind to this branch (repeatable)
+#   --branch <name>      restrict the commits kind to this branch (repeatable).
+#                        Naming a branch also skips the pull request head pass,
+#                        so a commit whose branch was deleted when its pull
+#                        request closed is not reached by that run.
 #   --budget <n>         maximum GitHub requests for the whole run (default 300).
 #                        There is no unlimited value: 0 permits no request at
 #                        all, and every scope then reports could-not-observe

--- a/bin/fm-attribution-sweep.sh
+++ b/bin/fm-attribution-sweep.sh
@@ -46,7 +46,10 @@
 #                        filter is a string comparison against GitHub's own UTC
 #                        timestamps, so any other spelling is refused outright
 #                        rather than sorting below every record and quietly
-#                        examining nothing.
+#                        examining nothing. A component outside its range -
+#                        month 13, day 32, hour 24 - is refused for the same
+#                        reason from the other side: it matches the shape, then
+#                        sorts above every record and drops them all.
 #   --branch <name>      restrict the commits kind to this branch (repeatable).
 #                        Naming a branch also skips the pull request head pass,
 #                        so a commit whose branch was deleted when its pull

--- a/bin/fm-attribution-sweep.sh
+++ b/bin/fm-attribution-sweep.sh
@@ -42,7 +42,7 @@
 #                        the account owns)
 #   --kind <kind>        comments | reviews | commits (repeatable; default: all three)
 #   --since <iso8601>    window start, spelled YYYY-MM-DDTHH:MM:SSZ (default:
-#                        FM_SWEEP_WINDOW_DAYS, itself 30, days back). Every window
+#                        FM_SWEEP_WINDOW_DAYS, itself 7, days back). Every window
 #                        filter is a string comparison against GitHub's own UTC
 #                        timestamps, so any other spelling is refused outright
 #                        rather than sorting below every record and quietly
@@ -227,7 +227,22 @@ for kind in "${KINDS[@]}"; do
   esac
 done
 
-WINDOW_DAYS=${FM_SWEEP_WINDOW_DAYS:-30}
+# The default window is 7 days, chosen so a default run FINISHES inside the
+# default budget rather than reporting could-not-observe. A detector whose first
+# run usually says it could not look trains its operator to ignore it, and an
+# ignored sweep is worth nothing.
+#
+# The arithmetic, measured on this fleet's own repositories rather than
+# estimated: the commits kind pays a window-independent cost of one listing page
+# per 25 branches plus one request per branch, which on a 128-branch repository
+# is about 134 requests before the window is considered at all, and roughly 155
+# across the three repositories the account owns. Reviews and commits then each
+# spend one request per pull request touched in the window. Measured pull request
+# counts were 38 over 7 days, 66 over 14, and 71 over 30, so the totals come to
+# about 250 requests at 7 days, 310 at 14, and 320 at 30 against a 300 budget.
+# Seven days is therefore the widest default that completes, and it was not a
+# close call against fourteen.
+WINDOW_DAYS=${FM_SWEEP_WINDOW_DAYS:-7}
 if [ -n "$SINCE" ]; then
   is_iso8601 "$SINCE" \
     || die_usage "--since must be a UTC ISO-8601 timestamp spelled YYYY-MM-DDTHH:MM:SSZ, e.g. 2026-01-01T00:00:00Z"
@@ -237,6 +252,9 @@ fi
 
 NOW=$(now_iso)
 
+# Set before any early could-not-observe can reach the summary under `set -u`.
+WINDOW_DESCRIPTION="an unresolved window"
+
 # Run-level tallies. Scope tallies are reset per scope.
 SCOPES=0
 SCOPES_OBSERVED=0
@@ -245,9 +263,6 @@ TOTAL_DECLARED=0
 TOTAL_CANDIDATES=0
 REQUESTS_SPENT=0
 
-# Emitted before the summary so an operator reading a truncated terminal still
-# sees why a scope was skipped.
-note() { printf 'note: %s\n' "$1"; }
 
 sanitize() {
   # One marker field: no newlines, no tabs, bounded length.
@@ -438,8 +453,14 @@ This sweep cannot determine who wrote anything. A candidate is a write under
 this account that does not carry ${FM_ATTRIBUTION_TOKEN} - which is equally what an
 undeclared model session and the captain's own hand-typed comment look like in
 every field GitHub exposes. The evidence on each line is a signal, not an
-attribution; the captain judges. Writes outside the window starting ${SINCE}
-were not examined at all.
+attribution; the captain judges.
+
+This run covered ${WINDOW_DESCRIPTION}, and writes outside it
+were not examined at all - a clean result says nothing about them. Widen the
+window with --since <iso8601> or FM_SWEEP_WINDOW_DAYS=<days>, and raise --budget
+with it: reviews and commits each spend about one request per pull request in
+the window, so a wider window on the current budget of ${BUDGET} will report
+could-not-observe instead of a result.
 EOF
   if [ "$SCOPES_UNOBSERVED" -gt 0 ]; then
     cat <<'EOF'
@@ -455,11 +476,14 @@ EOF
 # needs the markers above to exist.
 if [ -z "$SINCE" ]; then
   SINCE=$(days_ago_iso "$WINDOW_DAYS")
+  WINDOW_DESCRIPTION="the $WINDOW_DAYS days since $SINCE"
   if ! is_iso8601 "$SINCE"; then
     SINCE=unresolved
     run_blocked missing-tool \
       "date could not compute a window start $WINDOW_DAYS days back, so there is no window to sweep"
   fi
+else
+  WINDOW_DESCRIPTION="everything since $SINCE, as given by --since"
 fi
 
 if [ -z "$B64D" ]; then
@@ -505,6 +529,18 @@ if [ "${#REPOS[@]}" -eq 0 ]; then
   if [ "$page" -gt "$MAX_PAGES" ]; then
     run_blocked max-pages "the account owns more repositories than --max-pages $MAX_PAGES would list; the repository set itself is incomplete"
   fi
+fi
+
+# An empty repository set is never a clean sweep. GitHub answers
+# /user/repos?affiliation=owner with HTTP 200 and an empty array both for a token
+# whose scopes exclude the account's repositories and for an account that owns
+# nothing, and those two are the same bytes on the wire - there is no field that
+# separates them. Calling either one clean would report "nothing to find" for a
+# run that could not look at anything, which is exactly the false clean this
+# sweep exists to make impossible.
+if [ "${#REPOS[@]}" -eq 0 ]; then
+  run_blocked empty-repository-set \
+    "no repository resolved, so nothing was examined; an empty owner listing means either a token whose scopes exclude the account's repositories or an account that owns none, and those are indistinguishable here - name a repository with --repo to sweep it directly"
 fi
 
 printf 'FM_SWEEP_BEGIN %s account=%s since=%s token=%s repos=%s budget=%s\n' \
@@ -876,10 +912,6 @@ sweep_commits() {
 
   scope_observed "$repo" commits "$examined" "$declared" "$candidates"
 }
-
-if [ "${#REPOS[@]}" -eq 0 ]; then
-  note "no repository was named and the account owns none, so nothing was examined"
-fi
 
 for repo in ${REPOS[@]+"${REPOS[@]}"}; do
   case $repo in

--- a/bin/fm-attribution-sweep.sh
+++ b/bin/fm-attribution-sweep.sh
@@ -1,0 +1,854 @@
+#!/usr/bin/env bash
+# fm-attribution-sweep.sh - read-only detector for GitHub writes made under the
+# captain's own account that do NOT carry the model-write attribution token.
+#
+# Why this exists. Every fleet write - issue comment, pull request review, and
+# pushed commit - authenticates as the captain's own GitHub account with
+# author_association OWNER and no bot marker or app identity, so nothing at
+# write time can tell a model session apart from the captain typing. The ruled
+# convention is therefore a self-identifying token led by the model session
+# itself, and a model can silently omit it. A convention nothing can enforce is
+# only worth something if omissions become visible afterwards, so this sweep is
+# what converts an unenforceable rule into a detectable one. The sweep's cadence
+# is the exposure window.
+#
+# docs/model-write-attribution.md owns the convention, the token's rationale,
+# and the residual exposure that was accepted knowingly.
+#
+# READ-ONLY. Every GitHub call is a GET issued through one chokepoint that
+# refuses any other method and any mutating flag. The sweep never comments on,
+# edits, closes, or deletes anything it finds, including the writes it reports.
+#
+# IT DOES NOT IDENTIFY AUTHORS. A write without the token is a CANDIDATE, never
+# a verdict: a comment the captain typed by hand is byte-identical in every
+# field GitHub exposes. Each candidate prints the evidence available so the
+# captain judges.
+#
+# Three-valued outcomes. Every scope - one repository and one kind of write -
+# ends in exactly one of observed-clean, candidates, or could-not-observe. An
+# unreachable API, an expired or missing token, a truncated response, an
+# exhausted request budget, and an unparsable reply are all could-not-observe,
+# and none of them is ever folded into a clean run.
+#
+# Usage:
+#   fm-attribution-sweep.sh [options]
+#   fm-attribution-sweep.sh --convention   print the paste-ready prompt preamble
+#   fm-attribution-sweep.sh --token        print the exact token, nothing else
+#   fm-attribution-sweep.sh --help         print this header
+#
+# Options:
+#   --account <login>    account whose writes are swept (default: the gh-axi login)
+#   --repo <owner/name>  repository to sweep (repeatable; default: every repository
+#                        the account owns)
+#   --kind <kind>        comments | reviews | commits (repeatable; default: all three)
+#   --since <iso8601>    window start (default: FM_SWEEP_WINDOW_DAYS, itself 30, days back)
+#   --branch <name>      restrict the commits kind to this branch (repeatable)
+#   --budget <n>         maximum GitHub requests for the whole run (default 300).
+#                        There is no unlimited value: 0 permits no request at
+#                        all, and every scope then reports could-not-observe
+#                        rather than a clean sweep of nothing.
+#   --max-pages <n>      maximum pages per individual listing (default 20)
+#   --per-page <n>       records per listing page (default 25, GitHub's cap is 100).
+#                        The client renders a bounded response and flags anything
+#                        longer as truncated, which this sweep reports as
+#                        could-not-observe, so a smaller page keeps a busy
+#                        repository readable. Correctness never depends on the
+#                        value: an over-large page is refused, not silently cut.
+#
+# The window and every bound are printed in the begin and summary markers, and
+# hitting one is reported as could-not-observe rather than silently narrowing
+# what was examined.
+#
+# Output markers (stdout):
+#   FM_SWEEP_BEGIN <iso> account=<login> since=<iso> token=<token> repos=<n> budget=<n>
+#   FM_SWEEP_SCOPE repo=<owner/name> kind=<kind> outcome=observed examined=<n> declared=<n> candidates=<n>
+#   FM_SWEEP_SCOPE repo=<owner/name> kind=<kind> outcome=could-not-observe reason=<slug> detail=<text>
+#   FM_SWEEP_CANDIDATE repo=<owner/name> kind=<kind> ref=<id> when=<iso> url=<url> evidence=<k=v,...>
+#   FM_SWEEP_SUMMARY scopes=<n> observed=<n> could_not_observe=<n> declared=<n> candidates=<n> outcome=<clean|candidates|could-not-observe>
+#
+# Exit status:
+#   0   every scope was observed and no candidate was found
+#   10  every scope was observed and at least one candidate was found
+#   20  at least one scope could not be observed; any candidates are still listed
+#   64  usage error
+set -u
+
+# The one attribution token. docs/model-write-attribution.md states why this
+# exact spelling and no other; changing it here without changing that doc splits
+# the convention from its detector.
+FM_ATTRIBUTION_TOKEN='SOL-AI:'
+
+EXIT_CLEAN=0
+EXIT_CANDIDATES=10
+EXIT_UNOBSERVED=20
+EXIT_USAGE=64
+
+SELF="${BASH_SOURCE[0]}"
+
+usage() {
+  sed -n '2,/^set -u$/p' "$SELF" | sed 's/^# \{0,1\}//; $d'
+}
+
+die_usage() {
+  printf 'fm-attribution-sweep: %s\n' "$1" >&2
+  printf 'run "%s --help" for usage\n' "$(basename "$SELF")" >&2
+  exit "$EXIT_USAGE"
+}
+
+ACCOUNT=
+SINCE=
+BUDGET=300
+MAX_PAGES=20
+PER_PAGE=25
+REPOS=()
+KINDS=()
+BRANCHES=()
+
+while [ "$#" -gt 0 ]; do
+  case $1 in
+    --help|-h) usage; exit 0 ;;
+    --token) printf '%s\n' "$FM_ATTRIBUTION_TOKEN"; exit 0 ;;
+    --convention) CONVENTION_ONLY=1; shift ;;
+    --account) [ "$#" -ge 2 ] || die_usage "--account needs a value"; ACCOUNT=$2; shift 2 ;;
+    --account=*) ACCOUNT=${1#--account=}; shift ;;
+    --repo) [ "$#" -ge 2 ] || die_usage "--repo needs a value"; REPOS+=("$2"); shift 2 ;;
+    --repo=*) REPOS+=("${1#--repo=}"); shift ;;
+    --kind) [ "$#" -ge 2 ] || die_usage "--kind needs a value"; KINDS+=("$2"); shift 2 ;;
+    --kind=*) KINDS+=("${1#--kind=}"); shift ;;
+    --branch) [ "$#" -ge 2 ] || die_usage "--branch needs a value"; BRANCHES+=("$2"); shift 2 ;;
+    --branch=*) BRANCHES+=("${1#--branch=}"); shift ;;
+    --since) [ "$#" -ge 2 ] || die_usage "--since needs a value"; SINCE=$2; shift 2 ;;
+    --since=*) SINCE=${1#--since=}; shift ;;
+    --budget) [ "$#" -ge 2 ] || die_usage "--budget needs a value"; BUDGET=$2; shift 2 ;;
+    --budget=*) BUDGET=${1#--budget=}; shift ;;
+    --max-pages) [ "$#" -ge 2 ] || die_usage "--max-pages needs a value"; MAX_PAGES=$2; shift 2 ;;
+    --max-pages=*) MAX_PAGES=${1#--max-pages=}; shift ;;
+    --per-page) [ "$#" -ge 2 ] || die_usage "--per-page needs a value"; PER_PAGE=$2; shift 2 ;;
+    --per-page=*) PER_PAGE=${1#--per-page=}; shift ;;
+    *) die_usage "unknown argument: $1" ;;
+  esac
+done
+
+# The prompt preamble. This is the artifact pasted at the top of a browser model
+# session, so the convention is reachable where a write is actually authored
+# rather than only in a decision record.
+print_convention() {
+  cat <<EOF
+--- paste this at the top of a browser model session that can write to GitHub ---
+
+Attribution rule for this session, and it is not optional.
+
+You are signed in to GitHub as the account owner. Everything you write there -
+an issue or pull request comment, a pull request review, and any commit you
+create - is recorded as the owner's own writing, with no bot marker and no
+separate machine identity. A human reading it later cannot tell it apart from
+something the owner typed.
+
+So every write you make must begin with this exact token, followed by one space:
+
+    ${FM_ATTRIBUTION_TOKEN}
+
+Put it at the very start of the comment body, the very start of the review body,
+and inside the commit message. Where a repository lints commit subjects, put it
+at the start of the first body line instead of the subject; anywhere in the
+commit message counts. Do not translate it, wrap it in punctuation, reformat it,
+or drop it because a write feels minor. If you are unsure whether something
+counts as a write, include the token.
+
+If you cannot include the token for any reason, do not make the write. Say so
+instead and stop.
+
+--- end of preamble ---
+
+The token is checked after the fact by bin/fm-attribution-sweep.sh; omissions
+are reported as candidates for the captain to judge.
+EOF
+}
+
+if [ "${CONVENTION_ONLY:-0}" = "1" ]; then
+  print_convention
+  exit 0
+fi
+
+now_iso() {
+  printf '%s\n' "${FM_SWEEP_NOW:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+}
+
+days_ago_iso() {
+  local days=$1
+  date -u -d "$days days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -v-"${days}"d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null
+}
+
+is_uint() {
+  case $1 in
+    ''|*[!0-9]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+is_uint "$BUDGET" || die_usage "--budget must be a non-negative integer"
+is_uint "$MAX_PAGES" || die_usage "--max-pages must be a non-negative integer"
+is_uint "$PER_PAGE" || die_usage "--per-page must be a non-negative integer"
+{ [ "$PER_PAGE" -ge 1 ] && [ "$PER_PAGE" -le 100 ]; } || die_usage "--per-page must be between 1 and 100"
+
+if [ "${#KINDS[@]}" -eq 0 ]; then
+  KINDS=(comments reviews commits)
+fi
+for kind in "${KINDS[@]}"; do
+  case $kind in
+    comments|reviews|commits) ;;
+    *) die_usage "unknown kind: $kind" ;;
+  esac
+done
+
+WINDOW_DAYS=${FM_SWEEP_WINDOW_DAYS:-30}
+if [ -z "$SINCE" ]; then
+  is_uint "$WINDOW_DAYS" || die_usage "FM_SWEEP_WINDOW_DAYS must be a non-negative integer"
+  SINCE=$(days_ago_iso "$WINDOW_DAYS")
+fi
+
+NOW=$(now_iso)
+
+# Run-level tallies. Scope tallies are reset per scope.
+SCOPES=0
+SCOPES_OBSERVED=0
+SCOPES_UNOBSERVED=0
+TOTAL_DECLARED=0
+TOTAL_CANDIDATES=0
+REQUESTS_SPENT=0
+
+# Emitted before the summary so an operator reading a truncated terminal still
+# sees why a scope was skipped.
+note() { printf 'note: %s\n' "$1"; }
+
+sanitize() {
+  # One marker field: no newlines, no tabs, bounded length.
+  printf '%s' "$1" | tr '\n\t' '  ' | cut -c1-200
+}
+
+# ---------------------------------------------------------------------------
+# base64 decoding, detected once. Records travel base64-encoded so no comment
+# body, commit subject, or review text can inject a newline, a tab, or a field
+# separator into a marker line.
+# ---------------------------------------------------------------------------
+B64D=
+for flag in --decode -D -d; do
+  if [ "$(printf 'eA==' | base64 "$flag" 2>/dev/null)" = "x" ]; then
+    B64D=$flag
+    break
+  fi
+done
+
+b64d() { printf '%s' "$1" | base64 "$B64D" 2>/dev/null; }
+
+# ---------------------------------------------------------------------------
+# The single GitHub chokepoint. GET only, through gh-axi, with no method
+# argument and no mutating flag reachable from anywhere in this script.
+#
+# On success the decoded response body is left in GH_BODY and GH_STATUS is "ok".
+# On any other result GH_STATUS names which could-not-observe it was and
+# GH_DETAIL carries a bounded diagnostic; there is no third state in which the
+# caller may treat the absence of a body as an answer.
+#
+# The body is returned in a variable rather than on stdout on purpose: a caller
+# writing out=$(gh_get ...) would run this in a subshell, and the status, the
+# diagnostic, and the spent-request count would all be discarded with it, which
+# is precisely how a could-not-observe turns into a silent clean run.
+# ---------------------------------------------------------------------------
+GH_STATUS=
+GH_DETAIL=
+GH_BODY=
+
+gh_get() {
+  local path=$1 jq_expr=$2 out rc first body trunc
+  GH_STATUS=
+  GH_DETAIL=
+  GH_BODY=
+
+  case $path in
+    /*) ;;
+    *) GH_STATUS=bad-request; GH_DETAIL="path must start with /: $path"; return 1 ;;
+  esac
+  case $path in
+    *[[:space:]]*) GH_STATUS=bad-request; GH_DETAIL="path contains whitespace"; return 1 ;;
+  esac
+
+  if [ "$REQUESTS_SPENT" -ge "$BUDGET" ]; then
+    GH_STATUS=request-budget
+    GH_DETAIL="request budget of $BUDGET exhausted before $path"
+    return 1
+  fi
+  REQUESTS_SPENT=$((REQUESTS_SPENT + 1))
+
+  out=$(gh-axi api "$path" --jq "$jq_expr" 2>&1)
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    GH_STATUS=api-error
+    GH_DETAIL=$(sanitize "$out")
+    return 1
+  fi
+
+  first=$(printf '%s\n' "$out" | head -1)
+  case $first in
+    error:*|code:*)
+      GH_STATUS=api-error
+      GH_DETAIL=$(sanitize "$out")
+      return 1
+      ;;
+    api_response:*)
+      trunc=$(printf '%s\n' "$out" | sed -n 's/^  *truncated: //p' | head -1)
+      if [ "$trunc" = "true" ]; then
+        GH_STATUS=truncated
+        GH_DETAIL=$(sanitize "response truncated by the client: $(printf '%s\n' "$out" | sed -n 's/^  *original_length: //p' | head -1) bytes")
+        return 1
+      fi
+      body=$(printf '%s\n' "$out" | sed -n 's/^  *body: //p' | head -1)
+      ;;
+    *)
+      # A bare scalar rendering with no envelope.
+      body=$out
+      ;;
+  esac
+
+  case $body in
+    '""') body='' ;;
+    '"'*'"') body=${body#\"}; body=${body%\"} ;;
+  esac
+
+  GH_STATUS=ok
+  GH_BODY=$(printf '%s' "$body" | sed 's/\\n/\
+/g')
+  return 0
+}
+
+# jq fragment shared by every listing: emit the raw page length on the first
+# line, then one "|"-joined record of base64 fields per surviving element.
+JQ_ENVELOPE='| ([(.n|tostring)] + .r) | join("\n")'
+
+# Percent-encode a value going into a request path or query. A branch named
+# "feat/a&b" would otherwise end the query early, and the sweep would report a
+# branch it never actually asked about as observed - a silent wrong answer of
+# exactly the kind this tool exists to prevent. Byte-wise under LC_ALL=C so a
+# non-ASCII name encodes correctly rather than per rendered character.
+urlq() {
+  local s=$1 out='' i c
+  LC_ALL=C
+  for ((i = 0; i < ${#s}; i++)); do
+    c=${s:i:1}
+    case $c in
+      [A-Za-z0-9._~/-]) out="$out$c" ;;
+      *) out="$out$(printf '%%%02X' "'$c")" ;;
+    esac
+  done
+  printf '%s' "$out"
+}
+
+jq_str() {
+  # Quote a shell value for embedding as a jq string literal.
+  local v=$1
+  v=${v//\\/\\\\}
+  v=${v//\"/\\\"}
+  printf '"%s"' "$v"
+}
+
+# ---------------------------------------------------------------------------
+# Scope reporting. Exactly one of these ends every scope.
+# ---------------------------------------------------------------------------
+scope_observed() {
+  local repo=$1 kind=$2 examined=$3 declared=$4 candidates=$5
+  SCOPES=$((SCOPES + 1))
+  SCOPES_OBSERVED=$((SCOPES_OBSERVED + 1))
+  TOTAL_DECLARED=$((TOTAL_DECLARED + declared))
+  TOTAL_CANDIDATES=$((TOTAL_CANDIDATES + candidates))
+  printf 'FM_SWEEP_SCOPE repo=%s kind=%s outcome=observed examined=%s declared=%s candidates=%s\n' \
+    "$repo" "$kind" "$examined" "$declared" "$candidates"
+}
+
+scope_unobserved() {
+  local repo=$1 kind=$2 reason=$3 detail=$4 declared=${5:-0} candidates=${6:-0}
+  SCOPES=$((SCOPES + 1))
+  SCOPES_UNOBSERVED=$((SCOPES_UNOBSERVED + 1))
+  TOTAL_DECLARED=$((TOTAL_DECLARED + declared))
+  TOTAL_CANDIDATES=$((TOTAL_CANDIDATES + candidates))
+  printf 'FM_SWEEP_SCOPE repo=%s kind=%s outcome=could-not-observe reason=%s detail=%s\n' \
+    "$repo" "$kind" "$reason" "$(sanitize "$detail")"
+}
+
+emit_candidate() {
+  local repo=$1 kind=$2 ref=$3 when=$4 url=$5 evidence=$6
+  printf 'FM_SWEEP_CANDIDATE repo=%s kind=%s ref=%s when=%s url=%s evidence=%s\n' \
+    "$repo" "$kind" "$(sanitize "$ref")" "$(sanitize "$when")" \
+    "$(sanitize "$url")" "$(sanitize "$evidence")"
+}
+
+# ---------------------------------------------------------------------------
+# Preconditions. Each failure is a run-level could-not-observe, never a clean run.
+# ---------------------------------------------------------------------------
+run_blocked() {
+  local reason=$1 detail=$2
+  printf 'FM_SWEEP_BEGIN %s account=%s since=%s token=%s repos=0 budget=%s\n' \
+    "$NOW" "${ACCOUNT:-unknown}" "$SINCE" "$FM_ATTRIBUTION_TOKEN" "$BUDGET"
+  scope_unobserved '-' '-' "$reason" "$detail"
+  print_summary
+  exit "$EXIT_UNOBSERVED"
+}
+
+print_summary() {
+  local outcome=clean
+  if [ "$SCOPES_UNOBSERVED" -gt 0 ]; then
+    outcome=could-not-observe
+  elif [ "$TOTAL_CANDIDATES" -gt 0 ]; then
+    outcome=candidates
+  fi
+  printf 'FM_SWEEP_SUMMARY scopes=%s observed=%s could_not_observe=%s declared=%s candidates=%s requests=%s outcome=%s\n' \
+    "$SCOPES" "$SCOPES_OBSERVED" "$SCOPES_UNOBSERVED" "$TOTAL_DECLARED" \
+    "$TOTAL_CANDIDATES" "$REQUESTS_SPENT" "$outcome"
+  cat <<EOF
+This sweep cannot determine who wrote anything. A candidate is a write under
+this account that does not carry ${FM_ATTRIBUTION_TOKEN} - which is equally what an
+undeclared model session and the captain's own hand-typed comment look like in
+every field GitHub exposes. The evidence on each line is a signal, not an
+attribution; the captain judges. Writes outside the window starting ${SINCE}
+were not examined at all.
+EOF
+  if [ "$SCOPES_UNOBSERVED" -gt 0 ]; then
+    cat <<'EOF'
+At least one scope could not be observed. This run is NOT a clean result: the
+unobserved scopes were not searched, so nothing is known about them either way.
+EOF
+  fi
+}
+
+if [ -z "$B64D" ]; then
+  run_blocked missing-tool "base64 cannot decode on this system; no response could be read"
+fi
+
+if ! command -v gh-axi >/dev/null 2>&1; then
+  run_blocked missing-tool "gh-axi is not installed, so no GitHub state could be read"
+fi
+
+if [ -z "$ACCOUNT" ]; then
+  gh_get '/user' '.login'
+  ACCOUNT=$GH_BODY
+  if [ "$GH_STATUS" != "ok" ] || [ -z "$ACCOUNT" ]; then
+    run_blocked "${GH_STATUS:-empty-result}" "could not resolve the authenticated account: ${GH_DETAIL:-empty login}"
+  fi
+fi
+
+ACCOUNT_JQ=$(jq_str "$ACCOUNT")
+TOKEN_JQ=$(jq_str "$FM_ATTRIBUTION_TOKEN")
+SINCE_JQ=$(jq_str "$SINCE")
+
+# ---------------------------------------------------------------------------
+# Repository set.
+# ---------------------------------------------------------------------------
+if [ "${#REPOS[@]}" -eq 0 ]; then
+  page=1
+  while [ "$page" -le "$MAX_PAGES" ]; do
+    gh_get "/user/repos?affiliation=owner&per_page=$PER_PAGE&page=$page" \
+      "{n: length, r: [ .[] | (.full_name|@base64) ]} $JQ_ENVELOPE"
+    if [ "$GH_STATUS" != "ok" ]; then
+      run_blocked "$GH_STATUS" "could not enumerate the account's repositories: $GH_DETAIL"
+    fi
+    raw=$(printf '%s\n' "$GH_BODY" | head -1)
+    is_uint "$raw" || run_blocked unparsable "repository listing page $page was not parsable"
+    while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      REPOS+=("$(b64d "$line")")
+    done < <(printf '%s\n' "$GH_BODY" | tail -n +2)
+    [ "$raw" -eq "$PER_PAGE" ] || break
+    page=$((page + 1))
+  done
+  if [ "$page" -gt "$MAX_PAGES" ]; then
+    run_blocked max-pages "the account owns more repositories than --max-pages $MAX_PAGES would list; the repository set itself is incomplete"
+  fi
+fi
+
+printf 'FM_SWEEP_BEGIN %s account=%s since=%s token=%s repos=%s budget=%s\n' \
+  "$NOW" "$ACCOUNT" "$SINCE" "$FM_ATTRIBUTION_TOKEN" "${#REPOS[@]}" "$BUDGET"
+
+# ---------------------------------------------------------------------------
+# comments: every issue and pull request conversation comment in the window.
+#
+# An app-performed comment is NOT skipped. The measured browser session writes
+# through the ChatGPT Codex Connector GitHub App, which sets
+# performed_via_github_app while still recording the comment under the account
+# owner's login with author_association OWNER, so it reads as the owner's own
+# writing everywhere a human looks. Filtering those out would drop exactly the
+# writes this sweep exists to surface, so the app slug is reported as evidence
+# instead.
+# ---------------------------------------------------------------------------
+sweep_comments() {
+  local repo=$1 page=1 raw line examined=0 declared=0 candidates=0
+  local id issue when has_token assoc app jq_expr
+
+  # Only what cannot be derived travels: the permalink is rebuilt from the
+  # repository, the issue number, and the comment id. Keeping records narrow is
+  # what keeps a busy repository under the client's render limit, and therefore
+  # observable at all rather than reported as truncated.
+  jq_expr="{n: length, r: [ .[]
+    | select(.user.login == $ACCOUNT_JQ)
+    | [ (.id|tostring|@base64),
+        (((.issue_url // \"\")|split(\"/\")|last)|@base64),
+        ((.created_at // \"\")|@base64),
+        (((.body // \"\")|contains($TOKEN_JQ))|tostring|@base64),
+        ((.author_association // \"\")|@base64),
+        ((if .performed_via_github_app == null then \"none\" else ((.performed_via_github_app.slug) // \"unnamed\") end)|@base64) ]
+    | join(\"|\") ]} $JQ_ENVELOPE"
+
+  while [ "$page" -le "$MAX_PAGES" ]; do
+    gh_get "/repos/$(urlq "$repo")/issues/comments?since=$(urlq "$SINCE")&per_page=$PER_PAGE&page=$page" "$jq_expr"
+    if [ "$GH_STATUS" != "ok" ]; then
+      scope_unobserved "$repo" comments "$GH_STATUS" "$GH_DETAIL" "$declared" "$candidates"
+      return
+    fi
+    raw=$(printf '%s\n' "$GH_BODY" | head -1)
+    if ! is_uint "$raw"; then
+      scope_unobserved "$repo" comments unparsable "comment page $page was not parsable" "$declared" "$candidates"
+      return
+    fi
+    examined=$((examined + raw))
+    while IFS='|' read -r id issue when has_token assoc app; do
+      [ -n "$id" ] || continue
+      if [ "$(b64d "$has_token")" = "true" ]; then
+        declared=$((declared + 1))
+        continue
+      fi
+      candidates=$((candidates + 1))
+      id=$(b64d "$id")
+      issue=$(b64d "$issue")
+      emit_candidate "$repo" comment "$id" "$(b64d "$when")" \
+        "https://github.com/$repo/issues/$issue#issuecomment-$id" \
+        "assoc=$(b64d "$assoc"),via_app=$(b64d "$app"),token=absent"
+    done < <(printf '%s\n' "$GH_BODY" | tail -n +2)
+    [ "$raw" -eq "$PER_PAGE" ] || break
+    page=$((page + 1))
+  done
+
+  if [ "$page" -gt "$MAX_PAGES" ]; then
+    scope_unobserved "$repo" comments max-pages \
+      "more comment pages than --max-pages $MAX_PAGES; the window was not fully read" "$declared" "$candidates"
+    return
+  fi
+  scope_observed "$repo" comments "$examined" "$declared" "$candidates"
+}
+
+# ---------------------------------------------------------------------------
+# Pull requests touched in the window. Both the reviews scope and the commits
+# scope need this list, so it is collected once here rather than walked twice
+# with two chances to drift.
+#
+# On success PR_NUMBERS holds the numbers and PR_STATUS is "ok"; otherwise
+# PR_STATUS and PR_DETAIL name the could-not-observe for the caller to report
+# against its own scope.
+# ---------------------------------------------------------------------------
+PR_NUMBERS=()
+PR_STATUS=
+PR_DETAIL=
+
+# Both scopes of a repository want the same list, so the walk is paid for once.
+# A failed walk is cached too: retrying it would spend the budget again to reach
+# the same could-not-observe.
+PR_CACHE_REPO=
+PR_CACHE=()
+PR_CACHE_STATUS=
+PR_CACHE_DETAIL=
+
+collect_prs() {
+  local repo=$1
+  if [ "$PR_CACHE_REPO" = "$repo" ]; then
+    PR_NUMBERS=(${PR_CACHE[@]+"${PR_CACHE[@]}"})
+    PR_STATUS=$PR_CACHE_STATUS
+    PR_DETAIL=$PR_CACHE_DETAIL
+    [ "$PR_STATUS" = "ok" ]
+    return
+  fi
+  collect_prs_uncached "$repo"
+  PR_CACHE_REPO=$repo
+  PR_CACHE=(${PR_NUMBERS[@]+"${PR_NUMBERS[@]}"})
+  PR_CACHE_STATUS=$PR_STATUS
+  PR_CACHE_DETAIL=$PR_DETAIL
+  [ "$PR_STATUS" = "ok" ]
+}
+
+collect_prs_uncached() {
+  local repo=$1 page=1 raw number updated exhausted=0 pr_jq
+  PR_NUMBERS=()
+  PR_STATUS=
+  PR_DETAIL=
+
+  pr_jq="{n: length, r: [ .[] | [ ((.number|tostring)|@base64), ((.updated_at // \"\")|@base64) ] | join(\"|\") ]} $JQ_ENVELOPE"
+
+  while [ "$page" -le "$MAX_PAGES" ]; do
+    gh_get "/repos/$(urlq "$repo")/pulls?state=all&sort=updated&direction=desc&per_page=$PER_PAGE&page=$page" "$pr_jq"
+    if [ "$GH_STATUS" != "ok" ]; then
+      PR_STATUS=$GH_STATUS
+      PR_DETAIL=$GH_DETAIL
+      return 1
+    fi
+    raw=$(printf '%s\n' "$GH_BODY" | head -1)
+    if ! is_uint "$raw"; then
+      PR_STATUS=unparsable
+      PR_DETAIL="pull request page $page was not parsable"
+      return 1
+    fi
+    while IFS='|' read -r number updated; do
+      [ -n "$number" ] || continue
+      updated=$(b64d "$updated")
+      if [ -n "$updated" ] && [ "$updated" \< "$SINCE" ]; then
+        exhausted=1
+        continue
+      fi
+      PR_NUMBERS+=("$(b64d "$number")")
+    done < <(printf '%s\n' "$GH_BODY" | tail -n +2)
+    [ "$exhausted" -eq 0 ] || break
+    [ "$raw" -eq "$PER_PAGE" ] || break
+    page=$((page + 1))
+  done
+
+  if [ "$exhausted" -eq 0 ] && [ "$page" -gt "$MAX_PAGES" ]; then
+    PR_STATUS=max-pages
+    PR_DETAIL="more pull request pages than --max-pages $MAX_PAGES; the window was not fully walked"
+    return 1
+  fi
+
+  PR_STATUS=ok
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# reviews: pull request review bodies. GitHub has no repository-wide review
+# listing, so pull requests touched in the window are walked first.
+# ---------------------------------------------------------------------------
+sweep_reviews() {
+  local repo=$1 page raw number
+  local examined=0 declared=0 candidates=0
+  local id when has_token assoc state
+  local review_jq
+  local prs=()
+
+  if ! collect_prs "$repo"; then
+    scope_unobserved "$repo" reviews "$PR_STATUS" "$PR_DETAIL" "$declared" "$candidates"
+    return
+  fi
+  prs=(${PR_NUMBERS[@]+"${PR_NUMBERS[@]}"})
+
+  review_jq="{n: length, r: [ .[]
+    | select(.user.login == $ACCOUNT_JQ)
+    | select((.submitted_at // \"\") >= $SINCE_JQ)
+    | [ (.id|tostring|@base64),
+        ((.submitted_at // \"\")|@base64),
+        (((.body // \"\")|contains($TOKEN_JQ))|tostring|@base64),
+        ((.author_association // \"\")|@base64),
+        ((.state // \"\")|@base64) ]
+    | join(\"|\") ]} $JQ_ENVELOPE"
+
+  for number in ${prs[@]+"${prs[@]}"}; do
+    page=1
+    while [ "$page" -le "$MAX_PAGES" ]; do
+      gh_get "/repos/$(urlq "$repo")/pulls/$number/reviews?per_page=$PER_PAGE&page=$page" "$review_jq"
+      if [ "$GH_STATUS" != "ok" ]; then
+        scope_unobserved "$repo" reviews "$GH_STATUS" "pull request $number: $GH_DETAIL" "$declared" "$candidates"
+        return
+      fi
+      raw=$(printf '%s\n' "$GH_BODY" | head -1)
+      if ! is_uint "$raw"; then
+        scope_unobserved "$repo" reviews unparsable "reviews of pull request $number were not parsable" "$declared" "$candidates"
+        return
+      fi
+      examined=$((examined + raw))
+      while IFS='|' read -r id when has_token assoc state; do
+        [ -n "$id" ] || continue
+        if [ "$(b64d "$has_token")" = "true" ]; then
+          declared=$((declared + 1))
+          continue
+        fi
+        candidates=$((candidates + 1))
+        id=$(b64d "$id")
+        emit_candidate "$repo" review "$id" "$(b64d "$when")" \
+          "https://github.com/$repo/pull/$number#pullrequestreview-$id" \
+          "assoc=$(b64d "$assoc"),state=$(b64d "$state"),pr=$number,token=absent"
+      done < <(printf '%s\n' "$GH_BODY" | tail -n +2)
+      [ "$raw" -eq "$PER_PAGE" ] || break
+      page=$((page + 1))
+    done
+    if [ "$page" -gt "$MAX_PAGES" ]; then
+      scope_unobserved "$repo" reviews max-pages \
+        "pull request $number has more review pages than --max-pages $MAX_PAGES" "$declared" "$candidates"
+      return
+    fi
+  done
+
+  scope_observed "$repo" reviews "$examined" "$declared" "$candidates"
+}
+
+# ---------------------------------------------------------------------------
+# commits: authored by the account. Branches are walked because the default
+# branch alone would miss a commit pushed to a side branch, which is exactly
+# where a browser session's commit lands.
+#
+# Pull request heads are walked too, and that pass is not redundant. A merged or
+# closed pull request usually has its branch deleted, after which the commit is
+# reachable by SHA and still visible on the pull request but appears in no
+# branch listing at all. Branch enumeration alone would therefore go quiet on
+# precisely the commits that are finished and shipped.
+# ---------------------------------------------------------------------------
+sweep_commits() {
+  local repo=$1 page=1 raw name number
+  local examined=0 declared=0 candidates=0
+  local sha when has_token verified committer
+  local branch_jq commit_jq label base source_seen
+  local branches=()
+  local labels=() paths=()
+  local seen=" "
+
+  if [ "${#BRANCHES[@]}" -gt 0 ]; then
+    branches=("${BRANCHES[@]}")
+  else
+    branch_jq="{n: length, r: [ .[] | (.name|@base64) ]} $JQ_ENVELOPE"
+    while [ "$page" -le "$MAX_PAGES" ]; do
+      gh_get "/repos/$(urlq "$repo")/branches?per_page=$PER_PAGE&page=$page" "$branch_jq"
+      if [ "$GH_STATUS" != "ok" ]; then
+        scope_unobserved "$repo" commits "$GH_STATUS" "$GH_DETAIL" "$declared" "$candidates"
+        return
+      fi
+      raw=$(printf '%s\n' "$GH_BODY" | head -1)
+      if ! is_uint "$raw"; then
+        scope_unobserved "$repo" commits unparsable "branch page $page was not parsable" "$declared" "$candidates"
+        return
+      fi
+      while IFS= read -r name; do
+        [ -n "$name" ] || continue
+        branches+=("$(b64d "$name")")
+      done < <(printf '%s\n' "$GH_BODY" | tail -n +2)
+      [ "$raw" -eq "$PER_PAGE" ] || break
+      page=$((page + 1))
+    done
+    if [ "$page" -gt "$MAX_PAGES" ]; then
+      scope_unobserved "$repo" commits max-pages \
+        "more branches than --max-pages $MAX_PAGES would list; some branches were never read" "$declared" "$candidates"
+      return
+    fi
+  fi
+
+  for name in ${branches[@]+"${branches[@]}"}; do
+    labels+=("branch=$name")
+    paths+=("/repos/$(urlq "$repo")/commits?sha=$(urlq "$name")&since=$(urlq "$SINCE")&author=$(urlq "$ACCOUNT")&per_page=$PER_PAGE")
+  done
+
+  # The pull request pass only makes sense for the whole repository; an explicit
+  # --branch means the caller asked for exactly that branch.
+  if [ "${#BRANCHES[@]}" -eq 0 ]; then
+    if ! collect_prs "$repo"; then
+      scope_unobserved "$repo" commits "$PR_STATUS" "$PR_DETAIL" "$declared" "$candidates"
+      return
+    fi
+    for number in ${PR_NUMBERS[@]+"${PR_NUMBERS[@]}"}; do
+      labels+=("pr=$number")
+      paths+=("/repos/$(urlq "$repo")/pulls/$number/commits?per_page=$PER_PAGE")
+    done
+  fi
+
+  # The pull request commit listing accepts neither an author nor a since
+  # filter, so the window and the account are applied here for every source.
+  # The raw page count stays unfiltered above this, so pagination still ends on
+  # the real page length rather than on how many records survived.
+  commit_jq="{n: length, r: [ .[]
+    | select(((.author.login) // \"\") == $ACCOUNT_JQ)
+    | select((((.commit.author.date) // \"\")) >= $SINCE_JQ)
+    | [ (.sha|@base64),
+        (((.commit.author.date) // \"\")|@base64),
+        (((((.commit.message) // \"\")|contains($TOKEN_JQ)))|tostring|@base64),
+        ((((.commit.verification.verified) // false)|tostring)|@base64),
+        (((.committer.login) // \"none\")|@base64) ]
+    | join(\"|\") ]} $JQ_ENVELOPE"
+
+  local index=0
+  while [ "$index" -lt "${#paths[@]}" ]; do
+    label=${labels[$index]}
+    base=${paths[$index]}
+    index=$((index + 1))
+    page=1
+    source_seen=0
+    while [ "$page" -le "$MAX_PAGES" ]; do
+      gh_get "$base&page=$page" "$commit_jq"
+      if [ "$GH_STATUS" != "ok" ]; then
+        scope_unobserved "$repo" commits "$GH_STATUS" "$label: $GH_DETAIL" "$declared" "$candidates"
+        return
+      fi
+      raw=$(printf '%s\n' "$GH_BODY" | head -1)
+      if ! is_uint "$raw"; then
+        scope_unobserved "$repo" commits unparsable "commits of $label were not parsable" "$declared" "$candidates"
+        return
+      fi
+      source_seen=$((source_seen + raw))
+      while IFS='|' read -r sha when has_token verified committer; do
+        [ -n "$sha" ] || continue
+        sha=$(b64d "$sha")
+        case $seen in
+          *" $sha "*) continue ;;
+        esac
+        seen="$seen$sha "
+        examined=$((examined + 1))
+        if [ "$(b64d "$has_token")" = "true" ]; then
+          declared=$((declared + 1))
+          continue
+        fi
+        candidates=$((candidates + 1))
+        emit_candidate "$repo" commit "$sha" "$(b64d "$when")" \
+          "https://github.com/$repo/commit/$sha" \
+          "$label,signed=$(b64d "$verified"),committer=$(b64d "$committer"),token=absent"
+      done < <(printf '%s\n' "$GH_BODY" | tail -n +2)
+      [ "$raw" -eq "$PER_PAGE" ] || break
+      page=$((page + 1))
+    done
+    if [ "$page" -gt "$MAX_PAGES" ]; then
+      scope_unobserved "$repo" commits max-pages \
+        "$label has more commit pages than --max-pages $MAX_PAGES" "$declared" "$candidates"
+      return
+    fi
+    # GitHub stops listing a pull request's commits at 250 and says nothing
+    # about the rest, so reaching that wall is a boundary of what was seen.
+    case $label in
+      pr=*)
+        if [ "$source_seen" -ge 250 ]; then
+          scope_unobserved "$repo" commits pr-commit-cap \
+            "$label reached GitHub's 250-commit listing limit; its remaining commits were never read" \
+            "$declared" "$candidates"
+          return
+        fi
+        ;;
+    esac
+  done
+
+  scope_observed "$repo" commits "$examined" "$declared" "$candidates"
+}
+
+if [ "${#REPOS[@]}" -eq 0 ]; then
+  note "no repository was named and the account owns none, so nothing was examined"
+fi
+
+for repo in ${REPOS[@]+"${REPOS[@]}"}; do
+  case $repo in
+    */*) ;;
+    *) scope_unobserved "$repo" '-' bad-request "not an owner/name repository"; continue ;;
+  esac
+  for kind in "${KINDS[@]}"; do
+    case $kind in
+      comments) sweep_comments "$repo" ;;
+      reviews) sweep_reviews "$repo" ;;
+      commits) sweep_commits "$repo" ;;
+    esac
+  done
+done
+
+print_summary
+
+if [ "$SCOPES_UNOBSERVED" -gt 0 ]; then
+  exit "$EXIT_UNOBSERVED"
+fi
+if [ "$TOTAL_CANDIDATES" -gt 0 ]; then
+  exit "$EXIT_CANDIDATES"
+fi
+exit "$EXIT_CLEAN"

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -199,6 +199,7 @@ family_for_basename() {
     fm-teardown-endpoint-safety.test.sh)
       printf '%s\n' backend-dispatch
       ;;
+    fm-attribution-sweep.test.sh|\
     fm-pr-check-security.test.sh|fm-pr-merge.test.sh|fm-review-diff.test.sh|\
     fm-teardown.test.sh|fm-x-mode.test.sh)
       printf '%s\n' pr-forge

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -273,6 +273,10 @@
       "audience": "operator-current"
     },
     {
+      "path": "docs/model-write-attribution.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/orca-backend.md",
       "audience": "operator-current"
     },

--- a/docs/model-write-attribution.md
+++ b/docs/model-write-attribution.md
@@ -143,8 +143,14 @@ A candidate that fails all four checks is not a probe artifact and should be jud
 They are what a browser model session produced on 2026-08-02 when it was asked to prove it could comment, review, and push a commit.
 That measurement is the evidence the whole convention rests on: every one of them recorded the account owner with `author_association: OWNER` and no bot marker, which is why write-time enforcement was ruled impossible and detection after the fact was chosen instead.
 Independent evidence is preserved outside this repository at `data/sol-capability-probe/github-evidence.md`.
-That note enumerates only four artifacts, omitting scaffolding commit `3e05033a95a1`, which appears there as a parent SHA rather than as a swept write.
+That note agrees with this section: it records the decision to keep the artifacts, calls them a deliberate permanent known-positive, states that a sweep reporting them is working correctly, and leaves the question of how to recognise them to this page.
+It enumerates only four artifacts, omitting scaffolding commit `3e05033a95a1`, which appears there as a parent SHA rather than as a swept write.
 The table above supersedes it on the set, and every entry was verified against the live API rather than copied from the note.
+
+Those two documents agreeing that the artifacts still exist is what keeps this section usable, and they have already disagreed once.
+The note previously opened by saying the artifacts had been deleted, which would lead a reader here to conclude that any candidate dated 2026-08-02 must be genuine - the exact inversion this section exists to prevent.
+No test can catch a repeat, because the note is private to the operator's home and absent from every clone and CI run, so a check asserting agreement would pass without reading anything.
+Whoever edits either document reconciles both by hand.
 
 ### Why they were not deleted
 

--- a/docs/model-write-attribution.md
+++ b/docs/model-write-attribution.md
@@ -119,7 +119,7 @@ If you are looking at a candidate and wondering whether to act on it, check this
 
 | Kind | Identifier | How it identifies itself |
 |---|---|---|
-| Issue comment | `5158866063` | body is the nonce |
+| Issue comment | `5158866063` | body carries the nonce |
 | Review | `4838962417` | body carries the nonce |
 | Review | `4838972180` | body carries the nonce |
 | Commit | `c73f62d045e8` | empty commit, message `test: verify browser commit capability` |
@@ -143,17 +143,19 @@ A candidate that fails all four checks is not a probe artifact and should be jud
 They are what a browser model session produced on 2026-08-02 when it was asked to prove it could comment, review, and push a commit.
 That measurement is the evidence the whole convention rests on: every one of them recorded the account owner with `author_association: OWNER` and no bot marker, which is why write-time enforcement was ruled impossible and detection after the fact was chosen instead.
 Independent evidence is preserved outside this repository at `data/sol-capability-probe/github-evidence.md`.
+That note enumerates only four artifacts, omitting scaffolding commit `3e05033a95a1`, which appears there as a parent SHA rather than as a swept write.
+The table above supersedes it on the set, and every entry was verified against the live API rather than copied from the note.
 
 ### Why they were not deleted
 
 Deletion was proposed, investigated, and declined on measured grounds.
 
-It is only partly possible in the first place: a pull request cannot be deleted, only closed, and the commit survives because the pull request retains it.
-Removing the comment while the reviews and commit stayed would have left a half-removed control, which is worse than either keeping or removing the whole thing.
+It is only partly possible in the first place: a pull request cannot be deleted, only closed, and both commits survive because the pull request retains them.
+Removing the comment while the reviews and commits stayed would have left a half-removed control, which is worse than either keeping or removing the whole thing.
 
 The stronger reason is that a red control which exists in the real world, on the real account, is worth more than tidiness.
 Every other control this detector has is synthetic, and a synthetic control can only confirm the assumption already written into it.
-These four already earned their keep: proving the sweep against them is what exposed a real defect, an early filter that skipped app-performed writes and would therefore have hidden comment `5158866063` - the single most representative example of what the sweep exists to catch.
+These five already earned their keep: proving the sweep against them is what exposed a real defect, an early filter that skipped app-performed writes and would therefore have hidden comment `5158866063` - the single most representative example of what the sweep exists to catch.
 
 ### Why they are not filtered out
 

--- a/docs/model-write-attribution.md
+++ b/docs/model-write-attribution.md
@@ -167,7 +167,8 @@ These five already earned their keep: proving the sweep against them is what exp
 
 The sweep does not special-case them, and it should not.
 A known-positive that stops being reported has stopped being a control, and a suppression list is exactly the mechanism that lets a detector quietly stop working.
-Labelling them belongs here, in prose a reader consults, not in a filter that removes them from the output.
+Labelling them is what replaces filtering, and a label only reaches a triager where that person is already standing.
+The sweep's own summary therefore says that candidates dated 2026-08-02 may be known permanent ones and points at this page; the table above owns recognising them.
 
 ## The residual exposure
 

--- a/docs/model-write-attribution.md
+++ b/docs/model-write-attribution.md
@@ -130,7 +130,7 @@ Four independent ways to confirm one, in order of how quickly you can check.
 - The identifier appears in the table above.
 - The timestamp falls on 2026-08-02 between 15:17Z and 15:31Z, a span of about thirteen minutes that holds all five.
 - A commit candidate carries `pr=24` in its evidence, because branch `probe/sol-capability` was deleted and only the pull request pass can still reach these two commits.
-- Opening one of the three text writes shows the nonce `SOLPROBE-AIBQQE4JCTMV`, which appears nowhere else.
+- Opening one of the three text writes shows the nonce `SOLPROBE-AIBQQE4JCTMV`, which was generated for this probe and appears in no other comment, review, or commit message.
 
 The nonce is a reliable marker for the comment and the two reviews only.
 Commit `c73f62d045e8` is the one the browser session pushed, and it changes no files at all, so neither the nonce nor any other content marker appears in it; its message and its emptiness are what identify it.

--- a/docs/model-write-attribution.md
+++ b/docs/model-write-attribution.md
@@ -91,6 +91,8 @@ Knowing where coverage stops is part of trusting a clean result.
 - A commit that belongs to no branch and no pull request is reachable only by SHA and is not enumerable. The sweep cannot see it and does not pretend to.
 - GitHub stops listing a pull request's commits at 250. Reaching that wall is reported as could-not-observe for the scope rather than treated as the end of the list.
 - Review comments left on individual diff lines are a separate GitHub object from the review bodies the `reviews` kind reads. They are not currently swept.
+- A review submitted with no body carries no token, so the `reviews` kind reports every bare approval as a candidate.
+  That is correct by the definition above - the write is undeclared - but it is the sweep's standing source of routine candidates, and the `state=` field in a candidate's evidence is what separates a bodiless `APPROVED` from a review that had prose and still omitted the token.
 - An issue body, a pull request title or body, and a commit comment are all writes under the same identity that no kind reads.
   They sit outside the swept scope of comments, reviews, and commits, so a clean run says nothing about them either way.
 - A commit is matched to the window by the later of its committer and author dates, because a rebase or cherry-pick carries an author date from before the window onto a commit pushed inside it.

--- a/docs/model-write-attribution.md
+++ b/docs/model-write-attribution.md
@@ -110,6 +110,57 @@ Knowing where coverage stops is part of trusting a clean result.
 - A commit is matched to the window by the later of its committer and author dates, because a rebase or cherry-pick carries an author date from before the window onto a commit pushed inside it.
   A commit whose branch and pull request were both touched entirely before the window is outside it and was not examined.
 
+## The retained probe writes, and how to recognise them
+
+Five writes in `sbracewell64/firstmate` are unprefixed, tied to the 2026-08-02 capability probe, and **deliberately kept**.
+They are the sweep's only real-world red control, and they will be reported as candidates by every run whose window covers 2026-08-02.
+
+If you are looking at a candidate and wondering whether to act on it, check this list first.
+
+| Kind | Identifier | How it identifies itself |
+|---|---|---|
+| Issue comment | `5158866063` | body is the nonce |
+| Review | `4838962417` | body carries the nonce |
+| Review | `4838972180` | body carries the nonce |
+| Commit | `c73f62d045e8` | empty commit, message `test: verify browser commit capability` |
+| Commit | `3e05033a95a1` | added `docs/sol-probe.md`, which carries the nonce |
+
+Four independent ways to confirm one, in order of how quickly you can check.
+
+- The identifier appears in the table above.
+- The timestamp falls on 2026-08-02 between 15:17Z and 15:31Z, a span of about thirteen minutes that holds all five.
+- A commit candidate carries `pr=24` in its evidence, because branch `probe/sol-capability` was deleted and only the pull request pass can still reach these two commits.
+- Opening one of the three text writes shows the nonce `SOLPROBE-AIBQQE4JCTMV`, which appears nowhere else.
+
+The nonce is a reliable marker for the comment and the two reviews only.
+Commit `c73f62d045e8` is the one the browser session pushed, and it changes no files at all, so neither the nonce nor any other content marker appears in it; its message and its emptiness are what identify it.
+Commit `3e05033a95a1` is the probe scaffolding that planted the nonce for the session to read, so it carries the nonce in its diff rather than in its message.
+
+A candidate that fails all four checks is not a probe artifact and should be judged on its own merits.
+
+### Why they exist
+
+They are what a browser model session produced on 2026-08-02 when it was asked to prove it could comment, review, and push a commit.
+That measurement is the evidence the whole convention rests on: every one of them recorded the account owner with `author_association: OWNER` and no bot marker, which is why write-time enforcement was ruled impossible and detection after the fact was chosen instead.
+Independent evidence is preserved outside this repository at `data/sol-capability-probe/github-evidence.md`.
+
+### Why they were not deleted
+
+Deletion was proposed, investigated, and declined on measured grounds.
+
+It is only partly possible in the first place: a pull request cannot be deleted, only closed, and the commit survives because the pull request retains it.
+Removing the comment while the reviews and commit stayed would have left a half-removed control, which is worse than either keeping or removing the whole thing.
+
+The stronger reason is that a red control which exists in the real world, on the real account, is worth more than tidiness.
+Every other control this detector has is synthetic, and a synthetic control can only confirm the assumption already written into it.
+These four already earned their keep: proving the sweep against them is what exposed a real defect, an early filter that skipped app-performed writes and would therefore have hidden comment `5158866063` - the single most representative example of what the sweep exists to catch.
+
+### Why they are not filtered out
+
+The sweep does not special-case them, and it should not.
+A known-positive that stops being reported has stopped being a control, and a suppression list is exactly the mechanism that lets a detector quietly stop working.
+Labelling them belongs here, in prose a reader consults, not in a filter that removes them from the output.
+
 ## The residual exposure
 
 A missing token is indistinguishable from the captain's own writing until a sweep runs.

--- a/docs/model-write-attribution.md
+++ b/docs/model-write-attribution.md
@@ -71,7 +71,7 @@ Detection after the fact is what converts an unenforceable rule into a detectabl
 
 **It reports candidates, not authors.**
 A write under this account without the token is exactly what an undeclared model session and a comment the captain typed by hand both look like in every field GitHub exposes.
-The sweep prints the evidence available for each candidate - author association, the app that performed the write when GitHub records one, and a commit's signature state, committer, and branch - and says in its own output that the captain judges.
+The sweep prints the evidence available for each candidate - author association, the app that performed the write when GitHub records one, and a commit's signature state, committer, and the branch or pull request it was found through - and says in its own output that the captain judges.
 
 **A clean run is distinguishable from a run that could not look.**
 Every scope ends in exactly one of observed-clean, candidates, or could-not-observe.

--- a/docs/model-write-attribution.md
+++ b/docs/model-write-attribution.md
@@ -1,0 +1,104 @@
+# Model-write attribution on GitHub
+
+A browser model session that can write to GitHub writes as the account owner.
+This page owns the token those writes carry, why that exact token, and the sweep that finds writes which lack it.
+
+## The problem this addresses
+
+Every write the fleet makes to GitHub authenticates as the captain's own account.
+An issue comment, a pull request review, and a pushed commit all record the owner's login with `author_association: OWNER`, no bot marker, and no separate machine identity.
+Some of those writes additionally carry `performed_via_github_app`, but that field appears nowhere a human reads a comment, so the write still presents as the owner's own writing.
+
+Nothing at write time can separate a model session from the captain typing, and nothing can be added to the identity that would.
+Using a distinct machine account was considered and rejected: the browser-to-GitHub link already exists on the personal account, and moving would mean creating an account and unlinking the personal one.
+
+The chosen design is therefore a convention the session applies to itself, plus detection after the fact.
+
+## The token
+
+The token is exactly:
+
+```
+SOL-AI:
+```
+
+A write that carries it is declaring itself as model-authored.
+A write that lacks it is not thereby the captain's - it is simply undeclared.
+
+This spelling was chosen because it survives every surface a write lands on and because it is greppable without false positives.
+
+- It is ASCII uppercase letters, one hyphen, and one trailing colon.
+- None of those characters carry meaning in GitHub-flavored Markdown, which renders comment and review bodies: there is no emphasis pair, no link or reference bracket, no autolink or raw HTML angle, no heading or issue-reference `#`, no `@` mention that would notify a real person, no emoji shortcode, no strikethrough, no code span, and no leading list marker.
+- A trailing colon does not make it a link: GitHub's autolinker wants a scheme with `://` or one of its known prefixes.
+- Git applies no markup to a commit message at all, so the same bytes survive a subject line unchanged.
+- An all-caps hyphenated compound ending in a colon is not a word in English or in code, so a search for it returns deliberate uses and nothing else.
+- A human reading a comment understands it without a lookup, which is the entire point.
+
+Changing the token means changing it in `bin/fm-attribution-sweep.sh` in the same commit.
+The script holds the one constant and this page holds the reasoning; splitting them would leave the convention and its detector disagreeing.
+
+## Where the token goes
+
+Lead the text with it.
+
+- An issue or pull request comment: the first characters of the body, followed by a space.
+- A pull request review: the first characters of the review body, followed by a space.
+- A commit: in the commit message. Prefer the subject; where a repository lints commit subjects, put it at the start of the first body line instead. The sweep reads the whole message, so either placement counts.
+
+## Reaching the convention when a prompt is written
+
+The rule is only useful if it is in front of whoever composes the session, so the tool emits it ready to paste:
+
+```
+bin/fm-attribution-sweep.sh --convention
+```
+
+Paste that block at the top of a browser model session that can write to GitHub.
+`bin/fm-attribution-sweep.sh --token` prints the bare token for scripting.
+
+## The sweep
+
+```
+bin/fm-attribution-sweep.sh [--repo <owner/name>]... [--kind comments|reviews|commits]... [--since <iso8601>]
+```
+
+The script's header and `--help` own its flags, bounds, and output markers.
+Four properties matter more than the mechanics.
+
+**It is the reason the convention is worth anything.**
+A model can silently omit the token, and no write-time mechanism can stop it on this identity.
+Detection after the fact is what converts an unenforceable rule into a detectable one.
+
+**It reports candidates, not authors.**
+A write under this account without the token is exactly what an undeclared model session and a comment the captain typed by hand both look like in every field GitHub exposes.
+The sweep prints the evidence available for each candidate - author association, the app that performed the write when GitHub records one, and a commit's signature state, committer, and branch - and says in its own output that the captain judges.
+
+**A clean run is distinguishable from a run that could not look.**
+Every scope ends in exactly one of observed-clean, candidates, or could-not-observe.
+An unreachable API, an expired token, a truncated response, an exhausted request budget, and an unparsable reply are all could-not-observe, never an empty finding.
+The exit status carries the same three values: `0` clean, `10` candidates, `20` at least one scope unobserved.
+Candidates found before a scope went unobserved are still listed, and the summary still reports the scope as unobserved.
+
+**It never writes.**
+Every call is a GET through one chokepoint, and the sweep does not comment on, edit, close, or delete anything it finds.
+
+## What the sweep can and cannot see
+
+Knowing where coverage stops is part of trusting a clean result.
+
+- Only writes inside the window are examined, and the window is printed in the run's own output. Anything older was not looked at.
+- Commits are reached through branches and through pull request heads. The pull request pass is what finds a commit whose branch was deleted after the pull request closed, which is the normal end state for finished work; without it that commit appears in no branch listing at all. It costs roughly one request per pull request in the window, which is what the request budget is for.
+- A commit that belongs to no branch and no pull request is reachable only by SHA and is not enumerable. The sweep cannot see it and does not pretend to.
+- GitHub stops listing a pull request's commits at 250. Reaching that wall is reported as could-not-observe for the scope rather than treated as the end of the list.
+- Review comments left on individual diff lines are a separate GitHub object from the review bodies the `reviews` kind reads. They are not currently swept.
+
+## The residual exposure
+
+A missing token is indistinguishable from the captain's own writing until a sweep runs.
+The sweep cadence is therefore the exposure window, and no cadence is currently scheduled: running it is a deliberate act.
+This was accepted knowingly when the convention was chosen over a separate machine identity.
+
+## Maintaining this page
+
+Keep the token, its rationale, and the sweep's guarantees here, and keep flags and output formats in the script's own header and `--help`.
+When the token changes, change both in one commit.

--- a/docs/model-write-attribution.md
+++ b/docs/model-write-attribution.md
@@ -91,6 +91,10 @@ Knowing where coverage stops is part of trusting a clean result.
 - A commit that belongs to no branch and no pull request is reachable only by SHA and is not enumerable. The sweep cannot see it and does not pretend to.
 - GitHub stops listing a pull request's commits at 250. Reaching that wall is reported as could-not-observe for the scope rather than treated as the end of the list.
 - Review comments left on individual diff lines are a separate GitHub object from the review bodies the `reviews` kind reads. They are not currently swept.
+- An issue body, a pull request title or body, and a commit comment are all writes under the same identity that no kind reads.
+  They sit outside the swept scope of comments, reviews, and commits, so a clean run says nothing about them either way.
+- A commit is matched to the window by the later of its committer and author dates, because a rebase or cherry-pick carries an author date from before the window onto a commit pushed inside it.
+  A commit whose branch and pull request were both touched entirely before the window is outside it and was not examined.
 
 ## The residual exposure
 

--- a/docs/model-write-attribution.md
+++ b/docs/model-write-attribution.md
@@ -43,7 +43,9 @@ Lead the text with it.
 
 - An issue or pull request comment: the first characters of the body, followed by a space.
 - A pull request review: the first characters of the review body, followed by a space.
-- A commit: in the commit message. Prefer the subject; where a repository lints commit subjects, put it at the start of the first body line instead. The sweep reads the whole message, so either placement counts.
+- A commit: in the commit message.
+  Prefer the subject; where a repository lints commit subjects, put it at the start of the first body line instead.
+  The sweep reads the whole message, so either placement counts.
 
 ## Reaching the convention when a prompt is written
 
@@ -86,11 +88,21 @@ Every call is a GET through one chokepoint, and the sweep does not comment on, e
 
 Knowing where coverage stops is part of trusting a clean result.
 
-- Only writes inside the window are examined, and the window is printed in the run's own output. Anything older was not looked at.
-- Commits are reached through branches and through pull request heads. The pull request pass is what finds a commit whose branch was deleted after the pull request closed, which is the normal end state for finished work; without it that commit appears in no branch listing at all. It costs roughly one request per pull request in the window, which is what the request budget is for.
-- A commit that belongs to no branch and no pull request is reachable only by SHA and is not enumerable. The sweep cannot see it and does not pretend to.
-- GitHub stops listing a pull request's commits at 250. Reaching that wall is reported as could-not-observe for the scope rather than treated as the end of the list.
-- Review comments left on individual diff lines are a separate GitHub object from the review bodies the `reviews` kind reads. They are not currently swept.
+- Only writes inside the window are examined, and the run's own summary names the window it covered.
+  Anything older was not looked at.
+  The default window is 7 days, chosen so a default run finishes inside the default request budget instead of reporting could-not-observe, because a detector whose first run usually says it could not look trains its operator to ignore it.
+  Widen it with `--since` or `FM_SWEEP_WINDOW_DAYS`, and raise `--budget` with it: measured on this fleet's own repositories, a 14-day window already costs more than the default budget allows.
+- An empty repository set is could-not-observe, never a clean sweep.
+  GitHub answers the owner listing with an empty array both for a token whose scopes exclude the account's repositories and for an account that owns nothing, and those are the same bytes on the wire, so neither can be reported as having found nothing.
+- Commits are reached through branches and through pull request heads.
+  The pull request pass is what finds a commit whose branch was deleted after the pull request closed, which is the normal end state for finished work; without it that commit appears in no branch listing at all.
+  It costs roughly one request per pull request in the window, which is what the request budget is for.
+- A commit that belongs to no branch and no pull request is reachable only by SHA and is not enumerable.
+  The sweep cannot see it and does not pretend to.
+- GitHub stops listing a pull request's commits at 250.
+  Reaching that wall is reported as could-not-observe for the scope rather than treated as the end of the list.
+- Review comments left on individual diff lines are a separate GitHub object from the review bodies the `reviews` kind reads.
+  They are not currently swept.
 - A review submitted with no body carries no token, so the `reviews` kind reports every bare approval as a candidate.
   That is correct by the definition above - the write is undeclared - but it is the sweep's standing source of routine candidates, and the `state=` field in a candidate's evidence is what separates a bodiless `APPROVED` from a review that had prose and still omitted the token.
 - An issue body, a pull request title or body, and a commit comment are all writes under the same identity that no kind reads.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -62,6 +62,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-project-mode.sh`     | Resolve a project's registered delivery posture from `data/projects.md` for fleet sync and home seeding |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval            |
 | `fm-review-diff.sh`      | Review a crewmate branch or resolved PR head against the authoritative base          |
+| `fm-attribution-sweep.sh` | Read-only sweep listing GitHub writes under the captain's account that lack the model-write attribution token ([convention](model-write-attribution.md)) |
 | `fm-marker-lib.sh`       | Compatibility entry point for the from-firstmate carrier owned by `fm-operational-input.sh` |
 | `fm-pending-reply-lib.sh` | Parent-owned secondmate pending-reply expectations, recovery, and keyed escalation lifecycle |
 | `fm-secondmate-report.sh` | Optional helper to append a correlated parent status or document-pointer report       |

--- a/tests/fm-attribution-sweep.test.sh
+++ b/tests/fm-attribution-sweep.test.sh
@@ -81,6 +81,13 @@ case $path in
     printf 'api_response:\n  body: testcaptain\n  truncated: false\n'
     exit 0
     ;;
+  /user/repos*)
+    # Exactly what GitHub returns for a token whose scopes exclude the account's
+    # repositories: HTTP 200 with an empty array. Identical bytes to an account
+    # that owns nothing.
+    printf 'api_response:\n  body: "%s"\n  truncated: false\n' "${FM_FAKE_REPOS:-0}"
+    exit 0
+    ;;
 esac
 
 # The commits scope walks branches, then pull request heads. Each listing gets
@@ -319,6 +326,47 @@ if grep -q '/repos/acme/widgets/pulls/24/commits' "$FM_FAKE_LOG"; then
   pass "the commits scope actually asks GitHub for the pull request's commits"
 else
   fail "the pull request commit listing was never requested"
+fi
+
+# --- an empty repository set is could-not-observe, never a clean sweep -------
+# A token whose scopes exclude the account's repositories gets HTTP 200 with an
+# empty array - the same bytes as an account that genuinely owns none. Neither
+# can be called clean, because a run that looked at nothing has found nothing.
+# No --repo is passed here, so the sweep must resolve the set itself.
+: >"$FM_FAKE_LOG"
+FM_FAKE_SCENARIO=clean FM_FAKE_BODY='' FM_FAKE_REPOS="0" PATH="$BIN:$PATH" \
+  "$SWEEP" --account testcaptain --since 2026-01-01T00:00:00Z \
+  >"$WORK/out" 2>"$WORK/err"
+printf '%s' $? >"$WORK/rc"
+
+if out | grep -q 'outcome=could-not-observe reason=empty-repository-set'; then
+  pass "an empty owner listing is reported as could-not-observe"
+else
+  fail "empty repository set was not could-not-observe: $(out)"
+fi
+if out | grep -q 'outcome=clean'; then
+  fail "an empty repository set printed a clean outcome"
+else
+  pass "an empty repository set never prints a clean outcome"
+fi
+if [ "$(rc)" = "20" ]; then
+  pass "an empty repository set exits 20"
+else
+  fail "expected exit 20 for an empty repository set, got $(rc)"
+fi
+# A resolvable repository set must still sweep normally, or the check above
+# would pass simply by refusing every run.
+: >"$FM_FAKE_LOG"
+FM_FAKE_SCENARIO=candidate \
+FM_FAKE_BODY="1\n$(comment_record 900007 42 2026-02-02T10:00:00Z false OWNER none)" \
+FM_FAKE_REPOS="1\n$(b64 acme/widgets)" PATH="$BIN:$PATH" \
+  "$SWEEP" --account testcaptain --since 2026-01-01T00:00:00Z --kind comments \
+  >"$WORK/out" 2>"$WORK/err"
+printf '%s' $? >"$WORK/rc"
+if out | grep -q 'FM_SWEEP_CANDIDATE .*repo=acme/widgets .*ref=900007'; then
+  pass "a resolved repository set is still swept normally"
+else
+  fail "self-resolved repository set was not swept: $(out)"
 fi
 
 # --- 4. the sweep is read-only ---------------------------------------------

--- a/tests/fm-attribution-sweep.test.sh
+++ b/tests/fm-attribution-sweep.test.sh
@@ -401,6 +401,24 @@ else
   fail "no GitHub calls were recorded, so the read-only assertion checked nothing"
 fi
 
+# --- the permanent known-positives are labelled where a triager stands ------
+# The probe artifacts are reported by every run whose window covers them, and an
+# unlabelled permanent known-positive gets investigated as a real finding every
+# time. The pointer therefore has to be in the output someone is holding, not
+# only in a document they would have to know to open.
+run_sweep candidate "1\n$(comment_record 900008 42 2026-02-02T10:00:00Z false OWNER none)" \
+  --repo acme/widgets --kind comments
+if out | grep -q 'docs/model-write-attribution.md'; then
+  pass "the summary points a triager at the retained-probe table"
+else
+  fail "no pointer to the probe table in the summary: $(out)"
+fi
+if out | grep -q '2026-08-02'; then
+  pass "the summary names the date whose candidates are known permanent ones"
+else
+  fail "the summary does not name the probe date: $(out)"
+fi
+
 # --- the convention is reachable from the tool itself ----------------------
 TOKEN=$(PATH="$BIN:$PATH" "$SWEEP" --token)
 if [ "$TOKEN" = "SOL-AI:" ]; then

--- a/tests/fm-attribution-sweep.test.sh
+++ b/tests/fm-attribution-sweep.test.sh
@@ -1,0 +1,378 @@
+#!/usr/bin/env bash
+# tests/fm-attribution-sweep.test.sh - contract test for the model-write
+# attribution sweep.
+#
+# The sweep's whole value is that an omitted attribution token becomes visible
+# after the fact, so the cases that matter are the ones where a wrong answer
+# would be indistinguishable from a right one:
+#
+#   1. A write WITHOUT the token is reported as a candidate (the red case).
+#   2. A write WITH the token is counted as declared and is NOT reported, so the
+#      sweep is a detector rather than a machine that flags everything.
+#   3. A clean run, a run that could not look, and a run that found something are
+#      three distinguishable outcomes with three distinct exit statuses. An API
+#      error, a truncated response, and an exhausted request budget must never
+#      read as clean.
+#   4. Every GitHub call is a GET. The sweep never mutates what it reports on.
+#
+# A fake gh-axi first on PATH stands in for GitHub. It answers with the same
+# AXI envelope the real client emits, and records every invocation so the
+# read-only contract is asserted against actual argv rather than assumed. The
+# token match itself lives inside the jq expression the real client evaluates
+# and is verified against live GitHub, not here.
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SWEEP="$ROOT/bin/fm-attribution-sweep.sh"
+
+WORK=
+FAILED=0
+
+fail() { printf 'not ok - %s\n' "$1" >&2; FAILED=1; }
+pass() { printf 'ok - %s\n' "$1"; }
+
+# shellcheck disable=SC2329 # Invoked by the EXIT trap below.
+cleanup() { [ -n "${WORK:-}" ] && rm -rf "$WORK"; }
+trap cleanup EXIT
+
+command -v base64 >/dev/null 2>&1 || { echo "skip: base64 not found"; exit 0; }
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/fm-attr-sweep.XXXXXX") || { echo "skip: mktemp failed"; exit 0; }
+BIN="$WORK/bin"
+mkdir -p "$BIN"
+
+b64() { printf '%s' "$1" | base64 | tr -d '\n'; }
+
+# One comment record as the sweep's transport encodes it:
+# id | issue-number | created-at | token-present | author-association | app-slug
+comment_record() {
+  printf '%s|%s|%s|%s|%s|%s' \
+    "$(b64 "$1")" "$(b64 "$2")" "$(b64 "$3")" "$(b64 "$4")" "$(b64 "$5")" "$(b64 "$6")"
+}
+
+cat >"$BIN/gh-axi" <<'FAKE'
+#!/usr/bin/env bash
+# Fake gh-axi. Records argv, then answers from the scenario in the environment.
+# The jq program legitimately spans lines, so newlines are folded away to keep
+# exactly one log record per invocation; a multi-line argument would otherwise
+# read back as extra calls. The logging runs in a subshell because its shift
+# would otherwise consume this script's own arguments.
+verb=${1:-}
+path=${2:-}
+(
+  printf '%s\t%s\t' "${1:-}" "${2:-}"
+  if [ "$#" -gt 2 ]; then
+    shift 2
+    for arg in "$@"; do printf '%s ' "$arg" | tr '\n' ' '; done
+  fi
+  printf '\n'
+) >>"$FM_FAKE_LOG"
+
+: "$verb"
+
+emit_envelope() {
+  printf 'api_response:\n'
+  printf '  body: "%s"\n' "$1"
+  printf '  truncated: %s\n' "${2:-false}"
+}
+
+case $path in
+  /user)
+    printf 'api_response:\n  body: testcaptain\n  truncated: false\n'
+    exit 0
+    ;;
+esac
+
+# The commits scope walks branches, then pull request heads. Each listing gets
+# its own canned answer so the test can prove a commit is found through the pull
+# request even when no branch carries it.
+if [ "${FM_FAKE_SCENARIO:-}" = "commits" ]; then
+  case $path in
+    */branches*)
+      printf 'api_response:\n  body: "%s"\n  truncated: false\n' "$FM_FAKE_BRANCHES"
+      exit 0
+      ;;
+    */pulls\?*)
+      printf 'api_response:\n  body: "%s"\n  truncated: false\n' "$FM_FAKE_PULLS"
+      exit 0
+      ;;
+    */pulls/*/commits*)
+      printf 'api_response:\n  body: "%s"\n  truncated: false\n' "$FM_FAKE_PR_COMMITS"
+      exit 0
+      ;;
+    */commits\?*)
+      printf 'api_response:\n  body: "%s"\n  truncated: false\n' "$FM_FAKE_BRANCH_COMMITS"
+      exit 0
+      ;;
+  esac
+fi
+
+case $FM_FAKE_SCENARIO in
+  apierror)
+    printf 'error: "gh: Bad credentials (HTTP 401)"\ncode: UNAUTHORIZED\n' >&2
+    exit 1
+    ;;
+  truncated)
+    emit_envelope "$FM_FAKE_BODY" true
+    printf '  original_length: 99999\n'
+    exit 0
+    ;;
+  *)
+    emit_envelope "$FM_FAKE_BODY" false
+    exit 0
+    ;;
+esac
+FAKE
+chmod +x "$BIN/gh-axi"
+
+FM_FAKE_LOG="$WORK/calls.log"
+export FM_FAKE_LOG
+
+# Runs the sweep with the fake client in front. Body and scenario come from the
+# caller; stdout, stderr, and the exit status land in the work dir.
+run_sweep() {
+  local scenario=$1 body=$2
+  shift 2
+  : >"$FM_FAKE_LOG"
+  FM_FAKE_SCENARIO=$scenario FM_FAKE_BODY=$body PATH="$BIN:$PATH" \
+    "$SWEEP" --account testcaptain --since 2026-01-01T00:00:00Z "$@" \
+    >"$WORK/out" 2>"$WORK/err"
+  printf '%s' $? >"$WORK/rc"
+}
+
+rc() { cat "$WORK/rc"; }
+out() { cat "$WORK/out"; }
+
+# --- 1. a write without the token is reported ------------------------------
+run_sweep candidate "1\n$(comment_record 900001 42 2026-02-02T10:00:00Z false OWNER none)" \
+  --repo acme/widgets --kind comments
+if out | grep -q 'FM_SWEEP_CANDIDATE .*kind=comment ref=900001 '; then
+  pass "an unprefixed comment is reported as a candidate"
+else
+  fail "an unprefixed comment was not reported; got: $(out | tr '\n' '~')"
+fi
+if out | grep -q 'FM_SWEEP_SCOPE .*kind=comments outcome=observed examined=1 declared=0 candidates=1'; then
+  pass "the candidate scope tallies one examined and one candidate"
+else
+  fail "candidate scope tally wrong: $(out | grep FM_SWEEP_SCOPE || true)"
+fi
+if out | grep -q 'FM_SWEEP_SUMMARY .*candidates=1 .*outcome=candidates'; then
+  pass "the summary reports the candidates outcome"
+else
+  fail "candidate summary wrong: $(out | grep FM_SWEEP_SUMMARY || true)"
+fi
+[ "$(rc)" = "10" ] || fail "expected exit 10 for candidates, got $(rc)"
+[ "$(rc)" = "10" ] && pass "candidates exit with 10"
+
+# The permalink is rebuilt rather than transported, so it has to be right.
+if out | grep -q 'url=https://github.com/acme/widgets/issues/42#issuecomment-900001'; then
+  pass "the candidate carries a usable permalink"
+else
+  fail "permalink wrong: $(out | grep FM_SWEEP_CANDIDATE || true)"
+fi
+
+# The app that performed the write is evidence, not a reason to skip it: the
+# measured browser session writes through a GitHub App while still recording the
+# comment under the account owner's own login.
+run_sweep candidate "1\n$(comment_record 900002 7 2026-02-02T10:00:00Z false OWNER chatgpt-codex-connector)" \
+  --repo acme/widgets --kind comments
+if out | grep -q 'FM_SWEEP_CANDIDATE .*ref=900002 .*via_app=chatgpt-codex-connector'; then
+  pass "an app-performed write is reported with the app named as evidence"
+else
+  fail "app-performed write not reported with its app: $(out | grep FM_SWEEP_CANDIDATE || true)"
+fi
+
+# --- 2. a write with the token is not reported -----------------------------
+run_sweep declared "1\n$(comment_record 900003 42 2026-02-02T10:00:00Z true OWNER none)" \
+  --repo acme/widgets --kind comments
+if out | grep -q 'FM_SWEEP_CANDIDATE'; then
+  fail "a token-carrying comment was reported as a candidate"
+else
+  pass "a token-carrying comment is not reported"
+fi
+if out | grep -q 'FM_SWEEP_SCOPE .*kind=comments outcome=observed examined=1 declared=1 candidates=0'; then
+  pass "a token-carrying comment is counted as declared"
+else
+  fail "declared tally wrong: $(out | grep FM_SWEEP_SCOPE || true)"
+fi
+if out | grep -q 'FM_SWEEP_SUMMARY .*outcome=clean'; then
+  pass "an all-declared run reports the clean outcome"
+else
+  fail "declared summary wrong: $(out | grep FM_SWEEP_SUMMARY || true)"
+fi
+[ "$(rc)" = "0" ] || fail "expected exit 0 for an all-declared run, got $(rc)"
+[ "$(rc)" = "0" ] && pass "an all-declared run exits 0"
+
+# --- 3. clean, could-not-observe, and candidates stay distinguishable ------
+run_sweep clean "0" --repo acme/widgets --kind comments
+CLEAN_OUT=$(out)
+CLEAN_RC=$(rc)
+if printf '%s' "$CLEAN_OUT" | grep -q 'FM_SWEEP_SCOPE .*outcome=observed examined=0 declared=0 candidates=0'; then
+  pass "an empty result set is reported as observed and empty"
+else
+  fail "empty result not reported as observed: $CLEAN_OUT"
+fi
+[ "$CLEAN_RC" = "0" ] || fail "expected exit 0 for a clean run, got $CLEAN_RC"
+[ "$CLEAN_RC" = "0" ] && pass "a clean run exits 0"
+
+run_sweep apierror "" --repo acme/widgets --kind comments
+ERR_OUT=$(out)
+ERR_RC=$(rc)
+if printf '%s' "$ERR_OUT" | grep -q 'FM_SWEEP_SCOPE .*outcome=could-not-observe reason=api-error'; then
+  pass "an API failure is reported as could-not-observe"
+else
+  fail "API failure not reported as could-not-observe: $ERR_OUT"
+fi
+if printf '%s' "$ERR_OUT" | grep -q 'outcome=clean'; then
+  fail "an API failure printed a clean outcome"
+else
+  pass "an API failure never prints a clean outcome"
+fi
+if printf '%s' "$ERR_OUT" | grep -q 'NOT a clean result'; then
+  pass "an unobserved run says in words that it is not clean"
+else
+  fail "unobserved run lacks its plain-language warning: $ERR_OUT"
+fi
+[ "$ERR_RC" = "20" ] || fail "expected exit 20 for an unobservable run, got $ERR_RC"
+[ "$ERR_RC" = "20" ] && pass "an unobservable run exits 20"
+
+if [ "$CLEAN_OUT" = "$ERR_OUT" ]; then
+  fail "a clean run and a run that could not look printed the same thing"
+else
+  pass "a clean run and a run that could not look are distinguishable"
+fi
+
+run_sweep truncated "1\n$(comment_record 900004 42 2026-02-02T10:00:00Z false OWNER none)" \
+  --repo acme/widgets --kind comments
+if out | grep -q 'FM_SWEEP_SCOPE .*outcome=could-not-observe reason=truncated'; then
+  pass "a truncated response is could-not-observe, not a partial answer"
+else
+  fail "truncated response mishandled: $(out)"
+fi
+[ "$(rc)" = "20" ] || fail "expected exit 20 for a truncated response, got $(rc)"
+[ "$(rc)" = "20" ] && pass "a truncated response exits 20"
+
+# The dangerous budget case is running out PART WAY through a listing: the sweep
+# then holds real findings but has not seen the whole window, and reporting that
+# as a finished scope would be a partial answer wearing a complete one's clothes.
+# A one-record page at --per-page 1 looks full, so a second page is due when the
+# budget is already spent.
+run_sweep candidate "1\n$(comment_record 900006 42 2026-02-02T10:00:00Z false OWNER none)" \
+  --repo acme/widgets --kind comments --per-page 1 --budget 1
+if out | grep -q 'FM_SWEEP_SCOPE .*outcome=could-not-observe reason=request-budget'; then
+  pass "a budget spent mid-listing is could-not-observe"
+else
+  fail "mid-listing budget exhaustion mishandled: $(out)"
+fi
+if out | grep -q 'FM_SWEEP_CANDIDATE .*ref=900006'; then
+  pass "findings already made are still listed when the scope goes unobserved"
+else
+  fail "a candidate found before the budget ran out was dropped: $(out)"
+fi
+if out | grep -q 'FM_SWEEP_SUMMARY .*candidates=1 .*outcome=could-not-observe'; then
+  pass "could-not-observe outranks candidates in the summary while both are counted"
+else
+  fail "partial-scope summary wrong: $(out | grep FM_SWEEP_SUMMARY || true)"
+fi
+[ "$(rc)" = "20" ] || fail "expected exit 20 for an exhausted budget, got $(rc)"
+[ "$(rc)" = "20" ] && pass "an exhausted budget exits 20"
+
+# Zero means no request may be made, never "unlimited".
+run_sweep clean "0" --repo acme/widgets --kind comments --budget 0
+if out | grep -q 'outcome=could-not-observe reason=request-budget'; then
+  pass "a zero budget permits no request and observes nothing"
+else
+  fail "a zero budget was treated as unlimited: $(out)"
+fi
+
+# --- a commit whose branch is gone is still found through its pull request ---
+# This is the normal end state for shipped work: the branch is deleted when the
+# pull request closes, and branch enumeration alone then goes quiet on exactly
+# the commits that landed. The branch listing here is deliberately empty.
+commit_record() {
+  printf '%s|%s|%s|%s|%s' \
+    "$(b64 "$1")" "$(b64 "$2")" "$(b64 "$3")" "$(b64 "$4")" "$(b64 "$5")"
+}
+: >"$FM_FAKE_LOG"
+FM_FAKE_SCENARIO=commits \
+FM_FAKE_BODY='' \
+FM_FAKE_BRANCHES="0" \
+FM_FAKE_PULLS="1\n$(b64 24)|$(b64 2026-02-03T00:00:00Z)" \
+FM_FAKE_PR_COMMITS="1\n$(commit_record c73f62d0 2026-02-02T15:28:55Z false false testcaptain)" \
+FM_FAKE_BRANCH_COMMITS="0" \
+PATH="$BIN:$PATH" \
+  "$SWEEP" --account testcaptain --since 2026-01-01T00:00:00Z \
+  --repo acme/widgets --kind commits >"$WORK/out" 2>"$WORK/err"
+printf '%s' $? >"$WORK/rc"
+
+if out | grep -q 'FM_SWEEP_CANDIDATE .*kind=commit ref=c73f62d0 .*pr=24'; then
+  pass "a commit reachable only through its pull request is still found"
+else
+  fail "deleted-branch commit was missed: $(out)"
+fi
+if out | grep -q 'FM_SWEEP_SCOPE .*kind=commits outcome=observed examined=1'; then
+  pass "the pull request pass counts toward the commits scope"
+else
+  fail "commits scope tally wrong: $(out | grep FM_SWEEP_SCOPE || true)"
+fi
+if grep -q '/repos/acme/widgets/pulls/24/commits' "$FM_FAKE_LOG"; then
+  pass "the commits scope actually asks GitHub for the pull request's commits"
+else
+  fail "the pull request commit listing was never requested"
+fi
+
+# --- 4. the sweep is read-only ---------------------------------------------
+run_sweep candidate "1\n$(comment_record 900005 42 2026-02-02T10:00:00Z false OWNER none)" \
+  --repo acme/widgets --kind comments
+BAD_CALL=
+while IFS=$'\t' read -r verb path rest; do
+  [ -n "$verb" ] || continue
+  if [ "$verb" != "api" ]; then
+    BAD_CALL="non-api subcommand: $verb"
+    break
+  fi
+  case $path in
+    /*) ;;
+    *) BAD_CALL="second argument is not a path: $path"; break ;;
+  esac
+  case " $rest " in
+    *" --field "*|*" -X "*|*" --method "*|*" POST "*|*" PATCH "*|*" PUT "*|*" DELETE "*)
+      BAD_CALL="mutating argument in: $rest"
+      break
+      ;;
+  esac
+done <"$FM_FAKE_LOG"
+if [ -n "$BAD_CALL" ]; then
+  fail "the sweep made a call that is not a plain GET ($BAD_CALL)"
+else
+  pass "every GitHub call is a plain GET"
+fi
+if [ -s "$FM_FAKE_LOG" ]; then
+  pass "the read-only assertion ran against recorded calls"
+else
+  fail "no GitHub calls were recorded, so the read-only assertion checked nothing"
+fi
+
+# --- the convention is reachable from the tool itself ----------------------
+TOKEN=$(PATH="$BIN:$PATH" "$SWEEP" --token)
+if [ "$TOKEN" = "SOL-AI:" ]; then
+  pass "the token is exactly SOL-AI:"
+else
+  fail "unexpected token: $TOKEN"
+fi
+if PATH="$BIN:$PATH" "$SWEEP" --convention | grep -qF "$TOKEN"; then
+  pass "the pasteable preamble carries the same token the sweep looks for"
+else
+  fail "the preamble and the detector disagree about the token"
+fi
+
+# A usage error is its own status, never confused with a finding or a failure.
+usage_rc=0
+PATH="$BIN:$PATH" "$SWEEP" --kind bogus >/dev/null 2>&1 || usage_rc=$?
+if [ "$usage_rc" = "64" ]; then
+  pass "an unknown kind exits 64"
+else
+  fail "expected exit 64 for an unknown kind, got $usage_rc"
+fi
+
+exit "$FAILED"

--- a/tests/fm-attribution-sweep.test.sh
+++ b/tests/fm-attribution-sweep.test.sh
@@ -445,7 +445,13 @@ fi
 # string comparison against GitHub's timestamps, so a plausible-looking "30d"
 # would sort below every record, examine nothing, and print a clean sweep. It has
 # to be refused before it is ever compared against anything.
-for bad_since in 30d 2026-01-01 "2026-01-01 00:00:00" 2026-01-01T00:00:00+05:00; do
+#
+# The impossible dates below are the same bug from the other side: they match the
+# shape a timestamp has, so a shape-only check would admit them, and they then
+# sort ABOVE every real timestamp and drop every record just as silently.
+for bad_since in 30d 2026-01-01 "2026-01-01 00:00:00" 2026-01-01T00:00:00+05:00 \
+  2026-13-01T00:00:00Z 2026-00-01T00:00:00Z 2026-01-32T00:00:00Z 2026-01-00T00:00:00Z \
+  2026-01-01T24:00:00Z 2026-01-01T00:00:69Z; do
   since_rc=0
   : >"$FM_FAKE_LOG"
   FM_FAKE_SCENARIO=clean FM_FAKE_BODY=0 PATH="$BIN:$PATH" \
@@ -457,6 +463,23 @@ for bad_since in 30d 2026-01-01 "2026-01-01 00:00:00" 2026-01-01T00:00:00+05:00;
     fail "--since '$bad_since' reached GitHub before it was refused"
   else
     pass "--since '$bad_since' is refused with exit 64 before any request"
+  fi
+done
+
+# A refusal that refuses everything would pass the loop above while making the
+# tool useless, so the edges of every accepted component are swept for real. The
+# leap second is one GitHub can print, and midnight and year end are the values a
+# hand-typed window most often carries.
+for good_since in 2026-01-01T00:00:00Z 2026-12-31T23:59:60Z 2026-08-09T09:08:07Z; do
+  good_rc=0
+  : >"$FM_FAKE_LOG"
+  FM_FAKE_SCENARIO=clean FM_FAKE_BODY=0 PATH="$BIN:$PATH" \
+    "$SWEEP" --account testcaptain --since "$good_since" --repo acme/widgets \
+    --kind comments >/dev/null 2>&1 || good_rc=$?
+  if [ "$good_rc" = "0" ] && [ -s "$FM_FAKE_LOG" ]; then
+    pass "--since '$good_since' is accepted and actually sweeps"
+  else
+    fail "a real timestamp was refused: --since '$good_since' exited $good_rc"
   fi
 done
 

--- a/tests/fm-attribution-sweep.test.sh
+++ b/tests/fm-attribution-sweep.test.sh
@@ -375,4 +375,23 @@ else
   fail "expected exit 64 for an unknown kind, got $usage_rc"
 fi
 
+# The worst window bug is the one that still exits 0. Every window filter is a
+# string comparison against GitHub's timestamps, so a plausible-looking "30d"
+# would sort below every record, examine nothing, and print a clean sweep. It has
+# to be refused before it is ever compared against anything.
+for bad_since in 30d 2026-01-01 "2026-01-01 00:00:00" 2026-01-01T00:00:00+05:00; do
+  since_rc=0
+  : >"$FM_FAKE_LOG"
+  FM_FAKE_SCENARIO=clean FM_FAKE_BODY=0 PATH="$BIN:$PATH" \
+    "$SWEEP" --account testcaptain --since "$bad_since" --repo acme/widgets \
+    >/dev/null 2>&1 || since_rc=$?
+  if [ "$since_rc" != "64" ]; then
+    fail "expected exit 64 for --since '$bad_since', got $since_rc"
+  elif [ -s "$FM_FAKE_LOG" ]; then
+    fail "--since '$bad_since' reached GitHub before it was refused"
+  else
+    pass "--since '$bad_since' is refused with exit 64 before any request"
+  fi
+done
+
 exit "$FAILED"


### PR DESCRIPTION
## Intent

Put the retained-probe known-positive label where a triager actually stands, and record that the preserved evidence note agrees with the guide. Follow-up commit on the existing validated branch for the sol-attribution-convention task: keep every prior pipeline fix commit present, never abort-and-restart or replace the branch.

Base task context, unchanged: implement the captain's ruled attribution convention for browser-Sol GitHub writes (token SOL-AI:, reachable at prompt-composition time via bin/fm-attribution-sweep.sh --convention, owned by docs/model-write-attribution.md) and make omissions DETECTABLE after the fact via that sweep, because write-time enforcement is impossible on this identity. Do NOT build write-time enforcement. The sweep stays read-only, reports candidates plus evidence rather than claiming authorship, and keeps could-not-observe as an outcome distinct from clean.

This commit implements the supervisor's explicit instruction that the triage labelling is LOAD-BEARING and must be explicit and easy to apply, not a footnote, because an unlabelled permanent known-positive gets investigated as a real finding by someone every single time.

Two changes.

1. The sweep's own summary now tells the reader that some candidates are known permanent ones: a 2026-08-02 capability probe left five deliberately unprefixed writes in place as the sweep's only real-world red control, that reporting them is correct behaviour rather than a finding, and that a candidate dated 2026-08-02 should be checked against the recognition table in docs/model-write-attribution.md before being investigated. A document a reader has to know to open is not a label; the pointer has to be in the output they are holding. Two colocated assertions cover this and were proven red-capable by removing the pointer and watching the suite fail.

2. docs/model-write-attribution.md now records that the preserved evidence note at data/sol-capability-probe/github-evidence.md AGREES with the guide - it keeps the artifacts, calls them a deliberate permanent known-positive, states a sweep reporting them is working correctly, and defers recognition to the guide by name.

The page also states plainly that this agreement is load-bearing and has already failed once: the note previously opened by saying the artifacts had been deleted, which would lead a reader to conclude any 2026-08-02 candidate must be genuine, the exact inversion the section exists to prevent. It records that NO TEST can catch a repeat, because the note is private to the operator's home and gitignored, therefore absent from every clone and every CI run, so a check asserting agreement between the two documents would pass without reading anything and report green while examining nothing. Hand reconciliation is named as the only real control. Preserve that reasoning: do not add or suggest an automated check across that boundary, and do not soften the statement into an implied guarantee.

Standing constraint for this run, from the supervisor: any review finding that asserts the CONTENTS of a file under data/ is unverifiable from this worktree, because data/ is gitignored and the probe evidence path does not exist here. Such findings must be routed to firstmate rather than acted on. A finding in an earlier round quoted a line of that note which no longer exists, and acting on it would have reintroduced the inversion one level further out.

Other constraints still in force: firstmate shared tracked material, so firstmate-coding-guidelines applies; one sentence per line in prose; plain dashes, never em dashes; shellcheck-clean bin/ scripts; colocated tests; never add an agent as a commit co-author; never carry the captain-address convention into a commit message, PR title, or PR body; use gh-axi for GitHub, never raw gh. Out of scope: refreshing the portable-serial shard table in docs/fm-test-portable-shards.md, which is pre-existing drift filed separately.

## What Changed

- New `bin/fm-attribution-sweep.sh`: a read-only, GET-only sweep that lists issue comments, reviews, and commits made under one account that lack the `SOL-AI:` attribution token. Every scope ends in exactly one of observed-clean, candidates, or could-not-observe, so an unreachable API, exhausted budget, or truncated page never folds into a clean run; candidates print evidence instead of asserting authorship, and `--convention` / `--token` make the convention reachable at prompt-composition time. `--since` is validated for both spelling and component ranges (`30d`, month 13, day 32, hour 24 all exit 64 before any GitHub call), a run that resolves no repository cannot report clean, and the request/page budgets are printed rather than silently narrowing what was examined.
- The sweep's summary now labels the retained 2026-08-02 capability-probe writes as a known permanent red control, states that reporting them is correct behaviour rather than a finding, and points a triager at the recognition table before they investigate; the sweep still does not filter them out.
- New `docs/model-write-attribution.md` owns the convention, the sweep's coverage limits, and the five-artifact recognition table, and records that the preserved private evidence note agrees with the guide, that this agreement has already failed once, and that hand reconciliation is the only control since the note is absent from every clone and CI run. Registered in `docs/scripts.md` and `docs/documentation-audiences.json`; colocated `tests/fm-attribution-sweep.test.sh` (51 assertions) is wired into `bin/fm-test-run.sh`'s `pr-forge` family, and the two new labelling assertions were proven red-capable by deleting the pointer.

## Risk Assessment

✅ Low: The only substantive prior finding is fixed and pinned by tests on both sides (impossible dates refused, real timestamps still swept), the envelope extraction is a pure mechanical deduplication with every call site verified, and the remaining gap is a single missing test input for one already-implemented guard.

## Testing

Ran the colocated sweep contract suite and the docs-audience test (both green), then produced product-level evidence rather than relying on pass/fail: a real CLI transcript of a sweep whose window covers 2026-08-02, where retained probe comment 5158866063 is reported beside an unrelated candidate and the printed summary tells the reader the 2026-08-02 candidates are known permanent ones, that reporting them is correct behaviour, and where the recognition table lives; a follow-the-pointer check showing that heading and that exact identifier in docs/model-write-attribution.md; a mutation run proving the two new assertions go red when the pointer paragraph is removed; and a CLI transcript showing impossible --since components refused with exit 64 and no GitHub calls while a leap-second timestamp still sweeps. The change is CLI-output and markdown prose, so the end-user surface is the terminal transcript itself, which is captured verbatim; there is no rendered UI to screenshot. Worktree left clean and scratch copies removed.

<details>
<summary>Evidence: Triager CLI transcript: probe candidate reported with the known-positive label in the summary</summary>

<code>FM_SWEEP_CANDIDATE repo=sbracewell64/firstmate kind=comment ref=5158866063 when=2026-08-02T15:17:41Z url=https://github.com/sbracewell64/firstmate/issues/24#issuecomment-5158866063 evidence=assoc=OWNER,via_app=chatgpt-codex-connector,token=absent&#10;FM_SWEEP_CANDIDATE repo=sbracewell64/firstmate kind=comment ref=5209911402 when=2026-08-09T18:02:10Z url=https://github.com/sbracewell64/firstmate/issues/2077#issuecomment-5209911402 evidence=assoc=OWNER,via_app=none,token=absent&#10;FM_SWEEP_SUMMARY scopes=1 observed=1 could_not_observe=0 declared=0 candidates=2 requests=1 outcome=candidates&#10;...&#10;Some candidates are known permanent ones. A capability probe on 2026-08-02 left&#10;five deliberately unprefixed writes in place as this sweep&#39;s only real-world red&#10;control, and reporting them is correct behaviour rather than a finding. Before&#10;investigating any candidate dated 2026-08-02, check it against the table in&#10;docs/model-write-attribution.md under &#34;The retained probe writes&#34;.&#10;&#10;$ echo $?&#10;10</code>

```text
FM_SWEEP_BEGIN 2026-08-10T16:57:28Z account=sbracewell64 since=2026-08-01T00:00:00Z token=SOL-AI: repos=1 budget=300
FM_SWEEP_CANDIDATE repo=sbracewell64/firstmate kind=comment ref=5158866063 when=2026-08-02T15:17:41Z url=https://github.com/sbracewell64/firstmate/issues/24#issuecomment-5158866063 evidence=assoc=OWNER,via_app=chatgpt-codex-connector,token=absent
FM_SWEEP_CANDIDATE repo=sbracewell64/firstmate kind=comment ref=5209911402 when=2026-08-09T18:02:10Z url=https://github.com/sbracewell64/firstmate/issues/2077#issuecomment-5209911402 evidence=assoc=OWNER,via_app=none,token=absent
FM_SWEEP_SCOPE repo=sbracewell64/firstmate kind=comments outcome=observed examined=2 declared=0 candidates=2
FM_SWEEP_SUMMARY scopes=1 observed=1 could_not_observe=0 declared=0 candidates=2 requests=1 outcome=candidates
This sweep cannot determine who wrote anything. A candidate is a write under
this account that does not carry SOL-AI: - which is equally what an
undeclared model session and the captain's own hand-typed comment look like in
every field GitHub exposes. The evidence on each line is a signal, not an
attribution; the captain judges.

Some candidates are known permanent ones. A capability probe on 2026-08-02 left
five deliberately unprefixed writes in place as this sweep's only real-world red
control, and reporting them is correct behaviour rather than a finding. Before
investigating any candidate dated 2026-08-02, check it against the table in
docs/model-write-attribution.md under "The retained probe writes".

This run covered everything since 2026-08-01T00:00:00Z, as given by --since, and writes outside it
were not examined at all - a clean result says nothing about them. Widen the
window with --since <iso8601> or FM_SWEEP_WINDOW_DAYS=<days>, and raise --budget
with it: reviews and commits each spend about one request per pull request in
the window, so a wider window on the current budget of 300 will report
could-not-observe instead of a result.

$ echo $?
10
```
</details>
<details>
<summary>Evidence: The summary&#39;s pointer resolves to the recognition table for the reported candidate</summary>

<code>$ grep -n &#34;^## The retained probe writes&#34; docs/model-write-attribution.md&#10;113:## The retained probe writes, and how to recognise them&#10;&#10;$ grep -n &#34;5158866063&#34; docs/model-write-attribution.md&#10;122:| Issue comment | `5158866063` | body carries the nonce |</code>

```text
$ # A triager holding candidate 5158866063 follows the pointer the summary gave them.
$ grep -n "^## The retained probe writes" docs/model-write-attribution.md
113:## The retained probe writes, and how to recognise them

$ grep -n "5158866063" docs/model-write-attribution.md
122:| Issue comment | `5158866063` | body carries the nonce |
164:These five already earned their keep: proving the sweep against them is what exposed a real defect, an early filter that skipped app-performed writes and would therefore have hidden comment `5158866063` - the single most representative example of what the sweep exists to catch.

$ # ...and the section states the preserved evidence note agrees with the guide.
$ sed -n "/^### Why they exist/,/^### Why they were not deleted/p" docs/model-write-attribution.md
### Why they exist

They are what a browser model session produced on 2026-08-02 when it was asked to prove it could comment, review, and push a commit.
That measurement is the evidence the whole convention rests on: every one of them recorded the account owner with `author_association: OWNER` and no bot marker, which is why write-time enforcement was ruled impossible and detection after the fact was chosen instead.
Independent evidence is preserved outside this repository at `data/sol-capability-probe/github-evidence.md`.
That note agrees with this section: it records the decision to keep the artifacts, calls them a deliberate permanent known-positive, states that a sweep reporting them is working correctly, and leaves the question of how to recognise them to this page.
It enumerates only four artifacts, omitting scaffolding commit `3e05033a95a1`, which appears there as a parent SHA rather than as a swept write.
The table above supersedes it on the set, and every entry was verified against the live API rather than copied from the note.

Those two documents agreeing that the artifacts still exist is what keeps this section usable, and they have already disagreed once.
The note previously opened by saying the artifacts had been deleted, which would lead a reader here to conclude that any candidate dated 2026-08-02 must be genuine - the exact inversion this section exists to prevent.
No test can catch a repeat, because the note is private to the operator's home and absent from every clone and CI run, so a check asserting agreement would pass without reading anything.
Whoever edits either document reconciles both by hand.

### Why they were not deleted
```
</details>
<details>
<summary>Evidence: Red-capability: removing the pointer turns both new assertions red</summary>

<code>not ok - no pointer to the probe table in the summary: ...&#10;not ok - the summary does not name the probe date: ...&#10;exit=1</code>

```text
$ # Mutant: the known-positive pointer paragraph is deleted from a COPY of the sweep.
$ diff <(sed -n "/cannot determine who wrote/,/Widen the/p" bin/fm-attribution-sweep.sh) <(sed -n "/cannot determine who wrote/,/Widen the/p" MUTANT/bin/fm-attribution-sweep.sh)
7,12d6
< Some candidates are known permanent ones. A capability probe on 2026-08-02 left
< five deliberately unprefixed writes in place as this sweep's only real-world red
< control, and reporting them is correct behaviour rather than a finding. Before
< investigating any candidate dated 2026-08-02, check it against the table in
< docs/model-write-attribution.md under "The retained probe writes".
< 

$ bash MUTANT/tests/fm-attribution-sweep.test.sh   # the two colocated assertions must go red
not ok - no pointer to the probe table in the summary: FM_SWEEP_BEGIN 2026-08-10T16:57:50Z account=testcaptain since=2026-01-01T00:00:00Z token=SOL-AI: repos=1 budget=300
not ok - the summary does not name the probe date: FM_SWEEP_BEGIN 2026-08-10T16:57:50Z account=testcaptain since=2026-01-01T00:00:00Z token=SOL-AI: repos=1 budget=300
exit=1
```
</details>
<details>
<summary>Evidence: --since range check: impossible dates refused before any GitHub call, leap second accepted</summary>

<code>$ ... --since 2026-13-01T00:00:00Z ...&#10;fm-attribution-sweep: --since must be a UTC ISO-8601 timestamp spelled YYYY-MM-DDTHH:MM:SSZ, e.g. 2026-01-01T00:00:00Z&#10;exit=64 GitHub calls made: 0&#10;&#10;$ ... --since 2026-12-31T23:59:60Z ...&#10;FM_SWEEP_SUMMARY scopes=1 observed=1 could_not_observe=0 declared=0 candidates=0 requests=1 outcome=clean&#10;exit=0</code>

```text
$ fm-attribution-sweep.sh --account sbracewell64 --since 2026-13-01T00:00:00Z --repo sbracewell64/firstmate --kind comments
fm-attribution-sweep: --since must be a UTC ISO-8601 timestamp spelled YYYY-MM-DDTHH:MM:SSZ, e.g. 2026-01-01T00:00:00Z
run "fm-attribution-sweep.sh --help" for usage
exit=64   GitHub calls made: 0

$ fm-attribution-sweep.sh --account sbracewell64 --since 2026-01-32T00:00:00Z --repo sbracewell64/firstmate --kind comments
fm-attribution-sweep: --since must be a UTC ISO-8601 timestamp spelled YYYY-MM-DDTHH:MM:SSZ, e.g. 2026-01-01T00:00:00Z
run "fm-attribution-sweep.sh --help" for usage
exit=64   GitHub calls made: 0

$ fm-attribution-sweep.sh --account sbracewell64 --since 2026-01-01T24:00:00Z --repo sbracewell64/firstmate --kind comments
fm-attribution-sweep: --since must be a UTC ISO-8601 timestamp spelled YYYY-MM-DDTHH:MM:SSZ, e.g. 2026-01-01T00:00:00Z
run "fm-attribution-sweep.sh --help" for usage
exit=64   GitHub calls made: 0

$ fm-attribution-sweep.sh --account sbracewell64 --since 2026-12-31T23:59:60Z --repo sbracewell64/firstmate --kind comments
FM_SWEEP_BEGIN 2026-08-10T16:58:03Z account=sbracewell64 since=2026-12-31T23:59:60Z token=SOL-AI: repos=1 budget=300
FM_SWEEP_SCOPE repo=sbracewell64/firstmate kind=comments outcome=observed examined=0 declared=0 candidates=0
FM_SWEEP_SUMMARY scopes=1 observed=1 could_not_observe=0 declared=0 candidates=0 requests=1 outcome=clean
This sweep cannot determine who wrote anything. A candidate is a write under
exit=0   GitHub calls made: 9
```
</details>
<details>
<summary>Evidence: Driver used to capture the triager transcript (reproducible)</summary>

```text
#!/usr/bin/env bash
# Drives the real bin/fm-attribution-sweep.sh against a fake gh-axi that replays
# a sweep window covering 2026-08-02, so the captured stdout is exactly what a
# triager is holding when a retained probe write comes back as a candidate.
#
# Two candidates are returned: issue comment 5158866063 (a real retained probe
# artifact, listed in the recognition table) and an unrelated 2026-08-09 write
# that is NOT a probe artifact. The label in the summary is what tells the two
# apart without the reader having to already know the guide exists.
set -u

ROOT=$1
OUT=$2

WORK=$(mktemp -d "${TMPDIR:-/tmp}/fm-attr-evidence.XXXXXX")
trap 'rm -rf "$WORK"' EXIT
BIN="$WORK/bin"
mkdir -p "$BIN"

b64() { printf '%s' "$1" | base64 | tr -d '\n'; }
comment_record() {
  printf '%s|%s|%s|%s|%s|%s' \
    "$(b64 "$1")" "$(b64 "$2")" "$(b64 "$3")" "$(b64 "$4")" "$(b64 "$5")" "$(b64 "$6")"
}

cat >"$BIN/gh-axi" <<'FAKE'
#!/usr/bin/env bash
path=${2:-}
case $path in
  /user) printf 'api_response:\n  body: sbracewell64\n  truncated: false\n'; exit 0 ;;
esac
printf 'api_response:\n  body: "%s"\n  truncated: false\n' "$FM_FAKE_BODY"
exit 0
FAKE
chmod +x "$BIN/gh-axi"

BODY="2\n$(comment_record 5158866063 24 2026-08-02T15:17:41Z false OWNER chatgpt-codex-connector)\n$(comment_record 5209911402 2077 2026-08-09T18:02:10Z false OWNER none)"

FM_FAKE_BODY=$BODY PATH="$BIN:$PATH" \
  "$ROOT/bin/fm-attribution-sweep.sh" \
  --account sbracewell64 --since 2026-08-01T00:00:00Z \
  --repo sbracewell64/firstmate --kind comments >"$OUT" 2>&1
rc=$?
printf '\n$ echo $?\n%s\n' "$rc" >>"$OUT"
exit 0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-attribution-sweep.sh:210` - is_iso8601 validates shape, not calendar ranges: [0-1][0-9] admits months 00 and 13-19, [0-3][0-9] admits days 00 and 32-39, [0-2][0-9] admits hours 24-29, [0-6][0-9] admits seconds 61-69. Such a value sorts ABOVE every real GitHub timestamp, which is the mirror image of the &#39;30d sorts below everything&#39; failure the function&#39;s own comment (lines 202-207) says it exists to prevent. The reviews kind applies the window entirely client-side (collect_prs_uncached:683 string compare, plus the jq select at line 723), so nothing server-side rejects the bad date: every PR is judged older than SINCE, PR_NUMBERS comes back empty with PR_STATUS=ok, and sweep_reviews reaches scope_observed with examined=0. Tighten the check to real component ranges (month 01-12, day 01-31, hour 00-23, second 00-60) so an impossible date is refused with exit 64 before any comparison, the same way &#39;30d&#39; already is.
- ℹ️ `bin/fm-attribution-sweep.sh:526` - The listing-envelope split is open-coded at five call sites: &#39;raw=$(printf &#39;%s\n&#39; &#34;$GH_BODY&#34; | head -1)&#39; followed by an is_uint guard (lines 526-527, 590-593, 674-679, 800-803, 874-878), and &#39;done &lt; &lt;(printf &#39;%s\n&#39; &#34;$GH_BODY&#34; | tail -n +2)&#39; (lines 531, 608, 688, 808, 896). Two small helpers - one returning the page count and one emitting the record lines - would collapse ten duplicated expressions and remove five independent chances for the count line and the record stream to drift apart, which is the exact split the JQ_ENVELOPE contract depends on.

🔧 Fix: range-check sweep window components; extract page envelope helpers
1 info still open:
- ℹ️ `tests/fm-attribution-sweep.test.sh:451` - The bad_since loop pins every component of the new validator except the minute: it covers month high (2026-13-01) and low (2026-00-01), day high (2026-01-32) and low (2026-01-00), hour high (T24:00:00) and second high (T00:00:69), but nothing exercises the &#39;[ &#34;$minute&#34; -le 59 ] || return 1&#39; guard at bin/fm-attribution-sweep.sh:230. That guard is therefore the one line of the range check a later edit could delete with the suite still green, and a value like 2026-01-01T00:60:00Z sorts above every real timestamp inside that hour, silently narrowing the window the same way the other components do. Add 2026-01-01T00:60:00Z to the existing array; no other change is needed.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-attribution-sweep.test.sh` - full colocated sweep contract suite, 51 assertions green, exit 0</code>
- <code>`bash tests/fm-documentation-audiences.test.sh` - docs inventory/link checks still green after the docs/model-write-attribution.md edit</code>
- <code>Manual end-to-end CLI run: real `bin/fm-attribution-sweep.sh --account sbracewell64 --since 2026-08-01T00:00:00Z --repo sbracewell64/firstmate --kind comments` against a stub gh-axi replaying probe comment `5158866063` (2026-08-02T15:17:41Z) plus an unrelated 2026-08-09 candidate; captured full stdout a triager holds</code>
- <code>Manual pointer-resolution check: `grep -n &#39;^## The retained probe writes&#39; docs/model-write-attribution.md` and `grep -n 5158866063 docs/model-write-attribution.md` confirm the summary&#39;s pointer lands on the table row for the reported candidate</code>
- <code>Red-capability check: copied bin/ + tests/ to a scratch dir, deleted the known-positive pointer paragraph from the copied sweep, reran the suite - both new assertions report `not ok`, suite exits 1</code>
- <code>Manual CLI range-check transcript: `--since` with 2026-13-01T00:00:00Z / 2026-01-32T00:00:00Z / 2026-01-01T24:00:00Z each exit 64 with zero GitHub calls, while 2026-12-31T23:59:60Z (leap second) is accepted and sweeps</code>
- <code>`grep -rn sol-capability-probe tests/ bin/` - confirms no automated check reads the gitignored private evidence note</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/model-write-attribution.md:146` - The &#34;Why they exist&#34; subsection asserts what the preserved note at data/sol-capability-probe/github-evidence.md says (keeps the artifacts, calls them a deliberate permanent known-positive, defers recognition to this page, enumerates four artifacts). That path does not exist in this worktree and data/ is gitignored, so the agreement claim cannot be verified here. Per the standing constraint this is routed to firstmate rather than acted on: no edit was made to that paragraph, and no automated cross-boundary check was added or suggested. The page&#39;s own statement that hand reconciliation is the only real control was left intact.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
