### PR TITLE
fix(watcher): keep a declared pause bounded across pane repaints

### DIFF
--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -370,8 +370,13 @@ clear_pause_tracking() {  # <window>
 }
 
 # Reconcile a declared pause or captain-held status with authoritative crew state.
-# Only a confidently dead ordinary crew may recover paused classification after
-# fm-crew-state has fallen back to stopped or unknown.
+# On FIRST sight only a confidently dead ordinary crew may recover paused
+# classification after fm-crew-state has fallen back to stopped or unknown: a
+# live agent's pane may be parked at a real gate that must reach firstmate once.
+# Once that first sight has surfaced and put the window on the bounded cadence
+# (.paused-<key> exists), a still-declared pause stays paused whether or not the
+# agent is alive, so an idle pane repainting a clock or token counter is absorbed
+# on the pause cadence instead of re-alerting per repaint.
 pause_state_class() {  # <window> <task>
   local win=$1 task=$2 key last recheck_file class agent_alive
   key=${win//:/_}
@@ -385,14 +390,6 @@ pause_state_class() {  # <window> <task>
     return
   fi
   if [ -e "$STATE/.paused-$key" ] && [ "$(age_of "$recheck_file")" -lt "$STALE_ESCALATE_SECS" ]; then
-    if [ "$(window_kind "$win")" != secondmate ]; then
-      agent_alive=$(fm_backend_agent_alive "$(window_backend "$win")" "$win" 2>/dev/null) || agent_alive=unknown
-      if [ "$agent_alive" != dead ]; then
-        rm -f "$recheck_file"
-        printf 'none'
-        return
-      fi
-    fi
     printf 'paused'
     return
   fi
@@ -402,7 +399,7 @@ pause_state_class() {  # <window> <task>
     printf 'working'
     return
   fi
-  if [ "$(window_kind "$win")" != secondmate ]; then
+  if [ "$(window_kind "$win")" != secondmate ] && [ ! -e "$STATE/.paused-$key" ]; then
     agent_alive=$(fm_backend_agent_alive "$(window_backend "$win")" "$win" 2>/dev/null) || agent_alive=unknown
     if [ "$agent_alive" != dead ]; then
       rm -f "$recheck_file"

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -373,12 +373,14 @@ clear_pause_tracking() {  # <window>
 # On FIRST sight only a confidently dead ordinary crew may recover paused
 # classification after fm-crew-state has fallen back to stopped or unknown: a
 # live agent's pane may be parked at a real gate that must reach firstmate once.
-# Once that first sight has surfaced and put the window on the bounded cadence
-# (.paused-<key> exists), a still-declared pause stays paused whether or not the
-# agent is alive, so an idle pane repainting a clock or token counter is absorbed
-# on the pause cadence instead of re-alerting per repaint.
+# Once that first sight has surfaced and put an ordinary crew on the bounded
+# cadence (.paused-<key> exists), a still-declared pause stays paused whether or
+# not the agent is alive, so an idle pane repainting a clock or token counter is
+# absorbed on the pause cadence instead of re-alerting per repaint. That
+# marker-based recovery is ordinary crew only: a secondmate is classified exactly
+# as it was before, keeping secondmate supervision outside this contract.
 pause_state_class() {  # <window> <task>
-  local win=$1 task=$2 key last recheck_file class agent_alive
+  local win=$1 task=$2 key last recheck_file class agent_alive kind
   key=${win//:/_}
   key=${key//\//_}
   key=${key//./_}
@@ -399,7 +401,8 @@ pause_state_class() {  # <window> <task>
     printf 'working'
     return
   fi
-  if [ "$(window_kind "$win")" != secondmate ] && [ ! -e "$STATE/.paused-$key" ]; then
+  kind=$(window_kind "$win")
+  if [ "$kind" != secondmate ] && [ ! -e "$STATE/.paused-$key" ]; then
     agent_alive=$(fm_backend_agent_alive "$(window_backend "$win")" "$win" 2>/dev/null) || agent_alive=unknown
     if [ "$agent_alive" != dead ]; then
       rm -f "$recheck_file"
@@ -407,7 +410,10 @@ pause_state_class() {  # <window> <task>
       return
     fi
   fi
-  [ "$class" = none ] && { [ "${agent_alive:-unknown}" = dead ] || [ -e "$STATE/.paused-$key" ]; } && class=paused
+  [ "$class" = none ] \
+    && { [ "${agent_alive:-unknown}" = dead ] \
+      || { [ "$kind" != secondmate ] && [ -e "$STATE/.paused-$key" ]; }; } \
+    && class=paused
   case "$class" in
     paused) date +%s > "$recheck_file" ;;
     *) rm -f "$recheck_file" ;;

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -1095,9 +1095,10 @@ EOF
           #   - working: an actively-running pipeline legitimately sits on a static
           #     pane (e.g. waiting on CI), so absorb and start the wedge timer so a
           #     genuinely frozen run still escalates past STALE_ESCALATE_SECS;
-          #   - paused: the crew declared an external wait, or a declared pause or
-          #     captain hold is paired with a confidently dead agent, so absorb on
-          #     the long PAUSE_RESURFACE_SECS cadence instead of wedge-escalating;
+          #   - paused: a declared external wait or captain hold that keeps that
+          #     classification under the contract in pause_state_class's header,
+          #     so absorb on the long PAUSE_RESURFACE_SECS cadence instead of
+          #     wedge-escalating;
           #   - none: no running pipeline, no exact busy verdict, no declared pause.
           #     Surface immediately so firstmate inspects the inconclusive state
           #     (it may be done via an interactive menu that wrote no done: status,

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -407,7 +407,7 @@ pause_state_class() {  # <window> <task>
       return
     fi
   fi
-  [ "$class" = none ] && [ "${agent_alive:-unknown}" = dead ] && class=paused
+  [ "$class" = none ] && { [ "${agent_alive:-unknown}" = dead ] || [ -e "$STATE/.paused-$key" ]; } && class=paused
   case "$class" in
     paused) date +%s > "$recheck_file" ;;
     *) rm -f "$recheck_file" ;;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,8 +19,8 @@ A concurrent replacement remains armed, every non-merged or invalid observation 
 `bin/fm-pr-lib.sh` owns the receipt format and strict identity mechanics, while `bin/fm-watch.sh` owns queue-before-retirement ordering.
 No-verb wakes, such as `working:` notes and bare turn-ended signals, are benign only when `bin/fm-crew-state.sh` reports positive evidence that the crew is still working: an actively running no-mistakes step attributed to that crew's current code, or an exact busy verdict from the semantic busy-state contract.
 A crew that declares `paused:` for a known external wait is separately absorbed while idle and re-surfaced only on the longer pause cadence, rather than being treated as a possible wedge.
-For an ordinary crew that has stopped, the normal-mode watcher first surfaces one stale wake, then applies that same cadence to an unchanged `paused:` or durable `captain-held` endpoint only when the backend confidently reports its agent dead.
-Live or inconclusive liveness remains fail-open at that initial surface, and the secondmate idle-endpoint exemption is unchanged.
+For an ordinary crew that has stopped, the normal-mode watcher first surfaces one stale wake, then applies that same cadence to a still-declared `paused:` or durable `captain-held` endpoint, holding it across pane repaints and whether or not the backend still reports the agent alive.
+Liveness governs only that initial surface, where live or inconclusive evidence keeps the wake flowing so a real decision gate is never hidden, and the secondmate idle-endpoint exemption is unchanged.
 Its initial normal-mode status signal still surfaces through the no-verb path, while away mode self-handles that routine signal and owns the later recheck.
 Fresh stale panes use the same current-state read before trusting the status log, so an active run or a proven busy worker outranks an old captain-relevant status-log line left behind before validation.
 No-change heartbeats are also benign.

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -878,6 +878,67 @@ test_live_declared_pause_repaints_stay_bounded() {
   pass "a live crew's declared pause stays on the bounded cadence across pane repaints, surfacing once"
 }
 
+# The same bounded cadence, but with the authoritative crew read inconclusive
+# instead of paused: fm-crew-state falls back to unknown (an unreadable pane, a
+# torn-down worktree, a harness state read that failed) while the status log
+# still declares the pause. A window already on the cadence must stay on it -
+# only an authoritative working verdict or a status line that no longer declares
+# a pause may take it off - so the repaint is absorbed and the recheck marker is
+# refreshed rather than dropped, keeping the cheap fast path available.
+test_declared_pause_survives_inconclusive_crew_state() {
+  local dir state fakebin out capture_file statusf window key pane_hash sig pid back ticks wakes bare recheck
+  dir=$(make_case pause-cadence-inconclusive-state); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; statusf="$state/held.status"
+  window="test:fm-held"
+  printf 'idle, holding for upstream (token 7)' > "$capture_file"
+  printf 'window=%s\nkind=ship\nharness=grok\nbackend=tmux\n' "$window" > "$state/held.meta"
+  printf 'paused: holding for the upstream tool release\n' > "$statusf"
+  back=$(( $(date +%s) - 500 ))
+  set_mtime "$back" "$statusf"
+  sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-held_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  pane_hash=$(hash_text 'idle, holding for upstream (token 7)')
+  printf '%s' "$pane_hash" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+
+  # Already on the cadence: surfaced once and re-surfaced recently (so the
+  # cadence itself stays quiet this poll), with the recheck marker aged past
+  # STALE_ESCALATE_SECS so this repaint takes the slow authoritative path.
+  : > "$state/.paused-$key"
+  date +%s > "$state/.paused-resurfaced-$key"
+  printf '%s\n' "$back" > "$state/.paused-rechecked-$key"
+  set_mtime "$back" "$state/.paused-rechecked-$key"
+
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=grok \
+    FM_FAKE_CREW_STATE='state: unknown · source: none · pane unreadable' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+    FM_STALE_ESCALATE_SECS=240 FM_PAUSE_RESURFACE_SECS=240 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  ticks=0
+  while [ "$ticks" -lt 150 ] && [ "$(cat "$state/.stale-$key" 2>/dev/null || true)" != "$pane_hash" ] \
+    && kill -0 "$pid" 2>/dev/null; do
+    sleep 0.1
+    ticks=$((ticks + 1))
+  done
+  kill -0 "$pid" 2>/dev/null \
+    || fail "an inconclusive crew read dropped a declared pause off the bounded cadence and re-alerted: $(cat "$out")"
+  [ "$(cat "$state/.stale-$key" 2>/dev/null || true)" = "$pane_hash" ] \
+    || { reap "$pid"; fail "the inconclusive-state pause repaint was never triaged (stale suppressor not advanced)"; }
+  reap "$pid"
+  wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' "$state/.wake-queue" 2>/dev/null || printf 0)
+  bare=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w && $5 == "stale: " w { n++ } END { print n + 0 }' "$state/.wake-queue" 2>/dev/null || printf 0)
+  [ "$bare" -eq 0 ] || fail "an inconclusive crew read emitted $bare bare stale wakes for a declared pause"
+  [ "$wakes" -eq 0 ] || fail "an inconclusive crew read queued $wakes stale wakes inside the pause re-surface window"
+  [ -e "$state/.paused-$key" ] || fail "an inconclusive crew read cleared the pause cadence marker"
+  recheck=$(cat "$state/.paused-rechecked-$key" 2>/dev/null || printf 0)
+  [ "$recheck" -gt "$back" ] \
+    || fail "an inconclusive crew read dropped the pause recheck marker, so the fast path can never re-engage"
+  [ ! -e "$state/.stale-since-$key" ] || fail "an absorbed inconclusive-state pause started the wedge timer"
+  pass "a declared pause already on the bounded cadence survives an inconclusive authoritative crew read"
+}
+
 test_secondmate_paused_resurfaces_in_normal_mode() {
   local dir state fakebin out capture_file statusf window key pane_hash sig pid back
   dir=$(make_case secondmate-paused-resurface); state="$dir/state"; fakebin="$dir/fakebin"
@@ -1949,6 +2010,7 @@ test_nonterminal_stale_not_working_surfaced
 test_nonterminal_stale_paused_absorbed_then_resurfaced
 test_exited_declared_pause_is_bounded_but_live_gate_surfaces
 test_live_declared_pause_repaints_stay_bounded
+test_declared_pause_survives_inconclusive_crew_state
 test_secondmate_paused_resurfaces_in_normal_mode
 test_secondmate_nonpaused_stale_remains_suppressed
 test_secondmate_unpause_clears_pause_tracking

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -802,6 +802,82 @@ test_exited_declared_pause_is_bounded_but_live_gate_surfaces() {
   pass "exited declared-pause and captain-held panes use bounded pause cadence while a live decision gate still surfaces once"
 }
 
+# Arm a watcher over a LIVE (grok) crew whose authoritative state is a declared
+# pause, on a re-surface window short enough to exercise inside one test.
+arm_live_paused_watcher() {  # <state> <fakebin> <out> <window> <capture>
+  PATH="$2:$PATH" FM_FAKE_TMUX_WINDOW="$4" FM_FAKE_TMUX_CAPTURE="$5" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=grok \
+    FM_FAKE_CREW_STATE='state: paused · source: status-log · holding for the upstream tool release' \
+    FM_STATE_OVERRIDE="$1" FM_CREW_STATE_BIN="$2/fm-crew-state.sh" \
+    FM_PAUSE_RESURFACE_SECS=240 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" >> "$3" &
+}
+
+# The live counterpart of the case above. An idle agent's pane keeps repainting
+# a clock or a token counter, and each repaint settles into a new stale hash, so
+# a live declared pause is re-triaged over and over during one external wait.
+# First sight must still surface once, so a real decision gate is never hidden,
+# but every repaint after it belongs to the bounded pause cadence.
+test_live_declared_pause_repaints_stay_bounded() {
+  local dir state fakebin out capture_file statusf window key sig pid back round ticks wakes bare last_hash
+  dir=$(make_case live-declared-pause-repaints); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; statusf="$state/held.status"
+  window="test:fm-held"
+  printf 'window=%s\nkind=ship\nharness=grok\nbackend=tmux\n' "$window" > "$state/held.meta"
+  printf 'paused: holding for the upstream tool release\n' > "$statusf"
+  # The pause is already older than the re-surface window, so only the throttle
+  # marker - not a fresh status file - can keep the repaints quiet.
+  back=$(( $(date +%s) - 500 ))
+  if [ "$(uname)" = Darwin ]; then touch -mt "$(date -r "$back" '+%Y%m%d%H%M.%S')" "$statusf"
+  else touch -m -d "@$back" "$statusf"; fi
+  sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-held_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+
+  # First sight of the declared pause: primed to go stale on the first poll.
+  printf 'idle, holding for upstream (token 1)' > "$capture_file"
+  last_hash=$(hash_text 'idle, holding for upstream (token 1)')
+  printf '%s' "$last_hash" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+  arm_live_paused_watcher "$state" "$fakebin" "$out" "$window" "$capture_file"
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "first sight of a live declared pause did not surface"
+  bare=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w && $5 == "stale: " w { n++ } END { print n + 0 }' "$state/.wake-queue")
+  [ "$bare" -eq 1 ] || fail "first sight of a live declared pause queued $bare bare stale wakes"
+  ack_stopped_cycle "$state" || fail "could not acknowledge the first-sight surface"
+
+  # One re-armed watcher now sees the idle pane repaint, exactly as a ticking
+  # clock or token counter does during the wait. Each repaint settles into a new
+  # stale hash, so each re-enters the first-sighting path; none may re-alert.
+  arm_live_paused_watcher "$state" "$fakebin" "$out" "$window" "$capture_file"
+  pid=$!
+  round=2
+  while [ "$round" -le 4 ]; do
+    printf 'idle, holding for upstream (token %s)' "$round" > "$capture_file"
+    last_hash=$(hash_text "idle, holding for upstream (token $round)")
+    # The stale suppressor advances on both the surface and the absorb path, so
+    # waiting for it keeps every repaint a real triage instead of a timing no-op.
+    ticks=0
+    while [ "$ticks" -lt 150 ] && [ "$(cat "$state/.stale-$key" 2>/dev/null || true)" != "$last_hash" ] \
+      && kill -0 "$pid" 2>/dev/null; do
+      sleep 0.1
+      ticks=$((ticks + 1))
+    done
+    wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' "$state/.wake-queue")
+    [ "$wakes" -eq 0 ] \
+      || fail "a repaint re-alerted a declared pause inside its re-surface window ($wakes extra stale wakes by round $round)"
+    kill -0 "$pid" 2>/dev/null \
+      || fail "the watcher exited on repaint round $round of a declared pause inside its re-surface window"
+    [ "$(cat "$state/.stale-$key" 2>/dev/null || true)" = "$last_hash" ] \
+      || fail "live paused repaint round $round was never triaged (stale suppressor not advanced)"
+    round=$((round + 1))
+  done
+  reap "$pid"
+
+  [ -e "$state/.paused-$key" ] || fail "the repaints lost the pause cadence marker"
+  [ ! -e "$state/.stale-since-$key" ] || fail "an absorbed live paused repaint started the wedge timer"
+  pass "a live crew's declared pause stays on the bounded cadence across pane repaints, surfacing once"
+}
+
 test_secondmate_paused_resurfaces_in_normal_mode() {
   local dir state fakebin out capture_file statusf window key pane_hash sig pid back
   dir=$(make_case secondmate-paused-resurface); state="$dir/state"; fakebin="$dir/fakebin"
@@ -1872,6 +1948,7 @@ test_busy_pane_default_turn_age_bound_is_3600s
 test_nonterminal_stale_not_working_surfaced
 test_nonterminal_stale_paused_absorbed_then_resurfaced
 test_exited_declared_pause_is_bounded_but_live_gate_surfaces
+test_live_declared_pause_repaints_stay_bounded
 test_secondmate_paused_resurfaces_in_normal_mode
 test_secondmate_nonpaused_stale_remains_suppressed
 test_secondmate_unpause_clears_pause_tracking

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -828,8 +828,7 @@ test_live_declared_pause_repaints_stay_bounded() {
   # The pause is already older than the re-surface window, so only the throttle
   # marker - not a fresh status file - can keep the repaints quiet.
   back=$(( $(date +%s) - 500 ))
-  if [ "$(uname)" = Darwin ]; then touch -mt "$(date -r "$back" '+%Y%m%d%H%M.%S')" "$statusf"
-  else touch -m -d "@$back" "$statusf"; fi
+  set_mtime "$back" "$statusf"
   sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-held_status"
   key=$(printf '%s' "$window" | tr ':/.' '___')
 


### PR DESCRIPTION
## Intent

Fix the Firstmate watcher so a worker that declares an external wait (a paused: status line) is re-alerted only once per FM_PAUSE_RESURFACE_SECS instead of on every idle pane repaint. Symptom: an idle TUI repaints a clock or token counter, each repaint settles into a new pane hash, and the watcher fired a fresh bare stale wake every time for the whole wait.

A prior investigation (data/firstmate-external-wait-fix/report.md) recommended adding a guard at the top of surface_nonterminal_stale that reads the .paused-resurfaced-KEY marker and delegates to handle_paused_stale. That fix was implemented first and proved insufficient: the hash-changed branch of the stale dispatcher (bin/fm-watch.sh around line 1170) calls clear_pause_tracking for a live crew, which deletes the very marker the guard reads, so it still re-alerted. Evidence for that rejection is in data/firstmate-external-wait-fix-retry/report.md section 2.

The shipped change corrects the root cause instead: pause_state_class downgraded a declared pause to none whenever the backend did not confidently report the agent dead, and that downgrade now applies only on first sight, gated on the absence of the .paused-KEY cadence marker.

Deliberate decisions a reviewer reading only the diff would not know:
1. First sight must still surface promptly so a live agent parked at a real decision gate is never hidden behind the pause cadence; the existing alive-decision-gate test pins this and must keep passing.
2. surface_nonterminal_stale is deliberately left byte-for-byte pristine. No guard was added there.
3. The fast paths liveness probe was deleted entirely rather than kept. That is intentional and also closes a separate finding from the discovery report: a live paused crew was re-reading authoritative crew state through fm-crew-state.sh on every poll for the whole wait, against the first-sight-only comment in the same file.
4. Secondmate handling is unchanged; both branches still skip the liveness check for kind=secondmate.
5. Scope was explicitly constrained by the captain: do not broaden the stale classification contract and do not alter unrelated supervision behavior. The change is net minus three lines of logic in one classifier.
6. The docs/architecture.md edit is required, not incidental: the old wording promised the bounded cadence only for an unchanged endpoint whose agent was confidently dead, which is no longer what the code does.
7. The regression test deliberately uses one long-lived watcher observing real pane repaints rather than re-arming a fresh watcher per repaint. That detail is load-bearing: the discovery repro re-armed per round with a pre-primed hash, which silently skips the hash-changed branch that defeated the first fix. The test fails on unmodified source and passes with the fix.

Verification already run locally: pinned shellcheck via bin/fm-lint.sh clean, bin/fm-doc-audience-check.sh clean, tests/fm-daemon.test.sh 99 ok, and all 40 tests of tests/fm-watch-triage.test.sh green (64 assertions, zero failures).

One unrelated pre-existing bug was found while verifying and deliberately NOT fixed here, because it is outside this scope: fm_lock_try_acquire in bin/fm-wake-lib.sh steals a stale lock by recursing on lockdir.steal and leaves each level on disk, so the chain grows one level per retry until the filename is too long, wedging the watcher and making it unable to service SIGTERM promptly. It is written up for its own task.

## What Changed

- `pause_state_class` in `bin/fm-watch.sh` no longer downgrades a declared `paused:` endpoint to `none` whenever the backend fails to confidently report the agent dead. That downgrade is now gated on the absence of the `.paused-<key>` cadence marker, so it applies only on first sight; once an ordinary crew is on the bounded cadence, a still-declared pause classifies as `paused` regardless of liveness, and repeated pane hash changes are absorbed on the `FM_PAUSE_RESURFACE_SECS` cadence instead of queueing a bare stale wake per repaint. Secondmate windows skip the liveness check on both branches exactly as before.
- The liveness probe on the classifier's fast path is deleted rather than gated, so a paused window no longer re-reads authoritative crew state through `fm-crew-state.sh` on every poll for the duration of the wait. `docs/architecture.md` is updated to match: the cadence now covers a still-declared `paused:` or durable `captain-held` endpoint across repaints, with liveness governing only the initial surface.
- `tests/fm-watch-triage.test.sh` adds two regression tests. One arms a single long-lived watcher over a live crew and rewrites the pane across four rounds, asserting one bare stale wake at first sight, zero afterward, an intact `.paused-<key>` marker, and no wedge timer. The other pins that a window already on the cadence stays paused and refreshes its recheck marker when the crew-state read falls back to inconclusive.

## Risk Assessment

✅ Low: The change is a three-condition edit to one classifier with verified secondmate byte-equivalence, escape hatches on every dispatcher path (status change, busy pane, authoritative working verdict) that prevent a pause from being absorbed indefinitely, an unconditional cadence wake so nothing goes silent, and two new tests that genuinely fail on unmodified source.

## Testing

Ran the focused end-to-end watcher test file and captured CLI evidence; the worktree remained clean. Linters and the full repository suite were not run per the assigned test-phase boundary.

<details>
<summary>Evidence: Pause cadence behavioral evidence</summary>

```text
ok - exited declared-pause and captain-held panes use bounded pause cadence while a live decision gate still surfaces once
ok - a live crew's declared pause stays on the bounded cadence across pane repaints, surfacing once
ok - a declared pause already on the bounded cadence survives an inconclusive authoritative crew read
ok - a declared paused secondmate re-surfaces on the bounded normal-mode cadence
ok - a non-paused secondmate retains normal stale suppression
ok - a resumed secondmate clears pause and stale tracking before stale exemption
ok - unchanged stale hashes reclassify when a crew enters or leaves pause
ok - a declared pause is periodically rechecked against authoritative active-run state
ok - a paused status overridden by authoritative working preserves its wedge timer and escalates
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"a80f36a15b83c5c859edf1363684962abe126766","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-watch.sh:410` - The new `|| [ -e &#34;$STATE/.paused-$key&#34; ]` disjunct changes secondmate classification, which the intent states is unchanged (&#34;Secondmate handling is unchanged; both branches still skip the liveness check for kind=secondmate&#34; and &#34;do not alter unrelated supervision behavior&#34;). The claim is true of the two liveness-probe branches, but line 410 is not gated on kind. Concrete path: a secondmate whose status log still says `paused:`, with `.paused-&lt;key&gt;` already set from an earlier paused verdict and `.paused-rechecked-&lt;key&gt;` aged past STALE_ESCALATE_SECS (240s), whose authoritative read has since fallen to stopped/unknown so `crew_absorb_class` returns `none`. Because secondmate skips the probe, `agent_alive` stays unset, so previously `[ &#34;${agent_alive:-unknown}&#34; = dead ]` was always false and the function returned `none` -&gt; the dispatcher at bin/fm-watch.sh:1039 and :1157 called `clear_pause_tracking`, wiping the markers and leaving that secondmate permanently silent. Now the marker exists, so class becomes `paused` -&gt; `handle_paused_stale` keeps the cadence and re-surfaces an &#34;awaiting external&#34; wake every PAUSE_RESURFACE_SECS (3600s default) for as long as the stale `paused:` line stands. This is arguably an improvement over the silent drop and is bounded, but it is a real, untested wake-behavior change: none of test_secondmate_paused_resurfaces_in_normal_mode (crew state is `paused`, so it never reaches line 410 with class=none), test_secondmate_nonpaused_stale_remains_suppressed, or test_secondmate_unpause_clears_pause_tracking covers it. Either confirm the new secondmate behavior is wanted and pin it with a test, or add `[ &#34;$(window_kind &#34;$win&#34;)&#34; != secondmate ]` to the marker disjunct to keep secondmate byte-equivalent.
- ℹ️ `tests/fm-watch-triage.test.sh:831` - The newly added test hand-rolls the Darwin/Linux back-date branch (`if [ &#34;$(uname)&#34; = Darwin ]; then touch -mt ... else touch -m -d &#34;@$back&#34; ...`) while the `set_mtime` helper at tests/fm-watch-triage.test.sh:88 already does exactly this, and the other test added in the same change (line 897) uses it. Replace lines 831-832 with `set_mtime &#34;$back&#34; &#34;$statusf&#34;`. Limited to the two lines this change adds; the pre-existing copies elsewhere in the file are out of scope.

🔧 Fix: gate pause marker recovery to ordinary crew
1 info still open:
- ℹ️ `bin/fm-watch.sh:413` - The four-line disjunction is provably equivalent to `[ &#34;$class&#34; = none ] &amp;&amp; [ &#34;$kind&#34; != secondmate ] &amp;&amp; class=paused`. `agent_alive` is assigned only inside the `:405` block, which is entered exactly when `kind != secondmate &amp;&amp; ! -e .paused-$key`, and that block returns early unless the value is `dead` — so `[ &#34;${agent_alive:-unknown}&#34; = dead ]` is reachable iff (kind != secondmate AND no marker), while the second disjunct is (kind != secondmate AND marker). Their union is just `kind != secondmate`. Also worth knowing for future edits: since `crew_absorb_class` only ever prints working/paused/none and `working` returns at :399, this means every ordinary crew reaching :417 is `paused`, so the `*) rm -f &#34;$recheck_file&#34;` arm at :419 is now reachable only for a secondmate. No action needed — the explicit form documents the two distinct reasons and stays correct if the probe ever moves — but the simpler form is available if the boolean is revisited.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `rtk bash tests/fm-watch-triage.test.sh`
- `Reviewed the generated pause-cadence behavioral transcript`
- `rtk git status --short --untracked-files=all`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
