### PR TITLE
Keep routine Herdr watcher reads passive

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2574,9 +2574,9 @@ fm_backend_herdr_send_key() {  # <target> <key>
   fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane send-keys "$FM_BACKEND_HERDR_PANE" "$key" >/dev/null 2>&1
 }
 
-# fm_backend_herdr_capture: bounded plain-text pane capture. Mirrors
-# fm-peek.sh's/fm-watch.sh's `tmux capture-pane -p -t T -S -N`. --source recent
-# is the closest herdr analogue to tmux's scrollback-bounded capture.
+# fm_backend_herdr_capture: bounded historical plain-text pane capture for
+# explicit diagnosis such as fm-peek.sh. --source recent is the closest Herdr
+# analogue to tmux's scrollback-bounded capture.
 #
 # Verified CLI quirk (herdr-verification-p2.md "pane read --lines bug", v0.7.1):
 # `pane read --source recent --lines N` returns COMPLETELY EMPTY output when N
@@ -2594,6 +2594,20 @@ fm_backend_herdr_capture() {  # <target> <lines>
   fetch=$lines
   case "$fetch" in ''|*[!0-9]*) fetch=200 ;; *) [ "$fetch" -ge 200 ] || fetch=200 ;; esac
   out=$(fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane read "$FM_BACKEND_HERDR_PANE" --source recent --lines "$fetch" 2>/dev/null) || return 1
+  printf '%s' "$out" | tail -n "$lines"
+}
+
+# fm_backend_herdr_monitor_capture: passive current-screen capture for recurring
+# watcher hashing. A plain recent read larger than the visible screen can drive
+# an idle recognized agent's alternate-screen mouse-scroll interface before
+# restoring the bottom. The visible source never moves the application viewport;
+# omitting --lines avoids the older small-line read bug, then local trim preserves
+# the caller's bounded-output contract.
+fm_backend_herdr_monitor_capture() {  # <target> <lines>
+  fm_backend_herdr_target_ready "$1" || return 1
+  local lines=${2:-200} out
+  case "$lines" in ''|*[!0-9]*) lines=200 ;; esac
+  out=$(fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane read "$FM_BACKEND_HERDR_PANE" --source visible 2>/dev/null) || return 1
   printf '%s' "$out" | tail -n "$lines"
 }
 

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -691,7 +691,8 @@ fm_backend_resolve_selector() {  # <raw-target> <state-dir>
 # at every call site. Each verified backend adds its own arm here, without
 # changing call sites.
 
-# fm_backend_capture: bounded plain-text session capture.
+# fm_backend_capture: bounded plain-text historical session capture for explicit
+# diagnosis, including fm-peek.sh. Backends may include scrollback/history.
 fm_backend_capture() {  # <backend> <target> <lines> [expected-label]
   local backend=$1
   shift
@@ -704,6 +705,21 @@ fm_backend_capture() {  # <backend> <target> <lines> [expected-label]
     cmux) fm_backend_cmux_capture "$@" ;;
     *) echo "error: no capture implementation for backend '$backend'" >&2; return 1 ;;
   esac
+}
+
+# fm_backend_monitor_capture: bounded plain-text capture for recurring passive
+# monitoring. Only Herdr distinguishes this from historical capture because an
+# oversized recent read can drive an idle agent's alternate-screen scroll UI.
+# Every other backend retains its existing capture behavior byte-for-byte.
+fm_backend_monitor_capture() {  # <backend> <target> <lines> [expected-label]
+  local backend=$1
+  shift
+  if [ "$backend" != herdr ]; then
+    fm_backend_capture "$backend" "$@"
+    return
+  fi
+  fm_backend_source herdr || return 1
+  fm_backend_herdr_monitor_capture "$@"
 }
 
 # fm_backend_send_key: one backend-supported named special key.

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -1014,7 +1014,7 @@ EOF
     if [ "$kind" = secondmate ] && ! status_is_paused "$last"; then
       continue
     fi
-    tail40=$(fm_backend_capture "$(window_backend "$w")" "$w" 40 "$(window_label "$w")" 2>/dev/null) || continue
+    tail40=$(fm_backend_monitor_capture "$(window_backend "$w")" "$w" 40 "$(window_label "$w")" 2>/dev/null) || continue
     h=$(printf '%s' "$tail40" | hash_pane)
     key=$(printf '%s' "$w" | tr ':/.' '___')
     hf="$STATE/.hash-$key"

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -218,8 +218,9 @@ A fully unreadable target stops retrying and reports unknown.
 The poll density bounds the residual possibility of an extremely fast complete turn; a missed transition can cause only a redundant Enter on an empty composer, never duplicate message text.
 
 `pane read --lines N` can return empty output when N is below the viewport height.
-The capture owner requests at least 200 lines from Herdr and trims locally to the caller's bound.
-This generous floor is required for small composer and peek reads.
+Historical and ANSI capture request at least 200 lines from Herdr and trim locally to the caller's bound.
+This generous floor is required for small composer and explicit peek reads.
+Recurring watcher hashing instead reads the passive `visible` snapshot and trims locally, so routine monitoring never requests alternate-screen history.
 
 Herdr's native agent state can read idle while a harness waits on its own long foreground tool.
 The shared crew-state path therefore accepts a native `busy` as evidence of activity but never a native `idle` as evidence that a worker has stopped; the task's own semantic busy state (`bin/fm-busy-lib.sh`) decides that.

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -3666,8 +3666,8 @@ SH
     FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     "$ROOT/bin/fm-peek.sh" default:w1:p2 5 2>/dev/null )
   [ "$out" = "captured herdr pane" ] || fail "fm-peek did not capture through herdr for an explicit metadata-matched target, got '$out'"
-  assert_contains "$(cat "$log")" $'\x1f''pane'$'\x1f''read'$'\x1f''w1:p2' \
-    "fm-peek did not route the explicit stale target through herdr capture"
+  assert_contains "$(cat "$log")" $'\x1f''pane'$'\x1f''read'$'\x1f''w1:p2'$'\x1f''--source'$'\x1f''recent'$'\x1f''--lines'$'\x1f''200' \
+    "fm-peek did not retain intentional recent history with the 200-line workaround"
 
   : > "$log"
   PATH="$fb:$PATH" FM_ROOT_OVERRIDE="$neutral" FM_HOME="$neutral" FM_STATE_OVERRIDE="$state" \

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -24,7 +24,7 @@
 # and tests/wake-helpers.sh (same fake-tmux convention, run against the
 # now-refactored bin/fm-watch.sh); this suite adds one direct old-vs-new
 # diff for the stale-pane path specifically, since that is the one wake path
-# that now calls through fm_backend_capture instead of tmux directly.
+# that now calls through fm_backend_monitor_capture instead of tmux directly.
 # The real tmux smoke test (create session, send text + Enter, capture, list,
 # kill) lives in tests/fm-backend-tmux-smoke.test.sh.
 set -u
@@ -501,6 +501,24 @@ test_backend_source_shell_portable() {
   assert_contains "$out" "unknown backend 'bogus'" \
     "bash: fm_backend_source did not reject bogus with the expected error"
   pass "bash: fm_backend_source recognizes known backends and rejects unknown ones"
+}
+
+test_monitor_capture_changes_only_herdr_dispatch() {
+  (
+    _FM_BACKEND_HERDR_SOURCED=1
+    # shellcheck disable=SC2329 # Indirectly invoked by fm_backend_monitor_capture.
+    fm_backend_capture() { printf 'historical:%s:%s:%s:%s' "$1" "$2" "$3" "$4"; }
+    # shellcheck disable=SC2329 # Indirectly invoked by fm_backend_monitor_capture.
+    fm_backend_herdr_monitor_capture() { printf 'herdr-passive:%s:%s' "$1" "$2"; }
+
+    [ "$(fm_backend_monitor_capture tmux t 40 label)" = "historical:tmux:t:40:label" ] || exit 1
+    [ "$(fm_backend_monitor_capture herdr h 40 label)" = "herdr-passive:h:40" ] || exit 1
+    [ "$(fm_backend_capture herdr h 40 label)" = "historical:herdr:h:40:label" ] || exit 1
+    [ "$(fm_backend_monitor_capture zellij z 40 label)" = "historical:zellij:z:40:label" ] || exit 1
+    [ "$(fm_backend_monitor_capture orca o 40 label)" = "historical:orca:o:40:label" ] || exit 1
+    [ "$(fm_backend_monitor_capture cmux c 40 label)" = "historical:cmux:c:40:label" ] || exit 1
+  ) || fail "monitor capture dispatch changed a non-Herdr backend or degraded Herdr historical capture"
+  pass "fm_backend_monitor_capture: only Herdr uses passive capture; every other backend and explicit Herdr history stay unchanged"
 }
 
 test_backend_validate_spawn_accepts_orca() {
@@ -1126,6 +1144,7 @@ test_backend_name_autodetect_notice
 test_backend_name_explicit_beats_detection
 test_backend_validate_refuses_unknown
 test_backend_source_shell_portable
+test_monitor_capture_changes_only_herdr_dispatch
 test_backend_validate_spawn_accepts_orca
 test_meta_get_and_backend_of_meta
 test_resolve_selector_three_forms

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -445,6 +445,49 @@ test_actionable_signal_surfaced() {
   pass "captain-relevant signal is surfaced (queue + exit) and marked surfaced"
 }
 
+test_herdr_recurring_capture_is_passive() {
+  local dir state fakebin out log pid i read_call
+  dir=$(make_case herdr-passive-capture); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; log="$dir/herdr.log"; : > "$log"
+  fm_write_meta "$state/herdr-passive.meta" \
+    "window=default:w1:p2" "backend=herdr" "kind=ship" "harness=pi"
+  cat > "$fakebin/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+{
+  printf 'HERDR_SESSION=%s' "${HERDR_SESSION:-}"
+  for arg in "$@"; do printf '\x1f%s' "$arg"; done
+  printf '\n'
+} >> "${FM_HERDR_LOG:?}"
+case "${1:-} ${2:-}" in
+  "status --json") printf '{"client":{"version":"0.8.0","protocol":19},"server":{"running":true}}\n' ;;
+  "pane read") printf 'passive current screen\n' ;;
+  "agent get") printf '{"error":{"code":"agent_not_found"}}\n' ;;
+  "api schema") printf '{}\n' ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/herdr"
+
+  FM_HERDR_LOG="$log" watch_bg "$state" "$fakebin" "$out"
+  pid=$!
+  i=0
+  while [ "$i" -lt 50 ]; do
+    grep "$(printf '\x1f')pane$(printf '\x1f')read$(printf '\x1f')w1:p2" "$log" >/dev/null 2>&1 && break
+    kill -0 "$pid" 2>/dev/null || { reap "$pid"; fail "watcher exited before reading the Herdr pane"; }
+    sleep 0.1
+    i=$((i + 1))
+  done
+  read_call=$(grep "$(printf '\x1f')pane$(printf '\x1f')read$(printf '\x1f')w1:p2" "$log" | head -n 1)
+  reap "$pid"
+  [ -n "$read_call" ] || fail "watcher never read the Herdr pane"
+  assert_contains "$read_call" "$(printf '\x1f')--source$(printf '\x1f')visible" \
+    "recurring Herdr monitoring did not use the passive visible source"
+  assert_not_contains "$read_call" "$(printf '\x1f')recent" \
+    "recurring Herdr monitoring requested alternate-screen history"
+  pass "watcher recurring Herdr capture uses the passive visible source"
+}
+
 test_terminal_stale_surfaced() {
   local dir state fakebin out drain_out capture_file window key pane_hash sig pid
   dir=$(make_case terminal-stale); state="$dir/state"; fakebin="$dir/fakebin"
@@ -1858,6 +1901,7 @@ test_turn_ended_provably_working_absorbed
 test_turn_ended_not_working_surfaced
 test_working_note_not_working_surfaced
 test_actionable_signal_surfaced
+test_herdr_recurring_capture_is_passive
 test_terminal_stale_surfaced
 test_stale_terminal_status_overridden_by_active_run
 test_nonterminal_stale_provably_working_absorbed_then_escalated


### PR DESCRIPTION
## Summary
- add a passive monitor-capture seam that changes only Herdr
- use Herdr `visible` snapshots for recurring watcher hashes while preserving `recent --lines 200` for explicit `fm-peek` history
- cover watcher command routing and unchanged non-Herdr dispatch behavior

## Verification
- `bin/fm-test-run.sh tests/fm-backend-herdr.test.sh`
- `bin/fm-test-run.sh tests/fm-backend.test.sh`
- `env -u FM_BUSY_TURN_MAX_SECS -u FM_STALE_ESCALATE_SECS bin/fm-test-run.sh tests/fm-watch-triage.test.sh`
- `bin/fm-lint.sh`
- `bin/fm-doc-audience-check.sh`

No no-mistakes run, per task direction.