### PR TITLE
fix: preserve actionable wake delivery during watcher recovery

### DIFF
--- a/.opencode/plugins/fm-primary-watch-arm.js
+++ b/.opencode/plugins/fm-primary-watch-arm.js
@@ -220,8 +220,9 @@ function retryDelay(attempt) {
 
 function waitForRetry(attempt) {
   return new Promise((resolve) => {
-    const timer = setTimeout(resolve, retryDelay(attempt));
-    timer.unref();
+    // A recovery wake is not best-effort: keep this arm's restoration chain
+    // alive until it launches the next bounded attempt or reports the failure.
+    setTimeout(resolve, retryDelay(attempt));
   });
 }
 

--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -274,8 +274,11 @@ export default function (pi: ExtensionAPI) {
 
   function waitForRetry(attempt: number): Promise<void> {
     return new Promise((resolveRetry) => {
-      const timer = setTimeout(resolveRetry, retryDelay(attempt));
-      timer.unref();
+      // The actionable-close restoration chain is an owned delivery contract,
+      // not a best-effort background retry. Once an unready successor is
+      // retired there may be no child handle left to keep Pi alive; retain the
+      // timer until we launch the next bounded attempt or surface its failure.
+      setTimeout(resolveRetry, retryDelay(attempt));
     });
   }
 

--- a/bin/fm-pr-check-migrate.sh
+++ b/bin/fm-pr-check-migrate.sh
@@ -6,7 +6,10 @@
 # registered custom checks remain armed, and every other task poll is
 # quarantined for private review. A current X-mode shim is preserved by exact
 # content, while the recognized older byte-static shim is refreshed in place.
-# Usage: fm-pr-check-migrate.sh [--checks-safe]
+# Usage: fm-pr-check-migrate.sh [--checks-safe] [--watcher-lock-held=<pid>]
+# `--watcher-lock-held` is watcher-internal: the caller must be the current
+# `fm-watch.sh` lock holder for this exact home. It lets the watcher complete
+# preflight under its already-held singleton rather than trying to pause itself.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -26,12 +29,29 @@ NONCANONICAL_PREFIX='!noncanonical'
 LEGACY_NONCANONICAL_PREFIX=_noncanonical
 
 ALLOW_INCOMPLETE_REPAIRS=0
-if [ "$#" -eq 1 ] && [ "$1" = --checks-safe ]; then
-  ALLOW_INCOMPLETE_REPAIRS=1
-elif [ "$#" -ne 0 ]; then
-  echo "error: invalid PR check migration request" >&2
+WATCHER_LOCK_HELD_PID=
+for arg in "$@"; do
+  case "$arg" in
+    --checks-safe) ALLOW_INCOMPLETE_REPAIRS=1 ;;
+    --watcher-lock-held=*) WATCHER_LOCK_HELD_PID=${arg#--watcher-lock-held=} ;;
+    *)
+      echo "error: invalid PR check migration request" >&2
+      exit 2
+      ;;
+  esac
+done
+if [ -n "$WATCHER_LOCK_HELD_PID" ] && [ "$ALLOW_INCOMPLETE_REPAIRS" -ne 1 ]; then
+  echo "error: --watcher-lock-held requires --checks-safe" >&2
   exit 2
 fi
+case "$WATCHER_LOCK_HELD_PID" in
+  ''|*[!0-9]*)
+    [ -z "$WATCHER_LOCK_HELD_PID" ] || {
+      echo "error: --watcher-lock-held requires a numeric watcher pid" >&2
+      exit 2
+    }
+    ;;
+esac
 
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
@@ -39,6 +59,8 @@ fi
 . "$SCRIPT_DIR/fm-x-lib.sh"
 # shellcheck source=bin/fm-check-lib.sh
 . "$SCRIPT_DIR/fm-check-lib.sh"
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
 
 umask 077
 if [ ! -e "$STATE" ] && [ ! -L "$STATE" ]; then
@@ -50,6 +72,14 @@ fi
 if [ ! -d "$STATE" ] || [ -L "$STATE" ]; then
   echo "PR_CHECK_MIGRATION: state directory is not a private ordinary directory; migration did not complete safely" >&2
   exit 1
+fi
+
+if [ -n "$WATCHER_LOCK_HELD_PID" ]; then
+  if [ "${PPID:-}" != "$WATCHER_LOCK_HELD_PID" ] \
+    || ! fm_watcher_lock_matches_pid "$STATE" "$WATCH" "$WATCHER_LOCK_HELD_PID" "$FM_HOME"; then
+    echo "PR_CHECK_MIGRATION: watcher-lock-held requires the current watcher singleton; refusing to scan state checks" >&2
+    exit 1
+  fi
 fi
 
 migration_marker_content_valid() {
@@ -261,53 +291,53 @@ if ! x_shim_locked_scan_needed; then
   [ "$ALLOW_INCOMPLETE_REPAIRS" -eq 1 ] && scan_complete && exit 0
 fi
 
-# shellcheck source=bin/fm-wake-lib.sh disable=SC1091
-. "$SCRIPT_DIR/fm-wake-lib.sh"
-
 stopped_watcher=0
-pid=$(cat "$WATCH_LOCK/pid" 2>/dev/null || true)
-if fm_pid_alive "$pid"; then
-  if ! fm_watcher_lock_matches_pid "$STATE" "$WATCH" "$pid" "$FM_HOME"; then
-    echo "PR_CHECK_MIGRATION: watcher ownership is ambiguous; review state/.watch.lock before rearming polls" >&2
-    exit 1
+lock_held=0
+if [ -z "$WATCHER_LOCK_HELD_PID" ]; then
+  pid=$(cat "$WATCH_LOCK/pid" 2>/dev/null || true)
+  if fm_pid_alive "$pid"; then
+    if ! fm_watcher_lock_matches_pid "$STATE" "$WATCH" "$pid" "$FM_HOME"; then
+      echo "PR_CHECK_MIGRATION: watcher ownership is ambiguous; review state/.watch.lock before rearming polls" >&2
+      exit 1
+    fi
+    kill -TERM "$pid" 2>/dev/null || {
+      echo "PR_CHECK_MIGRATION: watcher could not be paused; review state/.watch.lock before rearming polls" >&2
+      exit 1
+    }
+    stopped_watcher=1
+    i=0
+    while [ "$i" -lt 100 ] && fm_pid_alive "$pid"; do
+      sleep 0.05
+      i=$((i + 1))
+    done
+    if fm_pid_alive "$pid"; then
+      echo "PR_CHECK_MIGRATION: watcher did not pause; review state/.watch.lock before rearming polls" >&2
+      exit 1
+    fi
   fi
-  kill -TERM "$pid" 2>/dev/null || {
-    echo "PR_CHECK_MIGRATION: watcher could not be paused; review state/.watch.lock before rearming polls" >&2
-    exit 1
-  }
-  stopped_watcher=1
+
   i=0
-  while [ "$i" -lt 100 ] && fm_pid_alive "$pid"; do
+  while [ "$i" -lt 100 ]; do
+    if fm_lock_try_acquire "$WATCH_LOCK"; then
+      lock_held=1
+      break
+    fi
+    # A concurrent migration may have completed while this process waited.
+    # Its validated marker proves the old watcher crossed the boundary, so this
+    # process can continue to the normal watcher singleton instead of competing
+    # with the newly started watcher for a second migration lock.
+    if migration_complete && ! x_shim_locked_scan_needed; then
+      exit 0
+    fi
     sleep 0.05
     i=$((i + 1))
   done
-  if fm_pid_alive "$pid"; then
-    echo "PR_CHECK_MIGRATION: watcher did not pause; review state/.watch.lock before rearming polls" >&2
+  if [ "$lock_held" -ne 1 ]; then
+    echo "PR_CHECK_MIGRATION: watcher exclusion could not be acquired; review state/.watch.lock before rearming polls" >&2
     exit 1
   fi
 fi
 
-lock_held=0
-i=0
-while [ "$i" -lt 100 ]; do
-  if fm_lock_try_acquire "$WATCH_LOCK"; then
-    lock_held=1
-    break
-  fi
-  # A concurrent migration may have completed while this process waited.
-  # Its validated marker proves the old watcher crossed the boundary, so this
-  # process can continue to the normal watcher singleton instead of competing
-  # with the newly started watcher for a second migration lock.
-  if migration_complete && ! x_shim_locked_scan_needed; then
-    exit 0
-  fi
-  sleep 0.05
-  i=$((i + 1))
-done
-if [ "$lock_held" -ne 1 ]; then
-  echo "PR_CHECK_MIGRATION: watcher exclusion could not be acquired; review state/.watch.lock before rearming polls" >&2
-  exit 1
-fi
 watch_recovery_required=0
 if [ "$stopped_watcher" -eq 1 ] || [ -n "${FM_LOCK_RECOVERED_PID:-}" ]; then
   watch_recovery_required=1

--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -70,8 +70,8 @@ BEAT="$STATE/.last-watcher-beat"
 # "Fresh" reuses the guard's threshold so there is one definition of liveness.
 GRACE=${FM_GUARD_GRACE:-300}
 # How long to wait for a freshly forked watcher to acquire the lock and beat.
-# Git Bash/MSYS pays a much higher fork cost, so its bounded default covers
-# that cold start.
+# Git Bash/MSYS pays a much higher fork cost while the watcher completes its
+# required pre-lock migration, so its bounded default covers that cold start.
 case "${OSTYPE:-}" in
   msys*|mingw*|cygwin*) ARM_CONFIRM_DEFAULT=30 ;;
   *) ARM_CONFIRM_DEFAULT=10 ;;

--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -70,8 +70,8 @@ BEAT="$STATE/.last-watcher-beat"
 # "Fresh" reuses the guard's threshold so there is one definition of liveness.
 GRACE=${FM_GUARD_GRACE:-300}
 # How long to wait for a freshly forked watcher to acquire the lock and beat.
-# Git Bash/MSYS pays a much higher fork cost while the watcher completes its
-# required pre-lock migration, so its bounded default covers that cold start.
+# Git Bash/MSYS pays a much higher fork cost, so its bounded default covers
+# that cold start.
 case "${OSTYPE:-}" in
   msys*|mingw*|cygwin*) ARM_CONFIRM_DEFAULT=30 ;;
   *) ARM_CONFIRM_DEFAULT=10 ;;

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -713,14 +713,6 @@ if [ "${BASH_SOURCE[0]}" != "$0" ]; then
   return 0
 fi
 
-# Before acquiring the watcher lock or enumerating any runnable check, replace
-# or quarantine checks created by older versions. The migration compares bytes
-# and reads data only; it never invokes legacy check files through Bash.
-"$SCRIPT_DIR/fm-pr-check-migrate.sh" --checks-safe || {
-  echo "watcher: PR check migration blocked; refusing to execute state checks" >&2
-  exit 1
-}
-
 if ! fm_lock_try_acquire "$WATCH_LOCK"; then
   BEAT="$STATE/.last-watcher-beat"
   if [ -n "${FM_LOCK_HELD_PID:-}" ]; then
@@ -787,6 +779,13 @@ printf '%s\n' "$FM_WATCH_DELIVERY_IDENTITY" > "$WATCH_LOCK/pid-identity" 2>/dev/
 
 [ -e "$STATE/.last-heartbeat" ] || touch "$STATE/.last-heartbeat"
 
+# Run the non-executing PR-check preflight only after this watcher owns the
+# singleton and reaches its first loop iteration. The initial beat below is
+# therefore honest: this process holds the home lock, has registered its
+# identity, and is in the supervision loop. It does not claim that preflight
+# completed or that a normal signal/check scan has run yet.
+startup_migration_pending=1
+
 # A merged poll may have queued its terminal wake and then lost the process
 # between receipt publication and fixed-path removal.
 # Finish only identity-bound retirement receipts before any check can run.
@@ -837,6 +836,14 @@ while :; do
   # Liveness beacon for fm-guard.sh: a fresh mtime here means a watcher is
   # alive. Supervision scripts warn when this goes stale with tasks in flight.
   touch "$STATE/.last-watcher-beat"
+
+  if [ "$startup_migration_pending" -eq 1 ]; then
+    "$SCRIPT_DIR/fm-pr-check-migrate.sh" --checks-safe --watcher-lock-held="$WATCHER_PID" || {
+      echo "watcher: PR check migration blocked; refusing to execute state checks" >&2
+      exit 1
+    }
+    startup_migration_pending=0
+  fi
 
   # Parent-owned secondmate pending-reply reconciliation: resolve correlated
   # parent reports, observe backend busy/idle turn completion, send one recovery

--- a/docs/watcher-continuity.md
+++ b/docs/watcher-continuity.md
@@ -26,6 +26,9 @@ It waits at most one readiness timeout per attempt, then sends TERM and waits a 
 If the unready arm does not retire within that bound, the adapter keeps ownership, starts no overlapping retry, and delivers the typed fallback immediately.
 When that retained arm later closes, its actual close is classified as a new supervised event without replaying the earlier fallback.
 After the configured retry bound is exhausted, it delivers the original wake with a typed continuity-restoration failure even if every successor arm hung without reporting readiness.
+For Pi, the actionable-close restoration retry timer remains referenced only until it launches the next bounded attempt or delivers that typed failure, so retiring an unready successor cannot let the runtime exit before Pi's owned wake-delivery contract completes.
+OpenCode's actionable-close restoration timer follows the same lifecycle.
+The background retry timers for non-actionable closes remain unreferenced.
 This is deliberate Option B ordering: the fleet is protected before the model handles the wake whenever restoration succeeds, but the model is never left blind when it does not.
 
 Claude's Stop hook starts the successor arm at the next Stop after the handling turn, rather than before notification as Pi and OpenCode do.
@@ -75,6 +78,7 @@ Only the watcher process touches `state/.last-watcher-beat`; no helper process c
 ## Regression coverage
 
 `tests/fm-pi-watch-extension.test.sh` checks Pi's first-cycle-or-explicit-repair tool metadata and ownership-based redundant-call no-ops, then simulates actionable and empty child closes against the actual Pi and OpenCode close handlers, blocks prompt delivery to prove the successor launches first, verifies single-flight behavior, changes the session lock before close to prove ownership is rechecked, and hangs each successor arm to prove bounded fallback delivery includes the typed restoration failure.
+Its no-extra-handle Pi control proves that the original actionable wake and bounded restoration failure are delivered after two retries even when no arm child remains to keep the runtime alive.
 The same suite covers ordinary same-process session replacement for `/new`, `/resume`, and `/fork`, same-instance shutdown-plus-start, stale prior-generation callbacks, repeated transitions with exactly one live cycle, disappearance of the shutting-down refusal after a valid replacement activates, and terminal quit still refusing late rearm.
 `tests/fm-watch-arm.test.sh` covers durable queue replay, real remote parent-replies ingestion into the authoritative status log, decision-only OPEN DECISIONS recovery, interrupted handling replay, generation-bound acknowledgement, a persistent live successor after recovery, a watcher close inside the handling window that must leave the printed acknowledgement valid, and the self-healing moved-generation acknowledgement that consumes its handled rows and names its remedy.
 `tests/fm-watcher-lock.test.sh` covers verified-successor attach, recovery publication before stale-lock removal, the typed self-eviction failure, bounded and successor-linked lifecycle rows, and a SIGSTOP counterfactual that distinguishes a live PID from a stale beacon before classifying termination.

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -475,6 +475,62 @@ EOF
   pass "Pi hung successor falls back to one typed actionable wake"
 }
 
+test_pi_hung_successor_recovery_keeps_the_runtime_alive() {
+  local repo home plugin log prompt out status
+  repo="$TMP_ROOT/pi-hung-successor-runtime-root"
+  home="$TMP_ROOT/pi-hung-successor-runtime-home"
+  log="$TMP_ROOT/pi-hung-successor-runtime.log"
+  prompt="$TMP_ROOT/pi-hung-successor-runtime.prompt"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'arm=%s\n' "$$" >> "${FM_ARM_LOG:?}"
+count=$(wc -l < "$FM_ARM_LOG" | tr -d '[:space:]')
+if [ "$count" -eq 1 ]; then
+  printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+  printf 'signal: synthetic wake\n'
+  exit 0
+fi
+trap 'exit 0' TERM INT
+while :; do sleep 0.02; done
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_PROMPT_FILE="$prompt" FM_PI_ARM_READY_TIMEOUT_MS=250 FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node --input-type=module 2>&1 <<'EOF'
+import { writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+let tool = null;
+const pi = {
+  on() {},
+  registerCommand() {},
+  registerTool(candidate) {
+    if (candidate.name === "fm_watch_arm_pi") tool = candidate;
+  },
+  sendUserMessage: async (message) => {
+    writeFileSync(process.env.FM_PROMPT_FILE, message);
+  },
+};
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+await tool.execute("tool-call-hung-successor-runtime", {}, undefined, undefined, {});
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "Pi hung-successor runtime control must start"
+  [ -z "$out" ] || fail "Pi hung-successor runtime control printed output: $out"
+  [ -f "$prompt" ] || fail "Pi left the restoration chain before delivering the bounded hung-successor wake"
+  grep -q 'signal: synthetic wake' "$prompt" \
+    || fail "Pi runtime control lost the original actionable wake"
+  grep -q 'could not restore watcher continuity after 2 retries' "$prompt" \
+    || fail "Pi runtime control did not deliver the bounded restoration failure"
+  [ "$(wc -l < "$log" | tr -d '[:space:]')" -eq 4 ] \
+    || fail "Pi runtime control did not launch the bounded successor and retries"
+  pass "Pi hung-successor restoration keeps the runtime alive through wake delivery"
+}
+
 test_pi_unretired_successor_falls_back_without_retry() {
   local repo home plugin log release out status
   repo="$TMP_ROOT/pi-unretired-successor-root"
@@ -2156,6 +2212,7 @@ test_pi_redundant_tool_call_is_owned_noop
 test_pi_scheduled_retry_call_is_owned_noop
 test_pi_actionable_close_starts_single_successor_before_delivery
 test_pi_hung_successor_falls_back_to_typed_wake
+test_pi_hung_successor_recovery_keeps_the_runtime_alive
 test_pi_unretired_successor_falls_back_without_retry
 test_pi_late_unretired_close_resumes_supervision
 test_pi_empty_close_retries_instead_of_disappearing

--- a/tests/fm-watch-startup.test.sh
+++ b/tests/fm-watch-startup.test.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Watcher cold-start ordering: the arm must confirm a real singleton holder
+# before a slow PR-check preflight can consume its default ten-second budget.
+set -u
+
+# shellcheck source=tests/wake-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/wake-helpers.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-watch-startup-tests)
+
+make_startup_fixture() {  # <name>
+  local name=$1 dir
+  dir=$(make_case "$name")
+  mkdir -p "$dir/home/state"
+  cp -R "$ROOT/bin" "$dir/bin"
+  printf '%s\n' "$dir"
+}
+
+wait_for_started_arm() {  # <arm-pid> <arm-output>
+  local arm_pid=$1 armout=$2 i=0
+  while [ "$i" -lt 60 ]; do
+    grep -q '^watcher: started pid=' "$armout" 2>/dev/null && return 0
+    is_live_non_zombie "$arm_pid" || return 1
+    sleep 0.1
+    i=$((i + 1))
+  done
+  return 1
+}
+
+test_slow_preflight_starts_after_confirmable_heartbeat() {
+  local dir state fakebin arm armout migration watcher_pid arm_pid started_at elapsed expected_watch
+  dir=$(make_startup_fixture startup-after-heartbeat)
+  state="$dir/home/state"
+  fakebin="$dir/fakebin"
+  arm="$dir/bin/fm-watch-arm.sh"
+  armout="$dir/arm.out"
+  migration="$dir/bin/fm-pr-check-migrate.sh"
+  expected_watch=$(cd "$dir/bin" && pwd)/fm-watch.sh
+  cat > "$migration" <<'SH'
+#!/usr/bin/env bash
+touch "$FM_HOME/state/migration-started"
+sleep 12
+SH
+  chmod +x "$migration"
+
+  started_at=$(date +%s)
+  env -u FM_ARM_CONFIRM_TIMEOUT PATH="$fakebin:$PATH" FM_HOME="$dir/home" \
+    FM_POLL=60 "$arm" > "$armout" &
+  arm_pid=$!
+
+  i=0
+  while [ "$i" -lt 60 ] && [ ! -e "$state/migration-started" ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ -e "$state/migration-started" ] || {
+    wait "$arm_pid" 2>/dev/null || true
+    fail "slow preflight did not start: $(cat "$armout")"
+  }
+  wait_for_started_arm "$arm_pid" "$armout" || {
+    wait "$arm_pid" 2>/dev/null || true
+    fail "default-budget arm did not confirm before slow preflight completed: $(cat "$armout")"
+  }
+  elapsed=$(( $(date +%s) - started_at ))
+  [ "$elapsed" -lt 10 ] || fail "arm confirmation took ${elapsed}s despite a held lock and first heartbeat"
+
+  watcher_pid=$(cat "$state/.watch.lock/pid" 2>/dev/null || true)
+  [ -n "$watcher_pid" ] || fail "confirmed watcher did not publish a lock pid"
+  [ "$(cat "$state/.watch.lock/fm-home" 2>/dev/null || true)" = "$dir/home" ] \
+    || fail "confirmed watcher did not bind its lock to the fixture home"
+  [ "$(cat "$state/.watch.lock/watcher-path" 2>/dev/null || true)" = "$expected_watch" ] \
+    || fail "confirmed watcher path was $(cat "$state/.watch.lock/watcher-path" 2>/dev/null || true), not $expected_watch"
+  [ -e "$state/.last-watcher-beat" ] || fail "slow preflight started without the first watcher heartbeat"
+  is_live_non_zombie "$watcher_pid" || fail "arm confirmed a non-live watcher pid $watcher_pid"
+
+  # Finish this fixture's one watcher exactly by its lock-owned pid; no broad
+  # process matching is acceptable in this test or production code.
+  kill "$watcher_pid" 2>/dev/null || true
+  wait_for_exit "$arm_pid" 120 >/dev/null 2>&1 || true
+  pass "slow preflight follows a lock-held, loop-entered heartbeat under the default arm budget"
+}
+
+test_arm_rejects_a_live_lock_holder_without_a_heartbeat() {
+  local dir state fakebin arm armout holder pid rc
+  dir=$(make_startup_fixture no-fabricated-beat)
+  state="$dir/home/state"
+  fakebin="$dir/fakebin"
+  arm="$dir/bin/fm-watch-arm.sh"
+  armout="$dir/arm.out"
+  cat > "$dir/bin/fm-pr-check-migrate.sh" <<'SH'
+#!/usr/bin/env bash
+touch "$FM_HOME/state/migration-ran"
+SH
+  chmod +x "$dir/bin/fm-pr-check-migrate.sh"
+
+  # A live foreign pid in the lock is the exact reason a watcher cannot acquire
+  # this home. It intentionally carries no watcher identity or beat.
+  sleep 30 &
+  holder=$!
+  mkdir "$state/.watch.lock" || fail "negative-control lock directory could not be created"
+  printf '%s\n' "$holder" > "$state/.watch.lock/pid"
+  touch "$state/foreign-lock-ready"
+  pid=$(cat "$state/.watch.lock/pid" 2>/dev/null || true)
+  is_live_non_zombie "$pid" || fail "negative-control lock pid did not name a live holder"
+
+  set +e
+  env FM_ARM_CONFIRM_TIMEOUT=1 PATH="$fakebin:$PATH" FM_HOME="$dir/home" \
+    FM_POLL=60 "$arm" > "$armout" 2>&1
+  rc=$?
+  set -e
+  kill "$holder" 2>/dev/null || true
+  wait "$holder" 2>/dev/null || true
+
+  [ "$rc" -ne 0 ] || fail "arm accepted a live foreign lock holder without a heartbeat"
+  grep -q 'watcher: FAILED - cycle ended without an actionable reason' "$armout" \
+    || fail "negative control did not fail at the arm honesty gate: $(cat "$armout")"
+  [ ! -e "$state/.last-watcher-beat" ] || fail "negative control fabricated a watcher heartbeat"
+  [ ! -e "$state/migration-ran" ] || fail "negative control ran migration before acquiring the watcher lock"
+  pass "arm rejects a live lock holder without a heartbeat instead of accepting fabricated liveness"
+}
+
+test_watcher_lock_held_mode_requires_the_parent_singleton() {
+  local dir state out rc holder identity expected_watch
+  dir=$(make_startup_fixture watcher-lock-held-guard)
+  state="$dir/home/state"
+  expected_watch=$(cd "$dir/bin" && pwd)/fm-watch.sh
+  sleep 30 &
+  holder=$!
+  identity=$(FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1/bin/fm-wake-lib.sh"
+    fm_pid_identity "$2"
+  ' _ "$ROOT" "$holder")
+  mkdir "$state/.watch.lock" || fail "watcher-lock-held guard fixture could not create its lock"
+  printf '%s\n' "$holder" > "$state/.watch.lock/pid"
+  printf '%s\n' "$identity" > "$state/.watch.lock/pid-identity"
+  printf '%s\n' "$dir/home" > "$state/.watch.lock/fm-home"
+  printf '%s\n' "$expected_watch" > "$state/.watch.lock/watcher-path"
+  set +e
+  FM_HOME="$dir/home" "$dir/bin/fm-pr-check-migrate.sh" --checks-safe --watcher-lock-held="$holder" > "$dir/out" 2>&1
+  rc=$?
+  set -e
+  kill "$holder" 2>/dev/null || true
+  wait "$holder" 2>/dev/null || true
+  out=$(cat "$dir/out")
+  [ "$rc" -ne 0 ] || fail "watcher-lock-held migration mode accepted a non-child of the singleton"
+  [ "$out" = 'PR_CHECK_MIGRATION: watcher-lock-held requires the current watcher singleton; refusing to scan state checks' ] \
+    || fail "watcher-lock-held guard fired for the wrong reason: $out"
+  pass "watcher-lock-held migration mode refuses a caller that is not the watcher singleton"
+}
+
+test_slow_preflight_starts_after_confirmable_heartbeat
+test_arm_rejects_a_live_lock_holder_without_a_heartbeat
+test_watcher_lock_held_mode_requires_the_parent_singleton


### PR DESCRIPTION
## Intent

Repair PR 2134’s real Pi continuity failure: after an actionable watcher close, an unready successor can be retired leaving only an unrefed retry timer, so Pi may exit before delivering the original typed wake and bounded restoration failure. Retain only the actionable-close retry timer until the next bounded attempt or typed failure; keep background scheduleRetry unrefed. Add a deterministic no-extra-handle control that proves delivery after two retries. This repair was independently red-before-green verified in the owning checkout: the new control failed with the existing unrefed timer, passed 31/31 after the repair, and failed again when unref was restored. The report’s full suite was started as requested but remains nonterminal in known Herdr/bootstrap shards, so its aggregate is NOT_VERIFIABLE; do not infer full-suite green. Update existing PR #2134 only; do not force-push, open a second PR, or merge. PR changes must state that the repair preserves Pi’s owned actionable wake-delivery contract.

## What Changed

- Start the watcher’s singleton heartbeat before its PR-check migration preflight, with a guarded lock-held migration path.
- Preserve Pi and OpenCode actionable recovery timers until the next bounded attempt or typed fallback delivers the original wake; background retries remain unreferenced.
- Add regression coverage for no-extra-handle Pi recovery and watcher startup ordering, and document the continuity contract.

## Risk Assessment

✅ Low: The bounded Pi actionable-close restoration path now retains the sole required retry timer through its next attempt or typed failure, while ordinary background retries remain unrefed; surrounding startup/migration changes preserve their singleton and preflight boundaries.

## Testing

Targeted validation confirmed the actionable-close retry timer is retained through bounded restoration while background scheduleRetry remains unrefed. The focused Pi extension test passed, and a no-extra-handle runtime control produced four arm cycles plus the reviewer-visible original typed wake and bounded failure; full-suite/remote CI status is NOT_VERIFIABLE because it was intentionally not run in this phase.

<details>
<summary>Evidence: Pi actionable-close runtime delivery transcript</summary>

```text
Pi actionable-close runtime delivery control
arm_cycles=4 (initial + successor + 2 retries)
typed_follow_up_delivered=yes
⁣FIRSTMATE_OP: v1 watcher: FIRSTMATE WATCHER WAKE: signal: synthetic wake

watcher: FAILED - Pi extension could not verify a ready successor watcher
watcher: FAILED - Pi extension could not restore watcher continuity after 2 retries

Run bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.
```
</details>
<details>
<summary>Evidence: Focused Pi extension test transcript</summary>

```text
ok - Pi extension reports external healthy watcher output
ok - Pi custom tool exposes repair-only metadata and returns automatic-continuation guidance
ok - Pi redundant tool call returns ownership guidance and spawns no second child
ok - Pi scheduled retry remains extension-owned after another tool call
ok - Pi actionable close starts one successor before wake delivery settles
ok - Pi hung successor falls back to one typed actionable wake
ok - Pi hung-successor restoration keeps the runtime alive through wake delivery
ok - Pi unretired successor falls back without an overlapping retry
ok - Pi late unretired closes resume classified supervision
ok - Pi clean empty close triggers a bounded continuity retry
ok - Pi established clean closes stop at the configured retry limit
ok - Pi close handler verifies session-lock ownership before successor launch
ok - Pi watcher arm distinguishes all session lock ownership states
ok - Pi session transitions use a generation owner across /new /resume /fork, stale callbacks, and quit
ok - Pi process-exit cleanup listener remains singular across session replacement
ok - Pi process-exit cleanup stops the attached arm child
ok - OpenCode plugins have an explicit ESM boundary even under a typeless parent package
ok - OpenCode watcher plugin uses the effective FM_HOME state
ok - OpenCode watcher plugin sources the effective config
ok - OpenCode watcher plugin requires session lock ownership
ok - OpenCode watcher coordinator respects primary scope
ok - OpenCode watcher plugin starts one successor before wake prompt delivery settles
ok - OpenCode pre-ready actionable close preserves its successor
ok - OpenCode hung successor falls back to one typed actionable wake
ok - OpenCode unretired successor falls back without an overlapping retry
ok - OpenCode late unretired closes resume classified supervision
ok - OpenCode clean empty close triggers a bounded continuity retry
ok - OpenCode established clean closes stop at the configured retry limit
ok - OpenCode close handler verifies session-lock ownership before successor launch
ok - OpenCode watcher plugin coordinates with the turn-end guard
ok - OpenCode healthy arm output does not suppress the turn-end guard
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --no-ext-diff --unified=20 b5d430d6fdcd961ce9b681bf196f365c1825c284 294986b638d8875d7960fb40bf6e7d754984dc17 -- .pi/extensions/fm-primary-pi-watch.ts tests/fm-pi-watch-extension.test.sh`
- `bash tests/fm-pi-watch-extension.test.sh`
- `/var/folders/cq/xf4qcb9j0qzc2dbh173mflbm0000gn/T/no-mistakes-evidence/01KZT3SEM1ZTPYKMXH9Y6BDGXE/pi-runtime-delivery-control.sh`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
