### PR TITLE
fix(bin): require quota-axi 0.1.25

### DIFF
--- a/bin/fm-quota-axi-lib.sh
+++ b/bin/fm-quota-axi-lib.sh
@@ -9,7 +9,7 @@
 # turns a failing check into the operator-facing MISSING diagnostic, which is
 # what keeps an older build from reaching a dispatch intake at all.
 
-FM_QUOTA_AXI_MIN=0.1.17
+FM_QUOTA_AXI_MIN=0.1.25
 
 fm_quota_axi_compatible() {
   local timeout=${1:-} output parts major minor patch extra

--- a/docs/verification/dispatch-auth.md
+++ b/docs/verification/dispatch-auth.md
@@ -143,7 +143,7 @@ Observed source statuses are `available`, `expired` (with an `error` slug), and 
 - A `pi:`-prefixed source exists only where Pi holds its own credential for that family (`pi:xai`, `pi:kimi-coding`). Pi's `openai-codex` family has none, because it authenticates through the Codex store that the `codex` provider already lists. A missing `pi:` source is therefore never evidence against a Pi candidate.
 
 Neither this per-source shape nor `state.authStatus` exists before quota-axi 0.1.16.
-`bin/fm-bootstrap.sh` enforces that floor through `bin/fm-quota-axi-lib.sh`.
+`bin/fm-bootstrap.sh` enforces the current compatibility floor through `bin/fm-quota-axi-lib.sh`.
 
 Grok also reports `credits.remaining: 0` alongside `percentRemaining: 41` on a healthy account.
 That zero is a prepaid balance, not the subscription window, and is never headroom.

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -95,7 +95,7 @@ add_quota_axi() {
   cat > "$fakebin/quota-axi" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
-  printf '%s\n' "${FM_FAKE_QUOTA_AXI_VERSION:-0.1.17}"
+  printf '%s\n' "${FM_FAKE_QUOTA_AXI_VERSION:-0.1.25}"
   exit 0
 fi
 exit 0
@@ -473,11 +473,11 @@ test_quota_axi_min_version() {
         [ "$out" = "$missing" ] || fail "$label: expected '$missing', got: $out" ;;
     esac
   done <<'ROWS'
-minimum quota-axi version is accepted^0.1.17^empty
-newer quota-axi patch is accepted^0.1.18^empty
+minimum quota-axi version is accepted^0.1.25^empty
+newer quota-axi patch is accepted^0.1.26^empty
 newer quota-axi minor is accepted^0.2.0^empty
 newer quota-axi major is accepted^1.0.0^empty
-the patch just below the floor reports an upgrade^0.1.16^missing
+the patch just below the floor reports an upgrade^0.1.24^missing
 much older quota-axi minor reports an upgrade^0.0.9^missing
 unparseable quota-axi version reports an upgrade^quota-axi development build^missing
 ROWS

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -1098,7 +1098,7 @@ SH
   cat > "$fakebin/quota-axi" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
-  printf '%s\n' '0.1.17'
+  printf '%s\n' '0.1.25'
   exit 0
 fi
 exit 0

--- a/tests/fm-secondmate-liveness.test.sh
+++ b/tests/fm-secondmate-liveness.test.sh
@@ -252,7 +252,7 @@ SH
   cat > "$fakebin/quota-axi" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
-  printf '%s\n' '0.1.17'
+  printf '%s\n' '0.1.25'
   exit 0
 fi
 exit 0

--- a/tests/fm-secondmate-sync.test.sh
+++ b/tests/fm-secondmate-sync.test.sh
@@ -359,7 +359,7 @@ SH
   cat > "$fakebin/quota-axi" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
-  printf '%s\n' 'quota-axi 0.1.17 (fake)'
+  printf '%s\n' 'quota-axi 0.1.25 (fake)'
 fi
 exit 0
 SH

--- a/tests/fm-shared-captain-inheritance.test.sh
+++ b/tests/fm-shared-captain-inheritance.test.sh
@@ -249,7 +249,7 @@ SH
   cat > "$fakebin/quota-axi" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
-  printf '%s\n' '0.1.17'
+  printf '%s\n' '0.1.25'
   exit 0
 fi
 exit 0

--- a/tests/fm-startup-memory-budget.test.sh
+++ b/tests/fm-startup-memory-budget.test.sh
@@ -27,7 +27,7 @@ SH
   cat > "$fakebin/quota-axi" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
-  printf '%s\n' 'quota-axi 0.1.17 (fake)'
+  printf '%s\n' 'quota-axi 0.1.25 (fake)'
 fi
 exit 0
 SH


### PR DESCRIPTION
## What Changed

- Raise the bootstrap compatibility floor for `quota-axi` from 0.1.17 to 0.1.25.
- Update bootstrap coverage, test fixtures, and verification documentation to reflect the new minimum version.

## Risk Assessment

✅ Low: The change is a well-bounded compatibility-floor bump with behavioral boundary coverage and consistent fixture updates.

## Testing

Targeted bootstrap regression coverage passed, and an end-user-style CLI demonstration confirmed the new 0.1.25 boundary: 0.1.24 emits the actionable MISSING diagnostic, while 0.1.25 and 0.1.26 are accepted silently; the transcript was preserved as reviewer evidence.

<details>
<summary>Evidence: Bootstrap quota-axi 0.1.25 floor demonstration transcript</summary>

<code>quota-axi 0.1.24 -&gt; MISSING: quota-axi (install: npm install -g quota-axi)&#10;quota-axi 0.1.25 -&gt; silent: compatible toolchain&#10;quota-axi 0.1.26 -&gt; silent: compatible toolchain</code>

```text
End-user bootstrap compatibility-floor demonstration

$ quota-axi --version  # installed version under test
quota-axi 0.1.24
$ fm-bootstrap.sh
MISSING: quota-axi (install: npm install -g quota-axi)

$ quota-axi --version  # installed version under test
quota-axi 0.1.25
$ fm-bootstrap.sh
<silent: compatible toolchain>

$ quota-axi --version  # installed version under test
quota-axi 0.1.26
$ fm-bootstrap.sh
<silent: compatible toolchain>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"9e182d65476e9e84a26c4b7fc8db4d7d8bb25f69","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `./tests/fm-bootstrap.test.sh`
- <code>Ran `bin/fm-bootstrap.sh` through its public CLI with fake installed quota-axi versions 0.1.24, 0.1.25, and 0.1.26 under detect-only/local mode; confirmed 0.1.24 requests an upgrade while 0.1.25 and newer remain silent.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
