### PR TITLE
fix(bin): stop task-scoped chrome-devtools-axi sessions at teardown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,6 +172,7 @@ When that section reports its checks still in progress it names exactly what is 
 Bootstrap detects first, asks for consent, and installs only after the captain approves in the current session.
 Do not dispatch until the required tools are present and GitHub authentication is good.
 Use `gh-axi` for GitHub, `chrome-devtools-axi` for browser work, and `lavish-axi` for structured decisions or reports; consult current help rather than memorizing flags.
+A crewmate's task-named `chrome-devtools-axi` session is stopped for it at task cleanup (`bin/fm-teardown.sh` Fix 4), but no equivalent mechanism covers a `chrome-devtools-axi` session you start here, so a headed window from your own browser work outlives the work that opened it.
 A silent bootstrap section needs no action; for any printed actionable diagnostic line, load `bootstrap-diagnostics` and follow its owner procedure.
 `BOOTSTRAP_INFO:` lines are completed no-action facts and do not require loading a skill.
 `secondmate-provisioning` owns startup secondmate sync, liveness, and inherited local-material convergence.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -317,6 +317,8 @@ The report is the only thing that survives, so anything worth keeping must be in
 1. Never push to any remote and never open a PR.
 2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+   If you use chrome-devtools-axi, set \`CHROME_DEVTOOLS_AXI_SESSION=$ID\` first.
+   A headed session (needed for GPU/WebGL checks - headless Chrome has no GPU) stays open as a real Chrome window until something stops it, so also run \`CHROME_DEVTOOLS_AXI_SESSION=$ID chrome-devtools-axi stop\` yourself once you are done checking; teardown stops that same named session as a backstop, but only because it carries this exact name.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
@@ -430,6 +432,8 @@ If the top-level path is the primary checkout or not the worktree you were launc
 $RULE1
 2. Stay inside this worktree; modify nothing outside it.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+   If you use chrome-devtools-axi, set \`CHROME_DEVTOOLS_AXI_SESSION=$ID\` first.
+   A headed session (needed for GPU/WebGL checks - headless Chrome has no GPU) stays open as a real Chrome window until something stops it, so also run \`CHROME_DEVTOOLS_AXI_SESSION=$ID chrome-devtools-axi stop\` yourself once you are done checking; teardown stops that same named session as a backstop, but only because it carries this exact name.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -49,6 +49,14 @@
 # declared-external-wait verb (FM_CLASSIFY_PAUSED_VERB, default "paused") from
 # "blocked:": pause for a known external wait expected to clear on its own,
 # blocked when firstmate must act.
+# Every ship and scout scaffold unconditionally tells the crewmate to name its
+# chrome-devtools-axi session CHROME_DEVTOOLS_AXI_SESSION=<task-id> and to stop
+# that session itself once it is done checking.
+# The name is a contract, not a hint: bin/fm-teardown.sh stops exactly that
+# session at teardown, so a headed browser window left behind by any browser
+# work still gets closed.
+# Secondmate charters omit it because a secondmate home is not returned as a
+# task worktree.
 # Ship tasks include a project-memory section so durable project-intrinsic
 # learnings can be committed to AGENTS.md through the project's delivery path;
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -133,6 +133,24 @@
 #     root still exists, so the account's healthy LaunchAgent worker and every
 #     live remote secondmate worker are out of scope. Best effort: a sweep
 #     failure never blocks this teardown.
+#   Fix 4 - stop a task-scoped chrome-devtools-axi session. A headed
+#     chrome-devtools-axi session (required for WebGL/GPU manual verification,
+#     since headless Chrome has no GPU) stays running - real Chrome window,
+#     real CPU - until something runs `chrome-devtools-axi stop` with the same
+#     session name; nothing does that automatically (observed 2026-08-12: 34
+#     visible Chrome windows accumulated over ~3h of crewmate validation, one
+#     at 35h CPU). bin/fm-brief.sh tells every crewmate to name its session
+#     after its own task id, so `CHROME_DEVTOOLS_AXI_SESSION=$ID
+#     chrome-devtools-axi stop` deterministically reaches it by construction.
+#     This is the tool's own graceful stop (releases the port and its
+#     ~/.chrome-devtools-axi/sessions/$ID state), not a process kill, and it
+#     is a documented no-op when no such session exists, so it runs
+#     unconditionally rather than only when a session is known to exist. Best
+#     effort: a missing chrome-devtools-axi binary or a stop failure never
+#     blocks this teardown. Fix 2 also reaps a same-cwd chrome-devtools-axi
+#     process tree as an ordinary leaked worktree process, but only when the
+#     browser's cwd still matches the worktree; Fix 4 is authoritative because
+#     it uses the tool's own session registry instead of depending on that.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -1512,6 +1530,16 @@ EOF
   return 1
 }
 
+# Fix 4 (see script header): stop the chrome-devtools-axi session named after
+# this task id, if any. bin/fm-brief.sh's convention makes CHROME_DEVTOOLS_AXI_SESSION=$ID
+# the session name every crewmate uses for browser work, so this deterministically
+# reaches it without depending on process cwd or tree shape. `stop` is a documented
+# no-op when no session by that name exists, so this always runs. Best effort only.
+stop_task_chrome_devtools_axi_session() {
+  command -v chrome-devtools-axi >/dev/null 2>&1 || return 0
+  CHROME_DEVTOOLS_AXI_SESSION="$ID" chrome-devtools-axi stop >&2 2>&1 || true
+}
+
 require_orca_worktree_path_match() {
   local worktree_id=$1 inspected=$2 resolved inspected_abs resolved_abs
   resolved=$(fm_backend_worktree_path orca "$worktree_id") || {
@@ -2373,15 +2401,16 @@ if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
 fi
 
 # Every landed/discard-work refusal above has now passed (or --force skipped
-# them). Fix 1 and Fix 2 (see script header) run here, unconditionally on
-# --force, and before ANY destructive step below - a still-parked run or a
-# leaked process can own live work in this exact worktree. Not for
-# kind=secondmate: a secondmate home's own runtime lifecycle is owned by the
-# dedicated process-event and firstmate-home removal machinery further below,
-# not by task-worktree cleanup.
+# them). Fix 1, Fix 2, and Fix 4 (see script header) run here, unconditionally
+# on --force, and before ANY destructive step below - a still-parked run, a
+# leaked process, or a headed browser session can own live work in this exact
+# worktree. Not for kind=secondmate: a secondmate home's own runtime lifecycle
+# is owned by the dedicated process-event and firstmate-home removal machinery
+# further below, not by task-worktree cleanup.
 if [ "$KIND" != secondmate ]; then
   conclude_task_no_mistakes_run "$WT"
   reap_task_worktree_processes worktree "$WT" "$TASK_TMP"
+  stop_task_chrome_devtools_axi_session
 fi
 
 # Fix 3 (see script header): sweep remote job workers abandoned by an already

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -152,7 +152,19 @@ case "${1:-}" in
 esac
 exit 0
 SH
-  chmod +x "$fakebin/treehouse" "$fakebin/tmux" "$fakebin/gh-axi" "$fakebin/gh" "$fakebin/no-mistakes"
+  # Default hermetic chrome-devtools-axi stub for Fix 4 (stop_task_chrome_devtools_axi_session):
+  # logs every "stop" call plus its CHROME_DEVTOOLS_AXI_SESSION to
+  # FM_FAKE_CHROME_AXI_LOG when set, and always reports success. Keeps every
+  # case hermetic - without it, `command -v chrome-devtools-axi` would fall
+  # through to whatever real binary happens to be on the test runner's PATH.
+  cat > "$fakebin/chrome-devtools-axi" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = stop ] && [ -n "${FM_FAKE_CHROME_AXI_LOG:-}" ]; then
+  printf 'stop session=%s\n' "${CHROME_DEVTOOLS_AXI_SESSION:-default}" >> "$FM_FAKE_CHROME_AXI_LOG"
+fi
+exit 0
+SH
+  chmod +x "$fakebin/treehouse" "$fakebin/tmux" "$fakebin/gh-axi" "$fakebin/gh" "$fakebin/no-mistakes" "$fakebin/chrome-devtools-axi"
 
   # Bare origin so the clone has an `origin` remote and origin/HEAD.
   git init -q --bare "$case_dir/origin.git"
@@ -2259,6 +2271,24 @@ test_leaked_tasktmp_process_is_reaped() {
   pass "a leaked descendant process rooted under the task's per-task tasktmp is reaped by teardown too"
 }
 
+test_task_scoped_chrome_devtools_axi_session_is_stopped() {
+  local case_dir rc
+  case_dir=$(make_case chrome-devtools-axi-stop)
+  write_meta "$case_dir" no-mistakes ship
+  land_shippable_commit "$case_dir"
+
+  rc=0
+  FM_FAKE_CHROME_AXI_LOG="$case_dir/chrome-devtools-axi.log" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+
+  expect_code 0 "$rc" "chrome-devtools-axi-stop: teardown should still succeed"
+  assert_present "$case_dir/chrome-devtools-axi.log" \
+    "chrome-devtools-axi-stop: chrome-devtools-axi stop was never invoked"
+  assert_grep "stop session=task-x1" "$case_dir/chrome-devtools-axi.log" \
+    "chrome-devtools-axi-stop: chrome-devtools-axi stop did not target the task-scoped session name"
+  pass "teardown stops the chrome-devtools-axi session named after the task, whether or not one exists"
+}
+
 test_lsof_absent_reaps_tmux_process_group() {
   local case_dir rc pid path_without_lsof
   case_dir=$(make_case lsof-absent-process-group-reap)
@@ -2641,6 +2671,7 @@ test_another_branchs_parked_run_is_never_touched
 test_own_autonomous_run_is_left_alone
 test_leaked_worktree_process_is_reaped
 test_leaked_tasktmp_process_is_reaped
+test_task_scoped_chrome_devtools_axi_session_is_stopped
 test_lsof_absent_reaps_tmux_process_group
 test_lsof_error_refuses_before_removal
 test_reused_pid_identity_is_not_force_killed


### PR DESCRIPTION
## Intent

Make browser-session cleanup structural in firstmate so agent-driven browser work stops leaving visible headed Chrome windows on the operator's machine. Incident (2026-08-12): 34 visible Chrome windows accumulated over ~3h of crewmate validation, one at 35h CPU - the WebGL/GPU manual verification via chrome-devtools-axi genuinely needs headed mode (headless Chrome has no GPU), so the window is a necessary tool that nothing ever puts away; a headed session stays alive until something runs 'chrome-devtools-axi stop' with the matching session name. Documenting this in a project AGENTS.md was already tried and relies on every future worker remembering, which is the same weakness as a guard nothing calls. Investigated both candidate seams named in the brief: bin/fm-brief.sh (the generated contract) and bin/fm-teardown.sh (task-worktree cleanup). Implemented both, since they reinforce each other: (1) bin/fm-brief.sh now adds an UNCONDITIONAL line (not gated behind a flag like --herdr-lab, since it's cheap boilerplate for any task, unlike Herdr's rare high-blast-radius lifecycle commands) telling every ship/scout crewmate to set CHROME_DEVTOOLS_AXI_SESSION=<task-id> when using chrome-devtools-axi and to stop it themselves when done checking. (2) bin/fm-teardown.sh adds a new best-effort Fix 4, stop_task_chrome_devtools_axi_session, that unconditionally runs 'CHROME_DEVTOOLS_AXI_SESSION=<task-id> chrome-devtools-axi stop' during the existing pre-destructive cleanup sequence (alongside Fix 1/Fix 2), before the worktree is returned. This is the mechanism that cannot be skipped: chrome-devtools-axi's own stop command is a documented no-op when no session by that name exists (verified live), so it is safe to call unconditionally for every ship/scout task regardless of whether it touched a browser, and it performs the tool's own graceful cleanup (releases the port, removes ~/.chrome-devtools-axi/sessions/<id> state) rather than a blunt process kill. Verified end to end by hand before writing the fix: started a real chrome-devtools-axi session named after a task id, confirmed its bridge.pid and live process, ran the exact function extracted from fm-teardown.sh, and confirmed the process died and the session directory was cleaned up; separately confirmed the no-op path exits 0 cleanly. Investigated whether cwd-based process reaping (the existing Fix 2, which already kills any process whose cwd matches the task's own worktree, and which I confirmed by direct testing DOES already reach the chrome-devtools-axi bridge and its Chrome child since they inherit the launching shell's cwd) would be sufficient alone; concluded it is a useful independent safety net but not authoritative, since it depends on process-tree/cwd fidelity that the officially exposed named-session stop API does not, so Fix 4 was implemented as the primary, authoritative mechanism rather than relying on Fix 2. Added a new colocated test in tests/fm-teardown.test.sh (test_task_scoped_chrome_devtools_axi_session_is_stopped) using a hermetic fakebin chrome-devtools-axi stub, asserting teardown invokes stop with the task-scoped session name; this repo's existing fm-teardown.test.sh and fm-brief.test.sh suites both still pass in full, and bin/fm-lint.sh (shellcheck) is clean. This is firstmate's own shared tracked material (bin/), so firstmate-coding-guidelines applies: one sentence per line in tracked prose/comments, plain dash never em dash, no agent name as commit co-author, shellcheck-clean bin scripts, and tests colocated in tests/ following the existing <subject>.test.sh naming and fakebin-stub pattern.

## What Changed

- `bin/fm-teardown.sh` gains Fix 4, `stop_task_chrome_devtools_axi_session`, which runs `CHROME_DEVTOOLS_AXI_SESSION=$ID chrome-devtools-axi stop` in the existing pre-destructive cleanup sequence (alongside Fix 1 and Fix 2, skipped for `kind=secondmate`). It is best-effort: a missing binary or a failing stop never blocks teardown, and `stop` is a no-op when no session by that name exists.
- `bin/fm-brief.sh` adds an unconditional line to both the ship and scout scaffolds telling the crewmate to set `CHROME_DEVTOOLS_AXI_SESSION=<task-id>` before using `chrome-devtools-axi` and to stop that session itself when done, so the session name teardown targets is a contract rather than a hint.
- `tests/fm-teardown.test.sh` adds a hermetic `chrome-devtools-axi` fakebin stub for all cases plus `test_task_scoped_chrome_devtools_axi_session_is_stopped`, asserting teardown invokes `stop` with the task-scoped session name and still exits 0. `AGENTS.md` records that this covers crewmate sessions only, not a session the primary agent starts itself.

## Risk Assessment

⚠️ Medium: The change is small, best-effort, and cannot block teardown, but its placement after two abort-capable steps and its dependence on the crewmate following brief prose leave the exact incident partly reachable, so it is safe to merge with those as follow-ups.

## Testing

`Exercised the change the way an operator hits it: opened a real headed chrome-devtools-axi session named after a task id from a directory outside the task worktree (so only the new named-session stop could reach it), walked away without stopping it, then ran the real bin/fm-teardown.sh for that task - the bridge process and the visible Google Chrome process both died, the session's bridge.pid/port registration was released, and the CLI reported no active session; the same unconditional stop is a clean exit-0 no-op for a task that never browsed. Also generated real ship and scout briefs and confirmed the emitted contract names the session after that brief's own task id, which is exactly the name teardown stops. Both colocated suites (tests/fm-teardown.test.sh, tests/fm-brief.test.sh) pass in full, and the new teardown test fails when pointed at the pre-fix script, so it guards the regression rather than merely passing. Artifacts are the CLI transcript of the real teardown run, the generated brief text, and a screenshot taken through the live leaked session before teardown; an OS-level capture of the Chrome window itself was not possible because this session lacks macOS automation/screen-recording permission and a full-screen capture was deliberately avoided for privacy, so the window's lifecycle is shown by before/after process state in the transcript instead. Minor observation, not a defect in this change: chrome-devtools-axi's own stop leaves a 1-byte snapshot-generation file, so the sessions/<id> directory itself survives even though the window, process, and port are gone. No transient files were left in the worktree and no browser processes were left running.`

<details>
<summary>Evidence: CLI transcript: teardown stops a real headed Chrome session</summary>

<code>## 2. the crewmate finishes and walks away without stopping it - the window stays up&#10;$ ps -o pid=,etime=,command= -p $bridge $chrome&#10;72900 00:03 node .../chrome-devtools-axi-bridge.js&#10;72921 00:02 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --allow-pre-commit-input ...&#10;bridge(72900)=alive headed-chrome(72921)=alive&#10;&#10;## 3. the task is torn down normally&#10;$ bin/fm-teardown.sh task-x1&#10;status: stopped&#10;teardown task-x1 complete (window firstmate:fm-task-x1, worktree .../chrome-axi-real-e2e/wt)&#10;teardown exit: 0&#10;&#10;## 4. after teardown: nothing left running on the operator&#39;s machine&#10;bridge(72900)=gone headed-chrome(72921)=gone&#10;$ CHROME_DEVTOOLS_AXI_SESSION=task-x1 chrome-devtools-axi&#10;browser: no active session&#10;&#10;## 5. the same unconditional stop is a clean no-op for a task that never browsed&#10;$ CHROME_DEVTOOLS_AXI_SESSION=task-never-browsed chrome-devtools-axi stop&#10;status: stopped (no-op)&#10;exit: 0&#10;&#10;RESULT: PASS - teardown stopped the headed session; bridge and visible Chrome both gone</code>

```text
/tmp/fm-fix4/helpers.sh: line 55: /tmp/fm-fix4/lib.sh: No such file or directory
## 1. a ship crewmate does headed browser work, naming the session after its task id
   (exactly as the regenerated brief instructs), from a cwd OUTSIDE its own task
   worktree - so the pre-existing cwd-based process reap cannot be what cleans up.
$ CHROME_DEVTOOLS_AXI_SESSION=task-x1 CHROME_DEVTOOLS_AXI_HEADED=1 chrome-devtools-axi open https://example.com
page:
  title: Example Domain
  url: "https://example.com"
  refs: 5

## 2. the crewmate finishes and walks away without stopping it - the window stays up
$ ls /Users/inactdev/.chrome-devtools-axi/sessions/task-x1
bridge.pid
snapshot-generation
$ ps -o pid=,etime=,command= -p $bridge $chrome
72900 00:03 node /Users/inactdev/.local/lib/node_modules/chrome-devtools-axi/dist/bin/chrome-devtools-axi-bridge.js
72921 00:02 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --allow-pre-commit-input --disable-background
bridge(72900)=alive  headed-chrome(72921)=alive
$ CHROME_DEVTOOLS_AXI_SESSION=task-x1 chrome-devtools-axi screenshot leaked-headed-session-before-teardown.png
screenshot: /tmp/fm-fix4/leaked-headed-session-before-teardown.png

## 3. the task is torn down normally (task worktree: /var/folders/cw/jc1frmf90w553nlz182plw900000gn/T//fm-teardown-tests.owtXF5/chrome-axi-real-e2e/wt)
$ bin/fm-teardown.sh task-x1
status: stopped
/var/folders/cw/jc1frmf90w553nlz182plw900000gn/T//fm-teardown-tests.owtXF5/chrome-axi-real-e2e/project: already current
teardown task-x1 complete (window firstmate:fm-task-x1, worktree /var/folders/cw/jc1frmf90w553nlz182plw900000gn/T//fm-teardown-tests.owtXF5/chrome-axi-real-e2e/wt)
Backlog: task-x1 just finished. Run tasks-axi done task-x1 --pr PR_URL, then run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due.
teardown exit: 0

## 4. after teardown: nothing left running on the operator's machine
$ ps -o pid=,etime=,command= -p $bridge $chrome
bridge(72900)=gone  headed-chrome(72921)=gone
$ ls /Users/inactdev/.chrome-devtools-axi/sessions/task-x1   # the bridge pid/port registration is gone
snapshot-generation
$ CHROME_DEVTOOLS_AXI_SESSION=task-x1 chrome-devtools-axi
browser: no active session

## 5. the same unconditional stop is a clean no-op for a task that never browsed
$ CHROME_DEVTOOLS_AXI_SESSION=task-never-browsed chrome-devtools-axi stop
status: stopped (no-op)
exit: 0

RESULT: PASS - teardown stopped the headed session; bridge and visible Chrome both gone
```
</details>
<details>
<summary>Evidence: Generated brief contract: session named after the task id (ship and scout)</summary>

<code>$ FM_HOME=&lt;home&gt; bin/fm-brief.sh task-x1 some-proj --mode no-mistakes&#10;scaffolded: .../data/task-x1/brief.md (ship, mode=no-mistakes; replace {TASK})&#10;&#10;# Rules&#10;3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.&#10;If you use chrome-devtools-axi, set `CHROME_DEVTOOLS_AXI_SESSION=task-x1` first.&#10;A headed session (needed for GPU/WebGL checks - headless Chrome has no GPU) stays open as a real Chrome window until something stops it, so also run `CHROME_DEVTOOLS_AXI_SESSION=task-x1 chrome-devtools-axi stop` yourself once you are done checking; teardown stops that same named session as a backstop, but only because it carries this exact name.&#10;&#10;$ FM_HOME=&lt;home&gt; bin/fm-brief.sh task-x2 some-proj --scout&#10;If you use chrome-devtools-axi, set `CHROME_DEVTOOLS_AXI_SESSION=task-x2` first.</code>

```text
$ FM_HOME=<home> bin/fm-brief.sh task-x1 some-proj --mode no-mistakes
scaffolded: /tmp/fm-fix4/brief-home/data/task-x1/brief.md (ship, mode=no-mistakes; replace {TASK})

--- generated ship brief: data/task-x1/brief.md (Rules section as the crewmate reads it) ---
# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
   If you use chrome-devtools-axi, set `CHROME_DEVTOOLS_AXI_SESSION=task-x1` first.
   A headed session (needed for GPU/WebGL checks - headless Chrome has no GPU) stays open as a real Chrome window until something stops it, so also run `CHROME_DEVTOOLS_AXI_SESSION=task-x1 chrome-devtools-axi stop` yourself once you are done checking; teardown stops that same named session as a backstop, but only because it carries this exact name.
4. Report status by appending one line:

$ FM_HOME=<home> bin/fm-brief.sh task-x2 some-proj --scout
scaffolded: /tmp/fm-fix4/brief-home/data/task-x2/brief.md (scout; replace {TASK})

--- generated scout brief: data/task-x2/brief.md (Rules section) ---
# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
   If you use chrome-devtools-axi, set `CHROME_DEVTOOLS_AXI_SESSION=task-x2` first.
   A headed session (needed for GPU/WebGL checks - headless Chrome has no GPU) stays open as a real Chrome window until something stops it, so also run `CHROME_DEVTOOLS_AXI_SESSION=task-x2 chrome-devtools-axi stop` yourself once you are done checking; teardown stops that same named session as a backstop, but only because it carries this exact name.
4. Report status by appending one line:
```
</details>
- Evidence: Screenshot taken through the leaked headed session just before teardown (local file: <code>/var/folders/cw/jc1frmf90w553nlz182plw900000gn/T/no-mistakes-evidence/01KZWZPDNCTQ5VBW460B9HNY1Q/leaked-headed-session-before-teardown.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"27164964691b7b6974e1700b06d35e4686d5f244","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 4 issues (2 warnings, 2 infos)</summary>

- ⚠️ `bin/fm-teardown.sh:2413` - Fix 4 is placed last in the pre-destructive block, after two steps that can either abort teardown or destroy its target first. Under `set -eu`, `conclude_task_no_mistakes_run` (return 1 at bin/fm-teardown.sh:1531) and `reap_task_worktree_processes` (return 1 on lsof failure or on a process surviving 3 passes) exit the script from inside the then-block, so `stop_task_chrome_devtools_axi_session` never runs. tests/fm-teardown.test.sh:1049 already asserts exit 1 for the lsof-error path. Separately, when reap does succeed it SIGKILLs the bridge pid first (the intent states the bridge&#39;s cwd matches the worktree), after which stopBridge reads a dead pid, returns false and prints `stopped (no-op)` - so the graceful process-group stop that would reap chrome-devtools-mcp and Chrome together is skipped in the common success path too. This contradicts the header&#39;s own claim that Fix 4 is authoritative and Fix 2 is a net. Move `stop_task_chrome_devtools_axi_session` to the first line of the `if [ &#34;$KIND&#34; != secondmate ]` block, before `conclude_task_no_mistakes_run`.
- ⚠️ `bin/fm-brief.sh:320` - The intent says documentation &#34;relies on every future worker remembering, which is the same weakness as a guard nothing calls&#34;, yet Fix 4 can only stop a session the crewmate actually named $ID, and the only thing establishing that name is the new brief sentence. A crewmate that runs `CHROME_DEVTOOLS_AXI_HEADED=1 chrome-devtools-axi open &lt;url&gt;` without the env var (forgotten, or in a subshell/subagent that did not carry it) gets session name `default`; teardown then stops session `$ID`, a no-op, and the headed window survives - the 2026-08-12 incident. Fix 2 only catches it when the bridge&#39;s cwd is still exactly the worktree root. bin/fm-spawn.sh:2801 already exports GOTMPDIR into the pane shell before launch, on a channel whose own comment says it reaches &#34;every backend and harness - ship, scout, and secondmate&#34;; adding `export CHROME_DEVTOOLS_AXI_SESSION=$ID` there makes the name structural, and the teardown header&#39;s &#34;by construction&#34; claim actually true. Flagging rather than fixing since it changes the seam the author deliberately chose.
- ℹ️ `bin/fm-teardown.sh:2410` - `if [ &#34;$KIND&#34; != secondmate ]` skips Fix 4 for a secondmate home, but `cleanup_firstmate_home_children` (bin/fm-teardown.sh:2202, called at :2339 under --force) removes each child ship/scout worktree directly and never runs any browser cleanup for them. Those children are exactly the crewmates the brief tells to name a session after their own task id, and their ids are enumerable from `$sub_state/*.meta`. Concrete path: secondmate home with a live child ship task that opened a headed session, `fm-teardown.sh &lt;secondmate-id&gt; --force` -&gt; child worktree removed, child&#39;s Chrome window survives. The header&#39;s justification (&#34;a secondmate home&#39;s own runtime lifecycle is owned by the dedicated process-event and firstmate-home removal machinery&#34;) covers the home, not the child tasks - no other machinery stops their named sessions. Narrower than the main path since non-forced teardown refuses while children exist.
- ℹ️ `bin/fm-teardown.sh:1540` - chrome-devtools-axi session state and port are global per user - `~/.chrome-devtools-axi/sessions/&lt;name&gt;` and a name-derived port (dist/src/sessions.js) - but firstmate task ids are only unique within one home&#39;s state dir and are operator-chosen (bin/fm-spawn.sh:893). Two homes on the same machine (main plus a secondmate) can both hold a task named e.g. `auth-fix`. Tearing down one then runs `CHROME_DEVTOOLS_AXI_SESSION=auth-fix chrome-devtools-axi stop` and kills the other home&#39;s live bridge and Chrome mid-verification; the same collision also makes the two crewmates share one bridge and port while both are running. A home-scoped discriminator in the brief&#39;s session name (task id plus a short home tag) would remove both.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-teardown.test.sh` - full colocated suite (60 cases), including the new `test_task_scoped_chrome_devtools_axi_session_is_stopped`</code>
- <code>`bash tests/fm-brief.test.sh` - full colocated brief suite</code>
- <code>Regression direction: ran `test_task_scoped_chrome_devtools_axi_session_is_stopped` with `TEARDOWN` pointed at the base-commit (pre-fix) copy of `bin/fm-teardown.sh` - it fails with `not ok - chrome-devtools-axi stop was never invoked`, and passes on the target commit</code>
- <code>Manual end-to-end on macOS with the REAL chrome-devtools-axi (hermetic stub removed from the fakebin): `CHROME_DEVTOOLS_AXI_SESSION=task-x1 CHROME_DEVTOOLS_AXI_HEADED=1 chrome-devtools-axi open https://example.com` launched from `$HOME` (outside the task worktree, so the cwd-based Fix 2 reap cannot claim the cleanup), then a real `bin/fm-teardown.sh task-x1` against a landed no-mistakes ship case; confirmed by pid before/after that the bridge process and the visible `/Applications/Google Chrome.app` process both died, `bridge.pid` was removed, and `chrome-devtools-axi` then reports `browser: no active session`</code>
- <code>Manual no-op path: `CHROME_DEVTOOLS_AXI_SESSION=task-never-browsed chrome-devtools-axi stop` -&gt; `status: stopped (no-op)`, exit 0, so the unconditional call is safe for tasks that never browsed</code>
- <code>Generated real briefs and read the emitted contract: `FM_HOME=&lt;tmp&gt; bin/fm-brief.sh task-x1 some-proj --mode no-mistakes` and `FM_HOME=&lt;tmp&gt; bin/fm-brief.sh task-x2 some-proj --scout`, confirming each brief&#39;s Rules block carries `CHROME_DEVTOOLS_AXI_SESSION=&lt;its own task id&gt;` - the same name teardown stops</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `AGENTS.md:174` - AGENTS.md:174 tells the primary firstmate agent to use chrome-devtools-axi for browser work but carries no session-naming or stop rule, and nothing tears down the primary&#39;s own headed sessions - only ship/scout task worktrees are covered by fm-teardown.sh&#39;s Fix 4. I deliberately did not add that rule: it would document a contract this change does not implement, and an unenforced instruction is exactly the weakness the intent identifies in the prior AGENTS.md-only attempt. Closing this needs a real mechanism first (a session-start or lock-release hook that stops the primary&#39;s named session), then one line in AGENTS.md pointing at it.

🔧 Fix: state primary-agent chrome-devtools-axi cleanup gap in AGENTS.md
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
