### PR TITLE
test(session): support Bash 3.2 contender identity

### DIFF
--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -903,7 +903,8 @@ SH
   i=1
   while [ "$i" -le 40 ]; do
     (
-      harness_pid=$(sh -c 'printf "%s\n" "$PPID"')
+      # Bash 3.2 has no BASHPID, so ask a child for this contender's parent pid.
+      harness_pid=${BASHPID:-$(sh -c 'printf "%s\n" "$PPID"')}
       : > "$home/state/harness-$harness_pid"
       : > "$ready/$i"
       while [ "$(find "$ready" -type f | wc -l | tr -d ' ')" -lt 40 ]; do


### PR DESCRIPTION
## Intent

Implement kunchenguid/firstmate#1241 exactly as specified by the issue: make only the concurrent session-lock test contender identity in tests/fm-session-start.test.sh compatible with stock macOS Bash 3.2, while preserving the existing Linux behavior. Exclude all product session-lock behavior and unrelated portability work. Target main and fully close #1241 with a standalone closing reference `Closes #1241`. Prove the reported fixture fails before and passes after where supported. Do not use a database or browser stack and never run local Cypress. Apply firstmate-coding-guidelines. Complete the full No Mistakes pipeline plus exact-head CI and mergeability validation, but never merge the PR. The scoped implementation should retain direct BASHPID identity on Bash versions that provide it and use a child-reported parent PID only as the Bash 3.2 fallback.

## What Changed

- Update the concurrent session-lock test to use `BASHPID` when available and fall back to a child-reported parent PID for Bash 3.2 compatibility.

## Risk Assessment

✅ Low: The change is narrowly scoped to the test fixture and correctly preserves direct BASHPID identity where available while using a child-reported parent PID only as the Bash 3.2 fallback.

## Testing

Inspected the one-file test-only diff, ran the focused concurrency fixture before and after on Linux, and directly exercised both contender-identity paths; Linux behavior passes, while the requested macOS Bash 3.2 failure-before/pass-after proof remains unavailable in this Linux-only environment.

<details>
<summary>Evidence: Target concurrency behavior on Linux</summary>

```text
Environment: GNU bash 5.2.21 on Linux
Target focused concurrency fixture: exit 0
ok - concurrent session-lock acquisition admits exactly one live harness
```
</details>
<details>
<summary>Evidence: Direct and fallback contender identity paths</summary>

```text
contender=187871 direct-BASHPID=187871 child-reported-parent=187871
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (4m45s)

## Decisions

- Stock macOS Bash 3.2 was unavailable on the Linux implementation host. Under the accepted ship-cycle authority, the exact-head `Stock macOS Bash snapshot compatibility` CI job is the authoritative evidence-equivalent validation for this regression; review readiness requires that job to pass.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"113e9bc93730bd6bf013c0e11300c6757e1e1f29","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `tests/fm-session-start.test.sh:907` - The required stock macOS Bash 3.2 before/after reproduction could not be demonstrated because this Linux environment only provides Bash 5.2. The focused fixture and both identity mechanisms pass on Linux, but macOS evidence must come from exact-head CI or a macOS host.
- `git diff --unified=80 b5d430d6fdcd961ce9b681bf196f365c1825c284..113e9bc93730bd6bf013c0e11300c6757e1e1f29 -- tests/fm-session-start.test.sh`
- <code>Isolated `test_session_lock_concurrent_single_winner` from the base revision under GNU Bash 5.2.21 on Linux; passed with exactly one live-harness winner</code>
- <code>Isolated `test_session_lock_concurrent_single_winner` from target commit 113e9bc93730bd6bf013c0e11300c6757e1e1f29 under GNU Bash 5.2.21 on Linux; passed with exactly one live-harness winner</code>
- <code>`bash -c &#39;direct=$BASHPID; fallback=$(sh -c &#39;\&#39;&#39;printf &#34;%s&#34; &#34;$PPID&#34;&#39;\&#39;&#39;); ...&#39;` verified direct BASHPID and child-reported parent PID both equal the contender PID</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

Closes #1241