### PR TITLE
fix(spawn): gate Pi TUI mode by CLI capability

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -276,7 +276,7 @@ The follow-up was verified in the interactive TUI; `opencode run` can exit befor
 | Interrupt | single Escape |
 
 Pi has no permission system, so crewmates are always autonomous.
-Pi's `packages/coding-agent/docs/settings.md` UI and display section documents `regular` as the `tuiMode` default, `fullscreen` as experimental, and `--tui-mode` as its startup override; fullscreen can bury steers by rewriting scrollback, so `fm-spawn` passes `--tui-mode regular` for Pi-family crews only when the selected executable's help advertises support and omits it when the capability check is unavailable or inconclusive.
+Pi's `packages/coding-agent/docs/settings.md` UI and display section documents `regular` as the `tuiMode` default, `fullscreen` as experimental, and `--tui-mode` as its startup override; fullscreen can bury steers by rewriting scrollback, so `fm-spawn` resolves one concrete Pi-family executable for both probing and launch, passes `--tui-mode regular` only when its help advertises support, and omits it when the check is inconclusive.
 `pi-signed` is the signed wrapper identity verified on version 0.82.0 and exposes the same CLI and TUI behavior as Pi.
 Firstmate launches the selected executable name from `PATH`, records `pi-signed` without normalization, and refuses rather than falling back to `pi` when that wrapper is unavailable.
 The observed signed process tree is an exact `pi-signed` wrapper parent with the Pi application as its child, while tmux reports the foreground command as the exact `pi-launcher` name for both selected executables.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -278,7 +278,7 @@ The follow-up was verified in the interactive TUI; `opencode run` can exit befor
 Pi has no permission system, so crewmates are always autonomous.
 Pi's `packages/coding-agent/docs/settings.md` UI and display section documents `regular` as the `tuiMode` default, `fullscreen` as experimental, and `--tui-mode` as its startup override; fullscreen can bury steers by rewriting scrollback, so `fm-spawn` resolves one concrete Pi-family executable for both probing and launch, passes `--tui-mode regular` only when its help advertises support, and omits it when the check is inconclusive.
 `pi-signed` is the signed wrapper identity verified on version 0.82.0 and exposes the same CLI and TUI behavior as Pi.
-Firstmate launches the selected executable name from `PATH`, records `pi-signed` without normalization, and refuses rather than falling back to `pi` when that wrapper is unavailable.
+Firstmate resolves the selected executable name from `PATH`, launches that pinned concrete path, records `pi-signed` without normalization, and refuses rather than falling back to `pi` when that wrapper is unavailable.
 The observed signed process tree is an exact `pi-signed` wrapper parent with the Pi application as its child, while tmux reports the foreground command as the exact `pi-launcher` name for both selected executables.
 The installed plain `pi` command also execs that signed launcher, so `FM_PI_HARNESS=pi-signed` is the authoritative selection marker and shared unmarked ancestry remains `pi`.
 Firstmate sets `FM_PI_HARNESS` explicitly for both worker launch identities, and a signed primary uses the README launch command to establish the same boundary.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -276,7 +276,7 @@ The follow-up was verified in the interactive TUI; `opencode run` can exit befor
 | Interrupt | single Escape |
 
 Pi has no permission system, so crewmates are always autonomous.
-Pi's `packages/coding-agent/docs/settings.md` UI and display section documents `regular` as the `tuiMode` default, `fullscreen` as experimental, and `--tui-mode` as its startup override; fullscreen can bury steers by rewriting scrollback, so `fm-spawn` always passes `--tui-mode regular` for Pi-family crews.
+Pi's `packages/coding-agent/docs/settings.md` UI and display section documents `regular` as the `tuiMode` default, `fullscreen` as experimental, and `--tui-mode` as its startup override; fullscreen can bury steers by rewriting scrollback, so `fm-spawn` passes `--tui-mode regular` for Pi-family crews only when the selected executable's help advertises support and omits it when the capability check is unavailable or inconclusive.
 `pi-signed` is the signed wrapper identity verified on version 0.82.0 and exposes the same CLI and TUI behavior as Pi.
 Firstmate launches the selected executable name from `PATH`, records `pi-signed` without normalization, and refuses rather than falling back to `pi` when that wrapper is unavailable.
 The observed signed process tree is an exact `pi-signed` wrapper parent with the Pi application as its child, while tmux reports the foreground command as the exact `pi-launcher` name for both selected executables.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -276,9 +276,10 @@ The follow-up was verified in the interactive TUI; `opencode run` can exit befor
 | Interrupt | single Escape |
 
 Pi has no permission system, so crewmates are always autonomous.
-Pi's `packages/coding-agent/docs/settings.md` UI and display section documents `regular` as the `tuiMode` default, `fullscreen` as experimental, and `--tui-mode` as its startup override; fullscreen can bury steers by rewriting scrollback, so `fm-spawn` resolves one concrete Pi-family executable for both probing and launch, passes `--tui-mode regular` only when its help advertises support, and omits it when the check is inconclusive.
+Pi's `packages/coding-agent/docs/settings.md` UI and display section documents `regular` as the `tuiMode` default and `fullscreen` as experimental; fullscreen can bury steers by rewriting scrollback, so Firstmate avoids it when the installed CLI supports the override.
+`fm-spawn.sh --help` owns the executable-pinning and version-safe launch mechanics.
 `pi-signed` is the signed wrapper identity verified on version 0.82.0 and exposes the same CLI and TUI behavior as Pi.
-Firstmate resolves the selected executable name from `PATH`, launches that pinned concrete path, records `pi-signed` without normalization, and refuses rather than falling back to `pi` when that wrapper is unavailable.
+Firstmate records `pi-signed` without normalization and refuses rather than falling back to `pi` when that wrapper is unavailable.
 The observed signed process tree is an exact `pi-signed` wrapper parent with the Pi application as its child, while tmux reports the foreground command as the exact `pi-launcher` name for both selected executables.
 The installed plain `pi` command also execs that signed launcher, so `FM_PI_HARNESS=pi-signed` is the authoritative selection marker and shared unmarked ancestry remains `pi`.
 Firstmate sets `FM_PI_HARNESS` explicitly for both worker launch identities, and a signed primary uses the README launch command to establish the same boundary.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -107,8 +107,9 @@
 #   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi|muse)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
-#   new adapters. pi-signed launches that exact executable name from PATH and
-#   refuses before endpoint creation when it is unavailable; it never falls back to pi.
+#   new adapters. pi-signed resolves that exact executable name from PATH, pins
+#   the concrete path for launch, and refuses before endpoint creation when it is
+#   unavailable; it never falls back to pi.
 #   config/secondmate-harness may also carry an optional model and effort as extra
 #   whitespace-separated tokens ("<harness> [<model>] [<effort>]"). For a
 #   --secondmate spawn, those tokens apply only when this spawn also resolves its
@@ -1190,7 +1191,7 @@ case "$HARNESS" in
     if pi_supports_tui_mode "$PI_BIN"; then
       PI_TUI_MODE=' --tui-mode regular'
     fi
-    LAUNCH=${LAUNCH//__PIBIN__/$(shell_quote "$PI_BIN")}
+    LAUNCH=${LAUNCH//__PIBIN__/"$(shell_quote "$PI_BIN")"}
     LAUNCH=${LAUNCH//__PITUIMODE__/$PI_TUI_MODE}
     LAUNCH="FM_PI_HARNESS=$HARNESS $LAUNCH"
     ;;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1045,10 +1045,20 @@ else
 fi
 [ -z "$HARNESS_ARG" ] || ARG3=$HARNESS_ARG
 
+# Pi's CLI surface is version-dependent, so probe the resolved executable's help
+# before composing the optional regular-TUI flag. An absent or inconclusive probe
+# omits the flag so older Pi versions can still spawn.
+pi_supports_tui_mode() {
+  local harness=$1 help
+  command -v "$harness" >/dev/null 2>&1 || return 1
+  help=$("$harness" --help 2>&1) || return 1
+  printf '%s\n' "$help" | grep -Eq -- '(^|[[:space:]])--tui-mode([[:space:]=]|$)'
+}
+
 # The verified launch command per adapter. The knowledge half of each adapter
 # (busy-state source, exit command, dialogs, quirks) lives in the harness-adapters skill.
 launch_template() {
-  local harness=$1 kind=${2:-ship}
+  local harness=$1 kind=${2:-ship} tui_mode=
   # shellcheck disable=SC2016  # single quotes are deliberate: $(cat ...) expands in the crewmate pane, not here
   case "$harness" in
     # CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false disables claude's interactive
@@ -1070,10 +1080,14 @@ launch_template() {
       ;;
     opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     pi|pi-signed)
+      if pi_supports_tui_mode "$harness"; then
+        tui_mode=' --tui-mode regular'
+      fi
+      printf '%s' "$harness$tui_mode"
       if [ "$kind" = secondmate ]; then
-        printf '%s%s' "$harness" ' --tui-mode regular __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' ' __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       else
-        printf '%s%s' "$harness" ' --tui-mode regular __MODELFLAG____EFFORTFLAG__-e __PIEXT__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' ' __MODELFLAG____EFFORTFLAG__-e __PIEXT__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       fi
       ;;
     # grok (Grok Build TUI): a positional prompt starts the supervised interactive

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1191,7 +1191,6 @@ case "$HARNESS" in
     if pi_supports_tui_mode "$PI_BIN"; then
       PI_TUI_MODE=' --tui-mode regular'
     fi
-    LAUNCH=${LAUNCH//__PIBIN__/"$(shell_quote "$PI_BIN")"}
     LAUNCH=${LAUNCH//__PITUIMODE__/$PI_TUI_MODE}
     LAUNCH="FM_PI_HARNESS=$HARNESS $LAUNCH"
     ;;
@@ -2592,6 +2591,9 @@ LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
 LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}
+case "$HARNESS" in
+  pi|pi-signed) LAUNCH=${LAUNCH//__PIBIN__/"$(shell_quote "$PI_BIN")"} ;;
+esac
 # Crewmate panes are created by a long-lived tmux/herdr daemon that does not
 # inherit firstmate's current environment, so a bare `claude` in the pane falls
 # back to the default ~/.claude store even when firstmate itself runs under a

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1045,20 +1045,38 @@ else
 fi
 [ -z "$HARNESS_ARG" ] || ARG3=$HARNESS_ARG
 
+shell_quote() {
+  printf "'"
+  printf '%s' "$1" | sed "s/'/'\\\\''/g"
+  printf "'"
+}
+
+resolve_pi_executable() {
+  local candidate dir
+  candidate=$(type -P -- "$1" 2>/dev/null) || return 1
+  [ -x "$candidate" ] || return 1
+  case "$candidate" in
+    /*) printf '%s\n' "$candidate" ;;
+    *)
+      dir=$(cd "$(dirname "$candidate")" 2>/dev/null && pwd -P) || return 1
+      printf '%s/%s\n' "$dir" "$(basename "$candidate")"
+      ;;
+  esac
+}
+
 # Pi's CLI surface is version-dependent, so probe the resolved executable's help
 # before composing the optional regular-TUI flag. An absent or inconclusive probe
 # omits the flag so older Pi versions can still spawn.
 pi_supports_tui_mode() {
-  local harness=$1 help
-  command -v "$harness" >/dev/null 2>&1 || return 1
-  help=$("$harness" --help 2>&1) || return 1
+  local executable=$1 help
+  help=$("$executable" --help 2>&1) || return 1
   printf '%s\n' "$help" | grep -Eq -- '(^|[[:space:]])--tui-mode([[:space:]=]|$)'
 }
 
 # The verified launch command per adapter. The knowledge half of each adapter
 # (busy-state source, exit command, dialogs, quirks) lives in the harness-adapters skill.
 launch_template() {
-  local harness=$1 kind=${2:-ship} tui_mode=
+  local harness=$1 kind=${2:-ship}
   # shellcheck disable=SC2016  # single quotes are deliberate: $(cat ...) expands in the crewmate pane, not here
   case "$harness" in
     # CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false disables claude's interactive
@@ -1080,10 +1098,7 @@ launch_template() {
       ;;
     opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     pi|pi-signed)
-      if pi_supports_tui_mode "$harness"; then
-        tui_mode=' --tui-mode regular'
-      fi
-      printf '%s' "$harness$tui_mode"
+      printf '%s' '__PIBIN____PITUIMODE__'
       if [ "$kind" = secondmate ]; then
         printf '%s' ' __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       else
@@ -1166,7 +1181,19 @@ case "$ARG3" in
 esac
 
 case "$HARNESS" in
-  pi|pi-signed) LAUNCH="FM_PI_HARNESS=$HARNESS $LAUNCH" ;;
+  pi|pi-signed)
+    PI_BIN=$(resolve_pi_executable "$HARNESS") || {
+      echo "error: $HARNESS executable not found on PATH; install it or select a different verified harness" >&2
+      exit 1
+    }
+    PI_TUI_MODE=
+    if pi_supports_tui_mode "$PI_BIN"; then
+      PI_TUI_MODE=' --tui-mode regular'
+    fi
+    LAUNCH=${LAUNCH//__PIBIN__/$(shell_quote "$PI_BIN")}
+    LAUNCH=${LAUNCH//__PITUIMODE__/$PI_TUI_MODE}
+    LAUNCH="FM_PI_HARNESS=$HARNESS $LAUNCH"
+    ;;
 esac
 
 # muse is verified as a CREWMATE/SCOUT adapter only. A secondmate is a firstmate
@@ -1177,14 +1204,6 @@ esac
 # secondmate whose supervision cycle could never be armed.
 if [ "$KIND" = secondmate ] && [ "$HARNESS" = muse ]; then
   echo "error: muse is a verified crewmate/scout adapter only and cannot run a secondmate; it has no primary supervision protocol. Select a harness verified for secondmates." >&2
-  exit 1
-fi
-
-# pi-signed is an explicitly selected executable identity, not an alias that may
-# silently fall back to pi. Resolve it from PATH before creating an endpoint and
-# retain the literal name in the launch command and task metadata.
-if [ "$HARNESS" = pi-signed ] && ! command -v pi-signed >/dev/null 2>&1; then
-  echo "error: pi-signed executable not found on PATH; install the signed Pi wrapper or select a different verified harness" >&2
   exit 1
 fi
 
@@ -1212,12 +1231,6 @@ fi
 
 secondmate_registry_value() {
   secondmate_registry_field "$DATA/secondmates.md" "$1" "$2"
-}
-
-shell_quote() {
-  printf "'"
-  printf '%s' "$1" | sed "s/'/'\\\\''/g"
-  printf "'"
 }
 
 resolve_kimi_binary() {

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -107,9 +107,12 @@
 #   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi|muse)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
-#   new adapters. pi-signed resolves that exact executable name from PATH, pins
-#   the concrete path for launch, and refuses before endpoint creation when it is
-#   unavailable; it never falls back to pi.
+#   new adapters. For pi and pi-signed, fm-spawn resolves the selected executable
+#   name from PATH once, probes that concrete path with --help, and launches the
+#   same path. It adds --tui-mode regular only when that help advertises the flag;
+#   a failed or inconclusive probe omits it so older Pi versions remain launchable.
+#   A missing selected executable refuses before endpoint creation, and pi-signed
+#   never falls back to pi.
 #   config/secondmate-harness may also carry an optional model and effort as extra
 #   whitespace-separated tokens ("<harness> [<model>] [<effort>]"). For a
 #   --secondmate spawn, those tokens apply only when this spawn also resolves its
@@ -143,6 +146,8 @@
 #   $vars and silently breaks ad-hoc `for ... in $pairs` loops).
 #   Launch templates live in launch_template() below; placeholders replaced before launch:
 #     __BRIEF__    absolute path to data/<task-id>/brief.md
+#     __PIBIN__    quoted concrete Pi-family executable path resolved from PATH
+#     __PITUIMODE__ optional --tui-mode regular when that executable advertises it
 #     __TURNEND__  absolute path to state/<task-id>.turn-ended (for harnesses whose
 #                  turn-end signal rides the launch command, e.g. codex -c notify=[...])
 #     __PIEXT__    absolute path to state/<task-id>.pi-ext.ts (pi turn-end extension,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -213,7 +213,7 @@ New harnesses get verified through a supervised trial task before joining the se
 The verified adapter evidence - each harness's busy-state source, interrupt and exit behavior, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 The executable interrupt and exit mechanics live in [`bin/fm-control-lib.sh`](../bin/fm-control-lib.sh), and [`docs/agent-control.md`](agent-control.md) owns their lifecycle-control architecture.
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
-Pi and pi-signed crew launches pass `--tui-mode regular` when the selected executable's help advertises support, so supporting versions avoid fullscreen rewriting scrollback and burying steers; unavailable or inconclusive capability checks omit the flag for compatibility with older versions.
+Pi and pi-signed crew launches resolve one concrete executable path for both capability detection and launch, passing `--tui-mode regular` when that executable's help advertises support; inconclusive checks omit the flag for compatibility with older versions.
 Enabled primary-session turn-end guard integrations are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).
 Kimi remains outside the primary turn-end guard integrations; [`docs/turnend-guard.md`](turnend-guard.md#compatibility-limits) owns its separate captain-approved crew wake hook.
 Primary-session watcher wake protocols are rendered at session start by [`bin/fm-supervision-instructions.sh`](../bin/fm-supervision-instructions.sh) from [`docs/supervision-protocols/`](supervision-protocols/).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -213,7 +213,7 @@ New harnesses get verified through a supervised trial task before joining the se
 The verified adapter evidence - each harness's busy-state source, interrupt and exit behavior, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 The executable interrupt and exit mechanics live in [`bin/fm-control-lib.sh`](../bin/fm-control-lib.sh), and [`docs/agent-control.md`](agent-control.md) owns their lifecycle-control architecture.
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
-Pi and pi-signed crew launches explicitly pass `--tui-mode regular` so fullscreen mode cannot rewrite scrollback and bury steers.
+Pi and pi-signed crew launches pass `--tui-mode regular` when the selected executable's help advertises support, so supporting versions avoid fullscreen rewriting scrollback and burying steers; unavailable or inconclusive capability checks omit the flag for compatibility with older versions.
 Enabled primary-session turn-end guard integrations are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).
 Kimi remains outside the primary turn-end guard integrations; [`docs/turnend-guard.md`](turnend-guard.md#compatibility-limits) owns its separate captain-approved crew wake hook.
 Primary-session watcher wake protocols are rendered at session start by [`bin/fm-supervision-instructions.sh`](../bin/fm-supervision-instructions.sh) from [`docs/supervision-protocols/`](supervision-protocols/).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -213,13 +213,13 @@ New harnesses get verified through a supervised trial task before joining the se
 The verified adapter evidence - each harness's busy-state source, interrupt and exit behavior, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 The executable interrupt and exit mechanics live in [`bin/fm-control-lib.sh`](../bin/fm-control-lib.sh), and [`docs/agent-control.md`](agent-control.md) owns their lifecycle-control architecture.
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
-Pi and pi-signed crew launches resolve one concrete executable path for both capability detection and launch, passing `--tui-mode regular` when that executable's help advertises support; inconclusive checks omit the flag for compatibility with older versions.
+Pi-family launches adapt the regular-TUI safeguard to the installed CLI's capabilities; [`fm-spawn.sh --help`](../bin/fm-spawn.sh) owns the exact version-safe launch mechanics.
 Enabled primary-session turn-end guard integrations are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).
 Kimi remains outside the primary turn-end guard integrations; [`docs/turnend-guard.md`](turnend-guard.md#compatibility-limits) owns its separate captain-approved crew wake hook.
 Primary-session watcher wake protocols are rendered at session start by [`bin/fm-supervision-instructions.sh`](../bin/fm-supervision-instructions.sh) from [`docs/supervision-protocols/`](supervision-protocols/).
 Claude's Stop `asyncRewake` hook owns tokenless re-arm cycles, Grok uses background-notify cycles, Codex uses bounded foreground checkpoints, Pi and pi-signed use the same two tracked primary extensions, and OpenCode uses its TUI plugin.
 `config/crew-harness` is a local, gitignored file containing one adapter name for crewmate and scout launches.
-When pi-signed is selected, Firstmate launches the executable named `pi-signed` from `PATH` with `FM_PI_HARNESS=pi-signed` and refuses the launch if it is unavailable rather than falling back to pi.
+When pi-signed is selected, Firstmate preserves `FM_PI_HARNESS=pi-signed` and refuses the launch if the selected executable is unavailable rather than falling back to pi; [`fm-spawn.sh --help`](../bin/fm-spawn.sh) owns executable resolution and launch mechanics.
 Plain Pi launches set `FM_PI_HARNESS=pi`, so a signed primary's environment cannot relabel a plain Pi worker.
 When it is absent or contains `default`, crewmates mirror the firstmate's own harness.
 `config/secondmate-harness` is a separate local, gitignored file containing the adapter the primary uses to launch secondmate agents, optionally followed by model and effort tokens on the same line.

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -604,6 +604,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" pi
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -548,6 +548,7 @@ EOF
   ln -s "$ROOT/bin" "$root/bin"
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
+  fm_fake_exit0 "$fakebin" pi
   make_fake_tmux_secondmate_recovery "$fakebin"
   : > "$log"
   printf '%s|%s|%s|%s|%s|%s\n' "$root" "$home" "$fakebin" "$mate" "$log" "$spawned"
@@ -594,6 +595,7 @@ EOF
   ln -s "$ROOT/bin" "$root/bin"
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
+  fm_fake_exit0 "$fakebin" pi
   make_fake_herdr_secondmate_recovery "$fakebin"
   : > "$log"
   printf '%s|%s|%s|%s|%s|%s\n' "$root" "$home" "$fakebin" "$mate" "$log" "$state"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -568,7 +568,7 @@ test_pi_tui_mode_probe_is_safe_for_old_and_new_pi() {
   for harness in pi pi-signed; do
     for version in 0.82.0 0.84.0; do
       id="profile-${harness}-tui-${version//./}-z8d"
-      rec=$(make_spawn_case "profile-${harness}-tui-${version//./}" "$harness" "$id")
+      rec=$(make_spawn_case "profile-__MODELFLAG__-${harness}-tui-${version//./}" "$harness" "$id")
       read_case_record "$rec"
 
       out=$(FM_TEST_PI_VERSION="$version" \

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -13,6 +13,23 @@ set -u
 SPAWN="$ROOT/bin/fm-spawn.sh"
 TMP_ROOT=$(fm_test_tmproot fm-spawn-dispatch-profile)
 
+make_spawn_pi_probe() {
+  local fakebin=$1 tool=$2
+  cat > "$fakebin/$tool" <<'SH'
+#!/usr/bin/env bash
+set -u
+if [ "${1:-}" = --help ]; then
+  if [ "${FM_FAKE_PI_VERSION:-0.84.0}" = 0.82.0 ]; then
+    printf '%s\n' 'Pi 0.82.0' 'Options: --help'
+  else
+    printf '%s\n' "Pi ${FM_FAKE_PI_VERSION:-0.84.0}" 'Options: --help --tui-mode <mode>'
+  fi
+fi
+exit 0
+SH
+  chmod +x "$fakebin/$tool"
+}
+
 make_spawn_fakebin() {
   local dir=$1 fakebin
   fakebin=$(fm_fakebin "$dir")
@@ -42,7 +59,9 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse pi-signed
+  fm_fake_exit0 "$fakebin" treehouse
+  make_spawn_pi_probe "$fakebin" pi
+  make_spawn_pi_probe "$fakebin" pi-signed
   printf '%s\n' "$fakebin"
 }
 
@@ -93,7 +112,8 @@ run_spawn() {
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
     CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
-    FM_FAKE_LAUNCH_LOG="$launchlog" GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
+    FM_FAKE_LAUNCH_LOG="$launchlog" FM_FAKE_PI_VERSION="${FM_TEST_PI_VERSION:-0.84.0}" \
+    GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
     "$SPAWN" "$@" 2>&1
 }
 
@@ -543,6 +563,32 @@ test_pi_signed_threads_shared_pi_profile_and_preserves_identity() {
   pass "pi-signed shares Pi launch semantics while preserving its configured and recorded identity"
 }
 
+test_pi_tui_mode_probe_is_safe_for_old_and_new_pi() {
+  local harness version rec id out status launch
+  for harness in pi pi-signed; do
+    for version in 0.82.0 0.84.0; do
+      id="profile-${harness}-tui-${version//./}-z8d"
+      rec=$(make_spawn_case "profile-${harness}-tui-${version//./}" "$harness" "$id")
+      read_case_record "$rec"
+
+      out=$(FM_TEST_PI_VERSION="$version" \
+        run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+        "$id" "$PROJ_DIR")
+      status=$?
+      expect_code 0 "$status" "$harness $version spawn should succeed"
+      launch=$(cat "$LAUNCH_LOG")
+      if [ "$version" = 0.82.0 ]; then
+        assert_not_contains "$launch" "--tui-mode" \
+          "$harness $version launch must omit unsupported --tui-mode"
+      else
+        assert_contains "$launch" "$harness --tui-mode regular" \
+          "$harness $version launch must preserve the regular TUI"
+      fi
+    done
+  done
+  pass "Pi launch probing omits --tui-mode on older Pi and preserves it on supporting Pi"
+}
+
 test_pi_signed_missing_binary_refuses_before_endpoint_or_metadata() {
   local rec id out status
   id=profile-pi-signed-missing-z8c
@@ -692,6 +738,7 @@ test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort
 test_opencode_threads_model_and_ignores_effort_axis
 test_pi_threads_model_and_max_effort
+test_pi_tui_mode_probe_is_safe_for_old_and_new_pi
 test_pi_signed_threads_shared_pi_profile_and_preserves_identity
 test_pi_signed_missing_binary_refuses_before_endpoint_or_metadata
 test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -521,7 +521,7 @@ test_pi_threads_model_and_max_effort() {
   expect_code 0 "$status" "pi spawn with max effort should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" pi openai-codex/gpt-5.6-sol max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "FM_PI_HARNESS=pi pi --tui-mode regular --model 'openai-codex/gpt-5.6-sol' --thinking 'max' -e" \
+  assert_contains "$launch" "FM_PI_HARNESS=pi '$FAKEBIN_DIR/pi' --tui-mode regular --model 'openai-codex/gpt-5.6-sol' --thinking 'max' -e" \
     "pi launch did not force the regular TUI while threading the requested model and max thinking level"
   assert_not_contains "$launch" "FM_FIRSTMATE_PI_LAUNCH_BRIEF=" \
     "pi launch still exports the removed Calm input-reroute binding"
@@ -543,7 +543,7 @@ test_pi_signed_threads_shared_pi_profile_and_preserves_identity() {
   assert_contains "$out" "spawned $id harness=pi-signed" "pi-signed spawn did not preserve its visible identity"
   assert_meta_profile "$HOME_DIR/state/$id.meta" pi-signed openai-codex/gpt-5.6-sol max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "FM_PI_HARNESS=pi-signed pi-signed --tui-mode regular --model 'openai-codex/gpt-5.6-sol' --thinking 'max' -e" \
+  assert_contains "$launch" "FM_PI_HARNESS=pi-signed '$FAKEBIN_DIR/pi-signed' --tui-mode regular --model 'openai-codex/gpt-5.6-sol' --thinking 'max' -e" \
     "pi-signed launch did not force the regular TUI with Pi's model, thinking, and extension semantics"
   assert_contains "$launch" "fm-operational-input.sh' encode launch-brief" \
     "pi-signed launch lost the canonical typed launch-brief envelope"
@@ -577,11 +577,15 @@ test_pi_tui_mode_probe_is_safe_for_old_and_new_pi() {
       status=$?
       expect_code 0 "$status" "$harness $version spawn should succeed"
       launch=$(cat "$LAUNCH_LOG")
+      assert_contains "$launch" "'$FAKEBIN_DIR/$harness'" \
+        "$harness $version launch must use the executable selected for probing"
+      assert_not_contains "$launch" "FM_PI_HARNESS=$harness $harness" \
+        "$harness $version launch must not re-resolve a bare executable in the worker"
       if [ "$version" = 0.82.0 ]; then
         assert_not_contains "$launch" "--tui-mode" \
           "$harness $version launch must omit unsupported --tui-mode"
       else
-        assert_contains "$launch" "$harness --tui-mode regular" \
+        assert_contains "$launch" "'$FAKEBIN_DIR/$harness' --tui-mode regular" \
           "$harness $version launch must preserve the regular TUI"
       fi
     done
@@ -629,7 +633,7 @@ test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity() {
     "pi-signed secondmate spawn did not preserve its runtime identity"
   assert_meta_profile "$HOME_DIR/state/$id.meta" pi-signed default default
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "FM_PI_HARNESS=pi-signed pi-signed --tui-mode regular -e '$sm/.pi/extensions/fm-primary-turnend-guard.ts' -e '$sm/.pi/extensions/fm-primary-pi-watch.ts'" \
+  assert_contains "$launch" "FM_PI_HARNESS=pi-signed '$FAKEBIN_DIR/pi-signed' --tui-mode regular -e '$sm/.pi/extensions/fm-primary-turnend-guard.ts' -e '$sm/.pi/extensions/fm-primary-pi-watch.ts'" \
     "pi-signed secondmate did not force the regular TUI with Pi's primary extension launch shape"
   pass "pi-signed is a distinct persistent secondmate runtime with shared Pi supervision semantics"
 }


### PR DESCRIPTION
## Intent

Fix the fleet-wide regression in firstmate shared tracked material caused by PR #2005 adding `pi --tui-mode regular` to Pi and pi-signed crew launch templates. Make fm-spawn VERSION-SAFE: pass `--tui-mode regular` only when the resolved Pi executable actually supports it, while older Pi versions such as 0.82.0 spawn cleanly without the flag; preserve PR #2005 regular-TUI behavior on supporting versions such as 0.84.0. Prefer cheap feature detection from the installed pi/pi-signed capability surface (`--help` or usage) over a hardcoded version gate, and fail safe by omitting the flag when support cannot be determined. Apply the same logic to both Pi and pi-signed templates and do not change non-Pi launch behavior. Add a portable regression test colocated with the existing tests that exercises fm-spawn real command composition with mocked/faked older and newer Pi executables, asserting omission for unsupported Pi and inclusion of `--tui-mode regular` for supporting Pi. Do not assert fm-spawn source text. Keep the diff minimal and shellcheck-clean, with the harness-dependent-checks two-tests rule respected: the portable mocked-version regression is required, and a live-harness-optin guard is only needed if warranted by the real Pi probe. Deliver through no-mistakes, yolo off, and stop at `done: PR <url> checks green`; do not self-merge or wait for same-session merge.

## What Changed

- Resolve and pin Pi and pi-signed executables, adding `--tui-mode regular` only when their help output advertises support.
- Omit the flag when probing fails or older Pi versions lack support, without changing non-Pi launch templates.
- Add mocked command-composition coverage for Pi 0.82.0 and 0.84.0 behavior and document the version-safe launch mechanics.

## Risk Assessment

✅ Low: The change is narrowly scoped, pins probing and launch to the same Pi executable path, safely gates the flag, and adds behavioral coverage for both supported and unsupported versions.

## Testing

The targeted spawn-profile suite passed across Pi-family and non-Pi launch paths; end-user command transcripts demonstrate both Pi identities omit `--tui-mode` for 0.82.0, include `--tui-mode regular` for 0.84.0, and fail safe on an inconclusive probe, while a base-commit reproduction shows the original unsupported-flag regression.

<details>
<summary>Evidence: Targeted fm-spawn dispatch-profile test run</summary>

```text
ok - no --model/--effort records defaults and types the claude launch instructions
ok - relative home overrides ignore CDPATH and become absolute before spawn launch construction
ok - FM_HOME defaults resolve relative paths and preserve absolute spellings
ok - absolute override spellings are preserved in spawn launch paths
ok - unresolvable relative spawn overrides fail with named diagnostics
ok - active crew-dispatch profile requires an explicit harness for ship spawns
ok - active crew-dispatch profile requires an explicit harness for scout spawns
ok - active crew-dispatch profile allows an explicit resolved harness
ok - active crew-dispatch profile allows the legacy positional harness form
ok - active crew-dispatch profile allows the raw launch-command escape hatch
ok - claude receives --model and --effort profile flags
ok - codex receives --model and model_reasoning_effort profile flags
ok - codex omits unsupported max effort instead of passing a bad config value
ok - grok receives --model and --reasoning-effort profile flags
ok - grok omits unsupported max reasoning effort
ok - grok omits unsupported xhigh reasoning effort
ok - opencode receives --model and omits the unsupported effort axis
ok - pi receives --model and --thinking max profile flags
ok - Pi launch probing omits --tui-mode on older Pi and preserves it on supporting Pi
ok - pi-signed shares Pi launch semantics while preserving its configured and recorded identity
ok - pi-signed refuses safely and actionably when the selected executable is unavailable
ok - pi-signed is a distinct persistent secondmate runtime with shared Pi supervision semantics
ok - batch dispatch forwards shared --harness, --model, and --effort to every pair
ok - claude forwards firstmate's CLAUDE_CONFIG_DIR so the crewmate uses the same credential store
ok - claude omits the config-dir prefix when firstmate runs with the single-store default
ok - non-claude harnesses do not receive the claude CLAUDE_CONFIG_DIR prefix
ok - active crew-dispatch profile does not block secondmate launches
# all fm-spawn-dispatch-profile tests passed
```
</details>
<details>
<summary>Evidence: Pi and pi-signed old/new/inconclusive composed launch commands</summary>

```text
CASE harness=pi advertised-version=0.82.0
RESULT warning: /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pi-evidence.6gmM1D/evidence-pi-0820/home/data/evidence-pi-0820/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
spawned evidence-pi-0820 harness=pi kind=ship mode=no-mistakes yolo=off window=firstmate:fm-evidence-pi-0820 worktree=/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pi-evidence.6gmM1D/evidence-pi-0820/wt
COMPOSED FM_PI_HARNESS=pi '/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pi-evidence.6gmM1D/evidence-pi-0820/fake/fakebin/pi' -e '/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pi-evidence.6gmM1D/evidence-pi-0820/home/state/evidence-pi-0820.pi-ext.ts' "$('/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KZQ46Z6RTGWTCD8603ERY698/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pi-evidence.6gmM1D/evidence-pi-0820/home/data/evidence-pi-0820/brief.md')"

CASE harness=pi advertised-version=0.84.0
RESULT warning: /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pi-evidence.6gmM1D/evidence-pi-0840/home/data/evidence-pi-0840/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
spawned evidence-pi-0840 harness=pi kind=ship mode=no-mistakes yolo=off window=firstmate:fm-evidence-pi-0840 worktree=/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pi-evidence.6gmM1D/evidence-pi-0840/wt
COMPOSED FM_PI_HARNESS=pi '/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pi-evidence.6gmM1D/evidence-pi-0840/fake/fakebin/pi' --tui-mode regular -e '/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pi-evidence.6gmM1D/evidence-pi-0840/home/state/evidence-pi-0840.pi-ext.ts' "$('/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KZQ46Z6RTGWTCD8603ERY698/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pi-evidence.6gmM1D/evidence-pi-0840/home/data/evidence-pi-0840/brief.md')"

CASE harness=pi-signed advertised-version=0.82.0
RESULT warning: /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pi-evidence.6gmM1D/evidence-pi-signed-0820/home/data/evidence-pi-signed-0820/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
spawned evidence-pi-signed-0820 harness=pi-signed kind=ship mode=no-mistakes yolo=off window=firstmate:fm-evidence-pi-signed-0820 worktree=/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pi-evidence.6gmM1D/evidence-pi-signed-0820/wt
COMPOSED FM_PI_HARNESS=pi-signed '/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pi-evidence.6gmM1D/evidence-pi-signed-0820/fake/fakebin/pi-signed' -e '/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pi-evidence.6gmM1D/evidence-pi-signed-0820/home/state/evidence-pi-signed-0820.pi-ext.ts' "$('/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KZQ46Z6RTGWTCD8603ERY698/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pi-evidence.6gmM1D/evidence-pi-signed-0820/home/data/evidence-pi-signed-0820/brief.md')"

CASE harness=pi-signed advertised-version=0.84.0
RESULT warning: /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pi-evidence.6gmM1D/evidence-pi-signed-0840/home/data/evidence-pi-signed-0840/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
spawned evidence-pi-signed-0840 harness=pi-signed kind=ship mode=no-mistakes yolo=off window=firstmate:fm-evidence-pi-signed-0840 worktree=/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pi-evidence.6gmM1D/evidence-pi-signed-0840/wt
COMPOSED FM_PI_HARNESS=pi-signed '/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pi-evidence.6gmM1D/evidence-pi-signed-0840/fake/fakebin/pi-signed' --tui-mode regular -e '/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pi-evidence.6gmM1D/evidence-pi-signed-0840/home/state/evidence-pi-signed-0840.pi-ext.ts' "$('/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KZQ46Z6RTGWTCD8603ERY698/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pi-evidence.6gmM1D/evidence-pi-signed-0840/home/data/evidence-pi-signed-0840/brief.md')"

CASE harness=pi help-probe=inconclusive(exit-2)
RESULT warning: /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pi-evidence.6gmM1D/evidence-pi-inconclusive/home/data/evidence-pi-inconclusive/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
spawned evidence-pi-inconclusive harness=pi kind=ship mode=no-mistakes yolo=off window=firstmate:fm-evidence-pi-inconclusive worktree=/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pi-evidence.6gmM1D/evidence-pi-inconclusive/wt
COMPOSED FM_PI_HARNESS=pi '/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pi-evidence.6gmM1D/evidence-pi-inconclusive/fake/fakebin/pi' -e '/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pi-evidence.6gmM1D/evidence-pi-inconclusive/home/state/evidence-pi-inconclusive.pi-ext.ts' "$('/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KZQ46Z6RTGWTCD8603ERY698/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-pi-evidence.6gmM1D/evidence-pi-inconclusive/home/data/evidence-pi-inconclusive/brief.md')"
```
</details>
<details>
<summary>Evidence: Base-commit unsupported-flag regression reproduction</summary>

```text
BASELINE CASE harness=pi advertised-version=0.82.0
RESULT warning: /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-base-evidence.iBsK8b/evidence-base-pi-0820/home/data/evidence-base-pi-0820/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
spawned evidence-base-pi-0820 harness=pi kind=ship mode=no-mistakes yolo=off window=firstmate:fm-evidence-base-pi-0820 worktree=/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-base-evidence.iBsK8b/evidence-base-pi-0820/wt
COMPOSED FM_PI_HARNESS=pi pi --tui-mode regular -e '/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-base-evidence.iBsK8b/evidence-base-pi-0820/home/state/evidence-base-pi-0820.pi-ext.ts' "$('/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KZQ46Z6RTGWTCD8603ERY698/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-spawn-base-evidence.iBsK8b/evidence-base-pi-0820/home/data/evidence-base-pi-0820/brief.md')"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"5f45badfce53f65e1617f1c86048fb1aa234c4b2","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (4) ✅</summary>

- 🚨 `bin/fm-spawn.sh:1054` - Intent requires passing the flag only when “the resolved Pi executable actually supports it,” but this hunk probes `&#34;$harness&#34; --help` in fm-spawn’s environment while line 1086 emits the bare harness name for later resolution inside the backend pane. For example, a tmux server retaining Pi 0.82.0 on PATH while the caller sees 0.84.0 causes the probe to add the unsupported flag and reproduces the regression. Resolve one executable path and use it for both probe and launch, or perform detection at the pane execution boundary.
- ⚠️ `docs/configuration.md:216` - The documentation still says Pi-family crews unconditionally pass `--tui-mode regular`, while the changed implementation now passes it only after successful capability detection. Update this statement and `.agents/skills/harness-adapters/SKILL.md:279` to describe the conditional, fail-safe behavior.

🔧 Fix: Document conditional Pi TUI capability detection
1 error still open:
- 🚨 `bin/fm-spawn.sh:1054` - The required invariant—pass the flag only when “the resolved Pi executable actually supports it”—is still violated. The probe runs `$harness --help` in fm-spawn’s environment, but line 1086 emits the bare harness name for resolution inside a pane created by a long-lived backend daemon. If fm-spawn sees Pi 0.84.0 while the tmux server’s PATH resolves Pi 0.82.0, the launch still receives the unsupported flag. Probe at the pane execution boundary, or resolve and launch the same executable path.

🔧 Fix: Pin Pi probing and launch to one executable
2 warnings still open:
- ⚠️ `bin/fm-spawn.sh:1193` - The unquoted Bash pattern replacement can reinterpret `&amp;` in the shell-quoted executable path when `patsub_replacement` is enabled, corrupting valid paths such as `/opt/R&amp;D/bin/pi` instead of launching the probed executable. Quote the replacement expansion or use a substitution helper that preserves replacement metacharacters literally.
- ⚠️ `.agents/skills/harness-adapters/SKILL.md:281` - This still claims Firstmate retains the literal `pi-signed` name in the launch command, but fm-spawn now emits the resolved absolute executable path. Update this statement and the equivalent header comment in `bin/fm-spawn.sh:110` to describe PATH resolution followed by pinned-path launch.

🔧 Fix: Preserve literal pinned Pi paths and update documentation
2 errors still open:
- 🚨 `bin/fm-spawn.sh:1186` - The new Pi branch also handles raw launch commands whose executable basename is `pi` or `pi-signed`. A valid escape-hatch command such as `/opt/custom/pi --foo` now fails unless an unrelated same-named executable exists on PATH, even though the raw executable itself would launch successfully. Only resolve/probe generated templates containing the Pi placeholders; preserve the existing identity prefix without rewriting or probing raw commands.
- 🚨 `bin/fm-spawn.sh:1194` - The required resolved-executable invariant remains breakable because the quoted path is inserted before subsequent placeholder substitutions. For example, a valid resolved path under `/tmp/__MODELFLAG__/bin/pi` is modified at line 2587, so the launched path differs from the probed path. Replace all other placeholders before inserting `__PIBIN__`, making the executable path the final literal substitution.

🔧 Fix: Defer pinned Pi path insertion until final substitution
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `tests/fm-spawn-dispatch-profile.test.sh`
- <code>Manual real `fm-spawn.sh` command-composition check with mocked Pi 0.82.0, Pi 0.84.0, pi-signed 0.82.0, pi-signed 0.84.0, and an inconclusive help probe</code>
- <code>Baseline reproduction using base-commit `fm-spawn.sh` with mocked Pi 0.82.0, confirming the regression previously composed the unsupported flag</code>
- `git diff --check 7f828ea2f28c83aa9e3afd44a2a5ee64795005f8..88a1f880b5a17709609b99d4d7349af44704abe7 -- bin/fm-spawn.sh tests/fm-spawn-dispatch-profile.test.sh`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
