### PR TITLE
fix: verify intended steer delivery

### DIFF
--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -707,7 +707,7 @@ fm_backend_capture() {  # <backend> <target> <lines> [expected-label]
 }
 
 # fm_backend_send_key: one backend-supported named special key.
-fm_backend_send_key() {  # <backend> <target> <key> [expected-label]
+fm_backend_send_key_unlocked() {  # <backend> <target> <key> [expected-label]
   local backend=$1
   shift
   fm_backend_source "$backend" || return 1
@@ -719,6 +719,16 @@ fm_backend_send_key() {  # <backend> <target> <key> [expected-label]
     cmux) fm_backend_cmux_send_key "$@" ;;
     *) echo "error: no send-key implementation for backend '$backend'" >&2; return 1 ;;
   esac
+}
+
+fm_backend_send_key() {  # <backend> <target> <key> [expected-label]
+  if ! command -v fm_lock_acquire_wait >/dev/null 2>&1; then
+    . "$FM_BACKEND_LIB_DIR/fm-wake-lib.sh"
+  fi
+  if ! command -v fm_backend_serialized_send_key >/dev/null 2>&1; then
+    . "$FM_BACKEND_LIB_DIR/fm-checked-submit-lib.sh"
+  fi
+  fm_backend_serialized_send_key "$@"
 }
 
 # fm_backend_send_text_submit: type text once, then submit and verify,

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -739,16 +739,16 @@ fm_backend_endpoint_identity() {  # <backend> <target> [expected-label]
   case "$backend" in
     tmux)
       identity=$(tmux display-message -p -t "$target" '#{pane_id}' 2>/dev/null) || return 1
-      case "$identity" in %*) printf '%s:%s' "$backend" "$identity" ;; *) return 1 ;; esac
+      case "$identity" in
+        %*) printf '%s:%s' "$backend" "$identity" ;;
+        *) printf '%s:%s' "$backend" "$target" ;;
+      esac
       ;;
     cmux)
       fm_backend_cmux_target_ready "$target" "$expected_label" || return 1
       printf '%s:%s:%s' "$backend" "$FM_BACKEND_CMUX_WORKSPACE" "$FM_BACKEND_CMUX_SURFACE"
       ;;
-    herdr|zellij|orca)
-      fm_backend_target_exists "$backend" "$target" "$expected_label" || return 1
-      printf '%s:%s' "$backend" "$target"
-      ;;
+    herdr|zellij|orca) printf '%s:%s' "$backend" "$target" ;;
     *) return 1 ;;
   esac
 }

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -731,16 +731,20 @@ fm_backend_send_key() {  # <backend> <target> <key> [expected-label]
   fm_backend_serialized_send_key "$@"
 }
 
-fm_backend_endpoint_identity() {  # <backend> <target>
-  local backend=$1 target=$2 identity
+fm_backend_endpoint_identity() {  # <backend> <target> [expected-label]
+  local backend=$1 target=$2 expected_label=${3:-} identity
   fm_backend_source "$backend" || return 1
   case "$backend" in
     tmux)
       identity=$(tmux display-message -p -t "$target" '#{pane_id}' 2>/dev/null) || return 1
       case "$identity" in %*) printf '%s:%s' "$backend" "$identity" ;; *) return 1 ;; esac
       ;;
-    herdr|zellij|orca|cmux)
-      fm_backend_target_exists "$backend" "$target" || return 1
+    cmux)
+      fm_backend_cmux_target_ready "$target" "$expected_label" || return 1
+      printf '%s:%s:%s' "$backend" "$FM_BACKEND_CMUX_WORKSPACE" "$FM_BACKEND_CMUX_SURFACE"
+      ;;
+    herdr|zellij|orca)
+      fm_backend_target_exists "$backend" "$target" "$expected_label" || return 1
       printf '%s:%s' "$backend" "$target"
       ;;
     *) return 1 ;;

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -724,7 +724,7 @@ fm_backend_send_key() {  # <backend> <target> <key> [expected-label]
 # fm_backend_send_text_submit: type text once, then submit and verify,
 # retrying only the submission (never retyping). Echoes the backend's
 # proof-carrying verdict; callers require exact empty for confirmed delivery.
-fm_backend_send_text_submit() {  # <backend> <target> <text> <retries> <enter-sleep> <settle> [expected-label]
+fm_backend_send_text_submit_unlocked() {  # <backend> <target> <text> <retries> <enter-sleep> <settle> [expected-label]
   local backend=$1
   shift
   fm_backend_source "$backend" || return 1
@@ -736,6 +736,16 @@ fm_backend_send_text_submit() {  # <backend> <target> <text> <retries> <enter-sl
     cmux) fm_backend_cmux_send_text_submit "$@" ;;
     *) echo "error: no send-text implementation for backend '$backend'" >&2; return 1 ;;
   esac
+}
+
+fm_backend_send_text_submit() {  # <backend> <target> <text> <retries> <enter-sleep> <settle> [expected-label]
+  if ! command -v fm_lock_acquire_wait >/dev/null 2>&1; then
+    . "$FM_BACKEND_LIB_DIR/fm-wake-lib.sh"
+  fi
+  if ! command -v fm_backend_serialized_send_text_submit >/dev/null 2>&1; then
+    . "$FM_BACKEND_LIB_DIR/fm-checked-submit-lib.sh"
+  fi
+  fm_backend_serialized_send_text_submit "$@"
 }
 
 # fm_backend_kill: remove the task's session endpoint (best-effort; a

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -723,9 +723,11 @@ fm_backend_send_key_unlocked() {  # <backend> <target> <key> [expected-label]
 
 fm_backend_send_key() {  # <backend> <target> <key> [expected-label]
   if ! command -v fm_lock_acquire_wait >/dev/null 2>&1; then
+    # shellcheck source=bin/fm-wake-lib.sh
     . "$FM_BACKEND_LIB_DIR/fm-wake-lib.sh"
   fi
   if ! command -v fm_backend_serialized_send_key >/dev/null 2>&1; then
+    # shellcheck source=bin/fm-checked-submit-lib.sh
     . "$FM_BACKEND_LIB_DIR/fm-checked-submit-lib.sh"
   fi
   fm_backend_serialized_send_key "$@"
@@ -770,9 +772,11 @@ fm_backend_send_text_submit_unlocked() {  # <backend> <target> <text> <retries> 
 
 fm_backend_send_text_submit() {  # <backend> <target> <text> <retries> <enter-sleep> <settle> [expected-label]
   if ! command -v fm_lock_acquire_wait >/dev/null 2>&1; then
+    # shellcheck source=bin/fm-wake-lib.sh
     . "$FM_BACKEND_LIB_DIR/fm-wake-lib.sh"
   fi
   if ! command -v fm_backend_serialized_send_text_submit >/dev/null 2>&1; then
+    # shellcheck source=bin/fm-checked-submit-lib.sh
     . "$FM_BACKEND_LIB_DIR/fm-checked-submit-lib.sh"
   fi
   fm_backend_serialized_send_text_submit "$@"

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -731,6 +731,22 @@ fm_backend_send_key() {  # <backend> <target> <key> [expected-label]
   fm_backend_serialized_send_key "$@"
 }
 
+fm_backend_endpoint_identity() {  # <backend> <target>
+  local backend=$1 target=$2 identity
+  fm_backend_source "$backend" || return 1
+  case "$backend" in
+    tmux)
+      identity=$(tmux display-message -p -t "$target" '#{pane_id}' 2>/dev/null) || return 1
+      case "$identity" in %*) printf '%s:%s' "$backend" "$identity" ;; *) return 1 ;; esac
+      ;;
+    herdr|zellij|orca|cmux)
+      fm_backend_target_exists "$backend" "$target" || return 1
+      printf '%s:%s' "$backend" "$target"
+      ;;
+    *) return 1 ;;
+  esac
+}
+
 # fm_backend_send_text_submit: type text once, then submit and verify,
 # retrying only the submission (never retyping). Echoes the backend's
 # proof-carrying verdict; callers require exact empty for confirmed delivery.

--- a/bin/fm-checked-submit-lib.sh
+++ b/bin/fm-checked-submit-lib.sh
@@ -30,15 +30,30 @@ fm_checked_submit_namespace() {
   printf '%s' "$dir"
 }
 
-fm_backend_checked_send_text_submit() {
-  local backend=$1 target=$2 text=$3 retries=$4 enter_sleep=$5 settle=$6 expected_label=${7:-}
-  local identity sum size namespace lock composer verdict rc=0
+fm_checked_submit_lock_path() {
+  local backend=$1 target=$2 identity sum size namespace
   identity="$backend"$'\t'"$target"
   read -r sum size _ <<EOF
 $(printf '%s' "$identity" | cksum)
 EOF
-  namespace=$(fm_checked_submit_namespace) || return 2
-  lock="$namespace/endpoint-$sum-$size.lock"
+  namespace=$(fm_checked_submit_namespace) || return 1
+  printf '%s/endpoint-%s-%s.lock' "$namespace" "$sum" "$size"
+}
+
+fm_backend_serialized_send_text_submit() {
+  local backend=$1 target=$2 lock verdict rc=0
+  lock=$(fm_checked_submit_lock_path "$backend" "$target") || return 2
+  fm_lock_acquire_wait "$lock" || return 2
+  verdict=$(fm_backend_send_text_submit_unlocked "$@") || rc=$?
+  printf '%s' "${verdict:-send-failed}"
+  fm_lock_release "$lock"
+  return "$rc"
+}
+
+fm_backend_checked_send_text_submit() {
+  local backend=$1 target=$2 text=$3 retries=$4 enter_sleep=$5 settle=$6 expected_label=${7:-}
+  local lock composer verdict rc=0
+  lock=$(fm_checked_submit_lock_path "$backend" "$target") || return 2
   fm_lock_acquire_wait "$lock" || return 2
   if ! composer=$(fm_backend_composer_state "$backend" "$target" "$expected_label"); then
     composer=unknown
@@ -48,7 +63,7 @@ EOF
     fm_lock_release "$lock"
     return 0
   fi
-  verdict=$(fm_backend_send_text_submit "$backend" "$target" "$text" "$retries" "$enter_sleep" "$settle" "$expected_label") || rc=$?
+  verdict=$(fm_backend_send_text_submit_unlocked "$backend" "$target" "$text" "$retries" "$enter_sleep" "$settle" "$expected_label") || rc=$?
   printf '%s' "${verdict:-send-failed}"
   fm_lock_release "$lock"
   return "$rc"

--- a/bin/fm-checked-submit-lib.sh
+++ b/bin/fm-checked-submit-lib.sh
@@ -32,7 +32,7 @@ fm_checked_submit_namespace() {
 
 fm_checked_submit_lock_path() {
   local backend=$1 target=$2 identity sum size namespace
-  identity="$backend"$'\t'"$target"
+  identity=$(fm_backend_endpoint_identity "$backend" "$target") || return 1
   read -r sum size _ <<EOF
 $(printf '%s' "$identity" | cksum)
 EOF

--- a/bin/fm-checked-submit-lib.sh
+++ b/bin/fm-checked-submit-lib.sh
@@ -30,9 +30,8 @@ fm_checked_submit_namespace() {
   printf '%s' "$dir"
 }
 
-fm_checked_submit_lock_path() {
-  local backend=$1 target=$2 expected_label=${3:-} identity sum size namespace
-  identity=$(fm_backend_endpoint_identity "$backend" "$target" "$expected_label") || return 1
+fm_checked_submit_identity_lock_path() {
+  local identity=$1 sum size namespace
   read -r sum size _ <<EOF
 $(printf '%s' "$identity" | cksum)
 EOF
@@ -40,49 +39,70 @@ EOF
   printf '%s/endpoint-%s-%s.lock' "$namespace" "$sum" "$size"
 }
 
+fm_checked_submit_lock_path() {
+  local identity
+  identity=$(fm_backend_endpoint_identity "$1" "$2" "${3:-}") || return 1
+  fm_checked_submit_identity_lock_path "$identity"
+}
+
 fm_backend_endpoint_lock_acquire() {
-  FM_BACKEND_ENDPOINT_LOCK=$(fm_checked_submit_lock_path "$1" "$2" "${3:-}") || return 2
-  fm_lock_acquire_wait "$FM_BACKEND_ENDPOINT_LOCK" || return 2
+  local backend=$1 target=$2 expected_label=${3:-} identity confirmed attempt=0
+  while [ "$attempt" -lt 10 ]; do
+    identity=$(fm_backend_endpoint_identity "$backend" "$target" "$expected_label") || return 2
+    FM_BACKEND_ENDPOINT_LOCK=$(fm_checked_submit_identity_lock_path "$identity") || return 2
+    fm_lock_acquire_wait "$FM_BACKEND_ENDPOINT_LOCK" || return 2
+    confirmed=$(fm_backend_endpoint_identity "$backend" "$target" "$expected_label") || {
+      fm_backend_endpoint_lock_release
+      return 2
+    }
+    if [ "$confirmed" = "$identity" ]; then
+      FM_BACKEND_ENDPOINT_TARGET=$target
+      return 0
+    fi
+    fm_backend_endpoint_lock_release
+    attempt=$((attempt + 1))
+  done
+  return 2
 }
 
 fm_backend_endpoint_lock_release() {
   fm_lock_release "$FM_BACKEND_ENDPOINT_LOCK"
   FM_BACKEND_ENDPOINT_LOCK=
+  FM_BACKEND_ENDPOINT_TARGET=
 }
 
 fm_backend_serialized_send_key() {
   local backend=$1 target=$2 expected_label=${4:-} rc=0
   fm_backend_endpoint_lock_acquire "$backend" "$target" "$expected_label" || return 2
-  fm_backend_send_key_unlocked "$@" || rc=$?
+  fm_backend_send_key_unlocked "$backend" "$FM_BACKEND_ENDPOINT_TARGET" "$3" "$expected_label" || rc=$?
   fm_backend_endpoint_lock_release
   return "$rc"
 }
 
 fm_backend_serialized_send_text_submit() {
-  local backend=$1 target=$2 expected_label=${7:-} lock verdict rc=0
-  lock=$(fm_checked_submit_lock_path "$backend" "$target" "$expected_label") || return 2
-  fm_lock_acquire_wait "$lock" || return 2
-  verdict=$(fm_backend_send_text_submit_unlocked "$@") || rc=$?
+  local backend=$1 target=$2 expected_label=${7:-} verdict rc=0
+  fm_backend_endpoint_lock_acquire "$backend" "$target" "$expected_label" || return 2
+  verdict=$(fm_backend_send_text_submit_unlocked "$backend" "$FM_BACKEND_ENDPOINT_TARGET" "$3" "$4" "$5" "$6" "$expected_label") || rc=$?
   printf '%s' "${verdict:-send-failed}"
-  fm_lock_release "$lock"
+  fm_backend_endpoint_lock_release
   return "$rc"
 }
 
 fm_backend_checked_send_text_submit() {
   local backend=$1 target=$2 text=$3 retries=$4 enter_sleep=$5 settle=$6 expected_label=${7:-}
-  local lock composer verdict rc=0
-  lock=$(fm_checked_submit_lock_path "$backend" "$target" "$expected_label") || return 2
-  fm_lock_acquire_wait "$lock" || return 2
+  local composer verdict rc=0
+  fm_backend_endpoint_lock_acquire "$backend" "$target" "$expected_label" || return 2
+  target=$FM_BACKEND_ENDPOINT_TARGET
   if ! composer=$(fm_backend_composer_state "$backend" "$target" "$expected_label"); then
     composer=unknown
   fi
   if [ "$composer" != empty ]; then
     printf '%s' "composer-$composer"
-    fm_lock_release "$lock"
+    fm_backend_endpoint_lock_release
     return 0
   fi
   verdict=$(fm_backend_send_text_submit_unlocked "$backend" "$target" "$text" "$retries" "$enter_sleep" "$settle" "$expected_label") || rc=$?
   printf '%s' "${verdict:-send-failed}"
-  fm_lock_release "$lock"
+  fm_backend_endpoint_lock_release
   return "$rc"
 }

--- a/bin/fm-checked-submit-lib.sh
+++ b/bin/fm-checked-submit-lib.sh
@@ -31,8 +31,8 @@ fm_checked_submit_namespace() {
 }
 
 fm_checked_submit_lock_path() {
-  local backend=$1 target=$2 identity sum size namespace
-  identity=$(fm_backend_endpoint_identity "$backend" "$target") || return 1
+  local backend=$1 target=$2 expected_label=${3:-} identity sum size namespace
+  identity=$(fm_backend_endpoint_identity "$backend" "$target" "$expected_label") || return 1
   read -r sum size _ <<EOF
 $(printf '%s' "$identity" | cksum)
 EOF
@@ -41,7 +41,7 @@ EOF
 }
 
 fm_backend_endpoint_lock_acquire() {
-  FM_BACKEND_ENDPOINT_LOCK=$(fm_checked_submit_lock_path "$1" "$2") || return 2
+  FM_BACKEND_ENDPOINT_LOCK=$(fm_checked_submit_lock_path "$1" "$2" "${3:-}") || return 2
   fm_lock_acquire_wait "$FM_BACKEND_ENDPOINT_LOCK" || return 2
 }
 
@@ -51,16 +51,16 @@ fm_backend_endpoint_lock_release() {
 }
 
 fm_backend_serialized_send_key() {
-  local backend=$1 target=$2 rc=0
-  fm_backend_endpoint_lock_acquire "$backend" "$target" || return 2
+  local backend=$1 target=$2 expected_label=${4:-} rc=0
+  fm_backend_endpoint_lock_acquire "$backend" "$target" "$expected_label" || return 2
   fm_backend_send_key_unlocked "$@" || rc=$?
   fm_backend_endpoint_lock_release
   return "$rc"
 }
 
 fm_backend_serialized_send_text_submit() {
-  local backend=$1 target=$2 lock verdict rc=0
-  lock=$(fm_checked_submit_lock_path "$backend" "$target") || return 2
+  local backend=$1 target=$2 expected_label=${7:-} lock verdict rc=0
+  lock=$(fm_checked_submit_lock_path "$backend" "$target" "$expected_label") || return 2
   fm_lock_acquire_wait "$lock" || return 2
   verdict=$(fm_backend_send_text_submit_unlocked "$@") || rc=$?
   printf '%s' "${verdict:-send-failed}"
@@ -71,7 +71,7 @@ fm_backend_serialized_send_text_submit() {
 fm_backend_checked_send_text_submit() {
   local backend=$1 target=$2 text=$3 retries=$4 enter_sleep=$5 settle=$6 expected_label=${7:-}
   local lock composer verdict rc=0
-  lock=$(fm_checked_submit_lock_path "$backend" "$target") || return 2
+  lock=$(fm_checked_submit_lock_path "$backend" "$target" "$expected_label") || return 2
   fm_lock_acquire_wait "$lock" || return 2
   if ! composer=$(fm_backend_composer_state "$backend" "$target" "$expected_label"); then
     composer=unknown

--- a/bin/fm-checked-submit-lib.sh
+++ b/bin/fm-checked-submit-lib.sh
@@ -40,6 +40,24 @@ EOF
   printf '%s/endpoint-%s-%s.lock' "$namespace" "$sum" "$size"
 }
 
+fm_backend_endpoint_lock_acquire() {
+  FM_BACKEND_ENDPOINT_LOCK=$(fm_checked_submit_lock_path "$1" "$2") || return 2
+  fm_lock_acquire_wait "$FM_BACKEND_ENDPOINT_LOCK" || return 2
+}
+
+fm_backend_endpoint_lock_release() {
+  fm_lock_release "$FM_BACKEND_ENDPOINT_LOCK"
+  FM_BACKEND_ENDPOINT_LOCK=
+}
+
+fm_backend_serialized_send_key() {
+  local backend=$1 target=$2 rc=0
+  fm_backend_endpoint_lock_acquire "$backend" "$target" || return 2
+  fm_backend_send_key_unlocked "$@" || rc=$?
+  fm_backend_endpoint_lock_release
+  return "$rc"
+}
+
 fm_backend_serialized_send_text_submit() {
   local backend=$1 target=$2 lock verdict rc=0
   lock=$(fm_checked_submit_lock_path "$backend" "$target") || return 2

--- a/bin/fm-checked-submit-lib.sh
+++ b/bin/fm-checked-submit-lib.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+fm_checked_submit_namespace_mode() {
+  if [ "$(uname -s 2>/dev/null)" = Darwin ]; then
+    stat -f '%Lp' "$1" 2>/dev/null
+  else
+    stat -c '%a' "$1" 2>/dev/null
+  fi
+}
+
+fm_checked_submit_namespace_uid() {
+  if [ "$(uname -s 2>/dev/null)" = Darwin ]; then
+    stat -f '%u' "$1" 2>/dev/null
+  else
+    stat -c '%u' "$1" 2>/dev/null
+  fi
+}
+
+fm_checked_submit_namespace() {
+  local uid dir owner mode
+  uid=$(id -u 2>/dev/null) || return 1
+  dir="/tmp/firstmate-send-$uid"
+  if [ ! -e "$dir" ] && [ ! -L "$dir" ]; then
+    mkdir -m 700 "$dir" 2>/dev/null || true
+  fi
+  [ -d "$dir" ] && [ ! -L "$dir" ] || return 1
+  owner=$(fm_checked_submit_namespace_uid "$dir") || return 1
+  mode=$(fm_checked_submit_namespace_mode "$dir") || return 1
+  [ "$owner" = "$uid" ] && [ "$mode" = 700 ] || return 1
+  printf '%s' "$dir"
+}
+
+fm_backend_checked_send_text_submit() {
+  local backend=$1 target=$2 text=$3 retries=$4 enter_sleep=$5 settle=$6 expected_label=${7:-}
+  local identity sum size namespace lock composer verdict rc=0
+  identity="$backend"$'\t'"$target"
+  read -r sum size _ <<EOF
+$(printf '%s' "$identity" | cksum)
+EOF
+  namespace=$(fm_checked_submit_namespace) || return 2
+  lock="$namespace/endpoint-$sum-$size.lock"
+  fm_lock_acquire_wait "$lock" || return 2
+  if ! composer=$(fm_backend_composer_state "$backend" "$target" "$expected_label"); then
+    composer=unknown
+  fi
+  if [ "$composer" != empty ]; then
+    printf '%s' "composer-$composer"
+    fm_lock_release "$lock"
+    return 0
+  fi
+  verdict=$(fm_backend_send_text_submit "$backend" "$target" "$text" "$retries" "$enter_sleep" "$settle" "$expected_label") || rc=$?
+  printf '%s' "${verdict:-send-failed}"
+  fm_lock_release "$lock"
+  return "$rc"
+}

--- a/bin/fm-checked-submit-lib.sh
+++ b/bin/fm-checked-submit-lib.sh
@@ -56,7 +56,7 @@ fm_backend_endpoint_lock_acquire() {
       return 2
     }
     if [ "$confirmed" = "$identity" ]; then
-      FM_BACKEND_ENDPOINT_TARGET=$target
+      FM_BACKEND_ENDPOINT_TARGET=${confirmed#*:}
       return 0
     fi
     fm_backend_endpoint_lock_release

--- a/bin/fm-checked-submit-lib.sh
+++ b/bin/fm-checked-submit-lib.sh
@@ -74,6 +74,7 @@ fm_backend_endpoint_lock_release() {
 fm_backend_serialized_send_key() {
   local backend=$1 target=$2 expected_label=${4:-} rc=0
   fm_backend_endpoint_lock_acquire "$backend" "$target" "$expected_label" || return 2
+  [ "$backend" != cmux ] || expected_label=
   fm_backend_send_key_unlocked "$backend" "$FM_BACKEND_ENDPOINT_TARGET" "$3" "$expected_label" || rc=$?
   fm_backend_endpoint_lock_release
   return "$rc"
@@ -82,6 +83,7 @@ fm_backend_serialized_send_key() {
 fm_backend_serialized_send_text_submit() {
   local backend=$1 target=$2 expected_label=${7:-} verdict rc=0
   fm_backend_endpoint_lock_acquire "$backend" "$target" "$expected_label" || return 2
+  [ "$backend" != cmux ] || expected_label=
   verdict=$(fm_backend_send_text_submit_unlocked "$backend" "$FM_BACKEND_ENDPOINT_TARGET" "$3" "$4" "$5" "$6" "$expected_label") || rc=$?
   printf '%s' "${verdict:-send-failed}"
   fm_backend_endpoint_lock_release
@@ -93,6 +95,7 @@ fm_backend_checked_send_text_submit() {
   local composer verdict rc=0
   fm_backend_endpoint_lock_acquire "$backend" "$target" "$expected_label" || return 2
   target=$FM_BACKEND_ENDPOINT_TARGET
+  [ "$backend" != cmux ] || expected_label=
   if ! composer=$(fm_backend_composer_state "$backend" "$target" "$expected_label"); then
     composer=unknown
   fi

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -354,15 +354,17 @@ send_interrupt_keys() {
   fm_backend_endpoint_lock_acquire "$BACKEND" "$T" "$LABEL" \
     || die "could not acquire the endpoint lock before interrupting task $ID on $BACKEND"
   local locked_target=$FM_BACKEND_ENDPOINT_TARGET
+  local operation_label=$LABEL
+  [ "$BACKEND" != cmux ] || operation_label=
   while [ "$i" -lt "$repeat" ]; do
-    if ! fm_backend_send_key_unlocked "$BACKEND" "$locked_target" "$key" "$LABEL"; then
+    if ! fm_backend_send_key_unlocked "$BACKEND" "$locked_target" "$key" "$operation_label"; then
       fm_backend_endpoint_lock_release
       die "interrupt key $key was not delivered to task $ID on $BACKEND"
     fi
     i=$((i + 1))
     [ "$i" -ge "$repeat" ] || sleep 0.2
   done
-  if [ -n "$clear" ] && ! fm_backend_send_key_unlocked "$BACKEND" "$locked_target" "$clear" "$LABEL"; then
+  if [ -n "$clear" ] && ! fm_backend_send_key_unlocked "$BACKEND" "$locked_target" "$clear" "$operation_label"; then
     fm_backend_endpoint_lock_release
     die "interrupt key $key reached task $ID, but $clear did not, so its composer still holds the cancelled prompt; clear it before the next lifecycle action"
   fi

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -353,15 +353,16 @@ send_interrupt_keys() {
     || die "harness $HARNESS needs $clear to clear its composer after an interrupt, which the $BACKEND backend cannot deliver; refusing to leave the cancelled prompt where the next submitted line would concatenate onto it"
   fm_backend_endpoint_lock_acquire "$BACKEND" "$T" "$LABEL" \
     || die "could not acquire the endpoint lock before interrupting task $ID on $BACKEND"
+  local locked_target=$FM_BACKEND_ENDPOINT_TARGET
   while [ "$i" -lt "$repeat" ]; do
-    if ! fm_backend_send_key_unlocked "$BACKEND" "$T" "$key" "$LABEL"; then
+    if ! fm_backend_send_key_unlocked "$BACKEND" "$locked_target" "$key" "$LABEL"; then
       fm_backend_endpoint_lock_release
       die "interrupt key $key was not delivered to task $ID on $BACKEND"
     fi
     i=$((i + 1))
     [ "$i" -ge "$repeat" ] || sleep 0.2
   done
-  if [ -n "$clear" ] && ! fm_backend_send_key_unlocked "$BACKEND" "$T" "$clear" "$LABEL"; then
+  if [ -n "$clear" ] && ! fm_backend_send_key_unlocked "$BACKEND" "$locked_target" "$clear" "$LABEL"; then
     fm_backend_endpoint_lock_release
     die "interrupt key $key reached task $ID, but $clear did not, so its composer still holds the cancelled prompt; clear it before the next lifecycle action"
   fi

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -351,7 +351,7 @@ send_interrupt_keys() {
     || die "harness $HARNESS interrupts with $key, which the $BACKEND backend cannot deliver; refusing to send a different key"
   [ -z "$clear" ] || fm_control_backend_supports_key "$BACKEND" "$clear" \
     || die "harness $HARNESS needs $clear to clear its composer after an interrupt, which the $BACKEND backend cannot deliver; refusing to leave the cancelled prompt where the next submitted line would concatenate onto it"
-  fm_backend_endpoint_lock_acquire "$BACKEND" "$T" \
+  fm_backend_endpoint_lock_acquire "$BACKEND" "$T" "$LABEL" \
     || die "could not acquire the endpoint lock before interrupting task $ID on $BACKEND"
   while [ "$i" -lt "$repeat" ]; do
     if ! fm_backend_send_key_unlocked "$BACKEND" "$T" "$key" "$LABEL"; then

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -134,6 +134,8 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 . "$SCRIPT_DIR/fm-pr-lib.sh"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-checked-submit-lib.sh
+. "$SCRIPT_DIR/fm-checked-submit-lib.sh"
 
 POLL=${FM_CONTROL_POLL:-0.5}
 SETTLE_WAIT=${FM_CONTROL_SETTLE_WAIT:-5}
@@ -349,14 +351,21 @@ send_interrupt_keys() {
     || die "harness $HARNESS interrupts with $key, which the $BACKEND backend cannot deliver; refusing to send a different key"
   [ -z "$clear" ] || fm_control_backend_supports_key "$BACKEND" "$clear" \
     || die "harness $HARNESS needs $clear to clear its composer after an interrupt, which the $BACKEND backend cannot deliver; refusing to leave the cancelled prompt where the next submitted line would concatenate onto it"
+  fm_backend_endpoint_lock_acquire "$BACKEND" "$T" \
+    || die "could not acquire the endpoint lock before interrupting task $ID on $BACKEND"
   while [ "$i" -lt "$repeat" ]; do
-    fm_backend_send_key "$BACKEND" "$T" "$key" "$LABEL" \
-      || die "interrupt key $key was not delivered to task $ID on $BACKEND"
+    if ! fm_backend_send_key_unlocked "$BACKEND" "$T" "$key" "$LABEL"; then
+      fm_backend_endpoint_lock_release
+      die "interrupt key $key was not delivered to task $ID on $BACKEND"
+    fi
     i=$((i + 1))
     [ "$i" -ge "$repeat" ] || sleep 0.2
   done
-  [ -z "$clear" ] || fm_backend_send_key "$BACKEND" "$T" "$clear" "$LABEL" \
-    || die "interrupt key $key reached task $ID, but $clear did not, so its composer still holds the cancelled prompt; clear it before the next lifecycle action"
+  if [ -n "$clear" ] && ! fm_backend_send_key_unlocked "$BACKEND" "$T" "$clear" "$LABEL"; then
+    fm_backend_endpoint_lock_release
+    die "interrupt key $key reached task $ID, but $clear did not, so its composer still holds the cancelled prompt; clear it before the next lifecycle action"
+  fi
+  fm_backend_endpoint_lock_release
 }
 
 prepare_interrupt_ack() {

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -429,7 +429,7 @@ if [ "${1:-}" = "--key" ]; then
   fm_send_record_interrupt "$semantic_key" || exit 1
 else
   MESSAGE=$*
-  send_lock_identity="$TARGET_BACKEND"$'\t'"$T"$'\t'"$EXPECTED_LABEL"
+  send_lock_identity="$TARGET_BACKEND"$'\t'"$T"
   read -r send_lock_sum send_lock_size _ <<EOF
 $(printf '%s' "$send_lock_identity" | cksum)
 EOF

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -424,7 +424,7 @@ if [ "${1:-}" = "--key" ]; then
       exit 1
     fi
   else
-    fm_backend_endpoint_lock_acquire "$TARGET_BACKEND" "$T" || {
+    fm_backend_endpoint_lock_acquire "$TARGET_BACKEND" "$T" "$EXPECTED_LABEL" || {
       echo "error: key '$key' not sent to $T (cannot acquire endpoint lock; tried $RESOLUTION_TRIED)" >&2
       exit 1
     }

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -107,6 +107,8 @@ fi
 . "$SCRIPT_DIR/fm-line-cap-lib.sh"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-checked-submit-lib.sh
+. "$SCRIPT_DIR/fm-checked-submit-lib.sh"
 
 FM_GUARD_CONTINUE_LINE='This is a supervision warning only; the requested message WILL still be sent.' "$SCRIPT_DIR/fm-guard.sh" || true
 
@@ -183,36 +185,6 @@ fm_send_count_colons() {  # <string>
   local s=$1 no_colons
   no_colons=${s//:/}
   printf '%s' $(( ${#s} - ${#no_colons} ))
-}
-
-fm_send_lock_namespace_mode() {
-  if [ "$(uname -s 2>/dev/null)" = Darwin ]; then
-    stat -f '%Lp' "$1" 2>/dev/null
-  else
-    stat -c '%a' "$1" 2>/dev/null
-  fi
-}
-
-fm_send_lock_namespace_uid() {
-  if [ "$(uname -s 2>/dev/null)" = Darwin ]; then
-    stat -f '%u' "$1" 2>/dev/null
-  else
-    stat -c '%u' "$1" 2>/dev/null
-  fi
-}
-
-fm_send_lock_namespace() {
-  local uid dir owner mode
-  uid=$(id -u 2>/dev/null) || return 1
-  dir="/tmp/firstmate-send-$uid"
-  if [ ! -e "$dir" ] && [ ! -L "$dir" ]; then
-    mkdir -m 700 "$dir" 2>/dev/null || true
-  fi
-  [ -d "$dir" ] && [ ! -L "$dir" ] || return 1
-  owner=$(fm_send_lock_namespace_uid "$dir") || return 1
-  mode=$(fm_send_lock_namespace_mode "$dir") || return 1
-  [ "$owner" = "$uid" ] && [ "$mode" = 700 ] || return 1
-  printf '%s' "$dir"
 }
 
 fm_send_resolve_target() {  # <raw-target>
@@ -459,17 +431,6 @@ if [ "${1:-}" = "--key" ]; then
   fm_send_record_interrupt "$semantic_key" || exit 1
 else
   MESSAGE=$*
-  send_lock_identity="$TARGET_BACKEND"$'\t'"$T"
-  read -r send_lock_sum send_lock_size _ <<EOF
-$(printf '%s' "$send_lock_identity" | cksum)
-EOF
-  send_lock_namespace=$(fm_send_lock_namespace) || {
-    echo "error: text not sent to $T (cannot establish the shared send-lock namespace)" >&2
-    exit 1
-  }
-  SEND_TEXT_LOCK="$send_lock_namespace/endpoint-$send_lock_sum-$send_lock_size.lock"
-  fm_lock_acquire_wait "$SEND_TEXT_LOCK"
-  trap 'fm_lock_release "$SEND_TEXT_LOCK"' EXIT
   # The pre-marker answer text, kept for the closing resolved note so the
   # durable ledger records the plain answer without marker or corr bytes.
   RESOLVE_ANSWER_TEXT=$MESSAGE
@@ -515,18 +476,6 @@ EOF
   esac
   retries=${FM_SEND_RETRIES:-3}
   sleep_s=${FM_SEND_SLEEP:-0.4}
-  if [ "$TARGET_BACKEND" != remote ]; then
-    if ! composer_before=$(fm_backend_composer_state "$TARGET_BACKEND" "$T" "$EXPECTED_LABEL"); then
-      composer_before=unknown
-    fi
-    if [ "$composer_before" != empty ]; then
-      if [ "$PENDING_REPLY_CREATED" = 1 ] && [ -n "$PENDING_REPLY_CORR" ]; then
-        fm_pending_reply_discard_undelivered "$STATE" "$PENDING_REPLY_CORR" || true
-      fi
-      echo "error: text not sent to $T (composer is not empty; verdict=${composer_before:-unknown}; refusing to append to or submit existing input; tried $RESOLUTION_TRIED)" >&2
-      exit 1
-    fi
-  fi
   # Type once, submit, verify. Only exact empty confirms delivery; every other
   # verdict preserves the loud refusal boundary.
   send_rc=0
@@ -537,7 +486,7 @@ EOF
       send_rc=$?
       verdict=send-failed
     fi
-  elif verdict=$(fm_backend_send_text_submit "$TARGET_BACKEND" "$T" "$MESSAGE" "$retries" "$sleep_s" "$settle" "$EXPECTED_LABEL"); then
+  elif verdict=$(fm_backend_checked_send_text_submit "$TARGET_BACKEND" "$T" "$MESSAGE" "$retries" "$sleep_s" "$settle" "$EXPECTED_LABEL"); then
     :
   else
     send_rc=$?
@@ -556,6 +505,14 @@ EOF
   fi
   case "$verdict" in
     empty)
+      ;;
+    composer-*)
+      if [ "$PENDING_REPLY_CREATED" = 1 ] && [ -n "$PENDING_REPLY_CORR" ]; then
+        fm_pending_reply_discard_undelivered "$STATE" "$PENDING_REPLY_CORR" || true
+      fi
+      composer_before=${verdict#composer-}
+      echo "error: text not sent to $T (composer is not empty; verdict=${composer_before:-unknown}; refusing to append to or submit existing input; tried $RESOLUTION_TRIED)" >&2
+      exit 1
       ;;
     send-failed)
       if [ "$PENDING_REPLY_CREATED" = 1 ] && [ -n "$PENDING_REPLY_CORR" ]; then
@@ -592,8 +549,6 @@ EOF
   if [ -n "$RESOLVE_KEYS" ]; then
     fm_send_close_resolved_keys "$RESOLVE_ANSWER_TEXT" || exit 1
   fi
-  fm_lock_release "$SEND_TEXT_LOCK"
-  trap - EXIT
   # Submit landed with exact empty. Confirmation only proves the text was
   # accepted; the harness still needs a beat to spin up the
   # turn before its busy footer shows. Pause so an immediate peek catches the

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -10,11 +10,13 @@
 # Key support is backend-specific: tmux/herdr support Escape, Enter, and C-c;
 # Orca currently supports Enter and C-c only, and rejects Escape.
 #
-# Text submission is verified: the line is typed ONCE, then Enter is sent and
-# retried (Enter only, never retyped) until the target backend confirms a
-# submit or reports an inconclusive send. If a swallowed Enter is positively
-# confirmed, fm-send exits NON-ZERO so the caller knows the steer did not land
-# instead of silently leaving an unsubmitted instruction.
+# Text submission is verified at both boundaries: the target composer must be
+# positively empty before the line is typed ONCE, then Enter is sent and retried
+# (Enter only, never retyped) until the target backend confirms a submit or
+# reports an inconclusive send. The empty preflight prevents a parked lane's
+# stale draft from being concatenated with and submitted as the new steer. If
+# either boundary is unconfirmed, fm-send exits NON-ZERO so success means the
+# intended steer, rather than merely some composer content, was accepted.
 # Submission dispatches through the target's recorded backend; the tmux adapter
 # shares its composer/submit core with the away-mode daemon via bin/fm-tmux-lib.sh.
 # Tune with FM_SEND_RETRIES (default 3) / FM_SEND_SLEEP (0.4).
@@ -428,6 +430,21 @@ else
   # The pre-marker answer text, kept for the closing resolved note so the
   # durable ledger records the plain answer without marker or corr bytes.
   RESOLVE_ANSWER_TEXT=$MESSAGE
+  # Prove the new steer owns an empty composer before creating any pending-reply
+  # expectation, transforming the message, or typing a byte. Post-Enter empty
+  # alone is insufficient: stale text in a parked lane can absorb the new text,
+  # submit the combined draft, clear successfully, and make the wrong instruction
+  # look delivered. Remote sends run fm-send again against their host-local
+  # explicit endpoint, so the inner send owns this same preflight there.
+  if [ "$TARGET_BACKEND" != remote ]; then
+    if ! composer_before=$(fm_backend_composer_state "$TARGET_BACKEND" "$T" "$EXPECTED_LABEL"); then
+      composer_before=unknown
+    fi
+    if [ "$composer_before" != empty ]; then
+      echo "error: text not sent to $T (composer is not empty; verdict=${composer_before:-unknown}; refusing to append to or submit existing input; tried $RESOLUTION_TRIED)" >&2
+      exit 1
+    fi
+  fi
   if [ "$MARK_FROM_FIRSTMATE" = 1 ]; then
     # Reuse an existing correlation id for recovery resends; otherwise create a
     # durable parent expectation before delivery. Transport success never

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -136,7 +136,7 @@ fm_send_clear_after_interrupt() {  # <key>
   clear=$(fm_control_interrupt_clear_key "$family") || return 0
   [ -n "$clear" ] || return 0
   [ "$TARGET_BACKEND" != remote ] || return 0
-  if ! fm_backend_send_key "$TARGET_BACKEND" "$T" "$clear" "$EXPECTED_LABEL"; then
+  if ! fm_backend_send_key_unlocked "$TARGET_BACKEND" "$T" "$clear" "$EXPECTED_LABEL"; then
     echo "error: Escape reached $T, but the $TARGET_HARNESS composer could not be cleared; it still holds the restored prompt. Clear it before sending the next message." >&2
     return 1
   fi
@@ -423,11 +423,22 @@ if [ "${1:-}" = "--key" ]; then
       echo "error: key '$key' not sent to remote secondmate $TARGET_REMOTE_ID; completion may be unknown" >&2
       exit 1
     fi
-  elif ! fm_backend_send_key "$TARGET_BACKEND" "$T" "$key" "$EXPECTED_LABEL"; then
-    echo "error: key '$key' not sent to $T ($TARGET_BACKEND send failed; tried $RESOLUTION_TRIED)" >&2
-    exit 1
+  else
+    fm_backend_endpoint_lock_acquire "$TARGET_BACKEND" "$T" || {
+      echo "error: key '$key' not sent to $T (cannot acquire endpoint lock; tried $RESOLUTION_TRIED)" >&2
+      exit 1
+    }
+    trap 'fm_backend_endpoint_lock_release' EXIT
+    if ! fm_backend_send_key_unlocked "$TARGET_BACKEND" "$T" "$key" "$EXPECTED_LABEL"; then
+      echo "error: key '$key' not sent to $T ($TARGET_BACKEND send failed; tried $RESOLUTION_TRIED)" >&2
+      exit 1
+    fi
   fi
   fm_send_clear_after_interrupt "$semantic_key" || exit 1
+  if [ "$TARGET_BACKEND" != remote ]; then
+    fm_backend_endpoint_lock_release
+    trap - EXIT
+  fi
   fm_send_record_interrupt "$semantic_key" || exit 1
 else
   MESSAGE=$*

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -429,7 +429,7 @@ if [ "${1:-}" = "--key" ]; then
       exit 1
     }
     trap 'fm_backend_endpoint_lock_release' EXIT
-    if ! fm_backend_send_key_unlocked "$TARGET_BACKEND" "$T" "$key" "$EXPECTED_LABEL"; then
+    if ! fm_backend_send_key_unlocked "$TARGET_BACKEND" "$FM_BACKEND_ENDPOINT_TARGET" "$key" "$EXPECTED_LABEL"; then
       echo "error: key '$key' not sent to $T ($TARGET_BACKEND send failed; tried $RESOLUTION_TRIED)" >&2
       exit 1
     fi

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -129,14 +129,15 @@ fm_send_id_from_meta() {  # <meta-file>
 # WHICH adapters need that clear, and which key clears them, comes from the one
 # control-plane capability table (bin/fm-control-lib.sh) rather than a second
 # copy here - the same table bin/fm-control.sh's interrupt verb reads.
-fm_send_clear_after_interrupt() {  # <key>
-  local key=$1 family clear
+fm_send_clear_after_interrupt() {  # <key> [target]
+  local key=$1 target=${2:-$T} family clear operation_label=$EXPECTED_LABEL
   [ "$key" = Escape ] || return 0
   family=$(fm_control_harness_family "$TARGET_HARNESS") || return 0
   clear=$(fm_control_interrupt_clear_key "$family") || return 0
   [ -n "$clear" ] || return 0
   [ "$TARGET_BACKEND" != remote ] || return 0
-  if ! fm_backend_send_key_unlocked "$TARGET_BACKEND" "$T" "$clear" "$EXPECTED_LABEL"; then
+  [ "$TARGET_BACKEND" != cmux ] || operation_label=
+  if ! fm_backend_send_key_unlocked "$TARGET_BACKEND" "$target" "$clear" "$operation_label"; then
     echo "error: Escape reached $T, but the $TARGET_HARNESS composer could not be cleared; it still holds the restored prompt. Clear it before sending the next message." >&2
     return 1
   fi
@@ -429,12 +430,14 @@ if [ "${1:-}" = "--key" ]; then
       exit 1
     }
     trap 'fm_backend_endpoint_lock_release' EXIT
-    if ! fm_backend_send_key_unlocked "$TARGET_BACKEND" "$FM_BACKEND_ENDPOINT_TARGET" "$key" "$EXPECTED_LABEL"; then
+    operation_label=$EXPECTED_LABEL
+    [ "$TARGET_BACKEND" != cmux ] || operation_label=
+    if ! fm_backend_send_key_unlocked "$TARGET_BACKEND" "$FM_BACKEND_ENDPOINT_TARGET" "$key" "$operation_label"; then
       echo "error: key '$key' not sent to $T ($TARGET_BACKEND send failed; tried $RESOLUTION_TRIED)" >&2
       exit 1
     fi
   fi
-  fm_send_clear_after_interrupt "$semantic_key" || exit 1
+  fm_send_clear_after_interrupt "$semantic_key" "${FM_BACKEND_ENDPOINT_TARGET:-$T}" || exit 1
   if [ "$TARGET_BACKEND" != remote ]; then
     fm_backend_endpoint_lock_release
     trap - EXIT

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -204,8 +204,7 @@ fm_send_lock_namespace_uid() {
 fm_send_lock_namespace() {
   local uid dir owner mode
   uid=$(id -u 2>/dev/null) || return 1
-  dir=${FM_SEND_LOCK_NAMESPACE:-${TMPDIR:-/tmp}/firstmate-send-$uid}
-  case "$dir" in /*) ;; *) return 1 ;; esac
+  dir="/tmp/firstmate-send-$uid"
   if [ ! -e "$dir" ] && [ ! -L "$dir" ]; then
     mkdir -m 700 "$dir" 2>/dev/null || true
   fi

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -105,6 +105,8 @@ fi
 . "$SCRIPT_DIR/fm-classify-lib.sh"
 # shellcheck source=bin/fm-line-cap-lib.sh
 . "$SCRIPT_DIR/fm-line-cap-lib.sh"
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
 
 FM_GUARD_CONTINUE_LINE='This is a supervision warning only; the requested message WILL still be sent.' "$SCRIPT_DIR/fm-guard.sh" || true
 
@@ -427,24 +429,16 @@ if [ "${1:-}" = "--key" ]; then
   fm_send_record_interrupt "$semantic_key" || exit 1
 else
   MESSAGE=$*
+  send_lock_identity="$TARGET_BACKEND"$'\t'"$T"$'\t'"$EXPECTED_LABEL"
+  read -r send_lock_sum send_lock_size _ <<EOF
+$(printf '%s' "$send_lock_identity" | cksum)
+EOF
+  SEND_TEXT_LOCK="$STATE/.fm-send-$send_lock_sum-$send_lock_size.lock"
+  fm_lock_acquire_wait "$SEND_TEXT_LOCK"
+  trap 'fm_lock_release "$SEND_TEXT_LOCK"' EXIT
   # The pre-marker answer text, kept for the closing resolved note so the
   # durable ledger records the plain answer without marker or corr bytes.
   RESOLVE_ANSWER_TEXT=$MESSAGE
-  # Prove the new steer owns an empty composer before creating any pending-reply
-  # expectation, transforming the message, or typing a byte. Post-Enter empty
-  # alone is insufficient: stale text in a parked lane can absorb the new text,
-  # submit the combined draft, clear successfully, and make the wrong instruction
-  # look delivered. Remote sends run fm-send again against their host-local
-  # explicit endpoint, so the inner send owns this same preflight there.
-  if [ "$TARGET_BACKEND" != remote ]; then
-    if ! composer_before=$(fm_backend_composer_state "$TARGET_BACKEND" "$T" "$EXPECTED_LABEL"); then
-      composer_before=unknown
-    fi
-    if [ "$composer_before" != empty ]; then
-      echo "error: text not sent to $T (composer is not empty; verdict=${composer_before:-unknown}; refusing to append to or submit existing input; tried $RESOLUTION_TRIED)" >&2
-      exit 1
-    fi
-  fi
   if [ "$MARK_FROM_FIRSTMATE" = 1 ]; then
     # Reuse an existing correlation id for recovery resends; otherwise create a
     # durable parent expectation before delivery. Transport success never
@@ -487,6 +481,18 @@ else
   esac
   retries=${FM_SEND_RETRIES:-3}
   sleep_s=${FM_SEND_SLEEP:-0.4}
+  if [ "$TARGET_BACKEND" != remote ]; then
+    if ! composer_before=$(fm_backend_composer_state "$TARGET_BACKEND" "$T" "$EXPECTED_LABEL"); then
+      composer_before=unknown
+    fi
+    if [ "$composer_before" != empty ]; then
+      if [ "$PENDING_REPLY_CREATED" = 1 ] && [ -n "$PENDING_REPLY_CORR" ]; then
+        fm_pending_reply_discard_undelivered "$STATE" "$PENDING_REPLY_CORR" || true
+      fi
+      echo "error: text not sent to $T (composer is not empty; verdict=${composer_before:-unknown}; refusing to append to or submit existing input; tried $RESOLUTION_TRIED)" >&2
+      exit 1
+    fi
+  fi
   # Type once, submit, verify. Only exact empty confirms delivery; every other
   # verdict preserves the loud refusal boundary.
   send_rc=0
@@ -552,6 +558,8 @@ else
   if [ -n "$RESOLVE_KEYS" ]; then
     fm_send_close_resolved_keys "$RESOLVE_ANSWER_TEXT" || exit 1
   fi
+  fm_lock_release "$SEND_TEXT_LOCK"
+  trap - EXIT
   # Submit landed with exact empty. Confirmation only proves the text was
   # accepted; the harness still needs a beat to spin up the
   # turn before its busy footer shows. Pause so an immediate peek catches the

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -185,6 +185,37 @@ fm_send_count_colons() {  # <string>
   printf '%s' $(( ${#s} - ${#no_colons} ))
 }
 
+fm_send_lock_namespace_mode() {
+  if [ "$(uname -s 2>/dev/null)" = Darwin ]; then
+    stat -f '%Lp' "$1" 2>/dev/null
+  else
+    stat -c '%a' "$1" 2>/dev/null
+  fi
+}
+
+fm_send_lock_namespace_uid() {
+  if [ "$(uname -s 2>/dev/null)" = Darwin ]; then
+    stat -f '%u' "$1" 2>/dev/null
+  else
+    stat -c '%u' "$1" 2>/dev/null
+  fi
+}
+
+fm_send_lock_namespace() {
+  local uid dir owner mode
+  uid=$(id -u 2>/dev/null) || return 1
+  dir=${FM_SEND_LOCK_NAMESPACE:-${TMPDIR:-/tmp}/firstmate-send-$uid}
+  case "$dir" in /*) ;; *) return 1 ;; esac
+  if [ ! -e "$dir" ] && [ ! -L "$dir" ]; then
+    mkdir -m 700 "$dir" 2>/dev/null || true
+  fi
+  [ -d "$dir" ] && [ ! -L "$dir" ] || return 1
+  owner=$(fm_send_lock_namespace_uid "$dir") || return 1
+  mode=$(fm_send_lock_namespace_mode "$dir") || return 1
+  [ "$owner" = "$uid" ] && [ "$mode" = 700 ] || return 1
+  printf '%s' "$dir"
+}
+
 fm_send_resolve_target() {  # <raw-target>
   local raw=$1 meta pane_meta target backend assumed colons id session hint
 
@@ -433,7 +464,11 @@ else
   read -r send_lock_sum send_lock_size _ <<EOF
 $(printf '%s' "$send_lock_identity" | cksum)
 EOF
-  SEND_TEXT_LOCK="$STATE/.fm-send-$send_lock_sum-$send_lock_size.lock"
+  send_lock_namespace=$(fm_send_lock_namespace) || {
+    echo "error: text not sent to $T (cannot establish the shared send-lock namespace)" >&2
+    exit 1
+  }
+  SEND_TEXT_LOCK="$send_lock_namespace/endpoint-$send_lock_sum-$send_lock_size.lock"
   fm_lock_acquire_wait "$SEND_TEXT_LOCK"
   trap 'fm_lock_release "$SEND_TEXT_LOCK"' EXIT
   # The pre-marker answer text, kept for the closing resolved note so the

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -237,6 +237,8 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-config-inherit-lib.sh"
 # shellcheck source=bin/fm-backend.sh
 . "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-checked-submit-lib.sh
+. "$SCRIPT_DIR/fm-checked-submit-lib.sh"
 # shellcheck source=bin/fm-control-lib.sh
 . "$SCRIPT_DIR/fm-control-lib.sh"
 # shellcheck source=bin/fm-gate-refuse-lib.sh
@@ -661,6 +663,7 @@ RELAUNCH_REPLACEMENT_STATE=
 RELAUNCH_REPLACEMENT_WT=
 CONFIG_INHERIT_LOCK=
 CONFIG_INHERIT_LOCK_HELD=0
+SPAWN_ENDPOINT_LOCK_HELD=0
 
 parse_orca_worktree_result() {
   local raw=$1 rest
@@ -771,6 +774,10 @@ spawn_abort_cleanup() {
   if [ "$CONFIG_INHERIT_LOCK_HELD" = 1 ]; then
     CONFIG_INHERIT_LOCK_HELD=0
     fm_lock_release "$CONFIG_INHERIT_LOCK" || true
+  fi
+  if [ "$SPAWN_ENDPOINT_LOCK_HELD" = 1 ]; then
+    SPAWN_ENDPOINT_LOCK_HELD=0
+    fm_backend_endpoint_lock_release || true
   fi
   return "$status"
 }
@@ -2058,22 +2065,39 @@ fi
 # WT_TARGET to $T for them (and for any future backend) - the shared treehouse-get +
 # worktree-detection steps below must never reference an unbound WT_TARGET under set -u.
 : "${WT_TARGET:=$T}"
+spawn_endpoint_lock_acquire() {
+  fm_backend_endpoint_lock_acquire "$BACKEND" "$1" "$W" || return 1
+  SPAWN_ENDPOINT_LOCK_HELD=1
+}
+spawn_endpoint_lock_release() {
+  SPAWN_ENDPOINT_LOCK_HELD=0
+  fm_backend_endpoint_lock_release
+}
 spawn_send_text_line() {  # <target> <text>
+  local target=$1 rc=0
+  spawn_endpoint_lock_acquire "$target" || return 1
   case "$BACKEND" in
-    tmux) fm_backend_tmux_send_text_line "$1" "$2" ;;
-    herdr) fm_backend_herdr_send_text_line "$1" "$2" ;;
-    zellij) fm_backend_zellij_send_text_line "$1" "$2" "$W" ;;
-    orca) fm_backend_orca_send_text_line "$1" "$2" ;;
-    cmux) fm_backend_cmux_send_text_line "$1" "$2" "$W" ;;
+    tmux) fm_backend_tmux_send_text_line "$1" "$2" || rc=$? ;;
+    herdr) fm_backend_herdr_send_text_line "$1" "$2" || rc=$? ;;
+    zellij) fm_backend_zellij_send_text_line "$1" "$2" "$W" || rc=$? ;;
+    orca) fm_backend_orca_send_text_line "$1" "$2" || rc=$? ;;
+    cmux) fm_backend_cmux_send_text_line "$1" "$2" "$W" || rc=$? ;;
   esac
+  spawn_endpoint_lock_release
+  return "$rc"
 }
 spawn_current_path() {  # <target>
+  local target=$1 rc=0 path
+  spawn_endpoint_lock_acquire "$target" || return 1
   case "$BACKEND" in
-    tmux) fm_backend_tmux_current_path "$1" ;;
-    herdr) fm_backend_herdr_current_path "$1" ;;
-    zellij) fm_backend_zellij_current_path "$1" "$W" ;;
-    cmux) fm_backend_cmux_current_path "$1" "$W" ;;
+    tmux) path=$(fm_backend_tmux_current_path "$target") || rc=$? ;;
+    herdr) path=$(fm_backend_herdr_current_path "$target") || rc=$? ;;
+    zellij) path=$(fm_backend_zellij_current_path "$target" "$W") || rc=$? ;;
+    cmux) path=$(fm_backend_cmux_current_path "$target" "$W") || rc=$? ;;
   esac
+  spawn_endpoint_lock_release
+  [ "$rc" -eq 0 ] || return "$rc"
+  printf '%s\n' "$path"
 }
 spawn_send_literal() {  # <target> <text>
   case "$BACKEND" in
@@ -2730,6 +2754,10 @@ if [ -n "$SPAWN_TRACEPARENT" ]; then
   fi
 fi
 sleep 0.3
+spawn_endpoint_lock_acquire "$T" || {
+  echo "error: could not lock $W's endpoint before launch submission" >&2
+  exit 1
+}
 spawn_send_literal "$T" "$LAUNCH"
 sleep 0.3
 if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
@@ -2737,6 +2765,7 @@ if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
   spawn_herdr_presentation_order_lock_release
 fi
 spawn_send_key "$T" Enter
+spawn_endpoint_lock_release
 if [ "$HARNESS" = kimi ]; then
   if ! kimi_wait_for_ready; then
     kimi_spawn_fail "kimi did not show a verified ready signal before brief delivery"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2076,12 +2076,13 @@ spawn_endpoint_lock_release() {
 spawn_send_text_line() {  # <target> <text>
   local target=$1 rc=0
   spawn_endpoint_lock_acquire "$target" || return 1
+  target=$FM_BACKEND_ENDPOINT_TARGET
   case "$BACKEND" in
-    tmux) fm_backend_tmux_send_text_line "$1" "$2" || rc=$? ;;
-    herdr) fm_backend_herdr_send_text_line "$1" "$2" || rc=$? ;;
-    zellij) fm_backend_zellij_send_text_line "$1" "$2" "$W" || rc=$? ;;
-    orca) fm_backend_orca_send_text_line "$1" "$2" || rc=$? ;;
-    cmux) fm_backend_cmux_send_text_line "$1" "$2" "$W" || rc=$? ;;
+    tmux) fm_backend_tmux_send_text_line "$target" "$2" || rc=$? ;;
+    herdr) fm_backend_herdr_send_text_line "$target" "$2" || rc=$? ;;
+    zellij) fm_backend_zellij_send_text_line "$target" "$2" "$W" || rc=$? ;;
+    orca) fm_backend_orca_send_text_line "$target" "$2" || rc=$? ;;
+    cmux) fm_backend_cmux_send_text_line "$target" "$2" "$W" || rc=$? ;;
   esac
   spawn_endpoint_lock_release
   return "$rc"
@@ -2089,6 +2090,7 @@ spawn_send_text_line() {  # <target> <text>
 spawn_current_path() {  # <target>
   local target=$1 rc=0 path
   spawn_endpoint_lock_acquire "$target" || return 1
+  target=$FM_BACKEND_ENDPOINT_TARGET
   case "$BACKEND" in
     tmux) path=$(fm_backend_tmux_current_path "$target") || rc=$? ;;
     herdr) path=$(fm_backend_herdr_current_path "$target") || rc=$? ;;
@@ -2758,13 +2760,14 @@ spawn_endpoint_lock_acquire "$T" || {
   echo "error: could not lock $W's endpoint before launch submission" >&2
   exit 1
 }
-spawn_send_literal "$T" "$LAUNCH"
+LAUNCH_TARGET=$FM_BACKEND_ENDPOINT_TARGET
+spawn_send_literal "$LAUNCH_TARGET" "$LAUNCH"
 sleep 0.3
 if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
   HERDR_PROJECTION_ABORT_CLEANUP=0
   spawn_herdr_presentation_order_lock_release
 fi
-spawn_send_key "$T" Enter
+spawn_send_key "$LAUNCH_TARGET" Enter
 spawn_endpoint_lock_release
 if [ "$HARNESS" = kimi ]; then
   if ! kimi_wait_for_ready; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2074,28 +2074,30 @@ spawn_endpoint_lock_release() {
   fm_backend_endpoint_lock_release
 }
 spawn_send_text_line() {  # <target> <text>
-  local target=$1 rc=0
+  local target=$1 operation_label=$W rc=0
   spawn_endpoint_lock_acquire "$target" || return 1
   target=$FM_BACKEND_ENDPOINT_TARGET
+  [ "$BACKEND" != cmux ] || operation_label=
   case "$BACKEND" in
     tmux) fm_backend_tmux_send_text_line "$target" "$2" || rc=$? ;;
     herdr) fm_backend_herdr_send_text_line "$target" "$2" || rc=$? ;;
-    zellij) fm_backend_zellij_send_text_line "$target" "$2" "$W" || rc=$? ;;
+    zellij) fm_backend_zellij_send_text_line "$target" "$2" "$operation_label" || rc=$? ;;
     orca) fm_backend_orca_send_text_line "$target" "$2" || rc=$? ;;
-    cmux) fm_backend_cmux_send_text_line "$target" "$2" "$W" || rc=$? ;;
+    cmux) fm_backend_cmux_send_text_line "$target" "$2" "$operation_label" || rc=$? ;;
   esac
   spawn_endpoint_lock_release
   return "$rc"
 }
 spawn_current_path() {  # <target>
-  local target=$1 rc=0 path
+  local target=$1 operation_label=$W rc=0 path
   spawn_endpoint_lock_acquire "$target" || return 1
   target=$FM_BACKEND_ENDPOINT_TARGET
+  [ "$BACKEND" != cmux ] || operation_label=
   case "$BACKEND" in
     tmux) path=$(fm_backend_tmux_current_path "$target") || rc=$? ;;
     herdr) path=$(fm_backend_herdr_current_path "$target") || rc=$? ;;
-    zellij) path=$(fm_backend_zellij_current_path "$target" "$W") || rc=$? ;;
-    cmux) path=$(fm_backend_cmux_current_path "$target" "$W") || rc=$? ;;
+    zellij) path=$(fm_backend_zellij_current_path "$target" "$operation_label") || rc=$? ;;
+    cmux) path=$(fm_backend_cmux_current_path "$target" "$operation_label") || rc=$? ;;
   esac
   spawn_endpoint_lock_release
   [ "$rc" -eq 0 ] || return "$rc"
@@ -2761,13 +2763,27 @@ spawn_endpoint_lock_acquire "$T" || {
   exit 1
 }
 LAUNCH_TARGET=$FM_BACKEND_ENDPOINT_TARGET
-spawn_send_literal "$LAUNCH_TARGET" "$LAUNCH"
+LAUNCH_LABEL=$W
+[ "$BACKEND" != cmux ] || LAUNCH_LABEL=
+case "$BACKEND" in
+  tmux) fm_backend_tmux_send_literal "$LAUNCH_TARGET" "$LAUNCH" ;;
+  herdr) fm_backend_herdr_send_literal "$LAUNCH_TARGET" "$LAUNCH" ;;
+  zellij) fm_backend_zellij_send_literal "$LAUNCH_TARGET" "$LAUNCH" "$LAUNCH_LABEL" ;;
+  orca) fm_backend_orca_send_literal "$LAUNCH_TARGET" "$LAUNCH" ;;
+  cmux) fm_backend_cmux_send_literal "$LAUNCH_TARGET" "$LAUNCH" "$LAUNCH_LABEL" ;;
+esac
 sleep 0.3
 if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
   HERDR_PROJECTION_ABORT_CLEANUP=0
   spawn_herdr_presentation_order_lock_release
 fi
-spawn_send_key "$LAUNCH_TARGET" Enter
+case "$BACKEND" in
+  tmux) fm_backend_tmux_send_key "$LAUNCH_TARGET" Enter ;;
+  herdr) fm_backend_herdr_send_key "$LAUNCH_TARGET" Enter ;;
+  zellij) fm_backend_zellij_send_key "$LAUNCH_TARGET" Enter "$LAUNCH_LABEL" ;;
+  orca) fm_backend_orca_send_key "$LAUNCH_TARGET" Enter ;;
+  cmux) fm_backend_cmux_send_key "$LAUNCH_TARGET" Enter "$LAUNCH_LABEL" ;;
+esac
 spawn_endpoint_lock_release
 if [ "$HARNESS" = kimi ]; then
   if ! kimi_wait_for_ready; then

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -156,6 +156,8 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 
 # shellcheck source=bin/fm-backend.sh
 . "$FM_DAEMON_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-checked-submit-lib.sh
+. "$FM_DAEMON_DIR/fm-checked-submit-lib.sh"
 
 # Canonical construction and parsing for every Firstmate operational input.
 # shellcheck source=bin/fm-operational-input.sh
@@ -1114,7 +1116,7 @@ window_for_task() {  # <task-key> [state]
 #     line, or a previous injection's unsent text), defer entirely - injecting
 #     would merge with the human's text.
 inject_msg() {  # <message> [state]
-  local msg=$1 state target backend retries sleep_s verdict composer encoded
+  local msg=$1 state target backend retries sleep_s verdict encoded
   state="${2:-$(_state_root)}"
   # (1) Presence-gate: inject ONLY when afk is active. When afk is off, the
   # daemon self-handles and stays quiet; firstmate drives the normal always-on
@@ -1149,11 +1151,6 @@ inject_msg() {  # <message> [state]
   #      target - typing the escalation into a shell could execute it - so defer
   #      on anything that is not affirmatively 'empty'. A deferred escalation
   #      stays buffered for the next cycle or the catch-up flush.
-  composer=$(fm_backend_composer_state "$backend" "$target" 2>/dev/null)
-  if [ "$composer" != empty ]; then
-    log "inject deferred: supervisor composer not confirmed-empty (state=${composer:-unknown}: pending input, dead-shell prompt, or unreadable pane)"
-    return 1
-  fi
   # (4) Type the digest ONCE, then submit with Enter (retry Enter only, never
   # retype) via the shared submit primitive. Success = the backend confirms
   # submit. An unconfirmed/unknown pane does NOT count as delivered, so the
@@ -1163,10 +1160,19 @@ inject_msg() {  # <message> [state]
   # re-export of fm_tmux_submit_core - byte-identical to calling it directly.
   retries=${FM_INJECT_CONFIRM_RETRIES:-$INJECT_CONFIRM_RETRIES_DEFAULT}
   sleep_s=${FM_INJECT_CONFIRM_SLEEP:-$INJECT_CONFIRM_SLEEP_DEFAULT}
-  verdict=$(fm_backend_send_text_submit "$backend" "$target" "$msg" "$retries" "$sleep_s" "$sleep_s")
+  if ! command -v fm_lock_acquire_wait >/dev/null 2>&1; then
+    FM_STATE_OVERRIDE="$state" . "$FM_DAEMON_DIR/fm-wake-lib.sh"
+  fi
+  verdict=$(fm_backend_checked_send_text_submit "$backend" "$target" "$msg" "$retries" "$sleep_s" "$sleep_s")
   if [ "$verdict" = empty ]; then
     return 0  # Backend confirmed the submit.
   fi
+  case "$verdict" in
+    composer-*)
+      log "inject deferred: supervisor composer not confirmed-empty (state=${verdict#composer-}: pending input, dead-shell prompt, or unreadable pane)"
+      return 1
+      ;;
+  esac
   log "inject failed: submit unconfirmed after $retries retries (verdict=$verdict, text may be in composer)"
   return 1
 }

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -1161,6 +1161,7 @@ inject_msg() {  # <message> [state]
   retries=${FM_INJECT_CONFIRM_RETRIES:-$INJECT_CONFIRM_RETRIES_DEFAULT}
   sleep_s=${FM_INJECT_CONFIRM_SLEEP:-$INJECT_CONFIRM_SLEEP_DEFAULT}
   if ! command -v fm_lock_acquire_wait >/dev/null 2>&1; then
+    # shellcheck source=bin/fm-wake-lib.sh
     FM_STATE_OVERRIDE="$state" . "$FM_DAEMON_DIR/fm-wake-lib.sh"
   fi
   verdict=$(fm_backend_checked_send_text_submit "$backend" "$target" "$msg" "$retries" "$sleep_s" "$sleep_s")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,12 +84,14 @@ In away mode, seen-status dedupe does not clear possible-wedge aging for nonterm
 The daemon escalates captain-relevant events, plus a bounded recheck for a declared pause that remains idle, as one batched, single-line digest using the canonical `away-supervisor` kind from `bin/fm-operational-input.sh` so firstmate can distinguish it structurally from real messages.
 Its supervisor injection path supports tmux and herdr panes, with `FM_SUPERVISOR_BACKEND` and `FM_SUPERVISOR_TARGET` resolved independently from the task-spawn backend.
 Pane existence, busy checks, composer checks, capture, and verified submit route through `bin/fm-backend.sh`: tmux keeps the same submit core used by the tmux send backend, while herdr uses native busy state and native agent-state submit confirmation on idle baselines.
+`bin/fm-checked-submit-lib.sh` serializes local composer mutations by resolved endpoint identity across homes and revalidates that identity after acquiring the lock, so a concurrent send, interrupt, launch, or supervisor injection cannot interleave with another mutation of the same composer.
 The tmux submit core treats a busy pane plus retries-exhausted plus composer-still-pending as a queued Enter because OpenCode 1.18.4 accepts Enter mid-turn and queues it for after the turn, reported as `empty` so the daemon and `fm-send` do not re-send.
 An idle pane keeps the `pending` verdict as a genuine swallow.
 The same OpenCode busy-queue case is a known gap on the herdr adapter and is recorded in `docs/herdr-backend.md` rather than patched here.
 Composer classification has one shared owner, `bin/fm-composer-lib.sh`: tmux, herdr, Zellij, Orca, and cmux contribute only a screen capture plus declarative styled, cursor, identity, and row capabilities, while the shared classifier owns every shape and the `empty`/`pending`/`pending-unproven`/`unknown` verdict.
 `fm-spawn.sh` also routes Kimi launch readiness through that classifier instead of carrying another shape copy.
 The daemon injects only into an affirmatively `empty` composer, so every other or future verdict defers; positive container proof is required, and a blank unidentified row or bare dead-shell prompt cannot receive an escalation.
+The `fm-send.sh` header owns its stronger user-facing delivery contract, including the empty-composer preflight that prevents a parked draft from being combined with a new steer.
 The current operator boundary is in [Composer and injection safety](herdr-backend.md#composer-and-injection-safety).
 Unsupported supervisor backends refuse at daemon startup.
 Stalled escalation delivery writes `state/.subsuper-inject-wedged` and attempts a configured backend-independent active alert after `FM_MAX_DEFER_SECS` instead of silently deferring forever.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -51,6 +51,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | [`fm-project-origin-lib.sh`](../bin/fm-project-origin-lib.sh) | Accepted origin-form owner shared by both remote provisioning boundaries |
 | `fm-spawn.sh`            | Spawn crewmates, scouts, `id=repo` batches, and secondmates on the resolved harness and runtime backend |
 | `fm-backend.sh`          | Runtime-backend selection, meta helpers, selector resolution, and operation dispatch |
+| `fm-checked-submit-lib.sh` | Shared endpoint-identity locking for composer-mutating backend operations           |
 | `fm-backend-hometag-lib.sh` | Shared per-installation home-tag derivation for zellij tab and cmux workspace titles |
 | `fm-composer-lib.sh`     | Single fleet-wide owner of composer shapes, capability-aware screen classification, and verdicts |
 | `backends/tmux.sh`       | Verified tmux session-provider adapter                                               |

--- a/tests/fm-backend-cmux.test.sh
+++ b/tests/fm-backend-cmux.test.sh
@@ -623,6 +623,25 @@ test_send_key_recovers_stale_target_by_label() {
   pass "fm_backend_cmux_send_key: recovers stale workspace/surface ids by expected label"
 }
 
+test_serialized_send_key_recovers_stale_target_by_label() {
+  local dir fb title
+  dir="$TMP_ROOT/serialized-sendkey-stale-target"; mkdir -p "$dir/responses"
+  title=$(cmux_expected_scoped_title fm-label)
+  cmux_workspace_list_response "$dir" 1 "cccccccc-2222-2222-2222-222222222222" "$title"
+  cmux_workspace_list_response "$dir" 2 "cccccccc-2222-2222-2222-222222222222" "$title"
+  cmux_panes_response "$dir" 3 "dddddddd-3333-3333-3333-333333333333"
+  cmux_workspace_list_response "$dir" 4 "cccccccc-2222-2222-2222-222222222222" "$title"
+  cmux_workspace_list_response "$dir" 5 "cccccccc-2222-2222-2222-222222222222" "$title"
+  cmux_panes_response "$dir" 6 "dddddddd-3333-3333-3333-333333333333"
+  fb=$(make_cmux_fakebin "$dir")
+  PATH="$fb:$PATH" FM_CMUX_LOG="$dir/log" FM_CMUX_RESPONSES="$dir/responses" \
+    bash -c '. "$0/bin/fm-backend.sh"; fm_backend_send_key cmux "aaaaaaaa-0000-0000-0000-000000000000:bbbbbbbb-1111-1111-1111-111111111111" Enter fm-label' "$ROOT"
+  expect_code 0 $? "serialized send_key should recover a stale cmux target when the expected label is live"
+  assert_contains "$(cat "$dir/log")" $'\x1f''send-key'$'\x1f''--workspace'$'\x1f''cccccccc-2222-2222-2222-222222222222'$'\x1f''--surface'$'\x1f''dddddddd-3333-3333-3333-333333333333'$'\x1f''enter' \
+    "serialized send_key did not use the refreshed cmux workspace/surface ids"
+  pass "fm_backend_send_key: locking preserves cmux stale-target label recovery"
+}
+
 test_send_literal_uses_separator_for_option_shaped_text() {
   local dir fb
   dir="$TMP_ROOT/sendliteral"; mkdir -p "$dir/responses"
@@ -1138,6 +1157,7 @@ test_capture_fails_when_read_screen_fails_empty
 test_capture_fails_when_target_not_ready
 test_send_key_normalizes_and_targets
 test_send_key_recovers_stale_target_by_label
+test_serialized_send_key_recovers_stale_target_by_label
 test_send_literal_uses_separator_for_option_shaped_text
 test_send_text_line_clears_partial_input_when_enter_fails
 test_send_text_line_reports_unsafe_input_when_cleanup_fails

--- a/tests/fm-backend-cmux.test.sh
+++ b/tests/fm-backend-cmux.test.sh
@@ -633,6 +633,7 @@ test_serialized_send_key_recovers_stale_target_by_label() {
   cmux_workspace_list_response "$dir" 4 "cccccccc-2222-2222-2222-222222222222" "$title"
   cmux_workspace_list_response "$dir" 5 "cccccccc-2222-2222-2222-222222222222" "$title"
   cmux_panes_response "$dir" 6 "dddddddd-3333-3333-3333-333333333333"
+  cmux_panes_response "$dir" 7 "dddddddd-3333-3333-3333-333333333333"
   fb=$(make_cmux_fakebin "$dir")
   PATH="$fb:$PATH" FM_CMUX_LOG="$dir/log" FM_CMUX_RESPONSES="$dir/responses" \
     bash -c '. "$0/bin/fm-backend.sh"; fm_backend_send_key cmux "aaaaaaaa-0000-0000-0000-000000000000:bbbbbbbb-1111-1111-1111-111111111111" Enter fm-label' "$ROOT"

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -729,13 +729,14 @@ test_peek_send_and_crew_state_route_through_orca_meta() {
     FM_ROOT_OVERRIDE="$neutral" FM_STATE_OVERRIDE="$state" FM_SEND_SETTLE=0 \
     "$ROOT/bin/fm-peek.sh" "fm-$id" 10 )
   [ "$out" = ready ] || fail "fm-peek should read through Orca metadata, got '$out'"
-  printf '{"ok":true,"result":{"send":{"handle":"term-io","accepted":true}}}\n' > "$RESP/2.out"
+  printf '{"ok":true,"result":{"terminal":{"tail":["╭───╮","│ > │","╰───╯"]}}}\n' > "$RESP/2.out"
   printf '{"ok":true,"result":{"send":{"handle":"term-io","accepted":true}}}\n' > "$RESP/3.out"
-  printf '{"ok":true,"result":{"terminal":{"tail":["│ > │"]}}}\n' > "$RESP/4.out"
+  printf '{"ok":true,"result":{"send":{"handle":"term-io","accepted":true}}}\n' > "$RESP/4.out"
+  printf '{"ok":true,"result":{"terminal":{"tail":["╭───╮","│ > │","╰───╯"]}}}\n' > "$RESP/5.out"
   PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     FM_ROOT_OVERRIDE="$neutral" FM_HOME="$neutral" FM_STATE_OVERRIDE="$state" FM_SEND_SETTLE=0 \
     "$ROOT/bin/fm-send.sh" "fm-$id" "hello orca"
-  printf '{"ok":true,"result":{"terminal":{"tail":["idle prompt"]}}}\n' > "$RESP/5.out"
+  printf '{"ok":true,"result":{"terminal":{"tail":["idle prompt"]}}}\n' > "$RESP/6.out"
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" "$ROOT/bin/fm-crew-state.sh" "$id" )
   assert_contains "$out" "state: unknown" "crew-state should fall back cleanly for an idle Orca scout"

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -168,7 +168,7 @@ test_stale_diagnostic_wedge_survives_busy_housekeeping() {
 
     (
       kill() { printf 'kill %s\n' "$*" >> "$action_log"; }
-      fm_backend_send_text_submit() { printf 'interrupt %s\n' "$*" >> "$action_log"; }
+      fm_backend_send_text_submit_unlocked() { printf 'interrupt %s\n' "$*" >> "$action_log"; }
       LOG="$dir/daemon.log" FM_STATE_OVERRIDE="$state" handle_wake "$reason" "$state"
       PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$win" FM_FAKE_TMUX_CAPTURE="$pane" \
         FM_STATE_OVERRIDE="$state" FM_ESCALATE_BATCH_SECS=999999 housekeeping "$state"
@@ -1732,7 +1732,7 @@ test_inject_msg_herdr_busy_guard_defers() {
     fm_backend_target_exists() { [ "$1" = herdr ] && [ "$2" = "default:w1:p2" ] || fail "unexpected target_exists args: $1 $2"; return 0; }
     pane_is_busy() { return 0; }
     fm_backend_composer_state() { fail "composer_state should not be consulted once the busy-guard already deferred"; }
-    fm_backend_send_text_submit() { fail "send_text_submit should not run when the busy-guard defers"; }
+    fm_backend_send_text_submit_unlocked() { fail "send_text_submit should not run when the busy-guard defers"; }
     if FM_SUPERVISOR_BACKEND=herdr FM_SUPERVISOR_TARGET="default:w1:p2" inject_msg "hello" "$state"; then
       fail "inject_msg should defer (return non-zero) when the herdr supervisor pane is busy"
     fi
@@ -1749,7 +1749,7 @@ test_inject_msg_herdr_composer_guard_defers() {
     fm_backend_target_exists() { return 0; }
     pane_is_busy() { return 1; }
     fm_backend_composer_state() { [ "$1" = herdr ] && [ "$2" = "default:w1:p2" ] || fail "unexpected composer_state args: $1 $2"; printf 'pending'; }
-    fm_backend_send_text_submit() { fail "send_text_submit should not run when the composer-guard defers"; }
+    fm_backend_send_text_submit_unlocked() { fail "send_text_submit should not run when the composer-guard defers"; }
     if FM_SUPERVISOR_BACKEND=herdr FM_SUPERVISOR_TARGET="default:w1:p2" inject_msg "hello" "$state"; then
       fail "inject_msg should defer when the herdr composer has pending input"
     fi
@@ -1765,7 +1765,7 @@ test_inject_msg_herdr_pane_gone_defers() {
   (
     fm_backend_target_exists() { return 1; }
     pane_is_busy() { fail "busy guard should not be consulted once the pane-exists check already failed"; }
-    fm_backend_send_text_submit() { fail "send_text_submit should not run when the pane does not exist"; }
+    fm_backend_send_text_submit_unlocked() { fail "send_text_submit should not run when the pane does not exist"; }
     if FM_SUPERVISOR_BACKEND=herdr FM_SUPERVISOR_TARGET="default:w1:gone" inject_msg "hello" "$state"; then
       fail "inject_msg should defer when the herdr target does not exist"
     fi
@@ -1782,7 +1782,7 @@ test_inject_msg_herdr_submits_through_backend_dispatch() {
     fm_backend_target_exists() { return 0; }
     pane_is_busy() { return 1; }
     fm_backend_composer_state() { printf 'empty'; }
-    fm_backend_send_text_submit() {
+    fm_backend_send_text_submit_unlocked() {
       [ "$1" = herdr ] && [ "$2" = "default:w1:p2" ] || fail "unexpected send_text_submit args: $1 $2"
       case "$3" in *"hello"*) : ;; *) fail "digest text missing from send_text_submit: $3" ;; esac
       printf 'empty'
@@ -1807,7 +1807,7 @@ test_inject_msg_defers_on_dead_shell_unknown() {
     fm_backend_target_exists() { return 0; }
     pane_is_busy() { return 1; }
     fm_backend_composer_state() { printf 'unknown'; }
-    fm_backend_send_text_submit() { fail "send_text_submit must NOT run when the composer is a dead shell (unknown)"; }
+    fm_backend_send_text_submit_unlocked() { fail "send_text_submit must NOT run when the composer is a dead shell (unknown)"; }
     if FM_SUPERVISOR_BACKEND=herdr FM_SUPERVISOR_TARGET="default:w1:p2" inject_msg "hello" "$state"; then
       fail "inject_msg should defer (never inject) when the composer reads unknown (dead shell / unreadable)"
     fi
@@ -1824,7 +1824,7 @@ test_inject_msg_defers_on_unrecognized_composer_state() {
     fm_backend_target_exists() { return 0; }
     pane_is_busy() { return 1; }
     fm_backend_composer_state() { printf 'future-state'; }
-    fm_backend_send_text_submit() { fail "send_text_submit must not run for an unrecognized composer state"; }
+    fm_backend_send_text_submit_unlocked() { fail "send_text_submit must not run for an unrecognized composer state"; }
     if FM_SUPERVISOR_BACKEND=herdr FM_SUPERVISOR_TARGET="default:w1:p2" inject_msg "hello" "$state"; then
       fail "inject_msg should defer on an unrecognized composer state"
     fi

--- a/tests/fm-gate-refuse.test.sh
+++ b/tests/fm-gate-refuse.test.sh
@@ -273,7 +273,7 @@ test_send_refuses_and_admits() {
   expect_code 0 "$rc" "send: a normal session must still send"
   assert_not_contains "$out" "$ENV_MSG" "send: normal send must not print the gate refusal"
   assert_not_contains "$out" "$PATH_MSG" "send: normal send must not print the backstop refusal"
-  assert_contains "$(cat "$log")" "target=sess:fm-lane-ok literal=1 arg=hello captain" "send: normal send should type the text"
+  assert_contains "$(cat "$log")" "target=%1 literal=1 arg=hello captain" "send: normal send should type the text through the locked canonical pane"
   pass "fm-send: refuses on marker and gate-worktree backstop; a normal steer is unaffected"
 }
 

--- a/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
@@ -79,13 +79,19 @@ case "\${1:-}" in
     case "\$*" in
       *'#{pane_current_path}'*) cut -d'|' -f2- "\$state" ;;
       *'#{pane_current_command}'*) printf 'codex\n' ;;
-      *'#{cursor_y}'*) printf '0\n' ;;
+      *'#{cursor_y}'*) printf '1\n' ;;
       *'#S'*) printf 'firstmate\n' ;;
       *) printf '%%1\n' ;;
     esac
     exit 0
     ;;
-  capture-pane) printf '❯\n'; exit 0 ;;
+  capture-pane)
+    case "\$*" in
+      *'-S 1 -E 1'*) printf '│    │\n' ;;
+      *) printf '╭────╮\n│    │\n╰────╯\n' ;;
+    esac
+    exit 0
+    ;;
   send-keys) [ ! -f "\$fail_send" ] || exit 1; exit 0 ;;
   kill-window) rm -f -- "\$state"; exit 0 ;;
   list-panes) printf 'codex\n'; exit 0 ;;

--- a/tests/fm-send-popup-settle.test.sh
+++ b/tests/fm-send-popup-settle.test.sh
@@ -51,7 +51,7 @@ case "${1:-}" in
   send-keys) exit 0 ;;
   display-message)
     for a in "$@"; do case "$a" in *cursor_y*) printf '1\n'; exit 0 ;; esac; done
-    printf 'fakepane\n'; exit 0 ;;
+    printf '%%1\n'; exit 0 ;;
   capture-pane) printf '╭────╮\n│    │\n╰────╯\n'; exit 0 ;;
   list-windows) exit 0 ;;
 esac

--- a/tests/fm-send-settle.test.sh
+++ b/tests/fm-send-settle.test.sh
@@ -39,7 +39,7 @@ case "${1:-}" in
   send-keys) exit 0 ;;
   display-message)
     for a in "$@"; do case "$a" in *cursor_y*) printf '1\n'; exit 0 ;; esac; done
-    printf 'fakepane\n'; exit 0 ;;
+    printf '%%1\n'; exit 0 ;;
   capture-pane) printf '╭────╮\n│    │\n╰────╯\n'; exit 0 ;;
   list-windows) exit 0 ;;
 esac

--- a/tests/fm-send-strict.test.sh
+++ b/tests/fm-send-strict.test.sh
@@ -41,6 +41,17 @@ case "${1:-}" in
     fi
     if [ -n "${FM_FAKE_TMUX_COMPOSER:-}" ]; then
       if [ "$literal" = 1 ]; then
+        if [ -n "${FM_FAKE_TMUX_TYPE_HOLD:-}" ]; then
+          if mkdir "$FM_FAKE_TMUX_TYPE_HOLD.active" 2>/dev/null; then
+            : > "$FM_FAKE_TMUX_TYPE_HOLD.started"
+            while [ ! -e "$FM_FAKE_TMUX_TYPE_HOLD.release" ]; do
+              /bin/sleep 0.01
+            done
+            rmdir "$FM_FAKE_TMUX_TYPE_HOLD.active"
+          else
+            : > "$FM_FAKE_TMUX_TYPE_HOLD.overlap"
+          fi
+        fi
         printf '╭──────────────────────────────╮\n│ > %-27.27s│\n╰──────────────────────────────╯\n' "${1:-}" > "$FM_FAKE_TMUX_COMPOSER"
         [ "${FM_FAKE_TMUX_SWALLOW_ENTER:-0}" != 1 ] || printf 'esc to interrupt\n' >> "$FM_FAKE_TMUX_COMPOSER"
       elif [ "${1:-}" = Enter ]; then
@@ -272,6 +283,41 @@ test_busy_queue_confirmation_survives_empty_preflight() {
   pass "fm-send delivery: empty preflight preserves proven busy-queue acceptance"
 }
 
+test_concurrent_sends_serialize_per_endpoint() {
+  local dir fb home log composer hold first_pid second_pid first_rc second_rc i
+  dir="$TMP_ROOT/concurrent-sends"; mkdir -p "$dir"
+  fb=$(make_stubs "$dir"); home=$(setup_home concurrent); log="$dir/tmux.log"; composer="$dir/composer"; hold="$dir/type-hold"
+  : > "$log"
+  printf '╭────╮\n│    │\n╰────╯\n' > "$composer"
+  fm_write_meta "$home/state/shared-codex.meta" "window=sess:fm-shared-codex" "kind=ship" "harness=codex"
+
+  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" FM_TMUX_LOG="$log" \
+    FM_FAKE_TMUX_COMPOSER="$composer" FM_FAKE_TMUX_TYPE_HOLD="$hold" FM_SEND_SETTLE=0 \
+    "$SEND" shared-codex "first intended steer" >/dev/null 2>"$dir/first.err" &
+  first_pid=$!
+  for i in $(seq 1 1000); do
+    [ ! -e "$hold.started" ] || break
+    /bin/sleep 0.01
+  done
+  [ -e "$hold.started" ] || fail "the first concurrent send never reached the held type boundary: $(cat "$dir/first.err")"
+
+  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" FM_TMUX_LOG="$log" \
+    FM_FAKE_TMUX_COMPOSER="$composer" FM_FAKE_TMUX_TYPE_HOLD="$hold" FM_SEND_SETTLE=0 \
+    "$SEND" shared-codex "second intended steer" >/dev/null 2>"$dir/second.err" &
+  second_pid=$!
+  /bin/sleep 0.1
+  : > "$hold.release"
+  wait "$first_pid"; first_rc=$?
+  wait "$second_pid"; second_rc=$?
+
+  expect_code 0 "$first_rc" "the first serialized send should succeed"
+  expect_code 0 "$second_rc" "the second serialized send should succeed"
+  [ ! -e "$hold.overlap" ] || fail "two sends entered the shared endpoint type boundary concurrently"
+  [ "$(grep -c 'literal=1 arg=.* intended steer' "$log")" -eq 2 ] \
+    || fail "serialized sends did not each type exactly once: $(cat "$log")"
+  pass "fm-send delivery: concurrent text sends serialize per resolved endpoint"
+}
+
 # A --key send is how firstmate interrupts a worker, so its exit status is the
 # only signal that the interrupt actually landed.
 # Reporting success for a key that was never delivered would leave supervision
@@ -305,6 +351,7 @@ test_key_send_exit_status_follows_delivery
 test_stale_composer_refuses_before_typing
 test_empty_composer_delivers_intended_text_once
 test_busy_queue_confirmation_survives_empty_preflight
+test_concurrent_sends_serialize_per_endpoint
 test_unset_fm_home_fails
 test_unresolvable_target_does_not_tmux_fallback
 test_prefixless_herdr_pane_id_fails

--- a/tests/fm-send-strict.test.sh
+++ b/tests/fm-send-strict.test.sh
@@ -306,7 +306,7 @@ test_concurrent_sends_serialize_per_endpoint() {
 
   PATH="$fb:$PATH" TMPDIR="$second_tmp" FM_HOME="$second_home" FM_ROOT_OVERRIDE="$second_home" FM_TMUX_LOG="$log" \
     FM_FAKE_TMUX_COMPOSER="$composer" FM_FAKE_TMUX_TYPE_HOLD="$hold" FM_SEND_SETTLE=0 \
-    bash -c '. "$1/bin/fm-backend.sh"; . "$1/bin/fm-wake-lib.sh"; . "$1/bin/fm-checked-submit-lib.sh"; [ "$(fm_backend_checked_send_text_submit tmux "$2" "second intended steer" 3 0 0)" = empty ]' \
+    bash -c '. "$1/bin/fm-backend.sh"; [ "$(fm_backend_send_text_submit tmux "$2" "second intended steer" 3 0 0)" = empty ]' \
       _ "$ROOT" "$endpoint" >/dev/null 2>"$dir/second.err" &
   second_pid=$!
   /bin/sleep 0.1

--- a/tests/fm-send-strict.test.sh
+++ b/tests/fm-send-strict.test.sh
@@ -284,14 +284,16 @@ test_busy_queue_confirmation_survives_empty_preflight() {
 }
 
 test_concurrent_sends_serialize_per_endpoint() {
-  local dir fb home log composer hold first_pid second_pid first_rc second_rc i
+  local dir fb first_home second_home lock_namespace log composer hold first_pid second_pid first_rc second_rc i
   dir="$TMP_ROOT/concurrent-sends"; mkdir -p "$dir"
-  fb=$(make_stubs "$dir"); home=$(setup_home concurrent); log="$dir/tmux.log"; composer="$dir/composer"; hold="$dir/type-hold"
+  fb=$(make_stubs "$dir"); first_home=$(setup_home concurrent-first); second_home=$(setup_home concurrent-second)
+  lock_namespace="$dir/send-locks"; log="$dir/tmux.log"; composer="$dir/composer"; hold="$dir/type-hold"
   : > "$log"
   printf '╭────╮\n│    │\n╰────╯\n' > "$composer"
-  fm_write_meta "$home/state/shared-codex.meta" "window=sess:fm-shared-codex" "kind=ship" "harness=codex"
+  fm_write_meta "$first_home/state/shared-codex.meta" "window=sess:fm-shared-codex" "kind=ship" "harness=codex"
 
-  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" FM_TMUX_LOG="$log" \
+  PATH="$fb:$PATH" FM_HOME="$first_home" FM_ROOT_OVERRIDE="$first_home" FM_TMUX_LOG="$log" \
+    FM_SEND_LOCK_NAMESPACE="$lock_namespace" \
     FM_FAKE_TMUX_COMPOSER="$composer" FM_FAKE_TMUX_TYPE_HOLD="$hold" FM_SEND_SETTLE=0 \
     "$SEND" shared-codex "first intended steer" >/dev/null 2>"$dir/first.err" &
   first_pid=$!
@@ -301,7 +303,8 @@ test_concurrent_sends_serialize_per_endpoint() {
   done
   [ -e "$hold.started" ] || fail "the first concurrent send never reached the held type boundary: $(cat "$dir/first.err")"
 
-  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" FM_TMUX_LOG="$log" \
+  PATH="$fb:$PATH" FM_HOME="$second_home" FM_ROOT_OVERRIDE="$second_home" FM_TMUX_LOG="$log" \
+    FM_SEND_LOCK_NAMESPACE="$lock_namespace" \
     FM_FAKE_TMUX_COMPOSER="$composer" FM_FAKE_TMUX_TYPE_HOLD="$hold" FM_SEND_SETTLE=0 \
     "$SEND" sess:fm-shared-codex "second intended steer" >/dev/null 2>"$dir/second.err" &
   second_pid=$!
@@ -315,7 +318,7 @@ test_concurrent_sends_serialize_per_endpoint() {
   [ ! -e "$hold.overlap" ] || fail "two sends entered the shared endpoint type boundary concurrently"
   [ "$(grep -c 'literal=1 arg=.* intended steer' "$log")" -eq 2 ] \
     || fail "serialized sends did not each type exactly once: $(cat "$log")"
-  pass "fm-send delivery: selector and explicit aliases serialize per resolved endpoint"
+  pass "fm-send delivery: cross-home aliases serialize per resolved endpoint"
 }
 
 # A --key send is how firstmate interrupts a worker, so its exit status is the

--- a/tests/fm-send-strict.test.sh
+++ b/tests/fm-send-strict.test.sh
@@ -39,6 +39,16 @@ case "${1:-}" in
       && [ "${1:-}" = "$FM_FAKE_TMUX_SEND_KEY_FAIL" ]; then
       exit 1
     fi
+    if [ -n "${FM_FAKE_TMUX_COMPOSER:-}" ]; then
+      if [ "$literal" = 1 ]; then
+        printf '╭──────────────────────────────╮\n│ > %-27.27s│\n╰──────────────────────────────╯\n' "${1:-}" > "$FM_FAKE_TMUX_COMPOSER"
+        [ "${FM_FAKE_TMUX_SWALLOW_ENTER:-0}" != 1 ] || printf 'esc to interrupt\n' >> "$FM_FAKE_TMUX_COMPOSER"
+      elif [ "${1:-}" = Enter ]; then
+        if [ "${FM_FAKE_TMUX_SWALLOW_ENTER:-0}" != 1 ]; then
+          printf '╭────╮\n│    │\n╰────╯\n' > "$FM_FAKE_TMUX_COMPOSER"
+        fi
+      fi
+    fi
     exit 0 ;;
   display-message)
     target=
@@ -57,7 +67,12 @@ case "${1:-}" in
     printf '%%1\n'
     exit 0 ;;
   capture-pane)
-    printf '╭────╮\n│    │\n╰────╯\n'
+    printf 'capture-pane\n' >> "$FM_TMUX_LOG"
+    if [ -n "${FM_FAKE_TMUX_COMPOSER:-}" ]; then
+      cat "$FM_FAKE_TMUX_COMPOSER"
+    else
+      printf '╭────╮\n│    │\n╰────╯\n'
+    fi
     exit 0 ;;
   list-windows)
     printf 'foreign:%s\n' "${FM_FAKE_TMUX_WINDOW:-fm-lost}"
@@ -197,6 +212,66 @@ test_healthy_fm_id_send_still_works() {
   pass "fm-send strict: healthy fm-<id> sends still type once and submit"
 }
 
+test_stale_composer_refuses_before_typing() {
+  local dir fb home err log composer rc
+  dir="$TMP_ROOT/stale-composer"; mkdir -p "$dir"
+  fb=$(make_stubs "$dir"); home=$(setup_home stalecomposer); err="$dir/send.err"; log="$dir/tmux.log"; composer="$dir/composer"
+  : > "$log"
+  printf '╭──────────────────────────────╮\n│ > %-27s│\n╰──────────────────────────────╯\n' 'stale instruction' > "$composer"
+  fm_write_meta "$home/state/parked-codex.meta" "window=sess:fm-parked-codex" "kind=ship" "harness=codex"
+
+  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" FM_TMUX_LOG="$log" \
+    FM_FAKE_TMUX_COMPOSER="$composer" FM_SEND_SETTLE=0 \
+    "$SEND" parked-codex "new intended steer" >/dev/null 2>"$err"; rc=$?
+  [ "$rc" -ne 0 ] || fail "a parked Codex lane with stale composer text reported successful delivery"
+  assert_contains "$(cat "$err")" "composer is not empty" "stale-composer refusal should name the unsafe baseline"
+  assert_no_grep 'send-keys .*literal=1' "$log" "stale-composer refusal must not append the intended steer"
+  assert_no_grep 'send-keys .*arg=Enter' "$log" "stale-composer refusal must not submit the stale instruction"
+  assert_contains "$(cat "$composer")" "stale instruction" "stale-composer refusal must preserve the existing draft"
+  pass "fm-send delivery: stale parked-lane composer refuses before typing or submitting"
+}
+
+test_empty_composer_delivers_intended_text_once() {
+  local dir fb home err log composer rc
+  dir="$TMP_ROOT/accepted-delivery"; mkdir -p "$dir"
+  fb=$(make_stubs "$dir"); home=$(setup_home accepted); err="$dir/send.err"; log="$dir/tmux.log"; composer="$dir/composer"
+  : > "$log"
+  printf '╭────╮\n│    │\n╰────╯\n' > "$composer"
+  fm_write_meta "$home/state/ready-codex.meta" "window=sess:fm-ready-codex" "kind=ship" "harness=codex"
+
+  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" FM_TMUX_LOG="$log" \
+    FM_FAKE_TMUX_COMPOSER="$composer" FM_SEND_SETTLE=0 \
+    "$SEND" ready-codex "new intended steer" >/dev/null 2>"$err"; rc=$?
+  expect_code 0 "$rc" "an empty Codex composer should accept the intended steer"
+  [ "$(grep -c 'literal=1 arg=new intended steer' "$log")" -eq 1 ] \
+    || fail "the intended steer was not typed exactly once: $(cat "$log")"
+  [ "$(grep -c 'literal=0 arg=Enter' "$log")" -eq 1 ] \
+    || fail "the intended steer was not submitted exactly once: $(cat "$log")"
+  [ "$(sed -n '2p' "$composer")" = '│    │' ] \
+    || fail "the accepted delivery did not clear the composer: $(cat "$composer")"
+  pass "fm-send delivery: an empty composer accepts the intended steer exactly once"
+}
+
+test_busy_queue_confirmation_survives_empty_preflight() {
+  local dir fb home err log composer rc
+  dir="$TMP_ROOT/busy-queue"; mkdir -p "$dir"
+  fb=$(make_stubs "$dir"); home=$(setup_home busyqueue); err="$dir/send.err"; log="$dir/tmux.log"; composer="$dir/composer"
+  : > "$log"
+  printf '╭────╮\n│    │\n╰────╯\nesc to interrupt\n' > "$composer"
+  fm_write_meta "$home/state/busy-codex.meta" "window=sess:fm-busy-codex" "kind=ship" "harness=codex"
+
+  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" FM_TMUX_LOG="$log" \
+    FM_FAKE_TMUX_COMPOSER="$composer" FM_FAKE_TMUX_SWALLOW_ENTER=1 \
+    FM_SEND_RETRIES=3 FM_SEND_SLEEP=0 FM_SEND_SETTLE=0 \
+    "$SEND" busy-codex "queued intended steer" >/dev/null 2>"$err"; rc=$?
+  expect_code 0 "$rc" "a busy lane should retain the proven queued-Enter confirmation"
+  [ "$(grep -c 'literal=1 arg=queued intended steer' "$log")" -eq 1 ] \
+    || fail "the busy-queued steer was not typed exactly once: $(cat "$log")"
+  [ "$(grep -c 'literal=0 arg=Enter' "$log")" -eq 3 ] \
+    || fail "the busy-queued steer did not consume the Enter retry budget: $(cat "$log")"
+  pass "fm-send delivery: empty preflight preserves proven busy-queue acceptance"
+}
+
 # A --key send is how firstmate interrupts a worker, so its exit status is the
 # only signal that the interrupt actually landed.
 # Reporting success for a key that was never delivered would leave supervision
@@ -227,6 +302,9 @@ test_key_send_exit_status_follows_delivery() {
 
 test_exact_lane_id_send_still_works
 test_key_send_exit_status_follows_delivery
+test_stale_composer_refuses_before_typing
+test_empty_composer_delivers_intended_text_once
+test_busy_queue_confirmation_survives_empty_preflight
 test_unset_fm_home_fails
 test_unresolvable_target_does_not_tmux_fallback
 test_prefixless_herdr_pane_id_fails

--- a/tests/fm-send-strict.test.sh
+++ b/tests/fm-send-strict.test.sh
@@ -287,7 +287,7 @@ test_busy_queue_confirmation_survives_empty_preflight() {
 }
 
 test_concurrent_sends_serialize_per_endpoint() {
-  local dir fb first_home second_home first_tmp second_tmp task endpoint log composer hold first_pid second_pid key_pid first_rc second_rc key_rc i
+  local dir fb first_home second_home first_tmp second_tmp task endpoint log composer hold first_pid second_pid key_pid first_rc second_rc key_rc
   dir="$TMP_ROOT/concurrent-sends"; mkdir -p "$dir"
   fb=$(make_stubs "$dir"); first_home=$(setup_home concurrent-first); second_home=$(setup_home concurrent-second)
   first_tmp="$dir/tmp-first"; second_tmp="$dir/tmp-second"; mkdir -p "$first_tmp" "$second_tmp"
@@ -301,7 +301,7 @@ test_concurrent_sends_serialize_per_endpoint() {
     FM_FAKE_TMUX_COMPOSER="$composer" FM_FAKE_TMUX_TYPE_HOLD="$hold" FM_SEND_SETTLE=0 \
     "$SEND" "$task" "first intended steer" >/dev/null 2>"$dir/first.err" &
   first_pid=$!
-  for i in $(seq 1 1000); do
+  for _ in $(seq 1 1000); do
     [ ! -e "$hold.started" ] || break
     /bin/sleep 0.01
   done

--- a/tests/fm-send-strict.test.sh
+++ b/tests/fm-send-strict.test.sh
@@ -130,8 +130,8 @@ test_exact_lane_id_send_still_works() {
     "$SEND" mpf-lane-m8 "lost dispatch" >/dev/null 2>"$err"; rc=$?
   expect_code 0 "$rc" "exact task id send should succeed when metadata exists"
   got=$(cat "$log")
-  assert_contains "$got" "target=sess:fm-mpf-lane-m8 literal=1 arg=lost dispatch" "exact id should type literal text to the meta target"
-  assert_contains "$got" "target=sess:fm-mpf-lane-m8 literal=0 arg=Enter" "exact id should submit with Enter"
+  assert_contains "$got" "target=%1 literal=1 arg=lost dispatch" "exact id should type literal text to the verified pane"
+  assert_contains "$got" "target=%1 literal=0 arg=Enter" "exact id should submit with Enter to the verified pane"
   pass "fm-send strict: exact task/lane ids resolve through home metadata"
 }
 
@@ -220,8 +220,8 @@ test_healthy_fm_id_send_still_works() {
     "$SEND" fm-lane-ok "hello captain" >/dev/null 2>"$err"; rc=$?
   expect_code 0 "$rc" "healthy fm-id send should succeed"
   got=$(cat "$log")
-  assert_contains "$got" "target=sess:fm-lane-ok literal=1 arg=hello captain" "healthy send should type literal text to the meta target"
-  assert_contains "$got" "target=sess:fm-lane-ok literal=0 arg=Enter" "healthy send should submit with Enter"
+  assert_contains "$got" "target=%1 literal=1 arg=hello captain" "healthy send should type literal text to the verified pane"
+  assert_contains "$got" "target=%1 literal=0 arg=Enter" "healthy send should submit with Enter to the verified pane"
   assert_contains "$(cat "$err")" "requested message WILL still be sent" "fm-send guard banner should keep send-specific continuation wording"
   pass "fm-send strict: healthy fm-<id> sends still type once and submit"
 }
@@ -346,7 +346,7 @@ test_key_send_exit_status_follows_delivery() {
   PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" FM_TMUX_LOG="$log" FM_SEND_SETTLE=0 \
     "$SEND" lane-key --key Escape >/dev/null 2>"$err"; rc=$?
   expect_code 0 "$rc" "a delivered --key interrupt should report success"
-  assert_contains "$(cat "$log")" "target=sess:fm-lane-key literal=0 arg=Escape" "the delivered case should send the named key"
+  assert_contains "$(cat "$log")" "target=%1 literal=0 arg=Escape" "the delivered case should send the named key"
 
   : > "$log"
   PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" FM_TMUX_LOG="$log" FM_SEND_SETTLE=0 \
@@ -354,7 +354,7 @@ test_key_send_exit_status_follows_delivery() {
     "$SEND" lane-key --key Escape >/dev/null 2>"$err"; rc=$?
   [ "$rc" -ne 0 ] || fail "an undelivered --key interrupt reported success"
   assert_contains "$(cat "$err")" "key 'Escape' not sent" "the undelivered case should name the key that failed"
-  assert_contains "$(cat "$log")" "target=sess:fm-lane-key literal=0 arg=Escape" "the undelivered case should still have attempted the send"
+  assert_contains "$(cat "$log")" "target=%1 literal=0 arg=Escape" "the undelivered case should still have attempted the send"
   pass "fm-send --key: exit status follows delivery, and an undelivered key never reports success"
 }
 

--- a/tests/fm-send-strict.test.sh
+++ b/tests/fm-send-strict.test.sh
@@ -303,7 +303,7 @@ test_concurrent_sends_serialize_per_endpoint() {
 
   PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" FM_TMUX_LOG="$log" \
     FM_FAKE_TMUX_COMPOSER="$composer" FM_FAKE_TMUX_TYPE_HOLD="$hold" FM_SEND_SETTLE=0 \
-    "$SEND" shared-codex "second intended steer" >/dev/null 2>"$dir/second.err" &
+    "$SEND" sess:fm-shared-codex "second intended steer" >/dev/null 2>"$dir/second.err" &
   second_pid=$!
   /bin/sleep 0.1
   : > "$hold.release"
@@ -315,7 +315,7 @@ test_concurrent_sends_serialize_per_endpoint() {
   [ ! -e "$hold.overlap" ] || fail "two sends entered the shared endpoint type boundary concurrently"
   [ "$(grep -c 'literal=1 arg=.* intended steer' "$log")" -eq 2 ] \
     || fail "serialized sends did not each type exactly once: $(cat "$log")"
-  pass "fm-send delivery: concurrent text sends serialize per resolved endpoint"
+  pass "fm-send delivery: selector and explicit aliases serialize per resolved endpoint"
 }
 
 # A --key send is how firstmate interrupts a worker, so its exit status is the

--- a/tests/fm-send-strict.test.sh
+++ b/tests/fm-send-strict.test.sh
@@ -309,12 +309,12 @@ test_concurrent_sends_serialize_per_endpoint() {
 
   PATH="$fb:$PATH" TMPDIR="$second_tmp" FM_HOME="$second_home" FM_ROOT_OVERRIDE="$second_home" FM_TMUX_LOG="$log" \
     FM_FAKE_TMUX_COMPOSER="$composer" FM_FAKE_TMUX_TYPE_HOLD="$hold" FM_SEND_SETTLE=0 \
-    bash -c '. "$1/bin/fm-backend.sh"; [ "$(fm_backend_send_text_submit tmux "$2" "second intended steer" 3 0 0)" = empty ]' \
+    bash -c '. "$1/bin/fm-backend.sh"; [ "$(fm_backend_send_text_submit tmux "$2.0" "second intended steer" 3 0 0)" = empty ]' \
       _ "$ROOT" "$endpoint" >/dev/null 2>"$dir/second.err" &
   second_pid=$!
   /bin/sleep 0.1
   PATH="$fb:$PATH" TMPDIR="$second_tmp" FM_HOME="$second_home" FM_ROOT_OVERRIDE="$second_home" FM_TMUX_LOG="$log" \
-    FM_FAKE_TMUX_COMPOSER="$composer" "$SEND" "$endpoint" --key C-c >/dev/null 2>"$dir/key.err" &
+    FM_FAKE_TMUX_COMPOSER="$composer" "$SEND" "$endpoint.0" --key C-c >/dev/null 2>"$dir/key.err" &
   key_pid=$!
   : > "$hold.release"
   wait "$first_pid"; first_rc=$?

--- a/tests/fm-send-strict.test.sh
+++ b/tests/fm-send-strict.test.sh
@@ -284,18 +284,19 @@ test_busy_queue_confirmation_survives_empty_preflight() {
 }
 
 test_concurrent_sends_serialize_per_endpoint() {
-  local dir fb first_home second_home lock_namespace log composer hold first_pid second_pid first_rc second_rc i
+  local dir fb first_home second_home first_tmp second_tmp task endpoint log composer hold first_pid second_pid first_rc second_rc i
   dir="$TMP_ROOT/concurrent-sends"; mkdir -p "$dir"
   fb=$(make_stubs "$dir"); first_home=$(setup_home concurrent-first); second_home=$(setup_home concurrent-second)
-  lock_namespace="$dir/send-locks"; log="$dir/tmux.log"; composer="$dir/composer"; hold="$dir/type-hold"
+  first_tmp="$dir/tmp-first"; second_tmp="$dir/tmp-second"; mkdir -p "$first_tmp" "$second_tmp"
+  task="shared-codex-$RANDOM"; endpoint="sess:fm-$task"
+  log="$dir/tmux.log"; composer="$dir/composer"; hold="$dir/type-hold"
   : > "$log"
   printf '╭────╮\n│    │\n╰────╯\n' > "$composer"
-  fm_write_meta "$first_home/state/shared-codex.meta" "window=sess:fm-shared-codex" "kind=ship" "harness=codex"
+  fm_write_meta "$first_home/state/$task.meta" "window=$endpoint" "kind=ship" "harness=codex"
 
-  PATH="$fb:$PATH" FM_HOME="$first_home" FM_ROOT_OVERRIDE="$first_home" FM_TMUX_LOG="$log" \
-    FM_SEND_LOCK_NAMESPACE="$lock_namespace" \
+  PATH="$fb:$PATH" TMPDIR="$first_tmp" FM_HOME="$first_home" FM_ROOT_OVERRIDE="$first_home" FM_TMUX_LOG="$log" \
     FM_FAKE_TMUX_COMPOSER="$composer" FM_FAKE_TMUX_TYPE_HOLD="$hold" FM_SEND_SETTLE=0 \
-    "$SEND" shared-codex "first intended steer" >/dev/null 2>"$dir/first.err" &
+    "$SEND" "$task" "first intended steer" >/dev/null 2>"$dir/first.err" &
   first_pid=$!
   for i in $(seq 1 1000); do
     [ ! -e "$hold.started" ] || break
@@ -303,10 +304,9 @@ test_concurrent_sends_serialize_per_endpoint() {
   done
   [ -e "$hold.started" ] || fail "the first concurrent send never reached the held type boundary: $(cat "$dir/first.err")"
 
-  PATH="$fb:$PATH" FM_HOME="$second_home" FM_ROOT_OVERRIDE="$second_home" FM_TMUX_LOG="$log" \
-    FM_SEND_LOCK_NAMESPACE="$lock_namespace" \
+  PATH="$fb:$PATH" TMPDIR="$second_tmp" FM_HOME="$second_home" FM_ROOT_OVERRIDE="$second_home" FM_TMUX_LOG="$log" \
     FM_FAKE_TMUX_COMPOSER="$composer" FM_FAKE_TMUX_TYPE_HOLD="$hold" FM_SEND_SETTLE=0 \
-    "$SEND" sess:fm-shared-codex "second intended steer" >/dev/null 2>"$dir/second.err" &
+    "$SEND" "$endpoint" "second intended steer" >/dev/null 2>"$dir/second.err" &
   second_pid=$!
   /bin/sleep 0.1
   : > "$hold.release"
@@ -318,7 +318,7 @@ test_concurrent_sends_serialize_per_endpoint() {
   [ ! -e "$hold.overlap" ] || fail "two sends entered the shared endpoint type boundary concurrently"
   [ "$(grep -c 'literal=1 arg=.* intended steer' "$log")" -eq 2 ] \
     || fail "serialized sends did not each type exactly once: $(cat "$log")"
-  pass "fm-send delivery: cross-home aliases serialize per resolved endpoint"
+  pass "fm-send delivery: cross-home aliases and TMPDIRs serialize per resolved endpoint"
 }
 
 # A --key send is how firstmate interrupts a worker, so its exit status is the

--- a/tests/fm-send-strict.test.sh
+++ b/tests/fm-send-strict.test.sh
@@ -306,7 +306,8 @@ test_concurrent_sends_serialize_per_endpoint() {
 
   PATH="$fb:$PATH" TMPDIR="$second_tmp" FM_HOME="$second_home" FM_ROOT_OVERRIDE="$second_home" FM_TMUX_LOG="$log" \
     FM_FAKE_TMUX_COMPOSER="$composer" FM_FAKE_TMUX_TYPE_HOLD="$hold" FM_SEND_SETTLE=0 \
-    "$SEND" "$endpoint" "second intended steer" >/dev/null 2>"$dir/second.err" &
+    bash -c '. "$1/bin/fm-backend.sh"; . "$1/bin/fm-wake-lib.sh"; . "$1/bin/fm-checked-submit-lib.sh"; [ "$(fm_backend_checked_send_text_submit tmux "$2" "second intended steer" 3 0 0)" = empty ]' \
+      _ "$ROOT" "$endpoint" >/dev/null 2>"$dir/second.err" &
   second_pid=$!
   /bin/sleep 0.1
   : > "$hold.release"
@@ -318,7 +319,7 @@ test_concurrent_sends_serialize_per_endpoint() {
   [ ! -e "$hold.overlap" ] || fail "two sends entered the shared endpoint type boundary concurrently"
   [ "$(grep -c 'literal=1 arg=.* intended steer' "$log")" -eq 2 ] \
     || fail "serialized sends did not each type exactly once: $(cat "$log")"
-  pass "fm-send delivery: cross-home aliases and TMPDIRs serialize per resolved endpoint"
+  pass "fm-send delivery: send and shared injection submit serialize per resolved endpoint"
 }
 
 # A --key send is how firstmate interrupts a worker, so its exit status is the

--- a/tests/fm-send-strict.test.sh
+++ b/tests/fm-send-strict.test.sh
@@ -54,6 +54,9 @@ case "${1:-}" in
         fi
         printf '╭──────────────────────────────╮\n│ > %-27.27s│\n╰──────────────────────────────╯\n' "${1:-}" > "$FM_FAKE_TMUX_COMPOSER"
         [ "${FM_FAKE_TMUX_SWALLOW_ENTER:-0}" != 1 ] || printf 'esc to interrupt\n' >> "$FM_FAKE_TMUX_COMPOSER"
+      elif [ "${1:-}" = C-c ]; then
+        [ ! -d "${FM_FAKE_TMUX_TYPE_HOLD:-}.active" ] || : > "$FM_FAKE_TMUX_TYPE_HOLD.overlap"
+        printf '╭────╮\n│    │\n╰────╯\n' > "$FM_FAKE_TMUX_COMPOSER"
       elif [ "${1:-}" = Enter ]; then
         if [ "${FM_FAKE_TMUX_SWALLOW_ENTER:-0}" != 1 ]; then
           printf '╭────╮\n│    │\n╰────╯\n' > "$FM_FAKE_TMUX_COMPOSER"
@@ -284,7 +287,7 @@ test_busy_queue_confirmation_survives_empty_preflight() {
 }
 
 test_concurrent_sends_serialize_per_endpoint() {
-  local dir fb first_home second_home first_tmp second_tmp task endpoint log composer hold first_pid second_pid first_rc second_rc i
+  local dir fb first_home second_home first_tmp second_tmp task endpoint log composer hold first_pid second_pid key_pid first_rc second_rc key_rc i
   dir="$TMP_ROOT/concurrent-sends"; mkdir -p "$dir"
   fb=$(make_stubs "$dir"); first_home=$(setup_home concurrent-first); second_home=$(setup_home concurrent-second)
   first_tmp="$dir/tmp-first"; second_tmp="$dir/tmp-second"; mkdir -p "$first_tmp" "$second_tmp"
@@ -310,12 +313,17 @@ test_concurrent_sends_serialize_per_endpoint() {
       _ "$ROOT" "$endpoint" >/dev/null 2>"$dir/second.err" &
   second_pid=$!
   /bin/sleep 0.1
+  PATH="$fb:$PATH" TMPDIR="$second_tmp" FM_HOME="$second_home" FM_ROOT_OVERRIDE="$second_home" FM_TMUX_LOG="$log" \
+    FM_FAKE_TMUX_COMPOSER="$composer" "$SEND" "$endpoint" --key C-c >/dev/null 2>"$dir/key.err" &
+  key_pid=$!
   : > "$hold.release"
   wait "$first_pid"; first_rc=$?
   wait "$second_pid"; second_rc=$?
+  wait "$key_pid"; key_rc=$?
 
   expect_code 0 "$first_rc" "the first serialized send should succeed"
   expect_code 0 "$second_rc" "the second serialized send should succeed"
+  expect_code 0 "$key_rc" "the serialized composer-mutating key should succeed"
   [ ! -e "$hold.overlap" ] || fail "two sends entered the shared endpoint type boundary concurrently"
   [ "$(grep -c 'literal=1 arg=.* intended steer' "$log")" -eq 2 ] \
     || fail "serialized sends did not each type exactly once: $(cat "$log")"

--- a/tests/fm-trace-context-spawn.test.sh
+++ b/tests/fm-trace-context-spawn.test.sh
@@ -23,6 +23,7 @@ make_spawn_fakebin() {
 set -u
 case "$*" in
   *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+  *"#{pane_id}"*) printf '%%1\n'; exit 0 ;;
 esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;

--- a/tests/remote-herdr-fixture.sh
+++ b/tests/remote-herdr-fixture.sh
@@ -96,7 +96,7 @@ case "${1:-} ${2:-}" in
   "pane send-keys")
     [ ! -f "$SEND_FAIL" ] || exit 1
     jq_state --arg p "${3:-}" '.typed[$p] = true | .working[$p] = true' | save ;;
-  "pane read") printf '\n' ;;
+  "pane read") printf '╭────╮\n│    │\n╰────╯\n' ;;
   "pane process-info") printf '{"result":{"process":{"name":"codex"}}}\n' ;;
   "agent get")
     pane=${3:-}

--- a/tests/wake-helpers.sh
+++ b/tests/wake-helpers.sh
@@ -127,7 +127,7 @@ case "${1:-}" in
       case "$_a" in *cursor_y*) printf '%s\n' "${FM_FAKE_TMUX_CURSOR_Y:-0}"; exit 0 ;; esac
       [ "$_a" = "-p" ] && _print=1
     done
-    [ "$_print" = 1 ] && printf 'fakepane\n'
+    [ "$_print" = 1 ] && printf '%%1\n'
     exit 0 ;;
   list-windows)
     [ -n "${FM_FAKE_TMUX_WINDOW:-}" ] && printf '%s\n' "$FM_FAKE_TMUX_WINDOW"
@@ -215,7 +215,7 @@ case "${1:-}" in
     print=0
     for a in "$@"; do case "$a" in *cursor_y*) printf '1\n'; exit 0 ;; esac; done
     for a in "$@"; do [ "$a" = "-p" ] && print=1; done
-    [ "$print" = 1 ] && printf 'fakepane\n'
+    [ "$print" = 1 ] && printf '%%1\n'
     exit 0 ;;
   capture-pane) cat "$COMPOSER" 2>/dev/null; exit 0 ;;
   list-windows) exit 0 ;;


### PR DESCRIPTION
## Intent

Implement kunchenguid/firstmate#1474 exactly as specified by the full GitHub issue. Make fm-send success mean the intended steer was observably accepted, including parked Codex lanes containing stale composer text, while preserving busy-queue handling and all verified adapter behavior. Exclude generalized activity monitoring. Target main and fully close #1474 with a standalone Closes #1474 PR body line. Follow firstmate-coding-guidelines and add focused stale-composer and successful-delivery regressions. Use no database or browser stack and never run local Cypress. Complete No Mistakes plus exact-head CI and mergeability verification, and never merge the PR.

## What Changed

- Require an affirmatively empty composer before typing, preventing stale parked-lane drafts from being combined with a new steer while preserving verified busy-queue delivery.
- Serialize sends, interrupts, launches, and supervisor injections by revalidated endpoint identity so composer mutations cannot interleave.
- Add focused regressions for stale-composer refusal, successful delivery, busy queues, endpoint recovery, and concurrent submissions.

Closes #1474

## Risk Assessment

⚠️ Medium: No material source defect was substantiated, but the fix now changes shared submission, key, control, daemon, spawn, and adapter paths, creating a broader regression surface than the original stale-composer fix.

## Testing

The public fm-send interface rejected stale Codex composer text without typing, accepted an empty composer exactly once, preserved busy-queue Enter retries, serialized concurrent endpoint delivery, and retained cmux/daemon adapter behavior; reviewer-visible CLI transcripts were captured, while no visual artifact applies to this CLI-only change.

<details>
<summary>Evidence: fm-send delivery transcript</summary>

```text
ok - fm-send strict: exact task/lane ids resolve through home metadata
ok - fm-send --key: exit status follows delivery, and an undelivered key never reports success
ok - fm-send delivery: stale parked-lane composer refuses before typing or submitting
ok - fm-send delivery: an empty composer accepts the intended steer exactly once
ok - fm-send delivery: empty preflight preserves proven busy-queue acceptance
ok - fm-send delivery: send and shared injection submit serialize per resolved endpoint
ok - fm-send strict: unset FM_HOME fails before target resolution
ok - fm-send strict: unresolvable selectors do not fall back to tmux
ok - fm-send strict: prefixless herdr pane ids are rejected before tmux fallback
ok - fm-send strict: unmatched single-colon explicit targets must verify live before sending
ok - fm-send strict: fm-prefixed Herdr sessions remain explicit backend targets
ok - fm-send strict: healthy fm-<id> sends still type once and submit
```
</details>
<details>
<summary>Evidence: daemon behavioral test transcript</summary>

```text
ok - fm-afk-start.sh fails before daemon startup when the afk flag cannot be written
ok - fm-afk-start.sh ignores stale pidfile-only live pids
ok - fm-afk-start.sh reclaims stale daemon locks whose live pid identity no longer matches
ok - supervise daemon state root is scoped by FM_HOME
ok - routine signal self-handles
ok - captain-relevant status verbs escalate
ok - check + unknown escalate; heartbeat self-handles
ok - transient stale self-handles and records a persistence marker
ok - enriched stale wedges bypass status absorption without disturbing busy workers
ok - stale + terminal status escalates immediately
ok - paused reasons with captain phrases remain pause-classified
ok - handle_wake on a paused stale records a pause marker, drops the wedge marker, and does not escalate
ok - handle_wake records a declared pause from a routine signal for long-cadence rechecks
ok - a terminal signal clears pause and stale tracking across both supervisors
ok - housekeeping migrates a normal-watcher's declared pause into daemon tracking
ok - housekeeping clears an already-resumed watcher pause across both supervisors
ok - housekeeping seeds pause tracking from status without a watcher marker
ok - persistent stale escalates after threshold and clears its marker
ok - resumed (busy) stale clears its marker without escalating
ok - housekeeping re-surfaces a stale declared pause on the long cadence and resets its window
ok - housekeeping clears a paused marker whose pane became busy again, without escalating
ok - housekeeping clears a paused marker once the crew is no longer declaring the pause
ok - housekeeping moves an existing stale marker to pause before wedge escalation
ok - housekeeping clears tracking when a crew leaves pause
ok - persistent herdr stale resolves the target from metadata and escalates
ok - herdr idle busy-footer stale clears through capture corroboration
ok - resumed herdr stale clears through backend-aware busy state
ok - persistent Orca stale resolves the terminal from metadata
ok - multiple escalations flush as a single batched digest
ok - batch flush measures max-delay from the first append, not the last
ok - catch-all scan escalates a missed terminal once, not twice
ok - handle_wake routes routine->self and captain->escalate
ok - INJECT_SKIP forces self-handle, bypassing captain-relevant classification
ok - is_wake_reason distinguishes watcher wake reasons from singleton-status stdout
ok - terminal-stale escalate removes its marker so housekeeping does not re-escalate
ok - captain signal escalate marks seen so the catch-all scan does not re-fire
ok - _collapse_newlines replaces newlines with literal separator
ok - afk flag absent: daemon does not inject, buffer preserved
ok - busy-guard defers injection when supervisor pane is busy
ok - marker detection: marker -> stay afk, no marker -> exit afk
ok - /afk invocation is exempt from afk exit (no self-cancel)
ok - should_exit_afk returns false when afk is not active
ok - strip_injection_marker removes the sentinel marker cleanly
ok - pane_input_pending detects partial input on the cursor line
ok - pane_input_pending: a blank unidentified cursor row defers (strict container-proof rule)
ok - pane_input_pending: only proven empty agent prompts pass
ok - fm_tmux_composer_state: a bare shell prompt ($/%/#/>) reads unknown, never empty (dead-shell injection safety)
ok - fm_tmux_composer_state: a bordered composer box and bare agent glyphs (❯/›) still read empty
ok - fm_tmux_composer_state: only matching edge borders form a composer box
ok - pane_input_pending preserves bright placeholder-like drafts in styled captures
ok - classify_signal dedupes against the catch-all scan seen marker
ok - classify_stale dedupes against the signal path seen marker
ok - AFK nonterminal working:+merged keeps wedge aging and re-escalates at bound
ok - genuine done: and merge-check events still escalate
ok - pane_input_pending: an idle bordered composer is NOT pending (afk-invx-i5)
ok - pane_input_pending: text inside a bordered composer is still pending
ok - submit-ACK confirms a submit when the composer returns to a bordered-empty box
ok - submit-ACK reports pending on a persistently swallowed Enter (type-once)
ok - max-defer on an empty stuck pane types once, alarms, and preserves the buffer
ok - max-defer flushes and clears the buffer on an empty bordered pane
ok - max-defer on a pending composer alarms without typing
ok - normal flush clears a stale wedge marker
ok - below MAX_DEFER: no inject, no alarm, buffer preserved
ok - max-defer does not flush or alarm while afk is inactive
ok - library mode: sourcing the daemon defaults FM_WEDGE_ALARM_EXEC to discard (no test can fire a real notification)
ok - wake helpers replace inherited notifier overrides with the safe recorder
ok - the discard seam suppresses every notifier, including command: (fires nothing)
ok - direct notifier helpers honor the discard seam, including command:
ok - osascript channel routes through the notifier seam with the summary (never a real notification)
ok - herdr channel routes through the notifier seam with the summary (never a real notification)
ok - command channel runs the captain command with the summary on $1 and on stdin
ok - command channel failures redact configured commands while logging their exit status
ok - unknown channel directives are redacted while the alarm keeps running
ok - off disables every active alert regardless of directive position (marker and tmux flash are unaffected)
ok - auto resolves to the macOS osascript notifier on Darwin (default-on)
ok - auto on a non-macOS platform selects no built-in OS channel (the marker or a configured command carries it)
ok - config/wedge-alarm selects every configured channel and skips comment and blank lines
ok - a failing channel logs and falls back to the next channel, never crashing the alarm
ok - a hung notifier is bounded, logged, and falls through to the next channel
ok - a backgrounded command notifier remains bounded until its process group is reaped
ok - a hung notifier override is bounded, logged, and proceeds to the next channel
[1]+  Terminated              sh -c 'sleep 30 & printf "%s" "$!" > "$1"; wait' sh "$child_file"
ok - daemon shutdown stops and reaps the active notifier process group
ok - inject_wedge_alarm writes the marker AND emits the active alert even with no tmux status-line (herdr backend)
ok - in-process wedge throttle prevents alert spam when the marker cannot persist
ok - fm-send exits non-zero on a confirmed swallow, zero on a clean submit
ok - fm-send exits non-zero when initial text send fails
ok - fm-send exits non-zero unless delivery is proven empty
ok - discover_supervisor_backend: override > TMUX_PANE > HERDR_ENV+HERDR_PANE_ID > tmux fallback
ok - discover_supervisor_target: override > TMUX_PANE > herdr '<session>:<pane-id>' composition > firstmate:0 fallback
ok - pane_is_busy: herdr native busy_state='busy' short-circuits without a capture fallback
ok - primary busy guard isolates rendered signatures by detected harness
ok - pane_is_busy: omitted backend defaults to tmux for Grok's isolated fallback
ok - pane_input_pending: dispatches through fm_backend_composer_state for backend=herdr
ok - inject_msg: herdr busy-guard defers before ever attempting a submit
ok - inject_msg: herdr composer-guard defers before ever attempting a submit
ok - inject_msg: herdr pane-gone check defers before any busy/composer/submit call
ok - inject_msg: dispatches busy-guard/composer-guard/submit through the herdr backend and succeeds on a confirmed empty composer
ok - inject_msg: defers on a dead-shell/unreadable composer (unknown), never typing the escalation into a shell
ok - inject_msg: unrecognized composer states defer by default
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ee7dd7041422f1f76df43edbacd6c2a95e1a663a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (13) ✅</summary>

- 🚨 `bin/fm-send.sh:440` - The required guarantee that “fm-send success mean the intended steer was observably accepted” remains racy: two concurrent fm-send processes can both observe `empty` here, then type before either submits, producing one combined composer payload that can clear afterward and let both callers report success. The gap is larger for marked secondmate sends because pending-reply persistence occurs between this check and typing. Serialize sends per resolved endpoint and perform the empty check inside that critical section immediately adjacent to the shared type/submit boundary.

🔧 Fix: Serialize concurrent text sends per resolved endpoint
1 error still open:
- 🚨 `bin/fm-send.sh:432` - The lock is not actually keyed only by the resolved endpoint: `EXPECTED_LABEL` differs between valid aliases for the same endpoint. A task selector sets it, while an explicit recorded window/terminal resolving to the same backend and `T` leaves it empty. Concurrent sends through those two forms therefore acquire different locks, can both observe an empty composer, and can still combine while both report success. Key the lock solely by the canonical backend and resolved target; retain `EXPECTED_LABEL` only for adapter verification.

🔧 Fix: Canonicalize send locks across endpoint aliases
1 error still open:
- 🚨 `bin/fm-send.sh:436` - Serialization is still scoped to `$STATE`, not solely to the resolved endpoint. Two supported invocations using different `FM_HOME` values can target the same physical endpoint through the explicit endpoint escape hatch, acquire different lock files, both observe an empty composer, and combine their text while reporting success. Put the endpoint-keyed lock at the shared composer/type-submit boundary in a lock namespace common to all homes that can address that backend endpoint.

🔧 Fix: Share endpoint send locks across homes
1 error still open:
- 🚨 `bin/fm-send.sh:207` - Serialization can still be bypassed because the supposedly shared namespace varies with caller-controlled `TMPDIR` or `FM_SEND_LOCK_NAMESPACE`. Two supported processes targeting the same endpoint with different values acquire different locks, can both observe an empty composer, combine their text, and report success. Use one fixed per-user namespace independent of each invocation’s environment; keep any test isolation seam outside production lock identity.

🔧 Fix: Fix send lock namespace across environments
1 error still open:
- 🚨 `bin/fm-send.sh:471` - The endpoint lock only serializes callers of `fm-send.sh`; the away supervisor still performs its own empty-composer check and calls `fm_backend_send_text_submit` without this lock. A daemon injection can therefore race a text send to the supervisor endpoint: both observe empty, both type, and `fm-send` can report success after the combined composer clears. Move the canonical endpoint lock to the shared composer-check/type-submit boundary and have both paths use it.

🔧 Fix: Share checked submit locking across writers
1 error still open:
- 🚨 `bin/fm-checked-submit-lib.sh:51` - The shared lock can still be bypassed by supported writers that call `fm_backend_send_text_submit` directly. For example, `fm-control exit` can type its lifecycle command into the same endpoint after fm-send&#39;s empty-composer check but before fm-send types, combining both inputs while fm-send can report success. Route every competing writer through the endpoint serialization boundary, or move locking into the common submit boundary while retaining the checked composer&#39;s atomic preflight.

🔧 Fix: Serialize all backend text submit writers
1 error still open:
- 🚨 `bin/fm-checked-submit-lib.sh:66` - The serialization boundary still excludes composer-mutating key sends. A concurrent `fm-send --key C-c` or `fm-control` interrupt can issue its required composer-clear key after a text send&#39;s empty preflight and typing but before submission; the clear removes the intended steer, then the text sender can observe an empty composer and falsely report success. Serialize composer-mutating key operations on the same canonical endpoint lock, covering the entire interrupt/clear sequence where applicable.

🔧 Fix: Serialize composer-mutating keys with text submits
1 error still open:
- 🚨 `bin/fm-checked-submit-lib.sh:35` - Serialization still keys on the caller&#39;s target spelling, not the physical endpoint. For tmux, supported selectors such as `session:window` and `session:window.0` can address the same pane but produce different locks; concurrent text/key operations through those aliases can therefore mutate one composer simultaneously and let `fm-send` falsely report acceptance. Resolve a stable adapter-owned endpoint identity (for tmux, the verified `#{pane_id}`) before acquiring the shared lock.

🔧 Fix: Canonicalize locks by physical endpoint identity
1 error still open:
- 🚨 `bin/fm-backend.sh:743` - This contradicts the required criterion to preserve “all verified adapter behavior.” For cmux, a recorded workspace/surface target may become stale and `fm_backend_cmux_target_ready(target, expected_label)` deliberately refreshes it by task label. This identity check drops the expected label and calls `fm_backend_target_exists` with only the stale target, so the new lock acquisition fails before the existing refresh path can run; `fm-send` and control operations now reject supported cmux tasks they previously recovered. Resolve the adapter-owned physical identity using the same expected-label-aware readiness path, then lock the refreshed workspace/surface IDs.

🔧 Fix: Preserve cmux stale-target recovery through locking
1 error still open:
- 🚨 `bin/fm-checked-submit-lib.sh:66` - The endpoint serialization boundary still excludes supported launch/readiness writers. `fm-spawn.sh` calls adapter-specific `send_text_line`, `send_literal`, and `send_key` functions directly (lines 2063–2093), so an explicit-endpoint `fm-send` can pass its empty-composer preflight and then race one of these operations; the spawn operation can alter or submit the composer while `fm-send` still reports success. Route applicable launch/readiness composer transactions through the same physical-endpoint lock, covering each complete multi-operation sequence without weakening the checked-submit preflight.

🔧 Fix: Serialize spawn composer transactions by endpoint
1 error still open:
- 🚨 `bin/fm-checked-submit-lib.sh:35` - The physical identity is resolved before waiting for its lock, but subsequent composer checks and writes still use the original logical target. For tmux, a supported selector such as `session:window` can be replaced or retargeted from pane A to pane B while this caller waits on pane A&#39;s lock; another caller can then lock pane B while this caller also writes to pane B, recreating the composer race and allowing `fm-send` to report success incorrectly. After acquiring the lock, re-resolve and compare the physical identity (retrying if it changed), or perform the transaction through the canonical adapter-owned physical target.

🔧 Fix: Revalidate endpoint identity after locking
1 error still open:
- 🚨 `bin/fm-checked-submit-lib.sh:59` - The retarget race remains reachable after the new revalidation: once the logical selector resolves to the locked pane, this assigns the original selector—not the verified physical target—to the transaction. If `session:window` is retargeted immediately afterward, another sender can lock the new pane while this transaction also writes there, allowing composer mutation and false delivery success. Have endpoint resolution return the canonical writable target (for tmux, the verified pane ID) and use that target for the entire locked transaction.

🔧 Fix: Use canonical targets throughout locked transactions
2 errors still open:
- 🚨 `bin/fm-send.sh:139` - The interrupt transaction still switches back to the mutable logical target for its required composer-clear key. If a tmux `session:window` selector is retargeted after the locked interrupt reaches pane A, this clear is sent to pane B while only pane A&#39;s lock is held; pane A retains the restored prompt and pane B&#39;s composer can race another writer. Pass the locked canonical target through `fm_send_clear_after_interrupt` so the interrupt and clear operate on the same endpoint under one lock.
- 🚨 `bin/fm-checked-submit-lib.sh:96` - The canonical cmux target can still migrate inside the locked transaction. After locking workspace/surface A, composer and submit operations receive `expected_label`; `fm_backend_cmux_target_ready` may therefore refresh stale A to replacement surface B. A concurrent caller can lock B&#39;s identity while this A-locked transaction also reads or writes B, recreating the composer race and false-success path. Add an adapter operation mode that uses the already-verified physical IDs without label-based retargeting for the duration of the lock, or revalidate/retry at the shared boundary before every migration-capable operation.

🔧 Fix: Pin locked operations to canonical endpoints
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-send-strict.test.sh`
- `bash tests/fm-backend-cmux.test.sh`
- <code>`bash tests/fm-daemon.test.sh` behavioral cases; stopped when the script entered its embedded shellcheck phase, which this test phase forbids</code>
- <code>`timeout 30 bash tests/fm-trace-context-spawn.test.sh` (seven affected spawn/trace cases passed before the imposed timeout)</code>
- <code>Updated `tests/wake-helpers.sh` fake tmux `#{pane_id}` responses from impossible `fakepane` values to `%1`, then reran the affected behavior</code>
- `git diff --check`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Fix ShellCheck source and unused-loop warnings
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
