### PR TITLE
fix: accept Kimi 0.34.0 folder-trust dialog during spawn

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -357,7 +357,7 @@ The tracked Claude hook entries whose event Grok already covers through its own 
 Project-local Grok hooks require folder trust, verified with launch-time `--trust`; if the primary firstmate checkout is not trusted for Grok hooks, this primary guard fails open and `fm-guard.sh` remains the next-command alarm.
 Grok's primary watcher protocol remains background-notify around `bin/fm-watch-arm.sh`; native Stop continuation does not provide Pi-like extension ownership.
 
-## kimi (VERIFIED 2026-07-25, kimi 0.29.1)
+## kimi (VERIFIED 2026-07-25, kimi 0.29.1; folder-trust handling live-verified 2026-08-11 on kimi 0.34.0)
 
 Kimi Code CLI launches from the absolute path resolved from `PATH`, falling back to the executable `$HOME/.kimi-code/bin/kimi`.
 
@@ -371,7 +371,7 @@ Kimi Code CLI launches from the absolute path resolved from `PATH`, falling back
 | Interrupt | Single Escape, which prints `Interrupted by user`. |
 | Skill invocation | `/<skill>`, for example `/no-mistakes`; firstmate skills are discovered. |
 | Autonomy | `--auto`; `-y` and `--yolo` are weaker and are not used. |
-| Trust dialog | None on a clean first launch in a fresh pooled worktree. |
+| Trust dialog | Kimi 0.34.0+ shows a `Trust this folder?` picker on the first launch in an untrusted workspace, before any banner or composer renders. It preselects `Trust this folder`, and one Enter accepts it; the choice persists per workspace root under `$HOME/.kimi-code/workspace-trust/`, so later spawns in the same worktree skip it. `fm-spawn.sh` detects the picker during its ready wait and sends that Enter itself, bounded by `FM_KIMI_TRUST_ACCEPTS` (default 3); a picker that never clears fails the spawn loudly and the brief pointer is never sent past it. Kimi older than 0.34.0 shows no picker and needs nothing. |
 | Slash submission | One Enter submits, with no popup swallow or settle hazard. |
 | Environment marker | None; detection relies on process ancestry command name `kimi`. |
 | Composer | Bordered box with a bare `>` prompt glyph and no observed ghost or placeholder text. |

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2076,13 +2076,27 @@ kimi_composer_is_empty() {
   [ "$(fm_backend_composer_state "$BACKEND" "$T" "$W" 2>/dev/null)" = empty ]
 }
 
+kimi_capture_has_trust_dialog() {  # <plain-pane-capture>
+  printf '%s\n' "$1" | grep -Fq 'Trust this folder?'
+}
+
 kimi_wait_for_ready() {
   local pane i=0 max=${FM_KIMI_READY_POLLS:-60} interval=${FM_KIMI_POLL_INTERVAL:-0.5}
+  local trust_accepts=0 trust_max=${FM_KIMI_TRUST_ACCEPTS:-3}
   while [ "$i" -lt "$max" ]; do
     pane=$(kimi_capture)
     if printf '%s\n' "$pane" | grep -Fq 'Welcome to Kimi Code!' \
        || kimi_composer_is_empty; then
       return 0
+    fi
+    # Kimi 0.34.0+ gates an untrusted workspace on its folder-trust picker
+    # before any banner or composer renders. The picker preselects "Trust this
+    # folder", so one Enter grants exactly the workspace trust this spawn needs;
+    # the choice persists under ~/.kimi-code/workspace-trust for later spawns.
+    # Older versions never show the picker and skip this branch entirely.
+    if [ "$trust_accepts" -lt "$trust_max" ] && kimi_capture_has_trust_dialog "$pane"; then
+      spawn_send_key "$T" Enter
+      trust_accepts=$((trust_accepts + 1))
     fi
     i=$((i + 1))
     [ "$i" -ge "$max" ] || sleep "$interval"
@@ -2700,7 +2714,11 @@ fi
 spawn_send_key "$T" Enter
 if [ "$HARNESS" = kimi ]; then
   if ! kimi_wait_for_ready; then
-    kimi_spawn_fail "kimi did not show a verified ready signal before brief delivery"
+    if kimi_capture_has_trust_dialog "$(kimi_capture)"; then
+      kimi_spawn_fail "kimi folder-trust dialog could not be accepted before brief delivery"
+    else
+      kimi_spawn_fail "kimi did not show a verified ready signal before brief delivery"
+    fi
     exit 1
   fi
   KIMI_POINTER="Read the brief at $BRIEF_REAL and follow it exactly."

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -40,6 +40,9 @@ fake_screen() {
     delivered)
       printf '✨ Read the brief at %s and follow it exactly.\ncontext: 1%% (2k/256k)\n╭────────────────────────────────╮\n│ >                              │\n╰────────────────────────────────╯\n' "$FM_FAKE_BRIEF_REAL"
       ;;
+    trust-dialog)
+      printf 'Trust this folder?\n↑↓ navigate · Enter select · Esc exit\n\n%s\n\n ❯ Trust this folder\n   Enable project MCP servers. Remembered for this folder.\n\n   Don'"'"'t trust\n   Exit Kimi Code. Asked again next launch.\n' "$FM_FAKE_PANE_PATH"
+      ;;
     *)
       printf 'shell starting\n$ \n'
       ;;
@@ -84,7 +87,16 @@ case "${1:-}" in
       *' Enter '*)
         case "$state" in
           launched)
-            if [ "${FM_FAKE_KIMI_READY:-yes}" = yes ]; then
+            if [ "${FM_FAKE_KIMI_TRUST_DIALOG:-no}" = yes ]; then
+              # The launch-submit Enter goes to the shell; Kimi 0.34.0+ then
+              # presents its folder-trust picker before any ready signal.
+              printf 'trust-dialog\n' > "$FM_FAKE_KIMI_STATE"
+            elif [ "${FM_FAKE_KIMI_READY:-yes}" = yes ]; then
+              printf 'ready\n' > "$FM_FAKE_KIMI_STATE"
+            fi
+            ;;
+          trust-dialog)
+            if [ "${FM_FAKE_KIMI_TRUST_STUCK:-no}" != yes ]; then
               printf 'ready\n' > "$FM_FAKE_KIMI_STATE"
             fi
             ;;
@@ -163,6 +175,8 @@ run_spawn() {
     FM_FAKE_KIMI_STATE="$case_dir/kimi.state" \
     FM_FAKE_KIMI_SWALLOWED="$case_dir/kimi.swallowed" \
     FM_FAKE_KIMI_SWALLOW_FIRST="${FM_FAKE_KIMI_SWALLOW_FIRST:-no}" \
+    FM_FAKE_KIMI_TRUST_DIALOG="${FM_FAKE_KIMI_TRUST_DIALOG:-no}" \
+    FM_FAKE_KIMI_TRUST_STUCK="${FM_FAKE_KIMI_TRUST_STUCK:-no}" \
     FM_FAKE_TMUX_CALL_LOG="$case_dir/tmux-calls.log" \
     FM_FAKE_BRIEF_REAL="$(cd "$home/data/$id" && pwd -P)/brief.md" \
     FM_KIMI_READY_POLLS=2 FM_KIMI_DELIVERY_POLLS=2 FM_KIMI_POLL_INTERVAL=0 \
@@ -503,6 +517,37 @@ test_kimi_readiness_gate_precedes_pointer() {
   pass "fm-spawn: kimi never sends the brief pointer before an observable ready signal"
 }
 
+test_kimi_trust_dialog_is_accepted_before_delivery() {
+  local id rec out rc
+  id="kimi-trust-z9-$$"
+  rec=$(make_spawn_case trust-accept "$id")
+  read_spawn_record "$rec"
+  out=$(FM_FAKE_KIMI_TRUST_DIALOG=yes run_spawn \
+    "$CASE_DIR" "$HOME_DIR" "$PROJ_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id")
+  rc=$?
+  expect_code 0 "$rc" "kimi spawn behind the 0.34.0 trust dialog should succeed"
+  assert_contains "$out" "spawned $id harness=kimi" "kimi trust-dialog spawn did not report success"
+  [ -s "$CASE_DIR/pointer.log" ] || fail "kimi pointer was not delivered after trust acceptance"
+  pass "fm-spawn: kimi accepts the 0.34.0 folder-trust dialog and delivers the brief"
+}
+
+test_kimi_unaccepted_trust_dialog_fails_loudly() {
+  local id rec out rc
+  id="kimi-trust-stuck-za-$$"
+  rec=$(make_spawn_case trust-stuck "$id")
+  read_spawn_record "$rec"
+  rc=0
+  out=$(FM_FAKE_KIMI_TRUST_DIALOG=yes FM_FAKE_KIMI_TRUST_STUCK=yes run_spawn \
+    "$CASE_DIR" "$HOME_DIR" "$PROJ_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "an unaccepted kimi trust dialog should fail the spawn"
+  assert_contains "$out" "kimi folder-trust dialog could not be accepted" \
+    "unaccepted kimi trust dialog lacked a loud diagnostic"
+  [ ! -s "$CASE_DIR/pointer.log" ] || fail "kimi pointer was sent while the trust dialog was still up"
+  assert_grep 'failed: kimi folder-trust dialog could not be accepted' "$HOME_DIR/state/$id.status" \
+    "unaccepted kimi trust dialog did not leave a supervisor-visible failure"
+  pass "fm-spawn: kimi never sends the brief pointer past an unaccepted trust dialog"
+}
+
 test_kimi_detection_uses_ancestry_after_markers() {
   local dir fakebin cfg out
   dir="$TMP_ROOT/detection"
@@ -669,6 +714,8 @@ test_kimi_falls_back_to_expanded_home_binary
 test_kimi_missing_binary_refuses_before_pane_creation
 test_kimi_unconfirmed_delivery_fails_loudly
 test_kimi_readiness_gate_precedes_pointer
+test_kimi_trust_dialog_is_accepted_before_delivery
+test_kimi_unaccepted_trust_dialog_fails_loudly
 test_kimi_detection_uses_ancestry_after_markers
 test_kimi_session_lock_identity
 test_kimi_busy_signature_is_scoped_to_spinner_lines


### PR DESCRIPTION
## Problem

Kimi 0.34.0 added a folder-trust picker ("Trust this folder?") that renders before any banner or composer on the first launch in an untrusted workspace. `fm-spawn.sh`'s Kimi ready wait never saw a ready signal, so every Kimi spawn failed with "did not show a verified ready signal" and the brief pointer was never sent.

## Fix

- `kimi_wait_for_ready` now detects the picker and accepts it with Enter through the backend key path. The picker preselects "Trust this folder", so one Enter grants exactly the workspace trust the spawn needs - no broader trust boundary. The choice persists per workspace root under `~/.kimi-code/workspace-trust/`, so later spawns in the same worktree skip the picker entirely.
- Acceptance is bounded by `FM_KIMI_TRUST_ACCEPTS` (default 3). A picker that never clears fails the spawn loudly with a trust-specific diagnostic, and the brief pointer is never sent past an unaccepted picker.
- Kimi older than 0.34.0 shows no picker and takes the unchanged path.
- `harness-adapters` skill Kimi section updated: stale "no trust dialog" row replaced with the verified 0.34.0 behavior.

## Verification

- Reproduced live on kimi 0.34.0: untrusted directory shows the picker, Enter accepts the preselected "Trust this folder", trust persists in `~/.kimi-code/workspace-trust/wd_*`.
- End-to-end live spawns through `fm-spawn.sh` on kimi 0.34.0 on BOTH the tmux and herdr backends: trust auto-accepted, brief delivered on the first spawn, worker read the brief and responded. No manual `--key Enter` or second steer needed.
- `tests/fm-kimi-harness.test.sh`: two new portable regressions pin the accept path and the stuck-dialog loud failure; full suite 19/19 ok.
- `bin/fm-lint.sh` (ShellCheck 0.11.0 pin) clean; `bin/fm-doc-audience-check.sh` ok.