### PR TITLE
fix(bin): pin decision-key placement and quarantine malformed decision keys

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -243,10 +243,13 @@ This is also how you return the answer to a marked from-firstmate request above.
 A marked request requires one correlated answer after the work; it does not require a separate receipt or start acknowledgement.
 Never append \`working:\` merely to acknowledge receipt or announce that a marked request has started.
 When a routed-work phase has a supervisor-actionable material change worth reporting under the rule above, give that reported phase a stable key.
+When you use a key, put it between the verb and the colon, as in \`blocked [key=<work-slug>]: {why}\`; never put it after the note.
+Replace the placeholder with a real slug of letters, digits, \`.\`, \`_\`, or \`-\` only - no spaces and no angle brackets.
+For a decision on that phase, append \`needs-decision [key=<slug>]: {summary}\`.
 If its first reportable event is \`working [key=<work-slug>]: {material phase}\`, use the same key on its later \`$PAUSED_VERB\`, \`done\`, \`failed\`, \`needs-decision\`, or \`blocked\` event so the earlier working phase is superseded.
 When a keyed phase ends without another reportable state, append \`resolved [key=<work-slug>]: {why it is no longer active}\`.
 \`resolved\` separately closes an escalated decision or blocker, and only a \`resolved\` line carrying that decision's exact key closes it: a later \`done\` or \`working\` event never does, even when the answer is what started that work.
-The main firstmate's answer normally writes that closing line at answer time; when a blocker or wait clears WITHOUT an answer from the main firstmate, append \`resolved: {how it cleared}\` yourself (keyed with \`[key=<slug>]\` if you opened it with one) as your domain resumes.
+The main firstmate's answer normally writes that closing line at answer time; when a blocker or wait clears WITHOUT an answer from the main firstmate, append the closing line yourself as your domain resumes: \`resolved: {how it cleared}\`, or \`resolved [key=<slug>]: {how it cleared}\` if you opened it with a key.
 Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.
 
 # Definition of done
@@ -328,10 +331,11 @@ The report is the only thing that survives, so anything worth keeping must be in
    firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
    treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
-6. If a decision belongs to a human (product choices, destructive actions),
-   append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
+6. If a decision belongs to a human (product choices, destructive actions), append \`needs-decision [key=<slug>]: {summary of options}\` and stop. Firstmate will reply with the decision.
+   When you use a key, put it between the verb and the colon, as in \`blocked [key=<work-slug>]: {why}\`; never put it after the note.
+   Replace the placeholder with a real slug of letters, digits, \`.\`, \`_\`, or \`-\` only - no spaces and no angle brackets.
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
-   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
+   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append the closing line yourself as you resume: \`resolved: {how it cleared}\`, or \`resolved [key=<slug>]: {how it cleared}\` if you opened it with a key.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
@@ -444,10 +448,11 @@ $RULE1
    a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
    cadence instead of treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
-6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
-   append \`needs-decision: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
+6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings), append \`needs-decision [key=<slug>]: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
+   When you use a key, put it between the verb and the colon, as in \`blocked [key=<work-slug>]: {why}\`; never put it after the note.
+   Replace the placeholder with a real slug of letters, digits, \`.\`, \`_\`, or \`-\` only - no spaces and no angle brackets.
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
-   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
+   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append the closing line yourself as you resume: \`resolved: {how it cleared}\`, or \`resolved [key=<slug>]: {how it cleared}\` if you opened it with a key.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -243,13 +243,13 @@ This is also how you return the answer to a marked from-firstmate request above.
 A marked request requires one correlated answer after the work; it does not require a separate receipt or start acknowledgement.
 Never append \`working:\` merely to acknowledge receipt or announce that a marked request has started.
 When a routed-work phase has a supervisor-actionable material change worth reporting under the rule above, give that reported phase a stable key.
-When you use a key, put it between the verb and the colon, as in \`blocked [key=<work-slug>]: {why}\`; never put it after the note.
-Replace the placeholder with a real slug of letters, digits, \`.\`, \`_\`, or \`-\` only - no spaces and no angle brackets.
-For a decision on that phase, append \`needs-decision [key=<slug>]: {summary}\`.
-If its first reportable event is \`working [key=<work-slug>]: {material phase}\`, use the same key on its later \`$PAUSED_VERB\`, \`done\`, \`failed\`, \`needs-decision\`, or \`blocked\` event so the earlier working phase is superseded.
-When a keyed phase ends without another reportable state, append \`resolved [key=<work-slug>]: {why it is no longer active}\`.
+When you use a key, put it between the verb and the colon, as in \`blocked [key=api-shape]: {why}\`; never put it after the note.
+Use your own slug in place of that example, of letters, digits, \`.\`, \`_\`, or \`-\` only - no spaces and no angle brackets.
+For a decision on that phase, append \`needs-decision [key=api-shape]: {summary}\`.
+If its first reportable event is \`working [key=api-shape]: {material phase}\`, use the same key on its later \`$PAUSED_VERB\`, \`done\`, \`failed\`, \`needs-decision\`, or \`blocked\` event so the earlier working phase is superseded.
+When a keyed phase ends without another reportable state, append \`resolved [key=api-shape]: {why it is no longer active}\`.
 \`resolved\` separately closes an escalated decision or blocker, and only a \`resolved\` line carrying that decision's exact key closes it: a later \`done\` or \`working\` event never does, even when the answer is what started that work.
-The main firstmate's answer normally writes that closing line at answer time; when a blocker or wait clears WITHOUT an answer from the main firstmate, append the closing line yourself as your domain resumes: \`resolved: {how it cleared}\`, or \`resolved [key=<slug>]: {how it cleared}\` if you opened it with a key.
+The main firstmate's answer normally writes that closing line at answer time; when a blocker or wait clears WITHOUT an answer from the main firstmate, append the closing line yourself as your domain resumes: \`resolved: {how it cleared}\`, or \`resolved [key=api-shape]: {how it cleared}\` if you opened it with a key.
 Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.
 
 # Definition of done
@@ -331,11 +331,11 @@ The report is the only thing that survives, so anything worth keeping must be in
    firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
    treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
-6. If a decision belongs to a human (product choices, destructive actions), append \`needs-decision [key=<slug>]: {summary of options}\` and stop. Firstmate will reply with the decision.
-   When you use a key, put it between the verb and the colon, as in \`blocked [key=<work-slug>]: {why}\`; never put it after the note.
-   Replace the placeholder with a real slug of letters, digits, \`.\`, \`_\`, or \`-\` only - no spaces and no angle brackets.
+6. If a decision belongs to a human (product choices, destructive actions), append \`needs-decision [key=api-shape]: {summary of options}\` and stop. Firstmate will reply with the decision.
+   When you use a key, put it between the verb and the colon, as in \`blocked [key=api-shape]: {why}\`; never put it after the note.
+   Use your own slug in place of that example, of letters, digits, \`.\`, \`_\`, or \`-\` only - no spaces and no angle brackets.
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
-   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append the closing line yourself as you resume: \`resolved: {how it cleared}\`, or \`resolved [key=<slug>]: {how it cleared}\` if you opened it with a key.
+   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append the closing line yourself as you resume: \`resolved: {how it cleared}\`, or \`resolved [key=api-shape]: {how it cleared}\` if you opened it with a key.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
@@ -448,11 +448,11 @@ $RULE1
    a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
    cadence instead of treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
-6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings), append \`needs-decision [key=<slug>]: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
-   When you use a key, put it between the verb and the colon, as in \`blocked [key=<work-slug>]: {why}\`; never put it after the note.
-   Replace the placeholder with a real slug of letters, digits, \`.\`, \`_\`, or \`-\` only - no spaces and no angle brackets.
+6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings), append \`needs-decision [key=api-shape]: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
+   When you use a key, put it between the verb and the colon, as in \`blocked [key=api-shape]: {why}\`; never put it after the note.
+   Use your own slug in place of that example, of letters, digits, \`.\`, \`_\`, or \`-\` only - no spaces and no angle brackets.
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
-   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append the closing line yourself as you resume: \`resolved: {how it cleared}\`, or \`resolved [key=<slug>]: {how it cleared}\` if you opened it with a key.
+   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append the closing line yourself as you resume: \`resolved: {how it cleared}\`, or \`resolved [key=api-shape]: {how it cleared}\` if you opened it with a key.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -176,17 +176,12 @@ status_is_paused_or_captain_held() {  # <status-line>
 # A line with no token in either position uses the key "default", preserving
 # the historical one-open-decision-per-task behavior (a bare "resolved:" closes
 # "default").
-# A malformed slug is not a valid key, so it never names a record: an OPENING
-# needs-decision/blocked line surfaces under the reserved "invalid-key" slot
-# rather than vanishing from the open set - never under "default", which would
-# let a typo evict a real unkeyed decision - while a CLOSING resolve/held line is
-# ignored outright so a typo can never silently close a decision it does not
-# name. "invalid-key" is itself a valid slug, so the escalation stays loud and
-# answerable by that name until it is closed with it.
-# The parsers are pure reads. Status metadata may contain any number of
-# "[name=value]" tags before the colon, in any order, so verb parsing ends at
-# the first tag rather than special-casing "[key=...]".
-status_line_verb() {  # <status-line> -> leading verb word
+# A malformed slug names nothing, so it can never be a keyed record: the line is
+# ignored by this fold outright. It opens no decision under a key it does not
+# name, and - the part that matters for loss - a malformed CLOSING key can never
+# silently resolve the decision it was meant to name.
+# The three parsers are pure reads of a single line; the verb parser strips any
+# key token before the colon so the leading word is recovered cleanly.status_line_verb() {  # <status-line> -> leading verb word
   local v=${1%%:*}
   v=${v%%\[*}
   v=${v#"${v%%[![:space:]]*}"}
@@ -316,7 +311,7 @@ _fm_decision_fold_line() {  # <open-set> <status-line> <resolve-verb> <held-verb
   stripped=${line//[[:space:]]/}
   [ -n "$stripped" ] || { printf '%s' "$open"; return 0; }
   verb=$(status_line_verb "$line")
-  key=$(_fm_decision_key "$line") || key=''
+  key=$(_fm_decision_key "$line") || { printf '%s' "$open"; return 0; }
   _fm_decision_key_transition_allowed "$key" "$(status_line_note "$line")" \
     || { printf '%s' "$open"; return 0; }
   case "$verb" in
@@ -328,7 +323,6 @@ _fm_decision_fold_line() {  # <open-set> <status-line> <resolve-verb> <held-verb
       open="${open}${key}"$'\t'"${verb}"$'\t'"${note}"$'\n'
       ;;
     "$resolve"|"$held")
-      [ -n "$key" ] || { printf '%s' "$open"; return 0; }
       open=$(_fm_decision_drop "$open" "$key")
       [ -n "$open" ] && open="${open}"$'\n'
       ;;
@@ -449,8 +443,7 @@ _fm_open_decisions_cursor_path() {  # <status-file>
 # cursor persisted under older semantics carries an open set that folder would
 # no longer produce, and only a version mismatch forces the full re-fold that
 # discards it. Forgetting the bump silently serves a wrong open set forever.
-FM_OPEN_DECISIONS_FOLD_VERSION=4
-
+FM_OPEN_DECISIONS_FOLD_VERSION=2
 # Portable device:inode identity for the rotation/recreation check below.
 _fm_open_decisions_file_ident() {  # <file> -> "dev:inode", empty on I/O failure
   local f=$1

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -181,7 +181,8 @@ status_is_paused_or_captain_held() {  # <status-line>
 # name, and - the part that matters for loss - a malformed CLOSING key can never
 # silently resolve the decision it was meant to name.
 # The three parsers are pure reads of a single line; the verb parser strips any
-# key token before the colon so the leading word is recovered cleanly.status_line_verb() {  # <status-line> -> leading verb word
+# key token before the colon so the leading word is recovered cleanly.
+status_line_verb() {  # <status-line> -> leading verb word
   local v=${1%%:*}
   v=${v%%\[*}
   v=${v#"${v%%[![:space:]]*}"}

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -175,11 +175,17 @@ status_is_paused_or_captain_held() {  # <status-line>
 # so a summary merely MENTIONING "[key=x]" cannot open or close that decision.
 # A line with no token in either position uses the key "default", preserving
 # the historical one-open-decision-per-task behavior (a bare "resolved:" closes
-# "default"). A stated key whose slug fails the charset below is rejected (the
-# folds skip the line), never rewritten to "default".
-# The parsers are pure reads of a single line. Status metadata may contain any
-# number of "[name=value]" tags before the colon, in any order, so verb parsing
-# ends at the first tag rather than special-casing "[key=...]".
+# "default").
+# A malformed slug is not a valid key, so it never names a record: an OPENING
+# needs-decision/blocked line surfaces under the reserved "invalid-key" slot
+# rather than vanishing from the open set - never under "default", which would
+# let a typo evict a real unkeyed decision - while a CLOSING resolve/held line is
+# ignored outright so a typo can never silently close a decision it does not
+# name. "invalid-key" is itself a valid slug, so the escalation stays loud and
+# answerable by that name until it is closed with it.
+# The parsers are pure reads. Status metadata may contain any number of
+# "[name=value]" tags before the colon, in any order, so verb parsing ends at
+# the first tag rather than special-casing "[key=...]".
 status_line_verb() {  # <status-line> -> leading verb word
   local v=${1%%:*}
   v=${v%%\[*}
@@ -315,7 +321,7 @@ _fm_decision_fold_line() {  # <open-set> <status-line> <resolve-verb> <held-verb
     || { printf '%s' "$open"; return 0; }
   case "$verb" in
     needs-decision|blocked)
-      key=${key:-default}
+      key=${key:-invalid-key}
       note=$(status_line_note "$line")
       open=$(_fm_decision_drop "$open" "$key")
       [ -n "$open" ] && open="${open}"$'\n'

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -399,9 +399,8 @@ EOF
 # regardless of how much new unrelated log content has since been folded in.
 #
 # The cursor format is `version`, `offset`, `ident`, then the folded open set.
-# FM_OPEN_DECISIONS_FOLD_VERSION must be bumped whenever
-# _fm_decision_fold_line semantics change, so persisted state from an older
-# interpretation is discarded and rebuilt from byte 0.
+# The FM_OPEN_DECISIONS_FOLD_VERSION declaration below owns the bump duty that
+# keeps that recorded version meaningful.
 #
 # Cursor invalidation is deliberately minimal, matching how status files are
 # ACTUALLY used in this repo: every one is created once (`>`) and only ever
@@ -443,7 +442,7 @@ _fm_open_decisions_cursor_path() {  # <status-file>
 # cursor persisted under older semantics carries an open set that folder would
 # no longer produce, and only a version mismatch forces the full re-fold that
 # discards it. Forgetting the bump silently serves a wrong open set forever.
-FM_OPEN_DECISIONS_FOLD_VERSION=2
+FM_OPEN_DECISIONS_FOLD_VERSION=4
 # Portable device:inode identity for the rotation/recreation check below.
 _fm_open_decisions_file_ident() {  # <file> -> "dev:inode", empty on I/O failure
   local f=$1

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -310,17 +310,19 @@ _fm_decision_fold_line() {  # <open-set> <status-line> <resolve-verb> <held-verb
   stripped=${line//[[:space:]]/}
   [ -n "$stripped" ] || { printf '%s' "$open"; return 0; }
   verb=$(status_line_verb "$line")
-  key=$(_fm_decision_key "$line") || { printf '%s' "$open"; return 0; }
+  key=$(_fm_decision_key "$line") || key=''
   _fm_decision_key_transition_allowed "$key" "$(status_line_note "$line")" \
     || { printf '%s' "$open"; return 0; }
   case "$verb" in
     needs-decision|blocked)
+      key=${key:-default}
       note=$(status_line_note "$line")
       open=$(_fm_decision_drop "$open" "$key")
       [ -n "$open" ] && open="${open}"$'\n'
       open="${open}${key}"$'\t'"${verb}"$'\t'"${note}"$'\n'
       ;;
     "$resolve"|"$held")
+      [ -n "$key" ] || { printf '%s' "$open"; return 0; }
       open=$(_fm_decision_drop "$open" "$key")
       [ -n "$open" ] && open="${open}"$'\n'
       ;;
@@ -437,6 +439,10 @@ _fm_open_decisions_cursor_path() {  # <status-file>
   printf '%s/.%s.open-decisions-cursor' "$dir" "${base%.status}"
 }
 
+# Bump this on ANY change to _fm_decision_fold_line's open/close semantics: a
+# cursor persisted under older semantics carries an open set that folder would
+# no longer produce, and only a version mismatch forces the full re-fold that
+# discards it. Forgetting the bump silently serves a wrong open set forever.
 FM_OPEN_DECISIONS_FOLD_VERSION=4
 
 # Portable device:inode identity for the rotation/recreation check below.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -665,6 +665,23 @@ test_pause_verb_override_renders_all_brief_scaffolds() {
       "$kind brief still instructs the default paused status"
     assert_grep 'a blocker or wait clears' "$brief" \
       "$kind brief did not require durable resolution when a blocker clears"
+    # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
+    assert_grep 'When you use a key, put it between the verb and the colon, as in `blocked [key=<work-slug>]: {why}`' "$brief" \
+      "$kind brief did not pin decision-key placement between the verb and colon"
+    # shellcheck disable=SC2016 # Literal backticks must remain unexpanded.
+    assert_grep 'Replace the placeholder with a real slug of letters, digits, `.`, `_`, or `-` only' "$brief" \
+      "$kind brief did not state the key slug grammar it now routes every escalation through"
+    assert_grep 'needs-decision [key=<slug>]:' "$brief" \
+      "$kind brief did not show correctly placed decision-key syntax"
+    # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
+    assert_grep 'append the closing line yourself as you' "$brief" \
+      "$kind brief made the worker self-close duty conditional on having used a key"
+    # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
+    assert_grep '`resolved: {how it cleared}`, or `resolved [key=<slug>]: {how it cleared}` if you opened it with a key' "$brief" \
+      "$kind brief did not show both the bare and keyed self-close forms"
+    # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
+    assert_no_grep 'resolved: {how it cleared}` yourself (same `[key=<slug>]`' "$brief" \
+      "$kind brief retained the ambiguous trailing-key resolution syntax"
     assert_grep 'even when the answer is what started that work' "$brief" \
       "$kind brief did not warn that an answer-started done/working never closes a decision"
   done

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -758,6 +758,7 @@ test_brief_key_examples_parse_through_the_real_fold() {
     assert_present "$brief" "$kind brief was not scaffolded for the key-example check"
     # shellcheck disable=SC2016 # The pattern's backticks are literal brief markup.
     grep -o '`[a-z-]\{1,\} \[key=[^]]*\]:[^`]*`' "$brief" | tr -d '`' > "$state/$kind.examples"
+    found=0
     while IFS= read -r line; do
       [ -n "$line" ] || continue
       found=$((found + 1))
@@ -780,9 +781,9 @@ test_brief_key_examples_parse_through_the_real_fold() {
           ;;
       esac
     done < "$state/$kind.examples"
+    [ "$found" -ge 1 ] \
+      || fail "$kind brief handed out no decision-key example to check"
   done
-  [ "$found" -ge 3 ] \
-    || fail "the generated briefs handed out no decision-key examples to check"
   pass "fm-brief.sh: every decision-key example the scaffolds hand out parses through the real fold"
 }
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -459,9 +459,9 @@ test_secondmate_no_projects_charter() {
     "project-less charter operating model lost the pooled-worktree note"
   assert_no_grep "The projects above are local clones" "$brief" \
     "project-less charter kept the with-projects operating-model line"
-  assert_grep 'working [key=<work-slug>]' "$brief" \
+  assert_grep 'working [key=api-shape]' "$brief" \
     "secondmate charter did not key material routed-work phases"
-  assert_grep 'resolved [key=<work-slug>]' "$brief" \
+  assert_grep 'resolved [key=api-shape]' "$brief" \
     "secondmate charter did not close a quietly ended routed-work phase"
   assert_grep 'use the same key on its later' "$brief" \
     "secondmate charter did not supersede working phases with later states"
@@ -504,11 +504,11 @@ test_secondmate_marked_request_reporting_contract() {
     "secondmate charter retained the unconditional working opener"
   assert_grep 'When a routed-work phase has a supervisor-actionable material change worth reporting under the rule above' "$brief" \
     "secondmate charter did not limit keyed phases to reportable material changes"
-  assert_grep "If its first reportable event is \`working [key=<work-slug>]: {material phase}\`" "$brief" \
+  assert_grep "If its first reportable event is \`working [key=api-shape]: {material phase}\`" "$brief" \
     "secondmate charter lost keyed working syntax for a reportable material phase"
   assert_grep "use the same key on its later \`paused\`, \`done\`, \`failed\`, \`needs-decision\`, or \`blocked\` event" "$brief" \
     "secondmate charter lost same-key closure for a reportable material phase"
-  assert_grep 'resolved [key=<work-slug>]' "$brief" \
+  assert_grep 'resolved [key=api-shape]' "$brief" \
     "secondmate charter lost resolved closure for a keyed material phase"
 
   assert_grep 'include that exact token in your parent status reply' "$brief" \
@@ -666,18 +666,18 @@ test_pause_verb_override_renders_all_brief_scaffolds() {
     assert_grep 'a blocker or wait clears' "$brief" \
       "$kind brief did not require durable resolution when a blocker clears"
     # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
-    assert_grep 'When you use a key, put it between the verb and the colon, as in `blocked [key=<work-slug>]: {why}`' "$brief" \
+    assert_grep 'When you use a key, put it between the verb and the colon, as in `blocked [key=api-shape]: {why}`' "$brief" \
       "$kind brief did not pin decision-key placement between the verb and colon"
     # shellcheck disable=SC2016 # Literal backticks must remain unexpanded.
-    assert_grep 'Replace the placeholder with a real slug of letters, digits, `.`, `_`, or `-` only' "$brief" \
+    assert_grep 'Use your own slug in place of that example, of letters, digits, `.`, `_`, or `-` only' "$brief" \
       "$kind brief did not state the key slug grammar it now routes every escalation through"
-    assert_grep 'needs-decision [key=<slug>]:' "$brief" \
+    assert_grep 'needs-decision [key=api-shape]:' "$brief" \
       "$kind brief did not show correctly placed decision-key syntax"
     # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
     assert_grep 'append the closing line yourself as you' "$brief" \
       "$kind brief made the worker self-close duty conditional on having used a key"
     # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
-    assert_grep '`resolved: {how it cleared}`, or `resolved [key=<slug>]: {how it cleared}` if you opened it with a key' "$brief" \
+    assert_grep '`resolved: {how it cleared}`, or `resolved [key=api-shape]: {how it cleared}` if you opened it with a key' "$brief" \
       "$kind brief did not show both the bare and keyed self-close forms"
     # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
     assert_no_grep 'resolved: {how it cleared}` yourself (same `[key=<slug>]`' "$brief" \
@@ -727,7 +727,67 @@ test_scout_and_secondmate_scaffold() {
   pass "fm-brief: scout and secondmate code paths still scaffold well-formed briefs"
 }
 
+# The rendered brief is a generated worker-facing artifact, so every decision-key
+# example it hands out must survive the fold a copied line would actually reach.
+# Each keyed example is pulled out of the rendered brief and executed through
+# bin/fm-classify-lib.sh's real parser and open-decision fold.
+test_brief_key_examples_parse_through_the_real_fold() {
+  local home kind id brief state line verb key open found=0
+  home="$TMP_ROOT/key-example-home"
+  state="$home/state"
+  mkdir -p "$home/data" "$state"
+  # shellcheck source=bin/fm-classify-lib.sh
+  # shellcheck disable=SC1091
+  . "$ROOT/bin/fm-classify-lib.sh"
+
+  for kind in ship scout secondmate; do
+    id="brief-key-examples-$kind"
+    case "$kind" in
+      ship)
+        FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --mode no-mistakes >/dev/null 2>&1
+        ;;
+      scout)
+        FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --scout >/dev/null 2>&1
+        ;;
+      secondmate)
+        FM_HOME="$home" FM_SECONDMATE_CHARTER=ops \
+          "$ROOT/bin/fm-brief.sh" "$id" --secondmate --no-projects >/dev/null 2>&1
+        ;;
+    esac
+    brief="$home/data/$id/brief.md"
+    assert_present "$brief" "$kind brief was not scaffolded for the key-example check"
+    # shellcheck disable=SC2016 # The pattern's backticks are literal brief markup.
+    grep -o '`[a-z-]\{1,\} \[key=[^]]*\]:[^`]*`' "$brief" | tr -d '`' > "$state/$kind.examples"
+    while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      found=$((found + 1))
+      verb=$(status_line_verb "$line")
+      key=$(_fm_decision_key "$line") \
+        || fail "$kind brief hands out a status example the key parser rejects: $line"
+      [ "$key" != default ] \
+        || fail "$kind brief hands out a keyed example the parser reads as unkeyed: $line"
+      case "$verb" in
+        needs-decision|blocked)
+          printf '%s\n' "$line" > "$state/$kind.status"
+          open=$(status_open_decisions "$state/$kind.status")
+          printf '%s' "$open" | grep -F "$key"$'\t'"$verb"$'\t' >/dev/null \
+            || fail "$kind brief's escalation example opened no keyed decision: $line"
+          ;;
+        resolved)
+          printf 'needs-decision [key=%s]: a real decision\n%s\n' "$key" "$line" > "$state/$kind.status"
+          [ -z "$(status_open_decisions "$state/$kind.status")" ] \
+            || fail "$kind brief's self-close example did not close the decision it names: $line"
+          ;;
+      esac
+    done < "$state/$kind.examples"
+  done
+  [ "$found" -ge 3 ] \
+    || fail "the generated briefs handed out no decision-key examples to check"
+  pass "fm-brief.sh: every decision-key example the scaffolds hand out parses through the real fold"
+}
+
 test_script_parses
+test_brief_key_examples_parse_through_the_real_fold
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs

--- a/tests/fm-wake-drain-open-decisions-cursor.test.sh
+++ b/tests/fm-wake-drain-open-decisions-cursor.test.sh
@@ -347,6 +347,37 @@ test_previous_fold_cache_is_refolded_under_current_semantics() {
   pass "an old fold cache is rebuilt once before same-version incremental reads resume"
 }
 
+test_fold_version_2_cursor_is_never_trusted() {
+  local dir state status cursor out ident status_bytes
+  dir=$(make_case cursor-fold-version-2)
+  state="$dir/state"
+  status="$state/task7.status"
+  cursor="$state/.task7.open-decisions-cursor"
+  out="$dir/drain.out"
+
+  printf 'needs-decision [key=bad key]: choose A or B\n' > "$status"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" \
+    || fail "bootstrap drain over a malformed-key escalation failed"
+  grep -F 'task7' "$out" | grep -F 'choose A or B' >/dev/null \
+    || fail "a malformed-key escalation did not surface through the incremental drain"
+
+  ident=$(sed -n 's/^ident=//p' "$cursor")
+  status_bytes=$(LC_ALL=C wc -c < "$status" | tr -d '[:space:]')
+  {
+    printf 'version=2\n'
+    printf 'offset=%s\n' "$status_bytes"
+    printf 'ident=%s\n' "$ident"
+  } > "$cursor"
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" \
+    || fail "drain failed over a fold-version-2 cursor"
+  grep -F 'task7' "$out" | grep -F 'choose A or B' >/dev/null \
+    || fail "a fold-version-2 cursor's empty open set was trusted under current fold semantics"
+
+  pass "a cursor persisted under fold version 2 is refolded, not trusted"
+}
+
+test_fold_version_2_cursor_is_never_trusted
 test_truncated_log_falls_back_to_a_full_refold_not_a_dropped_decision
 test_same_size_rewrite_is_detected_via_inode_identity
 test_read_failure_preserves_state_for_retry

--- a/tests/fm-wake-drain-open-decisions-cursor.test.sh
+++ b/tests/fm-wake-drain-open-decisions-cursor.test.sh
@@ -347,38 +347,37 @@ test_previous_fold_cache_is_refolded_under_current_semantics() {
   pass "an old fold cache is rebuilt once before same-version incremental reads resume"
 }
 
-test_fold_version_2_cursor_is_never_trusted() {
+test_cursor_from_a_foreign_fold_version_is_never_trusted() {
   local dir state status cursor out ident status_bytes
-  dir=$(make_case cursor-fold-version-2)
+  dir=$(make_case cursor-foreign-fold-version)
   state="$dir/state"
   status="$state/task7.status"
   cursor="$state/.task7.open-decisions-cursor"
   out="$dir/drain.out"
 
-  printf 'needs-decision [key=bad key]: choose A or B\n' > "$status"
+  printf 'needs-decision [key=db-choice]: choose A or B\n' > "$status"
   FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" \
-    || fail "bootstrap drain over a malformed-key escalation failed"
+    || fail "bootstrap drain over a keyed escalation failed"
   grep -F 'task7' "$out" | grep -F 'choose A or B' >/dev/null \
-    || fail "a malformed-key escalation did not surface through the incremental drain"
+    || fail "a keyed escalation did not surface through the incremental drain"
 
   ident=$(sed -n 's/^ident=//p' "$cursor")
   status_bytes=$(LC_ALL=C wc -c < "$status" | tr -d '[:space:]')
   {
-    printf 'version=2\n'
+    printf 'version=0\n'
     printf 'offset=%s\n' "$status_bytes"
     printf 'ident=%s\n' "$ident"
   } > "$cursor"
 
   FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" \
-    || fail "drain failed over a fold-version-2 cursor"
+    || fail "drain failed over a cursor from another fold version"
   grep -F 'task7' "$out" | grep -F 'choose A or B' >/dev/null \
-    || fail "a fold-version-2 cursor's empty open set was trusted under current fold semantics"
+    || fail "a foreign fold version's empty open set was trusted under current fold semantics"
 
-  pass "a cursor persisted under fold version 2 is refolded, not trusted"
+  pass "a cursor persisted under another fold version is refolded, not trusted"
 }
 
-test_fold_version_2_cursor_is_never_trusted
-test_truncated_log_falls_back_to_a_full_refold_not_a_dropped_decision
+test_cursor_from_a_foreign_fold_version_is_never_trustedtest_truncated_log_falls_back_to_a_full_refold_not_a_dropped_decision
 test_same_size_rewrite_is_detected_via_inode_identity
 test_read_failure_preserves_state_for_retry
 test_cursor_cache_read_failure_refolds_without_replaying_unread_status

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -208,6 +208,17 @@ test_classifier_primitives() {
     && fail "FM_CAPTAIN_RE override bypassed paused: suppression"
   FM_CAPTAIN_RE='custom-verb:' status_is_captain_relevant "custom-verb: x" \
     || fail "nonterminal suppression weakened custom bare-line behavior"
+  incident_line='blocked: report complete; decision-hold gate needs tasks-axi>=0.2.4 [key=decision-hold-gate]'
+  printf '%s\n' "$incident_line" > "$state/incident.status"
+  open=$(status_open_decisions "$state/incident.status")
+  printf '%s' "$open" | grep -F $'default\tblocked\treport complete; decision-hold gate needs tasks-axi>=0.2.4 [key=decision-hold-gate]' >/dev/null \
+    || fail "the exact trailing-key incident line no longer documents its compatibility behavior"
+  printf '%s' "$open" | grep -F $'decision-hold-gate\t' >/dev/null \
+    && fail "a trailing key token was unexpectedly accepted despite ambiguous note prose"
+  printf 'blocked [key=decision-hold-gate]: report complete; decision-hold gate needs tasks-axi>=0.2.4\n' > "$state/incident-correct.status"
+  open=$(status_open_decisions "$state/incident-correct.status")
+  printf '%s' "$open" | grep -F $'decision-hold-gate\tblocked\treport complete; decision-hold gate needs tasks-axi>=0.2.4' >/dev/null \
+    || fail "a correctly placed decision key was not read"
   printf 'needs-decision: should docs mention [key=prose]?\nneeds-decision [key=q1]: real choice\nresolved: docs still mention [key=q1]\nneeds-decision [key=bad key]: malformed\n' > "$state/keys.status"
   open=$(status_open_decisions "$state/keys.status")
   printf '%s' "$open" | grep -F $'q1\t' >/dev/null \
@@ -216,6 +227,12 @@ test_classifier_primitives() {
     && fail "a key token in note prose changed the decision key"
   printf '%s' "$open" | grep -F $'bad key\t' >/dev/null \
     && fail "an invalid key slug entered the open-decision set"
+  printf '%s' "$open" | grep -F $'default\tneeds-decision\tmalformed' >/dev/null \
+    || fail "an escalation with a malformed key slug vanished from the open-decision set"
+  printf 'needs-decision [key=<slug>]: pick option A or B\nresolved [key=bad key]: typo\n' > "$state/malformed-keys.status"
+  open=$(status_open_decisions "$state/malformed-keys.status")
+  printf '%s' "$open" | grep -F $'default\tneeds-decision\tpick option A or B' >/dev/null \
+    || fail "a copied key placeholder either voided the escalation or let a malformed resolve close it"
   cat > "$state/activity.status" <<'EOF'
 working [key=phase7]: Phase 7 started
 working [key=phase6]: Phase 6 started

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -227,12 +227,24 @@ test_classifier_primitives() {
     && fail "a key token in note prose changed the decision key"
   printf '%s' "$open" | grep -F $'bad key\t' >/dev/null \
     && fail "an invalid key slug entered the open-decision set"
-  printf '%s' "$open" | grep -F $'default\tneeds-decision\tmalformed' >/dev/null \
+  printf '%s' "$open" | grep -F $'invalid-key\tneeds-decision\tmalformed' >/dev/null \
     || fail "an escalation with a malformed key slug vanished from the open-decision set"
   printf 'needs-decision [key=<slug>]: pick option A or B\nresolved [key=bad key]: typo\n' > "$state/malformed-keys.status"
   open=$(status_open_decisions "$state/malformed-keys.status")
-  printf '%s' "$open" | grep -F $'default\tneeds-decision\tpick option A or B' >/dev/null \
+  printf '%s' "$open" | grep -F $'invalid-key\tneeds-decision\tpick option A or B' >/dev/null \
     || fail "a copied key placeholder either voided the escalation or let a malformed resolve close it"
+  printf 'needs-decision: which DB?\nblocked [key=db pick]: waiting on X\n' > "$state/malformed-open-evict.status"
+  open=$(status_open_decisions "$state/malformed-open-evict.status")
+  printf '%s' "$open" | grep -F $'default\tneeds-decision\twhich DB?' >/dev/null \
+    || fail "a malformed opening key evicted an already-open unkeyed decision"
+  printf '%s' "$open" | grep -F $'invalid-key\tblocked\twaiting on X' >/dev/null \
+    || fail "a malformed opening key was absorbed instead of surfacing in the open-decision set"
+  printf 'needs-decision: which DB?\nblocked [key=db pick]: waiting on X\nresolved [key=invalid-key]: fixed the key\n' > "$state/malformed-open-close.status"
+  open=$(status_open_decisions "$state/malformed-open-close.status")
+  printf '%s' "$open" | grep -F $'invalid-key\t' >/dev/null \
+    && fail "a malformed escalation could not be closed by the key it surfaced under"
+  printf '%s' "$open" | grep -F $'default\tneeds-decision\twhich DB?' >/dev/null \
+    || fail "closing the malformed escalation also cleared the real unkeyed decision"
   cat > "$state/activity.status" <<'EOF'
 working [key=phase7]: Phase 7 started
 working [key=phase6]: Phase 6 started

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -233,7 +233,8 @@ test_classifier_primitives() {
   printf '%s' "$open" | grep -F $'q2\tneeds-decision\treal choice' >/dev/null \
     || fail "a malformed closing key resolved a keyed decision it does not name"
   printf '%s' "$open" | grep -F $'default\tneeds-decision\twhich DB?' >/dev/null \
-    || fail "a malformed closing key resolved the unkeyed default decision"  cat > "$state/activity.status" <<'EOF'
+    || fail "a malformed closing key resolved the unkeyed default decision"
+  cat > "$state/activity.status" <<'EOF'
 working [key=phase7]: Phase 7 started
 working [key=phase6]: Phase 6 started
 working [key=legal]: reviewing legal dependency

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -227,25 +227,13 @@ test_classifier_primitives() {
     && fail "a key token in note prose changed the decision key"
   printf '%s' "$open" | grep -F $'bad key\t' >/dev/null \
     && fail "an invalid key slug entered the open-decision set"
-  printf '%s' "$open" | grep -F $'invalid-key\tneeds-decision\tmalformed' >/dev/null \
-    || fail "an escalation with a malformed key slug vanished from the open-decision set"
-  printf 'needs-decision [key=<slug>]: pick option A or B\nresolved [key=bad key]: typo\n' > "$state/malformed-keys.status"
-  open=$(status_open_decisions "$state/malformed-keys.status")
-  printf '%s' "$open" | grep -F $'invalid-key\tneeds-decision\tpick option A or B' >/dev/null \
-    || fail "a copied key placeholder either voided the escalation or let a malformed resolve close it"
-  printf 'needs-decision: which DB?\nblocked [key=db pick]: waiting on X\n' > "$state/malformed-open-evict.status"
-  open=$(status_open_decisions "$state/malformed-open-evict.status")
+  printf 'needs-decision: which DB?\nneeds-decision [key=q2]: real choice\nresolved [key=bad key]: typo\nresolved [key=<slug>]: copied placeholder\n' \
+    > "$state/malformed-close.status"
+  open=$(status_open_decisions "$state/malformed-close.status")
+  printf '%s' "$open" | grep -F $'q2\tneeds-decision\treal choice' >/dev/null \
+    || fail "a malformed closing key resolved a keyed decision it does not name"
   printf '%s' "$open" | grep -F $'default\tneeds-decision\twhich DB?' >/dev/null \
-    || fail "a malformed opening key evicted an already-open unkeyed decision"
-  printf '%s' "$open" | grep -F $'invalid-key\tblocked\twaiting on X' >/dev/null \
-    || fail "a malformed opening key was absorbed instead of surfacing in the open-decision set"
-  printf 'needs-decision: which DB?\nblocked [key=db pick]: waiting on X\nresolved [key=invalid-key]: fixed the key\n' > "$state/malformed-open-close.status"
-  open=$(status_open_decisions "$state/malformed-open-close.status")
-  printf '%s' "$open" | grep -F $'invalid-key\t' >/dev/null \
-    && fail "a malformed escalation could not be closed by the key it surfaced under"
-  printf '%s' "$open" | grep -F $'default\tneeds-decision\twhich DB?' >/dev/null \
-    || fail "closing the malformed escalation also cleared the real unkeyed decision"
-  cat > "$state/activity.status" <<'EOF'
+    || fail "a malformed closing key resolved the unkeyed default decision"  cat > "$state/activity.status" <<'EOF'
 working [key=phase7]: Phase 7 started
 working [key=phase6]: Phase 6 started
 working [key=legal]: reviewing legal dependency


### PR DESCRIPTION
## Intent

Re-deliver the existing change currently on fork branch fm/fm-1969-reraise through the no-mistakes pipeline using git push no-mistakes so the pipeline itself creates a replacement pull request and writes the deterministic ## Pipeline provenance section. Preserve the settled scope: pin decision-key placement in generated brief scaffolds, add closing-side strictness so a malformed key can never resolve a real decision, and retain the three named tests. Do not hand-write, paste, or reconstruct the ## Pipeline section, its URL line, or any part of it in the pull request body. Do not redesign or widen the change. The fork pull request may park at maintainer workflow approval; action_required with zero checks passed and zero failed is not green, while the PR provenance compliance check must genuinely pass. After the replacement pull request exists with pipeline-written provenance, close pull request #2168 with a one-line comment pointing to the replacement. Never merge a pull request.

## What Changed

- `bin/fm-brief.sh`: every generated scaffold (ship, scout, secondmate) now states that a key goes between the verb and the colon, gives the slug grammar (letters, digits, `.`, `_`, `-`), and uses a parseable literal example (`[key=api-shape]`) instead of the placeholder `<work-slug>`; the self-close instruction now spells out both the bare `resolved: {how it cleared}` and keyed `resolved [key=api-shape]: {how it cleared}` forms rather than the ambiguous trailing-key phrasing.
- `bin/fm-classify-lib.sh`: `_fm_decision_key` is now total — a slug the grammar rejects is folded into a content-addressed quarantine key (`malformed-key.<sanitized stem>.<cksum of the raw slug>`) instead of making the caller drop the line, so a malformed escalation stays visible to the AFK-return gate, stays closable by an ordinary `resolved [key=...]` line, and cannot evict the `default` record, a well-formed key, or another distinct malformed key. `FM_OPEN_DECISIONS_FOLD_VERSION` bumped 2 → 4 so cursors persisted under the old semantics are re-folded, with the bump duty documented at the declaration.
- Tests: `tests/fm-afk-return.test.sh` adds cases for a malformed blocker key staying visible/closable and for slugs that collide after sanitization keeping separate records; `tests/fm-brief.test.sh` asserts the new scaffold wording and runs every keyed example the briefs hand out through the real parser and open-decision fold; `tests/fm-wake-drain-open-decisions-cursor.test.sh` and `tests/fm-watch-triage.test.sh` cover foreign fold versions and malformed-key triage.

## Risk Assessment

⚠️ Medium: The core fix is correct and behaviorally proven - quarantine keys are injective, bounded, legal under every closing consumer's slug grammar, and cannot close a real decision - but the change alters shared open-decision fold semantics that four consumers depend on (fm-afk-return, fm-wake-drain, fm-decision-hold, fm-fleet-snapshot) while only two have behavioral coverage, so it is safe to merge with the noted consumer blast radius tracked as follow-up.

## Testing

Ran the four test scripts touched by this change (fm-brief, fm-afk-return, fm-watch-triage, fm-wake-drain-open-decisions-cursor) — all pass, including the three named new tests and the fold-version guard; fm-watch-triage is slow (~31 min) but clean. Because passing tests alone do not show the operator-visible behavior, I also produced two CLI transcripts against the real scripts: a before/after `bin/fm-afk-return.sh` run showing that a worker's malformed-key blocker was previously invisible to the return gate and is now presented under a legal content-addressed quarantine key that an ordinary `resolved [key=...]` line closes without evicting the well-formed blocker; and a rendered-brief transcript showing the pinned `[key=api-shape]` placement in all three scaffolds, with those exact example lines round-tripping through the real parser and fold, plus proof that malformed closing keys resolve nothing real and that the historical trailing-key incident line still reads as `default`. No UI surface is involved (bash CLI and generated markdown briefs only), so the evidence is command transcripts and rendered brief excerpts. Scratch directories were removed and the worktree is clean; PR creation and the pipeline-written provenance section belong to other phases and were not exercised here.

<details>
<summary>Evidence: AFK-return gate: malformed decision key before vs after</summary>

<code>BEFORE (base 76355e2):&#10;$ bin/fm-afk-return.sh begin&#10;firstmate-actionable blocker: repair-task [key=vendor-release] synthetic vendor window is closed&#10;!!! the malformed-key blocker never reached the return gate&#10;&#10;AFTER (015eed6):&#10;$ bin/fm-afk-return.sh begin&#10;firstmate-actionable blocker: repair-task [key=vendor-release] synthetic vendor window is closed&#10;firstmate-actionable blocker: repair-task [key=malformed-key.api-shape.76a95cf3] firstmate must pick the synthetic API shape before work resumes&#10;$ echo &#39;resolved [key=malformed-key.api-shape.76a95cf3]: chose the synthetic API shape&#39; &gt;&gt; repair-task.status&#10;remaining blocker records:&#10;key=vendor-release</code>

```text
==============================================================
  BEFORE (base 76355e2): malformed decision key
==============================================================

--- worker's durable status file (what the stopped worker wrote) ---
blocked [key=vendor-release]: synthetic vendor window is closed
blocked [key=api shape]: firstmate must pick the synthetic API shape before work resumes

--- $ bin/fm-afk-return.sh begin   (what the human sees on return) ---
fm-afk-return: catch-up must finish before the captain request
firstmate-actionable blocker: repair-task [key=vendor-release] synthetic vendor window is closed
fm-afk-return: handle each blocker now, or close it with resolved [key=...] and append a durable reclassification reason, then run bin/fm-afk-return.sh check
[exit 3]

--- recorded return-gate blocker records ---
  key=vendor-release  note=synthetic vendor window is closed

!!! the malformed-key blocker never reached the return gate: the stopped
!!! worker's escalation is invisible and there is nothing to close.

==============================================================
  AFTER (015eed6): malformed decision key quarantined
==============================================================

--- worker's durable status file (what the stopped worker wrote) ---
blocked [key=vendor-release]: synthetic vendor window is closed
blocked [key=api shape]: firstmate must pick the synthetic API shape before work resumes

--- $ bin/fm-afk-return.sh begin   (what the human sees on return) ---
fm-afk-return: catch-up must finish before the captain request
firstmate-actionable blocker: repair-task [key=vendor-release] synthetic vendor window is closed
firstmate-actionable blocker: repair-task [key=malformed-key.api-shape.76a95cf3] firstmate must pick the synthetic API shape before work resumes
fm-afk-return: handle each blocker now, or close it with resolved [key=...] and append a durable reclassification reason, then run bin/fm-afk-return.sh check
[exit 3]

--- recorded return-gate blocker records ---
  key=vendor-release  note=synthetic vendor window is closed
  key=malformed-key.api-shape.76a95cf3  note=firstmate must pick the synthetic API shape before work resumes

--- human closes the quarantined record by hand ---
  $ echo 'resolved [key=malformed-key.api-shape.76a95cf3]: chose the synthetic API shape' >> repair-task.status
  remaining blocker records:
    key=vendor-release
```
</details>
<details>
<summary>Evidence: Rendered briefs: pinned decision-key placement, parsed through the real fold</summary>

<code>ship brief:&#10;6. ... append `needs-decision [key=api-shape]: {summary of options}` and stop.&#10;When you use a key, put it between the verb and the colon, as in `blocked [key=api-shape]: {why}`; never put it after the note.&#10;... `resolved: {how it cleared}`, or `resolved [key=api-shape]: {how it cleared}` if you opened it with a key.&#10;&#10;Worker copies the brief example verbatim:&#10;needs-decision [key=api-shape]: pick the API shape&#10;status_open_decisions -&gt; api-shape\tneeds-decision\tpick the API shape&#10;+ resolved [key=api-shape]: captain chose B -&gt; &#39;&#39; (closed)&#10;&#10;Closing-side strictness:&#10;needs-decision: which DB? / needs-decision [key=q2]: real choice&#10;resolved [key=bad key]: typo / resolved [key=&lt;slug&gt;]: copied placeholder&#10;status_open_decisions -&gt; default\tneeds-decision\twhich DB?&#10;q2\tneeds-decision\treal choice (neither closed)</code>

```text
==============================================================
  1. Decision-key guidance as rendered into each brief scaffold
==============================================================

--- ship brief: /tmp/no-mistakes-evidence/01KZR5Z7GTG0MPQCNYDZGE6SK8/.scratch-brief.T3cI/data/demo-ship/brief.md ---
  39:6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings), append `needs-decision [key=api-shape]: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
  40:   When you use a key, put it between the verb and the colon, as in `blocked [key=api-shape]: {why}`; never put it after the note.
  43:   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append the closing line yourself as you resume: `resolved: {how it cleared}`, or `resolved [key=api-shape]: {how it cleared}` if you opened it with a key.

--- scout brief: /tmp/no-mistakes-evidence/01KZR5Z7GTG0MPQCNYDZGE6SK8/.scratch-brief.T3cI/data/demo-scout/brief.md ---
  32:6. If a decision belongs to a human (product choices, destructive actions), append `needs-decision [key=api-shape]: {summary of options}` and stop. Firstmate will reply with the decision.
  33:   When you use a key, put it between the verb and the colon, as in `blocked [key=api-shape]: {why}`; never put it after the note.
  36:   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append the closing line yourself as you resume: `resolved: {how it cleared}`, or `resolved [key=api-shape]: {how it cleared}` if you opened it with a key.

--- secondmate brief: /tmp/no-mistakes-evidence/01KZR5Z7GTG0MPQCNYDZGE6SK8/.scratch-brief.T3cI/data/demo-second/brief.md ---
  44:When you use a key, put it between the verb and the colon, as in `blocked [key=api-shape]: {why}`; never put it after the note.
  46:For a decision on that phase, append `needs-decision [key=api-shape]: {summary}`.
  47:If its first reportable event is `working [key=api-shape]: {material phase}`, use the same key on its later `paused`, `done`, `failed`, `needs-decision`, or `blocked` event so the earlier working phase is superseded.
  48:When a keyed phase ends without another reportable state, append `resolved [key=api-shape]: {why it is no longer active}`.
  50:The main firstmate's answer normally writes that closing line at answer time; when a blocker or wait clears WITHOUT an answer from the main firstmate, append the closing line yourself as your domain resumes: `resolved: {how it cleared}`, or `resolved [key=api-shape]: {how it cleared}` if you opened it with a key.

==============================================================
  2. A worker copies the brief's examples verbatim
==============================================================

--- BEFORE this change the brief taught `[key=<work-slug>]` / `[key=<slug>]`
--- (angle brackets are illegal in the slug grammar). Copied verbatim:
    needs-decision [key=<work-slug>]: pick the API shape
  status_open_decisions ->
    malformed-key.-work-slug-.0a142b21	needs-decision	pick the API shape
  (quarantined under a legal, human-closable key instead of vanishing)

--- AFTER: the brief's own example, copied verbatim ---
    needs-decision [key=api-shape]: pick the API shape
  status_open_decisions ->
    api-shape	needs-decision	pick the API shape

--- and the brief's own self-close example closes it ---
    needs-decision [key=api-shape]: pick the API shape
    resolved [key=api-shape]: captain chose B
  status_open_decisions -> ''  (empty = closed)

==============================================================
  3. Closing-side strictness: a malformed key resolves nothing real
==============================================================
    needs-decision: which DB?
    needs-decision [key=q2]: real choice
    resolved [key=bad key]: typo
    resolved [key=<slug>]: copied placeholder
  status_open_decisions ->
    default	needs-decision	which DB?
    q2	needs-decision	real choice
  (both real decisions still open: each malformed close names only its
   own quarantine key, so it can never resolve a real decision)

==============================================================
  4. The real 2026 incident line: trailing key after the note
==============================================================
    blocked: report complete; decision-hold gate needs tasks-axi>=0.2.4 [key=decision-hold-gate]
  status_open_decisions ->
    default	blocked	report complete; decision-hold gate needs tasks-axi>=0.2.4 [key=decision-hold-gate]
  (key=default: a trailing token is note prose, never a key - which is
   exactly why the brief now pins placement between verb and colon)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 3 infos</summary>

- ⚠️ `bin/fm-brief.sh:334` - Rule 6 in every scaffold changed from a bare `needs-decision: {summary}` to an always-keyed `needs-decision [key=api-shape]: {summary}`, so every worker escalation now flows through slug parsing. On the OPENING side a malformed slug is still dropped outright: `_fm_decision_key` returns 1 and `_fm_decision_fold_line` (bin/fm-classify-lib.sh:260) discards the line. Concrete path: worker appends `needs-decision [key=api shape]: drop the users column?` (space, `/`, `#`, or angle brackets all do it) -&gt; the record never enters the open set -&gt; `print_open_decisions_section` (bin/fm-wake-drain.sh:67) omits it and `scan_open_blockers` (bin/fm-afk-return.sh:72) reports no blocker, so the AFK-return gate passes while the worker is stopped waiting. Only the live watcher still sees the raw line (`status_line_verb` strips the token before matching), so the durable ledger is where it is lost. This is strictly better than the pre-change `&lt;work-slug&gt;` placeholder (guaranteed malformed if copied), and the intent authorizes closing-side strictness only, so this is a residual gap rather than a regression - but the earliest shared boundary that would close it is `_fm_decision_fold_line`: fold an unparseable key on `needs-decision`/`blocked` into the `default` record instead of dropping the line, while keeping the malformed-close strictness on `resolved`/`captain-held` exactly as it is (this is what commit dde1ed5 did before ce7b310 scoped it back). Confirm the prose-only pinning is the intended stopping point.
- ℹ️ `bin/fm-brief.sh:246` - The example slug is now a literal (`api-shape`) rather than an obvious placeholder, so a worker that copies it verbatim produces a parseable key. Tradeoff: two concurrent decisions in one task both keyed `api-shape` collide - `_fm_decision_drop` in `_fm_decision_fold_line` evicts the first record, so the earlier summary disappears from the open set. The two &#34;Use your own slug in place of that example&#34; lines are the only guard. Noted as the deliberate tradeoff behind commit e5cdba1; a literal that reads less copyable (e.g. `your-slug-here`) would still parse while discouraging reuse.
- ℹ️ `.agents/skills/afk/SKILL.md:64` - Sibling agent-facing artifact outside the pinned scaffolds still hands out `resolved [key=...]`. `...` is a *valid* slug under the `[A-Za-z0-9._-]` grammar, so a verbatim copy parses and resolves a key nothing ever opened - it looks like a successful close but drops nothing. It fails safe (the blocker stays open and `fm-afk-return.sh check` keeps failing loudly, and firstmate&#39;s real path goes through `fm-send --resolve-key`, which validates writer-side), so no action here; flagged only because the intent forbids widening this change.

🔧 Fix: quarantine malformed decision keys instead of dropping them
3 issues (1 warning, 2 infos) still open:
- ⚠️ `tests/fm-brief.test.sh:766` - `test_brief_key_examples_parse_through_the_real_fold` is now vacuous: commit fa7ef1a made `_fm_decision_key` never return nonzero and never return `default` for a `[key=...]` token, so the guard it was added as (4403e4e) can no longer fail. Concrete: revert bin/fm-brief.sh to the pre-change `needs-decision [key=&lt;work-slug&gt;]: {summary}` placeholder - the exact defect 1ef0b96 fixes - and the test still passes. `_fm_decision_key` returns `malformed-key.-work-slug-`, so the `|| fail` at line 766 is dead code, `[ &#34;$key&#34; != default ]` at 768 passes, the `needs-decision|blocked` branch finds `malformed-key.-work-slug-\tneeds-decision\t` in `status_open_decisions` output, and the `resolved` branch seeds its own `needs-decision [key=$key]` line from the same derived key so closure always matches. Only the separate literal `assert_grep &#39;needs-decision [key=api-shape]:&#39;` in `test_pause_verb_override_renders_all_brief_scaffolds` would still catch it, and that is a source-content grep, not the semantic guard. Fix: after `key=$(_fm_decision_key &#34;$line&#34;)`, fail when the derived key begins with `$FM_DECISION_MALFORMED_KEY_PREFIX` (that is exactly &#34;the brief handed out a slug the parser rejects&#34; under the new fold).
- ℹ️ `bin/fm-classify-lib.sh:210` - Quarantine key derivation is many-to-one, so two malformed escalations can still evict each other. `k=${k//[!A-Za-z0-9._-]/-}` followed by truncation to 40 bytes maps distinct slugs onto one record: `needs-decision [key=api shape]: X` then `needs-decision [key=api/shape]: Y` both derive `malformed-key.api-shape`, and `_fm_decision_drop` in the needs-decision branch evicts X so only Y survives in the open set (same for two malformed slugs sharing the first 40 sanitized bytes). Also, `malformed-key.` is itself a legal slug, so the header comment&#39;s claim that a malformed line &#34;never overwrites the `default` record or any well-formed key&#34; is unenforced - a writer choosing the literal key `malformed-key.api-shape` collides with the quarantine record. Both are strictly better than the base behavior (which dropped every malformed line outright), and the authorized properties hold for the single-malformed-key case, so no action; flagged because the header states the stronger invariant as fact.
- ℹ️ `bin/fm-classify-lib.sh:570` - The same `|| continue` removal was applied to `_fm_status_open_activities_stream`, widening the parent-activity fold too - the authorized widening was about the open-decision/AFK-return path. Reachable consequence: a worker writes `working [key=api shape]: doing X` (typo) and later the corrected `done [key=api-shape]: finished`; the phase opened under `malformed-key.api-shape` is never closed by the `api-shape` terminal line, so bin/fm-fleet-snapshot.sh:956 reports an ended phase as still open indefinitely. Bounded: that function&#39;s own header states the fold is supersession evidence only, never authoritative crew state, and output is capped by FM_SNAPSHOT_PARENT_ACTIVITIES. The symmetric case (a malformed-keyed `working` with no terminal line) is more correct than before, so this is a tradeoff note rather than a defect.

🔧 Fix: brief key-example guard rejects quarantined slugs
3 issues (1 warning, 2 infos) still open:
- ⚠️ `bin/fm-classify-lib.sh:210` - Quarantine key derivation is many-to-one, so the authorized property &#34;no eviction of a real decision&#34; is not established. `k=${k//[!A-Za-z0-9._-]/-}` then `${k:0:40}` maps distinct malformed slugs onto one record. Verified against the real fold: a status file containing `needs-decision [key=api shape]: drop users column?` followed by `needs-decision [key=api/shape]: rename orders table?` yields exactly one row, `malformed-key.api-shape\tneeds-decision\trename orders table?` - the `_fm_decision_drop` in the needs-decision branch evicted the first worker&#39;s escalation, and that worker is stopped waiting on it. Same collision for any two slugs sharing the first 40 sanitized bytes, and for non-ASCII keys, which collapse to punctuation (`[key=ünïcødé]` -&gt; `malformed-key.-n-c-d-`). The mirror of this also weakens the closing-side strictness the intent requires: `resolved [key=api/shape]` closes the quarantined record opened by `[key=api shape]`, a real decision it does not name. The header at lines 177-180 states the invariant more narrowly (&#34;never overwrites the `default` record or any well-formed key&#34;), which is true, but it is not the property the widening was authorized against - and `malformed-key.` is itself a legal slug, so a writer choosing `[key=malformed-key.api-shape]` collides too. This is still strictly better than the base behavior (which dropped every malformed line), so it is not a regression; but the round-1 authorization said to stop and report if all three properties cannot hold simultaneously. Collision-free derivation that keeps all three: append a short checksum of the RAW key bytes to the sanitized stem (e.g. `malformed-key.&lt;sanitized-stem&gt;.&lt;8 hex&gt;`), so identical raw keys still fold onto one record - which is correct - while distinct ones never merge; the result stays bounded in charset and length and remains a legal, hand-closable slug.
- ℹ️ `bin/fm-classify-lib.sh:570` - The same `|| continue` removal was applied to `_fm_status_open_activities_stream`, which is outside the authorized widening (the round-1 instruction scoped it to open decisions and the bin/fm-afk-return.sh consumer). Reachable consequence: `working [key=api shape]: starting` opens a phase under `malformed-key.api-shape` that the later, corrected `done [key=api-shape]: finished` never closes, so bin/fm-fleet-snapshot.sh:956 reports an ended parent phase as still open. Bounded and self-limiting - that fold&#39;s own header states it is supersession evidence only, never authoritative crew state, and the snapshot keeps only the last FM_SNAPSHOT_PARENT_ACTIVITY records, so an old phantom is the first thing dropped. Noted because the symmetric case (a malformed `working` with no terminal line) is genuinely more correct than before; flagged only as scope.
- ℹ️ `tests/fm-brief.test.sh:669` - The five prose assertions added to `test_pause_verb_override_renders_all_brief_scaffolds` are substring greps over the rendered brief - permitted, since the brief is the generated prompt artifact - but four of them are now redundant with `test_brief_key_examples_parse_through_the_real_fold`, which proves the same contract by executing each rendered example through the real parser and fold. Only the `assert_no_grep &#39;resolved: {how it cleared}` yourself (same `[key=&lt;slug&gt;]`&#39;` guard at line 682 adds unique regression value (it matches the exact removed wording, confirmed with grep -F). The semantic guard also does not check that the `needs-decision` and `resolved` examples share a slug, so cross-example key drift would pass both tests; adding that one comparison would be worth more than the four prose greps.

🔧 Fix: content-address quarantined decision keys so collisions cannot evict
3 infos still open:
- ℹ️ `bin/fm-classify-lib.sh:220` - `sum=$(printf &#39;%s&#39; &#34;$raw&#34; | LC_ALL=C cksum 2&gt;/dev/null) || sum=&#39;&#39;` followed by the `&#39;&#39;|*[!0-9]*) sum=0` guard means any cksum failure degrades silently to a constant checksum: every malformed slug then derives `malformed-key.&lt;stem&gt;.00000000`, `api shape` and `api/shape` collide again, and the eviction this round was authorized to remove returns with no signal. The repo already hard-depends on coreutils elsewhere in this same file (`stat`, `wc`, `tail`), so this is practically unreachable rather than a live defect - noted because the fallback quietly voids the one property the derivation exists to guarantee, and a pure-bash byte accumulator over `$raw` would keep it under any environment. Related: the header at lines 176-190 states two absolutes the code does not enforce - `cksum` is 32-bit so distinct slugs can collide (birthday ~65k distinct malformed slugs on one task), and `malformed-key.` is itself a legal slug, so a writer choosing `[key=malformed-key.api-shape.76a95cf3]` lands on the quarantine record directly. Both are acceptable engineering; the comment just reads as a proof rather than a practical bound.
- ℹ️ `bin/fm-classify-lib.sh:234` - Making malformed opening keys visible reaches a consumer outside the two the widening was scoped and tested against (bin/fm-afk-return.sh, bin/fm-wake-drain.sh): bin/fm-decision-hold.sh:333 and :382 hard-fail with &#34;open structured decision &lt;origin&gt;/&lt;key&gt; has no captain-held inventory entry&#34; for any key `status_open_decisions` reports. A single typo&#39;d `needs-decision [key=api shape]:` on a live (non-terminal, or secondmate) task therefore now fails `fm-decision-hold.sh complete` and `verify` until the operator either closes it with `resolved [key=malformed-key.api-shape.76a95cf3]` or opens a durable backlog item for that key via `hold --title/--reason`. Both escapes work because the quarantine key passes `validate_slug` (bin/fm-decision-hold.sh:84), and the key is printed verbatim by fm-afk-return.sh:119, so nothing is unrecoverable - this is the intended &#34;stop hiding the escalation&#34; semantics landing in a second gate. Flagged only so the blast radius is on record; no test covers this consumer.
- ℹ️ `bin/fm-classify-lib.sh:190` - Intent conformance note, reconciled rather than raised as a contradiction. The intent states &#34;Preserve the settled scope&#34; and &#34;Do not redesign or widen the change&#34;, and the shipped change does widen it: `_fm_decision_key` no longer fails, `_fm_decision_fold_line` and `_fm_status_open_activities_stream` lost their `|| continue`/`|| return` drop, a quarantine namespace was added, and the fold version went 2 -&gt; 4 instead of 2 -&gt; 3. That widening was explicitly directed by the author in this same run (round 1: &#34;WIDEN NOW&#34;, round 3: &#34;Make quarantine key derivation injective&#34;), which supersedes the pre-run scope text, so it is not an unauthorized deviation. The originally named cursor test was also renamed `test_fold_version_2_cursor_is_never_trusted` -&gt; `test_cursor_from_a_foreign_fold_version_is_never_trusted` and now writes `version=0`; the three required coverage items (trailing-key incident line, correctly placed keys, fold-version bump) are all retained, and the rename makes that test survive future version bumps. Raised so the PR body&#39;s &#34;settled scope&#34; framing is not taken at face value.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-test-run.sh tests/fm-brief.test.sh` (includes the new `test_brief_key_examples_parse_through_the_real_fold`)</code>
- <code>`bin/fm-test-run.sh tests/fm-afk-return.test.sh` (includes `test_malformed_blocker_key_stays_visible_and_closable` and `test_colliding_malformed_blocker_keys_stay_distinct`)</code>
- <code>`bin/fm-test-run.sh tests/fm-watch-triage.test.sh` (classifier primitives: trailing-key incident line, malformed closing keys)</code>
- <code>`bin/fm-test-run.sh tests/fm-wake-drain-open-decisions-cursor.test.sh` (new `test_cursor_from_a_foreign_fold_version_is_never_trusted`, guarding the FM_OPEN_DECISIONS_FOLD_VERSION 2-&gt;4 bump)</code>
- <code>Manual before/after run of `bin/fm-afk-return.sh begin` / `check` against the base (76355e2) and target (015eed6) `bin/fm-classify-lib.sh`, with a worker status file containing `blocked [key=vendor-release]:` plus `blocked [key=api shape]:`</code>
- <code>Manual render of ship, scout, and secondmate briefs via `bin/fm-brief.sh`, then feeding each rendered `[key=...]` example line through `status_line_verb` / `_fm_decision_key` / `status_open_decisions` from `bin/fm-classify-lib.sh`</code>
- <code>Manual closing-side strictness check: `resolved [key=bad key]` and `resolved [key=&lt;slug&gt;]` against an open `default` and `q2` decision</code>
- <code>Manual replay of the real trailing-key incident line `blocked: ... [key=decision-hold-gate]` through `status_open_decisions`</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `bin/fm-pending-reply-lib.sh:920` - bin/fm-pending-reply-lib.sh:920 still guards `key=$(_fm_decision_key &#34;$escalation&#34;) || key=&#39;&#39;`. That failure branch is now unreachable — _fm_decision_key returns a quarantine key instead of `return 1` for a malformed slug. Documented as total at its declaration; removing the dead guard is executable code and out of this phase&#39;s scope.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
