### PR TITLE
fix: recover missing Herdr relaunch slots

### DIFF
--- a/.agents/skills/stuck-crewmate-recovery/SKILL.md
+++ b/.agents/skills/stuck-crewmate-recovery/SKILL.md
@@ -43,7 +43,7 @@ Escalate in order:
 1. Peek the pane.
 2. If the crewmate is waiting on a question its brief already answers, answer in one line via `FM_HOME=<this-firstmate-home> bin/fm-send.sh` from an active firstmate session unless `FM_HOME` is already set to the active firstmate home.
 3. If the crewmate is confused or looping, interrupt with `FM_HOME=<this-firstmate-home> bin/fm-control.sh <task-id> interrupt`, then redirect with one corrective line through `fm-send`.
-4. If the crewmate is genuinely wedged after redirection, relaunch it with `FM_HOME=<this-firstmate-home> bin/fm-control.sh <task-id> relaunch --note '<progress so far>'`, which stops the agent, carries the brief plus that note into a replacement in the same local copy, and restores the prior record if the replacement cannot start.
+4. If the crewmate is genuinely wedged after redirection, relaunch it with `FM_HOME=<this-firstmate-home> bin/fm-control.sh <task-id> relaunch --note '<progress so far>'`, which stops the agent (or, for a structurally missing Herdr pane, replaces only that exact recorded slot), carries the brief plus that note into a replacement in the same local copy, and restores the prior record if the replacement cannot start.
    Pass `--harness`, `--model`, or `--effort` on that same command when the worker should come back on a different runtime.
    Genuine wedging means looping, unresponsive, repeating the same obstacle, or truly dead.
    A low context reading is not wedging; modern harnesses auto-compact and keep going.

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2056,7 +2056,7 @@ EOF
 # Return codes: 0 replacement created, 2 exact endpoint revived agent-free,
 # 1 refusal or failed/ambiguous Herdr response. On success or return 2, the
 # FM_BACKEND_HERDR_RELAUNCH_* globals contain the authoritative exact ids.
-fm_backend_herdr_relaunch_missing_task() {  # <session> <workspace> <tab> <pane> <label> <cwd>
+fm_backend_herdr_relaunch_missing_task_serialized() {  # <session> <workspace> <tab> <pane> <label> <cwd>
   local session=$1 workspace=$2 recorded_tab=$3 recorded_pane=$4 label=$5 cwd=$6
   local tabs panes tab_count label_count exact_count old_pane old_pane_count recorded_pane_count recorded_pane_tab
   local out new_tab new_pane remaining old_present new_present new_pane_count
@@ -2223,6 +2223,32 @@ fm_backend_herdr_relaunch_missing_task() {  # <session> <workspace> <tab> <pane>
   # shellcheck disable=SC2034 # callers consume these same-process output globals
   FM_BACKEND_HERDR_RELAUNCH_PANE_ID=$new_pane
   return 0
+}
+
+fm_backend_herdr_relaunch_missing_task() {  # <session> <workspace> <tab> <pane> <label> <cwd>
+  local session=$1 lock_path attempt=0 lock_held=0
+  if ! declare -F fm_lock_try_acquire >/dev/null 2>&1; then
+    # shellcheck source=bin/fm-wake-lib.sh
+    . "$FM_BACKEND_HERDR_ROOT/bin/fm-wake-lib.sh"
+  fi
+  if lock_path=$(fm_backend_herdr_presentation_session_lock_path "$session"); then
+    while [ "$attempt" -lt 50 ]; do
+      if fm_lock_try_acquire "$lock_path"; then
+        lock_held=1
+        break
+      fi
+      sleep 0.1
+      attempt=$((attempt + 1))
+    done
+  fi
+  if [ "$lock_held" = 1 ]; then
+    fm_backend_herdr_relaunch_missing_task_serialized "$@"
+    local status=$?
+    fm_lock_release "$lock_path" || true
+    return "$status"
+  fi
+  echo "error: could not acquire Herdr session presentation lock; refusing recovery" >&2
+  return 1
 }
 
 # fm_backend_herdr_projection_create_task: create one disposable presentation

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2058,7 +2058,7 @@ EOF
 # FM_BACKEND_HERDR_RELAUNCH_* globals contain the authoritative exact ids.
 fm_backend_herdr_relaunch_missing_task() {  # <session> <workspace> <tab> <pane> <label> <cwd>
   local session=$1 workspace=$2 recorded_tab=$3 recorded_pane=$4 label=$5 cwd=$6
-  local tabs panes tab_count label_count exact_count old_pane old_pane_count recorded_pane_count
+  local tabs panes tab_count label_count exact_count old_pane old_pane_count recorded_pane_count recorded_pane_tab
   local out new_tab new_pane remaining old_present new_present new_pane_count
   FM_BACKEND_HERDR_RELAUNCH_SESSION=""
   FM_BACKEND_HERDR_RELAUNCH_WORKSPACE_ID=""
@@ -2119,12 +2119,15 @@ fm_backend_herdr_relaunch_missing_task() {  # <session> <workspace> <tab> <pane>
   }
   old_pane_count=$(printf '%s' "$panes" | jq -r --arg tab "$recorded_tab" '[.result.panes[] | select(.tab_id == $tab)] | length' 2>/dev/null)
   recorded_pane_count=$(printf '%s' "$panes" | jq -r --arg pane "$recorded_pane" '[.result.panes[] | select(.pane_id == $pane)] | length' 2>/dev/null)
+  recorded_pane_tab=$(printf '%s' "$panes" | jq -r --arg pane "$recorded_pane" '[.result.panes[] | select(.pane_id == $pane) | .tab_id][0] // empty' 2>/dev/null)
   case "$old_pane_count:$recorded_pane_count" in :|:*|*:|*[!0-9:]*)
     echo "error: recorded Herdr tab '$recorded_tab' returned an unparseable pane count; refusing recovery" >&2
     return 1
     ;;
   esac
-  if [ "$exact_count" -eq 0 ] && [ "$recorded_pane_count" != 0 ]; then
+  if [ "$recorded_pane_count" -gt 1 ] || {
+    [ "$recorded_pane_count" -eq 1 ] && [ "$recorded_pane_tab" != "$recorded_tab" ];
+  }; then
     echo "error: recorded Herdr pane '$recorded_pane' is attached to another tab; refusing recovery" >&2
     return 1
   fi
@@ -2165,6 +2168,7 @@ fm_backend_herdr_relaunch_missing_task() {  # <session> <workspace> <tab> <pane>
   new_tab=$(printf '%s' "$out" | jq -r '.result.tab.tab_id // empty' 2>/dev/null)
   new_pane=$(printf '%s' "$out" | jq -r '.result.root_pane.pane_id // empty' 2>/dev/null)
   [ -n "$new_tab" ] && [ -n "$new_pane" ] && [ "$new_tab" != "$recorded_tab" ] || {
+    [ -n "$new_tab" ] && fm_backend_herdr_cli "$session" tab close "$new_tab" >/dev/null 2>&1 || true
     echo "error: replacement Herdr tab response was missing or conflicting; refusing recovery" >&2
     return 1
   }
@@ -2180,6 +2184,7 @@ fm_backend_herdr_relaunch_missing_task() {  # <session> <workspace> <tab> <pane>
     fi
   fi
   tabs=$(fm_backend_herdr_cli "$session" tab list --workspace "$workspace" 2>/dev/null) || {
+    fm_backend_herdr_cli "$session" tab close "$new_tab" >/dev/null 2>&1 || true
     echo "error: could not verify replacement Herdr tab '$new_tab'; refusing recovery" >&2
     return 1
   }
@@ -2187,16 +2192,19 @@ fm_backend_herdr_relaunch_missing_task() {  # <session> <workspace> <tab> <pane>
     '[.result.tabs[]? | select(.label == $label and .tab_id != $replacement)] | length' 2>/dev/null)
   new_present=$(printf '%s' "$tabs" | jq -r --arg tab "$new_tab" '[.result.tabs[]? | select(.tab_id == $tab)] | length' 2>/dev/null)
   [ "$remaining" = 0 ] && [ "$new_present" = 1 ] || {
+    fm_backend_herdr_cli "$session" tab close "$new_tab" >/dev/null 2>&1 || true
     echo "error: replacement Herdr tab '$new_tab' did not leave exactly one task tab; refusing recovery" >&2
     return 1
   }
   panes=$(fm_backend_herdr_cli "$session" pane list --workspace "$workspace" 2>/dev/null) || {
+    fm_backend_herdr_cli "$session" tab close "$new_tab" >/dev/null 2>&1 || true
     echo "error: could not verify replacement Herdr pane '$new_pane'; refusing recovery" >&2
     return 1
   }
   new_pane_count=$(printf '%s' "$panes" | jq -r --arg tab "$new_tab" --arg pane "$new_pane" \
     '[.result.panes[]? | select(.tab_id == $tab and .pane_id == $pane)] | length' 2>/dev/null)
   [ "$new_pane_count" = 1 ] || {
+    fm_backend_herdr_cli "$session" tab close "$new_tab" >/dev/null 2>&1 || true
     echo "error: replacement Herdr pane '$new_pane' did not bind exactly to tab '$new_tab'; refusing recovery" >&2
     return 1
   }

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2180,17 +2180,22 @@ fm_backend_herdr_relaunch_missing_task_serialized() {  # <session> <workspace> <
   remaining=$(printf '%s' "$tabs" | jq -r --arg label "$label" --arg replacement "$new_tab" \
     '[.result.tabs[]? | select(.label == $label and .tab_id != $replacement)] | length' 2>/dev/null)
   new_present=$(printf '%s' "$tabs" | jq -r --arg tab "$new_tab" '[.result.tabs[]? | select(.tab_id == $tab)] | length' 2>/dev/null)
+  task_tabs_valid=0
   if [ "$exact_count" -eq 1 ]; then
-    [ "$remaining" = 1 ] && printf '%s' "$tabs" | jq -e --arg label "$label" --arg tab "$recorded_tab" \
-      '[.result.tabs[]? | select(.label == $label and .tab_id == $tab)] | length == 1' >/dev/null 2>&1
-  else
-    [ "$remaining" = 0 ]
+    if [ "$remaining" = 1 ] && printf '%s' "$tabs" | jq -e --arg label "$label" --arg tab "$recorded_tab" \
+      '[.result.tabs[]? | select(.label == $label and .tab_id == $tab)] | length == 1' >/dev/null 2>&1; then
+      task_tabs_valid=1
+    fi
+  elif [ "$remaining" = 0 ]; then
+    task_tabs_valid=1
   fi
-  [ "$?" -eq 0 ] && [ "$new_present" = 1 ] || {
+  if [ "$task_tabs_valid" -eq 1 ] && [ "$new_present" = 1 ]; then
+    :
+  else
     fm_backend_herdr_cli "$session" tab close "$new_tab" >/dev/null 2>&1 || true
     echo "error: replacement Herdr tab '$new_tab' did not leave exactly one task tab; refusing recovery" >&2
     return 1
-  }
+  fi
   panes=$(fm_backend_herdr_cli "$session" pane list --workspace "$workspace" 2>/dev/null) || {
     fm_backend_herdr_cli "$session" tab close "$new_tab" >/dev/null 2>&1 || true
     echo "error: could not verify replacement Herdr pane '$new_pane'; refusing recovery" >&2

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2172,17 +2172,6 @@ fm_backend_herdr_relaunch_missing_task() {  # <session> <workspace> <tab> <pane>
     echo "error: replacement Herdr tab response was missing or conflicting; refusing recovery" >&2
     return 1
   }
-  if [ "$exact_count" -eq 1 ]; then
-    if ! fm_backend_herdr_cli "$session" tab close "$recorded_tab" >/dev/null 2>&1; then
-      old_present=$(fm_backend_herdr_cli "$session" tab list --workspace "$workspace" 2>/dev/null \
-        | jq -r --arg tab "$recorded_tab" '[.result.tabs[]? | select(.tab_id == $tab)] | length' 2>/dev/null || true)
-      if [ "$old_present" != 0 ]; then
-        fm_backend_herdr_cli "$session" tab close "$new_tab" >/dev/null 2>&1 || true
-        echo "error: could not close the missing Herdr tab '$recorded_tab'; refusing recovery" >&2
-        return 1
-      fi
-    fi
-  fi
   tabs=$(fm_backend_herdr_cli "$session" tab list --workspace "$workspace" 2>/dev/null) || {
     fm_backend_herdr_cli "$session" tab close "$new_tab" >/dev/null 2>&1 || true
     echo "error: could not verify replacement Herdr tab '$new_tab'; refusing recovery" >&2
@@ -2191,7 +2180,13 @@ fm_backend_herdr_relaunch_missing_task() {  # <session> <workspace> <tab> <pane>
   remaining=$(printf '%s' "$tabs" | jq -r --arg label "$label" --arg replacement "$new_tab" \
     '[.result.tabs[]? | select(.label == $label and .tab_id != $replacement)] | length' 2>/dev/null)
   new_present=$(printf '%s' "$tabs" | jq -r --arg tab "$new_tab" '[.result.tabs[]? | select(.tab_id == $tab)] | length' 2>/dev/null)
-  [ "$remaining" = 0 ] && [ "$new_present" = 1 ] || {
+  if [ "$exact_count" -eq 1 ]; then
+    [ "$remaining" = 1 ] && printf '%s' "$tabs" | jq -e --arg label "$label" --arg tab "$recorded_tab" \
+      '[.result.tabs[]? | select(.label == $label and .tab_id == $tab)] | length == 1' >/dev/null 2>&1
+  else
+    [ "$remaining" = 0 ]
+  fi
+  [ "$?" -eq 0 ] && [ "$new_present" = 1 ] || {
     fm_backend_herdr_cli "$session" tab close "$new_tab" >/dev/null 2>&1 || true
     echo "error: replacement Herdr tab '$new_tab' did not leave exactly one task tab; refusing recovery" >&2
     return 1
@@ -2208,6 +2203,17 @@ fm_backend_herdr_relaunch_missing_task() {  # <session> <workspace> <tab> <pane>
     echo "error: replacement Herdr pane '$new_pane' did not bind exactly to tab '$new_tab'; refusing recovery" >&2
     return 1
   }
+  if [ "$exact_count" -eq 1 ]; then
+    if ! fm_backend_herdr_cli "$session" tab close "$recorded_tab" >/dev/null 2>&1; then
+      old_present=$(fm_backend_herdr_cli "$session" tab list --workspace "$workspace" 2>/dev/null \
+        | jq -r --arg tab "$recorded_tab" '[.result.tabs[]? | select(.tab_id == $tab)] | length' 2>/dev/null || true)
+      if [ "$old_present" != 0 ]; then
+        fm_backend_herdr_cli "$session" tab close "$new_tab" >/dev/null 2>&1 || true
+        echo "error: could not close the missing Herdr tab '$recorded_tab'; refusing recovery" >&2
+        return 1
+      fi
+    fi
+  fi
   # shellcheck disable=SC2034 # callers consume these same-process output globals
   FM_BACKEND_HERDR_RELAUNCH_SESSION=$session
   # shellcheck disable=SC2034 # callers consume these same-process output globals

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2047,6 +2047,170 @@ EOF
   printf '%s %s' "$tab_id" "$pane_id"
 }
 
+# fm_backend_herdr_relaunch_missing_task: replace one missing authoritative task
+# slot in the exact recorded workspace. This is narrower than create_task: it
+# never resolves a workspace by label, never adopts a different same-labeled
+# tab, and never creates a worktree. A recorded tab with no root pane is
+# replaced only after the new tab and pane exist; a tab that has reappeared with
+# no registered agent is returned to the ordinary relaunch path instead.
+# Return codes: 0 replacement created, 2 exact endpoint revived agent-free,
+# 1 refusal or failed/ambiguous Herdr response. On success or return 2, the
+# FM_BACKEND_HERDR_RELAUNCH_* globals contain the authoritative exact ids.
+fm_backend_herdr_relaunch_missing_task() {  # <session> <workspace> <tab> <pane> <label> <cwd>
+  local session=$1 workspace=$2 recorded_tab=$3 recorded_pane=$4 label=$5 cwd=$6
+  local tabs panes tab_count label_count exact_count old_pane old_pane_count recorded_pane_count
+  local out new_tab new_pane remaining old_present new_present new_pane_count
+  FM_BACKEND_HERDR_RELAUNCH_SESSION=""
+  FM_BACKEND_HERDR_RELAUNCH_WORKSPACE_ID=""
+  FM_BACKEND_HERDR_RELAUNCH_TAB_ID=""
+  FM_BACKEND_HERDR_RELAUNCH_PANE_ID=""
+  [ -n "$session" ] && [ -n "$workspace" ] && [ -n "$recorded_tab" ] \
+    && [ -n "$recorded_pane" ] && [ -n "$label" ] && [ -d "$cwd" ] || {
+    echo "error: missing Herdr relaunch has an incomplete exact identity or worktree; refusing recovery" >&2
+    return 1
+  }
+  [ "$(fm_backend_herdr_workspace_presence_state "$session" "$workspace")" = present ] || {
+    echo "error: recorded Herdr workspace '$workspace' is missing or ambiguous in session '$session'; refusing recovery" >&2
+    return 1
+  }
+  tabs=$(fm_backend_herdr_cli "$session" tab list --workspace "$workspace" 2>/dev/null) || {
+    echo "error: could not inspect recorded Herdr workspace '$workspace'; refusing recovery" >&2
+    return 1
+  }
+  printf '%s' "$tabs" | jq -e '(.result.tabs | type) == "array"' >/dev/null 2>&1 || {
+    echo "error: recorded Herdr workspace '$workspace' returned an ambiguous tab list; refusing recovery" >&2
+    return 1
+  }
+  tab_count=$(printf '%s' "$tabs" | jq -r '.result.tabs | length' 2>/dev/null)
+  label_count=$(printf '%s' "$tabs" | jq -r --arg label "$label" '[.result.tabs[] | select(.label == $label)] | length' 2>/dev/null)
+  exact_count=$(printf '%s' "$tabs" | jq -r --arg tab "$recorded_tab" '[.result.tabs[] | select(.tab_id == $tab)] | length' 2>/dev/null)
+  case "$tab_count:$label_count:$exact_count" in
+    *[!0-9:]*|*::*)
+      echo "error: recorded Herdr workspace '$workspace' returned unparseable tab counts; refusing recovery" >&2
+      return 1
+      ;;
+  esac
+  [ "$exact_count" -le 1 ] || {
+    echo "error: recorded Herdr tab '$recorded_tab' is duplicated in workspace '$workspace'; refusing recovery" >&2
+    return 1
+  }
+  if [ "$exact_count" -eq 1 ]; then
+    [ "$label_count" = 1 ] || {
+      echo "error: recorded Herdr task label '$label' is duplicated or absent around tab '$recorded_tab'; refusing recovery" >&2
+      return 1
+    }
+    if ! printf '%s' "$tabs" | jq -e --arg tab "$recorded_tab" --arg label "$label" \
+      '[.result.tabs[] | select(.tab_id == $tab and .label == $label)] | length == 1' >/dev/null 2>&1; then
+      echo "error: recorded Herdr tab '$recorded_tab' has a conflicting label; refusing recovery" >&2
+      return 1
+    fi
+  elif [ "$label_count" != 0 ]; then
+    echo "error: another Herdr tab already carries task label '$label' in workspace '$workspace'; refusing recovery" >&2
+    return 1
+  fi
+
+  panes=$(fm_backend_herdr_cli "$session" pane list --workspace "$workspace" 2>/dev/null) || {
+    echo "error: could not inspect panes in recorded Herdr workspace '$workspace'; refusing recovery" >&2
+    return 1
+  }
+  printf '%s' "$panes" | jq -e '(.result.panes | type) == "array"' >/dev/null 2>&1 || {
+    echo "error: recorded Herdr workspace '$workspace' returned an ambiguous pane list; refusing recovery" >&2
+    return 1
+  }
+  old_pane_count=$(printf '%s' "$panes" | jq -r --arg tab "$recorded_tab" '[.result.panes[] | select(.tab_id == $tab)] | length' 2>/dev/null)
+  recorded_pane_count=$(printf '%s' "$panes" | jq -r --arg pane "$recorded_pane" '[.result.panes[] | select(.pane_id == $pane)] | length' 2>/dev/null)
+  case "$old_pane_count:$recorded_pane_count" in :|:*|*:|*[!0-9:]*)
+    echo "error: recorded Herdr tab '$recorded_tab' returned an unparseable pane count; refusing recovery" >&2
+    return 1
+    ;;
+  esac
+  if [ "$exact_count" -eq 0 ] && [ "$recorded_pane_count" != 0 ]; then
+    echo "error: recorded Herdr pane '$recorded_pane' is attached to another tab; refusing recovery" >&2
+    return 1
+  fi
+  case "$old_pane_count" in ''|*[!0-9]*)
+    echo "error: recorded Herdr tab '$recorded_tab' returned an unparseable pane count; refusing recovery" >&2
+    return 1
+    ;;
+  esac
+  if [ "$exact_count" -eq 1 ] && [ "$old_pane_count" -gt 0 ]; then
+    [ "$old_pane_count" = 1 ] || {
+      echo "error: recorded Herdr tab '$recorded_tab' has multiple root panes; refusing recovery" >&2
+      return 1
+    }
+    old_pane=$(printf '%s' "$panes" | jq -r --arg tab "$recorded_tab" '.result.panes[] | select(.tab_id == $tab) | .pane_id' 2>/dev/null)
+    [ "$old_pane" = "$recorded_pane" ] || {
+      echo "error: recorded Herdr tab '$recorded_tab' is bound to pane '${old_pane:-missing}', not '$recorded_pane'; refusing recovery" >&2
+      return 1
+    }
+    case "$(fm_backend_herdr_pane_agent_state "$session" "$old_pane")" in
+      no-agent)
+        FM_BACKEND_HERDR_RELAUNCH_SESSION=$session
+        FM_BACKEND_HERDR_RELAUNCH_WORKSPACE_ID=$workspace
+        FM_BACKEND_HERDR_RELAUNCH_TAB_ID=$recorded_tab
+        FM_BACKEND_HERDR_RELAUNCH_PANE_ID=$old_pane
+        return 2
+        ;;
+      live|unknown|dead)
+        echo "error: recorded Herdr pane '$old_pane' is live or ambiguous after the missing-slot check; refusing recovery" >&2
+        return 1
+        ;;
+    esac
+  fi
+
+  out=$(fm_backend_herdr_cli "$session" tab create --workspace "$workspace" --cwd "$cwd" --label "$label" --no-focus 2>/dev/null) || {
+    echo "error: could not create a replacement Herdr tab for '$label' in recorded workspace '$workspace'" >&2
+    return 1
+  }
+  new_tab=$(printf '%s' "$out" | jq -r '.result.tab.tab_id // empty' 2>/dev/null)
+  new_pane=$(printf '%s' "$out" | jq -r '.result.root_pane.pane_id // empty' 2>/dev/null)
+  [ -n "$new_tab" ] && [ -n "$new_pane" ] && [ "$new_tab" != "$recorded_tab" ] || {
+    echo "error: replacement Herdr tab response was missing or conflicting; refusing recovery" >&2
+    return 1
+  }
+  if [ "$exact_count" -eq 1 ]; then
+    if ! fm_backend_herdr_cli "$session" tab close "$recorded_tab" >/dev/null 2>&1; then
+      old_present=$(fm_backend_herdr_cli "$session" tab list --workspace "$workspace" 2>/dev/null \
+        | jq -r --arg tab "$recorded_tab" '[.result.tabs[]? | select(.tab_id == $tab)] | length' 2>/dev/null || true)
+      if [ "$old_present" != 0 ]; then
+        fm_backend_herdr_cli "$session" tab close "$new_tab" >/dev/null 2>&1 || true
+        echo "error: could not close the missing Herdr tab '$recorded_tab'; refusing recovery" >&2
+        return 1
+      fi
+    fi
+  fi
+  tabs=$(fm_backend_herdr_cli "$session" tab list --workspace "$workspace" 2>/dev/null) || {
+    echo "error: could not verify replacement Herdr tab '$new_tab'; refusing recovery" >&2
+    return 1
+  }
+  remaining=$(printf '%s' "$tabs" | jq -r --arg label "$label" --arg replacement "$new_tab" \
+    '[.result.tabs[]? | select(.label == $label and .tab_id != $replacement)] | length' 2>/dev/null)
+  new_present=$(printf '%s' "$tabs" | jq -r --arg tab "$new_tab" '[.result.tabs[]? | select(.tab_id == $tab)] | length' 2>/dev/null)
+  [ "$remaining" = 0 ] && [ "$new_present" = 1 ] || {
+    echo "error: replacement Herdr tab '$new_tab' did not leave exactly one task tab; refusing recovery" >&2
+    return 1
+  }
+  panes=$(fm_backend_herdr_cli "$session" pane list --workspace "$workspace" 2>/dev/null) || {
+    echo "error: could not verify replacement Herdr pane '$new_pane'; refusing recovery" >&2
+    return 1
+  }
+  new_pane_count=$(printf '%s' "$panes" | jq -r --arg tab "$new_tab" --arg pane "$new_pane" \
+    '[.result.panes[]? | select(.tab_id == $tab and .pane_id == $pane)] | length' 2>/dev/null)
+  [ "$new_pane_count" = 1 ] || {
+    echo "error: replacement Herdr pane '$new_pane' did not bind exactly to tab '$new_tab'; refusing recovery" >&2
+    return 1
+  }
+  # shellcheck disable=SC2034 # callers consume these same-process output globals
+  FM_BACKEND_HERDR_RELAUNCH_SESSION=$session
+  # shellcheck disable=SC2034 # callers consume these same-process output globals
+  FM_BACKEND_HERDR_RELAUNCH_WORKSPACE_ID=$workspace
+  # shellcheck disable=SC2034 # callers consume these same-process output globals
+  FM_BACKEND_HERDR_RELAUNCH_TAB_ID=$new_tab
+  # shellcheck disable=SC2034 # callers consume these same-process output globals
+  FM_BACKEND_HERDR_RELAUNCH_PANE_ID=$new_pane
+  return 0
+}
+
 # fm_backend_herdr_projection_create_task: create one disposable presentation
 # workspace and its normal fm-<id> task tab without looking up, adopting, or
 # reusing any existing workspace.

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -804,7 +804,16 @@ do_relaunch() {
   journal_write noted "${CHECKPOINT_LINES[@]}" "$note_line"
 
   journal_write stopping "${CHECKPOINT_LINES[@]}" "$note_line"
-  exit_result=$(do_exit)
+  # Herdr can lose the recorded pane while leaving the task's durable copy and
+  # identity intact; the launch owner has an exact missing-slot recovery path.
+  # Do not turn this into a generic missing-endpoint exemption for other
+  # backends, whose relaunch must still stop a positively identified agent.
+  state=$(agent_state)
+  if [ "$BACKEND" = herdr ] && [ "$state" = missing ]; then
+    exit_result=already-stopped
+  else
+    exit_result=$(do_exit)
+  fi
   journal_write exited "${CHECKPOINT_LINES[@]}" "$note_line" "exit_result=$exit_result"
 
   # The launch owner (fm-spawn --relaunch) clears the previous incarnation's
@@ -822,6 +831,11 @@ do_relaunch() {
       || RELAUNCH_META_PUBLISHED=1
     die "the replacement agent for $ID could not be launched on $TARGET_HARNESS"
   fi
+  fm_backend_validate_task_endpoint "$META" "$ID" || \
+    die "the replacement agent for $ID published an invalid endpoint record; refusing to wait on an unverified target"
+  [ "$FM_BACKEND_VALIDATED_BACKEND" = "$BACKEND" ] || \
+    die "the replacement agent for $ID changed backend identity unexpectedly; refusing to wait on a conflicting target"
+  T=$FM_BACKEND_VALIDATED_TARGET
 
   state=$(wait_agent_state "$LAUNCH_WAIT" alive) || {
     die "the replacement agent for $ID did not come up within ${LAUNCH_WAIT}s (endpoint reads '$state')"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -643,6 +643,9 @@ SPAWN_META_PUBLISH_STARTED=0
 SPAWN_TASK_SET_LOCK=
 SPAWN_TASK_SET_LOCK_HELD=0
 RELAUNCH_REPLACEMENT_PENDING=0
+RELAUNCH_REPLACEMENT_ENDPOINT_PENDING=0
+RELAUNCH_REPLACEMENT_ENDPOINT_BACKEND=
+RELAUNCH_REPLACEMENT_ENDPOINT_TARGET=
 RELAUNCH_REPLACEMENT_BUSY_GEN=
 RELAUNCH_REPLACEMENT_HARNESS=
 RELAUNCH_REPLACEMENT_STATE=
@@ -691,6 +694,13 @@ spawn_abort_cleanup() {
           --gen "$RELAUNCH_REPLACEMENT_BUSY_GEN"; then
         echo "warning: could not retire replacement busy generation after aborted relaunch of $ID" >&2
       fi
+    fi
+  fi
+  if [ "$RELAUNCH_REPLACEMENT_ENDPOINT_PENDING" = 1 ]; then
+    RELAUNCH_REPLACEMENT_ENDPOINT_PENDING=0
+    if ! fm_backend_kill "$RELAUNCH_REPLACEMENT_ENDPOINT_BACKEND" \
+        "$RELAUNCH_REPLACEMENT_ENDPOINT_TARGET"; then
+      echo "warning: could not remove the unrecorded replacement endpoint for $ID" >&2
     fi
   fi
   if [ "$HERDR_PROJECTION_ABORT_CLEANUP" = 1 ] \
@@ -979,11 +989,6 @@ if [ "$RELAUNCH" -eq 1 ]; then
     echo "error: backend '$BACKEND' has no recovery-grade agent-state classifier, so a relaunch cannot prove the previous agent exited; refusing rather than risking two agents in one endpoint" >&2
     exit 1
   }
-  RELAUNCH_STATE=$(fm_backend_agent_state "$BACKEND" "$RELAUNCH_TARGET")
-  [ "$RELAUNCH_STATE" = dead ] || {
-    echo "error: task $ID's endpoint reads '$RELAUNCH_STATE'; a relaunch requires a positively agent-free endpoint (stop the agent first with bin/fm-control.sh $ID exit)" >&2
-    exit 1
-  }
   RELAUNCH_PRIOR_HARNESS=$(fm_meta_get "$RELAUNCH_META" harness)
   KIND=$(fm_meta_get "$RELAUNCH_META" kind)
   [ -n "$KIND" ] || KIND=ship
@@ -1010,6 +1015,31 @@ if [ "$RELAUNCH" -eq 1 ]; then
     HERDR_TAB_ID=$(fm_meta_get "$RELAUNCH_META" herdr_tab_id)
     HERDR_PANE_ID=$(fm_meta_get "$RELAUNCH_META" herdr_pane_id)
   fi
+  RELAUNCH_STATE=$(fm_backend_agent_state "$BACKEND" "$RELAUNCH_TARGET")
+  if [ "$RELAUNCH_STATE" = missing ] && [ "$BACKEND" = herdr ]; then
+    if fm_backend_herdr_relaunch_missing_task \
+      "$HERDR_SES" "$HERDR_WORKSPACE_ID" "$HERDR_TAB_ID" "$HERDR_PANE_ID" \
+      "fm-$ID" "$RELAUNCH_WT"; then
+      RELAUNCH_TARGET="$FM_BACKEND_HERDR_RELAUNCH_SESSION:$FM_BACKEND_HERDR_RELAUNCH_PANE_ID"
+      HERDR_SES=$FM_BACKEND_HERDR_RELAUNCH_SESSION
+      HERDR_WORKSPACE_ID=$FM_BACKEND_HERDR_RELAUNCH_WORKSPACE_ID
+      HERDR_TAB_ID=$FM_BACKEND_HERDR_RELAUNCH_TAB_ID
+      HERDR_PANE_ID=$FM_BACKEND_HERDR_RELAUNCH_PANE_ID
+      RELAUNCH_STATE=dead
+      RELAUNCH_REPLACEMENT_ENDPOINT_PENDING=1
+      RELAUNCH_REPLACEMENT_ENDPOINT_BACKEND=herdr
+      RELAUNCH_REPLACEMENT_ENDPOINT_TARGET=$RELAUNCH_TARGET
+    else
+      recovery_status=$?
+      [ "$recovery_status" -eq 2 ] || exit 1
+      RELAUNCH_TARGET="$HERDR_SES:$HERDR_PANE_ID"
+      RELAUNCH_STATE=dead
+    fi
+  fi
+  [ "$RELAUNCH_STATE" = dead ] || {
+    echo "error: task $ID's endpoint reads '$RELAUNCH_STATE'; a relaunch requires a positively agent-free endpoint (stop the agent first with bin/fm-control.sh $ID exit)" >&2
+    exit 1
+  }
   # With no explicit harness, a relaunch reuses the harness already recorded
   # for this task. It must NOT fall through to the fresh-spawn config
   # resolution, which would silently move an existing task onto whatever the
@@ -2534,6 +2564,7 @@ if [ "$RELAUNCH" -eq 1 ]; then
   SPAWN_META_PUBLISH_STARTED=1
   mv -f "$SPAWN_META_TMP" "$STATE/$ID.meta"
   RELAUNCH_REPLACEMENT_PENDING=0
+  RELAUNCH_REPLACEMENT_ENDPOINT_PENDING=0
   SPAWN_META_PUBLISH_STARTED=0
   SPAWN_META_TMP=
   fm_lock_release "$SPAWN_META_LOCK"

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -69,6 +69,7 @@ It is not deterministic across the verified adapters: codex and grok resume only
    A ship or scout relaunch requires `--note`, because the replacement inherits the local copy but none of the conversation; the note is appended to the instructions it reads.
    A secondmate relaunch does not require one and never rewrites its standing charter.
 4. **Stop the old agent** through the `exit` verb, with its postcondition.
+   For Herdr, when the recorded pane is structurally `missing`, the relaunch owner proves the exact recorded workspace and task identity, replaces that one missing slot in place, and skips an exit against the already-gone endpoint.
 5. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.
 
 Switching harness is therefore one ordinary relaunch rather than a separate mechanism.
@@ -99,6 +100,7 @@ Switching harness is therefore one ordinary relaunch rather than a separate mech
 - An ambiguous or unreadable endpoint state refuses.
   Only a positively classified state acts.
 - `fm-spawn --relaunch` independently refuses unless the recorded endpoint is positively agent-free and its shell is sitting in the recorded worktree, so a replacement can never join a live agent or start outside the copy holding the work.
+  The Herdr missing-slot recovery is the narrow exception: it replaces only the exact recorded missing tab in the recorded workspace, verifies the replacement before closing the husk, and uses the recorded worktree as its cwd.
 
 ## Capability matrix
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -255,6 +255,8 @@ This prevents closing the workspace's last tab before a replacement exists.
 The generic Herdr agent-liveness probe reuses the same classifier.
 A structurally gone pane becomes `missing`, a restored agent-less shell becomes `dead`, a registered agent becomes `alive`, and an unexpected read becomes `unreadable`.
 Unlike tmux process-name inspection, native registration can classify Pi without guessing from a generic interpreter name.
+A supervised relaunch whose recorded pane is `missing` may replace exactly that task tab in its recorded workspace, using the recorded isolated copy as the new pane cwd and publishing the new tab and pane ids in the existing task record.
+The recovery refuses a missing or ambiguous workspace, a conflicting task label or tab binding, a live or unreadable pane, or any malformed identity, and never resolves a workspace by label or acquires a new worktree.
 
 The session-start sweep uses this probe.
 Mid-session secondmate liveness is not implemented because idle secondmates are deliberately exempt from stale-pane escalation and need a separate periodic identity signal.

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -122,6 +122,90 @@ SH
   chmod +x "$fb/sleep"
 }
 
+# make_herdr_relaunch_stub models only the public relaunch calls needed by the
+# missing-slot path. It records exact Herdr requests and keeps workspace, tab,
+# pane, and agent identity in a JSON fixture so tests never touch a live server.
+make_herdr_relaunch_stub() {  # <case-dir>
+  local fb="$1/fakebin"
+  mkdir -p "$fb"
+  cat > "$fb/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+STATE=${FM_FAKE_HERDR_STATE:?}
+LOG=${FM_FAKE_HERDR_LOG:?}
+{
+  printf 'HERDR_SESSION=%s' "${HERDR_SESSION:-}"
+  for arg in "$@"; do printf '\x1f%s' "$arg"; done
+  printf '\n'
+} >> "$LOG"
+get_arg() {
+  local want=$1 arg next=0
+  shift
+  for arg in "$@"; do
+    if [ "$next" = 1 ]; then printf '%s' "$arg"; return 0; fi
+    [ "$arg" = "$want" ] && next=1
+  done
+}
+save() { local tmp="$STATE.tmp.$$"; cat > "$tmp" && mv "$tmp" "$STATE"; }
+cmd=${1:-}; sub=${2:-}
+workspace=$(get_arg --workspace "$@" || true)
+label=$(get_arg --label "$@" || true)
+case "$cmd $sub" in
+  'status --json')
+    printf '%s\n' '{"client":{"protocol":14,"version":"0.7.3"},"server":{"running":true}}' ;;
+  'session list')
+    jq -c '{sessions:[.sessions[]?]}' "$STATE" ;;
+  'workspace list')
+    jq -c '{result:{workspaces:.workspaces}}' "$STATE" ;;
+  'tab list')
+    jq -c --arg workspace "$workspace" '{result:{tabs:[.tabs[]? | select(.workspace_id == $workspace)]}}' "$STATE" ;;
+  'pane list')
+    jq -c --arg workspace "$workspace" '{result:{panes:[.tabs[]? | select(.workspace_id == $workspace and .pane_id != null) | {pane_id,tab_id}]}}' "$STATE" ;;
+  'pane get')
+    pane=${3:-}
+    if jq -e --arg pane "$pane" '.tabs[]? | select(.pane_id == $pane)' "$STATE" >/dev/null 2>&1; then
+      jq -c --arg pane "$pane" --arg cwd "$(jq -r '.cwd' "$STATE")" \
+        '.tabs[] | select(.pane_id == $pane) | {result:{pane:{pane_id,tab_id,workspace_id,foreground_cwd:$cwd}}}' "$STATE"
+    else
+      printf '%s\n' '{"error":{"code":"pane_not_found"}}'
+    fi
+    ;;
+  'agent get')
+    pane=${3:-}
+    status=$(jq -r --arg pane "$pane" '.agents[$pane] // empty' "$STATE")
+    if [ -n "$status" ]; then
+      printf '{"result":{"agent":{"agent_status":"%s"}}}\n' "$status"
+    else
+      printf '%s\n' '{"error":{"code":"agent_not_found"}}'
+    fi
+    ;;
+  'tab create')
+    next_tab=$(jq -r '.next_tab' "$STATE")
+    next_pane=$(jq -r '.next_pane' "$STATE")
+    jq -c --arg tab "$next_tab" --arg pane "$next_pane" --arg workspace "$workspace" --arg label "$label" \
+      '.tabs += [{tab_id:$tab,label:$label,workspace_id:$workspace,pane_id:$pane}]' "$STATE" \
+      | jq --arg tab "$next_tab" --arg pane "$next_pane" '.next_tab="t-replacement" | .next_pane="wK:p-replacement"' \
+      | save
+    printf '%s\n' '{"result":{"tab":{"tab_id":"t-replacement"},"root_pane":{"pane_id":"wK:p-replacement"}}}'
+    ;;
+  'tab close')
+    tab=${3:-}
+    jq -c --arg tab "$tab" '.tabs |= [.[] | select(.tab_id != $tab)]' "$STATE" | save
+    ;;
+  'pane run'|'pane send-text') : ;;
+  'pane send-keys')
+    pane=${3:-}
+    key=${4:-}
+    if [ "$pane" = 'wK:p-replacement' ] && [ "$key" = enter ]; then
+      jq -c '.agents["wK:p-replacement"] = "idle"' "$STATE" | save
+    fi
+    ;;
+  *) : ;;
+esac
+SH
+  chmod +x "$fb/herdr"
+}
+
 # new_case <name> [id] -> echoes a case dir with a live claude ship task.
 new_case() {
   local id=${2:-t1} dir="$TMP_ROOT/$1-$RANDOM"
@@ -160,6 +244,48 @@ add_ship_task() {
   TASK_TMPS+=("/tmp/fm-$id")
 }
 
+add_herdr_scout_task() {  # <case-dir> <id> <fixture-shape>
+  local dir=$1 id=$2 shape=$3 home="$1/home" proj="$1/proj" wt="$1/wt"
+  fm_git_worktree "$proj" "$wt" "task-$id"
+  mkdir -p "$home/data/$id"
+  printf '# scout brief\n' > "$home/data/$id/brief.md"
+  {
+    echo "window=default:wK:p2"
+    echo "endpoint_task_id=$id"
+    echo "worktree=$wt"
+    echo "project=$proj"
+    echo 'harness=pi'
+    echo 'kind=scout'
+    echo 'backend=herdr'
+    echo 'herdr_session=default'
+    echo 'herdr_workspace_id=wK'
+    echo 'herdr_tab_id=t-old'
+    echo 'herdr_pane_id=wK:p2'
+  } > "$home/state/$id.meta"
+  case "$shape" in
+    missing-slot)
+      printf '{"cwd":%s,"sessions":[{"name":"default","default":true,"running":true,"socket_path":"/tmp/default.sock"}],"workspaces":[{"workspace_id":"wK","label":"firstmate"}],"tabs":[{"tab_id":"t-old","label":"fm-%s","workspace_id":"wK","pane_id":null}],"agents":{},"next_tab":"t-replacement","next_pane":"wK:p-replacement"}\n' \
+        "$(printf '%s' "$wt" | jq -Rs .)" "$id" > "$dir/herdr-state.json"
+      ;;
+    missing-workspace)
+      printf '{"cwd":%s,"sessions":[{"name":"default","default":true,"running":true,"socket_path":"/tmp/default.sock"}],"workspaces":[],"tabs":[],"agents":{},"next_tab":"t-replacement","next_pane":"wK:p-replacement"}\n' \
+        "$(printf '%s' "$wt" | jq -Rs .)" > "$dir/herdr-state.json"
+      ;;
+    conflicting-label)
+      printf '{"cwd":%s,"sessions":[{"name":"default","default":true,"running":true,"socket_path":"/tmp/default.sock"}],"workspaces":[{"workspace_id":"wK","label":"firstmate"}],"tabs":[{"tab_id":"t-other","label":"fm-%s","workspace_id":"wK","pane_id":"wK:p-other"}],"agents":{},"next_tab":"t-replacement","next_pane":"wK:p-replacement"}\n' \
+        "$(printf '%s' "$wt" | jq -Rs .)" "$id" > "$dir/herdr-state.json"
+      ;;
+    live)
+      printf '{"cwd":%s,"sessions":[{"name":"default","default":true,"running":true,"socket_path":"/tmp/default.sock"}],"workspaces":[{"workspace_id":"wK","label":"firstmate"}],"tabs":[{"tab_id":"t-old","label":"fm-%s","workspace_id":"wK","pane_id":"wK:p2"}],"agents":{"wK:p2":"working"},"next_tab":"t-replacement","next_pane":"wK:p-replacement"}\n' \
+        "$(printf '%s' "$wt" | jq -Rs .)" "$id" > "$dir/herdr-state.json"
+      ;;
+    *) fail "unknown Herdr fixture shape: $shape" ;;
+  esac
+  : > "$dir/herdr.log"
+  make_herdr_relaunch_stub "$dir"
+  TASK_TMPS+=("/tmp/fm-$id")
+}
+
 run_control() {  # <case-dir> <args...>
   local dir=$1; shift
   env PATH="$dir/fakebin:$PATH" FM_HOME="$dir/home" FM_FAKE_DIR="$dir/fake" \
@@ -171,12 +297,14 @@ run_control() {  # <case-dir> <args...>
     FM_FAKE_TRACE_PREPARE="${FM_FAKE_TRACE_PREPARE:-}" \
     FM_FAKE_META_WRITER_READY="${FM_FAKE_META_WRITER_READY:-}" \
     FM_FAKE_TRACE_EXPORTED="${FM_FAKE_TRACE_EXPORTED:-}" \
+    FM_FAKE_HERDR_STATE="${FM_FAKE_HERDR_STATE:-}" FM_FAKE_HERDR_LOG="${FM_FAKE_HERDR_LOG:-}" \
     "$CONTROL" "$@" 2>&1
 }
 
 run_spawn() {  # <case-dir> <args...>
   local dir=$1; shift
   env PATH="$dir/fakebin:$PATH" FM_HOME="$dir/home" FM_FAKE_DIR="$dir/fake" \
+    FM_FAKE_HERDR_STATE="${FM_FAKE_HERDR_STATE:-}" FM_FAKE_HERDR_LOG="${FM_FAKE_HERDR_LOG:-}" \
     FM_SPAWN_NO_GUARD=1 GROK_HOME="$dir/grokhome" \
     "$SPAWN" "$@" 2>&1
 }
@@ -1299,6 +1427,115 @@ test_spawn_relaunch_refuses_a_pane_outside_the_worktree() {
   pass "fm-spawn --relaunch: refuses to start a replacement outside the copy holding the work"
 }
 
+test_spawn_relaunch_replaces_a_missing_herdr_slot_in_place() {
+  local dir out rc meta tab_count worktree_before
+  dir=$(new_case herdr-missing hm1)
+  add_herdr_scout_task "$dir" hm1 missing-slot
+  worktree_before=$(meta_field "$dir" hm1 worktree)
+  export FM_FAKE_HERDR_STATE="$dir/herdr-state.json" FM_FAKE_HERDR_LOG="$dir/herdr.log"
+  out=$(run_spawn "$dir" hm1 --relaunch --harness pi --model luna); rc=$?
+  unset FM_FAKE_HERDR_STATE FM_FAKE_HERDR_LOG
+  expect_code 0 "$rc" "a missing Herdr slot should relaunch through the public spawn interface"$'\n'"$out"
+  assert_contains "$out" "spawned hm1 harness=pi kind=scout window=default:wK:p-replacement" \
+    "the relaunch should report the exact replacement endpoint"
+  meta="$dir/home/state/hm1.meta"
+  [ "$(meta_field "$dir" hm1 worktree)" = "$worktree_before" ] \
+    || fail "missing-slot recovery must preserve the recorded isolated copy"
+  [ "$(meta_field "$dir" hm1 herdr_workspace_id)" = wK ] \
+    || fail "missing-slot recovery must stay in the recorded Herdr workspace"
+  [ "$(meta_field "$dir" hm1 herdr_tab_id)" = t-replacement ] \
+    || fail "missing-slot recovery must publish the replacement tab id"
+  [ "$(meta_field "$dir" hm1 herdr_pane_id)" = wK:p-replacement ] \
+    || fail "missing-slot recovery must publish the replacement pane id"
+  tab_count=$(jq -r '[.tabs[] | select(.label == "fm-hm1")] | length' "$dir/herdr-state.json")
+  [ "$tab_count" = 1 ] || fail "missing-slot recovery must leave exactly one task tab, got $tab_count"
+  assert_grep $'\x1ftab\x1fcreate' "$dir/herdr.log" "recovery should create one replacement tab"
+  assert_no_grep $'\x1fworkspace\x1fcreate' "$dir/herdr.log" "recovery must not create a replacement workspace"
+  assert_no_grep $'\x1ftreehouse\x1fget' "$dir/herdr.log" "recovery must not reacquire or move the preserved worktree"
+  [ "$(find "$dir/home/state" -maxdepth 1 -name '*.meta' -type f | wc -l | tr -d ' ')" = 1 ] \
+    || fail "missing-slot recovery must not create a duplicate task record"
+  pass "fm-spawn --relaunch: replaces one missing Herdr slot in the recorded workspace and copy"
+}
+
+test_control_relaunch_recovers_a_missing_herdr_slot() {
+  local dir out rc
+  dir=$(new_case herdr-supervised hm6)
+  add_herdr_scout_task "$dir" hm6 missing-slot
+  export FM_FAKE_HERDR_STATE="$dir/herdr-state.json" FM_FAKE_HERDR_LOG="$dir/herdr.log"
+  out=$(run_control "$dir" hm6 relaunch --harness pi --model luna --note "resume the preserved analysis"); rc=$?
+  unset FM_FAKE_HERDR_STATE FM_FAKE_HERDR_LOG
+  expect_code 0 "$rc" "supervised relaunch should recover a missing Herdr slot"$'\n'"$out"
+  assert_contains "$out" "relaunched hm6 harness=pi" \
+    "the supervised outcome should name the recovered task"
+  assert_contains "$out" "endpoint=default:wK:p-replacement" \
+    "the supervised outcome should use the replacement endpoint"
+  assert_grep 'luna' "$dir/herdr.log" "the configured Luna model should reach the Pi replacement launch"
+  [ "$(meta_field "$dir" hm6 worktree)" = "$dir/wt" ] \
+    || fail "supervised recovery must preserve the existing isolated copy"
+  [ "$(meta_field "$dir" hm6 herdr_pane_id)" = wK:p-replacement ] \
+    || fail "supervised recovery must wait on the newly published exact pane"
+  [ "$(meta_field "$dir" hm6 control_relaunch_tx)" != "" ] \
+    || fail "supervised recovery must retain the transaction binding"
+  pass "fm-control relaunch: recovers a missing Herdr slot and waits on its exact replacement"
+}
+
+test_spawn_relaunch_refuses_missing_herdr_workspace() {
+  local dir out rc
+  dir=$(new_case herdr-workspace-missing hm2)
+  add_herdr_scout_task "$dir" hm2 missing-workspace
+  export FM_FAKE_HERDR_STATE="$dir/herdr-state.json" FM_FAKE_HERDR_LOG="$dir/herdr.log"
+  out=$(run_spawn "$dir" hm2 --relaunch --harness pi); rc=$?
+  unset FM_FAKE_HERDR_STATE FM_FAKE_HERDR_LOG
+  expect_code 1 "$rc" "a missing recorded Herdr workspace should refuse"
+  assert_contains "$out" "workspace 'wK' is missing or ambiguous" \
+    "the refusal should name the missing exact workspace"
+  assert_no_grep $'\x1ftab\x1fcreate' "$dir/herdr.log" "a missing workspace must not create a guessed replacement"
+  pass "fm-spawn --relaunch: refuses when the recorded Herdr workspace is missing"
+}
+
+test_spawn_relaunch_refuses_a_conflicting_herdr_task_label() {
+  local dir out rc
+  dir=$(new_case herdr-conflict hm3)
+  add_herdr_scout_task "$dir" hm3 conflicting-label
+  export FM_FAKE_HERDR_STATE="$dir/herdr-state.json" FM_FAKE_HERDR_LOG="$dir/herdr.log"
+  out=$(run_spawn "$dir" hm3 --relaunch --harness pi); rc=$?
+  unset FM_FAKE_HERDR_STATE FM_FAKE_HERDR_LOG
+  expect_code 1 "$rc" "a conflicting Herdr task label should refuse"
+  assert_contains "$out" "another Herdr tab already carries task label" \
+    "the refusal should identify the conflicting task label"
+  assert_no_grep $'\x1ftab\x1fcreate' "$dir/herdr.log" "a conflicting label must not create a duplicate tab"
+  pass "fm-spawn --relaunch: refuses an ambiguous same-label Herdr record"
+}
+
+test_spawn_relaunch_refuses_a_live_herdr_slot() {
+  local dir out rc
+  dir=$(new_case herdr-live hm4)
+  add_herdr_scout_task "$dir" hm4 live
+  export FM_FAKE_HERDR_STATE="$dir/herdr-state.json" FM_FAKE_HERDR_LOG="$dir/herdr.log"
+  out=$(run_spawn "$dir" hm4 --relaunch --harness pi); rc=$?
+  unset FM_FAKE_HERDR_STATE FM_FAKE_HERDR_LOG
+  expect_code 1 "$rc" "a live Herdr slot should refuse"
+  assert_contains "$out" "positively agent-free endpoint" \
+    "the live-slot refusal should retain the lifecycle safety boundary"
+  assert_no_grep $'\x1ftab\x1fcreate' "$dir/herdr.log" "a live slot must not create a replacement tab"
+  pass "fm-spawn --relaunch: refuses a live Herdr slot"
+}
+
+test_spawn_relaunch_refuses_malformed_herdr_identity() {
+  local dir out rc
+  dir=$(new_case herdr-malformed hm5)
+  add_herdr_scout_task "$dir" hm5 missing-slot
+  printf 'herdr_tab_id=t-extra\n' >> "$dir/home/state/hm5.meta"
+  export FM_FAKE_HERDR_STATE="$dir/herdr-state.json" FM_FAKE_HERDR_LOG="$dir/herdr.log"
+  out=$(run_spawn "$dir" hm5 --relaunch --harness pi); rc=$?
+  unset FM_FAKE_HERDR_STATE FM_FAKE_HERDR_LOG
+  expect_code 1 "$rc" "ambiguous Herdr metadata should refuse"
+  assert_contains "$out" "malformed or inconsistent" \
+    "the refusal should identify malformed Herdr endpoint metadata"
+  assert_no_grep $'\x1ftab\x1fcreate' "$dir/herdr.log" "malformed metadata must not create a replacement tab"
+  pass "fm-spawn --relaunch: refuses malformed Herdr endpoint identity"
+}
+
 test_same_harness_relaunch_keeps_identity_and_reuses_the_endpoint
 test_relaunch_preserves_durable_task_metadata
 test_relaunch_serializes_concurrent_durable_metadata_publication
@@ -1344,3 +1581,9 @@ test_spawn_relaunch_refuses_a_live_agent
 test_spawn_relaunch_refuses_contradicting_flags
 test_spawn_relaunch_refuses_an_unrecorded_task
 test_spawn_relaunch_refuses_a_pane_outside_the_worktree
+test_spawn_relaunch_replaces_a_missing_herdr_slot_in_place
+test_control_relaunch_recovers_a_missing_herdr_slot
+test_spawn_relaunch_refuses_missing_herdr_workspace
+test_spawn_relaunch_refuses_a_conflicting_herdr_task_label
+test_spawn_relaunch_refuses_a_live_herdr_slot
+test_spawn_relaunch_refuses_malformed_herdr_identity


### PR DESCRIPTION
## Intent

The developer wanted to repair and validate Firstmate’s supervised relaunch path for ordinary Pi scouts whose recorded Herdr runtime slot disappeared, reusing the exact existing isolated copy and preserving authoritative task records without creating worktrees or duplicates. The repair had to recover one replacement slot, retain fail-closed identity checks and refusal behavior, add lifecycle regression tests, support Pi with the configured OpenAI Luna profile, and avoid touching live Herdr sessions or preserved CipherOS copies. After committing the implementation as 853b69d, they wanted no-mistakes validation rerun with the original intent using verified Codex, without editing the implementation or bypassing gates with --yes.

## What Changed

- Added supervised Herdr relaunch recovery for missing recorded runtime slots, reusing the existing isolated copy with fail-closed tab/pane identity checks and session-lock serialization.
- Updated FirstMate control/spawn handling and documented the recovery path.
- Added lifecycle regression coverage; the full validation pipeline passed, including review, tests, documentation, lint, and push.

## Risk Assessment

✅ Low: The final change serializes the complete Herdr relaunch transaction under the session lock and preserves the prior cleanup and identity-verification safeguards; no additional source-level defects were substantiated.

## Testing

Ran the focused relaunch lifecycle test twice, including missing-Herdr-slot recovery, exact workspace/worktree reuse, replacement confirmation, and fail-closed refusal cases; captured the passing end-user CLI transcript and confirmed no worktree changes.

<details>
<summary>Evidence: Focused relaunch regression transcript</summary>

<code>exit_code=0&#10;ok - fm-spawn --relaunch: replaces one missing Herdr slot in the recorded workspace and copy&#10;ok - fm-control relaunch: recovers a missing Herdr slot and waits on its exact replacement&#10;ok - fm-spawn --relaunch: refuses when the recorded Herdr workspace is missing&#10;ok - fm-spawn --relaunch: refuses an ambiguous same-label Herdr record&#10;ok - fm-spawn --relaunch: refuses a live Herdr slot&#10;ok - fm-spawn --relaunch: refuses malformed Herdr endpoint identity</code>

```text
ok - fm-control relaunch: a same-harness relaunch replaces the agent in the same endpoint and worktree
ok - fm-control relaunch: durable task metadata survives replacement launch publication
ok - fm-control relaunch: trace and concurrent task metadata publications serialize
ok - fm-control relaunch: disabling tracing clears metadata and pane context
ok - fm-control relaunch: the progress note lands in the instructions the replacement reads
ok - fm-control relaunch: a ship task refuses without the progress note its replacement needs
ok - fm-control relaunch: switching harness is one ordinary relaunch, and the old wiring goes with the old agent
ok - fm-control relaunch: a harness switch resets model and effort unless they are named too
ok - fm-control relaunch: a prefixed recorded harness can switch adapters transactionally
ok - fm-control relaunch: a prefixed command requires an explicit replacement harness
ok - fm-control relaunch: a same-harness relaunch keeps the profile axes it was running with
ok - fm-control relaunch: explicit model and effort win over the recorded ones
ok - fm-control relaunch: refuses to relaunch onto an adapter with no verified mechanics
ok - fm-control relaunch: the retired incarnation's global turn-end token is revoked
ok - fm-control relaunch: wiring cleanup failure refuses replacement arming
ok - fm-control-lib: one owner resolves each harness's turn-end registry entry, and refuses a malformed token
ok - fm-control relaunch: a secondmate relaunch re-resolves its durable configured harness pin
ok - fm-control relaunch: invalid configured effort is ignored before stop
ok - fm-control relaunch: an adapter unverified for this task kind refuses before the agent is stopped
ok - fm-control relaunch: explicit secondmate harness resets unnamed profile axes
ok - fm-control relaunch: a ship task keeps its recorded harness instead of re-reading crew config
ok - fm-spawn --relaunch: with no explicit harness it reuses the task's recorded one, never the crew default
ok - fm-spawn --relaunch: wiring armed under a prefixed harness name is still retired
ok - fm-spawn --relaunch: switching away from muse retires its session binding
ok - fm-control relaunch: an unaccountable local copy refuses before the agent is touched
ok - fm-control relaunch: a worker with nothing to work from is never launched
ok - fm-control relaunch: a refusal before the agent is stopped leaves the durable record untouched
ok - fm-control relaunch: checkpoint inspection failures refuse before stopping
ok - fm-control relaunch: a launch failure after the stop keeps the prior record and reports the real state
ok - fm-control relaunch: unpublished rollback keeps concurrent durable metadata
ok - fm-control relaunch: post-publication failure keeps the new durable record
ok - fm-control relaunch: partial stop reconciles actual agent state
ok - fm-control relaunch: failed journal replacement preserves durable phase
ok - fm-spawn relaunch: prepublication abort removes replacement state
ok - fm-control relaunch: the checkpoint records the exact unlanded work it preserved
ok - fm-control relaunch: a secondmate's child work is accounted for and its charter is left alone
ok - fm-control relaunch: a secondmate home that is not this secondmate's is refused
ok - fm-control relaunch: unreadable and untraversable child state fails checkpoint
ok - fm-control relaunch: two control actions on one task serialize instead of interleaving
ok - fm-spawn relaunch: direct entry participates in lifecycle serialization
ok - fm-promote: promotion participates in lifecycle serialization
ok - fm-spawn --relaunch: refuses to launch a second agent into a live endpoint
ok - fm-spawn --relaunch: every identity axis comes from the record, and a contradicting flag refuses
ok - fm-spawn --relaunch: an unrecorded task is refused
ok - fm-spawn --relaunch: refuses to start a replacement outside the copy holding the work
ok - fm-spawn --relaunch: replaces one missing Herdr slot in the recorded workspace and copy
ok - fm-control relaunch: recovers a missing Herdr slot and waits on its exact replacement
ok - fm-spawn --relaunch: refuses when the recorded Herdr workspace is missing
ok - fm-spawn --relaunch: refuses an ambiguous same-label Herdr record
ok - fm-spawn --relaunch: refuses a live Herdr slot
ok - fm-spawn --relaunch: refuses malformed Herdr endpoint identity
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (3) ✅</summary>

- 🚨 `bin/backends/herdr.sh:2167` - If replacement creation succeeds but its response or any subsequent tab/pane verification fails, this function returns without removing the newly created tab/pane. The caller only arms `RELAUNCH_REPLACEMENT_ENDPOINT_PENDING` after a successful return, so `spawn_abort_cleanup` cannot clean up this unrecorded endpoint; when an old tab existed, it may already have been closed, leaving the durable record stale and the task stranded.
- 🚨 `bin/backends/herdr.sh:2127` - The conflict check only rejects a recorded pane attached to another tab when the recorded tab is absent. If the recorded tab still exists but has no pane while the recorded pane ID is attached elsewhere, recovery proceeds and replaces the task tab despite an exact pane-identity conflict. This violates the fail-closed identity boundary and can relaunch against an ambiguous/stale record.

🔧 Fix: Harden Herdr relaunch cleanup and pane identity checks
1 error still open:
- 🚨 `bin/backends/herdr.sh:2182` - The cleanup added for verification failures removes the replacement tab, but the original recorded tab has already been closed at this point. If any post-create verification fails, the durable task record still points to the now-closed original endpoint, leaving the task unrelaunchable despite the cleanup. Verify the replacement fully before closing the old tab, or preserve a rollback path.

🔧 Fix: Verify replacements before closing recorded Herdr tabs
1 error still open:
- 🚨 `bin/backends/herdr.sh:2207` - The relaunch helper performs its initial identity/state reads, replacement creation, and closing of the recorded tab without acquiring the Herdr session presentation lock. Another lifecycle/projection operation can restore or modify the recorded tab between the missing-slot check and line 2207; the helper would then close a live/reused endpoint while publishing the replacement. Serialize the whole recovery transaction under the session lock (or revalidate the exact old tab and pane immediately before closing).

🔧 Fix: Serialize Herdr relaunch under the session lock
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-control-relaunch.test.sh`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Fixed Herdr relaunch lint error and passed fm-lint
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
