### PR TITLE
fix: preserve live pipeline run state during crew reporting

### DIFF
--- a/.agents/skills/stuck-crewmate-recovery/SKILL.md
+++ b/.agents/skills/stuck-crewmate-recovery/SKILL.md
@@ -28,7 +28,7 @@ Recover a genuinely stuck remote mate only through `bin/fm-spawn.sh <id> --secon
 
 Treat the digest's endpoint result as a presence signal, not proof that the task's work or validation run is gone.
 Read the targeted current state with `bin/fm-crew-state.sh <id>` before deciding to relaunch.
-A no-mistakes run matched to the crew's branch and current code remains authoritative when the endpoint is dead: handle a terminal or parked run through the normal lifecycle, and keep supervising an active run instead of creating a duplicate worker.
+A no-mistakes run attributed to the crew by `bin/fm-crew-state.sh` remains authoritative when the endpoint is dead: handle a terminal or parked run through the normal lifecycle, and keep supervising an active run instead of creating a duplicate worker.
 
 When no authoritative run accounts for the task, inspect only its recorded backend and worktree inventory.
 Use `treehouse status` for treehouse-backed tmux, herdr, zellij, or cmux tasks, and use the recorded `orca_worktree_id=` and `terminal=` for Orca tasks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,7 +356,7 @@ Send the same worker one exact decision naming the decision key, step, action, a
 Require the matching `resolved` event, forbid `--yes`, and require the worker to process every synchronous return until completion or a genuinely new escalation.
 Resume fleet supervision immediately after the decision lands.
 
-Judge validation by the current-code-matched run step through `bin/fm-crew-state.sh`, not by shell liveness or the last status event.
+Judge validation by the current run step reported through `bin/fm-crew-state.sh`, not by shell liveness or the last status event.
 Running, fixing, or CI states remain working; parked approval or fix-review states require the worker to follow the active gate help; passed or checks-passed is done; failed or cancelled is failed.
 A worker hand-editing, committing, aborting, or restarting during an active validation run duplicates pipeline ownership outside the supersession sequence above; steer it back to the gate response flow.
 The worker reports the PR when CI first becomes green rather than waiting for merge monitoring to finish.

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -8,9 +8,9 @@
 # or blocked and the crew resumes (responds to the gate, the pipeline fixes, it
 # re-validates), the log's last line stays stale. This helper never infers the
 # current state from a tail of the log: it reads the authoritative source (a
-# no-mistakes run-step attributed to this crew's branch and current code
-# identity, else the pane busy-signature) and reconciles the possibly-stale log
-# against it.
+# no-mistakes run-step attributed to this crew's branch under the reporting
+# policy in fm-nm-run-lib.sh, else the pane busy-signature) and reconciles the
+# possibly-stale log against it.
 #
 # The determinism lives entirely here - only run-step / pane / log reads plus
 # fixed mapping logic, no heuristics and no LLM. Output is one stable, parseable,
@@ -27,14 +27,12 @@
 #      to the routed status log; dead/missing report the remote verdict; an
 #      unreachable or unreadable remote reports unknown-remote, never a false
 #      gone/dead.
-#   2. Matching no-mistakes run for this crew's branch AND current code identity,
-#      active or terminal (from `axi status`, or the coarse `no-mistakes runs`
-#      fallback)? Branch name alone is not enough: a historical run on a reused
-#      branch whose head was rewritten or diverged must not be attributed.
-#      A run matches when its head equals the worktree HEAD, or the worktree HEAD
-#      is an ancestor of the run head (pipeline fix commits advanced the run on
-#      the same line of history). Local work that advanced past the run head, or
-#      diverged from it, invalidates attribution.
+#   2. Reportable no-mistakes run for this crew's branch, active or terminal
+#      (from `axi status`, or the coarse `no-mistakes runs` fallback)? A missing
+#      head or locally resolvable rewritten/diverged head is not attributed.
+#      A nonempty head unavailable in the local object store remains reportable
+#      because it may be a live pipeline commit not yet fetched here. The shared
+#      library owns the exact reporting and strict teardown matching policies.
 #      The run-step is AUTHORITATIVE: running/fixing -> working, ci -> working,
 #      awaiting_approval/fix_review -> parked (with gate findings), terminal
 #      passed/checks-passed -> done, failed/cancelled -> failed. EXCEPT: while
@@ -217,10 +215,10 @@ crew_busy_verdict() {  # <target>
   fm_busy_classify "$TASK_BACKEND" "$1" "$HARNESS" "$ID" "$STATE" "$tail40"
 }
 
-# --- no-mistakes run lookup (authoritative when a run matches this branch) --
+# --- no-mistakes run lookup (authoritative when reporting attributes a run) -
 # trim, strip_quotes, the bounded nm_run call, nm_field's TOON parse, and the
-# branch+head attribution rule below are thin wrappers over the ONE owner in
-# bin/fm-nm-run-lib.sh, shared with fm-teardown.sh's pre-teardown run abort.
+# reporting attribution rule below are thin wrappers over the owner in
+# bin/fm-nm-run-lib.sh. Teardown uses that library's stricter policy.
 
 trim() { fm_nm_trim "$@"; }
 strip_quotes() { fm_nm_strip_quotes "$@"; }
@@ -353,40 +351,11 @@ nm_ci_checks_state() {
     *) printf 'unknown' ;;
   esac
 }
-# Coarse fallback for cross-branch attribution. `no-mistakes axi status` (bare)
-# reports the active-or-most-recent run for the CURRENT branch when one
-# exists, else falls back to some other branch's run purely as informational
-# display (verified empirically: querying a worktree with its own active run
-# reliably returns that run, even under concurrent load from several other
-# validating crews on the same underlying repo). A crew whose branch genuinely
-# has no run yet therefore sees another branch's answer here.
-#
-# This fallback used to shell out to `no-mistakes axi` (bare, no subcommand)
-# expecting a `runs[N]{id,branch,status,...}:` TOON table and re-query the
-# matched id via `axi status --run <id>`. Verified against the real installed
-# CLI (v1.32.2): the `axi` surface exposes only abort/logs/respond/run/status -
-# there is no runs-listing subcommand under `axi` at all, so that table never
-# appears and the lookup was silently dead code; whenever the bare `axi
-# status` answer was not this crew's own branch, attribution always failed and
-# the caller fell straight through to the pane/log fallback below. (The
-# PRIMARY cause of the 2026-07 herdr false-surface incidents turned out to be
-# a separate bug in bin/fm-watch.sh's stale_is_terminal precedence - see that
-# file's history - but this cross-branch path was independently confirmed
-# dead code and is worth having actually work.)
-#
-# The real run-listing command is the top-level `no-mistakes runs` (verified:
-# `no-mistakes --help` lists it separately from `axi`). It is plain, human-
-# oriented text - no run id, no JSON/TOON, newest-first, columns
-# "<status> <branch> <short-sha> <date> [<pr-url>]" separated by runs of
-# spaces (verified: no quoting, so splitting on the first two whitespace runs
-# is exact) - but branch + coarse status is exactly what this predicate needs:
-# is a run for THIS branch active right now. Echoes the branch's active
-# (running) matching row's status word when one exists, else the first
-# (most recent) terminal matching row's status word (completed/cancelled/
-# failed), or empty when the branch has no matching row within
-# FM_CREW_STATE_RUNS_LIMIT rows. An active row always outranks a terminal
-# one regardless of list order: a stale failed/completed row for this branch
-# must never shadow a live running row.
+# `axi status` can describe another branch's run, so the fallback scans the
+# top-level `no-mistakes runs` rows for this branch. Its plain rows provide only
+# a status, branch, and short SHA. Return a reportably matching running row in
+# preference to any terminal row, regardless of list order, so stale terminal
+# output cannot hide live validation.
 nm_runs_status_for_branch() {  # <branch>
   local branch=$1 out row st rest br sha terminal=''
   out=$(nm_run runs --limit "$FM_CREW_STATE_RUNS_LIMIT")
@@ -402,8 +371,8 @@ nm_runs_status_for_branch() {  # <branch>
     rest=$(trim "$rest")
     sha=${rest%% *}
     [ "$br" = "$branch" ] || continue
-    # Same code-identity rule as axi status: skip a same-branch row whose
-    # short-sha does not match this worktree (rewritten or advanced tip).
+    # A missing or locally incompatible head cannot be attributed; the shared
+    # reporting rule accepts only heads unavailable in the local object store.
     nm_coarse_head_matches_worktree "$sha" || continue
     if [ "$st" = running ]; then
       printf '%s' "$st"
@@ -419,8 +388,8 @@ nm_runs_status_for_branch() {  # <branch>
 # scratch worktree); with no branch there is no run to attribute to this crew.
 CREW_BRANCH=$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
 
-# 0 if the active axi-status run's head field matches this worktree's code
-# identity. Branch match is a precondition (caller).
+# 0 if the active axi-status run's head is reportable for this worktree.
+# Branch match is a precondition (caller).
 nm_run_head_matches_worktree() {
   local run_head
   run_head=$(strip_quotes "$(nm_field head)")
@@ -428,7 +397,7 @@ nm_run_head_matches_worktree() {
 }
 
 # Coarse runs-list rows are "<status> <branch> <short-sha> ...". 0 if the short
-# sha for this branch row matches the worktree head under the same rules as
+# SHA for this branch row is reportable under the same rules as
 # nm_run_head_matches_worktree.
 nm_coarse_head_matches_worktree() {  # <short-sha>
   fm_nm_head_matches_worktree_reporting "$WT" "$1"
@@ -450,9 +419,8 @@ if [ "$KIND" = ship ] && [ -n "$CREW_BRANCH" ] && command -v no-mistakes >/dev/n
     if [ -n "$run_branch" ] && [ "$run_branch" = "$CREW_BRANCH" ] && nm_run_head_matches_worktree; then
       HAVE_RUN=1
     else
-      # The active-or-most-recent run is for another branch, or same branch with
-      # a rewritten/diverged head (the CLI is alive and answered; only the
-      # attribution missed) - try the coarse fallback.
+      # The reported run belongs to another branch or is not reportable here.
+      # The CLI answered, so try the coarse fallback.
       # Deliberately nested inside `[ -n "$RUN_OUT" ]`: an empty/timed-out
       # primary call means the CLI itself did not respond, so retrying it
       # immediately with a second bounded call would just double the wait

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -380,11 +380,16 @@ nm_ci_checks_state() {
 # "<status> <branch> <short-sha> <date> [<pr-url>]" separated by runs of
 # spaces (verified: no quoting, so splitting on the first two whitespace runs
 # is exact) - but branch + coarse status is exactly what this predicate needs:
-# is a run for THIS branch active right now. Echoes the first (most recent)
-# matching row's status word (running/completed/cancelled/failed), or empty
-# when the branch has no run within FM_CREW_STATE_RUNS_LIMIT rows.
+# is a run for THIS branch active right now. Echoes the branch's active
+# (running) matching row's status word when one exists, else the first
+# (most recent) terminal matching row's status word (completed/cancelled/
+# failed), or empty when the branch has no matching row within
+# FM_CREW_STATE_RUNS_LIMIT rows. An active row always outranks a terminal
+# one regardless of list order: a stale failed/completed row for this branch
+# must never shadow a live running row (see fm_nm_head_matches_worktree's
+# header for why an unresolvable head must not be read as divergence either).
 nm_runs_status_for_branch() {  # <branch>
-  local branch=$1 out row st rest br sha
+  local branch=$1 out row st rest br sha terminal=''
   out=$(nm_run runs --limit "$FM_CREW_STATE_RUNS_LIMIT")
   [ -n "$out" ] || return 0
   while IFS= read -r row; do
@@ -397,16 +402,17 @@ nm_runs_status_for_branch() {  # <branch>
     rest=${rest#* }
     rest=$(trim "$rest")
     sha=${rest%% *}
-    if [ "$br" = "$branch" ]; then
-      # Same code-identity rule as axi status: skip a same-branch row whose
-      # short-sha does not match this worktree (rewritten or advanced tip).
-      if ! nm_coarse_head_matches_worktree "$sha"; then
-        continue
-      fi
+    [ "$br" = "$branch" ] || continue
+    # Same code-identity rule as axi status: skip a same-branch row whose
+    # short-sha does not match this worktree (rewritten or advanced tip).
+    nm_coarse_head_matches_worktree "$sha" || continue
+    if [ "$st" = running ]; then
       printf '%s' "$st"
       return 0
     fi
+    [ -n "$terminal" ] || terminal=$st
   done <<< "$out"
+  [ -n "$terminal" ] && printf '%s' "$terminal"
   return 0
 }
 

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -386,8 +386,7 @@ nm_ci_checks_state() {
 # failed), or empty when the branch has no matching row within
 # FM_CREW_STATE_RUNS_LIMIT rows. An active row always outranks a terminal
 # one regardless of list order: a stale failed/completed row for this branch
-# must never shadow a live running row (see fm_nm_head_matches_worktree's
-# header for why an unresolvable head must not be read as divergence either).
+# must never shadow a live running row.
 nm_runs_status_for_branch() {  # <branch>
   local branch=$1 out row st rest br sha terminal=''
   out=$(nm_run runs --limit "$FM_CREW_STATE_RUNS_LIMIT")
@@ -421,19 +420,18 @@ nm_runs_status_for_branch() {  # <branch>
 CREW_BRANCH=$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
 
 # 0 if the active axi-status run's head field matches this worktree's code
-# identity. Branch match is a precondition (caller). Rule owned by
-# fm_nm_head_matches_worktree in bin/fm-nm-run-lib.sh.
+# identity. Branch match is a precondition (caller).
 nm_run_head_matches_worktree() {
   local run_head
   run_head=$(strip_quotes "$(nm_field head)")
-  fm_nm_head_matches_worktree "$WT" "$run_head"
+  fm_nm_head_matches_worktree_reporting "$WT" "$run_head"
 }
 
 # Coarse runs-list rows are "<status> <branch> <short-sha> ...". 0 if the short
 # sha for this branch row matches the worktree head under the same rules as
-# nm_run_head_matches_worktree (equal, or local is ancestor of run tip).
+# nm_run_head_matches_worktree.
 nm_coarse_head_matches_worktree() {  # <short-sha>
-  fm_nm_head_matches_worktree "$WT" "$1"
+  fm_nm_head_matches_worktree_reporting "$WT" "$1"
 }
 
 HAVE_RUN=0

--- a/bin/fm-nm-run-lib.sh
+++ b/bin/fm-nm-run-lib.sh
@@ -63,19 +63,20 @@ fm_nm_field() {  # <toon-output> <key>
 #     the same history advanced the run tip past local HEAD)
 #   - run head is a strict ancestor of worktree HEAD, or diverged: no match
 #     (local work advanced outside the run, or the branch tip was rewritten)
-#   - run head not resolvable as a local object: cannot prove either relation,
-#     so match rather than reject. A live pipeline-owned run legitimately
-#     advances the branch past a commit this worktree's object store has not
-#     observed yet (branch_sync.state: pipeline_owned - "the pipeline head has
-#     moved but has not been successfully pushed"); rejecting on unresolvable
-#     input previously fell through to a stale terminal run at the worktree's
-#     own sha and reported a live run as failed. A false "still working" here
-#     is harmless (supervision just keeps watching); a false "failed" is not.
 fm_nm_head_matches_worktree() {  # <worktree> <run_head>
   local wt=$1 run_head=$2 local_full run_full
   [ -n "$run_head" ] || return 1
   local_full=$(git -C "$wt" rev-parse HEAD 2>/dev/null) || return 1
-  run_full=$(git -C "$wt" rev-parse --verify "${run_head}^{commit}" 2>/dev/null) || return 0
+  run_full=$(git -C "$wt" rev-parse --verify "${run_head}^{commit}" 2>/dev/null) || return 1
   [ "$run_full" = "$local_full" ] && return 0
   git -C "$wt" merge-base --is-ancestor "$local_full" "$run_full" 2>/dev/null
+}
+
+fm_nm_head_matches_worktree_reporting() {  # <worktree> <run_head>
+  local wt=$1 run_head=$2
+  fm_nm_head_matches_worktree "$wt" "$run_head" && return 0
+  [ -n "$run_head" ] || return 1
+  git -C "$wt" rev-parse HEAD >/dev/null 2>&1 || return 1
+  git -C "$wt" rev-parse --verify "${run_head}^{commit}" >/dev/null 2>&1 && return 1
+  return 0
 }

--- a/bin/fm-nm-run-lib.sh
+++ b/bin/fm-nm-run-lib.sh
@@ -63,11 +63,19 @@ fm_nm_field() {  # <toon-output> <key>
 #     the same history advanced the run tip past local HEAD)
 #   - run head is a strict ancestor of worktree HEAD, or diverged: no match
 #     (local work advanced outside the run, or the branch tip was rewritten)
+#   - run head not resolvable as a local object: cannot prove either relation,
+#     so match rather than reject. A live pipeline-owned run legitimately
+#     advances the branch past a commit this worktree's object store has not
+#     observed yet (branch_sync.state: pipeline_owned - "the pipeline head has
+#     moved but has not been successfully pushed"); rejecting on unresolvable
+#     input previously fell through to a stale terminal run at the worktree's
+#     own sha and reported a live run as failed. A false "still working" here
+#     is harmless (supervision just keeps watching); a false "failed" is not.
 fm_nm_head_matches_worktree() {  # <worktree> <run_head>
   local wt=$1 run_head=$2 local_full run_full
   [ -n "$run_head" ] || return 1
   local_full=$(git -C "$wt" rev-parse HEAD 2>/dev/null) || return 1
-  run_full=$(git -C "$wt" rev-parse --verify "${run_head}^{commit}" 2>/dev/null) || return 1
+  run_full=$(git -C "$wt" rev-parse --verify "${run_head}^{commit}" 2>/dev/null) || return 0
   [ "$run_full" = "$local_full" ] && return 0
   git -C "$wt" merge-base --is-ancestor "$local_full" "$run_full" 2>/dev/null
 }

--- a/bin/fm-nm-run-lib.sh
+++ b/bin/fm-nm-run-lib.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 # Shared no-mistakes axi run attribution primitives.
 #
-# ONE owner for the branch+code-identity matching rule that decides whether a
-# no-mistakes run belongs to a given worktree, used by fm-crew-state.sh
-# (read-only current-state reporting) and fm-teardown.sh (pre-teardown run
-# abort, see its "Fix 1" header comment). Getting this wrong in either
-# direction is unsafe: a false negative hides a genuinely parked run, and a
-# false positive lets teardown act on a run it does not own.
+# Owns the branch-and-code-identity policies that decide whether a no-mistakes
+# run belongs to a worktree. `fm_nm_head_matches_worktree` is the strict policy
+# required before teardown can abort a parked run. Read-only reporting uses the
+# reporting variant: it accepts a nonempty run head that is unavailable in the
+# local object store, so a live pipeline-owned run is not reported as diverged.
+# A locally resolvable head must still pass the strict policy. Never use the
+# reporting variant for a destructive action.
 #
 # Bounded call to `no-mistakes "$@"` in dir $1, timeout $2 seconds. The bounded
 # form preserves stdout, stderr, and exit status; the checked form discards
@@ -55,8 +56,7 @@ fm_nm_field() {  # <toon-output> <key>
   printf '%s\n' "$1" | sed -n "s/^[[:space:]]*$2:[[:space:]]*\(.*\)/\1/p" | head -1
 }
 
-# 0 if run head $2 matches worktree $1's code identity, per the same rule
-# everywhere this attribution is needed:
+# 0 if run head $2 strictly matches worktree $1's code identity:
 #   - missing/empty head: cannot bind; reject
 #   - equal commits (short or full SHA): match
 #   - worktree HEAD is an ancestor of run head: match (pipeline fix commits on
@@ -72,6 +72,10 @@ fm_nm_head_matches_worktree() {  # <worktree> <run_head>
   git -C "$wt" merge-base --is-ancestor "$local_full" "$run_full" 2>/dev/null
 }
 
+# 0 for read-only reporting when the strict rule matches or when a nonempty
+# run head cannot be resolved locally. An unresolvable head may be a pipeline
+# commit not yet fetched into this worktree, so it must not be treated as a
+# proven divergence. This must never authorize teardown or another mutation.
 fm_nm_head_matches_worktree_reporting() {  # <worktree> <run_head>
   local wt=$1 run_head=$2
   fm_nm_head_matches_worktree "$wt" "$run_head" && return 0

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -107,9 +107,9 @@
 #     alone: no-mistakes drives those against its own gate-repo clone, not the
 #     crew's worktree, so they are not orphaned by removing the worktree.
 #     conclude_task_no_mistakes_run attributes the active-or-most-recent run to
-#     THIS task only when its branch AND code identity (bin/fm-nm-run-lib.sh's
-#     fm_nm_head_matches_worktree, the same rule bin/fm-crew-state.sh uses) both
-#     match this worktree, then runs `no-mistakes axi abort --run <id>` for
+#     THIS task only when its branch and code identity pass
+#     bin/fm-nm-run-lib.sh's strict fm_nm_head_matches_worktree policy, then
+#     runs `no-mistakes axi abort --run <id>` for
 #     that verified run instance. A run already terminal
 #     (an outcome is set) or not parked at a gate is left untouched. Idempotent:
 #     an already-aborted run reads back terminal and is skipped on retry.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,8 +53,9 @@ The explicit resolution is written by the actor that answers, not the busy worke
 This home's answerer close, pending-reply escalation close, and captain-held transfer use the provenance-guarded append owned by `bin/fm-wake-lib.sh`, so they advance the watcher marker only across their own bytes when all earlier bytes were already announced; pending or interleaved foreign bytes fail toward an ordinary wake.
 A turn-ended-only queue row omits its historical status annotation when that status file exactly matches the same seen marker.
 Any direct or remaining historical annotation prints every status line unread at the presentation cursor instead of replaying only the latest line.
-`bin/fm-crew-state.sh <id>` is the cheap current-state read for an actionable heartbeat review: it attributes a no-mistakes run, active or terminal, only when it matches the crew's branch and current code identity, then keeps that run-step authoritative even if the pane has closed.
-The script header owns the exact run-head ancestry rules.
+`bin/fm-crew-state.sh <id>` is the cheap current-state read for an actionable heartbeat review: it attributes an active or terminal no-mistakes run to the crew's branch and keeps that run-step authoritative even if the pane has closed.
+Read-only reporting accepts a run whose nonempty head is unavailable in the local object store, while teardown requires a strict locally resolved code-identity match before it may abort a run.
+`bin/fm-nm-run-lib.sh` owns those exact attribution policies.
 During no-mistakes' `ci` monitor phase, it also reads the ci step log tail because `axi status` reports both "still waiting on checks" and "checks green, waiting on merge" as `ci,running`.
 The most recent recognized ci log marker wins, so checks-green monitoring reports done while a later re-arm, failed-check, or issue marker returns the crew to working.
 Only when no matching run exists does it consult semantic busy state; exact busy reports working, exact idle permits fallback to a status-log event whose verb maps to a recognized run-state, and unknown or a dead pane stays unknown instead of trusting a stale log.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -81,7 +81,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-supervisor-target-lib.sh` | Resolve the shared supervisor target and backend for the daemon and launcher       |
 | `fm-supervise-daemon.sh` | Presence-gated away-mode sub-supervisor: self-handle routine wakes, guard injection by the detected primary harness, escalate batched digests, alert on failed delivery |
 | `fm-crew-state.sh`       | Print one deterministic current-state line for a crew                                |
-| `fm-nm-run-lib.sh`       | Shared branch-and-code-identity attribution for no-mistakes runs                    |
+| `fm-nm-run-lib.sh`       | Shared strict teardown and read-only reporting attribution for no-mistakes runs     |
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification          |
 | `fm-timeout-lib.sh`      | Single owner of hard-bounded command execution and its fallback watchdog |
 | `fm-timing-lib.sh`       | Single owner of the deferred network stage's per-step elapsed-time records, inert unless a run asks for them |

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -25,11 +25,9 @@
 #       This is the direct regression pair for the 2026-07-02 herdr incident,
 #       proving the watcher's own absorb-only-when-provably-working predicate
 #       benefits from the fix in both directions.
-#   (l) a live pipeline-owned run whose head has not been fetched into this
-#       worktree's object store yet is never read as diverged/failed, at
-#       either head-matching call site, and an active row for a branch always
-#       outranks a stale terminal row for that branch. Regression coverage
-#       for the 2026-08 false-failed incident.
+#   (l) a run whose nonempty head is unavailable locally remains reportable at
+#       both attribution call sites, and an active row outranks a stale terminal
+#       row for the same branch.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -1413,12 +1411,7 @@ test_missing_run_head_falls_back_to_current_state() {
   pass "missing run head falls back instead of matching by branch"
 }
 
-# Regression coverage for the false "failed" incident (2026-08): a live,
-# pipeline-owned run whose head has advanced past this worktree's own HEAD but
-# has not yet been fetched/pushed into this worktree's object store (the
-# `branch_sync.state: pipeline_owned` case - "the pipeline head has moved but
-# has not been successfully pushed") must never be read as diverged. Call
-# site 1: `axi status` answers for THIS branch directly.
+# An unresolvable nonempty head remains reportable through `axi status`.
 test_pipeline_owned_run_unresolvable_head_remains_current() {
   reset_fakes
   local d out
@@ -1426,9 +1419,7 @@ test_pipeline_owned_run_unresolvable_head_remains_current() {
   make_repo_on_branch "$d/wt" fm/feat-unresolved
   make_fakebin "$d" >/dev/null
   fm_write_meta "$d/state/unresolved.meta" "window=fm:fm-unresolved" "worktree=$d/wt" "kind=ship"
-  # A head this worktree's object store has never observed - not a real
-  # commit anywhere in the throwaway repo, standing in for a pipeline fix
-  # commit made elsewhere and not yet fetched/pushed back here.
+  # This synthetic head is unavailable in the throwaway worktree's object store.
   FM_FAKE_RUN_HEAD="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
   FM_FAKE_AXI_STATUS="$(run_fixing fm/feat-unresolved)"
   out=$(run_crew_state "$d" unresolved)
@@ -1438,11 +1429,7 @@ test_pipeline_owned_run_unresolvable_head_remains_current() {
   pass "pipeline-owned run with a not-yet-fetched head remains attributed as current (call site 1)"
 }
 
-# Same incident, call site 2: `axi status` answers for a DIFFERENT branch (a
-# concurrent crew), forcing the coarse `no-mistakes runs` fallback, where the
-# exact reported shape reproduces: the live running row's head has not been
-# fetched locally, and an older failed row for the same branch happens to sit
-# at this worktree's own current sha - the row that used to win by accident.
+# The coarse runs fallback also retains an active row with an unresolvable head.
 test_coarse_fallback_prefers_live_pipeline_run_over_stale_failed_row() {
   reset_fakes
   local d wt_head out
@@ -1465,9 +1452,7 @@ EOF
   pass "coarse fallback resolves the live pipeline run instead of an older stale failed row (call site 2)"
 }
 
-# An active row for a branch must outrank a terminal row for that branch
-# regardless of which one the (newest-first, but not contract-guaranteed-
-# strict) runs list happens to surface first.
+# An active row for a branch must outrank a terminal row regardless of list order.
 test_coarse_fallback_active_row_outranks_terminal_regardless_of_order() {
   reset_fakes
   local d wt_head fix_head base_head out

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -25,6 +25,11 @@
 #       This is the direct regression pair for the 2026-07-02 herdr incident,
 #       proving the watcher's own absorb-only-when-provably-working predicate
 #       benefits from the fix in both directions.
+#   (l) a live pipeline-owned run whose head has not been fetched into this
+#       worktree's object store yet is never read as diverged/failed, at
+#       either head-matching call site, and an active row for a branch always
+#       outranks a stale terminal row for that branch. Regression coverage
+#       for the 2026-08 false-failed incident.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -1408,6 +1413,88 @@ test_missing_run_head_falls_back_to_current_state() {
   pass "missing run head falls back instead of matching by branch"
 }
 
+# Regression coverage for the false "failed" incident (2026-08): a live,
+# pipeline-owned run whose head has advanced past this worktree's own HEAD but
+# has not yet been fetched/pushed into this worktree's object store (the
+# `branch_sync.state: pipeline_owned` case - "the pipeline head has moved but
+# has not been successfully pushed") must never be read as diverged. Call
+# site 1: `axi status` answers for THIS branch directly.
+test_pipeline_owned_run_unresolvable_head_remains_current() {
+  reset_fakes
+  local d out
+  d=$(new_case pipeline-unresolvable)
+  make_repo_on_branch "$d/wt" fm/feat-unresolved
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/unresolved.meta" "window=fm:fm-unresolved" "worktree=$d/wt" "kind=ship"
+  # A head this worktree's object store has never observed - not a real
+  # commit anywhere in the throwaway repo, standing in for a pipeline fix
+  # commit made elsewhere and not yet fetched/pushed back here.
+  FM_FAKE_RUN_HEAD="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+  FM_FAKE_AXI_STATUS="$(run_fixing fm/feat-unresolved)"
+  out=$(run_crew_state "$d" unresolved)
+  assert_contains "$out" "source: run-step" "unresolvable pipeline head is still attributed via axi status"
+  assert_contains "$out" "state: working" "unresolvable pipeline head reads as working, not failed"
+  assert_not_contains "$out" "state: failed" "a live pipeline-owned run must never read as failed"
+  pass "pipeline-owned run with a not-yet-fetched head remains attributed as current (call site 1)"
+}
+
+# Same incident, call site 2: `axi status` answers for a DIFFERENT branch (a
+# concurrent crew), forcing the coarse `no-mistakes runs` fallback, where the
+# exact reported shape reproduces: the live running row's head has not been
+# fetched locally, and an older failed row for the same branch happens to sit
+# at this worktree's own current sha - the row that used to win by accident.
+test_coarse_fallback_prefers_live_pipeline_run_over_stale_failed_row() {
+  reset_fakes
+  local d wt_head out
+  d=$(new_case coarse-pipeline-vs-stale-failed)
+  make_repo_on_branch "$d/wt" fm/feat-race
+  wt_head=$(git -C "$d/wt" rev-parse --short=7 HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/race.meta" "window=fm:fm-race" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  running    fm/other-crew aaaaaaa  2026-08-06 10:00
+  running    fm/feat-race deadbee  2026-08-06 09:55
+  failed     fm/feat-race ${wt_head}  2026-08-06 09:40
+EOF
+)"
+  local out; out=$(run_crew_state "$d" race)
+  assert_contains "$out" "state: working" "the live pipeline-owned run wins over a stale failed row at the worktree sha"
+  assert_contains "$out" "source: run-step" "coarse-resolved live run remains run-step sourced"
+  assert_not_contains "$out" "state: failed" "the reported bug: a stale failed row must never outrank the live run"
+  pass "coarse fallback resolves the live pipeline run instead of an older stale failed row (call site 2)"
+}
+
+# An active row for a branch must outrank a terminal row for that branch
+# regardless of which one the (newest-first, but not contract-guaranteed-
+# strict) runs list happens to surface first.
+test_coarse_fallback_active_row_outranks_terminal_regardless_of_order() {
+  reset_fakes
+  local d wt_head fix_head base_head out
+  d=$(new_case coarse-active-over-terminal-order)
+  make_repo_on_branch "$d/wt" fm/feat-order
+  base_head=$(git -C "$d/wt" rev-parse HEAD)
+  git -C "$d/wt" commit -q --allow-empty -m 'pipeline fix commit'
+  fix_head=$(git -C "$d/wt" rev-parse --short=7 HEAD)
+  git -C "$d/wt" reset -q --hard "$base_head"
+  wt_head=$(git -C "$d/wt" rev-parse --short=7 HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/order.meta" "window=fm:fm-order" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  # The terminal row is listed BEFORE the active one - list order alone must
+  # not decide the winner.
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  failed     fm/feat-order ${wt_head}  2026-08-06 09:40
+  running    fm/feat-order ${fix_head}  2026-08-06 09:55
+  running    fm/other-crew aaaaaaa  2026-08-06 10:00
+EOF
+)"
+  local out; out=$(run_crew_state "$d" order)
+  assert_contains "$out" "state: working" "the active row wins even though a terminal row for the branch is listed first"
+  assert_not_contains "$out" "state: failed" "a terminal row must never outrank an active row for the same branch"
+  pass "active row for a branch outranks a terminal row for that branch regardless of list order"
+}
+
 test_active_run_is_authoritative
 test_stale_needs_decision_superseded
 test_stale_blocked_superseded
@@ -1461,5 +1548,8 @@ test_historical_same_branch_rewritten_head_not_current
 test_active_run_descendant_fix_head_remains_current
 test_local_advanced_past_run_head_invalidates
 test_missing_run_head_falls_back_to_current_state
+test_pipeline_owned_run_unresolvable_head_remains_current
+test_coarse_fallback_prefers_live_pipeline_run_over_stale_failed_row
+test_coarse_fallback_active_row_outranks_terminal_regardless_of_order
 
 echo "all fm-crew-state tests passed"

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -2183,6 +2183,25 @@ test_another_branchs_parked_run_is_never_touched() {
   pass "a parked run on another branch is never aborted by this task's teardown (ownership is precise)"
 }
 
+test_same_branch_unresolvable_parked_run_is_never_aborted() {
+  local case_dir rc
+  case_dir=$(make_case parked-run-unresolvable-head)
+  write_meta "$case_dir" no-mistakes ship
+  land_shippable_commit "$case_dir"
+
+  rc=0
+  FM_FAKE_AXI_STATUS="$(parked_axi_status_toon fm/task-x1 deadbeefdeadbeefdeadbeefdeadbeefdeadbeef)" \
+  FM_FAKE_NM_ABORT_LOG="$case_dir/nm-abort.log" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+
+  expect_code 0 "$rc" "parked-run-unresolvable-head: teardown should still succeed"
+  assert_absent "$case_dir/nm-abort.log" \
+    "parked-run-unresolvable-head: teardown aborted an unverified run"
+  assert_not_contains "$(cat "$case_dir/stderr")" "aborting" \
+    "parked-run-unresolvable-head: teardown reported aborting an unverified run"
+  pass "a same-branch parked run with an unresolvable head is never aborted"
+}
+
 test_own_autonomous_run_is_left_alone() {
   local case_dir rc head
   case_dir=$(make_case autonomous-run-left-alone)
@@ -2638,6 +2657,7 @@ test_mismatched_run_after_abort_refuses_unconfirmed
 test_empty_status_after_abort_refuses_unconfirmed
 test_not_found_status_after_abort_confirms_completion
 test_another_branchs_parked_run_is_never_touched
+test_same_branch_unresolvable_parked_run_is_never_aborted
 test_own_autonomous_run_is_left_alone
 test_leaked_worktree_process_is_reaped
 test_leaked_tasktmp_process_is_reaped


### PR DESCRIPTION
## What Changed
- Attribute read-only crew state to same-branch pipeline runs whose nonempty commit heads are not yet locally available, while retaining strict matching for teardown aborts.
- Prefer active matching run rows over terminal rows when resolving coarse run listings.
- Document the separate reporting and teardown attribution policies and add regression coverage.

## Risk Assessment

✅ Low: The reporting-only attribution relaxation is confined to fm-crew-state while teardown retains the strict verified-head predicate for destructive aborts.

## Testing

Reviewed the target diff, ran the two focused behavior suites, and exercised the crew-state CLI end-to-end against representative no-mistakes responses; both unresolved live-run scenarios rendered `state: working · source: run-step`, with no working-tree artifacts left behind.

<details>
<summary>Evidence: Crew-state CLI end-to-end transcript</summary>

```text
Scenario 1: pipeline-owned validation reports a head not yet in this worktree; its own axi status remains working.
state: working · source: run-step · validating (fixing)

Scenario 2: runs list puts a stale failed row before the current unresolved running row; active row must win.
state: working · source: run-step · validating (background run)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c376f6e8d2c3f7dfe83d746ede7c4c1592aa7358","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-nm-run-lib.sh:78` - This shared ownership predicate now accepts any unresolvable head, but fm-teardown.sh uses it before `axi abort --run` and explicitly requires a verified branch+head match. A stale/invalid or GC-pruned parked run on a reused branch therefore passes attribution and is aborted during teardown. Keep the resolvable-head requirement for destructive callers; add a reporting-only compatibility predicate (or explicit mode) for fm-crew-state&#39;s pipeline-owned containment path.

🔧 Fix: Separate reporting-only run attribution from teardown safety
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --check e836a7f28bc5100f517c1d672a56483754899add 40622263504b110ac729a57ea1351fc3c6dc8117`
- `bin/fm-test-run.sh tests/fm-crew-state.test.sh`
- `bin/fm-test-run.sh tests/fm-teardown.test.sh`
- <code>Manual `bin/fm-crew-state.sh` CLI exercise with a pipeline-owned unresolved head and with a stale failed runs-list row preceding a live running row.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
