### PR TITLE
feat(pi): add compact system-health status to Pi's footer area

### DIFF
--- a/.pi/extensions/fm-system-health.ts
+++ b/.pi/extensions/fm-system-health.ts
@@ -1,0 +1,274 @@
+// Firstmate's compact Pi system-health status.
+//
+// The extension reports OS free RAM and sampled aggregate CPU utilization only.
+// It deliberately does not call a subprocess or inspect files, so the status stays
+// cheap and truthful on macOS and on platforms where only Node's portable metrics exist.
+import * as os from "node:os";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+export const SYSTEM_HEALTH_STATUS_KEY = "firstmate-system-health";
+export const SYSTEM_HEALTH_REFRESH_MS = 3_000;
+
+export type CpuTimesLike = {
+  user: number;
+  nice: number;
+  sys: number;
+  idle: number;
+  irq: number;
+};
+
+export type CpuInfoLike = {
+  times: CpuTimesLike;
+};
+
+export type CpuSnapshot = {
+  idle: number;
+  total: number;
+};
+
+export type HealthMetrics = {
+  memoryFreePercent?: number;
+  cpuUtilizationPercent?: number;
+};
+
+export type HealthSources = {
+  totalMemoryBytes?: number;
+  freeMemoryBytes?: number;
+  cpus?: readonly CpuInfoLike[];
+};
+
+export type HealthTone = "muted" | "warning" | "error";
+export type MetricKind = "memory" | "cpu";
+export type HealthTheme = Pick<ExtensionContext["ui"]["theme"], "fg">;
+
+function boundedPercent(value: number): number {
+  return Math.max(0, Math.min(100, value));
+}
+
+export function calculateMemoryFreePercent(
+  totalMemoryBytes: number | undefined,
+  freeMemoryBytes: number | undefined,
+): number | undefined {
+  if (
+    totalMemoryBytes === undefined ||
+    freeMemoryBytes === undefined ||
+    !Number.isFinite(totalMemoryBytes) ||
+    !Number.isFinite(freeMemoryBytes) ||
+    totalMemoryBytes <= 0 ||
+    freeMemoryBytes < 0 ||
+    freeMemoryBytes > totalMemoryBytes
+  ) {
+    return undefined;
+  }
+  return boundedPercent((freeMemoryBytes / totalMemoryBytes) * 100);
+}
+
+export function captureCpuSnapshot(
+  cpus: readonly CpuInfoLike[] | undefined,
+): CpuSnapshot | undefined {
+  if (!cpus || cpus.length === 0) return undefined;
+
+  let idle = 0;
+  let total = 0;
+  for (const cpu of cpus) {
+    const times = cpu?.times;
+    if (!times) return undefined;
+    const values = [times.user, times.nice, times.sys, times.idle, times.irq];
+    if (values.some((value) => !Number.isFinite(value) || value < 0)) return undefined;
+    idle += times.idle;
+    total += values.reduce((sum, value) => sum + value, 0);
+  }
+
+  if (!Number.isFinite(idle) || !Number.isFinite(total) || total <= 0) return undefined;
+  return { idle, total };
+}
+
+export function calculateCpuUtilization(
+  previous: CpuSnapshot | undefined,
+  current: CpuSnapshot | undefined,
+): number | undefined {
+  if (!previous || !current) return undefined;
+  const totalDelta = current.total - previous.total;
+  const idleDelta = current.idle - previous.idle;
+  if (
+    !Number.isFinite(totalDelta) ||
+    !Number.isFinite(idleDelta) ||
+    totalDelta <= 0 ||
+    idleDelta < 0 ||
+    idleDelta > totalDelta
+  ) {
+    return undefined;
+  }
+  return boundedPercent(((totalDelta - idleDelta) / totalDelta) * 100);
+}
+
+export function sampleHealthSources(
+  sources: HealthSources,
+  previousCpuSnapshot?: CpuSnapshot,
+): { metrics: HealthMetrics; cpuSnapshot: CpuSnapshot | undefined } {
+  const metrics: HealthMetrics = {};
+  const memoryFreePercent = calculateMemoryFreePercent(
+    sources.totalMemoryBytes,
+    sources.freeMemoryBytes,
+  );
+  if (memoryFreePercent !== undefined) metrics.memoryFreePercent = memoryFreePercent;
+
+  const cpuSnapshot = captureCpuSnapshot(sources.cpus);
+  const cpuUtilizationPercent = calculateCpuUtilization(previousCpuSnapshot, cpuSnapshot);
+  if (cpuUtilizationPercent !== undefined) metrics.cpuUtilizationPercent = cpuUtilizationPercent;
+
+  return { metrics, cpuSnapshot };
+}
+
+function readOptionalNumber(read: () => number): number | undefined {
+  try {
+    const value = read();
+    return Number.isFinite(value) && value >= 0 ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readOptionalCpus(): readonly CpuInfoLike[] | undefined {
+  try {
+    const cpus = os.cpus();
+    return cpus.length > 0 ? cpus : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function sampleCurrentHealth(previousCpuSnapshot?: CpuSnapshot): {
+  metrics: HealthMetrics;
+  cpuSnapshot: CpuSnapshot | undefined;
+} {
+  return sampleHealthSources(
+    {
+      totalMemoryBytes: readOptionalNumber(() => os.totalmem()),
+      freeMemoryBytes: readOptionalNumber(() => os.freemem()),
+      cpus: readOptionalCpus(),
+    },
+    previousCpuSnapshot,
+  );
+}
+
+export function metricTone(kind: MetricKind, value: number | undefined): HealthTone {
+  if (value === undefined) return "muted";
+  const warningThreshold = kind === "memory" ? 20 : 70;
+  const errorThreshold = kind === "memory" ? 10 : 90;
+  if (kind === "memory") {
+    if (value < errorThreshold) return "error";
+    if (value < warningThreshold) return "warning";
+    return "muted";
+  }
+  if (value >= errorThreshold) return "error";
+  if (value >= warningThreshold) return "warning";
+  return "muted";
+}
+
+function displayPercent(value: number): string {
+  return `${Math.round(boundedPercent(value))}%`;
+}
+
+export function formatHealthStatus(metrics: HealthMetrics): string {
+  const parts: string[] = [];
+  if (metrics.memoryFreePercent !== undefined) {
+    parts.push(`RAM ${displayPercent(metrics.memoryFreePercent)} free`);
+  }
+  if (metrics.cpuUtilizationPercent !== undefined) {
+    parts.push(`CPU ${displayPercent(metrics.cpuUtilizationPercent)}`);
+  }
+  return parts.join(" · ");
+}
+
+export function renderHealthStatus(metrics: HealthMetrics, theme: HealthTheme): string {
+  const parts: string[] = [];
+  if (metrics.memoryFreePercent !== undefined) {
+    parts.push(
+      theme.fg(
+        metricTone("memory", metrics.memoryFreePercent),
+        `RAM ${displayPercent(metrics.memoryFreePercent)} free`,
+      ),
+    );
+  }
+  if (metrics.cpuUtilizationPercent !== undefined) {
+    parts.push(
+      theme.fg(
+        metricTone("cpu", metrics.cpuUtilizationPercent),
+        `CPU ${displayPercent(metrics.cpuUtilizationPercent)}`,
+      ),
+    );
+  }
+  return parts.join(theme.fg("dim", " · "));
+}
+
+export function formatHealthReport(metrics: HealthMetrics): string {
+  const status = formatHealthStatus(metrics);
+  return status ? `System health: ${status}` : "System health: no supported metrics available";
+}
+
+export default function systemHealthExtension(pi: ExtensionAPI): void {
+  let enabled = true;
+  let active = false;
+  let timer: ReturnType<typeof setInterval> | undefined;
+  let previousCpuSnapshot: CpuSnapshot | undefined;
+  let latestMetrics: HealthMetrics = {};
+
+  const clearTimer = (ctx?: ExtensionContext): void => {
+    active = false;
+    if (timer !== undefined) clearInterval(timer);
+    timer = undefined;
+    previousCpuSnapshot = undefined;
+    latestMetrics = {};
+    ctx?.ui.setStatus(SYSTEM_HEALTH_STATUS_KEY, undefined);
+  };
+
+  const publish = (ctx: ExtensionContext): void => {
+    const text = enabled ? renderHealthStatus(latestMetrics, ctx.ui.theme) : "";
+    ctx.ui.setStatus(SYSTEM_HEALTH_STATUS_KEY, text || undefined);
+  };
+
+  const sample = (ctx: ExtensionContext): void => {
+    const result = sampleCurrentHealth(previousCpuSnapshot);
+    previousCpuSnapshot = result.cpuSnapshot;
+    latestMetrics = result.metrics;
+    publish(ctx);
+  };
+
+  const start = (_event: unknown, ctx: ExtensionContext): void => {
+    clearTimer(ctx);
+    active = true;
+    sample(ctx);
+    timer = setInterval(() => {
+      if (active) sample(ctx);
+    }, SYSTEM_HEALTH_REFRESH_MS);
+    timer.unref?.();
+  };
+
+  pi.on("session_start", start);
+  pi.on("session_shutdown", (_event, ctx) => clearTimer(ctx));
+
+  pi.registerCommand("system-health", {
+    description: "Report or toggle the compact system-health status",
+    handler: async (args, ctx) => {
+      const command = args.trim().toLowerCase();
+      if (command === "toggle" || command === "on" || command === "off") {
+        enabled = command === "toggle" ? !enabled : command === "on";
+        publish(ctx);
+        ctx.ui.notify(
+          `${enabled ? "System health indicator on" : "System health indicator off"}. ${formatHealthReport(latestMetrics)}`,
+          "info",
+        );
+        return;
+      }
+      if (command !== "" && command !== "show") {
+        ctx.ui.notify("Usage: /system-health [show|toggle|on|off]", "warning");
+        return;
+      }
+      const hasMetrics =
+        latestMetrics.memoryFreePercent !== undefined ||
+        latestMetrics.cpuUtilizationPercent !== undefined;
+      ctx.ui.notify(formatHealthReport(latestMetrics), hasMetrics ? "info" : "warning");
+    },
+  });
+}

--- a/.pi/extensions/fm-system-health.ts
+++ b/.pi/extensions/fm-system-health.ts
@@ -166,17 +166,17 @@ export function metricTone(kind: MetricKind, value: number | undefined): HealthT
   return "muted";
 }
 
-function displayPercent(value: number): string {
-  return `${Math.round(boundedPercent(value))}%`;
+export function displayedPercent(value: number): number {
+  return Math.round(boundedPercent(value));
 }
 
 export function formatHealthStatus(metrics: HealthMetrics): string {
   const parts: string[] = [];
   if (metrics.memoryFreePercent !== undefined) {
-    parts.push(`RAM ${displayPercent(metrics.memoryFreePercent)} free`);
+    parts.push(`RAM ${displayedPercent(metrics.memoryFreePercent)}% free`);
   }
   if (metrics.cpuUtilizationPercent !== undefined) {
-    parts.push(`CPU ${displayPercent(metrics.cpuUtilizationPercent)}`);
+    parts.push(`CPU ${displayedPercent(metrics.cpuUtilizationPercent)}%`);
   }
   return parts.join(" · ");
 }
@@ -184,20 +184,12 @@ export function formatHealthStatus(metrics: HealthMetrics): string {
 export function renderHealthStatus(metrics: HealthMetrics, theme: HealthTheme): string {
   const parts: string[] = [];
   if (metrics.memoryFreePercent !== undefined) {
-    parts.push(
-      theme.fg(
-        metricTone("memory", metrics.memoryFreePercent),
-        `RAM ${displayPercent(metrics.memoryFreePercent)} free`,
-      ),
-    );
+    const shown = displayedPercent(metrics.memoryFreePercent);
+    parts.push(theme.fg(metricTone("memory", shown), `RAM ${shown}% free`));
   }
   if (metrics.cpuUtilizationPercent !== undefined) {
-    parts.push(
-      theme.fg(
-        metricTone("cpu", metrics.cpuUtilizationPercent),
-        `CPU ${displayPercent(metrics.cpuUtilizationPercent)}`,
-      ),
-    );
+    const shown = displayedPercent(metrics.cpuUtilizationPercent);
+    parts.push(theme.fg(metricTone("cpu", shown), `CPU ${shown}%`));
   }
   return parts.join(theme.fg("dim", " · "));
 }

--- a/.pi/extensions/fm-system-health.ts
+++ b/.pi/extensions/fm-system-health.ts
@@ -1,13 +1,22 @@
 // Firstmate's compact Pi system-health status.
 //
-// The extension reports OS free RAM and sampled aggregate CPU utilization only.
-// It deliberately does not call a subprocess or inspect files, so the status stays
-// cheap and truthful on macOS and on platforms where only Node's portable metrics exist.
+// The extension reports available RAM and sampled aggregate CPU utilization only.
+//
+// Memory semantics are platform-specific on purpose. Node's `os.freemem()` reports
+// only wholly unused pages, which on macOS excludes the inactive, speculative, and
+// purgeable pages the OS itself counts as available. Reporting that number would
+// show a single-digit percentage on an idle Mac while macOS reports two thirds free.
+// On macOS the extension therefore derives available memory from `vm_stat` page
+// counts, matching the OS view within rounding. Elsewhere `os.freemem()` is truthful
+// and is used directly. The `vm_stat` call is a bounded, cached subprocess run only
+// from the sampler at its fixed cadence, never from render() or a repaint.
 import * as os from "node:os";
+import { execFile } from "node:child_process";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 export const SYSTEM_HEALTH_STATUS_KEY = "firstmate-system-health";
 export const SYSTEM_HEALTH_REFRESH_MS = 3_000;
+export const SYSTEM_HEALTH_VM_STAT_TIMEOUT_MS = 1_000;
 
 export type CpuTimesLike = {
   user: number;
@@ -35,14 +44,77 @@ export type HealthSources = {
   totalMemoryBytes?: number;
   freeMemoryBytes?: number;
   cpus?: readonly CpuInfoLike[];
+  // When true the macOS availability rules apply and `freeMemoryBytes` is ignored,
+  // because `os.freemem()` is not a truthful availability signal on that platform.
+  isMacOs?: boolean;
+  // Parsed `vm_stat` counters; absent when the source could not be read.
+  vmStat?: VmStatPageCounts;
 };
 
 export type HealthTone = "muted" | "warning" | "error";
 export type MetricKind = "memory" | "cpu";
 export type HealthTheme = Pick<ExtensionContext["ui"]["theme"], "fg">;
 
+// The subset of `vm_stat` page counters needed to describe macOS memory availability.
+export type VmStatPageCounts = {
+  pageSizeBytes: number;
+  wired: number;
+  compressorOccupied: number;
+};
+
 function boundedPercent(value: number): number {
   return Math.max(0, Math.min(100, value));
+}
+
+function parseVmStatCounter(text: string, label: string): number | undefined {
+  // vm_stat prints "Pages wired down:      274568." — a trailing period, and the
+  // label itself may contain regex-significant characters in future macOS versions.
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`^${escaped}:\\s*(\\d+)\\.?\\s*$`, "m").exec(text);
+  if (!match) return undefined;
+  const value = Number(match[1]);
+  return Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+export function parseVmStat(text: string | undefined): VmStatPageCounts | undefined {
+  if (!text) return undefined;
+  const pageSizeMatch = /page size of (\d+) bytes/.exec(text);
+  const pageSizeBytes = pageSizeMatch ? Number(pageSizeMatch[1]) : undefined;
+  const wired = parseVmStatCounter(text, "Pages wired down");
+  const compressorOccupied = parseVmStatCounter(text, "Pages occupied by compressor");
+  if (
+    pageSizeBytes === undefined ||
+    !Number.isFinite(pageSizeBytes) ||
+    pageSizeBytes <= 0 ||
+    wired === undefined ||
+    compressorOccupied === undefined
+  ) {
+    return undefined;
+  }
+  return { pageSizeBytes, wired, compressorOccupied };
+}
+
+// macOS treats wired and compressor-occupied pages as genuinely unavailable; active,
+// inactive, speculative, and purgeable pages are all reclaimable and are counted as
+// available by the OS. This mirrors the percentage `memory_pressure` reports.
+export function calculateMacOsAvailableMemoryPercent(
+  counts: VmStatPageCounts | undefined,
+  totalMemoryBytes: number | undefined,
+): number | undefined {
+  if (
+    !counts ||
+    totalMemoryBytes === undefined ||
+    !Number.isFinite(totalMemoryBytes) ||
+    totalMemoryBytes <= 0
+  ) {
+    return undefined;
+  }
+  const totalPages = totalMemoryBytes / counts.pageSizeBytes;
+  if (!Number.isFinite(totalPages) || totalPages <= 0) return undefined;
+  const unavailablePages = counts.wired + counts.compressorOccupied;
+  if (!Number.isFinite(unavailablePages) || unavailablePages < 0) return undefined;
+  if (unavailablePages > totalPages) return undefined;
+  return boundedPercent(((totalPages - unavailablePages) / totalPages) * 100);
 }
 
 export function calculateMemoryFreePercent(
@@ -107,10 +179,12 @@ export function sampleHealthSources(
   previousCpuSnapshot?: CpuSnapshot,
 ): { metrics: HealthMetrics; cpuSnapshot: CpuSnapshot | undefined } {
   const metrics: HealthMetrics = {};
-  const memoryFreePercent = calculateMemoryFreePercent(
-    sources.totalMemoryBytes,
-    sources.freeMemoryBytes,
-  );
+  // On macOS only the vm_stat-derived availability is truthful, so when that source
+  // is missing the memory metric is omitted rather than falling back to the
+  // os.freemem() ratio, which would read as near-zero on a healthy Mac.
+  const memoryFreePercent = sources.isMacOs
+    ? calculateMacOsAvailableMemoryPercent(sources.vmStat, sources.totalMemoryBytes)
+    : calculateMemoryFreePercent(sources.totalMemoryBytes, sources.freeMemoryBytes);
   if (memoryFreePercent !== undefined) metrics.memoryFreePercent = memoryFreePercent;
 
   const cpuSnapshot = captureCpuSnapshot(sources.cpus);
@@ -138,15 +212,40 @@ function readOptionalCpus(): readonly CpuInfoLike[] | undefined {
   }
 }
 
-export function sampleCurrentHealth(previousCpuSnapshot?: CpuSnapshot): {
+// Runs `vm_stat` with a bounded timeout and no shell. Resolves to undefined on any
+// failure so an unavailable source degrades to an omitted metric rather than a guess.
+export function readVmStat(
+  platform: string = process.platform,
+  timeoutMs: number = SYSTEM_HEALTH_VM_STAT_TIMEOUT_MS,
+): Promise<VmStatPageCounts | undefined> {
+  if (platform !== "darwin") return Promise.resolve(undefined);
+  return new Promise((resolve) => {
+    try {
+      execFile(
+        "/usr/bin/vm_stat",
+        [],
+        { timeout: timeoutMs, maxBuffer: 64 * 1024, windowsHide: true },
+        (error, stdout) => resolve(error ? undefined : parseVmStat(stdout)),
+      );
+    } catch {
+      resolve(undefined);
+    }
+  });
+}
+
+export async function sampleCurrentHealth(previousCpuSnapshot?: CpuSnapshot): Promise<{
   metrics: HealthMetrics;
   cpuSnapshot: CpuSnapshot | undefined;
-} {
+}> {
+  const isMacOs = process.platform === "darwin";
+  const vmStat = await readVmStat();
   return sampleHealthSources(
     {
       totalMemoryBytes: readOptionalNumber(() => os.totalmem()),
       freeMemoryBytes: readOptionalNumber(() => os.freemem()),
       cpus: readOptionalCpus(),
+      isMacOs,
+      vmStat,
     },
     previousCpuSnapshot,
   );
@@ -205,9 +304,11 @@ export default function systemHealthExtension(pi: ExtensionAPI): void {
   let timer: ReturnType<typeof setInterval> | undefined;
   let previousCpuSnapshot: CpuSnapshot | undefined;
   let latestMetrics: HealthMetrics = {};
+  let startGeneration = 0;
 
   const clearTimer = (ctx?: ExtensionContext): void => {
     active = false;
+    startGeneration += 1;
     if (timer !== undefined) clearInterval(timer);
     timer = undefined;
     previousCpuSnapshot = undefined;
@@ -220,19 +321,31 @@ export default function systemHealthExtension(pi: ExtensionAPI): void {
     ctx.ui.setStatus(SYSTEM_HEALTH_STATUS_KEY, text || undefined);
   };
 
-  const sample = (ctx: ExtensionContext): void => {
-    const result = sampleCurrentHealth(previousCpuSnapshot);
-    previousCpuSnapshot = result.cpuSnapshot;
-    latestMetrics = result.metrics;
-    publish(ctx);
+  // Guards against a slow vm_stat call overlapping the next tick, and against a
+  // sample that resolves after shutdown resurrecting a cleared status.
+  let sampling = false;
+
+  const sample = async (ctx: ExtensionContext): Promise<void> => {
+    if (sampling) return;
+    sampling = true;
+    const generation = startGeneration;
+    try {
+      const result = await sampleCurrentHealth(previousCpuSnapshot);
+      if (generation !== startGeneration) return;
+      previousCpuSnapshot = result.cpuSnapshot;
+      latestMetrics = result.metrics;
+      publish(ctx);
+    } finally {
+      sampling = false;
+    }
   };
 
   const start = (_event: unknown, ctx: ExtensionContext): void => {
     clearTimer(ctx);
     active = true;
-    sample(ctx);
+    void sample(ctx);
     timer = setInterval(() => {
-      if (active) sample(ctx);
+      if (active) void sample(ctx);
     }, SYSTEM_HEALTH_REFRESH_MS);
     timer.unref?.();
   };

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Pi's `/calm` toggle hides supported transcript chrome, including canonically cla
 The hidden operational inputs remain ordinary user-role messages with unchanged delivery, ordering, authority, persistence, and exports.
 The preference persists for the effective Firstmate home, and toggling it off restores ordinary rendering.
 [Calm's current behavior and supported limits](docs/calm.md) are separate from its [version-scoped maintainer evidence](docs/calm-mode-feasibility.md).
+Pi's compact [system-health indicator](docs/pi-system-health.md) reports free RAM and sampled CPU utilization without replacing the built-in footer.
 
 ### Talk to it
 

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -140,7 +140,7 @@ family_for_basename() {
     fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-kimi-harness.test.sh|fm-muse-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
-    fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
+    fm-operational-input.test.sh|fm-pi-primary-types.test.sh|fm-pi-system-health.test.sh|\
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|\
     fm-subagent-pretool-check.test.sh|\
     fm-supervision-instructions.test.sh|fm-task-delivery.test.sh|\

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -277,6 +277,10 @@
       "audience": "operator-current"
     },
     {
+      "path": "docs/pi-system-health.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/remote-secondmates.md",
       "audience": "operator-current"
     },

--- a/docs/pi-system-health.md
+++ b/docs/pi-system-health.md
@@ -16,6 +16,7 @@ Use `/system-health` to report the latest values.
 Use `/system-health toggle`, `/system-health on`, or `/system-health off` to control the status display for the current Pi extension lifetime.
 Unavailable sources are omitted from both the status and the command report instead of being represented as invented values.
 Semantic `muted`, `warning`, and `error` tones use Pi's active theme palette, which keeps the default Rose Pine Moon presentation calm until a threshold is crossed.
+Thresholds are evaluated against the same rounded percentage that is displayed, so two readings shown as the same number always carry the same colour.
 
 Regression entry points:
 

--- a/docs/pi-system-health.md
+++ b/docs/pi-system-health.md
@@ -3,14 +3,25 @@
 The project-local Pi extension adds a compact system-health status beside Pi's built-in footer information.
 It uses `ctx.ui.setStatus()` with the unique key `firstmate-system-health`, so Pi's token, context, model, and other extension status displays remain intact.
 
-The status reports `RAM <percent> free` from Node's OS-reported free-to-total memory ratio and sampled aggregate `CPU <percent>` utilization.
-The RAM value is explicitly free memory, not macOS memory pressure, because Node's portable `os.freemem()` value does not provide that pressure classification.
+The status reports `RAM <percent> free` and sampled aggregate `CPU <percent>` utilization.
+
+The RAM value is available memory, and its source is platform-specific so that the number stays truthful on the Captain's Mac.
+On macOS the extension reads `vm_stat` page counters and reports `(total pages - wired pages - compressor-occupied pages) / total pages`.
+macOS treats active, inactive, speculative, and purgeable pages as reclaimable, so counting only wired and compressor-occupied pages as unavailable matches the percentage `memory_pressure` reports, within rounding.
+Node's `os.freemem()` is deliberately **not** used on macOS: it counts only wholly unused pages, which reads as a single-digit percentage on an idle Mac that macOS itself reports as roughly two thirds free.
+On every other platform `os.freemem()` is truthful and is used directly as the free-to-total ratio.
+The value is available memory, not a macOS memory-pressure classification.
+
 The CPU value is calculated from deltas between `os.cpus()` time snapshots rather than from a load-average label.
-Swap is intentionally omitted because this extension does not have a compact, truthful, cross-platform swap source without adding subprocess or filesystem work.
+Swap is intentionally omitted because this extension does not have a compact, truthful, cross-platform swap source.
 
 Sampling starts at `session_start`, refreshes every three seconds, and is cleared at `session_shutdown`.
 The startup path clears an existing timer before creating one, so reload and in-process session replacement do not accumulate samplers.
-The extension performs no network access, telemetry persistence, Herdr configuration, supervision work, subprocess execution, or filesystem scan.
+Sampling is asynchronous and its result is cached, so nothing is measured from `render()` or on a repaint.
+The macOS `vm_stat` read is the extension's only subprocess: it is invoked without a shell, bounded by a one-second timeout, and never runs more than once at a time.
+A sample that resolves after a shutdown or reload is discarded rather than restoring a cleared status.
+If `vm_stat` is missing, fails, or times out, the memory metric is omitted instead of falling back to a misleading value.
+The extension performs no network access, telemetry persistence, machine-measurement persistence, Herdr configuration, or supervision work.
 
 Use `/system-health` to report the latest values.
 Use `/system-health toggle`, `/system-health on`, or `/system-health off` to control the status display for the current Pi extension lifetime.

--- a/docs/pi-system-health.md
+++ b/docs/pi-system-health.md
@@ -1,0 +1,26 @@
+# Pi system-health indicator
+
+The project-local Pi extension adds a compact system-health status beside Pi's built-in footer information.
+It uses `ctx.ui.setStatus()` with the unique key `firstmate-system-health`, so Pi's token, context, model, and other extension status displays remain intact.
+
+The status reports `RAM <percent> free` from Node's OS-reported free-to-total memory ratio and sampled aggregate `CPU <percent>` utilization.
+The RAM value is explicitly free memory, not macOS memory pressure, because Node's portable `os.freemem()` value does not provide that pressure classification.
+The CPU value is calculated from deltas between `os.cpus()` time snapshots rather than from a load-average label.
+Swap is intentionally omitted because this extension does not have a compact, truthful, cross-platform swap source without adding subprocess or filesystem work.
+
+Sampling starts at `session_start`, refreshes every three seconds, and is cleared at `session_shutdown`.
+The startup path clears an existing timer before creating one, so reload and in-process session replacement do not accumulate samplers.
+The extension performs no network access, telemetry persistence, Herdr configuration, supervision work, subprocess execution, or filesystem scan.
+
+Use `/system-health` to report the latest values.
+Use `/system-health toggle`, `/system-health on`, or `/system-health off` to control the status display for the current Pi extension lifetime.
+Unavailable sources are omitted from both the status and the command report instead of being represented as invented values.
+Semantic `muted`, `warning`, and `error` tones use Pi's active theme palette, which keeps the default Rose Pine Moon presentation calm until a threshold is crossed.
+
+Regression entry points:
+
+```sh
+tests/fm-pi-system-health.test.sh
+tests/fm-pi-primary-types.test.sh
+bin/fm-doc-audience-check.sh
+```

--- a/docs/pi-system-health.md
+++ b/docs/pi-system-health.md
@@ -1,6 +1,7 @@
 # Pi system-health indicator
 
 The project-local Pi extension adds a compact system-health status beside Pi's built-in footer information.
+It lives at `.pi/extensions/fm-system-health.ts`, a tracked file Pi auto-discovers once the project is trusted, and it registers no LLM tool and no system-prompt text.
 It uses `ctx.ui.setStatus()` with the unique key `firstmate-system-health`, so Pi's token, context, model, and other extension status displays remain intact.
 
 The status reports `RAM <percent> free` and sampled aggregate `CPU <percent>` utilization.
@@ -13,6 +14,7 @@ On every other platform `os.freemem()` is truthful and is used directly as the f
 The value is available memory, not a macOS memory-pressure classification.
 
 The CPU value is calculated from deltas between `os.cpus()` time snapshots rather than from a load-average label.
+Because a delta needs two snapshots, CPU is unavailable on the first sample of a session and is omitted until the second one, roughly three seconds later.
 Swap is intentionally omitted because this extension does not have a compact, truthful, cross-platform swap source.
 
 Sampling starts at `session_start`, refreshes every three seconds, and is cleared at `session_shutdown`.
@@ -23,10 +25,17 @@ A sample that resolves after a shutdown or reload is discarded rather than resto
 If `vm_stat` is missing, fails, or times out, the memory metric is omitted instead of falling back to a misleading value.
 The extension performs no network access, telemetry persistence, machine-measurement persistence, Herdr configuration, or supervision work.
 
-Use `/system-health` to report the latest values.
-Use `/system-health toggle`, `/system-health on`, or `/system-health off` to control the status display for the current Pi extension lifetime.
+Use `/system-health` or `/system-health show` to report the latest values; any other unrecognized argument reports the supported usage instead of acting.
+The indicator is on by default; `/system-health toggle`, `/system-health on`, and `/system-health off` control the status display for the current Pi extension lifetime and are not persisted.
 Unavailable sources are omitted from both the status and the command report instead of being represented as invented values.
 Semantic `muted`, `warning`, and `error` tones use Pi's active theme palette, which keeps the default Rose Pine Moon presentation calm until a threshold is crossed.
+Each metric is `muted` in its normal band, so an ordinary machine shows no colour emphasis at all:
+
+| Metric | `warning` | `error` |
+|---|---|---|
+| RAM free | below 20% | below 10% |
+| CPU used | 70% and above | 90% and above |
+
 Thresholds are evaluated against the same rounded percentage that is displayed, so two readings shown as the same number always carry the same colour.
 
 Regression entry points:

--- a/tests/fm-pi-primary-types.test.sh
+++ b/tests/fm-pi-primary-types.test.sh
@@ -27,6 +27,7 @@ trap cleanup EXIT
 
 mkdir -p "$TMP_ROOT/lib" "$TMP_ROOT/node_modules/@earendil-works" "$TMP_ROOT/node_modules/@types"
 cp "$ROOT/.pi/extensions/fm-calm.ts" "$TMP_ROOT/fm-calm.ts"
+cp "$ROOT/.pi/extensions/fm-system-health.ts" "$TMP_ROOT/fm-system-health.ts"
 cp "$ROOT/.pi/extensions/fm-primary-pi-watch.ts" "$TMP_ROOT/fm-primary-pi-watch.ts"
 cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$TMP_ROOT/fm-primary-turnend-guard.ts"
 cp "$ROOT/.pi/extensions/lib/fm-calm-assistant-layout.ts" "$TMP_ROOT/lib/fm-calm-assistant-layout.ts"

--- a/tests/fm-pi-system-health.test.sh
+++ b/tests/fm-pi-system-health.test.sh
@@ -113,6 +113,109 @@ assertEqual(
 const unavailable = mod.sampleHealthSources({ totalMemoryBytes: 0, freeMemoryBytes: 0, cpus: [] });
 assertEqual(Object.keys(unavailable.metrics).length, 0, "unavailable sources stay absent");
 
+// macOS memory availability: parsing real vm_stat output and deriving the percentage
+// the operating system itself reports, rather than the wholly-unused-page ratio.
+const vmStatSample = `Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free:                                    21405.
+Pages active:                                 501482.
+Pages inactive:                               471564.
+Pages speculative:                             31359.
+Pages throttled:                                   0.
+Pages wired down:                             274568.
+Pages purgeable:                               16774.
+File-backed pages:                            325436.
+Anonymous pages:                              678969.
+Pages occupied by compressor:                 233146.
+Pageins:                                   104187920.`;
+
+const counts = mod.parseVmStat(vmStatSample);
+assertEqual(counts.pageSizeBytes, 16384, "vm_stat page size parsing");
+assertEqual(counts.wired, 274568, "vm_stat wired page parsing");
+assertEqual(counts.compressorOccupied, 233146, "vm_stat compressor page parsing");
+assertEqual(mod.parseVmStat(""), undefined, "empty vm_stat output is unavailable");
+assertEqual(mod.parseVmStat(undefined), undefined, "missing vm_stat output is unavailable");
+assertEqual(
+  mod.parseVmStat("Mach Virtual Memory Statistics: (page size of 16384 bytes)\nPages free: 1."),
+  undefined,
+  "vm_stat output missing required counters is unavailable",
+);
+
+// 24 GiB across 16 KiB pages is 1572864 pages; 274568 wired + 233146 compressed are
+// unavailable, leaving ~67.7% available, matching what macOS reports for this sample.
+const totalBytes = 25769803776;
+assertNear(
+  mod.calculateMacOsAvailableMemoryPercent(counts, totalBytes),
+  ((1572864 - 274568 - 233146) / 1572864) * 100,
+  "macOS available memory percentage",
+);
+assertEqual(mod.displayedPercent(mod.calculateMacOsAvailableMemoryPercent(counts, totalBytes)), 68,
+  "macOS available memory rounds to the OS-reported percentage");
+assertEqual(mod.metricTone("memory", 68), "muted", "an unstressed Mac renders a calm tone");
+assertEqual(
+  mod.calculateMacOsAvailableMemoryPercent(counts, 0),
+  undefined,
+  "unknown total memory makes macOS availability unavailable",
+);
+assertEqual(
+  mod.calculateMacOsAvailableMemoryPercent(undefined, totalBytes),
+  undefined,
+  "absent vm_stat counts make macOS availability unavailable",
+);
+assertEqual(
+  mod.calculateMacOsAvailableMemoryPercent(
+    { pageSizeBytes: 16384, wired: 9e9, compressorOccupied: 0 },
+    totalBytes,
+  ),
+  undefined,
+  "impossible page counts are unavailable rather than clamped",
+);
+
+// The macOS source supersedes os.freemem(): the same host that looks 1% free by
+// wholly-unused pages is reported at its true availability.
+const macSample = mod.sampleHealthSources({
+  totalMemoryBytes: totalBytes,
+  freeMemoryBytes: Math.round(totalBytes * 0.01),
+  isMacOs: true,
+  vmStat: counts,
+});
+assertEqual(mod.displayedPercent(macSample.metrics.memoryFreePercent), 68,
+  "vm_stat availability supersedes the misleading free-memory ratio");
+assertEqual(
+  mod.metricTone("memory", mod.displayedPercent(macSample.metrics.memoryFreePercent)),
+  "muted",
+  "a healthy Mac is not shown as critical",
+);
+
+// Off macOS the portable free-memory ratio is truthful and is still used.
+const portableSample = mod.sampleHealthSources({ totalMemoryBytes: 1000, freeMemoryBytes: 250 });
+assertNear(portableSample.metrics.memoryFreePercent, 25, "non-macOS memory stays os.freemem based");
+
+// On macOS a failed vm_stat omits the memory metric rather than falling back to the
+// misleading free-memory ratio, while the CPU metric remains available.
+const macWithoutVmStat = mod.sampleHealthSources(
+  {
+    totalMemoryBytes: totalBytes,
+    freeMemoryBytes: Math.round(totalBytes * 0.01),
+    isMacOs: true,
+    vmStat: undefined,
+    cpus: [cpu({ user: 70, sys: 30, idle: 50 })],
+  },
+  firstCpu,
+);
+assertEqual(
+  macWithoutVmStat.metrics.memoryFreePercent,
+  undefined,
+  "an unreadable macOS memory source omits the metric instead of guessing",
+);
+assertNear(macWithoutVmStat.metrics.cpuUtilizationPercent, 60, "CPU survives an unreadable memory source");
+assertEqual(
+  mod.formatHealthStatus(macWithoutVmStat.metrics),
+  "CPU 60%",
+  "only truthful supported metrics are shown",
+);
+
+assertEqual(await mod.readVmStat("linux"), undefined, "vm_stat is not invoked off macOS");
+
 const nativeSetInterval = globalThis.setInterval;
 const nativeClearInterval = globalThis.clearInterval;
 const intervals = [];
@@ -167,19 +270,28 @@ const context = {
   },
 };
 
+// Sampling is asynchronous because the macOS memory source is a bounded subprocess,
+// so a refresh publishes once the in-flight sample settles rather than inline.
+const settle = async () => {
+  for (let i = 0; i < 50; i += 1) await new Promise((resolve) => setImmediate(resolve));
+};
+
 await handlers.get("session_start")({ reason: "startup" }, context);
+await settle();
 assertEqual(intervals.length, 1, "session_start starts one sampler");
 assertEqual(intervals[0].delay, mod.SYSTEM_HEALTH_REFRESH_MS, "sampler uses bounded cadence");
 assert(intervals[0].unrefCalled, "sampler does not keep Pi alive");
 assert(statuses.some((entry) => entry.key === mod.SYSTEM_HEALTH_STATUS_KEY), "status uses the unique health key");
 
 await handlers.get("session_start")({ reason: "reload" }, context);
+await settle();
 assertEqual(intervals.length, 2, "reload creates one replacement sampler");
 assert(intervals[0].cleared, "reload clears the previous sampler");
 assertEqual(intervals.filter((entry) => !entry.cleared).length, 1, "reload does not leak duplicate samplers");
 
 const statusCountBeforeTick = statuses.length;
 intervals[1].callback();
+await settle();
 assert(statuses.length > statusCountBeforeTick, "timer refresh publishes status");
 
 await command.handler("off", context);
@@ -195,6 +307,7 @@ assert(intervals[1].cleared, "session_shutdown clears the active sampler");
 assertEqual(intervals.filter((entry) => !entry.cleared).length, 0, "shutdown leaves no sampler");
 const statusCountAfterShutdown = statuses.length;
 intervals[1].callback();
+await settle();
 assertEqual(statuses.length, statusCountAfterShutdown, "late timer callbacks are inert after shutdown");
 
 globalThis.setInterval = nativeSetInterval;
@@ -205,3 +318,59 @@ status=$?
 expect_code 0 "$status" "Pi system-health public-interface behavior tests"
 [ -z "$out" ] || fail "Pi system-health tests printed output: $out"
 pass "Pi system-health metrics, rendering, lifecycle cleanup, unavailable sources, and footer preservation"
+
+# The tone assertions above use synthetic percentages, so they cannot show what
+# the Captain actually sees on a Mac. This exercises the live sampling path end to
+# end and compares the displayed value and tone against the availability accounting
+# reported by macOS, covering both truthfulness and the calm-default rule.
+if [ "$(uname -s)" = "Darwin" ] && command -v memory_pressure >/dev/null 2>&1; then
+  os_free_percent=$(memory_pressure 2>/dev/null |
+    sed -n 's/.*[Ff]ree percentage: *\([0-9][0-9]*\)%.*/\1/p' | tail -1)
+  if [ -n "$os_free_percent" ]; then
+    health_out=$(EXT="$EXT" OS_FREE_PERCENT="$os_free_percent" node --input-type=module 2>&1 <<'JS'
+const mod = await import(process.env.EXT);
+const osFreePercent = Number(process.env.OS_FREE_PERCENT);
+
+// macOS reports memory as unstressed, so the indicator must read calm too.
+if (osFreePercent < 40) {
+  console.log(`skip: host is genuinely low on memory (${osFreePercent}% free)`);
+  process.exit(0);
+}
+
+const { metrics } = await mod.sampleCurrentHealth();
+if (metrics.memoryFreePercent === undefined) {
+  console.error("system-health reported no memory metric on a Mac where vm_stat is available");
+  process.exit(1);
+}
+const shown = mod.displayedPercent(metrics.memoryFreePercent);
+const tone = mod.metricTone("memory", shown);
+if (tone !== "muted") {
+  console.error(
+    `system-health shows "RAM ${shown}% free" in "${tone}" tone while macOS reports ` +
+      `${osFreePercent}% memory free; an unstressed Mac must render calm`,
+  );
+  process.exit(1);
+}
+
+// The displayed value must track the accounting macOS itself reports, not merely
+// look calm. memory_pressure truncates and samples a moment apart, so allow drift.
+if (Math.abs(shown - osFreePercent) > 8) {
+  console.error(
+    `system-health reports ${shown}% available while macOS reports ${osFreePercent}%; ` +
+      "the memory metric must reflect the availability accounting reported by macOS",
+  );
+  process.exit(1);
+}
+JS
+    )
+    health_status=$?
+    case "$health_out" in
+      skip:*) echo "$health_out" ;;
+      *)
+        expect_code 0 "$health_status" "live macOS memory reading stays calm when the OS reports memory free"
+        [ -z "$health_out" ] || fail "$health_out"
+        pass "live macOS memory reading renders a calm tone on an unstressed host"
+        ;;
+    esac
+  fi
+fi

--- a/tests/fm-pi-system-health.test.sh
+++ b/tests/fm-pi-system-health.test.sh
@@ -61,6 +61,50 @@ const styled = mod.renderHealthStatus(sampled.metrics, theme);
 assert(styled.includes("<muted>RAM 25% free</muted>"), `memory status lost calm styling: ${styled}`);
 assert(styled.includes("<muted>CPU 60%</muted>"), `CPU status lost calm styling: ${styled}`);
 assertEqual(mod.renderHealthStatus({}, theme), "", "unavailable metrics render no unsupported values");
+
+function toneOf(styled, label) {
+  const match = new RegExp(`<([a-z]+)>${label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}</`).exec(styled);
+  assert(match, `expected a styled "${label}" segment in ${styled}`);
+  return match[1];
+}
+
+for (const [rawA, rawB, label, tone] of [
+  [9.6, 10.4, "RAM 10% free", "warning"],
+  [19.6, 20.4, "RAM 20% free", "muted"],
+  [8.6, 9.4, "RAM 9% free", "error"],
+]) {
+  const first = mod.renderHealthStatus({ memoryFreePercent: rawA }, theme);
+  const second = mod.renderHealthStatus({ memoryFreePercent: rawB }, theme);
+  assertEqual(first, second, `memory boundary ${rawA}/${rawB} must render identically`);
+  assertEqual(toneOf(first, label), tone, `memory boundary tone for "${label}"`);
+}
+
+for (const [rawA, rawB, label, tone] of [
+  [69.6, 70.4, "CPU 70%", "warning"],
+  [89.6, 90.4, "CPU 90%", "error"],
+  [68.6, 69.4, "CPU 69%", "muted"],
+]) {
+  const first = mod.renderHealthStatus({ cpuUtilizationPercent: rawA }, theme);
+  const second = mod.renderHealthStatus({ cpuUtilizationPercent: rawB }, theme);
+  assertEqual(first, second, `CPU boundary ${rawA}/${rawB} must render identically`);
+  assertEqual(toneOf(first, label), tone, `CPU boundary tone for "${label}"`);
+}
+
+for (const raw of [9.6, 10.4, 19.6, 20.4]) {
+  assert(
+    mod.renderHealthStatus({ memoryFreePercent: raw }, theme).includes(
+      `RAM ${mod.displayedPercent(raw)}% free`,
+    ),
+    `styled memory label must match the compact label for ${raw}`,
+  );
+}
+for (const raw of [69.6, 70.4, 89.6, 90.4]) {
+  assertEqual(
+    mod.formatHealthStatus({ cpuUtilizationPercent: raw }),
+    `CPU ${mod.displayedPercent(raw)}%`,
+    `compact CPU label for ${raw}`,
+  );
+}
 assertEqual(
   mod.formatHealthReport({}),
   "System health: no supported metrics available",

--- a/tests/fm-pi-system-health.test.sh
+++ b/tests/fm-pi-system-health.test.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Public-interface behavior tests for the Pi system-health status extension.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+fm_test_tmproot fm-pi-system-health >/dev/null
+EXT="$ROOT/.pi/extensions/fm-system-health.ts"
+
+cleanup() {
+  fm_test_cleanup
+}
+trap cleanup EXIT
+
+out=$(EXT="$EXT" node --input-type=module 2>&1 <<'JS'
+const mod = await import(process.env.EXT);
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function assertEqual(actual, expected, message) {
+  assert(Object.is(actual, expected), `${message}: expected ${expected}, got ${actual}`);
+}
+
+function assertNear(actual, expected, message) {
+  assert(actual !== undefined && Math.abs(actual - expected) < 0.0001, `${message}: expected ${expected}, got ${actual}`);
+}
+
+const cpu = (times) => ({ times: { user: 0, nice: 0, sys: 0, idle: 0, irq: 0, ...times } });
+const firstCpu = mod.captureCpuSnapshot([cpu({ user: 50, sys: 20, idle: 30 })]);
+const secondCpu = mod.captureCpuSnapshot([cpu({ user: 70, sys: 30, idle: 50 })]);
+
+assertEqual(mod.calculateMemoryFreePercent(1000, 250), 25, "memory percentage calculation");
+assertEqual(mod.calculateMemoryFreePercent(0, 250), undefined, "zero total memory is unavailable");
+assertEqual(mod.calculateMemoryFreePercent(1000, 1200), undefined, "impossible free memory is unavailable");
+assertNear(mod.calculateCpuUtilization(firstCpu, secondCpu), 60, "CPU delta calculation");
+assertEqual(mod.calculateCpuUtilization(undefined, secondCpu), undefined, "first CPU sample is unavailable");
+assertEqual(mod.calculateCpuUtilization(firstCpu, { idle: 1, total: 1 }), undefined, "counter reset is unavailable");
+
+const sampled = mod.sampleHealthSources(
+  { totalMemoryBytes: 200, freeMemoryBytes: 50, cpus: [cpu({ user: 70, sys: 30, idle: 50 })] },
+  firstCpu,
+);
+assertNear(sampled.metrics.memoryFreePercent, 25, "sampled memory percentage");
+assertNear(sampled.metrics.cpuUtilizationPercent, 60, "sampled CPU percentage");
+
+assertEqual(mod.metricTone("memory", 25), "muted", "healthy memory tone");
+assertEqual(mod.metricTone("memory", 19), "warning", "low memory tone");
+assertEqual(mod.metricTone("memory", 9), "error", "critical memory tone");
+assertEqual(mod.metricTone("cpu", 69), "muted", "healthy CPU tone");
+assertEqual(mod.metricTone("cpu", 70), "warning", "busy CPU tone");
+assertEqual(mod.metricTone("cpu", 90), "error", "critical CPU tone");
+
+const theme = { fg: (color, text) => `<${color}>${text}</${color}>` };
+const compact = mod.formatHealthStatus(sampled.metrics);
+assertEqual(compact, "RAM 25% free · CPU 60%", "compact status rendering");
+assert(compact.length <= 32, `status should stay compact: ${compact}`);
+const styled = mod.renderHealthStatus(sampled.metrics, theme);
+assert(styled.includes("<muted>RAM 25% free</muted>"), `memory status lost calm styling: ${styled}`);
+assert(styled.includes("<muted>CPU 60%</muted>"), `CPU status lost calm styling: ${styled}`);
+assertEqual(mod.renderHealthStatus({}, theme), "", "unavailable metrics render no unsupported values");
+assertEqual(
+  mod.formatHealthReport({}),
+  "System health: no supported metrics available",
+  "unavailable metrics report",
+);
+const unavailable = mod.sampleHealthSources({ totalMemoryBytes: 0, freeMemoryBytes: 0, cpus: [] });
+assertEqual(Object.keys(unavailable.metrics).length, 0, "unavailable sources stay absent");
+
+const nativeSetInterval = globalThis.setInterval;
+const nativeClearInterval = globalThis.clearInterval;
+const intervals = [];
+const cleared = [];
+globalThis.setInterval = (callback, delay) => {
+  const handle = { callback, delay, cleared: false, unrefCalled: false };
+  handle.unref = () => { handle.unrefCalled = true; };
+  intervals.push(handle);
+  return handle;
+};
+globalThis.clearInterval = (handle) => {
+  handle.cleared = true;
+  cleared.push(handle);
+};
+
+const handlers = new Map();
+let command;
+let footerCalls = 0;
+const statuses = [];
+const notices = [];
+const pi = {
+  on(name, handler) {
+    handlers.set(name, handler);
+  },
+  registerCommand(name, definition) {
+    if (name === "system-health") command = definition;
+  },
+  registerTool() {
+    throw new Error("system-health must not register an LLM tool");
+  },
+};
+mod.default(pi);
+assertEqual(intervals.length, 0, "sampler starts only at session_start");
+assert(command, "slash command was registered");
+assert(handlers.has("session_start"), "session_start handler was registered");
+assert(handlers.has("session_shutdown"), "session_shutdown handler was registered");
+
+const context = {
+  mode: "tui",
+  hasUI: true,
+  ui: {
+    theme,
+    setStatus(key, text) {
+      statuses.push({ key, text });
+    },
+    setFooter() {
+      footerCalls += 1;
+    },
+    notify(message, type) {
+      notices.push({ message, type });
+    },
+  },
+};
+
+await handlers.get("session_start")({ reason: "startup" }, context);
+assertEqual(intervals.length, 1, "session_start starts one sampler");
+assertEqual(intervals[0].delay, mod.SYSTEM_HEALTH_REFRESH_MS, "sampler uses bounded cadence");
+assert(intervals[0].unrefCalled, "sampler does not keep Pi alive");
+assert(statuses.some((entry) => entry.key === mod.SYSTEM_HEALTH_STATUS_KEY), "status uses the unique health key");
+
+await handlers.get("session_start")({ reason: "reload" }, context);
+assertEqual(intervals.length, 2, "reload creates one replacement sampler");
+assert(intervals[0].cleared, "reload clears the previous sampler");
+assertEqual(intervals.filter((entry) => !entry.cleared).length, 1, "reload does not leak duplicate samplers");
+
+const statusCountBeforeTick = statuses.length;
+intervals[1].callback();
+assert(statuses.length > statusCountBeforeTick, "timer refresh publishes status");
+
+await command.handler("off", context);
+assertEqual(statuses.at(-1).text, undefined, "off clears only the extension status");
+await command.handler("on", context);
+assertEqual(notices.at(-1).type, "info", "on reports through the slash command");
+await command.handler("show", context);
+assert(notices.at(-1).message.startsWith("System health:"), "show reports current values");
+assertEqual(footerCalls, 0, "built-in footer is never replaced");
+
+await handlers.get("session_shutdown")({ reason: "reload" }, context);
+assert(intervals[1].cleared, "session_shutdown clears the active sampler");
+assertEqual(intervals.filter((entry) => !entry.cleared).length, 0, "shutdown leaves no sampler");
+const statusCountAfterShutdown = statuses.length;
+intervals[1].callback();
+assertEqual(statuses.length, statusCountAfterShutdown, "late timer callbacks are inert after shutdown");
+
+globalThis.setInterval = nativeSetInterval;
+globalThis.clearInterval = nativeClearInterval;
+JS
+)
+status=$?
+expect_code 0 "$status" "Pi system-health public-interface behavior tests"
+[ -z "$out" ] || fail "Pi system-health tests printed output: $out"
+pass "Pi system-health metrics, rendering, lifecycle cleanup, unavailable sources, and footer preservation"


### PR DESCRIPTION
Thank you — I love what you’ve built and genuinely appreciate your work.

## Intent

Add a compact, low-overhead system-health indicator to Pi’s existing status area without replacing the built-in footer or token/context/model display.

## What changed

- Added a Pi status extension showing truthful available-memory and CPU percentages.
- Uses a bounded asynchronous macOS sampler with cached values and graceful omission when a metric is unavailable.
- Starts and disposes sampling with the Pi session lifecycle, preventing duplicate timers after reload or session replacement.
- Added `/system-health` controls, behavioral tests, and operator documentation.

## Verification

- Focused behavior tests, lint, and documentation checks pass.
- Healthy-macOS comparison evidence confirms the memory display avoids the misleading `os.freemem()` interpretation.
- CI currently requires repository-maintainer approval before the remaining checks can run.

## Privacy

The extension writes no telemetry, persists no machine measurements, uses no network access, and includes no personal content, credentials, account identifiers, private documents, or uploaded local data.
