### PR TITLE
feat(bin): add opt-in per-task Fast Repair delivery path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ state/
 data/
 .no-mistakes/
 .lavish/
+.impeccable/
 .fm-secondmate-home
 .fm-secondmate-parent
 .DS_Store

--- a/.impeccable/hook.cache.json
+++ b/.impeccable/hook.cache.json
@@ -1,0 +1,1 @@
+{"version":1,"sessions":{}}

--- a/.impeccable/hook.cache.json
+++ b/.impeccable/hook.cache.json
@@ -1,1 +1,0 @@
-{"version":1,"sessions":{}}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,6 +273,7 @@ A diagnostic request, report, recommendation, or implementation-ready finding is
 Load `diagnostic-reasoning` before scoping a reported bug and before acting on a diagnostic report.
 
 Resolve every ship task's concrete delivery mode and yolo posture at intake, and pass both explicitly to the brief, the spawn, and any scout promotion, which all refuse to guess.
+A request beginning exactly `fast-repair: ` is an eligibility request for one strict per-task Fast Repair exception, so use `docs/fast-repair.md` and `bin/fm-fast-repair.sh` before selecting it; a refusal returns to normal intake and this mode always keeps captain-only merge approval.
 A current explicit captain instruction wins; otherwise the project's registry entry is the captain's standing posture, and dropping below its rigor needs a reason you can state.
 On a `no-mistakes-prod-only` project, classify the task's surface: internal-only tooling, automation, contributor or operator process, and release or submission work ships `direct-PR`, while product-facing, mixed, and uncertain work ships `no-mistakes`; never infer internal-only from file location or project name.
 An unregistered project or absent registry resolves to `no-mistakes` with yolo off, and the registration gap goes to the captain.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,7 +273,7 @@ A diagnostic request, report, recommendation, or implementation-ready finding is
 Load `diagnostic-reasoning` before scoping a reported bug and before acting on a diagnostic report.
 
 Resolve every ship task's concrete delivery mode and yolo posture at intake, and pass both explicitly to the brief, the spawn, and any scout promotion, which all refuse to guess.
-A request beginning exactly `fast-repair: ` is an eligibility request for one strict per-task Fast Repair exception, so use `docs/fast-repair.md` and `bin/fm-fast-repair.sh` before selecting it; a refusal returns to normal intake and this mode always keeps captain-only merge approval.
+A request beginning exactly `fast-repair: ` is an eligibility request for one strict per-task Fast Repair exception, so use `docs/fast-repair.md` and `bin/fm-fast-repair.sh` before selecting it, and a refusal returns to normal intake.
 A current explicit captain instruction wins; otherwise the project's registry entry is the captain's standing posture, and dropping below its rigor needs a reason you can state.
 On a `no-mistakes-prod-only` project, classify the task's surface: internal-only tooling, automation, contributor or operator process, and release or submission work ships `direct-PR`, while product-facing, mixed, and uncertain work ships `no-mistakes`; never infer internal-only from file location or project name.
 An unregistered project or absent registry resolves to `no-mistakes` with yolo off, and the registration gap goes to the captain.
@@ -310,6 +310,7 @@ The path's worker, automated gates, and captain approval remain authoritative:
 - **no-mistakes** runs the full pipeline through a PR, then waits for the configured merge authority.
 - **direct-PR** has the worker push and open a PR without the no-mistakes pipeline, then waits for the configured merge authority.
 - **local-only** has the worker stop with a clean ready branch, then waits for the configured merge authority before firstmate uses the guarded fast-forward merge path.
+- **fast-repair** is the strict opt-in per-task exception ([docs/fast-repair.md](docs/fast-repair.md)), which runs with `yolo` off and never auto-merges, so the captain alone is the merge authority.
 
 Delivery mode and `yolo` are orthogonal.
 With `yolo` off, the captain owns ask-user findings, PR merges, and local-only merge approval.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ data/                personal fleet records; LOCAL, gitignored as a whole
   secondmates.md      local and remote secondmate routing table; firstmate-private, maintained by the secondmate seed helpers (section 6)
   <id>/brief.md      per-task crewmate brief, or per-secondmate charter brief when kind=secondmate
   <id>/report.md     scout task deliverable, written by the crewmate; survives teardown
+  <id>/fast-repair-eligibility  private typed Fast Repair authorization record written by bin/fm-fast-repair.sh intake; every mode=fast-repair brief, spawn, and gate re-proves it (docs/fast-repair.md)
 projects/            cloned repos; gitignored; read-only except under hard rule 1's concrete captain-approved project operation exception
 state/               volatile runtime signals; gitignored
   <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth
@@ -92,10 +93,11 @@ state/               volatile runtime signals; gitignored
   <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
   <id>.kimi-turnend-token   firstmate-owned Kimi hook registry token for the task; removed by teardown
   <id>.muse-session  muse busy-source binding (sessions root plus task worktree) written by fm-spawn; removed by teardown
-  <id>.meta          written by fm-spawn: window=, endpoint_task_id=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; an optional traceparent= only when trace context is enabled (docs/configuration.md "Trace context propagation"); kind=secondmate also records home= and projects=, plus remote_host=/remote_root=/remote_backend=/remote_herdr_session=/remote_target= for a remote route; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, records one canonical pr= and the forge's pr_head= when available (GitHub pull requests and GitLab merge requests; docs/gitlab-merge-watch.md); fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for a Relay-originated task (section 14)
+  <id>.meta          written by fm-spawn: window=, endpoint_task_id=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; a mode=fast-repair ship also records fast_repair=eligible, which is the watcher's only durable authority for the Fast Repair progress cadence (docs/fast-repair.md); an optional traceparent= only when trace context is enabled (docs/configuration.md "Trace context propagation"); kind=secondmate also records home= and projects=, plus remote_host=/remote_root=/remote_backend=/remote_herdr_session=/remote_target= for a remote route; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, records one canonical pr= and the forge's pr_head= when available (GitHub pull requests and GitLab merge requests; docs/gitlab-merge-watch.md); fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for a Relay-originated task (section 14)
   <id>.herdr-presentation  quarantinable attempt and restart-binding journal for Herdr's optional visual projection; never task or endpoint authority; see docs/herdr-backend.md "Presentation spaces"
   <id>.check.sh      authenticated slow poll; the watcher dispatches validated PR data and the byte-identified Relay shim through trusted repository scripts, runs registered custom checks from hash-validated private snapshots, and rejects every other state check without execution
   <id>.check-trust   private content binding created by fm-check-register.sh for an intentional custom check
+  <id>.fast-repair-tests <id>.fast-repair-broader (and their .log files)  private Fast Repair test-evidence records written by bin/fm-fast-repair.sh; removed by teardown; see docs/fast-repair.md
   <id>.pr-poll       private validated data sidecar for the byte-static PR merge poll
   <id>.pr-poll-registration  private transactional provenance record binding the task, canonical metadata identity, sidecar, and static poll publication
   <id>.pr-poll-retirement  private identity-bound crash-recovery receipt for one exact validated merged result; removed after its poll artifacts retire
@@ -118,7 +120,7 @@ state/               volatile runtime signals; gitignored
   .afk               durable away-mode flag; present = sub-supervisor may inject escalations (set by /afk, cleared on user return)
   .watch.lock .wake-queue.lock watcher singleton and queue serialization locks
   .claude-autoarm.lock .claude-autoarm-epoch .claude-autoarm-failure-notified .claude-autoarm-failure-alarmed .turnend-claude-blocks .turnend-claude-blocks.lock   Claude Stop auto-arm single-flight, epoch, failure-episode, attended-alarm, guard-budget, and budget-lock records; never touch
-  .hash-* .count-* .stale-* .stale-since-* .paused-* .wedge-escalations-* .seen-* .hb-surfaced-* .last-* .heartbeat-streak   watcher internals; never touch
+  .hash-* .count-* .stale-* .stale-since-* .paused-* .wedge-escalations-* .seen-* .hb-surfaced-* .last-* .heartbeat-streak .fast-repair-progress-*   watcher internals; never touch
   .watch-triage.log  watcher's absorbed-wake debug log (size-capped); never relied on, safe to delete
   .last-watcher-beat watcher liveness beacon, touched every poll (including while absorbing benign wakes); guard scripts read it
   .subsuper-* .supervise-daemon.*   sub-supervisor internals; never touch

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/architecture.md](docs/architecture.md) - maintainer architecture for the crew, supervision, worktrees, secondmates, and project modes.
 - [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, runtime backend selection, optional Relay and its X and Discord setup steps, the files you set, and harness support.
 - [docs/remote-secondmates.md](docs/remote-secondmates.md) - current setup, routing, transfer, recovery, and safety behavior for whole-home remote second mates.
+- [docs/fast-repair.md](docs/fast-repair.md) - the opt-in per-task Fast Repair path: its exact request prefix, what it must prove, when it refuses, and how it delivers.
 - [docs/calm.md](docs/calm.md) - current Pi `/calm` behavior and supported presentation limits.
 - [docs/wedge-alarm.md](docs/wedge-alarm.md) - configure the active alert for an away-mode escalation delivery that gets stuck.
 - [docs/tmux-backend.md](docs/tmux-backend.md) - current setup and limits for the tmux reference backend.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -380,7 +380,7 @@ Add a new regression test that reproduces the reported defect and make the narro
 Run \`$FAST_REPAIR_HELPER evidence $ID --regression-test '<runner family>' --focused-test '<different runner family>'\` through the tracked \`bin/fm-test-run.sh\` runner.
 It runs and records both gates, and it refuses PR publication when either result is missing or failed.
 After it passes, use \`$FAST_REPAIR_HELPER publish-pr $ID --title '<title>' --body-file <path>\` to open and register the direct PR immediately.
-Then run \`$FAST_REPAIR_HELPER broader $ID --test '<runner family>'\` while the new PR's checks run concurrently.
+Then run \`$FAST_REPAIR_HELPER broader $ID --test '<runner family broader than the focused one>'\` while the new PR's checks run concurrently.
 Do not call the PR ready or green until \`$FAST_REPAIR_HELPER ready $ID\` passes.
 If broader tests or PR checks fail after the PR opens, append \`failed: PR {url} is open but not green because {failed evidence}\` and stop.
 Never enable auto-merge, and never merge the PR.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -377,7 +377,7 @@ This task is a strict Fast Repair exception and has already passed the typed eli
 Every command below carries that absolute helper path and firstmate's own state and data directories, because your worktree is the project's, not firstmate's; run each one verbatim from your worktree.
 Do not create a scout or run plan, design, CEO, engineering, or other extra review workflows.
 Add a new regression test that reproduces the reported defect and make the narrow repair.
-Run \`$FAST_REPAIR_HELPER evidence $ID --regression-test '<relative executable regression test path>' --focused-command '<command>'\`.
+Run \`$FAST_REPAIR_HELPER evidence $ID --regression-test '<relative executable regression test path>' --focused-test '<relative executable focused-module test path>'\`.
 It runs and records both gates, and it refuses PR publication when either result is missing or failed.
 After it passes, use \`$FAST_REPAIR_HELPER publish-pr $ID --title '<title>' --body-file <path>\` to open and register the direct PR immediately.
 Then run \`$FAST_REPAIR_HELPER broader $ID --command '<broader test command>'\` while the new PR's checks run concurrently.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -364,18 +364,24 @@ case "$MODE" in
   fast-repair)
     SETUP2=""
     RULE1='1. Never push to the default branch, never merge a PR, and never use a different profile than Codex gpt-5.6-luna with medium effort.'
+    # The crewmate's pane comes from a long-lived tmux/herdr daemon and inherits
+    # none of firstmate's environment, so the helper would otherwise re-derive
+    # its own home and read a different (or absent) task record. The resolved
+    # state and data directories are therefore frozen into every command here,
+    # exactly as the crewmate's status path is above.
+    FAST_REPAIR_HELPER="FM_STATE_OVERRIDE=$(shell_quote "$STATE") FM_DATA_OVERRIDE=$(shell_quote "$DATA") $(shell_quote "$FM_ROOT/bin/fm-fast-repair.sh")"
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 Delivery contract: mode=fast-repair
 This task is a strict Fast Repair exception and has already passed the typed eligibility record owned by \`$FM_ROOT/bin/fm-fast-repair.sh\`.
-Every command below is that absolute helper path because your worktree is the project's, not firstmate's; run each one from your worktree.
+Every command below carries that absolute helper path and firstmate's own state and data directories, because your worktree is the project's, not firstmate's; run each one verbatim from your worktree.
 Do not create a scout or run plan, design, CEO, engineering, or other extra review workflows.
 Add a new regression test that reproduces the reported defect and make the narrow repair.
-Run \`$FM_ROOT/bin/fm-fast-repair.sh evidence $ID --regression-command '<command>' --focused-command '<command>'\`.
+Run \`$FAST_REPAIR_HELPER evidence $ID --regression-command '<command>' --focused-command '<command>'\`.
 It runs and records both gates, and it refuses PR publication when either result is missing or failed.
-After it passes, use \`$FM_ROOT/bin/fm-fast-repair.sh publish-pr $ID --title '<title>' --body-file <path>\` to open and register the direct PR immediately.
-Then run \`$FM_ROOT/bin/fm-fast-repair.sh broader $ID --command '<broader test command>'\` while the new PR's checks run concurrently.
-Do not call the PR ready or green until \`$FM_ROOT/bin/fm-fast-repair.sh ready $ID\` passes.
+After it passes, use \`$FAST_REPAIR_HELPER publish-pr $ID --title '<title>' --body-file <path>\` to open and register the direct PR immediately.
+Then run \`$FAST_REPAIR_HELPER broader $ID --command '<broader test command>'\` while the new PR's checks run concurrently.
+Do not call the PR ready or green until \`$FAST_REPAIR_HELPER ready $ID\` passes.
 If broader tests or PR checks fail after the PR opens, append \`failed: PR {url} is open but not green because {failed evidence}\` and stop.
 Never enable auto-merge, and never merge the PR.
 When ready passes, append \`done: PR {url} checks green\` and stop for captain approval.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -377,7 +377,7 @@ This task is a strict Fast Repair exception and has already passed the typed eli
 Every command below carries that absolute helper path and firstmate's own state and data directories, because your worktree is the project's, not firstmate's; run each one verbatim from your worktree.
 Do not create a scout or run plan, design, CEO, engineering, or other extra review workflows.
 Add a new regression test that reproduces the reported defect and make the narrow repair.
-Run \`$FAST_REPAIR_HELPER evidence $ID --regression-command '<command>' --focused-command '<command>'\`.
+Run \`$FAST_REPAIR_HELPER evidence $ID --regression-test '<relative executable regression test path>' --focused-command '<command>'\`.
 It runs and records both gates, and it refuses PR publication when either result is missing or failed.
 After it passes, use \`$FAST_REPAIR_HELPER publish-pr $ID --title '<title>' --body-file <path>\` to open and register the direct PR immediately.
 Then run \`$FAST_REPAIR_HELPER broader $ID --command '<broader test command>'\` while the new PR's checks run concurrently.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -380,7 +380,7 @@ Add a new regression test that reproduces the reported defect and make the narro
 Run \`$FAST_REPAIR_HELPER evidence $ID --regression-test '<runner family>' --focused-test '<different runner family>'\` through the tracked \`bin/fm-test-run.sh\` runner.
 It runs and records both gates, and it refuses PR publication when either result is missing or failed.
 After it passes, use \`$FAST_REPAIR_HELPER publish-pr $ID --title '<title>' --body-file <path>\` to open and register the direct PR immediately.
-Then run \`$FAST_REPAIR_HELPER broader $ID --command '<broader test command>'\` while the new PR's checks run concurrently.
+Then run \`$FAST_REPAIR_HELPER broader $ID --test '<runner family>'\` while the new PR's checks run concurrently.
 Do not call the PR ready or green until \`$FAST_REPAIR_HELPER ready $ID\` passes.
 If broader tests or PR checks fail after the PR opens, append \`failed: PR {url} is open but not green because {failed evidence}\` and stop.
 Never enable auto-merge, and never merge the PR.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -377,7 +377,7 @@ This task is a strict Fast Repair exception and has already passed the typed eli
 Every command below carries that absolute helper path and firstmate's own state and data directories, because your worktree is the project's, not firstmate's; run each one verbatim from your worktree.
 Do not create a scout or run plan, design, CEO, engineering, or other extra review workflows.
 Add a new regression test that reproduces the reported defect and make the narrow repair.
-Run \`$FAST_REPAIR_HELPER evidence $ID --regression-test '<relative executable regression test path>' --focused-test '<relative executable focused-module test path>'\`.
+Run \`$FAST_REPAIR_HELPER evidence $ID --regression-test 'tests/<name>-regression.test.sh' --focused-test 'tests/<name>-focused.test.sh'\` through the tracked \`bin/fm-test-run.sh\` runner.
 It runs and records both gates, and it refuses PR publication when either result is missing or failed.
 After it passes, use \`$FAST_REPAIR_HELPER publish-pr $ID --title '<title>' --body-file <path>\` to open and register the direct PR immediately.
 Then run \`$FAST_REPAIR_HELPER broader $ID --command '<broader test command>'\` while the new PR's checks run concurrently.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -377,7 +377,7 @@ This task is a strict Fast Repair exception and has already passed the typed eli
 Every command below carries that absolute helper path and firstmate's own state and data directories, because your worktree is the project's, not firstmate's; run each one verbatim from your worktree.
 Do not create a scout or run plan, design, CEO, engineering, or other extra review workflows.
 Add a new regression test that reproduces the reported defect and make the narrow repair.
-Run \`$FAST_REPAIR_HELPER evidence $ID --regression-test 'tests/<name>-regression.test.sh' --focused-test 'tests/<name>-focused.test.sh'\` through the tracked \`bin/fm-test-run.sh\` runner.
+Run \`$FAST_REPAIR_HELPER evidence $ID --regression-test '<runner family>' --focused-test '<different runner family>'\` through the tracked \`bin/fm-test-run.sh\` runner.
 It runs and records both gates, and it refuses PR publication when either result is missing or failed.
 After it passes, use \`$FAST_REPAIR_HELPER publish-pr $ID --title '<title>' --body-file <path>\` to open and register the direct PR immediately.
 Then run \`$FAST_REPAIR_HELPER broader $ID --command '<broader test command>'\` while the new PR's checks run concurrently.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -367,14 +367,15 @@ case "$MODE" in
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 Delivery contract: mode=fast-repair
-This task is a strict Fast Repair exception and has already passed the typed eligibility record owned by \`bin/fm-fast-repair.sh\`.
+This task is a strict Fast Repair exception and has already passed the typed eligibility record owned by \`$FM_ROOT/bin/fm-fast-repair.sh\`.
+Every command below is that absolute helper path because your worktree is the project's, not firstmate's; run each one from your worktree.
 Do not create a scout or run plan, design, CEO, engineering, or other extra review workflows.
 Add a new regression test that reproduces the reported defect and make the narrow repair.
-Run \`bin/fm-fast-repair.sh evidence $ID --regression-command '<command>' --focused-command '<command>'\`.
+Run \`$FM_ROOT/bin/fm-fast-repair.sh evidence $ID --regression-command '<command>' --focused-command '<command>'\`.
 It runs and records both gates, and it refuses PR publication when either result is missing or failed.
-After it passes, use \`bin/fm-fast-repair.sh publish-pr $ID --title '<title>' --body-file <path>\` to open and register the direct PR immediately.
-Then run \`bin/fm-fast-repair.sh broader $ID --command '<broader test command>'\` while the new PR's checks run concurrently.
-Do not call the PR ready or green until \`bin/fm-fast-repair.sh ready $ID\` passes.
+After it passes, use \`$FM_ROOT/bin/fm-fast-repair.sh publish-pr $ID --title '<title>' --body-file <path>\` to open and register the direct PR immediately.
+Then run \`$FM_ROOT/bin/fm-fast-repair.sh broader $ID --command '<broader test command>'\` while the new PR's checks run concurrently.
+Do not call the PR ready or green until \`$FM_ROOT/bin/fm-fast-repair.sh ready $ID\` passes.
 If broader tests or PR checks fail after the PR opens, append \`failed: PR {url} is open but not green because {failed evidence}\` and stop.
 Never enable auto-merge, and never merge the PR.
 When ready passes, append \`done: PR {url} checks green\` and stop for captain approval.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -6,7 +6,7 @@
 # description, acceptance criteria, and context, and may adjust other sections
 # when the task genuinely deviates (e.g. working an existing external PR instead
 # of shipping a new one).
-# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only> [--herdr-lab]
+# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only|fast-repair> [--herdr-lab]
 #        fm-brief.sh <task-id> <repo-name> --scout [--herdr-lab]
 #        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
 #   --scout writes the scout contract instead: the deliverable is a report at
@@ -34,6 +34,8 @@
 #   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> configured merge authority
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                the configured merge authority approves, firstmate merges to local main
+#   fast-repair  only after bin/fm-fast-repair.sh recorded eligible typed evidence;
+#                use its regression/focused evidence and direct-PR commands
 # no-mistakes-prod-only is a registry policy, not a task mode; resolve it to one of
 # the three concrete modes at intake before calling this script.
 # The generated ship brief records the chosen mode as a fixed machine-readable
@@ -140,21 +142,28 @@ done
 # missing or invalid value stops the scaffold rather than silently defaulting.
 if [ "$KIND" = ship ]; then
   [ "$MODE_SET" -eq 1 ] || {
-    echo "error: ship briefs require --mode <no-mistakes|direct-PR|local-only>; resolve it at intake from the captain's instruction and the project's registered posture in data/projects.md" >&2
+    echo "error: ship briefs require --mode <no-mistakes|direct-PR|local-only|fast-repair>; resolve it at intake from the captain's instruction and the project's registered posture in data/projects.md" >&2
     exit 1
   }
   case "$MODE" in
-    no-mistakes|direct-PR|local-only) ;;
+    no-mistakes|direct-PR|local-only|fast-repair) ;;
     no-mistakes-prod-only)
       echo "error: no-mistakes-prod-only is a registry policy, not a task mode; classify this task's surface and resolve it to no-mistakes or direct-PR at intake" >&2
       exit 1 ;;
-    *) echo "error: --mode must be one of no-mistakes, direct-PR, local-only (got '$MODE')" >&2; exit 1 ;;
+    *) echo "error: --mode must be one of no-mistakes, direct-PR, local-only, fast-repair (got '$MODE')" >&2; exit 1 ;;
   esac
 elif [ "$MODE_SET" -eq 1 ]; then
   echo "error: --mode applies only to ship briefs; a scout delivers a report and a secondmate charter is not a delivery contract" >&2
   exit 1
 fi
 ID=${POS[0]}
+
+if [ "$KIND" = ship ] && [ "$MODE" = fast-repair ]; then
+  "$SCRIPT_DIR/fm-fast-repair.sh" eligible "$ID" >/dev/null || {
+    echo "error: Fast Repair brief refused because its typed eligibility evidence is absent or incomplete; use normal intake for this task" >&2
+    exit 1
+  }
+fi
 
 if [ "$KIND" = secondmate ] && [ "$HERDR_LAB" -eq 1 ]; then
   echo "error: --herdr-lab applies only to crewmate ship or scout briefs" >&2
@@ -352,6 +361,25 @@ fi
 # "Delivery contract: mode=<mode>" line that bin/fm-spawn.sh checks against its own
 # explicit --mode before launching.
 case "$MODE" in
+  fast-repair)
+    SETUP2=""
+    RULE1='1. Never push to the default branch, never merge a PR, and never use a different profile than Codex gpt-5.6-luna with medium effort.'
+    IFS= read -r -d '' DOD <<EOF || true
+# Definition of done
+Delivery contract: mode=fast-repair
+This task is a strict Fast Repair exception and has already passed the typed eligibility record owned by \`bin/fm-fast-repair.sh\`.
+Do not create a scout or run plan, design, CEO, engineering, or other extra review workflows.
+Add a new regression test that reproduces the reported defect and make the narrow repair.
+Run \`bin/fm-fast-repair.sh evidence $ID --regression-command '<command>' --focused-command '<command>'\`.
+It runs and records both gates, and it refuses PR publication when either result is missing or failed.
+After it passes, use \`bin/fm-fast-repair.sh publish-pr $ID --title '<title>' --body-file <path>\` to open and register the direct PR immediately.
+Then run \`bin/fm-fast-repair.sh broader $ID --command '<broader test command>'\` while the new PR's checks run concurrently.
+Do not call the PR ready or green until \`bin/fm-fast-repair.sh ready $ID\` passes.
+If broader tests or PR checks fail after the PR opens, append \`failed: PR {url} is open but not green because {failed evidence}\` and stop.
+Never enable auto-merge, and never merge the PR.
+When ready passes, append \`done: PR {url} checks green\` and stop for captain approval.
+EOF
+    ;;
   direct-PR)
     SETUP2=""
     RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'

--- a/bin/fm-fast-repair.sh
+++ b/bin/fm-fast-repair.sh
@@ -6,7 +6,7 @@
 #     --reproduction reproduced --reproduction-revision <commit> --root-cause confirmed --isolation isolated \
 #     --schema none --authentication none --authorization none --secrets none \
 #     --financial none --legal none --side-effects none
-#   fm-fast-repair.sh eligible <task-id>
+#   fm-fast-repair.sh eligible <task-id> [--worktree <path>]
 #   fm-fast-repair.sh evidence <task-id> --regression-test <runner-family> --focused-test <runner-family>
 #   fm-fast-repair.sh publish-pr <task-id> --title <text> --body-file <path> [--base <branch>] [--head <branch>]
 #   fm-fast-repair.sh broader <task-id> --command <command>
@@ -76,6 +76,16 @@ task_worktree_for() {
 
 task_revision_for() {
   task_worktree_for "$1" || return 1
+  task_revision_at_worktree "$TASK_WORKTREE"
+}
+
+task_revision_at_worktree() {
+  local worktree=$1 root
+  [ -d "$worktree" ] || return 1
+  root=$(git -C "$worktree" rev-parse --show-toplevel 2>/dev/null) || return 1
+  root=$(cd "$root" && pwd -P) || return 1
+  [ "$root" = "$(cd "$worktree" && pwd -P)" ] || return 1
+  TASK_WORKTREE=$root
   TASK_BRANCH=$(git -C "$TASK_WORKTREE" symbolic-ref --quiet --short HEAD 2>/dev/null) || return 1
   TASK_HEAD=$(git -C "$TASK_WORKTREE" rev-parse --verify HEAD 2>/dev/null) || return 1
 }
@@ -149,11 +159,41 @@ reproduction_revision_for() {
   git -C "$TASK_WORKTREE" cat-file -e "$revision^{commit}" 2>/dev/null || return 1
   [ "$revision" != "$TASK_HEAD" ] || return 1
   git -C "$TASK_WORKTREE" merge-base --is-ancestor "$revision" "$TASK_HEAD" || return 1
-  git -C "$TASK_WORKTREE" diff --no-ext-diff --quiet "$revision" "$TASK_HEAD" -- bin/fm-test-run.sh || return 1
   REPRODUCTION_REVISION=$revision
 }
 
-regression_test_valid() { runner_family_valid "$1"; }
+runner_selected_tests() { # <family>
+  "$TEST_RUNNER" --list --family "$1" 2>/dev/null
+}
+
+runner_selected_test_valid() { # <path>
+  local path=$1 parent resolved
+  case "$path" in tests/*.test.sh) ;; *) return 1 ;; esac
+  parent=$(dirname "$TASK_WORKTREE/$path")
+  resolved=$(cd "$parent" 2>/dev/null && pwd -P) || return 1
+  resolved="$resolved/$(basename "$path")"
+  [ "$resolved" = "$TASK_WORKTREE/$path" ] || return 1
+  regular_file "$resolved" || return 1
+  [ "$(git -C "$TASK_WORKTREE" cat-file -t "$TASK_HEAD:$path" 2>/dev/null || true)" = blob ] || return 1
+  git -C "$TASK_WORKTREE" diff --no-ext-diff --quiet "$TASK_HEAD" -- ":(literal)$path" || return 1
+}
+
+regression_test_valid() { # <task-id> <family>
+  local id=$1 family=$2 selected path has_new=0
+  runner_family_valid "$family" || return 1
+  reproduction_revision_for "$id" || return 1
+  selected=$(runner_selected_tests "$family") || return 1
+  [ -n "$selected" ] || return 1
+  while IFS= read -r path; do
+    [ -n "$path" ] || return 1
+    runner_selected_test_valid "$path" || return 1
+    git -C "$TASK_WORKTREE" cat-file -e "$REPRODUCTION_REVISION:$path" 2>/dev/null || has_new=1
+  done <<EOF
+$selected
+EOF
+  [ "$has_new" = 1 ]
+}
+
 focused_test_valid() { runner_family_valid "$1"; }
 
 run_typed_test() { # <worktree> <family> <pass|fail> <log>
@@ -180,20 +220,6 @@ run_typed_test() { # <worktree> <family> <pass|fail> <log>
   fi
   rm -f "$output"
   return 1
-}
-
-regression_proof_valid() { # <task-id> <family> <log>
-  local id=$1 family=$2 log=$3 sandbox
-  reproduction_revision_for "$id" || return 1
-  sandbox=$(mktemp -d "$STATE/.fast-repair-reproduction.XXXXXX") || return 1
-  rmdir "$sandbox" || return 1
-  if ! git clone --quiet --no-hardlinks "$TASK_WORKTREE" "$sandbox" \
-    || ! git -C "$sandbox" checkout --quiet --detach "$REPRODUCTION_REVISION" \
-    || ! run_typed_test "$sandbox" "$family" fail "$log"; then
-    rm -rf "$sandbox"
-    return 1
-  fi
-  rm -rf "$sandbox"
 }
 
 eligibility_file() { printf '%s/%s/fast-repair-eligibility\n' "$DATA" "$1"; }
@@ -249,9 +275,9 @@ tests_passed() {
   worktree=$(field_get "$f" worktree)
   branch=$(field_get "$f" branch)
   head=$(field_get "$f" head)
-  regression_test_valid "$regression_test" || return 1
-  focused_test_valid "$focused_test" || return 1
   reproduction_revision_for "$id" || return 1
+  regression_test_valid "$id" "$regression_test" || return 1
+  focused_test_valid "$focused_test" || return 1
   [ "$reproduction_revision" = "$REPRODUCTION_REVISION" ] || return 1
   [ "$worktree" = "$TASK_WORKTREE" ] || return 1
   [ "$branch" = "$TASK_BRANCH" ] || return 1
@@ -458,11 +484,24 @@ case "$command" in
     printf 'fast-repair eligible: %s\n' "$id"
     ;;
   eligible)
-    [ "$#" -eq 1 ] || { usage >&2; exit 2; }
-    if ! task_id_valid "$1" || ! eligibility_valid "$1"; then
-      fail "eligibility evidence is absent, incomplete, or no longer valid for $1"
+    id=${1:-}
+    shift || true
+    task_id_valid "$id" || fail "task id is missing or invalid"
+    worktree=
+    if [ "$#" -gt 0 ]; then
+      [ "$#" -eq 2 ] && [ "$1" = --worktree ] || { usage >&2; exit 2; }
+      worktree=$2
     fi
-    printf 'fast-repair eligible: %s\n' "$1"
+    if ! eligibility_valid "$id"; then
+      fail "eligibility evidence is absent, incomplete, or no longer valid for $id"
+    fi
+    if [ -n "$worktree" ] && ! task_revision_at_worktree "$worktree"; then
+      fail "task $id has no safe git worktree for reproduction proof"
+    fi
+    if [ -n "$worktree" ] && ! reproduction_revision_for "$id"; then
+      fail "reproduction revision is unknown, current, or not an ancestor of the task head"
+    fi
+    printf 'fast-repair eligible: %s\n' "$id"
     ;;
   evidence)
     id=${1:-}
@@ -485,8 +524,10 @@ case "$command" in
     require_fast_repair_meta "$id"
     eligibility_valid "$id" || fail "eligibility evidence is absent or invalid"
     task_revision_for "$id" || fail "task $id has no safe git worktree at its metadata path"
-    regression_test_valid "$regression_test" \
-      || fail "regression-test must name a supported bin/fm-test-run.sh family"
+    reproduction_revision_for "$id" \
+      || fail "reproduction revision is unknown, current, or not an ancestor of the task head"
+    regression_test_valid "$id" "$regression_test" \
+      || fail "regression-test must name a supported runner family with a new tracked selector"
     focused_test_valid "$focused_test" \
       || fail "focused-test must name a supported bin/fm-test-run.sh family"
     [ "$regression_test" != "$focused_test" ] \
@@ -495,8 +536,7 @@ case "$command" in
     log="$STATE/$id.fast-repair-tests.log"
     record="$STATE/.$id.fast-repair-tests.$$"
     private_truncate "$log" || fail "the evidence log could not be created"
-    if run_typed_test "$TASK_WORKTREE" "$regression_test" pass "$log" \
-      && regression_proof_valid "$id" "$regression_test" "$log"; then regression_result=passed; else regression_result=failed; fi
+    if run_typed_test "$TASK_WORKTREE" "$regression_test" pass "$log"; then regression_result=passed; else regression_result=failed; fi
     if [ "$regression_result" = passed ] && run_typed_test "$TASK_WORKTREE" "$focused_test" pass "$log"; then focused_result=passed; else focused_result=failed; fi
     {
       printf 'regression=%s\n' "$regression_result"

--- a/bin/fm-fast-repair.sh
+++ b/bin/fm-fast-repair.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+# Manage the strict opt-in Fast Repair delivery path.
+# Usage:
+#   fm-fast-repair.sh is-request <request>
+#   fm-fast-repair.sh intake <task-id> --request 'fast-repair: <task>' \
+#     --reproduction <evidence> --root-cause <evidence> --isolation <evidence> \
+#     --schema none --authentication none --authorization none --secrets none \
+#     --financial none --legal none --side-effects none
+#   fm-fast-repair.sh eligible <task-id>
+#   fm-fast-repair.sh evidence <task-id> --regression-command <command> --focused-command <command>
+#   fm-fast-repair.sh publish-pr <task-id> --title <text> --body-file <path> [--base <branch>] [--head <branch>]
+#   fm-fast-repair.sh broader <task-id> --command <command>
+#   fm-fast-repair.sh progress <task-id>
+#   fm-fast-repair.sh ready <task-id>
+#
+# `fast-repair:` is the only accepted request prefix, and it must be followed by
+# one space and a non-empty request. `intake` records a typed, private evidence
+# record only when all three positive facts are non-empty and all seven risk
+# exclusions equal `none`. Any missing, unknown, ambiguous, or different value
+# refuses Fast Repair before a task can use this delivery mode; firstmate then
+# uses normal intake for that request.
+#
+# A Fast Repair spawn must use mode=fast-repair, yolo=off, and the built-in
+# Codex gpt-5.6-luna medium profile. `evidence` executes a regression command
+# and a focused-module command and records their result. `publish-pr` refuses
+# until both passed, then opens and registers a direct PR. `broader` is run
+# after publication while PR checks run concurrently. `ready` refuses until the
+# broader command and all PR checks are green. `progress` prints only a changed
+# actionable state for the watcher's Fast-Repair-only cadence.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+
+usage() {
+  sed -n '2,${/^#/!q;p;}' "$0" | sed 's/^# \{0,1\}//'
+}
+
+fail() {
+  printf 'fast-repair refused: %s\n' "$*" >&2
+  exit 2
+}
+
+task_id_valid() {
+  case "$1" in ''|*[!A-Za-z0-9._-]*) return 1 ;; esac
+  return 0
+}
+
+regular_file() {
+  [ -f "$1" ] && [ ! -L "$1" ]
+}
+
+field_get() { # <file> <field>
+  sed -n "s/^$2=//p" "$1" | head -n 1
+}
+
+request_valid() {
+  case "$1" in
+    fast-repair:\ ?*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+eligibility_file() { printf '%s/%s/fast-repair-eligibility\n' "$DATA" "$1"; }
+tests_file() { printf '%s/%s.fast-repair-tests\n' "$STATE" "$1"; }
+
+require_fast_repair_meta() {
+  local id meta
+  id=$1
+  meta="$STATE/$id.meta"
+  regular_file "$meta" || fail "task $id has no safe metadata record"
+  [ "$(field_get "$meta" mode)" = fast-repair ] || fail "task $id is not a Fast Repair task"
+  [ "$(field_get "$meta" fast_repair)" = eligible ] || fail "task $id has no eligible Fast Repair result"
+}
+
+eligibility_valid() {
+  local id=$1 f request positive risk
+  f=$(eligibility_file "$id")
+  regular_file "$f" || return 1
+  request=$(field_get "$f" request)
+  request_valid "$request" || return 1
+  for positive in reproduction root_cause isolation; do
+    case "$(field_get "$f" "$positive")" in ''|unknown|ambiguous) return 1 ;; esac
+  done
+  for risk in schema authentication authorization secrets financial legal side_effects; do
+    [ "$(field_get "$f" "$risk")" = none ] || return 1
+  done
+}
+
+tests_passed() {
+  local id=$1 f
+  f=$(tests_file "$id")
+  regular_file "$f" || return 1
+  [ "$(field_get "$f" regression)" = passed ] && [ "$(field_get "$f" focused)" = passed ]
+}
+
+parse_url_number() {
+  case "$1" in
+    https://github.com/*/pull/[0-9]*) printf '%s\n' "${1##*/}" ;;
+    *) return 1 ;;
+  esac
+}
+
+pr_url_for() {
+  local id meta url
+  id=$1
+  meta="$STATE/$id.meta"
+  url=$(field_get "$meta" pr)
+  parse_url_number "$url" >/dev/null || return 1
+  printf '%s\n' "$url"
+}
+
+checks_summary() {
+  local url=$1 number
+  number=$(parse_url_number "$url") || return 1
+  command -v gh-axi >/dev/null 2>&1 || return 1
+  gh-axi pr checks "$number" 2>/dev/null | sed -n 's/^summary: *//p' | head -n 1
+}
+
+checks_state() { # <summary> -> green|failed|pending|unknown
+  case "$1" in
+    *'0 failed, 0 pending,'*) printf 'green\n' ;;
+    *'0 failed,'*) printf 'pending\n' ;;
+    *' failed,'*) printf 'failed\n' ;;
+    *) printf 'unknown\n' ;;
+  esac
+}
+
+command=${1:-}
+[ -n "$command" ] || { usage >&2; exit 2; }
+shift || true
+
+case "$command" in
+  -h|--help|help) usage; exit 0 ;;
+  is-request)
+    [ "$#" -eq 1 ] || { usage >&2; exit 2; }
+    request_valid "$1"
+    ;;
+  intake)
+    id=${1:-}
+    shift || true
+    task_id_valid "$id" || fail "task id is missing or invalid"
+    request=
+    reproduction=
+    root_cause=
+    isolation=
+    schema=
+    authentication=
+    authorization=
+    secrets=
+    financial=
+    legal=
+    side_effects=
+    while [ "$#" -gt 0 ]; do
+      key=$1
+      shift
+      [ "$#" -gt 0 ] || fail "$key needs an explicit value"
+      value=$1
+      shift
+      case "$key" in
+        --request) request=$value ;;
+        --reproduction) reproduction=$value ;;
+        --root-cause) root_cause=$value ;;
+        --isolation) isolation=$value ;;
+        --schema) schema=$value ;;
+        --authentication) authentication=$value ;;
+        --authorization) authorization=$value ;;
+        --secrets) secrets=$value ;;
+        --financial) financial=$value ;;
+        --legal) legal=$value ;;
+        --side-effects) side_effects=$value ;;
+        *) fail "unknown intake evidence flag $key" ;;
+      esac
+    done
+    request_valid "$request" || fail "request does not use the exact 'fast-repair: ' prefix"
+    for field in reproduction root_cause isolation; do
+      eval "value=\${$field}"
+      case "$value" in ''|unknown|ambiguous|false|no) fail "$field is absent, unknown, ambiguous, or not proven" ;; esac
+      case "$value" in *$'\n'*|*$'\r'*) fail "$field must be one typed evidence value" ;; esac
+    done
+    for field in schema authentication authorization secrets financial legal side_effects; do
+      eval "value=\${$field}"
+      [ "$value" = none ] || fail "$field is not explicitly proven none"
+    done
+    dir="$DATA/$id"
+    mkdir -p "$dir"
+    tmp="$dir/.fast-repair-eligibility.$$"
+    umask 077
+    {
+      printf 'request=%s\n' "$request"
+      printf 'reproduction=%s\n' "$reproduction"
+      printf 'root_cause=%s\n' "$root_cause"
+      printf 'isolation=%s\n' "$isolation"
+      printf 'schema=%s\n' "$schema"
+      printf 'authentication=%s\n' "$authentication"
+      printf 'authorization=%s\n' "$authorization"
+      printf 'secrets=%s\n' "$secrets"
+      printf 'financial=%s\n' "$financial"
+      printf 'legal=%s\n' "$legal"
+      printf 'side_effects=%s\n' "$side_effects"
+    } > "$tmp"
+    chmod 600 "$tmp"
+    mv -f "$tmp" "$(eligibility_file "$id")"
+    printf 'fast-repair eligible: %s\n' "$id"
+    ;;
+  eligible)
+    [ "$#" -eq 1 ] || { usage >&2; exit 2; }
+    if ! task_id_valid "$1" || ! eligibility_valid "$1"; then
+      fail "eligibility evidence is absent, incomplete, or no longer valid for $1"
+    fi
+    printf 'fast-repair eligible: %s\n' "$1"
+    ;;
+  evidence)
+    id=${1:-}
+    shift || true
+    task_id_valid "$id" || fail "task id is missing or invalid"
+    regression=
+    focused=
+    while [ "$#" -gt 0 ]; do
+      key=$1
+      shift
+      [ "$#" -gt 0 ] || fail "$key needs a command"
+      value=$1
+      shift
+      case "$key" in
+        --regression-command) regression=$value ;;
+        --focused-command) focused=$value ;;
+        *) fail "unknown test evidence flag $key" ;;
+      esac
+    done
+    require_fast_repair_meta "$id"
+    eligibility_valid "$id" || fail "eligibility evidence is absent or invalid"
+    [ -n "$regression" ] && [ -n "$focused" ] || fail "regression and focused commands are both required"
+    mkdir -p "$STATE"
+    log="$STATE/$id.fast-repair-tests.log"
+    record="$STATE/.$id.fast-repair-tests.$$"
+    umask 077
+    if bash -lc "$regression" >"$log" 2>&1; then regression_result=passed; else regression_result=failed; fi
+    if [ "$regression_result" = passed ] && bash -lc "$focused" >>"$log" 2>&1; then focused_result=passed; else focused_result=failed; fi
+    {
+      printf 'regression=%s\n' "$regression_result"
+      printf 'focused=%s\n' "$focused_result"
+    } > "$record"
+    chmod 600 "$record"
+    mv -f "$record" "$(tests_file "$id")"
+    tests_passed "$id" || fail "regression or focused-module evidence failed; PR publication remains blocked"
+    printf 'fast-repair focused evidence passed: %s\n' "$id"
+    ;;
+  publish-pr)
+    id=${1:-}
+    shift || true
+    task_id_valid "$id" || fail "task id is missing or invalid"
+    title=
+    body_file=
+    base=
+    head=
+    while [ "$#" -gt 0 ]; do
+      key=$1
+      shift
+      [ "$#" -gt 0 ] || fail "$key needs a value"
+      value=$1
+      shift
+      case "$key" in
+        --title) title=$value ;;
+        --body-file) body_file=$value ;;
+        --base) base=$value ;;
+        --head) head=$value ;;
+        *) fail "unknown PR flag $key" ;;
+      esac
+    done
+    require_fast_repair_meta "$id"
+    eligibility_valid "$id" || fail "eligibility evidence is absent or invalid"
+    tests_passed "$id" || fail "focused evidence is absent or failed; direct PR publication is blocked"
+    if [ -z "$title" ] || ! regular_file "$body_file"; then
+      fail "a title and safe body file are required"
+    fi
+    args=(pr create --title "$title" --body-file "$body_file")
+    [ -z "$base" ] || args+=(--base "$base")
+    [ -z "$head" ] || args+=(--head "$head")
+    out=$(gh-axi "${args[@]}") || exit $?
+    printf '%s\n' "$out"
+    url=$(printf '%s\n' "$out" | grep -Eo 'https://github\.com/[^[:space:]]+/pull/[0-9]+' | head -n 1 || true)
+    [ -n "$url" ] || fail "PR creation returned no GitHub pull-request URL"
+    "$SCRIPT_DIR/fm-pr-check.sh" "$id" "$url" >/dev/null
+    printf 'fast-repair PR opened: %s\n' "$url"
+    ;;
+  broader)
+    id=${1:-}
+    shift || true
+    task_id_valid "$id" || fail "task id is missing or invalid"
+    [ "${1:-}" = --command ] && [ "$#" -eq 2 ] || fail "broader requires exactly --command <command>"
+    broader_command=$2
+    require_fast_repair_meta "$id"
+    pr_url_for "$id" >/dev/null || fail "broader tests start only after the direct PR is registered"
+    [ -n "$broader_command" ] || fail "broader command is empty"
+    log="$STATE/$id.fast-repair-broader.log"
+    record="$STATE/.$id.fast-repair-broader.$$"
+    umask 077
+    if bash -lc "$broader_command" >"$log" 2>&1; then result=passed; else result=failed; fi
+    printf 'broader=%s\n' "$result" > "$record"
+    chmod 600 "$record"
+    mv -f "$record" "$STATE/$id.fast-repair-broader"
+    [ "$result" = passed ] || fail "broader tests failed after PR publication; inspect $log and report the open PR as not green"
+    printf 'fast-repair broader tests passed: %s\n' "$id"
+    ;;
+  progress)
+    [ "$#" -eq 1 ] || { usage >&2; exit 2; }
+    id=$1
+    require_fast_repair_meta "$id"
+    if regular_file "$STATE/$id.fast-repair-broader" && [ "$(field_get "$STATE/$id.fast-repair-broader" broader)" = failed ]; then
+      printf 'fast-repair %s broader-tests-failed\n' "$id"
+      exit 0
+    fi
+    url=$(pr_url_for "$id" 2>/dev/null || true)
+    [ -n "$url" ] || exit 0
+    summary=$(checks_summary "$url" 2>/dev/null || true)
+    state=$(checks_state "$summary")
+    case "$state" in
+      failed) printf 'fast-repair %s pr-checks-failed: %s\n' "$id" "$summary" ;;
+      green) printf 'fast-repair %s pr-checks-green: %s\n' "$id" "$summary" ;;
+    esac
+    ;;
+  ready)
+    [ "$#" -eq 1 ] || { usage >&2; exit 2; }
+    id=$1
+    require_fast_repair_meta "$id"
+    tests_passed "$id" || fail "focused evidence is absent or failed"
+    [ "$(field_get "$STATE/$id.fast-repair-broader" broader)" = passed ] || fail "broader tests are not passed"
+    url=$(pr_url_for "$id") || fail "no registered Fast Repair PR"
+    summary=$(checks_summary "$url") || fail "PR checks could not be read"
+    [ "$(checks_state "$summary")" = green ] || fail "PR checks are not green: $summary"
+    printf 'fast-repair ready: %s\n' "$url"
+    ;;
+  *) usage >&2; exit 2 ;;
+esac

--- a/bin/fm-fast-repair.sh
+++ b/bin/fm-fast-repair.sh
@@ -56,6 +56,17 @@ regular_file() {
   [ -f "$1" ] && [ ! -L "$1" ]
 }
 
+# Evidence logs and records are private to this home. The umask is scoped to the
+# creation itself so it never reaches the caller-supplied test commands, whose
+# own output files must keep the permissions their build or suite intends.
+private_truncate() { # <path>
+  ( umask 077; : > "$1" ) && chmod 600 "$1"
+}
+
+private_write() { # <path>, content on stdin
+  ( umask 077; cat > "$1" ) && chmod 600 "$1"
+}
+
 field_get() { # <file> <field>
   sed -n "s/^$2=//p" "$1" | head -n 1
 }
@@ -301,14 +312,13 @@ case "$command" in
     mkdir -p "$STATE"
     log="$STATE/$id.fast-repair-tests.log"
     record="$STATE/.$id.fast-repair-tests.$$"
-    umask 077
-    if bash -lc "$regression" >"$log" 2>&1; then regression_result=passed; else regression_result=failed; fi
-    if [ "$regression_result" = passed ] && bash -lc "$focused" >>"$log" 2>&1; then focused_result=passed; else focused_result=failed; fi
+    private_truncate "$log" || fail "the evidence log could not be created"
+    if bash -c "$regression" >>"$log" 2>&1; then regression_result=passed; else regression_result=failed; fi
+    if [ "$regression_result" = passed ] && bash -c "$focused" >>"$log" 2>&1; then focused_result=passed; else focused_result=failed; fi
     {
       printf 'regression=%s\n' "$regression_result"
       printf 'focused=%s\n' "$focused_result"
-    } > "$record"
-    chmod 600 "$record"
+    } | private_write "$record" || fail "the evidence record could not be written"
     mv -f "$record" "$(tests_file "$id")"
     tests_passed "$id" || fail "regression or focused-module evidence failed; PR publication remains blocked"
     printf 'fast-repair focused evidence passed: %s\n' "$id"
@@ -362,10 +372,10 @@ case "$command" in
     [ -n "$broader_command" ] || fail "broader command is empty"
     log="$STATE/$id.fast-repair-broader.log"
     record="$STATE/.$id.fast-repair-broader.$$"
-    umask 077
-    if bash -lc "$broader_command" >"$log" 2>&1; then result=passed; else result=failed; fi
-    printf 'broader=%s\n' "$result" > "$record"
-    chmod 600 "$record"
+    private_truncate "$log" || fail "the broader-test log could not be created"
+    if bash -c "$broader_command" >>"$log" 2>&1; then result=passed; else result=failed; fi
+    printf 'broader=%s\n' "$result" | private_write "$record" \
+      || fail "the broader-test record could not be written"
     mv -f "$record" "$STATE/$id.fast-repair-broader"
     [ "$result" = passed ] || fail "broader tests failed after PR publication; inspect $log and report the open PR as not green"
     printf 'fast-repair broader tests passed: %s\n' "$id"

--- a/bin/fm-fast-repair.sh
+++ b/bin/fm-fast-repair.sh
@@ -7,7 +7,7 @@
 #     --schema none --authentication none --authorization none --secrets none \
 #     --financial none --legal none --side-effects none
 #   fm-fast-repair.sh eligible <task-id>
-#   fm-fast-repair.sh evidence <task-id> --regression-test <relative-executable-test> --focused-command <command>
+#   fm-fast-repair.sh evidence <task-id> --regression-test <relative-executable-test> --focused-test <relative-executable-test>
 #   fm-fast-repair.sh publish-pr <task-id> --title <text> --body-file <path> [--base <branch>] [--head <branch>]
 #   fm-fast-repair.sh broader <task-id> --command <command>
 #   fm-fast-repair.sh progress <task-id>
@@ -21,8 +21,8 @@
 # uses normal intake for that request.
 #
 # A Fast Repair spawn must use mode=fast-repair, yolo=off, and the built-in
-# Codex gpt-5.6-luna medium profile. `evidence` executes one named regression
-# test directly and a focused-module command and records their result. `publish-pr` refuses
+# Codex gpt-5.6-luna medium profile. `evidence` executes named regression and
+# focused-module tests directly and records their result. `publish-pr` refuses
 # until both passed, then opens and registers a direct PR. `broader` is run
 # after publication while PR checks run concurrently. `ready` refuses until the
 # broader command and all PR checks are green. `progress` prints only a changed
@@ -48,8 +48,7 @@ fail() {
 }
 
 task_id_valid() {
-  case "$1" in ''|*[!A-Za-z0-9._-]*) return 1 ;; esac
-  return 0
+  fm_task_id_creation_valid "$1"
 }
 
 regular_file() {
@@ -92,12 +91,15 @@ positive_fact_valid() { # <field> <value>
 
 risk_excluded() { [ "$1" = none ]; }
 
-regression_test_valid() { # <relative path>
+test_path_valid() {
   case "$1" in
     ''|/*|.|..|../*|*/../*|*'/..'|*$'\n'*|*$'\r'*) return 1 ;;
   esac
   regular_file "$1" && [ -x "$1" ]
 }
+
+regression_test_valid() { test_path_valid "$1"; }
+focused_test_valid() { test_path_valid "$1"; }
 
 eligibility_file() { printf '%s/%s/fast-repair-eligibility\n' "$DATA" "$1"; }
 tests_file() { printf '%s/%s.fast-repair-tests\n' "$STATE" "$1"; }
@@ -130,15 +132,18 @@ eligibility_valid() {
 }
 
 tests_passed() {
-  local id=$1 f regression_test
+  local id=$1 f regression_test focused_test
   f=$(tests_file "$id")
   regular_file "$f" || return 1
   regression_test=$(field_get "$f" regression_test)
+  focused_test=$(field_get "$f" focused_test)
   regression_test_valid "$regression_test" || return 1
-  [ "$(wc -l < "$f" | tr -d '[:space:]')" = 3 ] || return 1
+  focused_test_valid "$focused_test" || return 1
+  [ "$(wc -l < "$f" | tr -d '[:space:]')" = 4 ] || return 1
   [ "$(grep -c '^regression=passed$' "$f")" = 1 ] || return 1
   [ "$(grep -c '^focused=passed$' "$f")" = 1 ] || return 1
-  [ "$(grep -Fxc "regression_test=$regression_test" "$f")" = 1 ]
+  [ "$(grep -Fxc "regression_test=$regression_test" "$f")" = 1 ] || return 1
+  [ "$(grep -Fxc "focused_test=$focused_test" "$f")" = 1 ]
 }
 
 broader_passed() {
@@ -310,7 +315,7 @@ case "$command" in
     shift || true
     task_id_valid "$id" || fail "task id is missing or invalid"
     regression_test=
-    focused=
+    focused_test=
     while [ "$#" -gt 0 ]; do
       key=$1
       shift
@@ -319,7 +324,7 @@ case "$command" in
       shift
       case "$key" in
         --regression-test) regression_test=$value ;;
-        --focused-command) focused=$value ;;
+        --focused-test) focused_test=$value ;;
         *) fail "unknown test evidence flag $key" ;;
       esac
     done
@@ -327,17 +332,19 @@ case "$command" in
     eligibility_valid "$id" || fail "eligibility evidence is absent or invalid"
     regression_test_valid "$regression_test" \
       || fail "regression-test must name an executable regular test file below the current worktree"
-    [ -n "$focused" ] || fail "a focused-module command is required"
+    focused_test_valid "$focused_test" \
+      || fail "focused-test must name an executable regular test file below the current worktree"
     mkdir -p "$STATE"
     log="$STATE/$id.fast-repair-tests.log"
     record="$STATE/.$id.fast-repair-tests.$$"
     private_truncate "$log" || fail "the evidence log could not be created"
     if "./$regression_test" >>"$log" 2>&1; then regression_result=passed; else regression_result=failed; fi
-    if [ "$regression_result" = passed ] && bash -c "$focused" >>"$log" 2>&1; then focused_result=passed; else focused_result=failed; fi
+    if [ "$regression_result" = passed ] && "./$focused_test" >>"$log" 2>&1; then focused_result=passed; else focused_result=failed; fi
     {
       printf 'regression=%s\n' "$regression_result"
       printf 'regression_test=%s\n' "$regression_test"
       printf 'focused=%s\n' "$focused_result"
+      printf 'focused_test=%s\n' "$focused_test"
     } | private_write "$record" || fail "the evidence record could not be written"
     mv -f "$record" "$(tests_file "$id")"
     tests_passed "$id" || fail "regression or focused-module evidence failed; PR publication remains blocked"

--- a/bin/fm-fast-repair.sh
+++ b/bin/fm-fast-repair.sh
@@ -3,11 +3,11 @@
 # Usage:
 #   fm-fast-repair.sh is-request <request>
 #   fm-fast-repair.sh intake <task-id> --request 'fast-repair: <task>' \
-#     --reproduction reproduced --root-cause confirmed --isolation isolated \
+#     --reproduction reproduced --reproduction-revision <commit> --root-cause confirmed --isolation isolated \
 #     --schema none --authentication none --authorization none --secrets none \
 #     --financial none --legal none --side-effects none
 #   fm-fast-repair.sh eligible <task-id>
-#   fm-fast-repair.sh evidence <task-id> --regression-test <relative-test-selector> --focused-test <relative-test-selector>
+#   fm-fast-repair.sh evidence <task-id> --regression-test <runner-family> --focused-test <runner-family>
 #   fm-fast-repair.sh publish-pr <task-id> --title <text> --body-file <path> [--base <branch>] [--head <branch>]
 #   fm-fast-repair.sh broader <task-id> --command <command>
 #   fm-fast-repair.sh progress <task-id>
@@ -22,7 +22,7 @@
 #
 # A Fast Repair spawn must use mode=fast-repair, yolo=off, and the built-in
 # Codex gpt-5.6-luna medium profile. `evidence` executes named regression and
-# focused-module test selectors through the supported test runner and records
+# focused-module runner families through the supported test runner and records
 # their result. `publish-pr` refuses
 # until both passed, then opens and registers a direct PR. `broader` is run
 # after publication while PR checks run concurrently. `ready` refuses until the
@@ -39,6 +39,7 @@ TASK_WORKTREE=
 TASK_BRANCH=
 TASK_HEAD=
 TEST_RUNNER=
+REPRODUCTION_REVISION=
 BODY_FILE=
 
 # shellcheck source=bin/fm-pr-lib.sh
@@ -128,50 +129,70 @@ test_runner_valid() {
   TEST_RUNNER=$resolved
 }
 
-test_selector_valid() {
-  local kind=$1 path=$2 parent resolved rel
-  case "$path" in
-    ''|/*|.|..|../*|*/../*|*'/..'|*$'\n'*|*$'\r'*) return 1 ;;
-  esac
-  [ -n "$TASK_WORKTREE" ] || return 1
-  parent=$(dirname "$TASK_WORKTREE/$path")
-  resolved=$(cd "$parent" 2>/dev/null && pwd -P) || return 1
-  resolved="$resolved/$(basename "$path")"
-  case "$resolved" in "$TASK_WORKTREE"/*) ;; *) return 1 ;; esac
-  regular_file "$resolved" || return 1
-  rel=${resolved#"$TASK_WORKTREE/"}
-  case "$kind:$rel" in
-    regression:tests/*-regression.test.sh|focused:tests/*-focused.test.sh) ;;
-    *) return 1 ;;
-  esac
-  [ "$(git -C "$TASK_WORKTREE" cat-file -t "$TASK_HEAD:$rel" 2>/dev/null || true)" = blob ] || return 1
-  git -C "$TASK_WORKTREE" diff --no-ext-diff --quiet "$TASK_HEAD" -- ":(literal)$rel" || return 1
+runner_family_valid() {
+  local family=$1
+  case "$family" in ''|*[!A-Za-z0-9_-]*|*'--'*) return 1 ;; esac
+  test_runner_valid || return 1
+  "$TEST_RUNNER" --list-families 2>/dev/null | grep -Fx "$family" >/dev/null
 }
 
-regression_test_valid() { test_selector_valid regression "$1" && test_runner_valid; }
-focused_test_valid() { test_selector_valid focused "$1" && test_runner_valid; }
+reproduction_revision_valid() {
+  case "$1" in ????????????????????????????????????????) ;; *) return 1 ;; esac
+  case "$1" in *[!0-9a-f]*) return 1 ;; esac
+}
 
-run_typed_test() { # <selector> <log>
-  local selector=$1 log=$2 output status
+reproduction_revision_for() {
+  local id=$1 revision
+  revision=$(field_get "$(eligibility_file "$id")" reproduction_revision)
+  reproduction_revision_valid "$revision" || return 1
+  git -C "$TASK_WORKTREE" cat-file -e "$revision^{commit}" 2>/dev/null || return 1
+  [ "$revision" != "$TASK_HEAD" ] || return 1
+  git -C "$TASK_WORKTREE" merge-base --is-ancestor "$revision" "$TASK_HEAD" || return 1
+  git -C "$TASK_WORKTREE" diff --no-ext-diff --quiet "$revision" "$TASK_HEAD" -- bin/fm-test-run.sh || return 1
+  REPRODUCTION_REVISION=$revision
+}
+
+regression_test_valid() { runner_family_valid "$1"; }
+focused_test_valid() { runner_family_valid "$1"; }
+
+run_typed_test() { # <worktree> <family> <pass|fail> <log>
+  local worktree=$1 family=$2 expected=$3 log=$4 output status
   output=$(mktemp "$STATE/.fast-repair-test-output.XXXXXX") || return 1
   chmod 600 "$output" || { rm -f "$output"; return 1; }
-  if ( cd "$TASK_WORKTREE" && "$TEST_RUNNER" "$selector" ) >"$output" 2>&1; then
+  if ( cd "$worktree" && "$worktree/bin/fm-test-run.sh" --family "$family" ) >"$output" 2>&1; then
     status=0
   else
     status=1
   fi
   cat "$output" >> "$log" || status=1
-  if [ "$status" -eq 0 ] \
-    && awk -v selector="$selector" '
-      $1 == "FM_TEST_BEGIN" && $3 == selector { began = 1 }
-      $1 == "FM_TEST_END" && $3 == selector && $4 == "exit=0" { passed = 1 }
-      END { exit !(began && passed) }
+  if awk -v expected="$expected" -v status="$status" '
+      $1 == "FM_TEST_BEGIN" { began = 1 }
+      $1 == "FM_TEST_END" && $4 == "exit=0" { passed = 1 }
+      $1 == "FM_TEST_END" && $4 != "exit=0" { failed = 1 }
+      END {
+        if (expected == "pass") exit !(status == 0 && began && passed)
+        exit !(status != 0 && began && failed)
+      }
     ' "$output"; then
     rm -f "$output"
     return 0
   fi
   rm -f "$output"
   return 1
+}
+
+regression_proof_valid() { # <task-id> <family> <log>
+  local id=$1 family=$2 log=$3 sandbox
+  reproduction_revision_for "$id" || return 1
+  sandbox=$(mktemp -d "$STATE/.fast-repair-reproduction.XXXXXX") || return 1
+  rmdir "$sandbox" || return 1
+  if ! git clone --quiet --no-hardlinks "$TASK_WORKTREE" "$sandbox" \
+    || ! git -C "$sandbox" checkout --quiet --detach "$REPRODUCTION_REVISION" \
+    || ! run_typed_test "$sandbox" "$family" fail "$log"; then
+    rm -rf "$sandbox"
+    return 1
+  fi
+  rm -rf "$sandbox"
 }
 
 eligibility_file() { printf '%s/%s/fast-repair-eligibility\n' "$DATA" "$1"; }
@@ -200,10 +221,12 @@ eligibility_valid() {
   local id=$1 f request positive risk
   f=$(eligibility_file "$id")
   regular_file "$f" || return 1
-  [ "$(wc -l < "$f" | tr -d '[:space:]')" = 11 ] || return 1
+  [ "$(wc -l < "$f" | tr -d '[:space:]')" = 12 ] || return 1
   request=$(field_get "$f" request)
   request_valid "$request" || return 1
   [ "$(grep -c '^request=' "$f")" = 1 ] || return 1
+  reproduction_revision_valid "$(field_get "$f" reproduction_revision)" || return 1
+  [ "$(grep -c '^reproduction_revision=' "$f")" = 1 ] || return 1
   for positive in reproduction root_cause isolation; do
     positive_fact_valid "$positive" "$(field_get "$f" "$positive")" || return 1
     [ "$(grep -c "^$positive=" "$f")" = 1 ] || return 1
@@ -215,25 +238,29 @@ eligibility_valid() {
 }
 
 tests_passed() {
-  local id=$1 f regression_test focused_test worktree branch head
+  local id=$1 f regression_test focused_test reproduction_revision worktree branch head
   f=$(tests_file "$id")
   regular_file "$f" || return 1
   task_revision_for "$id" || return 1
   regression_test=$(field_get "$f" regression_test)
   focused_test=$(field_get "$f" focused_test)
+  reproduction_revision=$(field_get "$f" reproduction_revision)
   worktree=$(field_get "$f" worktree)
   branch=$(field_get "$f" branch)
   head=$(field_get "$f" head)
   regression_test_valid "$regression_test" || return 1
   focused_test_valid "$focused_test" || return 1
+  reproduction_revision_for "$id" || return 1
+  [ "$reproduction_revision" = "$REPRODUCTION_REVISION" ] || return 1
   [ "$worktree" = "$TASK_WORKTREE" ] || return 1
   [ "$branch" = "$TASK_BRANCH" ] || return 1
   [ "$head" = "$TASK_HEAD" ] || return 1
-  [ "$(wc -l < "$f" | tr -d '[:space:]')" = 7 ] || return 1
+  [ "$(wc -l < "$f" | tr -d '[:space:]')" = 8 ] || return 1
   [ "$(grep -c '^regression=passed$' "$f")" = 1 ] || return 1
   [ "$(grep -c '^focused=passed$' "$f")" = 1 ] || return 1
   [ "$(grep -Fxc "regression_test=$regression_test" "$f")" = 1 ] || return 1
   [ "$(grep -Fxc "focused_test=$focused_test" "$f")" = 1 ] || return 1
+  [ "$(grep -Fxc "reproduction_revision=$reproduction_revision" "$f")" = 1 ] || return 1
   [ "$(grep -Fxc "worktree=$worktree" "$f")" = 1 ] || return 1
   [ "$(grep -Fxc "branch=$branch" "$f")" = 1 ] || return 1
   [ "$(grep -Fxc "head=$head" "$f")" = 1 ]
@@ -363,6 +390,7 @@ case "$command" in
     task_id_valid "$id" || fail "task id is missing or invalid"
     request=
     reproduction=
+    reproduction_revision=
     root_cause=
     isolation=
     schema=
@@ -381,6 +409,7 @@ case "$command" in
       case "$key" in
         --request) request=$value ;;
         --reproduction) reproduction=$value ;;
+        --reproduction-revision) reproduction_revision=$value ;;
         --root-cause) root_cause=$value ;;
         --isolation) isolation=$value ;;
         --schema) schema=$value ;;
@@ -399,6 +428,8 @@ case "$command" in
       positive_fact_valid "$field" "$value" \
         || fail "$field must equal its exact typed proof value"
     done
+    reproduction_revision_valid "$reproduction_revision" \
+      || fail "reproduction-revision must be a lowercase commit SHA"
     for field in schema authentication authorization secrets financial legal side_effects; do
       eval "value=\${$field}"
       risk_excluded "$value" || fail "$field is not explicitly proven none"
@@ -410,6 +441,7 @@ case "$command" in
     {
       printf 'request=%s\n' "$request"
       printf 'reproduction=%s\n' "$reproduction"
+      printf 'reproduction_revision=%s\n' "$reproduction_revision"
       printf 'root_cause=%s\n' "$root_cause"
       printf 'isolation=%s\n' "$isolation"
       printf 'schema=%s\n' "$schema"
@@ -453,22 +485,24 @@ case "$command" in
     eligibility_valid "$id" || fail "eligibility evidence is absent or invalid"
     task_revision_for "$id" || fail "task $id has no safe git worktree at its metadata path"
     regression_test_valid "$regression_test" \
-      || fail "regression-test must name an unchanged tests/*-regression.test.sh selector supported by bin/fm-test-run.sh"
+      || fail "regression-test must name a supported bin/fm-test-run.sh family"
     focused_test_valid "$focused_test" \
-      || fail "focused-test must name an unchanged tests/*-focused.test.sh selector supported by bin/fm-test-run.sh"
+      || fail "focused-test must name a supported bin/fm-test-run.sh family"
     [ "$regression_test" != "$focused_test" ] \
       || fail "regression-test and focused-test must name different test selectors"
     mkdir -p "$STATE"
     log="$STATE/$id.fast-repair-tests.log"
     record="$STATE/.$id.fast-repair-tests.$$"
     private_truncate "$log" || fail "the evidence log could not be created"
-    if run_typed_test "$regression_test" "$log"; then regression_result=passed; else regression_result=failed; fi
-    if [ "$regression_result" = passed ] && run_typed_test "$focused_test" "$log"; then focused_result=passed; else focused_result=failed; fi
+    if run_typed_test "$TASK_WORKTREE" "$regression_test" pass "$log" \
+      && regression_proof_valid "$id" "$regression_test" "$log"; then regression_result=passed; else regression_result=failed; fi
+    if [ "$regression_result" = passed ] && run_typed_test "$TASK_WORKTREE" "$focused_test" pass "$log"; then focused_result=passed; else focused_result=failed; fi
     {
       printf 'regression=%s\n' "$regression_result"
       printf 'regression_test=%s\n' "$regression_test"
       printf 'focused=%s\n' "$focused_result"
       printf 'focused_test=%s\n' "$focused_test"
+      printf 'reproduction_revision=%s\n' "$REPRODUCTION_REVISION"
       printf 'worktree=%s\n' "$TASK_WORKTREE"
       printf 'branch=%s\n' "$TASK_BRANCH"
       printf 'head=%s\n' "$TASK_HEAD"

--- a/bin/fm-fast-repair.sh
+++ b/bin/fm-fast-repair.sh
@@ -254,11 +254,12 @@ run_typed_test() { # <worktree> <family> <pass|fail> <log>
   cat "$output" >> "$log" || status=1
   if awk -v expected="$expected" -v status="$status" '
       $1 == "FM_TEST_BEGIN" { began = 1 }
+      $1 == "FM_TEST_END" && $0 ~ /(^|[[:space:]])gate_skip=true([[:space:]]|$)/ { skipped = 1 }
       $1 == "FM_TEST_END" && $4 == "exit=0" { passed = 1 }
       $1 == "FM_TEST_END" && $4 != "exit=0" { failed = 1 }
       END {
-        if (expected == "pass") exit !(status == 0 && began && passed)
-        exit !(status != 0 && began && failed)
+        if (expected == "pass") exit !(status == 0 && began && passed && !skipped)
+        exit !(status != 0 && began && failed && !skipped)
       }
     ' "$output"; then
     rm -f "$output"
@@ -280,11 +281,12 @@ run_typed_selector() { # <worktree> <selector> <pass|fail> <log>
   cat "$output" >> "$log" || status=1
   if awk -v expected="$expected" -v status="$status" '
       $1 == "FM_TEST_BEGIN" { began = 1 }
+      $1 == "FM_TEST_END" && $0 ~ /(^|[[:space:]])gate_skip=true([[:space:]]|$)/ { skipped = 1 }
       $1 == "FM_TEST_END" && $4 == "exit=0" { passed = 1 }
       $1 == "FM_TEST_END" && $4 != "exit=0" { failed = 1 }
       END {
-        if (expected == "pass") exit !(status == 0 && began && passed)
-        exit !(status != 0 && began && failed)
+        if (expected == "pass") exit !(status == 0 && began && passed && !skipped)
+        exit !(status != 0 && began && failed && !skipped)
       }
     ' "$output"; then
     rm -f "$output"
@@ -367,12 +369,14 @@ eligibility_valid() {
   local id=$1 f request positive risk
   f=$(eligibility_file "$id")
   regular_file "$f" || return 1
-  [ "$(wc -l < "$f" | tr -d '[:space:]')" = 12 ] || return 1
+  [ "$(wc -l < "$f" | tr -d '[:space:]')" = 13 ] || return 1
   request=$(field_get "$f" request)
   request_valid "$request" || return 1
   [ "$(grep -c '^request=' "$f")" = 1 ] || return 1
   reproduction_revision_valid "$(field_get "$f" reproduction_revision)" || return 1
   [ "$(grep -c '^reproduction_revision=' "$f")" = 1 ] || return 1
+  case "$(field_get "$f" lifecycle)" in ?*[!A-Za-z0-9._-]*|'') return 1 ;; esac
+  [ "$(grep -c '^lifecycle=' "$f")" = 1 ] || return 1
   for positive in reproduction root_cause isolation; do
     positive_fact_valid "$positive" "$(field_get "$f" "$positive")" || return 1
     [ "$(grep -c "^$positive=" "$f")" = 1 ] || return 1
@@ -601,6 +605,7 @@ case "$command" in
       eval "value=\${$field}"
       risk_excluded "$value" || fail "$field is not explicitly proven none"
     done
+    lifecycle="$(date +%s)-$$-$RANDOM"
     dir="$DATA/$id"
     mkdir -p "$dir"
     tmp="$dir/.fast-repair-eligibility.$$"
@@ -609,6 +614,7 @@ case "$command" in
       printf 'request=%s\n' "$request"
       printf 'reproduction=%s\n' "$reproduction"
       printf 'reproduction_revision=%s\n' "$reproduction_revision"
+      printf 'lifecycle=%s\n' "$lifecycle"
       printf 'root_cause=%s\n' "$root_cause"
       printf 'isolation=%s\n' "$isolation"
       printf 'schema=%s\n' "$schema"

--- a/bin/fm-fast-repair.sh
+++ b/bin/fm-fast-repair.sh
@@ -39,6 +39,7 @@ TASK_WORKTREE=
 TASK_BRANCH=
 TASK_HEAD=
 TEST_RUNNER=
+TEST_RUNNER_ARTIFACT=
 REPRODUCTION_REVISION=
 REGRESSION_SELECTOR=
 REGRESSION_ARTIFACT=
@@ -130,7 +131,7 @@ positive_fact_valid() { # <field> <value>
 risk_excluded() { [ "$1" = none ]; }
 
 test_runner_valid() {
-  local parent resolved rel=bin/fm-test-run.sh
+  local parent resolved rel=bin/fm-test-run.sh artifact
   [ -n "$TASK_WORKTREE" ] || return 1
   parent=$(dirname "$TASK_WORKTREE/$rel")
   resolved=$(cd "$parent" 2>/dev/null && pwd -P) || return 1
@@ -139,7 +140,10 @@ test_runner_valid() {
   regular_file "$resolved" && [ -x "$resolved" ] || return 1
   [ "$(git -C "$TASK_WORKTREE" cat-file -t "$TASK_HEAD:$rel" 2>/dev/null || true)" = blob ] || return 1
   git -C "$TASK_WORKTREE" diff --no-ext-diff --quiet "$TASK_HEAD" -- ":(literal)$rel" || return 1
+  artifact=$(git -C "$TASK_WORKTREE" ls-tree "$TASK_HEAD" -- "$rel" 2>/dev/null | awk '{print $1 ":" $2 ":" $3}') || return 1
+  case "$artifact" in 100755:blob:*) ;; *) return 1 ;; esac
   TEST_RUNNER=$resolved
+  TEST_RUNNER_ARTIFACT="${artifact%%:blob:*}:${artifact#*:blob:}"
 }
 
 runner_family_valid() {
@@ -258,7 +262,7 @@ run_typed_selector() { # <worktree> <selector> <pass|fail> <log>
 }
 
 regression_witness_valid() { # <family> <selector> <artifact> <log>
-  local family=$1 selector=$2 artifact=$3 log=$4 sandbox mode file_mode oid old_selected
+  local family=$1 selector=$2 artifact=$3 log=$4 sandbox sandbox_root parent resolved component target mode file_mode oid runner_oid selected
   case "$artifact" in 100755:*) ;; *) return 1 ;; esac
   mode=${artifact%%:*}
   file_mode=${mode#100}
@@ -266,19 +270,37 @@ regression_witness_valid() { # <family> <selector> <artifact> <log>
   sandbox=$(mktemp -d "$STATE/.fast-repair-reproduction.XXXXXX") || return 1
   rmdir "$sandbox" || return 1
   if ! git clone --quiet --no-hardlinks "$TASK_WORKTREE" "$sandbox" \
-    || ! git -C "$sandbox" checkout --quiet --detach "$REPRODUCTION_REVISION" \
-    || ! mkdir -p "$(dirname "$sandbox/$selector")" \
+    || ! git -C "$sandbox" checkout --quiet --detach "$REPRODUCTION_REVISION"; then
+    rm -rf "$sandbox"
+    return 1
+  fi
+  sandbox_root=$(cd "$sandbox" && pwd -P) || { rm -rf "$sandbox"; return 1; }
+  for parent in "$(dirname "$selector")" bin; do
+    target=$sandbox
+    IFS=/ read -r -a components <<< "$parent"
+    for component in "${components[@]}"; do
+      [ -n "$component" ] || continue
+      target="$target/$component"
+      [ -e "$target" ] || mkdir "$target" || { rm -rf "$sandbox"; return 1; }
+      resolved=$(cd "$target" && pwd -P) || { rm -rf "$sandbox"; return 1; }
+      case "$resolved" in "$sandbox_root"|"$sandbox_root"/*) ;; *) rm -rf "$sandbox"; return 1 ;; esac
+    done
+  done
+  runner_oid=${TEST_RUNNER_ARTIFACT#*:}
+  if ! git -C "$TASK_WORKTREE" show "$TASK_HEAD:bin/fm-test-run.sh" > "$sandbox/bin/fm-test-run.sh" \
+    || ! chmod 755 "$sandbox/bin/fm-test-run.sh" \
+    || ! [ "$(git -C "$sandbox" hash-object bin/fm-test-run.sh)" = "$runner_oid" ] \
     || ! git -C "$TASK_WORKTREE" show "$TASK_HEAD:$selector" > "$sandbox/$selector" \
     || ! chmod "$file_mode" "$sandbox/$selector" \
     || ! [ "$(git -C "$sandbox" hash-object "$selector")" = "$oid" ]; then
     rm -rf "$sandbox"
     return 1
   fi
-  old_selected=$(cd "$sandbox" && ./bin/fm-test-run.sh --list --family "$family" 2>/dev/null) || {
+  selected=$(cd "$sandbox" && ./bin/fm-test-run.sh --list --family "$family" 2>/dev/null) || {
     rm -rf "$sandbox"
     return 1
   }
-  if ! printf '%s\n' "$old_selected" | grep -Fx "$selector" >/dev/null \
+  if ! printf '%s\n' "$selected" | grep -Fx "$selector" >/dev/null \
     || ! run_typed_selector "$sandbox" "$selector" fail "$log"; then
     rm -rf "$sandbox"
     return 1
@@ -329,13 +351,14 @@ eligibility_valid() {
 }
 
 tests_passed() {
-  local id=$1 f regression_test regression_selector regression_artifact regression_reproduction regression_head focused_test reproduction_revision worktree branch head
+  local id=$1 f regression_test regression_selector regression_artifact regression_runner regression_reproduction regression_head focused_test reproduction_revision worktree branch head
   f=$(tests_file "$id")
   regular_file "$f" || return 1
   task_revision_for "$id" || return 1
   regression_test=$(field_get "$f" regression_test)
   regression_selector=$(field_get "$f" regression_selector)
   regression_artifact=$(field_get "$f" regression_artifact)
+  regression_runner=$(field_get "$f" regression_runner)
   regression_reproduction=$(field_get "$f" regression_reproduction)
   regression_head=$(field_get "$f" regression_head)
   focused_test=$(field_get "$f" focused_test)
@@ -349,17 +372,19 @@ tests_passed() {
   [ "$reproduction_revision" = "$REPRODUCTION_REVISION" ] || return 1
   [ "$regression_selector" = "$REGRESSION_SELECTOR" ] || return 1
   [ "$regression_artifact" = "$REGRESSION_ARTIFACT" ] || return 1
+  [ "$regression_runner" = "$TEST_RUNNER_ARTIFACT" ] || return 1
   [ "$regression_reproduction" = failed ] || return 1
   [ "$regression_head" = passed ] || return 1
   [ "$worktree" = "$TASK_WORKTREE" ] || return 1
   [ "$branch" = "$TASK_BRANCH" ] || return 1
   [ "$head" = "$TASK_HEAD" ] || return 1
-  [ "$(wc -l < "$f" | tr -d '[:space:]')" = 12 ] || return 1
+  [ "$(wc -l < "$f" | tr -d '[:space:]')" = 13 ] || return 1
   [ "$(grep -c '^regression=passed$' "$f")" = 1 ] || return 1
   [ "$(grep -c '^focused=passed$' "$f")" = 1 ] || return 1
   [ "$(grep -Fxc "regression_test=$regression_test" "$f")" = 1 ] || return 1
   [ "$(grep -Fxc "regression_selector=$regression_selector" "$f")" = 1 ] || return 1
   [ "$(grep -Fxc "regression_artifact=$regression_artifact" "$f")" = 1 ] || return 1
+  [ "$(grep -Fxc "regression_runner=$regression_runner" "$f")" = 1 ] || return 1
   [ "$(grep -c '^regression_reproduction=failed$' "$f")" = 1 ] || return 1
   [ "$(grep -c '^regression_head=passed$' "$f")" = 1 ] || return 1
   [ "$(grep -Fxc "focused_test=$focused_test" "$f")" = 1 ] || return 1
@@ -622,6 +647,7 @@ case "$command" in
       printf 'regression_test=%s\n' "$regression_test"
       printf 'regression_selector=%s\n' "$REGRESSION_SELECTOR"
       printf 'regression_artifact=%s\n' "$REGRESSION_ARTIFACT"
+      printf 'regression_runner=%s\n' "$TEST_RUNNER_ARTIFACT"
       printf 'regression_reproduction=%s\n' "$regression_reproduction"
       printf 'regression_head=%s\n' "$regression_head"
       printf 'focused=%s\n' "$focused_result"

--- a/bin/fm-fast-repair.sh
+++ b/bin/fm-fast-repair.sh
@@ -37,6 +37,8 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 TASK_WORKTREE=
 TASK_BRANCH=
 TASK_HEAD=
+TEST_PATH=
+BODY_FILE=
 
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
@@ -113,7 +115,7 @@ positive_fact_valid() { # <field> <value>
 risk_excluded() { [ "$1" = none ]; }
 
 test_path_valid() {
-  local path=$1 parent resolved
+  local path=$1 parent resolved rel
   case "$path" in
     ''|/*|.|..|../*|*/../*|*'/..'|*$'\n'*|*$'\r'*) return 1 ;;
   esac
@@ -122,7 +124,11 @@ test_path_valid() {
   resolved=$(cd "$parent" 2>/dev/null && pwd -P) || return 1
   resolved="$resolved/$(basename "$path")"
   case "$resolved" in "$TASK_WORKTREE"/*) ;; *) return 1 ;; esac
-  regular_file "$resolved" && [ -x "$resolved" ]
+  regular_file "$resolved" && [ -x "$resolved" ] || return 1
+  rel=${resolved#"$TASK_WORKTREE/"}
+  [ "$(git -C "$TASK_WORKTREE" cat-file -t "$TASK_HEAD:$rel" 2>/dev/null || true)" = blob ] || return 1
+  git -C "$TASK_WORKTREE" diff --no-ext-diff --quiet "$TASK_HEAD" -- ":(literal)$rel" || return 1
+  TEST_PATH=$resolved
 }
 
 regression_test_valid() { test_path_valid "$1"; }
@@ -130,6 +136,16 @@ focused_test_valid() { test_path_valid "$1"; }
 
 eligibility_file() { printf '%s/%s/fast-repair-eligibility\n' "$DATA" "$1"; }
 tests_file() { printf '%s/%s.fast-repair-tests\n' "$STATE" "$1"; }
+
+body_file_valid() {
+  local path=$1 parent resolved
+  [ -n "$path" ] || return 1
+  parent=$(dirname "$path")
+  resolved=$(cd "$parent" 2>/dev/null && pwd -P) || return 1
+  resolved="$resolved/$(basename "$path")"
+  regular_file "$resolved" || return 1
+  BODY_FILE=$resolved
+}
 
 require_fast_repair_meta() {
   local id meta
@@ -397,15 +413,17 @@ case "$command" in
     eligibility_valid "$id" || fail "eligibility evidence is absent or invalid"
     task_revision_for "$id" || fail "task $id has no safe git worktree at its metadata path"
     regression_test_valid "$regression_test" \
-      || fail "regression-test must name an executable regular test file below the current worktree"
+      || fail "regression-test must name an unchanged executable test file in the task commit"
+    regression_path=$TEST_PATH
     focused_test_valid "$focused_test" \
-      || fail "focused-test must name an executable regular test file below the current worktree"
+      || fail "focused-test must name an unchanged executable test file in the task commit"
+    focused_path=$TEST_PATH
     mkdir -p "$STATE"
     log="$STATE/$id.fast-repair-tests.log"
     record="$STATE/.$id.fast-repair-tests.$$"
     private_truncate "$log" || fail "the evidence log could not be created"
-    if ( cd "$TASK_WORKTREE" && "./$regression_test" ) >>"$log" 2>&1; then regression_result=passed; else regression_result=failed; fi
-    if [ "$regression_result" = passed ] && ( cd "$TASK_WORKTREE" && "./$focused_test" ) >>"$log" 2>&1; then focused_result=passed; else focused_result=failed; fi
+    if "$regression_path" >>"$log" 2>&1; then regression_result=passed; else regression_result=failed; fi
+    if [ "$regression_result" = passed ] && "$focused_path" >>"$log" 2>&1; then focused_result=passed; else focused_result=failed; fi
     {
       printf 'regression=%s\n' "$regression_result"
       printf 'regression_test=%s\n' "$regression_test"
@@ -446,13 +464,13 @@ case "$command" in
     tests_passed "$id" || fail "focused evidence is absent or failed; direct PR publication is blocked"
     [ -z "$head" ] || [ "$head" = "$TASK_BRANCH" ] \
       || fail "--head must equal the tested task branch $TASK_BRANCH"
-    if [ -z "$title" ] || ! regular_file "$body_file"; then
+    if [ -z "$title" ] || ! body_file_valid "$body_file"; then
       fail "a title and safe body file are required"
     fi
-    args=(pr create --title "$title" --body-file "$body_file")
+    args=(pr create --title "$title" --body-file "$BODY_FILE")
     [ -z "$base" ] || args+=(--base "$base")
     args+=(--head "$TASK_BRANCH")
-    out=$(gh-axi "${args[@]}") || exit $?
+    out=$(cd "$TASK_WORKTREE" && gh-axi "${args[@]}") || exit $?
     printf '%s\n' "$out"
     url=$(printf '%s\n' "$out" | grep -Eo 'https://github\.com/[^[:space:]]+/pull/[0-9]+' | head -n 1 || true)
     [ -n "$url" ] || fail "PR creation returned no GitHub pull-request URL"

--- a/bin/fm-fast-repair.sh
+++ b/bin/fm-fast-repair.sh
@@ -10,7 +10,7 @@
 #   fm-fast-repair.sh evidence <task-id> --regression-test <runner-family> --focused-test <runner-family>
 #   fm-fast-repair.sh publish-pr <task-id> --title <text> --body-file <path> [--base <branch>] [--head <branch>]
 #   fm-fast-repair.sh broader <task-id> --test <runner-family>
-#   fm-fast-repair.sh progress <task-id>
+#   fm-fast-repair.sh progress <task-id> [--local-only]
 #   fm-fast-repair.sh ready <task-id>
 #
 # `fast-repair:` is the only accepted request prefix, and it must be followed by
@@ -28,7 +28,10 @@
 # after publication while PR checks run concurrently, and its family must differ
 # from the focused family already proven before the PR. `ready` refuses until the
 # broader test family and all PR checks are green. `progress` prints only a changed
-# actionable state for the watcher's Fast-Repair-only cadence.
+# actionable state for the watcher's Fast-Repair-only cadence. `progress
+# --local-only` reads just this home's own broader-test record and never contacts
+# the forge, so the watcher can keep following a still-running broader family
+# after it has stopped polling PR checks.
 #
 # `eligible --worktree` is the dispatch-time gate, so it proves only what exists
 # before the crewmate branches and commits: a clean worktree of the task's own
@@ -820,8 +823,13 @@ case "$command" in
     printf 'fast-repair broader tests passed: %s\n' "$id"
     ;;
   progress)
-    [ "$#" -eq 1 ] || { usage >&2; exit 2; }
-    id=$1
+    id=${1:-}
+    shift || true
+    local_only=0
+    if [ "$#" -gt 0 ]; then
+      [ "$#" -eq 1 ] && [ "$1" = --local-only ] || { usage >&2; exit 2; }
+      local_only=1
+    fi
     task_id_valid "$id" || fail "task id is missing or invalid"
     require_fast_repair_meta "$id"
     eligibility_valid "$id" || fail "eligibility evidence is absent or invalid"
@@ -829,6 +837,7 @@ case "$command" in
       printf 'fast-repair %s broader-tests-failed\n' "$id"
       exit 0
     fi
+    [ "$local_only" -eq 0 ] || exit 0
     pr_identity_for "$id" 2>/dev/null || exit 0
     summary=$(checks_summary "$FM_PR_NUMBER" "$FM_PR_OWNER/$FM_PR_REPO" 2>/dev/null || true)
     state=$(checks_state "$summary")

--- a/bin/fm-fast-repair.sh
+++ b/bin/fm-fast-repair.sh
@@ -9,7 +9,7 @@
 #   fm-fast-repair.sh eligible <task-id> [--worktree <path>]
 #   fm-fast-repair.sh evidence <task-id> --regression-test <runner-family> --focused-test <runner-family>
 #   fm-fast-repair.sh publish-pr <task-id> --title <text> --body-file <path> [--base <branch>] [--head <branch>]
-#   fm-fast-repair.sh broader <task-id> --command <command>
+#   fm-fast-repair.sh broader <task-id> --test <runner-family>
 #   fm-fast-repair.sh progress <task-id>
 #   fm-fast-repair.sh ready <task-id>
 #
@@ -26,7 +26,7 @@
 # their result. `publish-pr` refuses
 # until both passed, then opens and registers a direct PR. `broader` is run
 # after publication while PR checks run concurrently. `ready` refuses until the
-# broader command and all PR checks are green. `progress` prints only a changed
+# broader test family and all PR checks are green. `progress` prints only a changed
 # actionable state for the watcher's Fast-Repair-only cadence.
 set -eu
 
@@ -82,6 +82,21 @@ task_revision_for() {
   task_revision_at_worktree "$TASK_WORKTREE"
 }
 
+task_worktree_clean() { # <worktree>
+  local worktree=$1 path rel output
+  local paths=(.)
+  for path in "$STATE" "$DATA"; do
+    case "$path" in
+      "$worktree"/*)
+        rel=${path#"$worktree"/}
+        paths+=(":(exclude,top)$rel")
+        ;;
+    esac
+  done
+  output=$(git -C "$worktree" status --porcelain=v1 --untracked-files=all -- "${paths[@]}" 2>/dev/null) || return 1
+  [ -z "$output" ]
+}
+
 task_revision_at_worktree() {
   local worktree=$1 root
   [ -d "$worktree" ] || return 1
@@ -91,6 +106,7 @@ task_revision_at_worktree() {
   TASK_WORKTREE=$root
   TASK_BRANCH=$(git -C "$TASK_WORKTREE" symbolic-ref --quiet --short HEAD 2>/dev/null) || return 1
   TASK_HEAD=$(git -C "$TASK_WORKTREE" rev-parse --verify HEAD 2>/dev/null) || return 1
+  task_worktree_clean "$TASK_WORKTREE"
 }
 
 # Evidence logs and records are private to this home. The umask is scoped to the
@@ -114,7 +130,10 @@ request_valid() {
     *) return 1 ;;
   esac
   case "$1" in *$'\n'*|*$'\r'*) return 1 ;; esac
-  case "${1#fast-repair: }" in *[![:space:]]*) ;; *) return 1 ;; esac
+  case "${1#fast-repair: }" in
+    *[![:space:]]*) ;;
+    *) return 1 ;;
+  esac
 }
 
 # The one rule for a proven positive fact and for an excluded risk. intake
@@ -207,7 +226,21 @@ EOF
   [ "$new_count" -eq 1 ]
 }
 
-focused_test_valid() { runner_family_valid "$1"; }
+runner_family_artifacts_valid() { # <family>
+  local selected path
+  runner_family_valid "$1" || return 1
+  selected=$(runner_selected_tests "$1") || return 1
+  [ -n "$selected" ] || return 1
+  while IFS= read -r path; do
+    [ -n "$path" ] || return 1
+    runner_selected_test_valid "$path" || return 1
+  done <<EOF
+$selected
+EOF
+}
+
+focused_test_valid() { runner_family_artifacts_valid "$1"; }
+broader_test_valid() { runner_family_artifacts_valid "$1"; }
 
 run_typed_test() { # <worktree> <family> <pass|fail> <log>
   local worktree=$1 family=$2 expected=$3 log=$4 output status
@@ -395,18 +428,24 @@ tests_passed() {
 }
 
 broader_passed() {
-  local id=$1 f worktree branch head
+  local id=$1 f broader_test broader_runner worktree branch head
   f="$STATE/$id.fast-repair-broader"
   regular_file "$f" || return 1
   task_revision_for "$id" || return 1
+  broader_test=$(field_get "$f" broader_test)
+  broader_runner=$(field_get "$f" broader_runner)
   worktree=$(field_get "$f" worktree)
   branch=$(field_get "$f" branch)
   head=$(field_get "$f" head)
+  broader_test_valid "$broader_test" || return 1
+  [ "$broader_runner" = "$TEST_RUNNER_ARTIFACT" ] || return 1
   [ "$worktree" = "$TASK_WORKTREE" ] || return 1
   [ "$branch" = "$TASK_BRANCH" ] || return 1
   [ "$head" = "$TASK_HEAD" ] || return 1
-  [ "$(wc -l < "$f" | tr -d '[:space:]')" = 4 ] || return 1
+  [ "$(wc -l < "$f" | tr -d '[:space:]')" = 6 ] || return 1
   [ "$(grep -c '^broader=passed$' "$f")" = 1 ] || return 1
+  [ "$(grep -Fxc "broader_test=$broader_test" "$f")" = 1 ] || return 1
+  [ "$(grep -Fxc "broader_runner=$broader_runner" "$f")" = 1 ] || return 1
   [ "$(grep -Fxc "worktree=$worktree" "$f")" = 1 ] || return 1
   [ "$(grep -Fxc "branch=$branch" "$f")" = 1 ] || return 1
   [ "$(grep -Fxc "head=$head" "$f")" = 1 ]
@@ -707,20 +746,22 @@ case "$command" in
     id=${1:-}
     shift || true
     task_id_valid "$id" || fail "task id is missing or invalid"
-    [ "${1:-}" = --command ] && [ "$#" -eq 2 ] || fail "broader requires exactly --command <command>"
-    broader_command=$2
+    [ "${1:-}" = --test ] && [ "$#" -eq 2 ] || fail "broader requires exactly --test <runner-family>"
+    broader_test=$2
     require_fast_repair_meta "$id"
     eligibility_valid "$id" || fail "eligibility evidence is absent or invalid"
     tests_passed "$id" || fail "focused evidence is absent or failed"
     task_revision_for "$id" || fail "task $id has no safe git worktree at its metadata path"
     pr_identity_for "$id" || fail "broader tests start only after the direct PR is registered"
-    [ -n "$broader_command" ] || fail "broader command is empty"
+    broader_test_valid "$broader_test" || fail "broader-test must name a supported runner family with bound artifacts"
     log="$STATE/$id.fast-repair-broader.log"
     record="$STATE/.$id.fast-repair-broader.$$"
     private_truncate "$log" || fail "the broader-test log could not be created"
-    if ( cd "$TASK_WORKTREE" && bash -c "$broader_command" ) >>"$log" 2>&1; then result=passed; else result=failed; fi
+    if run_typed_test "$TASK_WORKTREE" "$broader_test" pass "$log"; then result=passed; else result=failed; fi
     {
       printf 'broader=%s\n' "$result"
+      printf 'broader_test=%s\n' "$broader_test"
+      printf 'broader_runner=%s\n' "$TEST_RUNNER_ARTIFACT"
       printf 'worktree=%s\n' "$TASK_WORKTREE"
       printf 'branch=%s\n' "$TASK_BRANCH"
       printf 'head=%s\n' "$TASK_HEAD"

--- a/bin/fm-fast-repair.sh
+++ b/bin/fm-fast-repair.sh
@@ -151,6 +151,12 @@ checks_summary() { # <number> <owner/repo>
 # misses green and reads "10 failed, 0 pending" as green. The counts are
 # therefore extracted and compared numerically, and any segment, label, or
 # total this does not recognize stays unknown rather than becoming green.
+#
+# gh-axi's own classifier folds SKIPPED, CANCELLED, EXPECTED and NEUTRAL-state
+# runs into one "skipped" count, so a cancelled workflow is indistinguishable
+# from a deliberately skipped job. A partial skip alongside real passes is
+# ordinary CI and stays green, but a rollup where nothing passed at all has
+# proven nothing and is never green.
 checks_state() { # <summary> -> green|failed|pending|unknown
   local rest=${1-} part count label
   local passed='' failed='' total='' skipped=0 pending=0
@@ -180,6 +186,8 @@ checks_state() { # <summary> -> green|failed|pending|unknown
     printf 'failed\n'
   elif [ "$pending" -gt 0 ]; then
     printf 'pending\n'
+  elif [ "$passed" -eq 0 ]; then
+    printf 'unknown\n'
   else
     printf 'green\n'
   fi
@@ -388,7 +396,7 @@ case "$command" in
     summary=$(checks_summary "$FM_PR_NUMBER" "$FM_PR_OWNER/$FM_PR_REPO") || fail "PR checks could not be read"
     [ -n "$summary" ] || fail "PR checks could not be read"
     [ "$(checks_state "$summary")" = green ] || fail "PR checks are not green: $summary"
-    printf 'fast-repair ready: %s\n' "$FM_PR_URL"
+    printf 'fast-repair ready: %s (%s)\n' "$FM_PR_URL" "$summary"
     ;;
   *) usage >&2; exit 2 ;;
 esac

--- a/bin/fm-fast-repair.sh
+++ b/bin/fm-fast-repair.sh
@@ -25,9 +25,16 @@
 # focused-module runner families through the supported test runner and records
 # their result. `publish-pr` refuses
 # until both passed, then opens and registers a direct PR. `broader` is run
-# after publication while PR checks run concurrently. `ready` refuses until the
+# after publication while PR checks run concurrently, and its family must differ
+# from the focused family already proven before the PR. `ready` refuses until the
 # broader test family and all PR checks are green. `progress` prints only a changed
 # actionable state for the watcher's Fast-Repair-only cadence.
+#
+# `eligible --worktree` is the dispatch-time gate, so it proves only what exists
+# before the crewmate branches and commits: a clean worktree of the task's own
+# repository whose history already holds the recorded reproduction commit. The
+# `fm/<id>` branch binding and the strictly-older reproduction revision are
+# proofs about the tested head and are enforced by every gate after dispatch.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -97,16 +104,29 @@ task_worktree_clean() { # <worktree>
   [ -z "$output" ]
 }
 
-task_revision_at_worktree() {
+# The identity every Fast Repair gate needs: the path is a real git worktree
+# root, its HEAD resolves, and nothing outside this home's own state and data is
+# modified. TASK_BRANCH is left empty on a detached HEAD, which is exactly the
+# state firstmate hands a freshly pooled task worktree before the crewmate has
+# created its `fm/<id>` branch.
+task_head_at_worktree() {
   local worktree=$1 root
   [ -d "$worktree" ] || return 1
   root=$(git -C "$worktree" rev-parse --show-toplevel 2>/dev/null) || return 1
   root=$(cd "$root" && pwd -P) || return 1
   [ "$root" = "$(cd "$worktree" && pwd -P)" ] || return 1
   TASK_WORKTREE=$root
-  TASK_BRANCH=$(git -C "$TASK_WORKTREE" symbolic-ref --quiet --short HEAD 2>/dev/null) || return 1
+  TASK_BRANCH=$(git -C "$TASK_WORKTREE" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
   TASK_HEAD=$(git -C "$TASK_WORKTREE" rev-parse --verify HEAD 2>/dev/null) || return 1
   task_worktree_clean "$TASK_WORKTREE"
+}
+
+# The tested-head identity: everything above plus the named branch every
+# evidence, publication, broader, and readiness record binds itself to. A
+# detached HEAD carries no branch to bind, so it is refused here.
+task_revision_at_worktree() {
+  task_head_at_worktree "$1" || return 1
+  [ -n "$TASK_BRANCH" ] || return 1
 }
 
 # Evidence logs and records are private to this home. The umask is scoped to the
@@ -177,14 +197,25 @@ reproduction_revision_valid() {
   case "$1" in *[!0-9a-f]*) return 1 ;; esac
 }
 
-reproduction_revision_for() {
+# What is knowable before the repair commit exists: the recorded revision is a
+# real commit in this worktree's own history at or below its HEAD. A task
+# worktree that has just been pooled sits exactly at the reproduction commit, so
+# the ancestry here is inclusive.
+reproduction_revision_recorded() {
   local id=$1 revision
   revision=$(field_get "$(eligibility_file "$id")" reproduction_revision)
   reproduction_revision_valid "$revision" || return 1
   git -C "$TASK_WORKTREE" cat-file -e "$revision^{commit}" 2>/dev/null || return 1
-  [ "$revision" != "$TASK_HEAD" ] || return 1
   git -C "$TASK_WORKTREE" merge-base --is-ancestor "$revision" "$TASK_HEAD" || return 1
   REPRODUCTION_REVISION=$revision
+}
+
+# The tested-head proof: the repair itself must sit above the reproduction, so
+# the recorded revision can no longer be the commit being tested. Only gates
+# that run after the repair commit exists may require this.
+reproduction_revision_for() {
+  reproduction_revision_recorded "$1" || return 1
+  [ "$REPRODUCTION_REVISION" != "$TASK_HEAD" ] || return 1
 }
 
 runner_selected_tests() { # <family>
@@ -240,13 +271,36 @@ EOF
 }
 
 focused_test_valid() { runner_family_artifacts_valid "$1"; }
-broader_test_valid() { runner_family_artifacts_valid "$1"; }
 
-run_typed_test() { # <worktree> <family> <pass|fail> <log>
-  local worktree=$1 family=$2 expected=$3 log=$4 output status
+recorded_focused_test() { # <task-id>
+  local f
+  f=$(tests_file "$1")
+  regular_file "$f" || return 1
+  field_get "$f" focused_test
+}
+
+# "Broader" is a coverage claim, not a second run of the module the early PR was
+# already published on. The family must be supported with bound artifacts AND
+# different from the focused family recorded in the evidence record, and every
+# later consumer of the broader record re-checks that same rule.
+broader_test_valid() { # <task-id> <family>
+  local id=$1 family=$2 focused
+  runner_family_artifacts_valid "$family" || return 1
+  focused=$(recorded_focused_test "$id") || return 1
+  [ -n "$focused" ] || return 1
+  [ "$family" != "$focused" ]
+}
+
+# The one owner of how a runner invocation is classified. Every Fast Repair
+# gate - the reproduction witness, the regression run at the tested head, the
+# focused family, and the broader family - differs only in the argv it hands the
+# tracked runner, so the typed begin/end, skip, and exit rules live here once.
+run_typed() { # <worktree> <pass|fail> <log> <runner-arg>...
+  local worktree=$1 expected=$2 log=$3 output status
+  shift 3
   output=$(mktemp "$STATE/.fast-repair-test-output.XXXXXX") || return 1
   chmod 600 "$output" || { rm -f "$output"; return 1; }
-  if ( cd "$worktree" && "$worktree/bin/fm-test-run.sh" --family "$family" ) >"$output" 2>&1; then
+  if ( cd "$worktree" && "$worktree/bin/fm-test-run.sh" "$@" ) >"$output" 2>&1; then
     status=0
   else
     status=1
@@ -269,31 +323,12 @@ run_typed_test() { # <worktree> <family> <pass|fail> <log>
   return 1
 }
 
+run_typed_test() { # <worktree> <family> <pass|fail> <log>
+  run_typed "$1" "$3" "$4" --family "$2"
+}
+
 run_typed_selector() { # <worktree> <selector> <pass|fail> <log>
-  local worktree=$1 selector=$2 expected=$3 log=$4 output status
-  output=$(mktemp "$STATE/.fast-repair-test-output.XXXXXX") || return 1
-  chmod 600 "$output" || { rm -f "$output"; return 1; }
-  if ( cd "$worktree" && "$worktree/bin/fm-test-run.sh" "$selector" ) >"$output" 2>&1; then
-    status=0
-  else
-    status=1
-  fi
-  cat "$output" >> "$log" || status=1
-  if awk -v expected="$expected" -v status="$status" '
-      $1 == "FM_TEST_BEGIN" { began = 1 }
-      $1 == "FM_TEST_END" && $0 ~ /(^|[[:space:]])gate_skip=true([[:space:]]|$)/ { skipped = 1 }
-      $1 == "FM_TEST_END" && $4 == "exit=0" { passed = 1 }
-      $1 == "FM_TEST_END" && $4 != "exit=0" { failed = 1 }
-      END {
-        if (expected == "pass") exit !(status == 0 && began && passed && !skipped)
-        exit !(status != 0 && began && failed && !skipped)
-      }
-    ' "$output"; then
-    rm -f "$output"
-    return 0
-  fi
-  rm -f "$output"
-  return 1
+  run_typed "$1" "$3" "$4" "$2"
 }
 
 regression_witness_valid() { # <family> <selector> <artifact> <log>
@@ -441,7 +476,7 @@ broader_passed() {
   worktree=$(field_get "$f" worktree)
   branch=$(field_get "$f" branch)
   head=$(field_get "$f" head)
-  broader_test_valid "$broader_test" || return 1
+  broader_test_valid "$id" "$broader_test" || return 1
   [ "$broader_runner" = "$TEST_RUNNER_ARTIFACT" ] || return 1
   [ "$worktree" = "$TASK_WORKTREE" ] || return 1
   [ "$branch" = "$TASK_BRANCH" ] || return 1
@@ -641,11 +676,17 @@ case "$command" in
     if ! eligibility_valid "$id"; then
       fail "eligibility evidence is absent, incomplete, or no longer valid for $id"
     fi
-    if [ -n "$worktree" ] && ! task_revision_at_worktree "$worktree"; then
+    # This runs at dispatch, before the crewmate has created its branch or made
+    # the repair commit, so it proves only what exists then: a clean worktree of
+    # this task's own repository whose history already carries the recorded
+    # reproduction commit. The branch and the strictly-older reproduction
+    # revision are proofs about the tested head, and stay in evidence,
+    # publish-pr, broader, and ready where that head is real.
+    if [ -n "$worktree" ] && ! task_head_at_worktree "$worktree"; then
       fail "task $id has no safe git worktree for reproduction proof"
     fi
-    if [ -n "$worktree" ] && ! reproduction_revision_for "$id"; then
-      fail "reproduction revision is unknown, current, or not an ancestor of the task head"
+    if [ -n "$worktree" ] && ! reproduction_revision_recorded "$id"; then
+      fail "reproduction revision is unknown or not an ancestor of the task worktree head"
     fi
     printf 'fast-repair eligible: %s\n' "$id"
     ;;
@@ -759,7 +800,8 @@ case "$command" in
     tests_passed "$id" || fail "focused evidence is absent or failed"
     task_revision_for "$id" || fail "task $id has no safe git worktree at its metadata path"
     pr_identity_for "$id" || fail "broader tests start only after the direct PR is registered"
-    broader_test_valid "$broader_test" || fail "broader-test must name a supported runner family with bound artifacts"
+    broader_test_valid "$id" "$broader_test" \
+      || fail "broader-test must name a supported runner family with bound artifacts that is not the focused family already proven before the PR"
     log="$STATE/$id.fast-repair-broader.log"
     record="$STATE/.$id.fast-repair-broader.$$"
     private_truncate "$log" || fail "the broader-test log could not be created"

--- a/bin/fm-fast-repair.sh
+++ b/bin/fm-fast-repair.sh
@@ -34,6 +34,9 @@ FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+TASK_WORKTREE=
+TASK_BRANCH=
+TASK_HEAD=
 
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
@@ -53,6 +56,24 @@ task_id_valid() {
 
 regular_file() {
   [ -f "$1" ] && [ ! -L "$1" ]
+}
+
+task_worktree_for() {
+  local meta worktree root
+  meta="$STATE/$1.meta"
+  regular_file "$meta" || return 1
+  worktree=$(field_get "$meta" worktree)
+  [ -n "$worktree" ] && [ -d "$worktree" ] || return 1
+  root=$(git -C "$worktree" rev-parse --show-toplevel 2>/dev/null) || return 1
+  root=$(cd "$root" && pwd -P) || return 1
+  [ "$root" = "$(cd "$worktree" && pwd -P)" ] || return 1
+  TASK_WORKTREE=$root
+}
+
+task_revision_for() {
+  task_worktree_for "$1" || return 1
+  TASK_BRANCH=$(git -C "$TASK_WORKTREE" symbolic-ref --quiet --short HEAD 2>/dev/null) || return 1
+  TASK_HEAD=$(git -C "$TASK_WORKTREE" rev-parse --verify HEAD 2>/dev/null) || return 1
 }
 
 # Evidence logs and records are private to this home. The umask is scoped to the
@@ -92,10 +113,16 @@ positive_fact_valid() { # <field> <value>
 risk_excluded() { [ "$1" = none ]; }
 
 test_path_valid() {
-  case "$1" in
+  local path=$1 parent resolved
+  case "$path" in
     ''|/*|.|..|../*|*/../*|*'/..'|*$'\n'*|*$'\r'*) return 1 ;;
   esac
-  regular_file "$1" && [ -x "$1" ]
+  [ -n "$TASK_WORKTREE" ] || return 1
+  parent=$(dirname "$TASK_WORKTREE/$path")
+  resolved=$(cd "$parent" 2>/dev/null && pwd -P) || return 1
+  resolved="$resolved/$(basename "$path")"
+  case "$resolved" in "$TASK_WORKTREE"/*) ;; *) return 1 ;; esac
+  regular_file "$resolved" && [ -x "$resolved" ]
 }
 
 regression_test_valid() { test_path_valid "$1"; }
@@ -132,18 +159,28 @@ eligibility_valid() {
 }
 
 tests_passed() {
-  local id=$1 f regression_test focused_test
+  local id=$1 f regression_test focused_test worktree branch head
   f=$(tests_file "$id")
   regular_file "$f" || return 1
+  task_revision_for "$id" || return 1
   regression_test=$(field_get "$f" regression_test)
   focused_test=$(field_get "$f" focused_test)
+  worktree=$(field_get "$f" worktree)
+  branch=$(field_get "$f" branch)
+  head=$(field_get "$f" head)
   regression_test_valid "$regression_test" || return 1
   focused_test_valid "$focused_test" || return 1
-  [ "$(wc -l < "$f" | tr -d '[:space:]')" = 4 ] || return 1
+  [ "$worktree" = "$TASK_WORKTREE" ] || return 1
+  [ "$branch" = "$TASK_BRANCH" ] || return 1
+  [ "$head" = "$TASK_HEAD" ] || return 1
+  [ "$(wc -l < "$f" | tr -d '[:space:]')" = 7 ] || return 1
   [ "$(grep -c '^regression=passed$' "$f")" = 1 ] || return 1
   [ "$(grep -c '^focused=passed$' "$f")" = 1 ] || return 1
   [ "$(grep -Fxc "regression_test=$regression_test" "$f")" = 1 ] || return 1
-  [ "$(grep -Fxc "focused_test=$focused_test" "$f")" = 1 ]
+  [ "$(grep -Fxc "focused_test=$focused_test" "$f")" = 1 ] || return 1
+  [ "$(grep -Fxc "worktree=$worktree" "$f")" = 1 ] || return 1
+  [ "$(grep -Fxc "branch=$branch" "$f")" = 1 ] || return 1
+  [ "$(grep -Fxc "head=$head" "$f")" = 1 ]
 }
 
 broader_passed() {
@@ -330,6 +367,7 @@ case "$command" in
     done
     require_fast_repair_meta "$id"
     eligibility_valid "$id" || fail "eligibility evidence is absent or invalid"
+    task_revision_for "$id" || fail "task $id has no safe git worktree at its metadata path"
     regression_test_valid "$regression_test" \
       || fail "regression-test must name an executable regular test file below the current worktree"
     focused_test_valid "$focused_test" \
@@ -338,13 +376,16 @@ case "$command" in
     log="$STATE/$id.fast-repair-tests.log"
     record="$STATE/.$id.fast-repair-tests.$$"
     private_truncate "$log" || fail "the evidence log could not be created"
-    if "./$regression_test" >>"$log" 2>&1; then regression_result=passed; else regression_result=failed; fi
-    if [ "$regression_result" = passed ] && "./$focused_test" >>"$log" 2>&1; then focused_result=passed; else focused_result=failed; fi
+    if ( cd "$TASK_WORKTREE" && "./$regression_test" ) >>"$log" 2>&1; then regression_result=passed; else regression_result=failed; fi
+    if [ "$regression_result" = passed ] && ( cd "$TASK_WORKTREE" && "./$focused_test" ) >>"$log" 2>&1; then focused_result=passed; else focused_result=failed; fi
     {
       printf 'regression=%s\n' "$regression_result"
       printf 'regression_test=%s\n' "$regression_test"
       printf 'focused=%s\n' "$focused_result"
       printf 'focused_test=%s\n' "$focused_test"
+      printf 'worktree=%s\n' "$TASK_WORKTREE"
+      printf 'branch=%s\n' "$TASK_BRANCH"
+      printf 'head=%s\n' "$TASK_HEAD"
     } | private_write "$record" || fail "the evidence record could not be written"
     mv -f "$record" "$(tests_file "$id")"
     tests_passed "$id" || fail "regression or focused-module evidence failed; PR publication remains blocked"
@@ -375,12 +416,14 @@ case "$command" in
     require_fast_repair_meta "$id"
     eligibility_valid "$id" || fail "eligibility evidence is absent or invalid"
     tests_passed "$id" || fail "focused evidence is absent or failed; direct PR publication is blocked"
+    [ -z "$head" ] || [ "$head" = "$TASK_BRANCH" ] \
+      || fail "--head must equal the tested task branch $TASK_BRANCH"
     if [ -z "$title" ] || ! regular_file "$body_file"; then
       fail "a title and safe body file are required"
     fi
     args=(pr create --title "$title" --body-file "$body_file")
     [ -z "$base" ] || args+=(--base "$base")
-    [ -z "$head" ] || args+=(--head "$head")
+    args+=(--head "$TASK_BRANCH")
     out=$(gh-axi "${args[@]}") || exit $?
     printf '%s\n' "$out"
     url=$(printf '%s\n' "$out" | grep -Eo 'https://github\.com/[^[:space:]]+/pull/[0-9]+' | head -n 1 || true)
@@ -411,6 +454,7 @@ case "$command" in
   progress)
     [ "$#" -eq 1 ] || { usage >&2; exit 2; }
     id=$1
+    task_id_valid "$id" || fail "task id is missing or invalid"
     require_fast_repair_meta "$id"
     eligibility_valid "$id" || fail "eligibility evidence is absent or invalid"
     if regular_file "$STATE/$id.fast-repair-broader" && [ "$(field_get "$STATE/$id.fast-repair-broader" broader)" = failed ]; then
@@ -428,6 +472,7 @@ case "$command" in
   ready)
     [ "$#" -eq 1 ] || { usage >&2; exit 2; }
     id=$1
+    task_id_valid "$id" || fail "task id is missing or invalid"
     require_fast_repair_meta "$id"
     eligibility_valid "$id" || fail "eligibility evidence is absent or invalid"
     tests_passed "$id" || fail "focused evidence is absent or failed"

--- a/bin/fm-fast-repair.sh
+++ b/bin/fm-fast-repair.sh
@@ -422,8 +422,8 @@ case "$command" in
     log="$STATE/$id.fast-repair-tests.log"
     record="$STATE/.$id.fast-repair-tests.$$"
     private_truncate "$log" || fail "the evidence log could not be created"
-    if "$regression_path" >>"$log" 2>&1; then regression_result=passed; else regression_result=failed; fi
-    if [ "$regression_result" = passed ] && "$focused_path" >>"$log" 2>&1; then focused_result=passed; else focused_result=failed; fi
+    if ( cd "$TASK_WORKTREE" && "$regression_path" ) >>"$log" 2>&1; then regression_result=passed; else regression_result=failed; fi
+    if [ "$regression_result" = passed ] && ( cd "$TASK_WORKTREE" && "$focused_path" ) >>"$log" 2>&1; then focused_result=passed; else focused_result=failed; fi
     {
       printf 'regression=%s\n' "$regression_result"
       printf 'regression_test=%s\n' "$regression_test"

--- a/bin/fm-fast-repair.sh
+++ b/bin/fm-fast-repair.sh
@@ -40,6 +40,8 @@ TASK_BRANCH=
 TASK_HEAD=
 TEST_RUNNER=
 REPRODUCTION_REVISION=
+REGRESSION_SELECTOR=
+REGRESSION_ARTIFACT=
 BODY_FILE=
 
 # shellcheck source=bin/fm-pr-lib.sh
@@ -179,19 +181,26 @@ runner_selected_test_valid() { # <path>
 }
 
 regression_test_valid() { # <task-id> <family>
-  local id=$1 family=$2 selected path has_new=0
+  local id=$1 family=$2 selected path artifact new_count=0
   runner_family_valid "$family" || return 1
   reproduction_revision_for "$id" || return 1
   selected=$(runner_selected_tests "$family") || return 1
   [ -n "$selected" ] || return 1
+  REGRESSION_SELECTOR=
+  REGRESSION_ARTIFACT=
   while IFS= read -r path; do
     [ -n "$path" ] || return 1
     runner_selected_test_valid "$path" || return 1
-    git -C "$TASK_WORKTREE" cat-file -e "$REPRODUCTION_REVISION:$path" 2>/dev/null || has_new=1
+    git -C "$TASK_WORKTREE" cat-file -e "$REPRODUCTION_REVISION:$path" 2>/dev/null && continue
+    artifact=$(git -C "$TASK_WORKTREE" ls-tree "$TASK_HEAD" -- "$path" 2>/dev/null | awk '{print $1 ":" $2 ":" $3}') || return 1
+    case "$artifact" in 100755:blob:*) ;; *) return 1 ;; esac
+    new_count=$((new_count + 1))
+    REGRESSION_SELECTOR=$path
+    REGRESSION_ARTIFACT="${artifact%%:blob:*}:${artifact#*:blob:}"
   done <<EOF
 $selected
 EOF
-  [ "$has_new" = 1 ]
+  [ "$new_count" -eq 1 ]
 }
 
 focused_test_valid() { runner_family_valid "$1"; }
@@ -220,6 +229,61 @@ run_typed_test() { # <worktree> <family> <pass|fail> <log>
   fi
   rm -f "$output"
   return 1
+}
+
+run_typed_selector() { # <worktree> <selector> <pass|fail> <log>
+  local worktree=$1 selector=$2 expected=$3 log=$4 output status
+  output=$(mktemp "$STATE/.fast-repair-test-output.XXXXXX") || return 1
+  chmod 600 "$output" || { rm -f "$output"; return 1; }
+  if ( cd "$worktree" && "$worktree/bin/fm-test-run.sh" "$selector" ) >"$output" 2>&1; then
+    status=0
+  else
+    status=1
+  fi
+  cat "$output" >> "$log" || status=1
+  if awk -v expected="$expected" -v status="$status" '
+      $1 == "FM_TEST_BEGIN" { began = 1 }
+      $1 == "FM_TEST_END" && $4 == "exit=0" { passed = 1 }
+      $1 == "FM_TEST_END" && $4 != "exit=0" { failed = 1 }
+      END {
+        if (expected == "pass") exit !(status == 0 && began && passed)
+        exit !(status != 0 && began && failed)
+      }
+    ' "$output"; then
+    rm -f "$output"
+    return 0
+  fi
+  rm -f "$output"
+  return 1
+}
+
+regression_witness_valid() { # <family> <selector> <artifact> <log>
+  local family=$1 selector=$2 artifact=$3 log=$4 sandbox mode file_mode oid old_selected
+  case "$artifact" in 100755:*) ;; *) return 1 ;; esac
+  mode=${artifact%%:*}
+  file_mode=${mode#100}
+  oid=${artifact#*:}
+  sandbox=$(mktemp -d "$STATE/.fast-repair-reproduction.XXXXXX") || return 1
+  rmdir "$sandbox" || return 1
+  if ! git clone --quiet --no-hardlinks "$TASK_WORKTREE" "$sandbox" \
+    || ! git -C "$sandbox" checkout --quiet --detach "$REPRODUCTION_REVISION" \
+    || ! mkdir -p "$(dirname "$sandbox/$selector")" \
+    || ! git -C "$TASK_WORKTREE" show "$TASK_HEAD:$selector" > "$sandbox/$selector" \
+    || ! chmod "$file_mode" "$sandbox/$selector" \
+    || ! [ "$(git -C "$sandbox" hash-object "$selector")" = "$oid" ]; then
+    rm -rf "$sandbox"
+    return 1
+  fi
+  old_selected=$(cd "$sandbox" && ./bin/fm-test-run.sh --list --family "$family" 2>/dev/null) || {
+    rm -rf "$sandbox"
+    return 1
+  }
+  if ! printf '%s\n' "$old_selected" | grep -Fx "$selector" >/dev/null \
+    || ! run_typed_selector "$sandbox" "$selector" fail "$log"; then
+    rm -rf "$sandbox"
+    return 1
+  fi
+  rm -rf "$sandbox"
 }
 
 eligibility_file() { printf '%s/%s/fast-repair-eligibility\n' "$DATA" "$1"; }
@@ -265,11 +329,15 @@ eligibility_valid() {
 }
 
 tests_passed() {
-  local id=$1 f regression_test focused_test reproduction_revision worktree branch head
+  local id=$1 f regression_test regression_selector regression_artifact regression_reproduction regression_head focused_test reproduction_revision worktree branch head
   f=$(tests_file "$id")
   regular_file "$f" || return 1
   task_revision_for "$id" || return 1
   regression_test=$(field_get "$f" regression_test)
+  regression_selector=$(field_get "$f" regression_selector)
+  regression_artifact=$(field_get "$f" regression_artifact)
+  regression_reproduction=$(field_get "$f" regression_reproduction)
+  regression_head=$(field_get "$f" regression_head)
   focused_test=$(field_get "$f" focused_test)
   reproduction_revision=$(field_get "$f" reproduction_revision)
   worktree=$(field_get "$f" worktree)
@@ -279,13 +347,21 @@ tests_passed() {
   regression_test_valid "$id" "$regression_test" || return 1
   focused_test_valid "$focused_test" || return 1
   [ "$reproduction_revision" = "$REPRODUCTION_REVISION" ] || return 1
+  [ "$regression_selector" = "$REGRESSION_SELECTOR" ] || return 1
+  [ "$regression_artifact" = "$REGRESSION_ARTIFACT" ] || return 1
+  [ "$regression_reproduction" = failed ] || return 1
+  [ "$regression_head" = passed ] || return 1
   [ "$worktree" = "$TASK_WORKTREE" ] || return 1
   [ "$branch" = "$TASK_BRANCH" ] || return 1
   [ "$head" = "$TASK_HEAD" ] || return 1
-  [ "$(wc -l < "$f" | tr -d '[:space:]')" = 8 ] || return 1
+  [ "$(wc -l < "$f" | tr -d '[:space:]')" = 12 ] || return 1
   [ "$(grep -c '^regression=passed$' "$f")" = 1 ] || return 1
   [ "$(grep -c '^focused=passed$' "$f")" = 1 ] || return 1
   [ "$(grep -Fxc "regression_test=$regression_test" "$f")" = 1 ] || return 1
+  [ "$(grep -Fxc "regression_selector=$regression_selector" "$f")" = 1 ] || return 1
+  [ "$(grep -Fxc "regression_artifact=$regression_artifact" "$f")" = 1 ] || return 1
+  [ "$(grep -c '^regression_reproduction=failed$' "$f")" = 1 ] || return 1
+  [ "$(grep -c '^regression_head=passed$' "$f")" = 1 ] || return 1
   [ "$(grep -Fxc "focused_test=$focused_test" "$f")" = 1 ] || return 1
   [ "$(grep -Fxc "reproduction_revision=$reproduction_revision" "$f")" = 1 ] || return 1
   [ "$(grep -Fxc "worktree=$worktree" "$f")" = 1 ] || return 1
@@ -527,7 +603,7 @@ case "$command" in
     reproduction_revision_for "$id" \
       || fail "reproduction revision is unknown, current, or not an ancestor of the task head"
     regression_test_valid "$id" "$regression_test" \
-      || fail "regression-test must name a supported runner family with a new tracked selector"
+      || fail "regression-test must name one new tracked runner selector"
     focused_test_valid "$focused_test" \
       || fail "focused-test must name a supported bin/fm-test-run.sh family"
     [ "$regression_test" != "$focused_test" ] \
@@ -536,11 +612,18 @@ case "$command" in
     log="$STATE/$id.fast-repair-tests.log"
     record="$STATE/.$id.fast-repair-tests.$$"
     private_truncate "$log" || fail "the evidence log could not be created"
-    if run_typed_test "$TASK_WORKTREE" "$regression_test" pass "$log"; then regression_result=passed; else regression_result=failed; fi
+    if regression_witness_valid "$regression_test" "$REGRESSION_SELECTOR" "$REGRESSION_ARTIFACT" "$log"; then regression_reproduction=failed; else regression_reproduction=unproven; fi
+    if [ "$regression_reproduction" = failed ] \
+      && run_typed_selector "$TASK_WORKTREE" "$REGRESSION_SELECTOR" pass "$log"; then regression_head=passed; else regression_head=failed; fi
+    if [ "$regression_reproduction" = failed ] && [ "$regression_head" = passed ]; then regression_result=passed; else regression_result=failed; fi
     if [ "$regression_result" = passed ] && run_typed_test "$TASK_WORKTREE" "$focused_test" pass "$log"; then focused_result=passed; else focused_result=failed; fi
     {
       printf 'regression=%s\n' "$regression_result"
       printf 'regression_test=%s\n' "$regression_test"
+      printf 'regression_selector=%s\n' "$REGRESSION_SELECTOR"
+      printf 'regression_artifact=%s\n' "$REGRESSION_ARTIFACT"
+      printf 'regression_reproduction=%s\n' "$regression_reproduction"
+      printf 'regression_head=%s\n' "$regression_head"
       printf 'focused=%s\n' "$focused_result"
       printf 'focused_test=%s\n' "$focused_test"
       printf 'reproduction_revision=%s\n' "$REPRODUCTION_REVISION"

--- a/bin/fm-fast-repair.sh
+++ b/bin/fm-fast-repair.sh
@@ -67,6 +67,19 @@ request_valid() {
   esac
 }
 
+# The one rule for a proven positive fact and for an excluded risk. intake
+# writes a record only when these hold, and every later gate re-checks the
+# stored record against these same predicates, so a record can never satisfy a
+# consumer that intake itself would have refused.
+positive_fact_valid() {
+  case "$1" in
+    ''|unknown|ambiguous|false|no) return 1 ;;
+    *$'\n'*|*$'\r'*) return 1 ;;
+  esac
+}
+
+risk_excluded() { [ "$1" = none ]; }
+
 eligibility_file() { printf '%s/%s/fast-repair-eligibility\n' "$DATA" "$1"; }
 tests_file() { printf '%s/%s.fast-repair-tests\n' "$STATE" "$1"; }
 
@@ -86,10 +99,10 @@ eligibility_valid() {
   request=$(field_get "$f" request)
   request_valid "$request" || return 1
   for positive in reproduction root_cause isolation; do
-    case "$(field_get "$f" "$positive")" in ''|unknown|ambiguous) return 1 ;; esac
+    positive_fact_valid "$(field_get "$f" "$positive")" || return 1
   done
   for risk in schema authentication authorization secrets financial legal side_effects; do
-    [ "$(field_get "$f" "$risk")" = none ] || return 1
+    risk_excluded "$(field_get "$f" "$risk")" || return 1
   done
 }
 
@@ -221,12 +234,12 @@ case "$command" in
     request_valid "$request" || fail "request does not use the exact 'fast-repair: ' prefix"
     for field in reproduction root_cause isolation; do
       eval "value=\${$field}"
-      case "$value" in ''|unknown|ambiguous|false|no) fail "$field is absent, unknown, ambiguous, or not proven" ;; esac
-      case "$value" in *$'\n'*|*$'\r'*) fail "$field must be one typed evidence value" ;; esac
+      positive_fact_valid "$value" \
+        || fail "$field is absent, unknown, ambiguous, not proven, or not one typed evidence value"
     done
     for field in schema authentication authorization secrets financial legal side_effects; do
       eval "value=\${$field}"
-      [ "$value" = none ] || fail "$field is not explicitly proven none"
+      risk_excluded "$value" || fail "$field is not explicitly proven none"
     done
     dir="$DATA/$id"
     mkdir -p "$dir"

--- a/bin/fm-fast-repair.sh
+++ b/bin/fm-fast-repair.sh
@@ -35,6 +35,9 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+
 usage() {
   sed -n '2,${/^#/!q;p;}' "$0" | sed 's/^# \{0,1\}//'
 }
@@ -97,36 +100,76 @@ tests_passed() {
   [ "$(field_get "$f" regression)" = passed ] && [ "$(field_get "$f" focused)" = passed ]
 }
 
-parse_url_number() {
-  case "$1" in
-    https://github.com/*/pull/[0-9]*) printf '%s\n' "${1##*/}" ;;
-    *) return 1 ;;
-  esac
+broader_passed() {
+  local f="$STATE/$1.fast-repair-broader"
+  regular_file "$f" || return 1
+  [ "$(field_get "$f" broader)" = passed ]
 }
 
-pr_url_for() {
-  local id meta url
-  id=$1
-  meta="$STATE/$id.meta"
+# The recorded pr= URL is re-parsed with the shared strict forge validator, so
+# the repository and number always come from that one canonical record instead
+# of from the caller's working directory. Fast Repair publishes through
+# gh-axi, so only a GitHub pull request can be read here. On success the
+# FM_PR_* identity of the shared parser is set for the caller.
+pr_identity_for() {
+  local meta url
+  meta="$STATE/$1.meta"
+  regular_file "$meta" || return 1
   url=$(field_get "$meta" pr)
-  parse_url_number "$url" >/dev/null || return 1
-  printf '%s\n' "$url"
+  fm_pr_url_parse "$url" || return 1
+  [ "$FM_PR_PROVIDER" = github ]
 }
 
-checks_summary() {
-  local url=$1 number
-  number=$(parse_url_number "$url") || return 1
+checks_summary() { # <number> <owner/repo>
+  local raw
   command -v gh-axi >/dev/null 2>&1 || return 1
-  gh-axi pr checks "$number" 2>/dev/null | sed -n 's/^summary: *//p' | head -n 1
+  raw=$(gh-axi pr checks "$1" --repo "$2" 2>/dev/null | sed -n 's/^summary: *//p' | head -n 1)
+  # gh-axi renders its fields as TOON, which double-quotes every value holding a
+  # comma, so the rollup summary always arrives quoted.
+  case "$raw" in
+    '"'*'"') raw=${raw#\"}; raw=${raw%\"} ;;
+  esac
+  printf '%s\n' "$raw"
 }
 
+# gh-axi renders the rollup as ["<n> passed","<n> failed", "<n> skipped" when
+# non-zero, "<n> pending" when non-zero, "<n> total"], so a green PR omits the
+# pending segment entirely and a substring test on the rendered string both
+# misses green and reads "10 failed, 0 pending" as green. The counts are
+# therefore extracted and compared numerically, and any segment, label, or
+# total this does not recognize stays unknown rather than becoming green.
 checks_state() { # <summary> -> green|failed|pending|unknown
-  case "$1" in
-    *'0 failed, 0 pending,'*) printf 'green\n' ;;
-    *'0 failed,'*) printf 'pending\n' ;;
-    *' failed,'*) printf 'failed\n' ;;
-    *) printf 'unknown\n' ;;
-  esac
+  local rest=${1-} part count label
+  local passed='' failed='' total='' skipped=0 pending=0
+  [ -n "$rest" ] || { printf 'unknown\n'; return 0; }
+  while [ -n "$rest" ]; do
+    case "$rest" in
+      *', '*) part=${rest%%, *}; rest=${rest#*, } ;;
+      *) part=$rest; rest= ;;
+    esac
+    case "$part" in *' '*) ;; *) printf 'unknown\n'; return 0 ;; esac
+    count=${part%% *}
+    label=${part#* }
+    case "$count" in ''|*[!0-9]*) printf 'unknown\n'; return 0 ;; esac
+    case "$label" in
+      passed) passed=$count ;;
+      failed) failed=$count ;;
+      skipped) skipped=$count ;;
+      pending) pending=$count ;;
+      total) total=$count ;;
+      *) printf 'unknown\n'; return 0 ;;
+    esac
+  done
+  [ -n "$passed" ] && [ -n "$failed" ] && [ -n "$total" ] || { printf 'unknown\n'; return 0; }
+  [ "$total" -gt 0 ] || { printf 'unknown\n'; return 0; }
+  [ "$((passed + failed + skipped + pending))" -eq "$total" ] || { printf 'unknown\n'; return 0; }
+  if [ "$failed" -gt 0 ]; then
+    printf 'failed\n'
+  elif [ "$pending" -gt 0 ]; then
+    printf 'pending\n'
+  else
+    printf 'green\n'
+  fi
 }
 
 command=${1:-}
@@ -294,7 +337,7 @@ case "$command" in
     [ "${1:-}" = --command ] && [ "$#" -eq 2 ] || fail "broader requires exactly --command <command>"
     broader_command=$2
     require_fast_repair_meta "$id"
-    pr_url_for "$id" >/dev/null || fail "broader tests start only after the direct PR is registered"
+    pr_identity_for "$id" || fail "broader tests start only after the direct PR is registered"
     [ -n "$broader_command" ] || fail "broader command is empty"
     log="$STATE/$id.fast-repair-broader.log"
     record="$STATE/.$id.fast-repair-broader.$$"
@@ -314,9 +357,8 @@ case "$command" in
       printf 'fast-repair %s broader-tests-failed\n' "$id"
       exit 0
     fi
-    url=$(pr_url_for "$id" 2>/dev/null || true)
-    [ -n "$url" ] || exit 0
-    summary=$(checks_summary "$url" 2>/dev/null || true)
+    pr_identity_for "$id" 2>/dev/null || exit 0
+    summary=$(checks_summary "$FM_PR_NUMBER" "$FM_PR_OWNER/$FM_PR_REPO" 2>/dev/null || true)
     state=$(checks_state "$summary")
     case "$state" in
       failed) printf 'fast-repair %s pr-checks-failed: %s\n' "$id" "$summary" ;;
@@ -328,11 +370,12 @@ case "$command" in
     id=$1
     require_fast_repair_meta "$id"
     tests_passed "$id" || fail "focused evidence is absent or failed"
-    [ "$(field_get "$STATE/$id.fast-repair-broader" broader)" = passed ] || fail "broader tests are not passed"
-    url=$(pr_url_for "$id") || fail "no registered Fast Repair PR"
-    summary=$(checks_summary "$url") || fail "PR checks could not be read"
+    broader_passed "$id" || fail "broader tests are not passed"
+    pr_identity_for "$id" || fail "no registered Fast Repair PR"
+    summary=$(checks_summary "$FM_PR_NUMBER" "$FM_PR_OWNER/$FM_PR_REPO") || fail "PR checks could not be read"
+    [ -n "$summary" ] || fail "PR checks could not be read"
     [ "$(checks_state "$summary")" = green ] || fail "PR checks are not green: $summary"
-    printf 'fast-repair ready: %s\n' "$url"
+    printf 'fast-repair ready: %s\n' "$FM_PR_URL"
     ;;
   *) usage >&2; exit 2 ;;
 esac

--- a/bin/fm-fast-repair.sh
+++ b/bin/fm-fast-repair.sh
@@ -3,11 +3,11 @@
 # Usage:
 #   fm-fast-repair.sh is-request <request>
 #   fm-fast-repair.sh intake <task-id> --request 'fast-repair: <task>' \
-#     --reproduction <evidence> --root-cause <evidence> --isolation <evidence> \
+#     --reproduction reproduced --root-cause confirmed --isolation isolated \
 #     --schema none --authentication none --authorization none --secrets none \
 #     --financial none --legal none --side-effects none
 #   fm-fast-repair.sh eligible <task-id>
-#   fm-fast-repair.sh evidence <task-id> --regression-command <command> --focused-command <command>
+#   fm-fast-repair.sh evidence <task-id> --regression-test <relative-executable-test> --focused-command <command>
 #   fm-fast-repair.sh publish-pr <task-id> --title <text> --body-file <path> [--base <branch>] [--head <branch>]
 #   fm-fast-repair.sh broader <task-id> --command <command>
 #   fm-fast-repair.sh progress <task-id>
@@ -15,14 +15,14 @@
 #
 # `fast-repair:` is the only accepted request prefix, and it must be followed by
 # one space and a non-empty request. `intake` records a typed, private evidence
-# record only when all three positive facts are non-empty and all seven risk
-# exclusions equal `none`. Any missing, unknown, ambiguous, or different value
+# record only when all three positive facts use their exact proof values and all
+# seven risk exclusions equal `none`. Any missing or different value
 # refuses Fast Repair before a task can use this delivery mode; firstmate then
 # uses normal intake for that request.
 #
 # A Fast Repair spawn must use mode=fast-repair, yolo=off, and the built-in
-# Codex gpt-5.6-luna medium profile. `evidence` executes a regression command
-# and a focused-module command and records their result. `publish-pr` refuses
+# Codex gpt-5.6-luna medium profile. `evidence` executes one named regression
+# test directly and a focused-module command and records their result. `publish-pr` refuses
 # until both passed, then opens and registers a direct PR. `broader` is run
 # after publication while PR checks run concurrently. `ready` refuses until the
 # broader command and all PR checks are green. `progress` prints only a changed
@@ -73,23 +73,31 @@ field_get() { # <file> <field>
 
 request_valid() {
   case "$1" in
-    fast-repair:\ ?*) return 0 ;;
+    fast-repair:\ ?*) ;;
     *) return 1 ;;
   esac
+  case "$1" in *$'\n'*|*$'\r'*) return 1 ;; esac
 }
 
 # The one rule for a proven positive fact and for an excluded risk. intake
 # writes a record only when these hold, and every later gate re-checks the
 # stored record against these same predicates, so a record can never satisfy a
 # consumer that intake itself would have refused.
-positive_fact_valid() {
-  case "$1" in
-    ''|unknown|ambiguous|false|no) return 1 ;;
-    *$'\n'*|*$'\r'*) return 1 ;;
+positive_fact_valid() { # <field> <value>
+  case "$1:$2" in
+    reproduction:reproduced|root_cause:confirmed|isolation:isolated) return 0 ;;
+    *) return 1 ;;
   esac
 }
 
 risk_excluded() { [ "$1" = none ]; }
+
+regression_test_valid() { # <relative path>
+  case "$1" in
+    ''|/*|.|..|../*|*/../*|*'/..'|*$'\n'*|*$'\r'*) return 1 ;;
+  esac
+  regular_file "$1" && [ -x "$1" ]
+}
 
 eligibility_file() { printf '%s/%s/fast-repair-eligibility\n' "$DATA" "$1"; }
 tests_file() { printf '%s/%s.fast-repair-tests\n' "$STATE" "$1"; }
@@ -107,21 +115,30 @@ eligibility_valid() {
   local id=$1 f request positive risk
   f=$(eligibility_file "$id")
   regular_file "$f" || return 1
+  [ "$(wc -l < "$f" | tr -d '[:space:]')" = 11 ] || return 1
   request=$(field_get "$f" request)
   request_valid "$request" || return 1
+  [ "$(grep -c '^request=' "$f")" = 1 ] || return 1
   for positive in reproduction root_cause isolation; do
-    positive_fact_valid "$(field_get "$f" "$positive")" || return 1
+    positive_fact_valid "$positive" "$(field_get "$f" "$positive")" || return 1
+    [ "$(grep -c "^$positive=" "$f")" = 1 ] || return 1
   done
   for risk in schema authentication authorization secrets financial legal side_effects; do
     risk_excluded "$(field_get "$f" "$risk")" || return 1
+    [ "$(grep -c "^$risk=" "$f")" = 1 ] || return 1
   done
 }
 
 tests_passed() {
-  local id=$1 f
+  local id=$1 f regression_test
   f=$(tests_file "$id")
   regular_file "$f" || return 1
-  [ "$(field_get "$f" regression)" = passed ] && [ "$(field_get "$f" focused)" = passed ]
+  regression_test=$(field_get "$f" regression_test)
+  regression_test_valid "$regression_test" || return 1
+  [ "$(wc -l < "$f" | tr -d '[:space:]')" = 3 ] || return 1
+  [ "$(grep -c '^regression=passed$' "$f")" = 1 ] || return 1
+  [ "$(grep -c '^focused=passed$' "$f")" = 1 ] || return 1
+  [ "$(grep -Fxc "regression_test=$regression_test" "$f")" = 1 ]
 }
 
 broader_passed() {
@@ -253,8 +270,8 @@ case "$command" in
     request_valid "$request" || fail "request does not use the exact 'fast-repair: ' prefix"
     for field in reproduction root_cause isolation; do
       eval "value=\${$field}"
-      positive_fact_valid "$value" \
-        || fail "$field is absent, unknown, ambiguous, not proven, or not one typed evidence value"
+      positive_fact_valid "$field" "$value" \
+        || fail "$field must equal its exact typed proof value"
     done
     for field in schema authentication authorization secrets financial legal side_effects; do
       eval "value=\${$field}"
@@ -292,31 +309,34 @@ case "$command" in
     id=${1:-}
     shift || true
     task_id_valid "$id" || fail "task id is missing or invalid"
-    regression=
+    regression_test=
     focused=
     while [ "$#" -gt 0 ]; do
       key=$1
       shift
-      [ "$#" -gt 0 ] || fail "$key needs a command"
+      [ "$#" -gt 0 ] || fail "$key needs a value"
       value=$1
       shift
       case "$key" in
-        --regression-command) regression=$value ;;
+        --regression-test) regression_test=$value ;;
         --focused-command) focused=$value ;;
         *) fail "unknown test evidence flag $key" ;;
       esac
     done
     require_fast_repair_meta "$id"
     eligibility_valid "$id" || fail "eligibility evidence is absent or invalid"
-    [ -n "$regression" ] && [ -n "$focused" ] || fail "regression and focused commands are both required"
+    regression_test_valid "$regression_test" \
+      || fail "regression-test must name an executable regular test file below the current worktree"
+    [ -n "$focused" ] || fail "a focused-module command is required"
     mkdir -p "$STATE"
     log="$STATE/$id.fast-repair-tests.log"
     record="$STATE/.$id.fast-repair-tests.$$"
     private_truncate "$log" || fail "the evidence log could not be created"
-    if bash -c "$regression" >>"$log" 2>&1; then regression_result=passed; else regression_result=failed; fi
+    if "./$regression_test" >>"$log" 2>&1; then regression_result=passed; else regression_result=failed; fi
     if [ "$regression_result" = passed ] && bash -c "$focused" >>"$log" 2>&1; then focused_result=passed; else focused_result=failed; fi
     {
       printf 'regression=%s\n' "$regression_result"
+      printf 'regression_test=%s\n' "$regression_test"
       printf 'focused=%s\n' "$focused_result"
     } | private_write "$record" || fail "the evidence record could not be written"
     mv -f "$record" "$(tests_file "$id")"
@@ -368,6 +388,7 @@ case "$command" in
     [ "${1:-}" = --command ] && [ "$#" -eq 2 ] || fail "broader requires exactly --command <command>"
     broader_command=$2
     require_fast_repair_meta "$id"
+    eligibility_valid "$id" || fail "eligibility evidence is absent or invalid"
     pr_identity_for "$id" || fail "broader tests start only after the direct PR is registered"
     [ -n "$broader_command" ] || fail "broader command is empty"
     log="$STATE/$id.fast-repair-broader.log"
@@ -384,6 +405,7 @@ case "$command" in
     [ "$#" -eq 1 ] || { usage >&2; exit 2; }
     id=$1
     require_fast_repair_meta "$id"
+    eligibility_valid "$id" || fail "eligibility evidence is absent or invalid"
     if regular_file "$STATE/$id.fast-repair-broader" && [ "$(field_get "$STATE/$id.fast-repair-broader" broader)" = failed ]; then
       printf 'fast-repair %s broader-tests-failed\n' "$id"
       exit 0
@@ -400,6 +422,7 @@ case "$command" in
     [ "$#" -eq 1 ] || { usage >&2; exit 2; }
     id=$1
     require_fast_repair_meta "$id"
+    eligibility_valid "$id" || fail "eligibility evidence is absent or invalid"
     tests_passed "$id" || fail "focused evidence is absent or failed"
     broader_passed "$id" || fail "broader tests are not passed"
     pr_identity_for "$id" || fail "no registered Fast Repair PR"

--- a/bin/fm-fast-repair.sh
+++ b/bin/fm-fast-repair.sh
@@ -184,9 +184,37 @@ tests_passed() {
 }
 
 broader_passed() {
-  local f="$STATE/$1.fast-repair-broader"
+  local id=$1 f worktree branch head
+  f="$STATE/$id.fast-repair-broader"
   regular_file "$f" || return 1
-  [ "$(field_get "$f" broader)" = passed ]
+  task_revision_for "$id" || return 1
+  worktree=$(field_get "$f" worktree)
+  branch=$(field_get "$f" branch)
+  head=$(field_get "$f" head)
+  [ "$worktree" = "$TASK_WORKTREE" ] || return 1
+  [ "$branch" = "$TASK_BRANCH" ] || return 1
+  [ "$head" = "$TASK_HEAD" ] || return 1
+  [ "$(wc -l < "$f" | tr -d '[:space:]')" = 4 ] || return 1
+  [ "$(grep -c '^broader=passed$' "$f")" = 1 ] || return 1
+  [ "$(grep -Fxc "worktree=$worktree" "$f")" = 1 ] || return 1
+  [ "$(grep -Fxc "branch=$branch" "$f")" = 1 ] || return 1
+  [ "$(grep -Fxc "head=$head" "$f")" = 1 ]
+}
+
+pr_head_matches_tested() {
+  local id=$1 meta pr_head remote_head
+  task_revision_for "$id" || return 1
+  meta="$STATE/$id.meta"
+  pr_identity_for "$id" || return 1
+  pr_head=$(field_get "$meta" pr_head)
+  fm_pr_head_valid "$pr_head" || return 1
+  [ "$(grep -Fxc "pr_head=$pr_head" "$meta")" = 1 ] || return 1
+  [ "$pr_head" = "$TASK_HEAD" ] || return 1
+  [ "$FM_PR_PROVIDER" = github ] || return 1
+  command -v gh >/dev/null 2>&1 || return 1
+  remote_head=$(cd "$TASK_WORKTREE" && gh pr view "$FM_PR_URL" --json headRefOid -q .headRefOid 2>/dev/null) || return 1
+  fm_pr_head_valid "$remote_head" || return 1
+  [ "$remote_head" = "$TASK_HEAD" ]
 }
 
 # The recorded pr= URL is re-parsed with the shared strict forge validator, so
@@ -429,6 +457,8 @@ case "$command" in
     url=$(printf '%s\n' "$out" | grep -Eo 'https://github\.com/[^[:space:]]+/pull/[0-9]+' | head -n 1 || true)
     [ -n "$url" ] || fail "PR creation returned no GitHub pull-request URL"
     "$SCRIPT_DIR/fm-pr-check.sh" "$id" "$url" >/dev/null
+    pr_head_matches_tested "$id" \
+      || fail "registered PR head does not match the exact tested task commit"
     printf 'fast-repair PR opened: %s\n' "$url"
     ;;
   broader)
@@ -439,13 +469,20 @@ case "$command" in
     broader_command=$2
     require_fast_repair_meta "$id"
     eligibility_valid "$id" || fail "eligibility evidence is absent or invalid"
+    tests_passed "$id" || fail "focused evidence is absent or failed"
+    task_revision_for "$id" || fail "task $id has no safe git worktree at its metadata path"
     pr_identity_for "$id" || fail "broader tests start only after the direct PR is registered"
     [ -n "$broader_command" ] || fail "broader command is empty"
     log="$STATE/$id.fast-repair-broader.log"
     record="$STATE/.$id.fast-repair-broader.$$"
     private_truncate "$log" || fail "the broader-test log could not be created"
-    if bash -c "$broader_command" >>"$log" 2>&1; then result=passed; else result=failed; fi
-    printf 'broader=%s\n' "$result" | private_write "$record" \
+    if ( cd "$TASK_WORKTREE" && bash -c "$broader_command" ) >>"$log" 2>&1; then result=passed; else result=failed; fi
+    {
+      printf 'broader=%s\n' "$result"
+      printf 'worktree=%s\n' "$TASK_WORKTREE"
+      printf 'branch=%s\n' "$TASK_BRANCH"
+      printf 'head=%s\n' "$TASK_HEAD"
+    } | private_write "$record" \
       || fail "the broader-test record could not be written"
     mv -f "$record" "$STATE/$id.fast-repair-broader"
     [ "$result" = passed ] || fail "broader tests failed after PR publication; inspect $log and report the open PR as not green"
@@ -477,6 +514,7 @@ case "$command" in
     eligibility_valid "$id" || fail "eligibility evidence is absent or invalid"
     tests_passed "$id" || fail "focused evidence is absent or failed"
     broader_passed "$id" || fail "broader tests are not passed"
+    pr_head_matches_tested "$id" || fail "registered PR head does not match the exact tested task commit"
     pr_identity_for "$id" || fail "no registered Fast Repair PR"
     summary=$(checks_summary "$FM_PR_NUMBER" "$FM_PR_OWNER/$FM_PR_REPO") || fail "PR checks could not be read"
     [ -n "$summary" ] || fail "PR checks could not be read"

--- a/bin/fm-fast-repair.sh
+++ b/bin/fm-fast-repair.sh
@@ -54,9 +54,49 @@ REPRODUCTION_REVISION=
 REGRESSION_SELECTOR=
 REGRESSION_ARTIFACT=
 BODY_FILE=
+FAST_REPAIR_TMP_SANDBOX=
+FAST_REPAIR_TMP_OUTPUT=
 
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
+
+# The two temporaries this script creates are anonymous - a mkstemp suffix with
+# no task id - so teardown's per-task globs can never reclaim them, and the
+# reproduction sandbox is a full object copy of the project. Both are therefore
+# owned here for the whole life of the process: whichever one is live when the
+# run ends, however it ends, is removed.
+fast_repair_temp_cleanup() {
+  local sandbox=$FAST_REPAIR_TMP_SANDBOX output=$FAST_REPAIR_TMP_OUTPUT
+  FAST_REPAIR_TMP_SANDBOX=
+  FAST_REPAIR_TMP_OUTPUT=
+  [ -z "$output" ] || rm -f "$output" || true
+  [ -z "$sandbox" ] || rm -rf "$sandbox" || true
+  return 0
+}
+
+# The single owner of retiring the reproduction sandbox, so every exit path of
+# the witness both removes the clone and drops it from the cleanup handler.
+fast_repair_sandbox_remove() {
+  local sandbox=$FAST_REPAIR_TMP_SANDBOX
+  FAST_REPAIR_TMP_SANDBOX=
+  [ -z "$sandbox" ] || rm -rf "$sandbox" || true
+  return 0
+}
+
+# Re-raise with the default disposition so callers still read a killed-by-signal
+# wait status rather than a plain exit code.
+fast_repair_signal_cleanup() { # <signal>
+  local sig=$1
+  fast_repair_temp_cleanup
+  trap - EXIT "$sig"
+  kill -s "$sig" $$ 2>/dev/null || exit 1
+  exit 1
+}
+
+trap fast_repair_temp_cleanup EXIT
+trap 'fast_repair_signal_cleanup HUP' HUP
+trap 'fast_repair_signal_cleanup INT' INT
+trap 'fast_repair_signal_cleanup TERM' TERM
 
 usage() {
   sed -n '2,${/^#/!q;p;}' "$0" | sed 's/^# \{0,1\}//'
@@ -195,9 +235,10 @@ runner_family_valid() {
   "$TEST_RUNNER" --list-families 2>/dev/null | grep -Fx "$family" >/dev/null
 }
 
+# One shape for one concept: a commit id here is the same identity the forge
+# validator already owns, so SHA-1 and SHA-256 object formats are both accepted.
 reproduction_revision_valid() {
-  case "$1" in ????????????????????????????????????????) ;; *) return 1 ;; esac
-  case "$1" in *[!0-9a-f]*) return 1 ;; esac
+  fm_pr_head_valid "${1-}"
 }
 
 # What is knowable before the repair commit exists: the recorded revision is a
@@ -302,7 +343,8 @@ run_typed() { # <worktree> <pass|fail> <log> <runner-arg>...
   local worktree=$1 expected=$2 log=$3 output status
   shift 3
   output=$(mktemp "$STATE/.fast-repair-test-output.XXXXXX") || return 1
-  chmod 600 "$output" || { rm -f "$output"; return 1; }
+  FAST_REPAIR_TMP_OUTPUT=$output
+  chmod 600 "$output" || { rm -f "$output"; FAST_REPAIR_TMP_OUTPUT=; return 1; }
   if ( cd "$worktree" && "$worktree/bin/fm-test-run.sh" "$@" ) >"$output" 2>&1; then
     status=0
   else
@@ -320,9 +362,11 @@ run_typed() { # <worktree> <pass|fail> <log> <runner-arg>...
       }
     ' "$output"; then
     rm -f "$output"
+    FAST_REPAIR_TMP_OUTPUT=
     return 0
   fi
   rm -f "$output"
+  FAST_REPAIR_TMP_OUTPUT=
   return 1
 }
 
@@ -336,27 +380,29 @@ run_typed_selector() { # <worktree> <selector> <pass|fail> <log>
 
 regression_witness_valid() { # <family> <selector> <artifact> <log>
   local family=$1 selector=$2 artifact=$3 log=$4 sandbox sandbox_root parent resolved component target mode file_mode oid runner_oid selected
+  local components=()
   case "$artifact" in 100755:*) ;; *) return 1 ;; esac
   mode=${artifact%%:*}
   file_mode=${mode#100}
   oid=${artifact#*:}
   sandbox=$(mktemp -d "$STATE/.fast-repair-reproduction.XXXXXX") || return 1
-  rmdir "$sandbox" || return 1
+  FAST_REPAIR_TMP_SANDBOX=$sandbox
+  rmdir "$sandbox" || { fast_repair_sandbox_remove; return 1; }
   if ! git clone --quiet --no-hardlinks "$TASK_WORKTREE" "$sandbox" \
     || ! git -C "$sandbox" checkout --quiet --detach "$REPRODUCTION_REVISION"; then
-    rm -rf "$sandbox"
+    fast_repair_sandbox_remove
     return 1
   fi
-  sandbox_root=$(cd "$sandbox" && pwd -P) || { rm -rf "$sandbox"; return 1; }
+  sandbox_root=$(cd "$sandbox" && pwd -P) || { fast_repair_sandbox_remove; return 1; }
   for parent in "$(dirname "$selector")" bin; do
     target=$sandbox
     IFS=/ read -r -a components <<< "$parent"
-    for component in "${components[@]}"; do
+    for component in "${components[@]+"${components[@]}"}"; do
       [ -n "$component" ] || continue
       target="$target/$component"
-      [ -e "$target" ] || mkdir "$target" || { rm -rf "$sandbox"; return 1; }
-      resolved=$(cd "$target" && pwd -P) || { rm -rf "$sandbox"; return 1; }
-      case "$resolved" in "$sandbox_root"|"$sandbox_root"/*) ;; *) rm -rf "$sandbox"; return 1 ;; esac
+      [ -e "$target" ] || mkdir "$target" || { fast_repair_sandbox_remove; return 1; }
+      resolved=$(cd "$target" && pwd -P) || { fast_repair_sandbox_remove; return 1; }
+      case "$resolved" in "$sandbox_root"|"$sandbox_root"/*) ;; *) fast_repair_sandbox_remove; return 1 ;; esac
     done
   done
   runner_oid=${TEST_RUNNER_ARTIFACT#*:}
@@ -366,19 +412,19 @@ regression_witness_valid() { # <family> <selector> <artifact> <log>
     || ! git -C "$TASK_WORKTREE" show "$TASK_HEAD:$selector" > "$sandbox/$selector" \
     || ! chmod "$file_mode" "$sandbox/$selector" \
     || ! [ "$(git -C "$sandbox" hash-object "$selector")" = "$oid" ]; then
-    rm -rf "$sandbox"
+    fast_repair_sandbox_remove
     return 1
   fi
   selected=$(cd "$sandbox" && ./bin/fm-test-run.sh --list --family "$family" 2>/dev/null) || {
-    rm -rf "$sandbox"
+    fast_repair_sandbox_remove
     return 1
   }
   if ! printf '%s\n' "$selected" | grep -Fx "$selector" >/dev/null \
     || ! run_typed_selector "$sandbox" "$selector" fail "$log"; then
-    rm -rf "$sandbox"
+    fast_repair_sandbox_remove
     return 1
   fi
-  rm -rf "$sandbox"
+  fast_repair_sandbox_remove
 }
 
 eligibility_file() { printf '%s/%s/fast-repair-eligibility\n' "$DATA" "$1"; }

--- a/bin/fm-fast-repair.sh
+++ b/bin/fm-fast-repair.sh
@@ -7,7 +7,7 @@
 #     --schema none --authentication none --authorization none --secrets none \
 #     --financial none --legal none --side-effects none
 #   fm-fast-repair.sh eligible <task-id>
-#   fm-fast-repair.sh evidence <task-id> --regression-test <relative-executable-test> --focused-test <relative-executable-test>
+#   fm-fast-repair.sh evidence <task-id> --regression-test <relative-test-selector> --focused-test <relative-test-selector>
 #   fm-fast-repair.sh publish-pr <task-id> --title <text> --body-file <path> [--base <branch>] [--head <branch>]
 #   fm-fast-repair.sh broader <task-id> --command <command>
 #   fm-fast-repair.sh progress <task-id>
@@ -22,7 +22,8 @@
 #
 # A Fast Repair spawn must use mode=fast-repair, yolo=off, and the built-in
 # Codex gpt-5.6-luna medium profile. `evidence` executes named regression and
-# focused-module tests directly and records their result. `publish-pr` refuses
+# focused-module test selectors through the supported test runner and records
+# their result. `publish-pr` refuses
 # until both passed, then opens and registers a direct PR. `broader` is run
 # after publication while PR checks run concurrently. `ready` refuses until the
 # broader command and all PR checks are green. `progress` prints only a changed
@@ -37,7 +38,7 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 TASK_WORKTREE=
 TASK_BRANCH=
 TASK_HEAD=
-TEST_PATH=
+TEST_RUNNER=
 BODY_FILE=
 
 # shellcheck source=bin/fm-pr-lib.sh
@@ -114,8 +115,21 @@ positive_fact_valid() { # <field> <value>
 
 risk_excluded() { [ "$1" = none ]; }
 
-test_path_valid() {
-  local path=$1 parent resolved rel
+test_runner_valid() {
+  local parent resolved rel=bin/fm-test-run.sh
+  [ -n "$TASK_WORKTREE" ] || return 1
+  parent=$(dirname "$TASK_WORKTREE/$rel")
+  resolved=$(cd "$parent" 2>/dev/null && pwd -P) || return 1
+  resolved="$resolved/$(basename "$rel")"
+  [ "$resolved" = "$TASK_WORKTREE/$rel" ] || return 1
+  regular_file "$resolved" && [ -x "$resolved" ] || return 1
+  [ "$(git -C "$TASK_WORKTREE" cat-file -t "$TASK_HEAD:$rel" 2>/dev/null || true)" = blob ] || return 1
+  git -C "$TASK_WORKTREE" diff --no-ext-diff --quiet "$TASK_HEAD" -- ":(literal)$rel" || return 1
+  TEST_RUNNER=$resolved
+}
+
+test_selector_valid() {
+  local kind=$1 path=$2 parent resolved rel
   case "$path" in
     ''|/*|.|..|../*|*/../*|*'/..'|*$'\n'*|*$'\r'*) return 1 ;;
   esac
@@ -124,15 +138,41 @@ test_path_valid() {
   resolved=$(cd "$parent" 2>/dev/null && pwd -P) || return 1
   resolved="$resolved/$(basename "$path")"
   case "$resolved" in "$TASK_WORKTREE"/*) ;; *) return 1 ;; esac
-  regular_file "$resolved" && [ -x "$resolved" ] || return 1
+  regular_file "$resolved" || return 1
   rel=${resolved#"$TASK_WORKTREE/"}
+  case "$kind:$rel" in
+    regression:tests/*-regression.test.sh|focused:tests/*-focused.test.sh) ;;
+    *) return 1 ;;
+  esac
   [ "$(git -C "$TASK_WORKTREE" cat-file -t "$TASK_HEAD:$rel" 2>/dev/null || true)" = blob ] || return 1
   git -C "$TASK_WORKTREE" diff --no-ext-diff --quiet "$TASK_HEAD" -- ":(literal)$rel" || return 1
-  TEST_PATH=$resolved
 }
 
-regression_test_valid() { test_path_valid "$1"; }
-focused_test_valid() { test_path_valid "$1"; }
+regression_test_valid() { test_selector_valid regression "$1" && test_runner_valid; }
+focused_test_valid() { test_selector_valid focused "$1" && test_runner_valid; }
+
+run_typed_test() { # <selector> <log>
+  local selector=$1 log=$2 output status
+  output=$(mktemp "$STATE/.fast-repair-test-output.XXXXXX") || return 1
+  chmod 600 "$output" || { rm -f "$output"; return 1; }
+  if ( cd "$TASK_WORKTREE" && "$TEST_RUNNER" "$selector" ) >"$output" 2>&1; then
+    status=0
+  else
+    status=1
+  fi
+  cat "$output" >> "$log" || status=1
+  if [ "$status" -eq 0 ] \
+    && awk -v selector="$selector" '
+      $1 == "FM_TEST_BEGIN" && $3 == selector { began = 1 }
+      $1 == "FM_TEST_END" && $3 == selector && $4 == "exit=0" { passed = 1 }
+      END { exit !(began && passed) }
+    ' "$output"; then
+    rm -f "$output"
+    return 0
+  fi
+  rm -f "$output"
+  return 1
+}
 
 eligibility_file() { printf '%s/%s/fast-repair-eligibility\n' "$DATA" "$1"; }
 tests_file() { printf '%s/%s.fast-repair-tests\n' "$STATE" "$1"; }
@@ -413,17 +453,17 @@ case "$command" in
     eligibility_valid "$id" || fail "eligibility evidence is absent or invalid"
     task_revision_for "$id" || fail "task $id has no safe git worktree at its metadata path"
     regression_test_valid "$regression_test" \
-      || fail "regression-test must name an unchanged executable test file in the task commit"
-    regression_path=$TEST_PATH
+      || fail "regression-test must name an unchanged tests/*-regression.test.sh selector supported by bin/fm-test-run.sh"
     focused_test_valid "$focused_test" \
-      || fail "focused-test must name an unchanged executable test file in the task commit"
-    focused_path=$TEST_PATH
+      || fail "focused-test must name an unchanged tests/*-focused.test.sh selector supported by bin/fm-test-run.sh"
+    [ "$regression_test" != "$focused_test" ] \
+      || fail "regression-test and focused-test must name different test selectors"
     mkdir -p "$STATE"
     log="$STATE/$id.fast-repair-tests.log"
     record="$STATE/.$id.fast-repair-tests.$$"
     private_truncate "$log" || fail "the evidence log could not be created"
-    if ( cd "$TASK_WORKTREE" && "$regression_path" ) >>"$log" 2>&1; then regression_result=passed; else regression_result=failed; fi
-    if [ "$regression_result" = passed ] && ( cd "$TASK_WORKTREE" && "$focused_path" ) >>"$log" 2>&1; then focused_result=passed; else focused_result=failed; fi
+    if run_typed_test "$regression_test" "$log"; then regression_result=passed; else regression_result=failed; fi
+    if [ "$regression_result" = passed ] && run_typed_test "$focused_test" "$log"; then focused_result=passed; else focused_result=failed; fi
     {
       printf 'regression=%s\n' "$regression_result"
       printf 'regression_test=%s\n' "$regression_test"

--- a/bin/fm-fast-repair.sh
+++ b/bin/fm-fast-repair.sh
@@ -101,6 +101,7 @@ request_valid() {
     *) return 1 ;;
   esac
   case "$1" in *$'\n'*|*$'\r'*) return 1 ;; esac
+  case "${1#fast-repair: }" in *[![:space:]]*) ;; *) return 1 ;; esac
 }
 
 # The one rule for a proven positive fact and for an excluded risk. intake

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -63,6 +63,9 @@ done
 }
 case "$MODE" in
   no-mistakes|direct-PR|local-only) ;;
+  fast-repair)
+    echo "error: Fast Repair cannot promote a scout; it requires a known end-user reproduction and typed eligibility at normal intake" >&2
+    exit 1 ;;
   no-mistakes-prod-only)
     echo "error: no-mistakes-prod-only is a registry policy, not a task mode; classify this task's surface and resolve it to no-mistakes or direct-PR" >&2
     exit 1 ;;

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -12,6 +12,9 @@
 # read the scout's report (AGENTS.md section 7); data/projects.md holds the
 # captain's standing posture as context, and this script never looks it up.
 # no-mistakes-prod-only is a registry policy rather than a task mode and is refused.
+# fast-repair is refused too: it is a per-task exception that needs a known
+# end-user reproduction and its typed eligibility record at normal intake
+# (docs/fast-repair.md), so a scout is never promoted into it.
 # Usage: fm-promote.sh <task-id> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off>
 set -eu
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1006,6 +1006,21 @@ if [ "$RELAUNCH" -eq 1 ]; then
   [ -n "$KIND" ] || KIND=ship
   MODE=$(fm_meta_get "$RELAUNCH_META" mode)
   YOLO=$(fm_meta_get "$RELAUNCH_META" yolo)
+  # Fast Repair's profile is part of its delivery contract, not a default the
+  # caller may re-resolve, so a relaunch reuses the recorded model and effort
+  # for exactly the same reason it reuses the recorded harness above. Without
+  # this the standard stuck-crewmate recovery is refused by the profile gate
+  # below. Other modes keep resolving model and effort as they always have.
+  if [ "$MODE" = fast-repair ]; then
+    RELAUNCH_PRIOR_MODEL=$(fm_meta_get "$RELAUNCH_META" model)
+    RELAUNCH_PRIOR_EFFORT=$(fm_meta_get "$RELAUNCH_META" effort)
+    if [ "$MODEL_SET" -eq 0 ] && [ -n "$RELAUNCH_PRIOR_MODEL" ] && [ "$RELAUNCH_PRIOR_MODEL" != default ]; then
+      MODEL=$RELAUNCH_PRIOR_MODEL
+    fi
+    if [ "$EFFORT_SET" -eq 0 ] && [ -n "$RELAUNCH_PRIOR_EFFORT" ] && [ "$RELAUNCH_PRIOR_EFFORT" != default ]; then
+      EFFORT=$RELAUNCH_PRIOR_EFFORT
+    fi
+  fi
   RELAUNCH_WT=$(fm_meta_get "$RELAUNCH_META" worktree)
   [ -n "$RELAUNCH_WT" ] && [ -d "$RELAUNCH_WT" ] || {
     echo "error: task $ID's recorded worktree '${RELAUNCH_WT:-none}' is missing; refusing to relaunch without the local copy its work lives in" >&2

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Spawn a direct report: a crewmate in a treehouse or Orca worktree, or a
 # secondmate in its isolated firstmate home.
-# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
+# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only|fast-repair> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
 #        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
 #        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] --secondmate
 #   --mode and --yolo are this task's delivery contract, REQUIRED for every ship
@@ -15,7 +15,10 @@
 #   the explicit mode carries less rigor than the project's standing posture, a
 #   loud one-line deviation notice is printed and the spawn continues.
 #   no-mistakes-prod-only is a registry policy rather than a task mode and is
-#   refused as a flag value.
+#   refused as a flag value. fast-repair is a strict per-task exception, never
+#   a project mode: it requires an eligible typed record from fm-fast-repair.sh,
+#   yolo=off, and the built-in Codex gpt-5.6-luna medium profile. A missing or
+#   conflicting profile refuses before an endpoint or metadata record exists.
 #        fm-spawn.sh <task-id> --relaunch [--harness <name>] [--model <name>] [--effort <level>]
 #   --relaunch launches a replacement agent for an EXISTING task into that
 #   task's own recorded endpoint and worktree instead of creating either. It is
@@ -353,7 +356,7 @@ else
   # and record no delivery posture; secondmate spawns hardcode theirs.
   if [ "$KIND" = ship ]; then
     [ "$MODE_SET" -eq 1 ] || {
-      echo "error: ship spawns require --mode <no-mistakes|direct-PR|local-only>; resolve it at intake from the captain's instruction and the project's registered posture in data/projects.md" >&2
+      echo "error: ship spawns require --mode <no-mistakes|direct-PR|local-only|fast-repair>; resolve it at intake from the captain's instruction and the project's registered posture in data/projects.md" >&2
       exit 1
     }
     [ "$YOLO_SET" -eq 1 ] || {
@@ -361,16 +364,20 @@ else
       exit 1
     }
     case "$MODE" in
-      no-mistakes|direct-PR|local-only) ;;
+      no-mistakes|direct-PR|local-only|fast-repair) ;;
       no-mistakes-prod-only)
         echo "error: no-mistakes-prod-only is a registry policy, not a task mode; classify this task's surface and resolve it to no-mistakes or direct-PR at intake" >&2
         exit 1 ;;
-      *) echo "error: --mode must be one of no-mistakes, direct-PR, local-only (got '$MODE')" >&2; exit 1 ;;
+      *) echo "error: --mode must be one of no-mistakes, direct-PR, local-only, fast-repair (got '$MODE')" >&2; exit 1 ;;
     esac
     case "$YOLO" in
       on|off) ;;
       *) echo "error: --yolo must be on or off (got '$YOLO')" >&2; exit 1 ;;
     esac
+    if [ "$MODE" = fast-repair ] && [ "$YOLO" != off ]; then
+      echo "error: Fast Repair always requires --yolo off; captain approval remains the only merge authority" >&2
+      exit 1
+    fi
   else
     [ "$MODE_SET" -eq 0 ] || {
       echo "error: --mode applies only to ship spawns; a scout delivers a report and a secondmate records its own fixed posture" >&2
@@ -1602,7 +1609,7 @@ fi
 delivery_rigor_rank() {  # <mode> -> 3 (most rigor) .. 1 (least); 0 = not a task mode
   case "$1" in
     no-mistakes) echo 3 ;;
-    direct-PR) echo 2 ;;
+    direct-PR|fast-repair) echo 2 ;;
     local-only) echo 1 ;;
     *) echo 0 ;;
   esac
@@ -1620,6 +1627,16 @@ if [ "$KIND" = ship ]; then
   elif [ "$BRIEF_MODE" != "$MODE" ]; then
     echo "error: delivery mismatch for $ID: the brief says mode=$BRIEF_MODE but this spawn passed --mode $MODE; correct the flag or re-scaffold the brief so the worker's instructions and the task record agree" >&2
     exit 1
+  fi
+  if [ "$MODE" = fast-repair ]; then
+    "$SCRIPT_DIR/fm-fast-repair.sh" eligible "$ID" >/dev/null || {
+      echo "error: Fast Repair spawn refused because its typed eligibility evidence is absent or incomplete; use the normal delivery path" >&2
+      exit 1
+    }
+    if [ "$HARNESS" != codex ] || [ "$MODEL" != gpt-5.6-luna ] || [ "$EFFORT" != medium ]; then
+      echo "error: Fast Repair requires the built-in profile --harness codex --model gpt-5.6-luna --effort medium; an explicit conflicting per-task profile is not overridden" >&2
+      exit 1
+    fi
   fi
   # The registry holds the captain's standing posture, so dropping below it is
   # allowed (a current explicit captain instruction wins) but never silent. An
@@ -2564,7 +2581,7 @@ fi
 preserve_relaunch_meta() {
   awk -F= '
     BEGIN {
-      split("window endpoint_task_id worktree project harness kind mode yolo tasktmp model effort busy_gen traceparent backend herdr_session herdr_workspace_id herdr_tab_id herdr_pane_id zellij_session zellij_tab_id zellij_pane_id orca_worktree_id terminal cmux_workspace_id cmux_surface_id home projects control_relaunch_tx", keys, " ")
+      split("window endpoint_task_id worktree project harness kind mode yolo fast_repair tasktmp model effort busy_gen traceparent backend herdr_session herdr_workspace_id herdr_tab_id herdr_pane_id zellij_session zellij_tab_id zellij_pane_id orca_worktree_id terminal cmux_workspace_id cmux_surface_id home projects control_relaunch_tx", keys, " ")
       for (i in keys) owned[keys[i]] = 1
     }
     !($1 in owned)
@@ -2579,6 +2596,7 @@ preserve_relaunch_meta() {
   echo "kind=$KIND"
   [ -z "$MODE" ] || echo "mode=$MODE"
   [ -z "$YOLO" ] || echo "yolo=$YOLO"
+  [ "$MODE" != fast-repair ] || echo "fast_repair=eligible"
   echo "tasktmp=$TASK_TMP"
   echo "model=${MODEL:-default}"
   echo "effort=${EFFORT:-default}"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2255,6 +2255,13 @@ if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
   freshen_spawn_worktree_base "$WT" || exit 1
 fi
 
+if [ "$KIND" = ship ] && [ "$MODE" = fast-repair ]; then
+  "$SCRIPT_DIR/fm-fast-repair.sh" eligible "$ID" --worktree "$WT" >/dev/null || {
+    echo "error: Fast Repair spawn refused because its reproduction revision is not proven for the task worktree; use the normal delivery path" >&2
+    exit 1
+  }
+fi
+
 # Per-task temp root: /tmp/fm-<id>/ with Go's build temp nested at gotmp/. Go won't
 # create GOTMPDIR, so mkdir before it is used; fm-teardown removes the whole root.
 # Nested (not a bare /tmp/fm-<id>/gotmp) so other per-task temp can live alongside

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2255,7 +2255,15 @@ if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
   freshen_spawn_worktree_base "$WT" || exit 1
 fi
 
-if [ "$KIND" = ship ] && [ "$MODE" = fast-repair ]; then
+# The --worktree proof is a DISPATCH-time gate: it asserts a pristine worktree
+# still sitting on the recorded reproduction commit, which is only true before a
+# crewmate branches, edits, or commits. A relaunch replaces a wedged crewmate in a
+# worktree that already holds unlanded repair work, so re-running that proof would
+# refuse the documented stuck-crewmate recovery purely for being dirty. The typed
+# eligibility gate above already re-proves the task's Fast Repair authorization on
+# every spawn, relaunch included, and the branch and tested-head proofs belong to
+# evidence, publish-pr, broader, and ready, which run once the repair commit exists.
+if [ "$KIND" = ship ] && [ "$MODE" = fast-repair ] && [ "$RELAUNCH" -eq 0 ]; then
   "$SCRIPT_DIR/fm-fast-repair.sh" eligible "$ID" --worktree "$WT" >/dev/null || {
     echo "error: Fast Repair spawn refused because its reproduction revision is not proven for the task worktree; use the normal delivery path" >&2
     exit 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1178,6 +1178,7 @@ launch_template() {
 
 case "$ARG3" in
   *' '*)  # raw launch command (unverified-adapter escape hatch)
+    RAW_LAUNCH=1
     LAUNCH=$ARG3
     HARNESS=""
     for word in $LAUNCH; do
@@ -1185,6 +1186,7 @@ case "$ARG3" in
     done
     ;;
   '')
+    RAW_LAUNCH=0
     # No explicit harness: resolve from config. A secondmate AGENT launches on the
     # secondmate harness (config/secondmate-harness -> config/crew-harness -> own);
     # every other kind uses the crew harness only when no dispatch profile file is
@@ -1207,6 +1209,7 @@ case "$ARG3" in
     LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: no launch template for harness '$HARNESS' (from $harness_src or detection); pass a raw launch command to use an unverified adapter" >&2; exit 1; }
     ;;
   *)
+    RAW_LAUNCH=0
     HARNESS=$ARG3
     LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: unknown harness '$HARNESS'; pass a raw launch command to use an unverified adapter" >&2; exit 1; }
     ;;
@@ -1648,7 +1651,7 @@ if [ "$KIND" = ship ]; then
       echo "error: Fast Repair spawn refused because its typed eligibility evidence is absent or incomplete; use the normal delivery path" >&2
       exit 1
     }
-    if [ "$HARNESS" != codex ] || [ "$MODEL" != gpt-5.6-luna ] || [ "$EFFORT" != medium ]; then
+    if [ "${RAW_LAUNCH:-0}" = 1 ] || [ "$HARNESS" != codex ] || [ "$MODEL" != gpt-5.6-luna ] || [ "$EFFORT" != medium ]; then
       echo "error: Fast Repair requires the built-in profile --harness codex --model gpt-5.6-luna --effort medium; an explicit conflicting per-task profile is not overridden" >&2
       exit 1
     fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2539,7 +2539,10 @@ rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
   "$STATE/$ID.muse-session-current" \
   "$STATE/.$ID.open-decisions-cursor" \
   "$STATE/$ID.control-relaunch" "$STATE/$ID.control-relaunch.meta-prior" \
-  "$STATE/$ID.control-relaunch.brief-prior" "$STATE/$ID.control-relaunch.note"
+  "$STATE/$ID.control-relaunch.brief-prior" "$STATE/$ID.control-relaunch.note" \
+  "$STATE/$ID.fast-repair-tests" "$STATE/$ID.fast-repair-tests.log" \
+  "$STATE/$ID.fast-repair-broader" "$STATE/$ID.fast-repair-broader.log" \
+  "$STATE/.fast-repair-progress-$ID"
 fm_lock_release "$META_LOCK"
 META_LOCK_HELD=0
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -756,6 +756,40 @@ remove_pr_poll_artifacts() {
   fi
 }
 
+# Fast Repair progress artifacts are named <prefix>-<id>-<generation> (child and
+# sequence records) or <prefix>-<id>-<generation>-<sequence> (handoff records),
+# and a task id may itself contain hyphens, so a bare <prefix>-<id>-* glob also
+# matches every OTHER task whose id begins with "<id>-". Tearing task `fix` down
+# would then delete live `fix-2` markers, leaving that task's progress child
+# unsignalled at the poll boundary and its undrained handoffs gone. Ownership is
+# decided on the remainder instead of the glob: it must be exactly the expected
+# count of numeric fields, followed by nothing or by one of the dot-suffixes the
+# watcher's writers append (.ready, .starting, .starting.closing, .lock,
+# .attempts, and mkstemp temporaries).
+fast_repair_artifact_fields_match() {  # <remainder> <field-count>
+  local rest=$1 fields=$2 head
+  while [ "$fields" -gt 0 ]; do
+    head=${rest%%[!0-9]*}
+    [ -n "$head" ] || return 1
+    rest=${rest#"$head"}
+    fields=$((fields - 1))
+    if [ "$fields" -gt 0 ]; then
+      case "$rest" in -*) rest=${rest#-} ;; *) return 1 ;; esac
+    fi
+  done
+  case "$rest" in ''|.*) return 0 ;; esac
+  return 1
+}
+
+remove_fast_repair_progress_artifacts() {  # <state-dir> <prefix> <task-id> <field-count>
+  local state_dir=$1 prefix=$2 id=$3 fields=$4 path
+  for path in "$state_dir/$prefix-$id-"*; do
+    [ -e "$path" ] || [ -L "$path" ] || continue
+    fast_repair_artifact_fields_match "${path#"$state_dir/$prefix-$id-"}" "$fields" || continue
+    rm -rf "$path" || return 1
+  done
+}
+
 # Resolve the PR number for a worktree branch via gh-axi. Echoes the number on a
 # single match and returns 0; returns non-zero on no match or any lookup failure,
 # so the caller treats it as "no PR found" (fail-safe).
@@ -2545,9 +2579,9 @@ rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
   "$STATE/.fast-repair-progress-$ID" "$STATE/.fast-repair-progress-generation-$ID" \
   "$STATE/.last-fast-repair-progress-$ID" "$STATE/.fast-repair-progress-next-due-$ID" \
   "$STATE/.fast-repair-progress-green-$ID"
-rm -rf "$STATE/.fast-repair-progress-handoff-$ID-"* \
-  "$STATE/.fast-repair-progress-sequence-$ID-"* \
-  "$STATE/.fast-repair-progress-child-$ID-"*
+remove_fast_repair_progress_artifacts "$STATE" .fast-repair-progress-handoff "$ID" 2 || exit 1
+remove_fast_repair_progress_artifacts "$STATE" .fast-repair-progress-sequence "$ID" 1 || exit 1
+remove_fast_repair_progress_artifacts "$STATE" .fast-repair-progress-child "$ID" 1 || exit 1
 fm_lock_release "$META_LOCK"
 META_LOCK_HELD=0
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2543,7 +2543,8 @@ rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
   "$STATE/$ID.fast-repair-tests" "$STATE/$ID.fast-repair-tests.log" \
   "$STATE/$ID.fast-repair-broader" "$STATE/$ID.fast-repair-broader.log" \
   "$STATE/.fast-repair-progress-$ID" "$STATE/.fast-repair-progress-generation-$ID" \
-  "$STATE/.last-fast-repair-progress-$ID" "$STATE/.fast-repair-progress-next-due-$ID"
+  "$STATE/.last-fast-repair-progress-$ID" "$STATE/.fast-repair-progress-next-due-$ID" \
+  "$STATE/.fast-repair-progress-green-$ID"
 rm -rf "$STATE/.fast-repair-progress-handoff-$ID-"* \
   "$STATE/.fast-repair-progress-sequence-$ID-"* \
   "$STATE/.fast-repair-progress-child-$ID-"*

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2542,7 +2542,11 @@ rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
   "$STATE/$ID.control-relaunch.brief-prior" "$STATE/$ID.control-relaunch.note" \
   "$STATE/$ID.fast-repair-tests" "$STATE/$ID.fast-repair-tests.log" \
   "$STATE/$ID.fast-repair-broader" "$STATE/$ID.fast-repair-broader.log" \
-  "$STATE/.fast-repair-progress-$ID"
+  "$STATE/.fast-repair-progress-$ID" "$STATE/.fast-repair-progress-generation-$ID" \
+  "$STATE/.last-fast-repair-progress-$ID" "$STATE/.fast-repair-progress-next-due-$ID"
+rm -rf "$STATE/.fast-repair-progress-handoff-$ID-"* \
+  "$STATE/.fast-repair-progress-sequence-$ID-"* \
+  "$STATE/.fast-repair-progress-child-$ID-"*
 fm_lock_release "$META_LOCK"
 META_LOCK_HELD=0
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -19,6 +19,7 @@
 #   fm-test-run.sh --list --lane portable-parallel-1
 #   fm-test-run.sh --list-families
 #   fm-test-run.sh --list-lanes
+#   fm-test-run.sh --list-shard-plan
 #   fm-test-run.sh --check-coverage
 #
 # Aggregation (no suite execution):
@@ -27,6 +28,13 @@
 # Options:
 #   --json <path>   write a deterministic timing artifact after the run
 #   --list          print selected script paths (one per line) and exit 0
+#   --list-shard-plan
+#                   print the derived portable serial shard plan and exit 0, one
+#                   line per shard:
+#                     portable-serial-<k>of<n> count=<n> estimated_ms=<n>
+#                   estimated_ms is this script's balance estimate, not a
+#                   measurement. docs/fm-test-portable-shards.md publishes this
+#                   plan and a test asserts the two agree.
 #   --base <ref>    with --changed, compare against this ref (default: origin/main)
 #   --exclude-family <name>
 #                   drop scripts whose primary family matches <name> after selection
@@ -77,6 +85,7 @@ MODE=
 LIST_ONLY=0
 LIST_FAMILIES=0
 LIST_LANES=0
+LIST_SHARD_PLAN=0
 CHECK_COVERAGE=0
 AGGREGATE_OUT=
 FAMILY=
@@ -488,6 +497,35 @@ portable_serial_assignments() {
       printf '%s\t%s\n' "$(portable_serial_weight_for "$script")" "$script"
     done < <(list_portable_serial) | LC_ALL=C sort -t$'\t' -k1,1nr -k2,2
   )
+}
+
+# Summary of that assignment: one line per shard with its script count and the
+# estimated millisecond load it received. docs/fm-test-portable-shards.md
+# publishes this plan as the balance evidence behind the portable-serial CI
+# timeout, so emitting it here keeps that table derived from this script rather
+# than hand-counted after every new test. estimated_ms sums the same balance
+# hints the assignment used, so it stays an estimate rather than a measurement
+# for any script with no hint.
+list_portable_serial_shard_plan() {
+  local idx script i
+  local -a counts=() loads=()
+  i=1
+  while [ "$i" -le "$PORTABLE_SERIAL_SHARDS" ]; do
+    counts[i]=0
+    loads[i]=0
+    i=$((i + 1))
+  done
+  while IFS=$'\t' read -r idx script; do
+    [ -n "$script" ] || continue
+    counts[idx]=$((counts[idx] + 1))
+    loads[idx]=$((loads[idx] + $(portable_serial_weight_for "$script")))
+  done < <(portable_serial_assignments)
+  i=1
+  while [ "$i" -le "$PORTABLE_SERIAL_SHARDS" ]; do
+    printf 'portable-serial-%sof%s count=%s estimated_ms=%s\n' \
+      "$i" "$PORTABLE_SERIAL_SHARDS" "${counts[i]}" "${loads[i]}"
+    i=$((i + 1))
+  done
 }
 
 # Parse "<k>of<n>" from a portable-serial shard lane and echo <k>, refusing when
@@ -1270,6 +1308,10 @@ while [ "$#" -gt 0 ]; do
       LIST_LANES=1
       shift
       ;;
+    --list-shard-plan)
+      LIST_SHARD_PLAN=1
+      shift
+      ;;
     --check-coverage)
       CHECK_COVERAGE=1
       shift
@@ -1335,6 +1377,11 @@ fi
 
 if [ "$LIST_LANES" -eq 1 ]; then
   list_known_lanes
+  exit 0
+fi
+
+if [ "$LIST_SHARD_PLAN" -eq 1 ]; then
+  list_portable_serial_shard_plan
   exit 0
 fi
 

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -132,7 +132,7 @@ now_ms() {
 # unclassified so new tests are still runnable and visible in summaries.
 family_for_basename() {
   case "$1" in
-    fm-arm-pretool-check.test.sh|fm-ask-user-authority.test.sh|\
+    fm-arm-pretool-check.test.sh|fm-ask-user-authority.test.sh|fm-fast-repair.test.sh|\
     fm-brief.test.sh|fm-vendor-auth-probe.test.sh|\
     fm-calm-pi-extension.test.sh|fm-cd-pretool-check.test.sh|\
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -467,6 +467,14 @@ scan_signals() {
 
 FAST_REPAIR_ACTIVE=0
 
+# The one place that decides whether durable task metadata opts a task into Fast
+# Repair. One tick collects the eligible ids with it once and reuses that list
+# for both the activity flag and the work.
+fast_repair_eligible_meta() {  # <meta-path>
+  grep -qx 'mode=fast-repair' "$1" 2>/dev/null || return 1
+  grep -qx 'fast_repair=eligible' "$1" 2>/dev/null
+}
+
 # Fast Repair has a short, task-scoped progress cadence for broader-test and PR
 # check results. It is inert, byte-for-byte, when no durable task metadata says
 # mode=fast-repair and fast_repair=eligible. It does not change the normal signal,
@@ -482,22 +490,20 @@ FAST_REPAIR_ACTIVE=0
 # forge call can neither stall the beat, the signal scan, and the stale and
 # wedge detection of other crewmates, nor hold off a stop signal.
 fast_repair_progress_tick() {
-  local meta id result marker prior active=0
+  local meta id result marker prior
+  local ids=()
   for meta in "$STATE"/*.meta; do
     [ -e "$meta" ] || continue
-    grep -qx 'mode=fast-repair' "$meta" 2>/dev/null || continue
-    grep -qx 'fast_repair=eligible' "$meta" 2>/dev/null || continue
-    active=1
-    break
+    fast_repair_eligible_meta "$meta" || continue
+    ids+=("$(basename "$meta" .meta)")
   done
-  FAST_REPAIR_ACTIVE=$active
-  [ "$active" -eq 1 ] || return 0
+  if [ "${#ids[@]}" -eq 0 ]; then
+    FAST_REPAIR_ACTIVE=0
+    return 0
+  fi
+  FAST_REPAIR_ACTIVE=1
   [ "$(age_of "$STATE/.last-fast-repair-progress")" -ge "$FAST_REPAIR_PROGRESS_INTERVAL" ] || return 0
-  for meta in "$STATE"/*.meta; do
-    [ -e "$meta" ] || continue
-    grep -qx 'mode=fast-repair' "$meta" 2>/dev/null || continue
-    grep -qx 'fast_repair=eligible' "$meta" 2>/dev/null || continue
-    id=$(basename "$meta" .meta)
+  for id in "${ids[@]}"; do
     FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
       run_check_capture "$SCRIPT_DIR/fm-fast-repair.sh" progress "$id" || exit 1
     result=$FM_CHECK_RESULT

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -721,7 +721,7 @@ run_check_capture() {
   FM_ACTIVE_CHECK_PGID=$FM_ACTIVE_CHECK_PID
   set +m
   pgid=$(ps -o pgid= -p "$FM_ACTIVE_CHECK_PID" 2>/dev/null | tr -d '[:space:]')
-  trap 'exit 1' HUP INT TERM
+  trap 'fm_active_check_stop || true; exit 1' HUP INT TERM
   if [ -n "$pgid" ] && [ "$pgid" != "$FM_ACTIVE_CHECK_PGID" ]; then
     fm_active_check_stop || true
     fm_check_output_cleanup
@@ -779,7 +779,7 @@ fast_repair_progress_timer_start() {
   parent=$WATCHER_PID
   (
     trap 'rm -f "$closing"' EXIT
-    trap 'exit 0' HUP INT TERM
+    trap 'fm_active_check_stop || true; exit 0' HUP INT TERM
     while [ -f "$marker" ]; do
       remaining=$(( FAST_REPAIR_PROGRESS_INTERVAL - $(age_of "$STATE/.last-fast-repair-progress") ))
       [ "$remaining" -ge 1 ] || remaining=1

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -551,10 +551,10 @@ fast_repair_progress_task_marker() { # <task-id> <generation>
 }
 
 fast_repair_progress_task_stop() { # <marker>
-  local marker=$1 pid i=0
+  local marker=$1 ready="$1.ready" pid i=0
   [ -f "$marker" ] && [ ! -L "$marker" ] || return 0
   pid=$(cat "$marker" 2>/dev/null || true)
-  case "$pid" in ''|*[!0-9]*) rm -f "$marker"; return 0 ;; esac
+  case "$pid" in ''|*[!0-9]*) rm -f "$marker" "$ready"; return 0 ;; esac
   if kill -0 "$pid" 2>/dev/null; then
     kill -TERM "$pid" 2>/dev/null || true
     while kill -0 "$pid" 2>/dev/null && [ "$i" -lt 20 ]; do
@@ -563,7 +563,7 @@ fast_repair_progress_task_stop() { # <marker>
     done
     kill -KILL "$pid" 2>/dev/null || true
   fi
-  rm -f "$marker"
+  rm -f "$marker" "$ready"
 }
 
 fast_repair_progress_timer_tasks_finish() { # <generation>
@@ -575,23 +575,31 @@ fast_repair_progress_timer_tasks_finish() { # <generation>
 }
 
 fast_repair_progress_task_start() { # <task-id> <generation>
-  local id=$1 generation=$2 marker result closing=${FM_FAST_REPAIR_TIMER_CLOSING:-}
+  local id=$1 generation=$2 marker ready result closing=${FM_FAST_REPAIR_TIMER_CLOSING:-} pid tmp
   marker=$(fast_repair_progress_task_marker "$id" "$generation") || return 1
+  ready="$marker.ready"
   if [ -f "$marker" ] && [ ! -L "$marker" ]; then
     return 0
   fi
   touch "$STATE/.last-fast-repair-progress-$id"
   (
-    [ -z "$closing" ] || [ ! -e "$closing" ] || exit 0
-    printf '%s\n' "${BASHPID:-$$}" > "$marker" || exit 1
-    trap 'rm -f "$marker"' EXIT
+    trap 'rm -f "$marker" "$ready"' EXIT
     trap 'fm_active_check_stop || true; exit 0' HUP INT TERM
+    while [ ! -f "$ready" ]; do sleep 0.01; done
     [ -z "$closing" ] || [ ! -e "$closing" ] || exit 0
     FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
       run_check_capture "$SCRIPT_DIR/fm-fast-repair.sh" progress "$id" || exit 1
     result=$FM_CHECK_RESULT
     [ -z "$result" ] || fast_repair_progress_timer_publish "$id" "$result"
   ) &
+  pid=$!
+  tmp=$(mktemp "$marker.XXXXXX") || { kill -TERM "$pid" 2>/dev/null || true; return 1; }
+  if ! printf '%s\n' "$pid" > "$tmp" || ! chmod 600 "$tmp" || ! mv -f "$tmp" "$marker"; then
+    rm -f "$tmp"
+    kill -TERM "$pid" 2>/dev/null || true
+    return 1
+  fi
+  touch "$ready"
 }
 
 fast_repair_progress_tick() {

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -465,6 +465,8 @@ scan_signals() {
   return 0
 }
 
+FAST_REPAIR_ACTIVE=0
+
 # Fast Repair has a short, task-scoped progress cadence for broader-test and PR
 # check results. It is inert, byte-for-byte, when no durable task metadata says
 # mode=fast-repair and fast_repair=eligible. It does not change the normal signal,
@@ -488,6 +490,7 @@ fast_repair_progress_tick() {
     active=1
     break
   done
+  FAST_REPAIR_ACTIVE=$active
   [ "$active" -eq 1 ] || return 0
   [ "$(age_of "$STATE/.last-fast-repair-progress")" -ge "$FAST_REPAIR_PROGRESS_INTERVAL" ] || return 0
   for meta in "$STATE"/*.meta; do
@@ -673,6 +676,29 @@ heartbeat_scan_finds_actionable() {
   return 1
 }
 
+# The terminal wait of a cycle, in seconds. Every home waits exactly POLL, as
+# it always has. The one exception is a home that currently holds an eligible
+# Fast Repair task: the cycle then waits only until that task's next progress
+# tick becomes due, because a POLL-sized wait cannot land on a shorter interval
+# and would stretch the Fast-Repair-only cadence to the next multiple of POLL.
+# This only ever shortens the wait, only while Fast Repair is active, and a
+# non-integer POLL (tests use fractional values) is passed through untouched.
+cycle_wait() {
+  local remaining
+  if [ "$FAST_REPAIR_ACTIVE" != 1 ]; then
+    printf '%s\n' "$POLL"
+    return 0
+  fi
+  case "$POLL" in ''|*[!0-9]*) printf '%s\n' "$POLL"; return 0 ;; esac
+  remaining=$(( FAST_REPAIR_PROGRESS_INTERVAL - $(age_of "$STATE/.last-fast-repair-progress") ))
+  [ "$remaining" -ge 1 ] || remaining=1
+  if [ "$remaining" -lt "$POLL" ]; then
+    printf '%s\n' "$remaining"
+  else
+    printf '%s\n' "$POLL"
+  fi
+}
+
 # event_wait_or_sleep: the terminal wait of each supervision cycle. For a home
 # with push-capable windows (herdr), it replaces the blind `sleep POLL` with a
 # bounded wait on the backend's native transition stream, so a crew going
@@ -686,7 +712,9 @@ heartbeat_scan_finds_actionable() {
 # a second watcher, so every guard/beacon/arm/turn-end mechanism is unchanged.
 event_wait_or_sleep() {
   local w b session first_backend="" first_session="" rec rc
+  local wait_budget
   local windows=()
+  wait_budget=$(cycle_wait)
   while IFS= read -r w; do
     b=$(window_backend "$w")
     fm_backend_has_push "$b" || continue
@@ -707,7 +735,7 @@ event_wait_or_sleep() {
   done < <(recorded_windows)
 
   if [ "${#windows[@]}" -eq 0 ]; then
-    sleep "$POLL"
+    sleep "$wait_budget"
     return
   fi
 
@@ -723,11 +751,11 @@ event_wait_or_sleep() {
     _event_cap_fails=0
   fi
   if [ "$_event_cap_ok" != 1 ]; then
-    sleep "$POLL"
+    sleep "$wait_budget"
     return
   fi
 
-  rec=$(FM_BACKEND_EVENTS_CAPABILITY_CONFIRMED=1 fm_backend_wait_transition "$first_backend" "$first_session" "$POLL" "$STATE" "${windows[@]}")
+  rec=$(FM_BACKEND_EVENTS_CAPABILITY_CONFIRMED=1 fm_backend_wait_transition "$first_backend" "$first_session" "$wait_budget" "$STATE" "${windows[@]}")
   rc=$?
   case "$rc" in
     0)
@@ -740,7 +768,7 @@ event_wait_or_sleep() {
       # pure polling for the rest of this watcher process.
       _event_cap_fails=$((_event_cap_fails + 1))
       [ "$_event_cap_fails" -ge "$EVENT_CAP_FAIL_MAX" ] && _event_cap_ok=0
-      sleep "$POLL"
+      sleep "$wait_budget"
       ;;
     *)
       # 1: a clean full-budget wait with no actionable edge - the reader already

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -908,7 +908,16 @@ run_check_capture() {
     fm_check_output_cleanup
     return 1
   fi
-  [ -z "$FM_CHECK_SIGNAL_PENDING" ] || exit 1
+  # A signal delivered between installing the pending-flag trap and swapping in
+  # the real one lands here instead of in a handler, so this exit owes the same
+  # guarantee the swapped-in trap gives: under --stop-active-check-on-signal the
+  # forked check's whole process group is stopped first, or it would outlive the
+  # caller with only its recorded child pid known to any later reaper.
+  if [ -n "$FM_CHECK_SIGNAL_PENDING" ]; then
+    [ "$stop_active_check" -eq 0 ] || fm_active_check_stop || true
+    fm_check_output_cleanup
+    exit 1
+  fi
   wait "$FM_ACTIVE_CHECK_PID" 2>/dev/null || true
   FM_ACTIVE_CHECK_PID=
   fm_active_check_stop || return 1

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -492,34 +492,115 @@ fast_repair_progress_forge_retired() {  # <task-id>
   [ -e "$(fast_repair_progress_green_marker "$1")" ]
 }
 
+fast_repair_progress_surfaced_marker() {  # <task-id>
+  printf '%s/.fast-repair-progress-%s' "$STATE" "$1"
+}
+
+fast_repair_progress_surfaced() {  # <task-id> <result>
+  [ "$(cat "$(fast_repair_progress_surfaced_marker "$1")" 2>/dev/null || true)" = "$2" ]
+}
+
+# The cadence exists to catch the transitions of an open Fast Repair PR, and its
+# last one is the broader family reaching a terminal result. A broader failure
+# permanently short-circuits the progress helper ahead of any forge read, so once
+# that failure is surfaced there is nothing left to report; a broader pass after
+# the forge poll already retired leaves the same nothing. In both cases the beat
+# retires and the ordinary lifecycle and PR polling own the task from then on.
+fast_repair_progress_followup_done() {  # <task-id>
+  local id=$1 record broader
+  record="$STATE/$id.fast-repair-broader"
+  [ -f "$record" ] && [ ! -L "$record" ] || return 1
+  broader=$(sed -n 's/^broader=//p' "$record" | head -n 1)
+  case "$broader" in
+    failed) fast_repair_progress_surfaced "$id" "fast-repair $id broader-tests-failed" ;;
+    passed) fast_repair_progress_forge_retired "$id" ;;
+    *) return 1 ;;
+  esac
+}
+
 # The single owner of which tasks the Fast Repair progress cadence works on:
-# durable metadata says eligible. Every consumer below - the activity flag, the
-# missing-schedule repair, the timer delay, and the tick itself - reads this one
-# emitter, so the rule and the id derivation have one place to change.
+# durable metadata says eligible and the cadence still has a transition left to
+# catch. Every consumer below - the activity flag, the missing-schedule repair,
+# the timer delay, and the tick itself - reads this one emitter, so the rule and
+# the id derivation have one place to change.
 fast_repair_progress_task_ids() {
-  local meta
+  local meta id
   for meta in "$STATE"/*.meta; do
     [ -e "$meta" ] || continue
     fast_repair_eligible_meta "$meta" || continue
-    basename "$meta" .meta
+    id=$(basename "$meta" .meta)
+    fast_repair_progress_followup_done "$id" && continue
+    printf '%s\n' "$id"
   done
   return 0
 }
 
-# A durable handoff already waiting to be drained. The wait entry points consult
-# this after publishing their interruptible pid, which closes the window between
-# forking a wait and making it reachable by fast_repair_progress_timer_notify.
+# A drain that cannot consume a handoff keeps the record durable for a later
+# retry, but the record must stop shortening waits once it has proven it cannot
+# be delivered - otherwise every later wait returns immediately and the whole
+# supervision loop spins. Attempts are counted per handoff so retry stays bounded
+# and the wake record itself is never discarded.
+FAST_REPAIR_HANDOFF_RETRY_MAX=${FM_FAST_REPAIR_HANDOFF_RETRY_MAX:-1}
+
+fast_repair_progress_handoff_attempts() {  # <handoff-file>
+  local n
+  n=$(cat "$1.attempts" 2>/dev/null || true)
+  case "$n" in ''|*[!0-9]*) n=0 ;; esac
+  printf '%s\n' "$n"
+}
+
+fast_repair_progress_handoff_attempt_record() {  # <handoff-file>
+  local file=$1 n tmp
+  n=$(( $(fast_repair_progress_handoff_attempts "$file") + 1 ))
+  tmp=$(mktemp "$STATE/.fast-repair-progress-attempt.XXXXXX") || return 1
+  if ! printf '%s\n' "$n" > "$tmp" || ! chmod 600 "$tmp" || ! mv -f "$tmp" "$file.attempts"; then
+    rm -f "$tmp"
+    return 1
+  fi
+}
+
+fast_repair_progress_handoff_forget() {  # <handoff-file>
+  rm -f "$1" "$1.attempts"
+}
+
+# A durable handoff that has not yet spent its delivery budget. The wait entry
+# points consult this after publishing their interruptible pid, which closes the
+# window between forking a wait and making it reachable by
+# fast_repair_progress_timer_notify.
 fast_repair_progress_handoff_pending() {
   local file
   for file in "$STATE"/.fast-repair-progress-handoff-*; do
     [ -f "$file" ] && [ ! -L "$file" ] || continue
+    case "$file" in *.attempts) continue ;; esac
+    [ "$(fast_repair_progress_handoff_attempts "$file")" -lt "$FAST_REPAIR_HANDOFF_RETRY_MAX" ] || continue
     return 0
   done
   return 1
 }
 
-fast_repair_progress_surfaced_marker() {  # <task-id>
-  printf '%s/.fast-repair-progress-%s' "$STATE" "$1"
+# Replaying an undeliverable result on every beat would otherwise leave one
+# handoff file per beat behind, since each cycle publishes under a fresh
+# generation. An identical undrained record for the same task carries no extra
+# information, so the replay supersedes it instead of stacking on it.
+fast_repair_progress_handoff_supersede() {  # <task-id> <result>
+  local id=$1 result=$2 file f_lifecycle f_id f_result
+  for file in "$STATE"/.fast-repair-progress-handoff-*; do
+    [ -f "$file" ] && [ ! -L "$file" ] || continue
+    case "$file" in *.attempts) continue ;; esac
+    exec 9< "$file" || continue
+    IFS= read -r f_lifecycle <&9 || { exec 9<&-; continue; }
+    # A record whose first line is the generation is the legacy three-line shape;
+    # anything else carries the lifecycle first and the generation on its own line.
+    if ! [[ "$f_lifecycle" =~ ^[0-9]+$ ]]; then
+      IFS= read -r _ <&9 || { exec 9<&-; continue; }
+    fi
+    IFS= read -r f_id <&9 || { exec 9<&-; continue; }
+    IFS= read -r f_result <&9 || { exec 9<&-; continue; }
+    exec 9<&-
+    [ "$f_id" = "$id" ] && [ "$f_result" = "$result" ] || continue
+    fast_repair_progress_handoff_forget "$file"
+  done
+  return 0
 }
 
 # A result byte-identical to the one already surfaced carries no transition, so
@@ -527,7 +608,7 @@ fast_repair_progress_surfaced_marker() {  # <task-id>
 # written only after the durable wake is queued, so a failed enqueue still leaves
 # the result unmarked and the next beat replays it.
 fast_repair_progress_result_is_new() {  # <task-id> <result>
-  [ "$(cat "$(fast_repair_progress_surfaced_marker "$1")" 2>/dev/null || true)" != "$2" ]
+  ! fast_repair_progress_surfaced "$1" "$2"
 }
 
 # Fast Repair has a short, task-scoped progress cadence for broader-test and PR
@@ -828,6 +909,7 @@ fast_repair_progress_timer_publish() {
   fm_pr_task_id_valid "$id" || return 1
   lifecycle=${FM_FAST_REPAIR_TASK_LIFECYCLE:-$(fast_repair_progress_lifecycle "$id")} || return 1
   case "$lifecycle" in ?*[!A-Za-z0-9._-]*|'') return 1 ;; esac
+  fast_repair_progress_handoff_supersede "$id" "$result"
   lock="$STATE/.fast-repair-progress-sequence-$id-$generation.lock"
   counter="$STATE/.fast-repair-progress-sequence-$id-$generation"
   fm_lock_acquire_wait "$lock" || return 1
@@ -1135,18 +1217,24 @@ fast_repair_progress_timer_wait_pid_clear() {
 }
 
 # Stop whatever interruptible wait is still live. Safe to call when none is
-# running, and idempotent. The group form is what reaches a backend event reader
-# forked inside the wait, and is used only once the recorded pid is proven to be
+# running, and idempotent. The recorded pid stays set for the window between
+# `wait` returning and the clear, so a signal arriving there would otherwise
+# reach an already-reaped pid; this applies the same rule
+# fast_repair_progress_timer_notify does - signal only a pid proven to be a
+# direct child of this watcher, and use the group form, which is what reaches a
+# backend event reader forked inside the wait, only once it is also proven to be
 # its own group leader.
 fast_repair_progress_wait_stop() {
-  local pid=${FAST_REPAIR_WAIT_PID:-} pgid
+  local pid=${FAST_REPAIR_WAIT_PID:-} parent=${WATCHER_PID:-} pgid
   [ -n "$pid" ] || return 0
+  FAST_REPAIR_WAIT_PID=
+  case "$parent" in *[!0-9]*|'') return 0 ;; esac
+  [ "$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')" = "$parent" ] || return 0
   pgid=$(ps -o pgid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
   if [ -n "$pgid" ] && [ "$pgid" = "$pid" ]; then
     kill -TERM -- "-$pid" 2>/dev/null || true
   fi
   kill -TERM "$pid" 2>/dev/null || true
-  FAST_REPAIR_WAIT_PID=
 }
 
 # Teardown form: stop the wait and drop the capture file the interrupted wait
@@ -1219,6 +1307,7 @@ fast_repair_progress_timer_wake() {
   local file lifecycle current_lifecycle generation id result status reasons=
   for file in "$STATE"/.fast-repair-progress-handoff-*; do
     [ -f "$file" ] && [ ! -L "$file" ] || continue
+    case "$file" in *.attempts) continue ;; esac
     exec 9< "$file" || continue
     IFS= read -r lifecycle <&9 || { exec 9<&-; continue; }
     if [[ "$lifecycle" =~ ^[0-9]+$ ]]; then
@@ -1238,19 +1327,19 @@ fast_repair_progress_timer_wake() {
     case "$result" in ''|*$'\n'*|*$'\r'*) continue ;; esac
     fm_pr_task_id_valid "$id" || continue
     if ! fast_repair_eligible_task "$id"; then
-      rm -f "$file" || continue
+      fast_repair_progress_handoff_forget "$file" || continue
       continue
     fi
     current_lifecycle=$(fast_repair_progress_lifecycle "$id" 2>/dev/null || true)
     if [ "$lifecycle" != "$current_lifecycle" ]; then
-      rm -f "$file" || continue
+      fast_repair_progress_handoff_forget "$file" || continue
       continue
     fi
     status=0
     fast_repair_progress_record "$id" "$result" "$generation" || status=$?
     case "$status" in
       0)
-        rm -f "$file" || continue
+        fast_repair_progress_handoff_forget "$file" || continue
         # The green rollup is the last transition this cadence exists to catch.
         # Retire the task from it only after its wake is durably queued, the same
         # order every other marker here follows.
@@ -1259,8 +1348,10 @@ fast_repair_progress_timer_wake() {
         esac
         reasons="$reasons $result"
         ;;
-      1|3) rm -f "$file" || continue ;;
-      *) continue ;;
+      1|3) fast_repair_progress_handoff_forget "$file" || continue ;;
+      # The wake queue refused the record. Keep it on disk so a later cycle can
+      # still deliver it, but count the attempt so it stops cutting waits short.
+      *) fast_repair_progress_handoff_attempt_record "$file" || true; continue ;;
     esac
   done
   [ -z "$reasons" ] || wake "check:${reasons}"

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -469,6 +469,7 @@ FAST_REPAIR_ACTIVE=0
 FAST_REPAIR_TIMER_PID=
 FAST_REPAIR_TIMER_MARKER=
 FAST_REPAIR_TIMER_GENERATION=0
+FAST_REPAIR_TIMER_WAIT_FILE=
 
 # The one place that decides whether durable task metadata opts a task into Fast
 # Repair. One tick collects the eligible ids with it once and reuses that list
@@ -763,10 +764,18 @@ fast_repair_progress_timer_publish() {
     return 1
   fi
   fm_lock_release "$lock"
+  fast_repair_progress_timer_notify
 }
 
 fast_repair_progress_timer_notify() {
-  return 0
+  local parent=${FM_FAST_REPAIR_TIMER_PARENT:-} wait_file=${FM_FAST_REPAIR_TIMER_WAIT_FILE:-} wait_pid wait_parent
+  case "$parent" in *[!0-9]*|'') return 0 ;; esac
+  [ -f "$wait_file" ] && [ ! -L "$wait_file" ] || return 0
+  wait_pid=$(cat "$wait_file" 2>/dev/null || true)
+  case "$wait_pid" in *[!0-9]*|'') return 0 ;; esac
+  wait_parent=$(ps -o ppid= -p "$wait_pid" 2>/dev/null | tr -d '[:space:]')
+  [ "$wait_parent" = "$parent" ] || return 0
+  kill -TERM "$wait_pid" 2>/dev/null || true
 }
 
 # Deliver a durably queued process-event result to firstmate. Publication is
@@ -940,7 +949,7 @@ heartbeat_scan_finds_actionable() {
 }
 
 fast_repair_progress_timer_start() {
-  local marker parent closing generation delay
+  local marker parent closing generation delay wait_file
   [ "$FAST_REPAIR_ACTIVE" = 1 ] || return 0
   case "$POLL:$FAST_REPAIR_PROGRESS_INTERVAL" in *[!0-9:]*|:*|*:) return 0 ;; esac
   fast_repair_progress_schedule_missing || return 0
@@ -948,7 +957,9 @@ fast_repair_progress_timer_start() {
   FAST_REPAIR_TIMER_GENERATION=$generation
   marker=$(mktemp "$STATE/.fast-repair-progress-timer.XXXXXX") || return 0
   closing="$marker.closing"
+  wait_file="$marker.wait-pid"
   FAST_REPAIR_TIMER_MARKER=$marker
+  FAST_REPAIR_TIMER_WAIT_FILE=$wait_file
   parent=$WATCHER_PID
   (
     trap 'rm -f "$closing"' EXIT
@@ -958,6 +969,7 @@ fast_repair_progress_timer_start() {
       FM_FAST_REPAIR_TIMER_PARENT="$parent" \
         FM_FAST_REPAIR_TIMER_CLOSING="$closing" \
         FM_FAST_REPAIR_TIMER_GENERATION="$generation" \
+        FM_FAST_REPAIR_TIMER_WAIT_FILE="$wait_file" \
         fast_repair_progress_tick
       [ "$FAST_REPAIR_ACTIVE" = 1 ] || rm -f "$marker"
       [ -f "$marker" ] || exit 0
@@ -972,7 +984,7 @@ fast_repair_progress_timer_start() {
 }
 
 fast_repair_progress_timer_finish() {
-  local marker=${FAST_REPAIR_TIMER_MARKER:-} pid=${FAST_REPAIR_TIMER_PID:-} generation=${FAST_REPAIR_TIMER_GENERATION:-} i=0
+  local marker=${FAST_REPAIR_TIMER_MARKER:-} pid=${FAST_REPAIR_TIMER_PID:-} generation=${FAST_REPAIR_TIMER_GENERATION:-} wait_file=${FAST_REPAIR_TIMER_WAIT_FILE:-} i=0
   [ -n "$marker" ] || return 0
   : > "$marker.closing" || return 0
   rm -f "$marker"
@@ -988,6 +1000,23 @@ fast_repair_progress_timer_finish() {
   fi
   [ -z "$pid" ] || wait "$pid" 2>/dev/null || true
   FAST_REPAIR_TIMER_PID=
+  rm -f "$wait_file"
+  FAST_REPAIR_TIMER_WAIT_FILE=
+}
+
+fast_repair_progress_timer_sleep() { # <seconds>
+  local seconds=$1 wait_file=${FAST_REPAIR_TIMER_WAIT_FILE:-} pid tmp
+  [ -n "$wait_file" ] || { sleep "$seconds"; return; }
+  sleep "$seconds" &
+  pid=$!
+  tmp=$(mktemp "$wait_file.XXXXXX") || { wait "$pid" || true; return; }
+  if ! printf '%s\n' "$pid" > "$tmp" || ! chmod 600 "$tmp" || ! mv -f "$tmp" "$wait_file"; then
+    rm -f "$tmp"
+    wait "$pid" || true
+    return
+  fi
+  wait "$pid" || true
+  rm -f "$wait_file"
 }
 
 fast_repair_progress_timer_wake() {
@@ -1067,7 +1096,7 @@ event_wait_or_sleep() {
   done < <(recorded_windows)
 
   if [ "${#windows[@]}" -eq 0 ]; then
-    sleep "$POLL"
+    fast_repair_progress_timer_sleep "$POLL"
     fast_repair_progress_timer_finish
     fast_repair_progress_timer_wake
     return

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -799,11 +799,21 @@ fast_repair_progress_timer_start() {
 }
 
 fast_repair_progress_timer_finish() {
-  local marker=${FAST_REPAIR_TIMER_MARKER:-}
+  local marker=${FAST_REPAIR_TIMER_MARKER:-} pid=${FAST_REPAIR_TIMER_PID:-} i=0
   [ -n "$marker" ] || return 0
   : > "$marker.closing" || return 0
   rm -f "$marker"
   FAST_REPAIR_TIMER_MARKER=
+  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    kill -TERM "$pid" 2>/dev/null || true
+    while kill -0 "$pid" 2>/dev/null && [ "$i" -lt 20 ]; do
+      sleep 0.01
+      i=$((i + 1))
+    done
+    kill -KILL "$pid" 2>/dev/null || true
+  fi
+  [ -z "$pid" ] || wait "$pid" 2>/dev/null || true
+  FAST_REPAIR_TIMER_PID=
 }
 
 fast_repair_progress_timer_wake() {
@@ -990,7 +1000,6 @@ watcher_cleanup() {
 }
 trap watcher_cleanup EXIT
 trap 'exit 1' HUP INT TERM
-trap '' USR1
 # This watcher's own pid, as recorded in the lock by fm_lock_claim (which writes
 # ${BASHPID:-$$} from this same main shell). Read directly, never via a command
 # substitution, so it matches the stored holder pid for the self-eviction check.

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -818,7 +818,7 @@ fast_repair_progress_task_start() { # <task-id> <generation>
     return 1
   fi
   if [ -e "$reservation.closing" ] || { [ -n "$closing" ] && [ -e "$closing" ]; }; then
-    rm -f "$reservation"
+    rm -f "$reservation" "$reservation.closing"
     return 0
   fi
   touch "$STATE/.last-fast-repair-progress-$id"

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -470,7 +470,10 @@ scan_signals() {
 # mode=fast-repair and fast_repair=eligible. It does not change the normal signal,
 # stale, custom-check, heartbeat, or sleep cadence, and it never starts another
 # watcher. Each actionable result is deduplicated per task so an unchanged failed
-# PR check cannot wake firstmate every twenty seconds.
+# PR check cannot wake firstmate every twenty seconds. That dedup marker is
+# advanced only after the durable wake is queued, the same discipline .seen-*
+# follows above, so a watcher that dies mid-cycle re-announces the transition
+# instead of swallowing it.
 # The progress helper reads the PR's checks from the forge, so it is a network
 # call and runs through run_check_capture exactly like every other per-task
 # check: bounded by CHECK_TIMEOUT in its own process group, so a hung or slow
@@ -492,19 +495,16 @@ fast_repair_progress_tick() {
     grep -qx 'mode=fast-repair' "$meta" 2>/dev/null || continue
     grep -qx 'fast_repair=eligible' "$meta" 2>/dev/null || continue
     id=$(basename "$meta" .meta)
-    if FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
-      run_check_capture "$SCRIPT_DIR/fm-fast-repair.sh" progress "$id"; then
-      result=$FM_CHECK_RESULT
-    else
-      result=
-    fi
+    FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
+      run_check_capture "$SCRIPT_DIR/fm-fast-repair.sh" progress "$id" || exit 1
+    result=$FM_CHECK_RESULT
     [ -n "$result" ] || continue
     marker="$STATE/.fast-repair-progress-$id"
     prior=$(cat "$marker" 2>/dev/null || true)
     [ "$prior" = "$result" ] && continue
+    fm_wake_append check "fast-repair:$id" "check: $result" || exit 1
     printf '%s' "$result" > "$marker"
     touch "$STATE/.last-fast-repair-progress"
-    fm_wake_append check "fast-repair:$id" "check: $result" || exit 1
     wake "check: $result"
   done
   touch "$STATE/.last-fast-repair-progress"

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -467,9 +467,6 @@ scan_signals() {
 
 FAST_REPAIR_ACTIVE=0
 FAST_REPAIR_TIMER_PID=
-FAST_REPAIR_WAIT_PID=
-FAST_REPAIR_WAIT_OUTPUT=
-FAST_REPAIR_EVENT_REC=
 
 # The one place that decides whether durable task metadata opts a task into Fast
 # Repair. One tick collects the eligible ids with it once and reuses that list
@@ -710,64 +707,13 @@ fast_repair_progress_timer_start() {
   FAST_REPAIR_TIMER_PID=$!
 }
 
-fast_repair_wait_sleep() {
-  local rc
-  if [ "$FAST_REPAIR_ACTIVE" != 1 ]; then
-    sleep "$POLL"
-    return
-  fi
-  sleep "$POLL" &
-  FAST_REPAIR_WAIT_PID=$!
-  while kill -0 "$FAST_REPAIR_WAIT_PID" 2>/dev/null; do
-    fast_repair_progress_timer_wake
-    sleep 0.1
-  done
-  wait "$FAST_REPAIR_WAIT_PID"
-  rc=$?
-  FAST_REPAIR_WAIT_PID=
-  return "$rc"
-}
-
-fast_repair_wait_stop() {
-  [ -n "${FAST_REPAIR_WAIT_PID:-}" ] || return 0
-  kill "$FAST_REPAIR_WAIT_PID" 2>/dev/null || true
-  wait "$FAST_REPAIR_WAIT_PID" 2>/dev/null || true
-  FAST_REPAIR_WAIT_PID=
-  rm -f "${FAST_REPAIR_WAIT_OUTPUT:-}" 2>/dev/null || true
-  FAST_REPAIR_WAIT_OUTPUT=
-}
-
 fast_repair_progress_timer_wake() {
   local result
   [ -f "$STATE/.fast-repair-progress-wake" ] || return 0
   result=$(cat "$STATE/.fast-repair-progress-wake" 2>/dev/null || true)
   rm -f "$STATE/.fast-repair-progress-wake"
   [ -n "$result" ] || return 0
-  fast_repair_wait_stop
   wake "check: $result"
-}
-
-fast_repair_wait_transition() {
-  local backend=$1 session=$2 rc
-  FAST_REPAIR_EVENT_REC=
-  if [ "$FAST_REPAIR_ACTIVE" != 1 ]; then
-    FAST_REPAIR_EVENT_REC=$(FM_BACKEND_EVENTS_CAPABILITY_CONFIRMED=1 fm_backend_wait_transition "$backend" "$session" "$POLL" "$STATE" "${windows[@]}")
-    return $?
-  fi
-  FAST_REPAIR_WAIT_OUTPUT=$(mktemp "$STATE/.fm-fast-repair-event.XXXXXX") || return 1
-  FM_BACKEND_EVENTS_CAPABILITY_CONFIRMED=1 fm_backend_wait_transition "$backend" "$session" "$POLL" "$STATE" "${windows[@]}" > "$FAST_REPAIR_WAIT_OUTPUT" &
-  FAST_REPAIR_WAIT_PID=$!
-  while kill -0 "$FAST_REPAIR_WAIT_PID" 2>/dev/null; do
-    fast_repair_progress_timer_wake
-    sleep 0.1
-  done
-  wait "$FAST_REPAIR_WAIT_PID"
-  rc=$?
-  FAST_REPAIR_WAIT_PID=
-  FAST_REPAIR_EVENT_REC=$(cat "$FAST_REPAIR_WAIT_OUTPUT" 2>/dev/null || true)
-  rm -f "$FAST_REPAIR_WAIT_OUTPUT"
-  FAST_REPAIR_WAIT_OUTPUT=
-  return "$rc"
 }
 
 # event_wait_or_sleep: the terminal wait of each supervision cycle. For a home
@@ -805,7 +751,8 @@ event_wait_or_sleep() {
   done < <(recorded_windows)
 
   if [ "${#windows[@]}" -eq 0 ]; then
-    fast_repair_wait_sleep
+    sleep "$POLL"
+    fast_repair_progress_timer_wake
     return
   fi
 
@@ -821,13 +768,13 @@ event_wait_or_sleep() {
     _event_cap_fails=0
   fi
   if [ "$_event_cap_ok" != 1 ]; then
-    fast_repair_wait_sleep
+    sleep "$POLL"
+    fast_repair_progress_timer_wake
     return
   fi
 
-  fast_repair_wait_transition "$first_backend" "$first_session"
+  rec=$(FM_BACKEND_EVENTS_CAPABILITY_CONFIRMED=1 fm_backend_wait_transition "$first_backend" "$first_session" "$POLL" "$STATE" "${windows[@]}")
   rc=$?
-  rec=$FAST_REPAIR_EVENT_REC
   case "$rc" in
     0)
       _event_cap_fails=0
@@ -839,7 +786,7 @@ event_wait_or_sleep() {
       # pure polling for the rest of this watcher process.
       _event_cap_fails=$((_event_cap_fails + 1))
       [ "$_event_cap_fails" -ge "$EVENT_CAP_FAIL_MAX" ] && _event_cap_ok=0
-      fast_repair_wait_sleep
+      sleep "$POLL"
       ;;
     *)
       # 1: a clean full-budget wait with no actionable edge - the reader already
@@ -847,6 +794,7 @@ event_wait_or_sleep() {
       _event_cap_fails=0
       ;;
   esac
+  fast_repair_progress_timer_wake
 }
 
 # --- Main entry: the runtime below runs only when this file is executed as a
@@ -905,7 +853,6 @@ watcher_cleanup() {
       transition=release-lock-existing
     fi
   fi
-  fast_repair_wait_stop
   fm_active_check_stop || cleanup_status=1
   fm_check_output_cleanup
   fm_custom_check_snapshot_cleanup

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -551,8 +551,13 @@ fast_repair_progress_task_marker() { # <task-id> <generation>
 }
 
 fast_repair_progress_timer_tasks_finish() { # <generation>
-  local generation=$1 marker ready pid i=0 live
+  local generation=$1 marker ready reservation pid i=0 live
   local markers=() pids=()
+  for reservation in "$STATE"/.fast-repair-progress-child-*"-$generation".starting; do
+    [ -f "$reservation" ] && [ ! -L "$reservation" ] || continue
+    : > "$reservation.closing" || continue
+    rm -f "$reservation"
+  done
   for marker in "$STATE"/.fast-repair-progress-child-*"-$generation"; do
     [ -f "$marker" ] && [ ! -L "$marker" ] || continue
     ready="$marker.ready"
@@ -582,17 +587,29 @@ fast_repair_progress_timer_tasks_finish() { # <generation>
 }
 
 fast_repair_progress_task_start() { # <task-id> <generation>
-  local id=$1 generation=$2 marker ready result closing=${FM_FAST_REPAIR_TIMER_CLOSING:-} pid tmp
+  local id=$1 generation=$2 marker ready reservation result closing=${FM_FAST_REPAIR_TIMER_CLOSING:-} pid tmp
+  [ -z "$closing" ] || [ ! -e "$closing" ] || return 0
   marker=$(fast_repair_progress_task_marker "$id" "$generation") || return 1
   ready="$marker.ready"
+  reservation="$marker.starting"
   if [ -f "$marker" ] && [ ! -L "$marker" ]; then
     return 0
   fi
+  [ ! -e "$reservation" ] || return 0
+  tmp=$(mktemp "$reservation.XXXXXX") || return 1
+  if ! chmod 600 "$tmp" || ! mv -f "$tmp" "$reservation"; then
+    rm -f "$tmp"
+    return 1
+  fi
   touch "$STATE/.last-fast-repair-progress-$id"
   (
-    trap 'rm -f "$marker" "$ready"' EXIT
+    trap 'rm -f "$marker" "$ready" "$reservation" "$reservation.closing"' EXIT
     trap 'fm_active_check_stop || true; exit 0' HUP INT TERM
-    while [ ! -f "$ready" ]; do sleep 0.01; done
+    while [ ! -f "$ready" ]; do
+      [ ! -e "$reservation.closing" ] || exit 0
+      sleep 0.01
+    done
+    [ ! -e "$reservation.closing" ] || exit 0
     [ -z "$closing" ] || [ ! -e "$closing" ] || exit 0
     FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
       run_check_capture --stop-active-check-on-signal "$SCRIPT_DIR/fm-fast-repair.sh" progress "$id" || exit 1
@@ -600,12 +617,24 @@ fast_repair_progress_task_start() { # <task-id> <generation>
     [ -z "$result" ] || fast_repair_progress_timer_publish "$id" "$result"
   ) &
   pid=$!
+  if [ -e "$reservation.closing" ]; then
+    kill -TERM "$pid" 2>/dev/null || true
+    rm -f "$reservation"
+    return 0
+  fi
   tmp=$(mktemp "$marker.XXXXXX") || { kill -TERM "$pid" 2>/dev/null || true; return 1; }
+  if [ -e "$reservation.closing" ] || { [ -n "$closing" ] && [ -e "$closing" ]; }; then
+    rm -f "$tmp" "$reservation"
+    kill -TERM "$pid" 2>/dev/null || true
+    return 0
+  fi
   if ! printf '%s\n' "$pid" > "$tmp" || ! chmod 600 "$tmp" || ! mv -f "$tmp" "$marker"; then
     rm -f "$tmp"
     kill -TERM "$pid" 2>/dev/null || true
+    rm -f "$reservation" "$reservation.closing"
     return 1
   fi
+  rm -f "$reservation"
   touch "$ready"
 }
 

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -544,11 +544,58 @@ fast_repair_progress_record() {
   fm_wake_append check "fast-repair:$id" "check: $result" || return 2
   printf '%s' "$result" > "$marker"
   [ -z "$generation" ] || printf '%s' "$generation" > "$generation_marker"
-  touch "$STATE/.last-fast-repair-progress"
+}
+
+fast_repair_progress_task_marker() { # <task-id> <generation>
+  printf '%s/.fast-repair-progress-child-%s-%s' "$STATE" "$1" "$2"
+}
+
+fast_repair_progress_task_stop() { # <marker>
+  local marker=$1 pid i=0
+  [ -f "$marker" ] && [ ! -L "$marker" ] || return 0
+  pid=$(cat "$marker" 2>/dev/null || true)
+  case "$pid" in ''|*[!0-9]*) rm -f "$marker"; return 0 ;; esac
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -TERM "$pid" 2>/dev/null || true
+    while kill -0 "$pid" 2>/dev/null && [ "$i" -lt 20 ]; do
+      sleep 0.01
+      i=$((i + 1))
+    done
+    kill -KILL "$pid" 2>/dev/null || true
+  fi
+  rm -f "$marker"
+}
+
+fast_repair_progress_timer_tasks_finish() { # <generation>
+  local generation=$1 marker
+  for marker in "$STATE"/.fast-repair-progress-child-*"-$generation"; do
+    [ -e "$marker" ] || continue
+    fast_repair_progress_task_stop "$marker"
+  done
+}
+
+fast_repair_progress_task_start() { # <task-id> <generation>
+  local id=$1 generation=$2 marker result closing=${FM_FAST_REPAIR_TIMER_CLOSING:-}
+  marker=$(fast_repair_progress_task_marker "$id" "$generation") || return 1
+  if [ -f "$marker" ] && [ ! -L "$marker" ]; then
+    return 0
+  fi
+  touch "$STATE/.last-fast-repair-progress-$id"
+  (
+    [ -z "$closing" ] || [ ! -e "$closing" ] || exit 0
+    printf '%s\n' "${BASHPID:-$$}" > "$marker" || exit 1
+    trap 'rm -f "$marker"' EXIT
+    trap 'fm_active_check_stop || true; exit 0' HUP INT TERM
+    [ -z "$closing" ] || [ ! -e "$closing" ] || exit 0
+    FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
+      run_check_capture "$SCRIPT_DIR/fm-fast-repair.sh" progress "$id" || exit 1
+    result=$FM_CHECK_RESULT
+    [ -z "$result" ] || fast_repair_progress_timer_publish "$id" "$result"
+  ) &
 }
 
 fast_repair_progress_tick() {
-  local meta id result progress_stamp timer_published=0
+  local meta id progress_stamp generation
   local ids=()
   for meta in "$STATE"/*.meta; do
     [ -e "$meta" ] || continue
@@ -560,26 +607,13 @@ fast_repair_progress_tick() {
     return 0
   fi
   FAST_REPAIR_ACTIVE=1
-  progress_stamp="$STATE/.last-fast-repair-progress"
-  [ "$(age_of "$progress_stamp")" -ge "$FAST_REPAIR_PROGRESS_INTERVAL" ] || return 0
-  touch "$progress_stamp"
+  generation=${FM_FAST_REPAIR_TIMER_GENERATION:-}
+  case "$generation" in *[!0-9]*|'') return 1 ;; esac
   for id in "${ids[@]}"; do
-    FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
-      run_check_capture "$SCRIPT_DIR/fm-fast-repair.sh" progress "$id" || exit 1
-    result=$FM_CHECK_RESULT
-    [ -n "$result" ] || continue
-    if [ -n "${FM_FAST_REPAIR_TIMER_PARENT:-}" ]; then
-      if fast_repair_progress_timer_publish "$id" "$result"; then
-        timer_published=1
-      fi
-      continue
-    fi
-    fast_repair_progress_record "$id" "$result" || continue
-    wake "check: $result"
+    progress_stamp="$STATE/.last-fast-repair-progress-$id"
+    [ "$(age_of "$progress_stamp")" -ge "$FAST_REPAIR_PROGRESS_INTERVAL" ] || continue
+    fast_repair_progress_task_start "$id" "$generation"
   done
-  if [ "$timer_published" = 1 ]; then
-    FAST_REPAIR_TIMER_RESULT_PUBLISHED=1
-  fi
 }
 
 fast_repair_progress_timer_publish() {
@@ -768,7 +802,7 @@ heartbeat_scan_finds_actionable() {
 }
 
 fast_repair_progress_timer_start() {
-  local marker remaining parent closing generation
+  local marker parent closing generation
   [ "$FAST_REPAIR_ACTIVE" = 1 ] || return 0
   case "$POLL:$FAST_REPAIR_PROGRESS_INTERVAL" in *[!0-9:]*|:*|*:) return 0 ;; esac
   generation=$(fast_repair_progress_generation_next) || return 0
@@ -781,17 +815,13 @@ fast_repair_progress_timer_start() {
     trap 'rm -f "$closing"' EXIT
     trap 'fm_active_check_stop || true; exit 0' HUP INT TERM
     while [ -f "$marker" ]; do
-      remaining=$(( FAST_REPAIR_PROGRESS_INTERVAL - $(age_of "$STATE/.last-fast-repair-progress") ))
-      [ "$remaining" -ge 1 ] || remaining=1
-      sleep $((remaining + 1))
+      sleep "$FAST_REPAIR_PROGRESS_INTERVAL"
       [ -f "$marker" ] || exit 0
       [ "$(cat "$WATCH_LOCK/pid" 2>/dev/null || true)" = "$parent" ] || exit 0
-      FAST_REPAIR_TIMER_RESULT_PUBLISHED=0
       FM_FAST_REPAIR_TIMER_PARENT="$parent" \
         FM_FAST_REPAIR_TIMER_CLOSING="$closing" \
         FM_FAST_REPAIR_TIMER_GENERATION="$generation" \
         fast_repair_progress_tick
-      [ "$FAST_REPAIR_TIMER_RESULT_PUBLISHED" = 1 ] && exit 0
       [ "$FAST_REPAIR_ACTIVE" = 1 ] || rm -f "$marker"
     done
   ) &
@@ -799,11 +829,12 @@ fast_repair_progress_timer_start() {
 }
 
 fast_repair_progress_timer_finish() {
-  local marker=${FAST_REPAIR_TIMER_MARKER:-} pid=${FAST_REPAIR_TIMER_PID:-} i=0
+  local marker=${FAST_REPAIR_TIMER_MARKER:-} pid=${FAST_REPAIR_TIMER_PID:-} generation=${FAST_REPAIR_TIMER_GENERATION:-} i=0
   [ -n "$marker" ] || return 0
   : > "$marker.closing" || return 0
   rm -f "$marker"
   FAST_REPAIR_TIMER_MARKER=
+  case "$generation" in *[!0-9]*|'') ;; *) fast_repair_progress_timer_tasks_finish "$generation" ;; esac
   if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
     kill -TERM "$pid" 2>/dev/null || true
     while kill -0 "$pid" 2>/dev/null && [ "$i" -lt 20 ]; do

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -51,6 +51,13 @@
 #   check: rejected unauthenticated PR poll retirement receipts: <paths>
 #                          invalid pending retirements were preserved without
 #                          running a check or removing poll artifacts
+#   check: fast-repair <id> <state>
+#                          the Fast-Repair-only progress cadence found a CHANGED
+#                          actionable state for a task whose meta records an
+#                          eligible fast-repair delivery: broader tests failed,
+#                          or its PR checks failed or turned green. A result
+#                          identical to the one already surfaced is never
+#                          re-surfaced (docs/fast-repair.md)
 #   heartbeat              fleet-scan backstop found an unsurfaced captain-relevant
 #                          status, unless afk is active
 # For normal supervision, resume the session-start primary-harness protocol

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -564,7 +564,7 @@ fast_repair_progress_timer_tasks_finish() { # <generation>
     pids+=("$pid")
     kill -TERM "$pid" 2>/dev/null || true
   done
-  while [ "$i" -lt 20 ]; do
+  while [ "$i" -lt 40 ]; do
     live=0
     for pid in "${pids[@]}"; do
       kill -0 "$pid" 2>/dev/null && { live=1; break; }
@@ -595,7 +595,7 @@ fast_repair_progress_task_start() { # <task-id> <generation>
     while [ ! -f "$ready" ]; do sleep 0.01; done
     [ -z "$closing" ] || [ ! -e "$closing" ] || exit 0
     FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
-      run_check_capture "$SCRIPT_DIR/fm-fast-repair.sh" progress "$id" || exit 1
+      run_check_capture --stop-active-check-on-signal "$SCRIPT_DIR/fm-fast-repair.sh" progress "$id" || exit 1
     result=$FM_CHECK_RESULT
     [ -z "$result" ] || fast_repair_progress_timer_publish "$id" "$result"
   ) &
@@ -757,7 +757,10 @@ fm_active_check_stop() {
 }
 
 run_check_capture() {
-  local pgid
+  local pgid stop_active_check=0
+  case "${1:-}" in
+    --stop-active-check-on-signal) stop_active_check=1; shift ;;
+  esac
   fm_check_output_cleanup
   FM_CHECK_RESULT=
   FM_CHECK_OUTPUT=$(mktemp "$STATE/.fm-check-output.XXXXXX") || return 1
@@ -770,7 +773,11 @@ run_check_capture() {
   FM_ACTIVE_CHECK_PGID=$FM_ACTIVE_CHECK_PID
   set +m
   pgid=$(ps -o pgid= -p "$FM_ACTIVE_CHECK_PID" 2>/dev/null | tr -d '[:space:]')
-  trap 'fm_active_check_stop || true; exit 1' HUP INT TERM
+  if [ "$stop_active_check" -eq 1 ]; then
+    trap 'fm_active_check_stop || true; exit 1' HUP INT TERM
+  else
+    trap 'exit 1' HUP INT TERM
+  fi
   if [ -n "$pgid" ] && [ "$pgid" != "$FM_ACTIVE_CHECK_PGID" ]; then
     fm_active_check_stop || true
     fm_check_output_cleanup
@@ -852,7 +859,7 @@ fast_repair_progress_timer_finish() {
   case "$generation" in *[!0-9]*|'') ;; *) fast_repair_progress_timer_tasks_finish "$generation" ;; esac
   if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
     kill -TERM "$pid" 2>/dev/null || true
-    while kill -0 "$pid" 2>/dev/null && [ "$i" -lt 20 ]; do
+    while kill -0 "$pid" 2>/dev/null && [ "$i" -lt 40 ]; do
       sleep 0.01
       i=$((i + 1))
     done

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -471,6 +471,11 @@ scan_signals() {
 # stale, custom-check, heartbeat, or sleep cadence, and it never starts another
 # watcher. Each actionable result is deduplicated per task so an unchanged failed
 # PR check cannot wake firstmate every twenty seconds.
+# The progress helper reads the PR's checks from the forge, so it is a network
+# call and runs through run_check_capture exactly like every other per-task
+# check: bounded by CHECK_TIMEOUT in its own process group, so a hung or slow
+# forge call can neither stall the beat, the signal scan, and the stale and
+# wedge detection of other crewmates, nor hold off a stop signal.
 fast_repair_progress_tick() {
   local meta id result marker prior active=0
   for meta in "$STATE"/*.meta; do
@@ -487,8 +492,12 @@ fast_repair_progress_tick() {
     grep -qx 'mode=fast-repair' "$meta" 2>/dev/null || continue
     grep -qx 'fast_repair=eligible' "$meta" 2>/dev/null || continue
     id=$(basename "$meta" .meta)
-    result=$(FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
-      "$SCRIPT_DIR/fm-fast-repair.sh" progress "$id" 2>/dev/null || true)
+    if FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
+      run_check_capture "$SCRIPT_DIR/fm-fast-repair.sh" progress "$id"; then
+      result=$FM_CHECK_RESULT
+    else
+      result=
+    fi
     [ -n "$result" ] || continue
     marker="$STATE/.fast-repair-progress-$id"
     prior=$(cat "$marker" 2>/dev/null || true)

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -472,11 +472,35 @@ FAST_REPAIR_TIMER_GENERATION=0
 FAST_REPAIR_TIMER_WAIT_FILE=
 
 # The one place that decides whether durable task metadata opts a task into Fast
-# Repair. One tick collects the eligible ids with it once and reuses that list
-# for both the activity flag and the work.
+# Repair.
 fast_repair_eligible_meta() {  # <meta-path>
   grep -qx 'mode=fast-repair' "$1" 2>/dev/null || return 1
   grep -qx 'fast_repair=eligible' "$1" 2>/dev/null
+}
+
+# The short cadence exists to surface the first actionable transition of an open
+# Fast Repair PR. Once a green rollup has been queued for firstmate there is
+# nothing left for it to catch, so the task is retired from the twenty-second
+# forge poll and the ordinary CHECK_INTERVAL PR poll owns it from then on.
+fast_repair_progress_green_marker() {  # <task-id>
+  printf '%s/.fast-repair-progress-green-%s' "$STATE" "$1"
+}
+
+# The single owner of which tasks the Fast Repair progress cadence still works
+# on: durable metadata says eligible, and no green rollup has been surfaced yet.
+# Every consumer below - the activity flag, the missing-schedule repair, the
+# timer delay, and the tick itself - reads this one emitter, so the rule and the
+# id derivation have one place to change.
+fast_repair_progress_task_ids() {
+  local meta id
+  for meta in "$STATE"/*.meta; do
+    [ -e "$meta" ] || continue
+    fast_repair_eligible_meta "$meta" || continue
+    id=$(basename "$meta" .meta)
+    [ -e "$(fast_repair_progress_green_marker "$id")" ] && continue
+    printf '%s\n' "$id"
+  done
+  return 0
 }
 
 # Fast Repair has a short, task-scoped progress cadence for broader-test and PR
@@ -494,14 +518,14 @@ fast_repair_eligible_meta() {  # <meta-path>
 # forge call can neither stall the beat, the signal scan, and the stale and
 # wedge detection of other crewmates, nor hold off a stop signal.
 fast_repair_progress_discover() {
-  local meta
+  local id
   FAST_REPAIR_ACTIVE=0
-  for meta in "$STATE"/*.meta; do
-    [ -e "$meta" ] || continue
-    fast_repair_eligible_meta "$meta" || continue
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
     FAST_REPAIR_ACTIVE=1
-    return 0
-  done
+    break
+  done < <(fast_repair_progress_task_ids)
+  return 0
 }
 
 fast_repair_progress_generation_next() {
@@ -568,30 +592,35 @@ fast_repair_progress_due_in() {
 }
 
 fast_repair_progress_schedule_missing() {
-  local meta id path now due
+  local id path now due
   now=$(date +%s) || return 1
-  for meta in "$STATE"/*.meta; do
-    [ -e "$meta" ] || continue
-    fast_repair_eligible_meta "$meta" || continue
-    id=$(basename "$meta" .meta)
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
     path=$(fast_repair_progress_due_path "$id") || continue
     due=$(cat "$path" 2>/dev/null || true)
     case "$due" in *[!0-9]*|'') fast_repair_progress_due_set "$id" "$((now + FAST_REPAIR_PROGRESS_INTERVAL))" || continue ;; esac
-  done
+  done < <(fast_repair_progress_task_ids)
+  return 0
 }
 
-fast_repair_progress_timer_delay() {
-  local meta id delay shortest=
-  for meta in "$STATE"/*.meta; do
-    [ -e "$meta" ] || continue
-    fast_repair_eligible_meta "$meta" || continue
-    id=$(basename "$meta" .meta)
+# A task whose progress child is still running has no schedule to wait on: its
+# next due time is written by that child when the check completes. Counting its
+# stale zero delay here would spin the timer loop once a second for the whole
+# life of a slow forge call, so it is skipped and the interval is used instead;
+# the child's own due write is what the next iteration reads.
+fast_repair_progress_timer_delay() {  # [<generation>]
+  local generation=${1:-} id delay shortest=
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    if [ -n "$generation" ] && fast_repair_progress_task_running "$id" "$generation"; then
+      continue
+    fi
     delay=$(fast_repair_progress_due_in "$id") || continue
     case "$delay" in *[!0-9]*|'') continue ;; esac
     if [ -z "$shortest" ] || [ "$delay" -lt "$shortest" ]; then
       shortest=$delay
     fi
-  done
+  done < <(fast_repair_progress_task_ids)
   printf '%s\n' "${shortest:-$FAST_REPAIR_PROGRESS_INTERVAL}"
 }
 
@@ -617,6 +646,13 @@ fast_repair_progress_record() {
 
 fast_repair_progress_task_marker() { # <task-id> <generation>
   printf '%s/.fast-repair-progress-child-%s-%s' "$STATE" "$1" "$2"
+}
+
+fast_repair_progress_task_running() { # <task-id> <generation>
+  local marker
+  marker=$(fast_repair_progress_task_marker "$1" "$2") || return 1
+  [ ! -e "$marker.starting" ] || return 0
+  [ -f "$marker" ] && [ ! -L "$marker" ]
 }
 
 fast_repair_progress_timer_tasks_finish() { # <generation>
@@ -656,7 +692,7 @@ fast_repair_progress_timer_tasks_finish() { # <generation>
 }
 
 fast_repair_progress_task_start() { # <task-id> <generation>
-  local id=$1 generation=$2 marker ready reservation result closing=${FM_FAST_REPAIR_TIMER_CLOSING:-} lifecycle pid tmp
+  local id=$1 generation=$2 marker ready reservation result now closing=${FM_FAST_REPAIR_TIMER_CLOSING:-} lifecycle pid tmp
   [ -z "$closing" ] || [ ! -e "$closing" ] || return 0
   marker=$(fast_repair_progress_task_marker "$id" "$generation") || return 1
   lifecycle=$(fast_repair_progress_lifecycle "$id") || return 1
@@ -685,9 +721,13 @@ fast_repair_progress_task_start() { # <task-id> <generation>
     done
     [ ! -e "$reservation.closing" ] || exit 0
     [ -z "$closing" ] || [ ! -e "$closing" ] || exit 0
-    FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
-      run_check_capture --stop-active-check-on-signal "$SCRIPT_DIR/fm-fast-repair.sh" progress "$id" || exit 1
-    result=$FM_CHECK_RESULT
+    if FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
+      run_check_capture --stop-active-check-on-signal "$SCRIPT_DIR/fm-fast-repair.sh" progress "$id"; then
+      result=$FM_CHECK_RESULT
+    else
+      result=
+    fi
+    now=$(date +%s) && fast_repair_progress_due_set "$id" "$((now + FAST_REPAIR_PROGRESS_INTERVAL))"
     [ -z "$result" ] || FM_FAST_REPAIR_TASK_LIFECYCLE="$lifecycle" fast_repair_progress_timer_publish "$id" "$result"
   ) &
   pid=$!
@@ -712,14 +752,20 @@ fast_repair_progress_task_start() { # <task-id> <generation>
   touch "$ready"
 }
 
+# One tick collects the eligible ids once and reuses that list for both the
+# activity flag and the work. The next due time is deliberately NOT advanced
+# here: the child that actually reaches the forge advances it once its check
+# completes. A child reaped at a poll boundary therefore leaves the due time
+# behind it, so the beat is retried on the next tick instead of being silently
+# skipped for a whole interval, and against a persistently slow forge the
+# cadence keeps trying rather than starving.
 fast_repair_progress_tick() {
-  local meta id due generation now
+  local id due generation
   local ids=()
-  for meta in "$STATE"/*.meta; do
-    [ -e "$meta" ] || continue
-    fast_repair_eligible_meta "$meta" || continue
-    ids+=("$(basename "$meta" .meta)")
-  done
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    ids+=("$id")
+  done < <(fast_repair_progress_task_ids)
   if [ "${#ids[@]}" -eq 0 ]; then
     FAST_REPAIR_ACTIVE=0
     return 0
@@ -730,11 +776,11 @@ fast_repair_progress_tick() {
   for id in "${ids[@]}"; do
     due=$(fast_repair_progress_due_in "$id") || continue
     [ "$due" -eq 0 ] || continue
-    now=$(date +%s) || continue
-    fast_repair_progress_due_set "$id" "$((now + FAST_REPAIR_PROGRESS_INTERVAL))" || continue
+    fast_repair_progress_task_running "$id" "$generation" && continue
     touch "$STATE/.last-fast-repair-progress-$id"
     fast_repair_progress_task_start "$id" "$generation"
   done
+  return 0
 }
 
 fast_repair_progress_timer_publish() {
@@ -767,14 +813,26 @@ fast_repair_progress_timer_publish() {
   fast_repair_progress_timer_notify
 }
 
+# Every interruptible wait is published as its own process-group leader, so the
+# whole wait - including a backend event reader forked inside it - can be stopped
+# here rather than only the shell that owns it. A recorded pid is signalled only
+# once it is proven to be BOTH a direct child of this watcher AND its own process
+# group leader: the group form is what reaches the reader, and without that proof
+# a pid that has already exited and been reused would aim it at an unrelated
+# group. Failing the group proof still stops the pid itself, which is all the
+# plain sleep path ever needed.
 fast_repair_progress_timer_notify() {
-  local parent=${FM_FAST_REPAIR_TIMER_PARENT:-} wait_file=${FM_FAST_REPAIR_TIMER_WAIT_FILE:-} wait_pid wait_parent
+  local parent=${FM_FAST_REPAIR_TIMER_PARENT:-} wait_file=${FM_FAST_REPAIR_TIMER_WAIT_FILE:-} wait_pid wait_parent wait_pgid
   case "$parent" in *[!0-9]*|'') return 0 ;; esac
   [ -f "$wait_file" ] && [ ! -L "$wait_file" ] || return 0
   wait_pid=$(cat "$wait_file" 2>/dev/null || true)
   case "$wait_pid" in *[!0-9]*|'') return 0 ;; esac
   wait_parent=$(ps -o ppid= -p "$wait_pid" 2>/dev/null | tr -d '[:space:]')
   [ "$wait_parent" = "$parent" ] || return 0
+  wait_pgid=$(ps -o pgid= -p "$wait_pid" 2>/dev/null | tr -d '[:space:]')
+  if [ -n "$wait_pgid" ] && [ "$wait_pgid" = "$wait_pid" ]; then
+    kill -TERM -- "-$wait_pid" 2>/dev/null || true
+  fi
   kill -TERM "$wait_pid" 2>/dev/null || true
 }
 
@@ -982,7 +1040,7 @@ fast_repair_progress_timer_start() {
         fast_repair_progress_tick
       [ "$FAST_REPAIR_ACTIVE" = 1 ] || rm -f "$marker"
       [ -f "$marker" ] || exit 0
-      delay=$(fast_repair_progress_timer_delay) || exit 0
+      delay=$(fast_repair_progress_timer_delay "$generation") || exit 0
       case "$delay" in *[!0-9]*|'') exit 0 ;; esac
       [ "$delay" -gt 0 ] || delay=1
       sleep "$delay"
@@ -1013,19 +1071,61 @@ fast_repair_progress_timer_finish() {
   FAST_REPAIR_TIMER_WAIT_FILE=
 }
 
-fast_repair_progress_timer_sleep() { # <seconds>
-  local seconds=$1 wait_file=${FAST_REPAIR_TIMER_WAIT_FILE:-} pid tmp
-  [ -n "$wait_file" ] || { sleep "$seconds"; return; }
-  sleep "$seconds" &
-  pid=$!
-  tmp=$(mktemp "$wait_file.XXXXXX") || { wait "$pid" || true; return; }
+fast_repair_progress_timer_wait_pid_publish() { # <pid>
+  local wait_file=${FAST_REPAIR_TIMER_WAIT_FILE:-} pid=$1 tmp
+  [ -n "$wait_file" ] || return 1
+  tmp=$(mktemp "$wait_file.XXXXXX") || return 1
   if ! printf '%s\n' "$pid" > "$tmp" || ! chmod 600 "$tmp" || ! mv -f "$tmp" "$wait_file"; then
     rm -f "$tmp"
+    return 1
+  fi
+}
+
+fast_repair_progress_timer_wait_pid_clear() {
+  local wait_file=${FAST_REPAIR_TIMER_WAIT_FILE:-}
+  [ -n "$wait_file" ] || return 0
+  rm -f "$wait_file"
+}
+
+fast_repair_progress_timer_sleep() { # <seconds>
+  local seconds=$1 wait_file=${FAST_REPAIR_TIMER_WAIT_FILE:-} pid
+  [ -n "$wait_file" ] || { sleep "$seconds"; return; }
+  set -m
+  ( sleep "$seconds" ) &
+  pid=$!
+  set +m
+  if ! fast_repair_progress_timer_wait_pid_publish "$pid"; then
     wait "$pid" || true
     return
   fi
   wait "$pid" || true
-  rm -f "$wait_file"
+  fast_repair_progress_timer_wait_pid_clear
+}
+
+# The push wait is a foreground read on the backend's event stream, so unlike the
+# sleep path it cannot be signalled where it stands. Run it as its own process
+# group whose leader is published as the interruptible wait, so a Fast Repair
+# progress result stops the wait and its backend reader together and the result
+# is delivered in this cycle instead of after the whole poll budget. The record
+# the wait printed is returned through FM_EVENT_WAIT_RECORD; the exit status is
+# the backend's own, and an interrupted wait reports neither an edge (0) nor an
+# unusable event path (2), so it falls through to the ordinary no-edge branch.
+FM_EVENT_WAIT_RECORD=
+fast_repair_progress_timer_wait_transition() { # <backend> <session> <budget> <state> <window...>
+  local out pid rc=0
+  FM_EVENT_WAIT_RECORD=
+  out=$(mktemp "$STATE/.fm-event-wait.XXXXXX") || return 2
+  chmod 0600 "$out" || { rm -f "$out"; return 2; }
+  set -m
+  ( FM_BACKEND_EVENTS_CAPABILITY_CONFIRMED=1 fm_backend_wait_transition "$@" ) > "$out" 2>/dev/null &
+  pid=$!
+  set +m
+  fast_repair_progress_timer_wait_pid_publish "$pid" || true
+  wait "$pid" || rc=$?
+  fast_repair_progress_timer_wait_pid_clear
+  FM_EVENT_WAIT_RECORD=$(cat "$out" 2>/dev/null || true)
+  rm -f "$out"
+  return "$rc"
 }
 
 fast_repair_progress_timer_wake() {
@@ -1062,7 +1162,16 @@ fast_repair_progress_timer_wake() {
     status=0
     fast_repair_progress_record "$id" "$result" "$generation" || status=$?
     case "$status" in
-      0) rm -f "$file" || continue; reasons="$reasons $result" ;;
+      0)
+        rm -f "$file" || continue
+        # The green rollup is the last transition this cadence exists to catch.
+        # Retire the task from it only after its wake is durably queued, the same
+        # order every other marker here follows.
+        case "$result" in
+          "fast-repair $id pr-checks-green:"*) : > "$(fast_repair_progress_green_marker "$id")" || true ;;
+        esac
+        reasons="$reasons $result"
+        ;;
       1|3) rm -f "$file" || continue ;;
       *) continue ;;
     esac
@@ -1123,14 +1232,20 @@ event_wait_or_sleep() {
     _event_cap_fails=0
   fi
   if [ "$_event_cap_ok" != 1 ]; then
-    sleep "$POLL"
+    fast_repair_progress_timer_sleep "$POLL"
     fast_repair_progress_timer_finish
     fast_repair_progress_timer_wake
     return
   fi
 
-  rec=$(FM_BACKEND_EVENTS_CAPABILITY_CONFIRMED=1 fm_backend_wait_transition "$first_backend" "$first_session" "$POLL" "$STATE" "${windows[@]}")
-  rc=$?
+  if [ -n "${FAST_REPAIR_TIMER_WAIT_FILE:-}" ]; then
+    fast_repair_progress_timer_wait_transition "$first_backend" "$first_session" "$POLL" "$STATE" "${windows[@]}"
+    rc=$?
+    rec=$FM_EVENT_WAIT_RECORD
+  else
+    rec=$(FM_BACKEND_EVENTS_CAPABILITY_CONFIRMED=1 fm_backend_wait_transition "$first_backend" "$first_session" "$POLL" "$STATE" "${windows[@]}")
+    rc=$?
+  fi
   case "$rc" in
     0)
       _event_cap_fails=0
@@ -1142,7 +1257,7 @@ event_wait_or_sleep() {
       # pure polling for the rest of this watcher process.
       _event_cap_fails=$((_event_cap_fails + 1))
       [ "$_event_cap_fails" -ge "$EVENT_CAP_FAIL_MAX" ] && _event_cap_ok=0
-      sleep "$POLL"
+      fast_repair_progress_timer_sleep "$POLL"
       ;;
     *)
       # 1: a clean full-budget wait with no actionable edge - the reader already

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -784,17 +784,17 @@ fast_repair_progress_timer_tasks_finish() { # <generation>
   done
   while [ "$i" -lt 40 ]; do
     live=0
-    for pid in "${pids[@]}"; do
+    for pid in "${pids[@]+"${pids[@]}"}"; do
       kill -0 "$pid" 2>/dev/null && { live=1; break; }
     done
     [ "$live" -eq 0 ] && break
     sleep 0.01
     i=$((i + 1))
   done
-  for pid in "${pids[@]}"; do
+  for pid in "${pids[@]+"${pids[@]}"}"; do
     kill -0 "$pid" 2>/dev/null && kill -KILL "$pid" 2>/dev/null || true
   done
-  for marker in "${markers[@]}"; do
+  for marker in "${markers[@]+"${markers[@]}"}"; do
     rm -f "$marker" "$marker.ready"
   done
 }
@@ -1191,6 +1191,7 @@ fast_repair_progress_timer_finish() {
   fi
   [ -z "$pid" ] || wait "$pid" 2>/dev/null || true
   FAST_REPAIR_TIMER_PID=
+  rm -f "$marker.closing"
   rm -f "$wait_file"
   FAST_REPAIR_TIMER_WAIT_FILE=
 }

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -467,6 +467,7 @@ scan_signals() {
 
 FAST_REPAIR_ACTIVE=0
 FAST_REPAIR_TIMER_PID=
+FAST_REPAIR_TIMER_MARKER=
 
 # The one place that decides whether durable task metadata opts a task into Fast
 # Repair. One tick collects the eligible ids with it once and reuses that list
@@ -688,23 +689,32 @@ heartbeat_scan_finds_actionable() {
 }
 
 fast_repair_progress_timer_start() {
-  local remaining parent
+  local marker remaining parent
   [ "$FAST_REPAIR_ACTIVE" = 1 ] || return 0
   case "$POLL:$FAST_REPAIR_PROGRESS_INTERVAL" in *[!0-9:]*|:*|*:) return 0 ;; esac
-  if [ -n "$FAST_REPAIR_TIMER_PID" ] && kill -0 "$FAST_REPAIR_TIMER_PID" 2>/dev/null; then
-    return 0
-  fi
-  remaining=$(( FAST_REPAIR_PROGRESS_INTERVAL - $(age_of "$STATE/.last-fast-repair-progress") ))
-  [ "$remaining" -ge 1 ] || remaining=1
-  [ "$remaining" -lt "$POLL" ] || return 0
+  rm -f "$STATE"/.fast-repair-progress-timer.*
+  marker=$(mktemp "$STATE/.fast-repair-progress-timer.XXXXXX") || return 0
+  FAST_REPAIR_TIMER_MARKER=$marker
   parent=$WATCHER_PID
   (
     trap - EXIT HUP INT TERM
-    sleep $((remaining + 1))
-    [ "$(cat "$WATCH_LOCK/pid" 2>/dev/null || true)" = "$parent" ] || exit 0
-    FM_FAST_REPAIR_TIMER_PARENT=1 fast_repair_progress_tick
+    while [ -f "$marker" ]; do
+      remaining=$(( FAST_REPAIR_PROGRESS_INTERVAL - $(age_of "$STATE/.last-fast-repair-progress") ))
+      [ "$remaining" -ge 1 ] || remaining=1
+      sleep $((remaining + 1))
+      [ -f "$marker" ] || exit 0
+      [ "$(cat "$WATCH_LOCK/pid" 2>/dev/null || true)" = "$parent" ] || exit 0
+      FM_FAST_REPAIR_TIMER_PARENT=1 fast_repair_progress_tick
+      [ "$FAST_REPAIR_ACTIVE" = 1 ] || rm -f "$marker"
+    done
   ) &
   FAST_REPAIR_TIMER_PID=$!
+}
+
+fast_repair_progress_timer_finish() {
+  [ -n "${FAST_REPAIR_TIMER_MARKER:-}" ] || return 0
+  rm -f "$FAST_REPAIR_TIMER_MARKER"
+  FAST_REPAIR_TIMER_MARKER=
 }
 
 fast_repair_progress_timer_wake() {
@@ -752,6 +762,7 @@ event_wait_or_sleep() {
 
   if [ "${#windows[@]}" -eq 0 ]; then
     sleep "$POLL"
+    fast_repair_progress_timer_finish
     fast_repair_progress_timer_wake
     return
   fi
@@ -769,6 +780,7 @@ event_wait_or_sleep() {
   fi
   if [ "$_event_cap_ok" != 1 ]; then
     sleep "$POLL"
+    fast_repair_progress_timer_finish
     fast_repair_progress_timer_wake
     return
   fi
@@ -794,6 +806,7 @@ event_wait_or_sleep() {
       _event_cap_fails=0
       ;;
   esac
+  fast_repair_progress_timer_finish
   fast_repair_progress_timer_wake
 }
 
@@ -846,6 +859,7 @@ elif [ "$FM_RECOVERY_MARKER_ACTION" = recover ]; then
 fi
 watcher_cleanup() {
   local cleanup_status=0 owns_lock=0 transition=release-lock
+  fast_repair_progress_timer_finish
   if [ "$(cat "$WATCH_LOCK/pid" 2>/dev/null || true)" = "${WATCHER_PID:-}" ]; then
     owns_lock=1
     if [ "${WATCHER_RECOVERY_PENDING:-0}" -eq 1 ] \

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -550,27 +550,34 @@ fast_repair_progress_task_marker() { # <task-id> <generation>
   printf '%s/.fast-repair-progress-child-%s-%s' "$STATE" "$1" "$2"
 }
 
-fast_repair_progress_task_stop() { # <marker>
-  local marker=$1 ready="$1.ready" pid i=0
-  [ -f "$marker" ] && [ ! -L "$marker" ] || return 0
-  pid=$(cat "$marker" 2>/dev/null || true)
-  case "$pid" in ''|*[!0-9]*) rm -f "$marker" "$ready"; return 0 ;; esac
-  if kill -0 "$pid" 2>/dev/null; then
-    kill -TERM "$pid" 2>/dev/null || true
-    while kill -0 "$pid" 2>/dev/null && [ "$i" -lt 20 ]; do
-      sleep 0.01
-      i=$((i + 1))
-    done
-    kill -KILL "$pid" 2>/dev/null || true
-  fi
-  rm -f "$marker" "$ready"
-}
-
 fast_repair_progress_timer_tasks_finish() { # <generation>
-  local generation=$1 marker
+  local generation=$1 marker ready pid i=0 live
+  local markers=() pids=()
   for marker in "$STATE"/.fast-repair-progress-child-*"-$generation"; do
-    [ -e "$marker" ] || continue
-    fast_repair_progress_task_stop "$marker"
+    [ -f "$marker" ] && [ ! -L "$marker" ] || continue
+    ready="$marker.ready"
+    pid=$(cat "$marker" 2>/dev/null || true)
+    case "$pid" in
+      ''|*[!0-9]*) rm -f "$marker" "$ready"; continue ;;
+    esac
+    markers+=("$marker")
+    pids+=("$pid")
+    kill -TERM "$pid" 2>/dev/null || true
+  done
+  while [ "$i" -lt 20 ]; do
+    live=0
+    for pid in "${pids[@]}"; do
+      kill -0 "$pid" 2>/dev/null && { live=1; break; }
+    done
+    [ "$live" -eq 0 ] && break
+    sleep 0.01
+    i=$((i + 1))
+  done
+  for pid in "${pids[@]}"; do
+    kill -0 "$pid" 2>/dev/null && kill -KILL "$pid" 2>/dev/null || true
+  done
+  for marker in "${markers[@]}"; do
+    rm -f "$marker" "$marker.ready"
   done
 }
 

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -504,17 +504,28 @@ fast_repair_progress_discover() {
 }
 
 fast_repair_progress_record() {
-  local id=$1 result=$2 marker prior
+  local id=$1 result=$2 generation=${3:-} marker generation_marker prior prior_generation
   marker="$STATE/.fast-repair-progress-$id"
+  generation_marker="$STATE/.fast-repair-progress-generation-$id"
+  if [ -n "$generation" ]; then
+    case "$generation" in *[!0-9]*|'') return 3 ;; esac
+    prior_generation=$(cat "$generation_marker" 2>/dev/null || true)
+    case "$prior_generation" in *[!0-9]*|'') prior_generation=0 ;; esac
+    [ "$prior_generation" -le "$generation" ] || return 3
+  fi
   prior=$(cat "$marker" 2>/dev/null || true)
-  [ "$prior" = "$result" ] && return 1
+  if [ "$prior" = "$result" ]; then
+    [ -z "$generation" ] || printf '%s' "$generation" > "$generation_marker"
+    return 1
+  fi
   fm_wake_append check "fast-repair:$id" "check: $result" || return 2
   printf '%s' "$result" > "$marker"
+  [ -z "$generation" ] || printf '%s' "$generation" > "$generation_marker"
   touch "$STATE/.last-fast-repair-progress"
 }
 
 fast_repair_progress_tick() {
-  local meta id result progress_stamp
+  local meta id result progress_stamp timer_published=0
   local ids=()
   for meta in "$STATE"/*.meta; do
     [ -e "$meta" ] || continue
@@ -537,22 +548,29 @@ fast_repair_progress_tick() {
     result=$FM_CHECK_RESULT
     [ -n "$result" ] || continue
     if [ -n "${FM_FAST_REPAIR_TIMER_PARENT:-}" ]; then
-      fast_repair_progress_timer_publish "$id" "$result"
-      return 0
+      if fast_repair_progress_timer_publish "$id" "$result"; then
+        timer_published=1
+      fi
+      continue
     fi
     fast_repair_progress_record "$id" "$result" || continue
     wake "check: $result"
   done
   touch "$progress_stamp"
+  if [ "$timer_published" = 1 ]; then
+    FAST_REPAIR_TIMER_RESULT_PUBLISHED=1
+    fast_repair_progress_timer_notify
+  fi
 }
 
 fast_repair_progress_timer_publish() {
   local id=$1 result=$2 generation=${FM_FAST_REPAIR_TIMER_GENERATION:-}
-  local parent=${FM_FAST_REPAIR_TIMER_PARENT:-} closing=${FM_FAST_REPAIR_TIMER_CLOSING:-}
+  local parent=${FM_FAST_REPAIR_TIMER_PARENT:-}
   local file tmp
   case "$generation:$parent" in *[!0-9:]*|:*|*:) return 1 ;; esac
   case "$id:$result" in *$'\n'*|*$'\r'*) return 1 ;; esac
-  file="$STATE/.fast-repair-progress-handoff-$parent-$generation"
+  fm_pr_task_id_valid "$id" || return 1
+  file="$STATE/.fast-repair-progress-handoff-$parent-$generation-$id"
   tmp=$(mktemp "$file.XXXXXX") || return 1
   if ! {
     printf '%s\n' "$generation"
@@ -562,7 +580,11 @@ fast_repair_progress_timer_publish() {
     rm -f "$tmp"
     return 1
   fi
-  FAST_REPAIR_TIMER_RESULT_PUBLISHED=1
+}
+
+fast_repair_progress_timer_notify() {
+  local parent=${FM_FAST_REPAIR_TIMER_PARENT:-} closing=${FM_FAST_REPAIR_TIMER_CLOSING:-}
+  case "$parent" in *[!0-9]*|'') return 1 ;; esac
   [ -f "$closing" ] || return 0
   kill -USR1 "$parent" 2>/dev/null || true
 }
@@ -770,26 +792,31 @@ fast_repair_progress_timer_finish() {
 }
 
 fast_repair_progress_timer_wake() {
-  local file generation id result extra watcher=${WATCHER_PID:-}
+  local file generation id result extra watcher=${WATCHER_PID:-} status reasons=
   [ -n "$watcher" ] || return 0
-  generation=$FAST_REPAIR_TIMER_GENERATION
-  file="$STATE/.fast-repair-progress-handoff-$watcher-$generation"
-  [ -f "$file" ] && [ ! -L "$file" ] || return 0
-  exec 9< "$file" || return 0
-  IFS= read -r generation <&9 || { exec 9<&-; return 0; }
-  IFS= read -r id <&9 || { exec 9<&-; return 0; }
-  IFS= read -r result <&9 || { exec 9<&-; return 0; }
-  if IFS= read -r extra <&9; then
+  for file in "$STATE"/.fast-repair-progress-handoff-"$watcher"-*; do
+    [ -f "$file" ] && [ ! -L "$file" ] || continue
+    exec 9< "$file" || continue
+    IFS= read -r generation <&9 || { exec 9<&-; continue; }
+    IFS= read -r id <&9 || { exec 9<&-; continue; }
+    IFS= read -r result <&9 || { exec 9<&-; continue; }
+    if IFS= read -r extra <&9; then
+      exec 9<&-
+      continue
+    fi
     exec 9<&-
-    return 0
-  fi
-  exec 9<&-
-  [ "$generation" = "$FAST_REPAIR_TIMER_GENERATION" ] || return 0
-  fm_pr_task_id_valid "$id" || return 0
-  [ -n "$result" ] || return 0
-  rm -f "$file" || return 0
-  fast_repair_progress_record "$id" "$result" || return 0
-  wake "check: $result"
+    case "$generation" in *[!0-9]*|'') continue ;; esac
+    case "$result" in ''|*$'\n'*|*$'\r'*) continue ;; esac
+    fm_pr_task_id_valid "$id" || continue
+    status=0
+    fast_repair_progress_record "$id" "$result" "$generation" || status=$?
+    case "$status" in
+      0) rm -f "$file" || continue; reasons="$reasons $result" ;;
+      1|3) rm -f "$file" || continue ;;
+      *) continue ;;
+    esac
+  done
+  [ -z "$reasons" ] || wake "check:${reasons}"
 }
 
 # event_wait_or_sleep: the terminal wait of each supervision cycle. For a home

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -561,10 +561,8 @@ fast_repair_progress_tick() {
   fi
   FAST_REPAIR_ACTIVE=1
   progress_stamp="$STATE/.last-fast-repair-progress"
-  if [ -n "${FM_FAST_REPAIR_TIMER_GENERATION:-}" ]; then
-    progress_stamp="$progress_stamp-$FM_FAST_REPAIR_TIMER_GENERATION"
-  fi
   [ "$(age_of "$progress_stamp")" -ge "$FAST_REPAIR_PROGRESS_INTERVAL" ] || return 0
+  touch "$progress_stamp"
   for id in "${ids[@]}"; do
     FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
       run_check_capture "$SCRIPT_DIR/fm-fast-repair.sh" progress "$id" || exit 1
@@ -579,10 +577,8 @@ fast_repair_progress_tick() {
     fast_repair_progress_record "$id" "$result" || continue
     wake "check: $result"
   done
-  touch "$progress_stamp"
   if [ "$timer_published" = 1 ]; then
     FAST_REPAIR_TIMER_RESULT_PUBLISHED=1
-    fast_repair_progress_timer_notify
   fi
 }
 
@@ -605,10 +601,7 @@ fast_repair_progress_timer_publish() {
 }
 
 fast_repair_progress_timer_notify() {
-  local parent=${FM_FAST_REPAIR_TIMER_PARENT:-} closing=${FM_FAST_REPAIR_TIMER_CLOSING:-}
-  case "$parent" in *[!0-9]*|'') return 1 ;; esac
-  [ -f "$closing" ] || return 0
-  kill -USR1 "$parent" 2>/dev/null || true
+  return 0
 }
 
 # Deliver a durably queued process-event result to firstmate. Publication is
@@ -997,7 +990,7 @@ watcher_cleanup() {
 }
 trap watcher_cleanup EXIT
 trap 'exit 1' HUP INT TERM
-trap 'fast_repair_progress_timer_wake' USR1
+trap '' USR1
 # This watcher's own pid, as recorded in the lock by fm_lock_claim (which writes
 # ${BASHPID:-$$} from this same main shell). Read directly, never via a command
 # substitution, so it matches the stored holder pid for the self-eviction check.

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -491,6 +491,17 @@ fast_repair_eligible_meta() {  # <meta-path>
 # check: bounded by CHECK_TIMEOUT in its own process group, so a hung or slow
 # forge call can neither stall the beat, the signal scan, and the stale and
 # wedge detection of other crewmates, nor hold off a stop signal.
+fast_repair_progress_discover() {
+  local meta
+  FAST_REPAIR_ACTIVE=0
+  for meta in "$STATE"/*.meta; do
+    [ -e "$meta" ] || continue
+    fast_repair_eligible_meta "$meta" || continue
+    FAST_REPAIR_ACTIVE=1
+    return 0
+  done
+}
+
 fast_repair_progress_tick() {
   local meta id result marker prior
   local ids=()
@@ -951,7 +962,7 @@ while :; do
 
   # This is the only shortened cadence. It reads only durable Fast Repair task
   # records and leaves ordinary task scanning and schedules untouched.
-  fast_repair_progress_tick
+  fast_repair_progress_discover
 
   # Process-to-event liveness repair. This never discovers a result by polling:
   # each registered source has its own child blocking on that source, and this

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -528,12 +528,46 @@ fast_repair_progress_tick() {
     printf '%s' "$result" > "$marker"
     touch "$STATE/.last-fast-repair-progress"
     if [ -n "${FM_FAST_REPAIR_TIMER_PARENT:-}" ]; then
-      printf '%s' "$result" > "$STATE/.fast-repair-progress-wake"
+      fast_repair_progress_timer_publish "$result"
       return 0
     fi
     wake "check: $result"
   done
   touch "$STATE/.last-fast-repair-progress"
+}
+
+fast_repair_progress_timer_deliver() {
+  local result=$1 parent=${FM_FAST_REPAIR_TIMER_PARENT:-}
+  [ -n "$parent" ] || return 1
+  [ "$(cat "$WATCH_LOCK/pid" 2>/dev/null || true)" = "$parent" ] || return 1
+  wake "check: $result"
+}
+
+fast_repair_progress_timer_publish() {
+  local result=$1 lock=${FM_FAST_REPAIR_TIMER_HANDOFF_LOCK:-}
+  local closing=${FM_FAST_REPAIR_TIMER_CLOSING:-} wake_file="$STATE/.fast-repair-progress-wake"
+  [ -n "$lock" ] && [ -n "$closing" ] || {
+    printf '%s' "$result" > "$wake_file"
+    return 0
+  }
+  fm_lock_acquire_wait "$lock"
+  if [ -f "$closing" ]; then
+    fm_lock_release "$lock"
+    fast_repair_progress_timer_deliver "$result"
+    return
+  fi
+  printf '%s' "$result" > "$wake_file"
+  fm_lock_release "$lock"
+  [ -f "$closing" ] || return 0
+  if fm_lock_try_acquire "$lock"; then
+    if [ -f "$wake_file" ]; then
+      rm -f "$wake_file"
+      fm_lock_release "$lock"
+      fast_repair_progress_timer_deliver "$result"
+      return
+    fi
+    fm_lock_release "$lock"
+  fi
 }
 
 # Deliver a durably queued process-event result to firstmate. Publication is
@@ -700,22 +734,28 @@ heartbeat_scan_finds_actionable() {
 }
 
 fast_repair_progress_timer_start() {
-  local marker remaining parent
+  local marker remaining parent closing lock
   [ "$FAST_REPAIR_ACTIVE" = 1 ] || return 0
   case "$POLL:$FAST_REPAIR_PROGRESS_INTERVAL" in *[!0-9:]*|:*|*:) return 0 ;; esac
-  rm -f "$STATE"/.fast-repair-progress-timer.*
   marker=$(mktemp "$STATE/.fast-repair-progress-timer.XXXXXX") || return 0
+  closing="$marker.closing"
+  lock="$marker.handoff.lock"
   FAST_REPAIR_TIMER_MARKER=$marker
+  FAST_REPAIR_TIMER_HANDOFF_LOCK=
   parent=$WATCHER_PID
   (
-    trap - EXIT HUP INT TERM
+    trap 'rm -f "$closing"' EXIT
+    trap 'exit 0' HUP INT TERM
     while [ -f "$marker" ]; do
       remaining=$(( FAST_REPAIR_PROGRESS_INTERVAL - $(age_of "$STATE/.last-fast-repair-progress") ))
       [ "$remaining" -ge 1 ] || remaining=1
       sleep $((remaining + 1))
       [ -f "$marker" ] || exit 0
       [ "$(cat "$WATCH_LOCK/pid" 2>/dev/null || true)" = "$parent" ] || exit 0
-      FM_FAST_REPAIR_TIMER_PARENT=1 fast_repair_progress_tick
+      FM_FAST_REPAIR_TIMER_PARENT="$parent" \
+        FM_FAST_REPAIR_TIMER_CLOSING="$closing" \
+        FM_FAST_REPAIR_TIMER_HANDOFF_LOCK="$lock" \
+        fast_repair_progress_tick
       [ "$FAST_REPAIR_ACTIVE" = 1 ] || rm -f "$marker"
     done
   ) &
@@ -723,16 +763,26 @@ fast_repair_progress_timer_start() {
 }
 
 fast_repair_progress_timer_finish() {
-  [ -n "${FAST_REPAIR_TIMER_MARKER:-}" ] || return 0
-  rm -f "$FAST_REPAIR_TIMER_MARKER"
+  local marker=${FAST_REPAIR_TIMER_MARKER:-}
+  [ -n "$marker" ] || return 0
+  : > "$marker.closing" || return 0
+  rm -f "$marker"
+  FAST_REPAIR_TIMER_HANDOFF_LOCK="$marker.handoff.lock"
   FAST_REPAIR_TIMER_MARKER=
 }
 
 fast_repair_progress_timer_wake() {
-  local result
-  [ -f "$STATE/.fast-repair-progress-wake" ] || return 0
-  result=$(cat "$STATE/.fast-repair-progress-wake" 2>/dev/null || true)
-  rm -f "$STATE/.fast-repair-progress-wake"
+  local result lock=${FAST_REPAIR_TIMER_HANDOFF_LOCK:-} wake_file="$STATE/.fast-repair-progress-wake"
+  if [ -n "$lock" ]; then
+    fm_lock_try_acquire "$lock" || return 0
+  fi
+  [ -f "$wake_file" ] || {
+    [ -z "$lock" ] || fm_lock_release "$lock"
+    return 0
+  }
+  result=$(cat "$wake_file" 2>/dev/null || true)
+  rm -f "$wake_file" || result=
+  [ -z "$lock" ] || fm_lock_release "$lock"
   [ -n "$result" ] || return 0
   wake "check: $result"
 }

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -1020,7 +1020,7 @@ fast_repair_progress_timer_sleep() { # <seconds>
 }
 
 fast_repair_progress_timer_wake() {
-  local file lifecycle current_lifecycle generation id result extra status reasons=
+  local file lifecycle current_lifecycle generation id result status reasons=
   for file in "$STATE"/.fast-repair-progress-handoff-*; do
     [ -f "$file" ] && [ ! -L "$file" ] || continue
     exec 9< "$file" || continue
@@ -1033,7 +1033,7 @@ fast_repair_progress_timer_wake() {
     fi
     IFS= read -r id <&9 || { exec 9<&-; continue; }
     IFS= read -r result <&9 || { exec 9<&-; continue; }
-    if IFS= read -r extra <&9; then
+    if IFS= read -r <&9; then
       exec 9<&-
       continue
     fi

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -526,6 +526,63 @@ fast_repair_eligible_task() {
   [ -f "$meta" ] && [ ! -L "$meta" ] && fast_repair_eligible_meta "$meta"
 }
 
+fast_repair_progress_due_path() {
+  printf '%s/.fast-repair-progress-next-due-%s' "$STATE" "$1"
+}
+
+fast_repair_progress_due_set() {
+  local id=$1 due=$2 path tmp
+  fm_pr_task_id_valid "$id" || return 1
+  case "$due" in *[!0-9]*|'') return 1 ;; esac
+  path=$(fast_repair_progress_due_path "$id") || return 1
+  tmp=$(mktemp "$path.XXXXXX") || return 1
+  if ! printf '%s\n' "$due" > "$tmp" || ! chmod 600 "$tmp" || ! mv -f "$tmp" "$path"; then
+    rm -f "$tmp"
+    return 1
+  fi
+}
+
+fast_repair_progress_due_in() {
+  local path now due
+  path=$(fast_repair_progress_due_path "$1") || return 1
+  now=$(date +%s) || return 1
+  due=$(cat "$path" 2>/dev/null || true)
+  case "$due" in *[!0-9]*|'') printf '0\n'; return 0 ;; esac
+  if [ "$due" -le "$now" ]; then
+    printf '0\n'
+  else
+    printf '%s\n' "$((due - now))"
+  fi
+}
+
+fast_repair_progress_schedule_missing() {
+  local meta id path now due
+  now=$(date +%s) || return 1
+  for meta in "$STATE"/*.meta; do
+    [ -e "$meta" ] || continue
+    fast_repair_eligible_meta "$meta" || continue
+    id=$(basename "$meta" .meta)
+    path=$(fast_repair_progress_due_path "$id") || continue
+    due=$(cat "$path" 2>/dev/null || true)
+    case "$due" in *[!0-9]*|'') fast_repair_progress_due_set "$id" "$((now + FAST_REPAIR_PROGRESS_INTERVAL))" || continue ;; esac
+  done
+}
+
+fast_repair_progress_timer_delay() {
+  local meta id delay shortest=
+  for meta in "$STATE"/*.meta; do
+    [ -e "$meta" ] || continue
+    fast_repair_eligible_meta "$meta" || continue
+    id=$(basename "$meta" .meta)
+    delay=$(fast_repair_progress_due_in "$id") || continue
+    case "$delay" in *[!0-9]*|'') continue ;; esac
+    if [ -z "$shortest" ] || [ "$delay" -lt "$shortest" ]; then
+      shortest=$delay
+    fi
+  done
+  printf '%s\n' "${shortest:-$FAST_REPAIR_PROGRESS_INTERVAL}"
+}
+
 fast_repair_progress_record() {
   local id=$1 result=$2 generation=${3:-} marker generation_marker prior prior_generation
   marker="$STATE/.fast-repair-progress-$id"
@@ -639,7 +696,7 @@ fast_repair_progress_task_start() { # <task-id> <generation>
 }
 
 fast_repair_progress_tick() {
-  local meta id progress_stamp generation
+  local meta id due generation now
   local ids=()
   for meta in "$STATE"/*.meta; do
     [ -e "$meta" ] || continue
@@ -654,28 +711,39 @@ fast_repair_progress_tick() {
   generation=${FM_FAST_REPAIR_TIMER_GENERATION:-}
   case "$generation" in *[!0-9]*|'') return 1 ;; esac
   for id in "${ids[@]}"; do
-    progress_stamp="$STATE/.last-fast-repair-progress-$id"
-    [ "$(age_of "$progress_stamp")" -ge "$FAST_REPAIR_PROGRESS_INTERVAL" ] || continue
+    due=$(fast_repair_progress_due_in "$id") || continue
+    [ "$due" -eq 0 ] || continue
+    now=$(date +%s) || continue
+    fast_repair_progress_due_set "$id" "$((now + FAST_REPAIR_PROGRESS_INTERVAL))" || continue
+    touch "$STATE/.last-fast-repair-progress-$id"
     fast_repair_progress_task_start "$id" "$generation"
   done
 }
 
 fast_repair_progress_timer_publish() {
   local id=$1 result=$2 generation=${FM_FAST_REPAIR_TIMER_GENERATION:-}
-  local file tmp
+  local file tmp lock counter current next
   case "$generation" in *[!0-9]*|'') return 1 ;; esac
   case "$id:$result" in *$'\n'*|*$'\r'*) return 1 ;; esac
   fm_pr_task_id_valid "$id" || return 1
-  file="$STATE/.fast-repair-progress-handoff-$id-$generation"
-  tmp=$(mktemp "$file.XXXXXX") || return 1
+  lock="$STATE/.fast-repair-progress-sequence-$id-$generation.lock"
+  counter="$STATE/.fast-repair-progress-sequence-$id-$generation"
+  fm_lock_acquire_wait "$lock" || return 1
+  current=$(cat "$counter" 2>/dev/null || true)
+  case "$current" in ''|*[!0-9]*) current=0 ;; esac
+  next=$((current + 1))
+  tmp=$(mktemp "$STATE/.fast-repair-progress-pending.XXXXXX") || { fm_lock_release "$lock"; return 1; }
+  file=$(printf '%s/.fast-repair-progress-handoff-%s-%s-%020d' "$STATE" "$id" "$generation" "$next")
   if ! {
     printf '%s\n' "$generation"
     printf '%s\n' "$id"
     printf '%s\n' "$result"
-  } > "$tmp" || ! chmod 600 "$tmp" || ! mv -f "$tmp" "$file"; then
+  } > "$tmp" || ! chmod 600 "$tmp" || ! mv -f "$tmp" "$file" || ! printf '%s\n' "$next" > "$counter"; then
     rm -f "$tmp"
+    fm_lock_release "$lock"
     return 1
   fi
+  fm_lock_release "$lock"
 }
 
 fast_repair_progress_timer_notify() {
@@ -853,9 +921,10 @@ heartbeat_scan_finds_actionable() {
 }
 
 fast_repair_progress_timer_start() {
-  local marker parent closing generation
+  local marker parent closing generation delay
   [ "$FAST_REPAIR_ACTIVE" = 1 ] || return 0
   case "$POLL:$FAST_REPAIR_PROGRESS_INTERVAL" in *[!0-9:]*|:*|*:) return 0 ;; esac
+  fast_repair_progress_schedule_missing || return 0
   generation=$(fast_repair_progress_generation_next) || return 0
   FAST_REPAIR_TIMER_GENERATION=$generation
   marker=$(mktemp "$STATE/.fast-repair-progress-timer.XXXXXX") || return 0
@@ -866,14 +935,18 @@ fast_repair_progress_timer_start() {
     trap 'rm -f "$closing"' EXIT
     trap 'fm_active_check_stop || true; exit 0' HUP INT TERM
     while [ -f "$marker" ]; do
-      sleep "$FAST_REPAIR_PROGRESS_INTERVAL"
-      [ -f "$marker" ] || exit 0
       [ "$(cat "$WATCH_LOCK/pid" 2>/dev/null || true)" = "$parent" ] || exit 0
       FM_FAST_REPAIR_TIMER_PARENT="$parent" \
         FM_FAST_REPAIR_TIMER_CLOSING="$closing" \
         FM_FAST_REPAIR_TIMER_GENERATION="$generation" \
         fast_repair_progress_tick
       [ "$FAST_REPAIR_ACTIVE" = 1 ] || rm -f "$marker"
+      [ -f "$marker" ] || exit 0
+      delay=$(fast_repair_progress_timer_delay) || exit 0
+      case "$delay" in *[!0-9]*|'') exit 0 ;; esac
+      [ "$delay" -gt 0 ] || delay=1
+      sleep "$delay"
+      [ -f "$marker" ] || exit 0
     done
   ) &
   FAST_REPAIR_TIMER_PID=$!

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -503,6 +503,29 @@ fast_repair_progress_discover() {
   done
 }
 
+fast_repair_progress_generation_next() {
+  local counter="$STATE/.fast-repair-progress-next-generation"
+  local lock="$STATE/.fast-repair-progress-generation.lock"
+  local current next tmp
+  fm_lock_acquire_wait "$lock" || return 1
+  current=$(cat "$counter" 2>/dev/null || true)
+  case "$current" in ''|*[!0-9]*) current=0 ;; esac
+  next=$((current + 1))
+  tmp=$(mktemp "$counter.XXXXXX") || { fm_lock_release "$lock"; return 1; }
+  if ! printf '%s\n' "$next" > "$tmp" || ! chmod 600 "$tmp" || ! mv -f "$tmp" "$counter"; then
+    rm -f "$tmp"
+    fm_lock_release "$lock"
+    return 1
+  fi
+  fm_lock_release "$lock"
+  printf '%s\n' "$next"
+}
+
+fast_repair_eligible_task() {
+  local meta="$STATE/$1.meta"
+  [ -f "$meta" ] && [ ! -L "$meta" ] && fast_repair_eligible_meta "$meta"
+}
+
 fast_repair_progress_record() {
   local id=$1 result=$2 generation=${3:-} marker generation_marker prior prior_generation
   marker="$STATE/.fast-repair-progress-$id"
@@ -565,12 +588,11 @@ fast_repair_progress_tick() {
 
 fast_repair_progress_timer_publish() {
   local id=$1 result=$2 generation=${FM_FAST_REPAIR_TIMER_GENERATION:-}
-  local parent=${FM_FAST_REPAIR_TIMER_PARENT:-}
   local file tmp
-  case "$generation:$parent" in *[!0-9:]*|:*|*:) return 1 ;; esac
+  case "$generation" in *[!0-9]*|'') return 1 ;; esac
   case "$id:$result" in *$'\n'*|*$'\r'*) return 1 ;; esac
   fm_pr_task_id_valid "$id" || return 1
-  file="$STATE/.fast-repair-progress-handoff-$parent-$generation-$id"
+  file="$STATE/.fast-repair-progress-handoff-$id-$generation"
   tmp=$(mktemp "$file.XXXXXX") || return 1
   if ! {
     printf '%s\n' "$generation"
@@ -756,8 +778,8 @@ fast_repair_progress_timer_start() {
   local marker remaining parent closing generation
   [ "$FAST_REPAIR_ACTIVE" = 1 ] || return 0
   case "$POLL:$FAST_REPAIR_PROGRESS_INTERVAL" in *[!0-9:]*|:*|*:) return 0 ;; esac
-  FAST_REPAIR_TIMER_GENERATION=$((FAST_REPAIR_TIMER_GENERATION + 1))
-  generation=$FAST_REPAIR_TIMER_GENERATION
+  generation=$(fast_repair_progress_generation_next) || return 0
+  FAST_REPAIR_TIMER_GENERATION=$generation
   marker=$(mktemp "$STATE/.fast-repair-progress-timer.XXXXXX") || return 0
   closing="$marker.closing"
   FAST_REPAIR_TIMER_MARKER=$marker
@@ -792,9 +814,8 @@ fast_repair_progress_timer_finish() {
 }
 
 fast_repair_progress_timer_wake() {
-  local file generation id result extra watcher=${WATCHER_PID:-} status reasons=
-  [ -n "$watcher" ] || return 0
-  for file in "$STATE"/.fast-repair-progress-handoff-"$watcher"-*; do
+  local file generation id result extra status reasons=
+  for file in "$STATE"/.fast-repair-progress-handoff-*; do
     [ -f "$file" ] && [ ! -L "$file" ] || continue
     exec 9< "$file" || continue
     IFS= read -r generation <&9 || { exec 9<&-; continue; }
@@ -808,6 +829,10 @@ fast_repair_progress_timer_wake() {
     case "$generation" in *[!0-9]*|'') continue ;; esac
     case "$result" in ''|*$'\n'*|*$'\r'*) continue ;; esac
     fm_pr_task_id_valid "$id" || continue
+    if ! fast_repair_eligible_task "$id"; then
+      rm -f "$file" || continue
+      continue
+    fi
     status=0
     fast_repair_progress_record "$id" "$result" "$generation" || status=$?
     case "$status" in
@@ -1046,6 +1071,7 @@ while :; do
   # This is the only shortened cadence. It reads only durable Fast Repair task
   # records and leaves ordinary task scanning and schedules untouched.
   fast_repair_progress_discover
+  fast_repair_progress_timer_wake
 
   # Process-to-event liveness repair. This never discovers a result by polling:
   # each registered source has its own child blocking on that source, and this

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -466,6 +466,10 @@ scan_signals() {
 }
 
 FAST_REPAIR_ACTIVE=0
+FAST_REPAIR_TIMER_PID=
+FAST_REPAIR_WAIT_PID=
+FAST_REPAIR_WAIT_OUTPUT=
+FAST_REPAIR_EVENT_REC=
 
 # The one place that decides whether durable task metadata opts a task into Fast
 # Repair. One tick collects the eligible ids with it once and reuses that list
@@ -514,6 +518,10 @@ fast_repair_progress_tick() {
     fm_wake_append check "fast-repair:$id" "check: $result" || exit 1
     printf '%s' "$result" > "$marker"
     touch "$STATE/.last-fast-repair-progress"
+    if [ -n "${FM_FAST_REPAIR_TIMER_PARENT:-}" ]; then
+      printf '%s' "$result" > "$STATE/.fast-repair-progress-wake"
+      return 0
+    fi
     wake "check: $result"
   done
   touch "$STATE/.last-fast-repair-progress"
@@ -682,27 +690,84 @@ heartbeat_scan_finds_actionable() {
   return 1
 }
 
-# The terminal wait of a cycle, in seconds. Every home waits exactly POLL, as
-# it always has. The one exception is a home that currently holds an eligible
-# Fast Repair task: the cycle then waits only until that task's next progress
-# tick becomes due, because a POLL-sized wait cannot land on a shorter interval
-# and would stretch the Fast-Repair-only cadence to the next multiple of POLL.
-# This only ever shortens the wait, only while Fast Repair is active, and a
-# non-integer POLL (tests use fractional values) is passed through untouched.
-cycle_wait() {
-  local remaining
-  if [ "$FAST_REPAIR_ACTIVE" != 1 ]; then
-    printf '%s\n' "$POLL"
+fast_repair_progress_timer_start() {
+  local remaining parent
+  [ "$FAST_REPAIR_ACTIVE" = 1 ] || return 0
+  case "$POLL:$FAST_REPAIR_PROGRESS_INTERVAL" in *[!0-9:]*|:*|*:) return 0 ;; esac
+  if [ -n "$FAST_REPAIR_TIMER_PID" ] && kill -0 "$FAST_REPAIR_TIMER_PID" 2>/dev/null; then
     return 0
   fi
-  case "$POLL" in ''|*[!0-9]*) printf '%s\n' "$POLL"; return 0 ;; esac
   remaining=$(( FAST_REPAIR_PROGRESS_INTERVAL - $(age_of "$STATE/.last-fast-repair-progress") ))
   [ "$remaining" -ge 1 ] || remaining=1
-  if [ "$remaining" -lt "$POLL" ]; then
-    printf '%s\n' "$remaining"
-  else
-    printf '%s\n' "$POLL"
+  [ "$remaining" -lt "$POLL" ] || return 0
+  parent=$WATCHER_PID
+  (
+    trap - EXIT HUP INT TERM
+    sleep $((remaining + 1))
+    [ "$(cat "$WATCH_LOCK/pid" 2>/dev/null || true)" = "$parent" ] || exit 0
+    FM_FAST_REPAIR_TIMER_PARENT=1 fast_repair_progress_tick
+  ) &
+  FAST_REPAIR_TIMER_PID=$!
+}
+
+fast_repair_wait_sleep() {
+  local rc
+  if [ "$FAST_REPAIR_ACTIVE" != 1 ]; then
+    sleep "$POLL"
+    return
   fi
+  sleep "$POLL" &
+  FAST_REPAIR_WAIT_PID=$!
+  while kill -0 "$FAST_REPAIR_WAIT_PID" 2>/dev/null; do
+    fast_repair_progress_timer_wake
+    sleep 0.1
+  done
+  wait "$FAST_REPAIR_WAIT_PID"
+  rc=$?
+  FAST_REPAIR_WAIT_PID=
+  return "$rc"
+}
+
+fast_repair_wait_stop() {
+  [ -n "${FAST_REPAIR_WAIT_PID:-}" ] || return 0
+  kill "$FAST_REPAIR_WAIT_PID" 2>/dev/null || true
+  wait "$FAST_REPAIR_WAIT_PID" 2>/dev/null || true
+  FAST_REPAIR_WAIT_PID=
+  rm -f "${FAST_REPAIR_WAIT_OUTPUT:-}" 2>/dev/null || true
+  FAST_REPAIR_WAIT_OUTPUT=
+}
+
+fast_repair_progress_timer_wake() {
+  local result
+  [ -f "$STATE/.fast-repair-progress-wake" ] || return 0
+  result=$(cat "$STATE/.fast-repair-progress-wake" 2>/dev/null || true)
+  rm -f "$STATE/.fast-repair-progress-wake"
+  [ -n "$result" ] || return 0
+  fast_repair_wait_stop
+  wake "check: $result"
+}
+
+fast_repair_wait_transition() {
+  local backend=$1 session=$2 rc
+  FAST_REPAIR_EVENT_REC=
+  if [ "$FAST_REPAIR_ACTIVE" != 1 ]; then
+    FAST_REPAIR_EVENT_REC=$(FM_BACKEND_EVENTS_CAPABILITY_CONFIRMED=1 fm_backend_wait_transition "$backend" "$session" "$POLL" "$STATE" "${windows[@]}")
+    return $?
+  fi
+  FAST_REPAIR_WAIT_OUTPUT=$(mktemp "$STATE/.fm-fast-repair-event.XXXXXX") || return 1
+  FM_BACKEND_EVENTS_CAPABILITY_CONFIRMED=1 fm_backend_wait_transition "$backend" "$session" "$POLL" "$STATE" "${windows[@]}" > "$FAST_REPAIR_WAIT_OUTPUT" &
+  FAST_REPAIR_WAIT_PID=$!
+  while kill -0 "$FAST_REPAIR_WAIT_PID" 2>/dev/null; do
+    fast_repair_progress_timer_wake
+    sleep 0.1
+  done
+  wait "$FAST_REPAIR_WAIT_PID"
+  rc=$?
+  FAST_REPAIR_WAIT_PID=
+  FAST_REPAIR_EVENT_REC=$(cat "$FAST_REPAIR_WAIT_OUTPUT" 2>/dev/null || true)
+  rm -f "$FAST_REPAIR_WAIT_OUTPUT"
+  FAST_REPAIR_WAIT_OUTPUT=
+  return "$rc"
 }
 
 # event_wait_or_sleep: the terminal wait of each supervision cycle. For a home
@@ -718,9 +783,8 @@ cycle_wait() {
 # a second watcher, so every guard/beacon/arm/turn-end mechanism is unchanged.
 event_wait_or_sleep() {
   local w b session first_backend="" first_session="" rec rc
-  local wait_budget
   local windows=()
-  wait_budget=$(cycle_wait)
+  fast_repair_progress_timer_start
   while IFS= read -r w; do
     b=$(window_backend "$w")
     fm_backend_has_push "$b" || continue
@@ -741,7 +805,7 @@ event_wait_or_sleep() {
   done < <(recorded_windows)
 
   if [ "${#windows[@]}" -eq 0 ]; then
-    sleep "$wait_budget"
+    fast_repair_wait_sleep
     return
   fi
 
@@ -757,12 +821,13 @@ event_wait_or_sleep() {
     _event_cap_fails=0
   fi
   if [ "$_event_cap_ok" != 1 ]; then
-    sleep "$wait_budget"
+    fast_repair_wait_sleep
     return
   fi
 
-  rec=$(FM_BACKEND_EVENTS_CAPABILITY_CONFIRMED=1 fm_backend_wait_transition "$first_backend" "$first_session" "$wait_budget" "$STATE" "${windows[@]}")
+  fast_repair_wait_transition "$first_backend" "$first_session"
   rc=$?
+  rec=$FAST_REPAIR_EVENT_REC
   case "$rc" in
     0)
       _event_cap_fails=0
@@ -774,7 +839,7 @@ event_wait_or_sleep() {
       # pure polling for the rest of this watcher process.
       _event_cap_fails=$((_event_cap_fails + 1))
       [ "$_event_cap_fails" -ge "$EVENT_CAP_FAIL_MAX" ] && _event_cap_ok=0
-      sleep "$wait_budget"
+      fast_repair_wait_sleep
       ;;
     *)
       # 1: a clean full-budget wait with no actionable edge - the reader already
@@ -840,6 +905,7 @@ watcher_cleanup() {
       transition=release-lock-existing
     fi
   fi
+  fast_repair_wait_stop
   fm_active_check_stop || cleanup_status=1
   fm_check_output_cleanup
   fm_custom_check_snapshot_cleanup

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -478,29 +478,56 @@ fast_repair_eligible_meta() {  # <meta-path>
   grep -qx 'fast_repair=eligible' "$1" 2>/dev/null
 }
 
-# The short cadence exists to surface the first actionable transition of an open
-# Fast Repair PR. Once a green rollup has been queued for firstmate there is
-# nothing left for it to catch, so the task is retired from the twenty-second
-# forge poll and the ordinary CHECK_INTERVAL PR poll owns it from then on.
+# The twenty-second forge poll exists to surface the first actionable transition
+# of an open Fast Repair PR. Once a green rollup has been queued for firstmate
+# there is nothing left for it to catch there, so this marker retires the task
+# from the forge poll and the ordinary CHECK_INTERVAL PR poll owns PR checks from
+# then on. The beat itself continues in local-only mode, because the broader test
+# family can still be running and its failure has no other machine-side surface.
 fast_repair_progress_green_marker() {  # <task-id>
   printf '%s/.fast-repair-progress-green-%s' "$STATE" "$1"
 }
 
-# The single owner of which tasks the Fast Repair progress cadence still works
-# on: durable metadata says eligible, and no green rollup has been surfaced yet.
-# Every consumer below - the activity flag, the missing-schedule repair, the
-# timer delay, and the tick itself - reads this one emitter, so the rule and the
-# id derivation have one place to change.
+fast_repair_progress_forge_retired() {  # <task-id>
+  [ -e "$(fast_repair_progress_green_marker "$1")" ]
+}
+
+# The single owner of which tasks the Fast Repair progress cadence works on:
+# durable metadata says eligible. Every consumer below - the activity flag, the
+# missing-schedule repair, the timer delay, and the tick itself - reads this one
+# emitter, so the rule and the id derivation have one place to change.
 fast_repair_progress_task_ids() {
-  local meta id
+  local meta
   for meta in "$STATE"/*.meta; do
     [ -e "$meta" ] || continue
     fast_repair_eligible_meta "$meta" || continue
-    id=$(basename "$meta" .meta)
-    [ -e "$(fast_repair_progress_green_marker "$id")" ] && continue
-    printf '%s\n' "$id"
+    basename "$meta" .meta
   done
   return 0
+}
+
+# A durable handoff already waiting to be drained. The wait entry points consult
+# this after publishing their interruptible pid, which closes the window between
+# forking a wait and making it reachable by fast_repair_progress_timer_notify.
+fast_repair_progress_handoff_pending() {
+  local file
+  for file in "$STATE"/.fast-repair-progress-handoff-*; do
+    [ -f "$file" ] && [ ! -L "$file" ] || continue
+    return 0
+  done
+  return 1
+}
+
+fast_repair_progress_surfaced_marker() {  # <task-id>
+  printf '%s/.fast-repair-progress-%s' "$STATE" "$1"
+}
+
+# A result byte-identical to the one already surfaced carries no transition, so
+# publishing it would tear the watcher out of its wait for nothing. The marker is
+# written only after the durable wake is queued, so a failed enqueue still leaves
+# the result unmarked and the next beat replays it.
+fast_repair_progress_result_is_new() {  # <task-id> <result>
+  [ "$(cat "$(fast_repair_progress_surfaced_marker "$1")" 2>/dev/null || true)" != "$2" ]
 }
 
 # Fast Repair has a short, task-scoped progress cadence for broader-test and PR
@@ -626,7 +653,7 @@ fast_repair_progress_timer_delay() {  # [<generation>]
 
 fast_repair_progress_record() {
   local id=$1 result=$2 generation=${3:-} marker generation_marker prior prior_generation
-  marker="$STATE/.fast-repair-progress-$id"
+  marker=$(fast_repair_progress_surfaced_marker "$id")
   generation_marker="$STATE/.fast-repair-progress-generation-$id"
   if [ -n "$generation" ]; then
     case "$generation" in *[!0-9]*|'') return 3 ;; esac
@@ -693,9 +720,11 @@ fast_repair_progress_timer_tasks_finish() { # <generation>
 
 fast_repair_progress_task_start() { # <task-id> <generation>
   local id=$1 generation=$2 marker ready reservation result now closing=${FM_FAST_REPAIR_TIMER_CLOSING:-} lifecycle pid tmp
+  local progress_args=(progress "$id")
   [ -z "$closing" ] || [ ! -e "$closing" ] || return 0
   marker=$(fast_repair_progress_task_marker "$id" "$generation") || return 1
   lifecycle=$(fast_repair_progress_lifecycle "$id") || return 1
+  ! fast_repair_progress_forge_retired "$id" || progress_args+=(--local-only)
   ready="$marker.ready"
   reservation="$marker.starting"
   if [ -f "$marker" ] && [ ! -L "$marker" ]; then
@@ -722,13 +751,15 @@ fast_repair_progress_task_start() { # <task-id> <generation>
     [ ! -e "$reservation.closing" ] || exit 0
     [ -z "$closing" ] || [ ! -e "$closing" ] || exit 0
     if FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
-      run_check_capture --stop-active-check-on-signal "$SCRIPT_DIR/fm-fast-repair.sh" progress "$id"; then
+      run_check_capture --stop-active-check-on-signal "$SCRIPT_DIR/fm-fast-repair.sh" "${progress_args[@]}"; then
       result=$FM_CHECK_RESULT
     else
       result=
     fi
     now=$(date +%s) && fast_repair_progress_due_set "$id" "$((now + FAST_REPAIR_PROGRESS_INTERVAL))"
-    [ -z "$result" ] || FM_FAST_REPAIR_TASK_LIFECYCLE="$lifecycle" fast_repair_progress_timer_publish "$id" "$result"
+    if [ -n "$result" ] && fast_repair_progress_result_is_new "$id" "$result"; then
+      FM_FAST_REPAIR_TASK_LIFECYCLE="$lifecycle" fast_repair_progress_timer_publish "$id" "$result"
+    fi
   ) &
   pid=$!
   if [ -e "$reservation.closing" ]; then
@@ -754,13 +785,17 @@ fast_repair_progress_task_start() { # <task-id> <generation>
 
 # One tick collects the eligible ids once and reuses that list for both the
 # activity flag and the work. The next due time is deliberately NOT advanced
-# here: the child that actually reaches the forge advances it once its check
+# here: the child that actually runs the check advances it once that check
 # completes. A child reaped at a poll boundary therefore leaves the due time
 # behind it, so the beat is retried on the next tick instead of being silently
-# skipped for a whole interval, and against a persistently slow forge the
-# cadence keeps trying rather than starving.
+# skipped for a whole interval. That is a retry guarantee, not a delivery one: a
+# forge call slower than the remaining poll window is reaped before it can
+# publish on every attempt, so a persistently slow forge still surfaces nothing
+# through this cadence and the ordinary CHECK_INTERVAL PR poll remains the
+# backstop. A start that fails before forking re-arms the due at the normal
+# interval, so it retries on the cadence instead of spinning the timer loop.
 fast_repair_progress_tick() {
-  local id due generation
+  local id due generation now
   local ids=()
   while IFS= read -r id; do
     [ -n "$id" ] || continue
@@ -778,7 +813,9 @@ fast_repair_progress_tick() {
     [ "$due" -eq 0 ] || continue
     fast_repair_progress_task_running "$id" "$generation" && continue
     touch "$STATE/.last-fast-repair-progress-$id"
-    fast_repair_progress_task_start "$id" "$generation"
+    if ! fast_repair_progress_task_start "$id" "$generation"; then
+      now=$(date +%s) && fast_repair_progress_due_set "$id" "$((now + FAST_REPAIR_PROGRESS_INTERVAL))"
+    fi
   done
   return 0
 }
@@ -1052,6 +1089,11 @@ fast_repair_progress_timer_start() {
 
 fast_repair_progress_timer_finish() {
   local marker=${FAST_REPAIR_TIMER_MARKER:-} pid=${FAST_REPAIR_TIMER_PID:-} generation=${FAST_REPAIR_TIMER_GENERATION:-} wait_file=${FAST_REPAIR_TIMER_WAIT_FILE:-} i=0
+  # Runs first and unconditionally: a watcher signalled while blocked in `wait`
+  # reaches here through its EXIT trap with the forked backend wait still live,
+  # and that wait's own reader keeps mutating this home's transition state until
+  # its budget expires. Nothing else knows the group.
+  fast_repair_progress_wait_cleanup
   [ -n "$marker" ] || return 0
   : > "$marker.closing" || return 0
   rm -f "$marker"
@@ -1071,8 +1113,12 @@ fast_repair_progress_timer_finish() {
   FAST_REPAIR_TIMER_WAIT_FILE=
 }
 
+FAST_REPAIR_WAIT_PID=
+FAST_REPAIR_WAIT_OUTPUT=
+
 fast_repair_progress_timer_wait_pid_publish() { # <pid>
   local wait_file=${FAST_REPAIR_TIMER_WAIT_FILE:-} pid=$1 tmp
+  FAST_REPAIR_WAIT_PID=$pid
   [ -n "$wait_file" ] || return 1
   tmp=$(mktemp "$wait_file.XXXXXX") || return 1
   if ! printf '%s\n' "$pid" > "$tmp" || ! chmod 600 "$tmp" || ! mv -f "$tmp" "$wait_file"; then
@@ -1083,8 +1129,41 @@ fast_repair_progress_timer_wait_pid_publish() { # <pid>
 
 fast_repair_progress_timer_wait_pid_clear() {
   local wait_file=${FAST_REPAIR_TIMER_WAIT_FILE:-}
+  FAST_REPAIR_WAIT_PID=
   [ -n "$wait_file" ] || return 0
   rm -f "$wait_file"
+}
+
+# Stop whatever interruptible wait is still live. Safe to call when none is
+# running, and idempotent. The group form is what reaches a backend event reader
+# forked inside the wait, and is used only once the recorded pid is proven to be
+# its own group leader.
+fast_repair_progress_wait_stop() {
+  local pid=${FAST_REPAIR_WAIT_PID:-} pgid
+  [ -n "$pid" ] || return 0
+  pgid=$(ps -o pgid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
+  if [ -n "$pgid" ] && [ "$pgid" = "$pid" ]; then
+    kill -TERM -- "-$pid" 2>/dev/null || true
+  fi
+  kill -TERM "$pid" 2>/dev/null || true
+  FAST_REPAIR_WAIT_PID=
+}
+
+# Teardown form: stop the wait and drop the capture file the interrupted wait
+# never got to read, so a stopped watcher leaves no .fm-event-wait.* behind.
+fast_repair_progress_wait_cleanup() {
+  fast_repair_progress_wait_stop
+  [ -z "${FAST_REPAIR_WAIT_OUTPUT:-}" ] || rm -f "$FAST_REPAIR_WAIT_OUTPUT"
+  FAST_REPAIR_WAIT_OUTPUT=
+}
+
+# A handoff published between forking a wait and making that wait reachable by
+# fast_repair_progress_timer_notify would otherwise sit undelivered for the whole
+# poll budget - the exact delay this cadence exists to remove. Re-scan once the
+# pid is published and interrupt immediately if one is already waiting.
+fast_repair_progress_wait_interrupt_if_pending() {
+  fast_repair_progress_handoff_pending || return 0
+  fast_repair_progress_wait_stop
 }
 
 fast_repair_progress_timer_sleep() { # <seconds>
@@ -1096,8 +1175,10 @@ fast_repair_progress_timer_sleep() { # <seconds>
   set +m
   if ! fast_repair_progress_timer_wait_pid_publish "$pid"; then
     wait "$pid" || true
+    FAST_REPAIR_WAIT_PID=
     return
   fi
+  fast_repair_progress_wait_interrupt_if_pending
   wait "$pid" || true
   fast_repair_progress_timer_wait_pid_clear
 }
@@ -1116,15 +1197,21 @@ fast_repair_progress_timer_wait_transition() { # <backend> <session> <budget> <s
   FM_EVENT_WAIT_RECORD=
   out=$(mktemp "$STATE/.fm-event-wait.XXXXXX") || return 2
   chmod 0600 "$out" || { rm -f "$out"; return 2; }
+  # Registered before the fork so a signalled teardown still removes it, and the
+  # backend's own stderr stays on the watcher's stderr exactly as it does on the
+  # unforked path, so a socket or subscribe diagnostic is reported identically.
+  FAST_REPAIR_WAIT_OUTPUT=$out
   set -m
-  ( FM_BACKEND_EVENTS_CAPABILITY_CONFIRMED=1 fm_backend_wait_transition "$@" ) > "$out" 2>/dev/null &
+  ( FM_BACKEND_EVENTS_CAPABILITY_CONFIRMED=1 fm_backend_wait_transition "$@" ) > "$out" &
   pid=$!
   set +m
   fast_repair_progress_timer_wait_pid_publish "$pid" || true
+  fast_repair_progress_wait_interrupt_if_pending
   wait "$pid" || rc=$?
   fast_repair_progress_timer_wait_pid_clear
   FM_EVENT_WAIT_RECORD=$(cat "$out" 2>/dev/null || true)
   rm -f "$out"
+  FAST_REPAIR_WAIT_OUTPUT=
   return "$rc"
 }
 

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -468,6 +468,7 @@ scan_signals() {
 FAST_REPAIR_ACTIVE=0
 FAST_REPAIR_TIMER_PID=
 FAST_REPAIR_TIMER_MARKER=
+FAST_REPAIR_TIMER_GENERATION=0
 
 # The one place that decides whether durable task metadata opts a task into Fast
 # Repair. One tick collects the eligible ids with it once and reuses that list
@@ -502,8 +503,18 @@ fast_repair_progress_discover() {
   done
 }
 
+fast_repair_progress_record() {
+  local id=$1 result=$2 marker prior
+  marker="$STATE/.fast-repair-progress-$id"
+  prior=$(cat "$marker" 2>/dev/null || true)
+  [ "$prior" = "$result" ] && return 1
+  fm_wake_append check "fast-repair:$id" "check: $result" || return 2
+  printf '%s' "$result" > "$marker"
+  touch "$STATE/.last-fast-repair-progress"
+}
+
 fast_repair_progress_tick() {
-  local meta id result marker prior
+  local meta id result progress_stamp
   local ids=()
   for meta in "$STATE"/*.meta; do
     [ -e "$meta" ] || continue
@@ -515,59 +526,45 @@ fast_repair_progress_tick() {
     return 0
   fi
   FAST_REPAIR_ACTIVE=1
-  [ "$(age_of "$STATE/.last-fast-repair-progress")" -ge "$FAST_REPAIR_PROGRESS_INTERVAL" ] || return 0
+  progress_stamp="$STATE/.last-fast-repair-progress"
+  if [ -n "${FM_FAST_REPAIR_TIMER_GENERATION:-}" ]; then
+    progress_stamp="$progress_stamp-$FM_FAST_REPAIR_TIMER_GENERATION"
+  fi
+  [ "$(age_of "$progress_stamp")" -ge "$FAST_REPAIR_PROGRESS_INTERVAL" ] || return 0
   for id in "${ids[@]}"; do
     FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
       run_check_capture "$SCRIPT_DIR/fm-fast-repair.sh" progress "$id" || exit 1
     result=$FM_CHECK_RESULT
     [ -n "$result" ] || continue
-    marker="$STATE/.fast-repair-progress-$id"
-    prior=$(cat "$marker" 2>/dev/null || true)
-    [ "$prior" = "$result" ] && continue
-    fm_wake_append check "fast-repair:$id" "check: $result" || exit 1
-    printf '%s' "$result" > "$marker"
-    touch "$STATE/.last-fast-repair-progress"
     if [ -n "${FM_FAST_REPAIR_TIMER_PARENT:-}" ]; then
-      fast_repair_progress_timer_publish "$result"
+      fast_repair_progress_timer_publish "$id" "$result"
       return 0
     fi
+    fast_repair_progress_record "$id" "$result" || continue
     wake "check: $result"
   done
-  touch "$STATE/.last-fast-repair-progress"
-}
-
-fast_repair_progress_timer_deliver() {
-  local result=$1 parent=${FM_FAST_REPAIR_TIMER_PARENT:-}
-  [ -n "$parent" ] || return 1
-  [ "$(cat "$WATCH_LOCK/pid" 2>/dev/null || true)" = "$parent" ] || return 1
-  wake "check: $result"
+  touch "$progress_stamp"
 }
 
 fast_repair_progress_timer_publish() {
-  local result=$1 lock=${FM_FAST_REPAIR_TIMER_HANDOFF_LOCK:-}
-  local closing=${FM_FAST_REPAIR_TIMER_CLOSING:-} wake_file="$STATE/.fast-repair-progress-wake"
-  [ -n "$lock" ] && [ -n "$closing" ] || {
-    printf '%s' "$result" > "$wake_file"
-    return 0
-  }
-  fm_lock_acquire_wait "$lock"
-  if [ -f "$closing" ]; then
-    fm_lock_release "$lock"
-    fast_repair_progress_timer_deliver "$result"
-    return
+  local id=$1 result=$2 generation=${FM_FAST_REPAIR_TIMER_GENERATION:-}
+  local parent=${FM_FAST_REPAIR_TIMER_PARENT:-} closing=${FM_FAST_REPAIR_TIMER_CLOSING:-}
+  local file tmp
+  case "$generation:$parent" in *[!0-9:]*|:*|*:) return 1 ;; esac
+  case "$id:$result" in *$'\n'*|*$'\r'*) return 1 ;; esac
+  file="$STATE/.fast-repair-progress-handoff-$parent-$generation"
+  tmp=$(mktemp "$file.XXXXXX") || return 1
+  if ! {
+    printf '%s\n' "$generation"
+    printf '%s\n' "$id"
+    printf '%s\n' "$result"
+  } > "$tmp" || ! chmod 600 "$tmp" || ! mv -f "$tmp" "$file"; then
+    rm -f "$tmp"
+    return 1
   fi
-  printf '%s' "$result" > "$wake_file"
-  fm_lock_release "$lock"
+  FAST_REPAIR_TIMER_RESULT_PUBLISHED=1
   [ -f "$closing" ] || return 0
-  if fm_lock_try_acquire "$lock"; then
-    if [ -f "$wake_file" ]; then
-      rm -f "$wake_file"
-      fm_lock_release "$lock"
-      fast_repair_progress_timer_deliver "$result"
-      return
-    fi
-    fm_lock_release "$lock"
-  fi
+  kill -USR1 "$parent" 2>/dev/null || true
 }
 
 # Deliver a durably queued process-event result to firstmate. Publication is
@@ -734,14 +731,14 @@ heartbeat_scan_finds_actionable() {
 }
 
 fast_repair_progress_timer_start() {
-  local marker remaining parent closing lock
+  local marker remaining parent closing generation
   [ "$FAST_REPAIR_ACTIVE" = 1 ] || return 0
   case "$POLL:$FAST_REPAIR_PROGRESS_INTERVAL" in *[!0-9:]*|:*|*:) return 0 ;; esac
+  FAST_REPAIR_TIMER_GENERATION=$((FAST_REPAIR_TIMER_GENERATION + 1))
+  generation=$FAST_REPAIR_TIMER_GENERATION
   marker=$(mktemp "$STATE/.fast-repair-progress-timer.XXXXXX") || return 0
   closing="$marker.closing"
-  lock="$marker.handoff.lock"
   FAST_REPAIR_TIMER_MARKER=$marker
-  FAST_REPAIR_TIMER_HANDOFF_LOCK=
   parent=$WATCHER_PID
   (
     trap 'rm -f "$closing"' EXIT
@@ -752,10 +749,12 @@ fast_repair_progress_timer_start() {
       sleep $((remaining + 1))
       [ -f "$marker" ] || exit 0
       [ "$(cat "$WATCH_LOCK/pid" 2>/dev/null || true)" = "$parent" ] || exit 0
+      FAST_REPAIR_TIMER_RESULT_PUBLISHED=0
       FM_FAST_REPAIR_TIMER_PARENT="$parent" \
         FM_FAST_REPAIR_TIMER_CLOSING="$closing" \
-        FM_FAST_REPAIR_TIMER_HANDOFF_LOCK="$lock" \
+        FM_FAST_REPAIR_TIMER_GENERATION="$generation" \
         fast_repair_progress_tick
+      [ "$FAST_REPAIR_TIMER_RESULT_PUBLISHED" = 1 ] && exit 0
       [ "$FAST_REPAIR_ACTIVE" = 1 ] || rm -f "$marker"
     done
   ) &
@@ -767,23 +766,29 @@ fast_repair_progress_timer_finish() {
   [ -n "$marker" ] || return 0
   : > "$marker.closing" || return 0
   rm -f "$marker"
-  FAST_REPAIR_TIMER_HANDOFF_LOCK="$marker.handoff.lock"
   FAST_REPAIR_TIMER_MARKER=
 }
 
 fast_repair_progress_timer_wake() {
-  local result lock=${FAST_REPAIR_TIMER_HANDOFF_LOCK:-} wake_file="$STATE/.fast-repair-progress-wake"
-  if [ -n "$lock" ]; then
-    fm_lock_try_acquire "$lock" || return 0
-  fi
-  [ -f "$wake_file" ] || {
-    [ -z "$lock" ] || fm_lock_release "$lock"
+  local file generation id result extra watcher=${WATCHER_PID:-}
+  [ -n "$watcher" ] || return 0
+  generation=$FAST_REPAIR_TIMER_GENERATION
+  file="$STATE/.fast-repair-progress-handoff-$watcher-$generation"
+  [ -f "$file" ] && [ ! -L "$file" ] || return 0
+  exec 9< "$file" || return 0
+  IFS= read -r generation <&9 || { exec 9<&-; return 0; }
+  IFS= read -r id <&9 || { exec 9<&-; return 0; }
+  IFS= read -r result <&9 || { exec 9<&-; return 0; }
+  if IFS= read -r extra <&9; then
+    exec 9<&-
     return 0
-  }
-  result=$(cat "$wake_file" 2>/dev/null || true)
-  rm -f "$wake_file" || result=
-  [ -z "$lock" ] || fm_lock_release "$lock"
+  fi
+  exec 9<&-
+  [ "$generation" = "$FAST_REPAIR_TIMER_GENERATION" ] || return 0
+  fm_pr_task_id_valid "$id" || return 0
   [ -n "$result" ] || return 0
+  rm -f "$file" || return 0
+  fast_repair_progress_record "$id" "$result" || return 0
   wake "check: $result"
 }
 
@@ -940,6 +945,7 @@ watcher_cleanup() {
 }
 trap watcher_cleanup EXIT
 trap 'exit 1' HUP INT TERM
+trap 'fast_repair_progress_timer_wake' USR1
 # This watcher's own pid, as recorded in the lock by fm_lock_claim (which writes
 # ${BASHPID:-$$} from this same main shell). Read directly, never via a command
 # substitution, so it matches the stored holder pid for the self-eviction check.

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -62,6 +62,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 mkdir -p "$STATE"
 
 # The native event fast-path and only its true dependencies have one narrow
@@ -117,6 +118,7 @@ HEARTBEAT=${FM_HEARTBEAT:-600}        # base seconds between heartbeat scans
 HEARTBEAT_MAX=${FM_HEARTBEAT_MAX:-7200}  # heartbeat backoff cap
 CHECK_INTERVAL=${FM_CHECK_INTERVAL:-300}  # seconds between *.check.sh sweeps
 CHECK_TIMEOUT=${FM_CHECK_TIMEOUT:-30}     # seconds allowed per *.check.sh
+FAST_REPAIR_PROGRESS_INTERVAL=${FM_FAST_REPAIR_PROGRESS_INTERVAL:-20} # Fast Repair only
 SIGNAL_GRACE=${FM_SIGNAL_GRACE:-30}   # seconds to linger after a signal so trailing
                                       # signals (a status write, then the same turn's
                                       # turn-end hook) coalesce into one wake
@@ -461,6 +463,42 @@ scan_signals() {
     fi
   done
   return 0
+}
+
+# Fast Repair has a short, task-scoped progress cadence for broader-test and PR
+# check results. It is inert, byte-for-byte, when no durable task metadata says
+# mode=fast-repair and fast_repair=eligible. It does not change the normal signal,
+# stale, custom-check, heartbeat, or sleep cadence, and it never starts another
+# watcher. Each actionable result is deduplicated per task so an unchanged failed
+# PR check cannot wake firstmate every twenty seconds.
+fast_repair_progress_tick() {
+  local meta id result marker prior active=0
+  for meta in "$STATE"/*.meta; do
+    [ -e "$meta" ] || continue
+    grep -qx 'mode=fast-repair' "$meta" 2>/dev/null || continue
+    grep -qx 'fast_repair=eligible' "$meta" 2>/dev/null || continue
+    active=1
+    break
+  done
+  [ "$active" -eq 1 ] || return 0
+  [ "$(age_of "$STATE/.last-fast-repair-progress")" -ge "$FAST_REPAIR_PROGRESS_INTERVAL" ] || return 0
+  for meta in "$STATE"/*.meta; do
+    [ -e "$meta" ] || continue
+    grep -qx 'mode=fast-repair' "$meta" 2>/dev/null || continue
+    grep -qx 'fast_repair=eligible' "$meta" 2>/dev/null || continue
+    id=$(basename "$meta" .meta)
+    result=$(FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
+      "$SCRIPT_DIR/fm-fast-repair.sh" progress "$id" 2>/dev/null || true)
+    [ -n "$result" ] || continue
+    marker="$STATE/.fast-repair-progress-$id"
+    prior=$(cat "$marker" 2>/dev/null || true)
+    [ "$prior" = "$result" ] && continue
+    printf '%s' "$result" > "$marker"
+    touch "$STATE/.last-fast-repair-progress"
+    fm_wake_append check "fast-repair:$id" "check: $result" || exit 1
+    wake "check: $result"
+  done
+  touch "$STATE/.last-fast-repair-progress"
 }
 
 # Deliver a durably queued process-event result to firstmate. Publication is
@@ -840,6 +878,10 @@ while :; do
   # repost after grace, and escalate once if the recovery turn is also missed.
   # No conversation scraping; unresolved records are never silently expired.
   fm_pending_reply_tick "$STATE" || true
+
+  # This is the only shortened cadence. It reads only durable Fast Repair task
+  # records and leaves ordinary task scanning and schedules untouched.
+  fast_repair_progress_tick
 
   # Process-to-event liveness repair. This never discovers a result by polling:
   # each registered source has its own child blocking on that source, and this

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -526,6 +526,17 @@ fast_repair_eligible_task() {
   [ -f "$meta" ] && [ ! -L "$meta" ] && fast_repair_eligible_meta "$meta"
 }
 
+fast_repair_progress_lifecycle() {
+  local f="$DATA/$1/fast-repair-eligibility" lifecycle
+  if [ -f "$f" ] && [ ! -L "$f" ]; then
+    lifecycle=$(sed -n 's/^lifecycle=//p' "$f" | head -n 1)
+    case "$lifecycle" in ?*[!A-Za-z0-9._-]*|'') return 1 ;; esac
+    printf '%s\n' "$lifecycle"
+    return 0
+  fi
+  printf '%s\n' legacy
+}
+
 fast_repair_progress_due_path() {
   printf '%s/.fast-repair-progress-next-due-%s' "$STATE" "$1"
 }
@@ -644,9 +655,10 @@ fast_repair_progress_timer_tasks_finish() { # <generation>
 }
 
 fast_repair_progress_task_start() { # <task-id> <generation>
-  local id=$1 generation=$2 marker ready reservation result closing=${FM_FAST_REPAIR_TIMER_CLOSING:-} pid tmp
+  local id=$1 generation=$2 marker ready reservation result closing=${FM_FAST_REPAIR_TIMER_CLOSING:-} lifecycle pid tmp
   [ -z "$closing" ] || [ ! -e "$closing" ] || return 0
   marker=$(fast_repair_progress_task_marker "$id" "$generation") || return 1
+  lifecycle=$(fast_repair_progress_lifecycle "$id") || return 1
   ready="$marker.ready"
   reservation="$marker.starting"
   if [ -f "$marker" ] && [ ! -L "$marker" ]; then
@@ -657,6 +669,10 @@ fast_repair_progress_task_start() { # <task-id> <generation>
   if ! chmod 600 "$tmp" || ! mv -f "$tmp" "$reservation"; then
     rm -f "$tmp"
     return 1
+  fi
+  if [ -e "$reservation.closing" ] || { [ -n "$closing" ] && [ -e "$closing" ]; }; then
+    rm -f "$reservation"
+    return 0
   fi
   touch "$STATE/.last-fast-repair-progress-$id"
   (
@@ -671,7 +687,7 @@ fast_repair_progress_task_start() { # <task-id> <generation>
     FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
       run_check_capture --stop-active-check-on-signal "$SCRIPT_DIR/fm-fast-repair.sh" progress "$id" || exit 1
     result=$FM_CHECK_RESULT
-    [ -z "$result" ] || fast_repair_progress_timer_publish "$id" "$result"
+    [ -z "$result" ] || FM_FAST_REPAIR_TASK_LIFECYCLE="$lifecycle" fast_repair_progress_timer_publish "$id" "$result"
   ) &
   pid=$!
   if [ -e "$reservation.closing" ]; then
@@ -722,10 +738,12 @@ fast_repair_progress_tick() {
 
 fast_repair_progress_timer_publish() {
   local id=$1 result=$2 generation=${FM_FAST_REPAIR_TIMER_GENERATION:-}
-  local file tmp lock counter current next
+  local file tmp lock counter current next lifecycle
   case "$generation" in *[!0-9]*|'') return 1 ;; esac
   case "$id:$result" in *$'\n'*|*$'\r'*) return 1 ;; esac
   fm_pr_task_id_valid "$id" || return 1
+  lifecycle=${FM_FAST_REPAIR_TASK_LIFECYCLE:-$(fast_repair_progress_lifecycle "$id")} || return 1
+  case "$lifecycle" in ?*[!A-Za-z0-9._-]*|'') return 1 ;; esac
   lock="$STATE/.fast-repair-progress-sequence-$id-$generation.lock"
   counter="$STATE/.fast-repair-progress-sequence-$id-$generation"
   fm_lock_acquire_wait "$lock" || return 1
@@ -735,6 +753,7 @@ fast_repair_progress_timer_publish() {
   tmp=$(mktemp "$STATE/.fast-repair-progress-pending.XXXXXX") || { fm_lock_release "$lock"; return 1; }
   file=$(printf '%s/.fast-repair-progress-handoff-%s-%s-%020d' "$STATE" "$id" "$generation" "$next")
   if ! {
+    printf '%s\n' "$lifecycle"
     printf '%s\n' "$generation"
     printf '%s\n' "$id"
     printf '%s\n' "$result"
@@ -972,11 +991,17 @@ fast_repair_progress_timer_finish() {
 }
 
 fast_repair_progress_timer_wake() {
-  local file generation id result extra status reasons=
+  local file lifecycle current_lifecycle generation id result extra status reasons=
   for file in "$STATE"/.fast-repair-progress-handoff-*; do
     [ -f "$file" ] && [ ! -L "$file" ] || continue
     exec 9< "$file" || continue
-    IFS= read -r generation <&9 || { exec 9<&-; continue; }
+    IFS= read -r lifecycle <&9 || { exec 9<&-; continue; }
+    if [[ "$lifecycle" =~ ^[0-9]+$ ]]; then
+      generation=$lifecycle
+      lifecycle=legacy
+    else
+      IFS= read -r generation <&9 || { exec 9<&-; continue; }
+    fi
     IFS= read -r id <&9 || { exec 9<&-; continue; }
     IFS= read -r result <&9 || { exec 9<&-; continue; }
     if IFS= read -r extra <&9; then
@@ -988,6 +1013,11 @@ fast_repair_progress_timer_wake() {
     case "$result" in ''|*$'\n'*|*$'\r'*) continue ;; esac
     fm_pr_task_id_valid "$id" || continue
     if ! fast_repair_eligible_task "$id"; then
+      rm -f "$file" || continue
+      continue
+    fi
+    current_lifecycle=$(fast_repair_progress_lifecycle "$id" 2>/dev/null || true)
+    if [ "$lifecycle" != "$current_lifecycle" ]; then
       rm -f "$file" || continue
       continue
     fi

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -61,6 +61,7 @@ It is not deterministic across the verified adapters: codex and grok resume only
    A ship or scout keeps the harness already recorded for it, because that harness comes from firstmate's dispatch-profile judgment at intake and must not be silently re-read from configuration.
    A recorded raw-command basename that differs from its resolved adapter cannot reproduce the command actually running, so relaunch refuses before the checkpoint unless the caller passes an explicit `--harness` to choose the replacement runtime deliberately.
    A harness change resets model and effort unless they are named too, because a model chosen for one adapter does not transfer to another.
+   A `mode=fast-repair` ship also keeps its recorded model and effort, because that profile is part of its delivery contract rather than a default to re-resolve ([fast-repair.md](fast-repair.md)).
 2. **Safe checkpoint.**
    The recorded worktree must exist and be a worktree root; its head and dirty state are recorded.
    For a `kind=secondmate` task, the home's identity marker must match and its child records must be readable, so a relaunch can never strand child work behind an unreadable home.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -228,6 +228,7 @@ The `data/secondmates.md` line contract is owned by the [`secondmate-provisionin
 ## Delivery modes are explicit per task
 
 `no-mistakes` tasks run the full validation pipeline, `direct-PR` tasks open PRs without that pipeline, and `local-only` tasks stay local until firstmate performs an approved fast-forward merge.
+[`fast-repair.md`](fast-repair.md) owns the strict opt-in per-task Fast Repair exception and its typed evidence, dedicated launch profile, early-PR gate, progress cadence, and captain-only merge authority.
 Each task's mode and `yolo` posture are firstmate's decision at intake and are passed explicitly to `bin/fm-brief.sh`, `bin/fm-spawn.sh`, and `bin/fm-promote.sh`, which refuse a ship task that does not carry them.
 A ship brief records its mode as a fixed machine-readable line and the spawn refuses to launch on a different one, so the worker's instructions and the recorded task delivery cannot diverge.
 `data/projects.md` records each project's standing posture and optional `+yolo` flag as the captain's default and as context for that decision, including the conditional `no-mistakes-prod-only` policy; a ship spawn that drops below the registered rigor prints a deviation notice and continues.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -524,6 +524,7 @@ FM_HEARTBEAT=600        # base seconds between heartbeat scans; no-change heartb
 FM_HEARTBEAT_MAX=7200   # heartbeat backoff cap
 FM_CHECK_INTERVAL=300   # seconds between slow checks (authenticated merge polls, custom checks, or Relay dispatch)
 FM_CHECK_TIMEOUT=30     # seconds allowed per slow check script
+FM_FAST_REPAIR_PROGRESS_INTERVAL=20   # seconds between Fast Repair progress beats; runs only while a task records an eligible Fast Repair (docs/fast-repair.md)
 FM_PROCEVENT_MAX_OUTPUT_BYTES=1048576   # bound on one captured process-to-event result
 FM_PROCEVENT_CLAIM_ROOT=                # machine-wide source claim root; default $XDG_STATE_HOME/firstmate/procevent-claims
 FM_CODEX_WATCH_CHECKPOINT=180   # seconds per foreground watcher checkpoint in Codex primary supervision

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -209,6 +209,10 @@
       "audience": "maintainer-architecture"
     },
     {
+      "path": "docs/fast-repair.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/architecture.md",
       "audience": "maintainer-architecture"
     },

--- a/docs/fast-repair.md
+++ b/docs/fast-repair.md
@@ -58,9 +58,13 @@ The worker then starts the broader test command while the new PR's checks run co
 Broader-test failures are recorded and surfaced as an open PR that is not green.
 The Fast Repair progress check also surfaces failed PR checks.
 A PR is not called ready or green until the broader test and all required PR checks pass.
+`ready` prints the exact check counts it approved on.
+A rollup where no check passed is never green, because the forge reports a cancelled check as a skipped one.
 
 The Fast Repair progress check runs about every 20 seconds only while durable task metadata records an eligible Fast Repair task.
+While such a task exists, the supervision cycle waits only until that task's next check is due, so the ordinary poll interval cannot stretch this cadence.
 It does not change ordinary task polling, stale handling, watcher behavior, or global defaults.
+A relaunch of a Fast Repair task reuses the recorded profile, so the standard recovery command needs no profile flags.
 
 ## Examples
 

--- a/docs/fast-repair.md
+++ b/docs/fast-repair.md
@@ -41,6 +41,7 @@ An absent, empty, unknown, ambiguous, false, or otherwise different value refuse
 Agent confidence is not evidence.
 The refusal names the condition that was not proven, and the request returns to normal intake with the project's existing delivery rules.
 An eligible Fast Repair does not create a scout or add plan, design, CEO, engineering, or other review workflows.
+A scout cannot be promoted into Fast Repair either, because eligibility needs a known end-user reproduction and its typed record at normal intake.
 
 The exact typed interface and evidence record are owned by `bin/fm-fast-repair.sh --help`.
 
@@ -54,7 +55,7 @@ Fast Repair never enables auto-merge.
 
 The repair must add a regression test that reproduces the defect and must pass focused module tests.
 `bin/fm-fast-repair.sh evidence` executes and records both gates.
-The only supported interface is the tracked `bin/fm-test-run.sh` runner and distinct families from its `--list-families` output: the regression family, the focused family, and later a third broader family.
+The only supported interface is the tracked `bin/fm-test-run.sh` runner and named families from its `--list-families` output: the regression family, a different focused family, and later a broader family.
 The recorded pre-fix reproduction commit must be an ancestor of the tested head.
 Fast Repair identifies exactly one new test artifact from the regression family's runner-owned selector, overlays that artifact onto an isolated reproduction checkout, and requires that selected artifact to fail there and pass at the tested head.
 The evidence record binds the selector, test artifact identity, reproduction revision, tested revision, and both results.

--- a/docs/fast-repair.md
+++ b/docs/fast-repair.md
@@ -48,6 +48,7 @@ The exact typed interface and evidence record are owned by `bin/fm-fast-repair.s
 
 Eligible work uses the built-in Codex profile `gpt-5.6-luna` with `medium` effort.
 An explicit conflicting task profile refuses instead of being replaced.
+A raw launch command also refuses because it cannot prove that canonical profile.
 The task always has `yolo=off`, so captain approval remains the only merge authority.
 Fast Repair never enables auto-merge.
 

--- a/docs/fast-repair.md
+++ b/docs/fast-repair.md
@@ -52,9 +52,11 @@ A raw launch command also refuses because it cannot prove that canonical profile
 The task always has `yolo=off`, so captain approval remains the only merge authority.
 Fast Repair never enables auto-merge.
 
-The repair must add an executable regression test that reproduces the defect and must pass focused module tests.
+The repair must add a regression test that reproduces the defect and must pass focused module tests.
 `bin/fm-fast-repair.sh evidence` executes and records both gates.
-Its `--regression-test` value is a relative executable test-file path, which the helper runs directly.
+The only supported interface is the tracked `bin/fm-test-run.sh` runner.
+Its selectors must be distinct, unchanged paths in the tested commit: `tests/<name>-regression.test.sh` and `tests/<name>-focused.test.sh`.
+Projects without this runner or these selectors refuse Fast Repair evidence.
 Missing or failed evidence blocks direct PR publication.
 
 After those gates pass, `bin/fm-fast-repair.sh publish-pr` opens and registers the direct PR immediately.

--- a/docs/fast-repair.md
+++ b/docs/fast-repair.md
@@ -85,6 +85,8 @@ A progress check that is stopped at a poll boundary keeps its due time, so the b
 That is a retry guarantee, not a delivery one: a forge call slower than the remaining poll window is reaped before it can publish, and the ordinary PR check poll stays the backstop.
 Once the first green rollup is queued the cadence stops polling the forge for that task, and the ordinary PR check poll owns its PR checks from then on.
 The task-scoped beat continues in a local-only form that reads only this home's own broader-test record, so a broader failure landing after the rollup turned green is still surfaced.
+That local follow-up ends once the broader family reaches its terminal result and that result is surfaced; the beat then retires entirely and the ordinary lifecycle and PR polling own the task.
+A progress result the wake queue refuses stays on disk for a later cycle to retry, but it stops shortening waits after its bounded attempt budget, so a degraded queue cannot turn every watcher wait into a zero-length one.
 A relaunch of a Fast Repair task reuses the recorded profile, so the standard recovery command needs no profile flags.
 
 ## Examples

--- a/docs/fast-repair.md
+++ b/docs/fast-repair.md
@@ -25,6 +25,8 @@ Fast Repair requires typed evidence for all of these positive facts:
 - A confirmed root cause.
 - A narrow, isolated code change.
 
+The intake values are exact: `--reproduction reproduced`, `--root-cause confirmed`, and `--isolation isolated`.
+
 It also requires each of these exclusions to be explicitly `none`:
 
 - Schema or migration change.
@@ -49,8 +51,9 @@ An explicit conflicting task profile refuses instead of being replaced.
 The task always has `yolo=off`, so captain approval remains the only merge authority.
 Fast Repair never enables auto-merge.
 
-The repair must add a regression test that reproduces the defect and must pass focused module tests.
+The repair must add an executable regression test that reproduces the defect and must pass focused module tests.
 `bin/fm-fast-repair.sh evidence` executes and records both gates.
+Its `--regression-test` value is a relative executable test-file path, which the helper runs directly.
 Missing or failed evidence blocks direct PR publication.
 
 After those gates pass, `bin/fm-fast-repair.sh publish-pr` opens and registers the direct PR immediately.
@@ -62,8 +65,7 @@ A PR is not called ready or green until the broader test and all required PR che
 A rollup where no check passed is never green, because the forge reports a cancelled check as a skipped one.
 
 The Fast Repair progress check runs about every 20 seconds only while durable task metadata records an eligible Fast Repair task.
-While such a task exists, the supervision cycle waits only until that task's next check is due, so the ordinary poll interval cannot stretch this cadence.
-It does not change ordinary task polling, stale handling, watcher behavior, or global defaults.
+The timer runs during the existing watcher wait, so it does not change ordinary task polling, stale handling, pane scans, backend capture cadence, backend transition budgets, or global defaults.
 A relaunch of a Fast Repair task reuses the recorded profile, so the standard recovery command needs no profile flags.
 
 ## Examples

--- a/docs/fast-repair.md
+++ b/docs/fast-repair.md
@@ -79,9 +79,12 @@ A rollup where no check passed is never green, because the forge reports a cance
 
 The Fast Repair progress check runs about every 20 seconds only while durable task metadata records an eligible Fast Repair task.
 The timer runs during the existing watcher wait, so it does not change ordinary task polling, stale handling, pane scans, backend capture cadence, backend transition budgets, or global defaults.
-A result found by that timer interrupts whichever wait the watcher is in, including the backend event and push-transition wait, so it reaches the captain in the cycle it was found rather than at the end of the poll budget.
+A changed result found by that timer interrupts whichever wait the watcher is in, including the backend event and push-transition wait, so it reaches the captain in the cycle it was found rather than at the end of the poll budget.
+A result identical to the one already surfaced never interrupts a wait, so an unchanged Fast Repair state costs no extra supervision cycles.
 A progress check that is stopped at a poll boundary keeps its due time, so the beat is retried on the next tick instead of being skipped for a whole interval.
-The cadence retires a task once its first green rollup is queued; from then on the ordinary PR check poll owns that PR.
+That is a retry guarantee, not a delivery one: a forge call slower than the remaining poll window is reaped before it can publish, and the ordinary PR check poll stays the backstop.
+Once the first green rollup is queued the cadence stops polling the forge for that task, and the ordinary PR check poll owns its PR checks from then on.
+The task-scoped beat continues in a local-only form that reads only this home's own broader-test record, so a broader failure landing after the rollup turned green is still surfaced.
 A relaunch of a Fast Repair task reuses the recorded profile, so the standard recovery command needs no profile flags.
 
 ## Examples

--- a/docs/fast-repair.md
+++ b/docs/fast-repair.md
@@ -64,6 +64,8 @@ Missing or failed evidence blocks direct PR publication.
 At dispatch the task worktree holds no repair yet, so the spawn gate proves only that it is a clean worktree of the task's own repository whose history already carries the recorded reproduction commit.
 That worktree is still at a detached HEAD then, because the crewmate creates its `fm/<id>` branch as its first action.
 The branch binding and the requirement that the reproduction commit be strictly older than the tested commit are proofs about the tested head, so every gate after dispatch enforces them.
+A relaunch replaces a wedged crewmate in a worktree that already holds unlanded repair work, so it skips that dispatch-time clean-worktree proof; the typed eligibility gate that runs on every Fast Repair spawn still refuses a relaunch whose authorization record is gone or no longer valid.
+The recorded reproduction revision is a lowercase commit id of 40 or 64 characters, so both git object formats are supported.
 
 After those gates pass, `bin/fm-fast-repair.sh publish-pr` opens and registers the direct PR immediately.
 The worker then starts one supported broader runner family while the new PR's checks run concurrently.

--- a/docs/fast-repair.md
+++ b/docs/fast-repair.md
@@ -1,0 +1,79 @@
+# Fast Repair
+
+Fast Repair is an opt-in, per-task delivery exception for a confirmed narrow repair.
+It does not change a project mode, its normal dispatch, its merge policy, or the handling of requests without the Fast Repair prefix.
+
+## Invoke it
+
+Use the exact request prefix `fast-repair: ` followed by the repair request.
+
+Example:
+
+```text
+fast-repair: Correct the Secretary search result count after deleting one local draft.
+```
+
+`fast-repair:` without a following request, `Fast-repair:`, `fast repair:`, and `fast-repair :` do not activate Fast Repair.
+
+The prefix requests an eligibility decision for that task only.
+
+## Eligibility
+
+Fast Repair requires typed evidence for all of these positive facts:
+
+- A known end-user reproduction.
+- A confirmed root cause.
+- A narrow, isolated code change.
+
+It also requires each of these exclusions to be explicitly `none`:
+
+- Schema or migration change.
+- Authentication change.
+- Permission or authorization change.
+- Secret handling change.
+- Financial behavior change.
+- Legal or compliance behavior change.
+- External side-effect change.
+
+An absent, empty, unknown, ambiguous, false, or otherwise different value refuses Fast Repair.
+Agent confidence is not evidence.
+The refusal names the condition that was not proven, and the request returns to normal intake with the project's existing delivery rules.
+An eligible Fast Repair does not create a scout or add plan, design, CEO, engineering, or other review workflows.
+
+The exact typed interface and evidence record are owned by `bin/fm-fast-repair.sh --help`.
+
+## Delivery
+
+Eligible work uses the built-in Codex profile `gpt-5.6-luna` with `medium` effort.
+An explicit conflicting task profile refuses instead of being replaced.
+The task always has `yolo=off`, so captain approval remains the only merge authority.
+Fast Repair never enables auto-merge.
+
+The repair must add a regression test that reproduces the defect and must pass focused module tests.
+`bin/fm-fast-repair.sh evidence` executes and records both gates.
+Missing or failed evidence blocks direct PR publication.
+
+After those gates pass, `bin/fm-fast-repair.sh publish-pr` opens and registers the direct PR immediately.
+The worker then starts the broader test command while the new PR's checks run concurrently.
+Broader-test failures are recorded and surfaced as an open PR that is not green.
+The Fast Repair progress check also surfaces failed PR checks.
+A PR is not called ready or green until the broader test and all required PR checks pass.
+
+The Fast Repair progress check runs about every 20 seconds only while durable task metadata records an eligible Fast Repair task.
+It does not change ordinary task polling, stale handling, watcher behavior, or global defaults.
+
+## Examples
+
+Eligible request:
+
+```text
+fast-repair: Fix an off-by-one count in the already reproduced Secretary deletion view; the root cause is one stale in-memory filter, the one-module patch has no schema, auth, permission, secret, financial, legal, or external-effect change.
+```
+
+Refused request:
+
+```text
+fast-repair: Add an audit field when a Secretary record is deleted.
+```
+
+This is refused because it changes schema and external behavior, so it follows the normal project path.

--- a/docs/fast-repair.md
+++ b/docs/fast-repair.md
@@ -54,9 +54,9 @@ Fast Repair never enables auto-merge.
 
 The repair must add a regression test that reproduces the defect and must pass focused module tests.
 `bin/fm-fast-repair.sh evidence` executes and records both gates.
-The only supported interface is the tracked `bin/fm-test-run.sh` runner.
-Its selectors must be distinct, unchanged paths in the tested commit: `tests/<name>-regression.test.sh` and `tests/<name>-focused.test.sh`.
-Projects without this runner or these selectors refuse Fast Repair evidence.
+The only supported interface is the tracked `bin/fm-test-run.sh` runner and two distinct families from its `--list-families` output.
+The recorded pre-fix reproduction commit must be an ancestor of the tested head, and the regression family must fail there before it can pass at the tested head.
+Projects without this runner, its family interface, or this proof refuse Fast Repair evidence.
 Missing or failed evidence blocks direct PR publication.
 
 After those gates pass, `bin/fm-fast-repair.sh publish-pr` opens and registers the direct PR immediately.

--- a/docs/fast-repair.md
+++ b/docs/fast-repair.md
@@ -54,15 +54,21 @@ Fast Repair never enables auto-merge.
 
 The repair must add a regression test that reproduces the defect and must pass focused module tests.
 `bin/fm-fast-repair.sh evidence` executes and records both gates.
-The only supported interface is the tracked `bin/fm-test-run.sh` runner and two distinct families from its `--list-families` output.
+The only supported interface is the tracked `bin/fm-test-run.sh` runner and distinct families from its `--list-families` output: the regression family, the focused family, and later a third broader family.
 The recorded pre-fix reproduction commit must be an ancestor of the tested head.
 Fast Repair identifies exactly one new test artifact from the regression family's runner-owned selector, overlays that artifact onto an isolated reproduction checkout, and requires that selected artifact to fail there and pass at the tested head.
 The evidence record binds the selector, test artifact identity, reproduction revision, tested revision, and both results.
 Projects without this runner, its selector overlay support, or this proof refuse Fast Repair evidence.
 Missing or failed evidence blocks direct PR publication.
 
+At dispatch the task worktree holds no repair yet, so the spawn gate proves only that it is a clean worktree of the task's own repository whose history already carries the recorded reproduction commit.
+That worktree is still at a detached HEAD then, because the crewmate creates its `fm/<id>` branch as its first action.
+The branch binding and the requirement that the reproduction commit be strictly older than the tested commit are proofs about the tested head, so every gate after dispatch enforces them.
+
 After those gates pass, `bin/fm-fast-repair.sh publish-pr` opens and registers the direct PR immediately.
 The worker then starts one supported broader runner family while the new PR's checks run concurrently.
+The broader family must differ from the focused family, because the focused module was already proven before the PR opened.
+Re-running the focused family as the broader gate is refused, and `ready` re-applies that same rule to the stored broader record.
 The task worktree must be clean and exactly at its tested revision before focused, regression, or broader evidence can run.
 Every selected focused and broader artifact must be tracked, regular, inside that worktree, and unchanged at the tested revision.
 Broader-test failures are recorded and surfaced as an open PR that is not green.

--- a/docs/fast-repair.md
+++ b/docs/fast-repair.md
@@ -55,8 +55,10 @@ Fast Repair never enables auto-merge.
 The repair must add a regression test that reproduces the defect and must pass focused module tests.
 `bin/fm-fast-repair.sh evidence` executes and records both gates.
 The only supported interface is the tracked `bin/fm-test-run.sh` runner and two distinct families from its `--list-families` output.
-The recorded pre-fix reproduction commit must be an ancestor of the tested head, and the regression family must fail there before it can pass at the tested head.
-Projects without this runner, its family interface, or this proof refuse Fast Repair evidence.
+The recorded pre-fix reproduction commit must be an ancestor of the tested head.
+Fast Repair identifies exactly one new test artifact from the regression family's runner-owned selector, overlays that artifact onto an isolated reproduction checkout, and requires that selected artifact to fail there and pass at the tested head.
+The evidence record binds the selector, test artifact identity, reproduction revision, tested revision, and both results.
+Projects without this runner, its selector overlay support, or this proof refuse Fast Repair evidence.
 Missing or failed evidence blocks direct PR publication.
 
 After those gates pass, `bin/fm-fast-repair.sh publish-pr` opens and registers the direct PR immediately.

--- a/docs/fast-repair.md
+++ b/docs/fast-repair.md
@@ -62,7 +62,9 @@ Projects without this runner, its selector overlay support, or this proof refuse
 Missing or failed evidence blocks direct PR publication.
 
 After those gates pass, `bin/fm-fast-repair.sh publish-pr` opens and registers the direct PR immediately.
-The worker then starts the broader test command while the new PR's checks run concurrently.
+The worker then starts one supported broader runner family while the new PR's checks run concurrently.
+The task worktree must be clean and exactly at its tested revision before focused, regression, or broader evidence can run.
+Every selected focused and broader artifact must be tracked, regular, inside that worktree, and unchanged at the tested revision.
 Broader-test failures are recorded and surfaced as an open PR that is not green.
 The Fast Repair progress check also surfaces failed PR checks.
 A PR is not called ready or green until the broader test and all required PR checks pass.

--- a/docs/fast-repair.md
+++ b/docs/fast-repair.md
@@ -79,6 +79,9 @@ A rollup where no check passed is never green, because the forge reports a cance
 
 The Fast Repair progress check runs about every 20 seconds only while durable task metadata records an eligible Fast Repair task.
 The timer runs during the existing watcher wait, so it does not change ordinary task polling, stale handling, pane scans, backend capture cadence, backend transition budgets, or global defaults.
+A result found by that timer interrupts whichever wait the watcher is in, including the backend event and push-transition wait, so it reaches the captain in the cycle it was found rather than at the end of the poll budget.
+A progress check that is stopped at a poll boundary keeps its due time, so the beat is retried on the next tick instead of being skipped for a whole interval.
+The cadence retires a task once its first green rollup is queued; from then on the ordinary PR check poll owns that PR.
 A relaunch of a Fast Repair task reuses the recorded profile, so the standard recovery command needs no profile flags.
 
 ## Examples

--- a/docs/fm-test-portable-shards.md
+++ b/docs/fm-test-portable-shards.md
@@ -46,6 +46,7 @@ The two parallel lanes use longest-processing-time assignment from those measure
 | imbalance | | 318 ms |
 
 `bin/fm-test-run.sh` contains the exact ordered memberships in `list_portable_parallel_1` and `list_portable_parallel_2`.
+Each estimate is the sum of that lane's durations in [fm-test-isolation-proof.json](fm-test-isolation-proof.json), and `tests/fm-test-run.test.sh` asserts the rows against that artifact.
 
 ## Portable serial remainder
 
@@ -68,7 +69,13 @@ The hints came from that run's `fm-test-timing-portable-serial` artifact on 2026
 A script with no hint gets the conservative `PORTABLE_SERIAL_DEFAULT_WEIGHT_MS` default.
 Hints only affect balance: the coverage guard keeps the partition complete and disjoint whatever they say, so a stale hint costs a slower shard rather than lost coverage.
 
-The table below is derived from the current lane membership and those hints, not measured directly.
+`bin/fm-test-run.sh --list-shard-plan` prints that assignment, one line per shard:
+
+```
+portable-serial-1of4 count=24 estimated_ms=455937
+```
+
+The table below renders that output, so it is derived from the current lane membership and those hints rather than measured directly.
 The lane has grown well past the 69 measured scripts, so a large part of each estimate is the default weight rather than an observed duration.
 Treat the estimates as balance evidence and shard-count sanity only; the measured lane total still comes from a CI timing artifact.
 
@@ -82,13 +89,13 @@ Treat the estimates as balance evidence and shard-count sanity only; the measure
 
 The single longest script, `tests/fm-pr-check-security.test.sh` at 199573 ms, is the floor for any shard count.
 
-Rederive the table above from the current branch with no CI artifact, whenever a test is added or removed:
+Adding or removing a test changes this table, because shard membership is derived.
+`tests/fm-test-run.test.sh` asserts the rows against `--list-shard-plan`, so a stale count fails the suite instead of quietly misstating the timeout basis.
+Rerun the plan and paste the counts and estimates back into the table:
 
 ```sh
 bin/fm-test-run.sh --check-coverage
-bin/fm-test-run.sh --list-lanes | grep '^portable-serial-[0-9]' | while read -r lane; do
-  printf '%s\t%s\n' "$lane" "$(bin/fm-test-run.sh --list --lane "$lane" | wc -l)"
-done
+bin/fm-test-run.sh --list-shard-plan
 ```
 
 Refresh the hints themselves by downloading the per-shard timing artifacts from a green CI run, replacing the `portable_serial_weight_hints` table in `bin/fm-test-run.sh` with the measured `path`/`duration_ms` pairs, and rederiving the table above:

--- a/docs/fm-test-portable-shards.md
+++ b/docs/fm-test-portable-shards.md
@@ -68,17 +68,30 @@ The hints came from that run's `fm-test-timing-portable-serial` artifact on 2026
 A script with no hint gets the conservative `PORTABLE_SERIAL_DEFAULT_WEIGHT_MS` default.
 Hints only affect balance: the coverage guard keeps the partition complete and disjoint whatever they say, so a stale hint costs a slower shard rather than lost coverage.
 
+The table below is derived from the current lane membership and those hints, not measured directly.
+The lane has grown well past the 69 measured scripts, so a large part of each estimate is the default weight rather than an observed duration.
+Treat the estimates as balance evidence and shard-count sanity only; the measured lane total still comes from a CI timing artifact.
+
 | Lane | Script count | Estimated duration |
 |---|---:|---:|
-| `portable-serial-1of4` | 15 | 285945 ms (~285.9 s) |
-| `portable-serial-2of4` | 18 | 285944 ms (~285.9 s) |
-| `portable-serial-3of4` | 17 | 285929 ms (~285.9 s) |
-| `portable-serial-4of4` | 19 | 285944 ms (~285.9 s) |
-| imbalance | | 16 ms |
+| `portable-serial-1of4` | 24 | 455937 ms (~455.9 s) |
+| `portable-serial-2of4` | 27 | 455940 ms (~455.9 s) |
+| `portable-serial-3of4` | 25 | 455948 ms (~455.9 s) |
+| `portable-serial-4of4` | 27 | 455937 ms (~455.9 s) |
+| imbalance | | 11 ms |
 
 The single longest script, `tests/fm-pr-check-security.test.sh` at 199573 ms, is the floor for any shard count.
 
-Refresh the hints by downloading the per-shard timing artifacts from a green CI run, replacing the `portable_serial_weight_hints` table in `bin/fm-test-run.sh` with the measured `path`/`duration_ms` pairs, and updating the table above:
+Rederive the table above from the current branch with no CI artifact, whenever a test is added or removed:
+
+```sh
+bin/fm-test-run.sh --check-coverage
+bin/fm-test-run.sh --list-lanes | grep '^portable-serial-[0-9]' | while read -r lane; do
+  printf '%s\t%s\n' "$lane" "$(bin/fm-test-run.sh --list --lane "$lane" | wc -l)"
+done
+```
+
+Refresh the hints themselves by downloading the per-shard timing artifacts from a green CI run, replacing the `portable_serial_weight_hints` table in `bin/fm-test-run.sh` with the measured `path`/`duration_ms` pairs, and rederiving the table above:
 
 ```sh
 gh run download <run-id> -R kunchenguid/firstmate --pattern 'fm-test-timing-portable-serial-*' -D /tmp/fm-serial
@@ -108,7 +121,7 @@ Portable shards, each portable serial shard, and the Herdr lane upload runner-ge
 | Job | timeout-minutes | Rationale |
 |---|---:|---|
 | portable parallel 1/2 | 10 | The measured shard sums are about three minutes and the timeout is a hang tripwire. |
-| portable serial 1-4 | 15 | Each balanced shard is about five minutes, leaving roughly 3x hang-tripwire margin. |
+| portable serial 1-4 | 15 | Each balanced shard estimates about seven and a half minutes, leaving roughly 2x hang-tripwire margin. |
 | Herdr | 40 | The real-Herdr lane keeps its dedicated timeout. |
 
 Timeouts are hang tripwires rather than expected healthy durations.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -1,7 +1,8 @@
 # The bin/ toolbelt
 
 The first mate drives these; interactive entrypoints work by hand too, while `*-lib.sh` files are sourced helpers.
-Each row is one purpose clause only: the script's own header comment is the authoritative description of its behavior, flags, and contracts, so read the header before first use.
+The table is a selective task-facing reference, not an exhaustive inventory of `bin/`: it lists the scripts you choose between during work, so a script with no row is not missing or deprecated.
+Each row is one purpose clause only: the script's own header comment is the authoritative description of its behavior, flags, and contracts, so read the header before first use, and list `bin/` itself when you need every script.
 If you have changed away from the firstmate home in an interactive shell, invoke these scripts by absolute path through the repo's `bin/` directory; the scripts self-locate internally after they start.
 The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarized in [architecture.md](architecture.md#no-mistakes-gate-authority-boundary), while `docs/sessionstart-nudge.md` covers the silent session-open hook use; `fm-gate-refuse-lib.sh`'s header owns its exact contract.
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -27,6 +27,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-backlog-receive.sh`  | Idempotently ingest one confined remote handoff outbox through tasks-axi             |
 | `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions                 |
 | `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs   |
+| `fm-fast-repair.sh`      | Own the opt-in per-task Fast Repair path: typed eligibility, test evidence, early direct PR, and progress ([fast-repair.md](fast-repair.md)) |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |
 | `fm-install-treehouse.sh`| Install CI's exact-version Treehouse pin for real-Herdr E2E that needs spawn worktrees |

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -771,6 +771,39 @@ test_ship_relaunch_ignores_the_crew_harness_config() {
   pass "fm-control relaunch: a ship task keeps its recorded harness instead of re-reading crew config"
 }
 
+# Fast Repair's profile is part of its delivery contract, so the recovery command
+# for a wedged Fast Repair crewmate must work with no profile flags, exactly as it
+# does for the recorded harness above.
+test_spawn_relaunch_reuses_a_fast_repair_profile() {
+  local dir out status meta
+  dir=$(new_case fastrepairprofile rl40)
+  add_ship_task "$dir" rl40 codex
+  meta="$dir/home/state/rl40.meta"
+  sed -e 's/^mode=.*/mode=fast-repair/' \
+      -e 's/^model=.*/model=gpt-5.6-luna/' \
+      -e 's/^effort=.*/effort=medium/' "$meta" > "$meta.tmp"
+  printf 'fast_repair=eligible\n' >> "$meta.tmp"
+  mv -f "$meta.tmp" "$meta"
+  printf 'Delivery contract: mode=fast-repair\n' > "$dir/home/data/rl40/brief.md"
+  FM_HOME="$dir/home" "$ROOT/bin/fm-fast-repair.sh" intake rl40 \
+    --request 'fast-repair: fixture' --reproduction reproduced --root-cause confirmed \
+    --isolation isolated --schema none --authentication none --authorization none \
+    --secrets none --financial none --legal none --side-effects none >/dev/null \
+    || fail "the Fast Repair eligibility fixture could not be recorded"
+  printf 'zsh' > "$dir/fake/command"
+
+  out=$(run_spawn "$dir" rl40 --relaunch)
+  status=$?
+  [ "$status" -eq 0 ] || fail "a Fast Repair relaunch needed profile flags it never had to pass: $out"
+  [ "$(meta_field "$dir" rl40 model)" = gpt-5.6-luna ] \
+    || fail "a Fast Repair relaunch lost its recorded model, got '$(meta_field "$dir" rl40 model)'"
+  [ "$(meta_field "$dir" rl40 effort)" = medium ] \
+    || fail "a Fast Repair relaunch lost its recorded effort, got '$(meta_field "$dir" rl40 effort)'"
+  [ "$(meta_field "$dir" rl40 mode)" = fast-repair ] \
+    || fail "a Fast Repair relaunch lost its delivery mode"
+  pass "fm-spawn --relaunch: a Fast Repair task reuses its recorded profile with no flags"
+}
+
 test_spawn_relaunch_without_a_harness_reuses_the_recorded_one() {
   local dir out
   dir=$(new_case spawnharness rl21)
@@ -1321,6 +1354,7 @@ test_secondmate_relaunch_onto_a_crewmate_only_adapter_refuses_before_stop
 test_explicit_secondmate_harness_ignores_configured_profile_axes
 test_ship_relaunch_ignores_the_crew_harness_config
 test_spawn_relaunch_without_a_harness_reuses_the_recorded_one
+test_spawn_relaunch_reuses_a_fast_repair_profile
 test_prefixed_prior_harness_wiring_is_still_retired
 test_muse_session_binding_is_retired_on_a_harness_switch
 test_missing_worktree_refuses_before_stopping_anything

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -786,7 +786,7 @@ test_spawn_relaunch_reuses_a_fast_repair_profile() {
   mv -f "$meta.tmp" "$meta"
   printf 'Delivery contract: mode=fast-repair\n' > "$dir/home/data/rl40/brief.md"
   FM_HOME="$dir/home" "$ROOT/bin/fm-fast-repair.sh" intake rl40 \
-    --request 'fast-repair: fixture' --reproduction reproduced --root-cause confirmed \
+    --request 'fast-repair: fixture' --reproduction reproduced --reproduction-revision 0000000000000000000000000000000000000000 --root-cause confirmed \
     --isolation isolated --schema none --authentication none --authorization none \
     --secrets none --financial none --legal none --side-effects none >/dev/null \
     || fail "the Fast Repair eligibility fixture could not be recorded"

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -805,6 +805,60 @@ test_spawn_relaunch_reuses_a_fast_repair_profile() {
   pass "fm-spawn --relaunch: a Fast Repair task reuses its recorded profile with no flags"
 }
 
+# The dispatch-time reproduction proof asserts a PRISTINE worktree still sitting
+# on the reproduction commit, which is only true before the crewmate branches,
+# edits, and commits. Recovering a wedged Fast Repair crewmate always happens
+# after that, so the recovery must adopt the worktree with its unlanded repair
+# intact instead of refusing it for being dirty - while the authorization that
+# made the task a Fast Repair in the first place stays mandatory.
+test_spawn_relaunch_preserves_unlanded_fast_repair_work() {
+  local dir out status meta
+  dir=$(new_case fastrepairdirty rl41)
+  add_ship_task "$dir" rl41 codex
+  meta="$dir/home/state/rl41.meta"
+  sed -e 's/^mode=.*/mode=fast-repair/' \
+      -e 's/^model=.*/model=gpt-5.6-luna/' \
+      -e 's/^effort=.*/effort=medium/' "$meta" > "$meta.tmp"
+  printf 'fast_repair=eligible\n' >> "$meta.tmp"
+  mv -f "$meta.tmp" "$meta"
+  printf 'Delivery contract: mode=fast-repair\n' > "$dir/home/data/rl41/brief.md"
+  git -C "$dir/wt" commit --quiet --allow-empty -m 'repair fixture head'
+  FM_HOME="$dir/home" "$ROOT/bin/fm-fast-repair.sh" intake rl41 \
+    --request 'fast-repair: fixture' --reproduction reproduced --reproduction-revision "$(git -C "$dir/wt" rev-parse HEAD~1)" --root-cause confirmed \
+    --isolation isolated --schema none --authentication none --authorization none \
+    --secrets none --financial none --legal none --side-effects none >/dev/null \
+    || fail "the Fast Repair eligibility fixture could not be recorded"
+
+  # What a wedged crewmate leaves behind: its own branch, a landed repair commit,
+  # and edits it never got to commit.
+  git -C "$dir/wt" checkout --quiet -b fm/rl41
+  printf 'repaired\n' > "$dir/wt/repair.txt"
+  git -C "$dir/wt" add -- repair.txt
+  git -C "$dir/wt" commit --quiet -m 'repair the reported defect'
+  printf 'still editing\n' >> "$dir/wt/repair.txt"
+  printf 'zsh' > "$dir/fake/command"
+
+  out=$(run_spawn "$dir" rl41 --relaunch)
+  status=$?
+  [ "$status" -eq 0 ] || fail "the stuck-crewmate recovery was refused for a Fast Repair worktree holding unlanded work: $out"
+  [ "$(git -C "$dir/wt" rev-parse --abbrev-ref HEAD)" = fm/rl41 ] \
+    || fail "the relaunch moved the Fast Repair task off its own branch"
+  [ "$(cat "$dir/wt/repair.txt")" = "$(printf 'repaired\nstill editing')" ] \
+    || fail "the relaunch discarded the crewmate's uncommitted repair work"
+  [ "$(meta_field "$dir" rl41 mode)" = fast-repair ] \
+    || fail "the relaunch lost the Fast Repair delivery mode"
+
+  # The dirty worktree is forgiven; a missing authorization is not.
+  rm -f "$dir/home/data/rl41/fast-repair-eligibility"
+  printf 'zsh' > "$dir/fake/command"
+  out=$(run_spawn "$dir" rl41 --relaunch)
+  status=$?
+  [ "$status" -ne 0 ] || fail "a relaunch launched a Fast Repair task whose eligibility evidence is gone"
+  assert_contains "$out" 'typed eligibility evidence is absent or incomplete' \
+    "the unauthorized-relaunch refusal was not actionable"
+  pass "fm-spawn --relaunch: a Fast Repair recovery keeps unlanded work but still requires its authorization"
+}
+
 test_spawn_relaunch_without_a_harness_reuses_the_recorded_one() {
   local dir out
   dir=$(new_case spawnharness rl21)
@@ -1356,6 +1410,7 @@ test_explicit_secondmate_harness_ignores_configured_profile_axes
 test_ship_relaunch_ignores_the_crew_harness_config
 test_spawn_relaunch_without_a_harness_reuses_the_recorded_one
 test_spawn_relaunch_reuses_a_fast_repair_profile
+test_spawn_relaunch_preserves_unlanded_fast_repair_work
 test_prefixed_prior_harness_wiring_is_still_retired
 test_muse_session_binding_is_retired_on_a_harness_switch
 test_missing_worktree_refuses_before_stopping_anything

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -785,8 +785,9 @@ test_spawn_relaunch_reuses_a_fast_repair_profile() {
   printf 'fast_repair=eligible\n' >> "$meta.tmp"
   mv -f "$meta.tmp" "$meta"
   printf 'Delivery contract: mode=fast-repair\n' > "$dir/home/data/rl40/brief.md"
+  git -C "$dir/wt" commit --quiet --allow-empty -m 'repair fixture head'
   FM_HOME="$dir/home" "$ROOT/bin/fm-fast-repair.sh" intake rl40 \
-    --request 'fast-repair: fixture' --reproduction reproduced --reproduction-revision 0000000000000000000000000000000000000000 --root-cause confirmed \
+    --request 'fast-repair: fixture' --reproduction reproduced --reproduction-revision "$(git -C "$dir/wt" rev-parse HEAD~1)" --root-cause confirmed \
     --isolation isolated --schema none --authentication none --authorization none \
     --secrets none --financial none --legal none --side-effects none >/dev/null \
     || fail "the Fast Repair eligibility fixture could not be recorded"

--- a/tests/fm-fast-repair.test.sh
+++ b/tests/fm-fast-repair.test.sh
@@ -401,7 +401,7 @@ test_regression_witness_requires_a_failing_reproduction() {
   pass "Fast Repair requires the overlaid regression selector to fail before the repair"
 }
 
-test_regression_witness_requires_overlay_runner_support() {
+test_regression_witness_uses_the_tested_runner() {
   local home id=unsupported-overlay out status
   home=$(make_home unsupported-overlay)
   sed -i 's/if \[ "${1:-}" = --list \].*/if [ "${1:-}" = --list ]; then exit 2; fi/' "$home/bin/fm-test-run.sh"
@@ -413,9 +413,10 @@ test_regression_witness_requires_overlay_runner_support() {
   write_fast_meta "$home" "$id"
   out=$(run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST")
   status=$?
-  [ "$status" -ne 0 ] || fail "an unsupported reproduction runner accepted overlay evidence"
-  assert_contains "$out" 'PR publication remains blocked' "an unsupported reproduction runner did not block publication"
-  pass "Fast Repair refuses a reproduction runner without selector overlay support"
+  [ "$status" -eq 0 ] || fail "the tested runner could not execute the reproduction overlay: $out"
+  assert_grep 'regression_runner=100755:' "$home/state/$id.fast-repair-tests" \
+    "the evidence record did not bind the tested runner artifact"
+  pass "Fast Repair uses one tested runner for both regression witness halves"
 }
 
 test_pr_check_rollup_states() {
@@ -627,6 +628,6 @@ test_private_records_do_not_impose_their_umask_on_tests
 test_evidence_and_ready_gates
 test_regression_selector_must_be_new_since_reproduction
 test_regression_witness_requires_a_failing_reproduction
-test_regression_witness_requires_overlay_runner_support
+test_regression_witness_uses_the_tested_runner
 test_pr_check_rollup_states
 echo "# all fm-fast-repair tests passed"

--- a/tests/fm-fast-repair.test.sh
+++ b/tests/fm-fast-repair.test.sh
@@ -80,6 +80,7 @@ write_test_runner() {
   mkdir -p "$home/bin"
   # shellcheck disable=SC2016 # Literal fixture code expands only when its generated script runs.
   printf '%s\n' '#!/usr/bin/env bash' 'set -eu' \
+    'if [ -n "${FM_FIXTURE_RUN_BLOCK:-}" ] && [ "${1:-}" != --list-families ] && [ "${1:-}" != --list ]; then : > "$FM_FIXTURE_RUN_BLOCK.started"; while [ -e "$FM_FIXTURE_RUN_BLOCK" ]; do sleep 0.05; done; fi' \
     'if [ "${1:-}" = --list-families ]; then printf "%s\n" fixture-regression fixture-focused fixture-broader; exit 0; fi' \
     'if [ "${1:-}" = --list ] && [ "${2:-}" = --family ]; then case "$3" in fixture-regression) printf "%s\n" tests/fixture-regression.test.sh ;; fixture-focused) printf "%s\n" tests/fixture-focused.test.sh ;; fixture-broader) printf "%s\n" tests/fixture-broader.test.sh ;; *) exit 2 ;; esac; exit 0; fi' \
     'if [ "${1:-}" = --family ] && [ "$#" = 2 ]; then family=$2; elif [ "$#" = 1 ]; then case "$1" in tests/fixture-regression.test.sh) family=fixture-regression ;; tests/fixture-focused.test.sh) family=fixture-focused ;; tests/fixture-broader.test.sh) family=fixture-broader ;; *) exit 2 ;; esac; else exit 2; fi' \
@@ -865,6 +866,85 @@ test_skipped_selector_run_cannot_satisfy_evidence() {
   pass "Fast Repair applies one skip rule to family and selector runner invocations alike"
 }
 
+# The reproduction witness fills a private sandbox with a full object copy of the
+# task repository, and every typed run writes a private output capture. Neither
+# name carries a task id, so nothing else can ever reclaim them: a crewmate whose
+# pane is killed mid-evidence would otherwise accumulate whole repository clones
+# under firstmate's state directory.
+test_interrupted_evidence_removes_its_temporary_artifacts() {
+  local home id=interrupted-evidence block out pid status i live leftover
+  home=$(make_home interrupted-evidence)
+  intake "$home" "$id" >/dev/null
+  write_regression_test "$home"
+  write_focused_test "$home"
+  write_fast_meta "$home" "$id"
+  block="$TMP_ROOT/interrupted-evidence.block"
+  out="$TMP_ROOT/interrupted-evidence.out"
+  : > "$block"
+  rm -f "$block.started"
+
+  FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_FIXTURE_RUN_BLOCK="$block" "$FAST" evidence "$id" \
+    --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST" > "$out" 2>&1 &
+  pid=$!
+  i=0
+  while [ ! -e "$block.started" ] && [ "$i" -lt 400 ]; do sleep 0.05; i=$((i + 1)); done
+  if [ ! -e "$block.started" ]; then
+    rm -f "$block"; kill -KILL "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true
+    fail "the evidence run never reached a tracked runner invocation: $(cat "$out")"
+  fi
+  live=$(find "$home/state" -maxdepth 1 -name '.fast-repair-reproduction.*' -print -quit)
+  if [ -z "$live" ]; then
+    rm -f "$block"; kill -KILL "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true
+    fail "the interrupted run was not holding a reproduction sandbox, so the fixture proves nothing"
+  fi
+
+  # The runner is a child of its own, so it never sees this signal; releasing the
+  # block lets the interrupted script reach its handler exactly as a real one does.
+  kill -TERM "$pid" 2>/dev/null || true
+  rm -f "$block"
+  wait "$pid" 2>/dev/null
+  status=$?
+  [ "$status" -ne 0 ] || fail "an interrupted evidence run reported success"
+  leftover=$(find "$home/state" -maxdepth 1 \
+    \( -name '.fast-repair-reproduction.*' -o -name '.fast-repair-test-output.*' \) -print | tr '\n' ' ')
+  [ -z "$leftover" ] \
+    || fail "an interrupted Fast Repair evidence run leaked unreclaimable temporaries: $leftover"
+  [ ! -e "$home/state/$id.fast-repair-tests" ] \
+    || fail "an interrupted evidence run still published an evidence record"
+  rm -f "$block.started"
+  pass "an interrupted Fast Repair evidence run removes its sandbox clone and output capture"
+}
+
+# A commit id is one concept with one shape, shared with the forge validator, so
+# both object formats git can produce are accepted and anything else is refused
+# before a task can enter the Fast Repair path.
+test_reproduction_revision_accepts_every_commit_id_width() {
+  local home id=revision-width out status bad
+  home=$(make_home revision-width)
+  run_fast "$home" intake "$id" --request 'fast-repair: repair fixture' \
+    --reproduction reproduced --reproduction-revision "$(printf '%064d' 0)" --root-cause confirmed \
+    --isolation isolated --schema none --authentication none --authorization none \
+    --secrets none --financial none --legal none --side-effects none >/dev/null \
+    || fail "a SHA-256 object-format commit id was refused at intake"
+  run_fast "$home" eligible "$id" >/dev/null \
+    || fail "a recorded SHA-256 commit id did not survive re-validation"
+
+  for bad in "$(printf '%039d' 0)" "$(printf '%041d' 0)" "$(printf '%063d' 0)" \
+    "$(printf '%065d' 0)" ABCDEF0123456789ABCDEF0123456789ABCDEF01 ''; do
+    out=$(run_fast "$home" intake "$id-bad" --request 'fast-repair: repair fixture' \
+      --reproduction reproduced --reproduction-revision "$bad" --root-cause confirmed \
+      --isolation isolated --schema none --authentication none --authorization none \
+      --secrets none --financial none --legal none --side-effects none)
+    status=$?
+    [ "$status" -ne 0 ] || fail "intake accepted '$bad' as a commit id"
+    assert_contains "$out" 'reproduction-revision must be' "the malformed-revision refusal was not actionable"
+  done
+  [ ! -e "$home/data/$id-bad/fast-repair-eligibility" ] \
+    || fail "a refused intake still recorded eligibility"
+  pass "Fast Repair records the commit id shapes git produces and refuses everything else"
+}
+
 # Once the watcher has stopped polling the forge for a task it still needs the
 # local half of the progress check, so --local-only must keep the broader-test
 # branch and must reach no forge command at all.
@@ -901,6 +981,8 @@ test_local_only_progress_reads_no_forge() {
 }
 
 test_exact_prefix_only
+test_interrupted_evidence_removes_its_temporary_artifacts
+test_reproduction_revision_accepts_every_commit_id_width
 test_eligibility_requires_every_typed_fact
 test_spawn_eligibility_accepts_the_detached_task_worktree
 test_tested_head_proofs_stay_strict_after_dispatch

--- a/tests/fm-fast-repair.test.sh
+++ b/tests/fm-fast-repair.test.sh
@@ -17,6 +17,7 @@ make_home() {
   local name=$1 home
   home="$TMP_ROOT/$name"
   mkdir -p "$home/data" "$home/state" "$home/config"
+  fm_git_init_commit "$home"
   printf '%s\n' "$home"
 }
 
@@ -88,7 +89,7 @@ write_fast_meta() {
   local home=$1 id=$2 pr=${3:-}
   {
     printf 'window=firstmate:fm-%s\n' "$id"
-    printf 'kind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n'
+    printf 'kind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\nworktree=%s\n' "$home"
     [ -z "$pr" ] || printf 'pr=%s\n' "$pr"
   } > "$home/state/$id.meta"
 }
@@ -118,6 +119,15 @@ test_eligibility_requires_every_typed_fact() {
   done
   [ ! -e "$home/data/fast-repair-eligibility" ] || fail "the dot task id wrote outside its task directory"
   [ ! -e "$home/fast-repair-eligibility" ] || fail "the dot-dot task id wrote outside the data directory"
+  write_fast_meta "$home" eligible-all
+  for id in ../outside ../../outside; do
+    out=$(run_fast "$home" progress "$id")
+    status=$?
+    [ "$status" -ne 0 ] || fail "progress accepted an escaping task id: $id"
+    out=$(run_fast "$home" ready "$id")
+    status=$?
+    [ "$status" -ne 0 ] || fail "ready accepted an escaping task id: $id"
+  done
 
   out=$(intake "$home" invalid-reproduction a confirmed isolated)
   status=$?
@@ -170,7 +180,7 @@ test_eligibility_requires_every_typed_fact() {
 }
 
 test_evidence_and_ready_gates() {
-  local home id=gate-fixture out status fakebin
+  local home id=gate-fixture out status fakebin outside branch
   home=$(make_home gates)
   intake "$home" "$id" >/dev/null
   write_fast_meta "$home" "$id"
@@ -189,6 +199,15 @@ test_evidence_and_ready_gates() {
   out=$(run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-command true)
   status=$?
   [ "$status" -ne 0 ] || fail "an arbitrary successful focused command was accepted"
+  outside="$TMP_ROOT/escaped-focused-test"
+  mkdir -p "$outside" "$home/tests"
+  printf '#!/usr/bin/env bash\ntouch %q\n' "$home/escaped-test-ran" > "$outside/escaped.test.sh"
+  chmod +x "$outside/escaped.test.sh"
+  ln -s "$outside" "$home/tests/link"
+  out=$(run_fast "$home" evidence "$id" --regression-test tests/link/escaped.test.sh --focused-test focused.test.sh)
+  status=$?
+  [ "$status" -ne 0 ] || fail "a parent symlink escaped the Fast Repair worktree"
+  [ ! -e "$home/escaped-test-ran" ] || fail "an escaped test path was executed"
   write_focused_test "$home" 1
   out=$(run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-test focused.test.sh)
   status=$?
@@ -196,14 +215,28 @@ test_evidence_and_ready_gates() {
   assert_contains "$out" "PR publication remains blocked" "failed focused evidence did not explain the publication block"
   write_focused_test "$home"
   run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-test focused.test.sh >/dev/null || fail "passing focused evidence was rejected"
+  git -C "$home" commit --quiet --allow-empty -m 'advance repair fixture'
+  printf 'Fast Repair fixture body.\n' > "$home/body.md"
+  out=$(run_fast "$home" publish-pr "$id" --title 'Fast Repair fixture' --body-file "$home/body.md")
+  status=$?
+  [ "$status" -ne 0 ] || fail "Fast Repair published a commit that its evidence did not test"
+  assert_contains "$out" 'focused evidence is absent or failed' "untested commit refusal was not actionable"
+  run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-test focused.test.sh >/dev/null || fail "updated task HEAD evidence was rejected"
   write_fake_gh "$home"
   fakebin="$home/fakebin"
   # The real green rollup omits the pending segment when nothing is pending.
   set_rollup "$home" '4 passed, 0 failed, 4 total'
-  printf 'Fast Repair fixture body.\n' > "$home/body.md"
+  out=$(PATH="$fakebin:$PATH" run_fast "$home" publish-pr "$id" --title 'Fast Repair fixture' --body-file "$home/body.md" --head unrelated)
+  status=$?
+  [ "$status" -ne 0 ] || fail "Fast Repair published an untested head branch"
+  assert_contains "$out" '--head must equal the tested task branch' "untested head refusal was not actionable"
+  assert_no_grep 'pr=' "$home/state/$id.meta" "untested head publication wrote a PR record"
   out=$(PATH="$fakebin:$PATH" run_fast "$home" publish-pr "$id" --title 'Fast Repair fixture' --body-file "$home/body.md")
   assert_contains "$out" 'fast-repair PR opened: https://github.com/acme/repo/pull/42' "passing evidence did not open the direct PR"
   assert_grep 'pr=https://github.com/acme/repo/pull/42' "$home/state/$id.meta" "direct PR was not registered"
+  branch=$(git -C "$home" symbolic-ref --short HEAD)
+  assert_grep "pr create --title Fast Repair fixture --body-file $home/body.md --head $branch" "$home/gh-axi.args" \
+    "direct PR did not use the tested task branch"
   PATH="$fakebin:$PATH" run_fast "$home" broader "$id" --command true >/dev/null || fail "broader tests could not start after direct PR publication"
   out=$(PATH="$fakebin:$PATH" run_fast "$home" ready "$id")
   assert_contains "$out" 'fast-repair ready: https://github.com/acme/repo/pull/42' "green broader and PR evidence did not make the PR ready"
@@ -301,8 +334,9 @@ test_later_gates_revalidate_typed_eligibility() {
   write_fast_meta "$home" "$id" https://github.com/acme/repo/pull/42
   write_regression_test "$home"
   write_focused_test "$home"
-  run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-test focused.test.sh >/dev/null \
-    || fail "the later-gate fixture could not record focused evidence"
+  out=$(run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-test focused.test.sh)
+  status=$?
+  [ "$status" -eq 0 ] || fail "the later-gate fixture could not record focused evidence: $out"
   f="$home/data/$id/fast-repair-eligibility"
   sed 's/^isolation=.*/isolation=isolated-change/' "$f" > "$f.tmp" && mv -f "$f.tmp" "$f"
   printf 'Fast Repair fixture body.\n' > "$home/body.md"

--- a/tests/fm-fast-repair.test.sh
+++ b/tests/fm-fast-repair.test.sh
@@ -176,11 +176,23 @@ test_pr_check_rollup_states() {
   PATH="$fakebin:$PATH" run_fast "$home" broader "$id" --command true >/dev/null \
     || fail "broader fixture was rejected"
 
-  # A skipped check is neither failed nor pending, so the rollup is still green.
+  # A skipped check alongside real passes is ordinary CI, so the rollup is green,
+  # but the counts stay visible in the ready line for the approving captain.
   set_rollup "$home" '3 passed, 1 skipped, 0 failed, 4 total'
   out=$(PATH="$fakebin:$PATH" run_fast "$home" ready "$id") \
     || fail "a rollup with only passed and skipped checks was refused: $out"
   assert_contains "$out" 'fast-repair ready:' "skipped-but-green rollup did not report ready"
+  assert_contains "$out" '1 skipped' "the ready line hid the rollup counts it was approved on"
+
+  # gh-axi folds CANCELLED into the same skipped count, so a rollup where nothing
+  # passed has proven nothing and is never green.
+  set_rollup "$home" '0 passed, 0 failed, 1 skipped, 1 total'
+  out=$(PATH="$fakebin:$PATH" run_fast "$home" ready "$id")
+  status=$?
+  [ "$status" -ne 0 ] || fail "a rollup whose only check was skipped or cancelled was reported ready"
+  assert_contains "$out" 'PR checks are not green' "an all-skipped rollup did not name the refusal"
+  out=$(PATH="$fakebin:$PATH" run_fast "$home" progress "$id")
+  [ -z "$out" ] || fail "an all-skipped rollup produced an actionable progress result: $out"
 
   # "10 failed, 0 pending" contains "0 failed, 0 pending" as a substring.
   set_rollup "$home" '3 passed, 10 failed, 0 pending, 13 total'

--- a/tests/fm-fast-repair.test.sh
+++ b/tests/fm-fast-repair.test.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Behavior tests for the strict opt-in Fast Repair intake, evidence, and
+# post-publication readiness gates.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+FAST="$ROOT/bin/fm-fast-repair.sh"
+TMP_ROOT=$(fm_test_tmproot fm-fast-repair)
+
+make_home() {
+  local name=$1 home
+  home="$TMP_ROOT/$name"
+  mkdir -p "$home/data" "$home/state" "$home/config"
+  printf '%s\n' "$home"
+}
+
+run_fast() {
+  local home=$1
+  shift
+  FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" "$FAST" "$@" 2>&1
+}
+
+intake() {
+  local home=$1 id=$2 reproduction=${3-known-reproduction} root_cause=${4-confirmed-root-cause} isolation=${5-isolated-change}
+  local schema=${6-none} authentication=${7-none} authorization=${8-none} secrets=${9-none} financial=${10-none} legal=${11-none} side_effects=${12-none}
+  run_fast "$home" intake "$id" --request 'fast-repair: repair fixture' \
+    --reproduction "$reproduction" --root-cause "$root_cause" --isolation "$isolation" \
+    --schema "$schema" --authentication "$authentication" --authorization "$authorization" \
+    --secrets "$secrets" --financial "$financial" --legal "$legal" --side-effects "$side_effects"
+}
+
+write_fast_meta() {
+  local home=$1 id=$2 pr=${3:-}
+  {
+    printf 'window=firstmate:fm-%s\n' "$id"
+    printf 'kind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n'
+    [ -z "$pr" ] || printf 'pr=%s\n' "$pr"
+  } > "$home/state/$id.meta"
+}
+
+test_exact_prefix_only() {
+  local request
+  for request in 'fast-repair: fix fixture' 'fast-repair: a'; do
+    "$FAST" is-request "$request" || fail "exact Fast Repair prefix was not recognized: $request"
+  done
+  for request in 'fast-repair:' 'Fast-repair: fix' 'fast repair: fix' 'fast-repair : fix' 'xfast-repair: fix'; do
+    "$FAST" is-request "$request" && fail "near-match activated Fast Repair: $request"
+  done
+  pass "Fast Repair recognizes only the exact fast-repair: prefix"
+}
+
+test_eligibility_requires_every_typed_fact() {
+  local home out status field id=eligible-all
+  home=$(make_home eligibility)
+  out=$(intake "$home" "$id")
+  assert_contains "$out" "fast-repair eligible: $id" "complete typed eligibility did not pass"
+  run_fast "$home" eligible "$id" >/dev/null || fail "stored complete eligibility did not validate"
+
+  for field in reproduction root_cause isolation; do
+    id="missing-$field"
+    case "$field" in
+      reproduction) out=$(intake "$home" "$id" '' confirmed-root-cause isolated-change) ;;
+      root_cause) out=$(intake "$home" "$id" known-reproduction '' isolated-change) ;;
+      isolation) out=$(intake "$home" "$id" known-reproduction confirmed-root-cause '') ;;
+    esac
+    status=$?
+    [ "$status" -ne 0 ] || fail "missing $field was accepted"
+    assert_contains "$out" "$field" "missing $field did not name its refusal"
+
+    id="unknown-$field"
+    case "$field" in
+      reproduction) out=$(intake "$home" "$id" unknown confirmed-root-cause isolated-change) ;;
+      root_cause) out=$(intake "$home" "$id" known-reproduction unknown isolated-change) ;;
+      isolation) out=$(intake "$home" "$id" known-reproduction confirmed-root-cause ambiguous) ;;
+    esac
+    status=$?
+    [ "$status" -ne 0 ] || fail "unknown or ambiguous $field was accepted"
+    assert_contains "$out" "$field" "unknown $field did not name its refusal"
+  done
+
+  for field in schema authentication authorization secrets financial legal side_effects; do
+    id="risk-$field"
+    case "$field" in
+      schema) out=$(intake "$home" "$id" a b c changed) ;;
+      authentication) out=$(intake "$home" "$id" a b c none changed) ;;
+      authorization) out=$(intake "$home" "$id" a b c none none changed) ;;
+      secrets) out=$(intake "$home" "$id" a b c none none none changed) ;;
+      financial) out=$(intake "$home" "$id" a b c none none none none changed) ;;
+      legal) out=$(intake "$home" "$id" a b c none none none none none changed) ;;
+      side_effects) out=$(intake "$home" "$id" a b c none none none none none none changed) ;;
+    esac
+    status=$?
+    [ "$status" -ne 0 ] || fail "forbidden $field change was accepted"
+    assert_contains "$out" "$field" "forbidden $field did not name its refusal"
+  done
+  pass "Fast Repair accepts only complete positive evidence and explicit no-risk exclusions"
+}
+
+test_evidence_and_ready_gates() {
+  local home id=gate-fixture out status fakebin
+  home=$(make_home gates)
+  intake "$home" "$id" >/dev/null
+  write_fast_meta "$home" "$id"
+
+  out=$(run_fast "$home" evidence "$id" --regression-command false --focused-command true)
+  status=$?
+  [ "$status" -ne 0 ] || fail "failed regression evidence allowed publication"
+  assert_contains "$out" "PR publication remains blocked" "failed evidence did not explain the publication block"
+
+  run_fast "$home" evidence "$id" --regression-command true --focused-command true >/dev/null || fail "passing focused evidence was rejected"
+  fakebin="$home/fakebin"
+  mkdir -p "$fakebin"
+  cat > "$fakebin/gh-axi" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+  pr)
+    case "${2:-}" in
+      create) printf 'https://github.com/acme/repo/pull/42\n' ;;
+      checks) printf 'summary: "4 passed, 0 failed, 0 pending, 4 total"\n' ;;
+    esac
+    ;;
+esac
+SH
+  cat > "$fakebin/gh" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+  chmod +x "$fakebin/gh-axi"
+  chmod +x "$fakebin/gh"
+  printf 'Fast Repair fixture body.\n' > "$home/body.md"
+  out=$(PATH="$fakebin:$PATH" run_fast "$home" publish-pr "$id" --title 'Fast Repair fixture' --body-file "$home/body.md")
+  assert_contains "$out" 'fast-repair PR opened: https://github.com/acme/repo/pull/42' "passing evidence did not open the direct PR"
+  assert_grep 'pr=https://github.com/acme/repo/pull/42' "$home/state/$id.meta" "direct PR was not registered"
+  PATH="$fakebin:$PATH" run_fast "$home" broader "$id" --command true >/dev/null || fail "broader tests could not start after direct PR publication"
+  out=$(PATH="$fakebin:$PATH" run_fast "$home" ready "$id")
+  assert_contains "$out" 'fast-repair ready: https://github.com/acme/repo/pull/42' "green broader and PR evidence did not make the PR ready"
+  out=$(PATH="$fakebin:$PATH" run_fast "$home" progress "$id")
+  assert_contains "$out" 'pr-checks-green' "green PR checks were not available to the Fast Repair progress cadence"
+  pass "Fast Repair blocks failed focused evidence and requires broader plus PR checks before ready"
+}
+
+test_exact_prefix_only
+test_eligibility_requires_every_typed_fact
+test_evidence_and_ready_gates
+echo "# all fm-fast-repair tests passed"

--- a/tests/fm-fast-repair.test.sh
+++ b/tests/fm-fast-repair.test.sh
@@ -8,6 +8,8 @@ set -u
 
 FAST="$ROOT/bin/fm-fast-repair.sh"
 TMP_ROOT=$(fm_test_tmproot fm-fast-repair)
+REGRESSION_TEST=tests/fm-fast-repair-regression.test.sh
+FOCUSED_TEST=tests/fm-fast-repair-focused.test.sh
 
 file_mode() {
   stat -c %a "$1" 2>/dev/null || stat -f %Lp "$1" 2>/dev/null
@@ -18,6 +20,7 @@ make_home() {
   home="$TMP_ROOT/$name"
   mkdir -p "$home/data" "$home/state" "$home/config"
   fm_git_init_commit "$home"
+  write_test_runner "$home"
   printf '%s\n' "$home"
 }
 
@@ -41,16 +44,29 @@ commit_test_file() {
 
 write_regression_test() {
   local home=$1 code=${2:-0}
-  printf '#!/usr/bin/env bash\nexit %s\n' "$code" > "$home/regression.test.sh"
-  chmod +x "$home/regression.test.sh"
-  commit_test_file "$home" regression.test.sh
+  mkdir -p "$home/tests"
+  printf '#!/usr/bin/env bash\nexit %s\n' "$code" > "$home/$REGRESSION_TEST"
+  chmod +x "$home/$REGRESSION_TEST"
+  commit_test_file "$home" "$REGRESSION_TEST"
 }
 
 write_focused_test() {
   local home=$1 code=${2:-0}
-  printf '#!/usr/bin/env bash\nexit %s\n' "$code" > "$home/focused.test.sh"
-  chmod +x "$home/focused.test.sh"
-  commit_test_file "$home" focused.test.sh
+  mkdir -p "$home/tests"
+  printf '#!/usr/bin/env bash\nexit %s\n' "$code" > "$home/$FOCUSED_TEST"
+  chmod +x "$home/$FOCUSED_TEST"
+  commit_test_file "$home" "$FOCUSED_TEST"
+}
+
+write_test_runner() {
+  local home=$1
+  mkdir -p "$home/bin"
+  printf '%s\n' '#!/usr/bin/env bash' 'set -eu' \
+    'case "${1:-}" in tests/*.test.sh) ;; *) exit 2 ;; esac' \
+    'printf "FM_TEST_BEGIN fixture %s family=fixture\n" "$1"' \
+    'if bash "$1"; then printf "FM_TEST_END fixture %s exit=0 duration_ms=0 gate_skip=false\n" "$1"; else printf "FM_TEST_END fixture %s exit=1 duration_ms=0 gate_skip=false\n" "$1"; exit 1; fi' > "$home/bin/fm-test-run.sh"
+  chmod +x "$home/bin/fm-test-run.sh"
+  commit_test_file "$home" bin/fm-test-run.sh
 }
 
 intake() {
@@ -211,72 +227,79 @@ test_evidence_and_ready_gates() {
   write_regression_test "$home" 1
   write_focused_test "$home"
 
-  out=$(run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-test focused.test.sh)
+  out=$(run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST")
   status=$?
   [ "$status" -ne 0 ] || fail "failed regression evidence allowed publication"
   assert_contains "$out" "PR publication remains blocked" "failed evidence did not explain the publication block"
 
-  out=$(run_fast "$home" evidence "$id" --regression-command true --focused-test focused.test.sh)
+  out=$(run_fast "$home" evidence "$id" --regression-command true --focused-test "$FOCUSED_TEST")
   status=$?
   [ "$status" -ne 0 ] || fail "an arbitrary successful regression command was accepted"
-  printf '#!/usr/bin/env bash\ntouch %q\n' "$home/untracked-test-ran" > "$home/untracked.test.sh"
-  chmod +x "$home/untracked.test.sh"
-  out=$(run_fast "$home" evidence "$id" --regression-test untracked.test.sh --focused-test focused.test.sh)
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$home/tests/pass.sh"
+  chmod +x "$home/tests/pass.sh"
+  commit_test_file "$home" tests/pass.sh
+  out=$(run_fast "$home" evidence "$id" --regression-test tests/pass.sh --focused-test "$FOCUSED_TEST")
+  status=$?
+  [ "$status" -ne 0 ] || fail "a generic exit-zero script satisfied regression evidence"
+  assert_contains "$out" 'tests/*-regression.test.sh' "the pass-script refusal did not require a typed test selector"
+  printf '#!/usr/bin/env bash\ntouch %q\n' "$home/untracked-test-ran" > "$home/tests/fm-untracked-regression.test.sh"
+  chmod +x "$home/tests/fm-untracked-regression.test.sh"
+  out=$(run_fast "$home" evidence "$id" --regression-test tests/fm-untracked-regression.test.sh --focused-test "$FOCUSED_TEST")
   status=$?
   [ "$status" -ne 0 ] || fail "an untracked regression test was accepted"
   [ ! -e "$home/untracked-test-ran" ] || fail "an untracked regression test was executed"
-  git -C "$home" add -- untracked.test.sh
-  out=$(run_fast "$home" evidence "$id" --regression-test untracked.test.sh --focused-test focused.test.sh)
+  git -C "$home" add -- tests/fm-untracked-regression.test.sh
+  out=$(run_fast "$home" evidence "$id" --regression-test tests/fm-untracked-regression.test.sh --focused-test "$FOCUSED_TEST")
   status=$?
   [ "$status" -ne 0 ] || fail "a staged-only regression test was accepted"
   [ ! -e "$home/untracked-test-ran" ] || fail "a staged-only regression test was executed"
-  git -C "$home" rm --cached --quiet -- untracked.test.sh
-  printf '#!/usr/bin/env bash\ntouch %q\n' "$home/modified-test-ran" > "$home/regression.test.sh"
-  chmod +x "$home/regression.test.sh"
-  out=$(run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-test focused.test.sh)
+  git -C "$home" rm --cached --quiet -- tests/fm-untracked-regression.test.sh
+  printf '#!/usr/bin/env bash\ntouch %q\n' "$home/modified-test-ran" > "$home/$REGRESSION_TEST"
+  chmod +x "$home/$REGRESSION_TEST"
+  out=$(run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST")
   status=$?
   [ "$status" -ne 0 ] || fail "a modified tracked regression test was accepted"
   [ ! -e "$home/modified-test-ran" ] || fail "a modified tracked regression test was executed"
   write_regression_test "$home"
-  out=$(run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-command true)
+  out=$(run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-command true)
   status=$?
   [ "$status" -ne 0 ] || fail "an arbitrary successful focused command was accepted"
   outside="$TMP_ROOT/escaped-focused-test"
   mkdir -p "$outside" "$home/tests"
-  printf '#!/usr/bin/env bash\ntouch %q\n' "$home/escaped-test-ran" > "$outside/escaped.test.sh"
-  chmod +x "$outside/escaped.test.sh"
+  printf '#!/usr/bin/env bash\ntouch %q\n' "$home/escaped-test-ran" > "$outside/fm-escaped-regression.test.sh"
+  chmod +x "$outside/fm-escaped-regression.test.sh"
   ln -s "$outside" "$home/tests/link"
-  out=$(run_fast "$home" evidence "$id" --regression-test tests/link/escaped.test.sh --focused-test focused.test.sh)
+  out=$(run_fast "$home" evidence "$id" --regression-test tests/link/fm-escaped-regression.test.sh --focused-test "$FOCUSED_TEST")
   status=$?
   [ "$status" -ne 0 ] || fail "a parent symlink escaped the Fast Repair worktree"
   [ ! -e "$home/escaped-test-ran" ] || fail "an escaped test path was executed"
   write_focused_test "$home" 1
-  out=$(run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-test focused.test.sh)
+  out=$(run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST")
   status=$?
   [ "$status" -ne 0 ] || fail "a failing focused test allowed publication"
   assert_contains "$out" "PR publication remains blocked" "failed focused evidence did not explain the publication block"
   write_focused_test "$home"
   printf 'task worktree\n' > "$home/cwd-proof"
   commit_test_file "$home" cwd-proof
-  printf '#!/usr/bin/env bash\n[ "$(cat cwd-proof)" = "task worktree" ]\n' > "$home/regression.test.sh"
-  chmod +x "$home/regression.test.sh"
-  commit_test_file "$home" regression.test.sh
-  printf '#!/usr/bin/env bash\n[ "$(cat cwd-proof)" = "task worktree" ]\n' > "$home/focused.test.sh"
-  chmod +x "$home/focused.test.sh"
-  commit_test_file "$home" focused.test.sh
+  printf '#!/usr/bin/env bash\n[ "$(cat cwd-proof)" = "task worktree" ]\n' > "$home/$REGRESSION_TEST"
+  chmod +x "$home/$REGRESSION_TEST"
+  commit_test_file "$home" "$REGRESSION_TEST"
+  printf '#!/usr/bin/env bash\n[ "$(cat cwd-proof)" = "task worktree" ]\n' > "$home/$FOCUSED_TEST"
+  chmod +x "$home/$FOCUSED_TEST"
+  commit_test_file "$home" "$FOCUSED_TEST"
   evidence_other=$(make_home evidence-cwd)
   printf 'other checkout\n' > "$evidence_other/cwd-proof"
-  out=$(run_fast_from "$evidence_other" "$home" evidence "$id" --regression-test regression.test.sh --focused-test focused.test.sh)
+  out=$(run_fast_from "$evidence_other" "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST")
   status=$?
   [ "$status" -eq 0 ] || fail "evidence tests did not run from the task worktree: $out"
-  run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-test focused.test.sh >/dev/null || fail "passing focused evidence was rejected"
+  run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST" >/dev/null || fail "passing focused evidence was rejected"
   git -C "$home" commit --quiet --allow-empty -m 'advance repair fixture'
   printf 'Fast Repair fixture body.\n' > "$home/body.md"
   out=$(run_fast "$home" publish-pr "$id" --title 'Fast Repair fixture' --body-file "$home/body.md")
   status=$?
   [ "$status" -ne 0 ] || fail "Fast Repair published a commit that its evidence did not test"
   assert_contains "$out" 'focused evidence is absent or failed' "untested commit refusal was not actionable"
-  run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-test focused.test.sh >/dev/null || fail "updated task HEAD evidence was rejected"
+  run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST" >/dev/null || fail "updated task HEAD evidence was rejected"
   write_fake_gh "$home"
   fakebin="$home/fakebin"
   printf '%040d\n' 0 > "$home/pr-head"
@@ -315,7 +338,7 @@ test_evidence_and_ready_gates() {
   assert_contains "$out" 'pr-checks-green' "green PR checks were not available to the Fast Repair progress cadence"
   assert_grep '--repo acme/repo' "$home/gh-axi.args" "PR checks were not read from the registered PR's own repository"
   git -C "$home" commit --quiet --allow-empty -m 'advance broader fixture'
-  run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-test focused.test.sh >/dev/null \
+  run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST" >/dev/null \
     || fail "updated focused evidence was rejected after a new commit"
   out=$(PATH="$fakebin:$PATH" run_fast "$home" ready "$id")
   status=$?
@@ -334,7 +357,7 @@ test_pr_check_rollup_states() {
   write_fake_gh "$home"
   fakebin="$home/fakebin"
   printf '%s\n' "$(git -C "$home" rev-parse HEAD)" > "$home/pr-head"
-  run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-test focused.test.sh >/dev/null \
+  run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST" >/dev/null \
     || fail "focused evidence fixture was rejected"
   PATH="$fakebin:$PATH" run_fast "$home" broader "$id" --command true >/dev/null \
     || fail "broader fixture was rejected"
@@ -400,7 +423,7 @@ test_stored_eligibility_uses_the_intake_rule() {
   status=$?
   [ "$status" -ne 0 ] || fail "a stored fact intake refuses still passed the eligibility gate"
   assert_contains "$out" "eligibility evidence" "the eligibility gate did not name its refusal"
-  out=$(run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-test focused.test.sh)
+  out=$(run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST")
   status=$?
   [ "$status" -ne 0 ] || fail "a stored fact intake refuses still reached the evidence gate"
   pass "every Fast Repair gate re-applies intake's own rule to the stored evidence record"
@@ -413,7 +436,7 @@ test_later_gates_revalidate_typed_eligibility() {
   write_fast_meta "$home" "$id" https://github.com/acme/repo/pull/42
   write_regression_test "$home"
   write_focused_test "$home"
-  out=$(run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-test focused.test.sh)
+  out=$(run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST")
   status=$?
   [ "$status" -eq 0 ] || fail "the later-gate fixture could not record focused evidence: $out"
   f="$home/data/$id/fast-repair-eligibility"
@@ -456,7 +479,7 @@ test_brief_commands_reach_the_scaffolding_home() {
   [ "$prefix" != "$cmd" ] || fail "the mandated evidence command could not be read from the brief"
 
   out=$(cd "$home" && env -u FM_HOME -u FM_STATE_OVERRIDE -u FM_DATA_OVERRIDE -u FM_ROOT_OVERRIDE \
-    bash -c "$prefix evidence $id --regression-test regression.test.sh --focused-test focused.test.sh" 2>&1)
+    bash -c "$prefix evidence $id --regression-test $REGRESSION_TEST --focused-test $FOCUSED_TEST" 2>&1)
   status=$?
   [ "$status" -eq 0 ] || fail "the brief's own evidence command could not reach the task record: $out"
   assert_grep 'regression=passed' "$home/state/$id.fast-repair-tests" \
@@ -482,14 +505,14 @@ exit 0
 SH
   chmod +x "$toolbin/fm-fixture-tool"
   write_regression_test "$home"
-  printf '#!/usr/bin/env bash\nfm-fixture-tool\n' > "$home/focused.test.sh"
-  chmod +x "$home/focused.test.sh"
-  commit_test_file "$home" focused.test.sh
+  printf '#!/usr/bin/env bash\nfm-fixture-tool\n' > "$home/$FOCUSED_TEST"
+  chmod +x "$home/$FOCUSED_TEST"
+  commit_test_file "$home" "$FOCUSED_TEST"
 
   out=$(cd "$home" && HOME="$loginhome" PATH="$toolbin:$PATH" FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
-    "$FAST" evidence "$id" --regression-test regression.test.sh \
-    --focused-test focused.test.sh 2>&1)
+    "$FAST" evidence "$id" --regression-test "$REGRESSION_TEST" \
+    --focused-test "$FOCUSED_TEST" 2>&1)
   status=$?
   [ "$status" -eq 0 ] \
     || fail "a login profile's PATH reset decided the evidence result: $out
@@ -508,14 +531,15 @@ test_private_records_do_not_impose_their_umask_on_tests() {
   intake "$home" "$id" >/dev/null
   write_fast_meta "$home" "$id"
   artifact="$home/suite-artifact"
-  printf '#!/usr/bin/env bash\ntouch %q\n' "$artifact" > "$home/regression.test.sh"
-  chmod +x "$home/regression.test.sh"
-  commit_test_file "$home" regression.test.sh
+  mkdir -p "$home/tests"
+  printf '#!/usr/bin/env bash\ntouch %q\n' "$artifact" > "$home/$REGRESSION_TEST"
+  chmod +x "$home/$REGRESSION_TEST"
+  commit_test_file "$home" "$REGRESSION_TEST"
   write_focused_test "$home"
 
   ( umask 022
     run_fast "$home" evidence "$id" \
-      --regression-test regression.test.sh --focused-test focused.test.sh >/dev/null ) \
+      --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST" >/dev/null ) \
     || fail "the evidence gate refused its own passing fixture commands"
 
   [ -e "$artifact" ] || fail "the regression command did not run"

--- a/tests/fm-fast-repair.test.sh
+++ b/tests/fm-fast-repair.test.sh
@@ -8,8 +8,8 @@ set -u
 
 FAST="$ROOT/bin/fm-fast-repair.sh"
 TMP_ROOT=$(fm_test_tmproot fm-fast-repair)
-REGRESSION_TEST=tests/fm-fast-repair-regression.test.sh
-FOCUSED_TEST=tests/fm-fast-repair-focused.test.sh
+REGRESSION_TEST=fixture-regression
+FOCUSED_TEST=fixture-focused
 
 file_mode() {
   stat -c %a "$1" 2>/dev/null || stat -f %Lp "$1" 2>/dev/null
@@ -21,6 +21,10 @@ make_home() {
   mkdir -p "$home/data" "$home/state" "$home/config"
   fm_git_init_commit "$home"
   write_test_runner "$home"
+  printf 'broken\n' > "$home/fixture-regression-state"
+  printf 'passed\n' > "$home/fixture-focused-state"
+  commit_test_file "$home" fixture-regression-state
+  commit_test_file "$home" fixture-focused-state
   printf '%s\n' "$home"
 }
 
@@ -44,27 +48,25 @@ commit_test_file() {
 
 write_regression_test() {
   local home=$1 code=${2:-0}
-  mkdir -p "$home/tests"
-  printf '#!/usr/bin/env bash\nexit %s\n' "$code" > "$home/$REGRESSION_TEST"
-  chmod +x "$home/$REGRESSION_TEST"
-  commit_test_file "$home" "$REGRESSION_TEST"
+  if [ "$code" = 0 ]; then printf 'fixed\n' > "$home/fixture-regression-state"; else printf 'broken\n' > "$home/fixture-regression-state"; fi
+  git -C "$home" diff --quiet -- fixture-regression-state || commit_test_file "$home" fixture-regression-state
 }
 
 write_focused_test() {
   local home=$1 code=${2:-0}
-  mkdir -p "$home/tests"
-  printf '#!/usr/bin/env bash\nexit %s\n' "$code" > "$home/$FOCUSED_TEST"
-  chmod +x "$home/$FOCUSED_TEST"
-  commit_test_file "$home" "$FOCUSED_TEST"
+  if [ "$code" = 0 ]; then printf 'passed\n' > "$home/fixture-focused-state"; else printf 'failed\n' > "$home/fixture-focused-state"; fi
+  git -C "$home" diff --quiet -- fixture-focused-state || commit_test_file "$home" fixture-focused-state
 }
 
 write_test_runner() {
   local home=$1
   mkdir -p "$home/bin"
   printf '%s\n' '#!/usr/bin/env bash' 'set -eu' \
-    'case "${1:-}" in tests/*.test.sh) ;; *) exit 2 ;; esac' \
-    'printf "FM_TEST_BEGIN fixture %s family=fixture\n" "$1"' \
-    'if bash "$1"; then printf "FM_TEST_END fixture %s exit=0 duration_ms=0 gate_skip=false\n" "$1"; else printf "FM_TEST_END fixture %s exit=1 duration_ms=0 gate_skip=false\n" "$1"; exit 1; fi' > "$home/bin/fm-test-run.sh"
+    'if [ "${1:-}" = --list-families ]; then printf "%s\n" fixture-regression fixture-focused; exit 0; fi' \
+    '[ "${1:-}" = --family ] && [ "$#" = 2 ] || exit 2' \
+    'printf "FM_TEST_BEGIN fixture %s family=%s\n" "$2" "$2"' \
+    'if case "$2" in fixture-regression) [ "$(cat fixture-regression-state)" = fixed ] ;; fixture-focused) [ "$(cat fixture-focused-state)" = passed ] ;; *) false ;; esac; then status=0; else status=1; fi' \
+    'printf "FM_TEST_END fixture %s exit=%s duration_ms=0 gate_skip=false\n" "$2" "$status"; exit "$status"' > "$home/bin/fm-test-run.sh"
   chmod +x "$home/bin/fm-test-run.sh"
   commit_test_file "$home" bin/fm-test-run.sh
 }
@@ -73,7 +75,7 @@ intake() {
   local home=$1 id=$2 reproduction=${3-reproduced} root_cause=${4-confirmed} isolation=${5-isolated}
   local schema=${6-none} authentication=${7-none} authorization=${8-none} secrets=${9-none} financial=${10-none} legal=${11-none} side_effects=${12-none}
   run_fast "$home" intake "$id" --request 'fast-repair: repair fixture' \
-    --reproduction "$reproduction" --root-cause "$root_cause" --isolation "$isolation" \
+    --reproduction "$reproduction" --reproduction-revision "$(git -C "$home" rev-parse HEAD)" --root-cause "$root_cause" --isolation "$isolation" \
     --schema "$schema" --authentication "$authentication" --authorization "$authorization" \
     --secrets "$secrets" --financial "$financial" --legal "$legal" --side-effects "$side_effects"
 }
@@ -235,13 +237,14 @@ test_evidence_and_ready_gates() {
   out=$(run_fast "$home" evidence "$id" --regression-command true --focused-test "$FOCUSED_TEST")
   status=$?
   [ "$status" -ne 0 ] || fail "an arbitrary successful regression command was accepted"
+  mkdir -p "$home/tests"
   printf '#!/usr/bin/env bash\nexit 0\n' > "$home/tests/pass.sh"
   chmod +x "$home/tests/pass.sh"
   commit_test_file "$home" tests/pass.sh
-  out=$(run_fast "$home" evidence "$id" --regression-test tests/pass.sh --focused-test "$FOCUSED_TEST")
+  out=$(run_fast "$home" evidence "$id" --regression-test pass --focused-test "$FOCUSED_TEST")
   status=$?
   [ "$status" -ne 0 ] || fail "a generic exit-zero script satisfied regression evidence"
-  assert_contains "$out" 'tests/*-regression.test.sh' "the pass-script refusal did not require a typed test selector"
+  assert_contains "$out" 'supported bin/fm-test-run.sh family' "the pass-script refusal did not require a runner-owned selector"
   printf '#!/usr/bin/env bash\ntouch %q\n' "$home/untracked-test-ran" > "$home/tests/fm-untracked-regression.test.sh"
   chmod +x "$home/tests/fm-untracked-regression.test.sh"
   out=$(run_fast "$home" evidence "$id" --regression-test tests/fm-untracked-regression.test.sh --focused-test "$FOCUSED_TEST")
@@ -531,10 +534,7 @@ test_private_records_do_not_impose_their_umask_on_tests() {
   intake "$home" "$id" >/dev/null
   write_fast_meta "$home" "$id"
   artifact="$home/suite-artifact"
-  mkdir -p "$home/tests"
-  printf '#!/usr/bin/env bash\ntouch %q\n' "$artifact" > "$home/$REGRESSION_TEST"
-  chmod +x "$home/$REGRESSION_TEST"
-  commit_test_file "$home" "$REGRESSION_TEST"
+  write_regression_test "$home"
   write_focused_test "$home"
 
   ( umask 022
@@ -542,9 +542,6 @@ test_private_records_do_not_impose_their_umask_on_tests() {
       --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST" >/dev/null ) \
     || fail "the evidence gate refused its own passing fixture commands"
 
-  [ -e "$artifact" ] || fail "the regression command did not run"
-  [ "$(file_mode "$artifact")" = 644 ] \
-    || fail "a test suite's own output inherited the record umask: $(file_mode "$artifact")"
   [ "$(file_mode "$home/state/$id.fast-repair-tests")" = 600 ] \
     || fail "the evidence record is not owner-only: $(file_mode "$home/state/$id.fast-repair-tests")"
   [ "$(file_mode "$home/state/$id.fast-repair-tests.log")" = 600 ] \

--- a/tests/fm-fast-repair.test.sh
+++ b/tests/fm-fast-repair.test.sh
@@ -583,7 +583,7 @@ test_later_gates_revalidate_typed_eligibility() {
 # command is extracted from it and executed in the environment a crewmate pane
 # actually has: no FM_HOME and no state or data override.
 test_brief_commands_reach_the_scaffolding_home() {
-  local home id=brief-home brief line cmd prefix out status
+  local home id=brief-home brief line cmd prefix broader_cmd out status fakebin body
   home=$(make_home brief-home)
   intake "$home" "$id" >/dev/null
   write_fast_meta "$home" "$id"
@@ -607,6 +607,29 @@ test_brief_commands_reach_the_scaffolding_home() {
   [ "$status" -eq 0 ] || fail "the brief's own evidence command could not reach the task record: $out"
   assert_grep 'regression=passed' "$home/state/$id.fast-repair-tests" \
     "the brief's evidence command recorded its result outside the scaffolding home"
+
+  write_fake_gh "$home"
+  fakebin=$FAKE_GH_BIN
+  printf '%s\n' "$(git -C "$home" rev-parse HEAD)" > "$FAKE_GH_DIR/pr-head"
+  set_rollup "$FAKE_GH_DIR" '4 passed, 0 failed, 4 total'
+  body="$TMP_ROOT/brief-body.md"
+  printf 'Fast Repair brief body.\n' > "$body"
+  out=$(cd "$home" && env -u FM_HOME -u FM_STATE_OVERRIDE -u FM_DATA_OVERRIDE -u FM_ROOT_OVERRIDE \
+    PATH="$fakebin:$PATH" bash -c "$prefix publish-pr $id --title 'Brief Fast Repair' --body-file $body" 2>&1)
+  status=$?
+  [ "$status" -eq 0 ] || fail "the brief's own publish command could not open the tested PR: $out"
+
+  line=$(grep -F " broader $id " "$brief" | head -n 1)
+  [ -n "$line" ] || fail "the Fast Repair brief mandates no broader-test command"
+  cmd=${line#*\`}
+  cmd=${cmd%\`*}
+  broader_cmd=${cmd/"'<runner family>'"/"$FOCUSED_TEST"}
+  out=$(cd "$home" && env -u FM_HOME -u FM_STATE_OVERRIDE -u FM_DATA_OVERRIDE -u FM_ROOT_OVERRIDE \
+    PATH="$fakebin:$PATH" bash -c "$broader_cmd" 2>&1)
+  status=$?
+  [ "$status" -eq 0 ] || fail "the brief's own broader-test command could not run: $out"
+  assert_contains "$out" "fast-repair broader tests passed: $id" \
+    "the brief's broader-test command did not use the typed test interface"
   pass "the Fast Repair brief's commands run against the home that scaffolded them"
 }
 

--- a/tests/fm-fast-repair.test.sh
+++ b/tests/fm-fast-repair.test.sh
@@ -865,6 +865,41 @@ test_skipped_selector_run_cannot_satisfy_evidence() {
   pass "Fast Repair applies one skip rule to family and selector runner invocations alike"
 }
 
+# Once the watcher has stopped polling the forge for a task it still needs the
+# local half of the progress check, so --local-only must keep the broader-test
+# branch and must reach no forge command at all.
+test_local_only_progress_reads_no_forge() {
+  local home id=local-only out status fakebin
+  home=$(make_home local-only-progress)
+  intake "$home" "$id" >/dev/null
+  write_fast_meta "$home" "$id" https://github.com/acme/repo/pull/42
+  write_fake_gh "$home"
+  fakebin="$FAKE_GH_BIN"
+  printf '%s\n' "$(git -C "$home" rev-parse HEAD)" > "$FAKE_GH_DIR/pr-head"
+  set_rollup "$FAKE_GH_DIR" '4 passed, 0 failed, 4 total'
+
+  out=$(PATH="$fakebin:$PATH" run_fast "$home" progress "$id")
+  assert_contains "$out" "fast-repair $id pr-checks-green" "the ordinary progress check did not read the PR rollup"
+  assert_grep 'pr checks' "$FAKE_GH_DIR/gh-axi.args" "the ordinary progress check did not reach the forge"
+
+  : > "$FAKE_GH_DIR/gh-axi.args"
+  out=$(PATH="$fakebin:$PATH" run_fast "$home" progress "$id" --local-only)
+  status=$?
+  [ "$status" -eq 0 ] || fail "the local-only progress check refused: $out"
+  [ -z "$out" ] || fail "the local-only progress check reported a forge state: $out"
+  [ ! -s "$FAKE_GH_DIR/gh-axi.args" ] || fail "the local-only progress check reached the forge: $(cat "$FAKE_GH_DIR/gh-axi.args")"
+
+  printf 'broader=failed\n' > "$home/state/$id.fast-repair-broader"
+  out=$(PATH="$fakebin:$PATH" run_fast "$home" progress "$id" --local-only)
+  assert_contains "$out" "fast-repair $id broader-tests-failed" "the local-only progress check hid a broader failure"
+  [ ! -s "$FAKE_GH_DIR/gh-axi.args" ] || fail "the local-only broader branch reached the forge: $(cat "$FAKE_GH_DIR/gh-axi.args")"
+
+  out=$(PATH="$fakebin:$PATH" run_fast "$home" progress "$id" --unknown-flag)
+  status=$?
+  [ "$status" -ne 0 ] || fail "progress accepted an unknown flag"
+  pass "the local-only Fast Repair progress check keeps broader follow-up without reading the forge"
+}
+
 test_exact_prefix_only
 test_eligibility_requires_every_typed_fact
 test_spawn_eligibility_accepts_the_detached_task_worktree
@@ -882,4 +917,5 @@ test_regression_witness_requires_a_failing_reproduction
 test_regression_witness_uses_the_tested_runner
 test_evidence_requires_clean_bound_artifacts
 test_pr_check_rollup_states
+test_local_only_progress_reads_no_forge
 echo "# all fm-fast-repair tests passed"

--- a/tests/fm-fast-repair.test.sh
+++ b/tests/fm-fast-repair.test.sh
@@ -208,8 +208,62 @@ test_pr_check_rollup_states() {
   pass "Fast Repair reads the PR rollup counts numerically for ready and the progress cadence"
 }
 
+# The eligibility record is this tool's own private, versioned evidence file, so
+# the test writes one directly to prove the gate re-applies the intake rule to
+# whatever the record actually holds.
+test_stored_eligibility_uses_the_intake_rule() {
+  local home id=stored-rule f tmp out status
+  home=$(make_home stored-rule)
+  intake "$home" "$id" >/dev/null
+  run_fast "$home" eligible "$id" >/dev/null || fail "a complete stored record did not validate"
+  write_fast_meta "$home" "$id"
+
+  f="$home/data/$id/fast-repair-eligibility"
+  tmp="$home/eligibility.tmp"
+  sed 's/^reproduction=.*/reproduction=false/' "$f" > "$tmp" && mv -f "$tmp" "$f"
+  out=$(run_fast "$home" eligible "$id")
+  status=$?
+  [ "$status" -ne 0 ] || fail "a stored fact intake refuses still passed the eligibility gate"
+  assert_contains "$out" "eligibility evidence" "the eligibility gate did not name its refusal"
+  out=$(run_fast "$home" evidence "$id" --regression-command true --focused-command true)
+  status=$?
+  [ "$status" -ne 0 ] || fail "a stored fact intake refuses still reached the evidence gate"
+  pass "every Fast Repair gate re-applies intake's own rule to the stored evidence record"
+}
+
+# The generated brief is firstmate's emitted worker interface, so the mandated
+# command is extracted from it and executed in the environment a crewmate pane
+# actually has: no FM_HOME and no state or data override.
+test_brief_commands_reach_the_scaffolding_home() {
+  local home id=brief-home brief line cmd prefix out status
+  home=$(make_home brief-home)
+  intake "$home" "$id" >/dev/null
+  write_fast_meta "$home" "$id"
+  FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    "$ROOT/bin/fm-brief.sh" "$id" fixtureproj --mode fast-repair >/dev/null \
+    || fail "the Fast Repair brief could not be scaffolded"
+
+  brief="$home/data/$id/brief.md"
+  line=$(grep -F " evidence $id " "$brief" | head -n 1)
+  [ -n "$line" ] || fail "the Fast Repair brief mandates no evidence command"
+  cmd=${line#*\`}
+  cmd=${cmd%\`*}
+  prefix=${cmd%% evidence *}
+  [ "$prefix" != "$cmd" ] || fail "the mandated evidence command could not be read from the brief"
+
+  out=$(env -u FM_HOME -u FM_STATE_OVERRIDE -u FM_DATA_OVERRIDE -u FM_ROOT_OVERRIDE \
+    bash -c "$prefix evidence $id --regression-command true --focused-command true" 2>&1)
+  status=$?
+  [ "$status" -eq 0 ] || fail "the brief's own evidence command could not reach the task record: $out"
+  assert_grep 'regression=passed' "$home/state/$id.fast-repair-tests" \
+    "the brief's evidence command recorded its result outside the scaffolding home"
+  pass "the Fast Repair brief's commands run against the home that scaffolded them"
+}
+
 test_exact_prefix_only
 test_eligibility_requires_every_typed_fact
+test_stored_eligibility_uses_the_intake_rule
+test_brief_commands_reach_the_scaffolding_home
 test_evidence_and_ready_gates
 test_pr_check_rollup_states
 echo "# all fm-fast-repair tests passed"

--- a/tests/fm-fast-repair.test.sh
+++ b/tests/fm-fast-repair.test.sh
@@ -32,6 +32,12 @@ write_regression_test() {
   chmod +x "$home/regression.test.sh"
 }
 
+write_focused_test() {
+  local home=$1 code=${2:-0}
+  printf '#!/usr/bin/env bash\nexit %s\n' "$code" > "$home/focused.test.sh"
+  chmod +x "$home/focused.test.sh"
+}
+
 intake() {
   local home=$1 id=$2 reproduction=${3-reproduced} root_cause=${4-confirmed} isolation=${5-isolated}
   local schema=${6-none} authentication=${7-none} authorization=${8-none} secrets=${9-none} financial=${10-none} legal=${11-none} side_effects=${12-none}
@@ -105,6 +111,14 @@ test_eligibility_requires_every_typed_fact() {
   assert_contains "$out" "fast-repair eligible: $id" "complete typed eligibility did not pass"
   run_fast "$home" eligible "$id" >/dev/null || fail "stored complete eligibility did not validate"
 
+  for id in . ..; do
+    out=$(intake "$home" "$id")
+    status=$?
+    [ "$status" -ne 0 ] || fail "a dot task id escaped the Fast Repair task directory: $id"
+  done
+  [ ! -e "$home/data/fast-repair-eligibility" ] || fail "the dot task id wrote outside its task directory"
+  [ ! -e "$home/fast-repair-eligibility" ] || fail "the dot-dot task id wrote outside the data directory"
+
   out=$(intake "$home" invalid-reproduction a confirmed isolated)
   status=$?
   [ "$status" -ne 0 ] || fail "an untyped reproduction proof was accepted"
@@ -161,17 +175,27 @@ test_evidence_and_ready_gates() {
   intake "$home" "$id" >/dev/null
   write_fast_meta "$home" "$id"
   write_regression_test "$home" 1
+  write_focused_test "$home"
 
-  out=$(run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-command true)
+  out=$(run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-test focused.test.sh)
   status=$?
   [ "$status" -ne 0 ] || fail "failed regression evidence allowed publication"
   assert_contains "$out" "PR publication remains blocked" "failed evidence did not explain the publication block"
 
-  out=$(run_fast "$home" evidence "$id" --regression-command true --focused-command true)
+  out=$(run_fast "$home" evidence "$id" --regression-command true --focused-test focused.test.sh)
   status=$?
   [ "$status" -ne 0 ] || fail "an arbitrary successful regression command was accepted"
   write_regression_test "$home"
-  run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-command true >/dev/null || fail "passing focused evidence was rejected"
+  out=$(run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-command true)
+  status=$?
+  [ "$status" -ne 0 ] || fail "an arbitrary successful focused command was accepted"
+  write_focused_test "$home" 1
+  out=$(run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-test focused.test.sh)
+  status=$?
+  [ "$status" -ne 0 ] || fail "a failing focused test allowed publication"
+  assert_contains "$out" "PR publication remains blocked" "failed focused evidence did not explain the publication block"
+  write_focused_test "$home"
+  run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-test focused.test.sh >/dev/null || fail "passing focused evidence was rejected"
   write_fake_gh "$home"
   fakebin="$home/fakebin"
   # The real green rollup omits the pending segment when nothing is pending.
@@ -195,9 +219,10 @@ test_pr_check_rollup_states() {
   intake "$home" "$id" >/dev/null
   write_fast_meta "$home" "$id" https://github.com/acme/repo/pull/42
   write_regression_test "$home"
+  write_focused_test "$home"
   write_fake_gh "$home"
   fakebin="$home/fakebin"
-  run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-command true >/dev/null \
+  run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-test focused.test.sh >/dev/null \
     || fail "focused evidence fixture was rejected"
   PATH="$fakebin:$PATH" run_fast "$home" broader "$id" --command true >/dev/null \
     || fail "broader fixture was rejected"
@@ -263,7 +288,7 @@ test_stored_eligibility_uses_the_intake_rule() {
   status=$?
   [ "$status" -ne 0 ] || fail "a stored fact intake refuses still passed the eligibility gate"
   assert_contains "$out" "eligibility evidence" "the eligibility gate did not name its refusal"
-  out=$(run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-command true)
+  out=$(run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-test focused.test.sh)
   status=$?
   [ "$status" -ne 0 ] || fail "a stored fact intake refuses still reached the evidence gate"
   pass "every Fast Repair gate re-applies intake's own rule to the stored evidence record"
@@ -275,7 +300,8 @@ test_later_gates_revalidate_typed_eligibility() {
   intake "$home" "$id" >/dev/null
   write_fast_meta "$home" "$id" https://github.com/acme/repo/pull/42
   write_regression_test "$home"
-  run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-command true >/dev/null \
+  write_focused_test "$home"
+  run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-test focused.test.sh >/dev/null \
     || fail "the later-gate fixture could not record focused evidence"
   f="$home/data/$id/fast-repair-eligibility"
   sed 's/^isolation=.*/isolation=isolated-change/' "$f" > "$f.tmp" && mv -f "$f.tmp" "$f"
@@ -303,6 +329,7 @@ test_brief_commands_reach_the_scaffolding_home() {
   intake "$home" "$id" >/dev/null
   write_fast_meta "$home" "$id"
   write_regression_test "$home"
+  write_focused_test "$home"
   FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     "$ROOT/bin/fm-brief.sh" "$id" fixtureproj --mode fast-repair >/dev/null \
     || fail "the Fast Repair brief could not be scaffolded"
@@ -316,7 +343,7 @@ test_brief_commands_reach_the_scaffolding_home() {
   [ "$prefix" != "$cmd" ] || fail "the mandated evidence command could not be read from the brief"
 
   out=$(cd "$home" && env -u FM_HOME -u FM_STATE_OVERRIDE -u FM_DATA_OVERRIDE -u FM_ROOT_OVERRIDE \
-    bash -c "$prefix evidence $id --regression-test regression.test.sh --focused-command true" 2>&1)
+    bash -c "$prefix evidence $id --regression-test regression.test.sh --focused-test focused.test.sh" 2>&1)
   status=$?
   [ "$status" -eq 0 ] || fail "the brief's own evidence command could not reach the task record: $out"
   assert_grep 'regression=passed' "$home/state/$id.fast-repair-tests" \
@@ -342,11 +369,13 @@ exit 0
 SH
   chmod +x "$toolbin/fm-fixture-tool"
   write_regression_test "$home"
+  printf '#!/usr/bin/env bash\nfm-fixture-tool\n' > "$home/focused.test.sh"
+  chmod +x "$home/focused.test.sh"
 
   out=$(cd "$home" && HOME="$loginhome" PATH="$toolbin:$PATH" FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     "$FAST" evidence "$id" --regression-test regression.test.sh \
-    --focused-command fm-fixture-tool 2>&1)
+    --focused-test focused.test.sh 2>&1)
   status=$?
   [ "$status" -eq 0 ] \
     || fail "a login profile's PATH reset decided the evidence result: $out
@@ -367,10 +396,11 @@ test_private_records_do_not_impose_their_umask_on_tests() {
   artifact="$home/suite-artifact"
   printf '#!/usr/bin/env bash\ntouch %q\n' "$artifact" > "$home/regression.test.sh"
   chmod +x "$home/regression.test.sh"
+  write_focused_test "$home"
 
   ( umask 022
     run_fast "$home" evidence "$id" \
-      --regression-test regression.test.sh --focused-command true >/dev/null ) \
+      --regression-test regression.test.sh --focused-test focused.test.sh >/dev/null ) \
     || fail "the evidence gate refused its own passing fixture commands"
 
   [ -e "$artifact" ] || fail "the regression command did not run"

--- a/tests/fm-fast-repair.test.sh
+++ b/tests/fm-fast-repair.test.sh
@@ -27,16 +27,30 @@ run_fast() {
   ( cd "$home" && FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" "$FAST" "$@" ) 2>&1
 }
 
+run_fast_from() {
+  local cwd=$1 home=$2
+  shift 2
+  ( cd "$cwd" && FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" "$FAST" "$@" ) 2>&1
+}
+
+commit_test_file() {
+  local home=$1 file=$2
+  git -C "$home" add -- "$file"
+  git -C "$home" commit --quiet --only -m "add Fast Repair test" -- "$file"
+}
+
 write_regression_test() {
   local home=$1 code=${2:-0}
   printf '#!/usr/bin/env bash\nexit %s\n' "$code" > "$home/regression.test.sh"
   chmod +x "$home/regression.test.sh"
+  commit_test_file "$home" regression.test.sh
 }
 
 write_focused_test() {
   local home=$1 code=${2:-0}
   printf '#!/usr/bin/env bash\nexit %s\n' "$code" > "$home/focused.test.sh"
   chmod +x "$home/focused.test.sh"
+  commit_test_file "$home" focused.test.sh
 }
 
 intake() {
@@ -61,6 +75,7 @@ FAKE_HOME='$home'
 EOF
   cat >> "$fakebin/gh-axi" <<'SH'
 printf '%s\n' "$*" >> "$FAKE_HOME/gh-axi.args"
+pwd >> "$FAKE_HOME/gh-axi.cwd"
 case "${1:-}" in
   pr)
     case "${2:-}" in
@@ -189,7 +204,7 @@ test_eligibility_requires_every_typed_fact() {
 }
 
 test_evidence_and_ready_gates() {
-  local home id=gate-fixture out status fakebin outside branch
+  local home id=gate-fixture out status fakebin outside branch other
   home=$(make_home gates)
   intake "$home" "$id" >/dev/null
   write_fast_meta "$home" "$id"
@@ -204,6 +219,24 @@ test_evidence_and_ready_gates() {
   out=$(run_fast "$home" evidence "$id" --regression-command true --focused-test focused.test.sh)
   status=$?
   [ "$status" -ne 0 ] || fail "an arbitrary successful regression command was accepted"
+  printf '#!/usr/bin/env bash\ntouch %q\n' "$home/untracked-test-ran" > "$home/untracked.test.sh"
+  chmod +x "$home/untracked.test.sh"
+  out=$(run_fast "$home" evidence "$id" --regression-test untracked.test.sh --focused-test focused.test.sh)
+  status=$?
+  [ "$status" -ne 0 ] || fail "an untracked regression test was accepted"
+  [ ! -e "$home/untracked-test-ran" ] || fail "an untracked regression test was executed"
+  git -C "$home" add -- untracked.test.sh
+  out=$(run_fast "$home" evidence "$id" --regression-test untracked.test.sh --focused-test focused.test.sh)
+  status=$?
+  [ "$status" -ne 0 ] || fail "a staged-only regression test was accepted"
+  [ ! -e "$home/untracked-test-ran" ] || fail "a staged-only regression test was executed"
+  git -C "$home" rm --cached --quiet -- untracked.test.sh
+  printf '#!/usr/bin/env bash\ntouch %q\n' "$home/modified-test-ran" > "$home/regression.test.sh"
+  chmod +x "$home/regression.test.sh"
+  out=$(run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-test focused.test.sh)
+  status=$?
+  [ "$status" -ne 0 ] || fail "a modified tracked regression test was accepted"
+  [ ! -e "$home/modified-test-ran" ] || fail "a modified tracked regression test was executed"
   write_regression_test "$home"
   out=$(run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-command true)
   status=$?
@@ -246,12 +279,16 @@ test_evidence_and_ready_gates() {
   [ "$status" -ne 0 ] || fail "Fast Repair accepted a PR with an untested remote head"
   assert_contains "$out" 'registered PR head does not match' "remote-head refusal was not actionable"
   printf '%s\n' "$(git -C "$home" rev-parse HEAD)" > "$home/pr-head"
-  out=$(PATH="$fakebin:$PATH" run_fast "$home" publish-pr "$id" --title 'Fast Repair fixture' --body-file "$home/body.md")
+  other=$(make_home other-caller)
+  printf 'Fast Repair caller body.\n' > "$other/body.md"
+  out=$(PATH="$fakebin:$PATH" run_fast_from "$other" "$home" publish-pr "$id" --title 'Fast Repair fixture' --body-file body.md)
   assert_contains "$out" 'fast-repair PR opened: https://github.com/acme/repo/pull/42' "passing evidence did not open the direct PR"
   assert_grep 'pr=https://github.com/acme/repo/pull/42' "$home/state/$id.meta" "direct PR was not registered"
   branch=$(git -C "$home" symbolic-ref --short HEAD)
-  assert_grep "pr create --title Fast Repair fixture --body-file $home/body.md --head $branch" "$home/gh-axi.args" \
+  assert_grep "pr create --title Fast Repair fixture --body-file $other/body.md --head $branch" "$home/gh-axi.args" \
     "direct PR did not use the tested task branch"
+  [ "$(tail -n 1 "$home/gh-axi.cwd")" = "$home" ] \
+    || fail "direct PR creation ran outside the task worktree"
   PATH="$fakebin:$PATH" run_fast "$home" broader "$id" --command true >/dev/null || fail "broader tests could not start after direct PR publication"
   out=$(PATH="$fakebin:$PATH" run_fast "$home" ready "$id")
   assert_contains "$out" 'fast-repair ready: https://github.com/acme/repo/pull/42' "green broader and PR evidence did not make the PR ready"
@@ -278,9 +315,9 @@ test_pr_check_rollup_states() {
   local home id=rollup-fixture fakebin out status
   home=$(make_home rollup)
   intake "$home" "$id" >/dev/null
-  write_fast_meta "$home" "$id" https://github.com/acme/repo/pull/42
   write_regression_test "$home"
   write_focused_test "$home"
+  write_fast_meta "$home" "$id" https://github.com/acme/repo/pull/42
   write_fake_gh "$home"
   fakebin="$home/fakebin"
   printf '%s\n' "$(git -C "$home" rev-parse HEAD)" > "$home/pr-head"
@@ -434,6 +471,7 @@ SH
   write_regression_test "$home"
   printf '#!/usr/bin/env bash\nfm-fixture-tool\n' > "$home/focused.test.sh"
   chmod +x "$home/focused.test.sh"
+  commit_test_file "$home" focused.test.sh
 
   out=$(cd "$home" && HOME="$loginhome" PATH="$toolbin:$PATH" FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
@@ -459,6 +497,7 @@ test_private_records_do_not_impose_their_umask_on_tests() {
   artifact="$home/suite-artifact"
   printf '#!/usr/bin/env bash\ntouch %q\n' "$artifact" > "$home/regression.test.sh"
   chmod +x "$home/regression.test.sh"
+  commit_test_file "$home" regression.test.sh
   write_focused_test "$home"
 
   ( umask 022

--- a/tests/fm-fast-repair.test.sh
+++ b/tests/fm-fast-repair.test.sh
@@ -75,6 +75,7 @@ write_focused_test() {
 write_test_runner() {
   local home=$1
   mkdir -p "$home/bin"
+  # shellcheck disable=SC2016 # Literal fixture code expands only when its generated script runs.
   printf '%s\n' '#!/usr/bin/env bash' 'set -eu' \
     'if [ "${1:-}" = --list-families ]; then printf "%s\n" fixture-regression fixture-focused; exit 0; fi' \
     'if [ "${1:-}" = --list ] && [ "${2:-}" = --family ]; then case "$3" in fixture-regression) printf "%s\n" tests/fixture-regression.test.sh ;; fixture-focused) printf "%s\n" tests/fixture-focused.test.sh ;; *) exit 2 ;; esac; exit 0; fi' \
@@ -165,7 +166,7 @@ test_exact_prefix_only() {
 }
 
 test_eligibility_requires_every_typed_fact() {
-  local home out status field id=eligible-all invalid
+  local home out status field id=eligible-all
   home=$(make_home eligibility)
   out=$(intake "$home" "$id")
   assert_contains "$out" "fast-repair eligible: $id" "complete typed eligibility did not pass"
@@ -305,9 +306,11 @@ test_evidence_and_ready_gates() {
   write_focused_test "$home"
   printf 'task worktree\n' > "$home/cwd-proof"
   commit_test_file "$home" cwd-proof
+  # shellcheck disable=SC2016 # Literal fixture code expands only when its generated script runs.
   printf '#!/usr/bin/env bash\n[ "$(cat cwd-proof)" = "task worktree" ]\n' > "$home/$REGRESSION_TEST"
   chmod +x "$home/$REGRESSION_TEST"
   commit_test_file "$home" "$REGRESSION_TEST"
+  # shellcheck disable=SC2016 # Literal fixture code expands only when its generated script runs.
   printf '#!/usr/bin/env bash\n[ "$(cat cwd-proof)" = "task worktree" ]\n' > "$home/$FOCUSED_TEST"
   chmod +x "$home/$FOCUSED_TEST"
   commit_test_file "$home" "$FOCUSED_TEST"
@@ -403,6 +406,7 @@ test_regression_witness_requires_a_failing_reproduction() {
   sed -i 's/fixture-regression fixture-focused/fixture-regression fixture-focused fixture-unrelated/' "$home/bin/fm-test-run.sh"
   sed -i 's/fixture-focused) printf "%s\\n" tests\/fixture-focused.test.sh ;;/fixture-focused) printf "%s\\n" tests\/fixture-focused.test.sh ;; fixture-unrelated) printf "%s\\n" tests\/fixture-unrelated.test.sh ;;/' "$home/bin/fm-test-run.sh"
   sed -i 's/tests\/fixture-focused.test.sh) family=fixture-focused ;;/tests\/fixture-focused.test.sh) family=fixture-focused ;; tests\/fixture-unrelated.test.sh) family=fixture-unrelated ;;/' "$home/bin/fm-test-run.sh"
+  # shellcheck disable=SC2016 # Literal fixture text must keep its generated command substitution.
   sed -i 's/fixture-focused) \[ "$(cat fixture-focused-state)" = passed \] ;;/fixture-focused) [ "$(cat fixture-focused-state)" = passed ] ;; fixture-unrelated) true ;;/' "$home/bin/fm-test-run.sh"
   commit_test_file "$home" bin/fm-test-run.sh
   write_focused_test "$home"
@@ -673,11 +677,10 @@ $(cat "$home/state/$id.fast-repair-tests.log" 2>/dev/null)"
 # The private records stay owner-only, while files the test suites create keep the
 # permissions the caller's umask asks for.
 test_private_records_do_not_impose_their_umask_on_tests() {
-  local home id=umask-scope artifact
+  local home id=umask-scope
   home=$(make_home umask-scope)
   intake "$home" "$id" >/dev/null
   write_fast_meta "$home" "$id"
-  artifact="$home/suite-artifact"
   write_regression_test "$home"
   write_focused_test "$home"
 

--- a/tests/fm-fast-repair.test.sh
+++ b/tests/fm-fast-repair.test.sh
@@ -204,7 +204,7 @@ test_eligibility_requires_every_typed_fact() {
 }
 
 test_evidence_and_ready_gates() {
-  local home id=gate-fixture out status fakebin outside branch other
+  local home id=gate-fixture out status fakebin outside branch other evidence_other
   home=$(make_home gates)
   intake "$home" "$id" >/dev/null
   write_fast_meta "$home" "$id"
@@ -256,6 +256,19 @@ test_evidence_and_ready_gates() {
   [ "$status" -ne 0 ] || fail "a failing focused test allowed publication"
   assert_contains "$out" "PR publication remains blocked" "failed focused evidence did not explain the publication block"
   write_focused_test "$home"
+  printf 'task worktree\n' > "$home/cwd-proof"
+  commit_test_file "$home" cwd-proof
+  printf '#!/usr/bin/env bash\n[ "$(cat cwd-proof)" = "task worktree" ]\n' > "$home/regression.test.sh"
+  chmod +x "$home/regression.test.sh"
+  commit_test_file "$home" regression.test.sh
+  printf '#!/usr/bin/env bash\n[ "$(cat cwd-proof)" = "task worktree" ]\n' > "$home/focused.test.sh"
+  chmod +x "$home/focused.test.sh"
+  commit_test_file "$home" focused.test.sh
+  evidence_other=$(make_home evidence-cwd)
+  printf 'other checkout\n' > "$evidence_other/cwd-proof"
+  out=$(run_fast_from "$evidence_other" "$home" evidence "$id" --regression-test regression.test.sh --focused-test focused.test.sh)
+  status=$?
+  [ "$status" -eq 0 ] || fail "evidence tests did not run from the task worktree: $out"
   run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-test focused.test.sh >/dev/null || fail "passing focused evidence was rejected"
   git -C "$home" commit --quiet --allow-empty -m 'advance repair fixture'
   printf 'Fast Repair fixture body.\n' > "$home/body.md"

--- a/tests/fm-fast-repair.test.sh
+++ b/tests/fm-fast-repair.test.sh
@@ -693,6 +693,23 @@ test_private_records_do_not_impose_their_umask_on_tests() {
   pass "Fast Repair keeps its evidence records private without changing what the test commands create"
 }
 
+test_skipped_runner_family_cannot_satisfy_evidence() {
+  local home id=skipped-family out status
+  home=$(make_home skipped-family)
+  intake "$home" "$id" >/dev/null
+  write_fast_meta "$home" "$id"
+  write_regression_test "$home"
+  write_focused_test "$home"
+  sed 's/gate_skip=false/gate_skip=true/' "$home/bin/fm-test-run.sh" > "$home/bin/fm-test-run.sh.tmp" \
+    && mv -f "$home/bin/fm-test-run.sh.tmp" "$home/bin/fm-test-run.sh"
+  chmod +x "$home/bin/fm-test-run.sh"
+  commit_test_file "$home" bin/fm-test-run.sh
+  out=$(run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST")
+  status=$?
+  [ "$status" -ne 0 ] || fail "a skipped runner family satisfied Fast Repair evidence: $out"
+  pass "Fast Repair evidence rejects skipped selected tests"
+}
+
 test_exact_prefix_only
 test_eligibility_requires_every_typed_fact
 test_stored_eligibility_uses_the_intake_rule
@@ -700,6 +717,7 @@ test_later_gates_revalidate_typed_eligibility
 test_brief_commands_reach_the_scaffolding_home
 test_evidence_commands_ignore_a_login_profile
 test_private_records_do_not_impose_their_umask_on_tests
+test_skipped_runner_family_cannot_satisfy_evidence
 test_evidence_and_ready_gates
 test_regression_selector_must_be_new_since_reproduction
 test_regression_witness_requires_a_failing_reproduction

--- a/tests/fm-fast-repair.test.sh
+++ b/tests/fm-fast-repair.test.sh
@@ -76,10 +76,10 @@ write_test_runner() {
   printf '%s\n' '#!/usr/bin/env bash' 'set -eu' \
     'if [ "${1:-}" = --list-families ]; then printf "%s\n" fixture-regression fixture-focused; exit 0; fi' \
     'if [ "${1:-}" = --list ] && [ "${2:-}" = --family ]; then case "$3" in fixture-regression) printf "%s\n" tests/fixture-regression.test.sh ;; fixture-focused) printf "%s\n" tests/fixture-focused.test.sh ;; *) exit 2 ;; esac; exit 0; fi' \
-    '[ "${1:-}" = --family ] && [ "$#" = 2 ] || exit 2' \
-    'printf "FM_TEST_BEGIN fixture %s family=%s\n" "$2" "$2"' \
-    'if case "$2" in fixture-regression) [ "$(cat fixture-regression-state)" = fixed ] ;; fixture-focused) [ "$(cat fixture-focused-state)" = passed ] ;; *) false ;; esac; then status=0; else status=1; fi' \
-    'printf "FM_TEST_END fixture %s exit=%s duration_ms=0 gate_skip=false\n" "$2" "$status"; exit "$status"' > "$home/bin/fm-test-run.sh"
+    'if [ "${1:-}" = --family ] && [ "$#" = 2 ]; then family=$2; elif [ "$#" = 1 ]; then case "$1" in tests/fixture-regression.test.sh) family=fixture-regression ;; tests/fixture-focused.test.sh) family=fixture-focused ;; *) exit 2 ;; esac; else exit 2; fi' \
+    'printf "FM_TEST_BEGIN fixture %s family=%s\n" "$family" "$family"' \
+    'if case "$family" in fixture-regression) [ "$(cat fixture-regression-state)" = fixed ] ;; fixture-focused) [ "$(cat fixture-focused-state)" = passed ] ;; *) false ;; esac; then status=0; else status=1; fi' \
+    'printf "FM_TEST_END fixture %s exit=%s duration_ms=0 gate_skip=false\n" "$family" "$status"; exit "$status"' > "$home/bin/fm-test-run.sh"
   chmod +x "$home/bin/fm-test-run.sh"
   commit_test_file "$home" bin/fm-test-run.sh
 }
@@ -257,7 +257,7 @@ test_evidence_and_ready_gates() {
   out=$(run_fast "$home" evidence "$id" --regression-test pass --focused-test "$FOCUSED_TEST")
   status=$?
   [ "$status" -ne 0 ] || fail "a generic exit-zero script satisfied regression evidence"
-  assert_contains "$out" 'supported runner family with a new tracked selector' "the pass-script refusal did not require a runner-owned selector"
+  assert_contains "$out" 'one new tracked runner selector' "the pass-script refusal did not require a runner-owned selector"
   printf '#!/usr/bin/env bash\ntouch %q\n' "$home/untracked-test-ran" > "$home/tests/fm-untracked-regression.test.sh"
   chmod +x "$home/tests/fm-untracked-regression.test.sh"
   out=$(run_fast "$home" evidence "$id" --regression-test tests/fm-untracked-regression.test.sh --focused-test "$FOCUSED_TEST")
@@ -375,8 +375,47 @@ test_regression_selector_must_be_new_since_reproduction() {
   out=$(run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST")
   status=$?
   [ "$status" -ne 0 ] || fail "a regression selector already present at reproduction was accepted"
-  assert_contains "$out" 'new tracked selector' "an old regression selector did not state the Fast Repair contract"
+  assert_contains "$out" 'one new tracked runner selector' "an old regression selector did not state the Fast Repair contract"
   pass "Fast Repair requires a runner-owned regression selector added after reproduction"
+}
+
+test_regression_witness_requires_a_failing_reproduction() {
+  local home id=unrelated-witness out status
+  home=$(make_home unrelated-witness)
+  intake "$home" "$id" >/dev/null
+  mkdir -p "$home/tests"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$home/tests/fixture-unrelated.test.sh"
+  chmod +x "$home/tests/fixture-unrelated.test.sh"
+  commit_test_file "$home" tests/fixture-unrelated.test.sh
+  sed -i 's/fixture-regression fixture-focused/fixture-regression fixture-focused fixture-unrelated/' "$home/bin/fm-test-run.sh"
+  sed -i 's/fixture-focused) printf "%s\\n" tests\/fixture-focused.test.sh ;;/fixture-focused) printf "%s\\n" tests\/fixture-focused.test.sh ;; fixture-unrelated) printf "%s\\n" tests\/fixture-unrelated.test.sh ;;/' "$home/bin/fm-test-run.sh"
+  sed -i 's/tests\/fixture-focused.test.sh) family=fixture-focused ;;/tests\/fixture-focused.test.sh) family=fixture-focused ;; tests\/fixture-unrelated.test.sh) family=fixture-unrelated ;;/' "$home/bin/fm-test-run.sh"
+  sed -i 's/fixture-focused) \[ "$(cat fixture-focused-state)" = passed \] ;;/fixture-focused) [ "$(cat fixture-focused-state)" = passed ] ;; fixture-unrelated) true ;;/' "$home/bin/fm-test-run.sh"
+  commit_test_file "$home" bin/fm-test-run.sh
+  write_focused_test "$home"
+  write_fast_meta "$home" "$id"
+  out=$(run_fast "$home" evidence "$id" --regression-test fixture-unrelated --focused-test "$FOCUSED_TEST")
+  status=$?
+  [ "$status" -ne 0 ] || fail "an unrelated passing selector proved reproduction evidence"
+  assert_contains "$out" 'PR publication remains blocked' "an unrelated passing selector did not block publication"
+  pass "Fast Repair requires the overlaid regression selector to fail before the repair"
+}
+
+test_regression_witness_requires_overlay_runner_support() {
+  local home id=unsupported-overlay out status
+  home=$(make_home unsupported-overlay)
+  sed -i 's/if \[ "${1:-}" = --list \].*/if [ "${1:-}" = --list ]; then exit 2; fi/' "$home/bin/fm-test-run.sh"
+  commit_test_file "$home" bin/fm-test-run.sh
+  intake "$home" "$id" >/dev/null
+  write_test_runner "$home"
+  write_regression_test "$home"
+  write_focused_test "$home"
+  write_fast_meta "$home" "$id"
+  out=$(run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST")
+  status=$?
+  [ "$status" -ne 0 ] || fail "an unsupported reproduction runner accepted overlay evidence"
+  assert_contains "$out" 'PR publication remains blocked' "an unsupported reproduction runner did not block publication"
+  pass "Fast Repair refuses a reproduction runner without selector overlay support"
 }
 
 test_pr_check_rollup_states() {
@@ -587,5 +626,7 @@ test_evidence_commands_ignore_a_login_profile
 test_private_records_do_not_impose_their_umask_on_tests
 test_evidence_and_ready_gates
 test_regression_selector_must_be_new_since_reproduction
+test_regression_witness_requires_a_failing_reproduction
+test_regression_witness_requires_overlay_runner_support
 test_pr_check_rollup_states
 echo "# all fm-fast-repair tests passed"

--- a/tests/fm-fast-repair.test.sh
+++ b/tests/fm-fast-repair.test.sh
@@ -23,11 +23,17 @@ make_home() {
 run_fast() {
   local home=$1
   shift
-  FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" "$FAST" "$@" 2>&1
+  ( cd "$home" && FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" "$FAST" "$@" ) 2>&1
+}
+
+write_regression_test() {
+  local home=$1 code=${2:-0}
+  printf '#!/usr/bin/env bash\nexit %s\n' "$code" > "$home/regression.test.sh"
+  chmod +x "$home/regression.test.sh"
 }
 
 intake() {
-  local home=$1 id=$2 reproduction=${3-known-reproduction} root_cause=${4-confirmed-root-cause} isolation=${5-isolated-change}
+  local home=$1 id=$2 reproduction=${3-reproduced} root_cause=${4-confirmed} isolation=${5-isolated}
   local schema=${6-none} authentication=${7-none} authorization=${8-none} secrets=${9-none} financial=${10-none} legal=${11-none} side_effects=${12-none}
   run_fast "$home" intake "$id" --request 'fast-repair: repair fixture' \
     --reproduction "$reproduction" --root-cause "$root_cause" --isolation "$isolation" \
@@ -93,18 +99,28 @@ test_exact_prefix_only() {
 }
 
 test_eligibility_requires_every_typed_fact() {
-  local home out status field id=eligible-all
+  local home out status field id=eligible-all invalid
   home=$(make_home eligibility)
   out=$(intake "$home" "$id")
   assert_contains "$out" "fast-repair eligible: $id" "complete typed eligibility did not pass"
   run_fast "$home" eligible "$id" >/dev/null || fail "stored complete eligibility did not validate"
 
+  out=$(intake "$home" invalid-reproduction a confirmed isolated)
+  status=$?
+  [ "$status" -ne 0 ] || fail "an untyped reproduction proof was accepted"
+  out=$(intake "$home" invalid-root-cause reproduced a isolated)
+  status=$?
+  [ "$status" -ne 0 ] || fail "an untyped root-cause proof was accepted"
+  out=$(intake "$home" invalid-isolation reproduced confirmed a)
+  status=$?
+  [ "$status" -ne 0 ] || fail "an untyped isolation proof was accepted"
+
   for field in reproduction root_cause isolation; do
     id="missing-$field"
     case "$field" in
-      reproduction) out=$(intake "$home" "$id" '' confirmed-root-cause isolated-change) ;;
-      root_cause) out=$(intake "$home" "$id" known-reproduction '' isolated-change) ;;
-      isolation) out=$(intake "$home" "$id" known-reproduction confirmed-root-cause '') ;;
+      reproduction) out=$(intake "$home" "$id" '' confirmed isolated) ;;
+      root_cause) out=$(intake "$home" "$id" reproduced '' isolated) ;;
+      isolation) out=$(intake "$home" "$id" reproduced confirmed '') ;;
     esac
     status=$?
     [ "$status" -ne 0 ] || fail "missing $field was accepted"
@@ -112,9 +128,9 @@ test_eligibility_requires_every_typed_fact() {
 
     id="unknown-$field"
     case "$field" in
-      reproduction) out=$(intake "$home" "$id" unknown confirmed-root-cause isolated-change) ;;
-      root_cause) out=$(intake "$home" "$id" known-reproduction unknown isolated-change) ;;
-      isolation) out=$(intake "$home" "$id" known-reproduction confirmed-root-cause ambiguous) ;;
+      reproduction) out=$(intake "$home" "$id" unknown confirmed isolated) ;;
+      root_cause) out=$(intake "$home" "$id" reproduced unknown isolated) ;;
+      isolation) out=$(intake "$home" "$id" reproduced confirmed ambiguous) ;;
     esac
     status=$?
     [ "$status" -ne 0 ] || fail "unknown or ambiguous $field was accepted"
@@ -124,13 +140,13 @@ test_eligibility_requires_every_typed_fact() {
   for field in schema authentication authorization secrets financial legal side_effects; do
     id="risk-$field"
     case "$field" in
-      schema) out=$(intake "$home" "$id" a b c changed) ;;
-      authentication) out=$(intake "$home" "$id" a b c none changed) ;;
-      authorization) out=$(intake "$home" "$id" a b c none none changed) ;;
-      secrets) out=$(intake "$home" "$id" a b c none none none changed) ;;
-      financial) out=$(intake "$home" "$id" a b c none none none none changed) ;;
-      legal) out=$(intake "$home" "$id" a b c none none none none none changed) ;;
-      side_effects) out=$(intake "$home" "$id" a b c none none none none none none changed) ;;
+      schema) out=$(intake "$home" "$id" reproduced confirmed isolated changed) ;;
+      authentication) out=$(intake "$home" "$id" reproduced confirmed isolated none changed) ;;
+      authorization) out=$(intake "$home" "$id" reproduced confirmed isolated none none changed) ;;
+      secrets) out=$(intake "$home" "$id" reproduced confirmed isolated none none none changed) ;;
+      financial) out=$(intake "$home" "$id" reproduced confirmed isolated none none none none changed) ;;
+      legal) out=$(intake "$home" "$id" reproduced confirmed isolated none none none none none changed) ;;
+      side_effects) out=$(intake "$home" "$id" reproduced confirmed isolated none none none none none none changed) ;;
     esac
     status=$?
     [ "$status" -ne 0 ] || fail "forbidden $field change was accepted"
@@ -144,13 +160,18 @@ test_evidence_and_ready_gates() {
   home=$(make_home gates)
   intake "$home" "$id" >/dev/null
   write_fast_meta "$home" "$id"
+  write_regression_test "$home" 1
 
-  out=$(run_fast "$home" evidence "$id" --regression-command false --focused-command true)
+  out=$(run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-command true)
   status=$?
   [ "$status" -ne 0 ] || fail "failed regression evidence allowed publication"
   assert_contains "$out" "PR publication remains blocked" "failed evidence did not explain the publication block"
 
-  run_fast "$home" evidence "$id" --regression-command true --focused-command true >/dev/null || fail "passing focused evidence was rejected"
+  out=$(run_fast "$home" evidence "$id" --regression-command true --focused-command true)
+  status=$?
+  [ "$status" -ne 0 ] || fail "an arbitrary successful regression command was accepted"
+  write_regression_test "$home"
+  run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-command true >/dev/null || fail "passing focused evidence was rejected"
   write_fake_gh "$home"
   fakebin="$home/fakebin"
   # The real green rollup omits the pending segment when nothing is pending.
@@ -173,9 +194,10 @@ test_pr_check_rollup_states() {
   home=$(make_home rollup)
   intake "$home" "$id" >/dev/null
   write_fast_meta "$home" "$id" https://github.com/acme/repo/pull/42
+  write_regression_test "$home"
   write_fake_gh "$home"
   fakebin="$home/fakebin"
-  run_fast "$home" evidence "$id" --regression-command true --focused-command true >/dev/null \
+  run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-command true >/dev/null \
     || fail "focused evidence fixture was rejected"
   PATH="$fakebin:$PATH" run_fast "$home" broader "$id" --command true >/dev/null \
     || fail "broader fixture was rejected"
@@ -241,10 +263,35 @@ test_stored_eligibility_uses_the_intake_rule() {
   status=$?
   [ "$status" -ne 0 ] || fail "a stored fact intake refuses still passed the eligibility gate"
   assert_contains "$out" "eligibility evidence" "the eligibility gate did not name its refusal"
-  out=$(run_fast "$home" evidence "$id" --regression-command true --focused-command true)
+  out=$(run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-command true)
   status=$?
   [ "$status" -ne 0 ] || fail "a stored fact intake refuses still reached the evidence gate"
   pass "every Fast Repair gate re-applies intake's own rule to the stored evidence record"
+}
+
+test_later_gates_revalidate_typed_eligibility() {
+  local home id=later-gates f out status gate
+  home=$(make_home later-gates)
+  intake "$home" "$id" >/dev/null
+  write_fast_meta "$home" "$id" https://github.com/acme/repo/pull/42
+  write_regression_test "$home"
+  run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-command true >/dev/null \
+    || fail "the later-gate fixture could not record focused evidence"
+  f="$home/data/$id/fast-repair-eligibility"
+  sed 's/^isolation=.*/isolation=isolated-change/' "$f" > "$f.tmp" && mv -f "$f.tmp" "$f"
+  printf 'Fast Repair fixture body.\n' > "$home/body.md"
+  for gate in publish-pr broader progress ready; do
+    case "$gate" in
+      publish-pr) out=$(run_fast "$home" publish-pr "$id" --title fixture --body-file "$home/body.md") ;;
+      broader) out=$(run_fast "$home" broader "$id" --command true) ;;
+      progress) out=$(run_fast "$home" progress "$id") ;;
+      ready) out=$(run_fast "$home" ready "$id") ;;
+    esac
+    status=$?
+    [ "$status" -ne 0 ] || fail "a later Fast Repair gate accepted tampered typed eligibility: $gate"
+    assert_contains "$out" 'eligibility evidence' "a later Fast Repair gate did not name invalid eligibility: $gate"
+  done
+  pass "all later Fast Repair gates revalidate typed eligibility"
 }
 
 # The generated brief is firstmate's emitted worker interface, so the mandated
@@ -255,6 +302,7 @@ test_brief_commands_reach_the_scaffolding_home() {
   home=$(make_home brief-home)
   intake "$home" "$id" >/dev/null
   write_fast_meta "$home" "$id"
+  write_regression_test "$home"
   FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     "$ROOT/bin/fm-brief.sh" "$id" fixtureproj --mode fast-repair >/dev/null \
     || fail "the Fast Repair brief could not be scaffolded"
@@ -267,8 +315,8 @@ test_brief_commands_reach_the_scaffolding_home() {
   prefix=${cmd%% evidence *}
   [ "$prefix" != "$cmd" ] || fail "the mandated evidence command could not be read from the brief"
 
-  out=$(env -u FM_HOME -u FM_STATE_OVERRIDE -u FM_DATA_OVERRIDE -u FM_ROOT_OVERRIDE \
-    bash -c "$prefix evidence $id --regression-command true --focused-command true" 2>&1)
+  out=$(cd "$home" && env -u FM_HOME -u FM_STATE_OVERRIDE -u FM_DATA_OVERRIDE -u FM_ROOT_OVERRIDE \
+    bash -c "$prefix evidence $id --regression-test regression.test.sh --focused-command true" 2>&1)
   status=$?
   [ "$status" -eq 0 ] || fail "the brief's own evidence command could not reach the task record: $out"
   assert_grep 'regression=passed' "$home/state/$id.fast-repair-tests" \
@@ -293,10 +341,11 @@ test_evidence_commands_ignore_a_login_profile() {
 exit 0
 SH
   chmod +x "$toolbin/fm-fixture-tool"
+  write_regression_test "$home"
 
-  out=$(HOME="$loginhome" PATH="$toolbin:$PATH" FM_HOME="$home" \
+  out=$(cd "$home" && HOME="$loginhome" PATH="$toolbin:$PATH" FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
-    "$FAST" evidence "$id" --regression-command fm-fixture-tool \
+    "$FAST" evidence "$id" --regression-test regression.test.sh \
     --focused-command fm-fixture-tool 2>&1)
   status=$?
   [ "$status" -eq 0 ] \
@@ -316,10 +365,12 @@ test_private_records_do_not_impose_their_umask_on_tests() {
   intake "$home" "$id" >/dev/null
   write_fast_meta "$home" "$id"
   artifact="$home/suite-artifact"
+  printf '#!/usr/bin/env bash\ntouch %q\n' "$artifact" > "$home/regression.test.sh"
+  chmod +x "$home/regression.test.sh"
 
   ( umask 022
     run_fast "$home" evidence "$id" \
-      --regression-command "touch '$artifact'" --focused-command true >/dev/null ) \
+      --regression-test regression.test.sh --focused-command true >/dev/null ) \
     || fail "the evidence gate refused its own passing fixture commands"
 
   [ -e "$artifact" ] || fail "the regression command did not run"
@@ -335,6 +386,7 @@ test_private_records_do_not_impose_their_umask_on_tests() {
 test_exact_prefix_only
 test_eligibility_requires_every_typed_fact
 test_stored_eligibility_uses_the_intake_rule
+test_later_gates_revalidate_typed_eligibility
 test_brief_commands_reach_the_scaffolding_home
 test_evidence_commands_ignore_a_login_profile
 test_private_records_do_not_impose_their_umask_on_tests

--- a/tests/fm-fast-repair.test.sh
+++ b/tests/fm-fast-repair.test.sh
@@ -48,12 +48,24 @@ commit_test_file() {
 
 write_regression_test() {
   local home=$1 code=${2:-0}
+  mkdir -p "$home/tests"
+  if ! git -C "$home" cat-file -e HEAD:tests/fixture-regression.test.sh 2>/dev/null; then
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$home/tests/fixture-regression.test.sh"
+    chmod +x "$home/tests/fixture-regression.test.sh"
+    commit_test_file "$home" tests/fixture-regression.test.sh
+  fi
   if [ "$code" = 0 ]; then printf 'fixed\n' > "$home/fixture-regression-state"; else printf 'broken\n' > "$home/fixture-regression-state"; fi
   git -C "$home" diff --quiet -- fixture-regression-state || commit_test_file "$home" fixture-regression-state
 }
 
 write_focused_test() {
   local home=$1 code=${2:-0}
+  mkdir -p "$home/tests"
+  if ! git -C "$home" cat-file -e HEAD:tests/fixture-focused.test.sh 2>/dev/null; then
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$home/tests/fixture-focused.test.sh"
+    chmod +x "$home/tests/fixture-focused.test.sh"
+    commit_test_file "$home" tests/fixture-focused.test.sh
+  fi
   if [ "$code" = 0 ]; then printf 'passed\n' > "$home/fixture-focused-state"; else printf 'failed\n' > "$home/fixture-focused-state"; fi
   git -C "$home" diff --quiet -- fixture-focused-state || commit_test_file "$home" fixture-focused-state
 }
@@ -63,6 +75,7 @@ write_test_runner() {
   mkdir -p "$home/bin"
   printf '%s\n' '#!/usr/bin/env bash' 'set -eu' \
     'if [ "${1:-}" = --list-families ]; then printf "%s\n" fixture-regression fixture-focused; exit 0; fi' \
+    'if [ "${1:-}" = --list ] && [ "${2:-}" = --family ]; then case "$3" in fixture-regression) printf "%s\n" tests/fixture-regression.test.sh ;; fixture-focused) printf "%s\n" tests/fixture-focused.test.sh ;; *) exit 2 ;; esac; exit 0; fi' \
     '[ "${1:-}" = --family ] && [ "$#" = 2 ] || exit 2' \
     'printf "FM_TEST_BEGIN fixture %s family=%s\n" "$2" "$2"' \
     'if case "$2" in fixture-regression) [ "$(cat fixture-regression-state)" = fixed ] ;; fixture-focused) [ "$(cat fixture-focused-state)" = passed ] ;; *) false ;; esac; then status=0; else status=1; fi' \
@@ -244,7 +257,7 @@ test_evidence_and_ready_gates() {
   out=$(run_fast "$home" evidence "$id" --regression-test pass --focused-test "$FOCUSED_TEST")
   status=$?
   [ "$status" -ne 0 ] || fail "a generic exit-zero script satisfied regression evidence"
-  assert_contains "$out" 'supported bin/fm-test-run.sh family' "the pass-script refusal did not require a runner-owned selector"
+  assert_contains "$out" 'supported runner family with a new tracked selector' "the pass-script refusal did not require a runner-owned selector"
   printf '#!/usr/bin/env bash\ntouch %q\n' "$home/untracked-test-ran" > "$home/tests/fm-untracked-regression.test.sh"
   chmod +x "$home/tests/fm-untracked-regression.test.sh"
   out=$(run_fast "$home" evidence "$id" --regression-test tests/fm-untracked-regression.test.sh --focused-test "$FOCUSED_TEST")
@@ -348,6 +361,22 @@ test_evidence_and_ready_gates() {
   [ "$status" -ne 0 ] || fail "Fast Repair accepted broader evidence from an earlier commit"
   assert_contains "$out" 'broader tests are not passed' "stale broader evidence was not refused"
   pass "Fast Repair blocks failed focused evidence and requires broader plus PR checks before ready"
+}
+
+test_regression_selector_must_be_new_since_reproduction() {
+  local home id=old-selector out status
+  home=$(make_home old-selector)
+  intake "$home" "$id" >/dev/null
+  write_focused_test "$home"
+  write_regression_test "$home"
+  intake "$home" "$id" >/dev/null
+  write_fast_meta "$home" "$id"
+  git -C "$home" commit --quiet --allow-empty -m 'repair head after selector'
+  out=$(run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST")
+  status=$?
+  [ "$status" -ne 0 ] || fail "a regression selector already present at reproduction was accepted"
+  assert_contains "$out" 'new tracked selector' "an old regression selector did not state the Fast Repair contract"
+  pass "Fast Repair requires a runner-owned regression selector added after reproduction"
 }
 
 test_pr_check_rollup_states() {
@@ -557,5 +586,6 @@ test_brief_commands_reach_the_scaffolding_home
 test_evidence_commands_ignore_a_login_profile
 test_private_records_do_not_impose_their_umask_on_tests
 test_evidence_and_ready_gates
+test_regression_selector_must_be_new_since_reproduction
 test_pr_check_rollup_states
 echo "# all fm-fast-repair tests passed"

--- a/tests/fm-fast-repair.test.sh
+++ b/tests/fm-fast-repair.test.sh
@@ -141,7 +141,7 @@ test_exact_prefix_only() {
   for request in 'fast-repair: fix fixture' 'fast-repair: a'; do
     "$FAST" is-request "$request" || fail "exact Fast Repair prefix was not recognized: $request"
   done
-  for request in 'fast-repair:' 'Fast-repair: fix' 'fast repair: fix' 'fast-repair : fix' 'xfast-repair: fix'; do
+  for request in 'fast-repair:' 'fast-repair: ' $'fast-repair: \t' 'Fast-repair: fix' 'fast repair: fix' 'fast-repair : fix' 'xfast-repair: fix'; do
     "$FAST" is-request "$request" && fail "near-match activated Fast Repair: $request"
   done
   pass "Fast Repair recognizes only the exact fast-repair: prefix"

--- a/tests/fm-fast-repair.test.sh
+++ b/tests/fm-fast-repair.test.sh
@@ -31,6 +31,43 @@ intake() {
     --secrets "$secrets" --financial "$financial" --legal "$legal" --side-effects "$side_effects"
 }
 
+# The fake reproduces the real `gh-axi pr checks` contract: one TOON `summary:`
+# field whose comma-bearing value is double-quoted, and the distinct
+# no-checks-configured shape that carries no summary field at all. Every argv is
+# recorded so the repository the checks were read from is observable.
+write_fake_gh() {
+  local home=$1 fakebin="$1/fakebin"
+  mkdir -p "$fakebin"
+  cat > "$fakebin/gh-axi" <<EOF
+#!/usr/bin/env bash
+FAKE_HOME='$home'
+EOF
+  cat >> "$fakebin/gh-axi" <<'SH'
+printf '%s\n' "$*" >> "$FAKE_HOME/gh-axi.args"
+case "${1:-}" in
+  pr)
+    case "${2:-}" in
+      create) printf 'https://github.com/acme/repo/pull/42\n' ;;
+      checks) cat "$FAKE_HOME/checks-output" ;;
+    esac
+    ;;
+esac
+SH
+  cat > "$fakebin/gh" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+  chmod +x "$fakebin/gh-axi" "$fakebin/gh"
+}
+
+set_rollup() { # <home> <summary text>
+  printf 'summary: "%s"\n' "$2" > "$1/checks-output"
+}
+
+set_no_checks_rollup() { # <home>
+  printf 'checks: "0 passed, 0 failed — this PR has no CI checks configured"\n' > "$1/checks-output"
+}
+
 write_fast_meta() {
   local home=$1 id=$2 pr=${3:-}
   {
@@ -110,25 +147,10 @@ test_evidence_and_ready_gates() {
   assert_contains "$out" "PR publication remains blocked" "failed evidence did not explain the publication block"
 
   run_fast "$home" evidence "$id" --regression-command true --focused-command true >/dev/null || fail "passing focused evidence was rejected"
+  write_fake_gh "$home"
   fakebin="$home/fakebin"
-  mkdir -p "$fakebin"
-  cat > "$fakebin/gh-axi" <<'SH'
-#!/usr/bin/env bash
-case "${1:-}" in
-  pr)
-    case "${2:-}" in
-      create) printf 'https://github.com/acme/repo/pull/42\n' ;;
-      checks) printf 'summary: "4 passed, 0 failed, 0 pending, 4 total"\n' ;;
-    esac
-    ;;
-esac
-SH
-  cat > "$fakebin/gh" <<'SH'
-#!/usr/bin/env bash
-exit 1
-SH
-  chmod +x "$fakebin/gh-axi"
-  chmod +x "$fakebin/gh"
+  # The real green rollup omits the pending segment when nothing is pending.
+  set_rollup "$home" '4 passed, 0 failed, 4 total'
   printf 'Fast Repair fixture body.\n' > "$home/body.md"
   out=$(PATH="$fakebin:$PATH" run_fast "$home" publish-pr "$id" --title 'Fast Repair fixture' --body-file "$home/body.md")
   assert_contains "$out" 'fast-repair PR opened: https://github.com/acme/repo/pull/42' "passing evidence did not open the direct PR"
@@ -138,10 +160,56 @@ SH
   assert_contains "$out" 'fast-repair ready: https://github.com/acme/repo/pull/42' "green broader and PR evidence did not make the PR ready"
   out=$(PATH="$fakebin:$PATH" run_fast "$home" progress "$id")
   assert_contains "$out" 'pr-checks-green' "green PR checks were not available to the Fast Repair progress cadence"
+  assert_grep '--repo acme/repo' "$home/gh-axi.args" "PR checks were not read from the registered PR's own repository"
   pass "Fast Repair blocks failed focused evidence and requires broader plus PR checks before ready"
+}
+
+test_pr_check_rollup_states() {
+  local home id=rollup-fixture fakebin out status
+  home=$(make_home rollup)
+  intake "$home" "$id" >/dev/null
+  write_fast_meta "$home" "$id" https://github.com/acme/repo/pull/42
+  write_fake_gh "$home"
+  fakebin="$home/fakebin"
+  run_fast "$home" evidence "$id" --regression-command true --focused-command true >/dev/null \
+    || fail "focused evidence fixture was rejected"
+  PATH="$fakebin:$PATH" run_fast "$home" broader "$id" --command true >/dev/null \
+    || fail "broader fixture was rejected"
+
+  # A skipped check is neither failed nor pending, so the rollup is still green.
+  set_rollup "$home" '3 passed, 1 skipped, 0 failed, 4 total'
+  out=$(PATH="$fakebin:$PATH" run_fast "$home" ready "$id") \
+    || fail "a rollup with only passed and skipped checks was refused: $out"
+  assert_contains "$out" 'fast-repair ready:' "skipped-but-green rollup did not report ready"
+
+  # "10 failed, 0 pending" contains "0 failed, 0 pending" as a substring.
+  set_rollup "$home" '3 passed, 10 failed, 0 pending, 13 total'
+  out=$(PATH="$fakebin:$PATH" run_fast "$home" ready "$id")
+  status=$?
+  [ "$status" -ne 0 ] || fail "a rollup with 10 failed checks was reported ready"
+  assert_contains "$out" 'PR checks are not green' "failed rollup did not name the refusal"
+  out=$(PATH="$fakebin:$PATH" run_fast "$home" progress "$id")
+  assert_contains "$out" 'pr-checks-failed' "failed rollup was not surfaced to the progress cadence"
+
+  set_rollup "$home" '2 passed, 0 failed, 2 pending, 4 total'
+  out=$(PATH="$fakebin:$PATH" run_fast "$home" ready "$id")
+  status=$?
+  [ "$status" -ne 0 ] || fail "a pending rollup was reported ready"
+  out=$(PATH="$fakebin:$PATH" run_fast "$home" progress "$id")
+  [ -z "$out" ] || fail "a pending rollup produced an actionable progress result: $out"
+
+  set_no_checks_rollup "$home"
+  out=$(PATH="$fakebin:$PATH" run_fast "$home" ready "$id")
+  status=$?
+  [ "$status" -ne 0 ] || fail "a PR with no configured checks was reported ready"
+  assert_contains "$out" 'PR checks could not be read' "an absent rollup did not name the refusal"
+  out=$(PATH="$fakebin:$PATH" run_fast "$home" progress "$id")
+  [ -z "$out" ] || fail "an absent rollup produced an actionable progress result: $out"
+  pass "Fast Repair reads the PR rollup counts numerically for ready and the progress cadence"
 }
 
 test_exact_prefix_only
 test_eligibility_requires_every_typed_fact
 test_evidence_and_ready_gates
+test_pr_check_rollup_states
 echo "# all fm-fast-repair tests passed"

--- a/tests/fm-fast-repair.test.sh
+++ b/tests/fm-fast-repair.test.sh
@@ -10,6 +10,8 @@ FAST="$ROOT/bin/fm-fast-repair.sh"
 TMP_ROOT=$(fm_test_tmproot fm-fast-repair)
 REGRESSION_TEST=fixture-regression
 FOCUSED_TEST=fixture-focused
+FAKE_GH_BIN=
+FAKE_GH_DIR=
 
 file_mode() {
   stat -c %a "$1" 2>/dev/null || stat -f %Lp "$1" 2>/dev/null
@@ -98,11 +100,13 @@ intake() {
 # no-checks-configured shape that carries no summary field at all. Every argv is
 # recorded so the repository the checks were read from is observable.
 write_fake_gh() {
-  local home=$1 fakebin="$1/fakebin"
-  mkdir -p "$fakebin"
+  local fakebin
+  fakebin=$(mktemp -d "$TMP_ROOT/fake-gh-bin.XXXXXX")
+  FAKE_GH_DIR=$(mktemp -d "$TMP_ROOT/fake-gh-data.XXXXXX")
+  FAKE_GH_BIN=$fakebin
   cat > "$fakebin/gh-axi" <<EOF
 #!/usr/bin/env bash
-FAKE_HOME='$home'
+FAKE_HOME='$FAKE_GH_DIR'
 EOF
   cat >> "$fakebin/gh-axi" <<'SH'
 printf '%s\n' "$*" >> "$FAKE_HOME/gh-axi.args"
@@ -118,7 +122,7 @@ esac
 SH
   cat > "$fakebin/gh" <<EOF
 #!/usr/bin/env bash
-FAKE_HOME='$home'
+FAKE_HOME='$FAKE_GH_DIR'
 EOF
   cat >> "$fakebin/gh" <<'SH'
 case "${1:-} ${2:-}" in
@@ -129,11 +133,11 @@ SH
   chmod +x "$fakebin/gh-axi" "$fakebin/gh"
 }
 
-set_rollup() { # <home> <summary text>
+set_rollup() { # <fake-gh-dir> <summary text>
   printf 'summary: "%s"\n' "$2" > "$1/checks-output"
 }
 
-set_no_checks_rollup() { # <home>
+set_no_checks_rollup() { # <fake-gh-dir>
   printf 'checks: "0 passed, 0 failed — this PR has no CI checks configured"\n' > "$1/checks-output"
 }
 
@@ -270,12 +274,15 @@ test_evidence_and_ready_gates() {
   [ "$status" -ne 0 ] || fail "a staged-only regression test was accepted"
   [ ! -e "$home/untracked-test-ran" ] || fail "a staged-only regression test was executed"
   git -C "$home" rm --cached --quiet -- tests/fm-untracked-regression.test.sh
+  rm -f "$home/tests/fm-untracked-regression.test.sh"
   printf '#!/usr/bin/env bash\ntouch %q\n' "$home/modified-test-ran" > "$home/$REGRESSION_TEST"
   chmod +x "$home/$REGRESSION_TEST"
   out=$(run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST")
   status=$?
   [ "$status" -ne 0 ] || fail "a modified tracked regression test was accepted"
   [ ! -e "$home/modified-test-ran" ] || fail "a modified tracked regression test was executed"
+  rm -f "$home/$REGRESSION_TEST"
+  git -C "$home" checkout -- tests/fixture-regression.test.sh
   write_regression_test "$home"
   out=$(run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-command true)
   status=$?
@@ -289,6 +296,7 @@ test_evidence_and_ready_gates() {
   status=$?
   [ "$status" -ne 0 ] || fail "a parent symlink escaped the Fast Repair worktree"
   [ ! -e "$home/escaped-test-ran" ] || fail "an escaped test path was executed"
+  rm -f "$home/tests/link"
   write_focused_test "$home" 1
   out=$(run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST")
   status=$?
@@ -310,49 +318,54 @@ test_evidence_and_ready_gates() {
   [ "$status" -eq 0 ] || fail "evidence tests did not run from the task worktree: $out"
   run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST" >/dev/null || fail "passing focused evidence was rejected"
   git -C "$home" commit --quiet --allow-empty -m 'advance repair fixture'
-  printf 'Fast Repair fixture body.\n' > "$home/body.md"
-  out=$(run_fast "$home" publish-pr "$id" --title 'Fast Repair fixture' --body-file "$home/body.md")
+  body="$TMP_ROOT/gates-body.md"
+  printf 'Fast Repair fixture body.\n' > "$body"
+  out=$(run_fast "$home" publish-pr "$id" --title 'Fast Repair fixture' --body-file "$body")
   status=$?
   [ "$status" -ne 0 ] || fail "Fast Repair published a commit that its evidence did not test"
   assert_contains "$out" 'focused evidence is absent or failed' "untested commit refusal was not actionable"
   run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST" >/dev/null || fail "updated task HEAD evidence was rejected"
   write_fake_gh "$home"
-  fakebin="$home/fakebin"
-  printf '%040d\n' 0 > "$home/pr-head"
+  fakebin="$FAKE_GH_BIN"
+  printf '%040d\n' 0 > "$FAKE_GH_DIR/pr-head"
   # The real green rollup omits the pending segment when nothing is pending.
-  set_rollup "$home" '4 passed, 0 failed, 4 total'
-  out=$(PATH="$fakebin:$PATH" run_fast "$home" publish-pr "$id" --title 'Fast Repair fixture' --body-file "$home/body.md" --head unrelated)
+  set_rollup "$FAKE_GH_DIR" '4 passed, 0 failed, 4 total'
+  out=$(PATH="$fakebin:$PATH" run_fast "$home" publish-pr "$id" --title 'Fast Repair fixture' --body-file "$body" --head unrelated)
   status=$?
   [ "$status" -ne 0 ] || fail "Fast Repair published an untested head branch"
   assert_contains "$out" '--head must equal the tested task branch' "untested head refusal was not actionable"
   assert_no_grep 'pr=' "$home/state/$id.meta" "untested head publication wrote a PR record"
-  out=$(PATH="$fakebin:$PATH" run_fast "$home" publish-pr "$id" --title 'Fast Repair fixture' --body-file "$home/body.md")
+  out=$(PATH="$fakebin:$PATH" run_fast "$home" publish-pr "$id" --title 'Fast Repair fixture' --body-file "$body")
   status=$?
   [ "$status" -ne 0 ] || fail "Fast Repair accepted a PR with an untested remote head"
   assert_contains "$out" 'registered PR head does not match' "remote-head refusal was not actionable"
-  printf '%s\n' "$(git -C "$home" rev-parse HEAD)" > "$home/pr-head"
+  printf '%s\n' "$(git -C "$home" rev-parse HEAD)" > "$FAKE_GH_DIR/pr-head"
   other=$(make_home other-caller)
   printf 'Fast Repair caller body.\n' > "$other/body.md"
   out=$(PATH="$fakebin:$PATH" run_fast_from "$other" "$home" publish-pr "$id" --title 'Fast Repair fixture' --body-file body.md)
   assert_contains "$out" 'fast-repair PR opened: https://github.com/acme/repo/pull/42' "passing evidence did not open the direct PR"
   assert_grep 'pr=https://github.com/acme/repo/pull/42' "$home/state/$id.meta" "direct PR was not registered"
   branch=$(git -C "$home" symbolic-ref --short HEAD)
-  assert_grep "pr create --title Fast Repair fixture --body-file $other/body.md --head $branch" "$home/gh-axi.args" \
+  assert_grep "pr create --title Fast Repair fixture --body-file $other/body.md --head $branch" "$FAKE_GH_DIR/gh-axi.args" \
     "direct PR did not use the tested task branch"
-  [ "$(tail -n 1 "$home/gh-axi.cwd")" = "$home" ] \
+  [ "$(tail -n 1 "$FAKE_GH_DIR/gh-axi.cwd")" = "$home" ] \
     || fail "direct PR creation ran outside the task worktree"
-  PATH="$fakebin:$PATH" run_fast "$home" broader "$id" --command true >/dev/null || fail "broader tests could not start after direct PR publication"
+  out=$(PATH="$fakebin:$PATH" run_fast "$home" broader "$id" --command true)
+  status=$?
+  [ "$status" -ne 0 ] || fail "an arbitrary successful broader command was accepted"
+  assert_contains "$out" 'broader requires exactly --test' "broader command refusal was not actionable"
+  PATH="$fakebin:$PATH" run_fast "$home" broader "$id" --test "$FOCUSED_TEST" >/dev/null || fail "broader tests could not start after direct PR publication"
   out=$(PATH="$fakebin:$PATH" run_fast "$home" ready "$id")
   assert_contains "$out" 'fast-repair ready: https://github.com/acme/repo/pull/42' "green broader and PR evidence did not make the PR ready"
-  printf '%040d\n' 0 > "$home/pr-head"
+  printf '%040d\n' 0 > "$FAKE_GH_DIR/pr-head"
   out=$(PATH="$fakebin:$PATH" run_fast "$home" ready "$id")
   status=$?
   [ "$status" -ne 0 ] || fail "Fast Repair accepted a PR whose remote head changed after publication"
   assert_contains "$out" 'registered PR head does not match' "changed remote-head refusal was not actionable"
-  printf '%s\n' "$(git -C "$home" rev-parse HEAD)" > "$home/pr-head"
+  printf '%s\n' "$(git -C "$home" rev-parse HEAD)" > "$FAKE_GH_DIR/pr-head"
   out=$(PATH="$fakebin:$PATH" run_fast "$home" progress "$id")
   assert_contains "$out" 'pr-checks-green' "green PR checks were not available to the Fast Repair progress cadence"
-  assert_grep '--repo acme/repo' "$home/gh-axi.args" "PR checks were not read from the registered PR's own repository"
+  assert_grep '--repo acme/repo' "$FAKE_GH_DIR/gh-axi.args" "PR checks were not read from the registered PR's own repository"
   git -C "$home" commit --quiet --allow-empty -m 'advance broader fixture'
   run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST" >/dev/null \
     || fail "updated focused evidence was rejected after a new commit"
@@ -419,6 +432,44 @@ test_regression_witness_uses_the_tested_runner() {
   pass "Fast Repair uses one tested runner for both regression witness halves"
 }
 
+test_evidence_requires_clean_bound_artifacts() {
+  local home id=dirty-source out status outside
+  home=$(make_home dirty-source)
+  intake "$home" "$id" >/dev/null
+  write_regression_test "$home"
+  write_focused_test "$home"
+  printf 'broken\n' > "$home/fixture-regression-state"
+  commit_test_file "$home" fixture-regression-state
+  write_fast_meta "$home" "$id"
+  printf 'fixed\n' > "$home/fixture-regression-state"
+  out=$(run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST")
+  status=$?
+  [ "$status" -ne 0 ] || fail "dirty repair source satisfied evidence for an older HEAD"
+  assert_contains "$out" 'no safe git worktree' "dirty source refusal was not actionable"
+  git -C "$home" checkout -- fixture-regression-state
+
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$home/tests/fixture-focused.test.sh"
+  chmod +x "$home/tests/fixture-focused.test.sh"
+  out=$(run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST")
+  status=$?
+  [ "$status" -ne 0 ] || fail "a modified focused artifact satisfied evidence"
+  git -C "$home" checkout -- tests/fixture-focused.test.sh
+
+  outside="$TMP_ROOT/focused-artifact-outside"
+  mkdir -p "$outside"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$outside/fixture-focused.test.sh"
+  chmod +x "$outside/fixture-focused.test.sh"
+  rm -f "$home/tests/fixture-focused.test.sh"
+  ln -s "$outside/fixture-focused.test.sh" "$home/tests/fixture-focused.test.sh"
+  git -C "$home" add -- tests/fixture-focused.test.sh
+  git -C "$home" commit --quiet -m 'replace focused artifact with symlink'
+  out=$(run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST")
+  status=$?
+  [ "$status" -ne 0 ] || fail "a symlinked focused artifact satisfied evidence"
+  assert_contains "$out" 'focused-test must name a supported' "symlinked focused artifact refusal was not actionable"
+  pass "Fast Repair binds evidence to clean tracked focused artifacts"
+}
+
 test_pr_check_rollup_states() {
   local home id=rollup-fixture fakebin out status
   home=$(make_home rollup)
@@ -427,16 +478,16 @@ test_pr_check_rollup_states() {
   write_focused_test "$home"
   write_fast_meta "$home" "$id" https://github.com/acme/repo/pull/42
   write_fake_gh "$home"
-  fakebin="$home/fakebin"
-  printf '%s\n' "$(git -C "$home" rev-parse HEAD)" > "$home/pr-head"
+  fakebin="$FAKE_GH_BIN"
+  printf '%s\n' "$(git -C "$home" rev-parse HEAD)" > "$FAKE_GH_DIR/pr-head"
   run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST" >/dev/null \
     || fail "focused evidence fixture was rejected"
-  PATH="$fakebin:$PATH" run_fast "$home" broader "$id" --command true >/dev/null \
+  PATH="$fakebin:$PATH" run_fast "$home" broader "$id" --test "$FOCUSED_TEST" >/dev/null \
     || fail "broader fixture was rejected"
 
   # A skipped check alongside real passes is ordinary CI, so the rollup is green,
   # but the counts stay visible in the ready line for the approving captain.
-  set_rollup "$home" '3 passed, 1 skipped, 0 failed, 4 total'
+  set_rollup "$FAKE_GH_DIR" '3 passed, 1 skipped, 0 failed, 4 total'
   out=$(PATH="$fakebin:$PATH" run_fast "$home" ready "$id") \
     || fail "a rollup with only passed and skipped checks was refused: $out"
   assert_contains "$out" 'fast-repair ready:' "skipped-but-green rollup did not report ready"
@@ -444,7 +495,7 @@ test_pr_check_rollup_states() {
 
   # gh-axi folds CANCELLED into the same skipped count, so a rollup where nothing
   # passed has proven nothing and is never green.
-  set_rollup "$home" '0 passed, 0 failed, 1 skipped, 1 total'
+  set_rollup "$FAKE_GH_DIR" '0 passed, 0 failed, 1 skipped, 1 total'
   out=$(PATH="$fakebin:$PATH" run_fast "$home" ready "$id")
   status=$?
   [ "$status" -ne 0 ] || fail "a rollup whose only check was skipped or cancelled was reported ready"
@@ -453,7 +504,7 @@ test_pr_check_rollup_states() {
   [ -z "$out" ] || fail "an all-skipped rollup produced an actionable progress result: $out"
 
   # "10 failed, 0 pending" contains "0 failed, 0 pending" as a substring.
-  set_rollup "$home" '3 passed, 10 failed, 0 pending, 13 total'
+  set_rollup "$FAKE_GH_DIR" '3 passed, 10 failed, 0 pending, 13 total'
   out=$(PATH="$fakebin:$PATH" run_fast "$home" ready "$id")
   status=$?
   [ "$status" -ne 0 ] || fail "a rollup with 10 failed checks was reported ready"
@@ -461,14 +512,14 @@ test_pr_check_rollup_states() {
   out=$(PATH="$fakebin:$PATH" run_fast "$home" progress "$id")
   assert_contains "$out" 'pr-checks-failed' "failed rollup was not surfaced to the progress cadence"
 
-  set_rollup "$home" '2 passed, 0 failed, 2 pending, 4 total'
+  set_rollup "$FAKE_GH_DIR" '2 passed, 0 failed, 2 pending, 4 total'
   out=$(PATH="$fakebin:$PATH" run_fast "$home" ready "$id")
   status=$?
   [ "$status" -ne 0 ] || fail "a pending rollup was reported ready"
   out=$(PATH="$fakebin:$PATH" run_fast "$home" progress "$id")
   [ -z "$out" ] || fail "a pending rollup produced an actionable progress result: $out"
 
-  set_no_checks_rollup "$home"
+  set_no_checks_rollup "$FAKE_GH_DIR"
   out=$(PATH="$fakebin:$PATH" run_fast "$home" ready "$id")
   status=$?
   [ "$status" -ne 0 ] || fail "a PR with no configured checks was reported ready"
@@ -517,7 +568,7 @@ test_later_gates_revalidate_typed_eligibility() {
   for gate in publish-pr broader progress ready; do
     case "$gate" in
       publish-pr) out=$(run_fast "$home" publish-pr "$id" --title fixture --body-file "$home/body.md") ;;
-      broader) out=$(run_fast "$home" broader "$id" --command true) ;;
+      broader) out=$(run_fast "$home" broader "$id" --test "$FOCUSED_TEST") ;;
       progress) out=$(run_fast "$home" progress "$id") ;;
       ready) out=$(run_fast "$home" ready "$id") ;;
     esac
@@ -567,8 +618,8 @@ test_evidence_commands_ignore_a_login_profile() {
   home=$(make_home login-profile)
   intake "$home" "$id" >/dev/null
   write_fast_meta "$home" "$id"
-  loginhome="$home/loginhome"
-  toolbin="$home/toolbin"
+  loginhome="$TMP_ROOT/login-profile-home"
+  toolbin="$TMP_ROOT/login-profile-bin"
   mkdir -p "$loginhome" "$toolbin"
   printf 'PATH=/nonexistent\nexport PATH\n' > "$loginhome/.bash_profile"
   cat > "$toolbin/fm-fixture-tool" <<'SH'
@@ -577,6 +628,7 @@ exit 0
 SH
   chmod +x "$toolbin/fm-fixture-tool"
   write_regression_test "$home"
+  write_focused_test "$home"
   printf '#!/usr/bin/env bash\nfm-fixture-tool\n' > "$home/$FOCUSED_TEST"
   chmod +x "$home/$FOCUSED_TEST"
   commit_test_file "$home" "$FOCUSED_TEST"
@@ -629,5 +681,6 @@ test_evidence_and_ready_gates
 test_regression_selector_must_be_new_since_reproduction
 test_regression_witness_requires_a_failing_reproduction
 test_regression_witness_uses_the_tested_runner
+test_evidence_requires_clean_bound_artifacts
 test_pr_check_rollup_states
 echo "# all fm-fast-repair tests passed"

--- a/tests/fm-fast-repair.test.sh
+++ b/tests/fm-fast-repair.test.sh
@@ -70,9 +70,15 @@ case "${1:-}" in
     ;;
 esac
 SH
-  cat > "$fakebin/gh" <<'SH'
+  cat > "$fakebin/gh" <<EOF
 #!/usr/bin/env bash
-exit 1
+FAKE_HOME='$home'
+EOF
+  cat >> "$fakebin/gh" <<'SH'
+case "${1:-} ${2:-}" in
+  "pr view") cat "$FAKE_HOME/pr-head" ;;
+  *) exit 1 ;;
+esac
 SH
   chmod +x "$fakebin/gh-axi" "$fakebin/gh"
 }
@@ -90,7 +96,10 @@ write_fast_meta() {
   {
     printf 'window=firstmate:fm-%s\n' "$id"
     printf 'kind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\nworktree=%s\n' "$home"
-    [ -z "$pr" ] || printf 'pr=%s\n' "$pr"
+    if [ -n "$pr" ]; then
+      printf 'pr=%s\n' "$pr"
+      printf 'pr_head=%s\n' "$(git -C "$home" rev-parse HEAD)"
+    fi
   } > "$home/state/$id.meta"
 }
 
@@ -224,6 +233,7 @@ test_evidence_and_ready_gates() {
   run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-test focused.test.sh >/dev/null || fail "updated task HEAD evidence was rejected"
   write_fake_gh "$home"
   fakebin="$home/fakebin"
+  printf '%040d\n' 0 > "$home/pr-head"
   # The real green rollup omits the pending segment when nothing is pending.
   set_rollup "$home" '4 passed, 0 failed, 4 total'
   out=$(PATH="$fakebin:$PATH" run_fast "$home" publish-pr "$id" --title 'Fast Repair fixture' --body-file "$home/body.md" --head unrelated)
@@ -231,6 +241,11 @@ test_evidence_and_ready_gates() {
   [ "$status" -ne 0 ] || fail "Fast Repair published an untested head branch"
   assert_contains "$out" '--head must equal the tested task branch' "untested head refusal was not actionable"
   assert_no_grep 'pr=' "$home/state/$id.meta" "untested head publication wrote a PR record"
+  out=$(PATH="$fakebin:$PATH" run_fast "$home" publish-pr "$id" --title 'Fast Repair fixture' --body-file "$home/body.md")
+  status=$?
+  [ "$status" -ne 0 ] || fail "Fast Repair accepted a PR with an untested remote head"
+  assert_contains "$out" 'registered PR head does not match' "remote-head refusal was not actionable"
+  printf '%s\n' "$(git -C "$home" rev-parse HEAD)" > "$home/pr-head"
   out=$(PATH="$fakebin:$PATH" run_fast "$home" publish-pr "$id" --title 'Fast Repair fixture' --body-file "$home/body.md")
   assert_contains "$out" 'fast-repair PR opened: https://github.com/acme/repo/pull/42' "passing evidence did not open the direct PR"
   assert_grep 'pr=https://github.com/acme/repo/pull/42' "$home/state/$id.meta" "direct PR was not registered"
@@ -240,9 +255,22 @@ test_evidence_and_ready_gates() {
   PATH="$fakebin:$PATH" run_fast "$home" broader "$id" --command true >/dev/null || fail "broader tests could not start after direct PR publication"
   out=$(PATH="$fakebin:$PATH" run_fast "$home" ready "$id")
   assert_contains "$out" 'fast-repair ready: https://github.com/acme/repo/pull/42' "green broader and PR evidence did not make the PR ready"
+  printf '%040d\n' 0 > "$home/pr-head"
+  out=$(PATH="$fakebin:$PATH" run_fast "$home" ready "$id")
+  status=$?
+  [ "$status" -ne 0 ] || fail "Fast Repair accepted a PR whose remote head changed after publication"
+  assert_contains "$out" 'registered PR head does not match' "changed remote-head refusal was not actionable"
+  printf '%s\n' "$(git -C "$home" rev-parse HEAD)" > "$home/pr-head"
   out=$(PATH="$fakebin:$PATH" run_fast "$home" progress "$id")
   assert_contains "$out" 'pr-checks-green' "green PR checks were not available to the Fast Repair progress cadence"
   assert_grep '--repo acme/repo' "$home/gh-axi.args" "PR checks were not read from the registered PR's own repository"
+  git -C "$home" commit --quiet --allow-empty -m 'advance broader fixture'
+  run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-test focused.test.sh >/dev/null \
+    || fail "updated focused evidence was rejected after a new commit"
+  out=$(PATH="$fakebin:$PATH" run_fast "$home" ready "$id")
+  status=$?
+  [ "$status" -ne 0 ] || fail "Fast Repair accepted broader evidence from an earlier commit"
+  assert_contains "$out" 'broader tests are not passed' "stale broader evidence was not refused"
   pass "Fast Repair blocks failed focused evidence and requires broader plus PR checks before ready"
 }
 
@@ -255,6 +283,7 @@ test_pr_check_rollup_states() {
   write_focused_test "$home"
   write_fake_gh "$home"
   fakebin="$home/fakebin"
+  printf '%s\n' "$(git -C "$home" rev-parse HEAD)" > "$home/pr-head"
   run_fast "$home" evidence "$id" --regression-test regression.test.sh --focused-test focused.test.sh >/dev/null \
     || fail "focused evidence fixture was rejected"
   PATH="$fakebin:$PATH" run_fast "$home" broader "$id" --command true >/dev/null \

--- a/tests/fm-fast-repair.test.sh
+++ b/tests/fm-fast-repair.test.sh
@@ -9,6 +9,10 @@ set -u
 FAST="$ROOT/bin/fm-fast-repair.sh"
 TMP_ROOT=$(fm_test_tmproot fm-fast-repair)
 
+file_mode() {
+  stat -c %a "$1" 2>/dev/null || stat -f %Lp "$1" 2>/dev/null
+}
+
 make_home() {
   local name=$1 home
   home="$TMP_ROOT/$name"
@@ -272,10 +276,68 @@ test_brief_commands_reach_the_scaffolding_home() {
   pass "the Fast Repair brief's commands run against the home that scaffolded them"
 }
 
+# The evidence commands must see the environment the crewmate hands the helper,
+# not a login profile's. The fixture HOME holds a profile that clobbers PATH,
+# which is exactly the reported harm: a correct repair recorded as failed.
+test_evidence_commands_ignore_a_login_profile() {
+  local home id=login-profile out status loginhome toolbin
+  home=$(make_home login-profile)
+  intake "$home" "$id" >/dev/null
+  write_fast_meta "$home" "$id"
+  loginhome="$home/loginhome"
+  toolbin="$home/toolbin"
+  mkdir -p "$loginhome" "$toolbin"
+  printf 'PATH=/nonexistent\nexport PATH\n' > "$loginhome/.bash_profile"
+  cat > "$toolbin/fm-fixture-tool" <<'SH'
+#!/bin/sh
+exit 0
+SH
+  chmod +x "$toolbin/fm-fixture-tool"
+
+  out=$(HOME="$loginhome" PATH="$toolbin:$PATH" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    "$FAST" evidence "$id" --regression-command fm-fixture-tool \
+    --focused-command fm-fixture-tool 2>&1)
+  status=$?
+  [ "$status" -eq 0 ] \
+    || fail "a login profile's PATH reset decided the evidence result: $out
+--- evidence log ---
+$(cat "$home/state/$id.fast-repair-tests.log" 2>/dev/null)"
+  assert_grep 'regression=passed' "$home/state/$id.fast-repair-tests" \
+    "the evidence record did not come from the inherited environment"
+  pass "Fast Repair evidence commands run with the worker's own environment, not a login profile's"
+}
+
+# The private records stay owner-only, while files the test suites create keep the
+# permissions the caller's umask asks for.
+test_private_records_do_not_impose_their_umask_on_tests() {
+  local home id=umask-scope artifact
+  home=$(make_home umask-scope)
+  intake "$home" "$id" >/dev/null
+  write_fast_meta "$home" "$id"
+  artifact="$home/suite-artifact"
+
+  ( umask 022
+    run_fast "$home" evidence "$id" \
+      --regression-command "touch '$artifact'" --focused-command true >/dev/null ) \
+    || fail "the evidence gate refused its own passing fixture commands"
+
+  [ -e "$artifact" ] || fail "the regression command did not run"
+  [ "$(file_mode "$artifact")" = 644 ] \
+    || fail "a test suite's own output inherited the record umask: $(file_mode "$artifact")"
+  [ "$(file_mode "$home/state/$id.fast-repair-tests")" = 600 ] \
+    || fail "the evidence record is not owner-only: $(file_mode "$home/state/$id.fast-repair-tests")"
+  [ "$(file_mode "$home/state/$id.fast-repair-tests.log")" = 600 ] \
+    || fail "the evidence log is not owner-only: $(file_mode "$home/state/$id.fast-repair-tests.log")"
+  pass "Fast Repair keeps its evidence records private without changing what the test commands create"
+}
+
 test_exact_prefix_only
 test_eligibility_requires_every_typed_fact
 test_stored_eligibility_uses_the_intake_rule
 test_brief_commands_reach_the_scaffolding_home
+test_evidence_commands_ignore_a_login_profile
+test_private_records_do_not_impose_their_umask_on_tests
 test_evidence_and_ready_gates
 test_pr_check_rollup_states
 echo "# all fm-fast-repair tests passed"

--- a/tests/fm-fast-repair.test.sh
+++ b/tests/fm-fast-repair.test.sh
@@ -10,6 +10,7 @@ FAST="$ROOT/bin/fm-fast-repair.sh"
 TMP_ROOT=$(fm_test_tmproot fm-fast-repair)
 REGRESSION_TEST=fixture-regression
 FOCUSED_TEST=fixture-focused
+BROADER_TEST=fixture-broader
 FAKE_GH_BIN=
 FAKE_GH_DIR=
 
@@ -25,8 +26,10 @@ make_home() {
   write_test_runner "$home"
   printf 'broken\n' > "$home/fixture-regression-state"
   printf 'passed\n' > "$home/fixture-focused-state"
+  printf 'passed\n' > "$home/fixture-broader-state"
   commit_test_file "$home" fixture-regression-state
   commit_test_file "$home" fixture-focused-state
+  commit_test_file "$home" fixture-broader-state
   printf '%s\n' "$home"
 }
 
@@ -77,14 +80,26 @@ write_test_runner() {
   mkdir -p "$home/bin"
   # shellcheck disable=SC2016 # Literal fixture code expands only when its generated script runs.
   printf '%s\n' '#!/usr/bin/env bash' 'set -eu' \
-    'if [ "${1:-}" = --list-families ]; then printf "%s\n" fixture-regression fixture-focused; exit 0; fi' \
-    'if [ "${1:-}" = --list ] && [ "${2:-}" = --family ]; then case "$3" in fixture-regression) printf "%s\n" tests/fixture-regression.test.sh ;; fixture-focused) printf "%s\n" tests/fixture-focused.test.sh ;; *) exit 2 ;; esac; exit 0; fi' \
-    'if [ "${1:-}" = --family ] && [ "$#" = 2 ]; then family=$2; elif [ "$#" = 1 ]; then case "$1" in tests/fixture-regression.test.sh) family=fixture-regression ;; tests/fixture-focused.test.sh) family=fixture-focused ;; *) exit 2 ;; esac; else exit 2; fi' \
+    'if [ "${1:-}" = --list-families ]; then printf "%s\n" fixture-regression fixture-focused fixture-broader; exit 0; fi' \
+    'if [ "${1:-}" = --list ] && [ "${2:-}" = --family ]; then case "$3" in fixture-regression) printf "%s\n" tests/fixture-regression.test.sh ;; fixture-focused) printf "%s\n" tests/fixture-focused.test.sh ;; fixture-broader) printf "%s\n" tests/fixture-broader.test.sh ;; *) exit 2 ;; esac; exit 0; fi' \
+    'if [ "${1:-}" = --family ] && [ "$#" = 2 ]; then family=$2; elif [ "$#" = 1 ]; then case "$1" in tests/fixture-regression.test.sh) family=fixture-regression ;; tests/fixture-focused.test.sh) family=fixture-focused ;; tests/fixture-broader.test.sh) family=fixture-broader ;; *) exit 2 ;; esac; else exit 2; fi' \
     'printf "FM_TEST_BEGIN fixture %s family=%s\n" "$family" "$family"' \
-    'if case "$family" in fixture-regression) [ "$(cat fixture-regression-state)" = fixed ] ;; fixture-focused) [ "$(cat fixture-focused-state)" = passed ] ;; *) false ;; esac; then status=0; else status=1; fi' \
+    'if case "$family" in fixture-regression) [ "$(cat fixture-regression-state)" = fixed ] ;; fixture-focused) [ "$(cat fixture-focused-state)" = passed ] ;; fixture-broader) [ "$(cat fixture-broader-state)" = passed ] ;; *) false ;; esac; then status=0; else status=1; fi' \
     'printf "FM_TEST_END fixture %s exit=%s duration_ms=0 gate_skip=false\n" "$family" "$status"; exit "$status"' > "$home/bin/fm-test-run.sh"
   chmod +x "$home/bin/fm-test-run.sh"
   commit_test_file "$home" bin/fm-test-run.sh
+}
+
+write_broader_test() {
+  local home=$1 code=${2:-0}
+  mkdir -p "$home/tests"
+  if ! git -C "$home" cat-file -e HEAD:tests/fixture-broader.test.sh 2>/dev/null; then
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$home/tests/fixture-broader.test.sh"
+    chmod +x "$home/tests/fixture-broader.test.sh"
+    commit_test_file "$home" tests/fixture-broader.test.sh
+  fi
+  if [ "$code" = 0 ]; then printf 'passed\n' > "$home/fixture-broader-state"; else printf 'failed\n' > "$home/fixture-broader-state"; fi
+  git -C "$home" diff --quiet -- fixture-broader-state || commit_test_file "$home" fixture-broader-state
 }
 
 intake() {
@@ -143,10 +158,10 @@ set_no_checks_rollup() { # <fake-gh-dir>
 }
 
 write_fast_meta() {
-  local home=$1 id=$2 pr=${3:-}
+  local home=$1 id=$2 pr=${3:-} wt=${4:-$1}
   {
     printf 'window=firstmate:fm-%s\n' "$id"
-    printf 'kind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\nworktree=%s\n' "$home"
+    printf 'kind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\nworktree=%s\n' "$wt"
     if [ -n "$pr" ]; then
       printf 'pr=%s\n' "$pr"
       printf 'pr_head=%s\n' "$(git -C "$home" rev-parse HEAD)"
@@ -246,6 +261,7 @@ test_evidence_and_ready_gates() {
   write_fast_meta "$home" "$id"
   write_regression_test "$home" 1
   write_focused_test "$home"
+  write_broader_test "$home"
 
   out=$(run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST")
   status=$?
@@ -357,7 +373,12 @@ test_evidence_and_ready_gates() {
   status=$?
   [ "$status" -ne 0 ] || fail "an arbitrary successful broader command was accepted"
   assert_contains "$out" 'broader requires exactly --test' "broader command refusal was not actionable"
-  PATH="$fakebin:$PATH" run_fast "$home" broader "$id" --test "$FOCUSED_TEST" >/dev/null || fail "broader tests could not start after direct PR publication"
+  out=$(PATH="$fakebin:$PATH" run_fast "$home" broader "$id" --test "$FOCUSED_TEST")
+  status=$?
+  [ "$status" -ne 0 ] || fail "re-running the focused family satisfied the broader gate"
+  assert_contains "$out" 'not the focused family' "the same-family broader refusal was not actionable"
+  [ ! -e "$home/state/$id.fast-repair-broader" ] || fail "a refused broader family still wrote a broader record"
+  PATH="$fakebin:$PATH" run_fast "$home" broader "$id" --test "$BROADER_TEST" >/dev/null || fail "broader tests could not start after direct PR publication"
   out=$(PATH="$fakebin:$PATH" run_fast "$home" ready "$id")
   assert_contains "$out" 'fast-repair ready: https://github.com/acme/repo/pull/42' "green broader and PR evidence did not make the PR ready"
   printf '%040d\n' 0 > "$FAKE_GH_DIR/pr-head"
@@ -480,13 +501,14 @@ test_pr_check_rollup_states() {
   intake "$home" "$id" >/dev/null
   write_regression_test "$home"
   write_focused_test "$home"
+  write_broader_test "$home"
   write_fast_meta "$home" "$id" https://github.com/acme/repo/pull/42
   write_fake_gh "$home"
   fakebin="$FAKE_GH_BIN"
   printf '%s\n' "$(git -C "$home" rev-parse HEAD)" > "$FAKE_GH_DIR/pr-head"
   run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST" >/dev/null \
     || fail "focused evidence fixture was rejected"
-  PATH="$fakebin:$PATH" run_fast "$home" broader "$id" --test "$FOCUSED_TEST" >/dev/null \
+  PATH="$fakebin:$PATH" run_fast "$home" broader "$id" --test "$BROADER_TEST" >/dev/null \
     || fail "broader fixture was rejected"
 
   # A skipped check alongside real passes is ordinary CI, so the rollup is green,
@@ -563,6 +585,7 @@ test_later_gates_revalidate_typed_eligibility() {
   write_fast_meta "$home" "$id" https://github.com/acme/repo/pull/42
   write_regression_test "$home"
   write_focused_test "$home"
+  write_broader_test "$home"
   out=$(run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST")
   status=$?
   [ "$status" -eq 0 ] || fail "the later-gate fixture could not record focused evidence: $out"
@@ -572,7 +595,7 @@ test_later_gates_revalidate_typed_eligibility() {
   for gate in publish-pr broader progress ready; do
     case "$gate" in
       publish-pr) out=$(run_fast "$home" publish-pr "$id" --title fixture --body-file "$home/body.md") ;;
-      broader) out=$(run_fast "$home" broader "$id" --test "$FOCUSED_TEST") ;;
+      broader) out=$(run_fast "$home" broader "$id" --test "$BROADER_TEST") ;;
       progress) out=$(run_fast "$home" progress "$id") ;;
       ready) out=$(run_fast "$home" ready "$id") ;;
     esac
@@ -593,6 +616,7 @@ test_brief_commands_reach_the_scaffolding_home() {
   write_fast_meta "$home" "$id"
   write_regression_test "$home"
   write_focused_test "$home"
+  write_broader_test "$home"
   FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     "$ROOT/bin/fm-brief.sh" "$id" fixtureproj --mode fast-repair >/dev/null \
     || fail "the Fast Repair brief could not be scaffolded"
@@ -627,7 +651,8 @@ test_brief_commands_reach_the_scaffolding_home() {
   [ -n "$line" ] || fail "the Fast Repair brief mandates no broader-test command"
   cmd=${line#*\`}
   cmd=${cmd%\`*}
-  broader_cmd=${cmd/"'<runner family>'"/"$FOCUSED_TEST"}
+  broader_cmd=${cmd/"'<runner family broader than the focused one>'"/"$BROADER_TEST"}
+  [ "$broader_cmd" != "$cmd" ] || fail "the brief's broader command carries no runner-family placeholder"
   out=$(cd "$home" && env -u FM_HOME -u FM_STATE_OVERRIDE -u FM_DATA_OVERRIDE -u FM_ROOT_OVERRIDE \
     PATH="$fakebin:$PATH" bash -c "$broader_cmd" 2>&1)
   status=$?
@@ -713,8 +738,138 @@ test_skipped_runner_family_cannot_satisfy_evidence() {
   pass "Fast Repair evidence rejects skipped selected tests"
 }
 
+# Dispatch hands the crewmate a freshly pooled worktree at a detached HEAD sitting
+# exactly on the commit the defect was reproduced at; the branch and the repair
+# commit only exist later. The spawn gate must therefore accept that state while
+# still refusing a worktree that is dirty, is not the task's repository root, or
+# whose history does not carry the recorded reproduction commit.
+test_spawn_eligibility_accepts_the_detached_task_worktree() {
+  local home id=detached-spawn ahead=detached-ahead unknown=detached-unknown wt out status first second
+  home=$(make_home detached-spawn)
+  intake "$home" "$id" >/dev/null
+  first=$(git -C "$home" rev-parse HEAD)
+  wt="$TMP_ROOT/detached-spawn-worktree"
+  git -C "$home" worktree add --quiet --detach "$wt" "$first" \
+    || fail "the detached task worktree fixture could not be created"
+  git -C "$wt" symbolic-ref --quiet --short HEAD >/dev/null 2>&1 \
+    && fail "the fixture worktree is not at a detached HEAD"
+
+  out=$(run_fast "$home" eligible "$id" --worktree "$wt")
+  status=$?
+  [ "$status" -eq 0 ] || fail "the real detached task worktree was refused at dispatch: $out"
+
+  printf 'uncommitted\n' > "$wt/spawn-dirt"
+  out=$(run_fast "$home" eligible "$id" --worktree "$wt")
+  status=$?
+  [ "$status" -ne 0 ] || fail "a dirty task worktree passed the dispatch eligibility proof"
+  assert_contains "$out" 'no safe git worktree' "the dirty-worktree refusal was not actionable"
+  rm -f "$wt/spawn-dirt"
+
+  out=$(run_fast "$home" eligible "$id" --worktree "$wt/bin")
+  status=$?
+  [ "$status" -ne 0 ] || fail "a path below the worktree root passed the dispatch eligibility proof"
+  assert_contains "$out" 'no safe git worktree' "the non-root refusal was not actionable"
+
+  # A reproduction commit the worktree's own history does not carry yet is still
+  # refused, so the spawn gate keeps binding the record to this task's history.
+  git -C "$home" commit --quiet --allow-empty -m 'advance past the pooled worktree'
+  second=$(git -C "$home" rev-parse HEAD)
+  run_fast "$home" intake "$ahead" --request 'fast-repair: repair fixture' \
+    --reproduction reproduced --reproduction-revision "$second" --root-cause confirmed \
+    --isolation isolated --schema none --authentication none --authorization none \
+    --secrets none --financial none --legal none --side-effects none >/dev/null \
+    || fail "the ahead-revision fixture could not be recorded"
+  out=$(run_fast "$home" eligible "$ahead" --worktree "$wt")
+  status=$?
+  [ "$status" -ne 0 ] || fail "a reproduction revision absent from the worktree history was accepted"
+  assert_contains "$out" 'not an ancestor' "the non-ancestor refusal was not actionable"
+
+  git -C "$wt" checkout --quiet --detach "$second"
+  run_fast "$home" eligible "$ahead" --worktree "$wt" >/dev/null \
+    || fail "a detached worktree sitting on the reproduction commit was refused"
+
+  run_fast "$home" intake "$unknown" --request 'fast-repair: repair fixture' \
+    --reproduction reproduced --reproduction-revision "$(printf '%040d' 0)" --root-cause confirmed \
+    --isolation isolated --schema none --authentication none --authorization none \
+    --secrets none --financial none --legal none --side-effects none >/dev/null \
+    || fail "the unknown-revision fixture could not be recorded"
+  out=$(run_fast "$home" eligible "$unknown" --worktree "$wt")
+  status=$?
+  [ "$status" -ne 0 ] || fail "a reproduction revision that is not a commit was accepted"
+  pass "the Fast Repair dispatch gate proves the real detached task worktree without weakening its bindings"
+}
+
+# The proofs the dispatch gate cannot make yet are still mandatory once the
+# tested head exists: evidence binds a named branch and requires the repair to
+# sit strictly above the reproduction commit.
+test_tested_head_proofs_stay_strict_after_dispatch() {
+  local home id=head-proofs wt out status
+  home=$(make_home head-proofs)
+  intake "$home" "$id" >/dev/null
+  write_regression_test "$home"
+  write_focused_test "$home"
+
+  wt="$TMP_ROOT/head-proofs-worktree"
+  git -C "$home" worktree add --quiet --detach "$wt" HEAD \
+    || fail "the detached evidence worktree fixture could not be created"
+  write_fast_meta "$home" "$id" '' "$wt"
+  out=$(run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST")
+  status=$?
+  [ "$status" -ne 0 ] || fail "evidence accepted a detached task worktree with no branch to bind"
+  assert_contains "$out" 'no safe git worktree' "the detached-evidence refusal was not actionable"
+  [ ! -e "$home/state/$id.fast-repair-tests" ] || fail "a branchless evidence run still wrote an evidence record"
+  git -C "$home" worktree remove --force "$wt"
+
+  # Re-record the reproduction at the branch tip: the repair commit no longer
+  # sits above it, so the tested-head gate must refuse even though the same
+  # record would satisfy the dispatch gate.
+  write_fast_meta "$home" "$id"
+  intake "$home" "$id" >/dev/null
+  run_fast "$home" eligible "$id" --worktree "$home" >/dev/null \
+    || fail "the dispatch gate refused a worktree sitting on its reproduction commit"
+  out=$(run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST")
+  status=$?
+  [ "$status" -ne 0 ] || fail "evidence accepted a reproduction revision equal to the tested head"
+  assert_contains "$out" 'reproduction revision is unknown, current, or not an ancestor' \
+    "the current-reproduction refusal was not actionable"
+  pass "Fast Repair still requires a bound branch and a strictly older reproduction commit at the tested head"
+}
+
+# Both halves of the regression proof reach the runner through a bare selector
+# rather than --family, so the skip rule must be enforced on that argv shape too;
+# a runner that reports the selector run as skipped can never prove a repair.
+test_skipped_selector_run_cannot_satisfy_evidence() {
+  local home id=skipped-selector out status
+  home=$(make_home skipped-selector)
+  intake "$home" "$id" >/dev/null
+  write_fast_meta "$home" "$id"
+  write_regression_test "$home"
+  write_focused_test "$home"
+  # shellcheck disable=SC2016 # Literal fixture code expands only when its generated script runs.
+  sed 's/gate_skip=false/gate_skip=$skip/' "$home/bin/fm-test-run.sh" > "$home/bin/fm-test-run.sh.tmp" \
+    && mv -f "$home/bin/fm-test-run.sh.tmp" "$home/bin/fm-test-run.sh"
+  # shellcheck disable=SC2016 # Literal fixture code expands only when its generated script runs.
+  sed 's/^printf "FM_TEST_BEGIN/if [ "${1:-}" = --family ]; then skip=false; else skip=true; fi\nprintf "FM_TEST_BEGIN/' \
+    "$home/bin/fm-test-run.sh" > "$home/bin/fm-test-run.sh.tmp" \
+    && mv -f "$home/bin/fm-test-run.sh.tmp" "$home/bin/fm-test-run.sh"
+  chmod +x "$home/bin/fm-test-run.sh"
+  commit_test_file "$home" bin/fm-test-run.sh
+  ( cd "$home" && ./bin/fm-test-run.sh --family "$FOCUSED_TEST" | grep -q 'gate_skip=false' ) \
+    || fail "the fixture runner no longer reports an unskipped family run"
+  ( cd "$home" && ./bin/fm-test-run.sh "tests/$REGRESSION_TEST.test.sh" | grep -q 'gate_skip=true' ) \
+    || fail "the fixture runner no longer reports a skipped selector run"
+  out=$(run_fast "$home" evidence "$id" --regression-test "$REGRESSION_TEST" --focused-test "$FOCUSED_TEST")
+  status=$?
+  [ "$status" -ne 0 ] || fail "a skipped selector run satisfied Fast Repair evidence: $out"
+  assert_contains "$out" 'PR publication remains blocked' "a skipped selector run did not block publication"
+  pass "Fast Repair applies one skip rule to family and selector runner invocations alike"
+}
+
 test_exact_prefix_only
 test_eligibility_requires_every_typed_fact
+test_spawn_eligibility_accepts_the_detached_task_worktree
+test_tested_head_proofs_stay_strict_after_dispatch
+test_skipped_selector_run_cannot_satisfy_evidence
 test_stored_eligibility_uses_the_intake_rule
 test_later_gates_revalidate_typed_eligibility
 test_brief_commands_reach_the_scaffolding_home

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -726,20 +726,39 @@ test_active_dispatch_profile_does_not_block_secondmate_launch() {
 }
 
 test_fast_repair_requires_and_records_its_builtin_profile() {
-  local rec id conflict_id raw_id out status launch
+  local rec id conflict_id raw_id unknown_id nonancestor_id out status launch reproduction nonancestor
   id=fast-repair-profile-z20
   conflict_id=fast-repair-conflict-z21
   raw_id=fast-repair-raw-z22
-  rec=$(make_spawn_case fast-repair-profile codex "$id" "$conflict_id" "$raw_id")
+  unknown_id=fast-repair-unknown-z23
+  nonancestor_id=fast-repair-nonancestor-z24
+  rec=$(make_spawn_case fast-repair-profile codex "$id" "$conflict_id" "$raw_id" "$unknown_id" "$nonancestor_id")
   read_case_record "$rec"
+  git -C "$WT_DIR" commit --quiet --allow-empty -m 'repair fixture head'
+  reproduction=$(git -C "$WT_DIR" rev-parse HEAD~1)
+  git -C "$PROJ_DIR" commit --quiet --allow-empty -m 'unrelated fixture revision'
+  nonancestor=$(git -C "$PROJ_DIR" rev-parse HEAD)
   for task in "$id" "$conflict_id" "$raw_id"; do
     printf 'Delivery contract: mode=fast-repair\n' > "$HOME_DIR/data/$task/brief.md"
     FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
       "$FAST_REPAIR" intake "$task" --request 'fast-repair: fixture' \
-      --reproduction reproduced --reproduction-revision 0000000000000000000000000000000000000000 --root-cause confirmed --isolation isolated \
+      --reproduction reproduced --reproduction-revision "$reproduction" --root-cause confirmed --isolation isolated \
       --schema none --authentication none --authorization none --secrets none \
       --financial none --legal none --side-effects none >/dev/null
   done
+  for task in "$unknown_id" "$nonancestor_id"; do
+    printf 'Delivery contract: mode=fast-repair\n' > "$HOME_DIR/data/$task/brief.md"
+  done
+  FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    "$FAST_REPAIR" intake "$unknown_id" --request 'fast-repair: fixture' \
+    --reproduction reproduced --reproduction-revision 0000000000000000000000000000000000000000 --root-cause confirmed --isolation isolated \
+    --schema none --authentication none --authorization none --secrets none \
+    --financial none --legal none --side-effects none >/dev/null
+  FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    "$FAST_REPAIR" intake "$nonancestor_id" --request 'fast-repair: fixture' \
+    --reproduction reproduced --reproduction-revision "$nonancestor" --root-cause confirmed --isolation isolated \
+    --schema none --authentication none --authorization none --secrets none \
+    --financial none --legal none --side-effects none >/dev/null
 
   out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
     --mode fast-repair --yolo off --harness codex --model gpt-5.6-luna --effort medium)
@@ -766,6 +785,14 @@ test_fast_repair_requires_and_records_its_builtin_profile() {
   [ "$status" -ne 0 ] || fail "Fast Repair accepted a raw launch command with a different actual profile"
   assert_contains "$out" "requires the built-in profile" "raw Fast Repair profile refusal was not actionable"
   assert_absent "$HOME_DIR/state/$raw_id.meta" "raw Fast Repair profile wrote metadata"
+  for task in "$unknown_id" "$nonancestor_id"; do
+    out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$task" "$PROJ_DIR" \
+      --mode fast-repair --yolo off --harness codex --model gpt-5.6-luna --effort medium)
+    status=$?
+    [ "$status" -ne 0 ] || fail "Fast Repair dispatched an unproven reproduction revision: $task"
+    assert_contains "$out" 'reproduction revision is not proven' "unproven reproduction refusal was not actionable: $task"
+    assert_absent "$HOME_DIR/state/$task.meta" "unproven Fast Repair reproduction wrote metadata: $task"
+  done
   pass "Fast Repair enforces Codex Luna medium without changing ordinary dispatch profiles"
 }
 

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -726,12 +726,13 @@ test_active_dispatch_profile_does_not_block_secondmate_launch() {
 }
 
 test_fast_repair_requires_and_records_its_builtin_profile() {
-  local rec id conflict_id out status launch
+  local rec id conflict_id raw_id out status launch
   id=fast-repair-profile-z20
   conflict_id=fast-repair-conflict-z21
-  rec=$(make_spawn_case fast-repair-profile codex "$id" "$conflict_id")
+  raw_id=fast-repair-raw-z22
+  rec=$(make_spawn_case fast-repair-profile codex "$id" "$conflict_id" "$raw_id")
   read_case_record "$rec"
-  for task in "$id" "$conflict_id"; do
+  for task in "$id" "$conflict_id" "$raw_id"; do
     printf 'Delivery contract: mode=fast-repair\n' > "$HOME_DIR/data/$task/brief.md"
     FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
       "$FAST_REPAIR" intake "$task" --request 'fast-repair: fixture' \
@@ -757,6 +758,14 @@ test_fast_repair_requires_and_records_its_builtin_profile() {
   [ "$status" -ne 0 ] || fail "Fast Repair silently accepted a conflicting profile"
   assert_contains "$out" "requires the built-in profile" "Fast Repair profile refusal was not actionable"
   assert_absent "$HOME_DIR/state/$conflict_id.meta" "conflicting Fast Repair profile wrote metadata"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$raw_id" "$PROJ_DIR" \
+    --mode fast-repair --yolo off --harness 'codex --model gpt-5.6-terra -c model_reasoning_effort=high' \
+    --model gpt-5.6-luna --effort medium)
+  status=$?
+  [ "$status" -ne 0 ] || fail "Fast Repair accepted a raw launch command with a different actual profile"
+  assert_contains "$out" "requires the built-in profile" "raw Fast Repair profile refusal was not actionable"
+  assert_absent "$HOME_DIR/state/$raw_id.meta" "raw Fast Repair profile wrote metadata"
   pass "Fast Repair enforces Codex Luna medium without changing ordinary dispatch profiles"
 }
 

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -11,6 +11,7 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 SPAWN="$ROOT/bin/fm-spawn.sh"
+FAST_REPAIR="$ROOT/bin/fm-fast-repair.sh"
 TMP_ROOT=$(fm_test_tmproot fm-spawn-dispatch-profile)
 
 make_spawn_pi_probe() {
@@ -724,7 +725,43 @@ test_active_dispatch_profile_does_not_block_secondmate_launch() {
   pass "active crew-dispatch profile does not block secondmate launches"
 }
 
+test_fast_repair_requires_and_records_its_builtin_profile() {
+  local rec id conflict_id out status launch
+  id=fast-repair-profile-z20
+  conflict_id=fast-repair-conflict-z21
+  rec=$(make_spawn_case fast-repair-profile codex "$id" "$conflict_id")
+  read_case_record "$rec"
+  for task in "$id" "$conflict_id"; do
+    printf 'Delivery contract: mode=fast-repair\n' > "$HOME_DIR/data/$task/brief.md"
+    FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+      "$FAST_REPAIR" intake "$task" --request 'fast-repair: fixture' \
+      --reproduction reproduced --root-cause confirmed --isolation isolated \
+      --schema none --authentication none --authorization none --secrets none \
+      --financial none --legal none --side-effects none >/dev/null
+  done
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --mode fast-repair --yolo off --harness codex --model gpt-5.6-luna --effort medium)
+  status=$?
+  expect_code 0 "$status" "Fast Repair spawn with its built-in profile should succeed"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5.6-luna medium
+  assert_grep 'mode=fast-repair' "$HOME_DIR/state/$id.meta" "Fast Repair meta missing canonical mode"
+  assert_grep 'fast_repair=eligible' "$HOME_DIR/state/$id.meta" "Fast Repair meta missing eligibility result"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "codex --model 'gpt-5.6-luna'" "Fast Repair launch did not use Luna"
+  assert_contains "$launch" "model_reasoning_effort=\"medium\"" "Fast Repair launch did not use medium effort"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$conflict_id" "$PROJ_DIR" \
+    --mode fast-repair --yolo off --harness codex --model gpt-5.6-terra --effort high)
+  status=$?
+  [ "$status" -ne 0 ] || fail "Fast Repair silently accepted a conflicting profile"
+  assert_contains "$out" "requires the built-in profile" "Fast Repair profile refusal was not actionable"
+  assert_absent "$HOME_DIR/state/$conflict_id.meta" "conflicting Fast Repair profile wrote metadata"
+  pass "Fast Repair enforces Codex Luna medium without changing ordinary dispatch profiles"
+}
+
 test_no_profile_keeps_claude_profile_defaults
+test_fast_repair_requires_and_records_its_builtin_profile
 test_relative_home_overrides_launch_with_absolute_cross_process_paths
 test_home_defaults_preserve_absolute_or_resolve_relative_paths
 test_absolute_override_spelling_is_preserved_in_launch_paths

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -734,8 +734,14 @@ test_fast_repair_requires_and_records_its_builtin_profile() {
   nonancestor_id=fast-repair-nonancestor-z24
   rec=$(make_spawn_case fast-repair-profile codex "$id" "$conflict_id" "$raw_id" "$unknown_id" "$nonancestor_id")
   read_case_record "$rec"
-  git -C "$WT_DIR" commit --quiet --allow-empty -m 'repair fixture head'
-  reproduction=$(git -C "$WT_DIR" rev-parse HEAD~1)
+  # The dispatch state firstmate actually creates: a pooled worktree at a
+  # detached HEAD sitting exactly on the commit the defect was reproduced at.
+  # The crewmate creates fm/<id> and the repair commit only after it launches,
+  # so the spawn gate sees no branch and no commit above the reproduction.
+  reproduction=$(git -C "$WT_DIR" rev-parse HEAD)
+  git -C "$WT_DIR" checkout --quiet --detach "$reproduction"
+  git -C "$WT_DIR" symbolic-ref --quiet --short HEAD >/dev/null 2>&1 \
+    && fail "the dispatch worktree fixture is not at a detached HEAD"
   git -C "$PROJ_DIR" commit --quiet --allow-empty -m 'unrelated fixture revision'
   nonancestor=$(git -C "$PROJ_DIR" rev-parse HEAD)
   for task in "$id" "$conflict_id" "$raw_id"; do

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -736,7 +736,7 @@ test_fast_repair_requires_and_records_its_builtin_profile() {
     printf 'Delivery contract: mode=fast-repair\n' > "$HOME_DIR/data/$task/brief.md"
     FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
       "$FAST_REPAIR" intake "$task" --request 'fast-repair: fixture' \
-      --reproduction reproduced --root-cause confirmed --isolation isolated \
+      --reproduction reproduced --reproduction-revision 0000000000000000000000000000000000000000 --root-cause confirmed --isolation isolated \
       --schema none --authentication none --authorization none --secrets none \
       --financial none --legal none --side-effects none >/dev/null
   done

--- a/tests/fm-supervision-events.test.sh
+++ b/tests/fm-supervision-events.test.sh
@@ -426,6 +426,51 @@ for retirement_id in a b; do
 done
 pass "fast_repair_progress_timer_tasks_finish: task retirement signals children concurrently"
 
+reset_state
+reservation_fakebin="$TMP/reservation-fakebin"
+reservation_started="$TMP/reservation-started"
+reservation_check="$TMP/reservation-check-ran"
+mkdir -p "$reservation_fakebin"
+cat > "$reservation_fakebin/mktemp" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+  *.starting.XXXXXX) ;;
+  *.fast-repair-progress-child-*.XXXXXX)
+    : > "$FM_RESERVATION_STARTED"
+    sleep 0.2
+    ;;
+esac
+exec "$FM_REAL_MKTEMP" "$@"
+SH
+chmod +x "$reservation_fakebin/mktemp"
+run_check_capture() {
+  : > "$reservation_check"
+  FM_CHECK_RESULT=
+}
+FM_RESERVATION_STARTED="$reservation_started" FM_REAL_MKTEMP="$(command -v mktemp)" \
+  FM_FAST_REPAIR_TIMER_CLOSING="$STATE_DIR/reservation.closing" \
+  PATH="$reservation_fakebin:$PATH" fast_repair_progress_task_start tk-reservation 21 &
+reservation_starter=$!
+for reservation_wait in $(seq 1 50); do
+  [ -e "$reservation_started" ] && break
+  command sleep 0.01
+done
+[ -e "$reservation_started" ] || fail "the Fast Repair task did not enter the pre-registration window"
+: > "$STATE_DIR/reservation.closing"
+fast_repair_progress_timer_tasks_finish 21
+wait "$reservation_starter" || fail "the Fast Repair task starter did not finish"
+for reservation_wait in $(seq 1 50); do
+  [ ! -e "$STATE_DIR/.fast-repair-progress-child-tk-reservation-21" ] \
+    && [ ! -e "$STATE_DIR/.fast-repair-progress-child-tk-reservation-21.ready" ] \
+    && break
+  command sleep 0.01
+done
+[ ! -e "$STATE_DIR/.fast-repair-progress-child-tk-reservation-21" ] \
+  && [ ! -e "$STATE_DIR/.fast-repair-progress-child-tk-reservation-21.ready" ] \
+  || fail "wait shutdown retained a pre-registration Fast Repair child"
+[ ! -e "$reservation_check" ] || fail "a pre-registration Fast Repair child ran after shutdown"
+pass "fast_repair_progress_timer_tasks_finish: reservations retire pre-registration children"
+
 ordinary_check_state="$TMP/ordinary-check-state"
 ordinary_check="$TMP/ordinary-check.sh"
 ordinary_check_pid="$TMP/ordinary-check.pid"

--- a/tests/fm-supervision-events.test.sh
+++ b/tests/fm-supervision-events.test.sh
@@ -29,7 +29,9 @@ FAST_REPAIR_PROGRESS_TICK_PRODUCTION=$(declare -f fast_repair_progress_tick)
 # Overrides: capture wake reasons and neutralize real sleeps (POLL is 15s).
 WAKE_LOG="$TMP/wakes"
 SLEEP_LOG="$TMP/sleeps"
+# shellcheck disable=SC2329 # Runtime override called by the isolated watcher.
 wake() { printf '%s\n' "$1" >> "$WAKE_LOG"; return 0; }
+# shellcheck disable=SC2329 # Runtime override called by the isolated watcher.
 sleep() { printf 'SLEEP\n' >> "$SLEEP_LOG"; }
 
 reset_state() {
@@ -46,6 +48,7 @@ reset_state() {
   _event_cap_key=""
   _event_cap_ok=0
   _event_cap_fails=0
+  # shellcheck disable=SC2034 # Reset global consumed by the sourced watcher.
   FAST_REPAIR_TIMER_MARKER=
   FAST_REPAIR_TIMER_GENERATION=0
 }
@@ -152,6 +155,7 @@ reset_state
 fm_write_meta "$STATE_DIR/tk6.meta" "window=default:wG:pQ" "kind=ship" "mode=fast-repair" "fast_repair=eligible"
 FAST_REPAIR_ACTIVE=0
 : > "$TMP/forge-called"
+# shellcheck disable=SC2329 # Runtime override called by the isolated watcher.
 fast_repair_progress_tick() { printf 'called\n' >> "$TMP/forge-called"; }
 fast_repair_progress_discover
 [ "$FAST_REPAIR_ACTIVE" = 1 ] || fail "Fast Repair metadata was not discovered for its wait-time timer"
@@ -190,6 +194,7 @@ FAST_REPAIR_TIMER_GENERATION=1
 WATCHER_PID=${BASHPID:-$$}
 mkdir -p "$WATCH_LOCK"
 printf '%s\n' "$WATCHER_PID" > "$WATCH_LOCK/pid"
+# shellcheck disable=SC2329 # Runtime override called by the isolated watcher.
 fast_repair_progress_timer_start() {
   (
     command sleep 0.05
@@ -197,7 +202,9 @@ fast_repair_progress_timer_start() {
       > "$STATE_DIR/.fast-repair-progress-handoff-tk6-1"
   ) &
 }
+# shellcheck disable=SC2329 # Runtime override called by the isolated watcher.
 fm_backend_events_capable() { return 0; }
+# shellcheck disable=SC2329 # Runtime override called by the isolated watcher.
 fm_backend_wait_transition() {
   command sleep 0.15
   printf 'complete\n' > "$TMP/fast-repair-transition-complete"
@@ -225,6 +232,7 @@ fast_repair_progress_timer_start() {
   generation=$FAST_REPAIR_TIMER_GENERATION
   marker=$(mktemp "$STATE_DIR/.fast-repair-progress-timer.XXXXXX")
   closing="$marker.closing"
+  # shellcheck disable=SC2034 # Timer cleanup in the sourced watcher reads this global.
   FAST_REPAIR_TIMER_MARKER=$marker
   (
     command sleep 0.5
@@ -311,13 +319,15 @@ reset_state
 fm_write_meta "$STATE_DIR/tk14.meta" "window=default:wG:pQ" "kind=ship" "mode=fast-repair" "fast_repair=eligible"
 FAST_REPAIR_PROGRESS_INTERVAL=20
 : > "$TMP/progress-checks"
+# shellcheck disable=SC2329 # Runtime override called by the isolated watcher.
 run_check_capture() {
   printf 'check\n' >> "$TMP/progress-checks"
+  # shellcheck disable=SC2034 # Result contract consumed by the sourced watcher.
   FM_CHECK_RESULT=
 }
 FM_FAST_REPAIR_TIMER_GENERATION=9 fast_repair_progress_tick
 FM_FAST_REPAIR_TIMER_GENERATION=10 fast_repair_progress_tick
-for progress_wait in $(seq 1 50); do
+for _ in $(seq 1 50); do
   [ -s "$TMP/progress-checks" ] && break
   command sleep 0.01
 done
@@ -327,15 +337,20 @@ pass "fast_repair_progress_tick: short waits retain the task progress cadence"
 
 reset_state
 fm_write_meta "$STATE_DIR/tk14a.meta" "window=default:wG:pQ" "kind=ship" "mode=fast-repair" "fast_repair=eligible"
+# shellcheck disable=SC2034 # Poll cadence consumed by the sourced watcher.
 POLL=15
+# shellcheck disable=SC2034 # Progress cadence consumed by the sourced watcher.
 FAST_REPAIR_PROGRESS_INTERVAL=20
 FAST_REPAIR_NOW=100
+# shellcheck disable=SC2329 # Runtime override called by the isolated watcher.
 date() {
   [ "${1:-}" = +%s ] && { printf '%s\n' "$FAST_REPAIR_NOW"; return 0; }
   command date "$@"
 }
+# shellcheck disable=SC2329 # Runtime override called by the isolated watcher.
 run_check_capture() {
   printf 'check\n' >> "$TMP/default-poll-checks"
+  # shellcheck disable=SC2034 # Result contract consumed by the sourced watcher.
   FM_CHECK_RESULT=
 }
 fast_repair_progress_schedule_missing
@@ -349,7 +364,7 @@ FM_FAST_REPAIR_TIMER_GENERATION=10 fast_repair_progress_tick
   || fail "the second default-poll timer did not retain the remaining due delay"
 FAST_REPAIR_NOW=120
 FM_FAST_REPAIR_TIMER_GENERATION=11 fast_repair_progress_tick
-for progress_wait in $(seq 1 50); do
+for _ in $(seq 1 50); do
   [ -s "$TMP/default-poll-checks" ] && break
   command sleep 0.01
 done
@@ -364,6 +379,7 @@ fm_write_meta "$STATE_DIR/tk9a.meta" "window=default:wG:pQ" "kind=ship" "mode=fa
 fm_write_meta "$STATE_DIR/tk9b.meta" "window=default:wG:pR" "kind=ship" "mode=fast-repair" "fast_repair=eligible"
 WATCHER_PID=${BASHPID:-$$}
 FAST_REPAIR_TIMER_GENERATION=3
+# shellcheck disable=SC2329 # Runtime override called by the isolated watcher.
 run_check_capture() {
   case "${!#}" in
     tk9a) FM_CHECK_RESULT='fast-repair tk9a pr-checks-green' ;;
@@ -374,7 +390,7 @@ run_check_capture() {
 FM_FAST_REPAIR_TIMER_PARENT="$WATCHER_PID" \
   FM_FAST_REPAIR_TIMER_GENERATION=3 \
   fast_repair_progress_tick
-for progress_wait in $(seq 1 50); do
+for _ in $(seq 1 50); do
   compgen -G "$STATE_DIR/.fast-repair-progress-handoff-tk9a-3-*" >/dev/null \
     && compgen -G "$STATE_DIR/.fast-repair-progress-handoff-tk9b-3-*" >/dev/null \
     && break
@@ -447,7 +463,7 @@ for retirement_id in a b; do
     bash -c 'trap '\''printf term > "$FM_RETIREMENT_TERM"; sleep 0.15; exit 0'\'' TERM; : > "$FM_RETIREMENT_READY"; while :; do :; done' &
   retirement_pid=$!
   retirement_pids+=("$retirement_pid")
-  for retirement_wait in $(seq 1 50); do
+  for _ in $(seq 1 50); do
     [ -e "$retirement_ready" ] && break
     command sleep 0.01
   done
@@ -493,15 +509,17 @@ esac
 exec "$FM_REAL_MKTEMP" "$@"
 SH
 chmod +x "$reservation_fakebin/mktemp"
+# shellcheck disable=SC2329 # Runtime override called by the isolated watcher.
 run_check_capture() {
   : > "$reservation_check"
+  # shellcheck disable=SC2034 # Result contract consumed by the sourced watcher.
   FM_CHECK_RESULT=
 }
 FM_RESERVATION_STARTED="$reservation_started" FM_REAL_MKTEMP="$(command -v mktemp)" \
   FM_FAST_REPAIR_TIMER_CLOSING="$STATE_DIR/reservation.closing" \
   PATH="$reservation_fakebin:$PATH" fast_repair_progress_task_start tk-reservation 21 &
 reservation_starter=$!
-for reservation_wait in $(seq 1 50); do
+for _ in $(seq 1 50); do
   [ -e "$reservation_started" ] && break
   command sleep 0.01
 done
@@ -509,7 +527,7 @@ done
 : > "$STATE_DIR/reservation.closing"
 fast_repair_progress_timer_tasks_finish 21
 wait "$reservation_starter" || fail "the Fast Repair task starter did not finish"
-for reservation_wait in $(seq 1 50); do
+for _ in $(seq 1 50); do
   [ ! -e "$STATE_DIR/.fast-repair-progress-child-tk-reservation-21" ] \
     && [ ! -e "$STATE_DIR/.fast-repair-progress-child-tk-reservation-21.ready" ] \
     && break
@@ -603,7 +621,7 @@ FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$normal_home" FM_STATE_OVERRIDE="$normal_state
   FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$ROOT/bin/fm-watch.sh" > "$normal_out" 2>&1 &
 normal_pid=$!
 normal_ready=0
-for normal_wait in $(seq 1 50); do
+for _ in $(seq 1 50); do
   if [ -s "$normal_state/.watch.lock/pid" ]; then
     normal_ready=1
     break

--- a/tests/fm-supervision-events.test.sh
+++ b/tests/fm-supervision-events.test.sh
@@ -426,6 +426,78 @@ for retirement_id in a b; do
 done
 pass "fast_repair_progress_timer_tasks_finish: task retirement signals children concurrently"
 
+ordinary_check_state="$TMP/ordinary-check-state"
+ordinary_check="$TMP/ordinary-check.sh"
+ordinary_check_pid="$TMP/ordinary-check.pid"
+ordinary_check_out="$TMP/ordinary-check.out"
+mkdir -p "$ordinary_check_state"
+cat > "$ordinary_check" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$$" > "$FM_ORDINARY_CHECK_PID"
+trap '' TERM
+while :; do sleep 1; done
+SH
+chmod +x "$ordinary_check"
+if ! FM_STATE_OVERRIDE="$ordinary_check_state" FM_ORDINARY_CHECK_PID="$ordinary_check_pid" \
+  bash -c '
+    set -u
+    . "$1"
+    run_check_capture "$2" &
+    runner=$!
+    i=0
+    while [ ! -s "$3" ] && [ "$i" -lt 50 ]; do sleep 0.01; i=$((i + 1)); done
+    [ -s "$3" ] || exit 1
+    check_pid=$(cat "$3")
+    pgid=$(ps -o pgid= -p "$check_pid" 2>/dev/null | tr -d "[:space:]")
+    case "$pgid" in ""|*[!0-9]*) exit 1 ;; esac
+    trap "kill -KILL -- -$pgid 2>/dev/null || true; wait \"$runner\" 2>/dev/null || true" EXIT
+    kill -TERM "$runner"
+    wait "$runner"
+    runner_status=$?
+    [ "$runner_status" -eq 1 ] || exit 1
+    kill -0 "$check_pid" 2>/dev/null
+  ' _ "$ROOT/bin/fm-watch.sh" "$ordinary_check" "$ordinary_check_pid" > "$ordinary_check_out" 2>&1; then
+  fail "an ordinary check signal stopped its active check group: $(cat "$ordinary_check_out")"
+fi
+pass "ordinary checks keep their original signal behavior"
+
+fast_check_state="$TMP/fast-check-state"
+fast_check="$TMP/fast-check.sh"
+fast_check_pid="$TMP/fast-check.pid"
+fast_check_out="$TMP/fast-check.out"
+mkdir -p "$fast_check_state"
+cat > "$fast_check" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$$" > "$FM_FAST_CHECK_PID"
+trap '' TERM
+while :; do sleep 1; done
+SH
+chmod +x "$fast_check"
+if ! FM_STATE_OVERRIDE="$fast_check_state" FM_FAST_CHECK_PID="$fast_check_pid" \
+  bash -c '
+    set -u
+    . "$1"
+    check=$2
+    WATCHER_PID=$$
+    mkdir -p "$WATCH_LOCK"
+    printf "%s\n" "$WATCHER_PID" > "$WATCH_LOCK/pid"
+    FAST_REPAIR_ACTIVE=1
+    POLL=10
+    FAST_REPAIR_PROGRESS_INTERVAL=1
+    fast_repair_progress_tick() { run_check_capture --stop-active-check-on-signal "$check"; }
+    fast_repair_progress_timer_start
+    trap "fast_repair_progress_timer_finish || true" EXIT
+    i=0
+    while [ ! -s "$3" ] && [ "$i" -lt 60 ]; do sleep 0.1; i=$((i + 1)); done
+    [ -s "$3" ] || exit 1
+    fast_repair_progress_timer_finish
+    check_pid=$(cat "$3")
+    ! kill -0 "$check_pid" 2>/dev/null
+  ' _ "$ROOT/bin/fm-watch.sh" "$fast_check" "$fast_check_pid" > "$fast_check_out" 2>&1; then
+  fail "Fast Repair timer retirement left its active check group alive: $(cat "$fast_check_out")"
+fi
+pass "Fast Repair timer retirement stops its active check group"
+
 normal_home="$TMP/normal-usr1-home"
 normal_state="$normal_home/state"
 normal_data="$normal_home/data"

--- a/tests/fm-supervision-events.test.sh
+++ b/tests/fm-supervision-events.test.sh
@@ -194,7 +194,7 @@ fast_repair_progress_timer_start() {
   (
     command sleep 0.05
     printf '%s\n%s\n%s\n' 1 tk6 'fast-repair tk6 broader-tests-failed' \
-      > "$STATE_DIR/.fast-repair-progress-handoff-$WATCHER_PID-1"
+      > "$STATE_DIR/.fast-repair-progress-handoff-tk6-1"
   ) &
 }
 fm_backend_events_capable() { return 0; }
@@ -281,6 +281,32 @@ fi
 pass "fast_repair_progress_timer_wake: stale timer results cannot publish"
 
 reset_state
+fm_write_meta "$STATE_DIR/tk12.meta" "window=default:wG:pQ" "kind=ship" "mode=fast-repair" "fast_repair=eligible"
+OLD_WATCHER=41001
+NEW_WATCHER=41002
+WATCHER_PID=$OLD_WATCHER
+FM_FAST_REPAIR_TIMER_PARENT="$OLD_WATCHER" \
+  FM_FAST_REPAIR_TIMER_GENERATION=7 \
+  fast_repair_progress_timer_publish tk12 'fast-repair tk12 broader-tests-failed'
+WATCHER_PID=$NEW_WATCHER
+fast_repair_progress_timer_wake
+grep -q 'fast-repair:tk12' "$STATE_DIR/.wake-queue" \
+  || fail "a replacement watcher did not deliver a prior watcher's Fast Repair handoff"
+pass "fast_repair_progress_timer_wake: task handoffs survive watcher replacement"
+
+reset_state
+fm_write_meta "$STATE_DIR/tk13.meta" "window=default:wG:pQ" "kind=ship" "mode=fast-repair" "fast_repair=eligible"
+FM_FAST_REPAIR_TIMER_GENERATION=8 \
+  fast_repair_progress_timer_publish tk13 'fast-repair tk13 pr-checks-failed'
+rm -f "$STATE_DIR/tk13.meta"
+fast_repair_progress_timer_wake
+[ ! -e "$STATE_DIR/.wake-queue" ] \
+  || fail "a torn-down Fast Repair task surfaced a queued progress result"
+[ ! -e "$STATE_DIR/.fast-repair-progress-handoff-tk13-8" ] \
+  || fail "a torn-down Fast Repair handoff was not discarded after lifecycle revalidation"
+pass "fast_repair_progress_timer_wake: torn-down tasks discard pending handoffs"
+
+reset_state
 fm_write_meta "$STATE_DIR/tk9a.meta" "window=default:wG:pQ" "kind=ship" "mode=fast-repair" "fast_repair=eligible"
 fm_write_meta "$STATE_DIR/tk9b.meta" "window=default:wG:pR" "kind=ship" "mode=fast-repair" "fast_repair=eligible"
 WATCHER_PID=${BASHPID:-$$}
@@ -303,6 +329,7 @@ grep -q 'fast-repair:tk9b' "$STATE_DIR/.wake-queue" \
 pass "fast_repair_progress_tick: one timer generation queues every eligible task"
 
 reset_state
+fm_write_meta "$STATE_DIR/tk10.meta" "window=default:wG:pQ" "kind=ship" "mode=fast-repair" "fast_repair=eligible"
 WATCHER_PID=${BASHPID:-$$}
 FAST_REPAIR_TIMER_GENERATION=5
 FM_FAST_REPAIR_TIMER_PARENT="$WATCHER_PID" \
@@ -314,6 +341,7 @@ grep -q 'fast-repair:tk10' "$STATE_DIR/.wake-queue" \
 pass "fast_repair_progress_timer_wake: late prior-generation handoffs remain deliverable"
 
 reset_state
+fm_write_meta "$STATE_DIR/tk11.meta" "window=default:wG:pQ" "kind=ship" "mode=fast-repair" "fast_repair=eligible"
 WATCHER_PID=${BASHPID:-$$}
 FAST_REPAIR_TIMER_GENERATION=6
 FM_FAST_REPAIR_TIMER_PARENT="$WATCHER_PID" \
@@ -326,10 +354,10 @@ fm_wake_append() {
   printf 'retry\t%s\t%s\n' "$2" "$3" >> "$STATE_DIR/.wake-queue"
 }
 fast_repair_progress_timer_wake
-compgen -G "$STATE_DIR/.fast-repair-progress-handoff-$WATCHER_PID-6-tk11" >/dev/null \
+compgen -G "$STATE_DIR/.fast-repair-progress-handoff-tk11-6" >/dev/null \
   || fail "a failed durable append discarded its Fast Repair handoff"
 fast_repair_progress_timer_wake
-[ ! -e "$STATE_DIR/.fast-repair-progress-handoff-$WATCHER_PID-6-tk11" ] \
+[ ! -e "$STATE_DIR/.fast-repair-progress-handoff-tk11-6" ] \
   || fail "a successfully queued Fast Repair handoff was not retired"
 grep -q 'fast-repair:tk11' "$STATE_DIR/.wake-queue" \
   || fail "a retained Fast Repair handoff did not retry its append"

--- a/tests/fm-supervision-events.test.sh
+++ b/tests/fm-supervision-events.test.sh
@@ -310,14 +310,19 @@ pass "fast_repair_progress_timer_wake: torn-down tasks discard pending handoffs"
 reset_state
 fm_write_meta "$STATE_DIR/tk14.meta" "window=default:wG:pQ" "kind=ship" "mode=fast-repair" "fast_repair=eligible"
 FAST_REPAIR_PROGRESS_INTERVAL=20
-PROGRESS_CHECKS=0
+: > "$TMP/progress-checks"
 run_check_capture() {
-  PROGRESS_CHECKS=$((PROGRESS_CHECKS + 1))
+  printf 'check\n' >> "$TMP/progress-checks"
   FM_CHECK_RESULT=
 }
 FM_FAST_REPAIR_TIMER_GENERATION=9 fast_repair_progress_tick
 FM_FAST_REPAIR_TIMER_GENERATION=10 fast_repair_progress_tick
-[ "$PROGRESS_CHECKS" = 1 ] || fail "short waits reset the Fast Repair progress cadence"
+for progress_wait in $(seq 1 50); do
+  [ -s "$TMP/progress-checks" ] && break
+  command sleep 0.01
+done
+[ "$(wc -l < "$TMP/progress-checks" | tr -d '[:space:]')" = 1 ] \
+  || fail "short waits reset the Fast Repair progress cadence"
 pass "fast_repair_progress_tick: short waits retain the task progress cadence"
 
 reset_state
@@ -335,6 +340,12 @@ run_check_capture() {
 FM_FAST_REPAIR_TIMER_PARENT="$WATCHER_PID" \
   FM_FAST_REPAIR_TIMER_GENERATION=3 \
   fast_repair_progress_tick
+for progress_wait in $(seq 1 50); do
+  compgen -G "$STATE_DIR/.fast-repair-progress-handoff-tk9a-3" >/dev/null \
+    && compgen -G "$STATE_DIR/.fast-repair-progress-handoff-tk9b-3" >/dev/null \
+    && break
+  command sleep 0.01
+done
 fast_repair_progress_timer_wake
 grep -q 'fast-repair:tk9a' "$STATE_DIR/.wake-queue" \
   || fail "the first Fast Repair task was not queued"
@@ -376,5 +387,73 @@ fast_repair_progress_timer_wake
 grep -q 'fast-repair:tk11' "$STATE_DIR/.wake-queue" \
   || fail "a retained Fast Repair handoff did not retry its append"
 pass "fast_repair_progress_timer_wake: append failure retains the handoff for retry"
+
+reset_state
+retirement_pids=()
+for retirement_id in a b; do
+  retirement_ready="$TMP/retirement-$retirement_id.ready"
+  retirement_term="$TMP/retirement-$retirement_id.term"
+  FM_RETIREMENT_READY="$retirement_ready" FM_RETIREMENT_TERM="$retirement_term" \
+    bash -c 'trap '\''printf term > "$FM_RETIREMENT_TERM"; sleep 0.15; exit 0'\'' TERM; : > "$FM_RETIREMENT_READY"; while :; do :; done' &
+  retirement_pid=$!
+  retirement_pids+=("$retirement_pid")
+  for retirement_wait in $(seq 1 50); do
+    [ -e "$retirement_ready" ] && break
+    command sleep 0.01
+  done
+  [ -e "$retirement_ready" ] || fail "a Fast Repair retirement fixture did not start"
+  printf '%s\n' "$retirement_pid" > "$STATE_DIR/.fast-repair-progress-child-$retirement_id-20"
+done
+fast_repair_progress_timer_tasks_finish 20 &
+retirement_finish_pid=$!
+command sleep 0.08
+[ -e "$TMP/retirement-a.term" ] && [ -e "$TMP/retirement-b.term" ] || {
+  kill "$retirement_finish_pid" 2>/dev/null || true
+  wait "$retirement_finish_pid" 2>/dev/null || true
+  for retirement_pid in "${retirement_pids[@]}"; do
+    kill -TERM "$retirement_pid" 2>/dev/null || true
+    wait "$retirement_pid" 2>/dev/null || true
+  done
+  fail "Fast Repair timer retirement did not signal every task before its bounded reap"
+}
+wait "$retirement_finish_pid" || fail "Fast Repair timer retirement did not finish"
+for retirement_pid in "${retirement_pids[@]}"; do
+  wait "$retirement_pid" 2>/dev/null || true
+done
+for retirement_id in a b; do
+  [ ! -e "$STATE_DIR/.fast-repair-progress-child-$retirement_id-20" ] \
+    || fail "Fast Repair timer retirement retained a child marker"
+done
+pass "fast_repair_progress_timer_tasks_finish: task retirement signals children concurrently"
+
+normal_home="$TMP/normal-usr1-home"
+normal_state="$normal_home/state"
+normal_data="$normal_home/data"
+normal_out="$TMP/normal-usr1.out"
+mkdir -p "$normal_state" "$normal_data"
+FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$normal_home" FM_STATE_OVERRIDE="$normal_state" \
+  FM_DATA_OVERRIDE="$normal_data" FM_POLL=60 FM_SIGNAL_GRACE=1 \
+  FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$ROOT/bin/fm-watch.sh" > "$normal_out" 2>&1 &
+normal_pid=$!
+normal_ready=0
+for normal_wait in $(seq 1 50); do
+  if [ -s "$normal_state/.watch.lock/pid" ]; then
+    normal_ready=1
+    break
+  fi
+  kill -0 "$normal_pid" 2>/dev/null || break
+  command sleep 0.02
+done
+if [ "$normal_ready" -ne 1 ]; then
+  kill "$normal_pid" 2>/dev/null || true
+  wait "$normal_pid" 2>/dev/null || true
+  fail "an ordinary watcher did not start for the USR1 regression: $(cat "$normal_out")"
+fi
+kill -USR1 "$normal_pid" || fail "could not signal the ordinary watcher with USR1"
+wait "$normal_pid"
+normal_status=$?
+[ "$normal_status" -eq 138 ] \
+  || fail "an ordinary watcher changed its USR1 termination status: $normal_status"
+pass "ordinary watcher keeps default USR1 termination behavior"
 
 echo "# fm-supervision-events.test.sh: all assertions passed"

--- a/tests/fm-supervision-events.test.sh
+++ b/tests/fm-supervision-events.test.sh
@@ -35,6 +35,7 @@ reset_state() {
   rm -f "$STATE_DIR"/*.meta "$STATE_DIR"/*.status "$STATE_DIR"/.wake-queue \
     "$STATE_DIR"/.wake-queue.seq "$STATE_DIR"/.watch-triage.log \
     "$STATE_DIR"/.herdr-escalated-* "$STATE_DIR"/.fast-repair-progress-wake \
+    "$STATE_DIR"/.fast-repair-progress-handoff-* \
     "$STATE_DIR"/.fast-repair-progress-timer.* \
     "$TMP"/panes "$TMP"/wtcalls "$TMP"/wtcalled "$TMP"/fast-repair-transition-complete \
     "$TMP"/fast-repair-parent-returned "$TMP"/fast-repair-handoff-blocked 2>/dev/null || true
@@ -44,7 +45,7 @@ reset_state() {
   _event_cap_ok=0
   _event_cap_fails=0
   FAST_REPAIR_TIMER_MARKER=
-  FAST_REPAIR_TIMER_HANDOFF_LOCK=
+  FAST_REPAIR_TIMER_GENERATION=0
 }
 
 mkrec() {  # <pane_id> <status>
@@ -182,8 +183,16 @@ pass "fast_repair_progress_timer_start: Fast Repair repeats progress ticks durin
 reset_state
 fm_write_meta "$STATE_DIR/tk6.meta" "window=default:wG:pQ" "backend=herdr" "kind=ship" "mode=fast-repair" "fast_repair=eligible"
 FAST_REPAIR_ACTIVE=1
+FAST_REPAIR_TIMER_GENERATION=1
+WATCHER_PID=${BASHPID:-$$}
+mkdir -p "$WATCH_LOCK"
+printf '%s\n' "$WATCHER_PID" > "$WATCH_LOCK/pid"
 fast_repair_progress_timer_start() {
-  ( command sleep 0.05; printf 'fast-repair tk6 broader-tests-failed' > "$STATE_DIR/.fast-repair-progress-wake" ) &
+  (
+    command sleep 0.05
+    printf '%s\n%s\n%s\n' 1 tk6 'fast-repair tk6 broader-tests-failed' \
+      > "$STATE_DIR/.fast-repair-progress-handoff-$WATCHER_PID-1"
+  ) &
 }
 fm_backend_events_capable() { return 0; }
 fm_backend_wait_transition() {
@@ -201,23 +210,26 @@ reset_state
 fm_write_meta "$STATE_DIR/tk7.meta" "window=default:wG:pQ" "backend=herdr" "kind=ship" "mode=fast-repair" "fast_repair=eligible"
 FAST_REPAIR_ACTIVE=1
 FAST_REPAIR_TIMER_MARKER=
-FAST_REPAIR_TIMER_HANDOFF_LOCK=
-WATCHER_PID=$$
+PARENT_PID=${BASHPID:-$$}
+WATCHER_PID=$PARENT_PID
 mkdir -p "$WATCH_LOCK"
 printf '%s\n' "$WATCHER_PID" > "$WATCH_LOCK/pid"
+trap 'fast_repair_progress_timer_wake' USR1
+wake() { printf '%s\t%s\n' "${BASHPID:-$$}" "$1" >> "$WAKE_LOG"; return 0; }
 fast_repair_progress_timer_start() {
-  local marker closing lock parent=$WATCHER_PID
+  local marker closing parent=$WATCHER_PID generation
+  FAST_REPAIR_TIMER_GENERATION=$((FAST_REPAIR_TIMER_GENERATION + 1))
+  generation=$FAST_REPAIR_TIMER_GENERATION
   marker=$(mktemp "$STATE_DIR/.fast-repair-progress-timer.XXXXXX")
   closing="$marker.closing"
-  lock="$marker.handoff.lock"
   FAST_REPAIR_TIMER_MARKER=$marker
   (
     command sleep 0.5
     [ -e "$TMP/fast-repair-parent-returned" ] || : > "$TMP/fast-repair-handoff-blocked"
     FM_FAST_REPAIR_TIMER_PARENT="$parent" \
       FM_FAST_REPAIR_TIMER_CLOSING="$closing" \
-      FM_FAST_REPAIR_TIMER_HANDOFF_LOCK="$lock" \
-      fast_repair_progress_timer_publish 'fast-repair tk7 pr-checks-failed'
+      FM_FAST_REPAIR_TIMER_GENERATION="$generation" \
+      fast_repair_progress_timer_publish tk7 'fast-repair tk7 pr-checks-failed'
   ) &
   FAST_REPAIR_TIMER_PID=$!
 }
@@ -232,8 +244,34 @@ event_wait_or_sleep
 command sleep 0.6
 [ -e "$TMP/fast-repair-transition-complete" ] || fail "the shutdown handoff interrupted the backend transition wait"
 [ ! -e "$TMP/fast-repair-handoff-blocked" ] || fail "the shutdown handoff blocked on the Fast Repair check"
-grep -q 'check: fast-repair tk7 pr-checks-failed' "$WAKE_LOG" \
+grep -q "^$PARENT_PID.*check: fast-repair tk7 pr-checks-failed" "$WAKE_LOG" \
   || fail "a result written after timer shutdown was not delivered"
 pass "event_wait_or_sleep: Fast Repair delivers a result that races timer shutdown"
+
+reset_state
+fm_write_meta "$STATE_DIR/tk8.meta" "window=default:wG:pQ" "kind=ship" "mode=fast-repair" "fast_repair=eligible"
+PARENT_PID=${BASHPID:-$$}
+WATCHER_PID=$PARENT_PID
+mkdir -p "$WATCH_LOCK"
+printf '%s\n' "$WATCHER_PID" > "$WATCH_LOCK/pid"
+FAST_REPAIR_TIMER_GENERATION=2
+: > "$STATE_DIR/current.closing"
+: > "$STATE_DIR/stale.closing"
+FM_FAST_REPAIR_TIMER_PARENT="$WATCHER_PID" \
+  FM_FAST_REPAIR_TIMER_CLOSING="$STATE_DIR/current.closing" \
+  FM_FAST_REPAIR_TIMER_GENERATION=2 \
+  fast_repair_progress_timer_publish tk8 'fast-repair tk8 pr-checks-green'
+command sleep 0.05
+FM_FAST_REPAIR_TIMER_PARENT="$WATCHER_PID" \
+  FM_FAST_REPAIR_TIMER_CLOSING="$STATE_DIR/stale.closing" \
+  FM_FAST_REPAIR_TIMER_GENERATION=1 \
+  fast_repair_progress_timer_publish tk8 'fast-repair tk8 pr-checks-failed'
+command sleep 0.05
+grep -q 'check: fast-repair tk8 pr-checks-green' "$WAKE_LOG" \
+  || fail "the newest Fast Repair result was not delivered"
+if grep -q 'check: fast-repair tk8 pr-checks-failed' "$WAKE_LOG"; then
+  fail "an older Fast Repair timer result published after a newer result"
+fi
+pass "fast_repair_progress_timer_wake: stale timer results cannot publish"
 
 echo "# fm-supervision-events.test.sh: all assertions passed"

--- a/tests/fm-supervision-events.test.sh
+++ b/tests/fm-supervision-events.test.sh
@@ -303,7 +303,7 @@ rm -f "$STATE_DIR/tk13.meta"
 fast_repair_progress_timer_wake
 [ ! -e "$STATE_DIR/.wake-queue" ] \
   || fail "a torn-down Fast Repair task surfaced a queued progress result"
-[ ! -e "$STATE_DIR/.fast-repair-progress-handoff-tk13-8" ] \
+[ -z "$(compgen -G "$STATE_DIR/.fast-repair-progress-handoff-tk13-8-*" || true)" ] \
   || fail "a torn-down Fast Repair handoff was not discarded after lifecycle revalidation"
 pass "fast_repair_progress_timer_wake: torn-down tasks discard pending handoffs"
 
@@ -326,6 +326,40 @@ done
 pass "fast_repair_progress_tick: short waits retain the task progress cadence"
 
 reset_state
+fm_write_meta "$STATE_DIR/tk14a.meta" "window=default:wG:pQ" "kind=ship" "mode=fast-repair" "fast_repair=eligible"
+POLL=15
+FAST_REPAIR_PROGRESS_INTERVAL=20
+FAST_REPAIR_NOW=100
+date() {
+  [ "${1:-}" = +%s ] && { printf '%s\n' "$FAST_REPAIR_NOW"; return 0; }
+  command date "$@"
+}
+run_check_capture() {
+  printf 'check\n' >> "$TMP/default-poll-checks"
+  FM_CHECK_RESULT=
+}
+fast_repair_progress_schedule_missing
+[ "$(cat "$STATE_DIR/.fast-repair-progress-next-due-tk14a")" = 120 ] \
+  || fail "the default poll did not persist a 20-second Fast Repair due time"
+FAST_REPAIR_NOW=115
+FM_FAST_REPAIR_TIMER_GENERATION=10 fast_repair_progress_tick
+[ ! -e "$TMP/default-poll-checks" ] \
+  || fail "the first 15-second normal wait ran Fast Repair progress too early"
+[ "$(fast_repair_progress_timer_delay)" = 5 ] \
+  || fail "the second default-poll timer did not retain the remaining due delay"
+FAST_REPAIR_NOW=120
+FM_FAST_REPAIR_TIMER_GENERATION=11 fast_repair_progress_tick
+for progress_wait in $(seq 1 50); do
+  [ -s "$TMP/default-poll-checks" ] && break
+  command sleep 0.01
+done
+[ -s "$TMP/default-poll-checks" ] \
+  || fail "the second default-poll wait did not run the due Fast Repair check"
+fast_repair_progress_timer_tasks_finish 11
+unset -f date
+pass "fast_repair_progress_tick: default polls retain Fast Repair due time across waits"
+
+reset_state
 fm_write_meta "$STATE_DIR/tk9a.meta" "window=default:wG:pQ" "kind=ship" "mode=fast-repair" "fast_repair=eligible"
 fm_write_meta "$STATE_DIR/tk9b.meta" "window=default:wG:pR" "kind=ship" "mode=fast-repair" "fast_repair=eligible"
 WATCHER_PID=${BASHPID:-$$}
@@ -341,8 +375,8 @@ FM_FAST_REPAIR_TIMER_PARENT="$WATCHER_PID" \
   FM_FAST_REPAIR_TIMER_GENERATION=3 \
   fast_repair_progress_tick
 for progress_wait in $(seq 1 50); do
-  compgen -G "$STATE_DIR/.fast-repair-progress-handoff-tk9a-3" >/dev/null \
-    && compgen -G "$STATE_DIR/.fast-repair-progress-handoff-tk9b-3" >/dev/null \
+  compgen -G "$STATE_DIR/.fast-repair-progress-handoff-tk9a-3-*" >/dev/null \
+    && compgen -G "$STATE_DIR/.fast-repair-progress-handoff-tk9b-3-*" >/dev/null \
     && break
   command sleep 0.01
 done
@@ -379,14 +413,30 @@ fm_wake_append() {
   printf 'retry\t%s\t%s\n' "$2" "$3" >> "$STATE_DIR/.wake-queue"
 }
 fast_repair_progress_timer_wake
-compgen -G "$STATE_DIR/.fast-repair-progress-handoff-tk11-6" >/dev/null \
+compgen -G "$STATE_DIR/.fast-repair-progress-handoff-tk11-6-*" >/dev/null \
   || fail "a failed durable append discarded its Fast Repair handoff"
 fast_repair_progress_timer_wake
-[ ! -e "$STATE_DIR/.fast-repair-progress-handoff-tk11-6" ] \
+[ -z "$(compgen -G "$STATE_DIR/.fast-repair-progress-handoff-tk11-6-*" || true)" ] \
   || fail "a successfully queued Fast Repair handoff was not retired"
 grep -q 'fast-repair:tk11' "$STATE_DIR/.wake-queue" \
   || fail "a retained Fast Repair handoff did not retry its append"
 pass "fast_repair_progress_timer_wake: append failure retains the handoff for retry"
+
+reset_state
+fm_write_meta "$STATE_DIR/tk15.meta" "window=default:wG:pQ" "kind=ship" "mode=fast-repair" "fast_repair=eligible"
+WATCHER_PID=${BASHPID:-$$}
+FM_FAST_REPAIR_TIMER_GENERATION=12 \
+  fast_repair_progress_timer_publish tk15 'fast-repair tk15 broader-tests-failed'
+FM_FAST_REPAIR_TIMER_GENERATION=12 \
+  fast_repair_progress_timer_publish tk15 'fast-repair tk15 pr-checks-failed'
+handoff_count=$(compgen -G "$STATE_DIR/.fast-repair-progress-handoff-tk15-12-*" | wc -l | tr -d '[:space:]')
+[ "$handoff_count" = 2 ] || fail "two Fast Repair ticks did not retain two task handoffs"
+fast_repair_progress_timer_wake
+grep -q 'check: fast-repair tk15 broader-tests-failed' "$WAKE_LOG" \
+  || fail "the first retained Fast Repair handoff was not surfaced"
+grep -q 'fast-repair tk15 pr-checks-failed' "$WAKE_LOG" \
+  || fail "the later retained Fast Repair handoff was not surfaced"
+pass "fast_repair_progress_timer_wake: multiple task handoffs remain distinct until drain"
 
 reset_state
 retirement_pids=()

--- a/tests/fm-supervision-events.test.sh
+++ b/tests/fm-supervision-events.test.sh
@@ -36,12 +36,15 @@ reset_state() {
     "$STATE_DIR"/.wake-queue.seq "$STATE_DIR"/.watch-triage.log \
     "$STATE_DIR"/.herdr-escalated-* "$STATE_DIR"/.fast-repair-progress-wake \
     "$STATE_DIR"/.fast-repair-progress-timer.* \
-    "$TMP"/panes "$TMP"/wtcalls "$TMP"/wtcalled "$TMP"/fast-repair-transition-complete 2>/dev/null || true
+    "$TMP"/panes "$TMP"/wtcalls "$TMP"/wtcalled "$TMP"/fast-repair-transition-complete \
+    "$TMP"/fast-repair-parent-returned "$TMP"/fast-repair-handoff-blocked 2>/dev/null || true
   : > "$WAKE_LOG"
   : > "$SLEEP_LOG"
   _event_cap_key=""
   _event_cap_ok=0
   _event_cap_fails=0
+  FAST_REPAIR_TIMER_MARKER=
+  FAST_REPAIR_TIMER_HANDOFF_LOCK=
 }
 
 mkrec() {  # <pane_id> <status>
@@ -193,5 +196,44 @@ event_wait_or_sleep
 grep -q 'check: fast-repair tk6 broader-tests-failed' "$WAKE_LOG" \
   || fail "the durable Fast Repair timer result was not surfaced after the backend transition wait"
 pass "event_wait_or_sleep: Fast Repair keeps its timer result durable through the full backend wait"
+
+reset_state
+fm_write_meta "$STATE_DIR/tk7.meta" "window=default:wG:pQ" "backend=herdr" "kind=ship" "mode=fast-repair" "fast_repair=eligible"
+FAST_REPAIR_ACTIVE=1
+FAST_REPAIR_TIMER_MARKER=
+FAST_REPAIR_TIMER_HANDOFF_LOCK=
+WATCHER_PID=$$
+mkdir -p "$WATCH_LOCK"
+printf '%s\n' "$WATCHER_PID" > "$WATCH_LOCK/pid"
+fast_repair_progress_timer_start() {
+  local marker closing lock parent=$WATCHER_PID
+  marker=$(mktemp "$STATE_DIR/.fast-repair-progress-timer.XXXXXX")
+  closing="$marker.closing"
+  lock="$marker.handoff.lock"
+  FAST_REPAIR_TIMER_MARKER=$marker
+  (
+    command sleep 0.5
+    [ -e "$TMP/fast-repair-parent-returned" ] || : > "$TMP/fast-repair-handoff-blocked"
+    FM_FAST_REPAIR_TIMER_PARENT="$parent" \
+      FM_FAST_REPAIR_TIMER_CLOSING="$closing" \
+      FM_FAST_REPAIR_TIMER_HANDOFF_LOCK="$lock" \
+      fast_repair_progress_timer_publish 'fast-repair tk7 pr-checks-failed'
+  ) &
+  FAST_REPAIR_TIMER_PID=$!
+}
+fm_backend_events_capable() { return 0; }
+fm_backend_wait_transition() {
+  command sleep 0.05
+  printf 'complete\n' > "$TMP/fast-repair-transition-complete"
+  return 1
+}
+event_wait_or_sleep
+: > "$TMP/fast-repair-parent-returned"
+command sleep 0.6
+[ -e "$TMP/fast-repair-transition-complete" ] || fail "the shutdown handoff interrupted the backend transition wait"
+[ ! -e "$TMP/fast-repair-handoff-blocked" ] || fail "the shutdown handoff blocked on the Fast Repair check"
+grep -q 'check: fast-repair tk7 pr-checks-failed' "$WAKE_LOG" \
+  || fail "a result written after timer shutdown was not delivered"
+pass "event_wait_or_sleep: Fast Repair delivers a result that races timer shutdown"
 
 echo "# fm-supervision-events.test.sh: all assertions passed"

--- a/tests/fm-supervision-events.test.sh
+++ b/tests/fm-supervision-events.test.sh
@@ -249,12 +249,11 @@ event_wait_or_sleep
 : > "$TMP/fast-repair-parent-returned"
 command sleep 0.6
 [ -e "$TMP/fast-repair-transition-complete" ] || fail "the shutdown handoff interrupted the backend transition wait"
-[ ! -e "$TMP/fast-repair-handoff-blocked" ] || fail "the shutdown handoff blocked on the Fast Repair check"
+[ ! -e "$TMP/fast-repair-handoff-blocked" ] || fail "the timer child survived the completed wait"
 [ ! -s "$WAKE_LOG" ] || fail "a shutdown handoff woke the watcher outside its safe boundary"
 fast_repair_progress_timer_wake
-grep -q "^$PARENT_PID.*check: fast-repair tk7 pr-checks-failed" "$WAKE_LOG" \
-  || fail "a result written after timer shutdown was not delivered"
-pass "event_wait_or_sleep: Fast Repair delivers a result that races timer shutdown"
+[ ! -s "$WAKE_LOG" ] || fail "a retired timer child published after the completed wait"
+pass "event_wait_or_sleep: Fast Repair retires a running timer child at wait shutdown"
 
 reset_state
 fm_write_meta "$STATE_DIR/tk8.meta" "window=default:wG:pQ" "kind=ship" "mode=fast-repair" "fast_repair=eligible"

--- a/tests/fm-supervision-events.test.sh
+++ b/tests/fm-supervision-events.test.sh
@@ -250,6 +250,8 @@ event_wait_or_sleep
 command sleep 0.6
 [ -e "$TMP/fast-repair-transition-complete" ] || fail "the shutdown handoff interrupted the backend transition wait"
 [ ! -e "$TMP/fast-repair-handoff-blocked" ] || fail "the shutdown handoff blocked on the Fast Repair check"
+[ ! -s "$WAKE_LOG" ] || fail "a shutdown handoff woke the watcher outside its safe boundary"
+fast_repair_progress_timer_wake
 grep -q "^$PARENT_PID.*check: fast-repair tk7 pr-checks-failed" "$WAKE_LOG" \
   || fail "a result written after timer shutdown was not delivered"
 pass "event_wait_or_sleep: Fast Repair delivers a result that races timer shutdown"
@@ -305,6 +307,19 @@ fast_repair_progress_timer_wake
 [ ! -e "$STATE_DIR/.fast-repair-progress-handoff-tk13-8" ] \
   || fail "a torn-down Fast Repair handoff was not discarded after lifecycle revalidation"
 pass "fast_repair_progress_timer_wake: torn-down tasks discard pending handoffs"
+
+reset_state
+fm_write_meta "$STATE_DIR/tk14.meta" "window=default:wG:pQ" "kind=ship" "mode=fast-repair" "fast_repair=eligible"
+FAST_REPAIR_PROGRESS_INTERVAL=20
+PROGRESS_CHECKS=0
+run_check_capture() {
+  PROGRESS_CHECKS=$((PROGRESS_CHECKS + 1))
+  FM_CHECK_RESULT=
+}
+FM_FAST_REPAIR_TIMER_GENERATION=9 fast_repair_progress_tick
+FM_FAST_REPAIR_TIMER_GENERATION=10 fast_repair_progress_tick
+[ "$PROGRESS_CHECKS" = 1 ] || fail "short waits reset the Fast Repair progress cadence"
+pass "fast_repair_progress_tick: short waits retain the task progress cadence"
 
 reset_state
 fm_write_meta "$STATE_DIR/tk9a.meta" "window=default:wG:pQ" "kind=ship" "mode=fast-repair" "fast_repair=eligible"

--- a/tests/fm-supervision-events.test.sh
+++ b/tests/fm-supervision-events.test.sh
@@ -142,6 +142,30 @@ WTN=$(wc -l < "$TMP/wtcalls" | tr -d '[:space:]')
 pass "event_wait_or_sleep: consecutive event-path failures disable the fast-path and revert to pure polling (fail-closed)"
 
 reset_state
+unset -f sleep
+FAST_REPAIR_ACTIVE=1
+FAST_REPAIR_TIMER_PID=
+FAST_REPAIR_TIMER_MARKER=
+FAST_REPAIR_PROGRESS_INTERVAL=1
+POLL=10
+WATCHER_PID=$$
+mkdir -p "$WATCH_LOCK"
+printf '%s\n' "$WATCHER_PID" > "$WATCH_LOCK/pid"
+touch "$STATE_DIR/.last-fast-repair-progress"
+: > "$TMP/fast-repair-timer-ticks"
+fast_repair_progress_tick() {
+  printf 'tick\n' >> "$TMP/fast-repair-timer-ticks"
+  FAST_REPAIR_ACTIVE=1
+}
+fast_repair_progress_timer_start
+command sleep 4.5
+fast_repair_progress_timer_finish
+wait "$FAST_REPAIR_TIMER_PID" 2>/dev/null || true
+[ "$(wc -l < "$TMP/fast-repair-timer-ticks" | tr -d '[:space:]')" -ge 2 ] \
+  || fail "a long Fast Repair wait did not repeat its progress timer"
+pass "fast_repair_progress_timer_start: Fast Repair repeats progress ticks during a long wait"
+
+reset_state
 fm_write_meta "$STATE_DIR/tk6.meta" "window=default:wG:pQ" "backend=herdr" "kind=ship" "mode=fast-repair" "fast_repair=eligible"
 FAST_REPAIR_ACTIVE=1
 fast_repair_progress_timer_start() {

--- a/tests/fm-supervision-events.test.sh
+++ b/tests/fm-supervision-events.test.sh
@@ -34,7 +34,8 @@ sleep() { printf 'SLEEP\n' >> "$SLEEP_LOG"; }
 reset_state() {
   rm -f "$STATE_DIR"/*.meta "$STATE_DIR"/*.status "$STATE_DIR"/.wake-queue \
     "$STATE_DIR"/.wake-queue.seq "$STATE_DIR"/.watch-triage.log \
-    "$STATE_DIR"/.herdr-escalated-* "$TMP"/panes "$TMP"/wtcalls "$TMP"/wtcalled 2>/dev/null || true
+    "$STATE_DIR"/.herdr-escalated-* "$STATE_DIR"/.fast-repair-progress-wake \
+    "$TMP"/panes "$TMP"/wtcalls "$TMP"/wtcalled "$TMP"/fast-repair-transition-complete 2>/dev/null || true
   : > "$WAKE_LOG"
   : > "$SLEEP_LOG"
   _event_cap_key=""
@@ -139,5 +140,23 @@ event_wait_or_sleep   # disabled: sleeps without calling wait_transition
 WTN=$(wc -l < "$TMP/wtcalls" | tr -d '[:space:]')
 [ "$WTN" = 2 ] || fail "after EVENT_CAP_FAIL_MAX connect failures the event path must be disabled for the process (expected 2 wait_transition calls, got $WTN)"
 pass "event_wait_or_sleep: consecutive event-path failures disable the fast-path and revert to pure polling (fail-closed)"
+
+reset_state
+fm_write_meta "$STATE_DIR/tk6.meta" "window=default:wG:pQ" "backend=herdr" "kind=ship" "mode=fast-repair" "fast_repair=eligible"
+FAST_REPAIR_ACTIVE=1
+fast_repair_progress_timer_start() {
+  ( command sleep 0.05; printf 'fast-repair tk6 broader-tests-failed' > "$STATE_DIR/.fast-repair-progress-wake" ) &
+}
+fm_backend_events_capable() { return 0; }
+fm_backend_wait_transition() {
+  command sleep 0.15
+  printf 'complete\n' > "$TMP/fast-repair-transition-complete"
+  return 1
+}
+event_wait_or_sleep
+[ -e "$TMP/fast-repair-transition-complete" ] || fail "a Fast Repair timer interrupted the existing backend transition wait"
+grep -q 'check: fast-repair tk6 broader-tests-failed' "$WAKE_LOG" \
+  || fail "the durable Fast Repair timer result was not surfaced after the backend transition wait"
+pass "event_wait_or_sleep: Fast Repair keeps its timer result durable through the full backend wait"
 
 echo "# fm-supervision-events.test.sh: all assertions passed"

--- a/tests/fm-supervision-events.test.sh
+++ b/tests/fm-supervision-events.test.sh
@@ -24,6 +24,7 @@ export FM_ROOT_OVERRIDE="$ROOT"
 # ShellCheck context local while preserving its unchanged runtime source path.
 # shellcheck source=/dev/null
 . "$ROOT/bin/fm-watch.sh"
+FAST_REPAIR_PROGRESS_TICK_PRODUCTION=$(declare -f fast_repair_progress_tick)
 
 # Overrides: capture wake reasons and neutralize real sleeps (POLL is 15s).
 WAKE_LOG="$TMP/wakes"
@@ -35,6 +36,7 @@ reset_state() {
   rm -f "$STATE_DIR"/*.meta "$STATE_DIR"/*.status "$STATE_DIR"/.wake-queue \
     "$STATE_DIR"/.wake-queue.seq "$STATE_DIR"/.watch-triage.log \
     "$STATE_DIR"/.herdr-escalated-* "$STATE_DIR"/.fast-repair-progress-wake \
+    "$STATE_DIR"/.fast-repair-progress-* "$STATE_DIR"/.last-fast-repair-progress* \
     "$STATE_DIR"/.fast-repair-progress-handoff-* \
     "$STATE_DIR"/.fast-repair-progress-timer.* \
     "$TMP"/panes "$TMP"/wtcalls "$TMP"/wtcalled "$TMP"/fast-repair-transition-complete \
@@ -179,6 +181,7 @@ wait "$FAST_REPAIR_TIMER_PID" 2>/dev/null || true
 [ "$(wc -l < "$TMP/fast-repair-timer-ticks" | tr -d '[:space:]')" -ge 2 ] \
   || fail "a long Fast Repair wait did not repeat its progress timer"
 pass "fast_repair_progress_timer_start: Fast Repair repeats progress ticks during a long wait"
+eval "$FAST_REPAIR_PROGRESS_TICK_PRODUCTION"
 
 reset_state
 fm_write_meta "$STATE_DIR/tk6.meta" "window=default:wG:pQ" "backend=herdr" "kind=ship" "mode=fast-repair" "fast_repair=eligible"
@@ -230,6 +233,9 @@ fast_repair_progress_timer_start() {
       FM_FAST_REPAIR_TIMER_CLOSING="$closing" \
       FM_FAST_REPAIR_TIMER_GENERATION="$generation" \
       fast_repair_progress_timer_publish tk7 'fast-repair tk7 pr-checks-failed'
+    FM_FAST_REPAIR_TIMER_PARENT="$parent" \
+      FM_FAST_REPAIR_TIMER_CLOSING="$closing" \
+      fast_repair_progress_timer_notify
   ) &
   FAST_REPAIR_TIMER_PID=$!
 }
@@ -258,20 +264,75 @@ FAST_REPAIR_TIMER_GENERATION=2
 : > "$STATE_DIR/current.closing"
 : > "$STATE_DIR/stale.closing"
 FM_FAST_REPAIR_TIMER_PARENT="$WATCHER_PID" \
-  FM_FAST_REPAIR_TIMER_CLOSING="$STATE_DIR/current.closing" \
-  FM_FAST_REPAIR_TIMER_GENERATION=2 \
+FM_FAST_REPAIR_TIMER_CLOSING="$STATE_DIR/current.closing" \
+FM_FAST_REPAIR_TIMER_GENERATION=2 \
   fast_repair_progress_timer_publish tk8 'fast-repair tk8 pr-checks-green'
-command sleep 0.05
+fast_repair_progress_timer_wake
 FM_FAST_REPAIR_TIMER_PARENT="$WATCHER_PID" \
-  FM_FAST_REPAIR_TIMER_CLOSING="$STATE_DIR/stale.closing" \
-  FM_FAST_REPAIR_TIMER_GENERATION=1 \
+FM_FAST_REPAIR_TIMER_CLOSING="$STATE_DIR/stale.closing" \
+FM_FAST_REPAIR_TIMER_GENERATION=1 \
   fast_repair_progress_timer_publish tk8 'fast-repair tk8 pr-checks-failed'
-command sleep 0.05
+fast_repair_progress_timer_wake
 grep -q 'check: fast-repair tk8 pr-checks-green' "$WAKE_LOG" \
   || fail "the newest Fast Repair result was not delivered"
 if grep -q 'check: fast-repair tk8 pr-checks-failed' "$WAKE_LOG"; then
   fail "an older Fast Repair timer result published after a newer result"
 fi
 pass "fast_repair_progress_timer_wake: stale timer results cannot publish"
+
+reset_state
+fm_write_meta "$STATE_DIR/tk9a.meta" "window=default:wG:pQ" "kind=ship" "mode=fast-repair" "fast_repair=eligible"
+fm_write_meta "$STATE_DIR/tk9b.meta" "window=default:wG:pR" "kind=ship" "mode=fast-repair" "fast_repair=eligible"
+WATCHER_PID=${BASHPID:-$$}
+FAST_REPAIR_TIMER_GENERATION=3
+run_check_capture() {
+  case "${!#}" in
+    tk9a) FM_CHECK_RESULT='fast-repair tk9a pr-checks-green' ;;
+    tk9b) FM_CHECK_RESULT='fast-repair tk9b broader-tests-failed' ;;
+    *) fail "unexpected Fast Repair progress task: ${!#}" ;;
+  esac
+}
+FM_FAST_REPAIR_TIMER_PARENT="$WATCHER_PID" \
+  FM_FAST_REPAIR_TIMER_GENERATION=3 \
+  fast_repair_progress_tick
+fast_repair_progress_timer_wake
+grep -q 'fast-repair:tk9a' "$STATE_DIR/.wake-queue" \
+  || fail "the first Fast Repair task was not queued"
+grep -q 'fast-repair:tk9b' "$STATE_DIR/.wake-queue" \
+  || fail "a later Fast Repair task was starved by the first task"
+pass "fast_repair_progress_tick: one timer generation queues every eligible task"
+
+reset_state
+WATCHER_PID=${BASHPID:-$$}
+FAST_REPAIR_TIMER_GENERATION=5
+FM_FAST_REPAIR_TIMER_PARENT="$WATCHER_PID" \
+  FM_FAST_REPAIR_TIMER_GENERATION=4 \
+  fast_repair_progress_timer_publish tk10 'fast-repair tk10 pr-checks-failed'
+fast_repair_progress_timer_wake
+grep -q 'fast-repair:tk10' "$STATE_DIR/.wake-queue" \
+  || fail "a late prior-generation handoff was not delivered"
+pass "fast_repair_progress_timer_wake: late prior-generation handoffs remain deliverable"
+
+reset_state
+WATCHER_PID=${BASHPID:-$$}
+FAST_REPAIR_TIMER_GENERATION=6
+FM_FAST_REPAIR_TIMER_PARENT="$WATCHER_PID" \
+  FM_FAST_REPAIR_TIMER_GENERATION=6 \
+  fast_repair_progress_timer_publish tk11 'fast-repair tk11 pr-checks-failed'
+APPEND_ATTEMPTS=0
+fm_wake_append() {
+  APPEND_ATTEMPTS=$((APPEND_ATTEMPTS + 1))
+  [ "$APPEND_ATTEMPTS" -gt 1 ] || return 1
+  printf 'retry\t%s\t%s\n' "$2" "$3" >> "$STATE_DIR/.wake-queue"
+}
+fast_repair_progress_timer_wake
+compgen -G "$STATE_DIR/.fast-repair-progress-handoff-$WATCHER_PID-6-tk11" >/dev/null \
+  || fail "a failed durable append discarded its Fast Repair handoff"
+fast_repair_progress_timer_wake
+[ ! -e "$STATE_DIR/.fast-repair-progress-handoff-$WATCHER_PID-6-tk11" ] \
+  || fail "a successfully queued Fast Repair handoff was not retired"
+grep -q 'fast-repair:tk11' "$STATE_DIR/.wake-queue" \
+  || fail "a retained Fast Repair handoff did not retry its append"
+pass "fast_repair_progress_timer_wake: append failure retains the handoff for retry"
 
 echo "# fm-supervision-events.test.sh: all assertions passed"

--- a/tests/fm-supervision-events.test.sh
+++ b/tests/fm-supervision-events.test.sh
@@ -35,6 +35,7 @@ reset_state() {
   rm -f "$STATE_DIR"/*.meta "$STATE_DIR"/*.status "$STATE_DIR"/.wake-queue \
     "$STATE_DIR"/.wake-queue.seq "$STATE_DIR"/.watch-triage.log \
     "$STATE_DIR"/.herdr-escalated-* "$STATE_DIR"/.fast-repair-progress-wake \
+    "$STATE_DIR"/.fast-repair-progress-timer.* \
     "$TMP"/panes "$TMP"/wtcalls "$TMP"/wtcalled "$TMP"/fast-repair-transition-complete 2>/dev/null || true
   : > "$WAKE_LOG"
   : > "$SLEEP_LOG"
@@ -140,6 +141,16 @@ event_wait_or_sleep   # disabled: sleeps without calling wait_transition
 WTN=$(wc -l < "$TMP/wtcalls" | tr -d '[:space:]')
 [ "$WTN" = 2 ] || fail "after EVENT_CAP_FAIL_MAX connect failures the event path must be disabled for the process (expected 2 wait_transition calls, got $WTN)"
 pass "event_wait_or_sleep: consecutive event-path failures disable the fast-path and revert to pure polling (fail-closed)"
+
+reset_state
+fm_write_meta "$STATE_DIR/tk6.meta" "window=default:wG:pQ" "kind=ship" "mode=fast-repair" "fast_repair=eligible"
+FAST_REPAIR_ACTIVE=0
+: > "$TMP/forge-called"
+fast_repair_progress_tick() { printf 'called\n' >> "$TMP/forge-called"; }
+fast_repair_progress_discover
+[ "$FAST_REPAIR_ACTIVE" = 1 ] || fail "Fast Repair metadata was not discovered for its wait-time timer"
+[ ! -s "$TMP/forge-called" ] || fail "Fast Repair Forge progress work ran in the main supervision loop"
+pass "fast_repair_progress_discover: main supervision reads only Fast Repair metadata"
 
 reset_state
 unset -f sleep

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -227,6 +227,11 @@ test_promote_requires_and_records_the_delivery_contract() {
   [ "$status" -ne 0 ] || fail "promotion on a conditional policy should exit non-zero"
   assert_contains "$out" "classify this task's surface" "promote did not refuse the conditional policy as a task mode"
 
+  out=$(FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" "$PROMOTE" promote-d1 --mode fast-repair --yolo off 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "a scout promotion to Fast Repair should exit non-zero"
+  assert_contains "$out" "Fast Repair cannot promote a scout" "promotion did not keep Fast Repair out of scout flow"
+
   out=$(FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" "$PROMOTE" promote-d1 --mode direct-PR --yolo on 2>&1)
   status=$?
   expect_code 0 "$status" "a promotion carrying both flags should succeed"

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -887,6 +887,63 @@ test_content_in_default_fallback_allows() {
   pass "worktree whose content already landed in the default branch is torn down (content fallback)"
 }
 
+# Fast Repair progress artifacts are keyed <prefix>-<id>-<generation>, and task ids
+# may contain hyphens, so tearing down `task-x1` must not touch `task-x1-2`. A live
+# sibling marker removed here would leave that task's progress child unsignalled at
+# the next poll boundary and drop its undrained handoff records.
+test_fast_repair_progress_cleanup_is_exact_for_one_task_id() {
+  local case_dir state rc own sibling
+  case_dir=$(make_case fast-repair-progress-scope)
+  state="$case_dir/state"
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  land_on_origin_main "$case_dir" feature.txt hello
+
+  own="$state/.fast-repair-progress-child-task-x1-7"
+  : > "$own"
+  : > "$own.ready"
+  : > "$own.starting"
+  : > "$own.starting.closing"
+  : > "$state/.fast-repair-progress-sequence-task-x1-7"
+  mkdir -p "$state/.fast-repair-progress-sequence-task-x1-7.lock"
+  : > "$state/.fast-repair-progress-handoff-task-x1-7-00000000000000000001"
+  : > "$state/.fast-repair-progress-handoff-task-x1-7-00000000000000000001.attempts"
+
+  # A different, still-running task whose id merely begins with "task-x1-".
+  sibling="$state/.fast-repair-progress-child-task-x1-2-7"
+  : > "$sibling"
+  : > "$sibling.ready"
+  : > "$state/.fast-repair-progress-sequence-task-x1-2-7"
+  : > "$state/.fast-repair-progress-handoff-task-x1-2-7-00000000000000000001"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "fast-repair-progress-scope: teardown should succeed (stderr: $(cat "$case_dir/stderr"))"
+
+  [ ! -e "$own" ] || fail "teardown left its own Fast Repair progress child marker behind"
+  [ ! -e "$own.ready" ] || fail "teardown left its own progress ready marker behind"
+  [ ! -e "$own.starting" ] || fail "teardown left its own progress reservation behind"
+  [ ! -e "$own.starting.closing" ] || fail "teardown left its own reservation closing marker behind"
+  [ ! -e "$state/.fast-repair-progress-sequence-task-x1-7" ] \
+    || fail "teardown left its own progress sequence counter behind"
+  [ ! -e "$state/.fast-repair-progress-sequence-task-x1-7.lock" ] \
+    || fail "teardown left its own progress sequence lock behind"
+  [ ! -e "$state/.fast-repair-progress-handoff-task-x1-7-00000000000000000001" ] \
+    || fail "teardown left its own progress handoff record behind"
+  [ ! -e "$state/.fast-repair-progress-handoff-task-x1-7-00000000000000000001.attempts" ] \
+    || fail "teardown left its own progress handoff attempt counter behind"
+
+  [ -e "$sibling" ] || fail "teardown of task-x1 removed the live progress child marker of task-x1-2"
+  [ -e "$sibling.ready" ] || fail "teardown of task-x1 removed the progress ready marker of task-x1-2"
+  [ -e "$state/.fast-repair-progress-sequence-task-x1-2-7" ] \
+    || fail "teardown of task-x1 removed the progress sequence counter of task-x1-2"
+  [ -e "$state/.fast-repair-progress-handoff-task-x1-2-7-00000000000000000001" ] \
+    || fail "teardown of task-x1 removed the undrained progress handoff of task-x1-2"
+  pass "Fast Repair progress cleanup removes only the torn-down task's artifacts, never a hyphenated sibling's"
+}
+
 test_content_fallback_refreshes_stale_origin_ref() {
   local case_dir rc
   case_dir=$(make_case content-stale-ref)
@@ -2619,6 +2676,7 @@ test_merged_pr_with_later_local_commit_refuses
 test_pr_check_does_not_refresh_stale_pr_head
 test_pr_check_records_remote_head_when_local_lags
 test_content_in_default_fallback_allows
+test_fast_repair_progress_cleanup_is_exact_for_one_task_id
 test_content_fallback_refreshes_stale_origin_ref
 test_dirty_worktree_refuses
 test_gh_error_and_content_absent_refuses

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -432,6 +432,141 @@ test_portable_serial_shards_partition_the_serial_lane() {
   pass "portable serial shards are a deterministic disjoint cover of the serial lane"
 }
 
+# The published shard table is balance evidence for the CI timeout rationale, so
+# it must stay derived from the runner rather than hand-counted. This compares the
+# document against --list-shard-plan and --list, never against runner source text.
+test_shard_plan_matches_documented_table() {
+  local doc plan count shard shard_lane line region row
+  local plan_count plan_ms doc_count doc_ms listed
+  local total min max imbalance doc_imbalance rows
+  doc="$ROOT/docs/fm-test-portable-shards.md"
+  assert_present "$doc" "docs/fm-test-portable-shards.md is missing"
+
+  plan=$("$RUNNER" --list-shard-plan)
+  [ -n "$plan" ] || fail "--list-shard-plan printed nothing"
+  count=$("$RUNNER" --list-lanes | grep -c '^portable-serial-[0-9]*of[0-9]*$')
+  [ "$(printf '%s\n' "$plan" | wc -l | tr -d ' ')" = "$count" ] \
+    || fail "--list-shard-plan must print one line per shard lane, got: $plan"
+  [ "$plan" = "$("$RUNNER" --list-shard-plan)" ] \
+    || fail "--list-shard-plan must be deterministic"
+
+  # The published table lives under its own heading, so read exactly that block
+  # instead of matching rows anywhere in the document.
+  region=$(awk '/^## Portable serial CI shards$/ {f=1; next} /^## / {f=0} f' "$doc")
+  [ -n "$region" ] || fail "docs/fm-test-portable-shards.md lost its serial shard section"
+  rows=$(printf '%s\n' "$region" | grep -c "^| .portable-serial-[0-9]*of[0-9]*. |" || true)
+  [ "$rows" = "$count" ] \
+    || fail "documented table has $rows shard rows but the runner derives $count"
+
+  total=0
+  min=
+  max=
+  shard=1
+  while [ "$shard" -le "$count" ]; do
+    shard_lane="portable-serial-${shard}of${count}"
+    line=$(printf '%s\n' "$plan" | grep -F "$shard_lane " || true)
+    [ -n "$line" ] || fail "--list-shard-plan is missing $shard_lane: $plan"
+    case "$line" in
+      "$shard_lane count="*" estimated_ms="*) ;;
+      *) fail "--list-shard-plan line has an unexpected shape: $line" ;;
+    esac
+    plan_count=${line##* count=}
+    plan_count=${plan_count%% *}
+    plan_ms=${line##* estimated_ms=}
+    case "$plan_count" in
+      ''|*[!0-9]*) fail "$shard_lane count is not a number: $line" ;;
+    esac
+    case "$plan_ms" in
+      ''|*[!0-9]*) fail "$shard_lane estimated_ms is not a number: $line" ;;
+    esac
+    [ "$plan_ms" -gt 0 ] || fail "$shard_lane estimated_ms must be positive: $line"
+
+    # The plan must describe the lane the runner actually selects.
+    listed=$("$RUNNER" --list --lane "$shard_lane" | wc -l | tr -d ' ')
+    [ "$plan_count" = "$listed" ] \
+      || fail "$shard_lane plan count $plan_count but --list selects $listed"
+
+    row=$(printf '%s\n' "$region" | grep -F "| \`${shard_lane}\` |" || true)
+    [ -n "$row" ] || fail "documented table has no row for $shard_lane"
+    [ "$(printf '%s\n' "$row" | wc -l | tr -d ' ')" = 1 ] \
+      || fail "documented table has more than one row for $shard_lane"
+    doc_count=$(printf '%s\n' "$row" | awk -F'|' '{gsub(/[^0-9]/, "", $3); print $3}')
+    doc_ms=$(printf '%s\n' "$row" | awk -F'|' '{print $4}' | awk '{print $1}')
+    [ "$doc_count" = "$plan_count" ] \
+      || fail "$shard_lane: doc says $doc_count scripts, runner derives $plan_count"
+    [ "$doc_ms" = "$plan_ms" ] \
+      || fail "$shard_lane: doc says ${doc_ms} ms, runner derives ${plan_ms} ms"
+
+    total=$((total + plan_count))
+    if [ -z "$min" ] || [ "$plan_ms" -lt "$min" ]; then min=$plan_ms; fi
+    if [ -z "$max" ] || [ "$plan_ms" -gt "$max" ]; then max=$plan_ms; fi
+    shard=$((shard + 1))
+  done
+
+  # The plan accounts for the whole lane, so a documented count can never
+  # describe a partition that quietly drops scripts.
+  listed=$("$RUNNER" --list --lane portable-serial | wc -l | tr -d ' ')
+  [ "$total" = "$listed" ] \
+    || fail "shard plan counts total $total but portable-serial holds $listed scripts"
+
+  imbalance=$((max - min))
+  doc_imbalance=$(printf '%s\n' "$region" | awk -F'|' '/^\| imbalance \|/ {print $4}' | awk '{print $1}')
+  [ -n "$doc_imbalance" ] || fail "documented serial table lost its imbalance row"
+  [ "$doc_imbalance" = "$imbalance" ] \
+    || fail "doc imbalance ${doc_imbalance} ms but the plan spread is ${imbalance} ms"
+  pass "documented portable serial shard table matches --list-shard-plan"
+}
+
+# The parallel lanes are enumerated in the runner and weighted by the recorded
+# concurrent proof, so their published table is checkable against that artifact
+# without any new runner output.
+test_parallel_lane_table_matches_proof_durations() {
+  local doc proof region lane row doc_count doc_ms real_count real_ms
+  local first second imbalance doc_imbalance
+  doc="$ROOT/docs/fm-test-portable-shards.md"
+  proof="$ROOT/docs/fm-test-isolation-proof.json"
+  assert_present "$doc" "docs/fm-test-portable-shards.md is missing"
+  assert_present "$proof" "docs/fm-test-isolation-proof.json is missing"
+  region=$(awk '/^## Parallel lanes$/ {f=1; next} /^## / {f=0} f' "$doc")
+  [ -n "$region" ] || fail "docs/fm-test-portable-shards.md lost its parallel lane section"
+
+  first=
+  second=
+  for lane in portable-parallel-1 portable-parallel-2; do
+    real_count=$("$RUNNER" --list --lane "$lane" | wc -l | tr -d ' ')
+    real_ms=$("$RUNNER" --list --lane "$lane" | python3 -c '
+import json, sys
+paths = [p for p in sys.stdin.read().split() if p]
+durations = {s["path"]: s["duration_ms"] for s in json.load(open(sys.argv[1]))["scripts"]}
+missing = [p for p in paths if p not in durations]
+if missing:
+    sys.exit("proof artifact has no duration for: " + " ".join(missing))
+print(sum(durations[p] for p in paths))
+' "$proof") || fail "$lane is not fully covered by the recorded isolation proof"
+
+    row=$(printf '%s\n' "$region" | grep -F "| \`${lane}\` |" || true)
+    [ -n "$row" ] || fail "documented parallel table has no row for $lane"
+    doc_count=$(printf '%s\n' "$row" | awk -F'|' '{gsub(/[^0-9]/, "", $3); print $3}')
+    doc_ms=$(printf '%s\n' "$row" | awk -F'|' '{print $4}' | awk '{print $1}')
+    [ "$doc_count" = "$real_count" ] \
+      || fail "$lane: doc says $doc_count scripts, lane holds $real_count"
+    [ "$doc_ms" = "$real_ms" ] \
+      || fail "$lane: doc says ${doc_ms} ms, proof durations sum to ${real_ms} ms"
+    if [ -z "$first" ]; then first=$real_ms; else second=$real_ms; fi
+  done
+
+  if [ "$first" -ge "$second" ]; then
+    imbalance=$((first - second))
+  else
+    imbalance=$((second - first))
+  fi
+  doc_imbalance=$(printf '%s\n' "$region" | awk -F'|' '/^\| imbalance \|/ {print $4}' | awk '{print $1}')
+  [ -n "$doc_imbalance" ] || fail "documented parallel table lost its imbalance row"
+  [ "$doc_imbalance" = "$imbalance" ] \
+    || fail "doc imbalance ${doc_imbalance} ms but the lanes differ by ${imbalance} ms"
+  pass "documented parallel lane table matches the recorded proof durations"
+}
+
 test_portable_serial_shard_lane_refusals() {
   local tmp count rc other
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-shard-lane.XXXXXX")
@@ -682,6 +817,8 @@ test_fail_on_gate_skip_token
 test_exclude_family
 test_portable_shard_union_and_coverage_guard
 test_portable_serial_shards_partition_the_serial_lane
+test_shard_plan_matches_documented_table
+test_parallel_lane_table_matches_proof_durations
 test_portable_serial_shard_lane_refusals
 test_jobs_requires_proven_isolated
 test_jobs_parallel_scheduler_and_failure_propagation

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -1871,8 +1871,39 @@ test_fast_repair_progress_cadence_is_task_scoped() {
   pass "Fast Repair uses a 20-second-class task-only progress cadence without changing ordinary watcher state"
 }
 
+# A directory at the wake queue's sequence path makes the durable append fail
+# the way a lock or disk error would, without touching the watcher's code.
+test_fast_repair_marker_waits_for_the_durable_wake() {
+  local dir state out pid exit_status
+  dir=$(make_case fast-repair-marker-order); state="$dir/state"; out="$dir/watch.out"
+  printf 'window=firstmate:fm-fast\nkind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$state/fast.meta"
+  printf 'broader=failed\n' > "$state/fast.fast-repair-broader"
+  mkdir -p "$state/.wake-queue.seq"
+  PATH="$dir/fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" \
+    FM_POLL=1 FM_SIGNAL_GRACE=1 FM_FAST_REPAIR_PROGRESS_INTERVAL=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" 2>/dev/null &
+  pid=$!
+  wait_for_exit "$pid" 60
+  exit_status=$?
+  [ "$exit_status" -ne 124 ] || fail "the watcher survived a failed Fast Repair wake enqueue"
+  [ ! -e "$state/.fast-repair-progress-fast" ] \
+    || fail "a failed enqueue still committed the Fast Repair dedup marker"
+
+  rmdir "$state/.wake-queue.seq"
+  : > "$out"
+  PATH="$dir/fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" \
+    FM_POLL=1 FM_SIGNAL_GRACE=1 FM_FAST_REPAIR_PROGRESS_INTERVAL=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 60 || fail "the Fast Repair transition did not replay after a failed enqueue"
+  grep -F 'check: fast-repair fast broader-tests-failed' "$out" >/dev/null \
+    || fail "a failed enqueue swallowed the Fast Repair transition: $(cat "$out")"
+  pass "a Fast Repair progress marker commits only after its durable wake is queued"
+}
+
 test_signal_reason_is_actionable_classifier
 test_fast_repair_progress_cadence_is_task_scoped
+test_fast_repair_marker_waits_for_the_durable_wake
 test_stale_is_terminal_classifier
 test_scan_captain_relevant_statuses_classifier
 test_classifier_primitives

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -2569,8 +2569,15 @@ legacy_empty_array_bash() {
 # marker, and a cycle shorter than the Fast Repair interval never starts one. The
 # sweep must therefore finish on an empty set and hand control back, or the
 # watcher dies mid-cycle and takes its EXIT-trap cleanup down with it.
+# The reproducing half needs a pre-4.4 interpreter: no modern Bash can be made to
+# fail this way (an empty AND an entirely unset array both expand to nothing under
+# `set -u` from 4.4 on, and BASH_COMPAT does not restore the old error), so the
+# ambient leg proves the sweep's behavior while the cross-version enforcement is
+# the stock-Bash interpreter itself. Whichever half ran is named in the result
+# line, and FM_TEST_REQUIRE_LEGACY_BASH=1 turns a missing interpreter into a
+# failure so a job can demand the reproduction rather than hope for it.
 test_fast_repair_timer_sweep_survives_an_empty_generation() {
-  local dir state probe out legacy
+  local dir state probe out legacy coverage
   dir=$(make_case fast-repair-empty-sweep); state="$dir/state"; probe="$dir/probe.sh"; out="$dir/result"
   printf 'kind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$state/fast.meta"
   record_fast_repair_eligibility "$dir" fast
@@ -2598,8 +2605,13 @@ SH
       || fail "the empty Fast Repair retirement sweep aborted under $legacy: $(cat "$out")"
     grep -Fx cycle-continued "$out" >/dev/null \
       || fail "the empty Fast Repair retirement sweep never returned under $legacy: $(cat "$out")"
+    coverage="unbound-array reproduction proven on $legacy"
+  elif [ "${FM_TEST_REQUIRE_LEGACY_BASH:-0}" = 1 ]; then
+    fail "FM_TEST_REQUIRE_LEGACY_BASH=1 requires a pre-4.4 Bash to reproduce the empty-array abort, but none of FM_TEST_LEGACY_BASH, /bin/bash, /usr/bin/bash, /usr/local/bin/bash, or /opt/homebrew/bin/bash is one"
+  else
+    coverage="unbound-array reproduction NOT exercised: no pre-4.4 Bash reachable (ambient $BASH_VERSION cannot fail this way; set FM_TEST_LEGACY_BASH, or FM_TEST_REQUIRE_LEGACY_BASH=1 to demand it)"
   fi
-  pass "the Fast Repair retirement sweep completes a generation with no live progress child"
+  pass "the Fast Repair retirement sweep completes a generation with no live progress child - $coverage"
 }
 
 # The parent announces retirement by writing a `.closing` handshake file that only
@@ -2637,9 +2649,38 @@ test_fast_repair_retirement_reaps_a_dead_childs_closing_marker() {
   pass "Fast Repair timer retirement reaps the closing handshake of an already-exited child"
 }
 
+# The retirement sweep hands a starting reservation its `.closing` flag and then
+# drops the reservation, so a beat that reaches the same reservation afterwards
+# must decline to fork AND clear the flag it just consumed. Only the forked child
+# has an EXIT trap for it, so a decline that never forks is the one path where
+# nobody else can: the flag would otherwise survive one per retired generation.
+test_fast_repair_retiring_generation_reaps_its_reservation_flag() {
+  local dir state out marker
+  dir=$(make_case fast-repair-reservation-closing); state="$dir/state"; out="$dir/result"
+  printf 'kind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$state/fast.meta"
+  record_fast_repair_eligibility "$dir" fast
+  marker="$state/.fast-repair-progress-child-fast-3"
+  : > "$marker.starting.closing"
+  FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" \
+    bash -c '
+      set -eu
+      . "$1"
+      FAST_REPAIR_ACTIVE=1
+      fast_repair_progress_task_start fast 3
+      [ -z "$(jobs -p)" ] || { echo "a retiring generation still forked a progress child"; exit 1; }
+    ' _ "$WATCH" > "$out" 2>&1 \
+    || fail "the retiring Fast Repair beat failed: $(cat "$out")"
+  [ ! -e "$marker" ] || fail "a retiring Fast Repair beat published a progress child marker"
+  [ ! -e "$marker.starting" ] || fail "a retiring Fast Repair beat left its reservation behind"
+  [ ! -e "$marker.starting.closing" ] \
+    || fail "a retiring Fast Repair beat left an orphan reservation closing marker behind"
+  pass "a Fast Repair beat that declines a retiring generation clears its reservation and closing marker"
+}
+
 test_signal_reason_is_actionable_classifier
 test_fast_repair_timer_sweep_survives_an_empty_generation
 test_fast_repair_retirement_reaps_a_dead_childs_closing_marker
+test_fast_repair_retiring_generation_reaps_its_reservation_flag
 test_fast_repair_undrainable_handoff_stops_shortening_waits
 test_fast_repair_local_followup_retires_after_the_broader_result
 test_fast_repair_local_followup_retires_on_a_broader_pass

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -2400,7 +2400,156 @@ test_fast_repair_backend_wait_keeps_stderr() {
   pass "the forked backend wait preserves backend stderr diagnostics"
 }
 
+# A handoff the wake queue refuses must stay on disk for a later retry, but it
+# must stop cutting waits short: otherwise every later wait returns immediately
+# and the whole supervision loop spins for as long as the queue stays broken.
+test_fast_repair_undrainable_handoff_stops_shortening_waits() {
+  local dir state out
+  dir=$(make_case fast-repair-undrainable); state="$dir/state"; out="$dir/result"
+  printf 'kind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$state/fast.meta"
+  record_fast_repair_eligibility "$dir" fast
+  # A directory at the wake queue's sequence path makes the durable append fail
+  # the way a lock or disk error would, without touching the watcher's code.
+  mkdir -p "$state/.wake-queue.seq"
+  FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" \
+    bash -c '
+      set -u
+      . "$1"
+      WATCHER_PID=$$
+      mkdir -p "$WATCH_LOCK"
+      printf "%s\n" "$WATCHER_PID" > "$WATCH_LOCK/pid"
+      wake() { printf "WAKE %s\n" "$*"; }
+      FAST_REPAIR_ACTIVE=1
+      POLL=8
+      FAST_REPAIR_PROGRESS_INTERVAL=600
+      fast_repair_progress_timer_start
+      FM_FAST_REPAIR_TIMER_GENERATION="$FAST_REPAIR_TIMER_GENERATION" \
+        fast_repair_progress_timer_publish fast "fast-repair fast broader-tests-failed" \
+        || { echo "the fixture handoff could not be published"; exit 1; }
+
+      start=$(date +%s)
+      fast_repair_progress_timer_sleep "$POLL"
+      first=$(( $(date +%s) - start ))
+      fast_repair_progress_timer_wake
+      [ "$first" -lt 6 ] \
+        || { echo "the undelivered handoff never shortened its own wait (${first}s)"; exit 1; }
+
+      # The record survived the refused enqueue, so a later cycle can still
+      # deliver it, but it has spent its budget and must not cut this wait.
+      fast_repair_progress_handoff_pending \
+        && { echo "a handoff that failed to drain still counts as pending"; exit 1; }
+      start=$(date +%s)
+      fast_repair_progress_timer_sleep "$POLL"
+      second=$(( $(date +%s) - start ))
+      fast_repair_progress_timer_finish
+      [ "$second" -ge 6 ] \
+        || { echo "an undrainable handoff turned the next wait into a ${second}s wait"; exit 1; }
+
+      # Durable for retry: with the queue repaired the retained record delivers.
+      rmdir "$STATE/.wake-queue.seq"
+      fast_repair_progress_timer_wake
+    ' _ "$WATCH" > "$out" 2>&1 \
+    || fail "the undrainable-handoff contract failed: $(cat "$out")"
+  grep -F 'WAKE check: fast-repair fast broader-tests-failed' "$out" >/dev/null \
+    || fail "the retained handoff was never delivered after the queue recovered: $(cat "$out")"
+  pass "a handoff the queue refuses stays durable for retry without shortening later waits"
+}
+
+# The local follow-up exists to catch a broader failure landing after the rollup
+# turned green. Once the broader family reaches a terminal result and that result
+# is surfaced there is nothing left for the beat to find, so it must retire.
+test_fast_repair_local_followup_retires_after_the_broader_result() {
+  local dir state out
+  dir=$(make_case fast-repair-followup-retire); state="$dir/state"; out="$dir/result"
+  printf 'kind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$state/fast.meta"
+  record_fast_repair_eligibility "$dir" fast
+  FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" \
+    bash -c '
+      set -u
+      . "$1"
+      wake() { printf "WAKE %s\n" "$*"; }
+      active() { fast_repair_progress_discover; printf "%s\n" "$FAST_REPAIR_ACTIVE"; }
+
+      [ "$(active)" = 1 ] || { echo "an eligible task was not discovered"; exit 1; }
+
+      # Green retires the forge poll; the still-running broader family keeps the
+      # local beat alive.
+      : > "$(fast_repair_progress_green_marker fast)"
+      [ "$(active)" = 1 ] || { echo "green retirement stopped the local follow-up"; exit 1; }
+
+      printf "broader=failed\n" > "$STATE/fast.fast-repair-broader"
+      [ "$(active)" = 1 ] \
+        || { echo "the beat retired before the broader failure was surfaced"; exit 1; }
+
+      FM_FAST_REPAIR_TIMER_GENERATION=1 \
+        fast_repair_progress_timer_publish fast "fast-repair fast broader-tests-failed"
+      fast_repair_progress_timer_wake
+      [ "$(active)" = 0 ] \
+        || { echo "the beat kept running after its broader failure was surfaced"; exit 1; }
+    ' _ "$WATCH" > "$out" 2>&1 \
+    || fail "the local follow-up retirement contract failed: $(cat "$out")"
+  grep -F 'WAKE check: fast-repair fast broader-tests-failed' "$out" >/dev/null \
+    || fail "the broader failure was never surfaced before retirement: $(cat "$out")"
+  pass "the local Fast Repair follow-up retires once the broader result is surfaced"
+}
+
+# A broader pass after the forge poll already retired leaves the cadence nothing
+# to report either, so it must retire on that path too.
+test_fast_repair_local_followup_retires_on_a_broader_pass() {
+  local dir state out
+  dir=$(make_case fast-repair-followup-pass); state="$dir/state"; out="$dir/result"
+  printf 'kind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$state/fast.meta"
+  record_fast_repair_eligibility "$dir" fast
+  FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" \
+    bash -c '
+      set -u
+      . "$1"
+      active() { fast_repair_progress_discover; printf "%s\n" "$FAST_REPAIR_ACTIVE"; }
+      printf "broader=passed\n" > "$STATE/fast.fast-repair-broader"
+      [ "$(active)" = 1 ] \
+        || { echo "a passing broader run retired the beat before the PR checks were green"; exit 1; }
+      : > "$(fast_repair_progress_green_marker fast)"
+      [ "$(active)" = 0 ] \
+        || { echo "the beat kept running with a green rollup and a passing broader run"; exit 1; }
+    ' _ "$WATCH" > "$out" 2>&1 \
+    || fail "the broader-pass retirement contract failed: $(cat "$out")"
+  pass "the Fast Repair beat retires once its PR is green and its broader run passed"
+}
+
+# The recorded wait pid stays set between `wait` returning and the clear, so a
+# teardown arriving in that window must not signal a reused pid it never forked.
+test_fast_repair_wait_stop_refuses_a_foreign_pid() {
+  local dir state out foreign
+  dir=$(make_case fast-repair-wait-foreign); state="$dir/state"; out="$dir/result"
+  # Killable on purpose: a guard that refuses to signal is the only thing that
+  # can keep this alive, so the assertion cannot pass on an ignored signal.
+  bash -c 'while :; do sleep 1; done' &
+  foreign=$!
+  FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" FM_TEST_FOREIGN_PID="$foreign" \
+    bash -c '
+      set -u
+      . "$1"
+      WATCHER_PID=$$
+      # Stands in for a pid this watcher never forked, which is what a reused pid
+      # looks like from here.
+      FAST_REPAIR_WAIT_PID=$FM_TEST_FOREIGN_PID
+      fast_repair_progress_wait_stop
+      [ -z "$FAST_REPAIR_WAIT_PID" ] || { echo "the stale wait pid was not cleared"; exit 1; }
+    ' _ "$WATCH" > "$out" 2>&1 \
+    || { kill -KILL "$foreign" 2>/dev/null; fail "the wait-stop guard failed: $(cat "$out")"; }
+  if ! kill -0 "$foreign" 2>/dev/null; then
+    fail "the wait stop signalled a process this watcher never forked"
+  fi
+  kill -KILL "$foreign" 2>/dev/null || true
+  wait "$foreign" 2>/dev/null || true
+  pass "the Fast Repair wait stop refuses a pid this watcher did not fork"
+}
+
 test_signal_reason_is_actionable_classifier
+test_fast_repair_undrainable_handoff_stops_shortening_waits
+test_fast_repair_local_followup_retires_after_the_broader_result
+test_fast_repair_local_followup_retires_on_a_broader_pass
+test_fast_repair_wait_stop_refuses_a_foreign_pid
 test_fast_repair_check_signal_race_stops_the_check_group
 test_fast_repair_cadence_interrupts_the_push_transition_wait
 test_fast_repair_beat_survives_the_poll_boundary

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -2156,53 +2156,260 @@ test_fast_repair_beat_survives_the_poll_boundary() {
 
 # The twenty-second forge poll exists to catch the first actionable transition of
 # an open Fast Repair PR. Once green is queued the ordinary PR poll owns it.
-test_fast_repair_cadence_retires_after_the_first_green_rollup() {
-  local dir state out
-  dir=$(make_case fast-repair-green-retire); state="$dir/state"; out="$dir/result"
-  printf 'kind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$state/fast.meta"
-  printf 'kind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$state/other.meta"
+# After the first green rollup the twenty-second beat must stop reading the forge
+# and let the ordinary PR poll own PR checks, but a broader family can still be
+# running and its failure has no other machine-side surface, so the local half of
+# the beat has to survive. This drives the real bin/fm-fast-repair.sh progress
+# helper against a fake gh-axi whose every invocation is recorded, so "stopped
+# polling the forge" is observed rather than assumed.
+test_fast_repair_green_stops_forge_poll_but_keeps_broader_followup() {
+  local dir state out fakebin ghargs
+  dir=$(make_case fast-repair-green-local); state="$dir/state"; out="$dir/result"
+  fakebin="$dir/fakebin"; ghargs="$dir/gh-axi.args"
+  printf 'kind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\npr=https://github.com/acme/repo/pull/42\n' \
+    > "$state/fast.meta"
   record_fast_repair_eligibility "$dir" fast
-  record_fast_repair_eligibility "$dir" other
-  FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" FM_FAST_REPAIR_PROGRESS_INTERVAL=20 \
+  cat > "$fakebin/gh-axi" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> '$ghargs'
+printf 'summary: "4 passed, 0 failed, 4 total"\n'
+EOF
+  chmod +x "$fakebin/gh-axi"
+  : > "$ghargs"
+  PATH="$fakebin:$PATH" FM_HOME="$dir" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" \
     bash -c '
       set -u
       . "$1"
+      ghargs=$2
       wake() { printf "WAKE %s\n" "$*"; }
-      fast_repair_progress_discover
-      [ "$FAST_REPAIR_ACTIVE" = 1 ] || { echo "an eligible task was not discovered"; exit 1; }
-      FM_FAST_REPAIR_TIMER_GENERATION=1 \
-        fast_repair_progress_timer_publish fast "fast-repair fast pr-checks-green: 4 passed, 0 failed, 4 total"
-      fast_repair_progress_timer_wake
-      fast_repair_progress_discover
-      [ "$FAST_REPAIR_ACTIVE" = 1 ] || { echo "the remaining Fast Repair task stopped the cadence"; exit 1; }
-      mv -f "$STATE/other.meta" "$STATE/other.meta.parked"
-      fast_repair_progress_discover
-      [ "$FAST_REPAIR_ACTIVE" = 0 ] || { echo "the cadence stayed active with only a green task left"; exit 1; }
-      FM_FAST_REPAIR_TIMER_GENERATION=1 FAST_REPAIR_ACTIVE=1 fast_repair_progress_tick
-      [ "$FAST_REPAIR_ACTIVE" = 0 ] || { echo "the tick kept working a retired green task"; exit 1; }
-      [ ! -e "$STATE/.last-fast-repair-progress-fast" ] \
-        || { echo "the retired green task was polled again"; exit 1; }
-      mv -f "$STATE/other.meta.parked" "$STATE/other.meta"
-      ids=$(fast_repair_progress_task_ids)
-      case "$ids" in
-        *fast*) echo "the green task is still worked by the twenty-second cadence"; exit 1 ;;
-      esac
-      case "$ids" in
-        *other*) ;;
-        *) echo "retiring the green task also retired an unrelated Fast Repair task"; exit 1 ;;
-      esac
-    ' _ "$WATCH" > "$out" 2>&1 \
-    || fail "the Fast Repair cadence did not retire after its first green rollup: $(cat "$out")"
+      FAST_REPAIR_ACTIVE=1
+      FAST_REPAIR_PROGRESS_INTERVAL=600
+      beat() {
+        local gen=$1 i=0
+        fast_repair_progress_due_set fast 0
+        FM_FAST_REPAIR_TIMER_GENERATION="$gen" fast_repair_progress_tick
+        while fast_repair_progress_task_running fast "$gen" && [ "$i" -lt 400 ]; do sleep 0.05; i=$((i + 1)); done
+        fast_repair_progress_timer_tasks_finish "$gen"
+        fast_repair_progress_timer_wake
+      }
+      beat 1
+      [ -e "$(fast_repair_progress_green_marker fast)" ] \
+        || { echo "the green rollup did not retire the forge poll"; exit 1; }
+      polled=$(wc -l < "$ghargs")
+      [ "$polled" -gt 0 ] || { echo "the first beat never reached the forge"; exit 1; }
+
+      beat 2
+      [ "$(wc -l < "$ghargs")" = "$polled" ] \
+        || { echo "the retired task kept polling the forge"; exit 1; }
+
+      printf "broader=failed\n" > "$STATE/fast.fast-repair-broader"
+      beat 3
+      [ "$(wc -l < "$ghargs")" = "$polled" ] \
+        || { echo "the local broader follow-up reached the forge"; exit 1; }
+    ' _ "$WATCH" "$ghargs" > "$out" 2>&1 \
+    || fail "the Fast Repair green retirement contract failed: $(cat "$out")"
   grep -F 'WAKE check: fast-repair fast pr-checks-green' "$out" >/dev/null \
-    || fail "the green rollup was not surfaced before the cadence retired: $(cat "$out")"
-  pass "the Fast Repair cadence retires a task after its first green rollup is queued"
+    || fail "the green rollup was not surfaced: $(cat "$out")"
+  grep -F 'WAKE check: fast-repair fast broader-tests-failed' "$out" >/dev/null \
+    || fail "a broader failure landing after the green rollup was never surfaced: $(cat "$out")"
+  pass "a green rollup stops the Fast Repair forge poll while local broader failures still surface"
+}
+
+# The cadence may only pull the watcher out of its wait for a transition. An
+# unchanged result would otherwise cost an extra full supervision cycle every
+# twenty seconds for the life of the task.
+test_fast_repair_unchanged_result_does_not_interrupt_the_wait() {
+  local dir state out
+  dir=$(make_case fast-repair-unchanged-wait); state="$dir/state"; out="$dir/result"
+  printf 'kind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$state/fast.meta"
+  record_fast_repair_eligibility "$dir" fast
+  FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" \
+    bash -c '
+      set -u
+      . "$1"
+      WATCHER_PID=$$
+      mkdir -p "$WATCH_LOCK"
+      printf "%s\n" "$WATCHER_PID" > "$WATCH_LOCK/pid"
+      wake() { printf "WAKE %s\n" "$*"; }
+      run_check_capture() { FM_CHECK_RESULT="fast-repair fast broader-tests-failed"; }
+      POLL=8
+      FAST_REPAIR_PROGRESS_INTERVAL=1
+      # Never run in a command substitution: the wait has to stay a direct child
+      # of this shell for the notify path to accept it, exactly as it is in the
+      # real watcher.
+      cycle() {  # <elapsed-file>
+        local start
+        fast_repair_progress_due_set fast 0
+        fast_repair_progress_discover
+        fast_repair_progress_timer_start
+        start=$(date +%s)
+        fast_repair_progress_timer_sleep "$POLL"
+        printf "%s\n" "$(( $(date +%s) - start ))" > "$1"
+        fast_repair_progress_timer_finish
+        fast_repair_progress_timer_wake
+      }
+      cycle "$STATE/.elapsed-changed"
+      changed=$(cat "$STATE/.elapsed-changed")
+      [ "$changed" -lt 6 ] \
+        || { echo "a new Fast Repair result did not interrupt the wait (${changed}s)"; exit 1; }
+      cycle "$STATE/.elapsed-unchanged"
+      unchanged=$(cat "$STATE/.elapsed-unchanged")
+      [ "$unchanged" -ge 6 ] \
+        || { echo "an unchanged Fast Repair result tore the watcher out of its wait (${unchanged}s)"; exit 1; }
+    ' _ "$WATCH" > "$out" 2>&1 \
+    || fail "the unchanged-result wait contract failed: $(cat "$out")"
+  [ "$(grep -cF 'WAKE check: fast-repair fast broader-tests-failed' "$out")" = 1 ] \
+    || fail "the unchanged result was surfaced more than once: $(cat "$out")"
+  pass "an unchanged Fast Repair result never interrupts the watcher's wait"
+}
+
+# A watcher signalled while blocked in the forked backend wait must stop that
+# wait's whole group - the backend event reader inside it keeps mutating this
+# home's transition state otherwise - and must leave no capture file behind.
+test_fast_repair_terminated_watcher_stops_the_backend_wait() {
+  local dir state out readerpid pid reader i
+  dir=$(make_case fast-repair-wait-teardown); state="$dir/state"; out="$dir/result"
+  readerpid="$dir/reader.pid"
+  printf 'kind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$state/fast.meta"
+  record_fast_repair_eligibility "$dir" fast
+  FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" FM_TEST_READER_PID="$readerpid" \
+    bash -c '
+      set -u
+      . "$1"
+      WATCHER_PID=$$
+      mkdir -p "$WATCH_LOCK"
+      printf "%s\n" "$WATCHER_PID" > "$WATCH_LOCK/pid"
+      FAST_REPAIR_ACTIVE=1
+      POLL=120
+      FAST_REPAIR_PROGRESS_INTERVAL=600
+      # Stands in for the backend event reader: a real subprocess of the wait
+      # that outlives its parent shell unless the whole group is signalled.
+      fm_backend_wait_transition() {
+        ( printf "%s\n" "$BASHPID" > "$FM_TEST_READER_PID"; exec sleep 300 ) &
+        wait $!
+      }
+      trap "exit 1" HUP INT TERM
+      trap fast_repair_progress_timer_finish EXIT
+      fast_repair_progress_timer_start
+      fast_repair_progress_timer_wait_transition herdr sess "$POLL" "$STATE" sess:pane1
+    ' _ "$WATCH" > "$out" 2>&1 &
+  pid=$!
+  i=0
+  while [ ! -s "$readerpid" ] && [ "$i" -lt 200 ]; do sleep 0.05; i=$((i + 1)); done
+  [ -s "$readerpid" ] || { kill -KILL "$pid" 2>/dev/null; fail "the backend wait never started its reader: $(cat "$out")"; }
+  reader=$(cat "$readerpid")
+  kill -TERM "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  i=0
+  while kill -0 "$reader" 2>/dev/null && [ "$i" -lt 100 ]; do sleep 0.05; i=$((i + 1)); done
+  if kill -0 "$reader" 2>/dev/null; then
+    kill -KILL "$reader" 2>/dev/null || true
+    fail "a terminated watcher orphaned its backend event reader (pid $reader)"
+  fi
+  set -- "$state"/.fm-event-wait.*
+  [ ! -e "$1" ] || fail "a terminated watcher left its backend wait capture file behind: $1"
+  pass "a terminated watcher stops its backend wait group and leaves no capture file"
+}
+
+# A result published before the wait is armed used to be invisible to notify and
+# cost the whole poll budget - the exact delay this cadence exists to remove.
+test_fast_repair_handoff_published_before_the_wait_is_consumed() {
+  local dir state out
+  dir=$(make_case fast-repair-prewait-race); state="$dir/state"; out="$dir/result"
+  printf 'kind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$state/fast.meta"
+  record_fast_repair_eligibility "$dir" fast
+  FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" \
+    bash -c '
+      set -u
+      . "$1"
+      WATCHER_PID=$$
+      mkdir -p "$WATCH_LOCK"
+      printf "%s\n" "$WATCHER_PID" > "$WATCH_LOCK/pid"
+      wake() { printf "WAKE %s\n" "$*"; }
+      FAST_REPAIR_ACTIVE=1
+      POLL=10
+      FAST_REPAIR_PROGRESS_INTERVAL=600
+      fast_repair_progress_timer_start
+      # Published with no wait armed and no notify parent, which is exactly the
+      # window between starting the timer and reaching the wait.
+      FM_FAST_REPAIR_TIMER_GENERATION="$FAST_REPAIR_TIMER_GENERATION" \
+        fast_repair_progress_timer_publish fast "fast-repair fast broader-tests-failed" \
+        || { echo "the fixture handoff could not be published"; exit 1; }
+      start=$(date +%s)
+      fast_repair_progress_timer_sleep "$POLL"
+      elapsed=$(( $(date +%s) - start ))
+      fast_repair_progress_timer_finish
+      fast_repair_progress_timer_wake
+      [ "$elapsed" -lt 6 ] \
+        || { echo "a handoff published before the wait was armed cost the whole ${elapsed}s budget"; exit 1; }
+    ' _ "$WATCH" > "$out" 2>&1 \
+    || fail "the pre-wait handoff race was not closed: $(cat "$out")"
+  grep -F 'WAKE check: fast-repair fast broader-tests-failed' "$out" >/dev/null \
+    || fail "the pre-wait handoff was never surfaced: $(cat "$out")"
+  pass "a handoff published before the wait is armed is consumed instead of waiting out the budget"
+}
+
+# A start that fails before forking must re-arm on the ordinary interval; leaving
+# the beat immediately due spins the timer loop for the rest of every cycle.
+test_fast_repair_failed_start_rearms_instead_of_spinning() {
+  local dir state out
+  dir=$(make_case fast-repair-failed-start); state="$dir/state"; out="$dir/result"
+  printf 'kind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$state/fast.meta"
+  mkdir -p "$dir/data/fast"
+  # An eligibility record with no lifecycle= line: task_start refuses before it
+  # can fork, which is the failure class that used to leave the due in the past.
+  printf 'request=fast-repair: fixture\n' > "$dir/data/fast/fast-repair-eligibility"
+  FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" \
+    bash -c '
+      set -u
+      . "$1"
+      FAST_REPAIR_ACTIVE=1
+      FAST_REPAIR_PROGRESS_INTERVAL=30
+      fast_repair_progress_due_set fast 0
+      FM_FAST_REPAIR_TIMER_GENERATION=1 fast_repair_progress_tick
+      fast_repair_progress_task_running fast 1 \
+        && { echo "the fixture unexpectedly forked a progress child"; exit 1; }
+      due=$(fast_repair_progress_due_in fast)
+      [ "$due" -gt 0 ] \
+        || { echo "a failed start left the beat immediately due"; exit 1; }
+      delay=$(fast_repair_progress_timer_delay 1)
+      [ "$delay" -gt 1 ] \
+        || { echo "the timer loop would spin at ${delay}s after a failed start"; exit 1; }
+    ' _ "$WATCH" > "$out" 2>&1 \
+    || fail "a failed Fast Repair start did not re-arm on the interval: $(cat "$out")"
+  pass "a Fast Repair start that fails before forking re-arms on the ordinary interval"
+}
+
+# The forked wait must report backend diagnostics exactly as the unforked call
+# does, or a herdr socket failure goes silent on Fast Repair homes only.
+test_fast_repair_backend_wait_keeps_stderr() {
+  local dir state out
+  dir=$(make_case fast-repair-wait-stderr); state="$dir/state"; out="$dir/result"
+  FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" \
+    bash -c '
+      set -u
+      . "$1"
+      fm_backend_wait_transition() { printf "herdr: subscribe refused\n" >&2; return 2; }
+      fast_repair_progress_timer_wait_transition herdr sess 1 "$STATE" sess:pane1
+      rc=$?
+      [ "$rc" = 2 ] || { echo "the forked wait lost the backend exit status ($rc)"; exit 1; }
+    ' _ "$WATCH" > "$out" 2>&1 \
+    || fail "the forked backend wait did not report its backend status: $(cat "$out")"
+  grep -F 'herdr: subscribe refused' "$out" >/dev/null \
+    || fail "the forked backend wait discarded its backend diagnostic: $(cat "$out")"
+  pass "the forked backend wait preserves backend stderr diagnostics"
 }
 
 test_signal_reason_is_actionable_classifier
 test_fast_repair_check_signal_race_stops_the_check_group
 test_fast_repair_cadence_interrupts_the_push_transition_wait
 test_fast_repair_beat_survives_the_poll_boundary
-test_fast_repair_cadence_retires_after_the_first_green_rollup
+test_fast_repair_green_stops_forge_poll_but_keeps_broader_followup
+test_fast_repair_unchanged_result_does_not_interrupt_the_wait
+test_fast_repair_terminated_watcher_stops_the_backend_wait
+test_fast_repair_handoff_published_before_the_wait_is_consumed
+test_fast_repair_failed_start_rearms_instead_of_spinning
+test_fast_repair_backend_wait_keeps_stderr
 test_fast_repair_progress_cadence_is_task_scoped
 test_fast_repair_marker_waits_for_the_durable_wake
 test_fast_repair_cadence_runs_inside_a_long_ordinary_poll

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -2076,8 +2076,133 @@ SH
   pass "a signal racing the active-check group handoff still stops that check group"
 }
 
+# On a push-capable home the terminal wait is a foreground read on the backend's
+# event stream, not an interruptible sleep, so a Fast Repair result found by the
+# timer must still stop that wait and reach the captain inside the same cycle.
+# The backend seam is stubbed so the assertion is about the watcher's own wait,
+# not about herdr.
+test_fast_repair_cadence_interrupts_the_push_transition_wait() {
+  local dir state out elapsed
+  dir=$(make_case fast-repair-push-cadence); state="$dir/state"; out="$dir/result"
+  printf 'window=herdrsess:pane1\nkind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\nbackend=herdr\n' > "$state/fast.meta"
+  record_fast_repair_eligibility "$dir" fast
+  printf 'broader=failed\n' > "$state/fast.fast-repair-broader"
+  PATH="$dir/fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" \
+    FM_POLL=25 FM_FAST_REPAIR_PROGRESS_INTERVAL=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 \
+    bash -c '
+      set -u
+      . "$1"
+      WATCHER_PID=$$
+      mkdir -p "$WATCH_LOCK"
+      printf "%s\n" "$WATCHER_PID" > "$WATCH_LOCK/pid"
+      recorded_windows() { printf "%s\n" herdrsess:pane1; }
+      window_backend() { printf "herdr\n"; }
+      window_kind() { printf "ship\n"; }
+      fm_backend_has_push() { return 0; }
+      fm_backend_events_capable() { return 0; }
+      # The real reader blocks on a fifo for the whole budget; this stands in for
+      # that uninterruptible foreground wait.
+      fm_backend_wait_transition() { sleep "$3"; return 1; }
+      handle_push_transition() { :; }
+      wake() { printf "WAKE %s\n" "$*"; }
+      start=$(date +%s)
+      fast_repair_progress_discover
+      event_wait_or_sleep
+      printf "ELAPSED %s\n" "$(( $(date +%s) - start ))"
+    ' _ "$WATCH" > "$out" 2>&1 \
+    || fail "the push-path Fast Repair cycle failed: $(cat "$out")"
+  grep -F 'WAKE check: fast-repair fast broader-tests-failed' "$out" >/dev/null \
+    || fail "the Fast Repair result was not delivered during the push-transition wait: $(cat "$out")"
+  elapsed=$(sed -n 's/^ELAPSED //p' "$out" | head -n 1)
+  case "$elapsed" in ''|*[!0-9]*) fail "the push-path cycle reported no elapsed time: $(cat "$out")" ;; esac
+  [ "$elapsed" -lt 15 ] \
+    || fail "the Fast Repair result waited out the ${elapsed}s push-transition budget instead of interrupting it"
+  pass "a Fast Repair result interrupts the push-transition wait instead of waiting out the poll budget"
+}
+
+# A progress child killed at the poll boundary has proven nothing, so its beat
+# must stay due; a child that completed its check owns the next due time.
+test_fast_repair_beat_survives_the_poll_boundary() {
+  local dir state out
+  dir=$(make_case fast-repair-beat-boundary); state="$dir/state"; out="$dir/result"
+  printf 'kind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$state/fast.meta"
+  record_fast_repair_eligibility "$dir" fast
+  FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" \
+    bash -c '
+      set -u
+      . "$1"
+      FAST_REPAIR_ACTIVE=1
+      FAST_REPAIR_PROGRESS_INTERVAL=600
+      run_check_capture() { : > "$STATE/.fixture-check-started"; sleep 10; FM_CHECK_RESULT=; }
+      FM_FAST_REPAIR_TIMER_GENERATION=1 fast_repair_progress_tick
+      i=0
+      while [ ! -e "$STATE/.fixture-check-started" ] && [ "$i" -lt 200 ]; do sleep 0.05; i=$((i + 1)); done
+      [ -e "$STATE/.fixture-check-started" ] || { echo "the progress child never started"; exit 1; }
+      fast_repair_progress_timer_tasks_finish 1
+      due=$(fast_repair_progress_due_in fast)
+      [ "$due" = 0 ] || { echo "a reaped beat advanced its due time to ${due}s"; exit 1; }
+
+      run_check_capture() { FM_CHECK_RESULT=; }
+      FM_FAST_REPAIR_TIMER_GENERATION=2 fast_repair_progress_tick
+      i=0
+      while [ "$(fast_repair_progress_due_in fast)" = 0 ] && [ "$i" -lt 200 ]; do sleep 0.05; i=$((i + 1)); done
+      due=$(fast_repair_progress_due_in fast)
+      [ "$due" -gt 0 ] || { echo "a completed check did not advance its own due time"; exit 1; }
+      fast_repair_progress_timer_tasks_finish 2
+    ' _ "$WATCH" > "$out" 2>&1 \
+    || fail "the Fast Repair beat was lost at the poll boundary: $(cat "$out")"
+  pass "a Fast Repair beat reaped at a poll boundary stays due and a completed check owns its next due"
+}
+
+# The twenty-second forge poll exists to catch the first actionable transition of
+# an open Fast Repair PR. Once green is queued the ordinary PR poll owns it.
+test_fast_repair_cadence_retires_after_the_first_green_rollup() {
+  local dir state out
+  dir=$(make_case fast-repair-green-retire); state="$dir/state"; out="$dir/result"
+  printf 'kind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$state/fast.meta"
+  printf 'kind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$state/other.meta"
+  record_fast_repair_eligibility "$dir" fast
+  record_fast_repair_eligibility "$dir" other
+  FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" FM_FAST_REPAIR_PROGRESS_INTERVAL=20 \
+    bash -c '
+      set -u
+      . "$1"
+      wake() { printf "WAKE %s\n" "$*"; }
+      fast_repair_progress_discover
+      [ "$FAST_REPAIR_ACTIVE" = 1 ] || { echo "an eligible task was not discovered"; exit 1; }
+      FM_FAST_REPAIR_TIMER_GENERATION=1 \
+        fast_repair_progress_timer_publish fast "fast-repair fast pr-checks-green: 4 passed, 0 failed, 4 total"
+      fast_repair_progress_timer_wake
+      fast_repair_progress_discover
+      [ "$FAST_REPAIR_ACTIVE" = 1 ] || { echo "the remaining Fast Repair task stopped the cadence"; exit 1; }
+      mv -f "$STATE/other.meta" "$STATE/other.meta.parked"
+      fast_repair_progress_discover
+      [ "$FAST_REPAIR_ACTIVE" = 0 ] || { echo "the cadence stayed active with only a green task left"; exit 1; }
+      FM_FAST_REPAIR_TIMER_GENERATION=1 FAST_REPAIR_ACTIVE=1 fast_repair_progress_tick
+      [ "$FAST_REPAIR_ACTIVE" = 0 ] || { echo "the tick kept working a retired green task"; exit 1; }
+      [ ! -e "$STATE/.last-fast-repair-progress-fast" ] \
+        || { echo "the retired green task was polled again"; exit 1; }
+      mv -f "$STATE/other.meta.parked" "$STATE/other.meta"
+      ids=$(fast_repair_progress_task_ids)
+      case "$ids" in
+        *fast*) echo "the green task is still worked by the twenty-second cadence"; exit 1 ;;
+      esac
+      case "$ids" in
+        *other*) ;;
+        *) echo "retiring the green task also retired an unrelated Fast Repair task"; exit 1 ;;
+      esac
+    ' _ "$WATCH" > "$out" 2>&1 \
+    || fail "the Fast Repair cadence did not retire after its first green rollup: $(cat "$out")"
+  grep -F 'WAKE check: fast-repair fast pr-checks-green' "$out" >/dev/null \
+    || fail "the green rollup was not surfaced before the cadence retired: $(cat "$out")"
+  pass "the Fast Repair cadence retires a task after its first green rollup is queued"
+}
+
 test_signal_reason_is_actionable_classifier
 test_fast_repair_check_signal_race_stops_the_check_group
+test_fast_repair_cadence_interrupts_the_push_transition_wait
+test_fast_repair_beat_survives_the_poll_boundary
+test_fast_repair_cadence_retires_after_the_first_green_rollup
 test_fast_repair_progress_cadence_is_task_scoped
 test_fast_repair_marker_waits_for_the_durable_wake
 test_fast_repair_cadence_runs_inside_a_long_ordinary_poll

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -2545,7 +2545,101 @@ test_fast_repair_wait_stop_refuses_a_foreign_pid() {
   pass "the Fast Repair wait stop refuses a pid this watcher did not fork"
 }
 
+# A Bash older than 4.4, where expanding an EMPTY array under `set -u` is a fatal
+# unbound-variable error rather than nothing. macOS still ships 3.2 as /bin/bash
+# and this repository supports it, so the empty-set paths below are replayed on
+# such an interpreter whenever one is reachable. Prints nothing (and returns 1)
+# on hosts that only carry a modern Bash.
+legacy_empty_array_bash() {
+  local candidate version
+  for candidate in ${FM_TEST_LEGACY_BASH:-} /bin/bash /usr/bin/bash /usr/local/bin/bash /opt/homebrew/bin/bash; do
+    [ -x "$candidate" ] || continue
+    # shellcheck disable=SC2016 # The candidate interpreter must expand its OWN version, not this shell's.
+    version=$("$candidate" -c 'printf "%s.%s\n" "${BASH_VERSINFO[0]}" "${BASH_VERSINFO[1]}"' 2>/dev/null) || continue
+    case "$version" in
+      1.*|2.*|3.*|4.0|4.1|4.2|4.3) printf '%s\n' "$candidate"; return 0 ;;
+    esac
+  done
+  return 1
+}
+
+# Every supervision cycle arms a Fast Repair generation and retires it at the
+# end of the cycle, and the overwhelming majority of cycles reach that sweep with
+# NOTHING live for the generation: a completed progress child removes its own
+# marker, and a cycle shorter than the Fast Repair interval never starts one. The
+# sweep must therefore finish on an empty set and hand control back, or the
+# watcher dies mid-cycle and takes its EXIT-trap cleanup down with it.
+test_fast_repair_timer_sweep_survives_an_empty_generation() {
+  local dir state probe out legacy
+  dir=$(make_case fast-repair-empty-sweep); state="$dir/state"; probe="$dir/probe.sh"; out="$dir/result"
+  printf 'kind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$state/fast.meta"
+  record_fast_repair_eligibility "$dir" fast
+  cat > "$probe" <<'SH'
+set -eu
+. "$1"
+FAST_REPAIR_ACTIVE=1
+fast_repair_progress_timer_tasks_finish 9
+printf 'cycle-continued\n'
+SH
+  # A marker whose recorded pid is unreadable is discarded before the sweep
+  # collects anything, so the sweep still reaches its reap phase with an empty
+  # set - the ordinary shape, not a contrived one.
+  : > "$state/.fast-repair-progress-child-fast-9"
+  FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" bash "$probe" "$WATCH" > "$out" 2>&1 \
+    || fail "the empty Fast Repair retirement sweep aborted the supervision cycle: $(cat "$out")"
+  grep -Fx cycle-continued "$out" >/dev/null \
+    || fail "the empty Fast Repair retirement sweep never returned to its caller: $(cat "$out")"
+  [ ! -e "$state/.fast-repair-progress-child-fast-9" ] \
+    || fail "the retirement sweep left a pidless progress-child marker behind"
+
+  if legacy=$(legacy_empty_array_bash); then
+    : > "$state/.fast-repair-progress-child-fast-9"
+    FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" "$legacy" "$probe" "$WATCH" > "$out" 2>&1 \
+      || fail "the empty Fast Repair retirement sweep aborted under $legacy: $(cat "$out")"
+    grep -Fx cycle-continued "$out" >/dev/null \
+      || fail "the empty Fast Repair retirement sweep never returned under $legacy: $(cat "$out")"
+  fi
+  pass "the Fast Repair retirement sweep completes a generation with no live progress child"
+}
+
+# The parent announces retirement by writing a `.closing` handshake file that only
+# the timer child's own EXIT trap removes. A child that already retired itself -
+# the watcher lock moved on, the beat was retired, or the schedule went invalid -
+# leaves that file with no owner, and its mkstemp name carries no task id, so
+# teardown's per-task globs can never reclaim it.
+test_fast_repair_retirement_reaps_a_dead_childs_closing_marker() {
+  local dir state out leftover
+  dir=$(make_case fast-repair-closing-orphan); state="$dir/state"; out="$dir/result"
+  printf 'kind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$state/fast.meta"
+  record_fast_repair_eligibility "$dir" fast
+  FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" \
+    bash -c '
+      set -eu
+      . "$1"
+      WATCHER_PID=$$
+      mkdir -p "$WATCH_LOCK"
+      # A watcher lock owned by somebody else is one of the ways the timer child
+      # retires itself long before the parent asks it to.
+      printf "%s\n" "$((WATCHER_PID + 1))" > "$WATCH_LOCK/pid"
+      FAST_REPAIR_ACTIVE=1
+      POLL=10
+      FAST_REPAIR_PROGRESS_INTERVAL=1
+      fast_repair_progress_timer_start
+      [ -n "$FAST_REPAIR_TIMER_PID" ] || { echo "the Fast Repair timer never armed"; exit 1; }
+      # Reap the child first, so the parent provably retires an already-dead one.
+      wait "$FAST_REPAIR_TIMER_PID" 2>/dev/null || true
+      fast_repair_progress_timer_finish
+    ' _ "$WATCH" > "$out" 2>&1 \
+    || fail "Fast Repair timer retirement failed: $(cat "$out")"
+  leftover=$(find "$state" -maxdepth 1 -name '.fast-repair-progress-timer.*' -print | tr '\n' ' ')
+  [ -z "$leftover" ] \
+    || fail "Fast Repair timer retirement orphaned an unreclaimable artifact: $leftover"
+  pass "Fast Repair timer retirement reaps the closing handshake of an already-exited child"
+}
+
 test_signal_reason_is_actionable_classifier
+test_fast_repair_timer_sweep_survives_an_empty_generation
+test_fast_repair_retirement_reaps_a_dead_childs_closing_marker
 test_fast_repair_undrainable_handoff_stops_shortening_waits
 test_fast_repair_local_followup_retires_after_the_broader_result
 test_fast_repair_local_followup_retires_on_a_broader_pass

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -1959,11 +1959,45 @@ test_fast_repair_timer_keeps_mixed_fleet_normal_polling() {
   pass "a Fast Repair timer leaves mixed-fleet normal polling unchanged"
 }
 
+test_fast_repair_timer_retirement_stops_active_check_group() {
+  local dir state check out
+  dir=$(make_case fast-repair-timer-retire); state="$dir/state"; check="$dir/check.sh"; out="$dir/result"
+  cat > "$check" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$$" > "$FM_TEST_CHECK_PID"
+trap '' TERM
+while :; do sleep 1; done
+SH
+  chmod +x "$check"
+  FM_STATE_OVERRIDE="$state" FM_TEST_CHECK_PID="$dir/check.pid" \
+    bash -c '
+      set -eu
+      . "$1"
+      WATCHER_PID=$$
+      mkdir -p "$WATCH_LOCK"
+      printf "%s\n" "$WATCHER_PID" > "$WATCH_LOCK/pid"
+      FAST_REPAIR_ACTIVE=1
+      POLL=10
+      FAST_REPAIR_PROGRESS_INTERVAL=1
+      fast_repair_progress_tick() { run_check_capture "$2"; }
+      fast_repair_progress_timer_start
+      i=0
+      while [ ! -s "$3" ] && [ "$i" -lt 60 ]; do sleep 0.1; i=$((i + 1)); done
+      [ -s "$3" ]
+      fast_repair_progress_timer_finish
+      pid=$(cat "$3")
+      ! kill -0 "$pid" 2>/dev/null
+    ' _ "$WATCH" "$check" "$dir/check.pid" > "$out" 2>&1 \
+    || fail "Fast Repair timer retirement left its active check group alive: $(cat "$out")"
+  pass "Fast Repair timer retirement stops its active Forge check group"
+}
+
 test_signal_reason_is_actionable_classifier
 test_fast_repair_progress_cadence_is_task_scoped
 test_fast_repair_marker_waits_for_the_durable_wake
 test_fast_repair_cadence_runs_inside_a_long_ordinary_poll
 test_fast_repair_timer_keeps_mixed_fleet_normal_polling
+test_fast_repair_timer_retirement_stops_active_check_group
 test_stale_is_terminal_classifier
 test_scan_captain_relevant_statuses_classifier
 test_classifier_primitives

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -1901,9 +1901,31 @@ test_fast_repair_marker_waits_for_the_durable_wake() {
   pass "a Fast Repair progress marker commits only after its durable wake is queued"
 }
 
+# The ordinary poll is deliberately far longer than the Fast Repair interval, so
+# the cycle's terminal wait is the only thing that could stretch the cadence: the
+# marker is pre-touched, which makes the first tick ineligible and forces the
+# watcher to wait before it can report.
+test_fast_repair_cadence_outlives_a_long_ordinary_poll() {
+  local dir state out pid
+  dir=$(make_case fast-repair-cadence); state="$dir/state"; out="$dir/watch.out"
+  printf 'window=firstmate:fm-fast\nkind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$state/fast.meta"
+  printf 'broader=failed\n' > "$state/fast.fast-repair-broader"
+  touch "$state/.last-fast-repair-progress"
+  PATH="$dir/fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" \
+    FM_POLL=60 FM_SIGNAL_GRACE=1 FM_FAST_REPAIR_PROGRESS_INTERVAL=2 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 120 \
+    || fail "the ordinary poll wait held the Fast Repair cadence past its own interval"
+  grep -F 'check: fast-repair fast broader-tests-failed' "$out" >/dev/null \
+    || fail "the Fast Repair progress result was not surfaced: $(cat "$out")"
+  pass "an eligible Fast Repair task keeps its own interval under a much longer ordinary poll"
+}
+
 test_signal_reason_is_actionable_classifier
 test_fast_repair_progress_cadence_is_task_scoped
 test_fast_repair_marker_waits_for_the_durable_wake
+test_fast_repair_cadence_outlives_a_long_ordinary_poll
 test_stale_is_terminal_classifier
 test_scan_captain_relevant_statuses_classifier
 test_classifier_primitives

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -2030,7 +2030,54 @@ SH
   pass "Fast Repair timer retirement stops its active Forge check group"
 }
 
+# A retirement signal can land in the window between arming the pending-flag trap
+# and swapping in the trap that stops the check, which is exactly when
+# fast_repair_progress_timer_tasks_finish signals the progress child. The capture
+# must then stop the whole forked check group itself; only the child pid is
+# recorded anywhere, so a group left running outlives watcher retirement.
+test_fast_repair_check_signal_race_stops_the_check_group() {
+  local dir state check out pid i
+  dir=$(make_case fast-repair-check-signal-race); state="$dir/state"; check="$dir/check.sh"; out="$dir/result"
+  cat > "$check" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$$" > "$FM_TEST_CHECK_PID"
+trap '' TERM
+while :; do sleep 1; done
+SH
+  chmod +x "$check"
+  # run_check_capture exits its own shell on a pending signal, so it runs as the
+  # whole bash -c process and the surviving-group assertion is made from here.
+  FM_STATE_OVERRIDE="$state" FM_TEST_CHECK_PID="$dir/check.pid" FM_CHECK_TIMEOUT=600 \
+    bash -c '
+      set -u
+      . "$1"
+      pidfile=$3
+      # ps is the only command run inside the unguarded window, so shimming it
+      # delivers the signal there deterministically instead of racing a timer.
+      ps() {
+        local i=0
+        while [ ! -s "$pidfile" ] && [ "$i" -lt 200 ]; do sleep 0.05; i=$((i + 1)); done
+        command ps "$@"
+        kill -TERM $$ 2>/dev/null || true
+      }
+      run_check_capture --stop-active-check-on-signal "$2"
+    ' _ "$WATCH" "$check" "$dir/check.pid" > "$out" 2>&1
+  [ -s "$dir/check.pid" ] || fail "the signalled capture never started its check: $(cat "$out")"
+  pid=$(cat "$dir/check.pid")
+  i=0
+  while kill -0 "$pid" 2>/dev/null && [ "$i" -lt 100 ]; do
+    sleep 0.05
+    i=$((i + 1))
+  done
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -KILL "$pid" 2>/dev/null || true
+    fail "a signal in the pre-group window orphaned the active check group: pid $pid survived"
+  fi
+  pass "a signal racing the active-check group handoff still stops that check group"
+}
+
 test_signal_reason_is_actionable_classifier
+test_fast_repair_check_signal_race_stops_the_check_group
 test_fast_repair_progress_cadence_is_task_scoped
 test_fast_repair_marker_waits_for_the_durable_wake
 test_fast_repair_cadence_runs_inside_a_long_ordinary_poll

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -1871,7 +1871,7 @@ test_fast_repair_progress_cadence_is_task_scoped() {
   normal_dir=$(make_case normal-no-fast-repair); normal_state="$normal_dir/state"; normal_bin="$normal_dir/fakebin"; normal_out="$normal_dir/watch.out"
   printf 'window=firstmate:fm-normal\nkind=ship\nmode=no-mistakes\nyolo=off\n' > "$normal_state/normal.meta"
   PATH="$normal_bin:$PATH" FM_STATE_OVERRIDE="$normal_state" FM_DATA_OVERRIDE="$normal_dir/data" \
-    FM_POLL=1 FM_SIGNAL_GRACE=1 FM_FAST_REPAIR_PROGRESS_INTERVAL=1 \
+    FM_POLL=3 FM_SIGNAL_GRACE=1 FM_FAST_REPAIR_PROGRESS_INTERVAL=1 \
     FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$normal_out" &
   normal_pid=$!
   sleep 2
@@ -1886,12 +1886,12 @@ test_fast_repair_progress_cadence_is_task_scoped() {
 test_fast_repair_marker_waits_for_the_durable_wake() {
   local dir state out pid exit_status
   dir=$(make_case fast-repair-marker-order); state="$dir/state"; out="$dir/watch.out"
-  printf 'window=firstmate:fm-fast\nkind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$state/fast.meta"
+  printf 'kind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$state/fast.meta"
   record_fast_repair_eligibility "$dir" fast
   printf 'broader=failed\n' > "$state/fast.fast-repair-broader"
   mkdir -p "$state/.wake-queue.seq"
-  PATH="$dir/fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" \
-    FM_POLL=1 FM_SIGNAL_GRACE=1 FM_FAST_REPAIR_PROGRESS_INTERVAL=1 \
+  PATH="$dir/fakebin:$PATH" FM_FAKE_CREW_STATE='state: working · source: run-step · validating (running)' FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" \
+    FM_POLL=3 FM_SIGNAL_GRACE=1 FM_FAST_REPAIR_PROGRESS_INTERVAL=1 \
     FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" 2>/dev/null &
   pid=$!
   wait_for_exit "$pid" 60
@@ -1902,11 +1902,20 @@ test_fast_repair_marker_waits_for_the_durable_wake() {
 
   rmdir "$state/.wake-queue.seq"
   : > "$out"
-  PATH="$dir/fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" \
+  PATH="$dir/fakebin:$PATH" FM_FAKE_CREW_STATE='state: working · source: run-step · validating (running)' FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" \
     FM_POLL=1 FM_SIGNAL_GRACE=1 FM_FAST_REPAIR_PROGRESS_INTERVAL=1 \
     FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
   pid=$!
   wait_for_exit "$pid" 60 || fail "the Fast Repair transition did not replay after a failed enqueue"
+  if grep -Fq 'check: rearm-resurface' "$out"; then
+    ack_stopped_cycle "$state" || fail "the failed Fast Repair wake could not clear recovery state"
+    : > "$out"
+    PATH="$dir/fakebin:$PATH" FM_FAKE_CREW_STATE='state: working · source: run-step · validating (running)' FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" \
+      FM_POLL=3 FM_SIGNAL_GRACE=1 FM_FAST_REPAIR_PROGRESS_INTERVAL=1 \
+      FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" 2>/dev/null &
+    pid=$!
+    wait_for_exit "$pid" 60 || fail "the Fast Repair transition did not replay after recovery acknowledgement"
+  fi
   grep -F 'check: fast-repair fast broader-tests-failed' "$out" >/dev/null \
     || fail "a failed enqueue swallowed the Fast Repair transition: $(cat "$out")"
   pass "a Fast Repair progress marker commits only after its durable wake is queued"
@@ -1959,6 +1968,34 @@ test_fast_repair_timer_keeps_mixed_fleet_normal_polling() {
   pass "a Fast Repair timer leaves mixed-fleet normal polling unchanged"
 }
 
+test_fast_repair_progress_tasks_are_independent() {
+  local dir state out
+  dir=$(make_case fast-repair-independent-progress); state="$dir/state"; out="$dir/result"
+  printf 'kind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$state/slow.meta"
+  printf 'kind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$state/timely.meta"
+  FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" bash -c '
+    set -eu
+    . "$1"
+    FAST_REPAIR_ACTIVE=1
+    FAST_REPAIR_PROGRESS_INTERVAL=1
+    run_check_capture() {
+      case "$3" in
+        slow) sleep 3; FM_CHECK_RESULT= ;;
+        timely) FM_CHECK_RESULT="fast-repair timely broader-tests-failed" ;;
+      esac
+    }
+    fast_repair_progress_timer_publish() {
+      printf "%s\n" "$2" > "$STATE/.timely-result-$1"
+    }
+    FM_FAST_REPAIR_TIMER_GENERATION=1 FM_FAST_REPAIR_TIMER_CLOSING="$STATE/.closing" fast_repair_progress_tick
+    sleep 0.3
+    [ -f "$STATE/.timely-result-timely" ]
+    fast_repair_progress_timer_tasks_finish 1
+  ' _ "$WATCH" > "$out" 2>&1 \
+    || fail "a slow Fast Repair progress check blocked another task: $(cat "$out")"
+  pass "Fast Repair progress checks keep each eligible task independent"
+}
+
 test_fast_repair_timer_retirement_stops_active_check_group() {
   local dir state check out
   dir=$(make_case fast-repair-timer-retire); state="$dir/state"; check="$dir/check.sh"; out="$dir/result"
@@ -1997,6 +2034,7 @@ test_fast_repair_progress_cadence_is_task_scoped
 test_fast_repair_marker_waits_for_the_durable_wake
 test_fast_repair_cadence_runs_inside_a_long_ordinary_poll
 test_fast_repair_timer_keeps_mixed_fleet_normal_polling
+test_fast_repair_progress_tasks_are_independent
 test_fast_repair_timer_retirement_stops_active_check_group
 test_stale_is_terminal_classifier
 test_scan_captain_relevant_statuses_classifier

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -127,7 +127,7 @@ record_fast_repair_eligibility() {
   local dir=$1 id=$2
   FM_HOME="$dir" FM_STATE_OVERRIDE="$dir/state" FM_DATA_OVERRIDE="$dir/data" \
     "$ROOT/bin/fm-fast-repair.sh" intake "$id" --request 'fast-repair: watcher fixture' \
-    --reproduction reproduced --root-cause confirmed --isolation isolated \
+    --reproduction reproduced --reproduction-revision "$(git -C "$ROOT" rev-parse HEAD)" --root-cause confirmed --isolation isolated \
     --schema none --authentication none --authorization none --secrets none \
     --financial none --legal none --side-effects none >/dev/null
 }
@@ -1857,11 +1857,11 @@ test_afk_paused_changed_pane_hands_off_plain_stale() {
 test_fast_repair_progress_cadence_is_task_scoped() {
   local fast_dir fast_state fast_bin fast_out fast_pid normal_dir normal_state normal_bin normal_out normal_pid
   fast_dir=$(make_case fast-repair-progress); fast_state="$fast_dir/state"; fast_bin="$fast_dir/fakebin"; fast_out="$fast_dir/watch.out"
-  printf 'window=firstmate:fm-fast\nkind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$fast_state/fast.meta"
+  printf 'kind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\nworktree=%s\n' "$ROOT" > "$fast_state/fast.meta"
   record_fast_repair_eligibility "$fast_dir" fast
   printf 'broader=failed\n' > "$fast_state/fast.fast-repair-broader"
-  PATH="$fast_bin:$PATH" FM_STATE_OVERRIDE="$fast_state" FM_DATA_OVERRIDE="$fast_dir/data" \
-    FM_POLL=1 FM_SIGNAL_GRACE=1 FM_FAST_REPAIR_PROGRESS_INTERVAL=1 \
+  PATH="$fast_bin:$PATH" FM_FAKE_CREW_STATE='state: working · source: run-step · validating (running)' FM_STATE_OVERRIDE="$fast_state" FM_DATA_OVERRIDE="$fast_dir/data" \
+    FM_POLL=3 FM_SIGNAL_GRACE=1 FM_FAST_REPAIR_PROGRESS_INTERVAL=1 \
     FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$fast_out" &
   fast_pid=$!
   wait_for_exit "$fast_pid" 40 || fail "Fast Repair progress result did not wake the watcher"

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -1875,7 +1875,7 @@ test_fast_repair_progress_cadence_is_task_scoped() {
     FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$normal_out" &
   normal_pid=$!
   sleep 2
-  [ ! -e "$normal_state/.last-fast-repair-progress" ] \
+  [ ! -e "$normal_state/.last-fast-repair-progress-normal" ] \
     || fail "ordinary task watcher wrote Fast Repair cadence state"
   reap "$normal_pid"
   pass "Fast Repair uses a 20-second-class task-only progress cadence without changing ordinary watcher state"
@@ -1930,7 +1930,7 @@ test_fast_repair_cadence_runs_inside_a_long_ordinary_poll() {
   printf 'window=firstmate:fm-fast\nkind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$state/fast.meta"
   record_fast_repair_eligibility "$dir" fast
   printf 'broader=failed\n' > "$state/fast.fast-repair-broader"
-  touch "$state/.last-fast-repair-progress"
+  touch "$state/.last-fast-repair-progress-fast"
   PATH="$dir/fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" \
     FM_POLL=60 FM_SIGNAL_GRACE=1 FM_FAST_REPAIR_PROGRESS_INTERVAL=2 \
     FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
@@ -1953,11 +1953,11 @@ test_fast_repair_timer_keeps_mixed_fleet_normal_polling() {
     FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
   pid=$!
   i=0
-  while [ ! -e "$state/.last-fast-repair-progress" ] && [ "$i" -lt 50 ]; do
+  while [ ! -e "$state/.last-fast-repair-progress-fast" ] && [ "$i" -lt 50 ]; do
     sleep 0.1
     i=$((i + 1))
   done
-  [ -e "$state/.last-fast-repair-progress" ] \
+  [ -e "$state/.last-fast-repair-progress-fast" ] \
     || fail "the mixed-fleet watcher never started its Fast Repair cadence"
   sleep 1
   printf 'blocked: normal task needs captain\n' > "$state/normal.status"
@@ -1979,7 +1979,7 @@ test_fast_repair_progress_tasks_are_independent() {
     FAST_REPAIR_ACTIVE=1
     FAST_REPAIR_PROGRESS_INTERVAL=1
     run_check_capture() {
-      case "$3" in
+      case "$4" in
         slow) sleep 3; FM_CHECK_RESULT= ;;
         timely) FM_CHECK_RESULT="fast-repair timely broader-tests-failed" ;;
       esac
@@ -2016,7 +2016,8 @@ SH
       FAST_REPAIR_ACTIVE=1
       POLL=10
       FAST_REPAIR_PROGRESS_INTERVAL=1
-      fast_repair_progress_tick() { run_check_capture "$2"; }
+      check=$2
+      fast_repair_progress_tick() { run_check_capture --stop-active-check-on-signal "$check"; }
       fast_repair_progress_timer_start
       i=0
       while [ ! -s "$3" ] && [ "$i" -lt 60 ]; do sleep 0.1; i=$((i + 1)); done

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -1845,7 +1845,34 @@ test_afk_paused_changed_pane_hands_off_plain_stale() {
   pass "AFK changed paused panes hand off plain stale identities for daemon-owned pause triage"
 }
 
+test_fast_repair_progress_cadence_is_task_scoped() {
+  local fast_dir fast_state fast_bin fast_out fast_pid normal_dir normal_state normal_bin normal_out normal_pid
+  fast_dir=$(make_case fast-repair-progress); fast_state="$fast_dir/state"; fast_bin="$fast_dir/fakebin"; fast_out="$fast_dir/watch.out"
+  printf 'window=firstmate:fm-fast\nkind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$fast_state/fast.meta"
+  printf 'broader=failed\n' > "$fast_state/fast.fast-repair-broader"
+  PATH="$fast_bin:$PATH" FM_STATE_OVERRIDE="$fast_state" FM_DATA_OVERRIDE="$fast_dir/data" \
+    FM_POLL=1 FM_SIGNAL_GRACE=1 FM_FAST_REPAIR_PROGRESS_INTERVAL=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$fast_out" &
+  fast_pid=$!
+  wait_for_exit "$fast_pid" 40 || fail "Fast Repair progress result did not wake the watcher"
+  grep -F 'check: fast-repair fast broader-tests-failed' "$fast_out" >/dev/null \
+    || fail "Fast Repair progress result was not surfaced: $(cat "$fast_out")"
+
+  normal_dir=$(make_case normal-no-fast-repair); normal_state="$normal_dir/state"; normal_bin="$normal_dir/fakebin"; normal_out="$normal_dir/watch.out"
+  printf 'window=firstmate:fm-normal\nkind=ship\nmode=no-mistakes\nyolo=off\n' > "$normal_state/normal.meta"
+  PATH="$normal_bin:$PATH" FM_STATE_OVERRIDE="$normal_state" FM_DATA_OVERRIDE="$normal_dir/data" \
+    FM_POLL=1 FM_SIGNAL_GRACE=1 FM_FAST_REPAIR_PROGRESS_INTERVAL=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$normal_out" &
+  normal_pid=$!
+  sleep 2
+  [ ! -e "$normal_state/.last-fast-repair-progress" ] \
+    || fail "ordinary task watcher wrote Fast Repair cadence state"
+  reap "$normal_pid"
+  pass "Fast Repair uses a 20-second-class task-only progress cadence without changing ordinary watcher state"
+}
+
 test_signal_reason_is_actionable_classifier
+test_fast_repair_progress_cadence_is_task_scoped
 test_stale_is_terminal_classifier
 test_scan_captain_relevant_statuses_classifier
 test_classifier_primitives

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -123,6 +123,15 @@ record_pi_busy() {  # <state-dir> <id>
 
 reap() { kill "$1" 2>/dev/null || true; wait "$1" 2>/dev/null || true; }
 
+record_fast_repair_eligibility() {
+  local dir=$1 id=$2
+  FM_HOME="$dir" FM_STATE_OVERRIDE="$dir/state" FM_DATA_OVERRIDE="$dir/data" \
+    "$ROOT/bin/fm-fast-repair.sh" intake "$id" --request 'fast-repair: watcher fixture' \
+    --reproduction reproduced --root-cause confirmed --isolation isolated \
+    --schema none --authentication none --authorization none --secrets none \
+    --financial none --legal none --side-effects none >/dev/null
+}
+
 # --- pure classifier predicates (fm-classify-lib.sh) ------------------------
 
 test_signal_reason_is_actionable_classifier() {
@@ -1849,6 +1858,7 @@ test_fast_repair_progress_cadence_is_task_scoped() {
   local fast_dir fast_state fast_bin fast_out fast_pid normal_dir normal_state normal_bin normal_out normal_pid
   fast_dir=$(make_case fast-repair-progress); fast_state="$fast_dir/state"; fast_bin="$fast_dir/fakebin"; fast_out="$fast_dir/watch.out"
   printf 'window=firstmate:fm-fast\nkind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$fast_state/fast.meta"
+  record_fast_repair_eligibility "$fast_dir" fast
   printf 'broader=failed\n' > "$fast_state/fast.fast-repair-broader"
   PATH="$fast_bin:$PATH" FM_STATE_OVERRIDE="$fast_state" FM_DATA_OVERRIDE="$fast_dir/data" \
     FM_POLL=1 FM_SIGNAL_GRACE=1 FM_FAST_REPAIR_PROGRESS_INTERVAL=1 \
@@ -1877,6 +1887,7 @@ test_fast_repair_marker_waits_for_the_durable_wake() {
   local dir state out pid exit_status
   dir=$(make_case fast-repair-marker-order); state="$dir/state"; out="$dir/watch.out"
   printf 'window=firstmate:fm-fast\nkind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$state/fast.meta"
+  record_fast_repair_eligibility "$dir" fast
   printf 'broader=failed\n' > "$state/fast.fast-repair-broader"
   mkdir -p "$state/.wake-queue.seq"
   PATH="$dir/fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" \
@@ -1902,13 +1913,13 @@ test_fast_repair_marker_waits_for_the_durable_wake() {
 }
 
 # The ordinary poll is deliberately far longer than the Fast Repair interval, so
-# the cycle's terminal wait is the only thing that could stretch the cadence: the
-# marker is pre-touched, which makes the first tick ineligible and forces the
-# watcher to wait before it can report.
-test_fast_repair_cadence_outlives_a_long_ordinary_poll() {
+# a task-only timer must produce the Fast Repair wake before that unchanged poll
+# ends.
+test_fast_repair_cadence_runs_inside_a_long_ordinary_poll() {
   local dir state out pid
   dir=$(make_case fast-repair-cadence); state="$dir/state"; out="$dir/watch.out"
   printf 'window=firstmate:fm-fast\nkind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$state/fast.meta"
+  record_fast_repair_eligibility "$dir" fast
   printf 'broader=failed\n' > "$state/fast.fast-repair-broader"
   touch "$state/.last-fast-repair-progress"
   PATH="$dir/fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" \
@@ -1916,16 +1927,43 @@ test_fast_repair_cadence_outlives_a_long_ordinary_poll() {
     FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
   pid=$!
   wait_for_exit "$pid" 120 \
-    || fail "the ordinary poll wait held the Fast Repair cadence past its own interval"
+    || fail "the ordinary poll wait held the Fast Repair cadence past its own interval: $(cat "$out")"
   grep -F 'check: fast-repair fast broader-tests-failed' "$out" >/dev/null \
     || fail "the Fast Repair progress result was not surfaced: $(cat "$out")"
-  pass "an eligible Fast Repair task keeps its own interval under a much longer ordinary poll"
+  pass "an eligible Fast Repair task keeps its own interval inside a much longer ordinary poll"
+}
+
+test_fast_repair_timer_keeps_mixed_fleet_normal_polling() {
+  local dir state out pid i
+  dir=$(make_case fast-repair-mixed-poll); state="$dir/state"; out="$dir/watch.out"
+  printf 'window=firstmate:fm-fast\nkind=ship\nmode=fast-repair\nyolo=off\nfast_repair=eligible\n' > "$state/fast.meta"
+  record_fast_repair_eligibility "$dir" fast
+  printf 'window=firstmate:fm-normal\nkind=ship\nmode=no-mistakes\nyolo=off\n' > "$state/normal.meta"
+  PATH="$dir/fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$dir/data" \
+    FM_POLL=8 FM_SIGNAL_GRACE=1 FM_FAST_REPAIR_PROGRESS_INTERVAL=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  i=0
+  while [ ! -e "$state/.last-fast-repair-progress" ] && [ "$i" -lt 50 ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ -e "$state/.last-fast-repair-progress" ] \
+    || fail "the mixed-fleet watcher never started its Fast Repair cadence"
+  sleep 1
+  printf 'blocked: normal task needs captain\n' > "$state/normal.status"
+  wait_live "$pid" 25 || fail "a Fast Repair timer shortened the normal task poll: $(cat "$out")"
+  wait_for_exit "$pid" 100 || fail "the unchanged normal poll did not later surface its blocked status"
+  grep -F "signal: $state/normal.status" "$out" >/dev/null \
+    || fail "the normal blocked status was not surfaced after its ordinary poll: $(cat "$out")"
+  pass "a Fast Repair timer leaves mixed-fleet normal polling unchanged"
 }
 
 test_signal_reason_is_actionable_classifier
 test_fast_repair_progress_cadence_is_task_scoped
 test_fast_repair_marker_waits_for_the_durable_wake
-test_fast_repair_cadence_outlives_a_long_ordinary_poll
+test_fast_repair_cadence_runs_inside_a_long_ordinary_poll
+test_fast_repair_timer_keeps_mixed_fleet_normal_polling
 test_stale_is_terminal_classifier
 test_scan_captain_relevant_statuses_classifier
 test_classifier_primitives


### PR DESCRIPTION
## Intent

Implement a strict opt-in per-task Fast Repair path in FirstMate, entered by one exact explicit prefix, that fails closed unless reproduction, root cause, isolation, and every forbidden-risk exclusion are proven; uses Codex gpt-5.6-luna at medium effort; skips scouts and extra plan/design reviews for eligible repairs; requires a regression test and focused module tests before an early direct PR; keeps broader tests and PR checks running concurrently; never auto-merges and always requires captain merge approval; adds an approximately 20-second progress cadence only for Fast Repair; leaves all project modes, dispatch, delivery, merge, teardown, and normal watcher behavior unchanged; documents invocation and refusal rules; and adds full eligibility, refusal, dispatch, direct-PR, cadence, and unchanged-normal regression tests.

## What Changed

- Adds `bin/fm-fast-repair.sh`, which owns the new per-task Fast Repair path: a typed eligibility record that fails closed unless reproduction, root cause, isolation, and every forbidden-risk exclusion are proven; `evidence` runs and records a regression family plus a different focused family through the tracked `bin/fm-test-run.sh` runner and proves the selected regression artifact fails at the recorded reproduction commit and passes at the tested head; `publish-pr` then opens the direct PR early, `broader` runs a wider family concurrently, and `ready` only reports green when the broader family and all required PR checks pass.
- Threads `fast-repair` through the existing entrypoints as a task mode, not a project mode: `fm-brief.sh` scaffolds a Fast Repair definition of done that skips scouts and extra reviews, `fm-spawn.sh` re-proves eligibility and pins the built-in `codex` / `gpt-5.6-luna` / `medium` profile with `yolo=off` (refusing a conflicting or raw launch command, and reusing the recorded profile on relaunch), `fm-promote.sh` refuses to promote a scout into it, and `fm-teardown.sh` removes the new evidence and progress artifacts with id-exact matching. `fm-watch.sh` gains a ~20-second task-scoped progress cadence that runs only while task metadata records `fast_repair=eligible`, interrupts waits only on a changed result, retires from forge polling after the first green rollup, and leaves normal polling, stale handling, and backend cadences untouched.
- Documents the path in new `docs/fast-repair.md` (invocation prefix, eligibility, refusals, delivery) with pointers from `README.md`, `AGENTS.md`, `docs/scripts.md`, and the audiences manifest; adds `fm-test-run.sh --list-shard-plan` so `docs/fm-test-portable-shards.md` derives its shard table from the runner; and adds regression tests for eligibility, refusal, dispatch, direct PR, cadence, teardown, relaunch, and unchanged normal-path behavior.

## Risk Assessment

⚠️ Medium: A large new subsystem (~4.5k lines) adds concurrent fork/marker/handoff machinery inside the watcher supervision loop and a new removal path in teardown, but every Fast Repair gate fails closed, the non-Fast-Repair watcher and teardown paths are verifiably inert, and both pipeline fix rounds land narrow corrections backed by regression tests that genuinely fail before the fix.

## Testing

I ran the targeted Fast Repair test scripts and the watcher, dispatch, relaunch, teardown, delivery, brief, and documentation scripts that the change touches; all passed with no failures or gate skips. Because passing tests alone do not show the feature, I also built a fixture project with a real off-by-one defect and drove the shipped scripts end to end against a recording forge fake: near-miss prefixes and an unproven root cause or in-scope schema change are refused; a complete typed record is accepted and stored private; the dispatch gate accepts the real detached pooled worktree and rejects a foreign repository; the generated brief tells the crewmate to skip scouts and extra reviews and gives the exact evidence, publish, broader, and ready commands; the regression test fails pre-fix and passes at the tested head; a PR before evidence and a non-new regression selector are refused; the direct PR opens right after the focused gates; the broader family runs and is refused when it repeats the focused family while checks are still pending; a failed rollup and an all-cancelled rollup are never called green; ready prints the approved counts; the whole path made zero merge or auto-merge forge calls with yolo=off; and a broader failure after green still surfaces locally. For cadence I ran the real watcher with no interval override inside a 600-second poll: the eligible Fast Repair task polled at +20s and +20s while an ordinary no-mistakes task polled the forge zero times and wrote no cadence state. This surface is CLI and generated-prose only, so there is no rendered UI to screenshot; the CLI transcripts are the end-user surface. I removed nothing from the working tree and it is clean; evidence files stay in the dedicated evidence directory.

<details>
<summary>Evidence: Fast Repair end-to-end CLI transcript (refusals, intake, dispatch gate, brief, evidence, direct PR, broader, ready, merge authority)</summary>

```text

=== 1. The reproduction the captain reported, on the pre-repair commit (a8d10918960cdb6c05aad8c1bab4993084922858) ===
  deleting 2 of 5 drafts still reports: 5
  expected: 3

=== 2. Fast Repair refuses everything it cannot prove ===
  'fast repair: fix the count'     -> not a Fast Repair request
  'Fast-repair: fix the count'     -> not a Fast Repair request
  'fast-repair:'                   -> not a Fast Repair request
  'fast-repair: fix the count'     -> Fast Repair request

$ fm-fast-repair.sh intake fr-secretary-count (root cause not confirmed)
  fast-repair refused: root_cause must equal its exact typed proof value
  [exit 2]

$ fm-fast-repair.sh intake fr-secretary-count (a schema change is in scope)
  fast-repair refused: schema is not explicitly proven none
  [exit 2]

$ fm-brief.sh --mode fast-repair with no eligibility record
  fast-repair refused: eligibility evidence is absent, incomplete, or no longer valid for fr-secretary-count
  error: Fast Repair brief refused because its typed eligibility evidence is absent or incomplete; use normal intake for this task
  [exit 1]

$ fm-promote.sh --mode fast-repair --yolo off (scout promotion)
  error: Fast Repair cannot promote a scout; it requires a known end-user reproduction and typed eligibility at normal intake
  [exit 1]

=== 3. Complete typed evidence is accepted ===

$ fm-fast-repair.sh intake fr-secretary-count (all facts proven, all risks none)
  fast-repair eligible: fr-secretary-count
  [exit 0]

  recorded evidence (data/fr-secretary-count/fast-repair-eligibility, mode 600):
    request=fast-repair: fix the Secretary deleted-draft count
    reproduction=reproduced
    reproduction_revision=a8d10918960cdb6c05aad8c1bab4993084922858
    lifecycle=1786433303-3632812-4053
    root_cause=confirmed
    isolation=isolated
    schema=none
    authentication=none
    authorization=none
    secrets=none
    financial=none
    legal=none
    side_effects=none

=== 4. Dispatch: the pooled task worktree gate ===

$ fm-fast-repair.sh eligible fr-secretary-count --worktree <pooled worktree>
  fast-repair eligible: fr-secretary-count
  [exit 0]
  worktree HEAD: a8d10918960cdb6c05aad8c1bab4993084922858 (detached: yes)

$ fm-fast-repair.sh eligible fr-secretary-count --worktree <another repository>
  fast-repair refused: reproduction revision is unknown or not an ancestor of the task worktree head
  [exit 2]

=== 4b. The Fast Repair brief the crewmate receives ===
  # Definition of done
  Delivery contract: mode=fast-repair
  This task is a strict Fast Repair exception and has already passed the typed eligibility record owned by `/home/kaan/.no-mistakes/worktrees/064d42a48643/01KZQP080N8FPWR1DGVE4F5SH3/bin/fm-fast-repair.sh`.
  Every command below carries that absolute helper path and firstmate's own state and data directories, because your worktree is the project's, not firstmate's; run each one verbatim from your worktree.
  Do not create a scout or run plan, design, CEO, engineering, or other extra review workflows.
  Add a new regression test that reproduces the reported defect and make the narrow repair.
  Run `FM_STATE_OVERRIDE='/tmp/no-mistakes-evidence/01KZQP080N8FPWR1DGVE4F5SH3/work/firstmate-home/state' FM_DATA_OVERRIDE='/tmp/no-mistakes-evidence/01KZQP080N8FPWR1DGVE4F5SH3/work/firstmate-home/data' '/home/kaan/.no-mistakes/worktrees/064d42a48643/01KZQP080N8FPWR1DGVE4F5SH3/bin/fm-fast-repair.sh' evidence fr-secretary-count --regression-test '<runner family>' --focused-test '<different runner family>'` through the tracked `bin/fm-test-run.sh` runner.
  It runs and records both gates, and it refuses PR publication when either result is missing or failed.
  After it passes, use `FM_STATE_OVERRIDE='/tmp/no-mistakes-evidence/01KZQP080N8FPWR1DGVE4F5SH3/work/firstmate-home/state' FM_DATA_OVERRIDE='/tmp/no-mistakes-evidence/01KZQP080N8FPWR1DGVE4F5SH3/work/firstmate-home/data' '/home/kaan/.no-mistakes/worktrees/064d42a48643/01KZQP080N8FPWR1DGVE4F5SH3/bin/fm-fast-repair.sh' publish-pr fr-secretary-count --title '<title>' --body-file <path>` to open and register the direct PR immediately.
  Then run `FM_STATE_OVERRIDE='/tmp/no-mistakes-evidence/01KZQP080N8FPWR1DGVE4F5SH3/work/firstmate-home/state' FM_DATA_OVERRIDE='/tmp/no-mistakes-evidence/01KZQP080N8FPWR1DGVE4F5SH3/work/firstmate-home/data' '/home/kaan/.no-mistakes/worktrees/064d42a48643/01KZQP080N8FPWR1DGVE4F5SH3/bin/fm-fast-repair.sh' broader fr-secretary-count --test '<runner family broader than the focused one>'` while the new PR's checks run concurrently.
  Do not call the PR ready or green until `FM_STATE_OVERRIDE='/tmp/no-mistakes-evidence/01KZQP080N8FPWR1DGVE4F5SH3/work/firstmate-home/state' FM_DATA_OVERRIDE='/tmp/no-mistakes-evidence/01KZQP080N8FPWR1DGVE4F5SH3/work/firstmate-home/data' '/home/kaan/.no-mistakes/worktrees/064d42a48643/01KZQP080N8FPWR1DGVE4F5SH3/bin/fm-fast-repair.sh' ready fr-secretary-count` passes.
  If broader tests or PR checks fail after the PR opens, append `failed: PR {url} is open but not green because {failed evidence}` and stop.
  Never enable auto-merge, and never merge the PR.
  When ready passes, append `done: PR {url} checks green` and stop for captain approval.

=== 5. The crewmate branches, adds the regression test, and makes the narrow repair ===
  regression test committed; it fails on the unrepaired module:
    FM_TEST_BEGIN 2026-08-11T07:28:24Z tests/secretary-count-regression.test.sh family=secretary-regression
    not ok - deleting 2 of 5 drafts reported 5, expected 3
    FM_TEST_END 2026-08-11T07:28:24Z tests/secretary-count-regression.test.sh exit=1 duration_ms=0 gate_skip=false
  narrow repair committed at 40074a0363a5c5417bd090e938b4d33cca7e0f40

=== 6. Durable task metadata for the dispatched Fast Repair task ===
  window=firstmate:fm-fr-secretary-count
  endpoint_task_id=fr-secretary-count
  worktree=/tmp/no-mistakes-evidence/01KZQP080N8FPWR1DGVE4F5SH3/work/task-worktree
  project=/tmp/no-mistakes-evidence/01KZQP080N8FPWR1DGVE4F5SH3/work/project
  harness=codex
  model=gpt-5.6-luna
  effort=medium
  kind=ship
  mode=fast-repair
  yolo=off
  fast_repair=eligible

=== 8. Evidence gates before the direct PR ===

  a PR before evidence:

$ fm-fast-repair.sh publish-pr fr-secretary-count (no evidence yet)
  fast-repair refused: focused evidence is absent or failed; direct PR publication is blocked
  [exit 2]

$ fm-fast-repair.sh evidence fr-secretary-count --regression-test secretary-search --focused-test secretary-suite (no new selector)
  fast-repair refused: regression-test must name one new tracked runner selector
  [exit 2]

$ fm-fast-repair.sh evidence fr-secretary-count --regression-test secretary-regression --focused-test secretary-search
  fast-repair focused evidence passed: fr-secretary-count
  [exit 0]

  evidence record (state/fr-secretary-count.fast-repair-tests):
    regression=passed
    regression_test=secretary-regression
    regression_selector=tests/secretary-count-regression.test.sh
    regression_artifact=100755:89862e53435b3d34fdf2971d749072f861002e39
    regression_runner=100755:4a0c763f0394a41eda56316e5b00a2ed1626b16c
    regression_reproduction=failed
    regression_head=passed
    focused=passed
    focused_test=secretary-search
    reproduction_revision=a8d10918960cdb6c05aad8c1bab4993084922858
    worktree=/tmp/no-mistakes-evidence/01KZQP080N8FPWR1DGVE4F5SH3/work/task-worktree
    branch=fm/fr-secretary-count
    head=40074a0363a5c5417bd090e938b4d33cca7e0f40

  executed test log (state/fr-secretary-count.fast-repair-tests.log):
    FM_TEST_BEGIN 2026-08-11T07:28:24Z tests/secretary-count-regression.test.sh family=secretary-regression
    not ok - deleting 2 of 5 drafts reported 5, expected 3
    FM_TEST_END 2026-08-11T07:28:24Z tests/secretary-count-regression.test.sh exit=1 duration_ms=0 gate_skip=false
    FM_TEST_BEGIN 2026-08-11T07:28:24Z tests/secretary-count-regression.test.sh family=secretary-regression
    ok - deleted drafts leave the search count
    FM_TEST_END 2026-08-11T07:28:24Z tests/secretary-count-regression.test.sh exit=0 duration_ms=0 gate_skip=false
    FM_TEST_BEGIN 2026-08-11T07:28:25Z tests/secretary-search.test.sh family=secretary-search
    ok - search reports every live draft
    FM_TEST_END 2026-08-11T07:28:25Z tests/secretary-search.test.sh exit=0 duration_ms=0 gate_skip=false

=== 9. The direct PR opens immediately after the focused gates ===

$ fm-fast-repair.sh publish-pr fr-secretary-count
  https://github.com/acme/secretary/pull/318
  ●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  ●  WATCHER DOWN - SUPERVISION IS OFF
  ●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: never, grace 300s).
  ●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
  ●  This is a supervision warning only; the guarded operation WILL still run.
  ●  watcher supervision needs Stop-owned automatic recovery; inspect the hook registration and startup status before ending the turn.
  ●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  fast-repair PR opened: https://github.com/acme/secretary/pull/318
  [exit 0]

  registered PR in task metadata:
    pr=https://github.com/acme/secretary/pull/318
    pr_head=40074a0363a5c5417bd090e938b4d33cca7e0f40

=== 10. Broader tests run while the PR checks are still pending ===

$ fm-fast-repair.sh ready fr-secretary-count (broader not run, checks pending)
  fast-repair refused: broader tests are not passed
  [exit 2]

$ fm-fast-repair.sh progress fr-secretary-count (checks still pending)
  [exit 0]

$ fm-fast-repair.sh broader fr-secretary-count --test secretary-search (same as focused)
  fast-repair refused: broader-test must name a supported runner family with bound artifacts that is not the focused family already proven before the PR
  [exit 2]

$ fm-fast-repair.sh broader fr-secretary-count --test secretary-suite
  fast-repair broader tests passed: fr-secretary-count
  [exit 0]

=== 11. A failing rollup is surfaced and never called ready ===

$ fm-fast-repair.sh progress fr-secretary-count (one check failed)
  fast-repair fr-secretary-count pr-checks-failed: 2 passed, 1 failed, 1 pending, 4 total
  [exit 0]

$ fm-fast-repair.sh ready fr-secretary-count (one check failed)
  fast-repair refused: PR checks are not green: 2 passed, 1 failed, 1 pending, 4 total
  [exit 2]

  a rollup where nothing passed is never green:

$ fm-fast-repair.sh ready fr-secretary-count (all checks cancelled/skipped)
  fast-repair refused: PR checks are not green: 0 passed, 0 failed, 4 skipped, 4 total
  [exit 2]

=== 12. Ready only when the broader family and every PR check pass ===

$ fm-fast-repair.sh progress fr-secretary-count (green rollup)
  fast-repair fr-secretary-count pr-checks-green: 4 passed, 0 failed, 4 total
  [exit 0]

$ fm-fast-repair.sh ready fr-secretary-count
  fast-repair ready: https://github.com/acme/secretary/pull/318 (4 passed, 0 failed, 4 total)
  [exit 0]

=== 13. Merge authority stays with the captain ===
  every forge call this whole path made:
    gh-axi pr create --title fix: Secretary deleted-draft count --body-file /tmp/no-mistakes-evidence/01KZQP080N8FPWR1DGVE4F5SH3/work/pr-body.md --head fm/fr-secretary-count
    gh-axi pr checks 318 --repo acme/secretary
    gh-axi pr checks 318 --repo acme/secretary
    gh-axi pr checks 318 --repo acme/secretary
    gh-axi pr checks 318 --repo acme/secretary
    gh-axi pr checks 318 --repo acme/secretary
    gh-axi pr checks 318 --repo acme/secretary
    gh pr view https://github.com/acme/secretary/pull/318 --json headRefOid -q .headRefOid
    gh pr view https://github.com/acme/secretary/pull/318 --json headRefOid -q .headRefOid
    gh pr view https://github.com/acme/secretary/pull/318 --json headRefOid -q .headRefOid
    gh pr view https://github.com/acme/secretary/pull/318 --json headRefOid -q .headRefOid
    gh pr view https://github.com/acme/secretary/pull/318 --json headRefOid -q .headRefOid
  merge or auto-merge calls: 0
  task yolo posture: yolo=off

=== 14. A broader failure after the PR turned green still surfaces locally ===

$ fm-fast-repair.sh progress fr-secretary-count --local-only (broader failed after green)
  fast-repair fr-secretary-count broader-tests-failed
  [exit 0]

=== done ===
```
</details>
<details>
<summary>Evidence: Reproducible driver for the end-to-end transcript</summary>

```text
#!/usr/bin/env bash
# End-to-end Fast Repair walkthrough against a realistic fixture project.
#
# It builds a small "secretary" project with a real off-by-one defect, then
# drives the shipped Fast Repair path exactly as firstmate and a crewmate would:
# refusals, typed intake, dispatch gate, brief, evidence (regression fails
# before the repair and passes at the tested head), early direct PR, concurrent
# broader family, readiness, and the merge-authority boundary.
#
# The forge is a recording fake, so nothing leaves this machine.
set -u

ROOT=${FM_SOURCE_ROOT:?set FM_SOURCE_ROOT to the firstmate checkout}
WORK=${1:?usage: demo-fast-repair-e2e.sh <work-dir>}
ID=fr-secretary-count

rm -rf "$WORK"
mkdir -p "$WORK"
PROJECT="$WORK/project"
TASKWT="$WORK/task-worktree"
HOME_DIR="$WORK/firstmate-home"
FAKEBIN="$WORK/fakebin"
FORGE="$WORK/forge"
mkdir -p "$HOME_DIR/state" "$HOME_DIR/data" "$FAKEBIN" "$FORGE"

FAST="$ROOT/bin/fm-fast-repair.sh"
BRIEF="$ROOT/bin/fm-brief.sh"
SPAWN="$ROOT/bin/fm-spawn.sh"

step() { printf '\n=== %s ===\n' "$*"; }
run() { # <label> <cmd...>
  local label=$1; shift
  printf '\n$ %s\n' "$label"
  "$@" 2>&1 | sed 's/^/  /'
  printf '  [exit %s]\n' "${PIPESTATUS[0]}"
}
fm() { # fast-repair helper with this home, called from outside the project
  ( cd "$WORK" && PATH="$FAKEBIN:$PATH" FM_HOME="$HOME_DIR" \
    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" "$FAST" "$@" )
}

########################################
# 1. The project, with the reported defect
########################################
mkdir -p "$PROJECT/lib" "$PROJECT/tests" "$PROJECT/bin"
cat > "$PROJECT/lib/search.sh" <<'SH'
#!/usr/bin/env bash
# Secretary local draft search.
search_count() { # <query> <deleted-count>
  local matches=$1 deleted=$2
  # Defect: the deleted drafts are never removed from the reported count.
  printf '%s\n' "$matches"
}
SH
cat > "$PROJECT/tests/secretary-search.test.sh" <<'SH'
#!/usr/bin/env bash
# Focused module test: search returns the raw match count when nothing is deleted.
set -u
. "$(dirname "$0")/../lib/search.sh"
[ "$(search_count 5 0)" = 5 ] || { echo "not ok - undeleted search count"; exit 1; }
echo "ok - search reports every live draft"
SH
cat > "$PROJECT/tests/secretary-suite.test.sh" <<'SH'
#!/usr/bin/env bash
# Broader suite: the module plus its neighbours.
set -u
. "$(dirname "$0")/../lib/search.sh"
[ "$(search_count 5 0)" = 5 ] || { echo "not ok - suite live count"; exit 1; }
[ "$(search_count 0 0)" = 0 ] || { echo "not ok - suite empty count"; exit 1; }
echo "ok - secretary suite"
SH
cat > "$PROJECT/bin/fm-test-run.sh" <<'SH'
#!/usr/bin/env bash
# Tracked project test runner: families, selectors, and typed markers.
set -u
family_tests() {
  case $1 in
    secretary-regression) printf '%s\n' tests/secretary-count-regression.test.sh ;;
    secretary-search) printf '%s\n' tests/secretary-search.test.sh ;;
    secretary-suite) printf '%s\n' tests/secretary-suite.test.sh ;;
    *) return 2 ;;
  esac
}
if [ "${1:-}" = --list-families ]; then
  printf '%s\n' secretary-regression secretary-search secretary-suite; exit 0
fi
if [ "${1:-}" = --list ] && [ "${2:-}" = --family ]; then family_tests "$3"; exit $?; fi
if [ "${1:-}" = --family ] && [ "$#" = 2 ]; then
  family=$2
  scripts=$(family_tests "$family") || exit 2
elif [ "$#" = 1 ]; then
  scripts=$1
  case $1 in
    tests/secretary-count-regression.test.sh) family=secretary-regression ;;
    tests/secretary-search.test.sh) family=secretary-search ;;
    tests/secretary-suite.test.sh) family=secretary-suite ;;
    *) exit 2 ;;
  esac
else
  exit 2
fi
status=0
for script in $scripts; do
  printf 'FM_TEST_BEGIN %s %s family=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$script" "$family"
  if bash "$script"; then code=0; else code=1; status=1; fi
  printf 'FM_TEST_END %s %s exit=%s duration_ms=0 gate_skip=false\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$script" "$code"
done
exit "$status"
SH
chmod +x "$PROJECT/bin/fm-test-run.sh" "$PROJECT/tests"/*.test.sh
git -C "$PROJECT" init --quiet -b main
git -C "$PROJECT" -c user.email=demo@example.com -c user.name=Demo add -A
git -C "$PROJECT" -c user.email=demo@example.com -c user.name=Demo commit --quiet -m 'secretary search with the reported count defect'
REPRO=$(git -C "$PROJECT" rev-parse HEAD)

step "1. The reproduction the captain reported, on the pre-repair commit ($REPRO)"
printf '  deleting 2 of 5 drafts still reports: %s\n' \
  "$(cd "$PROJECT" && . lib/search.sh && search_count 5 2)"
printf '  expected: 3\n'

########################################
# 2. Refusals: fail closed
########################################
step "2. Fast Repair refuses everything it cannot prove"
for request in 'fast repair: fix the count' 'Fast-repair: fix the count' 'fast-repair:'; do
  if fm is-request "$request"; then verdict="ACTIVATED"; else verdict="not a Fast Repair request"; fi
  printf '  %-32s -> %s\n' "'$request'" "$verdict"
done
if fm is-request 'fast-repair: fix the count'; then verdict="Fast Repair request"; else verdict="ACTIVATED"; fi
printf '  %-32s -> %s\n' "'fast-repair: fix the count'" "$verdict"

run "fm-fast-repair.sh intake $ID (root cause not confirmed)" \
  fm intake "$ID" --request 'fast-repair: fix the count' \
  --reproduction reproduced --reproduction-revision "$REPRO" --root-cause suspected --isolation isolated \
  --schema none --authentication none --authorization none --secrets none \
  --financial none --legal none --side-effects none
run "fm-fast-repair.sh intake $ID (a schema change is in scope)" \
  fm intake "$ID" --request 'fast-repair: fix the count' \
  --reproduction reproduced --reproduction-revision "$REPRO" --root-cause confirmed --isolation isolated \
  --schema changed --authentication none --authorization none --secrets none \
  --financial none --legal none --side-effects none
run "fm-brief.sh --mode fast-repair with no eligibility record" \
  env FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
  "$BRIEF" "$ID" secretary --mode fast-repair
run "fm-promote.sh --mode fast-repair --yolo off (scout promotion)" \
  env FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
  "$ROOT/bin/fm-promote.sh" "$ID" --mode fast-repair --yolo off

########################################
# 3. Eligible intake
########################################
step "3. Complete typed evidence is accepted"
run "fm-fast-repair.sh intake $ID (all facts proven, all risks none)" \
  fm intake "$ID" --request 'fast-repair: fix the Secretary deleted-draft count' \
  --reproduction reproduced --reproduction-revision "$REPRO" --root-cause confirmed --isolation isolated \
  --schema none --authentication none --authorization none --secrets none \
  --financial none --legal none --side-effects none
printf '\n  recorded evidence (data/%s/fast-repair-eligibility, mode %s):\n' "$ID" \
  "$(stat -c %a "$HOME_DIR/data/$ID/fast-repair-eligibility")"
sed 's/^/    /' "$HOME_DIR/data/$ID/fast-repair-eligibility"

########################################
# 4. Dispatch gate on the real task worktree
########################################
step "4. Dispatch: the pooled task worktree gate"
git -C "$PROJECT" worktree add --quiet --detach "$TASKWT" "$REPRO"
run "fm-fast-repair.sh eligible $ID --worktree <pooled worktree>" fm eligible "$ID" --worktree "$TASKWT"
printf '  worktree HEAD: %s (detached: %s)\n' "$(git -C "$TASKWT" rev-parse HEAD)" \
  "$(git -C "$TASKWT" symbolic-ref --quiet --short HEAD >/dev/null 2>&1 && echo no || echo yes)"
printf 'foreign\n' > "$WORK/foreign-file"
mkdir -p "$WORK/foreign" && git -C "$WORK/foreign" init --quiet -b main \
  && git -C "$WORK/foreign" -c user.email=d@e.f -c user.name=D commit --quiet --allow-empty -m foreign
run "fm-fast-repair.sh eligible $ID --worktree <another repository>" fm eligible "$ID" --worktree "$WORK/foreign"

step "4b. The Fast Repair brief the crewmate receives"
cat > "$HOME_DIR/data/projects.md" <<EOF
- secretary: $PROJECT (mode: no-mistakes)
EOF
( cd "$HOME_DIR" && FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
  FM_ROOT_OVERRIDE="$ROOT" "$BRIEF" "$ID" secretary --mode fast-repair >/dev/null 2>&1 ) || true
if [ -f "$HOME_DIR/data/$ID/brief.md" ]; then
  sed -n '/# Definition of done/,$p' "$HOME_DIR/data/$ID/brief.md" | sed 's/^/  /'
else
  printf '  (brief not written)\n'
fi

########################################
# 5. The crewmate's repair: regression test + narrow fix
########################################
step "5. The crewmate branches, adds the regression test, and makes the narrow repair"
git -C "$TASKWT" checkout --quiet -b "fm/$ID"
cat > "$TASKWT/tests/secretary-count-regression.test.sh" <<'SH'
#!/usr/bin/env bash
# Regression test for the reported defect: deleting drafts must reduce the count.
set -u
. "$(dirname "$0")/../lib/search.sh"
got=$(search_count 5 2)
[ "$got" = 3 ] || { echo "not ok - deleting 2 of 5 drafts reported $got, expected 3"; exit 1; }
echo "ok - deleted drafts leave the search count"
SH
chmod +x "$TASKWT/tests/secretary-count-regression.test.sh"
git -C "$TASKWT" -c user.email=crew@example.com -c user.name=Crew add -A
git -C "$TASKWT" -c user.email=crew@example.com -c user.name=Crew commit --quiet -m 'test: reproduce the Secretary deleted-draft count defect'
printf '  regression test committed; it fails on the unrepaired module:\n'
( cd "$TASKWT" && ./bin/fm-test-run.sh --family secretary-regression 2>&1 | sed 's/^/    /' )
cat > "$TASKWT/lib/search.sh" <<'SH'
#!/usr/bin/env bash
# Secretary local draft search.
search_count() { # <query> <deleted-count>
  local matches=$1 deleted=$2
  printf '%s\n' "$((matches - deleted))"
}
SH
git -C "$TASKWT" -c user.email=crew@example.com -c user.name=Crew commit --quiet -am 'fix: drop deleted drafts from the Secretary search count'
HEAD_REV=$(git -C "$TASKWT" rev-parse HEAD)
printf '  narrow repair committed at %s\n' "$HEAD_REV"

########################################
# 6. Metadata a Fast Repair spawn records
########################################
cat > "$HOME_DIR/state/$ID.meta" <<EOF
window=firstmate:fm-$ID
endpoint_task_id=$ID
worktree=$TASKWT
project=$PROJECT
harness=codex
model=gpt-5.6-luna
effort=medium
kind=ship
mode=fast-repair
yolo=off
fast_repair=eligible
EOF
step "6. Durable task metadata for the dispatched Fast Repair task"
sed 's/^/  /' "$HOME_DIR/state/$ID.meta"

########################################
# 7. The recording forge fake
########################################
cat > "$FAKEBIN/gh-axi" <<EOF
#!/usr/bin/env bash
FORGE='$FORGE'
EOF
cat >> "$FAKEBIN/gh-axi" <<'SH'
printf '%s\n' "$*" >> "$FORGE/gh-axi.args"
case "${1:-} ${2:-}" in
  "pr create") printf 'https://github.com/acme/secretary/pull/318\n' ;;
  "pr checks") cat "$FORGE/checks" ;;
  *) exit 1 ;;
esac
SH
cat > "$FAKEBIN/gh" <<EOF
#!/usr/bin/env bash
FORGE='$FORGE'
EOF
cat >> "$FAKEBIN/gh" <<'SH'
printf '%s\n' "$*" >> "$FORGE/gh.args"
case "${1:-} ${2:-}" in
  "pr view") cat "$FORGE/pr-head" ;;
  *) exit 1 ;;
esac
SH
chmod +x "$FAKEBIN/gh-axi" "$FAKEBIN/gh"
printf '%s\n' "$HEAD_REV" > "$FORGE/pr-head"
printf 'summary: "1 passed, 0 failed, 3 pending, 4 total"\n' > "$FORGE/checks"

########################################
# 8. Evidence: regression + focused before any PR
########################################
step "8. Evidence gates before the direct PR"
printf '\n  a PR before evidence:\n'
printf 'Fixes the Secretary deleted-draft count.\n' > "$WORK/pr-body.md"
run "fm-fast-repair.sh publish-pr $ID (no evidence yet)" \
  fm publish-pr "$ID" --title 'fix: Secretary deleted-draft count' --body-file "$WORK/pr-body.md"
run "fm-fast-repair.sh evidence $ID --regression-test secretary-search --focused-test secretary-suite (no new selector)" \
  fm evidence "$ID" --regression-test secretary-search --focused-test secretary-suite
run "fm-fast-repair.sh evidence $ID --regression-test secretary-regression --focused-test secretary-search" \
  fm evidence "$ID" --regression-test secretary-regression --focused-test secretary-search
printf '\n  evidence record (state/%s.fast-repair-tests):\n' "$ID"
sed 's/^/    /' "$HOME_DIR/state/$ID.fast-repair-tests"
printf '\n  executed test log (state/%s.fast-repair-tests.log):\n' "$ID"
sed 's/^/    /' "$HOME_DIR/state/$ID.fast-repair-tests.log"

########################################
# 9. The early direct PR
########################################
step "9. The direct PR opens immediately after the focused gates"
run "fm-fast-repair.sh publish-pr $ID" \
  fm publish-pr "$ID" --title 'fix: Secretary deleted-draft count' --body-file "$WORK/pr-body.md"
printf '\n  registered PR in task metadata:\n'
grep -E '^(pr|pr_head)=' "$HOME_DIR/state/$ID.meta" | sed 's/^/    /'

########################################
# 10. Broader family concurrent with PR checks
########################################
step "10. Broader tests run while the PR checks are still pending"
run "fm-fast-repair.sh ready $ID (broader not run, checks pending)" fm ready "$ID"
run "fm-fast-repair.sh progress $ID (checks still pending)" fm progress "$ID"
run "fm-fast-repair.sh broader $ID --test secretary-search (same as focused)" \
  fm broader "$ID" --test secretary-search
run "fm-fast-repair.sh broader $ID --test secretary-suite" fm broader "$ID" --test secretary-suite

########################################
# 11. Failed PR checks surface through the cadence check
########################################
step "11. A failing rollup is surfaced and never called ready"
printf 'summary: "2 passed, 1 failed, 1 pending, 4 total"\n' > "$FORGE/checks"
run "fm-fast-repair.sh progress $ID (one check failed)" fm progress "$ID"
run "fm-fast-repair.sh ready $ID (one check failed)" fm ready "$ID"
printf '\n  a rollup where nothing passed is never green:\n'
printf 'summary: "0 passed, 0 failed, 4 skipped, 4 total"\n' > "$FORGE/checks"
run "fm-fast-repair.sh ready $ID (all checks cancelled/skipped)" fm ready "$ID"

########################################
# 12. Ready
########################################
step "12. Ready only when the broader family and every PR check pass"
printf 'summary: "4 passed, 0 failed, 4 total"\n' > "$FORGE/checks"
run "fm-fast-repair.sh progress $ID (green rollup)" fm progress "$ID"
run "fm-fast-repair.sh ready $ID" fm ready "$ID"

########################################
# 13. Merge authority
########################################
step "13. Merge authority stays with the captain"
printf '  every forge call this whole path made:\n'
sed 's/^/    gh-axi /' "$FORGE/gh-axi.args"
sed 's/^/    gh /' "$FORGE/gh.args"
printf '  merge or auto-merge calls: %s\n' \
  "$(grep -cE 'merge' "$FORGE/gh-axi.args" "$FORGE/gh.args" | awk -F: '{s+=$2} END {print s+0}')"
printf '  task yolo posture: %s\n' "$(grep '^yolo=' "$HOME_DIR/state/$ID.meta")"

########################################
# 14. Broader failure after a green rollup
########################################
step "14. A broader failure after the PR turned green still surfaces locally"
printf 'broken\n' > "$TASKWT/lib/search.sh"
cat > "$TASKWT/lib/search.sh" <<'SH'
#!/usr/bin/env bash
search_count() { printf '%s\n' "$(( $1 - $2 ))"; }
SH
git -C "$TASKWT" -c user.email=crew@example.com -c user.name=Crew commit --quiet -am 'refactor: inline the count helper'
printf 'broader=failed\nbroader_test=secretary-suite\n' > "$HOME_DIR/state/$ID.fast-repair-broader"
run "fm-fast-repair.sh progress $ID --local-only (broader failed after green)" fm progress "$ID" --local-only

step "done"
```
</details>
<details>
<summary>Evidence: 20-second Fast Repair cadence from the real watcher, with the ordinary task for contrast</summary>

<code>shipped default in bin/fm-watch.sh: FAST_REPAIR_PROGRESS_INTERVAL=${FM_FAST_REPAIR_PROGRESS_INTERVAL:-20} # Fast Repair only&#10;&#10;=== eligible Fast Repair task ===&#10;forge polls made by the watcher in 75s (FM_POLL=600, no interval override):&#10;07:37:11 pr checks 318 --repo acme/secretary&#10;07:37:31 pr checks 318 --repo acme/secretary (+20s since the previous beat)&#10;07:37:51 pr checks 318 --repo acme/secretary (+20s since the previous beat)&#10;&#10;=== ordinary no-mistakes task (same watcher, same knobs) ===&#10;forge polls made by the watcher in 75s (FM_POLL=600, no interval override):&#10;(none)&#10;&#10;fast-repair cadence state files written for the ordinary task: 0&#10;fast-repair cadence state files written for the Fast Repair task: 3</code>

```text
shipped default in bin/fm-watch.sh: FAST_REPAIR_PROGRESS_INTERVAL=${FM_FAST_REPAIR_PROGRESS_INTERVAL:-20} # Fast Repair only

=== eligible Fast Repair task ===
forge polls made by the watcher in 75s (FM_POLL=600, no interval override):
  07:37:11  pr checks 318 --repo acme/secretary
  07:37:31  pr checks 318 --repo acme/secretary   (+20s since the previous beat)
  07:37:51  pr checks 318 --repo acme/secretary   (+20s since the previous beat)

=== ordinary no-mistakes task (same watcher, same knobs) ===
forge polls made by the watcher in 75s (FM_POLL=600, no interval override):
  (none)

fast-repair cadence state files written for the ordinary task: 0
fast-repair cadence state files written for the Fast Repair task: 3
```
</details>
- Evidence: Reproducible driver for the cadence measurement (local file: <code>/tmp/no-mistakes-evidence/01KZQP080N8FPWR1DGVE4F5SH3/demo-fast-repair-cadence.sh</code>)
<details>
<summary>Evidence: Regression proof recorded by the evidence gate: the same selector fails at the reproduction revision and passes at the tested head</summary>

```text
regression=passed
regression_test=secretary-regression
regression_selector=tests/secretary-count-regression.test.sh
regression_reproduction=failed
regression_head=passed
focused=passed
focused_test=secretary-search
branch=fm/fr-secretary-count
---
FM_TEST_BEGIN tests/secretary-count-regression.test.sh family=secretary-regression
not ok - deleting 2 of 5 drafts reported 5, expected 3
FM_TEST_END tests/secretary-count-regression.test.sh exit=1 gate_skip=false
FM_TEST_BEGIN tests/secretary-count-regression.test.sh family=secretary-regression
ok - deleted drafts leave the search count
FM_TEST_END tests/secretary-count-regression.test.sh exit=0 gate_skip=false
```
</details>
<details>
<summary>Evidence: Dispatch, relaunch, teardown, and delivery test run (Fast Repair profile, relaunch, and teardown scoping assertions)</summary>

Source: Dispatch, relaunch, teardown, and delivery test run (Fast Repair profile, relaunch, and teardown scoping assertions) (local file: <code>/tmp/no-mistakes-evidence/01KZQP080N8FPWR1DGVE4F5SH3/dispatch-lifecycle-tests.log</code>)

```text
ok - Fast Repair enforces Codex Luna medium without changing ordinary dispatch profiles
ok - fm-spawn --relaunch: a Fast Repair task reuses its recorded profile with no flags
ok - fm-spawn --relaunch: a Fast Repair recovery keeps unlanded work but still requires its authorization
ok - Fast Repair progress cleanup removes only the torn-down task's artifacts, never a hyphenated sibling's
FM_TEST_SUMMARY total=4 failed=0 skipped_gate=0 duration_ms=182613
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- 🚨 `bin/fm-watch.sh:787` - fast_repair_progress_timer_tasks_finish expands empty arrays unguarded under `set -u`: `for pid in &#34;${pids[@]}&#34;` (lines 787 and 794) and `for marker in &#34;${markers[@]}&#34;` (line 797). On bash &lt; 4.4 - including macOS&#39;s system bash 3.2, which this repo explicitly supports (see the comments at bin/fm-classify-lib.sh:198 and bin/fm-timing-lib.sh:55, and the `&#34;${arr[@]+&#34;${arr[@]}&#34;}&#34;` idiom used ~20 times in bin/fm-test-run.sh, bin/fm-spawn.sh, bin/fm-pr-merge.sh) - expanding an empty array with `set -u` active aborts the shell with `pids[@]: unbound variable`. Failure sequence: a Fast Repair task records mode=fast-repair/fast_repair=eligible, so fast_repair_progress_timer_start arms a generation every supervision cycle; at the end of the cycle fast_repair_progress_timer_finish (bin/fm-watch.sh:1184) calls fast_repair_progress_timer_tasks_finish with that generation. With POLL=15 and FM_FAST_REPAIR_PROGRESS_INTERVAL=20 most cycles have no live progress child for the generation (and a completed child removes its own marker via its EXIT trap at line 826), so both arrays are empty and the watcher exits at line 787 instead of finishing the cycle. Same crash reaches watcher_cleanup&#39;s EXIT trap. CI on bash 5.x never sees it. Fix mechanically with the repo&#39;s existing idiom: `for pid in &#34;${pids[@]+&#34;${pids[@]}&#34;}&#34;` and likewise for markers, or return early when `[ &#34;${#pids[@]}&#34; -eq 0 ]`.
- ⚠️ `bin/fm-spawn.sh:2258` - The dispatch-time reproduction proof `&#34;$SCRIPT_DIR/fm-fast-repair.sh&#34; eligible &#34;$ID&#34; --worktree &#34;$WT&#34;` is guarded only by `[ &#34;$KIND&#34; = ship ] &amp;&amp; [ &#34;$MODE&#34; = fast-repair ]`, not by `[ &#34;$RELAUNCH&#34; -eq 0 ]`, and the relaunch branch at bin/fm-spawn.sh:2188 falls through to it. That gate calls task_head_at_worktree, which requires task_worktree_clean (bin/fm-fast-repair.sh:95-108, `git status --porcelain --untracked-files=all` must be empty). Failure sequence: a Fast Repair crewmate creates fm/&lt;id&gt;, edits files, and wedges before committing (or commits and keeps editing); firstmate runs the documented recovery `fm-spawn.sh &lt;id&gt; --relaunch`; line 2258 refuses with &#34;Fast Repair spawn refused because its reproduction revision is not proven for the task worktree&#34; purely because the worktree is dirty, so the stuck crewmate cannot be replaced. This defeats the purpose of the relaunch profile-reuse block added at bin/fm-spawn.sh:1009 (&#34;Without this the standard stuck-crewmate recovery is refused by the profile gate below&#34;) and contradicts docs/agent-control.md, where the relaunch checkpoint records the worktree&#39;s dirty state rather than refusing on it. tests/fm-control-relaunch.test.sh:774 only exercises a clean worktree, so the case is uncovered. Whether the right resolution is to skip the --worktree proof on relaunch (the branch/head proofs in evidence/publish-pr/broader/ready already cover the tested head) or to accept a dirty worktree here is a product call, so please confirm the intended behavior.
- ⚠️ `bin/fm-fast-repair.sh:343` - bin/fm-fast-repair.sh installs no EXIT/signal trap, so two temporary artifacts leak whenever an evidence run is interrupted. regression_witness_valid creates `$STATE/.fast-repair-reproduction.XXXXXX` and fills it with `git clone --no-hardlinks` of the whole task repository (line 345); run_typed creates `$STATE/.fast-repair-test-output.XXXXXX` (line 304). Both are removed only on the normal success and failure returns. Failure sequence: the crewmate&#39;s `evidence` command runs the regression witness (a full object copy of the project, potentially hundreds of MB) and the crewmate or its pane is killed, or the run is Ctrl-C&#39;d, while the overlaid selector is executing; `set -eu` with no trap means the sandbox clone survives in firstmate&#39;s state directory. Neither name carries the task id, so the per-task cleanup added in bin/fm-teardown.sh:2542-2550 cannot target them and they are never reclaimed - repeated interrupted attempts accumulate full repo clones under $STATE. Add a trap that removes the current sandbox and output temp on EXIT/HUP/INT/TERM (or name them with the task id so teardown&#39;s existing globs reach them).
- ℹ️ `bin/fm-watch.sh:1180` - fast_repair_progress_timer_finish creates `$marker.closing` at line 1180, but the only thing that removes it is the timer subshell&#39;s EXIT trap at line 1151 (`trap &#39;rm -f &#34;$closing&#34;&#39; EXIT`). When the subshell has already exited on its own before line 1180 runs, the parent creates a file nobody deletes. Reachable paths inside the subshell loop: `[ &#34;$FAST_REPAIR_ACTIVE&#34; = 1 ] || rm -f &#34;$marker&#34;` followed by `[ -f &#34;$marker&#34; ] || exit 0` (fires once per task when the beat retires after the broader result is surfaced), the WATCH_LOCK/pid mismatch exit at line 1154, and the invalid-delay exit at line 1163. `fast_repair_progress_timer_finish` then reaches line 1180 with the pid already dead, so its `kill -0` guard skips the TERM that would have run the trap. The result is a stray zero-byte `$STATE/.fast-repair-progress-timer.XXXXXX.closing` per occurrence; it carries no task id, so bin/fm-teardown.sh&#39;s Fast Repair cleanup globs cannot reach it. Add `rm -f &#34;$marker.closing&#34;` after the pid reap in fast_repair_progress_timer_finish.
- ℹ️ `bin/fm-fast-repair.sh:199` - reproduction_revision_valid accepts only a 40-character lowercase hex string, while the shared forge validator fm_pr_head_valid (bin/fm-pr-lib.sh:210) accepts 40 or 64 hex characters for exactly the same kind of identity. On a SHA-256 object-format repository `git rev-parse HEAD` yields 64 characters, so `intake` refuses with &#34;reproduction-revision must be a lowercase commit SHA&#34; and Fast Repair is unavailable for that project. This fails closed (the request falls back to normal intake), and docs/fast-repair.md does not promise SHA-256 support, so no behavior is wrong today - noting it only because the two validators for the same concept now disagree, and matching fm_pr_head_valid&#39;s `^[0-9a-f]{40}$|^[0-9a-f]{64}$` would remove the divergence.

🔧 Fix: Fix Fast Repair array, relaunch, temp, and id gates
3 issues (1 warning, 2 infos) still open:
- ⚠️ `bin/fm-teardown.sh:2548` - The three new cleanup globs `rm -rf &#34;$STATE/.fast-repair-progress-handoff-$ID-&#34;*`, `&#34;...-sequence-$ID-&#34;*`, and `&#34;...-child-$ID-&#34;*` (lines 2548-2550) match another task&#39;s files whenever that task&#39;s id begins with `$ID-`. Task ids allow hyphens (fm_task_id_path_safe at bin/fm-pr-lib.sh:93 accepts `[A-Za-z0-9._-]`), and the per-task names are `.fast-repair-progress-child-&lt;id&gt;-&lt;generation&gt;` (bin/fm-watch.sh:756) and `.fast-repair-progress-handoff-&lt;id&gt;-&lt;generation&gt;-&lt;seq&gt;` (bin/fm-watch.sh:920). Failure sequence: tasks `fix` and `fix-2` are both eligible Fast Repairs; `fix-2`&#39;s progress child is live under generation 7, so `$STATE/.fast-repair-progress-child-fix-2-7` holds its pid. Teardown of `fix` globs `.fast-repair-progress-child-fix-`* and removes that marker. `fast_repair_progress_timer_tasks_finish` (bin/fm-watch.sh:766) then finds no marker for `fix-2`, so it never TERMs that child and its `run_check_capture` forge call outlives the poll boundary with its process group unstopped; `fast_repair_progress_task_running` also now reads false, so `fast_repair_progress_tick` forks a second child for the same task and generation. The same glob drops `fix-2`&#39;s not-yet-drained handoff records. Fix by validating the suffix instead of trusting the glob, e.g. iterate the glob and skip any match whose remainder after stripping `$ID-` is not all digits (child/sequence) or not `&lt;digits&gt;-&lt;digits&gt;` (handoff).
- ℹ️ `bin/fm-watch.sh:820` - In `fast_repair_progress_task_start`, the pre-fork early return at lines 820-823 does `rm -f &#34;$reservation&#34;` but leaves `$reservation.closing` behind. Every sibling path does clean it: the mv-failure branch at line 858 removes `&#34;$reservation&#34; &#34;$reservation.closing&#34;`, and the forked child&#39;s EXIT trap at line 826 removes it too. Reachable sequence: the timer child creates `$reservation` (line 815 mv), the watcher parent&#39;s `fast_repair_progress_timer_tasks_finish` sees that regular file and writes `$reservation.closing` before removing the reservation (bin/fm-watch.sh:770-772), then the timer child reaches line 820, sees `.closing`, and returns 0 without a fork - so nothing ever removes it. The result is one zero-byte `$STATE/.fast-repair-progress-child-&lt;id&gt;-&lt;generation&gt;.starting.closing` per occurrence, accumulating one per affected generation until the task is torn down. It does carry the task id, so bin/fm-teardown.sh:2550 eventually reclaims it; the gap is only that the reservation&#39;s own owner does not. Add `rm -f &#34;$reservation.closing&#34;` alongside the existing `rm -f &#34;$reservation&#34;` at line 821.
- ℹ️ `tests/fm-watch-triage.test.sh:2595` - `test_fast_repair_timer_sweep_survives_an_empty_generation` guards the error-severity `set -u` empty-array regression, but its only leg that can actually reproduce that failure is the `if legacy=$(legacy_empty_array_bash); then` branch at line 2595. `legacy_empty_array_bash` (line 2553) probes FM_TEST_LEGACY_BASH, /bin/bash, /usr/bin/bash, /usr/local/bin/bash, and /opt/homebrew/bin/bash for a version in 1.x-4.3 and returns 1 when none exists, so on any Linux CI host with only bash 5.x the legacy leg never runs and the remaining modern-bash leg passes identically with or without the `&#34;${pids[@]+&#34;${pids[@]}&#34;}&#34;` guards at bin/fm-watch.sh:787,794,797. The skip is also silent - no notice is printed - so the coverage gap is invisible in the run output. The modern leg still has value (it proves the sweep returns on an empty generation and reaps a pidless marker), and there is no way to make bash 5 fail this way, so this is a note rather than a defect: print a visible skip notice when no legacy interpreter is found, so the run records that the bash 3.2 half of the regression was not exercised.

🔧 Fix: Scope Fast Repair teardown and reservation cleanup
1 info still open:
- ℹ️ `bin/fm-teardown.sh:769` - `fast_repair_artifact_fields_match` hand-rolls a generic N-field numeric parser (peel the maximal digit run with `${rest%%[!0-9]*}`, require a `-` between fields, then accept an empty or dot-prefixed remainder) to decide whether a globbed path belongs to `$ID`. I verified it is correct in both collision directions for all three prefixes and every suffix the watcher&#39;s writers append, and `tests/fm-teardown.test.sh:895` covers it. The note is only that the two shapes it actually serves have a one-line form each - `[[ $rest =~ ^[0-9]+(\..*)?$ ]]` for the child and sequence records and `[[ $rest =~ ^[0-9]+-[0-9]+(\..*)?$ ]]` for handoffs - which is provably equivalent (both accept a trailing `.` with nothing after it) and much cheaper to audit on a path whose only action is `rm -rf`. The repo already uses `[[ =~ ]]` for exactly this kind of shape check (bin/fm-watch.sh:596, bin/fm-pr-lib.sh:213). No action needed; recorded because this is newly added pipeline-authored code guarding a destructive removal, so the reviewer&#39;s cost of re-proving it recurs.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-test-run.sh tests/fm-fast-repair.test.sh` — 20 assertions, exit 0</code>
- <code>`bin/fm-test-run.sh tests/fm-watch-triage.test.sh tests/fm-supervision-events.test.sh` — full watcher triage plus the Fast Repair cadence, timer, retirement, and unchanged-normal supervision assertions, exit 0</code>
- <code>`bin/fm-test-run.sh tests/fm-spawn-dispatch-profile.test.sh tests/fm-control-relaunch.test.sh tests/fm-teardown.test.sh tests/fm-task-delivery.test.sh` — exit 0, including `ok - Fast Repair enforces Codex Luna medium without changing ordinary dispatch profiles`, both relaunch assertions, and the teardown sibling-scoping assertion</code>
- <code>`bin/fm-test-run.sh tests/fm-brief.test.sh tests/fm-documentation-audiences.test.sh` — exit 0 (brief scaffolds and documented-surface ownership)</code>
- <code>Manual end-to-end walkthrough: `/tmp/no-mistakes-evidence/01KZQP080N8FPWR1DGVE4F5SH3/demo-fast-repair-e2e.sh` — fixture project with a real off-by-one defect driven through `fm-fast-repair.sh is-request/intake/eligible/evidence/publish-pr/broader/progress/ready`, `fm-brief.sh --mode fast-repair`, and `fm-promote.sh --mode fast-repair`, with a recording `gh-axi`/`gh` fake</code>
- <code>Manual cadence measurement: `/tmp/no-mistakes-evidence/01KZQP080N8FPWR1DGVE4F5SH3/demo-fast-repair-cadence.sh` — real `bin/fm-watch.sh`, no `FM_FAST_REPAIR_PROGRESS_INTERVAL` override, `FM_POLL=600`, `FM_CHECK_INTERVAL=999999`, run once for an eligible Fast Repair task and once for an ordinary no-mistakes task</code>
- <code>Regression-before-fix check inside the demo: `./bin/fm-test-run.sh --family secretary-regression` fails on the unrepaired module (`exit=1`) and passes at the repaired head (`exit=0`), both recorded in the evidence log</code>
- <code>Reviewed the poll-wait diff to confirm the no-Fast-Repair path is still a plain `sleep`, so ordinary watcher signal timing is unchanged</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/fm-test-portable-shards.md:73` - docs/fm-test-portable-shards.md lists per-shard script counts (15/18/17/19) that no longer match the derived lanes (now 24/27/25/27). This change adds tests/fm-fast-repair.test.sh, which lands in portable-serial by derivation and shifts one count, but the table was already stale by ~35 scripts added since its 2026-08-02 measurement. Refreshing it correctly needs the timing artifacts from a green CI run per the procedure the doc itself documents, so it is a follow-up rather than an edit here.

🔧 Fix: Refresh derived portable-serial shard counts and estimates
1 info still open:
- ℹ️ `docs/fm-test-portable-shards.md:75` - The per-shard count and estimated-duration table is still hand-maintained, so it can silently drift again the next time a test is added. I refreshed the numbers and added the local rederive command, but no deterministic check enforces them. Fully removing the manual table is not safe: bin/fm-test-run.sh has no flag that prints per-shard estimated duration, and that column is the stated basis for the 15-minute portable-serial CI timeout. Closing this properly needs a runner flag (e.g. --list-shard-plan emitting shard/count/estimated_ms) plus a test asserting the doc table matches it - both executable and test changes, which this documentation-only phase must not make. Proposed as a follow-up.

🔧 Fix: Derive portable shard table from runner and guard drift
1 info still open:
- ℹ️ `bin/fm-test-run.sh:502` - Per the round 2 user instruction I added executable and test changes from this documentation phase: a new inspection-only --list-shard-plan flag in bin/fm-test-run.sh and two regression tests in tests/fm-test-run.test.sh. This is outside the phase&#39;s default documentation-only rule, so the outer executor should route these files through the normal review and test phases. No runtime behavior changed: the flag only prints the existing derivation and exits 0, and lane assignment, PORTABLE_SERIAL_SHARDS, timeout values, and Fast Repair scope are untouched.

🔧 Fix: Verify Fast Repair and shard docs; no edits needed
1 info still open:
- ℹ️ `bin/fm-test-run.sh:502` - Commit 0cf315f (authored by this documentation phase at the round-2 user instruction) contains executable and test changes that this phase cannot route to review or test itself: the inspection-only --list-shard-plan flag in bin/fm-test-run.sh (header contract at lines 31-37, list_portable_serial_shard_plan at 502-528, arg parsing at 1311-1314, dispatch at 1383-1386) and two regression tests in tests/fm-test-run.test.sh (test_shard_plan_matches_documented_table, test_parallel_lane_table_matches_proof_durations). The outer executor owns the review and test phases, so it must run the final current-code revision through them before push. This round I made no edits and only re-verified: git status is clean, tests/fm-test-run.test.sh passes 19/19, --list-shard-plan reproduces the published table exactly (24/455937, 27/455940, 25/455948, 27/455937, imbalance 11 ms), bin/fm-doc-audience-check.sh and tests/fm-documentation-audiences.test.sh pass, and bin/fm-lint.sh exits 0 for both touched scripts. No runtime shard behavior changed: the flag prints the existing derivation and exits 0, and lane assignment, PORTABLE_SERIAL_SHARDS, the 10/15/40-minute timeouts, and Fast Repair scope are untouched. Do not revert the deterministic guard to close this.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
