### PR TITLE
fix(bin): sanitize unsupported Darwin C.UTF-8 locales

### DIFF
--- a/bin/fm-backend-hometag-lib.sh
+++ b/bin/fm-backend-hometag-lib.sh
@@ -26,6 +26,13 @@
 # an accepted limitation, no worse than the existing fact that a task's
 # recorded absolute worktree path does not survive a move either.
 
+# Best-effort for hand-built partial bin/ fixtures without this sibling.
+FM_LOCALE_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/fm-locale-lib.sh"
+if [ -f "$FM_LOCALE_LIB" ]; then
+  # shellcheck source=bin/fm-locale-lib.sh
+  . "$FM_LOCALE_LIB"
+fi
+
 FM_BACKEND_HOMETAG_SECONDMATE_MARKER=".fm-secondmate-home"
 
 fm_backend_hometag() {

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -59,6 +59,11 @@
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Best-effort for hand-built partial bin/ fixtures without this sibling.
+if [ -f "$SCRIPT_DIR/fm-locale-lib.sh" ]; then
+  # shellcheck source=bin/fm-locale-lib.sh
+  . "$SCRIPT_DIR/fm-locale-lib.sh"
+fi
 FLEET="$SCRIPT_DIR/fm-fleet-snapshot.sh"
 # shellcheck source=bin/fm-timeout-lib.sh
 # shellcheck disable=SC1091

--- a/bin/fm-check-lib.sh
+++ b/bin/fm-check-lib.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# Best-effort for hand-built partial bin/ fixtures without this sibling.
+FM_LOCALE_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/fm-locale-lib.sh"
+if [ -f "$FM_LOCALE_LIB" ]; then
+  # shellcheck source=bin/fm-locale-lib.sh
+  . "$FM_LOCALE_LIB"
+fi
+
 FM_CUSTOM_CHECK_HASH=
 FM_CUSTOM_CHECK_SNAPSHOT=
 

--- a/bin/fm-config-inherit-lib.sh
+++ b/bin/fm-config-inherit-lib.sh
@@ -51,6 +51,13 @@
 # reconciled by the ordinary remote sync/update path before the transfer
 # succeeds; there is no separate allowlist version negotiation.
 #
+# Best-effort for hand-built partial bin/ fixtures without this sibling.
+FM_LOCALE_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/fm-locale-lib.sh"
+if [ -f "$FM_LOCALE_LIB" ]; then
+  # shellcheck source=bin/fm-locale-lib.sh
+  . "$FM_LOCALE_LIB"
+fi
+
 # shellcheck source=bin/fm-startup-memory-budget-lib.sh
 . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/fm-startup-memory-budget-lib.sh"
 

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -56,6 +56,11 @@ FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 
+# Best-effort for hand-built partial bin/ fixtures without this sibling.
+if [ -f "$SCRIPT_DIR/fm-locale-lib.sh" ]; then
+  # shellcheck source=bin/fm-locale-lib.sh
+  . "$SCRIPT_DIR/fm-locale-lib.sh"
+fi
 # shellcheck source=bin/fm-tmux-lib.sh
 . "$SCRIPT_DIR/fm-tmux-lib.sh"
 # shellcheck source=bin/fm-backend.sh

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -45,6 +45,12 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 
+# Best-effort for hand-built partial bin/ fixtures without this sibling.
+if [ -f "$SCRIPT_DIR/fm-locale-lib.sh" ]; then
+  # shellcheck source=bin/fm-locale-lib.sh
+  # shellcheck disable=SC1091
+  . "$SCRIPT_DIR/fm-locale-lib.sh"
+fi
 # shellcheck source=bin/fm-classify-lib.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-classify-lib.sh"

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -60,6 +60,11 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+# Best-effort for hand-built partial bin/ fixtures without this sibling.
+if [ -f "$SCRIPT_DIR/fm-locale-lib.sh" ]; then
+  # shellcheck source=bin/fm-locale-lib.sh
+  . "$SCRIPT_DIR/fm-locale-lib.sh"
+fi
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"

--- a/bin/fm-fleet-sync.sh
+++ b/bin/fm-fleet-sync.sh
@@ -33,6 +33,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
+# Best-effort for hand-built partial bin/ fixtures without this sibling.
+if [ -f "$SCRIPT_DIR/fm-locale-lib.sh" ]; then
+  # shellcheck source=bin/fm-locale-lib.sh
+  . "$SCRIPT_DIR/fm-locale-lib.sh"
+fi
 # shellcheck source=bin/fm-lock-lib.sh
 . "$SCRIPT_DIR/fm-lock-lib.sh"
 # Inert unless FM_TIMING_LOG names a file; only the deferred network stage sets it.

--- a/bin/fm-locale-lib.sh
+++ b/bin/fm-locale-lib.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# bin/fm-locale-lib.sh - the single owner of locale sanitization for
+# supervision-critical Perl and shasum paths.
+#
+# macOS system Perl can panic before executing when it inherits C.UTF-8 through
+# LC_CTYPE or LANG while LC_ALL is unset. C.UTF-8 is valid on modern Linux, so
+# this repair is deliberately Darwin-only. It uses bash's builtin OSTYPE rather
+# than uname because supervision helpers can run with a restricted PATH.
+#
+# Source this file before invoking Perl or shasum. Sourcing applies the repair
+# immediately and is idempotent. Explicit LC_ALL values and all other locales
+# are preserved.
+
+fm_locale_sanitize() {
+  [ -z "${LC_ALL:-}" ] || return 0
+  case "${OSTYPE:-}" in
+    darwin*) ;;
+    *) return 0 ;;
+  esac
+  case "${LC_CTYPE:-}${LANG:-}" in
+    *C.UTF-8*) export LC_ALL=C ;;
+  esac
+}
+
+fm_locale_sanitize

--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -17,6 +17,13 @@
 # The receipt binds the terminal observation to the canonical registration and
 # lets a restart finish fixed-path removal without executing state-file bytes.
 
+# Best-effort for hand-built partial bin/ fixtures without this sibling.
+FM_LOCALE_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/fm-locale-lib.sh"
+if [ -f "$FM_LOCALE_LIB" ]; then
+  # shellcheck source=bin/fm-locale-lib.sh
+  . "$FM_LOCALE_LIB"
+fi
+
 FM_PR_PROVIDER=
 FM_PR_URL=
 FM_PR_HOST=

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -218,6 +218,11 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+# Best-effort for hand-built partial bin/ fixtures without this sibling.
+if [ -f "$SCRIPT_DIR/fm-locale-lib.sh" ]; then
+  # shellcheck source=bin/fm-locale-lib.sh
+  . "$SCRIPT_DIR/fm-locale-lib.sh"
+fi
 COMPLETION_FILE="$STATE/.session-start-complete"
 AGENTS_BASELINE_FILE="$STATE/.session-start-agents-baseline"
 

--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -61,6 +61,11 @@
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Best-effort for hand-built partial bin/ fixtures without this sibling.
+if [ -f "$SCRIPT_DIR/fm-locale-lib.sh" ]; then
+  # shellcheck source=bin/fm-locale-lib.sh
+  . "$SCRIPT_DIR/fm-locale-lib.sh"
+fi
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 

--- a/bin/fm-watch-checkpoint.sh
+++ b/bin/fm-watch-checkpoint.sh
@@ -4,6 +4,11 @@
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Best-effort for hand-built partial bin/ fixtures without this sibling.
+if [ -f "$SCRIPT_DIR/fm-locale-lib.sh" ]; then
+  # shellcheck source=bin/fm-locale-lib.sh
+  . "$SCRIPT_DIR/fm-locale-lib.sh"
+fi
 SECONDS_ARG=${FM_CODEX_WATCH_CHECKPOINT:-180}
 
 usage() {

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -78,6 +78,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-supervisor-target-lib.sh` | Resolve the shared supervisor target and backend for the daemon and launcher       |
 | `fm-supervise-daemon.sh` | Presence-gated away-mode sub-supervisor: self-handle routine wakes, guard injection by the detected primary harness, escalate batched digests, alert on failed delivery |
 | `fm-crew-state.sh`       | Print one deterministic current-state line for a crew                                |
+| `fm-locale-lib.sh`       | Sanitize unsupported inherited Darwin C.UTF-8 for supervision-critical Perl and shasum paths |
 | `fm-nm-run-lib.sh`       | Shared branch-and-code-identity attribution for no-mistakes runs                    |
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification          |
 | `fm-timeout-lib.sh`      | Single owner of hard-bounded command execution and its fallback watchdog |

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -1116,6 +1116,37 @@ SH
   pass "no timeout command uses perl bound"
 }
 
+test_no_timeout_perl_bound_survives_broken_darwin_locale() {
+  reset_fakes
+  local d toolbin real_perl out
+  d=$(new_case no-timeout-broken-locale)
+  make_repo_on_branch "$d/wt" fm/feat-locale
+  make_fakebin "$d" >/dev/null
+  toolbin=$(make_no_timeout_toolbin "$d")
+  real_perl=$(command -v perl)
+  rm -f "$toolbin/perl"
+  cat > "$toolbin/perl" <<'SH'
+#!/usr/bin/env bash
+if [ "${LC_ALL:-}" != C ] && { [ "${LC_CTYPE:-}" = C.UTF-8 ] || [ "${LANG:-}" = C.UTF-8 ]; }; then
+  echo "panic: unsupported inherited C.UTF-8" >&2
+  exit 9
+fi
+exec "$FM_FAKE_REAL_PERL" "$@"
+SH
+  chmod +x "$toolbin/perl"
+  fm_write_meta "$d/state/feat-locale.meta" "window=fm:fm-feat-locale" "worktree=$d/wt" "kind=ship" \
+    "harness=claude"
+  FM_FAKE_AXI_STATUS="$(run_running fm/feat-locale)"
+  # shellcheck disable=SC2016  # Positional expansion is intentionally deferred to the child bash.
+  out=$(env -u LC_ALL LC_CTYPE=C.UTF-8 LANG=C.UTF-8 \
+    PATH="$d/fakebin:$toolbin" FM_FAKE_REAL_PERL="$real_perl" FM_STATE_OVERRIDE="$d/state" \
+    FM_CREW_STATE_NM_TIMEOUT=5 bash -c 'OSTYPE=darwin24; . "$1" "$2"' \
+    _ "$CREW_STATE" feat-locale)
+  assert_contains "$out" "state: working" "active run must survive the broken inherited Darwin locale"
+  assert_contains "$out" "source: run-step" "locale repair must preserve the perl-bound run-step lookup"
+  pass "the perl-bound no-mistakes lookup survives a broken inherited Darwin C.UTF-8 locale"
+}
+
 # (i) kind=scout skips the run lookup entirely (its deliverable is a report).
 test_scout_skips_run_lookup() {
   reset_fakes
@@ -1348,6 +1379,7 @@ test_dead_window_ignores_stale_status_log
 test_dead_window_still_reports_terminal_run_step
 test_dead_window_still_reports_active_run_step
 test_no_timeout_uses_perl_bound
+test_no_timeout_perl_bound_survives_broken_darwin_locale
 test_scout_skips_run_lookup
 test_torn_down_worktree
 test_missing_meta

--- a/tests/fm-locale-lib.test.sh
+++ b/tests/fm-locale-lib.test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# tests/fm-locale-lib.test.sh - focused coverage for Darwin C.UTF-8 sanitization.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+LOCALE_LIB="$ROOT/bin/fm-locale-lib.sh"
+TMP_ROOT=$(fm_test_tmproot fm-locale-lib)
+
+run_locale_case() {  # <ostype> <lc-ctype> <lang> <lc-all-or-unset>
+  local ostype=$1 lc_ctype=$2 lang=$3 lc_all=$4
+  if [ "$lc_all" = unset ]; then
+    # shellcheck disable=SC2016  # Positional and locale expansion belongs to the child bash.
+    env -u LC_ALL LC_CTYPE="$lc_ctype" LANG="$lang" bash -c \
+      'OSTYPE=$1; . "$2"; printf "%s\n" "${LC_ALL:-unset}"' _ "$ostype" "$LOCALE_LIB"
+  else
+    LC_ALL="$lc_all" LC_CTYPE="$lc_ctype" LANG="$lang" bash -c \
+      'OSTYPE=$1; . "$2"; printf "%s\n" "$LC_ALL"' _ "$ostype" "$LOCALE_LIB"
+  fi
+}
+
+test_darwin_c_utf8_is_sanitized() {
+  local out
+  out=$(run_locale_case darwin24 C.UTF-8 C.UTF-8 unset)
+  [ "$out" = C ] || fail "Darwin C.UTF-8 must export LC_ALL=C, got '$out'"
+  pass "fm_locale_sanitize: broken C.UTF-8 locale on Darwin exports LC_ALL=C"
+}
+
+test_darwin_lang_alone_is_sanitized() {
+  local out
+  out=$(run_locale_case darwin24 '' C.UTF-8 unset)
+  [ "$out" = C ] || fail "Darwin LANG=C.UTF-8 must export LC_ALL=C, got '$out'"
+  pass "fm_locale_sanitize: LANG=C.UTF-8 alone on Darwin triggers sanitization"
+}
+
+test_darwin_lc_ctype_alone_is_sanitized() {
+  local out
+  out=$(run_locale_case darwin24 C.UTF-8 '' unset)
+  [ "$out" = C ] || fail "Darwin LC_CTYPE=C.UTF-8 must export LC_ALL=C, got '$out'"
+  pass "fm_locale_sanitize: LC_CTYPE=C.UTF-8 alone on Darwin triggers sanitization"
+}
+
+test_sanitized_locale_makes_fixture_perl_executable_without_uname() {
+  local toolbin="$TMP_ROOT/no-uname" out
+  mkdir -p "$toolbin"
+  ln -s "$(command -v bash)" "$toolbin/bash"
+  cat > "$toolbin/perl" <<'SH'
+#!/usr/bin/env bash
+[ "${LC_ALL:-}" = C ] || {
+  echo "panic: unsupported inherited C.UTF-8" >&2
+  exit 9
+}
+printf 'perl-ok\n'
+SH
+  chmod +x "$toolbin/perl"
+  # shellcheck disable=SC2016  # The library path is expanded by the restricted child bash.
+  out=$(env -u LC_ALL LC_CTYPE=C.UTF-8 LANG=C.UTF-8 PATH="$toolbin" bash -c \
+    'OSTYPE=darwin24; . "$1"; perl' _ "$LOCALE_LIB" 2>&1)
+  [ "$out" = perl-ok ] || fail "sanitized fixture perl must execute without uname on PATH, got '$out'"
+  pass "fm_locale_sanitize: restricted PATH child perl runs after sanitization"
+}
+
+test_working_darwin_locale_is_untouched() {
+  local out
+  out=$(run_locale_case darwin24 en_US.UTF-8 en_US.UTF-8 unset)
+  [ "$out" = unset ] || fail "working Darwin UTF-8 locale must remain untouched, got '$out'"
+  pass "fm_locale_sanitize: working Darwin UTF-8 locale is untouched"
+}
+
+test_explicit_lc_all_is_preserved() {
+  local out
+  out=$(run_locale_case darwin24 C.UTF-8 C.UTF-8 POSIX)
+  [ "$out" = POSIX ] || fail "explicit LC_ALL must be preserved, got '$out'"
+  pass "fm_locale_sanitize: explicit LC_ALL is preserved"
+}
+
+test_linux_c_utf8_is_untouched() {
+  local out
+  out=$(run_locale_case linux-gnu C.UTF-8 C.UTF-8 unset)
+  [ "$out" = unset ] || fail "Linux C.UTF-8 must remain untouched, got '$out'"
+  pass "fm_locale_sanitize: Linux C.UTF-8 is untouched"
+}
+
+test_resourcing_is_idempotent() {
+  local out
+  # shellcheck disable=SC2016  # Library paths and LC_ALL are expanded by the child bash.
+  out=$(env -u LC_ALL LC_CTYPE=C.UTF-8 LANG=C.UTF-8 bash -c \
+    'OSTYPE=darwin24; . "$1"; . "$1"; printf "%s\n" "$LC_ALL"' _ "$LOCALE_LIB")
+  [ "$out" = C ] || fail "re-sourcing must leave LC_ALL=C, got '$out'"
+  pass "fm_locale_sanitize: re-sourcing is idempotent"
+}
+
+test_darwin_c_utf8_is_sanitized
+test_darwin_lang_alone_is_sanitized
+test_darwin_lc_ctype_alone_is_sanitized
+test_sanitized_locale_makes_fixture_perl_executable_without_uname
+test_working_darwin_locale_is_untouched
+test_explicit_lc_all_is_preserved
+test_linux_c_utf8_is_untouched
+test_resourcing_is_idempotent


### PR DESCRIPTION
## Intent

Implement kunchenguid/firstmate#724 exactly as specified by the full issue.
Add one Darwin-only locale-sanitization owner for inherited unsupported `C.UTF-8` and wire only supervision-critical Perl and `shasum` paths, preserving explicit `LC_ALL`, working Darwin locales, Linux behavior, and partial fixtures.
Exclude general locale policy.
Target `main`, reproduce the failure with hermetic fixtures, add focused integration coverage, complete No Mistakes plus exact-head CI and mergeability validation, and never merge.

## What Changed

- Add a Darwin-only locale helper that replaces inherited `C.UTF-8` with `LC_ALL=C` while preserving explicit `LC_ALL`, supported locales, and Linux behavior.
- Source the helper from supervision-critical Perl and `shasum` paths, with optional loading for partial fixtures.
- Add focused locale-owner and crew-state regression coverage.

## Decisions

- Keep sanitization narrowly scoped to Darwin and only the inherited `C.UTF-8` failure when `LC_ALL` is unset; explicit `LC_ALL`, working Darwin locales, and Linux behavior remain untouched.
- Use bash builtin `OSTYPE` instead of `uname` so the repair works in supervision helpers with restricted tool paths.
- Wire only supervision-critical Perl and `shasum` paths, and existence-guard every source point so partial `bin` fixtures remain compatible.
- Do not establish or broaden general locale policy.

Closes #724

## Risk Assessment

Low. The behavior change is Darwin-only and conditional, while the executable regression matrix covers the preserved boundaries.

## Testing

- `bash tests/fm-locale-lib.test.sh`
- `bash tests/fm-crew-state.test.sh`
- `bin/fm-lint.sh`
- No Mistakes review, test, documentation, lint, push, PR, and CI gates.
- Exact head `439922bae4a22a76b397e1912a927db83cf928d0`: 13 checks passed, 0 failed.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"439922bae4a22a76b397e1912a927db83cf928d0","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>Validation evidence</summary>

- Review completed with no findings.
- The focused sanitizer suite verifies Darwin `LC_CTYPE` and `LANG` repair, restricted `PATH`, explicit `LC_ALL`, working Darwin locales, Linux behavior, and idempotency.
- The crew-state suite exercises the real Perl timeout fallback under a hermetic unsupported Darwin-locale fixture.
- Repository ShellCheck lint passed at the pinned version.
- GitHub CI passed all 13 checks at the exact PR head.

</details>