### PR TITLE
fix: file-feed fleet snapshot backlog JSON

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,8 +350,8 @@ jobs:
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"
           snapshot_count=$(printf '%s\n' "$snapshot_output" | grep -c '^ok - ')
-          [ "$snapshot_count" -eq 15 ] || {
-            echo "::error::expected 15 snapshot/fleet-view tests, got $snapshot_count"
+          [ "$snapshot_count" -eq 16 ] || {
+            echo "::error::expected 16 snapshot/fleet-view tests, got $snapshot_count"
             exit 1
           }
 

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -609,8 +609,9 @@ task_json_lines() {
 # discloses backlog↔task inconsistency for renderers (Bearings omitted/gates).
 main_inventory_json() {  # <backlog-json> <tasks-json>
   jq -n \
-    --argjson backlog "$1" \
+    --slurpfile backlog <(printf '%s' "$1") \
     --argjson tasks "$2" '
+    ($backlog[0]) as $backlog |
     ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]?
@@ -643,11 +644,12 @@ secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
     --argjson queued_n "$FM_SNAPSHOT_SECONDMATE_QUEUED" \
     --argjson decisions_n "$FM_SNAPSHOT_SECONDMATE_DECISIONS" \
     --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" \
-    --argjson backlog "$1" \
+    --slurpfile backlog <(printf '%s' "$1") \
     --argjson tasks "$2" '
     def trunc($n):
       tostring | gsub("\\s+"; " ")
       | if length > $n then .[:$n] + "…" else . end;
+    ($backlog[0]) as $backlog |
     ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]? | select(.state == "in_flight" and .structured) ]) as $owned_in_flight
@@ -1370,13 +1372,14 @@ jq -n \
   --arg data "$DATA" \
   --arg config "$CONFIG" \
   --arg projects "$PROJECTS" \
-  --argjson backlog "$BACKLOG_JSON" \
+  --slurpfile backlog <(printf '%s' "$BACKLOG_JSON") \
   --argjson tasks "$TASKS_JSON" \
   --argjson main_inventory "$MAIN_INVENTORY_JSON" \
   --argjson scout_reports "$SCOUT_REPORTS_JSON" \
   --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
   --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
-  'def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
+  '($backlog[0]) as $backlog |
+   def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");
    {

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -151,6 +151,37 @@ test_empty_fleet_json() {
   pass "empty fleet snapshot and view use explicit absence markers"
 }
 
+test_large_backlog_json_is_file_fed() {
+  local home out summary
+  home=$(make_home large-backlog)
+  {
+    printf '## In flight\n\n## Queued\n\n## Done\n'
+    printf '%s' '- [x] oversized-done - '
+    dd if=/dev/zero bs=1024 count=140 2>/dev/null | tr '\000' x
+    printf ' (repo: alpha) (kind: ship) (done 2026-08-12)\n'
+  } > "$home/data/backlog.md"
+
+  out=$(FM_HOME="$home" "$SNAPSHOT" --json) \
+    || fail "snapshot must accept backlog JSON larger than one argv entry"
+  printf '%s' "$out" | jq -e '
+    .schema == "fm-fleet-snapshot.v1"
+      and (.backlog.records | length) == 1
+      and .backlog.records[0].id == "oversized-done"
+      and (.backlog.records[0].title | length) > 131072
+      and (.tasks | length) == 0
+  ' >/dev/null || fail "large-backlog snapshot output changed or truncated"
+  summary=$(FM_HOME="$home" "$SNAPSHOT" --secondmate-home-summary) \
+    || fail "secondmate summary must accept backlog JSON larger than one argv entry"
+  printf '%s' "$summary" | jq -e '
+    .schema == "fm-secondmate-home-summary.v1"
+      and .valid == true
+      and .counts.landed == 1
+      and (.landed | length) == 1
+      and .landed[0].id == "oversized-done"
+  ' >/dev/null || fail "large-backlog secondmate summary changed or truncated"
+  pass "fleet snapshot file-feeds backlog JSON larger than the argv limit"
+}
+
 test_fixture_snapshot_json() {
   local home fakebin out ids
   home=$(make_home fixture)
@@ -780,6 +811,7 @@ test_parked_scout_decision_stays_pending() {
 }
 
 test_empty_fleet_json
+test_large_backlog_json_is_file_fed
 test_fixture_snapshot_json
 test_main_inventory_orphan_and_unstructured_disclosure
 test_normalized_roles_and_plural_blocker_readiness


### PR DESCRIPTION
## Intent

Implement kunchenguid/firstmate issue #1558 exactly as specified. Fix the three fleet-snapshot jq call sites so backlog JSON is file-fed rather than passed through argv, preserving output and cleanup. Use closed PR #1557 only as evidence; do not create a duplicate validation run or reuse its head. Exclude snapshot schema changes. Target main and fully close #1558 with a standalone Closes #1558 line. Add a behavior regression with backlog JSON above 128KB that reproduces the reported failure before the fix and passes afterward. Use no database or browser stack and never run local Cypress. Complete the full No Mistakes pipeline and exact-head CI and mergeability verification, but never merge.

## What Changed

- File-feed backlog JSON into all three fleet-snapshot `jq` call sites to avoid argument-size failures while preserving snapshot schemas and output.
- Add regression coverage using backlog JSON larger than 128 KB for snapshot and secondmate-summary behavior.

Closes #1558

## Risk Assessment

✅ Low: The change cleanly file-feeds backlog JSON at all three required jq boundaries, preserves the existing schemas and behavior, and adds an executable >128KB regression covering both output modes.

## Testing

The focused snapshot/view behavior suite passed, and manual before/after CLI verification reproduced the argv-limit failure at the base commit while confirming both target snapshot modes preserve and process backlog JSON above 128 KiB; reviewer-visible CLI evidence was captured and the worktree was left clean.

<details>
<summary>Evidence: Large-backlog end-to-end transcript</summary>

`143,462-byte backlog: before fix, jq failed with “Argument list too long”; after fix, both snapshot modes succeeded without truncation.`

```text
fixture_backlog_bytes=143462
before_fix_exit=1
before_fix_error=/tmp/no-mistakes-evidence/01KZTB6MJ58KW1DBVA5JSC494Z/before-bin/fm-fleet-snapshot.sh: line 611: /usr/bin/jq: Argument list too long
fm-fleet-snapshot: main inventory summary failed
after_fix_exit=0
after_fix_schema=fm-fleet-snapshot.v1
after_fix_record_id=oversized-done
after_fix_title_length=143360
after_fix_task_count=0
summary_schema=fm-secondmate-home-summary.v1
summary_valid=true
summary_landed_id=oversized-done
```
</details>
<details>
<summary>Evidence: Focused fleet snapshot/view behavior test</summary>

```text
ok - empty fleet snapshot and view use explicit absence markers
ok - fleet snapshot file-feeds backlog JSON larger than the argv limit
ok - fixture snapshot covers task rows, backlog rows, pointers, and stable ordering
ok - main_inventory discloses orphan/unstructured and clears when inventory is consistent
ok - backlog normalization preserves strict roles and resolves every blocker compatibly
ok - snapshot event hints follow reconciled current state
ok - durable fold keeps an open decision past a later unrelated event
ok - a live secondmate endpoint preserves unrelated open decisions
ok - durable captain-held transfer closes the duplicate live status decision
ok - durable fold clears a decision only on a keyed resolution
ok - a completed scout's stale decision surfaces as a report pointer, not pending
ok - a scout still parked at a decision stays pending (terminal clear does not over-fire)
ok - snapshot includes durable scout reports after teardown
ok - snapshot parses tasks-axi rows and respects operational overrides
ok - fleet view renders the snapshot without secondmate peek guidance
ok - fleet view renders secondmate agent liveness
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"f36dda9f7bdbe05d51e94551d8a28f2ab3c094f5","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `/bin/bash tests/fm-fleet-snapshot-view.test.sh`
- <code>Executed the base-commit `fm-fleet-snapshot.sh --json` against a 143,462-byte backlog; reproduced `/usr/bin/jq: Argument list too long`.</code>
- <code>Executed target `bin/fm-fleet-snapshot.sh --json` against the same backlog; verified `fm-fleet-snapshot.v1`, record `oversized-done`, and the complete 143,360-character title.</code>
- <code>Executed target `bin/fm-fleet-snapshot.sh --secondmate-home-summary` against the same backlog; verified `fm-secondmate-home-summary.v1`, valid inventory, and landed record `oversized-done`.</code>
- <code>Verified `git status --porcelain` was empty after testing.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
