### PR TITLE
fix: Enable max effort for Codex

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -120,7 +120,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | Harness | Model flag | Effort flag | Notes |
 |---|---|---|---|
 | claude | `--model <model>` | `--effort <low\|medium\|high\|xhigh\|max>` | Verified on Claude Code 2.1.196. |
-| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'` | Verified on codex-cli 0.142.1. The installed binary schema contains `model_reasoning_effort`, the active config uses it, and the bundled model catalog advertises only low/medium/high/xhigh. `max` is omitted. |
+| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh\|max>"'` | Verified on codex-cli 0.147.0 with `gpt-5.6-luna`. The installed binary schema and model catalog accept low/medium/high/xhigh/max. `max` is reachable only from an explicit captain per-task or standing preference, never from the generic fallback. |
 | grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
 | pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,7 +194,7 @@ When every candidate is tight, preserve the captain's strongest-reasoning class 
 Break genuine evidence ties without array-order or harness bias.
 `quota-axi` owns how model or product windows relate to bounding account windows and remains data-only.
 Load `quota-array-dispatch` before choosing among a matched profile array; that skill is the single owner of the completion-aware selection procedure.
-The generic effort fallback and its precedence are owned by `harness-adapters`: explicit captain and standing configured effort win; otherwise use low for well-understood explicit work, xhigh for ambiguous investigation or design, intermediate levels proportionally, and never max without explicit captain preference.
+The generic effort fallback and its precedence are owned by `harness-adapters`: explicit captain and standing configured effort win; otherwise use low for well-understood explicit work, xhigh for ambiguous investigation or design, intermediate levels proportionally, and never max without an explicit captain or standing preference.
 Do not add model-specific versions of that policy.
 
 `secondmate-provisioning` owns secondmate harness pins and inherited local material, while `harness-adapters` owns the harness consequences.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1002,7 +1002,7 @@ crew_dispatch_validate() {
       if $e == null then true
       elif ($e | type) != "string" then false
       elif $h == "claude" then (["low","medium","high","xhigh","max"] | index($e))
-      elif $h == "codex" then (["low","medium","high","xhigh"] | index($e))
+      elif $h == "codex" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "grok" then (["low","medium","high"] | index($e))
       elif $h == "pi" or $h == "pi-signed" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "muse" then (["low","medium","high","xhigh","max"] | index($e))

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1338,10 +1338,9 @@ effort_flag_for_harness() {
       ;;
     codex)
       # The installed codex config schema uses model_reasoning_effort, and the
-      # bundled model catalog advertises low|medium|high|xhigh. Omit max rather
-      # than passing an unsupported value.
+      # current bundled model catalog advertises low|medium|high|xhigh|max.
       case "$effort" in
-        low|medium|high|xhigh) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")" ;;
+        low|medium|high|xhigh|max) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")" ;;
       esac
       ;;
     grok)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -276,7 +276,7 @@ Profile `model` and `effort` fields and rule `why` are optional.
 An omitted model or effort means the selected harness uses its own default for that axis.
 Every profile array is an implicit quota-aware choice resolved through `quota-array-dispatch`.
 If no dispatch rule fits, firstmate resolves `default` through the same object-or-array path before falling back to `config/crew-harness`.
-If a selected profile carries an effort value the chosen harness does not accept, `fm-spawn.sh` records the requested `effort=` in task meta for traceability but omits the launch flag, and bootstrap reports the invalid harness/effort pair as a `CREW_DISPATCH` diagnostic when it is visible in the file.
+If a selected profile carries an effort value the chosen harness does not accept, `fm-spawn.sh` records the requested `effort=` in task meta for traceability but omits the launch flag, and bootstrap reports the invalid harness/effort pair as a `CREW_DISPATCH` diagnostic when it is visible in the file; the [harness-adapters launch-profile matrix](../.agents/skills/harness-adapters/SKILL.md#launch-profile-axes) owns each adapter's accepted effort values and launch flag.
 See [`docs/examples/crew-dispatch.json`](examples/crew-dispatch.json) for a starting point to copy into local `config/crew-dispatch.json`.
 When the file exists, bootstrap validates it with `jq`.
 Valid files stay silent by default; with `FM_BOOTSTRAP_VERBOSE_FACTS=1`, bootstrap emits `BOOTSTRAP_INFO: crew dispatch active config/crew-dispatch.json`, one `BOOTSTRAP_INFO:` fact per rule, and one fact for the optional default profile set.

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -1118,7 +1118,8 @@ test_crew_dispatch_validation() {
   done <<'ROWS'
 malformed dispatch config is flagged^{"rules":[^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - malformed JSON
 unverified dispatch harness is flagged^{"rules":[{"when":"anything","use":{"harness":"spaceship"}}],"default":{"harness":"codex"}}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unverified harness: spaceship
-unsupported codex max effort is flagged^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
+codex max effort is accepted^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5","effort":"max"}}]}^empty^
+unsupported codex ultra effort is flagged^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5","effort":"ultra"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:ultra
 unsupported grok max effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:max
 unsupported grok xhigh effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"xhigh"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:xhigh
 pi max effort is accepted^{"rules":[{"when":"deep coding","use":{"harness":"pi","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
@@ -1137,7 +1138,7 @@ empty array use is flagged^{"rules":[{"when":"big feature","use":[]}]}^exact^CRE
 array profile without harness is flagged^{"rules":[{"when":"big feature","use":[{"model":"gpt-5.5"}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each use profile needs harness
 array profile with malformed model is flagged^{"rules":[{"when":"big feature","use":[{"harness":"codex","model":5}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - use profile model and effort must be non-empty strings when present
 unknown select is flagged^{"rules":[{"when":"big feature","use":[{"harness":"claude"},{"harness":"codex"}],"select":"mystery"}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unknown select: mystery
-array profile unsupported effort is flagged^{"rules":[{"when":"big feature","use":[{"harness":"codex","effort":"max"}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
+array profile codex max effort is accepted^{"rules":[{"when":"big feature","use":[{"harness":"codex","effort":"max"}]}]}^empty^
 empty default array is flagged^{"default":[]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - default needs at least one profile
 non-object default array entry is flagged^{"default":["codex"]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each default profile must be an object
 default array profile without harness is flagged^{"default":[{"model":"gpt-5.5"}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each default profile needs harness

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -519,6 +519,27 @@ test_same_harness_relaunch_keeps_the_profile_axes() {
   pass "fm-control relaunch: a same-harness relaunch keeps the profile axes it was running with"
 }
 
+test_codex_relaunch_preserves_max_effort_in_the_launch_command() {
+  local dir out rc
+  dir=$(new_case codexmax rl6a)
+  add_ship_task "$dir" rl6a codex
+  sed 's/^model=default$/model=gpt-5.6-luna/; s/^effort=default$/effort=max/' \
+    "$dir/home/state/rl6a.meta" > "$dir/home/state/rl6a.meta.tmp"
+  mv "$dir/home/state/rl6a.meta.tmp" "$dir/home/state/rl6a.meta"
+  printf 'codex' > "$dir/fake/command"
+
+  out=$(run_control "$dir" rl6a relaunch --note "preserve explicit max reasoning effort"); rc=$?
+  expect_code 0 "$rc" "a Codex relaunch with max effort should succeed"$'\n'"$out"
+  [ "$(meta_field "$dir" rl6a model)" = gpt-5.6-luna ] \
+    || fail "a Codex relaunch must preserve its recorded model"
+  [ "$(meta_field "$dir" rl6a effort)" = max ] \
+    || fail "a Codex relaunch must preserve its recorded max effort"
+  assert_contains "$(cat "$dir/fake/literal")" \
+    "codex --model 'gpt-5.6-luna' -c 'model_reasoning_effort=\"max\"'" \
+    "a Codex relaunch must pass max reasoning effort to the replacement process"
+  pass "fm-control relaunch: Codex preserves max effort in metadata and the replacement command"
+}
+
 test_explicit_model_wins_over_the_recorded_one() {
   local dir out rc
   dir=$(new_case explicit rl7)
@@ -1310,6 +1331,7 @@ test_harness_switch_does_not_carry_the_old_profile_axes
 test_harness_switch_resolves_a_prefixed_recorded_harness
 test_prefixed_recorded_harness_requires_explicit_replacement
 test_same_harness_relaunch_keeps_the_profile_axes
+test_codex_relaunch_preserves_max_effort_in_the_launch_command
 test_explicit_model_wins_over_the_recorded_one
 test_relaunch_onto_an_unverified_harness_is_refused
 test_prior_harness_turnend_registry_entry_is_cleared

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -419,21 +419,36 @@ test_codex_threads_model_and_effort() {
   pass "codex receives --model and model_reasoning_effort profile flags"
 }
 
-test_codex_omits_invalid_max_effort() {
+test_codex_passes_max_effort() {
   local rec id out status launch
   id=profile-codex-max-z4
   rec=$(make_spawn_case profile-codex-max codex "$id")
   read_case_record "$rec"
 
-  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5 --effort max)
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5.6-luna --effort max)
   status=$?
-  expect_code 0 "$status" "codex spawn with unsupported max effort should omit the effort flag"
-  assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 max
+  expect_code 0 "$status" "codex spawn with max effort should succeed"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5.6-luna max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' --dangerously-bypass-approvals-and-sandbox" \
-    "codex launch did not preserve the model flag when max effort was omitted"
-  assert_not_contains "$launch" "model_reasoning_effort" "codex launch must omit unsupported max reasoning effort"
-  pass "codex omits unsupported max effort instead of passing a bad config value"
+  assert_contains "$launch" "codex --model 'gpt-5.6-luna' -c 'model_reasoning_effort=\"max\"' --dangerously-bypass-approvals-and-sandbox" \
+    "codex launch did not thread max reasoning effort"
+  pass "codex receives the explicit max reasoning effort config"
+}
+
+test_codex_fallback_does_not_select_max_effort() {
+  local rec id out status launch
+  id=profile-codex-fallback-z4a
+  rec=$(make_spawn_case profile-codex-fallback codex "$id")
+  read_case_record "$rec"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "codex spawn without an effort preference should succeed"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" codex default default
+  launch=$(cat "$LAUNCH_LOG")
+  assert_not_contains "$launch" "model_reasoning_effort" \
+    "codex fallback must not choose max or any other effort without a preference"
+  pass "codex fallback keeps effort unset instead of selecting max"
 }
 
 test_grok_threads_model_and_reasoning_effort() {
@@ -736,7 +751,8 @@ test_active_dispatch_profile_allows_positional_harness
 test_active_dispatch_profile_allows_raw_launch_command
 test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
-test_codex_omits_invalid_max_effort
+test_codex_passes_max_effort
+test_codex_fallback_does_not_select_max_effort
 test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort


### PR DESCRIPTION
## Intent

Enable Codex max reasoning effort for the authoritative gpt-5.6-luna catalog through the existing per-spawn and per-task paths. Accept codex:max in bootstrap, emit -c 'model_reasoning_effort="max"' for fresh Codex spawns, preserve effort=max in relaunch metadata and the actual replacement command, retain explicit captain/per-task and standing profile precedence, keep generic fallback from selecting max, and never mutate ~/.codex/config.toml. Keep unsupported values fail-closed, including codex:ultra, and keep fallback effort unset. Update the authoritative harness-adapters documentation with Codex 0.147.0 Luna evidence and the rule that max is reachable only from explicit captain or standing preference, plus the applicable docs/configuration.md cross-reference. This origin branch supersedes and extends external-fork PR #2008; create one new origin PR with the complete validated diff, do not modify PR #2008, do not merge, and report unrelated full-suite baseline failures transparently rather than hiding them.

## What Changed

- Rozšiřuje bootstrap validaci o `codex:max`, při zachování fail-closed odmítnutí nepodporovaných hodnot jako `codex:ultra`.
- Předává Codexu `-c 'model_reasoning_effort="max"'`, zachovává `model` a `effort=max` při relaunch a ponechává generický fallback bez effortu.
- Aktualizuje dokumentaci s evidencí Codex CLI 0.147.0 a `gpt-5.6-luna`, včetně precedence kapitánské nebo standing preference, a přidává regresní testy pro bootstrap, dispatch a relaunch.

## Risk Assessment

✅ Low: The change is narrowly scoped and satisfies the stated Codex max-effort source requirements without introducing a substantiated defect.

## Testing

The focused suites demonstrated explicit max propagation, unset fallback, codex:ultra rejection, relaunch preservation, and unchanged user Codex configuration. Bootstrap emitted repeated fixture-level git diagnostics but exited successfully. Full-suite baseline was not run in this assigned targeted-validation phase.

<details>
<summary>Evidence: Codex max-effort validation transcript</summary>

<code>codex-cli 0.147.0&#10;Fresh spawn: gpt-5.6-luna + max -&gt; -c &#39;model_reasoning_effort=&#34;max&#34;&#39;&#10;Fallback: effort override unset&#10;Bootstrap: codex:max accepted; codex:ultra rejected&#10;Relaunch: max preserved in metadata and replacement command&#10;~/.codex/config.toml SHA-256 unchanged before/after</code>

```text
Codex max-effort validation evidence
Installed Codex: codex-cli 0.147.0

Fresh spawn path:
spawned profile-codex-max-z4 harness=codex
meta: harness=codex model=gpt-5.6-luna effort=max
launch: codex --model 'gpt-5.6-luna' -c 'model_reasoning_effort="max"' --dangerously-bypass-approvals-and-sandbox
fallback launch: no model_reasoning_effort config override when no effort preference is supplied

Bootstrap validation:
codex:max accepted
codex:ultra rejected as invalid effort

Relaunch path:
Codex metadata preserved as model=gpt-5.6-luna effort=max
replacement command preserved -c 'model_reasoning_effort="max"'

User config side-effect check:
SHA-256 before: 004e651bb91e2df7f7f8c9de7da2ddff5447957e402b274f5ab0f20222028412  ~/.codex/config.toml
SHA-256 after:  004e651bb91e2df7f7f8c9de7da2ddff5447957e402b274f5ab0f20222028412  ~/.codex/config.toml

CLI parser check:
codex exec --ephemeral --ignore-user-config --skip-git-repo-check --model gpt-5.6-luna -c 'model_reasoning_effort="max"' --help
exit=0

Documentation cross-reference:
.agents/skills/harness-adapters/SKILL.md documents Codex 0.147.0, gpt-5.6-luna, max effort, and explicit captain/standing-only reachability.
docs/configuration.md links to the harness-adapters launch-profile matrix.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c14da6460c97672001e6d8b70946c1fb77c62ee8","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-spawn-dispatch-profile.test.sh`
- `bash tests/fm-control-relaunch.test.sh`
- `bash tests/fm-bootstrap.test.sh`
- `Codex 0.147.0 parser check with gpt-5.6-luna and max effort`
- <code>SHA-256 comparison of `~/.codex/config.toml`</code>
- `Documentation cross-reference checks`
- `Final clean-worktree check`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
