### PR TITLE
fix(spawn): enforce verified reasoning effort launches

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -148,8 +148,8 @@ For an unfamiliar harness or model namespace, establish support and provider ide
 A listing that reaches the account and does not contain the model is concrete evidence the model is unsupported: block that candidate and quote the result.
 A discovery surface you could not reach establishes nothing; report that as uncertainty rather than turning it into a supported or unsupported verdict.
 
-When a requested effort value is outside the harness-specific accepted set, `fm-spawn` records the requested `effort=` in meta but emits no effort flag for that harness.
-This preserves launch success instead of passing a known-bad value.
+When a requested effort value is outside the harness-specific accepted set, `fm-spawn` refuses before writing metadata or launching the worker.
+This preserves the invariant that recorded effort always matches the launch flag.
 
 ## no-mistakes skill invocation
 

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -120,12 +120,12 @@ The supported launch-profile flags below are verified locally; each row records 
 | Harness | Model flag | Effort flag | Notes |
 |---|---|---|---|
 | claude | `--model <model>` | `--effort <low\|medium\|high\|xhigh\|max>` | Verified on Claude Code 2.1.196. |
-| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'` | Verified on codex-cli 0.142.1. The installed binary schema contains `model_reasoning_effort`, the active config uses it, and the bundled model catalog advertises only low/medium/high/xhigh. `max` is omitted. |
-| grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
+| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh\|max>"'` | Verified on codex-cli 0.147.0 (2026-08-08) by a successful ephemeral `gpt-5.6-luna` run at `max`. |
+| grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. The ceiling is `high`; requested `xhigh` and `max` refuse before metadata or launch. |
 | pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
-| opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
-| kimi | `--model <model>` | none | Verified 2026-07-25 on Kimi Code CLI 0.29.1. |
-| muse | `--model <model>` | `--reasoning-effort <low\|medium\|high\|xhigh>`, and `ultra` only for an explicit `max` | Verified 2026-08-05 on Muse Code 0.1.0-R708.1. The flag accepts `none\|minimal\|low\|medium\|high\|xhigh\|ultra` and defaults to `high`. `ultra` is muse's max-class level, so it is reachable only through an explicit captain `max`, never from the generic fallback; `none` and `minimal` sit below the shared vocabulary and stay unreachable. |
+| opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag, so any non-default request refuses before metadata or launch. |
+| kimi | `--model <model>` | none | Verified 2026-07-25 on Kimi Code CLI 0.29.1. Any non-default effort request refuses before metadata or launch. |
+| muse | `--model <model>` | `--reasoning-effort <low\|medium\|high\|xhigh>` | Verified 2026-08-05 on Muse Code 0.1.0-R708.1. The flag accepts `none\|minimal\|low\|medium\|high\|xhigh\|ultra` and defaults to `high`; only the shared literal levels through `xhigh` launch, while `max` refuses rather than mapping to `ultra`. |
 
 The concrete `harness` field owns adapter identity independently of the model provider: `harness=pi` with `model=xai/grok-*` is Pi using xAI, not `harness=grok`, and does not require Grok CLI login; `harness=grok` remains the standalone Grok Build CLI adapter.
 No script resolves that split for you: establish which credential store a tuple reads from the discovery surfaces below plus `quota-axi auth --json`'s per-provider sources, and show that reasoning rather than inferring it from a harness, model, or source name.
@@ -306,7 +306,7 @@ When a secondmate is launched on Pi or pi-signed, `fm-spawn.sh --secondmate` lau
 
 Grok Build TUI (`grok`), a Claude-Code-compatible CLI from xAI.
 Launch with a positional prompt: `grok --always-approve "$(cat <brief>)"`.
-For Grok's supported reasoning-effort values and omission behavior, see the [launch-profile-axes table](#launch-profile-axes).
+For Grok's supported reasoning-effort values and refusal behavior, see the [launch-profile-axes table](#launch-profile-axes).
 
 | Fact | Value |
 |---|---|
@@ -376,7 +376,7 @@ Kimi Code CLI launches from the absolute path resolved from `PATH`, falling back
 | Slash submission | One Enter submits, with no popup swallow or settle hazard. |
 | Environment marker | None; detection relies on process ancestry command name `kimi`. |
 | Composer | Bordered box with a bare `>` prompt glyph and no observed ghost or placeholder text. |
-| Effort | No reasoning-effort flag exists, so requested effort is recorded in task metadata but omitted from launch. |
+| Effort | No reasoning-effort flag exists, so a non-default requested effort refuses before metadata or launch. |
 
 `fm-spawn.sh` launches Kimi bare, waits for the composer box or `Welcome to Kimi Code!`, sends only `Read the brief at <absolute-path> and follow it exactly.`, and requires a cleared composer plus either the echoed `✨` submission or nonzero context before accepting delivery.
 This launch-then-send shape is mandatory because Kimi rejects a positional brief as an unknown command.
@@ -417,7 +417,7 @@ Muse Code is a CREWMATE and SCOUT adapter only.
 | Trust dialog | `Do you trust this workspace?` with `1 Trust and continue` preselected, accepted by Enter. `--yolo` suppresses it entirely, which is what firstmate relies on because every task gets a fresh worktree path. |
 | Environment marker | None. Detection is process ancestry on the anchored prefix `muse-bin-*`. The launch clears foreign primary markers before Muse starts so their higher detection precedence cannot override that ancestry. `MUSE_CURRENT_SESSION_LOG` is a session-log PATH rather than an identity, and its export to tool subprocesses is unverified. |
 | Composer | Bordered box whose prompt glyph is `⟩` (U+27E9) in truecolor `38;2;90;160;255`, luminance ~149.9 - the narrowest margin over the 128 ghost threshold in the fleet. Typed text is `38;2;204;211;219` (~209.8). No idle placeholder or ghost text was observed. |
-| Effort | `--reasoning-effort`, default `high`; see the launch-profile table above for the mapping. |
+| Effort | `--reasoning-effort`, default `high`; see the launch-profile table above for accepted shared levels. |
 | Resume | `muse resume --last` or `muse resume <session-uuid>`; bare `muse resume` opens a picker. |
 
 ### Credentials are a spawn preflight, not a screen check

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1002,10 +1002,10 @@ crew_dispatch_validate() {
       if $e == null then true
       elif ($e | type) != "string" then false
       elif $h == "claude" then (["low","medium","high","xhigh","max"] | index($e))
-      elif $h == "codex" then (["low","medium","high","xhigh"] | index($e))
+      elif $h == "codex" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "grok" then (["low","medium","high"] | index($e))
       elif $h == "pi" or $h == "pi-signed" then (["low","medium","high","xhigh","max"] | index($e))
-      elif $h == "muse" then (["low","medium","high","xhigh","max"] | index($e))
+      elif $h == "muse" then (["low","medium","high","xhigh"] | index($e))
       elif $h == "opencode" or $h == "kimi" then false
       else true
       end;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -36,8 +36,8 @@
 #   positional harness arg still works for back-compat.
 #   --model <name> and --effort <low|medium|high|xhigh|max> are concrete profile
 #   axes chosen by firstmate at intake. They are only threaded into harnesses whose
-#   installed CLIs were verified to support that axis; unsupported axes are omitted
-#   from that harness's launch rather than guessed.
+#   installed CLIs were verified to support that axis; unsupported requested axes
+#   refuse before metadata and launch rather than guessed.
 #   --backend <name> is the explicit runtime session-provider backend for this
 #   exact task only (docs/configuration.md "Runtime backend" owns when that flag
 #   is authorized). Without it, the script resolves FM_BACKEND, then
@@ -383,6 +383,32 @@ else
   fi
 fi
 
+effort_flag_for_harness() {
+  local harness=$1 effort=$2
+  [ -n "$effort" ] && [ "$effort" != default ] || return 0
+  case "$harness:$effort" in
+    claude:low|claude:medium|claude:high|claude:xhigh|claude:max)
+      printf -- "--effort '%s' " "$effort"
+      ;;
+    codex:low|codex:medium|codex:high|codex:xhigh|codex:max)
+      printf -- "-c 'model_reasoning_effort=\"%s\"' " "$effort"
+      ;;
+    grok:low|grok:medium|grok:high)
+      printf -- "--reasoning-effort '%s' " "$effort"
+      ;;
+    pi:low|pi:medium|pi:high|pi:xhigh|pi:max|pi-signed:low|pi-signed:medium|pi-signed:high|pi-signed:xhigh|pi-signed:max)
+      printf -- "--thinking '%s' " "$effort"
+      ;;
+    muse:low|muse:medium|muse:high|muse:xhigh)
+      printf -- "--reasoning-effort '%s' " "$effort"
+      ;;
+    *)
+      echo "error: refusing $harness spawn with effort '$effort': no verified launch flag expresses that exact effort" >&2
+      return 1
+      ;;
+  esac
+}
+
 spawn_remote_secondmate() {
   local id=$1 remote host root home harness positional model effort backend out rc meta tmp
   local remote_backend remote_target remote_harness remote_herdr_session registry_lock remote_lock remote_generation
@@ -446,6 +472,11 @@ spawn_remote_secondmate() {
       [ -n "$effort" ] || effort=-
     fi
   fi
+  effort_flag_for_harness "$harness" "$effort" >/dev/null || {
+    fm_lock_release "$registry_lock" || true
+    fm_lock_release "$SPAWN_TASK_LOCK" || true
+    return 1
+  }
   # A remote second mate always runs on Herdr: its server belongs to the host's
   # own GUI login session, so the endpoint outlives every SSH connection that
   # supervises it. bin/fm-remote-doctor.sh gates that host on the same
@@ -1323,49 +1354,6 @@ model_flag_for_harness() {
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
   esac
-}
-
-effort_flag_for_harness() {
-  local harness=$1 effort=$2
-  [ -n "$effort" ] && [ "$effort" != default ] || return 0
-  case "$harness" in
-    claude)
-      case "$effort" in
-        low|medium|high|xhigh|max) printf -- '--effort %s ' "$(shell_quote "$effort")"; return 0 ;;
-      esac
-      ;;
-    codex)
-      # Codex 0.147.0 accepts every shared effort level through its
-      # model_reasoning_effort config key, including max.
-      case "$effort" in
-        low|medium|high|xhigh|max) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")"; return 0 ;;
-      esac
-      ;;
-    grok)
-      # Grok exposes both --effort and --reasoning-effort; firstmate's profile
-      # axis is the reasoning knob, which accepts only low, medium, and high.
-      case "$effort" in
-        low|medium|high) printf -- '--reasoning-effort %s ' "$(shell_quote "$effort")"; return 0 ;;
-      esac
-      ;;
-    pi|pi-signed)
-      # Pi accepts the full shared effort vocabulary through its --thinking flag.
-      case "$effort" in
-        low|medium|high|xhigh|max) printf -- '--thinking %s ' "$(shell_quote "$effort")"; return 0 ;;
-      esac
-      ;;
-    muse)
-      # Muse accepts low through xhigh literally.
-      # Its ultra level is not firstmate's max, so it is deliberately not mapped.
-      case "$effort" in
-        low|medium|high|xhigh) printf -- '--reasoning-effort %s ' "$(shell_quote "$effort")"; return 0 ;;
-      esac
-      ;;
-    # OpenCode's interactive launch and Kimi have no verified effort flag.
-  esac
-
-  echo "error: refusing $harness spawn with effort '$effort': no verified launch flag expresses that exact effort" >&2
-  return 1
 }
 
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT") || exit 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1331,54 +1331,44 @@ effort_flag_for_harness() {
   case "$harness" in
     claude)
       case "$effort" in
-        low|medium|high|xhigh|max) printf -- '--effort %s ' "$(shell_quote "$effort")" ;;
+        low|medium|high|xhigh|max) printf -- '--effort %s ' "$(shell_quote "$effort")"; return 0 ;;
       esac
       ;;
     codex)
-      # The installed codex config schema uses model_reasoning_effort, and the
-      # bundled model catalog advertises low|medium|high|xhigh. Omit max rather
-      # than passing an unsupported value.
+      # Codex 0.147.0 accepts every shared effort level through its
+      # model_reasoning_effort config key, including max.
       case "$effort" in
-        low|medium|high|xhigh) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")" ;;
+        low|medium|high|xhigh|max) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")"; return 0 ;;
       esac
       ;;
     grok)
-      # grok exposes both --effort and --reasoning-effort; firstmate's profile
-      # axis is the reasoning knob. As of grok 0.2.99, --reasoning-effort accepts
-      # only low|medium|high and rejects both xhigh and max, so omit those rather
-      # than passing a known-bad value.
+      # Grok exposes both --effort and --reasoning-effort; firstmate's profile
+      # axis is the reasoning knob, which accepts only low, medium, and high.
       case "$effort" in
-        low|medium|high) printf -- '--reasoning-effort %s ' "$(shell_quote "$effort")" ;;
+        low|medium|high) printf -- '--reasoning-effort %s ' "$(shell_quote "$effort")"; return 0 ;;
       esac
       ;;
     pi|pi-signed)
-      # Pi 0.80.6 accepts the full shared effort vocabulary, including max, through
-      # its --thinking flag.
+      # Pi accepts the full shared effort vocabulary through its --thinking flag.
       case "$effort" in
-        low|medium|high|xhigh|max) printf -- '--thinking %s ' "$(shell_quote "$effort")" ;;
+        low|medium|high|xhigh|max) printf -- '--thinking %s ' "$(shell_quote "$effort")"; return 0 ;;
       esac
       ;;
     muse)
-      # muse 0.1.0-R708.1 --reasoning-effort accepts none|minimal|low|medium|
-      # high|xhigh|ultra and defaults to high, so low..xhigh map straight across.
-      # ultra is muse's max-CLASS level, so firstmate's max maps onto it - but
-      # only ever as an EXPLICIT captain choice, never as a fallback, because
-      # AGENTS.md section 4 forbids selecting max without captain preference and
-      # the omitted effort here leaves muse on its own high default. muse's extra
-      # none/minimal levels sit below firstmate's shared vocabulary and are
-      # deliberately unreachable rather than remapped onto low.
+      # Muse accepts low through xhigh literally.
+      # Its ultra level is not firstmate's max, so it is deliberately not mapped.
       case "$effort" in
-        low|medium|high|xhigh) printf -- '--reasoning-effort %s ' "$(shell_quote "$effort")" ;;
-        max) printf -- '--reasoning-effort %s ' "$(shell_quote ultra)" ;;
+        low|medium|high|xhigh) printf -- '--reasoning-effort %s ' "$(shell_quote "$effort")"; return 0 ;;
       esac
       ;;
-    # opencode's interactive `opencode --prompt` launch has a verified --model
-    # flag but no verified effort flag. Its `opencode run --variant` flag belongs
-    # to a different, non-interactive launch mode, so fm-spawn does not pass it.
-    # kimi likewise has no reasoning-effort flag; the requested axis stays in
-    # task metadata but never reaches the launch command.
+    # OpenCode's interactive launch and Kimi have no verified effort flag.
   esac
+
+  echo "error: refusing $harness spawn with effort '$effort': no verified launch flag expresses that exact effort" >&2
+  return 1
 }
+
+EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT") || exit 1
 
 case "$LAUNCH" in
   *__MUSEBIN__*)
@@ -2643,7 +2633,6 @@ sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
-EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
 LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -385,7 +385,7 @@ fi
 
 effort_flag_for_harness() {
   local harness=$1 effort=$2
-  [ -n "$effort" ] && [ "$effort" != default ] && [ "$effort" != - ] || return 0
+  [ -n "$effort" ] && [ "$effort" != default ] || return 0
   case "$harness:$effort" in
     claude:low|claude:medium|claude:high|claude:xhigh|claude:max)
       printf -- "--effort '%s' " "$effort"
@@ -410,7 +410,7 @@ effort_flag_for_harness() {
 }
 
 spawn_remote_secondmate() {
-  local id=$1 remote host root home harness positional model effort backend out rc meta tmp
+  local id=$1 remote host root home harness positional model effort capability_effort backend out rc meta tmp
   local remote_backend remote_target remote_harness remote_herdr_session registry_lock remote_lock remote_generation
   local remote_traceparent remote_recorded_traceparent
   local -a launch_args
@@ -472,7 +472,9 @@ spawn_remote_secondmate() {
       [ -n "$effort" ] || effort=-
     fi
   fi
-  effort_flag_for_harness "$harness" "$effort" >/dev/null || {
+  capability_effort=$effort
+  [ "$capability_effort" != - ] || capability_effort=
+  effort_flag_for_harness "$harness" "$capability_effort" >/dev/null || {
     fm_lock_release "$registry_lock" || true
     fm_lock_release "$SPAWN_TASK_LOCK" || true
     return 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -385,7 +385,7 @@ fi
 
 effort_flag_for_harness() {
   local harness=$1 effort=$2
-  [ -n "$effort" ] && [ "$effort" != default ] || return 0
+  [ -n "$effort" ] && [ "$effort" != default ] && [ "$effort" != - ] || return 0
   case "$harness:$effort" in
     claude:low|claude:medium|claude:high|claude:xhigh|claude:max)
       printf -- "--effort '%s' " "$effort"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -180,8 +180,8 @@ The shell scripts validate the JSON shape and verified harness/effort combinatio
 The session-start bootstrap step keeps valid dispatch configuration silent unless verbose facts are enabled and surfaces a concise invalid-config line when validation fails.
 When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
-Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
-That keeps spawn launch compatible across claude, codex, opencode, pi, pi-signed, grok, kimi, and muse while preserving the requested profile for later audit.
+If a requested effort cannot be expressed by the selected harness's verified launch flag, `fm-spawn.sh` refuses before writing task metadata or launching the worker.
+That keeps recorded effort aligned with the actual launch across claude, codex, opencode, pi, pi-signed, grok, kimi, and muse.
 
 ## Optional secondmates
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -276,7 +276,7 @@ Profile `model` and `effort` fields and rule `why` are optional.
 An omitted model or effort means the selected harness uses its own default for that axis.
 Every profile array is an implicit quota-aware choice resolved through `quota-array-dispatch`.
 If no dispatch rule fits, firstmate resolves `default` through the same object-or-array path before falling back to `config/crew-harness`.
-If a selected profile carries an effort value the chosen harness does not accept, `fm-spawn.sh` records the requested `effort=` in task meta for traceability but omits the launch flag, and bootstrap reports the invalid harness/effort pair as a `CREW_DISPATCH` diagnostic when it is visible in the file.
+If a selected profile carries an effort value the chosen harness does not accept, `fm-spawn.sh` refuses before writing task metadata or launching the worker, and bootstrap reports the invalid harness/effort pair as a `CREW_DISPATCH` diagnostic when it is visible in the file.
 See [`docs/examples/crew-dispatch.json`](examples/crew-dispatch.json) for a starting point to copy into local `config/crew-dispatch.json`.
 When the file exists, bootstrap validates it with `jq`.
 Valid files stay silent by default; with `FM_BOOTSTRAP_VERBOSE_FACTS=1`, bootstrap emits `BOOTSTRAP_INFO: crew dispatch active config/crew-dispatch.json`, one `BOOTSTRAP_INFO:` fact per rule, and one fact for the optional default profile set.

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -1118,12 +1118,13 @@ test_crew_dispatch_validation() {
   done <<'ROWS'
 malformed dispatch config is flagged^{"rules":[^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - malformed JSON
 unverified dispatch harness is flagged^{"rules":[{"when":"anything","use":{"harness":"spaceship"}}],"default":{"harness":"codex"}}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unverified harness: spaceship
-unsupported codex max effort is flagged^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
+codex max effort is accepted^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5","effort":"max"}}]}^empty^
 unsupported grok max effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:max
 unsupported grok xhigh effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"xhigh"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:xhigh
 pi max effort is accepted^{"rules":[{"when":"deep coding","use":{"harness":"pi","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
 pi-signed max effort is accepted^{"rules":[{"when":"signed coding","use":{"harness":"pi-signed","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
-muse shared efforts are accepted^{"rules":[{"when":"muse low","use":{"harness":"muse","effort":"low"}},{"when":"muse medium","use":{"harness":"muse","effort":"medium"}},{"when":"muse high","use":{"harness":"muse","effort":"high"}},{"when":"muse xhigh","use":{"harness":"muse","effort":"xhigh"}},{"when":"muse max","use":{"harness":"muse","effort":"max"}}]}^empty^
+muse supported efforts are accepted^{"rules":[{"when":"muse low","use":{"harness":"muse","effort":"low"}},{"when":"muse medium","use":{"harness":"muse","effort":"medium"}},{"when":"muse high","use":{"harness":"muse","effort":"high"}},{"when":"muse xhigh","use":{"harness":"muse","effort":"xhigh"}}]}^empty^
+unsupported muse max effort is flagged^{"rules":[{"when":"muse max","use":{"harness":"muse","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: muse:max
 unsupported muse ultra effort is flagged^{"rules":[{"when":"muse ultra","use":{"harness":"muse","effort":"ultra"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: muse:ultra
 unsupported opencode effort is flagged^{"rules":[{"when":"opencode work","use":{"harness":"opencode","model":"anthropic/claude-sonnet-4-5","effort":"high"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: opencode:high
 kimi model profile is accepted^{"rules":[{"when":"kimi work","use":{"harness":"kimi","model":"kimi-code/k3"}}]}^empty^
@@ -1137,7 +1138,7 @@ empty array use is flagged^{"rules":[{"when":"big feature","use":[]}]}^exact^CRE
 array profile without harness is flagged^{"rules":[{"when":"big feature","use":[{"model":"gpt-5.5"}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each use profile needs harness
 array profile with malformed model is flagged^{"rules":[{"when":"big feature","use":[{"harness":"codex","model":5}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - use profile model and effort must be non-empty strings when present
 unknown select is flagged^{"rules":[{"when":"big feature","use":[{"harness":"claude"},{"harness":"codex"}],"select":"mystery"}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unknown select: mystery
-array profile unsupported effort is flagged^{"rules":[{"when":"big feature","use":[{"harness":"codex","effort":"max"}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
+array profile codex max effort is accepted^{"rules":[{"when":"big feature","use":[{"harness":"codex","effort":"max"}]}]}^empty^
 empty default array is flagged^{"default":[]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - default needs at least one profile
 non-object default array entry is flagged^{"default":["codex"]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each default profile must be an object
 default array profile without harness is flagged^{"default":[{"model":"gpt-5.5"}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each default profile needs harness

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -236,6 +236,27 @@ test_kimi_nondefault_effort_refuses_before_metadata_or_launch() {
   pass "fm-spawn: Kimi non-default effort refuses before metadata and launch"
 }
 
+test_kimi_effort_sentinel_refuses_before_metadata_or_launch() {
+  local id rec out rc
+  id=kimi-effort-sentinel-refuse-z1
+  rec=$(make_spawn_case effort-sentinel-refuse "$id")
+  read_spawn_record "$rec"
+
+  rc=0
+  out=$(run_spawn "$CASE_DIR" "$HOME_DIR" "$PROJ_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" \
+    --model kimi-code/k3 --effort -) || rc=$?
+  expect_code 1 "$rc" "Kimi effort sentinel must remain an invalid local request"
+  assert_contains "$out" "error: --effort must be one of low, medium, high, xhigh, max" \
+    "Kimi effort sentinel refusal did not reject the invalid local request"
+  assert_absent "$HOME_DIR/state/$id.meta" "Kimi effort sentinel refusal wrote metadata"
+  [ ! -s "$CASE_DIR/launch.log" ] || fail "Kimi effort sentinel refusal sent a launch command"
+  [ ! -s "$CASE_DIR/pointer.log" ] || fail "Kimi effort sentinel refusal sent a brief pointer"
+  if grep -Eq '(^| )new-(session|window)( |$)' "$CASE_DIR/tmux-calls.log"; then
+    fail "Kimi effort sentinel refusal created a tmux container or pane"
+  fi
+  pass "fm-spawn: local Kimi effort sentinel refuses before metadata and launch"
+}
+
 test_kimi_hook_install_is_surgical_idempotent_and_removable() {
   local home config original once stripped count
   home="$TMP_ROOT/config-surgery"
@@ -683,6 +704,7 @@ test_kimi_hook_fails_closed_on_missing_malformed_or_partial_config
 test_kimi_hook_install_refuses_without_jq
 test_kimi_launch_then_send_is_verified
 test_kimi_nondefault_effort_refuses_before_metadata_or_launch
+test_kimi_effort_sentinel_refuses_before_metadata_or_launch
 test_kimi_hook_is_silent_and_requires_registered_workspace_token
 test_kimi_spawn_refuses_unsafe_global_config_before_pane_creation
 test_kimi_teardown_removes_pointer_and_registry_token

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -186,7 +186,7 @@ test_kimi_launch_then_send_is_verified() {
   read_spawn_record "$rec"
   out=$(FM_FAKE_KIMI_SWALLOW_FIRST=yes run_spawn \
     "$CASE_DIR" "$HOME_DIR" "$PROJ_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" \
-    --model kimi-code/k3 --effort high)
+    --model kimi-code/k3)
   rc=$?
   expect_code 0 "$rc" "verified kimi launch-then-send should succeed"
   assert_contains "$out" "spawned $id harness=kimi" "kimi spawn did not report success"
@@ -204,7 +204,6 @@ test_kimi_launch_then_send_is_verified() {
     || fail "kimi pointer was not the exact absolute-path-only instruction: $pointer"
   meta="$HOME_DIR/state/$id.meta"
   assert_grep 'model=kimi-code/k3' "$meta" "kimi meta lost the requested model"
-  assert_grep 'effort=high' "$meta" "kimi meta did not retain the unsupported effort axis"
   assert_grep "tasktmp=$task_tmp" "$meta" "kimi meta did not record its task temp root"
   assert_present "$task_tmp/gotmp" "kimi spawn did not create its Go temp directory"
   assert_grep "export GOTMPDIR=$task_tmp/gotmp" "$CASE_DIR/tmux-calls.log" \
@@ -214,6 +213,27 @@ test_kimi_launch_then_send_is_verified() {
   assert_grep 'token=' "$WT_DIR/.fm-kimi-turnend" "kimi spawn did not write its token pointer"
   assert_present "$HOME_DIR/state/$id.kimi-turnend-token" "kimi spawn did not record its token"
   pass "fm-spawn: kimi launches, delivers its brief, and registers a guarded turn-end token"
+}
+
+test_kimi_nondefault_effort_refuses_before_metadata_or_launch() {
+  local id rec out rc
+  id=kimi-effort-refuse-z1
+  rec=$(make_spawn_case effort-refuse "$id")
+  read_spawn_record "$rec"
+
+  rc=0
+  out=$(run_spawn "$CASE_DIR" "$HOME_DIR" "$PROJ_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" \
+    --model kimi-code/k3 --effort high) || rc=$?
+  expect_code 1 "$rc" "Kimi high effort without an exact launch flag must refuse"
+  assert_contains "$out" "error: refusing kimi spawn with effort 'high'" \
+    "Kimi effort refusal did not name the unsupported exact effort"
+  assert_absent "$HOME_DIR/state/$id.meta" "Kimi effort refusal wrote metadata"
+  [ ! -s "$CASE_DIR/launch.log" ] || fail "Kimi effort refusal sent a launch command"
+  [ ! -s "$CASE_DIR/pointer.log" ] || fail "Kimi effort refusal sent a brief pointer"
+  if grep -Eq '(^| )new-(session|window)( |$)' "$CASE_DIR/tmux-calls.log"; then
+    fail "Kimi effort refusal created a tmux container or pane"
+  fi
+  pass "fm-spawn: Kimi non-default effort refuses before metadata and launch"
 }
 
 test_kimi_hook_install_is_surgical_idempotent_and_removable() {
@@ -662,6 +682,7 @@ test_kimi_hook_remove_preserves_owned_newline_boundary
 test_kimi_hook_fails_closed_on_missing_malformed_or_partial_config
 test_kimi_hook_install_refuses_without_jq
 test_kimi_launch_then_send_is_verified
+test_kimi_nondefault_effort_refuses_before_metadata_or_launch
 test_kimi_hook_is_silent_and_requires_registered_workspace_token
 test_kimi_spawn_refuses_unsafe_global_config_before_pane_creation
 test_kimi_teardown_removes_pointer_and_registry_token

--- a/tests/fm-muse-harness.test.sh
+++ b/tests/fm-muse-harness.test.sh
@@ -252,7 +252,6 @@ test_spawn_maps_effort_and_model() {
     "medium|--reasoning-effort 'medium'"
     "high|--reasoning-effort 'high'"
     "xhigh|--reasoning-effort 'xhigh'"
-    "max|--reasoning-effort 'ultra'"
   )
   local entry effort expect
   for entry in "${cases[@]}"; do
@@ -269,8 +268,20 @@ EOF
     assert_contains "$launch" "$expect" "muse effort $effort did not map to '$expect'"
     assert_contains "$launch" "--model 'muse-spark-1.2'" "muse spawn dropped the model axis"
   done
-  # ultra is muse's max-class level and must be reachable ONLY through an
-  # explicit max, never as the fallback when no effort was chosen.
+  rec=$(make_spawn_case effort-max)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  out=$(run_muse_spawn "$home" "$proj" "$wt" "$fakebin" "$id" \
+    --mode no-mistakes --yolo off --model muse-spark-1.2 --effort max 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "muse max effort was accepted"
+  assert_contains "$out" "refusing muse spawn with effort 'max'" \
+    "muse max refusal did not explain the unsupported exact effort"
+  assert_absent "$home/state/$id.meta" "muse max refusal wrote metadata"
+  assert_absent "$home/launch.log" "muse max refusal launched a worker"
+
+  # No effort remains omitted rather than being invented at launch.
   rec=$(make_spawn_case effort-default)
   IFS='|' read -r case_dir home proj wt fakebin id <<EOF
 $rec
@@ -279,7 +290,7 @@ EOF
     || fail "muse spawn without an effort axis failed"
   launch=$(cat "$home/launch.log")
   assert_not_contains "$launch" '--reasoning-effort' "muse spawn invented an effort when none was chosen"
-  pass "muse maps the shared effort vocabulary and reaches ultra only via explicit max"
+  pass "muse maps only verified efforts and refuses max before launch"
 }
 
 # An unauthenticated muse pane does not exit: it sits on an OAuth device-code

--- a/tests/fm-muse-harness.test.sh
+++ b/tests/fm-muse-harness.test.sh
@@ -97,12 +97,14 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  cp "$(command -v bash)" "$fakebin/muse-bin-test-version"
+  ln -s "$(command -v perl)" "$fakebin/muse-bin-test-version"
   cat > "$fakebin/muse" <<'SH'
 #!/usr/bin/env bash
 set -u
 [ -n "${FM_FAKE_HARNESS_RESULT:-}" ] || exit 0
-exec "$FM_FAKE_MUSE_VERSIONED" -c 'result=$($FM_FAKE_HARNESS_PROBE); printf "%s" "$result" > "$FM_FAKE_HARNESS_RESULT"'
+  versioned_dir=$(dirname "$FM_FAKE_MUSE_VERSIONED")
+  versioned_name=$(basename "$FM_FAKE_MUSE_VERSIONED")
+  (cd "$versioned_dir" && "./$versioned_name" -e 'my $result=`$ENV{FM_FAKE_HARNESS_PROBE}`; open my $fh, ">", $ENV{FM_FAKE_HARNESS_RESULT}; print {$fh} $result')
 SH
   chmod +x "$fakebin/muse"
   fm_fake_exit0 "$fakebin" treehouse gh-axi gh
@@ -157,18 +159,17 @@ run_muse_spawn() {  # <home> <proj> <wt> <fakebin> <id> [extra args...]
 # The foreign env markers are cleared because muse is markerless and the marker
 # layer deliberately outranks ancestry: with one retained, these cases would
 # assert the marker's verdict instead of the ancestry match they exist to pin.
-# The command substitution around the probe is load-bearing: a bare `-c <cmd>`
-# lets the shell exec the probe in place, which REPLACES the muse-bin-* process
-# name the walk is supposed to find. Real muse keeps its TUI process alive and
-# runs tools as children, so forcing a fork is what reproduces that shape.
+# The Perl fixture keeps the versioned process alive while its child runs the
+# probe, reproducing Muse's process ancestry without relying on a copied system
+# Bash binary, which macOS may kill with SIGKILL before the probe runs.
 test_detects_versioned_process_ancestor() {
   local dir bin out
   dir="$TMP_ROOT/detect"
   mkdir -p "$dir"
   for bin in muse-bin-0.1.0-R708.1 muse-bin-9.9.9-RZZZ.9 muse; do
-    cp "$(command -v bash)" "$dir/$bin"
-    out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
-      "$dir/$bin" -c "r=\$(\"$HARNESS\"); printf '%s' \"\$r\"")
+    ln -s "$(command -v perl)" "$dir/$bin"
+    out=$(cd "$dir" && env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+      FM_HARNESS_PROBE="$HARNESS" "./$bin" -e 'print `$ENV{FM_HARNESS_PROBE}`')
     [ "$out" = muse ] || fail "fm-harness.sh under process '$bin' reported '$out', expected muse"
   done
   pass "muse is detected through any versioned muse-bin ancestor"
@@ -181,9 +182,9 @@ test_detection_is_anchored() {
   dir="$TMP_ROOT/detect-neg"
   mkdir -p "$dir"
   for bin in musescore amuse notmuse-bin muse-binary muse-bind; do
-    cp "$(command -v bash)" "$dir/$bin"
-    out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
-      "$dir/$bin" -c "r=\$(\"$HARNESS\"); printf '%s' \"\$r\"")
+    ln -s "$(command -v perl)" "$dir/$bin"
+    out=$(cd "$dir" && env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+      FM_HARNESS_PROBE="$HARNESS" "./$bin" -e 'print `$ENV{FM_HARNESS_PROBE}`')
     [ "$out" != muse ] || fail "fm-harness.sh misdetected unrelated process '$bin' as muse"
   done
   pass "muse detection does not claim unrelated muse-containing commands"

--- a/tests/fm-muse-harness.test.sh
+++ b/tests/fm-muse-harness.test.sh
@@ -168,6 +168,7 @@ test_detects_versioned_process_ancestor() {
   mkdir -p "$dir"
   for bin in muse-bin-0.1.0-R708.1 muse-bin-9.9.9-RZZZ.9 muse; do
     ln -s "$(command -v perl)" "$dir/$bin"
+    # shellcheck disable=SC2016 # Perl expands the probe expression in the fixture.
     out=$(cd "$dir" && env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
       FM_HARNESS_PROBE="$HARNESS" "./$bin" -e 'print `$ENV{FM_HARNESS_PROBE}`')
     [ "$out" = muse ] || fail "fm-harness.sh under process '$bin' reported '$out', expected muse"
@@ -183,6 +184,7 @@ test_detection_is_anchored() {
   mkdir -p "$dir"
   for bin in musescore amuse notmuse-bin muse-binary muse-bind; do
     ln -s "$(command -v perl)" "$dir/$bin"
+    # shellcheck disable=SC2016 # Perl expands the probe expression in the fixture.
     out=$(cd "$dir" && env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
       FM_HARNESS_PROBE="$HARNESS" "./$bin" -e 'print `$ENV{FM_HARNESS_PROBE}`')
     [ "$out" != muse ] || fail "fm-harness.sh misdetected unrelated process '$bin' as muse"

--- a/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
@@ -724,6 +724,28 @@ publish_healthy_watcher_identity "$PARENT/state" "$PARENT" "$ROOT/bin/fm-watch.s
   || fail "remote endpoint delivery observation did not execute on its own host"
 pass "remote spawn launches on the remote-local backend and records a host-qualified route"
 
+cp "$PARENT/state/ios.meta" "$TMP_ROOT/parent-ios-before-kimi-effort-refusal.meta"
+cp "$REMOTE_HOME/state/parent-route/ios.meta" "$TMP_ROOT/remote-ios-before-kimi-effort-refusal.meta"
+ssh_before_kimi_effort_refusal=$(cat "$SSH_COUNT")
+launches_before_kimi_effort_refusal=$(grep -c '^tab create' "$HERDR_LOG" || true)
+set +e
+remote_env "$ROOT/bin/fm-spawn.sh" ios --secondmate --harness kimi --effort high \
+  > "$TMP_ROOT/spawn-kimi-effort-refusal.out" 2>&1
+kimi_effort_refusal_rc=$?
+set -e
+[ "$kimi_effort_refusal_rc" -ne 0 ] || fail "remote reused endpoint accepted unsupported Kimi effort"
+assert_grep "error: refusing kimi spawn with effort 'high'" "$TMP_ROOT/spawn-kimi-effort-refusal.out" \
+  "remote reused endpoint did not name the unsupported Kimi effort"
+[ "$(cat "$SSH_COUNT")" = "$ssh_before_kimi_effort_refusal" ] \
+  || fail "remote Kimi effort refusal reached readiness, inheritance, or endpoint reuse"
+cmp -s "$TMP_ROOT/parent-ios-before-kimi-effort-refusal.meta" "$PARENT/state/ios.meta" \
+  || fail "remote Kimi effort refusal rewrote parent metadata"
+cmp -s "$TMP_ROOT/remote-ios-before-kimi-effort-refusal.meta" "$REMOTE_HOME/state/parent-route/ios.meta" \
+  || fail "remote Kimi effort refusal rewrote reused endpoint metadata"
+[ "$(grep -c '^tab create' "$HERDR_LOG" || true)" = "$launches_before_kimi_effort_refusal" ] \
+  || fail "remote Kimi effort refusal created a remote endpoint"
+pass "remote reused endpoints refuse unsupported effort before remote work or metadata"
+
 remote_route_meta="$REMOTE_HOME/state/parent-route/ios.meta"
 cp "$remote_route_meta" "$TMP_ROOT/remote-ios-before-default-session.meta"
 legacy_pane=$(sed -n 's/^herdr_pane_id=//p' "$remote_route_meta")

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -419,7 +419,7 @@ test_codex_threads_model_and_effort() {
   pass "codex receives --model and model_reasoning_effort profile flags"
 }
 
-test_codex_omits_invalid_max_effort() {
+test_codex_threads_max_effort() {
   local rec id out status launch
   id=profile-codex-max-z4
   rec=$(make_spawn_case profile-codex-max codex "$id")
@@ -427,13 +427,12 @@ test_codex_omits_invalid_max_effort() {
 
   out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5 --effort max)
   status=$?
-  expect_code 0 "$status" "codex spawn with unsupported max effort should omit the effort flag"
+  expect_code 0 "$status" "codex spawn with max effort should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' --dangerously-bypass-approvals-and-sandbox" \
-    "codex launch did not preserve the model flag when max effort was omitted"
-  assert_not_contains "$launch" "model_reasoning_effort" "codex launch must omit unsupported max reasoning effort"
-  pass "codex omits unsupported max effort instead of passing a bad config value"
+  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"max\"' --dangerously-bypass-approvals-and-sandbox" \
+    "codex launch did not thread max model reasoning effort"
+  pass "codex receives max model_reasoning_effort when metadata records max"
 }
 
 test_grok_threads_model_and_reasoning_effort() {
@@ -453,60 +452,29 @@ test_grok_threads_model_and_reasoning_effort() {
   pass "grok receives --model and --reasoning-effort profile flags"
 }
 
-test_grok_omits_invalid_max_reasoning_effort() {
-  local rec id out status launch
-  id=profile-grok-max-z6
-  rec=$(make_spawn_case profile-grok-max grok "$id")
-  read_case_record "$rec"
+test_unsupported_efforts_refuse_before_metadata_or_launch() {
+  local case_name harness effort id rec out status
+  while IFS='|' read -r case_name harness effort; do
+    [ -n "$case_name" ] || continue
+    id="profile-$case_name-z6"
+    rec=$(make_spawn_case "profile-$case_name" "$harness" "$id")
+    read_case_record "$rec"
 
-  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model grok-4 --effort max)
-  status=$?
-  expect_code 0 "$status" "grok spawn with unsupported max reasoning effort should omit the effort flag"
-  assert_meta_profile "$HOME_DIR/state/$id.meta" grok grok-4 max
-  launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "grok --always-approve --model 'grok-4' \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < " \
-    "grok launch did not preserve the model flag and typed brief when max effort was omitted"
-  assert_not_contains "$launch" "--reasoning-effort" "grok launch must omit unsupported max reasoning effort"
-  assert_not_contains "$launch" "--effort" "grok launch must not fall back to --effort for reasoning effort"
-  pass "grok omits unsupported max reasoning effort"
-}
-
-test_grok_omits_invalid_xhigh_reasoning_effort() {
-  local rec id out status launch
-  id=profile-grok-xhigh-z6b
-  rec=$(make_spawn_case profile-grok-xhigh grok "$id")
-  read_case_record "$rec"
-
-  # grok 0.2.99 rejects xhigh (accepted set is only low|medium|high).
-  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model grok-4 --effort xhigh)
-  status=$?
-  expect_code 0 "$status" "grok spawn with unsupported xhigh reasoning effort should omit the effort flag"
-  assert_meta_profile "$HOME_DIR/state/$id.meta" grok grok-4 xhigh
-  launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "grok --always-approve --model 'grok-4' \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < " \
-    "grok launch did not preserve the model flag and typed brief when xhigh effort was omitted"
-  assert_not_contains "$launch" "--reasoning-effort" "grok launch must omit unsupported xhigh reasoning effort"
-  assert_not_contains "$launch" "--effort" "grok launch must not fall back to --effort for reasoning effort"
-  pass "grok omits unsupported xhigh reasoning effort"
-}
-
-test_opencode_threads_model_and_ignores_effort_axis() {
-  local rec id out status launch
-  id=profile-opencode-z7
-  rec=$(make_spawn_case profile-opencode opencode "$id")
-  read_case_record "$rec"
-
-  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model anthropic/claude-sonnet-4-5 --effort high)
-  status=$?
-  expect_code 0 "$status" "opencode spawn with model and ignored effort should succeed"
-  assert_meta_profile "$HOME_DIR/state/$id.meta" opencode anthropic/claude-sonnet-4-5 high
-  launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "opencode --model 'anthropic/claude-sonnet-4-5' --prompt" \
-    "opencode launch did not thread model"
-  assert_not_contains "$launch" "--effort" "opencode launch must not pass unsupported --effort"
-  assert_not_contains "$launch" "--variant" "opencode launch must not pass run-only --variant"
-  assert_not_contains "$launch" "--thinking" "opencode launch must not pass pi thinking flag"
-  pass "opencode receives --model and omits the unsupported effort axis"
+    out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --effort "$effort")
+    status=$?
+    expect_code 1 "$status" "$case_name: unsupported effort should refuse the spawn"
+    assert_contains "$out" "error: refusing $harness spawn with effort '$effort'" \
+      "$case_name: refusal did not name the harness and effort"
+    assert_absent "$HOME_DIR/state/$id.meta" "$case_name: refusal wrote metadata"
+    [ ! -s "$LAUNCH_LOG" ] || fail "$case_name: refusal sent a launch command"
+  done <<'ROWS'
+grok-max|grok|max
+grok-xhigh|grok|xhigh
+opencode-high|opencode|high
+kimi-low|kimi|low
+muse-max|muse|max
+ROWS
+  pass "unsupported harness effort levels refuse before metadata or launch"
 }
 
 test_pi_threads_model_and_max_effort() {
@@ -736,11 +704,9 @@ test_active_dispatch_profile_allows_positional_harness
 test_active_dispatch_profile_allows_raw_launch_command
 test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
-test_codex_omits_invalid_max_effort
+test_codex_threads_max_effort
 test_grok_threads_model_and_reasoning_effort
-test_grok_omits_invalid_max_reasoning_effort
-test_grok_omits_invalid_xhigh_reasoning_effort
-test_opencode_threads_model_and_ignores_effort_axis
+test_unsupported_efforts_refuse_before_metadata_or_launch
 test_pi_threads_model_and_max_effort
 test_pi_tui_mode_probe_is_safe_for_old_and_new_pi
 test_pi_signed_threads_shared_pi_profile_and_preserves_identity


### PR DESCRIPTION
## Intent

Get upstream PR #1993 green for maintainer merge. Preserve the fail-closed invariant: fm-spawn must never record a requested reasoning effort unless the selected harness launches with that exact effort, or refuse before metadata and launch. Codex 0.147.0 must emit model_reasoning_effort=max for gpt-5.6-luna. The PR already implements that behavior; this follow-up repairs the pre-existing Kimi fixture expectation exposed by the invariant. Kimi has no verified effort launch flag, so its former --effort high success expectation is invalid. Keep normal Kimi model launch coverage without an effort, and add a regression proving high effort refuses before metadata, pane creation, launch command, or brief delivery. Update the existing PR #1993 branch only; no force-push, no second PR, no merge. Local changed-scope aggregate is NOT_VERIFIABLE because it does not terminate after Herdr backend coverage on this host; focused Kimi red/green proof is load-bearing.

## What Changed

- Fail closed before metadata or launch when a harness cannot express the requested reasoning effort, including remote secondmate endpoint reuse.
- Pass Codex `max` effort through as `model_reasoning_effort="max"`, while retaining only verified effort mappings for other harnesses.
- Update adapter guidance and regression coverage for Kimi, Muse, remote lifecycle, and dispatch-profile effort handling.

## Risk Assessment

✅ Low: The shared capability predicate now covers remote reused endpoints while the remote-only sentinel normalization preserves ordinary no-effort launches and local invalid efforts refuse early.

## Testing

Confirmed the target head, ran the focused Kimi harness suite, and captured a direct CLI-flow artifact showing normal model launch and brief delivery plus high-effort refusal before metadata, pane creation, launch, or brief delivery. The known changed-scope aggregate remains NOT_VERIFIABLE on this host and was not run.

<details>
<summary>Evidence: Kimi end-to-end CLI flow</summary>

<code>Normal Kimi model-only launch exited 0, invoked `kimi --model kimi-code/k3 --auto`, and delivered the brief. A requested `--effort high` exited 1 before metadata, launch, brief delivery, or tmux pane creation.</code>

```text
=== normal Kimi model-only launch ===
exit=0
output=warning: /var/folders/cq/xf4qcb9j0qzc2dbh173mflbm0000gn/T//fm-kimi-harness.d6GD6H/manual-evidence-normal/home/data/manual-kimi-normal-z1/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
spawned manual-kimi-normal-z1 harness=kimi kind=ship mode=no-mistakes yolo=off window=firstmate:fm-manual-kimi-normal-z1 worktree=/var/folders/cq/xf4qcb9j0qzc2dbh173mflbm0000gn/T//fm-kimi-harness.d6GD6H/manual-evidence-normal/wt
launch='/var/folders/cq/xf4qcb9j0qzc2dbh173mflbm0000gn/T//fm-kimi-harness.d6GD6H/manual-evidence-normal/fake/fakebin/kimi' --model 'kimi-code/k3' --auto
brief=Read the brief at /private/var/folders/cq/xf4qcb9j0qzc2dbh173mflbm0000gn/T/fm-kimi-harness.d6GD6H/manual-evidence-normal/home/data/manual-kimi-normal-z1/brief.md and follow it exactly.
metadata=window=firstmate:fm-manual-kimi-normal-z1;endpoint_task_id=manual-kimi-normal-z1;worktree=/var/folders/cq/xf4qcb9j0qzc2dbh173mflbm0000gn/T//fm-kimi-harness.d6GD6H/manual-evidence-normal/wt;project=/var/folders/cq/xf4qcb9j0qzc2dbh173mflbm0000gn/T/fm-kimi-harness.d6GD6H/manual-evidence-normal/project;harness=kimi;kind=ship;mode=no-mistakes;yolo=off;tasktmp=/tmp/fm-manual-kimi-normal-z1;model=kimi-code/k3;effort=default;
=== requested high-effort Kimi launch ===
exit=1
output=error: refusing kimi spawn with effort 'high': no verified launch flag expresses that exact effort
metadata_exists=no
launch_bytes=       0
brief_bytes=       0
tmux_pane_creation=no
```
</details>
<details>
<summary>Evidence: Focused Kimi test transcript</summary>

`Focused Kimi harness behavior transcript for target b4ddd853e88894b8d4e297775d35cc203520709a.`

```text
target_commit=b4ddd853e88894b8d4e297775d35cc203520709a
ok - Kimi hook install is idempotent and removal restores every foreign config byte
ok - Kimi hook removal preserves owned newline boundaries and pristine bytes
ok - Kimi hook install refuses missing, malformed, and surprising config without writing
ok - Kimi hook install refuses without jq before any config write
ok - fm-spawn: kimi launches, delivers its brief, and registers a guarded turn-end token
ok - fm-spawn: Kimi non-default effort refuses before metadata and launch
ok - fm-spawn: local Kimi effort sentinel refuses before metadata and launch
ok - Kimi hook stays silent and inert without a Firstmate registry token
ok - fm-spawn: unsafe Kimi global config refuses before pane creation
ok - fm-teardown: Kimi task pointer and registry token are removed
ok - fm-spawn: Kimi fallback expands the active HOME
ok - fm-spawn: missing Kimi executable refuses before pane creation
ok - fm-spawn: kimi treats a silent pointer drop as a failed spawn
ok - fm-spawn: kimi never sends the brief pointer before an observable ready signal
ok - fm-harness: markerless kimi is detected by ancestry after env-marker precedence
lock acquired: harness pid 5328
ok - fm-lock recognizes Kimi ancestry and live lock holders
ok - busy detection: real Kimi moon-plus-middot captures require its harness while idle labels stay idle
ok - fm-watch classifies Kimi as unknown rather than from its spinner, and Grok's fallback stays isolated
ok - composer classifier: kimi's existing bordered > shape is already safe without an override
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (3) ✅</summary>

- 🚨 `bin/fm-spawn.sh:1371` - The changed local guard at line 1371 is bypassed by the earlier remote-secondmate return path: when a remote Kimi endpoint is already alive, `fm-remote-secondmate-control.sh launch` returns its route before it invokes remote `fm-spawn`; the parent then writes `effort=high` at `bin/fm-spawn.sh:608`. Thus `fm-spawn &lt;id&gt; --secondmate --harness kimi --effort high` can record an unlaunched, unsupported effort. This contradicts the required criterion, “fm-spawn must never record a requested reasoning effort unless the selected harness launches with that exact effort, or refuse before metadata and launch.” Put the same capability check at the parent remote-secondmate boundary (before readiness/inheritance/route reuse), using a helper defined before that branch, so a reused endpoint cannot bypass it.

🔧 Fix: Fail close remote Kimi effort reuse
1 error still open:
- 🚨 `bin/fm-spawn.sh:475` - The new shared predicate treats the remote no-effort sentinel `-` as an unsupported requested effort. `spawn_remote_secondmate` sets `effort=${EFFORT:--}` and calls this helper before contacting the remote host, so a normal remote secondmate spawn with no `--effort` now refuses instead of preserving the documented/default launch. Accept `-` as the remote “no requested effort” sentinel (or normalize it to empty before the shared predicate).

🔧 Fix: Normalize remote no-effort sentinel
1 error still open:
- 🚨 `bin/fm-spawn.sh:388` - The sentinel fix makes `--effort -` a successful local spawn for every harness: the changed `&amp;&amp; [ &#34;$effort&#34; != - ] || return 0` path emits no effort flag, while metadata later records `effort=-`. For example, a local Kimi spawn with `--effort -` now violates the required criterion, “fm-spawn must never record a requested reasoning effort unless the selected harness launches with that exact effort, or refuse before metadata and launch.” Keep `-` as a remote transport sentinel only—normalize it at the remote caller before invoking the shared predicate—so a user-supplied `--effort -` remains fail-closed.

🔧 Fix: Scope effort sentinel to remote transport
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-kimi-harness.test.sh`
- <code>Manual fixture-backed Kimi CLI flow captured in `kimi-user-flow-transcript.txt`</code>
- <code>`git rev-parse HEAD` confirmed `b4ddd853e88894b8d4e297775d35cc203520709a`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
