### PR TITLE
fix(bin): honor decision keys after the verb colon

### DIFF
--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -160,13 +160,25 @@ status_is_paused_or_captain_held() {  # <status-line>
 # rule 6), so closure never depends on a busy worker's discipline.
 #
 # Decision key grammar (backward-compatible with the existing "<verb>: <note>"
-# format): an OPTIONAL "[key=<slug>]" token sits between the verb and the colon,
+# format): an OPTIONAL "[key=<slug>]" token names the decision. Its documented
+# position sits between the verb and the colon, and a complete token at the
+# head of the note is accepted as an EQUIVALENT position, because that
+# misplaced-colon shape is common real worker output whose stated key must
+# never silently collapse into the shared "default" bucket (issue #2109):
 #   needs-decision [key=api-shape]: <summary>
+#   needs-decision: [key=api-shape] <summary>
 #   resolved       [key=api-shape]: <how it was decided>
-# A line with no token uses the key "default", preserving the historical
-# one-open-decision-per-task behavior (a bare "resolved:" closes "default").
-# The three parsers are pure reads of a single line; the verb parser strips any
-# key token before the colon so the leading word is recovered cleanly.
+# Both positions state the same key and yield the same note (a consumed
+# note-head token is key metadata, stripped from the note); when both positions
+# carry a token, the documented before-colon one wins and the note-head token
+# stays note text. A token deeper inside the note is prose, never a stated key,
+# so a summary merely MENTIONING "[key=x]" cannot open or close that decision.
+# A line with no token in either position uses the key "default", preserving
+# the historical one-open-decision-per-task behavior (a bare "resolved:" closes
+# "default"). A stated key whose slug fails the charset below is rejected (the
+# folds skip the line), never rewritten to "default".
+# The parsers are pure reads of a single line; the verb parser strips any key
+# token before the colon so the leading word is recovered cleanly.
 status_line_verb() {  # <status-line> -> leading verb word
   local v=${1%%:*}
   v=${v%%\[key=*}
@@ -174,25 +186,65 @@ status_line_verb() {  # <status-line> -> leading verb word
   v=${v%"${v##*[![:space:]]}"}
   printf '%s' "$v"
 }
-status_line_note() {  # <status-line> -> text after the first colon, trimmed
-  case "$1" in
-    *:*) local n=${1#*:}; printf '%s' "${n#"${n%%[![:space:]]*}"}" ;;
-    *) printf '%s' "$1" ;;
+# 0 when a complete "[key=...]" token sits in the documented position before
+# the line's first colon (or anywhere on a line that has no colon at all).
+_fm_key_before_colon() {  # <status-line>
+  case "${1%%:*}" in
+    *\[key=*\]*) return 0 ;;
+    *) return 1 ;;
   esac
 }
-_fm_decision_key() {  # <status-line> -> key slug, or "default" when no token
-  local prefix=${1%%:*} k
-  case "$prefix" in
-    *\[key=*\]*)
-      k=${prefix#*\[key=}
-      k=${k%%\]*}
-      case "$k" in
-        ''|*[!A-Za-z0-9._-]*) return 1 ;;
-        *) printf '%s' "$k" ;;
-      esac
-      ;;
-    *) printf 'default' ;;
+# Raw slug of a complete "[key=<slug>]" token at the head of the note (the
+# first thing after the line's first colon, ignoring whitespace). Fails when
+# the line has no colon or no complete token there; slug charset validity is
+# the caller's check via _fm_decision_slug_ok, exactly as for the before-colon
+# position.
+_fm_key_at_note_head() {  # <status-line> -> raw slug
+  local rest
+  case "$1" in
+    *:*) rest=${1#*:} ;;
+    *) return 1 ;;
   esac
+  rest=${rest#"${rest%%[![:space:]]*}"}
+  case "$rest" in
+    \[key=*\]*) rest=${rest#\[key=}; printf '%s' "${rest%%\]*}" ;;
+    *) return 1 ;;
+  esac
+}
+# 0 when a stated key slug is well-formed: nonempty, A-Za-z0-9._- only.
+_fm_decision_slug_ok() {  # <slug>
+  case "$1" in
+    ''|*[!A-Za-z0-9._-]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+status_line_note() {  # <status-line> -> text after the first colon, trimmed
+  local n k
+  case "$1" in
+    *:*) n=${1#*:}; n=${n#"${n%%[![:space:]]*}"} ;;
+    *) printf '%s' "$1"; return 0 ;;
+  esac
+  # A note-head token that states this line's key (no before-colon token, valid
+  # slug) is key metadata, not note text: strip it so both stated-key positions
+  # yield the same note.
+  if ! _fm_key_before_colon "$1" && k=$(_fm_key_at_note_head "$1") \
+    && _fm_decision_slug_ok "$k"; then
+    n=${n#"[key=$k]"}
+    n=${n#"${n%%[![:space:]]*}"}
+  fi
+  printf '%s' "$n"
+}
+_fm_decision_key() {  # <status-line> -> key slug, or "default" when no token
+  local k
+  if _fm_key_before_colon "$1"; then
+    k=${1%%:*}
+    k=${k#*\[key=}
+    k=${k%%\]*}
+  else
+    k=$(_fm_key_at_note_head "$1") || { printf 'default'; return 0; }
+  fi
+  _fm_decision_slug_ok "$k" || return 1
+  printf '%s' "$k"
 }
 # Drop the record for <key> from a newline-terminated "<key>\t<verb>\t<note>" set.
 # Portable (no associative arrays) so the fold runs on bash 3.2 as well as 4+.
@@ -384,7 +436,7 @@ _fm_open_decisions_cursor_path() {  # <status-file>
   printf '%s/.%s.open-decisions-cursor' "$dir" "${base%.status}"
 }
 
-FM_OPEN_DECISIONS_FOLD_VERSION=2
+FM_OPEN_DECISIONS_FOLD_VERSION=3
 
 # Portable device:inode identity for the rotation/recreation check below.
 _fm_open_decisions_file_ident() {  # <file> -> "dev:inode", empty on I/O failure

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -135,6 +135,7 @@ family_for_basename() {
     fm-arm-pretool-check.test.sh|fm-ask-user-authority.test.sh|\
     fm-brief.test.sh|fm-vendor-auth-probe.test.sh|\
     fm-calm-pi-extension.test.sh|fm-cd-pretool-check.test.sh|\
+    fm-classify-decision-key.test.sh|\
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
     fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\

--- a/tests/fm-classify-decision-key.test.sh
+++ b/tests/fm-classify-decision-key.test.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# tests/fm-classify-decision-key.test.sh - decision-key position tolerance in
+# the open-decisions fold (bin/fm-classify-lib.sh). A "[key=<slug>]" token is
+# documented between the verb and the colon (needs-decision [key=x]: note), but
+# workers commonly write the colon first (needs-decision: [key=x] note); that
+# stated key must be honored, never silently folded into the shared "default"
+# bucket where an answer can close the wrong record (issue #2109). These tests
+# drive the REAL status_open_decisions / status_open_decisions_incremental
+# functions over crafted status files and assert their folded output, never the
+# fold's own source text. Cross-drain cursor persistence and the incremental
+# cost bound live in tests/fm-wake-drain-open-decisions-cursor.test.sh; the
+# drain wiring lives in tests/fm-wake-drain-open-decisions.test.sh.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# shellcheck source=bin/fm-classify-lib.sh
+. "$ROOT/bin/fm-classify-lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-classify-decision-key-tests)
+
+# Fresh per-case dir so each case's incremental cursor sidecar cannot leak into
+# another case.
+case_dir() {  # <name>
+  local d="$TMP_ROOT/$1"
+  mkdir -p "$d"
+  printf '%s' "$d"
+}
+
+# Assert the whole-file fold of <status-file> equals <expected>, and that the
+# incremental fold agrees with it on the exact same input - the two consumption
+# strategies must never diverge on what is open.
+assert_fold() {  # <status-file> <expected> <label>
+  local f=$1 expected=$2 label=$3 full incr
+  full=$(status_open_decisions "$f")
+  incr=$(status_open_decisions_incremental "$f")
+  [ "$full" = "$expected" ] \
+    || fail "$label: full fold mismatch: got '$full' want '$expected'"
+  [ "$incr" = "$full" ] \
+    || fail "$label: incremental fold diverged from the full fold: got '$incr' want '$full'"
+}
+
+test_stated_key_is_honored_in_both_positions() {
+  local dir before after expected
+  dir=$(case_dir positions)
+  printf 'needs-decision [key=api-shape]: pick REST or RPC\n' > "$dir/before.status"
+  printf 'needs-decision: [key=api-shape] pick REST or RPC\n' > "$dir/after.status"
+  expected=$(printf 'api-shape\tneeds-decision\tpick REST or RPC\n')
+
+  assert_fold "$dir/before.status" "$expected" "documented before-colon form"
+  assert_fold "$dir/after.status" "$expected" "colon-first form"
+
+  # Equivalence is byte-for-byte: both positions yield the same key AND the
+  # same note (a consumed note-head token is key metadata, not note text).
+  before=$(status_open_decisions "$dir/before.status")
+  after=$(status_open_decisions "$dir/after.status")
+  [ "$before" = "$after" ] \
+    || fail "the two key positions folded to different records: '$before' vs '$after'"
+  pass "a stated [key=X] opens X whether it precedes or follows the verb colon"
+}
+
+test_bare_keyless_line_still_folds_to_default() {
+  local dir
+  dir=$(case_dir keyless)
+  printf 'needs-decision: which color\n' > "$dir/bare.status"
+  assert_fold "$dir/bare.status" "$(printf 'default\tneeds-decision\twhich color\n')" \
+    "bare keyless line"
+
+  # And a bare keyless resolution still closes it - the historical
+  # one-open-decision-per-task behavior is unchanged.
+  printf 'resolved: went with blue\n' >> "$dir/bare.status"
+  assert_fold "$dir/bare.status" "" "bare keyless resolution"
+  pass "a keyless needs-decision still opens and closes the default key"
+}
+
+test_resolution_closes_across_positions() {
+  local dir
+  dir=$(case_dir cross-close)
+  # Opened colon-first, closed in the documented form (what fm-send's
+  # --resolve-key writes): the exact failure from issue #2109.
+  printf 'needs-decision: [key=seam-max-bound] pick the bound\n' > "$dir/a.status"
+  printf 'resolved [key=seam-max-bound]: answered: use 4\n' >> "$dir/a.status"
+  assert_fold "$dir/a.status" "" "documented resolution closing a colon-first open"
+
+  # And the mirror: opened documented, closed colon-first.
+  printf 'needs-decision [key=seam-max-bound]: pick the bound\n' > "$dir/b.status"
+  printf 'resolved: [key=seam-max-bound] answered: use 4\n' >> "$dir/b.status"
+  assert_fold "$dir/b.status" "" "colon-first resolution closing a documented open"
+  pass "a resolution closes its decision regardless of either line's key position"
+}
+
+test_blocked_is_position_tolerant_like_needs_decision() {
+  local dir expected
+  dir=$(case_dir blocked)
+  expected=$(printf 'creds\tblocked\twaiting on the deploy token\n')
+  printf 'blocked [key=creds]: waiting on the deploy token\n' > "$dir/before.status"
+  printf 'blocked: [key=creds] waiting on the deploy token\n' > "$dir/after.status"
+  assert_fold "$dir/before.status" "$expected" "documented blocked form"
+  assert_fold "$dir/after.status" "$expected" "colon-first blocked form"
+  pass "blocked [key=X] opens X in both key positions"
+}
+
+test_two_colon_form_decisions_stay_distinct() {
+  local dir expected
+  dir=$(case_dir distinct)
+  # The concrete hazard behind the silent collapse: two colon-form decisions on
+  # one task used to share the default bucket, so answering one could close the
+  # other. They must stay independently open and independently closable.
+  printf 'needs-decision: [key=alpha] first question\n' > "$dir/t.status"
+  printf 'needs-decision: [key=beta] second question\n' >> "$dir/t.status"
+  expected=$(printf 'alpha\tneeds-decision\tfirst question\nbeta\tneeds-decision\tsecond question\n')
+  assert_fold "$dir/t.status" "$expected" "two colon-form decisions"
+
+  printf 'resolved [key=alpha]: answered: yes\n' >> "$dir/t.status"
+  assert_fold "$dir/t.status" "$(printf 'beta\tneeds-decision\tsecond question\n')" \
+    "closing one of two colon-form decisions"
+  pass "two colon-form keyed decisions never collapse into one shared bucket"
+}
+
+test_mid_note_prose_mention_is_not_a_stated_key() {
+  local dir
+  dir=$(case_dir prose)
+  # Only a token at the head of the note states a key; a summary merely
+  # mentioning "[key=x]" deeper in must neither open nor close that key.
+  printf 'needs-decision: pick a [key=red] or [key=blue] theme\n' > "$dir/t.status"
+  assert_fold "$dir/t.status" \
+    "$(printf 'default\tneeds-decision\tpick a [key=red] or [key=blue] theme\n')" \
+    "mid-note prose mention"
+
+  printf 'needs-decision [key=red]: which shade\n' >> "$dir/t.status"
+  printf 'working: still thinking about [key=red] here\n' >> "$dir/t.status"
+  assert_fold "$dir/t.status" \
+    "$(printf 'default\tneeds-decision\tpick a [key=red] or [key=blue] theme\nred\tneeds-decision\twhich shade\n')" \
+    "prose mention leaves the open set untouched"
+  pass "a [key=x] mentioned mid-note is prose, never an opened or closed key"
+}
+
+test_malformed_stated_key_never_collapses_to_default() {
+  local dir
+  dir=$(case_dir malformed)
+  # A stated-but-invalid slug is rejected in BOTH positions - identically,
+  # and never rewritten into the shared default bucket.
+  printf 'needs-decision [key=bad key]: before-colon malformed\n' > "$dir/before.status"
+  printf 'needs-decision: [key=bad key] colon-first malformed\n' > "$dir/after.status"
+  assert_fold "$dir/before.status" "" "malformed before-colon key"
+  assert_fold "$dir/after.status" "" "malformed colon-first key"
+  pass "a malformed stated key is rejected in both positions, never folded as default"
+}
+
+test_incremental_agrees_with_full_fold_across_appends() {
+  local dir f expected
+  dir=$(case_dir incremental)
+  f="$dir/t.status"
+  # assert_fold already pins incremental==full per snapshot; this case pins the
+  # agreement ACROSS appends, where the incremental path folds only the new
+  # bytes on top of its persisted open set while the full fold re-reads
+  # everything from scratch.
+  printf 'needs-decision: [key=seam-max-bound] pick the bound\n' > "$f"
+  expected=$(printf 'seam-max-bound\tneeds-decision\tpick the bound\n')
+  assert_fold "$f" "$expected" "colon-first open, first read"
+
+  printf 'working: routine progress note\n' >> "$f"
+  printf 'needs-decision: [key=other] a second colon-form question\n' >> "$f"
+  expected=$(printf 'seam-max-bound\tneeds-decision\tpick the bound\nother\tneeds-decision\ta second colon-form question\n')
+  assert_fold "$f" "$expected" "colon-first opens buried under later appends"
+
+  printf 'resolved [key=seam-max-bound]: answered: use 4\n' >> "$f"
+  printf 'resolved: [key=other] cleared on its own\n' >> "$f"
+  assert_fold "$f" "" "cross-position resolutions close both"
+  pass "the incremental fold matches the full fold across appends in both key positions"
+}
+
+test_stated_key_is_honored_in_both_positions
+test_bare_keyless_line_still_folds_to_default
+test_resolution_closes_across_positions
+test_blocked_is_position_tolerant_like_needs_decision
+test_two_colon_form_decisions_stay_distinct
+test_mid_note_prose_mention_is_not_a_stated_key
+test_malformed_stated_key_never_collapses_to_default
+test_incremental_agrees_with_full_fold_across_appends

--- a/tests/fm-send-resolve-key.test.sh
+++ b/tests/fm-send-resolve-key.test.sh
@@ -132,6 +132,35 @@ test_answer_send_closes_open_decision() {
   pass "fm-send --resolve-key: the answer send itself closes the open decision"
 }
 
+# The reported failure behind issue #2109: a worker that put the colon first
+# (needs-decision: [key=X] ...) had its key silently folded to "default", so
+# the answer's --resolve-key X refused with "no open decision or blocker with
+# that key". The stated key must be honored in that position too, end to end
+# through the real send.
+test_colon_first_key_position_is_answerable() {
+  local dir fb log home rc out
+  dir="$TMP_ROOT/colon-first"; mkdir -p "$dir"
+  fb=$(make_stubs "$dir"); log="$dir/send.log"
+  home=$(setup_home colon-first)
+  fm_write_meta "$home/state/t8.meta" "window=sess:fm-t8" "kind=ship"
+  printf 'needs-decision: [key=seam-max-bound] cap the seam at 4 or 8\n' > "$home/state/t8.status"
+
+  out=$(drain_out "$home")
+  printf '%s' "$out" | grep -F '[key=seam-max-bound]' >/dev/null \
+    || fail "precondition: the colon-first decision should list as open under its stated key: $out"
+
+  run_send "$fb" "$home" "$log" t8 --resolve-key seam-max-bound "cap it at 4"; rc=$?
+  expect_code 0 "$rc" "answering a colon-first stated key should succeed, not refuse as unknown"
+  grep -F 'resolved [key=seam-max-bound]: answered: cap it at 4' "$home/state/t8.status" >/dev/null \
+    || fail "the closing resolved line is missing:"$'\n'"$(cat "$home/state/t8.status")"
+
+  out=$(drain_out "$home")
+  if printf '%s' "$out" | grep -F 'OPEN DECISIONS' >/dev/null; then
+    fail "the answered colon-first decision still lists as open: $out"
+  fi
+  pass "fm-send --resolve-key: a colon-first stated key is open under that key and answerable"
+}
+
 test_answer_starts_work_never_orphans() {
   local dir fb log home rc out
   dir="$TMP_ROOT/starts-work"; mkdir -p "$dir"
@@ -396,6 +425,7 @@ test_flag_misuse_refuses() {
 }
 
 test_answer_send_closes_open_decision
+test_colon_first_key_position_is_answerable
 test_answer_starts_work_never_orphans
 test_routine_steer_never_closes
 test_not_open_key_refuses_before_send


### PR DESCRIPTION
## Intent

Fix firstmate GitHub issue #2109: status decision keys silently collapse to 'default' when the [key=X] token follows the verb colon. The open-decisions key parser in bin/fm-classify-lib.sh (status_open_decisions and its incremental cursor-backed variant status_open_decisions_incremental) only recognized a key in the documented position 'needs-decision [key=X]: ...' (token before the verb colon). A worker writing 'needs-decision: [key=X] ...' (token after the colon) had its stated key silently parsed as 'default' - a shared bucket - so two open decisions on one task collapsed into one record, an answer could close the wrong record, and bin/fm-send.sh --resolve-key X refused with 'no open decision or blocker with that key'. Observed live on independent claude and codex tasks, so the misplaced-colon shape is common worker output. Chosen behavior, per the issue's stated preference: accept '<verb>: [key=<slug>]' as an EQUIVALENT form - extract the stated key correctly regardless of its position relative to the verb colon (silently rewriting a stated key to 'default' is the unsafe option and must end). Requirements carried from the task: (1) both status_open_decisions AND status_open_decisions_incremental must agree - the fix goes through the shared single-owner key extractor (_fm_decision_key) feeding the one fold rule (_fm_decision_fold_line) so the incremental cursor path cannot diverge from the full fold, and FM_OPEN_DECISIONS_FOLD_VERSION is bumped (2->3) so persisted cursors folded under the old interpretation are discarded and rebuilt from byte 0 as that constant's contract requires; (2) the same position-robust extraction applies symmetrically to 'resolved [key=X]:' / 'blocked [key=X]:' (and captain-held and the activities fold) so an answer closes the right record from either position; (3) a genuinely keyless line keeps its meaning - bare 'needs-decision:' with no [key=...] still folds to 'default'. Deliberate scoping decisions: only a complete [key=<slug>] token at the HEAD of the note (immediately after the first colon, ignoring leading whitespace) states a key - a token deeper inside the note is prose, so a summary merely mentioning '[key=x]' cannot open or close that decision; when both positions carry a token the documented before-colon position wins and the note-head token stays note text; a consumed note-head token is stripped from the note so both positions yield byte-identical fold records (this also keeps the reserved-key namespace vocabulary check in _fm_decision_key_transition_allowed working symmetrically); a stated-but-malformed slug (charset violation in a complete token) is rejected in both positions exactly like the pre-existing before-colon behavior - the folds skip the line - never silently rewritten to 'default'. The documented before-colon form remains the canonical taught form (briefs and fm-send still write it); the note-head form is parser tolerance. Regression tests are required to be behavioral through the real functions, never source-text asserts: new tests/fm-classify-decision-key.test.sh sources the real lib and covers the documented before-colon form -> X, the colon-first form -> X (the fixed case), bare keyless -> default (unchanged, open and close), resolved/blocked symmetry in both positions including cross-position open/close, two colon-form decisions staying distinct and independently closable, mid-note prose mentions not hijacking keys, malformed stated keys rejected in both positions, and the incremental path matching the full fold on the same input including across appends; it is registered in bin/fm-test-run.sh's pure-contract-unit family. One end-to-end case was also added to tests/fm-send-resolve-key.test.sh pinning the exact reported symptom: a colon-first open is listed under its stated key and fm-send --resolve-key answers and closes it. Acceptance criteria: no silent collapse of a stated key; bin/fm-lint.sh clean (it covers bin/*.sh and tests/*.sh); minimal focused diff (bin/fm-classify-lib.sh, bin/fm-test-run.sh family registration, the two test files). Delivery: this no-mistakes run must reach a PR with genuinely green CI; yolo is OFF - the captain merges, no self-merge.

## What Changed

- Accept complete `[key=<slug>]` tokens immediately after the verb colon while preserving the canonical before-colon form and keyless `default` behavior.
- Keep key extraction consistent across full and incremental decision folds, reject malformed stated keys, and bump the persisted fold version to rebuild stale cursors.
- Add behavioral unit and end-to-end coverage for position-tolerant opening, closing, and `fm-send --resolve-key` handling.

## Risk Assessment

✅ Low: The focused shared-parser change satisfies the stated invariants, keeps full and incremental folds aligned, bumps persisted fold state, and adds behavioral regression coverage without a substantiated source defect.

## Testing

After inspecting the focused diff and clean worktree baseline, targeted parser, fm-send, and cursor-rebuild tests passed; manual checks confirmed captain-held/activity symmetry and an end-to-end colon-first decision was listed under its stated key, answered successfully, persisted as resolved, and disappeared from OPEN DECISIONS. CLI transcript evidence was captured; no visual screenshot was applicable.

<details>
<summary>Evidence: Colon-first keyed decision listed, resolved through fm-send, and closed</summary>

```text
=== Worker status (colon-first key) ===
needs-decision: [key=seam-max-bound] cap the seam at 4 or 8
=== Firstmate OPEN DECISIONS before answer ===
OPEN DECISIONS (still open, folded from the durable status logs - not just the latest line):
t2109 [key=seam-max-bound] needs-decision: cap the seam at 4 or 8
OPEN DECISIONS: close one by answering it: bin/fm-send.sh <task> --resolve-key <key> '<answer>'
=== Captain answers with fm-send --resolve-key seam-max-bound ===
exit=0
delivered-to-worker=cap it at 4
=== Persisted status ledger after answer ===
needs-decision: [key=seam-max-bound] cap the seam at 4 or 8
resolved [key=seam-max-bound]: answered: cap it at 4
=== Firstmate OPEN DECISIONS after answer ===
(none)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"fe9d158779dbd5de516af35422669a7fb0a0f1e5","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-classify-decision-key.test.sh`
- `bash tests/fm-send-resolve-key.test.sh`
- `bin/fm-test-run.sh tests/fm-classify-decision-key.test.sh tests/fm-send-resolve-key.test.sh`
- `bash tests/fm-wake-drain-open-decisions-cursor.test.sh`
- <code>Manual fold checks exercised colon-first `captain-held`, activity open/close symmetry, and canonical before-colon precedence when both positions contain keys.</code>
- <code>Manual end-to-end fixture ran `bin/fm-wake-drain.sh`, then `bin/fm-send.sh t2109 --resolve-key seam-max-bound &#39;cap it at 4&#39;`, and drained again.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
