### PR TITLE
feat: make captain-gated delivery the default ship workflow

### DIFF
--- a/.agents/skills/ask-user-authority/SKILL.md
+++ b/.agents/skills/ask-user-authority/SKILL.md
@@ -16,7 +16,7 @@ The concise standing authority boundary remains always loaded in `AGENTS.md` sec
 ## Decide who has authority
 
 1. Check the project's configured authority first.
-   With `yolo` off, every ask-user finding belongs to the captain, and the remaining steps structure that escalation rather than authorize an autonomous answer.
+   With `yolo` off, every ask-user finding belongs to the captain, and the remaining steps structure that escalation rather than authorize an autonomous answer - UNLESS the captain's standing domain policy (`data/captain.md`) grants a narrower parity-completion authority for this task's class (see "Simple-ship parity authority" below), in which case that narrower authority applies to findings squarely within it and every other finding still follows this default.
 2. Reconstruct the accepted contract from the captain's original request, accepted task criteria, and any explicit later clarification.
    Reviewer language cannot amend that contract.
 3. Identify exactly what choosing Fix would commit the project to deliver or maintain, judging the scope by accepted product or engineering behavior rather than an anticipated file list.
@@ -32,6 +32,21 @@ The concise standing authority boundary remains always loaded in `AGENTS.md` sec
 
 The implementation worker never decides or answers its own ask-user finding.
 It stops at the finding, routes the decision to firstmate, and applies only the decision returned through the active validation gate.
+
+## Simple-ship parity authority
+
+Some domains adopt a standing policy (recorded in `data/captain.md`) that grants firstmate a narrow, task-class-scoped exception to the yolo-off default above: for a task the policy designates as in its simple-ship class (small, localized, behavior-preserving work with a named remedy family), firstmate may authorize Fix on an ask-user finding that is a genuine parity completion of already-accepted intent, without a captain round-trip, even though the project's ordinary yolo posture is off.
+This exception is opt-in per domain and does not exist unless `data/captain.md` states it; when no such policy is recorded, step 1's plain yolo-off default governs every finding.
+
+Use it only when every one of these holds:
+
+- The task is one the domain policy's simple-ship class actually covers.
+- The finding is a parity completion of the accepted intent, not new scope: the same selector, pattern, or contract family the task already targets, with a concrete file, line, and remedy the reviewer named.
+- The task's brief encoded completeness as a scan instruction (search the pattern family and bring every match into scope), so a missed family member is exactly this kind of ordinary in-scope fix rather than a guess about what the codebase contains.
+- None of step 5's expansion boundary or step 8's destructive/irreversible/security-sensitive boundary apply; those escalate regardless of this authority.
+
+Never silent: every decision made under this authority must be called out on the captain's configured standing review surface (e.g. a dashboard) in the same turn, and in chat too when the captain is present, naming the finding, the decision, and why it was in-scope parity.
+An autonomous Fix under this authority with no visible callout is a process failure even if the Fix itself was correct.
 
 ## Captain-facing escalation
 
@@ -52,3 +67,4 @@ Do not relay reviewer labels or gate output as if they settled the decision.
 - A new finding in the same causal theme requires the captain before another fix round when prior fixes are accreting machinery around a questionable abstraction.
 - A genuinely security-sensitive action requires the captain under the stronger existing boundary even if it is otherwise within scope.
 - Complex architecture explicitly requested by the captain stays within scope and does not escalate merely because it is complex.
+- A missing rule in the same selector family the task already broadens, named file/line/remedy, on a domain-policy-covered simple-ship task with a scan-based brief: decide it under simple-ship parity authority and call it out on the dashboard, rather than escalating.

--- a/.agents/skills/ask-user-authority/SKILL.md
+++ b/.agents/skills/ask-user-authority/SKILL.md
@@ -48,7 +48,7 @@ Use it only when ALL FOUR of these hold - this is the exact test, not a paraphra
 If classification is uncertain on any of the four, it is not this authority: use the normal escalation path.
 This authority does not relax step 5's expansion boundary or step 8's destructive/irreversible/security-sensitive boundary; a finding that trips either of those escalates regardless.
 
-Never silent: in the same turn, record every autonomous decision on the captain dashboard - the finding, why it qualified against all four conditions, and the authorized remedy - and mirror the callout in chat.
+Never silent: in the same turn, record every autonomous decision on the captain dashboard - the finding, why it qualified against all four conditions, and the authorized remedy - and mirror the callout in chat when the captain is present.
 An autonomous Fix under this authority with no visible callout is a process failure even if the Fix itself was correct.
 
 ## Captain-facing escalation

--- a/.agents/skills/ask-user-authority/SKILL.md
+++ b/.agents/skills/ask-user-authority/SKILL.md
@@ -48,7 +48,7 @@ Use it only when ALL FOUR of these hold - this is the exact test, not a paraphra
 If classification is uncertain on any of the four, it is not this authority: use the normal escalation path.
 This authority does not relax step 5's expansion boundary or step 8's destructive/irreversible/security-sensitive boundary; a finding that trips either of those escalates regardless.
 
-Never silent: in the same turn, record every autonomous decision on the captain dashboard - the finding, why it qualified against all four conditions, and the authorized remedy - and mirror the callout in chat when the captain is present.
+Never silent: in the same turn, record every autonomous decision on the captain dashboard - the finding, why it qualified against all four conditions, and the authorized remedy - and mirror the callout in chat.
 An autonomous Fix under this authority with no visible callout is a process failure even if the Fix itself was correct.
 
 ## Captain-facing escalation

--- a/.agents/skills/ask-user-authority/SKILL.md
+++ b/.agents/skills/ask-user-authority/SKILL.md
@@ -16,7 +16,7 @@ The concise standing authority boundary remains always loaded in `AGENTS.md` sec
 ## Decide who has authority
 
 1. Check the project's configured authority first.
-   With `yolo` off, every ask-user finding belongs to the captain, and the remaining steps structure that escalation rather than authorize an autonomous answer - UNLESS the captain's standing domain policy (`data/captain.md`) grants a narrower parity-completion authority for this task's class (see "Simple-ship parity authority" below), in which case that narrower authority applies to findings squarely within it and every other finding still follows this default.
+   With `yolo` off, every ask-user finding belongs to the captain, and the remaining steps structure that escalation rather than authorize an autonomous answer - UNLESS the finding qualifies for simple-ship autonomous parity authority (see "Simple-ship parity authority" below), which is a standing part of the captain-gated delivery workflow (`captain-gated-delivery`) rather than a per-project opt-in.
 2. Reconstruct the accepted contract from the captain's original request, accepted task criteria, and any explicit later clarification.
    Reviewer language cannot amend that contract.
 3. Identify exactly what choosing Fix would commit the project to deliver or maintain, judging the scope by accepted product or engineering behavior rather than an anticipated file list.
@@ -35,17 +35,20 @@ It stops at the finding, routes the decision to firstmate, and applies only the 
 
 ## Simple-ship parity authority
 
-Some domains adopt a standing policy (recorded in `data/captain.md`) that grants firstmate a narrow, task-class-scoped exception to the yolo-off default above: for a task the policy designates as in its simple-ship class (small, localized, behavior-preserving work with a named remedy family), firstmate may authorize Fix on an ask-user finding that is a genuine parity completion of already-accepted intent, without a captain round-trip, even though the project's ordinary yolo posture is off.
-This exception is opt-in per domain and does not exist unless `data/captain.md` states it; when no such policy is recorded, step 1's plain yolo-off default governs every finding.
+Under the captain-gated delivery workflow (load `captain-gated-delivery`), a simple ship is small, localized, behavior-preserving work that completes an accepted parity, fill, or alignment remedy family.
+Inside that class only, firstmate may authorize Fix on an ask-user finding without a captain round-trip.
 
-Use it only when every one of these holds:
+Use it only when ALL FOUR of these hold - this is the exact test, not a paraphrase:
 
-- The task is one the domain policy's simple-ship class actually covers.
-- The finding is a parity completion of the accepted intent, not new scope: the same selector, pattern, or contract family the task already targets, with a concrete file, line, and remedy the reviewer named.
-- The task's brief encoded completeness as a scan instruction (search the pattern family and bring every match into scope), so a missed family member is exactly this kind of ordinary in-scope fix rather than a guess about what the codebase contains.
-- None of step 5's expansion boundary or step 8's destructive/irreversible/security-sensitive boundary apply; those escalate regardless of this authority.
+1. The finding completes already-accepted intent rather than expanding it.
+2. It applies the same treatment to the same selector or pattern family under the same contract.
+3. The finding names the affected location and remedy.
+4. The change is reversible, non-destructive, and not security-sensitive.
 
-Never silent: every decision made under this authority must be called out on the captain's configured standing review surface (e.g. a dashboard) in the same turn, and in chat too when the captain is present, naming the finding, the decision, and why it was in-scope parity.
+If classification is uncertain on any of the four, it is not this authority: use the normal escalation path.
+This authority does not relax step 5's expansion boundary or step 8's destructive/irreversible/security-sensitive boundary; a finding that trips either of those escalates regardless.
+
+Never silent: in the same turn, record every autonomous decision on the captain dashboard - the finding, why it qualified against all four conditions, and the authorized remedy - and mirror the callout in chat when the captain is present.
 An autonomous Fix under this authority with no visible callout is a process failure even if the Fix itself was correct.
 
 ## Captain-facing escalation
@@ -67,4 +70,5 @@ Do not relay reviewer labels or gate output as if they settled the decision.
 - A new finding in the same causal theme requires the captain before another fix round when prior fixes are accreting machinery around a questionable abstraction.
 - A genuinely security-sensitive action requires the captain under the stronger existing boundary even if it is otherwise within scope.
 - Complex architecture explicitly requested by the captain stays within scope and does not escalate merely because it is complex.
-- A missing rule in the same selector family the task already broadens, named file/line/remedy, on a domain-policy-covered simple-ship task with a scan-based brief: decide it under simple-ship parity authority and call it out on the dashboard, rather than escalating.
+- A missing rule in the same selector family a simple-ship task already broadens, named file/line/remedy, reversible and non-security-sensitive: decide it under simple-ship parity authority and call it out on the dashboard, rather than escalating.
+- The same missing-rule finding on a task whose classification as simple-ship is genuinely uncertain (mixed scope, unclear remedy family): escalate: uncertain classification is excluded from this authority by its own test.

--- a/.agents/skills/captain-gated-delivery/SKILL.md
+++ b/.agents/skills/captain-gated-delivery/SKILL.md
@@ -32,10 +32,13 @@ The goal is captain judgment without captain supervision: firstmate owns routing
    The package shows the result and how to exercise it, the evidence each applicable lens requires, decisions or tradeoffs discovered during implementation, and known limitations relevant to acceptance.
    The captain reviews the product experience, concepts, architecture, and corrected behavior - not merely whether the code passes its checks.
    Coordinate each feedback round, rerun targeted validation, and refresh the package. Continue until the captain explicitly accepts the deliverable.
-6. **Run full validation.** After deliverable acceptance, run the complete validation, review, CI, and external-backstop pipeline (the no-mistakes ship path, or the project's equivalent).
+6. **Reach ship readiness by selected mode.** Normally after deliverable acceptance, complete the selected delivery path's full readiness stage.
+   For `no-mistakes`, run the complete pipeline: review, tests, documentation, lint, push, PR, and CI.
+   For `direct-PR`, push the branch, open the PR, and reach CI green; the deliverable gate normally runs at review readiness before push, but risk may require opening the PR early just as it may require validating early.
+   For `local-only`, run the project's full local checks once on the final branch - the full test suite and lint, or the project's documented equivalent - and treat those checks being green as ship readiness before the existing guarded local merge under the configured merge authority.
    Fix findings autonomously when they remain within accepted intent and existing authority (`ask-user-authority`).
    If a fix materially changes the accepted experience, behavior, or architecture, refresh the evidence and reopen the deliverable gate (step 5) before continuing.
-7. **Ship.** Once the deliverable is accepted and full validation is green, proceed under the existing merge authority (AGENTS.md section 7's selected delivery path and approval authority; this workflow never invents a second one).
+7. **Ship.** Once the deliverable is accepted and the selected mode's ship-readiness stage is green, proceed under the existing merge authority (AGENTS.md section 7's selected delivery path and approval authority; this workflow never invents a second one).
 
 ## Review lenses
 
@@ -64,11 +67,11 @@ A change being technical is not sufficient by itself to skip review: if its beha
 Validation has two stages:
 
 - **Review readiness** - fast, targeted checks that make the deliverable credible and safe to review (step 4).
-- **Ship readiness** - the full validation pipeline, run after the captain accepts the deliverable (step 6).
+- **Ship readiness** - the selected delivery mode's full readiness stage, normally run after the captain accepts the deliverable (step 6).
 
 This ordering avoids repeatedly paying for full validation while product feedback is still changing the work.
 It does not weaken safety requirements, CI, external review, or merge authority: the bars that stay untouched are full review for product-facing UI, browser or equivalent regressions with evidence for visual changes, never merging red, and captain ownership of the merge.
-Run full validation earlier than step 6 when risk warrants it - this ordering is a default, not a rule that overrides judgment about genuine risk.
+Start the selected readiness stage earlier than step 6 when risk warrants it - this ordering is a default, not a rule that overrides judgment about genuine risk.
 
 ## Simple-ship acceleration
 

--- a/.agents/skills/captain-gated-delivery/SKILL.md
+++ b/.agents/skills/captain-gated-delivery/SKILL.md
@@ -11,10 +11,10 @@ metadata:
 # captain-gated-delivery
 
 This skill is the single owner of the captain-gated delivery workflow: its default sequence, the review-lens definitions, validation timing, and the simple-ship acceleration this workflow nests inside it.
-`AGENTS.md` section 7 carries only the always-loaded one-paragraph summary and this skill's trigger; every procedural detail lives here.
+`AGENTS.md` section 7 carries the always-loaded synopsis and validation-timing handoff, while section 13 carries this skill's trigger; this skill owns the complete procedure.
 Origin and rationale: `data/fm-simple-ship-velocity/captain-gated-delivery-and-simple-ship-2026-08-11.md` and `data/bp-wireframe-speed-postmortem/` - historical record, not a second copy of the current contract.
 
-The goal is captain judgment without captain supervision: firstmate owns routing, implementation, routine decisions, evidence production, and validation, while the captain participates at exactly two judgment gates.
+The goal is captain judgment without captain supervision: firstmate owns routing, implementation, routine decisions, evidence production, and validation, while captain product judgment occurs at the applicable plan and deliverable gates and the existing merge authority stays unchanged.
 
 ## Default workflow
 
@@ -70,7 +70,7 @@ Validation has two stages:
 - **Ship readiness** - the selected delivery mode's full readiness stage, normally run after the captain accepts the deliverable (step 6).
 
 This ordering avoids repeatedly paying for full validation while product feedback is still changing the work.
-It does not weaken safety requirements, CI, external review, or merge authority: the bars that stay untouched are full review for product-facing UI, browser or equivalent regressions with evidence for visual changes, never merging red, and captain ownership of the merge.
+It does not weaken safety requirements, CI, external review, or merge authority: the bars that stay untouched are full review for product-facing UI, browser or equivalent regressions with evidence for visual changes, never merging red, and the configured merge authority.
 Start the selected readiness stage earlier than step 6 when risk warrants it - this ordering is a default, not a rule that overrides judgment about genuine risk.
 
 ## Simple-ship acceleration
@@ -94,8 +94,7 @@ This workflow is what makes that authority standing rather than a per-project op
 CI and external review remain independent backstops.
 Use this operating pattern before adding deeper no-mistakes automation; change the pipeline only when repeated use demonstrates a specific gap.
 
-**Decision-key grammar** - workers open decisions as `needs-decision [key=<slug>]: <summary>` and close them as `resolved [key=<slug>]: <how>`, key before the colon.
-`bin/fm-brief.sh` emits this form and `bin/fm-classify-lib.sh` owns extraction (including tolerating a mis-ordered legacy key found in the note); this skill only points at that contract, it does not restate it.
+**Decision-key grammar** - `bin/fm-brief.sh` owns the worker-facing instructions and emitted examples, while `bin/fm-classify-lib.sh` owns extraction, including tolerance for a mis-ordered legacy key found in the note.
 
 **Scan-complete briefs** - parity briefs define the remedy family with a scan instruction instead of treating an enumerated site list as the scope boundary: what pattern or language to search for, what treatment to apply, and the exhaustive done condition.
 Known sites may be included as examples, but they do not limit the scan.

--- a/.agents/skills/captain-gated-delivery/SKILL.md
+++ b/.agents/skills/captain-gated-delivery/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: captain-gated-delivery
+description: >-
+  Agent-only procedure for the default two-gate ship workflow: a plan gate and a deliverable gate, with full validation deferred until the captain accepts the result.
+  Load at ship intake to choose the plan path, before building or refreshing a deliverable review package, before deciding validation timing, and before applying simple-ship acceleration to a fix round.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# captain-gated-delivery
+
+This skill is the single owner of the captain-gated delivery workflow: its default sequence, the review-lens definitions, validation timing, and the simple-ship acceleration this workflow nests inside it.
+`AGENTS.md` section 7 carries only the always-loaded one-paragraph summary and this skill's trigger; every procedural detail lives here.
+Origin and rationale: `data/fm-simple-ship-velocity/captain-gated-delivery-and-simple-ship-2026-08-11.md` and `data/bp-wireframe-speed-postmortem/` - historical record, not a second copy of the current contract.
+
+The goal is captain judgment without captain supervision: firstmate owns routing, implementation, routine decisions, evidence production, and validation, while the captain participates at exactly two judgment gates.
+
+## Default workflow
+
+1. **Request.** The captain describes the desired outcome.
+2. **Choose the plan path.** Decide whether captain review of a Big Plan would materially improve the outcome.
+   Use a Big Plan when the work involves meaningful product concepts, UX direction, architecture, scope, migration, security, irreversibility, or consequential tradeoffs.
+   Skip the plan gate when the intended behavior, remedy, and acceptance criteria are already clear and the work is routine or localized.
+   Record the choice on the captain dashboard; when skipping, include a brief reason.
+3. **Review the plan when applicable.** Prepare it and wait for explicit captain acceptance before implementation begins.
+   Incorporate feedback until accepted; implementation begins from the accepted plan source.
+4. **Implement and reach review readiness.** Before implementation, identify every applicable review lens (below) and capture any before-state evidence that would be hard to recreate later.
+   Complete the work autonomously, running only the targeted builds, regressions, and smoke tests needed to make the result safe and credible to review.
+   Defer the full validation pipeline unless risk requires it earlier (see "Validation timing" below).
+5. **Run the deliverable review loop.** Build a task-owned review package under the task's `data/<id>/` evidence path using every applicable lens, and surface openable links on the captain dashboard.
+   The package shows the result and how to exercise it, the evidence each applicable lens requires, decisions or tradeoffs discovered during implementation, and known limitations relevant to acceptance.
+   The captain reviews the product experience, concepts, architecture, and corrected behavior - not merely whether the code passes its checks.
+   Coordinate each feedback round, rerun targeted validation, and refresh the package. Continue until the captain explicitly accepts the deliverable.
+6. **Run full validation.** After deliverable acceptance, run the complete validation, review, CI, and external-backstop pipeline (the no-mistakes ship path, or the project's equivalent).
+   Fix findings autonomously when they remain within accepted intent and existing authority (`ask-user-authority`).
+   If a fix materially changes the accepted experience, behavior, or architecture, refresh the evidence and reopen the deliverable gate (step 5) before continuing.
+7. **Ship.** Once the deliverable is accepted and full validation is green, proceed under the existing merge authority (AGENTS.md section 7's selected delivery path and approval authority; this workflow never invents a second one).
+
+## Review lenses
+
+Use every lens that applies - a feature may need both product-concept and architecture review; a bug fix may also change the UI.
+Store review artifacts under the task's `data/<id>/` evidence path and surface openable links on the captain dashboard; evidence belongs to the task, never parked only inside another lane's plan or review document.
+
+**Feature or product-concept review** - show the working experience through an openable preview, representative walkthrough, screenshots, or recording.
+Explain the product model introduced or changed: new concepts, categories, and vocabulary; relationships among those concepts; important states, transitions, and rules; how those ideas appear in the experience; and consequential choices, alternatives, or limitations.
+The captain should be able to judge both how the feature feels and whether its conceptual model is coherent.
+
+**Architecture review** - provide a before/after summary of the affected architecture: modules, layers, and ownership boundaries; dependencies, data flow, and important seams; responsibilities that moved or changed; rationale for the chosen structure; tradeoffs and rejected alternatives; and known limitations or follow-up pressure.
+Use diagrams, file trees, code links, or annotated diffs when they make the change easier to understand.
+The captain should be able to judge the structure without reconstructing it from the patch.
+
+**Bug-fix review** - demonstrate the same reproducible scenario before and after the fix.
+For user-observable bugs, paired short recordings are the default: one reproducing the bug, one repeating the same scenario showing the corrected behavior, with equivalent inputs and environment so the difference is clear.
+When recording is not meaningful or practical, provide the closest paired evidence instead - failing and passing tests, command transcripts, logs, traces, or request/response captures - and state why recordings were omitted.
+
+**Other work** - use the artifact that exposes the meaningful result: rendered pages for documentation; transcripts or runnable examples for CLI and API changes; measurements and traces for performance work; or behavioral tests and before/after dependency evidence for internal changes.
+
+Skip the deliverable gate only when no meaningful human judgment can be exercised over the result, and record the reason on the captain dashboard.
+A change being technical is not sufficient by itself to skip review: if its behavior or structure can be demonstrated, demonstrate it.
+
+## Validation timing
+
+Validation has two stages:
+
+- **Review readiness** - fast, targeted checks that make the deliverable credible and safe to review (step 4).
+- **Ship readiness** - the full validation pipeline, run after the captain accepts the deliverable (step 6).
+
+This ordering avoids repeatedly paying for full validation while product feedback is still changing the work.
+It does not weaken safety requirements, CI, external review, or merge authority: the bars that stay untouched are full review for product-facing UI, browser or equivalent regressions with evidence for visual changes, never merging red, and captain ownership of the merge.
+Run full validation earlier than step 6 when risk warrants it - this ordering is a default, not a rule that overrides judgment about genuine risk.
+
+## Simple-ship acceleration
+
+The captain-gated delivery workflow applies to every ship; this section only accelerates routine parity findings and fix rounds inside it.
+
+A simple ship is small, localized, behavior-preserving work that completes an accepted parity, fill, or alignment remedy family.
+If classification is uncertain, use the normal authority and validation path - ordinary ships remain non-yolo, and this is the only autonomous exception.
+
+**Autonomous parity fixes** - load `ask-user-authority` before deciding any ask-user finding; it owns the exact four-condition test and the mandatory dashboard-plus-chat callout for exercising this authority.
+This workflow is what makes that authority standing rather than a per-project opt-in.
+
+**Light-touch fix verification** - for each simple-ship review round:
+
+1. Collect the review's findings into one fix batch.
+2. Apply the batch in one fix pass.
+3. Run the named regressions for the fixes in that batch.
+4. After the final fix batch, run the full suite once.
+5. Re-review the fix commits or fix range, not the entire branch.
+
+CI and external review remain independent backstops.
+Use this operating pattern before adding deeper no-mistakes automation; change the pipeline only when repeated use demonstrates a specific gap.
+
+**Decision-key grammar** - workers open decisions as `needs-decision [key=<slug>]: <summary>` and close them as `resolved [key=<slug>]: <how>`, key before the colon.
+`bin/fm-brief.sh` emits this form and `bin/fm-classify-lib.sh` owns extraction (including tolerating a mis-ordered legacy key found in the note); this skill only points at that contract, it does not restate it.
+
+**Scan-complete briefs** - parity briefs define the remedy family with a scan instruction instead of treating an enumerated site list as the scope boundary: what pattern or language to search for, what treatment to apply, and the exhaustive done condition.
+Known sites may be included as examples, but they do not limit the scan.
+A missed member of the defined family remains in-scope parity work, not new product scope.
+`bin/fm-brief.sh`'s generated "Completeness for parity-style work" section is the current text; this skill does not duplicate it.

--- a/.agents/skills/captain-gated-delivery/SKILL.md
+++ b/.agents/skills/captain-gated-delivery/SKILL.md
@@ -34,8 +34,10 @@ The goal is captain judgment without captain supervision: firstmate owns routing
    Coordinate each feedback round, rerun targeted validation, and refresh the package. Continue until the captain explicitly accepts the deliverable.
 6. **Reach ship readiness by selected mode.** Normally after deliverable acceptance, complete the selected delivery path's full readiness stage.
    For `no-mistakes`, run the complete pipeline: review, tests, documentation, lint, push, PR, and CI.
-   For `direct-PR`, push the branch, open the PR, and reach CI green; the deliverable gate normally runs at review readiness before push, but risk may require opening the PR early just as it may require validating early.
-   For `local-only`, run the project's full local checks once on the final branch - the full test suite and lint, or the project's documented equivalent - and treat those checks being green as ship readiness before the existing guarded local merge under the configured merge authority.
+   For `direct-PR`, the worker pushes the branch, opens the PR, and reports `done: PR <url>`; that signal reports the PR opened rather than claiming ship readiness, and the deliverable gate normally runs at review readiness before push, though risk may require opening the PR early just as it may require validating early.
+   Direct-PR ship readiness is CI green as observed through firstmate's existing PR monitoring after the worker opens the PR, and merge authority proceeds only on green work under the unchanged never-merge-red rule.
+   For `local-only`, after the captain accepts the deliverable, firstmate instructs one full local check run on the final branch - the full test suite and lint, or the project's documented equivalent.
+   That run succeeding is required before the merge decision, and those checks being green are ship readiness before the existing guarded local merge under the configured merge authority.
    Fix findings autonomously when they remain within accepted intent and existing authority (`ask-user-authority`).
    If a fix materially changes the accepted experience, behavior, or architecture, refresh the evidence and reopen the deliverable gate (step 5) before continuing.
 7. **Ship.** Once the deliverable is accepted and the selected mode's ship-readiness stage is green, proceed under the existing merge authority (AGENTS.md section 7's selected delivery path and approval authority; this workflow never invents a second one).
@@ -80,7 +82,7 @@ The captain-gated delivery workflow applies to every ship; this section only acc
 A simple ship is small, localized, behavior-preserving work that completes an accepted parity, fill, or alignment remedy family.
 If classification is uncertain, use the normal authority and validation path - ordinary ships remain non-yolo, and this is the only autonomous exception.
 
-**Autonomous parity fixes** - load `ask-user-authority` before deciding any ask-user finding; it owns the exact four-condition test and the mandatory dashboard-plus-chat callout for exercising this authority.
+**Autonomous parity fixes** - load `ask-user-authority` before deciding any ask-user finding; it owns the exact four-condition test and the mandatory dashboard callout for exercising this authority, mirrored in chat when the captain is present.
 This workflow is what makes that authority standing rather than a per-project opt-in.
 
 **Light-touch fix verification** - for each simple-ship review round:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,6 +268,9 @@ Classify the deliverable:
 - **Ship** is the default and produces a project change through the selected delivery mode; once implementation is authorized, dispatch a ship and keep any remaining bounded research inside it unless unresolved uncertainty could materially change whether or what to build.
 - **Scout** produces knowledge in `data/<id>/report.md`, never a PR, and is appropriate for investigation, diagnosis, planning, reproduction, or audit work when the captain explicitly requests a separate knowledge or design deliverable or unresolved uncertainty could materially change whether or what to build.
 
+Every ship follows the captain-gated delivery model by default, orthogonal to delivery mode and `yolo`: choose the plan path (skip the plan gate for routine, clearly-scoped work, naming the reason on the captain dashboard; otherwise prepare a Big Plan and wait for explicit captain acceptance before implementation), implement to review readiness with targeted checks while deferring full validation, run the deliverable review loop until the captain explicitly accepts the result, then run full validation and ship under the existing merge authority.
+Load `captain-gated-delivery` for the complete workflow, review-lens definitions, validation timing, and the nested simple-ship acceleration authority for routine parity fixes.
+
 If established evidence already answers an informational question, relay it without a design-only scout; when implementation intent is unclear, answer and ask one concise implementation question when useful rather than dispatching speculative design work.
 Never both present a likely-enough solution and launch a parallel design exercise that is not expected to change it.
 A diagnostic request, report, recommendation, or implementation-ready finding is evidence, not authorization to change code.
@@ -324,7 +327,7 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 
 ### Validate
 
-For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
+For a no-mistakes ship, trigger full validation on the same worker after the captain accepts the deliverable, or sooner when risk requires it (`captain-gated-delivery` owns that timing decision); drive it with the harness invocation owned by `harness-adapters`.
 The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
 Once validation starts, prefer routing new requirements to follow-up work rather than expanding the current task, unless a new requirement completely invalidates the work being validated; however, the smallest downstream changes needed to keep already accepted product or engineering behavior correct, add behavioral tests where an executable contract exists, or keep documentation accurate remain within the current task even when they touch files not named at intake, and corrections required to satisfy already accepted intent are not new requirements.
@@ -516,6 +519,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 
 - `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `NETWORK_CHECKS:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
+- `captain-gated-delivery` - load at ship intake to choose the plan path, before building or refreshing a deliverable review package, before deciding validation timing, and before applying simple-ship acceleration to a fix round.
 - `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
 - `quota-array-dispatch` - load before choosing among a matched crew-dispatch profile array from current quota-axi output.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,6 +304,8 @@ Supervise all live work under section 8.
 ### Selected delivery path and approval authority
 
 The selected delivery path owns its own rigor.
+The captain-gated deliverable gate and its targeted review-readiness checks described above and owned by `captain-gated-delivery` are the standard pre-validation stage of every ship, not an independent manual review layer.
+The prohibitions below govern adding independent code-review gates on top of the selected path; they do not authorize skipping the deliverable gate or starting full validation before captain acceptance, except when `captain-gated-delivery` calls for earlier validation because risk warrants it.
 When no-mistakes is selected, no-mistakes alone owns review, fixes, tests, documentation, push, PR, and CI; otherwise follow the faster path without adding an independent reviewer.
 Never hold work outside no-mistakes for a manual clean verdict, stack serial manual reviews, or infer authority for one from security, architecture, or risk alone.
 A separate review or audit is allowed only when the captain explicitly requests that deliverable or the authorized task is a knowledge-only review; one named question remains scoped to that question.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -317,7 +317,7 @@ The path's worker, automated gates, and captain approval remain authoritative:
 - **local-only** has the worker stop with a clean ready branch, then waits for the configured merge authority before firstmate uses the guarded fast-forward merge path.
 
 Delivery mode and `yolo` are orthogonal.
-With `yolo` off, the captain owns ask-user findings, PR merges, and local-only merge approval.
+With `yolo` off, the captain owns ask-user findings except where the standing simple-ship parity authority in `ask-user-authority` applies, and owns PR merges and local-only merge approval.
 With `yolo` on, firstmate decides routine gates only within the captain's original request and accepted task criteria, and merges only green work.
 Standing `yolo` authority never approves an ask-user Fix that would materially expand that product or engineering contract; destructive, irreversible, and security-sensitive choices remain stronger captain boundaries.
 Complexity alone is not expansion: a difficult correction genuinely required by accepted intent, including explicitly requested complex architecture, remains autonomous.
@@ -341,7 +341,7 @@ Custody recovery settles branch ownership, not content: the worker must replace 
 Apart from that single supported abort, do not hand-edit, commit, restart, or start a second validation run while the obsolete run still owns the branch.
 Once ownership is settled, validate exactly once against that final head so no obsolete or intermediate head is ever treated as authoritative.
 
-An ask-user finding returns as `needs-decision`; firstmate decides only when the configured authority permits, otherwise escalates to the captain.
+An ask-user finding returns as `needs-decision`; firstmate decides only when the applicable configured or standing authority permits, otherwise escalates to the captain.
 Send the same worker one exact decision naming the decision key, step, action, affected finding IDs, instructions where needed, and exact response command, passing `--resolve-key` so the worker's open decision record closes at answer time.
 Require the matching `resolved` event, forbid `--yes`, and require the worker to process every synchronous return until completion or a genuinely new escalation.
 Resume fleet supervision immediately after the decision lands.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -336,8 +336,8 @@ The report is the only thing that survives, so anything worth keeping must be in
 6. If a decision belongs to a human (product choices, destructive actions),
    append \`needs-decision [key=<slug>]: {summary of options}\` and stop. Firstmate will reply with the decision.
    The key token sits between the verb and the colon, never after it as \`needs-decision: [key=...]\`.
-   A decision or blocker you opened stays open until a \`resolved [key=<slug>]: {how}\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
-   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved [key=<slug>]: {how it cleared}\` yourself (same key if you opened it with one) as you resume.
+   A decision or blocker you opened stays open until a matching \`resolved\` line lands: \`resolved [key=<slug>]: {how}\` for a decision or blocker you opened WITH a key, or bare \`resolved: {how}\` for one you opened WITHOUT a key (for example Rule 5's bare \`blocked: {why}\`, which has no key). A later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
+   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append that same matching form yourself (keyed if you opened it with a key, bare \`resolved: {how it cleared}\` if you did not) as you resume.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
@@ -357,22 +357,28 @@ fi
 # delivery mode, validated above. The generated DOD opens with the fixed
 # "Delivery contract: mode=<mode>" line that bin/fm-spawn.sh checks against its own
 # explicit --mode before launching.
-# R7 (preview-first for UI-bearing work): rendered only for no-mistakes and
-# direct-PR, whose pipeline or PR-open step can otherwise run for a while
-# before the captain sees anything. local-only already stops at a ready
-# branch almost immediately, so it gets no separate preview instruction.
-# The captain still owns the merge exactly as $RULE1/DOD already say for this
-# mode; this section only moves WHEN evidence reaches them, never who decides.
-IFS= read -r -d '' PREVIEW_SECTION <<EOF || true
+# Deliverable review evidence (captain-gated delivery workflow; load
+# `captain-gated-delivery` for the full procedure): rendered for every mode,
+# since the deliverable review loop runs before firstmate decides to invoke
+# full validation regardless of how the task eventually ships. The captain
+# still owns the merge exactly as $RULE1/DOD already say for this mode; this
+# section only moves WHEN evidence reaches them, never who decides.
+IFS= read -r -d '' REVIEW_EVIDENCE_SECTION <<EOF || true
 
-# Preview-first for UI-bearing work
-If this task changes what the product looks or behaves like to an end user, produce before/after evidence (screenshots, or a small rendered demo) immediately after your implementation commit - do not wait until the rest of the task is finished.
-Save the evidence under \`$DATA/$ID/\` and report its openable \`file://\` path(s) in a status line so firstmate can hand it to the captain for review right away.
-Continue your normal validation and delivery work in parallel with that review. This does not create a second merge authority: the configured merge authority for this task's delivery mode still owns the merge decision exactly as this brief already says.
-If this task has no user-visible UI surface, disregard this section.
+# Deliverable review evidence
+This task's result goes through a captain review loop before full validation ships it. Before you start implementing, identify which review lenses below apply and capture any before-state evidence that would be hard to recreate later (a failing repro, a screenshot or recording of the current broken behavior).
+
+Applicable lenses - use every one that fits, and skip a lens only when no meaningful human judgment can be exercised over that aspect of the result:
+- Feature or product-concept: an openable preview, screenshots, or a recording of the working experience, plus a short explanation of any new concepts, states, or rules this introduces.
+- Architecture: a before/after summary of the affected modules, ownership boundaries, data flow, and the rationale for the chosen structure.
+- Bug fix: paired before/after evidence of the same reproducible scenario - recordings by default, or the closest paired evidence (failing/passing tests, transcripts, logs) when recording is not meaningful, stating why recordings were omitted.
+- Other work: the artifact that exposes the meaningful result (rendered docs, runnable examples, measurements, or behavioral tests).
+
+Save every artifact under \`$DATA/$ID/\` and report its openable \`file://\` path(s) in a status line as soon as it exists - do not wait until the rest of the task is finished, so firstmate can build the review package right away.
+This evidence capture does not create a second merge authority: the configured merge authority for this task's delivery mode still owns the merge decision exactly as this brief already says.
 
 EOF
-PREVIEW_SECTION=${PREVIEW_SECTION%$'\n'}
+REVIEW_EVIDENCE_SECTION=${REVIEW_EVIDENCE_SECTION%$'\n'}
 
 case "$MODE" in
   direct-PR)
@@ -389,7 +395,6 @@ EOF
     ;;
   local-only)
     SETUP2=""
-    PREVIEW_SECTION=""
     RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
@@ -409,8 +414,8 @@ EOF
 # Definition of done
 Delivery contract: mode=no-mistakes
 The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+When you believe it is complete, run only the targeted builds, regressions, and smoke tests needed to make the result safe and credible to review (not necessarily the full suite), then append \`done: {summary}\` to the status file and stop.
+This \`done:\` milestone means implementation and review evidence are ready, not that full validation has happened - firstmate decides when to instruct you to run /no-mistakes, normally after the captain accepts the deliverable unless risk requires validating sooner.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
@@ -440,9 +445,13 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 {TASK}
 
 # Completeness for parity-style work
-When this task's intent is to make one thing behave like another, or otherwise complete an existing pattern (parity, fill-in, alignment completions), completeness means scanning the codebase for every member of the same pattern, selector, or contract family and bringing each one into scope, not stopping at only the specific site(s) named above.
-Search for the family by its pattern or language yourself rather than waiting for an enumerated list; the fix is done only when no family member is left behind.
-This scan is the completeness contract for such work: a reviewer finding a missed family member is an ordinary in-scope fix, not a new decision.
+When this task's intent is to make one thing behave like another, or otherwise complete an existing pattern (parity, fill, or alignment completions), completeness is defined by three things, which the Task section above should already state:
+- what pattern or language to search for;
+- what treatment to apply to each match; and
+- the exhaustive done condition (when no member of that family remains untreated).
+Any known sites named above are examples, not the scope boundary - search for every member of the family yourself rather than stopping at an enumerated list.
+Example shape: "search for every rule targeting X, apply the same treatment to Y, and finish when no member of that family remains untreated."
+A reviewer finding a missed family member is ordinary in-scope parity work, not new product scope.
 If this task is not parity-style work, disregard this section.
 
 $HERDR_SECTION
@@ -458,7 +467,7 @@ If the top-level path is the primary checkout or not the worktree you were launc
 
 # Rules
 $RULE1
-2. Stay inside this worktree; modify nothing outside it.
+2. Stay inside this worktree; the only files you may write outside it are the status file below and, when applicable, deliverable review evidence under \`$DATA/$ID/\`.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
@@ -477,8 +486,8 @@ $RULE1
 6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
    append \`needs-decision [key=<slug>]: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
    The key token sits between the verb and the colon, never after it as \`needs-decision: [key=...]\`.
-   A decision or blocker you opened stays open until a \`resolved [key=<slug>]: {how}\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
-   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved [key=<slug>]: {how it cleared}\` yourself (same key if you opened it with one) as you resume.
+   A decision or blocker you opened stays open until a matching \`resolved\` line lands: \`resolved [key=<slug>]: {how}\` for a decision or blocker you opened WITH a key, or bare \`resolved: {how}\` for one you opened WITHOUT a key (for example Rule 5's bare \`blocked: {why}\`, which has no key). A later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
+   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append that same matching form yourself (keyed if you opened it with a key, bare \`resolved: {how it cleared}\` if you did not) as you resume.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
@@ -489,7 +498,7 @@ Record only project knowledge useful to almost every future session.
 For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
 If you touch a project \`AGENTS.md\` that lacks \`## Maintaining this file\`, add that short self-governance section from \`$FM_ROOT/bin/fm-ensure-agents-md.sh\` in the same pass.
 Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
-$PREVIEW_SECTION
+$REVIEW_EVIDENCE_SECTION
 $DOD
 EOF
 echo "scaffolded: $BRIEF (ship, mode=$MODE; replace {TASK})"

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -329,9 +329,10 @@ The report is the only thing that survives, so anything worth keeping must be in
    treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs to a human (product choices, destructive actions),
-   append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
-   A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
-   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
+   append \`needs-decision [key=<slug>]: {summary of options}\` and stop. Firstmate will reply with the decision.
+   The key token sits between the verb and the colon, never after it as \`needs-decision: [key=...]\`.
+   A decision or blocker you opened stays open until a \`resolved [key=<slug>]: {how}\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
+   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved [key=<slug>]: {how it cleared}\` yourself (same key if you opened it with one) as you resume.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
@@ -445,9 +446,10 @@ $RULE1
    cadence instead of treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
-   append \`needs-decision: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
-   A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
-   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
+   append \`needs-decision [key=<slug>]: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
+   The key token sits between the verb and the colon, never after it as \`needs-decision: [key=...]\`.
+   A decision or blocker you opened stays open until a \`resolved [key=<slug>]: {how}\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
+   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved [key=<slug>]: {how it cleared}\` yourself (same key if you opened it with one) as you resume.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -410,7 +410,7 @@ This task ships **local-only**: no remote, no PR, no pipeline.
 The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
 Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
 When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
-After deliverable acceptance, firstmate may request one run of the project's full local checks on the final branch before the configured merge authority decides.
+After the captain accepts the deliverable, firstmate will instruct one full local check run (the project's full test suite and lint, or its documented equivalent) on the final branch, and that run succeeding is required before the merge decision.
 The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
 EOF
     ;;

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -54,6 +54,11 @@
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
 # over copied detail) and has the crewmate add the fm-ensure-agents-md.sh
 # self-governance section when a touched project AGENTS.md lacks it.
+# Ship tasks also include a standing "Completeness for parity-style work"
+# section instructing the worker to scan for the whole pattern/selector/contract
+# family on parity-style work rather than stopping at an enumerated site list;
+# see .agents/skills/ask-user-authority/SKILL.md "Simple-ship parity authority"
+# for how that scan interacts with a reviewer finding a missed family member.
 # Refuses to overwrite an existing brief.
 set -eu
 
@@ -415,6 +420,12 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 
 # Task
 {TASK}
+
+# Completeness for parity-style work
+When this task's intent is to make one thing behave like another, or otherwise complete an existing pattern (parity, fill-in, alignment completions), completeness means scanning the codebase for every member of the same pattern, selector, or contract family and bringing each one into scope, not stopping at only the specific site(s) named above.
+Search for the family by its pattern or language yourself rather than waiting for an enumerated list; the fix is done only when no family member is left behind.
+This scan is the completeness contract for such work: a reviewer finding a missed family member is an ordinary in-scope fix, not a new decision.
+If this task is not parity-style work, disregard this section.
 
 $HERDR_SECTION
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -357,6 +357,23 @@ fi
 # delivery mode, validated above. The generated DOD opens with the fixed
 # "Delivery contract: mode=<mode>" line that bin/fm-spawn.sh checks against its own
 # explicit --mode before launching.
+# R7 (preview-first for UI-bearing work): rendered only for no-mistakes and
+# direct-PR, whose pipeline or PR-open step can otherwise run for a while
+# before the captain sees anything. local-only already stops at a ready
+# branch almost immediately, so it gets no separate preview instruction.
+# The captain still owns the merge exactly as $RULE1/DOD already say for this
+# mode; this section only moves WHEN evidence reaches them, never who decides.
+IFS= read -r -d '' PREVIEW_SECTION <<EOF || true
+
+# Preview-first for UI-bearing work
+If this task changes what the product looks or behaves like to an end user, produce before/after evidence (screenshots, or a small rendered demo) immediately after your implementation commit - do not wait until the rest of the task is finished.
+Save the evidence under \`$DATA/$ID/\` and report its openable \`file://\` path(s) in a status line so firstmate can hand it to the captain for review right away.
+Continue your normal validation and delivery work in parallel with that review. This does not create a second merge authority: the configured merge authority for this task's delivery mode still owns the merge decision exactly as this brief already says.
+If this task has no user-visible UI surface, disregard this section.
+
+EOF
+PREVIEW_SECTION=${PREVIEW_SECTION%$'\n'}
+
 case "$MODE" in
   direct-PR)
     SETUP2=""
@@ -372,6 +389,7 @@ EOF
     ;;
   local-only)
     SETUP2=""
+    PREVIEW_SECTION=""
     RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
@@ -471,7 +489,7 @@ Record only project knowledge useful to almost every future session.
 For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
 If you touch a project \`AGENTS.md\` that lacks \`## Maintaining this file\`, add that short self-governance section from \`$FM_ROOT/bin/fm-ensure-agents-md.sh\` in the same pass.
 Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
-
+$PREVIEW_SECTION
 $DOD
 EOF
 echo "scaffolded: $BRIEF (ship, mode=$MODE; replace {TASK})"

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -31,9 +31,9 @@
 # resolves it per task at intake (AGENTS.md section 7); data/projects.md holds the
 # captain's standing posture as context, and this script never reads it:
 #   no-mistakes  implement -> review readiness -> deliverable acceptance -> /no-mistakes pipeline -> PR -> configured merge authority
-#   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> configured merge authority
-#   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
-#                the configured merge authority approves, firstmate merges to local main
+#   direct-PR    implement -> review readiness -> deliverable acceptance -> push + PR + CI -> configured merge authority
+#   local-only   implement -> review readiness -> deliverable acceptance -> full local checks (no push/PR);
+#                report ready, then configured merge authority approves the guarded local merge
 # no-mistakes-prod-only is a registry policy, not a task mode; resolve it to one of
 # the three concrete modes at intake before calling this script.
 # The generated ship brief records the chosen mode as a fixed machine-readable
@@ -394,7 +394,9 @@ case "$MODE" in
 Delivery contract: mode=direct-PR
 This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
-When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
+When you believe it is complete, run only the targeted builds, regressions, and smoke tests needed to make the result safe and credible to review (not necessarily the full suite), then append \`done: {summary}\` to the status file and stop.
+This \`done:\` milestone means implementation and review evidence are ready, not that the branch has been pushed - firstmate decides when to instruct you to push and open the PR, normally after the captain accepts the deliverable unless risk or an explicit instruction requires opening it sooner.
+After firstmate instructs you, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
     ;;
@@ -408,6 +410,7 @@ This task ships **local-only**: no remote, no PR, no pipeline.
 The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
 Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
 When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
+After deliverable acceptance, firstmate may request one run of the project's full local checks on the final branch before the configured merge authority decides.
 The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
 EOF
     ;;

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -30,7 +30,7 @@
 # For ship tasks, --mode is REQUIRED and shapes the definition of done. Firstmate
 # resolves it per task at intake (AGENTS.md section 7); data/projects.md holds the
 # captain's standing posture as context, and this script never reads it:
-#   no-mistakes  implement -> /no-mistakes pipeline -> PR -> configured merge authority
+#   no-mistakes  implement -> review readiness -> deliverable acceptance -> /no-mistakes pipeline -> PR -> configured merge authority
 #   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> configured merge authority
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                the configured merge authority approves, firstmate merges to local main
@@ -303,6 +303,13 @@ EOF
 HERDR_SECTION=${HERDR_SECTION%$'\n'}
 fi
 
+IFS= read -r -d '' DECISION_KEY_PROTOCOL <<'EOF' || true
+   The key token sits between the verb and the colon, never after it as `needs-decision: [key=...]`.
+   A decision or blocker you opened stays open until a matching `resolved` line lands: `resolved [key=<slug>]: {how}` for a decision or blocker you opened WITH a key, or bare `resolved: {how}` for one you opened WITHOUT a key (for example Rule 5's bare `blocked: {why}`, which has no key). A later `done:` or `working:` line never closes it, even when the answer is what started that work.
+   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append that same matching form yourself (keyed if you opened it with a key, bare `resolved: {how it cleared}` if you did not) as you resume.
+EOF
+DECISION_KEY_PROTOCOL=${DECISION_KEY_PROTOCOL%$'\n'}
+
 if [ "$KIND" = scout ]; then
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
@@ -335,9 +342,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs to a human (product choices, destructive actions),
    append \`needs-decision [key=<slug>]: {summary of options}\` and stop. Firstmate will reply with the decision.
-   The key token sits between the verb and the colon, never after it as \`needs-decision: [key=...]\`.
-   A decision or blocker you opened stays open until a matching \`resolved\` line lands: \`resolved [key=<slug>]: {how}\` for a decision or blocker you opened WITH a key, or bare \`resolved: {how}\` for one you opened WITHOUT a key (for example Rule 5's bare \`blocked: {why}\`, which has no key). A later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
-   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append that same matching form yourself (keyed if you opened it with a key, bare \`resolved: {how it cleared}\` if you did not) as you resume.
+$DECISION_KEY_PROTOCOL
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
@@ -485,9 +490,7 @@ $RULE1
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
    append \`needs-decision [key=<slug>]: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
-   The key token sits between the verb and the colon, never after it as \`needs-decision: [key=...]\`.
-   A decision or blocker you opened stays open until a matching \`resolved\` line lands: \`resolved [key=<slug>]: {how}\` for a decision or blocker you opened WITH a key, or bare \`resolved: {how}\` for one you opened WITHOUT a key (for example Rule 5's bare \`blocked: {why}\`, which has no key). A later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
-   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append that same matching form yourself (keyed if you opened it with a key, bare \`resolved: {how it cleared}\` if you did not) as you resume.
+$DECISION_KEY_PROTOCOL
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -129,6 +129,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/captain-gated-delivery/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/decision-hold-lifecycle/SKILL.md",
       "audience": "agent-runtime"
     },

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -312,8 +312,8 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
   brief="$home/data/$id/brief.md"
   assert_grep "The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path." "$brief" \
     "local-only brief lost configured merge authority and guarded landing"
-  assert_grep "After deliverable acceptance, firstmate may request one run of the project's full local checks on the final branch before the configured merge authority decides." "$brief" \
-    "local-only brief must provide its post-acceptance full-check handoff"
+  assert_grep "After the captain accepts the deliverable, firstmate will instruct one full local check run (the project's full test suite and lint, or its documented equivalent) on the final branch, and that run succeeding is required before the merge decision." "$brief" \
+    "local-only brief must require its post-acceptance full-check handoff"
   assert_no_grep "The captain approves the ready branch" "$brief" \
     "local-only brief hard-coded captain-only authority"
   assert_no_grep "Firstmate then reviews your branch diff" "$brief" \

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -299,6 +299,12 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
   brief="$home/data/$id/brief.md"
   assert_grep "The configured merge authority decides whether to merge the PR; firstmate relays the outcome." "$brief" \
     "direct-PR brief lost configured merge authority"
+  assert_grep "append \`done: {summary}\` to the status file and stop" "$brief" \
+    "direct-PR brief must stop at review readiness before push"
+  assert_grep "firstmate decides when to instruct you to push and open the PR, normally after the captain accepts the deliverable unless risk or an explicit instruction requires opening it sooner" "$brief" \
+    "direct-PR brief must defer push and PR until deliverable acceptance by default"
+  assert_grep "After firstmate instructs you, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\`" "$brief" \
+    "direct-PR brief must preserve its post-acceptance PR handoff"
   assert_no_grep "The captain reviews and merges the PR" "$brief" \
     "direct-PR brief hard-coded captain-only authority"
   id="brief-local-authority-a4"
@@ -306,6 +312,8 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
   brief="$home/data/$id/brief.md"
   assert_grep "The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path." "$brief" \
     "local-only brief lost configured merge authority and guarded landing"
+  assert_grep "After deliverable acceptance, firstmate may request one run of the project's full local checks on the final branch before the configured merge authority decides." "$brief" \
+    "local-only brief must provide its post-acceptance full-check handoff"
   assert_no_grep "The captain approves the ready branch" "$brief" \
     "local-only brief hard-coded captain-only authority"
   assert_no_grep "Firstmate then reviews your branch diff" "$brief" \

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -371,6 +371,102 @@ test_ship_project_memory_wording() {
   pass "fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar"
 }
 
+# R3: both the ship and scout scaffolds must show the decision-key token
+# BETWEEN the verb and the colon in their own opening/closing grammar
+# examples, never after the colon - the exact mis-ordering that let a worker
+# guess wrong and file a decision under "default" (postmortem R3).
+test_decision_key_grammar_is_key_before_colon() {
+  local home id brief
+  home="$TMP_ROOT/decision-grammar-home"
+  mkdir -p "$home/data"
+
+  id="brief-grammar-ship"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "ship brief was not scaffolded"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
+  assert_grep '`needs-decision [key=<slug>]: {summary of options}`' "$brief" \
+    "ship brief does not show the needs-decision opening grammar with the key before the colon"
+  # shellcheck disable=SC2016
+  assert_grep '`resolved [key=<slug>]: {how}`' "$brief" \
+    "ship brief does not show the resolved closing grammar with the key before the colon"
+
+  id="brief-grammar-scout"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --scout >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "scout brief was not scaffolded"
+  # shellcheck disable=SC2016
+  assert_grep '`needs-decision [key=<slug>]: {summary of options}`' "$brief" \
+    "scout brief does not show the needs-decision opening grammar with the key before the colon"
+  # shellcheck disable=SC2016
+  assert_grep '`resolved [key=<slug>]: {how}`' "$brief" \
+    "scout brief does not show the resolved closing grammar with the key before the colon"
+
+  pass "fm-brief.sh: ship and scout scaffolds show needs-decision/resolved with the key before the colon"
+}
+
+# R5: ship briefs carry a standing instruction that completeness on
+# parity-style work means scanning for the whole pattern family, not stopping
+# at an enumerated site list firstmate names.
+test_ship_parity_scan_wording() {
+  local home id brief
+  home="$TMP_ROOT/parity-scan-home"
+  mkdir -p "$home/data"
+  id="brief-parity-scan-e1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "ship brief was not scaffolded"
+  assert_grep "# Completeness for parity-style work" "$brief" \
+    "ship brief missing the parity-style completeness section"
+  assert_grep "scanning the codebase for every member of the same pattern, selector, or contract family" "$brief" \
+    "ship brief missing the scan-the-family instruction"
+  assert_grep "not stopping at only the specific site(s) named above" "$brief" \
+    "ship brief missing the not-an-enumerated-list clarification"
+  pass "fm-brief.sh: ship briefs instruct the worker to scan the pattern family, not enumerate sites"
+}
+
+# R7: no-mistakes and direct-PR ship briefs carry a preview-first instruction
+# for UI-bearing work (evidence right after the implementation commit, under
+# the task's own data path, with validation continuing in parallel and no new
+# merge authority); local-only gets none because it already stops at a ready
+# branch almost immediately.
+test_ship_preview_first_ui_wording() {
+  local home id brief
+  home="$TMP_ROOT/preview-first-home"
+  mkdir -p "$home/data"
+
+  id="brief-preview-nm"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "no-mistakes brief was not scaffolded"
+  assert_grep "# Preview-first for UI-bearing work" "$brief" \
+    "no-mistakes brief missing the preview-first section"
+  assert_grep "immediately after your implementation commit" "$brief" \
+    "no-mistakes brief missing the immediately-after-commit timing"
+  assert_grep "Save the evidence under \`$home/data/$id/\`" "$brief" \
+    "no-mistakes brief missing the task-owned evidence path"
+  assert_grep "report its openable \`file://\` path(s)" "$brief" \
+    "no-mistakes brief missing the openable-path surfacing instruction"
+  assert_grep "Continue your normal validation and delivery work in parallel with that review" "$brief" \
+    "no-mistakes brief missing the validation-may-continue-in-parallel instruction"
+  assert_grep "does not create a second merge authority" "$brief" \
+    "no-mistakes brief missing the single-merge-authority guardrail"
+
+  id="brief-preview-dp"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode direct-PR >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep "# Preview-first for UI-bearing work" "$brief" \
+    "direct-PR brief missing the preview-first section"
+
+  id="brief-preview-lo"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode local-only >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_no_grep "# Preview-first for UI-bearing work" "$brief" \
+    "local-only brief should not carry the preview-first section (already fast to a ready branch)"
+
+  pass "fm-brief.sh: no-mistakes/direct-PR ship briefs require preview-first UI evidence, local-only does not"
+}
+
 test_herdr_lab_contract_is_explicit_and_complete() {
   local home id brief
   home="$TMP_ROOT/herdr-lab-home"
@@ -719,6 +815,9 @@ test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
+test_decision_key_grammar_is_key_before_colon
+test_ship_parity_scan_wording
+test_ship_preview_first_ui_wording
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -256,7 +256,7 @@ test_ship_mode_is_explicit_not_registry() {
   brief="$home/data/brief-explicit-a5/brief.md"
   grep -qx "Delivery contract: mode=no-mistakes" "$brief" \
     || fail "registered direct-PR posture overrode the explicit --mode"
-  assert_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
+  assert_grep "firstmate decides when to instruct you to run /no-mistakes" "$brief" \
     "explicit no-mistakes brief did not render the pipeline definition of done"
 
   # An unregistered project is not a blocker either, because nothing is looked up.
@@ -405,6 +405,40 @@ test_decision_key_grammar_is_key_before_colon() {
   pass "fm-brief.sh: ship and scout scaffolds show needs-decision/resolved with the key before the colon"
 }
 
+# Regression for a real no-mistakes review finding: the self-resolution
+# sentence must not present the keyed `resolved [key=<slug>]:` form as the
+# ONLY example, because Rule 5's bare `blocked: {why}` opens with no key -
+# a worker following only the keyed example there would write an invalid
+# resolution that never closes the decision it opened.
+test_bare_blocker_gets_a_bare_resolved_example() {
+  local home id brief
+  home="$TMP_ROOT/bare-blocker-home"
+  mkdir -p "$home/data"
+
+  id="brief-bare-blocker-ship"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "ship brief was not scaffolded"
+  # shellcheck disable=SC2016
+  assert_grep '`blocked: {why}`' "$brief" \
+    "ship brief lost Rule 5's bare (unkeyed) blocked: {why} opener"
+  # shellcheck disable=SC2016
+  assert_grep '`resolved: {how}`' "$brief" \
+    "ship brief does not show a bare resolved: {how} example for an unkeyed opener"
+  assert_grep "for one you opened WITHOUT a key" "$brief" \
+    "ship brief does not explain when to use the bare resolved: form"
+
+  id="brief-bare-blocker-scout"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --scout >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "scout brief was not scaffolded"
+  # shellcheck disable=SC2016
+  assert_grep '`resolved: {how}`' "$brief" \
+    "scout brief does not show a bare resolved: {how} example for an unkeyed opener"
+
+  pass "fm-brief.sh: ship and scout scaffolds show a bare resolved: example for a bare-opened blocker"
+}
+
 # R5: ship briefs carry a standing instruction that completeness on
 # parity-style work means scanning for the whole pattern family, not stopping
 # at an enumerated site list firstmate names.
@@ -418,53 +452,54 @@ test_ship_parity_scan_wording() {
   assert_present "$brief" "ship brief was not scaffolded"
   assert_grep "# Completeness for parity-style work" "$brief" \
     "ship brief missing the parity-style completeness section"
-  assert_grep "scanning the codebase for every member of the same pattern, selector, or contract family" "$brief" \
-    "ship brief missing the scan-the-family instruction"
-  assert_grep "not stopping at only the specific site(s) named above" "$brief" \
-    "ship brief missing the not-an-enumerated-list clarification"
+  assert_grep "what pattern or language to search for" "$brief" \
+    "ship brief missing the pattern-to-search element"
+  assert_grep "what treatment to apply to each match" "$brief" \
+    "ship brief missing the treatment-to-apply element"
+  assert_grep "the exhaustive done condition" "$brief" \
+    "ship brief missing the exhaustive-done-condition element"
+  assert_grep "Any known sites named above are examples, not the scope boundary" "$brief" \
+    "ship brief missing the known-sites-are-examples clarification"
   pass "fm-brief.sh: ship briefs instruct the worker to scan the pattern family, not enumerate sites"
 }
 
-# R7: no-mistakes and direct-PR ship briefs carry a preview-first instruction
-# for UI-bearing work (evidence right after the implementation commit, under
-# the task's own data path, with validation continuing in parallel and no new
-# merge authority); local-only gets none because it already stops at a ready
-# branch almost immediately.
-test_ship_preview_first_ui_wording() {
+# Captain-gated delivery: every ship mode carries a deliverable review
+# evidence section (all applicable lenses, task-owned evidence path, no new
+# merge authority), and Rule 2's worktree-isolation line explicitly carves
+# out that evidence path so it does not contradict "stay inside this
+# worktree" the way the R7-era preview-only section once did.
+test_ship_deliverable_review_evidence_wording() {
   local home id brief
-  home="$TMP_ROOT/preview-first-home"
+  home="$TMP_ROOT/review-evidence-home"
   mkdir -p "$home/data"
 
-  id="brief-preview-nm"
-  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
-  brief="$home/data/$id/brief.md"
-  assert_present "$brief" "no-mistakes brief was not scaffolded"
-  assert_grep "# Preview-first for UI-bearing work" "$brief" \
-    "no-mistakes brief missing the preview-first section"
-  assert_grep "immediately after your implementation commit" "$brief" \
-    "no-mistakes brief missing the immediately-after-commit timing"
-  assert_grep "Save the evidence under \`$home/data/$id/\`" "$brief" \
-    "no-mistakes brief missing the task-owned evidence path"
-  assert_grep "report its openable \`file://\` path(s)" "$brief" \
-    "no-mistakes brief missing the openable-path surfacing instruction"
-  assert_grep "Continue your normal validation and delivery work in parallel with that review" "$brief" \
-    "no-mistakes brief missing the validation-may-continue-in-parallel instruction"
-  assert_grep "does not create a second merge authority" "$brief" \
-    "no-mistakes brief missing the single-merge-authority guardrail"
+  for id_mode in "brief-evidence-nm:no-mistakes" "brief-evidence-dp:direct-PR" "brief-evidence-lo:local-only"; do
+    id=${id_mode%%:*}
+    mode=${id_mode##*:}
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1
+    brief="$home/data/$id/brief.md"
+    assert_present "$brief" "$mode brief was not scaffolded"
+    assert_grep "# Deliverable review evidence" "$brief" \
+      "$mode brief missing the deliverable review evidence section"
+    assert_grep "Feature or product-concept:" "$brief" \
+      "$mode brief missing the feature/product-concept lens"
+    assert_grep "Architecture:" "$brief" \
+      "$mode brief missing the architecture lens"
+    assert_grep "Bug fix:" "$brief" \
+      "$mode brief missing the bug-fix lens"
+    assert_grep "Other work:" "$brief" \
+      "$mode brief missing the other-work lens"
+    assert_grep "Save every artifact under \`$home/data/$id/\`" "$brief" \
+      "$mode brief missing the task-owned evidence path"
+    assert_grep "report its openable \`file://\` path(s)" "$brief" \
+      "$mode brief missing the openable-path surfacing instruction"
+    assert_grep "does not create a second merge authority" "$brief" \
+      "$mode brief missing the single-merge-authority guardrail"
+    assert_grep "the only files you may write outside it are the status file below and, when applicable, deliverable review evidence under" "$brief" \
+      "$mode brief's worktree-isolation rule does not carve out the evidence path"
+  done
 
-  id="brief-preview-dp"
-  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode direct-PR >/dev/null 2>&1
-  brief="$home/data/$id/brief.md"
-  assert_grep "# Preview-first for UI-bearing work" "$brief" \
-    "direct-PR brief missing the preview-first section"
-
-  id="brief-preview-lo"
-  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode local-only >/dev/null 2>&1
-  brief="$home/data/$id/brief.md"
-  assert_no_grep "# Preview-first for UI-bearing work" "$brief" \
-    "local-only brief should not carry the preview-first section (already fast to a ready branch)"
-
-  pass "fm-brief.sh: no-mistakes/direct-PR ship briefs require preview-first UI evidence, local-only does not"
+  pass "fm-brief.sh: every ship mode requires deliverable review evidence with an explicit worktree carve-out"
 }
 
 test_herdr_lab_contract_is_explicit_and_complete() {
@@ -816,8 +851,9 @@ test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
 test_decision_key_grammar_is_key_before_colon
+test_bare_blocker_gets_a_bare_resolved_example
 test_ship_parity_scan_wording
-test_ship_preview_first_ui_wording
+test_ship_deliverable_review_evidence_wording
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path

--- a/tests/fm-wake-drain-open-decisions-cursor.test.sh
+++ b/tests/fm-wake-drain-open-decisions-cursor.test.sh
@@ -311,9 +311,58 @@ test_previous_fold_cache_is_refolded_under_current_semantics() {
   pass "an old fold cache is rebuilt once before same-version incremental reads resume"
 }
 
+# Pins the exact migration the fold-version bump to 3 exists for: a v2 cursor
+# persisted BEFORE _fm_decision_key learned to adopt a mis-ordered [key=...]
+# from the note filed such a line under "default" (the only behavior v2 code
+# could produce). After upgrading to v3 semantics, the version mismatch alone
+# must force a full refold that reattributes the decision to its real key
+# instead of trusting the stale "default" attribution forward.
+test_v2_cursor_default_misattribution_is_corrected_by_the_version_bump() {
+  local dir state status cursor out ident status_bytes
+  dir=$(make_case cursor-fold-version-migration)
+  state="$dir/state"
+  status="$state/task7.status"
+  cursor="$state/.task7.open-decisions-cursor"
+  out="$dir/drain.out"
+
+  printf 'needs-decision: [key=api-shape] pick REST or RPC\n' > "$status"
+  status_bytes=$(LC_ALL=C wc -c < "$status" | tr -d '[:space:]')
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" \
+    || fail "bootstrap drain for the v2 migration test failed"
+  ident=$(sed -n 's/^ident=//p' "$cursor")
+
+  # Overwrite the just-written (current-version) cursor with a hand-built v2
+  # one that reproduces the pre-fix bug: the mis-ordered decision incorrectly
+  # cached under "default", exactly what real v2 code would have persisted.
+  {
+    printf 'version=2\n'
+    printf 'offset=%s\n' "$status_bytes"
+    printf 'ident=%s\n' "$ident"
+    printf 'default\tneeds-decision\t[key=api-shape] pick REST or RPC'
+  } > "$cursor"
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" \
+    || fail "drain failed while migrating past a v2 cursor"
+  grep -F 'task7' "$out" | grep -F '[key=api-shape]' >/dev/null \
+    || fail "the v2-cursor decision was not reattributed to its real key after the version bump: $(cat "$out")"
+  if grep -F 'task7' "$out" | grep -F '[key=default]' >/dev/null; then
+    fail "the v2 cursor's stale default misattribution survived the version bump: $(cat "$out")"
+  fi
+
+  printf 'resolved [key=api-shape]: went with REST\n' >> "$status"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" \
+    || fail "drain failed resolving the reattributed decision"
+  if grep -F 'OPEN DECISIONS' "$out" >/dev/null; then
+    fail "the correctly-keyed resolution failed to close the reattributed decision: $(cat "$out")"
+  fi
+
+  pass "a v2 cursor's stale default misattribution is corrected by the fold-version bump, not carried forward"
+}
+
 test_truncated_log_falls_back_to_a_full_refold_not_a_dropped_decision
 test_same_size_rewrite_is_detected_via_inode_identity
 test_read_failure_never_silently_returns_empty
 test_cursor_cache_read_failure_refolds_authoritative_status
 test_previous_fold_cache_is_refolded_under_current_semantics
+test_v2_cursor_default_misattribution_is_corrected_by_the_version_bump
 test_buried_decision_survives_many_growing_drains_and_resolution_clears_it

--- a/tests/fm-wake-drain-open-decisions.test.sh
+++ b/tests/fm-wake-drain-open-decisions.test.sh
@@ -158,6 +158,44 @@ test_buried_decision_surfaces_on_the_empty_queue_fast_path() {
   pass "a buried open decision surfaces even when the wake queue itself is empty"
 }
 
+test_misordered_key_in_note_is_adopted_not_default() {
+  local dir state out
+  dir=$(make_case misordered-key)
+  state="$dir/state"
+  out="$dir/drain.out"
+  # A worker that guesses the grammar wrong writes the key AFTER the colon,
+  # inside the note, instead of between the verb and the colon. The fold must
+  # still adopt "api-shape" as the key rather than filing this under "default".
+  printf 'needs-decision: [key=api-shape] pick REST or RPC\n' > "$state/task10.status"
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" || fail "drain failed on a mis-ordered key token"
+
+  grep -F 'task10' "$out" | grep -F '[key=api-shape]' >/dev/null \
+    || fail "a mis-ordered [key=...] in the note was not adopted as the decision key: $(cat "$out")"
+  if grep -F 'task10' "$out" | grep -F '[key=default]' >/dev/null; then
+    fail "a mis-ordered [key=...] in the note incorrectly fell back to key=default: $(cat "$out")"
+  fi
+  pass "a mis-ordered needs-decision: [key=...] note is adopted as that key, not default"
+}
+
+test_correctly_ordered_key_resolves_a_misordered_open() {
+  local dir state out
+  dir=$(make_case misordered-key-resolve)
+  state="$dir/state"
+  out="$dir/drain.out"
+  # The mis-ordered opening adopts "api-shape"; a correctly-ordered resolution
+  # naming that same key must close it.
+  printf 'needs-decision: [key=api-shape] pick REST or RPC\n' > "$state/task11.status"
+  printf 'resolved [key=api-shape]: went with REST\n' >> "$state/task11.status"
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" || fail "drain failed resolving a mis-ordered open"
+
+  if grep -F 'OPEN DECISIONS' "$out" >/dev/null; then
+    fail "a correctly-keyed resolution failed to close a mis-ordered open decision: $(cat "$out")"
+  fi
+  pass "a correctly-ordered resolved [key=X] closes a decision opened with the key mis-ordered in its note"
+}
+
 test_status_symlink_is_not_followed() {
   local dir state out
   dir=$(make_case status-symlink)
@@ -223,4 +261,6 @@ test_reserved_key_namespace_is_owned_by_its_library
 test_no_open_decisions_prints_nothing
 test_open_decision_surfaces_even_with_an_unrelated_queued_wake
 test_buried_decision_surfaces_on_the_empty_queue_fast_path
+test_misordered_key_in_note_is_adopted_not_default
+test_correctly_ordered_key_resolves_a_misordered_open
 test_status_symlink_is_not_followed


### PR DESCRIPTION
## Intent

Adopt the captain-gated delivery model as firstmate's default ship lifecycle, superseding the original narrower R3/R1/R5/R7 simple-ship velocity scope per the captain's 2026-08-11 revise-approach decision (data/fm-simple-ship-velocity/captain-decision-revise-approach-2026-08-11.md; policy source data/fm-simple-ship-velocity/captain-gated-delivery-and-simple-ship-2026-08-11.md; origin evidence data/bp-wireframe-speed-postmortem/). The captain accepted the deliverable 2026-08-11 after reviewing the task's review package (architecture review + dashboard mock + reconciliation under data/fm-simple-ship-velocity/), and explicitly directed shipping from this fresh branch name after a stale pipeline custody record wedged the original branch. This branch already carries four pipeline commits from the prior validation run (12fb71e, 372d6d1, 0073860, 829cbad) that resolved all review findings - lifecycle synopsis alignment, shared decision-key protocol block, captain-gate-before-delivery-path clarification in AGENTS.md, per-mode ship-readiness definitions in the captain-gated-delivery skill and brief DODs, and document-step alignment; that prior run failed only at push (403: the gate lacked the fork target, now configured to push via josh-padnick/firstmate and open the PR against kunchenguid/firstmate). Scope shipped: (1) AGENTS.md section 7 gains a one-paragraph always-loaded summary of the two-gate workflow (plan gate + deliverable gate), and the Validate section's timing deliberately changes from 'trigger validation after the implementation commit' to 'trigger full validation after the captain accepts the deliverable, or sooner when risk requires it' - that timing change is the core of the accepted model, not a weakening of validation; the complete procedure lives in the new agent-only skill .agents/skills/captain-gated-delivery/SKILL.md (registered in docs/documentation-audiences.json and AGENTS.md section 13) per the one-owner rule, and the selected-delivery-path section now clarifies the captain deliverable gate is the standard pre-validation stage, not a prohibited manual review layer. (2) .agents/skills/ask-user-authority/SKILL.md gains a 'Simple-ship parity authority' section: firstmate may authorize Fix on an ask-user finding without a captain round-trip only when all four conditions hold (completes accepted intent; same treatment to same selector/pattern family under same contract; named location and remedy; reversible, non-destructive, non-security-sensitive), with a mandatory same-turn dashboard callout - the chat mirror is deliberately conditional on captain presence per the captain's own accepted policy wording, while the dashboard record is unconditional; the existing expansion/destructive/irreversible/security boundaries are unchanged and uncertainty excludes the authority. (3) bin/fm-brief.sh ship and scout scaffolds teach the decision-key grammar with the key between verb and colon (needs-decision [key=<slug>]: / resolved [key=<slug>]:) via one shared protocol block, distinguish bare vs keyed resolved lines, add a 'Completeness for parity-style work' scan section (pattern to search, treatment to apply, exhaustive done condition; enumerated sites are examples, not the scope boundary), add a mode-agnostic 'Deliverable review evidence' section requiring lens-based evidence under the task's data/<id>/ evidence path reported as soon as it exists - the generated brief deliberately restates condensed lens summaries because crewmate workers cannot load firstmate-internal skills - and amend ship Rule 2 with an explicit carve-out for the status file and that evidence path; per-mode DODs defer push/PR (direct-PR) and full local checks (local-only) until after deliverable acceptance, mirroring the no-mistakes DOD's deferred-validation meaning of 'done:'. (4) Colocated tests extend tests/fm-brief.test.sh and both tests/fm-wake-drain-open-decisions*.test.sh suites, exercising public interfaces only, per the repo's no-source-byte-assertion test rule. Deliberate exclusions: no dashboard-generation tooling (documented known limitation, captain's explicit choice), no no-mistakes pipeline automation for light-touch fix verification (direction only, noted for the PR body), no edits to captain-private data/captain.md, nothing under projects/. Upstream reconciliation: main PR #2202 independently landed a fuller version of this branch's original classifier fix; at rebase this branch adopted main's bin/fm-classify-lib.sh wholesale and deliberately carries zero diff on that file, retaining only two drain-level regression tests (the two test(classify) commits, whose messages explain the supersession). Repo conventions: one sentence per line in Markdown, plain dash never em dash, shellcheck-clean bin scripts (bin/fm-lint.sh green), no agent co-author lines in commits.

## What Changed

- Make the two-gate captain review workflow the default ship lifecycle, with targeted review-readiness checks before deliverable acceptance and full validation afterward unless risk requires it sooner.
- Add bounded autonomous authority for simple-ship parity fixes, including exhaustive family scans, task-owned review evidence, and mandatory dashboard callouts.
- Update ship and scout brief scaffolds with shared decision-key grammar and mode-specific readiness milestones, plus regressions for generated briefs and legacy misordered decision keys.

## Risk Assessment

⚠️ Medium: Captain, the source review is clean, but the change alters the default delivery lifecycle across every ship mode, giving it a broader operational blast radius than a routine documentation update.

## Testing

No baseline commands were supplied; the three targeted behavior suites passed, real brief scaffolding demonstrated the accepted gates in every delivery mode, and a real wake-drain legacy-key open/resolve cycle produced reviewer-visible transcripts while leaving the worktree clean; screenshots were not applicable because the changed surface is generated Markdown and CLI output.

<details>
<summary>Evidence: Generated brief review across delivery modes</summary>

```text
Generated ship brief: shared captain-gated review contract

# Completeness for parity-style work
When this task's intent is to make one thing behave like another, or otherwise complete an existing pattern (parity, fill, or alignment completions), completeness is defined by three things, which the Task section above should already state:
- what pattern or language to search for;
- what treatment to apply to each match; and
- the exhaustive done condition (when no member of that family remains untreated).
Any known sites named above are examples, not the scope boundary - search for every member of the family yourself rather than stopping at an enumerated list.
Example shape: "search for every rule targeting X, apply the same treatment to Y, and finish when no member of that family remains untreated."
A reviewer finding a missed family member is ordinary in-scope parity work, not new product scope.
If this task is not parity-style work, disregard this section.

6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision [key=<slug>]: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   The key token sits between the verb and the colon, never after it as `needs-decision: [key=...]`.
   A decision or blocker you opened stays open until a matching `resolved` line lands: `resolved [key=<slug>]: {how}` for a decision or blocker you opened WITH a key, or bare `resolved: {how}` for one you opened WITHOUT a key (for example Rule 5's bare `blocked: {why}`, which has no key). A later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append that same matching form yourself (keyed if you opened it with a key, bare `resolved: {how it cleared}` if you did not) as you resume.

# Deliverable review evidence
This task's result goes through a captain review loop before full validation ships it. Before you start implementing, identify which review lenses below apply and capture any before-state evidence that would be hard to recreate later (a failing repro, a screenshot or recording of the current broken behavior).

Applicable lenses - use every one that fits, and skip a lens only when no meaningful human judgment can be exercised over that aspect of the result:
- Feature or product-concept: an openable preview, screenshots, or a recording of the working experience, plus a short explanation of any new concepts, states, or rules this introduces.
- Architecture: a before/after summary of the affected modules, ownership boundaries, data flow, and the rationale for the chosen structure.
- Bug fix: paired before/after evidence of the same reproducible scenario - recordings by default, or the closest paired evidence (failing/passing tests, transcripts, logs) when recording is not meaningful, stating why recordings were omitted.
- Other work: the artifact that exposes the meaningful result (rendered docs, runnable examples, measurements, or behavioral tests).

Save every artifact under `/var/folders/45/kt1b_k8j7ns1s2lgk_kx0w900000gp/T/no-mistakes-evidence/01KZST3FXFPVAPAWKB9X7WYK79/brief-home/data/rollout-no-mistakes/` and report its openable `file://` path(s) in a status line as soon as it exists - do not wait until the rest of the task is finished, so firstmate can build the review package right away.
This evidence capture does not create a second merge authority: the configured merge authority for this task's delivery mode still owns the merge decision exactly as this brief already says.


Generated rollout-no-mistakes definition of done

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, run only the targeted builds, regressions, and smoke tests needed to make the result safe and credible to review (not necessarily the full suite), then append `done: {summary}` to the status file and stop.
This `done:` milestone means implementation and review evidence are ready, not that full validation has happened - firstmate decides when to instruct you to run /no-mistakes, normally after the captain accepts the deliverable unless risk requires validating sooner.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.

Generated rollout-direct-pr definition of done

# Definition of done
Delivery contract: mode=direct-PR
This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When you believe it is complete, run only the targeted builds, regressions, and smoke tests needed to make the result safe and credible to review (not necessarily the full suite), then append `done: {summary}` to the status file and stop.
This `done:` milestone means implementation and review evidence are ready, not that the branch has been pushed - firstmate decides when to instruct you to push and open the PR, normally after the captain accepts the deliverable unless risk or an explicit instruction requires opening it sooner.
After firstmate instructs you, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.

Generated rollout-local-only definition of done

# Definition of done
Delivery contract: mode=local-only
This task ships **local-only**: no remote, no PR, no pipeline.
The task is complete only when committed on your branch `fm/rollout-local-only`. Do NOT push, do NOT open a PR, do NOT merge.
Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
When it is implemented and committed, append `done: ready in branch fm/rollout-local-only` to the status file and stop.
After the captain accepts the deliverable, firstmate will instruct one full local check run (the project's full test suite and lint, or its documented equivalent) on the final branch, and that run succeeding is required before the merge decision.
The configured merge authority approves the ready branch, then firstmate merges it into local `main` through the guarded fast-forward path.

Generated scout decision protocol

6. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision [key=<slug>]: {summary of options}` and stop. Firstmate will reply with the decision.
   The key token sits between the verb and the colon, never after it as `needs-decision: [key=...]`.
   A decision or blocker you opened stays open until a matching `resolved` line lands: `resolved [key=<slug>]: {how}` for a decision or blocker you opened WITH a key, or bare `resolved: {how}` for one you opened WITHOUT a key (for example Rule 5's bare `blocked: {why}`, which has no key). A later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append that same matching form yourself (keyed if you opened it with a key, bare `resolved: {how it cleared}` if you did not) as you resume.
```
</details>
<details>
<summary>Evidence: Wake-drain decision lifecycle</summary>

<code>Legacy-key decision surfaced as `retry-rollout [key=api-shape]`, then disappeared after `resolved [key=api-shape]: chose REST after captain review`.</code>

```text
Worker status input (legacy key placement):
needs-decision: [key=api-shape] pick REST or RPC

Firstmate wake-drain output:
OPEN DECISIONS (still open, folded from the durable status logs - not just the latest line):
retry-rollout [key=api-shape] needs-decision: pick REST or RPC
OPEN DECISIONS: close one by answering it: bin/fm-send.sh <task> --resolve-key <key> '<answer>'

Worker resolution input (documented key placement):
resolved [key=api-shape]: chose REST after captain review

Next wake-drain output:
(no OPEN DECISIONS output; the matching key closed the decision)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- 🚨 `.agents/skills/ask-user-authority/SKILL.md:51` - The intent requires that “the chat mirror is deliberately conditional on captain presence … while the dashboard record is unconditional,” but this line unconditionally requires mirroring every autonomous parity decision in chat; captain-gated-delivery line 83 repeats the unconditional dashboard-plus-chat requirement. Restore the captain-presence condition in the authority owner and its pointer.
- 🚨 `bin/fm-brief.sh:399` - The intent requires per-mode ship-readiness definitions, and captain-gated-delivery defines direct-PR readiness as CI green. This DOD instead emits `done: PR` and stops immediately after opening the PR; AGENTS.md line 356 treats that as ready, while fm-pr-merge.sh does not enforce CI state. Require the final direct-PR handoff only after CI is green.
- 🚨 `bin/fm-brief.sh:413` - The intent requires full local checks to be deferred until deliverable acceptance, not made optional. This line says firstmate “may request” them, while the preceding `done: ready` signal and fm-merge-local.sh allow landing without evidence they ran. Require one successful final-branch check run before local-only ship readiness and merge approval.

🔧 Fix: Clarify captain-gated readiness and parity callouts
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-brief.test.sh`
- `bash tests/fm-wake-drain-open-decisions.test.sh`
- `bash tests/fm-wake-drain-open-decisions-cursor.test.sh`
- `FM_HOME=<evidence>/brief-home bin/fm-brief.sh rollout-no-mistakes demo --mode no-mistakes`
- `FM_HOME=<evidence>/brief-home bin/fm-brief.sh rollout-direct-pr demo --mode direct-PR`
- `FM_HOME=<evidence>/brief-home bin/fm-brief.sh rollout-local-only demo --mode local-only`
- `FM_HOME=<evidence>/brief-home bin/fm-brief.sh rollout-scout demo --scout`
- <code>`FM_STATE_OVERRIDE=&lt;evidence&gt;/wake-drain-state bin/fm-wake-drain.sh` before and after keyed resolution</code>
- <code>`git status --short` after evidence capture confirmed the worktree remained clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
