### PR TITLE
feat(pi): add Codex quota statusline

### DIFF
--- a/.pi/extensions/fm-quota-statusline.ts
+++ b/.pi/extensions/fm-quota-statusline.ts
@@ -18,7 +18,7 @@
 //
 // Refresh triggers: session start, model/thinking-level change, the
 // `/statusline refresh` command, and a bounded periodic timer (5 minutes). The
-// timer and the in-flight refresh guard are cleared on session shutdown.
+// timer is cleared and in-flight results are invalidated on session shutdown.
 //
 // Rendering is owned by ./lib/fm-quota-statusline-render.ts and is ANSI
 // visible-width safe and narrow-terminal aware.
@@ -28,6 +28,7 @@ import type { TUI, Theme } from "@earendil-works/pi-tui";
 import type { ReadonlyFooterDataProvider } from "@earendil-works/pi-coding-agent";
 import {
 	extractWindows,
+	getProviderQuotaStatus,
 	parseQuotaJson,
 	type QuotaFetchStatus,
 	type QuotaWindow,
@@ -69,21 +70,28 @@ export default function (pi: ExtensionAPI) {
 	let windows: QuotaWindow[] = [];
 	let quotaStatus: QuotaFetchStatus = "unavailable";
 	let refreshInFlight = false;
+	let pendingRefreshCtx: ExtensionContext | undefined;
+	let lifecycleGeneration = 0;
 	let periodicTimer: ReturnType<typeof setTimeout> | undefined;
 	let footerRef: { invalidate(): void } | undefined;
 
 	const refreshQuota = async (ctx: ExtensionContext): Promise<void> => {
 		if (refreshInFlight) {
+			pendingRefreshCtx = ctx;
 			return;
 		}
 		refreshInFlight = true;
+		const refreshGeneration = lifecycleGeneration;
 		try {
 			const result = await pi.exec(
 				"quota-axi",
 				["--provider", QUOTA_PROVIDER, "--json"],
 				{ timeout: REFRESH_TIMEOUT_MS, cwd: ctx.cwd },
 			);
-			if (result.killed || (result.code !== 0 && !result.stdout)) {
+			if (refreshGeneration !== lifecycleGeneration) {
+				return;
+			}
+			if (result.killed || result.code !== 0) {
 				markStaleOrUnavailable();
 				return;
 			}
@@ -93,12 +101,21 @@ export default function (pi: ExtensionAPI) {
 				return;
 			}
 			windows = extractWindows(parsed, QUOTA_PROVIDER);
-			quotaStatus = windows.length > 0 ? "fresh" : "unavailable";
+			quotaStatus = getProviderQuotaStatus(parsed, QUOTA_PROVIDER);
 		} catch {
-			markStaleOrUnavailable();
+			if (refreshGeneration === lifecycleGeneration) {
+				markStaleOrUnavailable();
+			}
 		} finally {
 			refreshInFlight = false;
-			footerRef?.invalidate();
+			if (refreshGeneration === lifecycleGeneration) {
+				footerRef?.invalidate();
+			}
+			const queuedCtx = pendingRefreshCtx;
+			pendingRefreshCtx = undefined;
+			if (queuedCtx) {
+				void refreshQuota(queuedCtx);
+			}
 		}
 	};
 
@@ -206,16 +223,19 @@ export default function (pi: ExtensionAPI) {
 				return;
 			}
 			if (sub === "refresh") {
-				if (!enabled) {
-					enableCustomFooter(ctx);
-					ensurePeriodicTimer(ctx);
-				} else {
-					void refreshQuota(ctx);
-				}
+				void refreshQuota(ctx);
 				ctx.ui.notify("Refreshing Codex quota data", "info");
 				return;
 			}
-			if (sub === "on" || sub === "") {
+			if (sub === "on") {
+				if (!enabled) {
+					enableCustomFooter(ctx);
+					ensurePeriodicTimer(ctx);
+					ctx.ui.notify("Statusline footer enabled", "info");
+				}
+				return;
+			}
+			if (sub === "") {
 				if (enabled) {
 					restoreStockFooter(ctx);
 					ctx.ui.notify("Stock footer restored", "info");
@@ -253,6 +273,7 @@ export default function (pi: ExtensionAPI) {
 	pi.on("thinking_level_select", (_event, ctx) => {
 		latestCtx = ctx;
 		if (enabled) {
+			void refreshQuota(ctx);
 			footerRef?.invalidate();
 		}
 	});
@@ -265,8 +286,9 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.on("session_shutdown", () => {
+		lifecycleGeneration += 1;
+		pendingRefreshCtx = undefined;
 		clearPeriodicTimer();
 		footerRef = undefined;
-		refreshInFlight = false;
 	});
 }

--- a/.pi/extensions/fm-quota-statusline.ts
+++ b/.pi/extensions/fm-quota-statusline.ts
@@ -1,27 +1,8 @@
-// Firstmate Pi extension: a compact, always-visible custom footer that shows
-// the repository path + git branch, live context usage, the active model and
-// thinking level, and every verified Codex quota window from `quota-axi`.
-//
-// Replaces Pi's stock footer only while this extension is active; the
-// `/statusline` command toggles it, `/statusline refresh` refreshes Codex
-// quota data, and `/statusline off` (or toggling off) restores the stock
-// footer. The footer reads live Pi session state on every render, so
-// context, branch, model, and thinking level update as their underlying Pi
-// state changes.
-//
-// Quota data is fetched through a bounded `quota-axi --provider codex --json`
-// subprocess with a timeout, parsed defensively (see
-// ./lib/fm-quota-statusline-data.ts). On a transient failure the last known
-// good windows are retained and marked stale; if no good data has ever been
-// seen the footer shows a concise unavailable marker. No credentials or raw
-// errors are exposed in the footer.
-//
-// Refresh triggers: session start, model/thinking-level change, the
-// `/statusline refresh` command, and a bounded periodic timer (5 minutes). The
-// timer is cleared and in-flight results are invalidated on session shutdown.
-//
-// Rendering is owned by ./lib/fm-quota-statusline-render.ts and is ANSI
-// visible-width safe and narrow-terminal aware.
+// Firstmate Pi quota-statusline extension.
+// docs/configuration.md owns the captain-facing `/statusline` contract.
+// The local safety boundary is a single bounded, non-overlapping quota-axi
+// refresh whose timer is cleared on disable and shutdown; parsing and
+// width-safe rendering are owned by the adjacent lib modules.
 
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { TUI, Theme } from "@earendil-works/pi-tui";

--- a/.pi/extensions/fm-quota-statusline.ts
+++ b/.pi/extensions/fm-quota-statusline.ts
@@ -36,7 +36,9 @@ import {
 import { renderFooter, type RenderInput } from "./lib/fm-quota-statusline-render.ts";
 
 const QUOTA_PROVIDER = "codex";
-const REFRESH_TIMEOUT_MS = 15_000;
+// quota-axi may need to refresh provider state before returning; keep enough
+// room for that normal path while retaining a hard upper bound.
+const REFRESH_TIMEOUT_MS = 45_000;
 const PERIODIC_REFRESH_MS = 5 * 60 * 1000;
 
 interface FooterComponent {

--- a/.pi/extensions/fm-quota-statusline.ts
+++ b/.pi/extensions/fm-quota-statusline.ts
@@ -58,12 +58,6 @@ function shortenPath(path: string, home: string | undefined): string {
 	return path;
 }
 
-function basename(path: string): string {
-	const trimmed = path.replace(/\/+$/, "");
-	const slash = trimmed.lastIndexOf("/");
-	return slash === -1 ? trimmed : trimmed.slice(slash + 1);
-}
-
 export default function (pi: ExtensionAPI) {
 	let enabled = false;
 	let latestCtx: ExtensionContext | undefined;
@@ -136,7 +130,6 @@ export default function (pi: ExtensionAPI) {
 			ctx.thinkingLevel ?? pi.getThinkingLevel() ?? null;
 		return {
 			repoPath: shortenPath(ctx.cwd, process.env.HOME),
-			repoBasename: basename(ctx.cwd),
 			branch: footerData.getGitBranch(),
 			contextPercent: usage?.percent ?? null,
 			contextTokens: usage?.tokens ?? null,

--- a/.pi/extensions/fm-quota-statusline.ts
+++ b/.pi/extensions/fm-quota-statusline.ts
@@ -135,6 +135,7 @@ export default function (pi: ExtensionAPI) {
 			branch: footerData.getGitBranch(),
 			contextPercent: usage?.percent ?? null,
 			contextTokens: usage?.tokens ?? null,
+			contextWindowTokens: usage?.contextWindow ?? null,
 			modelId: ctx.model?.id ?? null,
 			thinkingLevel: thinking,
 			windows,

--- a/.pi/extensions/fm-quota-statusline.ts
+++ b/.pi/extensions/fm-quota-statusline.ts
@@ -162,6 +162,7 @@ export default function (pi: ExtensionAPI) {
 	const restoreStockFooter = (ctx: ExtensionContext): void => {
 		enabled = false;
 		footerRef = undefined;
+		clearPeriodicTimer();
 		ctx.ui.setFooter(undefined);
 	};
 

--- a/.pi/extensions/fm-quota-statusline.ts
+++ b/.pi/extensions/fm-quota-statusline.ts
@@ -1,0 +1,271 @@
+// Firstmate Pi extension: a compact, always-visible custom footer that shows
+// the repository path + git branch, live context usage, the active model and
+// thinking level, and every verified Codex quota window from `quota-axi`.
+//
+// Replaces Pi's stock footer only while this extension is active; the
+// `/statusline` command toggles it, `/statusline refresh` refreshes Codex
+// quota data, and `/statusline off` (or toggling off) restores the stock
+// footer. The footer reads live Pi session state on every render, so
+// context, branch, model, and thinking level update as their underlying Pi
+// state changes.
+//
+// Quota data is fetched through a bounded `quota-axi --provider codex --json`
+// subprocess with a timeout, parsed defensively (see
+// ./lib/fm-quota-statusline-data.ts). On a transient failure the last known
+// good windows are retained and marked stale; if no good data has ever been
+// seen the footer shows a concise unavailable marker. No credentials or raw
+// errors are exposed in the footer.
+//
+// Refresh triggers: session start, model/thinking-level change, the
+// `/statusline refresh` command, and a bounded periodic timer (5 minutes). The
+// timer and the in-flight refresh guard are cleared on session shutdown.
+//
+// Rendering is owned by ./lib/fm-quota-statusline-render.ts and is ANSI
+// visible-width safe and narrow-terminal aware.
+
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { TUI, Theme } from "@earendil-works/pi-tui";
+import type { ReadonlyFooterDataProvider } from "@earendil-works/pi-coding-agent";
+import {
+	extractWindows,
+	parseQuotaJson,
+	type QuotaFetchStatus,
+	type QuotaWindow,
+} from "./lib/fm-quota-statusline-data.ts";
+import { renderFooter, type RenderInput } from "./lib/fm-quota-statusline-render.ts";
+
+const QUOTA_PROVIDER = "codex";
+const REFRESH_TIMEOUT_MS = 15_000;
+const PERIODIC_REFRESH_MS = 5 * 60 * 1000;
+
+interface FooterComponent {
+	dispose?(): void;
+	invalidate(): void;
+	render(width: number): string[];
+}
+
+function shortenPath(path: string, home: string | undefined): string {
+	if (!home || home === "/") {
+		return path;
+	}
+	if (path === home) {
+		return "~";
+	}
+	if (path.startsWith(home + "/")) {
+		return "~" + path.slice(home.length);
+	}
+	return path;
+}
+
+function basename(path: string): string {
+	const trimmed = path.replace(/\/+$/, "");
+	const slash = trimmed.lastIndexOf("/");
+	return slash === -1 ? trimmed : trimmed.slice(slash + 1);
+}
+
+export default function (pi: ExtensionAPI) {
+	let enabled = false;
+	let latestCtx: ExtensionContext | undefined;
+	let windows: QuotaWindow[] = [];
+	let quotaStatus: QuotaFetchStatus = "unavailable";
+	let refreshInFlight = false;
+	let periodicTimer: ReturnType<typeof setTimeout> | undefined;
+	let footerRef: { invalidate(): void } | undefined;
+
+	const refreshQuota = async (ctx: ExtensionContext): Promise<void> => {
+		if (refreshInFlight) {
+			return;
+		}
+		refreshInFlight = true;
+		try {
+			const result = await pi.exec(
+				"quota-axi",
+				["--provider", QUOTA_PROVIDER, "--json"],
+				{ timeout: REFRESH_TIMEOUT_MS, cwd: ctx.cwd },
+			);
+			if (result.killed || (result.code !== 0 && !result.stdout)) {
+				markStaleOrUnavailable();
+				return;
+			}
+			const parsed = parseQuotaJson(result.stdout);
+			if (!parsed) {
+				markStaleOrUnavailable();
+				return;
+			}
+			windows = extractWindows(parsed, QUOTA_PROVIDER);
+			quotaStatus = windows.length > 0 ? "fresh" : "unavailable";
+		} catch {
+			markStaleOrUnavailable();
+		} finally {
+			refreshInFlight = false;
+			footerRef?.invalidate();
+		}
+	};
+
+	const markStaleOrUnavailable = (): void => {
+		if (windows.length > 0) {
+			quotaStatus = "stale";
+		} else {
+			quotaStatus = "unavailable";
+		}
+	};
+
+	const buildRenderInput = (
+		ctx: ExtensionContext,
+		footerData: ReadonlyFooterDataProvider,
+	): RenderInput => {
+		const usage = ctx.getContextUsage();
+		const thinking =
+			ctx.thinkingLevel ?? pi.getThinkingLevel() ?? null;
+		return {
+			repoPath: shortenPath(ctx.cwd, process.env.HOME),
+			repoBasename: basename(ctx.cwd),
+			branch: footerData.getGitBranch(),
+			contextPercent: usage?.percent ?? null,
+			contextTokens: usage?.tokens ?? null,
+			modelId: ctx.model?.id ?? null,
+			thinkingLevel: thinking,
+			windows,
+			quotaStatus,
+			now: Date.now(),
+		};
+	};
+
+	const installFooter = (ctx: ExtensionContext): void => {
+		ctx.ui.setFooter(
+			(tui: TUI, theme: Theme, footerData: ReadonlyFooterDataProvider) => {
+				const unsub = footerData.onBranchChange(() => tui.requestRender());
+				const component: FooterComponent = {
+					dispose: () => {
+						unsub();
+					},
+					invalidate() {
+						tui.requestRender();
+					},
+					render(width: number): string[] {
+						if (!latestCtx) {
+							return [theme.fg("dim", "statusline initializing")];
+						}
+						return renderFooter(
+							buildRenderInput(latestCtx, footerData),
+							theme,
+							width,
+						);
+					},
+				};
+				footerRef = component;
+				return component;
+			},
+		);
+	};
+
+	const restoreStockFooter = (ctx: ExtensionContext): void => {
+		enabled = false;
+		footerRef = undefined;
+		ctx.ui.setFooter(undefined);
+	};
+
+	const enableCustomFooter = (ctx: ExtensionContext): void => {
+		enabled = true;
+		latestCtx = ctx;
+		installFooter(ctx);
+		void refreshQuota(ctx);
+	};
+
+	const ensurePeriodicTimer = (ctx: ExtensionContext): void => {
+		if (periodicTimer) {
+			return;
+		}
+		periodicTimer = setInterval(() => {
+			if (enabled) {
+				void refreshQuota(ctx);
+			}
+		}, PERIODIC_REFRESH_MS);
+		// Node's setInterval is unbounded only if not cleared; clear it on
+		// shutdown (see session_shutdown handler) so no timer outlives the
+		// session.
+	};
+
+	const clearPeriodicTimer = (): void => {
+		if (periodicTimer) {
+			clearInterval(periodicTimer);
+			periodicTimer = undefined;
+		}
+	};
+
+	pi.registerCommand("statusline", {
+		description:
+			"Toggle the Firstmate quota statusline footer; 'refresh' refreshes Codex data, 'off' restores the stock footer",
+		handler: async (args, ctx) => {
+			latestCtx = ctx;
+			const sub = args.trim().toLowerCase();
+			if (sub === "off" || sub === "restore" || sub === "stock") {
+				restoreStockFooter(ctx);
+				ctx.ui.notify("Stock footer restored", "info");
+				return;
+			}
+			if (sub === "refresh") {
+				if (!enabled) {
+					enableCustomFooter(ctx);
+					ensurePeriodicTimer(ctx);
+				} else {
+					void refreshQuota(ctx);
+				}
+				ctx.ui.notify("Refreshing Codex quota data", "info");
+				return;
+			}
+			if (sub === "on" || sub === "") {
+				if (enabled) {
+					restoreStockFooter(ctx);
+					ctx.ui.notify("Stock footer restored", "info");
+				} else {
+					enableCustomFooter(ctx);
+					ensurePeriodicTimer(ctx);
+					ctx.ui.notify("Statusline footer enabled", "info");
+				}
+				return;
+			}
+			ctx.ui.notify(
+				"Usage: /statusline [on|off|refresh]",
+				"warning",
+			);
+		},
+	});
+
+	pi.on("session_start", (_event, ctx) => {
+		latestCtx = ctx;
+		if (enabled) {
+			installFooter(ctx);
+			void refreshQuota(ctx);
+			ensurePeriodicTimer(ctx);
+		}
+	});
+
+	pi.on("model_select", (_event, ctx) => {
+		latestCtx = ctx;
+		if (enabled) {
+			void refreshQuota(ctx);
+			footerRef?.invalidate();
+		}
+	});
+
+	pi.on("thinking_level_select", (_event, ctx) => {
+		latestCtx = ctx;
+		if (enabled) {
+			footerRef?.invalidate();
+		}
+	});
+
+	pi.on("turn_end", (_event, ctx) => {
+		latestCtx = ctx;
+		if (enabled) {
+			footerRef?.invalidate();
+		}
+	});
+
+	pi.on("session_shutdown", () => {
+		clearPeriodicTimer();
+		footerRef = undefined;
+		refreshInFlight = false;
+	});
+}

--- a/.pi/extensions/lib/fm-quota-statusline-data.ts
+++ b/.pi/extensions/lib/fm-quota-statusline-data.ts
@@ -28,6 +28,10 @@ export interface QuotaProvider {
 	provider: string;
 	label?: string;
 	windows: QuotaWindow[];
+	state?: {
+		status?: string;
+		stale?: boolean;
+	};
 }
 
 /** Normalized quota-axi document. */
@@ -49,6 +53,10 @@ function asNumber(value: unknown): number | undefined {
 
 function asString(value: unknown): string | undefined {
 	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asBoolean(value: unknown): boolean | undefined {
+	return typeof value === "boolean" ? value : undefined;
 }
 
 function parseWindow(raw: unknown): QuotaWindow | null {
@@ -91,10 +99,19 @@ function parseProvider(raw: unknown): QuotaProvider | null {
 			windows.push(window);
 		}
 	}
+	const rawState = p.state && typeof p.state === "object"
+		? p.state as Record<string, unknown>
+		: undefined;
 	return {
 		provider,
 		label: asString(p.label),
 		windows,
+		state: rawState
+			? {
+				status: asString(rawState.status),
+				stale: asBoolean(rawState.stale),
+			}
+			: undefined,
 	};
 }
 
@@ -162,6 +179,21 @@ export function extractWindows(
 			window.percentRemaining !== undefined ||
 			window.percentUsed !== undefined,
 	);
+}
+
+export function getProviderQuotaStatus(
+	state: QuotaState | null,
+	provider: string,
+): QuotaFetchStatus {
+	const match = state?.providers.find(
+		(entry) => entry.provider === provider,
+	);
+	if (!match || extractWindows(state, provider).length === 0) {
+		return "unavailable";
+	}
+	return match.state?.status === "fresh" && match.state.stale === false
+		? "fresh"
+		: "stale";
 }
 
 /**

--- a/.pi/extensions/lib/fm-quota-statusline-data.ts
+++ b/.pi/extensions/lib/fm-quota-statusline-data.ts
@@ -1,0 +1,199 @@
+// Pure quota-axi JSON parsing and window extraction for the
+// fm-quota-statusline Pi extension.
+//
+// This module has no Pi or terminal dependencies: it only normalizes the
+// `quota-axi --provider <p> --json` schema (schemaVersion 3 observed) into a
+// stable shape the renderer consumes. Defensive parsing keeps a malformed or
+// partial document from crashing the footer: a structurally unusable document
+// resolves to null so the caller can fall back to an unavailable state.
+//
+// quota-axi's own --help and current JSON output are the authoritative schema
+// sources; this module never invents fields and exposes only what the JSON
+// actually supplies, so a future window kind or reset timestamp appears
+// automatically without a parser change.
+
+/** A single quota window exactly as quota-axi reports it. */
+export interface QuotaWindow {
+	id: string;
+	label: string;
+	kind?: string;
+	percentUsed?: number;
+	percentRemaining?: number;
+	resetsAt?: string;
+	windowSeconds?: number;
+}
+
+/** One provider entry from quota-axi JSON. */
+export interface QuotaProvider {
+	provider: string;
+	label?: string;
+	windows: QuotaWindow[];
+}
+
+/** Normalized quota-axi document. */
+export interface QuotaState {
+	generatedAt?: string;
+	schemaVersion?: number;
+	providers: QuotaProvider[];
+}
+
+/** Freshness of the cached quota data shown to the captain. */
+export type QuotaFetchStatus = "fresh" | "stale" | "unavailable";
+
+function asNumber(value: unknown): number | undefined {
+	if (typeof value === "number" && Number.isFinite(value)) {
+		return value;
+	}
+	return undefined;
+}
+
+function asString(value: unknown): string | undefined {
+	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function parseWindow(raw: unknown): QuotaWindow | null {
+	if (!raw || typeof raw !== "object") {
+		return null;
+	}
+	const w = raw as Record<string, unknown>;
+	const id = asString(w.id);
+	const label = asString(w.label) ?? id;
+	if (!id) {
+		// An id-less window is not a quota window we can label, so drop it
+		// rather than render an unlabeled percentage.
+		return null;
+	}
+	return {
+		id,
+		label,
+		kind: asString(w.kind),
+		percentUsed: asNumber(w.percentUsed),
+		percentRemaining: asNumber(w.percentRemaining),
+		resetsAt: asString(w.resetsAt),
+		windowSeconds: asNumber(w.windowSeconds),
+	};
+}
+
+function parseProvider(raw: unknown): QuotaProvider | null {
+	if (!raw || typeof raw !== "object") {
+		return null;
+	}
+	const p = raw as Record<string, unknown>;
+	const provider = asString(p.provider);
+	if (!provider) {
+		return null;
+	}
+	const windows: QuotaWindow[] = [];
+	const rawWindows = Array.isArray(p.windows) ? p.windows : [];
+	for (const rawWindow of rawWindows) {
+		const window = parseWindow(rawWindow);
+		if (window) {
+			windows.push(window);
+		}
+	}
+	return {
+		provider,
+		label: asString(p.label),
+		windows,
+	};
+}
+
+/**
+ * Parse a raw quota-axi JSON string into a normalized QuotaState.
+ *
+ * Returns null when the document is not a JSON object or has no usable
+ * providers array, so the renderer can show an unavailable state instead of
+ * crashing on a transiently malformed response.
+ */
+export function parseQuotaJson(input: string): QuotaState | null {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(input);
+	} catch {
+		return null;
+	}
+	if (!parsed || typeof parsed !== "object") {
+		return null;
+	}
+	const doc = parsed as Record<string, unknown>;
+	const rawProviders = Array.isArray(doc.providers) ? doc.providers : [];
+	if (rawProviders.length === 0) {
+		return null;
+	}
+	const providers: QuotaProvider[] = [];
+	for (const rawProvider of rawProviders) {
+		const provider = parseProvider(rawProvider);
+		if (provider) {
+			providers.push(provider);
+		}
+	}
+	if (providers.length === 0) {
+		return null;
+	}
+	return {
+		generatedAt: asString(doc.generatedAt),
+		schemaVersion: asNumber(doc.schemaVersion),
+		providers,
+	};
+}
+
+/**
+ * Extract the display windows for a named provider from a parsed state.
+ *
+ * Only windows with a real percentage (used or remaining) are returned: a
+ * window without any percentage carries no information the footer can render,
+ * so it is dropped rather than shown as a fabricated value.
+ */
+export function extractWindows(
+	state: QuotaState | null,
+	provider: string,
+): QuotaWindow[] {
+	if (!state) {
+		return [];
+	}
+	const match = state.providers.find(
+		(entry) => entry.provider === provider,
+	);
+	if (!match) {
+		return [];
+	}
+	return match.windows.filter(
+		(window) =>
+			window.percentRemaining !== undefined ||
+			window.percentUsed !== undefined,
+	);
+}
+
+/**
+ * Compact humanized countdown from `now` to an ISO reset timestamp.
+ *
+ * Returns undefined when the timestamp is missing or already in the past, so
+ * the renderer omits reset information the quota data does not actually
+ * supply.
+ */
+export function formatResetCountdown(
+	resetsAt: string | undefined,
+	now: number,
+): string | undefined {
+	if (!resetsAt) {
+		return undefined;
+	}
+	const target = Date.parse(resetsAt);
+	if (!Number.isFinite(target)) {
+		return undefined;
+	}
+	const seconds = Math.round((target - now) / 1000);
+	if (seconds <= 0) {
+		return undefined;
+	}
+	const days = Math.floor(seconds / 86400);
+	const hours = Math.floor((seconds % 86400) / 3600);
+	const minutes = Math.floor((seconds % 3600) / 60);
+	if (days >= 1) {
+		return `${days}d`;
+	}
+	if (hours >= 1) {
+		return `${hours}h`;
+	}
+	return `${minutes}m`;
+}

--- a/.pi/extensions/lib/fm-quota-statusline-render.ts
+++ b/.pi/extensions/lib/fm-quota-statusline-render.ts
@@ -134,7 +134,10 @@ export function renderFooter(
 	theme: RenderTheme,
 	width: number,
 ): string[] {
-	const safeWidth = Math.max(8, width);
+	const safeWidth = Number.isFinite(width) ? Math.max(0, Math.floor(width)) : 0;
+	if (safeWidth === 0) {
+		return [""];
+	}
 	const repoForLine1 = safeWidth < 48 ? input.repoBasename : input.repoPath;
 	const branchSuffix = input.branch ? ` (${input.branch})` : "";
 	const line1 = theme.fg("dim", `${repoForLine1}${branchSuffix}`);

--- a/.pi/extensions/lib/fm-quota-statusline-render.ts
+++ b/.pi/extensions/lib/fm-quota-statusline-render.ts
@@ -1,0 +1,176 @@
+// Pure footer rendering for the fm-quota-statusline Pi extension.
+//
+// This module owns only the visible-width-safe composition of the footer
+// lines. It takes already-normalized inputs (parsed by
+// ./fm-quota-statusline-data.ts) plus the live Pi session values, and returns
+// the rendered string lines. It has no timers, no subprocesses, and no Pi
+// lifecycle coupling, so the focused tests can drive it directly through a
+// thin node harness without booting the TUI.
+//
+// Layout (matches the captain's compact example):
+//   line 1: <repoPath> (<branch>)
+//   line 2: <ctx%> / <tokens>   <quota windows>   <model> <thinking>
+//
+// A stale quota cache keeps its last-good windows but prefixes the segment
+// so the captain can see the data may be behind. An unavailable quota shows a
+// concise marker and never fabricates a window or percentage.
+//
+// Narrow terminals: segments are dropped by priority (reset countdowns first,
+// then quota windows, then thinking, then repo path collapses to basename)
+// before any line is truncated to the available width.
+
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import type {
+	QuotaFetchStatus,
+	QuotaWindow,
+} from "./fm-quota-statusline-data.ts";
+import { formatResetCountdown } from "./fm-quota-statusline-data.ts";
+
+/** Live session values the renderer needs from Pi. */
+export interface RenderInput {
+	/** Repository path for the first line (already shortened, e.g. ~/dev/proj). */
+	repoPath: string;
+	/** Bare repo path with no shortening, used when width forces a basename. */
+	repoBasename: string;
+	/** Current git branch, or null for detached/no repo. */
+	branch: string | null;
+	/** Context usage percent (0-100), or null when Pi has no estimate yet. */
+	contextPercent: number | null;
+	/** Context tokens used, or null. */
+	contextTokens: number | null;
+	/** Active model id, or null. */
+	modelId: string | null;
+	/** Effective thinking level, or null. */
+	thinkingLevel: string | null;
+	/** Verified quota windows to render. */
+	windows: QuotaWindow[];
+	/** Freshness of the windows (fresh / stale / unavailable). */
+	quotaStatus: QuotaFetchStatus;
+	/** Epoch milliseconds, used for reset countdowns. */
+	now: number;
+}
+
+/**
+ * Minimal theme surface the renderer needs.
+ *
+ * The real Pi Theme satisfies this; the indirection keeps the renderer
+ * testable with a plain stub that does not depend on the full Theme type.
+ */
+export interface RenderTheme {
+	fg: (color: string, text: string) => string;
+}
+
+const SEP = "   ";
+
+function formatTokens(tokens: number | null): string {
+	if (tokens === null || tokens <= 0) {
+		return "?";
+	}
+	if (tokens < 1000) {
+		return `${tokens}`;
+	}
+	if (tokens < 1_000_000) {
+		return `${(tokens / 1000).toFixed(1)}k`;
+	}
+	return `${(tokens / 1_000_000).toFixed(1)}M`;
+}
+
+function renderContextSegment(input: RenderInput): string {
+	if (input.contextPercent === null && input.contextTokens === null) {
+		return "ctx: —";
+	}
+	const percent =
+		input.contextPercent !== null ? `${input.contextPercent.toFixed(1)}%` : "?";
+	return `ctx ${percent} / ${formatTokens(input.contextTokens)}`;
+}
+
+function renderWindowSegment(window: QuotaWindow, now: number): string {
+	const remaining = window.percentRemaining;
+	const used = window.percentUsed;
+	let pct: string;
+	if (remaining !== undefined) {
+		pct = `${Math.round(remaining)}%`;
+	} else if (used !== undefined) {
+		pct = `${Math.round(100 - used)}%`;
+	} else {
+		return "";
+	}
+	const reset = formatResetCountdown(window.resetsAt, now);
+	const label = window.label || window.id;
+	return reset ? `${label}: ${pct} (${reset})` : `${label}: ${pct}`;
+}
+
+function renderQuotaSegment(input: RenderInput): string {
+	if (input.quotaStatus === "unavailable" || input.windows.length === 0) {
+		return input.quotaStatus === "unavailable" ? "quota: n/a" : "";
+	}
+	const parts = input.windows
+		.map((window) => renderWindowSegment(window, input.now))
+		.filter((segment) => segment.length > 0);
+	if (parts.length === 0) {
+		return "";
+	}
+	const prefix = input.quotaStatus === "stale" ? "quota~ " : "quota ";
+	return prefix + parts.join("   ");
+}
+
+function renderModelSegment(input: RenderInput): string {
+	const model = input.modelId ?? "no-model";
+	const thinking = input.thinkingLevel && input.thinkingLevel !== "off"
+		? ` ${input.thinkingLevel}`
+		: "";
+	return `${model}${thinking}`;
+}
+
+/**
+ * Render the statusline footer for the given input and terminal width.
+ *
+ * Returns one or two lines. When width is too small for two readable lines,
+ * the second line is dropped entirely; the first line is then truncated to
+ * the width so the footer never overflows the terminal.
+ */
+export function renderFooter(
+	input: RenderInput,
+	theme: RenderTheme,
+	width: number,
+): string[] {
+	const safeWidth = Math.max(8, width);
+	const repoForLine1 = safeWidth < 48 ? input.repoBasename : input.repoPath;
+	const branchSuffix = input.branch ? ` (${input.branch})` : "";
+	const line1 = theme.fg("dim", `${repoForLine1}${branchSuffix}`);
+
+	const context = renderContextSegment(input);
+	const quota = renderQuotaSegment(input);
+	const model = renderModelSegment(input);
+
+	let line2Parts: string[] = [];
+	if (safeWidth >= 40) {
+		line2Parts.push(context);
+	}
+	if (safeWidth >= 60 && quota.length > 0) {
+		line2Parts.push(quota);
+	}
+	if (safeWidth >= 50) {
+		line2Parts.push(model);
+	}
+	let line2 = line2Parts.length > 0 ? line2Parts.join(SEP) : "";
+	if (line2.length > 0 && visibleWidth(line2) > safeWidth) {
+		// Drop the model segment first, then quota, to keep the most
+		// decision-relevant context number visible.
+		const trimmed = [...line2Parts];
+		while (
+			trimmed.length > 1 &&
+			visibleWidth(trimmed.join(SEP)) > safeWidth
+		) {
+			trimmed.splice(trimmed.length - 1, 1);
+		}
+		line2 = trimmed.join(SEP);
+	}
+
+	if (line2.length === 0) {
+		return [truncateToWidth(line1, safeWidth)];
+	}
+	const line1Clamped = truncateToWidth(line1, safeWidth);
+	const line2Clamped = truncateToWidth(line2, safeWidth);
+	return [line1Clamped, line2Clamped];
+}

--- a/.pi/extensions/lib/fm-quota-statusline-render.ts
+++ b/.pi/extensions/lib/fm-quota-statusline-render.ts
@@ -9,7 +9,7 @@
 //
 // Layout (matches the captain's compact example):
 //   line 1: <repoPath> (<branch>)
-//   following lines: <ctx%> / <tokens>   <quota windows>   <model> <thinking>
+//   following lines: <ctx%> <tokens>/<window>   <quota windows>   <model> <thinking>
 //
 // A stale quota cache keeps its last-good windows but prefixes the segment
 // so the captain can see the data may be behind. An unavailable quota shows a
@@ -35,6 +35,8 @@ export interface RenderInput {
 	contextPercent: number | null;
 	/** Context tokens used, or null. */
 	contextTokens: number | null;
+	/** Active model context-window size in tokens, or null. */
+	contextWindowTokens: number | null;
 	/** Active model id, or null. */
 	modelId: string | null;
 	/** Effective thinking level, or null. */
@@ -73,12 +75,16 @@ function formatTokens(tokens: number | null): string {
 }
 
 function renderContextSegment(input: RenderInput): string {
-	if (input.contextPercent === null && input.contextTokens === null) {
+	if (
+		input.contextPercent === null &&
+		input.contextTokens === null &&
+		input.contextWindowTokens === null
+	) {
 		return "ctx: —";
 	}
 	const percent =
 		input.contextPercent !== null ? `${input.contextPercent.toFixed(1)}%` : "?";
-	return `ctx ${percent} / ${formatTokens(input.contextTokens)}`;
+	return `ctx ${percent} · ${formatTokens(input.contextTokens)}/${formatTokens(input.contextWindowTokens)}`;
 }
 
 function renderWindowSegment(window: QuotaWindow, now: number): string {
@@ -110,7 +116,7 @@ function renderQuotaSegments(input: RenderInput): string[] {
 
 function renderModelSegment(input: RenderInput): string {
 	const model = input.modelId ?? "no-model";
-	const thinking = input.thinkingLevel && input.thinkingLevel !== "off"
+	const thinking = input.thinkingLevel
 		? ` ${input.thinkingLevel}`
 		: "";
 	return `${model}${thinking}`;

--- a/.pi/extensions/lib/fm-quota-statusline-render.ts
+++ b/.pi/extensions/lib/fm-quota-statusline-render.ts
@@ -9,17 +9,16 @@
 //
 // Layout (matches the captain's compact example):
 //   line 1: <repoPath> (<branch>)
-//   line 2: <ctx%> / <tokens>   <quota windows>   <model> <thinking>
+//   following lines: <ctx%> / <tokens>   <quota windows>   <model> <thinking>
 //
 // A stale quota cache keeps its last-good windows but prefixes the segment
 // so the captain can see the data may be behind. An unavailable quota shows a
 // concise marker and never fabricates a window or percentage.
 //
-// Narrow terminals: segments are dropped by priority (reset countdowns first,
-// then quota windows, then thinking, then repo path collapses to basename)
-// before any line is truncated to the available width.
+// Narrow terminals use continuation lines so every field remains present
+// without exceeding the available width.
 
-import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { visibleWidth } from "@earendil-works/pi-tui";
 import type {
 	QuotaFetchStatus,
 	QuotaWindow,
@@ -30,8 +29,6 @@ import { formatResetCountdown } from "./fm-quota-statusline-data.ts";
 export interface RenderInput {
 	/** Repository path for the first line (already shortened, e.g. ~/dev/proj). */
 	repoPath: string;
-	/** Bare repo path with no shortening, used when width forces a basename. */
-	repoBasename: string;
 	/** Current git branch, or null for detached/no repo. */
 	branch: string | null;
 	/** Context usage percent (0-100), or null when Pi has no estimate yet. */
@@ -100,18 +97,15 @@ function renderWindowSegment(window: QuotaWindow, now: number): string {
 	return reset ? `${label}: ${pct} (${reset})` : `${label}: ${pct}`;
 }
 
-function renderQuotaSegment(input: RenderInput): string {
+function renderQuotaSegments(input: RenderInput): string[] {
 	if (input.quotaStatus === "unavailable" || input.windows.length === 0) {
-		return input.quotaStatus === "unavailable" ? "quota: n/a" : "";
+		return input.quotaStatus === "unavailable" ? ["quota: n/a"] : [];
 	}
 	const parts = input.windows
 		.map((window) => renderWindowSegment(window, input.now))
 		.filter((segment) => segment.length > 0);
-	if (parts.length === 0) {
-		return "";
-	}
 	const prefix = input.quotaStatus === "stale" ? "quota~ " : "quota ";
-	return prefix + parts.join("   ");
+	return parts.map((part) => prefix + part);
 }
 
 function renderModelSegment(input: RenderInput): string {
@@ -122,12 +116,52 @@ function renderModelSegment(input: RenderInput): string {
 	return `${model}${thinking}`;
 }
 
+function wrapToWidth(text: string, width: number): string[] {
+	const lines: string[] = [];
+	let current = "";
+	for (const character of text) {
+		if (current.length > 0 && visibleWidth(current + character) > width) {
+			lines.push(current);
+			current = "";
+		}
+		if (visibleWidth(character) <= width) {
+			current += character;
+		}
+	}
+	if (current.length > 0 || lines.length === 0) {
+		lines.push(current);
+	}
+	return lines;
+}
+
+function packSegments(segments: string[], width: number): string[] {
+	const lines: string[] = [];
+	let current = "";
+	for (const segment of segments) {
+		const combined = current.length > 0 ? current + SEP + segment : segment;
+		if (visibleWidth(combined) <= width) {
+			current = combined;
+			continue;
+		}
+		if (current.length > 0) {
+			lines.push(current);
+			current = "";
+		}
+		const wrapped = wrapToWidth(segment, width);
+		lines.push(...wrapped.slice(0, -1));
+		current = wrapped.at(-1) ?? "";
+	}
+	if (current.length > 0) {
+		lines.push(current);
+	}
+	return lines;
+}
+
 /**
  * Render the statusline footer for the given input and terminal width.
  *
- * Returns one or two lines. When width is too small for two readable lines,
- * the second line is dropped entirely; the first line is then truncated to
- * the width so the footer never overflows the terminal.
+ * Returns width-safe lines, adding continuation lines when the available
+ * width cannot contain every field.
  */
 export function renderFooter(
 	input: RenderInput,
@@ -138,42 +172,15 @@ export function renderFooter(
 	if (safeWidth === 0) {
 		return [""];
 	}
-	const repoForLine1 = safeWidth < 48 ? input.repoBasename : input.repoPath;
 	const branchSuffix = input.branch ? ` (${input.branch})` : "";
-	const line1 = theme.fg("dim", `${repoForLine1}${branchSuffix}`);
+	const repoLines = wrapToWidth(`${input.repoPath}${branchSuffix}`, safeWidth)
+		.map((line) => theme.fg("dim", line));
 
 	const context = renderContextSegment(input);
-	const quota = renderQuotaSegment(input);
 	const model = renderModelSegment(input);
-
-	let line2Parts: string[] = [];
-	if (safeWidth >= 40) {
-		line2Parts.push(context);
-	}
-	if (safeWidth >= 60 && quota.length > 0) {
-		line2Parts.push(quota);
-	}
-	if (safeWidth >= 50) {
-		line2Parts.push(model);
-	}
-	let line2 = line2Parts.length > 0 ? line2Parts.join(SEP) : "";
-	if (line2.length > 0 && visibleWidth(line2) > safeWidth) {
-		// Drop the model segment first, then quota, to keep the most
-		// decision-relevant context number visible.
-		const trimmed = [...line2Parts];
-		while (
-			trimmed.length > 1 &&
-			visibleWidth(trimmed.join(SEP)) > safeWidth
-		) {
-			trimmed.splice(trimmed.length - 1, 1);
-		}
-		line2 = trimmed.join(SEP);
-	}
-
-	if (line2.length === 0) {
-		return [truncateToWidth(line1, safeWidth)];
-	}
-	const line1Clamped = truncateToWidth(line1, safeWidth);
-	const line2Clamped = truncateToWidth(line2, safeWidth);
-	return [line1Clamped, line2Clamped];
+	const detailLines = packSegments(
+		[context, ...renderQuotaSegments(input), model],
+		safeWidth,
+	);
+	return [...repoLines, ...detailLines];
 }

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -140,6 +140,7 @@ family_for_basename() {
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-kimi-harness.test.sh|fm-muse-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
     fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
+    fm-quota-statusline.test.sh|\
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|\
     fm-subagent-pretool-check.test.sh|\
     fm-supervision-instructions.test.sh|fm-task-delivery.test.sh|\

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,6 +32,16 @@ The `/calm` command replaces the file atomically before changing live presentati
 The extension reloads this preference on every Pi `session_start`, including startup, new, resume, fork, and reload reasons.
 This preference is local to each Firstmate home and is not part of secondmate inherited configuration.
 
+## Pi statusline footer (/statusline)
+
+The tracked `.pi/extensions/fm-quota-statusline.ts` extension replaces Pi's stock footer only while it is active, and the `/statusline` command owns its activation.
+`/statusline` (or `/statusline on`) enables the footer and starts the periodic Codex quota refresh; `/statusline off` restores Pi's stock footer; `/statusline refresh` refreshes the Codex quota data without changing whether the footer is active.
+The footer shows the repository path and current git branch, the active model and effective thinking level, the live context usage against the active model's context window, and every verified Codex quota window that `quota-axi --provider codex --json` reports, each labeled with its real window label, remaining percentage, and reset countdown when supplied.
+It never invents a quota window or percentage: when quota data is unavailable the footer shows a concise `quota: n/a` marker, and a transient `quota-axi` failure retains the last known good windows marked stale with a `quota~` prefix.
+The extension refreshes quota data on Pi `session_start`, when the active model or thinking level changes, on `/statusline refresh`, and on a bounded five-minute timer that is cleared on `session_shutdown`.
+The refresh runs a bounded `quota-axi --provider codex --json` subprocess with a fifteen-second timeout and an in-flight guard, and the renderer is ANSI visible-width safe and collapses or truncates on narrow terminals.
+No credentials or raw `quota-axi` errors appear in the footer; only the normalized window data is shown.
+
 ## Backlog backend (.tasks.toml / config/backlog-backend)
 
 The tracked `.tasks.toml` pins the default `tasks-axi` markdown backend to `data/backlog.md`, with `done_keep = 10` and an archive at `data/done-archive.md`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,10 +35,10 @@ This preference is local to each Firstmate home and is not part of secondmate in
 ## Pi statusline footer (/statusline)
 
 The tracked `.pi/extensions/fm-quota-statusline.ts` extension replaces Pi's stock footer only while it is active, and the `/statusline` command owns its activation.
-`/statusline` (or `/statusline on`) enables the footer and starts the periodic Codex quota refresh; `/statusline off` restores Pi's stock footer; `/statusline refresh` refreshes the Codex quota data without changing whether the footer is active.
+`/statusline` toggles between the custom and stock footers; `/statusline on` idempotently enables the custom footer and starts the periodic Codex quota refresh; `/statusline off` restores Pi's stock footer; `/statusline refresh` refreshes the Codex quota data without changing whether the footer is active.
 The footer shows the repository path and current git branch, the active model and effective thinking level, the live context usage against the active model's context window, and every verified Codex quota window that `quota-axi --provider codex --json` reports, each labeled with its real window label, remaining percentage, and reset countdown when supplied.
 It never invents a quota window or percentage: when quota data is unavailable the footer shows a concise `quota: n/a` marker, and a transient `quota-axi` failure retains the last known good windows marked stale with a `quota~` prefix.
-The extension refreshes quota data on Pi `session_start`, when the active model or thinking level changes, on `/statusline refresh`, and on a bounded five-minute timer that is cleared on `session_shutdown`.
+The extension refreshes quota data on Pi `session_start`, when the active model or thinking level changes, on `/statusline refresh`, and on a bounded five-minute timer that is cleared on `session_shutdown` and `/statusline off`.
 The refresh runs a bounded `quota-axi --provider codex --json` subprocess with a fifteen-second timeout and an in-flight guard, and the renderer is ANSI visible-width safe and collapses or truncates on narrow terminals.
 No credentials or raw `quota-axi` errors appear in the footer; only the normalized window data is shown.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,7 +39,7 @@ The tracked `.pi/extensions/fm-quota-statusline.ts` extension replaces Pi's stoc
 The footer shows the repository path and current git branch, the active model and effective thinking level, the live context usage against the active model's context window, and every verified Codex quota window that `quota-axi --provider codex --json` reports, each labeled with its real window label, remaining percentage, and reset countdown when supplied.
 It never invents a quota window or percentage: when quota data is unavailable the footer shows a concise `quota: n/a` marker, and a transient `quota-axi` failure retains the last known good windows marked stale with a `quota~` prefix.
 The extension refreshes quota data on Pi `session_start`, when the active model or thinking level changes, on `/statusline refresh`, and on a bounded five-minute timer that is cleared on `session_shutdown` and `/statusline off`.
-The refresh runs a bounded `quota-axi --provider codex --json` subprocess with a fifteen-second timeout and an in-flight guard, and the renderer is ANSI visible-width safe and uses continuation lines on narrow terminals so verified fields are not dropped.
+The refresh runs a bounded `quota-axi --provider codex --json` subprocess with a hard timeout and an in-flight guard, and the renderer is ANSI visible-width safe and uses continuation lines on narrow terminals so verified fields are not dropped.
 No credentials or raw `quota-axi` errors appear in the footer; only the normalized window data is shown.
 
 ## Backlog backend (.tasks.toml / config/backlog-backend)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,11 +34,13 @@ This preference is local to each Firstmate home and is not part of secondmate in
 
 ## Pi statusline footer (/statusline)
 
-The tracked `.pi/extensions/fm-quota-statusline.ts` extension replaces Pi's stock footer only while it is active, and the `/statusline` command owns its activation.
+The tracked `.pi/extensions/fm-quota-statusline.ts` extension starts with Pi's stock footer and replaces it only while the custom footer is active; the choice is process-local rather than persisted.
 `/statusline` toggles between the custom and stock footers; `/statusline on` idempotently enables the custom footer and starts the periodic Codex quota refresh; `/statusline off` restores Pi's stock footer; `/statusline refresh` refreshes the Codex quota data without changing whether the footer is active.
-The footer shows the repository path and current git branch, the active model and effective thinking level, the live context usage against the active model's context window, and every verified Codex quota window that `quota-axi --provider codex --json` reports, each labeled with its real window label, remaining percentage, and reset countdown when supplied.
-It never invents a quota window or percentage: when quota data is unavailable the footer shows a concise `quota: n/a` marker, and a transient `quota-axi` failure retains the last known good windows marked stale with a `quota~` prefix.
-The extension refreshes quota data on Pi `session_start`, when the active model or thinking level changes, on `/statusline refresh`, and on a bounded five-minute timer that is cleared on `session_shutdown` and `/statusline off`.
+The footer shows the repository path and current git branch, the active model and effective thinking level, the live context usage against the active model's context window, and every labeled Codex quota window with a percentage that `quota-axi --provider codex --json` reports.
+Each quota window shows the reported remaining percentage, or `100 - percentUsed` when only the used percentage is reported, plus a reset countdown when a valid future reset timestamp is supplied.
+It never invents a quota window or percentage: when quota data is unavailable the footer shows a concise `quota: n/a` marker, while provider-declared stale data or a transient refresh failure is shown with a `quota~` prefix and the last known good windows remain available after a failed refresh.
+While the custom footer is enabled, the extension refreshes quota data on Pi `session_start`, when the active model or thinking level changes, and on a five-minute periodic timer; `/statusline refresh` also refreshes it while either footer is active.
+The periodic timer is cleared on `session_shutdown` and `/statusline off`.
 The refresh runs a bounded `quota-axi --provider codex --json` subprocess with a hard timeout and an in-flight guard, and the renderer is ANSI visible-width safe and uses continuation lines on narrow terminals so verified fields are not dropped.
 No credentials or raw `quota-axi` errors appear in the footer; only the normalized window data is shown.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,7 +39,7 @@ The tracked `.pi/extensions/fm-quota-statusline.ts` extension replaces Pi's stoc
 The footer shows the repository path and current git branch, the active model and effective thinking level, the live context usage against the active model's context window, and every verified Codex quota window that `quota-axi --provider codex --json` reports, each labeled with its real window label, remaining percentage, and reset countdown when supplied.
 It never invents a quota window or percentage: when quota data is unavailable the footer shows a concise `quota: n/a` marker, and a transient `quota-axi` failure retains the last known good windows marked stale with a `quota~` prefix.
 The extension refreshes quota data on Pi `session_start`, when the active model or thinking level changes, on `/statusline refresh`, and on a bounded five-minute timer that is cleared on `session_shutdown` and `/statusline off`.
-The refresh runs a bounded `quota-axi --provider codex --json` subprocess with a fifteen-second timeout and an in-flight guard, and the renderer is ANSI visible-width safe and collapses or truncates on narrow terminals.
+The refresh runs a bounded `quota-axi --provider codex --json` subprocess with a fifteen-second timeout and an in-flight guard, and the renderer is ANSI visible-width safe and uses continuation lines on narrow terminals so verified fields are not dropped.
 No credentials or raw `quota-axi` errors appear in the footer; only the normalized window data is shown.
 
 ## Backlog backend (.tasks.toml / config/backlog-backend)

--- a/tests/fm-quota-statusline.test.sh
+++ b/tests/fm-quota-statusline.test.sh
@@ -67,6 +67,7 @@ cp "$RENDER" "$fixture/lib/fm-quota-statusline-render.ts"
 output_file="$fixture/node-output"
 ( cd "$fixture" && node --input-type=module ) >"$output_file" 2>&1 <<'JS'
 import { pathToFileURL } from "node:url";
+import { visibleWidth } from "@earendil-works/pi-tui";
 import { parseQuotaJson, extractWindows, getProviderQuotaStatus } from "./lib/fm-quota-statusline-data.ts";
 import { renderFooter } from "./lib/fm-quota-statusline-render.ts";
 
@@ -121,7 +122,6 @@ const theme = { fg: (_color, text) => text };
 const now = Date.parse("2026-08-11T07:00:00.000Z");
 const freshInput = {
   repoPath: "~/Developer/firstmate",
-  repoBasename: "firstmate",
   branch: "main",
   contextPercent: 70.1,
   contextTokens: 272000,
@@ -169,18 +169,36 @@ check("stale footer preserves the last-good weekly window", staleLine2.includes(
 check("stale footer marks the data stale", staleLine2.includes("quota~"));
 
 // --- Narrow width behavior ---------------------------------------------
-// Below the two-line threshold the footer collapses to one line and never
-// overflows the terminal width.
+// Narrow layouts use continuation lines without overflowing the terminal.
 const narrowLines = renderFooter(freshInput, theme, 18);
-check("narrow footer renders a single line", narrowLines.length === 1);
-check("narrow footer stays within the width", (narrowLines[0] ?? "").length <= 18);
-check("narrow footer shows the repo basename", (narrowLines[0] ?? "").startsWith("firstmate"));
+const narrowJoined = narrowLines.join("");
+check("narrow footer uses continuation lines", narrowLines.length > 1);
+check("narrow footer stays within the width", narrowLines.every((line) => visibleWidth(line) <= 18));
+check("narrow footer preserves repo and branch", narrowJoined.includes("~/Developer/firstmate") && narrowJoined.includes("main"));
+check("narrow footer preserves context", narrowJoined.includes("70.1%") && narrowJoined.includes("272.0k"));
+check("narrow footer preserves quota", narrowJoined.includes("week: 95%") && narrowJoined.includes("6d"));
+check("narrow footer preserves model and thinking", narrowJoined.includes("gpt-5.6-terra") && narrowJoined.includes("high"));
 // Even narrower: truncation must be ANSI-safe and not throw.
 const tinyLines = renderFooter(freshInput, theme, 6);
-check("tiny width does not throw and yields one line", tinyLines.length === 1);
-check("tiny footer stays within the requested width", (tinyLines[0] ?? "").length <= 6);
+check("tiny width does not throw and yields lines", tinyLines.length > 0);
+check("tiny footer stays within the requested width", tinyLines.every((line) => visibleWidth(line) <= 6));
 const zeroLines = renderFooter(freshInput, theme, 0);
 check("zero-width footer is empty", (zeroLines[0] ?? "").length === 0);
+
+const multiWindowInput = {
+  ...freshInput,
+  windows: [
+    { id: "primary", label: "5h", percentRemaining: 73, resetsAt: "2026-08-11T12:00:00.000Z" },
+    { id: "weekly", label: "week", percentRemaining: 86, resetsAt: "2026-08-18T03:30:39.000Z" },
+    { id: "review", label: "code-review", percentRemaining: 64, resetsAt: "2026-08-13T07:00:00.000Z" },
+    { id: "model", label: "gpt-5.6", percentRemaining: 51, resetsAt: "2026-08-12T07:00:00.000Z" },
+  ],
+};
+const multiWindowLines = renderFooter(multiWindowInput, theme, 48);
+const multiWindowText = multiWindowLines.join("\n");
+check("multi-window footer stays within width", multiWindowLines.every((line) => visibleWidth(line) <= 48));
+check("multi-window footer preserves every label", ["5h: 73%", "week: 86%", "code-review: 64%", "gpt-5.6: 51%"].every((value) => multiWindowText.includes(value)));
+check("multi-window footer preserves every reset", ["(5h)", "(6d)", "(2d)", "(1d)"].every((value) => multiWindowText.includes(value)));
 
 // --- Defensive parsing --------------------------------------------------
 // A non-JSON string and a structurally empty document both resolve to null

--- a/tests/fm-quota-statusline.test.sh
+++ b/tests/fm-quota-statusline.test.sh
@@ -218,6 +218,7 @@ let notifyMessages = [];
 let statusCmd = null;
 let execResult = { stdout: freshJson, stderr: "", code: 0, killed: false };
 let execCalls = 0;
+let execOptions = null;
 const fakeCtx = () => ({
   cwd: "/Users/ediz/Developer/firstmate",
   model: { id: "gpt-5.6-terra" },
@@ -229,8 +230,9 @@ const fakeCtx = () => ({
   },
 });
 const fakePi = {
-  exec: async () => {
+  exec: async (_command, _args, options) => {
     execCalls += 1;
+    execOptions = options;
     return execResult;
   },
   getThinkingLevel: () => "high",
@@ -250,6 +252,10 @@ await new Promise((resolve) => setTimeout(resolve, 50));
 check("enable installs a footer factory", typeof footerFactory === "function");
 check("enable notifies the captain", notifyMessages.some((n) => /enabled/i.test(n.message)));
 check("enable refreshes quota once", execCalls === 1);
+check(
+  "quota refresh has a positive bounded timeout",
+  Number.isFinite(execOptions?.timeout) && execOptions.timeout > 0 && execOptions.timeout <= 60_000,
+);
 
 const enabledFooterFactory = footerFactory;
 notifyMessages = [];

--- a/tests/fm-quota-statusline.test.sh
+++ b/tests/fm-quota-statusline.test.sh
@@ -233,4 +233,64 @@ if grep -q "^not ok" "$output_file"; then
   fail "statusline node harness reported failing checks"
 fi
 
+# --- Clean-exit regression --------------------------------------------------
+# /statusline off must clear the periodic refresh timer so the process can
+# exit on its own. This probe enables then offs the footer WITHOUT firing
+# session_shutdown (which would clear the timer unconditionally and mask a
+# leak), and without process.exit, so a leaked setInterval keeps node alive
+# and the bounded wait below catches it.
+cat >"$fixture/clean-exit-probe.mjs" <<'JS'
+import { pathToFileURL } from "node:url";
+const mod = await import(pathToFileURL("./fm-quota-statusline.ts").href);
+const eventHandlers = new Map();
+let statusCmd = null;
+const fakeCtx = () => ({
+  cwd: "/Users/ediz/Developer/firstmate",
+  model: { id: "gpt-5.6-terra" },
+  thinkingLevel: "high",
+  getContextUsage: () => ({ tokens: 272000, contextWindow: 200000, percent: 70.1 }),
+  ui: { setFooter: () => {}, notify: () => {} },
+});
+const fakePi = {
+  exec: async () => ({
+    stdout: '{"providers":[{"provider":"codex","windows":[{"id":"weekly","label":"week","percentRemaining":95}]}]}',
+    stderr: "", code: 0, killed: false,
+  }),
+  getThinkingLevel: () => "high",
+  on: (ev, h) => {
+    const a = eventHandlers.get(ev) ?? [];
+    a.push(h);
+    eventHandlers.set(ev, a);
+  },
+  registerCommand: (_n, o) => { statusCmd = o; },
+};
+mod.default(fakePi);
+await statusCmd.handler("", fakeCtx());   // enable arms the periodic timer
+await statusCmd.handler("off", fakeCtx()); // off must clear it
+// Deliberately no session_shutdown and no process.exit: a clean
+// implementation exits naturally once the periodic timer is cleared.
+JS
+
+( cd "$fixture" && node clean-exit-probe.mjs ) &
+probe_pid=$!
+probe_ok=1
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  sleep 1
+  if ! kill -0 "$probe_pid" 2>/dev/null; then
+    probe_ok=0
+    break
+  fi
+done
+if [ "$probe_ok" -ne 0 ]; then
+  kill -9 "$probe_pid" 2>/dev/null
+  wait "$probe_pid" 2>/dev/null
+  fail "/statusline off did not clear the periodic timer: process stayed alive without session_shutdown"
+fi
+wait "$probe_pid" 2>/dev/null
+probe_exit=$?
+if [ "$probe_exit" -ne 0 ]; then
+  fail "clean-exit probe exited non-zero ($probe_exit)"
+fi
+pass "clean-exit: /statusline off clears the periodic timer without session_shutdown"
+
 pass "fm-quota-statusline rendering, staleness, narrow-width, and lifecycle checks"

--- a/tests/fm-quota-statusline.test.sh
+++ b/tests/fm-quota-statusline.test.sh
@@ -27,15 +27,38 @@ if ! command -v node >/dev/null 2>&1; then
   echo "skip: node not found for statusline renderer test"
   exit 0
 fi
-if [ ! -f "$PI_PACKAGE_DIR/package.json" ]; then
-  echo "skip: installed @earendil-works/pi-coding-agent package not found"
-  exit 0
-fi
-
 fixture="$TMP_ROOT/fixture"
 mkdir -p "$fixture/node_modules/@earendil-works" "$fixture/lib"
-ln -s "$PI_PACKAGE_DIR" "$fixture/node_modules/@earendil-works/pi-coding-agent"
-ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$fixture/node_modules/@earendil-works/pi-tui"
+if [ -f "$PI_PACKAGE_DIR/package.json" ]; then
+  ln -s "$PI_PACKAGE_DIR" "$fixture/node_modules/@earendil-works/pi-coding-agent"
+  ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$fixture/node_modules/@earendil-works/pi-tui"
+else
+  mkdir -p "$fixture/node_modules/@earendil-works/pi-tui"
+  printf '%s\n' '{"type":"module","exports":"./index.js"}' >"$fixture/node_modules/@earendil-works/pi-tui/package.json"
+  cat >"$fixture/node_modules/@earendil-works/pi-tui/index.js" <<'JS'
+export function visibleWidth(text) {
+  return [...text.replace(/\x1b\[[0-9;]*m/g, "")].length;
+}
+export function truncateToWidth(text, width) {
+  if (width <= 0) return "";
+  let output = "";
+  let visible = 0;
+  for (let index = 0; index < text.length && visible < width;) {
+    const ansi = text.slice(index).match(/^\x1b\[[0-9;]*m/);
+    if (ansi) {
+      output += ansi[0];
+      index += ansi[0].length;
+      continue;
+    }
+    const point = String.fromCodePoint(text.codePointAt(index));
+    output += point;
+    index += point.length;
+    visible += 1;
+  }
+  return output;
+}
+JS
+fi
 printf '%s\n' '{"type":"module"}' >"$fixture/package.json"
 cp "$EXT" "$fixture/fm-quota-statusline.ts"
 cp "$DATA" "$fixture/lib/fm-quota-statusline-data.ts"
@@ -44,7 +67,7 @@ cp "$RENDER" "$fixture/lib/fm-quota-statusline-render.ts"
 output_file="$fixture/node-output"
 ( cd "$fixture" && node --input-type=module ) >"$output_file" 2>&1 <<'JS'
 import { pathToFileURL } from "node:url";
-import { parseQuotaJson, extractWindows } from "./lib/fm-quota-statusline-data.ts";
+import { parseQuotaJson, extractWindows, getProviderQuotaStatus } from "./lib/fm-quota-statusline-data.ts";
 import { renderFooter } from "./lib/fm-quota-statusline-render.ts";
 
 const results = [];
@@ -69,12 +92,30 @@ const freshJson = JSON.stringify({
       resetsAt: "2026-08-18T03:30:39.000Z",
       windowSeconds: 604800,
     }],
+    state: { status: "fresh", stale: false },
   }],
 });
 const freshState = parseQuotaJson(freshJson);
 check("parses a fresh quota document", freshState !== null);
 const freshWindows = extractWindows(freshState, "codex");
 check("extracts the weekly window", freshWindows.length === 1 && freshWindows[0].id === "weekly");
+check("classifies provider-declared fresh data", getProviderQuotaStatus(freshState, "codex") === "fresh");
+
+const staleState = parseQuotaJson(JSON.stringify({
+  providers: [{
+    provider: "codex",
+    windows: [{ id: "weekly", label: "week", percentRemaining: 82 }],
+    state: { status: "stale", stale: true },
+  }],
+}));
+const noStateState = parseQuotaJson(JSON.stringify({
+  providers: [{
+    provider: "codex",
+    windows: [{ id: "weekly", label: "week", percentRemaining: 82 }],
+  }],
+}));
+check("preserves provider-declared stale data", getProviderQuotaStatus(staleState, "codex") === "stale");
+check("does not assume missing freshness metadata is fresh", getProviderQuotaStatus(noStateState, "codex") === "stale");
 
 const theme = { fg: (_color, text) => text };
 const now = Date.parse("2026-08-11T07:00:00.000Z");
@@ -132,11 +173,14 @@ check("stale footer marks the data stale", staleLine2.includes("quota~"));
 // overflows the terminal width.
 const narrowLines = renderFooter(freshInput, theme, 18);
 check("narrow footer renders a single line", narrowLines.length === 1);
-check("narrow footer stays within the width", (narrowLines[0] ?? "").length <= 18 || !narrowLines[0].includes("\n"));
+check("narrow footer stays within the width", (narrowLines[0] ?? "").length <= 18);
 check("narrow footer shows the repo basename", (narrowLines[0] ?? "").startsWith("firstmate"));
 // Even narrower: truncation must be ANSI-safe and not throw.
 const tinyLines = renderFooter(freshInput, theme, 6);
 check("tiny width does not throw and yields one line", tinyLines.length === 1);
+check("tiny footer stays within the requested width", (tinyLines[0] ?? "").length <= 6);
+const zeroLines = renderFooter(freshInput, theme, 0);
+check("zero-width footer is empty", (zeroLines[0] ?? "").length === 0);
 
 // --- Defensive parsing --------------------------------------------------
 // A non-JSON string and a structurally empty document both resolve to null
@@ -155,6 +199,7 @@ let footerFactory = "STOCK";
 let notifyMessages = [];
 let statusCmd = null;
 let execResult = { stdout: freshJson, stderr: "", code: 0, killed: false };
+let execCalls = 0;
 const fakeCtx = () => ({
   cwd: "/Users/ediz/Developer/firstmate",
   model: { id: "gpt-5.6-terra" },
@@ -166,7 +211,10 @@ const fakeCtx = () => ({
   },
 });
 const fakePi = {
-  exec: async () => execResult,
+  exec: async () => {
+    execCalls += 1;
+    return execResult;
+  },
   getThinkingLevel: () => "high",
   on: (event, handler) => {
     const list = eventHandlers.get(event) ?? [];
@@ -183,6 +231,19 @@ await statusCmd.handler("", fakeCtx());
 await new Promise((resolve) => setTimeout(resolve, 50));
 check("enable installs a footer factory", typeof footerFactory === "function");
 check("enable notifies the captain", notifyMessages.some((n) => /enabled/i.test(n.message)));
+check("enable refreshes quota once", execCalls === 1);
+
+const enabledFooterFactory = footerFactory;
+notifyMessages = [];
+await statusCmd.handler("on", fakeCtx());
+check("on is idempotent while enabled", footerFactory === enabledFooterFactory);
+check("idempotent on does not restore stock", !notifyMessages.some((n) => /stock/i.test(n.message)));
+
+for (const handler of (eventHandlers.get("thinking_level_select") ?? [])) {
+  handler({}, fakeCtx());
+}
+await new Promise((resolve) => setTimeout(resolve, 50));
+check("thinking-level changes refresh quota", execCalls === 2);
 
 // Render through the installed component to confirm it produces the footer.
 const component = footerFactory(
@@ -194,15 +255,25 @@ const componentLines = component.render(120);
 check("installed footer renders two lines", componentLines.length === 2);
 check("installed footer line 1 shows branch", (componentLines[0] ?? "").includes("(main)"));
 
-// Refresh: a second fetch after a transient failure keeps last-good windows
-// and marks them stale.
-execResult = { stdout: "", stderr: "boom", code: 1, killed: false };
+execResult = { stdout: JSON.stringify({
+  providers: [{
+    provider: "codex",
+    windows: [{ id: "weekly", label: "week", percentRemaining: 82 }],
+    state: { status: "stale", stale: true },
+  }],
+}), stderr: "", code: 0, killed: false };
 await statusCmd.handler("refresh", fakeCtx());
 await new Promise((resolve) => setTimeout(resolve, 50));
 const staleComponentLines = component.render(120);
 const staleComponentLine2 = staleComponentLines[1] ?? "";
-check("refresh after failure keeps the last-good window", staleComponentLine2.includes("week: 95%"));
-check("refresh after failure marks stale", staleComponentLine2.includes("quota~"));
+check("provider-stale refresh uses reported windows", staleComponentLine2.includes("week: 82%"));
+check("provider-stale refresh is marked stale", staleComponentLine2.includes("quota~"));
+
+execResult = { stdout: freshJson, stderr: "boom", code: 1, killed: false };
+await statusCmd.handler("refresh", fakeCtx());
+await new Promise((resolve) => setTimeout(resolve, 50));
+const failedRefreshLine2 = component.render(120)[1] ?? "";
+check("nonzero refresh does not accept stdout as fresh", failedRefreshLine2.includes("quota~") && failedRefreshLine2.includes("week: 82%"));
 
 // Restore stock footer.
 notifyMessages = [];
@@ -210,9 +281,95 @@ await statusCmd.handler("off", fakeCtx());
 check("off restores the stock footer (undefined)", footerFactory === undefined);
 check("off notifies the captain", notifyMessages.some((n) => /stock/i.test(n.message)));
 
+const callsBeforeInactiveRefresh = execCalls;
+execResult = { stdout: freshJson, stderr: "", code: 0, killed: false };
+await statusCmd.handler("refresh", fakeCtx());
+await new Promise((resolve) => setTimeout(resolve, 50));
+check("inactive refresh fetches quota", execCalls === callsBeforeInactiveRefresh + 1);
+check("inactive refresh does not enable the footer", footerFactory === undefined);
+
+await statusCmd.handler("on", fakeCtx());
+await new Promise((resolve) => setTimeout(resolve, 50));
+const onFooterFactory = footerFactory;
+await statusCmd.handler("on", fakeCtx());
+check("repeated on keeps the custom footer installed", footerFactory === onFooterFactory);
+await statusCmd.handler("", fakeCtx());
+check("bare statusline toggles an enabled footer off", footerFactory === undefined);
+
 // Fire session_shutdown to clear the periodic timer so the harness exits.
 for (const handler of (eventHandlers.get("session_shutdown") ?? [])) {
   handler({}, fakeCtx());
+}
+
+const lifecycleHandlers = new Map();
+let lifecycleCommand = null;
+let lifecycleFooterFactory = undefined;
+let lifecycleCalls = 0;
+let activeExecs = 0;
+let maxActiveExecs = 0;
+const execResolvers = [];
+const lifecycleCtx = () => ({
+  cwd: "/tmp/new-session",
+  model: { id: "gpt-5.6-terra" },
+  thinkingLevel: "high",
+  getContextUsage: () => ({ tokens: 10, contextWindow: 100, percent: 10 }),
+  ui: {
+    setFooter: (factory) => { lifecycleFooterFactory = factory; },
+    notify: () => {},
+  },
+});
+mod.default({
+  exec: () => new Promise((resolve) => {
+    lifecycleCalls += 1;
+    activeExecs += 1;
+    maxActiveExecs = Math.max(maxActiveExecs, activeExecs);
+    execResolvers.push((result) => {
+      activeExecs -= 1;
+      resolve(result);
+    });
+  }),
+  getThinkingLevel: () => "high",
+  on: (event, handler) => {
+    const list = lifecycleHandlers.get(event) ?? [];
+    list.push(handler);
+    lifecycleHandlers.set(event, list);
+  },
+  registerCommand: (_name, options) => { lifecycleCommand = options; },
+});
+await lifecycleCommand.handler("on", lifecycleCtx());
+for (const handler of (lifecycleHandlers.get("session_shutdown") ?? [])) {
+  handler({}, lifecycleCtx());
+}
+for (const handler of (lifecycleHandlers.get("session_start") ?? [])) {
+  handler({}, lifecycleCtx());
+}
+check("session restart does not overlap an in-flight refresh", lifecycleCalls === 1 && maxActiveExecs === 1);
+execResolvers.shift()({ stdout: JSON.stringify({
+  providers: [{
+    provider: "codex",
+    windows: [{ id: "weekly", label: "week", percentRemaining: 11 }],
+    state: { status: "fresh", stale: false },
+  }],
+}), stderr: "", code: 0, killed: false });
+await new Promise((resolve) => setTimeout(resolve, 50));
+check("session restart queues a replacement refresh", lifecycleCalls === 2 && maxActiveExecs === 1);
+execResolvers.shift()({ stdout: JSON.stringify({
+  providers: [{
+    provider: "codex",
+    windows: [{ id: "weekly", label: "week", percentRemaining: 77 }],
+    state: { status: "fresh", stale: false },
+  }],
+}), stderr: "", code: 0, killed: false });
+await new Promise((resolve) => setTimeout(resolve, 50));
+const lifecycleComponent = lifecycleFooterFactory(
+  { requestRender() {} },
+  { fg: (_c, t) => t },
+  { getGitBranch: () => "main", onBranchChange: () => () => {} },
+);
+const lifecycleLine2 = lifecycleComponent.render(120)[1] ?? "";
+check("pre-shutdown refresh cannot overwrite the new session", lifecycleLine2.includes("week: 77%") && !lifecycleLine2.includes("week: 11%"));
+for (const handler of (lifecycleHandlers.get("session_shutdown") ?? [])) {
+  handler({}, lifecycleCtx());
 }
 
 const failed = results.filter((r) => !r.ok);

--- a/tests/fm-quota-statusline.test.sh
+++ b/tests/fm-quota-statusline.test.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# Focused rendering, quota-data, staleness, narrow-width, and lifecycle
+# checks for the fm-quota-statusline Pi extension.
+#
+# The node harness below imports the tracked extension and its pure data and
+# render modules, drives them through their public interface (the parsed
+# quota-axi JSON shape, the live Pi session values, and the footer component's
+# render(width) method), and asserts the visible output. It never asserts
+# implementation source bytes.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-quota-statusline)
+EXT="$ROOT/.pi/extensions/fm-quota-statusline.ts"
+DATA="$ROOT/.pi/extensions/lib/fm-quota-statusline-data.ts"
+RENDER="$ROOT/.pi/extensions/lib/fm-quota-statusline-render.ts"
+PI_PACKAGE_DIR=${FM_PI_PACKAGE_DIR:-"$(npm root -g 2>/dev/null)/@earendil-works/pi-coding-agent"}
+
+cleanup() {
+  fm_test_cleanup
+}
+trap cleanup EXIT
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "skip: node not found for statusline renderer test"
+  exit 0
+fi
+if [ ! -f "$PI_PACKAGE_DIR/package.json" ]; then
+  echo "skip: installed @earendil-works/pi-coding-agent package not found"
+  exit 0
+fi
+
+fixture="$TMP_ROOT/fixture"
+mkdir -p "$fixture/node_modules/@earendil-works" "$fixture/lib"
+ln -s "$PI_PACKAGE_DIR" "$fixture/node_modules/@earendil-works/pi-coding-agent"
+ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$fixture/node_modules/@earendil-works/pi-tui"
+printf '%s\n' '{"type":"module"}' >"$fixture/package.json"
+cp "$EXT" "$fixture/fm-quota-statusline.ts"
+cp "$DATA" "$fixture/lib/fm-quota-statusline-data.ts"
+cp "$RENDER" "$fixture/lib/fm-quota-statusline-render.ts"
+
+output_file="$fixture/node-output"
+( cd "$fixture" && node --input-type=module ) >"$output_file" 2>&1 <<'JS'
+import { pathToFileURL } from "node:url";
+import { parseQuotaJson, extractWindows } from "./lib/fm-quota-statusline-data.ts";
+import { renderFooter } from "./lib/fm-quota-statusline-render.ts";
+
+const results = [];
+const check = (name, cond) => {
+  results.push({ name, ok: !!cond });
+  console.log(`${cond ? "ok -" : "not ok -"} ${name}`);
+};
+
+// --- Fresh quota rendering ----------------------------------------------
+// A representative schemaVersion-3 document with one weekly window.
+const freshJson = JSON.stringify({
+  generatedAt: "2026-08-11T06:49:19.223Z",
+  schemaVersion: 3,
+  providers: [{
+    provider: "codex",
+    label: "Codex",
+    windows: [{
+      id: "weekly",
+      label: "week",
+      percentUsed: 5,
+      percentRemaining: 95,
+      resetsAt: "2026-08-18T03:30:39.000Z",
+      windowSeconds: 604800,
+    }],
+  }],
+});
+const freshState = parseQuotaJson(freshJson);
+check("parses a fresh quota document", freshState !== null);
+const freshWindows = extractWindows(freshState, "codex");
+check("extracts the weekly window", freshWindows.length === 1 && freshWindows[0].id === "weekly");
+
+const theme = { fg: (_color, text) => text };
+const now = Date.parse("2026-08-11T07:00:00.000Z");
+const freshInput = {
+  repoPath: "~/Developer/firstmate",
+  repoBasename: "firstmate",
+  branch: "main",
+  contextPercent: 70.1,
+  contextTokens: 272000,
+  modelId: "gpt-5.6-terra",
+  thinkingLevel: "high",
+  windows: freshWindows,
+  quotaStatus: "fresh",
+  now,
+};
+const freshLines = renderFooter(freshInput, theme, 120);
+check("fresh footer has two lines", freshLines.length === 2);
+check("line 1 shows repo path and branch", /~\/Developer\/firstmate \(main\)/.test(freshLines[0] ?? ""));
+const freshLine2 = freshLines[1] ?? "";
+check("line 2 shows context percent", freshLine2.includes("70.1%"));
+check("line 2 shows context tokens", freshLine2.includes("272.0k"));
+check("line 2 shows the weekly window label", freshLine2.includes("week: 95%"));
+check("line 2 shows reset countdown", freshLine2.includes("6d"));
+check("line 2 shows model and thinking level", freshLine2.includes("gpt-5.6-terra") && freshLine2.includes("high"));
+// Only verified windows appear: a fabricated short window must never render.
+check("fresh footer never invents a 5h window", !freshLine2.includes("5h:"));
+
+// --- Absent / unavailable quota -----------------------------------------
+// Empty providers array parses to null so the footer shows unavailable.
+const emptyState = parseQuotaJson('{"providers":[]}');
+check("empty providers document is null", emptyState === null);
+const unavailableLines = renderFooter(
+  { ...freshInput, windows: [], quotaStatus: "unavailable" },
+  theme,
+  120,
+);
+const unavailableLine2 = unavailableLines[1] ?? "";
+check("unavailable footer shows n/a marker", unavailableLine2.includes("quota: n/a"));
+check("unavailable footer shows no fabricated percentage", !/\d+%.*quota|quota.*\d+%/.test(unavailableLine2.replace("quota: n/a", "")));
+
+// --- Stale last-good data -----------------------------------------------
+// On a transient failure the last known good windows are retained and the
+// segment is marked stale so the captain can see the data may be behind.
+const staleLines = renderFooter(
+  { ...freshInput, windows: freshWindows, quotaStatus: "stale" },
+  theme,
+  120,
+);
+const staleLine2 = staleLines[1] ?? "";
+check("stale footer preserves the last-good weekly window", staleLine2.includes("week: 95%"));
+check("stale footer marks the data stale", staleLine2.includes("quota~"));
+
+// --- Narrow width behavior ---------------------------------------------
+// Below the two-line threshold the footer collapses to one line and never
+// overflows the terminal width.
+const narrowLines = renderFooter(freshInput, theme, 18);
+check("narrow footer renders a single line", narrowLines.length === 1);
+check("narrow footer stays within the width", (narrowLines[0] ?? "").length <= 18 || !narrowLines[0].includes("\n"));
+check("narrow footer shows the repo basename", (narrowLines[0] ?? "").startsWith("firstmate"));
+// Even narrower: truncation must be ANSI-safe and not throw.
+const tinyLines = renderFooter(freshInput, theme, 6);
+check("tiny width does not throw and yields one line", tinyLines.length === 1);
+
+// --- Defensive parsing --------------------------------------------------
+// A non-JSON string and a structurally empty document both resolve to null
+// rather than crashing the footer.
+check("malformed JSON is null", parseQuotaJson("not json") === null);
+check("non-object JSON is null", parseQuotaJson('"hello"') === null);
+const noWindowsState = parseQuotaJson('{"providers":[{"provider":"codex","windows":[]}]}');
+check("provider with no usable windows extracts none", extractWindows(noWindowsState, "codex").length === 0);
+
+// --- Lifecycle via the extension ----------------------------------------
+// Exercise the tracked extension through a fake ExtensionAPI so the public
+// command and footer factory behave correctly without booting the TUI.
+const mod = await import(pathToFileURL("./fm-quota-statusline.ts").href);
+const eventHandlers = new Map();
+let footerFactory = "STOCK";
+let notifyMessages = [];
+let statusCmd = null;
+let execResult = { stdout: freshJson, stderr: "", code: 0, killed: false };
+const fakeCtx = () => ({
+  cwd: "/Users/ediz/Developer/firstmate",
+  model: { id: "gpt-5.6-terra" },
+  thinkingLevel: "high",
+  getContextUsage: () => ({ tokens: 272000, contextWindow: 200000, percent: 70.1 }),
+  ui: {
+    setFooter: (f) => { footerFactory = f; },
+    notify: (message, type) => { notifyMessages.push({ message, type }); },
+  },
+});
+const fakePi = {
+  exec: async () => execResult,
+  getThinkingLevel: () => "high",
+  on: (event, handler) => {
+    const list = eventHandlers.get(event) ?? [];
+    list.push(handler);
+    eventHandlers.set(event, list);
+  },
+  registerCommand: (_name, options) => { statusCmd = options; },
+};
+mod.default(fakePi);
+check("extension registers the /statusline command", statusCmd !== null);
+
+// Enable: installs a footer factory and refreshes quota.
+await statusCmd.handler("", fakeCtx());
+await new Promise((resolve) => setTimeout(resolve, 50));
+check("enable installs a footer factory", typeof footerFactory === "function");
+check("enable notifies the captain", notifyMessages.some((n) => /enabled/i.test(n.message)));
+
+// Render through the installed component to confirm it produces the footer.
+const component = footerFactory(
+  { requestRender() {} },
+  { fg: (_c, t) => t },
+  { getGitBranch: () => "main", onBranchChange: () => () => {} },
+);
+const componentLines = component.render(120);
+check("installed footer renders two lines", componentLines.length === 2);
+check("installed footer line 1 shows branch", (componentLines[0] ?? "").includes("(main)"));
+
+// Refresh: a second fetch after a transient failure keeps last-good windows
+// and marks them stale.
+execResult = { stdout: "", stderr: "boom", code: 1, killed: false };
+await statusCmd.handler("refresh", fakeCtx());
+await new Promise((resolve) => setTimeout(resolve, 50));
+const staleComponentLines = component.render(120);
+const staleComponentLine2 = staleComponentLines[1] ?? "";
+check("refresh after failure keeps the last-good window", staleComponentLine2.includes("week: 95%"));
+check("refresh after failure marks stale", staleComponentLine2.includes("quota~"));
+
+// Restore stock footer.
+notifyMessages = [];
+await statusCmd.handler("off", fakeCtx());
+check("off restores the stock footer (undefined)", footerFactory === undefined);
+check("off notifies the captain", notifyMessages.some((n) => /stock/i.test(n.message)));
+
+// Fire session_shutdown to clear the periodic timer so the harness exits.
+for (const handler of (eventHandlers.get("session_shutdown") ?? [])) {
+  handler({}, fakeCtx());
+}
+
+const failed = results.filter((r) => !r.ok);
+if (failed.length > 0) {
+  console.error(`${failed.length} statusline check(s) failed`);
+  process.exit(1);
+}
+JS
+
+node_exit=$?
+if [ "$node_exit" -ne 0 ]; then
+  cat "$output_file" >&2
+  fail "statusline node harness failed (exit $node_exit)"
+fi
+
+if grep -q "^not ok" "$output_file"; then
+  cat "$output_file" >&2
+  fail "statusline node harness reported failing checks"
+fi
+
+pass "fm-quota-statusline rendering, staleness, narrow-width, and lifecycle checks"

--- a/tests/fm-quota-statusline.test.sh
+++ b/tests/fm-quota-statusline.test.sh
@@ -125,6 +125,7 @@ const freshInput = {
   branch: "main",
   contextPercent: 70.1,
   contextTokens: 272000,
+  contextWindowTokens: 200000,
   modelId: "gpt-5.6-terra",
   thinkingLevel: "high",
   windows: freshWindows,
@@ -137,9 +138,16 @@ check("line 1 shows repo path and branch", /~\/Developer\/firstmate \(main\)/.te
 const freshLine2 = freshLines[1] ?? "";
 check("line 2 shows context percent", freshLine2.includes("70.1%"));
 check("line 2 shows context tokens", freshLine2.includes("272.0k"));
+check("line 2 shows the active context window", freshLine2.includes("272.0k/200.0k"));
 check("line 2 shows the weekly window label", freshLine2.includes("week: 95%"));
 check("line 2 shows reset countdown", freshLine2.includes("6d"));
 check("line 2 shows model and thinking level", freshLine2.includes("gpt-5.6-terra") && freshLine2.includes("high"));
+const thinkingOffLines = renderFooter(
+  { ...freshInput, thinkingLevel: "off" },
+  theme,
+  120,
+);
+check("footer shows an effective thinking level of off", thinkingOffLines.join("\n").includes("gpt-5.6-terra off"));
 // Only verified windows appear: a fabricated short window must never render.
 check("fresh footer never invents a 5h window", !freshLine2.includes("5h:"));
 
@@ -175,7 +183,7 @@ const narrowJoined = narrowLines.join("");
 check("narrow footer uses continuation lines", narrowLines.length > 1);
 check("narrow footer stays within the width", narrowLines.every((line) => visibleWidth(line) <= 18));
 check("narrow footer preserves repo and branch", narrowJoined.includes("~/Developer/firstmate") && narrowJoined.includes("main"));
-check("narrow footer preserves context", narrowJoined.includes("70.1%") && narrowJoined.includes("272.0k"));
+check("narrow footer preserves context", narrowJoined.includes("70.1%") && narrowJoined.includes("272.0k/200.0k"));
 check("narrow footer preserves quota", narrowJoined.includes("week: 95%") && narrowJoined.includes("6d"));
 check("narrow footer preserves model and thinking", narrowJoined.includes("gpt-5.6-terra") && narrowJoined.includes("high"));
 // Even narrower: truncation must be ANSI-safe and not throw.
@@ -278,6 +286,7 @@ const component = footerFactory(
 const componentLines = component.render(120);
 check("installed footer renders two lines", componentLines.length === 2);
 check("installed footer line 1 shows branch", (componentLines[0] ?? "").includes("(main)"));
+check("installed footer uses Pi's active context window", componentLines.join("\n").includes("272.0k/200.0k"));
 
 execResult = { stdout: JSON.stringify({
   providers: [{


### PR DESCRIPTION
## Intent

Add a tracked FirstMate Pi extension that gives the captain a compact, always-visible custom footer showing the repo path and git branch, live context usage against the active model's context window, the active model and effective thinking level, and every verified Codex quota window (label, remaining percentage, reset countdown) from quota-axi. The /statusline command toggles it on, restores Pi's stock footer, and refreshes Codex data. It must never fabricate quota windows or percentages, must show concise stale/unavailable states, refresh on session start / model or thinking-level change / /statusline refresh / a bounded timer cleared on shutdown and on /statusline off, use a bounded quota-axi subprocess with an in-flight guard, and render ANSI-width-safe on narrow terminals. Add regression coverage and a stable doc owner.

## What Changed

- Add a Pi `/statusline` footer showing repository, branch, context usage, model, thinking level, and verified Codex quota windows with reset countdowns.
- Refresh quota data through a bounded, serialized `quota-axi` subprocess, preserving stale data, reporting unavailable states, and safely wrapping output on narrow terminals.
- Document the statusline contract and add regression coverage for rendering, refresh lifecycle, timer cleanup, and footer toggling.

## Risk Assessment

✅ Low: The change is well-bounded and satisfies the required footer data, lifecycle refresh, stale/unavailable handling, subprocess guard, narrow-terminal rendering, documentation, and regression-coverage contracts without a substantiated material defect.

## Testing

The focused regression ran directly and through the repository test runner, while a live `quota-axi` response was rendered into wide, narrow, stale, and unavailable footer artifacts; after correcting one evidence-only module-resolution setup issue, all checks passed and the worktree remained clean.

<details>
<summary>Evidence: Live FirstMate footer rendering: wide, narrow, stale, and unavailable states</summary>

```text
<!doctype html>
<html lang="en"><meta charset="utf-8"><title>FirstMate Pi statusline evidence</title>
<style>
body{font-family:system-ui;background:#111827;color:#e5e7eb;margin:32px}h1{font-size:22px}h2{font-size:14px;color:#93c5fd;margin-top:24px}.terminal{background:#020617;border:1px solid #334155;border-radius:8px;padding:14px;box-shadow:0 8px 30px #0008}pre{margin:0;white-space:pre-wrap;font:14px/1.45 ui-monospace,SFMono-Regular,Menlo,monospace;color:#f8fafc}.note{color:#94a3b8;font-size:13px}</style>
<body><h1>FirstMate Pi custom footer</h1><p class="note">Generated end-to-end from live <code>quota-axi --provider codex --json</code> output through the tracked parser and renderer.</p>

  <section>
    <h2>Fresh data — 120 columns</h2>
    <div class="terminal" style="max-width:1080px"><pre>~/.no-mistakes/worktrees/c76aac46b405/01KZRDN7GPT0Q9V14K51XKBVHK (fm/pi-codex-quota-statusline)
ctx 34.7% · 69.4k/200.0k   quota week: 64% (6d)   gpt-5.6-terra high</pre></div>
  </section>

  <section>
    <h2>Fresh data — 28 columns (continuation lines)</h2>
    <div class="terminal" style="max-width:360px"><pre>~/.no-mistakes/worktrees/c76
aac46b405/01KZRDN7GPT0Q9V14K
51XKBVHK (fm/pi-codex-quota-
statusline)
ctx 34.7% · 69.4k/200.0k
quota week: 64% (6d)
gpt-5.6-terra high</pre></div>
  </section>

  <section>
    <h2>Transient failure with last-known-good data</h2>
    <div class="terminal" style="max-width:1080px"><pre>~/.no-mistakes/worktrees/c76aac46b405/01KZRDN7GPT0Q9V14K51XKBVHK (fm/pi-codex-quota-statusline)
ctx 34.7% · 69.4k/200.0k   quota~ week: 64% (6d)   gpt-5.6-terra high</pre></div>
  </section>

  <section>
    <h2>Unavailable data with no fabricated window</h2>
    <div class="terminal" style="max-width:1080px"><pre>~/.no-mistakes/worktrees/c76aac46b405/01KZRDN7GPT0Q9V14K51XKBVHK (fm/pi-codex-quota-statusline)
ctx 34.7% · 69.4k/200.0k   quota: n/a   gpt-5.6-terra high</pre></div>
  </section>
</body></html>
```
</details>
<details>
<summary>Evidence: Live quota-to-footer transcript</summary>

`ctx 34.7% · 69.4k/200.0k quota week: 64% (6d) gpt-5.6-terra high`

```text
LIVE QUOTA -> FRESH FOOTER (120 cols)
~/.no-mistakes/worktrees/c76aac46b405/01KZRDN7GPT0Q9V14K51XKBVHK (fm/pi-codex-quota-statusline)
ctx 34.7% · 69.4k/200.0k   quota week: 64% (6d)   gpt-5.6-terra high

LIVE QUOTA -> NARROW FOOTER (28 cols)
~/.no-mistakes/worktrees/c76
aac46b405/01KZRDN7GPT0Q9V14K
51XKBVHK (fm/pi-codex-quota-
statusline)
ctx 34.7% · 69.4k/200.0k
quota week: 64% (6d)
gpt-5.6-terra high

LAST-KNOWN-GOOD -> STALE FOOTER
~/.no-mistakes/worktrees/c76aac46b405/01KZRDN7GPT0Q9V14K51XKBVHK (fm/pi-codex-quota-statusline)
ctx 34.7% · 69.4k/200.0k   quota~ week: 64% (6d)   gpt-5.6-terra high

NO WINDOWS -> UNAVAILABLE FOOTER
~/.no-mistakes/worktrees/c76aac46b405/01KZRDN7GPT0Q9V14K51XKBVHK (fm/pi-codex-quota-statusline)
ctx 34.7% · 69.4k/200.0k   quota: n/a   gpt-5.6-terra high
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-quota-statusline.test.sh`
- `bin/fm-test-run.sh tests/fm-quota-statusline.test.sh`
- <code>`quota-axi --provider codex --json` using the installed provider, then the tracked parser and renderer at 120- and 28-column widths</code>
- <code>Rendered live fresh data plus stale last-known-good and unavailable states into `statusline-live-render.html`</code>
- <code>Verified `/statusline` toggle/on/off/refresh behavior, stock-footer restoration, context/model/thinking display, all reported windows, reset countdowns, bounded subprocess timeout, refresh serialization, lifecycle refreshes, timer cleanup, and ANSI-visible-width limits</code>
- <code>Verified `docs/configuration.md` is explicitly referenced as the captain-facing contract owner and contains the `/statusline` documentation section</code>
- `Corrected an evidence-only Pi TUI module stub after the first rendering attempt encountered a missing temporary dependency, then reran successfully`
- <code>Confirmed `git status --short` remained clean after testing</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
