### PR TITLE
fix(bin): prevent watcher recovery acknowledgement livelock

### DIFF
--- a/bin/fm-wake-drain.sh
+++ b/bin/fm-wake-drain.sh
@@ -175,14 +175,22 @@ if [ -n "$ACK_THROUGH" ]; then
   awk -F '\t' -v cutoff="$ACK_THROUGH" '
     NF < 5 || $2 !~ /^[0-9]+$/ || $2 > cutoff { print }
   ' "$FM_WAKE_QUEUE" > "$DRAIN_TMP" || exit 1
-  fm_recovery_marker_snapshot "$RECOVERY_MARKER" || exit 1
-  RECOVERY_MARKER_TOKEN=$FM_RECOVERY_MARKER_TOKEN
-  if [ "${RECOVERY_MARKER_TOKEN##*:}" != "$ACK_GENERATION" ]; then
-    RECOVERY_ACK_MOVED=true
-  elif [ ! -s "$DRAIN_TMP" ]; then
-    if ! fm_recovery_marker_ack "$RECOVERY_MARKER" "$ACK_GENERATION"; then
-      echo "wake drain: recovery episode could not be retired safely; re-run bin/fm-wake-drain.sh and use the new WAKE_ACK_REQUIRED command" >&2
-      exit 1
+  if [ ! -s "$DRAIN_TMP" ]; then
+    fm_recovery_marker_ack "$RECOVERY_MARKER" "$ACK_GENERATION"
+    RECOVERY_ACK_STATUS=$?
+    case "$RECOVERY_ACK_STATUS" in
+      0) ;;
+      3) RECOVERY_ACK_MOVED=true ;;
+      *)
+        echo "wake drain: recovery episode could not be retired safely; re-run bin/fm-wake-drain.sh and use the new WAKE_ACK_REQUIRED command" >&2
+        exit 1
+        ;;
+    esac
+  else
+    fm_recovery_marker_snapshot "$RECOVERY_MARKER" || exit 1
+    RECOVERY_MARKER_TOKEN=$FM_RECOVERY_MARKER_TOKEN
+    if [ "${RECOVERY_MARKER_TOKEN##*:}" != "$ACK_GENERATION" ]; then
+      RECOVERY_ACK_MOVED=true
     fi
   fi
   if ! _fm_atomic_replace "$DRAIN_TMP" "$FM_WAKE_QUEUE"; then

--- a/bin/fm-wake-drain.sh
+++ b/bin/fm-wake-drain.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 # Present durable watcher wake records, optionally acknowledge handled records,
 # annotate validated signal status keys, then assert liveness.
+#
+# An acknowledgement carries two separable facts, and this script keeps them
+# separate. Queue-row consumption is bound to the monotonic --ack-through
+# sequence the caller was given, so it is safe under any marker state and always
+# happens. Only retiring the recovery episode is bound to --recovery-generation.
+# A generation that moved on while this turn handled its wakes is therefore a
+# non-fatal result: the handled rows are still consumed, and the message names
+# its own remedy (re-drain, then acknowledge the new generation). It is never a
+# failure that consumes nothing and leaves behind the exact pending state that
+# makes the next armed watcher spend its whole cycle re-announcing the same
+# recovery. See docs/watcher-continuity.md for the contract.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -17,6 +28,7 @@ RAW_ROWS=
 RECOVERY_MARKER="$STATE/.watcher-down"
 RECOVERY_MARKER_TOKEN=
 RECOVERY_ACK_REQUIRED=false
+RECOVERY_ACK_MOVED=false
 ACK_THROUGH=
 ACK_GENERATION=
 ACK_FINGERPRINTS=
@@ -147,12 +159,6 @@ fm_lock_acquire_wait "$FM_WAKE_QUEUE_LOCK"
 DRAIN_LOCK_HELD=true
 
 if [ -n "$ACK_THROUGH" ]; then
-  fm_recovery_marker_snapshot "$RECOVERY_MARKER" || exit 1
-  RECOVERY_MARKER_TOKEN=$FM_RECOVERY_MARKER_TOKEN
-  if [ "${RECOVERY_MARKER_TOKEN##*:}" != "$ACK_GENERATION" ]; then
-    echo "wake drain: recovery generation is stale or could not be acknowledged safely" >&2
-    exit 1
-  fi
   ACK_FINGERPRINTS=$(inactive_outcome_fingerprints "$ACK_THROUGH" 'inactive-outcome:') || exit 1
   ACK_NOTICE_FINGERPRINTS=$(inactive_outcome_fingerprints "$ACK_THROUGH" 'inactive-reconcile:') || exit 1
   fm_lock_release "$FM_WAKE_QUEUE_LOCK"
@@ -164,20 +170,18 @@ if [ -n "$ACK_THROUGH" ]; then
   fi
   fm_lock_acquire_wait "$FM_WAKE_QUEUE_LOCK"
   DRAIN_LOCK_HELD=true
-  fm_recovery_marker_snapshot "$RECOVERY_MARKER" || exit 1
-  RECOVERY_MARKER_TOKEN=$FM_RECOVERY_MARKER_TOKEN
-  if [ "${RECOVERY_MARKER_TOKEN##*:}" != "$ACK_GENERATION" ]; then
-    echo "wake drain: recovery generation changed while recording inactive outcome receipts" >&2
-    exit 1
-  fi
   DRAIN_TMP=$(mktemp "$STATE/.wake-queue.ack.XXXXXX") || exit 1
   chmod 0600 "$DRAIN_TMP" || exit 1
   awk -F '\t' -v cutoff="$ACK_THROUGH" '
     NF < 5 || $2 !~ /^[0-9]+$/ || $2 > cutoff { print }
   ' "$FM_WAKE_QUEUE" > "$DRAIN_TMP" || exit 1
-  if [ ! -s "$DRAIN_TMP" ]; then
+  fm_recovery_marker_snapshot "$RECOVERY_MARKER" || exit 1
+  RECOVERY_MARKER_TOKEN=$FM_RECOVERY_MARKER_TOKEN
+  if [ "${RECOVERY_MARKER_TOKEN##*:}" != "$ACK_GENERATION" ]; then
+    RECOVERY_ACK_MOVED=true
+  elif [ ! -s "$DRAIN_TMP" ]; then
     if ! fm_recovery_marker_ack "$RECOVERY_MARKER" "$ACK_GENERATION"; then
-      echo "wake drain: recovery generation is stale or could not be acknowledged safely" >&2
+      echo "wake drain: recovery episode could not be retired safely; re-run bin/fm-wake-drain.sh and use the new WAKE_ACK_REQUIRED command" >&2
       exit 1
     fi
   fi
@@ -188,6 +192,10 @@ if [ -n "$ACK_THROUGH" ]; then
   DRAIN_TMP=
   fm_lock_release "$FM_WAKE_QUEUE_LOCK"
   DRAIN_LOCK_HELD=false
+  if [ "$RECOVERY_ACK_MOVED" = true ]; then
+    printf 'wake drain: acknowledged wakes through %s, but a newer recovery episode is pending; re-run bin/fm-wake-drain.sh and use the new WAKE_ACK_REQUIRED command\n' \
+      "$ACK_THROUGH" >&2
+  fi
   exit 0
 fi
 

--- a/bin/fm-wake-drain.sh
+++ b/bin/fm-wake-drain.sh
@@ -2,16 +2,8 @@
 # Present durable watcher wake records, optionally acknowledge handled records,
 # annotate validated signal status keys, then assert liveness.
 #
-# An acknowledgement carries two separable facts, and this script keeps them
-# separate. Queue-row consumption is bound to the monotonic --ack-through
-# sequence the caller was given, so it is safe under any marker state and always
-# happens. Only retiring the recovery episode is bound to --recovery-generation.
-# A generation that moved on while this turn handled its wakes is therefore a
-# non-fatal result: the handled rows are still consumed, and the message names
-# its own remedy (re-drain, then acknowledge the new generation). It is never a
-# failure that consumes nothing and leaves behind the exact pending state that
-# makes the next armed watcher spend its whole cycle re-announcing the same
-# recovery. See docs/watcher-continuity.md for the contract.
+# Keep sequence-bound row consumption independent from generation-bound episode
+# retirement; docs/watcher-continuity.md owns the recovery contract.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -416,8 +416,18 @@ _fm_recovery_marker_write_locked() {
   fi
 }
 
+# A downtime publication reuses the generation of an outstanding handling
+# episode instead of minting a fresh one. Every watcher close and every queue
+# append publishes downtime, so minting here would invalidate the exact
+# acknowledgement the drain just printed for the episode the caller is still
+# handling. That acknowledgement then retired nothing, which left the marker
+# pending and made the next armed watcher spend its whole cycle re-announcing
+# the same recovery - the livelock this reuse removes.
+# Retirement stays correct because the acknowledgement clears the marker only
+# once the remaining queue is empty: a wake appended after the drain carries a
+# higher sequence, so it keeps the queue non-empty and the episode pending.
 _fm_recovery_marker_publish() {
-  local marker=$1 kind=${2:-downtime} lock
+  local marker=$1 kind=${2:-downtime} lock saved_token generation=''
   case "$kind" in handling|downtime) ;; *) return 1 ;; esac
   lock="${marker}.lock"
   fm_lock_acquire_wait "$lock" || return 1
@@ -425,7 +435,19 @@ _fm_recovery_marker_publish() {
     fm_lock_release "$lock"
     return 1
   fi
-  if ! _fm_recovery_marker_write_locked "$marker" "$kind"; then
+  if [ "$kind" = downtime ]; then
+    # Read inline rather than in a command substitution: this runs inside the
+    # marker-lock critical section, so it must not add a subshell fork there.
+    # The token is restored because publishing owns no snapshot of its own.
+    saved_token=$FM_RECOVERY_MARKER_TOKEN
+    if fm_recovery_marker_read "$marker"; then
+      case "$FM_RECOVERY_MARKER_TOKEN" in
+        pending:handling:*) generation=${FM_RECOVERY_MARKER_TOKEN##*:} ;;
+      esac
+    fi
+    FM_RECOVERY_MARKER_TOKEN=$saved_token
+  fi
+  if ! _fm_recovery_marker_write_locked "$marker" "$kind" "$generation"; then
     fm_lock_release "$lock"
     return 1
   fi

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -442,7 +442,7 @@ _fm_recovery_marker_publish() {
     saved_token=$FM_RECOVERY_MARKER_TOKEN
     if fm_recovery_marker_read "$marker"; then
       case "$FM_RECOVERY_MARKER_TOKEN" in
-        pending:handling:*) generation=${FM_RECOVERY_MARKER_TOKEN##*:} ;;
+        pending:handling:*|pending:downtime:*) generation=${FM_RECOVERY_MARKER_TOKEN##*:} ;;
       esac
     fi
     FM_RECOVERY_MARKER_TOKEN=$saved_token

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -416,16 +416,9 @@ _fm_recovery_marker_write_locked() {
   fi
 }
 
-# A downtime publication reuses the generation of an outstanding handling
-# episode instead of minting a fresh one. Every watcher close and every queue
-# append publishes downtime, so minting here would invalidate the exact
-# acknowledgement the drain just printed for the episode the caller is still
-# handling. That acknowledgement then retired nothing, which left the marker
-# pending and made the next armed watcher spend its whole cycle re-announcing
-# the same recovery - the livelock this reuse removes.
-# Retirement stays correct because the acknowledgement clears the marker only
-# once the remaining queue is empty: a wake appended after the drain carries a
-# higher sequence, so it keeps the queue non-empty and the episode pending.
+# Preserve a pending episode's generation across downtime republication so its
+# outstanding acknowledgement remains usable; docs/watcher-continuity.md owns
+# the recovery contract and sequence-safety rationale.
 _fm_recovery_marker_publish() {
   local marker=$1 kind=${2:-downtime} lock saved_token generation=''
   case "$kind" in handling|downtime) ;; *) return 1 ;; esac

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -451,7 +451,7 @@ Registration writes one private record under `state/procevent/`, and a completed
 Results are published as ordinary `check` wakes carrying the source id and committed result sequence through the existing durable wake queue, so the runner adds no second notification control plane.
 The watcher delivers a queued result on its ordinary cycle by reporting it as an actionable `check` wake, so a captured result reaches firstmate through the same rewake path every other wake uses and never waits for a manual drain.
 Delivery is reported at most once per captured source and sequence while any records for that key remain queued.
-A durable handled acknowledgement stops future source re-announcement, while a record already queued remains under the durable queue's authority until the ordinary drain's separate generation-bound post-handling acknowledgement consumes it.
+A durable handled acknowledgement stops future source re-announcement, while a record already queued remains under the durable queue's authority until the ordinary drain's sequence-bound post-handling acknowledgement consumes it.
 
 Discovery is never a timer.
 Each registered source has its own child process blocking on that source, and the watcher's per-cycle `reconcile` republishes every captured result with no durable handled acknowledgement yet - regardless of any earlier publication - restarts a source whose owner is gone, and stops this home's runner when reconciliation runs after its registration disappeared unexpectedly.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -89,7 +89,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-tasks-axi-lib.sh`    | Shared backlog-backend selector and `tasks-axi` compatibility probe                  |
 | `fm-quota-axi-lib.sh`    | Shared `quota-axi` compatibility floor for the bootstrap diagnostic                  |
 | `fm-vendor-auth-probe.sh`| Run one hard-bounded, non-destructive authentication probe of a named vendor CLI and report the fact |
-| `fm-wake-drain.sh`       | Present durable watcher wakes and OPEN DECISIONS, consume only a generation-bound post-handling acknowledgement, then assert supervision health |
+| `fm-wake-drain.sh`       | Present durable watcher wakes and OPEN DECISIONS, consume acknowledged rows through their sequence, retire only the matching recovery generation, then assert supervision health |
 | `fm-wake-lib.sh`         | Shared durable wake queue, recovery generations, portable locks, and watcher identity/health helpers |
 | `fm-classify-lib.sh`     | Shared wake-classification vocabulary and durable keyed-decision folds and scans     |
 | `fm-send.sh`             | Send one verified literal line or supported key through the target's recorded backend |

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -243,7 +243,7 @@ Harness identity is read from the executable path and `argv[0]` as well as the c
 `tests/fm-session-lock-ancestry.test.sh` pins both platforms' reporting semantics behind a deterministic process table and runs the real Stop auto-arm in version-named, daemon-parented, and combined real process trees.
 `tests/fm-watch-arm.test.sh` runs real watcher and arm cycles against durable on-disk state to verify that a delivered reason survives until post-handling acknowledgement and stops replaying after acknowledgement, while an unrelated queue append cannot make a watcher cycle that delivered nothing look successful.
 The same suite ingests a keyed remote-secondmate parent reply through the real adapter, establishes the incremental OPEN DECISIONS cursor, interrupts supervision, and proves re-arm replays every unacknowledged queue row plus the still-open decision through the ordinary drain path.
-It also covers decision-only recovery, interrupted handling, stale acknowledgement rejection, and a persistent successor remaining live after recovery is acknowledged.
+It also covers decision-only recovery, interrupted handling, handling-window generation reuse, non-fatal moved-generation acknowledgement with sequence-bounded consumption, and a persistent successor remaining live after recovery is acknowledged.
 
 The Claude product live path ran with Claude Code 2.1.219 on 2026-07-24:
 

--- a/docs/watcher-continuity.md
+++ b/docs/watcher-continuity.md
@@ -42,6 +42,15 @@ No adapter starts a replacement with shell `&`.
 
 The turn-end guard remains the final backstop rather than the normal continuity mechanism and cooperates with the auto-arm in its `--claude` mode.
 
+## Recovery episode acknowledgement
+
+A recovery episode is one generation of `state/.watcher-down`, and it is retired only by the generation-bound acknowledgement the drain prints as `WAKE_ACK_REQUIRED`.
+Every watcher close and every durable queue append publishes downtime, so a republication reuses the generation of an episode that is already being handled instead of minting a new one.
+Without that reuse, a watcher cycle that opened and closed inside the handling window invalidated the acknowledgement the model had just been given, that acknowledgement then consumed nothing, and the still-pending marker made every later arm spend its whole cycle re-announcing the same recovery instead of supervising.
+An acknowledgement carries two separable facts and `bin/fm-wake-drain.sh` keeps them separate: queue-row consumption is bound to the monotonic `--ack-through` sequence and always happens, while only retiring the episode is bound to `--recovery-generation`.
+A generation that moved on is therefore a non-fatal result that still consumes the handled rows and names its own remedy - re-drain, then acknowledge the newer episode - rather than a refusal that consumes nothing.
+An acknowledged episode does not freeze the generation, because the next downtime after it opens an episode of its own.
+
 ## Arm-layer cycle contract
 
 `bin/fm-watch-arm.sh` never returns a clean empty success.
@@ -64,7 +73,7 @@ Only the watcher process touches `state/.last-watcher-beat`; no helper process c
 
 `tests/fm-pi-watch-extension.test.sh` checks Pi's first-cycle-or-explicit-repair tool metadata and ownership-based redundant-call no-ops, then simulates actionable and empty child closes against the actual Pi and OpenCode close handlers, blocks prompt delivery to prove the successor launches first, verifies single-flight behavior, changes the session lock before close to prove ownership is rechecked, and hangs each successor arm to prove bounded fallback delivery includes the typed restoration failure.
 The same suite covers ordinary same-process session replacement for `/new`, `/resume`, and `/fork`, same-instance shutdown-plus-start, stale prior-generation callbacks, repeated transitions with exactly one live cycle, disappearance of the shutting-down refusal after a valid replacement activates, and terminal quit still refusing late rearm.
-`tests/fm-watch-arm.test.sh` covers durable queue replay, real remote parent-replies ingestion into the authoritative status log, decision-only OPEN DECISIONS recovery, interrupted handling replay, generation-bound acknowledgement, and a persistent live successor after recovery.
+`tests/fm-watch-arm.test.sh` covers durable queue replay, real remote parent-replies ingestion into the authoritative status log, decision-only OPEN DECISIONS recovery, interrupted handling replay, generation-bound acknowledgement, a persistent live successor after recovery, a watcher close inside the handling window that must leave the printed acknowledgement valid, and the self-healing moved-generation acknowledgement that consumes its handled rows and names its remedy.
 `tests/fm-watcher-lock.test.sh` covers verified-successor attach, recovery publication before stale-lock removal, the typed self-eviction failure, bounded and successor-linked lifecycle rows, and a SIGSTOP counterfactual that distinguishes a live PID from a stale beacon before classifying termination.
 `tests/fm-subagent-pretool-check.test.sh` proves Claude retains only the non-status Bash seatbelts.
 `tests/fm-claude-stop-autoarm.test.sh` covers the auto-arm's scope, stale and live session owners, unchanged AFK and need boundaries, single-flight, bounded failure retries, benign live-watcher cycle ends, one-notice failure episodes, and exit-2 translation.

--- a/docs/watcher-continuity.md
+++ b/docs/watcher-continuity.md
@@ -45,10 +45,13 @@ The turn-end guard remains the final backstop rather than the normal continuity 
 ## Recovery episode acknowledgement
 
 A recovery episode is one generation of `state/.watcher-down`, and it is retired only by the generation-bound acknowledgement the drain prints as `WAKE_ACK_REQUIRED`.
-Every watcher close and every durable queue append publishes downtime, so a republication reuses the generation of an episode that is already being handled instead of minting a new one.
-Without that reuse, a watcher cycle that opened and closed inside the handling window invalidated the acknowledgement the model had just been given, that acknowledgement then consumed nothing, and the still-pending marker made every later arm spend its whole cycle re-announcing the same recovery instead of supervising.
-An acknowledgement carries two separable facts and `bin/fm-wake-drain.sh` keeps them separate: queue-row consumption is bound to the monotonic `--ack-through` sequence and always happens, while only retiring the episode is bound to `--recovery-generation`.
-A generation that moved on is therefore a non-fatal result that still consumes the handled rows and names its own remedy - re-drain, then acknowledge the newer episode - rather than a refusal that consumes nothing.
+Every watcher close and every durable queue append publishes downtime, so a downtime republication of any pending episode reuses its generation instead of minting a new one.
+That reuse keeps a watcher close inside the handling window from orphaning the acknowledgement already presented and trapping later arms in repeated recovery presentation.
+An acknowledgement carries two separable facts: queue-row consumption is bound to the monotonic `--ack-through` sequence, while only retiring the episode is bound to `--recovery-generation`.
+A generation mismatch therefore does not block consumption of rows through that sequence; it is a non-fatal result that names its own remedy - re-drain, then acknowledge the newer episode.
+The acknowledgement retires the marker only when no rows remain after sequence-bound consumption.
+A concurrently appended wake has a higher sequence, remains queued, and keeps the episode pending for presentation.
+Consequently, an empty-queue downtime publication during handling can be retired by the outstanding acknowledgement without a dedicated recovery turn.
 An acknowledged episode does not freeze the generation, because the next downtime after it opens an episode of its own.
 
 ## Arm-layer cycle contract

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -483,8 +483,16 @@ test_legacy_generationless_wake_is_adopted() {
   pass "wake drain: generation-less legacy wakes are adopted and acknowledged"
 }
 
-test_stale_recovery_generation_is_rejected() {
-  local dir state first_err replay_err sequence generation newer_marker newer_sequence newer_generation rc
+# The two facts an acknowledgement carries, pinned at the library level.
+# A publication while an episode is being handled keeps that episode's
+# generation, so the acknowledgement the caller was just given stays valid. Once
+# an episode is retired the next publication opens its own generation, and an
+# acknowledgement for the retired one may neither retire nor consume the newer
+# episode's work - it consumes only what its own sequence covers and names the
+# remedy for the rest.
+test_stale_recovery_generation_cannot_touch_a_newer_episode() {
+  local dir state first_err replay_err sequence generation handling_marker
+  local newer_marker newer_sequence newer_generation rc
   dir=$(make_case stale-recovery-generation)
   state="$dir/state"
 
@@ -498,35 +506,57 @@ test_stale_recovery_generation_is_rejected() {
   [ -n "$sequence" ] && [ -n "$generation" ] \
     || fail "first drain did not emit a generation-bound acknowledgement"
 
-  append_wake "$state" check second 'check: newer recovery generation' \
-    || fail "newer generation wake append failed"
-  newer_marker=$(cat "$state/.watcher-down")
-  [ "${newer_marker##*:}" != "$generation" ] \
-    || fail "new durable publication did not advance the recovery generation"
+  append_wake "$state" check second 'check: same episode' \
+    || fail "same-episode wake append failed"
+  handling_marker=$(cat "$state/.watcher-down")
+  [ "${handling_marker##*:}" = "$generation" ] \
+    || fail "a publication during handling replaced the outstanding recovery generation"
 
-  set +e
   FM_STATE_OVERRIDE="$state" "$DRAIN" --ack-through "$sequence" \
-    --recovery-generation "$generation" > "$dir/stale-ack.out" 2> "$dir/stale-ack.err"
-  rc=$?
-  set -e
-  [ "$rc" -ne 0 ] || fail "stale acknowledgement consumed a newer recovery generation"
-  [ "$(cat "$state/.watcher-down")" = "$newer_marker" ] \
-    || fail "stale acknowledgement changed the newer recovery marker"
+    --recovery-generation "$generation" > "$dir/handled-ack.out" 2> "$dir/handled-ack.err" \
+    || fail "a publication during handling invalidated the printed acknowledgement"
+  ! grep "$(printf '\tcheck\tfirst\t')" "$state/.wake-queue" >/dev/null \
+    || fail "the handled row was not consumed"
   grep "$(printf '\tcheck\tsecond\t')" "$state/.wake-queue" >/dev/null \
-    || fail "stale acknowledgement removed the newer durable wake"
+    || fail "a row above the acknowledged sequence was consumed"
+  case "$(cat "$state/.watcher-down")" in
+    pending:*) ;;
+    *) fail "an episode with rows still queued was retired" ;;
+  esac
 
+  # Retire that episode, then let a genuinely newer one open.
   FM_STATE_OVERRIDE="$state" "$DRAIN" > "$dir/replay.out" 2> "$dir/replay.err" \
-    || fail "newer generation could not be re-drained"
+    || fail "remaining wake could not be re-drained"
   replay_err="$dir/replay.err"
   grep "$(printf '\tcheck\tsecond\t')" "$dir/replay.out" >/dev/null \
-    || fail "newer generation wake did not re-surface"
+    || fail "remaining wake did not re-surface"
   newer_sequence=$(sed -n 's/^WAKE_ACK_REQUIRED:.*--ack-through \([0-9][0-9]*\) --recovery-generation [A-Za-z0-9._-][A-Za-z0-9._-]*$/\1/p' "$replay_err")
   newer_generation=$(sed -n 's/^WAKE_ACK_REQUIRED:.*--ack-through [0-9][0-9]* --recovery-generation \([A-Za-z0-9._-][A-Za-z0-9._-]*\)$/\1/p' "$replay_err")
   FM_STATE_OVERRIDE="$state" "$DRAIN" --ack-through "$newer_sequence" \
     --recovery-generation "$newer_generation" \
-    || fail "newer recovery generation could not be acknowledged"
-  [ ! -s "$state/.wake-queue" ] || fail "newer acknowledgement left durable wakes queued"
-  pass "wake drain: stale acknowledgement cannot consume a newer recovery generation"
+    || fail "the handled episode could not be acknowledged"
+  [ ! -s "$state/.wake-queue" ] || fail "acknowledgement left durable wakes queued"
+
+  append_wake "$state" check third 'check: newer recovery generation' \
+    || fail "newer generation wake append failed"
+  newer_marker=$(cat "$state/.watcher-down")
+  [ "${newer_marker##*:}" != "$generation" ] \
+    || fail "a retired episode did not open a new recovery generation"
+
+  rc=0
+  FM_STATE_OVERRIDE="$state" "$DRAIN" --ack-through "$sequence" \
+    --recovery-generation "$generation" > "$dir/stale-ack.out" 2> "$dir/stale-ack.err" || rc=$?
+  [ "$rc" -eq 0 ] \
+    || fail "a stale acknowledgement failed instead of degrading safely: $(cat "$dir/stale-ack.err")"
+  if ! grep -F 'WAKE_ACK_REQUIRED' "$dir/stale-ack.err" >/dev/null \
+    || ! grep -F 're-run' "$dir/stale-ack.err" >/dev/null; then
+    fail "a stale acknowledgement did not name its own remedy: $(cat "$dir/stale-ack.err")"
+  fi
+  [ "$(cat "$state/.watcher-down")" = "$newer_marker" ] \
+    || fail "a stale acknowledgement retired the newer recovery episode"
+  grep "$(printf '\tcheck\tthird\t')" "$state/.wake-queue" >/dev/null \
+    || fail "a stale acknowledgement consumed the newer durable wake"
+  pass "wake drain: a stale acknowledgement cannot retire or consume a newer recovery episode"
 }
 
 test_recovery_ack_failure_is_reported() {
@@ -557,8 +587,10 @@ SH
   rc=$?
   set -e
   [ "$rc" -ne 0 ] || fail "recovery acknowledgement failure was reported as success"
-  grep -F 'recovery generation is stale or could not be acknowledged safely' "$dir/drain.err" >/dev/null \
+  grep -F 'recovery episode could not be retired safely' "$dir/drain.err" >/dev/null \
     || fail "recovery acknowledgement failure had no explicit diagnostic"
+  grep -F 'WAKE_ACK_REQUIRED' "$dir/drain.err" >/dev/null \
+    || fail "recovery acknowledgement failure did not name its own remedy"
   [ "$(cat "$state/.watcher-down")" = "pending:handling:$generation" ] \
     || fail "failed acknowledgement corrupted the pending recovery marker"
 
@@ -639,6 +671,6 @@ test_enrichment_caps_and_status_file_failures
 test_slow_annotation_does_not_block_append_and_deleted_file_fails_open
 test_wake_publish_requires_atomic_recovery_evidence
 test_legacy_generationless_wake_is_adopted
-test_stale_recovery_generation_is_rejected
+test_stale_recovery_generation_cannot_touch_a_newer_episode
 test_recovery_ack_failure_is_reported
 test_interruption_before_and_after_raw_commit

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -507,10 +507,12 @@ test_stale_recovery_generation_cannot_touch_a_newer_episode() {
     || fail "first drain did not emit a generation-bound acknowledgement"
 
   append_wake "$state" check second 'check: same episode' \
-    || fail "same-episode wake append failed"
+    || fail "first same-episode wake append failed"
+  append_wake "$state" check third 'check: same episode again' \
+    || fail "second same-episode wake append failed"
   handling_marker=$(cat "$state/.watcher-down")
   [ "${handling_marker##*:}" = "$generation" ] \
-    || fail "a publication during handling replaced the outstanding recovery generation"
+    || fail "repeated publications replaced the outstanding recovery generation"
 
   FM_STATE_OVERRIDE="$state" "$DRAIN" --ack-through "$sequence" \
     --recovery-generation "$generation" > "$dir/handled-ack.out" 2> "$dir/handled-ack.err" \
@@ -519,6 +521,8 @@ test_stale_recovery_generation_cannot_touch_a_newer_episode() {
     || fail "the handled row was not consumed"
   grep "$(printf '\tcheck\tsecond\t')" "$state/.wake-queue" >/dev/null \
     || fail "a row above the acknowledged sequence was consumed"
+  grep "$(printf '\tcheck\tthird\t')" "$state/.wake-queue" >/dev/null \
+    || fail "the second row above the acknowledged sequence was consumed"
   case "$(cat "$state/.watcher-down")" in
     pending:*) ;;
     *) fail "an episode with rows still queued was retired" ;;
@@ -530,6 +534,8 @@ test_stale_recovery_generation_cannot_touch_a_newer_episode() {
   replay_err="$dir/replay.err"
   grep "$(printf '\tcheck\tsecond\t')" "$dir/replay.out" >/dev/null \
     || fail "remaining wake did not re-surface"
+  grep "$(printf '\tcheck\tthird\t')" "$dir/replay.out" >/dev/null \
+    || fail "second remaining wake did not re-surface"
   newer_sequence=$(sed -n 's/^WAKE_ACK_REQUIRED:.*--ack-through \([0-9][0-9]*\) --recovery-generation [A-Za-z0-9._-][A-Za-z0-9._-]*$/\1/p' "$replay_err")
   newer_generation=$(sed -n 's/^WAKE_ACK_REQUIRED:.*--ack-through [0-9][0-9]* --recovery-generation \([A-Za-z0-9._-][A-Za-z0-9._-]*\)$/\1/p' "$replay_err")
   FM_STATE_OVERRIDE="$state" "$DRAIN" --ack-through "$newer_sequence" \
@@ -537,7 +543,7 @@ test_stale_recovery_generation_cannot_touch_a_newer_episode() {
     || fail "the handled episode could not be acknowledged"
   [ ! -s "$state/.wake-queue" ] || fail "acknowledgement left durable wakes queued"
 
-  append_wake "$state" check third 'check: newer recovery generation' \
+  append_wake "$state" check fourth 'check: newer recovery generation' \
     || fail "newer generation wake append failed"
   newer_marker=$(cat "$state/.watcher-down")
   [ "${newer_marker##*:}" != "$generation" ] \
@@ -554,7 +560,7 @@ test_stale_recovery_generation_cannot_touch_a_newer_episode() {
   fi
   [ "$(cat "$state/.watcher-down")" = "$newer_marker" ] \
     || fail "a stale acknowledgement retired the newer recovery episode"
-  grep "$(printf '\tcheck\tthird\t')" "$state/.wake-queue" >/dev/null \
+  grep "$(printf '\tcheck\tfourth\t')" "$state/.wake-queue" >/dev/null \
     || fail "a stale acknowledgement consumed the newer durable wake"
   pass "wake drain: a stale acknowledgement cannot retire or consume a newer recovery episode"
 }

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -483,13 +483,8 @@ test_legacy_generationless_wake_is_adopted() {
   pass "wake drain: generation-less legacy wakes are adopted and acknowledged"
 }
 
-# The two facts an acknowledgement carries, pinned at the library level.
-# A publication while an episode is being handled keeps that episode's
-# generation, so the acknowledgement the caller was just given stays valid. Once
-# an episode is retired the next publication opens its own generation, and an
-# acknowledgement for the retired one may neither retire nor consume the newer
-# episode's work - it consumes only what its own sequence covers and names the
-# remedy for the rest.
+# Pin the recovery acknowledgement contract from docs/watcher-continuity.md at
+# the queue-library boundary.
 test_stale_recovery_generation_cannot_touch_a_newer_episode() {
   local dir state first_err replay_err sequence generation handling_marker
   local newer_marker newer_sequence newer_generation rc

--- a/tests/fm-watch-arm.test.sh
+++ b/tests/fm-watch-arm.test.sh
@@ -128,6 +128,16 @@ ack_wakes() {  # <state>
     --recovery-generation "$generation"
 }
 
+# Print "<sequence>\t<generation>" from the acknowledgement command a drain
+# printed, so a case can replay that exact pair later.
+drain_ack_pair() {  # <drain-stderr>
+  local err=$1 sequence generation
+  sequence=$(sed -n 's/^WAKE_ACK_REQUIRED:.*--ack-through \([0-9][0-9]*\) --recovery-generation [A-Za-z0-9._-][A-Za-z0-9._-]*$/\1/p' "$err")
+  generation=$(sed -n 's/^WAKE_ACK_REQUIRED:.*--ack-through [0-9][0-9]* --recovery-generation \([A-Za-z0-9._-][A-Za-z0-9._-]*\)$/\1/p' "$err")
+  [ -n "$sequence" ] && [ -n "$generation" ] || return 1
+  printf '%s\t%s\n' "$sequence" "$generation"
+}
+
 start_rearm_arm() {  # <home> <state> <fakebin> <arm-out> [predecessor-arm-pid]
   local home=$1 state=$2 fakebin=$3 armout=$4 predecessor=${5:-} i
   PATH="$fakebin:$PATH" FM_HOME="$home" FM_STATE_OVERRIDE="$state" \
@@ -621,6 +631,143 @@ test_markerless_legacy_queue_is_recovered_on_arm() {
   pass "watch-arm: markerless legacy queues are adopted and recovered"
 }
 
+# Every watcher close and every queue append publishes downtime, so a watcher
+# cycle that opens and closes while the model handles its drained wakes used to
+# mint a fresh recovery generation and invalidate the acknowledgement that drain
+# had just printed. That acknowledgement then consumed nothing and left the
+# marker pending, which made every later arm spend its whole cycle re-announcing
+# the same recovery instead of supervising - a livelock the home could not leave.
+test_handling_window_close_keeps_the_acknowledgement_valid() {
+  local dir home state fakebin pair sequence generation handling_watcher_pid
+  dir=$(make_case handling-window-close-acknowledgement)
+  home="$dir/home"
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  mkdir -p "$home/data"
+
+  start_rearm_arm "$home" "$state" "$fakebin" "$dir/first-arm.out"
+  is_live_non_zombie "$ARM_PID" || fail "handling-window fixture watcher did not stay live"
+  printf 'done: wake handled while a watcher cycle closes\n' > "$state/handled.status"
+  wait_for_exit "$ARM_PID" 120 || fail "fixture watcher did not deliver its wake"
+  grep "$(printf '\tsignal\thandled.status\t')" "$state/.wake-queue" >/dev/null \
+    || fail "delivered wake was not durable before handling"
+
+  FM_HOME="$home" FM_STATE_OVERRIDE="$state" "$DRAIN" > "$dir/drain.out" 2> "$dir/drain.err" \
+    || fail "handling drain did not present the durable wake"
+  pair=$(drain_ack_pair "$dir/drain.err") \
+    || fail "drain did not print a generation-bound acknowledgement command"
+  sequence=${pair%%$'\t'*}
+  generation=${pair##*$'\t'}
+
+  # One full watcher cycle opens and closes inside the handling window.
+  start_rearm_arm "$home" "$state" "$fakebin" "$dir/handling-window-arm.out"
+  is_live_non_zombie "$ARM_PID" || fail "handling-window watcher did not stay live"
+  handling_watcher_pid=$(cat "$state/.watch.lock/pid" 2>/dev/null || true)
+  [ -n "$handling_watcher_pid" ] || fail "handling-window watcher did not take the lock"
+  kill -TERM "$handling_watcher_pid" 2>/dev/null \
+    || fail "could not close the handling-window watcher"
+  wait_for_exit "$ARM_PID" 120
+
+  [ "$(cat "$state/.watcher-down" 2>/dev/null || true)" = "pending:downtime:$generation" ] \
+    || fail "a watcher close during handling replaced the outstanding recovery generation"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" --ack-through "$sequence" \
+    --recovery-generation "$generation" 2> "$dir/ack.err" \
+    || fail "the printed acknowledgement was rejected after a handling-window close: $(cat "$dir/ack.err")"
+  [ ! -s "$state/.wake-queue" ] || fail "the acknowledged wake was not consumed"
+  case "$(cat "$state/.watcher-down" 2>/dev/null || true)" in
+    acked:*) ;;
+    *) fail "the handled recovery episode was not retired" ;;
+  esac
+
+  # The next arm must supervise rather than spend its whole cycle on recovery.
+  start_rearm_arm "$home" "$state" "$fakebin" "$dir/next-arm.out"
+  is_live_non_zombie "$ARM_PID" \
+    || fail "the watcher armed after acknowledgement died inside its first cycle"
+  ! grep -F 'check: rearm-resurface' "$dir/next-arm.out" >/dev/null \
+    || fail "the watcher armed after acknowledgement re-announced a retired recovery"
+  printf 'blocked: a later wake the live watcher must still surface\n' > "$state/later.status"
+  wait_for_exit "$ARM_PID" 120 || fail "the live watcher did not surface a later wake"
+  grep -q '^signal:' "$dir/next-arm.out" \
+    || fail "the watcher armed after acknowledgement never reached real supervision work: $(cat "$dir/next-arm.out")"
+  pass "watch-arm: a watcher close during handling keeps the printed acknowledgement valid"
+}
+
+# The acknowledgement carries two separable facts. Queue-row consumption is bound
+# to the monotonic --ack-through sequence the caller was given, so it is safe
+# under any marker state; only retiring the recovery episode is bound to
+# --recovery-generation. A generation that moved on must therefore consume the
+# handled rows and name its own remedy, never refuse and consume nothing.
+test_moved_generation_acknowledgement_is_self_healing() {
+  local dir home state fakebin pair first_sequence first_generation second_generation
+  dir=$(make_case moved-generation-acknowledgement)
+  home="$dir/home"
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  mkdir -p "$home/data"
+
+  start_rearm_arm "$home" "$state" "$fakebin" "$dir/first-arm.out"
+  is_live_non_zombie "$ARM_PID" || fail "moved-generation fixture watcher did not stay live"
+  printf 'done: first handled wake\n' > "$state/first.status"
+  wait_for_exit "$ARM_PID" 120 || fail "fixture watcher did not deliver its first wake"
+  FM_HOME="$home" FM_STATE_OVERRIDE="$state" "$DRAIN" > "$dir/first-drain.out" \
+    2> "$dir/first-drain.err" || fail "first drain did not present the durable wake"
+  pair=$(drain_ack_pair "$dir/first-drain.err") \
+    || fail "first drain did not print a generation-bound acknowledgement command"
+  first_sequence=${pair%%$'\t'*}
+  first_generation=${pair##*$'\t'}
+  FM_STATE_OVERRIDE="$state" "$DRAIN" --ack-through "$first_sequence" \
+    --recovery-generation "$first_generation" \
+    || fail "the first handled wake could not be acknowledged"
+
+  # A retired episode does not freeze the generation: the next one is its own.
+  start_rearm_arm "$home" "$state" "$fakebin" "$dir/second-arm.out"
+  is_live_non_zombie "$ARM_PID" || fail "second fixture watcher did not stay live"
+  printf 'done: second wake in a newer recovery episode\n' > "$state/second.status"
+  wait_for_exit "$ARM_PID" 120 || fail "second fixture watcher did not deliver its wake"
+  second_generation=$(sed -n 's/^pending:downtime:\(.*\)$/\1/p' "$state/.watcher-down")
+  [ -n "$second_generation" ] || fail "a wake after acknowledgement did not open a recovery episode"
+  [ "$second_generation" != "$first_generation" ] \
+    || fail "an acknowledged episode kept its generation instead of opening a new one"
+
+  # Replaying the stale pair must not fail, must not over-consume, and must not
+  # retire the newer episode.
+  FM_STATE_OVERRIDE="$state" "$DRAIN" --ack-through "$first_sequence" \
+    --recovery-generation "$first_generation" 2> "$dir/stale-ack.err" \
+    || fail "a replayed stale acknowledgement was rejected instead of degrading safely"
+  if ! grep -F 'WAKE_ACK_REQUIRED' "$dir/stale-ack.err" >/dev/null \
+    || ! grep -F 're-run' "$dir/stale-ack.err" >/dev/null; then
+    fail "a moved recovery generation did not name its own remedy: $(cat "$dir/stale-ack.err")"
+  fi
+  grep "$(printf '\tsignal\tsecond.status\t')" "$state/.wake-queue" >/dev/null \
+    || fail "a stale acknowledgement consumed a wake above its sequence"
+  [ "$(cat "$state/.watcher-down" 2>/dev/null || true)" = "pending:downtime:$second_generation" ] \
+    || fail "a stale acknowledgement retired the newer recovery episode"
+
+  # The sequence alone owns consumption, so the handled rows go even while the
+  # generation is stale, and only the episode stays pending.
+  FM_STATE_OVERRIDE="$state" "$DRAIN" --ack-through 999 \
+    --recovery-generation "$first_generation" 2> "$dir/stale-consume.err" \
+    || fail "a stale acknowledgement refused to consume the rows it was given"
+  [ ! -s "$state/.wake-queue" ] \
+    || fail "a stale acknowledgement left its handled rows on the durable queue"
+  [ "$(cat "$state/.watcher-down" 2>/dev/null || true)" = "pending:downtime:$second_generation" ] \
+    || fail "row consumption under a stale generation retired the pending episode"
+
+  # Following the printed remedy closes the episode, so the loop is self-healing.
+  FM_HOME="$home" FM_STATE_OVERRIDE="$state" "$DRAIN" > "$dir/redrain.out" \
+    2> "$dir/redrain.err" || fail "the remedy re-drain did not run"
+  pair=$(drain_ack_pair "$dir/redrain.err") \
+    || fail "the remedy re-drain did not print the newer acknowledgement command"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" --ack-through "${pair%%$'\t'*}" \
+    --recovery-generation "${pair##*$'\t'}" \
+    || fail "the newer recovery episode could not be acknowledged"
+  case "$(cat "$state/.watcher-down" 2>/dev/null || true)" in
+    acked:*) ;;
+    *) fail "following the printed remedy did not retire the newer recovery episode" ;;
+  esac
+  pass "watch-arm: a moved recovery generation consumes handled rows and names its remedy"
+}
+
 test_downtime_marker_does_not_follow_symlink() {
   local dir home state fakebin armout watcher_pid sentinel
   dir=$(make_case downtime-marker-symlink)
@@ -657,4 +804,6 @@ test_malformed_marker_is_quarantined_once
 test_recovery_consumption_serializes_queue_publication
 test_restart_preserves_recovery_across_reused_pid_lock
 test_markerless_legacy_queue_is_recovered_on_arm
+test_handling_window_close_keeps_the_acknowledgement_valid
+test_moved_generation_acknowledgement_is_self_healing
 test_downtime_marker_does_not_follow_symlink

--- a/tests/fm-watch-arm.test.sh
+++ b/tests/fm-watch-arm.test.sh
@@ -638,7 +638,7 @@ test_markerless_legacy_queue_is_recovered_on_arm() {
 # marker pending, which made every later arm spend its whole cycle re-announcing
 # the same recovery instead of supervising - a livelock the home could not leave.
 test_handling_window_close_keeps_the_acknowledgement_valid() {
-  local dir home state fakebin pair sequence generation handling_watcher_pid
+  local dir home state fakebin pair sequence generation
   dir=$(make_case handling-window-close-acknowledgement)
   home="$dir/home"
   state="$dir/state"
@@ -659,21 +659,32 @@ test_handling_window_close_keeps_the_acknowledgement_valid() {
   sequence=${pair%%$'\t'*}
   generation=${pair##*$'\t'}
 
-  # One full watcher cycle opens and closes inside the handling window.
+  # One full watcher cycle appends a wake and then closes inside the handling window.
   start_rearm_arm "$home" "$state" "$fakebin" "$dir/handling-window-arm.out"
   is_live_non_zombie "$ARM_PID" || fail "handling-window watcher did not stay live"
-  handling_watcher_pid=$(cat "$state/.watch.lock/pid" 2>/dev/null || true)
-  [ -n "$handling_watcher_pid" ] || fail "handling-window watcher did not take the lock"
-  kill -TERM "$handling_watcher_pid" 2>/dev/null \
-    || fail "could not close the handling-window watcher"
-  wait_for_exit "$ARM_PID" 120
+  printf 'done: wake published during handling\n' > "$state/during-handling.status"
+  wait_for_exit "$ARM_PID" 120 || fail "handling-window watcher did not deliver its wake"
+  grep "$(printf '\tsignal\tduring-handling.status\t')" "$state/.wake-queue" >/dev/null \
+    || fail "handling-window watcher did not durably append its wake"
 
   [ "$(cat "$state/.watcher-down" 2>/dev/null || true)" = "pending:downtime:$generation" ] \
-    || fail "a watcher close during handling replaced the outstanding recovery generation"
+    || fail "repeated publications during handling replaced the outstanding recovery generation"
   FM_STATE_OVERRIDE="$state" "$DRAIN" --ack-through "$sequence" \
     --recovery-generation "$generation" 2> "$dir/ack.err" \
-    || fail "the printed acknowledgement was rejected after a handling-window close: $(cat "$dir/ack.err")"
-  [ ! -s "$state/.wake-queue" ] || fail "the acknowledged wake was not consumed"
+    || fail "the printed acknowledgement was rejected after repeated publications: $(cat "$dir/ack.err")"
+  ! grep "$(printf '\tsignal\thandled.status\t')" "$state/.wake-queue" >/dev/null \
+    || fail "the acknowledged wake was not consumed"
+  grep "$(printf '\tsignal\tduring-handling.status\t')" "$state/.wake-queue" >/dev/null \
+    || fail "the newer handling-window wake was over-consumed"
+
+  FM_HOME="$home" FM_STATE_OVERRIDE="$state" "$DRAIN" > "$dir/remaining-drain.out" \
+    2> "$dir/remaining-drain.err" || fail "remaining wake could not be re-drained"
+  pair=$(drain_ack_pair "$dir/remaining-drain.err") \
+    || fail "remaining drain did not print an acknowledgement command"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" --ack-through "${pair%%$'\t'*}" \
+    --recovery-generation "${pair##*$'\t'}" \
+    || fail "remaining handling-window wake could not be acknowledged"
+  [ ! -s "$state/.wake-queue" ] || fail "remaining wake was not consumed"
   case "$(cat "$state/.watcher-down" 2>/dev/null || true)" in
     acked:*) ;;
     *) fail "the handled recovery episode was not retired" ;;

--- a/tests/fm-watch-arm.test.sh
+++ b/tests/fm-watch-arm.test.sh
@@ -631,12 +631,8 @@ test_markerless_legacy_queue_is_recovered_on_arm() {
   pass "watch-arm: markerless legacy queues are adopted and recovered"
 }
 
-# Every watcher close and every queue append publishes downtime, so a watcher
-# cycle that opens and closes while the model handles its drained wakes used to
-# mint a fresh recovery generation and invalidate the acknowledgement that drain
-# had just printed. That acknowledgement then consumed nothing and left the
-# marker pending, which made every later arm spend its whole cycle re-announcing
-# the same recovery instead of supervising - a livelock the home could not leave.
+# Exercise the handling-window recovery invariant owned by
+# docs/watcher-continuity.md through real watcher processes.
 test_handling_window_close_keeps_the_acknowledgement_valid() {
   local dir home state fakebin pair sequence generation
   dir=$(make_case handling-window-close-acknowledgement)
@@ -703,11 +699,8 @@ test_handling_window_close_keeps_the_acknowledgement_valid() {
   pass "watch-arm: a watcher close during handling keeps the printed acknowledgement valid"
 }
 
-# The acknowledgement carries two separable facts. Queue-row consumption is bound
-# to the monotonic --ack-through sequence the caller was given, so it is safe
-# under any marker state; only retiring the recovery episode is bound to
-# --recovery-generation. A generation that moved on must therefore consume the
-# handled rows and name its own remedy, never refuse and consume nothing.
+# Exercise the moved-generation recovery invariant owned by
+# docs/watcher-continuity.md through real watcher processes.
 test_moved_generation_acknowledgement_is_self_healing() {
   local dir home state fakebin pair first_sequence first_generation second_generation
   dir=$(make_case moved-generation-acknowledgement)


### PR DESCRIPTION
## Intent

Fix the watcher supervision livelock this task's own scout investigation diagnosed (data/fm-watcher-postcompaction-death-s1/report.md): on a Claude primary, after a context compaction the primary-session watcher died within seconds of every arm and the home could not recover on its own. Root cause: the rearm-resurface recovery episode is retired only by a nonce-bound acknowledgement, ANY concurrent republication of state/.watcher-down mints a fresh nonce and invalidates the acknowledgement the drain just printed, and that failed acknowledgement consumed NOTHING - leaving exactly the pending:downtime state that forces the next armed watcher to spend its whole cycle on 'check: rearm-resurface' and exit after one poll.

The captain reviewed the report and explicitly chose SCOPE B, which is exactly three changes: (1) PRIMARY - a downtime publication in bin/fm-wake-lib.sh reuses the generation of an outstanding pending:handling episode instead of minting a new nonce, so a watcher close during the handling window cannot orphan the printed acknowledgement; (2) COMPANION - bin/fm-wake-drain.sh separates the two facts an acknowledgement carries, so queue-row consumption bound to the monotonic --ack-through sequence always happens under any marker state while only retiring the episode stays bound to --recovery-generation, and a moved generation degrades to a NON-FATAL result instead of the old exit-1 that consumed nothing; (3) DIAGNOSTIC - the acknowledgement failure messages now name the remedy (re-drain, then use the new WAKE_ACK_REQUIRED command) so a session self-heals on the first failure.

The captain explicitly EXCLUDED two things the report also raised, so their absence is deliberate and must not be flagged as an omission: do NOT add a queue-non-empty condition to the pending:downtime branch of the arm-check state machine (the empty-queue resurface re-presents the cursor-folded OPEN DECISIONS set and is documented as intentional in docs/watcher-continuity.md), and do NOT give Claude the Pi/OpenCode --handling-delivered successor handoff (a real architectural change to the Stop-hook contract, not the smallest fix).

Accepted trade-off the captain chose knowingly: because a preserved generation lets the acknowledgement match, an empty-queue downtime episode can now be retired without its own dedicated recovery turn. Correctness is preserved because the acknowledgement still retires the marker only when the remaining queue is empty, and any wake appended after the drain carries a higher sequence, keeps the queue non-empty, and keeps the episode pending and re-presented.

Deliberate test changes: tests/fm-watch-arm.test.sh gains two new real-process cases reproducing report section 5d (a watcher close inside the handling window must leave the printed acknowledgement valid) and the drain-side self-healing moved-generation path. tests/fm-wake-queue.test.sh's test_stale_recovery_generation_is_rejected PINNED THE OLD CONTRACT (it asserted that a publication during handling must advance the generation, and that a stale acknowledgement must exit non-zero), so it was deliberately rewritten into test_stale_recovery_generation_cannot_touch_a_newer_episode, which keeps the real safety properties (a stale acknowledgement may neither retire the newer episode nor consume rows above its sequence) while pinning the new behaviour; its sibling ack-failure case was updated for the reworded diagnostic. Both rewritten and both new cases were verified to FAIL on pre-fix bin/ and pass after, and the new cases ran 5/5 stable.

This machinery is harness-agnostic shell shared by every harness, and the fix is pure state-machine logic, so portable tests/ regressions are sufficient and no live-harness guard is warranted. bin/fm-lint.sh and bin/fm-doc-audience-check.sh are clean; docs/watcher-continuity.md owns this contract and was patched there rather than restated elsewhere.

Known and unrelated: tests/fm-watch-arm.test.sh's pre-existing test_rearm_resurfaces_durable_queue_and_remote_open_decision case can hang (measured 1 in 5 runs on pristine origin/main, same rate on this branch). Its cause is a separate pre-existing defect - a watcher signalled while holding the recovery-marker lock unwinds via trap 'exit 1' without releasing it, then watcher_cleanup waits on that same lock forever - and it is being reported to the captain as follow-up work rather than fixed here.

## What Changed

- Preserve pending recovery generations across downtime republication so watcher closes cannot invalidate outstanding acknowledgements.
- Consume queue rows by acknowledgement sequence independently of recovery generation, treating moved generations as non-fatal and directing users to re-drain and acknowledge the newer episode.
- Document the recovery contract and add queue and real-process watcher regression coverage.

## Risk Assessment

✅ Low: The durable generation-preservation and non-fatal stale-acknowledgement paths now satisfy the stated invariants with behavioral regression coverage and no material source risks found.

## Testing

Inspected the clean targeted diff, ran the two new real-process watcher regressions and the focused wake-queue regression suite, then demonstrated the complete acknowledgement workflow through production interfaces: handling-window republication preserved the generation, sequence-bounded acknowledgement retained newer rows, a genuinely stale generation exited successfully with the re-drain remedy, and the newer episode remained pending. All checks succeeded; no worktree artifacts remained.

<details>
<summary>Evidence: End-to-end recovery contract demonstration</summary>

```text
=== Open and drain an episode ===
1786497405	1	check	first	check: first handled wake
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 1 --recovery-generation 99820.1786497406.kUbX5C
printed_ack: sequence=1 generation=99820.1786497406.kUbX5C
=== Publish again during handling; generation stays valid ===
marker_after_republication: pending:downtime:99820.1786497406.kUbX5C
first_ack_exit: 0
remaining_queue:
1786497406	2	check	second	check: wake published during handling
marker_after_first_ack: pending:downtime:99820.1786497406.kUbX5C
=== Drain and retire remaining work ===
1786497406	2	check	second	check: wake published during handling
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 2 --recovery-generation 99820.1786497406.kUbX5C
retired_marker: acked:handling:99820.1786497406.kUbX5C
=== New episode plus stale acknowledgement degrades safely ===
new_episode_marker: pending:downtime:666.1786497406.MYHYsr
stale_ack_exit: 0
stale_ack_diagnostic: wake drain: acknowledged wakes through 2, but a newer recovery episode is pending; re-run bin/fm-wake-drain.sh and use the new WAKE_ACK_REQUIRED command
queue_still_contains_newer_row:
1786497406	3	check	third	check: newer episode wake
new_episode_still_pending: pending:downtime:666.1786497406.MYHYsr
```
</details>
<details>
<summary>Evidence: Focused real-process watcher regression transcript</summary>

```text
ok - watch-arm: a watcher close during handling keeps the printed acknowledgement valid
ok - watch-arm: a moved recovery generation consumes handled rows and names its remedy
```
</details>
<details>
<summary>Evidence: Wake-queue behavioral regression transcript</summary>

```text
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 34 --recovery-generation 74902.1786497351.vLFcs2
ok - concurrent append plus drain preserves durable records through acknowledgement
ok - signal written while no watcher runs is caught on next run
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 1 --recovery-generation 89113.1786497361.HVkifG
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no live watcher process holds this home lock (last beat: 1s ago).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  After draining queued wakes, repair a missing or failed watcher cycle with the Pi tool fm_watch_arm_pi, or restart Pi with -e /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-wake-tangle-root.1c3KMz/.pi/extensions/fm-primary-turnend-guard.ts -e /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-wake-tangle-root.1c3KMz/.pi/extensions/fm-primary-pi-watch.ts if the extensions are not loaded.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
WARNING: queued wakes pending - drain them with bin/fm-wake-drain.sh before anything else.
ok - stale wake is queued before suppressor state is advanced
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 1 --recovery-generation 90120.1786497362.yebWe9
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no live watcher process holds this home lock (last beat: 1s ago).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  After draining queued wakes, repair a missing or failed watcher cycle with the Pi tool fm_watch_arm_pi, or restart Pi with -e /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-wake-tangle-root.1c3KMz/.pi/extensions/fm-primary-turnend-guard.ts -e /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-wake-tangle-root.1c3KMz/.pi/extensions/fm-primary-pi-watch.ts if the extensions are not loaded.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
WARNING: queued wakes pending - drain them with bin/fm-wake-drain.sh before anything else.
ok - a not-provably-working stale wake is queued before its suppressor is advanced
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 1 --recovery-generation 90948.1786497363.jNleTu
ok - registered custom check output is queued before cadence suppression
ok - concurrent drains replay until one post-handling acknowledgement consumes records
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 4 --recovery-generation 92042.1786497364.uJ0DTf
ok - drain collapses obvious duplicate heartbeat and signal records
ok - drain asserts watcher liveness: warns on a lapse, stays silent for a live watcher with a fresh beacon
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 8 --recovery-generation 92779.1786497365.POqhKk
ok - structural signal enrichment is separate, deduped, home-local, and tier-zero for other wakes
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 13 --recovery-generation 93618.1786497366.6YIRUA
ok - bounded reads and per-item/global caps fail open with explicit truncation and omission markers
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 1 --recovery-generation 95068.1786497367.Rw2HK4
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 2 --recovery-generation 95068.1786497367.Rw2HK4
ok - slow annotation releases the append lock and a deleted status file fails open
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 1 --recovery-generation existing
ok - wake append publishes atomic recovery evidence before durable rows
ok - wake drain: generation-less legacy wakes are adopted and acknowledged
ok - wake drain: a stale acknowledgement cannot retire or consume a newer recovery episode
ok - wake drain: recovery acknowledgement failures are explicit and retryable
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 2 --recovery-generation 98183.1786497374.Tq0jY7
ok - interruptions preserve durable rows until post-handling acknowledgement
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"a546d0a2351d6e4f68280d4d6ede1018313f8e52","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `bin/fm-wake-lib.sh:443` - The required durable fix says any publication during the handling window must preserve the printed acknowledgement, but this hunk preserves the generation only for `pending:handling:*`. A first concurrent append/close rewrites it to `pending:downtime:G`; a second publication then mints G2 and invalidates the acknowledgement for G. Preserve the generation for the entire outstanding pending episode, including `pending:downtime:*`.
- 🚨 `bin/fm-wake-drain.sh:183` - The required companion behavior says a moved generation must be non-fatal and queue consumption must still happen, but generation is snapshotted at line 178 and acknowledged under a separate marker-lock acquisition here. If the generation moves between those operations, `fm_recovery_marker_ack` returns stale and this branch exits 1 before replacing the queue—the original consume-nothing failure. Distinguish a stale-generation return from an actual marker-write failure and continue queue consumption for the former.

🔧 Fix: Preserve recovery generations and consume stale acknowledgements safely
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git status --short` and `git diff 614fae60879372978a4480e22ec4d41eef083b3c..297fb7855f6e13dcebd2d28bc5d35a9d2e7439b4`</code>
- <code>Focused real-process cases: `test_handling_window_close_keeps_the_acknowledgement_valid` and `test_moved_generation_acknowledgement_is_self_healing`</code>
- `./tests/fm-wake-queue.test.sh`
- <code>Manual production-interface recovery demo using `fm_wake_append` and `bin/fm-wake-drain.sh`, recording marker generations, queue state, acknowledgement results, and recovery diagnostics</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
