### PR TITLE
fix(brief): make a ship brief's terminal condition unambiguous

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -49,6 +49,16 @@
 # declared-external-wait verb (FM_CLASSIFY_PAUSED_VERB, default "paused") from
 # "blocked:": pause for a known external wait expected to clear on its own,
 # blocked when firstmate must act.
+# Every generated ship brief names exactly ONE terminal condition, and "done:" is
+# reserved for that event alone, because firstmate acts on it as a reviewable
+# result. A no-mistakes brief therefore reports its finished implementation as
+# "working: implemented, ready for validation" and stops there for firstmate's
+# validation instruction - the single stop the ship status protocol's "never end a
+# turn on working:" rule exempts, named where that rule is stated. That redirect
+# replaced an instruction to append "done: {summary}" at the same point, which four
+# consecutive no-mistakes workers followed without ever starting the pipeline; the
+# status protocol now states the general rule rather than citing that episode,
+# since the instruction that produced it no longer exists to be corrected.
 # Ship tasks include a project-memory section so durable project-intrinsic
 # learnings can be committed to AGENTS.md through the project's delivery path;
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
@@ -359,7 +369,7 @@ case "$MODE" in
 # Definition of done
 Delivery contract: mode=direct-PR
 This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
-The task is complete only when committed on your branch.
+Its one terminal condition is the open PR; committed work alone is not done, and uncommitted work cannot ship.
 When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
@@ -371,7 +381,7 @@ EOF
 # Definition of done
 Delivery contract: mode=local-only
 This task ships **local-only**: no remote, no PR, no pipeline.
-The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
+Its one terminal condition is your work committed on branch \`fm/$ID\` as a clean fast-forward. Do NOT push, do NOT open a PR, do NOT merge.
 Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
 When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
 The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
@@ -384,8 +394,8 @@ EOF
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 Delivery contract: mode=no-mistakes
-The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
+This task has exactly one terminal condition: a PR whose CI is green. Finishing the implementation is not it.
+When you believe the implementation is complete, commit it on your branch - uncommitted work cannot ship - then append \`working: implemented, ready for validation\` to the status file and stop there.
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
@@ -433,12 +443,16 @@ $RULE1
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
+   \`done:\` reports ONLY the one terminal condition named under Definition of done, never
+   that your code works: it tells firstmate a reviewable result exists. Report every
+   earlier phase, however finished the implementation feels, with \`working:\`.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
    would act on (setup done, bug reproduced, fix implemented, validation passed) and the
    needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
    firstmate reads your pane for that.
    A mid-task \`working:\` line (including setup complete) is nonterminal: do not end the
-   turn after it; continue the same stage until a defined \`done:\` gate under Definition of done.
+   turn after it, unless Definition of done names that exact line as a stop point; otherwise
+   continue the same stage until you reach its terminal condition.
    Use \`$PAUSED_VERB: {why}\` - distinct from \`blocked:\` - ONLY when you are deliberately idling on a
    known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
    a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -354,6 +354,63 @@ test_no_mistakes_dod_wording() {
   pass "fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe"
 }
 
+# Every generated brief must instruct exactly ONE `done:` append, and it must be
+# that delivery mode's real end state. The no-mistakes brief used to instruct a
+# `done: {summary}` on the finished implementation as well, and four consecutive
+# workers reported done with no pipeline run because nothing checked the generated
+# text. Counting the instructions is what makes a second terminal-sounding `done:`
+# fail here instead of in a worker's status file.
+test_brief_instructs_exactly_one_terminal_done() {
+  local home id brief kind flag terminal count
+  home="$TMP_ROOT/terminal-condition-home"
+  mkdir -p "$home/data"
+  while IFS='|' read -r kind flag terminal; do
+    [ -n "$kind" ] || continue
+    id="brief-terminal-$kind"
+    # shellcheck disable=SC2086  # flag is an intentional word-split arg list
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj $flag >/dev/null 2>&1 \
+      || fail "$kind: brief should scaffold"
+    brief="$home/data/$id/brief.md"
+    count=$(grep -c 'append `done' "$brief")
+    [ "$count" -eq 1 ] \
+      || fail "$kind: brief instructs $count \`done:\` appends; it must name exactly one terminal condition"
+    assert_grep "$terminal" "$brief" \
+      "$kind: the single \`done:\` instruction is not this mode's terminal condition"
+  done <<'ROWS'
+no-mistakes|--mode no-mistakes|append `done: PR {url} checks green`
+direct-PR|--mode direct-PR|append `done: PR {url}` to the status file
+local-only|--mode local-only|append `done: ready in branch fm/brief-terminal-local-only`
+scout|--scout|append `done: {one-line conclusion}` to the status file
+ROWS
+  pass "fm-brief.sh: every brief instructs exactly one terminal \`done:\` append"
+}
+
+# A rule that only forbids leaves the finished implementation with nowhere to go,
+# which is how the mislabelled `done:` arose. The no-mistakes brief must name the
+# non-terminal line explicitly, state that the green PR is the only terminal
+# condition, and exempt that one named stop from the "never end a turn on
+# `working:`" rule, or the worker is left with two contradictory instructions.
+test_no_mistakes_brief_redirects_the_finished_implementation() {
+  local home id brief
+  home="$TMP_ROOT/implementation-report-home"
+  mkdir -p "$home/data"
+  id="brief-impl-report-b2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1 \
+    || fail "no-mistakes brief should scaffold"
+  brief="$home/data/$id/brief.md"
+  assert_grep "exactly one terminal condition: a PR whose CI is green" "$brief" \
+    "no-mistakes brief did not state the green PR as its only terminal condition"
+  assert_grep "append \`working: implemented, ready for validation\` to the status file and stop there" "$brief" \
+    "no-mistakes brief left the finished implementation with no non-terminal line to report"
+  assert_no_grep "append \`done: {summary}\`" "$brief" \
+    "no-mistakes brief reinstated a pre-validation \`done:\`"
+  assert_grep "\`done:\` reports ONLY the one terminal condition named under Definition of done" "$brief" \
+    "status protocol lost the meaning of \`done:\`"
+  assert_grep "unless Definition of done names that exact line as a stop point" "$brief" \
+    "status protocol forbids the very stop the no-mistakes definition of done requires"
+  pass "fm-brief.sh: the no-mistakes brief redirects a finished implementation to a non-terminal report"
+}
+
 test_ship_project_memory_wording() {
   local home id brief
   home="$TMP_ROOT/project-memory-home"
@@ -719,6 +776,8 @@ test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
+test_brief_instructs_exactly_one_terminal_done
+test_no_mistakes_brief_redirects_the_finished_implementation
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path


### PR DESCRIPTION
## Intent

Make a generated ship brief unambiguous about which event the word `done` labels, so a worker on a mode=no-mistakes task cannot honestly believe it has finished before its validation pipeline has run.

THE FAILURE THIS FIXES. On 2026-08-08 and 2026-08-09, four separate mode=no-mistakes workers appended a line of the form `done: <the change works>` to their status file without ever starting the pipeline. Every one picked the pipeline up immediately when told to, and none argued. The workers were not confused about whether a pipeline existed or what it was for; they were confused about which event in their own task the word `done` names. That is a defect in the brief's wording, not four careless workers: a wording that four independent readers take the same wrong way is the wording's problem. The consequence is not cosmetic - `done` is a supervisor-actionable terminal signal that firstmate acts on to check a PR, arm a merge poll, and record completion, so a `done` meaning 'the code works' makes the supervisor believe a reviewable result exists when none does, costing a full supervision round trip every time.

SCOPE. bin/fm-brief.sh, specifically its status-protocol section and its per-mode definition-of-done sections; both are generated into every ship brief and both were in scope. The task also required applying the same judgment to the other delivery modes: direct-PR has its own terminal condition and local-only has no PR at all, so each one's `done` had to be checked on its own terms rather than assuming only no-mistakes was affected.

TWO DECISIONS THE TASK DELEGATED TO ME, WITH THE ANSWERS I CHOSE.
(1) Whether reaching the end of the implementation should be an explicit `working:` line so the worker has a correct place to put the report it currently mislabels as `done` - the task's stated reasoning being that a rule that only forbids does worse than one that redirects. I decided yes. The no-mistakes brief now names `working: implemented, ready for validation` explicitly and tells the worker to stop there for firstmate's validation instruction.
(2) Whether the status protocol should name this specific past failure directly. The argument against is that it dates the document; the argument for is that four readers made the same inference, suggesting the correct reading is not self-evident from a general statement. I decided NOT to cite the episode in the generated brief text, on this evidence: the root cause I verified was that the brief LITERALLY INSTRUCTED a second `done: {summary}` append on the finished implementation, so the four workers were following an instruction rather than misreading a general rule. Once that instruction is replaced by an explicit redirect, a dated caution would outlive its own cause. What was genuinely missing - a general statement of what `done:` means - never existed in the status protocol at all and is now present without dating the document. The incident reasoning is recorded in bin/fm-brief.sh's header comment, which --help prints and which a maintainer reads before touching this text; that is where a later reader will find it.

ROOT CAUSE VERIFIED, NOT ASSUMED. The task flagged the adjacency of 'The task is complete only when committed on your branch' to the final `done: PR {url} checks green` instruction as a strong candidate cause and asked me to verify rather than assume it. I verified it and found a stronger one: the mode=no-mistakes definition of done instructed TWO `done:` appends - `done: {summary}` after the implementation, and `done: PR {url} checks green` after CI. The 'complete only when committed' adjacency was an amplifier, not the cause.

WHAT CHANGED IN bin/fm-brief.sh.
- no-mistakes definition of done: states one terminal condition (a PR whose CI is green), says finishing the implementation is not it, and redirects the finished implementation to `working: implemented, ready for validation` with an explicit instruction to stop there. The pre-existing handshake is deliberately preserved: AGENTS.md section 7 has firstmate trigger validation on the same worker after its implementation commit, so the worker must still stop and wait - only the label moved off a terminal verb. The final `done: PR {url} checks green` instruction is unchanged.
- Ship status protocol (rule 4, shared by all three ship modes): adds a general statement that `done:` reports only the one terminal condition named under Definition of done and never that the code works, with every earlier phase reported as `working:`. It also amends the existing 'a mid-task working: line is nonterminal, do not end the turn after it' sentence with a carve-out for a stop point the Definition of done names explicitly. That carve-out is load-bearing: without it the status protocol would directly contradict the new no-mistakes definition of done, leaving the worker with two conflicting instructions.
- direct-PR: replaced 'The task is complete only when committed on your branch' with a statement that the open PR is its one terminal condition and that committed work alone is not done. Only one `done:` was ever instructed here, so the defect was weaker, but the identical ambiguous sentence was present.
- local-only: its terminal condition genuinely is the committed branch, so the wording was already coincident with its single `done:`; I made the sentence name the clean fast-forward state that its own next line requires, which the previous 'complete only when committed' undersold.
- scout: deliberately left unchanged. It already has a single unambiguous terminal condition (the report, behind the decision-hold completion gate its definition of done already enforces), and no scout ever mislabeled, so adding the sentence would cost a line in every scout brief for no evidenced defect.
- Header comment: records the one-terminal-condition rule, the named non-terminal report, the reason the working:-stop carve-out must stay named where the rule is stated, and a concise statement of the incident so a future maintainer does not 'simplify' the handshake back into a `done:`.

CONSTRAINTS I WAS GIVEN AND HELD TO.
- The brief scaffold is a safety contract: I did not weaken, reorder, or drop any existing safety instruction while rewording the terminal condition - specifically the worktree-isolation assertion, the ask-user escalation rule, and the no---yes rule are all untouched. I was told that if a safety instruction and a clarity improvement genuinely conflict, keep the safety instruction and report the conflict rather than resolving it myself. One near-conflict arose (rule 4's 'never end a turn on a working: line' versus the new no-mistakes stop) and I resolved it by narrowly exempting only the stop that the Definition of done names explicitly, which preserves the rule's force everywhere else; this is the one place where a reviewer should look hardest.
- No length for its own sake: these sections are read by every crewmate at the start of every task, so a longer brief has a real recurring cost. The per-mode definitions of done are the same line count as before; the status protocol grew by three lines total.
- This is firstmate's shared tracked material, so I loaded the firstmate-coding-guidelines skill before editing, and followed its repo style rules (plain dash never an em dash, shellcheck-clean bin scripts, colocated tests named <subject>.test.sh extending the existing runner, tests that exercise a public interface rather than asserting implementation-source bytes).

DEFINITION OF DONE I WAS HELD TO, AND THE PROOF REQUIRED. A generated mode=no-mistakes ship brief states exactly one terminal condition and it is the green PR; a reader who has just finished implementing has an unambiguous, explicitly named non-terminal event to report instead. I was told to prove this rather than assert it: generate a brief in each delivery mode from the changed script and show the resulting terminal wording in the PR body, and if the repository has a test covering the generated brief's content, extend it so the terminal condition is asserted mechanically - and that if it does not, adding one is worth it, since this defect reached four workers precisely because nothing checked the generated text.

WHAT I DID FOR THAT PROOF. I generated a brief in all three ship modes plus scout from the changed script and confirmed each instructs exactly one `done:` append: no-mistakes 'done: PR {url} checks green', direct-PR 'done: PR {url}', local-only 'done: ready in branch fm/<id>', scout 'done: {one-line conclusion}'. The repository did have a test covering generated brief content (tests/fm-brief.test.sh), so I extended it with two tests registered in its existing runner list: test_brief_instructs_exactly_one_terminal_done counts the `done:` append instructions in every generated brief across all four scaffold kinds and asserts the single instruction is that mode's real end state, and test_no_mistakes_brief_redirects_the_finished_implementation pins the green-PR terminal statement, the named non-terminal working: line, the absence of the old pre-validation `done: {summary}`, and the status protocol's meaning-of-done sentence and its stop-point carve-out. I verified both tests FAIL against the pre-change script by running them against a mirrored root holding git show HEAD:bin/fm-brief.sh - the count test fails with 'no-mistakes: brief instructs 2 done: appends' and the second with 'did not state the green PR as its only terminal condition' - and pass against the change, with the whole file green at 22 ok. bin/fm-lint.sh exits 0.

MECHANISM CHECK BEHIND THE CHOSEN FIX, WORTH A REVIEWER'S ATTENTION. Switching the implementation report from a terminal `done:` to a nonterminal `working:` had to keep firstmate reliably woken. I confirmed in bin/fm-classify-lib.sh that a `working:` line is absorbed only when crew_absorb_class returns 'working', which requires positive evidence of an active no-mistakes run step or a busy pane; a worker that appends the line and then stops its turn is not provably working, so the signal surfaces, with the turn-end marker as the backstop for the race where the pane is still busy at the moment the wake is processed. I also checked that no other owner depends on the removed wording: bin/fm-spawn.sh couples only to the unchanged 'Delivery contract: mode=<mode>' line, and no doc or skill restates the implementation-complete convention.

DELIVERY. Mode is no-mistakes with a PR; AGENTS.md is unchanged on purpose, since section 11 already records that bin/fm-brief.sh and its help own the scaffold's status protocol and delivery-mode definitions of done, so no instruction-surface edit was needed and the size-discipline rule argues against one. An earlier run of this pipeline passed review, test, document and lint with zero findings and then failed at push because the gate's push target lacked write access; that has been fixed outside this branch by registering the fork as the push target while origin stays upstream, and no git remote in this checkout was changed.

## What Changed

- `bin/fm-brief.sh`'s no-mistakes definition of done now names one terminal condition (a PR whose CI is green) and redirects a finished implementation to `working: implemented, ready for validation` instead of the old `done: {summary}` append, removing the second `done:` instruction that caused workers to report the implementation itself as finished.
- The shared ship status protocol (rule 4) adds a general statement that `done:` reports only the single terminal condition named under Definition of done, never that the code works, and carves out an explicit exemption to the "never end a turn on `working:`" rule for the one stop point Definition of done names.
- direct-PR's and local-only's definitions of done are reworded to state their own terminal condition explicitly (open PR; clean fast-forward commit on the delivery branch) in place of the previously ambiguous "complete only when committed" phrasing; scout is left unchanged.
- A header comment records the rationale and the incident that motivated the change.
- `tests/fm-brief.test.sh` gains two tests: one asserting each generated brief (across all delivery modes) instructs exactly one terminal `done:` append matching that mode's real end state, and one pinning the no-mistakes brief's green-PR terminal condition, its non-terminal `working:` redirect, and the status protocol's meaning-of-done wording.

## Risk Assessment

✅ Low: The change is a well-scoped wording fix to generated ship-brief text across three delivery modes plus the shared status protocol; I regenerated briefs for all four scaffold kinds (no-mistakes, direct-PR, local-only, scout) and confirmed each names exactly one `done:` terminal condition matching the intent's stated proof, verified the `working:` absorption mechanism claim against bin/fm-classify-lib.sh, confirmed no stale references to the removed `done: {summary}` instruction remain, and ran shellcheck/fm-lint.sh clean.

## Testing

Targeted tests/fm-brief.test.sh passes fully at the target commit (22/22), the two tests added for this change were verified to actually fail against the pre-change script (not tautological), and end-to-end generation of real ship briefs in all four delivery modes confirms the rendered text matches the claimed fix: no-mistakes now redirects a finished implementation to a non-terminal `working:` line and keeps a single `done:` reserved for the green-PR event, while direct-PR, local-only, and scout each retain exactly one correctly-worded terminal `done:`. No issues found; worktree left clean.

<details>
<summary>Evidence: Generated no-mistakes ship brief (full)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of some-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/evidence-brief-no-mistakes`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/tmp.EppaHmRTvG/state/evidence-brief-no-mistakes.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   `done:` reports ONLY the one terminal condition named under Definition of done, never
   that your code works: it tells firstmate a reviewable result exists. Report every
   earlier phase, however finished the implementation feels, with `working:`.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it, unless Definition of done names that exact line as a stop point; otherwise
   continue the same stage until you reach its terminal condition.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/dev/.no-mistakes/worktrees/5480956096ee/01KZQ2QT42DTCWC29AKPZEHGXZ/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/dev/.no-mistakes/worktrees/5480956096ee/01KZQ2QT42DTCWC29AKPZEHGXZ/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
This task has exactly one terminal condition: a PR whose CI is green. Finishing the implementation is not it.
When you believe the implementation is complete, commit it on your branch - uncommitted work cannot ship - then append `working: implemented, ready for validation` to the status file and stop there.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Generated direct-PR ship brief (full)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of some-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/evidence-brief-direct-PR`

# Rules
1. Never push to the default branch (push only your `fm/evidence-brief-direct-PR` branch). Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/tmp.EppaHmRTvG/state/evidence-brief-direct-PR.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   `done:` reports ONLY the one terminal condition named under Definition of done, never
   that your code works: it tells firstmate a reviewable result exists. Report every
   earlier phase, however finished the implementation feels, with `working:`.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it, unless Definition of done names that exact line as a stop point; otherwise
   continue the same stage until you reach its terminal condition.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/dev/.no-mistakes/worktrees/5480956096ee/01KZQ2QT42DTCWC29AKPZEHGXZ/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/dev/.no-mistakes/worktrees/5480956096ee/01KZQ2QT42DTCWC29AKPZEHGXZ/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=direct-PR
This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
Its one terminal condition is the open PR; committed work alone is not done, and uncommitted work cannot ship.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
```
</details>
<details>
<summary>Evidence: Generated local-only ship brief (full)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of some-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/evidence-brief-local-only`

# Rules
1. Never push to any remote and never open a PR. Work only on your `fm/evidence-brief-local-only` branch; firstmate handles the merge into local `main`.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/tmp.EppaHmRTvG/state/evidence-brief-local-only.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   `done:` reports ONLY the one terminal condition named under Definition of done, never
   that your code works: it tells firstmate a reviewable result exists. Report every
   earlier phase, however finished the implementation feels, with `working:`.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it, unless Definition of done names that exact line as a stop point; otherwise
   continue the same stage until you reach its terminal condition.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/dev/.no-mistakes/worktrees/5480956096ee/01KZQ2QT42DTCWC29AKPZEHGXZ/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/dev/.no-mistakes/worktrees/5480956096ee/01KZQ2QT42DTCWC29AKPZEHGXZ/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=local-only
This task ships **local-only**: no remote, no PR, no pipeline.
Its one terminal condition is your work committed on branch `fm/evidence-brief-local-only` as a clean fast-forward. Do NOT push, do NOT open a PR, do NOT merge.
Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
When it is implemented and committed, append `done: ready in branch fm/evidence-brief-local-only` to the status file and stop.
The configured merge authority approves the ready branch, then firstmate merges it into local `main` through the guarded fast-forward path.
```
</details>
<details>
<summary>Evidence: Generated scout brief (full, unchanged mode, for comparison)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of some-proj, at a detached HEAD on a clean default branch.
This is a SCOUT task: the deliverable is a written report, not a PR.
The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
The report is the only thing that survives, so anything worth keeping must be in it.

# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/tmp.EppaHmRTvG/state/evidence-brief-scout.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
   FYI progress lines; firstmate reads your pane for that.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
   firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
   treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Definition of done
Write your findings to `/tmp/tmp.EppaHmRTvG/data/evidence-brief-scout/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
Before reporting done, read and follow `/home/dev/.no-mistakes/worktrees/5480956096ee/01KZQ2QT42DTCWC29AKPZEHGXZ/.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
```
</details>
<details>
<summary>Evidence: no-mistakes brief: terminal-condition wording (working: redirect + green-PR done:)</summary>

```text
61:...append `working: implemented, ready for validation` to the status file and stop there.
75:After /no-mistakes reports CI green... append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Proof the two new tests fail against the pre-change script (base commit)</summary>

```text
not ok - no-mistakes: brief instructs 2 `done:` appends; it must name exactly one terminal condition
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-brief.test.sh (target commit 6cb4030) — 22/22 ok`
- <code>bash tests/fm-brief.test.sh copied onto base commit f74d9e4 worktree — new test_brief_instructs_exactly_one_terminal_done fails as expected with &#39;no-mistakes: brief instructs 2 `done:` appends&#39;</code>
- `FM_HOME=<tmp> bin/fm-brief.sh <id> some-proj --mode no-mistakes — inspected generated brief.md for working:/done: wording`
- `FM_HOME=<tmp> bin/fm-brief.sh <id> some-proj --mode direct-PR — inspected generated brief.md`
- `FM_HOME=<tmp> bin/fm-brief.sh <id> some-proj --mode local-only — inspected generated brief.md`
- `FM_HOME=<tmp> bin/fm-brief.sh <id> some-proj --scout — inspected generated brief.md (unchanged mode, sanity check)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
