### PR TITLE
fix(spawn): support launches from remoteless projects

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -138,6 +138,11 @@
 #   origin, resolves the current remote default branch, and resets to its tip.
 #   An unreachable origin, unresolved default branch, or non-clean worktree
 #   refuses the spawn rather than risking a PR based on stale history.
+#   A project with no origin remote configured has no remote to be stale against,
+#   so that spawn warns once and refreshes the worktree from the local default
+#   branch instead; the clean-worktree requirement is unchanged. That skip is
+#   decided from the configured remote list alone, never from a failed fetch, so
+#   a configured-but-unreachable origin still refuses.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -1684,23 +1689,45 @@ validate_spawn_worktree() {  # <source> <inspect-target>
 }
 
 freshen_spawn_worktree_base() {  # <worktree>
-  local worktree=$1 default target expected actual status
-  if ! git -C "$worktree" fetch --quiet origin; then
-    echo "error: could not fetch origin for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
-    return 1
-  fi
-  if ! git -C "$worktree" remote set-head origin --auto >/dev/null 2>&1; then
-    echo "error: could not resolve origin's current default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
-    return 1
-  fi
-  default=$(default_branch "$worktree") || {
-    echo "error: could not determine origin's default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+  local worktree=$1 remotes default target expected actual status
+  # The staleness this guard exists to prevent is staleness relative to origin,
+  # so a repo with no origin configured has nothing to be stale against. Decide
+  # that from the configured remote list, never from a failed fetch: a network
+  # error and a missing remote must not collapse into one branch, because only
+  # the second is safe to skip. Everything after the origin-only steps - the
+  # clean-worktree requirement, the reset, and the verified result - still runs.
+  remotes=$(git -C "$worktree" remote) || {
+    echo "error: could not inspect the remotes of pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
     return 1
   }
-  target="origin/$default"
-  if ! git -C "$worktree" fetch --quiet origin "+refs/heads/$default:refs/remotes/origin/$default"; then
-    echo "error: could not fetch '$target' for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
-    return 1
+  if printf '%s\n' "$remotes" | grep -qx origin; then
+    if ! git -C "$worktree" fetch --quiet origin; then
+      echo "error: could not fetch origin for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+      return 1
+    fi
+    if ! git -C "$worktree" remote set-head origin --auto >/dev/null 2>&1; then
+      echo "error: could not resolve origin's current default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+      return 1
+    fi
+    default=$(default_branch "$worktree") || {
+      echo "error: could not determine origin's default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+      return 1
+    }
+    target="origin/$default"
+    if ! git -C "$worktree" fetch --quiet origin "+refs/heads/$default:refs/remotes/origin/$default"; then
+      echo "error: could not fetch '$target' for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+      return 1
+    fi
+  else
+    default=$(default_branch "$worktree") || {
+      echo "error: could not determine the local default branch of pooled worktree '$worktree', which has no origin remote; refusing to launch from a potentially stale base" >&2
+      return 1
+    }
+    target="refs/heads/$default"
+    # Warn rather than skip silently: the launch still gets a clean, current
+    # local base, but the stronger remote-freshness guarantee did not apply, and
+    # a silent skip is exactly what makes a weakened guard hard to notice later.
+    echo "warning: pooled worktree '$worktree' has no origin remote; refreshing its base from the local '$default' instead of a fetched remote tip" >&2
   fi
   expected=$(git -C "$worktree" rev-parse --verify --quiet "$target^{commit}" 2>/dev/null) || {
     echo "error: '$target' is not a commit for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -147,6 +147,7 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
 `fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
+A project with no origin remote configured has no remote tip to be stale against, so it warns and refreshes from its local default branch instead; only a missing remote takes that path, and a configured origin that cannot be fetched still stops the spawn.
 Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,7 +146,7 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
-`fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
+`fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree has a safe, current base, and any unsafe or unverifiable base stops the spawn.
 A project with no origin remote configured has no remote tip to be stale against, so it warns and refreshes from its local default branch instead; only a missing remote takes that path, and a configured origin that cannot be fetched still stops the spawn.
 Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
 

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -6,6 +6,9 @@
 # These tests drive the real spawn path with a fake terminal, then prove it
 # starts the worker from the fetched origin/main tip or stops when origin is
 # unreachable.
+# A project with no origin remote has nothing to be stale against, so these also
+# pin the other half of that distinction: a remoteless repo launches from its
+# local default branch while a configured-but-unfetchable origin still refuses.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -34,8 +37,13 @@ SH
   printf '%s\n' "$fakebin"
 }
 
+# make_case <name> <id> [default-branch] [remote]
+# <remote> is `origin` (the default: a bare origin whose default branch is
+# advanced past the pool base by a separate publisher clone) or `none` (no
+# remote at all, with the LOCAL default branch advanced past the pool base
+# instead, so the same "did the base move" assertions still mean something).
 make_case() {
-  local name=$1 id=$2 default=${3:-main} case_dir home project origin pool publisher fakebin initial
+  local name=$1 id=$2 default=${3:-main} remote=${4:-origin} case_dir home project origin pool publisher fakebin initial
   case_dir="$TMP_ROOT/$name"
   home="$case_dir/home"
   project="$case_dir/project"
@@ -53,16 +61,23 @@ make_case() {
   printf 'base\n' > "$project/README.md"
   git -C "$project" add README.md
   git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
-  git clone --quiet --bare "$project" "$origin"
-  git -C "$project" remote add origin "file://$origin"
   initial=$(git -C "$project" rev-parse HEAD)
-  git -C "$project" worktree add --quiet --detach "$pool" "$initial"
+  if [ "$remote" = none ]; then
+    git -C "$project" worktree add --quiet --detach "$pool" "$initial"
+    printf 'must survive a newly spawned branch\n' > "$project/advanced-main.txt"
+    git -C "$project" add advanced-main.txt
+    git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm advance-local-default
+  else
+    git clone --quiet --bare "$project" "$origin"
+    git -C "$project" remote add origin "file://$origin"
+    git -C "$project" worktree add --quiet --detach "$pool" "$initial"
 
-  git clone --quiet "file://$origin" "$publisher"
-  printf 'must survive a newly spawned branch\n' > "$publisher/advanced-main.txt"
-  git -C "$publisher" add advanced-main.txt
-  git -C "$publisher" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm advance-main
-  git -C "$publisher" push --quiet origin "$default"
+    git clone --quiet "file://$origin" "$publisher"
+    printf 'must survive a newly spawned branch\n' > "$publisher/advanced-main.txt"
+    git -C "$publisher" add advanced-main.txt
+    git -C "$publisher" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm advance-main
+    git -C "$publisher" push --quiet origin "$default"
+  fi
 
   printf '%s\n' "$case_dir|$home|$project|$pool|$fakebin|$initial|$default"
 }
@@ -150,6 +165,10 @@ test_unreachable_origin_refuses_stale_pool_base() {
   [ "$status" -ne 0 ] || fail "spawn succeeded despite an unreachable origin"
   assert_contains "$out" "could not fetch origin" \
     "spawn did not clearly refuse an unreachable origin"
+  # The refusal must come from the fetch failing, not from mistaking a
+  # configured-but-unreachable origin for a repo that has no origin at all.
+  assert_not_contains "$out" "has no origin remote" \
+    "spawn treated an unreachable origin as a missing remote"
   after=$(git -C "$POOL_DIR" rev-parse HEAD)
   [ "$after" = "$before" ] || fail "spawn changed the pooled worktree after origin became unreachable"
   if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
@@ -227,11 +246,68 @@ test_unresolved_remote_default_refuses_pool() {
   pass "an unresolved remote default branch refuses the pooled worktree"
 }
 
+test_remoteless_project_launches_from_local_default() {
+  local rec id out status current branch_head
+  id='pool-remoteless-r6'
+  rec=$(make_case remoteless "$id" main none)
+  read_case_record "$rec"
+  [ -z "$(git -C "$POOL_DIR" remote)" ] || fail "fixture did not produce a repository without any remote"
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 0 "$status" "spawn should launch a ship into a project with no origin remote"
+  assert_contains "$out" "spawned $id" "spawn did not report success for a remoteless project"
+  assert_contains "$out" "has no origin remote" \
+    "spawn skipped the origin refresh without disclosing the weaker guarantee"
+  current=$(git -C "$POOL_DIR" rev-parse "refs/heads/$DEFAULT_BRANCH")
+  branch_head=$(git -C "$POOL_DIR" rev-parse HEAD)
+  [ "$branch_head" = "$current" ] || fail "spawn left the remoteless pooled worktree off the local default branch tip"
+  [ "$branch_head" != "$INITIAL_SHA" ] || fail "fixture did not prove the local default branch advanced past the pool base"
+  assert_grep 'must survive a newly spawned branch' "$POOL_DIR/advanced-main.txt" \
+    "the remoteless spawn omitted the local default branch's newest content"
+
+  id='pool-remoteless-scout-r6'
+  mkdir -p "$HOME_DIR/data/$id"
+  printf 'brief for %s\n' "$id" > "$HOME_DIR/data/$id/brief.md"
+  out=$(run_spawn "$id" --scout)
+  status=$?
+  expect_code 0 "$status" "spawn should launch a scout into a project with no origin remote"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$current" ] \
+    || fail "the remoteless scout spawn did not start at the local default branch tip"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed remoteless spawn: %s\n' "$(printf '%s\n' "$out" | tail -n 1)"
+    printf '# observed remoteless base: HEAD=%s local-%s=%s\n' "$branch_head" "$DEFAULT_BRANCH" "$current"
+  fi
+  pass "a project with no origin remote launches ships and scouts from its local default branch"
+}
+
+test_remoteless_dirty_pool_still_refuses() {
+  local rec id out status before
+  id='pool-remoteless-dirty-r7'
+  rec=$(make_case remoteless-dirty "$id" main none)
+  read_case_record "$rec"
+  before=$(git -C "$POOL_DIR" rev-parse HEAD)
+  printf 'keep this local work\n' > "$POOL_DIR/uncommitted.txt"
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn succeeded despite a dirty pooled worktree with no origin remote"
+  assert_contains "$out" "is not clean" \
+    "skipping the origin refresh also dropped the clean-worktree requirement"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
+    || fail "spawn moved HEAD while refusing a dirty remoteless pooled worktree"
+  assert_grep 'keep this local work' "$POOL_DIR/uncommitted.txt" \
+    "spawn discarded uncommitted work while refusing a remoteless pool"
+  pass "a remoteless project still refuses a dirty pooled worktree without discarding its work"
+}
+
 test_stale_pool_base_refreshes_before_branching
 test_non_main_default_branch_refreshes_before_branching
 test_direct_pr_and_scout_refresh_before_launch
 test_dirty_pool_refuses_without_discarding_work
 test_unresolved_remote_default_refuses_pool
 test_unreachable_origin_refuses_stale_pool_base
+test_remoteless_project_launches_from_local_default
+test_remoteless_dirty_pool_still_refuses
 
 echo "# all fm-spawn-pool-base-freshen tests passed"


### PR DESCRIPTION
## Intent

Fix a spawn regression that blocks every crewmate and scout launch into a project with no `origin` remote. This is urgent: it currently blocks all work on two of the three registered projects, both gated by a hard 2026-08-22 deadline.

The defect: commit fc5f164 ("fix(spawn): refresh pooled worktrees from origin before launch") added freshen_spawn_worktree_base() to bin/fm-spawn.sh, called for every spawn that is not a relaunch and not a secondmate, so it covers ship and scout launches on every backend. Its first action is `git -C "$worktree" fetch --quiet origin`. A repository with no `origin` remote cannot satisfy that, so the spawn dies with "fatal: 'origin' does not appear to be a git repository" followed by "error: could not fetch origin for pooled worktree '<path>'; refusing to launch from a potentially stale base". Reproducible with any remoteless repo: projects/tacos-draft-dashboard and projects/fantasy-football-draft both have zero remotes, while projects/smarttail has one and spawns fine.

The requested fix: the guard's premise is staleness relative to `origin`, and that premise is vacuous when there is no `origin`, so the refresh should be skipped for a remoteless repo. Every existing refusal for a repo that DOES have an `origin` it cannot reach must stay intact - that case is genuinely unsafe and is exactly what fc5f164 was written to prevent. The distinction is "no origin is configured" versus "origin is configured and the fetch failed", and only the first is safe to skip. The configured remote must be detected explicitly rather than inferred from the fetch failure, because a network error and a missing remote must not collapse into the same branch. Whether the skip is silent or prints a one-line notice was an explicitly delegated decision, to be made deliberately with the reason stated in the commit message. A pooled worktree of a remoteless repo still needs its base to be a clean, current default branch from the local repository, so the rest of the launch path must still leave it in the intended state and the cleanliness check must not be silently dropped along with the fetch.

Decisions made while implementing, which a reviewer reading only the diff would not know:
- Detection reads the configured remote list (`git remote`, matched exactly against `origin`) BEFORE any fetch, so the branch is chosen from configuration and never from a failed fetch. A failure of `git remote` itself refuses rather than silently taking the remoteless path.
- The remoteless path deliberately skips ONLY the origin-dependent steps (the two fetches and `remote set-head`). It still resolves the default branch through the existing shared default_branch helper, still refuses a worktree with uncommitted work, still resets to the default branch tip, and still verifies the resulting HEAD. Its reset target is the local `refs/heads/<default>` instead of `origin/<default>`, which is the local-repository equivalent of the same clean, current base - not a weakening of the guard into a no-op.
- The skip WARNS on stderr rather than staying silent. This was the delegated call: the launch is safe, but the stronger remote-freshness guarantee did not apply to it, and a guard that quietly weakens itself is hard to notice later. One stderr line per affected spawn keeps that visible without touching the success path. The rationale is recorded in the commit message as required. The wording ("has no origin remote") is deliberately distinct from the unreachable-origin refusal wording, and a regression test asserts the unreachable case never emits it.
- Deliberately NOT reverted: fc5f164 also added local origins to previously remoteless fixtures in tests/lib.sh, tests/fm-tangle-guard.test.sh, and tests/fm-gate-refuse.test.sh. Those now exercise the origin path on purpose and were left alone.

Repo rules that apply: this is firstmate's own shared tracked material, so the firstmate-coding-guidelines skill was loaded and followed - one sentence per line in prose, plain dash rather than the em dash character, shellcheck-clean bin/ scripts, colocated tests under tests/ extending the existing script rather than a new runner, the one-owner rule (the script header owns exact mechanics while docs/architecture.md owns the boundary statement), and never adding an agent name as a commit co-author.

Verification required and performed: a regression test was mandatory, not optional, covering both halves of the distinction - (1) a remoteless repo spawns instead of refusing, and (2) a repo with an `origin` that cannot be fetched still refuses with the existing message. tests/fm-spawn-pool-base-freshen.test.sh was extended with a remoteless fixture whose LOCAL default branch is advanced past the pool base, covering a ship launch, a scout launch, the disclosure line, and a dirty remoteless pool that must still be refused without discarding uncommitted work; the pre-existing unreachable-origin test additionally asserts the refusal never reports a missing remote. Each new assertion was proven able to go red by breaking the code on purpose (forcing the origin path unconditionally, removing the warning, inferring the skip from a failed fetch, dropping the clean-worktree check along with the fetch, and returning early without the local reset), and each break was reverted. bin/fm-lint.sh (shellcheck 0.11.0) and bin/fm-doc-audience-check.sh are clean, and the changed-file selection through bin/fm-test-run.sh exited 0.

Acceptance criteria: bin/fm-spawn.sh launches a ship or scout task into a remoteless project; every pre-existing refusal for a reachable-origin repo is preserved, including an origin that is configured but unfetchable; regression tests cover both cases and were each proven able to fail; shellcheck is clean on every script touched.

## What Changed

- Skip only origin-dependent freshness checks for projects without an `origin` remote, while refreshing from the local default branch and preserving clean-worktree and verification guards.
- Preserve existing refusal behavior for configured but unreachable origins, with distinct warning and error messages.
- Document the remoteless-project boundary and add regression coverage for ship, scout, dirty-worktree, and unreachable-origin cases.

## Risk Assessment

✅ Low: The change explicitly distinguishes a missing origin from an unreachable configured origin, preserves the existing refusal and cleanliness checks, and keeps the local default-branch reset and verification on the remoteless path.

## Testing

The focused regression test passed, covering remoteless ship/scout launches, local default refresh, warning disclosure, dirty-worktree refusal, and preserved unreachable-origin refusal. No source or test files were changed.

<details>
<summary>Evidence: Spawn regression evidence</summary>

`Focused regression transcript shows successful ship/scout launches for remoteless repos, local-default HEAD alignment, dirty-pool preservation, and refusal for unreachable origin.`

```text
# observed spawn: spawned pool-current-base-r1 harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-pool-current-base-r1 worktree=/var/folders/yz/tvv5c7_n0yqdw9bmvyyknvwc0000gn/T//fm-spawn-pool-base-freshen.2XueT5/current-base/pool
# observed base: HEAD=8fac3c00f1c90fec881ee558f00f292b9deff748 origin/main=8fac3c00f1c90fec881ee558f00f292b9deff748 advanced-main=must survive a newly spawned branch
ok - a stale pooled worktree refreshes to current origin/main before a crew branch is created
ok - a stale pooled worktree resolves and refreshes a non-main default branch
# observed direct-pr spawn: spawned pool-direct-pr-r3 harness=codex kind=ship mode=direct-PR yolo=off window=firstmate:fm-pool-direct-pr-r3 worktree=/var/folders/yz/tvv5c7_n0yqdw9bmvyyknvwc0000gn/T//fm-spawn-pool-base-freshen.2XueT5/direct-pr/pool
# observed scout spawn: spawned pool-scout-r3 harness=codex kind=scout window=firstmate:fm-pool-scout-r3 worktree=/var/folders/yz/tvv5c7_n0yqdw9bmvyyknvwc0000gn/T//fm-spawn-pool-base-freshen.2XueT5/scout/pool
ok - direct-PR ships and scouts both refresh stale pooled worktrees before launch
# observed dirty refusal: error: pooled worktree '/var/folders/yz/tvv5c7_n0yqdw9bmvyyknvwc0000gn/T//fm-spawn-pool-base-freshen.2XueT5/dirty-refusal/pool' is not clean; refusing to discard uncommitted work while refreshing its base; preserved=keep this local work
ok - a dirty pooled worktree is refused without discarding its local work
# observed unresolved-default refusal: error: could not resolve origin's current default branch for pooled worktree '/var/folders/yz/tvv5c7_n0yqdw9bmvyyknvwc0000gn/T//fm-spawn-pool-base-freshen.2XueT5/unresolved-default/pool'; refusing to launch from a potentially stale base
ok - an unresolved remote default branch refuses the pooled worktree
# observed unreachable-origin refusal: error: could not fetch origin for pooled worktree '/var/folders/yz/tvv5c7_n0yqdw9bmvyyknvwc0000gn/T//fm-spawn-pool-base-freshen.2XueT5/unreachable-origin/pool'; refusing to launch from a potentially stale base
ok - an unreachable origin refuses a potentially stale pooled worktree
# observed remoteless spawn: spawned pool-remoteless-scout-r6 harness=codex kind=scout window=firstmate:fm-pool-remoteless-scout-r6 worktree=/var/folders/yz/tvv5c7_n0yqdw9bmvyyknvwc0000gn/T//fm-spawn-pool-base-freshen.2XueT5/remoteless/pool
# observed remoteless base: HEAD=2fddf81df8d2ef5dd5c7e73b1d25bdb9e884b686 local-main=2fddf81df8d2ef5dd5c7e73b1d25bdb9e884b686
ok - a project with no origin remote launches ships and scouts from its local default branch
ok - a remoteless project still refuses a dirty pooled worktree without discarding its work
# all fm-spawn-pool-base-freshen tests passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`FM_TEST_EVIDENCE=1 bash tests/fm-spawn-pool-base-freshen.test.sh` using a temporary process-identity fixture</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
