### PR TITLE
docs(vision): elevate experience, pain narrative, and distro virtues

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -1,17 +1,23 @@
 # Vision
 
 `firstmate` exists so that one person can run a crew of coding agents with the leverage of a team and the accountability of a single pair of hands.
+The biggest thing it aims to create is not a smart workflow, a useful tool, or an impressive piece of technology.
+It aims to create an experience: a sense of peacefulness, confidence that everything is under control, and an ease of mind that nothing will fall through the cracks the moment the captain looks away.
+That experience is the experience of being a good captain who sails with a well-managed crew, with a first mate that carries out the captain's direction.
 It serves the captain: an individual operator whose ambitions outrun their attention, and it turns intent stated once into delegated, supervised, evidence-backed work across every project they care about.
 It empowers exactly one individual; collaboration between humans belongs to other systems.
 It owns exactly one thing: the layer between the captain's intent and the agents that carry it out.
 
 ## One captain, one interface
 
+Without a first mate, parallel agent sessions force constant context-switching: the captain juggles a long list of sessions, relearns what each one was about and what the right next step should be, and watches coding's focus, flow, and peace replaced by non-stop tab-juggling.
+Most harnesses and orchestrator apps make it easier to see those sessions and jump between them, but the context switch remains the captain's burden.
 The captain talks to the first mate and to nobody else; every worker reports through the first mate and never addresses the captain directly.
 Captain-facing language is outcomes, consequences, and decisions; the machinery that produced them stays below deck.
 An escalation exists for a decision only a human can make; progress, retries, and internal mechanics are never news.
 The interface must stay honest under load: batching and silence are presentation choices, and never hide a failure, a decision, or a risk.
-Experience features on top of this interface are welcome only when they compose with the workflows the captain already has: opt-in, and never in the way.
+Peace of mind is the purpose of this interface, not a garnish on top of it.
+Presentation and convenience features that serve that experience are welcome when they compose with the workflows the captain already has: opt-in, and never in the way of the captaincy itself.
 
 ## Authority is explicit and never inferred
 
@@ -37,6 +43,7 @@ The command structure stays flat: every layer between the captain's intent and t
 Everything that matters survives the death of any conversation: work in flight, promises made, decisions pending, and the captain's preferences live in durable records, never in chat memory.
 The fleet reconciles from disk and from live session state, so killing any session, including the first mate's own, loses nothing and surprises no one.
 Obligations are closed by records, not by recollection: a promised reply, an open decision, or a queued wake is retired only by the durable event that answers it.
+This durability is how the experience holds when attention leaves: confidence that everything is under control, and ease of mind that nothing falls through the cracks the moment the captain looks away.
 
 ## Delegation with a spine
 
@@ -48,8 +55,11 @@ A new task shape earns its way in only when existing primitives genuinely cannot
 
 ## The fleet outlives any vendor
 
-The first mate is an agent distro, not an app: instructions, skills, scripts, and state conventions that any verified harness can inhabit.
-The first mate can read, understand, and evolve every part of itself: plain instructions, scripts, and text records keep the whole system introspectable and hot-modifiable by the very agent that runs it.
+The first mate is not another harness and not another orchestrator app.
+The experience it creates is a new way of working, orthogonal to which agent harness or session manager the captain already uses.
+It is an agent distro, not an app: instructions, skills, scripts, and state conventions that any verified harness can inhabit - Claude Code, Codex, Pi, and others - and that run across session managers such as tmux, Herdr, and Orca.
+The first mate can read, understand, and evolve every part of itself: plain instructions, scripts, and text records keep the whole system introspectable, hot-modifiable, and self-evolving by the very agent that runs it.
+When something is not working well, the captain can ask the first mate and it figures it out; captains using their own firstmate to improve the shared surface is how the fleet evolves in the open.
 Harness adapters earn trust through verification, and the fleet keeps sailing when any one vendor's tool degrades.
 Contracts bind to semantics a vendor actually exposes, never to the pixels of today's UI.
 Quota, model, and effort choices stay inspectable and captain-owned; the first mate never downgrades the intelligence doing the work without the captain's standing, explicit permission.
@@ -58,8 +68,9 @@ Quota, model, and effort choices stay inspectable and captain-owned; the first m
 
 firstmate is the command layer, not the workshop: validation belongs to no-mistakes, CI belongs to the forge, and merge policy belongs to the configured authority.
 It is not a general agent framework, not a hosted service, and not a prepackaged product; it is a template one person clones, owns, deeply customizes, and operates under their own identity.
+Setup stays that simple by design: clone the repo, run your agent in it, and that is it.
 The shared surface is generic and captain-agnostic; everything personal - preferences, projects, records, credentials - stays private to the home that owns it.
 This repository ships through its own discipline: firstmate work is validated like any other project's, and field incidents become regression coverage.
 
-A change aligns when it gives the captain more shipped outcomes per unit of attention and tokens, makes delegation safer or more legible, strengthens a refusal path, keeps the system introspectable and hot-modifiable, or lets the fleet survive another failure mode.
-A change should be resisted when it lets the fleet act beyond adjudicable intent, assumes consent instead of asking for it, adds a layer between intent and action, mixes scripted mechanics with agent judgment, spends tokens where a script would do, serves anyone but the captain, couples the distro to one vendor, buries an outcome in mechanics, or grows the command layer into the workshop it commands.
+A change aligns when it deepens the captain's peace of mind, confidence, and ease of looking away, gives more shipped outcomes per unit of attention and tokens, makes delegation safer or more legible, strengthens a refusal path, keeps the system introspectable, hot-modifiable, and self-evolving, or lets the fleet survive another failure mode.
+A change should be resisted when it trades that experience for more noise or more context-switching, lets the fleet act beyond adjudicable intent, assumes consent instead of asking for it, adds a layer between intent and action, mixes scripted mechanics with agent judgment, spends tokens where a script would do, serves anyone but the captain, couples the distro to one vendor or session manager, buries an outcome in mechanics, or grows the command layer into the workshop it commands.

--- a/VISION.md
+++ b/VISION.md
@@ -1,7 +1,6 @@
 # Vision
 
 `firstmate` exists so that one person can run a crew of coding agents with the leverage of a team and the accountability of a single pair of hands.
-The biggest thing it aims to create is not a smart workflow, a useful tool, or an impressive piece of technology.
 It aims to create an experience: a sense of peacefulness, confidence that everything is under control, and an ease of mind that nothing will fall through the cracks the moment the captain looks away.
 That experience is the experience of being a good captain who sails with a well-managed crew, with a first mate that carries out the captain's direction.
 It serves the captain: an individual operator whose ambitions outrun their attention, and it turns intent stated once into delegated, supervised, evidence-backed work across every project they care about.


### PR DESCRIPTION
## Summary

Updates `VISION.md` so the public vision matches the captain's own framing from the 3k-stars reflection tweet: experience as the primary goal, multi-session pain as the problem, clone-and-run ease, self-evolution (including community), and explicit harness/backend orthogonality.

This is a docs-only PR for captain review. Direct-PR delivery (no no-mistakes pipeline). Do not merge without captain word.

## What changed (5 elements)

1. **Experience north star as primary goal** (opening + One captain, one interface + restart + aligns/resists)
   - Opening now states the biggest aim is not a smart workflow / useful tool / impressive technology, but an experience: peacefulness, confidence everything is under control, ease of mind that nothing falls through the cracks when the captain looks away.
   - Captaincy metaphor kept: well-managed crew with a first mate carrying out direction.
   - **Reconciled former L14-15 garnish framing:** replaced "Experience features on top of this interface are welcome only when..." with "Peace of mind is the purpose of this interface, not a garnish on top of it," then re-scoped presentation/convenience features as servants of that experience (still opt-in, still never in the way of the captaincy).
   - Durable restart section now explicitly connects records-based durability to how that experience holds when attention leaves.

2. **Multi-session juggling pain narrative** (One captain, one interface)
   - Added problem statement before the interface rules: parallel sessions, context-switching, relearning each session, focus/flow/peace replaced by tab-juggling; harnesses/orchestrators only make jumping easier without removing the burden.

3. **Clone-and-run setup ease** (Scope)
   - Alongside template/clone/own: "Setup stays that simple by design: clone the repo, run your agent in it, and that is it."

4. **Self-introspect + self-evolution, including community** (The fleet outlives any vendor)
   - Elevated hot-modifiable to self-evolving; added "ask the first mate and it figures it out" plus community self-evolution of the shared surface.

5. **Harness- and backend-agnostic / not another harness** (The fleet outlives any vendor)
   - Explicit "not another harness and not another orchestrator app"; "new way of working" orthogonal to harness and session manager; names example harnesses and backends while preserving distro shape.

## Aligns / resists

Structure preserved (two adjudication sentences at the end).

- **Aligns** now leads with deepening peace of mind, confidence, and ease of looking away; also includes self-evolving.
- **Resists** adds trading that experience for more noise or more context-switching, and couples-to-one-vendor expanded to "one vendor or session manager."

Unchanged in substance: authority/consent, scripts-vs-agents, delegation-with-spine, token efficiency, scope boundaries.

## Checks

- One sentence per physical line; plain dash (no em dash).
- `bin/fm-doc-audience-check.sh` → ok (VISION.md remains `public-product`).

## Source

Captain tweet https://x.com/kunchenguid/status/2086834015278137549 (full verbatim capture in scout report for this task). Scout findings only; ship is the VISION.md fold authorized after promotion.
