### PR TITLE
fix(herdr): refuse panes whose shell was replaced

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1189,7 +1189,8 @@ fm_backend_herdr_pid_is_bare_shell() {  # <ps-bin> <pid>
 # window and succeeds on the first fully clean one; a genuinely busy pane
 # fails every sample and still refuses.
 # This is the single owner of the idle-shell proof; the session-start
-# projection cleanup and every pane-death close path both rely on it.
+# projection cleanup, every pane-death close path, and the spawn-time
+# send-target proof below all rely on it.
 fm_backend_herdr_pane_idle_shell_pid() {  # <session> <pane-id>
   local attempt=0 max_attempts=${FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS:-10}
   while :; do
@@ -1248,6 +1249,92 @@ fm_backend_herdr_pane_idle_shell_sample() {  # <session> <pane-id>
   stat=$("$ps_bin" -p "$shell_pid" -o stat= 2>/dev/null | tr -d '[:space:]') || return 1
   case "$stat" in S*|I*) ;; *) return 1 ;; esac
   printf '%s\n' "$shell_pid"
+}
+
+# fm_backend_herdr_created_pane_shell_intact: one process-info sample of
+# <pane-id>'s tracked shell pid. Deliberately lighter than the idle-shell proof
+# above (no OS process-table cross-check, no requirement that the shell be the
+# pane's SOLE foreground process): a freshly created pane's shell may still be
+# legitimately busy sourcing rc files - forking short-lived helpers like
+# `command -v tmux` - and that must never read as a failure here.
+# Returns:
+#   0 - shell_pid IS currently the (a) foreground process and its name/argv0
+#       resolve to a recognized shell - proven intact this sample.
+#   1 - shell_pid IS currently the (a) foreground process but its name/argv0
+#       do NOT resolve to a recognized shell - proven REPLACED (e.g. by an rc
+#       `exec`). `exec` keeps the same pid, so identity, not pid, is what
+#       distinguishes this from an intact shell.
+#   2 - inconclusive (shell_pid is not currently a foreground process, or the
+#       pane could not be read this sample) - the caller should retry.
+fm_backend_herdr_created_pane_shell_intact() {  # <session> <pane-id>
+  local session=$1 pane=$2 info shell_pid name argv0 shell_name
+  info=$(fm_backend_herdr_cli "$session" pane process-info --pane "$pane" 2>/dev/null) || return 2
+  printf '%s' "$info" | jq -e --arg pane "$pane" '
+    .result.type == "pane_process_info"
+    and .result.process_info.pane_id == $pane
+  ' >/dev/null 2>&1 || return 2
+  shell_pid=$(printf '%s' "$info" | jq -er \
+    '.result.process_info.shell_pid | select(type == "number" and . > 1) | floor' 2>/dev/null) || return 2
+  name=$(printf '%s' "$info" | jq -er --argjson pid "$shell_pid" '
+    (.result.process_info.foreground_processes // []) | map(select(.pid == $pid)) | .[0].name
+    | select(type == "string" and length > 0)
+  ' 2>/dev/null) || return 2
+  argv0=$(printf '%s' "$info" | jq -er --argjson pid "$shell_pid" '
+    (.result.process_info.foreground_processes // []) | map(select(.pid == $pid)) | .[0] as $process
+    | ($process.argv0 // $process.argv[0])
+    | select(type == "string" and length > 0)
+  ' 2>/dev/null) || return 2
+  shell_name=${name##*/}
+  argv0=${argv0#-}
+  argv0=${argv0##*/}
+  [ "$argv0" = "$shell_name" ] || return 1
+  case "$shell_name" in sh|bash|zsh|dash|ksh|fish) return 0 ;; esac
+  return 1
+}
+
+# fm_backend_herdr_verify_created_pane_shell: refuse a freshly created task
+# pane unless fm_backend_herdr_created_pane_shell_intact proves it, retried
+# across a settle window so a still-initializing shell gets a fair chance to
+# reach a sample where it is legibly its own foreground process, while a
+# PROVEN identity change (return 1 above) stops retrying immediately - `exec`
+# is irreversible, so waiting longer cannot un-happen it. Called once by
+# fm_backend_herdr_create_task, immediately after tab create, before any typed
+# delivery is attempted against the new pane.
+#
+# Why this exists (issue #1912): fm_backend_herdr_create_task creates the task
+# pane as a bare interactive shell and returns immediately; fm-spawn.sh then
+# TYPES the launch command into it afterwards (fm_backend_herdr_send_text_line
+# / fm_backend_herdr_send_literal). If the operator's shell rc replaces that
+# shell via `exec` (e.g. an auto-attach `exec tmux new-session -A -s main`)
+# before the typed text arrives, the worker never starts and the text lands in
+# whatever the replacement process is showing - on a host whose rc
+# auto-attaches to a shared session, that is the operator's own live session.
+#
+# Deliberately NOT wired into fm_backend_herdr_send_text_line /
+# fm_backend_herdr_send_literal themselves: fm_backend_herdr_send_text_submit
+# reuses those same two functions to deliver ordinary steering text to an
+# established, already-running (non-shell) agent pane, where this proof would
+# always and incorrectly refuse - fm-send.sh's own comment above its send call
+# is explicit that herdr's target-readiness check is the only backend-
+# readiness gate on that shared path, and this must not add a second one.
+# Proving once here, right after creation and before the caller ever types
+# into the pane, closes the reported deterministic case (the rc's `exec` fires
+# at shell start, so it has already happened, or is about to, well before this
+# proof or the first typed command either way) without touching that shared,
+# steering-reachable delivery path at all.
+fm_backend_herdr_verify_created_pane_shell() {  # <session> <pane-id>
+  local session=$1 pane=$2 attempt=0 max_attempts=${FM_BACKEND_HERDR_CREATED_SHELL_PROOF_POLLS:-30} rc
+  while :; do
+    fm_backend_herdr_created_pane_shell_intact "$session" "$pane"
+    rc=$?
+    [ "$rc" -eq 0 ] && return 0
+    [ "$rc" -eq 1 ] && break
+    attempt=$((attempt + 1))
+    [ "$attempt" -lt "$max_attempts" ] || break
+    sleep 0.1
+  done
+  echo "error: herdr pane $pane (session $session) does not host a bare recognized shell right after creation - refusing to type into it (a shell startup file may have exec'd it away, e.g. an auto-attach into another session)" >&2
+  return 1
 }
 
 # fm_backend_herdr_projection_order_best_effort: place the exact workspace id
@@ -2020,6 +2107,11 @@ EOF
     echo "error: could not parse tab/pane id from herdr tab create output" >&2
     return 1
   fi
+  # issue #1912: refuse before anything is ever typed into this pane unless it
+  # still provably hosts the bare shell just created - see
+  # fm_backend_herdr_verify_created_pane_shell for why this lives here and not
+  # in the (steering-shared) send functions fm-spawn.sh calls afterwards.
+  fm_backend_herdr_verify_created_pane_shell "$session" "$pane_id" || return 1
   [ -z "$seeded_tab_id" ] || fm_backend_herdr_workspace_prune_seeded_default_tab "$session" "$wsid" "$seeded_tab_id"
   if [ -n "$dup_tab_ids" ]; then
     while IFS= read -r dup; do
@@ -2534,6 +2626,11 @@ fm_backend_herdr_current_path() {  # <target>
 # ATOMICALLY - mirrors tmux's `send-keys -t T text Enter`. Used for the fixed
 # spawn-time commands (treehouse get, the GOTMPDIR export). `pane run` types
 # the command and submits it in one call (verified).
+# Deliberately NOT given a bare-shell proof (issue #1912's fix lives in
+# fm_backend_herdr_create_task instead): fm_backend_herdr_send_text_submit
+# below reuses this same function to deliver ordinary steering text to an
+# already-running, non-shell agent pane, where a bare-shell requirement would
+# always and incorrectly refuse.
 fm_backend_herdr_send_text_line() {  # <target> <text>
   fm_backend_herdr_target_ready "$1" || return 1
   fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane run "$FM_BACKEND_HERDR_PANE" "$2" >/dev/null 2>&1
@@ -2543,6 +2640,8 @@ fm_backend_herdr_send_text_line() {  # <target> <text>
 # caller sends Enter separately. Mirrors tmux's `send-keys -t T -l text`.
 # Verified: `pane send-text` does NOT auto-submit (contrary to the addendum's
 # original guess); it behaves exactly like tmux's `-l` literal send.
+# Deliberately NOT given a bare-shell proof - see the note on
+# fm_backend_herdr_send_text_line above; the same sharing applies here.
 fm_backend_herdr_send_literal() {  # <target> <text>
   fm_backend_herdr_target_ready "$1" || return 1
   fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane send-text "$FM_BACKEND_HERDR_PANE" "$2" >/dev/null 2>&1

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -101,12 +101,13 @@ jq_state() { jq "$@" "$STATE"; }
 save() { local tmp="$STATE.tmp.$$"; cat > "$tmp" && mv "$tmp" "$STATE"; }
 
 cmd=${1:-}; sub=${2:-}
-ws=""; label=""
+ws=""; label=""; pane_arg=""
 args=("$@")
 for ((i=0; i<${#args[@]}; i++)); do
   case "${args[$i]}" in
     --workspace) ws=${args[$((i+1))]:-} ;;
     --label) label=${args[$((i+1))]:-} ;;
+    --pane) pane_arg=${args[$((i+1))]:-} ;;
   esac
 done
 
@@ -156,6 +157,15 @@ case "$cmd $sub" in
     else
       printf '{"error":{"code":"agent_not_found","message":"agent target %s not found"}}\n' "$pane"
     fi
+    ;;
+  "pane process-info")
+    # A freshly created task pane always reports as a healthy bare zsh - this
+    # fake never models an rc `exec` replacement (issue #1912's own hijacked
+    # case is covered by a dedicated non-stateful fixture instead). The pid is
+    # synthetic (never a real OS process) because
+    # fm_backend_herdr_created_pane_shell_intact only reads this JSON identity,
+    # never the OS process table.
+    printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"%s","shell_pid":999999,"foreground_process_group_id":999999,"foreground_processes":[{"pid":999999,"name":"zsh","argv0":"zsh"}]}}}\n' "$pane_arg"
     ;;
   *) : ;;
 esac
@@ -617,7 +627,9 @@ test_create_task_closes_and_replaces_dead_pane_husk() {
   printf '{"error":{"code":"pane_not_found","message":"pane w1:p2 not found"}}\n' > "$resp/3.out"
   # 4: tab create -> the replacement tab (created BEFORE the husk is closed)
   printf '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}\n' > "$resp/4.out"
-  printf '{"result":{"tabs":[{"tab_id":"w1:t3","label":"fm-husk1","workspace_id":"w1"}]}}\n' > "$resp/6.out"
+  # 5: pane process-info -> the new pane's own shell (issue #1912 proof)
+  death_process_info_fixture w1:p3 999999 > "$resp/5.out"
+  printf '{"result":{"tabs":[{"tab_id":"w1:t3","label":"fm-husk1","workspace_id":"w1"}]}}\n' > "$resp/7.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-husk1 /tmp/proj' "$ROOT" ) \
@@ -645,7 +657,9 @@ test_create_task_closes_and_replaces_no_agent_husk() {
   printf '{"error":{"code":"agent_not_found","message":"agent target w1:p2 not found"}}\n' > "$resp/4.out"
   # 5: tab create -> the replacement tab (created BEFORE the husk is closed)
   printf '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}\n' > "$resp/5.out"
-  printf '{"result":{"tabs":[{"tab_id":"w1:t3","label":"fm-husk2","workspace_id":"w1"}]}}\n' > "$resp/7.out"
+  # 6: pane process-info -> the new pane's own shell (issue #1912 proof)
+  death_process_info_fixture w1:p3 999999 > "$resp/6.out"
+  printf '{"result":{"tabs":[{"tab_id":"w1:t3","label":"fm-husk2","workspace_id":"w1"}]}}\n' > "$resp/8.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-husk2 /tmp/proj' "$ROOT" ) \
@@ -673,7 +687,9 @@ test_create_task_closes_all_duplicate_husks_after_replacement() {
   printf '{"result":{"pane":{"pane_id":"w1:p3"}}}\n' > "$resp/6.out"
   printf '{"error":{"code":"agent_not_found","message":"agent target w1:p3 not found"}}\n' > "$resp/7.out"
   printf '{"result":{"tab":{"tab_id":"w1:t4"},"root_pane":{"pane_id":"w1:p4"}}}\n' > "$resp/8.out"
-  printf '{"result":{"tabs":[{"tab_id":"w1:t4","label":"fm-husk-many","workspace_id":"w1"}]}}\n' > "$resp/11.out"
+  # 9: pane process-info -> the new pane's own shell (issue #1912 proof)
+  death_process_info_fixture w1:p4 999999 > "$resp/9.out"
+  printf '{"result":{"tabs":[{"tab_id":"w1:t4","label":"fm-husk-many","workspace_id":"w1"}]}}\n' > "$resp/12.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-husk-many /tmp/proj' "$ROOT" ) \
@@ -704,8 +720,10 @@ test_create_task_refuses_when_preexisting_husk_tab_remains() {
   printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/3.out"
   printf '{"error":{"code":"agent_not_found","message":"agent target w1:p2 not found"}}\n' > "$resp/4.out"
   printf '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}\n' > "$resp/5.out"
-  printf '1\n' > "$resp/6.exit"
-  printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"fm-stale-husk","workspace_id":"w1"},{"tab_id":"w1:t3","label":"fm-stale-husk","workspace_id":"w1"}]}}\n' > "$resp/7.out"
+  # 6: pane process-info -> the new pane's own shell (issue #1912 proof)
+  death_process_info_fixture w1:p3 999999 > "$resp/6.out"
+  printf '1\n' > "$resp/7.exit"
+  printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"fm-stale-husk","workspace_id":"w1"},{"tab_id":"w1:t3","label":"fm-stale-husk","workspace_id":"w1"}]}}\n' > "$resp/8.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-stale-husk /tmp/proj' "$ROOT" 2>&1 )
@@ -753,7 +771,9 @@ test_create_task_husk_replacement_creates_before_closing() {
   printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}\n' > "$resp/2.out"
   printf '{"error":{"code":"pane_not_found","message":"pane w1:p2 not found"}}\n' > "$resp/3.out"
   printf '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}\n' > "$resp/4.out"
-  printf '{"result":{"tabs":[{"tab_id":"w1:t3","label":"fm-order1","workspace_id":"w1"}]}}\n' > "$resp/6.out"
+  # 5: pane process-info -> the new pane's own shell (issue #1912 proof)
+  death_process_info_fixture w1:p3 999999 > "$resp/5.out"
+  printf '{"result":{"tabs":[{"tab_id":"w1:t3","label":"fm-order1","workspace_id":"w1"}]}}\n' > "$resp/7.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-order1 /tmp/proj' "$ROOT" ) \
@@ -771,6 +791,8 @@ test_create_task_creates_and_parses_ids() {
   dir="$TMP_ROOT/create-task"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"tabs":[]}}\n' > "$resp/1.out"
   printf '{"result":{"tab":{"tab_id":"w1:t2"},"root_pane":{"pane_id":"w1:p2"}}}\n' > "$resp/2.out"
+  # 3: pane process-info -> the new pane's own shell (issue #1912 proof)
+  death_process_info_fixture w1:p2 999999 > "$resp/3.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-newtask /tmp/proj' "$ROOT" )
@@ -822,6 +844,8 @@ test_create_task_creates_with_no_focus_flag() {
   dir="$TMP_ROOT/create-task-no-focus"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '{"result":{"tabs":[]}}\n' > "$resp/1.out"
   printf '{"result":{"tab":{"tab_id":"w1:t2"},"root_pane":{"pane_id":"w1:p2"}}}\n' > "$resp/2.out"
+  # 3: pane process-info -> the new pane's own shell (issue #1912 proof)
+  death_process_info_fixture w1:p2 999999 > "$resp/3.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-newtask /tmp/proj' "$ROOT" )
@@ -829,6 +853,96 @@ test_create_task_creates_with_no_focus_flag() {
   assert_contains "$(cat "$log")" $'\x1f''tab'$'\x1f''create'$'\x1f''--workspace'$'\x1f''w1'$'\x1f''--cwd'$'\x1f''/tmp/proj'$'\x1f''--label'$'\x1f''fm-newtask'$'\x1f''--no-focus' \
     "create_task's tab create did not pass --no-focus"
   pass "fm_backend_herdr_create_task: tab create passes --no-focus"
+}
+
+# --- issue #1912: refuse a task pane whose shell was exec'd away ------------
+#
+# The herdr backend used to create the task pane as a bare interactive shell
+# and return immediately; fm-spawn.sh then TYPED the launch command into it
+# afterwards. If the operator's shell rc replaced that shell via `exec` (e.g.
+# an auto-attach `exec tmux new-session -A -s main`) before the typed text
+# arrived, the worker never started and the launch command landed in whatever
+# the replacement process was showing - on a host whose rc auto-attaches to a
+# shared session, that is the operator's own live session. `exec` keeps the
+# same pid, so only process IDENTITY (name/argv0), not pid, tells the two
+# states apart.
+
+# hijacked_process_info_fixture <pane> <pid> <name>: models a pane whose
+# tracked shell pid now runs <name> instead (an exec replacement), reusing
+# death_process_info_fixture's verified JSON shape with a non-shell name/argv0.
+hijacked_process_info_fixture() {  # <pane> <pid> <name>
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"%s","shell_pid":%s,"foreground_process_group_id":%s,"foreground_processes":[{"pid":%s,"name":"%s","argv0":"%s"}]}}}\n' "$1" "$2" "$2" "$2" "$3" "$3"
+}
+
+test_create_task_refuses_when_pane_shell_was_exec_replaced() {
+  local dir log resp fb out status
+  dir="$TMP_ROOT/create-task-hijacked"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"tabs":[]}}\n' > "$resp/1.out"
+  printf '{"result":{"tab":{"tab_id":"w1:t2"},"root_pane":{"pane_id":"w1:p2"}}}\n' > "$resp/2.out"
+  # 3: pane process-info -> reproduces issue #1912: an rc `exec tmux
+  # new-session -A -s main` replaced the pane's shell before this fix's proof
+  # (and, before the fix existed at all, before the typed launch command)
+  # arrived. Same pid, but the foreground process is now "tmux".
+  hijacked_process_info_fixture w1:p2 4242 tmux > "$resp/3.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-hijacked /tmp/proj' "$ROOT" 2>&1 )
+  status=$?
+  [ "$status" -ne 0 ] || fail "create_task must refuse a pane whose shell has been exec'd away, got success: $out"
+  assert_contains "$out" "does not host a bare recognized shell" "create_task's refusal did not explain why"
+  assert_not_contains "$out" "w1:t2 w1:p2" "create_task must not echo tab/pane ids for a hijacked pane - a caller that missed the exit code must never mistake this for success"
+  pass "fm_backend_herdr_create_task: refuses (issue #1912) a pane whose shell was exec'd away right after creation, before any launch text is ever typed into it"
+}
+
+# --- fm_backend_herdr_verify_created_pane_shell: retry/no-retry semantics ---
+
+test_verify_created_pane_shell_refuses_a_confirmed_replacement_without_retrying() {
+  local dir log resp fb out status calls
+  dir="$TMP_ROOT/verify-shell-hijacked"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  hijacked_process_info_fixture w1:p2 4242 tmux > "$resp/1.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_verify_created_pane_shell default w1:p2' "$ROOT" 2>&1 )
+  status=$?
+  [ "$status" -ne 0 ] || fail "verify_created_pane_shell must refuse a confirmed non-shell identity"
+  calls=$(grep -c $'pane\x1fprocess-info' "$log")
+  [ "$calls" -eq 1 ] || fail "a PROVEN identity change is irreversible - retrying cannot un-happen an exec, so this must sample exactly once, not poll the default budget; got $calls sample(s)"
+  pass "fm_backend_herdr_verify_created_pane_shell: refuses a confirmed exec replacement on the first sample, without wasting the retry budget"
+}
+
+test_verify_created_pane_shell_tolerates_a_transiently_busy_shell() {
+  local dir log resp fb status calls
+  dir="$TMP_ROOT/verify-shell-busy-then-ok"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  # 1: the shell is momentarily not its own foreground process (e.g. rc
+  # sourcing forked a short-lived `command -v tmux`) - inconclusive, not proof
+  # of anything, so this must NOT read as a failure.
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":999999,"foreground_process_group_id":555555,"foreground_processes":[{"pid":555555,"name":"command","argv0":"command"}]}}}\n' > "$resp/1.out"
+  # 2: the shell is back to being its own foreground process, and it is
+  # recognized - proven intact.
+  death_process_info_fixture w1:p2 999999 > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_verify_created_pane_shell default w1:p2' "$ROOT"
+  status=$?
+  [ "$status" -eq 0 ] || fail "verify_created_pane_shell should tolerate a transiently busy (not yet foreground) shell and succeed once it resolves"
+  calls=$(grep -c $'pane\x1fprocess-info' "$log")
+  [ "$calls" -eq 2 ] || fail "expected exactly 2 samples (one inconclusive, one proof), got $calls"
+  pass "fm_backend_herdr_verify_created_pane_shell: tolerates a transiently busy shell (rc still sourcing) instead of false-refusing it"
+}
+
+test_verify_created_pane_shell_gives_up_after_budget_exhausted() {
+  local dir log resp fb status calls
+  dir="$TMP_ROOT/verify-shell-never-resolves"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":999999,"foreground_process_group_id":555555,"foreground_processes":[{"pid":555555,"name":"command","argv0":"command"}]}}}\n' > "$resp/1.out"
+  cp "$resp/1.out" "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_BACKEND_HERDR_CREATED_SHELL_PROOF_POLLS=2 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_verify_created_pane_shell default w1:p2' "$ROOT" >/dev/null 2>&1
+  status=$?
+  [ "$status" -ne 0 ] || fail "verify_created_pane_shell must refuse (fail-safe) if the shell never legibly proves intact within the budget"
+  calls=$(grep -c $'pane\x1fprocess-info' "$log")
+  [ "$calls" -eq 2 ] || fail "expected exactly the configured 2-sample budget to be spent, got $calls"
+  pass "fm_backend_herdr_verify_created_pane_shell: refuses (fail-safe) rather than guessing when the shell never legibly proves intact within the budget"
 }
 
 # --- default-on disposable presentation projection --------------------------
@@ -4243,6 +4357,10 @@ test_create_task_refuses_when_agent_state_ambiguous
 test_create_task_husk_replacement_creates_before_closing
 test_create_task_creates_and_parses_ids
 test_create_task_creates_with_no_focus_flag
+test_create_task_refuses_when_pane_shell_was_exec_replaced
+test_verify_created_pane_shell_refuses_a_confirmed_replacement_without_retrying
+test_verify_created_pane_shell_tolerates_a_transiently_busy_shell
+test_verify_created_pane_shell_gives_up_after_budget_exhausted
 test_presentation_defaults_on_at_or_above_the_floor
 test_presentation_default_falls_back_below_the_floor
 test_presentation_unreadable_release_falls_back


### PR DESCRIPTION
## Summary

- verify that a newly created Herdr task pane still hosts its recognized shell before any launch text is typed into it
- fail immediately when the shell identity was replaced via `exec`, while retrying inconclusive samples during shell startup
- add regression coverage for replaced, transiently busy, and never-resolving shell states

Closes #1912
