### PR TITLE
test: stabilize real-Herdr end-to-end assertions

### DIFF
--- a/tests/fm-afk-inject-herdr-e2e.test.sh
+++ b/tests/fm-afk-inject-herdr-e2e.test.sh
@@ -46,7 +46,9 @@ command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the her
 # as a cross-session parent identity (tests/herdr-test-safety.sh).
 herdr_forget_inherited_pane
 
-fail() { printf 'not ok - %s\n' "$1" >&2; cleanup_all; exit 1; }
+fail() {
+  herdr_test_fail "$1" cleanup_all
+}
 pass() { printf 'ok - %s\n' "$1"; }
 
 SESSION="fm-lab-afk-herdr-e2e-$$"
@@ -214,6 +216,10 @@ submit_line() {
   report_agent_state idle
 }
 
+# Remove any output emitted by the user's login-shell startup files before the
+# fixture took over the pane. Composer assertions below then inspect only the
+# deterministic no-rc fixture region.
+printf '\033[3J\033[H\033[2J'
 redraw
 while IFS= read -r -n 1 _ch; do
   if [ -z "$_ch" ]; then
@@ -229,9 +235,9 @@ done
 LOOP
 chmod +x "$LOOP_SCRIPT"
 
-fm_backend_herdr_send_text_line "$SUPERVISOR_TARGET" "bash '$LOOP_SCRIPT' '$LOG_FILE'" \
+fm_backend_herdr_send_text_line "$SUPERVISOR_TARGET" \
+  "exec env BASH_ENV=/dev/null bash --noprofile --norc '$LOOP_SCRIPT' '$LOG_FILE'" \
   || fail "could not start the supervisor-loop script in the scratch herdr pane"
-sleep 1  # let the loop start and settle
 
 # --- herdr shim: forwards to the real binary, optionally swallows one Enter --
 REAL_HERDR=$(command -v herdr)
@@ -249,6 +255,21 @@ fi
 exec "$REAL_HERDR" "\$@"
 SHIM
 chmod +x "$HERDR_SHIM_DIR/herdr"
+
+wait_for_composer_state() {  # <expected> [attempts]
+  local expected=$1 attempts=${2:-100} actual=unknown
+  composer_state_matches() {
+    actual=$(PATH="$HERDR_SHIM_DIR:$PATH" \
+      fm_backend_composer_state herdr "$SUPERVISOR_TARGET" 2>/dev/null)
+    [ "$actual" = "$expected" ]
+  }
+  herdr_test_poll "$attempts" 0.1 composer_state_matches && return 0
+  printf 'last composer state: %s\n' "$actual" >&2
+  return 1
+}
+
+wait_for_composer_state empty \
+  || fail "the no-rc supervisor fixture did not render an empty composer within 10s"
 
 wait_daemon_started() {
   local label=${1:-daemon} start_line=${2:-0} i=0 new_log
@@ -327,13 +348,14 @@ selfcheck_pane_input_pending() {
   local check_text="selfcheck-marker-12345"
   fm_backend_herdr_send_literal "$SUPERVISOR_TARGET" "$check_text" \
     || fail "selfcheck: could not send literal text to the scratch pane"
-  sleep 0.5
-  if PATH="$HERDR_SHIM_DIR:$PATH" pane_input_pending "$SUPERVISOR_TARGET" herdr; then
+  if wait_for_composer_state pending \
+    && PATH="$HERDR_SHIM_DIR:$PATH" pane_input_pending "$SUPERVISOR_TARGET" herdr; then
     fm_backend_herdr_send_key "$SUPERVISOR_TARGET" Enter
-    sleep 0.5
+    wait_for_composer_state empty \
+      || fail "selfcheck: composer did not return to empty after submitting the typed marker"
     return 0
   fi
-  echo "pane_input_pending cannot detect typed text in this real-herdr environment" >&2
+  echo "pane_input_pending cannot detect typed text within 10s in this real-herdr environment" >&2
   fm_backend_herdr_capture "$SUPERVISOR_TARGET" 10 | sed 's/^/    /' >&2
   fm_backend_herdr_send_key "$SUPERVISOR_TARGET" Enter
   fail "pane_input_pending self-check failed against real herdr"

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -9,7 +9,9 @@ set -u
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HERDR_LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
 
-fail() { printf 'not ok - %s\n' "$1" >&2; cleanup_all; exit 1; }
+fail() {
+  herdr_test_fail "$1" cleanup_all
+}
 pass() { printf 'ok - %s\n' "$1"; }
 
 command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found"; exit 0; }
@@ -762,20 +764,29 @@ ORDER_B_META="$HOME_DIR/state/order-b.meta"
 remember_meta_worktree "$ORDER_A_META" >/dev/null
 remember_meta_worktree "$ORDER_B_META" >/dev/null
 
-ORDER_LIST=$(lab workspace list) || fail "could not inspect concurrent presentation ordering"
 CREATED_LABELS=$(projection_labels_from_log "$PROJECTION_ORDER_START")
 EXPECTED_LABELS=$(printf 'firstmate\n%s\n%s\n2ndmate-alpha\n2ndmate-bravo' "$PROJECTED_LABEL" "$CREATED_LABELS")
-ACTUAL_LABELS=$(printf '%s' "$ORDER_LIST" | jq -r '.result.workspaces[].label')
+ORDER_READY=false
+concurrent_order_is_ready() {
+  ORDER_LIST=$(lab workspace list 2>/dev/null || true)
+  ACTUAL_LABELS=$(printf '%s' "$ORDER_LIST" | jq -r '.result.workspaces[]?.label' 2>/dev/null || true)
+  PRIMARY_IDS=$(printf '%s' "$ORDER_LIST" | jq -r '
+    .result.workspaces[]?
+    | select((.label | startswith("└ ")) or (.label | startswith("firstmate/")))
+    | .workspace_id
+  ' 2>/dev/null || true)
+  MOVE_TARGETS=$(cut -f2 "$MOVE_CALL_LOG")
+  MOVE_INDEXES=$(cut -f3 "$MOVE_CALL_LOG")
+  [ "$ACTUAL_LABELS" = "$EXPECTED_LABELS" ] \
+    && [ "$MOVE_TARGETS" = "$PRIMARY_IDS" ] \
+    && [ "$MOVE_INDEXES" = $'1\n2\n3' ]
+}
+herdr_test_poll 100 0.1 concurrent_order_is_ready && ORDER_READY=true
+[ "$ORDER_READY" = true ] \
+  || fail "concurrent primary workers did not reach stable contiguous ordering within 10s (labels: $ACTUAL_LABELS; move indexes: $MOVE_INDEXES)"
 [ "$ACTUAL_LABELS" = "$EXPECTED_LABELS" ] || fail "workspace order was not firstmate, stable primary block, secondmates: $ACTUAL_LABELS"
-PRIMARY_IDS=$(printf '%s' "$ORDER_LIST" | jq -r '
-  .result.workspaces[]
-  | select((.label | startswith("└ ")) or (.label | startswith("firstmate/")))
-  | .workspace_id
-')
-MOVE_TARGETS=$(cut -f2 "$MOVE_CALL_LOG")
 [ "$MOVE_TARGETS" = "$PRIMARY_IDS" ] \
   || fail "workspace.move targeted something other than each exact current projected-create id"
-MOVE_INDEXES=$(cut -f3 "$MOVE_CALL_LOG")
 [ "$MOVE_INDEXES" = $'1\n2\n3' ] \
   || fail "concurrent primary workers did not append stably to the contiguous block: $MOVE_INDEXES"
 SECOND_ORDER_AFTER=$(printf '%s' "$ORDER_LIST" | jq -r '.result.workspaces[] | select(.label | startswith("2ndmate-")) | .workspace_id')

--- a/tests/fm-backend-herdr-prune-safety-e2e.test.sh
+++ b/tests/fm-backend-herdr-prune-safety-e2e.test.sh
@@ -24,8 +24,27 @@ set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-fail() { printf 'not ok - %s\n' "$1" >&2; cleanup_all; exit 1; }
+fail() {
+  herdr_test_fail "$1" cleanup_all
+}
 pass() { printf 'ok - %s\n' "$1"; }
+
+wait_for_nonempty_file() {  # <path> [attempts]
+  herdr_test_poll "${2:-100}" 0.1 test -s "$1"
+}
+
+wait_for_line_count_above() {  # <path> <minimum-exclusive> [attempts]
+  local path=$1 minimum=$2
+  marker_line_count_is_above() {
+    local count
+    count=$(wc -l < "$path" 2>/dev/null | tr -d '[:space:]')
+    case "$count" in
+      ''|*[!0-9]*) return 1 ;;
+      *) [ "$count" -gt "$minimum" ] ;;
+    esac
+  }
+  herdr_test_poll "${3:-100}" 0.1 marker_line_count_is_above
+}
 
 command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found"; exit 0; }
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the herdr adapter)"; exit 0; }
@@ -106,8 +125,8 @@ MARKER="$SCRATCH/heartbeat.log"
 fm_backend_herdr_cli "$SESSION" pane run "$LIVE_PANE_ID" \
   "sh -c 'while true; do date +%s >> $MARKER; sleep 1; done'" >/dev/null 2>&1 \
   || fail "could not start the live heartbeat process in the startup workspace's pane"
-sleep 2
-[ -s "$MARKER" ] || fail "the live heartbeat process did not start writing its marker file"
+wait_for_nonempty_file "$MARKER" \
+  || fail "the live heartbeat process did not start writing its marker file within 10s"
 BEFORE_COUNT=$(wc -l < "$MARKER" | tr -d '[:space:]')
 pass "repro setup: a live long-running process is running in the startup workspace's single tab (label '1'), heartbeating to a marker file"
 
@@ -135,7 +154,8 @@ fi
 if ! herdr pane get "$LIVE_PANE_ID" --session "$SESSION" >/dev/null 2>&1; then
   fail "REGRESSION (2026-07-02 self-kill): the live startup-workspace pane was CLOSED by create_task"
 fi
-sleep 2
+wait_for_line_count_above "$MARKER" "$BEFORE_COUNT" \
+  || fail "REGRESSION: the live heartbeat process did not write again within 10s after create_task ran"
 AFTER_COUNT=$(wc -l < "$MARKER" | tr -d '[:space:]')
 [ "$AFTER_COUNT" -gt "$BEFORE_COUNT" ] \
   || fail "REGRESSION: the live heartbeat process stopped writing after create_task ran - it was killed even though its pane object survived"

--- a/tests/fm-herdr-lab.test.sh
+++ b/tests/fm-herdr-lab.test.sh
@@ -71,8 +71,8 @@ esac
 SH
 chmod +x "$FAKEBIN/herdr"
 
-# shellcheck source=/dev/null
-. "$ROOT/bin/fm-herdr-lab.sh"
+# shellcheck source=tests/herdr-test-safety.sh
+. "$ROOT/tests/herdr-test-safety.sh"
 
 run_with_fake() {
   PATH="$FAKEBIN:$PATH" \
@@ -234,6 +234,30 @@ SH
   pass "fm-herdr-lab: timed-out provisioning cancels the launch before teardown"
 }
 
+test_bounded_polling_and_failure_cleanup() {
+  local attempts=0 status=0 output
+  poll_after_three_attempts() {
+    attempts=$((attempts + 1))
+    [ "$attempts" -ge 3 ]
+  }
+  herdr_test_poll 5 0 poll_after_three_attempts \
+    || fail "bounded test poll did not observe a predicate that became true"
+  [ "$attempts" -eq 3 ] || fail "bounded test poll made $attempts attempts instead of stopping at 3"
+  attempts=0
+  herdr_test_poll 2 0 poll_after_three_attempts >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "bounded test poll must fail after its attempt limit"
+  [ "$attempts" -eq 2 ] || fail "bounded test poll exceeded its two-attempt limit"
+
+  cleanup_probe() { printf 'cleanup diagnostic\n' >&2; }
+  status=0
+  output=$(trap 'printf "duplicate cleanup\n" >&2' EXIT; \
+    herdr_test_fail 'causal assertion' cleanup_probe 2>&1) || status=$?
+  expect_code 1 "$status" "Herdr test failure helper must preserve a failing status"
+  [ "$output" = $'cleanup diagnostic\nnot ok - causal assertion' ] \
+    || fail "cleanup diagnostics did not remain subordinate to one causal assertion: $output"
+  pass "Herdr test safety: polling is bounded and cleanup remains subordinate to the causal assertion"
+}
+
 test_refuses_unsafe_names
 test_provision_run_and_guarded_teardown
 test_missing_tripwire_blocks_destruction
@@ -241,3 +265,4 @@ test_changed_default_trips_after_teardown
 test_stopped_owned_lab_can_reprovision
 test_failed_delete_retains_tripwire
 test_timed_out_provision_cancels_late_launch
+test_bounded_polling_and_failure_cleanup

--- a/tests/herdr-test-safety.sh
+++ b/tests/herdr-test-safety.sh
@@ -40,3 +40,22 @@ herdr_refuse_if_default() { # <session>
 herdr_safe_stop_and_delete() { # <session>
   fm_herdr_lab_teardown "$1"
 }
+
+herdr_test_poll() { # <attempts> <interval-seconds> <predicate> [args...]
+  local max_attempts=$1 interval=$2 attempt_index=0
+  shift 2
+  while [ "$attempt_index" -lt "$max_attempts" ]; do
+    "$@" && return 0
+    attempt_index=$((attempt_index + 1))
+    [ "$attempt_index" -ge "$max_attempts" ] || sleep "$interval"
+  done
+  return 1
+}
+
+herdr_test_fail() { # <message> <cleanup-function>
+  local message=$1 cleanup=$2
+  trap - EXIT
+  "$cleanup"
+  printf 'not ok - %s\n' "$message" >&2
+  exit 1
+}


### PR DESCRIPTION
## Intent

Implement kunchenguid/firstmate issue #860 exactly as specified: replace the named fixed waits and single captures in the real-Herdr end-to-end tests with bounded condition polling for the heartbeat marker, typed-marker pane render, and concurrent contiguous-block ordering assertions; isolate pane-content assertions from developer shell-rc noise; and keep cleanup diagnostics subordinate to the causal assertion. Exclude Herdr product behavior changes, broad runner pacing, and blanket sleeps. Prefer hermetic test fixtures and exercise live Herdr only through the generated guarded named-session lab contract, never the shared default session. Validate affected tests individually and sequentially, while accepting that live Herdr can only run where the binary is installed. Target main, include standalone Closes #860, use no database or browser stack and never local Cypress. Complete No Mistakes plus exact-head CI and mergeability, and never merge the PR.

## What Changed

- Replace fixed waits and single captures in real-Herdr E2E tests with bounded polling for heartbeat, composer-state, and concurrent workspace-order conditions.
- Run the supervisor fixture without shell startup files and clear prior pane output so composer assertions remain hermetic.
- Centralize bounded polling and failure cleanup helpers, preserving the causal assertion after cleanup diagnostics.

Closes #860

## Risk Assessment

✅ Low: The test-only change directly addresses the three documented races, isolates pane assertions from shell-rc noise, preserves guarded named-session handling, and keeps cleanup diagnostics subordinate without introducing material source risk.

## Testing

Inspected the target diff, passed the hermetic bounded-polling and subordinate-cleanup contract, then invoked the three affected live-Herdr scenarios individually and sequentially; all skipped because Herdr is not installed, so full end-to-end evidence remains outstanding while the worktree stayed clean.

<details>
<summary>Evidence: Hermetic polling and cleanup transcript</summary>

```text
ok - fm-herdr-lab: names fail closed and require the lab prefix
ok - fm-herdr-lab: provisioning, scoped calls, guarded teardown, and fleet tripwire are deterministic
ok - fm-herdr-lab: missing tripwire refuses teardown before any Herdr call
ok - fm-herdr-lab: changed default fleet state is a hard failure
ok - fm-herdr-lab: an owned stopped lab can re-provision safely
ok - fm-herdr-lab: failed deletion retains ownership until absence is confirmed
ok - fm-herdr-lab: timed-out provisioning cancels the launch before teardown
ok - Herdr test safety: polling is bounded and cleanup remains subordinate to the causal assertion
```
</details>
<details>
<summary>Evidence: Heartbeat-marker live test</summary>

`skip: herdr not found`

```text
skip: herdr not found
```
</details>
<details>
<summary>Evidence: Typed-marker pane-render live test</summary>

`skip: herdr not found`

```text
skip: herdr not found
```
</details>
<details>
<summary>Evidence: Concurrent contiguous-ordering live test</summary>

`skip: herdr not found`

```text
skip: herdr not found
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (1m13s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c6b87082b5337b9af16783ac61bdfb4ecc9fcc5c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ Live end-to-end evidence for heartbeat polling, typed-marker rendering, and concurrent contiguous ordering could not be produced because this host lacks the Herdr binary. These scenarios need execution on a Herdr-equipped host before the complete user intent is demonstrated.
- <code>Inspected `git diff b5d430d6fdcd961ce9b681bf196f365c1825c284..c6b87082b5337b9af16783ac61bdfb4ecc9fcc5c` to select the affected executable tests.</code>
- `bash tests/fm-herdr-lab.test.sh`
- <code>`bash tests/fm-backend-herdr-prune-safety-e2e.test.sh` (skipped: `herdr` unavailable)</code>
- <code>`bash tests/fm-afk-inject-herdr-e2e.test.sh` (skipped: `herdr` unavailable)</code>
- <code>`bash tests/fm-backend-herdr-presentation-e2e.test.sh` (skipped: `herdr` unavailable)</code>
- <code>`git status --short` to confirm no transient worktree artifacts remained</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
