### PR TITLE
fix(remote-job): reclaim interrupted lock publications

### DIFF
--- a/bin/fm-remote-job-worker.sh
+++ b/bin/fm-remote-job-worker.sh
@@ -143,6 +143,20 @@ worker_recover_quarantine() { # <account-home>
   rm -f -- "$WORKER_LOCK/quarantine"
 }
 
+# Every lock file is published through mktemp inside the lock directory, so a
+# worker killed between mktemp and mv leaves a dot-prefixed temporary behind.
+# Reclaiming a provably stale lock has to discard those too: rmdir refuses a
+# non-empty directory, and without this every replacement worker would fail
+# ownership forever against residue its predecessor could no longer clean up.
+worker_discard_lock_temporaries() {
+  local entry
+  for entry in "$WORKER_LOCK"/.pid.* "$WORKER_LOCK"/.start.* \
+    "$WORKER_LOCK"/.command.* "$WORKER_LOCK"/.quarantine.*; do
+    [ -e "$entry" ] || [ -L "$entry" ] || continue
+    rm -f -- "$entry" || return 1
+  done
+}
+
 worker_acquire_lock() {
   local account_home=$1 attempt=0
   while [ "$attempt" -lt 150 ]; do
@@ -164,6 +178,7 @@ worker_acquire_lock() {
     fi
     [ ! -L "$WORKER_LOCK/pid" ] && [ ! -L "$WORKER_LOCK/start" ] && [ ! -L "$WORKER_LOCK/command" ] || return 1
     rm -f -- "$WORKER_LOCK/pid" "$WORKER_LOCK/start" "$WORKER_LOCK/command" || return 1
+    worker_discard_lock_temporaries || return 1
     rmdir "$WORKER_LOCK" || return 1
   done
   return 1

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -285,6 +285,28 @@ wait "$OTHER_PID" 2>/dev/null || true
 OTHER_PID=
 pass "stale ownership is reclaimed without signaling a reused pid"
 
+# A worker killed between mktemp and mv leaves a dot-prefixed publish temporary
+# inside its own lock directory. Reclaiming that provably stale lock has to
+# discard the residue, or rmdir refuses the directory and every replacement
+# worker exits before it can ever publish readiness.
+INTERRUPTED_WORKER_PID=$(cat "$STATE_ROOT/worker.pid")
+fm_remote_job_stop_worker_tree "$INTERRUPTED_WORKER_PID" \
+  || fail "the interrupted-publish fixture could not stop the running worker"
+rm -f -- "$STATE_ROOT/worker.ready"
+mkdir -p "$STATE_ROOT/worker.lock"
+chmod 700 "$STATE_ROOT/worker.lock"
+LOCK_RESIDUE="$STATE_ROOT/worker.lock/.quarantine.aBc123"
+: > "$LOCK_RESIDUE"
+touch -t 200001010000 "$STATE_ROOT/worker.lock"
+fm_remote_job_ensure_worker "$REMOTE_ROOT" "$ACCOUNT_HOME" || fail "$FM_REMOTE_JOB_ERROR"
+assert_absent "$LOCK_RESIDUE" "the reclaimed lock retained an interrupted publish temporary"
+NEW_WORKER_PID=$(cat "$STATE_ROOT/worker.pid")
+[ "$NEW_WORKER_PID" != "$INTERRUPTED_WORKER_PID" ] \
+  || fail "the replacement adopted the interrupted worker's pid"
+fm_remote_job_worker_identity_matches "$REMOTE_ROOT" "$ACCOUNT_HOME" \
+  || fail "interrupted publish residue prevented the current worker from starting"
+pass "an interrupted ownership publish never strands every replacement worker"
+
 FM_REMOTE_JOB_TIMEOUT=1
 fm_remote_job_stage "$ACCOUNT_HOME" "$REMOTE_ROOT" "$REMOTE_HOME" fm-timeout-job.sh < /dev/null > /dev/null
 JOB_ID=$FM_REMOTE_JOB_ID


### PR DESCRIPTION
api_response:
  body: "## Intent\n\nPrevent a remote job worker killed during atomic lock-owner publication from permanently stranding every replacement worker. Reclaim only dot-prefixed mktemp residue created by the existing lock publication paths after the existing stale-owner proof succeeds, preserve all process-identity, quarantine, timeout, no-signal, and no-discard safety boundaries, and add a behavioral regression through the public worker interface. Ship this generic fix to canonical Firstmate through a green PR; never merge it.\n\n## What Changed\n\n- Added `worker_discard_lock_temporaries` to `bin/fm-remote-job-worker.sh`, which removes dot-prefixed `mktemp` residue (`.pid.*`, `.start.*`, `.command.*`, `.quarantine.*`) left inside the worker lock directory when a worker is killed between `mktemp` and `mv`.\n- Wired the discard into `worker_acquire_lock` after the existing stale-owner proof and symlink refusal, immediately before `rmdir`, so a provably stale lock can actually be released instead of failing `rmdir` on a non-empty directory and stranding every replacement worker.\n- Added a regression case to `tests/fm-remote-job.test.sh` that kills a running worker, plants `.quarantine.aBc123` residue in an aged lock directory, and asserts the next `fm_remote_job_ensure_worker` clears the residue, starts under a fresh pid, and reports identity — verified to fail when the new call is removed.\n\n## Risk Assessment\n\n✅ Low: Additive, tightly scoped 15-line change confined to the single code path that removes the worker lock directory, gated behind the pre-existing stale-owner proof, with identity/quarantine/no-signal boundaries intact and a behavioral regression test through the public worker interface.\n\n## Testing\n\n<code>I ran the targeted remote-job behavior suite (`tests/fm-remote-job.test.sh`), which passes in full including the new interrupted-publish regression case, and confirmed that case genuinely pins the fix by deleting the reclaim call and watching the suite fail at exactly that assertion before restoring the tree. For product-level evidence I wrote a harness that drives the same ensure-worker/stage/wait sequence `fm-remote-entrypoint.sh` performs for every `fm-on.sh &lt;route&gt; fm-*.sh` call, against a real fixture checkout and a live worker process, then simulated a worker killed between mktemp and mv: on the base commit every subsequent operator invocation fails permanently with `remote job worker is unavailable`-class errors, while on this commit the next invocation reclaims the lock, starts a fresh worker with a different pid, and returns the job&#39;s output with exit 0. No visual artifact applies — this is an SSH-relayed CLI/daemon path, so the CLI transcripts are the end-user surface. Working tree is clean; all evidence lives in the dedicated evidence directory.</code>\n\n<details>\n<summary>Evidence: Operator transcript — BASE 96876db: interrupted publish strands every replacement worker</summary>\n\n<code>=== worker variant: BASE 96876db (before fix) ===&#10;&#10;$ fm-on.sh secondmate fm-report-job.sh # healthy account, first run&#10;firstmate remote job ran on the secondmate account&#10;[exit 0] serving worker pid=56498&#10;&#10;--- simulating a worker killed mid-publication (mktemp done, mv not) ---&#10;lock directory left behind:&#10;.&#10;..&#10;.pid.aBc123&#10;&#10;$ fm-on.sh secondmate fm-report-job.sh # replacement worker attempt 1&#10;error: remote job worker did not report ready after startup&#10;[exit 64]&#10;&#10;$ fm-on.sh secondmate fm-report-job.sh # replacement worker attempt 2&#10;error: remote job worker did not report ready after startup&#10;[exit 64]&#10;&#10;$ fm-on.sh secondmate fm-report-job.sh # replacement worker attempt 3&#10;error: remote job worker did not report ready after startup&#10;[exit 64]</code>\n\n```text\n=== worker variant: BASE 96876db (before fix) ===\n\n$ fm-on.sh secondmate fm-report-job.sh   # healthy account, first run\nfirstmate remote job ran on the secondmate account\nFM_HOME=/private/var/folders"
  truncated: true
  original_length: 13311
