### PR TITLE
fix(bin): preserve identity for quoted decision hold retries

### DIFF
--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -128,6 +128,15 @@ show_field() {  # <show-output> <field>
   printf '%s\n' "$output" | sed -n "s/^  $field: //p" | head -1
 }
 
+show_string_field() {  # <show-output> <field>
+  local value
+  value=$(show_field "$1" "$2")
+  case "$value" in
+    \"*\") printf '%s\n' "$value" | jq -Rer 'fromjson | select(type == "string")' ;;
+    *) printf '%s\n' "$value" ;;
+  esac
+}
+
 origin_exists_here() {  # <origin-id>
   [ -f "$STATE/$1.meta" ] && return 0
   [ -f "$DATA/$1/report.md" ] && return 0
@@ -265,11 +274,8 @@ command_hold() {
   if show=$(task_show "$id"); then
     state=$(show_field "$show" state)
     kind=$(show_field "$show" kind)
-    existing_title=$(show_field "$show" title)
-    # tasks-axi quotes punctuation-heavy titles in show output.
-    case "$existing_title" in
-      \"*\") existing_title=${existing_title#\"}; existing_title=${existing_title%\"} ;;
-    esac
+    existing_title=$(show_string_field "$show" title) \
+      || fail "existing captain hold $id has an invalid encoded title"
     [ "$state" != "done" ] || fail "captain decision $id is already durably resolved; use a new decision key for a new decision"
     [ "$kind" = captain ] || fail "existing backlog identity $id is not kind captain"
     [ "$existing_title" = "$title" ] || fail "existing captain hold $id has a different title"

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -266,6 +266,10 @@ command_hold() {
     state=$(show_field "$show" state)
     kind=$(show_field "$show" kind)
     existing_title=$(show_field "$show" title)
+    # tasks-axi quotes punctuation-heavy titles in show output.
+    case "$existing_title" in
+      \"*\") existing_title=${existing_title#\"}; existing_title=${existing_title%\"} ;;
+    esac
     [ "$state" != "done" ] || fail "captain decision $id is already durably resolved; use a new decision key for a new decision"
     [ "$kind" = captain ] || fail "existing backlog identity $id is not kind captain"
     [ "$existing_title" = "$title" ] || fail "existing captain hold $id has a different title"

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -132,7 +132,43 @@ show_string_field() {  # <show-output> <field>
   local value
   value=$(show_field "$1" "$2")
   case "$value" in
-    \"*\") printf '%s\n' "$value" | jq -Rer 'fromjson | select(type == "string")' ;;
+    \"*\")
+      printf '%s\n' "$value" | awk '
+        function hex_value(hex,    digits, value, i, digit) {
+          digits = "0123456789abcdef"
+          hex = tolower(hex)
+          value = 0
+          for (i = 1; i <= 4; i++) {
+            digit = index(digits, substr(hex, i, 1)) - 1
+            if (digit < 0) return -1
+            value = value * 16 + digit
+          }
+          return value
+        }
+        {
+          if (length($0) < 2 || substr($0, 1, 1) != "\"" || substr($0, length($0), 1) != "\"") exit 1
+          decoded = ""
+          for (i = 2; i < length($0); i++) {
+            char = substr($0, i, 1)
+            if (char != "\\") {
+              decoded = decoded char
+              continue
+            }
+            escape = substr($0, ++i, 1)
+            if (escape == "\\" || escape == "\"") decoded = decoded escape
+            else if (escape == "n") decoded = decoded "\n"
+            else if (escape == "r") decoded = decoded "\r"
+            else if (escape == "t") decoded = decoded "\t"
+            else if (escape == "u") {
+              code = hex_value(substr($0, i + 1, 4))
+              if (code < 0 || code > 31) exit 1
+              decoded = decoded sprintf("%c", code)
+              i += 4
+            } else exit 1
+          }
+          print decoded
+        }
+      ' ;;
     *) printf '%s\n' "$value" ;;
   esac
 }

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -43,11 +43,13 @@ The projection remains read-only and does not inspect historical prose.
 Verification date: 2026-07-14.
 Additional quoted `blocked_by` regression verification date: 2026-07-17.
 Plural blocker-readiness and mixed-home projection verification date: 2026-07-22.
+Quoted-title retry regression verification date: 2026-08-12.
 
 The focused end-to-end regression uses only synthetic `sample` identities and decision text.
 It begins with a completed investigation and visual review whose genuine unresolved choice exists only in the report.
 The initial Bearings snapshot correctly has no open decision, and the new teardown gate refuses to erase the source.
 A later regression covers tasks-axi's quoted multi-entry `blocked_by` output so `resolve` matches the first, middle, and last ids and rejects a genuinely absent id.
+The quoted-title regression creates a punctuation-heavy captain hold, repeats the identical `hold` call without changing its identity, and verifies that a genuinely changed title still fails closed.
 
 The final verification commands and their exact summarized outputs follow.
 
@@ -61,6 +63,7 @@ ok - ended visual review follows the same decision-hold completion owner
 ok - resolved findings and decision-like prose do not create false holds
 ok - terminal single-owner stale status decisions do not block empty inventory
 ok - main-home and secondmate-home captain holds remain correctly routed
+ok - quoted-title hold retries preserve exact identity and reject changed titles
 ok - resolve matches first/middle/last in quoted blocked_by and rejects a genuinely absent id
 
 $ bash tests/fm-fleet-snapshot-view.test.sh

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -455,6 +455,47 @@ EOF
   pass "main-home and secondmate-home captain holds remain correctly routed"
 }
 
+test_hold_retry_matches_quoted_title() {
+  local home origin title hold retry show
+  home=$(make_home quoted-title-retry)
+  origin=sample-budget-review
+  title='Is sample budget-bucket computation done locally per edge site, or centrally with buckets shipped to edge Redis over Kafka?'
+  mkdir -p "$home/data/$origin"
+  tasks_in "$home" add "$origin" "Review sample budget routing" --kind scout --repo sample --start >/dev/null \
+    || fail "could not create quoted-title origin"
+  write_origin_meta "$home" "$origin"
+  printf 'done: report complete\n' > "$home/state/$origin.status"
+  printf '# Sample budget review\n\nOne routing decision remains.\n' > "$home/data/$origin/report.md"
+
+  hold=$(run_decisions "$home" hold "$origin" bucket-route \
+    --title "$title" --reason "captain budget route pending" --repo sample) \
+    || fail "could not register quoted-title hold"
+  show=$(tasks_in "$home" show "$hold" --full)
+  assert_contains "$show" "title: \"$title\"" \
+    "quoted-title fixture must exercise tasks-axi's quoted rendering"
+
+  retry=$(run_decisions "$home" hold "$origin" bucket-route \
+    --title "$title" --reason "captain budget route pending" --repo sample) \
+    || fail "identical quoted-title hold retry failed"
+  [ "$retry" = "$hold" ] || fail "identical quoted-title retry changed task identity: $retry"
+  [ "$(grep -cE "^- \[ \] $hold -" "$home/data/backlog.md")" = 1 ] \
+    || fail "identical quoted-title retry duplicated the hold"
+
+  if run_decisions "$home" hold "$origin" bucket-route \
+    --title "Choose a different sample budget route" \
+    --reason "captain budget route pending" --repo sample \
+    > "$home/changed-title.out" 2> "$home/changed-title.err"; then
+    fail "quoted-title hold accepted a changed title for the same identity"
+  fi
+  assert_grep "has a different title" "$home/changed-title.err" \
+    "changed title must retain the identity-collision refusal"
+  show=$(tasks_in "$home" show "$hold" --full)
+  assert_contains "$show" "title: \"$title\"" "changed-title refusal altered the original title"
+  assert_contains "$show" "held: yes" "changed-title refusal released the captain hold"
+
+  pass "quoted-title hold retries preserve exact identity and reject changed titles"
+}
+
 # tasks-axi quotes multi-entry blocked_by values as "a,b,c". resolve must strip
 # those surrounding quotes before comma-boundary membership so the first and last
 # list elements match, not only middle elements.
@@ -559,4 +600,5 @@ test_visual_review_uses_shared_completion_owner
 test_none_inventory_and_resolved_prose_do_not_create_holds
 test_terminal_single_owner_status_decision_does_not_block_empty_inventory
 test_secondmate_hold_stays_in_authoritative_home
+test_hold_retry_matches_quoted_title
 test_resolve_matches_quoted_blocked_by_edges

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -459,7 +459,7 @@ test_hold_retry_matches_quoted_title() {
   local home origin title hold retry show
   home=$(make_home quoted-title-retry)
   origin=sample-budget-review
-  title='Is sample budget-bucket computation done locally per edge site, or centrally with buckets shipped to edge Redis over Kafka?'
+  title='Is sample "budget-bucket" computation local at C:\edge\site, or central?'
   mkdir -p "$home/data/$origin"
   tasks_in "$home" add "$origin" "Review sample budget routing" --kind scout --repo sample --start >/dev/null \
     || fail "could not create quoted-title origin"
@@ -471,7 +471,7 @@ test_hold_retry_matches_quoted_title() {
     --title "$title" --reason "captain budget route pending" --repo sample) \
     || fail "could not register quoted-title hold"
   show=$(tasks_in "$home" show "$hold" --full)
-  assert_contains "$show" "title: \"$title\"" \
+  assert_contains "$show" 'title: "Is sample \"budget-bucket\" computation local at C:\\edge\\site, or central?"' \
     "quoted-title fixture must exercise tasks-axi's quoted rendering"
 
   retry=$(run_decisions "$home" hold "$origin" bucket-route \
@@ -490,7 +490,8 @@ test_hold_retry_matches_quoted_title() {
   assert_grep "has a different title" "$home/changed-title.err" \
     "changed title must retain the identity-collision refusal"
   show=$(tasks_in "$home" show "$hold" --full)
-  assert_contains "$show" "title: \"$title\"" "changed-title refusal altered the original title"
+  assert_contains "$show" 'title: "Is sample \"budget-bucket\" computation local at C:\\edge\\site, or central?"' \
+    "changed-title refusal altered the original title"
   assert_contains "$show" "held: yes" "changed-title refusal released the captain hold"
 
   pass "quoted-title hold retries preserve exact identity and reject changed titles"

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -458,6 +458,7 @@ EOF
 test_hold_retry_matches_quoted_title() {
   local home origin title hold retry show
   home=$(make_home quoted-title-retry)
+  fm_fake_exit0 "$home/fakebin" jq
   origin=sample-budget-review
   title='Is sample "budget-bucket" computation local at C:\edge\site, or central?'
   mkdir -p "$home/data/$origin"


### PR DESCRIPTION
## Intent

Implement kunchenguid/firstmate#1599 exactly as specified. Make decision-hold creation idempotent for titles containing characters quoted by tasks-axi while preserving exact task identity and existing hold semantics. Exclude backlog-format redesign. Target main and fully close #1599 with a standalone . Use no database or browser stack and never run local Cypress. Reproduce the failure with hermetic punctuation-heavy quoted titles and add focused repeated-call coverage. Normalize only tasks-axi's balanced presentation quotes for the existing-title comparison so identical retries retain one task identity while genuinely changed titles still fail closed. Complete No Mistakes and exact-head CI/mergeability, and never merge the PR.

## What Changed

- Decode tasks-axi’s balanced quoted title rendering before comparing an existing captain hold, preserving task identity for identical retries.
- Continue failing closed for invalid encodings and genuinely changed titles.
- Add focused punctuation-heavy retry coverage and document the regression.

## Risk Assessment

✅ Low: The change is narrowly scoped, semantically decodes tasks-axi’s quoted title representation without adding a new dependency, preserves unquoted values and fail-closed identity checks, and includes executable repeated-call regression coverage for quotes and backslashes.

## Testing

The targeted lifecycle suite and hermetic CLI/state walkthrough passed: balanced tasks-axi presentation quotes normalize for identical retries, one task identity is retained, and genuinely changed titles still fail closed. No browser, database, Cypress, lint, or broad suite was run.

<details>
<summary>Evidence: Quoted-title CLI transcript</summary>

```text
$ fm-decision-hold.sh hold sample-budget-review bucket-route --title <punctuation-heavy-title> ...
first identity: sample-budget-review-decision-bucket-route

$ tasks-axi show sample-budget-review-decision-bucket-route --full
task:
  id: sample-budget-review-decision-bucket-route
  title: "Is sample \"budget-bucket\" computation local at C:\\edge\\site, or central?"
  state: queued
  blocked: no
  blocked_by: none
  held: yes
  hold_reason: captain budget route pending
  hold_kind: captain
  hold_until: "-"
  kind: captain
  repo: sample
  priority: "-"
  created: 2026-08-12
  closed: "-"
  deps: none
  links: none
  body: "Origin: sample-budget-review\nDecision key: bucket-route\nState: awaiting captain decision."

$ repeat identical hold call
retry identity: sample-budget-review-decision-bucket-route
persisted live entries for identity: 1

$ retry same identity with a genuinely changed title
fm-decision-hold: existing captain hold sample-budget-review-decision-bucket-route has a different title
exit status: 1

$ tasks-axi show sample-budget-review-decision-bucket-route --full (after refusal)
task:
  id: sample-budget-review-decision-bucket-route
  title: "Is sample \"budget-bucket\" computation local at C:\\edge\\site, or central?"
  state: queued
  blocked: no
  blocked_by: none
  held: yes
  hold_reason: captain budget route pending
  hold_kind: captain
  hold_until: "-"
  kind: captain
  repo: sample
  priority: "-"
  created: 2026-08-12
  closed: "-"
  deps: none
  links: none
  body: "Origin: sample-budget-review\nDecision key: bucket-route\nState: awaiting captain decision."
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"29b0d7bd914b42035a5b2587b4768b69cf5f8c3f","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-decision-hold.sh:270` - The new normalization removes only TOON&#39;s outer quotes but does not decode escaped title bytes. `tasks-axi show` renders valid one-line titles containing `&#34;` or `\` as escaped sequences (for example, `A &#34;quoted&#34; choice` becomes `&#34;A \&#34;quoted\&#34; choice&#34;`), so an identical retry still compares unequal and fails. This contradicts the required exact-title idempotency. Decode the quoted TOON scalar at the shared `show_field` boundary (or with an equivalent semantic parser), and add repeated-call coverage containing literal quotes and backslashes.

🔧 Fix: Decode escaped decision titles for idempotent retries
1 error still open:
- 🚨 `bin/fm-decision-hold.sh:135` - A quoted-title retry now requires `jq`, but `jq` is not part of the universal toolchain and is only required for selected backends/features. On a supported tmux home with compatible `tasks-axi` but no `jq`, initial hold creation succeeds, while the identical retry reaches this command, fails with `jq: command not found`, and is reported as an invalid title. Decode the scalar without introducing an undeclared optional dependency, or establish and enforce `jq` as a prerequisite at the supported command boundary.

🔧 Fix: Remove jq dependency from quoted title retries
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected the target diff against `b5d430d6fdcd961ce9b681bf196f365c1825c284` for acceptance-criteria coverage.</code>
- `bash tests/fm-decision-hold-lifecycle.test.sh`
- <code>Hermetic real-CLI walkthrough using `tasks-axi 0.2.5`: created a punctuation-heavy quoted hold, repeated it identically, verified one persisted identity, attempted a changed title, and inspected the preserved held state.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
