### PR TITLE
fix: allow explicit home for watcher commands

### DIFF
--- a/bin/fm-arm-command-policy.mjs
+++ b/bin/fm-arm-command-policy.mjs
@@ -382,6 +382,7 @@ export class Lexer {
         continue;
       }
       if (char === "$") word.literal = false;
+      if (char === "~" && (word.value === "" || /[=:]$/.test(word.value))) word.unquotedExpansion = true;
       if ("*?[]{}".includes(char)) word.unquotedExpansion = true;
       word.value += char;
       this.index += 1;
@@ -868,7 +869,7 @@ function explicitHomePrefixAllowed(position) {
   if (position.prefixAssignments === 0) return true;
   if (position.prefixAssignments !== 1) return false;
   const assignment = position.words[0];
-  return assignment.literal && /^FM_HOME=.+/.test(assignment.value);
+  return assignment.literal && !assignment.unquotedExpansion && /^FM_HOME=.+/.test(assignment.value);
 }
 
 function setupKind(info, context) {

--- a/bin/fm-arm-command-policy.mjs
+++ b/bin/fm-arm-command-policy.mjs
@@ -864,6 +864,13 @@ function ordinaryWordsOnly(tokens) {
   return tokens.every((token) => token.type === "word" && token.subs.length === 0);
 }
 
+function explicitHomePrefixAllowed(position) {
+  if (position.prefixAssignments === 0) return true;
+  if (position.prefixAssignments !== 1) return false;
+  const assignment = position.words[0];
+  return assignment.literal && /^FM_HOME=.+/.test(assignment.value);
+}
+
 function setupKind(info, context) {
   const { tokens, position } = info;
   if (!ordinaryWordsOnly(tokens) || position.prefixAssignments > 0 || position.wrappers.length > 0) return "";
@@ -877,7 +884,7 @@ function setupKind(info, context) {
 
 function finalProtectedAllowed(info) {
   if (!info.protectedKind || info.protectedKind === "watch" || info.redirection || info.substitution) return false;
-  if (!ordinaryWordsOnly(info.tokens) || info.position.prefixAssignments > 0) return false;
+  if (!ordinaryWordsOnly(info.tokens) || !explicitHomePrefixAllowed(info.position)) return false;
   const wrappers = info.position.wrappers;
   return wrappers.length === 0 || (wrappers.length === 1 && wrappers[0] === "exec");
 }

--- a/docs/arm-pretool-check.md
+++ b/docs/arm-pretool-check.md
@@ -107,9 +107,10 @@ Approved nodes may be separated by `;`, a real newline, or `&&`.
 
 The final protected node may have one immediate `exec` wrapper.
 Its arguments are ordinary shell words and may contain quoted semicolons or watcher names.
+The final protected node may also begin with exactly one non-empty, literal `FM_HOME=<path>` assignment so an operator can override a stale inherited home for that arm or checkpoint call.
 No other wrapper is approved.
 
-Inline environment assignments, `env`, `sudo`, `nohup`, nested shells, `eval`, subshell groups, substitutions, redirections, pipelines, asynchronous lists, `disown`, unrelated list nodes, and unsupported compound syntax are not blessed.
+Other inline environment assignments, empty or expanded `FM_HOME` assignments, `env`, `sudo`, `nohup`, nested shells, `eval`, subshell groups, substitutions, redirections, pipelines, asynchronous lists, `disown`, unrelated list nodes, and unsupported compound syntax are not blessed.
 
 ## Broad watcher kills
 

--- a/tests/fm-arm-pretool-check.test.sh
+++ b/tests/fm-arm-pretool-check.test.sh
@@ -142,6 +142,8 @@ matrix_case E16 allow '~/firstmate/bin/fm-watch-checkpoint.sh --seconds 180'
 matrix_case E17 allow 'for f in 1; do echo fm-watch; done'
 matrix_case E18 deny 'OTHER_HOME=/tmp bin/fm-watch-arm.sh'
 matrix_case E19 deny 'FM_HOME= bin/fm-watch-arm.sh'
+matrix_case E20 deny 'FM_HOME=~/sibling bin/fm-watch-arm.sh'
+matrix_case E21 allow "FM_HOME='~/sibling' bin/fm-watch-arm.sh"
 
 MATRIX_TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-arm-policy-matrix.XXXXXX")
 FM_TEST_CLEANUP_DIRS+=("$MATRIX_TMP")

--- a/tests/fm-arm-pretool-check.test.sh
+++ b/tests/fm-arm-pretool-check.test.sh
@@ -127,7 +127,7 @@ matrix_case E01 allow "bin/fm-watch-checkpoint.sh --seconds '180;still-one-arg'"
 matrix_case E02 allow "bin/fm-watch-checkpoint.sh --label 'fm-watch-arm.sh; literal argument'"
 matrix_case E03 allow 'bin/fm-watch-arm.sh # output > file &'
 matrix_case E04 allow $'# setup comment with fm-watch.sh; && >\nsource "config/x-mode.env"\nbin/fm-watch-checkpoint.sh --seconds 180'
-matrix_case E05 deny "FM_HOME=$ROOT bin/fm-watch-checkpoint.sh --seconds 180"
+matrix_case E05 allow "FM_HOME=$ROOT bin/fm-watch-checkpoint.sh --seconds 180"
 matrix_case E06 deny "env FM_HOME=$ROOT bin/fm-watch-arm.sh"
 matrix_case E07 deny "source '/tmp/not-firstmate/config/x-mode.env'; bin/fm-watch-checkpoint.sh --seconds 180"
 matrix_case E08 deny "bash -lc 'bin/fm-watch-checkpoint.sh --seconds 180'"
@@ -140,6 +140,8 @@ matrix_case E14 allow '$FM_HOME/bin/fm-teardown.sh &'
 matrix_case E15 allow '$FM_HOME/bin/fm-watch-arm.sh'
 matrix_case E16 allow '~/firstmate/bin/fm-watch-checkpoint.sh --seconds 180'
 matrix_case E17 allow 'for f in 1; do echo fm-watch; done'
+matrix_case E18 deny 'OTHER_HOME=/tmp bin/fm-watch-arm.sh'
+matrix_case E19 deny 'FM_HOME= bin/fm-watch-arm.sh'
 
 MATRIX_TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-arm-policy-matrix.XXXXXX")
 FM_TEST_CLEANUP_DIRS+=("$MATRIX_TMP")


### PR DESCRIPTION
## Intent

Fix #2002 so non-pane shells do not remain unarmable when they must override a sibling home's inherited `FM_HOME`. Permit exactly one non-empty literal `FM_HOME=<path>` prefix on the final watcher arm or checkpoint command while preserving every other watcher safety denial and unrelated behavior.

Closes #2002

## What Changed

- Allow exactly one non-empty literal `FM_HOME=<path>` prefix for a final `fm-watch-arm.sh` or `fm-watch-checkpoint.sh` invocation.
- Reject unquoted tilde-prefixed values because Bash expands them before execution.
- Preserve wholly quoted literal tilde paths, while intentionally rejecting mixed quoted/unquoted tilde prefixes.
- Add behavioral regression coverage across all supported hook transports and document the narrow exception.

## Reproduction

Before the fix, a scratch non-pane shell with an inherited sibling `FM_HOME` could not safely arm the intended home: the explicit command `FM_HOME=<intended-home> bin/fm-watch-checkpoint.sh --seconds 180` was rejected as `watcher-nested`. The new E05 behavioral case failed before the implementation and passed afterward across Codex, Claude, Grok, OpenCode, and Pi hook transports.

Manual post-fix scratch verification showed the explicit-home checkpoint command exiting 0 with no stdout or stderr through all five transports. Representative unrelated safety violations remained denied, including empty or alternate assignments, unquoted tilde expansion, background execution, pipelines, and redirection.

## Decisions

- Firstmate directed the narrow follow-up fix to reject unquoted tilde expansion while preserving wholly quoted literal `FM_HOME` paths, with focused failing-before/passing-after coverage and no general shell-parser redesign.
- Firstmate, under delegated routine authority, declined compatibility for mixed quoted/unquoted tilde prefixes. Therefore values such as `FM_HOME=~'user'/firstmate` remain denied; only wholly quoted literal tilde paths are preserved.

## Validation

- `tests/fm-arm-pretool-check.test.sh` passed, including the cross-transport behavioral matrix and focused tilde-prefix cases.
- Manual executable-hook verification passed for the explicit-home checkpoint command through all five supported transports.
- The full repository suite at the feature head reported ten failures outside the touched suite. The same ten failure suites reproduced at merge-base `7f051002`; the historical control additionally exposed two remote-worker timing failures and a longer watcher-lock hang. These results are pre-existing and outside this change's scope.
- Browser validation is not applicable because this repository has no browser-facing surface.
- Cypress was not run; this repository has no Cypress suite.
- No database is involved.

## Risk

The change is limited to the watcher arm/checkpoint command policy and its behavioral tests. Other assignments, shell composition, and watcher safety boundaries remain denied as before.