### PR TITLE
fix(bin): suppress empty Grok watcher turns

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -96,7 +96,7 @@ Before inspecting or changing session-open behavior, read `docs/sessionstart-nud
 
 At session start, `bin/fm-session-start.sh` prints exactly one watcher supervision block for the detected primary harness.
 Do not substitute another harness's wait shape when resuming supervision.
-Claude's Stop `asyncRewake` hook (`bin/fm-claude-stop-autoarm.sh`) owns tokenless re-arm around `bin/fm-watch-arm.sh`, and Grok uses tracked background-notify cycles around `bin/fm-watch-arm.sh`.
+Claude's Stop `asyncRewake` hook (`bin/fm-claude-stop-autoarm.sh`) owns tokenless re-arm around `bin/fm-watch-arm.sh`, and Grok uses one tracked `bin/fm-watch-arm-grok.sh` background owner that keeps empty child closes inside the same task.
 Codex uses bounded foreground checkpoints through `bin/fm-watch-checkpoint.sh` because Codex cannot reason while a foreground tool call is running.
 OpenCode uses `.opencode/plugins/fm-primary-watch-arm.js`, which coordinates with the turn-end guard plugin and wakes the TUI with `client.session.promptAsync`.
 Pi and pi-signed use the tracked `.pi/extensions/fm-primary-turnend-guard.ts` plus the tracked `.pi/extensions/fm-primary-pi-watch.ts`, both project-local extensions the Pi engine auto-discovers once trusted.
@@ -356,7 +356,7 @@ Grok 0.2.112 exposes native same-process Stop continuation in its running payloa
 The exact adaptive and malformed-input contract is owned by `docs/turnend-guard.md`.
 The tracked Claude hook entries whose event Grok already covers through its own `.grok/hooks/` registration skip themselves under `GROK_AGENT` or `GROK_HOOK_EVENT`, because Grok also loads Claude-compatible project settings and otherwise creates a second blocking path; the exact marker set and why `GROK_SESSION_ID` is excluded are owned by `docs/turnend-guard.md` "Harness integrations".
 Project-local Grok hooks require folder trust, verified with launch-time `--trust`; if the primary firstmate checkout is not trusted for Grok hooks, this primary guard fails open and `fm-guard.sh` remains the next-command alarm.
-Grok's primary watcher protocol remains background-notify around `bin/fm-watch-arm.sh`; native Stop continuation does not provide Pi-like extension ownership.
+Grok's primary watcher protocol remains background-notify through `bin/fm-watch-arm-grok.sh`; its persistent tracked owner absorbs empty child closes before Grok can notify the model, while native Stop continuation still does not provide Pi-like extension ownership.
 
 ## kimi (VERIFIED 2026-07-25, kimi 0.29.1)
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Backend-specific setup is linked in [Documentation](#documentation).
 ### Recommended harnesses
 
 **Claude Code, Grok, and Pi are equal co-primary recommendations** for running the primary firstmate session, with `pi-signed` supported as Pi's distinct signed-wrapper identity.
-Claude Code uses a tracked Stop hook for tokenless watcher re-arm and rewake, Grok uses background-notify wake cycles, and Pi uses its tracked primary watcher extension.
+Claude Code uses a tracked Stop hook for tokenless watcher re-arm and rewake, Grok uses one persistent background-notify owner that absorbs empty watcher closes, and Pi uses its tracked primary watcher extension.
 All three have verified turn-end guard paths when launched with their documented setup.
 Pick whichever one matches your subscription and workflow.
 

--- a/bin/fm-arm-command-policy.mjs
+++ b/bin/fm-arm-command-policy.mjs
@@ -25,7 +25,7 @@ const REASONS = {
   "watcher-nested": "a protected watcher command must not run through a wrapper, substitution, or compound command",
   "broad-watcher-kill": "a broad process kill targeting the firstmate watcher is forbidden",
   "unclassifiable-protected-command": "unsupported or malformed shell syntax contains a protected watcher command",
-  "watcher-direct": "bin/fm-watch.sh must not be run directly; arm the watcher with bin/fm-watch-arm.sh or run bin/fm-watch-checkpoint.sh instead",
+  "watcher-direct": "bin/fm-watch.sh must not be run directly; use bin/fm-watch-arm.sh, Grok's bin/fm-watch-arm-grok.sh owner, or bin/fm-watch-checkpoint.sh instead",
 };
 
 function parseArguments(argv) {
@@ -44,7 +44,7 @@ function parseArguments(argv) {
 }
 
 function rawMentionsProtected(command) {
-  return /(?:^|[/\s'"`(])fm-watch(?:-(?:arm|checkpoint))?\.sh\b/.test(normalizeLineContinuations(command));
+  return /(?:^|[/\s'"`(])fm-watch(?:-(?:arm(?:-grok)?|checkpoint))?\.sh\b/.test(normalizeLineContinuations(command));
 }
 
 function rawMentionsBroadKill(command) {
@@ -597,6 +597,7 @@ export function commandPosition(tokens) {
 
 const PROTECTED_SCRIPTS = [
   { relative: "bin/fm-watch-arm.sh", kind: "arm" },
+  { relative: "bin/fm-watch-arm-grok.sh", kind: "arm" },
   { relative: "bin/fm-watch-checkpoint.sh", kind: "checkpoint" },
   { relative: "bin/fm-watch.sh", kind: "watch" },
 ];

--- a/bin/fm-supervision-instructions.sh
+++ b/bin/fm-supervision-instructions.sh
@@ -147,7 +147,7 @@ repair_line() {
       printf '%s%s\n' "$prefix" 'repair missing watcher supervision by letting the OpenCode TUI plugin arm after idle; use bin/fm-watch-arm.sh only as a manual recovery probe if the plugin reports failure.'
       ;;
     grok)
-      printf '%s%s\n' "$prefix" 'repair missing watcher supervision with bin/fm-watch-arm.sh as its own Grok tracked background task, never shell &.'
+      printf '%s%s\n' "$prefix" 'repair missing watcher supervision with bin/fm-watch-arm-grok.sh as its own Grok tracked background task, never shell &.'
       ;;
     *)
       printf '%s%s\n' "$prefix" 'repair missing watcher supervision according to the session-start block for this harness; do not use shell &.'
@@ -170,7 +170,7 @@ ordinary_wake_line() {
       printf '%s\n' '- Ordinary wake: the OpenCode TUI plugin already owns watcher continuity; do not arm manually.'
       ;;
     grok)
-      printf '%s\n' '- Ordinary wake: re-arm exactly one bin/fm-watch-arm.sh Grok tracked background task as directed below.'
+      printf '%s\n' '- Ordinary wake: start exactly one bin/fm-watch-arm-grok.sh Grok tracked background task as directed below.'
       ;;
     *)
       printf '%s\n' '- Ordinary wake: follow the continuation in the harness protocol below; do not use shell &.'

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -149,7 +149,7 @@ family_for_basename() {
     fm-test-run.test.sh|fm-test-isolation-proof.test.sh)
       printf '%s\n' pure-contract-unit
       ;;
-    fm-daemon.test.sh|fm-guard-stale-banner.test.sh|fm-pi-watch-extension.test.sh|\
+    fm-daemon.test.sh|fm-grok-watch-arm.test.sh|fm-guard-stale-banner.test.sh|fm-pi-watch-extension.test.sh|\
     fm-session-lock-ancestry.test.sh|\
     fm-supervision-events.test.sh|fm-turnend-guard.test.sh|fm-wake-daemon-lifecycle-e2e.test.sh|\
     fm-wake-queue.test.sh|fm-watch-arm.test.sh|fm-watch-checkpoint.test.sh|fm-watch-triage.test.sh|\

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -847,6 +847,33 @@ fm_wake_append() {
   return "$status"
 }
 
+fm_wake_append_preserving_recovery() {
+  local kind=$1 key=$2 payload=$3 clean_key clean_payload epoch seq seq_file status
+  case "$kind" in
+    signal|stale|check|heartbeat) ;;
+    *) printf 'fm_wake_append_preserving_recovery: invalid wake kind: %s\n' "$kind" >&2; return 2 ;;
+  esac
+
+  clean_key=$(printf '%s' "$key" | fm_wake_clean_field)
+  clean_payload=$(printf '%s' "$payload" | fm_wake_clean_field)
+  epoch=$(date +%s)
+  seq_file="$STATE/.wake-queue.seq"
+  status=0
+
+  fm_lock_acquire_wait "$FM_WAKE_QUEUE_LOCK"
+  seq=$(cat "$seq_file" 2>/dev/null || echo 0)
+  case "$seq" in
+    ''|*[!0-9]*) seq=0 ;;
+  esac
+  seq=$((seq + 1))
+  printf '%s\n' "$seq" > "$seq_file" || status=$?
+  if [ "$status" -eq 0 ]; then
+    printf '%s\t%s\t%s\t%s\t%s\n' "$epoch" "$seq" "$kind" "$clean_key" "$clean_payload" >> "$FM_WAKE_QUEUE" || status=$?
+  fi
+  fm_lock_release "$FM_WAKE_QUEUE_LOCK"
+  return "$status"
+}
+
 # fm_wake_queued_keys <kind>
 # Print the distinct keys currently queued for <kind>, oldest first. Read under
 # the append lock so a concurrent append is never observed half-written. The

--- a/bin/fm-watch-arm-grok.sh
+++ b/bin/fm-watch-arm-grok.sh
@@ -194,6 +194,12 @@ while :; do
   verdict=$?
   case "$verdict" in
     0)
+      if [ -e "$STATE/.afk" ] || ! fm_supervision_needed "$STATE" || ! session_owner_is_still_valid; then
+        rm -rf "$stream_dir"
+        stream_dir=
+        wait_until_needed
+        continue
+      fi
       rm -rf "$stream_dir"
       stream_dir=
       exit 0

--- a/bin/fm-watch-arm-grok.sh
+++ b/bin/fm-watch-arm-grok.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# Grok-owned persistent watcher arm.
+#
+# Grok bills a model turn whenever one tracked background command completes.
+# Run this script, rather than fm-watch-arm.sh directly, as Grok's tracked
+# background command. It keeps that one command alive across an arm close that
+# has no durable wake row, no open decision, no pending recovery episode, and
+# no failure. A close with any of those actionable facts returns immediately so
+# Grok's native task-completed notification still wakes the model.
+#
+# This owner never drains or acknowledges work. Queue rows, decision records,
+# and recovery episodes retain their existing owners. It only performs bounded
+# read-side classification after the child arm has already closed. If that
+# classification cannot be completed safely, it fails loudly instead of hiding
+# a possible wake. Before every child arm it also requires the same live harness
+# pid to own the session lock, normal supervision need, and no away-mode flag.
+# Losing any of those conditions leaves this tracked task dormant instead of
+# mutating fleet state or completing an empty task.
+#
+# FM_GROK_WATCH_ARM_SCRIPT and FM_GROK_WATCH_IDLE_POLL are deterministic test
+# seams. Production uses the sibling fm-watch-arm.sh and a one-second idle poll.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+ARM="${FM_GROK_WATCH_ARM_SCRIPT:-$SCRIPT_DIR/fm-watch-arm.sh}"
+IDLE_POLL=${FM_GROK_WATCH_IDLE_POLL:-1}
+RECOVERY_MARKER="$STATE/.watcher-down"
+
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-classify-lib.sh
+. "$SCRIPT_DIR/fm-classify-lib.sh"
+# shellcheck source=bin/fm-supervision-lib.sh
+. "$SCRIPT_DIR/fm-supervision-lib.sh"
+# shellcheck source=bin/fm-session-lock-lib.sh
+. "$SCRIPT_DIR/fm-session-lock-lib.sh"
+
+case "${1:-}" in
+  '') ;;
+  -h|--help)
+    printf 'Usage: %s\n' "$(basename "$0")"
+    printf 'Run one persistent Grok tracked background watcher task.\n'
+    exit 0
+    ;;
+  *)
+    printf 'usage: %s\n' "$(basename "$0")" >&2
+    exit 2
+    ;;
+esac
+
+mkdir -p "$STATE"
+SESSION_OWNER=$(cat "$STATE/.lock" 2>/dev/null || true)
+
+child=
+reader=
+stream_dir=
+
+cleanup_cycle() {
+  if [ -n "$child" ] && fm_pid_alive "$child"; then
+    kill -TERM "$child" 2>/dev/null || true
+    wait "$child" 2>/dev/null || true
+  fi
+  if [ -n "$reader" ] && fm_pid_alive "$reader"; then
+    kill -TERM "$reader" 2>/dev/null || true
+    wait "$reader" 2>/dev/null || true
+  fi
+  if [ -n "$stream_dir" ]; then
+    rm -rf "$stream_dir" 2>/dev/null || true
+  fi
+  child=
+  reader=
+  stream_dir=
+}
+
+# shellcheck disable=SC2329 # Invoked indirectly by the signal traps below.
+handle_signal() {
+  local rc=$1
+  trap - HUP TERM INT
+  cleanup_cycle
+  exit "$rc"
+}
+
+trap 'handle_signal 129' HUP
+trap 'handle_signal 143' TERM
+trap 'handle_signal 130' INT
+trap cleanup_cycle EXIT
+
+CLASSIFY_FAILURE=
+
+# Exit 0 when durable state requires a Grok model wake, 1 when the close is
+# genuinely empty, and 2 when the read-side verdict cannot be established.
+durable_action_pending() {
+  local i open token
+  CLASSIFY_FAILURE=
+
+  i=0
+  while ! fm_lock_try_acquire "$FM_WAKE_QUEUE_LOCK"; do
+    if [ "$i" -ge 20 ]; then
+      CLASSIFY_FAILURE='wake queue lock remained unavailable'
+      return 2
+    fi
+    sleep 0.05
+    i=$((i + 1))
+  done
+  if [ -s "$FM_WAKE_QUEUE" ]; then
+    fm_lock_release "$FM_WAKE_QUEUE_LOCK"
+    return 0
+  fi
+  fm_lock_release "$FM_WAKE_QUEUE_LOCK"
+
+  open=$(scan_open_decisions "$STATE") || {
+    CLASSIFY_FAILURE='open-decision scan failed'
+    return 2
+  }
+  [ -z "$open" ] || return 0
+
+  if ! fm_recovery_marker_snapshot "$RECOVERY_MARKER"; then
+    CLASSIFY_FAILURE='recovery marker snapshot failed'
+    return 2
+  fi
+  token=$FM_RECOVERY_MARKER_TOKEN
+  if [ -e "$RECOVERY_MARKER" ] || [ -L "$RECOVERY_MARKER" ]; then
+    case "$token" in
+      acked:*) ;;
+      pending:*) return 0 ;;
+      *)
+        CLASSIFY_FAILURE='recovery marker is unreadable or malformed'
+        return 2
+        ;;
+    esac
+  fi
+
+  return 1
+}
+
+wait_until_needed() {
+  while [ -e "$STATE/.afk" ] || ! fm_supervision_needed "$STATE" || ! session_owner_is_still_valid; do
+    sleep "$IDLE_POLL"
+  done
+}
+
+session_owner_is_still_valid() {
+  local current
+  case "$SESSION_OWNER" in ''|*[!0-9]*) return 1 ;; esac
+  current=$(cat "$STATE/.lock" 2>/dev/null || true)
+  [ "$current" = "$SESSION_OWNER" ] || return 1
+  fm_harness_pid_alive "$SESSION_OWNER"
+}
+
+while :; do
+  wait_until_needed
+
+  stream_dir=$(mktemp -d "$STATE/.grok-watch-arm.XXXXXX") || {
+    echo 'watcher: FAILED - Grok continuity could not allocate its arm output stream'
+    exit 1
+  }
+  mkfifo "$stream_dir/stream" || {
+    echo 'watcher: FAILED - Grok continuity could not create its arm output stream'
+    exit 1
+  }
+  : > "$stream_dir/output"
+
+  tee "$stream_dir/output" < "$stream_dir/stream" &
+  reader=$!
+  "$ARM" > "$stream_dir/stream" 2>&1 &
+  child=$!
+  wait "$child"
+  rc=$?
+  child=
+  wait "$reader" 2>/dev/null || true
+  reader=
+
+  if [ "$rc" -ne 0 ] || grep -q '^watcher: FAILED' "$stream_dir/output" 2>/dev/null; then
+    if [ "$rc" -eq 0 ]; then rc=1; fi
+    if ! grep -q '^watcher: FAILED' "$stream_dir/output" 2>/dev/null; then
+      printf 'watcher: FAILED - Grok continuity arm exited %s\n' "$rc"
+    fi
+    rm -rf "$stream_dir"
+    stream_dir=
+    exit "$rc"
+  fi
+
+  durable_action_pending
+  verdict=$?
+  case "$verdict" in
+    0)
+      rm -rf "$stream_dir"
+      stream_dir=
+      exit 0
+      ;;
+    1)
+      rm -rf "$stream_dir"
+      stream_dir=
+      ;;
+    *)
+      printf 'watcher: FAILED - Grok continuity could not classify a completed arm: %s\n' "$CLASSIFY_FAILURE"
+      rm -rf "$stream_dir"
+      stream_dir=
+      exit 1
+      ;;
+  esac
+done

--- a/bin/fm-watch-arm-grok.sh
+++ b/bin/fm-watch-arm-grok.sh
@@ -192,14 +192,14 @@ while :; do
 
   durable_action_pending
   verdict=$?
+  if [ -e "$STATE/.afk" ] || ! fm_supervision_needed "$STATE" || ! session_owner_is_still_valid; then
+    rm -rf "$stream_dir"
+    stream_dir=
+    wait_until_needed
+    continue
+  fi
   case "$verdict" in
     0)
-      if [ -e "$STATE/.afk" ] || ! fm_supervision_needed "$STATE" || ! session_owner_is_still_valid; then
-        rm -rf "$stream_dir"
-        stream_dir=
-        wait_until_needed
-        continue
-      fi
       rm -rf "$stream_dir"
       stream_dir=
       exit 0

--- a/bin/fm-watch-arm-grok.sh
+++ b/bin/fm-watch-arm-grok.sh
@@ -177,7 +177,8 @@ while :; do
 
   if [ "$rc" -ne 0 ] || grep -q '^watcher: FAILED' "$stream_dir/output" 2>/dev/null; then
     if [ "$rc" -eq 0 ]; then rc=1; fi
-    if ! grep -q '^watcher: FAILED' "$stream_dir/output" 2>/dev/null; then
+    completion_failure=$(grep -m 1 '^watcher: FAILED' "$stream_dir/output" 2>/dev/null || true)
+    if [ -z "$completion_failure" ]; then
       completion_failure="watcher: FAILED - Grok continuity arm exited $rc"
     fi
     completion_rc=$rc
@@ -202,7 +203,8 @@ while :; do
 
   if [ -n "$completion_rc" ]; then
     if [ -e "$STATE/.afk" ] || ! fm_supervision_needed "$STATE" || ! session_owner_is_still_valid; then
-      if [ "$completion_rc" -ne 0 ] && ! fm_recovery_marker_publish "$RECOVERY_MARKER" downtime; then
+      if [ "$completion_rc" -ne 0 ] \
+        && ! fm_wake_append_preserving_recovery check "grok-transfer-failure:${stream_dir##*.}" "$completion_failure"; then
         while :; do sleep "$IDLE_POLL"; done
       fi
       rm -rf "$stream_dir"

--- a/bin/fm-watch-arm-grok.sh
+++ b/bin/fm-watch-arm-grok.sh
@@ -164,8 +164,15 @@ while :; do
     exit 1
   }
   : > "$stream_dir/output"
+  : > "$stream_dir/terminal"
 
-  tee "$stream_dir/output" < "$stream_dir/stream" &
+  while IFS= read -r line; do
+    printf '%s\n' "$line" >> "$stream_dir/output"
+    case "$line" in
+      'watcher: started '*|'watcher: attached '*) printf '%s\n' "$line" ;;
+      *) printf '%s\n' "$line" >> "$stream_dir/terminal" ;;
+    esac
+  done < "$stream_dir/stream" &
   reader=$!
   "$ARM" > "$stream_dir/stream" 2>&1 &
   child=$!
@@ -212,7 +219,11 @@ while :; do
       wait_until_needed
       continue
     fi
-    [ -z "$completion_failure" ] || printf '%s\n' "$completion_failure"
+    cat "$stream_dir/terminal"
+    if [ -n "$completion_failure" ] \
+      && ! grep -q '^watcher: FAILED' "$stream_dir/terminal" 2>/dev/null; then
+      printf '%s\n' "$completion_failure"
+    fi
     rm -rf "$stream_dir"
     stream_dir=
     exit "$completion_rc"

--- a/bin/fm-watch-arm-grok.sh
+++ b/bin/fm-watch-arm-grok.sh
@@ -172,29 +172,34 @@ while :; do
     echo 'watcher: FAILED - Grok continuity could not create its arm output stream'
     exit 1
   }
-  : > "$stream_dir/terminal"
+  : > "$stream_dir/capture"
   : > "$stream_dir/overflow"
 
   "$ARM" > "$stream_dir/stream" 2>&1 &
   child=$!
   (
-    LC_ALL=C
     captured=0
-    overflowed=0
-    while IFS= read -r line; do
-      bytes=$((${#line} + 1))
-      if [ "$overflowed" -eq 0 ] && [ $((captured + bytes)) -gt "$OUTPUT_MAX_BYTES" ]; then
-        overflowed=1
+    emitted=0
+    while :; do
+      : > "$stream_dir/chunk"
+      dd bs=4096 count=1 of="$stream_dir/chunk" 2>/dev/null || true
+      bytes=$(wc -c < "$stream_dir/chunk" | tr -d '[:space:]')
+      [ "$bytes" -gt 0 ] || break
+      remaining=$((OUTPUT_MAX_BYTES - captured))
+      if [ "$bytes" -gt "$remaining" ]; then
+        head -c "$remaining" "$stream_dir/chunk" >> "$stream_dir/capture"
         printf 'watcher: FAILED - Grok continuity arm output exceeded %s bytes\n' "$OUTPUT_MAX_BYTES" > "$stream_dir/overflow"
         kill -TERM "$child" 2>/dev/null || true
-        continue
+        break
       fi
-      [ "$overflowed" -eq 0 ] || continue
       captured=$((captured + bytes))
-      case "$line" in
-        'watcher: started '*|'watcher: attached '*) printf '%s\n' "$line" ;;
-        *) printf '%s\n' "$line" >> "$stream_dir/terminal" ;;
-      esac
+      cat "$stream_dir/chunk" >> "$stream_dir/capture"
+      complete=$(wc -l < "$stream_dir/capture" | tr -d '[:space:]')
+      if [ "$complete" -gt "$emitted" ]; then
+        sed -n "$((emitted + 1)),${complete}p" "$stream_dir/capture" \
+          | awk '/^watcher: started / || /^watcher: attached /'
+        emitted=$complete
+      fi
     done < "$stream_dir/stream"
   ) &
   reader=$!
@@ -203,6 +208,7 @@ while :; do
   child=
   wait "$reader" 2>/dev/null || true
   reader=
+  awk '!/^watcher: started / && !/^watcher: attached /' "$stream_dir/capture" > "$stream_dir/terminal"
 
   if [ -s "$stream_dir/overflow" ]; then
     rc=1

--- a/bin/fm-watch-arm-grok.sh
+++ b/bin/fm-watch-arm-grok.sh
@@ -152,6 +152,8 @@ session_owner_is_still_valid() {
 
 while :; do
   wait_until_needed
+  completion_rc=
+  completion_failure=
 
   stream_dir=$(mktemp -d "$STATE/.grok-watch-arm.XXXXXX") || {
     echo 'watcher: FAILED - Grok continuity could not allocate its arm output stream'
@@ -183,36 +185,35 @@ while :; do
   if [ "$rc" -ne 0 ] || grep -q '^watcher: FAILED' "$stream_dir/output" 2>/dev/null; then
     if [ "$rc" -eq 0 ]; then rc=1; fi
     if ! grep -q '^watcher: FAILED' "$stream_dir/output" 2>/dev/null; then
-      printf 'watcher: FAILED - Grok continuity arm exited %s\n' "$rc"
+      completion_failure="watcher: FAILED - Grok continuity arm exited $rc"
     fi
-    rm -rf "$stream_dir"
-    stream_dir=
-    exit "$rc"
+    completion_rc=$rc
+  else
+    durable_action_pending
+    verdict=$?
+    case "$verdict" in
+      0) completion_rc=0 ;;
+      1) ;;
+      *)
+        completion_rc=1
+        completion_failure="watcher: FAILED - Grok continuity could not classify a completed arm: $CLASSIFY_FAILURE"
+        ;;
+    esac
   fi
 
-  durable_action_pending
-  verdict=$?
-  if [ -e "$STATE/.afk" ] || ! fm_supervision_needed "$STATE" || ! session_owner_is_still_valid; then
+  if [ -n "$completion_rc" ]; then
+    if [ -e "$STATE/.afk" ] || ! fm_supervision_needed "$STATE" || ! session_owner_is_still_valid; then
+      rm -rf "$stream_dir"
+      stream_dir=
+      wait_until_needed
+      continue
+    fi
+    [ -z "$completion_failure" ] || printf '%s\n' "$completion_failure"
     rm -rf "$stream_dir"
     stream_dir=
-    wait_until_needed
-    continue
+    exit "$completion_rc"
   fi
-  case "$verdict" in
-    0)
-      rm -rf "$stream_dir"
-      stream_dir=
-      exit 0
-      ;;
-    1)
-      rm -rf "$stream_dir"
-      stream_dir=
-      ;;
-    *)
-      printf 'watcher: FAILED - Grok continuity could not classify a completed arm: %s\n' "$CLASSIFY_FAILURE"
-      rm -rf "$stream_dir"
-      stream_dir=
-      exit 1
-      ;;
-  esac
+
+  rm -rf "$stream_dir"
+  stream_dir=
 done

--- a/bin/fm-watch-arm-grok.sh
+++ b/bin/fm-watch-arm-grok.sh
@@ -93,31 +93,53 @@ EOF
   done
 }
 
-retire_child_tree() {
-  local root=$1 seed=${2:-} signal pid i=0 pids pgid
-  pgid=$(ps -o pgid= -p "$root" 2>/dev/null | tr -d '[:space:]' || true)
-  pids=$(printf '%s\n' "$(cat "$seed" 2>/dev/null || true)" "$(child_tree_pids "$root")" | awk 'NF && !seen[$0]++')
-  for signal in TERM KILL; do
-    if [ "$pgid" = "$root" ]; then
-      kill -"$signal" -- "-$pgid" 2>/dev/null || true
-    fi
-    printf '%s\n' "$pids" | awk 'NF' | sort -rn | while read -r pid; do
-      kill -"$signal" "$pid" 2>/dev/null || true
-    done
-    if [ "$signal" = TERM ]; then
-      while fm_pid_alive "$root" && [ "$i" -lt 20 ]; do
-        sleep "$(awk -v grace="$CHILD_TERM_GRACE" 'BEGIN { print grace / 20 }')"
-        i=$((i + 1))
-      done
-      pids=$(printf '%s\n' "$pids" "$(child_tree_pids "$root")" | awk 'NF && !seen[$0]++')
-    fi
+child_tree_identities() {
+  local root=$1 pid identity
+  child_tree_pids "$root" | while read -r pid; do
+    identity=$(fm_pid_identity "$pid" 2>/dev/null) || continue
+    printf '%s\t%s\n' "$pid" "$identity"
   done
+}
+
+signal_identity_records() {
+  local records=$1 signal=$2 pid expected current mismatch=0
+  while IFS=$'\t' read -r pid expected; do
+    [ -n "$pid" ] && [ -n "$expected" ] || continue
+    current=$(fm_pid_identity "$pid" 2>/dev/null || true)
+    if [ "$current" != "$expected" ]; then
+      mismatch=1
+      continue
+    fi
+    kill -"$signal" "$pid" 2>/dev/null || true
+  done < "$records"
+  return "$mismatch"
+}
+
+retire_child_tree() {
+  local root=$1 seed=${2:-} i=0 records current incomplete=0
+  records=$(mktemp "$STATE/.grok-retire.XXXXXX") || return 1
+  printf '%s\n' "$(cat "$seed" 2>/dev/null || true)" \
+    "$(cat "${FM_GROK_WATCH_RETIRE_TEST_SEED:-/dev/null}" 2>/dev/null || true)" \
+    "$(child_tree_identities "$root")" \
+    | awk -F '\t' 'NF >= 2 && !seen[$1 FS $2]++' > "$records"
+  signal_identity_records "$records" TERM || incomplete=1
+  while fm_pid_alive "$root" && [ "$i" -lt 20 ]; do
+    sleep "$(awk -v grace="$CHILD_TERM_GRACE" 'BEGIN { print grace / 20 }')"
+    i=$((i + 1))
+  done
+  current="$records.current"
+  printf '%s\n' "$(cat "$records")" "$(child_tree_identities "$root")" \
+    | awk -F '\t' 'NF >= 2 && !seen[$1 FS $2]++' > "$current"
+  mv "$current" "$records"
+  signal_identity_records "$records" KILL || incomplete=1
   wait "$root" 2>/dev/null || true
+  rm -f "$records"
+  [ "$incomplete" -eq 0 ]
 }
 
 cleanup_cycle() {
   if [ -n "$child" ] && fm_pid_alive "$child"; then
-    retire_child_tree "$child"
+    retire_child_tree "$child" || true
   fi
   if [ -n "$reader" ] && fm_pid_alive "$reader"; then
     kill -TERM "$reader" 2>/dev/null || true
@@ -237,7 +259,7 @@ while :; do
       remaining=$((OUTPUT_MAX_BYTES - captured))
       if [ "$bytes" -gt "$remaining" ]; then
         head -c "$remaining" "$stream_dir/chunk" >> "$stream_dir/capture"
-        child_tree_pids "$child" > "$stream_dir/overflow-pids"
+        child_tree_identities "$child" > "$stream_dir/overflow-pids"
         printf 'watcher: FAILED - Grok continuity arm output exceeded %s bytes\n' "$OUTPUT_MAX_BYTES" > "$stream_dir/overflow"
         break
       fi
@@ -256,7 +278,9 @@ while :; do
     sleep 0.02
   done
   if [ -s "$stream_dir/overflow" ]; then
-    retire_child_tree "$child" "$stream_dir/overflow-pids"
+    if ! retire_child_tree "$child" "$stream_dir/overflow-pids"; then
+      printf 'watcher: FAILED - Grok continuity arm output exceeded %s bytes; exact child retirement was incomplete\n' "$OUTPUT_MAX_BYTES" > "$stream_dir/overflow"
+    fi
   fi
   wait "$child"
   rc=$?

--- a/bin/fm-watch-arm-grok.sh
+++ b/bin/fm-watch-arm-grok.sh
@@ -17,8 +17,9 @@
 # Losing any of those conditions leaves this tracked task dormant instead of
 # mutating fleet state or completing an empty task.
 #
-# FM_GROK_WATCH_ARM_SCRIPT and FM_GROK_WATCH_IDLE_POLL are deterministic test
-# seams. Production uses the sibling fm-watch-arm.sh and a one-second idle poll.
+# FM_GROK_WATCH_ARM_SCRIPT, FM_GROK_WATCH_IDLE_POLL, and
+# FM_GROK_WATCH_OUTPUT_MAX_BYTES are deterministic test seams. Production uses
+# the sibling fm-watch-arm.sh, a one-second idle poll, and a 65536-byte cap.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -27,7 +28,15 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 ARM="${FM_GROK_WATCH_ARM_SCRIPT:-$SCRIPT_DIR/fm-watch-arm.sh}"
 IDLE_POLL=${FM_GROK_WATCH_IDLE_POLL:-1}
+OUTPUT_MAX_BYTES=${FM_GROK_WATCH_OUTPUT_MAX_BYTES:-65536}
 RECOVERY_MARKER="$STATE/.watcher-down"
+
+case "$OUTPUT_MAX_BYTES" in
+  ''|*[!0-9]*|0)
+    echo 'watcher: FAILED - Grok continuity output cap must be a positive integer'
+    exit 1
+    ;;
+esac
 
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
@@ -163,28 +172,45 @@ while :; do
     echo 'watcher: FAILED - Grok continuity could not create its arm output stream'
     exit 1
   }
-  : > "$stream_dir/output"
   : > "$stream_dir/terminal"
+  : > "$stream_dir/overflow"
 
-  while IFS= read -r line; do
-    printf '%s\n' "$line" >> "$stream_dir/output"
-    case "$line" in
-      'watcher: started '*|'watcher: attached '*) printf '%s\n' "$line" ;;
-      *) printf '%s\n' "$line" >> "$stream_dir/terminal" ;;
-    esac
-  done < "$stream_dir/stream" &
-  reader=$!
   "$ARM" > "$stream_dir/stream" 2>&1 &
   child=$!
+  (
+    LC_ALL=C
+    captured=0
+    overflowed=0
+    while IFS= read -r line; do
+      bytes=$((${#line} + 1))
+      if [ "$overflowed" -eq 0 ] && [ $((captured + bytes)) -gt "$OUTPUT_MAX_BYTES" ]; then
+        overflowed=1
+        printf 'watcher: FAILED - Grok continuity arm output exceeded %s bytes\n' "$OUTPUT_MAX_BYTES" > "$stream_dir/overflow"
+        kill -TERM "$child" 2>/dev/null || true
+        continue
+      fi
+      [ "$overflowed" -eq 0 ] || continue
+      captured=$((captured + bytes))
+      case "$line" in
+        'watcher: started '*|'watcher: attached '*) printf '%s\n' "$line" ;;
+        *) printf '%s\n' "$line" >> "$stream_dir/terminal" ;;
+      esac
+    done < "$stream_dir/stream"
+  ) &
+  reader=$!
   wait "$child"
   rc=$?
   child=
   wait "$reader" 2>/dev/null || true
   reader=
 
-  if [ "$rc" -ne 0 ] || grep -q '^watcher: FAILED' "$stream_dir/output" 2>/dev/null; then
+  if [ -s "$stream_dir/overflow" ]; then
+    rc=1
+    completion_failure=$(cat "$stream_dir/overflow")
+    completion_rc=1
+  elif [ "$rc" -ne 0 ] || grep -q '^watcher: FAILED' "$stream_dir/terminal" 2>/dev/null; then
     if [ "$rc" -eq 0 ]; then rc=1; fi
-    completion_failure=$(grep -m 1 '^watcher: FAILED' "$stream_dir/output" 2>/dev/null || true)
+    completion_failure=$(grep -m 1 '^watcher: FAILED' "$stream_dir/terminal" 2>/dev/null || true)
     if [ -z "$completion_failure" ]; then
       completion_failure="watcher: FAILED - Grok continuity arm exited $rc"
     fi

--- a/bin/fm-watch-arm-grok.sh
+++ b/bin/fm-watch-arm-grok.sh
@@ -116,7 +116,7 @@ signal_identity_records() {
 }
 
 retire_child_tree() {
-  local root=$1 seed=${2:-} i=0 records current incomplete=0
+  local root=$1 seed=${2:-} i=0 records current kill_records pid expected observed incomplete=0
   records=$(mktemp "$STATE/.grok-retire.XXXXXX") || return 1
   printf '%s\n' "$(cat "$seed" 2>/dev/null || true)" \
     "$(cat "${FM_GROK_WATCH_RETIRE_TEST_SEED:-/dev/null}" 2>/dev/null || true)" \
@@ -128,12 +128,23 @@ retire_child_tree() {
     i=$((i + 1))
   done
   current="$records.current"
-  printf '%s\n' "$(cat "$records")" "$(child_tree_identities "$root")" \
-    | awk -F '\t' 'NF >= 2 && !seen[$1 FS $2]++' > "$current"
-  mv "$current" "$records"
-  signal_identity_records "$records" KILL || incomplete=1
+  child_tree_identities "$root" > "$current"
+  kill_records="$records.kill"
+  awk -F '\t' 'NR == FNR { current[$1 FS $2]=1; next } current[$1 FS $2]' \
+    "$current" "$records" > "$kill_records"
+  while IFS=$'\t' read -r pid expected; do
+    [ -n "$pid" ] && [ -n "$expected" ] || continue
+    observed=$(fm_pid_identity "$pid" 2>/dev/null || true)
+    [ -z "$observed" ] && continue
+    if [ "$observed" = "$expected" ] \
+      && ! awk -F '\t' -v pid="$pid" -v identity="$expected" \
+        '$1 == pid && $2 == identity { found=1 } END { exit !found }' "$kill_records"; then
+      incomplete=1
+    fi
+  done < "$records"
+  signal_identity_records "$kill_records" KILL || incomplete=1
   wait "$root" 2>/dev/null || true
-  rm -f "$records"
+  rm -f "$records" "$current" "$kill_records"
   [ "$incomplete" -eq 0 ]
 }
 

--- a/bin/fm-watch-arm-grok.sh
+++ b/bin/fm-watch-arm-grok.sh
@@ -175,13 +175,6 @@ while :; do
   wait "$reader" 2>/dev/null || true
   reader=
 
-  if [ -e "$STATE/.afk" ] || ! fm_supervision_needed "$STATE" || ! session_owner_is_still_valid; then
-    rm -rf "$stream_dir"
-    stream_dir=
-    wait_until_needed
-    continue
-  fi
-
   if [ "$rc" -ne 0 ] || grep -q '^watcher: FAILED' "$stream_dir/output" 2>/dev/null; then
     if [ "$rc" -eq 0 ]; then rc=1; fi
     if ! grep -q '^watcher: FAILED' "$stream_dir/output" 2>/dev/null; then
@@ -189,6 +182,12 @@ while :; do
     fi
     completion_rc=$rc
   else
+    if [ -e "$STATE/.afk" ] || ! fm_supervision_needed "$STATE" || ! session_owner_is_still_valid; then
+      rm -rf "$stream_dir"
+      stream_dir=
+      wait_until_needed
+      continue
+    fi
     durable_action_pending
     verdict=$?
     case "$verdict" in
@@ -203,6 +202,9 @@ while :; do
 
   if [ -n "$completion_rc" ]; then
     if [ -e "$STATE/.afk" ] || ! fm_supervision_needed "$STATE" || ! session_owner_is_still_valid; then
+      if [ "$completion_rc" -ne 0 ] && ! fm_recovery_marker_publish "$RECOVERY_MARKER" downtime; then
+        while :; do sleep "$IDLE_POLL"; done
+      fi
       rm -rf "$stream_dir"
       stream_dir=
       wait_until_needed

--- a/bin/fm-watch-arm-grok.sh
+++ b/bin/fm-watch-arm-grok.sh
@@ -173,6 +173,13 @@ while :; do
   wait "$reader" 2>/dev/null || true
   reader=
 
+  if [ -e "$STATE/.afk" ] || ! fm_supervision_needed "$STATE" || ! session_owner_is_still_valid; then
+    rm -rf "$stream_dir"
+    stream_dir=
+    wait_until_needed
+    continue
+  fi
+
   if [ "$rc" -ne 0 ] || grep -q '^watcher: FAILED' "$stream_dir/output" 2>/dev/null; then
     if [ "$rc" -eq 0 ]; then rc=1; fi
     if ! grep -q '^watcher: FAILED' "$stream_dir/output" 2>/dev/null; then

--- a/bin/fm-watch-arm-grok.sh
+++ b/bin/fm-watch-arm-grok.sh
@@ -29,11 +29,18 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 ARM="${FM_GROK_WATCH_ARM_SCRIPT:-$SCRIPT_DIR/fm-watch-arm.sh}"
 IDLE_POLL=${FM_GROK_WATCH_IDLE_POLL:-1}
 OUTPUT_MAX_BYTES=${FM_GROK_WATCH_OUTPUT_MAX_BYTES:-65536}
+CHILD_TERM_GRACE=${FM_GROK_WATCH_CHILD_TERM_GRACE:-1}
 RECOVERY_MARKER="$STATE/.watcher-down"
 
 case "$OUTPUT_MAX_BYTES" in
   ''|*[!0-9]*|0)
     echo 'watcher: FAILED - Grok continuity output cap must be a positive integer'
+    exit 1
+    ;;
+esac
+case "$CHILD_TERM_GRACE" in
+  ''|*[!0-9.]*|.*|*.*.*)
+    echo 'watcher: FAILED - Grok continuity child TERM grace must be a positive number'
     exit 1
     ;;
 esac
@@ -67,10 +74,50 @@ child=
 reader=
 stream_dir=
 
+child_tree_pids() {
+  local root=$1 frontier=$1 next pid ppid
+  printf '%s\n' "$root"
+  while [ -n "$frontier" ]; do
+    next=
+    while read -r pid ppid; do
+      case " $frontier " in
+        *" $ppid "*)
+          printf '%s\n' "$pid"
+          next="$next $pid"
+          ;;
+      esac
+    done <<EOF
+$(ps -eo pid=,ppid= 2>/dev/null)
+EOF
+    frontier=${next# }
+  done
+}
+
+retire_child_tree() {
+  local root=$1 seed=${2:-} signal pid i=0 pids pgid
+  pgid=$(ps -o pgid= -p "$root" 2>/dev/null | tr -d '[:space:]' || true)
+  pids=$(printf '%s\n' "$(cat "$seed" 2>/dev/null || true)" "$(child_tree_pids "$root")" | awk 'NF && !seen[$0]++')
+  for signal in TERM KILL; do
+    if [ "$pgid" = "$root" ]; then
+      kill -"$signal" -- "-$pgid" 2>/dev/null || true
+    fi
+    printf '%s\n' "$pids" | awk 'NF' | sort -rn | while read -r pid; do
+      kill -"$signal" "$pid" 2>/dev/null || true
+    done
+    if [ "$signal" = TERM ]; then
+      while fm_pid_alive "$root" && [ "$i" -lt 20 ]; do
+        sleep "$(awk -v grace="$CHILD_TERM_GRACE" 'BEGIN { print grace / 20 }')"
+        i=$((i + 1))
+      done
+      pids=$(printf '%s\n' "$pids" "$(child_tree_pids "$root")" | awk 'NF && !seen[$0]++')
+    fi
+  done
+  wait "$root" 2>/dev/null || true
+}
+
 cleanup_cycle() {
   if [ -n "$child" ] && fm_pid_alive "$child"; then
-    kill -TERM "$child" 2>/dev/null || true
-    wait "$child" 2>/dev/null || true
+    retire_child_tree "$child"
   fi
   if [ -n "$reader" ] && fm_pid_alive "$reader"; then
     kill -TERM "$reader" 2>/dev/null || true
@@ -175,8 +222,10 @@ while :; do
   : > "$stream_dir/capture"
   : > "$stream_dir/overflow"
 
+  set -m
   "$ARM" > "$stream_dir/stream" 2>&1 &
   child=$!
+  set +m
   (
     captured=0
     emitted=0
@@ -188,8 +237,8 @@ while :; do
       remaining=$((OUTPUT_MAX_BYTES - captured))
       if [ "$bytes" -gt "$remaining" ]; then
         head -c "$remaining" "$stream_dir/chunk" >> "$stream_dir/capture"
+        child_tree_pids "$child" > "$stream_dir/overflow-pids"
         printf 'watcher: FAILED - Grok continuity arm output exceeded %s bytes\n' "$OUTPUT_MAX_BYTES" > "$stream_dir/overflow"
-        kill -TERM "$child" 2>/dev/null || true
         break
       fi
       captured=$((captured + bytes))
@@ -203,6 +252,12 @@ while :; do
     done < "$stream_dir/stream"
   ) &
   reader=$!
+  while fm_pid_alive "$child" && [ ! -s "$stream_dir/overflow" ]; do
+    sleep 0.02
+  done
+  if [ -s "$stream_dir/overflow" ]; then
+    retire_child_tree "$child" "$stream_dir/overflow-pids"
+  fi
   wait "$child"
   rc=$?
   child=

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,8 +60,9 @@ The default path remains local-only; live GitHub enrichment exists only behind t
 Optional Relay integrates with the watcher only after explicit opt-in; [configuration.md](configuration.md#relay-env) owns its generated-artifact and dispatch mechanics.
 
 At session start, `bin/fm-session-start.sh` emits exactly one primary-harness supervision block rendered by `bin/fm-supervision-instructions.sh` from `docs/supervision-protocols/`.
-That block owns the live wait shape for the running primary harness: Claude's Stop `asyncRewake` hook owns tokenless re-arm cycles, Grok uses background-notify cycles, Codex uses bounded foreground checkpoints, Pi and pi-signed use the same two tracked primary extensions, and OpenCode uses its TUI plugin.
+That block owns the live wait shape for the running primary harness: Claude's Stop `asyncRewake` hook owns tokenless re-arm cycles, Grok uses a persistent background-notify owner that suppresses empty child closes, Codex uses bounded foreground checkpoints, Pi and pi-signed use the same two tracked primary extensions, and OpenCode uses its TUI plugin.
 `bin/fm-watch-arm.sh` remains the verified arm wrapper for protocols that call it; it forks the watcher as a tracked child, verifies it is genuinely alive with a fresh liveness beacon, and prints an honest `started`, `attached`, or nonzero `FAILED` status.
+`bin/fm-watch-arm-grok.sh` is the Grok-only tracked owner above that wrapper; it keeps an empty close inside one background task so Grok receives completion only for durable actionable state or failure.
 [`watcher-continuity.md`](watcher-continuity.md#arm-layer-cycle-contract) owns the arm layer's successor, terminal-delivery, re-arm recovery, and typed clean-close failure contract.
 The arm layer records one bounded lifecycle row per observed cycle in `state/.watch-cycle-exits.log`; `state/.watch-triage.log` remains exclusively the absorbed-wake debug log.
 Pi and OpenCode verify session-lock ownership and launch one singleton successor from their child-close handlers before delivering an actionable wake prompt, with bounded exponential retry for failed restoration.

--- a/docs/arm-pretool-check.md
+++ b/docs/arm-pretool-check.md
@@ -8,7 +8,7 @@ The tracked harness adapters forward command text without classifying it.
 
 ## Purpose and boundary
 
-A firstmate primary must arm `bin/fm-watch-arm.sh` or run `bin/fm-watch-checkpoint.sh` through an observable harness call.
+A firstmate primary must arm `bin/fm-watch-arm.sh`, run Grok's persistent `bin/fm-watch-arm-grok.sh` owner, or run `bin/fm-watch-checkpoint.sh` through an observable harness call.
 A shell background operator, pipeline, redirection, wrapper, or unrelated command list can hide failure or let the watcher child die with the tool call.
 The seatbelt rejects those command shapes before execution.
 
@@ -62,6 +62,7 @@ A command word in executed position is a protected execution when its normalized
 
 ```text
 bin/fm-watch-arm.sh          (arm; blessed entry point)
+bin/fm-watch-arm-grok.sh     (Grok persistent arm owner; blessed entry point)
 bin/fm-watch-checkpoint.sh   (checkpoint; blessed entry point)
 bin/fm-watch.sh              (watch; protected but never blessed)
 ```
@@ -73,7 +74,7 @@ Static quote forms are cooked before the suffix match, so a command word split b
 This covers statically-visible literal words in command position; opaque dynamic dataflow such as `bash -lc "$WHOLE_COMMAND"` remains out of scope.
 
 `bin/fm-watch.sh` is protected but is not a blessed entry point.
-A direct `bin/fm-watch.sh` execution - relative, `<code-root>`-anchored, `$VAR`-prefixed, or `~`-prefixed - always denies with `watcher-direct`, whose reason points the caller at `bin/fm-watch-arm.sh` and `bin/fm-watch-checkpoint.sh`.
+A direct `bin/fm-watch.sh` execution - relative, `<code-root>`-anchored, `$VAR`-prefixed, or `~`-prefixed - always denies with `watcher-direct`, whose reason points the caller at `bin/fm-watch-arm.sh`, Grok's `bin/fm-watch-arm-grok.sh` owner, and `bin/fm-watch-checkpoint.sh`.
 
 The same bytes in an argument, comment, assertion, documentation query, Python string, `printf`, or `tmux send-keys` payload are data and do not make the outer command relevant.
 
@@ -90,7 +91,7 @@ An actual protected command with a heredoc still has a redirection and is denied
 ## Blessed syntax tree
 
 An allowed watcher program is one linear outer command list with zero or more approved setup nodes followed by exactly one direct protected node.
-`bin/fm-watch-arm.sh` and `bin/fm-watch-checkpoint.sh` are the only blessed final nodes, including their expanded-path forms; a `bin/fm-watch.sh` final node is never blessed and denies with `watcher-direct`.
+`bin/fm-watch-arm.sh`, `bin/fm-watch-arm-grok.sh`, and `bin/fm-watch-checkpoint.sh` are the only blessed final nodes, including their expanded-path forms; a `bin/fm-watch.sh` final node is never blessed and denies with `watcher-direct`.
 
 Approved setup nodes are:
 
@@ -138,7 +139,7 @@ Every semantic deny includes one stable code in square brackets before its prose
 | `watcher-nested` | A wrapper, group, substitution, nested shell, `eval`, or constructed dynamic payload executes the protected command. |
 | `broad-watcher-kill` | An actual broad process kill targets the watcher. |
 | `unclassifiable-protected-command` | Malformed or unsupported syntax contains a protected command and cannot be safely classified. |
-| `watcher-direct` | A direct `bin/fm-watch.sh` execution; the watcher must be reached through `bin/fm-watch-arm.sh` or `bin/fm-watch-checkpoint.sh`. |
+| `watcher-direct` | A direct `bin/fm-watch.sh` execution; the watcher must be reached through `bin/fm-watch-arm.sh`, Grok's `bin/fm-watch-arm-grok.sh` owner, or `bin/fm-watch-checkpoint.sh`. |
 
 Reason codes are the stable contract for tests and adapters.
 Prose may improve without changing adapter behavior.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -217,7 +217,7 @@ Pi-family launches adapt the regular-TUI safeguard to the installed CLI's capabi
 Enabled primary-session turn-end guard integrations are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).
 Kimi remains outside the primary turn-end guard integrations; [`docs/turnend-guard.md`](turnend-guard.md#compatibility-limits) owns its separate captain-approved crew wake hook.
 Primary-session watcher wake protocols are rendered at session start by [`bin/fm-supervision-instructions.sh`](../bin/fm-supervision-instructions.sh) from [`docs/supervision-protocols/`](supervision-protocols/).
-Claude's Stop `asyncRewake` hook owns tokenless re-arm cycles, Grok uses background-notify cycles, Codex uses bounded foreground checkpoints, Pi and pi-signed use the same two tracked primary extensions, and OpenCode uses its TUI plugin.
+Claude's Stop `asyncRewake` hook owns tokenless re-arm cycles, Grok uses a persistent background-notify owner that absorbs empty child closes before task completion, Codex uses bounded foreground checkpoints, Pi and pi-signed use the same two tracked primary extensions, and OpenCode uses its TUI plugin.
 `config/crew-harness` is a local, gitignored file containing one adapter name for crewmate and scout launches.
 When pi-signed is selected, Firstmate preserves `FM_PI_HARNESS=pi-signed` and refuses the launch if the selected executable is unavailable rather than falling back to pi; [`fm-spawn.sh --help`](../bin/fm-spawn.sh) owns executable resolution and launch mechanics.
 Plain Pi launches set `FM_PI_HARNESS=pi`, so a signed primary's environment cannot relabel a plain Pi worker.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -69,6 +69,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-procevent-when.sh`   | Fire a trust-bound deterministic action at most once when its registered condition holds, then wake with the outcome |
 | `fm-gate-refuse-lib.sh`  | Shared no-mistakes gate-context refusal for fleet lifecycle entrypoints               |
 | `fm-watch-arm.sh`        | Verified home-scoped watcher arm wrapper with loud cycle endings and bounded lifecycle ledger |
+| `fm-watch-arm-grok.sh`   | Persistent Grok tracked-task owner that suppresses empty arm closes before model notification |
 | `fm-watch-checkpoint.sh` | Run one bounded foreground watcher checkpoint for Codex-style supervision            |
 | `fm-watch.sh`            | Singleton-safe always-on watcher: absorb benign wakes, queue and exit on actionable ones |
 | `fm-inactive-reconcile.sh` | Reconcile long-inactive direct crewmate terminal outcomes without forge access |

--- a/docs/supervision-protocols/grok.md
+++ b/docs/supervision-protocols/grok.md
@@ -1,4 +1,4 @@
-Mode: Grok background-notify supervision.
+Mode: Grok persistent background-notify supervision.
 
 When this session owns supervision and away mode is not active:
 1. Drain first with `bin/fm-wake-drain.sh`.
@@ -7,28 +7,29 @@ When this session owns supervision and away mode is not active:
 3. First cycle: arm with Grok's tracked background tool, as its own call:
 
    `run_terminal_command` with `background: true` on:
-   `[ -f __FM_X_MODE_ENV_SH__ ] && . __FM_X_MODE_ENV_SH__; exec bin/fm-watch-arm.sh`
+   `[ -f __FM_X_MODE_ENV_SH__ ] && . __FM_X_MODE_ENV_SH__; exec bin/fm-watch-arm-grok.sh`
 
 4. Trust only the arm's one-line status.
 5. `watcher: started ...` or `watcher: attached ...` means a live cycle exists.
    On attach, the background task follows verified identity-matched successors instead of exiting when the first cycle ends.
 6. Failure or missing cycle only: `watcher: FAILED ...` means supervision is down; fix and re-arm.
 7. After a successful start or attach status, end the turn.
-   The background arm remains the live wait until it returns an actionable wake or failure.
+   The persistent Grok owner remains the live wait until it returns an actionable wake or failure.
+   It re-arms internally when a completed arm has no queued wake, open decision, pending recovery episode, or failure, so that empty close does not complete Grok's background task.
 8. Waiting is silent.
 9. Never use shell `&` for firstmate supervision.
 10. Never bundle the arm onto another command.
     A shell `&`, a truncating pipe, or bundling is denied automatically by the PreToolUse seatbelt (`bin/fm-arm-pretool-check.sh`) whenever this project's Grok hooks are trusted.
 
-Grok injects a synthetic user message with `synthetic_reason: task_completed` when the background arm completes.
+Grok injects a synthetic user message with `synthetic_reason: task_completed` only when the persistent background owner completes for actionable state or failure.
 When you see a background-task-completed system reminder for the arm:
 1. Run `bin/fm-wake-drain.sh` first.
 2. Optionally fetch arm output with `get_command_or_subagent_output(<task_id>)` for the reason line.
 3. Handle `signal`, `stale`, `check`, or `heartbeat` using the harness-neutral contract in `AGENTS.md`.
-4. Ordinary wake: re-arm the next cycle with the same background `bin/fm-watch-arm.sh` call if work remains in flight or Relay still needs polling.
+4. Ordinary wake: start the next persistent background `bin/fm-watch-arm-grok.sh` owner if work remains in flight or Relay still needs polling.
 5. Do not invent a wake from an attach-status line alone.
    Drain the queue and act only on real wake records, the drain's `OPEN DECISIONS` entries, or a real watcher reason line.
-   Re-arm attaches to an existing healthy cycle when one is already present and follows its verified successor chain.
+   Its child arm attaches to an existing healthy cycle when one is already present and follows its verified successor chain.
    See [`watcher-continuity.md`](../watcher-continuity.md) for the arm-layer successor and clean-close failure contract.
 
 The primary project Stop hook runs `bin/fm-turnend-guard-grok.sh` as a backstop, not the normal wake path.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -345,6 +345,25 @@ grok 0.2.103 (89c3d36fb6f1) [stable]
 | Pi | `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` | One initial tool call led to extension-owned successors and clean child retirement on exit. |
 | Grok | `FM_GROK_LIVE_E2E=1 tests/fm-grok-continuity-live-e2e.test.sh` | Native task completion surfaced the actionable close and the cycle ledger recorded `reason=actionable-signal`. |
 
+Grok's persistent empty-close owner was verified deterministically on 2026-08-12 without starting a live harness or spending a model turn.
+The focused suite proved that an empty child close stays inside one tracked task, while a durable queue row, open decision, pending recovery episode, malformed recovery state, arm failure, or owner termination preserves its actionable or cleanup behavior.
+It also proved that away-mode transfer, ended supervision need, and a changed session-lock owner remain dormant without launching another child or completing an empty Grok task.
+The same pass covered the five-harness PreToolUse matrix, rendered Grok protocol, empty-queue OPEN DECISIONS path, and Grok turn-end guard.
+
+```sh
+bin/fm-lint.sh
+bin/fm-doc-audience-check.sh
+bin/fm-test-run.sh tests/fm-grok-watch-arm.test.sh tests/fm-arm-pretool-check.test.sh tests/fm-supervision-instructions.test.sh tests/fm-wake-drain-open-decisions.test.sh tests/fm-turnend-guard.test.sh
+```
+
+Observed output:
+
+```text
+fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
+fm-doc-audience-check: ok surfaces=67 local_links=240
+FM_TEST_SUMMARY total=5 failed=0 skipped_gate=0 duration_ms=160496
+```
+
 Pi 0.81.1 repeated the continuity and clean-exit lifecycle on 2026-07-23 after the Calm presentation changes.
 
 Pi same-process session-transition ownership was verified on 2026-07-27 against the tracked extension with a faithful in-process factory rebind (module cache retained, real arm children):

--- a/docs/watcher-continuity.md
+++ b/docs/watcher-continuity.md
@@ -9,6 +9,10 @@ Pi's `.pi/extensions/fm-primary-pi-watch.ts` and OpenCode's `.opencode/plugins/f
 Each adapter starts the next arm before delivering the wake prompt, checks current session-lock ownership at launch, preserves one child or scheduled retry at a time, and applies bounded exponential retry after an unexpected or failed close.
 A failed follow-up never cancels continuity restoration.
 Pi same-process session replacement follows the generation-owner contract in `.pi/extensions/fm-primary-pi-watch.ts`.
+Grok's tracked `bin/fm-watch-arm-grok.sh` process owns empty-close suppression before Grok can emit a billable task-completed message.
+It returns only when a child arm fails or read-side classification finds a durable queue row, an open decision, or a pending recovery episode; an empty close stays inside that same tracked process and launches another child only while supervision remains necessary.
+It never drains or acknowledges durable work, and any unavailable queue lock or malformed recovery state fails loudly rather than suppressing a possible wake.
+Before each child arm it rechecks that the same live harness process still owns the session lock and that away mode remains inactive; loss of ownership, away-mode transfer, or ended supervision need leaves the tracked task dormant without completing an empty Grok task.
 Claude's `.claude/settings.json` Stop `asyncRewake` hook (`bin/fm-claude-stop-autoarm.sh`) owns routine tokenless re-arm.
 The hook fires on every Stop, and an eligible primary with supervision need admits one home-scoped owner that foregrounds `bin/fm-watch-arm.sh` inside the hook-owned process tree.
 A numeric session-lock owner that fails the shared `fm_harness_pid_alive` predicate is reclaimed through `bin/fm-lock.sh` before auto-arm state changes, while a live owner, absent lock, or malformed lock keeps the competing hook inert.
@@ -37,7 +41,7 @@ No PreToolUse hook denies fleet commands based on watcher status.
 A genuine auto-arm failure describes the automatic mechanism as broken and never directs a routine manual background arm.
 Terminal arm-output classification (`started`, `attached`, or `FAILED`) remains defense in depth for the manual recovery path.
 Codex retains its bounded foreground checkpoint protocol.
-Grok retains its tracked background-task notification protocol.
+Grok retains tracked background-task notification for actionable state and failure, with empty arm closes absorbed inside `bin/fm-watch-arm-grok.sh` before the task completes.
 No adapter starts a replacement with shell `&`.
 
 The turn-end guard remains the final backstop rather than the normal continuity mechanism and cooperates with the auto-arm in its `--claude` mode.
@@ -77,6 +81,7 @@ Only the watcher process touches `state/.last-watcher-beat`; no helper process c
 `tests/fm-pi-watch-extension.test.sh` checks Pi's first-cycle-or-explicit-repair tool metadata and ownership-based redundant-call no-ops, then simulates actionable and empty child closes against the actual Pi and OpenCode close handlers, blocks prompt delivery to prove the successor launches first, verifies single-flight behavior, changes the session lock before close to prove ownership is rechecked, and hangs each successor arm to prove bounded fallback delivery includes the typed restoration failure.
 The same suite covers ordinary same-process session replacement for `/new`, `/resume`, and `/fork`, same-instance shutdown-plus-start, stale prior-generation callbacks, repeated transitions with exactly one live cycle, disappearance of the shutting-down refusal after a valid replacement activates, and terminal quit still refusing late rearm.
 `tests/fm-watch-arm.test.sh` covers durable queue replay, real remote parent-replies ingestion into the authoritative status log, decision-only OPEN DECISIONS recovery, interrupted handling replay, generation-bound acknowledgement, a persistent live successor after recovery, a watcher close inside the handling window that must leave the printed acknowledgement valid, and the self-healing moved-generation acknowledgement that consumes its handled rows and names its remedy.
+`tests/fm-grok-watch-arm.test.sh` proves an empty close re-arms without completing Grok's tracked task, while a queue row, open decision, pending recovery episode, classification failure, or arm failure remains actionable; it also pins away-mode transfer, changed session ownership, ended supervision need, and owner-signal cleanup.
 `tests/fm-watcher-lock.test.sh` covers verified-successor attach, recovery publication before stale-lock removal, the typed self-eviction failure, bounded and successor-linked lifecycle rows, and a SIGSTOP counterfactual that distinguishes a live PID from a stale beacon before classifying termination.
 `tests/fm-subagent-pretool-check.test.sh` proves Claude retains only the non-status Bash seatbelts.
 `tests/fm-claude-stop-autoarm.test.sh` covers the auto-arm's scope, stale and live session owners, unchanged AFK and need boundaries, single-flight, bounded failure retries, benign live-watcher cycle ends, one-notice failure episodes, and exit-2 translation.
@@ -88,6 +93,6 @@ The same suite covers ordinary same-process session replacement for `/new`, `/re
 The goal is continuity without a Pi or OpenCode model-memory re-arm step.
 No zero-latency guarantee is claimed because lock verification, watcher startup, and bounded retry delays remain deliberate safety work.
 OpenCode support targets persistent TUI sessions rather than headless `opencode run`.
-Claude depends on the Stop `asyncRewake` rewake, Grok retains native background-completion notifications, and Codex retains bounded foreground checkpoints.
+Claude depends on the Stop `asyncRewake` rewake, Grok retains native background-completion notifications only after its persistent owner finds actionable state or failure, and Codex retains bounded foreground checkpoints.
 
 [`verification/supervision.md`](verification/supervision.md#watcher-continuity) records the current five-harness live evidence, the 2026-07-24 Stop-owned Claude auto-arm results, and exact opt-in commands.

--- a/tests/fm-arm-pretool-check.test.sh
+++ b/tests/fm-arm-pretool-check.test.sh
@@ -27,6 +27,7 @@ matrix_case() {
 }
 
 matrix_case A01 allow 'bin/fm-watch-arm.sh'
+matrix_case A01G allow 'bin/fm-watch-arm-grok.sh'
 matrix_case A02 allow './bin/fm-watch-arm.sh --restart'
 matrix_case A03 allow 'exec bin/fm-watch-arm.sh'
 matrix_case A04 allow 'bin/fm-watch-checkpoint.sh --seconds 180'
@@ -65,6 +66,7 @@ matrix_case R18 allow "sh -c 'tmux send-keys -t lab \"bin/fm-watch-arm.sh &\" En
 matrix_case R19 allow "eval 'printf \"%s\\n\" \"bin/fm-watch-arm.sh &\"'"
 
 matrix_case D01 deny 'bin/fm-watch-arm.sh &'
+matrix_case D01G deny 'bin/fm-watch-arm-grok.sh &'
 matrix_case D02 deny 'nohup bin/fm-watch-arm.sh'
 matrix_case D03 deny 'bin/fm-watch-arm.sh & disown'
 matrix_case D04 deny '(bin/fm-watch-arm.sh) &'

--- a/tests/fm-grok-continuity-live-e2e.test.sh
+++ b/tests/fm-grok-continuity-live-e2e.test.sh
@@ -69,6 +69,7 @@ trap cleanup EXIT
 mkdir -p "$LAB"
 git clone -q "$ROOT" "$PROJECT"
 cp "$ROOT/bin/fm-watch-arm.sh" "$PROJECT/bin/fm-watch-arm.sh"
+cp "$ROOT/bin/fm-watch-arm-grok.sh" "$PROJECT/bin/fm-watch-arm-grok.sh"
 mkdir -p "$HOME_DIR/state" "$HOME_DIR/config"
 printf 'project=fixture\n' > "$HOME_DIR/state/grok-e2e.meta"
 
@@ -78,7 +79,7 @@ printf 'project=fixture\n' > "$HOME_DIR/state/grok-e2e.meta"
 wait_for_text "Grok Build" 180 || fail "Grok did not reach its ready composer"
 sleep 1
 # shellcheck disable=SC2016 # Backticks are literal prompt markup.
-PROMPT='Use run_terminal_command with background=true to run exactly `bin/fm-watch-arm.sh`. Never use a shell ampersand. Once it reports started, respond briefly.'
+PROMPT='Use run_terminal_command with background=true to run exactly `bin/fm-watch-arm-grok.sh`. Never use a shell ampersand. Once it reports started, respond briefly.'
 "$TMUX" -L "$SOCKET" send-keys -t "$SESSION" -l "$PROMPT"
 "$TMUX" -L "$SOCKET" send-keys -t "$SESSION" Enter
 
@@ -105,7 +106,7 @@ grep -Eq 'reason=actionable-signal' "$HOME_DIR/state/.watch-cycle-exits.log" 2>/
   || fail "Grok action cycle was not classified in the lifecycle ledger"
 wait_for_text "Task completed in" 120 || fail "Grok did not surface its native background-task completion notification"
 pane=$(capture)
-if printf '%s\n' "$pane" | grep -Fq 'bin/fm-watch-arm.sh &'; then
+if printf '%s\n' "$pane" | grep -Fq 'bin/fm-watch-arm-grok.sh &'; then
   fail "Grok used a shell ampersand instead of its tracked background task"
 fi
 

--- a/tests/fm-grok-watch-arm.test.sh
+++ b/tests/fm-grok-watch-arm.test.sh
@@ -267,6 +267,61 @@ SH
   pass "a Grok task whose session lost the fleet lock stays dormant and does not re-arm"
 }
 
+test_actionable_close_after_away_transfer_stays_dormant() {
+  local home arm out pid count
+  home=$(make_home actionable-away-transfer)
+  arm="$home/fake-arm.sh"
+  out="$home/owner.out"
+  cat > "$arm" <<'SH'
+#!/usr/bin/env bash
+printf '1\t1\tsignal\ttask\tsignal: away-owned action\n' > "$FM_HOME/state/.wake-queue"
+: > "$FM_HOME/state/.afk"
+printf 'signal: away-owned action\n'
+SH
+  chmod +x "$arm"
+
+  FM_HOME="$home" FM_GROK_WATCH_ARM_SCRIPT="$arm" FM_GROK_WATCH_IDLE_POLL=0.05 "$OWNER" > "$out" 2>&1 &
+  pid=$!
+  wait_for_file "$home/state/.afk" || fail "actionable away-transfer arm did not finish"
+  sleep 0.2
+  kill -0 "$pid" 2>/dev/null || fail "actionable close completed after away mode took supervision"
+  [ -s "$home/state/.wake-queue" ] || fail "old Grok owner consumed away mode's durable wake"
+  kill -TERM "$pid"
+  wait "$pid" 2>/dev/null || true
+  pass "an actionable close stays dormant when away mode takes supervision"
+}
+
+test_actionable_close_after_session_transfer_stays_dormant() {
+  local home arm out pid replacement
+  home=$(make_home actionable-session-transfer)
+  arm="$home/fake-arm.sh"
+  out="$home/owner.out"
+  replacement=$$
+  cat > "$arm" <<'SH'
+#!/usr/bin/env bash
+printf '1\t1\tsignal\ttask\tsignal: successor-owned action\n' > "$FM_HOME/state/.wake-queue"
+printf '%s\n' "$REPLACEMENT_OWNER" > "$FM_HOME/state/.lock"
+printf 'signal: successor-owned action\n'
+SH
+  chmod +x "$arm"
+
+  FM_HOME="$home" REPLACEMENT_OWNER="$replacement" FM_GROK_WATCH_ARM_SCRIPT="$arm" FM_GROK_WATCH_IDLE_POLL=0.05 "$OWNER" > "$out" 2>&1 &
+  pid=$!
+  i=0
+  while [ "$i" -lt 100 ]; do
+    [ "$(cat "$home/state/.lock" 2>/dev/null || true)" = "$replacement" ] && break
+    sleep 0.05
+    i=$((i + 1))
+  done
+  [ "$(cat "$home/state/.lock")" = "$replacement" ] || fail "actionable session-transfer arm did not change ownership"
+  sleep 0.2
+  kill -0 "$pid" 2>/dev/null || fail "actionable close completed after the session lock transferred"
+  [ -s "$home/state/.wake-queue" ] || fail "old Grok owner consumed the successor's durable wake"
+  kill -TERM "$pid"
+  wait "$pid" 2>/dev/null || true
+  pass "an actionable close stays dormant after session-lock ownership transfers"
+}
+
 test_owner_signal_retires_arm_child() {
   local home arm out pid child status
   home=$(make_home signal-cleanup)
@@ -300,4 +355,6 @@ test_malformed_recovery_fails_closed
 test_no_supervision_need_stays_dormant_until_work_returns
 test_away_mode_stays_dormant_until_normal_supervision_returns
 test_changed_session_owner_stays_dormant
+test_actionable_close_after_away_transfer_stays_dormant
+test_actionable_close_after_session_transfer_stays_dormant
 test_owner_signal_retires_arm_child

--- a/tests/fm-grok-watch-arm.test.sh
+++ b/tests/fm-grok-watch-arm.test.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+# Regression for Grok's persistent tracked background watcher owner.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+OWNER="$ROOT/bin/fm-watch-arm-grok.sh"
+TMP_ROOT=$(fm_test_tmproot fm-grok-watch-arm)
+ln -s /bin/sleep "$TMP_ROOT/grok"
+"$TMP_ROOT/grok" 300 &
+SESSION_OWNER=$!
+
+cleanup_grok_owner() {
+  kill -TERM "$SESSION_OWNER" 2>/dev/null || true
+  wait "$SESSION_OWNER" 2>/dev/null || true
+  fm_test_cleanup
+}
+
+trap cleanup_grok_owner EXIT
+trap 'cleanup_grok_owner; exit 130' INT
+trap 'cleanup_grok_owner; exit 143' TERM
+
+wait_for_file() {
+  local file=$1 attempts=${2:-100} i=0
+  while [ "$i" -lt "$attempts" ]; do
+    [ -e "$file" ] && return 0
+    sleep 0.05
+    i=$((i + 1))
+  done
+  return 1
+}
+
+wait_for_exit() {
+  local pid=$1 attempts=${2:-100} i=0
+  while [ "$i" -lt "$attempts" ]; do
+    kill -0 "$pid" 2>/dev/null || return 0
+    sleep 0.05
+    i=$((i + 1))
+  done
+  return 1
+}
+
+make_home() {
+  local name=$1 home
+  home="$TMP_ROOT/$name"
+  mkdir -p "$home/state" "$home/config"
+  : > "$home/state/task.meta"
+  printf '%s\n' "$SESSION_OWNER" > "$home/state/.lock"
+  printf '%s\n' "$home"
+}
+
+test_empty_close_rearms_without_completing_grok_task() {
+  local home arm out pid count
+  home=$(make_home empty-close)
+  arm="$home/fake-arm.sh"
+  out="$home/owner.out"
+  cat > "$arm" <<'SH'
+#!/usr/bin/env bash
+set -u
+count_file="$FM_HOME/state/arm-count"
+count=$(( $(cat "$count_file" 2>/dev/null || echo 0) + 1 ))
+printf '%s\n' "$count" > "$count_file"
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+if [ "$count" -eq 1 ]; then
+  printf 'signal: already handled before Grok could be notified\n'
+  exit 0
+fi
+while [ ! -e "$FM_HOME/state/release-actionable" ]; do sleep 0.05; done
+printf '1\t1\tsignal\ttask\tsignal: actionable\n' > "$FM_HOME/state/.wake-queue"
+printf 'signal: actionable\n'
+SH
+  chmod +x "$arm"
+
+  FM_HOME="$home" FM_GROK_WATCH_ARM_SCRIPT="$arm" FM_GROK_WATCH_IDLE_POLL=0.05 "$OWNER" > "$out" 2>&1 &
+  pid=$!
+  wait_for_file "$home/state/arm-count" || fail "Grok owner never launched its first arm"
+  i=0
+  while [ "$i" -lt 100 ]; do
+    count=$(cat "$home/state/arm-count" 2>/dev/null || echo 0)
+    [ "$count" -ge 2 ] && break
+    sleep 0.05
+    i=$((i + 1))
+  done
+  [ "${count:-0}" -ge 2 ] || fail "empty arm close did not re-arm inside the same tracked command"
+  kill -0 "$pid" 2>/dev/null || fail "empty arm close completed Grok's tracked command and would bill a model turn"
+
+  : > "$home/state/release-actionable"
+  wait_for_exit "$pid" || fail "durable actionable wake did not complete Grok's tracked command"
+  wait "$pid" || fail "Grok owner failed after a durable actionable wake"
+  assert_contains "$(cat "$out")" "signal: actionable" "actionable reason was not preserved"
+  pass "empty close re-arms internally while a durable actionable wake completes the tracked Grok task"
+}
+
+test_failure_completes_loudly() {
+  local home arm out status
+  home=$(make_home failure)
+  arm="$home/fake-arm.sh"
+  out="$home/owner.out"
+  cat > "$arm" <<'SH'
+#!/usr/bin/env bash
+printf 'watcher: FAILED - fixture arm failure\n'
+exit 7
+SH
+  chmod +x "$arm"
+
+  FM_HOME="$home" FM_GROK_WATCH_ARM_SCRIPT="$arm" "$OWNER" > "$out" 2>&1
+  status=$?
+  expect_code 7 "$status" "arm failure must propagate through Grok's tracked task"
+  assert_contains "$(cat "$out")" "watcher: FAILED - fixture arm failure" "arm failure text was suppressed"
+  pass "arm failure completes the Grok task loudly"
+}
+
+test_open_decision_completes_without_queue_row() {
+  local home arm out
+  home=$(make_home open-decision)
+  arm="$home/fake-arm.sh"
+  out="$home/owner.out"
+  cat > "$arm" <<'SH'
+#!/usr/bin/env bash
+printf 'needs-decision: choose the safe path [key=path]\n' >> "$FM_HOME/state/task.status"
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+exit 0
+SH
+  chmod +x "$arm"
+
+  FM_HOME="$home" FM_GROK_WATCH_ARM_SCRIPT="$arm" "$OWNER" > "$out" 2>&1 \
+    || fail "open decision did not complete Grok's tracked task"
+  pass "an OPEN DECISIONS entry completes the Grok task even without a queue row"
+}
+
+test_pending_recovery_completes_without_queue_row() {
+  local home arm out
+  home=$(make_home pending-recovery)
+  arm="$home/fake-arm.sh"
+  out="$home/owner.out"
+  printf 'pending:downtime:fixture-generation\n' > "$home/state/.watcher-down"
+  cat > "$arm" <<'SH'
+#!/usr/bin/env bash
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+exit 0
+SH
+  chmod +x "$arm"
+
+  FM_HOME="$home" FM_GROK_WATCH_ARM_SCRIPT="$arm" "$OWNER" > "$out" 2>&1 \
+    || fail "pending recovery episode did not complete Grok's tracked task"
+  pass "a pending recovery episode completes the Grok task even without a queue row"
+}
+
+test_malformed_recovery_fails_closed() {
+  local home arm out status
+  home=$(make_home malformed-recovery)
+  arm="$home/fake-arm.sh"
+  out="$home/owner.out"
+  printf 'not-a-valid-recovery-marker\n' > "$home/state/.watcher-down"
+  cat > "$arm" <<'SH'
+#!/usr/bin/env bash
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+exit 0
+SH
+  chmod +x "$arm"
+
+  FM_HOME="$home" FM_GROK_WATCH_ARM_SCRIPT="$arm" "$OWNER" > "$out" 2>&1
+  status=$?
+  expect_code 1 "$status" "malformed recovery state must fail closed"
+  assert_contains "$(cat "$out")" "watcher: FAILED - Grok continuity could not classify" "classification failure was not surfaced"
+  pass "malformed recovery state completes the Grok task with a loud failure"
+}
+
+test_no_supervision_need_stays_dormant_until_work_returns() {
+  local home arm out pid count
+  home=$(make_home dormant)
+  arm="$home/fake-arm.sh"
+  out="$home/owner.out"
+  cat > "$arm" <<'SH'
+#!/usr/bin/env bash
+set -u
+count_file="$FM_HOME/state/arm-count"
+count=$(( $(cat "$count_file" 2>/dev/null || echo 0) + 1 ))
+printf '%s\n' "$count" > "$count_file"
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+if [ "$count" -eq 1 ]; then
+  rm -f "$FM_HOME/state/task.meta"
+  exit 0
+fi
+printf '1\t1\tcheck\ttask\tcheck: resumed\n' > "$FM_HOME/state/.wake-queue"
+printf 'check: resumed\n'
+SH
+  chmod +x "$arm"
+
+  FM_HOME="$home" FM_GROK_WATCH_ARM_SCRIPT="$arm" FM_GROK_WATCH_IDLE_POLL=0.05 "$OWNER" > "$out" 2>&1 &
+  pid=$!
+  wait_for_file "$home/state/arm-count" || fail "dormant case never launched its first arm"
+  sleep 0.2
+  count=$(cat "$home/state/arm-count")
+  [ "$count" -eq 1 ] || fail "owner kept arming after supervision need ended"
+  kill -0 "$pid" 2>/dev/null || fail "no-need close completed Grok's task and would bill an empty turn"
+
+  : > "$home/state/task.meta"
+  wait_for_exit "$pid" || fail "owner did not resume after supervision need returned"
+  wait "$pid" || fail "resumed actionable wake failed"
+  [ "$(cat "$home/state/arm-count")" -eq 2 ] || fail "owner did not launch exactly one resumed arm"
+  pass "an empty close with no supervision need stays dormant until work returns"
+}
+
+test_away_mode_stays_dormant_until_normal_supervision_returns() {
+  local home arm out pid count
+  home=$(make_home away-mode)
+  arm="$home/fake-arm.sh"
+  out="$home/owner.out"
+  cat > "$arm" <<'SH'
+#!/usr/bin/env bash
+set -u
+count_file="$FM_HOME/state/arm-count"
+count=$(( $(cat "$count_file" 2>/dev/null || echo 0) + 1 ))
+printf '%s\n' "$count" > "$count_file"
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+if [ "$count" -eq 1 ]; then
+  : > "$FM_HOME/state/.afk"
+  exit 0
+fi
+printf '1\t1\tcheck\ttask\tcheck: normal supervision resumed\n' > "$FM_HOME/state/.wake-queue"
+printf 'check: normal supervision resumed\n'
+SH
+  chmod +x "$arm"
+
+  FM_HOME="$home" FM_GROK_WATCH_ARM_SCRIPT="$arm" FM_GROK_WATCH_IDLE_POLL=0.05 "$OWNER" > "$out" 2>&1 &
+  pid=$!
+  wait_for_file "$home/state/.afk" || fail "away-mode case never completed its first empty arm"
+  sleep 0.2
+  count=$(cat "$home/state/arm-count")
+  [ "$count" -eq 1 ] || fail "persistent Grok owner competed with away-mode supervision"
+  kill -0 "$pid" 2>/dev/null || fail "away-mode handoff completed Grok's task and would bill an empty turn"
+
+  rm -f "$home/state/.afk"
+  wait_for_exit "$pid" || fail "Grok owner did not resume after away mode ended"
+  wait "$pid" || fail "post-away actionable wake failed"
+  [ "$(cat "$home/state/arm-count")" -eq 2 ] || fail "Grok owner did not launch exactly one post-away arm"
+  pass "away mode keeps the Grok owner dormant until normal supervision returns"
+}
+
+test_changed_session_owner_stays_dormant() {
+  local home arm out pid count
+  home=$(make_home session-owner-change)
+  arm="$home/fake-arm.sh"
+  out="$home/owner.out"
+  cat > "$arm" <<'SH'
+#!/usr/bin/env bash
+count_file="$FM_HOME/state/arm-count"
+count=$(( $(cat "$count_file" 2>/dev/null || echo 0) + 1 ))
+printf '%s\n' "$count" > "$count_file"
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+exit 0
+SH
+  chmod +x "$arm"
+
+  FM_HOME="$home" FM_GROK_WATCH_ARM_SCRIPT="$arm" FM_GROK_WATCH_IDLE_POLL=0.05 "$OWNER" > "$out" 2>&1 &
+  pid=$!
+  wait_for_file "$home/state/arm-count" || fail "session-owner case never launched its first arm"
+  printf '%s\n' "$$" > "$home/state/.lock"
+  sleep 0.2
+  count=$(cat "$home/state/arm-count")
+  [ "$count" -eq 1 ] || fail "old Grok owner re-armed after the fleet lock changed sessions"
+  kill -0 "$pid" 2>/dev/null || fail "lost session ownership completed Grok's task and would bill an empty turn"
+  kill -TERM "$pid"
+  wait "$pid" 2>/dev/null || true
+  pass "a Grok task whose session lost the fleet lock stays dormant and does not re-arm"
+}
+
+test_owner_signal_retires_arm_child() {
+  local home arm out pid child status
+  home=$(make_home signal-cleanup)
+  arm="$home/fake-arm.sh"
+  out="$home/owner.out"
+  cat > "$arm" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$$" > "$FM_HOME/state/child-pid"
+trap 'exit 143' TERM
+while :; do sleep 0.1; done
+SH
+  chmod +x "$arm"
+
+  FM_HOME="$home" FM_GROK_WATCH_ARM_SCRIPT="$arm" "$OWNER" > "$out" 2>&1 &
+  pid=$!
+  wait_for_file "$home/state/child-pid" || fail "signal cleanup case never launched its arm child"
+  child=$(cat "$home/state/child-pid")
+  kill -TERM "$pid"
+  wait "$pid"
+  status=$?
+  expect_code 143 "$status" "Grok owner must preserve its termination status"
+  kill -0 "$child" 2>/dev/null && fail "terminating the Grok owner left its arm child alive"
+  pass "terminating the tracked Grok owner retires its arm child"
+}
+
+test_empty_close_rearms_without_completing_grok_task
+test_failure_completes_loudly
+test_open_decision_completes_without_queue_row
+test_pending_recovery_completes_without_queue_row
+test_malformed_recovery_fails_closed
+test_no_supervision_need_stays_dormant_until_work_returns
+test_away_mode_stays_dormant_until_normal_supervision_returns
+test_changed_session_owner_stays_dormant
+test_owner_signal_retires_arm_child

--- a/tests/fm-grok-watch-arm.test.sh
+++ b/tests/fm-grok-watch-arm.test.sh
@@ -396,6 +396,61 @@ SH
   pass "session transfer during actionable classification keeps the old owner dormant"
 }
 
+test_away_transfer_during_failed_classification_stays_dormant() {
+  local home arm out pid
+  home=$(make_home failed-classification-away-transfer)
+  arm="$home/fake-arm.sh"
+  out="$home/owner.out"
+  cat > "$arm" <<'SH'
+#!/usr/bin/env bash
+: > "$FM_HOME/state/arm-closed"
+printf 'signal: classification will fail\n'
+SH
+  chmod +x "$arm"
+  hold_wake_queue_lock "$home"
+
+  FM_HOME="$home" FM_GROK_WATCH_ARM_SCRIPT="$arm" FM_GROK_WATCH_IDLE_POLL=0.05 "$OWNER" > "$out" 2>&1 &
+  pid=$!
+  wait_for_file "$home/state/arm-closed" || fail "failed-classification away arm did not close"
+  : > "$home/state/.afk"
+  sleep 1.2
+  kill -0 "$pid" 2>/dev/null || fail "classification failure completed after away mode took supervision"
+  : > "$home/state/release-classification"
+  wait "$CLASSIFICATION_LOCK_PID" || fail "wake queue lock holder failed"
+  kill -TERM "$pid"
+  wait "$pid" 2>/dev/null || true
+  assert_not_contains "$(cat "$out")" "watcher: FAILED - Grok continuity could not classify" "old owner surfaced classification failure after away transfer"
+  pass "away transfer during failed classification keeps the old owner dormant"
+}
+
+test_session_transfer_during_failed_classification_stays_dormant() {
+  local home arm out pid replacement
+  home=$(make_home failed-classification-session-transfer)
+  arm="$home/fake-arm.sh"
+  out="$home/owner.out"
+  replacement=$$
+  cat > "$arm" <<'SH'
+#!/usr/bin/env bash
+: > "$FM_HOME/state/arm-closed"
+printf 'signal: classification will fail\n'
+SH
+  chmod +x "$arm"
+  hold_wake_queue_lock "$home"
+
+  FM_HOME="$home" FM_GROK_WATCH_ARM_SCRIPT="$arm" FM_GROK_WATCH_IDLE_POLL=0.05 "$OWNER" > "$out" 2>&1 &
+  pid=$!
+  wait_for_file "$home/state/arm-closed" || fail "failed-classification session arm did not close"
+  printf '%s\n' "$replacement" > "$home/state/.lock"
+  sleep 1.2
+  kill -0 "$pid" 2>/dev/null || fail "classification failure completed after session ownership transferred"
+  : > "$home/state/release-classification"
+  wait "$CLASSIFICATION_LOCK_PID" || fail "wake queue lock holder failed"
+  kill -TERM "$pid"
+  wait "$pid" 2>/dev/null || true
+  assert_not_contains "$(cat "$out")" "watcher: FAILED - Grok continuity could not classify" "old owner surfaced classification failure after session transfer"
+  pass "session transfer during failed classification keeps the old owner dormant"
+}
+
 test_owner_signal_retires_arm_child() {
   local home arm out pid child status
   home=$(make_home signal-cleanup)
@@ -433,4 +488,6 @@ test_actionable_close_after_away_transfer_stays_dormant
 test_actionable_close_after_session_transfer_stays_dormant
 test_away_transfer_during_actionable_classification_stays_dormant
 test_session_transfer_during_actionable_classification_stays_dormant
+test_away_transfer_during_failed_classification_stays_dormant
+test_session_transfer_during_failed_classification_stays_dormant
 test_owner_signal_retires_arm_child

--- a/tests/fm-grok-watch-arm.test.sh
+++ b/tests/fm-grok-watch-arm.test.sh
@@ -200,7 +200,7 @@ test_term_resistant_overflow_is_forced_bounded() {
   out="$home/owner.out"
   cat > "$arm" <<'SH'
 #!/usr/bin/env bash
-trap '' TERM
+trap '' TERM PIPE
 (trap '' TERM; while :; do sleep 1; done) &
 printf '%s\n' "$!" > "$FM_HOME/state/overflow-descendant-pid"
 printf '%s\n' "$$" > "$FM_HOME/state/overflow-child-pid"
@@ -252,6 +252,36 @@ SH
   kill -TERM "$unrelated" 2>/dev/null || true
   wait "$unrelated" 2>/dev/null || true
   pass "retirement skips changed identities and preserves unrelated processes"
+}
+
+test_retirement_reparented_identity_is_not_forced() {
+  local home arm out status escaped identity fake_seed failure
+  home=$(make_home retirement-reparented-identity)
+  arm="$home/fake-arm.sh"
+  out="$home/owner.out"
+  bash -c 'trap "" TERM; while :; do sleep 1; done' &
+  escaped=$!
+  identity=$(FM_HOME="$home" bash -c '. "$1"; fm_pid_identity "$2"' _ "$ROOT/bin/fm-wake-lib.sh" "$escaped") \
+    || fail "could not identify reparented retirement counterfactual"
+  fake_seed="$home/state/fake-overflow-identities"
+  printf '%s\t%s\n' "$escaped" "$identity" > "$fake_seed"
+  cat > "$arm" <<'SH'
+#!/usr/bin/env bash
+trap '' TERM
+while :; do printf '0123456789abcdef0123456789abcdef'; done
+SH
+  chmod +x "$arm"
+
+  FM_HOME="$home" FM_GROK_WATCH_ARM_SCRIPT="$arm" FM_GROK_WATCH_OUTPUT_MAX_BYTES=128 \
+    FM_GROK_WATCH_CHILD_TERM_GRACE=0.2 FM_GROK_WATCH_RETIRE_TEST_SEED="$fake_seed" "$OWNER" > "$out" 2>&1
+  status=$?
+  expect_code 1 "$status" "reparented identity retirement must fail through the typed boundary"
+  kill -0 "$escaped" 2>/dev/null || fail "unchanged reparented identity was forcibly signaled"
+  failure='exact child retirement was incomplete'
+  assert_contains "$(cat "$out")" "$failure" "reparented identity did not surface incomplete retirement"
+  kill -KILL "$escaped" 2>/dev/null || true
+  wait "$escaped" 2>/dev/null || true
+  pass "retirement skips unchanged identities outside the current tree"
 }
 
 test_transferred_no_newline_overflow_queues_once() {
@@ -755,6 +785,7 @@ test_transferred_output_overflow_queues_once
 test_no_newline_output_overflow_is_bounded
 test_term_resistant_overflow_is_forced_bounded
 test_retirement_identity_mismatch_preserves_unrelated_process
+test_retirement_reparented_identity_is_not_forced
 test_transferred_no_newline_overflow_queues_once
 test_open_decision_completes_without_queue_row
 test_pending_recovery_completes_without_queue_row

--- a/tests/fm-grok-watch-arm.test.sh
+++ b/tests/fm-grok-watch-arm.test.sh
@@ -412,9 +412,15 @@ SH
   FM_HOME="$home" FM_GROK_WATCH_ARM_SCRIPT="$arm" FM_GROK_WATCH_IDLE_POLL=0.05 "$OWNER" > "$out" 2>&1 &
   pid=$!
   wait_for_file "$home/state/arm-closed" || fail "failed-classification away arm did not close"
+  sleep 0.1
   : > "$home/state/.afk"
   sleep 1.2
   kill -0 "$pid" 2>/dev/null || fail "classification failure completed after away mode took supervision"
+  wait_for_file "$home/state/.watcher-down" || fail "classification failure was not published for away supervision"
+  recovery=$(cat "$home/state/.watcher-down")
+  case "$recovery" in pending:downtime:*) ;; *) fail "away classification failure published invalid recovery state: $recovery" ;; esac
+  sleep 0.2
+  [ "$(cat "$home/state/.watcher-down")" = "$recovery" ] || fail "away classification failure was published more than once"
   : > "$home/state/release-classification"
   wait "$CLASSIFICATION_LOCK_PID" || fail "wake queue lock holder failed"
   kill -TERM "$pid"
@@ -440,9 +446,15 @@ SH
   FM_HOME="$home" FM_GROK_WATCH_ARM_SCRIPT="$arm" FM_GROK_WATCH_IDLE_POLL=0.05 "$OWNER" > "$out" 2>&1 &
   pid=$!
   wait_for_file "$home/state/arm-closed" || fail "failed-classification session arm did not close"
+  sleep 0.1
   printf '%s\n' "$replacement" > "$home/state/.lock"
   sleep 1.2
   kill -0 "$pid" 2>/dev/null || fail "classification failure completed after session ownership transferred"
+  wait_for_file "$home/state/.watcher-down" || fail "classification failure was not published for successor supervision"
+  recovery=$(cat "$home/state/.watcher-down")
+  case "$recovery" in pending:downtime:*) ;; *) fail "session classification failure published invalid recovery state: $recovery" ;; esac
+  sleep 0.2
+  [ "$(cat "$home/state/.watcher-down")" = "$recovery" ] || fail "session classification failure was published more than once"
   : > "$home/state/release-classification"
   wait "$CLASSIFICATION_LOCK_PID" || fail "wake queue lock holder failed"
   kill -TERM "$pid"
@@ -488,6 +500,11 @@ SH
   : > "$home/state/release-failure-classification"
   sleep 0.2
   kill -0 "$pid" 2>/dev/null || fail "arm failure completed after away mode took supervision"
+  wait_for_file "$home/state/.watcher-down" || fail "arm failure was not published for away supervision"
+  recovery=$(cat "$home/state/.watcher-down")
+  case "$recovery" in pending:downtime:*) ;; *) fail "away arm failure published invalid recovery state: $recovery" ;; esac
+  sleep 0.2
+  [ "$(cat "$home/state/.watcher-down")" = "$recovery" ] || fail "away arm failure was published more than once"
   kill -TERM "$pid"
   wait "$pid" 2>/dev/null || true
   pass "away transfer during arm failure classification keeps the old owner dormant"
@@ -514,6 +531,11 @@ SH
   : > "$home/state/release-failure-classification"
   sleep 0.2
   kill -0 "$pid" 2>/dev/null || fail "arm failure completed after session ownership transferred"
+  wait_for_file "$home/state/.watcher-down" || fail "arm failure was not published for successor supervision"
+  recovery=$(cat "$home/state/.watcher-down")
+  case "$recovery" in pending:downtime:*) ;; *) fail "session arm failure published invalid recovery state: $recovery" ;; esac
+  sleep 0.2
+  [ "$(cat "$home/state/.watcher-down")" = "$recovery" ] || fail "session arm failure was published more than once"
   kill -TERM "$pid"
   wait "$pid" 2>/dev/null || true
   pass "session transfer during arm failure classification keeps the old owner dormant"

--- a/tests/fm-grok-watch-arm.test.sh
+++ b/tests/fm-grok-watch-arm.test.sh
@@ -168,6 +168,65 @@ SH
   pass "transferred bounded overflow queues once without completing"
 }
 
+test_no_newline_output_overflow_is_bounded() {
+  local home arm out status child failure size
+  home=$(make_home no-newline-overflow)
+  arm="$home/fake-arm.sh"
+  out="$home/owner.out"
+  cat > "$arm" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$$" > "$FM_HOME/state/overflow-child-pid"
+trap 'exit 143' TERM
+while :; do printf '0123456789abcdef0123456789abcdef'; done
+SH
+  chmod +x "$arm"
+
+  FM_HOME="$home" FM_GROK_WATCH_ARM_SCRIPT="$arm" FM_GROK_WATCH_OUTPUT_MAX_BYTES=128 "$OWNER" > "$out" 2>&1
+  status=$?
+  expect_code 1 "$status" "no-newline overflow must fail the Grok tracked task"
+  child=$(cat "$home/state/overflow-child-pid")
+  kill -0 "$child" 2>/dev/null && fail "no-newline overflow left the arm child alive"
+  failure='watcher: FAILED - Grok continuity arm output exceeded 128 bytes'
+  [ "$(grep -cF "$failure" "$out")" -eq 1 ] || fail "no-newline overflow failure was not emitted exactly once"
+  size=$(wc -c < "$out" | tr -d '[:space:]')
+  [ "$size" -le 256 ] || fail "no-newline overflow produced unbounded owner output: $size bytes"
+  pass "no-newline output is bounded and retires the child"
+}
+
+test_transferred_no_newline_overflow_queues_once() {
+  local home arm out pid child failure size
+  home=$(make_home transferred-no-newline-overflow)
+  arm="$home/fake-arm.sh"
+  out="$home/owner.out"
+  cat > "$arm" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$$" > "$FM_HOME/state/overflow-child-pid"
+while [ ! -e "$FM_HOME/state/release-overflow" ]; do sleep 0.05; done
+trap 'exit 143' TERM
+while :; do printf '0123456789abcdef0123456789abcdef'; done
+SH
+  chmod +x "$arm"
+
+  FM_HOME="$home" FM_GROK_WATCH_ARM_SCRIPT="$arm" FM_GROK_WATCH_OUTPUT_MAX_BYTES=128 FM_GROK_WATCH_IDLE_POLL=0.05 "$OWNER" > "$out" 2>&1 &
+  pid=$!
+  wait_for_file "$home/state/overflow-child-pid" || fail "transferred no-newline child did not start"
+  : > "$home/state/.afk"
+  : > "$home/state/release-overflow"
+  wait_for_file "$home/state/.wake-queue" || fail "transferred no-newline failure was not queued"
+  sleep 0.2
+  kill -0 "$pid" 2>/dev/null || fail "transferred no-newline overflow completed the old task"
+  child=$(cat "$home/state/overflow-child-pid")
+  kill -0 "$child" 2>/dev/null && fail "transferred no-newline overflow left the child alive"
+  failure='watcher: FAILED - Grok continuity arm output exceeded 128 bytes'
+  [ "$(grep -cF "$failure" "$home/state/.wake-queue")" -eq 1 ] || fail "transferred no-newline failure was not queued exactly once"
+  assert_not_contains "$(cat "$out")" "$failure" "old owner emitted transferred no-newline failure"
+  size=$(wc -c < "$out" | tr -d '[:space:]')
+  [ "$size" -le 128 ] || fail "transferred no-newline overflow produced unbounded output: $size bytes"
+  kill -TERM "$pid"
+  wait "$pid" 2>/dev/null || true
+  pass "transferred no-newline overflow stays bounded and queues once"
+}
+
 test_open_decision_completes_without_queue_row() {
   local home arm out
   home=$(make_home open-decision)
@@ -632,6 +691,8 @@ test_empty_close_rearms_without_completing_grok_task
 test_failure_completes_loudly
 test_output_overflow_retires_child_and_fails_once
 test_transferred_output_overflow_queues_once
+test_no_newline_output_overflow_is_bounded
+test_transferred_no_newline_overflow_queues_once
 test_open_decision_completes_without_queue_row
 test_pending_recovery_completes_without_queue_row
 test_malformed_recovery_fails_closed

--- a/tests/fm-grok-watch-arm.test.sh
+++ b/tests/fm-grok-watch-arm.test.sh
@@ -108,6 +108,7 @@ SH
   status=$?
   expect_code 7 "$status" "arm failure must propagate through Grok's tracked task"
   assert_contains "$(cat "$out")" "watcher: FAILED - fixture arm failure" "arm failure text was suppressed"
+  [ "$(grep -cF 'watcher: FAILED - fixture arm failure' "$out")" -eq 1 ] || fail "same-owner arm failure was emitted more than once"
   pass "arm failure completes the Grok task loudly"
 }
 
@@ -508,6 +509,7 @@ SH
   assert_contains "$(cat "$home/state/.wake-queue")" "$failure" "away successor could not see the exact arm failure"
   sleep 0.2
   [ "$(grep -cF "$failure" "$home/state/.wake-queue")" -eq 1 ] || fail "away arm failure was queued more than once"
+  assert_not_contains "$(cat "$out")" "$failure" "old owner emitted arm failure after away transfer"
   kill -TERM "$pid"
   wait "$pid" 2>/dev/null || true
   pass "away transfer during arm failure classification keeps the old owner dormant"
@@ -539,6 +541,7 @@ SH
   assert_contains "$(cat "$home/state/.wake-queue")" "$failure" "session successor could not see the exact arm failure"
   sleep 0.2
   [ "$(grep -cF "$failure" "$home/state/.wake-queue")" -eq 1 ] || fail "session arm failure was queued more than once"
+  assert_not_contains "$(cat "$out")" "$failure" "old owner emitted arm failure after session transfer"
   kill -TERM "$pid"
   wait "$pid" 2>/dev/null || true
   pass "session transfer during arm failure classification keeps the old owner dormant"

--- a/tests/fm-grok-watch-arm.test.sh
+++ b/tests/fm-grok-watch-arm.test.sh
@@ -193,6 +193,37 @@ SH
   pass "no-newline output is bounded and retires the child"
 }
 
+test_term_resistant_overflow_is_forced_bounded() {
+  local home arm out status child descendant failure started elapsed
+  home=$(make_home term-resistant-overflow)
+  arm="$home/fake-arm.sh"
+  out="$home/owner.out"
+  cat > "$arm" <<'SH'
+#!/usr/bin/env bash
+trap '' TERM
+(trap '' TERM; while :; do sleep 1; done) &
+printf '%s\n' "$!" > "$FM_HOME/state/overflow-descendant-pid"
+printf '%s\n' "$$" > "$FM_HOME/state/overflow-child-pid"
+while :; do printf '0123456789abcdef0123456789abcdef'; done
+SH
+  chmod +x "$arm"
+
+  started=$(date +%s)
+  FM_HOME="$home" FM_GROK_WATCH_ARM_SCRIPT="$arm" FM_GROK_WATCH_OUTPUT_MAX_BYTES=128 FM_GROK_WATCH_CHILD_TERM_GRACE=0.2 "$OWNER" > "$out" 2>&1
+  status=$?
+  elapsed=$(( $(date +%s) - started ))
+  expect_code 1 "$status" "TERM-resistant overflow must fail the Grok tracked task"
+  [ "$elapsed" -le 5 ] || fail "TERM-resistant overflow retirement exceeded its bound"
+  child=$(cat "$home/state/overflow-child-pid")
+  descendant=$(cat "$home/state/overflow-descendant-pid")
+  kill -0 "$child" 2>/dev/null && fail "TERM-resistant overflow left the exact child alive"
+  descendant_state=$(ps -o stat= -p "$descendant" 2>/dev/null | tr -d ' ' || true)
+  case "$descendant_state" in ''|Z*) ;; *) fail "TERM-resistant overflow left its descendant alive ($descendant_state)" ;; esac
+  failure='watcher: FAILED - Grok continuity arm output exceeded 128 bytes'
+  [ "$(grep -cF "$failure" "$out")" -eq 1 ] || fail "TERM-resistant overflow failure was not emitted exactly once"
+  pass "TERM-resistant overflow forcibly retires its exact process tree"
+}
+
 test_transferred_no_newline_overflow_queues_once() {
   local home arm out pid child failure size
   home=$(make_home transferred-no-newline-overflow)
@@ -692,6 +723,7 @@ test_failure_completes_loudly
 test_output_overflow_retires_child_and_fails_once
 test_transferred_output_overflow_queues_once
 test_no_newline_output_overflow_is_bounded
+test_term_resistant_overflow_is_forced_bounded
 test_transferred_no_newline_overflow_queues_once
 test_open_decision_completes_without_queue_row
 test_pending_recovery_completes_without_queue_row

--- a/tests/fm-grok-watch-arm.test.sh
+++ b/tests/fm-grok-watch-arm.test.sh
@@ -350,7 +350,6 @@ printf 'signal: classified away action\n'
 SH
   chmod +x "$arm"
   hold_wake_queue_lock "$home"
-
   FM_HOME="$home" FM_GROK_WATCH_ARM_SCRIPT="$arm" FM_GROK_WATCH_IDLE_POLL=0.05 "$OWNER" > "$out" 2>&1 &
   pid=$!
   wait_for_file "$home/state/arm-closed" || fail "classification away-transfer arm did not close"
@@ -397,7 +396,7 @@ SH
 }
 
 test_away_transfer_during_failed_classification_stays_dormant() {
-  local home arm out pid
+  local home arm out pid failure rows
   home=$(make_home failed-classification-away-transfer)
   arm="$home/fake-arm.sh"
   out="$home/owner.out"
@@ -414,15 +413,16 @@ SH
   wait_for_file "$home/state/arm-closed" || fail "failed-classification away arm did not close"
   sleep 0.1
   : > "$home/state/.afk"
-  sleep 1.2
+  sleep 2
   kill -0 "$pid" 2>/dev/null || fail "classification failure completed after away mode took supervision"
-  wait_for_file "$home/state/.watcher-down" || fail "classification failure was not published for away supervision"
-  recovery=$(cat "$home/state/.watcher-down")
-  case "$recovery" in pending:downtime:*) ;; *) fail "away classification failure published invalid recovery state: $recovery" ;; esac
-  sleep 0.2
-  [ "$(cat "$home/state/.watcher-down")" = "$recovery" ] || fail "away classification failure was published more than once"
   : > "$home/state/release-classification"
   wait "$CLASSIFICATION_LOCK_PID" || fail "wake queue lock holder failed"
+  failure='watcher: FAILED - Grok continuity could not classify a completed arm: wake queue lock remained unavailable'
+  wait_for_file "$home/state/.wake-queue" || fail "classification failure was not queued for away supervision"
+  rows=$(cat "$home/state/.wake-queue")
+  assert_contains "$rows" "$failure" "away successor could not see the exact classification failure"
+  sleep 0.2
+  [ "$(grep -cF "$failure" "$home/state/.wake-queue")" -eq 1 ] || fail "away classification failure was queued more than once"
   kill -TERM "$pid"
   wait "$pid" 2>/dev/null || true
   assert_not_contains "$(cat "$out")" "watcher: FAILED - Grok continuity could not classify" "old owner surfaced classification failure after away transfer"
@@ -430,7 +430,7 @@ SH
 }
 
 test_session_transfer_during_failed_classification_stays_dormant() {
-  local home arm out pid replacement
+  local home arm out pid replacement failure rows
   home=$(make_home failed-classification-session-transfer)
   arm="$home/fake-arm.sh"
   out="$home/owner.out"
@@ -442,21 +442,24 @@ printf 'signal: classification will fail\n'
 SH
   chmod +x "$arm"
   hold_wake_queue_lock "$home"
+  printf 'pending:handling:existing-generation\n' > "$home/state/.watcher-down"
 
   FM_HOME="$home" FM_GROK_WATCH_ARM_SCRIPT="$arm" FM_GROK_WATCH_IDLE_POLL=0.05 "$OWNER" > "$out" 2>&1 &
   pid=$!
   wait_for_file "$home/state/arm-closed" || fail "failed-classification session arm did not close"
   sleep 0.1
   printf '%s\n' "$replacement" > "$home/state/.lock"
-  sleep 1.2
+  sleep 2
   kill -0 "$pid" 2>/dev/null || fail "classification failure completed after session ownership transferred"
-  wait_for_file "$home/state/.watcher-down" || fail "classification failure was not published for successor supervision"
-  recovery=$(cat "$home/state/.watcher-down")
-  case "$recovery" in pending:downtime:*) ;; *) fail "session classification failure published invalid recovery state: $recovery" ;; esac
-  sleep 0.2
-  [ "$(cat "$home/state/.watcher-down")" = "$recovery" ] || fail "session classification failure was published more than once"
   : > "$home/state/release-classification"
   wait "$CLASSIFICATION_LOCK_PID" || fail "wake queue lock holder failed"
+  failure='watcher: FAILED - Grok continuity could not classify a completed arm: wake queue lock remained unavailable'
+  wait_for_file "$home/state/.wake-queue" || fail "classification failure was not queued for successor supervision"
+  rows=$(cat "$home/state/.wake-queue")
+  assert_contains "$rows" "$failure" "session successor could not see the exact classification failure"
+  sleep 0.2
+  [ "$(grep -cF "$failure" "$home/state/.wake-queue")" -eq 1 ] || fail "session classification failure was queued more than once"
+  [ "$(cat "$home/state/.watcher-down")" = 'pending:handling:existing-generation' ] || fail "failure publication clobbered active recovery handling"
   kill -TERM "$pid"
   wait "$pid" 2>/dev/null || true
   assert_not_contains "$(cat "$out")" "watcher: FAILED - Grok continuity could not classify" "old owner surfaced classification failure after session transfer"
@@ -481,7 +484,7 @@ SH
 }
 
 test_away_transfer_during_arm_failure_classification_stays_dormant() {
-  local home arm out pid
+  local home arm out pid failure
   home=$(make_home arm-failure-away-transfer)
   arm="$home/fake-arm.sh"
   out="$home/owner.out"
@@ -500,18 +503,18 @@ SH
   : > "$home/state/release-failure-classification"
   sleep 0.2
   kill -0 "$pid" 2>/dev/null || fail "arm failure completed after away mode took supervision"
-  wait_for_file "$home/state/.watcher-down" || fail "arm failure was not published for away supervision"
-  recovery=$(cat "$home/state/.watcher-down")
-  case "$recovery" in pending:downtime:*) ;; *) fail "away arm failure published invalid recovery state: $recovery" ;; esac
+  failure='watcher: FAILED - classified after away transfer'
+  wait_for_file "$home/state/.wake-queue" || fail "arm failure was not queued for away supervision"
+  assert_contains "$(cat "$home/state/.wake-queue")" "$failure" "away successor could not see the exact arm failure"
   sleep 0.2
-  [ "$(cat "$home/state/.watcher-down")" = "$recovery" ] || fail "away arm failure was published more than once"
+  [ "$(grep -cF "$failure" "$home/state/.wake-queue")" -eq 1 ] || fail "away arm failure was queued more than once"
   kill -TERM "$pid"
   wait "$pid" 2>/dev/null || true
   pass "away transfer during arm failure classification keeps the old owner dormant"
 }
 
 test_session_transfer_during_arm_failure_classification_stays_dormant() {
-  local home arm out pid replacement
+  local home arm out pid replacement failure
   home=$(make_home arm-failure-session-transfer)
   arm="$home/fake-arm.sh"
   out="$home/owner.out"
@@ -531,11 +534,11 @@ SH
   : > "$home/state/release-failure-classification"
   sleep 0.2
   kill -0 "$pid" 2>/dev/null || fail "arm failure completed after session ownership transferred"
-  wait_for_file "$home/state/.watcher-down" || fail "arm failure was not published for successor supervision"
-  recovery=$(cat "$home/state/.watcher-down")
-  case "$recovery" in pending:downtime:*) ;; *) fail "session arm failure published invalid recovery state: $recovery" ;; esac
+  failure='watcher: FAILED - classified after session transfer'
+  wait_for_file "$home/state/.wake-queue" || fail "arm failure was not queued for successor supervision"
+  assert_contains "$(cat "$home/state/.wake-queue")" "$failure" "session successor could not see the exact arm failure"
   sleep 0.2
-  [ "$(cat "$home/state/.watcher-down")" = "$recovery" ] || fail "session arm failure was published more than once"
+  [ "$(grep -cF "$failure" "$home/state/.wake-queue")" -eq 1 ] || fail "session arm failure was queued more than once"
   kill -TERM "$pid"
   wait "$pid" 2>/dev/null || true
   pass "session transfer during arm failure classification keeps the old owner dormant"

--- a/tests/fm-grok-watch-arm.test.sh
+++ b/tests/fm-grok-watch-arm.test.sh
@@ -112,6 +112,62 @@ SH
   pass "arm failure completes the Grok task loudly"
 }
 
+test_output_overflow_retires_child_and_fails_once() {
+  local home arm out status child failure
+  home=$(make_home output-overflow)
+  arm="$home/fake-arm.sh"
+  out="$home/owner.out"
+  cat > "$arm" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$$" > "$FM_HOME/state/overflow-child-pid"
+trap 'exit 143' TERM
+while :; do printf '0123456789abcdef0123456789abcdef\n'; done
+SH
+  chmod +x "$arm"
+
+  FM_HOME="$home" FM_GROK_WATCH_ARM_SCRIPT="$arm" FM_GROK_WATCH_OUTPUT_MAX_BYTES=128 "$OWNER" > "$out" 2>&1
+  status=$?
+  expect_code 1 "$status" "output overflow must fail the Grok tracked task"
+  child=$(cat "$home/state/overflow-child-pid")
+  kill -0 "$child" 2>/dev/null && fail "output overflow left the arm child alive"
+  failure='watcher: FAILED - Grok continuity arm output exceeded 128 bytes'
+  [ "$(grep -cF "$failure" "$out")" -eq 1 ] || fail "same-owner overflow failure was not emitted exactly once"
+  pass "bounded output overflow retires the child and fails once"
+}
+
+test_transferred_output_overflow_queues_once() {
+  local home arm out pid child failure
+  home=$(make_home transferred-output-overflow)
+  arm="$home/fake-arm.sh"
+  out="$home/owner.out"
+  cat > "$arm" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$$" > "$FM_HOME/state/overflow-child-pid"
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+while [ ! -e "$FM_HOME/state/release-overflow" ]; do sleep 0.05; done
+trap 'exit 143' TERM
+while :; do printf '0123456789abcdef0123456789abcdef\n'; done
+SH
+  chmod +x "$arm"
+
+  FM_HOME="$home" FM_GROK_WATCH_ARM_SCRIPT="$arm" FM_GROK_WATCH_OUTPUT_MAX_BYTES=128 FM_GROK_WATCH_IDLE_POLL=0.05 "$OWNER" > "$out" 2>&1 &
+  pid=$!
+  wait_for_file "$home/state/overflow-child-pid" || fail "transferred overflow child did not start"
+  : > "$home/state/.afk"
+  : > "$home/state/release-overflow"
+  wait_for_file "$home/state/.wake-queue" || fail "transferred overflow failure was not queued"
+  sleep 0.2
+  kill -0 "$pid" 2>/dev/null || fail "transferred overflow completed the old Grok task"
+  child=$(cat "$home/state/overflow-child-pid")
+  kill -0 "$child" 2>/dev/null && fail "transferred overflow left the arm child alive"
+  failure='watcher: FAILED - Grok continuity arm output exceeded 128 bytes'
+  [ "$(grep -cF "$failure" "$home/state/.wake-queue")" -eq 1 ] || fail "transferred overflow failure was not queued exactly once"
+  assert_not_contains "$(cat "$out")" "$failure" "old owner emitted transferred overflow failure"
+  kill -TERM "$pid"
+  wait "$pid" 2>/dev/null || true
+  pass "transferred bounded overflow queues once without completing"
+}
+
 test_open_decision_completes_without_queue_row() {
   local home arm out
   home=$(make_home open-decision)
@@ -574,6 +630,8 @@ SH
 
 test_empty_close_rearms_without_completing_grok_task
 test_failure_completes_loudly
+test_output_overflow_retires_child_and_fails_once
+test_transferred_output_overflow_queues_once
 test_open_decision_completes_without_queue_row
 test_pending_recovery_completes_without_queue_row
 test_malformed_recovery_fails_closed

--- a/tests/fm-grok-watch-arm.test.sh
+++ b/tests/fm-grok-watch-arm.test.sh
@@ -451,6 +451,74 @@ SH
   pass "session transfer during failed classification keeps the old owner dormant"
 }
 
+make_blocking_failure_grep() {
+  local home=$1 real_grep
+  real_grep=$(command -v grep)
+  mkdir -p "$home/test-bin"
+  cat > "$home/test-bin/grep" <<SH
+#!/usr/bin/env bash
+case "\$*" in
+  *"^watcher: FAILED"*)
+    : > "\$FM_HOME/state/failure-classification-blocked"
+    while [ ! -e "\$FM_HOME/state/release-failure-classification" ]; do sleep 0.05; done
+    ;;
+esac
+exec "$real_grep" "\$@"
+SH
+  chmod +x "$home/test-bin/grep"
+}
+
+test_away_transfer_during_arm_failure_classification_stays_dormant() {
+  local home arm out pid
+  home=$(make_home arm-failure-away-transfer)
+  arm="$home/fake-arm.sh"
+  out="$home/owner.out"
+  cat > "$arm" <<'SH'
+#!/usr/bin/env bash
+printf 'watcher: FAILED - classified after away transfer\n'
+exit 7
+SH
+  chmod +x "$arm"
+  make_blocking_failure_grep "$home"
+
+  PATH="$home/test-bin:$PATH" FM_HOME="$home" FM_GROK_WATCH_ARM_SCRIPT="$arm" FM_GROK_WATCH_IDLE_POLL=0.05 "$OWNER" > "$out" 2>&1 &
+  pid=$!
+  wait_for_file "$home/state/failure-classification-blocked" || fail "arm failure classification did not block"
+  : > "$home/state/.afk"
+  : > "$home/state/release-failure-classification"
+  sleep 0.2
+  kill -0 "$pid" 2>/dev/null || fail "arm failure completed after away mode took supervision"
+  kill -TERM "$pid"
+  wait "$pid" 2>/dev/null || true
+  pass "away transfer during arm failure classification keeps the old owner dormant"
+}
+
+test_session_transfer_during_arm_failure_classification_stays_dormant() {
+  local home arm out pid replacement
+  home=$(make_home arm-failure-session-transfer)
+  arm="$home/fake-arm.sh"
+  out="$home/owner.out"
+  replacement=$$
+  cat > "$arm" <<'SH'
+#!/usr/bin/env bash
+printf 'watcher: FAILED - classified after session transfer\n'
+exit 7
+SH
+  chmod +x "$arm"
+  make_blocking_failure_grep "$home"
+
+  PATH="$home/test-bin:$PATH" FM_HOME="$home" FM_GROK_WATCH_ARM_SCRIPT="$arm" FM_GROK_WATCH_IDLE_POLL=0.05 "$OWNER" > "$out" 2>&1 &
+  pid=$!
+  wait_for_file "$home/state/failure-classification-blocked" || fail "arm failure classification did not block"
+  printf '%s\n' "$replacement" > "$home/state/.lock"
+  : > "$home/state/release-failure-classification"
+  sleep 0.2
+  kill -0 "$pid" 2>/dev/null || fail "arm failure completed after session ownership transferred"
+  kill -TERM "$pid"
+  wait "$pid" 2>/dev/null || true
+  pass "session transfer during arm failure classification keeps the old owner dormant"
+}
+
 test_owner_signal_retires_arm_child() {
   local home arm out pid child status
   home=$(make_home signal-cleanup)
@@ -490,4 +558,6 @@ test_away_transfer_during_actionable_classification_stays_dormant
 test_session_transfer_during_actionable_classification_stays_dormant
 test_away_transfer_during_failed_classification_stays_dormant
 test_session_transfer_during_failed_classification_stays_dormant
+test_away_transfer_during_arm_failure_classification_stays_dormant
+test_session_transfer_during_arm_failure_classification_stays_dormant
 test_owner_signal_retires_arm_child

--- a/tests/fm-grok-watch-arm.test.sh
+++ b/tests/fm-grok-watch-arm.test.sh
@@ -224,6 +224,36 @@ SH
   pass "TERM-resistant overflow forcibly retires its exact process tree"
 }
 
+test_retirement_identity_mismatch_preserves_unrelated_process() {
+  local home arm out status unrelated identity fake_seed failure
+  home=$(make_home retirement-identity-mismatch)
+  arm="$home/fake-arm.sh"
+  out="$home/owner.out"
+  sleep 300 &
+  unrelated=$!
+  identity=$(FM_HOME="$home" bash -c '. "$1"; fm_pid_identity "$2"' _ "$ROOT/bin/fm-wake-lib.sh" "$unrelated") \
+    || fail "could not identify unrelated retirement counterfactual"
+  fake_seed="$home/state/fake-overflow-identities"
+  printf '%s\t%s-mismatch\n' "$unrelated" "$identity" > "$fake_seed"
+  cat > "$arm" <<'SH'
+#!/usr/bin/env bash
+trap '' TERM
+while :; do printf '0123456789abcdef0123456789abcdef'; done
+SH
+  chmod +x "$arm"
+
+  FM_HOME="$home" FM_GROK_WATCH_ARM_SCRIPT="$arm" FM_GROK_WATCH_OUTPUT_MAX_BYTES=128 \
+    FM_GROK_WATCH_CHILD_TERM_GRACE=0.2 FM_GROK_WATCH_RETIRE_TEST_SEED="$fake_seed" "$OWNER" > "$out" 2>&1
+  status=$?
+  expect_code 1 "$status" "identity-mismatch retirement must fail through the typed boundary"
+  kill -0 "$unrelated" 2>/dev/null || fail "identity mismatch killed an unrelated process"
+  failure='exact child retirement was incomplete'
+  assert_contains "$(cat "$out")" "$failure" "identity mismatch did not surface incomplete retirement"
+  kill -TERM "$unrelated" 2>/dev/null || true
+  wait "$unrelated" 2>/dev/null || true
+  pass "retirement skips changed identities and preserves unrelated processes"
+}
+
 test_transferred_no_newline_overflow_queues_once() {
   local home arm out pid child failure size
   home=$(make_home transferred-no-newline-overflow)
@@ -724,6 +754,7 @@ test_output_overflow_retires_child_and_fails_once
 test_transferred_output_overflow_queues_once
 test_no_newline_output_overflow_is_bounded
 test_term_resistant_overflow_is_forced_bounded
+test_retirement_identity_mismatch_preserves_unrelated_process
 test_transferred_no_newline_overflow_queues_once
 test_open_decision_completes_without_queue_row
 test_pending_recovery_completes_without_queue_row

--- a/tests/fm-grok-watch-arm.test.sh
+++ b/tests/fm-grok-watch-arm.test.sh
@@ -322,6 +322,80 @@ SH
   pass "an actionable close stays dormant after session-lock ownership transfers"
 }
 
+hold_wake_queue_lock() {
+  local home=$1
+  (
+    FM_HOME="$home"
+    STATE="$home/state"
+    . "$ROOT/bin/fm-wake-lib.sh"
+    fm_lock_try_acquire "$FM_WAKE_QUEUE_LOCK" || exit 1
+    : > "$home/state/classification-blocked"
+    while [ ! -e "$home/state/release-classification" ]; do sleep 0.05; done
+    fm_lock_release "$FM_WAKE_QUEUE_LOCK"
+  ) &
+  CLASSIFICATION_LOCK_PID=$!
+  wait_for_file "$home/state/classification-blocked" || fail "could not hold wake queue lock"
+}
+
+test_away_transfer_during_actionable_classification_stays_dormant() {
+  local home arm out pid
+  home=$(make_home classification-away-transfer)
+  arm="$home/fake-arm.sh"
+  out="$home/owner.out"
+  cat > "$arm" <<'SH'
+#!/usr/bin/env bash
+printf '1\t1\tsignal\ttask\tsignal: classified away action\n' > "$FM_HOME/state/.wake-queue"
+: > "$FM_HOME/state/arm-closed"
+printf 'signal: classified away action\n'
+SH
+  chmod +x "$arm"
+  hold_wake_queue_lock "$home"
+
+  FM_HOME="$home" FM_GROK_WATCH_ARM_SCRIPT="$arm" FM_GROK_WATCH_IDLE_POLL=0.05 "$OWNER" > "$out" 2>&1 &
+  pid=$!
+  wait_for_file "$home/state/arm-closed" || fail "classification away-transfer arm did not close"
+  sleep 0.1
+  : > "$home/state/.afk"
+  : > "$home/state/release-classification"
+  wait "$CLASSIFICATION_LOCK_PID" || fail "wake queue lock holder failed"
+  sleep 0.2
+  kill -0 "$pid" 2>/dev/null || fail "actionable classification completed after away mode took supervision"
+  [ -s "$home/state/.wake-queue" ] || fail "old Grok owner consumed away mode's classified wake"
+  kill -TERM "$pid"
+  wait "$pid" 2>/dev/null || true
+  pass "away transfer during actionable classification keeps the old owner dormant"
+}
+
+test_session_transfer_during_actionable_classification_stays_dormant() {
+  local home arm out pid replacement
+  home=$(make_home classification-session-transfer)
+  arm="$home/fake-arm.sh"
+  out="$home/owner.out"
+  replacement=$$
+  cat > "$arm" <<'SH'
+#!/usr/bin/env bash
+printf '1\t1\tsignal\ttask\tsignal: classified successor action\n' > "$FM_HOME/state/.wake-queue"
+: > "$FM_HOME/state/arm-closed"
+printf 'signal: classified successor action\n'
+SH
+  chmod +x "$arm"
+  hold_wake_queue_lock "$home"
+
+  FM_HOME="$home" FM_GROK_WATCH_ARM_SCRIPT="$arm" FM_GROK_WATCH_IDLE_POLL=0.05 "$OWNER" > "$out" 2>&1 &
+  pid=$!
+  wait_for_file "$home/state/arm-closed" || fail "classification session-transfer arm did not close"
+  sleep 0.1
+  printf '%s\n' "$replacement" > "$home/state/.lock"
+  : > "$home/state/release-classification"
+  wait "$CLASSIFICATION_LOCK_PID" || fail "wake queue lock holder failed"
+  sleep 0.2
+  kill -0 "$pid" 2>/dev/null || fail "actionable classification completed after session ownership transferred"
+  [ -s "$home/state/.wake-queue" ] || fail "old Grok owner consumed the successor's classified wake"
+  kill -TERM "$pid"
+  wait "$pid" 2>/dev/null || true
+  pass "session transfer during actionable classification keeps the old owner dormant"
+}
+
 test_owner_signal_retires_arm_child() {
   local home arm out pid child status
   home=$(make_home signal-cleanup)
@@ -357,4 +431,6 @@ test_away_mode_stays_dormant_until_normal_supervision_returns
 test_changed_session_owner_stays_dormant
 test_actionable_close_after_away_transfer_stays_dormant
 test_actionable_close_after_session_transfer_stays_dormant
+test_away_transfer_during_actionable_classification_stays_dormant
+test_session_transfer_during_actionable_classification_stays_dormant
 test_owner_signal_retires_arm_child

--- a/tests/fm-grok-watch-arm.test.sh
+++ b/tests/fm-grok-watch-arm.test.sh
@@ -530,18 +530,18 @@ SH
 }
 
 hold_wake_queue_lock() {
-  local home=$1
+  local lock_home=$1 blocked_file="$1/state/classification-blocked"
   (
-    FM_HOME="$home"
-    STATE="$home/state"
+    FM_HOME="$lock_home"
+    STATE="$lock_home/state"
     . "$ROOT/bin/fm-wake-lib.sh"
     fm_lock_try_acquire "$FM_WAKE_QUEUE_LOCK" || exit 1
-    : > "$home/state/classification-blocked"
-    while [ ! -e "$home/state/release-classification" ]; do sleep 0.05; done
+    : > "$blocked_file"
+    while [ ! -e "$lock_home/state/release-classification" ]; do sleep 0.05; done
     fm_lock_release "$FM_WAKE_QUEUE_LOCK"
   ) &
   CLASSIFICATION_LOCK_PID=$!
-  wait_for_file "$home/state/classification-blocked" || fail "could not hold wake queue lock"
+  wait_for_file "$blocked_file" || fail "could not hold wake queue lock"
 }
 
 test_away_transfer_during_actionable_classification_stays_dormant() {

--- a/tests/fm-supervision-instructions.test.sh
+++ b/tests/fm-supervision-instructions.test.sh
@@ -101,12 +101,12 @@ test_cross_harness_ordinary_continuation_and_repair_matrix() {
 
   out=$("$RENDER" --harness grok)
   ordinary=$(printf '%s\n' "$out" | grep -F -- '- Ordinary wake:')
-  assert_contains "$ordinary" "re-arm" "grok ordinary-wake line does not tell the model to re-arm"
+  assert_contains "$ordinary" "start exactly one" "grok ordinary-wake line does not tell the model to start one persistent owner"
   assert_contains "$ordinary" "Grok tracked background task" "grok ordinary-wake line lost tracked background ownership"
-  assert_contains "$ordinary" "bin/fm-watch-arm.sh" "grok ordinary-wake line lost the background arm command"
+  assert_contains "$ordinary" "bin/fm-watch-arm-grok.sh" "grok ordinary-wake line lost the persistent background owner"
   out=$("$RENDER" --harness grok --repair-line)
   assert_contains "$out" "Grok tracked background task" "grok recovery line lost its tracked background repair"
-  assert_contains "$out" "bin/fm-watch-arm.sh" "grok recovery line lost the arm command"
+  assert_contains "$out" "bin/fm-watch-arm-grok.sh" "grok recovery line lost the persistent background owner"
 
   out=$("$RENDER" --harness codex)
   ordinary=$(printf '%s\n' "$out" | grep -F -- '- Ordinary wake:')
@@ -139,10 +139,10 @@ test_pi_signed_preserves_identity_with_pi_supervision_protocol() {
 test_grok_is_background_notify() {
   local out
   out=$("$RENDER" --harness grok)
-  assert_contains "$out" "Mode: Grok background-notify supervision." "grok snippet missing background-notify mode"
+  assert_contains "$out" "Mode: Grok persistent background-notify supervision." "grok snippet missing persistent background-notify mode"
   assert_contains "$out" "background: true" "grok snippet missing tracked background tool instruction"
   assert_contains "$out" "synthetic_reason: task_completed" "grok snippet missing auto-wake synthetic prompt detail"
-  assert_contains "$out" "bin/fm-watch-arm.sh" "grok snippet missing watcher arm"
+  assert_contains "$out" "bin/fm-watch-arm-grok.sh" "grok snippet missing persistent watcher owner"
   assert_not_contains "$out" "__FM_X_MODE_ENV" "renderer leaked an x-mode path placeholder"
   assert_not_contains "$out" "foreground checkpoint" "grok snippet must not be Codex-style foreground checkpoint"
   out=$("$RENDER" --harness grok --repair-line)
@@ -156,7 +156,7 @@ test_grok_command_sources_effective_config() {
   config="$TMP_ROOT/grok-config"
   mkdir -p "$home/state" "$config"
   out=$(FM_HOME="$home" FM_CONFIG_OVERRIDE="$config" "$RENDER" --harness grok --x-mode 1)
-  assert_contains "$out" "[ -f '$config/x-mode.env' ] && . '$config/x-mode.env'; exec bin/fm-watch-arm.sh" "grok arm command did not use the effective x-mode config path"
+  assert_contains "$out" "[ -f '$config/x-mode.env' ] && . '$config/x-mode.env'; exec bin/fm-watch-arm-grok.sh" "grok arm command did not use the effective x-mode config path"
   pass "grok rendered command sources the effective x-mode config"
 }
 


### PR DESCRIPTION
## Intent

Implement kunchenguid/firstmate#2227 exactly as specified by the full issue. Eliminate billable empty Grok watcher-cycle model turns while preserving every actionable wake, OPEN DECISIONS entry, watcher failure, durable-queue/lifecycle semantic, session-lock ownership boundary, away-mode supervision transfer, and supervision safety. Focus only on eliminating billable empty Grok watcher-cycle turns; exclude unrelated harness and quota work and exclude the upstream Grok automatic session recap behavior. Target main. Reproduce the billing-triggering control flow and add focused behavioral regression evidence. For the unchanged remote-decision watcher regression, inspect its exact expected contract and compare the owning implementation and fixture against main before changing implementation; if unrelated or pre-existing, record equivalent focused evidence, and if caused by this branch, fix it causally rather than repeating the same test-only attempt. No database or browser behavior is involved; do not start a stack and never run Cypress locally. Complete No Mistakes, obtain exact-head authoritative CI and mergeability, never merge, and ensure the final PR body contains a standalone Closes #2227.

## What Changed

- Add a persistent Grok watcher owner that internally re-arms empty closes without completing a billable background model turn.
- Preserve actionable wakes, open decisions, recovery episodes, failures, session-lock boundaries, and away-mode supervision transfers.
- Update Grok supervision guidance, command policy, and focused regression coverage for the persistent owner.

Closes #2227

## Decisions

- Chose **Fix** under ship-cycle authority: after every watcher child closes and immediately before actionable completion, recheck session-lock ownership and `.afk`. If ownership transferred or away mode took supervision, keep the former Grok task dormant and leave durable work or failure evidence for the current owner. Executable coverage exercises actionable-close, classification-failure, and arm-failure transfer sequences.

## Risk Assessment

✅ Low: The change now consistently enforces the ownership and away-mode boundary across all completion paths, preserves transferred failures through the durable queue, and performs bounded identity- and membership-checked child retirement without a substantiated remaining defect.

## Testing

Targeted shell tests exercised the end-user Grok tracked-task flow and rendered launch/policy surfaces: empty closes re-armed without completing the tracked task, while durable wakes, OPEN DECISIONS, recovery states, and failures completed visibly; ownership transfer, away mode, lifecycle, bounded-output, and cleanup safety also passed. Equivalent open-decision coverage passed in the new suite, and the unchanged remote-decision contract matched base. No visual artifact was attempted because the authoritative intent explicitly excludes browser behavior.

<details>
<summary>Evidence: Grok persistent watcher behavioral transcript</summary>

```text
ok - empty close re-arms internally while a durable actionable wake completes the tracked Grok task
ok - arm failure completes the Grok task loudly
ok - bounded output overflow retires the child and fails once
ok - transferred bounded overflow queues once without completing
ok - no-newline output is bounded and retires the child
ok - TERM-resistant overflow forcibly retires its exact process tree
ok - retirement skips changed identities and preserves unrelated processes
ok - retirement skips unchanged identities outside the current tree
ok - transferred no-newline overflow stays bounded and queues once
ok - an OPEN DECISIONS entry completes the Grok task even without a queue row
ok - a pending recovery episode completes the Grok task even without a queue row
ok - malformed recovery state completes the Grok task with a loud failure
ok - an empty close with no supervision need stays dormant until work returns
ok - away mode keeps the Grok owner dormant until normal supervision returns
ok - a Grok task whose session lost the fleet lock stays dormant and does not re-arm
ok - an actionable close stays dormant when away mode takes supervision
ok - an actionable close stays dormant after session-lock ownership transfers
ok - away transfer during actionable classification keeps the old owner dormant
ok - session transfer during actionable classification keeps the old owner dormant
ok - away transfer during failed classification keeps the old owner dormant
ok - session transfer during failed classification keeps the old owner dormant
ok - away transfer during arm failure classification keeps the old owner dormant
ok - session transfer during arm failure classification keeps the old owner dormant
ok - terminating the tracked Grok owner retires its arm child
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"6e5f8e31160de0544bee1efb1a8e3346907a6c09","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (12) ✅</summary>

- 🚨 `bin/fm-watch-arm-grok.sh:189` - The required “session-lock ownership boundary” and “away-mode supervision transfer” remain bypassable when either state changes while the child arm is running: after the child closes, `durable_action_pending` can return actionable and this branch immediately completes the old Grok task without rechecking ownership or `.afk`. That wakes a session which no longer owns supervision (or competes with away-mode supervision). Recheck these boundaries after every child close and before actionable completion; when ownership transferred, leave the durable work for its new owner and keep this old task dormant. The added tests cover transfer only after an empty close, so they do not exercise this reachable sequence.

🔧 Fix: Guard actionable Grok closes after supervision transfer
1 error still open:
- 🚨 `bin/fm-watch-arm-grok.sh:196` - The ownership/away check occurs before `durable_action_pending`, which can wait on the queue lock and scan other state. If `.afk` appears or `.lock` transfers during that classification, verdict 0 still completes the old Grok task. Recheck supervision ownership immediately before this exit; the new tests transfer only inside the child arm and therefore miss this remaining sequence.

🔧 Fix: Recheck Grok ownership after durable classification
1 error still open:
- 🚨 `bin/fm-watch-arm-grok.sh:212` - A supervision transfer during `durable_action_pending` is handled only when the verdict is actionable. If `.afk` appears or the session lock changes while classification waits and classification then fails (for example, the queue lock times out), this branch still completes the old Grok task with a failure, violating the required away-mode/session-ownership boundary and waking a session that no longer owns supervision. Recheck supervision ownership after classification for every completing verdict; if ownership transferred, leave the old task dormant and let the new owner surface durable state or failure.

🔧 Fix: Centralize post-classification Grok ownership guard
1 error still open:
- 🚨 `bin/fm-watch-arm-grok.sh:183` - The required “session-lock ownership boundary” and “away-mode supervision transfer” remain bypassable for child-arm failures. After the check at line 176, failure detection can inspect the captured output; if `.afk` appears or `.lock` transfers during that work, lines 183–190 still complete the old Grok task and wake its former session. Route child failure through the same centralized ownership guard immediately before any task completion, and add executable coverage for transfer during failure classification.

🔧 Fix: Centralize all Grok completion ownership checks
1 error still open:
- 🚨 `bin/fm-watch-arm-grok.sh:199` - The captain required transferred completion paths to “leave durable work/failure evidence for the new owner,” and the intent requires preserving every watcher failure. Here a classification failure exists only in `completion_failure`; if ownership or away mode changes, lines 205–209 delete the stream and continue without printing or durably recording that failure. The old task then remains dormant, so neither it nor the new supervisor surfaces the failed classification. Persist the failure at the centralized completion boundary before yielding to the new owner, using the earliest existing durable failure/recovery channel.

🔧 Fix: Persist transferred Grok failures through recovery
1 error still open:
- 🚨 `bin/fm-watch-arm-grok.sh:205` - Transferred failures are reduced to a generic downtime marker, so the required watcher failure evidence is lost; additionally, publishing `downtime` rewrites an existing `pending:handling:&lt;generation&gt;` episode to `pending:downtime:&lt;generation&gt;`, making an already-delivered recovery actionable again and risking duplicate resurfacing. Persist the actual failure through the existing durable wake channel without changing an active recovery episode. The new tests only verify a fresh generic marker, not failure visibility to the successor or coexistence with `pending:handling`.

🔧 Fix: Queue exact transferred failures without reopening recovery
1 error still open:
- 🚨 `bin/fm-watch-arm-grok.sh:168` - The accepted transfer contract says not to print or complete the old task, but `tee` streams child output before the final ownership/away-mode check. A child can print `watcher: FAILED`, then ownership transfers while failure classification is blocked; the failure is durably queued for the successor, yet it has already been printed through the former owner. Buffer child output until the centralized completion boundary, emitting it only when this owner may complete; on transfer, publish the captured failure solely through the durable queue. This also avoids printing ordinary child failures twice via `tee` and line 215.

🔧 Fix: Buffer Grok terminal output behind ownership checks
1 error still open:
- 🚨 `bin/fm-watch-arm-grok.sh:169` - The accepted fix explicitly requires a “bounded reader,” but this loop writes every child-output line to `output` and usually a second copy to `terminal` without any byte or line limit. A noisy or malfunctioning arm can therefore grow state files until disk exhaustion and make terminal replay arbitrarily long, undermining supervision safety and widening the final ownership-transfer window. Enforce a finite capture limit and convert overflow into a typed failure handled through the existing completion boundary.

🔧 Fix: Bound Grok output and handle overflow safely
1 error still open:
- 🚨 `bin/fm-watch-arm-grok.sh:184` - The required finite output cap is bypassable by a child that emits an unbounded stream without newline characters. Bash `read` buffers until a delimiter or EOF, so this loop never reaches the byte-count check, cannot retire the child, and can grow memory indefinitely. This contradicts the required supervision safety and bounded-reader behavior. Consume fixed-size byte chunks or otherwise enforce the cap before newline framing, then route overflow through the existing centralized completion boundary. Add executable coverage using a no-newline producer.

🔧 Fix: Enforce Grok cap before newline framing
1 error still open:
- 🚨 `bin/fm-watch-arm-grok.sh:192` - Output overflow sends only SIGTERM and the parent then waits indefinitely for the child. A malfunctioning/noisy arm that ignores or mishandles SIGTERM can therefore keep producing output, leave the tracked owner hung, and prevent the typed overflow failure from reaching either owner. The new cleanup tests use cooperative TERM handlers, so they miss this reachable failure. Add a bounded TERM grace period followed by forced retirement of the child/process tree before completing through the centralized ownership boundary.

🔧 Fix: Bound Grok overflow process-tree retirement
1 error still open:
- 🚨 `bin/fm-watch-arm-grok.sh:104` - `pids` is a cached list collected before the TERM grace, then every numeric PID is sent SIGKILL without revalidating that it still belongs to this child tree. A cooperative descendant can exit during the grace and its PID can be reused by an unrelated process, which this loop would then kill—violating the supervision-safety requirement and the requested exact-child identity boundary. Before KILL, re-resolve descendants/process-group membership and validate identity; never signal stale cached PIDs.

🔧 Fix: Validate Grok child identities before forced retirement
1 error still open:
- 🚨 `bin/fm-watch-arm-grok.sh:131` - Forced retirement still retains every pre-TERM identity record and sends KILL based only on unchanged PID identity. If the root exits during the grace period and a descendant is reparented, that process is no longer in the currently resolved child tree but lines 131–134 retain and kill it anyway, violating the required current-membership check. Build KILL candidates only from the freshly resolved tree intersected with recorded identities; treat escaped former descendants as incomplete retirement without signaling them. The new mismatch test covers changed identity, not unchanged identity after reparenting.

🔧 Fix: Require current membership before forced Grok retirement
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `gh-axi issue view 2227 --full`
- `bash tests/fm-grok-watch-arm.test.sh`
- `bash tests/fm-supervision-instructions.test.sh`
- `bash tests/fm-arm-pretool-check.test.sh`
- <code>`bash tests/fm-watch-arm.test.sh` (the unchanged remote-decision fixture reached three passing cases before its pre-existing Linux process-kill behavior terminated the invoking shell)</code>
- <code>`git diff b5d430d6fdcd961ce9b681bf196f365c1825c284..636b1654872a93aa35765a2be091f8b155aebf1b -- tests/fm-watch-arm.test.sh bin/fm-watch-arm.sh bin/fm-watch-once.sh bin/fm-wake-daemon.sh` (confirmed the remote-decision fixture and owning implementation are unchanged from base)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Fix subshell-safe classification lock path
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>