### PR TITLE
feat(guard): refuse destructive tmux commands at the tool boundary

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,6 +22,10 @@
           {
             "type": "command",
             "command": "[ -z \"${GROK_AGENT:-}${GROK_HOOK_EVENT:-}\" ] || exit 0; exec \"$CLAUDE_PROJECT_DIR\"/bin/fm-cd-pretool-check.sh --claude"
+          },
+          {
+            "type": "command",
+            "command": "[ -z \"${GROK_AGENT:-}${GROK_HOOK_EVENT:-}\" ] || exit 0; exec \"$CLAUDE_PROJECT_DIR\"/bin/fm-tmux-pretool-check.sh --claude"
           }
         ]
       },

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -24,6 +24,11 @@
             "type": "command",
             "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-cd-pretool-check.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.PreToolUse[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-cd-pretool-check.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-cd-pretool-check.sh\"'",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-tmux-pretool-check.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.PreToolUse[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-tmux-pretool-check.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-tmux-pretool-check.sh\"'",
+            "timeout": 10
           }
         ]
       }

--- a/.grok/hooks/fm-tmux-check.json
+++ b/.grok/hooks/fm-tmux-check.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -lc '[ -n \"${GROK_WORKSPACE_ROOT:-}\" ] || exit 0; exec \"${GROK_WORKSPACE_ROOT:-}/bin/fm-tmux-pretool-check.sh\"'",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.opencode/plugins/fm-tmux-check.js
+++ b/.opencode/plugins/fm-tmux-check.js
@@ -1,0 +1,67 @@
+import { realpathSync } from "node:fs";
+import { resolve } from "node:path";
+import { spawn } from "node:child_process";
+
+// PreToolUse seatbelt for OpenCode: block a tmux command that would destroy a
+// session, window, or pane on the shared tmux server the captain and the whole
+// fleet live on (see bin/fm-tmux-pretool-check.sh and docs/tmux-guard.md).
+// This mirrors fm-primary-cd-check.js, calling the tmux-guard owner instead of
+// the cd one. tool.execute.before can block by throwing (verified 2026-07-09
+// against OpenCode 1.17.15 for the watcher-arm plugin; the same mechanism
+// carries this guard).
+//
+// Deliberately UNLIKE the cd-guard: the owner script here is NOT inert in a
+// crewmate/scout task worktree, because a worker is exactly the agent this
+// guard exists to bind. It stays inert outside a firstmate checkout.
+
+function runProcess(command, args) {
+  return new Promise((resolvePromise) => {
+    const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", () => resolvePromise({ code: 0, stdout: "", stderr: "" }));
+    child.on("close", (code) => resolvePromise({ code: code ?? 0, stdout, stderr }));
+  });
+}
+
+async function resolveRoot(anchor) {
+  if (!anchor) return "";
+  const result = await runProcess("git", ["-C", anchor, "rev-parse", "--show-toplevel"]);
+  const root = result.stdout.trim();
+  if (result.code === 0 && root) return root;
+  try {
+    return realpathSync(anchor);
+  } catch {
+    return resolve(anchor);
+  }
+}
+
+export const FmTmuxCheck = async ({ directory, worktree }) => {
+  const root = worktree ? (() => {
+    try {
+      return realpathSync(worktree);
+    } catch {
+      return resolve(worktree);
+    }
+  })() : await resolveRoot(directory);
+
+  return {
+    "tool.execute.before": async (input, output) => {
+      if (!root || input?.tool !== "bash") return;
+      const command = output?.args?.command;
+      if (!command || typeof command !== "string") return;
+
+      const result = await runProcess(`${root}/bin/fm-tmux-pretool-check.sh`, ["--command", command]);
+      if (result.code !== 2) return;
+
+      const reason = result.stderr.trim() || "denied by the tmux-guard PreToolUse seatbelt";
+      throw new Error(reason);
+    },
+  };
+};

--- a/.pi/extensions/fm-primary-turnend-guard.ts
+++ b/.pi/extensions/fm-primary-turnend-guard.ts
@@ -138,12 +138,14 @@ function runGuard(): Promise<{ code: number; stderr: string }> {
 }
 
 // PreToolUse seatbelts (bin/fm-arm-pretool-check.sh, docs/arm-pretool-check.md;
-// bin/fm-cd-pretool-check.sh, docs/cd-guard.md). Both piggyback on this same
-// extension file rather than separate ones so no extra Pi -e flag is needed at
-// launch - the primary already loads this file for the turn-end guard, and
-// pi.on("tool_call", ...) can block (verified 2026-07-09 against pi 0.80.5:
-// returning {block: true} prevents the bash command from running). Each owner
-// script owns its own decision and is inert outside the real primary checkout.
+// bin/fm-cd-pretool-check.sh, docs/cd-guard.md; bin/fm-tmux-pretool-check.sh,
+// docs/tmux-guard.md). All three piggyback on this same extension file rather
+// than separate ones so no extra Pi -e flag is needed at launch - the primary
+// already loads this file for the turn-end guard, and pi.on("tool_call", ...)
+// can block (verified 2026-07-09 against pi 0.80.5: returning {block: true}
+// prevents the bash command from running). Each owner script owns its own
+// decision. The arm and cd owners are inert outside the real primary checkout;
+// the tmux owner deliberately is not, because it binds workers too.
 function runChecker(script: string, command: string): Promise<{ code: number; stderr: string }> {
   return new Promise((resolveResult) => {
     const child = spawn(`${root}/bin/${script}`, ["--command", command], {
@@ -166,6 +168,14 @@ function runCdCheck(command: string): Promise<{ code: number; stderr: string }> 
   return runChecker("fm-cd-pretool-check.sh", command);
 }
 
+// The tmux-guard (bin/fm-tmux-pretool-check.sh, docs/tmux-guard.md). Unlike the
+// other two seatbelts its owner script is NOT inert in a crewmate/scout task
+// worktree - a worker destroying the shared tmux server is the exact threat it
+// exists to stop.
+function runTmuxCheck(command: string): Promise<{ code: number; stderr: string }> {
+  return runChecker("fm-tmux-pretool-check.sh", command);
+}
+
 export default function (pi: ExtensionAPI) {
   pi.on?.("session_start", async (event) => {
     const reason = String((event as { reason?: unknown }).reason ?? "");
@@ -185,6 +195,10 @@ export default function (pi: ExtensionAPI) {
     if (event.type !== "tool_call" || event.toolName !== "bash") return {};
     const command = String((event.input as { command?: unknown })?.command ?? "");
     if (!command) return {};
+    const tmuxResult = await runTmuxCheck(command);
+    if (tmuxResult.code === 2) {
+      return { block: true, reason: tmuxResult.stderr.trim() || "denied by the tmux-guard PreToolUse seatbelt" };
+    }
     const cdResult = await runCdCheck(command);
     if (cdResult.code === 2) {
       return { block: true, reason: cdResult.stderr.trim() || "denied by the cd-guard PreToolUse seatbelt" };

--- a/bin/fm-tmux-command-policy.mjs
+++ b/bin/fm-tmux-command-policy.mjs
@@ -1,0 +1,347 @@
+#!/usr/bin/env node
+// Semantic policy for the tmux-guard: would a shell command destroy a tmux
+// session, window, or pane on the SHARED server the captain and the whole fleet
+// live on?
+//
+// Firstmate runs the captain's session and every worker window on one tmux
+// server. A worker that runs `tmux kill-server` there destroys the captain's
+// session, its own pane, and every sibling worker at once, and leaves no trace
+// in any system log because a deliberate kill-server is an orderly shutdown.
+// This policy blocks exactly that class of command at the tool boundary; the
+// harness plumbing lives in the bin/fm-tmux-pretool-check.sh transport, not
+// here. See docs/tmux-guard.md for the full contract.
+//
+// The shell tokenizer and command-position analysis are imported from
+// bin/fm-arm-command-policy.mjs, the sole owner of firstmate's shell
+// classification, so this guard never duplicates shell lexing. This policy
+// never evaluates, expands, sources, or runs any byte of the submitted command;
+// it inspects lexical command positions only.
+
+import { Lexer, splitProgram, commandPosition } from "./fm-arm-command-policy.mjs";
+import path from "node:path";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// The one fix every deny must teach. A refusal that leaves the agent guessing
+// gets worked around, and the worked-around form is the one that killed the
+// fleet: TMUX_TMPDIR looks like isolation and is not.
+const REMEDY =
+  "Run tmux work on an isolated server instead: `env -u TMUX tmux -L fm-test-$$ <args>`, tearing it down with `env -u TMUX tmux -L fm-test-$$ kill-server`. " +
+  "Setting TMUX_TMPDIR alone is NOT isolation: a tmux client reads its socket path out of $TMUX, which overrides TMUX_TMPDIR completely, so while $TMUX is set every command still addresses the captain's shared server. " +
+  "Unsetting $TMUX alone is NOT isolation either: tmux then falls back to the DEFAULT socket, which is where the captain's server already lives - you must also name a socket with -L or -S. " +
+  "Prove isolation before experimenting: `env -u TMUX tmux -L fm-test-$$ list-sessions` must not list the firstmate session. " +
+  "Firstmate's own window and session teardown runs through bin/fm-teardown.sh and bin/fm-control.sh, never a hand-typed tmux kill.";
+
+const REASONS = {
+  "shared-tmux-kill-server":
+    `tmux kill-server on the shared server is blocked; it would end the tmux server that hosts the captain's session, this pane, and every sibling worker. ${REMEDY}`,
+  "shared-tmux-kill-session":
+    `tmux kill-session on the shared server is blocked; the session hosting this pane is the captain's own, so killing it takes the captain's session and every sibling worker with it. ${REMEDY}`,
+  "shared-tmux-kill-window":
+    `tmux kill-window/kill-pane on the shared server is blocked; with no target it takes this pane or the attached client's current window, and with a target it can take a sibling worker's window. ${REMEDY}`,
+  "unclassifiable-tmux-kill":
+    `unsupported or malformed shell syntax contains a tmux kill command, so this guard cannot prove it addresses an isolated server. ${REMEDY}`,
+};
+
+// Every tmux command name that destroys a session, window, pane, or the server,
+// including tmux's own documented aliases (killp, killw; kill-server and
+// kill-session have none). Verified against tmux 3.7b `list-commands`.
+const DESTRUCTIVE_COMMANDS = ["kill-server", "kill-session", "kill-window", "kill-pane", "killp", "killw"];
+
+// tmux global options, from `tmux -h` on 3.7b:
+//   tmux [-2CDhlNuVv] [-c shell-command] [-f file] [-L socket-name]
+//        [-S socket-path] [-T features] [command [flags]]
+const TMUX_FLAGS_NO_ARGUMENT = new Set(["2", "C", "D", "h", "l", "N", "u", "V", "v"]);
+const TMUX_FLAGS_WITH_ARGUMENT = new Set(["c", "f", "L", "S", "T"]);
+
+// tmux's own default socket name. `-L default` names the very server this guard
+// is protecting, so it is explicitly NOT an isolated socket.
+const DEFAULT_SOCKET_NAME = "default";
+
+function basename(value) {
+  return value.split("/").filter(Boolean).at(-1) || value;
+}
+
+function deny(code) {
+  return { decision: "deny", code, reason: REASONS[code] };
+}
+
+// tmux resolves any UNAMBIGUOUS prefix of a command name, so `tmux kill-serv`
+// ends the server just as `tmux kill-server` does (verified on 3.7b). Treat a
+// word as destructive when it is a prefix of any destructive name. This
+// deliberately over-approximates the ambiguous prefixes (`k`, `kill`,
+// `kill-s`), which costs nothing: tmux rejects those outright, so a command
+// this guard blocks was never going to run in the first place. The
+// over-approximation is safe in the other direction too - every tmux command
+// name beginning with `k` is a kill command, so no benign command can be caught
+// by it.
+function destructiveCategory(word) {
+  if (!word) return "";
+  const matches = DESTRUCTIVE_COMMANDS.filter((name) => name.startsWith(word));
+  if (matches.length === 0) return "";
+  // Report the most severe reachable command when a prefix is ambiguous.
+  if (matches.includes("kill-server")) return "shared-tmux-kill-server";
+  if (matches.includes("kill-session")) return "shared-tmux-kill-session";
+  return "shared-tmux-kill-window";
+}
+
+// Walk tmux's own global options to find where its subcommand begins, and
+// capture any explicit socket selection on the way.
+function parseTmuxGlobalOptions(words, start) {
+  let index = start;
+  let socketName = null;
+  let socketPath = null;
+  let unresolved = false;
+
+  while (index < words.length) {
+    const value = words[index].value;
+    if (value === "--") {
+      index += 1;
+      break;
+    }
+    if (!value.startsWith("-") || value === "-") break;
+
+    let consumedArgument = false;
+    for (let offset = 1; offset < value.length; offset += 1) {
+      const flag = value[offset];
+      if (TMUX_FLAGS_NO_ARGUMENT.has(flag)) continue;
+      if (!TMUX_FLAGS_WITH_ARGUMENT.has(flag)) {
+        unresolved = true;
+        break;
+      }
+      let argument;
+      if (offset + 1 < value.length) {
+        argument = value.slice(offset + 1);
+        index += 1;
+      } else {
+        if (!words[index + 1]) {
+          unresolved = true;
+          break;
+        }
+        argument = words[index + 1].value;
+        index += 2;
+      }
+      if (flag === "L") socketName = argument;
+      if (flag === "S") socketPath = argument;
+      consumedArgument = true;
+      break;
+    }
+    if (unresolved) break;
+    if (!consumedArgument) index += 1;
+  }
+
+  return { index, socketName, socketPath, unresolved };
+}
+
+// tmux accepts several commands in one invocation, separated by a literal `;`
+// argument (`tmux new-session -d \; kill-server`). Only the first word of each
+// such slot is a command name.
+function destructiveCategoriesIn(words, start) {
+  const categories = [];
+  let expectCommandName = true;
+  for (let index = start; index < words.length; index += 1) {
+    const value = words[index].value;
+    if (value === ";") {
+      expectCommandName = true;
+      continue;
+    }
+    if (!expectCommandName) continue;
+    expectCommandName = false;
+    const category = destructiveCategory(value);
+    if (category) categories.push(category);
+  }
+  return categories;
+}
+
+// `env -u TMUX` / `env --unset TMUX`, in any of the spellings env accepts.
+function unsetsTmuxVariable(position) {
+  const prefix = position.words.slice(0, position.index);
+  for (let index = 0; index < prefix.length; index += 1) {
+    const value = prefix[index].value;
+    if (value === "--unset=TMUX") return true;
+    if ((value === "--unset" || /^-[A-Za-z]*u$/.test(value)) && prefix[index + 1]?.value === "TMUX") return true;
+    if (/^-[A-Za-z]*uTMUX$/.test(value)) return true;
+  }
+  return false;
+}
+
+// A non-empty TMUX_TMPDIR assignment anywhere in this command's prefix, whether
+// written as a shell assignment (`TMUX_TMPDIR=x env ...`) or handed to env
+// itself (`env -u TMUX TMUX_TMPDIR=x tmux ...`).
+function setsPrivateTmpdir(position) {
+  return position.words
+    .slice(0, position.index)
+    .some((word) => /^TMUX_TMPDIR=./.test(word.value));
+}
+
+// Does this invocation provably address a server other than the shared one?
+//
+// Only an explicitly named socket proves it, because socket selection is the
+// single thing that decides which server a tmux client talks to. The one
+// exception is the genuinely private-tmpdir form: with $TMUX unset AND
+// TMUX_TMPDIR pointing somewhere private, tmux's default socket resolves under
+// that private directory instead (verified on tmux 3.7b).
+function addressesIsolatedServer(position, invocation, liveSocketPath) {
+  if (invocation.socketPath !== null) {
+    if (!invocation.socketPath) return false;
+    if (liveSocketPath && path.normalize(invocation.socketPath) === path.normalize(liveSocketPath)) return false;
+    return true;
+  }
+  if (invocation.socketName !== null) {
+    return Boolean(invocation.socketName) && invocation.socketName !== DEFAULT_SOCKET_NAME;
+  }
+  return unsetsTmuxVariable(position) && setsPrivateTmpdir(position);
+}
+
+function rawMentionsTmuxKill(source) {
+  return /(?:^|[/\s'"`($;&|])tmux\b/.test(source) && /kill/.test(source);
+}
+
+// Literal `sh -c` / `bash -c` / `zsh -c` payloads, so a kill one level down is
+// still seen. A non-literal payload (one carrying an expansion or a
+// substitution) is left alone: this guard classifies, it never expands.
+function shellCommandPayload(position) {
+  if (!position.command) return null;
+  if (!["sh", "bash", "zsh"].includes(basename(position.command.value))) return null;
+  const words = position.words;
+  for (let index = position.index + 1; index < words.length; index += 1) {
+    if (!/^-[A-Za-z]*c[A-Za-z]*$/.test(words[index].value)) continue;
+    let payloadIndex = index + 1;
+    if (words[payloadIndex]?.value === "--") payloadIndex += 1;
+    const payload = words[payloadIndex];
+    if (!payload || !payload.literal || payload.subs.length > 0) return null;
+    return payload.value;
+  }
+  return null;
+}
+
+function evalCommandPayload(position) {
+  if (!position.command || basename(position.command.value) !== "eval") return null;
+  const payloads = position.words.slice(position.index + 1);
+  if (payloads.length === 0) return null;
+  if (payloads.some((payload) => !payload.literal || payload.subs.length > 0)) return null;
+  return payloads.map((payload) => payload.value).join(" ");
+}
+
+// Unlike the sibling cd-guard, this scan never skips a node for running in a
+// subshell, a pipeline, or the background: none of those contain the damage.
+// `(tmux kill-server)` and `tmux kill-server &` end the shared server exactly
+// as the bare form does, so every executed position is inspected.
+function scanProgram(source, liveSocketPath, depth = 0) {
+  if (depth > 8) return rawMentionsTmuxKill(source) ? "unclassifiable-tmux-kill" : "";
+
+  const lexed = new Lexer(source).tokenize();
+  if (lexed.error) {
+    // Fail CLOSED on syntax this classifier cannot tokenize, but only when the
+    // raw text looks like a tmux kill. The sibling cd-guard fails open because a
+    // false block there costs a wrong-directory write; here a false ALLOW costs
+    // the captain's session and every running worker, so an unclassifiable
+    // command that mentions a tmux kill is refused rather than waved through.
+    return rawMentionsTmuxKill(source) ? "unclassifiable-tmux-kill" : "";
+  }
+
+  const { nodes } = splitProgram(lexed.tokens);
+  for (const tokens of nodes) {
+    const position = commandPosition(tokens);
+
+    // Recurse into every nested program this node carries: subshell and brace
+    // groups, command and process substitutions, and literal shell payloads.
+    for (const token of tokens) {
+      if (token.type === "group") {
+        const nested = scanProgram(token.content, liveSocketPath, depth + 1);
+        if (nested) return nested;
+      }
+      if (token.type === "word") {
+        for (const substitution of token.subs) {
+          const nested = scanProgram(substitution.content, liveSocketPath, depth + 1);
+          if (nested) return nested;
+        }
+      }
+    }
+    for (const payload of [shellCommandPayload(position), evalCommandPayload(position)]) {
+      if (payload === null) continue;
+      const nested = scanProgram(payload, liveSocketPath, depth + 1);
+      if (nested) return nested;
+    }
+
+    if (!position.command) continue;
+    if (basename(position.command.value) !== "tmux") continue;
+
+    const invocation = parseTmuxGlobalOptions(position.words, position.index + 1);
+    const categories = destructiveCategoriesIn(position.words, invocation.index);
+    if (categories.length === 0) continue;
+    // An option this classifier cannot account for may itself be `-L`, so the
+    // invocation is no longer provably isolated.
+    if (invocation.unresolved) return "unclassifiable-tmux-kill";
+    if (addressesIsolatedServer(position, invocation, liveSocketPath)) continue;
+    return categories[0];
+  }
+
+  return "";
+}
+
+function decision(command, liveSocketPath = "") {
+  const code = scanProgram(command, liveSocketPath);
+  return code ? deny(code) : { decision: "allow" };
+}
+
+function parseArguments(argv) {
+  const result = { command: "", commandSet: false, socket: "" };
+  for (let i = 0; i < argv.length; i += 1) {
+    const name = argv[i];
+    if (name === "--command" || name === "--socket") {
+      if (i + 1 >= argv.length) throw new Error(`${name} requires a value`);
+      if (name === "--command") {
+        result.command = argv[i + 1];
+        result.commandSet = true;
+      } else {
+        result.socket = argv[i + 1];
+      }
+      i += 1;
+      continue;
+    }
+    if (name.startsWith("--command=")) {
+      result.command = name.slice("--command=".length);
+      result.commandSet = true;
+      continue;
+    }
+    if (name.startsWith("--socket=")) {
+      result.socket = name.slice("--socket=".length);
+      continue;
+    }
+    throw new Error(`unknown argument: ${name}`);
+  }
+  return result;
+}
+
+function invokedDirectly() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  const self = fileURLToPath(import.meta.url);
+  try {
+    return realpathSync(entry) === realpathSync(self);
+  } catch {
+    return entry === self;
+  }
+}
+
+if (invokedDirectly()) {
+  try {
+    const args = parseArguments(process.argv.slice(2));
+    if (!args.commandSet || !args.command) {
+      process.stdout.write("allow\n");
+    } else {
+      const result = decision(args.command, args.socket);
+      if (result.decision === "allow") {
+        process.stdout.write("allow\n");
+      } else {
+        process.stdout.write(`deny\t${result.code}\t${result.reason}\n`);
+      }
+    }
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+export { decision };

--- a/bin/fm-tmux-pretool-check.sh
+++ b/bin/fm-tmux-pretool-check.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Stable PreToolUse transport for the tmux-guard command policy.
+#
+# Firstmate runs the captain's session and every worker window on ONE tmux
+# server. A `tmux kill-server` from any agent pane therefore ends the captain's
+# session, that agent, and every sibling worker at once. This seatbelt denies
+# such a command before it runs.
+# bin/fm-tmux-command-policy.mjs is the sole owner of the block/allow decision;
+# it reuses the shell classifier owned by bin/fm-arm-command-policy.mjs. This
+# wrapper only acquires the harness payload, supplies the live socket path,
+# invokes that policy, and renders the established harness responses. It never
+# executes, sources, evaluates, or expands the command.
+# See docs/tmux-guard.md for the complete contract and validation record.
+#
+# SCOPE, deliberately UNLIKE the sibling cd-guard: this guard binds EVERY agent
+# in a firstmate checkout - the primary firstmate session and every crewmate or
+# scout task worktree alike. The cd-guard is inert in a linked worktree because
+# only the primary's cwd is worth protecting; here the worker IS the threat, so
+# there is no checkout-shape scoping at all. Firstmate's own control plane needs
+# no carve-out: bin/backends/tmux.sh and bin/fm-afk-launch.sh call tmux from
+# inside script processes, which a PreToolUse hook never sees, so their
+# kill-window and kill-session calls are outside this guard's aperture by
+# construction.
+#
+# Usage:
+#   <PreToolUse JSON on stdin> | bin/fm-tmux-pretool-check.sh
+#   bin/fm-tmux-pretool-check.sh --command '<cmd>'
+#
+# Stdin mode extracts .toolInput.command for Grok or .tool_input.command for
+# Claude and Codex. CLI mode is used by OpenCode and Pi after their adapters
+# extract the exact command string.
+#
+# Exit/output contract (identical shape to bin/fm-cd-pretool-check.sh):
+#   ALLOW - exit 0 and no output.
+#   DENY - exit 2, a Claude-shaped deny object on stderr, and a Grok-shaped
+#          deny object on stdout unless --claude was supplied.
+#   INERT - not a firstmate checkout: exit 0 with no output, exactly like ALLOW.
+#   FAIL OPEN - malformed or empty stdin, missing jq for stdin transport,
+#               missing Node or policy owner, or an invalid policy response.
+#
+# Claude requires stdout to remain empty on deny.
+# Codex blocks on exit 2 and displays stderr.
+# Grok consumes the stdout decision object.
+# OpenCode and Pi consume exit 2 plus stderr.
+set -u
+
+CMD=""
+CMD_SET=0
+CLAUDE_MODE=0
+
+usage() {
+  cat <<'EOF'
+Usage: fm-tmux-pretool-check.sh [--command <cmd>] [--claude]
+
+With no --command, reads a PreToolUse-style JSON payload on stdin (Grok
+toolInput.command, or Claude/Codex tool_input.command).
+Fires for every agent in a firstmate checkout, primary and task worktree alike;
+it is a silent no-op outside one.
+Exits 0 to allow and 2 to deny a tmux command that would destroy a session,
+window, or pane on the shared server the captain and the fleet share.
+The deny reason is written to stderr, with a Grok decision object on stdout
+unless --claude is supplied.
+Malformed transport and an unavailable classifier runtime fail open.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --command)
+      [ "$#" -gt 1 ] || { echo "error: --command requires a value" >&2; exit 2; }
+      CMD=$2
+      CMD_SET=1
+      shift 2
+      ;;
+    --command=*)
+      CMD=${1#--command=}
+      CMD_SET=1
+      shift
+      ;;
+    --claude)
+      CLAUDE_MODE=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ "$CMD_SET" -eq 0 ]; then
+  PAYLOAD=$(cat 2>/dev/null || true)
+  [ -n "$PAYLOAD" ] || exit 0
+  command -v jq >/dev/null 2>&1 || exit 0
+  CMD=$(printf '%s' "$PAYLOAD" | jq -r '(.toolInput.command // .tool_input.command // empty)' 2>/dev/null) || exit 0
+fi
+
+[ -n "$CMD" ] || exit 0
+
+# Strict-superset prefilter (transport only; owns zero classification
+# semantics). Strip syntax bytes that the classifier joins within a shell word
+# before looking for tmux, so ordinary quoted or escaped fragments cannot hide a
+# deniable command from the policy owner. A quoting-decoder marker - a $
+# immediately followed by a single quote (ANSI-C $'...') or a double quote (bash
+# locale $"...") - delegates too, because the classifier decodes those and can
+# reconstruct tmux from bytes this substring test cannot see. This marker set is
+# COUPLED to the classifier's decoder set in bin/fm-arm-command-policy.mjs:
+# adding any new quote/expansion form the classifier decodes REQUIRES extending
+# it here in the same change, or the prefilter stops being a strict superset.
+# Deliberate deeper obfuscation is out of scope by the same agent-mistake threat
+# model the policy uses.
+PREFILTER=$CMD
+PREFILTER=${PREFILTER//\\/}
+PREFILTER=${PREFILTER//\"/}
+PREFILTER=${PREFILTER//\'/}
+PREFILTER=${PREFILTER//$'\n'/}
+PREFILTER=${PREFILTER//$'\r'/}
+case "$CMD" in
+  *"\$'"*|*'$"'*) ;;
+  *)
+    case "$PREFILTER" in
+      *tmux*) ;;
+      *) exit 0 ;;
+    esac
+    ;;
+esac
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" 2>/dev/null && pwd -P) || exit 0
+FM_ROOT=${FM_ROOT_OVERRIDE:-$(CDPATH='' cd -- "$SCRIPT_DIR/.." 2>/dev/null && pwd -P)} || exit 0
+
+# Confirm a firstmate checkout and nothing more. There is deliberately no
+# git-dir/git-common-dir test here: a crewmate or scout task worktree is a
+# linked worktree, and that is exactly the agent this guard exists to bind.
+# Any failure to confirm the checkout is inert (exit 0), never a block, so a
+# broken environment never denies a shell command.
+[ -f "$FM_ROOT/AGENTS.md" ] || exit 0
+[ -d "$FM_ROOT/bin" ] || exit 0
+
+POLICY="$FM_ROOT/bin/fm-tmux-command-policy.mjs"
+command -v node >/dev/null 2>&1 || exit 0
+[ -f "$POLICY" ] || exit 0
+
+# The live server's socket path, so the policy can tell an explicit
+# `-S <path>` that names a genuinely separate server from one that just spells
+# out the shared server's own socket. $TMUX is "<socket>,<pid>,<session>".
+LIVE_SOCKET=${TMUX%%,*}
+
+POLICY_OUTPUT=$(node "$POLICY" --command "$CMD" --socket "$LIVE_SOCKET" 2>/dev/null) || exit 0
+[ -n "$POLICY_OUTPUT" ] || exit 0
+
+TAB=$(printf '\t')
+DECISION=${POLICY_OUTPUT%%"$TAB"*}
+[ "$DECISION" = "deny" ] || exit 0
+REST=${POLICY_OUTPUT#*"$TAB"}
+[ "$REST" != "$POLICY_OUTPUT" ] || exit 0
+CODE=${REST%%"$TAB"*}
+REASON=${REST#*"$TAB"}
+[ -n "$CODE" ] && [ -n "$REASON" ] && [ "$REASON" != "$REST" ] || exit 0
+
+json_escape() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' | tr '\n' ' '
+}
+
+DETAIL="[$CODE] $REASON"
+ESCAPED=$(json_escape "$DETAIL")
+printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"},"systemMessage":"%s"}\n' "$ESCAPED" >&2
+[ "$CLAUDE_MODE" -eq 1 ] || printf '{"decision":"deny","reason":"%s"}\n' "$ESCAPED"
+exit 2

--- a/docs/cd-guard.md
+++ b/docs/cd-guard.md
@@ -5,8 +5,9 @@ This document is the authoritative human-readable contract for the cd-guard PreT
 `bin/fm-cd-pretool-check.sh` is the stable harness transport, primary-checkout scope, and output renderer.
 The tracked harness adapters forward command text without classifying it.
 
-It is the third member of a family of primary-session guards that share the same cross-harness hook machinery:
-the watcher-arm PreToolUse seatbelt (`bin/fm-arm-pretool-check.sh`, `docs/arm-pretool-check.md`) and the turn-end supervision guard (`bin/fm-turnend-guard.sh`, `docs/turnend-guard.md`).
+It is one of a family of guards that share the same cross-harness hook machinery:
+the watcher-arm PreToolUse seatbelt (`bin/fm-arm-pretool-check.sh`, `docs/arm-pretool-check.md`), the turn-end supervision guard (`bin/fm-turnend-guard.sh`, `docs/turnend-guard.md`), and the tmux-guard (`bin/fm-tmux-pretool-check.sh`, `docs/tmux-guard.md`).
+The cd-guard and the watcher-arm seatbelt are primary-session guards; the tmux-guard deliberately binds workers as well, and owns the reasoning for that difference.
 
 ## Purpose and boundary
 

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -321,6 +321,10 @@
       "audience": "operator-current"
     },
     {
+      "path": "docs/tmux-guard.md",
+      "audience": "maintainer-architecture"
+    },
+    {
       "path": "docs/trace-context.md",
       "audience": "maintainer-architecture"
     },

--- a/docs/tmux-guard.md
+++ b/docs/tmux-guard.md
@@ -1,0 +1,224 @@
+# tmux-guard PreToolUse seatbelt
+
+This document is the authoritative human-readable contract for the tmux-guard PreToolUse seatbelt.
+`bin/fm-tmux-command-policy.mjs` is the single decision owner.
+`bin/fm-tmux-pretool-check.sh` is the stable harness transport and output renderer.
+The tracked harness adapters forward command text without classifying it.
+
+It is the fourth member of a family of guards that share the same cross-harness hook machinery:
+the watcher-arm PreToolUse seatbelt (`bin/fm-arm-pretool-check.sh`, `docs/arm-pretool-check.md`), the cd-guard (`bin/fm-cd-pretool-check.sh`, `docs/cd-guard.md`), and the turn-end supervision guard (`bin/fm-turnend-guard.sh`, `docs/turnend-guard.md`).
+
+## Purpose and boundary
+
+Firstmate runs the captain's session and every worker window on ONE tmux server.
+A `tmux kill-server` from any agent pane therefore ends the captain's session, that agent, and every sibling worker at once.
+
+That has actually happened.
+On 2026-08-11 a worker set `TMUX_TMPDIR=$(mktemp -d)`, believed it had obtained a private server, and ended its script with `tmux kill-server`.
+The isolation was a no-op, so every command in that script addressed the live shared server, and the final `kill-server` destroyed the captain's session, the worker itself, and three other working agents.
+Nothing appeared in any system log, because a deliberate `kill-server` is an orderly shutdown.
+
+The seatbelt denies exactly that class of command - a tmux command that would destroy a session, window, pane, or the server itself on the shared server - before it runs.
+
+This guard is not a general sandbox.
+It classifies shell command positions only; it never evaluates, expands, sources, or runs any byte of the submitted command.
+Its threat model is agent mistakes, the same as its siblings: a worker that believes it is isolated and is not, rather than a deliberately obfuscated bypass.
+
+## Scope: every agent, primary and worker alike
+
+The guard binds **everyone**: firstmate's primary session and every crewmate or scout task worktree.
+This is a deliberate inversion of the cd-guard, which is inert in a linked worktree because only the primary's working directory is worth protecting.
+Here the worker is the threat, so there is no checkout-shape scoping at all.
+
+`bin/fm-tmux-pretool-check.sh` confirms only that it sits in a firstmate checkout (`AGENTS.md` and `bin/` are present) and is a silent no-op (exit 0, no output) anywhere else.
+Any failure to confirm the checkout is treated as inert, never as a block.
+
+### The control plane needs no carve-out
+
+Firstmate's own scripts legitimately run destructive tmux commands: `bin/backends/tmux.sh` kills a task window, and `bin/fm-afk-launch.sh` kills its dedicated daemon session.
+Neither is affected, because **this guard is a tool-boundary check**.
+It only ever sees the command string an agent submits to its shell tool.
+Those scripts call tmux from inside a script process, which no PreToolUse hook observes, so their calls are outside the guard's aperture by construction rather than by an exemption that could be spoofed.
+
+The sanctioned path for the control plane is therefore the existing one: window and session teardown runs through `bin/fm-teardown.sh` and `bin/fm-control.sh`, never a hand-typed `tmux kill-*`.
+An agent that types a destructive tmux command directly is denied, primary included, and the deny message names those scripts.
+
+`tests/fm-tmux-pretool-check.test.sh` proves both halves: the control-plane kill shapes still remove their targets and only their targets on a live private server, and the tool-boundary commands that drive those scripts are allowed.
+
+## Block vs allow
+
+The discriminator is **which tmux server the command addresses**, not the mere presence of the token `tmux`.
+
+The guard **blocks** a destructive tmux command that is not proven to address an isolated server:
+
+- `kill-server` in any form.
+- `kill-session`, with or without a target.
+- `kill-window` and `kill-pane`, with or without a target.
+
+This covers the command-name prefixes tmux itself resolves and its documented aliases, any list or compound form where the command still runs (`(tmux kill-server)`, `tmux kill-server &`, `tmux kill-server | cat`, `true && tmux kill-server`, newline-separated lists, `2>/dev/null` redirection), a literal `bash -c` / `sh -c` / `zsh -c` payload one level down, leading assignments, quoted or escaped command words that cook to `tmux`, a path-qualified `/usr/bin/tmux`, and tmux's own `\;` multi-command separator.
+
+The guard **allows** everything else, including these forms that must never attract friction:
+
+- An explicitly named socket: `tmux -L <socket>` (any name but `default`), `-L<socket>` clustered, or `tmux -S <path>` naming a socket other than the live server's own.
+- The genuinely private-tmpdir form: `env -u TMUX TMUX_TMPDIR=<dir> tmux ...`, in either word order.
+- Every non-destructive tmux command: `list-sessions`, `list-windows`, `new-session`, `new-window`, `send-keys`, `capture-pane`, `display-message`, `has-session`.
+- The firstmate scripts that own teardown: `bin/fm-teardown.sh`, `bin/fm-control.sh`, `bin/fm-afk-launch.sh`.
+- The token as data: quoted text, a `printf` payload, a `grep` pattern, or a different program entirely (`tmuxinator`, `killall`, `pkill`, `kill`).
+
+### Why `kill-session` and `kill-window` are denied even with an explicit target
+
+On the shared server there is no session an agent may legitimately kill: the session hosting its own pane **is** the captain's.
+Killing "its own" session takes the captain's session and every sibling worker with it.
+A targeted `kill-window` is likewise indistinguishable, at classification time, from taking a sibling worker's window, and an untargeted one takes the attached client's current window or this very pane.
+
+Denying the whole class is simpler than a target-identity test the guard cannot perform reliably, and the cost asymmetry justifies it: a false block costs one retry with `-L`, while a false allow costs the captain's session and every running worker.
+The escape hatch is always available and is the same one an agent should have used anyway.
+
+### Why `env -u TMUX` alone is NOT treated as isolation
+
+This is the guard's most important divergence from intuition, and it is empirically grounded (see the validation record below).
+
+Unsetting `$TMUX` removes the inherited server binding, but tmux then falls back to its **default** socket - which is exactly where the captain's server lives.
+`env -u TMUX tmux kill-server` therefore still destroys the shared server.
+`env -u TMUX` is necessary for isolation but not sufficient; a socket must also be named, or `TMUX_TMPDIR` must relocate the default socket into a private directory.
+
+Accepting `env -u TMUX` on its own would have left the incident reproducible behind a twelve-character prefix that reads as safe, so the guard requires the socket.
+
+### Accepted non-goals
+
+Consistent with the agent-mistake threat model, the guard deliberately does not chase every obfuscated bypass:
+
+- A destructive command inside a separate script file (`bash /tmp/repro.sh`) is not seen, because the guard classifies the submitted command, not files it would have to read and execute.
+- A `tmux` word reconstructed by a command substitution, or a non-literal `bash -c "$VAR"` payload, is not resolved, because the guard never expands.
+- `tmux source-file` and `tmux run-shell` payloads are not followed.
+
+Unlike the cd-guard, malformed or untokenizable syntax **fails closed** when the raw text mentions a tmux kill, returning `unclassifiable-tmux-kill`.
+The cd-guard prioritizes zero false blocks because a blocked backlog write is a correctness hazard; here a false allow destroys the fleet, so the asymmetry points the other way.
+
+## Stable reason codes
+
+Every deny carries one stable code in square brackets before its prose reason.
+
+| Code | Meaning |
+| --- | --- |
+| `shared-tmux-kill-server` | A `kill-server` would end the tmux server hosting the captain's session, this pane, and every sibling worker. |
+| `shared-tmux-kill-session` | A `kill-session` would take the captain's own session and every worker in it. |
+| `shared-tmux-kill-window` | A `kill-window` or `kill-pane` would take this pane, the attached client's current window, or a sibling worker's window. |
+| `unclassifiable-tmux-kill` | Unsupported or malformed shell syntax contains a tmux kill, so isolation cannot be proven. |
+
+An ambiguous command-name prefix that could reach more than one of these reports the most severe reachable command.
+
+### The deny message must teach the fix
+
+A refusal that leaves the agent guessing gets worked around, and the worked-around form is the one that killed the fleet.
+Every deny therefore names the isolated form (`env -u TMUX tmux -L fm-test-$$ <args>`), states that `TMUX_TMPDIR` is ignored while `$TMUX` is set, states that unsetting `$TMUX` alone falls back to the default socket, gives the pre-flight isolation check, and names the firstmate scripts that own real teardown.
+`tests/fm-tmux-pretool-check.test.sh` pins those contents so the teaching cannot be dropped.
+
+## Transport and fail-open behavior
+
+`bin/fm-tmux-pretool-check.sh` supports all five harness-engine entry shapes used by the tracked adapters, with pi-signed sharing Pi's shape:
+
+- Claude sends stdin JSON at `.tool_input.command` and adds `--claude` to preserve Claude's stderr-only deny requirement.
+- Codex sends stdin JSON at `.tool_input.command` without `--claude`.
+- Grok sends stdin JSON at `.toolInput.command`.
+- OpenCode sends the exact command string through `--command <exact string>`.
+- Pi and pi-signed send the exact command string through `--command <exact string>`.
+
+Processing order is cheapest-first: a strict-superset prefilter, then the firstmate-checkout confirmation, then the Node policy owner.
+The prefilter removes ordinary single quotes, double quotes, backslashes, carriage returns, and newlines before fast-allowing any command that carries no `tmux` substring and no quoting-decoder marker (`$'` ANSI-C or `$"` locale), so quoted or escaped command-word fragments delegate to the policy while most commands never pay for the Node process.
+The quoting-decoder marker set is coupled to the classifier's decoder set in `bin/fm-arm-command-policy.mjs`: adding any new quote or expansion form the classifier decodes requires extending the prefilter marker set in the same change, or it stops being a strict superset.
+
+The transport passes the live server's socket path (`${TMUX%%,*}`) to the policy as `--socket`, so an explicit `-S` that merely spells out the shared server's own socket is still denied.
+
+Empty stdin, unparseable JSON, missing `jq` on the stdin path, missing Node, a missing policy owner, or an invalid policy response all fail open with exit 0 and no output.
+A broken hook must never deny every shell tool call.
+Note that this transport-level fail-open is distinct from the policy's classification-level fail-closed: a working guard refuses an unclassifiable tmux kill, while a broken guard steps aside entirely.
+
+## Output contract
+
+Identical in shape to `docs/cd-guard.md`:
+
+- Allow (and inert-outside-firstmate) returns exit 0 with both streams empty.
+- Deny returns exit 2 and writes `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"},"systemMessage":"[<code>] reason"}` to stderr.
+- Default deny mode also writes `{"decision":"deny","reason":"[<code>] reason"}` to stdout for Grok.
+- `--claude` suppresses stdout completely because Claude ignores a PreToolUse deny when stdout is nonempty.
+- Codex blocks on exit 2 and displays stderr.
+- OpenCode throws only when the checker exits 2.
+- Pi and pi-signed return `{block: true}` only when the checker exits 2.
+
+## Shared classifier ownership
+
+`bin/fm-tmux-command-policy.mjs` imports the shell tokenizer and command-position analysis (`Lexer`, `splitProgram`, `commandPosition`) from `bin/fm-arm-command-policy.mjs`, the sole owner of firstmate's shell classification.
+The tmux-guard never duplicates shell lexing; it adds only the tmux-specific decision on top of that shared classifier.
+`bin/fm-arm-command-policy.mjs` runs its own CLI entry point only when invoked directly, never on import, so the policies stay independent CLIs over one parser.
+
+Unlike the cd policy, this one does not skip a node for running in a subshell, a pipeline, or the background: none of those contain the damage, so every executed position is inspected, and subshell groups, brace groups, substitutions, and literal shell payloads are scanned recursively to a bounded depth.
+
+## Harness wiring
+
+| Harness | Entry | Adapter behavior on checker exit 2 |
+| --- | --- | --- |
+| Claude | `.claude/settings.json` PreToolUse Bash hook forwarding stdin with `--claude` | Blocks the tool call; stderr deny object, stdout empty. |
+| Codex | `.codex/hooks.json` PreToolUse hook that anchors from `pwd -P`, verifies the hook-loaded firstmate root, and forwards the payload | Blocks on exit 2 and displays stderr. |
+| Grok | `.grok/hooks/fm-tmux-check.json` PreToolUse hook anchored on `${GROK_WORKSPACE_ROOT:-}` | Consumes the stdout `decision=deny` object. |
+| OpenCode | `.opencode/plugins/fm-tmux-check.js` `tool.execute.before` | Throws, which surfaces as the failed tool result. |
+| Pi | `.pi/extensions/fm-primary-turnend-guard.ts` `tool_call` handler | Returns `{block: true}`; piggybacks on the already-loaded primary extension so no extra `-e` flag is needed. |
+
+Each harness runs the tmux-guard alongside the watcher-arm and cd seatbelts; the three are independent checks, and any deny blocks the command.
+Every shell variable reference in the Grok hook command carries an inline default (`${GROK_WORKSPACE_ROOT:-}`) because Grok expands the raw hook command before `bash -lc` runs it, the same requirement documented in `docs/arm-pretool-check.md`.
+
+### Known residual gaps
+
+These are named rather than silently accepted, and none of them is a regression: they are the existing reach of this repo's hook wiring.
+
+- **Worker coverage depends on the harness loading this repo's hook config.**
+  Claude (`.claude/settings.json`) and OpenCode (`.opencode/plugins/`) load project configuration from the worktree automatically, so a firstmate-repo worker on those harnesses is covered.
+  Codex and Grok gate project hooks behind folder trust, which `bin/fm-spawn.sh` does not establish for a worker pane.
+  A Pi worker loads only the per-task extension `bin/fm-spawn.sh` generates (`state/<task-id>.pi-ext.ts`), not `.pi/extensions/fm-primary-turnend-guard.ts`, so it currently receives none of the three PreToolUse seatbelts - a pre-existing gap that predates this guard and applies equally to the watcher-arm and cd guards.
+- **`kimi` and `muse` have no PreToolUse hook mechanism configured in this repo at all**, so they carry none of the four guards.
+- **Workers on a project clone load that project's configuration, not firstmate's**, so the guard does not reach them.
+  The incident worker was a firstmate-repo worker, which is covered.
+
+Closing the Pi per-task and trust-gated paths means changing `bin/fm-spawn.sh` launch plumbing and belongs in follow-up work.
+
+## Automated validation
+
+`tests/fm-tmux-pretool-check.test.sh` owns the acceptance matrix.
+Every block and allow case runs through Codex-shaped stdin, Claude-shaped stdin, Grok-shaped stdin, OpenCode-shaped CLI, and Pi-shaped CLI entry forms.
+The suite also proves the end-to-end incident regression, the control-plane calls still working, the scoping (fires in a crewmate/scout linked worktree and in the primary, inert outside a firstmate checkout), the deny message's teaching content, the fail-open transport behavior, the prefilter fast path, the policy CLI output contract, and the per-harness wiring.
+
+The incident regression is a real reproduction, not a fixture assertion.
+It stands up a throwaway tmux server on a private socket as a stand-in for the captain's, confirms that a pane on that server inherits a `$TMUX` pointing at the private socket before anything destructive runs, then executes the incident's script byte for byte inside that pane and asserts the stand-in server died - proving `TMUX_TMPDIR` was a no-op - before asserting that the guard denies the exact same command text.
+The test refuses to run its destructive fixture at all if the pre-flight socket check does not match.
+
+Run:
+
+```sh
+bash -n bin/fm-tmux-pretool-check.sh
+shellcheck bin/fm-tmux-pretool-check.sh tests/fm-tmux-pretool-check.test.sh
+node --check bin/fm-tmux-command-policy.mjs
+node --check bin/fm-arm-command-policy.mjs
+tests/fm-tmux-pretool-check.test.sh
+tests/fm-turnend-guard.test.sh
+```
+
+`tests/fm-turnend-guard.test.sh` is listed because it owns the cross-cutting assertion that every tracked `.claude/settings.json` entry runs under native Claude and stays inert under Grok, which this guard's entry must satisfy.
+
+## Empirical record, 2026-08-11 (tmux 3.7b, Linux)
+
+These facts are what the classifier's shape rests on, and each was measured on an isolated server (`env -u TMUX tmux -L fm-test-$$ ...`) or through a read-only listing.
+
+- **`$TMUX` overrides `TMUX_TMPDIR`.** With `$TMUX` set, `TMUX_TMPDIR=/tmp/claude-1000/privtest tmux list-sessions` returned the captain's `firstmate: 3 windows (attached)`, not an empty private server. This is the incident's root cause, reproduced read-only.
+- **`env -u TMUX` alone is not isolation.** `env -u TMUX tmux list-sessions` also returned `firstmate: 3 windows (attached)`, because tmux falls back to the default socket, which is where that server lives.
+- **`env -u TMUX` plus `TMUX_TMPDIR` is genuine isolation.** `env -u TMUX TMUX_TMPDIR=/tmp/claude-1000/privtest tmux new-session -d -s priv` created a server whose socket was `<TMUX_TMPDIR>/tmux-1000/default`, separate from the captain's.
+- **tmux resolves unambiguous command-name prefixes.** `tmux kill-serv` exited 0 and ended the server. `tmux kill-w` and `tmux kill-p` resolved to `kill-window` and `kill-pane`. `tmux k`, `tmux kill`, and `tmux kill-s` were rejected as ambiguous, which is why over-approximating the ambiguous prefixes costs nothing.
+- **The destructive alias set is exactly `killp` and `killw`.** `tmux list-commands -F '#{command_list_name} | #{command_list_alias}'` shows `kill-pane | killp`, `kill-window | killw`, and no alias for `kill-server` or `kill-session`.
+- **Every tmux command name beginning with `k` is a kill command.** Filtering the full 169-name command and alias list for `^k` yields only the four `kill-*` names plus `killp` and `killw`, so treating "is a prefix of a destructive name" as destructive cannot catch a benign command.
+
+Refresh this record after a tmux major-version upgrade; the alias set and prefix-resolution behavior are the parts most likely to move.
+
+## Live per-harness validation
+
+Not yet run.
+The cross-harness entry shapes are covered by `tests/fm-tmux-pretool-check.test.sh`, and the Claude entry's grok-inertness and native-Claude liveness are covered by `tests/fm-turnend-guard.test.sh`, but no harness has been launched against this guard.
+Live validation follows the procedure and launch commands in `docs/cd-guard.md` "Live validation record", substituting a top-level `tmux kill-server` (must be denied) and `env -u TMUX tmux -L fm-test-$$ kill-server` against a throwaway private server (must run) as the probe pair.

--- a/tests/fm-tmux-pretool-check.test.sh
+++ b/tests/fm-tmux-pretool-check.test.sh
@@ -1,0 +1,548 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091,SC2016
+# Behavior tests for the tmux-guard PreToolUse seatbelt (docs/tmux-guard.md).
+#
+# bin/fm-tmux-command-policy.mjs is the single owner of the block/allow decision;
+# it reuses the shell classifier owned by bin/fm-arm-command-policy.mjs.
+# bin/fm-tmux-pretool-check.sh is the stable transport driving all five harness
+# entry forms. This suite proves the decision matrix, the harness-output shaping,
+# the deliberate scoping difference from the cd-guard (this guard is NOT inert in
+# a crewmate/scout worktree), the fail-open transport behavior, the prefilter
+# fast path, the end-to-end incident regression, and that firstmate's own
+# control-plane tmux calls still work. No harness is spawned; live per-harness
+# evidence lives in docs/tmux-guard.md.
+#
+# TMUX SAFETY: every tmux command in this file runs as
+# `env -u TMUX tmux -L <private socket> ...`. $TMUX is unset because a tmux
+# client reads its socket path out of $TMUX, which overrides TMUX_TMPDIR
+# entirely; the socket is named explicitly because unsetting $TMUX alone falls
+# back to the DEFAULT socket, which is a real server. The one deliberately
+# destructive fixture runs INSIDE a pane of a private throwaway server, so the
+# $TMUX it inherits points at that server and nothing else.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+fm_git_identity fmtest fmtest@example.invalid
+TMP_ROOT=$(fm_test_tmproot fm-tmux-pretool-check)
+
+# End a private test server and remove the socket file it leaves behind, so
+# repeated runs do not litter the tmux socket directory. Refuses the default
+# socket name outright: nothing in this suite may ever address a real server.
+kill_private_server() {  # <socket-name>
+  local sock=$1
+  case "$sock" in
+    default|"") fail "kill_private_server refused a non-private socket name: '$sock'" ;;
+  esac
+  env -u TMUX tmux -L "$sock" kill-server 2>/dev/null || true
+  rm -f "${TMUX_TMPDIR:-/tmp}/tmux-$(id -u)/$sock"
+}
+
+install_tmux_scripts() {
+  local dir=$1
+  mkdir -p "$dir/bin"
+  cp "$ROOT/bin/fm-tmux-pretool-check.sh" "$dir/bin/fm-tmux-pretool-check.sh"
+  cp "$ROOT/bin/fm-tmux-command-policy.mjs" "$dir/bin/fm-tmux-command-policy.mjs"
+  cp "$ROOT/bin/fm-arm-command-policy.mjs" "$dir/bin/fm-arm-command-policy.mjs"
+  chmod +x "$dir/bin/fm-tmux-pretool-check.sh" "$dir/bin/fm-tmux-command-policy.mjs"
+}
+
+make_primary_fixture() {
+  local dir=$1
+  git init -q "$dir"
+  git -C "$dir" commit -q --allow-empty -m init
+  : > "$dir/AGENTS.md"
+  install_tmux_scripts "$dir"
+  printf '%s\n' "$dir"
+}
+
+# A genuine linked git worktree - the shape bin/fm-spawn.sh hands crewmate/scout
+# tasks, and the agent that caused the incident.
+make_child_worktree_fixture() {
+  local base=$1 dir=$2
+  fm_git_worktree "$base" "$dir" fm/tmux-guard-test-branch
+  : > "$dir/AGENTS.md"
+  install_tmux_scripts "$dir"
+  printf '%s\n' "$dir"
+}
+
+PRIMARY=$(make_primary_fixture "$TMP_ROOT/primary")
+CHECK="$PRIMARY/bin/fm-tmux-pretool-check.sh"
+
+# --- full cross-harness acceptance matrix ----------------------------------
+
+MATRIX_IDS=()
+MATRIX_EXPECTED=()
+MATRIX_COMMANDS=()
+
+matrix_case() {
+  MATRIX_IDS+=("$1")
+  MATRIX_EXPECTED+=("$2")
+  MATRIX_COMMANDS+=("$3")
+}
+
+# BLOCK: destroys a session, window, or pane on the shared server.
+matrix_case B01 deny 'tmux kill-server'
+matrix_case B02 deny 'tmux kill-server 2>/dev/null'
+matrix_case B03 deny 'tmux kill-session'
+matrix_case B04 deny 'tmux kill-session -t firstmate'
+matrix_case B05 deny 'tmux kill-window'
+matrix_case B06 deny 'tmux kill-window -t firstmate:fm-other-task'
+matrix_case B07 deny 'tmux kill-pane'
+matrix_case B08 deny 'tmux kill-pane -t %3'
+# tmux resolves unambiguous command-name prefixes and documented aliases.
+matrix_case B09 deny 'tmux kill-serv'
+matrix_case B10 deny 'tmux killw -t firstmate:fm-other-task'
+matrix_case B11 deny 'tmux killp'
+matrix_case B12 deny 'tmux kill-w'
+matrix_case B13 deny 'tmux kill-p'
+# Ambiguous prefixes: tmux rejects these, so denying them costs nothing.
+matrix_case B14 deny 'tmux kill'
+matrix_case B15 deny 'tmux k'
+# TMUX_TMPDIR is not isolation while $TMUX is set - the incident's exact error.
+matrix_case B16 deny 'TMUX_TMPDIR=/tmp/private tmux kill-server'
+matrix_case B17 deny 'export TMUX_TMPDIR=$(mktemp -d); tmux kill-server'
+# Unsetting $TMUX alone falls back to the DEFAULT socket, still a real server.
+matrix_case B18 deny 'env -u TMUX tmux kill-server'
+matrix_case B19 deny 'env --unset TMUX tmux kill-server'
+# -L default names the very server being protected.
+matrix_case B20 deny 'tmux -L default kill-server'
+# A subshell, pipeline, or background job does not contain the damage.
+matrix_case B21 deny '(tmux kill-server)'
+matrix_case B22 deny 'tmux kill-server &'
+matrix_case B23 deny 'tmux kill-server | cat'
+matrix_case B24 deny 'true && tmux kill-server'
+matrix_case B25 deny 'echo go; tmux kill-server'
+matrix_case B26 deny $'cleanup() { :; }\ntmux kill-server'
+# One level of literal shell payload.
+matrix_case B27 deny 'bash -c "tmux kill-server"'
+matrix_case B28 deny "sh -c 'tmux kill-window -t other'"
+# Quoted or path-qualified command words still cook to tmux.
+matrix_case B29 deny '"tmux" kill-server'
+matrix_case B30 deny '/usr/bin/tmux kill-server'
+matrix_case B31 deny 'tm\ux kill-server'
+# tmux's own multi-command separator.
+matrix_case B32 deny 'tmux new-session -d \; kill-server'
+# Leading assignments and global options before the subcommand.
+matrix_case B33 deny 'FOO=1 tmux kill-server'
+matrix_case B34 deny 'tmux -2 kill-server'
+matrix_case B35 deny 'tmux -f /dev/null kill-server'
+
+# ALLOW: an isolated server, a non-destructive tmux command, or not tmux.
+# These are the forms the guard must never make friction for.
+matrix_case A01 allow 'env -u TMUX tmux -L fm-test-1234 kill-server'
+matrix_case A02 allow 'env -u TMUX tmux -L fm-test-1234 kill-session -t probe'
+matrix_case A03 allow 'env -u TMUX tmux -L fm-test-1234 kill-window -t probe:victim'
+matrix_case A04 allow 'env -u TMUX tmux -L fm-test-1234 kill-pane -t probe:0.1'
+matrix_case A05 allow 'tmux -L fm-test-1234 kill-server'
+matrix_case A06 allow 'tmux -Lfm-test-1234 kill-server'
+matrix_case A07 allow 'tmux -S /tmp/fm-private/socket kill-server'
+matrix_case A08 allow 'env -u TMUX TMUX_TMPDIR=/tmp/fm-private tmux kill-server'
+matrix_case A09 allow 'TMUX_TMPDIR=/tmp/fm-private env -u TMUX tmux kill-server'
+matrix_case A10 allow 'env -u TMUX tmux -L fm-test-1234 list-sessions'
+matrix_case A11 allow 'tmux list-sessions'
+matrix_case A12 allow 'tmux list-windows -a'
+matrix_case A13 allow 'tmux new-session -d -s probe'
+matrix_case A14 allow 'tmux new-window -d -n foo'
+matrix_case A15 allow 'tmux send-keys -t firstmate:fm-task hello Enter'
+matrix_case A16 allow 'tmux capture-pane -p -t firstmate:fm-task'
+matrix_case A17 allow 'tmux display-message -p "#S"'
+matrix_case A18 allow 'tmux has-session -t firstmate'
+# The control plane reaches tmux through firstmate scripts, never a typed kill.
+matrix_case A19 allow 'bin/fm-teardown.sh some-task'
+matrix_case A20 allow 'bin/fm-control.sh some-task interrupt'
+matrix_case A21 allow 'bin/fm-afk-launch.sh stop'
+# The token as data, or another program entirely.
+matrix_case A22 allow 'echo "tmux kill-server"'
+matrix_case A23 allow "printf '%s\\n' 'tmux kill-server'"
+matrix_case A24 allow 'grep -rn "tmux kill-server" docs/'
+matrix_case A25 allow 'killall sleep'
+matrix_case A26 allow 'pkill -f sleep'
+matrix_case A27 allow 'git status'
+matrix_case A28 allow 'kill -9 1234'
+matrix_case A29 allow 'cat bin/backends/tmux.sh'
+matrix_case A30 allow 'tmuxinator start foo'
+
+MATRIX_TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-tmux-policy-matrix.XXXXXX")
+FM_TEST_CLEANUP_DIRS+=("$MATRIX_TMP")
+
+run_matrix_entry() {
+  local id=$1 expected=$2 entry=$3 cmd=$4 payload out_file err_file rc
+  out_file="$MATRIX_TMP/$id-$entry.out"
+  err_file="$MATRIX_TMP/$id-$entry.err"
+
+  case "$entry" in
+    codex)
+      payload=$(jq -cn --arg command "$cmd" '{tool_name:"Bash",tool_input:{command:$command}}')
+      printf '%s' "$payload" | "$CHECK" >"$out_file" 2>"$err_file"
+      rc=$?
+      ;;
+    claude)
+      payload=$(jq -cn --arg command "$cmd" '{tool_name:"Bash",tool_input:{command:$command}}')
+      printf '%s' "$payload" | "$CHECK" --claude >"$out_file" 2>"$err_file"
+      rc=$?
+      ;;
+    grok)
+      payload=$(jq -cn --arg command "$cmd" '{toolName:"run_terminal_command",toolInput:{command:$command}}')
+      printf '%s' "$payload" | "$CHECK" >"$out_file" 2>"$err_file"
+      rc=$?
+      ;;
+    opencode|pi)
+      "$CHECK" --command "$cmd" >"$out_file" 2>"$err_file"
+      rc=$?
+      ;;
+    *)
+      fail "unknown matrix entry form: $entry"
+      ;;
+  esac
+
+  if [ "$expected" = allow ]; then
+    [ "$rc" -eq 0 ] || fail "$id via $entry must allow, got exit $rc: $(cat "$err_file")"
+    [ ! -s "$out_file" ] || fail "$id via $entry allow must leave stdout empty: $(cat "$out_file")"
+    [ ! -s "$err_file" ] || fail "$id via $entry allow must leave stderr empty: $(cat "$err_file")"
+    return
+  fi
+
+  [ "$rc" -eq 2 ] || fail "$id via $entry must deny, got exit $rc"
+  jq -e '.hookSpecificOutput.permissionDecision == "deny" and (.systemMessage | test("\\[(shared-tmux-kill-(server|session|window)|unclassifiable-tmux-kill)\\]"))' "$err_file" >/dev/null 2>&1 \
+    || fail "$id via $entry deny must carry a tmux-guard reason code on stderr: $(cat "$err_file")"
+  if [ "$entry" = claude ]; then
+    [ ! -s "$out_file" ] || fail "$id via claude deny must leave stdout empty: $(cat "$out_file")"
+  elif [ "$entry" = grok ]; then
+    jq -e '.decision == "deny"' "$out_file" >/dev/null 2>&1 \
+      || fail "$id via grok deny must carry decision=deny on stdout: $(cat "$out_file")"
+  fi
+}
+
+test_full_acceptance_matrix() {
+  local i entry
+  for ((i = 0; i < ${#MATRIX_IDS[@]}; i++)); do
+    for entry in codex claude grok opencode pi; do
+      run_matrix_entry "${MATRIX_IDS[$i]}" "${MATRIX_EXPECTED[$i]}" "$entry" "${MATRIX_COMMANDS[$i]}"
+    done
+  done
+  pass "tmux-guard acceptance matrix: ${#MATRIX_IDS[@]} cases x 5 harness entry forms, block/allow all correct"
+}
+
+# --- the deny message must teach the fix ------------------------------------
+
+test_deny_message_teaches_the_isolated_form() {
+  local err
+  err=$("$CHECK" --claude --command 'tmux kill-server' 2>&1 >/dev/null)
+  assert_contains "$err" 'env -u TMUX tmux -L fm-test-$$' \
+    "deny must name the isolated form the agent should use instead"
+  assert_contains "$err" 'TMUX_TMPDIR' \
+    "deny must mention TMUX_TMPDIR, the trap that caused the incident"
+  assert_contains "$err" 'overrides TMUX_TMPDIR' \
+    "deny must state that \$TMUX overrides TMUX_TMPDIR"
+  pass "tmux-guard: the deny message teaches the isolated form and the TMUX_TMPDIR trap"
+}
+
+# --- end-to-end incident regression ----------------------------------------
+
+# Reproduces the 2026-08-11 incident for real, then proves the guard denies the
+# exact command that caused it. The stand-in for the captain's server is a
+# private throwaway socket; the destructive script runs inside a pane of THAT
+# server, so the $TMUX it inherits can only point there.
+test_e2e_incident_regression() {
+  local sock script tmuxdir probe_out victim_socket rc out
+  if ! command -v tmux >/dev/null 2>&1; then
+    pass "tmux not installed, skipping the live incident reproduction"
+    return
+  fi
+
+  sock="fm-test-victim-$$"
+  tmuxdir="$TMP_ROOT/incident"
+  mkdir -p "$tmuxdir"
+  probe_out="$tmuxdir/inherited-tmux"
+  script="$tmuxdir/incident.sh"
+
+  # A stand-in for the captain's shared server, on a private socket.
+  env -u TMUX tmux -L "$sock" new-session -d -s captain -n capwin 'sleep 300' \
+    || { pass "cannot start a private tmux server here, skipping the live reproduction"; return; }
+
+  # SAFETY GATE: confirm a pane on this server inherits a $TMUX that points at
+  # the private socket, BEFORE anything destructive runs. If it does not, the
+  # reproduction is abandoned rather than risking another server.
+  env -u TMUX tmux -L "$sock" new-window -d "bash -c 'printf %s \"\$TMUX\" > $probe_out; sleep 300'"
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    [ -s "$probe_out" ] && break
+    sleep 0.2
+  done
+  victim_socket=$(cut -d, -f1 < "$probe_out" 2>/dev/null || true)
+  case "$victim_socket" in
+    *"$sock") ;;
+    *)
+      kill_private_server "$sock"
+      fail "pane did not inherit the private socket in \$TMUX (got '$victim_socket'); refusing to run the destructive fixture"
+      ;;
+  esac
+
+  # The incident's exact command, byte for byte from the transcript.
+  cat > "$script" <<'INCIDENT'
+export TMUX_TMPDIR=$(mktemp -d)
+S=fmrepro$$
+tmux new-session -d -s "$S" -n realwin 'sleep 300'
+tmux kill-server 2>/dev/null; rm -rf "$TMUX_TMPDIR"
+INCIDENT
+
+  # Run it from a pane of the victim server, exactly as the worker did.
+  env -u TMUX tmux -L "$sock" new-window -d "bash $script"
+  for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+    env -u TMUX tmux -L "$sock" has-session -t captain 2>/dev/null || break
+    sleep 0.2
+  done
+
+  # The reproduction: TMUX_TMPDIR was a no-op, so kill-server took the server
+  # the pane was attached to - the stand-in for the captain's.
+  if env -u TMUX tmux -L "$sock" has-session -t captain 2>/dev/null; then
+    kill_private_server "$sock"
+    fail "baseline: the incident did not reproduce, the victim server survived"
+  fi
+  kill_private_server "$sock"
+
+  # With the guard, the exact command is denied before it can run.
+  out=$("$CHECK" --claude --command "$(cat "$script")" 2>&1); rc=$?
+  expect_code 2 "$rc" "guard must deny the exact incident command"
+  assert_contains "$out" '[shared-tmux-kill-server]' "incident block must carry the kill-server reason code"
+  pass "tmux-guard: reproduces the incident (TMUX_TMPDIR is a no-op) and denies the exact command"
+}
+
+# --- the control plane still works -----------------------------------------
+
+# The guard is a TOOL-boundary check: it only ever sees the command an agent
+# submits to its shell tool. bin/backends/tmux.sh and bin/fm-afk-launch.sh call
+# tmux from inside script processes, which no PreToolUse hook observes. This
+# proves both halves - the real control-plane function still kills its target,
+# and the tool-boundary command that invokes it is allowed.
+test_control_plane_kill_still_works() {
+  local sock windows
+  if ! command -v tmux >/dev/null 2>&1; then
+    pass "tmux not installed, skipping the control-plane proof"
+    return
+  fi
+  sock="fm-test-cp-$$"
+  env -u TMUX tmux -L "$sock" new-session -d -s cp -n keepwin 'sleep 300' \
+    || { pass "cannot start a private tmux server here, skipping the control-plane proof"; return; }
+  env -u TMUX tmux -L "$sock" new-window -d -n fm-victim 'sleep 300'
+
+  # bin/backends/tmux.sh's fm_backend_tmux_kill body, run against the private
+  # server: an explicitly named target, exactly as the real function builds it.
+  env -u TMUX tmux -L "$sock" kill-window -t '=cp:=fm-victim' 2>/dev/null || true
+  windows=$(env -u TMUX tmux -L "$sock" list-windows -t cp -F '#{window_name}' 2>/dev/null | tr '\n' ' ')
+  case "$windows" in
+    *fm-victim*) kill_private_server "$sock"
+                 fail "control-plane kill-window did not remove its target: $windows" ;;
+  esac
+  case "$windows" in
+    *keepwin*) ;;
+    *) kill_private_server "$sock"
+       fail "control-plane kill-window removed the wrong window: $windows" ;;
+  esac
+
+  # bin/fm-afk-launch.sh's dedicated-session close, same shape.
+  env -u TMUX tmux -L "$sock" new-session -d -s fm-afk-daemon 'sleep 300'
+  env -u TMUX tmux -L "$sock" kill-session -t fm-afk-daemon 2>/dev/null || true
+  if env -u TMUX tmux -L "$sock" has-session -t fm-afk-daemon 2>/dev/null; then
+    kill_private_server "$sock"
+    fail "control-plane kill-session did not remove its dedicated daemon session"
+  fi
+  env -u TMUX tmux -L "$sock" has-session -t cp 2>/dev/null \
+    || { kill_private_server "$sock"
+         fail "control-plane kill-session took the wrong session"; }
+  kill_private_server "$sock"
+
+  # And the tool-boundary commands that drive those scripts are never blocked.
+  "$CHECK" --claude --command 'bin/fm-teardown.sh some-task' \
+    || fail "guard must allow the teardown script at the tool boundary"
+  "$CHECK" --claude --command 'bin/fm-control.sh some-task exit' \
+    || fail "guard must allow the control script at the tool boundary"
+  pass "tmux-guard: firstmate's control-plane window/session kills still work and stay allowed"
+}
+
+# --- scoping: unlike the cd-guard, workers are bound -------------------------
+
+test_fires_in_child_worktree() {
+  local base dir out rc
+  base="$TMP_ROOT/child-base"
+  dir="$TMP_ROOT/child-wt"
+  make_child_worktree_fixture "$base" "$dir" >/dev/null
+  out=$("$dir/bin/fm-tmux-pretool-check.sh" --claude --command 'tmux kill-server' 2>&1); rc=$?
+  expect_code 2 "$rc" "tmux-guard MUST fire in a crewmate/scout worktree - that is the agent that caused the incident"
+  assert_contains "$out" '[shared-tmux-kill-server]' "worktree block must carry the reason code"
+  pass "tmux-guard: fires in a crewmate/scout task worktree (deliberately unlike the cd-guard)"
+}
+
+test_fires_in_primary_checkout() {
+  local out rc
+  out=$("$CHECK" --claude --command 'tmux kill-server' 2>&1); rc=$?
+  expect_code 2 "$rc" "tmux-guard must bind the primary session too"
+  assert_contains "$out" '[shared-tmux-kill-server]' "primary block must carry the reason code"
+  pass "tmux-guard: binds firstmate's primary session as well as workers"
+}
+
+test_inert_when_not_firstmate_repo() {
+  local dir out rc
+  dir="$TMP_ROOT/not-firstmate"
+  mkdir -p "$dir"
+  install_tmux_scripts "$dir"   # bin/ present but no AGENTS.md
+  out=$("$dir/bin/fm-tmux-pretool-check.sh" --claude --command 'tmux kill-server' 2>&1); rc=$?
+  expect_code 0 "$rc" "tmux-guard must be inert without AGENTS.md (not a firstmate checkout)"
+  [ -z "$out" ] || fail "tmux-guard produced output outside a firstmate checkout: $out"
+  pass "tmux-guard: inert outside a firstmate checkout"
+}
+
+# --- fail-open transport behavior ------------------------------------------
+
+test_fail_open_empty_stdin() {
+  local out rc
+  out=$("$CHECK" < /dev/null 2>&1); rc=$?
+  expect_code 0 "$rc" "transport must exit 0 on empty stdin"
+  [ -z "$out" ] || fail "transport produced output on empty stdin: $out"
+  pass "tmux-guard: fails open on empty stdin"
+}
+
+test_fail_open_unparseable_json() {
+  local out rc
+  out=$(printf 'not json at all' | "$CHECK" 2>&1); rc=$?
+  expect_code 0 "$rc" "transport must exit 0 on unparseable stdin JSON"
+  [ -z "$out" ] || fail "transport produced output on unparseable JSON: $out"
+  pass "tmux-guard: fails open on unparseable stdin JSON"
+}
+
+test_fail_open_missing_node() {
+  local fakebin tool tool_path out rc
+  fakebin=$(fm_fakebin "$TMP_ROOT/nonode")
+  for tool in bash sh git dirname cat printf sed tr jq; do
+    tool_path=$(command -v "$tool") || continue
+    ln -s "$tool_path" "$fakebin/$tool"
+  done
+  # node deliberately absent from this PATH.
+  out=$(PATH="$fakebin" "$CHECK" --command 'tmux kill-server' 2>&1); rc=$?
+  expect_code 0 "$rc" "transport must fail open when node is unavailable"
+  [ -z "$out" ] || fail "transport produced output without node: $out"
+  pass "tmux-guard: fails open (never blocks) when node is missing"
+}
+
+test_fail_open_missing_jq_on_stdin() {
+  local fakebin tool tool_path out rc
+  fakebin=$(fm_fakebin "$TMP_ROOT/nojq")
+  for tool in bash sh git dirname cat printf sed tr node; do
+    tool_path=$(command -v "$tool") || continue
+    ln -s "$tool_path" "$fakebin/$tool"
+  done
+  out=$(printf '{"tool_input":{"command":"tmux kill-server"}}' | PATH="$fakebin" "$CHECK" 2>&1); rc=$?
+  expect_code 0 "$rc" "stdin transport must fail open when jq is unavailable"
+  [ -z "$out" ] || fail "transport produced output without jq on the stdin path: $out"
+  pass "tmux-guard: fails open on the stdin path when jq is missing"
+}
+
+# --- prefilter fast path ----------------------------------------------------
+
+test_prefilter_skips_node_without_tmux_substring() {
+  local dir fakebin marker tool tool_path out rc
+  dir="$TMP_ROOT/prefilter"
+  make_primary_fixture "$dir" >/dev/null
+  fakebin=$(fm_fakebin "$TMP_ROOT/prefilter-fake")
+  marker="$TMP_ROOT/prefilter-node-called"
+  for tool in bash sh git dirname cat printf sed tr jq; do
+    tool_path=$(command -v "$tool") || continue
+    ln -s "$tool_path" "$fakebin/$tool"
+  done
+  cat > "$fakebin/node" <<EOF
+#!/usr/bin/env bash
+: > "$marker"
+exit 0
+EOF
+  chmod +x "$fakebin/node"
+  out=$(PATH="$fakebin" "$dir/bin/fm-tmux-pretool-check.sh" --command 'git status' 2>&1); rc=$?
+  expect_code 0 "$rc" "prefilter must fast-allow a command with no tmux substring"
+  [ -z "$out" ] || fail "prefilter fast-allow produced output: $out"
+  [ ! -e "$marker" ] || fail "prefilter fast-allow still invoked the node policy owner"
+  pass "tmux-guard: prefilter fast-allows (skips node) when no tmux substring is present"
+}
+
+# --- policy CLI contract ----------------------------------------------------
+
+test_policy_cli_direct() {
+  local policy
+  policy="$ROOT/bin/fm-tmux-command-policy.mjs"
+  [ "$(node "$policy" --command 'tmux kill-server' | cut -f1)" = deny ] \
+    || fail "policy CLI must deny a bare tmux kill-server"
+  [ "$(node "$policy" --command 'env -u TMUX tmux -L fm-test-1 kill-server')" = allow ] \
+    || fail "policy CLI must allow an explicitly socketed kill-server"
+  [ "$(node "$policy" --command 'tmux list-sessions')" = allow ] \
+    || fail "policy CLI must allow a non-destructive tmux command"
+  [ "$(node "$policy")" = allow ] \
+    || fail "policy CLI must allow when no command is supplied"
+  # --socket lets the transport name the live server, so an explicit -S that
+  # merely spells out the shared socket is still denied.
+  [ "$(node "$policy" --command 'tmux -S /tmp/tmux-1000/default kill-server' --socket /tmp/tmux-1000/default | cut -f1)" = deny ] \
+    || fail "policy CLI must deny an -S that names the live shared socket"
+  [ "$(node "$policy" --command 'tmux -S /tmp/private/sock kill-server' --socket /tmp/tmux-1000/default)" = allow ] \
+    || fail "policy CLI must allow an -S that names a different socket"
+  pass "tmux-guard: fm-tmux-command-policy.mjs CLI honors the deny/allow output contract"
+}
+
+# --- per-harness wiring -----------------------------------------------------
+
+test_harness_wiring_present() {
+  jq -e '[.hooks.PreToolUse[] | select(.matcher=="Bash") | .hooks[].command]
+         | any(test("fm-tmux-pretool-check\\.sh"))' "$ROOT/.claude/settings.json" >/dev/null \
+    || fail "claude PreToolUse Bash matcher does not run the tmux-guard"
+  jq -e '[.hooks.PreToolUse[].hooks[].command] | any(test("fm-tmux-pretool-check\\.sh"))' \
+    "$ROOT/.codex/hooks.json" >/dev/null \
+    || fail "codex PreToolUse hooks do not run the tmux-guard"
+  jq -e '[.hooks.PreToolUse[].hooks[].command] | any(test("fm-tmux-pretool-check\\.sh"))' \
+    "$ROOT/.grok/hooks/fm-tmux-check.json" >/dev/null \
+    || fail "grok PreToolUse hook does not run the tmux-guard"
+  grep -q 'fm-tmux-pretool-check.sh' "$ROOT/.opencode/plugins/fm-tmux-check.js" \
+    || fail "opencode plugin does not run the tmux-guard"
+  grep -q 'fm-tmux-pretool-check.sh' "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" \
+    || fail "pi extension does not run the tmux-guard"
+  pass "tmux-guard: wired into all five harness hook trees (claude, codex, grok, opencode, pi)"
+}
+
+test_grok_hook_variables_carry_defaults() {
+  # Grok expands the raw hook command before bash -lc runs it, so every $VAR
+  # must carry an inline default or the hook fails to launch at all.
+  local command remaining
+  command=$(jq -r '.hooks.PreToolUse[].hooks[].command' "$ROOT/.grok/hooks/fm-tmux-check.json")
+  case "$command" in
+    *'${GROK_WORKSPACE_ROOT:-}'*) ;;
+    *) fail "grok hook must reference GROK_WORKSPACE_ROOT with an inline default" ;;
+  esac
+  # Delete every ${NAME:-...} / ${NAME:=...} form, then any surviving $ is a
+  # reference without an inline default. Deleting first avoids the backtracking
+  # a single negative pattern would be prone to.
+  remaining=$(printf '%s' "$command" | sed -E 's/\$\{[A-Za-z_][A-Za-z0-9_]*:[-=][^}]*\}//g')
+  case "$remaining" in
+    *'$'*) fail "grok hook contains a variable reference without an inline default: $command" ;;
+  esac
+  pass "tmux-guard: grok hook variables all carry inline defaults"
+}
+
+test_scripts_are_shellcheck_clean() {
+  command -v shellcheck >/dev/null 2>&1 || { pass "shellcheck not installed, skipping"; return; }
+  shellcheck "$ROOT/bin/fm-tmux-pretool-check.sh" >/dev/null 2>&1 \
+    || fail "bin/fm-tmux-pretool-check.sh is not shellcheck-clean"
+  pass "bin/fm-tmux-pretool-check.sh is shellcheck-clean"
+}
+
+test_full_acceptance_matrix
+test_deny_message_teaches_the_isolated_form
+test_e2e_incident_regression
+test_control_plane_kill_still_works
+test_fires_in_child_worktree
+test_fires_in_primary_checkout
+test_inert_when_not_firstmate_repo
+test_fail_open_empty_stdin
+test_fail_open_unparseable_json
+test_fail_open_missing_node
+test_fail_open_missing_jq_on_stdin
+test_prefilter_skips_node_without_tmux_substring
+test_policy_cli_direct
+test_harness_wiring_present
+test_grok_hook_variables_carry_defaults
+test_scripts_are_shellcheck_clean

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -799,7 +799,8 @@ test_tracked_claude_entries_inert_under_grok() {
   dir="$TMP_ROOT/claude-entries-grok-inert"
   mkdir -p "$dir/bin"
   for script in fm-turnend-guard.sh fm-claude-stop-autoarm.sh fm-sessionstart-run.sh \
-    fm-arm-pretool-check.sh fm-cd-pretool-check.sh fm-subagent-pretool-check.sh; do
+    fm-arm-pretool-check.sh fm-cd-pretool-check.sh fm-tmux-pretool-check.sh \
+    fm-subagent-pretool-check.sh; do
     printf '#!/usr/bin/env bash\nprintf ran >> %q\n' "$dir/invoked" > "$dir/bin/$script"
     chmod +x "$dir/bin/$script"
   done
@@ -840,7 +841,7 @@ test_tracked_claude_entries_inert_under_grok() {
       || fail "tracked entry for $target ran under a legacy GROK_AGENT environment"
   done < <(jq -r '.hooks[][].hooks[].command' "$ROOT/.claude/settings.json")
 
-  [ "$guarded" -eq 5 ] || fail "expected 5 grok-guarded tracked entries, saw $guarded"
+  [ "$guarded" -eq 6 ] || fail "expected 6 grok-guarded tracked entries, saw $guarded"
   [ "$unguarded" -eq 1 ] || fail "expected 1 documented unguarded tracked entry, saw $unguarded"
   pass "tracked .claude/settings.json entries: $guarded inert under grok, the documented subagent exception still armed, all live under Claude"
 }


### PR DESCRIPTION
## What this fixes

A worker that runs `tmux kill-server` from its pane ends the tmux server that hosts the captain's session, itself, and every sibling worker.
Nothing appears in any system log, because a deliberate `kill-server` is an orderly shutdown.

On 2026-08-11 that happened for real, 50 seconds after dispatch:

```sh
export TMUX_TMPDIR=$(mktemp -d)
S=fmrepro$$
tmux new-session -d -s "$S" -n realwin 'sleep 300'
...
tmux kill-server 2>/dev/null; rm -rf "$TMUX_TMPDIR"
```

The isolation was a no-op, so every command addressed the live shared server, and the final `kill-server` took the captain's session and three other working agents.

## What this adds

A fourth member of the existing PreToolUse guard family, following the established three-part shape rather than inventing a fourth:

| File | Role |
| --- | --- |
| `bin/fm-tmux-command-policy.mjs` | The classifier, sole owner of the decision and its reason codes. Reuses `Lexer`, `splitProgram` and `commandPosition` from `bin/fm-arm-command-policy.mjs`, so it never duplicates shell lexing, and never evaluates, expands, sources or runs any byte of the command. |
| `bin/fm-tmux-pretool-check.sh` | The transport, modelled on `bin/fm-cd-pretool-check.sh` including its fail-open cases and per-harness deny shapes. |
| `docs/tmux-guard.md` | The contract, matching `docs/cd-guard.md`. |

The discriminator is **which tmux server the command addresses**, not the presence of the token `tmux`.
`kill-server`, `kill-session`, `kill-window` and `kill-pane` are denied unless an explicitly named socket (`-L`/`-S`) or a genuinely private `TMUX_TMPDIR` with `$TMUX` unset proves the target is isolated.

## One deliberate divergence from the brief, with evidence

The brief asked to allow "anything under `env -u TMUX`".
**This does not ship that**, because it is not safe, and the measurement is direct:

```
$ env -u TMUX tmux list-sessions
firstmate: 3 windows (created Tue Aug 11 14:08:45 2026) (attached)
```

With `$TMUX` unset, tmux falls back to the **default** socket, which is exactly where the captain's server lives (`$TMUX` reports `/tmp/tmux-1000/default,...`).
`env -u TMUX tmux kill-server` therefore still destroys the shared server.
Accepting it would have left the incident reproducible behind a twelve-character prefix that reads as safe.

`env -u TMUX` is required but not sufficient: a socket must also be named, or `TMUX_TMPDIR` must relocate the default socket into a private directory (which does work, and is allowed).

## The deny message teaches the fix

Every deny names `env -u TMUX tmux -L fm-test-$$ ...`, states that `TMUX_TMPDIR` is ignored while `$TMUX` is set, states that unsetting `$TMUX` alone falls back to the default socket, gives the pre-flight isolation check, and names the scripts that own real teardown.
The test suite pins those contents so the teaching cannot be dropped.

## Who the guard binds, and why the control plane is safe

**It binds everyone** - firstmate's primary session and every crewmate or scout worktree.
This deliberately inverts the cd-guard, which is inert in a linked worktree; here the worker is the threat.

The legitimate control-plane calls (`bin/backends/tmux.sh:137` `kill-window`, `bin/fm-afk-launch.sh:216` `kill-session`) need **no carve-out at all**, because this is a *tool-boundary* check: it only ever sees the command an agent submits to its shell tool, and those calls happen inside script processes that no PreToolUse hook observes.
They are outside the guard's aperture by construction rather than by an exemption that could be spoofed.

This is proven, not assumed: `test_control_plane_kill_still_works` runs both kill shapes against a live private server and asserts they remove their target and only their target, then asserts the tool-boundary commands that drive those scripts (`bin/fm-teardown.sh`, `bin/fm-control.sh`) are allowed.

`kill-session` and `kill-window` are denied even with an explicit target: on the shared server the session hosting an agent's pane **is** the captain's, and a targeted `kill-window` is indistinguishable at classification time from taking a sibling worker's window. A false block costs one retry with `-L`; a false allow costs the fleet.

## Empirical findings that shaped the classifier (tmux 3.7b)

All measured on an isolated server or through a read-only listing:

- **tmux resolves unambiguous command-name prefixes.** `tmux kill-serv` exited 0 and ended the server. `kill-w` and `kill-p` resolve too. `k`, `kill`, `kill-s` are rejected as ambiguous.
- **Every tmux command name beginning with `k` is a kill command** (checked against the full 169-name command and alias list), so treating "is a prefix of a destructive name" as destructive cannot catch a benign command, and over-approximating the ambiguous prefixes costs nothing since tmux rejects them anyway.
- **`killp` and `killw` are real aliases**; `kill-server` and `kill-session` have none.
- **`$TMUX` overrides `TMUX_TMPDIR`** - reproduced read-only, the incident's root cause.

Unlike the cd-guard, malformed syntax **fails closed** when the raw text mentions a tmux kill: a blocked backlog write is a correctness hazard, but a false allow here destroys the fleet.

## Harness coverage

Wired into all five harness hook trees this repo configures, exactly as the cd-guard is:

| Harness | Wiring | Verified by |
| --- | --- | --- |
| Claude | `.claude/settings.json` PreToolUse Bash matcher, third check | `test_harness_wiring_present`; plus `tests/fm-turnend-guard.test.sh` proves the entry runs under native Claude and stays inert under Grok |
| Codex | `.codex/hooks.json` PreToolUse, same anchoring/self-verification as the siblings | `test_harness_wiring_present` |
| Grok | `.grok/hooks/fm-tmux-check.json` | `test_harness_wiring_present`, plus `test_grok_hook_variables_carry_defaults` |
| OpenCode | `.opencode/plugins/fm-tmux-check.js` | `test_harness_wiring_present` |
| Pi / pi-signed | `.pi/extensions/fm-primary-turnend-guard.ts` `tool_call` handler | `test_harness_wiring_present` |

All five entry shapes are additionally exercised end to end: every one of the 65 matrix cases runs through Codex-shaped stdin, Claude-shaped stdin, Grok-shaped stdin, OpenCode CLI and Pi CLI.

### Gaps named rather than silently accepted

None is a regression; these are the existing reach of this repo's hook wiring, and they are documented in `docs/tmux-guard.md` "Known residual gaps".

- **`kimi` and `muse` have no PreToolUse hook mechanism configured in this repo at all**, so they carry none of the four guards.
- **A Pi worker loads only the per-task extension `bin/fm-spawn.sh` generates** (`state/<task-id>.pi-ext.ts`), not `.pi/extensions/fm-primary-turnend-guard.ts`, so it currently receives none of the three PreToolUse seatbelts. Pre-existing, and applies equally to the watcher-arm and cd guards.
- **Codex and Grok gate project hooks behind folder trust**, which `fm-spawn` does not establish for a worker pane.
- **Workers on a project clone load that project's config, not firstmate's.** The incident worker was a firstmate-repo worker, which is covered.

Closing the Pi per-task and trust-gated paths means changing `bin/fm-spawn.sh` launch plumbing, which collides with `tmux-endpoint-false-alive` and belongs in follow-up work.

**No live harness run yet.** Cross-harness entry shapes are covered by the portable suite, but no harness has been launched against this guard; `docs/tmux-guard.md` records that honestly and gives the probe pair for when it is run.

## Tests

`tests/fm-tmux-pretool-check.test.sh`, 16 tests, colocated per repo convention.

The incident regression is a **real reproduction**, not a fixture assertion. It stands up a throwaway server on a private socket as a stand-in for the captain's, confirms a pane on it inherits a `$TMUX` pointing at that private socket *before* anything destructive runs (and refuses to proceed otherwise), runs the incident script byte for byte inside that pane, asserts the stand-in server died - proving `TMUX_TMPDIR` was a no-op - then asserts the guard denies the same command text.

The 65-case matrix covers the allowed isolated forms (`-L`, clustered `-L`, `-S`, `env -u TMUX` + `TMUX_TMPDIR` in both word orders), every non-destructive tmux command, and the firstmate teardown scripts, so the guard cannot regress into blanket refusal.

```
tests/fm-tmux-pretool-check.test.sh   exit=0  ok=16  not ok=0
tests/fm-cd-pretool-check.test.sh     exit=0  ok=13  not ok=0
tests/fm-arm-pretool-check.test.sh    exit=0  ok=146 not ok=0
tests/fm-turnend-guard.test.sh        exit=0  ok=64  not ok=0
bin/fm-lint.sh                        exit=0  (ShellCheck 0.11.0, pinned)
bin/fm-doc-audience-check.sh          ok surfaces=68 local_links=236
```

`tests/fm-turnend-guard.test.sh` needed a two-line update: it owns a cross-cutting assertion over every tracked `.claude/settings.json` entry, so the new hook had to join its stub list and its expected guarded count (5 -> 6).

## Scope

`bin/fm-backend.sh`, `bin/backends/tmux.sh` target resolution, and `bin/fm-spawn.sh` endpoint recording are untouched, per the stated boundary. Moving worker windows onto their own socket remains the separate structural half.
