### PR TITLE
feat(bin): add --autocompact flag to fm-spawn.sh for claude-harness spawns

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -104,8 +104,9 @@ When changing any primary watcher adapter, update `docs/supervision-protocols/`,
 
 ## Launch profile axes
 
-`bin/fm-spawn.sh` accepts concrete `--harness`, `--model`, and `--effort` values chosen by firstmate at intake.
+`bin/fm-spawn.sh` accepts concrete `--harness`, `--model`, `--effort`, and `--autocompact` values chosen by firstmate at intake.
 Do not make the shell scripts parse or match natural-language dispatch rules.
+`--autocompact` is a claude-CLI-specific axis: `bin/fm-spawn.sh`'s own header owns its exact accepted values, default, and per-spawn override contract; it is threaded only into claude-harness spawns.
 
 Effort precedence is an explicit per-task captain instruction first, then any applicable standing dispatch profile or secondmate pin, then the generic fallback below.
 Never replace an effort value supplied by either higher-precedence source.
@@ -117,15 +118,15 @@ Never select `max` from this fallback; use it only when the captain has explicit
 
 The supported launch-profile flags below are verified locally; each row records its evidence.
 
-| Harness | Model flag | Effort flag | Notes |
-|---|---|---|---|
-| claude | `--model <model>` | `--effort <low\|medium\|high\|xhigh\|max>` | Verified on Claude Code 2.1.196. |
-| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'` | Verified on codex-cli 0.142.1. The installed binary schema contains `model_reasoning_effort`, the active config uses it, and the bundled model catalog advertises only low/medium/high/xhigh. `max` is omitted. |
-| grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
-| pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
-| opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
-| kimi | `--model <model>` | none | Verified 2026-07-25 on Kimi Code CLI 0.29.1. |
-| muse | `--model <model>` | `--reasoning-effort <low\|medium\|high\|xhigh>`, and `ultra` only for an explicit `max` | Verified 2026-08-05 on Muse Code 0.1.0-R708.1. The flag accepts `none\|minimal\|low\|medium\|high\|xhigh\|ultra` and defaults to `high`. `ultra` is muse's max-class level, so it is reachable only through an explicit captain `max`, never from the generic fallback; `none` and `minimal` sit below the shared vocabulary and stay unreachable. |
+| Harness | Model flag | Effort flag | Autocompact flag | Notes |
+|---|---|---|---|---|
+| claude | `--model <model>` | `--effort <low\|medium\|high\|xhigh\|max>` | `--autocompact <auto\|100k-1M tokens>`, defaults to `272k` | Verified on Claude Code 2.1.196. |
+| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'` | none | Verified on codex-cli 0.142.1. The installed binary schema contains `model_reasoning_effort`, the active config uses it, and the bundled model catalog advertises only low/medium/high/xhigh. `max` is omitted. |
+| grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | none | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
+| pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | none | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
+| opencode | `--model <provider/model>` | none for firstmate's interactive launch | none | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
+| kimi | `--model <model>` | none | none | Verified 2026-07-25 on Kimi Code CLI 0.29.1. |
+| muse | `--model <model>` | `--reasoning-effort <low\|medium\|high\|xhigh>`, and `ultra` only for an explicit `max` | none | Verified 2026-08-05 on Muse Code 0.1.0-R708.1. The flag accepts `none\|minimal\|low\|medium\|high\|xhigh\|ultra` and defaults to `high`. `ultra` is muse's max-class level, so it is reachable only through an explicit captain `max`, never from the generic fallback; `none` and `minimal` sit below the shared vocabulary and stay unreachable. |
 
 The concrete `harness` field owns adapter identity independently of the model provider: `harness=pi` with `model=xai/grok-*` is Pi using xAI, not `harness=grok`, and does not require Grok CLI login; `harness=grok` remains the standalone Grok Build CLI adapter.
 No script resolves that split for you: establish which credential store a tuple reads from the discovery surfaces below plus `quota-axi auth --json`'s per-provider sources, and show that reasoning rather than inferring it from a harness, model, or source name.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Spawn a direct report: a crewmate in a treehouse or Orca worktree, or a
 # secondmate in its isolated firstmate home.
-# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
-#        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
-#        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] --secondmate
+# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--autocompact <value>] [--backend <name>]
+#        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--autocompact <value>] [--backend <name>]
+#        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--autocompact <value>] [--backend <name>] --secondmate
 #   --mode and --yolo are this task's delivery contract, REQUIRED for every ship
 #   spawn and refused on --scout and --secondmate spawns. Firstmate resolves both
 #   per task at intake (AGENTS.md section 7); data/projects.md holds the captain's
@@ -16,7 +16,7 @@
 #   loud one-line deviation notice is printed and the spawn continues.
 #   no-mistakes-prod-only is a registry policy rather than a task mode and is
 #   refused as a flag value.
-#        fm-spawn.sh <task-id> --relaunch [--harness <name>] [--model <name>] [--effort <level>]
+#        fm-spawn.sh <task-id> --relaunch [--harness <name>] [--model <name>] [--effort <level>] [--autocompact <value>]
 #   --relaunch launches a replacement agent for an EXISTING task into that
 #   task's own recorded endpoint and worktree instead of creating either. It is
 #   the launch half of the control plane (bin/fm-control.sh relaunch), which
@@ -38,6 +38,17 @@
 #   axes chosen by firstmate at intake. They are only threaded into harnesses whose
 #   installed CLIs were verified to support that axis; unsupported axes are omitted
 #   from that harness's launch rather than guessed.
+#   --autocompact <value> is a claude-CLI-specific profile axis: claude's own
+#   --autocompact flag accepts "auto" or a token-count window from 100k to 1M
+#   (verified via `claude --help`: "Auto-compact window size (auto, or 100k-1M
+#   tokens)"). A value outside that set is refused before any spawn attempt. It
+#   is threaded only into claude-harness crewmate spawns; every other harness
+#   omits it, exactly like an unsupported --effort value. When the resolved
+#   harness is claude and the caller passes no --autocompact at all, it defaults
+#   to 272k (the captain-approved standing default), but this is a per-spawn
+#   default, not a hard cap: pass --autocompact <bigger value> explicitly at
+#   intake for a task that needs a larger window, such as a long audit or
+#   investigation.
 #   --backend <name> is the explicit runtime session-provider backend for this
 #   exact task only (docs/configuration.md "Runtime backend" owns when that flag
 #   is authorized). Without it, the script resolves FM_BACKEND, then
@@ -260,6 +271,7 @@ KIND_SET=0
 HARNESS_ARG=
 MODEL=
 EFFORT=
+AUTOCOMPACT=
 BACKEND_ARG=
 MODE=
 YOLO=
@@ -267,6 +279,7 @@ TRACEPARENT_ARG=
 HARNESS_SET=0
 MODEL_SET=0
 EFFORT_SET=0
+AUTOCOMPACT_SET=0
 BACKEND_SET=0
 MODE_SET=0
 YOLO_SET=0
@@ -283,6 +296,7 @@ for a in "$@"; do
       harness) HARNESS_ARG=$a; HARNESS_SET=1 ;;
       model) MODEL=$a; MODEL_SET=1 ;;
       effort) EFFORT=$a; EFFORT_SET=1 ;;
+      autocompact) AUTOCOMPACT=$a; AUTOCOMPACT_SET=1 ;;
       backend) BACKEND_ARG=$a; BACKEND_SET=1 ;;
       mode) MODE=$a; MODE_SET=1 ;;
       yolo) YOLO=$a; YOLO_SET=1 ;;
@@ -302,6 +316,8 @@ for a in "$@"; do
     --model=*) MODEL=${a#--model=}; MODEL_SET=1 ;;
     --effort) want_value=effort ;;
     --effort=*) EFFORT=${a#--effort=}; EFFORT_SET=1 ;;
+    --autocompact) want_value=autocompact ;;
+    --autocompact=*) AUTOCOMPACT=${a#--autocompact=}; AUTOCOMPACT_SET=1 ;;
     --backend) want_value=backend ;;
     --backend=*) BACKEND_ARG=${a#--backend=}; BACKEND_SET=1 ;;
     --mode) want_value=mode ;;
@@ -317,6 +333,7 @@ done
 [ "$HARNESS_SET" -eq 0 ] || [ -n "$HARNESS_ARG" ] || { echo "error: --harness requires a non-empty value" >&2; exit 1; }
 [ "$MODEL_SET" -eq 0 ] || [ -n "$MODEL" ] || { echo "error: --model requires a non-empty value" >&2; exit 1; }
 [ "$EFFORT_SET" -eq 0 ] || [ -n "$EFFORT" ] || { echo "error: --effort requires a non-empty value" >&2; exit 1; }
+[ "$AUTOCOMPACT_SET" -eq 0 ] || [ -n "$AUTOCOMPACT" ] || { echo "error: --autocompact requires a non-empty value" >&2; exit 1; }
 [ "$BACKEND_SET" -eq 0 ] || [ -n "$BACKEND_ARG" ] || { echo "error: --backend requires a non-empty value" >&2; exit 1; }
 [ "$MODE_SET" -eq 0 ] || [ -n "$MODE" ] || { echo "error: --mode requires a non-empty value" >&2; exit 1; }
 [ "$YOLO_SET" -eq 0 ] || [ -n "$YOLO" ] || { echo "error: --yolo requires a non-empty value" >&2; exit 1; }
@@ -337,6 +354,25 @@ fi
 case "$EFFORT" in
   ''|low|medium|high|xhigh|max) ;;
   *) echo "error: --effort must be one of low, medium, high, xhigh, max" >&2; exit 1 ;;
+esac
+# claude's own --autocompact accepts "auto" or a 100k-1M token window
+# (verified via `claude --help`: "Auto-compact window size (auto, or 100k-1M
+# tokens)"). Validate here, before any resolution or launch work, the same way
+# --effort's allowed set is validated above.
+case "$AUTOCOMPACT" in
+  ''|auto) ;;
+  *)
+    autocompact_tokens=
+    if [[ "$AUTOCOMPACT" =~ ^([0-9]+)[kK]$ ]]; then
+      autocompact_tokens=$(( BASH_REMATCH[1] * 1000 ))
+    elif [[ "$AUTOCOMPACT" =~ ^1[mM]$ ]]; then
+      autocompact_tokens=1000000
+    fi
+    if [ -z "$autocompact_tokens" ] || [ "$autocompact_tokens" -lt 100000 ] || [ "$autocompact_tokens" -gt 1000000 ]; then
+      echo "error: --autocompact must be 'auto' or a token count from 100k to 1M (e.g. 272k, 500k, 1M), got '$AUTOCOMPACT'" >&2
+      exit 1
+    fi
+    ;;
 esac
 
 # --relaunch reuses an existing task's endpoint, worktree, project, and kind,
@@ -743,6 +779,7 @@ spawn_abort_cleanup() {
             echo "tasktmp=${TASK_TMP:-}"
             echo "model=${MODEL:-default}"
             echo "effort=${EFFORT:-default}"
+            echo "autocompact=${AUTOCOMPACT:-default}"
             echo "backend=orca"
             echo "orca_worktree_id=$ORCA_WORKTREE_ID"
             [ -z "${ORCA_TERMINAL:-}" ] || echo "terminal=$ORCA_TERMINAL"
@@ -851,6 +888,7 @@ if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in *
   [ -z "$HARNESS_ARG" ] || shared_args+=(--harness "$HARNESS_ARG")
   [ -z "$MODEL" ] || shared_args+=(--model "$MODEL")
   [ -z "$EFFORT" ] || shared_args+=(--effort "$EFFORT")
+  [ -z "$AUTOCOMPACT" ] || shared_args+=(--autocompact "$AUTOCOMPACT")
   [ -z "$BACKEND_ARG" ] || shared_args+=(--backend "$BACKEND_ARG")
   # One delivery contract applies to every pair in a batch, exactly like the shared
   # harness. Each pair still re-validates it against its own brief, so a batch
@@ -1100,7 +1138,7 @@ launch_template() {
     # does NOT suppress the interactive ghost text (verified empirically), so the env
     # var is the correct control. The dim-aware composer reader in fm-tmux-lib.sh is
     # the defense-in-depth backstop for any pane this flag cannot reach.
-    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG____AUTOCOMPACTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     codex)
       if [ "$kind" = secondmate ]; then
         printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
@@ -1206,6 +1244,14 @@ case "$HARNESS" in
     LAUNCH="FM_PI_HARNESS=$HARNESS $LAUNCH"
     ;;
 esac
+
+# --autocompact is a claude-CLI-specific axis (see the header). When the caller
+# left it unset AND the resolved harness is claude, apply the captain-approved
+# standing default rather than leaving it unset; every other harness is left
+# alone, since --autocompact has not been verified against their CLIs.
+if [ "$AUTOCOMPACT_SET" -eq 0 ] && [ "$HARNESS" = claude ]; then
+  AUTOCOMPACT=272k
+fi
 
 # muse is verified as a CREWMATE/SCOUT adapter only. A secondmate is a firstmate
 # instance, so it needs a primary supervision protocol; muse has none, and its
@@ -1379,6 +1425,16 @@ effort_flag_for_harness() {
     # to a different, non-interactive launch mode, so fm-spawn does not pass it.
     # kimi likewise has no reasoning-effort flag; the requested axis stays in
     # task metadata but never reaches the launch command.
+  esac
+}
+
+autocompact_flag_for_harness() {
+  local harness=$1 autocompact=$2
+  [ -n "$autocompact" ] && [ "$autocompact" != default ] || return 0
+  case "$harness" in
+    # --autocompact is verified against the claude CLI only (see the header);
+    # every other harness omits it rather than guessing at an equivalent flag.
+    claude) printf -- '--autocompact %s ' "$(shell_quote "$autocompact")" ;;
   esac
 }
 
@@ -2567,7 +2623,7 @@ fi
 preserve_relaunch_meta() {
   awk -F= '
     BEGIN {
-      split("window endpoint_task_id worktree project harness kind mode yolo tasktmp model effort busy_gen spawn_gen traceparent backend herdr_session herdr_workspace_id herdr_tab_id herdr_pane_id zellij_session zellij_tab_id zellij_pane_id orca_worktree_id terminal cmux_workspace_id cmux_surface_id home projects control_relaunch_tx", keys, " ")
+      split("window endpoint_task_id worktree project harness kind mode yolo tasktmp model effort autocompact busy_gen spawn_gen traceparent backend herdr_session herdr_workspace_id herdr_tab_id herdr_pane_id zellij_session zellij_tab_id zellij_pane_id orca_worktree_id terminal cmux_workspace_id cmux_surface_id home projects control_relaunch_tx", keys, " ")
       for (i in keys) owned[keys[i]] = 1
     }
     !($1 in owned)
@@ -2585,6 +2641,7 @@ preserve_relaunch_meta() {
   echo "tasktmp=$TASK_TMP"
   echo "model=${MODEL:-default}"
   echo "effort=${EFFORT:-default}"
+  echo "autocompact=${AUTOCOMPACT:-default}"
   [ -z "${BUSY_GEN:-}" ] || echo "busy_gen=$BUSY_GEN"
   echo "spawn_gen=$SPAWN_GEN"
   # Default-off writes no traceparent= line.
@@ -2648,8 +2705,10 @@ sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
+AUTOCOMPACTFLAG=$(autocompact_flag_for_harness "$HARNESS" "$AUTOCOMPACT")
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
 LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
+LAUNCH=${LAUNCH//__AUTOCOMPACTFLAG__/$AUTOCOMPACTFLAG}
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}
 LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -136,6 +136,11 @@ assert_meta_profile() {
   assert_grep "effort=$effort" "$meta" "meta missing effort=$effort"
 }
 
+assert_meta_autocompact() {
+  local meta=$1 autocompact=$2
+  assert_grep "autocompact=$autocompact" "$meta" "meta missing autocompact=$autocompact"
+}
+
 test_no_profile_keeps_claude_profile_defaults() {
   local rec id out status expected launch
   id=profile-off-z1
@@ -147,11 +152,12 @@ test_no_profile_keeps_claude_profile_defaults() {
   expect_code 0 "$status" "claude spawn without profile flags should succeed"
   assert_contains "$out" "spawned $id harness=claude" "spawn did not report claude"
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
+  assert_meta_autocompact "$HOME_DIR/state/$id.meta" 272k
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
+  expected="CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions --autocompact '272k' \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch did not use the canonical launch kind"$'\n'"expected: $expected"$'\n'"actual:   $launch"
-  pass "no --model/--effort records defaults and types the claude launch instructions"
+  pass "no --model/--effort records defaults and types the claude launch instructions, with the standing 272k autocompact default"
 }
 
 test_relative_home_overrides_launch_with_absolute_cross_process_paths() {
@@ -396,11 +402,74 @@ test_claude_threads_model_and_effort() {
   status=$?
   expect_code 0 "$status" "claude spawn with profile flags should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude sonnet high
+  assert_meta_autocompact "$HOME_DIR/state/$id.meta" 272k
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "claude --dangerously-skip-permissions --model 'sonnet' --effort 'high'" \
-    "claude launch did not thread model and effort flags"
+  assert_contains "$launch" "claude --dangerously-skip-permissions --model 'sonnet' --effort 'high' --autocompact '272k'" \
+    "claude launch did not thread model, effort, and the default autocompact flags"
   assert_not_contains "$launch" "--tui-mode" "non-Pi launches must not receive Pi's TUI mode override"
-  pass "claude receives --model and --effort profile flags"
+  pass "claude receives --model and --effort profile flags, plus the default autocompact flag"
+}
+
+test_claude_threads_explicit_autocompact_override() {
+  local rec id out status launch
+  id=profile-claude-autocompact-z2b
+  rec=$(make_spawn_case profile-claude-autocompact claude "$id")
+  read_case_record "$rec"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --autocompact 500k)
+  status=$?
+  expect_code 0 "$status" "claude spawn with an explicit --autocompact should succeed"
+  assert_meta_autocompact "$HOME_DIR/state/$id.meta" 500k
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "claude --dangerously-skip-permissions --autocompact '500k'" \
+    "explicit --autocompact did not override the standing 272k default"
+  pass "an explicit --autocompact overrides the standing 272k default"
+}
+
+test_non_claude_harness_ignores_autocompact() {
+  local rec id out status launch
+  id=profile-codex-autocompact-z3b
+  rec=$(make_spawn_case profile-codex-autocompact codex "$id")
+  read_case_record "$rec"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --autocompact 500k)
+  status=$?
+  expect_code 0 "$status" "codex spawn with --autocompact should still succeed"
+  assert_meta_autocompact "$HOME_DIR/state/$id.meta" 500k
+  launch=$(cat "$LAUNCH_LOG")
+  assert_not_contains "$launch" "--autocompact" "codex launch must not receive the claude-only --autocompact flag"
+  assert_not_contains "$launch" "AUTOCOMPACTFLAG" "an unsubstituted autocompact placeholder leaked into the codex launch"
+  pass "--autocompact has zero effect on a non-claude harness's rendered launch command"
+}
+
+test_autocompact_rejects_below_floor_value() {
+  local rec id out status
+  id=profile-claude-autocompact-low-z2c
+  rec=$(make_spawn_case profile-claude-autocompact-low claude "$id")
+  read_case_record "$rec"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --autocompact 50k)
+  status=$?
+  expect_code 1 "$status" "--autocompact below the 100k floor should be refused"
+  assert_contains "$out" "error: --autocompact must be" "refusal did not name the actionable requirement"
+  assert_absent "$HOME_DIR/state/$id.meta" "rejected --autocompact wrote task metadata"
+  [ ! -s "$LAUNCH_LOG" ] || fail "rejected --autocompact typed a launch command"
+  pass "--autocompact below the 100k floor is refused before any spawn attempt"
+}
+
+test_autocompact_rejects_non_numeric_value() {
+  local rec id out status
+  id=profile-claude-autocompact-bad-z2d
+  rec=$(make_spawn_case profile-claude-autocompact-bad claude "$id")
+  read_case_record "$rec"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --autocompact banana)
+  status=$?
+  expect_code 1 "$status" "a non-numeric --autocompact should be refused"
+  assert_contains "$out" "error: --autocompact must be" "refusal did not name the actionable requirement"
+  assert_absent "$HOME_DIR/state/$id.meta" "rejected --autocompact wrote task metadata"
+  [ ! -s "$LAUNCH_LOG" ] || fail "rejected --autocompact typed a launch command"
+  pass "an invalid --autocompact value is refused before any spawn attempt"
 }
 
 test_codex_threads_model_and_effort() {
@@ -735,6 +804,10 @@ test_active_dispatch_profile_allows_explicit_harness
 test_active_dispatch_profile_allows_positional_harness
 test_active_dispatch_profile_allows_raw_launch_command
 test_claude_threads_model_and_effort
+test_claude_threads_explicit_autocompact_override
+test_non_claude_harness_ignores_autocompact
+test_autocompact_rejects_below_floor_value
+test_autocompact_rejects_non_numeric_value
 test_codex_threads_model_and_effort
 test_codex_omits_invalid_max_effort
 test_grok_threads_model_and_reasoning_effort


### PR DESCRIPTION
## Summary

Adds a `--autocompact <value>` flag to `bin/fm-spawn.sh` for claude-harness
crewmate spawns, following the exact `--model`/`--effort` pattern already in
the file: same CLI parsing shape, same validation shape, same threading
through `shared_args`, same per-harness flag-rendering function, same
`__PLACEHOLDER__` substitution mechanism.

claude's own `--autocompact` accepts `auto` or a 100k-1M token window
(confirmed via `claude --help`: "Auto-compact window size (auto, or 100k-1M
tokens)"). An out-of-range or non-numeric value is refused with a clear
`error:` before any spawn attempt.

When the caller passes no `--autocompact` at all and the resolved harness is
`claude`, it now defaults to `272k` (the captain-approved standing default).
This is a per-spawn default, not a hard cap — a task that needs a larger
window (a long audit or investigation) can still pass
`--autocompact <bigger value>` explicitly at that one spawn.

`--autocompact` is threaded only into claude-harness spawns; every other
verified harness (codex, opencode, pi/pi-signed, grok, kimi, muse) omits it,
since the flag has not been verified against their CLIs, matching how an
unsupported `--effort` value is already omitted per-harness.

## Changes

- `bin/fm-spawn.sh`: CLI parsing, validation, default resolution, batch
  `shared_args` threading, `autocompact_flag_for_harness` (sibling of
  `effort_flag_for_harness`), claude launch template placeholder,
  placeholder substitution, `state/<id>.meta` recording (main write, the
  Orca abort-cleanup fallback write, and the relaunch owned-keys list), and
  header/usage documentation.
- `tests/fm-spawn-dispatch-profile.test.sh`: extends the existing
  `--model`/`--effort` coverage with cases for the 272k default, an explicit
  override, a non-claude harness being unaffected (no flag, no leaked
  placeholder), and rejection of a below-floor and a non-numeric value.
- `.agents/skills/harness-adapters/SKILL.md`: adds an Autocompact flag
  column to the existing launch-profile-axes table.

## Explicitly out of scope (per brief)

- `AGENTS.md` is untouched; flag mechanics live in `fm-spawn.sh`'s own
  header per the knowledge-placement rule.
- No other harness's launch template changed.
- Default model/effort behavior is unchanged.

## Findings for a possible follow-up

- `bin/fm-control.sh`'s relaunch orchestration restores a task's prior
  `--model`/`--effort` from its recorded meta on relaunch, but this change
  does not touch `fm-control.sh`. A relaunch driven through
  `bin/fm-control.sh relaunch` will therefore NOT carry forward a task's
  prior explicit `--autocompact` value — it re-resolves the 272k default (or
  omits it entirely on a harness switch away from claude) rather than
  reading `autocompact=` back out of meta the way it does for model/effort.
  A direct `fm-spawn.sh <id> --relaunch` with no `--autocompact` behaves
  consistently with model/effort (falls back to the resolved-harness
  default rather than the prior value), so this gap is specific to the
  `fm-control.sh` wrapper. Flagging as a finding since the brief scoped this
  task to `fm-spawn.sh` only.
- `tests/fm-backend-orca.test.sh`'s "Orca spawn should fail when metadata
  cannot be written" test fails the same way on unmodified `main` in this
  environment (confirmed via `git stash`); pre-existing, not a regression
  from this change.

## Validation

- `bin/fm-lint.sh` passes (shellcheck-clean).
- `tests/fm-spawn-dispatch-profile.test.sh` passes in full (30/30), including
  the new autocompact cases.
- `tests/fm-control-relaunch.test.sh`, `tests/fm-spawn-batch.test.sh`,
  `tests/fm-secondmate-harness.test.sh` pass with no regressions.
- `tests/fm-backend-orca.test.sh` passes except the one pre-existing failure
  noted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
