### PR TITLE
docs(agents): enforce knowledge placement

### DIFF
--- a/.agents/skills/firstmate-coding-guidelines/SKILL.md
+++ b/.agents/skills/firstmate-coding-guidelines/SKILL.md
@@ -109,7 +109,7 @@ Record the dated per-harness result in `docs/verification/runtime-backends.md`, 
 For every changed maintained prose surface, identify its inventory audience, authoritative owner, current-behavior relevance, destination for supporting evidence, and any unique safety fact that removal could lose.
 Move or delete evidence only after the current owner and regression pointer are verified.
 After all documentation, review-fix, and lint-fix commits, review the complete branch diff again against those criteria rather than reviewing only the latest commit.
-Run `bin/fm-doc-audience-check.sh`; it enforces classification, README setup routing, local link targets, and owner pointers without keyword-linting legitimate evidence prose.
+Run `bin/fm-doc-audience-check.sh`; [`docs/documentation-audiences.md`](../../../docs/documentation-audiences.md) owns exactly what it enforces.
 
 ## Repo style rules
 

--- a/.agents/skills/fmx-respond/SKILL.md
+++ b/.agents/skills/fmx-respond/SKILL.md
@@ -18,7 +18,7 @@ Relay lets a firstmate instance answer and act on public mentions routed through
 A mention arrives through the watcher as a `check:` wake whose payload is `x-mention <request_id>`.
 The full mention is stashed locally; this skill acts on any request it carries and turns it into one public reply, or deliberately skips it when there is nothing to answer.
 
-This runs only when Relay is on (the user dropped `FMX_PAIRING_TOKEN` into `.env`; see AGENTS.md "Relay").
+This runs only when Relay is on (the user dropped `FMX_PAIRING_TOKEN` into `.env`; see `docs/configuration.md` "Relay (.env)").
 If you ever see an `x-mention` wake without Relay configured, do nothing.
 A `check:` wake can also carry `x-mode-error ...` instead of `x-mention <request_id>` - that is a poll or relay configuration problem, not a mention to answer.
 Report it directly to the captain as a Relay configuration blocker and do not treat it as a mention to answer.

--- a/.agents/skills/validation-supersession/SKILL.md
+++ b/.agents/skills/validation-supersession/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: validation-supersession
+description: >-
+  Agent-only procedure for replacing work after a current explicit captain instruction completely invalidates an active no-mistakes validation run.
+  Load before aborting that run, recovering branch custody, replacing obsolete work, or starting the one authoritative replacement validation.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# Validation supersession
+
+Use this procedure only when a current, explicit captain instruction completely invalidates work already under active no-mistakes validation.
+Lesser changes go to follow-up work under the task lifecycle in `AGENTS.md` section 7.
+The same worker retains the task for a qualifying supersession.
+
+## Procedure
+
+1. Cancel the active run through no-mistakes axi's supported abort command.
+2. Confirm through structured axi status that the run has stopped before changing any code.
+3. Follow `branch_sync.next_action` from that status.
+4. Use axi sync's supported guarded recovery only when the action code is `recover_custody`; otherwise proceed only when status confirms branch ownership is already returned and no recovery is required.
+5. Treat custody recovery as ownership recovery, not content recovery.
+6. Replace the obsolete work from the correct pre-invalidation base instead of building on the recovered-but-obsolete head, and keep the obsolete run's pipeline-fix commits out of the replacement.
+7. Validate exactly once against the final replacement head so no obsolete or intermediate head becomes authoritative.
+
+Apart from the supported abort above, do not hand-edit, commit, restart, or start a second validation run while the obsolete run owns the branch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,6 +420,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `NETWORK_CHECKS:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
 - `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
+- `validation-supersession` - load before acting when a current, explicit captain instruction completely invalidates work under active no-mistakes validation, per section 7's Validate subsection.
 - `quota-array-dispatch` - load before choosing among a matched crew-dispatch profile array from current quota-axi output.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
 - `firstmate-orca` - load before switching to Orca, spawning or supervising Orca-backed work, smoke-testing Orca backend behavior, debugging Orca task state, or reconciling Orca-backed task metadata.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,6 @@ Never add an agent name as a commit co-author.
 Each secondmate has a persistent isolated `FM_HOME`, including its own state, backlog, projects, and session lock.
 `bin/fm-send.sh` fails closed unless `FM_HOME` is explicit, so a steer cannot silently resolve against another home.
 
-Section 1 lists the shared tracked material.
 `data/` holds durable private fleet records, `state/` holds volatile runtime records, `config/` holds local operating choices, and `projects/` contains project clones.
 `.env` and `.no-mistakes/` are local and gitignored.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,7 +278,7 @@ The promoted worker must inventory scratch state, return to a clean default-bran
 Fleet supervision is an always-loaded operational contract; `docs/architecture.md`, `docs/turnend-guard.md`, the emitted session-start block, and script help own mechanisms and harness-specific recipes.
 
 Whenever work is under way, keep exactly one live supervision cycle using the emitted protocol for this primary harness.
-Relay may require that same live cycle with no fleet work.
+A Relay-only home requires that same live cycle so mentions can wake it with no other fleet work.
 Do not substitute another harness's wait shape, use shell `&`, or create a second cycle when a healthy one already exists.
 For every actionable wake, follow the ordinary-wake continuation in the emitted protocol; use its repair action only when the live cycle is missing or failed.
 No turn ends blind while work is under way, including turns described as holding or waiting.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,83 +51,9 @@ Never add an agent name as a commit co-author.
 Each secondmate has a persistent isolated `FM_HOME`, including its own state, backlog, projects, and session lock.
 `bin/fm-send.sh` fails closed unless `FM_HOME` is explicit, so a steer cannot silently resolve against another home.
 
-Tracked files hold shared instructions and tooling; `data/` holds durable private fleet records; `state/` holds runtime records and append-only status events; `config/` holds local operating choices; and `projects/` contains clones that are read-only to firstmate except under hard rule 1's concrete captain-approved project operation exception.
-
-```
-AGENTS.md            this file (CLAUDE.md is a symlink to it)
-CONTRIBUTING.md      contributor workflow and repo conventions
-README.md            public overview and development notes
-.github/workflows/   shared CI and PR enforcement, committed
-.tasks.toml          tracked tasks-axi markdown backend config for the default backlog backend (section 10)
-.agents/skills/      firstmate-loaded internal skills, committed; each carries metadata.internal=true for installers
-.claude/skills       symlink to .agents/skills for claude compatibility
-skills/              standalone public installer-facing skills, committed; not loaded by firstmate
-bin/                 helper scripts, committed; read each script's header before first use
-.env                 optional Relay pairing token; LOCAL, gitignored; presence-gates section 14
-config/crew-harness  crewmate harness override; LOCAL, gitignored; absent or "default" = same as firstmate. Inherited as the literal file: a concrete primary adapter value also controls a secondmate home's own crewmates (section 4)
-config/crew-dispatch.json  optional crewmate dispatch profiles; LOCAL, gitignored; firstmate-maintained but human-editable natural-language rules that choose a per-task harness/model/effort profile (section 4). Inherited by secondmate homes
-config/secondmate-harness  harness the PRIMARY uses to launch SECONDMATE agents, optionally followed by a model and effort token on the same line ("<harness> [<model>] [<effort>]"; section 4); LOCAL, gitignored; absent or "default" harness falls back to config/crew-harness then firstmate's own. The primary's own setting; NOT inherited into secondmate homes (secondmates do not spawn secondmates)
-config/backlog-backend  backlog backend override; LOCAL, gitignored; absent or "tasks-axi" = default tasks-axi backend, "manual" = force routine backlog updates to hand-editing; inherited by secondmate homes (section 10)
-config/backend  runtime session-provider backend override for new tasks; LOCAL, gitignored; absent = falls through to runtime auto-detection (the runtime firstmate itself is executing inside), then tmux; tmux is the verified reference backend (docs/tmux-backend.md), while herdr, zellij, orca, and cmux are experimental spawn backends (docs/herdr-backend.md, docs/zellij-backend.md, docs/orca-backend.md, docs/cmux-backend.md) - herdr and cmux can also be selected by runtime auto-detection, zellij and orca never are (always explicit), and codex-app is not accepted; see docs/codex-app-backend.md; inherited by secondmate homes under the primary-authoritative contract in secondmate-provisioning
-config/calm     Pi Calm presentation preference; LOCAL, gitignored, and not inherited; see docs/configuration.md "Pi Calm preference"
-config/startup-memory-budget     primary-authoritative per-home startup-memory budget; LOCAL, gitignored, materialized as 7,500 estimated tokens by locked primary bootstrap and inherited into secondmate homes; see docs/configuration.md "Startup memory budget"
-config/herdr-presentation-spaces  optional "off" opt-out from, or "on" opt-in to, Herdr's default-on disposable single-task visual projection, which is unconfigured-default-on only at or above a Herdr version floor; LOCAL, gitignored; inherited by secondmate homes; see docs/herdr-backend.md "Presentation spaces"
-config/trace-context  optional presence flag enabling default-off native W3C trace-context propagation to spawned agents; LOCAL, gitignored; inherited by secondmate homes; see docs/configuration.md "Trace context propagation" and docs/trace-context.md
-config/cmux-socket-password  optional cmux control-socket password; LOCAL, gitignored; read fresh on every cmux CLI call and passed through without ever overriding an operator's own ambient CMUX_SOCKET_PASSWORD when absent (docs/cmux-backend.md "Setup")
-config/wedge-alarm  optional away-mode wedge-alarm active-alert directives; LOCAL, gitignored; absent means auto (macOS Notification Center when available); see docs/wedge-alarm.md
-config/x-mode.env    generated Relay watcher cadence; LOCAL, gitignored; source before arming watcher when present
-data/                personal fleet records; LOCAL, gitignored as a whole
-  backlog.md         task queue, dependencies, history
-  captain.md         this home's domain-local captain preferences and working style; LOCAL, gitignored, canonical even if harness memory mirrors it, and updated with inspect-then-update
-  captain-shared.md  main-authoritative shared captain preferences propagated read-only to secondmate homes; LOCAL, gitignored, owned by secondmate-provisioning
-  learnings.md       fleet-local operational facts and gotchas; LOCAL, gitignored; dated, evidence-backed, curated, and updated with inspect-then-update - rewrite and prune rather than append forever, the same contract as captain.md; created lazily, absent until this home has a learning to store
-  projects.md        thin fleet navigation registry recording each project's standing delivery posture; firstmate-private, parsed for mechanical sync and seeding by fm-project-mode.sh (section 6)
-  secondmates.md      local and remote secondmate routing table; firstmate-private, maintained by the secondmate seed helpers (section 6)
-  <id>/brief.md      per-task crewmate brief, or per-secondmate charter brief when kind=secondmate
-  <id>/report.md     scout task deliverable, written by the crewmate; survives teardown
-projects/            cloned repos; gitignored; read-only except under hard rule 1's concrete captain-approved project operation exception
-state/               runtime records and signals; gitignored
-  <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth
-  <id>.turn-ended    touched by turn-end hooks
-  <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
-  <id>.kimi-turnend-token   firstmate-owned Kimi hook registry token for the task; removed by teardown
-  <id>.muse-session  muse busy-source binding (sessions root plus task worktree) written by fm-spawn; removed by teardown
-  <id>.meta          task metadata; each producer script's header owns its exact fields and mutation contract, with docs/configuration.md routing operator-facing backend and trace-context details
-  <id>.herdr-presentation  quarantinable attempt and restart-binding journal for Herdr's optional visual projection; never task or endpoint authority; see docs/herdr-backend.md "Presentation spaces"
-  <id>.check.sh      authenticated slow poll; the watcher dispatches validated PR data and the byte-identified Relay shim through trusted repository scripts, runs registered custom checks from hash-validated private snapshots, and rejects every other state check without execution
-  <id>.check-trust   private content binding created by fm-check-register.sh for an intentional custom check
-  <id>.pr-poll       private validated data sidecar for the byte-static PR merge poll
-  <id>.pr-poll-registration  private transactional provenance record binding the task, canonical metadata identity, sidecar, and static poll publication
-  <id>.pr-poll-retirement  private identity-bound crash-recovery receipt for one exact validated merged result; removed after its poll artifacts retire
-  .pr-check-quarantine/  private non-runnable storage for checks neutralized by the non-executing migration
-  .pr-check-migration.log  private per-task outcomes distinguishing rebuilt or canonically registered replacement polls, quarantined unarmed polls, and incomplete migrations
-  .pr-check-migration-scan-v1  private marker proving the non-executing scan disabled every unsafe legacy check; .pr-check-migration-v1 separately records completed private repairs
-  x-watch.check.sh   generated Relay poll shim; present only when opted in (section 14)
-  pending-replies/   parent-owned secondmate pending-reply records (correlation id, delivery vs reply, recovery, escalation); fm-pending-reply-lib.sh
-  procevent/         registered process-to-event sources, one private record per canonical source id; written only by bin/fm-procevent.sh, and their presence alone keeps supervision required (section 13)
-  procevent-inbox/   private captured results and their durable handled-acknowledgement markers; source output lives here and never in an event line
-  when/              private condition->action watch specs, their trust bindings, and single-fire markers; written only by bin/fm-procevent-when.sh (section 13's process-event-sources trigger)
-  x-inbox/           generated Relay pending mention payloads; fmx-respond drains it (section 14)
-  x-context/         generated Relay durable per-request reply context and one-wake offer markers, keyed by request_id; survives inbox cleanup and expires within seven days (section 14; bin/fm-x-lib.sh)
-  x-outbox/          generated Relay dry-run reply and dismiss previews; inspect it when FMX_DRY_RUN is set (section 14)
-  public-followup/   generated private transport for promised public replies: commitment registrations, typed terminal-result inbox, accepted/rejected ledgers (section 14; bin/fm-public-followup.sh)
-  x-poll.error x-poll.claim-error  generated Relay and offer-claim diagnostic dedupe markers
-  .startup-network.*  status, report, per-step elapsed timings, inline-print claim, and lock for the deferred network stage session start runs off its blocking path; bin/fm-startup-network.sh
-  .wake-queue        durable queued wakes retained until post-handling acknowledgement: epoch<TAB>seq<TAB>kind<TAB>key<TAB>payload
-  .watcher-down      private generation-bound recovery state coupling watcher downtime, durable wake presentation, and post-handling acknowledgement; never touch
-  .<id>.open-decisions-cursor  per-task byte cursor and folded open-decision set bounding the OPEN DECISIONS scan's cost to new status-log appends; written only by fm-classify-lib.sh's status_open_decisions_incremental, removed by teardown, safe to delete (forces one full re-fold)
-  .afk               durable away-mode flag; present = sub-supervisor may inject escalations (set by /afk, cleared on user return)
-  .watch.lock .wake-queue.lock watcher singleton and queue serialization locks
-  .claude-autoarm.lock .claude-autoarm-epoch .claude-autoarm-failure-notified .claude-autoarm-failure-alarmed .turnend-claude-blocks .turnend-claude-blocks.lock   Claude Stop auto-arm single-flight, epoch, failure-episode, attended-alarm, guard-budget, and budget-lock records; never touch
-  .hash-* .count-* .stale-* .stale-since-* .paused-* .wedge-escalations-* .seen-* .hb-surfaced-* .last-* .heartbeat-streak   watcher internals; never touch
-  .watch-triage.log  watcher's absorbed-wake debug log (size-capped); never relied on, safe to delete
-  .last-watcher-beat watcher liveness beacon, touched every poll (including while absorbing benign wakes); guard scripts read it
-  .subsuper-* .supervise-daemon.*   sub-supervisor internals; never touch
-.no-mistakes/        local validation state and evidence; gitignored
-```
-
-A `state/<id>.status` line is a wake event, not current-state truth; `bin/fm-crew-state.sh` owns current-state reconciliation.
-Treat `data/captain.md` as the domain-local record of captain preferences, optional `data/captain-shared.md` as the main-authoritative shared captain-preference file for secondmate inheritance, and `data/learnings.md` as curated home-local knowledge, regardless of harness memory.
+Section 1 lists the shared tracked material.
+`data/` holds durable private fleet records, `state/` holds volatile runtime records, `config/` holds local operating choices, and `projects/` contains project clones.
+`.env` and `.no-mistakes/` are local and gitignored.
 
 ## 3. Session start (run once at every session start)
 
@@ -145,28 +71,10 @@ An `ABSENT` captain, shared-captain, secondmate, or learnings file means the fir
 If the session lock cannot be acquired and verified, report its exact diagnostic and remain read-only; another active session is only one possible cause.
 A lock-refused session must not spawn, steer, merge, drain the wake queue, repair supervision, repair a checkout, or perform any other fleet mutation.
 
-The digest itself makes no external-network call and never waits for one.
-Every network check a session start owes - GitHub auth, dead-secondmate relaunch, secondmate convergence, pending handoff delivery, and project clone refresh - runs concurrently in a bounded worker owned by `bin/fm-startup-network.sh` and is reported in the digest's own `NETWORK CHECKS` section.
-When that section reports its checks still in progress it names exactly what is unconfirmed; treat none of those as passed until the result lands, either from `bin/fm-startup-network.sh report` or as a `check: startup-network` wake.
-
-1. **Lock** - acquires the per-home session lock first, before anything mutates shared state, then starts the deferred network stage above.
-2. **Bootstrap** - detect-only checks (tool/version problems, the worktree-tangle check, harness override, dispatch-profile validation, backlog-backend status) always run, but routine confirmations stay silent by default.
-   When the lock could not be acquired, the worktree-tangle check uses read-only advisory wording without a checkout repair command.
-   Home-local stale Herdr projection cleanup and the six bootstrap MUTATING sweeps - non-executing legacy PR-check migration, fleet sync, secondmate convergence, secondmate liveness, pending remote handoff retry, and Relay artifact writes - run only when this session actually holds the lock from step 1; the four network ones among them run in the deferred stage rather than in this section.
-   The secondmate liveness sweep deterministically accounts for every registered secondmate: it relaunches only from the recovery-grade `dead` or `missing` states, preserves ambiguous, unreadable, or unreachable remote targets, and reports skipped or failed guarantees as `SECONDMATE_LIVENESS:` lines (`bin/fm-bootstrap.sh`; `bin/fm-backend.sh`'s `fm_backend_agent_state`; `docs/remote-secondmates.md`).
-3. **Wake queue** - when locked, presents the durable wake queue and prints the raw records prominently as this turn's first work queue; a bounded, clearly labeled historical status-event annotation may follow a valid `signal` record but never replaces it or current-state reconciliation, and a lapsed watcher chain still surfaces here via the same guard alarm.
-   Presented records remain durable until the handling turn runs the generation-bound acknowledgement printed by the drain.
-   Every locked drain also prints a bounded fleet-wide `OPEN DECISIONS` section when durable decision records remain open, including when the queue itself is empty; reconcile those entries before continuing.
-   When the lock could not be acquired and verified, the queue is left untouched because no session mutation is authorized, and the guard's tangle/watcher-liveness alarms still print in read-only advisory mode without drain, supervision repair, or checkout repair commands.
-4. **Supervision operating instructions** - after the wake queue and before both digests, the digest emits exactly one operating block for the detected primary harness, followed by the read-once contract that governs them.
-   The script itself never starts supervision; the emitted harness protocol owns the exact wait or wake mechanism.
-5. **Fleet-state digest** - after that read-once contract and ahead of the context digest, the compact backlog listing owned by `bin/fm-session-start.sh`; every `state/<id>.meta`; a bounded tail of each task's `state/<id>.status` (labeled as wake-EVENT history, not current state, with the full log path printed for a deeper read); the `state/.afk` flag; and one cheap alive/dead read of each task's recorded backend endpoint.
-   That liveness line is a fast presence check only, not a full state read - when you need a crew's actual current state (a run-step, not just "is the pane there"), read it with `bin/fm-crew-state.sh <id>` as before; the digest deliberately skips that deeper, slower read for every task so it stays fast and bounded.
-6. **Network checks** - after the fleet-state digest, the deferred stage's result, or an explicit statement of what it has not confirmed yet.
-   A read-only session runs no network checks at all and says so.
-7. **Context digest and next step** - last of the bulk sections, the full contents of `data/projects.md`, `data/secondmates.md`, `data/captain.md`, `data/captain-shared.md`, and `data/learnings.md`, each clearly delimited, followed by the closing reminder.
-   A file that does not exist prints an explicit `ABSENT` marker, never confused with an empty-but-present file: absence is meaningful (`captain.md` absent means use the firstmate repo's built-in defaults, `projects.md` absent means rebuild it from the clones under `projects/`, etc.).
-   The closing reminder points back to the emitted supervision block and preserves only the lock, afk, Relay, and read-once reminders.
+The digest owns its lock result, queued wakes, open decisions, supervision instructions, fleet state, network-check result, durable context, and next step.
+Act on those live results rather than reconstructing them from this file.
+Its local phase makes no external-network call and never waits for one; `bin/fm-startup-network.sh` owns the concurrent bounded network phase.
+Treat every network check reported in progress as unconfirmed until its result lands through the command or wake named by the digest.
 
 Bootstrap detects first, asks for consent, and installs only after the captain approves in the current session.
 Do not dispatch until the required tools are present and GitHub authentication is good.
@@ -329,12 +237,8 @@ The task worker that starts a no-mistakes run drives the pipeline and owns every
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
 Once validation starts, prefer routing new requirements to follow-up work rather than expanding the current task, unless a new requirement completely invalidates the work being validated; however, the smallest downstream changes needed to keep already accepted product or engineering behavior correct, add behavioral tests where an executable contract exists, or keep documentation accurate remain within the current task even when they touch files not named at intake, and corrections required to satisfy already accepted intent are not new requirements.
 
-Only a current, explicit captain instruction that completely invalidates the work being validated keeps the task with the same worker instead of routing it to follow-up work or handing it to a replacement.
-That worker cancels the active run through no-mistakes axi's supported abort command and confirms through axi status that the run has stopped before changing any code.
-The worker then follows `branch_sync.next_action` from structured axi status: use axi sync's supported guarded recovery only when its code is `recover_custody`, and otherwise proceed only when structured status confirms that branch ownership is already returned and no recovery is required.
-Custody recovery settles branch ownership, not content: the worker must replace the obsolete work from the correct pre-invalidation base rather than building on top of the recovered-but-obsolete head, keeping the obsolete run's own pipeline-fix commits out of what gets validated and shipped.
-Apart from that single supported abort, do not hand-edit, commit, restart, or start a second validation run while the obsolete run still owns the branch.
-Once ownership is settled, validate exactly once against that final head so no obsolete or intermediate head is ever treated as authoritative.
+Do not hand-edit, commit, abort, restart, or start a second validation run while no-mistakes owns the branch.
+Only when a current, explicit captain instruction completely invalidates the work being validated, keep the task with the same worker and load `validation-supersession` before acting; that skill owns supported abort, custody recovery, obsolete-work replacement, and final-head revalidation.
 
 An ask-user finding returns as `needs-decision`; firstmate decides only when the configured authority permits, otherwise escalates to the captain.
 Send the same worker one exact decision naming the decision key, step, action, affected finding IDs, instructions where needed, and exact response command, passing `--resolve-key` so the worker's open decision record closes at answer time.
@@ -343,7 +247,6 @@ Resume fleet supervision immediately after the decision lands.
 
 Judge validation by the current-code-matched run step through `bin/fm-crew-state.sh`, not by shell liveness or the last status event.
 Running, fixing, or CI states remain working; parked approval or fix-review states require the worker to follow the active gate help; passed or checks-passed is done; failed or cancelled is failed.
-A worker hand-editing, committing, aborting, or restarting during an active validation run duplicates pipeline ownership outside the supersession sequence above; steer it back to the gate response flow.
 The worker reports the PR when CI first becomes green rather than waiting for merge monitoring to finish.
 
 ### PR ready, landing, and teardown
@@ -527,24 +430,9 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `decision-hold-lifecycle` - load before treating an investigation or visual review as complete, before ending a visual review that exposed a decision, and when recording or routing the captain's answer.
 - `process-event-sources` - load before arming a long-polling source, before registering a deterministic condition->action watch (do X as soon as Y is true), and on any `procevent <adapter> <source-id> <sequence>` check wake.
   Never run a registered source's blocking command yourself in a conversational turn.
-- `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the Relay configuration blocker, on a `public-followup ...` `check:` wake or a startup-surfaced public commitment, and on any milestone or terminal wake for a Relay-linked task before posting its completion follow-up; relevant only when Relay is on.
+- `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the Relay configuration blocker, before promising a final public reply, on a `public-followup ...` `check:` wake or a startup-surfaced public commitment, and on any milestone or terminal wake for a Relay-linked task before posting its completion follow-up; relevant only when Relay is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
-
-## 14. Relay
-
-Relay is the public-mention integration older docs and some emitted lines still call "X mode"; its identifiers keep the `FMX_`, `x-`, and `fm-x-` spellings.
-Relay ships inert and causes no behavior change until the home opts in by placing `FMX_PAIRING_TOKEN` in its gitignored `.env`.
-That token is consent for public replies and normal reversible lifecycle actions from eligible mentions, not authority for destructive, irreversible, or security-sensitive action; those still require trusted-channel confirmation.
-`docs/configuration.md` owns activation, generated state, cadence, wire protocol, and opt-out mechanics.
-
-A Relay-only home still requires the live supervision cycle so mentions can wake it without fleet work.
-On an `x-mention <request_id>` or `x-mode-error ...` check wake, load `fmx-respond`, which owns classification, public-safety policy, reply or dismissal, task linking, and follow-ups.
-For every Relay-linked terminal outcome, load that owner and use the promised-final reconciliation when a typed public commitment exists, otherwise post the final completion follow-up before teardown.
-
-A promised final public reply is durable state, never conversation memory.
-Load `fmx-respond` before promising one, on a `public-followup ...` check wake, and whenever the session-start digest lists a public commitment awaiting delivery.
-Only the home holding the relay consent and thread binding ever posts it, so never ask a secondmate or crewmate to find the thread or send the reply, and never recover a terminal result by reading a `done:` sentence.
 
 ## Captain instruction precedence
 

--- a/bin/fm-doc-audience-check.sh
+++ b/bin/fm-doc-audience-check.sh
@@ -183,6 +183,32 @@ def validate(root: Path, inventory_path: Path) -> tuple[int, int]:
             details.append("not tracked/in scope: " + ", ".join(extra))
         fail("; ".join(details))
 
+    word_limits = data.get("agentRuntimeWordLimits")
+    if not isinstance(word_limits, list) or not word_limits:
+        fail("agentRuntimeWordLimits must be a non-empty array")
+    limited_paths: list[str] = []
+    for index, entry in enumerate(word_limits):
+        if not isinstance(entry, dict):
+            fail(f"agentRuntimeWordLimits[{index}] must be an object")
+        path = entry.get("path")
+        maximum = entry.get("maxWords")
+        if not isinstance(path, str) or not path:
+            fail(f"agentRuntimeWordLimits[{index}].path must be a non-empty string")
+        if not isinstance(maximum, int) or isinstance(maximum, bool) or maximum <= 0:
+            fail(f"agentRuntimeWordLimits[{index}].maxWords must be a positive integer")
+        if classifications.get(path) != "agent-runtime":
+            fail(f"agent-runtime word limit path is not classified agent-runtime: {path}")
+        limited_paths.append(path)
+        try:
+            words = len((root / path).read_text(encoding="utf-8").split())
+        except (OSError, UnicodeDecodeError) as exc:
+            fail(f"cannot read agent-runtime word limit path {path}: {exc}")
+        if words > maximum:
+            fail(f"{path} exceeds agent-runtime word limit: {words} > {maximum}")
+    duplicate_limits = sorted(path for path, count in Counter(limited_paths).items() if count != 1)
+    if duplicate_limits:
+        fail("agent-runtime word limits declared more than once: " + ", ".join(duplicate_limits))
+
     readme_path = root / "README.md"
     readme_targets = {
         os.path.relpath(target, root).replace(os.sep, "/")

--- a/bin/fm-remote-job-lib.sh
+++ b/bin/fm-remote-job-lib.sh
@@ -884,7 +884,9 @@ fm_remote_job_probe() { # <account-home>; a fresh worker heartbeat or active job
 
 fm_remote_job_wait_for_probe() { # <remote-root> <account-home>
   local root=$1 account_home=$2 i=0
-  while [ "$i" -lt 200 ]; do
+  # A replacement can spend 15 seconds waiting out the prior lock owner before
+  # its supervisor's first bounded restart, so leave that restart time to boot.
+  while [ "$i" -lt 300 ]; do
     fm_remote_job_probe "$account_home" && fm_remote_job_worker_identity_matches "$root" "$account_home" && return 0
     i=$((i + 1))
     sleep 0.1

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -23,6 +23,12 @@
     "operator-current",
     "operator-example"
   ],
+  "agentRuntimeWordLimits": [
+    {
+      "path": "AGENTS.md",
+      "maxWords": 7500
+    }
+  ],
   "readmeSetupTargets": [
     "docs/configuration.md",
     "docs/wedge-alarm.md",
@@ -182,6 +188,10 @@
     },
     {
       "path": ".agents/skills/updatefirstmate/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
+      "path": ".agents/skills/validation-supersession/SKILL.md",
       "audience": "agent-runtime"
     },
     {

--- a/docs/documentation-audiences.md
+++ b/docs/documentation-audiences.md
@@ -1,7 +1,7 @@
 # Documentation audiences
 
 [`documentation-audiences.json`](documentation-audiences.json) is the machine-consumed classification owner for every maintained prose surface.
-`bin/fm-doc-audience-check.sh` validates exact inventory coverage, README setup routing, required owner pointers, and local link targets.
+`bin/fm-doc-audience-check.sh` validates exact inventory coverage, the always-loaded agent-runtime word limit, README setup routing, required owner pointers, and local link targets.
 Audience metadata is centralized there rather than copied into front matter on every page.
 
 The audience classes have one placement purpose each:
@@ -14,6 +14,7 @@ The audience classes have one placement purpose each:
 - `agent-runtime` is loaded or rendered as an operating contract for Firstmate agents rather than read as product documentation.
 
 The knowledge-placement policy is owned by [`firstmate-coding-guidelines`](../.agents/skills/firstmate-coding-guidelines/SKILL.md).
+The inventory's `agentRuntimeWordLimits` keeps `AGENTS.md` within a reviewable ceiling while conditional procedures live behind precise skill triggers.
 Task-specific chronology, delivery transcripts, temporary paths, branches, failed hypotheses, and one-off process identifiers stay in private task reports or PR evidence by default.
 Before removing that evidence from a tracked page, distill every unique current fact into its classified owner and retain a focused regression pointer.
 

--- a/tests/fm-documentation-audiences.test.sh
+++ b/tests/fm-documentation-audiences.test.sh
@@ -131,6 +131,11 @@ MD
   "$CHECK" --root "$repo" >/dev/null \
     || fail "structural checker rejected legitimate maintainer evidence prose"
 
+  printf '%s\n' '# Agent runtime' 'one two three four five six seven' > "$repo/AGENTS.md"
+  git -C "$repo" add AGENTS.md
+  "$CHECK" --root "$repo" >/dev/null \
+    || fail "agent-runtime word limit rejected a document at the exact boundary"
+
   printf '%s\n' '# Agent runtime' 'one two three four five six seven eight nine' > "$repo/AGENTS.md"
   git -C "$repo" add AGENTS.md
   run_expect_failure "AGENTS.md exceeds agent-runtime word limit" "$CHECK" --root "$repo"

--- a/tests/fm-documentation-audiences.test.sh
+++ b/tests/fm-documentation-audiences.test.sh
@@ -91,13 +91,15 @@ write_fixture_inventory() {
 {
   "version": 1,
   "scope": {"trackedPatterns": ["*.md", "*.mdx", "*.rst", "*.txt", "docs/examples/*"]},
-  "allowedAudiences": ["public-product", "operator-current", "maintainer-verification"],
+  "allowedAudiences": ["public-product", "operator-current", "maintainer-verification", "agent-runtime"],
   "setupAudiences": ["public-product", "operator-current"],
+  "agentRuntimeWordLimits": [{"path": "AGENTS.md", "maxWords": 10}],
   "readmeSetupTargets": ["docs/setup.md"],
   "requiredOwnerPointers": [
     {"source": "README.md", "target": "docs/policy.md"}
   ],
   "surfaces": [
+    {"path": "AGENTS.md", "audience": "agent-runtime"},
     {"path": "README.md", "audience": "public-product"},
     {"path": "docs/evidence.md", "audience": "maintainer-verification"},
     {"path": "docs/policy.md", "audience": "operator-current"},
@@ -111,6 +113,7 @@ test_local_links_and_no_keyword_heuristic() {
   local repo="$TMP_ROOT/fixture"
   mkdir -p "$repo/docs"
   git -C "$repo" init -q
+  printf '%s\n' '# Agent runtime' 'Keep this concise.' > "$repo/AGENTS.md"
   printf '%s\n' '[Setup](docs/setup.md) [Policy](docs/policy.md)' > "$repo/README.md"
   printf '%s\n' '# Setup' > "$repo/docs/setup.md"
   printf '%s\n' '# Policy' > "$repo/docs/policy.md"
@@ -124,15 +127,21 @@ test_local_links_and_no_keyword_heuristic() {
 Observed version 1.2.3 on branch `fm/example`.
 MD
   write_fixture_inventory "$repo"
-  git -C "$repo" add README.md docs
+  git -C "$repo" add AGENTS.md README.md docs
   "$CHECK" --root "$repo" >/dev/null \
     || fail "structural checker rejected legitimate maintainer evidence prose"
+
+  printf '%s\n' '# Agent runtime' 'one two three four five six seven eight nine' > "$repo/AGENTS.md"
+  git -C "$repo" add AGENTS.md
+  run_expect_failure "AGENTS.md exceeds agent-runtime word limit" "$CHECK" --root "$repo"
+  printf '%s\n' '# Agent runtime' 'Keep this concise.' > "$repo/AGENTS.md"
+  git -C "$repo" add AGENTS.md
 
   printf '%s\n' '[Setup](docs/setup.md) [Policy](docs/policy.md) [Broken](docs/missing.bin)' \
     > "$repo/README.md"
   git -C "$repo" add README.md
   run_expect_failure "unresolved local link" "$CHECK" --root "$repo"
-  pass "local links resolve while dates, versions, commands, and incident prose remain semantically reviewed"
+  pass "agent-runtime word limits and local links fail safely without keyword-linting evidence"
 }
 
 test_repository_inventory_passes

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -316,10 +316,10 @@ pass "the worker expires queued jobs before they can mutate"
 
 FIRST_DELAYED_SIDE_EFFECT="$TMP_ROOT/first-delayed-side-effect"
 SECOND_DELAYED_SIDE_EFFECT="$TMP_ROOT/second-delayed-side-effect"
-FM_REMOTE_JOB_QUEUE_TIMEOUT=5
-FM_REMOTE_JOB_TIMEOUT=3
+FM_REMOTE_JOB_QUEUE_TIMEOUT=6
+FM_REMOTE_JOB_TIMEOUT=5
 fm_remote_job_stage "$ACCOUNT_HOME" "$REMOTE_ROOT" "$REMOTE_HOME" \
-  fm-delay-job.sh 1.8 "$FIRST_DELAYED_SIDE_EFFECT" < /dev/null > /dev/null
+  fm-delay-job.sh 3 "$FIRST_DELAYED_SIDE_EFFECT" < /dev/null > /dev/null
 FIRST_JOB_ID=$FM_REMOTE_JOB_ID
 FIRST_JOB_DIR="$STATE_ROOT/jobs/$FIRST_JOB_ID"
 for _ in $(seq 1 100); do
@@ -328,8 +328,9 @@ for _ in $(seq 1 100); do
 done
 [ "$(fm_remote_job_read_state "$FIRST_JOB_DIR" 2>/dev/null || true)" = running ] \
   || fail "the first delayed job did not begin running"
+FM_REMOTE_JOB_TIMEOUT=2
 fm_remote_job_stage "$ACCOUNT_HOME" "$REMOTE_ROOT" "$REMOTE_HOME" \
-  fm-delay-job.sh 1.8 "$SECOND_DELAYED_SIDE_EFFECT" < /dev/null > /dev/null
+  fm-delay-job.sh 0.1 "$SECOND_DELAYED_SIDE_EFFECT" < /dev/null > /dev/null
 JOB_ID=$FM_REMOTE_JOB_ID
 fm_remote_job_wait "$ACCOUNT_HOME" "$FIRST_JOB_ID" || fail "$FM_REMOTE_JOB_ERROR"
 fm_remote_job_wait "$ACCOUNT_HOME" "$JOB_ID" || fail "$FM_REMOTE_JOB_ERROR"


### PR DESCRIPTION
## Summary

- Apply Firstmate's own knowledge-placement and one-owner rules to the always-loaded `AGENTS.md` contract.
- Replace the duplicated operational-home inventory and session-start stage narration with concise owner pointers.
- Move exceptional validation-supersession mechanics into a precisely triggered agent-only skill.
- Remove the conditional Relay section while preserving the pre-trigger supervision rule inline and keeping all five prime safety rules unchanged.
- Add an executable documentation-audience word-budget guard so future growth fails the maintained documentation check.

## Reproduction

Before the fix, `wc -w AGENTS.md` reported 8,972 words.
The original file also carried 58 field-level layout entries, seven narrated session-start stages, seven lines of validation-supersession procedure, and a 222-word always-loaded Relay section.
Running the new executable documentation-audience limit against the original head fails with `AGENTS.md exceeds agent-runtime word limit: 8972 > 7500`.
At this PR's final head, the same checker passes and `AGENTS.md` contains 6,689 words.

## Decisions

Section 14's Relay activation, generated-state, cadence, and protocol details moved to `docs/configuration.md`, their existing authoritative owner.
Relay mention handling, public-safety policy, reply/dismissal, task linking, completion follow-ups, and pairing-token authorization boundaries moved to `fmx-respond`, which loads on every `x-mention`, `x-mode-error`, `public-followup`, startup-surfaced public commitment, and Relay-linked milestone or terminal wake before any reply or lifecycle action occurs.
The pairing token remains consent for public replies and normal reversible lifecycle actions, never for destructive, irreversible, or security-sensitive action.
That rule needs no earlier effect because no such reply or action occurs before the mandatory `fmx-respond` trigger loads the owner.
The Relay-only supervision rule does need effect before a mention can wake the session, so it remains explicitly inline in AGENTS.md section 8: a Relay-only home requires the live supervision cycle even with no other fleet work.

The validation-supersession procedure moved into `validation-supersession`, which loads only when a current explicit captain instruction completely invalidates an active no-mistakes run.
AGENTS.md retains the prohibition on hand-editing, committing, aborting, restarting, or starting a second validation run while no-mistakes owns the branch.

The no-mistakes review added the new skill to the section 13 agent-only catalog.
Its documentation pass also replaced the coding-guideline skill's stale enumeration of documentation-check responsibilities with a pointer to the single owner.

## Validation

- `bin/fm-doc-audience-check.sh`
- `bin/fm-lint.sh` with pinned ShellCheck 0.11.0
- `bin/fm-test-run.sh tests/fm-documentation-audiences.test.sh`
- `bin/fm-test-run.sh --changed --base origin/main`: 29 passed, 0 failed, 2 declared tool-gated skips
- no-mistakes review, targeted tests, documentation review, and lint all completed without remaining findings on exact head `545ad48120fb53eeca158156b97f61796b23d085`

Browser validation is not applicable because this repository has no browser-facing surface.
Cypress was not run because this repository has no Cypress suite.
No database is involved.

Closes #1955


## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

> Provenance note: this section was written by the delivery worker rather than emitted by the
> pipeline. The `pr` step attempted to write it and was rejected by GitHub with
> `gh pr edit: GraphQL: ... The 'login' field requires one of the following scopes: ['read:org'],
> but your token has only been granted the: ['repo', 'workflow'] scopes.` The step results below
> are reproduced verbatim from run `01KZT0RBZ798EEAVTT9WFH40YM`, which owns this branch.

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found remaining. Findings raised during this step were applied by the pipeline in
commit `62c392c` (`no-mistakes(review): docs(agents): list validation-supersession in agent-only
skill catalog`).

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `fm-documentation-audiences.test.sh`
- `bin/fm-test-run.sh --changed --base origin/main`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found remaining. Findings raised during this step were applied by the pipeline in
commit `f6931a8` (`no-mistakes(document): docs(agents): repoint stale doc-check enumeration to its
owner`).

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏳ **CI** - in progress</summary>

Not yet passed at the time this section was written. Every repository check on head `6581bbc8`
passed except `PR must be raised via no-mistakes`, which failed solely because the marker line
above was missing from this body. This edit supplies it so that check can re-run.

</details>
