### PR TITLE
fix(bin): stop session owner from misclassifying agent-directory helpers

### DIFF
--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -166,12 +166,12 @@ fm_backend_tmux_classify_process_name() {  # <path> [argv0] -> agent|shell|other
     # `codex` the substring `muse` is a common English fragment - a *muse* glob
     # would classify musescore or amuse as a live agent pane. The install path
     # cannot carry it either: ~/.local/bin/muse-bin-<version> has no `muse` path
-    # COMPONENT, so the fm_harness_path_name fallback below never fires for it.
+    # COMPONENT, so the Claude-only path fallback below never fires for it.
     muse|muse-bin-*) printf 'agent' ;;
     *claude*|*codex*|*opencode*|*grok*|*kimi*|pi|pi-signed|pi-launcher|Pi) printf 'agent' ;;
     zsh|bash|sh|dash|ash|ksh|mksh|tcsh|csh|fish) printf 'shell' ;;
     *)
-      if fm_harness_path_name "$path" >/dev/null || fm_harness_path_name "$argv0" >/dev/null; then
+      if fm_harness_claude_path_matches "$path" || fm_harness_claude_path_matches "$argv0"; then
         printf 'agent'
       else
         printf 'other'

--- a/bin/fm-install-shellcheck.sh
+++ b/bin/fm-install-shellcheck.sh
@@ -14,7 +14,12 @@ DESTINATION=${1:?usage: fm-install-shellcheck.sh <destination-directory>}
 TMP=$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/fm-shellcheck.XXXXXX")
 trap 'rm -rf "$TMP"' EXIT
 
-DOWNLOAD_ATTEMPTS=3
+# CI runners occasionally hit a several-second connectivity blip to GitHub's
+# release CDN (curl exit 56, "Connection died") that a short 1s+2s backoff
+# does not survive. Five attempts with a 3s-stepped backoff (3/6/9/12s, ~30s
+# worst case) stays well inside the job timeout while giving a transient blip
+# room to clear.
+DOWNLOAD_ATTEMPTS=5
 download_attempt=1
 while ! curl -fsSL "$URL" -o "$TMP/$ARCHIVE"; do
   [ "$download_attempt" -lt "$DOWNLOAD_ATTEMPTS" ] || {
@@ -22,7 +27,7 @@ while ! curl -fsSL "$URL" -o "$TMP/$ARCHIVE"; do
     exit 1
   }
   printf 'fm-install-shellcheck.sh: download attempt %s failed; retrying\n' "$download_attempt" >&2
-  sleep "$download_attempt"
+  sleep "$((download_attempt * 3))"
   download_attempt=$((download_attempt + 1))
 done
 ACTUAL_SHA256=$(sha256sum "$TMP/$ARCHIVE" | awk '{print $1}')

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -8,94 +8,90 @@
 # lock-owning primary session before it may arm or rewake.
 # This file is sourced by scripts and has no side effects on source.
 
-# Known harness command names; extend when a new adapter is verified.
-FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$'
+# Known exact harness command names; extend when a new adapter is verified.
+FM_HARNESS_RE='^(claude|codex|opencode|grok|kimi|pi|pi-signed)$'
 
-# The same harnesses as exact executable names. Keep in sync with
-# FM_HARNESS_RE. Used only by the bare-interpreter script-argument check below,
-# where an interpreter's immediate script argument is allowed to name any
-# supported harness, not only Claude.
+# The same harnesses as exact executable names.
+# Keep in sync with FM_HARNESS_RE.
 FM_HARNESS_NAMES=(claude codex opencode grok kimi pi-signed pi)
 
-# True when path $1 has $2 as a whole path component - its own basename or any
-# directory component, but never a component that merely contains $2 as a
-# substring (an unrelated directory such as pi-codex-conversion must not read
-# as "codex", and .pi must not read as "pi").
-fm_path_has_component() {  # <path> <name>
-  local path=$1 name=$2
-  [ -n "$path" ] && [ -n "$name" ] || return 1
+# True when executable path $1 has Claude Code's version-named native-install
+# shape.
+#
+# Claude Code's native installer names the executable by its version
+# (~/.local/share/claude/versions/2.1.220), so the basename identifies nothing.
+# No other verified harness needs path evidence, and accepting an arbitrary
+# harness-named directory would attribute unrelated helpers to that harness.
+fm_harness_claude_path_matches() {  # <path>
+  local path=$1
+  [ -n "$path" ] || return 1
   case "/$path/" in
-    */"$name"/*) return 0 ;;
+    */claude/versions/?*/) return 0 ;;
   esac
   return 1
 }
 
-# True when executable path $1 carries a "claude" whole path component.
+# Print the exact harness name identified by immediate interpreter script path
+# $1, or return 1.
 #
-# This exists because Claude Code's native installer names the per-session
-# executable by its version (~/.local/share/claude/versions/2.1.220), so the
-# basename identifies nothing while the install path still says claude. Matching
-# whole path components only is what keeps that widening safe: an ordinary path
-# such as bin/fm-claude-stop-autoarm.sh or ~/.claude/hooks/notify.sh has no
-# "claude" component and is correctly not a harness process.
-#
-# Deliberately Claude-only: no other supported harness names its per-session
-# executable by version, so widening this to every FM_HARNESS_NAMES entry would
-# accept an unrelated helper merely installed under an agent-named directory
-# (e.g. .../node_modules/@vendor/pi-codex-conversion/.../exec_bridge) as that
-# agent. bin/backends/tmux.sh's fm_backend_tmux_classify_process_name shares
-# this exact fallback for the same reason.
-fm_harness_path_name() {  # <path>
-  fm_path_has_component "$1" claude || return 1
-  printf 'claude'
+# A package directory component may carry the identity when its generic entry
+# point is named cli.js, while a script basename may carry it as codex.js.
+# Whole-component and exact basename matching keep unrelated substrings out.
+fm_harness_script_name() {  # <path>
+  local path=$1 name base
+  [ -n "$path" ] || return 1
+  base=${path##*/}
+  case "$base" in
+    *.js|*.mjs|*.cjs|*.py) base=${base%.*} ;;
+  esac
+  for name in "${FM_HARNESS_NAMES[@]}"; do
+    if [ "$base" = "$name" ]; then
+      printf '%s' "$name"
+      return 0
+    fi
+    case "/$path/" in
+      */"$name"/*) printf '%s' "$name"; return 0 ;;
+    esac
+  done
+  return 1
 }
 
 # True when the process described by command name $1 and full argument string $2
 # is a verified harness. Sets FM_HARNESS_IS_CLAUDE for the ancestry walk.
 #
 # Evidence, in order:
-#   1. the basename of the reported command name, against FM_HARNESS_RE.
-#   2. a "claude" whole path component in that command path or in argv[0]. Both
-#      are needed because the two platforms report different things: macOS
-#      reports argv[0] in `ps -o comm=`, while procps on Linux reports the
-#      kernel exec name and ignores argv[0] entirely, so a version-named Claude
-#      Code binary is identified by its install path on macOS and by argv[0] on
-#      Linux.
-#   3. a bare interpreter (node, python) whose IMMEDIATE script argument - not
-#      the whole argument string - names a supported harness via a whole path
-#      component. Checking only argv[1] and only whole components is what keeps
-#      an unrelated helper safe: a compiled binary that merely lives under
-#      node_modules (so $base, its own basename, never contains "node") and
-#      whose install path merely contains a harness name as part of a longer,
-#      unrelated component (e.g. pi-codex-conversion) must never match here.
+#   1. the exact basename of the reported command name, against FM_HARNESS_RE.
+#   2. Claude Code's version-named native-install shape in that command path or
+#      in argv[0]. Both are needed because macOS reports argv[0] in `ps -o
+#      comm=`, while procps on Linux reports the kernel exec name and ignores
+#      argv[0] entirely.
+#   3. an exact bare interpreter (node or python) whose immediate script
+#      argument identifies a harness.
 FM_HARNESS_IS_CLAUDE=0
 fm_harness_process_matches() {  # <comm> <args>
-  local comm=$1 args=$2 base argv0 argv1 rest name
+  local comm=$1 args=$2 base argv0 rest script name
   FM_HARNESS_IS_CLAUDE=0
   base=$(basename -- "$comm")
   if printf '%s' "$base" | grep -qE "$FM_HARNESS_RE"; then
-    case "$base" in *claude*) FM_HARNESS_IS_CLAUDE=1 ;; esac
+    [ "$base" = claude ] && FM_HARNESS_IS_CLAUDE=1
     return 0
   fi
-  argv0=${args%% *}
-  if fm_harness_path_name "$comm" >/dev/null || fm_harness_path_name "$argv0" >/dev/null; then
+  argv0=${args%%[[:space:]]*}
+  if fm_harness_claude_path_matches "$comm" || fm_harness_claude_path_matches "$argv0"; then
     FM_HARNESS_IS_CLAUDE=1
     return 0
   fi
-  case "$base" in
-    *node*|*python*)
-      case "$args" in
-        *' '*) rest=${args#* }; argv1=${rest%% *} ;;
-        *) argv1='' ;;
-      esac
-      for name in "${FM_HARNESS_NAMES[@]}"; do
-        if fm_path_has_component "$argv1" "$name"; then
-          case "$name" in claude) FM_HARNESS_IS_CLAUDE=1 ;; esac
-          return 0
-        fi
-      done
-      ;;
-  esac
+  if printf '%s' "$base" | grep -qE '^(node|nodejs|python([0-9]+(\.[0-9]+)?)?)$'; then
+    rest=${args#"$argv0"}
+    rest=${rest#"${rest%%[![:space:]]*}"}
+    script=${rest%%[[:space:]]*}
+    if name=$(fm_harness_script_name "$script"); then
+      if [ "$name" = claude ]; then
+        FM_HARNESS_IS_CLAUDE=1
+      fi
+      return 0
+    fi
+  fi
   return 1
 }
 

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -12,13 +12,25 @@
 FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$'
 
 # The same harnesses as exact executable names. Keep in sync with
-# FM_HARNESS_RE. Used only for the stricter path evidence below, where the
-# loose regex would also match ordinary firstmate paths such as
-# bin/fm-claude-stop-autoarm.sh.
+# FM_HARNESS_RE. Used only by the bare-interpreter script-argument check below,
+# where an interpreter's immediate script argument is allowed to name any
+# supported harness, not only Claude.
 FM_HARNESS_NAMES=(claude codex opencode grok kimi pi-signed pi)
 
-# Print the exact harness name carried by executable path $1 - its own basename
-# or any directory component - or return 1.
+# True when path $1 has $2 as a whole path component - its own basename or any
+# directory component, but never a component that merely contains $2 as a
+# substring (an unrelated directory such as pi-codex-conversion must not read
+# as "codex", and .pi must not read as "pi").
+fm_path_has_component() {  # <path> <name>
+  local path=$1 name=$2
+  [ -n "$path" ] && [ -n "$name" ] || return 1
+  case "/$path/" in
+    */"$name"/*) return 0 ;;
+  esac
+  return 1
+}
+
+# True when executable path $1 carries a "claude" whole path component.
 #
 # This exists because Claude Code's native installer names the per-session
 # executable by its version (~/.local/share/claude/versions/2.1.220), so the
@@ -26,15 +38,16 @@ FM_HARNESS_NAMES=(claude codex opencode grok kimi pi-signed pi)
 # whole path components only is what keeps that widening safe: an ordinary path
 # such as bin/fm-claude-stop-autoarm.sh or ~/.claude/hooks/notify.sh has no
 # "claude" component and is correctly not a harness process.
+#
+# Deliberately Claude-only: no other supported harness names its per-session
+# executable by version, so widening this to every FM_HARNESS_NAMES entry would
+# accept an unrelated helper merely installed under an agent-named directory
+# (e.g. .../node_modules/@vendor/pi-codex-conversion/.../exec_bridge) as that
+# agent. bin/backends/tmux.sh's fm_backend_tmux_classify_process_name shares
+# this exact fallback for the same reason.
 fm_harness_path_name() {  # <path>
-  local path=$1 name
-  [ -n "$path" ] || return 1
-  for name in "${FM_HARNESS_NAMES[@]}"; do
-    case "/$path/" in
-      */"$name"/*) printf '%s' "$name"; return 0 ;;
-    esac
-  done
-  return 1
+  fm_path_has_component "$1" claude || return 1
+  printf 'claude'
 }
 
 # True when the process described by command name $1 and full argument string $2
@@ -42,15 +55,22 @@ fm_harness_path_name() {  # <path>
 #
 # Evidence, in order:
 #   1. the basename of the reported command name, against FM_HARNESS_RE.
-#   2. an exact harness component in that command path or in argv[0]. Both are
-#      needed because the two platforms report different things: macOS reports
-#      argv[0] in `ps -o comm=`, while procps on Linux reports the kernel exec
-#      name and ignores argv[0] entirely, so a version-named Claude Code binary
-#      is identified by its install path on macOS and by argv[0] on Linux.
-#   3. a bare interpreter (node, python) running a harness script path.
+#   2. a "claude" whole path component in that command path or in argv[0]. Both
+#      are needed because the two platforms report different things: macOS
+#      reports argv[0] in `ps -o comm=`, while procps on Linux reports the
+#      kernel exec name and ignores argv[0] entirely, so a version-named Claude
+#      Code binary is identified by its install path on macOS and by argv[0] on
+#      Linux.
+#   3. a bare interpreter (node, python) whose IMMEDIATE script argument - not
+#      the whole argument string - names a supported harness via a whole path
+#      component. Checking only argv[1] and only whole components is what keeps
+#      an unrelated helper safe: a compiled binary that merely lives under
+#      node_modules (so $base, its own basename, never contains "node") and
+#      whose install path merely contains a harness name as part of a longer,
+#      unrelated component (e.g. pi-codex-conversion) must never match here.
 FM_HARNESS_IS_CLAUDE=0
 fm_harness_process_matches() {  # <comm> <args>
-  local comm=$1 args=$2 base argv0 name
+  local comm=$1 args=$2 base argv0 argv1 rest name
   FM_HARNESS_IS_CLAUDE=0
   base=$(basename -- "$comm")
   if printf '%s' "$base" | grep -qE "$FM_HARNESS_RE"; then
@@ -58,17 +78,22 @@ fm_harness_process_matches() {  # <comm> <args>
     return 0
   fi
   argv0=${args%% *}
-  if name=$(fm_harness_path_name "$comm") || name=$(fm_harness_path_name "$argv0"); then
-    case "$name" in claude) FM_HARNESS_IS_CLAUDE=1 ;; esac
+  if fm_harness_path_name "$comm" >/dev/null || fm_harness_path_name "$argv0" >/dev/null; then
+    FM_HARNESS_IS_CLAUDE=1
     return 0
   fi
-  # Bare interpreter (e.g. node): match the harness name in its script path.
-  case "$comm" in
+  case "$base" in
     *node*|*python*)
-      if printf '%s' "$args" | grep -qE "$FM_HARNESS_RE"; then
-        case "$args" in *claude*) FM_HARNESS_IS_CLAUDE=1 ;; esac
-        return 0
-      fi
+      case "$args" in
+        *' '*) rest=${args#* }; argv1=${rest%% *} ;;
+        *) argv1='' ;;
+      esac
+      for name in "${FM_HARNESS_NAMES[@]}"; do
+        if fm_path_has_component "$argv1" "$name"; then
+          case "$name" in claude) FM_HARNESS_IS_CLAUDE=1 ;; esac
+          return 0
+        fi
+      done
       ;;
   esac
   return 1

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -5,7 +5,8 @@
 # lock, and does the current process descend from that same harness?" decision.
 # bin/fm-lock.sh uses it to acquire and inspect state/.lock;
 # bin/fm-claude-stop-autoarm.sh uses it to prove a Stop hook fires inside the
-# lock-owning primary session before it may arm or rewake.
+# lock-owning primary session before it may arm or rewake; bin/backends/tmux.sh
+# uses its Claude native-install path check to attribute tmux pane liveness.
 # This file is sourced by scripts and has no side effects on source.
 
 # Known exact harness command names; extend when a new adapter is verified.

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -61,7 +61,10 @@ fm_harness_script_name() {  # <path>
 # is a verified harness. Sets FM_HARNESS_IS_CLAUDE for the ancestry walk.
 #
 # Evidence, in order:
-#   1. the exact basename of the reported command name, against FM_HARNESS_RE.
+#   1. the exact basename of the reported command name, against FM_HARNESS_RE -
+#      stripping one leading "-" first, since a login-shell-style invocation
+#      (`exec -a -codex ...`) reports comm/argv[0] with that convention-carried
+#      dash and is still the same exact harness executable.
 #   2. Claude Code's version-named native-install shape in that command path or
 #      in argv[0]. Both are needed because macOS reports argv[0] in `ps -o
 #      comm=`, while procps on Linux reports the kernel exec name and ignores
@@ -70,11 +73,12 @@ fm_harness_script_name() {  # <path>
 #      argument identifies a harness.
 FM_HARNESS_IS_CLAUDE=0
 fm_harness_process_matches() {  # <comm> <args>
-  local comm=$1 args=$2 base argv0 rest script name
+  local comm=$1 args=$2 base dashless argv0 rest script name
   FM_HARNESS_IS_CLAUDE=0
   base=$(basename -- "$comm")
-  if printf '%s' "$base" | grep -qE "$FM_HARNESS_RE"; then
-    [ "$base" = claude ] && FM_HARNESS_IS_CLAUDE=1
+  dashless=${base#-}
+  if printf '%s' "$dashless" | grep -qE "$FM_HARNESS_RE"; then
+    [ "$dashless" = claude ] && FM_HARNESS_IS_CLAUDE=1
     return 0
   fi
   argv0=${args%%[[:space:]]*}

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -36,7 +36,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and unhealthy supervision    |
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |
-| `fm-session-lock-lib.sh` | Shared session-lock harness identity (ancestry walk and holder liveness) for fm-lock.sh and the Claude Stop auto-arm |
+| `fm-session-lock-lib.sh` | Shared session-lock harness identity for fm-lock.sh and the Claude Stop auto-arm, with Claude path attribution reused by tmux |
 | `fm-claude-stop-autoarm.sh` | Claude Stop `asyncRewake` hook owning tokenless watcher continuity with single-flight exit-2 rewake (docs/watcher-continuity.md) |
 | `fm-turnend-guard.sh`    | Shared primary turn-end guard predicate so no turn ends blind (docs/turnend-guard.md) |
 | `fm-turnend-guard-grok.sh` | Grok Stop-hook adapter for the primary turn-end guard                              |

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -53,7 +53,7 @@ Only `dead` and `missing` authorize recovery because a false dead result could l
 
 For positive attribution, the probe combines two independent name sources rather than making either one load-bearing.
 `#{pane_current_command}` and the pane tty foreground process group's kernel `comm` values expose different name fields, and which one retains executable identity is platform-dependent.
-The foreground probe also reads argv[0] so an exact harness install-path component can carry the verdict when the other fields expose a rewritten process name.
+The foreground probe also reads argv[0] so Claude Code's version-named native-install path can carry the verdict when the other fields expose a rewritten process name.
 Either source naming a verified harness is enough for `alive`, because a false `dead` is the one verdict that can start a duplicate agent on a live worktree, while a readable foreground process group settles the negative verdicts.
 
 Scoping the second source to the foreground process group rather than to the pane's descendants is deliberate: a harness-named process left running in the background of an otherwise idle pane must not read as an agent.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -78,7 +78,27 @@ alive
 
 `#{pane_current_command}` and foreground `ps -o comm=` read different name fields, but which one preserves executable identity is platform-dependent.
 On macOS the pane command reflected the rewritable title while the full install path could survive in `ps -o comm=`; in the Linux portable regression those roles reversed for the version-named native executable, with the identifying path retained in argv[0].
-The classifier therefore accepts a harness basename first, then an exact harness path component in the full executable path, then the same component in argv[0], without depending on which field carries it on a given platform.
+The classifier therefore accepts a harness basename first, then Claude Code's version-named native-install shape in the full executable path or argv[0], without depending on which field carries it on a given platform.
+
+The helper-path boundary and the exact primary-harness controls were reverified on 2026-08-11 with GNU bash 5.2.21 and tmux 3.4 on Linux x86_64.
+
+```sh
+bash --version | head -1
+tmux -V
+tests/fm-session-lock-ancestry.test.sh | rg 'supported exact|bare interpreters|exec_bridge'
+tests/fm-tmux-agent-liveness.test.sh | rg 'helper executables'
+```
+
+Observed output:
+
+```text
+GNU bash, version 5.2.21(1)-release (x86_64-pc-linux-gnu)
+tmux 3.4
+ok - session-lock: every supported exact harness executable resolves
+ok - session-lock: bare interpreters use only the immediate harness script argument
+ok - session-lock: exec_bridge under an agent-named install path defers to its parent Pi harness
+ok - tmux liveness: helper executables under agent-named install paths stay unattributed
+```
 
 The portable regression is CI-enforced, while the real-harness drift guard is opt-in under the policy in `.agents/skills/firstmate-coding-guidelines/SKILL.md`.
 Run the live guard after any harness upgrade and before trusting or refreshing the table above:

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -87,6 +87,97 @@ SH
   pass "session-lock: a version-named Claude Code session is identified from its install path and argv[0]"
 }
 
+test_exact_supported_harness_names_resolve() {
+  local dir fakebin harness got
+  dir="$TMP_ROOT/exact-harnesses"
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field= pid=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) pid=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$pid:$field" in
+  720:comm=) printf '%s\n' "$FM_TEST_HARNESS" ;;
+  720:args=) printf '%s\n' "$FM_TEST_HARNESS --resume" ;;
+  720:ppid=) printf '%s\n' 1 ;;
+  *:comm=) printf '%s\n' bash ;;
+  *:args=) printf '%s\n' 'bash /repo/bin/fm-watch-arm.sh' ;;
+  *:ppid=) printf '%s\n' 720 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+
+  for harness in claude codex opencode pi pi-signed grok kimi; do
+    got=$(FM_TEST_HARNESS="$harness" lib_eval "$fakebin" 'fm_harness_ancestry_pid') \
+      || fail "$harness: the exact harness executable was not found in ancestry"
+    [ "$got" = 720 ] || fail "$harness: ancestry resolved '$got', expected harness pid 720"
+    FM_TEST_HARNESS="$harness" lib_eval "$fakebin" 'fm_harness_pid_alive 720' \
+      || fail "$harness: the exact harness executable failed the liveness predicate"
+  done
+  pass "session-lock: every supported exact harness executable resolves"
+}
+
+test_bare_interpreter_script_paths_resolve() {
+  local harness
+  for harness in claude codex opencode pi pi-signed grok kimi; do
+    lib_eval /usr/bin "fm_harness_process_matches node 'node /opt/$harness/bin/cli.js --resume'" \
+      || fail "$harness: an immediate bare-interpreter script path was not recognized"
+  done
+  if lib_eval /usr/bin "fm_harness_process_matches node 'node /opt/tools/runner.js --label codex'"; then
+    fail "a harness name in an unrelated later interpreter argument was recognized"
+  fi
+  pass "session-lock: bare interpreters use only the immediate harness script argument"
+}
+
+test_exec_bridge_defers_to_parent_pi() {
+  local dir fakebin got helper
+  dir="$TMP_ROOT/exec-bridge"
+  fakebin=$(fm_fakebin "$dir")
+  helper='/Users/u/.pi/agent/npm/node_modules/@howaboua/pi-codex-conversion/src/tools/exec/bin/darwin-arm64/exec_bridge'
+  mkdir -p "$dir/state"
+  cat > "$fakebin/ps" <<SH
+#!/usr/bin/env bash
+set -u
+field= pid=
+while [ "\$#" -gt 0 ]; do
+  case "\$1" in
+    -o) field=\$2; shift 2 ;;
+    -p) pid=\$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "\$pid:\$field" in
+  820:comm=) printf '%s\\n' '$helper' ;;
+  820:args=) printf '%s\\n' '$helper --pipe' ;;
+  820:ppid=) printf '%s\\n' 830 ;;
+  830:comm=) printf '%s\\n' pi ;;
+  830:args=) printf '%s\\n' 'pi --mode rpc' ;;
+  830:ppid=) printf '%s\\n' 1 ;;
+  *:comm=) printf '%s\\n' bash ;;
+  *:args=) printf '%s\\n' 'bash /repo/bin/fm-watch-arm.sh' ;;
+  *:ppid=) printf '%s\\n' 820 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+  printf '830\n' > "$dir/state/.lock"
+
+  if lib_eval "$fakebin" 'fm_harness_pid_alive 820'; then
+    fail "exec_bridge under .pi/node_modules/pi-codex-conversion was classified as a harness"
+  fi
+  got=$(lib_eval "$fakebin" 'fm_harness_ancestry_pid') \
+    || fail "the parent Pi harness was not found above exec_bridge"
+  [ "$got" = 830 ] || fail "ancestry resolved '$got', expected parent Pi pid 830"
+  lib_eval "$fakebin" "fm_session_lock_owned_by_self '$dir/state'" \
+    || fail "the parent Pi harness did not recognize its session lock"
+  pass "session-lock: exec_bridge under an agent-named install path defers to its parent Pi harness"
+}
+
 test_ordinary_paths_are_never_harness_processes() {
   local dir fakebin shape
   dir="$TMP_ROOT/ordinary-paths"
@@ -117,9 +208,9 @@ SH
   chmod +x "$fakebin/ps"
   printf '810\n' > "$dir/state/.lock"
 
-  # Identity may be read from an executable path, but only from whole path
-  # components: anything merely living under ~/.claude, and any component that
-  # merely starts with a harness name, must stay outside the harness identity.
+  # Only Claude's verified native-install shape may supply path identity.
+  # Anything merely living under ~/.claude, and any component that merely
+  # starts with a harness name, must stay outside the harness identity.
   for shape in hookdir piprefix; do
     if FM_TEST_PATH_SHAPE="$shape" lib_eval "$fakebin" 'fm_harness_ancestry_pid'; then
       fail "$shape: an ordinary script path was treated as a harness process"
@@ -493,6 +584,9 @@ test_e2e_daemon_parented_version_named_session_keeps_its_lock() {
 }
 
 test_version_named_session_is_identified_on_both_platforms
+test_exact_supported_harness_names_resolve
+test_bare_interpreter_script_paths_resolve
+test_exec_bridge_defers_to_parent_pi
 test_ordinary_paths_are_never_harness_processes
 test_exec_bridge_under_agent_named_directory_is_not_misclassified
 test_every_supported_harness_still_resolves_as_lock_owner

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -134,6 +134,144 @@ SH
   pass "session-lock: ordinary script paths under a harness directory are not harness processes"
 }
 
+test_exec_bridge_under_agent_named_directory_is_not_misclassified() {
+  local dir fakebin shape got
+  dir="$TMP_ROOT/exec-bridge"
+  fakebin=$(fm_fakebin "$dir")
+  mkdir -p "$dir/state"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field= pid=
+EXEC_BRIDGE_PATH='/Users/u/.pi/agent/npm/node_modules/@howaboua/pi-codex-conversion/src/tools/exec/bin/darwin-arm64/exec_bridge'
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) pid=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$pid:$field:${FM_TEST_BRIDGE_SHAPE:-linux}" in
+  # Linux: ps -o comm= reports the kernel exec name, so comm is exec_bridge's
+  # own basename with no directory components at all.
+  300:comm=:linux) printf '%s\n' 'exec_bridge' ;;
+  300:args=:linux) printf '%s\n' "$EXEC_BRIDGE_PATH --serve" ;;
+  # macOS: ps -o comm= reports argv[0], the full install path - the exact shape
+  # the reported issue reproduced.
+  300:comm=:macos) printf '%s\n' "$EXEC_BRIDGE_PATH" ;;
+  300:args=:macos) printf '%s\n' "$EXEC_BRIDGE_PATH --serve" ;;
+  # A genuine node interpreter whose immediate script argument happens to be
+  # this same unrelated helper path.
+  300:comm=:node_argv1) printf '%s\n' node ;;
+  300:args=:node_argv1) printf '%s\n' "node $EXEC_BRIDGE_PATH --serve" ;;
+  300:ppid=:*) printf '%s\n' 310 ;;
+  310:comm=:*) printf '%s\n' pi ;;
+  310:args=:*) printf '%s\n' pi ;;
+  310:ppid=:*) printf '%s\n' 1 ;;
+  *:comm=:*) printf '%s\n' bash ;;
+  *:args=:*) printf '%s\n' 'bash /repo/bin/fm-watch-arm.sh' ;;
+  *:ppid=:*) printf '%s\n' 300 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+  printf '310\n' > "$dir/state/.lock"
+
+  for shape in linux macos node_argv1; do
+    got=$(FM_TEST_BRIDGE_SHAPE="$shape" lib_eval "$fakebin" 'fm_harness_ancestry_pid') \
+      || fail "$shape: no harness ancestor was found at all above the exec_bridge helper"
+    [ "$got" = 310 ] || fail "$shape: ancestry resolved '$got', expected the parent Pi engine pid 310, not the exec_bridge helper (300)"
+    FM_TEST_BRIDGE_SHAPE="$shape" lib_eval "$fakebin" "fm_session_lock_owned_by_self '$dir/state'" \
+      || fail "$shape: the real Pi session holding the lock was not recognized as the owner"
+  done
+  pass "session-lock: a helper executable under an agent-named directory (exec_bridge) is never the session owner - its parent harness is"
+}
+
+test_every_supported_harness_still_resolves_as_lock_owner() {
+  local dir fakebin harness got
+  dir="$TMP_ROOT/every-harness"
+  fakebin=$(fm_fakebin "$dir")
+  mkdir -p "$dir/state"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field= pid=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) pid=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$pid:$field" in
+  950:comm=) printf '%s\n' "${FM_TEST_HARNESS_NAME:-claude}" ;;
+  950:args=) printf '%s\n' "${FM_TEST_HARNESS_NAME:-claude}" ;;
+  950:ppid=) printf '%s\n' 1 ;;
+  *:comm=) printf '%s\n' bash ;;
+  *:args=) printf '%s\n' 'bash tests/run.sh' ;;
+  *:ppid=) printf '%s\n' 950 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+  printf '950\n' > "$dir/state/.lock"
+
+  # Negative controls against the exec_bridge fix above: the narrowed
+  # classifier must still recognize every verified adapter's exact executable
+  # name, so tightening the false-positive paths never locks a real session
+  # out of its own fleet.
+  for harness in claude codex opencode pi pi-signed grok kimi; do
+    got=$(FM_TEST_HARNESS_NAME="$harness" lib_eval "$fakebin" 'fm_harness_ancestry_pid') \
+      || fail "$harness: exact executable name was not recognized as a harness process at all"
+    [ "$got" = 950 ] || fail "$harness: ancestry resolved '$got', expected the exact-named harness pid 950"
+    FM_TEST_HARNESS_NAME="$harness" lib_eval "$fakebin" "fm_session_lock_owned_by_self '$dir/state'" \
+      || fail "$harness: the session holding the lock did not recognize itself as the owner"
+  done
+  pass "session-lock: every supported harness's exact executable name still resolves as the lock owner"
+}
+
+test_bare_interpreter_positive_cases_still_resolve() {
+  local dir fakebin shape got
+  dir="$TMP_ROOT/bare-interpreter"
+  fakebin=$(fm_fakebin "$dir")
+  mkdir -p "$dir/state"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field= pid=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) pid=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$pid:$field:${FM_TEST_INTERP_SHAPE:-node-codex}" in
+  400:comm=:node-codex) printf '%s\n' node ;;
+  400:args=:node-codex) printf '%s\n' '/usr/local/bin/node /usr/local/lib/node_modules/@vendor/codex/bin/codex.js --flag' ;;
+  400:comm=:node-opencode) printf '%s\n' node ;;
+  400:args=:node-opencode) printf '%s\n' 'node /home/u/.opencode/bin/opencode' ;;
+  400:comm=:python-grok) printf '%s\n' python3 ;;
+  400:args=:python-grok) printf '%s\n' 'python3 /opt/grok/grok_cli.py' ;;
+  400:comm=:python-kimi) printf '%s\n' python ;;
+  400:args=:python-kimi) printf '%s\n' 'python /opt/kimi/kimi.py' ;;
+  400:ppid=:*) printf '%s\n' 1 ;;
+  *:comm=:*) printf '%s\n' bash ;;
+  *:args=:*) printf '%s\n' 'bash tests/run.sh' ;;
+  *:ppid=:*) printf '%s\n' 400 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+  printf '400\n' > "$dir/state/.lock"
+
+  for shape in node-codex node-opencode python-grok python-kimi; do
+    got=$(FM_TEST_INTERP_SHAPE="$shape" lib_eval "$fakebin" 'fm_harness_ancestry_pid') \
+      || fail "$shape: a bare interpreter whose immediate script argument names a harness was not recognized"
+    [ "$got" = 400 ] || fail "$shape: ancestry resolved '$got', expected the interpreter pid 400"
+    FM_TEST_INTERP_SHAPE="$shape" lib_eval "$fakebin" "fm_session_lock_owned_by_self '$dir/state'" \
+      || fail "$shape: the interpreter-run harness holding the lock did not recognize itself as the owner"
+  done
+  pass "session-lock: a bare node/python interpreter whose immediate script argument names a harness still resolves"
+}
+
 test_harness_beyond_a_gap_never_owns_the_lock() {
   local dir fakebin got
   dir="$TMP_ROOT/gap"
@@ -356,6 +494,9 @@ test_e2e_daemon_parented_version_named_session_keeps_its_lock() {
 
 test_version_named_session_is_identified_on_both_platforms
 test_ordinary_paths_are_never_harness_processes
+test_exec_bridge_under_agent_named_directory_is_not_misclassified
+test_every_supported_harness_still_resolves_as_lock_owner
+test_bare_interpreter_positive_cases_still_resolve
 test_harness_beyond_a_gap_never_owns_the_lock
 test_competing_version_named_session_is_seen_as_live
 test_e2e_version_named_session_claims_the_home

--- a/tests/fm-tmux-agent-liveness.test.sh
+++ b/tests/fm-tmux-agent-liveness.test.sh
@@ -81,6 +81,11 @@ chmod +x "$LAB/bin/agent-launcher"
 . "$ROOT/bin/fm-backend.sh"
 fm_backend_source tmux || fail "fm_backend_source tmux failed"
 
+exec_bridge='/Users/u/.pi/agent/npm/node_modules/@howaboua/pi-codex-conversion/src/tools/exec/bin/darwin-arm64/exec_bridge'
+[ "$(fm_backend_tmux_classify_process_name "$exec_bridge" "$exec_bridge")" = other ] \
+  || fail "exec_bridge under an agent-named install path must not classify as an agent"
+pass "tmux liveness: helper executables under agent-named install paths stay unattributed"
+
 "$REAL_TMUX" -L "$SOCKET" new-session -d -s "$SESSION" -n idle -c "$LAB/wt" \
   || fail "could not start the private tmux server"
 
@@ -186,14 +191,14 @@ if [ -n "$CC_BIN" ] &&
   "$CC_BIN" -o "$LAB/bin/decoy/2.1.220" "$LAB/spin.c" 2>/dev/null; then
   new_window titled "$LAB/bin/claude/2.1.220"
   wait_for_state "$SESSION:titled" alive \
-    || fail "a version-named executable under a harness install path must classify alive"
+    || fail "a version-named executable under Claude's native install path must classify alive"
   assert_sources_disagree "$SESSION:titled" "version-string process name"
-  pass "tmux liveness: a version-named executable under a harness install path classifies alive"
+  pass "tmux liveness: a version-named executable under Claude's native install path classifies alive"
 
   new_window path-decoy "$LAB/bin/decoy/2.1.220"
   wait_for_state "$SESSION:path-decoy" ambiguous \
-    || fail "a version-named executable without a whole harness path component must stay ambiguous"
-  pass "tmux liveness: a version-named executable under a decoy path stays ambiguous"
+    || fail "a version-named executable outside Claude's native install path must stay ambiguous"
+  pass "tmux liveness: a version-named executable outside Claude's native install path stays ambiguous"
 else
   echo "skip: no C compiler, so the version-string process-name case cannot build its executable"
 fi

--- a/tests/fm-tmux-agent-liveness.test.sh
+++ b/tests/fm-tmux-agent-liveness.test.sh
@@ -38,7 +38,7 @@ trap cleanup_all EXIT
 
 # A `tmux` shim on PATH so bin/backends/tmux.sh's bare `tmux` calls reach the
 # private socket and never touch the host's real sessions.
-mkdir -p "$LAB/shim" "$LAB/bin" "$LAB/bin/claude" "$LAB/bin/decoy" "$LAB/wt"
+mkdir -p "$LAB/shim" "$LAB/bin" "$LAB/bin/claude/versions" "$LAB/bin/decoy" "$LAB/wt"
 cat > "$LAB/shim/tmux" <<SH
 #!/usr/bin/env bash
 exec "$REAL_TMUX" -L "$SOCKET" "\$@"
@@ -187,9 +187,9 @@ pass "tmux liveness: unrelated muse-containing command names stay ambiguous"
 CC_BIN=$(command -v cc 2>/dev/null || command -v gcc 2>/dev/null || true)
 if [ -n "$CC_BIN" ] &&
   printf '%s\n' '#include <unistd.h>' 'int main(void){for(;;)sleep(60);return 0;}' > "$LAB/spin.c" &&
-  "$CC_BIN" -o "$LAB/bin/claude/2.1.220" "$LAB/spin.c" 2>/dev/null &&
+  "$CC_BIN" -o "$LAB/bin/claude/versions/2.1.220" "$LAB/spin.c" 2>/dev/null &&
   "$CC_BIN" -o "$LAB/bin/decoy/2.1.220" "$LAB/spin.c" 2>/dev/null; then
-  new_window titled "$LAB/bin/claude/2.1.220"
+  new_window titled "$LAB/bin/claude/versions/2.1.220"
   wait_for_state "$SESSION:titled" alive \
     || fail "a version-named executable under Claude's native install path must classify alive"
   assert_sources_disagree "$SESSION:titled" "version-string process name"

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -1123,7 +1123,11 @@ install_integrated_autoarm() {
   cp "$ROOT/bin/fm-session-lock-lib.sh" "$dir/bin/fm-session-lock-lib.sh"
   cp "$ROOT/bin/fm-lock.sh" "$dir/bin/fm-lock.sh"
   chmod +x "$dir/bin/fm-claude-stop-autoarm.sh" "$dir/bin/fm-lock.sh"
-  ln -s /bin/bash "$dir/fake-claude"
+  # Named exactly "claude" (not e.g. "fake-claude"): the session-lock harness
+  # identity match is an exact basename match, so a decoy name only containing
+  # "claude" as a substring would not resolve as the harness ancestry does for
+  # a genuine Claude Code process.
+  ln -s /bin/bash "$dir/claude"
 }
 
 run_integrated_autoarm() {
@@ -1131,7 +1135,7 @@ run_integrated_autoarm() {
   home=$(cd "$dir" && pwd)
   # shellcheck disable=SC2016 # the fake harness expands FM_HOME inside its child shell.
   printf '{"session_id":"sess-claude-mode","stop_hook_active":false}\n' \
-    | FM_HOME="$home" "$dir/fake-claude" -c '
+    | FM_HOME="$home" "$dir/claude" -c '
         printf "%s\n" "$$" > "$FM_HOME/state/.lock"
         "$FM_HOME/bin/fm-claude-stop-autoarm.sh"
       ' 2>&1


### PR DESCRIPTION
## Summary

- restrict path-based harness identity to Claude’s version-named install layout
- inspect only a bare interpreter’s immediate script argument using whole path components
- add regression coverage for exec_bridge false positives and all supported harness detection paths

## Decisions

- Kept this PR narrow to the reported path-only false positive. The tmux classifier retains its existing substring basename policy because this issue’s exec_bridge regression does not prove a broader exact-identity refactor is required, and observed vendor identities such as codex-aarch64-a and kimi-code still depend on that flexibility.
- This change does alter holder-liveness matching, disclosed here so it can be tracked separately. `fm_harness_pid_alive()` (`bin/fm-session-lock-lib.sh:159`) reaches the shared harness-identity rule by calling `fm_harness_process_matches()` (`:164`), and that rule now strips one leading `-` from the reported basename before the exact match. A login-shell-style harness invocation (`exec -a -codex ...`) previously failed to match and was therefore judged not alive; it now matches and is judged a live holder. This readmits genuine harness processes that the first version of this fix had wrongly excluded, and it does not restore substring path matching, so the reported exec_bridge false positive stays fixed.
- Withdrawing the earlier claim that this PR does not change holder-liveness semantics: it does, as described above. What still holds is the narrower claim that this PR does not change the lock write boundary. Composability with PR #2132’s recycled-PID identity work should therefore be re-checked against the dash-stripped matching rule rather than assumed.
- The separate Codex Desktop app-server lifetime problem remains unchanged and out of scope.

Closes #2067
