### PR TITLE
fix(composer): unify composer classification behind shared thin backend adapters

### DIFF
--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -66,7 +66,11 @@
 #                identity reporting an idle/done/blocked pi (herdr `agent
 #                get`; the tmux foreground-process probe), because a blank
 #                region between two transcript rules is otherwise exactly the
-#                strict rule's unidentifiable blank row.
+#                strict rule's unidentifiable blank row. A bare agent-glyph
+#                row inside the separator pair defers as `unknown` on
+#                identity-less backends when the row carries only the glyph;
+#                Claude's real idle row retains U+00A0 after the glyph and
+#                still reads empty there.
 #
 # THE SAFETY RULE for glyphs: a bare shell prompt glyph (`>` `$` `%` `#`) -
 # what a pane shows once its agent has exited to a plain login shell - is a
@@ -1217,8 +1221,28 @@ _fm_composer_classify_pi_rows() {  # <screen> <styled>
 }
 
 _fm_composer_classify_bare_pi_overlap() {  # <screen> <styled> <has-identity> <identity> <bare-row>
-  local screen=$1 styled=$2 has_identity=$3 identity=$4 row=$5 agent
+  local screen=$1 styled=$2 has_identity=$3 identity=$4 row=$5 agent raw plain glyph='' rest
   if [ "$has_identity" != 1 ]; then
+    raw=$(_fm_composer_screen_row "$row" "$screen")
+    if [ "$styled" = 1 ]; then
+      plain=$(printf '%s\n' "$raw" | fm_composer_strip_ghost)
+    else
+      plain=$(printf '%s\n' "$raw" | fm_composer_strip_ansi)
+    fi
+    case "$plain" in
+      '│'*'│') plain=${plain#│}; plain=${plain%│} ;;
+      '┃'*'┃') plain=${plain#┃}; plain=${plain%┃} ;;
+      '║'*'║') plain=${plain#║}; plain=${plain%║} ;;
+      '|'*'|') plain=${plain#|}; plain=${plain%|} ;;
+    esac
+    plain="${plain#"${plain%%[![:space:]]*}"}"
+    if fm_composer_leading_agent_glyph_var glyph "$plain"; then
+      rest=${plain#"$glyph"}
+      if [ -z "$rest" ]; then
+        printf 'unknown'
+        return 0
+      fi
+    fi
     _fm_composer_classify_bare_row "$screen" "$styled" "$row"
     return 0
   fi

--- a/docs/cmux-backend.md
+++ b/docs/cmux-backend.md
@@ -93,6 +93,7 @@ Spawn-time worktree discovery sends begin and end markers around `pwd`, captures
 Literal send and Enter are separate calls.
 Enter, Escape, and Ctrl-C are supported.
 The composer verifier is a thin adapter: it captures a bounded plain-text tail and hands it with cmux's capability facts to the fleet-wide classifier in `bin/fm-composer-lib.sh`, which owns every shape, including Claude's borderless `❯` row with its U+00A0 separator.
+A lone `❯` glyph row inside Pi's separator pair defers as `unknown` here because cmux supplies no agent identity probe.
 `read-screen` is plain text with no cursor primitive, so the shared classifier degrades a glyph row carrying trailing text to `unknown` rather than misreading a harness's own idle suggestion as unsent input.
 An unstructured bare prompt is `unknown`, and a slash-popup placeholder remains `pending`, so only Enter is retried and text is never retyped.
 cmux exposes no native generic agent busy signal, so supervision uses capture/hash polling for screen changes and each harness adapter's semantic lifecycle for worker state.

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -52,6 +52,7 @@ Exact command flags and response parsing are owned by `bin/backends/orca.sh` and
 `fm-send.sh` types and verifies composer clearance through the fleet-wide classifier in `bin/fm-composer-lib.sh`, retrying Enter without retyping when a slash popup first fills an argument placeholder.
 The composer read is one bounded tail of the live terminal and never pages backward into scrollback, so a stale startup banner cannot compete with the bottom-anchored composer.
 A bare shell row is `unknown`, not an empty agent composer, and plain-text captures degrade a glyph row carrying trailing text to `unknown` rather than a false `pending`.
+A lone `❯` glyph row inside Pi's separator pair also defers as `unknown` because Orca supplies no agent identity probe; Claude's real idle row retains U+00A0 after the glyph and still reads empty.
 The watcher has no native Orca busy signal, so each harness adapter's semantic lifecycle supplies worker state.
 Grok alone retains its isolated rendered-tail fallback.
 

--- a/docs/zellij-backend.md
+++ b/docs/zellij-backend.md
@@ -78,6 +78,7 @@ Literal send uses bracketed paste followed by a separate explicit Enter.
 Before sending Enter, the adapter proves that the selected composer's normalized content changed by exactly the pasted text; an unreadable composer, a paste that lands elsewhere, or unrelated pane output fails without submitting.
 The adapter supports `Enter`, `Esc`, and the one-argument key expression `Ctrl c` through the shared key vocabulary.
 Zellij exposes no cursor-row or native agent-state signal, but `dump-screen --ansi` (verified at 0.44.0) preserves styling, so the composer is read through the same fleet-wide classifier as tmux and herdr (`bin/fm-composer-lib.sh`), with ghost and placeholder text stripped before the verdict.
+A lone `❯` glyph row inside Pi's separator pair defers as `unknown` because Zellij supplies no agent identity probe.
 Submit acknowledgement requires a positively classified empty composer.
 The retired content-delta acknowledgement could report a message delivered whenever the pane changed for any reason - a spinner, streaming output, a clock - which could silently close a decision record for a message the crew never received; a pane that merely changed no longer confirms anything.
 A dead pane still fails safe: Zellij's unconditional-exit-0 actions dump nothing, and an empty dump classifies `unknown`, never a confirmation.

--- a/tests/fm-backend-cmux.test.sh
+++ b/tests/fm-backend-cmux.test.sh
@@ -726,7 +726,7 @@ test_composer_state_bare_prompt_is_empty() {
   pass "fm_backend_cmux_composer_state: a bare '❯' composer row reads empty"
 }
 
-test_composer_state_borderless_claude_prompt_is_empty() {
+test_composer_state_borderless_lone_glyph_overlap_defers() {
   local dir fb out
   dir="$TMP_ROOT/composer-borderless-claude"; mkdir -p "$dir/responses"
   cmux_panes_response "$dir" 1 "bbbbbbbb-1111-1111-1111-111111111111"
@@ -734,11 +734,11 @@ test_composer_state_borderless_claude_prompt_is_empty() {
   fb=$(make_cmux_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_CMUX_LOG="$dir/log" FM_CMUX_RESPONSES="$dir/responses" \
     bash -c '. "$0/bin/backends/cmux.sh"; fm_backend_cmux_composer_state "aaaaaaaa-0000-0000-0000-000000000000:bbbbbbbb-1111-1111-1111-111111111111"' "$ROOT" )
-  [ "$out" = empty ] || fail "a borderless Claude '❯' row bounded by horizontal rules should read empty, got '$out'"
-  pass "fm_backend_cmux_composer_state: a borderless Claude '❯' composer row reads empty"
+  [ "$out" = unknown ] || fail "a lone '❯' row inside Pi separator rules must defer without identity, got '$out'"
+  pass "fm_backend_cmux_composer_state: a lone '❯' overlap defers without identity"
 }
 
-test_composer_state_borderless_claude_prompt_outranks_stale_bordered_row() {
+test_composer_state_borderless_lone_glyph_overlap_outranks_stale_bordered_row() {
   local dir fb out
   dir="$TMP_ROOT/composer-borderless-claude-after-bordered"; mkdir -p "$dir/responses"
   cmux_panes_response "$dir" 1 "bbbbbbbb-1111-1111-1111-111111111111"
@@ -746,8 +746,8 @@ test_composer_state_borderless_claude_prompt_outranks_stale_bordered_row() {
   fb=$(make_cmux_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_CMUX_LOG="$dir/log" FM_CMUX_RESPONSES="$dir/responses" \
     bash -c '. "$0/bin/backends/cmux.sh"; fm_backend_cmux_composer_state "aaaaaaaa-0000-0000-0000-000000000000:bbbbbbbb-1111-1111-1111-111111111111"' "$ROOT" )
-  [ "$out" = empty ] || fail "a current borderless Claude row should outrank stale bordered scrollback, got '$out'"
-  pass "fm_backend_cmux_composer_state: a borderless Claude row outranks stale bordered scrollback"
+  [ "$out" = unknown ] || fail "a lone '❯' overlap must defer even when it outranks stale bordered scrollback, got '$out'"
+  pass "fm_backend_cmux_composer_state: a lone '❯' overlap defers even after outranking stale bordered scrollback"
 }
 
 test_composer_state_borderless_claude_nbsp_prompt_is_empty() {
@@ -1143,8 +1143,8 @@ test_send_text_line_clears_partial_input_when_enter_fails
 test_send_text_line_reports_unsafe_input_when_cleanup_fails
 test_current_path_probes_with_marker
 test_composer_state_bare_prompt_is_empty
-test_composer_state_borderless_claude_prompt_is_empty
-test_composer_state_borderless_claude_prompt_outranks_stale_bordered_row
+test_composer_state_borderless_lone_glyph_overlap_defers
+test_composer_state_borderless_lone_glyph_overlap_outranks_stale_bordered_row
 test_composer_state_borderless_claude_nbsp_prompt_is_empty
 test_composer_state_borderless_claude_text_is_unknown_plain
 test_composer_state_ghost_placeholder_is_empty

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -155,11 +155,9 @@ test_send_text_submit_verifies_empty_composer_after_enter() {
   pass "fm_backend_orca_send_text_submit: verifies empty composer after Enter with one bounded read"
 }
 
-test_send_text_submit_borderless_claude_confirms() {
-  # The #2029 analogue this adapter never received: a borderless claude
-  # composer (bare `❯` row between horizontal rules) must confirm a submit.
-  # Before consolidation orca knew only the bordered shape, so every steer to
-  # a borderless harness exited unconfirmed and --resolve-key never closed.
+test_send_text_submit_borderless_lone_glyph_overlap_defers() {
+  # A lone `❯` row between horizontal rules is byte-identical to Pi's overlap
+  # shape; without an identity probe Orca defers rather than falsely confirming.
   local out
   orca_case send-submit-borderless
   printf '{"ok":true,"result":{"send":{"handle":"term-123","accepted":true}}}\n' > "$RESP/1.out"
@@ -167,8 +165,8 @@ test_send_text_submit_borderless_claude_confirms() {
   printf '{"ok":true,"result":{"terminal":{"tail":["────────────────","❯","────────────────"]}}}\n' > "$RESP/3.out"
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_send_text_submit term-123 "hello captain" 3 0.01 0.01' "$ROOT" )
-  [ "$out" = empty ] || fail "a borderless claude composer should confirm the submit, got '$out'"
-  pass "fm_backend_orca_send_text_submit: a borderless claude composer confirms delivery (the missing #2029 shape)"
+  [ "$out" = unknown ] || fail "a lone '❯' overlap must defer submit confirmation without identity, got '$out'"
+  pass "fm_backend_orca_send_text_submit: a lone '❯' overlap defers without identity"
 }
 
 test_composer_state_stale_banner_never_wins() {
@@ -1303,7 +1301,7 @@ test_capture_fails_on_orca_error_json
 test_runtime_check_accepts_ready_orca_status
 test_runtime_check_refuses_unready_orca_status
 test_send_text_submit_verifies_empty_composer_after_enter
-test_send_text_submit_borderless_claude_confirms
+test_send_text_submit_borderless_lone_glyph_overlap_defers
 test_composer_state_stale_banner_never_wins
 test_send_text_submit_retries_when_composer_stays_pending
 test_composer_state_popup_placeholder_fill_is_pending

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -249,8 +249,8 @@ test_matrix_pi_separated_needs_identity() {
   typed=$'────────────────────────\n❯\n────────────────────────'
   assert_screen "pi lone-glyph draft with identity" pending "$CAPS_STYLED" "$typed" '' "$pi_idle"
   assert_screen "pi lone-glyph draft on tmux" pending "$CAPS_TMUX" "$typed" 1 "$pi_idle"
-  assert_screen "lone glyph without identity capability" empty "$CAPS_STYLED_NOID" "$typed"
-  assert_screen "lone glyph on plain backend" empty "$CAPS_PLAIN" "$typed"
+  assert_screen "lone glyph without identity capability" unknown "$CAPS_STYLED_NOID" "$typed"
+  assert_screen "lone glyph on plain backend" unknown "$CAPS_PLAIN" "$typed"
   assert_screen "lone glyph with non-pi identity" empty "$CAPS_STYLED" "$typed" '' "$none"
   pass "matrix: pi's separated composer needs identity + structure; the blank row alone never proves it"
 }
@@ -417,8 +417,8 @@ test_cursorless_bare_wrap_region_classifies() {
 
   bounded=$'────────────────────────\n❯\n────────────────────────\nClaude 4.1'
   assert_screen "rule-bounded claude footer on herdr" empty "$CAPS_STYLED" "$bounded" '' probe-absent
-  assert_screen "rule-bounded claude footer on zellij" empty "$CAPS_STYLED_NOID" "$bounded"
-  assert_screen "rule-bounded claude footer on cmux/orca" empty "$CAPS_PLAIN" "$bounded"
+  assert_screen "rule-bounded lone glyph overlap on zellij" unknown "$CAPS_STYLED_NOID" "$bounded"
+  assert_screen "rule-bounded lone glyph overlap on cmux/orca" unknown "$CAPS_PLAIN" "$bounded"
 
   ghost=$'❯ '"${ESC}[2ma long rotating suggestion that${ESC}[0m"$'\n'"${ESC}[2mwraps onto the next line${ESC}[0m"
   out=$(fm_composer_classify_screen "$CAPS_STYLED" "$ghost")


### PR DESCRIPTION
## Supersedes

This PR **replaces and supersedes** https://github.com/kunchenguid/firstmate/pull/2066.
It carries the same composer thin-adapter refactor rebased onto current `main` (including merged #2065 recovery semantics) plus the captain-approved fix deferring lone Pi `❯` glyph overlap as `unknown` on identity-less backends.

**Validated content head:** `2714c51b3dc75380809e58e543b3733e02a88c29` (29-commit rebased branch history; local review/test/document/lint proof anchored here).
**Fork push head:** `51c20cbdf3142ad3d84e40444491d5033d5c4e85` on `camilojourney/firstmate:fm/fm-composer-thin-adapter-refactor-r2`.

Upstream maintainer review is requested. The `camilojourney` account cannot merge into `kunchenguid/firstmate`. Fork-origin PRs report zero upstream workflow runs until a maintainer approves or re-runs CI; the no-mistakes CI monitor was intentionally aborted after push/PR completion.

## Intent

Ship replacement PR for firstmate composer thin-adapter refactor from preserved head 2714c51 on branch fm/fm-composer-thin-adapter-refactor-r2. Push through no-mistakes fork flow to git@github.com:camilojourney/firstmate.git and open PR against kunchenguid/firstmate:main. The replacement PR must explicitly supersede https://github.com/kunchenguid/firstmate/pull/2066 and carry fresh final-head attestation. Preserve single shared composer classifier, thin adapter architecture, all rebased commits including merged #2065 recovery semantics, and captain-approved deferral of lone Pi glyph overlap as unknown on identity-less backends. Do not merge.

## What Changed

- Consolidated composer shape/state classification (bordered, bare, and separated shapes; empty/pending/unknown/pending-unproven verdicts) into a single shared classifier in `bin/fm-composer-lib.sh` (`fm_composer_classify_screen` and supporting helpers), which is now the sole owner of every glyph, border family, geometry rule, and verdict decision.
- Reworked the tmux, herdr, cmux, orca, and zellij backends into thin adapters that contribute only capture and capability facts (styled/cursor/identity/rows) to the shared classifier, removing herdr's duplicated shape-detection logic and zellij's content-diff submit heuristic (which could false-positive "delivered" on any pane change, including spinners or streaming output).
- Deferred lone Pi glyph overlap to an `unknown` verdict on identity-less backends instead of guessing, alongside fixes for cursorless stale composers, wrapped-paste continuations, and shell-prompt placeholder rows being misread as composer content.
- Added `tests/fm-composer-matrix-live-e2e.test.sh` and substantially expanded the backend and composer-lib test suites to cover the shared classifier and each adapter's capture/capability contract; updated architecture and per-backend docs to describe the new thin-adapter model.

## Risk Assessment

✅ Low: The final commit (defer lone Pi glyph overlap as unknown on identity-less backends) is small, well-scoped, and matches the captain-approved decision quoted in the intent: identity-less backends (cmux/orca/zellij, all identity=0) now defer a bare Pi-glyph-only row to unknown while Claude's real idle row still reads empty via its preserved U+00A0 suffix (verified via the unchanged nbsp test), and tmux/herdr identity-aware paths are untouched, consistent with docs and tests updated in the same commit; the larger preceding thin-adapter consolidation (edec3cc and subsequent review commits) is carried over from earlier iterative review and preserves the single shared classifier / thin-adapter architecture with the base commit itself being the merged #2065, satisfying the recovery-semantics preservation requirement.

## Testing

Targeted composer-classifier and cmux/orca/zellij adapter test suites pass at validated head `2714c51`, and reverting only `bin/fm-composer-lib.sh` to its pre-fix version reproduces the exact failure the fix addresses (lone Pi-glyph overlap misread as `empty` instead of deferring to `unknown`); a direct CLI invocation of the shared classifier function confirms the same before/after behavior outside the test harness.

<details>
<summary>Evidence: CLI transcript: fm_composer_classify_screen before vs. after the fix</summary>

```text
=== CLI reproduction: fm_composer_classify_screen on a lone Pi-glyph row, no backend identity ===
$ bash -c 'source bin/fm-composer-lib.sh; fm_composer_classify_screen "plain" $typed'
  (typed = a bare '❯' row bounded above/below by horizontal rules, no identity probe)

--- BEFORE (HEAD~1, pre-fix source) ---
classify_screen -> empty   (bug: falsely reads empty, would allow unsafe submit-confirmation on an identity-less backend)

--- AFTER (2714c51, target commit) ---
classify_screen -> unknown   (fix: defers as unknown; caller must wait for identity/structure before treating it as empty)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2714c51b3dc75380809e58e543b3733e02a88c29","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"completed"},{"step":"ci","status":"cancelled"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh tests/fm-composer-lib.test.sh tests/fm-backend-cmux.test.sh tests/fm-backend-orca.test.sh tests/fm-backend-zellij.test.sh` (all pass at validated head `2714c51`)
- Regression reproduction: temporarily restored `bin/fm-composer-lib.sh` to HEAD~1 (pre-fix) and reran the same test files; lone-glyph-overlap assertions fail (`got 'empty'`), confirming the tests exercise the fixed behavior; restored HEAD and reran green
- Manual CLI transcript: sourced `bin/fm-composer-lib.sh` and called `fm_composer_classify_screen` on a bare `❯` row between horizontal rules with no identity probe; pre-fix returns `empty`, validated head returns `unknown`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - approved with local ShellCheck absent</summary>

- ⚠️ `bin/fm-lint.sh` exit 127 locally (ShellCheck not installed in gate worktree); step approved. Upstream CI runs pinned ShellCheck via `.github/workflows/ci.yml`.

</details>

<details>
<summary>✅ **Push** - passed (fork)</summary>

✅ Pushed to `git@github.com:camilojourney/firstmate.git` branch `fm/fm-composer-thin-adapter-refactor-r2`.

</details>

<details>
<summary>✅ **PR** - passed</summary>

✅ Opened against `kunchenguid/firstmate:main`.

</details>

<details>
<summary>⏹ **CI** - intentionally aborted</summary>

No upstream workflow runs were created for this fork-origin PR (GitHub reports zero checks). The no-mistakes CI monitor was stopped with `no-mistakes axi abort` after push/PR completion so delivery does not block on unreachable upstream CI from the contributor account. Maintainer should run or approve upstream CI before merge.

</details>
