### PR TITLE
fix(spawn): durably lease task worktrees

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,20 @@ jobs:
           set -eu
           npm install -g tasks-axi
           tasks-axi --version
+      - name: Install pinned Treehouse
+        run: |
+          set -eu
+          # fm-tangle-guard's lease lifecycle coverage drives real treehouse get
+          # and return to prove a task-scoped lease survives a stopped worker and
+          # concurrently-live workers. Assert the binary rather than skipping, so
+          # a missing pin fails the lane instead of silently dropping that proof.
+          bin/fm-install-treehouse.sh "$RUNNER_TEMP/bin"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+      - name: Assert Treehouse pin
+        run: |
+          set -eu
+          command -v treehouse >/dev/null || { echo "::error::treehouse not on PATH after install"; exit 1; }
+          treehouse --version
       - name: Run portable serial shard ${{ matrix.shard }}
         env:
           # job-total rather than a literal, so shrinking or growing the matrix

--- a/bin/backends/cmux.sh
+++ b/bin/backends/cmux.sh
@@ -438,10 +438,8 @@ fm_backend_cmux_target_ready() {  # <target> [expected-label]
 # Verified pitfall (finding #2 above): cmux's `current_directory` field DOES
 # reflect a `cd` run directly in the surface's own top-level shell, but stays
 # FROZEN when an interactive subshell is held open in the foreground instead.
-# The worktree-acquisition line fm-spawn.sh actually sends,
-# `cd "$(treehouse get --lease --lease-holder <id>)"`, avoids that: `--lease`
-# prints the path and exits without opening a subshell, so the `cd` itself is
-# a plain top-level command. cmux's control socket exposes no live-process cwd
+# fm-spawn.sh's controller instead acquires the durable lease synchronously,
+# then sends only a plain top-level `cd <leased-path>`. cmux's control socket exposes no live-process cwd
 # field to fall back on if that assumption ever breaks (unlike herdr's
 # `foreground_cwd`), so this probe stays in place as the already-proven
 # mechanism rather than passive polling. Active probe instead: print the

--- a/bin/backends/cmux.sh
+++ b/bin/backends/cmux.sh
@@ -439,8 +439,9 @@ fm_backend_cmux_target_ready() {  # <target> [expected-label]
 # reflect a `cd` run directly in the surface's own top-level shell, but stays
 # FROZEN when an interactive subshell is held open in the foreground instead.
 # fm-spawn.sh's controller instead acquires the durable lease synchronously,
-# then sends only a plain top-level `cd <leased-path>`. cmux's control socket exposes no live-process cwd
-# field to fall back on if that assumption ever breaks (unlike herdr's
+# then sends only a plain top-level `cd <leased-path>`. cmux's control socket
+# exposes no live-process cwd field to fall back on if that assumption ever
+# breaks (unlike herdr's
 # `foreground_cwd`), so this probe stays in place as the already-proven
 # mechanism rather than passive polling. Active probe instead: print the
 # surface's `$PWD` with a unique marker (atomically submitted via

--- a/bin/backends/cmux.sh
+++ b/bin/backends/cmux.sh
@@ -437,14 +437,17 @@ fm_backend_cmux_target_ready() {  # <target> [expected-label]
 #
 # Verified pitfall (finding #2 above): cmux's `current_directory` field DOES
 # reflect a `cd` run directly in the surface's own top-level shell, but stays
-# FROZEN at whatever directory that shell was in when it launched `treehouse
-# get` as a foreground command - it never follows that command's own internal
-# `cd` into the acquired worktree. cmux's control socket exposes no
-# live-process cwd field either (unlike herdr's `foreground_cwd`), so passive
-# polling cannot solve this here any more than it could for zellij. Active
-# probe instead: print the surface's `$PWD` with a unique marker (atomically
-# submitted via send_text_line), briefly settle, then capture and read only
-# that marker line. Scoped to fm-spawn.sh's own worktree-discovery poll loop.
+# FROZEN when an interactive subshell is held open in the foreground instead.
+# The worktree-acquisition line fm-spawn.sh actually sends,
+# `cd "$(treehouse get --lease --lease-holder <id>)"`, avoids that: `--lease`
+# prints the path and exits without opening a subshell, so the `cd` itself is
+# a plain top-level command. cmux's control socket exposes no live-process cwd
+# field to fall back on if that assumption ever breaks (unlike herdr's
+# `foreground_cwd`), so this probe stays in place as the already-proven
+# mechanism rather than passive polling. Active probe instead: print the
+# surface's `$PWD` with a unique marker (atomically submitted via
+# send_text_line), briefly settle, then capture and read only that marker
+# line. Scoped to fm-spawn.sh's own worktree-discovery poll loop.
 fm_backend_cmux_current_path() {  # <target> [expected-label]
   local target=$1 expected_label=${2:-} out line marker_begin="__FM_CMUX_CWD_BEGIN__" marker_end="__FM_CMUX_CWD_END__" in_block=0 chunk="" last=""
   fm_backend_cmux_target_ready "$target" "$expected_label" || return 0

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2514,16 +2514,17 @@ fm_backend_herdr_target_ready() {  # <target>
 
 # fm_backend_herdr_current_path: the live FOREGROUND process's cwd, or empty on
 # any error. Mirrors tmux's pane_current_path poll used for worktree-path
-# discovery after `treehouse get`.
+# discovery after the controller acquires a Treehouse lease and sends `cd`.
 #
 # Verified pitfall: `pane get`'s `.result.pane.cwd` is the pane's cwd AT
 # CREATION TIME - the top-level shell's cwd - and does NOT update when that
-# shell `cd`s or enters a subshell (as `treehouse get` does). Reading it here
+# shell `cd`s or enters a subshell. Reading it here
 # would make fm-spawn.sh's worktree-discovery poll never see the pane "leave"
 # the project directory, since `cwd` stays frozen at the original path forever.
 # `.result.pane.foreground_cwd` tracks the ACTUALLY RUNNING foreground
-# process's cwd instead, which is what changes when `treehouse get` enters its
-# worktree subshell - confirmed live against a real treehouse acquisition.
+# process's cwd instead, which is what changes after the controller sends the
+# leased worktree's top-level `cd` - the distinction was confirmed live against
+# both a direct `cd` and a Treehouse-shaped foreground subshell.
 fm_backend_herdr_current_path() {  # <target>
   fm_backend_herdr_target_ready "$1" || return 0
   fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane get "$FM_BACKEND_HERDR_PANE" 2>/dev/null \
@@ -2532,8 +2533,8 @@ fm_backend_herdr_current_path() {  # <target>
 
 # fm_backend_herdr_send_text_line: send one line of TEXT then submit,
 # ATOMICALLY - mirrors tmux's `send-keys -t T text Enter`. Used for the fixed
-# spawn-time commands (treehouse get, the GOTMPDIR export). `pane run` types
-# the command and submits it in one call (verified).
+# spawn-time commands (the leased-worktree `cd`, the GOTMPDIR export).
+# `pane run` types the command and submits it in one call (verified).
 fm_backend_herdr_send_text_line() {  # <target> <text>
   fm_backend_herdr_target_ready "$1" || return 1
   fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane run "$FM_BACKEND_HERDR_PANE" "$2" >/dev/null 2>&1

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -8,10 +8,10 @@
 # default (tmux, `backend=` absent) path stays byte-identical. Sourced only
 # through bin/fm-backend.sh's fm_backend_source, never directly.
 #
-# Worktree acquisition (running `treehouse get` inside the pane, and polling
-# its cwd) is unchanged by this extraction: P1 scopes only the session
-# provider, not the worktree provider, so fm-spawn.sh still drives that part
-# inline with these same send/current-path primitives.
+# Worktree acquisition remains outside this session-provider adapter:
+# fm-spawn.sh synchronously acquires the durable Treehouse lease, sends the
+# leased-worktree `cd` into the pane, and polls its cwd through these same
+# send/current-path primitives.
 #
 # The verified composer/busy-detection and verify-and-retry-submit primitives
 # already live in bin/fm-tmux-lib.sh, shared with the away-mode daemon
@@ -105,7 +105,7 @@ fm_backend_tmux_current_path() {  # <target>
 
 # fm_backend_tmux_send_text_line: send one line of TEXT then Enter, with no
 # composer verification - used for the fixed spawn-time commands
-# (`treehouse get`, the GOTMPDIR export) that already ran this exact sequence
+# (the leased-worktree `cd`, the GOTMPDIR export) that run this exact sequence
 # inline in fm-spawn.sh. Mirrors `tmux send-keys -t "$T" "<text>" Enter`.
 fm_backend_tmux_send_text_line() {  # <target> <text>
   tmux send-keys -t "$1" "$2" Enter

--- a/bin/backends/zellij.sh
+++ b/bin/backends/zellij.sh
@@ -388,7 +388,7 @@ fm_backend_zellij_target_ready() {  # <target> [expected-label]
 
 # fm_backend_zellij_current_path: the live pane's cwd, or empty on any error.
 # Mirrors tmux's pane_current_path poll used for worktree-path discovery after
-# `treehouse get --lease`.
+# the controller acquires a lease and sends the leased-worktree `cd`.
 #
 # Verified pitfall (docs/zellij-backend.md "Worktree-path discovery: pane_cwd
 # does not track a subshell"): `list-panes --json`'s `pane_cwd` DOES reflect a
@@ -396,8 +396,8 @@ fm_backend_zellij_target_ready() {  # <target> [expected-label]
 # interactive subshell is held open in the foreground instead - verified
 # against a bare `treehouse get`, which opens exactly such a subshell. The
 # controller instead acquires the durable lease synchronously, then sends only
-# a plain top-level `cd <leased-path>`. Zellij's CLI exposes no per-pane pid and no
-# live-process cwd field to fall back on if that assumption ever breaks
+# a plain top-level `cd <leased-path>`. Zellij's CLI exposes no per-pane pid
+# and no live-process cwd field to fall back on if that assumption ever breaks
 # (unlike herdr's `foreground_cwd`), so this probe stays in place as the
 # already-proven mechanism rather than passive JSON polling. Active probe:
 # print the pane's `$PWD` with a unique marker (atomically submitted,

--- a/bin/backends/zellij.sh
+++ b/bin/backends/zellij.sh
@@ -395,10 +395,8 @@ fm_backend_zellij_target_ready() {  # <target> [expected-label]
 # `cd` run directly in the pane's own top-level shell, but stays FROZEN when an
 # interactive subshell is held open in the foreground instead - verified
 # against a bare `treehouse get`, which opens exactly such a subshell. The
-# worktree-acquisition line fm-spawn.sh actually sends,
-# `cd "$(treehouse get --lease --lease-holder <id>)"`, avoids that: `--lease`
-# prints the path and exits without opening a subshell, so the `cd` itself is
-# a plain top-level command. Zellij's CLI exposes no per-pane pid and no
+# controller instead acquires the durable lease synchronously, then sends only
+# a plain top-level `cd <leased-path>`. Zellij's CLI exposes no per-pane pid and no
 # live-process cwd field to fall back on if that assumption ever breaks
 # (unlike herdr's `foreground_cwd`), so this probe stays in place as the
 # already-proven mechanism rather than passive JSON polling. Active probe:

--- a/bin/backends/zellij.sh
+++ b/bin/backends/zellij.sh
@@ -388,23 +388,25 @@ fm_backend_zellij_target_ready() {  # <target> [expected-label]
 
 # fm_backend_zellij_current_path: the live pane's cwd, or empty on any error.
 # Mirrors tmux's pane_current_path poll used for worktree-path discovery after
-# `treehouse get`.
+# `treehouse get --lease`.
 #
 # Verified pitfall (docs/zellij-backend.md "Worktree-path discovery: pane_cwd
 # does not track a subshell"): `list-panes --json`'s `pane_cwd` DOES reflect a
-# `cd` run directly in the pane's own top-level shell, but stays FROZEN at
-# whatever directory the pane's shell was in when it launched `treehouse get`
-# as a foreground command - it never follows that command's own internal `cd`
-# into the acquired worktree, even after the subshell is fully interactive and
-# a `pwd` typed into it prints the correct live path on screen. Zellij's CLI
-# exposes no per-pane pid and no live-process cwd field to read instead
-# (unlike herdr's `foreground_cwd`), so passive JSON polling cannot solve
-# this. Active probe instead: print the pane's `$PWD` with a unique marker
-# (atomically submitted, mirroring send_text_line), briefly settle, then capture
-# and read only that marker line. Scoped to fm-spawn.sh's own worktree-discovery
-# poll loop (the only caller of this op), where injecting a harmless extra
-# command before the harness ever launches is an acceptable trade for a reliable
-# answer.
+# `cd` run directly in the pane's own top-level shell, but stays FROZEN when an
+# interactive subshell is held open in the foreground instead - verified
+# against a bare `treehouse get`, which opens exactly such a subshell. The
+# worktree-acquisition line fm-spawn.sh actually sends,
+# `cd "$(treehouse get --lease --lease-holder <id>)"`, avoids that: `--lease`
+# prints the path and exits without opening a subshell, so the `cd` itself is
+# a plain top-level command. Zellij's CLI exposes no per-pane pid and no
+# live-process cwd field to fall back on if that assumption ever breaks
+# (unlike herdr's `foreground_cwd`), so this probe stays in place as the
+# already-proven mechanism rather than passive JSON polling. Active probe:
+# print the pane's `$PWD` with a unique marker (atomically submitted,
+# mirroring send_text_line), briefly settle, then capture and read only that
+# marker line. Scoped to fm-spawn.sh's own worktree-discovery poll loop (the
+# only caller of this op), where injecting a harmless extra command before the
+# harness ever launches is an acceptable trade for a reliable answer.
 fm_backend_zellij_current_path() {  # <target> [expected-label]
   local target=$1 expected_label=${2:-} out line marker_begin="__FM_ZELLIJ_CWD_BEGIN__" marker_end="__FM_ZELLIJ_CWD_END__" in_block=0 chunk="" last=""
   fm_backend_zellij_target_ready "$target" "$expected_label" || return 0

--- a/bin/fm-install-treehouse.sh
+++ b/bin/fm-install-treehouse.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # fm-install-treehouse.sh - install CI's pinned, verified Treehouse build.
 #
-# Used only by the required real-Herdr CI lane for E2E scripts that genuinely
-# need treehouse (spawn worktree acquisition). Same pin/checksum discipline as
+# Used by the required real-Herdr CI lane for E2E scripts that genuinely need
+# treehouse (spawn worktree acquisition), and by the portable serial lane for
+# the lease lifecycle coverage. Same pin/checksum discipline as
 # fm-install-herdr.sh: official release URL, exact asset, SHA-256, bounded
 # download, post-install version check. Never a floating package-manager latest.
 #

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2180,9 +2180,10 @@ if [ "$RELAUNCH" -eq 1 ]; then
   [ "$KIND" = secondmate ] || validate_spawn_worktree "relaunch" "$T"
 elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   SPAWN_TREEHOUSE_ACQUIRE_ERR="$STATE/.$ID.treehouse-get.${BASHPID:-$$}.err"
-  if ! SPAWN_TREEHOUSE_LEASE_WT=$(cd "$PROJ_ABS" && treehouse get --lease --lease-holder "$ID" 2> "$SPAWN_TREEHOUSE_ACQUIRE_ERR") \
-     || [ -z "$SPAWN_TREEHOUSE_LEASE_WT" ]; then
-    SPAWN_TREEHOUSE_LEASE_WT=
+  treehouse_get_status=0
+  SPAWN_TREEHOUSE_LEASE_WT=$(cd "$PROJ_ABS" && treehouse get --lease --lease-holder "$ID" 2> "$SPAWN_TREEHOUSE_ACQUIRE_ERR") \
+    || treehouse_get_status=$?
+  if [ "$treehouse_get_status" -ne 0 ] || [ -z "$SPAWN_TREEHOUSE_LEASE_WT" ]; then
     cat "$SPAWN_TREEHOUSE_ACQUIRE_ERR" >&2
     rm -f -- "$SPAWN_TREEHOUSE_ACQUIRE_ERR"
     SPAWN_TREEHOUSE_ACQUIRE_ERR=

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -662,6 +662,7 @@ RELAUNCH_REPLACEMENT_WT=
 CONFIG_INHERIT_LOCK=
 CONFIG_INHERIT_LOCK_HELD=0
 SPAWN_TREEHOUSE_LEASE_WT=
+SPAWN_TREEHOUSE_LEASE_HANDOFF=
 
 parse_orca_worktree_result() {
   local raw=$1 rest
@@ -682,6 +683,7 @@ parse_orca_worktree_result() {
 
 spawn_abort_cleanup() {
   local status=$?
+  [ -z "$SPAWN_TREEHOUSE_LEASE_HANDOFF" ] || rm -f -- "$SPAWN_TREEHOUSE_LEASE_HANDOFF" 2>/dev/null || true
   if [ -n "$SPAWN_TREEHOUSE_LEASE_WT" ]; then
     if ! (cd "$PROJ_ABS" && treehouse return --force "$SPAWN_TREEHOUSE_LEASE_WT") >/dev/null 2>&1; then
       echo "warning: could not return treehouse lease after aborted spawn of $ID; inspect '$SPAWN_TREEHOUSE_LEASE_WT'" >&2
@@ -2177,7 +2179,10 @@ if [ "$RELAUNCH" -eq 1 ]; then
   fi
   [ "$KIND" = secondmate ] || validate_spawn_worktree "relaunch" "$T"
 elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
-  spawn_send_text_line "$WT_TARGET" "fm_treehouse_wt=\$(treehouse get --lease --lease-holder $ID) && [ -n \"\$fm_treehouse_wt\" ] && cd \"\$fm_treehouse_wt\""
+  SPAWN_TREEHOUSE_LEASE_HANDOFF="$STATE/.$ID.treehouse-lease.${BASHPID:-$$}"
+  rm -f -- "$SPAWN_TREEHOUSE_LEASE_HANDOFF"
+  sq_treehouse_lease_handoff=$(shell_quote "$SPAWN_TREEHOUSE_LEASE_HANDOFF")
+  spawn_send_text_line "$WT_TARGET" "fm_treehouse_wt=\$(treehouse get --lease --lease-holder $ID) && [ -n \"\$fm_treehouse_wt\" ] && printf '%s\\n' \"\$fm_treehouse_wt\" > $sq_treehouse_lease_handoff && cd \"\$fm_treehouse_wt\""
 
   # Wait for the durable treehouse lease and cd: the pane's cwd moves from the project to the worktree.
   # Target the stable window id, not the name: if the name is ever lost (e.g. an
@@ -2201,10 +2206,17 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # inter-poll sleep as confirmation, not a whole extra cycle on top.
   candidate=""
   for _ in $(seq 1 60); do
+    if [ -z "$SPAWN_TREEHOUSE_LEASE_WT" ] && [ -s "$SPAWN_TREEHOUSE_LEASE_HANDOFF" ]; then
+      IFS= read -r SPAWN_TREEHOUSE_LEASE_WT < "$SPAWN_TREEHOUSE_LEASE_HANDOFF" || true
+      rm -f -- "$SPAWN_TREEHOUSE_LEASE_HANDOFF"
+    fi
     p=$(spawn_current_path "$WT_TARGET" || true)
     if [ -n "$p" ]; then
       p_real=$(real_path_or_raw "$p")
-      if [ "$p_real" != "$PROJ_ABS_REAL" ]; then
+      lease_real=$(real_path_or_raw "$SPAWN_TREEHOUSE_LEASE_WT")
+      if [ -n "$SPAWN_TREEHOUSE_LEASE_WT" ] \
+         && [ "$p_real" = "$lease_real" ] \
+         && [ "$p_real" != "$PROJ_ABS_REAL" ]; then
         if [ -n "$candidate" ] && [ "$p_real" = "$candidate" ]; then
           WT="$p"
           break
@@ -2223,7 +2235,6 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
     exit 1
   fi
 
-  SPAWN_TREEHOUSE_LEASE_WT=$WT
   validate_spawn_worktree "treehouse get" "$T"
 fi
 if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -684,12 +684,6 @@ parse_orca_worktree_result() {
 spawn_abort_cleanup() {
   local status=$?
   [ -z "$SPAWN_TREEHOUSE_ACQUIRE_ERR" ] || rm -f -- "$SPAWN_TREEHOUSE_ACQUIRE_ERR" 2>/dev/null || true
-  if [ -n "$SPAWN_TREEHOUSE_LEASE_WT" ]; then
-    if ! (cd "$PROJ_ABS" && treehouse return --force "$SPAWN_TREEHOUSE_LEASE_WT") >/dev/null 2>&1; then
-      echo "warning: could not return treehouse lease after aborted spawn of $ID; inspect '$SPAWN_TREEHOUSE_LEASE_WT'" >&2
-    fi
-    SPAWN_TREEHOUSE_LEASE_WT=
-  fi
   if [ "$RELAUNCH_REPLACEMENT_PENDING" = 1 ] \
      && [ "$SPAWN_META_PUBLISH_STARTED" = 1 ] \
      && [ -n "$SPAWN_META_TMP" ] \
@@ -731,6 +725,18 @@ spawn_abort_cleanup() {
   if [ "$HERDR_PRESENTATION_ORDER_LOCK_HELD" = 1 ]; then
     HERDR_PRESENTATION_ORDER_LOCK_HELD=0
     fm_lock_release "$HERDR_PRESENTATION_ORDER_LOCK" || true
+  fi
+  # Return the lease only after the projected-pane cleanup above has finished and
+  # released the presentation order lock. That cleanup must close this spawn's own
+  # pane while the lock is still held, so concurrent aborts stay serialized as
+  # create/close pairs. `treehouse return` resets the worktree under Treehouse's
+  # own pool lock, so a wide fan-out serializes there; no Herdr state depends on
+  # the rollback, so it belongs outside the focus-sensitive critical section.
+  if [ -n "$SPAWN_TREEHOUSE_LEASE_WT" ]; then
+    if ! (cd "$PROJ_ABS" && treehouse return --force "$SPAWN_TREEHOUSE_LEASE_WT") >/dev/null 2>&1; then
+      echo "warning: could not return treehouse lease after aborted spawn of $ID; inspect '$SPAWN_TREEHOUSE_LEASE_WT'" >&2
+    fi
+    SPAWN_TREEHOUSE_LEASE_WT=
   fi
   if [ "$ORCA_ABORT_CLEANUP" = 1 ]; then
     ORCA_ABORT_CLEANUP=0

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -48,8 +48,8 @@
 #   then tmux.
 #   Spawn-capable backends are the reference tmux adapter and experimental
 #   herdr, zellij, orca, and cmux. Orca owns both the task worktree and
-#   terminal, so ship/scout Orca spawns do not run treehouse get; cmux is a
-#   session provider only, exactly like herdr/zellij, so it does. An
+#   terminal, so ship/scout Orca spawns do not acquire a Treehouse lease; cmux
+#   is a session provider only, exactly like herdr/zellij, so it does. An
 #   auto-detected herdr or cmux spawn prints a loud stderr notice;
 #   auto-detected tmux stays silent; zellij and orca are never auto-detected.
 #   codex-app is not a known backend yet; docs/codex-app-backend.md owns that
@@ -2207,7 +2207,7 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # A single read that already differs from PROJ_ABS_REAL is not proof the pane
   # settled there: on some tmux/WSL setups a brand-new window's pane_current_path
   # transiently reports an unrelated stale path (seen live as another real git
-  # checkout entirely) before the shell catches up with treehouse get's cd. That
+  # checkout entirely) before the shell catches up with the controller's cd. That
   # stale path still passes the PROJ_ABS_REAL comparison and validate_spawn_worktree
   # below (it resolves to a real, distinct worktree top-level too), so accepting it
   # on one read alone silently records the wrong worktree= in state/<id>.meta. Require

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -661,6 +661,7 @@ RELAUNCH_REPLACEMENT_STATE=
 RELAUNCH_REPLACEMENT_WT=
 CONFIG_INHERIT_LOCK=
 CONFIG_INHERIT_LOCK_HELD=0
+SPAWN_TREEHOUSE_LEASE_WT=
 
 parse_orca_worktree_result() {
   local raw=$1 rest
@@ -681,6 +682,12 @@ parse_orca_worktree_result() {
 
 spawn_abort_cleanup() {
   local status=$?
+  if [ -n "$SPAWN_TREEHOUSE_LEASE_WT" ]; then
+    if ! (cd "$PROJ_ABS" && treehouse return --force "$SPAWN_TREEHOUSE_LEASE_WT") >/dev/null 2>&1; then
+      echo "warning: could not return treehouse lease after aborted spawn of $ID; inspect '$SPAWN_TREEHOUSE_LEASE_WT'" >&2
+    fi
+    SPAWN_TREEHOUSE_LEASE_WT=
+  fi
   if [ "$RELAUNCH_REPLACEMENT_PENDING" = 1 ] \
      && [ "$SPAWN_META_PUBLISH_STARTED" = 1 ] \
      && [ -n "$SPAWN_META_TMP" ] \
@@ -2170,7 +2177,7 @@ if [ "$RELAUNCH" -eq 1 ]; then
   fi
   [ "$KIND" = secondmate ] || validate_spawn_worktree "relaunch" "$T"
 elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
-  spawn_send_text_line "$WT_TARGET" "cd \"\$(treehouse get --lease --lease-holder $ID)\""
+  spawn_send_text_line "$WT_TARGET" "fm_treehouse_wt=\$(treehouse get --lease --lease-holder $ID) && [ -n \"\$fm_treehouse_wt\" ] && cd \"\$fm_treehouse_wt\""
 
   # Wait for the durable treehouse lease and cd: the pane's cwd moves from the project to the worktree.
   # Target the stable window id, not the name: if the name is ever lost (e.g. an
@@ -2216,6 +2223,7 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
     exit 1
   fi
 
+  SPAWN_TREEHOUSE_LEASE_WT=$WT
   validate_spawn_worktree "treehouse get" "$T"
 fi
 if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
@@ -2622,6 +2630,7 @@ preserve_relaunch_meta() {
     echo "control_relaunch_tx=$FM_CONTROL_RELAUNCH_TX"
   fi
 } > "$SPAWN_META_PATH"
+SPAWN_TREEHOUSE_LEASE_WT=
 if [ "$RELAUNCH" -eq 1 ]; then
   SPAWN_META_PUBLISH_STARTED=1
   mv -f "$SPAWN_META_TMP" "$STATE/$ID.meta"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -662,6 +662,7 @@ RELAUNCH_REPLACEMENT_WT=
 CONFIG_INHERIT_LOCK=
 CONFIG_INHERIT_LOCK_HELD=0
 SPAWN_TREEHOUSE_LEASE_WT=
+SPAWN_TREEHOUSE_ACQUIRE_ERR=
 
 parse_orca_worktree_result() {
   local raw=$1 rest
@@ -682,6 +683,7 @@ parse_orca_worktree_result() {
 
 spawn_abort_cleanup() {
   local status=$?
+  [ -z "$SPAWN_TREEHOUSE_ACQUIRE_ERR" ] || rm -f -- "$SPAWN_TREEHOUSE_ACQUIRE_ERR" 2>/dev/null || true
   if [ -n "$SPAWN_TREEHOUSE_LEASE_WT" ]; then
     if ! (cd "$PROJ_ABS" && treehouse return --force "$SPAWN_TREEHOUSE_LEASE_WT") >/dev/null 2>&1; then
       echo "warning: could not return treehouse lease after aborted spawn of $ID; inspect '$SPAWN_TREEHOUSE_LEASE_WT'" >&2
@@ -2177,12 +2179,18 @@ if [ "$RELAUNCH" -eq 1 ]; then
   fi
   [ "$KIND" = secondmate ] || validate_spawn_worktree "relaunch" "$T"
 elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
-  if ! SPAWN_TREEHOUSE_LEASE_WT=$(cd "$PROJ_ABS" && treehouse get --lease --lease-holder "$ID" 2>/dev/null) \
+  SPAWN_TREEHOUSE_ACQUIRE_ERR="$STATE/.$ID.treehouse-get.${BASHPID:-$$}.err"
+  if ! SPAWN_TREEHOUSE_LEASE_WT=$(cd "$PROJ_ABS" && treehouse get --lease --lease-holder "$ID" 2> "$SPAWN_TREEHOUSE_ACQUIRE_ERR") \
      || [ -z "$SPAWN_TREEHOUSE_LEASE_WT" ]; then
     SPAWN_TREEHOUSE_LEASE_WT=
+    cat "$SPAWN_TREEHOUSE_ACQUIRE_ERR" >&2
+    rm -f -- "$SPAWN_TREEHOUSE_ACQUIRE_ERR"
+    SPAWN_TREEHOUSE_ACQUIRE_ERR=
     echo "error: treehouse get did not enter a worktree within 60s; inspect window $T" >&2
     exit 1
   fi
+  rm -f -- "$SPAWN_TREEHOUSE_ACQUIRE_ERR"
+  SPAWN_TREEHOUSE_ACQUIRE_ERR=
   sq_treehouse_lease_wt=$(shell_quote "$SPAWN_TREEHOUSE_LEASE_WT")
   spawn_send_text_line "$WT_TARGET" "cd $sq_treehouse_lease_wt"
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -662,7 +662,6 @@ RELAUNCH_REPLACEMENT_WT=
 CONFIG_INHERIT_LOCK=
 CONFIG_INHERIT_LOCK_HELD=0
 SPAWN_TREEHOUSE_LEASE_WT=
-SPAWN_TREEHOUSE_LEASE_HANDOFF=
 
 parse_orca_worktree_result() {
   local raw=$1 rest
@@ -683,7 +682,6 @@ parse_orca_worktree_result() {
 
 spawn_abort_cleanup() {
   local status=$?
-  [ -z "$SPAWN_TREEHOUSE_LEASE_HANDOFF" ] || rm -f -- "$SPAWN_TREEHOUSE_LEASE_HANDOFF" 2>/dev/null || true
   if [ -n "$SPAWN_TREEHOUSE_LEASE_WT" ]; then
     if ! (cd "$PROJ_ABS" && treehouse return --force "$SPAWN_TREEHOUSE_LEASE_WT") >/dev/null 2>&1; then
       echo "warning: could not return treehouse lease after aborted spawn of $ID; inspect '$SPAWN_TREEHOUSE_LEASE_WT'" >&2
@@ -2179,10 +2177,14 @@ if [ "$RELAUNCH" -eq 1 ]; then
   fi
   [ "$KIND" = secondmate ] || validate_spawn_worktree "relaunch" "$T"
 elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
-  SPAWN_TREEHOUSE_LEASE_HANDOFF="$STATE/.$ID.treehouse-lease.${BASHPID:-$$}"
-  rm -f -- "$SPAWN_TREEHOUSE_LEASE_HANDOFF"
-  sq_treehouse_lease_handoff=$(shell_quote "$SPAWN_TREEHOUSE_LEASE_HANDOFF")
-  spawn_send_text_line "$WT_TARGET" "fm_treehouse_wt=\$(treehouse get --lease --lease-holder $ID) && [ -n \"\$fm_treehouse_wt\" ] && printf '%s\\n' \"\$fm_treehouse_wt\" > $sq_treehouse_lease_handoff && cd \"\$fm_treehouse_wt\""
+  if ! SPAWN_TREEHOUSE_LEASE_WT=$(cd "$PROJ_ABS" && treehouse get --lease --lease-holder "$ID" 2>/dev/null) \
+     || [ -z "$SPAWN_TREEHOUSE_LEASE_WT" ]; then
+    SPAWN_TREEHOUSE_LEASE_WT=
+    echo "error: treehouse get did not enter a worktree within 60s; inspect window $T" >&2
+    exit 1
+  fi
+  sq_treehouse_lease_wt=$(shell_quote "$SPAWN_TREEHOUSE_LEASE_WT")
+  spawn_send_text_line "$WT_TARGET" "cd $sq_treehouse_lease_wt"
 
   # Wait for the durable treehouse lease and cd: the pane's cwd moves from the project to the worktree.
   # Target the stable window id, not the name: if the name is ever lost (e.g. an
@@ -2205,17 +2207,12 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # pane that is already settled by the first real read only costs the one existing
   # inter-poll sleep as confirmation, not a whole extra cycle on top.
   candidate=""
+  lease_real=$(real_path_or_raw "$SPAWN_TREEHOUSE_LEASE_WT")
   for _ in $(seq 1 60); do
-    if [ -z "$SPAWN_TREEHOUSE_LEASE_WT" ] && [ -s "$SPAWN_TREEHOUSE_LEASE_HANDOFF" ]; then
-      IFS= read -r SPAWN_TREEHOUSE_LEASE_WT < "$SPAWN_TREEHOUSE_LEASE_HANDOFF" || true
-      rm -f -- "$SPAWN_TREEHOUSE_LEASE_HANDOFF"
-    fi
     p=$(spawn_current_path "$WT_TARGET" || true)
     if [ -n "$p" ]; then
       p_real=$(real_path_or_raw "$p")
-      lease_real=$(real_path_or_raw "$SPAWN_TREEHOUSE_LEASE_WT")
-      if [ -n "$SPAWN_TREEHOUSE_LEASE_WT" ] \
-         && [ "$p_real" = "$lease_real" ] \
+      if [ "$p_real" = "$lease_real" ] \
          && [ "$p_real" != "$PROJ_ABS_REAL" ]; then
         if [ -n "$candidate" ] && [ "$p_real" = "$candidate" ]; then
           WT="$p"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2187,7 +2187,7 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
     cat "$SPAWN_TREEHOUSE_ACQUIRE_ERR" >&2
     rm -f -- "$SPAWN_TREEHOUSE_ACQUIRE_ERR"
     SPAWN_TREEHOUSE_ACQUIRE_ERR=
-    echo "error: treehouse get did not enter a worktree within 60s; inspect window $T" >&2
+    echo "error: treehouse get failed to acquire a worktree lease for task $ID" >&2
     exit 1
   fi
   rm -f -- "$SPAWN_TREEHOUSE_ACQUIRE_ERR"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2646,7 +2646,10 @@ preserve_relaunch_meta() {
   if [ "$SPAWN_CONTROL_PARENT" = 1 ] && [ -n "${FM_CONTROL_RELAUNCH_TX:-}" ]; then
     echo "control_relaunch_tx=$FM_CONTROL_RELAUNCH_TX"
   fi
-} > "$SPAWN_META_PATH"
+} > "$SPAWN_META_PATH" || {
+  echo "error: could not publish spawn metadata for task $ID" >&2
+  exit 1
+}
 SPAWN_TREEHOUSE_LEASE_WT=
 if [ "$RELAUNCH" -eq 1 ]; then
   SPAWN_META_PUBLISH_STARTED=1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2170,9 +2170,9 @@ if [ "$RELAUNCH" -eq 1 ]; then
   fi
   [ "$KIND" = secondmate ] || validate_spawn_worktree "relaunch" "$T"
 elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
-  spawn_send_text_line "$WT_TARGET" 'treehouse get'
+  spawn_send_text_line "$WT_TARGET" "cd \"\$(treehouse get --lease --lease-holder $ID)\""
 
-  # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
+  # Wait for the durable treehouse lease and cd: the pane's cwd moves from the project to the worktree.
   # Target the stable window id, not the name: if the name is ever lost (e.g. an
   # automatic-rename slips through), display-message -t <bad-name> falls back to the
   # active client's window, which would misread firstmate's OWN pane path as the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,7 +148,8 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 ## Worktrees, not branches in your checkout
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
-`fm-spawn.sh` acquires each pooled worktree with `treehouse get --lease --lease-holder <task-id>`, durably leasing the slot to the task rather than relying on pid liveness, so a stopped-but-preserved or concurrently-live worker's worktree is never recycled; only `fm-teardown.sh`'s `treehouse return` frees it.
+`fm-spawn.sh` acquires each pooled worktree with `treehouse get --lease --lease-holder <task-id>`, durably leasing the slot to the task rather than relying on pid liveness, so a stopped-but-preserved or concurrently-live worker's worktree is never recycled.
+After spawn publishes the task metadata, only `fm-teardown.sh`'s `treehouse return` frees the slot; an aborted spawn returns its unpublished lease during cleanup.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
 `fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
 Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,6 +148,7 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 ## Worktrees, not branches in your checkout
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
+`fm-spawn.sh` acquires each pooled worktree with `treehouse get --lease --lease-holder <task-id>`, durably leasing the slot to the task rather than relying on pid liveness, so a stopped-but-preserved or concurrently-live worker's worktree is never recycled; only `fm-teardown.sh`'s `treehouse return` frees it.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
 `fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
 Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.

--- a/docs/cmux-backend.md
+++ b/docs/cmux-backend.md
@@ -87,7 +87,8 @@ A genuinely fresh surface returns an internal error from `read-screen` until som
 Target readiness therefore uses the structural `list-panes` response instead of a content read.
 Capture remains bounded and locally trimmed after `read-screen` becomes available.
 
-`current_directory` follows a top-level shell `cd` but not the foreground subshell opened by `treehouse get`.
+`current_directory` follows a top-level shell `cd` but not an interactive subshell held open in the foreground, verified live against a nested `bash -c 'cd ... && exec bash'`.
+`fm-spawn.sh`'s worktree acquisition instead runs `cd "$(treehouse get --lease --lease-holder <task-id>)"`: `--lease` prints the path and exits without opening a subshell, so the `cd` itself is the plain top-level command this rule already tracks; the marker probe stays in place regardless, as the already-proven mechanism.
 Spawn-time worktree discovery sends begin and end markers around `pwd`, captures the marked block, and joins wrapped path lines.
 
 Literal send and Enter are separate calls.

--- a/docs/cmux-backend.md
+++ b/docs/cmux-backend.md
@@ -88,7 +88,7 @@ Target readiness therefore uses the structural `list-panes` response instead of 
 Capture remains bounded and locally trimmed after `read-screen` becomes available.
 
 `current_directory` follows a top-level shell `cd` but not an interactive subshell held open in the foreground, verified live against a nested `bash -c 'cd ... && exec bash'`.
-`fm-spawn.sh`'s worktree acquisition instead runs `cd "$(treehouse get --lease --lease-holder <task-id>)"`: `--lease` prints the path and exits without opening a subshell, so the `cd` itself is the plain top-level command this rule already tracks; the marker probe stays in place regardless, as the already-proven mechanism.
+`fm-spawn.sh` instead acquires the durable lease synchronously in its controller and sends only a plain top-level `cd <leased-path>` to the surface; the marker probe stays in place regardless, as the already-proven mechanism.
 Spawn-time worktree discovery sends begin and end markers around `pwd`, captures the marked block, and joins wrapped path lines.
 
 Literal send and Enter are separate calls.

--- a/docs/zellij-backend.md
+++ b/docs/zellij-backend.md
@@ -67,7 +67,7 @@ A pane can still disappear between verification and the operation; downstream su
 Every pane operation passes an explicit `--pane-id` because a new session can focus its release-notes plugin pane, whose numeric plugin id is in a separate namespace from terminal pane ids.
 
 `pane_cwd` follows a top-level shell `cd` but not an interactive subshell held open in the foreground, verified against a bare `treehouse get`, which opens exactly such a subshell.
-`fm-spawn.sh`'s worktree acquisition instead runs `cd "$(treehouse get --lease --lease-holder <task-id>)"`: `--lease` prints the path and exits without opening a subshell, so the `cd` itself is the plain top-level command this rule already tracks; the marker probe stays in place regardless, as the already-proven mechanism.
+`fm-spawn.sh` instead acquires the durable lease synchronously in its controller and sends only a plain top-level `cd <leased-path>` to the pane; the marker probe stays in place regardless, as the already-proven mechanism.
 Worktree discovery therefore sends begin and end markers around `pwd`, captures the marked block, and joins wrapped path lines.
 This active probe is scoped to spawn-time worktree discovery and is not advertised as a general live-cwd API.
 

--- a/docs/zellij-backend.md
+++ b/docs/zellij-backend.md
@@ -66,7 +66,8 @@ A pane can still disappear between verification and the operation; downstream su
 
 Every pane operation passes an explicit `--pane-id` because a new session can focus its release-notes plugin pane, whose numeric plugin id is in a separate namespace from terminal pane ids.
 
-`pane_cwd` follows a top-level shell `cd` but not the foreground subshell opened by `treehouse get`.
+`pane_cwd` follows a top-level shell `cd` but not an interactive subshell held open in the foreground, verified against a bare `treehouse get`, which opens exactly such a subshell.
+`fm-spawn.sh`'s worktree acquisition instead runs `cd "$(treehouse get --lease --lease-holder <task-id>)"`: `--lease` prints the path and exits without opening a subshell, so the `cd` itself is the plain top-level command this rule already tracks; the marker probe stays in place regardless, as the already-proven mechanism.
 Worktree discovery therefore sends begin and end markers around `pwd`, captures the marked block, and joins wrapped path lines.
 This active probe is scoped to spawn-time worktree discovery and is not advertised as a general live-cwd API.
 

--- a/tests/fm-backend-cmux.test.sh
+++ b/tests/fm-backend-cmux.test.sh
@@ -684,7 +684,7 @@ test_current_path_probes_with_marker() {
   local dir fb out
   # Verified real-cmux pitfall (docs/cmux-backend.md finding #2): the surface's
   # cwd is frozen at creation time (the top-level shell's cwd), never following
-  # a foreground subshell (e.g. treehouse get) - so current_path actively
+  # a foreground subshell - so current_path actively
   # prints a marked cwd line and reads only that marker from the capture.
   dir="$TMP_ROOT/cwd"; mkdir -p "$dir/responses"
   # 1: list-panes (current_path's own target_ready)

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -208,6 +208,7 @@ set -u
   printf '\n'
 } >> "$TREEHOUSE_CALL_LOG"
 if [ -d "$POST_CREATE_ABORT_CONTROL" ] && [ "${1:-}" = get ]; then
+  printf '%s\n' "$POST_CREATE_ABORT_CONTROL/not-a-worktree"
   exit 0
 fi
 exec "$REAL_TREEHOUSE" "$@"
@@ -822,6 +823,7 @@ assert_no_ordering_lifecycle_calls_since "$FAIL_START" "failed presentation orde
 pass "real Herdr lab: forced workspace.move failure leaves a successful worker in default order with a warning and no cleanup"
 
 mkdir -p "$POST_CREATE_ABORT_CONTROL"
+mkdir -p "$POST_CREATE_ABORT_CONTROL/not-a-worktree"
 ABORT_START=$(log_line_count)
 ABORT_FOCUS_START=$(focus_audit_line_count)
 spawn_task abort-a "$HOME_DIR" "$PROJECT_DIR" > "$TMP_ROOT/abort-a.out" 2> "$TMP_ROOT/abort-a.err" &

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -2929,7 +2929,8 @@ test_current_path_reads_cwd() {
   dir="$TMP_ROOT/cwd"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   # Verified pitfall (herdr-verification-p2.md): .result.pane.cwd is frozen at
   # pane-creation time and never updates; .foreground_cwd tracks the live
-  # running process (e.g. a treehouse get subshell) and is what must be read.
+  # running process (including a direct leased-worktree cd) and is what must be
+  # read.
   printf '{"result":{"pane":{"cwd":"/tmp/pane-creation-dir","foreground_cwd":"/tmp/fake-worktree"}}}\n' > "$resp/1.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \

--- a/tests/fm-backend-zellij.test.sh
+++ b/tests/fm-backend-zellij.test.sh
@@ -697,7 +697,7 @@ test_current_path_probes_with_marker_and_ignores_prompt_paths() {
   local dir fb out
   # Verified real-zellij pitfall (docs/zellij-backend.md "Worktree-path
   # discovery: pane_cwd does not track a subshell"): pane_cwd never updates
-  # once a subshell (e.g. treehouse get) takes over, so current_path actively
+  # once a subshell takes over, so current_path actively
   # prints a marked cwd line and reads only that marker from the capture,
   # rather than reading a JSON field.
   dir="$TMP_ROOT/cwd"; mkdir -p "$dir/responses"

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -785,7 +785,14 @@ esac
 exit 0
 SH
   chmod +x "$fb/tmux"
-  fm_fake_exit0 "$fb" treehouse
+  cat > "$fb/treehouse" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = get ]; then
+  printf '%s\n' "$wt"
+fi
+exit 0
+SH
+  chmod +x "$fb/treehouse"
   printf '%s\n' "$fb"
 }
 
@@ -855,7 +862,14 @@ esac
 exit 0
 SH
   chmod +x "$fb/tmux"
-  fm_fake_exit0 "$fb" treehouse
+  cat > "$fb/treehouse" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = get ]; then
+  printf '%s\n' "$wt"
+fi
+exit 0
+SH
+  chmod +x "$fb/treehouse"
   printf '%s\n' "$fb"
 }
 

--- a/tests/fm-busy-adapter-wiring.test.sh
+++ b/tests/fm-busy-adapter-wiring.test.sh
@@ -35,7 +35,8 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse pi opencode claude codex
+  fm_fake_treehouse_get_path "$fakebin"
+  fm_fake_exit0 "$fakebin" pi opencode claude codex
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-gate-refuse.test.sh
+++ b/tests/fm-gate-refuse.test.sh
@@ -152,7 +152,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  fm_fake_treehouse_get_path "$fakebin"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-grok-harness.test.sh
+++ b/tests/fm-grok-harness.test.sh
@@ -26,7 +26,8 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
+  fm_fake_treehouse_get_path "$fakebin"
+  fm_fake_exit0 "$fakebin" gh-axi gh
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -125,7 +125,8 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
+  fm_fake_treehouse_get_path "$fakebin"
+  fm_fake_exit0 "$fakebin" gh-axi gh
   fm_fake_exit0 "$fakebin" kimi
   ln -s "$JQ_BIN" "$fakebin/jq"
   printf '%s\n' "$fakebin"

--- a/tests/fm-muse-harness.test.sh
+++ b/tests/fm-muse-harness.test.sh
@@ -105,7 +105,8 @@ set -u
 exec "$FM_FAKE_MUSE_VERSIONED" -c 'result=$($FM_FAKE_HARNESS_PROBE); printf "%s" "$result" > "$FM_FAKE_HARNESS_RESULT"'
 SH
   chmod +x "$fakebin/muse"
-  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
+  fm_fake_treehouse_get_path "$fakebin"
+  fm_fake_exit0 "$fakebin" gh-axi gh
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -604,6 +604,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
+  fm_fake_treehouse_get_path "$fakebin"
   fm_fake_exit0 "$fakebin" pi
   printf '%s\n' "$fakebin"
 }
@@ -1025,6 +1026,8 @@ SH
 #!/usr/bin/env bash
 if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
   printf '%s\n' 'Usage: treehouse get [--lease]'
+elif [ "${1:-}" = get ]; then
+  printf '%s\n' "${FM_FAKE_PANE_PATH:-}"
 fi
 exit 0
 SH

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -59,7 +59,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  fm_fake_treehouse_get_path "$fakebin"
   make_spawn_pi_probe "$fakebin" pi
   make_spawn_pi_probe "$fakebin" pi-signed
   printf '%s\n' "$fakebin"

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -30,7 +30,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  fm_fake_treehouse_get_path "$fakebin"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -54,7 +54,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  fm_fake_treehouse_get_path "$fakebin"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# Regression test for the fm-spawn.sh treehouse-get worktree-detection settle
-# loop (bin/fm-spawn.sh, the `for _ in $(seq 1 60)` loop after `treehouse get`).
+# Regression test for the fm-spawn.sh leased-worktree detection settle loop
+# (bin/fm-spawn.sh, the `for _ in $(seq 1 60)` loop after the controller's `cd`).
 #
 # On some tmux/WSL setups a brand-new window's pane_current_path transiently
 # reports a stale, unrelated-but-real path on the very first poll, before the
-# pane actually settles into the worktree treehouse get moved it to. That stale
+# pane actually settles into the worktree selected by the lease. That stale
 # path still passes the loop's "differs from the project" check and
 # validate_spawn_worktree's "is a real, distinct worktree" check (it IS a real
 # git checkout, just the wrong one), so a naive single-read loop silently

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -312,17 +312,8 @@ make_lease_lifecycle_fakebin() {
   cat > "$fakebin/treehouse" <<'SH'
 #!/usr/bin/env bash
 set -u
-case "${1:-}" in
-  get)
-    [ ! -e "$FM_FAKE_LEASE" ] || exit 1
-    printf '%s\n' "${4:-unknown}" > "$FM_FAKE_LEASE"
-    printf '%s\n' "$FM_FAKE_POOL_WT"
-    ;;
-  return)
-    [ "${3:-}" = "$FM_FAKE_POOL_WT" ] || exit 1
-    rm -f "$FM_FAKE_LEASE"
-    ;;
-esac
+cd "$FM_REAL_TREEHOUSE_PROJECT"
+exec env HOME="$FM_REAL_TREEHOUSE_HOME" "$FM_REAL_TREEHOUSE" "$@"
 SH
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
@@ -352,13 +343,10 @@ SH
 }
 
 test_treehouse_lease_lifecycle() {
-  local home proj wt fakebin lease pane out status id
+  local home proj wt stopped_wt live_wt contender_wt successor_wt fakebin pane out status id live_pid
   home="$TMP_ROOT/lease-home"
   proj=$(make_repo "$TMP_ROOT/lease-proj")
-  wt="$TMP_ROOT/lease-wt"
-  git -C "$proj" worktree add -q --detach "$wt" >/dev/null 2>&1
   fakebin=$(make_lease_lifecycle_fakebin "$TMP_ROOT/lease-fake")
-  lease="$TMP_ROOT/lease-held"
   pane="$TMP_ROOT/lease-pane"
   id=lease-life-hh8
   mkdir -p "$home/data/$id"
@@ -368,27 +356,45 @@ test_treehouse_lease_lifecycle() {
   out=$(FM_ROOT_OVERRIDE='' FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
     FM_DATA_OVERRIDE="$home/data" FM_PROJECTS_OVERRIDE="$home/projects" \
     FM_CONFIG_OVERRIDE="$home/config" FM_SPAWN_NO_GUARD=1 TMUX=fake \
-    FM_FAKE_LEASE="$lease" FM_FAKE_POOL_WT="$wt" FM_FAKE_PANE_STATE="$pane" \
+    FM_REAL_TREEHOUSE="$(command -v treehouse)" FM_REAL_TREEHOUSE_HOME="$TMP_ROOT/treehouse-home" \
+    FM_REAL_TREEHOUSE_PROJECT="$proj" FM_FAKE_PANE_STATE="$pane" \
     PATH="$fakebin:$PATH" "$ROOT/bin/fm-spawn.sh" "$id" "$proj" codex \
     --mode no-mistakes --yolo off 2>&1); status=$?
   expect_code 0 "$status" "durably leased spawn should succeed: $out"
-  assert_present "$lease" "spawn did not retain the durable lease"
+  stopped_wt=$(sed -n 's/^worktree=//p' "$home/state/$id.meta")
+  [ -d "$stopped_wt" ] || fail "spawn did not retain a real Treehouse worktree"
 
-  if FM_FAKE_LEASE="$lease" FM_FAKE_POOL_WT="$wt" "$fakebin/treehouse" get --lease --lease-holder contender >/dev/null 2>&1; then
-    fail "a concurrently-live worker reacquired the leased pool slot"
-  fi
+  live_wt=$(FM_REAL_TREEHOUSE="$(command -v treehouse)" FM_REAL_TREEHOUSE_HOME="$TMP_ROOT/treehouse-home" \
+    FM_REAL_TREEHOUSE_PROJECT="$proj" "$fakebin/treehouse" get --lease --lease-holder live-worker) \
+    || fail "real Treehouse could not acquire a concurrent lease"
+  [ "$live_wt" != "$stopped_wt" ] || fail "real Treehouse recycled the stopped-but-preserved lease"
+  (cd "$live_wt" && sleep 60) &
+  live_pid=$!
+  contender_wt=$(FM_REAL_TREEHOUSE="$(command -v treehouse)" FM_REAL_TREEHOUSE_HOME="$TMP_ROOT/treehouse-home" \
+    FM_REAL_TREEHOUSE_PROJECT="$proj" "$fakebin/treehouse" get --lease --lease-holder contender) \
+    || fail "real Treehouse could not acquire a contender lease"
+  [ "$contender_wt" != "$stopped_wt" ] && [ "$contender_wt" != "$live_wt" ] \
+    || fail "real Treehouse double-booked a durable lease"
 
   out=$(FM_ROOT_OVERRIDE='' FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
     FM_DATA_OVERRIDE="$home/data" FM_CONFIG_OVERRIDE="$home/config" \
-    FM_FAKE_LEASE="$lease" FM_FAKE_POOL_WT="$wt" FM_FAKE_PANE_STATE="$pane" \
+    FM_REAL_TREEHOUSE="$(command -v treehouse)" FM_REAL_TREEHOUSE_HOME="$TMP_ROOT/treehouse-home" \
+    FM_REAL_TREEHOUSE_PROJECT="$proj" FM_FAKE_PANE_STATE="$pane" \
     PATH="$fakebin:$PATH" "$ROOT/bin/fm-teardown.sh" "$id" --force 2>&1); status=$?
   expect_code 0 "$status" "teardown should release the durable lease: $out"
-  assert_absent "$lease" "teardown left the durable lease held"
-  FM_FAKE_LEASE="$lease" FM_FAKE_POOL_WT="$wt" "$fakebin/treehouse" get --lease --lease-holder successor >/dev/null \
-    || fail "the pool slot was not reusable after teardown"
-  FM_FAKE_LEASE="$lease" FM_FAKE_POOL_WT="$wt" "$fakebin/treehouse" return --force "$wt"
+  successor_wt=$(FM_REAL_TREEHOUSE="$(command -v treehouse)" FM_REAL_TREEHOUSE_HOME="$TMP_ROOT/treehouse-home" \
+    FM_REAL_TREEHOUSE_PROJECT="$proj" "$fakebin/treehouse" get --lease --lease-holder successor) \
+    || fail "real Treehouse could not reuse the released slot"
+  [ "$successor_wt" = "$stopped_wt" ] || fail "teardown did not make its released slot reusable"
 
-  pass "fm-spawn/fm-teardown: durable leases prevent reuse until teardown"
+  kill "$live_pid" 2>/dev/null || true
+  wait "$live_pid" 2>/dev/null || true
+  for wt in "$live_wt" "$contender_wt" "$successor_wt"; do
+    FM_REAL_TREEHOUSE="$(command -v treehouse)" FM_REAL_TREEHOUSE_HOME="$TMP_ROOT/treehouse-home" \
+      FM_REAL_TREEHOUSE_PROJECT="$proj" "$fakebin/treehouse" return --force "$wt" >/dev/null
+  done
+
+  pass "fm-spawn/fm-teardown: real durable leases remain distinct until teardown"
 }
 
 test_lib_classification

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -338,6 +338,10 @@ make_lease_lifecycle_fakebin() {
   cat > "$fakebin/treehouse" <<'SH'
 #!/usr/bin/env bash
 set -u
+if [ "${FM_FAKE_TREEHOUSE_ERROR:-0}" = 1 ]; then
+  echo "treehouse fixture acquisition failed" >&2
+  exit 1
+fi
 cd "$FM_REAL_TREEHOUSE_PROJECT"
 exec env HOME="$FM_REAL_TREEHOUSE_HOME" "$FM_REAL_TREEHOUSE" "$@"
 SH
@@ -374,7 +378,7 @@ SH
 }
 
 test_treehouse_lease_lifecycle() {
-  local home proj wt stopped_wt live_wt contender_wt successor_wt fakebin pane out status id abort_id live_pid
+  local home proj wt stopped_wt live_wt contender_wt successor_wt fakebin pane out status id abort_id live_pid real_sleep
   home="$TMP_ROOT/lease-home"
   proj=$(make_repo "$TMP_ROOT/lease-proj")
   fakebin=$(make_lease_lifecycle_fakebin "$TMP_ROOT/lease-fake")
@@ -383,6 +387,20 @@ test_treehouse_lease_lifecycle() {
   mkdir -p "$home/data/$id"
   printf 'brief\n' > "$home/data/$id/brief.md"
   printf '%s\n' "$proj" > "$pane"
+  real_sleep=$(command -v sleep) || fail "real sleep is unavailable"
+
+  mkdir -p "$home/data/lease-error-jj0"
+  printf 'brief\n' > "$home/data/lease-error-jj0/brief.md"
+  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    FM_DATA_OVERRIDE="$home/data" FM_PROJECTS_OVERRIDE="$home/projects" \
+    FM_CONFIG_OVERRIDE="$home/config" FM_SPAWN_NO_GUARD=1 TMUX=fake \
+    FM_REAL_TREEHOUSE="$(command -v treehouse)" FM_REAL_TREEHOUSE_HOME="$TMP_ROOT/treehouse-home" \
+    FM_REAL_TREEHOUSE_PROJECT="$proj" FM_FAKE_PANE_STATE="$pane" FM_FAKE_TREEHOUSE_ERROR=1 \
+    PATH="$fakebin:$PATH" "$ROOT/bin/fm-spawn.sh" lease-error-jj0 "$proj" codex \
+    --mode no-mistakes --yolo off 2>&1); status=$?
+  expect_code 1 "$status" "failed Treehouse acquisition should abort"
+  assert_contains "$out" "treehouse fixture acquisition failed" "spawn discarded Treehouse acquisition diagnostics"
+  assert_contains "$out" "treehouse get did not enter a worktree within 60s" "spawn dropped its public acquisition error"
 
   abort_id=lease-abort-ii9
   mkdir -p "$home/data/$abort_id"
@@ -416,8 +434,9 @@ test_treehouse_lease_lifecycle() {
     FM_REAL_TREEHOUSE_PROJECT="$proj" "$fakebin/treehouse" get --lease --lease-holder live-worker) \
     || fail "real Treehouse could not acquire a concurrent lease"
   [ "$live_wt" != "$stopped_wt" ] || fail "real Treehouse recycled the stopped-but-preserved lease"
-  (cd "$live_wt" && sleep 60) &
+  (cd "$live_wt" && "$real_sleep" 60) &
   live_pid=$!
+  kill -0 "$live_pid" 2>/dev/null || fail "concurrent lease holder did not remain live"
   contender_wt=$(FM_REAL_TREEHOUSE="$(command -v treehouse)" FM_REAL_TREEHOUSE_HOME="$TMP_ROOT/treehouse-home" \
     FM_REAL_TREEHOUSE_PROJECT="$proj" "$fakebin/treehouse" get --lease --lease-holder contender) \
     || fail "real Treehouse could not acquire a contender lease"

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -404,7 +404,7 @@ test_treehouse_lease_lifecycle() {
     --mode no-mistakes --yolo off 2>&1); status=$?
   expect_code 1 "$status" "failed Treehouse acquisition should abort"
   assert_contains "$out" "treehouse fixture acquisition failed" "spawn discarded Treehouse acquisition diagnostics"
-  assert_contains "$out" "treehouse get did not enter a worktree within 60s" "spawn dropped its public acquisition error"
+  assert_contains "$out" "treehouse get failed to acquire a worktree lease for task lease-error-jj0" "spawn dropped its public acquisition error"
 
   mkdir -p "$home/data/lease-nonzero-kk1"
   printf 'brief\n' > "$home/data/lease-nonzero-kk1/brief.md"

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -364,6 +364,9 @@ case "${1:-}" in
     command_text=${4:-}
     case "$command_text" in
       'cd '*)
+        if [ -n "${FM_FAKE_BLOCK_META_PATH:-}" ]; then
+          mkdir -p "$FM_FAKE_BLOCK_META_PATH"
+        fi
         if [ "${FM_FAKE_SUPPRESS_PANE_CWD:-0}" = 1 ]; then
           :
         else
@@ -382,7 +385,7 @@ SH
 }
 
 test_treehouse_lease_lifecycle() {
-  local home proj wt stopped_wt live_wt contender_wt successor_wt fakebin pane out status id abort_id live_pid real_sleep
+  local home proj wt stopped_wt live_wt contender_wt successor_wt fakebin pane out status id abort_id publish_id live_pid real_sleep
   home="$TMP_ROOT/lease-home"
   proj=$(make_repo "$TMP_ROOT/lease-proj")
   fakebin=$(make_lease_lifecycle_fakebin "$TMP_ROOT/lease-fake")
@@ -437,6 +440,26 @@ test_treehouse_lease_lifecycle() {
     FM_REAL_TREEHOUSE_PROJECT="$proj" "$fakebin/treehouse" status --json \
     | jq -e --arg holder "$abort_id" '[.. | objects | .lease_holder? // empty] | index($holder) != null' >/dev/null; then
     fail "aborted spawn leaked its pre-cwd-discovery lease"
+  fi
+
+  publish_id=lease-publish-ll2
+  mkdir -p "$home/data/$publish_id"
+  printf 'brief\n' > "$home/data/$publish_id/brief.md"
+  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    FM_DATA_OVERRIDE="$home/data" FM_PROJECTS_OVERRIDE="$home/projects" \
+    FM_CONFIG_OVERRIDE="$home/config" FM_SPAWN_NO_GUARD=1 TMUX=fake \
+    FM_REAL_TREEHOUSE="$(command -v treehouse)" FM_REAL_TREEHOUSE_HOME="$TMP_ROOT/treehouse-home" \
+    FM_REAL_TREEHOUSE_PROJECT="$proj" FM_FAKE_PANE_STATE="$pane" \
+    FM_FAKE_BLOCK_META_PATH="$home/state/$publish_id.meta" \
+    PATH="$fakebin:$PATH" "$ROOT/bin/fm-spawn.sh" "$publish_id" "$proj" codex \
+    --mode no-mistakes --yolo off 2>&1); status=$?
+  expect_code 1 "$status" "spawn with unpublished metadata should abort: $out"
+  assert_contains "$out" "could not publish spawn metadata for task $publish_id" \
+    "spawn dropped its metadata publication error"
+  if FM_REAL_TREEHOUSE="$(command -v treehouse)" FM_REAL_TREEHOUSE_HOME="$TMP_ROOT/treehouse-home" \
+    FM_REAL_TREEHOUSE_PROJECT="$proj" "$fakebin/treehouse" status --json \
+    | jq -e --arg holder "$publish_id" '[.. | objects | .lease_holder? // empty] | index($holder) != null' >/dev/null; then
+    fail "metadata publication failure leaked its acquired lease"
   fi
 
   out=$(FM_ROOT_OVERRIDE='' FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -323,7 +323,7 @@ test_spawn_tmux_window_construction() {
   # the stable id. The task id is the lease holder, so a stopped-but-preserved
   # worker and concurrently-live workers keep their slots until teardown returns
   # the worktree explicitly.
-  lease_command='send-keys -t @spawnwid fm_treehouse_wt=$(treehouse get --lease --lease-holder rec-win-gg7)'
+  lease_command='send-keys -t @spawnwid cd '
   assert_grep "$lease_command" "$rec" \
     "treehouse get must durably lease the slot to the task on the stable window id"
   assert_grep "display-message -p -t @spawnwid #{pane_current_path}" "$rec" \
@@ -355,9 +355,9 @@ case "${1:-}" in
   send-keys)
     command_text=${4:-}
     case "$command_text" in
-      *'treehouse get --lease'*)
+      'cd '*)
         if [ "${FM_FAKE_SUPPRESS_PANE_CWD:-0}" = 1 ]; then
-          PATH="$PATH" bash -c "$command_text" >/dev/null 2>&1 || true
+          :
         else
           PATH="$PATH" bash -c "$command_text && pwd > \"$FM_FAKE_PANE_STATE\"" \
             >/dev/null 2>&1 || true

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -267,7 +267,7 @@ run_spawn_record() {
 }
 
 test_spawn_tmux_window_construction() {
-  local home proj fakebin rec wt out status
+  local home proj fakebin rec wt out status lease_command
   home="$TMP_ROOT/spawn-rec-home"
   mkdir -p "$home/data"
   proj=$(make_repo "$TMP_ROOT/spawn-rec-proj")
@@ -293,9 +293,13 @@ test_spawn_tmux_window_construction() {
   assert_grep "set-window-option -t @spawnwid allow-rename off" "$rec" \
     "must disable allow-rename on the spawned window"
 
-  # Bug 2 fix (b): treehouse-get and the worktree wait loop target the stable id.
-  assert_grep "send-keys -t @spawnwid treehouse get Enter" "$rec" \
-    "treehouse get must be sent to the stable window id"
+  # Bug 2 fix (b): the durable treehouse lease and the worktree wait loop target
+  # the stable id. The task id is the lease holder, so a stopped-but-preserved
+  # worker and concurrently-live workers keep their slots until teardown returns
+  # the worktree explicitly.
+  lease_command="send-keys -t @spawnwid cd \"\$(treehouse get --lease --lease-holder rec-win-gg7)\" Enter"
+  assert_grep "$lease_command" "$rec" \
+    "treehouse get must durably lease the slot to the task on the stable window id"
   assert_grep "display-message -p -t @spawnwid #{pane_current_path}" "$rec" \
     "the worktree wait loop must query the stable window id, not the name"
 

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -165,12 +165,25 @@ esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;
-  has-session|new-session|new-window|send-keys) exit 0 ;;
+  send-keys)
+    case "${4:-}" in
+      *'treehouse get --lease'*) bash -c "${4:-}" >/dev/null 2>&1 || true ;;
+    esac
+    exit 0
+    ;;
+  has-session|new-session|new-window) exit 0 ;;
 esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+  get) printf '%s\n' "$FM_FAKE_PANE_PATH" ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 
@@ -244,12 +257,25 @@ case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   new-window) printf '%s\n' "@spawnwid"; exit 0 ;;
   list-windows) exit 0 ;;
-  has-session|new-session|send-keys|set-window-option) exit 0 ;;
+  send-keys)
+    case "${4:-}" in
+      *'treehouse get --lease'*) bash -c "${4:-}" >/dev/null 2>&1 || true ;;
+    esac
+    exit 0
+    ;;
+  has-session|new-session|set-window-option) exit 0 ;;
 esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+  get) printf '%s\n' "$FM_FAKE_PANE_PATH" ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 
@@ -297,7 +323,7 @@ test_spawn_tmux_window_construction() {
   # the stable id. The task id is the lease holder, so a stopped-but-preserved
   # worker and concurrently-live workers keep their slots until teardown returns
   # the worktree explicitly.
-  lease_command='send-keys -t @spawnwid fm_treehouse_wt=$(treehouse get --lease --lease-holder rec-win-gg7) && [ -n "$fm_treehouse_wt" ] && cd "$fm_treehouse_wt" Enter'
+  lease_command='send-keys -t @spawnwid fm_treehouse_wt=$(treehouse get --lease --lease-holder rec-win-gg7)'
   assert_grep "$lease_command" "$rec" \
     "treehouse get must durably lease the slot to the task on the stable window id"
   assert_grep "display-message -p -t @spawnwid #{pane_current_path}" "$rec" \
@@ -330,20 +356,25 @@ case "${1:-}" in
     command_text=${4:-}
     case "$command_text" in
       *'treehouse get --lease'*)
-        PATH="$PATH" bash -c "$command_text && pwd > \"$FM_FAKE_PANE_STATE\"" \
-          >/dev/null 2>&1 || true
+        if [ "${FM_FAKE_SUPPRESS_PANE_CWD:-0}" = 1 ]; then
+          PATH="$PATH" bash -c "$command_text" >/dev/null 2>&1 || true
+        else
+          PATH="$PATH" bash -c "$command_text && pwd > \"$FM_FAKE_PANE_STATE\"" \
+            >/dev/null 2>&1 || true
+        fi
         ;;
     esac
     ;;
 esac
 exit 0
 SH
-  chmod +x "$fakebin/treehouse" "$fakebin/tmux"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$fakebin/sleep"
+  chmod +x "$fakebin/treehouse" "$fakebin/tmux" "$fakebin/sleep"
   printf '%s\n' "$fakebin"
 }
 
 test_treehouse_lease_lifecycle() {
-  local home proj wt stopped_wt live_wt contender_wt successor_wt fakebin pane out status id live_pid
+  local home proj wt stopped_wt live_wt contender_wt successor_wt fakebin pane out status id abort_id live_pid
   home="$TMP_ROOT/lease-home"
   proj=$(make_repo "$TMP_ROOT/lease-proj")
   fakebin=$(make_lease_lifecycle_fakebin "$TMP_ROOT/lease-fake")
@@ -352,6 +383,23 @@ test_treehouse_lease_lifecycle() {
   mkdir -p "$home/data/$id"
   printf 'brief\n' > "$home/data/$id/brief.md"
   printf '%s\n' "$proj" > "$pane"
+
+  abort_id=lease-abort-ii9
+  mkdir -p "$home/data/$abort_id"
+  printf 'brief\n' > "$home/data/$abort_id/brief.md"
+  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    FM_DATA_OVERRIDE="$home/data" FM_PROJECTS_OVERRIDE="$home/projects" \
+    FM_CONFIG_OVERRIDE="$home/config" FM_SPAWN_NO_GUARD=1 TMUX=fake \
+    FM_REAL_TREEHOUSE="$(command -v treehouse)" FM_REAL_TREEHOUSE_HOME="$TMP_ROOT/treehouse-home" \
+    FM_REAL_TREEHOUSE_PROJECT="$proj" FM_FAKE_PANE_STATE="$pane" FM_FAKE_SUPPRESS_PANE_CWD=1 \
+    PATH="$fakebin:$PATH" "$ROOT/bin/fm-spawn.sh" "$abort_id" "$proj" codex \
+    --mode no-mistakes --yolo off 2>&1); status=$?
+  expect_code 1 "$status" "spawn without cwd discovery should abort: $out"
+  if FM_REAL_TREEHOUSE="$(command -v treehouse)" FM_REAL_TREEHOUSE_HOME="$TMP_ROOT/treehouse-home" \
+    FM_REAL_TREEHOUSE_PROJECT="$proj" "$fakebin/treehouse" status --json \
+    | jq -e --arg holder "$abort_id" '[.. | objects | .lease_holder? // empty] | index($holder) != null' >/dev/null; then
+    fail "aborted spawn leaked its pre-cwd-discovery lease"
+  fi
 
   out=$(FM_ROOT_OVERRIDE='' FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
     FM_DATA_OVERRIDE="$home/data" FM_PROJECTS_OVERRIDE="$home/projects" \

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -343,6 +343,10 @@ if [ "${FM_FAKE_TREEHOUSE_ERROR:-0}" = 1 ]; then
   exit 1
 fi
 cd "$FM_REAL_TREEHOUSE_PROJECT"
+if [ "${FM_FAKE_TREEHOUSE_NONZERO_PATH:-0}" = 1 ] && [ "${1:-}" = get ]; then
+  env HOME="$FM_REAL_TREEHOUSE_HOME" "$FM_REAL_TREEHOUSE" "$@" || exit $?
+  exit 1
+fi
 exec env HOME="$FM_REAL_TREEHOUSE_HOME" "$FM_REAL_TREEHOUSE" "$@"
 SH
   cat > "$fakebin/tmux" <<'SH'
@@ -401,6 +405,22 @@ test_treehouse_lease_lifecycle() {
   expect_code 1 "$status" "failed Treehouse acquisition should abort"
   assert_contains "$out" "treehouse fixture acquisition failed" "spawn discarded Treehouse acquisition diagnostics"
   assert_contains "$out" "treehouse get did not enter a worktree within 60s" "spawn dropped its public acquisition error"
+
+  mkdir -p "$home/data/lease-nonzero-kk1"
+  printf 'brief\n' > "$home/data/lease-nonzero-kk1/brief.md"
+  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    FM_DATA_OVERRIDE="$home/data" FM_PROJECTS_OVERRIDE="$home/projects" \
+    FM_CONFIG_OVERRIDE="$home/config" FM_SPAWN_NO_GUARD=1 TMUX=fake \
+    FM_REAL_TREEHOUSE="$(command -v treehouse)" FM_REAL_TREEHOUSE_HOME="$TMP_ROOT/treehouse-home" \
+    FM_REAL_TREEHOUSE_PROJECT="$proj" FM_FAKE_PANE_STATE="$pane" FM_FAKE_TREEHOUSE_NONZERO_PATH=1 \
+    PATH="$fakebin:$PATH" "$ROOT/bin/fm-spawn.sh" lease-nonzero-kk1 "$proj" codex \
+    --mode no-mistakes --yolo off 2>&1); status=$?
+  expect_code 1 "$status" "nonzero Treehouse acquisition should abort: $out"
+  if FM_REAL_TREEHOUSE="$(command -v treehouse)" FM_REAL_TREEHOUSE_HOME="$TMP_ROOT/treehouse-home" \
+    FM_REAL_TREEHOUSE_PROJECT="$proj" "$fakebin/treehouse" status --json \
+    | jq -e --arg holder lease-nonzero-kk1 '[.. | objects | .lease_holder? // empty] | index($holder) != null' >/dev/null; then
+    fail "nonzero Treehouse acquisition leaked its emitted lease path"
+  fi
 
   abort_id=lease-abort-ii9
   mkdir -p "$home/data/$abort_id"

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -297,7 +297,7 @@ test_spawn_tmux_window_construction() {
   # the stable id. The task id is the lease holder, so a stopped-but-preserved
   # worker and concurrently-live workers keep their slots until teardown returns
   # the worktree explicitly.
-  lease_command="send-keys -t @spawnwid cd \"\$(treehouse get --lease --lease-holder rec-win-gg7)\" Enter"
+  lease_command='send-keys -t @spawnwid fm_treehouse_wt=$(treehouse get --lease --lease-holder rec-win-gg7) && [ -n "$fm_treehouse_wt" ] && cd "$fm_treehouse_wt" Enter'
   assert_grep "$lease_command" "$rec" \
     "treehouse get must durably lease the slot to the task on the stable window id"
   assert_grep "display-message -p -t @spawnwid #{pane_current_path}" "$rec" \
@@ -306,9 +306,95 @@ test_spawn_tmux_window_construction() {
   pass "fm-spawn: appends windows by session-colon, pins the name, and targets the window id"
 }
 
+make_lease_lifecycle_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  get)
+    [ ! -e "$FM_FAKE_LEASE" ] || exit 1
+    printf '%s\n' "${4:-unknown}" > "$FM_FAKE_LEASE"
+    printf '%s\n' "$FM_FAKE_POOL_WT"
+    ;;
+  return)
+    [ "${3:-}" = "$FM_FAKE_POOL_WT" ] || exit 1
+    rm -f "$FM_FAKE_LEASE"
+    ;;
+esac
+SH
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  new-window) printf '%s\n' '@leasewid' ;;
+  display-message)
+    case "$*" in
+      *'#{pane_current_path}'*) cat "$FM_FAKE_PANE_STATE" ;;
+      *) printf '%s\n' firstmate ;;
+    esac
+    ;;
+  send-keys)
+    command_text=${4:-}
+    case "$command_text" in
+      *'treehouse get --lease'*)
+        PATH="$PATH" bash -c "$command_text && pwd > \"$FM_FAKE_PANE_STATE\"" \
+          >/dev/null 2>&1 || true
+        ;;
+    esac
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/treehouse" "$fakebin/tmux"
+  printf '%s\n' "$fakebin"
+}
+
+test_treehouse_lease_lifecycle() {
+  local home proj wt fakebin lease pane out status id
+  home="$TMP_ROOT/lease-home"
+  proj=$(make_repo "$TMP_ROOT/lease-proj")
+  wt="$TMP_ROOT/lease-wt"
+  git -C "$proj" worktree add -q --detach "$wt" >/dev/null 2>&1
+  fakebin=$(make_lease_lifecycle_fakebin "$TMP_ROOT/lease-fake")
+  lease="$TMP_ROOT/lease-held"
+  pane="$TMP_ROOT/lease-pane"
+  id=lease-life-hh8
+  mkdir -p "$home/data/$id"
+  printf 'brief\n' > "$home/data/$id/brief.md"
+  printf '%s\n' "$proj" > "$pane"
+
+  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    FM_DATA_OVERRIDE="$home/data" FM_PROJECTS_OVERRIDE="$home/projects" \
+    FM_CONFIG_OVERRIDE="$home/config" FM_SPAWN_NO_GUARD=1 TMUX=fake \
+    FM_FAKE_LEASE="$lease" FM_FAKE_POOL_WT="$wt" FM_FAKE_PANE_STATE="$pane" \
+    PATH="$fakebin:$PATH" "$ROOT/bin/fm-spawn.sh" "$id" "$proj" codex \
+    --mode no-mistakes --yolo off 2>&1); status=$?
+  expect_code 0 "$status" "durably leased spawn should succeed: $out"
+  assert_present "$lease" "spawn did not retain the durable lease"
+
+  if FM_FAKE_LEASE="$lease" FM_FAKE_POOL_WT="$wt" "$fakebin/treehouse" get --lease --lease-holder contender >/dev/null 2>&1; then
+    fail "a concurrently-live worker reacquired the leased pool slot"
+  fi
+
+  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    FM_DATA_OVERRIDE="$home/data" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_FAKE_LEASE="$lease" FM_FAKE_POOL_WT="$wt" FM_FAKE_PANE_STATE="$pane" \
+    PATH="$fakebin:$PATH" "$ROOT/bin/fm-teardown.sh" "$id" --force 2>&1); status=$?
+  expect_code 0 "$status" "teardown should release the durable lease: $out"
+  assert_absent "$lease" "teardown left the durable lease held"
+  FM_FAKE_LEASE="$lease" FM_FAKE_POOL_WT="$wt" "$fakebin/treehouse" get --lease --lease-holder successor >/dev/null \
+    || fail "the pool slot was not reusable after teardown"
+  FM_FAKE_LEASE="$lease" FM_FAKE_POOL_WT="$wt" "$fakebin/treehouse" return --force "$wt"
+
+  pass "fm-spawn/fm-teardown: durable leases prevent reuse until teardown"
+}
+
 test_lib_classification
 test_guard_banner
 test_bootstrap_line
 test_brief_assertion_precedes_branch
 test_spawn_isolation_abort
 test_spawn_tmux_window_construction
+test_treehouse_lease_lifecycle

--- a/tests/fm-trace-context-spawn.test.sh
+++ b/tests/fm-trace-context-spawn.test.sh
@@ -78,7 +78,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  fm_fake_treehouse_get_path "$fakebin"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -170,6 +170,20 @@ SH
   done
 }
 
+# fm_fake_treehouse_get_path <fakebin> writes a Treehouse stub whose get
+# command returns the worktree already exposed by the fixture's fake backend.
+fm_fake_treehouse_get_path() {
+  local fakebin=$1
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = get ]; then
+  printf '%s\n' "${FM_FAKE_PANE_PATH:-}"
+fi
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
+}
+
 # fm_fake_version_tool <fakebin> <tool> <override-env-var> <default-version>
 # The stub answers `--version` with <override-env-var> when that variable is set
 # and non-empty, and with <default-version> otherwise; every other invocation


### PR DESCRIPTION
## Summary

- acquire every non-Orca crewmate/scout worktree synchronously in the controller with a durable Treehouse lease labeled by task id, then move the backend shell into that exact path
- preserve the project cwd and surface Treehouse diagnostics when acquisition fails
- return a newly acquired lease if spawn aborts before publishing teardown-owning metadata, while retaining `fm-teardown.sh` as the successful spawn release boundary
- add real isolated Treehouse lifecycle coverage for stopped-but-preserved and concurrently-live workers, abort rollback, teardown release, and later slot reuse
- keep the Herdr post-create-abort fixture valid for the controller-acquired path by returning a real non-git directory, so it continues to exercise serialized cleanup rather than a failing shell `cd`

## Reproduction

Before the fix, the spawn behavior test captured a bare `treehouse get` without `--lease`; the regression assertion failed against the pre-fix script because the task endpoint acquired only a PID-liveness lease.
In an isolated scratch Treehouse pool, a stopped-but-preserved worker and a concurrently-live worker demonstrated the reported risk: an ordinary acquisition could recycle a slot whose allocator process had exited even though the task still owned the worktree.

The fixed lifecycle test uses a real isolated Treehouse pool.
It demonstrates three distinct durable leases for stopped-preserved and concurrently-live holders, verifies pre-metadata spawn abort returns its lease, then proves a slot becomes reusable only after the existing `fm-teardown.sh` release boundary.

## CI failure reconciliation

- The prior `Behavior tests (Herdr)` failure came from the abort fixture returning an empty Treehouse path after acquisition moved into `cd "$(...)"`; the failed `cd` allowed the pane to disappear without the explicit close event the test intended to assert. The fixture now returns and enters a real non-git directory, preserving the intended validation failure and serialized cleanup path.
- `Behavior portable serial 3` was cancelled downstream when the Herdr job failed; it had no independent assertion failure. The new exact-head run re-executes it.
- The prior provenance job failed because the manually created PR lacked the required no-mistakes signature. This body now records the pipeline provenance below after review, focused tests, documentation, lint, and the authorized fork push completed.

## Validation

- `bin/fm-test-run.sh tests/fm-tangle-guard.test.sh` - passed with real isolated Treehouse lifecycle coverage
- `bin/fm-test-run.sh tests/fm-backend-herdr-presentation-e2e.test.sh` - locally gated because Herdr is unavailable; required exact-head CI covers this lane
- `bin/fm-lint.sh` - passed with pinned ShellCheck 0.11.0
- Browser validation is not applicable because this repository has no browser-facing surface.
- Cypress was not run; this repository has no Cypress suite.

## Decisions

- FIRSTMATE decision under delegated authority: verify and correct the stale Zellij/cmux foreground-subshell rationale now. Keeping documentation accurate is within the accepted scope of the surrounding behavior change, and a stale rationale is actively harmful because future maintainers would reason from a workaround premise that no longer matches the actual spawn command. The correction remains limited to the affected rationale.
- FIRSTMATE instruction: do not drive Herdr lifecycle from this unguarded lane; use the required exact-head CI Herdr job to validate the corrected real-Herdr fixture.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

Closes #2013
