### PR TITLE
fix(bin): recover comment-stripped Kimi hook markers

### DIFF
--- a/bin/fm-kimi-turnend-hook.sh
+++ b/bin/fm-kimi-turnend-hook.sh
@@ -193,6 +193,13 @@ def locate_unmarked_block(data: bytes, parsed):
     start = data.find(body)
     if start != 0 and data[start - 1 : start] != b"\n":
         refuse("the unmarked Firstmate hook block is not at a line boundary.")
+    remainder = data[:start] + data[start + len(body) :]
+    parsed_remainder = parse_toml(remainder, "config.toml without the unmarked Firstmate hook block")
+    if any(item == expected for item in parsed_remainder.get("hooks", [])):
+        refuse("the byte-identical unmarked Firstmate hook text is not the canonical top-level hook block.")
+    remarked = data[:start] + block(BEGIN) + data[start + len(body) :]
+    if parse_toml(remarked, "re-marked config.toml") != parsed:
+        refuse("re-marking the unmarked Firstmate hook block changes config.toml semantics.")
     return start, start + len(body)
 
 

--- a/bin/fm-kimi-turnend-hook.sh
+++ b/bin/fm-kimi-turnend-hook.sh
@@ -4,8 +4,10 @@
 # This command is the sole owner of the text-level edit to
 # $HOME/.kimi-code/config.toml. It validates the existing TOML but never
 # serializes it: install adds or replaces one marker-delimited Firstmate region,
-# and remove excises only that region. Missing, malformed, symlinked, partially
-# marked, or otherwise surprising config is refused without a config write.
+# or re-marks one byte-identical canonical hook block left by a comment-stripping
+# Kimi rewrite. Remove excises only a marked region. Missing, malformed,
+# symlinked, altered, ambiguous, or otherwise surprising config is refused
+# without a config write.
 #
 # The installed Stop hook always exits 0 and stays silent. It reads cwd from the
 # hook payload, checks for a .fm-kimi-turnend pointer before registry work, and
@@ -159,15 +161,39 @@ def block(marker: bytes) -> bytes:
     return b"\n".join(
         (
             marker,
+            unmarked_block(),
+            END,
+            b"",
+        )
+    )
+
+
+def unmarked_block() -> bytes:
+    return b"\n".join(
+        (
             b"[[hooks]]",
             b'event = "Stop"',
             b'matcher = "^$"',
             b'command = "bash \\"$HOME/.kimi-code/fm-turn-end.sh\\" >/dev/null 2>&1 || true"',
             b"timeout = 1",
-            END,
-            b"",
         )
     )
+
+
+def locate_unmarked_block(data: bytes, parsed):
+    body = unmarked_block() + b"\n"
+    count = data.count(body)
+    if count > 1:
+        refuse("config.toml has duplicated unmarked Firstmate hook blocks.")
+    if count == 0:
+        return None
+    expected = tomllib.loads(unmarked_block().decode("utf-8"))["hooks"][0]
+    if sum(item == expected for item in parsed.get("hooks", [])) != 1:
+        refuse("the byte-identical unmarked Firstmate hook text is not one unambiguous hook block.")
+    start = data.find(body)
+    if start != 0 and data[start - 1 : start] != b"\n":
+        refuse("the unmarked Firstmate hook block is not at a line boundary.")
+    return start, start + len(body)
 
 
 def without_region(data: bytes, region) -> bytes:
@@ -223,9 +249,14 @@ try:
     config_info = regular_not_symlink(CONFIG, "Kimi config")
     with open(CONFIG, "rb") as stream:
         original = stream.read()
-    parse_toml(original, "config.toml")
+    parsed = parse_toml(original, "config.toml")
     region = locate_region(original)
     outside = original if region is None else without_region(original, region)
+    unmarked = None
+    if ACTION == "install" and region is None:
+        unmarked = locate_unmarked_block(original, parsed)
+        if unmarked is not None:
+            outside = original[: unmarked[0]] + original[unmarked[1] :]
     if HOOK_NAME in outside:
         refuse("config.toml references fm-turn-end.sh outside the Firstmate-owned region.")
 
@@ -242,7 +273,9 @@ try:
                 b"#!/usr/bin/env bash\n# Firstmate Kimi turn-end hook."
             ):
                 refuse(f"Firstmate hook path has unexpected content at {HOOK}.")
-        if region is None:
+        if unmarked is not None:
+            candidate = original[: unmarked[0]] + block(BEGIN) + original[unmarked[1] :]
+        elif region is None:
             marker = BEGIN if original.endswith(b"\n") else BEGIN_OWNS_NEWLINE
             addition = block(marker)
             candidate = original + (b"" if original.endswith(b"\n") else b"\n") + addition

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -238,7 +238,8 @@ Those inherited values are defaults and rules only; `fm-spawn` still permits a c
 For grok, `fm-spawn.sh` installs one firstmate-owned global turn-end hook under `$GROK_HOME/hooks/`, or `~/.grok/hooks/` when `GROK_HOME` is unset, and drops a per-task `.fm-grok-turnend` pointer in the worktree, with teardown removing the task token and pointer.
 For Kimi crews, `fm-spawn.sh` runs `fm-kimi-turnend-hook.sh install`, drops a per-task `.fm-kimi-turnend` pointer in the worktree, and records the matching private registry token for teardown.
 Kimi continues to use the captain's normal Kimi home, including the existing config, skills, and memory; Firstmate does not create an isolated Kimi home.
-The Kimi installer requires an existing regular non-symlink `~/.kimi-code/config.toml`, `python3` with `tomllib`, and `jq`; it validates but never serializes the captain's TOML and refuses before writing when the config is missing, malformed, or surprising or when either tool requirement is unavailable.
+The Kimi installer requires an existing regular non-symlink `~/.kimi-code/config.toml`, `python3` with `tomllib`, and `jq`; it validates but never serializes the captain's TOML and refuses before writing when the config is missing, malformed, altered, ambiguous, or otherwise surprising or when either tool requirement is unavailable.
+If Kimi has stripped only the Firstmate marker comments, installation safely re-marks one byte-identical canonical top-level hook block in place; it does not claim altered, duplicated, or coincidental TOML text.
 Its `remove` action excises only the marker-delimited Firstmate region and removes Firstmate's hook files.
 For Pi and pi-signed secondmate launches, `fm-spawn.sh` starts the selected executable with `-e` pointed at the secondmate home's own tracked `.pi/extensions/fm-primary-pi-watch.ts` and `.pi/extensions/fm-primary-turnend-guard.ts`, both already present from the secondmate home's git worktree.
 

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -101,7 +101,8 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 - OpenCode headless mode and untrusted Grok project hooks remain fail-open at the host boundary.
 - Kimi Code CLI 0.29.1 exposes only global `[[hooks]]` configuration in `~/.kimi-code/config.toml`, including a `Stop` event with snake_case payload fields `hook_event_name`, `session_id`, `cwd`, and `stop_hook_active`.
 - Kimi has no project-level hook configuration and remains outside the primary guard integrations above.
-- Captain-approved Kimi crew wake support uses `bin/fm-kimi-turnend-hook.sh` to edit only one marker-delimited Firstmate region in that global config and install a silent always-zero hook.
+- Captain-approved Kimi crew wake support uses `bin/fm-kimi-turnend-hook.sh` to install a silent always-zero hook in one marker-delimited Firstmate region in that global config.
+- If Kimi strips the region's comments, installation re-marks only one byte-identical canonical top-level hook block and refuses altered, duplicated, or ambiguous matches without writing the config.
 - The hook remains inert unless the payload `cwd` contains a per-task token pointer that resolves through Firstmate's private registry to one `state/<id>.turn-ended` marker.
 - Installation refuses before writing unless `python3` with `tomllib` and `jq` are available.
 - If `jq` is removed after installation, the hook remains silent and exits 0, turn-end wakes stop, and Kimi crews fall back to idle detection.
@@ -112,7 +113,7 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 
 `tests/fm-turnend-guard.test.sh` covers the predicate, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the live-lock and fresh-beacon guard predicate, the cooperative `--claude` claim wait, monotonic failed-epoch progression, bounded attended fail-open, post-alarm continuation suppression, positive recovery reset, Pi logical-run latching, missing-`jq` behavior, all five primary registrations, Grok native and legacy selection, typed field precedence, malformed input, and exactly-one-path safety.
 `tests/fm-guard-stale-banner.test.sh` covers the pull-guard predicate, including the persistent-model fresh-leftover-beacon negative control, the auto-arm model's healthy fresh-beacon-without-a-watcher case and its stale-beacon alarm, the true-reason banner wording, and the reason-keyed episode dedup surviving a beacon mtime change.
-`tests/fm-kimi-harness.test.sh` covers the separate Kimi crew hook's format preservation, idempotence, refusal cases, token guard, spawn registration, and teardown cleanup.
+`tests/fm-kimi-harness.test.sh` covers the separate Kimi crew hook's format preservation, idempotence, exact unmarked-block recovery, altered and ambiguous refusal cases, token guard, spawn registration, and teardown cleanup.
 `tests/fm-supervision-instructions.test.sh` covers recovery-line ownership and pi-signed's identity-preserving reuse of Pi's protocol.
 `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` is the opt-in isolated Pi path.
 [`verification/supervision.md`](verification/supervision.md#turn-end-guard) records the active cross-harness empirical evidence, including the 2026-07-24 Claude `asyncRewake` revalidation.

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -261,6 +261,70 @@ EOF
   pass "Kimi hook install is idempotent and removal restores every foreign config byte"
 }
 
+test_kimi_hook_recovers_only_one_exact_unmarked_block() {
+  local altered before body config duplicate exact marked normal out rc seed
+  seed="$TMP_ROOT/config-unmarked-seed"
+  exact="$TMP_ROOT/config-unmarked-exact"
+  altered="$TMP_ROOT/config-unmarked-altered"
+  duplicate="$TMP_ROOT/config-unmarked-duplicate"
+  normal="$TMP_ROOT/config-unmarked-normal"
+  marked="$seed/marked.toml"
+  body="$seed/body.toml"
+  mkdir -p "$seed/.kimi-code" "$exact/.kimi-code" "$altered/.kimi-code" \
+    "$duplicate/.kimi-code" "$normal/.kimi-code"
+  printf 'default_model = "test"\n' > "$seed/.kimi-code/config.toml"
+  HOME="$seed" "$KIMI_HOOK" install || fail "seed Kimi hook install failed"
+  cp "$seed/.kimi-code/config.toml" "$marked"
+  awk '
+    /^# BEGIN FIRSTMATE KIMI TURN-END HOOK/ { inside = 1; next }
+    /^# END FIRSTMATE KIMI TURN-END HOOK/ { inside = 0 }
+    inside { print }
+  ' "$marked" > "$body"
+
+  sed '/^# BEGIN FIRSTMATE KIMI TURN-END HOOK/d; /^# END FIRSTMATE KIMI TURN-END HOOK/d' \
+    "$marked" > "$exact/.kimi-code/config.toml"
+  HOME="$exact" "$KIMI_HOOK" install || fail "exact unmarked Kimi hook block was not recovered"
+  cmp -s "$marked" "$exact/.kimi-code/config.toml" \
+    || fail "exact unmarked Kimi hook block was not re-marked in place"
+
+  {
+    printf 'default_model = "test"\n'
+    sed 's/^timeout = 1$/timeout = 2/' "$body"
+  } > "$altered/.kimi-code/config.toml"
+  before="$altered/before.toml"
+  cp "$altered/.kimi-code/config.toml" "$before"
+  rc=0
+  out=$(HOME="$altered" "$KIMI_HOOK" install 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "altered unmarked Kimi hook block was recovered"
+  assert_contains "$out" "references fm-turn-end.sh outside" \
+    "altered unmarked Kimi hook refusal lost the outside-reference reason"
+  cmp -s "$before" "$altered/.kimi-code/config.toml" \
+    || fail "altered unmarked Kimi hook refusal changed config bytes"
+
+  {
+    printf 'default_model = "test"\n'
+    cat "$body" "$body"
+  } > "$duplicate/.kimi-code/config.toml"
+  before="$duplicate/before.toml"
+  cp "$duplicate/.kimi-code/config.toml" "$before"
+  rc=0
+  out=$(HOME="$duplicate" "$KIMI_HOOK" install 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "duplicate unmarked Kimi hook blocks were recovered"
+  assert_contains "$out" "duplicated unmarked Firstmate hook blocks" \
+    "duplicate unmarked Kimi hook refusal lost the ambiguity reason"
+  cmp -s "$before" "$duplicate/.kimi-code/config.toml" \
+    || fail "duplicate unmarked Kimi hook refusal changed config bytes"
+
+  config="$normal/.kimi-code/config.toml"
+  printf 'default_model = "normal"\n' > "$config"
+  HOME="$normal" "$KIMI_HOOK" install || fail "normal Kimi hook install regressed"
+  assert_grep '# BEGIN FIRSTMATE KIMI TURN-END HOOK' "$config" \
+    "normal Kimi hook install omitted its begin marker"
+  assert_present "$normal/.kimi-code/fm-turn-end.sh" \
+    "normal Kimi hook install omitted its hook script"
+  pass "Kimi hook install re-marks only one exact orphan and preserves fail-closed installs"
+}
+
 test_kimi_hook_remove_preserves_owned_newline_boundary() {
   local appended config expected home original
   home="$TMP_ROOT/config-owned-newline"
@@ -658,6 +722,7 @@ test_kimi_bordered_prompt_needs_no_override() {
 }
 
 test_kimi_hook_install_is_surgical_idempotent_and_removable
+test_kimi_hook_recovers_only_one_exact_unmarked_block
 test_kimi_hook_remove_preserves_owned_newline_boundary
 test_kimi_hook_fails_closed_on_missing_malformed_or_partial_config
 test_kimi_hook_install_refuses_without_jq

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -320,6 +320,7 @@ test_kimi_hook_recovers_only_one_exact_unmarked_block() {
     printf "decoy = '''\n"
     cat "$body"
     printf "'''\n\n"
+    # shellcheck disable=SC2016 # Literal TOML fixture bytes must not expand in the test shell.
     printf '%s\n' \
       '[[hooks]]' \
       'event = "\u0053top"' \

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -262,16 +262,17 @@ EOF
 }
 
 test_kimi_hook_recovers_only_one_exact_unmarked_block() {
-  local altered before body config duplicate exact marked normal out rc seed
+  local altered before body config decoy duplicate exact marked normal out rc seed
   seed="$TMP_ROOT/config-unmarked-seed"
   exact="$TMP_ROOT/config-unmarked-exact"
   altered="$TMP_ROOT/config-unmarked-altered"
   duplicate="$TMP_ROOT/config-unmarked-duplicate"
+  decoy="$TMP_ROOT/config-unmarked-decoy"
   normal="$TMP_ROOT/config-unmarked-normal"
   marked="$seed/marked.toml"
   body="$seed/body.toml"
   mkdir -p "$seed/.kimi-code" "$exact/.kimi-code" "$altered/.kimi-code" \
-    "$duplicate/.kimi-code" "$normal/.kimi-code"
+    "$duplicate/.kimi-code" "$decoy/.kimi-code" "$normal/.kimi-code"
   printf 'default_model = "test"\n' > "$seed/.kimi-code/config.toml"
   HOME="$seed" "$KIMI_HOOK" install || fail "seed Kimi hook install failed"
   cp "$seed/.kimi-code/config.toml" "$marked"
@@ -314,6 +315,27 @@ test_kimi_hook_recovers_only_one_exact_unmarked_block() {
     "duplicate unmarked Kimi hook refusal lost the ambiguity reason"
   cmp -s "$before" "$duplicate/.kimi-code/config.toml" \
     || fail "duplicate unmarked Kimi hook refusal changed config bytes"
+
+  {
+    printf "decoy = '''\n"
+    cat "$body"
+    printf "'''\n\n"
+    printf '%s\n' \
+      '[[hooks]]' \
+      'event = "\u0053top"' \
+      'matcher = "\u005e$"' \
+      'command = "bash \"$HOME/.kimi-code/fm-turn-end.sh\" >/dev/null 2>&1 || tru\u0065"' \
+      'timeout = 1'
+  } > "$decoy/.kimi-code/config.toml"
+  before="$decoy/before.toml"
+  cp "$decoy/.kimi-code/config.toml" "$before"
+  rc=0
+  out=$(HOME="$decoy" "$KIMI_HOOK" install 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "literal-string decoy was recovered instead of the canonical top-level hook"
+  assert_contains "$out" "is not the canonical top-level hook block" \
+    "literal-string decoy refusal lost the parsed-object binding reason"
+  cmp -s "$before" "$decoy/.kimi-code/config.toml" \
+    || fail "literal-string decoy refusal changed config bytes"
 
   config="$normal/.kimi-code/config.toml"
   printf 'default_model = "normal"\n' > "$config"


### PR DESCRIPTION
## Intent

Implement kunchenguid/firstmate#1064 exactly as specified by gh-axi issue view 1064 -R kunchenguid/firstmate --full. Recover only a byte-identical unmarked Firstmate Kimi hook block after Kimi strips TOML comments, re-marking it safely while retaining fail-closed refusal for altered or ambiguous blocks. Exclude Kimi config redesign. Target main; fully close #1064 with standalone Closes #1064. Use no database or browser stack and never run local Cypress. Follow firstmate-coding-guidelines. Add exact-match, altered, duplicate, and normal-install regressions. Complete No Mistakes and exact-head CI and mergeability verification; never merge. Require recovered text to parse as exactly one canonical top-level hook so coincidental TOML text is not claimed.

## What Changed

- Recover and safely re-mark a byte-identical canonical Kimi turn-end hook block when Kimi strips its TOML comments.
- Refuse altered, duplicated, ambiguous, or non-top-level matches without changing the configuration.
- Document the recovery behavior and add regressions for exact recovery, refusal cases, and normal installation.

Closes #1064

## Risk Assessment

✅ Low: The fix is narrowly scoped, binds the byte-identical span to exactly one canonical parsed top-level hook, preserves fail-closed behavior for altered or ambiguous configurations, and adds behavioral regressions through the executable installer interface.

## Testing

The focused Kimi harness suite passed; end-to-end executable checks reproduced the base failure, demonstrated normal installation and byte-identical recovery after comment stripping, verified unchanged TOML semantics with exactly one canonical top-level hook, and confirmed altered blocks remain refused without config mutation.

<details>
<summary>Evidence: End-to-end Kimi recovery transcript</summary>

`Normal install produced one hook; after simulating Kimi’s comment-stripping rewrite, the next install restored the byte-identical marked config with unchanged TOML semantics and exactly one top-level hook. An altered orphan was refused without changing bytes.`

```text
STEP 1: normal install
markers=1 hooks=1

STEP 2: simulate Kimi TOML rewrite stripping comments
markers=0 hooks=1

STEP 3: next install recovers and re-marks in place
byte_identical_to_original_marked=yes markers=1 hooks=1
toml_semantics_unchanged=True canonical_top_level_hooks=1

STEP 4: altered orphan remains fail-closed and unchanged
unchanged_after_refusal=yes error=fm-kimi-turnend-hook: refused: config.toml references fm-turn-end.sh outside the Firstmate-owned region. 
```
</details>
<details>
<summary>Evidence: Base-commit regression reproduction</summary>

`At the base commit, the second installation exits 1 after markers are stripped, reproducing issue #1064.`

```text
BASE COMMIT REPRODUCTION: second install after Kimi strips comments
fm-kimi-turnend-hook: refused: config.toml references fm-turn-end.sh outside the Firstmate-owned region.
exit_code=1
markers_after_attempt=0 hooks_after_attempt=1
```
</details>
<details>
<summary>Evidence: Recovered marked Kimi configuration</summary>

```text
default_model = "test"
# BEGIN FIRSTMATE KIMI TURN-END HOOK
[[hooks]]
event = "Stop"
matcher = "^$"
command = "bash \"$HOME/.kimi-code/fm-turn-end.sh\" >/dev/null 2>&1 || true"
timeout = 1
# END FIRSTMATE KIMI TURN-END HOOK
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"16d2ad0a38874bd77221f48a6d6c3e9f75508115","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-kimi-turnend-hook.sh:185` - The required criterion says “Require recovered text to parse as exactly one canonical top-level hook so coincidental TOML text is not claimed,” but this hunk independently checks that the bytes occur once and that an equivalent hook exists somewhere in the parsed document; it never proves they are the same object. A reachable counterexample is the exact byte block inside a multiline TOML string plus one semantically equivalent top-level hook encoded differently (for example with Unicode escapes): the string is re-marked while the real hook remains unowned. Bind the byte span to the semantic hook at this boundary—e.g. parse after removing that span and require the canonical hook to disappear, then verify re-marking preserves the original semantic model—and add the corresponding behavioral regression.

🔧 Fix: Bind recovered Kimi hook bytes to parsed object
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `gh-axi issue view 1064 -R kunchenguid/firstmate --full`
- `bash tests/fm-kimi-harness.test.sh`
- <code>Standalone `install → strip TOML comments → install` recovery check with byte comparison and `tomllib` semantic comparison</code>
- `Standalone altered-orphan refusal check with before/after byte comparison`
- `Executed the base commit’s hook installer against the same comment-stripped configuration to reproduce its second-install refusal`
- <code>`git status --short` after testing confirmed no transient working-tree artifacts</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Suppress literal TOML fixture ShellCheck warning
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


## Decisions

- Autonomous decision: Fix [key=unmarked-span-binding] by binding the exact byte span to the parsed top-level canonical hook and adding the counterexample regression.
- The shipped head already implements this in test_kimi_hook_recovers_only_one_exact_unmarked_block; no code amendment is needed.
- Never merge without maintainer approval.