### PR TITLE
fix(project-mode): match multi-word registry names

### DIFF
--- a/bin/fm-project-mode.sh
+++ b/bin/fm-project-mode.sh
@@ -66,8 +66,11 @@ parsed=$(awk -v n="$NAME" '
     match($0, /^[ \t]*-[ \t]+/);
     line = substr($0, RSTART + RLENGTH);
     name = line;
-    if (match(name, / \[/)) name = substr(name, 1, RSTART - 1);
-    else if (match(name, / - /)) name = substr(name, 1, RSTART - 1);
+    bpos = 0; dpos = 0;
+    if (match(name, / \[/)) bpos = RSTART;
+    if (match(name, / - /)) dpos = RSTART;
+    if (bpos > 0 && (dpos == 0 || bpos < dpos)) name = substr(name, 1, bpos - 1);
+    else if (dpos > 0) name = substr(name, 1, dpos - 1);
     if (name != n) next;
     mode="no-mistakes"; yolo="off";
     rest = substr(line, length(name) + 1);

--- a/bin/fm-project-mode.sh
+++ b/bin/fm-project-mode.sh
@@ -56,14 +56,25 @@ if [ ! -f "$REG" ]; then
   exit 0
 fi
 
+# The name is a free-text span, not a single token, so it is recovered from
+# the leading "- " up to the first " [" (mode annotation) or " - "
+# (description) delimiter rather than compared field-by-field; matching on
+# a fixed field (e.g. $2==n) silently drops every multi-word project name.
 # awk emits "<mode> <yolo>" (one line) or nothing if the project is absent.
 parsed=$(awk -v n="$NAME" '
-  $1=="-" && $2==n {
+  $1=="-" {
+    match($0, /^[ \t]*-[ \t]+/);
+    line = substr($0, RSTART + RLENGTH);
+    name = line;
+    if (match(name, / \[/)) name = substr(name, 1, RSTART - 1);
+    else if (match(name, / - /)) name = substr(name, 1, RSTART - 1);
+    if (name != n) next;
     mode="no-mistakes"; yolo="off";
-    if ($3 ~ /^\[/) {
-      s="";
-      for (i=3; i<=NF; i++) { s = s (s==""?"":" ") $i; if ($i ~ /\]$/) break }
-      gsub(/^\[|\]$/, "", s);           # strip the surrounding brackets
+    rest = substr(line, length(name) + 1);
+    if (rest ~ /^ \[/) {
+      sub(/^ \[/, "", rest);
+      close_pos = index(rest, "]");
+      s = (close_pos > 0) ? substr(rest, 1, close_pos - 1) : rest;
       k = split(s, a, " ");
       if (a[1] != "" && a[1] != "+yolo") mode = a[1];
       for (j=1; j<=k; j++) if (a[j]=="+yolo") yolo="on";

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -272,6 +272,41 @@ EOF
   pass "fm-project-mode: the conditional policy is accepted, mapped for mechanical callers, and readable raw"
 }
 
+# The registry name is free text, not a single token, so the parser must
+# recover the whole span up to its " [" or " - " delimiter rather than
+# comparing a fixed field. A field-keyed match (issue: $2==n) silently drops
+# every multi-word name to the not-in-registry warning and its no-mistakes-off
+# default, which is a silent posture downgrade for a project that IS registered.
+test_project_mode_matches_multi_word_names() {
+  local home out err
+  home="$TMP_ROOT/project-mode-spaces/home"
+  mkdir -p "$home/data"
+  cat > "$home/data/projects.md" <<'EOF'
+- 048. Blast- Lease summary drafter [local-only] - BLAST lease summary drafter (added 2026-08-08)
+- ARI eDiscovery Development - fixture (added 2026-01-01)
+- Foo Bar Baz [local-only +yolo] - fixture (added 2026-01-01)
+EOF
+
+  out=$(FM_HOME="$home" "$PROJECT_MODE" "048. Blast- Lease summary drafter" 2>/dev/null)
+  [ "$out" = "local-only off" ] || fail "a multi-word registry name with a mode annotation was not matched (got '$out')"
+  err=$(FM_HOME="$home" "$PROJECT_MODE" "048. Blast- Lease summary drafter" 2>&1 >/dev/null)
+  [ -z "$err" ] || fail "a registered multi-word project still warned as not in the registry: $err"
+
+  out=$(FM_HOME="$home" "$PROJECT_MODE" "ARI eDiscovery Development" 2>/dev/null)
+  [ "$out" = "no-mistakes off" ] || fail "a multi-word legacy-default registry name was not matched (got '$out')"
+
+  out=$(FM_HOME="$home" "$PROJECT_MODE" "Foo Bar Baz" 2>/dev/null)
+  [ "$out" = "local-only on" ] || fail "a multi-word name with a mode annotation and +yolo was not matched (got '$out')"
+
+  # A genuine registry miss, including a bare prefix of a multi-word name,
+  # must still fall through to the loud not-in-registry warning.
+  out=$(FM_HOME="$home" "$PROJECT_MODE" "048." 2>/dev/null)
+  [ "$out" = "no-mistakes off" ] || fail "an unregistered prefix of a multi-word name unexpectedly matched (got '$out')"
+  err=$(FM_HOME="$home" "$PROJECT_MODE" "048." 2>&1 >/dev/null)
+  assert_contains "$err" "not in registry" "a genuine registry miss stopped warning loudly"
+  pass "fm-project-mode: multi-word registry names match on their full free-text span"
+}
+
 test_ship_spawn_requires_a_valid_delivery_contract
 test_scout_and_secondmate_refuse_delivery_flags
 test_spawn_refuses_a_brief_mode_mismatch
@@ -279,4 +314,5 @@ test_spawn_notices_a_rigor_downgrade_against_the_registry
 test_scout_records_no_delivery_posture
 test_promote_requires_and_records_the_delivery_contract
 test_project_mode_maps_the_conditional_policy
+test_project_mode_matches_multi_word_names
 echo "# all fm-task-delivery tests passed"

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -285,6 +285,7 @@ test_project_mode_matches_multi_word_names() {
 - 048. Blast- Lease summary drafter [local-only] - BLAST lease summary drafter (added 2026-08-08)
 - ARI eDiscovery Development - fixture (added 2026-01-01)
 - Foo Bar Baz [local-only +yolo] - fixture (added 2026-01-01)
+- Acme Corp - Redesign the [checkout] flow (added 2026-01-01)
 EOF
 
   out=$(FM_HOME="$home" "$PROJECT_MODE" "048. Blast- Lease summary drafter" 2>/dev/null)
@@ -297,6 +298,14 @@ EOF
 
   out=$(FM_HOME="$home" "$PROJECT_MODE" "Foo Bar Baz" 2>/dev/null)
   [ "$out" = "local-only on" ] || fail "a multi-word name with a mode annotation and +yolo was not matched (got '$out')"
+
+  # A "[" that appears in the free-text description (not as a mode
+  # annotation) must not be preferred over an earlier " - " delimiter: the
+  # name span ends at whichever delimiter occurs first in the line.
+  out=$(FM_HOME="$home" "$PROJECT_MODE" "Acme Corp" 2>/dev/null)
+  [ "$out" = "no-mistakes off" ] || fail "a name followed by a '-' description containing a later '[' was not matched (got '$out')"
+  err=$(FM_HOME="$home" "$PROJECT_MODE" "Acme Corp" 2>&1 >/dev/null)
+  [ -z "$err" ] || fail "a registered project with a bracketed description word still warned as not in the registry: $err"
 
   # A genuine registry miss, including a bare prefix of a multi-word name,
   # must still fall through to the loud not-in-registry warning.


### PR DESCRIPTION
## Summary

- parse project registry names as full free-text spans instead of matching only the first whitespace-delimited token
- choose the earliest mode-annotation or description delimiter so brackets in descriptions do not truncate project names incorrectly
- add regression coverage for multi-word names, delivery modes, `+yolo`, bracketed descriptions, and genuine registry misses

Closes #1977
