### PR TITLE
fix(watch): throttle unread signal backlog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,7 @@ state/               volatile runtime signals; gitignored
   .afk               durable away-mode flag; present = sub-supervisor may inject escalations (set by /afk, cleared on user return)
   .watch.lock .wake-queue.lock watcher singleton and queue serialization locks
   .claude-autoarm.lock .claude-autoarm-epoch .claude-autoarm-failure-notified .claude-autoarm-failure-alarmed .turnend-claude-blocks .turnend-claude-blocks.lock   Claude Stop auto-arm single-flight, epoch, failure-episode, attended-alarm, guard-budget, and budget-lock records; never touch
-  .hash-* .count-* .stale-* .stale-since-* .paused-* .wedge-escalations-* .seen-* .hb-surfaced-* .last-* .heartbeat-streak   watcher internals; never touch
+  .hash-* .count-* .stale-* .stale-since-* .paused-* .wedge-escalations-* .seen-* .hb-surfaced-* .last-* .heartbeat-streak .signal-unacked-since-* .signal-unacked-count-*   watcher internals; never touch
   .watch-triage.log  watcher's absorbed-wake debug log (size-capped); never relied on, safe to delete
   .last-watcher-beat watcher liveness beacon, touched every poll (including while absorbing benign wakes); guard scripts read it
   .subsuper-* .supervise-daemon.*   sub-supervisor internals; never touch

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -13,7 +13,22 @@
 # on every wake. Printed reason lines:
 #   signal: <file>...      status/turn-end signals, surfaced when a listed status
 #                          has a captain-relevant verb OR a no-verb signal's crew
-#                          is not provably working, unless afk is active
+#                          is not provably working, unless afk is active. When
+#                          every file in the batch is already queued and
+#                          undrained from a prior cycle (a report the operator
+#                          has not read yet, not one the watcher lost track
+#                          of), a repeat is throttled instead of re-exiting
+#                          every poll: it is absorbed until
+#                          FM_SIGNAL_UNACKED_ESCALATE_SECS have passed since
+#                          the last unacked report for that exact file set,
+#                          then surfaced again tagged "unread backlog, not
+#                          stalled" with an escalating count, and at
+#                          FM_SIGNAL_UNACKED_ALARM_COUNT consecutive repeats
+#                          the reason additionally carries a "SUPERVISION
+#                          ALARM" marker naming the exact unread task ids -
+#                          the reporting half of the fix for "supervision
+#                          looks stalled when it is actually thrashing on
+#                          unread worker reports", unless afk is active
 #   stale: <window>        a provably-working stale is ALWAYS absorbed (with a wedge
 #                          timer) regardless of what the status log says - an active
 #                          run-step or busy pane outranks even a captain-relevant log
@@ -459,6 +474,94 @@ scan_signals() {
   return 0
 }
 
+# Unread-backlog throttle (issue: "supervision looks stalled when it is
+# actually thrashing on unread worker reports"). An actionable signal batch
+# every file of which already sits queued and UNDRAINED from a prior cycle
+# (fm_wake_queued_keys is the durable acknowledgement authority - a key
+# appears there exactly while its record is queued and unconsumed, per
+# fm-wake-lib.sh) carries no new information: the operator has not read it
+# yet, the watcher has not lost track of it. Re-appending and re-exiting on it
+# every poll is indistinguishable from a fresh detection in both the printed
+# reason and the arm-layer cycle log, which is exactly what made a live
+# instance look permanently stalled while it was actually re-detecting the
+# same eight-file backlog every ~30s. FM_SIGNAL_UNACKED_ESCALATE_SECS/
+# FM_SIGNAL_UNACKED_ALARM_COUNT reuse STALE_ESCALATE_SECS/
+# FM_WEDGE_DEMAND_INSPECT_COUNT as defaults so the two throttles share one
+# operator-tuned cadence unless overridden independently.
+FM_SIGNAL_UNACKED_ESCALATE_SECS=${FM_SIGNAL_UNACKED_ESCALATE_SECS:-$STALE_ESCALATE_SECS}
+FM_SIGNAL_UNACKED_ALARM_COUNT=${FM_SIGNAL_UNACKED_ALARM_COUNT:-$FM_WEDGE_DEMAND_INSPECT_COUNT}
+
+# signal_batch_key: a stable identifier for a set of changed signal files,
+# order-independent so the same backlog always throttles under one key
+# regardless of scan order.
+signal_batch_key() {
+  printf '%s\n' "$@" | LC_ALL=C sort -u | tr '\n' ' ' | hash_pane
+}
+
+# signal_batch_fully_unacked: 0 (true) iff EVERY file in <files...> already has
+# an undrained record queued under kind=signal from a prior cycle. A batch that
+# mixes an already-queued file with a genuinely new one is treated as fresh
+# (the new file is real information), so this requires the whole batch to be a
+# pure repeat before anything is throttled.
+signal_batch_fully_unacked() {  # <files...>
+  local f base queued
+  queued=$(fm_wake_queued_keys signal)
+  [ -n "$queued" ] || return 1
+  for f in "$@"; do
+    base=$(basename "$f")
+    printf '%s\n' "$queued" | grep -Fxq "$base" || return 1
+  done
+  return 0
+}
+
+# signal_unacked_timer_check: report the FIRST sighting of a fully-unacked
+# batch immediately (tagged unacked, escalation 1) so it is never confused
+# with a fresh signal even on the very next arm - the literal reproduction of
+# the reported incident's "second exit". Only REPEATS of the identical file
+# set within FM_SIGNAL_UNACKED_ESCALATE_SECS of the last unacked report are
+# throttled (absorbed: no exit, no duplicate queue record - the original entry
+# is still undrained and delivers the same information on the next drain),
+# which is what turns the reported every-~30s thrash into a bounded cadence.
+# Never silently drops the report forever: once the cooldown elapses it always
+# exits again with an incremented count, and once that count reaches
+# FM_SIGNAL_UNACKED_ALARM_COUNT the reason is additionally tagged a
+# supervision alarm naming the exact unread task ids - the same "make the
+# reason itself force a closer look" idea as wedge_timer_check's
+# demand-deep-inspection marker.
+signal_unacked_timer_check() {  # <files...>
+  local key since_file count_file since age n reason task ids f base
+  key=$(signal_batch_key "$@")
+  since_file="$STATE/.signal-unacked-since-$key"
+  count_file="$STATE/.signal-unacked-count-$key"
+  since=$(cat "$since_file" 2>/dev/null || true)
+  case "$since" in
+    ''|*[!0-9]*) age=$FM_SIGNAL_UNACKED_ESCALATE_SECS ;;
+    *) age=$(( $(date +%s) - since )) ;;
+  esac
+  if [ "$age" -lt "$FM_SIGNAL_UNACKED_ESCALATE_SECS" ]; then
+    triage_log "absorbed unacked signal (already queued, awaiting drain, ${age}s): $*"
+    return 0
+  fi
+  n=$(( $(cat "$count_file" 2>/dev/null || echo 0) + 1 ))
+  echo "$n" > "$count_file"
+  date +%s > "$since_file"
+  ids=""
+  for f in "$@"; do
+    base=$(basename "$f")
+    task=${base%.status}
+    task=${task%.turn-ended}
+    case " $ids " in *" $task "*) ;; *) ids="$ids $task" ;; esac
+  done
+  reason="signal:$* (unread backlog, not stalled: unacknowledged for ${age}s, unacked-escalation $n - run bin/fm-wake-drain.sh and handle it)"
+  if [ "$n" -ge "$FM_SIGNAL_UNACKED_ALARM_COUNT" ]; then
+    reason="signal:$* (SUPERVISION ALARM: unread backlog stuck for $n consecutive checks - the watcher is thrashing on an unacknowledged report, not stalled; run bin/fm-wake-drain.sh and answer these workers now, tasks:$ids)"
+  fi
+  for f in "$@"; do
+    fm_wake_append signal "$(basename "$f")" "$reason" || exit 1
+  done
+  wake "$reason"
+}
+
 # Deliver a durably queued process-event result to firstmate. Publication is
 # owned by bin/fm-procevent.sh - by the runner at capture time and by reconcile's
 # re-announcement - so this decides only whether a queued check record has been
@@ -894,20 +997,39 @@ EOF
     # ordering evaluates it ONLY for a non-afk, no-captain-verb signal.
     # shellcheck disable=SC2086  # $files is a space-separated status-path list (ids carry no spaces)
     if afk_present || signal_reason_is_actionable $files || ! signal_crew_provably_working $files; then
-      while IFS=$(printf '\t') read -r sf sig f; do
-        [ -n "$sf" ] || continue
-        fm_wake_append signal "$(basename "$f")" "$reason" || exit 1
-      done <<EOF
+      # Unread-backlog guard: a batch every file of which is already sitting
+      # queued and undrained from a prior cycle is not new information - see
+      # signal_unacked_timer_check. afk mode keeps its unmodified contract
+      # (the daemon owns triage and must see every wake unthrottled).
+      # shellcheck disable=SC2086
+      if ! afk_present && signal_batch_fully_unacked $files; then
+        while IFS=$(printf '\t') read -r sf sig f; do
+          [ -n "$sf" ] || continue
+          printf '%s' "$sig" > "$sf"
+        done <<EOF
 $pending
 EOF
-      while IFS=$(printf '\t') read -r sf sig f; do
-        [ -n "$sf" ] || continue
-        printf '%s' "$sig" > "$sf"
-        mark_surfaced "$f"
-      done <<EOF
+        # shellcheck disable=SC2086
+        signal_unacked_timer_check $files
+      else
+        while IFS=$(printf '\t') read -r sf sig f; do
+          [ -n "$sf" ] || continue
+          fm_wake_append signal "$(basename "$f")" "$reason" || exit 1
+        done <<EOF
 $pending
 EOF
-      wake "$reason"
+        while IFS=$(printf '\t') read -r sf sig f; do
+          [ -n "$sf" ] || continue
+          printf '%s' "$sig" > "$sf"
+          mark_surfaced "$f"
+        done <<EOF
+$pending
+EOF
+        # shellcheck disable=SC2086  # $files is a space-separated status-path list (ids carry no spaces)
+        unacked_key=$(signal_batch_key $files)
+        rm -f "$STATE/.signal-unacked-since-$unacked_key" "$STATE/.signal-unacked-count-$unacked_key"
+        wake "$reason"
+      fi
     else
       while IFS=$(printf '\t') read -r sf sig f; do
         [ -n "$sf" ] || continue

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -8,9 +8,11 @@
 # provably-working no-verb wakes absorbed (no exit, no queue entry, suppressor
 # advanced, beacon fresh), stopped-crew no-verb wakes surfaced (queue + exit),
 # provably-working stale panes absorbed-then-escalated past the threshold,
-# terminal-looking stale status lines overridden by an active run, the heartbeat
-# backstop fail-safe, and afk coherence (no double-triage while the away-mode
-# daemon owns supervision).
+# terminal-looking stale status lines overridden by an active run, the
+# unread-backlog throttle that distinguishes a repeat exit on an already-queued
+# signal from a fresh one and escalates a named alarm after N repeats, the
+# heartbeat backstop fail-safe, and afk coherence (no double-triage while the
+# away-mode daemon owns supervision).
 #
 # Daemon-side classification/injection lives in fm-daemon.test.sh; watcher/lock
 # liveness in fm-watcher-lock.test.sh; the durable-queue safety matrix in
@@ -431,6 +433,128 @@ test_actionable_signal_surfaced() {
   grep "$(printf '\tsignal\t')" "$drain_out" | grep -F "$status_file" >/dev/null || fail "actionable signal was not queued"
   [ -s "$state/.hb-surfaced-task" ] || fail "actionable signal did not record the surfaced marker"
   pass "captain-relevant signal is surfaced (queue + exit) and marked surfaced"
+}
+
+# --- unread-backlog throttle: a repeat exit on a signal already queued and
+# undrained from a prior cycle is not new information (issue: "supervision
+# looks stalled when it is actually thrashing on unread worker reports" -
+# armed 00:17:45, exited 00:18:17, eight consecutive cycles reason=
+# actionable-signal on the same undrained status files). These reproduce the
+# reported thrash - re-detecting and re-exiting on the exact same undrained
+# signal every cycle - then assert the fix distinguishes it from a fresh
+# signal, escalates a named alarm after N repeats, and never re-fires once the
+# queue is actually drained and nothing further changes. -------------------
+
+test_signal_batch_fully_unacked_classifier() {
+  local dir state
+  dir=$(make_case classify-fully-unacked); state="$dir/state"
+  printf 'a\n' > "$state/a.status"
+  printf 'b\n' > "$state/b.status"
+  append_wake "$state" signal a.status "signal: $state/a.status"
+  ( export FM_STATE_OVERRIDE="$state" FM_ROOT_OVERRIDE="$ROOT"
+    # shellcheck source=/dev/null
+    . "$ROOT/bin/fm-watch.sh"
+    signal_batch_fully_unacked "$state/a.status" "$state/b.status" \
+      && fail "a batch with one un-queued file was classified fully unacked"
+    signal_batch_fully_unacked "$state/a.status" \
+      || fail "a batch whose only file is already queued was not classified fully unacked"
+  ) || exit 1
+  pass "signal_batch_fully_unacked requires every file in the batch to already be undrained-queued"
+}
+
+test_repeat_exit_on_undrained_signal_is_tagged_unacked() {
+  local dir state fakebin out drain_out status_file pid
+  dir=$(make_case unacked-second-exit); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch1.out"; drain_out="$dir/drain.out"
+  status_file="$state/task.status"
+  printf 'working: setup\nneeds-decision: pick A or B\n' > "$status_file"
+
+  # Cycle 1: a fresh detection queues and exits, unannotated.
+  watch_bg "$state" "$fakebin" "$out"
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "watcher did not exit for the fresh actionable signal"
+  grep -Fx "signal: $status_file" "$out" >/dev/null \
+    || fail "first cycle was not reported as a plain fresh signal: $(cat "$out")"
+
+  # The operator never drains the queue: touch the file again (fresh mtime,
+  # same content - reproduces "each carrying the same status files" from the
+  # reported evidence) so the watcher re-detects it as pending on the next arm.
+  touch "$status_file"
+  out="$dir/watch2.out"
+  export FM_SIGNAL_UNACKED_ESCALATE_SECS=0
+  watch_bg "$state" "$fakebin" "$out"
+  unset FM_SIGNAL_UNACKED_ESCALATE_SECS
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "watcher did not exit for the repeat undrained signal"
+  grep -F "signal:" "$out" | grep -Fq "unread backlog, not stalled" \
+    || fail "second exit on the SAME undrained signal was not distinguished from a fresh one: $(cat "$out")"
+  grep -Fq "SUPERVISION ALARM" "$out" \
+    && fail "a single repeat must not already read as the alarm: $(cat "$out")"
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain failed"
+  pass "a repeat exit on an already-queued, undrained signal is tagged unacked, not fresh"
+}
+
+test_n_consecutive_unacked_exits_raise_named_alarm() {
+  local dir state fakebin out status_file pid n
+  dir=$(make_case unacked-alarm); state="$dir/state"; fakebin="$dir/fakebin"
+  status_file="$state/decide-me.status"
+  printf 'needs-decision: pick A or B\n' > "$status_file"
+
+  out="$dir/watch0.out"
+  watch_bg "$state" "$fakebin" "$out"
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "watcher did not exit for the fresh actionable signal"
+
+  # Leave the queue undrained and keep re-touching the same file across
+  # FM_SIGNAL_UNACKED_ALARM_COUNT repeats with zero cooldown, so every cycle
+  # escalates the same unacked counter instead of idling on the throttle.
+  export FM_SIGNAL_UNACKED_ESCALATE_SECS=0 FM_SIGNAL_UNACKED_ALARM_COUNT=3
+  n=1
+  while [ "$n" -le 3 ]; do
+    touch "$status_file"
+    out="$dir/watch$n.out"
+    watch_bg "$state" "$fakebin" "$out"
+    pid=$!
+    wait_for_exit "$pid" 40 || fail "watcher did not exit on unacked-escalation cycle $n"
+    if [ "$n" -lt 3 ]; then
+      grep -Fq "SUPERVISION ALARM" "$out" && fail "alarm fired before the configured count on cycle $n: $(cat "$out")"
+    else
+      grep -Fq "SUPERVISION ALARM" "$out" || fail "alarm did not fire at the configured count: $(cat "$out")"
+      grep -Fq "decide-me" "$out" || fail "alarm did not name the unread task id: $(cat "$out")"
+    fi
+    n=$((n + 1))
+  done
+  unset FM_SIGNAL_UNACKED_ESCALATE_SECS FM_SIGNAL_UNACKED_ALARM_COUNT
+  pass "N consecutive unacked exits on the same signal raise a named supervision alarm with task ids"
+}
+
+test_drained_unacked_queue_holds_lock_beyond_one_cycle() {
+  local dir state fakebin out drain_out status_file pid
+  dir=$(make_case unacked-drained); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch1.out"; drain_out="$dir/drain.out"
+  status_file="$state/task.status"
+  printf 'needs-decision: pick A or B\n' > "$status_file"
+
+  watch_bg "$state" "$fakebin" "$out"
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "watcher did not exit for the fresh actionable signal"
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain failed"
+  grep "$(printf '\tsignal\t')" "$drain_out" | grep -F "$status_file" >/dev/null \
+    || fail "the original signal was not queued for drain"
+
+  # Nothing touches the status file again after the drain: a healthy watcher
+  # must just block on the poll loop, not re-fire on stale bookkeeping this
+  # throttle introduced.
+  out="$dir/watch2.out"
+  watch_bg "$state" "$fakebin" "$out"
+  pid=$!
+  wait_live "$pid" 20 || fail "watcher exited instead of holding its lock after a drained, unchanged queue"
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  [ -s "$out" ] && fail "watcher printed a reason with nothing left to report: $(cat "$out")"
+  pass "an arm with a drained, unchanged queue holds its lock beyond one cycle"
 }
 
 test_terminal_stale_surfaced() {
@@ -1812,6 +1936,10 @@ test_turn_ended_provably_working_absorbed
 test_turn_ended_not_working_surfaced
 test_working_note_not_working_surfaced
 test_actionable_signal_surfaced
+test_signal_batch_fully_unacked_classifier
+test_repeat_exit_on_undrained_signal_is_tagged_unacked
+test_n_consecutive_unacked_exits_raise_named_alarm
+test_drained_unacked_queue_holds_lock_beyond_one_cycle
 test_terminal_stale_surfaced
 test_stale_terminal_status_overridden_by_active_run
 test_nonterminal_stale_provably_working_absorbed_then_escalated


### PR DESCRIPTION
## Summary

- distinguish repeated watcher signals that are already queued and undrained from genuinely fresh signals
- throttle repeated unread-backlog reports while periodically escalating them with an explicit supervision alarm and affected task IDs
- document the new watcher state files and add coverage for classification, repeat reporting, alarm escalation, and post-drain behavior

Closes #2028
