### PR TITLE
feat: add opt-in Moshi lifecycle notifications

### DIFF
--- a/bin/fm-moshi-notify.sh
+++ b/bin/fm-moshi-notify.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# Best-effort local Moshi webhook owner for captain-relevant lifecycle milestones.
+#
+# The opt-in token is read only from the effective home's private
+# config/moshi-webhook-token file, which must be a readable regular file with no
+# group or world read bit and must not be a symlink.
+# The fixed Moshi endpoint is https://api.getmoshi.app/api/v1/events.
+# Missing or unsafe configuration, missing dependencies, request failures, and
+# deduplication are all silent no-ops so notifications never break operations.
+# The token is used only as the request authorization header and is never placed
+# in the JSON payload, durable marker, command output, or diagnostics.
+#
+# Source mode exposes these lifecycle owners:
+#   fm_moshi_notify_pr_ready <task-id> <pr-url>
+#   fm_moshi_notify_pr_merged <task-id> <pr-url>
+#   fm_moshi_notify_attention <task-id> <needs-decision|blocked> <summary>
+#   fm_moshi_notify_task_completed <task-id>
+#
+# CLI usage:
+#   fm-moshi-notify.sh <pr-ready|pr-merged|attention|task-completed> <dedup-key> <title> <message>
+#   fm-moshi-notify.sh --help
+set -u
+
+FM_MOSHI_NOTIFY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_MOSHI_WEBHOOK_ENDPOINT='https://api.getmoshi.app/api/v1/events'
+FM_MOSHI_TOKEN=
+
+fm_moshi_usage() {
+  printf '%s\n' \
+    'Usage: fm-moshi-notify.sh <pr-ready|pr-merged|attention|task-completed> <dedup-key> <title> <message>' \
+    '       fm-moshi-notify.sh --help' \
+    '' \
+    'Posts one concise JSON event to the fixed Moshi webhook when the private' \
+    'effective-home config/moshi-webhook-token file is safe and present.'
+}
+
+fm_moshi_home() {
+  local root
+  root="${FM_ROOT_OVERRIDE:-${FM_ROOT:-$(cd "$FM_MOSHI_NOTIFY_DIR/.." && pwd)}}"
+  printf '%s\n' "${FM_HOME:-$root}"
+}
+
+fm_moshi_state() {
+  local home
+  home=$(fm_moshi_home)
+  printf '%s\n' "${FM_STATE_OVERRIDE:-$home/state}"
+}
+
+fm_moshi_config() {
+  local home
+  home=$(fm_moshi_home)
+  printf '%s\n' "${FM_CONFIG_OVERRIDE:-$home/config}"
+}
+
+fm_moshi_token_path() {
+  printf '%s/moshi-webhook-token\n' "$(fm_moshi_config)"
+}
+
+fm_moshi_token_safe() {
+  local path=$1 mode padded
+  [ -f "$path" ] && [ ! -L "$path" ] || return 1
+  mode=$(stat -c %a "$path" 2>/dev/null || stat -f %Lp "$path" 2>/dev/null) || return 1
+  case "$mode" in
+    ''|*[!0-7]*) return 1 ;;
+  esac
+  padded=$(printf '%04s' "$mode" | tr ' ' 0) || return 1
+  [ "${#padded}" -eq 4 ] || return 1
+  case "${padded:2:1}${padded:3:1}" in
+    *[4-7]*) return 1 ;;
+  esac
+  [ -r "$path" ]
+}
+
+fm_moshi_read_token() {
+  local path=$1 token= extra=
+  FM_MOSHI_TOKEN=
+  fm_moshi_token_safe "$path" || return 1
+  exec 3< "$path" 2>/dev/null || return 1
+  if ! IFS= read -r token <&3; then
+    [ -n "$token" ] || { exec 3<&-; return 1; }
+  fi
+  if IFS= read -r extra <&3; then
+    exec 3<&-
+    return 1
+  fi
+  exec 3<&-
+  [ -z "$extra" ] || return 1
+  case "$token" in
+    ''|*$'\r'*|*$'\n'*) return 1 ;;
+  esac
+  FM_MOSHI_TOKEN=$token
+}
+
+fm_moshi_digest() {
+  local event=$1 dedup_key=$2 input
+  input=$(printf '%s\n%s' "$event" "$dedup_key")
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$input" | sha256sum | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$input" | shasum -a 256 | awk '{print $1}'
+  else
+    return 1
+  fi
+}
+
+fm_moshi_event_valid() {
+  case "$1" in
+    pr-ready|pr-merged|attention|task-completed) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+fm_moshi_mark_once() {
+  local state=$1 digest=$2 root marker
+  root="$state/.moshi-notifications"
+  if [ -e "$root" ] || [ -L "$root" ]; then
+    [ -d "$root" ] && [ ! -L "$root" ] || return 1
+  else
+    mkdir -p -m 700 "$root" 2>/dev/null || return 1
+  fi
+  marker="$root/$digest"
+  if [ -e "$marker" ] || [ -L "$marker" ]; then
+    return 1
+  fi
+  mkdir "$marker" 2>/dev/null
+}
+
+fm_moshi_notify() {
+  local event=$1 dedup_key=$2 title=$3 message=$4 state token_path token digest
+  local payload header_file
+  fm_moshi_event_valid "$event" || return 0
+  [ -n "$dedup_key" ] && [ -n "$title" ] && [ -n "$message" ] || return 0
+  token_path=$(fm_moshi_token_path)
+  fm_moshi_read_token "$token_path" || return 0
+  token=$FM_MOSHI_TOKEN
+  digest=$(fm_moshi_digest "$event" "$dedup_key") || return 0
+  state=$(fm_moshi_state)
+  [ -d "$state" ] || return 0
+  title=${title:0:160}
+  message=${message:0:512}
+  command -v jq >/dev/null 2>&1 || return 0
+  payload=$(jq -cn --arg title "$title" --arg message "$message" \
+    '{title: $title, message: $message}' 2>/dev/null) || return 0
+  case "$payload" in
+    *"$token"*) return 0 ;;
+  esac
+  fm_moshi_mark_once "$state" "$digest" || return 0
+  header_file=$(mktemp "$state/.moshi-header.XXXXXX" 2>/dev/null) || return 0
+  if ! chmod 600 "$header_file" 2>/dev/null ||
+    ! printf 'Authorization: Bearer %s\n' "$token" > "$header_file"; then
+    rm -f -- "$header_file"
+    return 0
+  fi
+  curl --silent --show-error --fail --proto '=https' --tlsv1.2 \
+    --connect-timeout 2 --max-time 5 --request POST \
+    --header 'Content-Type: application/json' \
+    --header "X-Idempotency-Key: firstmate-$digest" \
+    --header "@$header_file" --data-binary "$payload" \
+    --output /dev/null "$FM_MOSHI_WEBHOOK_ENDPOINT" >/dev/null 2>&1 || true
+  rm -f -- "$header_file"
+  return 0
+}
+
+fm_moshi_notify_pr_ready() {
+  local task_id=$1 pr_url=$2
+  fm_moshi_notify pr-ready "pr-ready:$task_id:$pr_url" \
+    'PR ready for review' "Task $task_id is ready for review: $pr_url"
+}
+
+fm_moshi_notify_pr_merged() {
+  local task_id=$1 pr_url=$2
+  fm_moshi_notify pr-merged "pr-merged:$task_id:$pr_url" \
+    'PR merged' "Task $task_id PR was merged: $pr_url"
+}
+
+fm_moshi_notify_attention() {
+  local task_id=$1 kind=$2 summary=$3 title
+  case "$kind" in
+    needs-decision) title='Firstmate decision needed' ;;
+    blocked) title='Firstmate blocker needs attention' ;;
+    *) return 0 ;;
+  esac
+  fm_moshi_notify attention "attention:$task_id:$kind:$summary" "$title" \
+    "Task $task_id $kind: $summary"
+}
+
+fm_moshi_notify_task_completed() {
+  local task_id=$1
+  fm_moshi_notify task-completed "task-completed:$task_id" \
+    'Task completed' "Task $task_id completed successfully after cleanup."
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  if [ "${1:-}" = --help ]; then
+    fm_moshi_usage
+    exit 0
+  fi
+  if [ "$#" -ne 4 ] || ! fm_moshi_event_valid "$1"; then
+    fm_moshi_usage >&2
+    exit 2
+  fi
+  fm_moshi_notify "$1" "$2" "$3" "$4"
+fi

--- a/bin/fm-moshi-notify.sh
+++ b/bin/fm-moshi-notify.sh
@@ -4,11 +4,11 @@
 # The opt-in token is read only from the effective home's private
 # config/moshi-webhook-token file, which must be a readable regular file with no
 # group or world read bit and must not be a symlink.
-# The fixed Moshi endpoint is https://api.getmoshi.app/api/v1/events.
+# The fixed Moshi endpoint is https://api.getmoshi.app/api/webhook.
 # Missing or unsafe configuration, missing dependencies, request failures, and
 # deduplication are all silent no-ops so notifications never break operations.
-# The token is used only as the request authorization header and is never placed
-# in the JSON payload, durable marker, command output, or diagnostics.
+# The token is sent only in the webhook JSON payload and never appears in a
+# durable marker, command output, or diagnostics.
 #
 # Source mode exposes these lifecycle owners:
 #   fm_moshi_notify_pr_ready <task-id> <pr-url>
@@ -22,7 +22,7 @@
 set -u
 
 FM_MOSHI_NOTIFY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-FM_MOSHI_WEBHOOK_ENDPOINT='https://api.getmoshi.app/api/v1/events'
+FM_MOSHI_WEBHOOK_ENDPOINT='https://api.getmoshi.app/api/webhook'
 FM_MOSHI_TOKEN=
 
 fm_moshi_usage() {
@@ -127,7 +127,7 @@ fm_moshi_mark_once() {
 
 fm_moshi_notify() {
   local event=$1 dedup_key=$2 title=$3 message=$4 state token_path token digest
-  local payload header_file
+  local payload marker_dir
   fm_moshi_event_valid "$event" || return 0
   [ -n "$dedup_key" ] && [ -n "$title" ] && [ -n "$message" ] || return 0
   token_path=$(fm_moshi_token_path)
@@ -139,25 +139,18 @@ fm_moshi_notify() {
   title=${title:0:160}
   message=${message:0:512}
   command -v jq >/dev/null 2>&1 || return 0
-  payload=$(jq -cn --arg title "$title" --arg message "$message" \
-    '{title: $title, message: $message}' 2>/dev/null) || return 0
-  case "$payload" in
-    *"$token"*) return 0 ;;
-  esac
+  payload=$(jq -cn --arg token "$token" --arg title "$title" --arg message "$message" \
+    '{token: $token, title: $title, message: $message}' 2>/dev/null) || return 0
   fm_moshi_mark_once "$state" "$digest" || return 0
-  header_file=$(mktemp "$state/.moshi-header.XXXXXX" 2>/dev/null) || return 0
-  if ! chmod 600 "$header_file" 2>/dev/null ||
-    ! printf 'Authorization: Bearer %s\n' "$token" > "$header_file"; then
-    rm -f -- "$header_file"
-    return 0
-  fi
-  curl --silent --show-error --fail --proto '=https' --tlsv1.2 \
+  marker_dir="$state/.moshi-notifications/$digest"
+  if curl --silent --show-error --fail --proto '=https' --tlsv1.2 \
     --connect-timeout 2 --max-time 5 --request POST \
     --header 'Content-Type: application/json' \
-    --header "X-Idempotency-Key: firstmate-$digest" \
-    --header "@$header_file" --data-binary "$payload" \
-    --output /dev/null "$FM_MOSHI_WEBHOOK_ENDPOINT" >/dev/null 2>&1 || true
-  rm -f -- "$header_file"
+    --data-binary "$payload" \
+    --output /dev/null "$FM_MOSHI_WEBHOOK_ENDPOINT" >/dev/null 2>&1; then
+    return 0
+  fi
+  rmdir -- "$marker_dir" 2>/dev/null || true
   return 0
 }
 

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -17,6 +17,8 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 . "$SCRIPT_DIR/fm-pr-lib.sh"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-moshi-notify.sh
+. "$SCRIPT_DIR/fm-moshi-notify.sh"
 
 if [ "$#" -ne 2 ]; then
   echo "error: invalid PR check request" >&2
@@ -134,4 +136,5 @@ fm_pr_poll_publish_prepared || {
   echo "error: could not publish PR poll" >&2
   exit 1
 }
+fm_moshi_notify_pr_ready "$ID" "$URL" || true
 printf 'armed: state/%s.check.sh\n' "$ID"

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -164,6 +164,8 @@ SUB_HOME_PARENT_MARKER=".fm-secondmate-parent"
 . "$SCRIPT_DIR/fm-secondmate-parent-lib.sh"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-moshi-notify.sh
+. "$SCRIPT_DIR/fm-moshi-notify.sh"
 # shellcheck source=bin/fm-nm-run-lib.sh
 . "$SCRIPT_DIR/fm-nm-run-lib.sh"
 if [ "$#" -lt 1 ] || ! fm_task_id_path_safe "$1"; then
@@ -394,6 +396,7 @@ remote_secondmate_teardown() {
   mv -f -- "$tmp" "$SECONDMATE_REG"
   rm -f -- "$STATE/$ID.status" "$STATE/$ID.meta" "$STATE/$ID.turn-ended" \
     "$STATE/.$ID.open-decisions-cursor"
+  fm_moshi_notify_task_completed "$ID" || true
   printf 'teardown %s complete (remote %s:%s)\n' "$ID" "$remote_host" "$remote_home"
   return 0
 }
@@ -2545,5 +2548,6 @@ META_LOCK_HELD=0
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
 fi
-echo "teardown $ID complete (window $T, worktree $WT)"
 backlog_refresh_reminder
+fm_moshi_notify_task_completed "$ID" || true
+echo "teardown $ID complete (window $T, worktree $WT)"

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -88,6 +88,8 @@ mkdir -p "$STATE"
 . "$SCRIPT_DIR/fm-pending-reply-lib.sh"
 # shellcheck source=bin/fm-busy-lib.sh
 . "$SCRIPT_DIR/fm-busy-lib.sh"
+# shellcheck source=bin/fm-moshi-notify.sh
+. "$SCRIPT_DIR/fm-moshi-notify.sh"
 
 WATCH_LOCK="$STATE/.watch.lock"
 WATCH_PATH="$SCRIPT_DIR/fm-watch.sh"
@@ -602,6 +604,39 @@ run_check_capture() {
 # Mark every current captain-relevant status as surfaced. Called after the
 # heartbeat backstop enqueues its wake, so the same statuses are not re-surfaced
 # by the next heartbeat.
+notify_attention_for_status_file() {
+  local path=$1 task line verb note
+  [ -f "$path" ] && [ ! -L "$path" ] || return 0
+  task=$(basename "$path" .status)
+  line=$(last_status_line "$path")
+  verb=$(status_line_verb "$line")
+  case "$verb" in
+    needs-decision|blocked)
+      note=$(status_line_note "$line")
+      fm_moshi_notify_attention "$task" "$verb" "$note" || true
+      ;;
+  esac
+}
+
+notify_attention_for_signal_files() {
+  local files=$1 f
+  # shellcheck disable=SC2086 # Task status paths contain no whitespace.
+  for f in $files; do
+    case "$f" in
+      *.status) notify_attention_for_status_file "$f" ;;
+    esac
+  done
+}
+
+notify_attention_for_fleet_statuses() {
+  local record f
+  while IFS= read -r record; do
+    f=${record%%$'\t'*}
+    [ -n "$f" ] || continue
+    notify_attention_for_status_file "$f"
+  done < <(scan_captain_relevant_statuses "$STATE")
+}
+
 mark_all_captain_relevant_surfaced() {
   local f task last
   while IFS=$(printf '\t') read -r f task last; do
@@ -920,6 +955,7 @@ while :; do
         reason="check: $c: $out"
         fm_wake_append check "$c" "$reason" || exit 1
         if [ "$is_pr_poll" -eq 1 ] && [ "$out" = merged ]; then
+          fm_moshi_notify_pr_merged "$id" "$url" || true
           if fm_pr_poll_retirement_publish "$STATE" "$id" "$SCRIPT_DIR/fm-pr-poll.sh" "$out"; then
             fm_pr_poll_retirement_recover_one "$STATE" "$id" "$SCRIPT_DIR/fm-pr-poll.sh" \
               || triage_log "merged PR poll retirement remains recoverable for $id"
@@ -985,6 +1021,7 @@ EOF
       done <<EOF
 $pending
 EOF
+      notify_attention_for_signal_files "$files"
       wake "$reason"
     else
       while IFS=$(printf '\t') read -r sf sig f; do
@@ -1190,6 +1227,7 @@ EOF
       fm_wake_append heartbeat heartbeat heartbeat || exit 1
       touch "$STATE/.last-heartbeat"
       mark_all_captain_relevant_surfaced
+      notify_attention_for_fleet_statuses
       wake "heartbeat"
     else
       touch "$STATE/.last-heartbeat"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,16 @@ The tracked code root contains the shared instruction, skill, documentation, wor
 The producing PR and Relay helpers own the fields they append, `bin/fm-classify-lib.sh` owns status-event vocabulary, and `bin/fm-crew-state.sh` owns current-state reconciliation.
 Wake, watcher, away-mode, and Relay-specific state mechanics remain with their named scripts and reference sections rather than being duplicated into one exhaustive state tree here.
 
+## Moshi webhook notifications
+
+Local Moshi notifications are opt-in through the private file `config/moshi-webhook-token` under the effective home.
+The file must be a non-symlink regular file that is readable by the owner and not group- or world-readable.
+The notification owner posts concise JSON to `https://api.getmoshi.app/api/v1/events` with a bounded timeout and an idempotency key.
+It covers PR-ready, merged-PR, blocker or captain-decision, and successful-cleanup milestones only.
+An absent or unsafe token file, an unavailable dependency, or a failed request is a silent no-op.
+The token is used only for request authorization and never enters the JSON payload or durable notification markers.
+See [`bin/fm-moshi-notify.sh`](../bin/fm-moshi-notify.sh) for the exact interface and mechanics.
+
 `bin/fm-session-start.sh`'s header is the single owner of session-start ordering, composed commands, digest contents, and the digest's startup mechanism.
 `bin/fm-startup-network.sh`'s header owns the deferred network stage that keeps every external-network call off that digest's blocking path, including its state files and the safety argument for running them later.
 `docs/sessionstart-nudge.md` owns the native session-open adapter tiers that run or nudge the digest command, and the source routing between them.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -105,6 +105,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-pr-check-migrate.sh` | Quarantine older task polls without execution and rebuild only canonical polls       |
 | `fm-pr-check.sh`         | Record validated `pr=` and `pr_head=` values, then atomically arm a static merge poll |
 | `fm-pr-merge.sh`         | Record PR metadata, then merge a task's canonical full GitHub URL                    |
+| `fm-moshi-notify.sh`     | Send one opt-in, deduplicated, best-effort Moshi lifecycle notification               |
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task with an explicit delivery mode |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |

--- a/tests/fm-moshi-notify.test.sh
+++ b/tests/fm-moshi-notify.test.sh
@@ -15,32 +15,21 @@ make_case() {
   cat > "$dir/fakebin/curl" <<'SH'
 #!/usr/bin/env bash
 payload=
-header_file=
-key=
+endpoint=
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --data-binary) payload=${2:-}; shift 2 ;;
-    --header)
-      case "${2:-}" in
-        @*) header_file=${2#@} ;;
-        Idempotency-Key:*) key=${2#Idempotency-Key: } ;;
-        X-Idempotency-Key:*) key=${2#X-Idempotency-Key: } ;;
-      esac
-      shift 2
-      ;;
+    --header) shift 2 ;;
     --output) shift 2 ;;
+    https://*) endpoint=$1; shift ;;
     *) shift ;;
   esac
 done
 if [ -n "${FM_MOSHI_TEST_PAYLOAD:-}" ]; then
   printf '%s' "$payload" > "$FM_MOSHI_TEST_PAYLOAD"
 fi
-if [ -n "${FM_MOSHI_TEST_HEADER_SEEN:-}" ] && [ -n "$header_file" ] &&
-  grep -q '^Authorization: Bearer ' "$header_file"; then
-  : > "$FM_MOSHI_TEST_HEADER_SEEN"
-fi
-if [ -n "${FM_MOSHI_TEST_KEY:-}" ] && [ -n "$key" ]; then
-  printf '%s\n' "$key" > "$FM_MOSHI_TEST_KEY"
+if [ -n "${FM_MOSHI_TEST_ENDPOINT:-}" ] && [ -n "$endpoint" ]; then
+  printf '%s\n' "$endpoint" > "$FM_MOSHI_TEST_ENDPOINT"
 fi
 if [ -n "${FM_MOSHI_TEST_CALLS:-}" ]; then
   printf 'call\n' >> "$FM_MOSHI_TEST_CALLS"
@@ -97,26 +86,24 @@ test_token_file_safety() {
   pass 'unsafe and absent token files are silent no-ops'
 }
 
-test_payload_escaping_and_authentication() {
-  local dir payload title message
+test_payload_escaping_and_endpoint() {
+  local dir payload title message endpoint
   dir=$(make_case payload)
   write_safe_token "$dir"
   title='PR "ready" \\"escaped"'
   message=$'line one\nline "two" and \\tail'
   FM_MOSHI_TEST_PAYLOAD="$dir/payload.json" \
-    FM_MOSHI_TEST_HEADER_SEEN="$dir/header-seen" \
-    FM_MOSHI_TEST_KEY="$dir/idempotency-key" \
+    FM_MOSHI_TEST_ENDPOINT="$dir/endpoint" \
     run_notify "$dir" pr-ready payload-key "$title" "$message" \
     || fail 'payload: helper returned failure'
   payload=$(cat "$dir/payload.json")
-  jq -e --arg title "$title" --arg message "$message" \
-    '.title == $title and .message == $message' "$dir/payload.json" >/dev/null \
-    || fail 'payload: title or message was not JSON-encoded exactly'
-  [ -e "$dir/header-seen" ] || fail 'payload: authorization header was not supplied'
-  [ -s "$dir/idempotency-key" ] || fail 'payload: idempotency key was not supplied'
-  ! grep -qF 'fixture-value' "$dir/payload.json" \
-    || fail 'payload: token appeared in the JSON payload'
-  pass 'payload escaping and authorization keep the token out of JSON'
+  jq -e --arg token fixture-value --arg title "$title" --arg message "$message" \
+    '.token == $token and .title == $title and .message == $message' "$dir/payload.json" >/dev/null \
+    || fail 'payload: token, title, or message was not JSON-encoded exactly'
+  endpoint=$(cat "$dir/endpoint")
+  [ "$endpoint" = 'https://api.getmoshi.app/api/webhook' ] \
+    || fail "payload: unexpected endpoint $endpoint"
+  pass 'payload escaping and Moshi webhook contract are correct'
 }
 
 test_deduplication() {
@@ -149,7 +136,7 @@ test_best_effort_failure() {
 }
 
 test_token_file_safety
-test_payload_escaping_and_authentication
+test_payload_escaping_and_endpoint
 test_deduplication
 test_best_effort_failure
 printf 'all fm-moshi-notify tests passed\n'

--- a/tests/fm-moshi-notify.test.sh
+++ b/tests/fm-moshi-notify.test.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Tests for the local, opt-in Moshi notification owner.
+# The suite uses a fake curl transport and never contacts Moshi.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+NOTIFY="$ROOT/bin/fm-moshi-notify.sh"
+TMP_ROOT=$(fm_test_tmproot fm-moshi-notify)
+
+make_case() {
+  local name=$1 dir=$TMP_ROOT/$1
+  mkdir -p "$dir/home/config" "$dir/home/state" "$dir/fakebin"
+  cat > "$dir/fakebin/curl" <<'SH'
+#!/usr/bin/env bash
+payload=
+header_file=
+key=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --data-binary) payload=${2:-}; shift 2 ;;
+    --header)
+      case "${2:-}" in
+        @*) header_file=${2#@} ;;
+        Idempotency-Key:*) key=${2#Idempotency-Key: } ;;
+        X-Idempotency-Key:*) key=${2#X-Idempotency-Key: } ;;
+      esac
+      shift 2
+      ;;
+    --output) shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [ -n "${FM_MOSHI_TEST_PAYLOAD:-}" ]; then
+  printf '%s' "$payload" > "$FM_MOSHI_TEST_PAYLOAD"
+fi
+if [ -n "${FM_MOSHI_TEST_HEADER_SEEN:-}" ] && [ -n "$header_file" ] &&
+  grep -q '^Authorization: Bearer ' "$header_file"; then
+  : > "$FM_MOSHI_TEST_HEADER_SEEN"
+fi
+if [ -n "${FM_MOSHI_TEST_KEY:-}" ] && [ -n "$key" ]; then
+  printf '%s\n' "$key" > "$FM_MOSHI_TEST_KEY"
+fi
+if [ -n "${FM_MOSHI_TEST_CALLS:-}" ]; then
+  printf 'call\n' >> "$FM_MOSHI_TEST_CALLS"
+fi
+exit "${FM_MOSHI_TEST_CURL_RC:-0}"
+SH
+  chmod +x "$dir/fakebin/curl"
+  printf '%s\n' "$dir"
+}
+
+run_notify() {
+  local dir=$1
+  shift
+  FM_HOME="$dir/home" \
+    PATH="$dir/fakebin:$PATH" \
+    "$NOTIFY" "$@"
+}
+
+write_safe_token() {
+  local dir=$1
+  printf 'fixture-value\n' > "$dir/home/config/moshi-webhook-token"
+  chmod 600 "$dir/home/config/moshi-webhook-token"
+}
+
+assert_no_call() {
+  local dir=$1 label=$2
+  [ ! -e "$dir/calls" ] || fail "$label: unsafe or absent token caused a webhook call"
+}
+
+test_token_file_safety() {
+  local dir kind
+  for kind in missing symlink directory readable fifo; do
+    dir=$(make_case "token-$kind")
+    case "$kind" in
+      symlink)
+        printf 'fixture-value\n' > "$dir/target"
+        chmod 600 "$dir/target"
+        ln -s "$dir/target" "$dir/home/config/moshi-webhook-token"
+        ;;
+      directory) mkdir "$dir/home/config/moshi-webhook-token" ;;
+      readable)
+        write_safe_token "$dir"
+        chmod 644 "$dir/home/config/moshi-webhook-token"
+        ;;
+      fifo)
+        mkfifo "$dir/home/config/moshi-webhook-token"
+        ;;
+    esac
+    FM_MOSHI_TEST_CALLS="$dir/calls" run_notify "$dir" \
+      pr-ready "safety-$kind" 'PR ready' 'safe test message' \
+      || fail "token-$kind: notification helper returned failure"
+    assert_no_call "$dir" "token-$kind"
+  done
+  pass 'unsafe and absent token files are silent no-ops'
+}
+
+test_payload_escaping_and_authentication() {
+  local dir payload title message
+  dir=$(make_case payload)
+  write_safe_token "$dir"
+  title='PR "ready" \\"escaped"'
+  message=$'line one\nline "two" and \\tail'
+  FM_MOSHI_TEST_PAYLOAD="$dir/payload.json" \
+    FM_MOSHI_TEST_HEADER_SEEN="$dir/header-seen" \
+    FM_MOSHI_TEST_KEY="$dir/idempotency-key" \
+    run_notify "$dir" pr-ready payload-key "$title" "$message" \
+    || fail 'payload: helper returned failure'
+  payload=$(cat "$dir/payload.json")
+  jq -e --arg title "$title" --arg message "$message" \
+    '.title == $title and .message == $message' "$dir/payload.json" >/dev/null \
+    || fail 'payload: title or message was not JSON-encoded exactly'
+  [ -e "$dir/header-seen" ] || fail 'payload: authorization header was not supplied'
+  [ -s "$dir/idempotency-key" ] || fail 'payload: idempotency key was not supplied'
+  ! grep -qF 'fixture-value' "$dir/payload.json" \
+    || fail 'payload: token appeared in the JSON payload'
+  pass 'payload escaping and authorization keep the token out of JSON'
+}
+
+test_deduplication() {
+  local dir calls
+  dir=$(make_case deduplication)
+  write_safe_token "$dir"
+  FM_MOSHI_TEST_CALLS="$dir/calls" run_notify "$dir" \
+    pr-merged same-event 'PR merged' 'same event' \
+    || fail 'deduplication: first notification failed'
+  FM_MOSHI_TEST_CALLS="$dir/calls" run_notify "$dir" \
+    pr-merged same-event 'PR merged' 'same event' \
+    || fail 'deduplication: repeated notification failed'
+  calls=$(wc -l < "$dir/calls" | tr -d '[:space:]')
+  [ "$calls" = 1 ] || fail "deduplication: expected one request, saw $calls"
+  pass 'repeated lifecycle calls produce one request'
+}
+
+test_best_effort_failure() {
+  local dir rc
+  dir=$(make_case best-effort)
+  write_safe_token "$dir"
+  set +e
+  FM_MOSHI_TEST_CURL_RC=22 FM_MOSHI_TEST_CALLS="$dir/calls" \
+    run_notify "$dir" attention failed-request 'Firstmate blocker' 'transport is unavailable'
+  rc=$?
+  set -e
+  [ "$rc" -eq 0 ] || fail 'best-effort: transport failure escaped the helper'
+  [ -s "$dir/calls" ] || fail 'best-effort: fake transport was not exercised'
+  pass 'transport failures remain best-effort and non-fatal'
+}
+
+test_token_file_safety
+test_payload_escaping_and_authentication
+test_deduplication
+test_best_effort_failure
+printf 'all fm-moshi-notify tests passed\n'


### PR DESCRIPTION
## Summary
- add a private, opt-in Moshi webhook owner with safe token-file validation, JSON encoding, bounded requests, and idempotent deduplication
- notify only for PR ready, merged PR, captain blockers or decisions, and successful cleanup
- integrate the owner with PR publication, merge polling, actionable status surfacing, and teardown
- add focused safety tests and concise configuration documentation

## Validation
- `bin/fm-test-run.sh tests/fm-moshi-notify.test.sh` - passed
- `bash tests/fm-moshi-notify.test.sh` - passed
- `bash tests/fm-pr-merge.test.sh` - passed
- `bash tests/fm-pr-check-security.test.sh` - passed
- `bash tests/fm-watch-triage.test.sh` - passed
- `bash tests/fm-teardown-endpoint-safety.test.sh` - passed
- `bin/fm-doc-audience-check.sh` - passed
- `bash -n` on all changed shell lint targets - passed
- `bin/fm-lint.sh` - not run: ShellCheck 0.11.0 is not installed
- `bash tests/fm-teardown.test.sh` - environment failure: Git 2.34.1 lacks `git merge-tree --write-tree`, so the pre-existing content-landed fallback test refuses the fixture