### PR TITLE
fix(snapshot): scale full-fleet reads safely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,8 +350,8 @@ jobs:
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"
           snapshot_count=$(printf '%s\n' "$snapshot_output" | grep -c '^ok - ')
-          [ "$snapshot_count" -eq 15 ] || {
-            echo "::error::expected 15 snapshot/fleet-view tests, got $snapshot_count"
+          [ "$snapshot_count" -eq 18 ] || {
+            echo "::error::expected 18 snapshot/fleet-view tests, got $snapshot_count"
             exit 1
           }
 

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -333,6 +333,13 @@ _fm_decision_key_transition_allowed() {  # <key> <note>
 _fm_decision_fold_line_set() {  # <open-set> <status-line> <resolve-verb> <held-verb>
   local open=$1 line=$2 resolve=$3 held=$4 verb key note stripped
   _FM_DECISION_FOLD_RESULT=$open
+  # A line without any transition verb cannot alter the open set. This cheap
+  # builtin guard avoids the subprocess-heavy authoritative fold for ordinary
+  # progress history; _fm_decision_fold_line still owns every transition rule.
+  case "$line" in
+    *needs-decision*|*blocked*|*"$resolve"*|*"$held"*) : ;;
+    *) return 0 ;;
+  esac
   stripped=${line//[[:space:]]/}
   [ -n "$stripped" ] || return 0
   _fm_status_line_verb_set "$line"
@@ -379,13 +386,6 @@ status_open_decisions() {  # <status-file>
   resolve=${FM_CLASSIFY_RESOLVE_VERB:-$FM_CLASSIFY_RESOLVE_VERB_DEFAULT}
   held=${FM_CLASSIFY_CAPTAIN_HELD_VERB:-$FM_CLASSIFY_CAPTAIN_HELD_VERB_DEFAULT}
   while IFS= read -r line || [ -n "$line" ]; do
-    # A line without any transition verb cannot alter the open set. This cheap
-    # builtin guard avoids the subprocess-heavy authoritative fold for ordinary
-    # progress history; _fm_decision_fold_line still owns every transition rule.
-    case "$line" in
-      *needs-decision*|*blocked*|*"$resolve"*|*"$held"*) : ;;
-      *) continue ;;
-    esac
     _fm_decision_fold_line_set "$open" "$line" "$resolve" "$held"
     open=$_FM_DECISION_FOLD_RESULT
   done < "$f"

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -180,12 +180,16 @@ status_is_paused_or_captain_held() {  # <status-line>
 # The parsers are pure reads of a single line. Status metadata may contain any
 # number of "[name=value]" tags before the colon, in any order, so verb parsing
 # ends at the first tag rather than special-casing "[key=...]".
-status_line_verb() {  # <status-line> -> leading verb word
+_fm_status_line_verb_set() {  # <status-line> -> _FM_STATUS_LINE_VERB_RESULT
   local v=${1%%:*}
   v=${v%%\[*}
   v=${v#"${v%%[![:space:]]*}"}
   v=${v%"${v##*[![:space:]]}"}
-  printf '%s' "$v"
+  _FM_STATUS_LINE_VERB_RESULT=$v
+}
+status_line_verb() {  # <status-line> -> leading verb word
+  _fm_status_line_verb_set "$1"
+  printf '%s' "$_FM_STATUS_LINE_VERB_RESULT"
 }
 # 0 when a complete "[key=...]" token sits in the documented position before
 # the line's first colon (or anywhere on a line that has no colon at all).
@@ -200,7 +204,7 @@ _fm_key_before_colon() {  # <status-line>
 # the line has no colon or no complete token there; slug charset validity is
 # the caller's check via _fm_decision_slug_ok, exactly as for the before-colon
 # position.
-_fm_key_at_note_head() {  # <status-line> -> raw slug
+_fm_key_at_note_head_set() {  # <status-line> -> _FM_KEY_AT_NOTE_HEAD_RESULT
   local rest
   case "$1" in
     *:*) rest=${1#*:} ;;
@@ -208,9 +212,13 @@ _fm_key_at_note_head() {  # <status-line> -> raw slug
   esac
   rest=${rest#"${rest%%[![:space:]]*}"}
   case "$rest" in
-    \[key=*\]*) rest=${rest#\[key=}; printf '%s' "${rest%%\]*}" ;;
+    \[key=*\]*) rest=${rest#\[key=}; _FM_KEY_AT_NOTE_HEAD_RESULT=${rest%%\]*} ;;
     *) return 1 ;;
   esac
+}
+_fm_key_at_note_head() {  # <status-line> -> raw slug
+  _fm_key_at_note_head_set "$1" || return 1
+  printf '%s' "$_FM_KEY_AT_NOTE_HEAD_RESULT"
 }
 # 0 when a stated key slug is well-formed: nonempty, A-Za-z0-9._- only.
 _fm_decision_slug_ok() {  # <slug>
@@ -219,48 +227,65 @@ _fm_decision_slug_ok() {  # <slug>
     *) return 0 ;;
   esac
 }
-status_line_note() {  # <status-line> -> text after the first colon, trimmed
+_fm_status_line_note_set() {  # <status-line> -> _FM_STATUS_LINE_NOTE_RESULT
   local n k
   case "$1" in
     *:*) n=${1#*:}; n=${n#"${n%%[![:space:]]*}"} ;;
-    *) printf '%s' "$1"; return 0 ;;
+    *) _FM_STATUS_LINE_NOTE_RESULT=$1; return 0 ;;
   esac
   # A note-head token that states this line's key (no before-colon token, valid
   # slug) is key metadata, not note text: strip it so both stated-key positions
   # yield the same note.
-  if ! _fm_key_before_colon "$1" && k=$(_fm_key_at_note_head "$1") \
-    && _fm_decision_slug_ok "$k"; then
-    n=${n#"[key=$k]"}
-    n=${n#"${n%%[![:space:]]*}"}
+  if ! _fm_key_before_colon "$1" && _fm_key_at_note_head_set "$1"; then
+    k=$_FM_KEY_AT_NOTE_HEAD_RESULT
+    if _fm_decision_slug_ok "$k"; then
+      n=${n#"[key=$k]"}
+      n=${n#"${n%%[![:space:]]*}"}
+    fi
   fi
-  printf '%s' "$n"
+  _FM_STATUS_LINE_NOTE_RESULT=$n
 }
-_fm_decision_key() {  # <status-line> -> key slug, or "default" when no token
+status_line_note() {  # <status-line> -> text after the first colon, trimmed
+  _fm_status_line_note_set "$1"
+  printf '%s' "$_FM_STATUS_LINE_NOTE_RESULT"
+}
+_fm_decision_key_set() {  # <status-line> -> _FM_DECISION_KEY_RESULT
   local k
   if _fm_key_before_colon "$1"; then
     k=${1%%:*}
     k=${k#*\[key=}
     k=${k%%\]*}
+  elif _fm_key_at_note_head_set "$1"; then
+    k=$_FM_KEY_AT_NOTE_HEAD_RESULT
   else
-    k=$(_fm_key_at_note_head "$1") || { printf 'default'; return 0; }
+    _FM_DECISION_KEY_RESULT=default
+    return 0
   fi
   _fm_decision_slug_ok "$k" || return 1
-  printf '%s' "$k"
+  _FM_DECISION_KEY_RESULT=$k
+}
+_fm_decision_key() {  # <status-line> -> key slug, or "default" when no token
+  _fm_decision_key_set "$1" || return 1
+  printf '%s' "$_FM_DECISION_KEY_RESULT"
 }
 # Drop the record for <key> from a newline-terminated "<key>\t<verb>\t<note>" set.
 # Portable (no associative arrays) so the fold runs on bash 3.2 as well as 4+.
-_fm_decision_drop() {  # <open-set> <key>
-  local set=$1 key=$2 line out=''
+_fm_decision_drop_set() {  # <open-set> <key> -> _FM_DECISION_DROP_RESULT
+  local set=$1 key=$2 line out='' sep=''
   while IFS= read -r line; do
     [ -n "$line" ] || continue
     case "$line" in
       "$key"$'\t'*) : ;;
-      *) out="${out}${line}"$'\n' ;;
+      *) out="${out}${sep}${line}"; sep=$'\n' ;;
     esac
   done <<EOF
 $set
 EOF
-  printf '%s' "$out"
+  _FM_DECISION_DROP_RESULT=$out
+}
+_fm_decision_drop() {  # <open-set> <key>
+  _fm_decision_drop_set "$1" "$2"
+  [ -n "$_FM_DECISION_DROP_RESULT" ] && printf '%s\n' "$_FM_DECISION_DROP_RESULT"
 }
 # Fold ONE status line into an existing "<key>\t<verb>\t<note>\n"-per-line open
 # set, applying the same needs-decision/blocked-opens, resolved/captain-held-closes
@@ -305,27 +330,35 @@ _fm_decision_key_transition_allowed() {  # <key> <note>
   return 0
 }
 
-_fm_decision_fold_line() {  # <open-set> <status-line> <resolve-verb> <held-verb>
+_fm_decision_fold_line_set() {  # <open-set> <status-line> <resolve-verb> <held-verb>
   local open=$1 line=$2 resolve=$3 held=$4 verb key note stripped
+  _FM_DECISION_FOLD_RESULT=$open
   stripped=${line//[[:space:]]/}
-  [ -n "$stripped" ] || { printf '%s' "$open"; return 0; }
-  verb=$(status_line_verb "$line")
-  key=$(_fm_decision_key "$line") || { printf '%s' "$open"; return 0; }
-  _fm_decision_key_transition_allowed "$key" "$(status_line_note "$line")" \
-    || { printf '%s' "$open"; return 0; }
+  [ -n "$stripped" ] || return 0
+  _fm_status_line_verb_set "$line"
+  verb=$_FM_STATUS_LINE_VERB_RESULT
+  _fm_decision_key_set "$line" || return 0
+  key=$_FM_DECISION_KEY_RESULT
+  _fm_status_line_note_set "$line"
+  note=$_FM_STATUS_LINE_NOTE_RESULT
+  _fm_decision_key_transition_allowed "$key" "$note" || return 0
   case "$verb" in
     needs-decision|blocked)
-      note=$(status_line_note "$line")
-      open=$(_fm_decision_drop "$open" "$key")
+      _fm_decision_drop_set "$open" "$key"
+      open=$_FM_DECISION_DROP_RESULT
       [ -n "$open" ] && open="${open}"$'\n'
-      open="${open}${key}"$'\t'"${verb}"$'\t'"${note}"$'\n'
+      open="${open}${key}"$'\t'"${verb}"$'\t'"${note}"
       ;;
     "$resolve"|"$held")
-      open=$(_fm_decision_drop "$open" "$key")
-      [ -n "$open" ] && open="${open}"$'\n'
+      _fm_decision_drop_set "$open" "$key"
+      open=$_FM_DECISION_DROP_RESULT
       ;;
   esac
-  printf '%s' "$open"
+  _FM_DECISION_FOLD_RESULT=$open
+}
+_fm_decision_fold_line() {  # <open-set> <status-line> <resolve-verb> <held-verb>
+  _fm_decision_fold_line_set "$1" "$2" "$3" "$4"
+  [ -n "$_FM_DECISION_FOLD_RESULT" ] && printf '%s\n' "$_FM_DECISION_FOLD_RESULT"
 }
 
 # Fold the WHOLE status stream into the set of decisions still open. Prints one
@@ -346,7 +379,15 @@ status_open_decisions() {  # <status-file>
   resolve=${FM_CLASSIFY_RESOLVE_VERB:-$FM_CLASSIFY_RESOLVE_VERB_DEFAULT}
   held=${FM_CLASSIFY_CAPTAIN_HELD_VERB:-$FM_CLASSIFY_CAPTAIN_HELD_VERB_DEFAULT}
   while IFS= read -r line || [ -n "$line" ]; do
-    open=$(_fm_decision_fold_line "$open" "$line" "$resolve" "$held")
+    # A line without any transition verb cannot alter the open set. This cheap
+    # builtin guard avoids the subprocess-heavy authoritative fold for ordinary
+    # progress history; _fm_decision_fold_line still owns every transition rule.
+    case "$line" in
+      *needs-decision*|*blocked*|*"$resolve"*|*"$held"*) : ;;
+      *) continue ;;
+    esac
+    _fm_decision_fold_line_set "$open" "$line" "$resolve" "$held"
+    open=$_FM_DECISION_FOLD_RESULT
   done < "$f"
   printf '%s' "$open"
 }
@@ -532,7 +573,8 @@ status_open_decisions_incremental() {  # <status-file>
     resolve=${FM_CLASSIFY_RESOLVE_VERB:-$FM_CLASSIFY_RESOLVE_VERB_DEFAULT}
     held=${FM_CLASSIFY_CAPTAIN_HELD_VERB:-$FM_CLASSIFY_CAPTAIN_HELD_VERB_DEFAULT}
     while IFS= read -r line || [ -n "$line" ]; do
-      open=$(_fm_decision_fold_line "$open" "$line" "$resolve" "$held")
+      _fm_decision_fold_line_set "$open" "$line" "$resolve" "$held"
+      open=$_FM_DECISION_FOLD_RESULT
     done < "$chunk_file"
     rm -f "$chunk_file"
     offset=$size

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -230,8 +230,9 @@ crew_state_json() {  # <id>
       esac
       ;;
   esac
-  jq -n --arg raw "$raw" --arg state "$state" --arg source "$source" --arg detail "$detail" \
-    '{state:$state,source:$source,detail:$detail,raw:$raw}'
+  printf '%s\0' "$state" "$source" "$detail" "$raw" | jq -Rs '
+    split("\u0000") as $fields
+    | {state:$fields[0],source:$fields[1],detail:$fields[2],raw:$fields[3]}'
 }
 
 status_event_json() {  # <status-log>
@@ -242,13 +243,11 @@ status_event_json() {  # <status-log>
     verb=$(status_line_verb "$raw")
     note=$(status_line_note "$raw")
   fi
-  jq -n \
-    --arg path "$log" \
-    --arg raw "$raw" \
-    --arg verb "$verb" \
-    --arg note "$note" \
-    --argjson present "$(bool_json "$present")" \
-    '{path:$path,present:$present,kind:"event_history",last_event:{state:$verb,note:$note,raw:$raw}}'
+  printf '%s\0' "$log" "$raw" "$verb" "$note" | jq -Rs \
+    --argjson present "$(bool_json "$present")" '
+    split("\u0000") as $fields
+    | {path:$fields[0],present:$present,kind:"event_history",
+       last_event:{state:$fields[2],note:$fields[3],raw:$fields[1]}}'
 }
 
 first_pr_url_in_file() {  # <file>

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -181,6 +181,12 @@ bool_json() {
   if [ "$1" = 1 ]; then printf 'true'; else printf 'false'; fi
 }
 
+# Stream JSON documents through stdin instead of expanding them into jq argv.
+# Shell function arguments do not cross exec(2), and printf is a bash builtin.
+json_documents() {
+  printf '%s\n' "$@"
+}
+
 path_present_json() {  # <path>
   local present=0
   [ -e "$1" ] && present=1
@@ -404,7 +410,7 @@ task_json_lines() {
   local meta id kind harness mode yolo project worktree home projects backend target status_log report_path
   local remote_host remote_root remote_state remote_rc remote_home_present
   local pr pr_source event_json current_json endpoint_exists agent_alive meta_json status_json report_json worktree_json home_json
-  local last_event_raw current_state current_source pending_decision blocked_event report_present=0 pr_from_status
+  local current_state current_source pending_decision blocked_event report_present=0 pr_from_status
   local open_decisions_tsv open_decisions_json
 
   for meta in "$STATE"/*.meta; do
@@ -445,7 +451,6 @@ task_json_lines() {
 
     current_json=$(crew_state_json "$id")
     event_json=$(status_event_json "$status_log")
-    last_event_raw=$(printf '%s' "$event_json" | jq -r '.last_event.raw // ""')
     current_state=$(printf '%s' "$current_json" | jq -r '.state // ""')
     current_source=$(printf '%s' "$current_json" | jq -r '.source // ""')
 
@@ -528,7 +533,15 @@ task_json_lines() {
       home_json=$(jq -n '{path:null,present:false}')
     fi
 
-    jq -n \
+    json_documents \
+      "$current_json" \
+      "$meta_json" \
+      "$status_json" \
+      "$report_json" \
+      "$worktree_json" \
+      "$home_json" \
+      "$open_decisions_json" \
+      | jq -s \
       --arg id "$id" \
       --arg kind "$kind" \
       --arg harness "$harness" \
@@ -546,19 +559,18 @@ task_json_lines() {
       --arg pr_source "$pr_source" \
       --arg agent_alive "$agent_alive" \
       --arg observed_at "$SNAPSHOT_NOW" \
-      --arg last_event_raw "$last_event_raw" \
-      --argjson current_state "$current_json" \
-      --argjson meta_path "$meta_json" \
-      --argjson status_log "$status_json" \
-      --argjson report "$report_json" \
-      --argjson worktree_path "$worktree_json" \
-      --argjson home_path "$home_json" \
       --argjson endpoint_exists "$endpoint_exists" \
-      --argjson open_decisions "$open_decisions_json" \
       --argjson pending_decision "$(bool_json "$pending_decision")" \
       --argjson blocked_event "$(bool_json "$blocked_event")" \
       --argjson report_present "$(bool_json "$report_present")" \
-      '{
+      '.[0] as $current_state
+      | .[1] as $meta_path
+      | .[2] as $status_log
+      | .[3] as $report
+      | .[4] as $worktree_path
+      | .[5] as $home_path
+      | .[6] as $open_decisions
+      | {
         id:$id,
         kind:$kind,
         harness:($harness // ""),
@@ -587,7 +599,7 @@ task_json_lines() {
           blocked_event:$blocked_event,
           open_decisions:$open_decisions,
           scout_report_present:$report_present,
-          last_event_text:$last_event_raw
+          last_event_text:($status_log.last_event.raw // "")
         },
         actions:(
           if $kind == "secondmate" then
@@ -608,9 +620,10 @@ task_json_lines() {
 # Meta inventory remains the sole source of live workers; this object only
 # discloses backlog↔task inconsistency for renderers (Bearings omitted/gates).
 main_inventory_json() {  # <backlog-json> <tasks-json>
-  jq -n \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
+  json_documents "$1" "$2" | jq -s '
+    .[0] as $backlog
+    | .[1] as $tasks
+    |
     ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]?
@@ -636,15 +649,16 @@ main_inventory_json() {  # <backlog-json> <tasks-json>
 # This mode never reads parent events or terminal text and never aggregates
 # nested secondmates.
 secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
-  jq -n \
+  json_documents "$1" "$2" | jq -s \
     --arg generated "$SNAPSHOT_NOW" \
     --arg home "$FM_HOME" \
     --argjson child_n "$FM_SNAPSHOT_SECONDMATE_CHILDREN" \
     --argjson queued_n "$FM_SNAPSHOT_SECONDMATE_QUEUED" \
     --argjson decisions_n "$FM_SNAPSHOT_SECONDMATE_DECISIONS" \
-    --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
+    --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" '
+    .[0] as $backlog
+    | .[1] as $tasks
+    |
     def trunc($n):
       tostring | gsub("\\s+"; " ")
       | if length > $n then .[:$n] + "…" else . end;
@@ -1051,7 +1065,11 @@ terminal_evidence_json() {  # <parent-task-json> <event-note> <evidence-contradi
 }
 
 parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <decisions-json>
-  jq -n --argjson summary "$1" --argjson activities "$2" --argjson decisions "$3" '
+  json_documents "$1" "$2" "$3" | jq -s '
+    .[0] as $summary
+    | .[1] as $activities
+    | .[2] as $decisions
+    |
     def keyed: . != null and . != "" and . != "default";
     def result($e; $matches; $complete; $surface):
       $e + {
@@ -1111,12 +1129,15 @@ parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <dec
 }
 
 secondmate_current_json() {  # <parent-tasks-json>
-  local tasks=$1 registry union rows total_registered total shown truncated
+  local tasks=$1 registry registry_json union rows total_registered total shown truncated
   local row id home host remote registered registry_error task status_file event_raw event_note event_epoch event_age
   local activity_scan activities decisions reconciliation provenance freshness reason summary summary_rc summary_bytes summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
   local records='[]' seen_homes=''
   registry=$(registry_secondmates_json) || return 1
-  union=$(jq -n --argjson registry "$registry" --argjson tasks "$tasks" '
+  union=$(json_documents "$registry" "$tasks" | jq -s '
+    .[0] as $registry
+    | .[1] as $tasks
+    |
     ($registry.records // []) as $registered
     | (($registered | map(.id)) // []) as $registered_ids
     | ([ $registered[] as $r
@@ -1246,8 +1267,10 @@ secondmate_current_json() {  # <parent-tasks-json>
       fi
       reconciliation=$(parent_evidence_reconciliation_json "$summary" "$activities" "$decisions")
       contradiction=$(printf '%s' "$reconciliation" | jq -r '.contradiction')
-      terminal_contradiction=$(printf '%s' "$reconciliation" | jq -r --arg note "$event_note" '
-        any(.activities[]; .verdict == "contradicts" and .summary == $note)')
+      terminal_contradiction=$(json_documents "$reconciliation" "$task" | jq -sr '
+        .[0] as $reconciliation
+        | (.[1].paths.status_log.last_event.note // "") as $note
+        | any($reconciliation.activities[]; .verdict == "contradicts" and .summary == $note)')
       if [ "$terminal_contradiction" = true ]; then
         terminal=$(terminal_evidence_json "$task" "$event_note" true)
       else
@@ -1255,12 +1278,28 @@ secondmate_current_json() {  # <parent-tasks-json>
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no useful contradiction check",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
       if printf '%s' "$terminal" | jq -e '.contradiction == true' >/dev/null; then contradiction=true; fi
-      record=$(jq -n \
+      record=$(json_documents \
+        "$summary" \
+        "$decisions" \
+        "$activities" \
+        "$activity_scan" \
+        "$reconciliation" \
+        "$terminal" \
+        "$task" \
+        | jq -s \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg current_reason "$current_reason" --arg observed "$SNAPSHOT_NOW" \
-        --argjson registered "$registered" --argjson summary "$summary" --argjson summary_valid "$summary_valid" --argjson decisions "$decisions" \
-        --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
-        --argjson reconciliation "$reconciliation" --argjson terminal "$terminal" --argjson contradiction "$contradiction" \
-        --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" '
+        --argjson registered "$registered" --argjson summary_valid "$summary_valid" --argjson contradiction "$contradiction" \
+        --argjson event_age "$event_age" '
+        .[0] as $summary
+        | .[1] as $decisions
+        | .[2] as $activities
+        | .[3] as $activity_scan
+        | .[4] as $reconciliation
+        | .[5] as $terminal
+        | .[6] as $task
+        | ($task.paths.status_log.last_event.raw // "") as $event_raw
+        | ($task.paths.status_log.last_event.note // "") as $event_note
+        |
         {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          current:{state:$state,reason:($current_reason | if . == "" then null else . end)},invalidity:$summary.invalidity,
          provenance:{selected:"structured-home",structured_home:$home,summary_valid:$summary_valid,
@@ -1285,11 +1324,24 @@ secondmate_current_json() {  # <parent-tasks-json>
         terminal=$(jq -n --arg observed "$SNAPSHOT_NOW" \
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no parent event to compare",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
-      record=$(jq -n \
+      record=$(json_documents \
+        "$activities" \
+        "$activity_scan" \
+        "$decisions" \
+        "$terminal" \
+        "$task" \
+        | jq -s \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg reason "$reason" --arg observed "$SNAPSHOT_NOW" \
-        --arg provenance "$provenance" --arg freshness "$freshness" --arg event_raw "$event_raw" --arg event_note "$event_note" \
-        --argjson registered "$registered" --argjson event_age "$event_age" --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
-        --argjson decisions "$decisions" --argjson terminal "$terminal" '
+        --arg provenance "$provenance" --arg freshness "$freshness" \
+        --argjson registered "$registered" --argjson event_age "$event_age" '
+        .[0] as $activities
+        | .[1] as $activity_scan
+        | .[2] as $decisions
+        | .[3] as $terminal
+        | .[4] as $task
+        | ($task.paths.status_log.last_event.raw // "") as $event_raw
+        | ($task.paths.status_log.last_event.note // "") as $event_note
+        |
         {id:$id,home:($home | if . == "" then null else . end),host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          current:{state:"unknown",reason:$reason},invalidity:null,
          provenance:{selected:$provenance,structured_home:($home | if . == "" then null else . end),parent_event_role:"fallback-only-not-current"},
@@ -1298,22 +1350,25 @@ secondmate_current_json() {  # <parent-tasks-json>
          parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan},
          terminal_evidence:$terminal,contradiction:false}')
     fi
-    records=$(jq -n --argjson records "$records" --argjson record "$record" '$records + [$record]')
+    records=$(json_documents "$records" "$record" | jq -s '.[0] + [.[1]]')
   done <<EOF
 $rows
 EOF
-  jq -n \
-    --argjson registry "$(printf '%s' "$union" | jq '.registry')" \
-    --argjson records "$records" \
+  registry_json=$(printf '%s' "$union" | jq '.registry')
+  json_documents "$registry_json" "$records" | jq -s \
     --argjson total_registered "$total_registered" \
     --argjson total "$total" \
     --argjson shown "$shown" \
     --argjson truncated "$truncated" \
-    '{registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
+    '.[0] as $registry
+     | .[1] as $records
+     | {registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
 }
 
 secondmate_landed_from_current_json() {  # <secondmate-current-json>
-  jq -n --argjson current "$1" '
+  json_documents "$1" | jq -s '
+    .[0] as $current
+    |
     {records:[ $current.records[]
       | select(.provenance.selected == "structured-home") as $mate
       | $mate.landed[]
@@ -1362,7 +1417,14 @@ SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON") \
 SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON") \
   || { echo "fm-fleet-snapshot: secondmate landed projection failed" >&2; exit 1; }
 
-jq -n \
+json_documents \
+  "$BACKLOG_JSON" \
+  "$TASKS_JSON" \
+  "$MAIN_INVENTORY_JSON" \
+  "$SCOUT_REPORTS_JSON" \
+  "$SECONDMATE_CURRENT_JSON" \
+  "$SECONDMATE_LANDED_JSON" \
+  | jq -s \
   --arg generated "$SNAPSHOT_NOW" \
   --arg fm_home "$FM_HOME" \
   --arg fm_root "$FM_ROOT" \
@@ -1370,13 +1432,13 @@ jq -n \
   --arg data "$DATA" \
   --arg config "$CONFIG" \
   --arg projects "$PROJECTS" \
-  --argjson backlog "$BACKLOG_JSON" \
-  --argjson tasks "$TASKS_JSON" \
-  --argjson main_inventory "$MAIN_INVENTORY_JSON" \
-  --argjson scout_reports "$SCOUT_REPORTS_JSON" \
-  --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
-  --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
-  'def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
+  '.[0] as $backlog
+   | .[1] as $tasks
+   | .[2] as $main_inventory
+   | .[3] as $scout_reports
+   | .[4] as $secondmate_current
+   | .[5] as $secondmate_landed
+   | def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");
    {

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -187,11 +187,16 @@ json_documents() {
   printf '%s\n' "$@"
 }
 
+path_presence_json() {  # <path> <present-json>
+  printf '%s\0' "$1" | jq -Rs --argjson present "$2" '
+    split("\u0000")[0] as $path
+    | {path:$path,present:$present}'
+}
+
 path_present_json() {  # <path>
-  local present=0
-  [ -e "$1" ] && present=1
-  jq -n --arg path "$1" --argjson present "$(bool_json "$present")" \
-    '{path:$path,present:$present}'
+  local present=false
+  [ -e "$1" ] && present=true
+  path_presence_json "$1" "$present"
 }
 
 meta_value() {  # <meta-file> <key>
@@ -408,7 +413,7 @@ backlog_json() {  # [<backlog-path>] - defaults to this home's $BACKLOG
 task_json_lines() {
   local meta id kind harness mode yolo project worktree home projects backend target status_log report_path
   local remote_host remote_root remote_state remote_rc remote_home_present
-  local pr pr_source event_json current_json endpoint_exists agent_alive meta_json status_json report_json worktree_json home_json
+  local pr pr_source event_json current_json endpoint_exists agent_alive meta_json status_json report_json worktree_json home_json task_fields_json
   local current_state current_source pending_decision blocked_event report_present=0 pr_from_status
   local open_decisions_tsv open_decisions_json
 
@@ -525,14 +530,25 @@ task_json_lines() {
     report_json=$(path_present_json "$report_path")
     if [ -n "$worktree" ]; then worktree_json=$(path_present_json "$worktree"); else worktree_json=$(jq -n '{path:null,present:false}'); fi
     if [ -n "$home" ] && [ -n "$remote_host" ]; then
-      home_json=$(jq -n --arg path "$home" --argjson present "$remote_home_present" '{path:$path,present:$present}')
+      home_json=$(path_presence_json "$home" "$remote_home_present")
     elif [ -n "$home" ]; then
       home_json=$(path_present_json "$home")
     else
       home_json=$(jq -n '{path:null,present:false}')
     fi
+    task_fields_json=$(printf '%s\0' \
+      "$id" "$kind" "$harness" "$mode" "$yolo" "$project" "$projects" \
+      "$backend" "$target" "$remote_host" "$remote_root" "$pr" "$pr_source" \
+      "$agent_alive" "$SNAPSHOT_NOW" | jq -Rs '
+      split("\u0000") as $fields
+      | {id:$fields[0],kind:$fields[1],harness:$fields[2],mode:$fields[3],
+         yolo:$fields[4],project:$fields[5],projects:$fields[6],backend:$fields[7],
+         target:$fields[8],remote_host:$fields[9],remote_root:$fields[10],
+         pr:$fields[11],pr_source:$fields[12],agent_alive:$fields[13],
+         observed_at:$fields[14]}')
 
     json_documents \
+      "$task_fields_json" \
       "$current_json" \
       "$meta_json" \
       "$status_json" \
@@ -541,43 +557,27 @@ task_json_lines() {
       "$home_json" \
       "$open_decisions_json" \
       | jq -s \
-      --arg id "$id" \
-      --arg kind "$kind" \
-      --arg harness "$harness" \
-      --arg mode "$mode" \
-      --arg yolo "$yolo" \
-      --arg project "$project" \
-      --arg worktree "$worktree" \
-      --arg home "$home" \
-      --arg projects "$projects" \
-      --arg backend "$backend" \
-      --arg target "$target" \
-      --arg remote_host "$remote_host" \
-      --arg remote_root "$remote_root" \
-      --arg pr "$pr" \
-      --arg pr_source "$pr_source" \
-      --arg agent_alive "$agent_alive" \
-      --arg observed_at "$SNAPSHOT_NOW" \
       --argjson endpoint_exists "$endpoint_exists" \
       --argjson pending_decision "$(bool_json "$pending_decision")" \
       --argjson blocked_event "$(bool_json "$blocked_event")" \
       --argjson report_present "$(bool_json "$report_present")" \
-      '.[0] as $current_state
-      | .[1] as $meta_path
-      | .[2] as $status_log
-      | .[3] as $report
-      | .[4] as $worktree_path
-      | .[5] as $home_path
-      | .[6] as $open_decisions
+      '.[0] as $fields
+      | .[1] as $current_state
+      | .[2] as $meta_path
+      | .[3] as $status_log
+      | .[4] as $report
+      | .[5] as $worktree_path
+      | .[6] as $home_path
+      | .[7] as $open_decisions
       | {
-        id:$id,
-        kind:$kind,
-        harness:($harness // ""),
-        mode:($mode // ""),
-        yolo:($yolo // ""),
-        project:($project // ""),
-        backend:$backend,
-        remote:(if $remote_host == "" then null else {host:$remote_host,root:$remote_root} end),
+        id:$fields.id,
+        kind:$fields.kind,
+        harness:($fields.harness // ""),
+        mode:($fields.mode // ""),
+        yolo:($fields.yolo // ""),
+        project:($fields.project // ""),
+        backend:$fields.backend,
+        remote:(if $fields.remote_host == "" then null else {host:$fields.remote_host,root:$fields.remote_root} end),
         paths:{
           meta:$meta_path,
           status_log:$status_log,
@@ -585,14 +585,14 @@ task_json_lines() {
           home:$home_path,
           report:$report
         },
-        secondmate_projects:($projects | if . == "" then [] else split(",") | map(gsub("^[[:space:]]+|[[:space:]]+$"; "")) | map(select(. != "")) end),
-        current_state:($current_state + {observed_at:$observed_at,freshness:"fresh"}),
-        endpoint:{target:($target | if . == "" then null else . end),exists:$endpoint_exists,agent_alive:$agent_alive,
+        secondmate_projects:($fields.projects | if . == "" then [] else split(",") | map(gsub("^[[:space:]]+|[[:space:]]+$"; "")) | map(select(. != "")) end),
+        current_state:($current_state + {observed_at:$fields.observed_at,freshness:"fresh"}),
+        endpoint:{target:($fields.target | if . == "" then null else . end),exists:$endpoint_exists,agent_alive:$fields.agent_alive,
           status:(if $endpoint_exists == false then "absent"
-                  elif $agent_alive == "alive" or $agent_alive == "dead" then $agent_alive
+                  elif $fields.agent_alive == "alive" or $fields.agent_alive == "dead" then $fields.agent_alive
                   else "unknown" end),
-          observed_at:$observed_at,freshness:"fresh"},
-        pr:{url:($pr | if . == "" then null else . end),source:$pr_source},
+          observed_at:$fields.observed_at,freshness:"fresh"},
+        pr:{url:($fields.pr | if . == "" then null else . end),source:$fields.pr_source},
         hints:{
           pending_decision:$pending_decision,
           blocked_event:$blocked_event,
@@ -601,13 +601,13 @@ task_json_lines() {
           last_event_text:($status_log.last_event.raw // "")
         },
         actions:(
-          if $kind == "secondmate" then
-            {send:"bin/fm-send.sh fm-\($id) \u0027<request>\u0027",
+          if $fields.kind == "secondmate" then
+            {send:"bin/fm-send.sh fm-\($fields.id) \u0027<request>\u0027",
              watch:"read status/doc return channel; do not routinely fm-peek a secondmate for answers",
              return_channel_note:"Secondmate answers come back through status/doc paths after a marked fm-send request."}
           else
-            {watch:"bin/fm-peek.sh fm-\($id)",
-             steer:"bin/fm-send.sh fm-\($id) \u0027<instruction>\u0027",
+            {watch:"bin/fm-peek.sh fm-\($fields.id)",
+             steer:"bin/fm-send.sh fm-\($fields.id) \u0027<instruction>\u0027",
              return_channel_note:null}
           end)
       }'
@@ -1131,6 +1131,7 @@ secondmate_current_json() {  # <parent-tasks-json>
   local tasks=$1 registry registry_json union rows total_registered total shown truncated
   local row id home host remote registered registry_error task status_file event_raw event_note event_epoch event_age
   local activity_scan activities decisions reconciliation provenance freshness reason summary summary_rc summary_bytes summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
+  local validation_fields_json record_fields_json
   local records='[]' seen_homes=''
   registry=$(registry_secondmates_json) || return 1
   union=$(json_documents "$registry" "$tasks" | jq -s '
@@ -1234,24 +1235,31 @@ secondmate_current_json() {  # <parent-tasks-json>
         summary_bytes=$(printf '%s' "$summary" | LC_ALL=C wc -c | tr -d ' ')
         if [ "$summary_bytes" -gt "$FM_SNAPSHOT_SECONDMATE_MAX_BYTES" ]; then
           reason="structured home snapshot exceeded byte limit"
-        elif ! printf '%s' "$summary" | jq -e --arg home "$home" --arg generated "$SNAPSHOT_NOW" --argjson remote "$remote" '
-          .schema == "fm-secondmate-home-summary.v1" and .home == $home
-          and (($remote == true) or .generated == $generated)
-          and (.valid | type) == "boolean" and (.state | type) == "string"
-          and (.invalidity | type) == "object" and (.invalidity.ids | type) == "array"
-          and (.active_children | type) == "array" and (.decisions_open | type) == "array"
-          and (.holds | type) == "array" and (.queued | type) == "array"
-          and (.landed | type) == "array" and (.endpoints | type) == "array"
-          and (.counts | type) == "object" and (.omitted | type) == "array"
-        ' >/dev/null 2>&1; then
-          reason="structured home snapshot was malformed or stale"
         else
-          summary_valid=$(printf '%s' "$summary" | jq -r '.valid')
-          if [ "$summary_valid" != true ]; then
-            summary_reason=$(printf '%s' "$summary" | jq -r '.reason // "unknown reason"')
-            summary_invalidity=$(printf '%s' "$summary" | jq -r '.invalidity.kind // "unknown"')
-            if [ "$summary_invalidity" != child_current_unavailable ]; then
-              reason="structured home state invalid: $summary_reason"
+          validation_fields_json=$(printf '%s\0' "$home" "$SNAPSHOT_NOW" | jq -Rs '
+            split("\u0000") as $fields
+            | {home:$fields[0],generated:$fields[1]}')
+          if ! json_documents "$summary" "$validation_fields_json" | jq -e --argjson remote "$remote" '
+            .[0] as $summary
+            | .[1] as $fields
+            | $summary.schema == "fm-secondmate-home-summary.v1" and $summary.home == $fields.home
+            and (($remote == true) or $summary.generated == $fields.generated)
+            and ($summary.valid | type) == "boolean" and ($summary.state | type) == "string"
+            and ($summary.invalidity | type) == "object" and ($summary.invalidity.ids | type) == "array"
+            and ($summary.active_children | type) == "array" and ($summary.decisions_open | type) == "array"
+            and ($summary.holds | type) == "array" and ($summary.queued | type) == "array"
+            and ($summary.landed | type) == "array" and ($summary.endpoints | type) == "array"
+            and ($summary.counts | type) == "object" and ($summary.omitted | type) == "array"
+          ' >/dev/null 2>&1; then
+            reason="structured home snapshot was malformed or stale"
+          else
+            summary_valid=$(printf '%s' "$summary" | jq -r '.valid')
+            if [ "$summary_valid" != true ]; then
+              summary_reason=$(printf '%s' "$summary" | jq -r '.reason // "unknown reason"')
+              summary_invalidity=$(printf '%s' "$summary" | jq -r '.invalidity.kind // "unknown"')
+              if [ "$summary_invalidity" != child_current_unavailable ]; then
+                reason="structured home state invalid: $summary_reason"
+              fi
             fi
           fi
         fi
@@ -1277,7 +1285,12 @@ secondmate_current_json() {  # <parent-tasks-json>
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no useful contradiction check",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
       if printf '%s' "$terminal" | jq -e '.contradiction == true' >/dev/null; then contradiction=true; fi
+      record_fields_json=$(printf '%s\0' "$id" "$home" "$host" "$state" "$current_reason" "$SNAPSHOT_NOW" | jq -Rs '
+        split("\u0000") as $fields
+        | {id:$fields[0],home:$fields[1],host:$fields[2],state:$fields[3],
+           current_reason:$fields[4],observed_at:$fields[5]}')
       record=$(json_documents \
+        "$record_fields_json" \
         "$summary" \
         "$decisions" \
         "$activities" \
@@ -1286,24 +1299,25 @@ secondmate_current_json() {  # <parent-tasks-json>
         "$terminal" \
         "$task" \
         | jq -s \
-        --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg current_reason "$current_reason" --arg observed "$SNAPSHOT_NOW" \
+        --argjson remote "$remote" \
         --argjson registered "$registered" --argjson summary_valid "$summary_valid" --argjson contradiction "$contradiction" \
         --argjson event_age "$event_age" '
-        .[0] as $summary
-        | .[1] as $decisions
-        | .[2] as $activities
-        | .[3] as $activity_scan
-        | .[4] as $reconciliation
-        | .[5] as $terminal
-        | .[6] as $task
+        .[0] as $fields
+        | .[1] as $summary
+        | .[2] as $decisions
+        | .[3] as $activities
+        | .[4] as $activity_scan
+        | .[5] as $reconciliation
+        | .[6] as $terminal
+        | .[7] as $task
         | ($task.paths.status_log.last_event.raw // "") as $event_raw
         | ($task.paths.status_log.last_event.note // "") as $event_note
         |
-        {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
-         current:{state:$state,reason:($current_reason | if . == "" then null else . end)},invalidity:$summary.invalidity,
-         provenance:{selected:"structured-home",structured_home:$home,summary_valid:$summary_valid,
+        {id:$fields.id,home:$fields.home,host:($fields.host | if . == "" then null else . end),remote:$remote,registered:$registered,
+         current:{state:$fields.state,reason:($fields.current_reason | if . == "" then null else . end)},invalidity:$summary.invalidity,
+         provenance:{selected:"structured-home",structured_home:$fields.home,summary_valid:$summary_valid,
            trust:(if $summary_valid then "complete" else "partial-structured" end),parent_event_role:"historical-only"},
-         freshness:{status:"fresh",observed_at:$observed,age_seconds:0},
+         freshness:{status:"fresh",observed_at:$fields.observed_at,age_seconds:0},
          active_children:$summary.active_children,
          decisions_open:$summary.decisions_open,holds:$summary.holds,queued:$summary.queued,
          landed:$summary.landed,endpoints:$summary.endpoints,counts:$summary.counts,omitted:$summary.omitted,
@@ -1323,28 +1337,33 @@ secondmate_current_json() {  # <parent-tasks-json>
         terminal=$(jq -n --arg observed "$SNAPSHOT_NOW" \
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no parent event to compare",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
+      record_fields_json=$(printf '%s\0' "$id" "$home" "$host" "$reason" "$SNAPSHOT_NOW" "$provenance" "$freshness" | jq -Rs '
+        split("\u0000") as $fields
+        | {id:$fields[0],home:$fields[1],host:$fields[2],reason:$fields[3],
+           observed_at:$fields[4],provenance:$fields[5],freshness:$fields[6]}')
       record=$(json_documents \
+        "$record_fields_json" \
         "$activities" \
         "$activity_scan" \
         "$decisions" \
         "$terminal" \
         "$task" \
         | jq -s \
-        --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg reason "$reason" --arg observed "$SNAPSHOT_NOW" \
-        --arg provenance "$provenance" --arg freshness "$freshness" \
+        --argjson remote "$remote" \
         --argjson registered "$registered" --argjson event_age "$event_age" '
-        .[0] as $activities
-        | .[1] as $activity_scan
-        | .[2] as $decisions
-        | .[3] as $terminal
-        | .[4] as $task
+        .[0] as $fields
+        | .[1] as $activities
+        | .[2] as $activity_scan
+        | .[3] as $decisions
+        | .[4] as $terminal
+        | .[5] as $task
         | ($task.paths.status_log.last_event.raw // "") as $event_raw
         | ($task.paths.status_log.last_event.note // "") as $event_note
         |
-        {id:$id,home:($home | if . == "" then null else . end),host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
-         current:{state:"unknown",reason:$reason},invalidity:null,
-         provenance:{selected:$provenance,structured_home:($home | if . == "" then null else . end),parent_event_role:"fallback-only-not-current"},
-         freshness:{status:$freshness,observed_at:$observed,age_seconds:$event_age},
+        {id:$fields.id,home:($fields.home | if . == "" then null else . end),host:($fields.host | if . == "" then null else . end),remote:$remote,registered:$registered,
+         current:{state:"unknown",reason:$fields.reason},invalidity:null,
+         provenance:{selected:$fields.provenance,structured_home:($fields.home | if . == "" then null else . end),parent_event_role:"fallback-only-not-current"},
+         freshness:{status:$fields.freshness,observed_at:$fields.observed_at,age_seconds:$event_age},
          active_children:[],decisions_open:[],holds:[],queued:[],landed:[],endpoints:[],counts:{active_children:0,decisions_open:0,holds:0,queued:0,landed:0,endpoints:0},omitted:[],
          parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan},
          terminal_evidence:$terminal,contradiction:false}')

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -1239,7 +1239,7 @@ secondmate_current_json() {  # <parent-tasks-json>
           validation_fields_json=$(printf '%s\0' "$home" "$SNAPSHOT_NOW" | jq -Rs '
             split("\u0000") as $fields
             | {home:$fields[0],generated:$fields[1]}')
-          if ! json_documents "$summary" "$validation_fields_json" | jq -e --argjson remote "$remote" '
+          if ! json_documents "$summary" "$validation_fields_json" | jq -se --argjson remote "$remote" '
             .[0] as $summary
             | .[1] as $fields
             | $summary.schema == "fm-secondmate-home-summary.v1" and $summary.home == $fields.home

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -172,7 +172,7 @@ test_large_backlog_crosses_argv_limit_via_public_interface() {
 }
 
 test_large_task_status_crosses_argv_limit_via_public_interface() {
-  local home fakebin out payload payload_bytes prefix prefix_bytes
+  local home fakebin out payload payload_bytes prefix prefix_bytes status_value status_bytes
   home=$(make_home large-task-status)
   mkdir -p "$home/projects/large-task-status"
   fm_write_meta "$home/state/large-task-status.meta" \
@@ -189,24 +189,57 @@ test_large_task_status_crosses_argv_limit_via_public_interface() {
   prefix_bytes=$(printf '%s' "$prefix" | LC_ALL=C wc -c | tr -d ' ')
   [ "$payload_bytes" -gt 131072 ] \
     || fail "large-status fixture must exceed the ordinary Linux per-argument limit"
-  printf '%s%s\n' "$prefix" "$payload" > "$home/state/large-task-status.status"
+  status_value="https://$payload/pull/1"
+  status_bytes=$(printf '%s' "$status_value" | LC_ALL=C wc -c | tr -d ' ')
+  printf '%s%s\n' "$prefix" "$status_value" > "$home/state/large-task-status.status"
 
   fakebin=$(make_fakebin "$home")
   out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json)
   printf '%s' "$out" | jq -e \
-    --argjson payload_bytes "$payload_bytes" \
+    --argjson status_bytes "$status_bytes" \
     --argjson prefix_bytes "$prefix_bytes" '
     .schema == "fm-fleet-snapshot.v1"
       and (.tasks | length) == 1
       and (.tasks[0].id == "large-task-status")
       and (.tasks[0].current_state.state == "parked")
       and (.tasks[0].current_state.source == "status-log")
-      and ((.tasks[0].current_state.detail | length) == $payload_bytes)
-      and ((.tasks[0].paths.status_log.last_event.raw | length) == ($prefix_bytes + $payload_bytes))
-      and ((.tasks[0].paths.status_log.last_event.note | length) == $payload_bytes)
-      and ((.tasks[0].hints.open_decisions[0].summary | length) == $payload_bytes)
+      and ((.tasks[0].current_state.detail | length) == $status_bytes)
+      and ((.tasks[0].paths.status_log.last_event.raw | length) == ($prefix_bytes + $status_bytes))
+      and ((.tasks[0].paths.status_log.last_event.note | length) == $status_bytes)
+      and ((.tasks[0].hints.open_decisions[0].summary | length) == $status_bytes)
+      and ((.tasks[0].pr.url | length) == $status_bytes)
+      and (.tasks[0].pr.source == "status_event")
   ' >/dev/null || fail "public snapshot must preserve complete task status above argv limits"
   pass "public snapshot transports task status above ordinary Linux argv limits"
+}
+
+test_large_task_metadata_crosses_argv_limit_via_public_interface() {
+  local home fakebin out payload payload_bytes
+  home=$(make_home large-task-metadata)
+  mkdir -p "$home/projects/large-task-metadata"
+  payload=$(LC_ALL=C awk 'BEGIN { for (i = 0; i < 196608; i++) printf "m" }')
+  payload_bytes=$(printf '%s' "$payload" | LC_ALL=C wc -c | tr -d ' ')
+  [ "$payload_bytes" -gt 131072 ] \
+    || fail "large-metadata fixture must exceed the ordinary Linux per-argument limit"
+  fm_write_meta "$home/state/large-task-metadata.meta" \
+    "window=firstmate:fm-large-task-metadata" \
+    "worktree=$home/projects/large-task-metadata" \
+    "project=$payload" \
+    "harness=claude" \
+    "kind=ship" \
+    "mode=ship"
+  record_claude_idle "$home/state" large-task-metadata
+  printf 'working: bounded status\n' > "$home/state/large-task-metadata.status"
+
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json)
+  printf '%s' "$out" | jq -e --argjson payload_bytes "$payload_bytes" '
+    .schema == "fm-fleet-snapshot.v1"
+      and (.tasks | length) == 1
+      and (.tasks[0].id == "large-task-metadata")
+      and ((.tasks[0].project | length) == $payload_bytes)
+  ' >/dev/null || fail "public snapshot must preserve complete task metadata above argv limits"
+  pass "public snapshot transports task metadata above ordinary Linux argv limits"
 }
 
 test_fixture_snapshot_json() {
@@ -840,6 +873,7 @@ test_parked_scout_decision_stays_pending() {
 test_empty_fleet_json
 test_large_backlog_crosses_argv_limit_via_public_interface
 test_large_task_status_crosses_argv_limit_via_public_interface
+test_large_task_metadata_crosses_argv_limit_via_public_interface
 test_fixture_snapshot_json
 test_main_inventory_orphan_and_unstructured_disclosure
 test_normalized_roles_and_plural_blocker_readiness

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -171,6 +171,44 @@ test_large_backlog_crosses_argv_limit_via_public_interface() {
   pass "public snapshot transports a backlog larger than ordinary Linux argv limits"
 }
 
+test_large_task_status_crosses_argv_limit_via_public_interface() {
+  local home fakebin out payload payload_bytes prefix prefix_bytes
+  home=$(make_home large-task-status)
+  mkdir -p "$home/projects/large-task-status"
+  fm_write_meta "$home/state/large-task-status.meta" \
+    "window=firstmate:fm-large-task-status" \
+    "worktree=$home/projects/large-task-status" \
+    "project=firstmate" \
+    "harness=claude" \
+    "kind=ship" \
+    "mode=ship"
+  record_claude_idle "$home/state" large-task-status
+  prefix='needs-decision [key=oversize]: '
+  payload=$(LC_ALL=C awk 'BEGIN { for (i = 0; i < 196608; i++) printf "s" }')
+  payload_bytes=$(printf '%s' "$payload" | LC_ALL=C wc -c | tr -d ' ')
+  prefix_bytes=$(printf '%s' "$prefix" | LC_ALL=C wc -c | tr -d ' ')
+  [ "$payload_bytes" -gt 131072 ] \
+    || fail "large-status fixture must exceed the ordinary Linux per-argument limit"
+  printf '%s%s\n' "$prefix" "$payload" > "$home/state/large-task-status.status"
+
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json)
+  printf '%s' "$out" | jq -e \
+    --argjson payload_bytes "$payload_bytes" \
+    --argjson prefix_bytes "$prefix_bytes" '
+    .schema == "fm-fleet-snapshot.v1"
+      and (.tasks | length) == 1
+      and (.tasks[0].id == "large-task-status")
+      and (.tasks[0].current_state.state == "parked")
+      and (.tasks[0].current_state.source == "status-log")
+      and ((.tasks[0].current_state.detail | length) == $payload_bytes)
+      and ((.tasks[0].paths.status_log.last_event.raw | length) == ($prefix_bytes + $payload_bytes))
+      and ((.tasks[0].paths.status_log.last_event.note | length) == $payload_bytes)
+      and ((.tasks[0].hints.open_decisions[0].summary | length) == $payload_bytes)
+  ' >/dev/null || fail "public snapshot must preserve complete task status above argv limits"
+  pass "public snapshot transports task status above ordinary Linux argv limits"
+}
+
 test_fixture_snapshot_json() {
   local home fakebin out ids
   home=$(make_home fixture)
@@ -801,6 +839,7 @@ test_parked_scout_decision_stays_pending() {
 
 test_empty_fleet_json
 test_large_backlog_crosses_argv_limit_via_public_interface
+test_large_task_status_crosses_argv_limit_via_public_interface
 test_fixture_snapshot_json
 test_main_inventory_orphan_and_unstructured_disclosure
 test_normalized_roles_and_plural_blocker_readiness

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -151,6 +151,26 @@ test_empty_fleet_json() {
   pass "empty fleet snapshot and view use explicit absence markers"
 }
 
+test_large_backlog_crosses_argv_limit_via_public_interface() {
+  local home out payload payload_bytes
+  home=$(make_home large-backlog)
+  payload=$(LC_ALL=C awk 'BEGIN { for (i = 0; i < 196608; i++) printf "x" }')
+  payload_bytes=$(printf '%s' "$payload" | LC_ALL=C wc -c | tr -d ' ')
+  [ "$payload_bytes" -gt 131072 ] \
+    || fail "large-backlog fixture must exceed the ordinary Linux per-argument limit"
+  printf '## Done\n%s\n' "$payload" > "$home/data/backlog.md"
+
+  out=$(FM_HOME="$home" "$SNAPSHOT" --json)
+  printf '%s' "$out" | jq -e --argjson payload_bytes "$payload_bytes" '
+    .schema == "fm-fleet-snapshot.v1"
+      and (.tasks | length) == 0
+      and (.backlog.records | length) == 1
+      and .backlog.records[0].structured == false
+      and (.backlog.records[0].raw | length) == $payload_bytes
+  ' >/dev/null || fail "public snapshot must return valid complete JSON above argv limits"
+  pass "public snapshot transports a backlog larger than ordinary Linux argv limits"
+}
+
 test_fixture_snapshot_json() {
   local home fakebin out ids
   home=$(make_home fixture)
@@ -780,6 +800,7 @@ test_parked_scout_decision_stays_pending() {
 }
 
 test_empty_fleet_json
+test_large_backlog_crosses_argv_limit_via_public_interface
 test_fixture_snapshot_json
 test_main_inventory_orphan_and_unstructured_disclosure
 test_normalized_roles_and_plural_blocker_readiness


### PR DESCRIPTION
## Intent

Repair Firstmate authoritative read-only full-fleet snapshot so bin/fm-fleet-snapshot.sh --json succeeds safely and promptly at the configured main home current scale. Reproduce the failure through the public interface without printing or retaining private JSON, establish causal boundaries beyond the argv failure, and remove every unbounded JSON-through-argv path needed by this operation using bounded file or stdin transport with mode-tight deterministic cleanup if temporary material is necessary. Preserve exact fm-fleet-snapshot.v1 semantics, field shapes, ordering, open-decision folding, home selection, error behavior, read-only operation, supported-platform portability, and privacy; never mutate configured-home history or operational records. Do not merely raise the Krisis timeout, edit its separately pinned Firstmate copy, change Krisis code/config/service/database, or restart anything. Add executable public-interface regression coverage above ordinary Linux argv limits without asserting implementation-source bytes; keep touched shell scripts clean under pinned bin/fm-lint.sh and run relevant existing tests. Validate the real configured home with at least three consecutive exit-zero runs under 10 seconds, retaining only timings, schema, and count summaries. Review supported platforms and avoid new GNU-only transport assumptions. Include an exact safe rollout plan for updating the separately pinned Krisis Firstmate root only after an approved merge, but do not perform that rollout. Keep the change minimal in existing contract owners without policy prose or parallel snapshot machinery. Validate and ship committed head 7696b6d through a green PR, but do not merge; the captain retains explicit merge authority.

## What Changed

- Stream fleet snapshot documents and oversized backlog, task status/PR, metadata, and secondmate fields through stdin so `--json` avoids process argument limits while preserving `fm-fleet-snapshot.v1` output.
- Speed authoritative open-decision reads by folding transitions in-process and centralizing transition filtering across whole-file and incremental paths.
- Add public-interface regressions covering 196,608-byte backlog, status/PR, and metadata values.

## Risk Assessment

✅ Low: Captain, the slurp correction closes the prior validation defect, and the full diff now preserves canonical structured-home behavior while removing the substantiated unbounded argv paths.

## Testing

Targeted snapshot, bearings, and decision-fold suites passed; the base/current causal matrix reproduced the former argv failure and silent field loss, normalized v1 output remained equivalent, the read-only fixture emitted no home mutations, and three privacy-safe configured-home runs completed under 10 seconds. A syscall trace was discarded after instrumentation exceeded its 30-second bound and was replaced by the successful filesystem-event check; no full suite, lint, push, PR, or CI phase was run because those belong to the outer executor.

<details>
<summary>Evidence: Base/current argv causal matrix</summary>

```text
payload_bytes=196608 ordinary_per_argument_threshold=131072
{"schema":"fm-fleet-snapshot.v1","task_count":0,"backlog_record_count":0}
base-small snapshot_exit=0 summary_exit=0 symptom=none
base-large-backlog snapshot_exit=1 summary_exit=4 symptom=argument-list-too-long
{"schema":"fm-fleet-snapshot.v1","raw_bytes":196608}
current-large-backlog snapshot_exit=0 summary_exit=0 symptom=none
{"schema":"fm-fleet-snapshot.v1","note_bytes":0,"decision_bytes":0}
base-large-status snapshot_exit=0 summary_exit=0 symptom=argument-list-too-long
{"schema":"fm-fleet-snapshot.v1","note_bytes":196608,"decision_bytes":196608}
current-large-status snapshot_exit=0 summary_exit=0 symptom=none
{"schema":"fm-fleet-snapshot.v1","project_bytes":0}
base-large-metadata snapshot_exit=0 summary_exit=0 symptom=argument-list-too-long
{"schema":"fm-fleet-snapshot.v1","project_bytes":196608}
current-large-metadata snapshot_exit=0 summary_exit=0 symptom=none
```
</details>
<details>
<summary>Evidence: Three configured-home runs</summary>

```text
run=1 exit=0 elapsed_seconds=8.06 summary={"schema":"fm-fleet-snapshot.v1","counts":{"backlog_records":60,"tasks":11,"open_decisions":0,"scout_reports":40,"secondmates_total":3,"secondmates_registered":3,"secondmates_shown":3,"secondmates_truncated":0,"landed":7,"landed_truncated":0,"unreadable_secondmates":2,"partial_secondmates":0}}
run=2 exit=0 elapsed_seconds=8.05 summary={"schema":"fm-fleet-snapshot.v1","counts":{"backlog_records":60,"tasks":11,"open_decisions":0,"scout_reports":40,"secondmates_total":3,"secondmates_registered":3,"secondmates_shown":3,"secondmates_truncated":0,"landed":7,"landed_truncated":0,"unreadable_secondmates":2,"partial_secondmates":0}}
run=3 exit=0 elapsed_seconds=7.85 summary={"schema":"fm-fleet-snapshot.v1","counts":{"backlog_records":60,"tasks":11,"open_decisions":0,"scout_reports":40,"secondmates_total":3,"secondmates_registered":3,"secondmates_shown":3,"secondmates_truncated":0,"landed":7,"landed_truncated":0,"unreadable_secondmates":2,"partial_secondmates":0}}
```
</details>
<details>
<summary>Evidence: Full snapshot semantic equivalence</summary>

```text
normalized_full_snapshot_match=true {"schema":"fm-fleet-snapshot.v1","task_order":["ship-one"],"backlog_order":["ship-one","queued-one","scout-one"],"open_decision_keys":["transport"],"scout_report_count":1}
```
</details>
<details>
<summary>Evidence: Read-only public-interface evidence</summary>

`snapshot_exit=0 summary_exit=0 configured_home_events=0 summary={"schema":"fm-fleet-snapshot.v1","counts":{"backlog_records":2,"tasks":1,"open_decisions":1,"scout_reports":1}}`

```text
snapshot_exit=0 summary_exit=0 configured_home_events=0 summary={"schema":"fm-fleet-snapshot.v1","counts":{"backlog_records":2,"tasks":1,"open_decisions":1,"scout_reports":1}}
```
</details>
<details>
<summary>Evidence: Focused snapshot regression tests</summary>

```text
ok - empty fleet snapshot and view use explicit absence markers
ok - public snapshot transports a backlog larger than ordinary Linux argv limits
ok - public snapshot transports task status above ordinary Linux argv limits
ok - public snapshot transports task metadata above ordinary Linux argv limits
ok - fixture snapshot covers task rows, backlog rows, pointers, and stable ordering
ok - main_inventory discloses orphan/unstructured and clears when inventory is consistent
ok - backlog normalization preserves strict roles and resolves every blocker compatibly
ok - snapshot event hints follow reconciled current state
ok - durable fold keeps an open decision past a later unrelated event
ok - a live secondmate endpoint preserves unrelated open decisions
ok - durable captain-held transfer closes the duplicate live status decision
ok - durable fold clears a decision only on a keyed resolution
ok - a completed scout's stale decision surfaces as a report pointer, not pending
ok - a scout still parked at a decision stays pending (terminal clear does not over-fire)
ok - snapshot includes durable scout reports after teardown
ok - snapshot parses tasks-axi rows and respects operational overrides
ok - fleet view renders the snapshot without secondmate peek guidance
ok - fleet view renders secondmate agent liveness
```
</details>
<details>
<summary>Evidence: Downstream fleet projection tests</summary>

```text
ok - Domain Alpha structured state overrides a stale parent Phase 7 event
ok - GNU stat file reads select -c without BSD filesystem-report pollution
ok - parent activity evidence is bounded and disclosed
ok - Bearings excludes a status-only child decision
ok - a structured child captain hold reaches Captain's Call
ok - missing, invalid, unreadable, malformed, and timed-out homes stay explicit unknowns
ok - an oversized secondmate summary retains the strict empty unknown fallback
ok - secondmate and per-home child counts are bounded, disclosed, and explicitly expandable
ok - parent decisions remain untrusted contradiction evidence
ok - parent evidence reconciliation distinguishes matching holds, blocks, and decisions
ok - nonprogressing child states are explicit and inconsistent terminal rows invalidate
ok - registry unavailability and bounded truncation remain explicit
ok - repeated snapshots keep the same current landed baseline and ignore prior reports
ok - default output is bounded, local-only, and marks omitted surfaces
ok - TOON and JSON are parity representations of the same model
ok - landed includes secondmate-managed merges alongside main-home merges
ok - default landed selection balances one dominant home with sparse homes
ok - landed selection refills capacity after sparse homes exhaust
ok - landed selection uses deterministic home order when homes exceed the cap
ok - landed selection preserves deterministic home and internal tie ordering
ok - landed selection handles no landed items
ok - --all-landed keeps the complete global landed output
ok - landed stays bounded with per-home + overall caps and omitted[] disclosure
ok - Bearings keeps a live blocker in structured live state and never converts it to Charted Next queue work
ok - action-free items (working/done/queued/landed) do not leak into Captain's Call
ok - main orphan in-flight stays out of Underway and is disclosed in omitted/gates
ok - main unstructured current is disclosed while structured siblings still project
ok - counterfactual meta clears main inventory warning and projects the live task
ok - mixed secondmate roles, partial state, and captain readiness project independently
ok - main and secondmate captain actionability use the same blocker readiness
ok - a completed scout with decision-like report prose is a pointer, not pending
ok - an authoritative captain hold surfaces end-to-end
ok - current report pointers surface
ok - superseded queued items are dropped by default and restored with --all-queued
ok - --include-prs is the only path that fetches, and it enriches correctly
ok - a partial GitHub failure degrades gracefully
ok - Perl fallback bounds stalled GitHub calls without coreutils timeout
ok - all fleet-sized sections are capped with counted opt-in expansion
ok - live PR enrichment caps repositories with counted expansion
ok - per-repository open-PR caps are disclosed with an expansion knob
ok - projection and TOON rendering failures exit nonzero with diagnostics
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (3) ✅</summary>

- 🚨 `bin/fm-fleet-snapshot.sh:184` - The required criterion says to “remove every unbounded JSON-through-argv path needed by this operation.” The new hunk only streams already-built JSON documents, while `crew_state_json` and `status_event_json` still pass unbounded status-derived text to `jq --arg` at lines 233 and 245–250. A contract-supported status line over Linux’s per-argument limit prevents `jq` from executing; the positional `jq -s` assembly at line 536 then ignores the empty document and shifts subsequent fields, potentially emitting incorrect v1 shapes. Move unbounded text transport to these producer boundaries and add public `--json` coverage with task metadata and a large status line.
- ⚠️ `bin/fm-classify-lib.sh:324` - The fast-path duplicates the transition vocabulary outside `_fm_decision_fold_line_set`, despite lines 232–235 naming that fold as the single semantic owner. Adding a transition there without also updating this prefilter would make whole-file and incremental folds disagree. Move the cheap eligibility check into the shared fold boundary.

🔧 Fix: Stream oversized status fields and centralize decision filtering
1 error still open:
- 🚨 `bin/fm-fleet-snapshot.sh:557` - The required criterion says to “remove every unbounded JSON-through-argv path needed by this operation.” The revised task-assembly hunk streams composite documents through `json_documents ... | jq -s` but retains `--arg pr &#34;$pr&#34;`; when metadata has no PR, this value comes from the explicitly unbounded status log. A status line containing a whitespace-free URL over 128 KiB ending in `/pull/1` therefore still prevents jq from executing, while the enclosing final `jq -s` can return success with that task silently omitted. Stream the extracted PR at its producer boundary and extend the public oversized-status regression with this variant.

🔧 Fix: Stream unbounded snapshot text through stdin
1 error still open:
- 🚨 `bin/fm-fleet-snapshot.sh:1242` - The required criterion says to “Preserve exact fm-fleet-snapshot.v1 semantics ... [and] error behavior.” This hunk pipes `$summary` and `$validation_fields_json` as two separate JSON documents into `jq -e`, but then indexes `.[0]` and `.[1]` without slurping. A valid object-shaped secondmate summary therefore fails validation and is labeled “malformed or stale,” replacing canonical structured-home state with the unknown fallback. Use `jq -se` or `jq -s -e` at this shared validation boundary.

🔧 Fix: Slurp structured secondmate validation documents
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `TMPDIR=/tmp/no-mistakes-evidence/01KZQPJVAWGTZPW0RE4KRH6WPE bash tests/fm-fleet-snapshot-view.test.sh`
- `TMPDIR=/tmp/no-mistakes-evidence/01KZQPJVAWGTZPW0RE4KRH6WPE bash tests/fm-bearings-snapshot.test.sh`
- `TMPDIR=/tmp/no-mistakes-evidence/01KZQPJVAWGTZPW0RE4KRH6WPE bash tests/fm-wake-drain-open-decisions.test.sh`
- `TMPDIR=/tmp/no-mistakes-evidence/01KZQPJVAWGTZPW0RE4KRH6WPE bash tests/fm-wake-drain-open-decisions-cursor.test.sh`
- <code>Compared base `e836a7f28bc5100f517c1d672a56483754899add` and current public snapshots using 196,608-byte backlog, status, and metadata fixtures, retaining only schema and field-length summaries</code>
- `Compared normalized complete base/current JSON for a representative bounded fleet; task ordering, backlog ordering, report projection, and open-decision folding matched exactly`
- <code>Ran `FM_ROOT_OVERRIDE=&#34;$PWD&#34; FM_HOME=/data/1/projects bin/fm-fleet-snapshot.sh --json | jq -ce &#39;&lt;schema-and-count-summary&gt;&#39;` three consecutive times with `/usr/bin/time`; results were 8.06s, 8.05s, and 7.85s</code>
- <code>Monitored an isolated configured home with `inotifywait` while invoking the public snapshot; it exited zero and produced no data/state/config filesystem events</code>
- `Reviewed the changed transport for supported-platform assumptions; it uses Bash built-ins and jq stdin slurping without new GNU-only transport dependencies`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
