### PR TITLE
fix(fm-brief): document keyed status form with the key before the colon

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -237,7 +237,7 @@ Handle routine work yourself.
 Report only true captain-relevant outcomes or a declared external wait by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
 States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
-A keyed event puts its \`[key=<slug>]\` tag BEFORE the colon, e.g. \`needs-decision [key=chosen-slug]: {summary}\`; never \`needs-decision: [key=slug] ...\`, which files under the \`default\` key so key-addressed resolution will not find it (\`bin/fm-classify-lib.sh\` owns keyed open/resolved semantics).
+A keyed event's documented \`[key=<slug>]\` position is BEFORE the colon, e.g. \`needs-decision [key=chosen-slug]: {summary}\`; a complete \`[key=slug]\` token at the head of the note (\`needs-decision: [key=slug] ...\`) is accepted as an equivalent fallback since #2202, with the before-colon token winning when both are present (\`bin/fm-classify-lib.sh\` owns keyed open/resolved semantics).
 Use \`$PAUSED_VERB: {why}\` (distinct from \`blocked:\`) only when your domain is deliberately idling on a known external wait you expect to clear on its own; use \`blocked:\` when you are stuck and need firstmate to act.
 Use this only for material phase changes, a captain decision, a real blocker, a failure, or work ready for review.
 This is also how you return the answer to a marked from-firstmate request above.
@@ -322,10 +322,10 @@ The report is the only thing that survives, so anything worth keeping must be in
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
    Keyed form (optional, for a decision or blocker a later reply must address by key):
-   \`needs-decision [key=chosen-slug]: {summary}\` - the \`[key=<slug>]\` tag goes BEFORE the colon.
-   NEVER write \`needs-decision: [key=slug] ...\`: a key after the colon files under the \`default\`
-   key and key-addressed resolution will not find it. \`$FM_ROOT/bin/fm-classify-lib.sh\` owns
-   keyed open/resolved semantics.
+   \`needs-decision [key=chosen-slug]: {summary}\` - the documented \`[key=<slug>]\` position is BEFORE the colon.
+   A complete \`[key=slug]\` token at the head of the note (\`needs-decision: [key=slug] ...\`) is accepted
+   as an equivalent fallback since #2202, with the before-colon token winning when both are present.
+   \`$FM_ROOT/bin/fm-classify-lib.sh\` owns keyed open/resolved semantics.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
    would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
    FYI progress lines; firstmate reads your pane for that.
@@ -440,10 +440,10 @@ $RULE1
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
    Keyed form (optional, for a decision or blocker a later reply must address by key):
-   \`needs-decision [key=chosen-slug]: {summary}\` - the \`[key=<slug>]\` tag goes BEFORE the colon.
-   NEVER write \`needs-decision: [key=slug] ...\`: a key after the colon files under the \`default\`
-   key and key-addressed resolution will not find it. \`$FM_ROOT/bin/fm-classify-lib.sh\` owns
-   keyed open/resolved semantics.
+   \`needs-decision [key=chosen-slug]: {summary}\` - the documented \`[key=<slug>]\` position is BEFORE the colon.
+   A complete \`[key=slug]\` token at the head of the note (\`needs-decision: [key=slug] ...\`) is accepted
+   as an equivalent fallback since #2202, with the before-colon token winning when both are present.
+   \`$FM_ROOT/bin/fm-classify-lib.sh\` owns keyed open/resolved semantics.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
    would act on (setup done, bug reproduced, fix implemented, validation passed) and the
    needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -237,6 +237,7 @@ Handle routine work yourself.
 Report only true captain-relevant outcomes or a declared external wait by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
 States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
+A keyed event puts its \`[key=<slug>]\` tag BEFORE the colon, e.g. \`needs-decision [key=chosen-slug]: {summary}\`; never \`needs-decision: [key=slug] ...\`, which files under the \`default\` key so key-addressed resolution will not find it (\`bin/fm-classify-lib.sh\` owns keyed open/resolved semantics).
 Use \`$PAUSED_VERB: {why}\` (distinct from \`blocked:\`) only when your domain is deliberately idling on a known external wait you expect to clear on its own; use \`blocked:\` when you are stuck and need firstmate to act.
 Use this only for material phase changes, a captain decision, a real blocker, a failure, or work ready for review.
 This is also how you return the answer to a marked from-firstmate request above.
@@ -320,6 +321,11 @@ The report is the only thing that survives, so anything worth keeping must be in
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
+   Keyed form (optional, for a decision or blocker a later reply must address by key):
+   \`needs-decision [key=chosen-slug]: {summary}\` - the \`[key=<slug>]\` tag goes BEFORE the colon.
+   NEVER write \`needs-decision: [key=slug] ...\`: a key after the colon files under the \`default\`
+   key and key-addressed resolution will not find it. \`$FM_ROOT/bin/fm-classify-lib.sh\` owns
+   keyed open/resolved semantics.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
    would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
    FYI progress lines; firstmate reads your pane for that.
@@ -433,6 +439,11 @@ $RULE1
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
+   Keyed form (optional, for a decision or blocker a later reply must address by key):
+   \`needs-decision [key=chosen-slug]: {summary}\` - the \`[key=<slug>]\` tag goes BEFORE the colon.
+   NEVER write \`needs-decision: [key=slug] ...\`: a key after the colon files under the \`default\`
+   key and key-addressed resolution will not find it. \`$FM_ROOT/bin/fm-classify-lib.sh\` owns
+   keyed open/resolved semantics.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
    would act on (setup done, bug reproduced, fix implemented, validation passed) and the
    needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -691,8 +691,9 @@ test_scout_and_secondmate_load_decision_hold_policy() {
 }
 
 # The status-protocol text must show the keyed form with the key BEFORE the
-# colon (the shape bin/fm-classify-lib.sh parses) and warn against the broken
-# key-after-colon form, in every scaffold variant that carries the protocol.
+# colon (the documented shape bin/fm-classify-lib.sh parses) and describe the
+# note-head token as an equivalent accepted fallback, in every scaffold
+# variant that carries the protocol.
 test_keyed_status_form_in_all_scaffolds() {
   local home kind id brief
   home="$TMP_ROOT/keyed-form-home"
@@ -720,12 +721,13 @@ test_keyed_status_form_in_all_scaffolds() {
       "$kind brief did not state that the key tag goes before the colon"
     # shellcheck disable=SC2016 # Literal backticks and brackets must remain unexpanded.
     assert_grep '`needs-decision: [key=slug] ...`' "$brief" \
-      "$kind brief did not warn against the key-after-colon form"
-    # shellcheck disable=SC2016 # Literal backticks must remain unexpanded.
-    assert_grep '`default`' "$brief" \
-      "$kind brief did not explain that a key after the colon files under the default key"
+      "$kind brief did not show the note-head fallback form"
+    assert_grep 'equivalent fallback since #2202' "$brief" \
+      "$kind brief did not describe the note-head token as an accepted fallback"
+    assert_grep 'before-colon token winning when both are present' "$brief" \
+      "$kind brief did not state that the before-colon token wins when both are present"
   done
-  pass "fm-brief.sh: every status-protocol scaffold shows the keyed form and warns against key-after-colon"
+  pass "fm-brief.sh: every status-protocol scaffold shows the keyed form and its note-head fallback"
 }
 
 # Scout and secondmate paths still scaffold well-formed briefs.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -690,6 +690,44 @@ test_scout_and_secondmate_load_decision_hold_policy() {
   pass "fm-brief.sh: investigation and visual-review completions load the shared decision policy"
 }
 
+# The status-protocol text must show the keyed form with the key BEFORE the
+# colon (the shape bin/fm-classify-lib.sh parses) and warn against the broken
+# key-after-colon form, in every scaffold variant that carries the protocol.
+test_keyed_status_form_in_all_scaffolds() {
+  local home kind id brief
+  home="$TMP_ROOT/keyed-form-home"
+  mkdir -p "$home/data"
+  for kind in ship scout secondmate; do
+    id="brief-keyed-form-$kind"
+    case "$kind" in
+      ship)
+        FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --mode no-mistakes >/dev/null 2>&1
+        ;;
+      scout)
+        FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --scout >/dev/null 2>&1
+        ;;
+      secondmate)
+        FM_HOME="$home" FM_SECONDMATE_CHARTER=x \
+          "$ROOT/bin/fm-brief.sh" "$id" --secondmate --no-projects >/dev/null 2>&1
+        ;;
+    esac
+    brief="$home/data/$id/brief.md"
+    assert_present "$brief" "$kind: brief was not scaffolded"
+    # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
+    assert_grep '`needs-decision [key=chosen-slug]: {summary}`' "$brief" \
+      "$kind brief did not show the keyed status form with the key before the colon"
+    assert_grep 'BEFORE the colon' "$brief" \
+      "$kind brief did not state that the key tag goes before the colon"
+    # shellcheck disable=SC2016 # Literal backticks and brackets must remain unexpanded.
+    assert_grep '`needs-decision: [key=slug] ...`' "$brief" \
+      "$kind brief did not warn against the key-after-colon form"
+    # shellcheck disable=SC2016 # Literal backticks must remain unexpanded.
+    assert_grep '`default`' "$brief" \
+      "$kind brief did not explain that a key after the colon files under the default key"
+  done
+  pass "fm-brief.sh: every status-protocol scaffold shows the keyed form and warns against key-after-colon"
+}
+
 # Scout and secondmate paths still scaffold well-formed briefs.
 test_scout_and_secondmate_scaffold() {
   local brief
@@ -729,4 +767,5 @@ test_secondmate_marked_request_reporting_contract
 test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
+test_keyed_status_form_in_all_scaffolds
 test_scout_and_secondmate_scaffold


### PR DESCRIPTION
Two workers in a row wrote `needs-decision: [key=slug] ...` because the brief scaffold's status-protocol rule only showed the unkeyed shape while later rules mentioned `[key=<slug>]` without showing its placement.

This documents the keyed form in every scaffold variant that carries the status protocol (ship, scout, secondmate):
- shows the canonical shape `needs-decision [key=chosen-slug]: {summary}` with the tag BEFORE the colon
- describes a complete `[key=slug]` token at the head of the note as an accepted equivalent fallback since #2202 (before-colon wins when both are present) - deliberately no false claim that the after-colon form files under the `default` key
- keeps the unkeyed `{state}: {one short line}` shape documented; `bin/fm-classify-lib.sh` remains the single owner of keyed open/resolved semantics

Test coverage extends tests/fm-brief.test.sh through the executable (generates each brief variant and asserts on its output), never asserting implementation-source bytes.

Validated by the no-mistakes pipeline (review, test, document clean; lint gate approved locally because ShellCheck is absent in the worker environment - CI enforces it). Shipped as a fork PR because the worker credential has no push access to this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)