### PR TITLE
fix: restore Pi 0.83 worker launches

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -276,7 +276,7 @@ The follow-up was verified in the interactive TUI; `opencode run` can exit befor
 | Interrupt | single Escape |
 
 Pi has no permission system, so crewmates are always autonomous.
-Pi's `packages/coding-agent/docs/settings.md` UI and display section documents `regular` as the `tuiMode` default, `fullscreen` as experimental, and `--tui-mode` as its startup override; fullscreen can bury steers by rewriting scrollback, so `fm-spawn` always passes `--tui-mode regular` for Pi-family crews.
+Pi 0.83 removed the former `--tui-mode` startup option and its `tuiMode` setting, while remaining an interactive terminal application by default; `fm-spawn` therefore omits the obsolete option so Pi-family crews can start on current installations.
 `pi-signed` is the signed wrapper identity verified on version 0.82.0 and exposes the same CLI and TUI behavior as Pi.
 Firstmate launches the selected executable name from `PATH`, records `pi-signed` without normalization, and refuses rather than falling back to `pi` when that wrapper is unavailable.
 The observed signed process tree is an exact `pi-signed` wrapper parent with the Pi application as its child, while tmux reports the foreground command as the exact `pi-launcher` name for both selected executables.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1071,9 +1071,9 @@ launch_template() {
     opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     pi|pi-signed)
       if [ "$kind" = secondmate ]; then
-        printf '%s%s' "$harness" ' --tui-mode regular __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s%s' "$harness" ' __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       else
-        printf '%s%s' "$harness" ' --tui-mode regular __MODELFLAG____EFFORTFLAG__-e __PIEXT__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s%s' "$harness" ' __MODELFLAG____EFFORTFLAG__-e __PIEXT__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       fi
       ;;
     # grok (Grok Build TUI): a positional prompt starts the supervised interactive

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -213,7 +213,7 @@ New harnesses get verified through a supervised trial task before joining the se
 The verified adapter evidence - each harness's busy-state source, interrupt and exit behavior, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 The executable interrupt and exit mechanics live in [`bin/fm-control-lib.sh`](../bin/fm-control-lib.sh), and [`docs/agent-control.md`](agent-control.md) owns their lifecycle-control architecture.
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
-Pi and pi-signed crew launches explicitly pass `--tui-mode regular` so fullscreen mode cannot rewrite scrollback and bury steers.
+Pi and pi-signed launches use Pi's default interactive terminal mode; Pi 0.83 removed the former `--tui-mode` startup option, so passing that obsolete override prevents the worker from starting.
 Enabled primary-session turn-end guard integrations are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).
 Kimi remains outside the primary turn-end guard integrations; [`docs/turnend-guard.md`](turnend-guard.md#compatibility-limits) owns its separate captain-approved crew wake hook.
 Primary-session watcher wake protocols are rendered at session start by [`bin/fm-supervision-instructions.sh`](../bin/fm-supervision-instructions.sh) from [`docs/supervision-protocols/`](supervision-protocols/).

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -501,8 +501,10 @@ test_pi_threads_model_and_max_effort() {
   expect_code 0 "$status" "pi spawn with max effort should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" pi openai-codex/gpt-5.6-sol max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "FM_PI_HARNESS=pi pi --tui-mode regular --model 'openai-codex/gpt-5.6-sol' --thinking 'max' -e" \
-    "pi launch did not force the regular TUI while threading the requested model and max thinking level"
+  assert_contains "$launch" "FM_PI_HARNESS=pi pi --model 'openai-codex/gpt-5.6-sol' --thinking 'max' -e" \
+    "pi launch did not thread the requested model and max thinking level"
+  assert_not_contains "$launch" "--tui-mode" \
+    "pi launch passed the removed Pi 0.83 TUI mode option"
   assert_not_contains "$launch" "FM_FIRSTMATE_PI_LAUNCH_BRIEF=" \
     "pi launch still exports the removed Calm input-reroute binding"
   assert_contains "$launch" "fm-operational-input.sh' encode launch-brief" \
@@ -523,8 +525,10 @@ test_pi_signed_threads_shared_pi_profile_and_preserves_identity() {
   assert_contains "$out" "spawned $id harness=pi-signed" "pi-signed spawn did not preserve its visible identity"
   assert_meta_profile "$HOME_DIR/state/$id.meta" pi-signed openai-codex/gpt-5.6-sol max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "FM_PI_HARNESS=pi-signed pi-signed --tui-mode regular --model 'openai-codex/gpt-5.6-sol' --thinking 'max' -e" \
-    "pi-signed launch did not force the regular TUI with Pi's model, thinking, and extension semantics"
+  assert_contains "$launch" "FM_PI_HARNESS=pi-signed pi-signed --model 'openai-codex/gpt-5.6-sol' --thinking 'max' -e" \
+    "pi-signed launch did not retain Pi's model, thinking, and extension semantics"
+  assert_not_contains "$launch" "--tui-mode" \
+    "pi-signed launch passed the removed Pi 0.83 TUI mode option"
   assert_contains "$launch" "fm-operational-input.sh' encode launch-brief" \
     "pi-signed launch lost the canonical typed launch-brief envelope"
   assert_present "$HOME_DIR/state/$id.pi-ext.ts" "pi-signed launch did not install Pi's turn-end extension"
@@ -583,8 +587,10 @@ test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity() {
     "pi-signed secondmate spawn did not preserve its runtime identity"
   assert_meta_profile "$HOME_DIR/state/$id.meta" pi-signed default default
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "FM_PI_HARNESS=pi-signed pi-signed --tui-mode regular -e '$sm/.pi/extensions/fm-primary-turnend-guard.ts' -e '$sm/.pi/extensions/fm-primary-pi-watch.ts'" \
-    "pi-signed secondmate did not force the regular TUI with Pi's primary extension launch shape"
+  assert_contains "$launch" "FM_PI_HARNESS=pi-signed pi-signed -e '$sm/.pi/extensions/fm-primary-turnend-guard.ts' -e '$sm/.pi/extensions/fm-primary-pi-watch.ts'" \
+    "pi-signed secondmate lost Pi's primary extension launch shape"
+  assert_not_contains "$launch" "--tui-mode" \
+    "pi-signed secondmate passed the removed Pi 0.83 TUI mode option"
   pass "pi-signed is a distinct persistent secondmate runtime with shared Pi supervision semantics"
 }
 

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -189,23 +189,24 @@ SH
 
 # --- deterministic git identity and fixtures --------------------------------
 
-# fm_git_identity [name] [email]: export a fixed author/committer identity so
-# fixture commits never depend on the host git config.
+# fm_git_identity [name] [email]: export a fixed author/committer identity and
+# disable inherited signing so fixture commits never depend on host Git config.
 fm_git_identity() {
   export GIT_AUTHOR_NAME=${1:-fmtest} GIT_AUTHOR_EMAIL=${2:-fmtest@example.invalid}
   export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
+  export GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false
 }
 
 # fm_git_init_commit <dir>: create a git repo at <dir> with a README and one
-# commit. Uses an inline identity so it works whether or not fm_git_identity was
-# called.
+# commit. Uses an inline identity and disables inherited signing so it works
+# whether or not fm_git_identity was called and regardless of global Git config.
 fm_git_init_commit() {
   local dir=$1
   mkdir -p "$dir"
   git -C "$dir" init -q
   printf '# %s\n' "$(basename "$dir")" > "$dir/README.md"
   git -C "$dir" add README.md
-  git -C "$dir" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+  git -C "$dir" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' -c commit.gpgsign=false commit -qm initial
 }
 
 # fm_git_add_origin <repo> <bare>: clone <repo> bare into <bare> and register it


### PR DESCRIPTION
## Intent

Land the already-written fix preserved from origin commit 639a8a6827c51c285afa70fdce96b4f2cd2776ae for Pi 0.83.0 removing the obsolete --tui-mode option. Pi 0.83.0 rejects --tui-mode regular at argument parsing, while bin/fm-spawn.sh still passed it for every Pi-family launch, causing apparently successful dispatches whose workers never started or read their instructions. Remove the obsolete option from both Pi-family launch templates while preserving crew and scout model selection, thinking level, per-task turn-end extension, and typed instructions, and preserving secondmate model selection, thinking level, and both primary supervision extensions. Keep the harness skill and configuration documentation aligned with current Pi behavior, and retain the test fixture hardening that prevents inherited Git signing configuration from leaking into fixtures. The intended scope is exactly five files: .agents/skills/harness-adapters/SKILL.md, bin/fm-spawn.sh, docs/configuration.md, tests/fm-spawn-dispatch-profile.test.sh, and tests/lib.sh. Do not remove, weaken, bypass, or falsely claim the PR must be raised via no-mistakes CI requirement; the earlier direct PR was deliberately closed, and this firstmate repository change must ship through no-mistakes. Re-verify Pi 0.83.0 behavior and the requested spawn dispatch, relaunch, secondmate, lint, and documentation checks. If bin/fm-spawn.sh conflicts with other recent work, preserve and deliberately reconcile both sides. The PR description must state what changed, the verification personally rerun, and any evidence differences.

## What Changed

- Remove the obsolete `--tui-mode regular` argument from Pi-family crew, scout, and secondmate launches while preserving model, thinking, instruction, and supervision-extension arguments.
- Align spawn-profile coverage and Pi harness/configuration documentation with Pi 0.83’s default interactive terminal behavior.
- Harden Git test fixtures against inherited commit-signing configuration.

## Risk Assessment

✅ Low: Captain, the narrow five-file patch removes the obsolete option at the shared Pi launch boundary while preserving all required launch arguments, extensions, documentation, and fixture isolation.

## Testing

No separate baseline logs were supplied; fresh Pi 0.83 parser checks, focused spawn/relaunch/secondmate suites, documentation checks, captured launch commands, and hostile Git-signing fixtures all succeeded. The parser reproduction used the safer no-prompt stdin form instead of the earlier JSON prompt and produced the same exit-1 error. This CLI-only change is demonstrated with transcripts rather than screenshots; a real Pi worker was not started because it would write user-level Pi state outside the worktree. `bin/fm-lint.sh` was intentionally left to the outer lint phase because this assigned test phase forbids linters.

<details>
<summary>Evidence: Pi 0.83 parser transcript</summary>

<code>Pi 0.83.0 exits 1 with `Error: Unknown option: --tui-mode`; help retains model, thinking, and extension options.</code>

```text
$ pi --version
0.83.0

$ pi --tui-mode regular </dev/null
Error: Unknown option: --tui-mode
exit=1

$ pi --help  # retained launch axes
  --model <pattern>              Model pattern or ID (supports "provider/id" and optional ":<thinking>")
  --thinking <level>             Set thinking level: off, minimal, low, medium, high, xhigh, max
  --extension, -e <path>         Load an extension file (can be used multiple times)
```
</details>
<details>
<summary>Evidence: Pi-family spawn transcript</summary>

`Captured successful Pi crew/scout and pi-signed secondmate dispatch output, metadata, and literal terminal launch commands.`

```text
$ fm-spawn Pi crew
warning: /var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T//fm-spawn-dispatch-profile.paybDH/evidence-pi-crew/home/data/evidence-pi-crew/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
spawned evidence-pi-crew harness=pi kind=ship mode=no-mistakes yolo=off window=firstmate:fm-evidence-pi-crew worktree=/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T//fm-spawn-dispatch-profile.paybDH/evidence-pi-crew/wt
meta: harness=pi kind=ship model=openai-codex/gpt-5.6-sol effort=max 
launch: FM_PI_HARNESS=pi pi --model 'openai-codex/gpt-5.6-sol' --thinking 'max' -e '/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T//fm-spawn-dispatch-profile.paybDH/evidence-pi-crew/home/state/evidence-pi-crew.pi-ext.ts' "$('/Users/tiago/.no-mistakes/worktrees/bbb16e1f0808/01KZPWWFGRFETP9DAXSF1KSXK4/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T//fm-spawn-dispatch-profile.paybDH/evidence-pi-crew/home/data/evidence-pi-crew/brief.md')"

$ fm-spawn Pi scout
spawned evidence-pi-scout harness=pi kind=scout window=firstmate:fm-evidence-pi-scout worktree=/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T//fm-spawn-dispatch-profile.paybDH/evidence-pi-scout/wt
meta: harness=pi kind=scout model=openai-codex/gpt-5.6-sol effort=high 
launch: FM_PI_HARNESS=pi pi --model 'openai-codex/gpt-5.6-sol' --thinking 'high' -e '/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T//fm-spawn-dispatch-profile.paybDH/evidence-pi-scout/home/state/evidence-pi-scout.pi-ext.ts' "$('/Users/tiago/.no-mistakes/worktrees/bbb16e1f0808/01KZPWWFGRFETP9DAXSF1KSXK4/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T//fm-spawn-dispatch-profile.paybDH/evidence-pi-scout/home/data/evidence-pi-scout/brief.md')"

$ fm-spawn pi-signed secondmate (config: pi-signed openai-codex/gpt-5.6-sol max)
warning: secondmate evidence-pi-secondmate sync skipped before launch: primary default-branch commit cannot be resolved
spawned evidence-pi-secondmate harness=pi-signed kind=secondmate mode=secondmate yolo=off window=firstmate:fm-evidence-pi-secondmate worktree=/private/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/fm-spawn-dispatch-profile.paybDH/evidence-pi-secondmate/secondmate-home
meta: harness=pi-signed kind=secondmate model=openai-codex/gpt-5.6-sol effort=max 
launch: FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_PUBLIC_FOLLOWUP_PRIMARY_HOME='/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T//fm-spawn-dispatch-profile.paybDH/evidence-pi-secondmate/home' FM_HOME='/private/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/fm-spawn-dispatch-profile.paybDH/evidence-pi-secondmate/secondmate-home' FM_TRACE_CONTEXT=off FM_SUPERVISION_MODEL=persistent FM_PI_HARNESS=pi-signed pi-signed --model 'openai-codex/gpt-5.6-sol' --thinking 'max' -e '/private/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/fm-spawn-dispatch-profile.paybDH/evidence-pi-secondmate/secondmate-home/.pi/extensions/fm-primary-turnend-guard.ts' -e '/private/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/fm-spawn-dispatch-profile.paybDH/evidence-pi-secondmate/secondmate-home/.pi/extensions/fm-primary-pi-watch.ts' "$('/Users/tiago/.no-mistakes/worktrees/bbb16e1f0808/01KZPWWFGRFETP9DAXSF1KSXK4/bin/fm-operational-input.sh' encode launch-brief < '/private/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/fm-spawn-dispatch-profile.paybDH/evidence-pi-secondmate/secondmate-home/data/charter.md')"
```
</details>
<details>
<summary>Evidence: Git-signing fixture transcript</summary>

<code>Both fixture helpers committed successfully with inherited `commit.gpgsign=true`; the deliberately failing signer was never invoked.</code>

```text
$ inherited Git config
commit.gpgsign=true
gpg.program=/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T//fm-signing-evidence.EkoJwh/fail-signer

$ fm_git_identity + ordinary git commit
commit=674459f effective commit.gpgsign=false signer invoked=no

$ fm_git_init_commit (without fm_git_identity)
commit=3c3bace signer invoked=no
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pi --version`
- `pi --tui-mode regular </dev/null`
- `pi --help`
- `bash tests/fm-spawn-dispatch-profile.test.sh`
- `bash tests/fm-control-relaunch.test.sh`
- `bash tests/fm-secondmate-harness.test.sh`
- `bin/fm-doc-audience-check.sh`
- `bash tests/fm-documentation-audiences.test.sh`
- <code>Focused fake-terminal `fm-spawn` invocations for a model-pinned Pi crew, Pi scout, and `pi-signed` secondmate</code>
- <code>Focused commits through `fm_git_identity` and `fm_git_init_commit` with inherited `commit.gpgsign=true` and a failing signer</code>
- `git diff --name-only 9068958b3e4bd71d5efd4ff1e0d350269d1ecf00..HEAD`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
