### PR TITLE
fix(spawn): prevent duplicate worktree ownership across live tasks

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -98,6 +98,15 @@
 #   even when they select different backends. A fresh spawn first takes the
 #   per-home task-set lock and refuses rather than waits when forced teardown owns
 #   it; relaunch is exempt because the existing task's control lock covers it.
+#   That same task-set lock serializes isolated-copy allocation through metadata
+#   publication across different task ids. Immediately after an allocator yields
+#   a canonical ship/scout worktree, and before fetch, checkout, reset, hook, or
+#   other spawn-owned mutation in it, spawn compares the path with every ordinary
+#   task record still present in this home's state directory. Any matching owner
+#   is refused by task id without consulting endpoint activity or status. Missing,
+#   duplicate, non-regular, non-canonical, or otherwise ambiguous ordinary-task
+#   ownership metadata also refuses allocation. Only absence after the existing
+#   teardown owner removes a task record proves that ownership retired.
 #   With no harness arg, a crewmate/scout spawn resolves the CREW harness only when
 #   config/crew-dispatch.json is absent. When that file exists, crewmate/scout
 #   spawns require an explicit harness so firstmate cannot silently skip dispatch
@@ -1685,6 +1694,62 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   fi
 }
 
+# Called only for a fresh ordinary task while SPAWN_TASK_SET_LOCK is held.
+# The task-set lock starts before allocation and remains held until this task's
+# metadata is published, so no competing spawn can pass this scan and publish
+# the same candidate in the check-to-publication interval. The existing teardown
+# path is the sole cleanup owner that removes retired task records; presence here
+# therefore means ownership, never merely an endpoint-liveness hint.
+assert_spawn_worktree_unowned() {  # <candidate-worktree>
+  local candidate=$1 candidate_real meta owner_id kind_count kind owner_worktree owner_real
+  candidate_real=$(cd "$candidate" 2>/dev/null && pwd -P) || {
+    echo "error: candidate worktree '$candidate' cannot be canonicalized; refusing allocation" >&2
+    return 1
+  }
+  for meta in "$STATE"/*.meta; do
+    [ -e "$meta" ] || [ -L "$meta" ] || continue
+    owner_id=${meta##*/}
+    owner_id=${owner_id%.meta}
+    [ "$owner_id" != "$ID" ] || continue
+    if [ ! -f "$meta" ] || [ -L "$meta" ] || ! fm_task_id_path_safe "$owner_id"; then
+      echo "error: ownership record '$meta' is not a regular, unambiguous task record; refusing worktree allocation" >&2
+      return 1
+    fi
+    kind_count=$(grep -c '^kind=' "$meta" 2>/dev/null || true)
+    case "$kind_count" in
+      0) kind=ship ;;
+      1) kind=$(fm_backend_meta_exact_value "$meta" kind) || kind= ;;
+      *) kind= ;;
+    esac
+    case "$kind" in
+      secondmate) continue ;;
+      ship|scout) ;;
+      *)
+        echo "error: ownership record for task $owner_id has a missing, duplicate, or unknown kind; refusing worktree allocation" >&2
+        return 1
+        ;;
+    esac
+    owner_worktree=$(fm_backend_meta_exact_value "$meta" worktree) || {
+      echo "error: ownership record for task $owner_id has a missing, empty, or ambiguous worktree; refusing worktree allocation" >&2
+      return 1
+    }
+    case "$owner_worktree" in
+      *$'\n'*|*$'\r'*|*$'\t'*)
+        echo "error: ownership record for task $owner_id has a malformed worktree; refusing worktree allocation" >&2
+        return 1
+        ;;
+    esac
+    owner_real=$(cd "$owner_worktree" 2>/dev/null && pwd -P) || {
+      echo "error: ownership record for task $owner_id names unavailable worktree '$owner_worktree'; refusing worktree allocation" >&2
+      return 1
+    }
+    if [ "$owner_real" = "$candidate_real" ]; then
+      echo "error: isolated worktree '$candidate_real' is already owned by live task $owner_id; refusing allocation for task $ID" >&2
+      return 1
+    fi
+  done
+}
+
 freshen_spawn_worktree_base() {  # <worktree>
   local worktree=$1 default target expected actual status
   if ! git -C "$worktree" fetch --quiet origin; then
@@ -2219,6 +2284,12 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   validate_spawn_worktree "treehouse get" "$T"
 fi
 if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
+  if ! assert_spawn_worktree_unowned "$WT"; then
+    # An Orca allocator may have returned a pre-existing worktree identity.
+    # Once ownership is uncertain, abort cleanup must not remove that copy.
+    [ "$BACKEND" != orca ] || ORCA_ABORT_CLEANUP=0
+    exit 1
+  fi
   freshen_spawn_worktree_base "$WT" || exit 1
 fi
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -149,8 +149,9 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
+While holding the home task-set lock from allocation through task-record publication, `fm-spawn.sh` also refuses any candidate canonically owned by another still-recorded ordinary task before its first post-allocation project-copy mutation; endpoint activity never releases ownership, and only teardown's task-record removal does.
 `fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
-Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
+Its header owns the exact refusal mechanics, while `tests/fm-spawn-worktree-settle.test.sh`, `tests/fm-backend-orca.test.sh`, and `tests/fm-spawn-pool-base-freshen.test.sh` own the portable regression coverage.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.
 Its operating checkout (`FM_ROOT`) and the disposable crewmate worktrees are all linked git worktrees of the same repository, so the valid discriminator is branch state, not whether the checkout is linked.

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -266,14 +266,20 @@ HERDR_LAB_SESSION=$(PATH="$HERDR_ORIGINAL_PATH" \
 export HERDR_SESSION="$HERDR_LAB_SESSION" HERDR_LAB_SESSION
 LAB_READY=0
 RECORDED_WORKTREES=""
+WORKTREE_HOLD_PIDS=""
 LOCK_CONTENTION_OWNER_PID=
 cleanup_all() {
-  local wt
+  local wt pid
   if [ -n "$LOCK_CONTENTION_OWNER_PID" ]; then
     kill "$LOCK_CONTENTION_OWNER_PID" 2>/dev/null || true
     wait "$LOCK_CONTENTION_OWNER_PID" 2>/dev/null || true
     LOCK_CONTENTION_OWNER_PID=
   fi
+  for pid in $WORKTREE_HOLD_PIDS; do
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+  done
+  WORKTREE_HOLD_PIDS=""
   while IFS= read -r wt; do
     [ -n "$wt" ] || continue
     [ -d "$wt" ] || continue
@@ -369,6 +375,31 @@ remember_meta_worktree() {  # <meta>
   [ -n "$wt" ] || fail "metadata did not record a worktree"
   RECORDED_WORKTREES="${RECORDED_WORKTREES}${wt}"$'\n'
   printf '%s' "$wt"
+}
+
+# Treehouse treats a worktree as free the moment no live process has its cwd
+# inside it, and hands the lowest free slot to the next `treehouse get`. A lab
+# session stop kills every pane shell at once, which would let the next spawn
+# be handed a copy that a still-recorded live task owns - a duplicate
+# allocation fm-spawn.sh refuses outright (assert_spawn_worktree_unowned)
+# rather than mutating another task's copy. A real live owner always keeps a
+# process inside its copy; these holders restore that invariant across the
+# suite's deliberate restarts so the restart cases exercise same-identity
+# reclaim rather than the ownership refusal. `treehouse return --force` during
+# ordinary teardown terminates a holder along with any other lingering
+# process, so held tasks tear down exactly as before.
+hold_recorded_worktrees() {
+  local home meta wt
+  for home in "${HOME_DIR:-}" "${SECOND_HOME_A:-}" "${SECOND_HOME_B:-}"; do
+    [ -n "$home" ] && [ -d "$home/state" ] || continue
+    for meta in "$home"/state/*.meta; do
+      [ -f "$meta" ] || continue
+      wt=$(grep '^worktree=' "$meta" | cut -d= -f2- | head -n 1)
+      [ -n "$wt" ] && [ -d "$wt" ] || continue
+      (cd "$wt" && exec sleep 900) &
+      WORKTREE_HOLD_PIDS="$WORKTREE_HOLD_PIDS $!"
+    done
+  done
 }
 
 make_project() {  # <dir>
@@ -1168,6 +1199,7 @@ for RESTART_ID in fm-hibit-resume-r1 wheelhouse-healing-r1; do
   PATH="$HERDR_ORIGINAL_PATH" \
     "$HERDR_LAB_HELPER" stop "$HERDR_LAB_SESSION" >/dev/null \
     || fail "could not stop the isolated session for $RESTART_ID validation"
+  hold_recorded_worktrees
   PATH="$HERDR_ORIGINAL_PATH" \
     "$HERDR_LAB_HELPER" provision "$HERDR_LAB_SESSION" \
     || fail "could not reprovision the isolated session for $RESTART_ID validation"
@@ -1198,6 +1230,7 @@ for RESTART_ID in fm-hibit-resume-r1 wheelhouse-healing-r1; do
   if [ "$RESTART_ID" = fm-hibit-resume-r1 ]; then
     PATH="$HERDR_ORIGINAL_PATH" "$HERDR_LAB_HELPER" stop "$HERDR_LAB_SESSION" >/dev/null \
       || fail "could not stop the isolated session for idempotent reclaim"
+    hold_recorded_worktrees
     PATH="$HERDR_ORIGINAL_PATH" "$HERDR_LAB_HELPER" provision "$HERDR_LAB_SESSION" \
       || fail "could not reprovision the isolated session for idempotent reclaim"
     PRIOR_RESTART_WT=$NEW_RESTART_WT
@@ -1241,6 +1274,7 @@ CROSS_BOUND_HOME=$(grep '^home=' "$SECOND_HOME_A/state/$CROSS_RESTART_ID.herdr-p
   || fail "cross-home restart published a journal in the primary home"
 PATH="$HERDR_ORIGINAL_PATH" "$HERDR_LAB_HELPER" stop "$HERDR_LAB_SESSION" >/dev/null \
   || fail "could not stop the isolated session for cross-home restart"
+hold_recorded_worktrees
 PATH="$HERDR_ORIGINAL_PATH" "$HERDR_LAB_HELPER" provision "$HERDR_LAB_SESSION" \
   || fail "could not reprovision the isolated session for cross-home restart"
 spawn_task "$CROSS_RESTART_ID" "$SECOND_HOME_A" "$PROJECT_DIR" > "$TMP_ROOT/cross-restart-resume.out" 2> "$TMP_ROOT/cross-restart-resume.err" \
@@ -1279,6 +1313,7 @@ PRIMARY_WAVE_OLD_PANE=$(grep '^herdr_pane_id=' "$PRIMARY_WAVE_META" | cut -d= -f
 BRAVO_WAVE_OLD_PANE=$(grep '^herdr_pane_id=' "$BRAVO_WAVE_META" | cut -d= -f2-)
 PATH="$HERDR_ORIGINAL_PATH" "$HERDR_LAB_HELPER" stop "$HERDR_LAB_SESSION" >/dev/null \
   || fail "could not stop the isolated session for concurrent recovery"
+hold_recorded_worktrees
 PATH="$HERDR_ORIGINAL_PATH" "$HERDR_LAB_HELPER" provision "$HERDR_LAB_SESSION" \
   || fail "could not reprovision the isolated session for concurrent recovery"
 CONCURRENT_RECOVERY_FOCUS=$(focus_snapshot)

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -526,6 +526,52 @@ test_spawn_writes_orca_metadata_and_launches_harness() {
   pass "fm-spawn.sh --backend orca: reuses implicit terminal, records metadata, launches harness"
 }
 
+test_spawn_refuses_orca_owned_worktree_without_removing_it() {
+  local proj wt data state config owner_id id out status
+  owner_id="orcaownerz7"
+  id="orcacontenderz8"
+  proj="$TMP_ROOT/owned-spawn-project"
+  wt="$TMP_ROOT/owned-spawn-wt"
+  data="$TMP_ROOT/owned-spawn-data"
+  state="$TMP_ROOT/owned-spawn-state"
+  config="$TMP_ROOT/owned-spawn-config"
+  fm_git_worktree "$proj" "$wt" "fm/$owner_id"
+  mkdir -p "$data/$id" "$state" "$config"
+  printf 'brief\n' > "$data/$id/brief.md"
+  touch "$state/.last-watcher-beat"
+  fm_write_meta "$state/$owner_id.meta" \
+    "window=fm-$owner_id" \
+    "endpoint_task_id=$owner_id" \
+    "worktree=$wt" \
+    "project=$proj" \
+    "harness=claude" \
+    "kind=ship" \
+    "backend=orca" \
+    "orca_worktree_id=wt-owned" \
+    "terminal=term-owned"
+  orca_case owned-spawn
+  printf '1\n' > "$RESP/1.exit"
+  printf '{"ok":true,"result":{"repo":{"id":"repo-owned"}}}\n' > "$RESP/2.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"wt-returned-owned","path":"%s"},"terminal":{"handle":"term-returned-owned"}}}\n' "$wt" > "$RESP/3.out"
+
+  set +e
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
+    FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" "$id" "$proj" claude --mode no-mistakes --yolo off --backend orca 2>&1 )
+  status=$?
+  set -e
+  [ "$status" -ne 0 ] || fail "Orca spawn reused a worktree owned by $owner_id"
+  assert_contains "$out" "$owner_id" "Orca ownership refusal did not identify the owner"
+  assert_absent "$state/$id.meta" "Orca ownership refusal published contender metadata"
+  assert_present "$state/$owner_id.meta" "Orca ownership refusal removed owner metadata"
+  assert_not_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm' \
+    "Orca abort cleanup removed a candidate that another task owns"
+  assert_not_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close' \
+    "Orca abort cleanup closed a terminal returned with another task's copy"
+  pass "fm-spawn.sh --backend orca: refuses an owned candidate without removing it"
+}
+
 test_spawn_refuses_orca_secondmate_before_home_mutation() {
   local home subhome data state config id out status
   id="orcasmz1"
@@ -1325,6 +1371,7 @@ test_worktree_and_terminal_helpers_parse_json
 test_worktree_create_removes_worktree_when_path_missing
 test_spawn_preserves_orca_metadata_when_pathless_worktree_cleanup_fails
 test_spawn_writes_orca_metadata_and_launches_harness
+test_spawn_refuses_orca_owned_worktree_without_removing_it
 test_spawn_refuses_orca_secondmate_before_home_mutation
 test_spawn_refuses_orca_when_runtime_not_ready
 test_spawn_refuses_orca_nonisolated_worktree

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -37,12 +37,28 @@ make_spawn_fakebin() {
 #!/usr/bin/env bash
 set -u
 case "$*" in
-  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+  *"#{pane_current_path}"*)
+    case "$*" in
+      *"-t @2"*) printf '%s\n' "${FM_FAKE_PANE_PATH_SECOND:-${FM_FAKE_PANE_PATH:-}}" ;;
+      *) printf '%s\n' "${FM_FAKE_PANE_PATH:-}" ;;
+    esac
+    exit 0
+    ;;
 esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;
-  has-session|new-session|new-window|kill-window) exit 0 ;;
+  new-window)
+    if [ -n "${FM_FAKE_WINDOW_COUNTFILE:-}" ]; then
+      n=0
+      [ ! -f "$FM_FAKE_WINDOW_COUNTFILE" ] || n=$(cat "$FM_FAKE_WINDOW_COUNTFILE")
+      n=$((n + 1))
+      printf '%s\n' "$n" > "$FM_FAKE_WINDOW_COUNTFILE"
+      printf '@%s\n' "$n"
+    fi
+    exit 0
+    ;;
+  has-session|new-session|kill-window) exit 0 ;;
   send-keys)
     if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
       prev=
@@ -184,7 +200,7 @@ test_relative_home_overrides_launch_with_absolute_cross_process_paths() {
 }
 
 test_home_defaults_preserve_absolute_or_resolve_relative_paths() {
-  local rec relative_id absolute_id out status launch home_real linked_home
+  local rec relative_id absolute_id out status launch home_real linked_home absolute_wt
   relative_id=profile-relative-home-defaults-z1c
   absolute_id=profile-absolute-home-defaults-z1d
   rec=$(make_spawn_case profile-home-defaults pi "$relative_id" "$absolute_id")
@@ -212,12 +228,14 @@ test_home_defaults_preserve_absolute_or_resolve_relative_paths() {
 
   linked_home="$CASE_DIR/home-link"
   ln -s "$HOME_DIR" "$linked_home"
+  absolute_wt="$CASE_DIR/wt-absolute-home-defaults"
+  git -C "$PROJ_DIR" worktree add --quiet -b "wt-$absolute_id" "$absolute_wt"
   : > "$LAUNCH_LOG"
   out=$(
     FM_ROOT_OVERRIDE='' FM_HOME="$linked_home" \
       FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' \
       FM_PROJECTS_OVERRIDE="$linked_home/projects" FM_CONFIG_OVERRIDE="$linked_home/config" \
-      FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
+      FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$absolute_wt" TMUX="fake,1,0" \
       CLAUDE_CONFIG_DIR='' FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" \
       GROK_HOME="$linked_home/grok-home" PATH="$FAKEBIN_DIR:$PATH" \
       "$SPAWN" "$absolute_id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1
@@ -639,15 +657,19 @@ test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity() {
 }
 
 test_batch_forwards_shared_profile_flags() {
-  local rec id1 id2 out status
+  local rec id1 id2 out status wt2 countfile
   id1=profile-batch-a-z9
   id2=profile-batch-b-z10
   rec=$(make_spawn_case profile-batch claude "$id1" "$id2")
   read_case_record "$rec"
   enable_dispatch_profile "$HOME_DIR"
+  wt2="$CASE_DIR/wt-batch-second"
+  countfile="$CASE_DIR/window-count"
+  git -C "$PROJ_DIR" worktree add --quiet -b "wt-$id2" "$wt2"
 
-  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
-    "$id1=$PROJ_DIR" "$id2=$PROJ_DIR" --harness codex --model gpt-5 --effort high)
+  out=$(FM_FAKE_PANE_PATH_SECOND="$wt2" FM_FAKE_WINDOW_COUNTFILE="$countfile" \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+      "$id1=$PROJ_DIR" "$id2=$PROJ_DIR" --harness codex --model gpt-5 --effort high)
   status=$?
   expect_code 0 "$status" "batch spawn with shared profile flags should succeed"
   assert_contains "$out" "spawned $id1 harness=codex" "first batch task did not use shared harness"

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -104,9 +104,8 @@ test_stale_pool_base_refreshes_before_branching() {
       "$branch_head" "$current" "$(cat "$POOL_DIR/advanced-main.txt")"
   fi
 
-  id='pool-current-base-repeat-r1'
-  mkdir -p "$HOME_DIR/data/$id"
-  printf 'brief for %s\n' "$id" > "$HOME_DIR/data/$id/brief.md"
+  # Repeat the same task identity so this remains a pure idempotence check.
+  # A different still-live task may no longer reuse this recorded pool copy.
   out=$(run_spawn "$id" --mode no-mistakes --yolo off)
   status=$?
   expect_code 0 "$status" "repeating the base refresh should be idempotent"

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -12,6 +12,10 @@
 # transient-then-settled pane_current_path sequence with a fake tmux and
 # asserts the recorded worktree resolves to the real, settled worktree, never
 # the stale first read.
+#
+# It also covers the ownership boundary after allocation: a candidate already
+# recorded by another ordinary task must be refused before spawn mutates that
+# copy or publishes a second owner.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -37,6 +41,9 @@ case "$*" in
     [ -f "$countfile" ] && n=$(cat "$countfile")
     n=$((n + 1))
     printf '%s\n' "$n" > "$countfile"
+    if [ -n "${FM_FAKE_PANE_READ_DELAY:-}" ]; then
+      sleep "$FM_FAKE_PANE_READ_DELAY"
+    fi
     if [ "$n" -le "${FM_FAKE_PANE_STALE_READS:-0}" ]; then
       printf '%s\n' "${FM_FAKE_PANE_STALE:-}"
     else
@@ -96,6 +103,7 @@ run_settle_spawn() {
     FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
     FM_FAKE_PANE_PATH="$WT_DIR" FM_FAKE_PANE_STALE="$STALE_DIR" \
     FM_FAKE_PANE_STALE_READS="$STALE_READS" FM_FAKE_PANE_COUNTFILE="$COUNTFILE" \
+    FM_FAKE_PANE_READ_DELAY="${FM_FAKE_PANE_READ_DELAY:-}" \
     PATH="$FAKEBIN_DIR:$PATH" \
     "$SPAWN" "$id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1
 }
@@ -141,7 +149,110 @@ test_already_settled_pane_costs_one_confirm_sleep() {
   pass "an already-settled pane confirms via the existing inter-poll sleep, not an extra full cycle"
 }
 
+# A recorded task remains the owner of its isolated copy regardless of whether
+# its endpoint is quiet, paused, blocked, or otherwise inactive. The allocator
+# may still return that copy, but spawn must refuse it before refreshing the
+# branch or publishing another task record.
+test_recorded_task_copy_is_not_reallocated() {
+  local rec owner_id new_id out status before after
+  owner_id=settle-owner-z3
+  new_id=settle-contender-z4
+  rec=$(make_settle_case settle-recorded-owner "$new_id" 0)
+  read_settle_record "$rec"
+  fm_write_meta "$HOME_DIR/state/$owner_id.meta" \
+    "window=firstmate:fm-$owner_id" \
+    "endpoint_task_id=$owner_id" \
+    "worktree=$WT_DIR" \
+    "project=$PROJ_DIR" \
+    "harness=codex" \
+    "kind=ship"
+  printf 'paused: waiting on an external answer\n' > "$HOME_DIR/state/$owner_id.status"
+  printf 'owner-only commit\n' > "$WT_DIR/owner-only.txt"
+  git -C "$WT_DIR" add owner-only.txt
+  git -C "$WT_DIR" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -qm 'owner branch must not move'
+  before=$(git -C "$WT_DIR" rev-parse HEAD)
+
+  set +e
+  out=$(run_settle_spawn "$new_id")
+  status=$?
+  set -e
+  [ "$status" -ne 0 ] || fail "spawn reused a copy already recorded by $owner_id"
+  assert_contains "$out" "$owner_id" "refusal did not identify the owning task"
+  assert_contains "$out" "$WT_DIR" "refusal did not identify the conflicting worktree"
+  assert_absent "$HOME_DIR/state/$new_id.meta" "refused spawn published a second owner"
+  after=$(git -C "$WT_DIR" rev-parse HEAD)
+  [ "$after" = "$before" ] || fail "refused spawn changed the recorded owner's branch head"
+  pass "a paused recorded task keeps exclusive ownership of its isolated copy"
+}
+
+# A present ordinary-task record with ambiguous ownership fields cannot prove a
+# copy is free. Spawn must stop without changing the candidate's clean branch.
+test_ambiguous_ownership_record_stops_allocation() {
+  local rec owner_id new_id out status before after
+  owner_id=settle-ambiguous-z5
+  new_id=settle-ambiguous-contender-z6
+  rec=$(make_settle_case settle-ambiguous-owner "$new_id" 0)
+  read_settle_record "$rec"
+  fm_write_meta "$HOME_DIR/state/$owner_id.meta" \
+    "window=firstmate:fm-$owner_id" \
+    "worktree=$WT_DIR" \
+    "worktree=$STALE_DIR" \
+    "kind=ship"
+  before=$(git -C "$WT_DIR" rev-parse HEAD)
+
+  set +e
+  out=$(run_settle_spawn "$new_id")
+  status=$?
+  set -e
+  [ "$status" -ne 0 ] || fail "spawn accepted ambiguous worktree ownership"
+  assert_contains "$out" "$owner_id" "ambiguous-record refusal did not identify the task"
+  assert_contains "$out" "ambiguous worktree" "ambiguous-record refusal did not explain the unsafe field"
+  assert_absent "$HOME_DIR/state/$new_id.meta" "ambiguous ownership published a contender record"
+  after=$(git -C "$WT_DIR" rev-parse HEAD)
+  [ "$after" = "$before" ] || fail "ambiguous ownership changed the candidate branch head"
+  pass "ambiguous ordinary-task ownership stops allocation safely"
+}
+
+# The per-home task-set lock spans candidate selection through metadata
+# publication. Two different task ids racing for one allocator result may have
+# either a lock refusal or a later owner refusal, but exactly one may publish.
+test_concurrent_spawns_cannot_claim_one_copy_twice() {
+  local rec first_id second_id first_pid second_pid first_status second_status owners
+  first_id=settle-race-a-z7
+  second_id=settle-race-b-z8
+  rec=$(make_settle_case settle-concurrent "$first_id" 0)
+  read_settle_record "$rec"
+  mkdir -p "$HOME_DIR/data/$second_id"
+  printf 'brief for %s\n' "$second_id" > "$HOME_DIR/data/$second_id/brief.md"
+
+  FM_FAKE_PANE_READ_DELAY=0.3 run_settle_spawn "$first_id" \
+    > "$HOME_DIR/first.out" 2>&1 &
+  first_pid=$!
+  sleep 0.1
+  FM_FAKE_PANE_READ_DELAY=0.3 run_settle_spawn "$second_id" \
+    > "$HOME_DIR/second.out" 2>&1 &
+  second_pid=$!
+  set +e
+  wait "$first_pid"
+  first_status=$?
+  wait "$second_pid"
+  second_status=$?
+  set -e
+
+  [ $(( (first_status == 0) + (second_status == 0) )) -eq 1 ] \
+    || fail "concurrent spawns produced $first_status/$second_status instead of exactly one owner"
+  owners=0
+  [ ! -f "$HOME_DIR/state/$first_id.meta" ] || owners=$((owners + 1))
+  [ ! -f "$HOME_DIR/state/$second_id.meta" ] || owners=$((owners + 1))
+  [ "$owners" -eq 1 ] || fail "concurrent spawns published $owners ownership records"
+  pass "concurrent spawns cannot both publish ownership of one isolated copy"
+}
+
 test_single_stale_first_read_is_not_accepted
 test_already_settled_pane_costs_one_confirm_sleep
+test_recorded_task_copy_is_not_reallocated
+test_ambiguous_ownership_record_stops_allocation
+test_concurrent_spawns_cannot_claim_one_copy_twice
 
 echo "# all fm-spawn-worktree-settle tests passed"


### PR DESCRIPTION
## Intent

Prevent a new task from ever reusing an isolated project copy already owned by another live task. Reproduce the duplicate-allocation path in an executable regression test before changing behavior. Before any checkout, branch switch, reset, or other project-copy mutation, compare the candidate's canonical path against every live ordinary task record in this Firstmate home and refuse with the conflicting task identity. Close the check-to-publication race under the appropriate task/allocation lock so two concurrent spawns cannot both claim one copy. Treat paused, blocked, working, idle, quiet, and otherwise still-recorded live tasks as owners; endpoint activity must not release a copy. Ignore only records proven retired through the existing cleanup owner, and stop safely on malformed or ambiguous ownership records. Preserve behavior across every supported spawn-capable runtime provider and ordinary ship/scout work. Do not use broad process killing, forcing, stashing, resetting, or deleting another task's state. Keep full mechanics in the authoritative fm-spawn script header/help and focused documentation without bloating AGENTS.md. Include concurrency, refusal, malformed-record, and provider regression coverage; run the complete relevant test suite, fm-lint, documentation checks, and shellcheck. Ship through the no-mistakes PR path, do not merge, and report the full PR URL only when checks are green.

## What Changed

- `bin/fm-spawn.sh` now runs a new `assert_spawn_worktree_unowned` check while holding the task-set lock: after allocating an isolated worktree and before any fetch/checkout/reset or other mutation, it canonicalizes the candidate path and compares it against every other ordinary (ship/scout) task record in the home's state directory, refusing allocation with the conflicting task id when a live owner matches. Malformed, duplicate, non-regular, or ambiguous ownership records also refuse allocation, and an Orca-backed refusal disables abort cleanup so the disputed copy is never removed.
- Regression coverage added across `tests/fm-spawn-worktree-settle.test.sh`, `tests/fm-backend-orca.test.sh`, `tests/fm-spawn-dispatch-profile.test.sh`, and `tests/fm-spawn-pool-base-freshen.test.sh` for the refusal, malformed-record, concurrency, and provider paths.
- `docs/architecture.md` documents the ownership refusal boundary and the test files that own its regression coverage.

## Risk Assessment

✅ Low: The change is a well-bounded fail-closed ownership check placed before the first spawn-owned mutation, correctly serialized under the pre-existing task-set lock held from allocation through publication, covered by behavioral regression tests for refusal, ambiguity, concurrency, and the Orca provider, with no reachable path found that reintroduces the duplicate-allocation failure.

## Testing

Ran the four touched test suites at the target commit (all pass), proved the new ownership regression tests fail against the pre-fix fm-spawn.sh from the base commit (reproducing the duplicate-allocation bug before the fix), and manually demonstrated the end-user behavior: a spawn handed a worktree owned by a paused live task is refused with the conflicting task's identity, publishes no second owner, and leaves the owner's record and branch untouched.

<details>
<summary>Evidence: Manual CLI transcript: spawn refuses worktree owned by paused live task</summary>

<code>=== SETUP: live task demo-owner-1 (paused) owns isolated worktree ===&#10;$ fm-spawn.sh demo-contender-2 &lt;project&gt; --mode no-mistakes --yolo off&#10;error: isolated worktree &#39;&lt;case&gt;/wt&#39; is already owned by live task demo-owner-1; refusing allocation for task demo-contender-2&#10;exit status: 1&#10;=== RESULT ===&#10;demo-contender-2.meta: not published (owner remains exclusive)&#10;demo-owner-1.meta: still present (owner untouched)&#10;owner worktree HEAD unchanged: a2537bd3e27e18cf9ae279ae1836c66b8ddbe912</code>

```text
=== SETUP: live task demo-owner-1 (paused) owns isolated worktree ===
owner meta (/tmp/fm-spawn-manual-demo.DDnw9H/demo/home/state/demo-owner-1.meta):
window=firstmate:fm-demo-owner-1
endpoint_task_id=demo-owner-1
worktree=<case>/wt
project=<case>/project
harness=codex
kind=ship

=== ACTION: spawn new task demo-contender-2, allocator hands back the same worktree ===
$ fm-spawn.sh demo-contender-2 <project> --mode no-mistakes --yolo off
warning: <case>/home/data/demo-contender-2/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
error: isolated worktree '<case>/wt' is already owned by live task demo-owner-1; refusing allocation for task demo-contender-2
exit status: 1

=== RESULT ===
demo-contender-2.meta: not published (owner remains exclusive)
demo-owner-1.meta: still present (owner untouched)
owner worktree HEAD unchanged: a2537bd3e27e18cf9ae279ae1836c66b8ddbe912
```
</details>
<details>
<summary>Evidence: Red/green regression proof (tests fail pre-fix, pass post-fix)</summary>

<code>Pre-fix (base 614fae6): not ok - spawn reused a copy already recorded by settle-owner-z3; not ok - Orca spawn reused a worktree owned by orcaownerz7&#10;Post-fix (target 48d4049): all fm-spawn-worktree-settle tests passed, including &#39;a paused recorded task keeps exclusive ownership&#39;, &#39;ambiguous ordinary-task ownership stops allocation safely&#39;, &#39;concurrent spawns cannot both publish ownership of one isolated copy&#39;</code>

```text
=== Regression proof: new ownership tests vs pre-fix bin/fm-spawn.sh (base 614fae6) ===

--- tests/fm-spawn-worktree-settle.test.sh (pre-fix: FAILS, reproducing the bug) ---
ok - a single transient stale pane_current_path read is not accepted as the worktree
ok - an already-settled pane confirms via the existing inter-poll sleep, not an extra full cycle
not ok - spawn reused a copy already recorded by settle-owner-z3

--- tests/fm-backend-orca.test.sh (pre-fix: FAILS) ---
not ok - Orca spawn reused a worktree owned by orcaownerz7

=== Same tests vs fixed bin/fm-spawn.sh (target 48d4049): PASS ===

--- tests/fm-spawn-worktree-settle.test.sh ---
ok - a single transient stale pane_current_path read is not accepted as the worktree
ok - an already-settled pane confirms via the existing inter-poll sleep, not an extra full cycle
ok - a paused recorded task keeps exclusive ownership of its isolated copy
ok - ambiguous ordinary-task ownership stops allocation safely
ok - concurrent spawns cannot both publish ownership of one isolated copy
# all fm-spawn-worktree-settle tests passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `bin/fm-spawn.sh:1744` - assert_spawn_worktree_unowned refuses ALL new allocations in the home when any live task&#39;s recorded worktree cannot be canonicalized (deleted dir, unreachable mount), even though a nonexistent owner worktree can never equal an existing candidate. This is stricter than needed and could cause a home-wide spawn outage after one dangling record or transient mount failure, but it is the fail-closed behavior the intent authorizes for ambiguous ownership records and the refusal identifies the offending task.
- ℹ️ `bin/fm-spawn.sh:2290` - On an Orca ownership refusal, ORCA_ABORT_CLEANUP=0 skips both worktree removal (correct — the copy may belong to the live owner) and terminal close, leaking the terminal created for the refused spawn. The new test explicitly asserts this, so it is a deliberate conservative tradeoff to avoid disturbing resources attached to the owner&#39;s copy; noting for awareness that refused Orca spawns leave a terminal behind for manual cleanup.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-spawn-worktree-settle.test.sh` at target 48d4049 (all pass, including paused-owner refusal, ambiguous-record stop, and concurrent-spawn single-publisher race)</code>
- <code>`bash tests/fm-backend-orca.test.sh` at target (all pass, including the new owned-candidate refusal that preserves the owner&#39;s Orca worktree and terminal)</code>
- <code>`bash tests/fm-spawn-dispatch-profile.test.sh` at target (all pass, batch spawns now use distinct worktrees per task)</code>
- <code>`bash tests/fm-spawn-pool-base-freshen.test.sh` at target (all pass, idempotence check reworked to same-task repeat)</code>
- <code>Red/green regression check: checked out pre-fix `bin/fm-spawn.sh` from base 614fae6 and re-ran the settle and Orca suites — both new ownership tests fail pre-fix, proving they reproduce the duplicate-allocation bug</code>
- <code>Manual end-to-end verification: built a Firstmate home with a paused live owner task, invoked `fm-spawn.sh` for a contender pointed at the same worktree, and confirmed refusal naming the owner, exit 1, no contender metadata published, owner metadata intact, owner branch HEAD unchanged</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
