### PR TITLE
fix: prevent open PRs from authorizing teardown

### DIFF
--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -9,8 +9,9 @@
 # reachable from any remote-tracking branch (a fork counts as a remote, so
 # upstream-contribution PRs pushed to a fork satisfy this in any mode), OR - for a
 # normal ship task whose commits are not so reachable - when its PR is merged and
-# GitHub reports a PR head that contains the current local work, or its content is
-# already present in the up-to-date default branch. This recognizes the common
+# GitHub reports a PR head that contains the current local work, or - when no
+# recorded or discoverable PR is known to be unmerged - its content is already
+# present in the up-to-date default branch. This recognizes the common
 # squash-merge-then-delete-branch flow, where the branch's own commits live nowhere
 # on a remote yet the change is fully in main.
 # The PR itself is resolved from the task's recorded pr= when present, or - when
@@ -19,6 +20,7 @@
 # up a merged PR whose head branch matches the worktree's branch, fetching its head
 # via refs/pull/<n>/head when the branch itself was deleted. So a missing pr= never
 # by itself causes a false refusal of landed work.
+# A known open or closed-unmerged PR blocks the content fallback.
 # A gh lookup error falls back to the content check; if that is also inconclusive,
 # teardown refuses rather than risk discarding unlanded work.
 # Uncommitted changes are never landed.
@@ -830,7 +832,9 @@ EOF
 # PR from the recorded pr= URL first, then from the branch name, and asks GitHub
 # for both the PR state and head. Returns non-zero when the PR is not merged, the
 # current work is not contained in the PR head, no PR is found, or any gh error
-# occurs - the caller then falls back to the content check.
+# occurs. Returns 2 when the resolved PR is known to be open or closed without a
+# merge, so the caller refuses without consulting the provenance-blind content
+# fallback.
 pr_is_merged() {
   local branch=$1 target view state head current
   if [ -n "$PR_URL" ]; then
@@ -845,6 +849,7 @@ pr_is_merged() {
   [ "$state" != "$view" ] || return 1
   case "$state" in
     MERGED|merged) ;;
+    OPEN|open|CLOSED|closed) return 2 ;;
     *) return 1 ;;
   esac
   [ -n "$head" ] || return 1
@@ -882,11 +887,16 @@ content_in_default() {
 # Has the worktree's committed work actually LANDED, though its commits are not
 # reachable from any remote-tracking branch? True when a merged PR proves the
 # current local work is contained in the PR head, OR the content is already in the
-# default branch (fallback, which also covers the no-PR and gh-error paths). False
-# only for genuinely unlanded work.
+# default branch and no resolved PR is known to be unmerged. The fallback still
+# covers the no-PR and gh-error paths. False only for genuinely unlanded work.
 work_is_landed() {
-  local branch=$1
-  pr_is_merged "$branch" && return 0
+  local branch=$1 pr_rc
+  if pr_is_merged "$branch"; then
+    return 0
+  else
+    pr_rc=$?
+  fi
+  [ "$pr_rc" -ne 2 ] || return 1
   content_in_default
 }
 

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -40,6 +40,7 @@
 #   (q) no-mistakes + NO pr= recorded, PR discovered by branch  -> ALLOW  (yolo/no-CI merge)
 #   (z) no-mistakes + recorded OPEN PR + sibling content landed -> REFUSE (live PR wins)
 #   (aa) no-mistakes + gh lookup error + content in default      -> ALLOW  (fallback preserved)
+#   (ab) no-mistakes + discovered OPEN PR + sibling content landed -> REFUSE (live PR wins)
 #
 # Also covers backlog teardown-lock-race: a git index.lock left in the worktree by a
 # killed crew process (bin/fm-teardown.sh's teardown_treehouse_return).
@@ -942,6 +943,31 @@ test_open_pr_with_sibling_content_in_default_refuses() {
   assert_present "$case_dir/state/task-x1.meta" "open-pr-sibling-content: teardown removed task metadata"
   assert_present "$case_dir/state/task-x1.status" "open-pr-sibling-content: teardown removed task status"
   pass "recorded open PR prevents sibling content in default from authorizing teardown"
+}
+
+test_discovered_open_pr_with_sibling_content_in_default_refuses() {
+  local case_dir rc pr_head
+  case_dir=$(make_case discovered-open-pr-sibling-content)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  pr_head=$(git -C "$case_dir/wt" rev-parse HEAD)
+  add_gh_pr_open_for_head "$case_dir" "$pr_head"
+  printf '%s\n' 'done: PR checks green but not merged' > "$case_dir/state/task-x1.status"
+
+  # No pr= is recorded: teardown must discover the branch's open PR before it
+  # considers content equality with an independently landed sibling change.
+  land_on_origin_main "$case_dir" feature.txt hello
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "discovered-open-pr-sibling-content: teardown should refuse while the discovered PR is open"
+  grep -q REFUSED "$case_dir/stderr" || fail "discovered-open-pr-sibling-content: no REFUSED line in stderr"
+  assert_present "$case_dir/state/task-x1.meta" "discovered-open-pr-sibling-content: teardown removed task metadata"
+  assert_present "$case_dir/state/task-x1.status" "discovered-open-pr-sibling-content: teardown removed task status"
+  pass "discovered open PR prevents sibling content in default from authorizing teardown"
 }
 
 test_gh_error_with_content_in_default_allows() {
@@ -2696,6 +2722,7 @@ test_pr_check_does_not_refresh_stale_pr_head
 test_pr_check_records_remote_head_when_local_lags
 test_content_in_default_fallback_allows
 test_open_pr_with_sibling_content_in_default_refuses
+test_discovered_open_pr_with_sibling_content_in_default_refuses
 test_gh_error_with_content_in_default_allows
 test_content_fallback_refreshes_stale_origin_ref
 test_dirty_worktree_refuses

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -38,6 +38,8 @@
 #   (o) fm-pr-check rerun after HEAD moved                      -> no stale pr_head
 #   (p) fm-pr-check when local HEAD lags                        -> record remote PR head
 #   (q) no-mistakes + NO pr= recorded, PR discovered by branch  -> ALLOW  (yolo/no-CI merge)
+#   (z) no-mistakes + recorded OPEN PR + sibling content landed -> REFUSE (live PR wins)
+#   (aa) no-mistakes + gh lookup error + content in default      -> ALLOW  (fallback preserved)
 #
 # Also covers backlog teardown-lock-race: a git index.lock left in the worktree by a
 # killed crew process (bin/fm-teardown.sh's teardown_treehouse_return).
@@ -274,6 +276,35 @@ case "\${1:-} \${2:-}" in
   "pr view")
     case " \$* " in
       *"state,headRefOid"*) printf '%s\t%s\n' 'MERGED' '$head' ; exit 0 ;;
+      *"headRefOid"*) printf '%s\n' '$head' ; exit 0 ;;
+    esac
+    ;;
+esac
+echo "error: pull request not found" >&2
+exit 1
+SH
+  chmod +x "$case_dir/fakebin/gh-axi" "$case_dir/fakebin/gh"
+}
+
+# Override GitHub lookups to report PR 7 as open with the supplied head.
+add_gh_pr_open_for_head() {
+  local case_dir=$1 head=$2
+  cat > "$case_dir/fakebin/gh-axi" <<'SH'
+#!/usr/bin/env bash
+case "${1:-} ${2:-}" in
+  "pr list")
+    printf '%s\n' "count: 1 (showing first 1)" "pull_requests[1]{number,state}:" "  7,open" ; exit 0 ;;
+  "pr view")
+    printf '%s\n' "pull_request:" "  number: 7" "  state: open" ; exit 0 ;;
+esac
+exit 0
+SH
+  cat > "$case_dir/fakebin/gh" <<SH
+#!/usr/bin/env bash
+case "\${1:-} \${2:-}" in
+  "pr view")
+    case " \$* " in
+      *"state,headRefOid"*) printf '%s\t%s\n' 'OPEN' '$head' ; exit 0 ;;
       *"headRefOid"*) printf '%s\n' '$head' ; exit 0 ;;
     esac
     ;;
@@ -885,6 +916,51 @@ test_content_in_default_fallback_allows() {
   expect_code 0 "$rc" "content-landed: teardown should succeed when content is already in the default branch"
   ! grep -q REFUSED "$case_dir/stderr" || fail "content-landed: teardown printed a REFUSED line"
   pass "worktree whose content already landed in the default branch is torn down (content fallback)"
+}
+
+test_open_pr_with_sibling_content_in_default_refuses() {
+  local case_dir rc pr_head
+  case_dir=$(make_case open-pr-sibling-content)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  append_pr_meta_for_current_head "$case_dir"
+  pr_head=$(git -C "$case_dir/wt" rev-parse HEAD)
+  add_gh_pr_open_for_head "$case_dir" "$pr_head"
+  printf '%s\n' 'done: PR checks green but not merged' > "$case_dir/state/task-x1.status"
+
+  # A sibling PR independently lands the same content while this task's own
+  # recorded PR remains open. Content equality must not authorize teardown.
+  land_on_origin_main "$case_dir" feature.txt hello
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "open-pr-sibling-content: teardown should refuse while the recorded PR is open"
+  grep -q REFUSED "$case_dir/stderr" || fail "open-pr-sibling-content: no REFUSED line in stderr"
+  assert_present "$case_dir/state/task-x1.meta" "open-pr-sibling-content: teardown removed task metadata"
+  assert_present "$case_dir/state/task-x1.status" "open-pr-sibling-content: teardown removed task status"
+  pass "recorded open PR prevents sibling content in default from authorizing teardown"
+}
+
+test_gh_error_with_content_in_default_allows() {
+  local case_dir rc
+  case_dir=$(make_case gh-error-content-landed)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  append_pr_meta_for_current_head "$case_dir"
+  add_gh_axi_error "$case_dir"
+  land_on_origin_main "$case_dir" feature.txt hello
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "gh-error-content-landed: teardown should retain the content fallback on lookup error"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "gh-error-content-landed: teardown printed a REFUSED line"
+  pass "GitHub lookup error retains the content-in-default fallback"
 }
 
 test_content_fallback_refreshes_stale_origin_ref() {
@@ -2619,6 +2695,8 @@ test_merged_pr_with_later_local_commit_refuses
 test_pr_check_does_not_refresh_stale_pr_head
 test_pr_check_records_remote_head_when_local_lags
 test_content_in_default_fallback_allows
+test_open_pr_with_sibling_content_in_default_refuses
+test_gh_error_with_content_in_default_allows
 test_content_fallback_refreshes_stale_origin_ref
 test_dirty_worktree_refuses
 test_gh_error_and_content_absent_refuses


### PR DESCRIPTION
## Intent

Implement kunchenguid/firstmate#986 exactly as specified: ensure a recorded or discoverable open/non-merged PR prevents fm-teardown's content-in-default fallback from authorizing teardown, while preserving merged-PR, no-PR, GitHub lookup-error, and existing fail-safe behavior. Add hermetic executable-interface regression coverage for an open recorded PR whose sibling content independently landed on origin/main. Exclude broader provenance redesign. Target main and fully close the issue with a standalone 'Closes #986' in the PR. Do not use a database/browser stack or local Cypress. Complete No Mistakes plus exact-head CI and mergeability validation, and never merge the PR. For validation, treat the unchanged leaked-process-reap failure as pre-existing unrelated evidence because the identical isolated case fails on fetched origin/main; use the focused open-PR sibling-content and preserved-path teardown regressions instead of repeating the same broad run.

## What Changed

- Prevent teardown when a recorded or branch-discovered pull request is open or closed without being merged, even if matching content exists on the default branch.
- Preserve the content-in-default fallback when no pull request is found or GitHub lookup fails.
- Add hermetic regressions for the open-PR sibling-content case and the GitHub-error fallback path.

## Risk Assessment

✅ Low: The change is narrowly scoped, preserves the required fallback paths, blocks teardown for recorded or discoverable known-unmerged PRs, and adds executable-interface regression coverage for the reported failure.

## Testing

Targeted executable fm-teardown validation passed end-to-end: an open recorded PR blocked teardown despite identical sibling content on origin/main, while merged-PR, discoverable merged-PR, no-PR content fallback, GitHub-error fallback, dirty-worktree, unlanded-work, and lookup-error fail-safe behavior remained intact. The broader run later encountered the explicitly acknowledged unchanged leaked-process-reap failure, which was treated as pre-existing unrelated evidence per the supplied intent.

<details>
<summary>Evidence: Focused fm-teardown executable-interface evidence</summary>

<code>ok - no-mistakes worktree with genuinely unlanded work is refused (safety preserved)&#10;ok - squash-merged + deleted-branch worktree (PR merged) is torn down (the fix)&#10;ok - teardown discovers a merged PR by branch name and tears down when no pr= was ever recorded&#10;ok - worktree whose content already landed in the default branch is torn down (content fallback)&#10;ok - recorded open PR prevents sibling content in default from authorizing teardown&#10;ok - GitHub lookup error retains the content-in-default fallback&#10;ok - dirty worktree is refused even when its committed work has landed (dirty always wins)&#10;ok - gh lookup error with content not in default refuses (fail-safe)</code>

```text
ok - no-mistakes worktree with genuinely unlanded work is refused (safety preserved)
ok - squash-merged + deleted-branch worktree (PR merged) is torn down (the fix)
ok - teardown discovers a merged PR by branch name and tears down when no pr= was ever recorded
ok - worktree whose content already landed in the default branch is torn down (content fallback)
ok - recorded open PR prevents sibling content in default from authorizing teardown
ok - GitHub lookup error retains the content-in-default fallback
ok - dirty worktree is refused even when its committed work has landed (dirty always wins)
ok - gh lookup error with content not in default refuses (fail-safe)
```
</details>
<details>
<summary>Evidence: Broader teardown transcript, including acknowledged pre-existing leaked-process-reap failure</summary>

```text
ok - local-only worktree with HEAD on a fork remote is torn down (fix holds)
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no live watcher process holds this home lock (last beat: 0s ago).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  repair missing watcher supervision according to the session-start block for this harness; do not use shell &.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
warning: lsof is unavailable; cannot resolve the tmux pane process group for task-x1
ok - teardown prompts tasks-axi backlog refresh when compatible
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no live watcher process holds this home lock (last beat: 1s ago).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  repair missing watcher supervision according to the session-start block for this harness; do not use shell &.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
warning: lsof is unavailable; cannot resolve the tmux pane process group for task-x1
ok - teardown honors config/backlog-backend=manual even when tasks-axi is compatible
ok - local-only worktree with truly unpushed work is refused (safety preserved)
ok - local-only worktree with work merged into local main is torn down (no regression)
ok - no-mistakes worktree with HEAD on origin is torn down (no regression)
ok - no-mistakes worktree with genuinely unlanded work is refused (safety preserved)
ok - local-only worktree with unpushed work is torn down under --force (escape hatch)
ok - teardown completes when an exact busy-state sidecar is already absent
ok - herdr teardown removes pane-owned escalation dedupe state
ok - herdr flat teardown refuses before returning the isolated copy under lock contention and the retry completes cleanly
ok - herdr flat teardown never erases records when pane presence is unparseable
ok - herdr flat teardown preflight refuses before every destructive change
ok - forced secondmate teardown preflights every Herdr child before cleanup mutation
ok - forced secondmate teardown holds every descendant lifecycle and metadata lock
ok - forced secondmate teardown retains Herdr child identity until exact pane disappearance
ok - forced teardown retains a nested secondmate home and its grandchild's Herdr identity when the grandchild close is unconfirmed
ok - herdr projection teardown retires its journal only after confirming the exact recorded pane is gone
ok - herdr projection teardown retains every record when post-close presence is unknown
ok - herdr projection teardown surfaces failed focus restoration without turning confirmed cleanup into a hard failure
ok - squash-merged + deleted-branch worktree (PR merged) is torn down (the fix)
ok - squash-merged PR accepts a local HEAD that is an ancestor of the final PR head
ok - teardown discovers a merged PR by branch name and tears down when no pr= was ever recorded
ok - squash-merged PR accepts replayed unpushed local patches contained in the PR head
ok - merged PR does not allow teardown after a later local commit
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no live watcher process holds this home lock (last beat: 1s ago).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  repair missing watcher supervision according to the session-start block for this harness; do not use shell &.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
WARNING: watcher still down (same stale episode; last beat: 6s ago, grace 300s) - full banner already printed this episode.
ok - fm-pr-check does not refresh PR head after HEAD moves
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no live watcher process holds this home lock (last beat: 1s ago).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  repair missing watcher supervision according to the session-start block for this harness; do not use shell &.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
ok - fm-pr-check records the remote PR head when the local worktree lags
ok - worktree whose content already landed in the default branch is torn down (content fallback)
ok - recorded open PR prevents sibling content in default from authorizing teardown
ok - GitHub lookup error retains the content-in-default fallback
ok - content fallback refreshes origin default before comparing trees
ok - dirty worktree is refused even when its committed work has landed (dirty always wins)
ok - gh lookup error with content not in default refuses (fail-safe)
ok - provably-stale worktree index.lock (old, no live holder) is cleared and teardown succeeds
ok - live-held worktree index.lock is never removed and teardown refuses
ok - lsof errors leave worktree index.lock in place and refuse teardown
ok - stale lock cleanup rechecks and refuses dirty worktree before return
ok - normal repo index.lock is resolved from the worktree and cleared when stale
ok - lock mtime read failures leave worktree index.lock in place and refuse teardown
ok - transient index.lock cleared after first failed return is retried successfully without force-remove
ok - persistent index.lock exhausts retries and refuses without force-removing the lock
ok - empty retry wait overrides use the default without aborting teardown
ok - fractional legacy retry wait remains supported without arithmetic
ok - a task's own parked no-mistakes run is aborted, not orphaned, before the worker is removed
ok - teardown refuses before reap or removal when a task-owned run remains parked
ok - a different run cannot confirm the targeted abort
ok - empty post-abort status is not accepted as confirmation
ok - the CLI's exact run-not-found signal confirms completion
ok - a parked run on another branch is never aborted by this task's teardown (ownership is precise)
ok - a task-owned autonomous running step is left alone rather than aborted
not ok - leaked-process-reap: leaked worktree process survived teardown
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"49fc936cd8dc7f8ac5327de8f61132d078d7807a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-teardown.test.sh` — all intent-relevant cases passed before the supplied acceptance-context-exempt `leaked-process-reap` failure occurred</code>
- <code>Focused executable harness invocation of `test_no_mistakes_truly_unpushed_refuses`, `test_squash_merged_branch_deleted_allows`, `test_no_pr_recorded_discovers_merged_pr_by_branch_allows`, `test_content_in_default_fallback_allows`, `test_open_pr_with_sibling_content_in_default_refuses`, `test_gh_error_with_content_in_default_allows`, `test_dirty_worktree_refuses`, and `test_gh_error_and_content_absent_refuses` — exited 0</code>
- <code>`git status --short` — confirmed testing left the worktree unchanged</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
