### PR TITLE
feat(bin): make daily fleet report and teardown curation pass mechanical

### DIFF
--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -23,6 +23,8 @@ It never tears down a task, merges a PR, dispatches new work, steers a worker, a
 - `/bearings file` gathers a fresh bounded snapshot, replaces today's `data/status-report-<YYYY-MM-DD>.md` from scratch, and renders the four-section chat digest with a link or path to that report.
 - Treat `file` only as an explicit invocation option in the slash command.
 - Do not treat natural-language requests such as "write a report", "save this", "persist it", or "make a file" as file mode unless the invocation explicitly includes the standalone `file` option.
+- The session-start digest's "Daily fleet report" directive is itself an explicit file-mode invocation, not a natural-language request: run `/bearings file` for it exactly as if the captain had typed it.
+  That directive is the standing daily trigger and `bin/fm-session-start.sh` owns when it fires; this skill's only job for it is the report.
 - When the captain asks to include PRs, pass the snapshot command's live-PR opt-in.
 - `/bearings include PRs` remains chat-only and makes the live-PR opt-in.
 - `/bearings file include PRs` writes the dated report and makes the live-PR opt-in.

--- a/.agents/skills/stow/SKILL.md
+++ b/.agents/skills/stow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stow
-description: Sweep the current session for uncaptured durable knowledge, file it to disk, and curate the home's tiered, decaying startup memory before a context reset. Use when the captain invokes /stow (e.g. "/stow", "stow what you've learned"), before a session reset or context compaction, or periodically to keep operational memory current.
+description: Sweep the current session for uncaptured durable knowledge, file it to disk, and curate the home's tiered, decaying startup memory before a context reset. Use when the captain invokes /stow (e.g. "/stow", "stow what you've learned"), before a session reset or context compaction, or periodically to keep operational memory current. Also use at every ship or scout teardown, where bin/fm-teardown.sh prints the trigger and this skill's scoped teardown curation pass runs instead of the full startup-memory pass.
 user-invocable: true
 metadata:
   internal: true
@@ -13,6 +13,7 @@ metadata:
 Sweep this session for durable knowledge that exists only in conversation, then leave the next session with a compact current operating map rather than an accumulating journal.
 Memory entries are tiered and decay between passes, and stale material retires to a cold archive instead of being deleted.
 This skill writes only through the existing Firstmate ownership and write boundaries.
+It has two entry points: a `/stow` invocation, which performs the complete required startup-memory pass below, and a task teardown, which performs only the scoped teardown curation pass.
 
 ## Memory tiers and entry markers
 
@@ -206,6 +207,26 @@ A local skill exists only in this home, so offloading an entry out of `data/capt
    The only graduation moves are promotion to tracked shared material through a PR, folding a learning into the captain-preference destination selected by AGENTS.md, archiving a stale entry to `data/memory-archive.md`, autonomous offload of an eligible non-pinned conditional entry to an already-existing allowed owner through the reduce flow above, captain-approved offload of a pinned durable conditional entry to a JIT-loaded owner executed through the migration step above, or deletion of an entry that is a duplicate or already preserved through a stronger existing owner.
    A stale unique fact is never deleted, only archived.
    Do not invent another graduation path.
+
+## Teardown curation pass
+
+`bin/fm-teardown.sh` prints this pass's trigger at the end of every ship and scout teardown, so it runs once per finished task without anyone having to remember it.
+It is scoped to that one task: it never runs the required startup-memory pass, the budget report, the decay sweep, the offload sweep, or the secondmate cascade.
+It runs after teardown has already completed and it changes no teardown outcome; the unlanded-work refusal and the unresolved-decision completion gate are owned entirely by that script and this pass can never relax either.
+Teardown prints the bounded tail of the task's wake log as it deletes it, because that is the one piece of the task's evidence teardown itself destroys.
+
+1. Sweep this task alone: what the work proved or disproved, what cost time that a future session could skip, a captain preference stated in passing, and project-intrinsic facts that project's own contributors need.
+2. Route each finding to its `AGENTS.md` section 6 owner, which is the source of truth for destinations and is not restated here.
+3. Curate the destination instead of appending to it.
+   Read the whole destination file first, ask what the finding supersedes, then take the strongest of these that applies: rewrite an existing entry so one current sentence replaces two, retire an entry this task proved obsolete, or add a new stamped entry only when nothing there already covers it.
+4. Removal and rewriting are the point of this pass rather than a side effect it tolerates.
+   An entry this task disproved is corrected or retired, never left standing next to its correction, and a pass that leaves the destination file shorter is a good outcome.
+5. Adding nothing is the common outcome and the correct one when the task produced no durable knowledge.
+   Never write an entry to show the pass ran.
+6. Removal still goes through the existing owners: prune a memory entry by moving it to `data/memory-archive.md` with provenance, replace a task note through `tasks-axi update <id> --body-file <path>` with `--archive-body` where recoverability matters, and never plainly delete a unique current fact.
+7. Stamp anything newly written with today's date and its tier per the marking rules above.
+
+This pass has no captain-facing report of its own; fold anything the captain needs into the teardown outcome already being reported.
 
 ## One-time migration of unmarked entries
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,7 @@ When that section reports its checks still in progress it names exactly what is 
    The script itself never starts supervision; the emitted harness protocol owns the exact wait or wake mechanism.
 5. **Fleet-state digest** - after that read-once contract and ahead of the context digest, the compact backlog listing owned by `bin/fm-session-start.sh`; every `state/<id>.meta`; a bounded tail of each task's `state/<id>.status` (labeled as wake-EVENT history, not current state, with the full log path printed for a deeper read); the `state/.afk` flag; and one cheap alive/dead read of each task's recorded backend endpoint.
    That liveness line is a fast presence check only, not a full state read - when you need a crew's actual current state (a run-step, not just "is the pane there"), read it with `bin/fm-crew-state.sh <id>` as before; the digest deliberately skips that deeper, slower read for every task so it stays fast and bounded.
+   Writing the day's dated fleet report is standing rather than a captain request: when this section names it absent, run `/bearings file` this session, and `bin/fm-session-start.sh` owns when that fires while the `bearings` skill owns the report.
 6. **Network checks** - after the fleet-state digest, the deferred stage's result, or an explicit statement of what it has not confirmed yet.
    A read-only session runs no network checks at all and says so.
 7. **Context digest and next step** - last of the bulk sections, the full contents of `data/projects.md`, `data/secondmates.md`, `data/captain.md`, `data/captain-shared.md`, and `data/learnings.md`, each clearly delimited, followed by the closing reminder.
@@ -362,6 +363,8 @@ Tear down a ship task only after landing is confirmed.
 A teardown refusal for uncommitted or unlanded work is a stop-and-investigate result, never an obstacle to bypass.
 Never force teardown without explicit discard authority.
 After successful teardown, record completion, retain only the configured recent Done history, and re-evaluate queued work whose blockers and time gates have cleared.
+Every ship and scout teardown also carries a curation pass: load `stow` for it when teardown prints its trigger, route the finished task's durable knowledge to its section 6 owner, and curate the destination rather than appending to it, which means rewriting and retiring entries as readily as adding one.
+That pass runs after teardown has already completed, so it never relaxes a refusal above.
 
 A secondmate is persistent and an empty queue is healthy.
 Retire one only on an explicit captain or main-firstmate decision, after loading `secondmate-provisioning`; its home must contain no work under way, and forced discard still requires explicit captain authority.

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Claude and grok use the slash form shown here; codex uses the same names with `$
 | `/ahoy`            | Recap visible session events since the prior real captain message plus visibly unanswered captain decisions, then guide the captain through any open decisions one at a time in agent-judged impact order; fall back to Bearings when invoked as the session's first real captain message |
 | `/bearings`        | Generate a concise four-section chat digest from bounded local fleet and registered-secondmate state; use `/bearings file` to also replace today's dated report in `data/`, and add `include PRs` when live PR enrichment is wanted |
 | `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
-| `/stow`            | Sweep the session for uncaptured durable knowledge, curate tiered startup memory with decay and cold archival, enforce each home's budget or surface the required decision, cascade to registered second mates, and report what is safe to reset |
+| `/stow`            | Sweep the session for uncaptured durable knowledge, curate tiered startup memory with decay and cold archival, enforce each home's budget or surface the required decision, cascade to registered second mates, and report what is safe to reset. The same skill also carries the scoped curation pass that every task teardown triggers |
 
 Bearings invocation examples:
 
@@ -183,6 +183,10 @@ Bearings invocation examples:
 - `/bearings include PRs` keeps chat-only mode and opts into live PR enrichment.
 - `/bearings file` replaces today's `data/status-report-<YYYY-MM-DD>.md` from scratch and links it from the four-section chat digest.
 - `/bearings file include PRs` combines the dated report with live PR enrichment.
+
+The dated report is also standing rather than something you have to ask for.
+Session start checks whether `data/status-report-<YYYY-MM-DD>.md` exists for today and, when it does not, directs firstmate to write it that session - so a home gets one report per day from its first session onward.
+The check is the file's own absence, so later sessions the same day stay silent, and it is skipped for a read-only session and for secondmate homes.
 
 Agent-only reference skills live under `.agents/skills/` and are loaded by firstmate at the trigger points named in [`AGENTS.md`](AGENTS.md).
 

--- a/bin/fm-inactive-reconcile.sh
+++ b/bin/fm-inactive-reconcile.sh
@@ -337,7 +337,15 @@ reconcile_direct_child_locked() { # <id> <meta> <secondmate-id-or-empty> <timeou
   [ "$age" -ge "$FM_INACTIVE_RECONCILE_SECS" ] || return 0
   state_line=$(fm_run_timed "$timeout" env FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" \
     "$CREW_STATE_BIN" "$id" 2>/dev/null) || state_rc=$?
-  [ "$state_rc" -ne 124 ] || return 3
+  # 124 is fm_run_timed's own bound firing. When the outer aggregate scan
+  # budget fires first instead, the signal can strike this nested `timeout`
+  # process too (bin/fm-timeout-lib.sh only isolates the process it directly
+  # wraps into a new process group, so a nested call shares its parent's
+  # group), which is reported as an ordinary signal death - 128+signal, e.g.
+  # 143 for TERM - not 124. That is still an interrupted read, not the tool
+  # answering with nothing to report, so treat every code from 124 up the
+  # same way: resume the scan rather than drop the child.
+  [ "$state_rc" -lt 124 ] || return 3
   case "$state_line" in
     'state: done '*) state='done' ;;
     'state: failed '*) state='failed' ;;

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -45,7 +45,8 @@
 #                       represented by the two digests below.
 #   6. fleet digest   - a compact data/backlog.md identity/metadata listing,
 #                       every state/*.meta, a bounded state/*.status tail,
-#                       state/.afk, and a cheap per-task endpoint-liveness read:
+#                       state/.afk, a cheap per-task endpoint-liveness read, and
+#                       the day's dated fleet report when it is still absent:
 #                       read-only, always runs.
 #   7. network checks - the result of the deferred network stage started back at
 #                       step 1, harvested WITHOUT waiting for it.
@@ -851,6 +852,35 @@ if fm_pf_relay_active "$FM_HOME" \
     printf '\nEach line is a public reply this home still owes. Reconcile terminal results with\n'
     printf '%s/bin/fm-public-followup.sh consume, then deliver a ready one with\n' "$FM_ROOT"
     printf '%s/bin/fm-public-followup.sh deliver <id>. Load fmx-respond for the procedure.\n' "$FM_ROOT"
+  fi
+fi
+
+# The day's dated fleet report, which AGENTS.md section 3 makes a standing
+# operating parameter rather than something the captain has to ask for.
+# WHY THE TRIGGER LIVES HERE and not in prose or in the bearings skill: a
+# session has no clock it can consult between turns, so "daily" has no mechanism
+# behind it and would decay into the same advice-that-loses-to-urgency this
+# replaces. This digest is the only point that runs exactly once per session
+# with the lock held, which makes "the first session of a day" a fact it can
+# establish and no later turn can.
+# The trigger is the artifact's own absence: today's report either exists or it
+# does not. That is idempotent across every session of the same day, needs no
+# marker file of its own, and stays silent on all but the first - a routine
+# confirmation costs nothing here, exactly as bootstrap's do.
+# --reemit deliberately still prints it. A /clear or compaction loses the
+# obligation exactly as it loses the wake queue, and the file check is what stops
+# a re-emit from asking twice for a report already written.
+# Excluded: a read-only session, because writing the report mutates data/ and
+# this session holds no authority to; and a secondmate home, because the report
+# is captain-facing and a secondmate never addresses the captain.
+if [ "$READ_ONLY" -eq 0 ] \
+  && [ ! -e "$FM_HOME/.fm-secondmate-home" ] && [ ! -L "$FM_HOME/.fm-secondmate-home" ]; then
+  DAILY_REPORT_FILE="$DATA/status-report-$(date +%Y-%m-%d).md"
+  if [ ! -f "$DAILY_REPORT_FILE" ]; then
+    subsection "Daily fleet report"
+    printf 'not written yet for today: %s\n' "$DAILY_REPORT_FILE"
+    printf 'Write it this session with /bearings file, which stays the single owner of the\n'
+    printf "report's contents and format. This is standing, not a captain request.\n"
   fi
 fi
 

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2,8 +2,10 @@
 # Tear down a finished task: return the treehouse worktree, release the Orca
 # worktree, or retire a secondmate home; kill the recorded runtime endpoint,
 # clear volatile state, refresh/prune the project's clone for PR-based ship
-# tasks, then print a backlog-refresh reminder for ship and scout teardowns
-# (a secondmate teardown prints none, since secondmates are not backlog items).
+# tasks, then print a backlog-refresh reminder and the teardown curation-pass
+# trigger for ship and scout teardowns (a secondmate teardown prints neither,
+# since secondmates are not backlog items). Both are print-only and run after
+# every safety check has already passed, so neither can affect a refusal.
 # REFUSES if the worktree holds work that has not LANDED, because cleanup
 # hard-resets/removes the worktree and kills its processes. Work has landed when it is
 # reachable from any remote-tracking branch (a fork counts as a remote, so
@@ -168,6 +170,8 @@ SUB_HOME_PARENT_MARKER=".fm-secondmate-parent"
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 # shellcheck source=bin/fm-nm-run-lib.sh
 . "$SCRIPT_DIR/fm-nm-run-lib.sh"
+# shellcheck source=bin/fm-line-cap-lib.sh
+. "$SCRIPT_DIR/fm-line-cap-lib.sh"
 if [ "$#" -lt 1 ] || ! fm_task_id_path_safe "$1"; then
   echo "error: invalid teardown request" >&2
   exit 2
@@ -917,6 +921,57 @@ backlog_refresh_reminder() {
     printf '%s\n' "Backlog: $ID just finished. Run $done_cmd, then run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due."
   else
     printf '%s\n' "Backlog: $ID just finished. Update data/backlog.md - move $ID to Done, keep Done to the 10 most recent, then re-scan Queued and dispatch only work whose blockers are gone and date is due."
+  fi
+}
+
+# --- teardown curation pass --------------------------------------------------
+# AGENTS.md section 7 makes a curation pass part of teardown, and the stow skill
+# owns the pass itself. This script's whole job for it is to make the pass
+# unmissable and to hand over the evidence it is about to destroy.
+#
+# WHY TEARDOWN: it is the one point in the lifecycle that already stops and
+# already forces a review (the unlanded-work refusal, the unresolved-decision
+# completion gate), so a finished task's durable knowledge gets routed while it
+# is still routable rather than whenever someone remembers.
+#
+# WHAT IT MUST NOT DO: nothing below participates in any safety decision. Both
+# functions run after every refusal has already passed and after cleanup has
+# already succeeded; they only print. A curation pass can therefore never be a
+# reason teardown proceeds where it would otherwise refuse.
+#
+# THE EVIDENCE: data/<id>/brief.md and data/<id>/report.md survive teardown, and
+# a ship task's commits live on the remote by the time the landed-work check
+# lets teardown run. The wake log state/<id>.status is the one readable piece of
+# this task's evidence teardown itself destroys, so a bounded tail of it is
+# captured BEFORE the rm and printed with the trigger. That is what makes
+# "routed before its evidence is discarded" true rather than aspirational.
+CURATION_STATUS_TAIL=
+CURATION_STATUS_TAIL_DEFAULT=12
+
+# Read a bounded, per-line-capped tail of this task's wake log into
+# CURATION_STATUS_TAIL. Must be called while state/<id>.status still exists.
+# A missing log is an ordinary empty result, never an error: teardown's outcome
+# does not depend on it.
+capture_curation_status_tail() {
+  local status="$STATE/$ID.status" lines=${FM_TEARDOWN_CURATION_STATUS_TAIL:-$CURATION_STATUS_TAIL_DEFAULT}
+  case "$lines" in ''|*[!0-9]*|0) lines=$CURATION_STATUS_TAIL_DEFAULT ;; esac
+  [ -f "$status" ] || return 0
+  CURATION_STATUS_TAIL=$(
+    tail -n "$lines" "$status" 2>/dev/null | while IFS= read -r line; do
+      fm_cap_line "$line"
+    done
+  ) || CURATION_STATUS_TAIL=
+}
+
+curation_pass_reminder() {
+  # Secondmates are not backlog work items and their retirement is owned by
+  # secondmate-provisioning, exactly as the backlog reminder above treats them.
+  [ "$KIND" = secondmate ] && return 0
+  printf '%s\n' "Curation: $ID is finished, so run the teardown curation pass before moving on. Load the stow skill for it; route each durable finding to its AGENTS.md section 6 owner and CURATE the destination rather than appending to it - rewriting or retiring an entry this task disproved is a better result than a new one, and adding nothing is the common one."
+  printf '%s\n' "Curation evidence that survives: data/$ID/brief.md, and data/$ID/report.md for a scout."
+  if [ -n "$CURATION_STATUS_TAIL" ]; then
+    printf '%s\n' "Curation evidence this cleanup just destroyed - the last lines of state/$ID.status, which no longer exists:"
+    printf '%s\n' "$CURATION_STATUS_TAIL"
   fi
 }
 
@@ -2537,8 +2592,12 @@ fm_backend_clear_transition "$BACKEND" "$STATE" "$T" || true
 [ -n "$TASK_TMP" ] && rm -rf "$TASK_TMP"
 remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
 retire_busy_state "$STATE" "$ID" "$BUSY_GEN" || exit 1
+# Last read of the wake log before status_retire_presentation_task's own rm
+# deletes it; the curation pass reminder hands the tail over. Print-only, so
+# it changes nothing below.
+capture_curation_status_tail
 status_retire_presentation_task "$STATE" "$ID" || exit 1
-rm -f "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
+rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
   "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
   "$STATE/$ID.kimi-turnend-token" "$STATE/$ID.muse-session" \
   "$STATE/$ID.muse-session-current" "$STATE/$ID.cursor-session" \
@@ -2551,3 +2610,4 @@ if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only 
 fi
 echo "teardown $ID complete (window $T, worktree $WT)"
 backlog_refresh_reminder
+curation_pass_reminder

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -587,6 +587,7 @@ FM_STALE_WORKTREE_LOCK_AGE_SECS=30       # min mtime age before fm-teardown.sh t
 FM_TREEHOUSE_RETURN_LOCK_RETRIES=3        # retries after a treehouse return fails on the transient git index.lock signature
 FM_TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS=1 # seconds fm-teardown.sh waits before each retry after that signature
 FM_STALE_WORKTREE_LOCK_RETRY_WAIT_SECS=   # legacy alias for FM_TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS when the new variable is unset
+FM_TEARDOWN_CURATION_STATUS_TAIL=12       # state/<id>.status lines fm-teardown.sh hands to the teardown curation pass as it deletes that log; each line is capped by bin/fm-line-cap-lib.sh
 FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRIES=3        # fetch retries after fm-fleet-sync.sh hits the orphaned .git/packed-refs.lock signature
 FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS=1 # seconds fm-fleet-sync.sh waits before each of those retries
 FM_FLEET_SYNC_PACKED_REFS_LOCK_AGE_SECS=30       # min mtime age before fm-fleet-sync.sh treats a leftover packed-refs.lock as provably stale

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -65,7 +65,8 @@ make_fake_root() {
   # ownership are sourced by teardown.
   ln -s "$ROOT/bin/fm-control-lib.sh" "$fake/bin/fm-control-lib.sh"
   ln -s "$ROOT/bin/fm-classify-lib.sh" "$fake/bin/fm-classify-lib.sh"
-  ln -s "$ROOT/bin/fm-wake-lib.sh" "$fake/bin/fm-wake-lib.sh"
+  # fm-line-cap-lib.sh: teardown sources it to bound the curation-pass status tail.
+  ln -s "$ROOT/bin/fm-line-cap-lib.sh" "$fake/bin/fm-line-cap-lib.sh"
   # fm-gate-refuse-lib.sh: teardown sources it before any fleet mutation.
   ln -s "$ROOT/bin/fm-gate-refuse-lib.sh" "$fake/bin/fm-gate-refuse-lib.sh"
   # fm-pr-lib.sh: teardown uses its canonical task-ID validator for poll cleanup.
@@ -78,6 +79,8 @@ make_fake_root() {
   ln -s "$ROOT/bin/fm-x-lib.sh" "$fake/bin/fm-x-lib.sh"
   ln -s "$ROOT/bin/fm-secondmate-registry-lib.sh" "$fake/bin/fm-secondmate-registry-lib.sh"
   ln -s "$ROOT/bin/fm-secondmate-parent-lib.sh" "$fake/bin/fm-secondmate-parent-lib.sh"
+  # fm-wake-lib.sh: teardown sources it for serialized secondmate lifecycle locks.
+  ln -s "$ROOT/bin/fm-wake-lib.sh" "$fake/bin/fm-wake-lib.sh"
   # fm-guard.sh: stub (teardown calls it with `|| true`).
   cat > "$fake/bin/fm-guard.sh" <<'SH'
 #!/usr/bin/env bash
@@ -143,7 +146,8 @@ test_teardown_skips_gracefully_without_tasktmp() {
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
   ln -s "$ROOT/bin/fm-control-lib.sh" "$fake/bin/fm-control-lib.sh"
   ln -s "$ROOT/bin/fm-classify-lib.sh" "$fake/bin/fm-classify-lib.sh"
-  ln -s "$ROOT/bin/fm-wake-lib.sh" "$fake/bin/fm-wake-lib.sh"
+  # fm-line-cap-lib.sh: teardown sources it to bound the curation-pass status tail.
+  ln -s "$ROOT/bin/fm-line-cap-lib.sh" "$fake/bin/fm-line-cap-lib.sh"
   # fm-gate-refuse-lib.sh: teardown sources it before any fleet mutation.
   ln -s "$ROOT/bin/fm-gate-refuse-lib.sh" "$fake/bin/fm-gate-refuse-lib.sh"
   # fm-pr-lib.sh: teardown uses its canonical task-ID validator for poll cleanup.
@@ -156,6 +160,7 @@ test_teardown_skips_gracefully_without_tasktmp() {
   ln -s "$ROOT/bin/fm-x-lib.sh" "$fake/bin/fm-x-lib.sh"
   ln -s "$ROOT/bin/fm-secondmate-registry-lib.sh" "$fake/bin/fm-secondmate-registry-lib.sh"
   ln -s "$ROOT/bin/fm-secondmate-parent-lib.sh" "$fake/bin/fm-secondmate-parent-lib.sh"
+  ln -s "$ROOT/bin/fm-wake-lib.sh" "$fake/bin/fm-wake-lib.sh"
   cat > "$fake/bin/fm-guard.sh" <<'SH'
 #!/usr/bin/env bash
 exit 0

--- a/tests/fm-inactive-reconcile.test.sh
+++ b/tests/fm-inactive-reconcile.test.sh
@@ -375,12 +375,12 @@ SH
   chmod +x "$WORLD/fakebin/fm-crew-state.sh"
 
   started=$(date +%s)
-  FM_INACTIVE_RECONCILE_BUDGET_SECS=1 run_reconcile "$MAIN" --startup
+  FM_INACTIVE_RECONCILE_BUDGET_SECS=3 run_reconcile "$MAIN" --startup
   elapsed=$(( $(date +%s) - started ))
-  [ "$elapsed" -le 3 ] || fail "stalled state read exceeded aggregate scan budget (${elapsed}s)"
+  [ "$elapsed" -le 6 ] || fail "stalled state read exceeded aggregate scan budget (${elapsed}s)"
 
   write_child "$MAIN" b 'done: green'
-  FM_INACTIVE_RECONCILE_BUDGET_SECS=1 run_reconcile "$MAIN" --startup
+  FM_INACTIVE_RECONCILE_BUDGET_SECS=3 run_reconcile "$MAIN" --startup
   grep -Fq 'child=b state=done' "$MAIN/state/.wake-queue" \
     || fail "next bounded scan did not resume with the following child"
   pass "stalled state reads are bounded without starving later children"

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -13,6 +13,9 @@
 #     read-once contract precedes both
 #   - context-aware next-step guidance for read-only, AFK, X mode, and normal
 #     watcher ownership
+#   - the standing daily fleet report: its trigger is today's report file being
+#     absent, it stays silent for the rest of that day, it survives a --reemit,
+#     and it is skipped for a read-only session and a secondmate home
 #   - status-tail bounding, default and FM_SESSION_START_STATUS_TAIL override
 #   - the per-line status-tail cap and its truncation marker
 #   - startup backlog composition: done rows dropped, every in-flight/held/
@@ -529,6 +532,25 @@ run_pi_session_start() {  # <home> <root> <path> [fm-session-start args...]
     FM_FAKE_HARNESS_PID="$SESSION_START_TEST_HARNESS_PID" \
     FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$path" \
     "$SESSION_START" "$@"
+}
+
+# make_fake_date <fakebin> <YYYY-MM-DD>: pin `date +%Y-%m-%d` to one day and
+# delegate every other invocation to the real date. The daily-report trigger
+# compares against today's date, so a test that reads the clock separately from
+# the script can straddle midnight; pinning it removes that flake outright
+# rather than leaving a once-a-day window open.
+make_fake_date() {
+  local fakebin=$1 day=$2 real
+  real=$(command -v date)
+  cat > "$fakebin/date" <<SH
+#!/usr/bin/env bash
+if [ "\$#" -eq 1 ] && [ "\$1" = '+%Y-%m-%d' ]; then
+  printf '%s\n' '$day'
+  exit 0
+fi
+exec "$real" "\$@"
+SH
+  chmod +x "$fakebin/date"
 }
 
 run_named_harness_session_start() {  # <harness> <home> <root> <path> [fm-session-start args...]
@@ -1953,6 +1975,10 @@ EOF
   assert_contains "$reemit" "CONTEXT" "--reemit dropped the context digest"
   assert_contains "$reemit" "FLEET STATE" "--reemit dropped the fleet-state digest"
   assert_contains "$reemit" "NEXT STEP" "--reemit dropped the closing reminder"
+  # A compaction loses the standing daily-report obligation exactly as it loses
+  # the wake queue, so the re-emit must carry it too.
+  assert_contains "$reemit" "Daily fleet report" \
+    "--reemit dropped the standing daily fleet report directive"
 
   pass "--reemit reprints the digest without repeating startup's mutating sweeps and still drains queued wakes"
 }
@@ -2201,6 +2227,111 @@ EOF
   pass "an empty fleet reports (none) for in-flight tasks and an absent AFK flag"
 }
 
+# --- the standing daily fleet report -----------------------------------------
+# AGENTS.md section 3 makes writing data/status-report-<YYYY-MM-DD>.md standing
+# rather than a captain request. A session has no clock between turns, so the
+# only mechanism available is this once-per-session digest testing whether
+# today's report file exists. These tests pin that trigger and its three
+# exclusions.
+
+test_daily_report_directive_on_first_session_of_day() {
+  local rec root home fakebin out today
+  rec=$(new_world daily-report-first)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_toolchain "$fakebin"
+  make_fake_ps_claude "$fakebin"
+  today=2026-05-04
+  make_fake_date "$fakebin" "$today"
+
+  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+
+  assert_contains "$out" "Daily fleet report" \
+    "the first session of a day did not name the missing dated report"
+  assert_contains "$out" "$home/data/status-report-$today.md" \
+    "the daily report directive did not name today's exact report path"
+  assert_contains "$out" "/bearings file" \
+    "the daily report directive did not name the command that writes it"
+  assert_contains "$out" "standing, not a captain request" \
+    "the daily report directive did not state that it is standing"
+
+  pass "the first session of a day is directed to write the dated fleet report"
+}
+
+test_daily_report_silent_once_today_report_exists() {
+  local rec root home fakebin out today
+  rec=$(new_world daily-report-written)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_toolchain "$fakebin"
+  make_fake_ps_claude "$fakebin"
+  today=2026-05-04
+  make_fake_date "$fakebin" "$today"
+  # Yesterday's report must not satisfy today's trigger, so seed both and let
+  # only today's absence-or-presence decide.
+  printf '# stale\n' > "$home/data/status-report-2026-01-01.md"
+  printf '# Bearings\n' > "$home/data/status-report-$today.md"
+
+  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+
+  assert_not_contains "$out" "Daily fleet report" \
+    "a later session the same day repeated the daily report directive"
+
+  # Prove the same fixture DOES fire once today's report is the only thing missing,
+  # so the assertion above cannot pass vacuously.
+  rm -f "$home/data/status-report-$today.md"
+  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+  assert_contains "$out" "Daily fleet report" \
+    "the directive did not return once today's report was removed"
+
+  pass "the daily report directive fires on today's absence only, once per day"
+}
+
+test_daily_report_skipped_in_a_secondmate_home() {
+  local rec root home fakebin out
+  rec=$(new_world daily-report-secondmate)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_toolchain "$fakebin"
+  make_fake_ps_claude "$fakebin"
+  printf 'sm-alpha\n' > "$home/.fm-secondmate-home"
+
+  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+
+  assert_not_contains "$out" "Daily fleet report" \
+    "a secondmate home was directed to write a captain-facing report"
+
+  pass "a secondmate home is never directed to write the dated fleet report"
+}
+
+test_daily_report_skipped_on_a_read_only_session() {
+  local rec root home fakebin holder_pid out
+  rec=$(new_world daily-report-read-only)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_toolchain "$fakebin"
+  make_fake_ps_claude "$fakebin"
+
+  sleep 300 &
+  holder_pid=$!
+  printf '%s\n' "$holder_pid" > "$home/state/.lock"
+
+  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+  kill "$holder_pid" 2>/dev/null || true
+  wait "$holder_pid" 2>/dev/null || true
+
+  assert_contains "$out" "READ-ONLY SESSION" \
+    "the read-only fixture did not actually refuse the lock"
+  assert_not_contains "$out" "Daily fleet report" \
+    "a read-only session was directed to write into data/"
+
+  pass "a read-only session is never directed to write the dated fleet report"
+}
+
 test_next_step_sources_x_mode_cadence() {
   local rec root home fakebin out
   rec=$(new_world next-step-x)
@@ -2426,6 +2557,10 @@ test_backlog_queued_bound_discloses_its_remainder
 test_backlog_compact_manual_backend_skips_indented_bodies
 test_backlog_compact_tasks_axi_unavailable_uses_manual_fallback
 test_fleet_digest_empty_fleet
+test_daily_report_directive_on_first_session_of_day
+test_daily_report_silent_once_today_report_exists
+test_daily_report_skipped_in_a_secondmate_home
+test_daily_report_skipped_on_a_read_only_session
 test_next_step_sources_x_mode_cadence
 test_next_step_afk_delegates_to_daemon
 test_supervision_block_exactly_one_and_pi_diagnostic

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -49,6 +49,12 @@
 #   (w) index.lock mtime read failure                         -> lock kept, REFUSE
 #   (x) transient lock cleared after first failed return      -> retry ALLOW
 #   (y) persistent lock (never clears, not provably stale)    -> REFUSE loudly
+#
+# Also covers the teardown curation pass (AGENTS.md section 7): the trigger is
+# printed on every completed ship/scout teardown, it permits removal and
+# rewriting rather than only addition, it hands over the bounded wake-log tail
+# that this cleanup deletes, and it never appears on a refusal - so the pass can
+# never be a reason teardown proceeds where it would otherwise refuse.
 set -u
 
 # shellcheck source=tests/lib.sh disable=SC1091
@@ -612,6 +618,84 @@ test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present() {
   printf '%s\n' "$out" | grep -F 'tasks-axi done' >/dev/null \
     && fail "teardown prompted tasks-axi despite manual backend opt-out: $out"
   pass "teardown honors config/backlog-backend=manual even when tasks-axi is compatible"
+}
+
+test_teardown_prints_curation_pass_with_destroyed_status_evidence() {
+  local case_dir out
+  case_dir=$(make_case curation-pass)
+  write_meta "$case_dir" no-mistakes ship
+  printf '%s\n' 'pr=https://github.com/example/repo/pull/7' >> "$case_dir/state/task-x1.meta"
+  printf '%s\n' \
+    'working: reproduced the wedge' \
+    'done: PR https://github.com/example/repo/pull/7 checks green' \
+    > "$case_dir/state/task-x1.status"
+
+  out=$(run_teardown "$case_dir") || fail "teardown failed on the curation-pass case"
+  printf '%s\n' "$out" | grep -F 'Curation: task-x1 is finished' >/dev/null \
+    || fail "teardown did not print the curation pass trigger: $out"
+  printf '%s\n' "$out" | grep -F 'Load the stow skill' >/dev/null \
+    || fail "teardown's curation trigger did not name its owning skill: $out"
+  printf '%s\n' "$out" | grep -F 'AGENTS.md section 6' >/dev/null \
+    || fail "teardown's curation trigger did not name the routing owner: $out"
+  # The whole point of the pass: it must be able to remove and rewrite, not only add.
+  printf '%s\n' "$out" | grep -F 'rewriting or retiring an entry this task disproved' >/dev/null \
+    || fail "teardown's curation trigger did not permit removal and rewriting: $out"
+  printf '%s\n' "$out" | grep -F 'adding nothing is the common one' >/dev/null \
+    || fail "teardown's curation trigger did not allow an empty pass: $out"
+  # The evidence teardown itself destroys is handed over in the same output, which
+  # is what makes the routing happen before the evidence is gone.
+  printf '%s\n' "$out" | grep -F 'reproduced the wedge' >/dev/null \
+    || fail "teardown did not hand over the status-log evidence it deleted: $out"
+  printf '%s\n' "$out" | grep -F "data/task-x1/brief.md" >/dev/null \
+    || fail "teardown did not name the evidence that survives: $out"
+  assert_absent "$case_dir/state/task-x1.status" \
+    "curation-pass: the wake log should still have been deleted by cleanup"
+  pass "teardown prints the curation pass and hands over the wake evidence it destroys"
+}
+
+test_teardown_curation_evidence_is_bounded_and_line_capped() {
+  local case_dir out long i
+  case_dir=$(make_case curation-bounds)
+  write_meta "$case_dir" no-mistakes ship
+  printf '%s\n' 'pr=https://github.com/example/repo/pull/7' >> "$case_dir/state/task-x1.meta"
+  long="working: $(printf 'x%.0s' $(seq 1 400))"
+  for i in 1 2 3 4 5; do
+    printf 'working: event %s\n' "$i" >> "$case_dir/state/task-x1.status"
+  done
+  printf '%s\n' "$long" >> "$case_dir/state/task-x1.status"
+
+  out=$(FM_TEARDOWN_CURATION_STATUS_TAIL=2 run_teardown "$case_dir") \
+    || fail "teardown failed on the curation-bounds case"
+  printf '%s\n' "$out" | grep -F 'working: event 5' >/dev/null \
+    || fail "teardown dropped a line inside the curation tail bound: $out"
+  printf '%s\n' "$out" | grep -F 'working: event 4' >/dev/null \
+    && fail "teardown ignored FM_TEARDOWN_CURATION_STATUS_TAIL: $out"
+  printf '%s\n' "$out" | grep -F '[truncated]' >/dev/null \
+    || fail "teardown did not apply the shared per-line cap to the curation tail: $out"
+  pass "the curation tail honors its line bound and the shared per-line cap"
+}
+
+test_refused_teardown_never_prints_the_curation_pass() {
+  local case_dir rc
+  case_dir=$(make_case curation-refusal)
+  write_meta "$case_dir" local-only ship
+  wt_commit "$case_dir" "unpushed work"
+  printf '%s\n' 'working: something worth keeping' > "$case_dir/state/task-x1.status"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "curation-refusal: unlanded work must still refuse"
+  assert_grep REFUSED "$case_dir/stderr" "curation-refusal: teardown should refuse"
+  assert_not_contains "$(cat "$case_dir/stdout" "$case_dir/stderr")" "Curation:" \
+    "curation-refusal: a refusal must not print the curation pass"
+  # The refusal path leaves the evidence in place, so the pass has nothing to run
+  # after and cannot become a reason the work was let go.
+  assert_present "$case_dir/state/task-x1.status" \
+    "curation-refusal: the wake log must survive a refusal"
+  pass "a teardown refusal prints no curation pass and preserves the task's evidence"
 }
 
 test_local_only_truly_unpushed_refuses() {
@@ -2594,6 +2678,9 @@ EOF
 test_local_only_fork_remote_allows
 test_teardown_prompts_tasks_axi_done_when_compatible
 test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
+test_teardown_prints_curation_pass_with_destroyed_status_evidence
+test_teardown_curation_evidence_is_bounded_and_line_capped
+test_refused_teardown_never_prints_the_curation_pass
 test_local_only_truly_unpushed_refuses
 test_local_only_merged_to_local_main_allows
 test_no_mistakes_origin_remote_allows


### PR DESCRIPTION
## Intent

Make two of firstmate's working-memory habits mechanical rather than optional, because curation is currently advice and advice loses to whatever is urgent. The captain's instruction, 2026-08-11, verbatim: 'add the creation of the dated fleet report a part of your operating parameters. also add a curation pass to the moment work is torn down.'

PIECE 1 - the dated fleet report becomes standing. /bearings file already writes data/status-report-<YYYY-MM-DD>.md, but only when the captain asks. It must become a standing operating parameter in AGENTS.md so a session produces one without being asked, with a stated trigger. The honest trigger is the first session of a day, because that is the only moment a session can tell it is starting fresh, and the session-start digest is the only point that already runs once per session with the lock held. Explicitly ruled OUT: inventing a scheduler. There is no clock a session can consult between turns, and a 'daily' rule with no mechanism is the same advice-that-loses-to-urgency this task exists to fix. The task required choosing between AGENTS.md prose, bin/fm-session-start.sh, or the bearings skill, and stating why in the commit message. I chose bin/fm-session-start.sh and stated the reasoning there and in the code comment: prose has no mechanism at all, the skill only runs once invoked, and the digest is the single once-per-session locked point that can establish 'first session of a day'. The trigger is the artifact's own absence (today's report file exists or does not), which is idempotent across a day and needs no marker file. Deliberate decisions: --reemit still prints it, because a compaction loses the obligation exactly as it loses the wake queue; read-only sessions are excluded because writing the report mutates data/ without authority; secondmate homes are excluded because the report is captain-facing and a secondmate never addresses the captain. The bearings skill gained one line saying the digest's directive counts as an explicit file-mode invocation, because that skill's own rule otherwise excludes natural-language requests from file mode and would have blocked the standing write.

PIECE 2 - a curation pass at teardown. Teardown already refuses on unlanded work and already enforces the unresolved-decision completion gate, which is exactly why it is the right hook: it is the one moment in the lifecycle that already stops and already forces a review. The pass covers the knowledge routing AGENTS.md section 6 already defines: data/captain.md, data/learnings.md, the backlog item, the project's own AGENTS.md. The point is that a finished task's durable knowledge is routed before its evidence is discarded. THE CONSTRAINT THAT MAKES THIS WORTH DOING: data/learnings.md in the main home is 826 lines against a contract that says curated, pruned, rewritten rather than appended, so a pass that only ever adds makes that file worse. The pass must be able to remove and rewrite and must say so explicitly. I put the pass itself in the stow skill rather than a new skill, because stow already owns the curation mechanics it needs (cold archive at data/memory-archive.md, inspect-then-update, and the rule that a unique current fact is archived rather than deleted); a new skill would have duplicated all of that. bin/fm-teardown.sh prints the trigger next to the backlog-refresh reminder it already prints, and hands over a bounded, per-line-capped tail of state/<id>.status captured before the rm deletes it, because that log is the one readable piece of the task's evidence teardown itself destroys (data/<id>/ survives, and a ship task's commits are already on the remote by the time the landed-work check permits teardown). That is what makes 'routed before its evidence is discarded' true rather than aspirational.

ACCEPTANCE CRITERIA: a session produces the dated fleet report without being asked, by a stated trigger with a real mechanism behind it; teardown carries a curation pass that routes durable knowledge per section 6 and explicitly permits removal and rewriting, not only addition; AGENTS.md's always-loaded contract stays concise per its own maintenance section, pointing at owners rather than restating them (it grew by 3 lines).

CONSTRAINTS: do not weaken any existing teardown refusal - the unlanded-work and decision-completion gates keep their current behaviour exactly. A curation pass must never become a reason teardown proceeds where it would otherwise refuse; both new teardown functions are print-only and run after every refusal has passed and after cleanup has succeeded, and a test pins that a refusal prints no trigger and preserves the wake log. Do not touch data/ contents themselves; this task changes the mechanism, not the current records. No em dash anywhere. Firstmate repo style applies: one sentence per line in tracked Markdown, plain dash, shellcheck-clean bin scripts, tests colocated in tests/ extending the existing suites rather than new runners, and no agent name as commit co-author.

TESTS ADDED: three teardown cases (the trigger with its removal-and-rewrite language, the bounded and line-capped evidence tail, and a refusal that prints no trigger and preserves the wake log) and four session-start cases (first session of a day, silence for the rest of that day, and skipped for read-only and secondmate homes), plus a --reemit assertion folded into the existing re-emit test. The date-sensitive cases pin date +%Y-%m-%d through a fixture rather than reading the clock twice, so a run crossing midnight cannot flake - the repo bars flaky tests. A new env knob FM_TEARDOWN_CURATION_STATUS_TAIL (default 12) was documented in docs/configuration.md alongside the other teardown knobs.

NOT DONE, deliberately and reported to firstmate: the task asked for an agent-standards:docs/how-to-agents.md entry, but that file is outside this worktree and the crewmate brief forbids modifying anything outside it; the changed surfaces are firstmate's own tracked skills and scripts, documented in this repo instead.

## What Changed

- `bin/fm-session-start.sh` now emits a standing directive to produce the dated `data/status-report-<YYYY-MM-DD>.md` fleet report on the first session of a day (trigger: the file's own absence), still re-emitted on `--reemit`, and skipped for read-only sessions and secondmate homes.
- `bin/fm-teardown.sh` gains a print-only curation-pass trigger that runs after every existing refusal check has passed and cleanup has succeeded, handing over a bounded, line-capped tail of the deleted `state/<id>.status` and pointing at the knowledge-routing targets from AGENTS.md section 6; existing unlanded-work and decision-completion refusals are unchanged and still print no trigger.
- `.agents/skills/stow/SKILL.md` documents that the curation pass may remove and rewrite entries in `data/learnings.md`, not only append to it, reusing stow's existing cold-archive and inspect-then-update mechanics; `.agents/skills/bearings/SKILL.md`, `AGENTS.md`, `README.md`, and `docs/configuration.md` are updated to describe the standing report, the curation pass, and the new `FM_TEARDOWN_CURATION_STATUS_TAIL` knob.
- Adds `tests/fm-session-start.test.sh` (4 new cases plus a folded `--reemit` assertion) and `tests/fm-teardown.test.sh` (3 new cases) covering the daily report trigger/silence/skip conditions and the curation trigger/evidence bounding/refusal-preserves-no-trigger behavior.

## Risk Assessment

✅ Low: The change is well-bounded: both new mechanisms (standing daily report trigger, teardown curation pass) are print-only or gated behind conditions that cannot affect existing teardown refusals or session-start safety checks, are exercised by new colocated tests that pin the date and assert refusal paths stay silent, reuse existing shared helpers (fm-line-cap-lib.sh) rather than duplicating logic, and match every constraint in the stated intent (no em dash, AGENTS.md grew exactly 3 lines, section 6/7 references are accurate, --reemit still prints the report directive, secondmate/read-only exclusions are correctly wired to existing READ_ONLY and secondmate-home checks).

## Testing

Ran the two colocated targeted test suites for this change; all new tests for the daily fleet-report trigger and the teardown curation pass (including the refusal-preserves-evidence and bounded/line-capped tail cases) passed, and no regressions appeared in either suite's existing matrix.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-teardown.test.sh (full suite, includes the 3 new curation-pass tests: test_teardown_prints_curation_pass_with_destroyed_status_evidence, test_teardown_curation_evidence_is_bounded_and_line_capped, test_refused_teardown_never_prints_the_curation_pass)`
- `bash tests/fm-session-start.test.sh (full suite, includes the 4 new daily-report tests: test_daily_report_directive_on_first_session_of_day, test_daily_report_silent_once_today_report_exists, test_daily_report_skipped_in_a_secondmate_home, test_daily_report_skipped_on_a_read_only_session, plus the folded --reemit assertion for the daily report directive)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
