### PR TITLE
test: gate Pi Calm follow-up pane assertions on rendered output

### DIFF
--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -36,9 +36,15 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Gate every pane assertion on this helper. Pi persists a completed turn to its
+# session file before it repaints the TUI, and under full-suite load that repaint
+# has been observed to lag persistence by seconds, so a pane read taken straight
+# off a session-file wait can hold none of the turn. The bound is generous for
+# that reason: it only removes false negatives, since a genuinely absent row
+# still fails once the loop runs out.
 wait_for_text() {
   local file=$1 text=$2 i=0
-  while [ "$i" -lt 120 ]; do
+  while [ "$i" -lt 400 ]; do
     # Include recent scrollback: expanding a long restored transcript can move
     # the asserted tool output above the current viewport while the footer and
     # editor remain visible.
@@ -1353,7 +1359,7 @@ JS
 }
 
 test_operational_followup_turn_e2e() {
-  local project home config sessions version label case_name calm_state expected_notifications session_file pane i captain_line handled_line geometry_gap exact_session
+  local project home config sessions version label case_name calm_state expected_notifications session_file pane pane_file captain_answers i captain_line handled_line geometry_gap exact_session
   if ! command -v pi >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then
     echo "skip: pi or tmux not found for Pi operational follow-up E2E"
     return 0
@@ -1552,11 +1558,18 @@ TS
       fail "Pi follow-up $label case did not process the monitoring notification"
     fi
 
-    pane=$(tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - 2>/dev/null || true)
-    [ "$(printf '%s\n' "$pane" | grep -Fc "CAPTAIN_ANSWER_$label" || true)" -eq 1 ] \
-      || fail "Pi follow-up $label case rendered a duplicate captain answer"
+    # The session-file wait above proves persistence, not rendering, so wait for
+    # the turn's last row to actually reach the pane before reading it. The
+    # captain-answer count below cannot tell an unrendered turn from a duplicated
+    # one, and would report the former as the latter.
+    pane_file="$TMP_ROOT/followup-pane-$label.txt"
+    wait_for_text "$pane_file" "MONITOR_HANDLED_${label}_ONE" \
+      || fail "Pi follow-up $label case did not render the intended processing result"
+    pane=$(cat "$pane_file")
+    captain_answers=$(printf '%s\n' "$pane" | grep -Fc "CAPTAIN_ANSWER_$label" || true)
+    [ "$captain_answers" -eq 1 ] \
+      || fail "Pi follow-up $label case rendered $captain_answers captain answer rows instead of exactly one"
     assert_contains "$pane" "CAPTAIN_PROMPT_$label" "Pi follow-up $label case hid the genuine captain prompt"
-    assert_contains "$pane" "MONITOR_HANDLED_${label}_ONE" "Pi follow-up $label case did not render the intended processing result"
     if [ "$calm_state" = on ]; then
       assert_not_contains "$pane" "MONITOR_${label}_ONE" "Pi follow-up $label case rendered a Calm-hidden operational user row"
       if [ "$label" = exact_watcher ]; then
@@ -1655,15 +1668,11 @@ JS
     printf '%s\n' on >"$home/config/calm"
     tmux -L "$TMUX_SOCKET" new-session -d -s "$TMUX_SESSION" -x 160 -y 36 \
       "cd '$project' && env FM_HOME='$home' PI_CODING_AGENT_DIR='$config' FM_OPERATIONAL_INPUT_SCRIPT='$OPERATIONAL_INPUT' PI_OFFLINE=1 pi --approve --no-context-files --no-skills --no-prompt-templates --no-extensions -e ./.pi/extensions/fm-calm.ts -e ./followup-e2e.ts --session '$exact_session'; rc=\$?; printf '\nPI_EXIT=%s\n' \"\$rc\"; sleep 20"
-    i=0
-    while [ "$i" -lt 120 ]; do
-      pane=$(tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - 2>/dev/null || true)
-      printf '%s\n' "$pane" | grep -Fq 'MONITOR_HANDLED_exact_watcher_ONE' && break
-      sleep 0.05
-      i=$((i + 1))
-    done
+    pane_file="$TMP_ROOT/followup-pane-restart-replay.txt"
+    wait_for_text "$pane_file" 'MONITOR_HANDLED_exact_watcher_ONE' \
+      || fail "Pi restart lost the operational processing response"
+    pane=$(cat "$pane_file")
     assert_contains "$pane" "CAPTAIN_PROMPT_exact_watcher" "Pi restart lost the genuine captain prompt"
-    assert_contains "$pane" "MONITOR_HANDLED_exact_watcher_ONE" "Pi restart lost the operational processing response"
     assert_not_contains "$pane" "FIRSTMATE WATCHER WAKE: signal: /home/fixture/github/kunchenguid/firstmate/state/oss-triage-t4.status" \
       "Pi restart replayed the Calm-hidden exact watcher row"
     captain_line=$(printf '%s\n' "$pane" | grep -Fn 'CAPTAIN_ANSWER_exact_watcher' | tail -1 | cut -d: -f1)

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -44,12 +44,21 @@ trap cleanup EXIT
 # still fails once the loop runs out.
 wait_for_text() {
   local file=$1 text=$2 i=0
+  # Stage each capture through a scratch path and promote it only when tmux
+  # succeeds. Writing straight to $file truncates it before tmux runs, so a
+  # capture against a session that has already exited would discard the last
+  # good frame - the one holding PI_EXIT and any startup error, and the only
+  # thing the dump below has to report.
+  local scratch="$TMP_ROOT/wait-for-text-capture.txt"
+  : >"$file"
   while [ "$i" -lt 400 ]; do
     # Include recent scrollback: expanding a long restored transcript can move
     # the asserted tool output above the current viewport while the footer and
     # editor remain visible.
-    tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S -600 >"$file" 2>/dev/null || true
-    grep -Fq "$text" "$file" 2>/dev/null && return 0
+    if tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S -600 >"$scratch" 2>/dev/null; then
+      mv -f "$scratch" "$file"
+      grep -Fq "$text" "$file" 2>/dev/null && return 0
+    fi
     sleep 0.05
     i=$((i + 1))
   done

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -53,6 +53,9 @@ wait_for_text() {
     sleep 0.05
     i=$((i + 1))
   done
+  # Emit the frame that never showed the text: TMP_ROOT is removed by the EXIT
+  # trap even on failure, so this is the only surviving evidence for a caller.
+  cat "$file" >&2
   return 1
 }
 
@@ -1533,14 +1536,8 @@ TS
 
     tmux -L "$TMUX_SOCKET" new-session -d -s "$TMUX_SESSION" -x 160 -y 36 \
       "cd '$project' && env FM_HOME='$home' PI_CODING_AGENT_DIR='$config' FM_OPERATIONAL_INPUT_SCRIPT='$OPERATIONAL_INPUT' PI_OFFLINE=1 pi --approve --no-context-files --no-skills --no-prompt-templates --no-extensions $extensions $session_arg; rc=\$?; printf '\nPI_EXIT=%s\n' \"\$rc\"; sleep 20"
-    i=0
-    while [ "$i" -lt 120 ]; do
-      pane=$(tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - 2>/dev/null || true)
-      printf '%s\n' "$pane" | grep -Fq 'followup-e2e.ts' && break
-      sleep 0.05
-      i=$((i + 1))
-    done
-    printf '%s\n' "$pane" | grep -Fq 'followup-e2e.ts' \
+    pane_file="$TMP_ROOT/followup-composer-$label.txt"
+    wait_for_text "$pane_file" 'followup-e2e.ts' \
       || fail "Pi follow-up $case_name case ($label) did not reach the ready composer"
 
     tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/followup-e2e $label $shape"


### PR DESCRIPTION
## Intent

Get tests/fm-calm-pi-extension.test.sh passing on the default branch, and fix the right thing rather than the convenient thing.

Known at intake: the test was reported failing on a clean default branch, found by another worker running a changed-file sweep for an unrelated change, and confirmed failing on base commit 76355e2, so it is pre-existing. The cause, scope, and when it started were all open and explicitly not to be assumed. The test exercises the Pi Calm extension; .pi/extensions/fm-calm.ts is the subject.

Required approach: reproduce first and confirm it genuinely fails rather than being specific to one worktree or machine; establish when it went red; deliberately decide whether the test is wrong or the thing it tests is wrong, since both are legitimate outcomes and picking whichever is easier to make green is not; then fix it and make sure the fix is covered so the same regression cannot return silently.

Hard constraints accepted: do not delete, skip, or weaken the test to reach green without escalating first, because a removed or neutered assertion is indistinguishable from a passing one afterwards. Stay scoped to this failure and report other nearby problems rather than folding them in. Anything touched stays shellcheck-clean. If the failure turned out to be a genuine defect in the Calm extension's behaviour rather than a test problem, say so plainly in the PR.

WHAT THE INVESTIGATION ESTABLISHED

The premise in the original report was wrong in an important way, and this is the headline result. The test is not permanently red - it is flaky, at roughly a 50 percent rate (three failures in six full-suite runs, on two different cases: 'absent' and 'loaded_off'). The failure is in the test, not in the Calm extension.

Root cause: test_operational_followup_turn_e2e's run_followup_case waited for the completed turn to reach Pi's session .jsonl file, then read the tmux pane immediately. Persistence and rendering are independent - Pi writes the turn to its session file before it repaints the TUI, and under full-suite load that repaint was observed lagging persistence by seconds. The pane read therefore landed on a pre-repaint frame carrying none of the turn at all, so the count of CAPTAIN_ANSWER_<label> occurrences was 0.

The assertion demanded exactly 1 and reported any other number, including 0, as 'rendered a duplicate captain answer'. That message disguised a test race as a Calm rendering defect and is what made this look like a permanent product bug.

Two independent pieces of evidence rule out the Calm extension: the failure also reproduces in the extension-absent case, where fm-calm.ts is never loaded at all; and in every observed failure the persisted session semantics were correct and the full correct transcript appeared in the pane about three seconds later. A standalone single-case reproduction outside the full suite passed consistently, consistent with a load-sensitive repaint lag rather than a behavioural defect.

Deliberate decision recorded: the test is wrong, not the code. Nothing was deleted, skipped, or weakened.

THE CHANGE, ACROSS THREE COMMITS ALREADY ON THIS BRANCH

Commit 1 (f64b91c) gates the turn-render and restart-replay pane assertions on the turn's last rendered row actually reaching the pane, using this file's own existing wait_for_text helper so there is one owner for 'wait until the pane shows this text'; reports the observed count in the failure message so a future failure distinguishes a missing turn from a duplicated one, which is the coverage that stops this regression returning silently mislabelled; and raises wait_for_text's bound from 120 to 400 iterations to cover the observed repaint lag, which only removes false negatives since a genuinely absent row still fails once the loop runs out. Two now-redundant assert_contains calls were folded into the gates, which assert the same predicate more strictly and keep the original failure message text - a strengthening, not a removal.

Commit 2 (4ca5f93) converts the remaining inline composer-readiness pane wait onto wait_for_text. This was flagged at review as out of the original scope and was explicitly approved by the repo owner, whose reasoning was: ninety clean runs do not prove a timing race absent, they only show it is less likely under the conditions tested; and leaving it means two different mechanisms own the same wait, so whoever fixes one later will not know the other exists. Clearing the whole race class was preferred over clearing one instance of it. Do not re-flag this as scope creep - it is a deliberate owner decision.

Commit 3 (4037167) fixes a real regression that commits 1 and 2 introduced together, caught at fix review: raising the bound past the 20-second tmux keepalive meant that on a genuine startup failure the final capture ran against a dead session, truncated the pane file to empty, and printed a blank dump in exactly the case the dump was added for. wait_for_text now stages each capture through a scratch path and promotes it only when tmux exits 0, so the last good frame - the one holding PI_EXIT and any startup error - survives for every caller.

VERIFICATION

Pi 0.80.6 on macOS: 3 failures in 6 runs before the fix; 10 consecutive passes after. Negative check proving the duplicate detection is intact rather than papered over: injecting a second rendered captain answer into the fixture's response makes the test fail with 'rendered 2 captain answer rows instead of exactly one'. bin/fm-lint.sh clean against pinned ShellCheck 0.11.0, verified by hand at the current head because ShellCheck is not installed on this machine and the pipeline's own lint step exits 127 without running.

SETTLED POINTS FROM THE PRIOR RUN - do not re-litigate

- Capture depth narrowing from -S - to -S -600 was reviewed and accepted as inert: these panes are about 30 lines against a 600-line window, and the geometry assertions compare a line difference so they are invariant to capture start.
- Verification ran on Pi 0.80.6, below the 0.81.1-0.82.0 range named as known-good evidence in the test header and the Calm verification records. This was reviewed and accepted: docs/calm.md states Calm has no numeric Pi minimum or maximum, the adapters probe the API seam rather than gating on version, and this change alters no Calm behaviour, so no compatibility claim went stale. No new dated verification record was added because repo documentation rules route task chronology and delivery evidence to the PR.
- Scope note reported rather than folded in: the other test scripts that mix session-file waits with pane captures (fm-control-relaunch, fm-control, fm-muse-signals-live-e2e) do not share this pattern, so the race was contained to this file.

DELIVERY

The prior run passed review, test, document and lint, then failed at push with a 403: the authenticated account has pull but not push on kunchenguid/firstmate. The repo owner decided to deliver through a fork. The gate has been repointed at https://github.com/FrancisDgtSol/firstmate.git via the supported no-mistakes init --fork-url path, and custody of the three validated commits was returned through the supported axi sync --recover path - nothing was hand-edited, restarted around, or forced, and no work was rebuilt. The pull request should open from FrancisDgtSol:fm/fm-calm-pi-extension-test-red against kunchenguid/firstmate main. Delivery mode for this task is no-mistakes.

## What Changed

- `run_followup_case` in `tests/fm-calm-pi-extension.test.sh` previously waited for the completed turn to land in Pi's session `.jsonl` and then read the tmux pane immediately. Persistence and rendering are independent, so under full-suite load the read landed on a pre-repaint frame holding none of the turn, and the exactly-one `CAPTAIN_ANSWER_<label>` check reported the resulting 0 as a duplicate. The turn-render and restart-replay pane assertions now gate on the turn's last rendered row (`MONITOR_HANDLED_..._ONE`) reaching the pane via the file's existing `wait_for_text` helper, and the count is reported in the failure message so a missing turn is no longer mislabelled as a duplicated one. Two now-redundant `assert_contains` calls were folded into those gates, which assert the same predicate more strictly and keep the original message text.
- `wait_for_text`'s bound went from 120 to 400 iterations to cover the observed repaint lag, and the remaining inline composer-readiness pane wait was converted onto the same helper so one mechanism owns "wait until the pane shows this text".
- `wait_for_text` now stages each `capture-pane` through a scratch path and promotes it only when tmux exits 0. Writing straight into the dump file truncated it before tmux ran, so once the raised bound outlived the 20-second tmux keepalive a genuine startup failure printed a blank dump; the last good frame - the one carrying `PI_EXIT` and any startup error - now survives for every caller.

This is a test-side fix, not a product one. The failure reproduces in the extension-absent case where `.pi/extensions/fm-calm.ts` is never loaded, and in every observed failure the persisted session semantics were correct and the full transcript appeared in the pane about three seconds later - so the Calm extension's rendering behaviour is unchanged and was never at fault. Nothing was deleted, skipped, or weakened. Measured 3 failures in 6 full-suite runs before the fix and 10 consecutive passes after (Pi 0.80.6, macOS); the Test gate reports 11 ok / 0 not ok across three runs at the target commit plus a pre-fix reproduction on the base commit, and a negative check confirming an injected second captain answer still fails with `rendered 2 captain answer rows instead of exactly one`.

Two notes carried forward rather than folded in: `test_hidden_block_geometry_e2e` still owns its own wait/capture pair with the old bound and unstaged capture (Review flagged this as a latent consistency risk with no evidence of flaking; converging it would need a capture-depth parameter on `wait_for_text`, since its `grep -n -m1` and `assert_not_contains` checks are not invariant to a `-S -600` capture). The Lint gate exited 127 without running because ShellCheck is not installed on the runner; `bin/fm-lint.sh` was verified clean by hand against pinned ShellCheck 0.11.0 at the current head.

## Risk Assessment

✅ Low: Well-bounded change to a single test file that strictly strengthens the assertions it touches (waits replace bare greps, failure messages gain the observed count), deletes or weakens nothing, and whose third commit already repairs the dead-session capture regression the first two introduced; the gated text is verifiably the turn's last rendered row, so the fix closes the identified race rather than relocating it.

## Testing

Reproduced the reported failure on this machine using the base-commit test file (red on the 'absent' case with the original misleading duplicate message), then ran the fixed file three times to a full 11/11 pass, with two of those runs deliberately concurrent so they generated the load condition the flake needs. Added a negative check proving the duplicate assertion still fires and now reports the observed count, and a focused probe showing the commit-3 capture staging preserves the failing pane frame where the previous helper dumped an empty file. Captured the actual Pi TUI panes for every case as the end-user surface - this is a terminal application with no graphical surface, so the reviewer-visible artifact is the rendered terminal frame rather than a screenshot, and it shows Calm hiding the operational row Calm-on and rendering it Calm-off, unchanged by this test-only fix. All targeted validation passed; no findings.

<details>
<summary>Evidence: Verification summary (red/green, negative check, commit-3 probe)</summary>

<code>RED (pre-fix test file, b5d430d):&#10;not ok - Pi follow-up absent case rendered a duplicate captain answer&#10;-&gt; reproduced independently in this run, on the &#34;absent&#34; case, with the old&#10;message that mislabels a missing turn as a duplicate.&#10;&#10;GREEN (fixed test file, e9e9ed7):&#10;run 1: 11 ok / 0 not ok&#10;run 2: 11 ok / 0 not ok&#10;run 3: 11 ok / 0 not ok&#10;runs 2 and 3 ran concurrently with each other and with the failing pre-fix run.&#10;&#10;NEGATIVE CHECK (second captain answer injected into the fixture response):&#10;not ok - Pi follow-up loaded_on case rendered 2 captain answer rows instead of exactly one&#10;-&gt; duplicate detection is intact and now reports the observed count.&#10;&#10;COMMIT 3 PROBE (dump survives a capture against a dead session):&#10;before_fix: wait timed out (expected); failure dump = 0 bytes&#10;--- dump-before_fix.txt ---&#10;(empty - no evidence for the caller)&#10;--- end ---&#10;after_fix: wait timed out (expected); failure dump = 105 bytes&#10;--- dump-after_fix.txt ---&#10;PI STARTUP ERROR: failed to load extension ./followup-e2e.ts&#10;PI_EXIT=1&#10;--- end ---</code>

```text
Local Test verification - fm/fm-calm-pi-extension-test-red @ e9e9ed7
Host: macOS, Pi 0.80.6, tmux 3.7b. Host was under heavy concurrent load throughout
(load avg 135-177 at the start of run 1), which is the condition the flake needs.

RED (pre-fix test file, b5d430d):  not ok - Pi follow-up absent case rendered a duplicate captain answer
  -> reproduced independently in this run, on the "absent" case, with the old
     message that mislabels a missing turn as a duplicate.

GREEN (fixed test file, e9e9ed7):
  run 1: 11 ok / 0 not ok
  run 2: 11 ok / 0 not ok
  run 3: 11 ok / 0 not ok
  runs 2 and 3 ran concurrently with each other and with the failing pre-fix run.

NEGATIVE CHECK (second captain answer injected into the fixture response):
  not ok - Pi follow-up loaded_on case rendered 2 captain answer rows instead of exactly one
  -> duplicate detection is intact and now reports the observed count.

COMMIT 3 PROBE (dump survives a capture against a dead session):
  before_fix: wait timed out (expected); failure dump = 0 bytes
  --- dump-before_fix.txt ---
  (empty - no evidence for the caller)
  --- end ---
  after_fix: wait timed out (expected); failure dump = 105 bytes
  --- dump-after_fix.txt ---
  PI STARTUP ERROR: failed to load extension ./followup-e2e.ts
  PI_EXIT=1
  --- end ---
```
</details>
<details>
<summary>Evidence: Rendered Pi TUI pane - Calm on vs Calm off (end-user surface)</summary>

<code>===== Calm ON - operational row hidden, two-row geometry =====&#10;pi v0.80.6&#10;[Extensions]&#10;fm-calm.ts, followup-e2e.ts&#10;&#10;CAPTAIN_PROMPT_loaded_on&#10;&#10;&#10;CAPTAIN_ANSWER_loaded_on&#10;&#10;MONITOR_HANDLED_loaded_on_ONE&#10;────────────────────────────────────────────────────────────&#10;&#10;===== Calm OFF - same turn, operational row rendered =====&#10;CAPTAIN_PROMPT_loaded_off&#10;&#10;&#10;CAPTAIN_ANSWER_loaded_off&#10;&#10;&#10;⁣FIRSTMATE_OP: v1 watcher: MONITOR_loaded_off_ONE&#10;&#10;&#10;MONITOR_HANDLED_loaded_off_ONE&#10;&#10;Exactly one CAPTAIN_ANSWER row in each - Calm rendering is unchanged by this test-only fix.</code>

```text

 pi v0.80.6
 escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more
 Press ctrl+o to show full startup help and loaded resources.

 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.

[Extensions]
  fm-calm.ts, followup-e2e.ts


 Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf and restart tmux.


 CAPTAIN_PROMPT_loaded_on


 CAPTAIN_ANSWER_loaded_on

 MONITOR_HANDLED_loaded_on_ONE

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
/private/var/folders/cm/9v4h6csn06l01n4bwyhycy440000gn/T/fm-calm-pi-extension.z2iPvx/followup-project (main)
0.8%/4.1k (auto)                                                                                                                                   deterministic
```
</details>
<details>
<summary>Evidence: Pre-fix failure reproduced on this host (base commit test file)</summary>

<code>ok - Pi calm centralizes transcript visibility, preserves execution/export data, keeps Pi&#39;s stock working row visible while no run is active, and persists its choice across session starts&#10;not ok - Pi follow-up absent case rendered a duplicate captain answer</code>

```text
ok - Pi calm resolves its persistent home independently of Pi's launch directory
ok - Pi calm compatibility evidence never rejects a Pi version for being newer than 0.82.0, and still fails closed on a missing or malformed version
ok - a missing collapsed-thinking presentation API degrades only that Calm adapter with a clear skip reason, while the rest of Calm still registers
ok - missing Pi presentation class exports reach the independent adapter degradation path
ok - Calm registers none of its 7 built-in tool wrappers at load while config/calm is off, and all 7 synchronously at load while config/calm is on
ok - Calm's first same-session /calm activation claims every uncontested built-in, leaves a foreign bash tool fully intact and callable, warns prominently and logs the contested name, and only rows constructed before that activation - the documented bound - fail to retroactively collapse
ok - Pi calm centralizes transcript visibility, preserves execution/export data, keeps Pi's stock working row visible while no run is active, and persists its choice across session starts
not ok - Pi follow-up absent case rendered a duplicate captain answer
```
</details>
<details>
<summary>Evidence: Negative check - injected duplicate captain answer still detected</summary>

`not ok - Pi follow-up loaded_on case rendered 2 captain answer rows instead of exactly one`

```text
not ok - Pi follow-up loaded_on case rendered 2 captain answer rows instead of exactly one
```
</details>
<details>
<summary>Evidence: Commit-3 probe - last good pane frame survives a capture against a dead session</summary>

<code>before_fix: wait timed out (expected); failure dump = 0 bytes&#10;(empty - no evidence for the caller)&#10;&#10;after_fix: wait timed out (expected); failure dump = 105 bytes&#10;PI STARTUP ERROR: failed to load extension ./followup-e2e.ts&#10;PI_EXIT=1</code>

```text
before_fix: wait timed out (expected); failure dump = 0 bytes
--- dump-before_fix.txt ---
(empty - no evidence for the caller)
--- end ---
after_fix: wait timed out (expected); failure dump = 105 bytes
--- dump-after_fix.txt ---
PI STARTUP ERROR: failed to load extension ./followup-e2e.ts
PI_EXIT=1
--- end ---
```
</details>
<details>
<summary>Evidence: Full-file run logs at target commit (3 runs, 11/11 each)</summary>

```text
ok - Pi calm resolves its persistent home independently of Pi's launch directory
ok - Pi calm compatibility evidence never rejects a Pi version for being newer than 0.82.0, and still fails closed on a missing or malformed version
ok - a missing collapsed-thinking presentation API degrades only that Calm adapter with a clear skip reason, while the rest of Calm still registers
ok - missing Pi presentation class exports reach the independent adapter degradation path
ok - Calm registers none of its 7 built-in tool wrappers at load while config/calm is off, and all 7 synchronously at load while config/calm is on
ok - Calm's first same-session /calm activation claims every uncontested built-in, leaves a foreign bash tool fully intact and callable, warns prominently and logs the contested name, and only rows constructed before that activation - the documented bound - fail to retroactively collapse
ok - Pi calm centralizes transcript visibility, preserves execution/export data, keeps Pi's stock working row visible while no run is active, and persists its choice across session starts
ok - Pi operational follow-up E2E processes exact user-role notifications once while Calm hides current and adjacent rows, Calm off and absent render them, and restart preserves semantics
ok - Pi Calm native /skill:ahoy geometry keeps every collapsed thinking and tool block at zero height while preserving expansion, history, restart, and Calm-off rendering
ok - Pi Calm working ship moves on a slow independent cadence over faster fixed-cell blue water, paints the complete boat standard yellow with balanced resets, keeps ANSI-stripped width exact, flips the directional sail on the exact bounce at both edges and every width, clamps visible and hidden resizes, falls back deterministically when narrow, freezes and resumes column/direction across settle/start without hidden-time jumps or duplicate timers, resets only on a fresh session, and installs and removes one scheduler-owning widget across starts, settle, abort, failure, shutdown, reload, replacement, and Calm toggles while leaving Calm-off visibility untouched
ok - Pi calm native E2E replaces the stock working row with a moving, resize-clamped working ship that freezes and resumes across two working periods in one Pi session, clears on abort, keeps captain turns visible, hides exact operational user rows without changing persistence, restores stock rendering Calm-off, survives restart, and preserves export plus Ctrl+O behavior
bash tests/fm-calm-pi-extension.test.sh  49.38s user 31.62s system 18% cpu 7:06.49 total
```
</details>
<details>
<summary>Evidence: Scratch harness diffs used for the negative check and pane capture</summary>

```text
diff --git a/tests/fm-calm-pi-extension.test.sh b/tests/fm-calm-pi-extension.negcheck.test.sh
old mode 100755
new mode 100644
index 602585e..eafa2c4
--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.negcheck.test.sh
@@ -1463,12 +1463,12 @@ export default function (pi: ExtensionAPI): void {
         .map((message) => contentText(message.content))
         .join("\n");
       const responseText = latestInputRole === "custom"
-        ? `CAPTAIN_ANSWER_${label}`
+        ? `CAPTAIN_ANSWER_${label}\nCAPTAIN_ANSWER_${label}`
         : allUserText.includes(monitorInput("ONE"))
           ? adjacent && allUserText.includes(monitorInput("TWO"))
             ? `MONITOR_HANDLED_${label}_ONE_TWO`
             : `MONITOR_HANDLED_${label}_ONE`
-          : `CAPTAIN_ANSWER_${label}`;
+          : `CAPTAIN_ANSWER_${label}\nCAPTAIN_ANSWER_${label}`;
       const output: AssistantMessage = {
         role: "assistant",
         content: [],
@@ -1612,7 +1612,7 @@ const text = (content) => typeof content === "string"
   ? content
   : (content ?? []).filter((item) => item.type === "text").map((item) => item.text).join("\n");
 const captainPrompt = `CAPTAIN_PROMPT_${label}`;
-const captainAnswer = `CAPTAIN_ANSWER_${label}`;
+const captainAnswer = `CAPTAIN_ANSWER_${label}\nCAPTAIN_ANSWER_${label}`;
 const handled = expected === 2
   ? `MONITOR_HANDLED_${label}_ONE_TWO`
   : `MONITOR_HANDLED_${label}_ONE`;
@@ -3667,14 +3667,14 @@ JS
   pass "Pi calm native E2E replaces the stock working row with a moving, resize-clamped working ship that freezes and resumes across two working periods in one Pi session, clears on abort, keeps captain turns visible, hides exact operational user rows without changing persistence, restores stock rendering Calm-off, survives restart, and preserves export plus Ctrl+O behavior"
 }
 
-test_home_resolution
-test_pi_compat_no_upper_bound
-test_pi_compat_degraded_adapter
-test_pi_compat_missing_adapter_exports
-test_builtin_gate_load_time
-test_calm_activation_collision_and_regression_bound
-test_rendering_and_session_lifecycle
+#test_home_resolution
+#test_pi_compat_no_upper_bound
+#test_pi_compat_degraded_adapter
+#test_pi_compat_missing_adapter_exports
+#test_builtin_gate_load_time
+#test_calm_activation_collision_and_regression_bound
+#test_rendering_and_session_lifecycle
 test_operational_followup_turn_e2e
-test_hidden_block_geometry_e2e
-test_working_ship_geometry_and_lifecycle
-test_interactive_terminal_e2e
+#test_hidden_block_geometry_e2e
+#test_working_ship_geometry_and_lifecycle
+#test_interactive_terminal_e2e
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `tests/fm-calm-pi-extension.test.sh:1838` - Residual second owner of the same pane-wait, reported not folded in per the intent&#39;s scope constraint. test_hidden_block_geometry_e2e still carries its own wait_for_geometry_text/capture_geometry_viewport pair (lines 1833-1846), which retains exactly the two properties commits 1 and 3 fixed in wait_for_text: the old 120-iteration (~6s) bound, and a capture that redirects straight into $file so a failed tmux capture truncates the frame to empty. That is the same &#39;two different mechanisms own the same wait&#39; hazard the owner cited when approving commit 2, one function away in the same file. Note it is not a trivial merge: assert_geometry_gap uses grep -n -m1 (first match) and the block&#39;s assert_not_contains checks would both break against a -S -600 capture, so converging would require giving wait_for_text a capture-depth parameter rather than just swapping the call. No source evidence here shows the geometry block has actually flaked, so this is a consistency/latent-risk note, not a reachable defect.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-calm-pi-extension.test.sh` - full file at target commit e9e9ed7, run 1 under host load avg ~177: 11 ok / 0 not ok</code>
- <code>`bash tests/fm-calm-pi-extension.test.sh` - runs 2 and 3, executed concurrently with each other and with the pre-fix run: 11 ok / 0 not ok each</code>
- <code>Pre-fix reproduction: ran the base-commit (b5d430d) copy of the test file under the same load - failed with `not ok - Pi follow-up absent case rendered a duplicate captain answer`</code>
- <code>Negative check: injected a second `CAPTAIN_ANSWER_${label}` into the fixture provider response and the driver expectation, ran `test_operational_followup_turn_e2e` - failed with `rendered 2 captain answer rows instead of exactly one`</code>
- <code>Commit-3 regression probe: extracted `wait_for_text` verbatim from 389c5ca and HEAD, timed both out against a tmux session that had already exited, compared the failure dumps</code>
- <code>Pane capture run: `test_operational_followup_turn_e2e` with each rendered pane archived, producing the Calm-on / Calm-off / restart-replay Pi TUI frames</code>
- <code>`git status --short` - confirmed clean worktree after removing scratch harnesses</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
