### PR TITLE
fix(bin): scale full-fleet snapshot reads safely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,8 +350,8 @@ jobs:
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"
           snapshot_count=$(printf '%s\n' "$snapshot_output" | grep -c '^ok - ')
-          [ "$snapshot_count" -eq 15 ] || {
-            echo "::error::expected 15 snapshot/fleet-view tests, got $snapshot_count"
+          [ "$snapshot_count" -eq 19 ] || {
+            echo "::error::expected 19 snapshot/fleet-view tests, got $snapshot_count"
             exit 1
           }
 

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -8,10 +8,11 @@
 # drift apart.
 #
 # Most functions are pure, side-effect-free reads of status files: each takes
-# what it needs as arguments and touches no globals beyond the optional
-# FM_CAPTAIN_RE override. Consumers layer their own dedup/marker state on top (the
-# daemon keeps its escalation-digest seen-markers; the watcher keeps its .seen-*
-# signatures).
+# what it needs as arguments and touches no public globals beyond the optional
+# FM_CAPTAIN_RE override. Private _FM_*_RESULT globals carry subprocess-avoidance
+# scratch outputs between this library's _set helpers and their callers. Consumers
+# layer their own dedup/marker state on top (the daemon keeps its escalation-digest
+# seen-markers; the watcher keeps its .seen-* signatures).
 #
 # There are two documented exceptions. The absorb classification
 # (crew_absorb_class and its working/paused wrappers) is NOT a pure status-file

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -332,6 +332,13 @@ _fm_decision_key_transition_allowed() {  # <key> <note>
 _fm_decision_fold_line_set() {  # <open-set> <status-line> <resolve-verb> <held-verb>
   local open=$1 line=$2 resolve=$3 held=$4 verb key note stripped
   _FM_DECISION_FOLD_RESULT=$open
+  # A line without any transition verb cannot alter the open set. This cheap
+  # builtin guard avoids the subprocess-heavy authoritative fold for ordinary
+  # progress history; _fm_decision_fold_line still owns every transition rule.
+  case "$line" in
+    *needs-decision*|*blocked*|*"$resolve"*|*"$held"*) : ;;
+    *) return 0 ;;
+  esac
   stripped=${line//[[:space:]]/}
   [ -n "$stripped" ] || return 0
   _fm_status_line_verb_set "$line"
@@ -378,13 +385,6 @@ status_open_decisions() {  # <status-file>
   resolve=${FM_CLASSIFY_RESOLVE_VERB:-$FM_CLASSIFY_RESOLVE_VERB_DEFAULT}
   held=${FM_CLASSIFY_CAPTAIN_HELD_VERB:-$FM_CLASSIFY_CAPTAIN_HELD_VERB_DEFAULT}
   while IFS= read -r line || [ -n "$line" ]; do
-    # A line without any transition verb cannot alter the open set. This cheap
-    # builtin guard avoids the subprocess-heavy authoritative fold for ordinary
-    # progress history; _fm_decision_fold_line still owns every transition rule.
-    case "$line" in
-      *needs-decision*|*blocked*|*"$resolve"*|*"$held"*) : ;;
-      *) continue ;;
-    esac
     _fm_decision_fold_line_set "$open" "$line" "$resolve" "$held"
     open=$_FM_DECISION_FOLD_RESULT
   done < "$f"

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -180,12 +180,16 @@ status_is_paused_or_captain_held() {  # <status-line>
 # The parsers are pure reads of a single line. Status metadata may contain any
 # number of "[name=value]" tags before the colon, in any order, so verb parsing
 # ends at the first tag rather than special-casing "[key=...]".
-status_line_verb() {  # <status-line> -> leading verb word
+_fm_status_line_verb_set() {  # <status-line> -> _FM_STATUS_LINE_VERB_RESULT
   local v=${1%%:*}
   v=${v%%\[*}
   v=${v#"${v%%[![:space:]]*}"}
   v=${v%"${v##*[![:space:]]}"}
-  printf '%s' "$v"
+  _FM_STATUS_LINE_VERB_RESULT=$v
+}
+status_line_verb() {  # <status-line> -> leading verb word
+  _fm_status_line_verb_set "$1"
+  printf '%s' "$_FM_STATUS_LINE_VERB_RESULT"
 }
 # 0 when a complete "[key=...]" token sits in the documented position before
 # the line's first colon (or anywhere on a line that has no colon at all).
@@ -200,7 +204,7 @@ _fm_key_before_colon() {  # <status-line>
 # the line has no colon or no complete token there; slug charset validity is
 # the caller's check via _fm_decision_slug_ok, exactly as for the before-colon
 # position.
-_fm_key_at_note_head() {  # <status-line> -> raw slug
+_fm_key_at_note_head_set() {  # <status-line> -> _FM_KEY_AT_NOTE_HEAD_RESULT
   local rest
   case "$1" in
     *:*) rest=${1#*:} ;;
@@ -208,9 +212,13 @@ _fm_key_at_note_head() {  # <status-line> -> raw slug
   esac
   rest=${rest#"${rest%%[![:space:]]*}"}
   case "$rest" in
-    \[key=*\]*) rest=${rest#\[key=}; printf '%s' "${rest%%\]*}" ;;
+    \[key=*\]*) rest=${rest#\[key=}; _FM_KEY_AT_NOTE_HEAD_RESULT=${rest%%\]*} ;;
     *) return 1 ;;
   esac
+}
+_fm_key_at_note_head() {  # <status-line> -> raw slug
+  _fm_key_at_note_head_set "$1" || return 1
+  printf '%s' "$_FM_KEY_AT_NOTE_HEAD_RESULT"
 }
 # 0 when a stated key slug is well-formed: nonempty, A-Za-z0-9._- only.
 _fm_decision_slug_ok() {  # <slug>
@@ -219,48 +227,64 @@ _fm_decision_slug_ok() {  # <slug>
     *) return 0 ;;
   esac
 }
-status_line_note() {  # <status-line> -> text after the first colon, trimmed
+_fm_status_line_note_set() {  # <status-line> -> _FM_STATUS_LINE_NOTE_RESULT
   local n k
   case "$1" in
     *:*) n=${1#*:}; n=${n#"${n%%[![:space:]]*}"} ;;
-    *) printf '%s' "$1"; return 0 ;;
+    *) _FM_STATUS_LINE_NOTE_RESULT=$1; return 0 ;;
   esac
   # A note-head token that states this line's key (no before-colon token, valid
   # slug) is key metadata, not note text: strip it so both stated-key positions
   # yield the same note.
-  if ! _fm_key_before_colon "$1" && k=$(_fm_key_at_note_head "$1") \
-    && _fm_decision_slug_ok "$k"; then
+  if ! _fm_key_before_colon "$1" && _fm_key_at_note_head_set "$1" \
+    && k=$_FM_KEY_AT_NOTE_HEAD_RESULT && _fm_decision_slug_ok "$k"; then
     n=${n#"[key=$k]"}
     n=${n#"${n%%[![:space:]]*}"}
   fi
-  printf '%s' "$n"
+  _FM_STATUS_LINE_NOTE_RESULT=$n
 }
-_fm_decision_key() {  # <status-line> -> key slug, or "default" when no token
+status_line_note() {  # <status-line> -> text after the first colon, trimmed
+  _fm_status_line_note_set "$1"
+  printf '%s' "$_FM_STATUS_LINE_NOTE_RESULT"
+}
+_fm_decision_key_set() {  # <status-line> -> _FM_DECISION_KEY_RESULT
   local k
   if _fm_key_before_colon "$1"; then
     k=${1%%:*}
     k=${k#*\[key=}
     k=${k%%\]*}
   else
-    k=$(_fm_key_at_note_head "$1") || { printf 'default'; return 0; }
+    if ! _fm_key_at_note_head_set "$1"; then
+      _FM_DECISION_KEY_RESULT=default
+      return 0
+    fi
+    k=$_FM_KEY_AT_NOTE_HEAD_RESULT
   fi
   _fm_decision_slug_ok "$k" || return 1
-  printf '%s' "$k"
+  _FM_DECISION_KEY_RESULT=$k
+}
+_fm_decision_key() {  # <status-line> -> key slug, or "default" when no token
+  _fm_decision_key_set "$1" || return 1
+  printf '%s' "$_FM_DECISION_KEY_RESULT"
 }
 # Drop the record for <key> from a newline-terminated "<key>\t<verb>\t<note>" set.
 # Portable (no associative arrays) so the fold runs on bash 3.2 as well as 4+.
-_fm_decision_drop() {  # <open-set> <key>
-  local set=$1 key=$2 line out=''
+_fm_decision_drop_set() {  # <open-set> <key> -> _FM_DECISION_DROP_RESULT
+  local set=$1 key=$2 line out='' sep=''
   while IFS= read -r line; do
     [ -n "$line" ] || continue
     case "$line" in
       "$key"$'\t'*) : ;;
-      *) out="${out}${line}"$'\n' ;;
+      *) out="${out}${sep}${line}"; sep=$'\n' ;;
     esac
   done <<EOF
 $set
 EOF
-  printf '%s' "$out"
+  _FM_DECISION_DROP_RESULT=$out
+}
+_fm_decision_drop() {  # <open-set> <key>
+  _fm_decision_drop_set "$1" "$2"
+  [ -n "$_FM_DECISION_DROP_RESULT" ] && printf '%s\n' "$_FM_DECISION_DROP_RESULT"
 }
 # Fold ONE status line into an existing "<key>\t<verb>\t<note>\n"-per-line open
 # set, applying the same needs-decision/blocked-opens, resolved/captain-held-closes
@@ -305,27 +329,35 @@ _fm_decision_key_transition_allowed() {  # <key> <note>
   return 0
 }
 
-_fm_decision_fold_line() {  # <open-set> <status-line> <resolve-verb> <held-verb>
+_fm_decision_fold_line_set() {  # <open-set> <status-line> <resolve-verb> <held-verb>
   local open=$1 line=$2 resolve=$3 held=$4 verb key note stripped
+  _FM_DECISION_FOLD_RESULT=$open
   stripped=${line//[[:space:]]/}
-  [ -n "$stripped" ] || { printf '%s' "$open"; return 0; }
-  verb=$(status_line_verb "$line")
-  key=$(_fm_decision_key "$line") || { printf '%s' "$open"; return 0; }
-  _fm_decision_key_transition_allowed "$key" "$(status_line_note "$line")" \
-    || { printf '%s' "$open"; return 0; }
+  [ -n "$stripped" ] || return 0
+  _fm_status_line_verb_set "$line"
+  verb=$_FM_STATUS_LINE_VERB_RESULT
+  _fm_decision_key_set "$line" || return 0
+  key=$_FM_DECISION_KEY_RESULT
+  _fm_status_line_note_set "$line"
+  note=$_FM_STATUS_LINE_NOTE_RESULT
+  _fm_decision_key_transition_allowed "$key" "$note" || return 0
   case "$verb" in
     needs-decision|blocked)
-      note=$(status_line_note "$line")
-      open=$(_fm_decision_drop "$open" "$key")
+      _fm_decision_drop_set "$open" "$key"
+      open=$_FM_DECISION_DROP_RESULT
       [ -n "$open" ] && open="${open}"$'\n'
-      open="${open}${key}"$'\t'"${verb}"$'\t'"${note}"$'\n'
+      open="${open}${key}"$'\t'"${verb}"$'\t'"${note}"
       ;;
     "$resolve"|"$held")
-      open=$(_fm_decision_drop "$open" "$key")
-      [ -n "$open" ] && open="${open}"$'\n'
+      _fm_decision_drop_set "$open" "$key"
+      open=$_FM_DECISION_DROP_RESULT
       ;;
   esac
-  printf '%s' "$open"
+  _FM_DECISION_FOLD_RESULT=$open
+}
+_fm_decision_fold_line() {  # <open-set> <status-line> <resolve-verb> <held-verb>
+  _fm_decision_fold_line_set "$1" "$2" "$3" "$4"
+  [ -n "$_FM_DECISION_FOLD_RESULT" ] && printf '%s\n' "$_FM_DECISION_FOLD_RESULT"
 }
 
 # Fold the WHOLE status stream into the set of decisions still open. Prints one
@@ -346,7 +378,15 @@ status_open_decisions() {  # <status-file>
   resolve=${FM_CLASSIFY_RESOLVE_VERB:-$FM_CLASSIFY_RESOLVE_VERB_DEFAULT}
   held=${FM_CLASSIFY_CAPTAIN_HELD_VERB:-$FM_CLASSIFY_CAPTAIN_HELD_VERB_DEFAULT}
   while IFS= read -r line || [ -n "$line" ]; do
-    open=$(_fm_decision_fold_line "$open" "$line" "$resolve" "$held")
+    # A line without any transition verb cannot alter the open set. This cheap
+    # builtin guard avoids the subprocess-heavy authoritative fold for ordinary
+    # progress history; _fm_decision_fold_line still owns every transition rule.
+    case "$line" in
+      *needs-decision*|*blocked*|*"$resolve"*|*"$held"*) : ;;
+      *) continue ;;
+    esac
+    _fm_decision_fold_line_set "$open" "$line" "$resolve" "$held"
+    open=$_FM_DECISION_FOLD_RESULT
   done < "$f"
   printf '%s' "$open"
 }
@@ -532,7 +572,8 @@ status_open_decisions_incremental() {  # <status-file>
     resolve=${FM_CLASSIFY_RESOLVE_VERB:-$FM_CLASSIFY_RESOLVE_VERB_DEFAULT}
     held=${FM_CLASSIFY_CAPTAIN_HELD_VERB:-$FM_CLASSIFY_CAPTAIN_HELD_VERB_DEFAULT}
     while IFS= read -r line || [ -n "$line" ]; do
-      open=$(_fm_decision_fold_line "$open" "$line" "$resolve" "$held")
+      _fm_decision_fold_line_set "$open" "$line" "$resolve" "$held"
+      open=$_FM_DECISION_FOLD_RESULT
     done < "$chunk_file"
     rm -f "$chunk_file"
     offset=$size

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -230,8 +230,9 @@ crew_state_json() {  # <id>
       esac
       ;;
   esac
-  jq -n --arg raw "$raw" --arg state "$state" --arg source "$source" --arg detail "$detail" \
-    '{state:$state,source:$source,detail:$detail,raw:$raw}'
+  printf '%s\0' "$state" "$source" "$detail" "$raw" | jq -Rs '
+    split("\u0000") as $fields
+    | {state:$fields[0],source:$fields[1],detail:$fields[2],raw:$fields[3]}'
 }
 
 status_event_json() {  # <status-log>
@@ -242,13 +243,11 @@ status_event_json() {  # <status-log>
     verb=$(status_line_verb "$raw")
     note=$(status_line_note "$raw")
   fi
-  jq -n \
-    --arg path "$log" \
-    --arg raw "$raw" \
-    --arg verb "$verb" \
-    --arg note "$note" \
-    --argjson present "$(bool_json "$present")" \
-    '{path:$path,present:$present,kind:"event_history",last_event:{state:$verb,note:$note,raw:$raw}}'
+  printf '%s\0' "$log" "$raw" "$verb" "$note" | jq -Rs \
+    --argjson present "$(bool_json "$present")" '
+    split("\u0000") as $fields
+    | {path:$fields[0],present:$present,kind:"event_history",
+       last_event:{state:$fields[2],note:$fields[3],raw:$fields[1]}}'
 }
 
 first_pr_url_in_file() {  # <file>

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -181,6 +181,12 @@ bool_json() {
   if [ "$1" = 1 ]; then printf 'true'; else printf 'false'; fi
 }
 
+# Stream JSON documents through stdin instead of expanding them into jq argv.
+# Shell function arguments do not cross exec(2), and printf is a bash builtin.
+json_documents() {
+  printf '%s\n' "$@"
+}
+
 path_present_json() {  # <path>
   local present=0
   [ -e "$1" ] && present=1
@@ -404,7 +410,7 @@ task_json_lines() {
   local meta id kind harness mode yolo project worktree home projects backend target status_log report_path
   local remote_host remote_root remote_state remote_rc remote_home_present
   local pr pr_source event_json current_json endpoint_exists agent_alive meta_json status_json report_json worktree_json home_json
-  local last_event_raw current_state current_source pending_decision blocked_event report_present=0 pr_from_status
+  local current_state current_source pending_decision blocked_event report_present=0 pr_from_status
   local open_decisions_tsv open_decisions_json
 
   for meta in "$STATE"/*.meta; do
@@ -445,7 +451,6 @@ task_json_lines() {
 
     current_json=$(crew_state_json "$id")
     event_json=$(status_event_json "$status_log")
-    last_event_raw=$(printf '%s' "$event_json" | jq -r '.last_event.raw // ""')
     current_state=$(printf '%s' "$current_json" | jq -r '.state // ""')
     current_source=$(printf '%s' "$current_json" | jq -r '.source // ""')
 
@@ -528,7 +533,15 @@ task_json_lines() {
       home_json=$(jq -n '{path:null,present:false}')
     fi
 
-    jq -n \
+    json_documents \
+      "$current_json" \
+      "$meta_json" \
+      "$status_json" \
+      "$report_json" \
+      "$worktree_json" \
+      "$home_json" \
+      "$open_decisions_json" \
+      | jq -s \
       --arg id "$id" \
       --arg kind "$kind" \
       --arg harness "$harness" \
@@ -546,19 +559,18 @@ task_json_lines() {
       --arg pr_source "$pr_source" \
       --arg agent_alive "$agent_alive" \
       --arg observed_at "$SNAPSHOT_NOW" \
-      --arg last_event_raw "$last_event_raw" \
-      --argjson current_state "$current_json" \
-      --argjson meta_path "$meta_json" \
-      --argjson status_log "$status_json" \
-      --argjson report "$report_json" \
-      --argjson worktree_path "$worktree_json" \
-      --argjson home_path "$home_json" \
       --argjson endpoint_exists "$endpoint_exists" \
-      --argjson open_decisions "$open_decisions_json" \
       --argjson pending_decision "$(bool_json "$pending_decision")" \
       --argjson blocked_event "$(bool_json "$blocked_event")" \
       --argjson report_present "$(bool_json "$report_present")" \
-      '{
+      '.[0] as $current_state
+      | .[1] as $meta_path
+      | .[2] as $status_log
+      | .[3] as $report
+      | .[4] as $worktree_path
+      | .[5] as $home_path
+      | .[6] as $open_decisions
+      | {
         id:$id,
         kind:$kind,
         harness:($harness // ""),
@@ -587,7 +599,7 @@ task_json_lines() {
           blocked_event:$blocked_event,
           open_decisions:$open_decisions,
           scout_report_present:$report_present,
-          last_event_text:$last_event_raw
+          last_event_text:($status_log.last_event.raw // "")
         },
         actions:(
           if $kind == "secondmate" then
@@ -608,9 +620,10 @@ task_json_lines() {
 # Meta inventory remains the sole source of live workers; this object only
 # discloses backlog↔task inconsistency for renderers (Bearings omitted/gates).
 main_inventory_json() {  # <backlog-json> <tasks-json>
-  jq -n \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
+  json_documents "$1" "$2" | jq -s '
+    .[0] as $backlog
+    | .[1] as $tasks
+    |
     ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]?
@@ -636,15 +649,16 @@ main_inventory_json() {  # <backlog-json> <tasks-json>
 # This mode never reads parent events or terminal text and never aggregates
 # nested secondmates.
 secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
-  jq -n \
+  json_documents "$1" "$2" | jq -s \
     --arg generated "$SNAPSHOT_NOW" \
     --arg home "$FM_HOME" \
     --argjson child_n "$FM_SNAPSHOT_SECONDMATE_CHILDREN" \
     --argjson queued_n "$FM_SNAPSHOT_SECONDMATE_QUEUED" \
     --argjson decisions_n "$FM_SNAPSHOT_SECONDMATE_DECISIONS" \
-    --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
+    --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" '
+    .[0] as $backlog
+    | .[1] as $tasks
+    |
     def trunc($n):
       tostring | gsub("\\s+"; " ")
       | if length > $n then .[:$n] + "…" else . end;
@@ -1051,7 +1065,11 @@ terminal_evidence_json() {  # <parent-task-json> <event-note> <evidence-contradi
 }
 
 parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <decisions-json>
-  jq -n --argjson summary "$1" --argjson activities "$2" --argjson decisions "$3" '
+  json_documents "$1" "$2" "$3" | jq -s '
+    .[0] as $summary
+    | .[1] as $activities
+    | .[2] as $decisions
+    |
     def keyed: . != null and . != "" and . != "default";
     def result($e; $matches; $complete; $surface):
       $e + {
@@ -1111,12 +1129,15 @@ parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <dec
 }
 
 secondmate_current_json() {  # <parent-tasks-json>
-  local tasks=$1 registry union rows total_registered total shown truncated
+  local tasks=$1 registry registry_json union rows total_registered total shown truncated
   local row id home host remote registered registry_error task status_file event_raw event_note event_epoch event_age
   local activity_scan activities decisions reconciliation provenance freshness reason summary summary_rc summary_bytes summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
   local records='[]' seen_homes=''
   registry=$(registry_secondmates_json) || return 1
-  union=$(jq -n --argjson registry "$registry" --argjson tasks "$tasks" '
+  union=$(json_documents "$registry" "$tasks" | jq -s '
+    .[0] as $registry
+    | .[1] as $tasks
+    |
     ($registry.records // []) as $registered
     | (($registered | map(.id)) // []) as $registered_ids
     | ([ $registered[] as $r
@@ -1246,8 +1267,10 @@ secondmate_current_json() {  # <parent-tasks-json>
       fi
       reconciliation=$(parent_evidence_reconciliation_json "$summary" "$activities" "$decisions")
       contradiction=$(printf '%s' "$reconciliation" | jq -r '.contradiction')
-      terminal_contradiction=$(printf '%s' "$reconciliation" | jq -r --arg note "$event_note" '
-        any(.activities[]; .verdict == "contradicts" and .summary == $note)')
+      terminal_contradiction=$(json_documents "$reconciliation" "$task" | jq -sr '
+        .[0] as $reconciliation
+        | (.[1].paths.status_log.last_event.note // "") as $note
+        | any($reconciliation.activities[]; .verdict == "contradicts" and .summary == $note)')
       if [ "$terminal_contradiction" = true ]; then
         terminal=$(terminal_evidence_json "$task" "$event_note" true)
       else
@@ -1255,12 +1278,28 @@ secondmate_current_json() {  # <parent-tasks-json>
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no useful contradiction check",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
       if printf '%s' "$terminal" | jq -e '.contradiction == true' >/dev/null; then contradiction=true; fi
-      record=$(jq -n \
+      record=$(json_documents \
+        "$summary" \
+        "$decisions" \
+        "$activities" \
+        "$activity_scan" \
+        "$reconciliation" \
+        "$terminal" \
+        "$task" \
+        | jq -s \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg current_reason "$current_reason" --arg observed "$SNAPSHOT_NOW" \
-        --argjson registered "$registered" --argjson summary "$summary" --argjson summary_valid "$summary_valid" --argjson decisions "$decisions" \
-        --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
-        --argjson reconciliation "$reconciliation" --argjson terminal "$terminal" --argjson contradiction "$contradiction" \
-        --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" '
+        --argjson registered "$registered" --argjson summary_valid "$summary_valid" --argjson contradiction "$contradiction" \
+        --argjson event_age "$event_age" '
+        .[0] as $summary
+        | .[1] as $decisions
+        | .[2] as $activities
+        | .[3] as $activity_scan
+        | .[4] as $reconciliation
+        | .[5] as $terminal
+        | .[6] as $task
+        | ($task.paths.status_log.last_event.raw // "") as $event_raw
+        | ($task.paths.status_log.last_event.note // "") as $event_note
+        |
         {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          current:{state:$state,reason:($current_reason | if . == "" then null else . end)},invalidity:$summary.invalidity,
          provenance:{selected:"structured-home",structured_home:$home,summary_valid:$summary_valid,
@@ -1285,11 +1324,24 @@ secondmate_current_json() {  # <parent-tasks-json>
         terminal=$(jq -n --arg observed "$SNAPSHOT_NOW" \
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no parent event to compare",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
-      record=$(jq -n \
+      record=$(json_documents \
+        "$activities" \
+        "$activity_scan" \
+        "$decisions" \
+        "$terminal" \
+        "$task" \
+        | jq -s \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg reason "$reason" --arg observed "$SNAPSHOT_NOW" \
-        --arg provenance "$provenance" --arg freshness "$freshness" --arg event_raw "$event_raw" --arg event_note "$event_note" \
-        --argjson registered "$registered" --argjson event_age "$event_age" --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
-        --argjson decisions "$decisions" --argjson terminal "$terminal" '
+        --arg provenance "$provenance" --arg freshness "$freshness" \
+        --argjson registered "$registered" --argjson event_age "$event_age" '
+        .[0] as $activities
+        | .[1] as $activity_scan
+        | .[2] as $decisions
+        | .[3] as $terminal
+        | .[4] as $task
+        | ($task.paths.status_log.last_event.raw // "") as $event_raw
+        | ($task.paths.status_log.last_event.note // "") as $event_note
+        |
         {id:$id,home:($home | if . == "" then null else . end),host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          current:{state:"unknown",reason:$reason},invalidity:null,
          provenance:{selected:$provenance,structured_home:($home | if . == "" then null else . end),parent_event_role:"fallback-only-not-current"},
@@ -1298,22 +1350,25 @@ secondmate_current_json() {  # <parent-tasks-json>
          parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan},
          terminal_evidence:$terminal,contradiction:false}')
     fi
-    records=$(jq -n --argjson records "$records" --argjson record "$record" '$records + [$record]')
+    records=$(json_documents "$records" "$record" | jq -s '.[0] + [.[1]]')
   done <<EOF
 $rows
 EOF
-  jq -n \
-    --argjson registry "$(printf '%s' "$union" | jq '.registry')" \
-    --argjson records "$records" \
+  registry_json=$(printf '%s' "$union" | jq '.registry')
+  json_documents "$registry_json" "$records" | jq -s \
     --argjson total_registered "$total_registered" \
     --argjson total "$total" \
     --argjson shown "$shown" \
     --argjson truncated "$truncated" \
-    '{registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
+    '.[0] as $registry
+     | .[1] as $records
+     | {registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
 }
 
 secondmate_landed_from_current_json() {  # <secondmate-current-json>
-  jq -n --argjson current "$1" '
+  json_documents "$1" | jq -s '
+    .[0] as $current
+    |
     {records:[ $current.records[]
       | select(.provenance.selected == "structured-home") as $mate
       | $mate.landed[]
@@ -1362,7 +1417,14 @@ SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON") \
 SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON") \
   || { echo "fm-fleet-snapshot: secondmate landed projection failed" >&2; exit 1; }
 
-jq -n \
+json_documents \
+  "$BACKLOG_JSON" \
+  "$TASKS_JSON" \
+  "$MAIN_INVENTORY_JSON" \
+  "$SCOUT_REPORTS_JSON" \
+  "$SECONDMATE_CURRENT_JSON" \
+  "$SECONDMATE_LANDED_JSON" \
+  | jq -s \
   --arg generated "$SNAPSHOT_NOW" \
   --arg fm_home "$FM_HOME" \
   --arg fm_root "$FM_ROOT" \
@@ -1370,13 +1432,13 @@ jq -n \
   --arg data "$DATA" \
   --arg config "$CONFIG" \
   --arg projects "$PROJECTS" \
-  --argjson backlog "$BACKLOG_JSON" \
-  --argjson tasks "$TASKS_JSON" \
-  --argjson main_inventory "$MAIN_INVENTORY_JSON" \
-  --argjson scout_reports "$SCOUT_REPORTS_JSON" \
-  --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
-  --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
-  'def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
+  '.[0] as $backlog
+   | .[1] as $tasks
+   | .[2] as $main_inventory
+   | .[3] as $scout_reports
+   | .[4] as $secondmate_current
+   | .[5] as $secondmate_landed
+   | def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");
    {

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -187,11 +187,16 @@ json_documents() {
   printf '%s\n' "$@"
 }
 
+path_presence_json() {  # <path> <present-json>
+  printf '%s\0' "$1" | jq -Rs --argjson present "$2" '
+    split("\u0000")[0] as $path
+    | {path:$path,present:$present}'
+}
+
 path_present_json() {  # <path>
-  local present=0
-  [ -e "$1" ] && present=1
-  jq -n --arg path "$1" --argjson present "$(bool_json "$present")" \
-    '{path:$path,present:$present}'
+  local present=false
+  [ -e "$1" ] && present=true
+  path_presence_json "$1" "$present"
 }
 
 meta_value() {  # <meta-file> <key>
@@ -408,7 +413,7 @@ backlog_json() {  # [<backlog-path>] - defaults to this home's $BACKLOG
 task_json_lines() {
   local meta id kind harness mode yolo project worktree home projects backend target status_log report_path
   local remote_host remote_root remote_state remote_rc remote_home_present
-  local pr pr_source event_json current_json endpoint_exists agent_alive meta_json status_json report_json worktree_json home_json
+  local pr pr_source event_json current_json endpoint_exists agent_alive meta_json status_json report_json worktree_json home_json task_fields_json
   local current_state current_source pending_decision blocked_event report_present=0 pr_from_status
   local open_decisions_tsv open_decisions_json
 
@@ -525,14 +530,25 @@ task_json_lines() {
     report_json=$(path_present_json "$report_path")
     if [ -n "$worktree" ]; then worktree_json=$(path_present_json "$worktree"); else worktree_json=$(jq -n '{path:null,present:false}'); fi
     if [ -n "$home" ] && [ -n "$remote_host" ]; then
-      home_json=$(jq -n --arg path "$home" --argjson present "$remote_home_present" '{path:$path,present:$present}')
+      home_json=$(path_presence_json "$home" "$remote_home_present")
     elif [ -n "$home" ]; then
       home_json=$(path_present_json "$home")
     else
       home_json=$(jq -n '{path:null,present:false}')
     fi
+    task_fields_json=$(printf '%s\0' \
+      "$id" "$kind" "$harness" "$mode" "$yolo" "$project" "$projects" \
+      "$backend" "$target" "$remote_host" "$remote_root" "$pr" "$pr_source" \
+      "$agent_alive" "$SNAPSHOT_NOW" | jq -Rs '
+      split("\u0000") as $fields
+      | {id:$fields[0],kind:$fields[1],harness:$fields[2],mode:$fields[3],
+         yolo:$fields[4],project:$fields[5],projects:$fields[6],backend:$fields[7],
+         target:$fields[8],remote_host:$fields[9],remote_root:$fields[10],
+         pr:$fields[11],pr_source:$fields[12],agent_alive:$fields[13],
+         observed_at:$fields[14]}')
 
     json_documents \
+      "$task_fields_json" \
       "$current_json" \
       "$meta_json" \
       "$status_json" \
@@ -541,43 +557,27 @@ task_json_lines() {
       "$home_json" \
       "$open_decisions_json" \
       | jq -s \
-      --arg id "$id" \
-      --arg kind "$kind" \
-      --arg harness "$harness" \
-      --arg mode "$mode" \
-      --arg yolo "$yolo" \
-      --arg project "$project" \
-      --arg worktree "$worktree" \
-      --arg home "$home" \
-      --arg projects "$projects" \
-      --arg backend "$backend" \
-      --arg target "$target" \
-      --arg remote_host "$remote_host" \
-      --arg remote_root "$remote_root" \
-      --arg pr "$pr" \
-      --arg pr_source "$pr_source" \
-      --arg agent_alive "$agent_alive" \
-      --arg observed_at "$SNAPSHOT_NOW" \
       --argjson endpoint_exists "$endpoint_exists" \
       --argjson pending_decision "$(bool_json "$pending_decision")" \
       --argjson blocked_event "$(bool_json "$blocked_event")" \
       --argjson report_present "$(bool_json "$report_present")" \
-      '.[0] as $current_state
-      | .[1] as $meta_path
-      | .[2] as $status_log
-      | .[3] as $report
-      | .[4] as $worktree_path
-      | .[5] as $home_path
-      | .[6] as $open_decisions
+      '.[0] as $fields
+      | .[1] as $current_state
+      | .[2] as $meta_path
+      | .[3] as $status_log
+      | .[4] as $report
+      | .[5] as $worktree_path
+      | .[6] as $home_path
+      | .[7] as $open_decisions
       | {
-        id:$id,
-        kind:$kind,
-        harness:($harness // ""),
-        mode:($mode // ""),
-        yolo:($yolo // ""),
-        project:($project // ""),
-        backend:$backend,
-        remote:(if $remote_host == "" then null else {host:$remote_host,root:$remote_root} end),
+        id:$fields.id,
+        kind:$fields.kind,
+        harness:($fields.harness // ""),
+        mode:($fields.mode // ""),
+        yolo:($fields.yolo // ""),
+        project:($fields.project // ""),
+        backend:$fields.backend,
+        remote:(if $fields.remote_host == "" then null else {host:$fields.remote_host,root:$fields.remote_root} end),
         paths:{
           meta:$meta_path,
           status_log:$status_log,
@@ -585,14 +585,14 @@ task_json_lines() {
           home:$home_path,
           report:$report
         },
-        secondmate_projects:($projects | if . == "" then [] else split(",") | map(gsub("^[[:space:]]+|[[:space:]]+$"; "")) | map(select(. != "")) end),
-        current_state:($current_state + {observed_at:$observed_at,freshness:"fresh"}),
-        endpoint:{target:($target | if . == "" then null else . end),exists:$endpoint_exists,agent_alive:$agent_alive,
+        secondmate_projects:($fields.projects | if . == "" then [] else split(",") | map(gsub("^[[:space:]]+|[[:space:]]+$"; "")) | map(select(. != "")) end),
+        current_state:($current_state + {observed_at:$fields.observed_at,freshness:"fresh"}),
+        endpoint:{target:($fields.target | if . == "" then null else . end),exists:$endpoint_exists,agent_alive:$fields.agent_alive,
           status:(if $endpoint_exists == false then "absent"
-                  elif $agent_alive == "alive" or $agent_alive == "dead" then $agent_alive
+                  elif $fields.agent_alive == "alive" or $fields.agent_alive == "dead" then $fields.agent_alive
                   else "unknown" end),
-          observed_at:$observed_at,freshness:"fresh"},
-        pr:{url:($pr | if . == "" then null else . end),source:$pr_source},
+          observed_at:$fields.observed_at,freshness:"fresh"},
+        pr:{url:($fields.pr | if . == "" then null else . end),source:$fields.pr_source},
         hints:{
           pending_decision:$pending_decision,
           blocked_event:$blocked_event,
@@ -601,13 +601,13 @@ task_json_lines() {
           last_event_text:($status_log.last_event.raw // "")
         },
         actions:(
-          if $kind == "secondmate" then
-            {send:"bin/fm-send.sh fm-\($id) \u0027<request>\u0027",
+          if $fields.kind == "secondmate" then
+            {send:"bin/fm-send.sh fm-\($fields.id) \u0027<request>\u0027",
              watch:"read status/doc return channel; do not routinely fm-peek a secondmate for answers",
              return_channel_note:"Secondmate answers come back through status/doc paths after a marked fm-send request."}
           else
-            {watch:"bin/fm-peek.sh fm-\($id)",
-             steer:"bin/fm-send.sh fm-\($id) \u0027<instruction>\u0027",
+            {watch:"bin/fm-peek.sh fm-\($fields.id)",
+             steer:"bin/fm-send.sh fm-\($fields.id) \u0027<instruction>\u0027",
              return_channel_note:null}
           end)
       }'
@@ -1131,6 +1131,7 @@ secondmate_current_json() {  # <parent-tasks-json>
   local tasks=$1 registry registry_json union rows total_registered total shown truncated
   local row id home host remote registered registry_error task status_file event_raw event_note event_epoch event_age
   local activity_scan activities decisions reconciliation provenance freshness reason summary summary_rc summary_bytes summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
+  local validation_fields_json record_fields_json
   local records='[]' seen_homes=''
   registry=$(registry_secondmates_json) || return 1
   union=$(json_documents "$registry" "$tasks" | jq -s '
@@ -1234,24 +1235,31 @@ secondmate_current_json() {  # <parent-tasks-json>
         summary_bytes=$(printf '%s' "$summary" | LC_ALL=C wc -c | tr -d ' ')
         if [ "$summary_bytes" -gt "$FM_SNAPSHOT_SECONDMATE_MAX_BYTES" ]; then
           reason="structured home snapshot exceeded byte limit"
-        elif ! printf '%s' "$summary" | jq -e --arg home "$home" --arg generated "$SNAPSHOT_NOW" --argjson remote "$remote" '
-          .schema == "fm-secondmate-home-summary.v1" and .home == $home
-          and (($remote == true) or .generated == $generated)
-          and (.valid | type) == "boolean" and (.state | type) == "string"
-          and (.invalidity | type) == "object" and (.invalidity.ids | type) == "array"
-          and (.active_children | type) == "array" and (.decisions_open | type) == "array"
-          and (.holds | type) == "array" and (.queued | type) == "array"
-          and (.landed | type) == "array" and (.endpoints | type) == "array"
-          and (.counts | type) == "object" and (.omitted | type) == "array"
-        ' >/dev/null 2>&1; then
-          reason="structured home snapshot was malformed or stale"
         else
-          summary_valid=$(printf '%s' "$summary" | jq -r '.valid')
-          if [ "$summary_valid" != true ]; then
-            summary_reason=$(printf '%s' "$summary" | jq -r '.reason // "unknown reason"')
-            summary_invalidity=$(printf '%s' "$summary" | jq -r '.invalidity.kind // "unknown"')
-            if [ "$summary_invalidity" != child_current_unavailable ]; then
-              reason="structured home state invalid: $summary_reason"
+          validation_fields_json=$(printf '%s\0' "$home" "$SNAPSHOT_NOW" | jq -Rs '
+            split("\u0000") as $fields
+            | {home:$fields[0],generated:$fields[1]}')
+          if ! json_documents "$summary" "$validation_fields_json" | jq -e --argjson remote "$remote" '
+            .[0] as $summary
+            | .[1] as $fields
+            | $summary.schema == "fm-secondmate-home-summary.v1" and $summary.home == $fields.home
+            and (($remote == true) or $summary.generated == $fields.generated)
+            and ($summary.valid | type) == "boolean" and ($summary.state | type) == "string"
+            and ($summary.invalidity | type) == "object" and ($summary.invalidity.ids | type) == "array"
+            and ($summary.active_children | type) == "array" and ($summary.decisions_open | type) == "array"
+            and ($summary.holds | type) == "array" and ($summary.queued | type) == "array"
+            and ($summary.landed | type) == "array" and ($summary.endpoints | type) == "array"
+            and ($summary.counts | type) == "object" and ($summary.omitted | type) == "array"
+          ' >/dev/null 2>&1; then
+            reason="structured home snapshot was malformed or stale"
+          else
+            summary_valid=$(printf '%s' "$summary" | jq -r '.valid')
+            if [ "$summary_valid" != true ]; then
+              summary_reason=$(printf '%s' "$summary" | jq -r '.reason // "unknown reason"')
+              summary_invalidity=$(printf '%s' "$summary" | jq -r '.invalidity.kind // "unknown"')
+              if [ "$summary_invalidity" != child_current_unavailable ]; then
+                reason="structured home state invalid: $summary_reason"
+              fi
             fi
           fi
         fi
@@ -1277,7 +1285,12 @@ secondmate_current_json() {  # <parent-tasks-json>
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no useful contradiction check",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
       if printf '%s' "$terminal" | jq -e '.contradiction == true' >/dev/null; then contradiction=true; fi
+      record_fields_json=$(printf '%s\0' "$id" "$home" "$host" "$state" "$current_reason" "$SNAPSHOT_NOW" | jq -Rs '
+        split("\u0000") as $fields
+        | {id:$fields[0],home:$fields[1],host:$fields[2],state:$fields[3],
+           current_reason:$fields[4],observed_at:$fields[5]}')
       record=$(json_documents \
+        "$record_fields_json" \
         "$summary" \
         "$decisions" \
         "$activities" \
@@ -1286,24 +1299,25 @@ secondmate_current_json() {  # <parent-tasks-json>
         "$terminal" \
         "$task" \
         | jq -s \
-        --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg current_reason "$current_reason" --arg observed "$SNAPSHOT_NOW" \
+        --argjson remote "$remote" \
         --argjson registered "$registered" --argjson summary_valid "$summary_valid" --argjson contradiction "$contradiction" \
         --argjson event_age "$event_age" '
-        .[0] as $summary
-        | .[1] as $decisions
-        | .[2] as $activities
-        | .[3] as $activity_scan
-        | .[4] as $reconciliation
-        | .[5] as $terminal
-        | .[6] as $task
+        .[0] as $fields
+        | .[1] as $summary
+        | .[2] as $decisions
+        | .[3] as $activities
+        | .[4] as $activity_scan
+        | .[5] as $reconciliation
+        | .[6] as $terminal
+        | .[7] as $task
         | ($task.paths.status_log.last_event.raw // "") as $event_raw
         | ($task.paths.status_log.last_event.note // "") as $event_note
         |
-        {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
-         current:{state:$state,reason:($current_reason | if . == "" then null else . end)},invalidity:$summary.invalidity,
-         provenance:{selected:"structured-home",structured_home:$home,summary_valid:$summary_valid,
+        {id:$fields.id,home:$fields.home,host:($fields.host | if . == "" then null else . end),remote:$remote,registered:$registered,
+         current:{state:$fields.state,reason:($fields.current_reason | if . == "" then null else . end)},invalidity:$summary.invalidity,
+         provenance:{selected:"structured-home",structured_home:$fields.home,summary_valid:$summary_valid,
            trust:(if $summary_valid then "complete" else "partial-structured" end),parent_event_role:"historical-only"},
-         freshness:{status:"fresh",observed_at:$observed,age_seconds:0},
+         freshness:{status:"fresh",observed_at:$fields.observed_at,age_seconds:0},
          active_children:$summary.active_children,
          decisions_open:$summary.decisions_open,holds:$summary.holds,queued:$summary.queued,
          landed:$summary.landed,endpoints:$summary.endpoints,counts:$summary.counts,omitted:$summary.omitted,
@@ -1323,28 +1337,33 @@ secondmate_current_json() {  # <parent-tasks-json>
         terminal=$(jq -n --arg observed "$SNAPSHOT_NOW" \
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no parent event to compare",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
+      record_fields_json=$(printf '%s\0' "$id" "$home" "$host" "$reason" "$SNAPSHOT_NOW" "$provenance" "$freshness" | jq -Rs '
+        split("\u0000") as $fields
+        | {id:$fields[0],home:$fields[1],host:$fields[2],reason:$fields[3],
+           observed_at:$fields[4],provenance:$fields[5],freshness:$fields[6]}')
       record=$(json_documents \
+        "$record_fields_json" \
         "$activities" \
         "$activity_scan" \
         "$decisions" \
         "$terminal" \
         "$task" \
         | jq -s \
-        --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg reason "$reason" --arg observed "$SNAPSHOT_NOW" \
-        --arg provenance "$provenance" --arg freshness "$freshness" \
+        --argjson remote "$remote" \
         --argjson registered "$registered" --argjson event_age "$event_age" '
-        .[0] as $activities
-        | .[1] as $activity_scan
-        | .[2] as $decisions
-        | .[3] as $terminal
-        | .[4] as $task
+        .[0] as $fields
+        | .[1] as $activities
+        | .[2] as $activity_scan
+        | .[3] as $decisions
+        | .[4] as $terminal
+        | .[5] as $task
         | ($task.paths.status_log.last_event.raw // "") as $event_raw
         | ($task.paths.status_log.last_event.note // "") as $event_note
         |
-        {id:$id,home:($home | if . == "" then null else . end),host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
-         current:{state:"unknown",reason:$reason},invalidity:null,
-         provenance:{selected:$provenance,structured_home:($home | if . == "" then null else . end),parent_event_role:"fallback-only-not-current"},
-         freshness:{status:$freshness,observed_at:$observed,age_seconds:$event_age},
+        {id:$fields.id,home:($fields.home | if . == "" then null else . end),host:($fields.host | if . == "" then null else . end),remote:$remote,registered:$registered,
+         current:{state:"unknown",reason:$fields.reason},invalidity:null,
+         provenance:{selected:$fields.provenance,structured_home:($fields.home | if . == "" then null else . end),parent_event_role:"fallback-only-not-current"},
+         freshness:{status:$fields.freshness,observed_at:$fields.observed_at,age_seconds:$event_age},
          active_children:[],decisions_open:[],holds:[],queued:[],landed:[],endpoints:[],counts:{active_children:0,decisions_open:0,holds:0,queued:0,landed:0,endpoints:0},omitted:[],
          parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan},
          terminal_evidence:$terminal,contradiction:false}')

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -177,6 +177,51 @@ esac
 
 command -v jq >/dev/null 2>&1 || { echo "fm-fleet-snapshot: jq not found" >&2; exit 1; }
 
+# Raw no-mistakes query reuse lives only for this process tree. Each invocation
+# creates a fresh private directory outside the operational home, passes it only
+# to its task-local current-state readers, and removes it on every normal or
+# signalled exit. If private temporary storage is unavailable, reads retain the
+# prior uncached behavior and failure semantics.
+NM_SNAPSHOT_CACHE_DIR=
+NM_SNAPSHOT_CACHE_TOKEN=
+snapshot_nm_cache_cleanup() {
+  local owner=
+  [ -n "$NM_SNAPSHOT_CACHE_DIR" ] || return 0
+  [ -f "$NM_SNAPSHOT_CACHE_DIR/.owner" ] && [ ! -L "$NM_SNAPSHOT_CACHE_DIR/.owner" ] \
+    || return 0
+  IFS= read -r owner < "$NM_SNAPSHOT_CACHE_DIR/.owner" 2>/dev/null || return 0
+  [ "$owner" = "$NM_SNAPSHOT_CACHE_TOKEN" ] || return 0
+  rm -rf -- "$NM_SNAPSHOT_CACHE_DIR"
+  NM_SNAPSHOT_CACHE_DIR=
+}
+snapshot_nm_cache_init() {
+  local base=${TMPDIR:-/tmp} base_real home_real
+  base_real=$(cd "$base" 2>/dev/null && pwd -P) || base_real=
+  home_real=$(cd "$FM_HOME" 2>/dev/null && pwd -P) || home_real=$FM_HOME
+  case "$base_real" in
+    "$home_real"|"$home_real"/*)
+      base=/tmp
+      base_real=$(cd "$base" 2>/dev/null && pwd -P) || return 0
+      case "$base_real" in "$home_real"|"$home_real"/*) return 0 ;; esac
+      ;;
+  esac
+  NM_SNAPSHOT_CACHE_DIR=$(umask 077; mktemp -d "$base/fm-nm-snapshot.XXXXXX" 2>/dev/null) \
+    || NM_SNAPSHOT_CACHE_DIR=
+  [ -n "$NM_SNAPSHOT_CACHE_DIR" ] || return 0
+  NM_SNAPSHOT_CACHE_TOKEN="$$:$RANDOM"
+  if ! (umask 077; printf '%s\n' "$NM_SNAPSHOT_CACHE_TOKEN" > "$NM_SNAPSHOT_CACHE_DIR/.owner"); then
+    rm -rf -- "$NM_SNAPSHOT_CACHE_DIR"
+    NM_SNAPSHOT_CACHE_DIR=
+    NM_SNAPSHOT_CACHE_TOKEN=
+    return 0
+  fi
+  trap snapshot_nm_cache_cleanup EXIT
+  trap 'exit 129' HUP
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+}
+snapshot_nm_cache_init
+
 bool_json() {
   if [ "$1" = 1 ]; then printf 'true'; else printf 'false'; fi
 }
@@ -217,6 +262,8 @@ crew_state_json() {  # <id>
       FM_DATA_OVERRIDE="$DATA" \
       FM_PROJECTS_OVERRIDE="$PROJECTS" \
       FM_CONFIG_OVERRIDE="$CONFIG" \
+      FM_NM_SNAPSHOT_CACHE_DIR="$NM_SNAPSHOT_CACHE_DIR" \
+      FM_NM_SNAPSHOT_CACHE_TOKEN="$NM_SNAPSHOT_CACHE_TOKEN" \
       "$SCRIPT_DIR/fm-crew-state.sh" "$id" 2>/dev/null || true
   )
   raw=$(printf '%s\n' "$raw" | head -1)

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -1239,7 +1239,7 @@ secondmate_current_json() {  # <parent-tasks-json>
           validation_fields_json=$(printf '%s\0' "$home" "$SNAPSHOT_NOW" | jq -Rs '
             split("\u0000") as $fields
             | {home:$fields[0],generated:$fields[1]}')
-          if ! json_documents "$summary" "$validation_fields_json" | jq -e --argjson remote "$remote" '
+          if ! json_documents "$summary" "$validation_fields_json" | jq -se --argjson remote "$remote" '
             .[0] as $summary
             | .[1] as $fields
             | $summary.schema == "fm-secondmate-home-summary.v1" and $summary.home == $fields.home

--- a/bin/fm-nm-run-lib.sh
+++ b/bin/fm-nm-run-lib.sh
@@ -52,7 +52,7 @@ fm_nm_snapshot_query() {  # <dir> <timeout_secs> <args...>
     common=$(cd "$common" 2>/dev/null && pwd -P) || return 1
     branch=$(git -C "$dir" symbolic-ref --quiet --short HEAD 2>/dev/null) || return 1
     head=$(git -C "$dir" rev-parse --verify HEAD 2>/dev/null) || return 1
-  elif [ "$#" -eq 3 ] && [ "$1" = runs ] && [ "$2" = --limit ]; then
+  elif [ "$#" -eq 3 ] && [ "$1" = runs ] && [ "$2" = --limit ] && [ "$3" = 200 ]; then
     query=coarse
     common=$(git -C "$dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
     common=$(cd "$common" 2>/dev/null && pwd -P) || return 1

--- a/bin/fm-nm-run-lib.sh
+++ b/bin/fm-nm-run-lib.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Shared no-mistakes axi run attribution primitives.
+# Shared no-mistakes run attribution and snapshot-local query primitives.
 #
 # ONE owner for the branch+code-identity matching rule that decides whether a
 # no-mistakes run belongs to a given worktree, used by fm-crew-state.sh

--- a/bin/fm-nm-run-lib.sh
+++ b/bin/fm-nm-run-lib.sh
@@ -30,7 +30,77 @@ fm_nm_run_checked() {  # <dir> <timeout_secs> <args...>
   fm_nm_run_bounded "$@" 2>/dev/null
 }
 
+# Fleet snapshots give each fm-crew-state.sh child the same private temporary
+# directory and owner token. Only the two raw read-only queries used for run
+# attribution participate. The primary result is bound to the canonical
+# repository, branch, and current worktree HEAD; the coarse result is bound to
+# the canonical repository. Exact key bytes are compared before reuse, so file
+# names are never an identity proof.
+fm_nm_snapshot_query() {  # <dir> <timeout_secs> <args...>
+  local dir=$1 timeout_secs=$2 cache=${FM_NM_SNAPSHOT_CACHE_DIR:-}
+  local token=${FM_NM_SNAPSHOT_CACHE_TOKEN:-} owner query common branch='' head=''
+  local candidate entry=1 prefix output_tmp
+  shift 2
+  [ -n "$cache" ] && [ -n "$token" ] && [ -d "$cache" ] && [ ! -L "$cache" ] || return 1
+  [ -f "$cache/.owner" ] && [ ! -L "$cache/.owner" ] || return 1
+  IFS= read -r owner < "$cache/.owner" 2>/dev/null || return 1
+  [ "$owner" = "$token" ] || return 1
+
+  if [ "$#" -eq 2 ] && [ "$1" = axi ] && [ "$2" = status ]; then
+    query=primary
+    common=$(git -C "$dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+    common=$(cd "$common" 2>/dev/null && pwd -P) || return 1
+    branch=$(git -C "$dir" symbolic-ref --quiet --short HEAD 2>/dev/null) || return 1
+    head=$(git -C "$dir" rev-parse --verify HEAD 2>/dev/null) || return 1
+  elif [ "$#" -eq 3 ] && [ "$1" = runs ] && [ "$2" = --limit ]; then
+    query=coarse
+    common=$(git -C "$dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+    common=$(cd "$common" 2>/dev/null && pwd -P) || return 1
+  else
+    return 1
+  fi
+
+  umask 077
+  candidate="$cache/.key.$$"
+  printf '%s\0%s\0%s\0%s\0' "$query" "$common" "$branch" "$head" > "$candidate" || return 1
+  while :; do
+    prefix="$cache/query-$entry"
+    if [ -f "$prefix.key" ]; then
+      if cmp -s "$candidate" "$prefix.key"; then
+        rm -f "$candidate"
+        if [ -f "$prefix.ready" ] && [ -f "$prefix.out" ]; then
+          cat "$prefix.out"
+          return 0
+        fi
+        break
+      fi
+    else
+      if mv "$candidate" "$prefix.key" 2>/dev/null; then
+        candidate=
+        break
+      fi
+    fi
+    entry=$((entry + 1))
+  done
+  [ -n "$candidate" ] && rm -f "$candidate"
+
+  output_tmp="$cache/.out.$$"
+  : > "$output_tmp" || return 1
+  fm_nm_run_checked "$dir" "$timeout_secs" "$@" > "$output_tmp" || true
+  if mv "$output_tmp" "$prefix.out" 2>/dev/null; then
+    : > "$prefix.ready" || true
+    cat "$prefix.out"
+  else
+    cat "$output_tmp"
+    rm -f "$output_tmp"
+  fi
+  return 0
+}
+
 fm_nm_run() {  # <dir> <timeout_secs> <args...>
+  if fm_nm_snapshot_query "$@"; then
+    return 0
+  fi
   fm_nm_run_checked "$@" || true
 }
 

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -931,9 +931,11 @@ families_for_changed_path() {
     bin/fm-nm-run-lib.sh)
       # Shared no-mistakes run-attribution primitives, sourced by both
       # bin/fm-crew-state.sh (pure-contract-unit) and bin/fm-teardown.sh's
-      # pre-teardown run abort (pr-forge).
+      # pre-teardown run abort (pr-forge). Fleet snapshots also use its
+      # snapshot-local raw-query reuse path through fm-crew-state.sh.
       printf '%s\n' pure-contract-unit
       printf '%s\n' pr-forge
+      printf '%s\n' snapshot-bearings
       ;;
     bin/fm-composer-lib.sh)
       # The shared shape catalogue is vendor-rendered signal; a change to it

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -78,7 +78,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-supervisor-target-lib.sh` | Resolve the shared supervisor target and backend for the daemon and launcher       |
 | `fm-supervise-daemon.sh` | Presence-gated away-mode sub-supervisor: self-handle routine wakes, guard injection by the detected primary harness, escalate batched digests, alert on failed delivery |
 | `fm-crew-state.sh`       | Print one deterministic current-state line for a crew                                |
-| `fm-nm-run-lib.sh`       | Shared branch-and-code-identity attribution for no-mistakes runs                    |
+| `fm-nm-run-lib.sh`       | Shared no-mistakes run attribution and snapshot-local raw-query reuse               |
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification          |
 | `fm-timeout-lib.sh`      | Single owner of hard-bounded command execution and its fallback watchdog |
 | `fm-timing-lib.sh`       | Single owner of the deferred network stage's per-step elapsed-time records, inert unless a run asks for them |

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -29,15 +29,18 @@ for arg in "$@"; do
   if [ "$prev" = "-t" ]; then target=$arg; fi
   prev=$arg
 done
+case "$target" in
+  *11-secondmate*) exit 1 ;;
+esac
 case "${1:-}" in
   list-windows)
-    sed -n 's/^window=[^:]*://p' "${FM_HOME:?}"/state/*.meta
+    sed -n 's/^window=[^:]*://p' "${FM_HOME:?}"/state/*.meta | sed '/^fm-11-secondmate$/d'
     ;;
   display-message)
     case "$*" in
       *pane_current_command*)
         case "$target" in
-          *dead-secondmate*) printf 'zsh\n' ;;
+          *dead-secondmate*|*10-secondmate*) printf 'zsh\n' ;;
           *) printf 'codex\n' ;;
         esac
         ;;
@@ -367,6 +370,7 @@ test_snapshot_reuses_raw_no_mistakes_queries_per_identity() {
   printf 'blocked [key=network]: task a remains independently blocked\n' > "$home/state/01-ship-a-blocked.status"
   printf 'done: task a duplicate is independently complete\n' > "$home/state/02-ship-a-done.status"
   printf 'needs-decision [key=shape]: task b awaits its own decision\n' > "$home/state/03-ship-b-decision.status"
+  printf 'working: task b continued unrelated setup\n' >> "$home/state/03-ship-b-decision.status"
   printf 'failed: task b duplicate failed independently\n' > "$home/state/04-ship-b-failed.status"
   printf 'working: task c keeps its own current event\n' > "$home/state/05-ship-c-working.status"
   printf 'paused: detached task keeps its own external wait\n' > "$home/state/06-ship-detached.status"
@@ -391,7 +395,7 @@ case "${1:-}" in
     printf 'branch: %s\nhead: %s\nstatus: running\n' "$branch" "${FM_FAKE_NM_UNPROVABLE_HEAD:?}"
     ;;
   runs)
-    printf 'coarse\t%s\n' "$common" >> "${FM_FAKE_NM_CALLS:?}"
+    printf 'coarse\t%s\t%s\n' "$common" "${3:-}" >> "${FM_FAKE_NM_CALLS:?}"
     sleep "${FM_FAKE_NM_LATENCY:-0.04}"
     printf 'running scale-a %s 2026-08-11\n' "${FM_FAKE_NM_UNPROVABLE_HEAD:?}"
     printf 'running scale-b %s 2026-08-11\n' "${FM_FAKE_NM_UNPROVABLE_HEAD:?}"
@@ -444,7 +448,7 @@ SH
     || fail "snapshot-local query reuse changed task-local public current-state bytes"
 
   primary_calls=$(awk -F '\t' '$1 == "primary" {n++} END {print n+0}' "$calls")
-  coarse_calls=$(awk -F '\t' '$1 == "coarse" {n++} END {print n+0}' "$calls")
+  coarse_calls=$(awk -F '\t' '$1 == "coarse" && $3 == "200" {n++} END {print n+0}' "$calls")
   total_calls=$(wc -l < "$calls" | tr -d ' ')
   [ "$primary_calls" -eq 3 ] \
     || fail "expected one primary query per exact identity, got $primary_calls: $(cat "$calls")"
@@ -467,15 +471,50 @@ SH
       and ([.tasks[].kind] | map(select(. == "ship")) | length) == 7
       and ([.tasks[].kind] | map(select(. == "scout")) | length) == 1
       and ([.tasks[].kind] | map(select(. == "secondmate")) | length) == 3
-      and task("01-ship-a-blocked").current_state.state == "blocked"
-      and task("02-ship-a-done").current_state.state == "done"
-      and task("03-ship-b-decision").current_state.state == "parked"
-      and task("04-ship-b-failed").current_state.state == "failed"
-      and task("05-ship-c-working").current_state.state == "working"
-      and all(.tasks[:5][]; .current_state.source == "status-log")
+      and ([.tasks[] | {id, state:.current_state.state, source:.current_state.source}] == [
+        {id:"01-ship-a-blocked", state:"blocked", source:"status-log"},
+        {id:"02-ship-a-done", state:"done", source:"status-log"},
+        {id:"03-ship-b-decision", state:"working", source:"status-log"},
+        {id:"04-ship-b-failed", state:"failed", source:"status-log"},
+        {id:"05-ship-c-working", state:"working", source:"status-log"},
+        {id:"06-ship-detached", state:"paused", source:"status-log"},
+        {id:"07-ship-plain", state:"done", source:"status-log"},
+        {id:"08-scout", state:"done", source:"status-log"},
+        {id:"09-mate", state:"working", source:"status-log"},
+        {id:"10-secondmate", state:"blocked", source:"status-log"},
+        {id:"11-secondmate", state:"unknown", source:"none"}
+      ])
+      and ([.tasks[] | {id, exists:.endpoint.exists, agent_alive:.endpoint.agent_alive}] == [
+        {id:"01-ship-a-blocked", exists:true, agent_alive:"not_checked"},
+        {id:"02-ship-a-done", exists:true, agent_alive:"not_checked"},
+        {id:"03-ship-b-decision", exists:true, agent_alive:"not_checked"},
+        {id:"04-ship-b-failed", exists:true, agent_alive:"not_checked"},
+        {id:"05-ship-c-working", exists:true, agent_alive:"not_checked"},
+        {id:"06-ship-detached", exists:true, agent_alive:"not_checked"},
+        {id:"07-ship-plain", exists:true, agent_alive:"not_checked"},
+        {id:"08-scout", exists:true, agent_alive:"not_checked"},
+        {id:"09-mate", exists:true, agent_alive:"alive"},
+        {id:"10-secondmate", exists:true, agent_alive:"dead"},
+        {id:"11-secondmate", exists:false, agent_alive:"dead"}
+      ])
+      and task("01-ship-a-blocked").hints.open_decisions == [
+        {key:"network", verb:"blocked", summary:"task a remains independently blocked"}
+      ]
+      and task("03-ship-b-decision").paths.status_log.last_event == {
+        state:"working", note:"task b continued unrelated setup",
+        raw:"working: task b continued unrelated setup"
+      }
+      and task("03-ship-b-decision").hints.open_decisions == [
+        {key:"shape", verb:"needs-decision", summary:"task b awaits its own decision"}
+      ]
+      and task("10-secondmate").hints.open_decisions == [
+        {key:"mate-block", verb:"blocked", summary:"secondmate block stays task-local"}
+      ]
+      and all(.tasks[] | select(.id != "01-ship-a-blocked"
+        and .id != "03-ship-b-decision" and .id != "10-secondmate");
+        .hints.open_decisions == [])
       and task("01-ship-a-blocked").hints.blocked_event == true
       and task("03-ship-b-decision").hints.pending_decision == true
-      and all(.tasks[]; .endpoint.exists == true)
       and (.secondmate_current.records[] | select(.id == "09-mate")
         | .registered == true and .provenance.summary_valid == true)
   ' >/dev/null || fail "scale snapshot changed ordering, task truth, endpoint truth, decisions, or registered-home validity: $out"
@@ -494,8 +533,23 @@ SH
     || fail "separate public snapshots with identical inputs were not byte-for-byte equivalent"
   [ "$(awk -F '\t' '$1 == "primary" {n++} END {print n+0}' "$calls")" -eq 3 ] \
     || fail "a later snapshot reused primary query data from an earlier snapshot"
-  [ "$(awk -F '\t' '$1 == "coarse" {n++} END {print n+0}' "$calls")" -eq 1 ] \
+  [ "$(awk -F '\t' '$1 == "coarse" && $3 == "200" {n++} END {print n+0}' "$calls")" -eq 1 ] \
     || fail "a later snapshot reused coarse query data from an earlier snapshot"
+
+  : > "$calls"
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_CREW_STATE_RUNS_LIMIT=50 \
+    FM_SNAPSHOT_NOW=2026-08-11T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1786449600 \
+    "$SNAPSHOT" --json 2> "$stderr_file") \
+    || fail "alternate-limit scale snapshot public read failed"
+  [ ! -s "$stderr_file" ] || fail "alternate-limit snapshot leaked private diagnostics: $(cat "$stderr_file")"
+  printf '%s' "$out" | cmp -s "$first_out" - \
+    || fail "alternate coarse query limit changed task-local public snapshot bytes"
+  [ "$(awk -F '\t' '$1 == "primary" {n++} END {print n+0}' "$calls")" -eq 3 ] \
+    || fail "alternate limit changed exact-identity primary reuse: $(cat "$calls")"
+  [ "$(awk -F '\t' '$1 == "coarse" && $3 == "50" {n++} END {print n+0}' "$calls")" -eq 5 ] \
+    || fail "non-200 coarse queries were reused or skipped: $(cat "$calls")"
+  [ "$(wc -l < "$calls" | tr -d ' ')" -eq 8 ] \
+    || fail "alternate-limit query shape was not task-local: $(cat "$calls")"
 
   after_manifest=$(snapshot_home_manifest "$home" "$mate")
   [ "$before_manifest" = "$after_manifest" ] \

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -8,6 +8,7 @@ set -u
 
 SNAPSHOT="$ROOT/bin/fm-fleet-snapshot.sh"
 VIEW="$ROOT/bin/fm-fleet-view.sh"
+CREW_STATE="$ROOT/bin/fm-crew-state.sh"
 TMP_ROOT=$(fm_test_tmproot fm-fleet-snapshot)
 
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
@@ -286,6 +287,220 @@ test_fixture_snapshot_json() {
     | .state == "done" and .pr_url == "https://github.com/kunchenguid/firstmate/pull/7"
   ' >/dev/null || fail "done backlog PR row missing"
   pass "fixture snapshot covers task rows, backlog rows, pointers, and stable ordering"
+}
+
+# Production-scale regression for snapshot-local reuse of raw no-mistakes
+# queries. Eleven task records preserve the observed 7 ship / 1 scout /
+# 3 secondmate mix. Five branched ships reduce to three exact
+# common-dir/branch/HEAD identities: scale-a and scale-b each have a duplicate,
+# while scale-c has one task. The fake returns heads absent from the repository
+# for both query forms, so the unchanged fail-closed head proof must reject every
+# row before each task independently falls back to its own status and endpoint.
+test_snapshot_reuses_raw_no_mistakes_queries_per_identity() {
+  local home repo wt_b wt_c wt_detached mate fakebin calls stderr_file expected_raw actual_raw
+  local before_manifest after_manifest out first_out second_out primary_calls coarse_calls total_calls branch branch_calls
+  home=$(make_home snapshot-query-reuse)
+  repo="$home/projects/scale-repo"
+  wt_b="$home/projects/scale-b"
+  wt_c="$home/projects/scale-c"
+  wt_detached="$home/projects/scale-detached"
+  mate="$TMP_ROOT/snapshot-query-reuse-mate"
+  calls="$TMP_ROOT/private-scale-call-ledger"
+  stderr_file="$TMP_ROOT/private-scale-stderr"
+  expected_raw="$TMP_ROOT/scale-expected-current-state"
+  actual_raw="$TMP_ROOT/scale-actual-current-state"
+  first_out="$TMP_ROOT/scale-first.json"
+  second_out="$TMP_ROOT/scale-second.json"
+
+  fm_git_init_commit "$repo"
+  git -C "$repo" branch -M scale-a
+  git -C "$repo" worktree add -q -b scale-b "$wt_b"
+  git -C "$repo" worktree add -q -b scale-c "$wt_c"
+  git -C "$repo" worktree add -q --detach "$wt_detached"
+  mkdir -p "$home/projects/plain" "$home/projects/scout"
+  mkdir -p "$mate/data" "$mate/state" "$mate/config" "$mate/projects" "$mate/bin"
+  printf '# Firstmate fixture\n' > "$mate/AGENTS.md"
+  printf '09-mate\n' > "$mate/.fm-secondmate-home"
+  printf '## In flight\n\n## Queued\n\n## Done\n' > "$mate/data/backlog.md"
+  printf -- '- 09-mate - scale fixture (home: %s; scope: scale fixture; projects: firstmate; added 2026-08-11)\n' \
+    "$mate" > "$home/data/secondmates.md"
+
+  fm_write_meta "$home/state/01-ship-a-blocked.meta" \
+    "window=firstmate:fm-01-ship-a-blocked" "worktree=$repo" "project=firstmate" \
+    "harness=claude" "kind=ship" "mode=no-mistakes"
+  fm_write_meta "$home/state/02-ship-a-done.meta" \
+    "window=firstmate:fm-02-ship-a-done" "worktree=$repo" "project=firstmate" \
+    "harness=claude" "kind=ship" "mode=no-mistakes"
+  fm_write_meta "$home/state/03-ship-b-decision.meta" \
+    "window=firstmate:fm-03-ship-b-decision" "worktree=$wt_b" "project=firstmate" \
+    "harness=claude" "kind=ship" "mode=no-mistakes"
+  fm_write_meta "$home/state/04-ship-b-failed.meta" \
+    "window=firstmate:fm-04-ship-b-failed" "worktree=$wt_b" "project=firstmate" \
+    "harness=claude" "kind=ship" "mode=no-mistakes"
+  fm_write_meta "$home/state/05-ship-c-working.meta" \
+    "window=firstmate:fm-05-ship-c-working" "worktree=$wt_c" "project=firstmate" \
+    "harness=claude" "kind=ship" "mode=no-mistakes"
+  fm_write_meta "$home/state/06-ship-detached.meta" \
+    "window=firstmate:fm-06-ship-detached" "worktree=$wt_detached" "project=firstmate" \
+    "harness=claude" "kind=ship" "mode=no-mistakes"
+  fm_write_meta "$home/state/07-ship-plain.meta" \
+    "window=firstmate:fm-07-ship-plain" "worktree=$home/projects/plain" "project=firstmate" \
+    "harness=claude" "kind=ship" "mode=no-mistakes"
+  fm_write_meta "$home/state/08-scout.meta" \
+    "window=firstmate:fm-08-scout" "worktree=$home/projects/scout" "project=firstmate" \
+    "harness=claude" "kind=scout" "mode=scout"
+  fm_write_meta "$home/state/09-mate.meta" \
+    "window=firstmate:fm-09-mate" "worktree=$mate" "project=$mate" \
+    "harness=codex" "kind=secondmate" "mode=secondmate" "home=$mate" "projects=firstmate"
+  fm_write_meta "$home/state/10-secondmate.meta" \
+    "window=firstmate:fm-10-secondmate" "worktree=$home/projects/plain" "project=firstmate" \
+    "harness=codex" "kind=secondmate" "mode=secondmate" "home=$home/projects/plain"
+  fm_write_meta "$home/state/11-secondmate.meta" \
+    "window=firstmate:fm-11-secondmate" "worktree=$home/projects/scout" "project=firstmate" \
+    "harness=codex" "kind=secondmate" "mode=secondmate" "home=$home/projects/scout"
+
+  for branch in \
+    01-ship-a-blocked 02-ship-a-done 03-ship-b-decision 04-ship-b-failed \
+    05-ship-c-working 06-ship-detached 07-ship-plain 08-scout; do
+    record_claude_idle "$home/state" "$branch"
+  done
+  printf 'blocked [key=network]: task a remains independently blocked\n' > "$home/state/01-ship-a-blocked.status"
+  printf 'done: task a duplicate is independently complete\n' > "$home/state/02-ship-a-done.status"
+  printf 'needs-decision [key=shape]: task b awaits its own decision\n' > "$home/state/03-ship-b-decision.status"
+  printf 'failed: task b duplicate failed independently\n' > "$home/state/04-ship-b-failed.status"
+  printf 'working: task c keeps its own current event\n' > "$home/state/05-ship-c-working.status"
+  printf 'paused: detached task keeps its own external wait\n' > "$home/state/06-ship-detached.status"
+  printf 'done: plain task keeps its own terminal state\n' > "$home/state/07-ship-plain.status"
+  printf 'done: scout report complete\n' > "$home/state/08-scout.status"
+  printf 'working: registered mate remains independently current\n' > "$home/state/09-mate.status"
+  printf 'blocked [key=mate-block]: secondmate block stays task-local\n' > "$home/state/10-secondmate.status"
+  printf 'done: secondmate terminal event stays task-local\n' > "$home/state/11-secondmate.status"
+
+  fakebin=$(make_fakebin "$home")
+  cat > "$fakebin/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+set -u
+common=$(git rev-parse --path-format=absolute --git-common-dir)
+case "${1:-}" in
+  axi)
+    [ "${2:-}" = status ] || exit 0
+    branch=$(git symbolic-ref --quiet --short HEAD)
+    head=$(git rev-parse HEAD)
+    printf 'primary\t%s\t%s\t%s\n' "$common" "$branch" "$head" >> "${FM_FAKE_NM_CALLS:?}"
+    sleep "${FM_FAKE_NM_LATENCY:-0.04}"
+    printf 'branch: %s\nhead: %s\nstatus: running\n' "$branch" "${FM_FAKE_NM_UNPROVABLE_HEAD:?}"
+    ;;
+  runs)
+    printf 'coarse\t%s\n' "$common" >> "${FM_FAKE_NM_CALLS:?}"
+    sleep "${FM_FAKE_NM_LATENCY:-0.04}"
+    printf 'running scale-a %s 2026-08-11\n' "${FM_FAKE_NM_UNPROVABLE_HEAD:?}"
+    printf 'running scale-b %s 2026-08-11\n' "${FM_FAKE_NM_UNPROVABLE_HEAD:?}"
+    printf 'running scale-c %s 2026-08-11\n' "${FM_FAKE_NM_UNPROVABLE_HEAD:?}"
+    ;;
+esac
+SH
+  chmod +x "$fakebin/no-mistakes"
+  : > "$calls"
+
+  snapshot_home_manifest() {  # <home> [<additional-home>]
+    local manifest_home
+    for manifest_home in "$@"; do
+      printf 'HOME %s\n' "$manifest_home"
+      (
+        cd "$manifest_home" || exit 1
+        find . -type d -print | LC_ALL=C sort
+        find . -type f -print | LC_ALL=C sort | while IFS= read -r file; do
+          cksum "$file"
+        done
+      )
+    done
+  }
+  before_manifest=$(snapshot_home_manifest "$home" "$mate")
+
+  export FM_FAKE_NM_CALLS="$calls"
+  export FM_FAKE_NM_LATENCY=0.04
+  export FM_FAKE_NM_UNPROVABLE_HEAD=ffffffffffffffffffffffffffffffffffffffff
+  if git -C "$repo" rev-parse --verify "${FM_FAKE_NM_UNPROVABLE_HEAD}^{commit}" >/dev/null 2>&1; then
+    fail "scale fixture's rejected no-mistakes head unexpectedly exists in the repository"
+  fi
+  : > "$expected_raw"
+  for branch in \
+    01-ship-a-blocked 02-ship-a-done 03-ship-b-decision 04-ship-b-failed \
+    05-ship-c-working 06-ship-detached 07-ship-plain 08-scout 09-mate \
+    10-secondmate 11-secondmate; do
+    PATH="$fakebin:$PATH" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+      "$CREW_STATE" "$branch" >> "$expected_raw"
+  done
+
+  : > "$calls"
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" \
+    FM_SNAPSHOT_NOW=2026-08-11T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1786449600 \
+    "$SNAPSHOT" --json 2> "$stderr_file") \
+    || fail "scale snapshot public read failed"
+  [ ! -s "$stderr_file" ] || fail "scale snapshot leaked private diagnostics: $(cat "$stderr_file")"
+  printf '%s' "$out" > "$first_out"
+  printf '%s' "$out" | jq -r '.tasks[].current_state.raw' > "$actual_raw"
+  cmp -s "$expected_raw" "$actual_raw" \
+    || fail "snapshot-local query reuse changed task-local public current-state bytes"
+
+  primary_calls=$(awk -F '\t' '$1 == "primary" {n++} END {print n+0}' "$calls")
+  coarse_calls=$(awk -F '\t' '$1 == "coarse" {n++} END {print n+0}' "$calls")
+  total_calls=$(wc -l < "$calls" | tr -d ' ')
+  [ "$primary_calls" -eq 3 ] \
+    || fail "expected one primary query per exact identity, got $primary_calls: $(cat "$calls")"
+  [ "$coarse_calls" -eq 1 ] \
+    || fail "expected one coarse query per canonical repository, got $coarse_calls: $(cat "$calls")"
+  [ "$total_calls" -eq 4 ] || fail "unexpected no-mistakes query shape: $(cat "$calls")"
+  for branch in scale-a scale-b scale-c; do
+    branch_calls=$(awk -F '\t' -v branch="$branch" '$1 == "primary" && $3 == branch {n++} END {print n+0}' "$calls")
+    [ "$branch_calls" -eq 1 ] || fail "primary identity $branch was queried $branch_calls times"
+  done
+
+  printf '%s' "$out" | jq -e '
+    def task($id): (.tasks[] | select(.id == $id));
+    .schema == "fm-fleet-snapshot.v1"
+      and ([.tasks[].id] == [
+        "01-ship-a-blocked", "02-ship-a-done", "03-ship-b-decision",
+        "04-ship-b-failed", "05-ship-c-working", "06-ship-detached",
+        "07-ship-plain", "08-scout", "09-mate", "10-secondmate", "11-secondmate"
+      ])
+      and ([.tasks[].kind] | map(select(. == "ship")) | length) == 7
+      and ([.tasks[].kind] | map(select(. == "scout")) | length) == 1
+      and ([.tasks[].kind] | map(select(. == "secondmate")) | length) == 3
+      and task("01-ship-a-blocked").current_state.state == "blocked"
+      and task("02-ship-a-done").current_state.state == "done"
+      and task("03-ship-b-decision").current_state.state == "parked"
+      and task("04-ship-b-failed").current_state.state == "failed"
+      and task("05-ship-c-working").current_state.state == "working"
+      and all(.tasks[:5][]; .current_state.source == "status-log")
+      and task("01-ship-a-blocked").hints.blocked_event == true
+      and task("03-ship-b-decision").hints.pending_decision == true
+      and all(.tasks[]; .endpoint.exists == true)
+      and (.secondmate_current.records[] | select(.id == "09-mate")
+        | .registered == true and .provenance.summary_valid == true)
+  ' >/dev/null || fail "scale snapshot changed ordering, task truth, endpoint truth, decisions, or registered-home validity: $out"
+  printf '%s' "$out" | jq -e --arg private "$calls" '
+    [.. | strings | select(contains($private) or contains("FM_FAKE_NM_LATENCY"))] | length == 0
+  ' >/dev/null || fail "snapshot exposed private query or performance state"
+
+  : > "$calls"
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" \
+    FM_SNAPSHOT_NOW=2026-08-11T12:00:00Z FM_SNAPSHOT_NOW_EPOCH=1786449600 \
+    "$SNAPSHOT" --json 2> "$stderr_file") \
+    || fail "repeat scale snapshot public read failed"
+  [ ! -s "$stderr_file" ] || fail "repeat scale snapshot leaked private diagnostics: $(cat "$stderr_file")"
+  printf '%s' "$out" > "$second_out"
+  cmp -s "$first_out" "$second_out" \
+    || fail "separate public snapshots with identical inputs were not byte-for-byte equivalent"
+  [ "$(awk -F '\t' '$1 == "primary" {n++} END {print n+0}' "$calls")" -eq 3 ] \
+    || fail "a later snapshot reused primary query data from an earlier snapshot"
+  [ "$(awk -F '\t' '$1 == "coarse" {n++} END {print n+0}' "$calls")" -eq 1 ] \
+    || fail "a later snapshot reused coarse query data from an earlier snapshot"
+
+  after_manifest=$(snapshot_home_manifest "$home" "$mate")
+  [ "$before_manifest" = "$after_manifest" ] \
+    || fail "public crew-state or fleet snapshot reads wrote to an operational home"
+  pass "fleet snapshot reuses only raw no-mistakes queries while preserving every task and home verdict"
 }
 
 # R1 owner contract: main_inventory discloses orphan in-flight and unstructured
@@ -875,6 +1090,7 @@ test_large_backlog_crosses_argv_limit_via_public_interface
 test_large_task_status_crosses_argv_limit_via_public_interface
 test_large_task_metadata_crosses_argv_limit_via_public_interface
 test_fixture_snapshot_json
+test_snapshot_reuses_raw_no_mistakes_queries_per_identity
 test_main_inventory_orphan_and_unstructured_disclosure
 test_normalized_roles_and_plural_blocker_readiness
 test_event_hints_follow_reconciled_current_state

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -172,7 +172,7 @@ test_large_backlog_crosses_argv_limit_via_public_interface() {
 }
 
 test_large_task_status_crosses_argv_limit_via_public_interface() {
-  local home fakebin out payload payload_bytes prefix prefix_bytes
+  local home fakebin out payload payload_bytes prefix prefix_bytes status_value status_bytes
   home=$(make_home large-task-status)
   mkdir -p "$home/projects/large-task-status"
   fm_write_meta "$home/state/large-task-status.meta" \
@@ -189,24 +189,57 @@ test_large_task_status_crosses_argv_limit_via_public_interface() {
   prefix_bytes=$(printf '%s' "$prefix" | LC_ALL=C wc -c | tr -d ' ')
   [ "$payload_bytes" -gt 131072 ] \
     || fail "large-status fixture must exceed the ordinary Linux per-argument limit"
-  printf '%s%s\n' "$prefix" "$payload" > "$home/state/large-task-status.status"
+  status_value="https://$payload/pull/1"
+  status_bytes=$(printf '%s' "$status_value" | LC_ALL=C wc -c | tr -d ' ')
+  printf '%s%s\n' "$prefix" "$status_value" > "$home/state/large-task-status.status"
 
   fakebin=$(make_fakebin "$home")
   out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json)
   printf '%s' "$out" | jq -e \
-    --argjson payload_bytes "$payload_bytes" \
+    --argjson status_bytes "$status_bytes" \
     --argjson prefix_bytes "$prefix_bytes" '
     .schema == "fm-fleet-snapshot.v1"
       and (.tasks | length) == 1
       and (.tasks[0].id == "large-task-status")
       and (.tasks[0].current_state.state == "parked")
       and (.tasks[0].current_state.source == "status-log")
-      and ((.tasks[0].current_state.detail | length) == $payload_bytes)
-      and ((.tasks[0].paths.status_log.last_event.raw | length) == ($prefix_bytes + $payload_bytes))
-      and ((.tasks[0].paths.status_log.last_event.note | length) == $payload_bytes)
-      and ((.tasks[0].hints.open_decisions[0].summary | length) == $payload_bytes)
+      and ((.tasks[0].current_state.detail | length) == $status_bytes)
+      and ((.tasks[0].paths.status_log.last_event.raw | length) == ($prefix_bytes + $status_bytes))
+      and ((.tasks[0].paths.status_log.last_event.note | length) == $status_bytes)
+      and ((.tasks[0].hints.open_decisions[0].summary | length) == $status_bytes)
+      and ((.tasks[0].pr.url | length) == $status_bytes)
+      and (.tasks[0].pr.source == "status_event")
   ' >/dev/null || fail "public snapshot must preserve complete task status above argv limits"
   pass "public snapshot transports task status above ordinary Linux argv limits"
+}
+
+test_large_task_metadata_crosses_argv_limit_via_public_interface() {
+  local home fakebin out payload payload_bytes
+  home=$(make_home large-task-metadata)
+  mkdir -p "$home/projects/large-task-metadata"
+  payload=$(LC_ALL=C awk 'BEGIN { for (i = 0; i < 196608; i++) printf "m" }')
+  payload_bytes=$(printf '%s' "$payload" | LC_ALL=C wc -c | tr -d ' ')
+  [ "$payload_bytes" -gt 131072 ] \
+    || fail "large-metadata fixture must exceed the ordinary Linux per-argument limit"
+  fm_write_meta "$home/state/large-task-metadata.meta" \
+    "window=firstmate:fm-large-task-metadata" \
+    "worktree=$home/projects/large-task-metadata" \
+    "project=$payload" \
+    "harness=claude" \
+    "kind=ship" \
+    "mode=ship"
+  record_claude_idle "$home/state" large-task-metadata
+  printf 'working: bounded status\n' > "$home/state/large-task-metadata.status"
+
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json)
+  printf '%s' "$out" | jq -e --argjson payload_bytes "$payload_bytes" '
+    .schema == "fm-fleet-snapshot.v1"
+      and (.tasks | length) == 1
+      and (.tasks[0].id == "large-task-metadata")
+      and ((.tasks[0].project | length) == $payload_bytes)
+  ' >/dev/null || fail "public snapshot must preserve complete task metadata above argv limits"
+  pass "public snapshot transports task metadata above ordinary Linux argv limits"
 }
 
 test_fixture_snapshot_json() {
@@ -840,6 +873,7 @@ test_parked_scout_decision_stays_pending() {
 test_empty_fleet_json
 test_large_backlog_crosses_argv_limit_via_public_interface
 test_large_task_status_crosses_argv_limit_via_public_interface
+test_large_task_metadata_crosses_argv_limit_via_public_interface
 test_fixture_snapshot_json
 test_main_inventory_orphan_and_unstructured_disclosure
 test_normalized_roles_and_plural_blocker_readiness

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -171,6 +171,44 @@ test_large_backlog_crosses_argv_limit_via_public_interface() {
   pass "public snapshot transports a backlog larger than ordinary Linux argv limits"
 }
 
+test_large_task_status_crosses_argv_limit_via_public_interface() {
+  local home fakebin out payload payload_bytes prefix prefix_bytes
+  home=$(make_home large-task-status)
+  mkdir -p "$home/projects/large-task-status"
+  fm_write_meta "$home/state/large-task-status.meta" \
+    "window=firstmate:fm-large-task-status" \
+    "worktree=$home/projects/large-task-status" \
+    "project=firstmate" \
+    "harness=claude" \
+    "kind=ship" \
+    "mode=ship"
+  record_claude_idle "$home/state" large-task-status
+  prefix='needs-decision [key=oversize]: '
+  payload=$(LC_ALL=C awk 'BEGIN { for (i = 0; i < 196608; i++) printf "s" }')
+  payload_bytes=$(printf '%s' "$payload" | LC_ALL=C wc -c | tr -d ' ')
+  prefix_bytes=$(printf '%s' "$prefix" | LC_ALL=C wc -c | tr -d ' ')
+  [ "$payload_bytes" -gt 131072 ] \
+    || fail "large-status fixture must exceed the ordinary Linux per-argument limit"
+  printf '%s%s\n' "$prefix" "$payload" > "$home/state/large-task-status.status"
+
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json)
+  printf '%s' "$out" | jq -e \
+    --argjson payload_bytes "$payload_bytes" \
+    --argjson prefix_bytes "$prefix_bytes" '
+    .schema == "fm-fleet-snapshot.v1"
+      and (.tasks | length) == 1
+      and (.tasks[0].id == "large-task-status")
+      and (.tasks[0].current_state.state == "parked")
+      and (.tasks[0].current_state.source == "status-log")
+      and ((.tasks[0].current_state.detail | length) == $payload_bytes)
+      and ((.tasks[0].paths.status_log.last_event.raw | length) == ($prefix_bytes + $payload_bytes))
+      and ((.tasks[0].paths.status_log.last_event.note | length) == $payload_bytes)
+      and ((.tasks[0].hints.open_decisions[0].summary | length) == $payload_bytes)
+  ' >/dev/null || fail "public snapshot must preserve complete task status above argv limits"
+  pass "public snapshot transports task status above ordinary Linux argv limits"
+}
+
 test_fixture_snapshot_json() {
   local home fakebin out ids
   home=$(make_home fixture)
@@ -801,6 +839,7 @@ test_parked_scout_decision_stays_pending() {
 
 test_empty_fleet_json
 test_large_backlog_crosses_argv_limit_via_public_interface
+test_large_task_status_crosses_argv_limit_via_public_interface
 test_fixture_snapshot_json
 test_main_inventory_orphan_and_unstructured_disclosure
 test_normalized_roles_and_plural_blocker_readiness

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -151,6 +151,26 @@ test_empty_fleet_json() {
   pass "empty fleet snapshot and view use explicit absence markers"
 }
 
+test_large_backlog_crosses_argv_limit_via_public_interface() {
+  local home out payload payload_bytes
+  home=$(make_home large-backlog)
+  payload=$(LC_ALL=C awk 'BEGIN { for (i = 0; i < 196608; i++) printf "x" }')
+  payload_bytes=$(printf '%s' "$payload" | LC_ALL=C wc -c | tr -d ' ')
+  [ "$payload_bytes" -gt 131072 ] \
+    || fail "large-backlog fixture must exceed the ordinary Linux per-argument limit"
+  printf '## Done\n%s\n' "$payload" > "$home/data/backlog.md"
+
+  out=$(FM_HOME="$home" "$SNAPSHOT" --json)
+  printf '%s' "$out" | jq -e --argjson payload_bytes "$payload_bytes" '
+    .schema == "fm-fleet-snapshot.v1"
+      and (.tasks | length) == 0
+      and (.backlog.records | length) == 1
+      and .backlog.records[0].structured == false
+      and (.backlog.records[0].raw | length) == $payload_bytes
+  ' >/dev/null || fail "public snapshot must return valid complete JSON above argv limits"
+  pass "public snapshot transports a backlog larger than ordinary Linux argv limits"
+}
+
 test_fixture_snapshot_json() {
   local home fakebin out ids
   home=$(make_home fixture)
@@ -780,6 +800,7 @@ test_parked_scout_decision_stays_pending() {
 }
 
 test_empty_fleet_json
+test_large_backlog_crosses_argv_limit_via_public_interface
 test_fixture_snapshot_json
 test_main_inventory_orphan_and_unstructured_disclosure
 test_normalized_roles_and_plural_blocker_readiness


### PR DESCRIPTION
## Intent

Implement the captain-authorized Firstmate scale correction required for Krisis continuity-safe physical acceptance as a no-mistakes superset PR to upstream main, based exactly on reviewed PR 2180 head af406a1161f38c8a64b5d4c72f9e375353907b32 and tree e40fd1a27c79fb90c52dbcab08056c4ee6789ec9, without mutating, force-pushing, closing, replacing, or otherwise changing PR 2180. Add one-snapshot-only process-local reuse of raw read-only no-mistakes query results at the fm-nm-run-lib.sh and fm-crew-state.sh owner boundary: key each primary axi status result by canonical git common-dir, branch, and current worktree HEAD, and key each coarse runs --limit 200 result by canonical repository, querying once for each exact identity or repository and independently applying the existing branch parser and exact existing fail-closed head proof for every task. Every task must still reconcile its own metadata, complete status history and open-decision truth, endpoint and liveness, and captain-relevant event state; never share a final verdict. Never persist or reuse cache data across snapshots or polls, fetch missing objects, weaken equality or ancestry proof, parallelize readers, skip any field, task, or home, increase the timeout, compact or rewrite history, or change the fm-fleet-snapshot.v1 schema, ordering, privacy, read-only behavior, failure semantics, or supported-platform portability. Keep the implementation minimal rather than creating a generalized cache framework. Add public-interface regressions colocated with crew-state and snapshot tests using eleven task records with the measured 7 ship, 1 scout, and 3 secondmate mix, five branched ships over three unique exact identities with two duplicate pairs, deterministic fake no-mistakes latency, a primary head absent from the repository, and coarse rows rejected by the unchanged fail-closed rule. Prove three primary calls and one coarse repository call, byte-for-byte task and repeat-snapshot semantics, exact task ordering, task-local status and liveness, current and open-decision truth, registered-home validity, no home writes, no private performance output, and no cross-snapshot reuse. Run pinned bin/fm-lint.sh and all affected current-state, decision, snapshot, cross-home, selection, and teardown tests. Against the real configured home, run three sequential production-equivalent public reads from the final executable under the 10-second kill boundary, require valid fm-fleet-snapshot.v1 and zero stderr each time, and retain only timing, schema, and count summaries; the completed candidate evidence was 8.118s, 8.317s, and 8.114s. Include the precise post-merge temporary-pin update and natural-reconciliation plan without executing it. Do not merge, update the retained Krisis pin, touch the primary checkout, or change or restart any Krisis service, observer, browser, database, state, decision, or task. Do not use a timeout workaround. The captain retains explicit merge and pin-update authority.

## What Changed

- Stream large fleet metadata, status history, backlog, and secondmate documents without placing unbounded payloads on process argument lists.
- Reuse raw no-mistakes query results only within a single snapshot, keyed by exact repository and worktree identity while preserving task-local reconciliation and fail-closed head validation.
- Add scale regressions covering 11-task fleets, large inputs, query counts, task ordering and liveness, decision history, read-only behavior, and cross-snapshot isolation.

## Risk Assessment

✅ Low: Captain, functional behavior and intent conformance are clean; only a stale per-function ownership comment remains.

## Testing

No prior baseline results were supplied; the focused current-state, decision, snapshot, cross-home projection/selection, selector, and teardown suites passed, the 11-task replay proved one-snapshot-only 3-primary/1-coarse reuse with byte-identical repeat output and unchanged home manifests, and three configured-home reads returned valid v1 JSON with zero stderr in 8.41s, 8.51s, and 8.61s under the unchanged 10-second boundary. Lint, the full suite, push, PR, and CI were not run because this assigned test phase forbids or does not own them; this CLI-only change is evidenced by public JSON and transcripts rather than screenshots.

<details>
<summary>Evidence: Configured-home public reads</summary>

<code>run=1 exit=0 elapsed=8.41s stderr=0&#10;run=2 exit=0 elapsed=8.51s stderr=0&#10;run=3 exit=0 elapsed=8.61s stderr=0</code>

```text
public_command=bin/fm-fleet-snapshot.sh --json (configured home, 10-second external boundary)
run=1 exit=0 elapsed_seconds=8.41 stderr_bytes=0 summary={"schema":"fm-fleet-snapshot.v1","counts":{"backlog_records":61,"tasks":12,"open_decisions":0,"scout_reports":40,"secondmates_total":3,"secondmates_registered":3,"secondmates_shown":3,"secondmates_truncated":0,"landed":7,"landed_truncated":0,"unreadable_secondmates":2,"partial_secondmates":0}}
run=2 exit=0 elapsed_seconds=8.51 stderr_bytes=0 summary={"schema":"fm-fleet-snapshot.v1","counts":{"backlog_records":61,"tasks":12,"open_decisions":0,"scout_reports":40,"secondmates_total":3,"secondmates_registered":3,"secondmates_shown":3,"secondmates_truncated":0,"landed":7,"landed_truncated":0,"unreadable_secondmates":2,"partial_secondmates":0}}
run=3 exit=0 elapsed_seconds=8.61 stderr_bytes=0 summary={"schema":"fm-fleet-snapshot.v1","counts":{"backlog_records":61,"tasks":12,"open_decisions":0,"scout_reports":40,"secondmates_total":3,"secondmates_registered":3,"secondmates_shown":3,"secondmates_truncated":0,"landed":7,"landed_truncated":0,"unreadable_secondmates":2,"partial_secondmates":0}}
```
</details>
<details>
<summary>Evidence: Snapshot query-reuse evidence</summary>

`primary=3, coarse=1; repeat primary=3, coarse=1; snapshots byte-identical; operational homes unchanged; task mix 7 ship/1 scout/3 secondmate`

```text
{"schema":"fm-fleet-snapshot.v1","task_order":["01-ship-a-blocked","02-ship-a-done","03-ship-b-decision","04-ship-b-failed","05-ship-c-working","06-ship-detached","07-ship-plain","08-scout","09-mate","10-secondmate","11-secondmate"],"kind_counts":{"ship":7,"scout":1,"secondmate":3},"task_truth":[{"id":"01-ship-a-blocked","state":"blocked","source":"status-log","endpoint_exists":true,"agent_alive":"not_checked","open_decisions":[{"key":"network","verb":"blocked","summary":"task a remains independently blocked"}]},{"id":"02-ship-a-done","state":"done","source":"status-log","endpoint_exists":true,"agent_alive":"not_checked","open_decisions":[]},{"id":"03-ship-b-decision","state":"working","source":"status-log","endpoint_exists":true,"agent_alive":"not_checked","open_decisions":[{"key":"shape","verb":"needs-decision","summary":"task b awaits its own decision"}]},{"id":"04-ship-b-failed","state":"failed","source":"status-log","endpoint_exists":true,"agent_alive":"not_checked","open_decisions":[]},{"id":"05-ship-c-working","state":"working","source":"status-log","endpoint_exists":true,"agent_alive":"not_checked","open_decisions":[]},{"id":"06-ship-detached","state":"paused","source":"status-log","endpoint_exists":true,"agent_alive":"not_checked","open_decisions":[]},{"id":"07-ship-plain","state":"done","source":"status-log","endpoint_exists":true,"agent_alive":"not_checked","open_decisions":[]},{"id":"08-scout","state":"done","source":"status-log","endpoint_exists":true,"agent_alive":"not_checked","open_decisions":[]},{"id":"09-mate","state":"working","source":"status-log","endpoint_exists":true,"agent_alive":"alive","open_decisions":[]},{"id":"10-secondmate","state":"blocked","source":"status-log","endpoint_exists":true,"agent_alive":"dead","open_decisions":[{"key":"mate-block","verb":"blocked","summary":"secondmate block stays task-local"}]},{"id":"11-secondmate","state":"unknown","source":"none","endpoint_exists":false,"agent_alive":"dead","open_decisions":[]}],"registered_home_valid":{"registered":true,"summary_valid":true},"query_instrumentation":{"primary_calls":3,"coarse_200_calls":1,"primary_branches":["scale-a","scale-b","scale-c"],"repeat_primary_calls":3,"repeat_coarse_200_calls":1},"repeat_snapshot_byte_equal":true,"operational_homes_byte_equal":true}
```
</details>
<details>
<summary>Evidence: Synthetic public snapshot</summary>

```text
{
  "schema": "fm-fleet-snapshot.v1",
  "generated": "2026-08-11T12:00:00Z",
  "fm_home": "/tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/fm-fleet-snapshot.k71zZm/snapshot-query-reuse",
  "roots": {
    "fm_root": "/home/anthony/.no-mistakes/worktrees/709ca3db2d35/01KZS313S8HSAEZ6C365J3DPMQ",
    "state": "/tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/fm-fleet-snapshot.k71zZm/snapshot-query-reuse/state",
    "data": "/tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/fm-fleet-snapshot.k71zZm/snapshot-query-reuse/data",
    "config": "/tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/fm-fleet-snapshot.k71zZm/snapshot-query-reuse/config",
    "projects": "/tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/fm-fleet-snapshot.k71zZm/snapshot-query-reuse/projects"
  },
  "backlog": {
    "path": "/tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/fm-fleet-snapshot.k71zZm/snapshot-query-reuse/data/backlog.md",
    "present": false,
    "records": []
  },
  "tasks": [
    {
      "id": "01-ship-a-blocked",
      "kind": "ship",
      "harness": "claude",
      "mode": "no-mistakes",
      "yolo": "",
      "project": "firstmate",
      "backend": "tmux",
      "remote": null,
      "paths": {
        "meta": {
          "path": "/tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/fm-fleet-snapshot.k71zZm/snapshot-query-reuse/state/01-ship-a-blocked.meta",
          "present": true
        },
        "status_log": {
          "path": "/tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/fm-fleet-snapshot.k71zZm/snapshot-query-reuse/state/01-ship-a-blocked.status",
          "present": true,
          "kind": "event_history",
          "last_event": {
            "state": "blocked",
            "note": "task a remains independently blocked",
            "raw": "blocked [key=network]: task a remains independently blocked"
          }
        },
        "worktree": {
          "path": "/tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/fm-fleet-snapshot.k71zZm/snapshot-query-reuse/projects/scale-repo",
          "present": true
        },
        "home": {
          "path": null,
          "present": false
        },
        "report": {
          "path": "/tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/fm-fleet-snapshot.k71zZm/snapshot-query-reuse/data/01-ship-a-blocked/report.md",
          "present": false
        }
      },
      "secondmate_projects": [],
      "current_state": {
        "state": "blocked",
        "source": "status-log",
        "detail": "task a remains independently blocked",
        "raw": "state: blocked · source: status-log · task a remains independently blocked",
        "observed_at": "2026-08-11T12:00:00Z",
        "freshness": "fresh"
      },
      "endpoint": {
        "target": "firstmate:fm-01-ship-a-blocked",
        "exists": true,
        "agent_alive": "not_checked",
        "status": "unknown",
        "observed_at": "2026-08-11T12:00:00Z",
        "freshness": "fresh"
      },
      "pr": {
        "url": null,
        "source": "absent"
      },
      "hints": {
        "pending_decision": false,
        "blocked_event": true,
        "open_decisions": [
          {
            "key": "network",
            "verb": "blocked",
            "summary": "task a remains independently blocked"
          }
        ],
        "scout_report_present": false,
        "last_event_text": "blocked [key=network]: task a remains independently blocked"
      },
      "actions": {
        "watch": "bin/fm-peek.sh fm-01-ship-a-blocked",
        "steer": "bin/fm-send.sh fm-01-ship-a-blocked '<instruction>'",
        "return_channel_note": null
      },
      "backlog": null
    },
    {
      "id": "02-ship-a-done",
      "kind": "ship",
      "harness": "claude",
      "mode": "no-mistakes",
      "yolo": "",
      "project": "firstmate",
      "backend": "tmux",
      "remote": null,
      "paths": {
        "meta": {
          "path": "/tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/fm-fleet-snapshot.k71zZm/snapshot-query-reuse/state/02-ship-a-done.meta",
          "present": true
        },
        "status_log": {
          "path": "/tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/fm-fleet-snapshot.k71zZm/snapshot-query-reuse/state/02-ship-a-done.status",
          "present": true,
          "kind": "event_history",
          "last_event": {
            "state": "done",
            "note": "task a duplicate is independently complete",
            "raw": "done: task a duplicate is independently complete"
          }
        },
        "worktree": {
          "path": "/tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/fm-fleet-snapshot.k71zZm/snapshot-query-reuse/projects/scale-repo",
          "present": true
        },
        "home": {
          "path": null,
          "present": false
        },
        "report": {
          "path": "/tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/fm-fleet-snapshot.k71zZm/snapshot-query-reuse/data/02-ship-a-done/report.md",
          "present": false
        }
      },
      "secondmate_projects": [],
      "current_state": {
        "state": "done",
        "source": "status-log",
        "detail": "task a duplicate is independently complete",
        "raw": "state: done · source: status-log · task a duplicate is independently complete",
        "observed_at": "2026-08-11T12:00:00Z",
        "freshness": "fresh"
      },
      "endpoint": {
        "target": "firstmate:fm-02-ship-a-done",
        "exists": true,
        "agent_alive": "not_checked",
        "status": "unknown",
        "observed_at": "2026-08-11T12:00:00Z",
        "freshness": "fresh"
      },
      "pr": {
        "url": null,
        "source": "absent"
      },
      "hints": {
        "pending_decision": false,
        "blocked_event": false,
        "open_decisions": [],
        "scout_report_present": false,
        "last_event_text": "done: task a duplicate is independently complete"
      },
      "actions": {
        "watch": "bin/fm-peek.sh fm-02-ship-a-done",
        "steer": "bin/fm-send.sh fm-02-ship-a-done '<instruction>'",
        "return_channel_note": null
      },
      "backlog": null
    },
    {
      "id": "03-ship-b-decision",
      "kind": "ship",
      "harness": "claude",
      "mode": "no-mistakes",
      "yolo": "",
      "project": "firstmate",
      "backend": "tmux",
      "remote": null,
      "paths": {
        "meta": {
          "path": "/tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/fm-fleet-snapshot.k71zZm/snapshot-query-reuse/state/03-ship-b-decision.meta",
          "present": true
        },
        "status_log": {
          "path": "/tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/fm-fleet-snapshot.k71zZm/snapshot-query-reuse/state/03-ship-b-decision.status",
          "present": true,
          "kind": "event_history",
          "last_event": {
            "state": "working",
            "note": "task b continued unrelated setup",
            "raw": "working: task b continued unrelated setup"
          }
        },
        "worktree": {
          "path": "/tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/fm-fleet-snapshot.k71zZm/snapshot-query-reuse/projects/scale-b",
          "present": true
        },
        "home": {
          "path": null,
          "present": false
        },
        "report": {
          "path": "/tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/fm-fleet-snapshot.k71zZm/snapshot-query-reuse/data/03-ship-b-decision/report.md",
          "present": false
        }
      },
      "secondmate_projects": [],
      "current_state": {
        "state": "working",
        "source": "status-log",
        "detail": "task b continued unrelated setup",
        "raw": "state: working · source: status-log · task b continued unrelated setup",
        "observed_at": "2026-08-11T12:00:00Z",
        "freshness": "fresh"
      },
      "endpoint": {
        "target": "firstmate:fm-03-ship-b-decision",
        "exists": true,
        "agent_alive": "not_checked",
        "status": "unknown",
        "observed_at": "2026-08-11T12:00:00Z",
        "freshness": "fresh"
      },
      "pr": {
        "url": null,

... [22724 bytes truncated] ...

": true,
        "current": {
          "state": "no_active_work",
          "reason": null
        },
        "invalidity": {
          "kind": null,
          "ids": []
        },
        "provenance": {
          "selected": "structured-home",
          "structured_home": "/tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/fm-fleet-snapshot.k71zZm/snapshot-query-reuse-mate",
          "summary_valid": true,
          "trust": "complete",
          "parent_event_role": "historical-only"
        },
        "freshness": {
          "status": "fresh",
          "observed_at": "2026-08-11T12:00:00Z",
          "age_seconds": 0
        },
        "active_children": [],
        "decisions_open": [],
        "holds": [],
        "queued": [],
        "landed": [],
        "endpoints": [],
        "counts": {
          "active_children": 0,
          "decisions_open": 0,
          "holds": 0,
          "queued": 0,
          "landed": 0,
          "endpoints": 0
        },
        "omitted": [],
        "parent_event": {
          "raw": "working: registered mate remains independently current",
          "note": "registered mate remains independently current",
          "age_seconds": 0,
          "open_activities": [
            {
              "key": "default",
              "verb": "working",
              "summary": "registered mate remains independently current"
            }
          ],
          "open_decisions": [],
          "activity_scan": {
            "records": [
              {
                "key": "default",
                "verb": "working",
                "summary": "registered mate remains independently current"
              }
            ],
            "available": true,
            "input_truncated": false,
            "retained_truncated": false,
            "reasons": [],
            "lines_in_window": 1,
            "records_in_window": 1
          },
          "reconciliation": {
            "provenance": "parent-status-keyed-fold",
            "trust": "untrusted-supplement",
            "activities": [
              {
                "key": "default",
                "verb": "working",
                "summary": "registered mate remains independently current",
                "verdict": "inconclusive",
                "compared_to": "active_children",
                "matched": null
              }
            ],
            "decisions": [],
            "contradiction": false,
            "inconclusive": true
          }
        },
        "terminal_evidence": {
          "provenance": "parent-direct-report-terminal",
          "trust": "untrusted-supplement",
          "captured": false,
          "observed_at": "2026-08-11T12:00:00Z",
          "freshness": "not-collected",
          "reason": "no useful contradiction check",
          "lines": 0,
          "bytes": 0,
          "event_note_seen": false,
          "contradiction": false
        },
        "contradiction": false
      },
      {
        "id": "10-secondmate",
        "home": "/tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/fm-fleet-snapshot.k71zZm/snapshot-query-reuse/projects/plain",
        "host": null,
        "remote": false,
        "registered": false,
        "current": {
          "state": "unknown",
          "reason": "secondmate metadata is not registered"
        },
        "invalidity": null,
        "provenance": {
          "selected": "parent-event-fallback",
          "structured_home": "/tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/fm-fleet-snapshot.k71zZm/snapshot-query-reuse/projects/plain",
          "parent_event_role": "fallback-only-not-current"
        },
        "freshness": {
          "status": "historical-event",
          "observed_at": "2026-08-11T12:00:00Z",
          "age_seconds": 0
        },
        "active_children": [],
        "decisions_open": [],
        "holds": [],
        "queued": [],
        "landed": [],
        "endpoints": [],
        "counts": {
          "active_children": 0,
          "decisions_open": 0,
          "holds": 0,
          "queued": 0,
          "landed": 0,
          "endpoints": 0
        },
        "omitted": [],
        "parent_event": {
          "raw": "blocked [key=mate-block]: secondmate block stays task-local",
          "note": "secondmate block stays task-local",
          "age_seconds": 0,
          "open_activities": [],
          "open_decisions": [
            {
              "key": "mate-block",
              "verb": "blocked",
              "summary": "secondmate block stays task-local"
            }
          ],
          "activity_scan": {
            "records": [],
            "available": true,
            "input_truncated": false,
            "retained_truncated": false,
            "reasons": [],
            "lines_in_window": 1,
            "records_in_window": 0
          }
        },
        "terminal_evidence": {
          "provenance": "parent-direct-report-terminal",
          "trust": "untrusted-supplement",
          "captured": true,
          "observed_at": "2026-08-11T12:00:00Z",
          "freshness": "fresh",
          "reason": null,
          "lines": 2,
          "bytes": 12,
          "event_note_seen": false,
          "contradiction": false
        },
        "contradiction": false
      },
      {
        "id": "11-secondmate",
        "home": "/tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/fm-fleet-snapshot.k71zZm/snapshot-query-reuse/projects/scout",
        "host": null,
        "remote": false,
        "registered": false,
        "current": {
          "state": "unknown",
          "reason": "secondmate metadata is not registered"
        },
        "invalidity": null,
        "provenance": {
          "selected": "parent-event-fallback",
          "structured_home": "/tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/fm-fleet-snapshot.k71zZm/snapshot-query-reuse/projects/scout",
          "parent_event_role": "fallback-only-not-current"
        },
        "freshness": {
          "status": "historical-event",
          "observed_at": "2026-08-11T12:00:00Z",
          "age_seconds": 0
        },
        "active_children": [],
        "decisions_open": [],
        "holds": [],
        "queued": [],
        "landed": [],
        "endpoints": [],
        "counts": {
          "active_children": 0,
          "decisions_open": 0,
          "holds": 0,
          "queued": 0,
          "landed": 0,
          "endpoints": 0
        },
        "omitted": [],
        "parent_event": {
          "raw": "done: secondmate terminal event stays task-local",
          "note": "secondmate terminal event stays task-local",
          "age_seconds": 0,
          "open_activities": [],
          "open_decisions": [],
          "activity_scan": {
            "records": [],
            "available": true,
            "input_truncated": false,
            "retained_truncated": false,
            "reasons": [],
            "lines_in_window": 1,
            "records_in_window": 0
          }
        },
        "terminal_evidence": {
          "provenance": "parent-direct-report-terminal",
          "trust": "untrusted-supplement",
          "captured": false,
          "observed_at": "2026-08-11T12:00:00Z",
          "freshness": "unknown",
          "reason": "terminal capture unavailable",
          "lines": 0,
          "bytes": 0,
          "event_note_seen": false,
          "contradiction": false
        },
        "contradiction": false
      }
    ],
    "total_registered": 1,
    "total": 3,
    "shown": 3,
    "truncated": 0
  },
  "secondmate_landed": {
    "records": [],
    "truncated": [],
    "unreadable": [
      "/tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/fm-fleet-snapshot.k71zZm/snapshot-query-reuse/projects/plain",
      "/tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/fm-fleet-snapshot.k71zZm/snapshot-query-reuse/projects/scout"
    ],
    "partial": []
  },
  "secondmate_guidance": {
    "note": "For kind=secondmate, bearings selects validated structured state from that registered home; parent events and bounded terminal evidence are fallback-only supplements and never current-state authority."
  }
}
```
</details>
<details>
<summary>Evidence: Focused test timing report</summary>

```text
{
  "families": [
    {
      "count": 1,
      "duration_ms": 104068,
      "failed": 0,
      "name": "pr-forge"
    },
    {
      "count": 3,
      "duration_ms": 56133,
      "failed": 0,
      "name": "pure-contract-unit"
    },
    {
      "count": 2,
      "duration_ms": 109909,
      "failed": 0,
      "name": "snapshot-bearings"
    },
    {
      "count": 2,
      "duration_ms": 9605,
      "failed": 0,
      "name": "unclassified"
    }
  ],
  "finished_at": "2026-08-11T19:35:59Z",
  "run_id": "fm-test-run-1786476679117-392669",
  "scripts": [
    {
      "duration_ms": 12571,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-crew-state.test.sh"
    },
    {
      "duration_ms": 25580,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-decision-hold-lifecycle.test.sh"
    },
    {
      "duration_ms": 3524,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "unclassified",
      "gate_skip": false,
      "path": "tests/fm-wake-drain-open-decisions.test.sh"
    },
    {
      "duration_ms": 6081,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "unclassified",
      "gate_skip": false,
      "path": "tests/fm-wake-drain-open-decisions-cursor.test.sh"
    },
    {
      "duration_ms": 22486,
      "exit": 0,
      "expected_gate_skip": "optional-binary",
      "family": "snapshot-bearings",
      "gate_skip": false,
      "path": "tests/fm-fleet-snapshot-view.test.sh"
    },
    {
      "duration_ms": 87423,
      "exit": 0,
      "expected_gate_skip": "optional-binary",
      "family": "snapshot-bearings",
      "gate_skip": false,
      "path": "tests/fm-bearings-snapshot.test.sh"
    },
    {
      "duration_ms": 17982,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-test-run.test.sh"
    },
    {
      "duration_ms": 104068,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pr-forge",
      "gate_skip": false,
      "path": "tests/fm-teardown.test.sh"
    }
  ],
  "selection": "scripts",
  "started_at": "2026-08-11T19:31:19Z",
  "summary": {
    "duration_ms": 279943,
    "failed": 0,
    "skipped_gate": 0,
    "total": 8
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- 🚨 `bin/fm-nm-run-lib.sh:55` - The intent authorizes reuse only for the coarse “runs --limit 200” query, but this matcher accepts every `runs --limit &lt;value&gt;` call and omits the limit from its key. Thus `FM_CREW_STATE_RUNS_LIMIT=50 fm-fleet-snapshot.sh --json` also enables unauthorized reuse. Restrict reuse to `$3 = 200`, or explicitly approve and key alternate limits.
- 🚨 `tests/fm-fleet-snapshot-view.test.sh:478` - The required proof of “task-local status and liveness” and “complete status history and open-decision truth” is incomplete: all eleven endpoints have the identical `exists == true` assertion, `agent_alive` is unasserted, and each fixture history contains only one event. Shared liveness or a fold that loses a buried decision would pass. Differentiate live/dead/missing endpoints and add a keyed decision followed by an unrelated event, then assert each task’s exact liveness and open-decision record.
- ℹ️ `bin/fm-classify-lib.sh:175` - The new `_set` helpers mutate private `_FM_*_RESULT` globals, while the library header still says functions touch no globals beyond `FM_CAPTAIN_RE`. Update the usage header to document these subprocess-avoidance scratch results, as required by CONTRIBUTING.md.

🔧 Fix: Restrict snapshot query reuse and strengthen task-local proofs
1 info still open:
- ℹ️ `bin/fm-classify-lib.sh:329` - The top-level header now documents private `_FM_*_RESULT` scratch globals, but `status_open_decisions` still claims at line 314 that it touches “no globals beyond” the override. This changed loop invokes setters that mutate those globals. Update the local function contract to distinguish public globals from the documented private scratch results.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh --json /tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/targeted-tests.json tests/fm-crew-state.test.sh tests/fm-decision-hold-lifecycle.test.sh tests/fm-wake-drain-open-decisions.test.sh tests/fm-wake-drain-open-decisions-cursor.test.sh tests/fm-fleet-snapshot-view.test.sh tests/fm-bearings-snapshot.test.sh tests/fm-test-run.test.sh tests/fm-teardown.test.sh`
- <code>Three sequential `timeout 10s env TMPDIR=/tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ FM_ROOT_OVERRIDE=&#34;$PWD&#34; FM_HOME=/data/1/projects bin/fm-fleet-snapshot.sh --json | jq -ce &#39;&lt;schema-and-count projection&gt;&#39;` reads, enforcing zero stderr and `fm-fleet-snapshot.v1`.</code>
- `bash /tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/replay-query-reuse-evidence.sh "$PWD"`
- `jq -e '<11-task/query-count/repeat/home-integrity assertions>' /tmp/no-mistakes-evidence/01KZS313S8HSAEZ6C365J3DPMQ/query-reuse-summary.json`
- <code>Compared stable patch IDs for the four reviewed PR 2180 commits against the four transplanted superset commits; all pairs were identical, and the reviewed head’s tree matched `e40fd1a27c79fb90c52dbcab08056c4ee6789ec9`.</code>
- <code>`git status --short --branch` and a worktree search for residual `fm-nm-snapshot.*` directories.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
