### PR TITLE
feat(skills): add durable cross-harness handoff recovery skill

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -213,6 +213,7 @@ A `$<skill>` invocation opens a `$`-autocomplete (skill) popup, the same hazard 
 That scope matters because, unlike `/`, a leading `$` commonly starts ordinary text (`$5/month`, `$HOME`), so a universal `$` rule would needlessly slow plain steers to claude/opencode/pi; only a codex target receiving a `$...` message gets the popup-settle.
 An explicit `session:window` target has no meta, so its harness is unknown and treated as non-codex (the safe fast-path default).
 This is why the validation trigger (`$no-mistakes`) to a codex crew now lands on the first Enter instead of biting the popup.
+Firstmate's project-local skills resolve for codex directly from `.agents/skills/`, with no `.codex/skills` copy, and claude reaches that same source through the `.claude/skills` symlink ([`docs/verification/runtime-backends.md`](../../../docs/verification/runtime-backends.md) owns the dated probe).
 
 Directory trust dialog on first run per repo root: "Do you trust the contents of this directory?"
 Accept with Enter.

--- a/.agents/skills/harness-handoff/SKILL.md
+++ b/.agents/skills/harness-handoff/SKILL.md
@@ -37,16 +37,16 @@ A provider-window death does not prove that every lane on that provider died.
 It also does not stop workers on the other provider.
 The primary may be gone while workers and pipeline processes continue unsupervised, so classify each task independently.
 
+- `fine` means its worker endpoint and authoritative pipeline state remain healthy and the task still has supervision.
+- `unsupervised` means work remains live or an authoritative pipeline run remains active, but the primary that owned supervision disappeared.
+- `dead` means durable endpoint inspection proves the agent is gone, or the authoritative run ended because its selected provider became unavailable.
+- `unknown` remains unknown and authorizes inspection only, never relaunch or teardown.
+
 Treat the no-mistakes gate agent as a separate provider axis from the worker harness.
 On this installation, `~/.no-mistakes/config.yaml` line 10 sets `agent: claude`, so review, test, document, and later gate agents consume Claude even when the task worker runs on Codex.
 That same setting supports `agent: codex` or an ordered fallback list such as `agent: [codex, claude]`.
 Read the current config during recovery and record its selected gate agent in the packet; never infer pipeline-provider consumption from the worker harness.
 Do not change the global no-mistakes config as part of a handoff, because it affects other live lanes and remains the captain's decision.
-
-- `fine` means its worker endpoint and authoritative pipeline state remain healthy and the task still has supervision.
-- `unsupervised` means work remains live or an authoritative pipeline run remains active, but the primary that owned supervision disappeared.
-- `dead` means durable endpoint inspection proves the agent is gone, or the authoritative run ended because its selected provider became unavailable.
-- `unknown` remains unknown and authorizes inspection only, never relaunch or teardown.
 
 ## Build one durable recovery packet per task
 

--- a/.agents/skills/harness-handoff/SKILL.md
+++ b/.agents/skills/harness-handoff/SKILL.md
@@ -52,11 +52,16 @@ Write the completed packet to `data/<task-id>/harness-handoff.md` so another col
 task_id=<task-id>
 fm_home=<absolute-firstmate-home>
 meta="$fm_home/state/$task_id.meta"
+worktree=$(sed -n 's/^worktree=//p' "$meta" | head -1)
+[ -n "$worktree" ] || { echo "no recorded worktree for $task_id; stop and escalate" >&2; exit 1; }
 
 sed -n '1,240p' "$meta"
 sed -n '1,260p' "$fm_home/state/$task_id.status"
 FM_HOME="$fm_home" bin/fm-crew-state.sh "$task_id"
 ```
+
+Derive `$worktree` from the meta and refuse to continue while it is empty.
+`git -C ""` silently runs in the current directory instead of failing, so an unset worktree records whatever repository you happen to be standing in as this task's durable evidence.
 
 Take the worktree, project, harness, backend, kind, delivery mode, yolo posture, and endpoint only from `state/<id>.meta`.
 Treat `state/<id>.status` as an event log, not current-state truth.
@@ -67,11 +72,13 @@ Prove the local copy without changing it:
 ```sh
 git -C "$worktree" status --short
 git -C "$worktree" rev-parse HEAD
-git -C "$worktree" rev-parse --abbrev-ref HEAD
+git -C "$worktree" symbolic-ref --quiet --short HEAD
 git -C "$worktree" branch --contains HEAD
 ```
 
-An empty branch name means detached HEAD, not lost work.
+Empty output from `symbolic-ref --quiet --short HEAD` means detached HEAD, not lost work.
+Do not read detachment from `rev-parse --abbrev-ref HEAD`, which prints the literal string `HEAD` at a detached head and never prints an empty name.
+`git branch --contains HEAD` lists a detached head as the placeholder row `* (no branch)`; record the real branch rows and never that placeholder.
 Record every branch that contains the commit and do not move HEAD while reconstructing.
 Record every uncommitted file from `git status`; uncommitted work must remain in place.
 
@@ -82,20 +89,35 @@ For a no-mistakes task, inspect the run named by durable records from the record
 (cd "$worktree" && no-mistakes axi status --run <run-id>)
 ```
 
+Bare `no-mistakes axi` reports the active-or-most-recent run for the current branch when one exists, and otherwise displays some other branch's run purely as informational output.
+Before recording custody, confirm that the displayed run's branch and head match this worktree's branch and HEAD.
+When they do not match, attribute by branch from the repository-wide listing instead:
+
+```sh
+(cd "$worktree" && no-mistakes runs)
+```
+
+A run you cannot positively attribute to this worktree's branch and head is not this task's run.
+Record `unknown` for pipeline custody rather than supervising, resuming, or acting on another task's run.
+
 Record the run id, outcome, submitted head, current pipeline head, pushed head, and the complete `branch_sync.next_action` object.
-An active run matched to the branch remains authoritative even when the worker endpoint is dead.
+An active run positively attributed to this worktree's branch remains authoritative even when the worker endpoint is dead.
 Do not create a duplicate run or act on custody until structured status tells you the next action.
 
 When status names a preserved or current pipeline head, prove that it is a real commit object in the gate repository before trusting recovery:
 
 ```sh
-gate_repo="$HOME/.no-mistakes/repos/<repo-hash>.git"
+gate_repo=$(git -C "$worktree" remote get-url no-mistakes)
 preserved_head=<full-object-id>
 git --git-dir="$gate_repo" cat-file -e "$preserved_head^{commit}"
 git --git-dir="$gate_repo" cat-file -t "$preserved_head"
 ```
 
-A recorded head whose `cat-file -e` check fails is the known phantom-custody class tracked by `fm-nomistakes-phantom-custody`.
+Derive the gate repository from the worktree's `no-mistakes` remote rather than guessing a directory hash, because a machine holds one gate repository per registered project and the wrong one fails every object check.
+When `remote get-url no-mistakes` itself fails, the worktree is not gate-registered; that is a registration gap, and `cat-file` proves nothing until you hold the correct repository.
+Resolve the repository before classifying anything, because a failed check in the wrong repository looks exactly like a missing object.
+
+A recorded head whose `cat-file -e` check fails in the correctly derived gate repository is the known phantom-custody class tracked by `fm-nomistakes-phantom-custody`.
 Do not run custody recovery, invent the object, or treat the record as preserved work.
 Leave the branch, worktree, run, and gate records intact and escalate the blocked recovery with the exact missing object id.
 

--- a/.agents/skills/harness-handoff/SKILL.md
+++ b/.agents/skills/harness-handoff/SKILL.md
@@ -58,11 +58,11 @@ Write the completed packet to `data/<task-id>/harness-handoff.md` so another col
 task_id=<task-id>
 fm_home=<absolute-firstmate-home>
 meta="$fm_home/state/$task_id.meta"
-worktree=$(sed -n 's/^worktree=//p' "$meta" | head -1)
+worktree=$(sed -n 's/^worktree=//p' "$meta" | tail -1)
 [ -n "$worktree" ] || { echo "no recorded worktree for $task_id; stop and escalate" >&2; exit 1; }
 
-sed -n '1,240p' "$meta"
-sed -n '1,260p' "$fm_home/state/$task_id.status"
+tail -n 240 "$meta"
+tail -n 260 "$fm_home/state/$task_id.status"
 FM_HOME="$fm_home" bin/fm-crew-state.sh "$task_id"
 ```
 

--- a/.agents/skills/harness-handoff/SKILL.md
+++ b/.agents/skills/harness-handoff/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: harness-handoff
+description: >-
+  Agent-only recovery procedure for a Claude or Codex usage-window death, a primary supervisor disappearing mid-flight, or an intentional cross-harness transfer of in-flight Firstmate work.
+  Use when a provider window expires or is about to expire, when several lanes lose supervision together, or before moving an active task between Claude and Codex because of capacity.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# harness-handoff
+
+Reconstruct the handoff entirely from durable records.
+Never use conversation memory as evidence, because the lost conversation is the failure this procedure exists to survive.
+
+Load [`harness-adapters`](../harness-adapters/SKILL.md) before any spawn, recovery, skill invocation, interrupt, exit, or resume operation.
+Use [`stuck-crewmate-recovery`](../stuck-crewmate-recovery/SKILL.md) for an isolated stale or missing ordinary direct report whose failure is not a provider-window event.
+Use [`secondmate-provisioning`](../secondmate-provisioning/SKILL.md) instead for a secondmate.
+
+Keep these companion backlog items as separate owners rather than absorbing their contracts here:
+
+- `fm-usage-window-resume` owns the future one-command mechanical recovery.
+- `fm-brief-harness-neutral` owns removing old-harness assumptions from generated briefs.
+- `fm-brief-compaction-note` owns the worker-side durable instruction note that becomes handoff input.
+
+## Recover the supervisor first
+
+When the expired window belonged to firstmate itself, start a fresh firstmate on the other available harness and treat it as a cold start with no conversation history.
+
+1. Confirm that the complete session-start digest is present, and run `bin/fm-session-start.sh` exactly once only when the harness did not already run it.
+2. Stop in read-only mode if the session lock is refused.
+3. Treat the wake queue, open decisions, task metadata, status-event tails, backend endpoint inventory, and context digest as the starting fleet record.
+4. Reconcile each affected direct report with `bin/fm-crew-state.sh <task-id>` before acting.
+5. Resume supervision with the protocol emitted for the new primary harness, never the protocol remembered from the expired one.
+
+A provider-window death does not prove that every lane on that provider died.
+It also does not stop workers on the other provider.
+The primary may be gone while workers and pipeline processes continue unsupervised, so classify each task independently.
+
+- `fine` means its worker endpoint and authoritative pipeline state remain healthy and the task still has supervision.
+- `unsupervised` means work remains live or an authoritative pipeline run remains active, but the primary that owned supervision disappeared.
+- `dead` means durable endpoint inspection proves the agent is gone, or the authoritative run ended because its selected provider became unavailable.
+- `unknown` remains unknown and authorizes inspection only, never relaunch or teardown.
+
+## Build one durable recovery packet per task
+
+Read the task's exact records rather than bulk-scanning unrelated tasks.
+Use the active firstmate home explicitly when commands require it.
+Write the completed packet to `data/<task-id>/harness-handoff.md` so another cold-start supervisor can recover the same evidence without reconstructing it again.
+
+```sh
+task_id=<task-id>
+fm_home=<absolute-firstmate-home>
+meta="$fm_home/state/$task_id.meta"
+
+sed -n '1,240p' "$meta"
+sed -n '1,260p' "$fm_home/state/$task_id.status"
+FM_HOME="$fm_home" bin/fm-crew-state.sh "$task_id"
+```
+
+Take the worktree, project, harness, backend, kind, delivery mode, yolo posture, and endpoint only from `state/<id>.meta`.
+Treat `state/<id>.status` as an event log, not current-state truth.
+Read `data/<id>/brief.md` for the durable task instruction and any recorded progress note.
+
+Prove the local copy without changing it:
+
+```sh
+git -C "$worktree" status --short
+git -C "$worktree" rev-parse HEAD
+git -C "$worktree" rev-parse --abbrev-ref HEAD
+git -C "$worktree" branch --contains HEAD
+```
+
+An empty branch name means detached HEAD, not lost work.
+Record every branch that contains the commit and do not move HEAD while reconstructing.
+Record every uncommitted file from `git status`; uncommitted work must remain in place.
+
+For a no-mistakes task, inspect the run named by durable records from the recorded worktree:
+
+```sh
+(cd "$worktree" && no-mistakes axi)
+(cd "$worktree" && no-mistakes axi status --run <run-id>)
+```
+
+Record the run id, outcome, submitted head, current pipeline head, pushed head, and the complete `branch_sync.next_action` object.
+An active run matched to the branch remains authoritative even when the worker endpoint is dead.
+Do not create a duplicate run or act on custody until structured status tells you the next action.
+
+When status names a preserved or current pipeline head, prove that it is a real commit object in the gate repository before trusting recovery:
+
+```sh
+gate_repo="$HOME/.no-mistakes/repos/<repo-hash>.git"
+preserved_head=<full-object-id>
+git --git-dir="$gate_repo" cat-file -e "$preserved_head^{commit}"
+git --git-dir="$gate_repo" cat-file -t "$preserved_head"
+```
+
+A recorded head whose `cat-file -e` check fails is the known phantom-custody class tracked by `fm-nomistakes-phantom-custody`.
+Do not run custody recovery, invent the object, or treat the record as preserved work.
+Leave the branch, worktree, run, and gate records intact and escalate the blocked recovery with the exact missing object id.
+
+Complete the packet with only durable facts:
+
+- Task identity, project, worktree, recorded endpoint, old harness, backend, kind, mode, and yolo posture.
+- Current branch or detached commit, full HEAD, containing branches, and the exact dirty-file summary.
+- Pipeline run id and outcome, all recorded heads, `branch_sync.next_action`, and the successful or failed `cat-file` proof.
+- PR number and state when one exists.
+- Still-open decisions and already-recorded resolutions from the status log and brief.
+- One exact next action that follows the current structured state.
+
+If a fact is absent from those records, write `unknown` in the packet.
+Never fill the gap from the expired conversation.
+
+## Choose the least invasive recovery
+
+1. Keep supervising an active authoritative pipeline run instead of spawning another worker or run.
+2. Keep a healthy worker running when only supervision lapsed.
+3. For a live, positively attributed endpoint that needs a harness change, use `bin/fm-control.sh <task-id> relaunch --harness <target> --note-file <packet>`.
+4. For a positively agent-free endpoint that is still present and sitting in the recorded worktree, add the packet to the task brief, then use `bin/fm-spawn.sh <task-id> --relaunch --harness <target>` only when the control-plane transaction has already stopped the old agent or the operator is deliberately relaunching an already-stopped task.
+5. Use the fresh-spawn fallback below only when the recorded endpoint is gone or the preserved endpoint cannot launch from the recorded worktree.
+
+`bin/fm-control.sh relaunch` deliberately refuses when the recorded endpoint is gone because there is no agent it can stop.
+Its launch half also refuses when the endpoint shell is not sitting in the recorded worktree.
+These refusals both occurred in the 2026-08-11 incident and are safety boundaries, not instructions to force the control plane.
+
+After either refusal, first prove that no live agent owns the task and that the recorded worktree still exists with the same physical path, HEAD, containing branches, and dirty state captured in the packet.
+Append the packet to `data/<task-id>/brief.md` under a clearly labeled harness-handoff heading so the replacement is guaranteed to read it.
+Then use a normal `bin/fm-spawn.sh <task-id> <project>` invocation with the existing task id, recorded task kind and delivery posture, and explicit target harness.
+For a ship task, pass the recorded `--mode` and `--yolo`; for a scout, pass `--scout`.
+Read current `bin/fm-spawn.sh --help` before composing the invocation because that executable owns the exact flags.
+
+The normal spawn path creates a replacement endpoint and, in the incident this skill codifies, reused the existing task worktree for the same task id.
+Immediately verify that the newly recorded physical worktree equals the packet's worktree and that exactly one live agent owns the task before sending any follow-up.
+If the path differs, the endpoint is ambiguous, or another agent may still be live, stop and preserve both copies without teardown.
+
+Never use `--force`, discard a dirty worktree, delete an endpoint to make a check pass, tear down unlanded work, or bypass a lifecycle refusal.
+
+## Translate the handoff across harnesses
+
+[`harness-adapters`](../harness-adapters/SKILL.md) remains the owner of current adapter behavior.
+Apply these handoff-critical differences explicitly:
+
+| Concern | Claude | Codex |
+|---|---|---|
+| Skill invocation | `/<skill>`, such as `/no-mistakes` | `$<skill>`, such as `$no-mistakes` |
+| Busy-state trust | Verified semantic lifecycle hooks | Unverified, so peek the endpoint and inspect the authoritative run instead of trusting a busy verdict |
+| Primary supervision | Use the Claude protocol emitted at session start | Use the Codex protocol emitted at session start |
+
+Inspect the brief and packet for an instruction that assumed the old harness, including skill syntax, lifecycle keys, hook paths, or a harness-private session command.
+Translate only that instruction into the target harness's current form.
+Do not rewrite task intent, prior decisions, or delivery posture during the transfer.
+Do not carry a provider-specific model name to the other harness; resolve the target harness, model, and effort through the normal dispatch rules.
+
+## Finish the handoff
+
+The handoff is complete only when all of these are true:
+
+1. Every affected task is classified from current durable evidence.
+2. Every local branch, commit, uncommitted change, pipeline head, open decision, and PR is accounted for.
+3. Every preserved pipeline head used for recovery passed `cat-file -e` in the correct gate repository.
+4. Exactly one worker owns each resumed task, and its recorded worktree matches the recovery packet.
+5. The replacement worker received the durable packet, and the fresh primary resumed the supervision protocol for its own harness.
+
+Leave blocked and ambiguous tasks intact with their exact evidence.
+Recovery preserves work; it never destroys evidence to make the fleet look healthy.

--- a/.agents/skills/harness-handoff/SKILL.md
+++ b/.agents/skills/harness-handoff/SKILL.md
@@ -146,21 +146,41 @@ Never fill the gap from the expired conversation.
 2. Keep a healthy worker running when only supervision lapsed.
 3. For a live, positively attributed endpoint that needs a harness change, use `bin/fm-control.sh <task-id> relaunch --harness <target> --note-file <packet>`.
 4. For a positively agent-free endpoint that is still present and sitting in the recorded worktree, add the packet to the task brief, then use `bin/fm-spawn.sh <task-id> --relaunch --harness <target>` only when the control-plane transaction has already stopped the old agent or the operator is deliberately relaunching an already-stopped task.
-5. Use the fresh-spawn fallback below only when the recorded endpoint is gone or the preserved endpoint cannot launch from the recorded worktree.
+5. When the recorded endpoint is gone, or the preserved endpoint cannot launch from the recorded worktree, stop and escalate to firstmate with the packet; this procedure has no blessed fresh-spawn fallback.
+
+`--relaunch` is the only spawn form this procedure authorizes against a recorded worktree, because it is the form that skips the base refresh described below.
 
 `bin/fm-control.sh relaunch` deliberately refuses when the recorded endpoint is gone because there is no agent it can stop.
 Its launch half also refuses when the endpoint shell is not sitting in the recorded worktree.
 These refusals both occurred in the 2026-08-11 incident and are safety boundaries, not instructions to force the control plane.
 
-After either refusal, first prove that no live agent owns the task and that the recorded worktree still exists with the same physical path, HEAD, containing branches, and dirty state captured in the packet.
-Append the packet to `data/<task-id>/brief.md` under a clearly labeled harness-handoff heading so the replacement is guaranteed to read it.
-Then use a normal `bin/fm-spawn.sh <task-id> <project>` invocation with the existing task id, recorded task kind and delivery posture, and explicit target harness.
-For a ship task, pass the recorded `--mode` and `--yolo`; for a scout, pass `--scout`.
-Read current `bin/fm-spawn.sh --help` before composing the invocation because that executable owns the exact flags.
+After either refusal, prove that no live agent owns the task and that the recorded worktree still exists with the same physical path, HEAD, containing branches, and dirty state captured in the packet.
+Append the packet to `data/<task-id>/brief.md` under a clearly labeled harness-handoff heading so the eventual replacement is guaranteed to read it.
+Then hand the blocked task to firstmate with that evidence intact rather than reaching for another spawn form.
 
-The normal spawn path creates a replacement endpoint and, in the incident this skill codifies, reused the existing task worktree for the same task id.
-Immediately verify that the newly recorded physical worktree equals the packet's worktree and that exactly one live agent owns the task before sending any follow-up.
-If the path differs, the endpoint is ambiguous, or another agent may still be live, stop and preserve both copies without teardown.
+### Never fresh-spawn a recorded worktree
+
+Do not recover a task with a normal non-`--relaunch` `bin/fm-spawn.sh <task-id> <project>` invocation.
+On current `origin/main`, `bin/fm-spawn.sh` runs `freshen_spawn_worktree_base` for every non-`--relaunch`, non-secondmate spawn, and that function ends in `git reset --hard origin/<default>`.
+Against a clean reused task worktree that reset moves the task branch off its unlanded commits, leaving them on zero branches and removing their files from the working tree.
+That destroys exactly the work this procedure exists to preserve.
+
+The 2026-08-11 incident did record three successful fresh spawns that reused the recorded worktree for the same task id, and that fact stands.
+It has a version boundary.
+The captain verified that the primary firstmate checkout used that day was 16 commits behind `origin/main` and contained no `reset --hard`, so those three spawns are evidence about that stale checkout, not evidence that the mechanism is safe.
+The captain confirmed that `fm/ow-311-charge-water` and `fm/ow-rites-part5-interaction` remain intact, at 12 and 4 commits above main.
+
+Fast-forwarding that checkout to current main turns the formerly successful fallback into a latent-dangerous one.
+Never reason about this from the incident.
+Read the `bin/fm-spawn.sh` implementation and version you are actually about to run, and confirm for yourself whether its non-`--relaunch` path still refreshes the worktree base.
+
+`fm-usage-window-resume` owns supplying a preservation-safe replacement mechanism.
+Until it does, no fresh-spawn fallback is blessed here.
+
+When the recorded worktree is dirty, `fm-spawn` refuses with `pooled worktree ... is not clean; refusing to discard uncommitted work while refreshing its base`.
+That refusal is correct, and it is a wall rather than an obstacle.
+Stop and escalate to firstmate.
+Never move, clean, stash, reset, force, tear down, or otherwise route around it.
 
 Never use `--force`, discard a dirty worktree, delete an endpoint to make a check pass, tear down unlanded work, or bypass a lifecycle refusal.
 

--- a/.agents/skills/harness-handoff/SKILL.md
+++ b/.agents/skills/harness-handoff/SKILL.md
@@ -37,6 +37,12 @@ A provider-window death does not prove that every lane on that provider died.
 It also does not stop workers on the other provider.
 The primary may be gone while workers and pipeline processes continue unsupervised, so classify each task independently.
 
+Treat the no-mistakes gate agent as a separate provider axis from the worker harness.
+On this installation, `~/.no-mistakes/config.yaml` line 10 sets `agent: claude`, so review, test, document, and later gate agents consume Claude even when the task worker runs on Codex.
+That same setting supports `agent: codex` or an ordered fallback list such as `agent: [codex, claude]`.
+Read the current config during recovery and record its selected gate agent in the packet; never infer pipeline-provider consumption from the worker harness.
+Do not change the global no-mistakes config as part of a handoff, because it affects other live lanes and remains the captain's decision.
+
 - `fine` means its worker endpoint and authoritative pipeline state remain healthy and the task still has supervision.
 - `unsupervised` means work remains live or an authoritative pipeline run remains active, but the primary that owned supervision disappeared.
 - `dead` means durable endpoint inspection proves the agent is gone, or the authoritative run ended because its selected provider became unavailable.
@@ -126,6 +132,7 @@ Complete the packet with only durable facts:
 - Task identity, project, worktree, recorded endpoint, old harness, backend, kind, mode, and yolo posture.
 - Current branch or detached commit, full HEAD, containing branches, and the exact dirty-file summary.
 - Pipeline run id and outcome, all recorded heads, `branch_sync.next_action`, and the successful or failed `cat-file` proof.
+- The no-mistakes gate agent selected by `~/.no-mistakes/config.yaml`, kept separate from the worker harness.
 - PR number and state when one exists.
 - Still-open decisions and already-recorded resolutions from the status log and brief.
 - One exact next action that follows the current structured state.

--- a/.agents/skills/stuck-crewmate-recovery/SKILL.md
+++ b/.agents/skills/stuck-crewmate-recovery/SKILL.md
@@ -33,7 +33,9 @@ Do not sweep another home's endpoints or infer ownership from a matching window 
 
 Before relaunch, prove that no live agent still owns the recorded task and that the existing worktree remains available.
 Preserve its uncommitted changes and commits, keep the same task identity, and resume or relaunch the recorded harness in that existing worktree with the same brief plus a concise progress note.
-Do not use a fresh generic spawn while the recorded worktree is unaccounted for, because allocating another worktree can split one task across two copies.
+Never recover a task with a fresh generic spawn, whether or not the recorded worktree is accounted for.
+An unaccounted-for worktree splits one task across two copies, and a reused one has its base refreshed under the task branch, which can strand unlanded commits.
+[`harness-handoff`](../harness-handoff/SKILL.md) owns that preservation rule, and `bin/fm-spawn.sh`'s header owns the exact refresh and refusal mechanics.
 If the worktree or ownership cannot be reconciled safely, leave all state intact and report the task failed or blocked with the conflicting evidence.
 
 ## Live-endpoint escalation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,8 +59,8 @@ CONTRIBUTING.md      contributor workflow and repo conventions
 README.md            public overview and development notes
 .github/workflows/   shared CI and PR enforcement, committed
 .tasks.toml          tracked tasks-axi markdown backend config for the default backlog backend (section 10)
-.agents/skills/      firstmate-loaded internal skills, committed; each carries metadata.internal=true for installers
-.claude/skills       symlink to .agents/skills for claude compatibility
+.agents/skills/      canonical firstmate-loaded internal skills, committed and discovered directly by Codex; each carries metadata.internal=true for installers
+.claude/skills       symlink to .agents/skills so Claude reads the same skill source
 skills/              standalone public installer-facing skills, committed; not loaded by firstmate
 bin/                 helper scripts, committed; read each script's header before first use
 .env                 optional Relay pairing token; LOCAL, gitignored; presence-gates section 14
@@ -519,6 +519,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
 - `quota-array-dispatch` - load before choosing among a matched crew-dispatch profile array from current quota-axi output.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
+- `harness-handoff` - load when a provider usage window expires or is about to expire, when a primary supervisor disappears mid-flight, or before moving in-flight work between Claude and Codex because of capacity.
 - `firstmate-orca` - load before switching to Orca, spawning or supervising Orca-backed work, smoke-testing Orca backend behavior, debugging Orca task state, or reconciling Orca-backed task metadata.
 - `project-management` - load before adding, creating, removing, or initializing a project.
   Cloning or registering a project is add intake and uses the same trigger.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -157,6 +157,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/harness-handoff/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/process-event-sources/SKILL.md",
       "audience": "agent-runtime"
     },

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -16,9 +16,12 @@ readlink .claude/skills
 codex exec --ephemeral -C "$PWD" -s read-only -m gpt-5.6-luna \
   '$harness-handoff Do not use tools or inspect the filesystem. Return exactly INVOKED followed by the first two sentences in the skill body under its title.'
 claude -p --model haiku --effort low --no-session-persistence \
-  --disallowedTools 'Bash,Read,Glob,Grep' -- \
-  'Use the harness-handoff skill. Do not use tools or inspect the filesystem. Return exactly INVOKED followed by the first two sentences in the skill body under its title.'
+  --disallowedTools 'Bash,Read,Glob,Grep,WebFetch,WebSearch' -- \
+  'Invoke the harness-handoff skill with the Skill tool. Use no other tool and do not inspect the filesystem. Then return exactly INVOKED followed by the first two sentences in the skill body under its title.'
 ```
+
+Name the Skill tool explicitly in the Claude probe.
+A prompt that says "use the skill" while forbidding all tools reads as self-contradictory, and Claude answers by asking which constraint wins instead of resolving the skill, so that phrasing does not reproduce.
 
 Observed output:
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -6,6 +6,31 @@ This record contains reusable version-scoped evidence for active runtime guarant
 The backend guides own current setup, safety boundaries, and limitations.
 Exact task chronology, branch names, temporary homes, local paths, process ids, thread ids, and delivery transcripts remain in private reports or PR evidence.
 
+## Shared project skill discovery
+
+Claude Code 2.1.228 and Codex CLI 0.147.0 were verified on 2026-08-11 from the same Firstmate worktree.
+The canonical skill source was `.agents/skills/`, with `.claude/skills` resolving to `../.agents/skills` and no project `.codex/skills` directory.
+
+```sh
+readlink .claude/skills
+codex exec --ephemeral -C "$PWD" -s read-only -m gpt-5.6-luna \
+  '$harness-handoff Do not use tools or inspect the filesystem. Return exactly INVOKED followed by the first two sentences in the skill body under its title.'
+claude -p --model haiku --effort low --no-session-persistence \
+  --disallowedTools 'Bash,Read,Glob,Grep' -- \
+  'Use the harness-handoff skill. Do not use tools or inspect the filesystem. Return exactly INVOKED followed by the first two sentences in the skill body under its title.'
+```
+
+Observed output:
+
+```text
+../.agents/skills
+INVOKED Reconstruct the handoff entirely from durable records. Never use conversation memory as evidence, because the lost conversation is the failure this procedure exists to survive.
+INVOKED Reconstruct the handoff entirely from durable records. Never use conversation memory as evidence, because the lost conversation is the failure this procedure exists to survive.
+```
+
+Codex discovered the project-local `.agents/skills/` source directly, while Claude reached that same source through the existing `.claude/skills` symlink.
+This gives crewmates, worktree-local primaries, and a captain-run session rooted in the Firstmate checkout one shared skill source without a second copy under `.codex/skills`.
+
 ## tmux
 
 Foreground-process behavior was verified on 2026-07-07 with tmux 3.6a on macOS.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -8,7 +8,7 @@ Exact task chronology, branch names, temporary homes, local paths, process ids, 
 
 ## Shared project skill discovery
 
-Claude Code 2.1.228 and Codex CLI 0.147.0 were verified on 2026-08-11 from the same Firstmate worktree.
+Claude Code 2.1.228 and Codex CLI 0.147.0 were verified on 2026-08-11 from the same isolated Firstmate task worktree, which was each session's working directory.
 The canonical skill source was `.agents/skills/`, with `.claude/skills` resolving to `../.agents/skills` and no project `.codex/skills` directory.
 
 ```sh
@@ -29,7 +29,12 @@ INVOKED Reconstruct the handoff entirely from durable records. Never use convers
 ```
 
 Codex discovered the project-local `.agents/skills/` source directly, while Claude reached that same source through the existing `.claude/skills` symlink.
-This gives crewmates, worktree-local primaries, and a captain-run session rooted in the Firstmate checkout one shared skill source without a second copy under `.codex/skills`.
+Both harnesses returned the skill's own body text under its title, so this records skill resolution and invocation rather than the mere existence of a path.
+This gives crewmates and worktree-local primaries one shared skill source without a second copy under `.codex/skills`.
+
+This evidence covers exactly one rooting: a session whose working directory is an isolated Firstmate task worktree.
+A session rooted in the primary Firstmate checkout is not covered here, because a crewmate must never write to or experiment in that checkout, which places that rooting outside worker scope.
+The shared source is committed, so a maintainer closes that gap after merge by running the recorded `codex exec` command from the primary checkout and confirming the same `INVOKED` output.
 
 ## tmux
 


### PR DESCRIPTION
## Intent

Create a harness-handoff skill for Firstmate that makes Claude-to-Codex and Codex-to-Claude recovery cheap when a usage window dies, including when Firstmate itself loses its supervisor window. The agent-only skill must live under the single source of truth in .agents/skills, be registered and discoverable by both providers through their supported project-local discovery, and trigger at provider-window death, supervisor loss, or intentional cross-harness transfer. Recovery must be executable by a cold-start agent using only durable records such as state/<id>.meta, state/<id>.status, pipeline run records, the task brief, and the PR, never conversation memory. It must recover the supervisor first, classify lanes independently, preserve all unlanded work, and never authorize force, teardown, discard, stash, reset, cleaning a dirty worktree, or bypass of a refusal. Record the 2026-08-11 facts that fm-control relaunch refuses when the endpoint is gone and when its shell is outside the recorded worktree. Record that normal fm-spawn with the existing task id did reuse recorded worktrees during that incident, but prohibit it as a current recovery fallback: the captain verified the primary checkout used that day was 16 commits behind origin/main and contained no reset --hard, while current origin/main runs freshen_spawn_worktree_base and reset --hard origin/<default>, so the historical success is evidence of a stale checkout rather than mechanism safety. The captain confirmed fm/ow-311-charge-water and fm/ow-rites-part5-interaction remained intact at 12 and 4 commits above main. Warn that updating to the current implementation makes the same fallback capable of moving a task branch off unlanded commits; if a reused worktree is dirty, its refusal is a correct wall and recovery must stop and escalate without moving, cleaning, stashing, resetting, forcing, or routing around it. fm-usage-window-resume must own a preservation-safe mechanism before any fallback is blessed. Verify every recorded pipeline head with cat-file in the correctly derived no-mistakes gate repository and identify phantom custody as fm-nomistakes-phantom-custody. Reference rather than duplicate fm-usage-window-resume, fm-brief-harness-neutral, and fm-brief-compaction-note. State handoff-relevant harness differences: skill invocation syntax, busy-state readability, supervision protocol, and old-harness assumptions in briefs. Test the procedure against real state. Prove only that a Codex session rooted in this isolated task worktree resolves a Firstmate skill; do not test or claim the captain-personal primary-checkout case. The PR body must visibly separate the exact worktree-rooted command and exact output, the primary-checkout verification gap and its hard-rule reason, and one copy-pasteable post-merge command for the captain to run from /Users/eric/dev/firstmate. State that the no-mistakes gate agent is a separate provider axis from the worker harness: ~/.no-mistakes/config.yaml line 10 currently selects agent: claude, so every gate consumes Claude even for a Codex worker; the setting also supports agent: codex or an ordered fallback list. Recovery must read and record that current setting, never infer it from the worker harness, and must not change global config because other lanes use it and the decision belongs to the captain. Do not create or apply an awaiting-validation label in kunchenguid/firstmate; describe completion and awaiting validation in the PR body and use an ordinary issue comment if needed. Deliver through the documented contributor fork but open the PR against kunchenguid/firstmate.

## What Changed

- Adds `.agents/skills/harness-handoff/SKILL.md`, an agent-only (`user-invocable: false`, `metadata.internal: true`) recovery procedure that triggers on provider-window death, supervisor loss, or intentional Claude↔Codex transfer: recover the supervisor first, classify each lane independently (`fine` / `unsupervised` / `dead` / `unknown`), build one durable packet per task from `state/<id>.meta`, `state/<id>.status`, `data/<id>/brief.md`, the pipeline run, and the PR — never conversation memory — and write it to `data/<task-id>/harness-handoff.md`. It records the no-mistakes gate agent as a provider axis separate from the worker harness (`~/.no-mistakes/config.yaml` line 10 currently `agent: claude`, with `agent: codex` / ordered-list support), requires reading and recording that setting rather than inferring it and forbids changing it, verifies every recorded pipeline head with `cat-file -e` in the gate repo derived from the worktree's `no-mistakes` remote (failure = `fm-nomistakes-phantom-custody`), and references rather than duplicates `fm-usage-window-resume`, `fm-brief-harness-neutral`, and `fm-brief-compaction-note`.
- Bans the fresh-spawn fallback and records why: `bin/fm-control.sh relaunch` refused on 2026-08-11 both when the endpoint was gone and when its shell sat outside the recorded worktree; the three fresh spawns that did reuse recorded worktrees that day came from a primary checkout 16 commits behind `origin/main` with no `reset --hard`, while current `origin/main` runs `freshen_spawn_worktree_base` ending in `git reset --hard origin/<default>` — so the same fallback can now move a task branch off unlanded commits. `fm/ow-311-charge-water` and `fm/ow-rites-part5-interaction` were confirmed intact at 12 and 4 commits above main. A dirty-worktree refusal is documented as a correct wall: stop and escalate, never move, clean, stash, reset, force, tear down, or route around it. `.agents/skills/stuck-crewmate-recovery/SKILL.md` drops its conditional and now prohibits fresh generic spawn unconditionally, pointing at this skill.
- Registers the skill for both providers off the single `.agents/skills` source — `AGENTS.md` gains the trigger line and now states that Codex discovers `.agents/skills/` directly while `.claude/skills` symlinks to it, `docs/documentation-audiences.json` adds the `agent-runtime` entry, `.agents/skills/harness-adapters/SKILL.md` points at the shared-discovery evidence, and `docs/verification/runtime-backends.md` records the dated probe.

## Skill discovery probe (exact command and exact output, run from this task worktree)

```sh
codex exec --ephemeral -C "$PWD" -s read-only -m gpt-5.6-luna \
  '$harness-handoff Do not use tools or inspect the filesystem. Return exactly INVOKED followed by the first two sentences in the skill body under its title.'
```

```text
INVOKED Reconstruct the handoff entirely from durable records. Never use conversation memory as evidence, because the lost conversation is the failure this procedure exists to survive.
```

Returning the skill's own body text proves resolution and invocation, not just the existence of a path. Codex CLI 0.147.0, with `readlink .claude/skills` → `../.agents/skills` and no project `.codex/skills` directory.

## Verification gap: the primary checkout is not covered

The probe above covers exactly one rooting: a session whose working directory is an isolated Firstmate task worktree. A session rooted in the primary Firstmate checkout at `/Users/eric/dev/firstmate` was deliberately **not** tested and is **not** claimed. The hard rule is that a crewmate must never write to or experiment in the captain's primary checkout, which places that rooting outside worker scope — so the gap is left open and stated rather than closed by guessing.

## Post-merge command for the captain

The shared skill source is committed, so after merge this one command closes the gap above. Run it from `/Users/eric/dev/firstmate` and confirm the same `INVOKED` line:

```sh
cd /Users/eric/dev/firstmate && codex exec --ephemeral -C "$PWD" -s read-only -m gpt-5.6-luna '$harness-handoff Do not use tools or inspect the filesystem. Return exactly INVOKED followed by the first two sentences in the skill body under its title.'
```

## Status

Work is complete and awaiting the captain's validation (tracked by #2223). No `awaiting-validation` label was created or applied.

## Risk Assessment

✅ Low: Documentation-and-skill-only change whose two round-1 findings were fixed exactly as recommended, with every safety-critical claim (fm-spawn's reset --hard gate, both fm-control refusals, the gate-repo derivation, the no-mistakes provider axis, and the recorded probe versions and flags) already verified against live source and installed CLIs, and registration complete in both AGENTS.md and the audience inventory.

## Testing

Reproduced the change's own recorded Codex and Claude skill-resolution probes from this isolated worktree and got output byte-identical to docs/verification/runtime-backends.md at the exact CLI versions named there, confirming both harnesses reach the single `.agents/skills` source with no `.codex/skills` copy. Went past documentation checks to validate the skill's central safety claim behaviorally: I extracted the real `freshen_spawn_worktree_base()` from bin/fm-spawn.sh and ran it in a disposable sandbox repo, where it stranded two unlanded commits on zero branches and deleted their files from a clean reused worktree, and refused with the exact quoted message on a dirty one while preserving everything — so the "never fresh-spawn" prohibition and the "refusal is a correct wall" framing are grounded in current code rather than in the incident. Also exercised the recovery packet procedure read-only against the live durable records for this very task, deriving the correct gate repo from the `no-mistakes` remote and proving a real preserved head with cat-file while a fabricated id in that same repo failed as the phantom-custody signal, and verified the recorded fm-control refusals, the `agent: claude` gate setting against a `harness=codex` worker, the two preserved branches at 12 and 4 commits above main, and all four referenced backlog ids. The documentation registry check and its test pass. Testing stayed inside the stated scope — the captain-personal primary-checkout rooting was never probed — the sandbox was removed, and the worktree is clean.

<details>
<summary>Evidence: Evidence summary (all checks, one page)</summary>

```text
# harness-handoff skill — test evidence (2026-08-11)

## 1. Both providers resolve the skill from the single `.agents/skills` source
Run from this isolated task worktree. `.codex/` exists but contains **no** `skills/` dir.

    $ readlink .claude/skills
    ../.agents/skills

    $ codex exec --ephemeral -C "$PWD" -s read-only -m gpt-5.6-luna \
        '$harness-handoff Do not use tools or inspect the filesystem. Return exactly INVOKED
         followed by the first two sentences in the skill body under its title.'
    INVOKED Reconstruct the handoff entirely from durable records. Never use conversation
    memory as evidence, because the lost conversation is the failure this procedure exists to survive.

    $ claude -p --model haiku --effort low --no-session-persistence \
        --disallowedTools 'Bash,Read,Glob,Grep,WebFetch,WebSearch' -- \
        'Invoke the harness-handoff skill with the Skill tool. ...'
    INVOKED Reconstruct the handoff entirely from durable records. Never use conversation
    memory as evidence, because the lost conversation is the failure this procedure exists to survive.

Byte-identical to `docs/verification/runtime-backends.md`. Versions matched the record
(Codex CLI 0.147.0, Claude Code 2.1.228). Scope limited to the worktree rooting, as required.

## 2. The "never fresh-spawn" rule is justified by real code, not assumption
Real `freshen_spawn_worktree_base()` extracted verbatim from `bin/fm-spawn.sh`, run against a
disposable sandbox repo. Call site guard confirmed: `[ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]`.

| Case | Result |
|---|---|
| Clean worktree, 2 unlanded commits | rc=0. Branch moved a9e6a5b -> d23d011 (origin/main). Unlanded files deleted. Unlanded commit left on **ZERO branches**. |
| Same worktree, dirty | rc=1, refused verbatim: `pooled worktree '...' is not clean; refusing to discard uncommitted work while refreshing its base`. Branch, HEAD, unlanded commits and dirty file all intact. |

## 3. Recorded facts verified against real state
- `~/.no-mistakes/config.yaml` line 10 = `agent: claude`; header documents `agent: [codex, claude]` fallback.
- Live task `fm-harness-handoff-skill` records `harness=codex` while the gate agent is `claude` — a live instance of the two provider axes.
- `fm-control.sh:445` — "recorded endpoint is gone, so there is no agent to stop".
- `fm-spawn.sh:32` — relaunch "refuses unless the endpoint's shell is sitting in the recorded worktree".
- `fm/ow-311-charge-water` INTACT at 12 commits above main; `fm/ow-rites-part5-interaction` INTACT at 4.
- All four referenced backlog ids are real filed items (`fm-usage-window-resume`, `fm-brief-harness-neutral`, `fm-brief-compaction-note`, `fm-nomistakes-phantom-custody`).

## 4. Packet procedure exercised on real durable records (read-only)
Gate repo derived from the worktree's `no-mistakes` remote -> `/Users/eric/.no-mistakes/repos/c74621a5fbf6.git`
(matches this run's actual gate repo; not a guessed hash). `cat-file -e` on the recorded head
succeeded; a fabricated id in the *correct* gate repo failed — the `fm-nomistakes-phantom-custody` signal.
This gate worktree itself has no `no-mistakes` remote, which lands on the skill's own documented
registration-gap branch rather than a false object result.

## 5. Registry
`bin/fm-doc-audience-check.sh: ok surfaces=68 local_links=245`; `tests/fm-documentation-audiences.test.sh` 4/4 ok.
Frontmatter: `user-invocable: false`, `metadata.internal: true`. No line in the skill instructs
force/reset/clean/stash/teardown.
```
</details>
<details>
<summary>Evidence: Codex resolves the Firstmate skill from this worktree (recorded probe reproduced)</summary>

<code>$ readlink .claude/skills&#10;../.agents/skills&#10;&#10;$ codex exec --ephemeral -C &#34;$PWD&#34; -s read-only -m gpt-5.6-luna \&#10;&#39;$harness-handoff Do not use tools or inspect the filesystem. Return exactly INVOKED followed by the first two sentences in the skill body under its title.&#39;&#10;workdir: /Users/eric/.no-mistakes/worktrees/c74621a5fbf6/01KZT4NYS560VXAM2CRX3A31T7&#10;model: gpt-5.6-luna sandbox: read-only&#10;codex&#10;INVOKED Reconstruct the handoff entirely from durable records. Never use conversation memory as evidence, because the lost conversation is the failure this procedure exists to survive.</code>

```text
Reading additional input from stdin...
OpenAI Codex v0.147.0
--------
workdir: /Users/eric/.no-mistakes/worktrees/c74621a5fbf6/01KZT4NYS560VXAM2CRX3A31T7
model: gpt-5.6-luna
provider: openai
approval: never
sandbox: read-only
reasoning effort: none
reasoning summaries: none
session id: 019ff458-243e-7f91-b76b-6f01aa5dfac8
--------
user
$harness-handoff Do not use tools or inspect the filesystem. Return exactly INVOKED followed by the first two sentences in the skill body under its title.
2026-08-12T05:00:45.407998Z ERROR rmcp::transport::worker: worker quit with fatal: Transport channel closed, when AuthRequired(AuthRequiredError { www_authenticate_header: "Bearer realm=\"OAuth\", resource_metadata=\"https://mcp.linear.app/.well-known/oauth-protected-resource/mcp\", error=\"invalid_token\", error_description=\"Missing or invalid access token\"" })
2026-08-12T05:00:45.419813Z ERROR rmcp::transport::worker: worker quit with fatal: Transport channel closed, when AuthRequired(AuthRequiredError { www_authenticate_header: "Bearer realm=\"OAuth\", resource_metadata=\"https://mcp.linear.app/.well-known/oauth-protected-resource/mcp\", error=\"invalid_token\", error_description=\"Missing or invalid access token\"" })
warning: Skill descriptions were shortened to fit the skills context budget. Codex can still see every skill, but some descriptions are shorter. Disable unused skills or plugins to leave more room for the rest.
hook: SessionStart
hook: SessionStart
hook: SessionStart
hook: SessionStart
hook: SessionStart Completed
hook: SessionStart Completed
hook: SessionStart Completed
hook: SessionStart Completed
codex
INVOKED Reconstruct the handoff entirely from durable records. Never use conversation memory as evidence, because the lost conversation is the failure this procedure exists to survive.
tokens used
22,389
INVOKED Reconstruct the handoff entirely from durable records. Never use conversation memory as evidence, because the lost conversation is the failure this procedure exists to survive.
```
</details>
<details>
<summary>Evidence: Claude resolves the same skill through the .claude/skills symlink</summary>

<code>$ claude -p --model haiku --effort low --no-session-persistence \&#10;--disallowedTools &#39;Bash,Read,Glob,Grep,WebFetch,WebSearch&#39; -- \&#10;&#39;Invoke the harness-handoff skill with the Skill tool. Use no other tool and do not inspect the filesystem. Then return exactly INVOKED followed by the first two sentences in the skill body under its title.&#39;&#10;INVOKED Reconstruct the handoff entirely from durable records. Never use conversation memory as evidence, because the lost conversation is the failure this procedure exists to survive.</code>

```text
$ claude -p --model haiku --effort low --no-session-persistence --disallowedTools ... 
INVOKED Reconstruct the handoff entirely from durable records. Never use conversation memory as evidence, because the lost conversation is the failure this procedure exists to survive.
```
</details>
<details>
<summary>Evidence: Real freshen_spawn_worktree_base() strands unlanded work when clean, walls off when dirty</summary>

<code>Code under test: freshen_spawn_worktree_base(), extracted verbatim from bin/fm-spawn.sh&#10;&#10;=== CASE A: clean reused task worktree with 2 unlanded commits ===&#10;BEFORE:&#10;branch: fm/sandbox-task&#10;HEAD: a9e6a5bcc59f2ae164f21958241cf0ea7adc40d5&#10;worktree files: unlanded1.txt unlanded2.txt&#10;branches containing the unlanded commit: fm/sandbox-task&#10;RUN freshen_spawn_worktree_base (what a non---relaunch fm-spawn does):&#10;exit rc=0&#10;AFTER:&#10;branch: fm/sandbox-task&#10;HEAD: d23d011aea2ff4706d77e461bee6e686e444b889&#10;worktree files:&#10;branches containing the unlanded commit: NONE (stranded)&#10;&#10;=== CASE B: same worktree, but DIRTY (uncommitted work present) ===&#10;BEFORE: dirty files -&gt; M base.txt&#10;RUN freshen_spawn_worktree_base:&#10;error: pooled worktree &#39;.../wt&#39; is not clean; refusing to discard uncommitted work while refreshing its base&#10;exit rc=1&#10;AFTER:&#10;branch: fm/sandbox-task&#10;HEAD: a9e6a5bcc59f2ae164f21958241cf0ea7adc40d5&#10;worktree files: unlanded1.txt unlanded2.txt&#10;branches containing the unlanded commit: fm/sandbox-task&#10;dirty file still present: M base.txt</code>

```text
### Sandbox proof of the hazard the skill forbids ###
Code under test: freshen_spawn_worktree_base(), extracted verbatim from bin/fm-spawn.sh
extracted 41 lines of real fm-spawn.sh code

=== CASE A: clean reused task worktree with 2 unlanded commits ===
BEFORE:
  branch:        fm/sandbox-task
  HEAD:          a9e6a5bcc59f2ae164f21958241cf0ea7adc40d5
  worktree files: unlanded1.txt unlanded2.txt 
  branches containing the unlanded commit: fm/sandbox-task 
RUN freshen_spawn_worktree_base (what a non---relaunch fm-spawn does):
  exit rc=0
AFTER:
  branch:        fm/sandbox-task
  HEAD:          d23d011aea2ff4706d77e461bee6e686e444b889
  worktree files: 
  branches containing the unlanded commit: NONE (stranded)

=== CASE B: same worktree, but DIRTY (uncommitted work present) ===
BEFORE: dirty files ->  M base.txt 
RUN freshen_spawn_worktree_base:
error: pooled worktree '/var/folders/jw/f991bknn0wgb_kdr0crztl7h0000gn/T//fm-freshen-sandbox.uAU3mz/wt' is not clean; refusing to discard uncommitted work while refreshing its base
  exit rc=1
AFTER:
  branch:        fm/sandbox-task
  HEAD:          a9e6a5bcc59f2ae164f21958241cf0ea7adc40d5
  worktree files: unlanded1.txt unlanded2.txt 
  branches containing the unlanded commit: fm/sandbox-task 
  dirty file still present:  M base.txt 

sandbox: /var/folders/jw/f991bknn0wgb_kdr0crztl7h0000gn/T//fm-freshen-sandbox.uAU3mz
```
</details>
<details>
<summary>Evidence: Recovery packet procedure against real durable state, incl. gate-repo cat-file proof</summary>

<code>== durable record fields (state/&lt;id&gt;.meta) ==&#10;worktree=/Users/eric/.treehouse/firstmate-7bab20/1/firstmate&#10;project=/Users/eric/dev/firstmate&#10;harness=codex &lt;- worker harness&#10;kind=ship mode=no-mistakes yolo=on backend=herdr&#10;&#10;== local copy proof (read-only) ==&#10;HEAD: 2d290a5c2ee2f17328970507af64a99227cd5c2f&#10;symbolic-ref --quiet --short HEAD: fm/fm-harness-handoff-skill&#10;branch --contains HEAD: * fm/fm-harness-handoff-skill&#10;&#10;== gate repository derivation + cat-file proof ==&#10;gate_repo=/Users/eric/.no-mistakes/repos/c74621a5fbf6.git&#10;cat-file -e 2d290a5...: OK (real commit object in gate repo)&#10;cat-file -t: commit&#10;-- phantom-custody negative control, correct gate repo, fabricated id --&#10;fatal: Not a valid object name dead000...beef^{commit}&#10;-&gt; missing object in the CORRECT gate repo = fm-nomistakes-phantom-custody&#10;&#10;(separately: ~/.no-mistakes/config.yaml line 10 = &#39;agent: claude&#39; -&gt; gate consumes Claude for this Codex worker)</code>

```text
== durable record fields (state/<id>.meta) ==
worktree=/Users/eric/.treehouse/firstmate-7bab20/1/firstmate
project=/Users/eric/dev/firstmate
harness=codex
kind=ship
mode=no-mistakes
yolo=on
backend=herdr

== local copy proof (read-only) ==
$ git -C "$worktree" status --short
$ git -C "$worktree" rev-parse HEAD
2d290a5c2ee2f17328970507af64a99227cd5c2f
$ git -C "$worktree" symbolic-ref --quiet --short HEAD
fm/fm-harness-handoff-skill
$ git -C "$worktree" branch --contains HEAD
* fm/fm-harness-handoff-skill

== gate repository derivation + cat-file proof ==
gate_repo=/Users/eric/.no-mistakes/repos/c74621a5fbf6.git
cat-file -e 2d290a5c2ee2f17328970507af64a99227cd5c2f: OK (real commit object in gate repo)
cat-file -t: commit
-- phantom-custody negative control, correct gate repo, fabricated id --
fatal: Not a valid object name dead00000000000000000000000000000000beef^{commit}
-> missing object in the CORRECT gate repo = fm-nomistakes-phantom-custody
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `.agents/skills/harness-handoff/SKILL.md:65` - SKILL.md:65 collects the status log with `sed -n &#39;1,260p&#39;`, which reads the FIRST 260 lines. `state/&lt;id&gt;.status` is an append-only event log (AGENTS.md:54, and bin/fm-crew-state.sh reconciles against its LAST line), so for any task whose log exceeds the cap the recovery packet is built from the oldest events and silently omits the newest ones — while the packet section at lines 137-138 requires &#39;still-open decisions and already-recorded resolutions&#39; and &#39;one exact next action that follows the current structured state&#39;. Real logs today top out at 24 lines, so this is latent rather than live. Fix: `tail -n 260 &#34;$fm_home/state/$task_id.status&#34;`. The neighbouring `sed -n &#39;1,240p&#39;` on the meta is fine — that file is a small fixed key/value record.
- ℹ️ `.agents/skills/harness-handoff/SKILL.md:61` - SKILL.md:61 derives the worktree with `sed -n &#39;s/^worktree=//p&#39; &#34;$meta&#34; | head -1`, taking the FIRST value. The repo has one meta-read contract and it is last-wins: `fm_meta_get` (bin/fm-backend.sh:338) is documented as &#39;the LAST value of `key=`&#39;, mirroring the `grep &#39;^key=&#39; | tail -1` idiom every fm-*.sh script used inline; meta files are appended to in practice (bin/fm-decision-hold.sh:341, bin/fm-pr-check.sh:114). Current writers keep `worktree=` unique (fm-spawn&#39;s `preserve_relaunch_meta` filters it out of preserved keys), so no failure is reachable today, but if a second `worktree=` line ever lands, `head -1` yields the stale path and every git proof at lines 79-89 is gathered from the wrong directory — precisely the hazard lines 69-70 warn about. Fix: `tail -1`.

🔧 Fix: read newest meta and status records in handoff packet
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`codex exec --ephemeral -C &#34;$PWD&#34; -s read-only -m gpt-5.6-luna &#39;$harness-handoff ...&#39;` — recorded probe reproduced verbatim from this worktree</code>
- <code>`claude -p --model haiku --effort low --no-session-persistence --disallowedTools &#39;Bash,Read,Glob,Grep,WebFetch,WebSearch&#39; -- &#39;Invoke the harness-handoff skill with the Skill tool. ...&#39;` — recorded probe reproduced verbatim</code>
- <code>`readlink .claude/skills` -&gt; `../.agents/skills`; confirmed `.codex/` has no `skills/` directory; `codex --version` = 0.147.0, `claude --version` = 2.1.228 (both match the dated record)</code>
- <code>Sandbox execution of the real `freshen_spawn_worktree_base()` extracted verbatim from `bin/fm-spawn.sh`, clean case: branch moved off 2 unlanded commits to origin/main, files deleted, commit left on zero branches</code>
- <code>Sandbox execution of the same function, dirty case: refused rc=1 with `pooled worktree &#39;...&#39; is not clean; refusing to discard uncommitted work while refreshing its base`, all work preserved</code>
- <code>Verified spawn guard `[ &#34;$RELAUNCH&#34; -eq 0 ] &amp;&amp; [ &#34;$KIND&#34; != secondmate ]` at bin/fm-spawn.sh:2221 and `target=&#34;origin/$default&#34;` + `git reset --hard` in the function body</code>
- <code>`bin/fm-doc-audience-check.sh` -&gt; `ok surfaces=68 local_links=245`</code>
- <code>`bash tests/fm-documentation-audiences.test.sh` -&gt; 4/4 ok</code>
- <code>Packet procedure on real durable state for task `fm-harness-handoff-skill`: read `state/&lt;id&gt;.meta`, `git --no-optional-locks status --short`, `rev-parse HEAD`, `symbolic-ref --quiet --short HEAD`, `branch --contains HEAD`</code>
- <code>`git -C &#34;$worktree&#34; remote get-url no-mistakes` -&gt; `/Users/eric/.no-mistakes/repos/c74621a5fbf6.git`, then `git --git-dir=... cat-file -e &lt;head&gt;^{commit}` (OK) and a fabricated id in the same correct repo (fails = fm-nomistakes-phantom-custody)</code>
- <code>`sed -n &#39;1,12p&#39; ~/.no-mistakes/config.yaml` -&gt; line 10 `agent: claude`, with `agent: [codex, claude]` fallback documented in the header</code>
- <code>`grep -n` on bin/fm-control.sh:445 (endpoint gone, nothing to stop) and bin/fm-spawn.sh:32 (relaunch refuses unless the endpoint shell sits in the recorded worktree)</code>
- <code>`git -C /Users/eric/dev/firstmate/projects/overwhelmed rev-list --count main..fm/ow-311-charge-water` = 12 and `..fm/ow-rites-part5-interaction` = 4</code>
- <code>Confirmed `fm-usage-window-resume`, `fm-brief-harness-neutral`, `fm-brief-compaction-note`, `fm-nomistakes-phantom-custody` are real entries in `data/backlog.md`</code>
- <code>Frontmatter convention check across `.agents/skills/*/SKILL.md` (`user-invocable: false`, `metadata.internal: true`) and a scan confirming no line in the new skill instructs force/reset/clean/stash/teardown</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/verification/runtime-backends.md:1` - docs/verification/runtime-backends.md is titled &#34;Runtime backend verification&#34; and README.md:198 describes it as &#34;active maintainer verification for runtime backend guarantees&#34;, but this change adds a harness-level section (shared project skill discovery) that is not a runtime backend. I left both alone deliberately: firstmate-coding-guidelines designates that file as the home for dated per-harness results, and it already carries non-backend sections (Composer classification matrix, Codex App host tools), so retitling the doc and rewording its README pointer is a naming consolidation beyond this change rather than a fact this change made wrong. Worth a follow-up if the file keeps accumulating harness-level evidence.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
