### PR TITLE
fix(brief): make the no-mistakes done gate behavioral and keyed decisions parse

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,7 +323,7 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 
 ### Validate
 
-For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
+A no-mistakes ship brief makes validation the worker's own next step after its implementation commit; trigger it on that same worker, using the harness invocation owned by `harness-adapters`, only when the worker has not started it itself.
 The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
 Once validation starts, prefer routing new requirements to follow-up work rather than expanding the current task, unless a new requirement completely invalidates the work being validated; however, the smallest downstream changes needed to keep already accepted product or engineering behavior correct, add behavioral tests where an executable contract exists, or keep documentation accurate remain within the current task even when they touch files not named at intake, and corrections required to satisfy already accepted intent are not new requirements.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -329,7 +329,8 @@ The report is the only thing that survives, so anything worth keeping must be in
    treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs to a human (product choices, destructive actions),
-   append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
+   append \`needs-decision [key=<slug>]: {summary of options}\` and stop. Firstmate will reply with the decision.
+   The \`[key=<slug>]\` token goes BEFORE the colon: \`needs-decision [key=api-shape]: REST or RPC\`.
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
    Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
@@ -384,9 +385,10 @@ EOF
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 Delivery contract: mode=no-mistakes
-The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+On this task \`done:\` means EXACTLY one line: \`done: PR {url} checks green\`.
+An implementation commit is NOT done. A green local test, lint, build, or review run is NOT done. Nothing is done until a PR exists and its CI is green.
+Running the pipeline is YOUR step, not firstmate's: the moment your implementation is committed, invoke the no-mistakes skill yourself (\`/no-mistakes\`, or \`\$no-mistakes\` on codex) without waiting to be told.
+Never append a \`done:\` line before that pipeline has produced a PR with green checks.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
@@ -445,7 +447,8 @@ $RULE1
    cadence instead of treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
-   append \`needs-decision: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
+   append \`needs-decision [key=<slug>]: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
+   The \`[key=<slug>]\` token goes BEFORE the colon: \`needs-decision [key=api-shape]: REST or RPC\`.
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
    Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -163,6 +163,12 @@ status_is_paused_or_captain_held() {  # <status-line>
 # format): an OPTIONAL "[key=<slug>]" token sits between the verb and the colon,
 #   needs-decision [key=api-shape]: <summary>
 #   resolved       [key=api-shape]: <how it was decided>
+# The token is also accepted at the head of the note, after the colon,
+#   needs-decision: [key=api-shape] <summary>
+# because that misplacement is a common worker output and folding an explicitly
+# stated key into the shared "default" bucket loses it silently: two decisions
+# then share one record, so an answer can close the wrong one. Both positions
+# mean the same key, and the note excludes the token wherever it was written.
 # A line with no token uses the key "default", preserving the historical
 # one-open-decision-per-task behavior (a bare "resolved:" closes "default").
 # The three parsers are pure reads of a single line; the verb parser strips any
@@ -174,11 +180,37 @@ status_line_verb() {  # <status-line> -> leading verb word
   v=${v%"${v##*[![:space:]]}"}
   printf '%s' "$v"
 }
-status_line_note() {  # <status-line> -> text after the first colon, trimmed
+# A valid "[key=<slug>]" token at the head of the note, or failure. Only a
+# well-formed slug counts, so ordinary note text starting with a bracket stays
+# note text instead of dropping the line.
+_fm_decision_note_key() {  # <status-line> -> key slug from the post-colon position
+  local n
   case "$1" in
-    *:*) local n=${1#*:}; printf '%s' "${n#"${n%%[![:space:]]*}"}" ;;
-    *) printf '%s' "$1" ;;
+    *:*) n=${1#*:} ;;
+    *) return 1 ;;
   esac
+  n=${n#"${n%%[![:space:]]*}"}
+  case "$n" in
+    \[key=*\]*) n=${n#\[key=}; n=${n%%\]*} ;;
+    *) return 1 ;;
+  esac
+  case "$n" in
+    ''|*[!A-Za-z0-9._-]*) return 1 ;;
+    *) printf '%s' "$n" ;;
+  esac
+}
+status_line_note() {  # <status-line> -> text after the first colon, trimmed
+  local n
+  case "$1" in
+    *:*) n=${1#*:} ;;
+    *) printf '%s' "$1"; return 0 ;;
+  esac
+  n=${n#"${n%%[![:space:]]*}"}
+  if _fm_decision_note_key "$1" >/dev/null; then
+    n=${n#*\]}
+    n=${n#"${n%%[![:space:]]*}"}
+  fi
+  printf '%s' "$n"
 }
 _fm_decision_key() {  # <status-line> -> key slug, or "default" when no token
   local prefix=${1%%:*} k
@@ -191,7 +223,7 @@ _fm_decision_key() {  # <status-line> -> key slug, or "default" when no token
         *) printf '%s' "$k" ;;
       esac
       ;;
-    *) printf 'default' ;;
+    *) _fm_decision_note_key "$1" || printf 'default' ;;
   esac
 }
 # Drop the record for <key> from a newline-terminated "<key>\t<verb>\t<note>" set.

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -416,7 +416,7 @@ _fm_open_decisions_cursor_path() {  # <status-file>
   printf '%s/.%s.open-decisions-cursor' "$dir" "${base%.status}"
 }
 
-FM_OPEN_DECISIONS_FOLD_VERSION=2
+FM_OPEN_DECISIONS_FOLD_VERSION=3
 
 # Portable device:inode identity for the rotation/recreation check below.
 _fm_open_decisions_file_ident() {  # <file> -> "dev:inode", empty on I/O failure

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -256,7 +256,7 @@ test_ship_mode_is_explicit_not_registry() {
   brief="$home/data/brief-explicit-a5/brief.md"
   grep -qx "Delivery contract: mode=no-mistakes" "$brief" \
     || fail "registered direct-PR posture overrode the explicit --mode"
-  assert_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
+  assert_grep "invoke the no-mistakes skill yourself" "$brief" \
     "explicit no-mistakes brief did not render the pipeline definition of done"
 
   # An unregistered project is not a blocker either, because nothing is looked up.
@@ -352,6 +352,60 @@ test_no_mistakes_dod_wording() {
   assert_grep "firstmate's authority check" "$brief" \
     "no-mistakes DOD lost the apostrophe prose that the structural fix makes parse-safe"
   pass "fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe"
+}
+
+# Seven no-mistakes crewmates in two days reported `done:` after a green local
+# gate and never ran the pipeline, because the DOD's own first instruction was
+# to commit, report done, and wait to be told. The generated brief must now name
+# the single done line, deny the near-miss finishes, and put the pipeline
+# invocation on the worker.
+test_no_mistakes_dod_makes_the_done_gate_behavioral() {
+  local home id brief
+  home="$TMP_ROOT/done-gate-home"
+  mkdir -p "$home/data"
+  id="brief-done-gate-b2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "brief was not scaffolded"
+  assert_grep 'done: PR {url} checks green' "$brief" \
+    "no-mistakes DOD must state the exact done line"
+  assert_grep "An implementation commit is NOT done" "$brief" \
+    "no-mistakes DOD must deny an implementation commit as done"
+  assert_grep "green local test, lint, build, or review run is NOT done" "$brief" \
+    "no-mistakes DOD must deny a green local gate as done"
+  assert_grep "invoke the no-mistakes skill yourself" "$brief" \
+    "no-mistakes DOD must put the pipeline invocation on the worker"
+  assert_no_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
+    "no-mistakes DOD still tells the worker to stop and wait to be told to validate"
+  assert_no_grep 'append `done: {summary}`' "$brief" \
+    "no-mistakes DOD still offers a pre-PR done line"
+  pass "fm-brief.sh: no-mistakes DOD names one done gate and owns the pipeline invocation"
+}
+
+# Two crewmates wrote `needs-decision: [key=slug]`, which folded to the shared
+# `default` bucket. Every scaffold's status protocol must show the key in the
+# position the fold's own grammar names first.
+test_status_protocol_shows_keyed_decision_grammar() {
+  local home id brief
+  home="$TMP_ROOT/decision-key-home"
+  mkdir -p "$home/data"
+  for id in ship scout; do
+    if [ "$id" = ship ]; then
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-key-ship some-proj --mode no-mistakes >/dev/null 2>&1
+      brief="$home/data/brief-key-ship/brief.md"
+    else
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-key-scout some-proj --scout >/dev/null 2>&1
+      brief="$home/data/brief-key-scout/brief.md"
+    fi
+    assert_present "$brief" "$id brief was not scaffolded"
+    assert_grep 'needs-decision [key=<slug>]: {summary of options}' "$brief" \
+      "$id brief's rule 6 does not show the keyed decision form"
+    assert_grep 'needs-decision [key=api-shape]: REST or RPC' "$brief" \
+      "$id brief does not show a keyed decision example"
+    assert_no_grep 'append `needs-decision: {summary of options}`' "$brief" \
+      "$id brief still shows the unkeyed decision form"
+  done
+  pass "fm-brief.sh: ship and scout status protocols show the key before the colon"
 }
 
 test_ship_project_memory_wording() {
@@ -719,6 +773,8 @@ test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
+test_no_mistakes_dod_makes_the_done_gate_behavioral
+test_status_protocol_shows_keyed_decision_grammar
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path

--- a/tests/fm-wake-drain-open-decisions.test.sh
+++ b/tests/fm-wake-drain-open-decisions.test.sh
@@ -37,6 +37,39 @@ test_buried_decision_still_surfaces() {
   pass "a needs-decision buried under later routine/other-key lines still reports as open"
 }
 
+# Workers commonly write the key after the verb's colon (issue #2109). Folding
+# that explicit key into the shared "default" bucket loses it silently, so both
+# positions must name the same decision - including across positions, so an
+# answer written in either form closes the record the other form opened.
+test_key_after_the_colon_names_the_same_decision() {
+  local dir state out
+  dir=$(make_case post-colon-key)
+  state="$dir/state"
+  out="$dir/drain.out"
+  printf 'needs-decision: [key=seam-max-bound] pick the bound\n' > "$state/task10.status"
+  printf 'working: continuing\n' >> "$state/task10.status"
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" || fail "drain failed on a post-colon key"
+
+  grep -F 'task10 [key=seam-max-bound] needs-decision: pick the bound' "$out" >/dev/null \
+    || fail "a post-colon key did not surface as its own decision: $(cat "$out")"
+
+  # Closing it in the documented pre-colon position must still match.
+  printf 'resolved [key=seam-max-bound]: bounded at 8\n' >> "$state/task10.status"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" || fail "drain failed after resolving a post-colon key"
+  if grep -F 'OPEN DECISIONS' "$out" >/dev/null; then
+    fail "a pre-colon resolution did not close the post-colon decision: $(cat "$out")"
+  fi
+
+  # A bracketed note that is not a well-formed key stays ordinary note text on
+  # the historical shared key rather than dropping the line out of the fold.
+  printf 'needs-decision: [key=not a slug] still a decision\n' > "$state/task11.status"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" || fail "drain failed on a malformed bracket note"
+  grep -F 'task11 needs-decision: [key=not a slug] still a decision' "$out" >/dev/null \
+    || fail "a malformed bracket note was not folded as an ordinary default decision: $(cat "$out")"
+  pass "a key written after the verb colon opens and closes the same keyed decision"
+}
+
 test_explicit_resolution_closes_it() {
   local dir state out
   dir=$(make_case resolved)
@@ -224,3 +257,4 @@ test_no_open_decisions_prints_nothing
 test_open_decision_surfaces_even_with_an_unrelated_queued_wake
 test_buried_decision_surfaces_on_the_empty_queue_fast_path
 test_status_symlink_is_not_followed
+test_key_after_the_colon_names_the_same_decision


### PR DESCRIPTION
## Problem

Two recurring crewmate failure modes, both traced to what the generated brief actually says.

**1. Seven no-mistakes crewmates in two days** (a4, b1, c2, e1, e2, f1, f2) declared `done:` after a green local gate without ever invoking the pipeline, each costing the supervisor the same correction steer. The root cause was the scaffold's own definition of done, which opened with:

> The task is complete only when committed on your branch.
> When you believe it is complete, append `done: {summary}` to the status file and stop.
> Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

The premature `done:` line was *correct by the brief*. Two `done:` gates in one section, and the first one told the worker to stop and wait.

**2. Two crewmates wrote `needs-decision: [key=slug]`** with the key after the colon. `_fm_decision_key` read the token only from the verb prefix *before* the colon, so those decisions folded into the shared `default` bucket and `fm-send --resolve-key <real-key>` refused. Filed upstream as #2109.

## Changes

**`bin/fm-brief.sh` - no-mistakes definition of done.** Removed the commit-and-wait opening. The section now names exactly one done line, denies the near-miss finishes by name, and puts the pipeline invocation on the worker:

```
On this task `done:` means EXACTLY one line: `done: PR {url} checks green`.
An implementation commit is NOT done. A green local test, lint, build, or review run is NOT done. Nothing is done until a PR exists and its CI is green.
Running the pipeline is YOUR step, not firstmate's: the moment your implementation is committed, invoke the no-mistakes skill yourself (`/no-mistakes`, or `$no-mistakes` on codex) without waiting to be told.
Never append a `done:` line before that pipeline has produced a PR with green checks.
```

Four lines replacing three, with no pipeline mechanics duplicated - the no-mistakes skill remains their owner. The codex invocation form is named because the *worker* now types it rather than firstmate; `harness-adapters` still owns the full matrix.

`AGENTS.md` section 7's Validate step follows: firstmate triggers validation only when the worker has not already started it. Left unchanged, it would have been a second contradictory owner of that trigger.

**Keyed-decision grammar - both owners fixed.** The task asked which fix is right; the answer is both, for different reasons:

- *Scaffold (prevention).* Ship and scout rule 6 now show `needs-decision [key=<slug>]: {summary of options}` plus the example `needs-decision [key=api-shape]: REST or RPC`. This is what stops new workers from writing the broken shape.
- *Parser (containment).* `_fm_decision_key` now also accepts a well-formed `[key=<slug>]` token at the head of the note. Wording alone reaches only workers that read the new brief - not the ones already running, on other harnesses, or writing from a remote home whose lines are mirrored into the same stream. And per #2109, silently rewriting an explicitly stated key into a shared bucket is the unsafe half: two decisions collapse into one record, so an answer can close the wrong one while the real decision stays open.

`status_line_note` strips an accepted post-colon token so the note text, the reserved-key vocabulary check, and displays all see the real note.

A **malformed** bracket note (`[key=not a slug]`) deliberately stays ordinary note text on the historical `default` key rather than returning failure. Failure would drop the line out of the fold entirely, losing the decision - strictly worse than mislabeling it. Pre-colon behavior is unchanged.

Review caught one thing the original commit missed, fixed in `015eeb2`: `FM_OPEN_DECISIONS_FOLD_VERSION` had to be bumped. Without it, a decision persisted in a cursor open-set under the old grammar could never be closed by a later `resolved [key=x]` line - a permanently open ghost record.

## Tests

Colocated, behavior-only, through the real executables:

- `tests/fm-brief.test.sh` - the done gate names one line, denies an implementation commit and a green local gate, puts the invocation on the worker, and no longer offers a pre-PR done line; ship and scout protocols show the key before the colon.
- `tests/fm-wake-drain-open-decisions.test.sh` - a post-colon key opens its own decision, a pre-colon `resolved` closes it across positions, and a malformed bracket note folds as an ordinary default decision instead of vanishing.

Existing suites green: `fm-brief`, `fm-wake-drain-open-decisions`, `fm-wake-drain-open-decisions-cursor`, `fm-decision-hold-lifecycle`, `fm-pending-reply`, `fm-crew-state`, `fm-watch-triage`, `fm-remote-reply`, `fm-fleet-snapshot-view`. Parser changes use only bash 3.2 constructs.

Local lint reported ShellCheck absent on this machine (exit 127), so `bin/fm-lint.sh` could not run for CI parity; the CI lint job covers it.

## Note

This is a fork PR: the pushing machine has no write access to this repository. Upstream CI may not run for fork PRs.
