### PR TITLE
fix(bin): keep large fleet inventories off jq argv in fm-fleet-snapshot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,8 +350,8 @@ jobs:
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"
           snapshot_count=$(printf '%s\n' "$snapshot_output" | grep -c '^ok - ')
-          [ "$snapshot_count" -eq 15 ] || {
-            echo "::error::expected 15 snapshot/fleet-view tests, got $snapshot_count"
+          [ "$snapshot_count" -eq 17 ] || {
+            echo "::error::expected 17 snapshot/fleet-view tests, got $snapshot_count"
             exit 1
           }
 

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -53,6 +53,19 @@
 #     unreadable, and retain independently trustworthy structured surfaces.
 #   secondmate_guidance: return-channel action note for renderers and bearings.
 #
+# Composition: inventory-scaled JSON (backlog, task inventory, secondmate
+# records, and the assembled snapshot) reaches jq on stdin through `jq -s`,
+# never as an `--argjson` value, because Linux caps one argv entry far below the
+# total argument budget, so a large but valid inventory otherwise aborts a
+# summary with "Argument list too long" and leaves Bearings unable to report the
+# live fleet.
+# Fixed-size scalars and per-record values still pass as arguments.
+# Each filter that slurps a fixed set of those payloads asserts its expected
+# input count, so a lost stdin input fails loudly instead of reading as absent
+# data.
+# `tests/fm-fleet-snapshot-view.test.sh` pins both the large-inventory and the
+# small-inventory paths.
+#
 # Compatibility: JSON is the primary machine-readable surface.
 # Human views must render this output instead of parsing state files again.
 set -u

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -609,7 +609,8 @@ task_json_lines() {
 # discloses backlog↔task inconsistency for renderers (Bearings omitted/gates).
 main_inventory_json() {  # <backlog-json> <tasks-json>
   printf '%s\n%s\n' "$1" "$2" | jq -s '
-    .[0] as $backlog
+    if length != 2 then error("fm-fleet-snapshot: main inventory lost a JSON input") else . end
+    | .[0] as $backlog
     | .[1] as $tasks
     | ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
@@ -643,7 +644,8 @@ secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
     --argjson queued_n "$FM_SNAPSHOT_SECONDMATE_QUEUED" \
     --argjson decisions_n "$FM_SNAPSHOT_SECONDMATE_DECISIONS" \
     --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" '
-    .[0] as $backlog
+    if length != 2 then error("fm-fleet-snapshot: secondmate home summary lost a JSON input") else . end
+    | .[0] as $backlog
     | .[1] as $tasks
     | def trunc($n):
       tostring | gsub("\\s+"; " ")
@@ -1051,8 +1053,9 @@ terminal_evidence_json() {  # <parent-task-json> <event-note> <evidence-contradi
 }
 
 parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <decisions-json>
-  jq -n --argjson summary "$1" --argjson activities "$2" --argjson decisions "$3" '
-    def keyed: . != null and . != "" and . != "default";
+  printf '%s\n' "$1" | jq -s --argjson activities "$2" --argjson decisions "$3" '
+    (if length != 1 then error("fm-fleet-snapshot: reconciliation lost the home summary input") else .[0] end) as $summary
+    | def keyed: . != null and . != "" and . != "default";
     def result($e; $matches; $complete; $surface):
       $e + {
         verdict:(if ($e.key | keyed | not) then "inconclusive"
@@ -1116,8 +1119,9 @@ secondmate_current_json() {  # <parent-tasks-json>
   local activity_scan activities decisions reconciliation provenance freshness reason summary summary_rc summary_bytes summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
   local records='[]' seen_homes=''
   registry=$(registry_secondmates_json) || return 1
-  union=$(jq -n --argjson registry "$registry" --argjson tasks "$tasks" '
-    ($registry.records // []) as $registered
+  union=$(printf '%s\n' "$tasks" | jq -s --argjson registry "$registry" '
+    (if length != 1 then error("fm-fleet-snapshot: secondmate union lost the task inventory input") else .[0] end) as $tasks
+    | ($registry.records // []) as $registered
     | (($registered | map(.id)) // []) as $registered_ids
     | ([ $registered[] as $r
          | $r + {parent_task:([$tasks[] | select(.id == $r.id)][0] // null)} ]
@@ -1255,13 +1259,14 @@ secondmate_current_json() {  # <parent-tasks-json>
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no useful contradiction check",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
       if printf '%s' "$terminal" | jq -e '.contradiction == true' >/dev/null; then contradiction=true; fi
-      record=$(jq -n \
+      record=$(printf '%s\n' "$summary" | jq -s \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg current_reason "$current_reason" --arg observed "$SNAPSHOT_NOW" \
-        --argjson registered "$registered" --argjson summary "$summary" --argjson summary_valid "$summary_valid" --argjson decisions "$decisions" \
+        --argjson registered "$registered" --argjson summary_valid "$summary_valid" --argjson decisions "$decisions" \
         --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
         --argjson reconciliation "$reconciliation" --argjson terminal "$terminal" --argjson contradiction "$contradiction" \
         --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" '
-        {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
+        (if length != 1 then error("fm-fleet-snapshot: secondmate record lost the home summary input") else .[0] end) as $summary
+        | {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          current:{state:$state,reason:($current_reason | if . == "" then null else . end)},invalidity:$summary.invalidity,
          provenance:{selected:"structured-home",structured_home:$home,summary_valid:$summary_valid,
            trust:(if $summary_valid then "complete" else "partial-structured" end),parent_event_role:"historical-only"},
@@ -1298,23 +1303,26 @@ secondmate_current_json() {  # <parent-tasks-json>
          parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan},
          terminal_evidence:$terminal,contradiction:false}')
     fi
-    records=$(jq -n --argjson records "$records" --argjson record "$record" '$records + [$record]')
+    records=$(printf '%s\n%s\n' "$records" "$record" | jq -s '
+      if length != 2 then error("fm-fleet-snapshot: secondmate record accumulation lost a JSON input") else . end
+      | .[0] + [.[1]]')
   done <<EOF
 $rows
 EOF
-  jq -n \
+  printf '%s\n' "$records" | jq -s \
     --argjson registry "$(printf '%s' "$union" | jq '.registry')" \
-    --argjson records "$records" \
     --argjson total_registered "$total_registered" \
     --argjson total "$total" \
     --argjson shown "$shown" \
     --argjson truncated "$truncated" \
-    '{registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
+    '(if length != 1 then error("fm-fleet-snapshot: secondmate aggregation lost the record set input") else .[0] end) as $records
+     | {registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
 }
 
 secondmate_landed_from_current_json() {  # <secondmate-current-json>
-  jq -n --argjson current "$1" '
-    {records:[ $current.records[]
+  printf '%s\n' "$1" | jq -s '
+    (if length != 1 then error("fm-fleet-snapshot: landed projection lost the secondmate current input") else .[0] end) as $current
+    | {records:[ $current.records[]
       | select(.provenance.selected == "structured-home") as $mate
       | $mate.landed[]
       | . + {home:$mate.home,home_id:$mate.id}],
@@ -1377,7 +1385,8 @@ printf '%s\n' \
       --arg data "$DATA" \
       --arg config "$CONFIG" \
       --arg projects "$PROJECTS" \
-  '.[0] as $backlog
+  'if length != 6 then error("fm-fleet-snapshot: snapshot assembly lost a JSON input") else . end
+   | .[0] as $backlog
    | .[1] as $tasks
    | .[2] as $main_inventory
    | .[3] as $scout_reports

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -53,13 +53,16 @@
 #     unreadable, and retain independently trustworthy structured surfaces.
 #   secondmate_guidance: return-channel action note for renderers and bearings.
 #
-# Composition: inventory-scaled JSON (backlog, task inventory, secondmate
-# records, and the assembled snapshot) reaches jq on stdin through `jq -s`,
-# never as an `--argjson` value, because Linux caps one argv entry far below the
-# total argument budget, so a large but valid inventory otherwise aborts a
-# summary with "Argument list too long" and leaves Bearings unable to report the
-# live fleet.
-# Fixed-size scalars and per-record values still pass as arguments.
+# Composition: Linux caps one argv entry far below the total argument budget, so
+# a large but valid inventory serialized into an argument aborts a summary with
+# "Argument list too long" and leaves Bearings unable to report the live fleet.
+# Every payload that can outgrow that per-entry cap therefore reaches jq on
+# stdin through `jq -s` instead of an `--argjson` value: the backlog, the task
+# inventory, each per-home secondmate summary (accepted up to
+# FM_SNAPSHOT_SECONDMATE_MAX_BYTES, itself above the cap), the accumulated
+# secondmate records, and the inputs of the final assembly.
+# Fixed-size scalars, per-record values, and the record-bounded registry still
+# pass as arguments.
 # Each filter that slurps a fixed set of those payloads asserts its expected
 # input count, so a lost stdin input fails loudly instead of reading as absent
 # data.

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -608,10 +608,10 @@ task_json_lines() {
 # Meta inventory remains the sole source of live workers; this object only
 # discloses backlog↔task inconsistency for renderers (Bearings omitted/gates).
 main_inventory_json() {  # <backlog-json> <tasks-json>
-  jq -n \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
-    ([ $backlog.records[]?
+  printf '%s\n%s\n' "$1" "$2" | jq -s '
+    .[0] as $backlog
+    | .[1] as $tasks
+    | ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]?
          | select(.state == "in_flight" and .structured and .requires_child_metadata) ]) as $owned_in_flight
@@ -636,16 +636,16 @@ main_inventory_json() {  # <backlog-json> <tasks-json>
 # This mode never reads parent events or terminal text and never aggregates
 # nested secondmates.
 secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
-  jq -n \
+  printf '%s\n%s\n' "$1" "$2" | jq -s \
     --arg generated "$SNAPSHOT_NOW" \
     --arg home "$FM_HOME" \
     --argjson child_n "$FM_SNAPSHOT_SECONDMATE_CHILDREN" \
     --argjson queued_n "$FM_SNAPSHOT_SECONDMATE_QUEUED" \
     --argjson decisions_n "$FM_SNAPSHOT_SECONDMATE_DECISIONS" \
-    --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
-    def trunc($n):
+    --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" '
+    .[0] as $backlog
+    | .[1] as $tasks
+    | def trunc($n):
       tostring | gsub("\\s+"; " ")
       | if length > $n then .[:$n] + "…" else . end;
     ([ $backlog.records[]?
@@ -1362,21 +1362,28 @@ SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON") \
 SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON") \
   || { echo "fm-fleet-snapshot: secondmate landed projection failed" >&2; exit 1; }
 
-jq -n \
-  --arg generated "$SNAPSHOT_NOW" \
-  --arg fm_home "$FM_HOME" \
-  --arg fm_root "$FM_ROOT" \
-  --arg state "$STATE" \
-  --arg data "$DATA" \
-  --arg config "$CONFIG" \
-  --arg projects "$PROJECTS" \
-  --argjson backlog "$BACKLOG_JSON" \
-  --argjson tasks "$TASKS_JSON" \
-  --argjson main_inventory "$MAIN_INVENTORY_JSON" \
-  --argjson scout_reports "$SCOUT_REPORTS_JSON" \
-  --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
-  --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
-  'def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
+printf '%s\n' \
+  "$BACKLOG_JSON" \
+  "$TASKS_JSON" \
+  "$MAIN_INVENTORY_JSON" \
+  "$SCOUT_REPORTS_JSON" \
+  "$SECONDMATE_CURRENT_JSON" \
+  "$SECONDMATE_LANDED_JSON" \
+  | jq -s \
+      --arg generated "$SNAPSHOT_NOW" \
+      --arg fm_home "$FM_HOME" \
+      --arg fm_root "$FM_ROOT" \
+      --arg state "$STATE" \
+      --arg data "$DATA" \
+      --arg config "$CONFIG" \
+      --arg projects "$PROJECTS" \
+  '.[0] as $backlog
+   | .[1] as $tasks
+   | .[2] as $main_inventory
+   | .[3] as $scout_reports
+   | .[4] as $secondmate_current
+   | .[5] as $secondmate_landed
+   | def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");
    {

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -220,6 +220,48 @@ test_large_backlog_snapshot_avoids_argv_limits() {
   pass "snapshot accepts a backlog larger than one Linux argv entry"
 }
 
+# The live task inventory crosses the same argv boundary as the backlog, on a
+# different internal path (secondmate aggregation), so it needs its own proof.
+test_large_task_inventory_snapshot_avoids_argv_limits() {
+  local home fakebin out count orphans i id
+  home=$(make_home large-inventory)
+  fakebin=$(make_fakebin "$home")
+  {
+    printf '## In flight\n'
+    i=1
+    while [ "$i" -le 90 ]; do
+      printf -- '- [ ] inv-%03d - Large live inventory row %03d (repo: alpha) (kind: ship) (since 2026-07-07)\n' "$i" "$i"
+      i=$((i + 1))
+    done
+    printf '\n## Queued\n\n## Done\n'
+  } > "$home/data/backlog.md"
+  i=1
+  while [ "$i" -le 90 ]; do
+    id=$(printf 'inv-%03d' "$i")
+    fm_write_meta "$home/state/$id.meta" \
+      "window=firstmate:fm-$id" \
+      "worktree=$home/projects/$id-worktree" \
+      "project=alpha" \
+      "harness=claude" \
+      "kind=ship" \
+      "mode=ship" \
+      "yolo=off"
+    i=$((i + 1))
+  done
+
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json) \
+    || fail "snapshot rejected a large valid task inventory"
+  count=$(printf '%s' "$out" | jq '.tasks | length')
+  [ "$count" -eq 90 ] \
+    || fail "large task inventory lost rows: expected 90, got $count"
+  orphans=$(printf '%s' "$out" | jq '.main_inventory.orphan_in_flight | length')
+  [ "$orphans" -eq 0 ] \
+    || fail "every in-flight row has metadata, so orphan disclosure should be empty, got $orphans"
+  printf '%s' "$out" | jq -e '.secondmate_current.total == 0 and .secondmate_landed.records == []' >/dev/null \
+    || fail "secondmate aggregation must still project an empty fleet from a large inventory"
+  pass "snapshot accepts a task inventory larger than one Linux argv entry"
+}
+
 # R1 owner contract: main_inventory discloses orphan in-flight and unstructured
 # current rows without inventing task rows.
 test_main_inventory_orphan_and_unstructured_disclosure() {
@@ -805,6 +847,7 @@ test_parked_scout_decision_stays_pending() {
 test_empty_fleet_json
 test_fixture_snapshot_json
 test_large_backlog_snapshot_avoids_argv_limits
+test_large_task_inventory_snapshot_avoids_argv_limits
 test_main_inventory_orphan_and_unstructured_disclosure
 test_normalized_roles_and_plural_blocker_readiness
 test_event_hints_follow_reconciled_current_state

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -197,6 +197,29 @@ test_fixture_snapshot_json() {
   pass "fixture snapshot covers task rows, backlog rows, pointers, and stable ordering"
 }
 
+# Linux limits each argv entry well below the total command-line budget.
+# A large but valid inventory must still cross the snapshot's public interface.
+test_large_backlog_snapshot_avoids_argv_limits() {
+  local home out count i
+  home=$(make_home large-backlog)
+  {
+    printf '## In flight\n\n## Queued\n'
+    i=1
+    while [ "$i" -le 1800 ]; do
+      printf -- '- [ ] large-%04d - Large inventory portability row %04d with enough repeated title material to exceed a single Linux argv entry (repo: firstmate) (kind: ship)\n' "$i" "$i"
+      i=$((i + 1))
+    done
+    printf '\n## Done\n'
+  } > "$home/data/backlog.md"
+
+  out=$(FM_HOME="$home" "$SNAPSHOT" --json) \
+    || fail "snapshot rejected a large valid backlog"
+  count=$(printf '%s' "$out" | jq '.backlog.records | length')
+  [ "$count" -eq 1800 ] \
+    || fail "large backlog snapshot lost records: expected 1800, got $count"
+  pass "snapshot accepts a backlog larger than one Linux argv entry"
+}
+
 # R1 owner contract: main_inventory discloses orphan in-flight and unstructured
 # current rows without inventing task rows.
 test_main_inventory_orphan_and_unstructured_disclosure() {
@@ -781,6 +804,7 @@ test_parked_scout_decision_stays_pending() {
 
 test_empty_fleet_json
 test_fixture_snapshot_json
+test_large_backlog_snapshot_avoids_argv_limits
 test_main_inventory_orphan_and_unstructured_disclosure
 test_normalized_roles_and_plural_blocker_readiness
 test_event_hints_follow_reconciled_current_state


### PR DESCRIPTION
## Resultado

O resumo da frota agora processa inventários grandes no Linux sem colocar JSON volumoso nos argumentos do `jq`, mantendo o snapshot completo e somente leitura.

## Mudanças

- Transporta os payloads de inventário por stdin com validação explícita da quantidade de entradas.
- Preserva o formato, a ordenação, os limites e as mensagens existentes.
- Adiciona regressões públicas para inventários grandes e mantém cobertura do caminho pequeno.

## Verificação

- Testes direcionados do snapshot e Bearings.
- `bin/fm-lint.sh`.
- Reprodução real com `FM_HOME=/home/rafaelfadel/labs/fm-home bin/fm-bearings-snapshot.sh`.

## Risco

Baixo e localizado na composição JSON do snapshot. A CI ainda depende da aprovação dos workflows pelo mantenedor upstream.