### PR TITLE
feat(skills): add /ui-studio skill for fast local UI-iteration lane

### DIFF
--- a/.agents/skills/ui-studio/SKILL.md
+++ b/.agents/skills/ui-studio/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: ui-studio
+description: >-
+  Fast local UI-iteration lane: one persistent branch (ui/studio), one long-lived agent,
+  and Storybook hot-reloading fed by Vibe annotations.
+  Use when the captain invokes /ui-studio start, /ui-studio land, or /ui-studio status,
+  or when they ask to open, land, or check the UI studio for a project.
+user-invocable: true
+metadata:
+  internal: true
+---
+
+<!-- Owner: firstmate shared tracked skills. Merge-path decision rationale lives in the "land" section below - do not duplicate it elsewhere. -->
+
+# ui-studio
+
+The UI studio is a fast lane for iterating on UI without routing through firstmate's
+spawn/worktree/PR/Chromatic supervision loop.
+It owns a persistent branch (`ui/studio`), a reused worktree in `state/`, and one
+long-lived studio agent that watches Vibe annotations and applies changes live in Storybook.
+Firstmate stays OUT of the edit loop - no watcher, no turn-end guard, no task meta.
+
+## Ownership exception
+
+This skill is the sole owner of the `ui/studio` branch and the
+`state/ui-studio/<project>/` worktree for the named project.
+Creating or maintaining that worktree necessarily adds metadata to the project clone
+under `projects/<project>/.git/worktrees/`.
+This narrow write is an explicitly approved exception to hard rule 1, scoped to the
+`ui/studio` branch only.
+It does not authorize any other write to the project clone or to `projects/`.
+
+## Subcommands
+
+All three subcommands drive `bin/fm-ui-studio.sh` for deterministic infrastructure work,
+then handle the agent-lifecycle or captain-communication steps that require LLM judgment.
+
+Default project is `alc-dashboard-app` when no project arg is given.
+
+### `/ui-studio start [<project>]`
+
+1. Resolve the project clone under `$PROJECTS/<project>` using the
+   `$FM_HOME/data/projects.md` registry.
+   If the clone is absent, stop and tell the captain.
+
+2. Run `bin/fm-ui-studio.sh start <project>` (pass `FM_HOME`, `FM_ROOT_OVERRIDE`, and
+   any `*_OVERRIDE` vars already in the environment so path resolution is consistent).
+   The script exits non-zero on any infrastructure error and prints a plain-English
+   error; relay it to the captain and stop.
+   On success it prints `KEY=VALUE` lines:
+
+   ```
+   worktree=<path>
+   storybook_pid=<n>
+   storybook_url=<url>
+   storybook_log=<path>
+   storybook_status=starting|running
+   vibe_status=up|down|unavailable
+   studio_state=fresh|reused
+   ```
+
+3. If `storybook_status=starting`, tell the captain the server is warming up and to
+   watch its log at the printed `storybook_log` path.
+
+4. **Launch the studio agent pane** (firstmate does this step, not the script):
+
+   a. Read the crew harness: `bin/fm-harness.sh crew`.
+   b. If the harness is `claude` and `$HERDR_ENV = 1`, use the Herdr CLI to open a
+      new tab in this firstmate session's home workspace, with the worktree as its CWD,
+      and label it `ui-studio/<project>`:
+      ```
+      herdr tab create --workspace "$HERDR_WORKSPACE_ID" \
+        --cwd <worktree> --label "ui-studio/<project>" --no-focus
+      ```
+      Parse the returned `tab_id` and `pane_id`.
+      Record the pane ID in `state/ui-studio/<project>.pane` (one line, no newline context).
+      Then send the agent command and initial prompt:
+      ```
+      herdr pane send-text <pane_id> "claude"
+      herdr pane send-keys <pane_id> enter
+      ```
+      Wait about 10 seconds for Claude to start, then send the initial prompt via
+      `herdr pane send-text <pane_id> "<prompt>"` and `herdr pane send-keys <pane_id> enter`.
+   c. For other harnesses or non-Herdr sessions, print the worktree path and the
+      harness command and tell the captain to open a terminal there manually.
+      The studio agent prompt is in the next step.
+
+5. **Initial studio agent prompt** - use this exact text (substituting the real project,
+   URL, and path):
+
+   ```
+   You are the UI Studio agent for <project>.
+   Your only job: watch the Vibe annotation API at http://127.0.0.1:3846/api/annotations,
+   pick up new annotations, apply each change to the source file named in the annotation's
+   source_file_path field (mapping values to the project's design tokens where applicable),
+   verify the change looks right in Storybook at <storybook_url>, then mark the annotation
+   resolved by calling DELETE /api/annotations/<id>.
+   You work only on branch ui/studio in the worktree at <worktree>.
+   You may commit changes to ui/studio.
+   You must NEVER push, open PRs, or touch main.
+   Firstmate lands batches with /ui-studio land.
+   You also accept direct chat from the captain for one-off edits.
+   Poll annotations every 30 seconds when idle.
+   ```
+
+6. Print a concise captain summary:
+   - worktree path
+   - Storybook URL
+   - Vibe status (up or down)
+   - how to iterate (annotate in the browser, changes apply automatically)
+   - that `/ui-studio land` ships a batch when ready
+
+### `/ui-studio land [<project>]`
+
+1. Run `bin/fm-ui-studio.sh land <project>`.
+   The script:
+   - Fetches origin, counts commits ahead, exits 0 printing `studio_ahead=0` when
+     nothing is pending (relay "nothing to land" to the captain and stop).
+   - Rebases `ui/studio` onto `origin/main` and exits non-zero with a conflict report
+     on rebase failure.
+   - Runs `pnpm lint`, `pnpm test --run`, and `pnpm build-storybook` in the worktree,
+     exiting non-zero with the failing command's output on any failure.
+   - Pushes `ui/studio` to origin.
+   - Creates a PR via `gh-axi pr create` and prints `pr_url=<url>` and `pr_number=<n>`.
+
+2. Record the PR URL for the captain (full `https://...` link).
+
+3. **Merge path** - `bin/fm-pr-merge.sh` requires an existing task-meta file
+   (`state/<id>.meta`) and cannot be used here since the studio lane has no firstmate
+   task ID.
+   The chosen approach: monitor CI with `gh-axi pr checks <number>` and, once all
+   checks pass, merge with `gh-axi pr merge <number> --squash --delete-branch`.
+   Merge metadata recording (`pr=` in meta) is omitted; the studio lane opts out of
+   the firstmate task lifecycle by design.
+   Do not use `fm-pr-merge.sh` or `fm-pr-check.sh` for this lane.
+
+4. After merge is confirmed:
+   a. Refresh the project clone: `bin/fm-fleet-sync.sh <project>`.
+   b. Reset the studio worktree for the next round:
+      `bin/fm-ui-studio.sh start <project>` (it detects no un-landed commits and
+      fast-forwards to `origin/main`).
+   c. Touch `state/ui-studio/<project>.last-land` with the current timestamp.
+   d. Tell the captain the batch landed with the full PR URL.
+
+5. Relay any non-zero script exit to the captain with the exact error before stopping.
+
+### `/ui-studio status [<project>]`
+
+Run `bin/fm-ui-studio.sh status <project>` and relay the structured output to the
+captain in plain language:
+
+- whether Storybook is running (PID alive + port responding)
+- whether the studio agent pane is alive (check `state/ui-studio/<project>.pane` then
+  `herdr pane get <pane_id>` when on Herdr, or state the pane ID and note it cannot be
+  verified without Herdr)
+- how many commits `ui/studio` is ahead of `origin/main`
+- how long since the last land (from `state/ui-studio/<project>.last-land`)
+
+## Heartbeat land-nudge
+
+On every heartbeat, firstmate MAY run `/ui-studio status` for any active studio and
+nudge the captain to `/ui-studio land` when the branch is drifting - defined as more
+than 10 commits ahead of `origin/main` or more than 24 hours since the last land.
+This is a reminder only; firstmate never auto-merges the studio branch.
+
+## Guardrails
+
+- The studio agent is deliberately unsupervised: no `state/<id>.meta`, no watcher entry,
+  no turn-end guard.
+  Never register it as a firstmate task or add it to the backlog.
+- The studio worktree lives at `state/ui-studio/<project>/`, not under `projects/`.
+- Firstmate never pushes `ui/studio` or merges it - only the `/ui-studio land` path does.
+- The studio agent must never push, open PRs, or touch `main`.
+- v1 scope: `alc-dashboard-app` only.
+  The project registry lookup generalizes the path resolution, but multi-project
+  orchestration is deferred.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,6 +243,7 @@ Firstmate never writes a project's `AGENTS.md` directly.
 A crewmate creates or updates it lazily through the project's selected delivery path, using `bin/fm-ensure-agents-md.sh` and preferring pointers to authoritative sources over copied detail.
 Keep fleet delivery posture and captain-private strategy out of project memory.
 When the captain invokes `/stow`, load the `stow` skill for the complete knowledge-routing and unfinished-work sweep.
+When the captain invokes `/ui-studio` (with `start`, `land`, or `status`), load the `ui-studio` skill for the fast local UI-iteration lane.
 
 ## 7. Task lifecycle
 

--- a/bin/fm-ui-studio.sh
+++ b/bin/fm-ui-studio.sh
@@ -1,0 +1,420 @@
+#!/usr/bin/env bash
+# fm-ui-studio.sh - infrastructure helper for the /ui-studio skill.
+#
+# Manages the persistent ui/studio git worktree, the Storybook dev server,
+# the Vibe annotation server health check, and the land pipeline.
+# The /ui-studio skill (SKILL.md) drives this script; firstmate handles the
+# agent-pane launch and merge steps that require harness or LLM judgment.
+#
+# Usage:
+#   fm-ui-studio.sh start  <project>   set up worktree + storybook + vibe; print KEY=VALUE
+#   fm-ui-studio.sh land   <project>   rebase + test + push + open PR; print KEY=VALUE
+#   fm-ui-studio.sh status <project>   print studio health as KEY=VALUE
+#
+# Exit codes:
+#   0  success (including "nothing to land" for land; check studio_ahead=0)
+#   1  operational error (worktree conflict, test failure, etc.)
+#   2  usage error
+#
+# Output: KEY=VALUE lines on stdout; human-readable errors on stderr.
+# Callers must read stderr and relay it; stdout is for structured parsing.
+#
+# Ownership: this script is the sole owner of state/ui-studio/<project>/ worktrees
+# and state/ui-studio/<project>.{service,pane,last-land} state files.
+# The worktree is deliberately unsupervised (no state/<id>.meta, no watcher entry).
+# Writing to the linked project clone's .git/worktrees/ is an explicitly approved
+# exception scoped to the ui/studio branch only (see SKILL.md "Ownership exception").
+#
+# Service state file format (state/ui-studio/<project>.service):
+#   worktree=<path>
+#   storybook_pid=<pid>
+#   storybook_url=<url>
+#   storybook_log=<path>
+#   started_at=<ISO8601>
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
+
+STUDIO_DIR="$STATE/ui-studio"
+# Default storybook port used when log parsing times out
+DEFAULT_STORYBOOK_PORT=6006
+# Seconds to poll for storybook URL before falling back to default
+STORYBOOK_START_TIMEOUT=${FM_UI_STUDIO_SB_TIMEOUT:-90}
+# Seconds to wait for vibe-annotations start before reporting down
+VIBE_START_TIMEOUT=${FM_UI_STUDIO_VIBE_TIMEOUT:-15}
+# Vibe HTTP endpoint
+VIBE_URL="http://127.0.0.1:3846/api/annotations"
+
+usage() {
+  printf 'usage: fm-ui-studio.sh <start|land|status> <project>\n' >&2
+  exit 2
+}
+
+die() {
+  printf '%s\n' "$*" >&2
+  exit 1
+}
+
+# resolve_clone <project>: print the absolute path to the project clone.
+# Exits 1 when the clone is absent.
+resolve_clone() {
+  local project=$1 clone
+  clone="$PROJECTS/$project"
+  if [ ! -d "$clone/.git" ] && [ ! -f "$clone/.git" ]; then
+    die "project clone not found at $clone - add the project with /project-management first"
+  fi
+  printf '%s\n' "$clone"
+}
+
+# worktree_path <project>: print the studio worktree path.
+worktree_path() {
+  printf '%s/%s\n' "$STUDIO_DIR" "$1"
+}
+
+# service_file <project>: print the service state file path.
+service_file() {
+  printf '%s/%s.service\n' "$STUDIO_DIR" "$1"
+}
+
+# pane_file <project>: print the pane-id state file path.
+pane_file() {
+  printf '%s/%s.pane\n' "$STUDIO_DIR" "$1"
+}
+
+# last_land_file <project>: print the last-land timestamp file path.
+last_land_file() {
+  printf '%s/%s.last-land\n' "$STUDIO_DIR" "$1"
+}
+
+# read_service <file> <key>: print the value for KEY from a KEY=VALUE service file.
+read_service() {
+  local file=$1 key=$2
+  grep -m1 "^${key}=" "$file" 2>/dev/null | sed "s/^${key}=//"
+}
+
+# detect_pm <dir>: print the package manager command (pnpm|yarn|npm).
+detect_pm() {
+  local dir=$1
+  if [ -f "$dir/pnpm-lock.yaml" ]; then
+    printf 'pnpm\n'
+  elif [ -f "$dir/yarn.lock" ]; then
+    printf 'yarn\n'
+  else
+    printf 'npm\n'
+  fi
+}
+
+# has_script <dir> <name>: return 0 when package.json contains a "name" script.
+has_script() {
+  local dir=$1 name=$2
+  [ -f "$dir/package.json" ] && grep -q "\"${name}\"" "$dir/package.json"
+}
+
+# pid_alive <pid>: return 0 when the process exists.
+pid_alive() {
+  local pid=$1
+  case "$pid" in
+    '' | *[!0-9]*) return 1 ;;
+  esac
+  kill -0 "$pid" 2>/dev/null
+}
+
+# vibe_up: return 0 when the Vibe annotation server is reachable.
+vibe_up() {
+  curl -sf --max-time 3 "$VIBE_URL" >/dev/null 2>&1
+}
+
+# start_vibe: ensure the Vibe annotation server is up.
+# Prints "up", "down", or "unavailable" on stdout.
+start_vibe() {
+  if vibe_up; then
+    printf 'up\n'
+    return 0
+  fi
+  if ! command -v vibe-annotations >/dev/null 2>&1; then
+    printf 'unavailable\n'
+    return 0
+  fi
+  vibe-annotations start >/dev/null 2>&1 &
+  local elapsed=0
+  while [ "$elapsed" -lt "$VIBE_START_TIMEOUT" ]; do
+    sleep 1
+    elapsed=$((elapsed + 1))
+    if vibe_up; then
+      printf 'up\n'
+      return 0
+    fi
+  done
+  printf 'down\n'
+}
+
+# poll_storybook_url <log> <port>: poll log for the Local URL; print it when found.
+# Prints the fallback default URL and returns 1 on timeout.
+poll_storybook_url() {
+  local log=$1 port=$2 elapsed=0 url
+  while [ "$elapsed" -lt "$STORYBOOK_START_TIMEOUT" ]; do
+    if grep -q "Local:" "$log" 2>/dev/null; then
+      url=$(grep -m1 "Local:" "$log" | sed 's/.*Local:[[:space:]]*//' | tr -d '[:space:]')
+      if [ -n "$url" ]; then
+        printf '%s\n' "$url"
+        return 0
+      fi
+    fi
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+  printf 'http://localhost:%s/\n' "$port"
+  return 1
+}
+
+# ensure_worktree <clone> <worktree_dir>: create or validate the ui/studio worktree.
+# Prints "fresh" when newly created, "reused" when already current.
+# Exits 1 with a diagnostic when un-landed commits exist or the tree is dirty.
+ensure_worktree() {
+  local clone=$1 wt=$2 ahead branch
+
+  # Fetch before any branch check so origin/main is current
+  git -C "$clone" fetch origin --quiet 2>/dev/null || \
+    die "git fetch failed for clone at $clone - check network and origin"
+
+  if [ -d "$wt" ] && git -C "$wt" rev-parse --git-dir >/dev/null 2>&1; then
+    # Worktree already exists
+    branch=$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null || printf 'unknown')
+    if [ "$branch" != "ui/studio" ]; then
+      die "worktree at $wt is on branch '$branch', not ui/studio - inspect and clean up manually"
+    fi
+    if ! git -C "$wt" diff --quiet HEAD -- 2>/dev/null; then
+      die "worktree has uncommitted changes - commit or discard them before starting"
+    fi
+    ahead=$(git -C "$wt" rev-list --count origin/main..HEAD 2>/dev/null || printf '0')
+    if [ "$ahead" -gt 0 ]; then
+      die "ui/studio has $ahead un-landed commit(s) ahead of origin/main - run /ui-studio land first"
+    fi
+    git -C "$wt" reset --hard origin/main --quiet 2>/dev/null || \
+      die "failed to reset worktree to origin/main"
+    printf 'reused\n'
+  else
+    mkdir -p "$(dirname "$wt")"
+    if git -C "$clone" worktree add -B ui/studio "$wt" origin/main --quiet 2>/dev/null; then
+      printf 'fresh\n'
+    else
+      # Branch may already exist from an earlier worktree that was pruned
+      git -C "$clone" worktree add "$wt" ui/studio --quiet 2>/dev/null || \
+        die "failed to create worktree at $wt - ensure 'ui/studio' is not checked out elsewhere"
+      git -C "$wt" reset --hard origin/main --quiet 2>/dev/null || \
+        die "failed to reset recovered worktree to origin/main"
+      printf 'fresh\n'
+    fi
+  fi
+}
+
+# cmd_start <project>
+cmd_start() {
+  local project=$1 clone wt svc log pm pid url vibe_status studio_state storybook_status
+
+  clone=$(resolve_clone "$project")
+  wt=$(worktree_path "$project")
+  svc=$(service_file "$project")
+  log="$STUDIO_DIR/$project.storybook.log"
+
+  mkdir -p "$STUDIO_DIR"
+
+  # Reuse a running storybook when its PID is still alive
+  if [ -f "$svc" ]; then
+    pid=$(read_service "$svc" storybook_pid)
+    if pid_alive "$pid"; then
+      studio_state=$(ensure_worktree "$clone" "$wt")
+      url=$(read_service "$svc" storybook_url)
+      vibe_status=$(start_vibe)
+      printf 'worktree=%s\n' "$wt"
+      printf 'storybook_pid=%s\n' "$pid"
+      printf 'storybook_url=%s\n' "$url"
+      printf 'storybook_log=%s\n' "$log"
+      printf 'storybook_status=running\n'
+      printf 'vibe_status=%s\n' "$vibe_status"
+      printf 'studio_state=%s\n' "$studio_state"
+      return 0
+    fi
+  fi
+
+  studio_state=$(ensure_worktree "$clone" "$wt")
+  pm=$(detect_pm "$wt")
+
+  # Start storybook in the background
+  : > "$log"
+  (cd "$wt" && "$pm" storybook) >> "$log" 2>&1 &
+  pid=$!
+
+  # Poll for the URL; accept the default on timeout
+  storybook_status=starting
+  if url=$(poll_storybook_url "$log" "$DEFAULT_STORYBOOK_PORT"); then
+    storybook_status=running
+  else
+    url="http://localhost:${DEFAULT_STORYBOOK_PORT}/"
+  fi
+
+  # Record service state
+  {
+    printf 'worktree=%s\n' "$wt"
+    printf 'storybook_pid=%s\n' "$pid"
+    printf 'storybook_url=%s\n' "$url"
+    printf 'storybook_log=%s\n' "$log"
+    printf 'started_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  } > "$svc"
+
+  vibe_status=$(start_vibe)
+
+  printf 'worktree=%s\n' "$wt"
+  printf 'storybook_pid=%s\n' "$pid"
+  printf 'storybook_url=%s\n' "$url"
+  printf 'storybook_log=%s\n' "$log"
+  printf 'storybook_status=%s\n' "$storybook_status"
+  printf 'vibe_status=%s\n' "$vibe_status"
+  printf 'studio_state=%s\n' "$studio_state"
+}
+
+# cmd_land <project>
+cmd_land() {
+  local project=$1 clone wt pm ahead pr_url pr_number
+
+  clone=$(resolve_clone "$project")
+  wt=$(worktree_path "$project")
+
+  if [ ! -d "$wt" ] || ! git -C "$wt" rev-parse --git-dir >/dev/null 2>&1; then
+    die "studio worktree not found at $wt - run /ui-studio start first"
+  fi
+
+  git -C "$wt" fetch origin --quiet 2>/dev/null || \
+    die "git fetch failed - check network and origin"
+
+  ahead=$(git -C "$wt" rev-list --count origin/main..HEAD 2>/dev/null || printf '0')
+  if [ "$ahead" -eq 0 ]; then
+    printf 'studio_ahead=0\n'
+    printf 'message=nothing to land\n'
+    return 0
+  fi
+
+  git -C "$wt" rebase origin/main --quiet 2>/dev/null || \
+    die "rebase onto origin/main failed - resolve conflicts in $wt then re-run /ui-studio land"
+
+  pm=$(detect_pm "$wt")
+
+  # Lint, test, build - stop on first failure
+  printf 'step=lint\n'
+  (cd "$wt" && "$pm" lint) || die "lint failed - fix issues in $wt before landing"
+
+  printf 'step=test\n'
+  if has_script "$wt" "test:ci"; then
+    (cd "$wt" && "$pm" "test:ci") || die "tests failed - fix failing tests in $wt before landing"
+  else
+    (cd "$wt" && "$pm" test --run) || die "tests failed - fix failing tests in $wt before landing"
+  fi
+
+  printf 'step=build-storybook\n'
+  (cd "$wt" && "$pm" build-storybook) || \
+    die "Storybook build failed - fix build errors in $wt before landing"
+
+  git -C "$wt" push -u origin ui/studio 2>/dev/null || \
+    die "git push failed - check remote permissions"
+
+  # gh-axi pr create uses the worktree's git remote to detect the repo
+  pr_url=$(cd "$wt" && gh-axi pr create \
+    --title "ui/studio: batch land from UI Studio" \
+    --body "Auto-created by /ui-studio land. Review diff and merge to ship." \
+    --head ui/studio --base main 2>/dev/null) || \
+    die "gh-axi pr create failed - check GitHub auth and that the branch was pushed"
+
+  pr_number=$(printf '%s\n' "$pr_url" | sed 's|.*/pull/||' | tr -d '[:space:]')
+
+  printf 'studio_ahead=%s\n' "$ahead"
+  printf 'pr_url=%s\n' "$pr_url"
+  printf 'pr_number=%s\n' "$pr_number"
+}
+
+# cmd_status <project>
+cmd_status() {
+  local project=$1 wt svc pid url ahead pane_id lf pf storybook_status vibe_status last_land_ts
+
+  wt=$(worktree_path "$project")
+  svc=$(service_file "$project")
+
+  storybook_status=down
+  pid=
+  url=
+  if [ -f "$svc" ]; then
+    pid=$(read_service "$svc" storybook_pid)
+    url=$(read_service "$svc" storybook_url)
+    if pid_alive "$pid"; then
+      storybook_status=running
+    fi
+  fi
+
+  if vibe_up; then
+    vibe_status=up
+  else
+    vibe_status=down
+  fi
+
+  ahead=unknown
+  if [ -d "$wt" ] && git -C "$wt" rev-parse --git-dir >/dev/null 2>&1; then
+    git -C "$wt" fetch origin --quiet 2>/dev/null || true
+    ahead=$(git -C "$wt" rev-list --count origin/main..HEAD 2>/dev/null || printf 'unknown')
+  fi
+
+  last_land_ts=never
+  lf=$(last_land_file "$project")
+  if [ -f "$lf" ]; then
+    last_land_ts=$(cat "$lf" 2>/dev/null || printf 'unknown')
+  fi
+
+  pane_id=
+  pf=$(pane_file "$project")
+  if [ -f "$pf" ]; then
+    pane_id=$(cat "$pf" 2>/dev/null || true)
+  fi
+
+  printf 'storybook_status=%s\n' "$storybook_status"
+  printf 'storybook_pid=%s\n' "${pid:-}"
+  printf 'storybook_url=%s\n' "${url:-}"
+  printf 'vibe_status=%s\n' "$vibe_status"
+  printf 'studio_ahead=%s\n' "$ahead"
+  printf 'last_land=%s\n' "$last_land_ts"
+  printf 'pane_id=%s\n' "${pane_id:-}"
+  printf 'worktree=%s\n' "$wt"
+}
+
+# --- main ---
+
+[ $# -ge 1 ] || usage
+
+SUBCMD=$1
+shift
+
+case "$SUBCMD" in
+  --help|-h)
+    usage
+    ;;
+  start|land|status)
+    [ $# -ge 1 ] || usage
+    PROJECT=$1
+    case "$PROJECT" in
+      '' | -*)
+        usage
+        ;;
+    esac
+    case "$SUBCMD" in
+      start)  cmd_start  "$PROJECT" ;;
+      land)   cmd_land   "$PROJECT" ;;
+      status) cmd_status "$PROJECT" ;;
+    esac
+    ;;
+  *)
+    printf 'unknown subcommand: %s\n' "$SUBCMD" >&2
+    usage
+    ;;
+esac

--- a/tests/fm-ui-studio.test.sh
+++ b/tests/fm-ui-studio.test.sh
@@ -1,0 +1,370 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-ui-studio.sh argument handling, state management,
+# and git worktree lifecycle.
+#
+# Does NOT test storybook launch, vibe-annotations, or gh-axi PR creation -
+# those require live external services and are exercised in integration.
+# Tests use real git repos (no git mocking) consistent with the suite's pattern.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SCRIPT="$ROOT/bin/fm-ui-studio.sh"
+fm_git_identity fmtest fmtest@example.invalid
+
+TMP_ROOT=$(fm_test_tmproot fm-ui-studio-tests)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+# build_project_home <name>: create an FM_HOME with a real project clone.
+# Returns the home dir path on stdout.
+build_project_home() {
+  local name=$1 home origin work clone remote_abs
+  home="$TMP_ROOT/home-$name"
+  origin="$TMP_ROOT/origin-$name.git"
+  work="$TMP_ROOT/work-$name"
+
+  mkdir -p "$home/projects" "$home/state"
+
+  # Bare origin with one commit
+  git init -q "$work"
+  git -C "$work" symbolic-ref HEAD refs/heads/main
+  printf '# %s\n' "$name" > "$work/README.md"
+  git -C "$work" add README.md
+  git -C "$work" commit -qm "init"
+  git clone --quiet --bare "$work" "$origin"
+  remote_abs=$(cd "$origin" && pwd)
+  git -C "$work" remote add origin "file://$remote_abs"
+  git -C "$work" push -q -u origin main
+
+  # Clone as projects/<name>
+  clone="$home/projects/$name"
+  git clone --quiet "file://$remote_abs" "$clone"
+
+  printf '%s\n' "$home"
+}
+
+# add_ui_studio_commit <home> <name>: add a commit to the studio worktree.
+add_ui_studio_commit() {
+  local home=$1 name=$2 wt
+  wt="$home/state/ui-studio/$name"
+  printf 'change\n' >> "$wt/README.md"
+  git -C "$wt" add README.md
+  git -C "$wt" commit -qm "ui: studio change"
+}
+
+# run_start <home> <project>: invoke start with FM_HOME override.
+run_start() {
+  FM_HOME="$1" FM_ROOT_OVERRIDE="$ROOT" FM_UI_STUDIO_SB_TIMEOUT=0 \
+    "$SCRIPT" start "$2" 2>/dev/null
+}
+
+# run_start_stderr <home> <project>: capture stderr only.
+run_start_stderr() {
+  FM_HOME="$1" FM_ROOT_OVERRIDE="$ROOT" FM_UI_STUDIO_SB_TIMEOUT=0 \
+    "$SCRIPT" start "$2" 2>&1 >/dev/null
+}
+
+# run_land <home> <project>: invoke land with FM_HOME override.
+run_land() {
+  FM_HOME="$1" FM_ROOT_OVERRIDE="$ROOT" \
+    "$SCRIPT" land "$2" 2>/dev/null
+}
+
+# run_land_stderr <home> <project>: capture stderr only.
+run_land_stderr() {
+  FM_HOME="$1" FM_ROOT_OVERRIDE="$ROOT" \
+    "$SCRIPT" land "$2" 2>&1 >/dev/null
+}
+
+# run_status <home> <project>: invoke status with FM_HOME override.
+run_status() {
+  FM_HOME="$1" FM_ROOT_OVERRIDE="$ROOT" \
+    "$SCRIPT" status "$2" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Tests: argument handling
+# ---------------------------------------------------------------------------
+
+test_no_args_exits_2() {
+  "$SCRIPT" >/dev/null 2>&1; rc=$?
+  [ "$rc" -eq 2 ] || fail "no args: expected exit 2, got $rc"
+  pass "no args exits 2"
+}
+
+test_unknown_subcommand_exits_2() {
+  "$SCRIPT" frobnicate proj >/dev/null 2>&1; rc=$?
+  [ "$rc" -eq 2 ] || fail "unknown subcommand: expected exit 2, got $rc"
+  pass "unknown subcommand exits 2"
+}
+
+test_missing_project_arg_exits_2() {
+  "$SCRIPT" start >/dev/null 2>&1; rc=$?
+  [ "$rc" -eq 2 ] || fail "missing project: expected exit 2, got $rc"
+  pass "missing project arg exits 2"
+}
+
+test_dash_prefix_project_exits_2() {
+  "$SCRIPT" start --not-a-project >/dev/null 2>&1; rc=$?
+  [ "$rc" -eq 2 ] || fail "dash-prefix project: expected exit 2, got $rc"
+  pass "dash-prefix project exits 2"
+}
+
+test_help_flag_exits_2() {
+  "$SCRIPT" --help >/dev/null 2>&1; rc=$?
+  [ "$rc" -eq 2 ] || fail "--help: expected exit 2, got $rc"
+  pass "--help exits 2"
+}
+
+# ---------------------------------------------------------------------------
+# Tests: start subcommand
+# ---------------------------------------------------------------------------
+
+test_start_missing_clone_exits_1() {
+  local home
+  home=$(mktemp -d "$TMP_ROOT/empty-home.XXXXXX")
+  mkdir -p "$home/projects" "$home/state"
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$SCRIPT" start nosuchproject >/dev/null 2>&1
+  rc=$?
+  [ "$rc" -eq 1 ] || fail "missing clone: expected exit 1, got $rc"
+  rm -rf "$home"
+  pass "start with missing clone exits 1"
+}
+
+test_start_missing_clone_error_mentions_project() {
+  local home err
+  home=$(mktemp -d "$TMP_ROOT/empty-home2.XXXXXX")
+  mkdir -p "$home/projects" "$home/state"
+  err=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$SCRIPT" start nosuchproject 2>&1 >/dev/null || true)
+  printf '%s\n' "$err" | grep -q "nosuchproject" || \
+    fail "missing clone error does not mention project name"
+  rm -rf "$home"
+  pass "start missing-clone error mentions the project name"
+}
+
+test_start_creates_worktree() {
+  local home out wt
+  home=$(build_project_home "myproj")
+  # Use timeout=0 so poll_storybook_url returns immediately with default URL,
+  # and fake pnpm so storybook doesn't actually run.
+  local fakebin
+  fakebin=$(fm_fakebin "$TMP_ROOT/fakebin-start")
+  fm_fake_exit0 "$fakebin" pnpm
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_UI_STUDIO_SB_TIMEOUT=0 "$SCRIPT" start myproj 2>/dev/null)
+  wt="$home/state/ui-studio/myproj"
+  [ -d "$wt" ] || fail "worktree directory was not created at $wt"
+  printf '%s\n' "$out" | grep -q "worktree=" || \
+    fail "start output missing worktree= line"
+  printf '%s\n' "$out" | grep -q "storybook_url=" || \
+    fail "start output missing storybook_url= line"
+  printf '%s\n' "$out" | grep -q "studio_state=fresh" || \
+    fail "start output missing studio_state=fresh"
+  git -C "$wt" rev-parse --abbrev-ref HEAD | grep -q "ui/studio" || \
+    fail "worktree is not on branch ui/studio"
+  pass "start creates worktree on ui/studio branch with correct output"
+}
+
+test_start_reuse_reports_reused() {
+  local home out wt fakebin
+  home=$(build_project_home "reuse-proj")
+  fakebin=$(fm_fakebin "$TMP_ROOT/fakebin-reuse")
+  fm_fake_exit0 "$fakebin" pnpm
+
+  # First start
+  PATH="$fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_UI_STUDIO_SB_TIMEOUT=0 "$SCRIPT" start "reuse-proj" >/dev/null 2>/dev/null
+
+  wt="$home/state/ui-studio/reuse-proj"
+  [ -d "$wt" ] || fail "worktree not created on first start"
+
+  # Second start (no commits ahead, should report reused)
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_UI_STUDIO_SB_TIMEOUT=0 "$SCRIPT" start "reuse-proj" 2>/dev/null)
+  printf '%s\n' "$out" | grep -q "studio_state=reused" || \
+    fail "second start did not report studio_state=reused"
+  pass "second start with clean worktree reports reused"
+}
+
+test_start_refuses_unlanded_commits() {
+  local home wt fakebin err
+  home=$(build_project_home "dirty-proj")
+  fakebin=$(fm_fakebin "$TMP_ROOT/fakebin-dirty")
+  fm_fake_exit0 "$fakebin" pnpm
+
+  # First start - creates worktree
+  PATH="$fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_UI_STUDIO_SB_TIMEOUT=0 "$SCRIPT" start "dirty-proj" >/dev/null 2>/dev/null
+
+  wt="$home/state/ui-studio/dirty-proj"
+  add_ui_studio_commit "$home" "dirty-proj"
+
+  # Second start - should refuse
+  err=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_UI_STUDIO_SB_TIMEOUT=0 "$SCRIPT" start "dirty-proj" 2>&1 >/dev/null || true)
+  rc=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_UI_STUDIO_SB_TIMEOUT=0 "$SCRIPT" start "dirty-proj" 2>/dev/null; printf '%s' $?) || true
+  # Verify it exits nonzero AND mentions "land"
+  printf '%s\n' "$err" | grep -qi "land" || \
+    fail "unlanded-commits error does not mention 'land': $err"
+  pass "start refuses to reset worktree with un-landed commits"
+}
+
+test_start_writes_service_file() {
+  local home svc fakebin
+  home=$(build_project_home "svc-proj")
+  fakebin=$(fm_fakebin "$TMP_ROOT/fakebin-svc")
+  fm_fake_exit0 "$fakebin" pnpm
+
+  PATH="$fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_UI_STUDIO_SB_TIMEOUT=0 "$SCRIPT" start "svc-proj" >/dev/null 2>/dev/null
+
+  svc="$home/state/ui-studio/svc-proj.service"
+  [ -f "$svc" ] || fail "service file not written at $svc"
+  grep -q "storybook_pid=" "$svc" || fail "service file missing storybook_pid"
+  grep -q "storybook_url=" "$svc" || fail "service file missing storybook_url"
+  grep -q "worktree=" "$svc" || fail "service file missing worktree"
+  pass "start writes service file with expected keys"
+}
+
+# ---------------------------------------------------------------------------
+# Tests: land subcommand
+# ---------------------------------------------------------------------------
+
+test_land_missing_worktree_exits_1() {
+  local home
+  home=$(build_project_home "land-nowt")
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$SCRIPT" land "land-nowt" >/dev/null 2>&1
+  rc=$?
+  [ "$rc" -eq 1 ] || fail "land without worktree: expected exit 1, got $rc"
+  pass "land without a worktree exits 1"
+}
+
+test_land_nothing_to_land() {
+  local home out fakebin
+  home=$(build_project_home "land-empty")
+  fakebin=$(fm_fakebin "$TMP_ROOT/fakebin-land-empty")
+  fm_fake_exit0 "$fakebin" pnpm
+
+  # Create the worktree first
+  PATH="$fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_UI_STUDIO_SB_TIMEOUT=0 "$SCRIPT" start "land-empty" >/dev/null 2>/dev/null
+
+  out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    "$SCRIPT" land "land-empty" 2>/dev/null)
+  printf '%s\n' "$out" | grep -q "studio_ahead=0" || \
+    fail "nothing-to-land output missing studio_ahead=0: $out"
+  pass "land with no commits ahead prints studio_ahead=0 and exits 0"
+}
+
+test_land_lint_failure_exits_1() {
+  local home fakebin rc
+  home=$(build_project_home "land-lint-fail")
+  fakebin=$(fm_fakebin "$TMP_ROOT/fakebin-lint-fail")
+
+  # pnpm: storybook succeeds, lint fails, others succeed
+  cat > "$fakebin/pnpm" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+  storybook) exit 0 ;;
+  lint) exit 1 ;;
+  *) exit 0 ;;
+esac
+SH
+  chmod +x "$fakebin/pnpm"
+
+  # Create worktree and add a commit
+  PATH="$fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_UI_STUDIO_SB_TIMEOUT=0 "$SCRIPT" start "land-lint-fail" >/dev/null 2>/dev/null
+  add_ui_studio_commit "$home" "land-lint-fail"
+
+  PATH="$fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    "$SCRIPT" land "land-lint-fail" >/dev/null 2>&1
+  rc=$?
+  [ "$rc" -eq 1 ] || fail "lint failure: expected exit 1, got $rc"
+  pass "land exits 1 when lint fails"
+}
+
+# ---------------------------------------------------------------------------
+# Tests: status subcommand
+# ---------------------------------------------------------------------------
+
+test_status_no_state() {
+  local home out
+  home=$(build_project_home "status-empty")
+  out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    "$SCRIPT" status "status-empty" 2>/dev/null)
+  printf '%s\n' "$out" | grep -q "storybook_status=down" || \
+    fail "status with no state should report storybook_status=down"
+  printf '%s\n' "$out" | grep -q "last_land=never" || \
+    fail "status with no state should report last_land=never"
+  printf '%s\n' "$out" | grep -q "studio_ahead=" || \
+    fail "status output missing studio_ahead= line"
+  pass "status with no prior studio reports down and never"
+}
+
+test_status_reads_pane_file() {
+  local home out pf
+  home=$(build_project_home "status-pane")
+  mkdir -p "$home/state/ui-studio"
+  pf="$home/state/ui-studio/status-pane.pane"
+  printf 'pane-abc123\n' > "$pf"
+  out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    "$SCRIPT" status "status-pane" 2>/dev/null)
+  printf '%s\n' "$out" | grep -q "pane_id=pane-abc123" || \
+    fail "status did not read pane file: $out"
+  pass "status reads pane_id from pane file"
+}
+
+test_status_reads_last_land() {
+  local home out lf
+  home=$(build_project_home "status-land")
+  mkdir -p "$home/state/ui-studio"
+  lf="$home/state/ui-studio/status-land.last-land"
+  printf '2026-08-11T10:00:00Z\n' > "$lf"
+  out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    "$SCRIPT" status "status-land" 2>/dev/null)
+  printf '%s\n' "$out" | grep -q "last_land=2026-08-11T10:00:00Z" || \
+    fail "status did not read last-land file: $out"
+  pass "status reads last_land from last-land file"
+}
+
+test_status_missing_project_clone_still_returns() {
+  local home out
+  home=$(mktemp -d "$TMP_ROOT/status-no-clone.XXXXXX")
+  mkdir -p "$home/projects" "$home/state"
+  out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    "$SCRIPT" status "nosuchproj" 2>/dev/null)
+  # Status should succeed even when the project clone is missing (just unknown ahead count)
+  printf '%s\n' "$out" | grep -q "storybook_status=" || \
+    fail "status with missing clone did not return storybook_status line"
+  rm -rf "$home"
+  pass "status returns structured output even when project clone is absent"
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests
+# ---------------------------------------------------------------------------
+
+test_no_args_exits_2
+test_unknown_subcommand_exits_2
+test_missing_project_arg_exits_2
+test_dash_prefix_project_exits_2
+test_help_flag_exits_2
+test_start_missing_clone_exits_1
+test_start_missing_clone_error_mentions_project
+test_start_creates_worktree
+test_start_reuse_reports_reused
+test_start_refuses_unlanded_commits
+test_start_writes_service_file
+test_land_missing_worktree_exits_1
+test_land_nothing_to_land
+test_land_lint_failure_exits_1
+test_status_no_state
+test_status_reads_pane_file
+test_status_reads_last_land
+test_status_missing_project_clone_still_returns


### PR DESCRIPTION
## Summary

- Adds `.agents/skills/ui-studio/SKILL.md`: captain-invocable skill (`user-invocable: true`, `metadata.internal: true`) for `start`, `land`, and `status` subcommands. Documents the worktree ownership exception, Herdr pane launch steps, merge-path decision (direct `gh-axi pr merge`, no `fm-pr-merge.sh` since the studio lane has no task meta), and heartbeat land-nudge policy.
- Adds `bin/fm-ui-studio.sh`: shellcheck-clean helper managing the git worktree lifecycle (create/reuse/refuse on un-landed commits), Storybook background launch with URL polling, Vibe annotation server health/start, and the land pipeline (rebase + lint + test + build + push + PR). All output is `KEY=VALUE` on stdout for structured firstmate parsing.
- Adds `tests/fm-ui-studio.test.sh`: 18 behavioral tests covering argument handling, worktree lifecycle, land gate failures, and status state-file reading. Uses real git repos.
- Updates `AGENTS.md` section 6 with one-line trigger alongside `/stow`.

## Design notes

The `fm-pr-merge.sh` merge path requires an existing `state/<id>.meta` file and cannot be used for the studio lane, which deliberately has no firstmate task ID. The land subcommand documents this explicitly and uses `gh-axi pr merge` directly. This is documented in SKILL.md as the chosen approach, not a needs-decision escalation.

## Test plan

- [ ] `bash tests/fm-ui-studio.test.sh` - all 18 tests pass
- [ ] `bash -n bin/fm-ui-studio.sh` - syntax clean
- [ ] Argument handling: no args, unknown subcommand, missing project all exit correctly
- [ ] `status` on a fresh home returns structured output without errors