### PR TITLE
docs: fold captain's global concision rule into AGENTS.md section 9

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -445,8 +445,9 @@ Never relay worker reports, status lines, tool output, validation-state labels, 
 Read them as evidence, then send the plain-English outcome and consequence.
 Private evidence reports may retain exact identifiers, paths, status lines, validation labels, and internal terms when they are useful, but the captain-facing chat summary that points to the report still follows this translation rule.
 
-Every escalation must stand alone and remain concise.
-Lead directly with concrete evidence, then the consequence, options when applicable, and a recommendation.
+In all interactions and responses, be extremely concise and direct, and skip conversational filler and pleasantries.
+This concision never licenses dropping the mandatory captain address, the outcome-not-mechanics translation above, or evidence the captain needs to act.
+Every escalation therefore stands alone and remains concise: lead directly with concrete evidence, then the consequence, options when applicable, and a recommendation.
 Use the same evidence-first form for objections or clarifying challenges rather than unsupported deference.
 
 Reach the captain immediately for:


### PR DESCRIPTION
## Intent

Add the captain's global communication rule to firstmate's AGENTS.md (CLAUDE.md is a symlink; the edit lives in AGENTS.md). The captain's verbatim rule: 'In all interactions and responses, be extremely concise and direct. Skip conversational filler and pleasantries.'

Placement was the crux: section 9 (Escalation and captain etiquette) already owns captain-facing communication style and already carried a narrower concision rule ('Every escalation must stand alone and remain concise'). Per the repo's one-owner rule, the broader rule was integrated into section 9's existing language rather than added as a separate overlapping statement or a new section. The narrower escalation-concision sentence was absorbed into and subordinated to the broader statement so section 9 reads as one coherent concision contract, not two rules about concision side by side.

The captain's wording is kept substantively intact (extremely concise and direct, no conversational filler or pleasantries). One guard sentence was deliberately added so concision cannot be read as licence to drop what section 9 still mandates: the captain must still be addressed, internal terms must still be translated to outcomes (the outcome-not-mechanics rules), and responses must still include the evidence the captain needs to act. That guard is intentional, not scope creep.

Scope is docs only: AGENTS.md section 9, no new section, no behaviour/script/skill changes, minimal restructuring. Repo style followed: one full sentence per line, plain dashes. bin/fm-doc-audience-check.sh passes (surfaces=67, local_links=233). Delivery is a PR for the captain to merge.

## What Changed

- Integrated the captain's global communication rule ("be extremely concise and direct, skip conversational filler and pleasantries") into section 9 of `AGENTS.md`, subordinating the pre-existing narrower escalation-concision sentence so section 9 reads as one coherent concision contract rather than two overlapping rules.
- Added a guard sentence clarifying that concision never licenses dropping the mandatory captain address, the outcome-not-mechanics translation, or the evidence the captain needs to act.
- Docs-only edit; `CLAUDE.md` continues to serve the updated text via its symlink and `bin/fm-doc-audience-check.sh` still passes (surfaces=67, local_links=233).

## Risk Assessment

✅ Low: A well-bounded docs-only edit that integrates the captain's concision rule into section 9's existing language, follows the one-owner rule, and whose intentional guard sentence references obligations that genuinely exist elsewhere in the file.

## Testing

Ran the doc audience-check script cited as the acceptance gate (bin/fm-doc-audience-check.sh), which passed with surfaces=67 and local_links=233 exactly as the intent states; confirmed the diff is docs-only (AGENTS.md, no new section), that the captain's verbatim concision rule, the absorbed escalation-concision clause, and the intentional guard sentence all render in section 9, and that the CLAUDE.md symlink serves the same edit. No rendered UI surface exists for this agent-facing markdown doc, so visual/screenshot evidence is not applicable; the CLI transcript of the audit plus the rendered section 9 text is the appropriate product-level evidence. All checks pass.

<details>
<summary>Evidence: Doc audience-check transcript + rendered section 9</summary>

<code>fm-doc-audience-check: ok surfaces=67 local_links=233&#10;&#10;AGENTS.md section 9:&#10;In all interactions and responses, be extremely concise and direct, and skip conversational filler and pleasantries.&#10;This concision never licenses dropping the mandatory captain address, the outcome-not-mechanics translation above, or evidence the captain needs to act.&#10;Every escalation therefore stands alone and remains concise: lead directly with concrete evidence, then the consequence, options when applicable, and a recommendation.&#10;&#10;CLAUDE.md -&gt; AGENTS.md (symlink)&#10;diff scope: AGENTS.md only, 3 insertions, 2 deletions, no new heading</code>

```text
=== bin/fm-doc-audience-check.sh (validates doc audience inventory / links) ===
fm-doc-audience-check: ok surfaces=67 local_links=233

=== AGENTS.md section 9, rendered (the integrated concision contract) ===
In all interactions and responses, be extremely concise and direct, and skip conversational filler and pleasantries.
This concision never licenses dropping the mandatory captain address, the outcome-not-mechanics translation above, or evidence the captain needs to act.
Every escalation therefore stands alone and remains concise: lead directly with concrete evidence, then the consequence, options when applicable, and a recommendation.
Use the same evidence-first form for objections or clarifying challenges rather than unsupported deference.

=== CLAUDE.md is a symlink -> AGENTS.md, so it serves the same edit ===
lrwxr-xr-x@ 1 wameson  staff  9 Aug 10 09:03 CLAUDE.md -> AGENTS.md

=== diff scope: docs-only, AGENTS.md, no new heading ===
 AGENTS.md | 5 +++--
 1 file changed, 3 insertions(+), 2 deletions(-)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-doc-audience-check.sh` → ok surfaces=67 local_links=233 (matches intent&#39;s cited acceptance numbers)</code>
- <code>`git diff --stat 85e750a f42ac7f` → only AGENTS.md changed (3 insertions, 2 deletions), no new heading added</code>
- <code>`grep -n &#34;extremely concise and direct&#34; CLAUDE.md` → symlink resolves and serves the edited text</code>
- `Manual read of AGENTS.md lines 448-451 confirming verbatim rule, guard sentence, and absorbed escalation-concision clause`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
