### PR TITLE
fix(bin): reclaim orphaned worker lock scratch

### DIFF
--- a/bin/fm-remote-job-worker.sh
+++ b/bin/fm-remote-job-worker.sh
@@ -143,6 +143,24 @@ worker_recover_quarantine() { # <account-home>
   rm -f -- "$WORKER_LOCK/quarantine"
 }
 
+# worker_publish_lock_owner and worker_publish_quarantine each stage their
+# atomic rename through a uniquely named scratch file directly inside the
+# lock directory. A child killed between mktemp and the rename - the second
+# TERM in worker_shutdown's disarmed window, or a SIGKILL - leaves that
+# scratch file behind with no owner left to finish or discard it, which
+# blocks every future rmdir reclaim of the lock forever. Clear every scratch
+# name pattern those two functions use before rmdir, refusing to follow a
+# symlink rather than removing it, exactly like the canonical pid/start/
+# command names next to it.
+worker_clear_publish_scratch() { # <lock-dir>
+  local lock=$1 file
+  for file in "$lock"/.pid.* "$lock"/.start.* "$lock"/.command.* "$lock"/.quarantine.*; do
+    [ -e "$file" ] || [ -L "$file" ] || continue
+    [ ! -L "$file" ] || return 1
+    rm -f -- "$file" || return 1
+  done
+}
+
 worker_acquire_lock() {
   local account_home=$1 attempt=0
   while [ "$attempt" -lt 150 ]; do
@@ -164,7 +182,14 @@ worker_acquire_lock() {
     fi
     [ ! -L "$WORKER_LOCK/pid" ] && [ ! -L "$WORKER_LOCK/start" ] && [ ! -L "$WORKER_LOCK/command" ] || return 1
     rm -f -- "$WORKER_LOCK/pid" "$WORKER_LOCK/start" "$WORKER_LOCK/command" || return 1
-    rmdir "$WORKER_LOCK" || return 1
+    worker_clear_publish_scratch "$WORKER_LOCK" || {
+      worker_error "worker ownership lock $WORKER_LOCK contains an unexpected symlink in its scratch names; refusing to reclaim"
+      return 1
+    }
+    rmdir "$WORKER_LOCK" || {
+      worker_error "worker ownership lock $WORKER_LOCK is wedged: unexpected entries remain after clearing known scratch files"
+      return 1
+    }
   done
   return 1
 }
@@ -190,6 +215,7 @@ worker_cleanup() {
   if [ -z "$owner_pid" ]; then
     [ ! -L "$WORKER_LOCK/start" ] && [ ! -L "$WORKER_LOCK/command" ] &&
       rm -f -- "$WORKER_LOCK/start" "$WORKER_LOCK/command" 2>/dev/null || true
+    worker_clear_publish_scratch "$WORKER_LOCK" 2>/dev/null || true
     rmdir "$WORKER_LOCK" 2>/dev/null || true
     WORKER_LOCK_HELD=0
     return 0
@@ -202,6 +228,7 @@ worker_cleanup() {
   [ ! -L "$ready" ] && rm -f -- "$ready" 2>/dev/null || true
   [ ! -L "$identity" ] && rm -f -- "$identity" 2>/dev/null || true
   rm -f -- "$WORKER_LOCK/pid" "$WORKER_LOCK/start" "$WORKER_LOCK/command" 2>/dev/null || true
+  worker_clear_publish_scratch "$WORKER_LOCK" 2>/dev/null || true
   rmdir "$WORKER_LOCK" 2>/dev/null || true
   WORKER_LOCK_HELD=0
 }
@@ -720,6 +747,7 @@ worker_supervisor_cleanup_dead_child() { # <account-home> <pid>
   [ ! -L "$identity" ] && rm -f -- "$identity" || return 1
   [ ! -L "$lock/start" ] && [ ! -L "$lock/command" ] || return 1
   rm -f -- "$lock/pid" "$lock/start" "$lock/command" || return 1
+  worker_clear_publish_scratch "$lock" || return 1
   rmdir "$lock"
 }
 

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -18,6 +18,7 @@ FAKE_PERL_LOG="$TMP_ROOT/perl.log"
 REAL_GIT=$(command -v git)
 OTHER_PID=
 RECOVERY_WORKER_PID=
+GHOST_WORKER_PID=
 mkdir -p "$REMOTE_ROOT/bin" "$REMOTE_HOME" "$ACCOUNT_HOME" "$RUNTIME_BIN"
 # worker.pid records the serving child, not its restart supervisor, so stopping
 # that pid alone leaves the supervisor to respawn - the leak
@@ -25,6 +26,7 @@ mkdir -p "$REMOTE_ROOT/bin" "$REMOTE_HOME" "$ACCOUNT_HOME" "$RUNTIME_BIN"
 cleanup_remote_job_fixture() {
   [ -z "$OTHER_PID" ] || kill "$OTHER_PID" 2>/dev/null || true
   [ -z "$RECOVERY_WORKER_PID" ] || kill "$RECOVERY_WORKER_PID" 2>/dev/null || true
+  [ -z "$GHOST_WORKER_PID" ] || kill "$GHOST_WORKER_PID" 2>/dev/null || true
   if [ -f "$STATE_ROOT/worker.pid" ]; then
     fm_remote_job_stop_worker_tree "$(cat "$STATE_ROOT/worker.pid")" || true
   fi
@@ -619,5 +621,40 @@ kill -TERM "$RECOVERY_WORKER_PID"
 wait "$RECOVERY_WORKER_PID" 2>/dev/null || true
 RECOVERY_WORKER_PID=
 pass "quarantine clears only after recorded execution has stopped"
+
+GHOST_HOME="$TMP_ROOT/ghost-account"
+GHOST_STATE="$TMP_ROOT/ghost-jobs"
+mkdir -p "$GHOST_HOME" "$GHOST_STATE/jobs" "$GHOST_STATE/logs" "$GHOST_STATE/worker.lock"
+chmod 700 "$GHOST_HOME" "$GHOST_STATE" "$GHOST_STATE/jobs" "$GHOST_STATE/logs" "$GHOST_STATE/worker.lock"
+sleep 0.01 &
+GHOST_OWNER_PID=$!
+wait "$GHOST_OWNER_PID" 2>/dev/null || true
+printf '%s\n' "$GHOST_OWNER_PID" > "$GHOST_STATE/worker.lock/pid"
+printf 'stale\n' > "$GHOST_STATE/worker.lock/start"
+printf 'stale\n' > "$GHOST_STATE/worker.lock/command"
+# An orphaned atomic-publish scratch file, exactly as a worker killed between
+# mktemp and rename would leave behind (issue #1972). Nothing else ever
+# removes this dotfile, so it must not be able to wedge reclaim forever.
+: > "$GHOST_STATE/worker.lock/.quarantine.orphan1"
+chmod 600 "$GHOST_STATE/worker.lock/pid" "$GHOST_STATE/worker.lock/start" \
+  "$GHOST_STATE/worker.lock/command" "$GHOST_STATE/worker.lock/.quarantine.orphan1"
+touch -t 200001010000 "$GHOST_STATE/worker.lock"
+HOME="$GHOST_HOME" FM_ROOT_OVERRIDE="$REMOTE_ROOT" FM_REMOTE_JOB_STATE_ROOT="$GHOST_STATE" \
+  FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux "$REMOTE_ROOT/bin/fm-remote-job-worker.sh" --serve \
+  > "$TMP_ROOT/ghost-worker.out" 2> "$TMP_ROOT/ghost-worker.err" &
+GHOST_WORKER_PID=$!
+for _ in $(seq 1 300); do
+  [ -f "$GHOST_STATE/worker.ready" ] && break
+  kill -0 "$GHOST_WORKER_PID" 2>/dev/null || break
+  sleep 0.05
+done
+assert_present "$GHOST_STATE/worker.ready" \
+  "an orphaned atomic-publish scratch file permanently wedged worker ownership"
+assert_absent "$GHOST_STATE/worker.lock/.quarantine.orphan1" \
+  "reclaim left the orphaned scratch file behind"
+kill -TERM "$GHOST_WORKER_PID" 2>/dev/null || true
+wait "$GHOST_WORKER_PID" 2>/dev/null || true
+GHOST_WORKER_PID=
+pass "an orphaned atomic-publish scratch file does not permanently wedge worker ownership"
 
 echo "ALL TESTS PASSED"


### PR DESCRIPTION
## Summary

- Reclaim orphaned atomic-publish scratch files after the existing worker-liveness checks establish that an ownership lock is stale.
- Clear the same known scratch patterns from both worker cleanup paths and the Linux supervisor cleanup path.
- Name the exact wedged ownership lock when an unexpected symlink or unknown entry prevents safe reclamation.
- Add a behavioral regression that creates a stale `worker.lock` containing an orphaned `.quarantine.*` file and proves a replacement worker becomes ready.

## Verification

- No-mistakes review completed with no findings.
- No-mistakes testing completed successfully, including a pre-fix run that proved the new regression fails without the fix.
- No-mistakes documentation validation completed successfully.
- No-mistakes lint completed successfully, including the shellcheck-clean `bin/` requirement.

## Decisions

- Fixed all three identical instances of the canonical-file-removal-then-`rmdir` pattern in `bin/fm-remote-job-worker.sh`: `worker_acquire_lock`, `worker_cleanup`, and `worker_supervisor_cleanup_dead_child`.
  Evidence: all three can encounter scratch names created by `worker_publish_lock_owner` or `worker_publish_quarantine`, and all three previously removed only canonical names before attempting `rmdir`.
- Did not implement the optional signal-trap hardening suggested by the issue.
  Evidence: changing `trap -` to `trap ''` narrows one interruption window but cannot prevent SIGKILL, OOM termination, or crashes from orphaning scratch files, while the stale-lock reclamation fixes the permanent deadlock without changing signal semantics.
- Refuse symlinked scratch entries instead of following or removing them.
  Evidence: this matches the existing symlink-refusal boundary for canonical `pid`, `start`, and `command` entries in the same ownership paths.
- Clear scratch entries only after the existing live-owner, readiness-probe, and recent-lock checks have all failed.
  Evidence: this preserves the same no-live-worker safety envelope already required before reclaiming canonical lock entries, so mutual exclusion is not weakened.
- Emit a worker error containing the exact `worker.lock` path when scratch cleanup is unsafe or unknown entries keep the directory nonempty.
  Evidence: the former generic acquisition failure did not identify the state root whose ownership lock required attention.

Closes #1972
