### PR TITLE
test: cover fail-closed session lock acquisition

### DIFF
--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -175,7 +175,7 @@ family_for_basename() {
     fm-send-secondmate-marker.test.sh|fm-shared-captain-inheritance.test.sh)
       printf '%s\n' secondmate
       ;;
-    fm-bootstrap.test.sh|fm-fleet-sync.test.sh|fm-gate-refuse.test.sh|fm-gotmp.test.sh|\
+    fm-bootstrap.test.sh|fm-fleet-sync.test.sh|fm-gate-refuse.test.sh|fm-gotmp.test.sh|fm-lock.test.sh|\
     fm-session-start.test.sh|fm-sessionstart-nudge.test.sh|fm-startup-network.test.sh|\
     fm-tangle-guard.test.sh|fm-update.test.sh)
       printf '%s\n' session-bootstrap

--- a/tests/fm-lock.test.sh
+++ b/tests/fm-lock.test.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# tests/fm-lock.test.sh - session-lock acquisition publication failures.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-lock)
+LOCK="$ROOT/bin/fm-lock.sh"
+
+make_fake_ps() {  # <case-dir>
+  local fakebin
+  fakebin=$(fm_fakebin "$1")
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$field" in
+  comm=|args=) printf '%s\n' codex ;;
+  ppid=) printf '%s\n' 1 ;;
+  *) exit 1 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+  printf '%s\n' "$fakebin"
+}
+
+test_state_creation_failure_is_read_only() {
+  local dir state out status
+  dir="$TMP_ROOT/state-creation"
+  mkdir -p "$dir"
+  : > "$dir/not-a-directory"
+  state="$dir/not-a-directory/state"
+
+  status=0
+  out=$(FM_STATE_OVERRIDE="$state" "$LOCK" 2>&1) || status=$?
+
+  [ "$status" -ne 0 ] || fail "state creation failure reported successful lock acquisition"
+  assert_contains "$out" "cannot create session-lock state directory" \
+    "state creation failure did not explain the read-only boundary"
+  assert_not_contains "$out" "lock acquired" \
+    "state creation failure printed a successful acquisition"
+  [ ! -e "$state/.lock" ] || fail "state creation failure published a session lock"
+  pass "fm-lock: state creation failure fails closed"
+}
+
+test_lock_write_failure_is_read_only() {
+  local dir state fakebin out status
+  dir="$TMP_ROOT/lock-write"
+  state="$dir/state"
+  mkdir -p "$state"
+  fakebin=$(make_fake_ps "$dir")
+  chmod 0500 "$state"
+
+  status=0
+  out=$(PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" "$LOCK" 2>&1) || status=$?
+  chmod 0700 "$state"
+
+  [ "$status" -ne 0 ] || fail "lock write failure reported successful acquisition"
+  assert_contains "$out" "cannot write session lock" \
+    "lock write failure did not explain the read-only boundary"
+  assert_not_contains "$out" "lock acquired" \
+    "lock write failure printed a successful acquisition"
+  [ ! -e "$state/.lock" ] || fail "lock write failure left a published session lock"
+  pass "fm-lock: lock write failure fails closed"
+}
+
+test_post_write_ownership_mismatch_is_read_only() {
+  local dir state fakebin out status
+  dir="$TMP_ROOT/ownership-mismatch"
+  state="$dir/state"
+  mkdir -p "$state"
+  fakebin=$(make_fake_ps "$dir")
+  cat > "$fakebin/cat" <<'SH'
+#!/usr/bin/env bash
+set -u
+if [ "${1:-}" = "${FM_TEST_CORRUPT_LOCK:-}" ]; then
+  printf '%s\n' 999999
+  exit 0
+fi
+exec /bin/cat "$@"
+SH
+  chmod +x "$fakebin/cat"
+
+  status=0
+  out=$(PATH="$fakebin:$PATH" FM_TEST_CORRUPT_LOCK="$state/.lock" \
+    FM_STATE_OVERRIDE="$state" "$LOCK" 2>&1) || status=$?
+
+  [ "$status" -ne 0 ] || fail "ownership mismatch reported successful lock acquisition"
+  assert_contains "$out" "session lock ownership verification failed" \
+    "ownership mismatch did not explain the read-only boundary"
+  assert_not_contains "$out" "lock acquired" \
+    "ownership mismatch printed a successful acquisition"
+  pass "fm-lock: post-write ownership mismatch fails closed"
+}
+
+test_success_publishes_verified_owner() {
+  local dir state fakebin out status owner
+  dir="$TMP_ROOT/success"
+  state="$dir/state"
+  mkdir -p "$state"
+  fakebin=$(make_fake_ps "$dir")
+
+  status=0
+  out=$(PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" "$LOCK" 2>&1) || status=$?
+
+  expect_code 0 "$status" "successful acquisition must exit zero"
+  assert_contains "$out" "lock acquired: harness pid " \
+    "successful acquisition did not report its verified owner"
+  owner=${out##*harness pid }
+  [ "$(cat "$state/.lock")" = "$owner" ] \
+    || fail "successful acquisition did not publish the reported owner"
+  pass "fm-lock: successful acquisition preserves its verified-owner behavior"
+}
+
+test_live_holder_preserves_contention_behavior() {
+  local dir state fakebin out status holder recorded
+  dir="$TMP_ROOT/contention"
+  state="$dir/state"
+  mkdir -p "$state"
+  fakebin=$(make_fake_ps "$dir")
+  sleep 30 &
+  holder=$!
+  printf '%s\n' "$holder" > "$state/.lock"
+
+  status=0
+  out=$(PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" "$LOCK" 2>&1) || status=$?
+  recorded=$(cat "$state/.lock")
+  kill "$holder" 2>/dev/null || true
+  wait "$holder" 2>/dev/null || true
+
+  [ "$status" -ne 0 ] || fail "contention with a live holder reported successful acquisition"
+  assert_contains "$out" "another live firstmate session holds the lock (pid $holder)" \
+    "contention did not identify the live holder"
+  assert_not_contains "$out" "lock acquired" \
+    "contention printed a successful acquisition"
+  [ "$recorded" = "$holder" ] || fail "contention replaced the live holder's lock"
+  pass "fm-lock: live-holder contention behavior is preserved"
+}
+
+test_state_creation_failure_is_read_only
+test_lock_write_failure_is_read_only
+test_post_write_ownership_mismatch_is_read_only
+test_success_publishes_verified_owner
+test_live_holder_preserves_contention_behavior

--- a/tests/fm-lock.test.sh
+++ b/tests/fm-lock.test.sh
@@ -52,23 +52,25 @@ test_state_creation_failure_is_read_only() {
 }
 
 test_lock_write_failure_is_read_only() {
-  local dir state fakebin out status
+  local dir state fakebin out status recorded
   dir="$TMP_ROOT/lock-write"
   state="$dir/state"
   mkdir -p "$state"
   fakebin=$(make_fake_ps "$dir")
-  chmod 0500 "$state"
+  printf '%s\n' 999999 > "$state/.lock"
+  chmod 0400 "$state/.lock"
 
   status=0
   out=$(PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" "$LOCK" 2>&1) || status=$?
-  chmod 0700 "$state"
+  recorded=$(cat "$state/.lock")
+  chmod 0600 "$state/.lock"
 
   [ "$status" -ne 0 ] || fail "lock write failure reported successful acquisition"
   assert_contains "$out" "cannot write session lock" \
     "lock write failure did not explain the read-only boundary"
   assert_not_contains "$out" "lock acquired" \
     "lock write failure printed a successful acquisition"
-  [ ! -e "$state/.lock" ] || fail "lock write failure left a published session lock"
+  [ "$recorded" = 999999 ] || fail "lock write failure replaced the stale lock owner"
   pass "fm-lock: lock write failure fails closed"
 }
 


### PR DESCRIPTION
## Intent

Implement kunchenguid/firstmate#1131 exactly as specified by gh-axi issue view 1131 -R kunchenguid/firstmate --full. Make session-lock acquisition fail closed when state creation, lock write, or post-write ownership verification fails; preserve successful and contention behavior. Exclude unrelated lock redesign. Target main and fully close #1131 with standalone `Closes #1131`. Use no database or browser stack and never local Cypress. Follow firstmate-coding-guidelines. Add focused regression coverage without touching live state. Because main already contains the required runtime fail-closed checks from adjacent prior work, close the issue by pinning those executable behaviors rather than redesigning the lock. Complete No Mistakes and verify exact-head CI and mergeability, but never merge.

## What Changed

- Add focused regression coverage for fail-closed session-lock acquisition when state creation, lock writes, or ownership verification fail.
- Pin successful acquisition and live-holder contention behavior without touching live state.
- Register the new lock suite with the session-bootstrap test family.

## Risk Assessment

✅ Low: The change is limited to executable regression coverage and test-family registration. The corrected case reaches the guarded lock write while preserving coverage of successful acquisition and contention behavior.

## Testing

Inspected the diff and repository guidance, ran the focused lock regressions directly and through the registered runner, manually verified real CLI success and fail-closed state-creation behavior, captured reviewer-visible transcripts, and confirmed a clean worktree; all required behavior passed.

<details>
<summary>Evidence: Focused runner transcript</summary>

<code>Runner classified the regression under `session-bootstrap` and executed all focused cases successfully.</code>

```text
FM_TEST_BEGIN 2026-08-12T07:16:52Z tests/fm-lock.test.sh family=session-bootstrap expected_gate_skip=none
ok - fm-lock: state creation failure fails closed
ok - fm-lock: lock write failure fails closed
ok - fm-lock: post-write ownership mismatch fails closed
ok - fm-lock: successful acquisition preserves its verified-owner behavior
ok - fm-lock: live-holder contention behavior is preserved
FM_TEST_END 2026-08-12T07:16:55Z tests/fm-lock.test.sh exit=0 duration_ms=2054 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=2163
FM_TEST_SUMMARY_FAMILY family=session-bootstrap count=1 duration_ms=2054 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-lock.test.sh duration_ms=2054
```
</details>
<details>
<summary>Evidence: Verified CLI experience</summary>

`A real CLI acquisition persisted its reported owner; an invalid state path exited 1 with the required read-only diagnostic.`

```text
$ FM_STATE_OVERRIDE=<evidence>/success-state bin/fm-lock.sh
lock acquired: harness pid 2324802
persisted lock owner: 2324802

$ FM_STATE_OVERRIDE=<file>/state bin/fm-lock.sh
error: cannot create session-lock state directory /tmp/no-mistakes-evidence/01KZT9FHSSBBSXE0NCWVC6G5XM/manual-cli-verified/not-a-directory/state; operate read-only until resolved
exit status: 1
```
</details>

## Decisions

- Chose Fix for `lock-write-test-stops-at-probe` under ship-cycle authority because the accepted task requires behavioral coverage of the guarded `.lock` write after the publication probe succeeds.
- Evidence: exact-head validation at `c6c0b6cc2cfb50a21c8655c1c13c642b162032cc` passed `tests/fm-lock.test.sh`, including `fm-lock: lock write failure fails closed`; No Mistakes re-reviewed the corrected case with no remaining findings.

Closes #1131

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c6c0b6cc2cfb50a21c8655c1c13c642b162032cc","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `tests/fm-lock.test.sh:60` - The required focused regression coverage for “lock write” does not reach the lock write itself. Making the state directory read-only causes the earlier `mktemp &#34;$STATE/.lock-write.XXXXXX&#34;` publication probe to fail, so this test would still pass if the guarded `printf &gt; &#34;$LOCK&#34;` were later regressed to unchecked success. This contradicts the intent to pin the executable behavior when “lock write ... fails.” Exercise a failure that occurs after the probe succeeds, such as a pre-existing stale read-only regular `.lock` file, and assert nonzero/no acquisition.

🔧 Fix: Fix lock-write regression to reach guarded write
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --stat b5d430d6fdcd961ce9b681bf196f365c1825c284..c6c0b6cc2cfb50a21c8655c1c13c642b162032cc`
- `bash tests/fm-lock.test.sh`
- `bin/fm-test-run.sh --list --family session-bootstrap | rg '^tests/fm-lock\.test\.sh$'`
- `bin/fm-test-run.sh tests/fm-lock.test.sh --json /tmp/no-mistakes-evidence/01KZT9FHSSBBSXE0NCWVC6G5XM/fm-lock-runner.json`
- <code>Manual `FM_STATE_OVERRIDE` CLI verification of successful acquisition/persisted ownership and state-directory creation failure/exit status</code>
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>