### PR TITLE
fix(spawn): allow local-only spawns without an origin remote

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1685,6 +1685,13 @@ validate_spawn_worktree() {  # <source> <inspect-target>
 
 freshen_spawn_worktree_base() {  # <worktree>
   local worktree=$1 default target expected actual status
+  if ! git -C "$worktree" remote get-url origin >/dev/null 2>&1; then
+    # Local-only repo with no origin remote: there is nothing to fetch and the
+    # pooled base cannot drift from origin, so the freshness guarantee is
+    # trivially satisfied. (fc5f164 introduced the fetch without this guard and
+    # broke spawning for every local-only project.)
+    return 0
+  fi
   if ! git -C "$worktree" fetch --quiet origin; then
     echo "error: could not fetch origin for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
     return 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -138,6 +138,8 @@
 #   origin, resolves the current remote default branch, and resets to its tip.
 #   An unreachable origin, unresolved default branch, or non-clean worktree
 #   refuses the spawn rather than risking a PR based on stale history.
+#   A local-only worktree with no origin remote skips the fetch: its pooled
+#   base cannot drift from a remote that does not exist.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,7 +146,7 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
-`fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
+`fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn; a local-only worktree with no origin remote skips the fetch, since its base cannot drift from a remote that does not exist.
 Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -227,11 +227,50 @@ test_unresolved_remote_default_refuses_pool() {
   pass "an unresolved remote default branch refuses the pooled worktree"
 }
 
+test_local_only_pool_without_origin_spawns() {
+  local name=local-only-no-origin id case_dir home project pool fakebin initial out status
+  id='pool-local-only-r6'
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  pool="$case_dir/pool"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'codex\n' > "$home/config/crew-harness"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  touch "$home/state/.last-watcher-beat"
+
+  # Local-only project: git init with NO origin remote, pooled worktree on base.
+  git init --quiet -b main "$project"
+  printf 'base\n' > "$project/README.md"
+  git -C "$project" add README.md
+  git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+  initial=$(git -C "$project" rev-parse HEAD)
+  git -C "$project" worktree add --quiet --detach "$pool" "$initial"
+
+  local rec
+  rec="$case_dir|$home|$project|$pool|$fakebin|$initial|main"
+  read_case_record "$rec"
+
+  out=$(run_spawn "$id" --mode local-only --yolo off)
+  status=$?
+  expect_code 0 "$status" "spawn should succeed for a local-only project with no origin"
+  assert_contains "$out" "spawned $id" "spawn did not report success for a local-only project"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$INITIAL_SHA" ] \
+    || fail "spawn moved the local-only pooled worktree base"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed local-only spawn: %s\n' "$(printf '%s\n' "$out" | tail -n 1)"
+  fi
+  pass "a local-only project with no origin remote spawns without an origin fetch"
+}
+
 test_stale_pool_base_refreshes_before_branching
 test_non_main_default_branch_refreshes_before_branching
 test_direct_pr_and_scout_refresh_before_launch
 test_dirty_pool_refuses_without_discarding_work
 test_unresolved_remote_default_refuses_pool
 test_unreachable_origin_refuses_stale_pool_base
+test_local_only_pool_without_origin_spawns
 
 echo "# all fm-spawn-pool-base-freshen tests passed"


### PR DESCRIPTION
## Problem

`freshen_spawn_worktree_base` (introduced in fc5f164) unconditionally runs `git fetch origin` for every pooled-worktree spawn. Projects registered as **local-only** (no origin remote - e.g. project A, project B) fail every spawn with:

```
error: could not fetch origin for pooled worktree '...'; refusing to launch from a potentially stale base
```

This makes local-only projects un-spawnable - a hard regression for a supported registry posture.

## Fix

Skip the origin fetch when the worktree has no origin remote. A pooled base cannot drift from a non-existent remote, so the freshness guarantee the guard provides is trivially satisfied for local-only repos. All existing guards (stale base refresh, non-main default branch, dirty refusal, unresolved remote default, unreachable origin refusal) are unchanged.

```bash
if ! git -C "$worktree" remote get-url origin >/dev/null 2>&1; then
  return 0
fi
```

## Tests

Added `test_local_only_pool_without_origin_spawns` to `tests/fm-spawn-pool-base-freshen.test.sh`: a local-only project (no origin) spawns successfully and the pooled base is untouched. Full suite passes (7 tests in the freshen file; whole test inventory green via the no-mistakes pipeline).

## Validation

- `tests/fm-spawn-pool-base-freshen.test.sh`: 7/7 pass
- no-mistakes pipeline: intent / rebase / review / test / document / lint all green (ShellCheck clean)
- Verified end-to-end: spawning `writer-m1-engine` (a local-only project) now succeeds with this fix