### PR TITLE
fix: prune resolved pending replies after retention

### DIFF
--- a/bin/fm-pending-reply-lib.sh
+++ b/bin/fm-pending-reply-lib.sh
@@ -66,11 +66,22 @@
 # or a remote mate's mirrored line - can take the key over or clear it; see the
 # reserved-key rule in bin/fm-classify-lib.sh.
 #
+# Retention: a resolved record is never open, so fm_pending_reply_task_has_open
+# already excludes it. fm_pending_reply_tick additionally prunes it from disk
+# once it has aged past the retention window AND its escalation (if any) is
+# closed. A resolved record whose escalation is still open is never pruned,
+# however old, because that close must still converge. An unresolved record of
+# any age or phase is never auto-deleted; that durable-retention contract is
+# unchanged.
+#
 # Sourced by bin/fm-send.sh, bin/fm-watch.sh, bin/fm-secondmate-report.sh, and
 # tests. No side effects on source. set -u / set -e safe.
 #
 # Tunables (env):
-#   FM_PENDING_REPLY_GRACE_SECS   default 120
+#   FM_PENDING_REPLY_GRACE_SECS     default 120
+#   FM_PENDING_REPLY_RETENTION_SECS default 3600; how long a resolved record
+#                                   with no open escalation stays on disk
+#                                   before fm_pending_reply_tick prunes it
 #   FM_PENDING_REPLY_DIR_OVERRIDE override the pending-replies directory (tests)
 #   FM_PENDING_REPLY_SEND_HOOK    optional command template for recovery delivery
 #                                 (tests); receives task_id and full message as args
@@ -90,6 +101,7 @@ _FM_PENDING_REPLY_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/n
 FM_PENDING_REPLY_SCHEMA='fm-pending-reply.v1'
 FM_PENDING_REPLY_CORR_RE='corr=[A-Fa-f0-9]{16}'
 FM_PENDING_REPLY_GRACE_DEFAULT=120
+FM_PENDING_REPLY_RETENTION_DEFAULT=3600
 
 fm_pending_reply_now() {
   if [ -n "${FM_PENDING_REPLY_NOW:-}" ]; then
@@ -105,6 +117,14 @@ fm_pending_reply_grace_secs() {
     ''|*[!0-9]*) g=$FM_PENDING_REPLY_GRACE_DEFAULT ;;
   esac
   printf '%s' "$g"
+}
+
+fm_pending_reply_retention_secs() {
+  local r=${FM_PENDING_REPLY_RETENTION_SECS:-$FM_PENDING_REPLY_RETENTION_DEFAULT}
+  case "$r" in
+    ''|*[!0-9]*) r=$FM_PENDING_REPLY_RETENTION_DEFAULT ;;
+  esac
+  printf '%s' "$r"
 }
 
 # Directory holding durable pending-reply records for <state-dir>.
@@ -417,6 +437,39 @@ fm_pending_reply_discard_undelivered() {  # <state-dir> <corr_id>
   [ -f "$rec" ] || return 0
   delivered=$(fm_pending_reply_get "$rec" delivered_epoch)
   [ -z "$delivered" ] || return 1
+  marker=$(fm_pending_reply_delivery_confirmation_path "$state" "$corr")
+  rm -f "$marker" 2>/dev/null || true
+  rm -f "$rec"
+}
+
+# True (0) when a resolved record may be pruned from disk: its escalation, if
+# any was opened, is already closed, and it has aged past the retention
+# window. A record with no resolved_epoch, or an open escalation, is never
+# eligible - it stays durable exactly like an unresolved record.
+fm_pending_reply_prune_eligible() {  # <record-path>
+  local rec=$1 phase escalated closed resolved now retention age
+  [ -f "$rec" ] || return 1
+  phase=$(fm_pending_reply_get "$rec" phase)
+  [ "$phase" = resolved ] || return 1
+  escalated=$(fm_pending_reply_get "$rec" escalated_epoch)
+  if [ -n "$escalated" ]; then
+    closed=$(fm_pending_reply_get "$rec" escalation_closed_epoch)
+    [ -n "$closed" ] || return 1
+  fi
+  resolved=$(fm_pending_reply_get "$rec" resolved_epoch)
+  case "$resolved" in ''|*[!0-9]*) return 1 ;; esac
+  now=$(fm_pending_reply_now)
+  retention=$(fm_pending_reply_retention_secs)
+  age=$((now - resolved))
+  [ "$age" -ge "$retention" ]
+}
+
+# Remove a resolved, retention-eligible record and its delivery marker.
+# A no-op (not an error) when the record does not yet qualify.
+fm_pending_reply_prune() {  # <state-dir> <corr_id>
+  local state=$1 corr=$2 rec marker
+  rec=$(fm_pending_reply_path "$state" "$corr")
+  fm_pending_reply_prune_eligible "$rec" || return 0
   marker=$(fm_pending_reply_delivery_confirmation_path "$state" "$corr")
   rm -f "$marker" 2>/dev/null || true
   rm -f "$rec"
@@ -884,6 +937,14 @@ fm_pending_reply_escalation_line() {  # <status-file> <record-path> <corr_id>
 # only while that exact keyed decision is still open in
 # bin/fm-classify-lib.sh's fold. Records that never escalated are left untouched.
 fm_pending_reply_close_escalation() {  # <state-dir> <corr_id>
+  # Cheap pre-lock check: a resolved record with no escalation ever opened
+  # costs no lock at all, so a tick over many such records stays lock-free.
+  local state=$1 corr=$2 rec lock rc=0
+  local STATE FM_WAKE_QUEUE FM_WAKE_QUEUE_LOCK
+  rec=$(fm_pending_reply_path "$state" "$corr")
+  [ -f "$rec" ] || return 1
+  [ "$(fm_pending_reply_get "$rec" phase)" = resolved ] || return 0
+  [ -n "$(fm_pending_reply_get "$rec" escalated_epoch)" ] || return 0
   # Serialized per correlation so a resolution and an escalation cannot interleave.
   # bin/fm-wake-lib.sh owns the lock primitives but assigns its own globals when
   # sourced, so they are declared local here: that contains them to this call
@@ -891,8 +952,6 @@ fm_pending_reply_close_escalation() {  # <state-dir> <corr_id>
   # subshell that would make every later use of them read as a lost write.
   # The lock is released explicitly rather than from an EXIT trap, because a trap
   # in a plain function would clobber the caller's own.
-  local state=$1 corr=$2 lock rc=0
-  local STATE FM_WAKE_QUEUE FM_WAKE_QUEUE_LOCK
   STATE=$state
   lock="$state/.pending-reply-$corr.lock"
   # shellcheck source=bin/fm-wake-lib.sh
@@ -1139,6 +1198,9 @@ fm_pending_reply_tick() {  # <state-dir>
       # Cheap no-op unless an escalation for this record is still open; this is
       # the retry that makes the close converge after a transient write failure.
       fm_pending_reply_close_escalation "$state" "$corr" || true
+      # Cheap no-op until the record ages past the retention window; never
+      # prunes an escalated record whose close has not converged yet.
+      fm_pending_reply_prune "$state" "$corr" || true
       continue
     fi
     fm_pending_reply_reconcile_delivery "$state" "$corr" || true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -591,6 +591,7 @@ FM_SEND_RETRIES=3       # fm-send Enter-retry attempts after typing the line onc
 FM_SEND_SLEEP=0.4       # seconds between fm-send submit checks
 FM_SEND_SETTLE=1        # seconds fm-send waits after a successful text submit; 0 disables
 FM_PENDING_REPLY_GRACE_SECS=120   # seconds after marked-request delivery before a completed turn without a correlated parent report is eligible for its one recovery repost
+FM_PENDING_REPLY_RETENTION_SECS=3600   # seconds a resolved pending-reply record with no open escalation stays on disk before fm_pending_reply_tick prunes it; a record whose escalation is still open is never pruned
 # sub-supervisor (bin/fm-supervise-daemon.sh); presence-gated via /afk
 FM_SUPERVISOR_BACKEND=             # optional supervisor pane backend override; tmux/herdr only, otherwise detects $TMUX_PANE then HERDR_ENV/HERDR_PANE_ID before tmux fallback
 FM_SUPERVISOR_TARGET=              # optional supervisor pane target override; tmux target or herdr <session>:<pane-id>, otherwise auto-detected

--- a/tests/fm-pending-reply.test.sh
+++ b/tests/fm-pending-reply.test.sh
@@ -19,6 +19,12 @@
 #  10. fm-send secondmate path embeds corr and creates durable pending records
 #  11. Backend busy/idle observation works through the shared busy abstraction
 #      used by Pi/Claude secondmate backends (no conversation scrape)
+#  12. A resolved record never counts as open, including immediately after
+#      resolution
+#  13. A tick prunes a resolved record once it ages past the retention
+#      window, keeps one that has not, never prunes one whose escalation
+#      close has not converged, and prunes only exactly those records that
+#      qualify
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -1039,6 +1045,150 @@ test_failed_send_discards_undelivered_expectation() {
   pass "failed transport discards undelivered expectation only"
 }
 
+test_resolved_record_excluded_from_open_count() {
+  local home state corr
+  home=$(setup_parent open-count)
+  state="$home/state"
+  export FM_PENDING_REPLY_NOW=10000
+  corr=$(fm_pending_reply_create "$home" "$state" "hibit" "still open")
+  fm_pending_reply_mark_delivered "$state" "$corr"
+  fm_pending_reply_task_has_open "$state" "hibit" \
+    || fail "unresolved record should count as open"
+  printf 'done [corr=%s]: answered\n' "$corr" > "$state/hibit.status"
+  fm_pending_reply_try_resolve "$state" "$corr" || fail "reply should resolve"
+  if fm_pending_reply_task_has_open "$state" "hibit"; then
+    fail "resolved record must never count as open"
+  fi
+  pass "resolved record never counts as open, including right after resolution"
+}
+
+test_tick_prunes_resolved_record_past_retention() {
+  local home state corr rec
+  home=$(setup_parent prune-past-retention)
+  state="$home/state"
+  export FM_PENDING_REPLY_RETENTION_SECS=100
+  export FM_PENDING_REPLY_NOW=11000
+  corr=$(fm_pending_reply_create "$home" "$state" "hibit" "prune me")
+  fm_pending_reply_mark_delivered "$state" "$corr"
+  printf 'done [corr=%s]: answered\n' "$corr" > "$state/hibit.status"
+  fm_pending_reply_try_resolve "$state" "$corr" || fail "reply should resolve"
+  rec=$(fm_pending_reply_path "$state" "$corr")
+  [ -f "$rec" ] || fail "resolved record missing before its retention window elapses"
+  export FM_PENDING_REPLY_NOW=11200
+  fm_pending_reply_tick "$state"
+  [ ! -f "$rec" ] || fail "resolved record past its retention window should be pruned"
+  unset FM_PENDING_REPLY_RETENTION_SECS
+  pass "tick prunes a resolved record once it ages past the retention window"
+}
+
+test_tick_keeps_resolved_record_within_retention() {
+  local home state corr rec
+  home=$(setup_parent prune-within-retention)
+  state="$home/state"
+  export FM_PENDING_REPLY_RETENTION_SECS=1000
+  export FM_PENDING_REPLY_NOW=12000
+  corr=$(fm_pending_reply_create "$home" "$state" "hibit" "keep me")
+  fm_pending_reply_mark_delivered "$state" "$corr"
+  printf 'done [corr=%s]: answered\n' "$corr" > "$state/hibit.status"
+  fm_pending_reply_try_resolve "$state" "$corr" || fail "reply should resolve"
+  rec=$(fm_pending_reply_path "$state" "$corr")
+  export FM_PENDING_REPLY_NOW=12500
+  fm_pending_reply_tick "$state"
+  [ -f "$rec" ] || fail "resolved record younger than its retention window should survive a tick"
+  unset FM_PENDING_REPLY_RETENTION_SECS
+  pass "tick keeps a resolved record that has not yet aged past the retention window"
+}
+
+test_tick_never_prunes_unconverged_escalation_close() {
+  local home state corr rec
+  home=$(setup_parent prune-open-escalation)
+  state="$home/state"
+  export FM_PENDING_REPLY_RETENTION_SECS=1000
+  export FM_PENDING_REPLY_NOW=13000
+  corr=$(fm_pending_reply_create "$home" "$state" "hibit" "escalated then resolved")
+  fm_pending_reply_mark_delivered "$state" "$corr"
+  rec=$(fm_pending_reply_path "$state" "$corr")
+  fm_pending_reply_set "$rec" phase resolved
+  fm_pending_reply_set "$rec" resolved_epoch 13000
+  fm_pending_reply_set "$rec" escalated_epoch 12000
+  # Simulate a close attempt that has not converged yet (e.g. a transient
+  # status-write failure): with no destination to append to, the escalation
+  # close can neither confirm nor record itself. Age it far past retention
+  # to prove age alone never substitutes for a converged close.
+  fm_pending_reply_set "$rec" parent_status ''
+  export FM_PENDING_REPLY_NOW=999999
+  fm_pending_reply_tick "$state"
+  [ -z "$(fm_pending_reply_get "$rec" escalation_closed_epoch)" ] \
+    || fail "test setup should have left the escalation close unconverged"
+  [ -f "$rec" ] \
+    || fail "a resolved record whose escalation close has not converged must never be pruned, however old"
+
+  # Restore the destination just after resolution, still within the
+  # retention window: the close should converge without being pruned yet.
+  export FM_PENDING_REPLY_NOW=13005
+  fm_pending_reply_set "$rec" parent_status "$state/hibit.status"
+  fm_pending_reply_tick "$state"
+  [ -n "$(fm_pending_reply_get "$rec" escalation_closed_epoch)" ] \
+    || fail "escalation close should converge once its status destination is restored"
+  [ -f "$rec" ] \
+    || fail "a freshly converged record still inside its retention window must not be pruned yet"
+
+  # Once it also ages past retention, a later tick prunes it.
+  export FM_PENDING_REPLY_NOW=$((13005 + 2000))
+  fm_pending_reply_tick "$state"
+  [ ! -f "$rec" ] \
+    || fail "resolved record should be pruned once its converged escalation ages past retention"
+  unset FM_PENDING_REPLY_RETENTION_SECS
+  pass "tick never prunes an unconverged escalation close, and prunes only once it converges and ages out"
+}
+
+test_tick_prune_removes_only_eligible_records() {
+  local home state
+  local corr_old corr_recent corr_unresolved corr_open_escalation
+  local rec_old rec_recent rec_unresolved rec_open_escalation
+  home=$(setup_parent prune-selectivity)
+  state="$home/state"
+  export FM_PENDING_REPLY_RETENTION_SECS=100
+
+  export FM_PENDING_REPLY_NOW=10000
+  corr_old=$(fm_pending_reply_create "$home" "$state" "hibit" "old resolved")
+  fm_pending_reply_mark_delivered "$state" "$corr_old"
+  printf 'done [corr=%s]: answered old\n' "$corr_old" > "$state/hibit.status"
+  fm_pending_reply_try_resolve "$state" "$corr_old" || fail "old record should resolve"
+  rec_old=$(fm_pending_reply_path "$state" "$corr_old")
+
+  corr_unresolved=$(fm_pending_reply_create "$home" "$state" "hibit" "still open")
+  fm_pending_reply_mark_delivered "$state" "$corr_unresolved"
+  rec_unresolved=$(fm_pending_reply_path "$state" "$corr_unresolved")
+
+  corr_open_escalation=$(fm_pending_reply_create "$home" "$state" "hibit" "escalation not converged")
+  fm_pending_reply_mark_delivered "$state" "$corr_open_escalation"
+  rec_open_escalation=$(fm_pending_reply_path "$state" "$corr_open_escalation")
+  fm_pending_reply_set "$rec_open_escalation" phase resolved
+  fm_pending_reply_set "$rec_open_escalation" resolved_epoch 10000
+  fm_pending_reply_set "$rec_open_escalation" escalated_epoch 9000
+  fm_pending_reply_set "$rec_open_escalation" parent_status ''
+
+  export FM_PENDING_REPLY_NOW=99980
+  corr_recent=$(fm_pending_reply_create "$home" "$state" "hibit" "recent resolved")
+  fm_pending_reply_mark_delivered "$state" "$corr_recent"
+  printf 'done [corr=%s]: answered recent\n' "$corr_recent" >> "$state/hibit.status"
+  fm_pending_reply_try_resolve "$state" "$corr_recent" || fail "recent record should resolve"
+  rec_recent=$(fm_pending_reply_path "$state" "$corr_recent")
+
+  export FM_PENDING_REPLY_NOW=100000
+  fm_pending_reply_tick "$state"
+
+  [ ! -f "$rec_old" ] || fail "resolved record past its retention window should have been pruned"
+  [ -f "$rec_recent" ] || fail "resolved record within its retention window should survive"
+  [ -f "$rec_unresolved" ] || fail "unresolved record should never be pruned"
+  [ -f "$rec_open_escalation" ] \
+    || fail "resolved record with an unconverged escalation close should never be pruned"
+
+  unset FM_PENDING_REPLY_RETENTION_SECS
+  pass "tick prunes only the resolved, retention-eligible record and nothing else"
+}
+
 # --- run --------------------------------------------------------------------
 
 test_normal_correlated_reply_resolves_once
@@ -1069,5 +1219,10 @@ test_tick_skips_terminal_and_reuses_target_observation
 test_correlations_reuse_only_for_matching_open_task
 test_tick_end_to_end_missed_then_escalate
 test_failed_send_discards_undelivered_expectation
+test_resolved_record_excluded_from_open_count
+test_tick_prunes_resolved_record_past_retention
+test_tick_keeps_resolved_record_within_retention
+test_tick_never_prunes_unconverged_escalation_close
+test_tick_prune_removes_only_eligible_records
 
 printf 'ok - all pending-reply tests passed\n'


### PR DESCRIPTION
## Summary

- prune resolved pending-reply records after a configurable retention window
- retain unresolved records and resolved records whose escalation closure has not converged
- avoid taking per-correlation locks for resolved records that were never escalated
- document the retention setting and cover retention, escalation, and open-count behavior with regression tests

Closes #2053
