### PR TITLE
fix(afk): refuse unverifiable away-mode delivery

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -31,7 +31,7 @@ batched digest rather than per-wake injections.
      `bin/fm-afk-launch.sh start-native`, then run
      `FM_AFK_STATE_PREPARED=1 bin/fm-afk-start.sh` through that native tool.
      This is a deliberate no-separate-terminal exception because the harness-hosted job creates no terminal or layout mutation, and a shell launcher cannot invoke a harness-native background tool.
-     The launcher still owns lifecycle state and records the no-terminal mode, while the daemon inherits and auto-discovers the captain pane.
+     The launcher still owns lifecycle state and records the no-terminal mode, while preflight verifies the inherited captain delivery endpoint before that state is written.
      If the native launch fails, run `bin/fm-afk-launch.sh stop` to roll back the prepared lifecycle.
      Do not wrap it in `nohup ... &` (Codex/herdr can reap fire-and-forget shell children after a tool call returns).
    - **Harness WITHOUT one** (e.g. pi): run `bin/fm-afk-launch.sh start`. It is
@@ -44,6 +44,8 @@ batched digest rather than per-wake injections.
      shrinks the captain's pane (docs/herdr-backend.md "Away-mode supervisor
      support").
    Both paths share `bin/fm-afk-start.sh` as the daemon entry.
+   Both paths preflight a supported delivery endpoint before writing active away state.
+   If preflight reports `away mode NOT ARMED`, remain in normal supervision and surface the exact refusal; the same refusal writes a durable marker and fires the configured pane-independent alarm.
    The native path tells it that the launcher already prepared lifecycle state; the terminal-backed path lets the entry perform its existing state setup inside the new terminal.
    It exits immediately if the identity-backed daemon lock already names a live process, otherwise it execs `bin/fm-supervise-daemon.sh` in the foreground.
    The daemon is **presence-gated**: it injects escalations only while
@@ -216,12 +218,16 @@ the operational prefix lets firstmate distinguish it from a real captain message
   (tmux vs herdr) and TARGET independently, mirroring
   `bin/fm-backend.sh`'s own runtime auto-detection. Backend: `FM_SUPERVISOR_BACKEND`
   override, then `$TMUX_PANE` set (tmux), then `$HERDR_ENV=1` with
-  `$HERDR_PANE_ID` present (herdr), then a tmux fallback. Target:
+  `$HERDR_PANE_ID` present (herdr), then explicit `UNVERIFIED` refusal. Target:
   `FM_SUPERVISOR_TARGET` override (a tmux target or a herdr
   `"<session>:<pane-id>"` target), then `$TMUX_PANE`, then
-  `"${HERDR_SESSION:-default}:${HERDR_PANE_ID}"` under herdr, then a
-  `firstmate:0` fallback with a warning. Both resolution sources are logged at
-  startup so a wrong-but-resolving fallback is detectable. Other runtime
+  `"${HERDR_SESSION:-default}:${HERDR_PANE_ID}"` under herdr, then explicit
+  `UNVERIFIED` refusal. Independently, the operator session resolves from a
+  live endpoint or from the existing session-lock harness pid plus controlling
+  TTY, so a Ghostty primary is identified without fabricating a pane. A plain
+  TTY is not an injectable composer; the launcher refuses before `.afk`, writes
+  `state/.subsuper-delivery-unavailable`, and fires the pane-independent alert.
+  Other runtime
   backends, including zellij, orca, and cmux, are not yet supported as
   supervisor backends; the daemon refuses loudly at startup instead of
   misapplying tmux primitives to a pane that isn't one
@@ -229,7 +235,7 @@ the operational prefix lets firstmate distinguish it from a real captain message
 
 ## Stale-artifact lifecycle
 
-Treat `state/.subsuper-escalations`, its `.since` sidecar, and `state/.subsuper-inject-wedged` as session-scoped delivery artifacts, not as the durable work record.
+Treat `state/.subsuper-escalations`, its `.since` sidecar, `state/.subsuper-inject-wedged`, and `state/.subsuper-delivery-unavailable` as session-scoped delivery artifacts, not as the durable work record.
 Always enter through `bin/fm-afk-launch.sh`, which clears prior-session artifacts only for a fresh entry and preserves the current session's buffer on refresh.
 Always exit through `bin/fm-afk-launch.sh stop`, which keeps `state/.afk` present through the daemon's shutdown flush and clears it last.
 `docs/herdr-backend.md` "Away-mode supervisor support" owns the current mechanism, and `docs/verification/runtime-backends.md` "Away-mode transport" owns active evidence.

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, runtime backend selection, optional Relay and its X and Discord setup steps, the files you set, and harness support.
 - [docs/remote-secondmates.md](docs/remote-secondmates.md) - current setup, routing, transfer, recovery, and safety behavior for whole-home remote second mates.
 - [docs/calm.md](docs/calm.md) - current Pi `/calm` behavior and supported presentation limits.
-- [docs/wedge-alarm.md](docs/wedge-alarm.md) - configure the active alert for an away-mode escalation delivery that gets stuck.
+- [docs/wedge-alarm.md](docs/wedge-alarm.md) - configure the active alert for refused or stalled away-mode escalation delivery.
 - [docs/tmux-backend.md](docs/tmux-backend.md) - current setup and limits for the tmux reference backend.
 - [docs/herdr-backend.md](docs/herdr-backend.md) - current setup, safety boundaries, and limits for the experimental Herdr backend.
 - [docs/zellij-backend.md](docs/zellij-backend.md) - current setup and limits for the experimental Zellij backend.

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -89,6 +89,28 @@ set +e
 
 fm_afk_launch_log() { printf 'fm-afk-launch: %s\n' "$*" >&2; }
 
+fm_afk_launch_delivery_preflight() {
+  local identity target backend target_rc backend_rc
+  identity=$(discover_operator_session_identity) || true
+  target=$(discover_supervisor_target)
+  target_rc=$?
+  backend=$(discover_supervisor_backend)
+  backend_rc=$?
+  if [ "$backend_rc" -eq 0 ] && ! supervisor_delivery_backend_supported "$backend"; then
+    backend="UNVERIFIED(unsupported-delivery-backend:${backend:-empty})"
+    backend_rc=1
+  fi
+  if [ "$target_rc" -ne 0 ] || [ "$backend_rc" -ne 0 ]; then
+    FM_OPERATOR_SESSION_IDENTITY="${identity:-UNVERIFIED(operator-session-blind)}" \
+      FM_SUPERVISOR_TARGET_DISCOVERY="$target" \
+      FM_SUPERVISOR_BACKEND_DISCOVERY="$backend" \
+      "$FM_AFK_LAUNCH_DIR/fm-supervise-daemon.sh" report-delivery-unavailable || true
+    return 1
+  fi
+  FM_AFK_CAPTAIN_TARGET=$target
+  FM_AFK_CAPTAIN_BACKEND=$backend
+}
+
 fm_afk_launch_lock_owned() {
   local pid expected actual
   [ -d "$FM_AFK_LAUNCH_LOCK" ] || return 1
@@ -362,11 +384,12 @@ fm_afk_launch_restore_backup() {  # <backup> <had-afk>
   rm -f "$FM_AFK_LAUNCH_STATE/.afk" \
     "$FM_AFK_LAUNCH_STATE/.subsuper-escalations" \
     "$FM_AFK_LAUNCH_STATE/.subsuper-escalations.since" \
-    "$FM_AFK_LAUNCH_STATE/.subsuper-inject-wedged" || result=1
+    "$FM_AFK_LAUNCH_STATE/.subsuper-inject-wedged" \
+    "$FM_AFK_LAUNCH_STATE/.subsuper-delivery-unavailable" || result=1
   if [ "$had_afk" -eq 1 ]; then
     cp "$backup/.afk" "$FM_AFK_LAUNCH_STATE/.afk" || result=1
   fi
-  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged; do
+  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged .subsuper-delivery-unavailable; do
     if [ -e "$backup/$artifact" ]; then
       cp -p "$backup/$artifact" "$FM_AFK_LAUNCH_STATE/$artifact" || result=1
     fi
@@ -466,11 +489,10 @@ fm_afk_launch_start() {
     fm_afk_launch_log "return catch-up is still pending; run bin/fm-afk-return.sh check before re-entering away mode"
     return 1
   fi
-  # Capture the captain pane FIRST, before creating anything.
-  captain_target=$(discover_supervisor_target) || {
-    fm_afk_launch_log "could not resolve the captain supervisor pane (set FM_SUPERVISOR_TARGET)"; return 1; }
-  captain_backend=$(discover_supervisor_backend) || {
-    fm_afk_launch_log "could not resolve the captain supervisor backend (set FM_SUPERVISOR_BACKEND)"; return 1; }
+  # Capture the captain delivery endpoint FIRST, before creating anything.
+  fm_afk_launch_delivery_preflight || return 1
+  captain_target=$FM_AFK_CAPTAIN_TARGET
+  captain_backend=$FM_AFK_CAPTAIN_BACKEND
 
   mkdir -p "$FM_AFK_LAUNCH_STATE"
 
@@ -489,7 +511,7 @@ fm_afk_launch_start() {
     had_afk=1
     cp "$FM_AFK_LAUNCH_STATE/.afk" "$backup/.afk" || { rm -rf "$backup"; return 1; }
   fi
-  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged; do
+  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged .subsuper-delivery-unavailable; do
     if [ -e "$FM_AFK_LAUNCH_STATE/$artifact" ]; then
       cp -p "$FM_AFK_LAUNCH_STATE/$artifact" "$backup/$artifact" || { rm -rf "$backup"; return 1; }
     fi
@@ -536,6 +558,7 @@ fm_afk_launch_start_native() {
     fm_afk_launch_log "return catch-up is still pending; run bin/fm-afk-return.sh check before re-entering away mode"
     return 1
   fi
+  fm_afk_launch_delivery_preflight || return 1
   if daemon_lock_held_by_live_daemon; then
     fm_afk_launch_record_validate_if_present || return 1
     fm_afk_launch_flag_write || return 1
@@ -547,7 +570,7 @@ fm_afk_launch_start_native() {
     had_afk=1
     cp "$FM_AFK_LAUNCH_STATE/.afk" "$backup/.afk" || { rm -rf "$backup"; return 1; }
   fi
-  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged; do
+  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged .subsuper-delivery-unavailable; do
     if [ -e "$FM_AFK_LAUNCH_STATE/$artifact" ]; then
       cp -p "$FM_AFK_LAUNCH_STATE/$artifact" "$backup/$artifact" || { rm -rf "$backup"; return 1; }
     fi

--- a/bin/fm-afk-return.sh
+++ b/bin/fm-afk-return.sh
@@ -124,7 +124,8 @@ clear_delivery_artifacts() {
   rm -f \
     "$STATE/.subsuper-escalations" \
     "$STATE/.subsuper-escalations.since" \
-    "$STATE/.subsuper-inject-wedged"
+    "$STATE/.subsuper-inject-wedged" \
+    "$STATE/.subsuper-delivery-unavailable"
 }
 
 return_guard() {
@@ -172,6 +173,10 @@ return_reconcile() {
   if [ -s "$STATE/.subsuper-inject-wedged" ]; then
     wedge=$(head -1 "$STATE/.subsuper-inject-wedged" 2>/dev/null || true)
     append_evidence wedge "$wedge" "$evidence"
+  fi
+  if [ -s "$STATE/.subsuper-delivery-unavailable" ]; then
+    wedge=$(head -1 "$STATE/.subsuper-delivery-unavailable" 2>/dev/null || true)
+    append_evidence delivery "$wedge" "$evidence"
   fi
   if [ -s "$STATE/.subsuper-escalations" ]; then
     escalations=$(cat "$STATE/.subsuper-escalations" 2>/dev/null || true)

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -20,8 +20,8 @@
 # This is the COMMON daemon entry for every backend. HOW it becomes a tracked
 # background process differs by harness/backend and is owned elsewhere:
 #   - Harnesses with a native in-pane tracked-background tool (e.g. claude, grok)
-#     run this directly via that tool, so the daemon inherits the captain pane's
-#     env and auto-discovers it.
+#     run this directly via that tool. Preflight accepts a real inherited
+#     tmux/herdr endpoint and refuses a plain terminal rather than guessing one.
 #   - Harnesses with NO native background mechanism (e.g. pi) run this THROUGH
 #     bin/fm-afk-launch.sh, which creates a non-visible tracked terminal per
 #     backend (herdr tab/workspace, tmux detached session) and passes the
@@ -41,6 +41,8 @@ FM_AFK_DAEMON="$FM_AFK_START_DIR/fm-supervise-daemon.sh"
 
 # shellcheck source=bin/fm-wake-lib.sh
 . "$FM_AFK_START_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-supervisor-target-lib.sh
+. "$FM_AFK_START_DIR/fm-supervisor-target-lib.sh"
 
 fm_afk_start_usage() {
   sed -n '2,14p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
@@ -63,7 +65,8 @@ fm_afk_clear_stale_artifacts() {  # <state-dir>
   local state=$1
   rm -f "$state/.subsuper-escalations" \
         "$state/.subsuper-escalations.since" \
-        "$state/.subsuper-inject-wedged" 2>/dev/null
+        "$state/.subsuper-inject-wedged" \
+        "$state/.subsuper-delivery-unavailable" 2>/dev/null
 }
 
 daemon_lock_owner() {
@@ -111,6 +114,7 @@ daemon_lock_held_by_live_daemon() {
 }
 
 fm_afk_start_main() {
+  local pid identity target backend target_rc backend_rc
   case "${1:-}" in
     '' ) ;;
     -h|--help) fm_afk_start_usage; return 0 ;;
@@ -118,17 +122,40 @@ fm_afk_start_main() {
   esac
 
   mkdir -p "$FM_AFK_STATE"
+  pid=$(daemon_lock_pid 2>/dev/null || true)
+  if daemon_lock_held_by_live_daemon; then
+    date '+%s' > "$FM_AFK_STATE/.afk"
+    echo "afk: daemon already running pid=$pid"
+    return 0
+  fi
+
+  identity=$(discover_operator_session_identity) || true
+  if target=$(discover_supervisor_target); then
+    target_rc=0
+  else
+    target_rc=$?
+  fi
+  if backend=$(discover_supervisor_backend); then
+    backend_rc=0
+  else
+    backend_rc=$?
+  fi
+  if [ "$backend_rc" -eq 0 ] && ! supervisor_delivery_backend_supported "$backend"; then
+    backend="UNVERIFIED(unsupported-delivery-backend:${backend:-empty})"
+    backend_rc=1
+  fi
+  if [ "$target_rc" -ne 0 ] || [ "$backend_rc" -ne 0 ]; then
+    FM_OPERATOR_SESSION_IDENTITY="${identity:-UNVERIFIED(operator-session-blind)}" \
+      FM_SUPERVISOR_TARGET_DISCOVERY="$target" \
+      FM_SUPERVISOR_BACKEND_DISCOVERY="$backend" \
+      "$FM_AFK_DAEMON" report-delivery-unavailable || true
+    return 1
+  fi
+
   if [ "${FM_AFK_STATE_PREPARED:-0}" = 1 ]; then
     [ -f "$FM_AFK_STATE/.afk" ] || { echo "afk: launcher-prepared state is missing" >&2; return 1; }
   else
     date '+%s' > "$FM_AFK_STATE/.afk"
-  fi
-
-  local pid
-  pid=$(daemon_lock_pid 2>/dev/null || true)
-  if daemon_lock_held_by_live_daemon; then
-    echo "afk: daemon already running pid=$pid"
-    return 0
   fi
 
   if fm_pid_alive "$pid" && [ -n "$pid" ]; then

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -67,8 +67,9 @@
 #          FM_SUPERVISOR_TARGET     supervisor pane target (override; otherwise
 #                                   auto-discovered per backend - $TMUX_PANE
 #                                   under tmux, "<session>:<pane-id>" from
-#                                   $HERDR_PANE_ID under herdr - then
-#                                   firstmate:0 fallback). Accepts either a
+#                                   $HERDR_PANE_ID under herdr). A runtime with
+#                                   no supported delivery endpoint refuses and
+#                                   raises the independent alarm. Accepts either a
 #                                   tmux target or a herdr "<session>:<pane-id>"
 #                                   target; which one it's read as is decided by
 #                                   FM_SUPERVISOR_BACKEND (below), independently.
@@ -77,8 +78,8 @@
 #                                   way bin/fm-backend.sh's fm_backend_detect
 #                                   resolves the runtime firstmate itself is
 #                                   executing inside - $TMUX_PANE selects tmux,
-#                                   $HERDR_ENV=1 selects herdr - falling back to
-#                                   tmux). zellij, orca, and cmux are not yet
+#                                   $HERDR_ENV=1 selects herdr). zellij, orca,
+#                                   and cmux are not yet
 #                                   supported as supervisor backends; the daemon
 #                                   refuses loudly at startup rather than trying
 #                                   tmux primitives against a non-tmux pane.
@@ -168,10 +169,9 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 # shellcheck source=bin/fm-classify-lib.sh
 . "$FM_DAEMON_DIR/fm-classify-lib.sh"
 
-# Supervisor-pane discovery (FM_SUPERVISOR_TARGET_DEFAULT,
-# FM_SUPERVISOR_BACKEND_DEFAULT, discover_supervisor_target,
-# discover_supervisor_backend). Shared with the script-owned away launcher
-# (bin/fm-afk-launch.sh) so the captain-pane resolution has exactly one owner.
+# Operator-session and delivery-endpoint discovery. Shared with the
+# script-owned away launcher (bin/fm-afk-launch.sh) so identity resolution has
+# exactly one owner.
 # shellcheck source=bin/fm-supervisor-target-lib.sh
 . "$FM_DAEMON_DIR/fm-supervisor-target-lib.sh"
 
@@ -188,7 +188,6 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 # harness-verification discipline. Selecting one refuses loudly at startup
 # instead of silently running tmux primitives against a pane that is not a tmux
 # pane.
-FM_SUPERVISOR_SUPPORTED_BACKENDS="tmux herdr"
 INJECT_SKIP_DEFAULT="heartbeat"
 STALE_ESCALATE_SECS_DEFAULT=240
 ESCALATE_BATCH_SECS_DEFAULT=90
@@ -798,7 +797,7 @@ wedge_alarm_via_osascript() {  # <summary>
   command -v osascript >/dev/null 2>&1 || {
     log "wedge alarm: osascript not found; cannot post a macOS notification"; return 1; }
   wedge_alarm_run_bounded osascript osascript -e 'on run argv' \
-    -e 'display notification (item 1 of argv) with title "firstmate: away-mode escalations WEDGED" sound name "Basso"' \
+    -e 'display notification (item 1 of argv) with title "firstmate: away-mode alarm" sound name "Basso"' \
     -e 'end run' "$summary" >/dev/null 2>&1 && return 0
   log "wedge alarm: osascript notification failed"
   return 1
@@ -886,6 +885,35 @@ wedge_alarm_notify() {  # <summary> <marker>
   return 0
 }
 
+# Refuse an away-mode entry whose operator session has no verified injectable
+# delivery endpoint. This alarm fires before the daemon loop and does not use
+# the endpoint whose discovery failed: stderr is immediate, the marker is
+# durable, and wedge_alarm_notify uses the existing OS/herdr/command channels.
+operator_delivery_unavailable_alarm() {  # <state> <operator-identity> <backend-result> <target-result>
+  local state=$1 operator_identity=$2 backend_result=$3 target_result=$4 marker summary
+  marker="$state/.subsuper-delivery-unavailable"
+  mkdir -p "$state" 2>/dev/null || true
+  summary="away mode NOT ARMED: escalation delivery unavailable; operator_session=$operator_identity; backend=$backend_result; target=$target_result"
+  {
+    printf '%s\n' "$summary"
+    printf 'Firstmate refused to guess an operator delivery endpoint. Configure FM_SUPERVISOR_BACKEND and FM_SUPERVISOR_TARGET for a supported endpoint.\n'
+  } > "$marker" 2>/dev/null || true
+  log "ERROR: $summary; alarm marker=$marker"
+  printf 'error: %s; alarm marker=%s\n' "$summary" "$marker" >&2
+  wedge_alarm_notify "$summary" "$marker"
+}
+
+fm_super_report_delivery_unavailable() {
+  local state operator_identity backend_result target_result LOG
+  state="$(_state_root)"
+  LOG="$state/.supervise-daemon.log"
+  operator_identity="${FM_OPERATOR_SESSION_IDENTITY:-UNVERIFIED(not-provided)}"
+  backend_result="${FM_SUPERVISOR_BACKEND_DISCOVERY:-UNVERIFIED(not-provided)}"
+  target_result="${FM_SUPERVISOR_TARGET_DISCOVERY:-UNVERIFIED(not-provided)}"
+  operator_delivery_unavailable_alarm "$state" "$operator_identity" "$backend_result" "$target_result"
+  return 1
+}
+
 # Raise a loud, rate-limited alarm when escalations cannot be delivered after
 # max-defer (the supervisor pane is genuinely busy/wedged, or the submit's Enter
 # is swallowed). The daemon must NEVER silently wedge: this logs
@@ -914,13 +942,13 @@ inject_wedge_alarm() {  # <state> <age-seconds>
     printf 'The supervisor pane could not accept an escalation. Buffered items:\n'
     cat "$state/.subsuper-escalations" 2>/dev/null
   } 2>/dev/null > "$marker" || true
-  target="${FM_SUPERVISOR_TARGET:-$FM_SUPERVISOR_TARGET_DEFAULT}"
-  backend="${FM_SUPERVISOR_BACKEND:-$FM_SUPERVISOR_BACKEND_DEFAULT}"
+  target="${FM_SUPERVISOR_TARGET:-}"
+  backend="${FM_SUPERVISOR_BACKEND:-}"
   # Best-effort status-line flash. tmux's display-message is a client-side OSD
   # with no herdr equivalent; the log line + durable marker above are already
   # the primary, backend-independent signal, so a non-tmux backend just skips
   # this cosmetic extra rather than attempting an unsupported call.
-  if [ "$backend" = tmux ]; then
+  if [ "$backend" = tmux ] && [ -n "$target" ]; then
     tmux display-message -t "$target" "fm: away-mode escalations WEDGED ${age}s — see $marker" 2>/dev/null || true
   fi
   # Backend-independent active alert. Unlike the tmux flash above (skipped on
@@ -1127,13 +1155,16 @@ inject_msg() {  # <message> [state]
   msg=$(_collapse_newlines "$msg")
   fm_operational_input_encode away-supervisor "$msg" encoded || return 1
   msg=$encoded
-  target="${FM_SUPERVISOR_TARGET:-$FM_SUPERVISOR_TARGET_DEFAULT}"
+  target="${FM_SUPERVISOR_TARGET:-}"
   # BACKEND-AWARE (previously a raw `tmux display-message` pane-exists probe):
   # dispatches through bin/fm-backend.sh so a herdr supervisor pane is checked
-  # via the herdr adapter instead of always assuming tmux. Falls back to tmux
-  # when unset (sourced/test contexts that never ran fm_super_main's startup
-  # discovery), matching this function's pre-existing default assumption.
-  backend="${FM_SUPERVISOR_BACKEND:-tmux}"
+  # via the herdr adapter instead of always assuming tmux. Missing delivery
+  # identity fails closed; it is never converted into a guessed endpoint.
+  backend="${FM_SUPERVISOR_BACKEND:-}"
+  if [ -z "$target" ] || [ -z "$backend" ]; then
+    log "inject refused: supervisor delivery identity is unverified (target=${target:-UNVERIFIED}, backend=${backend:-UNVERIFIED})"
+    return 1
+  fi
   fm_backend_target_exists "$backend" "$target" || return 1
   # (3) Busy-guard: never inject into an in-use supervisor pane.
   if pane_is_busy "$target" "$backend"; then
@@ -1367,15 +1398,19 @@ fm_super_main() {
   echo "$$" > "$PIDFILE"
   fm_pid_identity "${BASHPID:-$$}" > "$LOCK/pid-identity" 2>/dev/null || true
 
+  # --- identify the operator session independently of its delivery backend --
+  local operator_identity
+  operator_identity=$(discover_operator_session_identity) || true
+
   # --- auto-discover the supervisor BACKEND (tmux vs herdr) first -----------
   # Priority: FM_SUPERVISOR_BACKEND override > $TMUX_PANE (tmux) > $HERDR_ENV=1
-  # (herdr) > tmux fallback. Resolved before the target below, since target
+  # (herdr) > explicit UNVERIFIED refusal. Resolved before the target below, since target
   # discovery composes a herdr "<session>:<pane-id>" string using the same
   # $HERDR_PANE_ID/$HERDR_SESSION markers this checks. Exporting the result
   # into FM_SUPERVISOR_BACKEND makes inject_msg/pane_is_busy/pane_input_pending
   # (which read that env var) dispatch through the right backend without an
   # extra global thread-through.
-  local discovered_backend backend_source
+  local discovered_backend backend_source backend_rc
   backend_source="FM_SUPERVISOR_BACKEND"
   if [ -z "${FM_SUPERVISOR_BACKEND:-}" ]; then
     if [ -n "${TMUX_PANE:-}" ]; then
@@ -1383,33 +1418,18 @@ fm_super_main() {
     elif [ "${HERDR_ENV:-}" = "1" ] && [ -n "${HERDR_PANE_ID:-}" ]; then
       backend_source="HERDR_ENV"
     else
-      backend_source="FALLBACK($FM_SUPERVISOR_BACKEND_DEFAULT)"
+      backend_source="UNVERIFIED"
     fi
   fi
-  discovered_backend=$(discover_supervisor_backend) || true
-  FM_SUPERVISOR_BACKEND="$discovered_backend"
-  local BACKEND="$FM_SUPERVISOR_BACKEND"
-
-  # --- refuse an unsupported supervisor backend loudly, before ever trying a
-  # tmux/herdr-specific call against it (zellij, orca, and cmux have no verified
-  # composer/busy primitives wired up for this daemon yet - AGENTS.md section 4
-  # harness-verification discipline). This is the clear refusal the task calls
-  # for, instead of a confusing "does not resolve to a tmux pane" error.
-  if ! fm_backend_list_contains "$FM_SUPERVISOR_SUPPORTED_BACKENDS" "$BACKEND"; then
-    echo "error: away-mode daemon does not support supervisor backend '$BACKEND' yet (supported: $FM_SUPERVISOR_SUPPORTED_BACKENDS); set FM_SUPERVISOR_BACKEND=tmux|herdr and FM_SUPERVISOR_TARGET to run firstmate's own pane under a supported backend" >&2
-    log "startup failed: unsupported supervisor backend '$BACKEND' (source=$backend_source)"
-    fm_lock_release "$LOCK" 2>/dev/null || true
-    rm -f "$PIDFILE" 2>/dev/null || true
-    exit 1
-  fi
+  discovered_backend=$(discover_supervisor_backend)
+  backend_rc=$?
 
   # --- auto-discover the supervisor target (the pane running firstmate) -----
   # Priority: FM_SUPERVISOR_TARGET override > $TMUX_PANE (tmux; inherited from
   # the pane that launched the daemon, normally firstmate's own) >
-  # $HERDR_PANE_ID (herdr, composed into "<session>:<pane-id>") > firstmate:0
-  # fallback. Exporting the result into FM_SUPERVISOR_TARGET makes inject_msg
-  # (which reads that env var) use the discovered pane without an extra global.
-  local discovered target_source
+  # $HERDR_PANE_ID (herdr, composed into "<session>:<pane-id>") > explicit
+  # UNVERIFIED refusal. A guessed session/window name is never returned.
+  local discovered target_source target_rc
   target_source="FM_SUPERVISOR_TARGET"
   if [ -z "${FM_SUPERVISOR_TARGET:-}" ]; then
     if [ -n "${TMUX_PANE:-}" ]; then
@@ -1417,16 +1437,36 @@ fm_super_main() {
     elif [ "${HERDR_ENV:-}" = "1" ] && [ -n "${HERDR_PANE_ID:-}" ]; then
       target_source="HERDR_ENV(HERDR_PANE_ID)"
     else
-      target_source="FALLBACK(firstmate:0)"
+      target_source="UNVERIFIED"
     fi
   fi
-  if discovered=$(discover_supervisor_target); then
-    : # resolved cleanly
-  else
-    echo "warn: could not auto-discover supervisor pane (no FM_SUPERVISOR_TARGET, TMUX_PANE, or HERDR_ENV/HERDR_PANE_ID); falling back to '$discovered' — verify this is firstmate's pane" >&2
+  discovered=$(discover_supervisor_target)
+  target_rc=$?
+
+  if [ "$backend_rc" -ne 0 ] || [ "$target_rc" -ne 0 ]; then
+    operator_delivery_unavailable_alarm "$STATE" "${operator_identity:-UNVERIFIED(operator-session-blind)}" "$discovered_backend" "$discovered"
+    fm_lock_release "$LOCK" 2>/dev/null || true
+    rm -f "$PIDFILE" 2>/dev/null || true
+    exit 1
   fi
+
+  FM_SUPERVISOR_BACKEND="$discovered_backend"
+  local BACKEND="$FM_SUPERVISOR_BACKEND"
   FM_SUPERVISOR_TARGET="$discovered"
   local TARGET="$FM_SUPERVISOR_TARGET"
+
+  # --- refuse an unsupported supervisor backend loudly, before ever trying a
+  # tmux/herdr-specific call against it (zellij, orca, and cmux have no verified
+  # composer/busy primitives wired up for this daemon yet - AGENTS.md section 4
+  # harness-verification discipline). This is the clear refusal the task calls
+  # for, instead of a confusing "does not resolve to a tmux pane" error.
+  if ! supervisor_delivery_backend_supported "$BACKEND"; then
+    log "startup failed: unsupported supervisor backend '$BACKEND' (source=$backend_source)"
+    operator_delivery_unavailable_alarm "$STATE" "${operator_identity:-UNVERIFIED(operator-session-blind)}" "UNVERIFIED(unsupported-backend:$BACKEND)" "$TARGET"
+    fm_lock_release "$LOCK" 2>/dev/null || true
+    rm -f "$PIDFILE" 2>/dev/null || true
+    exit 1
+  fi
 
   # --- validate supervisor target at startup (a missing target is a typo) ---
   # Dispatches through bin/fm-backend.sh instead of a raw `tmux display-message`
@@ -1434,8 +1474,8 @@ fm_super_main() {
   # backend=tmux this runs the exact same `tmux display-message -p -t "$TARGET"
   # '#{pane_id}'` call as before.
   if ! fm_backend_target_exists "$BACKEND" "$TARGET"; then
-    echo "error: supervisor target '$TARGET' does not resolve to a $BACKEND pane; set FM_SUPERVISOR_TARGET" >&2
     log "startup failed: target '$TARGET' not found (backend=$BACKEND)"
+    operator_delivery_unavailable_alarm "$STATE" "${operator_identity:-UNVERIFIED(operator-session-blind)}" "$BACKEND" "UNVERIFIED(target-not-found:$TARGET)"
     fm_lock_release "$LOCK" 2>/dev/null || true
     rm -f "$PIDFILE" 2>/dev/null || true
     exit 1
@@ -1562,7 +1602,10 @@ fm_super_main() {
 
 # Run only when executed, not when sourced (tests source the classifiers).
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
-  fm_super_main "$@"
+  case "${1:-}" in
+    report-delivery-unavailable) fm_super_report_delivery_unavailable ;;
+    *) fm_super_main "$@" ;;
+  esac
 else
   # Library mode: these functions were SOURCED (only tests do this - production
   # execs the daemon, see bin/fm-afk-start.sh). Make it structurally impossible

--- a/bin/fm-supervisor-target-lib.sh
+++ b/bin/fm-supervisor-target-lib.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# fm-supervisor-target-lib.sh - the single owner of supervisor-pane discovery.
+# fm-supervisor-target-lib.sh - operator-session and delivery-endpoint discovery.
 #
 # The away-mode daemon (bin/fm-supervise-daemon.sh) must know which pane runs
 # firstmate itself, both to inject escalations into it and, for the daemon, to
@@ -9,17 +9,79 @@
 # FM_SUPERVISOR_TARGET (otherwise the daemon, running in its own terminal, would
 # auto-discover its OWN pane and inject there instead of into the captain's).
 #
-# Because both callers need the identical resolution, it lives here once. The
-# function names and precedence are unchanged from when this logic lived inline
-# in bin/fm-supervise-daemon.sh, so its unit tests (tests/fm-daemon.test.sh)
-# keep exercising the same names after the daemon sources this file.
+# Because both callers need identical resolution, it lives here once.
+# Operator-session identity and escalation-delivery identity are deliberately
+# separate: a primary harness process on a plain Ghostty TTY is a real operator
+# session, but that TTY is not an addressable agent composer.
 
-# Default supervisor pane target/backend when nothing is configured or detected.
-# "firstmate:0" is a tmux session:window name, so the bare fallback (nothing
-# configured, nothing detected) assumes tmux - matching the daemon's pre-herdr
-# behavior byte-for-byte when run outside both tmux and herdr.
-FM_SUPERVISOR_TARGET_DEFAULT="firstmate:0"
-FM_SUPERVISOR_BACKEND_DEFAULT="tmux"
+FM_SUPERVISOR_TARGET_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/fm-session-lock-lib.sh
+. "$FM_SUPERVISOR_TARGET_DIR/fm-session-lock-lib.sh"
+
+supervisor_delivery_backend_supported() {  # <backend>
+  case "$1" in tmux|herdr) return 0 ;; esac
+  return 1
+}
+
+fm_supervisor_unverified() {  # <reason>
+  printf 'UNVERIFIED(%s)' "$1"
+  return 1
+}
+
+# discover_operator_session_identity: identify the primary operator session
+# without requiring tmux. A directly addressable tmux/herdr endpoint is already
+# a complete identity. Otherwise the existing per-home session lock supplies
+# the live primary-harness pid, and its controlling TTY distinguishes a Ghostty
+# terminal session from every sibling session. The harness pid remains the
+# identity if the kernel cannot expose a TTY; that field is reported explicitly
+# as unverified rather than confidently absent.
+discover_operator_session_identity() {
+  local state lock pid tty
+  if [ -n "${FM_SUPERVISOR_TARGET:-}" ] && [ -n "${FM_SUPERVISOR_BACKEND:-}" ]; then
+    printf 'backend=%s;target=%s' "$FM_SUPERVISOR_BACKEND" "$FM_SUPERVISOR_TARGET"
+    return 0
+  fi
+  if [ -n "${TMUX_PANE:-}" ]; then
+    printf 'backend=tmux;target=%s' "$TMUX_PANE"
+    return 0
+  fi
+  if [ "${HERDR_ENV:-}" = "1" ] && [ -n "${HERDR_PANE_ID:-}" ]; then
+    printf 'backend=herdr;target=%s:%s' "${HERDR_SESSION:-default}" "$HERDR_PANE_ID"
+    return 0
+  fi
+
+  if [ -n "${FM_STATE_OVERRIDE:-}" ]; then
+    state=$FM_STATE_OVERRIDE
+  elif [ -n "${FM_HOME:-}" ]; then
+    state=$FM_HOME/state
+  else
+    fm_supervisor_unverified no-state-root
+    return
+  fi
+  lock="$state/.lock"
+  if [ ! -f "$lock" ] || [ -L "$lock" ]; then
+    fm_supervisor_unverified no-regular-session-lock
+    return
+  fi
+  pid=$(cat "$lock" 2>/dev/null) || {
+    fm_supervisor_unverified unreadable-session-lock
+    return
+  }
+  case "$pid" in
+    ''|*[!0-9]*) fm_supervisor_unverified malformed-session-lock; return ;;
+  esac
+  if ! fm_harness_pid_alive "$pid"; then
+    fm_supervisor_unverified session-lock-holder-not-live-harness
+    return
+  fi
+  tty=$(ps -o tty= -p "$pid" 2>/dev/null | awk 'NR == 1 { gsub(/^[[:space:]]+|[[:space:]]+$/, ""); print; exit }')
+  case "$tty" in
+    ''|'?'|'??'|'-') tty='UNVERIFIED(no-controlling-terminal)' ;;
+    /dev/*) ;;
+    *) tty="/dev/$tty" ;;
+  esac
+  printf 'harness-pid=%s;tty=%s' "$pid" "$tty"
+}
 
 # discover_supervisor_target: resolve the pane running firstmate. Priority:
 #   1. FM_SUPERVISOR_TARGET env (explicit override) - may be a tmux target or a
@@ -33,8 +95,7 @@ FM_SUPERVISOR_BACKEND_DEFAULT="tmux"
 #      fm_backend_herdr_session) and $HERDR_PANE_ID. Checked after $TMUX_PANE so a
 #      tmux pane nested inside herdr still resolves to tmux, matching
 #      fm_backend_detect's innermost-first rule.
-#   4. FM_SUPERVISOR_TARGET_DEFAULT - legacy tmux fallback (may not resolve if the
-#      session is named differently). Returns 1 so the caller can warn.
+#   4. Explicit UNVERIFIED result. A guessed target is never returned.
 discover_supervisor_target() {
   if [ -n "${FM_SUPERVISOR_TARGET:-}" ]; then
     printf '%s' "$FM_SUPERVISOR_TARGET"
@@ -48,8 +109,7 @@ discover_supervisor_target() {
     printf '%s:%s' "${HERDR_SESSION:-default}" "$HERDR_PANE_ID"
     return 0
   fi
-  printf '%s' "$FM_SUPERVISOR_TARGET_DEFAULT"
-  return 1
+  fm_supervisor_unverified no-supported-delivery-target
 }
 
 # discover_supervisor_backend: resolve the supervisor pane's BACKEND, independent
@@ -59,7 +119,7 @@ discover_supervisor_target() {
 #   1. FM_SUPERVISOR_BACKEND env (explicit override).
 #   2. $TMUX_PANE set - tmux.
 #   3. $HERDR_ENV=1 (with $HERDR_PANE_ID present) - herdr.
-#   4. FM_SUPERVISOR_BACKEND_DEFAULT (tmux) - matches the target fallback. Returns 1.
+#   4. Explicit UNVERIFIED result. A guessed backend is never returned.
 discover_supervisor_backend() {
   if [ -n "${FM_SUPERVISOR_BACKEND:-}" ]; then
     printf '%s' "$FM_SUPERVISOR_BACKEND"
@@ -73,6 +133,5 @@ discover_supervisor_backend() {
     printf 'herdr'
     return 0
   fi
-  printf '%s' "$FM_SUPERVISOR_BACKEND_DEFAULT"
-  return 1
+  fm_supervisor_unverified no-supported-delivery-backend
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,6 +92,8 @@ Composer classification has one shared owner, `bin/fm-composer-lib.sh`: tmux, he
 The daemon injects only into an affirmatively `empty` composer, so every other or future verdict defers; positive container proof is required, and a blank unidentified row or bare dead-shell prompt cannot receive an escalation.
 The current operator boundary is in [Composer and injection safety](herdr-backend.md#composer-and-injection-safety).
 Unsupported supervisor backends refuse at daemon startup.
+Missing delivery identity refuses before away mode is armed, while the existing session lock still identifies a non-tmux operator session by live harness pid and controlling TTY.
+That refusal writes `state/.subsuper-delivery-unavailable` and uses the same pane-independent active alert as a later injection wedge.
 Stalled escalation delivery writes `state/.subsuper-inject-wedged` and attempts a configured backend-independent active alert after `FM_MAX_DEFER_SECS` instead of silently deferring forever.
 On an unmarked return, `bin/fm-afk-return.sh` owns ordered shutdown, durable catch-up evidence, and the fail-closed gate that keeps ordinary work behind every live firstmate-actionable blocker.
 `fm-send.sh` selects a pre-Enter popup-settle for slash commands and for codex `$...` skill invocations using metadata-routed target `harness=` values, then adds its own `FM_SEND_SETTLE` pause after successful text sends so immediate peeks catch the receiving turn starting; the sub-supervisor uses only the shared submit core and does not pay that post-submit pause.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,7 +111,8 @@ Selecting any other supervisor backend, including `zellij`, `orca`, or `cmux`, r
 ## Away-mode wedge alarm channels (config/wedge-alarm)
 
 When away-mode delivery identity is unavailable, or injection wedges past `FM_MAX_DEFER_SECS`, the sub-supervisor raises a loud alarm.
-Beyond the durable `state/.subsuper-inject-wedged` marker and the tmux status-line flash, it attempts a configured backend-independent active alert that can reach the captain even when every pane and its backend status-line is unreadable.
+An unavailable delivery endpoint emits an error and writes `state/.subsuper-delivery-unavailable`; a later injection wedge writes `state/.subsuper-inject-wedged` and adds a tmux status-line flash when applicable.
+Both conditions attempt a configured backend-independent active alert that can reach the captain even when every pane and its backend status-line is unreadable.
 `config/wedge-alarm` (local, gitignored) lists channel directives, one per non-empty, non-comment line; every listed non-`off` channel fires, best-effort.
 `FM_WEDGE_ALARM_CHANNEL` overrides the file with a single directive.
 Directives are `off` (a position-independent kill switch that disables every active alert), `auto`/`default`, `osascript` (macOS Notification Center banner), `herdr` (herdr UI notification), and `command:<cmd>` (run `<cmd>` via `sh -c`, summary on `$1` and stdin).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,19 +100,22 @@ Test cleanup must use the guarded path in [`docs/cmux-backend.md`](cmux-backend.
 The `/afk` sub-supervisor injects escalation digests into firstmate's own pane independently of where new task endpoints are spawned.
 It currently supports only `tmux` and `herdr` supervisor panes.
 Set `FM_SUPERVISOR_BACKEND=tmux|herdr` and `FM_SUPERVISOR_TARGET=<target>` to override both axes explicitly; for herdr the target is `"<session>:<pane-id>"`.
-Without overrides, backend detection uses `$TMUX_PANE` first, then `HERDR_ENV=1` with `HERDR_PANE_ID`, then falls back to `tmux`.
+Without overrides, backend detection uses `$TMUX_PANE` first, then `HERDR_ENV=1` with `HERDR_PANE_ID`.
 That keeps a tmux pane nested inside herdr on the tmux transport, matching the runtime backend's innermost-first rule.
-Target detection uses `FM_SUPERVISOR_TARGET`, then `$TMUX_PANE`, then `"${HERDR_SESSION:-default}:${HERDR_PANE_ID}"` under herdr, then the legacy `firstmate:0` tmux fallback with a warning.
+Target detection uses `FM_SUPERVISOR_TARGET`, then `$TMUX_PANE`, then `"${HERDR_SESSION:-default}:${HERDR_PANE_ID}"` under herdr.
+When neither delivery endpoint is available, discovery returns an explicit `UNVERIFIED(...)` result and refuses before away mode is armed.
+Operator-session identity is independent of that delivery address: a live tmux/herdr endpoint wins, otherwise the existing per-home session lock identifies the primary harness pid and its controlling TTY, including a primary running in Ghostty.
+A plain TTY is not treated as an injectable composer; when the operator session is real but no supported delivery endpoint exists, the refusal writes `state/.subsuper-delivery-unavailable` and fires the pane-independent active alert below.
 Selecting any other supervisor backend, including `zellij`, `orca`, or `cmux`, refuses at daemon startup instead of trying tmux injection primitives against a non-tmux pane.
 
 ## Away-mode wedge alarm channels (config/wedge-alarm)
 
-When away-mode injection wedges past `FM_MAX_DEFER_SECS`, the sub-supervisor raises a loud, rate-limited alarm.
+When away-mode delivery identity is unavailable, or injection wedges past `FM_MAX_DEFER_SECS`, the sub-supervisor raises a loud alarm.
 Beyond the durable `state/.subsuper-inject-wedged` marker and the tmux status-line flash, it attempts a configured backend-independent active alert that can reach the captain even when every pane and its backend status-line is unreadable.
 `config/wedge-alarm` (local, gitignored) lists channel directives, one per non-empty, non-comment line; every listed non-`off` channel fires, best-effort.
 `FM_WEDGE_ALARM_CHANNEL` overrides the file with a single directive.
 Directives are `off` (a position-independent kill switch that disables every active alert), `auto`/`default`, `osascript` (macOS Notification Center banner), `herdr` (herdr UI notification), and `command:<cmd>` (run `<cmd>` via `sh -c`, summary on `$1` and stdin).
-An absent file means `auto`, i.e. default-on on macOS: the alarm exists precisely so a wedged away-mode primary is never silent, and it fires at most once per max-defer window after a genuine wedge.
+An absent file means `auto`, i.e. default-on on macOS: an unavailable endpoint fires on the refused entry, while a genuine injection wedge fires at most once per max-defer window.
 A missing or failing channel logs and falls through to the next, never crashing the daemon.
 See [`wedge-alarm.md`](wedge-alarm.md) for the current channel reference, [`verification/supervision.md`](verification/supervision.md#wedge-alarm-channels) for active evidence, and [`examples/wedge-alarm`](examples/wedge-alarm) for a copyable config.
 
@@ -596,7 +599,7 @@ FM_SEND_SLEEP=0.4       # seconds between fm-send submit checks
 FM_SEND_SETTLE=1        # seconds fm-send waits after a successful text submit; 0 disables
 FM_PENDING_REPLY_GRACE_SECS=120   # seconds after marked-request delivery before a completed turn without a correlated parent report is eligible for its one recovery repost
 # sub-supervisor (bin/fm-supervise-daemon.sh); presence-gated via /afk
-FM_SUPERVISOR_BACKEND=             # optional supervisor pane backend override; tmux/herdr only, otherwise detects $TMUX_PANE then HERDR_ENV/HERDR_PANE_ID before tmux fallback
+FM_SUPERVISOR_BACKEND=             # optional supervisor pane backend override; tmux/herdr only, otherwise detects $TMUX_PANE then HERDR_ENV/HERDR_PANE_ID and refuses explicitly when neither exists
 FM_SUPERVISOR_TARGET=              # optional supervisor pane target override; tmux target or herdr <session>:<pane-id>, otherwise auto-detected
 FM_INJECT_SKIP=heartbeat           # |-prefixes force-self-handled bypassing classification; empty disables
 FM_ESCALATE_BATCH_SECS=90          # buffer window for batched escalation digests; 0 = flush immediately

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -372,6 +372,36 @@ tests/fm-claude-stop-autoarm.test.sh
 tests/fm-turnend-guard.test.sh
 ```
 
+## Operator-session identity and delivery refusal
+
+The non-tmux identity path was measured on 2026-08-06 with Ghostty 1.3.1 and a Claude primary whose live session-lock process had controlling TTY `ttys000`.
+
+Process evidence:
+
+```sh
+ps -o pid=,ppid=,tty=,comm= -p 16960
+ps -o pid=,ppid=,tty=,comm= -p 60454
+```
+
+Observed output:
+
+```text
+16960     1 ??       /Applications/Ghostty.app/Contents/MacOS/ghostty
+60454 58782 ttys000  claude
+```
+
+With `60454` written only to a disposable fixture's `state/.lock`, and with `FM_SUPERVISOR_TARGET`, `FM_SUPERVISOR_BACKEND`, `TMUX_PANE`, `HERDR_ENV`, and `HERDR_PANE_ID` unset, the production discovery functions returned:
+
+```text
+operator_identity rc=0 output=<harness-pid=60454;tty=/dev/ttys000>
+delivery_target rc=1 output=<UNVERIFIED(no-supported-delivery-target)>
+delivery_backend rc=1 output=<UNVERIFIED(no-supported-delivery-backend)>
+```
+
+This proves the operator session can be identified without tmux while the unsupported delivery surface still refuses honestly instead of fabricating an endpoint.
+`tests/fm-daemon.test.sh` pins that Ghostty-shaped identity result, the exact `UNVERIFIED` blind result, the refusal marker, and the independent alert firing input.
+`tests/fm-afk-launch.test.sh` pins the lifecycle boundary: missing delivery refuses before `.afk` is written, while an explicit discovered endpoint is the negative control and fires no alert.
+
 ## Wedge-alarm channels
 
 The two real notification channels were bounded manually on 2026-07-10 on macOS 26.5.2 with Herdr 0.7.3.

--- a/docs/wedge-alarm.md
+++ b/docs/wedge-alarm.md
@@ -1,10 +1,10 @@
 # Away-mode delivery alarm
 
 The away-mode sub-supervisor (`bin/fm-supervise-daemon.sh`) buffers escalations and injects them into Firstmate's own pane.
-When delivery identity cannot be verified, entry refuses and raises the alarm immediately.
+When delivery identity cannot be verified, entry refuses, emits an error, writes `state/.subsuper-delivery-unavailable`, and raises the alarm immediately.
 When injection cannot confirm a submit past `FM_MAX_DEFER_SECS`, `inject_wedge_alarm` raises the same alarm on a rate-limited cadence so the stall never stays invisible.
 The active alert is pane-independent because a tmux status-line flash has no cross-backend equivalent and cannot reach an unattended captain reliably.
-The refusal marker is `state/.subsuper-delivery-unavailable`; the wedge marker and tmux flash remain as additional signals after an established delivery path stalls.
+After an established delivery path stalls, `state/.subsuper-inject-wedged` and the tmux flash remain as additional signals.
 
 ## Channels
 

--- a/docs/wedge-alarm.md
+++ b/docs/wedge-alarm.md
@@ -1,9 +1,10 @@
-# Away-mode injection wedge alarm
+# Away-mode delivery alarm
 
 The away-mode sub-supervisor (`bin/fm-supervise-daemon.sh`) buffers escalations and injects them into Firstmate's own pane.
-When injection cannot confirm a submit past `FM_MAX_DEFER_SECS`, `inject_wedge_alarm` raises a loud, rate-limited alarm so the stall never stays invisible.
+When delivery identity cannot be verified, entry refuses and raises the alarm immediately.
+When injection cannot confirm a submit past `FM_MAX_DEFER_SECS`, `inject_wedge_alarm` raises the same alarm on a rate-limited cadence so the stall never stays invisible.
 The active alert is pane-independent because a tmux status-line flash has no cross-backend equivalent and cannot reach an unattended captain reliably.
-The durable marker and tmux flash remain as additional signals.
+The refusal marker is `state/.subsuper-delivery-unavailable`; the wedge marker and tmux flash remain as additional signals after an established delivery path stalls.
 
 ## Channels
 
@@ -19,7 +20,7 @@ It lists channel directives, one per non-empty, non-comment line, and every list
 - `command:<cmd>` runs `<cmd>` through `sh -c` with the alarm summary as `$1` and on stdin, allowing delivery to a phone or pager service.
 
 An absent `config/wedge-alarm` behaves as `auto`, which is default-on on macOS.
-This is deliberate because the alarm fires only after a genuine max-defer wedge and is rate-limited to at most once per max-defer window.
+This is deliberate because the alarm fires only for a refused away-mode entry or a genuine max-defer wedge; wedge repeats are rate-limited to at most once per max-defer window.
 
 Each channel is best-effort.
 A missing binary or non-zero exit logs a warning and continues to the next channel without crashing the daemon loop.

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -22,6 +22,7 @@ set -u
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LAUNCH="$ROOT/bin/fm-afk-launch.sh"
 START="$ROOT/bin/fm-afk-start.sh"
+export FM_WEDGE_ALARM_EXEC=discard
 
 FAILED=0
 fail() { printf 'not ok - %s\n' "$1" >&2; FAILED=1; }
@@ -41,7 +42,7 @@ GLOBAL_CLEANUP() {
 trap GLOBAL_CLEANUP EXIT
 
 # ---------------------------------------------------------------------------
-# UNIT 1: fm_afk_clear_stale_artifacts removes exactly the three stale artifacts.
+# UNIT 1: fm_afk_clear_stale_artifacts removes the session-scoped delivery artifacts.
 # ---------------------------------------------------------------------------
 unit_clear_stale() {
   local st
@@ -50,6 +51,7 @@ unit_clear_stale() {
   : > "$st/state/.subsuper-escalations"
   : > "$st/state/.subsuper-escalations.since"
   : > "$st/state/.subsuper-inject-wedged"
+  : > "$st/state/.subsuper-delivery-unavailable"
   : > "$st/state/.wake-queue"          # durable queue must be untouched
   # Source fm-afk-start.sh inside a child bash (it sets `set -eu` and would
   # otherwise leak that into this test shell) and call the clear helper.
@@ -57,7 +59,8 @@ unit_clear_stale() {
     bash -c '. "$1"; fm_afk_clear_stale_artifacts "$2"' _ "$START" "$st/state"
   if [ ! -e "$st/state/.subsuper-escalations" ] \
      && [ ! -e "$st/state/.subsuper-escalations.since" ] \
-     && [ ! -e "$st/state/.subsuper-inject-wedged" ]; then
+     && [ ! -e "$st/state/.subsuper-inject-wedged" ] \
+     && [ ! -e "$st/state/.subsuper-delivery-unavailable" ]; then
     pass "clear-stale: removes escalations buffer, sidecar, and wedge marker"
   else
     fail "clear-stale: stale artifacts survived"
@@ -488,7 +491,8 @@ unit_native_lifecycle() {
   st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-native.XXXXXX")
   mkdir -p "$st/state"
   : > "$st/state/.subsuper-escalations"
-  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" "$LAUNCH" start-native >/dev/null 2>&1 \
+  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" FM_SUPERVISOR_TARGET=test-pane \
+    FM_SUPERVISOR_BACKEND=tmux "$LAUNCH" start-native >/dev/null 2>&1 \
     && [ "$(cut -f1 "$st/state/.afk-daemon-terminal")" = none ] \
     && [ -e "$st/state/.afk" ] \
     && [ ! -e "$st/state/.subsuper-escalations" ]; then
@@ -511,7 +515,8 @@ unit_native_entry_preserves_prepared_state() {
   mkdir -p "$st/state"
   : > "$st/state/.afk"
   : > "$st/state/.subsuper-escalations"
-  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" FM_AFK_STATE_PREPARED=1 bash -c '
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" FM_SUPERVISOR_TARGET=test-pane \
+    FM_SUPERVISOR_BACKEND=tmux FM_AFK_STATE_PREPARED=1 bash -c '
     . "$1"
     FM_AFK_DAEMON=/bin/true
     fm_afk_start_main
@@ -520,6 +525,46 @@ unit_native_entry_preserves_prepared_state() {
     pass "native entry: launcher-prepared lifecycle state is not rewritten"
   else
     fail "native entry: launcher-prepared lifecycle state was mutated"
+  fi
+  rm -rf "$st"
+}
+
+unit_delivery_preflight_alarm_controls() {
+  local st recorder alerts
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-delivery-preflight.XXXXXX")
+  recorder="$st/record-alert"
+  alerts="$st/alerts"
+  # shellcheck disable=SC2016  # recorder variables expand when the fixture runs
+  printf '#!/usr/bin/env bash\nprintf "%%s\\t%%s\\n" "$1" "$2" >> "$FM_TEST_ALERTS"\n' > "$recorder"
+  chmod +x "$recorder"
+  : > "$alerts"
+
+  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" FM_WEDGE_ALARM_EXEC="$recorder" \
+    FM_WEDGE_ALARM_CHANNEL=osascript FM_TEST_ALERTS="$alerts" bash -c '
+      . "$1"
+      discover_operator_session_identity() { printf "harness-pid=4242;tty=/dev/ttys042"; }
+      discover_supervisor_target() { printf "UNVERIFIED(no-supported-delivery-target)"; return 1; }
+      discover_supervisor_backend() { printf "UNVERIFIED(no-supported-delivery-backend)"; return 1; }
+      ! fm_afk_launch_delivery_preflight
+    ' _ "$LAUNCH" \
+    && grep -F 'osascript' "$alerts" >/dev/null \
+    && grep -F 'away mode NOT ARMED' "$st/state/.subsuper-delivery-unavailable" >/dev/null \
+    && [ ! -e "$st/state/.afk" ]; then
+    pass "delivery preflight: Ghostty-shaped missing endpoint refuses before away state and fires the independent alarm"
+  else
+    fail "delivery preflight: missing endpoint did not refuse visibly before away state"
+  fi
+
+  : > "$alerts"
+  rm -f "$st/state/.subsuper-delivery-unavailable"
+  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" FM_WEDGE_ALARM_EXEC="$recorder" \
+    FM_WEDGE_ALARM_CHANNEL=osascript FM_TEST_ALERTS="$alerts" \
+    FM_SUPERVISOR_TARGET=test-pane FM_SUPERVISOR_BACKEND=tmux \
+    bash -c '. "$1"; fm_afk_launch_delivery_preflight' _ "$LAUNCH" \
+    && [ ! -s "$alerts" ] && [ ! -e "$st/state/.subsuper-delivery-unavailable" ]; then
+    pass "delivery preflight: discovered endpoint is the negative control and fires no alarm"
+  else
+    fail "delivery preflight: discovered endpoint fired or retained a false alarm"
   fi
   rm -rf "$st"
 }
@@ -759,7 +804,8 @@ unit_clear_failure_aborts_entry() {
   st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-clear-fail.XXXXXX")
   mkdir -p "$st/state"
   : > "$st/state/.subsuper-escalations"
-  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
+  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" FM_SUPERVISOR_TARGET=test-pane \
+    FM_SUPERVISOR_BACKEND=tmux bash -c '
     . "$1"
     fm_afk_launch_reconcile() { return 0; }
     fm_afk_clear_stale_artifacts() { return 1; }
@@ -812,7 +858,8 @@ unit_flag_write_failure_aborts() {
   local st
   st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-flag-fail.XXXXXX")
   mkdir -p "$st/state"
-  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" FM_SUPERVISOR_TARGET=test-pane \
+    FM_SUPERVISOR_BACKEND=tmux bash -c '
     . "$1"
     fm_afk_launch_flag_write() { return 1; }
     ! fm_afk_launch_start_native
@@ -941,6 +988,7 @@ unit_readiness_failure_preserves_unconfirmed_record
 unit_tmux_absence_distinguishes_probe_failure
 unit_native_lifecycle
 unit_native_entry_preserves_prepared_state
+unit_delivery_preflight_alarm_controls
 unit_close_failure_preserves_record
 unit_record_publication_atomic
 unit_malformed_record_fails_closed

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -21,6 +21,12 @@ if [ -z "${FM_TEST_DAEMON_SOURCED:-}" ]; then
   . "$DAEMON"
 fi
 
+# Pure injection tests do not run daemon startup discovery. Give them an
+# explicit delivery endpoint instead of relying on a production fallback.
+FM_SUPERVISOR_TARGET=test-supervisor-pane
+FM_SUPERVISOR_BACKEND=tmux
+export FM_SUPERVISOR_TARGET FM_SUPERVISOR_BACKEND
+
 TMP_ROOT=$(fm_test_tmproot fm-daemon-tests)
 FM_DAEMON_PRIMARY_HARNESS=claude
 export FM_DAEMON_PRIMARY_HARNESS
@@ -31,7 +37,7 @@ test_afk_start_refuses_when_flag_cannot_be_written() {
   state="$dir/state"
   mkdir -p "$state/.afk"
 
-  out=$(FM_STATE_OVERRIDE="$state" FM_SUPERVISOR_BACKEND=unsupported "$AFK_START" 2>&1)
+  out=$(FM_STATE_OVERRIDE="$state" FM_SUPERVISOR_BACKEND=tmux "$AFK_START" 2>&1)
   status=$?
 
   [ "$status" -ne 0 ] || fail "fm-afk-start.sh should fail when state/.afk cannot be written"
@@ -49,11 +55,11 @@ test_afk_start_ignores_stale_pidfile_without_lock() {
   out=$(FM_STATE_OVERRIDE="$state" FM_SUPERVISOR_BACKEND=unsupported "$AFK_START" 2>&1)
   status=$?
 
-  [ "$status" -ne 0 ] || fail "fm-afk-start.sh should attempt daemon startup instead of trusting a pidfile-only live pid"
-  assert_contains "$out" "starting supervise daemon" "fm-afk-start.sh did not attempt daemon startup"
-  assert_contains "$out" "does not support supervisor backend 'unsupported'" "daemon startup did not reach backend validation"
+  [ "$status" -ne 0 ] || fail "fm-afk-start.sh should attempt delivery preflight instead of trusting a pidfile-only live pid"
+  assert_contains "$out" "backend=UNVERIFIED(unsupported-delivery-backend:unsupported)" \
+    "daemon startup did not report the unsupported backend as unavailable delivery"
   assert_not_contains "$out" "daemon already running" "fm-afk-start.sh trusted a stale pidfile-only live pid"
-  pass "fm-afk-start.sh ignores stale pidfile-only live pids"
+  pass "fm-afk-start.sh ignores stale pidfile-only live pids and reaches delivery validation"
 }
 
 test_afk_start_reclaims_stale_daemon_lock_reused_pid() {
@@ -69,12 +75,33 @@ test_afk_start_reclaims_stale_daemon_lock_reused_pid() {
   out=$(FM_STATE_OVERRIDE="$state" FM_SUPERVISOR_BACKEND=unsupported "$AFK_START" 2>&1)
   status=$?
 
-  [ "$status" -ne 0 ] || fail "fm-afk-start.sh should attempt daemon startup after rejecting a reused-pid lock"
-  assert_contains "$out" "starting supervise daemon" "fm-afk-start.sh did not attempt daemon startup after rejecting the stale lock"
-  assert_contains "$out" "does not support supervisor backend 'unsupported'" "daemon startup did not reach backend validation after stale lock cleanup"
+  [ "$status" -ne 0 ] || fail "fm-afk-start.sh should attempt delivery preflight after rejecting a reused-pid lock"
+  assert_contains "$out" "backend=UNVERIFIED(unsupported-delivery-backend:unsupported)" \
+    "daemon startup did not reach delivery validation after stale lock cleanup"
   assert_not_contains "$out" "daemon already running" "fm-afk-start.sh trusted a stale daemon lock with a reused pid"
   assert_not_contains "$out" "another fm-supervise-daemon is already running" "daemon singleton lock still trusted the reused pid"
   pass "fm-afk-start.sh reclaims stale daemon locks whose live pid identity no longer matches"
+}
+
+test_afk_start_blind_delivery_alarms_before_away_state() {
+  local dir state alert out status
+  dir=$(make_supercase afk-start-blind-delivery)
+  state="$dir/state"
+  alert="$dir/alert.log"
+  : > "$alert"
+
+  out=$(FM_STATE_OVERRIDE="$state" FM_SUPERVISOR_TARGET='' FM_SUPERVISOR_BACKEND='' \
+    TMUX_PANE='' HERDR_ENV='' HERDR_PANE_ID='' FM_WEDGE_ALARM_CHANNEL=osascript \
+    FM_WEDGE_ALARM_LOG="$alert" "$AFK_START" 2>&1)
+  status=$?
+
+  [ "$status" -ne 0 ] || fail "fm-afk-start.sh should refuse blind delivery discovery"
+  [ ! -e "$state/.afk" ] || fail "fm-afk-start.sh armed away mode before delivery identity was verified"
+  assert_contains "$out" 'away mode NOT ARMED: escalation delivery unavailable' \
+    "fm-afk-start.sh blind delivery refusal was not printed"
+  assert_contains "$(cat "$alert" 2>/dev/null || true)" 'osascript' \
+    "fm-afk-start.sh blind delivery refusal did not fire the independent alarm"
+  pass "fm-afk-start.sh blind delivery refuses and alarms before away state"
 }
 
 test_daemon_state_root_uses_fm_home() {
@@ -1640,11 +1667,12 @@ test_discover_supervisor_backend_precedence() {
   [ "$out" = herdr ] || fail "HERDR_ENV=1 with HERDR_PANE_ID present should resolve to herdr: $out"
 
   if out=$(FM_SUPERVISOR_BACKEND='' TMUX_PANE='' HERDR_ENV='' HERDR_PANE_ID='' discover_supervisor_backend); then
-    fail "bare fallback (no override, no TMUX_PANE, no HERDR_ENV) should return non-zero"
+    fail "blind backend discovery should return non-zero"
   fi
-  [ "$out" = tmux ] || fail "bare fallback should still print tmux: $out"
+  [ "$out" = 'UNVERIFIED(no-supported-delivery-backend)' ] \
+    || fail "blind backend discovery did not report explicit UNVERIFIED: $out"
 
-  pass "discover_supervisor_backend: override > TMUX_PANE > HERDR_ENV+HERDR_PANE_ID > tmux fallback"
+  pass "discover_supervisor_backend: override > TMUX_PANE > HERDR_ENV+HERDR_PANE_ID > explicit UNVERIFIED"
 }
 
 test_discover_supervisor_target_herdr() {
@@ -1662,11 +1690,65 @@ test_discover_supervisor_target_herdr() {
   [ "$out" = "iso1:w1:p9" ] || fail "herdr target should use an explicit HERDR_SESSION: $out"
 
   if out=$(FM_SUPERVISOR_TARGET='' TMUX_PANE='' HERDR_ENV='' HERDR_PANE_ID='' discover_supervisor_target); then
-    fail "bare fallback should return non-zero"
+    fail "blind target discovery should return non-zero"
   fi
-  [ "$out" = "firstmate:0" ] || fail "bare fallback should still print firstmate:0: $out"
+  [ "$out" = 'UNVERIFIED(no-supported-delivery-target)' ] \
+    || fail "blind target discovery did not report explicit UNVERIFIED: $out"
 
-  pass "discover_supervisor_target: override > TMUX_PANE > herdr '<session>:<pane-id>' composition > firstmate:0 fallback"
+  pass "discover_supervisor_target: override > TMUX_PANE > herdr '<session>:<pane-id>' composition > explicit UNVERIFIED"
+}
+
+test_operator_session_identity_ghostty_lock() {
+  local dir state out
+  dir=$(make_supercase operator-ghostty-lock)
+  state="$dir/state"
+  printf '4242\n' > "$state/.lock"
+  out=$(
+    fm_harness_pid_alive() { [ "$1" = 4242 ]; }
+    ps() { printf 'ttys042\n'; }
+    FM_STATE_OVERRIDE="$state" FM_HOME='' FM_SUPERVISOR_TARGET='' FM_SUPERVISOR_BACKEND='' \
+      TMUX_PANE='' HERDR_ENV='' HERDR_PANE_ID='' TERM_PROGRAM=ghostty \
+      discover_operator_session_identity
+  )
+  [ "$out" = 'harness-pid=4242;tty=/dev/ttys042' ] \
+    || fail "Ghostty session lock did not resolve the harness pid and controlling TTY: $out"
+  pass "operator identity: Ghostty primary resolves from the live session lock and controlling TTY without tmux"
+}
+
+test_operator_session_identity_blind_is_unverified() {
+  local dir state out
+  dir=$(make_supercase operator-blind)
+  state="$dir/state"
+  if out=$(FM_STATE_OVERRIDE="$state" FM_HOME='' FM_SUPERVISOR_TARGET='' FM_SUPERVISOR_BACKEND='' \
+      TMUX_PANE='' HERDR_ENV='' HERDR_PANE_ID='' discover_operator_session_identity); then
+    fail "operator identity discovery passed without an endpoint or session lock"
+  fi
+  [ "$out" = 'UNVERIFIED(no-regular-session-lock)' ] \
+    || fail "blind operator identity did not report exact UNVERIFIED reason: $out"
+  pass "operator identity: a blind path reports UNVERIFIED rather than confidently absent"
+}
+
+test_delivery_unavailable_refusal_fires_independent_alarm() {
+  local dir state alert out rc
+  dir=$(make_supercase delivery-unavailable-alarm)
+  state="$dir/state"
+  alert="$dir/alert.log"
+  : > "$alert"
+  out=$(FM_STATE_OVERRIDE="$state" FM_OPERATOR_SESSION_IDENTITY='harness-pid=4242;tty=/dev/ttys042' \
+    FM_SUPERVISOR_BACKEND_DISCOVERY='UNVERIFIED(no-supported-delivery-backend)' \
+    FM_SUPERVISOR_TARGET_DISCOVERY='UNVERIFIED(no-supported-delivery-target)' \
+    FM_WEDGE_ALARM_CHANNEL=osascript FM_WEDGE_ALARM_LOG="$alert" \
+    "$DAEMON" report-delivery-unavailable 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "delivery-unavailable alarm mode did not refuse"
+  assert_contains "$out" 'away mode NOT ARMED: escalation delivery unavailable' \
+    "delivery-unavailable refusal was not printed independently of the pane"
+  assert_contains "$(cat "$state/.subsuper-delivery-unavailable" 2>/dev/null || true)" \
+    'operator_session=harness-pid=4242;tty=/dev/ttys042' \
+    "delivery-unavailable marker lost the operator identity"
+  assert_contains "$(cat "$alert" 2>/dev/null || true)" 'osascript' \
+    "delivery-unavailable refusal did not fire the independent alert channel"
+  pass "delivery refusal: exact Ghostty-shaped firing input writes a marker and fires the independent alert"
 }
 
 test_pane_is_busy_herdr_native_busy_state() {
@@ -1835,6 +1917,7 @@ test_inject_msg_defers_on_unrecognized_composer_state() {
 test_afk_start_refuses_when_flag_cannot_be_written
 test_afk_start_ignores_stale_pidfile_without_lock
 test_afk_start_reclaims_stale_daemon_lock_reused_pid
+test_afk_start_blind_delivery_alarms_before_away_state
 test_daemon_state_root_uses_fm_home
 test_classify_routine_signal_self
 test_classify_terminal_signal_escalates
@@ -1921,6 +2004,9 @@ test_fm_send_exits_nonzero_on_initial_send_failure
 test_fm_send_exits_nonzero_on_unproven_submit
 test_discover_supervisor_backend_precedence
 test_discover_supervisor_target_herdr
+test_operator_session_identity_ghostty_lock
+test_operator_session_identity_blind_is_unverified
+test_delivery_unavailable_refusal_fires_independent_alarm
 test_pane_is_busy_herdr_native_busy_state
 test_primary_busy_guard_is_harness_scoped
 test_pane_is_busy_defaults_to_tmux_when_backend_omitted

--- a/tests/fm-wake-daemon-lifecycle-e2e.test.sh
+++ b/tests/fm-wake-daemon-lifecycle-e2e.test.sh
@@ -110,7 +110,8 @@ test_routine_then_terminal_after_restart() {
   sent="$dir/sent.log"; : > "$sent"
   printf '❯\n' > "$dir/pane.txt"
   afk_enter "$state"
-  PATH="$fakebin:$PATH" FM_FAKE_TMUX_PANE_ALIVE=1 FM_FAKE_TMUX_SENT="$sent" \
+  PATH="$fakebin:$PATH" FM_SUPERVISOR_TARGET="test:fakepane" FM_SUPERVISOR_BACKEND=tmux \
+    FM_FAKE_TMUX_PANE_ALIVE=1 FM_FAKE_TMUX_SENT="$sent" \
     FM_FAKE_TMUX_CAPTURE="$dir/pane.txt" FM_ESCALATE_BATCH_SECS=0 escalate_flush "$state" \
     || fail "escalate_flush failed for the buffered digest"
   [ "$(grep -c '\[ENTER\]' "$sent")" -eq 1 ] || fail "buffered digest was not submitted exactly once"


### PR DESCRIPTION
## Intent

Publish the captain-approved local fix for defect A of https://github.com/kunchenguid/firstmate/issues/1506. The change must stop absent TMUX_PANE from becoming the fabricated firstmate:0 target, identify the real non-tmux Ghostty operator session from stable existing session-lock process and controlling-TTY evidence, preserve strict composer identity by refusing a plain TTY as an injectable endpoint, report blind discovery as explicit UNVERIFIED rather than confidently absent, and make refused/unavailable delivery observable through a durable marker, stderr, and an independent configured alarm path with firing and negative controls. The pull request body must reference https://github.com/kunchenguid/firstmate/issues/1506 and clearly say it fixes defect A: fabricated operator-session identity silently disabling away-mode escalation delivery. Push only to the configured coreldh/firstmate fork, open exactly one PR against kunchenguid/firstmate:main, and do not merge, self-approve, force-push, comment on the issue, or contact the maintainer.

## What Changed

- Fixes defect A: fabricated operator-session identity silently disabling away-mode escalation delivery ([#1506](https://github.com/kunchenguid/firstmate/issues/1506)).
- Refuse unverified supervisor delivery targets before arming away mode, while retaining Ghostty operator identity from the session lock and controlling TTY.
- Record and alarm on unavailable delivery, with updated lifecycle coverage and operator documentation.

## Risk Assessment

✅ Low: Captain, the change cleanly replaces the fabricated fallback with fail-closed discovery and covers the required refusal, marker, and alarm paths.

## Testing

Reviewed the target diff, ran the focused daemon and away-launch tests, and captured a direct blind-discovery CLI refusal artifact; the required fail-closed delivery path works end-to-end, while the optional Herdr topology E2E is not verifiable in this shared environment because its lab-session tripwire failed.

<details>
<summary>Evidence: Blind-delivery refusal CLI transcript</summary>

```text
command_exit=1
--- CLI output ---
error: away mode NOT ARMED: escalation delivery unavailable; operator_session=UNVERIFIED(no-regular-session-lock); backend=UNVERIFIED(no-supported-delivery-backend); target=UNVERIFIED(no-supported-delivery-target); alarm marker=/var/folders/cq/xf4qcb9j0qzc2dbh173mflbm0000gn/T/no-mistakes-evidence/01KZSWNJR03XFHAYZZX3V4JWRF/manual-command-alarm.qVMVgm/.subsuper-delivery-unavailable
--- durable marker ---
away mode NOT ARMED: escalation delivery unavailable; operator_session=UNVERIFIED(no-regular-session-lock); backend=UNVERIFIED(no-supported-delivery-backend); target=UNVERIFIED(no-supported-delivery-target)
Firstmate refused to guess an operator delivery endpoint. Configure FM_SUPERVISOR_BACKEND and FM_SUPERVISOR_TARGET for a supported endpoint.
--- configured alarm output ---
away mode NOT ARMED: escalation delivery unavailable; operator_session=UNVERIFIED(no-regular-session-lock); backend=UNVERIFIED(no-supported-delivery-backend); target=UNVERIFIED(no-supported-delivery-target)
away_flag=ABSENT
```
</details>
<details>
<summary>Evidence: Focused daemon test log</summary>

```text
ok - fm-afk-start.sh fails before daemon startup when the afk flag cannot be written
ok - fm-afk-start.sh ignores stale pidfile-only live pids and reaches delivery validation
ok - fm-afk-start.sh reclaims stale daemon locks whose live pid identity no longer matches
ok - fm-afk-start.sh blind delivery refuses and alarms before away state
ok - supervise daemon state root is scoped by FM_HOME
ok - routine signal self-handles
ok - captain-relevant status verbs escalate
ok - check + unknown escalate; heartbeat self-handles
ok - transient stale self-handles and records a persistence marker
ok - enriched stale wedges bypass status absorption without disturbing busy workers
ok - stale + terminal status escalates immediately
ok - paused reasons with captain phrases remain pause-classified
ok - handle_wake on a paused stale records a pause marker, drops the wedge marker, and does not escalate
ok - handle_wake records a declared pause from a routine signal for long-cadence rechecks
ok - a terminal signal clears pause and stale tracking across both supervisors
ok - housekeeping migrates a normal-watcher's declared pause into daemon tracking
ok - housekeeping clears an already-resumed watcher pause across both supervisors
ok - housekeeping seeds pause tracking from status without a watcher marker
ok - persistent stale escalates after threshold and clears its marker
ok - resumed (busy) stale clears its marker without escalating
ok - housekeeping re-surfaces a stale declared pause on the long cadence and resets its window
ok - housekeeping clears a paused marker whose pane became busy again, without escalating
ok - housekeeping clears a paused marker once the crew is no longer declaring the pause
ok - housekeeping moves an existing stale marker to pause before wedge escalation
ok - housekeeping clears tracking when a crew leaves pause
ok - persistent herdr stale resolves the target from metadata and escalates
ok - herdr idle busy-footer stale clears through capture corroboration
ok - resumed herdr stale clears through backend-aware busy state
ok - persistent Orca stale resolves the terminal from metadata
ok - multiple escalations flush as a single batched digest
ok - batch flush measures max-delay from the first append, not the last
ok - catch-all scan escalates a missed terminal once, not twice
ok - handle_wake routes routine->self and captain->escalate
ok - INJECT_SKIP forces self-handle, bypassing captain-relevant classification
ok - is_wake_reason distinguishes watcher wake reasons from singleton-status stdout
ok - terminal-stale escalate removes its marker so housekeeping does not re-escalate
ok - captain signal escalate marks seen so the catch-all scan does not re-fire
ok - _collapse_newlines replaces newlines with literal separator
ok - afk flag absent: daemon does not inject, buffer preserved
ok - busy-guard defers injection when supervisor pane is busy
ok - marker detection: marker -> stay afk, no marker -> exit afk
ok - /afk invocation is exempt from afk exit (no self-cancel)
ok - should_exit_afk returns false when afk is not active
ok - strip_injection_marker removes the sentinel marker cleanly
ok - pane_input_pending detects partial input on the cursor line
ok - pane_input_pending: a blank unidentified cursor row defers (strict container-proof rule)
ok - pane_input_pending: only proven empty agent prompts pass
ok - fm_tmux_composer_state: a bare shell prompt ($/%/#/>) reads unknown, never empty (dead-shell injection safety)
ok - fm_tmux_composer_state: a bordered composer box and bare agent glyphs (❯/›) still read empty
ok - fm_tmux_composer_state: only matching edge borders form a composer box
ok - pane_input_pending preserves bright placeholder-like drafts in styled captures
ok - classify_signal dedupes against the catch-all scan seen marker
ok - classify_stale dedupes against the signal path seen marker
ok - AFK nonterminal working:+merged keeps wedge aging and re-escalates at bound
ok - genuine done: and merge-check events still escalate
ok - pane_input_pending: an idle bordered composer is NOT pending (afk-invx-i5)
ok - pane_input_pending: text inside a bordered composer is still pending
ok - submit-ACK confirms a submit when the composer returns to a bordered-empty box
ok - submit-ACK reports pending on a persistently swallowed Enter (type-once)
ok - max-defer on an empty stuck pane types once, alarms, and preserves the buffer
ok - max-defer flushes and clears the buffer on an empty bordered pane
ok - max-defer on a pending composer alarms without typing
ok - normal flush clears a stale wedge marker
ok - below MAX_DEFER: no inject, no alarm, buffer preserved
ok - max-defer does not flush or alarm while afk is inactive
ok - library mode: sourcing the daemon defaults FM_WEDGE_ALARM_EXEC to discard (no test can fire a real notification)
ok - wake helpers replace inherited notifier overrides with the safe recorder
ok - the discard seam suppresses every notifier, including command: (fires nothing)
ok - direct notifier helpers honor the discard seam, including command:
ok - osascript channel routes through the notifier seam with the summary (never a real notification)
ok - herdr channel routes through the notifier seam with the summary (never a real notification)
ok - command channel runs the captain command with the summary on $1 and on stdin
ok - command channel failures redact configured commands while logging their exit status
ok - unknown channel directives are redacted while the alarm keeps running
ok - off disables every active alert regardless of directive position (marker and tmux flash are unaffected)
ok - auto resolves to the macOS osascript notifier on Darwin (default-on)
ok - auto on a non-macOS platform selects no built-in OS channel (the marker or a configured command carries it)
ok - config/wedge-alarm selects every configured channel and skips comment and blank lines
ok - a failing channel logs and falls back to the next channel, never crashing the alarm
ok - a hung notifier is bounded, logged, and falls through to the next channel
ok - a backgrounded command notifier remains bounded until its process group is reaped
ok - a hung notifier override is bounded, logged, and proceeds to the next channel
/Users/admin/.no-mistakes/worktrees/aa652f3359ba/01KZSWNJR03XFHAYZZX3V4JWRF/bin/fm-supervise-daemon.sh: line 752: 39373 Terminated: 15          sh -c 'sleep 30 & printf "%s" "$!" > "$1"; wait' sh "$child_file"
ok - daemon shutdown stops and reaps the active notifier process group
ok - inject_wedge_alarm writes the marker AND emits the active alert even with no tmux status-line (herdr backend)
ok - in-process wedge throttle prevents alert spam when the marker cannot persist
ok - fm-send exits non-zero on a confirmed swallow, zero on a clean submit
ok - fm-send exits non-zero when initial text send fails
ok - fm-send exits non-zero unless delivery is proven empty
ok - discover_supervisor_backend: override > TMUX_PANE > HERDR_ENV+HERDR_PANE_ID > explicit UNVERIFIED
ok - discover_supervisor_target: override > TMUX_PANE > herdr '<session>:<pane-id>' composition > explicit UNVERIFIED
ok - operator identity: Ghostty primary resolves from the live session lock and controlling TTY without tmux
ok - operator identity: a blind path reports UNVERIFIED rather than confidently absent
ok - delivery refusal: exact Ghostty-shaped firing input writes a marker and fires the independent alert
ok - pane_is_busy: herdr native busy_state='busy' short-circuits without a capture fallback
ok - primary busy guard isolates rendered signatures by detected harness
ok - pane_is_busy: omitted backend defaults to tmux for Grok's isolated fallback
ok - pane_input_pending: dispatches through fm_backend_composer_state for backend=herdr
ok - inject_msg: herdr busy-guard defers before ever attempting a submit
ok - inject_msg: herdr composer-guard defers before ever attempting a submit
ok - inject_msg: herdr pane-gone check defers before any busy/composer/submit call
ok - inject_msg: dispatches busy-guard/composer-guard/submit through the herdr backend and succeeds on a confirmed empty composer
ok - inject_msg: defers on a dead-shell/unreadable composer (unknown), never typing the escalation into a shell
ok - inject_msg: unrecognized composer states defer by default
```
</details>
<details>
<summary>Evidence: Focused launcher test log</summary>

```text
ok - clear-stale: removes escalations buffer, sidecar, and wedge marker
ok - clear-stale: leaves the durable wake-queue intact (no pending work dropped)
ok - launcher paths: relative home and state ignore CDPATH before daemon command construction
ok - launcher paths: absolute symlink spellings are preserved
ok - launcher paths: unresolved relative FM_HOME fails loudly
ok - launcher paths: unresolved relative FM_STATE_OVERRIDE fails loudly
ok - refresh: daemon already alive - stale artifacts preserved (current session's buffer kept)
ok - stop-ordering: daemon SIGTERM'd while .afk still present (flush is not a no-op)
ok - stop-ordering: .afk cleared last
ok - stop-ordering: daemon-terminal record removed
ok - stop identity: stale lock cannot signal an unrelated live process
ok - failed start: away flag and delivery artifacts roll back
ok - concurrent start: one serialized daemon terminal remains tracked
ok - launcher lock: incomplete publication receives initialization grace
ok - launcher signal: TERM exits and releases the lifecycle lock
fm-afk-launch: daemon launched in non-visible herdr workspace ws-partial (pane lab:pane-exact), supervising lab:captain
ok - herdr create: malformed response recovers durable exact ownership
fm-afk-launch: herdr create failed after returning exact ids; closing lab:pane-exact
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - herdr create error: unconfirmed exact id is persisted for reconciliation
fm-afk-launch: failed to run daemon in herdr pane lab:pane-exact; closing it
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - herdr run failure: unconfirmed exact id remains reconcilable
fm-afk-launch: failed to persist daemon terminal record; closing tmux:exact-session
ok - record failure: newly created terminal is closed by exact id
fm-afk-launch: daemon did not become ready; closing tmux:exact-session
ok - readiness failure: exact terminal and durable record roll back
fm-afk-launch: daemon did not become ready; closing tmux:exact-session
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - readiness failure: unconfirmed terminal retains its reconciliation id
ok - tmux absence: clean missing differs from transport probe failure
ok - native lifecycle: launcher owns state with no terminal
ok - native lifecycle: uniform stop clears state without closing a terminal
ok - native entry: launcher-prepared lifecycle state is not rewritten
error: away mode NOT ARMED: escalation delivery unavailable; operator_session=harness-pid=4242;tty=/dev/ttys042; backend=UNVERIFIED(no-supported-delivery-backend); target=UNVERIFIED(no-supported-delivery-target); alarm marker=/var/folders/cq/xf4qcb9j0qzc2dbh173mflbm0000gn/T//fm-afk-delivery-preflight.223Lmt/state/.subsuper-delivery-unavailable
ok - delivery preflight: Ghostty-shaped missing endpoint refuses before away state and fires the independent alarm
ok - delivery preflight: discovered endpoint is the negative control and fires no alarm
fm-afk-launch: reconciling leaked daemon terminal tmux:exact-session
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - teardown failure: exact terminal record is preserved
ok - record publication: failed atomic rename preserves the complete prior record
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
ok - record read: malformed record fails closed without acting on a partial id
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
fm-afk-launch: malformed daemon terminal record; refusing to stop away mode
ok - stop: malformed terminal record preserves away state and fails closed
fm-afk-launch: failed to create detached tmux daemon session 'fm-afk-daemon-4081440915-81743-24273-1786501997'
ok - tmux launch: planned exact target is recorded before creation and removed on failure
fm-afk-launch: failed to create detached tmux daemon session 'fm-afk-daemon-1523449970-81843-4168-1786501998'
ok - tmux launch: unique names eliminate collision teardown
ok - stop validation: malformed record causes no daemon or state side effects
ok - launcher lock: incomplete metadata fails acquisition and releases lock
fm-afk-launch: failed to clear away-mode flag
fm-afk-launch: away mode stopped; terminal teardown remains recorded for retry
ok - stop state: away-flag removal failure is surfaced
fm-afk-launch: away-mode daemon did not exit after SIGTERM; preserving lifecycle state
ok - stop liveness: captured live daemon preserves lifecycle state after lock release
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
ok - refresh record: malformed terminal identity fails closed
fm-afk-launch: failed to clear stale away-mode artifacts
ok - clear failure: native entry aborts and restores prior state
fm-afk-launch: reconciling leaked daemon terminal tmux:exact-session
fm-afk-launch: terminal close command failed, but exact absence was confirmed
ok - confirmed absence: cleanup succeeds and removes the stale record
fm-afk-launch: rollback restoration incomplete; backup retained at /var/folders/cq/xf4qcb9j0qzc2dbh173mflbm0000gn/T//fm-afk-restore-fail.mVdBEQ/state/.afk-launch-backup.3gkK1N
ok - rollback restore: incomplete restoration retains its recovery backup
ok - flag failure: lifecycle aborts without active state
fm-herdr-lab: fleet-state tripwire requires exactly one running default session
not ok - herdr e2e: could not prepare isolated lab session
ok - tmux e2e: captain window pane count unchanged after start (no split-window)
ok - tmux e2e: daemon launched in a separate detached session
ok - tmux e2e: captain window pane count unchanged after stop
ok - tmux e2e: daemon session killed by exact id on stop
ok - tmux e2e: record + .afk cleared on stop
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (6m55s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `tests/fm-afk-launch.test.sh` - The optional Herdr topology E2E could not prepare its isolated lab because the shared Herdr environment failed its required default-session tripwire. The tmux topology E2E and the targeted Ghostty-shaped delivery-preflight controls completed; this worktree-local test phase cannot safely alter shared Herdr state.
- <code>`git diff --stat b5d430d6fdcd961ce9b681bf196f365c1825c284 cb8711e4bc5397a21b1a993e0c33e1af6f38f7f2` and targeted source/test inspection</code>
- <code>`bash tests/fm-daemon.test.sh` (focused supervisor discovery, Ghostty lock/TTY identity, strict composer refusal, delivery-unavailable marker/alarm controls)</code>
- <code>`bash tests/fm-afk-launch.test.sh` (focused launch preflight firing and negative controls; tmux topology E2E)</code>
- <code>Direct end-user CLI check: `bin/fm-afk-start.sh` with TMUX/Herdr and supervisor overrides empty plus a configured command alarm; captured refusal, durable marker, alarm output, and absent away flag</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
