### PR TITLE
feat: support superseding prior captain decisions

### DIFF
--- a/.agents/skills/decision-hold-lifecycle/SKILL.md
+++ b/.agents/skills/decision-hold-lifecycle/SKILL.md
@@ -22,6 +22,7 @@ A completed investigation and an ended visual review use this same owner and com
 Run the command in the originating work's authoritative `FM_HOME`; main-home work creates main-home holds, and secondmate-owned work creates holds in that secondmate home's backlog rather than copying them into the main backlog.
 Do not close a hold merely because the originating investigation completed, its report was archived, its visual review ended, or its task was torn down.
 The hold remains the authoritative Captain's Call item until the captain's answer is durably recorded, dependent work is created in the same backlog and blocked by that hold, and `bin/fm-decision-hold.sh resolve` routes the answer by clearing those dependency edges before closing the hold.
+A later resolution that replaces a prior answer records the superseded hold's stable identity, requires that prior captain decision to be durably resolved, and leaves the prior record intact.
 Resolved findings, recommendations that need no captain choice, and prose that merely sounds decision-like do not create holds.
 Bearings reads the resulting structured state and must never compensate by scraping historical reports, visual-review artifacts, terminal output, chat, or other prose.
 
@@ -33,7 +34,7 @@ Bearings reads the resulting structured state and must never compensate by scrap
 4. Run the script's `complete` command with the full unresolved-key inventory for that review pass.
 5. Relay the choices to the captain as decisions from Bearings' Captain's Call section under `AGENTS.md` section 9; do not use the word hold in captain chat.
 6. After the captain decides, record dependent work with normal tasks-axi commands and block it by the hold identity.
-7. Put the captain's exact durable decision in a file and use the script's `resolve` command with every routed task.
+7. Put the captain's exact durable decision in a file and use the script's `resolve` command with every routed task, naming the prior hold when this answer supersedes an earlier decision.
 8. Confirm Bearings no longer shows the closed hold and that routed work remains in structured backlog state.
 
 `bin/fm-decision-hold.sh --help` owns command syntax, identity construction, completion attestation, retry behavior, and close ordering.

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -23,7 +23,8 @@
 #   fm-decision-hold.sh complete <origin-id> (--none | <decision-key>...)
 #   fm-decision-hold.sh verify <origin-id>
 #   fm-decision-hold.sh resolve <origin-id> <decision-key> \
-#     --decision-file <path> --routed-to <task-id> [--routed-to <task-id>...]
+#     --decision-file <path> [--supersedes <prior-hold-id>] \
+#     --routed-to <task-id> [--routed-to <task-id>...]
 #
 # `complete` is the shared investigation and visual-review completion gate.
 # `--none` is an explicit semantic attestation that the just-reviewed surface has
@@ -34,9 +35,11 @@
 # source before this gate has succeeded.
 #
 # `resolve` requires every --routed-to task to exist and to be blocked by the hold.
-# It writes the captain decision and routed identities into the hold body, clears
-# those dependency edges, and only then marks the hold Done. A failure before the
-# final step leaves the captain hold open.
+# An optional --supersedes identity must name a prior captain decision already
+# durably resolved by this command. The pointer is recorded in the new hold body
+# and its retry identity without rewriting the prior decision. The command clears
+# routed dependency edges and only then marks the new hold Done. A failure before
+# the final step leaves the new captain hold open.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -217,23 +220,38 @@ verify_hold_durable() {  # <hold-id>
 }
 
 verify_resolution_identity() {
-  local id=$1 hold_body=$2 decision_digest=$3 routed_csv=$4 resolution_prefix resolution_fields recorded_digest recorded_routes
+  local id=$1 hold_body=$2 decision_digest=$3 routed_csv=$4 supersedes=$5
+  local resolution_prefix resolution_fields resolution_tail recorded_digest recorded_routes recorded_supersedes=''
   resolution_prefix='"Resolution recorded by fm-decision-hold.\nDecision digest: '
   case "$hold_body" in
     "$resolution_prefix"*) resolution_fields=${hold_body#"$resolution_prefix"} ;;
     *) fail "captain hold $id has no retry identity record" ;;
   esac
   case "$resolution_fields" in
-    *'\nRouted identities: '*'\n\nCaptain decision:'*) : ;;
+    *'\nRouted identities: '*) : ;;
     *) fail "captain hold $id has an invalid retry identity record" ;;
   esac
   recorded_digest=${resolution_fields%%\\n*}
   resolution_fields=${resolution_fields#*\\nRouted identities: }
   recorded_routes=${resolution_fields%%\\n*}
+  resolution_tail=${resolution_fields#*\\n}
+  case "$resolution_tail" in
+    'supersedes: '*)
+      recorded_supersedes=${resolution_tail#supersedes: }
+      recorded_supersedes=${recorded_supersedes%%\\n*}
+      resolution_tail=${resolution_tail#*\\n}
+      ;;
+  esac
+  case "$resolution_tail" in
+    '\nCaptain decision:'*) : ;;
+    *) fail "captain hold $id has an invalid retry identity record" ;;
+  esac
   [ "$recorded_digest" = "$decision_digest" ] \
     || fail "captain hold $id records a different captain decision"
   [ "$recorded_routes" = "$routed_csv" ] \
     || fail "captain hold $id records different routed work"
+  [ "$recorded_supersedes" = "$supersedes" ] \
+    || fail "captain hold $id records a different superseded decision"
 }
 
 command_id() {
@@ -396,12 +414,13 @@ EOF
 }
 
 command_resolve() {
-  local origin=${1:-} key=${2:-} decision_file='' id='' decision='' decision_digest='' body='' routed='' routed_csv='' dep show blocked state hold_show hold_body resolution_recorded=0
+  local origin=${1:-} key=${2:-} decision_file='' supersedes='' id='' decision='' decision_digest='' body='' routed='' routed_csv='' dep show blocked state hold_show hold_body resolution_recorded=0
   [ "$#" -ge 2 ] || { usage >&2; exit 2; }
   shift 2
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --decision-file) shift; decision_file=${1:-} ;;
+      --supersedes) shift; supersedes=${1:-} ;;
       --routed-to) shift; validate_slug routed-task "${1:-}"; routed="${routed}${routed:+ }${1:-}" ;;
       *) usage >&2; exit 2 ;;
     esac
@@ -409,6 +428,7 @@ command_resolve() {
   done
   validate_slug origin-id "$origin"
   validate_slug decision-key "$key"
+  [ -z "$supersedes" ] || validate_slug supersedes "$supersedes"
   [ -n "$decision_file" ] || fail "--decision-file is required"
   [ -f "$decision_file" ] || fail "decision file does not exist: $decision_file"
   decision=$(cat "$decision_file")
@@ -421,10 +441,15 @@ command_resolve() {
   decision_digest=$(sha256_text "$decision")
   require_tasks_axi
   id=$(hold_id "$origin" "$key")
+  if [ -n "$supersedes" ]; then
+    [ "$supersedes" != "$id" ] || fail "captain hold $id cannot supersede itself"
+    verify_hold_resolved "$supersedes" \
+      || fail "superseded decision $supersedes is not durably resolved"
+  fi
   if verify_hold_resolved "$id"; then
     hold_show=$(task_show "$id")
     hold_body=$(show_field "$hold_show" body)
-    verify_resolution_identity "$id" "$hold_body" "$decision_digest" "$routed_csv"
+    verify_resolution_identity "$id" "$hold_body" "$decision_digest" "$routed_csv" "$supersedes"
     printf 'resolved: %s\n' "$id"
     return 0
   fi
@@ -433,7 +458,7 @@ command_resolve() {
   hold_body=$(show_field "$hold_show" body)
   case "$hold_body" in
     *"Resolution recorded by fm-decision-hold."*)
-      verify_resolution_identity "$id" "$hold_body" "$decision_digest" "$routed_csv"
+      verify_resolution_identity "$id" "$hold_body" "$decision_digest" "$routed_csv" "$supersedes"
       resolution_recorded=1
       ;;
   esac
@@ -458,7 +483,13 @@ command_resolve() {
     esac
   done
 
-  body=$(printf 'Resolution recorded by fm-decision-hold.\nDecision digest: %s\nRouted identities: %s\n\nCaptain decision:\n%s\n\nRouted work:\n' "$decision_digest" "$routed_csv" "$decision")
+  if [ -n "$supersedes" ]; then
+    body=$(printf 'Resolution recorded by fm-decision-hold.\nDecision digest: %s\nRouted identities: %s\nsupersedes: %s\n\nCaptain decision:\n%s\n\nRouted work:\n' \
+      "$decision_digest" "$routed_csv" "$supersedes" "$decision")
+  else
+    body=$(printf 'Resolution recorded by fm-decision-hold.\nDecision digest: %s\nRouted identities: %s\n\nCaptain decision:\n%s\n\nRouted work:\n' \
+      "$decision_digest" "$routed_csv" "$decision")
+  fi
   for dep in $routed; do
     body="${body}- ${dep}"$'\n'
   done

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -414,13 +414,13 @@ EOF
 }
 
 command_resolve() {
-  local origin=${1:-} key=${2:-} decision_file='' supersedes='' id='' decision='' decision_digest='' body='' routed='' routed_csv='' dep show blocked state hold_show hold_body resolution_recorded=0
+  local origin=${1:-} key=${2:-} decision_file='' supersedes='' supersedes_set=0 id='' decision='' decision_digest='' body='' routed='' routed_csv='' dep show blocked state hold_show hold_body resolution_recorded=0
   [ "$#" -ge 2 ] || { usage >&2; exit 2; }
   shift 2
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --decision-file) shift; decision_file=${1:-} ;;
-      --supersedes) shift; supersedes=${1:-} ;;
+      --supersedes) supersedes_set=1; shift; supersedes=${1:-} ;;
       --routed-to) shift; validate_slug routed-task "${1:-}"; routed="${routed}${routed:+ }${1:-}" ;;
       *) usage >&2; exit 2 ;;
     esac
@@ -428,6 +428,8 @@ command_resolve() {
   done
   validate_slug origin-id "$origin"
   validate_slug decision-key "$key"
+  [ "$supersedes_set" = 0 ] || [ -n "$supersedes" ] \
+    || fail "--supersedes requires a non-empty prior hold id"
   [ -z "$supersedes" ] || validate_slug supersedes "$supersedes"
   [ -n "$decision_file" ] || fail "--decision-file is required"
   [ -f "$decision_file" ] || fail "decision file does not exist: $decision_file"
@@ -441,11 +443,7 @@ command_resolve() {
   decision_digest=$(sha256_text "$decision")
   require_tasks_axi
   id=$(hold_id "$origin" "$key")
-  if [ -n "$supersedes" ]; then
-    [ "$supersedes" != "$id" ] || fail "captain hold $id cannot supersede itself"
-    verify_hold_resolved "$supersedes" \
-      || fail "superseded decision $supersedes is not durably resolved"
-  fi
+  [ "$supersedes" != "$id" ] || fail "captain hold $id cannot supersede itself"
   if verify_hold_resolved "$id"; then
     hold_show=$(task_show "$id")
     hold_body=$(show_field "$hold_show" body)
@@ -462,6 +460,10 @@ command_resolve() {
       resolution_recorded=1
       ;;
   esac
+  if [ -n "$supersedes" ] && [ "$resolution_recorded" = 0 ]; then
+    verify_hold_resolved "$supersedes" \
+      || fail "superseded decision $supersedes is not durably resolved"
+  fi
 
   for dep in $routed; do
     show=$(task_show "$dep") || fail "routed task $dep does not exist in the active home"

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -35,11 +35,14 @@
 # source before this gate has succeeded.
 #
 # `resolve` requires every --routed-to task to exist and to be blocked by the hold.
-# An optional --supersedes identity must name a prior captain decision already
-# durably resolved by this command. The pointer is recorded in the new hold body
-# and its retry identity without rewriting the prior decision. The command clears
-# routed dependency edges and only then marks the new hold Done. A failure before
-# the final step leaves the new captain hold open.
+# A supplied --supersedes value must be non-empty and name a prior captain
+# decision already durably resolved by this command.
+# The pointer is recorded in the new hold body and its retry identity without
+# rewriting the prior decision.
+# Exact retries compare that identity and remain idempotent after retention moves
+# the prior record to the tasks-axi archive; omitting or changing it is rejected.
+# The command clears routed dependency edges and only then marks the new hold Done.
+# A failure before the final step leaves the new captain hold open.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -24,8 +24,9 @@ Scout teardown calls the script's read-only `verify` subcommand after checking f
 The `--force` path remains the explicit captain-approved discard escape hatch.
 
 The `resolve` subcommand requires a decision file and at least one existing dependent task whose structured `blocked-by` edge points to the hold.
-It records the decision digest and routed task identities as a retry identity in the hold body, clears each dependency edge through tasks-axi, and marks the hold Done only after those writes succeed.
-An exact retry can finish a partial routing operation, while a changed decision or routed-task set is rejected.
+It optionally accepts one superseded hold identity only when that prior captain decision is already durably resolved, then retains the pointer without rewriting the prior record.
+It records the decision digest, routed task identities, and optional supersession pointer as a retry identity in the hold body, clears each dependency edge through tasks-axi, and marks the hold Done only after those writes succeed.
+An exact retry can finish a partial routing operation, while a changed decision, routed-task set, or supersession pointer is rejected.
 A failed intermediate step leaves the hold open.
 
 ## Structured read surfaces
@@ -43,6 +44,7 @@ The projection remains read-only and does not inspect historical prose.
 Verification date: 2026-07-14.
 Additional quoted `blocked_by` regression verification date: 2026-07-17.
 Plural blocker-readiness and mixed-home projection verification date: 2026-07-22.
+Supersession-pointer regression verification date: 2026-08-13.
 
 The focused end-to-end regression uses only synthetic `sample` identities and decision text.
 It begins with a completed investigation and visual review whose genuine unresolved choice exists only in the report.
@@ -61,6 +63,7 @@ ok - ended visual review follows the same decision-hold completion owner
 ok - resolved findings and decision-like prose do not create false holds
 ok - terminal single-owner stale status decisions do not block empty inventory
 ok - main-home and secondmate-home captain holds remain correctly routed
+ok - resolve records a stable supersession pointer only to a durably resolved prior decision
 ok - resolve matches first/middle/last in quoted blocked_by and rejects a genuinely absent id
 
 $ bash tests/fm-fleet-snapshot-view.test.sh

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -23,10 +23,8 @@ For an open keyed status decision, it appends a `captain-held [key=<key>]: ...` 
 Scout teardown calls the script's read-only `verify` subcommand after checking for the report and before removing any source state.
 The `--force` path remains the explicit captain-approved discard escape hatch.
 
-The `resolve` subcommand requires a decision file and at least one existing dependent task whose structured `blocked-by` edge points to the hold.
-It records the decision digest, routed task identities, and optional supersession pointer as a retry identity in the hold body, clears each dependency edge through tasks-axi, and marks the hold Done only after those writes succeed.
-An exact retry can finish a partial routing operation, while a changed decision, routed-task set, or supersession pointer is rejected.
-A failed intermediate step leaves the hold open.
+The `resolve` subcommand stores its durable resolution record on the captain item and routes dependent work through tasks-axi.
+`bin/fm-decision-hold.sh --help` owns its required inputs, retry identity fields, validation, and close ordering.
 
 ## Structured read surfaces
 

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -24,7 +24,6 @@ Scout teardown calls the script's read-only `verify` subcommand after checking f
 The `--force` path remains the explicit captain-approved discard escape hatch.
 
 The `resolve` subcommand requires a decision file and at least one existing dependent task whose structured `blocked-by` edge points to the hold.
-It optionally accepts one superseded hold identity only when that prior captain decision is already durably resolved, then retains the pointer without rewriting the prior record.
 It records the decision digest, routed task identities, and optional supersession pointer as a retry identity in the hold body, clears each dependency edge through tasks-axi, and marks the hold Done only after those writes succeed.
 An exact retry can finish a partial routing operation, while a changed decision, routed-task set, or supersession pointer is rejected.
 A failed intermediate step leaves the hold open.

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -465,6 +465,74 @@ EOF
   pass "main-home and secondmate-home captain holds remain correctly routed"
 }
 
+test_resolve_records_superseded_prior_decision() {
+  local home origin prior_hold replacement_hold pending_hold show help
+  home=$(make_home superseded-decision)
+  help=$(run_decisions "$home" --help)
+  assert_contains "$help" "[--supersedes <prior-hold-id>]" \
+    "resolve help omitted the supersession field"
+  origin=sample-supersession-review
+  mkdir -p "$home/data/$origin"
+  tasks_in "$home" add "$origin" "Review superseding sample decisions" \
+    --kind scout --repo sample --start >/dev/null \
+    || fail "could not create supersession origin"
+  write_origin_meta "$home" "$origin"
+  printf 'done: report complete\n' > "$home/state/$origin.status"
+  printf '# Supersession review\n\nA later decision replaces an earlier answer.\n' \
+    > "$home/data/$origin/report.md"
+
+  prior_hold=$(run_decisions "$home" hold "$origin" prior-route \
+    --title "Choose the prior route" --reason "captain prior route pending" --repo sample) \
+    || fail "could not register prior decision"
+  tasks_in "$home" add prior-route-work "Apply the prior route" --kind ship --repo sample \
+    --blocked-by "$prior_hold" >/dev/null || fail "could not create prior routed work"
+  printf 'Use the original sample route.\n' > "$home/prior-decision.txt"
+  run_decisions "$home" resolve "$origin" prior-route \
+    --decision-file "$home/prior-decision.txt" --routed-to prior-route-work >/dev/null \
+    || fail "could not resolve prior decision"
+
+  replacement_hold=$(run_decisions "$home" hold "$origin" replacement-route \
+    --title "Choose the replacement route" --reason "captain replacement route pending" --repo sample) \
+    || fail "could not register replacement decision"
+  tasks_in "$home" add replacement-route-work "Apply the replacement route" \
+    --kind ship --repo sample --blocked-by "$replacement_hold" >/dev/null \
+    || fail "could not create replacement routed work"
+  printf 'Use the replacement sample route.\n' > "$home/replacement-decision.txt"
+
+  pending_hold=$(run_decisions "$home" hold "$origin" pending-route \
+    --title "Choose a pending route" --reason "captain pending route choice" --repo sample) \
+    || fail "could not register pending decision"
+  if run_decisions "$home" resolve "$origin" replacement-route \
+    --decision-file "$home/replacement-decision.txt" --routed-to replacement-route-work \
+    --supersedes "$pending_hold" > "$home/pending-supersedes.out" 2> "$home/pending-supersedes.err"; then
+    fail "resolve accepted an unresolved decision as the superseded prior decision"
+  fi
+  show=$(tasks_in "$home" show "$replacement_hold" --full)
+  assert_contains "$show" "state: queued" "invalid supersession closed the replacement hold"
+  assert_contains "$show" "held: yes" "invalid supersession released the replacement hold"
+
+  run_decisions "$home" resolve "$origin" replacement-route \
+    --decision-file "$home/replacement-decision.txt" --routed-to replacement-route-work \
+    --supersedes "$prior_hold" >/dev/null \
+    || fail "could not resolve a decision with a supersession pointer"
+  show=$(tasks_in "$home" show "$replacement_hold" --full)
+  assert_contains "$show" "state: done" "superseding decision did not close"
+  assert_contains "$show" "supersedes: $prior_hold" \
+    "superseding decision did not retain the prior hold identity"
+  show=$(tasks_in "$home" show "$prior_hold" --full)
+  assert_contains "$show" "state: done" "superseding decision changed the prior decision record"
+  run_decisions "$home" resolve "$origin" replacement-route \
+    --decision-file "$home/replacement-decision.txt" --routed-to replacement-route-work \
+    --supersedes "$prior_hold" >/dev/null \
+    || fail "identical supersession retry was not idempotent"
+  if run_decisions "$home" resolve "$origin" replacement-route \
+    --decision-file "$home/replacement-decision.txt" --routed-to replacement-route-work \
+    > "$home/missing-supersedes.out" 2> "$home/missing-supersedes.err"; then
+    fail "resolution retry accepted a missing supersession pointer"
+  fi
+  pass "resolve records a stable supersession pointer only to a durably resolved prior decision"
+}
+
 # tasks-axi quotes multi-entry blocked_by values as "a,b,c". resolve must strip
 # those surrounding quotes before comma-boundary membership so the first and last
 # list elements match, not only middle elements.
@@ -569,4 +637,5 @@ test_visual_review_uses_shared_completion_owner
 test_none_inventory_and_resolved_prose_do_not_create_holds
 test_terminal_single_owner_status_decision_does_not_block_empty_inventory
 test_secondmate_hold_stays_in_authoritative_home
+test_resolve_records_superseded_prior_decision
 test_resolve_matches_quoted_blocked_by_edges

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -466,7 +466,7 @@ EOF
 }
 
 test_resolve_records_superseded_prior_decision() {
-  local home origin prior_hold replacement_hold pending_hold show help
+  local home origin prior_hold replacement_hold pending_hold show help index
   home=$(make_home superseded-decision)
   help=$(run_decisions "$home" --help)
   assert_contains "$help" "[--supersedes <prior-hold-id>]" \
@@ -490,6 +490,15 @@ test_resolve_records_superseded_prior_decision() {
   run_decisions "$home" resolve "$origin" prior-route \
     --decision-file "$home/prior-decision.txt" --routed-to prior-route-work >/dev/null \
     || fail "could not resolve prior decision"
+  for index in 1 2 3 4 5 6 7 8 9; do
+    tasks_in "$home" add "supersession-pad-$index" "Supersession padding $index" \
+      --kind ship --repo sample >/dev/null || fail "could not create supersession padding $index"
+    tasks_in "$home" "done" "supersession-pad-$index" >/dev/null \
+      || fail "could not close supersession padding $index"
+  done
+  show=$(tasks_in "$home" show "$prior_hold" --full) \
+    || fail "prior decision left the live Done window before the retention boundary"
+  assert_contains "$show" "state: done" "prior decision was not resolved at the retention boundary"
 
   replacement_hold=$(run_decisions "$home" hold "$origin" replacement-route \
     --title "Choose the replacement route" --reason "captain replacement route pending" --repo sample) \
@@ -510,6 +519,19 @@ test_resolve_records_superseded_prior_decision() {
   show=$(tasks_in "$home" show "$replacement_hold" --full)
   assert_contains "$show" "state: queued" "invalid supersession closed the replacement hold"
   assert_contains "$show" "held: yes" "invalid supersession released the replacement hold"
+  if run_decisions "$home" resolve "$origin" replacement-route \
+    --decision-file "$home/replacement-decision.txt" --routed-to replacement-route-work \
+    --supersedes "" > "$home/empty-supersedes.out" 2> "$home/empty-supersedes.err"; then
+    fail "resolve accepted an explicitly empty supersession identity"
+  fi
+  assert_grep "requires a non-empty prior hold id" "$home/empty-supersedes.err" \
+    "explicitly empty supersession did not report a clear error"
+  show=$(tasks_in "$home" show "$replacement_hold" --full)
+  assert_contains "$show" "state: queued" "empty supersession closed the replacement hold"
+  assert_contains "$show" "held: yes" "empty supersession released the replacement hold"
+  show=$(tasks_in "$home" show replacement-route-work --full)
+  assert_contains "$show" "blocked_by: $replacement_hold" \
+    "empty supersession mutated the replacement routing edge"
 
   run_decisions "$home" resolve "$origin" replacement-route \
     --decision-file "$home/replacement-decision.txt" --routed-to replacement-route-work \
@@ -519,8 +541,11 @@ test_resolve_records_superseded_prior_decision() {
   assert_contains "$show" "state: done" "superseding decision did not close"
   assert_contains "$show" "supersedes: $prior_hold" \
     "superseding decision did not retain the prior hold identity"
-  show=$(tasks_in "$home" show "$prior_hold" --full)
-  assert_contains "$show" "state: done" "superseding decision changed the prior decision record"
+  if tasks_in "$home" show "$prior_hold" --full > "$home/archived-prior.out" 2>&1; then
+    fail "oldest prior decision remained in the live Done window after retention pruning"
+  fi
+  assert_grep "$prior_hold" "$home/data/done-archive.md" \
+    "retention pruning did not preserve the prior decision in the archive"
   run_decisions "$home" resolve "$origin" replacement-route \
     --decision-file "$home/replacement-decision.txt" --routed-to replacement-route-work \
     --supersedes "$prior_hold" >/dev/null \


### PR DESCRIPTION
## Intent

Implement only the shared-code half of the fleet-record cleanup in Firstmate: extend bin/fm-decision-hold.sh so resolving and closing a decision may explicitly record that it supersedes a named prior decision. Keep the mechanism minimal and consistent with the existing command shape, reflect the supersession pointer in the hold body and close/retry semantics, update --help and the one-owner decision-hold-lifecycle skill contract as needed, and add colocated end-to-end coverage with shellcheck-clean shared code. The accepted implementation uses optional --supersedes <prior-hold-id>, requires the named prior captain decision to be durably resolved, preserves the prior record, and binds the pointer into idempotent retry identity. Exact retries must remain durable and idempotent when the named superseded decision has already moved to the tasks-axi archive. An explicitly supplied empty --supersedes value must fail with a clear error before mutation. Add coverage for both cases. Do not perform the separate firstmate-private captain.md or learnings.md cleanup, and do not build new record machinery. Deliver upstream-only through the HTTPS public fork https://github.com/haroarthur/firstmate.git as a PR against kunchenguid/firstmate; only Kun may merge. Stop when CI is green and report the full PR URL.

## What Changed

- Add optional `--supersedes <prior-hold-id>` support to decision resolution, requiring a non-empty, durably resolved prior captain decision while preserving its record.
- Bind the supersession pointer into the new hold body and retry identity so exact retries remain idempotent after archival and changed or omitted pointers are rejected.
- Update lifecycle guidance and add end-to-end coverage for validation failures, archive retention, and supersession retry behavior.

## Risk Assessment

✅ Low: Captain, the change is well-bounded and satisfies the supersession, durable retry, archive, empty-value, documentation, and scope constraints without a substantiated source defect.

## Testing

At the exact target commit, the focused lifecycle regression passed and a direct tasks-axi-backed CLI exercise demonstrated every required supersession behavior, including no mutation for an explicit empty value and an idempotent retry after the prior decision moved to the archive. The transcript is reviewer-visible evidence; no screenshot was applicable because this is a CLI-only change. No linters or static analysis were run, as required by the assigned test-phase boundary.

<details>
<summary>Evidence: Supersession end-to-end transcript</summary>

`Direct CLI evidence of empty-value rejection without mutation, unresolved-prior rejection, stored supersession pointer, archived prior record, exact retry, and changed-identity rejection.`

```text
$ fm-decision-hold.sh resolve ... prior-route
resolved: sample-supersession-review-decision-prior-route -> prior-route-work

$ fm-decision-hold.sh resolve ... --supersedes ""
exit: 1
fm-decision-hold: --supersedes requires a non-empty prior hold id
backlog sha256 before: 3cdfe59a3475e1235262e517cb8e1a034596f8a5a15997a80e0b46c6912cdff5
backlog sha256 after:  3cdfe59a3475e1235262e517cb8e1a034596f8a5a15997a80e0b46c6912cdff5

$ tasks-axi show replacement hold after empty value
task:
  id: sample-supersession-review-decision-replacement-route
  title: Choose the replacement route
  state: queued
  blocked: no
  blocked_by: none
  held: yes
  hold_reason: captain replacement route pending
  hold_kind: captain
  hold_until: "-"
  kind: captain
  repo: sample
  priority: "-"
  created: 2026-08-13
  closed: "-"
  deps: none
  links: none
  body: "Origin: sample-supersession-review\nDecision key: replacement-route\nState: awaiting captain decision."

$ tasks-axi show routed work after empty value
task:
  id: replacement-route-work
  title: Apply the replacement route
  state: queued
  blocked: yes
  blocked_by: sample-supersession-review-decision-replacement-route
  held: no
  hold_reason: "-"
  hold_kind: "-"
  hold_until: "-"
  kind: ship
  repo: sample
  priority: "-"
  created: 2026-08-13
  closed: "-"
  deps: "blocked-by:sample-supersession-review-decision-replacement-route"
  links: none
  body: ""
help[2]:
  - Run `tasks-axi unblock replacement-route-work --by <other>` to clear a blocker
  - Run `tasks-axi start replacement-route-work` to move it to in flight

$ fm-decision-hold.sh resolve ... --supersedes unresolved-prior
exit: 1
fm-decision-hold: superseded decision sample-supersession-review-decision-pending-route is not durably resolved

$ fm-decision-hold.sh resolve ... --supersedes sample-supersession-review-decision-prior-route
resolved: sample-supersession-review-decision-replacement-route -> replacement-route-work

$ tasks-axi show replacement hold --full
task:
  id: sample-supersession-review-decision-replacement-route
  title: Choose the replacement route
  state: done
  blocked: no
  blocked_by: none
  held: no
  hold_reason: captain replacement route pending
  hold_kind: captain
  hold_until: "-"
  kind: captain
  repo: sample
  priority: "-"
  created: "-"
  closed: 2026-08-13
  deps: none
  links: none
  body: "Resolution recorded by fm-decision-hold.\nDecision digest: 1e0620171517fe5f25e0d20ecd7c7b8f4df755d7b925babc5ba1766b4dbb30ae\nRouted identities: replacement-route-work\nsupersedes: sample-supersession-review-decision-prior-route\n\nCaptain decision:\nUse the replacement sample route.\n\nRouted work:- replacement-route-work"

$ tasks-axi show routed work after resolution
task:
  id: replacement-route-work
  title: Apply the replacement route
  state: queued
  blocked: no
  blocked_by: none
  held: no
  hold_reason: "-"
  hold_kind: "-"
  hold_until: "-"
  kind: ship
  repo: sample
  priority: "-"
  created: 2026-08-13
  closed: "-"
  deps: none
  links: none
  body: ""

$ tasks-axi show superseded prior in live Done window
exit: 1
error: "Task \"sample-supersession-review-decision-prior-route\" not found in this backlog"
code: NOT_FOUND
help[1]: Run `tasks-axi list` to see existing tasks

$ rg -n -C 6 superseded-prior data/done-archive.md
1-
2-## Archived 2026-08-13
3:- [x] sample-supersession-review-decision-prior-route - Choose the prior route (repo: sample) (kind: captain) (done 2026-08-13) (hold: captain prior route pending) (hold-kind: captain)
4-  Resolution recorded by fm-decision-hold.
5-  Decision digest: 267156a4ab1b6a93e16255f0f5e2ff32f5c3850b22ec666016ada844c30c75d0
6-  Routed identities: prior-route-work
7-
8-  Captain decision:
9-  Use the original sample route.

$ exact retry with archived superseded prior
resolved: sample-supersession-review-decision-replacement-route

$ changed retry omitting --supersedes
exit: 1
fm-decision-hold: captain hold sample-supersession-review-decision-replacement-route records a different superseded decision

fixture: /tmp/no-mistakes-evidence/01KZXDTEQ3K0RZKY4SC1K7TKVH/supersession-e2e.w4OKby
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --name-status 96876db31009d011694a0174a460d2c587f2c6c8..efd6378a4d2166621b5354d32983fedca618ba40` and focused source/test inspection</code>
- `bin/fm-decision-hold.sh --help`
- `bash tests/fm-decision-hold-lifecycle.test.sh`
- <code>Direct synthetic-home CLI exercise of empty and unresolved `--supersedes` failures, successful supersession, archive retention, exact retry, and changed retry identity using `fm-decision-hold.sh`, `tasks-axi show --full`, `sha256sum`, and archive inspection</code>
- <code>`git status --porcelain` after testing</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
