### PR TITLE
test: make Bearings fixture appends portable

### DIFF
--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -1695,8 +1695,7 @@ EOF
         and (.reason | contains("unreadable-child"))))
   ' >/dev/null || fail "end-to-end mixed-domain projection was wrong: $json"
 
-  sed '/unreadable-child/a\
-- [ ] ordinary-orphan - Unowned release task (repo: sshhip) (kind: ship)' \
+  awk '{print} /unreadable-child/{print "- [ ] ordinary-orphan - Unowned release task (repo: sshhip) (kind: ship)"}' \
     "$sshhip/data/backlog.md" > "$sshhip/data/backlog.next"
   mv "$sshhip/data/backlog.next" "$sshhip/data/backlog.md"
   canonical=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SNAPSHOT_NOW=2026-07-11T18:00:00Z \
@@ -1734,8 +1733,7 @@ EOF
       and .landed == []
       and .endpoints == []
   ' >/dev/null || fail "an unowned unknown child received partial structured projection: $canonical"
-  sed '/## In flight/a\
-- [ ] unreadable-child - Submit App Store build (repo: sshhip) (kind: ship)' \
+  awk '{print} /## In flight/{print "- [ ] unreadable-child - Submit App Store build (repo: sshhip) (kind: ship)"}' \
     "$sshhip/data/backlog.md" > "$sshhip/data/backlog.next"
   mv "$sshhip/data/backlog.next" "$sshhip/data/backlog.md"
 


### PR DESCRIPTION
## Intent

Implement kunchenguid/firstmate#1242 exactly as specified by the full issue. Replace only the two nonportable BSD sed fixture appends in tests/fm-bearings-snapshot.test.sh with the smallest portable equivalent, preserving the intended bytes and excluding product snapshot behavior and unrelated fixture cleanup. Target main and fully close issue #1242 with a standalone Closes #1242 line. Do not use a database or browser stack and never run Cypress locally. Validate the intended bytes and the focused suite, then complete No Mistakes plus exact-head CI and mergeability verification. Never merge the PR.

## What Changed

- Replace two BSD-specific `sed` fixture appends with portable `awk` equivalents while preserving the inserted backlog bytes and positions.

Closes #1242

## Risk Assessment

✅ Low: The narrowly scoped test-fixture change replaces exactly the two nonportable BSD sed appends with portable awk equivalents while preserving the intended line order, content, and terminating newlines.

## Testing

Inspected the base-to-target delta, byte-compared both portable append operations—including newline placement and repeated matches—then ran the focused bearings snapshot suite successfully; reviewer-visible byte artifacts were captured, no browser or database stack was used, and testing left the worktree clean.

<details>
<summary>Evidence: Portable fixture byte transcript</summary>

```text
ordinary-orphan: exact bytes match; sha256=4f922b30c51317744a09f8265656fac8898a06fe62b961d53402ebbc3d540734
   62 65 66 6f 72 65 0a 75 6e 72 65 61 64 61 62 6c
   65 2d 63 68 69 6c 64 0a 2d 20 5b 20 5d 20 6f 72
   64 69 6e 61 72 79 2d 6f 72 70 68 61 6e 20 2d 20
   55 6e 6f 77 6e 65 64 20 72 65 6c 65 61 73 65 20
   74 61 73 6b 20 28 72 65 70 6f 3a 20 73 73 68 68
   69 70 29 20 28 6b 69 6e 64 3a 20 73 68 69 70 29
   0a 61 66 74 65 72 0a 75 6e 72 65 61 64 61 62 6c
   65 2d 63 68 69 6c 64 0a 2d 20 5b 20 5d 20 6f 72
   64 69 6e 61 72 79 2d 6f 72 70 68 61 6e 20 2d 20
   55 6e 6f 77 6e 65 64 20 72 65 6c 65 61 73 65 20
   74 61 73 6b 20 28 72 65 70 6f 3a 20 73 73 68 68
   69 70 29 20 28 6b 69 6e 64 3a 20 73 68 69 70 29
   0a
unreadable-child: exact bytes match; sha256=85ccfbe5528625d90dea39d72a56b793f7ad218272a62ba28a38f47cdc041689
   62 65 66 6f 72 65 0a 23 23 20 49 6e 20 66 6c 69
   67 68 74 0a 2d 20 5b 20 5d 20 75 6e 72 65 61 64
   61 62 6c 65 2d 63 68 69 6c 64 20 2d 20 53 75 62
   6d 69 74 20 41 70 70 20 53 74 6f 72 65 20 62 75
   69 6c 64 20 28 72 65 70 6f 3a 20 73 73 68 68 69
   70 29 20 28 6b 69 6e 64 3a 20 73 68 69 70 29 0a
   61 66 74 65 72 0a 23 23 20 49 6e 20 66 6c 69 67
   68 74 0a 2d 20 5b 20 5d 20 75 6e 72 65 61 64 61
   62 6c 65 2d 63 68 69 6c 64 20 2d 20 53 75 62 6d
   69 74 20 41 70 70 20 53 74 6f 72 65 20 62 75 69
   6c 64 20 28 72 65 70 6f 3a 20 73 73 68 68 69 70
   29 20 28 6b 69 6e 64 3a 20 73 68 69 70 29 0a
```
</details>
<details>
<summary>Evidence: ordinary-orphan generated fixture bytes</summary>

```text
before
unreadable-child
- [ ] ordinary-orphan - Unowned release task (repo: sshhip) (kind: ship)
after
unreadable-child
- [ ] ordinary-orphan - Unowned release task (repo: sshhip) (kind: ship)
```
</details>
<details>
<summary>Evidence: unreadable-child generated fixture bytes</summary>

```text
before
## In flight
- [ ] unreadable-child - Submit App Store build (repo: sshhip) (kind: ship)
after
## In flight
- [ ] unreadable-child - Submit App Store build (repo: sshhip) (kind: ship)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"7fff12a089300a7ed597b4acc85ce5d1b7f9391d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --no-ext-diff b5d430d6fdcd961ce9b681bf196f365c1825c284..7fff12a089300a7ed597b4acc85ce5d1b7f9391d -- tests/fm-bearings-snapshot.test.sh`
- `/tmp/no-mistakes-evidence/01KZT811JM6PMPHKGNB2EG5ZEA/verify-portable-fixture-appends.sh`
- `bin/fm-test-run.sh tests/fm-bearings-snapshot.test.sh`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
