### PR TITLE
fix(bin): surface Pi MCP tool-approval wait instead of false-working busy

### DIFF
--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -41,24 +41,42 @@
 # Classifier-only sources (never written into a record):
 #   endpoint-gone, herdr-native, grok-regex, muse-session-log, missing,
 #   malformed, gen-mismatch, source-mismatch, kimi-unverified,
-#   codex-unverified, capture-failed, no-target
+#   codex-unverified, capture-failed, no-target, pi-mcp-approval
 #
-# Classification (fm_busy_classify): busy | idle | unknown | dead, always
-# with the producing source as the second token. Precedence:
+# Classification (fm_busy_classify): busy | idle | approval-wait | unknown |
+# dead, always with the producing source as the second token. Precedence:
 #   1. dead endpoint (fm_busy_classify_live only) -> dead endpoint-gone
 #   2. standalone Kimi before verification       -> unknown kimi-unverified
-#   3. a valid, gen-matching, source-trusted record -> its state and source
+#   3. a valid, gen-matching, source-trusted record -> its state and source,
+#      EXCEPT the Pi MCP tool-approval refinement below
 #   4. no record at all: herdr's native busy verdict is trusted as busy
 #      (generation state is sufficient for busy, not for idle), then the
 #      muse session-log pull source, then the Grok-only temporary regex fallback
 #      classifies a grok task from its rendered tail, then unknown missing
 #   5. malformed, stale, or untrusted records -> unknown, never a fallback
-# The Grok arm is the ONLY rendered-text classification that survives the
-# redesign, because Grok's structured lifecycle was not credited-live-verified
-# in the approved audit; it is scoped to harness=grok and can never classify
+# The Grok arm is the only rendered-text arm that CLASSIFIES a task busy or
+# idle, because Grok's structured lifecycle was not credited-live-verified in
+# the approved audit; it is scoped to harness=grok and can never classify
 # another adapter. The delivery guards in bin/fm-tmux-lib.sh match rendered
 # footers for submit acknowledgement and away-mode supervisor injection only;
 # neither is a recorded worker state source.
+#
+# Pi MCP tool-approval refinement (fm_busy_pi_mcp_approval_selector, scoped to
+# harness pi/pi-signed): a valid busy pi-ext record only proves the Pi agent
+# turn has not settled, and Pi keeps that turn un-settled while it blocks on its
+# modal MCP tool-approval selector - agent_settled never fires while the modal
+# waits, so ordinary busy classification (and the watcher's stale absorption)
+# would hide the wait as provably-working. When that exact selector is on the
+# rendered tail, classification reports approval-wait pi-mcp-approval instead of
+# busy pi-ext, so current-state reconciliation and supervision surface an
+# actionable trust wait. This is the ONE rendered-text arm that REFINES an
+# already-busy record downward to a non-busy actionable wait; it never invents
+# busy from text, so the "converted adapters never classify busy from rendered
+# footer text" invariant still holds, and it never inspects the tool arguments.
+# Removing the selector (the modal was answered or dismissed) reverts to the
+# record's own verdict, so the wait clears through pi-ext's own agent_settled
+# lifecycle with no extra state. Verified renderer facts and the fork scoping
+# limitation: docs/verification/supervision.md "Pi MCP tool-approval wait".
 #
 # The muse pull source is semantic, not rendered: it folds muse's own durable
 # session event log. It has no writer, no arm, and no gen, because
@@ -604,12 +622,55 @@ fm_busy_grok_tail_busy() {
     | grep -qiE "${FM_BUSY_REGEX:-${FM_TMUX_GROK_BUSY_REGEX_DEFAULT:-Ctrl\\+c:cancel}}"
 }
 
+# fm_busy_pi_mcp_approval_selector: 0 iff <tail-on-stdin> structurally shows
+# Pi's exact MCP tool-approval selector currently on screen. Pi's
+# pi-mcp-adapter builds a request titled "MCP: <server> wants to run <tool>"
+# offering exactly "Allow once", "Allow for session", and "Deny", and
+# pi-coding-agent's ExtensionSelectorComponent renders that title above the
+# three choices, one per line, in that order. This requires BOTH the title line
+# and those three choices as CONSECUTIVE selector-option lines in order (the
+# exact rendered layout), which is specific enough that ordinary agent work,
+# prose, or code cannot reproduce it. It reads ONLY those structural anchors -
+# never the Arguments block and never any tool argument value. Pi's default
+# TuiMainScreen is a diff renderer that never commits the ephemeral selector to
+# scrollback, so the selector appears in a capture iff it is currently
+# displayed. Bounded limitation: if the Arguments block is tall enough to push
+# the title line off the top of the captured region the title is not seen and
+# this reports no selector (conservative miss, never a false wait). Callers
+# scope this to harness pi/pi-signed; Pi forks are covered only when launched as
+# pi/pi-signed AND their renderer is empirically identical
+# (docs/verification/supervision.md "Pi MCP tool-approval wait").
+fm_busy_pi_mcp_approval_selector() {
+  local tail
+  tail=$(cat)
+  printf '%s\n' "$tail" \
+    | grep -Eq '(^|[[:space:]])MCP:[[:space:]].+[[:space:]]wants to run[[:space:]].+' || return 1
+  printf '%s\n' "$tail" | awk '
+    function opt(line, label,   s) {
+      s = line
+      sub(/^[^A-Za-z0-9]*/, "", s)
+      sub(/[[:space:]]*$/, "", s)
+      return s == label
+    }
+    { line[NR] = $0 }
+    END {
+      for (i = 1; i <= NR - 2; i++) {
+        if (opt(line[i], "Allow once") \
+          && opt(line[i + 1], "Allow for session") \
+          && opt(line[i + 2], "Deny")) exit 0
+      }
+      exit 1
+    }
+  '
+}
+
 # fm_busy_classify: semantic classification for a task whose endpoint the
 # caller has already established as present. Prints "<verdict> <source>":
-# busy|idle|unknown plus the producing source (see header). Never probes
-# process state. <tail40> is optional pre-captured plain output used only by
-# the Grok arm; when absent the Grok arm captures through fm_backend_capture
-# if available, else reports unknown capture-failed.
+# busy|idle|approval-wait|unknown plus the producing source (see header). Never
+# probes process state. <tail40> is optional pre-captured plain output used by
+# the Grok arm and the Pi MCP tool-approval refinement; when absent each arm
+# captures through fm_backend_capture if available, else the Grok arm reports
+# unknown capture-failed and the Pi arm leaves the busy record unrefined.
 fm_busy_classify() {  # <backend> <target> <harness> <id> <state-dir> [tail40]
   local backend=$1 target=$2 harness=$3 id=$4 state=$5 tail40=${6-}
   local out rc r_state r_source native log
@@ -633,6 +694,22 @@ fm_busy_classify() {  # <backend> <target> <harness> <id> <state-dir> [tail40]
     out=${out#* }
     r_source=${out%% *}
     if fm_busy_source_trusted "$harness" "$r_source"; then
+      # Pi MCP tool-approval refinement (see the header): a valid busy pi-ext
+      # record hides a blocked-on-approval turn as busy. Downgrade it to an
+      # actionable approval-wait only while that exact selector is on the tail.
+      if [ "$r_state" = busy ] && [ "$r_source" = pi-ext ]; then
+        case "$harness" in
+          pi|pi-signed)
+            if [ -z "$tail40" ] && command -v fm_backend_capture >/dev/null 2>&1; then
+              tail40=$(fm_backend_capture "$backend" "$target" 40 2>/dev/null) || tail40=''
+            fi
+            if [ -n "$tail40" ] && printf '%s' "$tail40" | fm_busy_pi_mcp_approval_selector; then
+              printf 'approval-wait pi-mcp-approval'
+              return 0
+            fi
+            ;;
+        esac
+      fi
       printf '%s %s' "$r_state" "$r_source"
     else
       printf 'unknown source-mismatch'

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -445,9 +445,11 @@ do_exit() {
     missing) die "task $ID's recorded endpoint is gone, so there is no agent to stop; reconcile the task before any further control action" ;;
     *) die "task $ID's endpoint reads '$state' rather than a positively classified state; refusing to send a lifecycle command into an unattributed endpoint" ;;
   esac
-  # A busy agent is interrupted first before the exit command is submitted.
+  # A busy agent - or one parked on a tool-approval wait, itself a busy turn
+  # blocked on a modal - is interrupted first before the exit command is
+  # submitted.
   case "$(busy_verdict)" in
-    busy*)
+    busy*|approval-wait*)
       cancel=$(deliver_interrupt) || return $?
       state=$(agent_state)
       case "$state" in

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -160,10 +160,13 @@ pane_readable() {  # <target>
 # when no record exists, but its native `idle` is NOT, because agent.get
 # reports generation state (idle while a crew blocks on its own long-running
 # foreground tool call) rather than turn state.
+# Grok reads its rendered-tail fallback; pi/pi-signed need the tail so the
+# contract can refine a busy pi-ext record into an approval-wait when Pi's MCP
+# tool-approval selector is on screen (bin/fm-busy-lib.sh owns that refinement).
 crew_busy_verdict() {  # <target>
   local tail40=''
   case "$HARNESS" in
-    grok*) tail40=$(fm_backend_capture "$TASK_BACKEND" "$1" 40 "$EXPECTED_LABEL" 2>/dev/null) || tail40='' ;;
+    grok*|pi|pi-signed) tail40=$(fm_backend_capture "$TASK_BACKEND" "$1" 40 "$EXPECTED_LABEL" 2>/dev/null) || tail40='' ;;
   esac
   fm_busy_classify "$TASK_BACKEND" "$1" "$HARNESS" "$ID" "$STATE" "$tail40"
 }
@@ -543,11 +546,15 @@ pane_readable "$BACKEND_TARGET" || emit unknown none "backend target gone: $BACK
 # state is not meaningful for them; read their state from the status log only.
 # Only an exact busy verdict reports working here, and only an exact idle
 # verdict permits the status-log fallback below. Missing, malformed, stale, or
-# unverified semantic state remains unknown.
+# unverified semantic state remains unknown. A Pi worker blocked on its MCP
+# tool-approval selector reads approval-wait (bin/fm-busy-lib.sh) and is
+# reported as an actionable parked/tool-approval state, never working, so
+# supervision surfaces the trust wait instead of absorbing it.
 if [ "$KIND" != secondmate ]; then
   BUSY_VERDICT=$(crew_busy_verdict "$BACKEND_TARGET")
   case "${BUSY_VERDICT%% *}" in
     busy) emit working pane "harness busy (${BUSY_VERDICT#* })" ;;
+    approval-wait) emit parked pane "waiting on tool approval (${BUSY_VERDICT#* })" ;;
     idle) ;;
     *) emit unknown pane "harness state unavailable ($BUSY_VERDICT)" ;;
   esac

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,11 +104,12 @@ Text for a worker to read and commands that drive a worker's process are separat
 ## Busy state is semantic, per adapter
 
 `bin/fm-busy-lib.sh` is the single owner of what "this worker is busy" means, and `bin/fm-busy-event.sh` is the only writer of the per-task records it reads.
-Every classification returns a verdict of busy, idle, unknown, or dead together with the source that produced it, so a consumer or a diagnostic can never confuse semantic state with a fallback.
+Every classification returns a verdict of busy, idle, approval-wait, unknown, or dead together with the source that produced it, so a consumer or a diagnostic can never confuse semantic state with a fallback.
 
 Each converted adapter reports its own turn lifecycle through a machine-readable contract the vendor already exposes, rather than through rendered footer text: Pi and pi-signed through the Firstmate-owned extension's `agent_start` and `agent_settled` confirmed by `ctx.isIdle()`, OpenCode through its plugin's semantic `session.status`, and Claude through owned `UserPromptSubmit`, `Stop`, `StopFailure`, and `SessionEnd` hooks.
 Kimi behind Pi inherits Pi's lifecycle.
-Codex and standalone Kimi classify unknown behind explicit probes until a semantic source is live-verified for them, and Grok keeps one clearly isolated rendered-tail fallback that can only ever classify a Grok task.
+Codex and standalone Kimi classify unknown behind explicit probes until a semantic source is live-verified for them, and Grok keeps one clearly isolated rendered-tail fallback that is the only arm to classify a task busy or idle from rendered text and can only ever classify a Grok task.
+A single further rendered-text arm lives inside the contract as a refinement, not a classification: on harness pi/pi-signed an already-busy `pi-ext` record is refined down to an actionable `approval-wait` while Pi's exact MCP tool-approval selector is on screen, because Pi never settles that turn and ordinary busy classification would otherwise hide the blocked-on-approval wait as provably working; it never invents busy from rendered text and reverts to the record's own verdict once the modal is answered or dismissed, so `bin/fm-crew-state.sh` surfaces the wait as a parked tool-approval state instead of absorbing it as working ([`verification/supervision.md`](verification/supervision.md) owns the renderer facts and the Pi-fork scoping limitation).
 
 Missing, malformed, stale, untrusted, or unverified semantic state is unknown, never idle, and unknown is never promoted to busy either.
 Ordinary task-state consumers act only on an exact busy verdict, so an unreadable worker surfaces for a closer look instead of being absorbed as still-working or written off as finished.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -203,6 +203,41 @@ tests/fm-busy-adapter-wiring.test.sh
 tests/fm-crew-state.test.sh
 ```
 
+### Pi MCP tool-approval wait
+
+A Pi worker blocks its whole turn on a modal MCP tool-approval selector, and Pi fires no `agent_settled` while that modal waits, so the `pi-ext` record stays `busy` and both current-state and the watcher would read the wait as provably-working.
+[`bin/fm-busy-lib.sh`](../../bin/fm-busy-lib.sh)'s `fm_busy_pi_mcp_approval_selector` refines that exact selector to `approval-wait pi-mcp-approval`, scoped to harness `pi`/`pi-signed`, so [`bin/fm-crew-state.sh`](../../bin/fm-crew-state.sh) reports a `parked` tool-approval wait and supervision surfaces it instead of absorbing it.
+
+The rendered strings the detector anchors on were read from the installed sources on 2026-08-08: `pi-mcp-adapter` 2.20.1, `@earendil-works/pi-coding-agent` 0.84.1, bundled `@earendil-works/pi-tui` 0.84.1, `pi --version` 0.84.1, on Node v24.15.0.
+`pi-mcp-adapter/tool-approval.ts` builds the title ``MCP: ${serverName} wants to run ${toolName}`` and offers exactly `["Allow once", "Allow for session", "Deny"]`, and `pi-coding-agent`'s `ExtensionSelectorComponent` (`dist/modes/interactive/components/extension-selector.js`) renders that title above the three choices, one option per line, the selected one prefixed with an arrow.
+Pi's default renderer is `TuiMainScreen` (`dist/tui-main-screen.js`), a diff renderer that never commits the ephemeral selector to scrollback, so the selector is present in a capture only while it is on screen and reverts to the record's own verdict once answered or dismissed.
+
+The selector was reproduced deterministically with no network, MCP server, credentials, or model call by rendering the real component the way Pi does and stripping ANSI:
+
+```js
+// node, PIA=<pi-coding-agent install dir>
+const t = await import(`${process.env.PIA}/dist/modes/interactive/theme/theme.js`);
+t.initTheme("dark");
+const { ExtensionSelectorComponent } = await import(`${process.env.PIA}/dist/modes/interactive/components/extension-selector.js`);
+const title = `MCP: demo-notes wants to run list_notes\n\nArguments:\n${JSON.stringify({ limit: 5, folder: "inbox" }, null, 2)}`;
+const c = new ExtensionSelectorComponent(title, ["Allow once", "Allow for session", "Deny"], () => {}, () => {}, {});
+process.stdout.write(c.render(80).map((l) => l.replace(/\x1b\[[0-9;]*m/g, "")).join("\n"));
+```
+
+The stripped output, which is what `tmux capture-pane -p` returns, was the border rule, a blank line, the ` MCP: demo-notes wants to run list_notes` title, the ` Arguments:` block, then the three consecutive option lines ` → Allow once`, `   Allow for session`, `   Deny`, the ` ↑↓ navigate  enter select  escape/ctrl+c cancel` hint, and the closing border rule.
+
+Detection requires the `MCP: <server> wants to run <tool>` title line plus the three fixed choices as consecutive selector-option lines in order; it reads no other pane content and never the `Arguments` block or any argument value.
+Bounded limitation: when the `Arguments` block is tall enough to push the title line off the top of the captured region, detection conservatively reports no selector (a missed wait, never a false one), and the pre-existing stale path still surfaces the frozen pane.
+Fork scoping: only harness `pi`/`pi-signed` is refined, so a Pi fork such as OMP is covered only when it is launched as `pi`/`pi-signed` and its renderer is empirically identical to the strings above; a fork whose selector renders differently is out of scope and keeps the pre-existing generic stale surfacing.
+
+Deterministic entry points for the refinement:
+
+```sh
+tests/fm-busy-state.test.sh    # fm_busy_pi_mcp_approval_selector + classify positive, negative, scope, and clear
+tests/fm-crew-state.test.sh    # parked/tool-approval reconciliation, working, and clear-after-answer
+tests/fm-watch-triage.test.sh  # the approval wait surfaces (crew_is_provably_working is false)
+```
+
 ## Turn-end guard
 
 The direct and passive mechanisms were validated across all five harnesses on 2026-07-08 through 2026-07-12, with Claude's replacement Stop-owned path revalidated on 2026-07-24.

--- a/tests/fm-busy-state.test.sh
+++ b/tests/fm-busy-state.test.sh
@@ -246,6 +246,115 @@ Ctrl+c:cancel')
   pass "the grok fallback is regex-scoped to grok and classifies only grok tasks"
 }
 
+# --- Pi MCP tool-approval refinement -----------------------------------------
+
+# A faithful plain-text capture of Pi's MCP tool-approval selector, as
+# pi-mcp-adapter/tool-approval.ts builds the title/choices and pi-coding-agent's
+# ExtensionSelectorComponent renders them (docs/verification/supervision.md "Pi
+# MCP tool-approval wait"). The three choices stay CONSECUTIVE, as rendered.
+pi_mcp_approval_capture() {  # [server] [tool]
+  local server=${1:-demo-notes} tool=${2:-list_notes}
+  cat <<EOF
+────────────────────────────────────────────────────────────────────
+
+ MCP: $server wants to run $tool
+
+ Arguments:
+ {
+   "limit": 5,
+   "folder": "inbox"
+ }
+
+ → Allow once
+   Allow for session
+   Deny
+
+ ↑↓ navigate  enter select  escape/ctrl+c cancel
+────────────────────────────────────────────────────────────────────
+EOF
+}
+
+test_pi_approval_selector_detects_exact_modal() {
+  pi_mcp_approval_capture | fm_busy_pi_mcp_approval_selector \
+    || fail "the exact rendered Pi MCP approval selector must be detected"
+  pi_mcp_approval_capture chrome-devtools navigate | fm_busy_pi_mcp_approval_selector \
+    || fail "detection is structural, not tied to one server or tool name"
+  pass "the exact Pi MCP tool-approval selector is detected structurally"
+}
+
+test_pi_approval_selector_rejects_non_modal() {
+  if printf '%s\n' '• Working (6s • esc to interrupt)' 'Working...' 'Ctrl+c:cancel' \
+    | fm_busy_pi_mcp_approval_selector; then fail "a working footer must not detect"; fi
+  if printf '%s\n' ' → Allow once' '   Allow for session' '   Deny' \
+    | fm_busy_pi_mcp_approval_selector; then fail "choices without the MCP title must not detect"; fi
+  if printf '%s\n' ' MCP: srv wants to run tool' ' → Allow once' '   Deny' \
+    | fm_busy_pi_mcp_approval_selector; then fail "an incomplete choice set must not detect"; fi
+  if printf '%s\n' ' MCP: srv wants to run tool' 'Allow once' 'blah' 'Allow for session' 'x' 'Deny' \
+    | fm_busy_pi_mcp_approval_selector; then fail "non-consecutive choices must not detect"; fi
+  if printf '%s\n' ' MCP: srv wants to run tool' '  "a": "Allow once",' '  "b": "Allow for session",' '  "c": "Deny"' \
+    | fm_busy_pi_mcp_approval_selector; then fail "quoted argument values must not count as option lines"; fi
+  pass "the selector detector rejects footers, prose, incomplete, and quoted matches"
+}
+
+test_pi_busy_record_with_modal_reads_approval_wait() {
+  local state gen out
+  state=$(new_state_dir pi-approval)
+  gen=$("$EV" arm "$state" t1)
+  "$EV" apply "$state" t1 busy --gen "$gen" --source pi-ext --event agent-start
+  out=$(fm_busy_classify tmux w1 pi t1 "$state" "$(pi_mcp_approval_capture)")
+  [ "$out" = "approval-wait pi-mcp-approval" ] || fail "pi busy + modal must read approval-wait, got '$out'"
+  out=$(fm_busy_classify tmux w1 pi-signed t1 "$state" "$(pi_mcp_approval_capture)")
+  [ "$out" = "approval-wait pi-mcp-approval" ] || fail "pi-signed busy + modal must read approval-wait, got '$out'"
+  if fm_busy_is_busy tmux w1 pi t1 "$state" "$(pi_mcp_approval_capture)"; then
+    fail "approval-wait must not read as busy, so a supervisor surfaces it"
+  fi
+  pass "a busy pi-ext record with the approval modal reads an actionable approval-wait"
+}
+
+test_pi_genuine_work_stays_busy() {
+  local state gen out
+  state=$(new_state_dir pi-working)
+  gen=$("$EV" arm "$state" t1)
+  "$EV" apply "$state" t1 busy --gen "$gen" --source pi-ext --event agent-start
+  out=$(fm_busy_classify tmux w1 pi t1 "$state" "$(printf 'Working (12s)\nesc to interrupt\n')")
+  [ "$out" = "busy pi-ext" ] || fail "genuine pi work must stay busy, got '$out'"
+  out=$(fm_busy_classify tmux w1 pi t1 "$state" "")
+  [ "$out" = "busy pi-ext" ] || fail "pi busy with no tail must stay busy, never fabricate a wait, got '$out'"
+  pass "genuine un-settled Pi work stays busy; a missing tail never fabricates an approval wait"
+}
+
+test_pi_approval_clears_after_answer() {
+  local state gen out
+  state=$(new_state_dir pi-approval-clear)
+  gen=$("$EV" arm "$state" t1)
+  "$EV" apply "$state" t1 busy --gen "$gen" --source pi-ext --event agent-start
+  out=$(fm_busy_classify tmux w1 pi t1 "$state" "$(pi_mcp_approval_capture)")
+  [ "$out" = "approval-wait pi-mcp-approval" ] || fail "precondition: modal reads approval-wait, got '$out'"
+  # Answered/dismissed: Pi settles the turn. The refinement fires only on busy,
+  # so even with the selector still on the tail the wait clears via pi-ext.
+  "$EV" apply "$state" t1 idle --gen "$gen" --source pi-ext --event agent-settled
+  out=$(fm_busy_classify tmux w1 pi t1 "$state" "$(pi_mcp_approval_capture)")
+  [ "$out" = "idle pi-ext" ] || fail "an answered modal must clear to idle pi-ext, got '$out'"
+  pass "an answered or dismissed modal clears through pi-ext's own settle event"
+}
+
+test_pi_approval_only_refines_valid_pi_ext_record() {
+  local state state2 gen out
+  state=$(new_state_dir pi-approval-scope)
+  gen=$("$EV" arm "$state" t1)
+  "$EV" apply "$state" t1 busy --gen "$gen" --source pi-ext --event agent-start
+  # Another adapter rendering the same text is never refined: a pi-ext record is
+  # untrusted for grok, so it stays source-mismatch, never approval-wait.
+  out=$(fm_busy_classify tmux w1 grok t1 "$state" "$(pi_mcp_approval_capture)")
+  [ "$out" = "unknown source-mismatch" ] || fail "grok must not be refined to approval-wait, got '$out'"
+  # No record + the modal on the tail stays unknown: the refinement never
+  # invents busy (or approval-wait) from rendered text.
+  state2=$(new_state_dir pi-approval-norecord)
+  out=$(fm_busy_classify tmux w1 pi t1 "$state2" "$(pi_mcp_approval_capture)")
+  [ "$out" = "unknown missing" ] || fail "no record must stay unknown, not approval-wait, got '$out'"
+  pass "the approval refinement needs a valid busy pi-ext record and never invents state from text"
+}
+
 # --- kimi verification gate -----------------------------------------------------
 
 test_codex_unverified_gate() {
@@ -370,6 +479,12 @@ test_record_without_sidecar_unknown
 test_source_mismatch_cross_adapter
 test_converted_adapters_ignore_footer_text
 test_grok_regex_isolated
+test_pi_approval_selector_detects_exact_modal
+test_pi_approval_selector_rejects_non_modal
+test_pi_busy_record_with_modal_reads_approval_wait
+test_pi_genuine_work_stays_busy
+test_pi_approval_clears_after_answer
+test_pi_approval_only_refines_valid_pi_ext_record
 test_codex_unverified_gate
 test_kimi_unverified_gate
 test_dead_endpoint_overrides

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -845,6 +845,105 @@ test_no_run_grok_uses_isolated_fallback() {
   pass "grok still reads working through its isolated rendered-tail fallback"
 }
 
+# A faithful plain-text capture of Pi's MCP tool-approval selector (see
+# tests/fm-busy-state.test.sh and docs/verification/supervision.md "Pi MCP
+# tool-approval wait"). The three choices stay consecutive, as rendered.
+pi_mcp_approval_capture() {
+  cat <<'EOF'
+────────────────────────────────────────
+
+ MCP: demo-notes wants to run list_notes
+
+ Arguments:
+ {
+   "limit": 5
+ }
+
+ → Allow once
+   Allow for session
+   Deny
+
+ ↑↓ navigate  enter select  escape/ctrl+c cancel
+────────────────────────────────────────
+EOF
+}
+
+# A Pi worker blocked on its MCP tool-approval selector keeps a valid busy
+# pi-ext record (agent_settled never fires while the modal waits), which would
+# otherwise reconcile to working. Current-state must instead report an
+# actionable parked/tool-approval wait so supervision surfaces the trust wait.
+test_no_run_pi_mcp_approval_reads_parked() {
+  reset_fakes
+  local d; d=$(new_case pi-approval)
+  make_repo_on_branch "$d/wt" fm/feat-piapp
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-piapp.meta" "window=fm:fm-feat-piapp" "worktree=$d/wt" "kind=ship" "harness=pi"
+  FM_FAKE_AXI_STATUS=""
+  FM_FAKE_RUNS_LIST=""
+  FM_FAKE_BUSY=1
+  FM_FAKE_BUSY_TEXT=$(pi_mcp_approval_capture)
+  export FM_FAKE_BUSY_TEXT
+  local gen; gen=$("$ROOT/bin/fm-busy-event.sh" arm "$d/state" feat-piapp)
+  "$ROOT/bin/fm-busy-event.sh" apply "$d/state" feat-piapp busy --gen "$gen" \
+    --source pi-ext --event agent-start
+  local out; out=$(run_crew_state "$d" feat-piapp)
+  assert_contains "$out" "state: parked" "a Pi worker on the MCP approval modal reads parked, not working"
+  assert_contains "$out" "source: pane" "the approval wait is pane-sourced"
+  assert_contains "$out" "tool approval" "the detail names the tool-approval wait"
+  assert_not_contains "$out" "state: working" "the approval wait must never read working"
+  pass "a Pi MCP tool-approval wait reconciles to an actionable parked state, not working"
+}
+
+# Genuine un-settled Pi work (no selector on the pane) still reads working.
+test_no_run_pi_busy_without_modal_reads_working() {
+  reset_fakes
+  local d; d=$(new_case pi-working)
+  make_repo_on_branch "$d/wt" fm/feat-piwork
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-piwork.meta" "window=fm:fm-feat-piwork" "worktree=$d/wt" "kind=ship" "harness=pi"
+  FM_FAKE_AXI_STATUS=""
+  FM_FAKE_RUNS_LIST=""
+  FM_FAKE_BUSY=1
+  FM_FAKE_BUSY_TEXT='Working (12s)'
+  export FM_FAKE_BUSY_TEXT
+  local gen; gen=$("$ROOT/bin/fm-busy-event.sh" arm "$d/state" feat-piwork)
+  "$ROOT/bin/fm-busy-event.sh" apply "$d/state" feat-piwork busy --gen "$gen" \
+    --source pi-ext --event agent-start
+  local out; out=$(run_crew_state "$d" feat-piwork)
+  assert_contains "$out" "state: working" "genuine un-settled Pi work still reads working"
+  assert_contains "$out" "source: pane" "the working verdict is pane-sourced"
+  assert_not_contains "$out" "state: parked" "genuine work must not read parked"
+  pass "genuine un-settled Pi work still reconciles to working"
+}
+
+# Once the modal is answered, Pi settles the turn (agent_settled -> idle). Even
+# with the selector still on the rendered pane, the wait clears through pi-ext's
+# own lifecycle, so current-state moves off parked promptly.
+test_no_run_pi_approval_clears_after_answer() {
+  reset_fakes
+  local d; d=$(new_case pi-approval-clear)
+  make_repo_on_branch "$d/wt" fm/feat-piclear
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-piclear.meta" "window=fm:fm-feat-piclear" "worktree=$d/wt" "kind=ship" "harness=pi"
+  FM_FAKE_AXI_STATUS=""
+  FM_FAKE_RUNS_LIST=""
+  FM_FAKE_BUSY=1
+  FM_FAKE_BUSY_TEXT=$(pi_mcp_approval_capture)
+  export FM_FAKE_BUSY_TEXT
+  local gen; gen=$("$ROOT/bin/fm-busy-event.sh" arm "$d/state" feat-piclear)
+  "$ROOT/bin/fm-busy-event.sh" apply "$d/state" feat-piclear busy --gen "$gen" \
+    --source pi-ext --event agent-start
+  local out; out=$(run_crew_state "$d" feat-piclear)
+  assert_contains "$out" "state: parked" "precondition: the modal reconciles to parked"
+  "$ROOT/bin/fm-busy-event.sh" apply "$d/state" feat-piclear idle --gen "$gen" \
+    --source pi-ext --event agent-settled
+  printf 'done: implemented the change\n' > "$d/state/feat-piclear.status"
+  out=$(run_crew_state "$d" feat-piclear)
+  assert_not_contains "$out" "state: parked" "an answered modal must not keep reading parked"
+  assert_contains "$out" "state: done" "a settled turn falls through to the status log"
+  pass "an answered Pi approval modal clears promptly through the semantic settle event"
+}
+
 test_no_run_herdr_unknown_uses_backend_capture() {
   command -v jq >/dev/null 2>&1 || { pass "herdr pane fallback skipped without jq"; return; }
   reset_fakes
@@ -1336,6 +1435,9 @@ test_other_branch_run_ignored
 test_no_run_busy_pane
 test_no_run_footer_text_alone_is_not_working
 test_no_run_grok_uses_isolated_fallback
+test_no_run_pi_mcp_approval_reads_parked
+test_no_run_pi_busy_without_modal_reads_working
+test_no_run_pi_approval_clears_after_answer
 test_no_run_herdr_unknown_uses_backend_capture
 test_no_run_herdr_idle_agent_status_outranked_by_record
 test_no_run_herdr_idle_agent_status_and_idle_record_stays_idle

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -260,6 +260,11 @@ test_crew_is_provably_working_classifier() {
   ! crew_is_provably_working a || fail "finished run treated as provably working"
   FM_FAKE_CREW_STATE='state: parked · source: run-step · parked at review'
   ! crew_is_provably_working a || fail "parked run treated as provably working"
+  # A Pi worker blocked on its MCP tool-approval selector reconciles to a
+  # pane-sourced parked/tool-approval wait; it must surface, not be absorbed as
+  # provably-working, so supervision wakes firstmate to handle the trust wait.
+  FM_FAKE_CREW_STATE='state: parked · source: pane · waiting on tool approval (pi-mcp-approval)'
+  ! crew_is_provably_working a || fail "Pi MCP tool-approval wait treated as provably working"
   FM_FAKE_CREW_STATE='state: failed · source: run-step · run failed'
   ! crew_is_provably_working a || fail "failed run treated as provably working"
   FM_FAKE_CREW_STATE='state: unknown · source: none · worktree gone'


### PR DESCRIPTION
## Intent

Fix Firstmate's Pi MCP approval-modal false-working wedge. A Pi worker can stay visually on 'Working...' while pi-mcp-adapter is actually blocked at the modal MCP tool-approval selector ('MCP: <server> wants to run <tool>' plus Allow once / Allow for session / Deny). Pi fires no agent_settled while that modal waits, so the pi-ext busy record stays busy and both current-state reconciliation and the watcher read the wait as provably-working - the false-working wedge that hides an actionable approval decision from supervision.

Design decisions and constraints (deliberate, so they should not read as mistakes): (1) Detection is structural and scoped strictly to pi/pi-signed via a new fm_busy_pi_mcp_approval_selector helper; it requires BOTH the 'MCP: <server> wants to run <tool>' title AND the complete consecutive Allow once / Allow for session / Deny choice structure on the rendered tail. It deliberately does NOT classify from generic words, spinner glyphs, or 'Working...' alone, and never parses or exposes tool arguments. (2) Only when a genuinely busy pi-ext record coincides with that exact selector does fm_busy_classify report an approval-wait (pi-mcp-approval), so fm-crew-state reports a parked tool-approval wait and supervision surfaces it instead of absorbing it as busy. (3) Genuine un-settled Pi work stays working; an answered or dismissed modal clears through pi-ext's own agent_settled lifecycle with no extra state or teardown. (4) MCP approval authority is fully preserved: no auto-approval, no blanket session approval, no argument inspection, no weakening of personal-tool gates - detection only surfaces the wait for the existing harness-adapters authority procedure. (5) Scope is bounded to pi/pi-signed; OMP and other Pi forks are explicitly NOT claimed unless their renderer is empirically identical, and that bounded limitation plus renderer evidence is recorded in docs/verification/supervision.md. (6) Contract ownership stays in the existing busy-state/current-state/supervision owners; AGENTS.md was intentionally not expanded. (7) Added public-interface regression tests covering positive, negative, stale, and clear-after-answer cases without asserting source bytes; preserved all existing busy sources, stale/wedge behavior, terminal-state absorption, custom checks, PR merge polls, heartbeat semantics, durable notifications, and non-Pi harness behavior. A separate review-step fix also extends bin/fm-control.sh do_exit so the pre-exit interrupt fires for the new approval-wait verdict too (matching 'busy*|approval-wait*'), preserving the pre-existing behavior of dismissing a Pi modal before exit. This ships through a PR and must not be merged by the pipeline.

## What Changed

- Added `fm_busy_pi_mcp_approval_selector` and a Pi-scoped refinement in `bin/fm-busy-lib.sh`: when a genuinely busy `pi-ext` record coincides with Pi's exact rendered MCP tool-approval selector (`MCP: <server> wants to run <tool>` title plus the consecutive `Allow once` / `Allow for session` / `Deny` choices), `fm_busy_classify` now returns `approval-wait pi-mcp-approval` instead of `busy pi-ext`; detection reads only those structural anchors, never tool arguments, and reverts to the record's verdict once the modal is answered or dismissed.
- Wired the new verdict through supervision: `bin/fm-crew-state.sh` now captures the tail for `pi`/`pi-signed`, emits a `parked` "waiting on tool approval" state (never `working`), and `bin/fm-control.sh` `do_exit` interrupts on `approval-wait*` as well as `busy*` so the pre-exit modal dismissal still fires.
- Documented the new verdict in `docs/architecture.md`'s busy-state contract and recorded the renderer evidence, deterministic reproduction, bounded limitation, and Pi-fork scoping in `docs/verification/supervision.md`; added public-interface regression tests in `tests/fm-busy-state.test.sh` and `tests/fm-crew-state.test.sh` covering positive, negative, stale, scope, and clear-after-answer cases, plus a watcher-triage assertion in `tests/fm-watch-triage.test.sh`.

## Risk Assessment

✅ Low: The change is a tightly-scoped, structural busy-state refinement with a matching do_exit companion fix; every verdict consumer was traced and correctly treats the new approval-wait state as surfaceable-not-busy with no destructive path, and comprehensive positive/negative/stale/clear tests plus verification docs back it.

## Testing

Ran the three smallest relevant hermetic suites (fm-busy-state, fm-crew-state, fm-watch-triage) — all pass, exercising the new fm_busy_pi_mcp_approval_selector helper and the busy→approval-wait refinement across positive, negative, stale/no-record, scope, and clear-after-answer cases. Beyond unit assertions I produced product-level CLI transcripts using the real production scripts: feeding Pi's exact rendered tool-approval modal through fm_busy_classify yields `approval-wait pi-mcp-approval` (reads NOT busy), genuine 'Working...' stays `busy pi-ext`, an answered modal clears to `idle pi-ext`, and fm-crew-state emits the operator-visible line `state: parked · source: pane · waiting on tool approval (pi-mcp-approval)` — directly demonstrating the false-working wedge is surfaced instead of absorbed. This is a CLI/text supervision surface (no UI/HTML), so evidence is captured as CLI transcripts rather than screenshots. Worktree left clean; evidence written to the dedicated evidence dir.

<details>
<summary>Evidence: Pi MCP approval-wait end-to-end transcript (real scripts)</summary>

```text
============================================================
SCENARIO A — Pi turn genuinely working (no modal on screen)
============================================================
rendered tail   : Working (12s) / esc to interrupt
busy classify   : busy pi-ext
reads as busy?  : YES

============================================================
SCENARIO B — Pi turn BLOCKED on the MCP tool-approval modal
  (agent_settled never fires -> record still says busy)
============================================================
--- rendered pane the operator sees ---
────────────────────────────────────────────────────────────────────
 MCP: demo-notes wants to run list_notes

 Arguments:
 {
   "limit": 5,
   "folder": "inbox"
 }

 → Allow once
   Allow for session
   Deny

 ↑↓ navigate  enter select  escape/ctrl+c cancel
────────────────────────────────────────────────────────────────────
--- classification of that same record+pane ---
busy classify   : approval-wait pi-mcp-approval   <-- surfaced, NOT 'busy pi-ext'
reads as busy?  : NO <-- so supervision cannot absorb it as working

============================================================
SCENARIO C — operator answers the modal; Pi settles the turn
============================================================
classify (even with selector still on tail) : idle pi-ext
  -> clears through pi-ext's own agent_settled lifecycle, no extra state

============================================================
SCENARIO D — do_exit interrupt gate (bin/fm-control.sh:452)
============================================================
case pattern for pre-exit interrupt: busy*|approval-wait*
  verdict "busy pi-ext"                -> INTERRUPT before exit (dismiss modal)
  verdict "approval-wait pi-mcp-approval" -> INTERRUPT before exit (dismiss modal)
  verdict "idle pi-ext"                -> exit directly
```
</details>
<details>
<summary>Evidence: Operator-visible fm-crew-state parked output</summary>

`state: parked · source: pane · waiting on tool approval (pi-mcp-approval)`

```text
/dev/fd/63: line 31: /dev/fd/lib.sh: No such file or directory
OPERATOR-VISIBLE fm-crew-state OUTPUT (Pi blocked on MCP approval modal):
state: parked · source: pane · waiting on tool approval (pi-mcp-approval)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `fm-busy-state.test.sh`
- `fm-crew-state.test.sh`
- `fm-watch-triage.test.sh`
- `manual e2e classify + crew-state transcript`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
