### PR TITLE
feat: add flake.nix for nix-based installation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  description = "firstmate — agent distro for running a crew";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "aarch64-darwin" "x86_64-darwin" "x86_64-linux" "aarch64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      packages = forAllSystems (system:
+        let pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          default = pkgs.stdenv.mkDerivation {
+            pname = "firstmate";
+            version = "unstable";
+            src = self;
+            installPhase = ''
+              mkdir -p $out
+              cp -r . $out/
+            '';
+            meta = with pkgs.lib; {
+              description = "Talk to one agent. Ship with a crew.";
+              license = licenses.mit;
+            };
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
Adds a `flake.nix` so firstmate can be installed declaratively via Nix flakes.

The flake exposes `packages.<system>.default` which installs the full firstmate distro (including all `bin/` scripts) into the nix store, making scripts like `fm-bootstrap.sh` available on PATH while preserving the directory structure that the scripts rely on for `FM_ROOT` resolution.