### PR TITLE
fix(ff): require a work-tree root before fast-forwarding a target

### DIFF
--- a/bin/fm-ff-lib.sh
+++ b/bin/fm-ff-lib.sh
@@ -279,8 +279,21 @@ ff_target() {
     echo "$label: skipped: not a directory"
     return 0
   fi
-  if ! git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  # Git repository discovery walks UPWARD, so --is-inside-work-tree is true for a
+  # target that merely SITS INSIDE a repository, and every command below would then
+  # fast-forward or prune that enclosing repository under this target's label.
+  # Every ff_target caller passes a work-tree root (a clone, a linked worktree, or a
+  # secondmate home), so require the root itself and skip anything else benignly.
+  local dir_real dir_toplevel dir_toplevel_real
+  dir_real=$(CDPATH='' cd -P -- "$dir" 2>/dev/null && pwd -P) || dir_real=$dir
+  dir_toplevel=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null) || dir_toplevel=
+  if [ -z "$dir_toplevel" ]; then
     echo "$label: skipped: not a git repo"
+    return 0
+  fi
+  dir_toplevel_real=$(CDPATH='' cd -P -- "$dir_toplevel" 2>/dev/null && pwd -P) || dir_toplevel_real=$dir_toplevel
+  if [ "$dir_toplevel_real" != "$dir_real" ]; then
+    echo "$label: skipped: not a clone root (inside $dir_toplevel)"
     return 0
   fi
 

--- a/bin/fm-ff-lib.sh
+++ b/bin/fm-ff-lib.sh
@@ -266,8 +266,9 @@ live_secondmate_meta_records() {
 #                  already exist in the target's object store, which it always does
 #                  for a worktree of this same repo; a standalone clone that lacks
 #                  it is skipped rather than fetched.
-# Guards are identical in both modes: ff-only (never force/merge/stash); skip a
-# dirty, diverged, or wrong-branch target and leave its work untouched.
+# Guards are identical in both modes: ff-only (never force/merge/stash); the target
+# must be the work-tree root itself (see the clone-root check below); skip a dirty,
+# diverged, or wrong-branch target and leave its work untouched.
 FF_STATUS=""
 FF_INSTR=""
 ff_target() {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -307,8 +307,8 @@ The refresh also prunes local branches whose remote is gone and that no worktree
 For a remote route, the configured code root updates from its own origin on that host before the persistent home fast-forwards to the code-root commit.
 The update is fast-forward only: dirty, diverged, offline, and off-default targets are reported and left untouched.
 Local homes share the guarded fast-forward helper, while remote updates delegate the same safety decision to the configured host through the generic transport.
-That shared helper, on the origin pull and the local secondmate sync alike, advances a target only when the target directory is itself the work-tree root, because git repository discovery walks upward: a directory merely nested inside a repository resolves to that enclosing repository, which would then be fast-forwarded or pruned under the target's label.
-A non-root target is reported as a benign skip instead.
+That shared helper serves the origin pull and the local secondmate sync alike, and it also requires each target directory to be the work-tree root itself, skipping anything else the same way.
+The root requirement exists because git repository discovery walks upward: a directory merely nested inside a repository resolves to that enclosing repository, which the helper would otherwise fast-forward or prune under the target's label.
 The mechanics are owned by the `/updatefirstmate` skill and firstmate's operating manual in [`AGENTS.md`](../AGENTS.md) (self-update).
 
 ## Restart-proof

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -307,6 +307,8 @@ The refresh also prunes local branches whose remote is gone and that no worktree
 For a remote route, the configured code root updates from its own origin on that host before the persistent home fast-forwards to the code-root commit.
 The update is fast-forward only: dirty, diverged, offline, and off-default targets are reported and left untouched.
 Local homes share the guarded fast-forward helper, while remote updates delegate the same safety decision to the configured host through the generic transport.
+That shared helper, on the origin pull and the local secondmate sync alike, advances a target only when the target directory is itself the work-tree root, because git repository discovery walks upward: a directory merely nested inside a repository resolves to that enclosing repository, which would then be fast-forwarded or pruned under the target's label.
+A non-root target is reported as a benign skip instead.
 The mechanics are owned by the `/updatefirstmate` skill and firstmate's operating manual in [`AGENTS.md`](../AGENTS.md) (self-update).
 
 ## Restart-proof

--- a/tests/fm-secondmate-sync.test.sh
+++ b/tests/fm-secondmate-sync.test.sh
@@ -233,6 +233,37 @@ test_ff_inflight_feature_branch() {
   pass "T5 in-flight: a home on a feature branch is skipped, its work preserved"
 }
 
+# --- T5b: a target that is not a work-tree root never advances its encloser ---
+# Git repository discovery walks UPWARD, so a directory that merely sits INSIDE a
+# repository resolves to that enclosing repository. Without the clone-root guard
+# ff_target fast-forwards the ENCLOSING worktree under the target's label, which is
+# how a plain container directory silently moves a home that was never named.
+# The container lives under the gitignored projects/ dir on purpose: an untracked
+# path would report the enclosing worktree dirty, and the skip would then prove
+# nothing because the dirty guard would have stopped the advance anyway.
+test_ff_non_root_target_never_advances_enclosing_repo() {
+  local w c1 base before
+  w=$(new_world ff-clone-root)
+  c1=$(head_of "$w/main")
+  git -C "$w/main" worktree add -q --detach "$w/sm" "$c1"
+  mkdir -p "$w/sm/projects/pool"
+  bump_primary "$w" instr
+  base=$(primary_head_commit "$w/main")
+  before=$(head_of "$w/sm")
+  [ "$before" != "$base" ] || fail "fixture is vacuous: the home is already at the base"
+  [ -z "$(git -C "$w/sm" status --porcelain 2>/dev/null | head -1)" ] \
+    || fail "fixture is vacuous: the enclosing worktree is dirty, so the dirty guard would skip anyway"
+
+  run_ff "$w/sm/projects/pool" "$base"
+
+  [ "$FF_STATUS" = skipped ] || fail "FF_STATUS: expected skipped, got '$FF_STATUS'"
+  assert_contains "$FF_OUT" "secondmate sm: skipped: not a clone root" \
+    "a target that is not a work-tree root is skipped as such"
+  [ "$(head_of "$w/sm")" = "$before" ] \
+    || fail "the enclosing worktree was fast-forwarded under a non-root target's label"
+  pass "T5b clone root: a non-root target is skipped and never advances its enclosing repo"
+}
+
 # --- T6: no origin fetch happens in the local-HEAD sync path -----------------
 # A bare `git fetch` would need the network; the sync must never reach for it.
 # Shadow git with a wrapper that records any `fetch` invocation, then drive the
@@ -855,6 +886,7 @@ test_ff_current
 test_ff_dirty
 test_ff_diverged
 test_ff_inflight_feature_branch
+test_ff_non_root_target_never_advances_enclosing_repo
 test_no_fetch_in_local_path
 test_sweep_nudge_requires_instruction_change
 test_bootstrap_sweep_nudges_only_instruction_change


### PR DESCRIPTION
## Summary

`ff_target` in `bin/fm-ff-lib.sh` guarded its target with `git rev-parse --is-inside-work-tree`.
Git repository discovery walks upward, so that check succeeds for any plain directory merely nested inside a repository.
`ff_target` therefore accepted such a directory and ran every subsequent `git -C "$dir" ...` against the **enclosing** repository under the target's label, fast-forwarding or pruning a repository the caller never named.

`ff_target` is the shared fast-forward machinery behind `/updatefirstmate` (`bin/fm-update.sh`) and the local-HEAD secondmate sync (`bin/fm-spawn.sh` on launch, `bin/fm-bootstrap.sh` on startup).

This change requires the target to **be** the work-tree root.
A non-root reports `skipped: not a clone root (inside <toplevel>)`, a benign skip rather than a silent advance of the wrong repository.
A directory in no repository at all still reports `skipped: not a git repo`, so that path is unchanged.

## Relationship to #2044

This is the **complement** to #2044, not a competing or duplicate fix.

#2044 fixes the same upward-discovery root cause for the `projects/` clone sweep in `bin/fm-fleet-sync.sh`.
That sweep fix is deliberately left to #2044, and `bin/fm-fleet-sync.sh` and `tests/fm-fleet-sync.test.sh` are intentionally untouched here.
What this PR adds is the identical hole on a different code path: `ff_target`, which #2044 does not touch at all.

## Scope - three files

- `bin/fm-ff-lib.sh` - the clone-root guard in `ff_target`.
- `tests/fm-secondmate-sync.test.sh` - the regression. This suite already exercises `ff_target`.
- `docs/architecture.md` - two sentences in the "Self-updates stay safe" section. This repo's conventions require documentation to stay accurate when behavior changes, and that section is the owner of self-update fast-forward safety. It says nothing about `bin/fm-fleet-sync.sh` or `projects/`, so it does not overlap #2044.

## Why both sides of the path comparison are canonicalized

Comparing a shell-resolved path against git's raw `--show-toplevel` output is not portable.
On Git Bash/MSYS, which this repo supports, git reports `C:/Users/...` while `pwd -P` reports `/c/Users/...`, so every target would be misclassified and self-update would silently become a no-op.
This matches the existing worktree-root checks in `bin/fm-control.sh` and `bin/fm-spawn.sh`, which canonicalize both sides for the same reason.
If the toplevel cannot be resolved physically the code falls back to the raw value rather than failing the sweep, consistent with `bin/fm-control.sh`.

## Test plan

- [x] `bin/fm-lint.sh` (ShellCheck 0.11.0)
- [x] `bin/fm-test-run.sh tests/fm-secondmate-sync.test.sh`
- [x] `bin/fm-test-run.sh tests/fm-update.test.sh` (the other suite covering `ff_target` callers)
- [x] The regression was verified to fail without the `bin/fm-ff-lib.sh` change and pass with it.

The regression pins the safety property rather than the message.
It points `ff_target` at a container directory inside a behind secondmate home and asserts the enclosing worktree's HEAD does not move.
Without the guard it fails with `FF_STATUS: expected skipped, got 'updated'` - the enclosing home is genuinely fast-forwarded.
The container sits under the gitignored `projects/` dir deliberately: anywhere else the enclosing worktree would be dirty, the existing dirty guard would stop the advance for an unrelated reason, and the test would pass with or without the fix.
The test asserts up front that the fixture is not vacuous on either count.

## Known follow-ups, deliberately not included here

- **Digest suppression, keyed to #2044.** Once #2044 merges, whichever skip reason it emits should be added to `fleet_sync_relay_filtered_output` in `bin/fm-bootstrap.sh`, and named in `.agents/skills/bootstrap-diagnostics/SKILL.md`. Otherwise every non-clone entry under `projects/` emits an actionable `FLEET_SYNC:` digest line on every session. This cannot be done here because the filter must match #2044's actual message, not this PR's.
- **Two path canonicalizers in `bin/fm-ff-lib.sh`.** The hardened inline form added here (`CDPATH=''`, `cd -P`, `--`) now stands beside the older unhardened `resolve_path` at line 64, which `process_secondmate` still uses. Consolidating them was considered and declined: `resolve_path` has an existing consumer, so changing it would turn a targeted fix into a library refactor. The older path keeps its current behavior, so this is not a regression.
- **Duplicate skip-condition enumeration in `.agents/skills/updatefirstmate/SKILL.md`.** The same list appears at line 21 and again at line 58 under Safety. This predates the change and neither copy is made stale by it, so collapsing one into a pointer was left alone rather than widening into a skill rewrite.
- **Same root cause in `bin/fm-home-seed.sh`.** `clone_project` and `validate_seed_project` gate on `git -C "$src" rev-parse --is-inside-work-tree`, so a non-clone `projects/` entry passes and `source_origin_url` then reads the enclosing checkout's origin - seeding a secondmate home would clone firstmate itself under that project's name. Same root cause, worse blast radius, lower reachability. Out of scope here; raised so it is not lost.
