### PR TITLE
feat(pi): attach pasted clipboard images

### DIFF
--- a/.pi/extensions/fm-clipboard-image.ts
+++ b/.pi/extensions/fm-clipboard-image.ts
@@ -1,0 +1,181 @@
+// Bridge Pi's interactive clipboard-image path marker into a structured image attachment.
+import { lstat, open, readdir, unlink, type FileHandle } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, extname, join, resolve } from "node:path";
+import type { Dirent, Stats } from "node:fs";
+import {
+  resizeImage,
+  type ExtensionAPI,
+  type InputEvent,
+} from "@earendil-works/pi-coding-agent";
+
+type ImageContent = NonNullable<InputEvent["images"]>[number];
+
+const STALE_CLIPBOARD_AGE_MS = 24 * 60 * 60 * 1000;
+const CLIPBOARD_BASENAME_SOURCE =
+  String.raw`pi-clipboard-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.(?:png|jpg|webp|gif)`;
+const CLIPBOARD_BASENAME = new RegExp(`^${CLIPBOARD_BASENAME_SOURCE}$`);
+const TEMP_DIRECTORY = resolve(tmpdir());
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function clipboardPathPattern(): RegExp {
+  const tempPath = escapeRegex(TEMP_DIRECTORY);
+  return new RegExp(
+    String.raw`(?<![A-Za-z0-9_./\\-])${tempPath}[\\/]${CLIPBOARD_BASENAME_SOURCE}(?![A-Za-z0-9_.\\/-])`,
+    "g",
+  );
+}
+
+function imageMimeType(bytes: Uint8Array): string | null {
+  if (
+    bytes.length >= 8 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47 &&
+    bytes[4] === 0x0d &&
+    bytes[5] === 0x0a &&
+    bytes[6] === 0x1a &&
+    bytes[7] === 0x0a
+  ) {
+    return "image/png";
+  }
+  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return "image/jpeg";
+  }
+  if (bytes.length >= 6) {
+    const header = Buffer.from(bytes.subarray(0, 6)).toString("ascii");
+    if (header === "GIF87a" || header === "GIF89a") return "image/gif";
+  }
+  if (
+    bytes.length >= 12 &&
+    Buffer.from(bytes.subarray(0, 4)).toString("ascii") === "RIFF" &&
+    Buffer.from(bytes.subarray(8, 12)).toString("ascii") === "WEBP"
+  ) {
+    return "image/webp";
+  }
+  return null;
+}
+
+function extensionMatchesMimeType(filePath: string, mimeType: string): boolean {
+  const extension = extname(filePath);
+  return (
+    (extension === ".png" && mimeType === "image/png") ||
+    (extension === ".jpg" && mimeType === "image/jpeg") ||
+    (extension === ".gif" && mimeType === "image/gif") ||
+    (extension === ".webp" && mimeType === "image/webp")
+  );
+}
+
+function sameFile(left: Stats, right: Stats): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.size === right.size &&
+    left.mtimeMs === right.mtimeMs
+  );
+}
+
+async function removeIfUnchanged(filePath: string, openedStats: Stats): Promise<void> {
+  try {
+    const currentStats = await lstat(filePath);
+    if (!currentStats.isFile() || !sameFile(openedStats, currentStats)) return;
+    await unlink(filePath);
+  } catch {
+    // The image is still safe to attach if a concurrent cleanup already removed it.
+  }
+}
+
+async function processClipboardImage(filePath: string): Promise<ImageContent | null> {
+  if (!CLIPBOARD_BASENAME.test(basename(filePath))) return null;
+
+  let handle: FileHandle | undefined;
+  try {
+    const pathStats = await lstat(filePath);
+    if (!pathStats.isFile()) return null;
+    handle = await open(filePath, "r");
+    const openedStats = await handle.stat();
+    if (!openedStats.isFile() || !sameFile(pathStats, openedStats)) return null;
+
+    const bytes = await handle.readFile();
+    const mimeType = imageMimeType(bytes);
+    if (!mimeType || !extensionMatchesMimeType(filePath, mimeType)) return null;
+
+    const processed = await resizeImage(bytes, mimeType);
+    if (!processed) return null;
+
+    await handle.close();
+    handle = undefined;
+    await removeIfUnchanged(filePath, openedStats);
+    return {
+      type: "image",
+      data: processed.data,
+      mimeType: processed.mimeType,
+    };
+  } catch {
+    return null;
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
+}
+
+async function cleanStaleClipboardImages(now = Date.now()): Promise<void> {
+  let entries: Dirent[];
+  try {
+    entries = await readdir(TEMP_DIRECTORY, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (!CLIPBOARD_BASENAME.test(entry.name) || !entry.isFile()) continue;
+    const filePath = join(TEMP_DIRECTORY, entry.name);
+    try {
+      const stats = await lstat(filePath);
+      if (!stats.isFile() || now - stats.mtimeMs < STALE_CLIPBOARD_AGE_MS) continue;
+      await removeIfUnchanged(filePath, stats);
+    } catch {
+      // Cleanup is best effort and never broadens beyond one exact stale basename.
+    }
+  }
+}
+
+export default function (pi: ExtensionAPI): void {
+  pi.on("session_start", async () => {
+    await cleanStaleClipboardImages();
+  });
+
+  pi.on("input", async (event, ctx) => {
+    if (event.source !== "interactive") return { action: "continue" };
+
+    const paths = [...event.text.matchAll(clipboardPathPattern())].map((match) => match[0]);
+    if (paths.length === 0) return { action: "continue" };
+
+    const consumed = new Set<string>();
+    const attached: ImageContent[] = [];
+    for (const filePath of new Set(paths)) {
+      const image = await processClipboardImage(filePath);
+      if (!image) continue;
+      consumed.add(filePath);
+      attached.push(image);
+    }
+    if (attached.length === 0) return { action: "continue" };
+
+    if (ctx.hasUI) {
+      ctx.ui.notify(
+        attached.length === 1 ? "Attached 1 clipboard image." : `Attached ${attached.length} clipboard images.`,
+        "info",
+      );
+    }
+    return {
+      action: "transform",
+      text: event.text.replace(clipboardPathPattern(), (filePath) =>
+        consumed.has(filePath) ? "" : filePath,
+      ),
+      images: [...(event.images ?? []), ...attached],
+    };
+  });
+}

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -140,7 +140,7 @@ family_for_basename() {
     fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-kimi-harness.test.sh|fm-muse-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
-    fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
+    fm-operational-input.test.sh|fm-pi-clipboard-image.test.sh|fm-pi-primary-types.test.sh|\
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|\
     fm-subagent-pretool-check.test.sh|\
     fm-supervision-instructions.test.sh|fm-task-delivery.test.sh|\

--- a/tests/fm-pi-clipboard-image.test.sh
+++ b/tests/fm-pi-clipboard-image.test.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# Behavior contract for the project-local Pi clipboard-image input bridge.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+command -v node >/dev/null 2>&1 || { echo "skip: node not found for Pi clipboard-image extension test"; exit 0; }
+
+PI_PACKAGE_DIR=${FM_PI_PACKAGE_DIR:-}
+if [ -z "$PI_PACKAGE_DIR" ] && command -v npm >/dev/null 2>&1; then
+  PI_PACKAGE_DIR="$(npm root -g 2>/dev/null)/@earendil-works/pi-coding-agent"
+fi
+
+TMP_ROOT=$(fm_test_tmproot fm-pi-clipboard-image)
+FIXTURE="$TMP_ROOT/fixture"
+CLIPBOARD_TMP="$TMP_ROOT/clipboard-temp"
+PACKAGE_FIXTURE="$FIXTURE/node_modules/@earendil-works/pi-coding-agent"
+mkdir -p "$FIXTURE/.pi/extensions" "$FIXTURE/node_modules/@earendil-works" "$CLIPBOARD_TMP"
+cp "$ROOT/.pi/extensions/fm-clipboard-image.ts" "$FIXTURE/.pi/extensions/fm-clipboard-image.ts"
+if [ -n "$PI_PACKAGE_DIR" ] && [ -f "$PI_PACKAGE_DIR/package.json" ]; then
+  ln -s "$PI_PACKAGE_DIR" "$PACKAGE_FIXTURE"
+else
+  mkdir -p "$PACKAGE_FIXTURE"
+  printf '%s\n' '{"name":"@earendil-works/pi-coding-agent","type":"module","exports":"./index.js"}' \
+    > "$PACKAGE_FIXTURE/package.json"
+  cat > "$PACKAGE_FIXTURE/index.js" <<'JS'
+export async function resizeImage(bytes, mimeType) {
+  return { data: Buffer.from(bytes).toString("base64"), mimeType };
+}
+JS
+fi
+printf '%s\n' '{"type":"module"}' > "$FIXTURE/package.json"
+
+output_file="$TMP_ROOT/output"
+set +e
+(
+  cd "$FIXTURE" || exit 1
+  TMPDIR="$CLIPBOARD_TMP" \
+    EXT="$FIXTURE/.pi/extensions/fm-clipboard-image.ts" \
+    OUTSIDE="$TMP_ROOT/outside" \
+    node --input-type=module
+) >"$output_file" 2>&1 <<'JS'
+import assert from "node:assert/strict";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  symlink,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const clipboardTmp = tmpdir();
+const outside = process.env.OUTSIDE;
+const png = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+  "base64",
+);
+const name = (id, extension = "png") => `pi-clipboard-${id}.${extension}`;
+const ids = {
+  stale: "10000000-0000-4000-8000-000000000001",
+  fresh: "10000000-0000-4000-8000-000000000002",
+  symlink: "10000000-0000-4000-8000-000000000003",
+  directory: "10000000-0000-4000-8000-000000000004",
+  first: "10000000-0000-4000-8000-000000000005",
+  second: "10000000-0000-4000-8000-000000000006",
+  injected: "10000000-0000-4000-8000-000000000007",
+  malformed: "10000000-0000-4000-8000-000000000008",
+  mismatch: "10000000-0000-4000-8000-000000000009",
+  outside: "10000000-0000-4000-8000-00000000000a",
+  unreadable: "10000000-0000-4000-8000-00000000000b",
+};
+
+const handlers = new Map();
+const notifications = [];
+const pi = {
+  on(event, handler) {
+    const eventHandlers = handlers.get(event) ?? [];
+    eventHandlers.push(handler);
+    handlers.set(event, eventHandlers);
+  },
+};
+const extension = await import(`${pathToFileURL(process.env.EXT).href}?test=${Date.now()}`);
+extension.default(pi);
+assert.equal(handlers.get("session_start")?.length, 1, "extension did not register stale cleanup");
+assert.equal(handlers.get("input")?.length, 1, "extension did not register the input transform");
+const sessionStart = handlers.get("session_start")[0];
+const input = handlers.get("input")[0];
+const context = {
+  hasUI: true,
+  ui: {
+    notify(message, level) {
+      notifications.push({ message, level });
+    },
+  },
+};
+const exists = async (path) => lstat(path).then(() => true, () => false);
+const oldTime = new Date(Date.now() - 48 * 60 * 60 * 1000);
+
+// Startup cleanup removes only old regular files in the exact Pi UUID/image family.
+const stale = join(clipboardTmp, name(ids.stale));
+const fresh = join(clipboardTmp, name(ids.fresh));
+const target = join(clipboardTmp, "unrelated-target.png");
+const exactSymlink = join(clipboardTmp, name(ids.symlink));
+const exactDirectory = join(clipboardTmp, name(ids.directory));
+const prefixed = join(clipboardTmp, `not-${name(ids.stale)}`);
+const suffixed = join(clipboardTmp, `${name(ids.stale)}.bak`);
+const malformedName = join(clipboardTmp, "pi-clipboard-not-a-uuid.png");
+for (const path of [stale, fresh, target, prefixed, suffixed, malformedName]) {
+  await writeFile(path, png);
+}
+await symlink(target, exactSymlink);
+await mkdir(exactDirectory);
+for (const path of [stale, prefixed, suffixed, malformedName, exactDirectory]) {
+  await utimes(path, oldTime, oldTime);
+}
+await sessionStart({}, context);
+assert.equal(await exists(stale), false, "stale exact clipboard file was not cleaned");
+for (const path of [fresh, target, exactSymlink, exactDirectory, prefixed, suffixed, malformedName]) {
+  assert.equal(await exists(path), true, `cleanup touched unrelated, fresh, or non-regular path: ${path}`);
+}
+assert.equal((await lstat(exactSymlink)).isSymbolicLink(), true, "cleanup followed or removed a symlink");
+
+// Interactive input consumes every valid path, preserves surrounding slash-command text,
+// and appends attachments without disturbing images that were already present.
+const first = join(clipboardTmp, name(ids.first));
+const second = join(clipboardTmp, name(ids.second));
+await writeFile(first, png);
+await writeFile(second, png);
+const existingImage = { type: "image", data: "existing-data", mimeType: "image/jpeg" };
+const positive = await input({
+  type: "input",
+  source: "interactive",
+  text: `/skill:inspect before ${first} middle ${second} after`,
+  images: [existingImage],
+}, context);
+assert.equal(positive.action, "transform");
+assert.equal(positive.text, "/skill:inspect before  middle  after");
+assert.deepEqual(positive.images[0], existingImage, "existing image attachment changed");
+assert.equal(positive.images.length, 3, "not every clipboard image was attached");
+for (const image of positive.images.slice(1)) {
+  assert.equal(image.type, "image");
+  assert.equal(image.mimeType, "image/png");
+  assert.deepEqual(Buffer.from(image.data, "base64"), png);
+}
+assert.equal(await exists(first), false, "consumed first clipboard temporary remained");
+assert.equal(await exists(second), false, "consumed second clipboard temporary remained");
+assert.deepEqual(notifications, [{ message: "Attached 2 clipboard images.", level: "info" }]);
+assert.equal(notifications[0].message.includes(clipboardTmp), false, "notification exposed a temporary path");
+
+// Extension-originated input is never interpreted as a clipboard paste.
+const injected = join(clipboardTmp, name(ids.injected));
+await writeFile(injected, png);
+const extensionInput = await input({
+  type: "input",
+  source: "extension",
+  text: `extension says ${injected}`,
+}, context);
+assert.deepEqual(extensionInput, { action: "continue" });
+assert.equal(await exists(injected), true, "extension-originated input consumed a file");
+
+// Invalid data, an extension/content mismatch, and a non-regular exact path remain text and stay on disk.
+const malformed = join(clipboardTmp, name(ids.malformed));
+const mismatch = join(clipboardTmp, name(ids.mismatch, "jpg"));
+await writeFile(malformed, "not an image");
+await writeFile(mismatch, png);
+const rejectedText = `${malformed} ${mismatch} ${exactSymlink} ${exactDirectory}`;
+const rejected = await input({ type: "input", source: "interactive", text: rejectedText }, context);
+assert.deepEqual(rejected, { action: "continue" });
+for (const path of [malformed, mismatch, exactSymlink, exactDirectory]) {
+  assert.equal(await exists(path), true, `unreadable or invalid path was consumed: ${path}`);
+}
+if (typeof process.getuid === "function" && process.getuid() !== 0) {
+  const unreadable = join(clipboardTmp, name(ids.unreadable));
+  await writeFile(unreadable, png);
+  await chmod(unreadable, 0o000);
+  const unreadableResult = await input({
+    type: "input",
+    source: "interactive",
+    text: `keep ${unreadable}`,
+  }, context);
+  assert.deepEqual(unreadableResult, { action: "continue" });
+  assert.equal(await exists(unreadable), true, "unreadable clipboard file was consumed");
+  await chmod(unreadable, 0o600);
+}
+
+// Paths outside Pi's temporary directory and lookalike basenames are ordinary text.
+await mkdir(outside, { recursive: true });
+const outsidePath = join(outside, name(ids.outside));
+await writeFile(outsidePath, png);
+const lookalikeText = [
+  outsidePath,
+  join(clipboardTmp, `not-${name(ids.outside)}`),
+  join(clipboardTmp, `${name(ids.outside)}.bak`),
+  join(clipboardTmp, "pi-clipboard-no-uuid.png"),
+].join(" ");
+const lookalikes = await input({ type: "input", source: "interactive", text: lookalikeText }, context);
+assert.deepEqual(lookalikes, { action: "continue" });
+assert.equal(await exists(outsidePath), true, "clipboard-looking file outside the temp directory was consumed");
+
+assert.deepEqual(
+  await input({ type: "input", source: "interactive", text: "/help" }, context),
+  { action: "continue" },
+  "ordinary slash command changed",
+);
+assert.deepEqual(
+  await input({ type: "input", source: "interactive", text: "ordinary text" }, context),
+  { action: "continue" },
+  "ordinary text changed",
+);
+assert.equal(notifications.length, 1, "rejected inputs produced an attachment notification");
+JS
+status=$?
+set -e
+[ "$status" -eq 0 ] || fail "Pi clipboard-image behavior failed: $(cat "$output_file")"
+[ ! -s "$output_file" ] || fail "Pi clipboard-image behavior printed output: $(cat "$output_file")"
+pass "Pi clipboard-image input attaches exact temporary images, preserves text and existing images, and cleans only consumed or stale exact files"

--- a/tests/fm-pi-primary-types.test.sh
+++ b/tests/fm-pi-primary-types.test.sh
@@ -27,6 +27,7 @@ trap cleanup EXIT
 
 mkdir -p "$TMP_ROOT/lib" "$TMP_ROOT/node_modules/@earendil-works" "$TMP_ROOT/node_modules/@types"
 cp "$ROOT/.pi/extensions/fm-calm.ts" "$TMP_ROOT/fm-calm.ts"
+cp "$ROOT/.pi/extensions/fm-clipboard-image.ts" "$TMP_ROOT/fm-clipboard-image.ts"
 cp "$ROOT/.pi/extensions/fm-primary-pi-watch.ts" "$TMP_ROOT/fm-primary-pi-watch.ts"
 cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$TMP_ROOT/fm-primary-turnend-guard.ts"
 cp "$ROOT/.pi/extensions/lib/fm-calm-assistant-layout.ts" "$TMP_ROOT/lib/fm-calm-assistant-layout.ts"


### PR DESCRIPTION
## Summary

- Convert exact Pi clipboard image paths into structured image attachments through the supported `input` extension event.
- Preserve surrounding text and existing attachments while leaving unrelated, unreadable, or invalid files untouched.
- Remove consumed images and clean only exact stale Pi clipboard files after 24 hours without following symlinks.
- Confirm attachments through Pi's UI without adding a model-visible message.

## Validation

- `tests/fm-pi-clipboard-image.test.sh`
- Native Pi 0.84.1 input-event E2E
- Strict standalone typecheck against Pi 0.84.1
- `tests/fm-test-run.test.sh`
- `bin/fm-lint.sh`
- `bin/fm-doc-audience-check.sh`
