### PR TITLE
feat: add Studio launchd watcher deadman

### DIFF
--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -88,6 +88,7 @@ Rules that keep the contract unambiguous:
 - The strict boundary keeps action-free items OUT of Captain's Call: a working or validating task, a queued item blocked on another task or a date, landed work, a completed scout's report pointer, a declared `paused:` external wait, and a bare recorded PR with no merge-ready signal each belong to one of the other three sections, never Captain's Call.
 - A secondmate's own row appears Underway only for `active_child_work`; `externally_held` belongs in Charted Next, and `unknown` belongs there as an unavailable-state gate unless its reason requires the captain's action.
 - Do not suppress separately projected decisions, landed records, or gates from a `partial-structured` home merely because that secondmate's own row is `unknown`.
+- An unavailable secondmate home, including a registered home that no longer exists, contributes no landed, queued, or decision work, so render its Charted Next unavailable-state row together with the related `omitted` warning and never present that missing contribution as an empty or complete baseline.
 - Include the required direct address to the captain inside one item or empty-state sentence.
 - Every PR appears as the full `https://...` URL; a shorthand `#number` is fine only as a back-reference after the full URL has already appeared in the same digest.
 - The chat follows `AGENTS.md` section 9 and carries one scannable line per item.

--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -38,6 +38,7 @@ It never tears down a task, merges a PR, dispatches new work, steers a worker, a
    For registered secondmates, use the snapshot's structured-home classification and provenance.
    A parent event or bounded terminal contradiction is fallback evidence, never authority over readable structured home state.
    Structured captain-held decisions come from `decision-hold-lifecycle` and appear under `decisions_open`.
+   Render a nonzero `ideas_unscheduled` count as one Charted Next line, and name any `ideas_warnings` disclosure rather than presenting an incomplete count as complete.
    Do not scrape reports, visual-review artifacts, raw status-event tails, or visible conversation history to supplement current state.
    A queued item under `gates` only becomes "next work" when its blocker is gone and its time/date gate has arrived.
    Until then it stays queued with the reason.
@@ -60,7 +61,7 @@ It never tears down a task, merges a PR, dispatches new work, steers a worker, a
    - **Captain's Call** - every open decision summarized with its options from the structured decision record, plus each PR ready to merge and each needed credential or login, every PR with the full `https://...` URL, never a bare `#number`.
    - **Recently Landed** - the bounded current recent-completions baseline from structured state across the main fleet and every registered secondmate home, rendered in full on every run.
    - **Underway** - each live direct report making progress, with its current state, and the plans or main pickup pointers worth reopening (`data/<id>/report.md` files, `.lavish/*.html` boards).
-   - **Charted Next** - queued or gated work, including any main-inventory integrity warning, with each item's blocker, date, or integrity reason.
+   - **Charted Next** - queued or gated work, a nonzero unscheduled-product-idea count, any `ideas_warnings` disclosure, and any main-inventory integrity warning, with each item's blocker, date, integrity, or incomplete-count reason.
    After writing the file, return the concise four-section chat digest and include the report path or link without adding a fifth section.
    For a richer review surface, optionally offer a Lavish board with `lavish-axi` when the report has enough structure to deserve one, but only after the required digest is ready.
 
@@ -75,7 +76,7 @@ Every `/bearings` chat response renders EXACTLY these four sections, in THIS ord
    Empty-state: "No recent completions are in the current baseline."
 3. **Underway** - live work progressing on its own, one line of current state per direct report.
    Empty-state: "Nothing is underway."
-4. **Charted Next** - queued or gated work waiting on the fleet or a date, plus action-free fleet-integrity warnings, never on the captain.
+4. **Charted Next** - queued or gated work waiting on the fleet or a date, a nonzero unscheduled-product-idea count, any `ideas_warnings` disclosure, plus action-free fleet-integrity warnings, never on the captain.
    Empty-state: "Nothing is queued."
 
 Rules that keep the contract unambiguous:
@@ -83,7 +84,7 @@ Rules that keep the contract unambiguous:
 - Every section ALWAYS renders, even when empty, with its short empty-state sentence; never omit a section.
 - Every chat digest and file-mode report is a complete current snapshot, never a delta against a prior report.
 - Recently Landed always renders the bounded current baseline, even when the same completions appeared in an earlier report.
-- The four buckets are mutually exclusive, so every item is forced into exactly one: needs-your-action is Captain's Call, done is Recently Landed, self-progressing is Underway, and not-yet-started work or an action-free fleet-integrity warning is Charted Next.
+- The four buckets are mutually exclusive, so every item is forced into exactly one: needs-your-action is Captain's Call, done is Recently Landed, self-progressing is Underway, and not-yet-started work, a nonzero unscheduled-product-idea count, an `ideas_warnings` disclosure, or an action-free fleet-integrity warning is Charted Next.
 - The strict boundary keeps action-free items OUT of Captain's Call: a working or validating task, a queued item blocked on another task or a date, landed work, a completed scout's report pointer, a declared `paused:` external wait, and a bare recorded PR with no merge-ready signal each belong to one of the other three sections, never Captain's Call.
 - A secondmate's own row appears Underway only for `active_child_work`; `externally_held` belongs in Charted Next, and `unknown` belongs there as an unavailable-state gate unless its reason requires the captain's action.
 - Do not suppress separately projected decisions, landed records, or gates from a `partial-structured` home merely because that secondmate's own row is `unknown`.

--- a/.agents/skills/codebase-design/DEEPENING.md
+++ b/.agents/skills/codebase-design/DEEPENING.md
@@ -1,0 +1,37 @@
+# Deepening
+
+How to deepen a cluster of shallow modules safely, given its dependencies. Assumes the vocabulary in [SKILL.md](SKILL.md) — **module**, **interface**, **seam**, **adapter**.
+
+## Dependency categories
+
+When assessing a candidate for deepening, classify its dependencies. The category determines how the deepened module is tested across its seam.
+
+### 1. In-process
+
+Pure computation, in-memory state, no I/O. Always deepenable — merge the modules and test through the new interface directly. No adapter needed.
+
+### 2. Local-substitutable
+
+Dependencies that have local test stand-ins (PGLite for Postgres, in-memory filesystem). Deepenable if the stand-in exists. The deepened module is tested with the stand-in running in the test suite. The seam is internal; no port at the module's external interface.
+
+### 3. Remote but owned (Ports & Adapters)
+
+Your own services across a network boundary (microservices, internal APIs). Define a **port** (interface) at the seam. The deep module owns the logic; the transport is injected as an **adapter**. Tests use an in-memory adapter. Production uses an HTTP/gRPC/queue adapter.
+
+Recommendation shape: *"Define a port at the seam, implement an HTTP adapter for production and an in-memory adapter for testing, so the logic sits in one deep module even though it's deployed across a network."*
+
+### 4. True external (Mock)
+
+Third-party services (Stripe, Twilio, etc.) you don't control. The deepened module takes the external dependency as an injected port; tests provide a mock adapter.
+
+## Seam discipline
+
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a port unless at least two adapters are justified (typically production + test). A single-adapter seam is just indirection.
+- **Internal seams vs external seams.** A deep module can have internal seams (private to its implementation, used by its own tests) as well as the external seam at its interface. Don't expose internal seams through the interface just because tests use them.
+
+## Testing strategy: replace, don't layer
+
+- Old unit tests on shallow modules become waste once tests at the deepened module's interface exist — delete them.
+- Write new tests at the deepened module's interface. The **interface is the test surface**.
+- Tests assert on observable outcomes through the interface, not internal state.
+- Tests should survive internal refactors — they describe behaviour, not implementation. If a test has to change when the implementation changes, it's testing past the interface.

--- a/.agents/skills/codebase-design/DESIGN-IT-TWICE.md
+++ b/.agents/skills/codebase-design/DESIGN-IT-TWICE.md
@@ -1,0 +1,44 @@
+# Design It Twice
+
+When the user wants to explore alternative interfaces for a chosen deepening candidate, use this parallel sub-agent pattern. Based on "Design It Twice" (Ousterhout) — your first idea is unlikely to be the best.
+
+Uses the vocabulary in [SKILL.md](SKILL.md) — **module**, **interface**, **seam**, **adapter**, **leverage**.
+
+## Process
+
+### 1. Frame the problem space
+
+Before spawning sub-agents, write a user-facing explanation of the problem space for the chosen candidate:
+
+- The constraints any new interface would need to satisfy
+- The dependencies it would rely on, and which category they fall into (see [DEEPENING.md](DEEPENING.md))
+- A rough illustrative code sketch to ground the constraints — not a proposal, just a way to make the constraints concrete
+
+Show this to the user, then immediately proceed to Step 2. The user reads and thinks while the sub-agents work in parallel.
+
+### 2. Spawn sub-agents
+
+Spawn 3+ sub-agents in parallel. Each must produce a **radically different** interface for the deepened module.
+
+Prompt each sub-agent with a separate technical brief (file paths, coupling details, dependency category from [DEEPENING.md](DEEPENING.md), what sits behind the seam). The brief is independent of the user-facing problem-space explanation in Step 1. Give each agent a different design constraint:
+
+- Agent 1: "Minimize the interface — aim for 1–3 entry points max. Maximise leverage per entry point."
+- Agent 2: "Maximise flexibility — support many use cases and extension."
+- Agent 3: "Optimise for the most common caller — make the default case trivial."
+- Agent 4 (if applicable): "Design around ports & adapters for cross-seam dependencies."
+
+Include both [SKILL.md](SKILL.md) vocabulary and CONTEXT.md vocabulary in the brief so each sub-agent names things consistently with the architecture language and the project's domain language.
+
+Each sub-agent outputs:
+
+1. Interface (types, methods, params — plus invariants, ordering, error modes)
+2. Usage example showing how callers use it
+3. What the implementation hides behind the seam
+4. Dependency strategy and adapters (see [DEEPENING.md](DEEPENING.md))
+5. Trade-offs — where leverage is high, where it's thin
+
+### 3. Present and compare
+
+Present designs sequentially so the user can absorb each one, then compare them in prose. Contrast by **depth** (leverage at the interface), **locality** (where change concentrates), and **seam placement**.
+
+After comparing, give your own recommendation: which design you think is strongest and why. If elements from different designs would combine well, propose a hybrid. Be opinionated — the user wants a strong read, not a menu.

--- a/.agents/skills/codebase-design/SKILL.md
+++ b/.agents/skills/codebase-design/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: codebase-design
+description: Shared vocabulary for designing deep modules. Use when the user wants to design or improve a module's interface, find deepening opportunities, decide where a seam goes, make code more testable or AI-navigable, or when another skill needs the deep-module vocabulary.
+---
+
+# Codebase Design
+
+Design **deep modules**: a lot of behaviour behind a small interface, placed at a clean seam, testable through that interface. Use this language and these principles wherever code is being designed or restructured. The aim is leverage for callers, locality for maintainers, and testability for everyone.
+
+## Glossary
+
+Use these terms exactly — don't substitute "component," "service," "API," or "boundary." Consistent language is the whole point.
+
+**Module** — anything with an interface and an implementation. Deliberately scale-agnostic: a function, class, package, or tier-spanning slice. _Avoid_: unit, component, service.
+
+**Interface** — everything a caller must know to use the module correctly: the type signature, but also invariants, ordering constraints, error modes, required configuration, and performance characteristics. _Avoid_: API, signature (too narrow — they refer only to the type-level surface).
+
+**Implementation** — what's inside a module, its body of code. Distinct from **Adapter**: a thing can be a small adapter with a large implementation (a Postgres repo) or a large adapter with a small implementation (an in-memory fake). Reach for "adapter" when the seam is the topic; "implementation" otherwise.
+
+**Depth** — leverage at the interface: the amount of behaviour a caller (or test) can exercise per unit of interface they have to learn. A module is **deep** when a large amount of behaviour sits behind a small interface, **shallow** when the interface is nearly as complex as the implementation.
+
+**Seam** _(Michael Feathers)_ — a place where you can alter behaviour without editing in that place; the *location* at which a module's interface lives. Where to put the seam is its own design decision, distinct from what goes behind it. _Avoid_: boundary (overloaded with DDD's bounded context).
+
+**Adapter** — a concrete thing that satisfies an interface at a seam. Describes *role* (what slot it fills), not substance (what's inside).
+
+**Leverage** — what callers get from depth: more capability per unit of interface they learn. One implementation pays back across N call sites and M tests.
+
+**Locality** — what maintainers get from depth: change, bugs, knowledge, and verification concentrate in one place rather than spreading across callers. Fix once, fixed everywhere.
+
+## Deep vs shallow
+
+**Deep module** = small interface + lots of implementation:
+
+```
+┌─────────────────────┐
+│   Small Interface   │  ← Few methods, simple params
+├─────────────────────┤
+│                     │
+│  Deep Implementation│  ← Complex logic hidden
+│                     │
+└─────────────────────┘
+```
+
+**Shallow module** = large interface + little implementation (avoid):
+
+```
+┌─────────────────────────────────┐
+│       Large Interface           │  ← Many methods, complex params
+├─────────────────────────────────┤
+│  Thin Implementation            │  ← Just passes through
+└─────────────────────────────────┘
+```
+
+When designing an interface, ask:
+
+- Can I reduce the number of methods?
+- Can I simplify the parameters?
+- Can I hide more complexity inside?
+
+## Principles
+
+- **Depth is a property of the interface, not the implementation.** A deep module can be internally composed of small, mockable, swappable parts — they just aren't part of the interface. A module can have **internal seams** (private to its implementation, used by its own tests) as well as the **external seam** at its interface.
+- **The deletion test.** Imagine deleting the module. If complexity vanishes, it was a pass-through. If complexity reappears across N callers, it was earning its keep.
+- **The interface is the test surface.** Callers and tests cross the same seam. If you want to test *past* the interface, the module is probably the wrong shape.
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a seam unless something actually varies across it.
+
+## Designing for testability
+
+Good interfaces make testing natural:
+
+1. **Accept dependencies, don't create them.**
+
+   ```typescript
+   // Testable
+   function processOrder(order, paymentGateway) {}
+
+   // Hard to test
+   function processOrder(order) {
+     const gateway = new StripeGateway();
+   }
+   ```
+
+2. **Return results, don't produce side effects.**
+
+   ```typescript
+   // Testable
+   function calculateDiscount(cart): Discount {}
+
+   // Hard to test
+   function applyDiscount(cart): void {
+     cart.total -= discount;
+   }
+   ```
+
+3. **Small surface area.** Fewer methods = fewer tests needed. Fewer params = simpler test setup.
+
+## Relationships
+
+- A **Module** has exactly one **Interface** (the surface it presents to callers and tests).
+- **Depth** is a property of a **Module**, measured against its **Interface**.
+- A **Seam** is where a **Module**'s **Interface** lives.
+- An **Adapter** sits at a **Seam** and satisfies the **Interface**.
+- **Depth** produces **Leverage** for callers and **Locality** for maintainers.
+
+## Rejected framings
+
+- **Depth as ratio of implementation-lines to interface-lines** (Ousterhout): rewards padding the implementation. We use depth-as-leverage instead.
+- **"Interface" as the TypeScript `interface` keyword or a class's public methods**: too narrow — interface here includes every fact a caller must know.
+- **"Boundary"**: overloaded with DDD's bounded context. Say **seam** or **interface**.
+
+## Going deeper
+
+- **Deepening a cluster given its dependencies** — see [DEEPENING.md](DEEPENING.md): dependency categories, seam discipline, and replace-don't-layer testing.
+- **Exploring alternative interfaces** — see [DESIGN-IT-TWICE.md](DESIGN-IT-TWICE.md): spin up parallel sub-agents to design the interface several radically different ways, then compare on depth, locality, and seam placement.

--- a/.agents/skills/codebase-design/agents/openai.yaml
+++ b/.agents/skills/codebase-design/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Codebase Design"
+  short_description: "Vocabulary for deep-module design"

--- a/.agents/skills/decision-hold-lifecycle/SKILL.md
+++ b/.agents/skills/decision-hold-lifecycle/SKILL.md
@@ -1,23 +1,24 @@
 ---
 name: decision-hold-lifecycle
 description: >-
-  Agent-only policy for completing investigations and visual reviews without losing unresolved captain decisions.
+  Agent-only policy for completing investigations and visual reviews without losing unresolved captain decisions or unscheduled product ideas.
   Load before treating an investigation, scout report, structured review, or Lavish review as complete, before ending a visual review that exposed a decision, and when recording or routing the captain's answer.
 user-invocable: false
 metadata:
   internal: true
 ---
 
-# Durable unresolved-decision lifecycle
+# Durable unresolved-decision and product-idea lifecycle
 
-This skill is the single policy owner for unresolved captain decisions discovered by an investigation or visual review.
+This skill is the single policy owner for unresolved captain decisions and unscheduled product ideas discovered by an investigation or visual review.
 
 ## Policy
 
 Every unresolved decision that belongs to the captain and is discovered while producing, reading, presenting, or ending an investigation or visual review must become a structured captain-held work item in the authoritative backlog of the home that owns the originating work before that work or review may be treated as complete.
-The agent performs the semantic inventory because scripts must not infer decisions from report prose, visual-review artifacts, terminal output, or chat.
+Every product idea, feature proposal, or strategic suggestion not yet scheduled as work must also become a row in that originating home's product-idea ledger with its report section as the source.
+The agent performs both semantic inventories because scripts must not infer decisions or ideas from report prose, visual-review artifacts, terminal output, or chat.
 Give each distinct unresolved decision a stable privacy-safe key, register it through `bin/fm-decision-hold.sh hold`, and use the same key on retry so registration is idempotent while different decisions retain different durable identities.
-After inventorying the whole report and review surface, run `bin/fm-decision-hold.sh complete` with every unresolved key, or with `--none` only when the reviewed surface contains no unresolved captain decision.
+After inventorying the whole report and review surface, append every discovered idea row and run `bin/fm-decision-hold.sh complete` with the decision inventory plus the idea inventory attestation.
 A completed investigation and an ended visual review use this same owner and completion command; a visual tool, including Lavish, never owns a parallel completion policy.
 Run the command in the originating work's authoritative `FM_HOME`; main-home work creates main-home holds, and secondmate-owned work creates holds in that secondmate home's backlog rather than copying them into the main backlog.
 Do not close a hold merely because the originating investigation completed, its report was archived, its visual review ended, or its task was torn down.
@@ -28,13 +29,14 @@ Bearings reads the resulting structured state and must never compensate by scrap
 ## Operating sequence
 
 1. Read the complete investigation result and complete the visual review before declaring either complete.
-2. Inventory only genuine unresolved choices that require the captain.
+2. Inventory genuine unresolved choices that require the captain and unscheduled product ideas that need durable discovery.
 3. For each choice, choose a stable key and use the script's `hold` command with a concise title, reason, and repository.
-4. Run the script's `complete` command with the full unresolved-key inventory for that review pass.
-5. Relay the choices to the captain as decisions from Bearings' Captain's Call section under `AGENTS.md` section 9; do not use the word hold in captain chat.
-6. After the captain decides, record dependent work with normal tasks-axi commands and block it by the hold identity.
-7. Put the captain's exact durable decision in a file and use the script's `resolve` command with every routed task.
-8. Confirm Bearings no longer shows the closed hold and that routed work remains in structured backlog state.
+4. Append each unscheduled idea to the originating home's `data/product-ideas.md` as a well-formed `PI-NNN` row whose Source is `data/<origin-id>/report.md#<section-heading>`, never a line number.
+5. Run the script's `complete` command with the decision inventory (`--none` or every unresolved key) and the idea inventory (`--ideas <PI-id>...` or `--no-ideas`) for that review pass.
+6. Relay the choices to the captain as decisions from Bearings' Captain's Call section under `AGENTS.md` section 9; do not use the word hold in captain chat.
+7. After the captain decides, record dependent work with normal tasks-axi commands and block it by the hold identity.
+8. Put the captain's exact durable decision in a file and use the script's `resolve` command with every routed task.
+9. Confirm Bearings no longer shows the closed hold and that routed work remains in structured backlog state.
 
 `bin/fm-decision-hold.sh --help` owns command syntax, identity construction, completion attestation, retry behavior, and close ordering.
 `docs/decision-hold-lifecycle.md` records the mechanism and regression evidence without restating this policy.

--- a/.agents/skills/domain-modeling/ADR-FORMAT.md
+++ b/.agents/skills/domain-modeling/ADR-FORMAT.md
@@ -1,0 +1,47 @@
+# ADR Format
+
+ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc.
+
+Create the `docs/adr/` directory lazily — only when the first ADR is needed.
+
+## Template
+
+```md
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+That's it. An ADR can be a single paragraph. The value is in recording *that* a decision was made and *why* — not in filling out sections.
+
+## Optional sections
+
+Only include these when they add genuine value. Most ADRs won't need them.
+
+- **Status** frontmatter (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — useful when decisions are revisited
+- **Considered Options** — only when the rejected alternatives are worth remembering
+- **Consequences** — only when non-obvious downstream effects need to be called out
+
+## Numbering
+
+Scan `docs/adr/` for the highest existing number and increment by one.
+
+## When to offer an ADR
+
+All three of these must be true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will look at the code and wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If a decision is easy to reverse, skip it — you'll just reverse it. If it's not surprising, nobody will wonder why. If there was no real alternative, there's nothing to record beyond "we did the obvious thing."
+
+### What qualifies
+
+- **Architectural shape.** "We're using a monorepo." "The write model is event-sourced, the read model is projected into Postgres."
+- **Integration patterns between contexts.** "Ordering and Billing communicate via domain events, not synchronous HTTP."
+- **Technology choices that carry lock-in.** Database, message bus, auth provider, deployment target. Not every library — just the ones that would take a quarter to swap out.
+- **Boundary and scope decisions.** "Customer data is owned by the Customer context; other contexts reference it by ID only." The explicit no-s are as valuable as the yes-s.
+- **Deliberate deviations from the obvious path.** "We're using manual SQL instead of an ORM because X." Anything where a reasonable reader would assume the opposite. These stop the next engineer from "fixing" something that was deliberate.
+- **Constraints not visible in the code.** "We can't use AWS because of compliance requirements." "Response times must be under 200ms because of the partner API contract."
+- **Rejected alternatives when the rejection is non-obvious.** If you considered GraphQL and picked REST for subtle reasons, record it — otherwise someone will suggest GraphQL again in six months.

--- a/.agents/skills/domain-modeling/CONTEXT-FORMAT.md
+++ b/.agents/skills/domain-modeling/CONTEXT-FORMAT.md
@@ -1,0 +1,60 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A one or two sentence description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others under `_Avoid_`.
+- **Keep definitions tight.** One or two sentences max. Define what it IS, not what it does.
+- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/.agents/skills/domain-modeling/CONTEXT-FORMAT.md
+++ b/.agents/skills/domain-modeling/CONTEXT-FORMAT.md
@@ -40,9 +40,9 @@ _Avoid_: Client, buyer, account
 
 ## Contexts
 
-- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
-- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
-- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+- Ordering (`src/ordering/CONTEXT.md`) — receives and tracks customer orders
+- Billing (`src/billing/CONTEXT.md`) — generates invoices and processes payments
+- Fulfillment (`src/fulfillment/CONTEXT.md`) — manages warehouse picking and shipping
 
 ## Relationships
 

--- a/.agents/skills/domain-modeling/SKILL.md
+++ b/.agents/skills/domain-modeling/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: domain-modeling
+description: Build and sharpen a project's domain model. Use when the user wants to pin down domain terminology or a ubiquitous language, record an architectural decision, or when another skill needs to maintain the domain model.
+---
+
+# Domain Modeling
+
+Actively build and sharpen the project's domain model as you design. This is the *active* discipline — challenging terms, inventing edge-case scenarios, and writing the glossary and decisions down the moment they crystallise. (Merely *reading* `CONTEXT.md` for vocabulary is not this skill — that's a one-line habit any skill can do. This skill is for when you're changing the model, not just consuming it.)
+
+## File structure
+
+Most repos have a single context:
+
+```
+/
+├── CONTEXT.md
+├── docs/
+│   └── adr/
+│       ├── 0001-event-sourced-orders.md
+│       └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+If a `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The map points to where each one lives:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/
+│   └── adr/                          ← system-wide decisions
+├── src/
+│   ├── ordering/
+│   │   ├── CONTEXT.md
+│   │   └── docs/adr/                 ← context-specific decisions
+│   └── billing/
+│       ├── CONTEXT.md
+│       └── docs/adr/
+```
+
+Create files lazily — only when you have something to write. If no `CONTEXT.md` exists, create one when the first term is resolved. If no `docs/adr/` exists, create it when the first ADR is needed.
+
+## During the session
+
+### Challenge against the glossary
+
+When the user uses a term that conflicts with the existing language in `CONTEXT.md`, call it out immediately. "Your glossary defines 'cancellation' as X, but you seem to mean Y — which is it?"
+
+### Sharpen fuzzy language
+
+When the user uses vague or overloaded terms, propose a precise canonical term. "You're saying 'account' — do you mean the Customer or the User? Those are different things."
+
+### Discuss concrete scenarios
+
+When domain relationships are being discussed, stress-test them with specific scenarios. Invent scenarios that probe edge cases and force the user to be precise about the boundaries between concepts.
+
+### Cross-reference with code
+
+When the user states how something works, check whether the code agrees. If you find a contradiction, surface it: "Your code cancels entire Orders, but you just said partial cancellation is possible — which is right?"
+
+### Update CONTEXT.md inline
+
+When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+
+`CONTEXT.md` should be totally devoid of implementation details. Do not treat `CONTEXT.md` as a spec, a scratch pad, or a repository for implementation decisions. It is a glossary and nothing else.
+
+### Offer ADRs sparingly
+
+Only offer to create an ADR when all three are true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will wonder "why did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If any of the three is missing, skip the ADR. Use the format in [ADR-FORMAT.md](./ADR-FORMAT.md).

--- a/.agents/skills/domain-modeling/agents/openai.yaml
+++ b/.agents/skills/domain-modeling/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Domain Modeling"
+  short_description: "Build and sharpen a domain model"

--- a/.agents/skills/grill-me/SKILL.md
+++ b/.agents/skills/grill-me/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: grill-me
+description: A relentless interview to sharpen a plan or design.
+disable-model-invocation: true
+---
+
+Run a `/grilling` session.

--- a/.agents/skills/grill-me/agents/openai.yaml
+++ b/.agents/skills/grill-me/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Grill Me"
+  short_description: "Sharpen a plan through interview"
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/grill-with-docs/SKILL.md
+++ b/.agents/skills/grill-with-docs/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: grill-with-docs
+description: A relentless interview to sharpen a plan or design, which also creates docs (ADR's and glossary) as we go.
+disable-model-invocation: true
+---
+
+Run a `/grilling` session, using the `/domain-modeling` skill.

--- a/.agents/skills/grill-with-docs/agents/openai.yaml
+++ b/.agents/skills/grill-with-docs/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Grill with Docs"
+  short_description: "Grill a design and write its docs"
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/grilling/SKILL.md
+++ b/.agents/skills/grilling/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: grilling
+description: Grill the user relentlessly about a plan, decision, or idea. Use when the user wants to stress-test their thinking, or uses any 'grill' trigger phrases.
+---
+
+Interview the user relentlessly until you reach a shared understanding. Map this as a **design tree**: every decision branches into the decisions that hang off it.
+
+Work the tree in **rounds**. The **frontier** is every decision whose prerequisites are already settled — the questions you can ask _now_ without guessing at answers you haven't heard yet. Ask the whole frontier in one round: number each question and give your recommended answer. Then wait for the user's answers before the next round.
+
+Each question should be formatted like so:
+
+```
+❓ **Q1** - **<question title>**: <question body, might be multiple paragraphs, including multiple choices>
+
+➡️ <your recommended answer>
+```
+
+Each round the user answers reshapes the tree — settled decisions push the frontier outward and unblock questions that depended on them. Recompute the frontier and ask the next round. A question whose answer depends on another question still open in this round belongs to a _later_ round, not this one.
+
+Finding _facts_ is your job, never the user's. When a frontier question needs a fact from the environment (filesystem, tools, etc.), dispatch a sub-agent to find it — don't ask the user for anything you could look up yourself. Don't block on it: a running exploration is an unsettled prerequisite, so only the questions downstream of it wait for the sub-agent to report — ask the rest of the frontier now. The _decisions_ are the user's — put each to them and wait.
+
+The session is done when the frontier is empty: every branch of the design tree visited, nothing left silently assumed. Do not act on it until the user confirms you have reached a shared understanding.

--- a/.agents/skills/grilling/agents/openai.yaml
+++ b/.agents/skills/grilling/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Grilling"
+  short_description: "Stress-test thinking a round of questions at a time"

--- a/.agents/skills/wait-what/SKILL.md
+++ b/.agents/skills/wait-what/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: wait-what
+description: Stop. That last message did not land — re-pitch it.
+disable-model-invocation: true
+---
+
+Wait — I don't understand where you've got to here. Re-pitch that: give me a little bit of context, talk in ASD-STE100 Simplified Technical English, and use the ubiquitous language from `CONTEXT.md`.

--- a/.agents/skills/wait-what/agents/openai.yaml
+++ b/.agents/skills/wait-what/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Wait What"
+  short_description: "Re-pitch that — simpler, with the context I'm missing"
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/wayfinder/SKILL.md
+++ b/.agents/skills/wayfinder/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: wayfinder
+description: Plan a huge chunk of work — more than one agent session can hold — as a shared map of decision tickets on your issue tracker, and resolve them one at a time until the way to the destination is clear.
+disable-model-invocation: true
+---
+
+A loose idea has arrived — too big for one agent session, and wrapped in fog: the way from here to the **destination** isn't visible yet. Wayfinding is about finding that way, not charging at the destination. This skill charts the way as a **shared map** on the repo's issue tracker, then works its **decision tickets** — questions whose resolution is a decision, not slices of a build to execute — one at a time until the route is clear.
+
+The destination varies per effort, and naming it is the first act of charting — it shapes every ticket. It might be a spec to hand off and iterate on, a decision to lock before planning starts, or a change made in place like a data-structure migration. The map is domain-agnostic — engineering work, course content, whatever fits the shape.
+
+## Plan, don't do
+
+Wayfinder is **planning** by default: each ticket resolves a decision, and the map is done when the way is clear — nothing left to decide before someone goes and does the thing. The pull to just do the work is usually the signal you've reached the edge of the map and it's time to hand off. An effort can override this in its **Notes** — carrying execution into the map itself — but absent that, produce decisions, not deliverables.
+
+## Refer by name
+
+Every map and ticket is an issue, so it has a **name** — its title. In everything the human reads — narration, the map's Decisions-so-far — refer to it by that name, never by a bare id, number, or slug. A wall of `#42, #43, #44` is illegible; names read at a glance. The id and URL don't vanish — a name wraps its link — but they ride _inside_ the name, never stand in for it.
+
+## The Map
+
+The map is a single issue on this repo's issue tracker, labelled `wayfinder:map` — the canonical artifact. Its tickets are child issues of the map.
+
+The map is an **index**, not a store. It lists the decisions made and points at the tickets that hold their detail; a decision lives in exactly one place — its ticket — so the map never restates it, only gists it and links.
+
+**Where the map, its child tickets, blocking, and frontier queries physically live is tracker-specific.** The issue tracker should have been provided to you — run `/setup-matt-pocock-skills` if not. Consult the tracker doc's "Wayfinding operations" section for how _this_ repo expresses them. If no tracker has been provided, default to the local-markdown tracker.
+
+### The map body
+
+The whole map at low resolution, loaded once per session. Open tickets are **not** listed — they are open child issues, found by query.
+
+```markdown
+## Destination
+
+<what reaching the end of this map looks like — the spec, decision, or change this effort is finding its way to. One or two lines; every session orients to it before choosing a ticket.>
+
+## Notes
+
+<domain; skills every session should consult; standing preferences for this effort>
+
+## Decisions so far
+
+<!-- the index — one line per closed ticket: enough to judge relevance, then zoom the link for the detail the ticket holds -->
+
+- [<closed ticket title>](link) — <one-line gist of the answer>
+
+## Not yet specified
+
+<!-- see "Fog of war": in-scope fog you can't ticket yet; graduates as the frontier advances -->
+
+## Out of scope
+
+<!-- see "Out of scope": work ruled beyond the destination; closed, never graduates -->
+```
+
+### Tickets
+
+Each ticket is a **child issue** of the map; the tracker's issue id is its identity. Its body is the question, sized to one 100K token agent session:
+
+```markdown
+## Question
+
+<the decision or investigation this ticket resolves>
+```
+
+Each ticket carries a `wayfinder:<type>` label — one of `research`, `prototype`, `grilling`, `task` (see [Ticket Types](#ticket-types)).
+
+A session **claims** a ticket by assigning it to the dev driving the map, **first**, before any work, so concurrent sessions skip it. That assignee _is_ the claim: an open, unassigned ticket is unclaimed.
+
+Blocking uses the tracker's **native** dependency relationship — essential because it renders the frontier _visually_ in the tracker's own UI, so the human sees what's takeable without opening the map. Only a tracker that lacks native blocking falls back to a body convention. A ticket is **unblocked** when every ticket blocking it is closed; the **frontier** is the open, unblocked, unclaimed children — the edge of the known.
+
+The answer isn't part of the body — it's recorded on resolution (see [Work through the map](#work-through-the-map)). Assets created while resolving a ticket are linked from the issue, not pasted in.
+
+## Ticket Types
+
+Every ticket is either **HITL** — human in the loop, worked _with_ a human who speaks for themselves — or **AFK**, driven by the agent alone. A HITL ticket only resolves through that live exchange; the agent never stands in for the human's side of it (a grilling agent that answers its own questions has broken this).
+
+- **Research** (AFK): Reading documentation, third-party APIs, or local resources like knowledge bases to surface a fact a decision waits on. Resolved by a `/research` **subagent**. Use when knowledge outside the current working directory is required.
+- **Prototype** (HITL): Raise the fidelity of the discussion by making a cheap, rough, concrete artifact to react to — an outline, a rough take, a stub, or UI/logic code via the /prototype skill. Links the prototype as an asset. Use when "how should it look" or "how should it behave" is the key question.
+- **Grilling** (HITL): Conversation. The default case. Always invoke the /grilling and /domain-modeling skills.
+- **Task** (HITL or AFK): Manual work that must happen before a _decision_ can be made — nothing to decide, prototype, or research, but the discussion is blocked until it's done. Signing up for a service so its API can be judged, provisioning access, moving data so its shape can be seen. This is the one type that _does_ rather than decides — and it earns its place by unblocking a decision, not by delivering the destination. The agent drives it alone where it can (AFK); otherwise it hands the human a precise checklist (HITL). Resolved when the work is done; the answer records what was done and any resulting facts (credentials location, new URLs, row counts) later tickets depend on.
+
+## Fog of war
+
+The map is _deliberately_ incomplete: don't chart what you can't yet see. Beyond the live tickets lies the **fog of war** — the dim view of decisions and investigations you can tell are coming but can't yet pin down, because they hang on questions still open. Resolving a ticket clears the fog ahead of it, graduating whatever's now specifiable into fresh tickets — one at a time, until the way to the destination is clear and no tickets remain.
+
+The map's **Not yet specified** section is where that dim view is written down: the suspected question, the area to revisit later. It's the undiscovered frontier _toward_ the destination — everything here is in scope, just not sharp enough to ticket. Write as loosely or as fully as the view allows; it doubles as a signpost for collaborators reading where the effort is headed.
+
+**Fog or ticket?** The test is whether you can state the question precisely now — _not_ whether you can answer it now.
+
+- **Ticket when** the question is already sharp — even if it's blocked and you can't act on it yet.
+- **Not yet specified when** you can't yet phrase it that sharply. Don't pre-slice the fog into ticket-sized pieces: it's coarser than a ticket, and one patch may graduate into several tickets, or none, once the frontier reaches it.
+
+**Not yet specified** excludes what's already decided (Decisions so far), what's already a live ticket, and what's out of scope (the next section).
+
+## Out of scope
+
+Fog only ever gathers _toward_ the destination. The destination fixes the scope, so work beyond it is **out of scope** — it isn't fog, and it doesn't belong in **Not yet specified**. It gets its own **Out of scope** section on the map: work you've consciously ruled out of _this_ effort. Scope, not sharpness, lands it here.
+
+Out-of-scope work never graduates — the frontier stops at the destination — so it returns only if the destination is redrawn, and then as a fresh effort, not a resumption.
+
+Ruling something out of scope is a scoping act, not a step on the route. When a ticket that already exists turns out to sit past the destination — mis-scoped in while charting, or exposed by a resolution — **close it** (a closed ticket is unambiguously off the frontier) and leave one line in the **Out of scope** section: the gist plus why it's out of scope, linking the closed ticket. It stays out of **Decisions so far**, which records the route actually walked — a scope boundary isn't a step on it.
+
+## Invocation
+
+Two modes. Either way, **never resolve more than one ticket per session** — with the exception of research tickets.
+
+### Chart the map
+
+User invokes with a loose idea.
+
+1. **Name the destination.** Run a `/grilling` and `/domain-modeling` session to pin down what this map is finding its way to — the spec, decision, or change. The destination fixes the scope, so it's settled first.
+2. **Map the frontier.** Grill again, **breadth-first** this time: fan out across the whole space rather than deep on any one thread, surfacing the open decisions and the first steps takeable now. **If this surfaces no fog** — the way to the destination is already clear, the whole journey small enough for one session — you don't need a map. Stop and ask the user how they'd like to proceed.
+3. **Create the map** (label `wayfinder:map`): Destination and Notes filled in, Decisions-so-far empty, the fog sketched into **Not yet specified**.
+4. **Create the tickets you can specify now** as child issues of the map — then wire blocking edges in a **second pass** (issues need ids before they can reference each other). Wiring sorts them into the frontier and the blocked; everything you can't yet specify stays in the fog — the **Not yet specified** section.
+5. **Fire the research subagents.** For each `research` ticket you just created, spin up a `/research` subagent to resolve it in parallel, capturing its findings on a throwaway `research/<name>` branch with a context pointer from the ticket.
+6. Stop — charting is one session's work; it hand-resolves nothing.
+
+### Work through the map
+
+User invokes with a map (URL or number). A ticket is **optional** — without one, you pick the next decision, not the user.
+
+1. Load the **map** — the low-res view, not every ticket body.
+2. Choose the ticket. If the user named one, use it. Otherwise take the first frontier ticket in order. **Claim it**: assign it to yourself before any work.
+3. Resolve it — **zoom as needed**: fetch the full body of any related or closed ticket on demand; invoke the skills the `## Notes` block names. If in doubt, use `/grilling` and `/domain-modeling`.
+4. Record the resolution: post the answer as a **resolution comment**, **close** the issue, and **append a context pointer** to the map's Decisions-so-far.
+5. Add newly-surfaced tickets (create-then-wire); graduate any fog the answer has made specifiable, clearing each graduated patch from **Not yet specified** so it lives only as its new ticket. If the answer reveals a ticket — this one or another — sits beyond the destination, **rule it out of scope** rather than resolving it on the route. If the decision invalidates other parts of the map, update or delete those tickets.
+
+The user may run unblocked tickets in parallel, so expect other sessions to be editing the tracker concurrently.

--- a/.agents/skills/wayfinder/SKILL.md
+++ b/.agents/skills/wayfinder/SKILL.md
@@ -41,7 +41,7 @@ The whole map at low resolution, loaded once per session. Open tickets are **not
 
 <!-- the index — one line per closed ticket: enough to judge relevance, then zoom the link for the detail the ticket holds -->
 
-- [<closed ticket title>](link) — <one-line gist of the answer>
+- <closed ticket title> — <one-line gist of the answer>
 
 ## Not yet specified
 

--- a/.agents/skills/wayfinder/agents/openai.yaml
+++ b/.agents/skills/wayfinder/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Wayfinder"
+  short_description: "Map a large effort as decision tickets"
+policy:
+  allow_implicit_invocation: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,8 +358,8 @@ jobs:
           bearings_output=$(/bin/bash tests/fm-bearings-snapshot.test.sh)
           printf '%s\n' "$bearings_output"
           bearings_count=$(printf '%s\n' "$bearings_output" | grep -c '^ok - ')
-          [ "$bearings_count" -eq 41 ] || {
-            echo "::error::expected 41 Bearings tests, got $bearings_count"
+          [ "$bearings_count" -eq 43 ] || {
+            echo "::error::expected 43 Bearings tests, got $bearings_count"
             exit 1
           }
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__/
 *.pyc
 .env
 config/
+.gstack/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Hard rules, in priority order:
 3. **Never tear down unlanded work.**
    Uncommitted changes are never landed, and `bin/fm-teardown.sh` owns the complete landed-work test.
    Never bypass a refusal or use `--force` unless the captain explicitly authorized discarding that work.
-   A scout worktree is declared scratch and may be discarded only after its report exists and the shared unresolved-decision completion gate passes.
+   A scout worktree is declared scratch and may be discarded only after its report exists and the shared decision-hold completion gate passes.
 4. **Crewmates never address the captain.**
    All crewmate communication flows through firstmate.
    Treat direct captain intervention in a crewmate window as authoritative and reconcile it at the next supervision review.
@@ -81,6 +81,7 @@ data/                personal fleet records; LOCAL, gitignored as a whole
   captain.md         this home's domain-local captain preferences and working style; LOCAL, gitignored, canonical even if harness memory mirrors it, and updated with inspect-then-update
   captain-shared.md  main-authoritative shared captain preferences propagated read-only to secondmate homes; LOCAL, gitignored, owned by secondmate-provisioning
   learnings.md       fleet-local operational facts and gotchas; LOCAL, gitignored; dated, evidence-backed, curated, and updated with inspect-then-update - rewrite and prune rather than append forever, the same contract as captain.md; created lazily, absent until this home has a learning to store
+  product-ideas.md   home-local product-idea ledger for unscheduled discoveries; LOCAL, gitignored; created lazily when first needed; row grammar owned by bin/fm-product-idea-lib.sh; empty template owned by bin/fm-decision-hold.sh
   projects.md        thin fleet navigation registry recording each project's standing delivery posture; firstmate-private, parsed for mechanical sync and seeding by fm-project-mode.sh (section 6)
   secondmates.md      local and remote secondmate routing table; firstmate-private, maintained by the secondmate seed helpers (section 6)
   <id>/brief.md      per-task crewmate brief, or per-secondmate charter brief when kind=secondmate
@@ -236,6 +237,7 @@ Route durable knowledge to its most specific owner:
 - Captain preferences shared across secondmate domains belong in the primary home's `data/captain-shared.md` under the `secondmate-provisioning` contract.
 - Fleet-local operational facts belong in curated, home-local `data/learnings.md`.
 - Task-scoped notes belong with the backlog item, and investigation findings belong in the scout report.
+- A product idea, feature proposal, or strategic suggestion not yet scheduled as work belongs in the discovering home's `data/product-ideas.md` with its discovering report section as the source.
 - Knowledge useful to almost every contributor to one project belongs in that project's committed `AGENTS.md`.
 - Knowledge general to every firstmate user belongs in this repo's shared tracked surface.
 
@@ -260,6 +262,9 @@ Send in-scope work to the fitting secondmate unless it is blocked or the captain
 If no secondmate scope fits, use the main home or discuss creating an appropriate persistent secondmate.
 For one-off or infrequent operational work, start with the simplest direct end-to-end path.
 Do not build wrappers, control planes, policy layers, custom verifiers, or automation unless the direct path exposes a concrete blocker or repeated need that justifies the added machinery.
+
+Before a planning, roadmap, or scope session, sweep the main product-idea ledger and every registered secondmate home's ledger and bring every unscheduled item to the captain.
+Name every item not carried forward and transition it to parked or dropped with a rationale, and name every registered home ledger that could not be read.
 
 Before commissioning an investigation, consult existing reports and established evidence.
 Classify the deliverable:
@@ -523,7 +528,7 @@ These skills are not captain-invocable; load them only at their precise triggers
   Cloning or registering a project is add intake and uses the same trigger.
 - `stuck-crewmate-recovery` - load when the session-start digest reports an ordinary direct report's endpoint dead or its metadata has no window, or after a stale wake, looping pane, repeated confusion, an answered-by-brief question, an unresponsive crewmate, or a failed steer.
 - `secondmate-provisioning` - load before creating, seeding, validating, launching, handing backlog to, recovering, pushing inherited local material into, or retiring a secondmate home, and before editing `data/secondmates.md`.
-- `decision-hold-lifecycle` - load before treating an investigation or visual review as complete, before ending a visual review that exposed a decision, and when recording or routing the captain's answer.
+- `decision-hold-lifecycle` - load before treating an investigation or visual review as complete so captain decisions and unscheduled product ideas are inventoried, before ending a visual review that exposed a decision, and when recording or routing the captain's answer.
 - `process-event-sources` - load before arming a long-polling source, and on any `procevent <adapter> <source-id> <sequence>` check wake.
   Never run a registered source's blocking command yourself in a conversational turn.
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the Relay configuration blocker, on a `public-followup ...` `check:` wake or a startup-surfaced public commitment, and on any milestone or terminal wake for a Relay-linked task before posting its completion follow-up; relevant only when Relay is on.

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Firstmate's skills live in two separate places with different audiences:
 
 - [docs/architecture.md](docs/architecture.md) - maintainer architecture for the crew, supervision, worktrees, secondmates, and project modes.
 - [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, runtime backend selection, optional Relay and its X and Discord setup steps, the files you set, and harness support.
+- [docs/deadman.md](docs/deadman.md) - install and operate the notify-only Studio watcher deadman.
 - [docs/remote-secondmates.md](docs/remote-secondmates.md) - current setup, routing, transfer, recovery, and safety behavior for whole-home remote second mates.
 - [docs/calm.md](docs/calm.md) - current Pi `/calm` behavior and supported presentation limits.
 - [docs/wedge-alarm.md](docs/wedge-alarm.md) - configure the active alert for an away-mode escalation delivery that gets stuck.

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Setup guides for tmux (the default) and every other supported backend (herdr, ze
      │
      ├─ ship: project mode ► PR/local merge ► teardown
      │
-     └─ scout: report at data/<id>/report.md ► decision inventory ► relay findings ► teardown
+     └─ scout: report at data/<id>/report.md ► decision and idea inventory ► relay findings ► teardown
 ```
 
 You chat with the first mate.

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -32,8 +32,12 @@
 # The landed section merges this home's Done with the canonical snapshot's
 # secondmate_landed roll-up (fm-fleet-snapshot.sh), so merges a secondmate managed -
 # recorded in ITS OWN backlog, never the main one - are visible. It stays bounded by
-# a per-home cap and an overall cap, with omitted[] disclosure of both and of any
-# secondmate home whose backlog was unreadable; no GitHub/network call is involved.
+# a per-home cap and an overall cap, with omitted[] disclosure of both; no
+# GitHub/network call is involved. Any registered secondmate whose own structured
+# home state could not be read - a missing home directory, an unusable one, or an
+# unreadable backlog - contributes nothing to landed, gates, and decisions, so
+# omitted[] names those homes and their reason instead of leaving the absence to
+# look like an empty baseline.
 # The default landed baseline is balanced across homes: each home keeps its internal
 # newest-first ordering, homes iterate in deterministic id order, sparse homes do not
 # waste capacity, and --all-landed switches back to the complete global newest-first
@@ -428,6 +432,9 @@ MODEL=$(printf '%s' "$SNAP" | jq \
           provenance:.provenance.selected,freshness:.freshness.status,
           age_seconds:.freshness.age_seconds,contradiction:(.contradiction // false),
           reason:(.current.reason // "-")} ]) as $secondmates_all
+  | ([ (.secondmate_current.records // [])[]
+       | select(.provenance.selected != "structured-home")
+       | {id, reason:((.current.reason // "state unavailable") | trunc(60))} ]) as $mates_unavailable
   | ([ .tasks[]
        | select(.kind != "secondmate")
        | select(.backlog.current_role != "program")
@@ -513,7 +520,12 @@ MODEL=$(printf '%s' "$SNAP" | jq \
         (if $all_queued == 1 then empty else {surface:"superseded queued items", reveal:"--all-queued"} end),
         (if $all_landed == 0 and ($per_home_capped | length) > ($done | length) then {surface:("landed showing \($done | length) of \($per_home_capped | length)" + (($done | map(.home_id) | unique | map(select(. != "(main)")) | length) as $k | if $k > 0 then " (incl. \($k) secondmate home(s))" else "" end)), reveal:"--all-landed"} else empty end),
         (if $all_landed == 0 and $home_cap_dropped > 0 then {surface:("landed per-home capped at \($landed_per_home_n) for \($home_cap_dropped) home(s)"), reveal:"--all-landed"} else empty end),
-        (if (($snap.secondmate_landed.unreadable // []) | length) > 0 then {surface:("secondmate home(s) with unreadable backlog: \(($snap.secondmate_landed.unreadable // []) | length)"), reveal:"inspect the listed secondmate home backlogs"} else empty end),
+        (if ($mates_unavailable | length) > 0 then
+           {surface:("secondmate home(s) unavailable, so their landed, queued, and decision work is excluded: "
+                     + ($mates_unavailable[:3] | map(.id + " (" + .reason + ")") | join("; "))
+                     + (if ($mates_unavailable | length) > 3 then "; +\(($mates_unavailable | length) - 3) more" else "" end)),
+            reveal:"inspect data/secondmates.md and those homes; re-seed or deregister an unavailable home"}
+         else empty end),
         (if $all_landed == 0 and (($snap.secondmate_landed.truncated // []) | length) > 0 then {surface:("secondmate home Done capped at the snapshot layer for \(($snap.secondmate_landed.truncated // []) | length) home(s)"), reveal:"--all-landed"} else empty end),
         ((($snap.main_inventory.orphan_in_flight // []) | length) as $n
          | if $n > 0 then {surface:("main in-flight backlog item(s) have no child metadata: \($n)"), reveal:"inspect main data/backlog.md In flight vs state/*.meta"} else empty end),

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -56,6 +56,9 @@
 #   -h,--help        usage
 #
 # Output contract: `fm-bearings.v1`. Read-only; no locks, no mutation, no reports.
+# `ideas_unscheduled` counts readable main and registered secondmate ledgers.
+# `ideas_warnings` names ledgers that could not be read or parsed, so an
+# incomplete count is never presented as a silent zero.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -63,6 +66,9 @@ FLEET="$SCRIPT_DIR/fm-fleet-snapshot.sh"
 # shellcheck source=bin/fm-timeout-lib.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-timeout-lib.sh"
+# shellcheck source=bin/fm-product-idea-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-product-idea-lib.sh"
 
 # Bounds (overridable for tests / large fleets).
 FM_BEARINGS_LANDED=${FM_BEARINGS_LANDED:-6}
@@ -107,7 +113,8 @@ Default is LOCAL-ONLY (no network); --include-prs is the only path that fetches.
 
 Default fields: schema, home, generated, prs, in_flight{id,kind,state,doing},
   secondmates{id,state,doing,provenance,freshness,age_seconds,contradiction,reason},
-  decisions_open{id,key,verb,summary,owner}, landed{id,what,artifact,owner},
+  decisions_open{id,key,verb,summary,owner}, ideas_unscheduled,
+  ideas_warnings{home,path,reason}, landed{id,what,artifact,owner},
   gates{id,title,blocked_by,reason,owner}, reports{id,path}, recorded_prs{id,url},
   unhealthy_endpoints{...} (only when non-empty), omitted{surface,reveal}.
 landed merges this home's Done with registered secondmate homes' Done, bounded by
@@ -178,6 +185,59 @@ else
 fi
 HOME_LABEL=$(printf '%s' "$SNAP" | jq -er '.fm_home | strings | split("/") | (.[-2:] | join("/"))') \
   || { echo "fm-bearings-snapshot: invalid canonical snapshot" >&2; exit 1; }
+IDEA_MAIN_DATA=$(printf '%s' "$SNAP" | jq -er '.roots.data | strings') \
+  || { echo "fm-bearings-snapshot: canonical data path is unavailable" >&2; exit 1; }
+
+IDEAS_UNSCHEDULED=0
+IDEAS_WARNINGS='[]'
+
+idea_warning_add() {  # <home-label> <path> <reason>
+  IDEAS_WARNINGS=$(jq -n \
+    --argjson warnings "$IDEAS_WARNINGS" --arg home "$1" --arg path "$2" --arg reason "$3" \
+    '$warnings + [{home:$home,path:$path,reason:$reason}]')
+}
+
+count_idea_ledger() {  # <home-label> <ledger-path>
+  local label=$1 ledger=$2 count rc
+  if count=$(fm_product_idea_ledger_count "$ledger"); then
+    IDEAS_UNSCHEDULED=$((IDEAS_UNSCHEDULED + count))
+    return 0
+  else
+    rc=$?
+  fi
+  if [ "$rc" -eq 2 ]; then
+    idea_warning_add "$label" "$ledger" "ledger is unreadable"
+  else
+    idea_warning_add "$label" "$ledger" "ledger is malformed"
+  fi
+}
+
+count_idea_ledger "(main)" "$IDEA_MAIN_DATA/product-ideas.md"
+while IFS=$'\t' read -r mate_id mate_home mate_remote; do
+  [ -n "$mate_id" ] || continue
+  if [ "$mate_remote" = true ]; then
+    idea_warning_add "$mate_id" "${mate_home:-unknown}/data/product-ideas.md" "remote ledger is not readable from the local snapshot"
+  elif [ -z "$mate_home" ]; then
+    idea_warning_add "$mate_id" "unknown" "registered home path is unavailable"
+  else
+    count_idea_ledger "$mate_id" "$mate_home/data/product-ideas.md"
+  fi
+done <<EOF
+$(printf '%s' "$SNAP" | jq -r '.secondmate_current.records[]? | [.id, (.home // ""), (.remote // false)] | @tsv')
+EOF
+if [ "$(printf '%s' "$SNAP" | jq -r '.secondmate_current.truncated // 0')" -gt 0 ]; then
+  idea_warning_add "(registry)" "$IDEA_MAIN_DATA/secondmates.md" "registered homes were omitted by the snapshot bound"
+fi
+if [ "$(printf '%s' "$SNAP" | jq -r '.secondmate_current.registry.available == false')" = true ]; then
+  idea_warning_add "(registry)" "$IDEA_MAIN_DATA/secondmates.md" \
+    "registry unavailable: $(printf '%s' "$SNAP" | jq -r '.secondmate_current.registry.reason // "registered secondmate table unavailable"')"
+fi
+if [ "$(printf '%s' "$SNAP" | jq -r '.secondmate_current.registry.input_truncated == true')" = true ]; then
+  idea_warning_add "(registry)" "$IDEA_MAIN_DATA/secondmates.md" "registry input was truncated"
+fi
+if [ "$(printf '%s' "$SNAP" | jq -r '.secondmate_current.registry.records_truncated == true')" = true ]; then
+  idea_warning_add "(registry)" "$IDEA_MAIN_DATA/secondmates.md" "registry records were truncated"
+fi
 
 # --- optional live PR enrichment (the ONLY network path) --------------------
 PR_STATUS='not_requested (run: /bearings include PRs)'
@@ -298,7 +358,9 @@ MODEL=$(printf '%s' "$SNAP" | jq \
   --argjson pr_repos_shown "$PR_REPOS_SHOWN" \
   --argjson pr_rows_capped "$PR_ROWS_CAPPED" \
   --argjson pr_rows_min_total "$PR_ROWS_MIN_TOTAL" \
-  --argjson candidate_prs "$CANDIDATE_PRS" '
+  --argjson candidate_prs "$CANDIDATE_PRS" \
+  --argjson ideas_unscheduled "$IDEAS_UNSCHEDULED" \
+  --argjson ideas_warnings "$IDEAS_WARNINGS" '
   def trunc($n): if . == null then null else
     (tostring | gsub("\\s+"; " ") | if (length > $n) then (.[:$n] + "…") else . end) end;
   def round_robin_landed($n):
@@ -426,6 +488,8 @@ MODEL=$(printf '%s' "$SNAP" | jq \
       in_flight: (if $all_in_flight == 1 then $in_flight_all else $in_flight_all[:$in_flight_n] end),
       secondmates: (if $all_secondmates == 1 then $secondmates_all else $secondmates_all[:$secondmates_n] end),
       decisions_open: (if $all_decisions == 1 then $decisions_all else $decisions_all[:$decisions_n] end),
+      ideas_unscheduled: $ideas_unscheduled,
+      ideas_warnings: $ideas_warnings,
       landed: ($done | map({id, what:(.title | trunc(70)),
                             artifact:(.pr_url // .report_path // .local_note // "-"),owner:.home_id})),
       gates: (if $all_queued == 1 then $gates_all else $gates_all[:$gates_n] end),

--- a/bin/fm-deadman-install.sh
+++ b/bin/fm-deadman-install.sh
@@ -111,6 +111,7 @@ uninstall_deadman() {
   rm -f "$INSTALL_DIR/installed-at" "$INSTALL_DIR/armed" "$INSTALL_DIR/first-stale"
   rm -f "$INSTALL_DIR/last-run-at" "$INSTALL_DIR/wake-grace-until" "$INSTALL_DIR/last-success-at"
   rm -f "$INSTALL_DIR/deadman.journal" "$INSTALL_DIR/deadman.stdout.log" "$INSTALL_DIR/deadman.stderr.log"
+  rmdir "$INSTALL_DIR/.probe.lock" 2>/dev/null || true
   rmdir "$INSTALL_DIR" 2>/dev/null || true
   printf 'Uninstalled com.firstmate.deadman.\n'
 }

--- a/bin/fm-deadman-install.sh
+++ b/bin/fm-deadman-install.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Install the Firstmate deadman as stable copies outside the git checkout.
+#
+# The installer atomically replaces individual installed files, writes the
+# LaunchAgent plist, and sends a mandatory canary notification. It bootstraps
+# launchd only when --bootstrap is explicit and only after that canary succeeds.
+# It never starts, stops, or repairs Firstmate fleet processes.
+#
+# Usage:
+#   fm-deadman-install.sh [--fm-home PATH] [--channel DIRECTIVE]... [--bootstrap]
+#   fm-deadman-install.sh --uninstall
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_PROBE="$SCRIPT_DIR/fm-deadman.sh"
+SOURCE_NOTIFY="$SCRIPT_DIR/fm-notify-lib.sh"
+TEMPLATE="$SCRIPT_DIR/launchd/com.firstmate.deadman.plist.template"
+INSTALL_DIR=${FM_DEADMAN_INSTALL_DIR:-$HOME/Library/Application Support/Firstmate/deadman}
+PLIST=${FM_DEADMAN_PLIST:-$HOME/Library/LaunchAgents/com.firstmate.deadman.plist}
+FM_HOME_VALUE=${FM_HOME:-$(cd "$SCRIPT_DIR/.." && pwd)}
+FM_HOME_EXPLICIT=0
+BOOTSTRAP=0
+UNINSTALL=0
+CHANNELS=()
+
+usage() {
+  sed -n '2,13{s/^# \{0,1\}//;p;}' "$0" >&2
+}
+
+atomic_install() {
+  local source=$1 target=$2 mode=$3 tmp
+  tmp="$target.tmp.$$"
+  install -m "$mode" "$source" "$tmp"
+  mv -f "$tmp" "$target"
+}
+
+xml_escape() {
+  sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\\&apos;/g"
+}
+
+sed_replacement() {
+  sed -e 's/[\\&|]/\\&/g'
+}
+
+write_plist() {
+  local script stdout_log stderr_log tmp
+  script=$(printf '%s' "$INSTALL_DIR/fm-deadman.sh" | xml_escape | sed_replacement)
+  stdout_log=$(printf '%s' "$INSTALL_DIR/deadman.stdout.log" | xml_escape | sed_replacement)
+  stderr_log=$(printf '%s' "$INSTALL_DIR/deadman.stderr.log" | xml_escape | sed_replacement)
+  tmp="$PLIST.tmp.$$"
+  sed -e "s|__DEADMAN_SCRIPT__|$script|g" \
+    -e "s|__STDOUT_LOG__|$stdout_log|g" \
+    -e "s|__STDERR_LOG__|$stderr_log|g" "$TEMPLATE" > "$tmp"
+  chmod 644 "$tmp"
+  mv -f "$tmp" "$PLIST"
+}
+
+write_config() {
+  local line found=0 tmp="$INSTALL_DIR/deadman.env.tmp.$$"
+  if [ -f "$INSTALL_DIR/deadman.env" ] && [ "$FM_HOME_EXPLICIT" -eq 0 ]; then
+    return 0
+  fi
+  (umask 077
+    if [ -f "$INSTALL_DIR/deadman.env" ]; then
+      while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+          FM_HOME=*)
+            if [ "$found" -eq 0 ]; then
+              printf 'FM_HOME=%s\n' "$FM_HOME_VALUE"
+              found=1
+            fi
+            ;;
+          *) printf '%s\n' "$line" ;;
+        esac
+      done < "$INSTALL_DIR/deadman.env"
+      [ "$found" -eq 1 ] || printf 'FM_HOME=%s\n' "$FM_HOME_VALUE"
+    else
+      printf 'FM_HOME=%s\n' "$FM_HOME_VALUE"
+      printf 'STALE_AFTER_SECS=600\n'
+      printf 'SAMPLE_GAP_SECS=60\n'
+      printf 'SAMPLE_MAX_GAP_SECS=120\n'
+      printf 'FIRST_ARM_GRACE_SECS=660\n'
+      printf 'WAKE_GRACE_SECS=300\n'
+      printf 'SLEEP_GAP_DETECT_SECS=180\n'
+      printf 'COOLDOWN_SECS=1800\n'
+    fi > "$tmp")
+  mv -f "$tmp" "$INSTALL_DIR/deadman.env"
+}
+
+write_channels() {
+  local channel tmp="$INSTALL_DIR/deadman.conf.tmp.$$"
+  if [ "${#CHANNELS[@]}" -eq 0 ] && [ -f "$INSTALL_DIR/deadman.conf" ]; then
+    return 0
+  fi
+  (umask 077
+    if [ "${#CHANNELS[@]}" -eq 0 ]; then
+      printf 'auto\n'
+    else
+      for channel in "${CHANNELS[@]}"; do
+        printf '%s\n' "$channel"
+      done
+    fi > "$tmp")
+  mv -f "$tmp" "$INSTALL_DIR/deadman.conf"
+}
+
+uninstall_deadman() {
+  launchctl bootout "gui/$UID/com.firstmate.deadman" >/dev/null 2>&1 || true
+  rm -f "$PLIST"
+  rm -f "$INSTALL_DIR/fm-deadman.sh" "$INSTALL_DIR/fm-notify-lib.sh"
+  rm -f "$INSTALL_DIR/deadman.env" "$INSTALL_DIR/deadman.conf"
+  rm -f "$INSTALL_DIR/installed-at" "$INSTALL_DIR/armed" "$INSTALL_DIR/first-stale"
+  rm -f "$INSTALL_DIR/last-run-at" "$INSTALL_DIR/wake-grace-until" "$INSTALL_DIR/last-success-at"
+  rm -f "$INSTALL_DIR/deadman.journal" "$INSTALL_DIR/deadman.stdout.log" "$INSTALL_DIR/deadman.stderr.log"
+  rmdir "$INSTALL_DIR" 2>/dev/null || true
+  printf 'Uninstalled com.firstmate.deadman.\n'
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --fm-home)
+      [ "$#" -ge 2 ] || { usage; exit 2; }
+      FM_HOME_VALUE=$2
+      FM_HOME_EXPLICIT=1
+      shift 2
+      ;;
+    --channel)
+      [ "$#" -ge 2 ] || { usage; exit 2; }
+      CHANNELS+=("$2")
+      shift 2
+      ;;
+    --bootstrap) BOOTSTRAP=1; shift ;;
+    --uninstall) UNINSTALL=1; shift ;;
+    --help|-h) usage; exit 0 ;;
+    *) usage; exit 2 ;;
+  esac
+done
+
+if [ "$UNINSTALL" -eq 1 ]; then
+  [ "$BOOTSTRAP" -eq 0 ] && [ "${#CHANNELS[@]}" -eq 0 ] || { usage; exit 2; }
+  uninstall_deadman
+  exit 0
+fi
+
+case "$FM_HOME_VALUE" in /*) ;; *) printf 'fm-deadman-install: FM_HOME must be absolute.\n' >&2; exit 2 ;; esac
+case "$FM_HOME_VALUE" in *$'\n'*|*$'\r'*) printf 'fm-deadman-install: FM_HOME must be one line.\n' >&2; exit 2 ;; esac
+for channel in "${CHANNELS[@]}"; do
+  case "$channel" in
+    *$'\n'*|*$'\r'*|'') printf 'fm-deadman-install: each channel must be one non-empty line.\n' >&2; exit 2 ;;
+    off|auto|default|osascript|herdr|command:*) ;;
+    *) printf 'fm-deadman-install: unrecognized channel directive.\n' >&2; exit 2 ;;
+  esac
+done
+[ -r "$SOURCE_PROBE" ] && [ -r "$SOURCE_NOTIFY" ] && [ -r "$TEMPLATE" ] || {
+  printf 'fm-deadman-install: source files are incomplete.\n' >&2
+  exit 2
+}
+
+mkdir -p "$INSTALL_DIR" "$(dirname "$PLIST")"
+atomic_install "$SOURCE_PROBE" "$INSTALL_DIR/fm-deadman.sh" 755
+atomic_install "$SOURCE_NOTIFY" "$INSTALL_DIR/fm-notify-lib.sh" 644
+write_config
+write_channels
+[ -f "$INSTALL_DIR/installed-at" ] || (umask 077 && date +%s > "$INSTALL_DIR/installed-at")
+write_plist
+if command -v plutil >/dev/null 2>&1; then
+  plutil -lint "$PLIST" >/dev/null
+fi
+
+printf 'Sending required deadman canary before launchd bootstrap...\n'
+if ! "$INSTALL_DIR/fm-deadman.sh" --canary; then
+  printf 'fm-deadman-install: canary delivery failed; LaunchAgent was not bootstrapped.\n' >&2
+  exit 1
+fi
+printf 'Canary delivery succeeded.\n'
+
+if [ "$BOOTSTRAP" -eq 1 ]; then
+  launchctl bootout "gui/$UID/com.firstmate.deadman" >/dev/null 2>&1 || true
+  launchctl bootstrap "gui/$UID" "$PLIST"
+  printf 'Bootstrapped com.firstmate.deadman.\n'
+else
+  printf 'Installed but not bootstrapped. Re-run with --bootstrap after reviewing the canary.\n'
+fi

--- a/bin/fm-deadman.sh
+++ b/bin/fm-deadman.sh
@@ -232,6 +232,10 @@ main() {
   NOW=${FM_DEADMAN_NOW:-$(date +%s)}
   valid_uint "$NOW" || self_fault "current time must be an unsigned integer"
   if ! acquire_lock; then
+    if [ "$mode" = --canary ]; then
+      journal "canary failed: another invocation holds the lock"
+      exit 1
+    fi
     journal "probe skipped: another invocation holds the lock"
     exit 0
   fi

--- a/bin/fm-deadman.sh
+++ b/bin/fm-deadman.sh
@@ -214,6 +214,23 @@ acquire_lock() {
   mkdir "$LOCK_DIR" 2>/dev/null
 }
 
+release_probe() {
+  if [ "${DEADMAN_CLEANUP_DONE:-}" = 1 ]; then
+    return 0
+  fi
+  DEADMAN_CLEANUP_DONE=1
+  trap - EXIT INT TERM
+  if declare -F fm_notify_stop_active >/dev/null 2>&1; then
+    fm_notify_stop_active
+  fi
+  rmdir "$LOCK_DIR" 2>/dev/null || true
+}
+
+handle_probe_signal() {
+  release_probe
+  exit 1
+}
+
 main() {
   local mode=${1:-} first_sample sample_time sample_class delta last_success summary
   case "$mode" in
@@ -239,7 +256,9 @@ main() {
     journal "probe skipped: another invocation holds the lock"
     exit 0
   fi
-  trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT INT TERM
+  DEADMAN_CLEANUP_DONE=
+  trap release_probe EXIT
+  trap handle_probe_signal INT TERM
 
   if [ "$mode" = --canary ]; then
     summary="FIRSTMATE DEADMAN CANARY - notification path is working for $FM_HOME"

--- a/bin/fm-deadman.sh
+++ b/bin/fm-deadman.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# Probe one Firstmate watcher's liveness from an installed launchd copy.
+#
+# The monitored FM_HOME is read-only probe input. All deadman configuration and
+# state live beside this installed script. Normal healthy and unhealthy probe
+# paths return 0, including failed notification attempts. Invalid configuration
+# or corrupt deadman-owned state returns 2 so launchd logs a self-fault.
+#
+# Usage: fm-deadman.sh [--canary|--help]
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_DIR=${FM_DEADMAN_INSTALL_DIR:-$SCRIPT_DIR}
+CONFIG_FILE="$INSTALL_DIR/deadman.env"
+CHANNEL_FILE="$INSTALL_DIR/deadman.conf"
+JOURNAL="$INSTALL_DIR/deadman.journal"
+LOCK_DIR="$INSTALL_DIR/.probe.lock"
+
+STALE_AFTER_SECS=600
+SAMPLE_GAP_SECS=60
+SAMPLE_MAX_GAP_SECS=120
+FIRST_ARM_GRACE_SECS=660
+WAKE_GRACE_SECS=300
+SLEEP_GAP_DETECT_SECS=180
+COOLDOWN_SECS=1800
+FM_HOME=
+
+usage() {
+  printf 'usage: fm-deadman.sh [--canary|--help]\n' >&2
+}
+
+rotate_log() {
+  local path=$1 size tmp
+  [ -f "$path" ] || return 0
+  size=$(wc -c < "$path" 2>/dev/null) || return 0
+  [ "$size" -le 131072 ] && return 0
+  tmp="$path.tmp.$$"
+  tail -n 500 "$path" > "$tmp" 2>/dev/null && mv -f "$tmp" "$path"
+  rm -f "$tmp" 2>/dev/null || true
+}
+
+journal() {
+  local line=$1 size tmp
+  printf '%s\t%s\n' "${NOW:-$(date +%s)}" "$line" >> "$JOURNAL" 2>/dev/null || return 0
+  size=$(wc -c < "$JOURNAL" 2>/dev/null) || return 0
+  [ "$size" -le 131072 ] && return 0
+  tmp="$JOURNAL.tmp.$$"
+  tail -n 500 "$JOURNAL" > "$tmp" 2>/dev/null && mv -f "$tmp" "$JOURNAL"
+  rm -f "$tmp" 2>/dev/null || true
+}
+
+self_fault() {
+  journal "self-fault: $1"
+  printf 'fm-deadman: %s\n' "$1" >&2
+  exit 2
+}
+
+atomic_write() {
+  local path=$1 value=$2 tmp="$1.tmp.$$"
+  (umask 077 && printf '%s\n' "$value" > "$tmp") || return 1
+  mv -f "$tmp" "$path"
+}
+
+valid_uint() {
+  case "$1" in ''|*[!0-9]*) return 1 ;; *) return 0 ;; esac
+}
+
+read_config() {
+  local line key value
+  [ -f "$CONFIG_FILE" ] && [ -r "$CONFIG_FILE" ] || self_fault "missing or unreadable config: $CONFIG_FILE"
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in ''|'#'*) continue ;; esac
+    case "$line" in *=*) ;; *) self_fault "invalid config line" ;; esac
+    key=${line%%=*}
+    value=${line#*=}
+    case "$key" in
+      FM_HOME) FM_HOME=$value ;;
+      STALE_AFTER_SECS) STALE_AFTER_SECS=$value ;;
+      SAMPLE_GAP_SECS) SAMPLE_GAP_SECS=$value ;;
+      SAMPLE_MAX_GAP_SECS) SAMPLE_MAX_GAP_SECS=$value ;;
+      FIRST_ARM_GRACE_SECS) FIRST_ARM_GRACE_SECS=$value ;;
+      WAKE_GRACE_SECS) WAKE_GRACE_SECS=$value ;;
+      SLEEP_GAP_DETECT_SECS) SLEEP_GAP_DETECT_SECS=$value ;;
+      COOLDOWN_SECS) COOLDOWN_SECS=$value ;;
+      *) self_fault "unknown config key: $key" ;;
+    esac
+  done < "$CONFIG_FILE"
+  case "$FM_HOME" in /*) ;; *) self_fault "FM_HOME must be an absolute path" ;; esac
+  valid_uint "$STALE_AFTER_SECS" || self_fault "STALE_AFTER_SECS must be an unsigned integer"
+  valid_uint "$SAMPLE_GAP_SECS" || self_fault "SAMPLE_GAP_SECS must be an unsigned integer"
+  valid_uint "$SAMPLE_MAX_GAP_SECS" || self_fault "SAMPLE_MAX_GAP_SECS must be an unsigned integer"
+  valid_uint "$FIRST_ARM_GRACE_SECS" || self_fault "FIRST_ARM_GRACE_SECS must be an unsigned integer"
+  valid_uint "$WAKE_GRACE_SECS" || self_fault "WAKE_GRACE_SECS must be an unsigned integer"
+  valid_uint "$SLEEP_GAP_DETECT_SECS" || self_fault "SLEEP_GAP_DETECT_SECS must be an unsigned integer"
+  valid_uint "$COOLDOWN_SECS" || self_fault "COOLDOWN_SECS must be an unsigned integer"
+  [ "$STALE_AFTER_SECS" -gt 0 ] || self_fault "STALE_AFTER_SECS must be positive"
+  [ "$SAMPLE_GAP_SECS" -ge 60 ] && [ "$SAMPLE_GAP_SECS" -le 120 ] || self_fault "SAMPLE_GAP_SECS must be 60-120"
+  [ "$SAMPLE_MAX_GAP_SECS" -ge "$SAMPLE_GAP_SECS" ] && [ "$SAMPLE_MAX_GAP_SECS" -le 120 ] || self_fault "SAMPLE_MAX_GAP_SECS must be SAMPLE_GAP_SECS-120"
+  [ "$SLEEP_GAP_DETECT_SECS" -gt 0 ] || self_fault "SLEEP_GAP_DETECT_SECS must be positive"
+}
+
+read_timestamp() {
+  local path=$1 value
+  [ -e "$path" ] || return 1
+  IFS= read -r value < "$path" || self_fault "cannot read deadman state: $path"
+  valid_uint "$value" || self_fault "invalid deadman timestamp: $path"
+  printf '%s\n' "$value"
+}
+
+beacon_mtime() {
+  local path=$1 value
+  value=$(stat -f %m "$path" 2>/dev/null) || value=$(stat -c %Y "$path" 2>/dev/null) || return 1
+  valid_uint "$value" || return 1
+  printf '%s\n' "$value"
+}
+
+probe_status() {
+  local beat="$FM_HOME/state/.last-watcher-beat" mtime age
+  if [ ! -d "$FM_HOME" ] || [ ! -r "$FM_HOME" ] || [ ! -x "$FM_HOME" ]; then
+    PROBE_CLASS=home-unavailable
+    PROBE_DETAIL="FM_HOME missing or unreadable: $FM_HOME"
+    return 1
+  fi
+  if [ ! -f "$beat" ] || [ ! -r "$beat" ]; then
+    PROBE_CLASS=beacon-unavailable
+    PROBE_DETAIL="watcher beacon missing or unreadable: $beat"
+    return 1
+  fi
+  if ! mtime=$(beacon_mtime "$beat"); then
+    PROBE_CLASS=beacon-unreadable
+    PROBE_DETAIL="watcher beacon mtime unreadable: $beat"
+    return 1
+  fi
+  age=$((NOW - mtime))
+  if [ "$age" -lt 0 ]; then
+    PROBE_CLASS=beacon-future
+    PROBE_DETAIL="watcher beacon has future mtime by $((-age))s: $beat"
+    return 1
+  fi
+  if [ "$age" -gt "$STALE_AFTER_SECS" ]; then
+    PROBE_CLASS=beacon-stale
+    PROBE_DETAIL="watcher beacon stale for ${age}s: $beat"
+    return 1
+  fi
+  PROBE_CLASS=healthy
+  PROBE_DETAIL="watcher beacon age ${age}s"
+  return 0
+}
+
+arm_if_ready() {
+  local installed_at
+  [ -e "$INSTALL_DIR/armed" ] && return 0
+  if probe_status; then
+    atomic_write "$INSTALL_DIR/armed" "$NOW" || self_fault "cannot arm deadman"
+    rm -f "$INSTALL_DIR/first-stale"
+    journal "armed after healthy beacon"
+    return 0
+  fi
+  if ! installed_at=$(read_timestamp "$INSTALL_DIR/installed-at"); then
+    atomic_write "$INSTALL_DIR/installed-at" "$NOW" || self_fault "cannot create first-arm timestamp"
+    journal "first-arm grace started"
+    return 1
+  fi
+  if [ "$NOW" -lt "$installed_at" ] || [ $((NOW - installed_at)) -lt "$FIRST_ARM_GRACE_SECS" ]; then
+    journal "first-arm grace: $PROBE_CLASS"
+    return 1
+  fi
+  atomic_write "$INSTALL_DIR/armed" "$NOW" || self_fault "cannot arm deadman after grace"
+  journal "armed after first-arm grace"
+  return 0
+}
+
+apply_sleep_wake_grace() {
+  local last_run grace_until delta
+  if last_run=$(read_timestamp "$INSTALL_DIR/last-run-at"); then
+    delta=$((NOW - last_run))
+    if [ "$delta" -lt 0 ] || [ "$delta" -gt "$SLEEP_GAP_DETECT_SECS" ]; then
+      grace_until=$((NOW + WAKE_GRACE_SECS))
+      atomic_write "$INSTALL_DIR/wake-grace-until" "$grace_until" || self_fault "cannot record wake grace"
+      rm -f "$INSTALL_DIR/first-stale"
+      journal "sleep/wake grace started after run gap ${delta}s"
+    fi
+  fi
+  atomic_write "$INSTALL_DIR/last-run-at" "$NOW" || self_fault "cannot record probe time"
+  if grace_until=$(read_timestamp "$INSTALL_DIR/wake-grace-until"); then
+    if [ "$NOW" -lt "$grace_until" ]; then
+      journal "sleep/wake grace active"
+      return 1
+    fi
+    rm -f "$INSTALL_DIR/wake-grace-until"
+  fi
+  return 0
+}
+
+notify() {
+  local summary=$1
+  local FM_NOTIFY_CONFIG_FILE=$CHANNEL_FILE
+  local FM_NOTIFY_CHANNEL=${FM_DEADMAN_CHANNEL:-}
+  local FM_NOTIFY_EXEC=${FM_DEADMAN_NOTIFY_EXEC:-}
+  local FM_NOTIFY_TIMEOUT_SECS=${FM_DEADMAN_NOTIFY_TIMEOUT_SECS:-10}
+  local FM_NOTIFY_TITLE="firstmate deadman"
+  fm_notify "$summary" "journal $JOURNAL"
+}
+
+acquire_lock() {
+  local mtime age
+  if mkdir "$LOCK_DIR" 2>/dev/null; then
+    return 0
+  fi
+  mtime=$(beacon_mtime "$LOCK_DIR") || return 1
+  age=$((NOW - mtime))
+  [ "$age" -gt 300 ] || return 1
+  rmdir "$LOCK_DIR" 2>/dev/null || return 1
+  mkdir "$LOCK_DIR" 2>/dev/null
+}
+
+main() {
+  local mode=${1:-} first_sample sample_time sample_class delta last_success summary
+  case "$mode" in
+    ''|--canary) ;;
+    --help|-h) usage; exit 0 ;;
+    *) usage; exit 2 ;;
+  esac
+  [ "$#" -le 1 ] || { usage; exit 2; }
+  [ -d "$INSTALL_DIR" ] && [ -w "$INSTALL_DIR" ] || self_fault "install directory missing or unwritable: $INSTALL_DIR"
+  rotate_log "$INSTALL_DIR/deadman.stdout.log"
+  rotate_log "$INSTALL_DIR/deadman.stderr.log"
+  read_config
+  [ -r "$SCRIPT_DIR/fm-notify-lib.sh" ] || self_fault "notification library missing"
+  # shellcheck source=bin/fm-notify-lib.sh
+  . "$SCRIPT_DIR/fm-notify-lib.sh"
+  NOW=${FM_DEADMAN_NOW:-$(date +%s)}
+  valid_uint "$NOW" || self_fault "current time must be an unsigned integer"
+  if ! acquire_lock; then
+    journal "probe skipped: another invocation holds the lock"
+    exit 0
+  fi
+  trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT INT TERM
+
+  if [ "$mode" = --canary ]; then
+    summary="FIRSTMATE DEADMAN CANARY - notification path is working for $FM_HOME"
+    if notify "$summary"; then
+      journal "canary notification succeeded"
+      exit 0
+    fi
+    journal "canary notification failed"
+    exit 1
+  fi
+
+  apply_sleep_wake_grace || exit 0
+  arm_if_ready || exit 0
+  if probe_status; then
+    rm -f "$INSTALL_DIR/first-stale"
+    exit 0
+  fi
+
+  first_sample="$INSTALL_DIR/first-stale"
+  if [ ! -e "$first_sample" ]; then
+    atomic_write "$first_sample" "$NOW|$PROBE_CLASS" || self_fault "cannot record first stale sample"
+    journal "first unhealthy sample: $PROBE_CLASS"
+    exit 0
+  fi
+  IFS='|' read -r sample_time sample_class < "$first_sample" || self_fault "cannot read first stale sample"
+  valid_uint "$sample_time" || self_fault "invalid first stale sample"
+  delta=$((NOW - sample_time))
+  if [ "$sample_class" != "$PROBE_CLASS" ] || [ "$delta" -lt "$SAMPLE_GAP_SECS" ] || [ "$delta" -gt "$SAMPLE_MAX_GAP_SECS" ]; then
+    if [ "$delta" -ge "$SAMPLE_GAP_SECS" ] && [ "$delta" -le "$SAMPLE_MAX_GAP_SECS" ] && [ "$sample_class" != "$PROBE_CLASS" ]; then
+      journal "unhealthy class changed: $sample_class -> $PROBE_CLASS"
+    fi
+    [ "$delta" -lt "$SAMPLE_GAP_SECS" ] || atomic_write "$first_sample" "$NOW|$PROBE_CLASS" || self_fault "cannot refresh first stale sample"
+    exit 0
+  fi
+
+  if last_success=$(read_timestamp "$INSTALL_DIR/last-success-at"); then
+    [ "$NOW" -ge "$last_success" ] || self_fault "successful-page timestamp is in the future"
+    if [ $((NOW - last_success)) -lt "$COOLDOWN_SECS" ]; then
+      journal "unhealthy but successful-page cooldown active: $PROBE_CLASS"
+      exit 0
+    fi
+  fi
+
+  summary="FIRSTMATE DEADMAN: $PROBE_DETAIL; scheduling path may be stopped"
+  if notify "$summary"; then
+    atomic_write "$INSTALL_DIR/last-success-at" "$NOW" || self_fault "cannot record successful page"
+    journal "page succeeded: $PROBE_CLASS"
+  else
+    journal "page failed: $PROBE_CLASS"
+  fi
+  atomic_write "$first_sample" "$NOW|$PROBE_CLASS" || self_fault "cannot refresh stale sample after page attempt"
+  exit 0
+}
+
+main "$@"

--- a/bin/fm-deadman.sh
+++ b/bin/fm-deadman.sh
@@ -214,6 +214,7 @@ acquire_lock() {
   mkdir "$LOCK_DIR" 2>/dev/null
 }
 
+# shellcheck disable=SC2329 # invoked by EXIT trap after probe lock acquisition
 release_probe() {
   if [ "${DEADMAN_CLEANUP_DONE:-}" = 1 ]; then
     return 0
@@ -226,6 +227,7 @@ release_probe() {
   rmdir "$LOCK_DIR" 2>/dev/null || true
 }
 
+# shellcheck disable=SC2329 # invoked by INT/TERM traps after probe lock acquisition
 handle_probe_signal() {
   release_probe
   exit 1

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
-# fm-decision-hold.sh - deterministic mechanics for durable captain decisions.
+# fm-decision-hold.sh - deterministic mechanics for durable captain decisions and
+# product-idea completion attestation.
 #
 # The semantic policy is owned once by
 # .agents/skills/decision-hold-lifecycle/SKILL.md. This script never reads report,
-# visual-review, chat, or terminal prose to guess whether a decision exists.
-# The invoking agent inventories unresolved decisions, assigns stable keys, and
-# routes dependent work. This script supplies deterministic identities, creates
-# and verifies structured tasks-axi captain holds, records completion attestation
-# in the originating task's metadata, and closes a hold only after a durable
-# decision record has been linked to existing dependent work.
+# visual-review, chat, or terminal prose to guess whether a decision or idea exists.
+# The invoking agent inventories unresolved decisions and unscheduled product ideas,
+# assigns stable decision keys, appends idea ledger rows, and routes dependent work.
+# This script supplies deterministic identities, creates and verifies structured
+# tasks-axi captain holds, validates the active home's product-idea ledger, records
+# completion attestation in the originating task's metadata, and closes a hold only
+# after a durable decision record has been linked to existing dependent work.
 #
 # A hold identity is <origin-id>-decision-<decision-key>. Origin ids and decision
 # keys must already be privacy-safe slugs. Repeating `hold` with the same identity
@@ -20,16 +22,32 @@
 #   fm-decision-hold.sh id <origin-id> <decision-key>
 #   fm-decision-hold.sh hold <origin-id> <decision-key> \
 #     --title <title> --reason <reason> [--repo <repo>]
-#   fm-decision-hold.sh complete <origin-id> (--none | <decision-key>...)
+#   fm-decision-hold.sh complete <origin-id> (--none | <decision-key>...) \
+#     (--ideas <PI-id>... | --no-ideas)
 #   fm-decision-hold.sh verify <origin-id>
 #   fm-decision-hold.sh resolve <origin-id> <decision-key> \
 #     --decision-file <path> --routed-to <task-id> [--routed-to <task-id>...]
 #
 # `complete` is the shared investigation and visual-review completion gate.
 # `--none` is an explicit semantic attestation that the just-reviewed surface has
-# no unresolved captain decision. Later review passes may add keys; a live task's
-# metadata inventory is unioned idempotently. A post-teardown visual review can
-# complete against the surviving report and holds without recreating task state.
+# no unresolved captain decision and cannot be combined with decision keys.
+# Exactly one idea attestation is also required: `--ideas` takes one or more
+# home-local PI-NNN ids and cannot be combined with `--no-ideas`; `--no-ideas`
+# means this pass found no new ideas and does not erase an earlier idea inventory.
+# Decision keys and idea ids from later review passes are unioned idempotently.
+# `complete` validates the full active-home ledger grammar and every unioned idea
+# id against an origin-bound Source. `verify` grandfathers pre-upgrade metadata
+# that carries only the earlier completed decision attestation.
+# A post-teardown visual review can complete against the surviving report and
+# holds without recreating task state.
+#
+# The active home's data/product-ideas.md is created lazily by `--no-ideas` from
+# this template. Its columns are ID | Idea | Status | Source. Status is exactly
+# one of: unscheduled; parked (captain <date>); scheduled -> <task-id>;
+# shipped (was <task-id>); dropped (<reason>). Source is the home-relative report
+# path plus section heading as data/<origin-id>/report.md#<section-heading>, never
+# a line number. Ids are PI-NNN and home-local; cross-home displays qualify them
+# with the home id, for example sm-tv:PI-003.
 # `verify` is read-only and is called by scout teardown so teardown cannot erase a
 # source before this gate has succeeded.
 #
@@ -54,6 +72,9 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 # shellcheck source=bin/fm-wake-lib.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-product-idea-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-product-idea-lib.sh"
 
 DECISION_META_LOCK=
 DECISION_META_LOCK_HELD=0
@@ -151,6 +172,51 @@ sorted_key_union() {  # <comma-list> <newline-or-space-separated-new-keys>
 
 meta_value() {  # <meta> <key>
   grep "^$2=" "$1" 2>/dev/null | tail -1 | cut -d= -f2- || true
+}
+
+validate_idea_id() {  # <value>
+  case "$1" in
+    PI-[0-9][0-9][0-9]) : ;;
+    *) fail "product idea id must use the home-local PI-NNN form: $1" ;;
+  esac
+}
+
+create_idea_ledger() {
+  local ledger="$DATA/product-ideas.md"
+  if [ -e "$ledger" ]; then
+    [ -f "$ledger" ] || fail "product idea ledger path is not a regular file: $ledger"
+    return 0
+  fi
+  ( umask 077
+    mkdir -p "$DATA" || exit 1
+    cat > "$ledger" <<'EOF'
+# Product ideas
+
+<!-- Columns: ID | Idea | Status | Source. -->
+<!-- Status: unscheduled | parked (captain <date>) | scheduled -> <task-id> | shipped (was <task-id>) | dropped (<reason>). -->
+<!-- Source: data/<origin-id>/report.md#<section-heading>; use a report path plus section heading, never a line number. -->
+<!-- IDs are home-local PI-NNN values; qualify cross-home displays as <home-id>:PI-NNN, for example sm-tv:PI-003. -->
+
+| ID | Idea | Status | Source |
+| --- | --- | --- | --- |
+EOF
+  ) || fail "cannot create product idea ledger: $ledger"
+}
+
+verify_idea_row() {  # <origin-id> <idea-id>
+  local origin=$1 idea_id=$2 ledger="$DATA/product-ideas.md" rc
+  validate_idea_id "$idea_id"
+  [ -f "$ledger" ] \
+    || fail "product idea ledger is absent: $ledger; append $idea_id with a source citing data/$origin/report.md#<section-heading>"
+  if fm_product_idea_verify_row "$ledger" "$origin" "$idea_id"; then
+    return 0
+  else
+    rc=$?
+  fi
+  if [ "$rc" -eq 4 ]; then
+    fail "product idea $idea_id is missing from $ledger"
+  fi
+  fail "product idea $idea_id must have one well-formed row whose Source cites data/$origin/report.md#<section-heading> without a line number"
 }
 
 origin_open_decisions() {  # <origin-id>
@@ -289,11 +355,53 @@ command_hold() {
 
 command_complete() {
   local origin=${1:-} meta previous='' supplied='' keys='' key status_file open raw_open key_seen=0 has_meta=0
+  local decision_none=0 decision_seen=0 idea_attestation='' idea_supplied='' previous_ideas='' idea_keys='' idea_id
   [ "$#" -ge 2 ] || { usage >&2; exit 2; }
   validate_slug origin-id "$origin"
   shift
   meta="$STATE/$origin.meta"
   [ -f "$meta" ] && has_meta=1
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --none)
+        [ "$decision_none" -eq 0 ] || fail "--none may be supplied only once"
+        [ -z "$supplied" ] || fail "--none cannot be combined with decision keys"
+        decision_none=1
+        decision_seen=1
+        shift
+        ;;
+      --no-ideas)
+        [ -z "$idea_attestation" ] || fail "--no-ideas cannot be combined with --ideas or repeated"
+        idea_attestation=none
+        shift
+        [ "$#" -eq 0 ] || fail "--no-ideas must follow the decision inventory and cannot take values"
+        ;;
+      --ideas)
+        [ -z "$idea_attestation" ] || fail "--ideas cannot be combined with --no-ideas or repeated"
+        idea_attestation=ideas
+        shift
+        [ "$#" -gt 0 ] || fail "--ideas requires at least one PI-NNN id"
+        while [ "$#" -gt 0 ]; do
+          case "$1" in
+            --ideas|--no-ideas) fail "--ideas cannot be combined with --no-ideas or repeated" ;;
+            --none) fail "--ideas must follow the decision inventory" ;;
+          esac
+          validate_idea_id "$1"
+          idea_supplied="${idea_supplied}${idea_supplied:+ }$1"
+          shift
+        done
+        ;;
+      *)
+        [ "$decision_none" -eq 0 ] || fail "--none cannot be combined with decision keys"
+        validate_slug decision-key "$1"
+        supplied="${supplied}${supplied:+ }$1"
+        decision_seen=1
+        shift
+        ;;
+    esac
+  done
+  [ "$decision_seen" -eq 1 ] || fail "decision attestation is required: use --none or name decision keys"
+  [ -n "$idea_attestation" ] || fail "idea attestation is required: use --ideas <PI-id>... or --no-ideas"
   if [ "$has_meta" = 1 ]; then
     DECISION_META_LOCK=$(fm_meta_lock_path "$meta") || fail "could not resolve task metadata lock"
     fm_lock_acquire_wait "$DECISION_META_LOCK"
@@ -302,16 +410,6 @@ command_complete() {
   fi
   require_tasks_axi
   origin_exists_here "$origin" || fail "origin $origin is not owned by the active home $FM_HOME"
-  if [ "$#" -eq 1 ] && [ "$1" = --none ]; then
-    supplied=''
-  else
-    while [ "$#" -gt 0 ]; do
-      [ "$1" != --none ] || fail "--none cannot be combined with decision keys"
-      validate_slug decision-key "$1"
-      supplied="${supplied}${supplied:+ }$1"
-      shift
-    done
-  fi
   if [ "$has_meta" = 1 ]; then
     previous=$(meta_value "$meta" decision_keys)
   fi
@@ -322,6 +420,22 @@ command_complete() {
       verify_hold_durable "$(hold_id "$origin" "$key")"
     done <<EOF
 $(printf '%s\n' "$keys" | tr ',' '\n')
+EOF
+  fi
+
+  if [ "$has_meta" = 1 ]; then
+    previous_ideas=$(meta_value "$meta" idea_ids)
+  fi
+  idea_keys=$(sorted_key_union "$previous_ideas" "$idea_supplied")
+  if [ "$idea_attestation" = none ]; then
+    create_idea_ledger
+  fi
+  if [ -n "$idea_keys" ]; then
+    while IFS= read -r idea_id; do
+      [ -n "$idea_id" ] || continue
+      verify_idea_row "$origin" "$idea_id"
+    done <<EOF
+$(printf '%s\n' "$idea_keys" | tr ',' '\n')
 EOF
   fi
 
@@ -340,6 +454,9 @@ EOF
     if [ "$(meta_value "$meta" decisions_reviewed)" != 1 ] || [ "$previous" != "$keys" ]; then
       printf 'decisions_reviewed=1\ndecision_keys=%s\n' "$keys" >> "$meta"
     fi
+    if [ "$(meta_value "$meta" ideas_reviewed)" != 1 ] || [ "$previous_ideas" != "$idea_keys" ]; then
+      printf 'ideas_reviewed=1\nidea_ids=%s\n' "$idea_keys" >> "$meta"
+    fi
     fm_lock_release "$DECISION_META_LOCK"
     DECISION_META_LOCK_HELD=0
 
@@ -355,11 +472,12 @@ $raw_open
 EOF
   fi
   : "$key_seen"
-  printf 'complete: %s decision inventory reviewed%s\n' "$origin" "${keys:+ ($keys)}"
+  printf 'complete: %s decision and product-idea inventories reviewed%s%s\n' \
+    "$origin" "${keys:+; decisions=$keys}" "${idea_keys:+; ideas=$idea_keys}"
 }
 
 command_verify() {
-  local origin=${1:-} meta reviewed keys key open
+  local origin=${1:-} meta reviewed keys key open ideas_reviewed idea_keys idea_id
   [ "$#" -eq 1 ] || { usage >&2; exit 2; }
   validate_slug origin-id "$origin"
   meta="$STATE/$origin.meta"
@@ -385,6 +503,19 @@ EOF
   done <<EOF
 $open
 EOF
+  ideas_reviewed=$(meta_value "$meta" ideas_reviewed)
+  if [ -n "$ideas_reviewed" ]; then
+    [ "$ideas_reviewed" = 1 ] || fail "origin $origin has an invalid product-idea inventory attestation"
+    idea_keys=$(meta_value "$meta" idea_ids)
+    if [ -n "$idea_keys" ]; then
+      while IFS= read -r idea_id; do
+        [ -n "$idea_id" ] || continue
+        verify_idea_row "$origin" "$idea_id"
+      done <<EOF
+$(printf '%s\n' "$idea_keys" | tr ',' '\n')
+EOF
+    fi
+  fi
   printf 'verified: %s unresolved-decision inventory\n' "$origin"
 }
 

--- a/bin/fm-ff-lib.sh
+++ b/bin/fm-ff-lib.sh
@@ -126,7 +126,13 @@ validate_secondmate_home() {
   VALIDATED_HOME=""
   VALIDATION_ERROR=""
   abs_home=$(resolved_existing_dir "$home") || {
-    VALIDATION_ERROR="not a directory"
+    # A registered home that is simply gone is a different operator problem from
+    # a path that exists but is unusable, so callers can say which one happened.
+    if [ -e "$home" ]; then
+      VALIDATION_ERROR="not a directory"
+    else
+      VALIDATION_ERROR="registered home directory does not exist"
+    fi
     return 1
   }
   abs_active_home=$(resolved_existing_dir "$FM_HOME") || {

--- a/bin/fm-notify-lib.sh
+++ b/bin/fm-notify-lib.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# Shared best-effort active-notification channels for Firstmate daemons.
+#
+# Callers set these variables before calling fm_notify:
+#   FM_NOTIFY_CONFIG_FILE       channel file; one directive per non-comment line
+#   FM_NOTIFY_CHANNEL           optional single-directive override
+#   FM_NOTIFY_EXEC              test seam: <cmd> <channel> <summary>; discard = no delivery
+#   FM_NOTIFY_TIMEOUT_SECS      per-channel timeout (default 10)
+#   FM_NOTIFY_TITLE             notification title
+#
+# Directives are off, auto/default, osascript, herdr, and command:<cmd>.
+# fm_notify returns success only when at least one channel reports successful
+# delivery. A disabled, unavailable, unrecognized, or failed set returns 1.
+
+FM_NOTIFY_TIMEOUT_DEFAULT=10
+FM_NOTIFY_ACTIVE_PID=
+
+fm_notify_log() {
+  local message="${FM_NOTIFY_LOG_PREFIX:-}$*"
+  if declare -F log >/dev/null 2>&1; then
+    log "$message"
+  else
+    printf '%s\n' "fm-notify: $message" >&2
+  fi
+}
+
+fm_notify_configured_channels() {
+  local cfg=${FM_NOTIFY_CONFIG_FILE:-} line found=
+  if [ -n "${FM_NOTIFY_CHANNEL:-}" ]; then
+    printf '%s\n' "$FM_NOTIFY_CHANNEL"
+    return 0
+  fi
+  if [ -n "$cfg" ] && [ -f "$cfg" ]; then
+    while IFS= read -r line || [ -n "$line" ]; do
+      line="${line#"${line%%[![:space:]]*}"}"
+      line="${line%"${line##*[![:space:]]}"}"
+      [ -n "$line" ] || continue
+      case "$line" in '#'*) continue ;; esac
+      printf '%s\n' "$line"
+      found=1
+    done < "$cfg"
+  fi
+  [ -n "$found" ] || printf 'auto\n'
+}
+
+fm_notify_platform_default() {
+  case "$(uname)" in
+    Darwin) command -v osascript >/dev/null 2>&1 && printf 'osascript\n' ;;
+    *) : ;;
+  esac
+}
+
+fm_notify_stop_active() {
+  local pid=${FM_NOTIFY_ACTIVE_PID:-}
+  [ -n "$pid" ] || return 0
+  FM_NOTIFY_ACTIVE_PID=
+  kill -TERM "-$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null || true
+  sleep 0.2
+  kill -KILL "-$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+}
+
+fm_notify_run_bounded() {
+  local channel=$1 timeout monitor_was_on=0 pid start elapsed rc
+  shift
+  timeout=${FM_NOTIFY_TIMEOUT_SECS:-$FM_NOTIFY_TIMEOUT_DEFAULT}
+  case "$timeout" in
+    ''|*[!0-9]*) timeout=$FM_NOTIFY_TIMEOUT_DEFAULT ;;
+    *) [ "$timeout" -gt 0 ] 2>/dev/null || timeout=$FM_NOTIFY_TIMEOUT_DEFAULT ;;
+  esac
+  case $- in *m*) monitor_was_on=1 ;; esac
+  set -m 2>/dev/null || true
+  case $- in
+    *m*) ;;
+    *) fm_notify_log "$channel notifier skipped because its watchdog could not start"; return 125 ;;
+  esac
+  "$@" &
+  pid=$!
+  FM_NOTIFY_ACTIVE_PID=$pid
+  start=$SECONDS
+  while kill -0 "-$pid" 2>/dev/null; do
+    elapsed=$((SECONDS - start))
+    if [ "$elapsed" -ge "$timeout" ]; then
+      fm_notify_stop_active
+      [ "$monitor_was_on" -eq 1 ] || set +m 2>/dev/null || true
+      fm_notify_log "$channel notifier timed out after ${elapsed}s (limit ${timeout}s)"
+      return 124
+    fi
+    sleep 0.1
+  done
+  if wait "$pid"; then rc=0; else rc=$?; fi
+  FM_NOTIFY_ACTIVE_PID=
+  [ "$monitor_was_on" -eq 1 ] || set +m 2>/dev/null || true
+  return "$rc"
+}
+
+fm_notify_override() {
+  local channel=$1 summary=$2 rc override=${FM_NOTIFY_EXEC:-}
+  case "$override" in
+    '') return 2 ;;
+    discard) return 1 ;;
+    *)
+      fm_notify_run_bounded "$channel" "$override" "$channel" "$summary" >/dev/null 2>&1
+      rc=$?
+      [ "$rc" -eq 0 ] && return 0
+      fm_notify_log "notifier override exited $rc for channel '$channel'"
+      return 1
+      ;;
+  esac
+}
+
+fm_notify_via_osascript() {
+  local summary=$1 rc
+  fm_notify_override osascript "$summary"
+  rc=$?
+  case "$rc" in
+    0) return 0 ;;
+    1) return 1 ;;
+  esac
+  command -v osascript >/dev/null 2>&1 || {
+    fm_notify_log "osascript not found; cannot post a macOS notification"
+    return 1
+  }
+  fm_notify_run_bounded osascript osascript -e 'on run argv' \
+    -e 'display notification (item 1 of argv) with title (item 2 of argv) sound name "Basso"' \
+    -e 'end run' "$summary" "${FM_NOTIFY_TITLE:-firstmate alert}" >/dev/null 2>&1 && return 0
+  fm_notify_log "osascript notification failed"
+  return 1
+}
+
+fm_notify_via_herdr() {
+  local summary=$1 rc
+  fm_notify_override herdr "$summary"
+  rc=$?
+  case "$rc" in
+    0) return 0 ;;
+    1) return 1 ;;
+  esac
+  command -v herdr >/dev/null 2>&1 || {
+    fm_notify_log "herdr not found; cannot post a herdr notification"
+    return 1
+  }
+  fm_notify_run_bounded herdr herdr notification show "${FM_NOTIFY_TITLE:-firstmate alert}" \
+    --body "$summary" --sound request >/dev/null 2>&1 && return 0
+  fm_notify_log "herdr notification failed"
+  return 1
+}
+
+fm_notify_via_command() {
+  local cmd=$1 summary=$2 rc
+  [ -n "$cmd" ] || { fm_notify_log "empty command: channel; nothing to run"; return 1; }
+  fm_notify_override command "$summary"
+  rc=$?
+  case "$rc" in
+    0) return 0 ;;
+    1) return 1 ;;
+  esac
+  fm_notify_run_bounded command sh -c "$cmd" fm-notify "$summary" \
+    <<< "$summary" >/dev/null 2>&1
+  rc=$?
+  [ "$rc" -eq 0 ] && return 0
+  fm_notify_log "command channel exited $rc (command redacted)"
+  return 1
+}
+
+fm_notify_emit() {
+  local channel=$1 summary=$2 cmd=${3:-}
+  case "$channel" in
+    osascript) fm_notify_via_osascript "$summary" ;;
+    herdr) fm_notify_via_herdr "$summary" ;;
+    command) fm_notify_via_command "$cmd" "$summary" ;;
+    *) return 1 ;;
+  esac
+}
+
+fm_notify() {
+  local summary=$1 marker=${2:-} ch successes=0
+  local -a channels=()
+  while IFS= read -r ch; do
+    [ -n "$ch" ] && channels+=("$ch")
+  done < <(fm_notify_configured_channels)
+  for ch in "${channels[@]}"; do
+    [ "$ch" = off ] && return 1
+  done
+  for ch in "${channels[@]}"; do
+    case "$ch" in auto|default) ch=$(fm_notify_platform_default) ;; esac
+    case "$ch" in
+      '') fm_notify_log "no OS-level alert channel on $(uname); ${marker:-no durable marker}; configure a command: directive" ;;
+      osascript|herdr) fm_notify_emit "$ch" "$summary" && successes=$((successes + 1)) ;;
+      command:*) fm_notify_emit command "$summary" "${ch#command:}" && successes=$((successes + 1)) ;;
+      *) fm_notify_log "unrecognized active-alert channel directive (redacted); ${FM_NOTIFY_UNKNOWN_SUFFIX:-notification skipped}" ;;
+    esac
+  done
+  [ "$successes" -gt 0 ]
+}

--- a/bin/fm-product-idea-lib.sh
+++ b/bin/fm-product-idea-lib.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# fm-product-idea-lib.sh - single owner of product-idea ledger row grammar.
+#
+# Sourced, never executed. Completion attestation and Bearings counting both
+# consume this grammar so a green completion cannot leave a row that Bearings
+# later marks malformed.
+#
+#   fm_product_idea_ledger_count <ledger-path>
+#       Prints the unscheduled count. Exit 0 on success, including an absent
+#       ledger which counts as 0. Exit 2 when unreadable. Exit 3 when malformed.
+#
+#   fm_product_idea_verify_row <ledger-path> <origin-id> <idea-id>
+#       Exit 0 when the ledger is fully well-formed under the count contract and
+#       exactly one well-formed row for idea-id cites
+#       data/<origin-id>/report.md#<section-heading> without a line number.
+#       Exit 4 when the ledger is well-formed and the id is absent. Exit 3 when
+#       the ledger is malformed, or the row is present but not origin-bound or
+#       not well-formed under the shared row contract.
+set -u
+
+fm_product_idea_ledger_count() {  # <ledger-path>
+  local ledger=$1 mode
+  [ -e "$ledger" ] || { printf '0\n'; return 0; }
+  if stat -f '%Lp' "$ledger" >/dev/null 2>&1; then
+    mode=$(stat -f '%Lp' "$ledger" 2>/dev/null || true)
+  else
+    mode=$(stat -c '%a' "$ledger" 2>/dev/null || true)
+  fi
+  [ -f "$ledger" ] || return 2
+  case "$mode" in ''|*[!0-7]*) return 2 ;; esac
+  [ $((8#$mode & 0444)) -ne 0 ] || return 2
+  awk -F '|' '
+    function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
+    function valid_status(s) {
+      return s == "unscheduled" \
+        || s ~ /^parked \(captain [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]\)$/ \
+        || s ~ /^scheduled -> [A-Za-z0-9._-]+$/ \
+        || s ~ /^shipped \(was [A-Za-z0-9._-]+\)$/ \
+        || s ~ /^dropped \([^()]+\)$/
+    }
+    function valid_source(s) {
+      return s ~ /^data\/[A-Za-z0-9._-]+\/report\.md#[^#[:space:]].*$/ \
+        && s !~ /:[0-9]+$/ \
+        && s !~ /#L?[0-9]+(-L?[0-9]+)?$/
+    }
+    /^\|[[:space:]]*ID[[:space:]]*\|[[:space:]]*Idea[[:space:]]*\|[[:space:]]*Status[[:space:]]*\|[[:space:]]*Source[[:space:]]*\|[[:space:]]*$/ { header++; next }
+    /^\|[[:space:]-]+\|[[:space:]-]+\|[[:space:]-]+\|[[:space:]-]+\|[[:space:]]*$/ { separator++; next }
+    /^[[:space:]]*$/ || /^#/ || /^<!--[[:space:][:print:]]*-->$/ { next }
+    /^\|/ {
+      if (NF != 6) { malformed=1; next }
+      id=trim($2); idea=trim($3); status=trim($4); source=trim($5)
+      if (id !~ /^PI-[0-9][0-9][0-9]$/ || idea == "" || !valid_status(status) \
+          || !valid_source(source) || seen[id]++) malformed=1
+      if (status == "unscheduled") count++
+      next
+    }
+    { malformed=1 }
+    END {
+      if (header != 1 || separator != 1 || malformed) exit 3
+      print count + 0
+    }
+  ' "$ledger"
+}
+
+fm_product_idea_verify_row() {  # <ledger-path> <origin-id> <idea-id>
+  local ledger=$1 origin=$2 idea_id=$3
+  if ! fm_product_idea_ledger_count "$ledger" >/dev/null; then
+    return 3
+  fi
+  awk -F '|' -v wanted="$idea_id" -v source_prefix="data/$origin/report.md#" '
+    function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
+    function valid_status(s) {
+      return s == "unscheduled" \
+        || s ~ /^parked \(captain [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]\)$/ \
+        || s ~ /^scheduled -> [A-Za-z0-9._-]+$/ \
+        || s ~ /^shipped \(was [A-Za-z0-9._-]+\)$/ \
+        || s ~ /^dropped \([^()]+\)$/
+    }
+    function valid_source(s) {
+      return s ~ /^data\/[A-Za-z0-9._-]+\/report\.md#[^#[:space:]].*$/ \
+        && s !~ /:[0-9]+$/ \
+        && s !~ /#L?[0-9]+(-L?[0-9]+)?$/
+    }
+    /^\|/ {
+      if (NF != 6) next
+      id = trim($2)
+      if (id != wanted) next
+      found++
+      idea = trim($3)
+      status = trim($4)
+      source = trim($5)
+      if (idea != "" && valid_status(status) && valid_source(source) \
+          && index(source, source_prefix) == 1 \
+          && length(source) > length(source_prefix)) good++
+    }
+    END {
+      if (found == 0) exit 4
+      if (found != 1 || good != 1) exit 3
+    }
+  ' "$ledger"
+}

--- a/bin/fm-remote-job-worker.sh
+++ b/bin/fm-remote-job-worker.sh
@@ -294,6 +294,15 @@ worker_stop_active_execution() {
 worker_shutdown() {
   trap - HUP INT TERM
   worker_publish_quarantine || {
+    # State/lock already gone (fixture teardown, pruned worktree cleanup, or an
+    # external rm of the state root). Nothing remains to guard, and the poll
+    # loop can recreate an empty state root via reap_stale - so refusing to exit
+    # would leave a TERM-immune orphan. Die with SIGTERM status (143) so a Linux
+    # restart supervisor still treats this like a default TERM kill, not a clean
+    # voluntary stop (exit 0).
+    if [ ! -d "${WORKER_LOCK:-}" ]; then
+      exit 143
+    fi
     worker_error "cannot guard worker ownership for shutdown"
     trap worker_shutdown HUP INT TERM
     return 0

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -1444,6 +1444,7 @@ fm_super_main() {
   cleanup() {
     trap - TERM INT
     wedge_alarm_stop_active_notifier
+    fm_notify_stop_active
     escalate_flush "$STATE" 2>/dev/null || true
     if [ -n "${WATCHER_PID:-}" ]; then
       kill "$WATCHER_PID" 2>/dev/null || true

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -146,6 +146,8 @@ set -u
 FM_DAEMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$FM_DAEMON_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+# shellcheck source=bin/fm-notify-lib.sh
+. "$FM_DAEMON_DIR/fm-notify-lib.sh"
 
 # Shared tmux pane primitives for supervisor injection (busy/composer detection
 # + verify-retry submit). Sourced at top level so BOTH the executed daemon and
@@ -865,24 +867,15 @@ wedge_alarm_emit() {  # <channel> <summary>
 # `auto` (no OS channel on this platform) logs that the durable marker is the
 # only signal. Every notifier routes through the test-forced recorder seam.
 wedge_alarm_notify() {  # <summary> <marker>
-  local summary=$1 marker=$2 ch
-  local -a channels=()
-  while IFS= read -r ch; do
-    [ -n "$ch" ] || continue
-    channels+=("$ch")
-  done < <(wedge_alarm_configured_channels)
-  for ch in "${channels[@]}"; do
-    [ "$ch" = off ] && return 0
-  done
-  for ch in "${channels[@]}"; do
-    case "$ch" in auto|default) ch=$(wedge_alarm_platform_default) ;; esac
-    case "$ch" in
-      '') log "wedge alarm: no OS-level alert channel on $(uname); durable marker $marker is the only signal - set config/wedge-alarm (e.g. a command: directive)" ;;
-      osascript|herdr) wedge_alarm_emit "$ch" "$summary" || true ;;
-      command:*) wedge_alarm_emit command "$summary" "${ch#command:}" || true ;;
-      *) log "wedge alarm: unrecognized active-alert channel directive (redacted); marker still written" ;;
-    esac
-  done
+  local summary=$1 marker=$2
+  local FM_NOTIFY_CONFIG_FILE="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}/wedge-alarm"
+  local FM_NOTIFY_CHANNEL=${FM_WEDGE_ALARM_CHANNEL:-}
+  local FM_NOTIFY_EXEC=${FM_WEDGE_ALARM_EXEC:-}
+  local FM_NOTIFY_TIMEOUT_SECS=${FM_WEDGE_ALARM_TIMEOUT_SECS:-$WEDGE_ALARM_TIMEOUT_SECS_DEFAULT}
+  local FM_NOTIFY_TITLE="firstmate: away-mode escalations WEDGED"
+  local FM_NOTIFY_LOG_PREFIX="wedge alarm: "
+  local FM_NOTIFY_UNKNOWN_SUFFIX="marker still written"
+  fm_notify "$summary" "durable marker $marker is the only signal" || true
   return 0
 }
 

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -28,7 +28,7 @@
 # Scout tasks (kind=scout in meta) carve out of that check: their worktree is
 # declared scratch and the report at data/<task-id>/report.md is the work
 # product. Teardown proceeds only once the report exists and the shared
-# unresolved-decision completion gate verifies its captain-held inventory.
+# decision-hold completion gate verifies its captain-held and product-idea inventory.
 # Before destructive cleanup, teardown validates task check artifacts and any
 # matching quarantine entries as ordinary single-link files on the state
 # device. It refuses and preserves task state when that proof fails; otherwise

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -855,6 +855,17 @@ fm_wake_queued_keys_locked() {
     "$FM_WAKE_QUEUE" 2>/dev/null || true
 }
 
+# Return 0 exactly while the durable queue has records that a successful drain
+# has not consumed. Read under the append/drain lock so an arm never mistakes a
+# queue being rotated by fm-wake-drain.sh for still-pending work.
+fm_wake_queue_pending() {
+  local status=1
+  fm_lock_acquire_wait "$FM_WAKE_QUEUE_LOCK"
+  [ -s "$FM_WAKE_QUEUE" ] && status=0
+  fm_lock_release "$FM_WAKE_QUEUE_LOCK"
+  return "$status"
+}
+
 fm_wake_restore_queue() {
   local drained=$1 restore
   restore="$STATE/.wake-queue.restore.$(fm_current_pid)"

--- a/bin/launchd/com.firstmate.deadman.plist.template
+++ b/bin/launchd/com.firstmate.deadman.plist.template
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.firstmate.deadman</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>__DEADMAN_SCRIPT__</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StartInterval</key>
+  <integer>60</integer>
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>LimitLoadToSessionType</key>
+  <string>Aqua</string>
+  <key>StandardOutPath</key>
+  <string>__STDOUT_LOG__</string>
+  <key>StandardErrorPath</key>
+  <string>__STDERR_LOG__</string>
+</dict>
+</plist>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -549,6 +549,7 @@ FM_CLAUDE_AUTOARM_EPOCH_FRESH=15   # seconds a recorded auto-arm outcome remains
 FM_CLAUDE_TURNEND_BLOCK_BUDGET=3   # consecutive --claude guard re-blocks before the verified one-time attended fail-open; safely below Claude Code's 8-block override
 FM_ARM_CONFIRM_TIMEOUT=10   # seconds fm-watch-arm waits to confirm a fresh watcher before reporting FAILED; default 30 on Git Bash/MSYS
 FM_ARM_ATTACH_POLL=0.5  # seconds between checks while fm-watch-arm is attached to an existing healthy watcher cycle
+FM_WATCH_QUEUE_REDELIVERY_GRACE=1   # seconds an ordinary fm-watch-arm waits for an in-flight drain before redelivering a still-undrained queue; 0 disables the wait
 FM_OPENCODE_ARM_READY_TIMEOUT_MS=12000   # milliseconds the OpenCode primary watcher plugin waits for an arm attempt to report started, healthy, wake, or failure; default 35000 on Windows to stay above the MSYS confirm budget
 FM_PI_ARM_READY_TIMEOUT_MS=12000   # milliseconds the Pi watcher extension waits for a successor arm to report started or attached; default 35000 on Windows to stay above the MSYS confirm budget
 FM_WATCH_ARM_RETIRE_TIMEOUT_MS=1000   # milliseconds Pi/OpenCode wait for an unready successor arm to exit before abandoning retries

--- a/docs/deadman.md
+++ b/docs/deadman.md
@@ -1,0 +1,78 @@
+# Studio deadman
+
+The Studio deadman is one notify-only macOS LaunchAgent that detects loss of Firstmate's watcher and scheduling path.
+It runs a stable installed copy outside the git checkout and never starts, stops, repairs, dispatches, merges, publishes, or changes fleet work.
+
+## Guarantee
+
+The probe reads one configured `FM_HOME` and checks only `state/.last-watcher-beat`.
+A beacon age greater than 600 seconds is unhealthy by default.
+A missing or unreadable home or beacon and a beacon timestamp in the future are also unhealthy.
+The deadman pages only after the same unhealthy class is observed twice, with the observations 60 to 120 seconds apart.
+The first installation window and a run gap that indicates host sleep or wake receive grace periods before paging.
+A healthy observation clears an unfinished stale confirmation.
+
+Successful pages are rate-limited for 30 minutes by default.
+A failed notification does not update the successful-page cooldown and is eligible for retry after another valid unhealthy sample.
+Deadman configuration, cooldown state, confirmation state, and its bounded journal live under `~/Library/Application Support/Firstmate/deadman/`, outside the monitored home.
+
+This is a watcher and scheduling-path guarantee, not proof that the entire Firstmate primary session is healthy.
+Version 1 does not check Tailscale, SSH port 2222, multiple Firstmate homes, product clocks, or phone-provider SDKs.
+It never restarts the watcher or any other service.
+
+## Notification channels
+
+`deadman.conf` uses the shared Firstmate notification grammar, with one directive per non-empty, non-comment line.
+The supported directives are `off`, `auto` or `default`, `osascript`, `herdr`, and `command:<cmd>`.
+`auto` selects macOS Notification Center through `osascript` and has no built-in channel on other platforms.
+Every configured non-`off` channel is attempted, so a `command:` phone path can accompany Notification Center as a secondary channel.
+The notification summary is passed to `command:` as `$1` and on standard input.
+Treat a `command:` value as executable shell configuration and keep `deadman.conf` readable only by the account that runs the agent.
+
+## Install
+
+Run the installer from the trusted Firstmate checkout and pass the operational home explicitly when it differs from that checkout.
+
+```bash
+bin/fm-deadman-install.sh \
+  --fm-home /absolute/path/to/firstmate-home \
+  --channel osascript \
+  --channel 'command:your-phone-notifier "$1"'
+```
+
+The installer atomically copies `fm-deadman.sh` and `fm-notify-lib.sh` into `~/Library/Application Support/Firstmate/deadman/`, writes `~/Library/LaunchAgents/com.firstmate.deadman.plist`, and sends a mandatory canary notification.
+Without `--bootstrap`, it does not load the LaunchAgent.
+Confirm the canary arrived, then run the same command with `--bootstrap` to send a fresh canary and load the agent.
+
+```bash
+bin/fm-deadman-install.sh \
+  --fm-home /absolute/path/to/firstmate-home \
+  --channel osascript \
+  --channel 'command:your-phone-notifier "$1"' \
+  --bootstrap
+```
+
+If the canary fails, the installer exits without bootstrapping launchd.
+The LaunchAgent always executes the installed script path, so later checkout changes cannot silently change a running deadman.
+Edit `deadman.env` only with the documented keys emitted by the installer because unknown keys and invalid values are self-faults.
+An update preserves the existing deadman configuration unless `--fm-home` is supplied, in which case only that key is replaced and the timing values remain intact.
+Edit `deadman.conf` to change channels without reinstalling, or pass all desired `--channel` values on the next install.
+
+After installation, verify four operator cases manually: the canary arrives, a healthy watcher stays silent, a stopped watcher pages after the stale threshold and confirmation sample, and waking the Studio does not page during grace.
+
+## Uninstall
+
+The uninstall operation unloads the LaunchAgent when present, removes the plist, and removes the known installed deadman files and state.
+
+```bash
+bin/fm-deadman-install.sh --uninstall
+```
+
+## Exit behavior and logs
+
+Normal healthy and unhealthy probes exit zero, including an unhealthy probe whose notification delivery failed.
+`--canary` exits zero only when at least one notification channel reports success and exits one when delivery fails.
+Invalid configuration, missing installed components, and corrupt deadman-owned state exit two as self-faults for launchd diagnostics.
+The bounded journal is `deadman.journal`, and launchd standard output and error logs are stored beside it.
+
+The source behavior is covered by `tests/fm-deadman.test.sh`, including age boundaries, confirmation timing, cooldown, flaps, hostile configuration, failed delivery, concurrent invocation, no-spawn behavior, installation, and plist linting.

--- a/docs/deadman.md
+++ b/docs/deadman.md
@@ -9,12 +9,13 @@ The probe reads one configured `FM_HOME` and checks only `state/.last-watcher-be
 A beacon age greater than 600 seconds is unhealthy by default.
 A missing or unreadable home or beacon and a beacon timestamp in the future are also unhealthy.
 The deadman pages only after the same unhealthy class is observed twice, with the observations 60 to 120 seconds apart.
-The first installation window and a run gap that indicates host sleep or wake receive grace periods before paging.
+The first installation window defaults to 660 seconds of grace, and a run gap greater than 180 seconds starts a 300-second sleep/wake grace before paging.
 A healthy observation clears an unfinished stale confirmation.
 
 Successful pages are rate-limited for 30 minutes by default.
-A failed notification does not update the successful-page cooldown and is eligible for retry after another valid unhealthy sample.
+A failed notification does not update the successful-page cooldown and is eligible for retry after another valid unhealthy confirmation sample.
 Deadman configuration, cooldown state, confirmation state, and its bounded journal live under `~/Library/Application Support/Firstmate/deadman/`, outside the monitored home.
+The LaunchAgent runs that installed probe every 60 seconds.
 
 This is a watcher and scheduling-path guarantee, not proof that the entire Firstmate primary session is healthy.
 Version 1 does not check Tailscale, SSH port 2222, multiple Firstmate homes, product clocks, or phone-provider SDKs.
@@ -22,7 +23,7 @@ It never restarts the watcher or any other service.
 
 ## Notification channels
 
-`deadman.conf` uses the shared Firstmate notification grammar, with one directive per non-empty, non-comment line.
+`deadman.conf` uses the shared Firstmate notification grammar owned by `bin/fm-notify-lib.sh`, with one directive per non-empty, non-comment line.
 The supported directives are `off`, `auto` or `default`, `osascript`, `herdr`, and `command:<cmd>`.
 `auto` selects macOS Notification Center through `osascript` and has no built-in channel on other platforms.
 Every configured non-`off` channel is attempted, so a `command:` phone path can accompany Notification Center as a secondary channel.
@@ -54,7 +55,17 @@ bin/fm-deadman-install.sh \
 
 If the canary fails, the installer exits without bootstrapping launchd.
 The LaunchAgent always executes the installed script path, so later checkout changes cannot silently change a running deadman.
-Edit `deadman.env` only with the documented keys emitted by the installer because unknown keys and invalid values are self-faults.
+`deadman.env` accepts only these keys; unknown keys and invalid values are self-faults:
+
+- `FM_HOME` - absolute path of the single monitored Firstmate home
+- `STALE_AFTER_SECS` - beacon age threshold in seconds; default `600`
+- `SAMPLE_GAP_SECS` - minimum seconds between the two unhealthy observations; default `60`, allowed range `60`-`120`
+- `SAMPLE_MAX_GAP_SECS` - maximum seconds between those observations; default `120`, must be between `SAMPLE_GAP_SECS` and `120`
+- `FIRST_ARM_GRACE_SECS` - first-install grace before an armed unhealthy path may page; default `660`
+- `WAKE_GRACE_SECS` - grace after a detected sleep/wake run gap; default `300`
+- `SLEEP_GAP_DETECT_SECS` - run-gap size that starts wake grace; default `180`
+- `COOLDOWN_SECS` - successful-page rate limit; default `1800`
+
 An update preserves the existing deadman configuration unless `--fm-home` is supplied, in which case only that key is replaced and the timing values remain intact.
 Edit `deadman.conf` to change channels without reinstalling, or pass all desired `--channel` values on the next install.
 
@@ -70,8 +81,9 @@ bin/fm-deadman-install.sh --uninstall
 
 ## Exit behavior and logs
 
-Normal healthy and unhealthy probes exit zero, including an unhealthy probe whose notification delivery failed.
-`--canary` exits zero only when at least one notification channel reports success and exits one when delivery fails.
+Normal healthy and unhealthy probes exit zero, including an unhealthy probe whose notification delivery failed and a probe skipped because another invocation holds the lock.
+`--canary` exits zero only when at least one notification channel reports success.
+It exits one when delivery fails or another invocation holds the probe lock.
 Invalid configuration, missing installed components, and corrupt deadman-owned state exit two as self-faults for launchd diagnostics.
 The bounded journal is `deadman.journal`, and launchd standard output and error logs are stored beside it.
 

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -5,18 +5,23 @@ This document records the deterministic mechanism, structured surfaces, and priv
 
 ## Mechanism
 
-`bin/fm-decision-hold.sh` is the only lifecycle command for an investigation or visual review's unresolved captain decisions.
+`bin/fm-decision-hold.sh` is the only lifecycle command for an investigation or visual review's unresolved captain decisions and product-idea completion attestation.
 The command runs tasks-axi in the active `FM_HOME`, so the existing backlog remains the only durable work database and a secondmate-owned decision stays in the secondmate home.
 It never reads report bodies, review artifacts, terminal output, or chat.
+`bin/fm-product-idea-lib.sh` owns the shared product-idea ledger row and unscheduled-count grammar consumed by completion and Bearings.
 
 The `hold` subcommand maps an originating work id and stable decision key to `<origin-id>-decision-<decision-key>`.
 It creates a kind `captain` backlog item when absent and invokes `tasks-axi hold <id> --reason <reason> --kind captain` on every retry.
 It rejects an identity collision, a changed title, and attempts to reopen an already resolved identity.
 
-The `complete` subcommand unions the reviewed keys into `decision_keys=` and appends `decisions_reviewed=1` while originating task metadata is live.
+The `complete` subcommand requires both a decision inventory and an idea inventory attestation on every pass.
+It accepts `--none` or decision keys for the decision side, and exactly one of `--ideas <PI-id>...` or `--no-ideas` for the idea side, while rejecting invalid combinations.
+It unions reviewed decision keys and product-idea ids into origin metadata while the task metadata is live.
+It validates the full active-home ledger grammar and every unioned idea id, requiring each matching row's Source to cite the completing origin's report section without a line number, and rejects missing, malformed, mismatched, and line-number references.
+An explicit no-idea inventory creates the script-owned ledger template lazily.
+Post-upgrade completions persist `ideas_reviewed=1` with the unioned `idea_ids`, while `verify` grandfathers metadata that still carries only the earlier completed decision attestation.
 A post-teardown visual review can complete against the surviving report and durable holds without recreating volatile task metadata.
-It accepts `--none` as an explicit semantic inventory result, not as inferred absence.
-It verifies every listed identity against tasks-axi before recording completion.
+It verifies every listed decision identity against tasks-axi before recording completion.
 For an open keyed status decision, it appends a `captain-held [key=<key>]: ...` transfer event only after the matching backlog hold is durable.
 `bin/fm-classify-lib.sh` recognizes that transfer as closing the live status copy without claiming that the captain has answered it.
 
@@ -35,6 +40,7 @@ It resolves every repeated `blocked-by:` edge against structured Done records, k
 Its secondmate-home summary classifies an actionable captain hold as `captain_decision` and preserves blocked captain holds as queued work in the owning home.
 
 `bin/fm-bearings-snapshot.sh` projects actionable captain holds into `decisions_open` and leaves blocked captain holds in ordinary queued gates.
+It also counts unscheduled rows across the canonical main data root and readable registered secondmate ledgers; an absent ledger in a readable home counts as zero, while unreadable, malformed, unavailable, remote, or truncated ledgers and registries are disclosed in `ideas_warnings` instead of silently treating those incomplete cases as empty.
 It excludes completed kind `captain` records from Recently Landed.
 The projection remains read-only and does not inspect historical prose.
 
@@ -43,6 +49,7 @@ The projection remains read-only and does not inspect historical prose.
 Verification date: 2026-07-14.
 Additional quoted `blocked_by` regression verification date: 2026-07-17.
 Plural blocker-readiness and mixed-home projection verification date: 2026-07-22.
+Product-idea inventory and Bearings-count verification date: 2026-08-10.
 
 The focused end-to-end regression uses only synthetic `sample` identities and decision text.
 It begins with a completed investigation and visual review whose genuine unresolved choice exists only in the report.
@@ -62,6 +69,8 @@ ok - resolved findings and decision-like prose do not create false holds
 ok - terminal single-owner stale status decisions do not block empty inventory
 ok - main-home and secondmate-home captain holds remain correctly routed
 ok - resolve matches first/middle/last in quoted blocked_by and rejects a genuinely absent id
+ok - product idea attestations are origin-bound, persisted, idempotent, lazy, and grandfather-safe
+ok - secondmate ideas stay home-local and Bearings discloses complete and incomplete counts
 
 $ bash tests/fm-fleet-snapshot-view.test.sh
 ok - backlog normalization preserves strict roles and resolves every blocker compatibly

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -25,6 +25,7 @@
   ],
   "readmeSetupTargets": [
     "docs/configuration.md",
+    "docs/deadman.md",
     "docs/wedge-alarm.md",
     "docs/tmux-backend.md",
     "docs/herdr-backend.md",
@@ -282,6 +283,10 @@
     },
     {
       "path": "docs/configuration.md",
+      "audience": "operator-current"
+    },
+    {
+      "path": "docs/deadman.md",
       "audience": "operator-current"
     },
     {

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -129,11 +129,35 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/codebase-design/DEEPENING.md",
+      "audience": "agent-runtime"
+    },
+    {
+      "path": ".agents/skills/codebase-design/DESIGN-IT-TWICE.md",
+      "audience": "agent-runtime"
+    },
+    {
+      "path": ".agents/skills/codebase-design/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/decision-hold-lifecycle/SKILL.md",
       "audience": "agent-runtime"
     },
     {
       "path": ".agents/skills/diagnostic-reasoning/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
+      "path": ".agents/skills/domain-modeling/ADR-FORMAT.md",
+      "audience": "agent-runtime"
+    },
+    {
+      "path": ".agents/skills/domain-modeling/CONTEXT-FORMAT.md",
+      "audience": "agent-runtime"
+    },
+    {
+      "path": ".agents/skills/domain-modeling/SKILL.md",
       "audience": "agent-runtime"
     },
     {
@@ -150,6 +174,18 @@
     },
     {
       "path": ".agents/skills/fmx-respond/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
+      "path": ".agents/skills/grill-me/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
+      "path": ".agents/skills/grill-with-docs/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
+      "path": ".agents/skills/grilling/SKILL.md",
       "audience": "agent-runtime"
     },
     {
@@ -182,6 +218,14 @@
     },
     {
       "path": ".agents/skills/updatefirstmate/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
+      "path": ".agents/skills/wait-what/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
+      "path": ".agents/skills/wayfinder/SKILL.md",
       "audience": "agent-runtime"
     },
     {

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -56,7 +56,7 @@ The watcher has no native Orca busy signal, so each harness adapter's semantic l
 Grok alone retains its isolated rendered-tail fallback.
 
 Cleanup keeps all shared Firstmate safety checks.
-A scout still requires its report and completed decision inventory.
+A scout still requires its report and completed decision-hold inventory, including the product-idea attestation.
 A ship still refuses dirty or unlanded work.
 Before release, cleanup resolves the recorded Orca worktree id and verifies its path matches the recorded worktree path.
 A missing, unreadable, or mismatched identity preserves metadata and stops rather than deleting anything.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -25,7 +25,8 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-remote-doctor.sh`    | Check, and with `--fix` repair, one remote account's second-mate readiness (remote job worker, Herdr, Aqua launch agents, PATH, and required tools) |
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-backlog-receive.sh`  | Idempotently ingest one confined remote handoff outbox through tasks-axi             |
-| `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions                 |
+| `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions and product-idea completion attestations |
+| `fm-product-idea-lib.sh` | Shared product-idea ledger row and unscheduled-count grammar for completion and Bearings |
 | `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs   |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -71,6 +71,9 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-watch-arm.sh`        | Verified home-scoped watcher arm wrapper with loud cycle endings and bounded lifecycle ledger |
 | `fm-watch-checkpoint.sh` | Run one bounded foreground watcher checkpoint for Codex-style supervision            |
 | `fm-watch.sh`            | Singleton-safe always-on watcher: absorb benign wakes, queue and exit on actionable ones |
+| `fm-deadman.sh`          | Notify-only probe of one home's watcher-beacon freshness from an installed launchd copy |
+| `fm-deadman-install.sh`  | Atomically install, canary, optionally bootstrap, or uninstall the Studio deadman LaunchAgent |
+| `fm-notify-lib.sh`       | Shared best-effort active-notification channel grammar for the wedge alarm and Studio deadman |
 | `fm-afk-start.sh`        | Run the common sourceable away-mode daemon entry in the foreground                      |
 | `fm-afk-launch.sh`       | Own away-mode entry, exit, rollback, and any backend terminal lifecycle                 |
 | `fm-afk-return.sh`       | Own deterministic return shutdown, catch-up evidence, and the firstmate-actionable blocker gate |

--- a/docs/wedge-alarm.md
+++ b/docs/wedge-alarm.md
@@ -7,6 +7,7 @@ The durable marker and tmux flash remain as additional signals.
 
 ## Channels
 
+`bin/fm-notify-lib.sh` owns the shared active-notification channel grammar used by this alarm and the Studio deadman.
 `config/wedge-alarm` is local and gitignored.
 It lists channel directives, one per non-empty, non-comment line, and every listed non-`off` channel fires best-effort.
 `FM_WEDGE_ALARM_CHANNEL` overrides the file with one directive for focused testing.

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -491,6 +491,56 @@ test_bad_secondmate_homes_never_revive_parent_work() {
   pass "missing, invalid, unreadable, malformed, and timed-out homes stay explicit unknowns"
 }
 
+# A registered home that no longer exists contributes zero landed, queued, and
+# decision work. That absence must arrive as a named warning, never as a baseline
+# that merely looks empty, and a present seeded home must not trip the warning.
+test_missing_registered_home_warns_instead_of_counting_zero() {
+  local home healthy fakebin json warning
+  home=$(make_home missing-home-warn)
+  : > "$home/data/secondmates.md"
+  printf '## In flight\n\n## Queued\n\n## Done\n' > "$home/data/backlog.md"
+
+  append_secondmate_registry "$home" gone "$TMP_ROOT/never-created-home"
+  healthy=$(make_landed_secondmate "$home" healthy)
+  append_landed_row "$healthy" mate-ship "Shipped from the healthy home" 2026-07-13
+
+  fakebin=$(make_fakebin "$home")
+  json=$(run "$home" "$fakebin" --json)
+
+  warning=$(printf '%s' "$json" | jq -r '
+    [.omitted[] | select(.surface | startswith("secondmate home(s) unavailable"))][0].surface // ""')
+  [ -n "$warning" ] || fail "a missing registered home produced no unavailable-home warning: $json"
+  case "$warning" in
+    *"gone (invalid home: registered home directory does not exist)"*) : ;;
+    *) fail "the warning must name the missing home and why it is unavailable, got: $warning" ;;
+  esac
+  case "$warning" in
+    *healthy*) fail "a present seeded home must not appear in the unavailable-home warning: $warning" ;;
+  esac
+  printf '%s' "$json" | jq -e '
+    (.landed | any(.[]; .id == "mate-ship" and .owner == "healthy"))
+      and (.secondmates | any(.[]; .id == "gone" and .state == "unknown"))
+  ' >/dev/null || fail "the readable home must still project its work beside the warning: $json"
+  pass "a missing registered home warns by name instead of silently counting zero"
+}
+
+test_present_empty_secondmate_home_raises_no_unavailable_warning() {
+  local home fakebin json
+  home=$(make_home idle-home-quiet)
+  : > "$home/data/secondmates.md"
+  printf '## In flight\n\n## Queued\n\n## Done\n' > "$home/data/backlog.md"
+  make_landed_secondmate "$home" idle >/dev/null
+
+  fakebin=$(make_fakebin "$home")
+  json=$(run "$home" "$fakebin" --json)
+  printf '%s' "$json" | jq -e '
+    (.omitted | all(.surface | startswith("secondmate home(s) unavailable") | not))
+      and (.secondmates | any(.[]; .id == "idle" and .provenance == "structured-home"
+        and .state == "no_active_work"))
+  ' >/dev/null || fail "a present, seeded, empty home must stay valid idle without a warning: $json"
+  pass "a present empty secondmate home stays valid idle with no false alarm"
+}
+
 test_oversized_secondmate_summary_stays_strict_unknown() {
   local home mate fakebin json i
   home=$(make_home oversized-home)
@@ -1895,6 +1945,8 @@ test_parent_activity_evidence_is_bounded_and_disclosed
 test_active_child_overrides_old_parent_event
 test_structured_child_decision_reaches_captains_call
 test_bad_secondmate_homes_never_revive_parent_work
+test_missing_registered_home_warns_instead_of_counting_zero
+test_present_empty_secondmate_home_raises_no_unavailable_warning
 test_oversized_secondmate_summary_stays_strict_unknown
 test_secondmate_and_child_bounds_are_disclosed
 test_parent_decision_is_untrusted_contradiction_only

--- a/tests/fm-deadman.test.sh
+++ b/tests/fm-deadman.test.sh
@@ -227,6 +227,70 @@ SH
   pass "probe is notify-only; concurrent probes serialize; canary fails closed on lock"
 }
 
+test_term_reaps_notifier_and_releases_lock() {
+  local dir slow pid rc notifier_pid i
+  dir=$(new_case term-signal)
+  set_mtime "$dir/home/state/.last-watcher-beat" 0
+  run_probe "$dir" 1000
+  [ "$(notify_count "$dir/notify.log")" -eq 0 ] || fail "setup first sample paged"
+
+  slow="$dir/slow-notifier"
+  cat > "$slow" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$$" > "$FM_TEST_NOTIFY_PID"
+sleep 30
+printf '%s|%s\n' "$1" "$2" >> "$FM_TEST_NOTIFY_LOG"
+SH
+  chmod +x "$slow"
+
+  rm -f "$dir/notify.pid" "$dir/notify.log"
+  FM_DEADMAN_INSTALL_DIR="$dir/install" \
+    FM_DEADMAN_NOW=1060 \
+    FM_DEADMAN_NOTIFY_EXEC="$slow" \
+    FM_TEST_NOTIFY_LOG="$dir/notify.log" \
+    FM_TEST_NOTIFY_PID="$dir/notify.pid" \
+    "$ROOT/bin/fm-deadman.sh" & pid=$!
+
+  i=0
+  while [ ! -f "$dir/notify.pid" ] && [ "$i" -lt 50 ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ -f "$dir/notify.pid" ] || fail "notifier did not start before TERM"
+  notifier_pid=$(cat "$dir/notify.pid")
+
+  kill -TERM "$pid"
+  set +e
+  wait "$pid"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "TERM probe exited 0 instead of nonzero"
+
+  [ ! -d "$dir/install/.probe.lock" ] || fail "TERM left probe lock behind"
+
+  i=0
+  while kill -0 "$notifier_pid" 2>/dev/null && [ "$i" -lt 50 ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  ! kill -0 "$notifier_pid" 2>/dev/null || fail "TERM left notifier process orphaned"
+
+  [ "$(notify_count "$dir/notify.log")" -eq 0 ] || fail "TERM allowed notifier to complete a page"
+
+  run_probe "$dir" 1120
+  [ "$(notify_count "$dir/notify.log")" -eq 1 ] || fail "post-TERM probe did not deliver exactly one page"
+
+  set_mtime "$dir/home/state/.last-watcher-beat" 2000
+  set +e
+  run_probe "$dir" 2000
+  rc=$?
+  set -e
+  [ "$rc" -eq 0 ] || fail "healthy probe exited $rc"
+  [ ! -d "$dir/install/.probe.lock" ] || fail "healthy probe left lock behind"
+
+  pass "TERM cleanup reaps notifier, releases lock, exits nonzero; normal exit stays zero"
+}
+
 test_installer_and_plist() {
   local dir plist install program
   dir="$TMP_ROOT/installer"
@@ -262,4 +326,5 @@ test_cooldown_and_failed_delivery
 test_first_arm_and_sleep_wake_grace
 test_hostile_config_is_data
 test_notify_only_and_concurrent_lock
+test_term_reaps_notifier_and_releases_lock
 test_installer_and_plist

--- a/tests/fm-deadman.test.sh
+++ b/tests/fm-deadman.test.sh
@@ -172,7 +172,7 @@ test_hostile_config_is_data() {
 }
 
 test_notify_only_and_concurrent_lock() {
-  local dir fakebin slow p1 p2
+  local dir fakebin slow p1 p2 rc
   dir=$(new_case no-spawn)
   set_mtime "$dir/home/state/.last-watcher-beat" 0
   fakebin="$dir/fakebin"
@@ -205,7 +205,26 @@ SH
   wait "$p1"
   wait "$p2"
   [ "$(notify_count "$dir/notify.log")" -eq 1 ] || fail "concurrent invocations delivered more than one page"
-  pass "probe is notify-only and concurrent invocations serialize"
+
+  dir=$(new_case canary-lock)
+  mkdir "$dir/install/.probe.lock"
+  set +e
+  FM_DEADMAN_INSTALL_DIR="$dir/install" \
+    FM_DEADMAN_NOW=1000 \
+    FM_DEADMAN_NOTIFY_EXEC="$NOTIFIER" \
+    FM_TEST_NOTIFY_LOG="$dir/notify.log" \
+    "$ROOT/bin/fm-deadman.sh" --canary
+  rc=$?
+  set -e
+  [ "$rc" -eq 1 ] || fail "canary under lock contention exited $rc instead of 1"
+  [ "$(notify_count "$dir/notify.log")" -eq 0 ] || fail "canary under lock contention still delivered a notification"
+  set +e
+  run_probe "$dir" 1000
+  rc=$?
+  set -e
+  [ "$rc" -eq 0 ] || fail "normal probe under lock contention exited $rc instead of 0"
+  [ "$(notify_count "$dir/notify.log")" -eq 0 ] || fail "normal probe under lock contention delivered a notification"
+  pass "probe is notify-only; concurrent probes serialize; canary fails closed on lock"
 }
 
 test_installer_and_plist() {

--- a/tests/fm-deadman.test.sh
+++ b/tests/fm-deadman.test.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# Behavioral coverage for the installed launchd deadman.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-deadman)
+NOTIFIER="$TMP_ROOT/notifier"
+cat > "$NOTIFIER" <<'SH'
+#!/usr/bin/env bash
+printf '%s|%s\n' "$1" "$2" >> "$FM_TEST_NOTIFY_LOG"
+[ "${FM_TEST_NOTIFY_FAIL:-0}" -eq 0 ]
+SH
+chmod +x "$NOTIFIER"
+
+set_mtime() {
+  local path=$1 epoch=$2 stamp
+  if touch -d "@$epoch" "$path" 2>/dev/null; then
+    return 0
+  fi
+  stamp=$(date -r "$epoch" +%Y%m%d%H%M.%S) || return 1
+  touch -t "$stamp" "$path"
+}
+
+new_case() {
+  local name=$1 dir="$TMP_ROOT/$1"
+  mkdir -p "$dir/install" "$dir/home/state"
+  : > "$dir/home/state/.last-watcher-beat"
+  cat > "$dir/install/deadman.env" <<EOF
+FM_HOME=$dir/home
+STALE_AFTER_SECS=600
+SAMPLE_GAP_SECS=60
+SAMPLE_MAX_GAP_SECS=120
+FIRST_ARM_GRACE_SECS=660
+WAKE_GRACE_SECS=300
+SLEEP_GAP_DETECT_SECS=99999
+COOLDOWN_SECS=1800
+EOF
+  printf 'command:true\n' > "$dir/install/deadman.conf"
+  printf '0\n' > "$dir/install/installed-at"
+  printf '0\n' > "$dir/install/armed"
+  printf '%s\n' "$dir"
+}
+
+run_probe() {
+  local dir=$1 now=$2
+  FM_DEADMAN_INSTALL_DIR="$dir/install" \
+    FM_DEADMAN_NOW="$now" \
+    FM_DEADMAN_NOTIFY_EXEC="$NOTIFIER" \
+    FM_TEST_NOTIFY_LOG="$dir/notify.log" \
+    FM_TEST_NOTIFY_FAIL=${FM_TEST_NOTIFY_FAIL:-0} \
+    "$ROOT/bin/fm-deadman.sh"
+}
+
+notify_count() {
+  local file=$1
+  [ -f "$file" ] && wc -l < "$file" | tr -d ' ' || printf '0\n'
+}
+
+test_age_boundary_and_double_sample() {
+  local dir
+  dir=$(new_case ages)
+  set_mtime "$dir/home/state/.last-watcher-beat" 400
+  run_probe "$dir" 1000
+  [ "$(notify_count "$dir/notify.log")" -eq 0 ] || fail "age exactly N paged"
+  set_mtime "$dir/home/state/.last-watcher-beat" 399
+  run_probe "$dir" 1001
+  run_probe "$dir" 1060
+  [ "$(notify_count "$dir/notify.log")" -eq 0 ] || fail "second sample before 60 seconds paged"
+  run_probe "$dir" 1061
+  [ "$(notify_count "$dir/notify.log")" -eq 1 ] || fail "second stale sample at 60 seconds did not page"
+  pass "staleness is age > N and requires two samples 60-120 seconds apart"
+}
+
+test_missing_future_and_unreadable() {
+  local missing future unreadable fakebin
+  missing=$(new_case missing)
+  rm -rf "${missing:?}/home"
+  run_probe "$missing" 1000
+  run_probe "$missing" 1060
+  [ "$(notify_count "$missing/notify.log")" -eq 1 ] || fail "missing FM_HOME did not page after confirmation"
+
+  future=$(new_case future)
+  set_mtime "$future/home/state/.last-watcher-beat" 1200
+  run_probe "$future" 1000
+  run_probe "$future" 1060
+  [ "$(notify_count "$future/notify.log")" -eq 1 ] || fail "future beacon did not page after confirmation"
+
+  unreadable=$(new_case unreadable)
+  fakebin="$unreadable/fakebin"
+  mkdir -p "$fakebin"
+  cat > "$fakebin/stat" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+  chmod +x "$fakebin/stat"
+  PATH="$fakebin:$PATH" run_probe "$unreadable" 1000
+  PATH="$fakebin:$PATH" run_probe "$unreadable" 1060
+  [ "$(notify_count "$unreadable/notify.log")" -eq 1 ] || fail "unreadable beacon mtime did not page after confirmation"
+  pass "missing, unreadable, and future beacon inputs are unhealthy"
+}
+
+test_flap_resets_confirmation() {
+  local dir
+  dir=$(new_case flap)
+  set_mtime "$dir/home/state/.last-watcher-beat" 0
+  run_probe "$dir" 1000
+  set_mtime "$dir/home/state/.last-watcher-beat" 1050
+  run_probe "$dir" 1050
+  set_mtime "$dir/home/state/.last-watcher-beat" 0
+  run_probe "$dir" 1110
+  [ "$(notify_count "$dir/notify.log")" -eq 0 ] || fail "healthy flap did not reset stale confirmation"
+  run_probe "$dir" 1170
+  [ "$(notify_count "$dir/notify.log")" -eq 1 ] || fail "post-flap second stale sample did not page"
+  pass "a healthy flap resets stale confirmation"
+}
+
+test_cooldown_and_failed_delivery() {
+  local dir
+  dir=$(new_case cooldown)
+  set_mtime "$dir/home/state/.last-watcher-beat" 0
+  run_probe "$dir" 1000
+  run_probe "$dir" 1060
+  run_probe "$dir" 1120
+  [ "$(notify_count "$dir/notify.log")" -eq 1 ] || fail "successful page cooldown did not suppress a retry"
+  [ "$(cat "$dir/install/last-success-at")" = 1060 ] || fail "successful cooldown marker is wrong"
+
+  dir=$(new_case notify-failure)
+  set_mtime "$dir/home/state/.last-watcher-beat" 0
+  run_probe "$dir" 1000
+  FM_TEST_NOTIFY_FAIL=1 run_probe "$dir" 1060
+  [ ! -e "$dir/install/last-success-at" ] || fail "failed notification consumed successful-page cooldown"
+  run_probe "$dir" 1120
+  [ "$(notify_count "$dir/notify.log")" -eq 2 ] || fail "failed notification was not retried at the next confirmed sample"
+  [ "$(cat "$dir/install/last-success-at")" = 1120 ] || fail "successful retry did not write cooldown marker"
+  pass "only successful delivery consumes the page cooldown"
+}
+
+test_first_arm_and_sleep_wake_grace() {
+  local dir
+  dir=$(new_case grace)
+  rm -f "$dir/install/armed"
+  printf '1000\n' > "$dir/install/installed-at"
+  set_mtime "$dir/home/state/.last-watcher-beat" 0
+  run_probe "$dir" 1000
+  run_probe "$dir" 1060
+  [ "$(notify_count "$dir/notify.log")" -eq 0 ] || fail "first-arm grace paged during installation window"
+  printf '0\n' > "$dir/install/armed"
+  sed -i.bak 's/SLEEP_GAP_DETECT_SECS=99999/SLEEP_GAP_DETECT_SECS=180/' "$dir/install/deadman.env"
+  rm -f "$dir/install/deadman.env.bak"
+  printf '1000\n' > "$dir/install/last-run-at"
+  run_probe "$dir" 1400
+  run_probe "$dir" 1460
+  [ "$(notify_count "$dir/notify.log")" -eq 0 ] || fail "sleep/wake grace paged immediately after a run gap"
+  pass "first-arm and inferred sleep/wake gaps defer pages"
+}
+
+test_hostile_config_is_data() {
+  local dir marker rc
+  dir=$(new_case hostile)
+  marker="$dir/executed"
+  # shellcheck disable=SC2016 # Literal command substitution is the hostile input under test.
+  printf 'FM_HOME=$(touch %s)\n' "$marker" > "$dir/install/deadman.env"
+  set +e
+  run_probe "$dir" 1000 >/dev/null 2>&1
+  rc=$?
+  set -e
+  [ "$rc" -eq 2 ] || fail "hostile config did not produce a self-fault"
+  [ ! -e "$marker" ] || fail "hostile config executed shell syntax"
+  pass "configuration is parsed as allowlisted data, never sourced"
+}
+
+test_notify_only_and_concurrent_lock() {
+  local dir fakebin slow p1 p2
+  dir=$(new_case no-spawn)
+  set_mtime "$dir/home/state/.last-watcher-beat" 0
+  fakebin="$dir/fakebin"
+  mkdir -p "$fakebin"
+  for name in git launchctl fm-spawn.sh; do
+    cat > "$fakebin/$name" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$0" >> "$FM_TEST_FORBIDDEN_LOG"
+exit 97
+SH
+    chmod +x "$fakebin/$name"
+  done
+  FM_TEST_FORBIDDEN_LOG="$dir/forbidden.log" PATH="$fakebin:$PATH" run_probe "$dir" 1000
+  FM_TEST_FORBIDDEN_LOG="$dir/forbidden.log" PATH="$fakebin:$PATH" run_probe "$dir" 1060
+  [ "$(notify_count "$dir/notify.log")" -eq 1 ] || fail "PATH mutation guards disrupted the notify-only probe"
+  [ ! -s "$dir/forbidden.log" ] || fail "probe invoked a forbidden fleet mutation command"
+
+  dir=$(new_case concurrent)
+  set_mtime "$dir/home/state/.last-watcher-beat" 0
+  run_probe "$dir" 1000
+  slow="$dir/slow-notifier"
+  cat > "$slow" <<'SH'
+#!/usr/bin/env bash
+sleep 1
+printf '%s|%s\n' "$1" "$2" >> "$FM_TEST_NOTIFY_LOG"
+SH
+  chmod +x "$slow"
+  FM_DEADMAN_INSTALL_DIR="$dir/install" FM_DEADMAN_NOW=1060 FM_DEADMAN_NOTIFY_EXEC="$slow" FM_TEST_NOTIFY_LOG="$dir/notify.log" "$ROOT/bin/fm-deadman.sh" & p1=$!
+  FM_DEADMAN_INSTALL_DIR="$dir/install" FM_DEADMAN_NOW=1060 FM_DEADMAN_NOTIFY_EXEC="$slow" FM_TEST_NOTIFY_LOG="$dir/notify.log" "$ROOT/bin/fm-deadman.sh" & p2=$!
+  wait "$p1"
+  wait "$p2"
+  [ "$(notify_count "$dir/notify.log")" -eq 1 ] || fail "concurrent invocations delivered more than one page"
+  pass "probe is notify-only and concurrent invocations serialize"
+}
+
+test_installer_and_plist() {
+  local dir plist install program
+  dir="$TMP_ROOT/installer"
+  install="$dir/Application Support/Firstmate/deadman"
+  plist="$dir/LaunchAgents/com.firstmate.deadman.plist"
+  mkdir -p "$dir/home/state"
+  : > "$dir/home/state/.last-watcher-beat"
+  FM_DEADMAN_INSTALL_DIR="$install" FM_DEADMAN_PLIST="$plist" \
+    FM_DEADMAN_NOTIFY_EXEC="$NOTIFIER" FM_TEST_NOTIFY_LOG="$dir/notify.log" \
+    "$ROOT/bin/fm-deadman-install.sh" --fm-home "$dir/home" --channel command:true >/dev/null
+  [ -x "$install/fm-deadman.sh" ] || fail "installer did not create an executable stable probe copy"
+  if command -v plutil >/dev/null 2>&1; then
+    program=$(plutil -extract ProgramArguments.0 raw -o - "$plist") || fail "plist program argument could not be decoded"
+    [ "$program" = "$install/fm-deadman.sh" ] || fail "plist does not run the installed probe copy"
+  fi
+  [ "$(notify_count "$dir/notify.log")" -eq 1 ] || fail "installer did not send its mandatory canary"
+  sed -i.bak 's/COOLDOWN_SECS=1800/COOLDOWN_SECS=42/' "$install/deadman.env"
+  rm -f "$install/deadman.env.bak"
+  FM_DEADMAN_INSTALL_DIR="$install" FM_DEADMAN_PLIST="$plist" \
+    FM_DEADMAN_NOTIFY_EXEC="$NOTIFIER" FM_TEST_NOTIFY_LOG="$dir/notify.log" \
+    "$ROOT/bin/fm-deadman-install.sh" --channel command:true >/dev/null
+  grep -Fx 'COOLDOWN_SECS=42' "$install/deadman.env" >/dev/null || fail "installer update replaced existing timing configuration"
+  if command -v plutil >/dev/null 2>&1; then
+    plutil -lint "$plist" >/dev/null || fail "installed plist failed plutil lint"
+  fi
+  pass "installer writes a valid stable-copy LaunchAgent and sends a canary"
+}
+
+test_age_boundary_and_double_sample
+test_missing_future_and_unreadable
+test_flap_resets_confirmation
+test_cooldown_and_failed_delivery
+test_first_arm_and_sleep_wake_grace
+test_hostile_config_is_data
+test_notify_only_and_concurrent_lock
+test_installer_and_plist

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -138,7 +138,7 @@ Two choices remain unresolved: the route and the sample access level.
 A separate recommendation is already resolved and requires no captain action.
 EOF
 
-  if run_decisions "$home" complete "$id" route access > "$home/early-complete.out" 2> "$home/early-complete.err"; then
+  if run_decisions "$home" complete "$id" route access --no-ideas > "$home/early-complete.out" 2> "$home/early-complete.err"; then
     fail "completion succeeded before unresolved decisions had captain holds"
   fi
   assert_no_grep "decisions_reviewed=1" "$home/state/$id.meta" \
@@ -151,7 +151,7 @@ EOF
   run_decisions "$home" hold "$id" route \
     --title "Choose the sample route" --reason "captain route choice pending" --repo sample >/dev/null \
     || fail "idempotent hold retry failed"
-  if run_decisions "$home" complete "$id" route access > "$home/partial-complete.out" 2> "$home/partial-complete.err"; then
+  if run_decisions "$home" complete "$id" route access --no-ideas > "$home/partial-complete.out" 2> "$home/partial-complete.err"; then
     fail "completion succeeded while one of two distinct decisions lacked a hold"
   fi
   access_hold=$(run_decisions "$home" hold "$id" access \
@@ -163,10 +163,15 @@ EOF
   [ "$(grep -cE "^- \[ \] $access_hold -" "$home/data/backlog.md")" = 1 ] \
     || fail "second decision did not retain one distinct backlog identity"
 
-  run_decisions "$home" complete "$id" route access >/dev/null \
+  run_decisions "$home" complete "$id" route access --no-ideas >/dev/null \
     || fail "shared investigation completion gate failed"
   assert_grep "decisions_reviewed=1" "$home/state/$id.meta" "completion attestation missing"
   assert_grep "decision_keys=access,route" "$home/state/$id.meta" "decision inventory was not deterministic"
+  assert_grep "ideas_reviewed=1" "$home/state/$id.meta" "no-idea attestation missing"
+  run_decisions "$home" complete "$id" route --no-ideas >/dev/null \
+    || fail "idempotent completion retry failed"
+  [ "$(grep '^decision_keys=' "$home/state/$id.meta" | tail -1)" = "decision_keys=access,route" ] \
+    || fail "completion retry did not preserve the unioned decision inventory"
   open=$(bash -c '. "$1"; status_open_decisions "$2"' _ \
     "$ROOT/bin/fm-classify-lib.sh" "$home/state/$id.status")
   [ -z "$open" ] || fail "captain-held transfer did not close duplicate live status decisions: $open"
@@ -310,7 +315,7 @@ test_origin_slug_validation_precedes_path_construction() {
   home=$(make_home origin-validation)
   escaped="$home/escaped-origin.meta"
   printf 'sentinel=unchanged\n' > "$escaped"
-  if run_decisions "$home" complete ../escaped-origin --none \
+  if run_decisions "$home" complete ../escaped-origin --none --no-ideas \
     > "$home/invalid-complete.out" 2> "$home/invalid-complete.err"; then
     fail "completion accepted an origin path traversal"
   fi
@@ -332,7 +337,7 @@ test_visual_review_uses_shared_completion_owner() {
   write_origin_meta "$home" "$id"
   printf 'done: investigation complete\n' > "$home/state/$id.status"
   printf '# Sample board investigation\n\nThe initial findings need no captain choice.\n' > "$home/data/$id/report.md"
-  run_decisions "$home" complete "$id" --none >/dev/null \
+  run_decisions "$home" complete "$id" --none --no-ideas >/dev/null \
     || fail "initial investigation could not pass the shared completion owner"
   run_teardown "$home" "$id" >/dev/null 2> "$home/visual-teardown.err" \
     || fail "completed investigation teardown failed: $(cat "$home/visual-teardown.err")"
@@ -343,7 +348,7 @@ test_visual_review_uses_shared_completion_owner() {
   hold=$(run_decisions "$home" hold "$id" layout \
     --title "Choose the sample layout" --reason "captain layout choice pending" --repo sample) \
     || fail "post-teardown visual review could not use the shared hold owner"
-  run_decisions "$home" complete "$id" layout >/dev/null \
+  run_decisions "$home" complete "$id" layout --no-ideas >/dev/null \
     || fail "post-teardown visual review could not use the shared completion owner"
   [ "$hold" = "$id-decision-layout" ] || fail "visual review used a separate identity policy"
   json=$(run_bearings "$home") || fail "Bearings failed after the ended visual review"
@@ -370,7 +375,7 @@ test_none_inventory_and_resolved_prose_do_not_create_holds() {
 Decision record: the earlier choice is resolved.
 The recommendation is informational and needs no captain action.
 EOF
-  run_decisions "$home" complete "$id" --none >/dev/null \
+  run_decisions "$home" complete "$id" --none --no-ideas >/dev/null \
     || fail "explicit no-decision inventory failed"
   json=$(run_bearings "$home") || fail "Bearings failed for no-decision inventory"
   printf '%s' "$json" | jq -e '
@@ -392,7 +397,7 @@ test_terminal_single_owner_status_decision_does_not_block_empty_inventory() {
   open=$(bash -c '. "$1"; status_open_decisions "$2"' _ \
     "$ROOT/bin/fm-classify-lib.sh" "$home/state/$id.status")
   assert_contains "$open" "default" "fixture must retain the raw stale status decision"
-  run_decisions "$home" complete "$id" --none >/dev/null \
+  run_decisions "$home" complete "$id" --none --no-ideas >/dev/null \
     || fail "terminal single-owner stale status decision blocked empty inventory completion"
   run_decisions "$home" verify "$id" >/dev/null \
     || fail "terminal single-owner stale status decision blocked inventory verification"
@@ -403,7 +408,7 @@ test_terminal_single_owner_status_decision_does_not_block_empty_inventory() {
   write_origin_meta "$home" "$secondmate" secondmate
   printf 'needs-decision [key=route]: choose route A or route B\ndone: heartbeat complete\n' \
     > "$home/state/$secondmate.status"
-  if run_decisions "$home" complete "$secondmate" --none \
+  if run_decisions "$home" complete "$secondmate" --none --no-ideas \
     > "$home/secondmate-terminal.out" 2> "$home/secondmate-terminal.err"; then
     fail "secondmate terminal status decision was incorrectly cleared"
   fi
@@ -436,7 +441,7 @@ EOF
   hold=$(run_decisions "$mate" hold "$origin" release \
     --title "Choose the sample release" --reason "captain release choice pending" --repo sample) \
     || fail "secondmate-owned hold creation failed"
-  run_decisions "$mate" complete "$origin" release >/dev/null \
+  run_decisions "$mate" complete "$origin" release --no-ideas >/dev/null \
     || fail "secondmate-owned completion failed"
   run_teardown "$mate" "$origin" >/dev/null 2> "$mate/teardown.err" \
     || fail "secondmate investigation teardown failed: $(cat "$mate/teardown.err")"
@@ -550,6 +555,344 @@ test_resolve_matches_quoted_blocked_by_edges() {
   pass "resolve matches first/middle/last in quoted blocked_by and rejects a genuinely absent id"
 }
 
+test_product_idea_attestation_contract() {
+  local home origin grandfather absent wrong matching shapes private private_origin private_mode private_dir_mode
+  home=$(make_home idea-attestation)
+  origin=sample-idea-review
+  mkdir -p "$home/data/$origin"
+  write_origin_meta "$home" "$origin"
+  printf '# Sample idea review\n\n## Ideas\nA useful product idea.\n' > "$home/data/$origin/report.md"
+
+  if run_decisions "$home" complete "$origin" --none > "$home/missing.out" 2> "$home/missing.err"; then
+    fail "completion succeeded without the required idea attestation"
+  fi
+  assert_grep "idea attestation is required" "$home/missing.err" \
+    "missing idea attestation did not name the requirement"
+  if run_decisions "$home" complete "$origin" --none route --no-ideas \
+    > "$home/decision-combo.out" 2> "$home/decision-combo.err"; then
+    fail "--none combined with a decision key"
+  fi
+  assert_grep "--none cannot be combined" "$home/decision-combo.err" \
+    "invalid decision combination was not explained"
+  if run_decisions "$home" complete "$origin" --none --no-ideas PI-001 \
+    > "$home/idea-combo.out" 2> "$home/idea-combo.err"; then
+    fail "--no-ideas accepted an idea id"
+  fi
+  assert_grep "--no-ideas must follow" "$home/idea-combo.err" \
+    "invalid idea combination was not explained"
+  if run_decisions "$home" complete "$origin" --none --ideas \
+    > "$home/empty-ideas.out" 2> "$home/empty-ideas.err"; then
+    fail "--ideas accepted an empty id inventory"
+  fi
+  assert_grep "--ideas requires at least one" "$home/empty-ideas.err" \
+    "empty --ideas inventory was not explained"
+  if run_decisions "$home" complete "$origin" --none --ideas PI-001 --no-ideas \
+    > "$home/mixed-ideas.out" 2> "$home/mixed-ideas.err"; then
+    fail "--ideas combined with --no-ideas"
+  fi
+  assert_grep "--ideas cannot be combined with --no-ideas" "$home/mixed-ideas.err" \
+    "mixed idea attestations were not explained"
+
+  run_decisions "$home" complete "$origin" --none --no-ideas >/dev/null \
+    || fail "explicit no-idea attestation failed"
+  assert_present "$home/data/product-ideas.md" "no-idea completion did not create the ledger lazily"
+  assert_grep "Status: unscheduled | parked (captain <date>) | scheduled -> <task-id>" \
+    "$home/data/product-ideas.md" "lazy ledger template did not define the status contract"
+  assert_grep "ideas_reviewed=1" "$home/state/$origin.meta" "idea review marker was not persisted"
+  assert_grep "idea_ids=" "$home/state/$origin.meta" "empty idea id inventory was not persisted"
+  run_decisions "$home" verify "$origin" >/dev/null || fail "no-idea completion did not verify"
+
+  private=$(make_home private-idea-ledger)
+  private_origin='private-ledger-review'
+  rm -rf "$private/data"
+  write_origin_meta "$private" "$private_origin"
+  ( umask 000
+    run_decisions "$private" complete "$private_origin" --none --no-ideas >/dev/null
+  ) || fail "private ledger creation failed under a permissive caller umask"
+  # Platform-detect stat(1): GNU treats -f as --file-system and can emit a dump
+  # before failing, so never use the `stat -f || stat -c` fallback here.
+  if [ "$(uname)" = Darwin ]; then
+    private_mode=$(stat -f %Lp "$private/data/product-ideas.md")
+    private_dir_mode=$(stat -f %Lp "$private/data")
+  else
+    private_mode=$(stat -c %a "$private/data/product-ideas.md")
+    private_dir_mode=$(stat -c %a "$private/data")
+  fi
+  [ "$private_mode" = 600 ] \
+    || fail "lazy ledger was not private under permissive umask: $private_mode"
+  [ "$private_dir_mode" = 700 ] \
+    || fail "lazy data dir was not private under permissive umask: $private_dir_mode"
+
+  cat >> "$home/data/product-ideas.md" <<EOF
+| PI-001 | Add a sample route preview | unscheduled | data/$origin/report.md#Ideas |
+| PI-002 | Add a sample route comparison | parked (captain 2026-08-10) | data/$origin/report.md#Ideas |
+EOF
+  run_decisions "$home" complete "$origin" --none --ideas PI-001 >/dev/null \
+    || fail "matching idea row did not pass completion"
+  run_decisions "$home" complete "$origin" --none --ideas PI-002 >/dev/null \
+    || fail "idempotent idea re-completion failed"
+  [ "$(grep '^idea_ids=' "$home/state/$origin.meta" | tail -1)" = "idea_ids=PI-001,PI-002" ] \
+    || fail "idea re-completion did not preserve the unioned inventory"
+  run_decisions "$home" verify "$origin" >/dev/null || fail "persisted idea inventory did not verify"
+
+  absent=$(make_home absent-idea-ledger)
+  mkdir -p "$absent/data/$origin"
+  write_origin_meta "$absent" "$origin"
+  printf '# Report\n\n## Ideas\nMissing ledger.\n' > "$absent/data/$origin/report.md"
+  if run_decisions "$absent" complete "$origin" --none --ideas PI-001 \
+    > "$absent/absent.out" 2> "$absent/absent.err"; then
+    fail "named idea passed with no ledger"
+  fi
+  assert_grep "product idea ledger is absent" "$absent/absent.err" \
+    "absent ledger failure did not name the requirement"
+
+  matching=$(make_home missing-idea-row)
+  mkdir -p "$matching/data/$origin"
+  write_origin_meta "$matching" "$origin"
+  printf '# Report\n\n## Ideas\nMissing row.\n' > "$matching/data/$origin/report.md"
+  run_decisions "$matching" complete "$origin" --none --no-ideas >/dev/null
+  if run_decisions "$matching" complete "$origin" --none --ideas PI-009 \
+    > "$matching/missing-row.out" 2> "$matching/missing-row.err"; then
+    fail "named idea passed without its row"
+  fi
+  assert_grep "product idea PI-009 is missing" "$matching/missing-row.err" \
+    "missing idea row failure was not explicit"
+
+  wrong=$(make_home wrong-idea-source)
+  mkdir -p "$wrong/data/$origin"
+  write_origin_meta "$wrong" "$origin"
+  printf '# Report\n\n## Ideas\nWrong source.\n' > "$wrong/data/$origin/report.md"
+  run_decisions "$wrong" complete "$origin" --none --no-ideas >/dev/null
+  printf '| PI-001 | Wrongly sourced idea | unscheduled | data/another-review/report.md#Ideas |\n' \
+    >> "$wrong/data/product-ideas.md"
+  if run_decisions "$wrong" complete "$origin" --none --ideas PI-001 \
+    > "$wrong/wrong-source.out" 2> "$wrong/wrong-source.err"; then
+    fail "idea row citing another origin passed"
+  fi
+  assert_grep "must have one well-formed row whose Source cites data/$origin/report.md" "$wrong/wrong-source.err" \
+    "wrong idea source failure did not name the origin-bound requirement"
+
+  shapes=$(make_home invalid-idea-shapes)
+  mkdir -p "$shapes/data/$origin"
+  write_origin_meta "$shapes" "$origin"
+  printf '# Report\n\n## Ideas\nShape cases.\n' > "$shapes/data/$origin/report.md"
+  run_decisions "$shapes" complete "$origin" --none --no-ideas >/dev/null
+  cp "$shapes/data/product-ideas.md" "$shapes/ledger-template.md"
+  printf '| PI-001 |  | unscheduled | data/%s/report.md#Ideas |\n' "$origin" \
+    >> "$shapes/data/product-ideas.md"
+  if run_decisions "$shapes" complete "$origin" --none --ideas PI-001 \
+    > "$shapes/empty-idea.out" 2> "$shapes/empty-idea.err"; then
+    fail "empty idea text passed completion"
+  fi
+  assert_grep "must have one well-formed row" "$shapes/empty-idea.err" \
+    "empty idea text failure was not explicit"
+  cp "$shapes/ledger-template.md" "$shapes/data/product-ideas.md"
+  printf '| PI-001 | Idea with bad status | pending | data/%s/report.md#Ideas |\n' "$origin" \
+    >> "$shapes/data/product-ideas.md"
+  if run_decisions "$shapes" complete "$origin" --none --ideas PI-001 \
+    > "$shapes/bad-status.out" 2> "$shapes/bad-status.err"; then
+    fail "non-contract status passed completion"
+  fi
+  assert_grep "must have one well-formed row" "$shapes/bad-status.err" \
+    "invalid status failure was not explicit"
+  cp "$shapes/ledger-template.md" "$shapes/data/product-ideas.md"
+  printf '| PI-001 | Idea with spaced heading | unscheduled | data/%s/report.md# Ideas |\n' "$origin" \
+    >> "$shapes/data/product-ideas.md"
+  if run_decisions "$shapes" complete "$origin" --none --ideas PI-001 \
+    > "$shapes/bad-source.out" 2> "$shapes/bad-source.err"; then
+    fail "source with space after # passed completion"
+  fi
+  assert_grep "must have one well-formed row" "$shapes/bad-source.err" \
+    "invalid source shape failure was not explicit"
+  cp "$shapes/ledger-template.md" "$shapes/data/product-ideas.md"
+  printf '| PI-001 | Idea with GitHub line pointer | unscheduled | data/%s/report.md#L12 |\n' "$origin" \
+    >> "$shapes/data/product-ideas.md"
+  if run_decisions "$shapes" complete "$origin" --none --ideas PI-001 \
+    > "$shapes/line-source.out" 2> "$shapes/line-source.err"; then
+    fail "source with #L12 line pointer passed completion"
+  fi
+  assert_grep "must have one well-formed row" "$shapes/line-source.err" \
+    "line-number source failure was not explicit"
+  cp "$shapes/ledger-template.md" "$shapes/data/product-ideas.md"
+  printf '| PI-001 | Idea with bare numeric pointer | unscheduled | data/%s/report.md#12 |\n' "$origin" \
+    >> "$shapes/data/product-ideas.md"
+  if run_decisions "$shapes" complete "$origin" --none --ideas PI-001 \
+    > "$shapes/bare-line-source.out" 2> "$shapes/bare-line-source.err"; then
+    fail "source with bare #12 line pointer passed completion"
+  fi
+  assert_grep "must have one well-formed row" "$shapes/bare-line-source.err" \
+    "bare line-number source failure was not explicit"
+  cp "$shapes/ledger-template.md" "$shapes/data/product-ideas.md"
+  printf '| PI-001 | Idea with line range pointer | unscheduled | data/%s/report.md#L12-L20 |\n' "$origin" \
+    >> "$shapes/data/product-ideas.md"
+  if run_decisions "$shapes" complete "$origin" --none --ideas PI-001 \
+    > "$shapes/line-range-source.out" 2> "$shapes/line-range-source.err"; then
+    fail "source with #L12-L20 line range passed completion"
+  fi
+  assert_grep "must have one well-formed row" "$shapes/line-range-source.err" \
+    "line-range source failure was not explicit"
+  cp "$shapes/ledger-template.md" "$shapes/data/product-ideas.md"
+  printf '| PI-001 | Idea with terminal colon line pointer | unscheduled | data/%s/report.md#Ideas:12 |\n' "$origin" \
+    >> "$shapes/data/product-ideas.md"
+  if run_decisions "$shapes" complete "$origin" --none --ideas PI-001 \
+    > "$shapes/colon-line-source.out" 2> "$shapes/colon-line-source.err"; then
+    fail "source with terminal #Ideas:12 line pointer passed completion"
+  fi
+  assert_grep "must have one well-formed row" "$shapes/colon-line-source.err" \
+    "terminal colon line-number source failure was not explicit"
+  cp "$shapes/ledger-template.md" "$shapes/data/product-ideas.md"
+  printf '| PI-001 | Idea under quarterly heading | unscheduled | data/%s/report.md#Q2:2026-plan |\n' "$origin" \
+    >> "$shapes/data/product-ideas.md"
+  run_decisions "$shapes" complete "$origin" --none --ideas PI-001 >/dev/null \
+    || fail "origin-bound source with #Q2:2026-plan heading was refused"
+  cp "$shapes/ledger-template.md" "$shapes/data/product-ideas.md"
+  printf '| PI-001 | Idea under phased heading | unscheduled | data/%s/report.md#Phase:1-rollout |\n' "$origin" \
+    >> "$shapes/data/product-ideas.md"
+  run_decisions "$shapes" complete "$origin" --none --ideas PI-001 >/dev/null \
+    || fail "origin-bound source with #Phase:1-rollout heading was refused"
+  cp "$shapes/ledger-template.md" "$shapes/data/product-ideas.md"
+  printf '| PI-001 | Good target idea | unscheduled | data/%s/report.md#Ideas |\n' "$origin" \
+    >> "$shapes/data/product-ideas.md"
+  printf '| PI-002 | Sibling with bad status | pending | data/%s/report.md#Ideas |\n' "$origin" \
+    >> "$shapes/data/product-ideas.md"
+  if run_decisions "$shapes" complete "$origin" --none --ideas PI-001 \
+    > "$shapes/sibling-bad.out" 2> "$shapes/sibling-bad.err"; then
+    fail "well-formed target row hid a malformed sibling"
+  fi
+  assert_grep "must have one well-formed row" "$shapes/sibling-bad.err" \
+    "malformed sibling failure was not explicit"
+  cp "$shapes/ledger-template.md" "$shapes/data/product-ideas.md"
+  printf '| PI-001 | Good target idea | unscheduled | data/%s/report.md#Ideas |\n' "$origin" \
+    >> "$shapes/data/product-ideas.md"
+  printf 'not a table row\n' >> "$shapes/data/product-ideas.md"
+  if run_decisions "$shapes" complete "$origin" --none --ideas PI-001 \
+    > "$shapes/junk-line.out" 2> "$shapes/junk-line.err"; then
+    fail "well-formed target row hid non-table junk"
+  fi
+  assert_grep "must have one well-formed row" "$shapes/junk-line.err" \
+    "junk-line ledger failure was not explicit"
+  printf '# Product ideas\n\n| PI-001 | Headerless good idea | unscheduled | data/%s/report.md#Ideas |\n' \
+    "$origin" > "$shapes/data/product-ideas.md"
+  if run_decisions "$shapes" complete "$origin" --none --ideas PI-001 \
+    > "$shapes/headerless.out" 2> "$shapes/headerless.err"; then
+    fail "headerless ledger with a good target row passed completion"
+  fi
+  assert_grep "must have one well-formed row" "$shapes/headerless.err" \
+    "headerless ledger failure was not explicit"
+
+  grandfather=$(make_home grandfathered-idea-gate)
+  write_origin_meta "$grandfather" pre-upgrade-review
+  printf 'decisions_reviewed=1\ndecision_keys=\n' >> "$grandfather/state/pre-upgrade-review.meta"
+  run_decisions "$grandfather" verify pre-upgrade-review >/dev/null \
+    || fail "pre-upgrade decision completion was not grandfathered"
+  assert_absent "$grandfather/data/product-ideas.md" \
+    "grandfathered verification unexpectedly created a ledger"
+
+  pass "product idea attestations are origin-bound, persisted, idempotent, lazy, and grandfather-safe"
+}
+
+test_secondmate_idea_inventory_and_bearings_count() {
+  local main mate origin json template
+  main=$(make_home idea-count-main)
+  mate=$(make_home idea-count-mate)
+  printf '# Synthetic secondmate home\n' > "$mate/AGENTS.md"
+  printf 'sample-mate\n' > "$mate/.fm-secondmate-home"
+  origin=sample-mate-ideas
+  mkdir -p "$mate/data/$origin"
+  write_origin_meta "$mate" "$origin"
+  printf '# Mate report\n\n## Product ideas\nMate idea detail.\n' > "$mate/data/$origin/report.md"
+  run_decisions "$mate" complete "$origin" --none --no-ideas >/dev/null
+  printf '| PI-003 | Mate-only sample idea | unscheduled | data/%s/report.md#Product-ideas |\n' "$origin" \
+    >> "$mate/data/product-ideas.md"
+  run_decisions "$mate" complete "$origin" --none --ideas PI-003 >/dev/null \
+    || fail "secondmate-home idea did not verify against its own ledger"
+  assert_absent "$main/data/product-ideas.md" "secondmate idea leaked into the main ledger"
+
+  mkdir -p "$main/data/main-idea-review"
+  write_origin_meta "$main" main-idea-review
+  printf '# Main report\n\n## Ideas\nMain idea detail.\n' > "$main/data/main-idea-review/report.md"
+  run_decisions "$main" complete main-idea-review --none --no-ideas >/dev/null
+  printf '| PI-001 | Main sample idea | unscheduled | data/main-idea-review/report.md#Ideas |\n' \
+    >> "$main/data/product-ideas.md"
+  printf -- '- sample-mate - synthetic scope (home: %s; scope: sample reviews; projects: sample; added 2026-07-14)\n' \
+    "$mate" > "$main/data/secondmates.md"
+  fm_write_secondmate_meta "$main/state/sample-mate.meta" "$mate" \
+    "firstmate:fm-sample-mate" sample
+
+  json=$(run_bearings "$main") || fail "Bearings could not count home idea ledgers"
+  printf '%s' "$json" | jq -e '.ideas_unscheduled == 2 and (.ideas_warnings | length) == 0' >/dev/null \
+    || fail "Bearings did not combine readable home idea counts: $json"
+
+  template="$main/product-ideas-template.md"
+  cp "$main/data/product-ideas.md" "$template"
+  printf 'not a product idea ledger\n' > "$main/data/product-ideas.md"
+  json=$(run_bearings "$main") || fail "Bearings crashed on a malformed idea ledger"
+  printf '%s' "$json" | jq -e '
+    .ideas_unscheduled == 1
+      and (.ideas_warnings | any(.home == "(main)" and .reason == "ledger is malformed"))
+  ' >/dev/null || fail "Bearings silently counted a malformed ledger as zero: $json"
+
+  cp "$template" "$main/data/product-ideas.md"
+  chmod 000 "$mate/data/product-ideas.md"
+  json=$(run_bearings "$main") || fail "Bearings crashed on an unreadable idea ledger"
+  printf '%s' "$json" | jq -e '
+    .ideas_unscheduled == 1
+      and (.ideas_warnings | any(.home == "sample-mate" and .reason == "ledger is unreadable"))
+  ' >/dev/null || fail "Bearings silently counted an unreadable ledger as zero: $json"
+  chmod 600 "$mate/data/product-ideas.md"
+
+  chmod 000 "$main/data/secondmates.md"
+  json=$(run_bearings "$main") || fail "Bearings crashed when the secondmate registry was unreadable"
+  printf '%s' "$json" | jq -e '
+    (.ideas_warnings | any(.home == "(registry)" and (.reason | startswith("registry unavailable:"))))
+  ' >/dev/null || fail "Bearings hid an unavailable registry from ideas_warnings: $json"
+  chmod 600 "$main/data/secondmates.md"
+
+  printf -- '- sample-mate - synthetic scope (home: %s; scope: sample reviews; projects: sample; added 2026-07-14)\n' \
+    "$mate" > "$main/data/secondmates.md"
+  printf -- '- extra-mate - synthetic scope (home: %s; scope: more reviews; projects: sample; added 2026-07-14)\n' \
+    "$mate" >> "$main/data/secondmates.md"
+  json=$(FM_SNAPSHOT_REGISTRY_RECORDS=1 PATH="$main/fakebin:$PATH" FM_HOME="$main" \
+    FM_BEARINGS_NOW=2026-07-14T12:00:00Z "$BEARINGS" --json) \
+    || fail "Bearings crashed when registry records were truncated"
+  printf '%s' "$json" | jq -e '
+    (.ideas_warnings | any(.home == "(registry)" and .reason == "registry records were truncated"))
+  ' >/dev/null || fail "Bearings hid truncated registry records from ideas_warnings: $json"
+
+  json=$(FM_SNAPSHOT_REGISTRY_LINES=1 PATH="$main/fakebin:$PATH" FM_HOME="$main" \
+    FM_BEARINGS_NOW=2026-07-14T12:00:00Z "$BEARINGS" --json) \
+    || fail "Bearings crashed when registry input was truncated"
+  printf '%s' "$json" | jq -e '
+    (.ideas_warnings | any(.home == "(registry)" and .reason == "registry input was truncated"))
+  ' >/dev/null || fail "Bearings hid truncated registry input from ideas_warnings: $json"
+
+  override=$(make_home idea-data-override)
+  alt_data="$override/alt-data"
+  mkdir -p "$alt_data" "$override/data"
+  cat > "$alt_data/product-ideas.md" <<'EOF'
+# Product ideas
+
+| ID | Idea | Status | Source |
+| --- | --- | --- | --- |
+| PI-007 | Override-only idea | unscheduled | data/main-idea-review/report.md#Ideas |
+EOF
+  cat > "$override/data/product-ideas.md" <<'EOF'
+# Product ideas
+
+| ID | Idea | Status | Source |
+| --- | --- | --- | --- |
+| PI-008 | Default-path decoy | unscheduled | data/main-idea-review/report.md#Ideas |
+| PI-009 | Second default-path decoy | unscheduled | data/main-idea-review/report.md#Ideas |
+EOF
+  json=$(PATH="$override/fakebin:$PATH" FM_HOME="$override" FM_DATA_OVERRIDE="$alt_data" \
+    FM_BEARINGS_NOW=2026-07-14T12:00:00Z "$BEARINGS" --json) \
+    || fail "Bearings crashed with FM_DATA_OVERRIDE for the main idea ledger"
+  printf '%s' "$json" | jq -e '.ideas_unscheduled == 1' >/dev/null \
+    || fail "Bearings ignored roots.data for the main idea ledger: $json"
+
+  pass "secondmate ideas stay home-local and Bearings discloses complete and incomplete counts"
+}
+
 test_uninventoried_report_decision_refuses_completion
 
 test_scout_teardown_always_requires_inventory_verification
@@ -560,3 +903,5 @@ test_none_inventory_and_resolved_prose_do_not_create_holds
 test_terminal_single_owner_status_decision_does_not_block_empty_inventory
 test_secondmate_hold_stays_in_authoritative_home
 test_resolve_matches_quoted_blocked_by_edges
+test_product_idea_attestation_contract
+test_secondmate_idea_inventory_and_bearings_count

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -867,6 +867,8 @@ SH
   grep -qF "watcher: started pid=$successor_pid" "$armout" || fail "successor ledger cycle did not start"
   grep -q "arm_pid=$first_arm.*successor=started:$successor_pid" "$state/.watch-cycle-exits.log" \
     || fail "predecessor ledger record was not linked to its verified successor"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" >/dev/null \
+    || fail "could not consume the handled wake before unrelated bounded ledger cycles"
   kill -HUP "$successor_arm" 2>/dev/null || true
   wait "$successor_arm" 2>/dev/null || true
   # The forced interruption is a watcher-down interval. Consume the prior


### PR DESCRIPTION
## Intent

Implement the Studio launchd deadman per the locked engineering plan and captain approval H3 deadman=yes. Ship Firstmate-owned source in bin/: a notify-only fm-deadman.sh probe, an atomic installer and LaunchAgent plist that run stable copies under ~/Library/Application Support/Firstmate/deadman rather than a live checkout, a small shared notification library using the existing wedge-alarm channel grammar, operator documentation, and behavioral tests. Hard-page only on the single configured FM_HOME watcher beacon freshness path: age greater than 600 seconds by default and a second unhealthy observation 60-120 seconds later; treat future timestamps and missing or unreadable home/beacon as unhealthy; include first-arm and sleep/wake grace; rate-limit only successful pages for 30 minutes by default, while failed notifications do not consume cooldown. Keep config, cooldown, confirmation, and journal outside FM_HOME. Bad config must self-fault nonzero while normal probe paths remain zero. The deadman must never spawn work, push, merge, publish, restart Firstmate/Herdr/watcher/no-mistakes, or mutate fleet work. Include a mandatory canary before optional launchctl bootstrap, but do not install or bootstrap the live Studio from CI or this task. Tailscale/SSH :2222, multi-home scanning, and phone vendor SDKs beyond command: remain out of scope. Preserve existing wedge-alarm behavior and tests, use no-mistakes through a green PR, and never merge the PR.

## What Changed
- Add a notify-only Studio launchd deadman (`bin/fm-deadman.sh`, atomic installer, LaunchAgent plist, shared `fm-notify-lib.sh`) that hard-pages only after double-confirmed watcher-beacon staleness, keeps config/state outside `FM_HOME`, canary-gates optional bootstrap, and ships operator docs plus behavioral tests
- Require product-idea capture on decision-hold complete, surface unscheduled ideas and named missing/unreadable secondmate homes in bearings, and redeliver undrained queued wakes
- Add local operator skills (wayfinder, grilling, codebase-design, domain-modeling, and related) and ignore `.gstack`

## Risk Assessment

✅ Low: Deadman feature matches the locked intent, and the four prior review defects are closed in source with no remaining reachable sibling failure paths of the same class.

## Testing

`Ran the focused deadman behavioral suite (all ok), re-ran the shared wedge-alarm notify tests after the fm-notify-lib extraction (20/20 ok), and manually installed a stable-copy LaunchAgent into a temp Application Support tree without live bootstrap—confirming canary delivery, hard-page only after age>600 with a second sample at 60s, cooldown/failed-notify rules, grace windows, config self-faults, notify-only behavior, and state kept outside FM_HOME.`

<details>
<summary>Evidence: Evidence summary (automated + operator E2E results)</summary>

```text
Studio launchd deadman — test evidence
=====================================

1) Automated behavioral suite: tests/fm-deadman.test.sh
   ok - staleness is age > N and requires two samples 60-120 seconds apart
   ok - missing, unreadable, and future beacon inputs are unhealthy
   ok - a healthy flap resets stale confirmation
   fm-notify: notifier override exited 1 for channel 'command'
   ok - only successful delivery consumes the page cooldown
   ok - first-arm and inferred sleep/wake gaps defer pages
   ok - configuration is parsed as allowlisted data, never sourced
   ok - probe is notify-only; concurrent probes serialize; canary fails closed on lock
   ok - TERM cleanup reaps notifier, releases lock, exits nonzero; normal exit stays zero
   ok - installer writes a valid stable-copy LaunchAgent and sends a canary

2) Wedge-alarm regression (shared notify grammar via fm-notify-lib.sh): 20 tests
   all passed (20 ok lines)

3) Operator E2E against installed stable copies (no live launchctl bootstrap)
   RESULT:stable_copy_ok
   RESULT:healthy_silent_ok
   RESULT:stale_page_ok
   RESULT:cooldown_ok
   RESULT:failed_notify_no_cooldown_ok
   RESULT:retry_page_ok
   RESULT:future_page_ok
   RESULT:missing_home_page_ok
   RESULT:first_arm_grace_ok
   RESULT:wake_grace_ok
   RESULT:hostile_not_executed_ok
   RESULT:self_fault_ok
   RESULT:notify_only_ok
   RESULT:state_outside_home_ok
   RESULT:canary_gate_ok
   RESULT:single_page_ok (section C body + journal show one page; demo marker grep was harness noise)

4) Operator-visible notification samples (real command: channel, $1 + stdin):
   - FIRSTMATE DEADMAN CANARY - notification path is working for /var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/home
   - FIRSTMATE DEADMAN: watcher beacon stale for 760s: /var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/home/state/.last-watcher-beat; scheduling path may be stopped
   - FIRSTMATE DEADMAN: watcher beacon stale for 2820s: /var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/home/state/.last-watcher-beat; scheduling path may be stopped
   - FIRSTMATE DEADMAN: watcher beacon stale for 3000000059s: /var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/home/state/.last-watcher-beat; scheduling path may be stopped

5) Artifacts:
   - fm-deadman-test-transcript.txt
   - operator-e2e-transcript.txt
   - wedge-alarm-regression.txt
   - installed-deadman.env / .conf / .journal
   - com.firstmate.deadman.plist + plist-decoded.txt
   - operator-e2e/ tree with install layout
```
</details>
<details>
<summary>Evidence: fm-deadman.test.sh full transcript</summary>

```text
ok - staleness is age > N and requires two samples 60-120 seconds apart
ok - missing, unreadable, and future beacon inputs are unhealthy
ok - a healthy flap resets stale confirmation
fm-notify: notifier override exited 1 for channel 'command'
ok - only successful delivery consumes the page cooldown
ok - first-arm and inferred sleep/wake gaps defer pages
ok - configuration is parsed as allowlisted data, never sourced
ok - probe is notify-only; concurrent probes serialize; canary fails closed on lock
ok - TERM cleanup reaps notifier, releases lock, exits nonzero; normal exit stays zero
ok - installer writes a valid stable-copy LaunchAgent and sends a canary
```
</details>
<details>
<summary>Evidence: Operator E2E transcript (install, canary, stale page, graces, self-fault, no-spawn)</summary>

```text
######################################################################
# Studio deadman operator E2E (no live launchctl bootstrap)
######################################################################

## A. Install stable copies + mandatory canary (no --bootstrap)
Sending required deadman canary before launchd bootstrap...
Canary delivery succeeded.
Installed but not bootstrapped. Re-run with --bootstrap after reviewing the canary.
install_exit=0

### operator canary notification content
argv1_summary=FIRSTMATE DEADMAN CANARY - notification path is working for /var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/home
stdin_body=FIRSTMATE DEADMAN CANARY - notification path is working for /var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/home


### installed layout
/var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/Application Support/Firstmate/deadman/deadman.conf
/var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/Application Support/Firstmate/deadman/deadman.env
/var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/Application Support/Firstmate/deadman/deadman.journal
/var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/Application Support/Firstmate/deadman/fm-deadman.sh
/var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/Application Support/Firstmate/deadman/fm-notify-lib.sh
/var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/Application Support/Firstmate/deadman/installed-at
/var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/LaunchAgents/com.firstmate.deadman.plist

### deadman.env (timing defaults)
FM_HOME=/var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/home
STALE_AFTER_SECS=600
SAMPLE_GAP_SECS=60
SAMPLE_MAX_GAP_SECS=120
FIRST_ARM_GRACE_SECS=660
WAKE_GRACE_SECS=300
SLEEP_GAP_DETECT_SECS=180
COOLDOWN_SECS=1800

### deadman.conf
command:/var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/bin/phone-notify "$1"

### plist ProgramArguments points at stable copy
/var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/Application Support/Firstmate/deadman/fm-deadman.sh
expected=/var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/Application Support/Firstmate/deadman/fm-deadman.sh
/var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/LaunchAgents/com.firstmate.deadman.plist: OK
RESULT:stable_copy_ok

## B. Healthy watcher remains silent
healthy1_exit=0
healthy2_exit=0
notification_count=0
RESULT:healthy_silent_ok

## C. Hard-page only after age>600 and second sample 60-120s later
sample1_exit=0
after_sample1 notifications=0
first-stale=2000000000|beacon-stale
sample_59s_exit=0
after_59s notifications=0
sample_60s_exit=0
after_60s notifications=0
### page content delivered to operator channel
argv1_summary=FIRSTMATE DEADMAN: watcher beacon stale for 760s: /var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/home/state/.last-watcher-beat; scheduling path may be stopped
stdin_body=FIRSTMATE DEADMAN: watcher beacon stale for 760s: /var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/home/state/.last-watcher-beat; scheduling path may be stopped

### journal
1786434638	canary notification succeeded
2000000000	first unhealthy sample: beacon-stale
2000000060	page succeeded: beacon-stale
RESULT:stale_page_ok
RESULT:single_page_FAIL

## D. Successful-page cooldown 30m suppresses re-page; failed notify does not
cooldown_probe_exit=0
cooldown_notifications=0
RESULT:cooldown_ok
fail_s1=0
fm-notify: command channel exited 1 (command redacted)
fail_s2=0
last-success-after-fail=none
retry_s3=0
### fail-then-retry log
FAIL summary=FIRSTMATE DEADMAN: watcher beacon stale for 2760s: /var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/home/state/.last-watcher-beat; scheduling path may be stopped
argv1_summary=FIRSTMATE DEADMAN: watcher beacon stale for 2820s: /var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/home/state/.last-watcher-beat; scheduling path may be stopped
stdin_body=FIRSTMATE DEADMAN: watcher beacon stale for 2820s: /var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/home/state/.last-watcher-beat; scheduling path may be stopped

last-success-after-retry=2000002120
RESULT:failed_notify_no_cooldown_ok
RESULT:retry_page_ok

## E. Future timestamp + missing home unhealthy
future1=0
future2=0
RESULT:future_page_ok
FM_HOME=/var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/missing-home
STALE_AFTER_SECS=600
SAMPLE_GAP_SECS=60
SAMPLE_MAX_GAP_SECS=120
FIRST_ARM_GRACE_SECS=660
WAKE_GRACE_SECS=300
SLEEP_GAP_DETECT_SECS=180
COOLDOWN_SECS=1800

miss1=0
miss2=0
RESULT:missing_home_page_ok

## F. First-arm grace and sleep/wake grace
arm1=0
arm2=0
during_first_arm_notifications=0
RESULT:first_arm_grace_ok
wake1=0
wake2=0
during_wake_grace_notifications=0
RESULT:wake_grace_ok
journal grace lines:
2000000000	first-arm grace: beacon-stale
2000000060	first-arm grace: beacon-stale
2000000400	sleep/wake grace started after run gap 400s
2000000400	sleep/wake grace active
2000000460	sleep/wake grace active

## G. Bad config self-faults (exit 2); normal paths exit 0; hostile not executed
hostile_exit=2
fm-deadman: FM_HOME must be an absolute path
RESULT:hostile_not_executed_ok
badkey_exit=2
fm-deadman: unknown config key: NOT_ALLOWED
normal_exit=0
RESULT:self_fault_ok

## H. Notify-only: never invokes fleet mutation tools
ns1=0
ns2=0
forbidden:
page:
argv1_summary=FIRSTMATE DEADMAN: watcher beacon stale for 3000000059s: /var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/home/state/.last-watcher-beat; scheduling path may be stopped
stdin_body=FIRSTMATE DEADMAN: watcher beacon stale for 3000000059s: /var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/home/state/.last-watcher-beat; scheduling path may be stopped

RESULT:notify_only_ok

## I. State kept outside FM_HOME
FM_HOME files:
/var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/home/state/.last-watcher-beat
install state:
armed
deadman.conf
deadman.env
deadman.journal
first-stale
fm-deadman.sh
fm-notify-lib.sh
installed-at
last-run-at
last-success-at
RESULT:state_outside_home_ok
has_deadman.env=yes
has_deadman.conf=yes
has_deadman.journal=yes
has_first-stale=yes
has_last-success-at=yes
has_armed=yes
has_installed-at=yes

## J. Canary fails closed without bootstrap side effects
canary_fail_exit=1
fm-notify: notifier override exited 1 for channel 'command'
Sending required deadman canary before launchd bootstrap...
bootstrap_on_failed_canary_exit=1
fm-notify: command channel exited 1 (command redacted)
fm-deadman-install: canary delivery failed; LaunchAgent was not bootstrapped.
RESULT:canary_gate_ok

######################################################################
# RESULT SUMMARY
######################################################################
RESULT:stable_copy_ok
RESULT:healthy_silent_ok
RESULT:stale_page_ok
RESULT:single_page_FAIL
RESULT:cooldown_ok
RESULT:failed_notify_no_cooldown_ok
RESULT:retry_page_ok
RESULT:future_page_ok
RESULT:missing_home_page_ok
RESULT:first_arm_grace_ok
RESULT:wake_grace_ok
RESULT:hostile_not_executed_ok
RESULT:self_fault_ok
RESULT:notify_only_ok
RESULT:state_outside_home_ok
RESULT:canary_gate_ok
```
</details>
<details>
<summary>Evidence: Wedge-alarm shared-notify regression transcript</summary>

```text
ok - library mode: sourcing the daemon defaults FM_WEDGE_ALARM_EXEC to discard (no test can fire a real notification)
ok - wake helpers replace inherited notifier overrides with the safe recorder
ok - the discard seam suppresses every notifier, including command: (fires nothing)
ok - direct notifier helpers honor the discard seam, including command:
ok - osascript channel routes through the notifier seam with the summary (never a real notification)
ok - herdr channel routes through the notifier seam with the summary (never a real notification)
ok - command channel runs the captain command with the summary on $1 and on stdin
ok - command channel failures redact configured commands while logging their exit status
ok - unknown channel directives are redacted while the alarm keeps running
ok - off disables every active alert regardless of directive position (marker and tmux flash are unaffected)
ok - auto resolves to the macOS osascript notifier on Darwin (default-on)
ok - auto on a non-macOS platform selects no built-in OS channel (the marker or a configured command carries it)
ok - config/wedge-alarm selects every configured channel and skips comment and blank lines
ok - a failing channel logs and falls back to the next channel, never crashing the alarm
ok - a hung notifier is bounded, logged, and falls through to the next channel
ok - a backgrounded command notifier remains bounded until its process group is reaped
ok - a hung notifier override is bounded, logged, and proceeds to the next channel
/Users/AI/.no-mistakes/worktrees/edb446952c22/01KZQTV2EG7W3E5C8WZZKQJA92/bin/fm-supervise-daemon.sh: line 755: 38883 Terminated: 15          sh -c 'sleep 30 & printf "%s" "$!" > "$1"; wait' sh "$child_file"
ok - daemon shutdown stops and reaps the active notifier process group
ok - inject_wedge_alarm writes the marker AND emits the active alert even with no tmux status-line (herdr backend)
ok - in-process wedge throttle prevents alert spam when the marker cannot persist
```
</details>
<details>
<summary>Evidence: Installed deadman.env defaults (STALE 600 / sample 60-120 / cooldown 1800)</summary>

```text
FM_HOME=/var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/home
STALE_AFTER_SECS=600
SAMPLE_GAP_SECS=60
SAMPLE_MAX_GAP_SECS=120
FIRST_ARM_GRACE_SECS=660
WAKE_GRACE_SECS=300
SLEEP_GAP_DETECT_SECS=180
COOLDOWN_SECS=1800
```
</details>
<details>
<summary>Evidence: Installed LaunchAgent plist (stable-copy ProgramArguments)</summary>

```text
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
  <key>Label</key>
  <string>com.firstmate.deadman</string>
  <key>ProgramArguments</key>
  <array>
    <string>/var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/Application Support/Firstmate/deadman/fm-deadman.sh</string>
  </array>
  <key>RunAtLoad</key>
  <true/>
  <key>StartInterval</key>
  <integer>60</integer>
  <key>ProcessType</key>
  <string>Background</string>
  <key>LimitLoadToSessionType</key>
  <string>Aqua</string>
  <key>StandardOutPath</key>
  <string>/var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/Application Support/Firstmate/deadman/deadman.stdout.log</string>
  <key>StandardErrorPath</key>
  <string>/var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/Application Support/Firstmate/deadman/deadman.stderr.log</string>
</dict>
</plist>
```
</details>
<details>
<summary>Evidence: Decoded plist via plutil -p</summary>

```text
{
  "Label" => "com.firstmate.deadman"
  "LimitLoadToSessionType" => "Aqua"
  "ProcessType" => "Background"
  "ProgramArguments" => [
    0 => "/var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/Application Support/Firstmate/deadman/fm-deadman.sh"
  ]
  "RunAtLoad" => true
  "StandardErrorPath" => "/var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/Application Support/Firstmate/deadman/deadman.stderr.log"
  "StandardOutPath" => "/var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZQTV2EG7W3E5C8WZZKQJA92/operator-e2e/Application Support/Firstmate/deadman/deadman.stdout.log"
  "StartInterval" => 60
}
```
</details>
<details>
<summary>Evidence: Installed deadman.journal (canary + first unhealthy + page succeeded)</summary>

```text
1786434638	canary notification succeeded
2000000000	first unhealthy sample: beacon-stale
2000000060	page succeeded: beacon-stale
2000000120	unhealthy but successful-page cooldown active: beacon-stale
2000002000	first unhealthy sample: beacon-stale
2000002060	page failed: beacon-stale
2000002120	page succeeded: beacon-stale
2000000000	first unhealthy sample: beacon-future
2000000060	page succeeded: beacon-future
2000001000	first unhealthy sample: home-unavailable
2000001060	page succeeded: home-unavailable
2000000000	first-arm grace: beacon-stale
2000000060	first-arm grace: beacon-stale
2000000400	sleep/wake grace started after run gap 400s
2000000400	sleep/wake grace active
2000000460	sleep/wake grace active
1786434641	self-fault: FM_HOME must be an absolute path
1786434641	self-fault: unknown config key: NOT_ALLOWED
1786434641	sleep/wake grace started after run gap -213565819s
1786434641	sleep/wake grace active
3000000000	first unhealthy sample: beacon-stale
3000000060	page succeeded: beacon-stale
1786434641	canary notification failed
```
</details>
<details>
<summary>Evidence: Key operator-visible outcomes</summary>

```text
Install (no --bootstrap): Canary delivery succeeded; Installed but not bootstrapped.
Canary $1: FIRSTMATE DEADMAN CANARY - notification path is working for <fm-home>
Stale hard-page $1: FIRSTMATE DEADMAN: watcher beacon stale for 760s: <fm-home>/state/.last-watcher-beat; scheduling path may be stopped
Hostile config: exit 2, 'FM_HOME must be an absolute path', marker not executed
Unknown key: exit 2, 'unknown config key: NOT_ALLOWED'
Failed canary + --bootstrap: exit 1, 'canary delivery failed; LaunchAgent was not bootstrapped.'
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 5 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-watch-arm.sh` - merge conflict rebasing onto origin/main
- ⚠️ `docs/architecture.md` - merge conflict rebasing onto origin/main
- ⚠️ `docs/verification/supervision.md` - merge conflict rebasing onto origin/main
- ⚠️ `docs/watcher-continuity.md` - merge conflict rebasing onto origin/main
- ⚠️ `tests/fm-watch-arm.test.sh` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (3) ✅</summary>

- 🚨 `bin/fm-supervise-daemon.sh:1446` - wedge_alarm_notify now delivers only through fm_notify (FM_NOTIFY_ACTIVE_PID), but daemon cleanup still calls wedge_alarm_stop_active_notifier, which only reaps WEDGE_ALARM_NOTIFIER_PID. A TERM/INT during an in-flight wedge notification no longer stops/reaps the notifier process group, regressing the previous shutdown guarantee and violating intent to preserve wedge-alarm behavior. Fix cleanup (or wedge_alarm_stop_active_notifier) to also call fm_notify_stop_active.
- ⚠️ `bin/fm-deadman-install.sh:107` - uninstall_deadman removes listed state files but not INSTALL_DIR/.probe.lock. A prior hard kill or failed EXIT trap can leave that lock directory behind; the next install/bootstrap then skips probes until the 300s stale-lock break. Remove .probe.lock during uninstall alongside the other deadman state.
- ℹ️ `bin/fm-supervise-daemon.sh:690` - After extracting fm-notify-lib.sh, the full legacy wedge_alarm_* channel stack remains in-tree while production notify uses fm_notify only. Direct tests still exercise the old helpers, so discard semantics already diverge (legacy discard returns 0; fm_notify discard returns 1). Not a current production functional break beyond the shutdown PID disconnect, but the duplicate stacks will drift further unless shutdown is bridged and the legacy path is deliberately kept test-only or removed.

🔧 Fix: Reap fm-notify on shutdown; rmdir probe lock
1 error still open:
- 🚨 `bin/fm-deadman.sh:234` - Mandatory --canary shares acquire_lock with normal probes and treats lock failure as success (exit 0) before any notify attempt. Installer uses `if ! fm-deadman.sh --canary`, so a concurrent probe, in-flight page, or stuck .probe.lock makes canary report success and allows --bootstrap without delivering a notification. This contradicts docs/deadman.md (`--canary` exits zero only when a channel reports success) and the intent-required mandatory canary. On lock failure in --canary mode, exit 1 (or retry then fail) without claiming delivery.

🔧 Fix: Canary fails closed on probe lock contention
1 error still open:
- 🚨 `bin/fm-deadman.sh:242` - trap on INT/TERM only rmdirs .probe.lock and does not exit or call fm_notify_stop_active. Bash continues after a non-exiting signal trap, so launchctl bootout/TERM releases the probe lock while the probe and in-flight notifier keep running (verified: handler runs, lock removed, script reaches later code and exits 0). That breaks mutual exclusion, can duplicate pages, and orphans notifier process groups. Use idempotent EXIT cleanup that stops fm_notify then removes the lock, and make INT/TERM run that cleanup and exit.

🔧 Fix: Reap notifier and exit on TERM
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-deadman.test.sh` (age boundary, double-sample, missing/future/unreadable, flap reset, cooldown vs failed notify, first-arm/sleep-wake grace, hostile config self-fault, notify-only/concurrency/canary lock, TERM reap, installer+plist+canary)</code>
- <code>Manual operator E2E install to temp `Application Support/Firstmate/deadman` via `bin/fm-deadman-install.sh` without `--bootstrap`, then probes of healthy silence, stale double-sample page, cooldown, failed-notify retry, future/missing home, first-arm and wake grace, hostile/unknown-key exit 2, PATH trap notify-only, state-outside-FM_HOME, and failed-canary bootstrap gate</code>
- <code>Wedge-alarm regression: 20 `test_wedge_alarm*` / related notify tests extracted from `tests/fm-daemon.test.sh` against shared `fm-notify-lib.sh`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Annotate trap handlers for ShellCheck SC2329
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
