### PR TITLE
fix: accept status keys after verb colon

### DIFF
--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -160,8 +160,10 @@ status_is_paused_or_captain_held() {  # <status-line>
 # rule 6), so closure never depends on a busy worker's discipline.
 #
 # Decision key grammar (backward-compatible with the existing "<verb>: <note>"
-# format): an OPTIONAL "[key=<slug>]" token sits between the verb and the colon,
+# format): an OPTIONAL "[key=<slug>]" token sits between the verb and the colon
+# or immediately after the colon,
 #   needs-decision [key=api-shape]: <summary>
+#   needs-decision: [key=api-shape] <summary>
 #   resolved       [key=api-shape]: <how it was decided>
 # A line with no token uses the key "default", preserving the historical
 # one-open-decision-per-task behavior (a bare "resolved:" closes "default").
@@ -181,17 +183,28 @@ status_line_note() {  # <status-line> -> text after the first colon, trimmed
   esac
 }
 _fm_decision_key() {  # <status-line> -> key slug, or "default" when no token
-  local prefix=${1%%:*} k
-  case "$prefix" in
-    *\[key=*\]*)
-      k=${prefix#*\[key=}
-      k=${k%%\]*}
-      case "$k" in
-        ''|*[!A-Za-z0-9._-]*) return 1 ;;
-        *) printf '%s' "$k" ;;
+  local candidate=${1%%:*} k
+  case "$candidate" in
+    *\[key=*\]*) ;;
+    *)
+      case "$1" in
+        *:*)
+          candidate=${1#*:}
+          candidate=${candidate#"${candidate%%[![:space:]]*}"}
+          case "$candidate" in
+            \[key=*\]*) ;;
+            *) printf 'default'; return ;;
+          esac
+          ;;
+        *) printf 'default'; return ;;
       esac
       ;;
-    *) printf 'default' ;;
+  esac
+  k=${candidate#*\[key=}
+  k=${k%%\]*}
+  case "$k" in
+    ''|*[!A-Za-z0-9._-]*) return 1 ;;
+    *) printf '%s' "$k" ;;
   esac
 }
 # Drop the record for <key> from a newline-terminated "<key>\t<verb>\t<note>" set.

--- a/tests/fm-send-resolve-key.test.sh
+++ b/tests/fm-send-resolve-key.test.sh
@@ -112,7 +112,7 @@ test_answer_send_closes_open_decision() {
   fb=$(make_stubs "$dir"); log="$dir/send.log"
   home=$(setup_home closes)
   fm_write_meta "$home/state/t1.meta" "window=sess:fm-t1" "kind=ship"
-  printf 'needs-decision [key=api-shape]: pick REST or RPC\n' > "$home/state/t1.status"
+  printf 'needs-decision: [key=api-shape] pick REST or RPC\n' > "$home/state/t1.status"
   printf 'working: kept busy on an unrelated stream\n' >> "$home/state/t1.status"
 
   out=$(drain_out "$home")

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -211,6 +211,14 @@ test_classifier_primitives() {
     && fail "a key token in note prose changed the decision key"
   printf '%s' "$open" | grep -F $'bad key\t' >/dev/null \
     && fail "an invalid key slug entered the open-decision set"
+  printf 'needs-decision: [key=post-colon-one] first choice\nneeds-decision: [key=post-colon-two] second choice\nresolved: [key=post-colon-one] first choice answered\n' > "$state/post-colon-keys.status"
+  open=$(status_open_decisions "$state/post-colon-keys.status")
+  printf '%s' "$open" | grep -F $'post-colon-two\tneeds-decision\t[key=post-colon-two] second choice' >/dev/null \
+    || fail "a leading post-colon key token did not open its named decision"
+  printf '%s' "$open" | grep -F $'post-colon-one\t' >/dev/null \
+    && fail "a leading post-colon key token did not resolve its named decision"
+  printf '%s' "$open" | grep -F $'default\t' >/dev/null \
+    && fail "leading post-colon key tokens silently collapsed to default"
   cat > "$state/activity.status" <<'EOF'
 working [key=phase7]: Phase 7 started
 working [key=phase6]: Phase 6 started


### PR DESCRIPTION
## Summary

- Accept `[key=<slug>]` when it is the first token after a status verb's colon, while preserving the existing pre-colon grammar.
- Keep key-like text later in ordinary note prose non-structural.
- Fix the shared parser cause behind both #2109 and #2081, including keyed `needs-decision`, `resolved`, and `fm-send --resolve-key` behavior.

## Reproduction

Before the fix, the issue's scratch-status reproduction returned the named key for the pre-colon form and silently returned `default` for the post-colon form:

```text
pre-colon: alpha    needs-decision    needs-decision [key=alpha] no colon form
post-colon: default needs-decision    [key=beta] colon form
```

The added classifier regression failed before the implementation change with:

```text
not ok - a leading post-colon key token did not open its named decision
FM_TEST_END ... exit=1
```

After the fix, that regression passed as part of `classifier primitives`, two post-colon keys remained distinct, and a post-colon `resolved` event closed only its named key.
The end-to-end `fm-send --resolve-key` regression also passed with a post-colon `needs-decision` event.

## Validation

- `git diff --check` - passed.
- `bin/fm-lint.sh` - passed with pinned ShellCheck 0.11.0.
- `bin/fm-doc-audience-check.sh` - passed (`surfaces=67 local_links=233`).
- `bin/fm-test-run.sh tests/fm-send-resolve-key.test.sh` - passed, 10 tests, exit 0.
- The new classifier assertion failed before the fix and passed after it.

`tests/fm-watch-triage.test.sh` has a pre-existing unrelated timing problem after the classifier tests complete.
On the changed branch, the first run passed `classifier primitives`, then failed later with `not ok - dead-agent declared pause flooded stale wakes across six unchanged polls` and exited 1.
The changed-branch rerun again passed `classifier primitives`, then stopped producing output and was interrupted after 250094 ms, exiting 130.

Firstmate authorized one bounded comparison against exact base commit `7f828ea2f28c83aa9e3afd44a2a5ee64795005f8` with both changed files restored to that commit.
That run printed `BASE_DIFF_BEGIN` followed immediately by `BASE_DIFF_END`, passed the same earlier classifier cases, then hung in the unrelated watcher timing cases and reached the 240-second bound:

```text
BASE_COMMIT=7f828ea2f28c83aa9e3afd44a2a5ee64795005f8
BASE_DIFF_BEGIN
BASE_DIFF_END
ok - classifier primitives: keyed decisions and activity phases, captain relevance, window-to-task, and overrides
...
BASE_TEST_EXIT=124
```

This proves the `fm-watch-triage` hang reproduces with the key-parser change absent.

## Decisions

- Firstmate authorized the base-commit comparison under delegated authority; the captain was not consulted and approved nothing for this lane.
- Firstmate kept the unrelated `fm-watch-triage` timing defect outside this issue because it reproduces on the base commit.
- Firstmate switched this lane to direct delivery after three guarded custody-recovery refusals reported `state=blocked_recover_gate_diverged` and `changed=false`; no files or refs changed, so no work was lost.
- Pipeline head `705c78ef` and local head `4405008` had identical stable patch ID `76bbd814ca0802bb40644310b0949bebe9426491`, proving both carry the same intended fix.
- `705c78ef` was preferred because it rebased that patch onto newer base `7f05100`, but it was not reachable from this worktree, so Firstmate authorized direct delivery from the content-equivalent `4405008` fallback.
- The pre-existing watcher-suite hang is documented here and is not fixed or otherwise widened into this PR.

## Not applicable

- Database: this repository has none; no stack was started.
- Browser validation: this repository has no browser-facing surface.
- Cypress: this repository has no Cypress suite, and Cypress was not run locally.

Closes #2109

Closes #2081
