### PR TITLE
feat(bin): add --driver and --split-gate brief scaffolds for the no-mistakes gate split

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -6,7 +6,8 @@
 # description, acceptance criteria, and context, and may adjust other sections
 # when the task genuinely deviates (e.g. working an existing external PR instead
 # of shipping a new one).
-# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only> [--herdr-lab]
+# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only> [--split-gate] [--herdr-lab]
+#        fm-brief.sh <task-id> <repo-name> --mode no-mistakes --driver
 #        fm-brief.sh <task-id> <repo-name> --scout [--herdr-lab]
 #        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
 #   --scout writes the scout contract instead: the deliverable is a report at
@@ -40,6 +41,28 @@
 # "Delivery contract: mode=<mode>" line. bin/fm-spawn.sh reads that line and refuses
 # to launch a ship task whose explicit --mode disagrees, so an adjusted brief and the
 # recorded task metadata cannot drift apart.
+# --split-gate (valid only with --mode no-mistakes) opts the BUILDER into the
+# split-gate definition of done: implement, commit, write or append a handoff
+# cycle at data/<task-id>/handoff.md, append
+# "done: built fm/<task-id> at <short-sha>, handoff ready", and stop - every
+# gate-driving instruction moves to the separate driver brief instead.
+# Without the flag the generated no-mistakes scaffold is unchanged.
+# --driver (valid only with --mode no-mistakes) writes the gate-driver brief to
+# data/<task-id>/driver-brief.md instead of brief.md. It is complete as
+# generated - no {TASK} placeholder - and records the fixed machine-readable
+# "Delivery contract: mode=no-mistakes phase=driver" line. Firstmate regenerates
+# it at each builder->driver flip, so an existing driver-brief.md is
+# overwritten deliberately; brief.md keeps its no-overwrite guarantee.
+# --driver is mutually exclusive with --split-gate and --herdr-lab: a driver
+# drives gate commands only and never runs task commands.
+# This header owns the handoff-file contract shared by both split scaffolds:
+# data/<task-id>/handoff.md is written by the builder, read by the driver as its
+# entire product context, and appended per cycle - one new cycle per builder
+# round, earlier cycles never rewritten. Each cycle carries five required
+# sections: Intent (one self-contained paragraph the driver passes verbatim as
+# the pipeline --intent), Change inventory (branch, base SHA, commit list,
+# touched areas), Verification notes, Review anticipation, and Escalation
+# guidance, at a target of 1-2k tokens per cycle.
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
 # --mode is refused on scout and secondmate scaffolds: a scout's deliverable is a
 # report rather than a merge, and a charter is not a delivery contract.
@@ -54,7 +77,8 @@
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
 # over copied detail) and has the crewmate add the fm-ensure-agents-md.sh
 # self-governance section when a touched project AGENTS.md lacks it.
-# Refuses to overwrite an existing brief.
+# Refuses to overwrite an existing brief. The regenerable driver-brief.md is the
+# one deliberate exception.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -104,6 +128,8 @@ fi
 KIND=ship
 HERDR_LAB=0
 NO_PROJECTS=0
+DRIVER=0
+SPLIT_GATE=0
 MODE=
 MODE_SET=0
 POS=()
@@ -125,6 +151,8 @@ for a in "$@"; do
     --secondmate) KIND=secondmate ;;
     --herdr-lab) HERDR_LAB=1 ;;
     --no-projects) NO_PROJECTS=1 ;;
+    --driver) DRIVER=1 ;;
+    --split-gate) SPLIT_GATE=1 ;;
     --mode) want_value=mode ;;
     --mode=*) MODE=${a#--mode=}; MODE_SET=1 ;;
     # yolo never reaches the worker: it is firstmate's approval authority, not a
@@ -154,6 +182,27 @@ elif [ "$MODE_SET" -eq 1 ]; then
   echo "error: --mode applies only to ship briefs; a scout delivers a report and a secondmate charter is not a delivery contract" >&2
   exit 1
 fi
+
+# --driver and --split-gate are the two halves of the no-mistakes builder/driver
+# gate split; anywhere else they are meaningless and refuse loudly rather than
+# scaffolding a brief that silently ignores them.
+if [ "$DRIVER" -eq 1 ]; then
+  if [ "$KIND" != ship ] || [ "$MODE" != no-mistakes ]; then
+    echo "error: --driver applies only to --mode no-mistakes ship briefs; the driver drives that pipeline's gates from the builder's handoff" >&2
+    exit 1
+  fi
+  if [ "$SPLIT_GATE" -eq 1 ]; then
+    echo "error: --driver and --split-gate are mutually exclusive; --split-gate shapes the builder definition of done and a driver brief has none" >&2
+    exit 1
+  fi
+  if [ "$HERDR_LAB" -eq 1 ]; then
+    echo "error: --herdr-lab does not apply to --driver briefs; a driver runs gate commands only, never task commands" >&2
+    exit 1
+  fi
+elif [ "$SPLIT_GATE" -eq 1 ] && { [ "$KIND" != ship ] || [ "$MODE" != no-mistakes ]; }; then
+  echo "error: --split-gate applies only to --mode no-mistakes ship briefs; it changes the no-mistakes builder definition of done" >&2
+  exit 1
+fi
 ID=${POS[0]}
 
 if [ "$KIND" = secondmate ] && [ "$HERDR_LAB" -eq 1 ]; then
@@ -166,8 +215,15 @@ if [ "$NO_PROJECTS" -eq 1 ] && [ "$KIND" != secondmate ]; then
   exit 1
 fi
 
-BRIEF="$DATA/$ID/brief.md"
-[ -e "$BRIEF" ] && { echo "error: $BRIEF already exists" >&2; exit 1; }
+if [ "$DRIVER" -eq 1 ]; then
+  # The driver brief carries no {TASK} placeholder, so its content is fully
+  # determined by its inputs; firstmate regenerates it at every builder->driver
+  # flip and overwriting is the intended idempotent path.
+  BRIEF="$DATA/$ID/driver-brief.md"
+else
+  BRIEF="$DATA/$ID/brief.md"
+  [ -e "$BRIEF" ] && { echo "error: $BRIEF already exists" >&2; exit 1; }
+fi
 mkdir -p "$DATA/$ID"
 
 shell_quote() {
@@ -265,6 +321,90 @@ exit 0
 fi
 
 REPO=${POS[1]}
+
+# Driver scaffold: the gate-driving half of the no-mistakes builder/driver
+# split. It is complete as generated (no {TASK}), inherits the builder's task
+# worktree, and its entire product context is the handoff file whose contract
+# this script's header owns. It carries no Herdr section because a driver never
+# runs task commands (the --herdr-lab combination is refused above).
+if [ "$DRIVER" -eq 1 ]; then
+cat > "$BRIEF" <<EOF
+You are a crewmate: a gate DRIVER agent managed by firstmate. Work on your own; do not wait for a human.
+
+# Task
+Drive the no-mistakes gate for branch \`fm/$ID\` of $REPO to completion.
+Your entire product context is \`$DATA/$ID/handoff.md\` - read it first, latest cycle first.
+You build nothing and decide nothing above the gate rules below: the builder owns code and firstmate owns decisions.
+
+# Setup
+You inherit the task's existing git worktree with branch \`fm/$ID\` checked out; verify it, create nothing.
+
+**Verify isolation before anything else.** Run \`pwd -P\` and \`git rev-parse --show-toplevel\`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
+The path check is authoritative: \`git rev-parse --git-dir\` and \`git rev-parse --git-common-dir\` can help inspect the repo, but they do not prove you are outside the primary checkout.
+If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not touch anything - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
+
+1. Confirm \`git rev-parse --abbrev-ref HEAD\` prints \`fm/$ID\` and matches the handoff's Change inventory; if not, append \`blocked: worktree branch does not match the handoff\` and stop.
+2. Run \`no-mistakes axi\` and read its \`branch_sync\` block before acting.
+
+# Gate rules
+1. Start or reattach the run: \`no-mistakes axi run --intent "<the handoff's Intent section, verbatim>"\`.
+   If axi reports an active run for this branch, reattach and drive it instead of starting a new one.
+2. Keep exactly one foreground blocking AXI call per turn; never end your turn while a call is executing.
+   End your turn only after writing a park (rule 4) or an outcome (rule 6 or 7).
+3. At a gate, read the findings table's action column:
+   - all findings auto-fix and/or no-op: respond yourself
+     (\`--action fix --findings <auto-fix ids>\`, or \`--action approve\` when only no-op).
+   - anything ask-user: park (rule 4). Never approve, fix, or skip an ask-user finding yourself.
+   - a problem you noticed that the pipeline missed: fold it in with \`--add-finding\`; never edit files.
+4. To park: write the gate's findings VERBATIM (id, severity, file, action, full description)
+   to \`$DATA/$ID/gate-findings-<run>-<step>.md\`, append
+   \`needs-decision [key=gate-<step>-<n>]: <one-line summary> (details: <that file>)\`,
+   and end your turn. The run stays parked daemon-side; that is safe and expected.
+5. On every wake, FIRST re-read \`no-mistakes axi status\` and reconcile before responding;
+   the run may have moved (merged PR, monitor progress) while you were parked.
+   Then translate firstmate's decision into the exact respond call it names.
+6. Outcome checks-passed: append \`done: PR <url> checks green\` to the status file and stop.
+   The daemon alone decides readiness, including the trusted \`no_ci: true\` case; never second-guess it against the forge's own check list.
+7. Outcome failed or cancelled: write the evidence (step, log tail, findings) to
+   \`$DATA/$ID/gate-report-<run>.md\`, append
+   \`blocked [key=builder-fix-<n>]: run <state> at <step>, code fix needed (details: <that file>)\`,
+   and stop. Firstmate flips the task back to a builder cycle.
+8. You never edit, commit, or revert ANY file, trivial or not; the pipeline owns fixes (\`--action fix\`) and the builder owns code.
+   You never run \`--yes\`; it would silently bypass firstmate's authority check and any required captain escalation.
+   You never abort or rerun mid-run except under an explicit supersession instruction from firstmate, in which case:
+   abort, confirm the run stopped via \`no-mistakes axi status\`, follow \`branch_sync.next_action\` exactly
+   (\`sync --recover\` only when it reports \`recover_custody\`; a \`branch_sync.state\` of \`user_owned\` means the run
+   went terminal without changing the submitted head, no sync action is needed, and a repeated \`--recover\` is a
+   harmless no-op), append \`resolved [key=<the instruction's key>]: run aborted, custody settled\`, and stop.
+9. On \`error.code: nested_gate_context\`, stop and append \`blocked: axi reports nested_gate_context - this driver was launched inside a pipeline context, a wiring bug\`; never retry the command.
+
+# Rules
+1. Never push to the default branch. Never merge a PR.
+2. Stay inside this worktree; your only writes are the gate files under \`$DATA/$ID/\` and the status file below.
+3. Use gh-axi for GitHub operations.
+4. Report status by appending one line:
+   \`echo "{state}: {one short line}" >> $STATUS_FILE\`
+   States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
+   Each append wakes firstmate, so report sparingly: only the parks, outcomes, and blockers the gate rules name.
+   Use \`$PAUSED_VERB: {why}\` - distinct from \`blocked:\` - ONLY when you are deliberately idling on a
+   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
+   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
+   cadence instead of treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
+5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
+6. A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
+   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
+7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
+   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
+   daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+
+# Definition of done
+Delivery contract: mode=no-mistakes phase=driver
+The gate rules above define your only endings: rule 6's \`done: PR <url> checks green\` on a passed run, or rule 7's keyed builder-fix blocker on a failed or cancelled run.
+There is no other completion path; you never implement, promote, or merge anything.
+EOF
+echo "scaffolded: $BRIEF (no-mistakes driver; complete as generated, regenerated per flip)"
+exit 0
+fi
 
 if [ "$HERDR_LAB" -eq 1 ]; then
 HERDR_LAB_HELPER=$(shell_quote "$FM_ROOT/bin/fm-herdr-lab.sh")
@@ -381,6 +521,32 @@ EOF
     SETUP2="
 2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
     RULE1='1. Never push to the default branch. Never merge a PR.'
+    if [ "$SPLIT_GATE" -eq 1 ]; then
+    # Split-gate builder: gate driving moves to the driver brief entirely; the
+    # builder's definition of done is implement, commit, and hand off. The
+    # handoff-file contract is owned by this script's header.
+    IFS= read -r -d '' DOD <<EOF || true
+# Definition of done
+Delivery contract: mode=no-mistakes
+This task uses the SPLIT gate: you are the builder only.
+You implement, commit, and write the handoff below; a separate driver agent runs the no-mistakes pipeline afterwards from that handoff.
+Do NOT run /no-mistakes, do not start, reattach, or respond to any pipeline run, and do not wait for validation; the driver owns the gate end to end.
+The task is complete only when the work is committed on your branch AND the current handoff cycle is written.
+
+Before your final status line, write or append a handoff cycle at \`$DATA/$ID/handoff.md\`.
+Each cycle must carry these five sections:
+1. **Intent** - one self-contained paragraph the driver passes verbatim as the pipeline's \`--intent\`: the task goal in the captain's terms plus every accepted requirement, clarification, constraint, exclusion, and supersession in its current accepted form, plus the decisions and tradeoffs made during implementation and anything deliberate that would look surprising in the diff.
+2. **Change inventory** - branch, base SHA, commit list (SHA + subject), touched-area summary.
+3. **Verification notes** - how you verified the change, what the test step should find, known-flaky areas.
+4. **Review anticipation** - findings you expect the review to raise, which are deliberate (with the rationale the driver or the captain will need), and known weak spots.
+5. **Escalation guidance** - anything you know that would change how firstmate or the captain should decide a parked finding.
+Append a new cycle for each builder round and never rewrite earlier cycles.
+Target 1-2k tokens per cycle: the driver's entire product context is this file, and a thin Intent buys avoidable ask-user parks in review.
+
+When the implementation is committed and the handoff cycle is written, append \`done: built fm/$ID at <short-sha>, handoff ready\` to the status file (short-sha from \`git rev-parse --short HEAD\`) and stop.
+A driver takes the gate from here; you are finished.
+EOF
+    else
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 Delivery contract: mode=no-mistakes
@@ -401,6 +567,7 @@ Two firstmate-specific rules layer on top of that guidance:
 
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
+    fi
     ;;
 esac
 
@@ -461,4 +628,8 @@ Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced 
 
 $DOD
 EOF
-echo "scaffolded: $BRIEF (ship, mode=$MODE; replace {TASK})"
+if [ "$SPLIT_GATE" -eq 1 ]; then
+  echo "scaffolded: $BRIEF (ship, mode=$MODE split-gate builder; replace {TASK})"
+else
+  echo "scaffolded: $BRIEF (ship, mode=$MODE; replace {TASK})"
+fi

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 # Scaffold a crewmate brief or persistent secondmate charter at
-# data/<task-id>/brief.md under the active firstmate home.
+# data/<task-id>/brief.md under the active firstmate home; --driver writes
+# data/<task-id>/driver-brief.md instead.
 # For ordinary tasks, the standard Setup/Rules/Definition-of-done contract is
 # filled in. Firstmate then replaces the {TASK} placeholder with the task
 # description, acceptance criteria, and context, and may adjust other sections
 # when the task genuinely deviates (e.g. working an existing external PR instead
 # of shipping a new one).
-# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only> [--split-gate] [--herdr-lab]
+# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only> [--herdr-lab]
+#        fm-brief.sh <task-id> <repo-name> --mode no-mistakes [--split-gate] [--herdr-lab]
 #        fm-brief.sh <task-id> <repo-name> --mode no-mistakes --driver
 #        fm-brief.sh <task-id> <repo-name> --scout [--herdr-lab]
 #        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -26,7 +26,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-backlog-receive.sh`  | Idempotently ingest one confined remote handoff outbox through tasks-axi             |
 | `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions                 |
-| `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs   |
+| `fm-brief.sh`            | Scaffold ship (explicit `--mode`, opt-in split-gate builder), no-mistakes gate-driver, scout, secondmate-charter, and Herdr-lab briefs |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |
 | `fm-install-treehouse.sh`| Install CI's exact-version Treehouse pin for real-Herdr E2E that needs spawn worktrees |

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -690,6 +690,185 @@ test_scout_and_secondmate_load_decision_hold_policy() {
   pass "fm-brief.sh: investigation and visual-review completions load the shared decision policy"
 }
 
+# --split-gate is the builder half of the no-mistakes builder/driver gate
+# split: the definition of done becomes implement, commit, and write the
+# handoff cycle, and every gate-driving instruction moves to the driver brief.
+test_split_gate_builder_definition_of_done() {
+  local home id brief
+  home="$TMP_ROOT/split-gate-home"
+  mkdir -p "$home/data"
+  id="brief-split-gate-e1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes --split-gate >/dev/null 2>&1 \
+    || fail "--split-gate no-mistakes brief should scaffold"
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "split-gate brief was not scaffolded"
+  grep -qx "Delivery contract: mode=no-mistakes" "$brief" \
+    || fail "split-gate builder lost the plain no-mistakes delivery contract line"
+  assert_grep "{TASK}" "$brief" "split-gate brief missing the {TASK} placeholder"
+  assert_grep "no-mistakes doctor" "$brief" "split-gate builder lost the doctor setup step"
+  assert_grep "Verify isolation before anything else." "$brief" \
+    "split-gate builder lost the worktree-isolation assertion"
+  assert_grep "Record only project knowledge useful to almost every future session." "$brief" \
+    "split-gate builder lost the project-memory section"
+  assert_grep "you are the builder only" "$brief" \
+    "split-gate builder DOD did not declare the builder role"
+  assert_grep "$home/data/$id/handoff.md" "$brief" \
+    "split-gate builder DOD did not name the handoff file"
+  for section in "**Intent**" "**Change inventory**" "**Verification notes**" "**Review anticipation**" "**Escalation guidance**"; do
+    assert_grep "$section" "$brief" "split-gate builder handoff spec lost its $section section"
+  done
+  assert_grep "passes verbatim as the pipeline's \`--intent\`" "$brief" \
+    "split-gate builder handoff Intent lost its verbatim --intent contract"
+  assert_grep "Append a new cycle for each builder round and never rewrite earlier cycles." "$brief" \
+    "split-gate builder handoff lost its append-per-cycle rule"
+  assert_grep "Target 1-2k tokens per cycle" "$brief" \
+    "split-gate builder handoff lost its token-budget target"
+  assert_grep "done: built fm/$id at <short-sha>, handoff ready" "$brief" \
+    "split-gate builder DOD lost its built/handoff-ready done line"
+  assert_grep "Do NOT run /no-mistakes" "$brief" \
+    "split-gate builder DOD did not forbid running the pipeline"
+  assert_no_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
+    "split-gate builder retained the single-worker validate handoff"
+  assert_no_grep "no-mistakes axi respond" "$brief" \
+    "split-gate builder retained gate-response driving text"
+  assert_no_grep "checks green" "$brief" \
+    "split-gate builder retained the driver's PR-ready done line"
+  assert_no_grep "--yes" "$brief" \
+    "split-gate builder retained the gate-driving --yes rule"
+  assert_no_grep "ask-user findings are never yours to answer" "$brief" \
+    "split-gate builder retained the gate escalation rule that now belongs to the driver"
+  pass "fm-brief.sh: --split-gate rewrites the no-mistakes builder definition of done"
+}
+
+# Chunk-1 guarantee: without the opt-in flag, the default no-mistakes scaffold
+# carries none of the split-gate text (byte-for-byte default preservation is
+# additionally pinned by test_no_mistakes_dod_wording and
+# test_ship_modes_generate_clean_briefs on the same output).
+test_no_mistakes_default_has_no_split_gate_text() {
+  local home brief
+  home="$TMP_ROOT/split-default-home"
+  mkdir -p "$home/data"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-split-default-e2 some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/brief-split-default-e2/brief.md"
+  assert_present "$brief" "default no-mistakes brief was not scaffolded"
+  assert_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
+    "default no-mistakes brief lost its single-worker validate handoff"
+  assert_no_grep "handoff" "$brief" \
+    "default no-mistakes brief leaked split-gate handoff text without the flag"
+  assert_no_grep "SPLIT gate" "$brief" \
+    "default no-mistakes brief leaked the split-gate role declaration"
+  assert_no_grep "phase=driver" "$brief" \
+    "default no-mistakes brief leaked the driver phase contract"
+  pass "fm-brief.sh: the default no-mistakes scaffold carries no split-gate text"
+}
+
+# --driver writes the gate-driver brief: complete as generated, phase-marked
+# contract line, gate rules with the v1.46.0 refinements, and deliberate
+# idempotent regeneration while brief.md keeps its no-overwrite guarantee.
+test_driver_brief_structure_and_contract() {
+  local home id brief first status
+  home="$TMP_ROOT/driver-home"
+  mkdir -p "$home/data"
+  id="brief-driver-e3"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes --driver >/dev/null 2>&1 \
+    || fail "--driver brief should scaffold"
+  brief="$home/data/$id/driver-brief.md"
+  assert_present "$brief" "driver brief was not written to driver-brief.md"
+  assert_absent "$home/data/$id/brief.md" "--driver must not write brief.md"
+  grep -qx "Delivery contract: mode=no-mistakes phase=driver" "$brief" \
+    || fail "driver brief missing its machine-readable phase contract line"
+  assert_no_grep "{TASK}" "$brief" \
+    "driver brief must be complete as generated, with no {TASK} placeholder"
+  assert_grep "Drive the no-mistakes gate for branch \`fm/$id\`" "$brief" \
+    "driver brief lost its task statement"
+  assert_grep "$home/data/$id/handoff.md" "$brief" "driver brief lost its handoff pointer"
+  assert_grep "read it first, latest cycle first" "$brief" \
+    "driver brief lost the latest-cycle-first read order"
+  assert_grep "Verify isolation before anything else." "$brief" \
+    "driver brief lost the worktree-isolation assertion"
+  assert_no_grep "git checkout -b" "$brief" \
+    "driver brief must inherit the builder's branch, never create one"
+  assert_grep "one foreground blocking AXI call per turn" "$brief" \
+    "driver brief lost the one-blocking-call turn rule"
+  assert_grep "Never approve, fix, or skip an ask-user finding yourself." "$brief" \
+    "driver brief lost the ask-user park rule"
+  assert_grep "needs-decision [key=gate-<step>-<n>]" "$brief" \
+    "driver brief lost the keyed gate park line"
+  assert_grep "done: PR <url> checks green" "$brief" \
+    "driver brief lost the PR-ready outcome line"
+  assert_grep "The daemon alone decides readiness, including the trusted \`no_ci: true\` case" "$brief" \
+    "driver brief lost the daemon-owned readiness rule"
+  assert_grep "blocked [key=builder-fix-<n>]" "$brief" \
+    "driver brief lost the keyed builder-fix blocker"
+  assert_grep "You never edit, commit, or revert ANY file" "$brief" \
+    "driver brief lost the no-edit rule"
+  assert_grep "You never run \`--yes\`" "$brief" "driver brief lost the --yes ban"
+  assert_grep "sync --recover" "$brief" "driver brief lost the custody-recovery rule"
+  assert_grep "\`user_owned\` means the run" "$brief" \
+    "driver brief lost the user_owned no-op supersession case"
+  assert_grep "a repeated \`--recover\` is a" "$brief" \
+    "driver brief lost the harmless repeated-recover clause"
+  assert_grep "nested_gate_context" "$brief" \
+    "driver brief lost the nested-gate stop-and-report rule"
+  assert_grep "never retry the command" "$brief" \
+    "driver brief must stop rather than retry on nested_gate_context"
+  assert_grep "Never stop, restart, or update the shared \`no-mistakes\` daemon" "$brief" \
+    "driver brief lost the shared-daemon safety rule"
+
+  # Deliberate idempotent regeneration: a second run overwrites with identical
+  # bytes and exits 0, because firstmate regenerates the driver brief per flip.
+  first="$TMP_ROOT/driver-first-cycle"
+  cp "$brief" "$first"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes --driver >/dev/null 2>&1; status=$?
+  expect_code 0 "$status" "regenerating an existing driver brief must succeed"
+  cmp -s "$first" "$brief" || fail "regenerated driver brief changed bytes"
+
+  # brief.md's no-overwrite guarantee is untouched: the builder brief scaffolds
+  # alongside the driver brief, and only brief.md refuses a second write.
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes --split-gate >/dev/null 2>&1; status=$?
+  expect_code 0 "$status" "builder brief should scaffold alongside an existing driver brief"
+  assert_present "$home/data/$id/brief.md" "builder brief missing next to driver brief"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes --split-gate >/dev/null 2>&1; status=$?
+  expect_code 1 "$status" "brief.md must still refuse overwrite when the driver brief is regenerable"
+  pass "fm-brief.sh: --driver emits the phase-marked gate-driver brief and regenerates idempotently"
+}
+
+# The split flags are meaningless outside a no-mistakes ship brief; every
+# misuse must refuse loudly and write nothing.
+test_driver_and_split_gate_flag_validation() {
+  local home out status label args expect
+  home="$TMP_ROOT/driver-refusals-home"
+  mkdir -p "$home/data"
+  while IFS='|' read -r label args expect; do
+    [ -n "$label" ] || continue
+    # shellcheck disable=SC2086  # args is an intentional word-split arg list
+    out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" $args 2>&1)
+    status=$?
+    [ "$status" -ne 0 ] || fail "$label: expected a non-zero exit"
+    assert_contains "$out" "$expect" "$label: refusal did not explain the contract"
+  done <<'ROWS'
+driver without mode|brief-drv-r1 some-proj --driver|ship briefs require --mode
+driver with direct-PR|brief-drv-r2 some-proj --mode direct-PR --driver|--driver applies only to --mode no-mistakes ship briefs
+driver with local-only|brief-drv-r3 some-proj --mode local-only --driver|--driver applies only to --mode no-mistakes ship briefs
+driver on a scout|brief-drv-r4 some-proj --scout --driver|--driver applies only to --mode no-mistakes ship briefs
+driver on a secondmate|brief-drv-r5 --secondmate --no-projects --driver|--driver applies only to --mode no-mistakes ship briefs
+driver with split-gate|brief-drv-r6 some-proj --mode no-mistakes --driver --split-gate|mutually exclusive
+driver with herdr-lab|brief-drv-r7 some-proj --mode no-mistakes --driver --herdr-lab|a driver runs gate commands only
+split-gate with direct-PR|brief-drv-r8 some-proj --mode direct-PR --split-gate|--split-gate applies only to --mode no-mistakes ship briefs
+split-gate with local-only|brief-drv-r9 some-proj --mode local-only --split-gate|--split-gate applies only to --mode no-mistakes ship briefs
+split-gate on a scout|brief-drv-r10 some-proj --scout --split-gate|--split-gate applies only to --mode no-mistakes ship briefs
+split-gate on a secondmate|brief-drv-r11 --secondmate --no-projects --split-gate|--split-gate applies only to --mode no-mistakes ship briefs
+ROWS
+  local i
+  for i in 1 2 3 4 5 6 7 8 9 10 11; do
+    assert_absent "$home/data/brief-drv-r$i/brief.md" \
+      "refused split-flag scaffold r$i still wrote brief.md"
+    assert_absent "$home/data/brief-drv-r$i/driver-brief.md" \
+      "refused split-flag scaffold r$i still wrote driver-brief.md"
+  done
+  pass "fm-brief.sh: --driver and --split-gate misuse is refused, never silently dropped"
+}
+
 # Scout and secondmate paths still scaffold well-formed briefs.
 test_scout_and_secondmate_scaffold() {
   local brief
@@ -719,6 +898,10 @@ test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
+test_split_gate_builder_definition_of_done
+test_no_mistakes_default_has_no_split_gate_text
+test_driver_brief_structure_and_contract
+test_driver_and_split_gate_flag_validation
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path


### PR DESCRIPTION
## Intent

Implement chunk 1 of the approved no-mistakes builder/driver gate split: the brief scaffolds in bin/fm-brief.sh, per the design report at data/nm-builder-driver-design/report.md sections 4.1, 4.2, and 9 and the v1.46.0 delta report at data/nm-split-recheck/report.md. Scope is deliberately limited to chunk 1: no caller changes (fm-spawn.sh and fm-control.sh untouched) and zero behavior change for existing flows - the default no-mistakes scaffold must stay byte-for-byte unchanged when the new flags are absent. Deliverables: (1) a new --driver variant, valid only with --mode no-mistakes, generating data/<id>/driver-brief.md per the design section 4.2 outline with the machine-readable contract line 'Delivery contract: mode=no-mistakes phase=driver'; the driver brief is complete as generated (no {TASK} placeholder) and deliberately overwritable/idempotent because firstmate regenerates it at every builder-to-driver flip - an intentional, documented exception to brief.md's no-overwrite rule; (2) a new --split-gate opt-in flag changing only the no-mistakes builder definition of done to: implement, commit, write or append a handoff cycle at data/<id>/handoff.md, append 'done: built fm/<id> at <short-sha>, handoff ready', and stop, with all gate-driving text removed from the builder scaffold; (3) the handoff-file contract (five required sections per cycle: Intent, Change inventory, Verification notes, Review anticipation, Escalation guidance; append-per-cycle, earlier cycles never rewritten; 1-2k token target per cycle) documented in fm-brief.sh's header comment, which owns scaffold contracts; (4) colocated tests in tests/fm-brief.test.sh matching the existing idiom: driver output structure and contract line, --split-gate definition of done, default scaffold free of split text without the flag, deliberate idempotent driver regeneration alongside brief.md's preserved no-overwrite refusal, and a flag-misuse refusal matrix (--driver without --mode no-mistakes or with direct-PR/local-only/--scout/--secondmate/--herdr-lab/--split-gate; --split-gate outside a no-mistakes ship brief). Three v1.46.0 refinements are deliberately folded into the driver scaffold text: the supersession rule mentions the branch_sync.state user_owned no-op case where a repeated --recover is harmless because the run went terminal without changing the submitted head; one rule says that on error.code nested_gate_context the driver stops and reports rather than retrying, since it would mean a wiring bug; and the outcome rule does not restate old checks-passed wording because the daemon alone decides readiness, including the trusted no_ci: true case. Deliberate choices a reviewer reading only the diff might otherwise flag: the driver brief intentionally omits the Herdr section and refuses --herdr-lab because a driver runs gate commands only and never task commands; the driver scaffold forbids ALL driver file edits, a deliberate design-report tightening of the original proposal; the split-gate builder keeps its doctor/init setup step, isolation assertion, rules, and project-memory section unchanged - only the definition of done differs; the scaffolded-output message gains a split-gate-builder marker only under the new flag so default output is untouched. The branch also carries a pipeline document-step commit updating fm-brief.sh's row in docs/scripts.md from the previous run, preserved per the custody-recovery contract. Repo style rules apply: plain dash never em dash, one sentence per line in generated markdown prose, shellcheck-clean under the pinned 0.11.0 via bin/fm-lint.sh, colocated tests extending the existing runner, and the handoff contract documented once in the script header rather than AGENTS.md because the AGENTS.md contract cutover is a later chunk by design. Default outputs were verified byte-for-byte identical against the pre-change script for all three ship modes, scout, herdr-lab, and secondmate scaffolds. Push goes to the configured fork egomez714/firstmate with the PR opened against upstream kunchenguid/firstmate, per the captain's decision.

## What Changed

- `bin/fm-brief.sh` gains two opt-in flags, both valid only with `--mode no-mistakes`: `--driver` writes a new gate-driver brief to `data/<id>/driver-brief.md` (complete as generated with no `{TASK}` placeholder, carrying the `Delivery contract: mode=no-mistakes phase=driver` line, gate/park/outcome rules, the `user_owned` supersession no-op case, a stop-and-report rule on `error.code: nested_gate_context`, and no Herdr section), and `--split-gate` replaces the no-mistakes builder's definition of done with implement, commit, write or append a handoff cycle at `data/<id>/handoff.md`, append `done: built fm/<id> at <short-sha>, handoff ready`, and stop - leaving that brief's setup, isolation assertion, rules, and project-memory sections untouched. Misuse of either flag (wrong mode, scout, secondmate, `--driver` with `--split-gate` or `--herdr-lab`) refuses with an explanatory error and writes nothing.
- `brief.md` keeps its no-overwrite refusal; `driver-brief.md` is deliberately regenerable so firstmate can rewrite it at each builder-to-driver flip. The script header now documents the handoff-file contract (per-cycle Intent, Change inventory, Verification notes, Review anticipation, Escalation guidance; append-only, 1-2k tokens per cycle) and both new flags. Default scaffolds are unchanged when the flags are absent; only `--split-gate` adds a marker to the scaffolded-output message. No callers were touched.
- `tests/fm-brief.test.sh` adds four tests in the existing idiom covering driver brief structure and contract line plus idempotent regeneration alongside `brief.md`'s preserved refusal, the `--split-gate` definition of done, absence of split text in the default no-mistakes scaffold, and an 11-row flag-misuse refusal matrix. `docs/scripts.md` updates the `fm-brief.sh` row to mention the split-gate builder and gate-driver variants.

## Risk Assessment

✅ Low: Purely additive opt-in scaffolding behind new flags with loud refusals on misuse, default outputs verified byte-for-byte identical to the base commit for all six scaffold variants, and behavioral colocated tests covering structure, idempotent regeneration, and the full flag-misuse matrix.

## Testing

Ran the colocated suite `bin/fm-test-run.sh tests/fm-brief.test.sh` (24 tests green, including the four new driver/split-gate tests) plus four adjacent brief and docs contract suites, then went beyond unit coverage to prove the intent directly: I reconstructed the pre-change script from the base commit and diffed its output against the new one across all ten default scaffold cases under an identical FM_HOME, confirming every generated brief is byte-for-byte identical by sha256 and the scaffolded-message stream is unchanged. I then drove the new flags as a user would and captured the real generated driver brief (phase-marked contract line, no {TASK}, no Herdr section, all three v1.46.0 refinements), a transcript showing the driver brief regenerating idempotently while brief.md still refuses overwrite, a normalized diff showing --split-gate changes only the Definition of done, and the full flag-misuse refusal matrix with no files written on refusal. No UI surface is involved - this is a shell scaffolder, so the reviewer-visible evidence is the generated markdown and CLI transcripts rather than screenshots. Everything passed; the only issue found is a pre-existing missing-repo-positional crash that behaves identically before and after the change.

<details>
<summary>Evidence: Default scaffolds byte-for-byte identical before vs after (10 cases)</summary>

<code>scaffold case sha256(base) sha256(new) verdict&#10;nm 0a14de1fbb8ae45e 0a14de1fbb8ae45e IDENTICAL&#10;dpr cc038fbca57e66aa cc038fbca57e66aa IDENTICAL&#10;lo 1f4bfa2db15f18de 1f4bfa2db15f18de IDENTICAL&#10;nm-herdr 95bc68dc000ea37b 95bc68dc000ea37b IDENTICAL&#10;dpr-herdr 3db2c649179f53d7 3db2c649179f53d7 IDENTICAL&#10;lo-herdr 199c7aeaf99bbd06 199c7aeaf99bbd06 IDENTICAL&#10;scout cebf57019c57a3b8 cebf57019c57a3b8 IDENTICAL&#10;scout-herdr b42a3adef057b38b b42a3adef057b38b IDENTICAL&#10;sm bdb50c86f7e74164 bdb50c86f7e74164 IDENTICAL&#10;sm-np 809277c0c2d9fb5a 809277c0c2d9fb5a IDENTICAL&#10;&#10;recursive diff of every generated brief:&#10;(no differences)&#10;scaffolded-message stream diff:&#10;(no differences)</code>

```text
Default-scaffold byte identity: pre-change (76355e2) vs post-change (4ef9e2f) bin/fm-brief.sh
Both runs used the identical FM_HOME and FM_ROOT_OVERRIDE, so any script-caused difference would show.

scaffold case            sha256(base)       sha256(new)        verdict
nm                       0a14de1fbb8ae45e   0a14de1fbb8ae45e   IDENTICAL
dpr                      cc038fbca57e66aa   cc038fbca57e66aa   IDENTICAL
lo                       1f4bfa2db15f18de   1f4bfa2db15f18de   IDENTICAL
nm-herdr                 95bc68dc000ea37b   95bc68dc000ea37b   IDENTICAL
dpr-herdr                3db2c649179f53d7   3db2c649179f53d7   IDENTICAL
lo-herdr                 199c7aeaf99bbd06   199c7aeaf99bbd06   IDENTICAL
scout                    cebf57019c57a3b8   cebf57019c57a3b8   IDENTICAL
scout-herdr              b42a3adef057b38b   b42a3adef057b38b   IDENTICAL
sm                       bdb50c86f7e74164   bdb50c86f7e74164   IDENTICAL
sm-np                    809277c0c2d9fb5a   809277c0c2d9fb5a   IDENTICAL

recursive diff of every generated brief:
  (no differences)
scaffolded-message stream diff:
  (no differences)
```
</details>
<details>
<summary>Evidence: Generated driver-brief.md (the new end-user product)</summary>

```text
You are a crewmate: a gate DRIVER agent managed by firstmate. Work on your own; do not wait for a human.

# Task
Drive the no-mistakes gate for branch `fm/split-demo-1` of firstmate to completion.
Your entire product context is `$FM_HOME/data/split-demo-1/handoff.md` - read it first, latest cycle first.
You build nothing and decide nothing above the gate rules below: the builder owns code and firstmate owns decisions.

# Setup
You inherit the task's existing git worktree with branch `fm/split-demo-1` checked out; verify it, create nothing.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not touch anything - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. Confirm `git rev-parse --abbrev-ref HEAD` prints `fm/split-demo-1` and matches the handoff's Change inventory; if not, append `blocked: worktree branch does not match the handoff` and stop.
2. Run `no-mistakes axi` and read its `branch_sync` block before acting.

# Gate rules
1. Start or reattach the run: `no-mistakes axi run --intent "<the handoff's Intent section, verbatim>"`.
   If axi reports an active run for this branch, reattach and drive it instead of starting a new one.
2. Keep exactly one foreground blocking AXI call per turn; never end your turn while a call is executing.
   End your turn only after writing a park (rule 4) or an outcome (rule 6 or 7).
3. At a gate, read the findings table's action column:
   - all findings auto-fix and/or no-op: respond yourself
     (`--action fix --findings <auto-fix ids>`, or `--action approve` when only no-op).
   - anything ask-user: park (rule 4). Never approve, fix, or skip an ask-user finding yourself.
   - a problem you noticed that the pipeline missed: fold it in with `--add-finding`; never edit files.
4. To park: write the gate's findings VERBATIM (id, severity, file, action, full description)
   to `$FM_HOME/data/split-demo-1/gate-findings-<run>-<step>.md`, append
   `needs-decision [key=gate-<step>-<n>]: <one-line summary> (details: <that file>)`,
   and end your turn. The run stays parked daemon-side; that is safe and expected.
5. On every wake, FIRST re-read `no-mistakes axi status` and reconcile before responding;
   the run may have moved (merged PR, monitor progress) while you were parked.
   Then translate firstmate's decision into the exact respond call it names.
6. Outcome checks-passed: append `done: PR <url> checks green` to the status file and stop.
   The daemon alone decides readiness, including the trusted `no_ci: true` case; never second-guess it against the forge's own check list.
7. Outcome failed or cancelled: write the evidence (step, log tail, findings) to
   `$FM_HOME/data/split-demo-1/gate-report-<run>.md`, append
   `blocked [key=builder-fix-<n>]: run <state> at <step>, code fix needed (details: <that file>)`,
   and stop. Firstmate flips the task back to a builder cycle.
8. You never edit, commit, or revert ANY file, trivial or not; the pipeline owns fixes (`--action fix`) and the builder owns code.
   You never run `--yes`; it would silently bypass firstmate's authority check and any required captain escalation.
   You never abort or rerun mid-run except under an explicit supersession instruction from firstmate, in which case:
   abort, confirm the run stopped via `no-mistakes axi status`, follow `branch_sync.next_action` exactly
   (`sync --recover` only when it reports `recover_custody`; a `branch_sync.state` of `user_owned` means the run
   went terminal without changing the submitted head, no sync action is needed, and a repeated `--recover` is a
   harmless no-op), append `resolved [key=<the instruction's key>]: run aborted, custody settled`, and stop.
9. On `error.code: nested_gate_context`, stop and append `blocked: axi reports nested_gate_context - this driver was launched inside a pipeline context, a wiring bug`; never retry the command.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; your only writes are the gate files under `$FM_HOME/data/split-demo-1/` and the status file below.
3. Use gh-axi for GitHub operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '$FM_HOME/state/split-demo-1.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only the parks, outcomes, and blockers the gate rules name.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Definition of done
Delivery contract: mode=no-mistakes phase=driver
The gate rules above define your only endings: rule 6's `done: PR <url> checks green` on a passed run, or rule 7's keyed builder-fix blocker on a failed or cancelled run.
There is no other completion path; you never implement, promote, or merge anything.
```
</details>
<details>
<summary>Evidence: CLI transcript: split-gate builder + driver scaffolding, idempotent regeneration, brief.md still refuses overwrite</summary>

<code>$ fm-brief.sh split-demo-1 firstmate --mode no-mistakes --split-gate&#10;scaffolded: $FM_HOME/data/split-demo-1/brief.md (ship, mode=no-mistakes split-gate builder; replace {TASK})&#10;&#10;$ fm-brief.sh split-demo-1 firstmate --mode no-mistakes --driver&#10;scaffolded: $FM_HOME/data/split-demo-1/driver-brief.md (no-mistakes driver; complete as generated, regenerated per flip)&#10;&#10;# regenerate the driver brief (idempotent by design, firstmate does this at each flip)&#10;$ fm-brief.sh split-demo-1 firstmate --mode no-mistakes --driver&#10;scaffolded: $FM_HOME/data/split-demo-1/driver-brief.md (no-mistakes driver; complete as generated, regenerated per flip)&#10;&#10;# but brief.md keeps its no-overwrite guarantee&#10;$ fm-brief.sh split-demo-1 firstmate --mode no-mistakes --split-gate&#10;error: $FM_HOME/data/split-demo-1/brief.md already exists&#10;exit=1&#10;&#10;$ ls data/split-demo-1&#10;brief.md&#10;driver-brief.md</code>

```text
$ fm-brief.sh split-demo-1 firstmate --mode no-mistakes --split-gate
scaffolded: $FM_HOME/data/split-demo-1/brief.md (ship, mode=no-mistakes split-gate builder; replace {TASK})

$ fm-brief.sh split-demo-1 firstmate --mode no-mistakes --driver
scaffolded: $FM_HOME/data/split-demo-1/driver-brief.md (no-mistakes driver; complete as generated, regenerated per flip)

# regenerate the driver brief (idempotent by design, firstmate does this at each flip)
$ fm-brief.sh split-demo-1 firstmate --mode no-mistakes --driver
scaffolded: $FM_HOME/data/split-demo-1/driver-brief.md (no-mistakes driver; complete as generated, regenerated per flip)

# but brief.md keeps its no-overwrite guarantee
$ fm-brief.sh split-demo-1 firstmate --mode no-mistakes --split-gate
error: $FM_HOME/data/split-demo-1/brief.md already exists
exit=1

$ ls data/split-demo-1
brief.md
driver-brief.md
```
</details>
<details>
<summary>Evidence: --split-gate changes only the Definition of done (normalized diff vs default builder brief)</summary>

```text
--- default/brief.md
+++ split-gate/brief.md
@@ -53,19 +53,20 @@
 
 # Definition of done
 Delivery contract: mode=no-mistakes
-The task is complete only when committed on your branch.
-When you believe it is complete, append `done: {summary}` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+This task uses the SPLIT gate: you are the builder only.
+You implement, commit, and write the handoff below; a separate driver agent runs the no-mistakes pipeline afterwards from that handoff.
+Do NOT run /no-mistakes, do not start, reattach, or respond to any pipeline run, and do not wait for validation; the driver owns the gate end to end.
+The task is complete only when the work is committed on your branch AND the current handoff cycle is written.
 
-You drive no-mistakes by responding to its gates, not by implementing fixes.
-Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
-When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
-Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
+Before your final status line, write or append a handoff cycle at `$FM_HOME/data/TASKID/handoff.md`.
+Each cycle must carry these five sections:
+1. **Intent** - one self-contained paragraph the driver passes verbatim as the pipeline's `--intent`: the task goal in the captain's terms plus every accepted requirement, clarification, constraint, exclusion, and supersession in its current accepted form, plus the decisions and tradeoffs made during implementation and anything deliberate that would look surprising in the diff.
+2. **Change inventory** - branch, base SHA, commit list (SHA + subject), touched-area summary.
+3. **Verification notes** - how you verified the change, what the test step should find, known-flaky areas.
+4. **Review anticipation** - findings you expect the review to raise, which are deliberate (with the rationale the driver or the captain will need), and known weak spots.
+5. **Escalation guidance** - anything you know that would change how firstmate or the captain should decide a parked finding.
+Append a new cycle for each builder round and never rewrite earlier cycles.
+Target 1-2k tokens per cycle: the driver's entire product context is this file, and a thin Intent buys avoidable ask-user parks in review.
 
-Two firstmate-specific rules layer on top of that guidance:
-- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
-  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
-  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
-- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.
-
-After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
+When the implementation is committed and the handoff cycle is written, append `done: built fm/TASKID at <short-sha>, handoff ready` to the status file (short-sha from `git rev-parse --short HEAD`) and stop.
+A driver takes the gate from here; you are finished.
```
</details>
<details>
<summary>Evidence: Flag-misuse refusal matrix transcript (11 documented cases + 3 extra probes)</summary>

<code>$ fm-brief.sh r2 some-proj --mode direct-PR --driver&#10;-&gt; exit=1 error: --driver applies only to --mode no-mistakes ship briefs; the driver drives that pipeline&#39;s gates from the builder&#39;s handoff&#10;&#10;$ fm-brief.sh r6 some-proj --mode no-mistakes --driver --split-gate&#10;-&gt; exit=1 error: --driver and --split-gate are mutually exclusive; --split-gate shapes the builder definition of done and a driver brief has none&#10;&#10;$ fm-brief.sh r7 some-proj --mode no-mistakes --driver --herdr-lab&#10;-&gt; exit=1 error: --herdr-lab does not apply to --driver briefs; a driver runs gate commands only, never task commands&#10;&#10;$ fm-brief.sh r11 --secondmate --no-projects --split-gate&#10;-&gt; exit=1 error: --split-gate applies only to --mode no-mistakes ship briefs; it changes the no-mistakes builder definition of done&#10;&#10;$ find $FM_HOME/data -type f # nothing written by a refused invocation&#10;(only the r12 --mode=VALUE-form success wrote driver-brief.md)</code>

```text
$ fm-brief.sh r1 some-proj --driver
  -> exit=1  error: ship briefs require --mode <no-mistakes|direct-PR|local-only>; resolve it at intake from the captain's instruction and the project's registered posture in data/projects.md

$ fm-brief.sh r2 some-proj --mode direct-PR --driver
  -> exit=1  error: --driver applies only to --mode no-mistakes ship briefs; the driver drives that pipeline's gates from the builder's handoff

$ fm-brief.sh r3 some-proj --mode local-only --driver
  -> exit=1  error: --driver applies only to --mode no-mistakes ship briefs; the driver drives that pipeline's gates from the builder's handoff

$ fm-brief.sh r4 some-proj --scout --driver
  -> exit=1  error: --driver applies only to --mode no-mistakes ship briefs; the driver drives that pipeline's gates from the builder's handoff

$ fm-brief.sh r5 --secondmate --no-projects --driver
  -> exit=1  error: --driver applies only to --mode no-mistakes ship briefs; the driver drives that pipeline's gates from the builder's handoff

$ fm-brief.sh r6 some-proj --mode no-mistakes --driver --split-gate
  -> exit=1  error: --driver and --split-gate are mutually exclusive; --split-gate shapes the builder definition of done and a driver brief has none

$ fm-brief.sh r7 some-proj --mode no-mistakes --driver --herdr-lab
  -> exit=1  error: --herdr-lab does not apply to --driver briefs; a driver runs gate commands only, never task commands

$ fm-brief.sh r8 some-proj --mode direct-PR --split-gate
  -> exit=1  error: --split-gate applies only to --mode no-mistakes ship briefs; it changes the no-mistakes builder definition of done

$ fm-brief.sh r9 some-proj --mode local-only --split-gate
  -> exit=1  error: --split-gate applies only to --mode no-mistakes ship briefs; it changes the no-mistakes builder definition of done

$ fm-brief.sh r10 some-proj --scout --split-gate
  -> exit=1  error: --split-gate applies only to --mode no-mistakes ship briefs; it changes the no-mistakes builder definition of done

$ fm-brief.sh r11 --secondmate --no-projects --split-gate
  -> exit=1  error: --split-gate applies only to --mode no-mistakes ship briefs; it changes the no-mistakes builder definition of done

# extra probes beyond the committed test matrix
$ fm-brief.sh r12 some-proj --mode=no-mistakes --driver
  -> exit=0  scaffolded: $FM_HOME/data/r12/driver-brief.md (no-mistakes driver; complete as generated, regenerated per flip)

$ fm-brief.sh r13 --mode no-mistakes --driver
  -> exit=1  /home/erickgomez/.no-mistakes/worktrees/6dcb064d8670/01KZRTN924H383R1YXPG1DG9KC/bin/fm-brief.sh: line 323: POS[1]: unbound variable

$ fm-brief.sh r14 some-proj --scout --mode no-mistakes --driver
  -> exit=1  error: --mode applies only to ship briefs; a scout delivers a report and a secondmate charter is not a delivery contract

$ find $FM_HOME/data -type f   # nothing may be written by a refused invocation
$FM_HOME/data/r12/driver-brief.md
(only r12's driver brief is expected below, if any)
```
</details>
<details>
<summary>Evidence: Generated split-gate builder brief.md</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of firstmate, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/split-demo-1`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '$FM_HOME/state/split-demo-1.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/erickgomez/.no-mistakes/worktrees/6dcb064d8670/01KZRTN924H383R1YXPG1DG9KC/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/erickgomez/.no-mistakes/worktrees/6dcb064d8670/01KZRTN924H383R1YXPG1DG9KC/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
This task uses the SPLIT gate: you are the builder only.
You implement, commit, and write the handoff below; a separate driver agent runs the no-mistakes pipeline afterwards from that handoff.
Do NOT run /no-mistakes, do not start, reattach, or respond to any pipeline run, and do not wait for validation; the driver owns the gate end to end.
The task is complete only when the work is committed on your branch AND the current handoff cycle is written.

Before your final status line, write or append a handoff cycle at `$FM_HOME/data/split-demo-1/handoff.md`.
Each cycle must carry these five sections:
1. **Intent** - one self-contained paragraph the driver passes verbatim as the pipeline's `--intent`: the task goal in the captain's terms plus every accepted requirement, clarification, constraint, exclusion, and supersession in its current accepted form, plus the decisions and tradeoffs made during implementation and anything deliberate that would look surprising in the diff.
2. **Change inventory** - branch, base SHA, commit list (SHA + subject), touched-area summary.
3. **Verification notes** - how you verified the change, what the test step should find, known-flaky areas.
4. **Review anticipation** - findings you expect the review to raise, which are deliberate (with the rationale the driver or the captain will need), and known weak spots.
5. **Escalation guidance** - anything you know that would change how firstmate or the captain should decide a parked finding.
Append a new cycle for each builder round and never rewrite earlier cycles.
Target 1-2k tokens per cycle: the driver's entire product context is this file, and a thin Intent buys avoidable ask-user parks in review.

When the implementation is committed and the handoff cycle is written, append `done: built fm/split-demo-1 at <short-sha>, handoff ready` to the status file (short-sha from `git rev-parse --short HEAD`) and stop.
A driver takes the gate from here; you are finished.
```
</details>
- Outcome: ⚠️ 1 info across 1 run (5m3s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"dfc12be395d7b753efec108f930bfe5f47e5c962","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-brief.sh:536` - The split-gate builder brief inherits ship Rule 2 (&#39;Stay inside this worktree; modify nothing outside it&#39;) while its new definition of done (bin/fm-brief.sh line 536) mandates writing data/&lt;id&gt;/handoff.md at an absolute path outside the worktree. The driver brief resolves the same tension with an explicit write carve-out in its Rule 2; the builder brief does not. The contradiction class is pre-existing (the status-file append has always sat outside Rule 2) and the intent explicitly pins the rules section unchanged for chunk 1, so no change is needed now - but the later chunk that touches builder rules should add an explicit handoff/status-file carve-out to Rule 2 to remove the ambiguity for the reading agent.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `bin/fm-brief.sh:323` - Pre-existing, not introduced by this change: omitting the repo positional (e.g. `fm-brief.sh &lt;id&gt; --mode no-mistakes`) aborts with `bin/fm-brief.sh: line 323: POS[1]: unbound variable` instead of a clean refusal, and leaves an empty `data/&lt;id&gt;/` directory behind. I verified the pre-change script at 76355e2 fails identically on the same inputs for --mode no-mistakes, --mode direct-PR, and --scout, so the new --driver/--split-gate paths only inherit it. Noted for awareness; fixing it is outside chunk 1&#39;s scope.
- <code>`bin/fm-test-run.sh tests/fm-brief.test.sh` - 24 tests green, including the four new ones (test_split_gate_builder_definition_of_done, test_no_mistakes_default_has_no_split_gate_text, test_driver_brief_structure_and_contract, test_driver_and_split_gate_flag_validation)</code>
- <code>Byte-identity harness: extracted the pre-change `bin/` tree via `git archive 76355e20b4f44d968ca43c14e1bb21c100ac90d7 bin`, ran old and new `fm-brief.sh` over 10 scaffold cases (no-mistakes / direct-PR / local-only, each with and without `--herdr-lab`; `--scout`; `--scout --herdr-lab`; `--secondmate proj-a proj-b`; `--secondmate --no-projects`) against the same `FM_HOME` and `FM_ROOT_OVERRIDE`, then compared with `sha256sum`, `cmp`, and `diff -r` - all 10 identical, `scaffolded:` message stream identical</code>
- <code>Manual CLI walkthrough: `fm-brief.sh split-demo-1 firstmate --mode no-mistakes --split-gate`, then `--mode no-mistakes --driver` twice (regeneration produced identical bytes, exit 0), then `--split-gate` again (exit 1, brief.md no-overwrite guarantee intact)</code>
- <code>Inspected the generated `driver-brief.md` as the end-user product: `Delivery contract: mode=no-mistakes phase=driver` on its own line, no `{TASK}` placeholder, no Herdr section, and the three v1.46.0 refinements present (branch_sync `user_owned` harmless repeated `--recover`, `nested_gate_context` stop-and-report without retry, daemon-owned readiness including trusted `no_ci: true`)</code>
- <code>Normalized `diff -u` of default no-mistakes `brief.md` vs `--split-gate` `brief.md` - the only hunk is the Definition of done; doctor/init setup, isolation assertion, rules, and project-memory sections are untouched</code>
- <code>Refusal matrix transcript: all 11 documented misuse combinations (`--driver` without `--mode`, with direct-PR, local-only, `--scout`, `--secondmate`, `--split-gate`, `--herdr-lab`; `--split-gate` with direct-PR, local-only, `--scout`, `--secondmate`) plus three extra probes (`--mode=no-mistakes --driver` equals-form, missing repo positional, `--scout --mode no-mistakes --driver`); `find` confirmed no refused invocation wrote brief.md or driver-brief.md</code>
- <code>Pre-change control: ran the 76355e2 script with `--driver` and `--split-gate` - both flags were silently swallowed and only a plain builder brief was produced, confirming the new tests fail before the change and pass after</code>
- <code>`bin/fm-test-run.sh tests/fm-documentation-audiences.test.sh tests/fm-task-delivery.test.sh tests/fm-ask-user-authority.test.sh tests/fm-herdr-lab.test.sh` - adjacent brief/docs contract suites, all green</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `AGENTS.md:86` - AGENTS.md&#39;s data layout inventory (line 86) lists only `&lt;id&gt;/brief.md` and `&lt;id&gt;/report.md` under `data/&lt;id&gt;/`, but the new scaffolds introduce `&lt;id&gt;/driver-brief.md`, `&lt;id&gt;/handoff.md`, and the driver-written `&lt;id&gt;/gate-findings-&lt;run&gt;-&lt;step&gt;.md` / `&lt;id&gt;/gate-report-&lt;run&gt;.md`. I deliberately did not add them: chunk 1 changes no callers, so no current flow creates those files, and the user intent states the AGENTS.md contract cutover is a later chunk by design with the handoff contract owned by the fm-brief.sh header for now. Worth a follow-up when chunk 2 wires fm-spawn.sh/fm-control.sh to the split, at which point the layout entry becomes genuinely stale.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
