### PR TITLE
fix(spawn): refresh pooled worktrees from origin before launch

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -130,6 +130,10 @@
 #   default-branch commit when safe; skipped syncs warn and launch unchanged.
 #   Ship/scout spawns refuse to launch unless the resolved task path is a real
 #   git worktree root distinct from the primary project checkout.
+#   Before the worker starts, each clean pooled worktree fetches origin, resolves
+#   its current remote default branch, and resets to its tip; an unreachable,
+#   unresolved, or non-clean base refuses the spawn rather than risking a PR
+#   based on stale history.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -1647,6 +1651,48 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   fi
 }
 
+freshen_spawn_worktree_base() {  # <worktree>
+  local worktree=$1 default target expected actual status
+  if ! git -C "$worktree" fetch --quiet origin; then
+    echo "error: could not fetch origin for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+    return 1
+  fi
+  if ! git -C "$worktree" remote set-head origin --auto >/dev/null 2>&1; then
+    echo "error: could not resolve origin's current default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+    return 1
+  fi
+  default=$(default_branch "$worktree") || {
+    echo "error: could not determine origin's default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+    return 1
+  }
+  target="origin/$default"
+  if ! git -C "$worktree" fetch --quiet origin "+refs/heads/$default:refs/remotes/origin/$default"; then
+    echo "error: could not fetch '$target' for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+    return 1
+  fi
+  expected=$(git -C "$worktree" rev-parse --verify --quiet "$target^{commit}" 2>/dev/null) || {
+    echo "error: '$target' is not a commit for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+    return 1
+  }
+  status=$(git -C "$worktree" status --porcelain) || {
+    echo "error: could not inspect pooled worktree '$worktree' before refreshing its base" >&2
+    return 1
+  }
+  if [ -n "$status" ]; then
+    echo "error: pooled worktree '$worktree' is not clean; refusing to discard uncommitted work while refreshing its base" >&2
+    return 1
+  fi
+  if ! git -C "$worktree" reset --hard "$target" >/dev/null; then
+    echo "error: could not reset pooled worktree '$worktree' to '$target'; refusing to launch from a potentially stale base" >&2
+    return 1
+  fi
+  actual=$(git -C "$worktree" rev-parse --verify --quiet HEAD 2>/dev/null || true)
+  if [ "$actual" != "$expected" ]; then
+    echo "error: pooled worktree '$worktree' is at '${actual:-unknown}', not current '$target' ('$expected'); refusing to launch" >&2
+    return 1
+  fi
+}
+
 herdr_projection_meta_field_exact() {  # <meta> <key>
   local meta=$1 key=$2 count
   [ -f "$meta" ] && [ ! -L "$meta" ] || return 1
@@ -2130,6 +2176,9 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   fi
 
   validate_spawn_worktree "treehouse get" "$T"
+fi
+if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
+  freshen_spawn_worktree_base "$WT" || exit 1
 fi
 
 # Per-task temp root: /tmp/fm-<id>/ with Go's build temp nested at gotmp/. Go won't

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -130,10 +130,10 @@
 #   default-branch commit when safe; skipped syncs warn and launch unchanged.
 #   Ship/scout spawns refuse to launch unless the resolved task path is a real
 #   git worktree root distinct from the primary project checkout.
-#   Before the worker starts, each clean pooled worktree fetches origin, resolves
-#   its current remote default branch, and resets to its tip; an unreachable,
-#   unresolved, or non-clean base refuses the spawn rather than risking a PR
-#   based on stale history.
+#   Before a fresh ship or scout worker starts, its clean task worktree fetches
+#   origin, resolves the current remote default branch, and resets to its tip.
+#   An unreachable origin, unresolved default branch, or non-clean worktree
+#   refuses the spawn rather than risking a PR based on stale history.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,6 +142,8 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
+`fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
+Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.
 Its operating checkout (`FM_ROOT`) and the disposable crewmate worktrees are all linked git worktrees of the same repository, so the valid discriminator is branch state, not whether the checkout is linked.

--- a/tests/fm-backend-autodetect-smoke.test.sh
+++ b/tests/fm-backend-autodetect-smoke.test.sh
@@ -98,6 +98,8 @@ git -C "$PROJ" init -q
 printf '# scratch\n' > "$PROJ/README.md"
 git -C "$PROJ" add README.md
 git -C "$PROJ" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+git clone --quiet --bare "$PROJ" "$PROJ.origin.git"
+git -C "$PROJ" remote add origin "file://$PROJ.origin.git"
 
 # --- spawn with NO explicit backend config; HERDR_ENV=1 is the only marker --
 

--- a/tests/fm-backend-herdr-launcher-workspace-e2e.test.sh
+++ b/tests/fm-backend-herdr-launcher-workspace-e2e.test.sh
@@ -86,6 +86,8 @@ make_scratch_project() {  # <dir>
   printf '# scratch\n' > "$dir/README.md"
   git -C "$dir" add README.md
   git -C "$dir" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+  git clone --quiet --bare "$dir" "$dir.origin.git"
+  git -C "$dir" remote add origin "file://$dir.origin.git"
 }
 
 # make_workspace <label> -> "<workspace_id> <tab_id> <root_pane_id>"

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -378,6 +378,8 @@ make_project() {  # <dir>
   printf '# Herdr projection E2E fixture\n' > "$dir/README.md"
   git -C "$dir" add README.md
   git -C "$dir" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+  git clone --quiet --bare "$dir" "$dir.origin.git"
+  git -C "$dir" remote add origin "file://$dir.origin.git"
 }
 
 spawn_task() {  # <id> <home> <project>

--- a/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
+++ b/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
@@ -106,6 +106,8 @@ make_scratch_project() {  # <dir>
   printf '# scratch\n' > "$dir/README.md"
   git -C "$dir" add README.md
   git -C "$dir" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+  git clone --quiet --bare "$dir" "$dir.origin.git"
+  git -C "$dir" remote add origin "file://$dir.origin.git"
 }
 
 PROJ1="$TMP_ROOT/scratch-project-1"; make_scratch_project "$PROJ1"

--- a/tests/fm-gate-refuse.test.sh
+++ b/tests/fm-gate-refuse.test.sh
@@ -174,6 +174,7 @@ test_spawn_refuses_and_admits() {
   local home proj fakebin wt out rc
   home="$TMP/spawn-home"; mkdir -p "$home/data"
   proj=$(make_normal_repo "$TMP/spawn-proj")
+  fm_git_add_origin "$proj" "$TMP/spawn-origin.git"
   fakebin=$(make_spawn_fakebin "$TMP/spawn-fake")
   wt="$TMP/spawn-wt"
   git -C "$proj" worktree add -q --detach "$wt" >/dev/null 2>&1

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -75,12 +75,13 @@ EOF
 
 run_spawn() {
   local id=$1
+  shift
   FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
     FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
     FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
     FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" FM_FAKE_PANE_PATH="$POOL_DIR" \
     PATH="$FAKEBIN_DIR:$PATH" \
-    "$SPAWN" "$id" "$PROJECT_DIR" --mode no-mistakes --yolo off 2>&1
+    "$SPAWN" "$id" "$PROJECT_DIR" "$@" 2>&1
 }
 
 test_stale_pool_base_refreshes_before_branching() {
@@ -89,7 +90,7 @@ test_stale_pool_base_refreshes_before_branching() {
   rec=$(make_case current-base "$id")
   read_case_record "$rec"
 
-  out=$(run_spawn "$id")
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
   status=$?
   expect_code 0 "$status" "spawn should refresh a stale pooled worktree"
   assert_contains "$out" "spawned $id" "spawn did not report success"
@@ -97,6 +98,20 @@ test_stale_pool_base_refreshes_before_branching() {
   branch_head=$(git -C "$POOL_DIR" rev-parse HEAD)
   [ "$branch_head" = "$current" ] || fail "spawn left the pooled worktree on stale history"
   [ "$branch_head" != "$INITIAL_SHA" ] || fail "fixture did not prove origin/main advanced past the pool base"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed spawn: %s\n' "$(printf '%s\n' "$out" | tail -n 1)"
+    printf '# observed base: HEAD=%s origin/main=%s advanced-main=%s\n' \
+      "$branch_head" "$current" "$(cat "$POOL_DIR/advanced-main.txt")"
+  fi
+
+  id='pool-current-base-repeat-r1'
+  mkdir -p "$HOME_DIR/data/$id"
+  printf 'brief for %s\n' "$id" > "$HOME_DIR/data/$id/brief.md"
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 0 "$status" "repeating the base refresh should be idempotent"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$current" ] \
+    || fail "an idempotent repeat moved the pool away from current origin/main"
 
   git -C "$POOL_DIR" checkout --quiet -b "fm/$id"
   git -C "$POOL_DIR" diff --exit-code origin/main...HEAD >/dev/null \
@@ -112,7 +127,7 @@ test_non_main_default_branch_refreshes_before_branching() {
   rec=$(make_case current-trunk "$id" trunk)
   read_case_record "$rec"
 
-  out=$(run_spawn "$id")
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
   status=$?
   expect_code 0 "$status" "spawn should refresh a stale pooled worktree on a non-main default branch"
   current=$(git -C "$POOL_DIR" rev-parse "origin/$DEFAULT_BRANCH")
@@ -130,18 +145,93 @@ test_unreachable_origin_refuses_stale_pool_base() {
   git -C "$POOL_DIR" remote set-url origin "file://$CASE_DIR/missing-origin.git"
   before=$(git -C "$POOL_DIR" rev-parse HEAD)
 
-  out=$(run_spawn "$id")
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
   status=$?
   [ "$status" -ne 0 ] || fail "spawn succeeded despite an unreachable origin"
   assert_contains "$out" "could not fetch origin" \
     "spawn did not clearly refuse an unreachable origin"
   after=$(git -C "$POOL_DIR" rev-parse HEAD)
   [ "$after" = "$before" ] || fail "spawn changed the pooled worktree after origin became unreachable"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed unreachable-origin refusal: %s\n' "$(printf '%s\n' "$out" | tail -n 1)"
+  fi
   pass "an unreachable origin refuses a potentially stale pooled worktree"
+}
+
+test_direct_pr_and_scout_refresh_before_launch() {
+  local rec id out status contract current
+  for contract in direct-pr scout; do
+    id="pool-${contract}-r3"
+    rec=$(make_case "$contract" "$id")
+    read_case_record "$rec"
+    if [ "$contract" = scout ]; then
+      out=$(run_spawn "$id" --scout)
+    else
+      out=$(run_spawn "$id" --mode direct-PR --yolo off)
+    fi
+    status=$?
+    expect_code 0 "$status" "$contract spawn should refresh a stale pooled worktree"
+    current=$(git -C "$POOL_DIR" rev-parse origin/main)
+    [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$current" ] \
+      || fail "$contract spawn did not start at current origin/main"
+    assert_grep 'must survive a newly spawned branch' "$POOL_DIR/advanced-main.txt" \
+      "$contract spawn omitted advanced-main content"
+    if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+      printf '# observed %s spawn: %s\n' "$contract" "$(printf '%s\n' "$out" | tail -n 1)"
+    fi
+  done
+  pass "direct-PR ships and scouts both refresh stale pooled worktrees before launch"
+}
+
+test_dirty_pool_refuses_without_discarding_work() {
+  local rec id out status before
+  id='pool-dirty-refusal-r4'
+  rec=$(make_case dirty-refusal "$id")
+  read_case_record "$rec"
+  before=$(git -C "$POOL_DIR" rev-parse HEAD)
+  printf 'keep this local work\n' > "$POOL_DIR/uncommitted.txt"
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn succeeded despite a dirty pooled worktree"
+  assert_contains "$out" "is not clean" "spawn did not clearly refuse a dirty pooled worktree"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
+    || fail "spawn moved HEAD while refusing a dirty pooled worktree"
+  assert_grep 'keep this local work' "$POOL_DIR/uncommitted.txt" \
+    "spawn discarded uncommitted work while refusing the pool"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed dirty refusal: %s; preserved=%s\n' \
+      "$(printf '%s\n' "$out" | tail -n 1)" "$(cat "$POOL_DIR/uncommitted.txt")"
+  fi
+  pass "a dirty pooled worktree is refused without discarding its local work"
+}
+
+test_unresolved_remote_default_refuses_pool() {
+  local rec id out status before
+  id='pool-unresolved-default-r5'
+  rec=$(make_case unresolved-default "$id")
+  read_case_record "$rec"
+  git --git-dir="$CASE_DIR/origin.git" symbolic-ref HEAD refs/heads/missing-default
+  before=$(git -C "$POOL_DIR" rev-parse HEAD)
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn succeeded despite an unresolved remote default branch"
+  assert_contains "$out" "could not resolve origin's current default branch" \
+    "spawn did not clearly refuse an unresolved remote default branch"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
+    || fail "spawn moved HEAD after failing to resolve the remote default branch"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed unresolved-default refusal: %s\n' "$(printf '%s\n' "$out" | tail -n 1)"
+  fi
+  pass "an unresolved remote default branch refuses the pooled worktree"
 }
 
 test_stale_pool_base_refreshes_before_branching
 test_non_main_default_branch_refreshes_before_branching
+test_direct_pr_and_scout_refresh_before_launch
+test_dirty_pool_refuses_without_discarding_work
+test_unresolved_remote_default_refuses_pool
 test_unreachable_origin_refuses_stale_pool_base
 
 echo "# all fm-spawn-pool-base-freshen tests passed"

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Regression tests for fm-spawn's pooled-worktree base refresh.
+#
+# A treehouse pool can return a clean detached worktree whose origin/main was
+# advanced after the worktree was allocated.
+# These tests drive the real spawn path with a fake terminal, then prove it
+# starts the worker from the fetched origin/main tip or stops when origin is
+# unreachable.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-pool-base-freshen)
+
+make_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:?FM_FAKE_PANE_PATH unset}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows|has-session|new-session|new-window|kill-window|send-keys) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  printf '%s\n' "$fakebin"
+}
+
+make_case() {
+  local name=$1 id=$2 default=${3:-main} case_dir home project origin pool publisher fakebin initial
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  origin="$case_dir/origin.git"
+  pool="$case_dir/pool"
+  publisher="$case_dir/publisher"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'codex\n' > "$home/config/crew-harness"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  touch "$home/state/.last-watcher-beat"
+
+  git init --quiet -b "$default" "$project"
+  printf 'base\n' > "$project/README.md"
+  git -C "$project" add README.md
+  git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+  git clone --quiet --bare "$project" "$origin"
+  git -C "$project" remote add origin "file://$origin"
+  initial=$(git -C "$project" rev-parse HEAD)
+  git -C "$project" worktree add --quiet --detach "$pool" "$initial"
+
+  git clone --quiet "file://$origin" "$publisher"
+  printf 'must survive a newly spawned branch\n' > "$publisher/advanced-main.txt"
+  git -C "$publisher" add advanced-main.txt
+  git -C "$publisher" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm advance-main
+  git -C "$publisher" push --quiet origin "$default"
+
+  printf '%s\n' "$case_dir|$home|$project|$pool|$fakebin|$initial|$default"
+}
+
+read_case_record() {
+  IFS='|' read -r CASE_DIR HOME_DIR PROJECT_DIR POOL_DIR FAKEBIN_DIR INITIAL_SHA DEFAULT_BRANCH <<EOF
+$1
+EOF
+}
+
+run_spawn() {
+  local id=$1
+  FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" FM_FAKE_PANE_PATH="$POOL_DIR" \
+    PATH="$FAKEBIN_DIR:$PATH" \
+    "$SPAWN" "$id" "$PROJECT_DIR" --mode no-mistakes --yolo off 2>&1
+}
+
+test_stale_pool_base_refreshes_before_branching() {
+  local rec id out status current branch_head
+  id='pool-current-base-r1'
+  rec=$(make_case current-base "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "spawn should refresh a stale pooled worktree"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  current=$(git -C "$POOL_DIR" rev-parse origin/main)
+  branch_head=$(git -C "$POOL_DIR" rev-parse HEAD)
+  [ "$branch_head" = "$current" ] || fail "spawn left the pooled worktree on stale history"
+  [ "$branch_head" != "$INITIAL_SHA" ] || fail "fixture did not prove origin/main advanced past the pool base"
+
+  git -C "$POOL_DIR" checkout --quiet -b "fm/$id"
+  git -C "$POOL_DIR" diff --exit-code origin/main...HEAD >/dev/null \
+    || fail "a branch created after spawn differs from current origin/main"
+  assert_grep 'must survive a newly spawned branch' "$POOL_DIR/advanced-main.txt" \
+    "the branch created after spawn omitted advanced-main content"
+  pass "a stale pooled worktree refreshes to current origin/main before a crew branch is created"
+}
+
+test_non_main_default_branch_refreshes_before_branching() {
+  local rec id out status current branch_head
+  id='pool-current-trunk-r2'
+  rec=$(make_case current-trunk "$id" trunk)
+  read_case_record "$rec"
+
+  out=$(run_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "spawn should refresh a stale pooled worktree on a non-main default branch"
+  current=$(git -C "$POOL_DIR" rev-parse "origin/$DEFAULT_BRANCH")
+  branch_head=$(git -C "$POOL_DIR" rev-parse HEAD)
+  [ "$branch_head" = "$current" ] || fail "spawn did not refresh to current origin/$DEFAULT_BRANCH"
+  [ "$branch_head" != "$INITIAL_SHA" ] || fail "fixture did not prove origin/$DEFAULT_BRANCH advanced past the pool base"
+  pass "a stale pooled worktree resolves and refreshes a non-main default branch"
+}
+
+test_unreachable_origin_refuses_stale_pool_base() {
+  local rec id out status before after
+  id='pool-unreachable-origin-r2'
+  rec=$(make_case unreachable-origin "$id")
+  read_case_record "$rec"
+  git -C "$POOL_DIR" remote set-url origin "file://$CASE_DIR/missing-origin.git"
+  before=$(git -C "$POOL_DIR" rev-parse HEAD)
+
+  out=$(run_spawn "$id")
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn succeeded despite an unreachable origin"
+  assert_contains "$out" "could not fetch origin" \
+    "spawn did not clearly refuse an unreachable origin"
+  after=$(git -C "$POOL_DIR" rev-parse HEAD)
+  [ "$after" = "$before" ] || fail "spawn changed the pooled worktree after origin became unreachable"
+  pass "an unreachable origin refuses a potentially stale pooled worktree"
+}
+
+test_stale_pool_base_refreshes_before_branching
+test_non_main_default_branch_refreshes_before_branching
+test_unreachable_origin_refuses_stale_pool_base
+
+echo "# all fm-spawn-pool-base-freshen tests passed"

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -24,11 +24,12 @@ set -u
 TMP_ROOT=$(fm_test_tmproot fm-tangle-guard)
 fm_git_identity fmtest fmtest@example.invalid
 
-# A fresh git repo on `main` with one commit. Echoes its path.
+# A fresh git repo on `main` with one commit and a local origin. Echoes its path.
 make_repo() {
   local dir=$1
   git init -q -b main "$dir"
   git -C "$dir" commit -q --allow-empty -m init
+  fm_git_add_origin "$dir" "$dir.origin.git"
   printf '%s\n' "$dir"
 }
 

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -217,11 +217,12 @@ fm_git_add_origin() {
   git -C "$repo" remote add origin "file://$remote_abs"
 }
 
-# fm_git_worktree <repo> <worktree> <branch>: init <repo> with one commit, then
-# add a worktree on a fresh branch.
+# fm_git_worktree <repo> <worktree> <branch>: initialize <repo> with one commit
+# and a local bare origin, then add a worktree on a fresh branch.
 fm_git_worktree() {
   local repo=$1 worktree=$2 branch=$3
   fm_git_init_commit "$repo"
+  fm_git_add_origin "$repo" "$repo.origin.git"
   git -C "$repo" worktree add --quiet -b "$branch" "$worktree"
 }
 


### PR DESCRIPTION
## Intent

URGENT recurring firstmate infrastructure fix for Treehouse pooled worktrees, after near-miss data-loss incidents where a crew received a stale origin/main base, branched from it, and its PR appeared to delete work merged since that base. Make bin/fm-spawn.sh guarantee every fresh ship or scout crew, including direct-PR and no-mistakes work, begins from the current tip of the project's origin default branch before the crew creates its branch, so stale bases cannot produce spurious-deletion PRs. Fetch origin, correctly resolve the current remote default branch rather than hardcoding main, and refresh the clean pooled worktree to current origin/<default-branch>; the operation must be deterministic and idempotent, preserve uncommitted work by refusing a non-clean worktree rather than discarding it, and fail loudly rather than silently continue if origin is unreachable, the default branch cannot be resolved, or the base cannot be made current. Keep this invariant in fm-spawn as the single owner instead of relying on a brief Setup rebase/reset step, because the spawn-side mechanism covers every crew type consistently before any worker edits. Evaluate that alternative in the PR rationale. Add portable behavior regression coverage through fm-spawn's real base-setup path using a fake/local origin whose main advances after a stale pool worktree is allocated, assert the spawned worktree equals current origin/main and a branch created afterward retains advanced-main content without spurious deletions; also cover non-main default-branch resolution and unreachable-origin refusal. Keep the diff minimal and focused on worktree base setup, avoiding the independent Pi --tui-mode version-gate region. Ensure bin/fm-lint.sh is clean. Deliver this through no-mistakes as a PR with genuine green checks, do not merge it, and report the PR when CI is green.

## What Changed

- Fetch and resolve origin’s default branch, then reset clean pooled worktrees to its current tip before fresh ship or scout launches.
- Refuse spawning when origin or its default branch cannot be resolved, or when the worktree is dirty or cannot be refreshed safely.
- Add regression coverage for stale bases, non-main defaults, direct-PR and scout launches, idempotency, and failure paths.

## Risk Assessment

✅ Low: The change is focused, fail-closed, preserves dirty worktrees, resolves the remote default branch dynamically, and includes behavior-level regression coverage for the required scenarios.

## Testing

Exercised fm-spawn’s real base-setup path for stale main and trunk bases, repeated/idempotent refreshes, no-mistakes and direct-PR ships, scouts, dirty-worktree preservation, unresolved defaults, and unreachable origins; related spawn tests also passed after correcting one fixture. CLI and Git-state evidence was captured. Lint was left to the pipeline’s separate lint phase as required.

<details>
<summary>Evidence: fm-spawn end-to-end CLI and Git-state evidence</summary>

```text
# observed spawn: spawned pool-current-base-r1 harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-pool-current-base-r1 worktree=/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pool-base-freshen.0zIdU5/current-base/pool
# observed base: HEAD=638d04c58d25138146d60e0255c721bc991d0764 origin/main=638d04c58d25138146d60e0255c721bc991d0764 advanced-main=must survive a newly spawned branch
ok - a stale pooled worktree refreshes to current origin/main before a crew branch is created
ok - a stale pooled worktree resolves and refreshes a non-main default branch
# observed direct-pr spawn: spawned pool-direct-pr-r3 harness=codex kind=ship mode=direct-PR yolo=off window=firstmate:fm-pool-direct-pr-r3 worktree=/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pool-base-freshen.0zIdU5/direct-pr/pool
# observed scout spawn: spawned pool-scout-r3 harness=codex kind=scout window=firstmate:fm-pool-scout-r3 worktree=/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pool-base-freshen.0zIdU5/scout/pool
ok - direct-PR ships and scouts both refresh stale pooled worktrees before launch
# observed dirty refusal: error: pooled worktree '/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pool-base-freshen.0zIdU5/dirty-refusal/pool' is not clean; refusing to discard uncommitted work while refreshing its base; preserved=keep this local work
ok - a dirty pooled worktree is refused without discarding its local work
# observed unresolved-default refusal: error: could not resolve origin's current default branch for pooled worktree '/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pool-base-freshen.0zIdU5/unresolved-default/pool'; refusing to launch from a potentially stale base
ok - an unresolved remote default branch refuses the pooled worktree
# observed unreachable-origin refusal: error: could not fetch origin for pooled worktree '/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pool-base-freshen.0zIdU5/unreachable-origin/pool'; refusing to launch from a potentially stale base
ok - an unreachable origin refuses a potentially stale pooled worktree
# all fm-spawn-pool-base-freshen tests passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"f87d699799802a8560f984c3833482f834de479c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `FM_TEST_EVIDENCE=1 bash tests/fm-spawn-pool-base-freshen.test.sh | tee <evidence-path>`
- <code>`bash tests/fm-tangle-guard.test.sh` (initially exposed a missing-origin fixture; rerun passed after fixing the fixture)</code>
- `bash tests/fm-spawn-batch.test.sh`
- `bash tests/fm-spawn-worktree-settle.test.sh`
- `bash tests/fm-task-delivery.test.sh`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
