### PR TITLE
feat(snapshot): expose registered projects

### DIFF
--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -52,6 +52,15 @@
 #     structured homes with an unknown current classification are partial, not
 #     unreadable, and retain independently trustworthy structured surfaces.
 #   secondmate_guidance: return-channel action note for renderers and bearings.
+#   project_registry: {present,available,complete,reason,records[],total,shown,
+#     truncated} - minimal public projection of data/projects.md: registered
+#     project NAMES only (records[].name), so a project with no backlog history
+#     and no live task can still be discovered. Never includes project paths,
+#     git remotes, descriptions, registration dates, or delivery mode/posture/
+#     yolo - those stay captain-private. present=false means no registry file
+#     (not an error); available=false means it exists but could not be read
+#     (permissions or timeout), with reason set. complete=false means the
+#     bounded read truncated before covering every registered project.
 #
 # Compatibility: JSON is the primary machine-readable surface.
 # Human views must render this output instead of parsing state files again.
@@ -161,9 +170,10 @@ FM_SNAPSHOT_TERMINAL_TIMEOUT and never becomes canonical current state.
 Parent activity evidence uses FM_SNAPSHOT_PARENT_ACTIVITY_LINES,
 FM_SNAPSHOT_PARENT_ACTIVITY_BYTES, FM_SNAPSHOT_PARENT_ACTIVITIES, and
 FM_SNAPSHOT_PARENT_ACTIVITY_TIMEOUT, with truncation disclosed in the result.
-The registered secondmate table uses FM_SNAPSHOT_REGISTRY_LINES,
-FM_SNAPSHOT_REGISTRY_BYTES, FM_SNAPSHOT_REGISTRY_RECORDS, and
-FM_SNAPSHOT_REGISTRY_TIMEOUT, with unavailability and truncation disclosed.
+The registered secondmate table and the project_registry projection of
+data/projects.md share FM_SNAPSHOT_REGISTRY_LINES, FM_SNAPSHOT_REGISTRY_BYTES,
+FM_SNAPSHOT_REGISTRY_RECORDS, and FM_SNAPSHOT_REGISTRY_TIMEOUT, with
+unavailability and truncation disclosed.
 EOF
 }
 
@@ -910,6 +920,99 @@ JQ
     '{present:true,available:false,complete:false,reason:$reason,provenance:"registered-table",path:$path,freshness:{status:"unavailable",observed_at:$observed},records:[],input_truncated:false,records_truncated:false,reasons:[$reason],lines_in_window:0,records_in_window:0}'
 }
 
+# Minimal public projection of data/projects.md: registered project NAMES only.
+# A project with no backlog history and no live state/<id>.meta is otherwise
+# invisible through this snapshot (issue #2007), which blocks external project
+# discovery. Deliberately excludes path, git remote, description, registration
+# date, and delivery mode/posture/yolo - those remain captain-private and are
+# never derived from this projection. Shares the registered-table bounded-read
+# shape (byte/line/record limits, timeout) with registry_secondmates_json.
+registry_projects_json() {
+  local reg="$DATA/projects.md" out rc reason mode script parse_filter
+  if [ ! -f "$reg" ]; then
+    jq -n --arg path "$reg" \
+      '{present:false,available:true,complete:true,reason:null,records:[],total:0,shown:0,truncated:0}'
+    return 0
+  fi
+  mode=$(file_mode_octal "$reg")
+  if [ -z "$mode" ] || [ $((8#$mode & 0444)) -eq 0 ]; then
+    jq -n --arg reason "project registry is unreadable" \
+      '{present:true,available:false,complete:false,reason:$reason,records:[],total:0,shown:0,truncated:0}'
+    return 0
+  fi
+  script=$(cat <<'BASH'
+    f=$1
+    max_lines=$2
+    max_bytes=$3
+    max_records=$4
+    parse_filter=$5
+    content=$(LC_ALL=C head -c "$((max_bytes + 1))" "$f" || exit 3; printf "\036") || exit 3
+    content=${content%$'\036'}
+    bytes=$(printf "%s" "$content" | LC_ALL=C wc -c | tr -d " ")
+    byte_truncated=false
+    if [ "$bytes" -gt "$max_bytes" ]; then
+      byte_truncated=true
+      content=$(printf "%s" "$content" | LC_ALL=C head -c "$max_bytes")
+      complete=${content%$'\n'*}
+      if [ "$complete" != "$content" ]; then
+        content=$complete
+      else
+        content=
+      fi
+    fi
+    if [ -n "$content" ]; then
+      lines=$(printf "%s\n" "$content" | awk "END {print NR}")
+    else
+      lines=0
+    fi
+    line_truncated=false
+    if [ "$lines" -gt "$max_lines" ]; then line_truncated=true; fi
+    window=$(printf "%s\n" "$content" | LC_ALL=C head -n "$max_lines") || exit 3
+    names=$(printf "%s\n" "$window" | jq -Rn "$parse_filter") || exit 3
+    total=$(printf "%s" "$names" | jq "length") || exit 3
+    records_truncated=false
+    if [ "$total" -gt "$max_records" ]; then records_truncated=true; fi
+    printf "%s" "$names" | jq \
+      --argjson byte_truncated "$byte_truncated" \
+      --argjson line_truncated "$line_truncated" \
+      --argjson records_truncated "$records_truncated" \
+      --argjson max_records "$max_records" '
+      {names:(if length > $max_records then .[:$max_records] else . end),
+       total:length,
+       byte_truncated:$byte_truncated,
+       line_truncated:$line_truncated,
+       records_truncated:$records_truncated}'
+BASH
+  )
+  parse_filter=$(cat <<'JQ'
+      [ inputs
+        | select(startswith("- "))
+        | (capture("^- (?<name>[^[:space:]]+)")?) as $m
+        | select($m != null)
+        | $m.name ]
+      | unique
+JQ
+  )
+  out=$(fm_run_timed "$FM_SNAPSHOT_REGISTRY_TIMEOUT" bash -c "$script" \
+    fm-project-registry "$reg" "$FM_SNAPSHOT_REGISTRY_LINES" "$FM_SNAPSHOT_REGISTRY_BYTES" \
+    "$FM_SNAPSHOT_REGISTRY_RECORDS" "$parse_filter" 2>/dev/null)
+  rc=$?
+  if [ "$rc" -eq 0 ] && printf '%s' "$out" | jq -e '(.names | type) == "array"' >/dev/null 2>&1; then
+    jq -n --argjson out "$out" '
+      {present:true,available:true,
+       complete:(($out.byte_truncated or $out.line_truncated or $out.records_truncated) | not),
+       reason:null,
+       records:[$out.names[] | {name:.}],
+       total:$out.total,
+       shown:($out.names | length),
+       truncated:($out.total - ($out.names | length))}'
+    return 0
+  fi
+  [ "$rc" -eq 124 ] && reason="project registry read timed out" || reason="project registry is unreadable"
+  jq -n --arg reason "$reason" \
+    '{present:true,available:false,complete:false,reason:$reason,records:[],total:0,shown:0,truncated:0}'
+}
+
 bounded_parent_activities_json() {  # <status-file>
   local f=$1 out rc reason script
   if [ ! -f "$f" ]; then
@@ -1361,6 +1464,8 @@ SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON") \
   || { echo "fm-fleet-snapshot: registered secondmate aggregation failed" >&2; exit 1; }
 SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON") \
   || { echo "fm-fleet-snapshot: secondmate landed projection failed" >&2; exit 1; }
+PROJECT_REGISTRY_JSON=$(registry_projects_json) \
+  || { echo "fm-fleet-snapshot: project registry projection failed" >&2; exit 1; }
 
 jq -n \
   --arg generated "$SNAPSHOT_NOW" \
@@ -1376,6 +1481,7 @@ jq -n \
   --argjson scout_reports "$SCOUT_REPORTS_JSON" \
   --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
   --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
+  --argjson project_registry "$PROJECT_REGISTRY_JSON" \
   'def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");
@@ -1390,6 +1496,7 @@ jq -n \
      scout_reports:($scout_reports | map(. + {kind:report_kind(.id)})),
      secondmate_current:$secondmate_current,
      secondmate_landed:$secondmate_landed,
+     project_registry:$project_registry,
      secondmate_guidance:{
        note:"For kind=secondmate, bearings selects validated structured state from that registered home; parent events and bounded terminal evidence are fallback-only supplements and never current-state authority."
      }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,7 +39,7 @@ Only when no matching run exists does it consult semantic busy state; exact busy
 Decision-only events such as `resolved` never become current state or leak their prose into the current-state detail.
 In that status-log fallback, a declared external wait reports the distinct `paused` state with its reason.
 The semantic branch reports working only on an exact busy verdict and names the source that produced it; an unknown verdict never becomes working, never permits the status-log fallback, and never becomes a silent idle.
-For whole-fleet read-only review, `bin/fm-fleet-snapshot.sh --json` emits schema `fm-fleet-snapshot.v1` from the backlog, task metadata, current crew state, endpoint probes, PR/report pointers, scout reports, bounded current summaries from registered secondmate homes, and secondmate return-channel guidance.
+For whole-fleet read-only review, `bin/fm-fleet-snapshot.sh --json` emits schema `fm-fleet-snapshot.v1` from the backlog, task metadata, current crew state, endpoint probes, PR/report pointers, scout reports, bounded current summaries from registered secondmate homes, secondmate return-channel guidance, and a minimal public projection of `data/projects.md`'s registered project names.
 `bin/fm-fleet-view.sh` renders that snapshot as Markdown for humans, while `bin/fm-bearings-snapshot.sh` provides the bounded bearings projection, so both views consume one structured contract instead of reparsing raw fleet files.
 The script header owns the exact JSON schema.
 

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -146,9 +146,87 @@ test_empty_fleet_json() {
       and .main_inventory.unstructured_current_count == 0
   ' >/dev/null \
     || fail "empty snapshot schema or absence markers wrong: $out"
+  printf '%s' "$out" | jq -e '
+    .project_registry.present == false
+      and .project_registry.available == true
+      and .project_registry.complete == true
+      and .project_registry.reason == null
+      and .project_registry.records == []
+      and .project_registry.total == 0
+      and .project_registry.shown == 0
+      and .project_registry.truncated == 0
+  ' >/dev/null || fail "project_registry must use an explicit present:false marker when data/projects.md is absent: $out"
   view=$(FM_HOME="$home" "$VIEW")
   assert_contains "$view" "No live task metadata found." "empty fleet view should say no live metadata"
   pass "empty fleet snapshot and view use explicit absence markers"
+}
+
+# fm-2007: a project registered in data/projects.md with no backlog history and
+# no live state/<id>.meta was completely invisible through the public snapshot,
+# blocking external project discovery. project_registry must expose its name
+# even though it has zero backlog rows and zero tasks anywhere else in the
+# snapshot.
+test_project_registry_exposes_backlogless_project() {
+  local home out
+  home=$(make_home project-registry)
+  cat > "$home/data/projects.md" <<'EOF'
+- silent-project [no-mistakes] - has no backlog history or live task (added 2026-07-01)
+EOF
+  out=$(FM_HOME="$home" "$SNAPSHOT" --json)
+  printf '%s' "$out" | jq -e '
+    (.tasks | length) == 0
+      and (.backlog.present == false)
+  ' >/dev/null || fail "fixture must reproduce the reported gap: no tasks and no backlog for silent-project: $out"
+  printf '%s' "$out" | jq -e '
+    .project_registry.present == true
+      and .project_registry.available == true
+      and .project_registry.complete == true
+      and .project_registry.reason == null
+      and .project_registry.records == [{name:"silent-project"}]
+      and .project_registry.total == 1
+      and .project_registry.shown == 1
+      and .project_registry.truncated == 0
+  ' >/dev/null || fail "project_registry did not expose a backlog-less registered project: $out"
+  pass "project_registry exposes a registered project with no backlog history or live task"
+}
+
+# The projection must stay minimal: only the name, never the registered mode,
+# yolo posture, description, or registration date that data/projects.md carries.
+test_project_registry_omits_private_registry_detail() {
+  local home out
+  home=$(make_home project-registry-privacy)
+  cat > "$home/data/projects.md" <<'EOF'
+- alpha [local-only +yolo] - internal tooling, do not expose posture (added 2026-07-02)
+- beta - legacy default project (added 2026-07-03)
+EOF
+  out=$(FM_HOME="$home" "$SNAPSHOT" --json)
+  printf '%s' "$out" | jq -e '
+    .project_registry.records == [{name:"alpha"},{name:"beta"}]
+      and (.project_registry.records | map(keys) | flatten | unique) == ["name"]
+  ' >/dev/null || fail "project_registry must expose names only, no mode/yolo/description/date: $out"
+  case "$out" in
+    *local-only*) fail "project_registry leaked delivery mode into the public snapshot: $out" ;;
+    *+yolo*) fail "project_registry leaked yolo posture into the public snapshot: $out" ;;
+    *"internal tooling"*) fail "project_registry leaked project description into the public snapshot: $out" ;;
+  esac
+  pass "project_registry exposes registered names only, never mode/yolo/description/date"
+}
+
+test_project_registry_unreadable_registry_discloses_reason() {
+  local home out
+  home=$(make_home project-registry-unreadable)
+  printf -- '- alpha - some project (added 2026-07-01)\n' > "$home/data/projects.md"
+  chmod 000 "$home/data/projects.md"
+  out=$(FM_HOME="$home" "$SNAPSHOT" --json)
+  chmod 644 "$home/data/projects.md"
+  printf '%s' "$out" | jq -e '
+    .project_registry.present == true
+      and .project_registry.available == false
+      and .project_registry.complete == false
+      and (.project_registry.reason | length) > 0
+      and .project_registry.records == []
+  ' >/dev/null || fail "an unreadable project registry must disclose unavailability with a reason, not fail silently: $out"
+  pass "project_registry discloses an unreadable registry file rather than silently omitting it"
 }
 
 test_fixture_snapshot_json() {
@@ -780,6 +858,9 @@ test_parked_scout_decision_stays_pending() {
 }
 
 test_empty_fleet_json
+test_project_registry_exposes_backlogless_project
+test_project_registry_omits_private_registry_detail
+test_project_registry_unreadable_registry_discloses_reason
 test_fixture_snapshot_json
 test_main_inventory_orphan_and_unstructured_disclosure
 test_normalized_roles_and_plural_blocker_readiness


### PR DESCRIPTION
## Summary

- add a bounded `project_registry` field to `fm-fleet-snapshot.v1` so registered projects remain discoverable without backlog history or live tasks
- expose project names only, preserving private registry metadata and reporting absence, truncation, timeout, or unreadability explicitly
- document the snapshot field and cover absent, backlogless, privacy, and unreadable-registry behavior

Closes #2007