### PR TITLE
fix(stow): bound secondmate receipt waits

### DIFF
--- a/.agents/skills/stow/SKILL.md
+++ b/.agents/skills/stow/SKILL.md
@@ -244,8 +244,8 @@ Every home is judged against its own `config/startup-memory-budget` allowance, s
 
 Act on each home by its reported `transport`:
 
-- `agent` - send the marked request with `bin/fm-send.sh fm-<id> "<request>"` so the live secondmate performs its own `/stow`, including the uncaptured knowledge that exists only in its session.
-  Ask it for the same completion receipt this skill defines, and read its reply from its status file or the document it points to, never from its chat.
+- `agent` - collect every live secondmate id, then run `bin/fm-stow-delegate.sh <id>...` once so all marked `/stow` requests are dispatched before their correlated completion receipts share one bounded foreground wait.
+  Its header owns the wait and result contract: include completed receipts, report `pending` or `send-error` as an unresolved exception, and never keep polling after the helper returns because every late reply remains durable through the normal pending-reply wake path.
 - `direct` - curate that local home's editable memory files yourself under the same retention plan, then re-run the cascade to confirm the after totals.
   `data/captain-shared.md` stays a read-only counted input there, exactly as it is in any secondmate home.
 - `deferred` - a remote home with no live agent. Its memory is accounted read-only and cannot be curated from here, because there is no generic remote write path for a home's own memory files.

--- a/bin/fm-stow-cascade.sh
+++ b/bin/fm-stow-cascade.sh
@@ -21,9 +21,10 @@
 #   reason=<one line>                 (whenever a step did not complete)
 #
 # transport says how the sweep reaches that home:
-#   agent     - a live secondmate agent owns the home; steer it with
-#               bin/fm-send.sh so it sweeps its own uncaptured session
-#               knowledge and replies through its marked return channel.
+#   agent     - a live secondmate agent owns the home; dispatch it through
+#               bin/fm-stow-delegate.sh, which sends the marked request with
+#               bin/fm-send.sh, correlates the completion receipt, and bounds
+#               the foreground wait across every live secondmate.
 #   direct    - a local home with no live agent; curate its editable memory
 #               files in place.
 #   deferred  - a remote home with no live agent. There is deliberately no
@@ -48,7 +49,7 @@
 set -u
 
 usage() {
-  sed -n '2,47{s/^# \{0,1\}//;p;}' "$0"
+  sed -n '2,48{s/^# \{0,1\}//;p;}' "$0"
 }
 
 case "${1:-}" in

--- a/bin/fm-stow-cascade.sh
+++ b/bin/fm-stow-cascade.sh
@@ -22,9 +22,8 @@
 #
 # transport says how the sweep reaches that home:
 #   agent     - a live secondmate agent owns the home; dispatch it through
-#               bin/fm-stow-delegate.sh, which sends the marked request with
-#               bin/fm-send.sh, correlates the completion receipt, and bounds
-#               the foreground wait across every live secondmate.
+#               bin/fm-stow-delegate.sh, which bounds the foreground wait for
+#               its correlated completion receipt.
 #   direct    - a local home with no live agent; curate its editable memory
 #               files in place.
 #   deferred  - a remote home with no live agent. There is deliberately no

--- a/bin/fm-stow-delegate.sh
+++ b/bin/fm-stow-delegate.sh
@@ -95,8 +95,15 @@ for id in "$@"; do
     "$SCRIPT_DIR/fm-send.sh" "fm-$id" "$REQUEST"; then
     printf '%s\t%s\tdispatched\n' "$id" "$corr" >> "$RESULTS"
   else
-    fm_pending_reply_discard_undelivered "$STATE" "$corr" >/dev/null 2>&1 || true
-    printf '%s\t%s\tsend-error\n' "$id" "$corr" >> "$RESULTS"
+    rec=$(fm_pending_reply_path "$STATE" "$corr")
+    phase=""
+    [ -f "$rec" ] && phase=$(fm_pending_reply_get "$rec" phase)
+    if [ "$phase" = delivery_unknown ]; then
+      printf '%s\t%s\tdelivery-unknown\n' "$id" "$corr" >> "$RESULTS"
+    else
+      fm_pending_reply_discard_undelivered "$STATE" "$corr" >/dev/null 2>&1 || true
+      printf '%s\t%s\tsend-error\n' "$id" "$corr" >> "$RESULTS"
+    fi
     incomplete=1
   fi
 done
@@ -120,6 +127,11 @@ while IFS=$'\t' read -r id corr dispatch; do
   if [ "$dispatch" = send-error ]; then
     printf 'result=send-error\n'
     printf 'reason=the marked stow request was not delivered\n'
+    continue
+  fi
+  if [ "$dispatch" = delivery-unknown ]; then
+    printf 'result=pending\n'
+    printf 'reason=delivery outcome is unknown; the pending receipt was preserved for reconciliation\n'
     continue
   fi
   if fm_pending_reply_try_resolve "$STATE" "$corr" >/dev/null 2>&1; then

--- a/bin/fm-stow-delegate.sh
+++ b/bin/fm-stow-delegate.sh
@@ -44,6 +44,8 @@ fi
 
 # shellcheck source=bin/fm-pending-reply-lib.sh
 . "$SCRIPT_DIR/fm-pending-reply-lib.sh"
+# shellcheck source=bin/fm-backend.sh
+. "$SCRIPT_DIR/fm-backend.sh"
 
 BOUND=${FM_STOW_CASCADE_TIMEOUT:-60}
 case "$BOUND" in
@@ -77,7 +79,7 @@ done
 
 for id in "$@"; do
   meta="$STATE/$id.meta"
-  if [ ! -f "$meta" ] || [ -L "$meta" ] || ! grep -q '^kind=secondmate$' "$meta" 2>/dev/null; then
+  if [ ! -f "$meta" ] || [ -L "$meta" ] || [ "$(fm_meta_get "$meta" kind)" != secondmate ]; then
     printf 'error: endpoint metadata does not identify a secondmate: %s\n' "$id" >&2
     exit 2
   fi

--- a/bin/fm-stow-delegate.sh
+++ b/bin/fm-stow-delegate.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Dispatch the live-secondmate portion of an internal /stow cascade and wait
+# for correlated completion receipts under one foreground bound.
+# Usage: fm-stow-delegate.sh <secondmate-id>...
+#
+# Every id must name a kind=secondmate endpoint in this explicit FM_HOME.
+# Requests are delivered through fm-send.sh, so each one keeps the existing
+# durable pending-reply expectation and correlation contract.
+# All requests are dispatched before receipt polling starts.
+# The entire receipt wait shares FM_STOW_CASCADE_TIMEOUT seconds (default 60),
+# regardless of how many secondmates were dispatched.
+# A receipt that misses the bound remains pending and can still surface through
+# the normal pending-reply wake path after this command returns.
+#
+# Each result is one blank-line-separated stanza:
+#   secondmate=<id>
+#   result=completed|pending|send-error
+#   receipt=<correlated status line>  (completed only)
+#   reason=<one line>                 (pending or send-error)
+#
+# Exit status: 0 every dispatched secondmate replied; 3 at least one result is
+# pending or failed to send; 1 local setup failed; 2 invalid use.
+set -u
+
+usage() {
+  sed -n '2,22{s/^# \{0,1\}//;p;}' "$0"
+}
+
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+  "") usage >&2; exit 2 ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -z "${FM_HOME+x}" ] || [ -z "${FM_HOME:-}" ]; then
+  printf 'error: FM_HOME is not set; stow delegation requires an explicit firstmate home\n' >&2
+  exit 1
+fi
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+if [ ! -d "$FM_HOME" ] || [ ! -d "$STATE" ]; then
+  printf 'error: stow delegation home or state dir is missing: %s\n' "$FM_HOME" >&2
+  exit 1
+fi
+
+# shellcheck source=bin/fm-pending-reply-lib.sh
+. "$SCRIPT_DIR/fm-pending-reply-lib.sh"
+
+BOUND=${FM_STOW_CASCADE_TIMEOUT:-60}
+case "$BOUND" in
+  ""|*[!0-9]*)
+    printf 'error: FM_STOW_CASCADE_TIMEOUT must be a positive integer: %s\n' "$BOUND" >&2
+    exit 2
+    ;;
+esac
+[ "$BOUND" -gt 0 ] || {
+  printf 'error: FM_STOW_CASCADE_TIMEOUT must be a positive integer: %s\n' "$BOUND" >&2
+  exit 2
+}
+
+for id in "$@"; do
+  case "$id" in
+    ""|*[!A-Za-z0-9._-]*)
+      printf 'error: invalid secondmate id: %s\n' "$id" >&2
+      exit 2
+      ;;
+  esac
+  seen=0
+  for prior in "$@"; do
+    [ "$prior" = "$id" ] || continue
+    seen=$((seen + 1))
+    [ "$seen" -le 1 ] || {
+      printf 'error: duplicate secondmate id: %s\n' "$id" >&2
+      exit 2
+    }
+  done
+done
+
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-stow-delegate.XXXXXX") || exit 1
+# shellcheck disable=SC2317,SC2329 # Invoked by the EXIT trap.
+cleanup() { rm -rf -- "$TMP"; }
+trap cleanup EXIT
+REQUEST='Run /stow for your home and report its completion receipt. Include the request correlation token in the parent status reply.'
+RESULTS="$TMP/results"
+: > "$RESULTS"
+incomplete=0
+
+for id in "$@"; do
+  corr=$(fm_pending_reply_create "$FM_HOME" "$STATE" "$id" "$REQUEST") || {
+    printf 'error: failed to create the pending stow receipt for %s\n' "$id" >&2
+    exit 1
+  }
+  if env FM_HOME="$FM_HOME" \
+    FM_STATE_OVERRIDE="$STATE" \
+    FM_PENDING_REPLY_EXISTING_CORR="$corr" \
+    "$SCRIPT_DIR/fm-send.sh" "fm-$id" "$REQUEST"; then
+    printf '%s\t%s\tdispatched\n' "$id" "$corr" >> "$RESULTS"
+  else
+    fm_pending_reply_discard_undelivered "$STATE" "$corr" >/dev/null 2>&1 || true
+    printf '%s\t%s\tsend-error\n' "$id" "$corr" >> "$RESULTS"
+    incomplete=1
+  fi
+done
+
+deadline=$(( $(date +%s) + BOUND ))
+while :; do
+  waiting=0
+  while IFS=$'\t' read -r id corr dispatch; do
+    [ "$dispatch" = dispatched ] || continue
+    if ! fm_pending_reply_try_resolve "$STATE" "$corr" >/dev/null 2>&1; then
+      waiting=1
+    fi
+  done < "$RESULTS"
+  [ "$waiting" -eq 1 ] || break
+  [ "$(date +%s)" -lt "$deadline" ] || break
+  sleep 1
+done
+
+while IFS=$'\t' read -r id corr dispatch; do
+  printf '\nsecondmate=%s\n' "$id"
+  if [ "$dispatch" = send-error ]; then
+    printf 'result=send-error\n'
+    printf 'reason=the marked stow request was not delivered\n'
+    continue
+  fi
+  if fm_pending_reply_try_resolve "$STATE" "$corr" >/dev/null 2>&1; then
+    receipt=$(fm_pending_reply_find_resolve_line "$STATE/$id.status" "$corr")
+    printf 'result=completed\n'
+    printf 'receipt=%s\n' "$receipt"
+  else
+    printf 'result=pending\n'
+    printf 'reason=foreground wait reached %ss; reply remains durable\n' "$BOUND"
+    incomplete=1
+  fi
+done < "$RESULTS"
+
+[ "$incomplete" -eq 0 ] || exit 3
+exit 0

--- a/bin/fm-stow-delegate.sh
+++ b/bin/fm-stow-delegate.sh
@@ -75,6 +75,14 @@ for id in "$@"; do
   done
 done
 
+for id in "$@"; do
+  meta="$STATE/$id.meta"
+  if [ ! -f "$meta" ] || [ -L "$meta" ] || ! grep -q '^kind=secondmate$' "$meta" 2>/dev/null; then
+    printf 'error: endpoint metadata does not identify a secondmate: %s\n' "$id" >&2
+    exit 2
+  fi
+done
+
 TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-stow-delegate.XXXXXX") || exit 1
 # shellcheck disable=SC2317,SC2329 # Invoked by the EXIT trap.
 cleanup() { rm -rf -- "$TMP"; }

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -900,7 +900,7 @@ families_for_changed_path() {
     bin/fm-secondmate*|bin/fm-remote*|bin/fm-on.sh|bin/fm-home-seed.sh|\
     bin/fm-backlog-handoff.sh|bin/fm-backlog-receive.sh|bin/fm-procevent-remote-reply.sh|\
     bin/fm-config-inherit-lib.sh|bin/fm-config-push.sh|bin/fm-shared*|\
-    bin/fm-stow-cascade.sh)
+    bin/fm-stow-cascade.sh|bin/fm-stow-delegate.sh)
       printf '%s\n' secondmate
       ;;
     bin/fm-session-start.sh|bin/fm-bootstrap.sh|bin/fm-fleet-sync.sh|\

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -64,6 +64,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-review-diff.sh`      | Review a crewmate branch or resolved PR head against the authoritative base          |
 | `fm-marker-lib.sh`       | Compatibility entry point for the from-firstmate carrier owned by `fm-operational-input.sh` |
 | `fm-pending-reply-lib.sh` | Parent-owned secondmate pending-reply expectations, recovery, and keyed escalation lifecycle |
+| `fm-stow-delegate.sh`   | Dispatch live-secondmate stow requests and collect their receipts under one bounded wait |
 | `fm-secondmate-report.sh` | Optional helper to append a correlated parent status or document-pointer report       |
 | `fm-procevent-remote-reply.sh` | Relay the remote-secondmate status stream through non-destructive process-event deltas |
 | `fm-procevent-when.sh`   | Fire a trust-bound deterministic action at most once when its registered condition holds, then wake with the outcome |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -64,7 +64,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-review-diff.sh`      | Review a crewmate branch or resolved PR head against the authoritative base          |
 | `fm-marker-lib.sh`       | Compatibility entry point for the from-firstmate carrier owned by `fm-operational-input.sh` |
 | `fm-pending-reply-lib.sh` | Parent-owned secondmate pending-reply expectations, recovery, and keyed escalation lifecycle |
-| `fm-stow-delegate.sh`   | Dispatch live-secondmate stow requests and collect their receipts under one bounded wait |
+| `fm-stow-delegate.sh`   | Dispatch live-secondmate stow requests and collect correlated receipts under one shared `FM_STOW_CASCADE_TIMEOUT` wait (60 seconds by default) |
 | `fm-secondmate-report.sh` | Optional helper to append a correlated parent status or document-pointer report       |
 | `fm-procevent-remote-reply.sh` | Relay the remote-secondmate status stream through non-destructive process-event deltas |
 | `fm-procevent-when.sh`   | Fire a trust-bound deterministic action at most once when its registered condition holds, then wake with the outcome |

--- a/tests/fm-stow-cascade.test.sh
+++ b/tests/fm-stow-cascade.test.sh
@@ -475,6 +475,7 @@ test_delegate_rejects_non_secondmate_batch_atomically() {
     'worktree=/tmp/worker' \
     'project=alpha' \
     'harness=claude' \
+    'kind=secondmate' \
     'kind=crewmate'
   make_delegate_stubs
 

--- a/tests/fm-stow-cascade.test.sh
+++ b/tests/fm-stow-cascade.test.sh
@@ -415,6 +415,7 @@ run_delegate() { # <home> <reply-mode> <timeout> <id>...
     FM_DELEGATE_REPLY_MODE="$reply_mode" \
     FM_SEND_SETTLE=0 \
     FM_STOW_CASCADE_TIMEOUT="$timeout" \
+    FM_GATE_REFUSE_BYPASS=1 \
     "$DELEGATE" "$@" 2>/dev/null
 }
 

--- a/tests/fm-stow-cascade.test.sh
+++ b/tests/fm-stow-cascade.test.sh
@@ -411,6 +411,7 @@ run_delegate() { # <home> <reply-mode> <timeout> <id>...
     TMPDIR="${TMPDIR:-/tmp}" \
     FM_ROOT_OVERRIDE="$home" \
     FM_HOME="$home" \
+    FM_GATE_REFUSE_BYPASS=1 \
     FM_SEND_LOG="$TMP_ROOT/delegate-send.log" \
     FM_DELEGATE_REPLY_MODE="$reply_mode" \
     FM_SEND_SETTLE=0 \
@@ -465,6 +466,60 @@ test_live_agent_receipt_is_returned_when_ready() {
   pass "a correlated secondmate receipt is returned without waiting out the bound"
 }
 
+# run_delegate_remote <home> <ssh-mode> <timeout> <id>...: drive the delegate
+# against a remote (ssh) secondmate route with no FM_ROOT_OVERRIDE, so
+# fm-send.sh's remote leg resolves fm-on.sh's tracked-command check against
+# this real checkout instead of the fake home.
+run_delegate_remote() {
+  local home=$1 ssh_mode=$2 timeout=$3
+  shift 3
+  env -i \
+    PATH="$FAKEBIN:$BASE_PATH" \
+    HOME="${HOME:-/tmp}" \
+    TMPDIR="${TMPDIR:-/tmp}" \
+    FM_HOME="$home" \
+    FM_GATE_REFUSE_BYPASS=1 \
+    FM_SSH_BIN="$FAKEBIN/fake-ssh" \
+    FM_FAKE_SSH_MODE="$ssh_mode" \
+    FM_SEND_SETTLE=0 \
+    FM_STOW_CASCADE_TIMEOUT="$timeout" \
+    "$DELEGATE" "$@" 2>/dev/null
+}
+
+test_ambiguous_remote_delivery_preserves_pending_receipt() {
+  local home remote out rc rec phase
+  home=$(new_primary delegate-remote-ambiguous)
+  remote="$TMP_ROOT/homes/delegate-remote-ambiguous-remote"
+  remote_record remote-domain remote-mac "$TMP_ROOT/remote-root" "$remote" \
+    > "$home/data/secondmates.md"
+  fm_write_meta "$home/state/remote-domain.meta" \
+    "window=remote:remote-domain" \
+    "worktree=$remote" \
+    "project=$remote" \
+    "harness=claude" \
+    "kind=secondmate" \
+    "mode=secondmate" \
+    "remote_host=remote-mac"
+
+  set +e
+  out=$(run_delegate_remote "$home" unreachable 1 remote-domain)
+  rc=$?
+  set -e
+
+  expect_code 3 "$rc" "an ambiguous remote delivery should not report a clean cascade"
+  assert_contains "$out" 'secondmate=remote-domain' "the ambiguous result did not identify its secondmate"
+  assert_contains "$out" 'result=pending' "an ambiguous remote delivery was not reported as pending"
+  assert_contains "$out" 'preserved for reconciliation' \
+    "the ambiguous outcome did not explain the preserved receipt"
+
+  rec=$(find "$home/state/pending-replies" -type f ! -name '.*' | head -1)
+  [ -n "$rec" ] || fail "the ambiguous remote delivery discarded the durable pending reply"
+  phase=$(sed -n 's/^phase=//p' "$rec")
+  [ "$phase" = delivery_unknown ] \
+    || fail "the pending reply was not preserved in its delivery_unknown phase: $phase"
+  pass "an ambiguous remote delivery preserves its pending receipt instead of discarding it"
+}
+
 test_budget_is_enforced_per_home_and_never_summed
 test_every_registered_home_is_enumerated_exactly_once
 test_transport_routes_by_placement_and_liveness
@@ -473,3 +528,4 @@ test_a_slow_remote_is_bounded_and_the_rest_still_report
 test_no_cascade_without_secondmates_or_from_a_secondmate_home
 test_live_agent_receipt_wait_is_bounded
 test_live_agent_receipt_is_returned_when_ready
+test_ambiguous_remote_delivery_preserves_pending_receipt

--- a/tests/fm-stow-cascade.test.sh
+++ b/tests/fm-stow-cascade.test.sh
@@ -10,6 +10,7 @@ set -u
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 CASCADE="$ROOT/bin/fm-stow-cascade.sh"
+DELEGATE="$ROOT/bin/fm-stow-delegate.sh"
 TMP_ROOT=$(fm_test_tmproot fm-stow-cascade)
 mkdir -p "$TMP_ROOT"
 TMP_ROOT=$(cd "$TMP_ROOT" && pwd -P)
@@ -362,9 +363,112 @@ test_no_cascade_without_secondmates_or_from_a_secondmate_home() {
   pass "the cascade stays silent with no secondmates and never runs from a secondmate home"
 }
 
+make_delegate_stubs() {
+  cat > "$FAKEBIN/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  send-keys)
+    shift
+    literal=0
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -t) shift 2 ;;
+        -l) literal=1; shift ;;
+        *) break ;;
+      esac
+    done
+    if [ "$literal" = 1 ]; then
+      printf '%s' "${1:-}" >> "$FM_SEND_LOG"
+      if [ "$FM_DELEGATE_REPLY_MODE" = reply ]; then
+        corr=$(printf '%s' "${1:-}" | grep -oE 'corr=[a-f0-9]{16}' | head -1)
+        printf 'done [%s]: secondmate stow complete\n' "$corr" >> "$FM_HOME/state/domain.status"
+      fi
+    fi
+    ;;
+  display-message)
+    for arg in "$@"; do
+      case "$arg" in
+        *cursor_y*) printf '1\n'; exit 0 ;;
+      esac
+    done
+    printf 'fakepane\n'
+    ;;
+  capture-pane) printf '╭────╮\n│    │\n╰────╯\n' ;;
+esac
+exit 0
+SH
+  chmod +x "$FAKEBIN/tmux"
+}
+
+run_delegate() { # <home> <reply-mode> <timeout> <id>...
+  local home=$1 reply_mode=$2 timeout=$3
+  shift 3
+  : > "$TMP_ROOT/delegate-send.log"
+  env -i \
+    PATH="$FAKEBIN:$BASE_PATH" \
+    HOME="${HOME:-/tmp}" \
+    TMPDIR="${TMPDIR:-/tmp}" \
+    FM_ROOT_OVERRIDE="$home" \
+    FM_HOME="$home" \
+    FM_SEND_LOG="$TMP_ROOT/delegate-send.log" \
+    FM_DELEGATE_REPLY_MODE="$reply_mode" \
+    FM_SEND_SETTLE=0 \
+    FM_STOW_CASCADE_TIMEOUT="$timeout" \
+    "$DELEGATE" "$@" 2>/dev/null
+}
+
+test_live_agent_receipt_wait_is_bounded() {
+  local home out rc started elapsed pending
+  home=$(new_primary delegate-pending)
+  fm_write_secondmate_meta "$home/state/domain.meta" "$home" 'sess:fm-domain'
+  make_delegate_stubs
+
+  started=$(date +%s)
+  set +e
+  out=$(run_delegate "$home" pending 1 domain)
+  rc=$?
+  set -e
+  elapsed=$(( $(date +%s) - started ))
+
+  [ "$elapsed" -lt 10 ] || fail "a missing secondmate receipt blocked for $elapsed seconds"
+  expect_code 3 "$rc" "a bounded missing receipt should remain distinguishable from completion"
+  assert_contains "$out" 'secondmate=domain' "the pending result did not identify its secondmate"
+  assert_contains "$out" 'result=pending' "the missing receipt was not reported as pending"
+  assert_contains "$out" 'reply remains durable' "the timeout did not preserve late-reply expectations"
+  pending=$(find "$home/state/pending-replies" -type f ! -name '.*' | head -1)
+  [ -n "$pending" ] || fail "the bounded wait discarded the durable pending reply"
+  assert_contains "$(cat "$pending")" 'phase=awaiting_report' \
+    "the bounded wait resolved a request that never replied"
+  assert_contains "$(cat "$TMP_ROOT/delegate-send.log")" 'Run /stow for your home' \
+    "the bounded wait did not dispatch the secondmate stow"
+  pass "a live secondmate that never replies cannot hold /stow past the foreground bound"
+}
+
+test_live_agent_receipt_is_returned_when_ready() {
+  local home out rc
+  home=$(new_primary delegate-complete)
+  fm_write_secondmate_meta "$home/state/domain.meta" "$home" 'sess:fm-domain'
+  make_delegate_stubs
+
+  set +e
+  out=$(run_delegate "$home" reply 5 domain)
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "a correlated secondmate receipt should complete cleanly"
+  assert_contains "$out" 'secondmate=domain' "the completed result did not identify its secondmate"
+  assert_contains "$out" 'result=completed' "the correlated receipt was not reported as complete"
+  assert_contains "$out" 'receipt=done [' "the correlated receipt was not returned to /stow"
+  assert_contains "$out" 'secondmate stow complete' "the completion detail was lost"
+  pass "a correlated secondmate receipt is returned without waiting out the bound"
+}
+
 test_budget_is_enforced_per_home_and_never_summed
 test_every_registered_home_is_enumerated_exactly_once
 test_transport_routes_by_placement_and_liveness
 test_receipt_facts_are_complete_and_show_before_and_after
 test_a_slow_remote_is_bounded_and_the_rest_still_report
 test_no_cascade_without_secondmates_or_from_a_secondmate_home
+test_live_agent_receipt_wait_is_bounded
+test_live_agent_receipt_is_returned_when_ready

--- a/tests/fm-stow-cascade.test.sh
+++ b/tests/fm-stow-cascade.test.sh
@@ -466,6 +466,33 @@ test_live_agent_receipt_is_returned_when_ready() {
   pass "a correlated secondmate receipt is returned without waiting out the bound"
 }
 
+test_delegate_rejects_non_secondmate_batch_atomically() {
+  local home out rc pending_count
+  home=$(new_primary delegate-kind-refusal)
+  fm_write_secondmate_meta "$home/state/domain.meta" "$home" 'sess:fm-domain'
+  fm_write_meta "$home/state/worker.meta" \
+    'window=sess:fm-worker' \
+    'worktree=/tmp/worker' \
+    'project=alpha' \
+    'harness=claude' \
+    'kind=crewmate'
+  make_delegate_stubs
+
+  set +e
+  out=$(run_delegate "$home" pending 1 domain worker)
+  rc=$?
+  set -e
+
+  expect_code 2 "$rc" "a mixed endpoint-kind batch should be refused"
+  [ ! -s "$TMP_ROOT/delegate-send.log" ] \
+    || fail "the refused batch dispatched a stow request"
+  pending_count=$(find "$home/state/pending-replies" -type f ! -name '.*' 2>/dev/null | wc -l | tr -d ' ')
+  [ "$pending_count" = 0 ] \
+    || fail "the refused batch created $pending_count pending receipts"
+  [ -z "$out" ] || fail "the refused batch emitted successful result stanzas"
+  pass "a non-secondmate endpoint refuses the entire delegate batch before side effects"
+}
+
 # run_delegate_remote <home> <ssh-mode> <timeout> <id>...: drive the delegate
 # against a remote (ssh) secondmate route with no FM_ROOT_OVERRIDE, so
 # fm-send.sh's remote leg resolves fm-on.sh's tracked-command check against
@@ -528,4 +555,5 @@ test_a_slow_remote_is_bounded_and_the_rest_still_report
 test_no_cascade_without_secondmates_or_from_a_secondmate_home
 test_live_agent_receipt_wait_is_bounded
 test_live_agent_receipt_is_returned_when_ready
+test_delegate_rejects_non_secondmate_batch_atomically
 test_ambiguous_remote_delivery_preserves_pending_receipt


### PR DESCRIPTION
## Intent

Bound `/stow`'s foreground wait for live secondmate receipts so one slow or missing reply cannot make the command take many minutes, while keeping late and delivery-unknown replies durable.

Closes #2095

## Decisions

- Firstmate treated preserving delivery-unknown pending receipts and atomically validating every delegated endpoint with the authoritative last-value-wins `kind` parser as required corrections to the new helper's stated safety and durability contracts, not as scope expansion.
- After the approval-blocked workflows completed, Firstmate adopted the No Mistakes pipeline head only after a range-diff proved it preserved all five original commits and added exactly three bounded, in-scope review and documentation fixes.

## Reproduction

Before the fix, I exercised the live-secondmate path in a scratch `FM_HOME` with a fake secondmate endpoint that accepted the marked stow request but never produced its correlated completion receipt. An outer watchdog expired with status 124 while the pending-reply record remained `awaiting_report`, demonstrating that the existing per-secondmate wait could hold `/stow` indefinitely in practice.

The regression test failed before the implementation because the bounded fleet delegate did not exist (status 127 instead of the expected bounded pending status 3). It passes after the fix: the helper dispatches every live secondmate first, applies one shared foreground deadline, returns pending within that bound, and leaves the late-reply record durable. Additional cases cover an immediate correlated receipt and ambiguous remote delivery, which must retain its `delivery_unknown` record.

## Validation

- `tests/fm-stow-cascade.test.sh` — 9 tests passed
- `bin/fm-lint.sh` — passed with pinned ShellCheck 0.11.0
- `bin/fm-doc-audience-check.sh` — passed
- `tests/fm-test-run.test.sh` — passed
- no-mistakes review, test, documentation, and lint gates — passed
- Database — not involved
- Browser validation — not applicable; this repository has no browser-facing surface
- Cypress — not run; this repository has no Cypress suite

The no-mistakes push gate hit the documented read-only `origin` 403, so the validated branch was pushed to the `4mb1t10n` fork as required.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)