### PR TITLE
fix(bin): resolve crew state by recorded window

### DIFF
--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -19,7 +19,8 @@
 #   state: <working|parked|done|blocked|paused|failed|unknown> · source: <run-step|pane|status-log|none> · <detail>
 #
 # Logic, in order:
-#   1. Resolve worktree + backend target + kind from state/<id>.meta.
+#   1. Resolve a task id directly or from one recorded window/terminal, then
+#      read worktree + backend target + kind from state/<id>.meta.
 #   2. Matching no-mistakes run for this crew's branch AND current code identity,
 #      active or terminal (from `axi status`, or the coarse `no-mistakes runs`
 #      fallback)? Branch name alone is not enough: a historical run on a reused
@@ -92,6 +93,22 @@ emit() {  # <state> <source> [detail]
 
 # --- meta resolution --------------------------------------------------------
 
+if [ ! -f "$META" ]; then
+  RESOLVED_ID=$(window_to_task "$ID" "$STATE")
+  MATCHES=0
+  for CANDIDATE_META in "$STATE"/*.meta; do
+    [ -e "$CANDIDATE_META" ] || continue
+    CANDIDATE_WINDOW=$(fm_meta_get "$CANDIDATE_META" window)
+    CANDIDATE_TERMINAL=$(fm_meta_get "$CANDIDATE_META" terminal)
+    [ "$CANDIDATE_WINDOW" = "$ID" ] || [ "$CANDIDATE_TERMINAL" = "$ID" ] || continue
+    MATCHES=$((MATCHES + 1))
+  done
+  [ "$MATCHES" -le 1 ] || emit unknown none "ambiguous metadata for $ID"
+  [ "$MATCHES" -eq 1 ] || emit unknown none "no metadata for $ID"
+  ID=$RESOLVED_ID
+  META="$STATE/$ID.meta"
+  LOG="$STATE/$ID.status"
+fi
 [ -f "$META" ] || emit unknown none "no metadata for $ID"
 
 meta_value() {  # <key>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,12 +72,13 @@ A herdr task additionally records `herdr_session=`, `herdr_workspace_id=`, `herd
 A zellij task additionally records `zellij_session=`, `zellij_tab_id=`, and `zellij_pane_id=`.
 An Orca task additionally records `orca_worktree_id=` and `terminal=`, with `window=fm-<id>` kept as the shared firstmate alias.
 A cmux task additionally records `cmux_workspace_id=` and `cmux_surface_id=`.
-Task selectors for `fm-peek.sh`, `fm-send.sh`, and `fm-crew-state.sh` resolve centrally through `fm_backend_resolve_selector`.
+Task selectors for `fm-peek.sh` and `fm-send.sh` resolve centrally through `fm_backend_resolve_selector`.
 A selector containing `:` is passed through as an explicit backend endpoint escape hatch.
 Otherwise an exact task id matching `state/<id>.meta` wins before the legacy `fm-<id>` label fallback, so task ids that themselves start with `fm-` route to their own metadata instead of being stripped.
 A metadata-routed selector returns the recorded backend target (`terminal=` for Orca, otherwise `window=`), and matching explicit targets can still recover the recorded backend when metadata contains the same endpoint.
 Only metadata-routed task selectors carry secondmate-marker and Codex-harness context; explicit endpoint escape hatches do not.
-These five sentences are the single owner of the task-selector vocabulary; backend guides and other documents point here instead of restating the resolution order.
+`fm-crew-state.sh` resolves its argument in the opposite direction, to a task rather than to an endpoint: an exact task id matching `state/<id>.meta` wins, otherwise a recorded `window=` or `terminal=` value (for example `default:w38:p2` or its bare `w38` terminal) resolves to the single task whose metadata records it, and both no match and more than one match report the unknown current state instead of choosing a task arbitrarily.
+These six sentences are the single owner of the task-selector vocabulary; backend guides and other documents point here instead of restating the resolution order.
 `fm-teardown.sh <id>` takes a task id directly and validates the complete metadata-only endpoint identity before any runtime dispatch or cleanup mutation.
 Missing, empty, duplicate, malformed, backend-inconsistent, or task-mismatched endpoint records are preserved and refused.
 Legacy tmux metadata remains cleanup-compatible when its exact window name is `fm-<id>`; opaque non-tmux endpoints require their recorded `endpoint_task_id=` binding.

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -1162,6 +1162,58 @@ test_missing_meta() {
   pass "missing meta is handled gracefully"
 }
 
+test_window_references_resolve_task() {
+  reset_fakes
+  local d by_id by_window by_terminal
+  d=$(new_case window-reference)
+  make_repo_on_branch "$d/wt" fm/window-reference
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/window-task.meta" "window=default:w38:p2" "terminal=w38" \
+    "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_running fm/window-reference)"
+  by_id=$(run_crew_state "$d" window-task)
+  by_window=$(run_crew_state "$d" default:w38:p2)
+  by_terminal=$(run_crew_state "$d" w38)
+  [ "$by_window" = "$by_id" ] || fail "full window reference changed the task state line"
+  [ "$by_terminal" = "$by_id" ] || fail "bare terminal reference changed the task state line"
+  pass "window references resolve to the recorded task"
+}
+
+test_unmatched_window_stays_unknown() {
+  reset_fakes
+  local d out
+  d=$(new_case unmatched-window)
+  make_repo_on_branch "$d/wt" fm/unrelated-p2
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/p2.meta" "window=default:w7:p2" "terminal=w7" \
+    "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_running fm/unrelated-p2)"
+  out=$(run_crew_state "$d" default:w404:p2)
+  assert_contains "$out" "state: unknown" "unmatched window -> unknown"
+  assert_contains "$out" "source: none" "unmatched window -> none source"
+  pass "unmatched window remains unknown"
+}
+
+test_ambiguous_windows_stay_unknown() {
+  reset_fakes
+  local d out
+  d=$(new_case ambiguous-window)
+  make_repo_on_branch "$d/wt" fm/ambiguous-window
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/alpha.meta" "window=default:w38:p2" "terminal=w38" \
+    "worktree=$d/wt" "kind=ship"
+  fm_write_meta "$d/state/beta.meta" "window=default:w38:p2" "terminal=w38" \
+    "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_running fm/ambiguous-window)"
+  out=$(run_crew_state "$d" default:w38:p2)
+  assert_contains "$out" "state: unknown" "ambiguous full window -> unknown"
+  assert_contains "$out" "source: none" "ambiguous full window -> none source"
+  out=$(run_crew_state "$d" w38)
+  assert_contains "$out" "state: unknown" "ambiguous bare terminal -> unknown"
+  assert_contains "$out" "source: none" "ambiguous bare terminal -> none source"
+  pass "ambiguous windows remain unknown"
+}
+
 # (k) crew_is_provably_working end-to-end over the REAL fm-crew-state.sh (not a
 # canned fake verdict, unlike tests/fm-watch-triage.test.sh's classifier
 # coverage). This is the direct regression pair for the 2026-07-02 herdr
@@ -1351,6 +1403,9 @@ test_no_timeout_uses_perl_bound
 test_scout_skips_run_lookup
 test_torn_down_worktree
 test_missing_meta
+test_window_references_resolve_task
+test_unmatched_window_stays_unknown
+test_ambiguous_windows_stay_unknown
 test_provably_working_via_runs_list_fallback
 test_not_provably_working_when_stopped
 test_usage_error


### PR DESCRIPTION
## Intent

Implement the provided crew-state window lookup handoff for Firstmate. Add the smallest correct behavior change to bin/fm-crew-state.sh: when the argument is not a task ID with matching state/<id>.meta, resolve it through the existing window_to_task helper from bin/fm-classify-lib.sh, then report the resolved task using the unchanged output contract. Both default:w38:p2 and w38 must resolve to the task whose metadata records that window. Unmatched and ambiguous windows must remain explicit unknown results and must never choose arbitrarily. Preserve existing task-ID behavior and the output line shape. Add behavior-level tests in the existing tests style without asserting source text. Do not change wake formatting or stale classification.

## What Changed

- `bin/fm-crew-state.sh` now accepts a recorded window or terminal reference: when the argument has no `state/<id>.meta`, it resolves through `window_to_task` and counts the metadata files whose `window=` or `terminal=` equals the argument, so both `default:w38:p2` and its bare `w38` form report the state of the task that records them. Exact task ids keep their existing path, and the emitted line shape is unchanged.
- Zero matches and more than one match both emit the existing `unknown`/`none` result (`no metadata for <id>` and `ambiguous metadata for <id>`) rather than picking a task.
- `docs/configuration.md` records that `fm-crew-state.sh` resolves toward a task rather than an endpoint, and `tests/fm-crew-state.test.sh` covers window/terminal references matching the task-id output plus the unmatched and ambiguous unknown cases.

## Risk Assessment

✅ Low: The change is an 18-line addition guarded entirely behind the existing missing-meta branch, leaves every task-ID path, the emit contract, and all callers (which pass resolved task ids) untouched, and ships behavior-level regression tests that specifically trap window_to_task's arbitrary ${w##*:} fallback.

## Testing

<code>I treated &#34;unit tests pass&#34; as insufficient and drove the helper as a supervisor would from the shell, building a fixture where `state/p2.meta` records `window=default:w38:p2` / `terminal=w38` on a real git worktree with a fake `no-mistakes` reporting a running run bound to that HEAD, then asked the same question five ways against both the base and the changed script.&#10;&#10;Before (base 96876db): `p2` → `state: working · source: run-step · validating (running)`; `default:w38:p2` and `w38` → `state: unknown · source: none · no metadata for …`.&#10;After (1174c4d): `p2`, `default:w38:p2`, and `w38` all → `state: working · source: run-step · validating (running)`; `default:w404:p2` → `state: unknown · source: none · no metadata for default:w404:p2`; the two-crew window → `state: unknown · source: none · ambiguous metadata for …` for both the full and bare forms, so `window_to_task`&#39;s suffix fallback can never silently pick one.&#10;&#10;One setup issue, fixed, not a product bug: running the suite plainly on this host failed at `not ok - empty no-mistakes status triggered extra lookups (0 calls)`. `bash -x` showed `RUN_OUT=error: repo not initialized (run &#39;no-mistakes init&#39; first)` — this machine&#39;s `BASH_ENV=/Users/host/.config/bash/env` prepends `~/.local/bin` to PATH in every non-interactive bash, so the real `no-mistakes` shadowed the test&#39;s fake in the one case that deliberately uses a restricted PATH with no `timeout`. Running as `env -u BASH_ENV bash tests/…` fixes it. It reproduces identically with the base script swapped in, so it is pre-existing and environmental; I changed no repo files for it and read (never modified) the machine config.&#10;&#10;Scope: only the suite covering the changed file was run — no full-repo suite, no linters, formatters, or static analysis. All scratch fixtures lived in `mktemp -d` dirs outside the worktree; the base-script swap was restored and `git status --porcelain` plus `git diff --stat` are both empty. Evidence files were written only under the designated evidence directory.</code>

<details>
<summary>Evidence: Before/after CLI transcript — crew state by task id, window, and terminal</summary>

<code>BEFORE - base 96876db&#10;$ fm-crew-state.sh p2 -&gt; state: working · source: run-step · validating (running)&#10;$ fm-crew-state.sh default:w38:p2 -&gt; state: unknown · source: none · no metadata for default:w38:p2&#10;$ fm-crew-state.sh w38 -&gt; state: unknown · source: none · no metadata for w38&#10;$ fm-crew-state.sh default:w404:p2 -&gt; state: unknown · source: none · no metadata for default:w404:p2&#10;ambiguous (alpha+beta) -&gt; state: unknown · source: none · no metadata for &lt;ref&gt;&#10;&#10;AFTER - this change 1174c4d&#10;$ fm-crew-state.sh p2 -&gt; state: working · source: run-step · validating (running)&#10;$ fm-crew-state.sh default:w38:p2 -&gt; state: working · source: run-step · validating (running)&#10;$ fm-crew-state.sh w38 -&gt; state: working · source: run-step · validating (running)&#10;$ fm-crew-state.sh default:w404:p2 -&gt; state: unknown · source: none · no metadata for default:w404:p2&#10;ambiguous default:w38:p2 -&gt; state: unknown · source: none · ambiguous metadata for default:w38:p2&#10;ambiguous w38 -&gt; state: unknown · source: none · ambiguous metadata for w38</code>

```text
==============================================================
 BEFORE - base 96876db
==============================================================
fleet state: state/p2.meta  (window=default:w38:p2  terminal=w38)

-- task id (unchanged behavior) ------------------------------
$ fm-crew-state.sh p2
state: working · source: run-step · validating (running)

-- full window reference -------------------------------------
$ fm-crew-state.sh default:w38:p2
state: unknown · source: none · no metadata for default:w38:p2

-- bare terminal reference -----------------------------------
$ fm-crew-state.sh w38
state: unknown · source: none · no metadata for w38

-- window nothing records ------------------------------------
$ fm-crew-state.sh default:w404:p2
state: unknown · source: none · no metadata for default:w404:p2

-- window two crews record (alpha.meta + beta.meta) ----------
$ fm-crew-state.sh default:w38:p2
state: unknown · source: none · no metadata for default:w38:p2
$ fm-crew-state.sh w38
state: unknown · source: none · no metadata for w38

==============================================================
 AFTER - this change 1174c4d
==============================================================
fleet state: state/p2.meta  (window=default:w38:p2  terminal=w38)

-- task id (unchanged behavior) ------------------------------
$ fm-crew-state.sh p2
state: working · source: run-step · validating (running)

-- full window reference -------------------------------------
$ fm-crew-state.sh default:w38:p2
state: working · source: run-step · validating (running)

-- bare terminal reference -----------------------------------
$ fm-crew-state.sh w38
state: working · source: run-step · validating (running)

-- window nothing records ------------------------------------
$ fm-crew-state.sh default:w404:p2
state: unknown · source: none · no metadata for default:w404:p2

-- window two crews record (alpha.meta + beta.meta) ----------
$ fm-crew-state.sh default:w38:p2
state: unknown · source: none · ambiguous metadata for default:w38:p2
$ fm-crew-state.sh w38
state: unknown · source: none · ambiguous metadata for w38
```
</details>
<details>
<summary>Evidence: Transcript generator (builds the throwaway fleet state, worktrees, and fake no-mistakes)</summary>

```text
#!/usr/bin/env bash
# End-user demo: ask fm-crew-state.sh for a crew's current state by task id, by
# full window reference, and by bare terminal reference.
#
# Usage: window-lookup-demo.sh <path-to-fm-crew-state.sh> <label>
#
# Builds a throwaway fleet state dir with two real git worktrees and a fake
# `no-mistakes` CLI that reports one running run, then prints the transcript a
# supervisor would see calling the helper with each reference form.
set -u
CREW_STATE=$1
LABEL=$2
D=$(mktemp -d)
mkdir -p "$D/state" "$D/fakebin"

# Crew "p2": window default:w38:p2, terminal w38, on branch fm/ship-p2.
mkdir -p "$D/p2"
(cd "$D/p2" && git init -q && git commit -q --allow-empty -m init && git checkout -q -b fm/ship-p2)
HEAD_SHA=$(cd "$D/p2" && git rev-parse HEAD)
printf 'window=default:w38:p2\nterminal=w38\nworktree=%s/p2\nkind=ship\n' "$D" > "$D/state/p2.meta"

# A second crew sharing the same window/terminal, in its own state dir, used
# only for the ambiguity case below.
mkdir -p "$D/amb/state"
cp "$D/state/p2.meta" "$D/amb/state/alpha.meta"
cp "$D/state/p2.meta" "$D/amb/state/beta.meta"

cat > "$D/fakebin/no-mistakes" <<SH
#!/usr/bin/env bash
[ "\${1:-}" = axi ] || exit 0
[ "\${2:-}" = status ] || exit 0
cat <<'TOON'
run:
  id: "01RUN"
  branch: fm/ship-p2
  status: running
  head: "$HEAD_SHA"
  pr: ""
  findings: none
  steps[2]{step,status,findings,duration_ms}:
    intent,completed,0,0
    review,running,0,0
TOON
SH
chmod +x "$D/fakebin/no-mistakes"

ask() {  # <state-dir> <reference>
  printf '$ fm-crew-state.sh %s\n' "$2"
  PATH="$D/fakebin:$PATH" FM_STATE_OVERRIDE="$1" "$CREW_STATE" "$2"
}

echo "=============================================================="
echo " $LABEL"
echo "=============================================================="
echo "fleet state: state/p2.meta  (window=default:w38:p2  terminal=w38)"
echo
echo "-- task id (unchanged behavior) ------------------------------"
ask "$D/state" p2
echo
echo "-- full window reference -------------------------------------"
ask "$D/state" default:w38:p2
echo
echo "-- bare terminal reference -----------------------------------"
ask "$D/state" w38
echo
echo "-- window nothing records ------------------------------------"
ask "$D/state" default:w404:p2
echo
echo "-- window two crews record (alpha.meta + beta.meta) ----------"
ask "$D/amb/state" default:w38:p2
ask "$D/amb/state" w38
echo
```
</details>
<details>
<summary>Evidence: Targeted suite result</summary>

```text
$ env -u BASH_ENV bash tests/fm-crew-state.test.sh
… ok - window references resolve to the recorded task
ok - unmatched window remains unknown
ok - ambiguous windows remain unknown
all fm-crew-state tests passed
EXIT=0

$ (base bin/fm-crew-state.sh swapped in) env -u BASH_ENV bash tests/fm-crew-state.test.sh
not ok - full window reference changed the task state line
BASE_SUITE_EXIT=1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d8f598e972da30937ea6876e08984591c15b51ae","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 3 infos</summary>

- ℹ️ `bin/fm-crew-state.sh:97` - The window/terminal match predicate is now implemented twice: window_to_task (bin/fm-classify-lib.sh:625) already walks $STATE/*.meta with the identical predicate, and the new loop re-walks it only to count matches. Both parse metadata the same way today (grep &#39;^key=&#39; | tail -1 | cut -d= -f2-), so this is currently just a wasted second scan — window_to_task also runs unconditionally at line 97 even when its result is discarded on the ambiguous/zero-match paths. It matters because the two copies live in different files: if window_to_task&#39;s matching ever changes (prefix normalization, session-qualified matching), MATCHES could be 1 while RESOLVED_ID names a different task, and the script would report another crew&#39;s state as a confident unique match. Line 112 only catches a resolved id with no meta file, not a resolved id pointing at a different existing meta. Fix while keeping window_to_task as the resolver per intent: capture the matching candidate&#39;s basename inside the loop and use it to confirm RESOLVED_ID, or move the window_to_task call below the count so it runs only on the unique-match path.
- ℹ️ `tests/fm-crew-state.test.sh:1177` - test_window_references_resolve_task asserts only that by_window and by_terminal equal by_id, never what that line is. The assertions are sound as written (unknown-path details embed the queried id, so a resolution regression does produce a diverging line), but the test never states the positive outcome it is protecting. One added assert_contains &#34;$by_id&#34; &#34;state: working&#34; documents the expected state and keeps fixture drift (branch/worktree/FM_FAKE_AXI_STATUS changes) from reducing the comparison to an uninformative all-unknown match.
- ℹ️ `bin/fm-classify-lib.sh:752` - Informational, pre-existing, and outside this handoff&#39;s stated scope: the &#39;never choose arbitrarily&#39; guarantee added by this change is local to bin/fm-crew-state.sh. stale_is_terminal still calls window_to_task directly, so an unmatched window falls through to ${win##*:} and can read an unrelated task&#39;s .status file. That is a different function with a best-effort contract and the intent scoped this change to bin/fm-crew-state.sh, so no action is required here — noted only so the shared helper&#39;s remaining fallback behavior is visible.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`env -u BASH_ENV bash tests/fm-crew-state.test.sh` — the suite that owns bin/fm-crew-state.sh (per fm-test-run.sh&#39;s file→family map, pure-contract-unit): 44/44 pass, exit 0, including the three new window-resolution cases</code>
- <code>Fail-before/pass-after regression check: same suite with the base (96876db) bin/fm-crew-state.sh swapped in → exit 1 at `not ok - full window reference changed the task state line`; head version restored, worktree verified clean</code>
- <code>Product-level CLI transcript (before vs after) against a throwaway fleet state dir with real git worktrees and a fake `no-mistakes` reporting a running run: task id `p2`, full window `default:w38:p2`, bare terminal `w38`, unmatched window `default:w404:p2`, and a window recorded by two crews (`alpha.meta` + `beta.meta`)</code>
- `Consumer contract check: every in-repo caller of fm-crew-state.sh passes a task id and reads the same one-line contract, which the transcript shows unchanged for task-ID input`

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `bin/fm-crew-state.sh:72` - bin/fm-crew-state.sh&#39;s usage string still reads `usage: fm-crew-state.sh &lt;id&gt;` and does not mention the newly accepted window/terminal reference form. Left unchanged deliberately: editing it alters program output, which is outside this documentation phase&#39;s edit boundary. The script header comment and docs/configuration.md now both cover the resolution, so the gap is cosmetic; a follow-up could widen the usage line to `&lt;id|window&gt;` alongside any behavior change.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
