### PR TITLE
test(classify): preserve legacy decision key syntax

### DIFF
--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -164,7 +164,8 @@ status_is_paused_or_captain_held() {  # <status-line>
 # position sits between the verb and the colon, and a complete token at the
 # head of the note is accepted as an EQUIVALENT position, because that
 # misplaced-colon shape is common real worker output whose stated key must
-# never silently collapse into the shared "default" bucket (issue #2109):
+# never silently collapse into the shared "default" bucket (issues #2081 and
+# #2109):
 #   needs-decision [key=api-shape]: <summary>
 #   needs-decision: [key=api-shape] <summary>
 #   resolved       [key=api-shape]: <how it was decided>

--- a/tests/fm-classify-decision-key.test.sh
+++ b/tests/fm-classify-decision-key.test.sh
@@ -4,7 +4,8 @@
 # documented between the verb and the colon (needs-decision [key=x]: note), but
 # workers commonly write the colon first (needs-decision: [key=x] note); that
 # stated key must be honored, never silently folded into the shared "default"
-# bucket where an answer can close the wrong record (issue #2109). These tests
+# bucket where an answer can close the wrong record (issues #2081 and #2109).
+# These tests
 # drive the REAL status_open_decisions / status_open_decisions_incremental
 # functions over crafted status files and assert their folded output, never the
 # fold's own source text. Cross-drain cursor persistence and the incremental
@@ -58,6 +59,22 @@ test_stated_key_is_honored_in_both_positions() {
   [ "$before" = "$after" ] \
     || fail "the two key positions folded to different records: '$before' vs '$after'"
   pass "a stated [key=X] opens X whether it precedes or follows the verb colon"
+}
+
+test_no_colon_legacy_form_remains_accepted() {
+  local dir
+  dir=$(case_dir no-colon)
+  # Before the note-head form was accepted, the parser also accepted a keyed
+  # status line with no colon. Keep that existing interpretation intact while
+  # making the documented and note-head positions equivalent.
+  printf 'needs-decision [key=legacy] choose the legacy route\n' > "$dir/t.status"
+  assert_fold "$dir/t.status" \
+    "$(printf 'legacy\tneeds-decision\tneeds-decision [key=legacy] choose the legacy route\n')" \
+    "legacy no-colon open"
+
+  printf 'resolved [key=legacy] chose the legacy route\n' >> "$dir/t.status"
+  assert_fold "$dir/t.status" "" "legacy no-colon resolution"
+  pass "the previously accepted no-colon keyed form still opens and closes its named key"
 }
 
 test_bare_keyless_line_still_folds_to_default() {
@@ -172,6 +189,7 @@ test_incremental_agrees_with_full_fold_across_appends() {
 }
 
 test_stated_key_is_honored_in_both_positions
+test_no_colon_legacy_form_remains_accepted
 test_bare_keyless_line_still_folds_to_default
 test_resolution_closes_across_positions
 test_blocked_is_position_tolerant_like_needs_decision

--- a/tests/fm-send-resolve-key.test.sh
+++ b/tests/fm-send-resolve-key.test.sh
@@ -132,7 +132,7 @@ test_answer_send_closes_open_decision() {
   pass "fm-send --resolve-key: the answer send itself closes the open decision"
 }
 
-# The reported failure behind issue #2109: a worker that put the colon first
+# The reported failure behind issues #2081 and #2109: a worker that put the colon first
 # (needs-decision: [key=X] ...) had its key silently folded to "default", so
 # the answer's --resolve-key X refused with "no open decision or blocker with
 # that key". The stated key must be honored in that position too, end to end


### PR DESCRIPTION
## Intent

Implement kunchenguid/firstmate#2081 exactly as specified: correct decision-key parsing so documented status forms retain their named key instead of folding to default, preserve every accepted legacy form and decision safety, and exclude broader grammar or lifecycle changes. Add bidirectional behavioral regression coverage. The equivalent parser correction already landed on main through merged duplicate #2109/#2202, so this branch must not duplicate or broaden parser behavior; it should add the remaining behavioral regression that proves the pre-existing no-colon keyed legacy form still opens and resolves under its named key, retain the existing before-colon and after-colon bidirectional coverage, and associate the contract with #2081. Target main, fully close #2081 with a standalone 'Closes #2081'. No database/browser stack and never local Cypress. Complete No Mistakes, create a PR, verify exact-head CI and mergeability, and never merge.

## What Changed

- Add full and incremental fold regression coverage proving the legacy no-colon keyed form opens and resolves under its named key.
- Associate the existing bidirectional decision-key parsing and send-resolution contract with issue #2081.

## Risk Assessment

✅ Low: The change is narrowly scoped to executable behavioral regression coverage for the legacy no-colon keyed form and issue-contract annotations, while preserving the existing bidirectional coverage without changing parser behavior.

## Testing

No prior baseline test commands were supplied; targeted classifier and real `fm-send --resolve-key` tests passed, and a manual executable-interface check demonstrated the legacy no-colon form opening under `legacy` and resolving cleanly in both full and incremental folds.

<details>
<summary>Evidence: Legacy no-colon decision lifecycle transcript</summary>

<code>No-colon event folded under key `legacy` in both full and incremental modes; after the matching resolution, both reported `(none)`.</code>

```text
USER-VISIBLE STATUS EVENT
needs-decision [key=legacy] choose the legacy route

OPEN DECISIONS (full fold)
legacy	needs-decision	needs-decision [key=legacy] choose the legacy route
OPEN DECISIONS (incremental fold)
legacy	needs-decision	needs-decision [key=legacy] choose the legacy route
RESOLUTION EVENT
resolved [key=legacy] chose the legacy route

OPEN DECISIONS AFTER RESOLUTION (full fold)
(none)

OPEN DECISIONS AFTER RESOLUTION (incremental fold)
(none)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"a9cbb8404eff541e40dca207a5940df24735cdc7","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff b5d430d6fdcd961ce9b681bf196f365c1825c284..a9cbb8404eff541e40dca207a5940df24735cdc7` and target commit metadata for regression-only scope.</code>
- `bash tests/fm-classify-decision-key.test.sh`
- `bash tests/fm-send-resolve-key.test.sh`
- <code>Manually exercised `status_open_decisions` and `status_open_decisions_incremental` using a no-colon keyed open event followed by its matching resolution; captured the state transition in the evidence transcript.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
