### PR TITLE
fix: recognize Grok 1.0.3 and verify watcher continuity

### DIFF
--- a/bin/fm-vendor-auth-probe.sh
+++ b/bin/fm-vendor-auth-probe.sh
@@ -29,7 +29,7 @@
 #
 # Registered probes:
 #   grok   `grok models` - the standalone Grok Build CLI. Verified on grok
-#          0.2.117: the command exits 0 in BOTH the authenticated and the
+#          1.0.3: the command exits 0 in BOTH the authenticated and the
 #          unauthenticated case, so only the literal first stdout line
 #          discriminates and the exit status is never a verdict.
 #
@@ -63,7 +63,7 @@
 #                                  `alarm 0` both mean "no deadline".
 set -u
 
-VERIFIED_GROK_VERSION=0.2.117
+VERIFIED_GROK_VERSION=1.0.3
 
 usage() {
   cat <<'EOF'
@@ -161,7 +161,7 @@ probe_grok() {
     printf 'timeout\n'
     return 0
   fi
-  # The exit status is deliberately ignored: grok 0.2.117 exits 0 in both the
+  # The exit status is deliberately ignored: grok 1.0.3 exits 0 in both the
   # authenticated and unauthenticated cases, so only the first stdout line
   # discriminates. Raw output is classified here and never printed.
   first=$(printf '%s\n' "$output" | head -n 1)

--- a/docs/verification/dispatch-auth.md
+++ b/docs/verification/dispatch-auth.md
@@ -150,23 +150,25 @@ That zero is a prepaid balance, not the subscription window, and is never headro
 
 ## Standalone Grok discovery probe
 
-Verified 2026-07-30 on `grok 0.2.117 (f1c06093089f) [stable]`.
+Verified 2026-08-12 on `grok 1.0.3 (1a29d5bc12) [stable]`, after the credentialed watcher-continuity contract passed on the same binary.
 
 ```sh
 grok --version
-grok models   # stdin closed, single attempt, hard-bounded
+bin/fm-vendor-auth-probe.sh grok
+GROK_HOME=<empty-isolated-home> grok models </dev/null
 ```
 
 Observed:
 
+- The maintained probe reports `probe=grok status=authenticated version=1.0.3 versionVerified=yes`.
 - `grok models` exits `0` and its first stdout line is `You are logged in with grok.com.` for an authenticated session.
 - With a home directory holding no Grok credential, the first stdout line is `You are not authenticated.`, also with exit status `0`.
 - Because the status is `0` in both cases, the exit status is not a verdict; only the literal first stdout line is examined, and a blank first line does not authenticate.
-- `<home>/.grok/auth.json` was byte-identical across the authenticated run (`mtime`, `size`, and mode `0600` unchanged), so the probe is a read in that path.
+- The live credential file was byte-identical by SHA-256 before and after both checks, so neither probe mutated it.
 
 These discriminator strings are un-owned vendor UI text.
 `bin/fm-vendor-auth-probe.sh` pins the verified version, reports `versionVerified=no` when the running CLI differs, and classifies any unrecognized first line as `indeterminate` rather than authenticated.
-Re-run the two commands above and update this section and the pinned version together when the vendor CLI changes.
+Re-run the three commands above and update this section and the pinned version together when the vendor CLI changes.
 
 ## Regression coverage
 

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -326,7 +326,7 @@ fm-claude-stop-autoarm: ok
 
 ## Watcher continuity
 
-The cross-harness evidence combines the 2026-07-17 live pass with Claude's replacement Stop-owned path revalidated on 2026-07-24, all against isolated project and home state.
+The cross-harness evidence combines the 2026-07-17 live pass with Claude's replacement Stop-owned path revalidated on 2026-07-24 and Grok's native completion path revalidated on 2026-08-12, all against isolated project and home state.
 No credential material was copied into a fixture.
 
 ```text
@@ -334,7 +334,7 @@ Claude Code 2.1.219
 codex-cli 0.144.4
 OpenCode 1.17.18
 Pi 0.80.10
-grok 0.2.103 (89c3d36fb6f1) [stable]
+grok 1.0.3 (1a29d5bc12) [stable]
 ```
 
 | Harness | Exact opt-in command | Observed guarantee |
@@ -343,7 +343,13 @@ grok 0.2.103 (89c3d36fb6f1) [stable]
 | Codex | `FM_CODEX_LIVE_E2E=1 tests/fm-codex-continuity-live-e2e.test.sh` | The one-second foreground checkpoint returned without switching to the arm wrapper. |
 | OpenCode | `FM_OPENCODE_LIVE_E2E=1 tests/fm-opencode-primary-live-e2e.test.sh` | A verified successor existed before prompt handling, with no model re-arm or turn-end fallback. |
 | Pi | `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` | One initial tool call led to extension-owned successors and clean child retirement on exit. |
-| Grok | `FM_GROK_LIVE_E2E=1 tests/fm-grok-continuity-live-e2e.test.sh` | Native task completion surfaced the actionable close and the cycle ledger recorded `reason=actionable-signal`. |
+| Grok | `FM_GROK_LIVE_E2E=1 tests/fm-grok-continuity-live-e2e.test.sh` | Native task completion delivered the actionable close into the same interactive session, the cycle ledger recorded `reason=actionable-signal`, and Grok started a distinct live successor arm without another human prompt. |
+
+The Grok refresh produced:
+
+```text
+ok - grok 1.0.3 (1a29d5bc12) [stable] live E2E consumed actionable native completion and re-armed a live successor in the same session
+```
 
 Pi 0.81.1 repeated the continuity and clean-exit lifecycle on 2026-07-23 after the Calm presentation changes.
 

--- a/tests/fm-grok-continuity-live-e2e.test.sh
+++ b/tests/fm-grok-continuity-live-e2e.test.sh
@@ -50,8 +50,21 @@ lab_pid_is_safe() {
   esac
 }
 
+arm_pid_is_tracked() {
+  local pid=$1 command
+  command=$(ps -p "$pid" -o command= 2>/dev/null || true)
+  case "$command" in
+    *bin/fm-watch-arm.sh*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 cleanup() {
-  local watcher_pid arm_pid
+  local watcher_pid arm_pid turn_barrier_pid
+  if [ -d "$HOME_DIR/state" ]; then
+    : > "$HOME_DIR/state/grok-initial-turn-release"
+  fi
+  turn_barrier_pid=$(cat "$HOME_DIR/state/grok-initial-turn-hook.pid" 2>/dev/null || true)
   watcher_pid=$(cat "$HOME_DIR/state/.watch.lock/pid" 2>/dev/null || true)
   arm_pid=$(ps -p "$watcher_pid" -o ppid= 2>/dev/null | tr -d ' ' || true)
   "$TMUX" -L "$SOCKET" kill-server 2>/dev/null || true
@@ -62,6 +75,9 @@ cleanup() {
   if [ -n "$arm_pid" ] && lab_pid_is_safe "$arm_pid"; then
     kill -TERM "$arm_pid" 2>/dev/null || true
   fi
+  if [ -n "$turn_barrier_pid" ] && lab_pid_is_safe "$turn_barrier_pid"; then
+    kill -TERM "$turn_barrier_pid" 2>/dev/null || true
+  fi
   rm -rf "$LAB"
 }
 trap cleanup EXIT
@@ -69,6 +85,21 @@ trap cleanup EXIT
 mkdir -p "$LAB"
 git clone -q "$ROOT" "$PROJECT"
 cp "$ROOT/bin/fm-watch-arm.sh" "$PROJECT/bin/fm-watch-arm.sh"
+cat > "$PROJECT/bin/fm-grok-continuity-turn-barrier.sh" <<'SH'
+#!/usr/bin/env bash
+set -u
+STATE="${FM_HOME:?}/state"
+[ ! -e "$STATE/grok-initial-turn-complete" ] || exit 0
+printf '%s\n' "${BASHPID:-$$}" > "$STATE/grok-initial-turn-hook.pid"
+while [ ! -e "$STATE/grok-initial-turn-release" ]; do
+  sleep 0.05
+done
+: > "$STATE/grok-initial-turn-complete"
+SH
+chmod +x "$PROJECT/bin/fm-grok-continuity-turn-barrier.sh"
+cat > "$PROJECT/.grok/hooks/zz-fm-continuity-turn-barrier.json" <<'JSON'
+{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"bash -lc 'exec \"${GROK_WORKSPACE_ROOT:?}/bin/fm-grok-continuity-turn-barrier.sh\"'","timeout":180}]}]}}
+JSON
 mkdir -p "$HOME_DIR/state" "$HOME_DIR/config"
 printf 'project=fixture\n' > "$HOME_DIR/state/grok-e2e.meta"
 
@@ -78,20 +109,51 @@ printf 'project=fixture\n' > "$HOME_DIR/state/grok-e2e.meta"
 wait_for_text "Grok Build" 180 || fail "Grok did not reach its ready composer"
 sleep 1
 # shellcheck disable=SC2016 # Backticks are literal prompt markup.
-PROMPT='Use run_terminal_command with background=true to run exactly `bin/fm-watch-arm.sh`. Never use a shell ampersand. Once it reports started, respond briefly.'
+PROMPT='Use run_terminal_command with background=true to run exactly `bin/fm-watch-arm.sh`. Never use a shell ampersand. Once it reports started, respond exactly INITIAL_WATCHER_READY. Only after that tracked background task later completes, run exactly `bin/fm-wake-drain.sh`, handle the durable wake, run the exact WAKE_ACK_REQUIRED command it prints, then use run_terminal_command with background=true to run exactly `bin/fm-watch-arm.sh` again. Never use a shell ampersand. Once the successor reports started, respond exactly WAKE_HANDLED_AND_REARMED.'
 "$TMUX" -L "$SOCKET" send-keys -t "$SESSION" -l "$PROMPT"
 "$TMUX" -L "$SOCKET" send-keys -t "$SESSION" Enter
 
 i=0
-initial_watcher=
+turn_barrier_pid=
 while [ "$i" -lt 240 ]; do
-  initial_watcher=$(cat "$HOME_DIR/state/.watch.lock/pid" 2>/dev/null || true)
-  [ -n "$initial_watcher" ] && kill -0 "$initial_watcher" 2>/dev/null && break
+  turn_barrier_pid=$(cat "$HOME_DIR/state/grok-initial-turn-hook.pid" 2>/dev/null || true)
+  [ -n "$turn_barrier_pid" ] && kill -0 "$turn_barrier_pid" 2>/dev/null && break
   sleep 0.5
   i=$((i + 1))
 done
-if [ -z "$initial_watcher" ] || ! kill -0 "$initial_watcher" 2>/dev/null; then
-  fail "Grok did not start the tracked background watcher"
+if [ -z "$turn_barrier_pid" ] \
+  || ! kill -0 "$turn_barrier_pid" 2>/dev/null \
+  || ! lab_pid_is_safe "$turn_barrier_pid"; then
+  capture >&2
+  fail "Grok initial turn did not reach its controlled Stop boundary"
+fi
+initial_watcher=$(cat "$HOME_DIR/state/.watch.lock/pid" 2>/dev/null || true)
+initial_arm_pid=$(ps -p "$initial_watcher" -o ppid= 2>/dev/null | tr -d ' ' || true)
+if [ -z "$initial_watcher" ] \
+  || ! kill -0 "$initial_watcher" 2>/dev/null \
+  || ! lab_pid_is_safe "$initial_watcher" \
+  || [ -z "$initial_arm_pid" ] \
+  || ! kill -0 "$initial_arm_pid" 2>/dev/null \
+  || ! arm_pid_is_tracked "$initial_arm_pid"; then
+  capture >&2
+  fail "Grok initial turn reached Stop without a tracked live watcher"
+fi
+: > "$HOME_DIR/state/grok-initial-turn-release"
+i=0
+while [ "$i" -lt 240 ] && kill -0 "$turn_barrier_pid" 2>/dev/null; do
+  sleep 0.05
+  i=$((i + 1))
+done
+if kill -0 "$turn_barrier_pid" 2>/dev/null \
+  || [ ! -e "$HOME_DIR/state/grok-initial-turn-complete" ]; then
+  fail "Grok initial turn did not complete its controlled Stop boundary"
+fi
+current_watcher=$(cat "$HOME_DIR/state/.watch.lock/pid" 2>/dev/null || true)
+if [ "$current_watcher" != "$initial_watcher" ] \
+  || ! kill -0 "$initial_watcher" 2>/dev/null \
+  || ! kill -0 "$initial_arm_pid" 2>/dev/null; then
+  capture >&2
+  fail "Grok initial turn completed without its original watcher live"
 fi
 
 printf 'done: grok live e2e watcher fire\n' > "$HOME_DIR/state/grok-e2e.status"
@@ -104,30 +166,45 @@ done
 grep -Eq 'reason=actionable-signal' "$HOME_DIR/state/.watch-cycle-exits.log" 2>/dev/null \
   || fail "Grok action cycle was not classified in the lifecycle ledger"
 
-# Native background completion is a behavioral contract, not a rendered phrase.
-# Grok's rendered completion copy changes across releases, while the continuity
-# invariant remains the same: the completed task re-enters this session and the
-# model starts a distinct live successor arm without a human prompt. Waiting for
-# that successor also proves the actionable cycle was consumed instead of
-# treating an ambiguous busy footer as success.
 i=0
 successor_watcher=
+recovery_state=
 while [ "$i" -lt 240 ]; do
   successor_watcher=$(cat "$HOME_DIR/state/.watch.lock/pid" 2>/dev/null || true)
+  recovery_state=$(cat "$HOME_DIR/state/.watcher-down" 2>/dev/null || true)
   if [ -n "$successor_watcher" ] \
     && [ "$successor_watcher" != "$initial_watcher" ] \
-    && kill -0 "$successor_watcher" 2>/dev/null; then
-    break
+    && kill -0 "$successor_watcher" 2>/dev/null \
+    && [ -f "$HOME_DIR/state/.wake-queue" ] \
+    && [ ! -s "$HOME_DIR/state/.wake-queue" ]; then
+    case "$recovery_state" in
+      acked:handling:*|acked:downtime:*) break ;;
+    esac
   fi
   sleep 0.5
   i=$((i + 1))
 done
 if [ -z "$successor_watcher" ] \
   || [ "$successor_watcher" = "$initial_watcher" ] \
-  || ! kill -0 "$successor_watcher" 2>/dev/null; then
+  || ! kill -0 "$successor_watcher" 2>/dev/null \
+  || ! lab_pid_is_safe "$successor_watcher"; then
   capture >&2
-  fail "Grok did not consume native background completion and start a live successor watcher"
+  fail "Grok did not start a live successor from native background completion"
 fi
+successor_arm_pid=$(ps -p "$successor_watcher" -o ppid= 2>/dev/null | tr -d ' ' || true)
+if [ -z "$successor_arm_pid" ] \
+  || ! kill -0 "$successor_arm_pid" 2>/dev/null \
+  || ! arm_pid_is_tracked "$successor_arm_pid"; then
+  fail "Grok successor was not owned by a tracked background task"
+fi
+if [ ! -f "$HOME_DIR/state/.wake-queue" ] \
+  || [ -s "$HOME_DIR/state/.wake-queue" ]; then
+  fail "Grok successor started before the durable wake was acknowledged"
+fi
+case "$(cat "$HOME_DIR/state/.watcher-down" 2>/dev/null || true)" in
+  acked:handling:*|acked:downtime:*) ;;
+  *) fail "Grok successor started before the recovery generation was acknowledged" ;;
+esac
 pane=$(capture)
 if printf '%s\n' "$pane" | grep -Fq 'GROK_EXIT='; then
   fail "Grok exited instead of continuing in the same interactive session"

--- a/tests/fm-grok-continuity-live-e2e.test.sh
+++ b/tests/fm-grok-continuity-live-e2e.test.sh
@@ -103,10 +103,37 @@ while [ "$i" -lt 240 ]; do
 done
 grep -Eq 'reason=actionable-signal' "$HOME_DIR/state/.watch-cycle-exits.log" 2>/dev/null \
   || fail "Grok action cycle was not classified in the lifecycle ledger"
-wait_for_text "Task completed in" 120 || fail "Grok did not surface its native background-task completion notification"
+
+# Native background completion is a behavioral contract, not a rendered phrase.
+# Grok's rendered completion copy changes across releases, while the continuity
+# invariant remains the same: the completed task re-enters this session and the
+# model starts a distinct live successor arm without a human prompt. Waiting for
+# that successor also proves the actionable cycle was consumed instead of
+# treating an ambiguous busy footer as success.
+i=0
+successor_watcher=
+while [ "$i" -lt 240 ]; do
+  successor_watcher=$(cat "$HOME_DIR/state/.watch.lock/pid" 2>/dev/null || true)
+  if [ -n "$successor_watcher" ] \
+    && [ "$successor_watcher" != "$initial_watcher" ] \
+    && kill -0 "$successor_watcher" 2>/dev/null; then
+    break
+  fi
+  sleep 0.5
+  i=$((i + 1))
+done
+if [ -z "$successor_watcher" ] \
+  || [ "$successor_watcher" = "$initial_watcher" ] \
+  || ! kill -0 "$successor_watcher" 2>/dev/null; then
+  capture >&2
+  fail "Grok did not consume native background completion and start a live successor watcher"
+fi
 pane=$(capture)
+if printf '%s\n' "$pane" | grep -Fq 'GROK_EXIT='; then
+  fail "Grok exited instead of continuing in the same interactive session"
+fi
 if printf '%s\n' "$pane" | grep -Fq 'bin/fm-watch-arm.sh &'; then
   fail "Grok used a shell ampersand instead of its tracked background task"
 fi
 
-printf 'ok - %s live E2E preserved tracked background completion and shared ledger classification\n' "$GROK_VERSION"
+printf 'ok - %s live E2E consumed actionable native completion and re-armed a live successor in the same session\n' "$GROK_VERSION"

--- a/tests/fm-vendor-auth-probe.test.sh
+++ b/tests/fm-vendor-auth-probe.test.sh
@@ -55,7 +55,7 @@ if IFS= read -r -t 2 leaked; then
   printf '%s\n' "$leaked" >> "$FM_FAKE_GROK_STDIN"
 fi
 if [ "${1:-}" = --version ]; then
-  printf 'grok %s (fakebuild) [stable]\n' "${FM_FAKE_GROK_VERSION:-0.2.117}"
+  printf 'grok %s (fakebuild) [stable]\n' "${FM_FAKE_GROK_VERSION:-1.0.3}"
   exit 0
 fi
 case "${FM_FAKE_GROK_MODE:-authenticated}" in
@@ -75,7 +75,7 @@ case "${FM_FAKE_GROK_MODE:-authenticated}" in
   empty) : ;;
   hang) sleep 30 ;;
 esac
-# grok 0.2.117 exits 0 whether or not the session authenticates; the fake keeps
+# grok 1.0.3 exits 0 whether or not the session authenticates; the fake keeps
 # that property so a regression to exit-status reading fails here.
 exit 0
 SH


### PR DESCRIPTION
## Intent

Diagnose and harden authenticated official Grok CLI 1.0.3 crew continuity so it is safe to enable only as a narrow FirstMate crewmate canary, or preserve it as unavailable with a precise evidence-backed blocker if supported continuity cannot be proven. Reproduce the credentialed FM_GROK_LIVE_E2E=1 tests/fm-grok-continuity-live-e2e.test.sh path in its isolated scratch checkout and prove launch of the tracked background watcher, native completion delivery, actionable signal consumption, and same-session continuation under the exact test contract. Record the initiating trigger, any independent masking condition, and the operator-visible symptom separately; compare the failure with the last proven Grok path or another verified harness path satisfying the same invariant; inspect adapter and live-test history; run the smallest one-variable counterfactual distinguishing adapter regression from insufficient completion budget or changed native-background UX; state and safely run a falsification check; keep observed facts, hypotheses, and uncertainty distinct. If a maintained supported fix exists, make the smallest fix plus a behavioral regression test and update verified vendor-version evidence only after the real credentialed live contract passes. The diagnosis found the supported Grok adapter path works: the failing oracle waited for stale literal rendered text while expected successor rearm retained a live task and masked successful continuation; harden the test by proving a distinct live successor and same-session survival, never by a vendor phrase or ambiguous busy footer. Keep the live test credential-safe and cleanup-safe. Never simulate completion from elapsed time, scrape an ambiguous busy footer as success, use shell ampersand backgrounding, detach an untracked poll, bypass the watcher owner, weaken the shared no-blind-stop boundary, install globally, change credentials, sign in again, alter live crew dispatch configuration, merge, or deploy. Re-run the six focused Grok harness, vendor auth probe, composer ghost, Herdr backend, turn-end guard, and pretool watcher-policy suites, the credentialed live E2E in its isolated scratch checkout, and all repository-required no-mistakes checks. Deliver a review-ready PR with passing checks and maintain the private evidence report with reproduction, cause analysis, counterfactuals, falsification, changed files, exact commands and results, commit, no-mistakes run id, and PR URL.

## What Changed

- Recognize Grok CLI 1.0.3 as the verified version in the bounded authentication probe and its regression fixture.
- Harden the credentialed continuity E2E to prove tracked watcher ownership, durable wake acknowledgement, a distinct live successor, and same-session survival without relying on vendor-rendered completion text.
- Refresh authentication and supervision evidence for the verified Grok 1.0.3 behavior.

## Risk Assessment

✅ Low: Captain, the change is narrowly scoped, and the revised live oracle now resolves both prior false-pass paths without introducing a substantiated source defect.

## Testing

After diff/history and tool preflight, the focused harness-policy suites, sanitized live auth probe, and authenticated scratch-checkout E2E all passed; the stale-copy counterfactual failed only at its intentionally injected phrase gate, and cleanup left the worktree clean with no scratch checkout. This is a CLI test-oracle change, so reviewer-visible evidence is captured terminal/TUI output rather than a browser screenshot.

<details>
<summary>Evidence: Credential-safe Grok auth probe</summary>

<code>grok 1.0.3 (1a29d5bc12) [stable]&#10;probe=grok status=authenticated version=1.0.3 versionVerified=yes</code>

```text
command: grok --version
grok 1.0.3 (1a29d5bc12) [stable]
command: bin/fm-vendor-auth-probe.sh grok
probe=grok status=authenticated version=1.0.3 versionVerified=yes
```
</details>
<details>
<summary>Evidence: Credentialed Grok continuity E2E</summary>

`ok - grok 1.0.3 (1a29d5bc12) [stable] live E2E consumed actionable native completion and re-armed a live successor in the same session`

```text
ok - grok 1.0.3 (1a29d5bc12) [stable] live E2E consumed actionable native completion and re-armed a live successor in the same session
```
</details>
<details>
<summary>Evidence: Stale rendered-text counterfactual</summary>

`Grok TUI showed “1 command still running” and remained interactive, while the injected legacy completion phrase stayed absent and timed out as expected.`

```text

   fm/firstmate-grok-v103-continuity-g1 ~/.no-mistakes/work… : 1 │ 34K / 500K

     ▾ Tasks 1                                                              █


     ❯ Use run_terminal_command with background=true to run          7:59 PM
       exactly `bin/fm-watch-arm.sh`. Never use a shell ampersand.

                                                                               █

    ○ 1 command still running

  Help improve Grok                                         [Opt out] [Opt in]
  Off by default. Opt-in to allow SpaceXAI to retain coding
  data, e.g., prompts, traces, & metrics, for training and
  Read Terms and Privacy Policy.

  ╭──────────────────────────────────────────────────────────────────────────╮
  │ ❯                                                                        │
  ╰──────────────────────────────────────── Grok 4.6 (low) · always-approve ─╯

  Shift+Tab:mode  │  Ctrl+x:shortcuts

not ok - counterfactual stale rendered completion phrase stayed absent
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"57a41c14b25c2af7c394018d40c453204e1ac020","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `tests/fm-grok-continuity-live-e2e.test.sh:115` - Intent requires proving “native completion delivery,” but this new loop accepts any distinct watcher PID. The test fires the signal as soon as the initial watcher starts, before the initiating Grok turn has completed. Reachable false pass: the watcher closes during that turn, the Grok Stop guard observes `grok-e2e.meta` with no watcher and triggers its independent continuation, and that continuation rearms without native background-task completion working. Add a deterministic first-turn-complete barrier while the initial watcher remains live before firing the signal; declining leaves the canary oracle unable to distinguish the required delivery path.
- 🚨 `tests/fm-grok-continuity-live-e2e.test.sh:111` - Intent requires proving “actionable signal consumption,” but the changed claim that a successor proves consumption is unsupported: the ledger only proves the watcher produced/classified the wake, and a model can immediately rearm without running `fm-wake-drain.sh` or acknowledging the durable queue. Assert the executable consumption contract—such as the emitted sequence being removed from `.wake-queue` and its recovery generation acknowledged—before accepting the successor; otherwise the test can pass while the actionable wake remains unhandled.

🔧 Fix: Harden Grok completion and durable wake acknowledgement oracle
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`grok --version` and `tmux -V`</code>
- `tests/fm-grok-harness.test.sh`
- `tests/fm-vendor-auth-probe.test.sh`
- `tests/fm-composer-ghost.test.sh`
- `tests/fm-backend-herdr.test.sh`
- `tests/fm-turnend-guard.test.sh`
- `tests/fm-arm-pretool-check.test.sh`
- `bin/fm-vendor-auth-probe.sh grok`
- `FM_GROK_LIVE_E2E=1 tests/fm-grok-continuity-live-e2e.test.sh`
- <code>Credentialed one-variable counterfactual executed the current live test with only an added legacy `wait_for_text &#34;Task completed in&#34;` gate; it failed at that injected gate as expected while the TUI retained a live command.</code>
- <code>`git status --short` and scratch-checkout cleanup audit</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
