### PR TITLE
fix(bin): correct keyed resolution form in briefs and promote operational learnings

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -234,6 +234,10 @@ Always enter through `bin/fm-afk-launch.sh`, which clears prior-session artifact
 Always exit through `bin/fm-afk-launch.sh stop`, which keeps `state/.afk` present through the daemon's shutdown flush and clears it last.
 `docs/herdr-backend.md` "Away-mode supervisor support" owns the current mechanism, and `docs/verification/runtime-backends.md` "Away-mode transport" owns active evidence.
 
+If `state/.afk` remains present after the daemon dies, away mode has suppressed the normal watcher without a daemon owning supervision.
+This has occurred when firstmate was not itself inside a tmux pane, as shown by an empty `$TMUX_PANE`, and when the harness background session hosting the daemon was terminated.
+Run `bin/fm-afk-launch.sh stop` to clear the stale lifecycle, or restart the away-mode daemon and verify that its process and lock are present before relying on away mode again.
+
 ## Reliability properties
 
 These properties must hold:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,16 +29,6 @@ GitHub Actions and Dependabot are exempt so their automation keeps working, but 
    Follow the installed no-mistakes version's SKILL.md and live `axi` help for gate mechanics.
 7. Once the pipeline passes, it pushes the branch to your fork and opens the PR against the parent repo for you.
 
-### Inspecting a no-mistakes run
-
-Run `(cd <crew-worktree> && no-mistakes axi status)` against the worktree whose run you are inspecting.
-`axi status` resolves by repository, so only one run can own a repository and a second concurrent task can finish without having driven the pipeline.
-A pipeline step that spawns its own agent flushes that step's log in one batch at step end, so sample the spawned process's CPU time before treating an unchanged step display as stuck.
-The Review block is a timeline rather than a current verdict, and `⚠️` means that the run had findings; read its `findings:` count and entries.
-A worker can commit and report `done:` without having driven the pipeline, so confirm that a PR exists before treating a ship task as finished.
-A broken pipe from a long blocking `axi respond` is a dropped connection, not proof that the run died.
-A run can die with the daemon while retaining custody of its commits, so follow the structured `branch_sync.next_action` and leave recovery to the worker that owns the branch.
-
 See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/start-here/quick-start/) for the full first-run walkthrough.
 
 ## Repo conventions
@@ -73,6 +63,9 @@ There is no reliable way for `bin/fm-brief.sh`'s scaffold to detect that a task'
 A crewmate picking up such a brief should load the skill even if the brief predates this instruction.
 When supervising live crewmates, keep firstmate's own long validation or build commands in the background so watcher wakes can still be handled.
 Crewmate validation follows the installed no-mistakes version's SKILL.md and live `axi` help instead of duplicating gate mechanics in firstmate docs.
+Two supervision invariants stay here because they are firstmate's, not the gate's.
+A gate run is owned per repository, so inspect a crew run from that crew's own worktree, and a second concurrent task in the same repository can commit and report `done:` without ever having driven the pipeline; `AGENTS.md` owns how a ship task's real ready signal is judged and who owns run custody and recovery.
+A pipeline step that spawns its own agent flushes that step's log in one batch when the step ends, so silence during a step is expected rather than a stall; inspect the spawned process itself before treating a run as stuck.
 Firstmate's wrapper still matters: crewmates route every `ask-user` finding to firstmate, which applies the authority contract in `AGENTS.md`, and crewmates avoid `--yes` because it would bypass that check and any required captain escalation.
 Local `.no-mistakes/` state and test evidence stay out of this repo; `.no-mistakes.yaml` keeps evidence in a temp directory and pins the gate's lint command to `bin/fm-lint.sh`, matching the Linux CI lint job.
 Local no-mistakes Test is intent-targeted and must not re-run every `tests/*.test.sh`; `.github/workflows/ci.yml` owns the broad behavior suite plus platform-specific compatibility lanes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,16 @@ GitHub Actions and Dependabot are exempt so their automation keeps working, but 
    Follow the installed no-mistakes version's SKILL.md and live `axi` help for gate mechanics.
 7. Once the pipeline passes, it pushes the branch to your fork and opens the PR against the parent repo for you.
 
+### Inspecting a no-mistakes run
+
+Run `(cd <crew-worktree> && no-mistakes axi status)` against the worktree whose run you are inspecting.
+`axi status` resolves by repository, so only one run can own a repository and a second concurrent task can finish without having driven the pipeline.
+A pipeline step that spawns its own agent flushes that step's log in one batch at step end, so sample the spawned process's CPU time before treating an unchanged step display as stuck.
+The Review block is a timeline rather than a current verdict, and `⚠️` means that the run had findings; read its `findings:` count and entries.
+A worker can commit and report `done:` without having driven the pipeline, so confirm that a PR exists before treating a ship task as finished.
+A broken pipe from a long blocking `axi respond` is a dropped connection, not proof that the run died.
+A run can die with the daemon while retaining custody of its commits, so follow the structured `branch_sync.next_action` and leave recovery to the worker that owns the branch.
+
 See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/start-here/quick-start/) for the full first-run walkthrough.
 
 ## Repo conventions
@@ -67,6 +77,10 @@ Firstmate's wrapper still matters: crewmates route every `ask-user` finding to f
 Local `.no-mistakes/` state and test evidence stay out of this repo; `.no-mistakes.yaml` keeps evidence in a temp directory and pins the gate's lint command to `bin/fm-lint.sh`, matching the Linux CI lint job.
 Local no-mistakes Test is intent-targeted and must not re-run every `tests/*.test.sh`; `.github/workflows/ci.yml` owns the broad behavior suite plus platform-specific compatibility lanes.
 That is firstmate-specific; do not commit `.no-mistakes/evidence/` here even when another no-mistakes-managed target project keeps committed PR evidence.
+
+Treehouse worktree pools hand out the first available slot, so a respawn can land in a different slot while the original branch remains checked out in the old one.
+`treehouse return` resets tracked content but keeps the branch ref and untracked files.
+A teardown refusal about leaked worktree processes often clears on a plain retry after those processes exit.
 
 Check and test the toolbelt before pushing:
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -246,7 +246,7 @@ When a routed-work phase has a supervisor-actionable material change worth repor
 If its first reportable event is \`working [key=<work-slug>]: {material phase}\`, use the same key on its later \`$PAUSED_VERB\`, \`done\`, \`failed\`, \`needs-decision\`, or \`blocked\` event so the earlier working phase is superseded.
 When a keyed phase ends without another reportable state, append \`resolved [key=<work-slug>]: {why it is no longer active}\`.
 \`resolved\` separately closes an escalated decision or blocker, and only a \`resolved\` line carrying that decision's exact key closes it: a later \`done\` or \`working\` event never does, even when the answer is what started that work.
-The main firstmate's answer normally writes that closing line at answer time; when a blocker or wait clears WITHOUT an answer from the main firstmate, append \`resolved: {how it cleared}\` yourself (keyed with \`[key=<slug>]\` if you opened it with one) as your domain resumes.
+The main firstmate's answer normally writes that closing line at answer time; when a blocker or wait clears WITHOUT an answer from the main firstmate, append \`resolved [key=<slug>]: {how it cleared}\` when you opened it keyed, or bare \`resolved: {how it cleared}\` for the default key, as your domain resumes.
 Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.
 
 # Definition of done
@@ -331,7 +331,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 6. If a decision belongs to a human (product choices, destructive actions),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
-   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
+   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved [key=<slug>]: {how it cleared}\` when you opened it keyed, or bare \`resolved: {how it cleared}\` for the default key, as you resume.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
@@ -447,7 +447,7 @@ $RULE1
 6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
-   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
+   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved [key=<slug>]: {how it cleared}\` when you opened it keyed, or bare \`resolved: {how it cleared}\` for the default key, as you resume.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -167,6 +167,8 @@ status_is_paused_or_captain_held() {  # <status-line>
 # one-open-decision-per-task behavior (a bare "resolved:" closes "default").
 # The three parsers are pure reads of a single line; the verb parser strips any
 # key token before the colon so the leading word is recovered cleanly.
+# To inspect the recorded open keys, source this file and run
+# `status_open_decisions state/<id>.status | cut -f1 | sort -u`.
 status_line_verb() {  # <status-line> -> leading verb word
   local v=${1%%:*}
   v=${v%%\[key=*}

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -5,7 +5,7 @@ Firstmate talks to a running agent two ways, and they are not the same channel.
 The **data plane** is [`bin/fm-send.sh`](../bin/fm-send.sh): conversational text for the agent to read.
 For a `kind=secondmate` target it always prepends the from-firstmate routing marker, because a secondmate is itself a firstmate and its reply must come back through the status path rather than a chat nobody reads.
 An unconfirmed `pending` verdict can still mean that the message landed while the target was mid-turn, so capture the target before deciding what to do and never resend the same steer.
-Use an explicit `FM_HOME=<home>` when invoking `fm-send.sh`; without it the command fails closed rather than risking delivery through another home.
+Invoke `fm-send.sh` with an explicit `FM_HOME=<home>`; [`configuration.md`](configuration.md) "FM_HOME" owns that fail-closed requirement.
 If `--resolve-key` refuses, treat that as a keyed-decision contract failure rather than a typo in the answer.
 The valid close form is `resolved [key=<slug>]:`, with the recorded key between the status verb and its colon, and `resolved: [key=<slug>]` does not close the record.
 The classifier's `status_open_decisions` read returns the durable keys currently open for that status file.

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -4,6 +4,11 @@ Firstmate talks to a running agent two ways, and they are not the same channel.
 
 The **data plane** is [`bin/fm-send.sh`](../bin/fm-send.sh): conversational text for the agent to read.
 For a `kind=secondmate` target it always prepends the from-firstmate routing marker, because a secondmate is itself a firstmate and its reply must come back through the status path rather than a chat nobody reads.
+An unconfirmed `pending` verdict can still mean that the message landed while the target was mid-turn, so capture the target before deciding what to do and never resend the same steer.
+Use an explicit `FM_HOME=<home>` when invoking `fm-send.sh`; without it the command fails closed rather than risking delivery through another home.
+If `--resolve-key` refuses, treat that as a keyed-decision contract failure rather than a typo in the answer.
+The valid close form is `resolved [key=<slug>]:`, with the recorded key between the status verb and its colon, and `resolved: [key=<slug>]` does not close the record.
+The classifier's `status_open_decisions` read returns the durable keys currently open for that status file.
 
 The **control plane** is [`bin/fm-control.sh`](../bin/fm-control.sh): allowlisted lifecycle verbs addressed to an exact task id.
 

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -19,6 +19,7 @@ It accepts `--none` as an explicit semantic inventory result, not as inferred ab
 It verifies every listed identity against tasks-axi before recording completion.
 For an open keyed status decision, it appends a `captain-held [key=<key>]: ...` transfer event only after the matching backlog hold is durable.
 `bin/fm-classify-lib.sh` recognizes that transfer as closing the live status copy without claiming that the captain has answered it.
+An open `blocked:` or `needs-decision:` record remains open through later `paused:`, `working:`, or `done:` events until a matching keyed `resolved` or `captain-held` event closes it.
 
 Scout teardown calls the script's read-only `verify` subcommand after checking for the report and before removing any source state.
 The `--force` path remains the explicit captain-approved discard escape hatch.

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -84,6 +84,7 @@ It types a message once and retries Enter only until the composer clears.
 Only a proven empty composer is a positive delivery acknowledgement.
 Text left in established structure remains `pending`, text in ambiguous structure remains unproven, and unreadable or unsafe state remains unknown.
 `fm-send.sh` reports every unconfirmed verdict as a failure instead of retyping or assuming delivery.
+The data-plane ambiguity and no-resend rule are described in [`agent-control.md`](agent-control.md).
 
 OpenCode 1.18.4 has one busy-queue exception.
 While OpenCode is mid-turn, Enter queues the message but leaves its text visible until the turn completes.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -75,6 +75,14 @@ The alarm cannot repeat during that failure episode, and a later unhealthy stop 
 A positively verified healthy watcher clears the failure notice, alarm, and block budget for a future independent episode.
 A Claude failure notice describes the automatic mechanism as broken and does not direct a routine manual background arm.
 
+### Diagnosing a suppressed auto-arm
+
+The Claude Stop auto-arm can record `outcome=failed-suppressed`, which means the home has no verified watcher while live work still needs supervision.
+The tell is an empty `Stop hook feedback` message.
+Read `state/.claude-autoarm-epoch`, `state/.last-watcher-beat`, and `state/.watch.lock` instead of trusting the notice or a process-name match.
+A beacon older than 300 seconds means the watcher is stale, an absent lock means no watcher owns the home, and an `fm-watch` process from another home is not evidence for this one.
+Do not hand-arm the watcher on your own initiative; the bounded Stop-owned recovery path may recover on its next cycle.
+
 OpenCode, Pi, and pi-signed expose passive callbacks for this purpose.
 Their adapters fail open at the hook boundary to protect the user session but schedule one bounded follow-up when the predicate blocks.
 The generated prompts use the canonical `turn-end-guard` kind after the U+2063 `FIRSTMATE_OP: ` prefix, so Ahoy does not treat them as captain messages.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -80,7 +80,7 @@ A Claude failure notice describes the automatic mechanism as broken and does not
 The Claude Stop auto-arm can record `outcome=failed-suppressed`, which means the home has no verified watcher while live work still needs supervision.
 The tell is an empty `Stop hook feedback` message.
 Read `state/.claude-autoarm-epoch`, `state/.last-watcher-beat`, and `state/.watch.lock` instead of trusting the notice or a process-name match.
-A beacon older than 300 seconds means the watcher is stale, an absent lock means no watcher owns the home, and an `fm-watch` process from another home is not evidence for this one.
+A beacon older than the `FM_GUARD_GRACE` freshness window above means the watcher is stale, an absent lock means no watcher owns the home, and an `fm-watch` process from another home is not evidence for this one.
 Do not hand-arm the watcher on your own initiative; the bounded Stop-owned recovery path may recover on its next cycle.
 
 OpenCode, Pi, and pi-signed expose passive callbacks for this purpose.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -667,7 +667,7 @@ test_pause_verb_override_renders_all_brief_scaffolds() {
       "$kind brief did not require durable resolution when a blocker clears"
     assert_grep 'resolved [key=<slug>]: {how it cleared}' "$brief" \
       "$kind brief did not put a keyed resolution token before the colon"
-    assert_no_grep 'resolved: {how it cleared}.*key=<slug>' "$brief" \
+    assert_no_grep_re 'resolved:.*\[key=' "$brief" \
       "$kind brief still taught the keyed resolution token after the colon"
     assert_grep 'even when the answer is what started that work' "$brief" \
       "$kind brief did not warn that an answer-started done/working never closes a decision"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -665,6 +665,10 @@ test_pause_verb_override_renders_all_brief_scaffolds() {
       "$kind brief still instructs the default paused status"
     assert_grep 'a blocker or wait clears' "$brief" \
       "$kind brief did not require durable resolution when a blocker clears"
+    assert_grep 'resolved [key=<slug>]: {how it cleared}' "$brief" \
+      "$kind brief did not put a keyed resolution token before the colon"
+    assert_no_grep 'resolved: {how it cleared}.*key=<slug>' "$brief" \
+      "$kind brief still taught the keyed resolution token after the colon"
     assert_grep 'even when the answer is what started that work' "$brief" \
       "$kind brief did not warn that an answer-started done/working never closes a decision"
   done

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -294,6 +294,12 @@ assert_no_grep() {
   ! grep -F -- "$1" "$2" >/dev/null || fail "$3"
 }
 
+# assert_no_grep_re <ere> <file> <msg>: extended-regex grep must NOT match.
+# Use this, not assert_no_grep, when the guard needs regex metacharacters.
+assert_no_grep_re() {
+  ! grep -E -- "$1" "$2" >/dev/null || fail "$3"
+}
+
 # assert_absent <path> <msg>: path must not exist.
 assert_absent() {
   [ ! -e "$1" ] || fail "$2"


### PR DESCRIPTION
## Intent

Promote six Firstmate-specific operational learnings from the local learnings file into the correct tracked Firstmate owners in one PR, preserving every operative safety fact and avoiding a dumping-ground document. Fix the brief scaffold defect so keyed resolution is written as resolved [key=slug]: with the key before the colon, teach how to read open recorded keys, and add regression coverage. Preserve and document that fm-send can report pending delivery unconfirmed after a mid-turn message has landed, so the sender must capture before deciding and never resend, and that fm-send fails closed unless FM_HOME is explicit. Document the away-mode stale-daemon supervision gap and both observed routes, the Claude Stop auto-arm failed-suppressed diagnostics and its three state files, the Treehouse pool first-available and return semantics, and the no-mistakes axi status one-run-per-repository, batch-flushed step log, and Review timeline behavior. Do not edit data/learnings.md in this branch because the supervisor owns deleting the six promoted sections after this promotion lands; state that action and the projected post-deletion startup-memory total of 6817 tokens in the PR. Do not touch captain preferences, use one sentence per tracked Markdown line, plain dashes, and no agent co-author.

## What Changed

- `bin/fm-brief.sh` now teaches the closing form as `resolved [key=<slug>]: {how it cleared}` with the key before the colon across all three scaffolds (ship, scout, secondmate), and reserves bare `resolved:` for the default key; previously the scaffolds taught a form that `bin/fm-classify-lib.sh` does not accept as closing a keyed decision. `tests/fm-brief.test.sh` gains a positive and a negative guard over every scaffold, backed by a new `assert_no_grep_re` regex helper in `tests/lib.sh` (the plain `assert_no_grep` used `grep -F`, so the negative guard could not fail); `bin/fm-classify-lib.sh` documents the `status_open_decisions ... | cut -f1 | sort -u` recipe for reading currently open keys.
- Six operational learnings moved into their tracked owners: `docs/agent-control.md` records that an unconfirmed `pending` verdict can still mean the message landed mid-turn (capture before deciding, never resend), that `fm-send.sh` requires an explicit `FM_HOME`, and what a `--resolve-key` refusal means, with `docs/tmux-backend.md` cross-linking the no-resend rule; `.agents/skills/afk/SKILL.md` documents the stale-`state/.afk` supervision gap and both observed routes into it; `docs/turnend-guard.md` adds a suppressed-auto-arm section naming `state/.claude-autoarm-epoch`, `state/.last-watcher-beat`, and `state/.watch.lock`; `docs/decision-hold-lifecycle.md` states that an open `blocked:`/`needs-decision:` record survives later `paused:`/`working:`/`done:` events.
- `CONTRIBUTING.md` keeps the two firstmate-owned supervision invariants (per-repository run custody, batch-flushed step logs so silence during a step is expected) and the Treehouse pool first-available/return semantics, and points gate-version-specific mechanics at the installed no-mistakes `SKILL.md` and live `axi` help rather than restating them; the Review timeline rendering was deliberately left out for that reason, and the Document step flagged that as a conscious deviation from the literal intent.

Follow-up owned by the supervisor, not this branch: `data/learnings.md` is intentionally untouched here, and the supervisor deletes the six promoted sections once this lands. Projected startup-memory total after that deletion is 6817 tokens.

## Risk Assessment

✅ Low: The branch is documentation plus generated-brief prose with no runtime behavior change, and the one substantive round-1 defect is now fixed by an additive regex test helper whose guard was statically verified to match the defect form and no correct scaffold line.

## Testing

Exercised the change through six targeted suites (73 checks, all passing) plus manual end-to-end verification of the documented contract. The core behavior change is the brief scaffold keyed-resolution fix, so I rendered the actual brief.md a worker agent reads from both the base and target commits and captured the before/after for all three scaffolds, then proved the new regression guard is real by reverting only bin/fm-brief.sh and watching the assertion fail. I separately confirmed the review commit's assert_no_grep_re swap was necessary, since the fixed-string variant matched nothing against the defective brief and would have passed vacuously. I ran the documented status_open_decisions recipe against a real status file to show that `resolved: [key=...]` leaves a decision open while `resolved [key=...]:` closes it, and verified every state file, outcome string, and threshold named by the new documentation resolves to live code. I could not hand-run bin/fm-send.sh because the repo's gate guard correctly refuses to let a gate agent drive the fleet, so those paths were exercised through the sanctioned test harness instead. The change is documentation plus one prose-generation fix with no rendered UI surface, so there is no screenshot; the equivalent end-user artifact is the generated brief.md text, which I captured directly. No failures, no flakiness, and the worktree is clean with all temporary render directories removed.

<details>
<summary>Evidence: Rendered brief.md before/after: the keyed-resolution line an agent actually reads (all three scaffolds)</summary>

<code>====== ship brief ======&#10;--- BEFORE (base 9068958) - what the worker agent read ---&#10;42: ...append `resolved: {how it cleared}` yourself (same `[key=&lt;slug&gt;]` if you opened it with one) as you resume.&#10;--- AFTER (target 1cceba5) ---&#10;42: ...append `resolved [key=&lt;slug&gt;]: {how it cleared}` when you opened it keyed, or bare `resolved: {how it cleared}` for the default key, as you resume.&#10;&#10;====== scout brief ======&#10;--- BEFORE (base 9068958) ---&#10;35: ...append `resolved: {how it cleared}` yourself (same `[key=&lt;slug&gt;]` if you opened it with one) as you resume.&#10;--- AFTER (target 1cceba5) ---&#10;35: ...append `resolved [key=&lt;slug&gt;]: {how it cleared}` when you opened it keyed, or bare `resolved: {how it cleared}` for the default key, as you resume.&#10;&#10;====== mate brief ======&#10;--- BEFORE (base 9068958) ---&#10;47:...append `resolved: {how it cleared}` yourself (keyed with `[key=&lt;slug&gt;]` if you opened it with one) as your domain resumes.&#10;--- AFTER (target 1cceba5) ---&#10;47:...append `resolved [key=&lt;slug&gt;]: {how it cleared}` when you opened it keyed, or bare `resolved: {how it cleared}` for the default key, as your domain resumes.</code>

```text
==================== ship brief ====================
--- BEFORE (base 9068958) — what the worker agent read ---
  42:   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
--- AFTER (target 1cceba5) ---
  42:   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved [key=<slug>]: {how it cleared}` when you opened it keyed, or bare `resolved: {how it cleared}` for the default key, as you resume.

==================== scout brief ====================
--- BEFORE (base 9068958) — what the worker agent read ---
  35:   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
--- AFTER (target 1cceba5) ---
  35:   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved [key=<slug>]: {how it cleared}` when you opened it keyed, or bare `resolved: {how it cleared}` for the default key, as you resume.

==================== mate brief ====================
--- BEFORE (base 9068958) — what the worker agent read ---
  47:The main firstmate's answer normally writes that closing line at answer time; when a blocker or wait clears WITHOUT an answer from the main firstmate, append `resolved: {how it cleared}` yourself (keyed with `[key=<slug>]` if you opened it with one) as your domain resumes.
--- AFTER (target 1cceba5) ---
  47:The main firstmate's answer normally writes that closing line at answer time; when a blocker or wait clears WITHOUT an answer from the main firstmate, append `resolved [key=<slug>]: {how it cleared}` when you opened it keyed, or bare `resolved: {how it cleared}` for the default key, as your domain resumes.
```
</details>
<details>
<summary>Evidence: End-to-end keyed-resolution contract: the wrong close form leaves the decision open, the new form closes it</summary>

<code>### 1. Documented recipe from bin/fm-classify-lib.sh: read the open recorded keys&#10;$ status_open_decisions state/ship-api.status | cut -f1 | sort -u&#10;api-shape&#10;&#10;--- the decision survived later working/paused/done events (docs/decision-hold-lifecycle.md) ---&#10;$ status_open_decisions state/ship-api.status&#10;api-shape needs-decision flat list or nested by competition&#10;&#10;### 2. WRONG close form taught as invalid in docs/agent-control.md&#10;$ echo &#39;resolved: [key=api-shape] nested by competition&#39; &gt;&gt; state/ship-api.status&#10;$ status_open_decisions state/ship-api.status | cut -f1 | sort -u&#10;api-shape&#10;=&gt; api-shape is STILL OPEN: &#39;resolved: [key=...]&#39; does not close the record.&#10;&#10;### 3. CORRECT close form the brief scaffold now teaches&#10;$ echo &#39;resolved [key=api-shape]: nested by competition&#39; &gt;&gt; state/ship-api.status&#10;$ status_open_decisions state/ship-api.status | cut -f1 | sort -u&#10;(no open decisions)&#10;=&gt; api-shape CLOSED by the key-before-colon form.</code>

```text
### 1. Documented recipe from bin/fm-classify-lib.sh: read the open recorded keys
$ status_open_decisions state/ship-api.status | cut -f1 | sort -u
api-shape

--- the decision survived later working/paused/done events (docs/decision-hold-lifecycle.md) ---
$ status_open_decisions state/ship-api.status
api-shape	needs-decision	flat list or nested by competition
### 2. WRONG close form taught as invalid in docs/agent-control.md
$ echo 'resolved: [key=api-shape] nested by competition' >> state/ship-api.status
$ status_open_decisions state/ship-api.status | cut -f1 | sort -u
api-shape
=> api-shape is STILL OPEN: 'resolved: [key=...]' does not close the record.

### 3. CORRECT close form the brief scaffold now teaches
$ echo 'resolved [key=api-shape]: nested by competition' >> state/ship-api.status
$ status_open_decisions state/ship-api.status | cut -f1 | sort -u
(no open decisions)
=> api-shape CLOSED by the key-before-colon form.
```
</details>
<details>
<summary>Evidence: Red-check: the new guard fails against the pre-fix scaffold</summary>

```text
$ git checkout 9068958 -- bin/fm-brief.sh # revert fix only, keep target tests
$ bash tests/fm-brief.test.sh
ok - fm-brief.sh: relative directory inputs ignore CDPATH, render stable absolute charter paths, or fail loudly
not ok - ship brief did not put a keyed resolution token before the colon

$ git checkout 1cceba5 -- bin/fm-brief.sh # restored; worktree clean
```
</details>
<details>
<summary>Evidence: Why the review commit&#39;s assert_no_grep_re fix was required (the fixed-string guard was vacuous)</summary>

<code>Guard pattern: resolved:.*\[key=&#10;&#10;--- against the BEFORE brief (defect present; guard MUST fire) ---&#10;grep -F (assert_no_grep) : no match -&gt; guard is VACUOUS, defect slips through&#10;grep -E (assert_no_grep_re) : MATCH -&gt; guard fires correctly&#10;&#10;--- against the AFTER brief (defect fixed; guard must stay silent) ---&#10;grep -E (assert_no_grep_re) : no match -&gt; passes correctly</code>

```text
Why the review commit swapped assert_no_grep -> assert_no_grep_re
Guard pattern: resolved:.*\[key=

--- against the BEFORE brief (defect present; guard MUST fire) ---
grep -F (assert_no_grep)    : no match -> guard is VACUOUS, defect slips through
grep -E (assert_no_grep_re) : MATCH -> guard fires correctly

--- against the AFTER brief (defect fixed; guard must stay silent) ---
grep -E (assert_no_grep_re) : no match -> passes correctly
```
</details>
<details>
<summary>Evidence: Targeted test run across the six owning suites</summary>

<code>### bash tests/fm-brief.test.sh =&gt; PASS (20 checks)&#10;### bash tests/fm-documentation-audiences.test.sh =&gt; PASS (4 checks)&#10;### bash tests/fm-decision-hold-lifecycle.test.sh =&gt; PASS (9 checks)&#10;### bash tests/fm-send-resolve-key.test.sh =&gt; PASS (10 checks)&#10;### bash tests/fm-send-strict.test.sh =&gt; PASS (8 checks)&#10;### bash tests/fm-claude-stop-autoarm.test.sh =&gt; PASS (22 checks)</code>

```text
### bash tests/fm-brief.test.sh
  ok - fm-brief.sh: bash -n succeeds
  ok - fm-brief.sh: no heredoc is nested inside a command substitution (Bash 3.2 parse-safe)
  ok - fm-brief.sh: --help renders the complete header
  ok - fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly
  ok - fm-brief.sh: ship --mode is required and closed-set validated
  ok - fm-brief.sh: the explicit ship mode wins over the registered posture
  ok - fm-brief.sh: --yolo and scout/secondmate --mode are refused, never silently dropped
  ok - fm-brief.sh: faster paths use configured authority without stacked review
  ok - fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe
  ok - fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar
  ok - fm-brief.sh: --herdr-lab emits the complete hard safety contract
  ok - fm-brief.sh: --herdr-lab uses its quoted Firstmate-owned helper path
  ok - fm-brief.sh: ship and scout scaffolds make omitted Herdr intent fail-visible
  ok - fm-brief.sh: Herdr lab contract covers scouts and rejects secondmate misuse
  ok - fm-brief.sh: --no-projects scaffolds a project-less charter and guards misuse
  ok - fm-brief.sh: marked requests avoid generic acknowledgements and preserve material reporting
  ok - fm-brief.sh: relative directory inputs ignore CDPATH, render stable absolute charter paths, or fail loudly
  ok - fm-brief.sh: custom pause verb renders in every scaffold
  ok - fm-brief.sh: investigation and visual-review completions load the shared decision policy
  ok - fm-brief: scout and secondmate code paths still scaffold well-formed briefs
  => PASS (20 checks)

### bash tests/fm-documentation-audiences.test.sh
  ok - documentation inventory classifies every maintained prose surface exactly once
  ok - classification, setup routing, and maintained-prose scope fail safely
  ok - required documentation owner pointers cannot silently disappear
  ok - local links resolve while dates, versions, commands, and incident prose remain semantically reviewed
  => PASS (4 checks)

### bash tests/fm-decision-hold-lifecycle.test.sh
  ok - report-only unresolved decision is reproduced and completion refuses before loss
  ok - non-forced scout teardown always requires durable inventory verification
  ok - captain holds are idempotent, distinct, teardown-safe, Bearings-visible, and durably routed before close
  ok - completion and verification validate origins before constructing paths
  ok - ended visual review follows the same decision-hold completion owner
  ok - resolved findings and decision-like prose do not create false holds
  ok - terminal single-owner stale status decisions do not block empty inventory
  ok - main-home and secondmate-home captain holds remain correctly routed
  ok - resolve matches first/middle/last in quoted blocked_by and rejects a genuinely absent id
  => PASS (9 checks)

### bash tests/fm-send-resolve-key.test.sh
  ok - fm-send --resolve-key: the answer send itself closes the open decision
  ok - fm-send --resolve-key: an answer that starts a workstream leaves no orphaned decision
  ok - fm-send: a send without --resolve-key never closes a decision, and working/done still cannot
  ok - fm-send --resolve-key: a key that is not open refuses loudly before anything is sent
  ok - fm-send --resolve-key: a failed send never closes the decision
  ok - fm-send --resolve-key: one answer closes each named key and only those
  ok - fm-send --resolve-key: a marked local-secondmate answer closes with the plain answer text
  ok - fm-send --resolve-key: a remote-secondmate answer closes the same local ledger, transport-only difference
  ok - fm-send --resolve-key: a failed remote transport never closes the decision
  ok - fm-send --resolve-key: --key, empty message, explicit targets, and malformed keys refuse loudly
  => PASS (10 checks)

### bash tests/fm-send-strict.test.sh
  ok - fm-send strict: exact task/lane ids resolve through home metadata
  ok - fm-send --key: exit status follows delivery, and an undelivered key never reports success
  ok - fm-send strict: unset FM_HOME fails before target resolution
  ok - fm-send strict: unresolvable selectors do not fall back to tmux
  ok - fm-send strict: prefixless herdr pane ids are rejected before tmux fallback
  ok - fm-send strict: unmatched single-colon explicit targets must verify live before sending
  ok - fm-send strict: fm-prefixed Herdr sessions remain explicit backend targets
  ok - fm-send strict: healthy fm-<id> sends still type once and submit
  => PASS (8 checks)

### bash tests/fm-claude-stop-autoarm.test.sh
  ok - auto-arm: inert in a linked child worktree even when in-flight
  ok - auto-arm: inert with no session lock
  ok - auto-arm: a demonstrably dead recorded session owner is reclaimed through fm-lock.sh before arming
  ok - auto-arm: inert without arm, rewake, or lock replacement when another live harness owns the home
  ok - auto-arm: inert while AFK owns supervision
  ok - auto-arm: stale-owner recovery leaves the AFK and supervision-need gates unchanged
  ok - auto-arm: resolves the outermost pid of a nested contiguous claude ancestry (bg-spare chain)
  ok - auto-arm: inert with nothing in flight and no X-mode need
  ok - auto-arm: actionable close translates to exactly one exit-2 rewake with reason
  ok - auto-arm: actionable close survives a healthy successor without duplicate delivery
  ok - auto-arm: bounded failure verification emits one automatic-mechanism alarm
  ok - auto-arm: consecutive failures keep Stop-owned retry without repeating notice
  ok - auto-arm: unverified clean close exhausts retries and fails closed
  ok - auto-arm: post-alarm actionable outcomes cannot continue or reset failure state
  ok - auto-arm: benign cycle end with a live watcher and fresh beacon stays silent across the next cycle
  ok - auto-arm: budget contention preserves the episode and forces a reset retry
  ok - auto-arm: X-mode poll need arms the cycle even with no tasks in flight
  ok - auto-arm: concurrent firings admit one owner and one rewake translation
  ok - auto-arm: need vanishing mid-cycle closes without a rewake
  ok - auto-arm: mid-cycle AFK hands triage to the daemon with no rewake
  ok - auto-arm: active in a marked secondmate home
  ok - fm-lock: shared session-lock lib preserves the status path
  => PASS (22 checks)
```
</details>
<details>
<summary>Evidence: fm-send documented facts: gate guard refusal and the key-before-colon form fm-send writes</summary>

<code>$ env -u FM_HOME bin/fm-send.sh some-task &#39;steer the worker&#39;&#10;error: no-mistakes gate agent must not drive the fleet (NO_MISTAKES_GATE set)&#10;exit=3&#10;(gate guard correctly blocks direct invocation; FM_HOME fail-closed is instead&#10;covered by tests/fm-send-strict.test.sh &#34;unset FM_HOME fails before target&#10;resolution&#34;, which also asserts no send was attempted)&#10;&#10;### the valid close form fm-send itself writes&#10;bin/fm-send.sh:385: line=&#34;resolved [key=$k]: answered: $note&#34;&#10;=&gt; key sits between the verb and the colon, matching the corrected brief scaffold.</code>

```text
### docs/agent-control.md: "Use an explicit FM_HOME=<home> ... without it the command fails closed"
$ env -u FM_HOME bin/fm-send.sh some-task 'steer the worker'
error: no-mistakes gate agent must not drive the fleet (NO_MISTAKES_GATE set)
exit=3

### docs/agent-control.md: the valid close form fm-send itself writes
385:    line="resolved [key=$k]: answered: $note"
=> key sits between the verb and the colon, matching the corrected brief scaffold.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `tests/fm-brief.test.sh:670` - The new negative regression assertion can never fail. `assert_no_grep` (tests/lib.sh:293) runs `grep -F`, so the pattern `resolved: {how it cleared}.*key=&lt;slug&gt;` is matched literally, `.*` included, and no brief can ever contain that byte sequence. The intended guard - &#34;the scaffold no longer teaches the key token after the colon&#34; - therefore provides zero coverage; only the positive assert_grep on line 668 actually protects the fix, and it cannot catch a future edit that re-adds the wrong form alongside the correct one. Use a fixed string that only the defect contains, e.g. `assert_no_grep &#39;resolved: [key=&#39;`, which is absent from the corrected prose and present in any key-after-colon regression.
- ℹ️ `docs/turnend-guard.md:80` - &#34;`outcome=failed-suppressed` ... means the home has no verified watcher&#34; is not true on all three write paths. bin/fm-claude-stop-autoarm.sh:214 writes `failed-suppressed` inside the `HEALTHY -eq 1` branch, reached when `fm_watcher_healthy` passed but `fm_failure_episode_reset` (bin/fm-wake-lib.sh:762) returned nonzero - realistically on contention for `state/.turnend-claude-blocks.lock`, which bin/fm-turnend-guard.sh:151 also takes on the same Stop event. The pre-existing line 65 states this more carefully (&#34;enter or advance the failure progression instead of acting as unconditional recovery proof&#34;). Softening to &#34;usually means&#34; or naming the healthy-but-contended case would keep the section from contradicting its own owner; the prescribed remedy (read the three state files) is already safe in both cases.
- ℹ️ `CONTRIBUTING.md:42` - The new `### Inspecting a no-mistakes run` heading at line 32 was inserted between the Workflow steps (1-7) and the closing pointer &#34;See the no-mistakes quick start ... for the full first-run walkthrough.&#34; That sentence used to close the Workflow section it refers to, and now reads as a pointer belonging to the run-inspection subsection. Moving the pointer above the new heading keeps it attached to the first-run workflow it documents.

🔧 Fix: test: make keyed-resolution regression guard actually assert
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-brief.test.sh` - 20 checks pass, including the new keyed-resolution guard across ship/scout/secondmate scaffolds</code>
- <code>Red-check: `git checkout 9068958 -- bin/fm-brief.sh &amp;&amp; bash tests/fm-brief.test.sh` - new guard correctly fails with `not ok - ship brief did not put a keyed resolution token before the colon`, then restored to target</code>
- <code>Non-vacuity check: `grep -F` vs `grep -E` for `resolved:.*\[key=` against the base-rendered brief, proving `assert_no_grep_re` was required over `assert_no_grep`</code>
- <code>Rendered real briefs from base and target via `FM_HOME=... bin/fm-brief.sh &lt;id&gt; firstmate --mode no-mistakes` / `--scout` / `--secondmate --no-projects` and diffed the taught resolution line</code>
- <code>Manual end-to-end keyed-resolution contract: sourced `bin/fm-classify-lib.sh` and ran the documented recipe `status_open_decisions state/&lt;id&gt;.status | cut -f1 | sort -u`, confirming survival through working/paused/done, non-closure by `resolved: [key=...]`, and closure by `resolved [key=...]:`</code>
- <code>`bash tests/fm-decision-hold-lifecycle.test.sh` - 9 checks pass (owner of the documented open/resolved fold)</code>
- <code>`bash tests/fm-documentation-audiences.test.sh` - 4 checks pass, covering the six edited prose surfaces and local link resolution for the new tmux-backend cross-link</code>
- <code>`bash tests/fm-send-resolve-key.test.sh` - 10 checks pass, covering the --resolve-key refusal contract documented in agent-control.md</code>
- <code>`bash tests/fm-send-strict.test.sh` - 8 checks pass, including `unset FM_HOME fails before target resolution` with no send attempted</code>
- <code>`bash tests/fm-claude-stop-autoarm.test.sh` - 22 checks pass, covering the failed-suppressed auto-arm diagnostics</code>
- <code>Verified documented identifiers resolve to live code: `.claude-autoarm-epoch`, `.last-watcher-beat`, `.watch.lock`, `.afk`, `failed-suppressed`, `FM_GUARD_GRACE:-300`, `bin/fm-afk-launch.sh stop`</code>
- <code>Constraint checks: `git diff --name-only 9068958..1cceba5` confirms data/learnings.md and captain-preference surfaces untouched; added Markdown lines scanned for em/en dashes and multi-sentence lines; commit trailers scanned for agent co-author</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ⚠️ `CONTRIBUTING.md:32` - The new &#34;Inspecting a no-mistakes run&#34; section documents gate mechanics (axi status resolution, batch-flushed step logs, the Review timeline and its ⚠️/findings: rendering, broken-pipe interpretation) inside firstmate&#39;s own docs, while the same file says twice - line 29 and line 75 - to follow the installed no-mistakes version&#39;s SKILL.md and live `axi` help &#34;instead of duplicating gate mechanics in firstmate docs&#34;. Two of the lines also restate fleet rules AGENTS.md already owns: line 38&#39;s ship-done-without-a-PR check overlaps AGENTS.md:346/350, and line 40&#39;s `branch_sync.next_action` rule is stated in full at AGENTS.md:333. The observations are accurate today, but they describe rendered output of a specific gate version (CONTRIBUTING.md:20 pins v1.31.2+) and will rot silently when no-mistakes changes its display. I did not edit them because the user intent explicitly requires these axi-status facts to be promoted into tracked owners, so deciding what stays local versus what reduces to a pointer is the author&#39;s scope call. Suggested follow-up: keep only the firstmate-specific supervision rules (and point the AGENTS.md-owned ones at AGENTS.md), or scope the section explicitly as version-observed notes subordinate to the installed version&#39;s help.

🔧 Fix: replace gate mechanics in CONTRIBUTING with owner pointers
1 info still open:
- ℹ️ `CONTRIBUTING.md:65` - The user intent&#39;s clause asking to document &#34;the no-mistakes axi status one-run-per-repository, batch-flushed step log, and Review timeline behavior&#34; is now only partially satisfied as tracked prose, by deliberate instruction. Per the round 1 fix direction, the one-run-per-repository and batch-flushed-step-log invariants are retained (CONTRIBUTING.md:67-68) reframed as version-independent firstmate supervision facts, while the Review timeline behavior (timeline-not-verdict, the ⚠️ marker, the findings: count) is deliberately not restated here: it is rendered output of the installed no-mistakes version, so CONTRIBUTING.md:29 and :65 point at that version&#39;s SKILL.md and live `axi` help instead. Flagging only because it is a conscious deviation from the literal intent text, resolved in favour of the later explicit instruction; no action needed unless the author wants that rendering fact captured somewhere firstmate can actually keep true.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
