### PR TITLE
fix: recognize a trailing [key=slug] token in status-line decisions

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -330,6 +330,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs to a human (product choices, destructive actions),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
+   Give it a key when you want the answer to close it by key: \`needs-decision [key=design-choice]: pick A or B\` - the \`[key=...]\` token sits between the verb and the colon, not after the summary.
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
    Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
@@ -446,6 +447,7 @@ $RULE1
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
+   Give it a key when you want the answer to close it by key: \`needs-decision [key=design-choice]: pick A or B\` - the \`[key=...]\` token sits between the verb and the colon, not after the summary.
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
    Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -221,10 +221,12 @@ _fm_key_at_note_head() {  # <status-line> -> raw slug
 # appends the tag after already writing the summary. Fails when the line does
 # not end in a complete token there; slug charset validity is the caller's
 # check via _fm_decision_slug_ok, exactly as for the other two positions. A
-# token that is not the line's own last token - i.e. anything followed by more
-# note text - is left as ordinary prose and never reaches this function's
-# match, which is what keeps a summary merely mentioning "[key=x]" mid-line
-# from being read as a stated key.
+# token mentioned mid-line is left as ordinary prose - even when the line
+# happens to end with an unrelated "]" - because the text after the line's
+# last "[key=" must run bracket-free to the closing "]" for the line-terminal
+# bracket group to count as one complete stated token; that is what keeps a
+# summary merely mentioning "[key=x]" mid-line from being read as a stated
+# key.
 _fm_key_trailing() {  # <status-line> -> raw slug
   local line=$1 tail
   line=${line%"${line##*[![:space:]]}"}
@@ -233,10 +235,11 @@ _fm_key_trailing() {  # <status-line> -> raw slug
     *) return 1 ;;
   esac
   tail=${line##*\[key=}
+  tail=${tail%\]}
   case "$tail" in
-    *\]) printf '%s' "${tail%\]}" ;;
-    *) return 1 ;;
+    *\[*|*\]*) return 1 ;;
   esac
+  printf '%s' "$tail"
 }
 # 0 when a stated key slug is well-formed: nonempty, A-Za-z0-9._- only.
 _fm_decision_slug_ok() {  # <slug>
@@ -472,7 +475,7 @@ _fm_open_decisions_cursor_path() {  # <status-file>
   printf '%s/.%s.open-decisions-cursor' "$dir" "${base%.status}"
 }
 
-FM_OPEN_DECISIONS_FOLD_VERSION=4
+FM_OPEN_DECISIONS_FOLD_VERSION=5
 
 # Portable device:inode identity for the rotation/recreation check below.
 _fm_open_decisions_file_ident() {  # <file> -> "dev:inode", empty on I/O failure

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -226,9 +226,12 @@ _fm_key_at_note_head() {  # <status-line> -> raw slug
 # last "[key=" must run bracket-free to the closing "]" for the line-terminal
 # bracket group to count as one complete stated token; that is what keeps a
 # summary merely mentioning "[key=x]" mid-line from being read as a stated
-# key.
+# key. The token must also stand alone as its own word - whitespace (or
+# nothing) immediately before its "[" - so prose glued to a terminal bracket
+# group (a summary ending in "cfg[key=env]") stays prose rather than opening
+# or closing the key "env".
 _fm_key_trailing() {  # <status-line> -> raw slug
-  local line=$1 tail
+  local line=$1 tail head
   line=${line%"${line##*[![:space:]]}"}
   case "$line" in
     *\[key=*\]) ;;
@@ -238,6 +241,11 @@ _fm_key_trailing() {  # <status-line> -> raw slug
   tail=${tail%\]}
   case "$tail" in
     *\[*|*\]*) return 1 ;;
+  esac
+  head=${line%"[key=$tail]"}
+  case "$head" in
+    ''|*[[:space:]]) ;;
+    *) return 1 ;;
   esac
   printf '%s' "$tail"
 }
@@ -475,7 +483,7 @@ _fm_open_decisions_cursor_path() {  # <status-file>
   printf '%s/.%s.open-decisions-cursor' "$dir" "${base%.status}"
 }
 
-FM_OPEN_DECISIONS_FOLD_VERSION=5
+FM_OPEN_DECISIONS_FOLD_VERSION=6
 
 # Portable device:inode identity for the rotation/recreation check below.
 _fm_open_decisions_file_ident() {  # <file> -> "dev:inode", empty on I/O failure

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -162,18 +162,22 @@ status_is_paused_or_captain_held() {  # <status-line>
 # Decision key grammar (backward-compatible with the existing "<verb>: <note>"
 # format): an OPTIONAL "[key=<slug>]" token names the decision. Its documented
 # position sits between the verb and the colon, and a complete token at the
-# head of the note is accepted as an EQUIVALENT position, because that
-# misplaced-colon shape is common real worker output whose stated key must
-# never silently collapse into the shared "default" bucket (issue #2109):
+# head of the note, or a complete token at the very end of the line, is each
+# accepted as an EQUIVALENT position, because those misplaced-colon shapes are
+# common real worker output whose stated key must never silently collapse into
+# the shared "default" bucket (issue #2109):
 #   needs-decision [key=api-shape]: <summary>
 #   needs-decision: [key=api-shape] <summary>
+#   needs-decision: <summary> [key=api-shape]
 #   resolved       [key=api-shape]: <how it was decided>
-# Both positions state the same key and yield the same note (a consumed
-# note-head token is key metadata, stripped from the note); when both positions
-# carry a token, the documented before-colon one wins and the note-head token
-# stays note text. A token deeper inside the note is prose, never a stated key,
-# so a summary merely MENTIONING "[key=x]" cannot open or close that decision.
-# A line with no token in either position uses the key "default", preserving
+# All three positions state the same key and yield the same note (a consumed
+# note-head or trailing token is key metadata, stripped from the note); when
+# more than one position carries a token, the documented before-colon one wins
+# over both alternates, and the losing token stays note text. A token deeper
+# inside the note - anywhere other than the note's own head or the line's own
+# end - is prose, never a stated key, so a summary merely MENTIONING "[key=x]"
+# cannot open or close that decision.
+# A line with no token in any position uses the key "default", preserving
 # the historical one-open-decision-per-task behavior (a bare "resolved:" closes
 # "default"). A stated key whose slug fails the charset below is rejected (the
 # folds skip the line), never rewritten to "default".
@@ -212,6 +216,28 @@ _fm_key_at_note_head() {  # <status-line> -> raw slug
     *) return 1 ;;
   esac
 }
+# Raw slug of a complete "[key=<slug>]" token anchored at the very END of the
+# line (trailing whitespace ignored), the position a worker lands in when it
+# appends the tag after already writing the summary. Fails when the line does
+# not end in a complete token there; slug charset validity is the caller's
+# check via _fm_decision_slug_ok, exactly as for the other two positions. A
+# token that is not the line's own last token - i.e. anything followed by more
+# note text - is left as ordinary prose and never reaches this function's
+# match, which is what keeps a summary merely mentioning "[key=x]" mid-line
+# from being read as a stated key.
+_fm_key_trailing() {  # <status-line> -> raw slug
+  local line=$1 tail
+  line=${line%"${line##*[![:space:]]}"}
+  case "$line" in
+    *\[key=*\]) ;;
+    *) return 1 ;;
+  esac
+  tail=${line##*\[key=}
+  case "$tail" in
+    *\]) printf '%s' "${tail%\]}" ;;
+    *) return 1 ;;
+  esac
+}
 # 0 when a stated key slug is well-formed: nonempty, A-Za-z0-9._- only.
 _fm_decision_slug_ok() {  # <slug>
   case "$1" in
@@ -232,6 +258,11 @@ status_line_note() {  # <status-line> -> text after the first colon, trimmed
     && _fm_decision_slug_ok "$k"; then
     n=${n#"[key=$k]"}
     n=${n#"${n%%[![:space:]]*}"}
+  elif ! _fm_key_before_colon "$1" && k=$(_fm_key_trailing "$1") \
+    && _fm_decision_slug_ok "$k"; then
+    n=${n%"${n##*[![:space:]]}"}
+    n=${n%"[key=$k]"}
+    n=${n%"${n##*[![:space:]]}"}
   fi
   printf '%s' "$n"
 }
@@ -241,8 +272,12 @@ _fm_decision_key() {  # <status-line> -> key slug, or "default" when no token
     k=${1%%:*}
     k=${k#*\[key=}
     k=${k%%\]*}
+  elif k=$(_fm_key_at_note_head "$1"); then
+    :
+  elif k=$(_fm_key_trailing "$1"); then
+    :
   else
-    k=$(_fm_key_at_note_head "$1") || { printf 'default'; return 0; }
+    printf 'default'; return 0
   fi
   _fm_decision_slug_ok "$k" || return 1
   printf '%s' "$k"

--- a/tests/fm-classify-decision-key.test.sh
+++ b/tests/fm-classify-decision-key.test.sh
@@ -236,6 +236,63 @@ test_blocked_and_resolved_are_tag_order_independent() {
   pass "blocked/resolved parse their bare verb with any bracket-tag order preceding the colon"
 }
 
+test_trailing_key_position_is_honored() {
+  local dir expected
+  dir=$(case_dir trailing)
+  # A worker sometimes appends the tag after the summary instead of the
+  # documented before-colon position (issue observed 2026-08-12): the token
+  # still names the decision and the note still reads the same either way.
+  printf 'needs-decision: pick REST or RPC [key=api-shape]\n' > "$dir/t.status"
+  expected=$(printf 'api-shape\tneeds-decision\tpick REST or RPC\n')
+  assert_fold "$dir/t.status" "$expected" "trailing key position"
+  pass "a stated [key=X] opens X when the token trails the summary"
+}
+
+test_trailing_key_matches_across_open_and_close_positions() {
+  local dir
+  dir=$(case_dir trailing-cross-close)
+  # Opened trailing, closed in the documented position.
+  printf 'needs-decision: pick the bound [key=seam-max-bound]\n' > "$dir/a.status"
+  printf 'resolved [key=seam-max-bound]: answered: use 4\n' >> "$dir/a.status"
+  assert_fold "$dir/a.status" "" "documented resolution closing a trailing open"
+
+  # And the mirror: opened documented, closed trailing.
+  printf 'needs-decision [key=seam-max-bound]: pick the bound\n' > "$dir/b.status"
+  printf 'resolved: answered: use 4 [key=seam-max-bound]\n' >> "$dir/b.status"
+  assert_fold "$dir/b.status" "" "trailing resolution closing a documented open"
+
+  # And opened trailing, closed trailing.
+  printf 'needs-decision: pick the bound [key=seam-max-bound]\n' > "$dir/c.status"
+  printf 'resolved: answered: use 4 [key=seam-max-bound]\n' >> "$dir/c.status"
+  assert_fold "$dir/c.status" "" "trailing resolution closing a trailing open"
+  pass "a resolution closes its decision regardless of open/close trailing-vs-documented position"
+}
+
+test_mid_line_bracket_is_not_a_trailing_key() {
+  local dir
+  dir=$(case_dir mid-line-not-trailing)
+  # A bracket that merely sits somewhere in the middle of the note - not at
+  # its head, not at the line's own end - is prose, never a stated key, even
+  # when it looks like a well-formed token.
+  printf 'needs-decision: consider [key=red] before deciding on a theme\n' > "$dir/t.status"
+  assert_fold "$dir/t.status" \
+    "$(printf 'default\tneeds-decision\tconsider [key=red] before deciding on a theme\n')" \
+    "mid-line bracket text"
+  pass "a [key=x] token that is not at the line's own end is never read as a stated key"
+}
+
+test_canonical_position_wins_over_disagreeing_trailing_token() {
+  local dir
+  dir=$(case_dir canonical-wins)
+  # Both positions carry a token and they disagree: the documented
+  # before-colon position wins, and the trailing token stays note text.
+  printf 'needs-decision [key=alpha]: pick the bound [key=beta]\n' > "$dir/t.status"
+  assert_fold "$dir/t.status" \
+    "$(printf 'alpha\tneeds-decision\tpick the bound [key=beta]\n')" \
+    "canonical vs trailing disagreement"
+  pass "the documented before-colon key wins when a disagreeing trailing token is also present"
+}
+
 test_incremental_agrees_with_full_fold_across_appends() {
   local dir f expected
   dir=$(case_dir incremental)
@@ -271,4 +328,8 @@ test_corr_and_key_tags_open_and_close_under_the_stated_key
 test_corr_only_tag_opens_as_default_like_a_bare_line
 test_key_only_before_colon_still_opens_no_regression
 test_blocked_and_resolved_are_tag_order_independent
+test_trailing_key_position_is_honored
+test_trailing_key_matches_across_open_and_close_positions
+test_mid_line_bracket_is_not_a_trailing_key
+test_canonical_position_wins_over_disagreeing_trailing_token
 test_incremental_agrees_with_full_fold_across_appends

--- a/tests/fm-classify-decision-key.test.sh
+++ b/tests/fm-classify-decision-key.test.sh
@@ -297,6 +297,28 @@ test_mid_line_mention_with_unrelated_terminal_bracket_stays_default() {
   pass "a mid-line [key=x] mention plus an unrelated terminal ']' still folds as default"
 }
 
+test_glued_trailing_bracket_group_is_prose_not_a_stated_key() {
+  local dir
+  dir=$(case_dir glued-trailing)
+  # A terminal bracket group glued to prose (no whitespace before its "[") is
+  # part of the summary, not a stated token: it must not open a key, and the
+  # note must keep it verbatim.
+  printf 'needs-decision: fixed the lookup in cfg[key=env]\n' > "$dir/t.status"
+  assert_fold "$dir/t.status" \
+    "$(printf 'default\tneeds-decision\tfixed the lookup in cfg[key=env]\n')" \
+    "glued trailing bracket group opens default"
+
+  # Nor may a glued group on a resolution close an unrelated keyed decision:
+  # this resolved line is keyless, so it closes only "default", leaving the
+  # real "env" decision open.
+  printf 'needs-decision [key=env]: which env layout\n' >> "$dir/t.status"
+  printf 'resolved: fixed the lookup in cfg[key=env]\n' >> "$dir/t.status"
+  assert_fold "$dir/t.status" \
+    "$(printf 'env\tneeds-decision\twhich env layout\n')" \
+    "glued trailing bracket group on resolved stays keyless"
+  pass "prose glued to a line-terminal [key=x] group never opens or closes x"
+}
+
 test_canonical_position_wins_over_disagreeing_trailing_token() {
   local dir
   dir=$(case_dir canonical-wins)
@@ -348,5 +370,6 @@ test_trailing_key_position_is_honored
 test_trailing_key_matches_across_open_and_close_positions
 test_mid_line_bracket_is_not_a_trailing_key
 test_mid_line_mention_with_unrelated_terminal_bracket_stays_default
+test_glued_trailing_bracket_group_is_prose_not_a_stated_key
 test_canonical_position_wins_over_disagreeing_trailing_token
 test_incremental_agrees_with_full_fold_across_appends

--- a/tests/fm-classify-decision-key.test.sh
+++ b/tests/fm-classify-decision-key.test.sh
@@ -2,7 +2,8 @@
 # tests/fm-classify-decision-key.test.sh - decision-key position tolerance in
 # the open-decisions fold (bin/fm-classify-lib.sh). A "[key=<slug>]" token is
 # documented between the verb and the colon (needs-decision [key=x]: note), but
-# workers commonly write the colon first (needs-decision: [key=x] note); that
+# workers commonly write the colon first (needs-decision: [key=x] note) or
+# append the token after the summary (needs-decision: note [key=x]); each
 # stated key must be honored, never silently folded into the shared "default"
 # bucket where an answer can close the wrong record (issue #2109). Also covers
 # status_line_verb's bracket-tag stripping: a remote secondmate reply prepends
@@ -125,8 +126,9 @@ test_two_colon_form_decisions_stay_distinct() {
 test_mid_note_prose_mention_is_not_a_stated_key() {
   local dir
   dir=$(case_dir prose)
-  # Only a token at the head of the note states a key; a summary merely
-  # mentioning "[key=x]" deeper in must neither open nor close that key.
+  # Only a token at the head of the note (or at the line's own end) states a
+  # key; a summary merely mentioning "[key=x]" deeper in must neither open nor
+  # close that key.
   printf 'needs-decision: pick a [key=red] or [key=blue] theme\n' > "$dir/t.status"
   assert_fold "$dir/t.status" \
     "$(printf 'default\tneeds-decision\tpick a [key=red] or [key=blue] theme\n')" \

--- a/tests/fm-classify-decision-key.test.sh
+++ b/tests/fm-classify-decision-key.test.sh
@@ -281,6 +281,22 @@ test_mid_line_bracket_is_not_a_trailing_key() {
   pass "a [key=x] token that is not at the line's own end is never read as a stated key"
 }
 
+test_mid_line_mention_with_unrelated_terminal_bracket_stays_default() {
+  local dir
+  dir=$(case_dir mid-line-terminal-bracket)
+  # A mid-line "[key=x]" mention on a line that happens to END with an
+  # unrelated "]" must still fold as a keyless line - never extract a garbage
+  # slug and silently drop the decision from the open set.
+  printf 'needs-decision: keep [key=alpha] naming or switch to map[beta]\n' > "$dir/t.status"
+  assert_fold "$dir/t.status" \
+    "$(printf 'default\tneeds-decision\tkeep [key=alpha] naming or switch to map[beta]\n')" \
+    "mid-line mention with unrelated terminal bracket"
+
+  printf 'resolved: went with the map\n' >> "$dir/t.status"
+  assert_fold "$dir/t.status" "" "keyless resolution still closes it"
+  pass "a mid-line [key=x] mention plus an unrelated terminal ']' still folds as default"
+}
+
 test_canonical_position_wins_over_disagreeing_trailing_token() {
   local dir
   dir=$(case_dir canonical-wins)
@@ -331,5 +347,6 @@ test_blocked_and_resolved_are_tag_order_independent
 test_trailing_key_position_is_honored
 test_trailing_key_matches_across_open_and_close_positions
 test_mid_line_bracket_is_not_a_trailing_key
+test_mid_line_mention_with_unrelated_terminal_bracket_stays_default
 test_canonical_position_wins_over_disagreeing_trailing_token
 test_incremental_agrees_with_full_fold_across_appends

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -208,7 +208,7 @@ test_classifier_primitives() {
     && fail "FM_CAPTAIN_RE override bypassed paused: suppression"
   FM_CAPTAIN_RE='custom-verb:' status_is_captain_relevant "custom-verb: x" \
     || fail "nonterminal suppression weakened custom bare-line behavior"
-  printf 'needs-decision: should docs mention [key=prose]?\nneeds-decision [key=q1]: real choice\nresolved: docs still mention [key=q1]\nneeds-decision [key=bad key]: malformed\n' > "$state/keys.status"
+  printf 'needs-decision: should docs mention [key=prose]?\nneeds-decision [key=q1]: real choice\nresolved: docs still mention [key=q1] here\nneeds-decision [key=bad key]: malformed\n' > "$state/keys.status"
   open=$(status_open_decisions "$state/keys.status")
   printf '%s' "$open" | grep -F $'q1\t' >/dev/null \
     || fail "a key token in resolved note prose closed the keyed decision"


### PR DESCRIPTION
## Summary
- Teach `bin/fm-classify-lib.sh`'s keyed-decision parser to also accept a trailing `[key=slug]` token at the end of a status line (for `needs-decision`, `blocked`, `paused`, and `resolved` lines), matching whichever position a worker actually used, while the canonical between-verb-and-colon position remains canonical and wins on disagreement.
- A trailing token now requires a whitespace boundary before `[key=`, so prose glued directly to a bracket group (e.g. `cfg[key=env]`) is never misread as a stated key.
- Add a one-line worked example to `bin/fm-brief.sh`'s generated status-protocol rules showing the canonical token position unambiguously.

## Test plan
- [x] `bash tests/fm-classify-decision-key.test.sh` — full suite passes, including new cases for canonical vs. trailing position, mixed open/close positions, mid-line mentions, and boundary rejection.
- [x] shellcheck clean on touched bin scripts.
- [x] no-mistakes pipeline: review, test, document, and lint steps all passed.
