### PR TITLE
Normalize Orca WSL UNC worktree paths

### DIFF
--- a/bin/backends/orca.sh
+++ b/bin/backends/orca.sh
@@ -53,6 +53,10 @@ fm_backend_orca_json_get() {  # <field> ; fields: worktree-id worktree-path term
   # result.terminal or a root terminal object with .handle. Undocumented
   # result.id and result.worktree.terminal shapes are ignored until a real Orca
   # smoke run proves them.
+  # worktree-path is normalized to a host-usable absolute path: Orca on WSL may
+  # return \\wsl.localhost\<Distro>\home\... (or //wsl.localhost/..., \\wsl$\...)
+  # which Linux cannot cd into until rewritten as /home/.... Worktree ids keep
+  # the opaque Orca form for API calls; only filesystem paths are rewritten.
   local field=$1
   node -e '
 const fs = require("fs");
@@ -75,9 +79,23 @@ function handle(obj) {
   if (typeof obj === "string" || typeof obj === "number") return String(obj);
   return scalar(obj.handle) || "";
 }
+// Orca WSL returns Windows UNC forms for in-distro paths. Map them to the
+// Linux absolute path Firstmate isolation checks and git -C need. Leave true
+// Windows drive paths and non-WSL UNCs unchanged so a mismatch still fails
+// closed rather than inventing a local path.
+function normalizeHostPath(p) {
+  if (typeof p !== "string" || !p) return p;
+  if (p.startsWith("/") && !p.startsWith("//")) return p;
+  const unified = p.replace(/\//g, "\\");
+  let m = unified.match(/^\\\\wsl\.localhost\\([^\\]+)\\(.+)$/i);
+  if (!m) m = unified.match(/^\\\\wsl\$\\([^\\]+)\\(.+)$/i);
+  if (!m) return p;
+  const rest = m[2].replace(/\\/g, "/").replace(/^\/+/, "");
+  return rest ? "/" + rest : p;
+}
 let v = "";
 if (field === "worktree-id") v = wt.id || wt.worktreeId || r.worktreeId || "";
-if (field === "worktree-path") v = wt.path || (wt.git && wt.git.path) || r.path || "";
+if (field === "worktree-path") v = normalizeHostPath(wt.path || (wt.git && wt.git.path) || r.path || "");
 if (field === "terminal-handle") v = handle(explicitTerm || r) || "";
 if (field === "worktree-terminal-handle") v = handle(explicitTerm) || "";
 if (field === "repo-id") v = repo.id || repo.repoId || r.repoId || "";

--- a/bin/fm-orca-wsl-cli.sh
+++ b/bin/fm-orca-wsl-cli.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# fm-orca-wsl-cli.sh - status and apply for Firstmate's Orca WSL CLI bridge patch.
+#
+# Orca on Windows+WSL installs ~/.local/bin/orca-ide and
+# ~/.local/share/orca/orca-wsl-bridge.ps1. Stock bridges (at least through
+# Orca 1.4.179) forward args with PowerShell 5.1's broken native splat, which
+# destroys ASCII double quotes in `orca terminal send --text` and related
+# commands (stablyai/orca#12231). Firstmate ships a patched bridge under
+# bin/patches/orca-wsl/ and this helper installs or reports its state.
+#
+# States printed by `status` (and as the apply result):
+#   missing   - no bridge and/or launcher under the usual paths
+#   stock     - Orca-managed files present without the Firstmate patch marker
+#   patched   - Firstmate patch marker present at the expected version
+#   foreign   - files exist but do not look like stock Orca or this patch
+#
+# Usage:
+#   fm-orca-wsl-cli.sh status
+#   fm-orca-wsl-cli.sh apply [--force]
+#   fm-orca-wsl-cli.sh --help
+set -euo pipefail
+
+PATCH_ID=firstmate-orca-wsl-bridge-patch-v1
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd -P)
+PATCH_DIR=$REPO_ROOT/bin/patches/orca-wsl
+PATCH_BRIDGE=$PATCH_DIR/orca-wsl-bridge.ps1
+
+XDG_DATA_HOME=${XDG_DATA_HOME:-$HOME/.local/share}
+SHARE=${FM_ORCA_WSL_SHARE:-$XDG_DATA_HOME/orca}
+BIN=${FM_ORCA_WSL_BIN:-$HOME/.local/bin}
+BRIDGE=$SHARE/orca-wsl-bridge.ps1
+LAUNCHER=$BIN/orca-ide
+ORCA_SHIM=$BIN/orca
+
+usage() {
+  sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+die() { echo "error: $*" >&2; exit 1; }
+
+require_patch_files() {
+  [ -f "$PATCH_BRIDGE" ] || die "missing patch bridge template: $PATCH_BRIDGE"
+}
+
+file_has_patch_marker() {
+  local path=$1
+  [ -f "$path" ] || return 1
+  grep -Fq "$PATCH_ID" "$path"
+}
+
+file_looks_stock_bridge() {
+  local path=$1
+  [ -f "$path" ] || return 1
+  # Stock Orca bridge: managed marker, raw splat, no Firstmate patch id.
+  grep -Fq 'Orca managed WSL CLI PowerShell bridge' "$path" \
+    && grep -Fq '& $OrcaLauncher @ForwardArgs' "$path" \
+    && ! grep -Fq "$PATCH_ID" "$path"
+}
+
+file_looks_stock_launcher() {
+  local path=$1
+  [ -f "$path" ] || return 1
+  grep -Fq 'Orca managed WSL CLI launcher' "$path" \
+    && grep -Eq 'ORCA_WIN_LAUNCHER=' "$path" \
+    && ! grep -Fq "$PATCH_ID" "$path"
+}
+
+classify_pair() {
+  if [ ! -f "$BRIDGE" ] && [ ! -f "$LAUNCHER" ]; then
+    printf 'missing'
+    return 0
+  fi
+  if [ -f "$BRIDGE" ] && file_has_patch_marker "$BRIDGE" \
+    && [ -f "$LAUNCHER" ] && file_has_patch_marker "$LAUNCHER"; then
+    printf 'patched'
+    return 0
+  fi
+  if [ -f "$BRIDGE" ] && [ -f "$LAUNCHER" ] \
+    && file_looks_stock_bridge "$BRIDGE" \
+    && file_looks_stock_launcher "$LAUNCHER"; then
+    printf 'stock'
+    return 0
+  fi
+  # Partial installs (only one file, mixed stock/patch, hand edits).
+  printf 'foreign'
+}
+
+extract_win_launcher() {
+  local path=$1 line
+  [ -f "$path" ] || return 1
+  line=$(grep -E '^ORCA_WIN_LAUNCHER=' "$path" | head -1 || true)
+  [ -n "$line" ] || return 1
+  line=${line#ORCA_WIN_LAUNCHER=}
+  line=${line#\'}
+  line=${line%\'}
+  line=${line#\"}
+  line=${line%\"}
+  [ -n "$line" ] || return 1
+  printf '%s' "$line"
+}
+
+discover_win_launcher() {
+  local candidate
+  if [ -n "${ORCA_WIN_LAUNCHER:-}" ]; then
+    printf '%s' "$ORCA_WIN_LAUNCHER"
+    return 0
+  fi
+  if candidate=$(extract_win_launcher "$LAUNCHER" 2>/dev/null); then
+    printf '%s' "$candidate"
+    return 0
+  fi
+  # Common Windows install location mounted in WSL.
+  for candidate in \
+    /mnt/c/Users/*/AppData/Local/Programs/orca/resources/bin/orca.exe
+  do
+    if [ -f "$candidate" ]; then
+      wslpath -w "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+print_status() {
+  local state
+  require_patch_files
+  state=$(classify_pair)
+  printf 'state=%s\n' "$state"
+  printf 'patch_id=%s\n' "$PATCH_ID"
+  printf 'bridge=%s\n' "$BRIDGE"
+  printf 'launcher=%s\n' "$LAUNCHER"
+  if [ -f "$BRIDGE" ]; then
+    if file_has_patch_marker "$BRIDGE"; then
+      printf 'bridge_kind=patched\n'
+    elif file_looks_stock_bridge "$BRIDGE"; then
+      printf 'bridge_kind=stock\n'
+    else
+      printf 'bridge_kind=foreign\n'
+    fi
+  else
+    printf 'bridge_kind=missing\n'
+  fi
+  if [ -f "$LAUNCHER" ]; then
+    if file_has_patch_marker "$LAUNCHER"; then
+      printf 'launcher_kind=patched\n'
+    elif file_looks_stock_launcher "$LAUNCHER"; then
+      printf 'launcher_kind=stock\n'
+    else
+      printf 'launcher_kind=foreign\n'
+    fi
+  else
+    printf 'launcher_kind=missing\n'
+  fi
+  if [ -L "$ORCA_SHIM" ] || [ -e "$ORCA_SHIM" ]; then
+    printf 'orca_shim=%s\n' "$ORCA_SHIM"
+    if [ -L "$ORCA_SHIM" ]; then
+      printf 'orca_shim_target=%s\n' "$(readlink "$ORCA_SHIM" || true)"
+    fi
+  else
+    printf 'orca_shim=missing\n'
+  fi
+  case "$state" in
+    missing)
+      printf 'note=No Orca WSL CLI files found. Run apply after Orca has created the managed WSL launcher, or pass ORCA_WIN_LAUNCHER for a new install.\n'
+      ;;
+    stock)
+      printf 'note=Stock Orca WSL bridge detected (quotes in terminal send are unsafe on PS 5.1). Run: bin/fm-orca-wsl-cli.sh apply\n'
+      ;;
+    patched)
+      printf 'note=Firstmate Orca WSL bridge patch is installed. Re-run apply after Orca overwrites the bridge on update.\n'
+      ;;
+    foreign)
+      printf 'note=WSL CLI files exist but are neither stock Orca nor this patch. Inspect before apply; use --force to overwrite.\n'
+      ;;
+  esac
+}
+
+backup_file() {
+  local path=$1 backup_root=$2 base
+  [ -e "$path" ] || return 0
+  mkdir -p "$backup_root"
+  base=$(basename -- "$path")
+  cp -a -- "$path" "$backup_root/$base"
+}
+
+write_launcher() {
+  local win_launcher=$1 dest=$2
+  cat > "$dest" <<EOF
+#!/usr/bin/env bash
+# $PATCH_ID
+# Orca managed WSL CLI launcher (installed by bin/fm-orca-wsl-cli.sh).
+set -euo pipefail
+ORCA_WIN_LAUNCHER='$win_launcher'
+ORCA_BRIDGE_PS1='$BRIDGE'
+if command -v pwsh.exe >/dev/null 2>&1; then
+  ORCA_POWERSHELL=pwsh.exe
+elif [ -x '/mnt/c/Program Files/PowerShell/7/pwsh.exe' ]; then
+  ORCA_POWERSHELL='/mnt/c/Program Files/PowerShell/7/pwsh.exe'
+elif command -v powershell.exe >/dev/null 2>&1; then
+  ORCA_POWERSHELL=powershell.exe
+elif [ -x /mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe ]; then
+  ORCA_POWERSHELL=/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe
+else
+  echo "Orca WSL CLI requires Windows interop and could not find powershell.exe." >&2
+  exit 1
+fi
+# Why: a shell can outlive a deleted worktree; keep explicit CLI selectors and
+# help usable, and repair cwd before any WSL interop tool tries to resolve it.
+ORCA_WSL_CWD=\$(pwd -P 2>/dev/null) || {
+  ORCA_WSL_CWD=/
+  cd /
+}
+ORCA_BRIDGE_PS1_WIN=\$(wslpath -w "\$ORCA_BRIDGE_PS1")
+ORCA_WSL_CWD_WIN=\$(wslpath -w "\$ORCA_WSL_CWD")
+exec "\$ORCA_POWERSHELL" -NoProfile -ExecutionPolicy Bypass -File "\$ORCA_BRIDGE_PS1_WIN" "\$ORCA_WIN_LAUNCHER" -WslCwd "\$ORCA_WSL_CWD_WIN" "\$@"
+EOF
+  chmod 0755 "$dest"
+}
+
+apply_patch() {
+  local force=${1:-0} state win_launcher backup_root
+  require_patch_files
+  state=$(classify_pair)
+  case "$state" in
+    patched)
+      if [ "$force" -ne 1 ]; then
+        echo "already patched ($PATCH_ID); pass --force to reinstall"
+        print_status
+        return 0
+      fi
+      ;;
+    foreign)
+      if [ "$force" -ne 1 ]; then
+        die "foreign WSL CLI files present (state=foreign); inspect $BRIDGE and $LAUNCHER, or re-run with --force"
+      fi
+      ;;
+    missing|stock) ;;
+    *) die "internal: unknown state '$state'" ;;
+  esac
+
+  win_launcher=$(discover_win_launcher) || die "cannot discover Windows orca.exe path; set ORCA_WIN_LAUNCHER='C:\\...\\orca.exe'"
+
+  mkdir -p "$SHARE" "$BIN"
+  backup_root=$SHARE/firstmate-bridge-backup-$(date +%Y%m%d-%H%M%S)
+  backup_file "$BRIDGE" "$backup_root"
+  backup_file "$LAUNCHER" "$backup_root"
+  if [ -e "$ORCA_SHIM" ]; then
+    backup_file "$ORCA_SHIM" "$backup_root"
+  fi
+  if [ -d "$backup_root" ]; then
+    echo "backup: $backup_root"
+  fi
+
+  cp -- "$PATCH_BRIDGE" "$BRIDGE"
+  write_launcher "$win_launcher" "$LAUNCHER"
+
+  # Ensure bare `orca` resolves to the managed launcher (not GNOME orca).
+  if [ -e "$ORCA_SHIM" ] && [ ! -L "$ORCA_SHIM" ]; then
+    if [ "$force" -ne 1 ]; then
+      echo "warning: $ORCA_SHIM exists and is not a symlink; not replacing (use --force)" >&2
+    else
+      ln -sfn "$LAUNCHER" "$ORCA_SHIM"
+    fi
+  else
+    ln -sfn "$LAUNCHER" "$ORCA_SHIM"
+  fi
+
+  date -Is > "$SHARE/.firstmate-orca-wsl-cli-applied" 2>/dev/null || true
+  echo "applied $PATCH_ID"
+  echo "win_launcher=$win_launcher"
+  print_status
+}
+
+cmd=${1:-}
+case "$cmd" in
+  ""|-h|--help) usage; exit 0 ;;
+  status) shift; [ "$#" -eq 0 ] || die "status takes no arguments"; print_status ;;
+  apply)
+    shift
+    force=0
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --force) force=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) die "unknown apply flag: $1" ;;
+      esac
+    done
+    apply_patch "$force"
+    ;;
+  *) die "unknown command: $cmd (try status or apply)" ;;
+esac

--- a/bin/patches/orca-wsl/orca-ide.sh
+++ b/bin/patches/orca-wsl/orca-ide.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# firstmate-orca-wsl-bridge-patch-v1
+# Orca managed WSL CLI launcher (template installed by bin/fm-orca-wsl-cli.sh).
+# Prefers PowerShell 7 when present; falls back to Windows PowerShell 5.1.
+# Placeholders replaced at apply time:
+#   @ORCA_WIN_LAUNCHER@  Windows path to orca.exe
+#   @ORCA_BRIDGE_PS1@    absolute Linux path to orca-wsl-bridge.ps1
+set -euo pipefail
+# Orca managed WSL CLI launcher
+ORCA_WIN_LAUNCHER='@ORCA_WIN_LAUNCHER@'
+ORCA_BRIDGE_PS1='@ORCA_BRIDGE_PS1@'
+if command -v pwsh.exe >/dev/null 2>&1; then
+  ORCA_POWERSHELL=pwsh.exe
+elif [ -x '/mnt/c/Program Files/PowerShell/7/pwsh.exe' ]; then
+  ORCA_POWERSHELL='/mnt/c/Program Files/PowerShell/7/pwsh.exe'
+elif command -v powershell.exe >/dev/null 2>&1; then
+  ORCA_POWERSHELL=powershell.exe
+elif [ -x /mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe ]; then
+  ORCA_POWERSHELL=/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe
+else
+  echo "Orca WSL CLI requires Windows interop and could not find powershell.exe." >&2
+  exit 1
+fi
+# Why: a shell can outlive a deleted worktree; keep explicit CLI selectors and
+# help usable, and repair cwd before any WSL interop tool tries to resolve it.
+ORCA_WSL_CWD=$(pwd -P 2>/dev/null) || {
+  ORCA_WSL_CWD=/
+  cd /
+}
+ORCA_BRIDGE_PS1_WIN=$(wslpath -w "$ORCA_BRIDGE_PS1")
+ORCA_WSL_CWD_WIN=$(wslpath -w "$ORCA_WSL_CWD")
+exec "$ORCA_POWERSHELL" -NoProfile -ExecutionPolicy Bypass -File "$ORCA_BRIDGE_PS1_WIN" "$ORCA_WIN_LAUNCHER" -WslCwd "$ORCA_WSL_CWD_WIN" "$@"

--- a/bin/patches/orca-wsl/orca-wsl-bridge.ps1
+++ b/bin/patches/orca-wsl/orca-wsl-bridge.ps1
@@ -1,0 +1,60 @@
+# Orca managed WSL CLI PowerShell bridge
+# firstmate-orca-wsl-bridge-patch-v1
+# Work around stablyai/orca#12231: Windows PowerShell 5.1 destroys ASCII "
+# in CLI arguments when forwarding via `& $OrcaLauncher @ForwardArgs`.
+# - PowerShell 7+: use Standard native argument passing (no pre-escape).
+# - Windows PowerShell 5.1: pre-escape ASCII " before the native splat.
+# Stock Orca 1.4.179 still ships the unfixed bridge; re-apply after Orca
+# reinstalls overwrite ~/.local/share/orca/orca-wsl-bridge.ps1.
+[CmdletBinding(PositionalBinding=$false)]
+param(
+  [Parameter(Mandatory=$true, Position=0)]
+  [string]$OrcaLauncher,
+
+  [string]$WslCwd,
+
+  [Parameter(ValueFromRemainingArguments=$true)]
+  [string[]]$ForwardArgs
+)
+
+$exitCode = 0
+try {
+  if ([string]::IsNullOrEmpty($WslCwd)) {
+    Remove-Item Env:ORCA_CLI_CWD -ErrorAction SilentlyContinue
+  } else {
+    $env:ORCA_CLI_CWD = $WslCwd
+  }
+
+  $argsToSend = $ForwardArgs
+  if ($PSVersionTable.PSVersion.Major -ge 7) {
+    # PS7 can pass argv losslessly when Standard mode is on.
+    $PSNativeCommandArgumentPassing = 'Standard'
+  } else {
+    # PS 5.1 strips unescaped ASCII double quotes on native calls (#12231).
+    $escaped = New-Object System.Collections.Generic.List[string]
+    foreach ($arg in $ForwardArgs) {
+      if ($null -eq $arg) {
+        [void]$escaped.Add($arg)
+        continue
+      }
+      [void]$escaped.Add([regex]::Replace([string]$arg, '(\\*)"', '$1$1\"'))
+    }
+    $argsToSend = $escaped.ToArray()
+  }
+
+  Push-Location -LiteralPath (Split-Path -Parent $OrcaLauncher)
+  & $OrcaLauncher @argsToSend
+  if ($null -eq $LASTEXITCODE) {
+    if (-not $?) {
+      $exitCode = 1
+    } else {
+      $exitCode = 0
+    }
+  } else {
+    $exitCode = $LASTEXITCODE
+  }
+} catch {
+  Write-Error $_
+  $exitCode = 1
+}
+exit $exitCode

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -24,6 +24,29 @@ The first task for a project registers that repository with `orca repo add --pat
 No manual repository registration is required.
 When Orca returns a WSL UNC worktree path (`\\wsl.localhost\<Distro>\...`, `//wsl.localhost/...`, or `\\wsl$\...`), Firstmate normalizes it to the Linux absolute path before isolation checks and metadata; the opaque `orca_worktree_id` is left unchanged for Orca API calls.
 
+### WSL CLI bridge patch (quotes in `terminal send`)
+
+On Windows+WSL, Orca installs a managed launcher at `~/.local/bin/orca-ide` and a PowerShell bridge at `~/.local/share/orca/orca-wsl-bridge.ps1`.
+Stock bridges (at least through Orca 1.4.179) forward CLI arguments with Windows PowerShell 5.1's native splat, which **destroys ASCII double quotes** before `orca.exe` parses them ([stablyai/orca#12231](https://github.com/stablyai/orca/issues/12231)).
+That breaks Firstmate steers and harness launch lines that contain `"..."` (for example `grok --always-approve "$(...)"`).
+
+Firstmate ships a patched bridge under `bin/patches/orca-wsl/` and a status/apply helper:
+
+```sh
+bin/fm-orca-wsl-cli.sh status   # missing | stock | patched | foreign
+bin/fm-orca-wsl-cli.sh apply    # install patch (backs up first); --force overwrites foreign/already-patched
+```
+
+| `status` state | Meaning | Action |
+| --- | --- | --- |
+| `missing` | No managed WSL CLI files yet (new machine / never opened Orca WSL) | Open an Orca-managed WSL terminal once, or set `ORCA_WIN_LAUNCHER` and `apply` for a new install |
+| `stock` | Orca's unpatched bridge | `apply` |
+| `patched` | Firstmate patch marker present | Nothing unless Orca overwrote files after an app update |
+| `foreign` | Files exist but match neither stock nor this patch | Inspect, then `apply --force` only if intentional |
+
+`apply` prefers PowerShell 7 (`pwsh.exe`) when present, and keeps a PS 5.1 pre-escape path for hosts without PS7.
+Re-run `status` after every Orca update; app upgrades may rewrite the stock bridge and drop the patch.
+
 Open the Orca app to watch a task's terminal.
 Routine supervision uses the recorded endpoint through `bin/fm-peek.sh <id>` and `FM_HOME=<home> bin/fm-send.sh <id> '<text>'`.
 Enter and Ctrl-C are supported; Escape is not.
@@ -75,6 +98,7 @@ It never raw-deletes an Orca worktree.
 - Only the verified terminal-handle and worktree result fields are accepted; speculative response shapes are rejected.
 - Worktree filesystem paths must resolve on the host that runs Firstmate.
   WSL UNC forms for in-distro paths are normalized; true Windows drive paths are not rewritten and still fail isolation closed.
+- On WSL, stock Orca bridges may still strip quotes from CLI args until Firstmate's `bin/fm-orca-wsl-cli.sh apply` patch is installed (or Orca ships a fixed bridge).
 - End-to-end WSL spawn, send, and teardown remain experimental relative to the macOS evidence in [`verification/runtime-backends.md`](verification/runtime-backends.md#orca).
 
 ## Regression entry points
@@ -83,6 +107,7 @@ It never raw-deletes an Orca worktree.
 tests/fm-backend-orca.test.sh
 tests/fm-backend.test.sh
 tests/fm-bootstrap.test.sh
+bin/fm-orca-wsl-cli.sh status
 ```
 
 [`verification/runtime-backends.md`](verification/runtime-backends.md#orca) records the real readiness and response-shape smoke.

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -1,18 +1,19 @@
 # Orca runtime backend
 
-Orca is an experimental macOS backend in which the Orca app owns both the task worktree and terminal endpoint.
+Orca is an experimental backend in which the Orca app owns both the task worktree and terminal endpoint.
 The crewmate harness remains the agent process launched inside that endpoint.
 Firstmate agents load [`firstmate-orca`](../.agents/skills/firstmate-orca/SKILL.md) before operating or recovering this backend.
 
 ## Setup
 
-Pick Orca when you already use the Orca macOS app and want Orca-managed worktrees and terminals instead of Treehouse plus a session multiplexer.
-Orca is macOS-only, explicit-only, and does not support secondmate spawns.
+Pick Orca when you already use the Orca app and want Orca-managed worktrees and terminals instead of Treehouse plus a session multiplexer.
+Orca is explicit-only and does not support secondmate spawns.
+macOS remains the best-proven host; WSL is supported only for in-distro worktrees whose paths Firstmate can normalize (see Active limits).
 
 Prerequisites:
 
-- `/Applications/Orca.app` installed, running, and ready.
-- The `orca` CLI, installed with `brew install orca`.
+- Orca app installed, running, and ready (macOS `/Applications/Orca.app`, or the Windows Orca EDA install with a WSL-managed terminal).
+- An `orca` CLI on `PATH` that talks to that app (`brew install orca` on macOS; on WSL the managed launcher is often `orca-ide`, so a `~/.local/bin/orca` shim to that launcher is typical).
 - The universal harness and toolchain requirements in [`configuration.md`](configuration.md#toolchain).
 
 Select Orca with local `config/backend` containing `orca`, `FM_BACKEND=orca` for one launch, or an explicit request to Firstmate.
@@ -21,6 +22,7 @@ It is never auto-detected.
 Before any spawn mutates repository state, Firstmate requires `orca status --json` to report `reachable=true` and `state="ready"`.
 The first task for a project registers that repository with `orca repo add --path` when needed.
 No manual repository registration is required.
+When Orca returns a WSL UNC worktree path (`\\wsl.localhost\<Distro>\...`, `//wsl.localhost/...`, or `\\wsl$\...`), Firstmate normalizes it to the Linux absolute path before isolation checks and metadata; the opaque `orca_worktree_id` is left unchanged for Orca API calls.
 
 Open the Orca app to watch a task's terminal.
 Routine supervision uses the recorded endpoint through `bin/fm-peek.sh <id>` and `FM_HOME=<home> bin/fm-send.sh <id> '<text>'`.
@@ -65,12 +67,15 @@ It never raw-deletes an Orca worktree.
 
 ## Active limits
 
-- Orca is macOS-only and explicit-only.
+- Orca is explicit-only; it is never auto-detected.
 - The app must be running and report ready.
 - Secondmate spawns are unsupported.
 - Escape is unsupported.
 - Orca exposes no stable CLI version or protocol marker, so readiness is the compatibility gate rather than a version floor.
 - Only the verified terminal-handle and worktree result fields are accepted; speculative response shapes are rejected.
+- Worktree filesystem paths must resolve on the host that runs Firstmate.
+  WSL UNC forms for in-distro paths are normalized; true Windows drive paths are not rewritten and still fail isolation closed.
+- End-to-end WSL spawn, send, and teardown remain experimental relative to the macOS evidence in [`verification/runtime-backends.md`](verification/runtime-backends.md#orca).
 
 ## Regression entry points
 

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -380,6 +380,53 @@ test_worktree_path_resolves_id() {
   pass "fm_backend_orca_worktree_path: resolves an Orca worktree id to its path"
 }
 
+test_worktree_path_normalizes_wsl_unc() {
+  local out wt_id wt_path unc_id unc_path
+  # Orca on WSL returns Windows UNC paths for in-distro worktrees. Isolation
+  # checks and git -C need the Linux absolute form; the opaque worktree id is
+  # left unchanged for Orca API calls. Build the JSON with node so the UNC
+  # bytes match a real orca --json response rather than hand-escaped printf.
+  orca_case path-wsl-unc
+  unc_path='\\wsl.localhost\Ubuntu\home\ldh\orca\workspaces\proj\fm-task'
+  unc_id="repo-1::${unc_path}"
+  node -e 'const id=process.argv[1], p=process.argv[2]; process.stdout.write(JSON.stringify({ok:true,result:{worktree:{id,path:p}}})+"\n")' \
+    "$unc_id" "$unc_path" > "$RESP/1.out"
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_worktree_path "$1"' "$ROOT" "$unc_id" )
+  [ "$out" = /home/ldh/orca/workspaces/proj/fm-task ] || \
+    fail "worktree path helper should normalize wsl.localhost UNC to a Linux path, got '$out'"
+
+  printf '1\n' > "$RESP/1.exit"
+  printf '{"ok":true,"result":{"repo":{"id":"repo-1"}}}\n' > "$RESP/2.out"
+  node -e 'const id=process.argv[1], p=process.argv[2]; process.stdout.write(JSON.stringify({ok:true,result:{worktree:{id,path:p}}})+"\n")' \
+    "$unc_id" "$unc_path" > "$RESP/3.out"
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_worktree_create /repo/path fm-task' "$ROOT" )
+  wt_id=${out%%$'\t'*}
+  wt_path=${out#*$'\t'}
+  wt_path=${wt_path%%$'\t'*}
+  [ "$wt_path" = /home/ldh/orca/workspaces/proj/fm-task ] || \
+    fail "worktree create should print a normalized Linux path, got '$wt_path'"
+  [ "$wt_id" = "$unc_id" ] || \
+    fail "worktree create should keep the opaque Orca worktree id unchanged, got '$wt_id'"
+
+  # Forward-slash UNC and wsl$ share forms must also normalize.
+  out=$( node -e 'process.stdout.write(JSON.stringify({ok:true,result:{worktree:{path:"//wsl.localhost/Ubuntu/home/ldh/wt"}}})+"\n")' | \
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_json_get worktree-path' "$ROOT" )
+  [ "$out" = /home/ldh/wt ] || fail "json_get should normalize //wsl.localhost/... paths, got '$out'"
+  out=$( node -e 'process.stdout.write(JSON.stringify({ok:true,result:{worktree:{path:"\\\\wsl$\\Ubuntu\\home\\ldh\\wt2"}}})+"\n")' | \
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_json_get worktree-path' "$ROOT" )
+  [ "$out" = /home/ldh/wt2 ] || fail "json_get should normalize \\\\wsl$\\... paths, got '$out'"
+  # Already-Linux and true Windows drive paths stay as returned.
+  out=$( node -e 'process.stdout.write(JSON.stringify({ok:true,result:{worktree:{path:"/tmp/already-linux"}}})+"\n")' | \
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_json_get worktree-path' "$ROOT" )
+  [ "$out" = /tmp/already-linux ] || fail "json_get should leave Linux paths alone, got '$out'"
+  out=$( node -e 'process.stdout.write(JSON.stringify({ok:true,result:{worktree:{path:"C:\\Users\\x\\wt"}}})+"\n")' | \
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_json_get worktree-path' "$ROOT" )
+  [ "$out" = 'C:\Users\x\wt' ] || fail "json_get should not invent a Linux path for a Windows drive path, got '$out'"
+  pass "Orca worktree path: normalizes WSL UNC forms to Linux absolute paths"
+}
+
 test_json_get_ignores_undocumented_terminal_id_shapes() {
   local out status wt_id wt_path term
   orca_case parser-pruned-terminal-shapes
@@ -1319,6 +1366,7 @@ test_kill_is_best_effort_close
 test_remove_worktree_refuses_empty_id
 test_remove_worktree_rejects_orca_error_json
 test_worktree_path_resolves_id
+test_worktree_path_normalizes_wsl_unc
 test_dispatcher_sources_orca_and_routes_primitives
 test_json_get_ignores_undocumented_terminal_id_shapes
 test_worktree_and_terminal_helpers_parse_json


### PR DESCRIPTION
## Summary
- Orca on WSL returns worktree paths as `\\wsl.localhost\<Distro>\...`, which Firstmate could not `cd` into, so spawn isolation failed closed after a successful `worktree create`.
- Normalize verified `worktree-path` fields to Linux absolute paths (`/home/...`) while leaving opaque `orca_worktree_id` values unchanged for Orca API calls.
- Document the WSL path translation and keep true Windows drive paths fail-closed.

## Test plan
- [x] `bin/fm-test-run.sh tests/fm-backend-orca.test.sh` (all pass, including new WSL UNC cases)
- [x] Live WSL spawn: metadata records `worktree=/home/ldh/orca/workspaces/...` instead of a UNC path
- [ ] no-mistakes pipeline (this home has no local no-mistakes init yet)
- [ ] Full harness launch/send smoke on WSL (terminal submit still returns delivery-unconfirmed; separate from path normalize)