### PR TITLE
feat(brief): support custom ship branch names

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -6,7 +6,7 @@
 # description, acceptance criteria, and context, and may adjust other sections
 # when the task genuinely deviates (e.g. working an existing external PR instead
 # of shipping a new one).
-# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only> [--herdr-lab]
+# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only> [--branch <name>] [--herdr-lab]
 #        fm-brief.sh <task-id> <repo-name> --scout [--herdr-lab]
 #        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
 #   --scout writes the scout contract instead: the deliverable is a report at
@@ -43,6 +43,15 @@
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
 # --mode is refused on scout and secondmate scaffolds: a scout's deliverable is a
 # report rather than a merge, and a charter is not a delivery contract.
+# --branch <name> overrides the ship branch the crewmate is told to create; it
+# defaults to fm/<task-id> so every existing caller is unaffected. It is refused
+# on scout and secondmate scaffolds (no branch is created there) and rejects an
+# empty value, a leading dash, whitespace, or a quote character, because the
+# name is interpolated into printed shell commands the crewmate and operator
+# run verbatim. It is also refused together with --mode local-only: firstmate's
+# own local merge gate (bin/fm-merge-local.sh) hardcodes branch fm/<task-id> and
+# hard-refuses when that ref is absent, so a custom branch there would scaffold
+# a task firstmate's own merge path can never land.
 # There is no --yolo flag here. The worker never owns approval decisions, so yolo is
 # a spawn-time and firstmate-side input only (AGENTS.md section 7).
 # Every scaffold's status protocol distinguishes the configured
@@ -106,6 +115,8 @@ HERDR_LAB=0
 NO_PROJECTS=0
 MODE=
 MODE_SET=0
+BRANCH=
+BRANCH_SET=0
 POS=()
 want_value=
 for a in "$@"; do
@@ -115,6 +126,7 @@ for a in "$@"; do
     esac
     case "$want_value" in
       mode) MODE=$a; MODE_SET=1 ;;
+      branch) BRANCH=$a; BRANCH_SET=1 ;;
       *) echo "error: internal parser state for --$want_value" >&2; exit 1 ;;
     esac
     want_value=
@@ -127,6 +139,8 @@ for a in "$@"; do
     --no-projects) NO_PROJECTS=1 ;;
     --mode) want_value=mode ;;
     --mode=*) MODE=${a#--mode=}; MODE_SET=1 ;;
+    --branch) want_value=branch ;;
+    --branch=*) BRANCH=${a#--branch=}; BRANCH_SET=1 ;;
     # yolo never reaches the worker: it is firstmate's approval authority, not a
     # brief input. Refuse it loudly so it is never silently dropped here and then
     # believed to have been recorded.
@@ -165,6 +179,36 @@ if [ "$NO_PROJECTS" -eq 1 ] && [ "$KIND" != secondmate ]; then
   echo "error: --no-projects applies only to --secondmate charters" >&2
   exit 1
 fi
+
+# --branch is a ship-only input: a scout creates no branch and a secondmate
+# charter is not a delivery contract, so a value here would look recorded and
+# change nothing, exactly the trap --mode already refuses above.
+if [ "$BRANCH_SET" -eq 1 ] && [ "$KIND" != ship ]; then
+  echo "error: --branch applies only to ship briefs; a scout creates no branch and a secondmate charter is not a delivery contract" >&2
+  exit 1
+fi
+if [ "$BRANCH_SET" -eq 1 ]; then
+  case "$BRANCH" in
+    '') echo "error: --branch requires a non-empty value" >&2; exit 1 ;;
+    -*) echo "error: --branch value must not start with '-' (got '$BRANCH')" >&2; exit 1 ;;
+  esac
+  case "$BRANCH" in
+    *[[:space:]]*) echo "error: --branch value must not contain whitespace (got '$BRANCH')" >&2; exit 1 ;;
+  esac
+  case "$BRANCH" in
+    *"'"*) echo "error: --branch value must not contain a single quote (got '$BRANCH')" >&2; exit 1 ;;
+    *'"'*) echo "error: --branch value must not contain a double quote (got '$BRANCH')" >&2; exit 1 ;;
+  esac
+  # bin/fm-merge-local.sh hardcodes BRANCH="fm/$ID" for a local-only task and
+  # hard-refuses when that ref is absent (its own load-bearing safety check,
+  # out of this script's scope to change): a custom branch here would scaffold
+  # a task firstmate's own local merge gate can never land.
+  if [ "$MODE" = local-only ]; then
+    echo "error: --branch is not supported with --mode local-only: bin/fm-merge-local.sh hardcodes branch fm/$ID and hard-refuses when that ref is absent, so a custom branch would leave this task unmergeable through firstmate's local merge path; use --mode no-mistakes or direct-PR with --branch, or omit --branch for local-only" >&2
+    exit 1
+  fi
+fi
+BRANCH=${BRANCH:-fm/$ID}
 
 BRIEF="$DATA/$ID/brief.md"
 [ -e "$BRIEF" ] && { echo "error: $BRIEF already exists" >&2; exit 1; }
@@ -354,7 +398,7 @@ fi
 case "$MODE" in
   direct-PR)
     SETUP2=""
-    RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
+    RULE1='1. Never push to the default branch (push only your `'"$BRANCH"'` branch). Never merge a PR.'
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 Delivery contract: mode=direct-PR
@@ -366,14 +410,14 @@ EOF
     ;;
   local-only)
     SETUP2=""
-    RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
+    RULE1="1. Never push to any remote and never open a PR. Work only on your \`$BRANCH\` branch; firstmate handles the merge into local \`main\`."
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 Delivery contract: mode=local-only
 This task ships **local-only**: no remote, no PR, no pipeline.
-The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
+The task is complete only when committed on your branch \`$BRANCH\`. Do NOT push, do NOT open a PR, do NOT merge.
 Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
-When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
+When it is implemented and committed, append \`done: ready in branch $BRANCH\` to the status file and stop.
 The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
 EOF
     ;;
@@ -424,7 +468,7 @@ You are in a disposable git worktree of $REPO, at a detached HEAD on a clean def
 The path check is authoritative: \`git rev-parse --git-dir\` and \`git rev-parse --git-common-dir\` can help inspect the repo, but they do not prove you are outside the primary checkout.
 If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
 
-1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2
+1. First action: create your branch: \`git checkout -b $BRANCH\`$SETUP2
 
 # Rules
 $RULE1

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -151,7 +151,7 @@ Only a named non-default branch checked out in `FM_ROOT` is a worktree tangle.
 `fm-tangle-lib.sh` resolves the default branch from `origin/HEAD`, then local `main` or `master`, and classifies that named non-default primary branch as the tangle.
 `fm-guard.sh` prints the repair command on the next mutable fleet action, while `bin/fm-session-start.sh` reports the same condition through bootstrap as a `TANGLE:` line at session start.
 If another live session holds the fleet lock, both surfaces keep the alarm but switch to read-only wording with no repair command.
-Ship briefs also tell the crewmate to verify `pwd -P` and `git rev-parse --show-toplevel` before creating `fm/<id>`, then stop with a blocked status if it landed in the primary checkout.
+Ship briefs also tell the crewmate to verify `pwd -P` and `git rev-parse --show-toplevel` before creating its ship branch (`fm/<id>` by default, or the name passed to `fm-brief.sh --branch`), then stop with a blocked status if it landed in the primary checkout.
 
 ## No-mistakes gate authority boundary
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -217,6 +217,110 @@ test_ship_modes_generate_clean_briefs() {
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"
 }
 
+# Issue #1887: fm-brief.sh hardcoded the ship branch as fm/<task-id>, so a team
+# with its own branch convention had to hand-edit every generated brief before
+# dispatch - and on unfixed code, passing --branch has no effect at all: the
+# flag was not recognized, silently absorbed as an inert positional argument,
+# and the brief still hardcoded fm/<id> regardless. This reproduces exactly
+# that reported condition (assert the custom name appears and the default
+# fm/<id> string is gone) rather than only checking a fresh happy path, and
+# also pins that the historical default stays byte-for-byte unchanged when
+# --branch is omitted, so existing homes see no behavior change.
+test_branch_flag_overrides_default_branch_name() {
+  local home id brief custom
+  home="$TMP_ROOT/branch-flag-home"
+  mkdir -p "$home/data"
+  custom="feat/646/migration-schema"
+
+  id="brief-branch-nomistakes-e1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes --branch "$custom" >/dev/null 2>&1 \
+    || fail "no-mistakes brief with --branch should exit 0"
+  brief="$home/data/$id/brief.md"
+  assert_grep "git checkout -b $custom" "$brief" \
+    "no-mistakes brief did not substitute --branch into the first-action step"
+  assert_grep "1. Never push to the default branch. Never merge a PR." "$brief" \
+    "no-mistakes brief RULE1 changed unexpectedly"
+  assert_no_grep "fm/$id" "$brief" \
+    "no-mistakes brief with --branch still carried the hardcoded fm/<id> default"
+
+  id="brief-branch-directpr-e2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode direct-PR --branch "$custom" >/dev/null 2>&1 \
+    || fail "direct-PR brief with --branch should exit 0"
+  brief="$home/data/$id/brief.md"
+  assert_grep "git checkout -b $custom" "$brief" \
+    "direct-PR brief did not substitute --branch into the first-action step"
+  assert_grep "push only your \`$custom\` branch" "$brief" \
+    "direct-PR brief did not substitute --branch into RULE1"
+  assert_no_grep "fm/$id" "$brief" \
+    "direct-PR brief with --branch still carried the hardcoded fm/<id> default"
+
+  # Omitting --branch must render byte-identical historical output: the same
+  # fm/<id> default no existing caller has ever had to change.
+  id="brief-branch-default-e3"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1 \
+    || fail "brief without --branch should exit 0"
+  brief="$home/data/$id/brief.md"
+  assert_grep "git checkout -b fm/$id" "$brief" \
+    "brief without --branch lost the historical fm/<id> default"
+  assert_grep "1. Never push to the default branch. Never merge a PR." "$brief" \
+    "brief without --branch changed RULE1 unexpectedly"
+  pass "fm-brief.sh: --branch overrides the ship branch and the fm/<id> default is unchanged when omitted"
+}
+
+# The value is rendered into printed shell commands the crewmate and operator
+# run verbatim (e.g. `git checkout -b <branch>`), so a value that would break
+# that quoting must be refused rather than silently corrupt the generated brief.
+test_branch_flag_validation_rejects_unsafe_values() {
+  local home id out status label value expect
+  home="$TMP_ROOT/branch-validation-home"
+  mkdir -p "$home/data"
+  id=0
+  while IFS='|' read -r label value expect; do
+    [ -n "$label" ] || continue
+    id=$((id + 1))
+    out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "brief-branch-invalid-$id" some-proj --mode no-mistakes --branch "$value" 2>&1)
+    status=$?
+    [ "$status" -ne 0 ] || fail "$label: expected a non-zero exit"
+    assert_contains "$out" "$expect" "$label: refusal did not explain the contract"
+    assert_absent "$home/data/brief-branch-invalid-$id/brief.md" "$label: refused scaffold still wrote a brief"
+  done <<'ROWS'
+empty value|--branch requires a non-empty value
+leading dash|-oops|must not start with '-'
+embedded whitespace|feat/with space|must not contain whitespace
+embedded single quote|feat/with'quote|must not contain a single quote
+embedded double quote|feat/with"quote|must not contain a double quote
+ROWS
+  pass "fm-brief.sh: --branch rejects empty, leading-dash, whitespace, and quote values"
+}
+
+# --branch applies only to a ship brief with a mergeable PR-based mode: a scout
+# creates no branch, a secondmate charter is not a delivery contract, and
+# bin/fm-merge-local.sh hardcodes branch fm/<task-id> for mode=local-only and
+# hard-refuses when that ref is absent - so honoring --branch there would
+# scaffold a task firstmate's own local merge gate could never land. Each case
+# must refuse loudly rather than accept and silently drop the flag.
+test_branch_flag_refused_where_it_does_not_apply() {
+  local home out status label args expect
+  home="$TMP_ROOT/branch-refused-home"
+  mkdir -p "$home/data"
+  while IFS='|' read -r label args expect; do
+    [ -n "$label" ] || continue
+    # shellcheck disable=SC2086  # args is an intentional word-split arg list
+    out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" $args 2>&1)
+    status=$?
+    [ "$status" -ne 0 ] || fail "$label: expected a non-zero exit"
+    assert_contains "$out" "$expect" "$label: refusal did not explain why"
+  done <<'ROWS'
+branch on a scout brief|brief-branch-refused-f1 some-proj --scout --branch feat/x|--branch applies only to ship briefs
+branch on a secondmate charter|brief-branch-refused-f2 --secondmate --no-projects --branch feat/x|--branch applies only to ship briefs
+branch with local-only mode|brief-branch-refused-f3 some-proj --mode local-only --branch feat/x|--branch is not supported with --mode local-only
+ROWS
+  assert_absent "$home/data/brief-branch-refused-f1/brief.md" "scout --branch refusal still wrote a brief"
+  assert_absent "$home/data/brief-branch-refused-f2/brief.md" "secondmate --branch refusal still wrote a brief"
+  assert_absent "$home/data/brief-branch-refused-f3/brief.md" "local-only --branch refusal still wrote a brief"
+  pass "fm-brief.sh: --branch is refused on scout, secondmate, and local-only scaffolds"
+}
+
 # A ship task's delivery mode is firstmate's per-task decision, so a missing or
 # unusable value must stop the scaffold instead of silently defaulting. The
 # no-mistakes-prod-only row is the conditional registry policy: it is never a task
@@ -714,6 +818,9 @@ test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
+test_branch_flag_overrides_default_branch_name
+test_branch_flag_validation_rejects_unsafe_values
+test_branch_flag_refused_where_it_does_not_apply
 test_ship_mode_is_required_and_closed_set
 test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -284,7 +284,7 @@ test_branch_flag_validation_rejects_unsafe_values() {
     assert_contains "$out" "$expect" "$label: refusal did not explain the contract"
     assert_absent "$home/data/brief-branch-invalid-$id/brief.md" "$label: refused scaffold still wrote a brief"
   done <<'ROWS'
-empty value|--branch requires a non-empty value
+empty value||--branch requires a non-empty value
 leading dash|-oops|must not start with '-'
 embedded whitespace|feat/with space|must not contain whitespace
 embedded single quote|feat/with'quote|must not contain a single quote


### PR DESCRIPTION
## Summary

- add a ship-only `--branch <name>` option to `fm-brief.sh`, while preserving `fm/<task-id>` as the default
- validate branch values and refuse the option for scouts, secondmates, and `local-only` delivery where it cannot be honored safely
- add regression coverage, repair the empty-value validation row, and document custom ship branches in the architecture guide

Closes #1887