### PR TITLE
fix: make Pi Calm quiet by default

### DIFF
--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -22,8 +22,8 @@ document:
     evidence destination, and unique safety facts, then review the complete
     branch diff again after every documentation or lint fix.
 
-# Pin lint to the same owner CI runs instead of leaving it to no-mistakes'
-# default handling, which does not invoke the repository's canonical lint gate.
+# Run the same lint owner CI runs through the repository's Nix ShellCheck
+# environment instead of relying on no-mistakes' ambient PATH.
 # `bin/fm-lint.sh` owns the complete lint definition and
 # `.github/workflows/ci.yml` invokes it directly, with parity asserted by
 # `tests/fm-lint.test.sh`.
@@ -34,7 +34,7 @@ document:
 # security, Herdr, tmux, and lifecycle coverage). A full-suite override here
 # would duplicate CI and defeat the targeted Test contract.
 commands:
-  lint: 'bin/fm-lint.sh'
+  lint: 'nix shell nixpkgs#shellcheck --command bin/fm-lint.sh'
 
 # Keep test evidence out of this repo; it stays in a temp dir instead.
 test:

--- a/.pi/extensions/fm-calm.ts
+++ b/.pi/extensions/fm-calm.ts
@@ -1,6 +1,6 @@
 // Firstmate's home-persistent Pi transcript presentation toggle.
 //
-// Verified against Pi 0.81.1 and 0.82.0, which expose built-in ToolDefinitions, per-slot
+// Verified against Pi 0.81.1, 0.82.0, and 0.84.0, which expose built-in ToolDefinitions, per-slot
 // renderers, renderShell: "self", session_start replacement reasons, agent_start and
 // agent_settled, ExtensionUIContext.setToolsExpanded(), setWorkingVisible(), setWidget()
 // with a disposable component factory, and setHiddenThinkingLabel().
@@ -47,7 +47,10 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { Box, Container, getKeybindings, type Component } from "@earendil-works/pi-tui";
 import type { TSchema } from "typebox";
-import { installCalmAssistantLayout } from "./lib/fm-calm-assistant-layout.ts";
+import {
+  installCalmAssistantLayout,
+  resetCalmAssistantLayout,
+} from "./lib/fm-calm-assistant-layout.ts";
 import { installCalmOperationalUserLayout } from "./lib/fm-calm-operational-user-layout.ts";
 import {
   CALM_WORKING_SHIP_WIDGET_KEY,
@@ -389,6 +392,7 @@ export default function (pi: ExtensionAPI) {
     reportBuiltInLosses();
     exportRendering = false;
     setCalmPresentation(loadCalmPreference());
+    resetCalmAssistantLayout();
     setCalmStockExportRendering(false);
     publishPresentationState();
     agentRunActive = false;
@@ -422,6 +426,7 @@ export default function (pi: ExtensionAPI) {
         ctx.ui.setToolsExpanded(!expanded);
         ctx.ui.setToolsExpanded(expanded);
       }, 0);
+      return undefined;
     });
   });
 
@@ -447,6 +452,7 @@ export default function (pi: ExtensionAPI) {
       const active = !calmPresentationIsActive();
       persistCalmPreference(active);
       setCalmPresentation(active);
+      resetCalmAssistantLayout();
       if (active) activateBuiltInsIfNeeded(ctx.ui);
       publishPresentationState();
       applyWorkingPresentation(ctx.ui, true);

--- a/.pi/extensions/lib/fm-calm-assistant-layout.ts
+++ b/.pi/extensions/lib/fm-calm-assistant-layout.ts
@@ -1,7 +1,8 @@
-// Verified against Pi 0.81.1 and 0.82.0, which export AssistantMessageComponent with an
-// updateContent method. installCalmAssistantLayout() probes that exact method and throws
-// if it is missing; fm-calm.ts catches that and skips only this adapter with a diagnostic
-// instead of blocking Calm or Pi.
+// Verified against Pi 0.81.1, 0.82.0, and 0.84.0, which export AssistantMessageComponent
+// with updateContent and setHideThinkingBlock methods plus InteractiveMode with
+// toggleThinkingBlockVisibility. installCalmAssistantLayout() probes those exact methods
+// and throws if one is missing; fm-calm.ts catches that and skips only this adapter with a
+// diagnostic instead of blocking Calm or Pi.
 import type { AssistantMessageComponent as PiAssistantMessageComponent } from "@earendil-works/pi-coding-agent";
 import * as PiCodingAgent from "@earendil-works/pi-coding-agent";
 import { calmPresentationHides } from "./fm-calm-visibility.ts";
@@ -14,8 +15,15 @@ type AssistantMessagePresentationState = {
   lastMessage?: AssistantMessage;
 };
 
+type InteractiveThinkingPresentationState = {
+  hideThinkingBlock: boolean;
+  toggleThinkingBlockVisibility(): void;
+};
+
 type CalmAssistantLayoutPatch = {
   hidesThinking: () => boolean;
+  thinkingExpanded: () => boolean;
+  setThinkingExpanded: (expanded: boolean) => void;
 };
 
 // Keep the introduction-version symbol stable so a compatible upgrade cannot
@@ -35,7 +43,11 @@ export function installCalmAssistantLayout(): void {
     return;
   }
 
-  const patch: CalmAssistantLayoutPatch = { hidesThinking };
+  const patch: CalmAssistantLayoutPatch = {
+    hidesThinking,
+    thinkingExpanded: () => false,
+    setThinkingExpanded: () => {},
+  };
   const AssistantMessageComponent = PiCodingAgent.AssistantMessageComponent;
   if (typeof AssistantMessageComponent !== "function") {
     throw new Error("Firstmate Calm requires Pi AssistantMessageComponent");
@@ -44,25 +56,67 @@ export function installCalmAssistantLayout(): void {
   if (typeof originalUpdateContent !== "function") {
     throw new Error("Firstmate Calm requires Pi AssistantMessageComponent.updateContent");
   }
+  const originalSetHideThinkingBlock = AssistantMessageComponent.prototype.setHideThinkingBlock;
+  if (typeof originalSetHideThinkingBlock !== "function") {
+    throw new Error("Firstmate Calm requires Pi AssistantMessageComponent.setHideThinkingBlock");
+  }
+  const InteractiveMode = PiCodingAgent.InteractiveMode as unknown as {
+    prototype: InteractiveThinkingPresentationState;
+  };
+  const originalToggleThinkingBlockVisibility = InteractiveMode.prototype.toggleThinkingBlockVisibility;
+  if (typeof originalToggleThinkingBlockVisibility !== "function") {
+    throw new Error("Firstmate Calm requires Pi InteractiveMode.toggleThinkingBlockVisibility");
+  }
+
+  let thinkingExpanded = false;
+  patch.thinkingExpanded = () => thinkingExpanded;
+  patch.setThinkingExpanded = (expanded) => {
+    thinkingExpanded = expanded;
+  };
+
+  AssistantMessageComponent.prototype.setHideThinkingBlock = function (hide: boolean): void {
+    if (patch.hidesThinking()) patch.setThinkingExpanded(!hide);
+    originalSetHideThinkingBlock.call(this, hide);
+  };
+
+  InteractiveMode.prototype.toggleThinkingBlockVisibility = function (): void {
+    if (patch.hidesThinking()) {
+      const nextExpanded = !patch.thinkingExpanded();
+      patch.setThinkingExpanded(nextExpanded);
+      // Pi's stock toggle negates this field before rebuilding the transcript.
+      // Seed it with the desired expansion so the resulting stock state remains aligned.
+      this.hideThinkingBlock = nextExpanded;
+    }
+    originalToggleThinkingBlockVisibility.call(this);
+  };
 
   AssistantMessageComponent.prototype.updateContent = function (
     message: AssistantMessage,
   ): void {
     const state = this as unknown as AssistantMessagePresentationState;
-    const hideThinking =
-      state.hiddenThinkingLabel === "" &&
-      state.hideThinkingBlock &&
-      patch.hidesThinking();
+    const hideThinking = patch.hidesThinking() && !patch.thinkingExpanded();
     const presentationMessage = hideThinking
       ? {
           ...message,
           content: message.content.filter((block) => block.type !== "thinking"),
         }
       : message;
-
-    originalUpdateContent.call(this, presentationMessage);
+    const restoreHideThinkingBlock = state.hideThinkingBlock;
+    if (patch.hidesThinking() && patch.thinkingExpanded()) state.hideThinkingBlock = false;
+    try {
+      originalUpdateContent.call(this, presentationMessage);
+    } finally {
+      state.hideThinkingBlock = restoreHideThinkingBlock;
+    }
     if (presentationMessage !== message) state.lastMessage = message;
   };
 
   registry[CALM_ASSISTANT_LAYOUT_PATCH] = patch;
+}
+
+export function resetCalmAssistantLayout(): void {
+  const registry = globalThis as typeof globalThis & {
+    [key: symbol]: CalmAssistantLayoutPatch | undefined;
+  };
+  registry[CALM_ASSISTANT_LAYOUT_PATCH]?.setThinkingExpanded(false);
 }

--- a/.pi/extensions/lib/fm-calm-operational-user-layout.ts
+++ b/.pi/extensions/lib/fm-calm-operational-user-layout.ts
@@ -1,5 +1,7 @@
-// Verified against Pi 0.81.1 and 0.82.0, which add the ordinary-user spacer and row
-// together via InteractiveMode.addMessageToChat. This adapter probes that exact method
+// Verified against Pi 0.81.1, 0.82.0, and 0.84.0, which add the ordinary-user spacer and row
+// together via InteractiveMode.addMessageToChat. Pi 0.84.0 also passes Markdown transformers
+// to UserMessageComponent, which this adapter forwards without changing older runtime calls.
+// This adapter probes that exact method
 // and throws if it is missing; fm-calm.ts catches that and skips only this adapter with a
 // diagnostic instead of blocking Calm or Pi. It changes only that presentation and never
 // message delivery.
@@ -25,6 +27,7 @@ type InteractiveModePresentation = {
     addToHistory?(text: string): void;
   };
   getMarkdownThemeWithSettings(): UserMessageConstructorArgs[1];
+  getMarkdownTransformers?(): unknown;
   getUserMessageText(message: UserMessageLike): string;
   outputPad: number;
 };
@@ -104,8 +107,12 @@ export function installCalmOperationalUserLayout(): void {
       markdownTheme: UserMessageConstructorArgs[1],
       outputPad: number,
       hasLeadingSpacer: boolean,
+      markdownTransformers: unknown,
     ) {
-      super(text, markdownTheme, outputPad);
+      // Pi 0.84 added markdown transformers as a fourth constructor argument.
+      // Older Pi versions ignore the extra runtime argument, so one call supports
+      // both declaration shapes without changing the stock off-path rendering.
+      super(text, markdownTheme, outputPad, markdownTransformers as never);
       this.hasLeadingSpacer = hasLeadingSpacer;
     }
 
@@ -136,6 +143,7 @@ export function installCalmOperationalUserLayout(): void {
       this.getMarkdownThemeWithSettings(),
       this.outputPad,
       this.chatContainer.children.length > 0,
+      this.getMarkdownTransformers?.() ?? [],
     );
     this.chatContainer.addChild(component);
     if (options?.populateHistory) this.editor.addToHistory?.(text);

--- a/.pi/extensions/lib/fm-calm-working-ship.ts
+++ b/.pi/extensions/lib/fm-calm-working-ship.ts
@@ -20,7 +20,7 @@
 // or new extension lifetime calls reset() and starts at the normal initial position.
 // State is never a module-level or process-global singleton.
 //
-// Verified against Pi 0.81.1 declarations and the Pi 0.82.0 CLI, which expose
+// Verified against Pi 0.81.1, 0.82.0, and 0.84.0, which expose
 // ExtensionUIContext.setWidget() with a component factory, per-widget dispose(), and
 // TUI.requestRender(). Pi renders a widget through Component.render(width), so this
 // module recomputes its track from that width on every frame instead of caching a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ A crewmate picking up such a brief should load the skill even if the brief preda
 When supervising live crewmates, keep firstmate's own long validation or build commands in the background so watcher wakes can still be handled.
 Crewmate validation follows the installed no-mistakes version's SKILL.md and live `axi` help instead of duplicating gate mechanics in firstmate docs.
 Firstmate's wrapper still matters: crewmates route every `ask-user` finding to firstmate, which applies the authority contract in `AGENTS.md`, and crewmates avoid `--yes` because it would bypass that check and any required captain escalation.
-Local `.no-mistakes/` state and test evidence stay out of this repo; `.no-mistakes.yaml` keeps evidence in a temp directory and pins the gate's lint command to `bin/fm-lint.sh`, matching the Linux CI lint job.
+The firstmate-specific gate defaults and evidence policy are owned by [`docs/configuration.md`](docs/configuration.md#gate-defaults-no-mistakesyaml).
 Local no-mistakes Test is intent-targeted and must not re-run every `tests/*.test.sh`; `.github/workflows/ci.yml` owns the broad behavior suite plus platform-specific compatibility lanes.
 That is firstmate-specific; do not commit `.no-mistakes/evidence/` here even when another no-mistakes-managed target project keeps committed PR evidence.
 

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -14,7 +14,7 @@ Changing persisted context to remove hidden content, filtering provider context,
 
 [`calm.md`](calm.md#pi-compatibility) owns the current Pi compatibility contract.
 Pi 0.81.1 was installed when Calm was first built, Pi 0.82.0 was the later reverification target, and Pi 0.84.0 is the current live verification target.
-The inspected Pi CHANGELOG shows no relevant presentation API introduced at either version, so those versions remain verification evidence rather than compatibility bounds.
+The inspected Pi CHANGELOG does not define a numeric compatibility bound for these presentation seams, so 0.81.1, 0.82.0, and 0.84.0 remain verification evidence rather than compatibility bounds.
 The exported classes used by the adapters (`AssistantMessageComponent` and `InteractiveMode`) are undocumented internals with no stated version guarantee.
 `tests/fm-calm-pi-extension.test.sh` records the installed Pi version as evidence without gating on it and covers both newer synthetic versions and an unavailable adapter seam.
 
@@ -80,7 +80,7 @@ PR 936 removed the unsafe operational-input reroute and preserved legacy zero-he
 
 The fix installs one idempotent presentation adapter, verified on Pi 0.81.1 through 0.84.0, on the exported `AssistantMessageComponent.updateContent` method.
 The adapter probes for that exact method and, per the [compatibility contract](calm.md#pi-compatibility), degrades independently with a diagnostic rather than gating on a version number.
-Only while Calm is active and Pi has collapsed thinking does the adapter pass a shallow thinking-free presentation copy into Pi's ordinary layout calculation, then retain the original message on the component for invalidation and thinking expansion.
+While Calm is active and explicit thinking expansion is not active, the adapter passes a shallow thinking-free presentation copy into Pi's ordinary layout calculation, then retains the original message on the component for invalidation and thinking expansion.
 The persisted assistant message, provider context, tool execution, export data, and expansion history remain unchanged.
 Collapsed thinking-only assistant messages now render zero rows, thinking before visible assistant text adds no spacing beyond the text-only baseline, and expanding thinking still renders the original reasoning.
 
@@ -197,7 +197,7 @@ Serialized session data and Pi 0.81.1's sidebar tree also retain legacy hidden o
 
 ## Complete currently reachable Pi transcript taxonomy
 
-The taxonomy was derived from Pi 0.81.1's installed public declarations, documentation, examples, `interactive-mode.js`, and its exported component implementations.
+The taxonomy was derived from Pi 0.84.0's installed public declarations, documentation, examples, `interactive-mode.js`, and its exported component implementations, with the earlier Pi 0.81.1 and 0.82.0 verification records retained below.
 The test fixture enumerates every class below through the centralized policy, and the interactive fixture exercises the screenshot classes, current user-role operational input, and legacy synthetic presentation entries.
 
 | Policy class | Pi transcript path | Calm result (verified on Pi 0.81.1 through 0.84.0) |
@@ -224,7 +224,7 @@ The test fixture enumerates every class below through the centralized policy, an
 | `unknown` | Future or unclassified transcript component | Policy-hidden, but no generic renderer exists; never claimed as covered. |
 
 The installed extension API has no supported global transcript filter, user-message renderer, assistant-message renderer, chat-container API, or generic custom-tool wrapper.
-Pi 0.81.1 through 0.84.0 export `AssistantMessageComponent` and `InteractiveMode`, so Calm uses separate idempotent, API-probed adapters for assistant thinking layout and the complete operational-user transcript row while leaving all message data and non-Calm rendering unchanged; see the [compatibility contract](calm.md#pi-compatibility) for how a future Pi lacking one of those exports is handled.
+Pi 0.81.1 through 0.84.0 export `AssistantMessageComponent` and `InteractiveMode`, with the required presentation methods available across the verified versions, so Calm uses separate idempotent, API-probed adapters for assistant thinking layout and the complete operational-user transcript row while leaving all message data and non-Calm rendering unchanged; see the [compatibility contract](calm.md#pi-compatibility) for how a future Pi lacking a required class or method is handled.
 General component replacement, ANSI cursor erasure, provider-context mutation, and installed-file patching remain rejected as unsupported or preservation-breaking workarounds.
 
 ## 2026-08-12 Pi 0.84.0 compatibility repair
@@ -263,7 +263,7 @@ This live result covers the harness-dependent presentation and restart behavior 
 
 ## Cross-harness verification record
 
-The original five-harness inspection was performed on 2026-07-22, with every integration surface rechecked and Pi reverified at 0.81.1 on 2026-07-23 for the latest Calm presentation change.
+The original five-harness inspection was performed on 2026-07-22, with every integration surface rechecked and Pi reverified at 0.81.1 on 2026-07-23 for the Calm presentation change current at that time.
 
 ```text
 $ claude --version
@@ -288,7 +288,7 @@ grok 0.2.106 (bde89716f679)
 
 These conclusions are deliberately limited to the named versions and supported surfaces.
 They do not claim that a harness can never add the missing renderer API.
-For the duplicate-turn fix and the latest presentation change, the launch templates for Claude, Codex, OpenCode, Pi, and Grok and the watcher, turn-end, session-start, away-supervisor, and from-firstmate producers were re-inspected.
+For the duplicate-turn fix and the presentation change current at that time, the launch templates for Claude, Codex, OpenCode, Pi, and Grok and the watcher, turn-end, session-start, away-supervisor, and from-firstmate producers were re-inspected.
 The canonical encoder and every non-Pi delivery path remain unchanged, and the tmux, Herdr, Zellij, Orca, and cmux runtime surfaces continue to transport the same input selected by the harness adapter.
 Only Pi's Calm presentation implementation changed; every producer and non-Pi transport remains unchanged.
 
@@ -301,7 +301,7 @@ The operational provider path covers Calm loaded on, loaded off, default prefere
 It asserts one persisted and rendered captain answer, exact user-role operational envelopes in order, no replacement custom messages, one processing result, zero operational transcript rows, and the two-row neighboring-assistant geometry for live, adjacent, and restart paths.
 Quoted current markers, ASCII-only labels, ordinary text before a marker, unrelated U+2063 placement, and image-bearing input remain visible in component and native transcript checks.
 `tests/fm-pi-primary-live-e2e.test.sh` also proves the working ship replaces the built-in `Working...` row while Calm is active on the credentialed provider path, and that it clears when the run settles, before continuing its ordinary watcher lifecycle.
-`tests/fm-pi-primary-types.test.sh` performs strict no-emit TypeScript checking against the installed Pi declarations, currently package version 0.81.1.
+`tests/fm-pi-primary-types.test.sh` performs strict no-emit TypeScript checking against the installed Pi declarations, currently package version 0.84.0.
 
 The relevant commands are:
 

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -13,7 +13,7 @@ Changing persisted context to remove hidden content, filtering provider context,
 ## Compatibility evidence
 
 [`calm.md`](calm.md#pi-compatibility) owns the current Pi compatibility contract.
-Pi 0.81.1 was installed when Calm was first built, and Pi 0.82.0 was the later reverification target.
+Pi 0.81.1 was installed when Calm was first built, Pi 0.82.0 was the later reverification target, and Pi 0.84.0 is the current live verification target.
 The inspected Pi CHANGELOG shows no relevant presentation API introduced at either version, so those versions remain verification evidence rather than compatibility bounds.
 The exported classes used by the adapters (`AssistantMessageComponent` and `InteractiveMode`) are undocumented internals with no stated version guarantee.
 `tests/fm-calm-pi-extension.test.sh` records the installed Pi version as evidence without gating on it and covers both newer synthetic versions and an unavailable adapter seam.
@@ -78,7 +78,7 @@ The single-thinking, tool-call-only, tool-result, Calm-off, and `clearOnShrink` 
 PR 927 made Calm persistent and described controlled rows as gapless while retaining a documented unsupported boundary for collapsed-thinking spacing.
 PR 936 removed the unsafe operational-input reroute and preserved legacy zero-height entries but did not change assistant-message layout.
 
-The fix installs one idempotent presentation adapter, verified on Pi 0.81.1 through 0.82.0, on the exported `AssistantMessageComponent.updateContent` method.
+The fix installs one idempotent presentation adapter, verified on Pi 0.81.1 through 0.84.0, on the exported `AssistantMessageComponent.updateContent` method.
 The adapter probes for that exact method and, per the [compatibility contract](calm.md#pi-compatibility), degrades independently with a diagnostic rather than gating on a version number.
 Only while Calm is active and Pi has collapsed thinking does the adapter pass a shallow thinking-free presentation copy into Pi's ordinary layout calculation, then retain the original message on the component for invalidation and thinking expansion.
 The persisted assistant message, provider context, tool execution, export data, and expansion history remain unchanged.
@@ -136,7 +136,7 @@ The real Pi viewport moved the unchanged assistant text from row 7 to row 2, ren
 The leading cause would have been falsified if the row or height remained, the provider lost or duplicated the message, or the persisted role or bytes changed.
 None occurred.
 
-The fix installs a separate idempotent presentation adapter, verified on Pi 0.81.1 through 0.82.0, on the exported `InteractiveMode.addMessageToChat` method.
+The fix installs a separate idempotent presentation adapter, verified on Pi 0.81.1 through 0.84.0, on the exported `InteractiveMode.addMessageToChat` method.
 The adapter probes for that exact method and, per the [compatibility contract](calm.md#pi-compatibility), degrades independently with a diagnostic rather than gating on a version number.
 It delegates current recognition to `bin/fm-operational-input.sh`, adds only the evidence-backed bare-U+2063 `Supervisor escalate (` presentation compatibility shape, mounts a `UserMessageComponent` subclass that preserves Pi's stock row plus leading spacer while Calm is off, and returns zero rendered lines while Calm is on.
 It never intercepts the input event, rewrites the message, changes its role, filters model context, or changes session data.
@@ -200,11 +200,11 @@ Serialized session data and Pi 0.81.1's sidebar tree also retain legacy hidden o
 The taxonomy was derived from Pi 0.81.1's installed public declarations, documentation, examples, `interactive-mode.js`, and its exported component implementations.
 The test fixture enumerates every class below through the centralized policy, and the interactive fixture exercises the screenshot classes, current user-role operational input, and legacy synthetic presentation entries.
 
-| Policy class | Pi transcript path | Calm result (verified on Pi 0.81.1 through 0.82.0) |
+| Policy class | Pi transcript path | Calm result (verified on Pi 0.81.1 through 0.84.0) |
 | --- | --- | --- |
 | `genuine-user-prompt` | `UserMessageComponent` | Visible, including every tested operational near miss. |
 | `genuine-agent-response` | Assistant text in `AssistantMessageComponent` | Visible. |
-| `assistant-thinking` | Thinking content in `AssistantMessageComponent` | Collapsed reasoning is removed from the shallow presentation copy before layout and occupies zero rows; explicit expansion renders the original reasoning. |
+| `assistant-thinking` | Thinking content in `AssistantMessageComponent` | Calm removes thinking blocks from the shallow presentation copy before layout by default and occupies zero rows; explicit expansion renders the original reasoning. |
 | `assistant-tool-call` | `ToolExecutionComponent` | Seven built-ins and `fm_watch_arm_pi` hidden; arbitrary custom tools remain an unsupported boundary. |
 | `tool-result` | `ToolExecutionComponent` | Text results for the controlled tools hidden; arbitrary custom results remain an unsupported boundary. |
 | `tool-image` | Image children appended outside tool renderer slots | Unsupported boundary; remains visible. |
@@ -219,13 +219,47 @@ The test fixture enumerates every class below through the centralized policy, an
 | `system-notice` | `showStatus`, `showError`, compaction, retry, and startup warning rows | Unsupported boundary; remains visible. |
 | `cache-notice` | Non-persisted cache-miss `Text` row | Unsupported boundary; remains visible. |
 | `project-trust-warning` | Non-persisted startup `Text` row | Unsupported boundary; remains visible. |
-| `synthetic-user` | Firstmate extension `sendUserMessage`, terminal-injected input, Firstmate-generated Pi positional brief, or the already non-displayed session-start nudge | Canonically classified text-only operational user messages stay ordinary semantic user messages but render through the zero-height adapter (verified on Pi 0.81.1 through 0.82.0) under Calm; legacy entries stay gaplessly controllable, and the session-start nudge retains its existing non-displayed custom-message path. |
+| `synthetic-user` | Firstmate extension `sendUserMessage`, terminal-injected input, Firstmate-generated Pi positional brief, or the already non-displayed session-start nudge | Canonically classified text-only operational user messages stay ordinary semantic user messages but render through the zero-height adapter (verified on Pi 0.81.1 through 0.84.0) under Calm; legacy entries stay gaplessly controllable, and the session-start nudge retains its existing non-displayed custom-message path. |
 | `synthetic-assistant` | No authoritative Firstmate source found | Policy-hidden, but Pi exposes no generic assistant-role renderer. |
 | `unknown` | Future or unclassified transcript component | Policy-hidden, but no generic renderer exists; never claimed as covered. |
 
 The installed extension API has no supported global transcript filter, user-message renderer, assistant-message renderer, chat-container API, or generic custom-tool wrapper.
-Pi 0.81.1 through 0.82.0 export `AssistantMessageComponent` and `InteractiveMode`, so Calm uses separate idempotent, API-probed adapters for assistant thinking layout and the complete operational-user transcript row while leaving all message data and non-Calm rendering unchanged; see the [compatibility contract](calm.md#pi-compatibility) for how a future Pi lacking one of those exports is handled.
+Pi 0.81.1 through 0.84.0 export `AssistantMessageComponent` and `InteractiveMode`, so Calm uses separate idempotent, API-probed adapters for assistant thinking layout and the complete operational-user transcript row while leaving all message data and non-Calm rendering unchanged; see the [compatibility contract](calm.md#pi-compatibility) for how a future Pi lacking one of those exports is handled.
 General component replacement, ANSI cursor erasure, provider-context mutation, and installed-file patching remain rejected as unsupported or preservation-breaking workarounds.
+
+## 2026-08-12 Pi 0.84.0 compatibility repair
+
+Pi 0.84.0 was the installed CLI during this verification.
+The prior assistant adapter only removed thinking when Pi had already set `hideThinkingBlock` and Calm had replaced the label with an empty string.
+Pi 0.84.0 defaults in this installation left `hideThinkingBlock` false, so Calm was recorded as active while ordinary thinking headings remained visible.
+The repaired adapter filters thinking blocks from a presentation-only copy whenever Calm is active, while the exported Pi thinking toggle records explicit expansion and restores the original reasoning on demand.
+The session-start and `/calm` transitions reset that explicit expansion state without changing serialized messages or model context.
+Pi 0.84.0 also passes Markdown transformers to `UserMessageComponent`, so the operational-user adapter now forwards that public constructor input and preserves Pi's current Markdown rendering.
+
+The supported primary harness surfaces were inspected for Claude, Codex, OpenCode, Pi, pi-signed, Grok, Kimi, and Muse.
+Only Pi and pi-signed expose the tracked Calm extension surface, and pi-signed uses the same Pi transcript implementation.
+The other harnesses remain not applicable because their inspected integrations expose no supported transcript-row renderer or transcript-wide redraw API.
+The tmux, Herdr, Zellij, Orca, and cmux runtime surfaces were also inspected, and they transport the selected harness without changing Pi's transcript renderer.
+
+```text
+$ pi --version
+0.84.0
+
+$ PATH="/nix/store/6r6gl2w15a87nfdxcf9wfnyfj6pn6axs-pi-coding-agent-rlm-fork-0.84.0-71ca6cf/lib/pi-rlm-fork/node_modules/.bin:$PATH" FM_PI_PACKAGE_DIR="/Users/dmitrijarkov/.npm-global/lib/node_modules/@earendil-works/pi-coding-agent" bash tests/fm-pi-primary-types.test.sh
+ok - tracked Pi extensions pass strict no-emit typecheck against Pi 0.84.0
+
+$ FORCE_COLOR= NO_COLOR= PATH="/nix/store/6r6gl2w15a87nfdxcf9wfnyfj6pn6axs-pi-coding-agent-rlm-fork-0.84.0-71ca6cf/lib/pi-rlm-fork/node_modules/.bin:$PATH" FM_PI_PACKAGE_DIR="/Users/dmitrijarkov/.npm-global/lib/node_modules/@earendil-works/pi-coding-agent" bash tests/fm-calm-pi-extension.test.sh
+ok - all portable Calm rendering, lifecycle, compatibility, persistence, and policy checks
+skip - tmux-dependent interactive checks because tmux was unavailable
+
+$ FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh
+skip: tmux not found
+```
+
+The complete native tmux fixture also passed against a temporary Pi 0.84.0 package copy carrying an evidence-only RLM endpoint repair.
+That external repair changed only daemon endpoint registration and did not change Pi's transcript renderer.
+The real Pi primary hid default-visible thinking and controlled tool and operational rows, restored original reasoning through the stock thinking toggle, preserved captain prompts and assistant outcomes, exported unchanged session data, and survived a real process restart.
+This live result covers the harness-dependent presentation and restart behavior that the portable fixture cannot prove.
 
 ## Cross-harness verification record
 
@@ -249,7 +283,7 @@ grok 0.2.106 (bde89716f679)
 | Claude Code 2.1.218 | Not feasible through the inspected supported project surface. | Project hooks can observe lifecycle and tool events, while the plugin CLI packages supported components; neither inspected surface exposes a transcript-row renderer or transcript-wide redraw API. |
 | Codex CLI 0.144.6 | Not feasible through the inspected supported project surface. | The tracked hooks expose session, pre-tool, and stop handling, while the plugin and feature inventories expose no TUI tool-row renderer or transcript redraw control. |
 | OpenCode 1.17.18 | Not feasible without violating the preservation boundary. | Plugins expose events and tool execution hooks, not a built-in transcript-row renderer; same-name tool replacement changes execution rather than presentation alone. |
-| Pi (verified 0.81.1 through 0.82.0) | Partially feasible with two API-probed exported-class adapters. | Public APIs control working visibility, collapsed labels, known tool slots, custom entries, and expansion redraws; exported assistant and interactive-mode classes provide the collapsed-thinking and operational-user layout boundaries, gated on the exact method's presence rather than a version number, while generic user, tool, and status filtering remains unavailable. |
+| Pi (verified 0.81.1 through 0.84.0) | Partially feasible with two API-probed exported-class adapters. | Public APIs control working visibility, collapsed labels, known tool slots, custom entries, and expansion redraws; exported assistant and interactive-mode classes provide the collapsed-thinking and operational-user layout boundaries, gated on the exact method's presence rather than a version number, while generic user, tool, and status filtering remains unavailable. |
 | Grok CLI 0.2.106 | Not feasible through the inspected supported project surface. | Project hooks expose lifecycle and tool interception, while the plugin CLI exposes no row-renderer contract; `--minimal` changes the whole screen mode rather than selected transcript rows. |
 
 These conclusions are deliberately limited to the named versions and supported surfaces.

--- a/docs/calm.md
+++ b/docs/calm.md
@@ -15,7 +15,7 @@ Very narrow terminals fall back to a smaller deterministic sprite.
 While Calm is off, Pi's stock working row is left exactly as Pi renders it.
 Calm hides routine thinking blocks by default, the shells for the Pi built-in tool names Calm owns, the `fm_watch_arm_pi` tool shell, and canonically classified Firstmate operational user rows.
 The operational inputs remain ordinary user-role messages, while Pi's transcript layout renders their complete rows at zero height.
-An explicit Pi thinking expansion shows the original reasoning until it is collapsed again or Calm is reset for a new session lifetime.
+An explicit Pi thinking expansion shows the original reasoning until it is collapsed again, Calm is toggled, or a new session lifetime begins.
 The session-start nudge remains on its existing non-displayed custom-message path.
 
 Outside Pi's same-name built-in override collision described below, Calm changes presentation only.
@@ -32,7 +32,7 @@ These are supported-API boundaries rather than hidden-content failures.
 
 Calm has no numeric Pi version minimum or maximum and never refuses Pi solely because its version is newer than a previously verified version.
 The collapsed-thinking and operational-user-row presentation adapters probe the exact Pi API seam they patch when Calm loads.
-The current Pi 0.84.0 build is verified, while the adapters continue to avoid a numeric support ceiling.
+Calm's current adapter behavior is verified against Pi 0.84.0, while the adapters continue to avoid a numeric support ceiling.
 If Pi removes one of those seams, Calm logs a diagnostic naming the unavailable adapter and skips only that adapter; `/calm`, the other adapter, and unrelated Pi extensions remain available.
 
 Calm's built-in tool presentation (`bash`, `read`, `edit`, `write`, `grep`, `find`, `ls`) shares Pi's single, unmerged override slot per name with any other extension that overrides the same tool.

--- a/docs/calm.md
+++ b/docs/calm.md
@@ -13,15 +13,16 @@ Hidden elapsed time does not advance the animation, and a resize while hidden cl
 A fresh Pi session or new Calm extension lifetime starts at the normal initial position.
 Very narrow terminals fall back to a smaller deterministic sprite.
 While Calm is off, Pi's stock working row is left exactly as Pi renders it.
-Calm hides collapsed thinking labels, the shells for the Pi built-in tool names Calm owns, the `fm_watch_arm_pi` tool shell, and canonically classified Firstmate operational user rows.
+Calm hides routine thinking blocks by default, the shells for the Pi built-in tool names Calm owns, the `fm_watch_arm_pi` tool shell, and canonically classified Firstmate operational user rows.
 The operational inputs remain ordinary user-role messages, while Pi's transcript layout renders their complete rows at zero height.
+An explicit Pi thinking expansion shows the original reasoning until it is collapsed again or Calm is reset for a new session lifetime.
 The session-start nudge remains on its existing non-displayed custom-message path.
 
 Outside Pi's same-name built-in override collision described below, Calm changes presentation only.
 Calm's built-in wrappers preserve Pi's execution behavior, and input delivery, ordering, model context, session storage, diagnostics, and `/export` and `/share` operation remain unchanged.
 Every hidden Firstmate input remains available to the model and in serialized session data and exported artifacts.
 Legacy operational custom messages remain in session data and Pi's sidebar tree, although the main HTML transcript may omit them.
-Toggling Calm off restores ordinary rendering, and `Ctrl+O` expansion state is preserved.
+Toggling Calm off restores ordinary rendering, and Pi's `Ctrl+O` expansion state is preserved.
 
 Pi's supported presentation API does not expose a global transcript filter.
 Expanded reasoning and its reserved spacing, built-in tool images, user-bash rows, skill and summary rows, generic status notices, and arbitrary custom-tool or extension rows remain visible.
@@ -31,6 +32,7 @@ These are supported-API boundaries rather than hidden-content failures.
 
 Calm has no numeric Pi version minimum or maximum and never refuses Pi solely because its version is newer than a previously verified version.
 The collapsed-thinking and operational-user-row presentation adapters probe the exact Pi API seam they patch when Calm loads.
+The current Pi 0.84.0 build is verified, while the adapters continue to avoid a numeric support ceiling.
 If Pi removes one of those seams, Calm logs a diagnostic naming the unavailable adapter and skips only that adapter; `/calm`, the other adapter, and unrelated Pi extensions remain available.
 
 Calm's built-in tool presentation (`bash`, `read`, `edit`, `write`, `grep`, `find`, `ls`) shares Pi's single, unmerged override slot per name with any other extension that overrides the same tool.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,7 +128,7 @@ See [`trace-context.md`](trace-context.md) for carrier semantics, supported rout
 
 ## Gate defaults (.no-mistakes.yaml)
 
-The tracked `.no-mistakes.yaml` keeps test evidence outside the repo and pins `commands.lint` to `bin/fm-lint.sh` so local lint matches CI.
+The tracked `.no-mistakes.yaml` keeps test evidence outside the repo and runs `commands.lint` as `nix shell nixpkgs#shellcheck --command bin/fm-lint.sh`, using `bin/fm-lint.sh` as the lint-definition owner so gate lint remains aligned with CI.
 That evidence policy is specific to the firstmate repo: target projects may legitimately commit `.no-mistakes/evidence/` from their own no-mistakes pipeline, but firstmate keeps `.no-mistakes/` local and CI rejects tracked entries under that path.
 It does not set `commands.test` to a complete `tests/*.test.sh` walk.
 See [CONTRIBUTING.md](../CONTRIBUTING.md) for the firstmate-specific local test policy and entry points.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -144,6 +144,21 @@ Zellij has no verified recovery-grade agent process probe, while Orca and cmux d
 The current classifier matrix and its refresh guard are recorded in [Composer classification matrix](#composer-classification-matrix), with portable shape coverage in `tests/fm-composer-lib.test.sh` and `tests/fm-composer-ghost.test.sh`.
 Kimi pointer delivery and OpenCode 1.18.4 busy-queue behavior remain pinned by `tests/fm-kimi-harness.test.sh` and `tests/fm-tmux-submit-busy.test.sh`.
 
+### Pi Calm presentation
+
+The Pi Calm presentation adapters were reverified on 2026-08-12 against Pi 0.84.0 in an isolated pseudo-terminal with a deterministic provider.
+The portable regression and strict typecheck commands remain:
+
+```sh
+FORCE_COLOR= NO_COLOR= PATH="/nix/store/6r6gl2w15a87nfdxcf9wfnyfj6pn6axs-pi-coding-agent-rlm-fork-0.84.0-71ca6cf/lib/pi-rlm-fork/node_modules/.bin:$PATH" FM_PI_PACKAGE_DIR="/Users/dmitrijarkov/.npm-global/lib/node_modules/@earendil-works/pi-coding-agent" bash tests/fm-calm-pi-extension.test.sh
+PATH="/nix/store/6r6gl2w15a87nfdxcf9wfnyfj6pn6axs-pi-coding-agent-rlm-fork-0.84.0-71ca6cf/lib/pi-rlm-fork/node_modules/.bin:$PATH" FM_PI_PACKAGE_DIR="/Users/dmitrijarkov/.npm-global/lib/node_modules/@earendil-works/pi-coding-agent" bash tests/fm-pi-primary-types.test.sh
+```
+
+The portable checks passed and self-skipped only the tmux-dependent cases when tmux was absent from the ordinary path.
+The complete native tmux fixture then passed against a temporary Pi 0.84.0 package copy carrying an evidence-only RLM endpoint repair that changed no transcript-rendering code.
+The real Pi primary hid default-visible thinking plus controlled tool and operational rows, restored original reasoning through Pi's stock thinking toggle, preserved captain prompts and assistant outcomes, exported unchanged session data, and survived a process restart.
+The live credentialed guard after a harness upgrade remains `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh`.
+
 ### Cleanup endpoint identity
 
 The cleanup identity boundary was validated on 2026-07-28 with tmux 3.6a and metadata fixtures for every supported backend.

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -816,6 +816,14 @@ const watcherBody =
   "Run bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.";
 const watcherMessage = operationalInput.encodeFirstmateOperationalInput("watcher", watcherBody);
 const legacyAwayMessage = "\u2063Supervisor escalate (legacy presentation compatibility)";
+const markdownTransformers = [
+  (markdown, context) => {
+    if (context.messageType !== "user" || context.isStreaming) {
+      throw new Error("operational Markdown transformer received the wrong render context");
+    }
+    return markdown.replace("signal: /tmp/probe.status", "signal: /tmp/transformed-probe.status");
+  },
+];
 const operationalHistory = [];
 const operationalChat = {
   children: [new Text("VISIBLE_PREDECESSOR", 0, 0)],
@@ -827,7 +835,7 @@ const operationalMode = {
   chatContainer: operationalChat,
   editor: { addToHistory: (value) => operationalHistory.push(value) },
   getMarkdownThemeWithSettings: () => undefined,
-  getMarkdownTransformers: () => [],
+  getMarkdownTransformers: () => markdownTransformers,
   getUserMessageText: (message) => typeof message.content === "string"
     ? message.content
     : message.content.filter((item) => item.type === "text").map((item) => item.text).join(""),
@@ -860,10 +868,18 @@ InteractiveMode.prototype.addMessageToChat.call(
 );
 const operationalComponent = operationalChat.children[1];
 const legacyOperationalComponent = operationalChat.children[2];
-const stockOperationalComponent = new UserMessageComponent(watcherMessage, undefined, 1);
+const stockOperationalComponent = new UserMessageComponent(
+  watcherMessage,
+  undefined,
+  1,
+  markdownTransformers,
+);
 const expectedCalmOffOperationalRows = ["", ...stockOperationalComponent.render(100)];
 if (JSON.stringify(operationalComponent.render(100)) !== JSON.stringify(expectedCalmOffOperationalRows)) {
   throw new Error("Calm-off operational user rendering changed from Pi stock rows");
+}
+if (!operationalComponent.render(100).join("\n").includes("/tmp/transformed-probe.status")) {
+  throw new Error("Pi Markdown transformer output did not reach the Calm operational user row");
 }
 if (operationalHistory.length !== 1 || operationalHistory[0] !== watcherMessage) {
   throw new Error("operational user presentation changed Pi input history behavior");
@@ -2871,7 +2887,7 @@ JS
 }
 
 test_interactive_terminal_e2e() {
-  local project config home session_file export_file export_dom default_snapshot expanded_snapshot hidden_snapshot active_before_snapshot active_hidden_snapshot restored_snapshot working_snapshot working_response_snapshot restarted_snapshot resumed_restored_snapshot hash_before hash_after now version chrome chrome_pid chrome_wait active_wait active_screen_wait boat_frame_one boat_frame_two boat_resized_snapshot boat_focus_snapshot boat_cleared_snapshot boat_hull_line boat_sail_line boat_column_one boat_column_two boat_line boat_color_snapshot boat_color_line boat_water_snapshot boat_water_line boat_water_first boat_water_changed boat_narrow_snapshot boat_narrow_sails boat_freeze_snapshot boat_resume_snapshot boat_freeze_column boat_freeze_sail boat_resume_column boat_resume_sail
+  local project config home session_file export_file export_dom default_snapshot expanded_snapshot hidden_snapshot hidden_viewport_snapshot active_before_snapshot active_hidden_snapshot restored_snapshot working_snapshot working_response_snapshot restarted_snapshot resumed_restored_snapshot hash_before hash_after now version chrome chrome_pid chrome_wait active_wait active_screen_wait boat_frame_one boat_frame_two boat_resized_snapshot boat_focus_snapshot boat_cleared_snapshot boat_hull_line boat_sail_line boat_column_one boat_column_two boat_line boat_color_snapshot boat_color_line boat_water_snapshot boat_water_line boat_water_first boat_water_changed boat_narrow_snapshot boat_narrow_sails boat_freeze_snapshot boat_resume_snapshot boat_freeze_column boat_freeze_sail boat_resume_column boat_resume_sail
   if ! command -v pi >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then
     echo "skip: pi or tmux not found for Pi calm interactive E2E"
     return 0
@@ -2888,6 +2904,7 @@ test_interactive_terminal_e2e() {
   default_snapshot="$TMP_ROOT/default.txt"
   expanded_snapshot="$TMP_ROOT/expanded.txt"
   hidden_snapshot="$TMP_ROOT/hidden.txt"
+  hidden_viewport_snapshot="$TMP_ROOT/hidden-viewport.txt"
   active_before_snapshot="$TMP_ROOT/active-before.txt"
   active_hidden_snapshot="$TMP_ROOT/active-hidden.txt"
   restored_snapshot="$TMP_ROOT/restored.txt"
@@ -3087,7 +3104,7 @@ export default function (pi: ExtensionAPI): void {
 }
 TS
   printf '%s\n' '{}' >"$config/keybindings.json"
-  printf '%s\n' '{"hideThinkingBlock":true}' >"$config/settings.json"
+  printf '%s\n' '{"hideThinkingBlock":false}' >"$config/settings.json"
   now=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
   cat >"$session_file" <<JSON
 {"type":"session","version":3,"id":"11111111-1111-4111-8111-111111111111","timestamp":"$now","cwd":"$project"}
@@ -3116,7 +3133,8 @@ JSON
   assert_contains "$(cat "$default_snapshot")" "CALM_E2E_OUTPUT" "calm mode was not off by default"
   assert_contains "$(cat "$default_snapshot")" "fm_watch_arm_pi" "Calm-off transcript did not show the Firstmate watcher tool"
   assert_contains "$(cat "$default_snapshot")" "FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status" "Calm-off transcript did not show the synthetic Firstmate presentation row"
-  assert_contains "$(cat "$default_snapshot")" "Thinking..." "reasoning fixture did not render Pi's collapsed thinking label"
+  assert_contains "$(cat "$default_snapshot")" "first internal reasoning block" \
+    "reasoning fixture did not render Pi's default-visible reasoning"
   assert_contains "$(cat "$default_snapshot")" "fm-calm.ts" "project-local Pi calm extension did not auto-load"
   # shellcheck disable=SC2016 # Backticks are literal prompt markup.
   assert_not_contains "$(cat "$default_snapshot")" 'Run `bin/fm-session-start.sh` now' \
@@ -3138,6 +3156,7 @@ JSON
     # (see below) lengthen the transcript enough to push earlier genuine content, such
     # as the original user prompt, above the plain viewport.
     tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S -600 >"$hidden_snapshot"
+    tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" >"$hidden_viewport_snapshot"
     # Wait for the redraw this block actually asserts: the collapsed-thinking adapter
     # (unconditional, unaffected by the built-in tool gate below) hides, and the
     # retained genuine rows are back on screen. Built-in tool rows from before this
@@ -3145,7 +3164,10 @@ JSON
     # file header and docs/calm.md): Pi gives no way to re-point an already-rendered
     # tool row at a definition registered later, so CALM_E2E_OUTPUT and friends stay
     # on screen through this whole redraw rather than disappearing with it.
-    if ! grep -Fq "Thinking..." "$hidden_snapshot" &&
+    if ! grep -Fq "Thinking..." "$hidden_viewport_snapshot" &&
+      ! grep -Fq "fm_watch_arm_pi" "$hidden_viewport_snapshot" &&
+      ! grep -Fq "watcher: started Pi extension arm child" "$hidden_viewport_snapshot" &&
+      ! grep -Fq "FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status" "$hidden_viewport_snapshot" &&
       ! grep -Fq "/calm" "$hidden_snapshot" &&
       grep -Fq "FIRSTMATE WATCHER WAKE: can you explain this phrase?" "$hidden_snapshot" &&
       grep -Fq "The deterministic tool example is complete." "$hidden_snapshot"; then
@@ -3168,11 +3190,19 @@ JSON
   [ "$(cat "$home/config/calm")" = on ] || fail "/calm did not persist its active choice"
   assert_contains "$(cat "$hidden_snapshot")" "CALM_EXPORT_GREP" "a pre-activation grep row unexpectedly hid; the documented bound regressed"
   assert_contains "$(cat "$hidden_snapshot")" "CALM_EXPORT_FIND" "a pre-activation find row unexpectedly hid; the documented bound regressed"
-  assert_not_contains "$(cat "$hidden_snapshot")" "Thinking..." "/calm left collapsed thinking labels in the transcript"
-  assert_not_contains "$(cat "$hidden_snapshot")" "fm_watch_arm_pi" "/calm left the Firstmate watcher tool call shell in the transcript"
-  assert_not_contains "$(cat "$hidden_snapshot")" "watcher: started Pi extension arm child" "/calm left the Firstmate watcher tool result in the transcript"
-  assert_not_contains "$(cat "$hidden_snapshot")" "FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status" "/calm left a synthetic Firstmate user-role presentation in the transcript"
-  assert_not_contains "$(cat "$hidden_snapshot")" "Tool activity is hidden where supported" "/calm appended its own command-status row"
+  assert_not_contains "$(cat "$hidden_viewport_snapshot")" "Thinking..." "/calm left collapsed thinking labels in the transcript"
+  for hidden_reasoning in \
+    "first internal reasoning block" \
+    "second internal reasoning block" \
+    "third internal reasoning block"
+  do
+    assert_not_contains "$(cat "$hidden_viewport_snapshot")" "$hidden_reasoning" \
+      "/calm left default-visible reasoning in the transcript"
+  done
+  assert_not_contains "$(cat "$hidden_viewport_snapshot")" "fm_watch_arm_pi" "/calm left the Firstmate watcher tool call shell in the transcript"
+  assert_not_contains "$(cat "$hidden_viewport_snapshot")" "watcher: started Pi extension arm child" "/calm left the Firstmate watcher tool result in the transcript"
+  assert_not_contains "$(cat "$hidden_viewport_snapshot")" "FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status" "/calm left a synthetic Firstmate user-role presentation in the transcript"
+  assert_not_contains "$(cat "$hidden_viewport_snapshot")" "Tool activity is hidden where supported" "/calm appended its own command-status row"
   assert_contains "$(cat "$hidden_snapshot")" "Show a deterministic tool example." "/calm removed a genuine user prompt"
   assert_contains "$(cat "$hidden_snapshot")" "FIRSTMATE WATCHER WAKE: can you explain this phrase?" "/calm hid a genuine near-miss user prompt"
   for near_miss in \
@@ -3370,7 +3400,8 @@ JS
   assert_contains "$(cat "$restored_snapshot")" "Warning: CALM_TRANSIENT_DIAGNOSTIC" "second /calm dropped a transient diagnostic"
   assert_contains "$(cat "$restored_snapshot")" " Error:" "second /calm dropped the synthetic delivery diagnostic"
   assert_not_contains "$(cat "$restored_snapshot")" "Navigated to selected point" "second /calm added a navigation status row"
-  assert_contains "$(cat "$restored_snapshot")" "Thinking..." "second /calm did not restore Pi's collapsed thinking labels"
+  assert_contains "$(cat "$restored_snapshot")" "first internal reasoning block" \
+    "second /calm did not restore Pi's default-visible reasoning"
   assert_contains "$(cat "$restored_snapshot")" "escape to interrupt" "/calm changed the active Ctrl+O expansion state"
 
   hash_after=$(shasum -a 256 "$session_file" | awk '{print $1}')

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -17,7 +17,7 @@ PI_OPERATIONAL_INPUT="$ROOT/.pi/extensions/lib/fm-operational-input.ts"
 PI_PACKAGE_DIR=${FM_PI_PACKAGE_DIR:-"$(npm root -g 2>/dev/null)/@earendil-works/pi-coding-agent"}
 TMUX_SOCKET="fm-calm-$$"
 TMUX_SESSION="fm-calm-e2e"
-# Verified against Pi 0.81.1 and 0.82.0 (docs/calm-mode-feasibility.md). This is
+# Verified against Pi 0.81.1, 0.82.0, and 0.84.0 (docs/calm-mode-feasibility.md). This is
 # known-good evidence, not a support ceiling: the fixtures below run against whatever
 # Pi is actually installed, and record_pi_version_evidence never rejects a newer
 # version. The tracked presentation adapters probe the exact API they patch (see
@@ -827,6 +827,7 @@ const operationalMode = {
   chatContainer: operationalChat,
   editor: { addToHistory: (value) => operationalHistory.push(value) },
   getMarkdownThemeWithSettings: () => undefined,
+  getMarkdownTransformers: () => [],
   getUserMessageText: (message) => typeof message.content === "string"
     ? message.content
     : message.content.filter((item) => item.type === "text").map((item) => item.text).join(""),
@@ -1045,11 +1046,18 @@ const assistantThinkingTool = new AssistantMessageComponent({
   ],
   stopReason: "toolUse",
 }, true);
+const assistantDefaultThinking = new AssistantMessageComponent({
+  ...assistantBase,
+  content: [
+    { type: "thinking", thinking: "HIDDEN_DEFAULT_THINKING" },
+    { type: "text", text: "VISIBLE_DEFAULT_TEXT" },
+  ],
+}, false);
 if (!assistantThinkingText.render(100).join("\n").includes("Thinking...")) {
   throw new Error("stock collapsed-thinking fixture did not render before Calm was active");
 }
 
-const assistantComponents = [assistantTextOnly, assistantThinkingText, assistantThinkingTool];
+const assistantComponents = [assistantTextOnly, assistantThinkingText, assistantThinkingTool, assistantDefaultThinking];
 let expanded = true;
 let editorText = "";
 let terminalInputHandler;
@@ -1095,6 +1103,9 @@ await handlers.get("session_start")[0]({ reason: "startup" }, commandContext);
 if (workingVisible !== true || hiddenThinkingLabel !== undefined) {
   throw new Error("session start did not restore Pi's stock working and thinking presentation");
 }
+if (!assistantDefaultThinking.render(100).join("\n").includes("HIDDEN_DEFAULT_THINKING")) {
+  throw new Error("Calm-off default thinking fixture did not preserve Pi's visible reasoning");
+}
 const presentationRenderer = entryRenderers.get("firstmate-synthetic-input-presentation");
 if (!presentationRenderer) throw new Error("legacy synthetic presentation renderer was not registered");
 const presentationEntry = {
@@ -1116,6 +1127,51 @@ if (expanded !== true || workingVisible !== true || hiddenThinkingLabel !== "" |
 }
 if (readFileSync(`${process.env.FM_HOME}/config/calm`, "utf8") !== "on\n") {
   throw new Error("Calm did not persist the active choice in the effective Firstmate home");
+}
+if (assistantDefaultThinking.render(100).join("\n").includes("HIDDEN_DEFAULT_THINKING")) {
+  throw new Error("Calm did not hide routine reasoning when Pi's default thinking setting is visible");
+}
+const thinkingSettings = [];
+const thinkingStatuses = [];
+const thinkingMode = {
+  hideThinkingBlock: false,
+  settingsManager: {
+    setHideThinkingBlock(hidden) {
+      thinkingSettings.push(hidden);
+    },
+  },
+  chatContainer: {
+    clear() {},
+  },
+  rebuildChatFromMessages() {
+    assistantDefaultThinking.invalidate();
+  },
+  streamingComponent: undefined,
+  streamingMessage: undefined,
+  showStatus(status) {
+    thinkingStatuses.push(status);
+  },
+};
+InteractiveMode.prototype.toggleThinkingBlockVisibility.call(thinkingMode);
+if (!assistantDefaultThinking.render(100).join("\n").includes("HIDDEN_DEFAULT_THINKING")) {
+  throw new Error("Pi thinking toggle did not restore the original reasoning");
+}
+if (thinkingMode.hideThinkingBlock !== false || thinkingSettings.at(-1) !== false) {
+  throw new Error("Calm thinking expansion diverged from Pi's stock visible state");
+}
+InteractiveMode.prototype.toggleThinkingBlockVisibility.call(thinkingMode);
+const collapsedDefaultThinking = assistantDefaultThinking.render(100).join("\n");
+if (collapsedDefaultThinking.includes("HIDDEN_DEFAULT_THINKING") || !collapsedDefaultThinking.includes("VISIBLE_DEFAULT_TEXT")) {
+  throw new Error("Pi thinking toggle did not restore Calm's hidden-reasoning presentation");
+}
+if (thinkingMode.hideThinkingBlock !== true || thinkingSettings.at(-1) !== true) {
+  throw new Error("Calm thinking collapse diverged from Pi's stock hidden state");
+}
+if (
+  JSON.stringify(thinkingStatuses) !==
+  JSON.stringify(["Thinking blocks: visible", "Thinking blocks: hidden"])
+) {
+  throw new Error(`unexpected Pi thinking toggle statuses: ${thinkingStatuses.join(", ")}`);
 }
 presentationComponent.setExpanded(!expanded);
 if (presentationComponent.hasContent() || presentationComponent.render(100).length !== 0) {
@@ -2815,7 +2871,7 @@ JS
 }
 
 test_interactive_terminal_e2e() {
-  local project config home session_file export_file export_dom default_snapshot expanded_snapshot hidden_snapshot active_before_snapshot active_hidden_snapshot export_snapshot restored_snapshot working_snapshot working_response_snapshot restarted_snapshot resumed_restored_snapshot hash_before hash_after now version chrome chrome_pid chrome_wait active_wait active_screen_wait boat_frame_one boat_frame_two boat_resized_snapshot boat_focus_snapshot boat_cleared_snapshot boat_hull_line boat_sail_line boat_column_one boat_column_two boat_line boat_color_snapshot boat_color_line boat_water_snapshot boat_water_line boat_water_first boat_water_changed boat_narrow_snapshot boat_narrow_sails boat_freeze_snapshot boat_resume_snapshot boat_freeze_column boat_freeze_sail boat_resume_column boat_resume_sail
+  local project config home session_file export_file export_dom default_snapshot expanded_snapshot hidden_snapshot active_before_snapshot active_hidden_snapshot restored_snapshot working_snapshot working_response_snapshot restarted_snapshot resumed_restored_snapshot hash_before hash_after now version chrome chrome_pid chrome_wait active_wait active_screen_wait boat_frame_one boat_frame_two boat_resized_snapshot boat_focus_snapshot boat_cleared_snapshot boat_hull_line boat_sail_line boat_column_one boat_column_two boat_line boat_color_snapshot boat_color_line boat_water_snapshot boat_water_line boat_water_first boat_water_changed boat_narrow_snapshot boat_narrow_sails boat_freeze_snapshot boat_resume_snapshot boat_freeze_column boat_freeze_sail boat_resume_column boat_resume_sail
   if ! command -v pi >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then
     echo "skip: pi or tmux not found for Pi calm interactive E2E"
     return 0
@@ -2834,7 +2890,6 @@ test_interactive_terminal_e2e() {
   hidden_snapshot="$TMP_ROOT/hidden.txt"
   active_before_snapshot="$TMP_ROOT/active-before.txt"
   active_hidden_snapshot="$TMP_ROOT/active-hidden.txt"
-  export_snapshot="$TMP_ROOT/export.txt"
   restored_snapshot="$TMP_ROOT/restored.txt"
   working_snapshot="$TMP_ROOT/working.txt"
   working_response_snapshot="$TMP_ROOT/working-response.txt"
@@ -3031,7 +3086,7 @@ export default function (pi: ExtensionAPI): void {
   });
 }
 TS
-  printf '%s\n' '{"tui.input.submit":"alt+s"}' >"$config/keybindings.json"
+  printf '%s\n' '{}' >"$config/keybindings.json"
   printf '%s\n' '{"hideThinkingBlock":true}' >"$config/settings.json"
   now=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
   cat >"$session_file" <<JSON
@@ -3076,7 +3131,7 @@ JSON
   assert_contains "$(cat "$expanded_snapshot")" "CALM_E2E_OUTPUT" "ordinary Ctrl+O expansion hid tool activity while calm mode was off"
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm"
-  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
   active_screen_wait=0
   while [ "$active_screen_wait" -lt 120 ]; do
     # Include scrollback: the built-in tool rows this documented bound keeps visible
@@ -3132,7 +3187,7 @@ JSON
   assert_contains "$(cat "$hidden_snapshot")" "The deterministic tool example is complete." "/calm removed assistant conversation after a tool"
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm-diagnostic-e2e"
-  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
   active_screen_wait=0
   while [ "$active_screen_wait" -lt 120 ]; do
     tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" >"$active_before_snapshot"
@@ -3156,7 +3211,7 @@ JSON
     kind=${fixture%%|*}
     needle=${fixture#*|}
     tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm-inject-e2e $kind"
-    tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
+    tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
     active_wait=0
     while ! grep -F '"role":"user"' "$session_file" 2>/dev/null |
       grep -Fq "$needle" && [ "$active_wait" -lt 120 ]; do
@@ -3210,9 +3265,10 @@ for (const [needle, kind] of expected) {
 }
 JS
   active_screen_wait=0
-  while [ "$active_screen_wait" -lt 120 ]; do
+  while [ "$active_screen_wait" -lt 240 ]; do
     tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" >"$active_hidden_snapshot"
-    if grep -Fq " Error:" "$active_hidden_snapshot" &&
+    error_count=$(grep -Fc "Error: CALM_OPERATIONAL_E2E_ERROR" "$active_hidden_snapshot" || true)
+    if [ "$error_count" -ge 5 ] &&
       ! grep -Fq "/calm-inject-e2e" "$active_hidden_snapshot"; then
       break
     fi
@@ -3237,9 +3293,13 @@ JS
   hash_before=$(shasum -a 256 "$session_file" | awk '{print $1}')
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/export $export_file"
-  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
-  wait_for_text "$export_snapshot" "Session exported to: $export_file" \
-    || fail "/export did not complete while calm mode was on"
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
+  active_screen_wait=0
+  while [ ! -s "$export_file" ] && [ "$active_screen_wait" -lt 120 ]; do
+    sleep 0.05
+    active_screen_wait=$((active_screen_wait + 1))
+  done
+  [ -s "$export_file" ] || fail "/export did not complete while calm mode was on"
   node - "$export_file" <<'JS' || fail "calm-mode HTML export lost tool data or persisted synthetic provenance"
 const html = require("node:fs").readFileSync(process.argv[2], "utf8");
 const match = html.match(/<script id="session-data" type="application\/json">([^<]+)<\/script>/);
@@ -3291,7 +3351,7 @@ if (!tree.includes("firstmate-synthetic-input") || !tree.includes("/tmp/probe.st
 JS
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm"
-  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
   wait_for_text "$restored_snapshot" "CALM_E2E_OUTPUT" \
     || fail "second /calm did not restore tool result output"
   wait_for_text "$restored_snapshot" "/tmp/active-probe.status" \
@@ -3317,7 +3377,7 @@ JS
   [ "$hash_before" = "$hash_after" ] || fail "/calm changed the persisted session or context data"
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm"
-  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
   active_screen_wait=0
   # CALM_E2E_OUTPUT is not a useful redraw signal here: it is the pre-activation
   # bash row covered by the documented bound above, so it never leaves the screen
@@ -3335,7 +3395,7 @@ JS
 
   # Calm on plus a genuinely active run replaces Pi's stock working row with the boat.
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm-boat-e2e"
-  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
   active_screen_wait=0
   while [ "$active_screen_wait" -lt 200 ]; do
     tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" >"$working_snapshot"
@@ -3529,7 +3589,7 @@ JS
   # sail rather than recreating the boat at the left edge. Capture the first resumed
   # frames quickly so the slow boat cadence cannot advance before the assertion.
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm-boat-e2e"
-  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
   boat_resume_column=""
   boat_resume_sail=""
   active_screen_wait=0
@@ -3571,7 +3631,7 @@ JS
 
   # Calm off restores Pi's stock working row and never shows the ship.
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm"
-  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
   active_screen_wait=0
   while [ "$active_screen_wait" -lt 200 ]; do
     if [ "$(cat "$home/config/calm")" = off ]; then
@@ -3582,7 +3642,7 @@ JS
   done
   [ "$(cat "$home/config/calm")" = off ] || fail "the Calm-off working-row probe did not turn Calm off"
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm-working-e2e"
-  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
   active_screen_wait=0
   while [ "$active_screen_wait" -lt 200 ]; do
     tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" >"$working_snapshot"
@@ -3603,7 +3663,7 @@ JS
 
   # Restore Calm for the persistence restart below.
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm"
-  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
   active_screen_wait=0
   while [ "$active_screen_wait" -lt 200 ]; do
     if [ "$(cat "$home/config/calm")" = on ]; then
@@ -3616,7 +3676,7 @@ JS
   tmux -L "$TMUX_SOCKET" resize-window -t "$TMUX_SESSION" -x 180 -y 44
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/quit"
-  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
   wait_for_text "$working_response_snapshot" "PI_EXIT=0" \
     || fail "Pi did not exit cleanly before the Calm persistence restart"
   tmux -L "$TMUX_SOCKET" kill-session -t "$TMUX_SESSION" 2>/dev/null || true
@@ -3643,12 +3703,12 @@ JS
   [ "$(cat "$home/config/calm")" = on ] || fail "restart/resume changed the persisted active choice"
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm"
-  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
   wait_for_text "$resumed_restored_snapshot" "CALM_E2E_OUTPUT" \
     || fail "/calm after restart did not restore ordinary transcript rows"
   [ "$(cat "$home/config/calm")" = off ] || fail "/calm after restart did not persist the inactive choice"
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/quit"
-  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
   pass "Pi calm native E2E replaces the stock working row with a moving, resize-clamped working ship that freezes and resumes across two working periods in one Pi session, clears on abort, keeps captain turns visible, hides exact operational user rows without changing persistence, restores stock rendering Calm-off, survives restart, and preserves export plus Ctrl+O behavior"
 }
 


### PR DESCRIPTION
## Intent

Diagnose and durably fix two connected operator failures in Firstmate/Pi, then validate and ship through the no-mistakes PR path without merging.

Before editing Firstmate shared tracked material, read and follow `.agents/skills/firstmate-coding-guidelines/SKILL.md` completely. Apply `.agents/skills/diagnostic-reasoning/SKILL.md` to both failures. Load the user-level `one-bin` skill before any executable ownership, package, dependency, PATH, or declarative Nix/dotfiles investigation. Follow the Pi documentation instructions in the repository `AGENTS.md`: read the installed Pi README and every relevant linked document and example completely, especially TUI, extensions, events, settings, display/collapse behavior, and themes.

Observed failure A - plain `pi` launch:
- From `~`, the captain's normal `pi` command exits with `endpoint_identity_conflict: RLM endpoint session identity is already registered` from the Nix-store Pi 0.84.0 package.
- Intake evidence only, not a cause: `one-bin audit exe pi` reports Nix first plus npm-global and Bun-global duplicate owners; a login shell resolves the Nix executable; child-command environments under a live Pi include PI_SESSION_ID, PI_SESSION_FILE, PI_SUBAGENT_PARENT_SESSION, PI_RLM_*, and RLM_* values; RLM persisted roots reject duplicate root/child stable identities.
- Establish the intended executable owner from the authoritative declarative Nix/dotfiles configuration. Do not assume duplicate executable owners cause the daemon conflict.

Required diagnosis A:
1. Build a tight safe reproduction for the captain's actual normal command path and for a proven genuinely fresh external login environment.
2. Explicitly separate initiating trigger, masking condition, and visible symptom.
3. Compare a genuinely fresh external login environment with a shell inherited from the live Pi session, changing one environment-variable group at a time.
4. Inspect settings, wrapper/launcher, daemon endpoint catalog, owner record, session lease, relevant source, history, and tests. Never expose tokens, mutate append-only journals, delete daemon/session artifacts, kill or disrupt the active captain/Firstmate Pi session, or remove duplicate executable owners as a debugging shortcut.
5. Determine whether the conflict comes from stale/inherited session identity, automatic resume of an active session, package/wrapper behavior, daemon recovery, or executable-owner mismatch. Include a proven good path, the earliest divergence, a smallest counterfactual, and explicit disconfirming evidence.

Observed failure B - Calm presentation:
- The primary Firstmate has Calm enabled, but the captain still sees long internal-reasoning headings, Python/tool calls, wake draining, state inspection, and implementation mechanics.
- The intended contract is a quiet captain-facing Pi session that still shows concise outcomes, interactive questions, failures, credential needs, and review-ready results.

Required diagnosis B:
1. Read `docs/configuration.md` as the owner of `config/calm`, inspect every current Calm integration, and reproduce current Pi-primary behavior with Calm enabled against the intended captain-facing contract.
2. Determine whether Calm is merely recorded, not applied to Pi, applied only at launch/reload, or implemented with an ineffective TUI setting or event hook.
3. Inspect all affected supported harness and runtime-backend integrations as required by firstmate-coding-guidelines; mark an axis not applicable only after inspection.
4. Preserve visible captain outcomes and interactive questions while suppressing routine reasoning, tool, and supervision mechanics by default. Never hide failures or decisions.

Authorized resolution:
- Implement the smallest durable tracked Firstmate fixes needed so a normal genuinely fresh-shell `pi` launch succeeds without endpoint identity conflict and Calm produces the intended quiet Pi presentation.
- If the authoritative fix belongs in declarative Nix/dotfiles or another external owner, do not modify it from this isolated project task. Use the one-bin ownership procedure and report the exact authoritative file and safe application step; do not run a self-updater against immutable Nix.
- Do not delete npm/Bun duplicate owners without a separate explicit cleanup decision.
- Preserve legitimate nested RLM children, session resume, daemon recovery, and the active session.
- Do not issue Herdr lifecycle commands from this unguarded task. Use a safe isolated test home/session or existing project test interface for live Pi evidence, never the captain's active Pi session.

Acceptance:
- The original launch reproduction is red before the fix and repeatedly green after it. A genuinely fresh shell resolves the intended `command -v`, real path, and version, and can enter and exit Pi normally.
- The fix does not break legitimate nested RLM children, session resume, daemon recovery, or the active session.
- With Calm enabled, a live isolated Pi primary no longer exposes routine reasoning/tool/supervision activity while concise outcomes, decisions, failures, credentials, and review-ready results remain visible.
- Turn the faithful reproduction into regression coverage at the correct seam and perform real live Pi verification for every harness-dependent verdict.
- Follow firstmate documentation ownership, one-owner, one-sentence-per-line, no-agent-coauthor, shellcheck, lint, test, and verification-record rules.
- Commit the implementation and a self-contained task report under this Firstmate home's `data/firstmate-pi-launch-calm-fix/` describing cause, trigger/mask/symptom, disconfirming evidence, changed tracked files or external authoritative config, exact validation commands/results, residual risks, and any explicit captain action still needed. The report is private evidence and must not be committed.
- Then stop at the ordinary implementation-ready `done:` point so Firstmate can trigger the no-mistakes validation run. Do not merge any PR.

Current accepted validation clarification:
- Drive the full no-mistakes pipeline through automated review, pipeline-owned fixes, tests, documentation checks, push, PR, and green CI, without merging.
- The external Nix-owned RLM fix may remain a proven required captain action only if validation confirms it is outside this tracked Firstmate PR's ownership.
- Do not falsely claim that the installed Pi is repaired.
- Do not modify or interfere with the separate active fm/pi-rlm-endpoint-fix run.

## What Changed

- Updated Pi Calm presentation adapters to hide default-visible reasoning, preserve Pi’s stock thinking expand/collapse behavior, reset expansion state on session or toggle transitions, and forward Pi 0.84 Markdown transformers.
- Expanded Calm regression coverage for default reasoning, thinking toggles, operational-row rendering, and Pi 0.84 compatibility; refreshed feasibility, behavior, and runtime verification documentation.
- Routed no-mistakes lint through the pinned Nix ShellCheck environment and aligned configuration documentation with the gate owner.

## Risk Assessment

🚨 High: The branch durably addresses only Calm presentation while leaving one of the two explicitly required operator failures unresolved or unproven as an external-owner action.

## Testing

Captain, the targeted Calm tests passed repeatedly against the real installed Nix Pi package, and live isolated Pi PTY verification showed the intended quiet Calm presentation with outcomes and warnings preserved. The normal daemon-backed launch still reproduces the external Nix RLM endpoint identity conflict, and tmux-based E2E/screenshot evidence remains unavailable because tmux is not installed.

<details>
<summary>Evidence: Pi launch reproduction</summary>

<code>Normal daemon-backed Pi launch exited 1 with `endpoint_identity_conflict: RLM endpoint session identity is already registered`.</code>

```text
file:///nix/store/6r6gl2w15a87nfdxcf9wfnyfj6pn6axs-pi-coding-agent-rlm-fork-0.84.0-71ca6cf/lib/pi-rlm-fork/packages/coding-agent/dist/modes/rlm-daemon/client.js:273
                        throw new RlmDaemonRemoteError(response.error, response.code);
                              ^

endpoint_identity_conflict: RLM endpoint session identity is already registered
    at Socket.<anonymous> (file:///nix/store/6r6gl2w15a87nfdxcf9wfnyfj6pn6axs-pi-coding-agent-rlm-fork-0.84.0-71ca6cf/lib/pi-rlm-fork/packages/coding-agent/dist/modes/rlm-daemon/client.js:273:31)
    at Socket.emit (node:events:509:28)
    at addChunk (node:internal/streams/readable:563:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:514:3)
    at Readable.push (node:internal/streams/readable:394:5)
    at Pipe.onStreamRead (node:internal/stream_base_commons:189:23)

Node.js v24.16.0

EXIT_CODE=1
```
</details>
<details>
<summary>Evidence: Live Calm-on Pi transcript</summary>

`Real isolated Pi PTY with Calm enabled exited cleanly; routine thinking/tool output was absent while the assistant outcome and Pi warning remained visible.`

```text
spawn env FM_HOME=/var/folders/dh/8gfrsysn4jj6_8s6s5cn69940000gn/T/no-mistakes-evidence/01KZTCM3B5CQ557E7DRNN8WZ7S/live-pi PI_CODING_AGENT_DIR=/var/folders/dh/8gfrsysn4jj6_8s6s5cn69940000gn/T/no-mistakes-evidence/01KZTCM3B5CQ557E7DRNN8WZ7S/live-pi/config PI_OFFLINE=1 PI_RLM_DAEMON=0 pi --approve --no-skills --no-prompt-templates --no-context-files --offline --session /var/folders/dh/8gfrsysn4jj6_8s6s5cn69940000gn/T/no-mistakes-evidence/01KZTCM3B5CQ557E7DRNN8WZ7S/live-pi/session.jsonl
[>7u
────────────────────────────────────────────────────────────────────────────────
                                                                                
────────────────────────────────────────────────────────────────────────────────
/var/folders/dh/8gfrsysn4jj6_8s6s5cn69940000gn/T/no-mistakes-evidence/01KZTCM...
↑3 ↓2 0.0%/0 (auto)                                                      unknown pi v0.84.0                                                                     
 escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o     
 more                                                                           
 Press ctrl+o to show full startup help and loaded resources.                   
                                                                                
 Pi can explain its own features and look up its docs. Ask it how to use or     
 extend Pi.                                                                     

[Extensions]                                                                    
  fm-calm.ts                                                                    

                                                                                
 Show a deterministic tool example.                                             
                                                                                

 I will run one command.                                                        

 The deterministic tool example is complete.                                    

 Warning: No models available. Use /login to log into a provider via OAuth or   
 API key. See:                                                                  
                                                                                
 /nix/store/6r6gl2w15a87nfdxcf9wfnyfj6pn6axs-pi-coding-agent-rlm-fork-0.84.0-71 
 ca6cf/lib/pi-rlm-fork/packages/coding-agent/docs/providers.md                  
                                                                                
 /nix/store/6r6gl2w15a87nfdxcf9wfnyfj6pn6axs-pi-coding-agent-rlm-fork-0.84.0-71 
 ca6cf/lib/pi-rlm-fork/packages/coding-agent/docs/models.md                     

────────────────────────────────────────────────────────────────────────────────
                                                                                
────────────────────────────────────────────────────────────────────────────────
/var/folders/dh/8gfrsysn4jj6_8s6s5cn69940000gn/T/no-mistakes-evidence/01KZTCM...
↑3 ↓2 0.0%/0 (auto)                                                      unknown[<u 
To resume this session: pi --session-dir /var/folders/dh/8gfrsysn4jj6_8s6s5cn69940000gn/T/no-mistakes-evidence/01KZTCM3B5CQ557E7DRNN8WZ7S/live-pi --session 11111111-1111-4111-8111-111111111111
```
</details>
<details>
<summary>Evidence: Repeated focused test evidence</summary>

`Repeated focused Calm extension runs produced identical results against the installed Nix Pi package.`

```text
RUN=1
ok - Pi calm resolves its persistent home independently of Pi's launch directory
ok - Pi calm compatibility evidence never rejects a Pi version for being newer than 0.82.0, and still fails closed on a missing or malformed version
ok - a missing collapsed-thinking presentation API degrades only that Calm adapter with a clear skip reason, while the rest of Calm still registers
ok - missing Pi presentation class exports reach the independent adapter degradation path
ok - Calm registers none of its 7 built-in tool wrappers at load while config/calm is off, and all 7 synchronously at load while config/calm is on
ok - Calm's first same-session /calm activation claims every uncontested built-in, leaves a foreign bash tool fully intact and callable, warns prominently and logs the contested name, and only rows constructed before that activation - the documented bound - fail to retroactively collapse
ok - Pi calm centralizes transcript visibility, preserves execution/export data, keeps Pi's stock working row visible while no run is active, and persists its choice across session starts
skip: pi or tmux not found for Pi operational follow-up E2E
skip: pi or tmux not found for Pi Calm hidden-block geometry E2E
ok - Pi Calm working ship moves on a slow independent cadence over faster fixed-cell blue water, paints the complete boat standard yellow with balanced resets, keeps ANSI-stripped width exact, flips the directional sail on the exact bounce at both edges and every width, clamps visible and hidden resizes, falls back deterministically when narrow, freezes and resumes column/direction across settle/start without hidden-time jumps or duplicate timers, resets only on a fresh session, and installs and removes one scheduler-owning widget across starts, settle, abort, failure, shutdown, reload, replacement, and Calm toggles while leaving Calm-off visibility untouched
skip: pi or tmux not found for Pi calm interactive E2E
RUN=2
ok - Pi calm resolves its persistent home independently of Pi's launch directory
ok - Pi calm compatibility evidence never rejects a Pi version for being newer than 0.82.0, and still fails closed on a missing or malformed version
ok - a missing collapsed-thinking presentation API degrades only that Calm adapter with a clear skip reason, while the rest of Calm still registers
ok - missing Pi presentation class exports reach the independent adapter degradation path
ok - Calm registers none of its 7 built-in tool wrappers at load while config/calm is off, and all 7 synchronously at load while config/calm is on
ok - Calm's first same-session /calm activation claims every uncontested built-in, leaves a foreign bash tool fully intact and callable, warns prominently and logs the contested name, and only rows constructed before that activation - the documented bound - fail to retroactively collapse
ok - Pi calm centralizes transcript visibility, preserves execution/export data, keeps Pi's stock working row visible while no run is active, and persists its choice across session starts
skip: pi or tmux not found for Pi operational follow-up E2E
skip: pi or tmux not found for Pi Calm hidden-block geometry E2E
ok - Pi Calm working ship moves on a slow independent cadence over faster fixed-cell blue water, paints the complete boat standard yellow with balanced resets, keeps ANSI-stripped width exact, flips the directional sail on the exact bounce at both edges and every width, clamps visible and hidden resizes, falls back deterministically when narrow, freezes and resumes column/direction across settle/start without hidden-time jumps or duplicate timers, resets only on a fresh session, and installs and removes one scheduler-owning widget across starts, settle, abort, failure, shutdown, reload, replacement, and Calm toggles while leaving Calm-off visibility untouched
skip: pi or tmux not found for Pi calm interactive E2E
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (13m8s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"31d3a2898f422a44ffd4903624963d47638c5fa5","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- 🚨 `docs/calm-mode-feasibility.md:259` - The authoritative intent requires: “Implement the smallest durable tracked Firstmate fixes needed so a normal genuinely fresh-shell `pi` launch succeeds without endpoint identity conflict,” or prove the exact external Nix owner and captain action. This diff contains no launcher, session-identity, or RLM change; its only launch-related evidence explicitly relies on a temporary Pi package with an external “evidence-only RLM endpoint repair” ([docs/calm-mode-feasibility.md](/Users/dmitrijarkov/.no-mistakes/worktrees/ba5c536ccc0a/01KZTCM3B5CQ557E7DRNN8WZ7S/docs/calm-mode-feasibility.md:259)). The installed Nix Pi failure therefore remains reachable, and the allowed external-owner handoff is not established in the reviewed change.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ The installed Nix Pi 0.84.0 still fails on the normal daemon-backed launch with endpoint_identity_conflict; the target commit contains no launcher/RLM ownership fix. An isolated real-Pi session succeeds with PI_RLM_DAEMON=0, confirming the remaining launch failure is outside this tracked Firstmate change. The repository&#39;s tmux-dependent live E2E cases and screenshot evidence could not run because tmux is unavailable; PTY verification was completed instead.
- <code>`one-bin audit exe pi`, `command -v pi`, `type -a pi`, and `pi --version` to verify executable ownership and the installed Pi version.</code>
- <code>`bash tests/fm-calm-pi-extension.test.sh` as the baseline; the default package lookup skipped because the installed package is Nix-managed.</code>
- <code>`FM_PI_PACKAGE_DIR=/var/folders/dh/8gfrsysn4jj6_8s6s5cn69940000gn/T/no-mistakes-evidence/01KZTCM3B5CQ557E7DRNN8WZ7S/pi-package-layout bash tests/fm-calm-pi-extension.test.sh`, repeated twice against the installed Nix Pi package.</code>
- <code>A normal isolated daemon-backed `pi` launch with `PI_OFFLINE=1`; captured the endpoint identity conflict and exit code 1.</code>
- <code>A real isolated Pi PTY launch with `PI_RLM_DAEMON=0`, followed by `/quit`, proving the fresh fixture can enter and exit Pi.</code>
- <code>A real isolated Pi PTY launch with persisted Calm enabled, followed by `/quit`; verified hidden routine thinking/tool presentation while retaining an outcome and warning.</code>
- <code>Read-only inspection of `docs/configuration.md`, `docs/calm.md`, installed Pi README/settings/TUI/themes/RLM documentation, and the target Calm extension/tests.</code>
- <code>Confirmed `tmux` is unavailable; used the available `expect` PTY path for live Pi evidence and recorded why screenshot/tmux evidence was not produced.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
