### PR TITLE
docs(agents): serialize no-mistakes runs within a Herdr crew group

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,6 +324,8 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 ### Validate
 
 For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
+When this crewmate is one of several dispatched onto the same shared project in a Herdr multiagent workflow, check before triggering whether another crewmate in that same group already has an active no-mistakes run, meaning a live run-step state such as running, fixing, or CI, not a task merely parked at a gate awaiting a captain decision, since that capacity is free while it waits.
+If one is active, hold off and continue normal supervision, retriggering this validation once the active run reaches a terminal or gated state; this governs only firstmate's own dispatch timing within that group, never the shared no-mistakes daemon itself.
 The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
 Once validation starts, prefer routing new requirements to follow-up work rather than expanding the current task, unless a new requirement completely invalidates the work being validated; however, the smallest downstream changes needed to keep already accepted product or engineering behavior correct, add behavioral tests where an executable contract exists, or keep documentation accurate remain within the current task even when they touch files not named at intake, and corrections required to satisfy already accepted intent are not new requirements.


### PR DESCRIPTION
## Intent

Add a standing operating rule to AGENTS.md section 7's Validate subsection: when firstmate has dispatched several crewmates onto the same shared project as part of a Herdr multiagent workflow, hold off triggering a new /no-mistakes run on one of them while another crewmate in that same group already has an active run (a live run-step state such as running/fixing/CI, not one merely parked at a gate awaiting a captain decision, since capacity is free while parked). Retrigger once the active run reaches a terminal or gated state. This addresses real resource contention the captain observed: multiple crewmates running /no-mistakes concurrently on the same shared project made CI runners unresponsive for hours and caused a daemon reattach timeout on a stalled run. This is a firstmate dispatch-timing rule only - it never manages, stops, or restarts the shared no-mistakes daemon itself, which is already established as an existing boundary elsewhere in AGENTS.md. Scope was deliberately narrowed from an earlier draft (which had proposed a blanket per-home serialization rule for any two tasks) to specifically the Herdr multiagent same-project scenario, per explicit captain clarification. This is a docs-only prose change (2 lines added) inline in AGENTS.md per firstmate-coding-guidelines - no new skill, no new script, no mechanism/queue implementation.

## What Changed

- Added a rule to AGENTS.md section 7's Validate subsection: when firstmate has dispatched several crewmates onto the same shared project as part of a Herdr multiagent workflow, hold off triggering a new no-mistakes run on one of them while another crewmate in that same group already has an active run (running, fixing, or CI), retriggering once that run reaches a terminal or gated state.
- Clarified this is a dispatch-timing rule only, scoped to firstmate's own triggering decisions within a Herdr crew group, and does not manage, stop, or restart the shared no-mistakes daemon.

## Risk Assessment

✅ Low: A precisely-scoped 2-line docs-only addition to AGENTS.md's Validate subsection that matches every constraint in the stated intent: correct location (section 7/Validate), correct narrow scope (Herdr multiagent same-project dispatch timing), correct definition of "active" run state excluding gate-parked tasks, retrigger condition specified, and explicit disclaimer that it does not manage the shared daemon; no mechanism, script, or queue was added.

## Testing

This is a pure prose addition to AGENTS.md with no executable interface, so per the test-quality rule no grep/string-matching test was written; instead the diff was verified for exact scope (2 lines, docs-only) and the new text was read in full context and cross-checked for placement, internal consistency, and consistency with the pre-existing daemon-restart boundary in stow/SKILL.md - all constraints in the intent are satisfied.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"8a175a380e94e9b7d890a9964cc13e4d65591b3a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat 76355e2..8a175a3` confirms the change touches only AGENTS.md with 2 insertions, 0 deletions (docs-only, no mechanism/skill/script added)</code>
- <code>Manually read the new lines in context (AGENTS.md:324-328) and confirmed they sit under `### Validate` inside `## 7. Task lifecycle`, matching the intent&#39;s required section</code>
- `Checked the new prose against every required/forbidden constraint in the intent: defines 'active run' as a live run-step state (running/fixing/CI) vs. parked-at-gate (excluded), requires holding off dispatch and retriggering once the run reaches terminal/gated state, and explicitly scopes the rule to firstmate's dispatch timing only, never managing/stopping/restarting the shared daemon`
- <code>`grep -rn &#39;no-mistakes daemon&#39; --include=&#39;*.md&#39; .` to confirm the referenced &#39;existing boundary elsewhere in AGENTS.md&#39; claim is accurate - found in .agents/skills/stow/SKILL.md:29 (&#39;Never restart the shared no-mistakes daemon while runs are active&#39;), which the new text is consistent with and does not duplicate or contradict</code>
- <code>`git status --porcelain` confirms a clean worktree with no stray artifacts from verification</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
