### PR TITLE
docs: register existing control and stow surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,9 @@ Firstmate's skills live in two separate places with different audiences:
 
 ## Documentation
 
+- [VISION.md](VISION.md) - what firstmate is for and where it is going.
 - [docs/architecture.md](docs/architecture.md) - maintainer architecture for the crew, supervision, worktrees, secondmates, and project modes.
+- [docs/agent-control.md](docs/agent-control.md) - the data/control plane split and the `interrupt`, `exit`, and `relaunch` lifecycle contract.
 - [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, runtime backend selection, optional Relay and its X and Discord setup steps, the files you set, and harness support.
 - [docs/remote-secondmates.md](docs/remote-secondmates.md) - current setup, routing, transfer, recovery, and safety behavior for whole-home remote second mates.
 - [docs/calm.md](docs/calm.md) - current Pi `/calm` behavior and supported presentation limits.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -600,6 +600,14 @@ FM_SEND_RETRIES=3       # fm-send Enter-retry attempts after typing the line onc
 FM_SEND_SLEEP=0.4       # seconds between fm-send submit checks
 FM_SEND_SETTLE=1        # seconds fm-send waits after a successful text submit; 0 disables
 FM_PENDING_REPLY_GRACE_SECS=120   # seconds after marked-request delivery before a completed turn without a correlated parent report is eligible for its one recovery repost
+FM_CONTROL_POLL=0.5     # seconds between fm-control.sh postcondition polls (docs/agent-control.md)
+FM_CONTROL_SETTLE_WAIT=5   # seconds fm-control.sh waits for an adapter acknowledgement after an interrupt
+FM_CONTROL_EXIT_WAIT=30    # seconds fm-control.sh waits for the alive->dead postcondition after the exit command
+FM_CONTROL_EXIT_RETRIES=3  # Enter retries for that exit command
+FM_CONTROL_LAUNCH_WAIT=90  # seconds fm-control.sh waits for the dead->alive postcondition after a relaunch
+FM_STOW_CASCADE_TIMEOUT=60   # seconds bounding each host-crossing or accounting step of bin/fm-stow-cascade.sh; a slower home is reported as an exception, never waited on
+FM_TIMING_LOG=          # optional append-only per-step elapsed-time record file for the deferred network stage; unset keeps bin/fm-timing-lib.sh inert
+FM_TIMING_DETAIL_MAX=80   # characters kept from one timing record's detail field
 # sub-supervisor (bin/fm-supervise-daemon.sh); presence-gated via /afk
 FM_SUPERVISOR_BACKEND=             # optional supervisor pane backend override; tmux/herdr only, otherwise detects $TMUX_PANE then HERDR_ENV/HERDR_PANE_ID before tmux fallback
 FM_SUPERVISOR_TARGET=              # optional supervisor pane target override; tmux target or herdr <session>:<pane-id>, otherwise auto-detected

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -49,6 +49,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-remote-home-seed.sh` | Register and provision a whole secondmate home on an SSH-reachable host              |
 | `fm-remote-readiness-lib.sh` | Shared remote second-mate readiness gate: check and, when needed, repair then re-check through `fm-remote-doctor.sh` |
 | [`fm-project-origin-lib.sh`](../bin/fm-project-origin-lib.sh) | Accepted origin-form owner shared by both remote provisioning boundaries |
+| `fm-stow-cascade.sh`     | Enumerate this home's registered secondmates for an internal `/stow` cascade: per-home budget accounting and how the sweep reaches each home |
 | `fm-spawn.sh`            | Spawn crewmates, scouts, `id=repo` batches, and secondmates on the resolved harness and runtime backend |
 | `fm-backend.sh`          | Runtime-backend selection, meta helpers, selector resolution, and operation dispatch |
 | `fm-backend-hometag-lib.sh` | Shared per-installation home-tag derivation for zellij tab and cmux workspace titles |


### PR DESCRIPTION
api_response:
  body: "## Intent\n\nRestore current operator and maintainer documentation for existing canonical Firstmate behavior without changing runtime code: register the existing Vision and agent-control documentation links, document the environment variables already consumed by lifecycle control, stow cascade, and deferred timing owners, and add the existing stow-cascade script to the toolbelt inventory. Keep each contract with its existing owner, add only concise references, follow documentation audience classification and one-sentence-per-line style, and ship through a green canonical Firstmate PR without merging it.\n\n## What Changed\n\n- Added the missing `VISION.md` and `docs/agent-control.md` entries to the README Documentation list so the vision statement and the data/control-plane lifecycle contract (`interrupt`, `exit`, `relaunch`) are reachable from the top-level index.\n- Documented the environment variables already consumed by lifecycle control, the stow cascade, and deferred timing in `docs/configuration.md`: `FM_CONTROL_POLL`, `FM_CONTROL_SETTLE_WAIT`, `FM_CONTROL_EXIT_WAIT`, `FM_CONTROL_EXIT_RETRIES`, `FM_CONTROL_LAUNCH_WAIT`, `FM_STOW_CASCADE_TIMEOUT`, `FM_TIMING_LOG`, and `FM_TIMING_DETAIL_MAX`, each with its existing default.\n- Added the existing `fm-stow-cascade.sh` row to the `docs/scripts.md` toolbelt inventory.\n\nDocumentation only — no runtime code changed. The pipeline's Test phase confirmed the diff touches only the three doc files, ran the repo's documentation-audience suite and the repo-wide audience/link check (67 surfaces, 245 links ok), and verified all 8 documented defaults match the `${VAR:-default}` values in `bin/fm-control.sh`, `bin/fm-stow-cascade.sh`, and `bin/fm-timing-lib.sh`.\n\n## Risk Assessment\n\n✅ Low: Documentation-only change (11 added lines across README.md, docs/configuration.md, docs/scripts.md) whose every claim I verified against the existing sources — all linked files exist, all documented env-var names and defaults match bin/fm-control.sh, bin/fm-stow-cascade.sh, and bin/fm-timing-lib.sh, and no runtime code is touched.\n\n## Testing\n\nI verified this docs-only change end-to-end as an operator would read it: the repo's documentation-audience check and its regression test both pass (67 classified surfaces, 245 local links resolving, which is what proves the two new README links point at real files), every one of the eight newly documented environment variables matches the default its owning script actually uses, and the docs/scripts.md toolbelt row matches bin/fm-stow-cascade.sh's own --help wording. I also exercised the documented behavior live — FM_TIMING_LOG inert when unset and emitting the documented record format when set, FM_TIMING_DETAIL_MAX truncating the detail field, and FM_STOW_CASCADE_TIMEOUT validated as a positive-integer bound — and captured rendered-Markdown screenshots of the three changed doc surfaces since these are reader-facing pages. Everything passed; no runtime code is touched by the diff and the worktree is clean.\n\n- Evidence: Rendered README Documentation section (VISION.md and docs/agent-control.md now registered) (local file: <code>/var/folders/wy/khrzvmhd0ss969ydn32ghccm0000gn/T/no-mistakes-evidence/01KZXGZJSN1S9K6EAPKP1HSFYT/rendered-docs.png</code>)\n- Evidence: Rendered docs/configuration.md environment-variable block and docs/scripts.md toolbelt row (local file: <code>/var/folders/wy/khrzvmhd0ss969ydn32ghccm0000gn/T/no-mistakes-evidence/01KZXGZJSN1S9K6EAPKP1HSFYT/rendered-docs-toolbelt.png</code>)\n- Evidence: Rendered docs (scrolled: full README list plus start of env block) (local file: <code>/var/folders/wy/khrzvmhd0ss969ydn32ghccm0000gn/T/no-mistakes-evidence/01KZXGZJSN1S9K6EAPKP1HSFYT/rendered-docs-env-and-toolbelt.png</code>)\n<details>\n<summary>Evidence: Standalone rendered HTML of the three changed doc surfaces</summary>\n\n```text\n<!doctype html><meta charset=utf-8><title>Firstmate docs registration</title><style>body{font-family:-apple-system,BlinkMacSystemFont,'Seg"
  truncated: true
  original_length: 17872
