### PR TITLE
feat(delivery): add neutral domain-review consumer

### DIFF
--- a/.agents/skills/consumed-domain-review/SKILL.md
+++ b/.agents/skills/consumed-domain-review/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: consumed-domain-review
+description: >-
+  Agent-only policy for consuming a versioned exact-head domain-review result as the review input to delivery without adding or repeating an independent review. Use before treating any prior domain review as a delivery input, before authorizing a no-mistakes review skip from such a result, and whenever code or identity changes may have invalidated a consumed result.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# consumed-domain-review
+
+This skill is the single owner of Firstmate's consumed-domain-review decision policy.
+A producer-specific consumer remains authoritative for its artifact schemas, integrity, evidence, review modes, findings, and invalidation mechanics.
+Firstmate never recreates those checks from prose and never turns this exception into another review pipeline.
+
+## Applicability
+
+Apply this policy only when an authorized domain workflow supplies a private delivery handoff and an explicitly selected external consumer implementing the neutral protocol in [`docs/consumed-domain-review.md`](../../../docs/consumed-domain-review.md).
+Provider adapters, provider allowlists, product names, internal evidence, and operating strategy stay with their producer or in the home-local gitignored `config/` and `data/` surfaces.
+They do not belong in Firstmate's tracked core.
+No consumer is discovered from an untrusted handoff, repository, or environment value.
+A colleague-PR review, sanitized comment, report without a machine consumer, or unsupported protocol version is not consumable under this policy.
+
+Consumption changes behavior only for a task whose selected path is `no-mistakes`.
+A `direct-PR` or `local-only` path already has no independent pipeline review to replace, so a result does not add a review, remove a delivery step, or change authority.
+A `no-mistakes-prod-only` registry posture has no direct runtime meaning here because intake must already have resolved it to one concrete task path.
+A result is an input to one delivery attempt, never a fourth delivery mode and never a standing project posture.
+
+The policy is independent of the primary runtime, worker runtime, and provider review mode.
+Use `harness-adapters` for the worker's version-specific no-mistakes invocation form, and do not add runtime-specific receipt rules.
+
+## Admission decision
+
+1. Resolve the task's project and expected repository identity independently of the handoff.
+   Never derive the expected identity or consumer executable from the artifact being tested.
+2. Require the handoff and provider evidence to remain in their authorized private location.
+   Never copy finding prose, evidence URLs, reviewer identities, credentials, or private repository names into a brief, status event, no-mistakes intent, PR, or captain-facing message.
+3. Run `bin/fm-domain-review-consume.sh` with the trusted external consumer, private handoff, exact clean product worktree, and independently resolved repository identity.
+   The external consumer owns provider-specific validation and emits `firstmate-domain-review-consumption.v1` only after acceptance.
+   Firstmate's adapter independently enforces the clean exact repository root, expected repository identity, current HEAD, neutral protocol version, and an allowlisted output that cannot forward provider-private fields.
+4. Admit the result only when that command exits zero with an accepted normalized result.
+   Nonzero consumer exits retain their provider-defined meaning, while exit 13 means the extension point or Firstmate binding was incompatible.
+5. Treat unresolved findings through the existing authority rules.
+   The implementation worker never approves its own domain-review findings, and a nonaccepted result never authorizes a review skip.
+6. On any missing or untrusted consumer, unsupported version, malformed result, repository mismatch, head mismatch, dirty worktree, changed artifact, nonaccepted review, or prior invalidation, do not consume the result.
+   Route a fresh matching domain review when the task still intends to use this exception; otherwise run the selected delivery path's ordinary review behavior.
+
+Do not accept a verbal statement that review passed, a status line, a report path, a matching branch name, a short commit id, or a pull request as a substitute for the accepted machine result.
+
+## No-mistakes handoff
+
+After admission, send the same task worker one exact instruction that identifies only the accepted receipt digest, product head, diff digest, review mode, and quality label.
+Do not expose private provider data or repository identity in the worker instruction.
+Tell the worker to use the installed no-mistakes version's `axi run --help` syntax to skip exactly the `review` step and no other step while preserving the complete accepted task intent.
+The consumed domain review is the no-mistakes review input for that exact code identity, not permission to add another independent reviewer before or during delivery.
+
+Every other no-mistakes owner and boundary remains unchanged:
+
+- the same task worker drives the run and every response;
+- no-mistakes retains branch custody and owns all in-run fixes;
+- tests, documentation, lint, push, PR creation, and CI still run;
+- findings still follow Firstmate's authority procedure;
+- the worker does not hand-edit, commit, abort, restart, or start a second run while no-mistakes owns the branch;
+- captain decisions, configured merge authority, the red-PR prohibition, and guarded landing remain intact.
+
+A skipped no-mistakes review is valid only for the accepted result's exact head and diff.
+Never convert it into a project default, a remembered exemption, or authority to skip review on a later run.
+
+## Invalidation after admission
+
+Any committed or uncommitted change after admission invalidates consumption, including a code, test, documentation, generated-file, or pipeline-fix change that moves the head, changes the canonical diff, or dirties the reviewed worktree.
+A repository-identity mismatch also invalidates consumption even if commit and diff bytes happen to match.
+Resetting to an old commit never revives a result that its producer marked invalidated.
+
+When code identity changes before no-mistakes starts, return through the producer's invalidation and fresh-review path before choosing the review skip again.
+When no-mistakes changes code under active branch custody, do not interrupt its supported response flow and do not edit around it.
+Withhold delivery readiness, let the current gate or outcome settle under no-mistakes ownership, then obtain a fresh exact-head domain review for the delivered head in a clean authorized worktree.
+If that review requires a fix, apply the existing no-mistakes branch-sync and custody procedure before any follow-up run.
+Never let an external reviewer or implementation worker take the branch mid-run.
+
+A pull request and green CI are not ready for captain review until the latest delivered head has both the selected delivery path's required results and an accepted matching domain-review result.
+If the final head differs, report the concrete review blocker rather than presenting stale review evidence as success.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,7 +302,8 @@ Supervise all live work under section 8.
 ### Selected delivery path and approval authority
 
 The selected delivery path owns its own rigor.
-When no-mistakes is selected, no-mistakes alone owns review, fixes, tests, documentation, push, PR, and CI; otherwise follow the faster path without adding an independent reviewer.
+When no-mistakes is selected, no-mistakes owns review, fixes, tests, documentation, push, PR, and CI; the only prior-review exception is an accepted consumed domain review under `consumed-domain-review`, which replaces its duplicate independent review step and nothing else.
+Load `consumed-domain-review` before treating any prior domain-review receipt as a delivery input, and otherwise follow the selected path without adding an independent reviewer.
 Never hold work outside no-mistakes for a manual clean verdict, stack serial manual reviews, or infer authority for one from security, architecture, or risk alone.
 A separate review or audit is allowed only when the captain explicitly requests that deliverable or the authorized task is a knowledge-only review; one named question remains scoped to that question.
 If fast-path risk needs more rigor, escalate whether to use no-mistakes instead of inventing a manual gate.
@@ -518,6 +519,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `NETWORK_CHECKS:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
 - `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
+- `consumed-domain-review` - load before treating any prior domain review as a delivery input, before authorizing a no-mistakes review skip from a receipt, and whenever code or identity changes may have invalidated a consumed receipt.
 - `quota-array-dispatch` - load before choosing among a matched crew-dispatch profile array from current quota-axi output.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
 - `firstmate-orca` - load before switching to Orca, spawning or supervising Orca-backed work, smoke-testing Orca backend behavior, debugging Orca task state, or reconciling Orca-backed task metadata.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,7 +303,7 @@ Supervise all live work under section 8.
 
 The selected delivery path owns its own rigor.
 When no-mistakes is selected, no-mistakes owns review, fixes, tests, documentation, push, PR, and CI; the only prior-review exception is an accepted consumed domain review under `consumed-domain-review`, which replaces its duplicate independent review step and nothing else.
-Load `consumed-domain-review` before treating any prior domain-review receipt as a delivery input, and otherwise follow the selected path without adding an independent reviewer.
+Load `consumed-domain-review` before treating any prior domain-review result as a delivery input, and otherwise follow the selected path without adding an independent reviewer.
 Never hold work outside no-mistakes for a manual clean verdict, stack serial manual reviews, or infer authority for one from security, architecture, or risk alone.
 A separate review or audit is allowed only when the captain explicitly requests that deliverable or the authorized task is a knowledge-only review; one named question remains scoped to that question.
 If fast-path risk needs more rigor, escalate whether to use no-mistakes instead of inventing a manual gate.
@@ -519,7 +519,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `NETWORK_CHECKS:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
 - `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
-- `consumed-domain-review` - load before treating any prior domain review as a delivery input, before authorizing a no-mistakes review skip from a receipt, and whenever code or identity changes may have invalidated a consumed receipt.
+- `consumed-domain-review` - load before treating any prior domain review as a delivery input, before authorizing a no-mistakes review skip from such a result, and whenever code or identity changes may have invalidated a consumed result.
 - `quota-array-dispatch` - load before choosing among a matched crew-dispatch profile array from current quota-axi output.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
 - `firstmate-orca` - load before switching to Orca, spawning or supervising Orca-backed work, smoke-testing Orca backend behavior, debugging Orca task state, or reconciling Orca-backed task metadata.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -391,6 +391,7 @@ Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
 When starting no-mistakes, make \`--intent\` preserve all relevant content from this brief's \`# Task\` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
+Only when Firstmate explicitly supplies an accepted result under its \`consumed-domain-review\` policy may you use current \`axi run --help\` syntax to skip exactly the duplicate \`review\` step; never infer receipt validity or omit another step.
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 
 Two firstmate-specific rules layer on top of that guidance:

--- a/bin/fm-domain-review-consume.sh
+++ b/bin/fm-domain-review-consume.sh
@@ -93,14 +93,28 @@ REPO_TOP=$(git -C "$REPO" rev-parse --show-toplevel 2>/dev/null) || {
   echo "error: --repo must name the exact product worktree root: $REPO" >&2
   exit 13
 }
-if [ -n "$(git -C "$REPO" status --porcelain --untracked-files=normal 2>/dev/null)" ]; then
-  echo "error: product worktree must be clean before domain-review consumption" >&2
-  exit 13
-fi
-PRODUCT_HEAD=$(git -C "$REPO" rev-parse HEAD 2>/dev/null) || {
-  echo "error: product HEAD cannot be resolved" >&2
-  exit 13
+resolve_clean_exact_head() {
+  expected=${1:-}
+  when=${2:-before}
+  if ! porcelain=$(git -C "$REPO" status --porcelain --untracked-files=normal 2>/dev/null); then
+    echo "error: product worktree state cannot be read $when domain-review consumption" >&2
+    exit 13
+  fi
+  if [ -n "$porcelain" ]; then
+    echo "error: product worktree must be clean $when domain-review consumption" >&2
+    exit 13
+  fi
+  PRODUCT_HEAD=$(git -C "$REPO" rev-parse HEAD 2>/dev/null) || {
+    echo "error: product HEAD cannot be resolved $when domain-review consumption" >&2
+    exit 13
+  }
+  if [ -n "$expected" ] && [ "$PRODUCT_HEAD" != "$expected" ]; then
+    echo "error: product HEAD moved during domain-review consumption" >&2
+    exit 13
+  fi
 }
+
+resolve_clean_exact_head "" "before"
 
 RESULT=$(mktemp "${TMPDIR:-/tmp}/fm-domain-review-consume.XXXXXX") || exit 13
 NORMALIZED=$(mktemp "${TMPDIR:-/tmp}/fm-domain-review-normalized.XXXXXX") || {
@@ -115,6 +129,8 @@ if [ "$CONSUMER_STATUS" -ne 0 ]; then
   cat "$RESULT"
   exit "$CONSUMER_STATUS"
 fi
+
+resolve_clean_exact_head "$PRODUCT_HEAD" "after"
 
 node - "$RESULT" "$REPOSITORY" "$PRODUCT_HEAD" "$NORMALIZED" <<'NODE'
 const fs = require('node:fs')

--- a/bin/fm-domain-review-consume.sh
+++ b/bin/fm-domain-review-consume.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Validate one exact-head domain-review handoff through an explicitly selected
+# external consumer, then enforce Firstmate's repository and worktree binding.
+# Usage: fm-domain-review-consume.sh --consumer <executable> \
+#          --handoff <provider-artifact> --repo <exact-clean-product-worktree> \
+#          --repository <expected-identity>
+#
+# The external consumer owns its provider-specific schemas, artifact integrity,
+# evidence, findings, and invalidation rules. It is invoked as:
+#   <consumer> consume <handoff> --repo <repo> --repository <identity>
+# On acceptance it must print one JSON object using the neutral
+# firstmate-domain-review-consumption.v1 protocol documented in
+# docs/consumed-domain-review.md. Firstmate independently verifies the exact
+# clean repository root, expected repository identity, and current HEAD, then
+# emits only the protocol's allowlisted delivery fields. Provider-private fields
+# are never forwarded.
+#
+# Nonzero consumer exits and output are preserved. Exit 13 means the selected
+# consumer, accepted result, repository binding, or clean exact-head binding was
+# incompatible with this extension point.
+set -u
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0"
+}
+
+fail_usage() {
+  echo "error: $*" >&2
+  usage >&2
+  exit 64
+}
+
+CONSUMER=
+HANDOFF=
+REPO=
+REPOSITORY=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --consumer|--handoff|--repo|--repository)
+      [ "$#" -ge 2 ] || fail_usage "$1 requires a value"
+      case "$1" in
+        --consumer) CONSUMER=$2 ;;
+        --handoff) HANDOFF=$2 ;;
+        --repo) REPO=$2 ;;
+        --repository) REPOSITORY=$2 ;;
+      esac
+      shift 2
+      ;;
+    *) fail_usage "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$CONSUMER" ] || fail_usage "--consumer is required"
+[ -n "$HANDOFF" ] || fail_usage "--handoff is required"
+[ -n "$REPO" ] || fail_usage "--repo is required"
+[ -n "$REPOSITORY" ] || fail_usage "--repository is required"
+[ -f "$CONSUMER" ] && [ ! -L "$CONSUMER" ] && [ -x "$CONSUMER" ] || {
+  echo "error: domain-review consumer must be an executable regular non-symlink file: $CONSUMER" >&2
+  exit 13
+}
+[ -f "$HANDOFF" ] && [ ! -L "$HANDOFF" ] || {
+  echo "error: domain-review handoff must be a regular non-symlink file: $HANDOFF" >&2
+  exit 13
+}
+case "$REPOSITORY" in
+  *$'\n'*|*$'\r'*) echo "error: repository identity must be one line" >&2; exit 13 ;;
+esac
+
+CONSUMER_DIR=$(CDPATH='' cd -- "$(dirname -- "$CONSUMER")" 2>/dev/null && pwd -P) || {
+  echo "error: domain-review consumer directory cannot be resolved: $CONSUMER" >&2
+  exit 13
+}
+CONSUMER="$CONSUMER_DIR/$(basename -- "$CONSUMER")"
+HANDOFF_DIR=$(CDPATH='' cd -- "$(dirname -- "$HANDOFF")" 2>/dev/null && pwd -P) || {
+  echo "error: domain-review handoff directory cannot be resolved: $HANDOFF" >&2
+  exit 13
+}
+HANDOFF="$HANDOFF_DIR/$(basename -- "$HANDOFF")"
+REPO=$(CDPATH='' cd -- "$REPO" 2>/dev/null && pwd -P) || {
+  echo "error: product worktree cannot be resolved: $REPO" >&2
+  exit 13
+}
+REPO_TOP=$(git -C "$REPO" rev-parse --show-toplevel 2>/dev/null) || {
+  echo "error: product worktree is not a git repository: $REPO" >&2
+  exit 13
+}
+[ "$REPO_TOP" = "$REPO" ] || {
+  echo "error: --repo must name the exact product worktree root: $REPO" >&2
+  exit 13
+}
+if [ -n "$(git -C "$REPO" status --porcelain --untracked-files=normal 2>/dev/null)" ]; then
+  echo "error: product worktree must be clean before domain-review consumption" >&2
+  exit 13
+fi
+PRODUCT_HEAD=$(git -C "$REPO" rev-parse HEAD 2>/dev/null) || {
+  echo "error: product HEAD cannot be resolved" >&2
+  exit 13
+}
+
+RESULT=$(mktemp "${TMPDIR:-/tmp}/fm-domain-review-consume.XXXXXX") || exit 13
+NORMALIZED=$(mktemp "${TMPDIR:-/tmp}/fm-domain-review-normalized.XXXXXX") || {
+  rm -f -- "$RESULT"
+  exit 13
+}
+trap 'rm -f "$RESULT" "$NORMALIZED"' EXIT HUP INT TERM
+
+"$CONSUMER" consume "$HANDOFF" --repo "$REPO" --repository "$REPOSITORY" > "$RESULT"
+CONSUMER_STATUS=$?
+if [ "$CONSUMER_STATUS" -ne 0 ]; then
+  cat "$RESULT"
+  exit "$CONSUMER_STATUS"
+fi
+
+node - "$RESULT" "$REPOSITORY" "$PRODUCT_HEAD" "$NORMALIZED" <<'NODE'
+const fs = require('node:fs')
+
+const [, , resultPath, expectedRepository, productHead, normalizedPath] = process.argv
+
+function fail(message) {
+  console.error(`error: accepted domain-review handoff is incompatible: ${message}`)
+  process.exit(13)
+}
+
+let result
+try {
+  result = JSON.parse(fs.readFileSync(resultPath, 'utf8'))
+} catch (error) {
+  fail(`consumer result is not valid JSON: ${error.message}`)
+}
+
+function requireString(value, label) {
+  if (typeof value !== 'string' || value.length === 0 || /[\r\n]/.test(value)) fail(`${label} is missing or multiline`)
+  return value
+}
+
+function requireDigest(value, label, lengths) {
+  requireString(value, label)
+  if (!lengths.includes(value.length) || !/^[0-9a-f]+$/.test(value)) fail(`${label} is not a lowercase hexadecimal digest`)
+  return value
+}
+
+if (result.schema_version !== 'firstmate-domain-review-consumption.v1') fail('unsupported consumer-result version')
+if (result.ok !== true || result.status !== 'accepted') fail('consumer exited successfully without an accepted result')
+if (result.review_strategy !== 'consume-existing-exact-head-domain-review') fail('unsupported review strategy')
+if (result.independent_review_required !== false) fail('consumer result requests an independent review')
+if (requireString(result.repository, 'repository identity') !== expectedRepository) {
+  fail(`repository identity ${JSON.stringify(result.repository)} does not match expected ${JSON.stringify(expectedRepository)}`)
+}
+if (requireDigest(result.product_head_sha, 'product HEAD', [40, 64]) !== productHead) {
+  fail('accepted product HEAD does not match the exact product worktree')
+}
+
+const normalized = {
+  ok: true,
+  schema_version: 'firstmate-domain-review-consumption.v1',
+  status: 'accepted',
+  receipt_sha256: requireDigest(result.receipt_sha256, 'receipt digest', [64]),
+  product_head_sha: result.product_head_sha,
+  diff_sha256: requireDigest(result.diff_sha256, 'diff digest', [64]),
+  review_mode: requireString(result.review_mode, 'review mode'),
+  quality_label: requireString(result.quality_label, 'quality label'),
+  review_strategy: result.review_strategy,
+  independent_review_required: false
+}
+
+fs.writeFileSync(normalizedPath, `${JSON.stringify(normalized, null, 2)}\n`)
+NODE
+NODE_STATUS=$?
+[ "$NODE_STATUS" -eq 0 ] || exit "$NODE_STATUS"
+
+cat "$NORMALIZED"

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -138,6 +138,7 @@ family_for_basename() {
     fm-classify-decision-key.test.sh|\
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
     fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
+    fm-domain-review-consume.test.sh|\
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-kimi-harness.test.sh|fm-muse-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
     fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
@@ -958,7 +959,7 @@ families_for_changed_path() {
       printf '%s\n' real-herdr-gated
       ;;
     bin/fm-lint.sh|bin/fm-install-shellcheck.sh|\
-    bin/fm-brief.sh|bin/fm-ensure-agents-md.sh|bin/fm-crew-state.sh|\
+    bin/fm-brief.sh|bin/fm-domain-review-consume.sh|bin/fm-ensure-agents-md.sh|bin/fm-crew-state.sh|\
     bin/fm-decision-hold.sh|bin/fm-supervision*|bin/fm-transition-lib.sh|\
     bin/fm-tmux-lib.sh|bin/fm-marker-lib.sh|bin/fm-operational-input.sh|bin/fm-tasks-axi-lib.sh|\
     bin/fm-vendor-auth-probe.sh|\
@@ -982,7 +983,8 @@ families_for_changed_path() {
       printf '%s\n' pure-contract-unit
       ;;
     .github/*|.tasks.toml|AGENTS.md|CLAUDE.md|CONTRIBUTING.md|\
-    docs/configuration.md|docs/supervision-protocols/*)
+    docs/configuration.md|docs/consumed-domain-review.md|docs/verification/consumed-domain-review.md|\
+    docs/documentation-audiences.json|docs/scripts.md|docs/architecture.md|docs/supervision-protocols/*)
       printf '%s\n' pure-contract-unit
       ;;
     tests/lib.sh|tests/*-helpers.sh)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -239,6 +239,7 @@ A ship brief records its mode as a fixed machine-readable line and the spawn ref
 `data/projects.md` records each project's standing posture and optional `+yolo` flag as the captain's default and as context for that decision, including the conditional `no-mistakes-prod-only` policy; a ship spawn that drops below the registered rigor prints a deviation notice and continues.
 `bin/fm-project-mode.sh` remains the one registry parser for the mechanical consumers that have no task in hand: fleet sync's `local-only` skip and home seeding's refusal and no-mistakes initialization.
 When a selected delivery path calls for a diff, `bin/fm-review-diff.sh` refreshes the authoritative base and, when task meta records `pr=`, always fetches and compares against `refs/pull/<n>/head` by default (recorded `pr_head=` is only an offline fallback) before falling back to the local branch with a warning.
+A versioned exact-head domain review may replace only a duplicate no-mistakes review under the conditional policy and integration boundaries in [`consumed-domain-review.md`](consumed-domain-review.md).
 For target project repos shipped through their own no-mistakes pipeline, commits under `.no-mistakes/evidence/` are the pipeline's PR-viewable validation evidence and are expected to stay in the crew branch until the evidence-hosting design changes.
 The firstmate repo itself is the exception: its `.no-mistakes/` directory is local state, stays gitignored, and is rejected by CI if tracked.
 PR-based task merges go through `bin/fm-pr-merge.sh`, which records `pr=` and any available `pr_head=` through `bin/fm-pr-check.sh` before calling `gh-axi pr merge`.
@@ -315,10 +316,11 @@ The refresh also prunes local branches whose remote is gone and that no worktree
 
 ## Self-updates stay safe
 
-`/updatefirstmate` fast-forwards the running firstmate repo and registered secondmate homes from `origin`, then re-reads updated instructions and nudges updated secondmates without touching project clones.
-For a remote route, the configured code root updates from its own origin on that host before the persistent home fast-forwards to the code-root commit.
-The update is fast-forward only: dirty, diverged, offline, and off-default targets are reported and left untouched.
-Local homes share the guarded fast-forward helper, while remote updates delegate the same safety decision to the configured host through the generic transport.
+`/updatefirstmate` compares the configured fork `origin` with canonical `https://github.com/kunchenguid/firstmate` `main`, selects a target only when one history cleanly contains the other, then re-reads updated instructions and nudges updated secondmates without touching project clones.
+This makes a fork that merely matches its own origin distinct from one that also contains the latest canonical upstream, while preserving fork-only commits whenever canonical is already their ancestor.
+Fork/canonical divergence or an unavailable source stops the update before any target moves, and dirty, locally diverged, offline, and off-default targets are reported and left untouched.
+For a remote route, the configured code root applies the same comparison on that host before the persistent home fast-forwards to the code-root commit.
+Local homes share the guarded fast-forward helper, and a standalone clone imports the exact selected commit from the primary code root before applying those same guards.
 The mechanics are owned by the `/updatefirstmate` skill and firstmate's operating manual in [`AGENTS.md`](../AGENTS.md) (self-update).
 
 ## Restart-proof

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -316,11 +316,10 @@ The refresh also prunes local branches whose remote is gone and that no worktree
 
 ## Self-updates stay safe
 
-`/updatefirstmate` compares the configured fork `origin` with canonical `https://github.com/kunchenguid/firstmate` `main`, selects a target only when one history cleanly contains the other, then re-reads updated instructions and nudges updated secondmates without touching project clones.
-This makes a fork that merely matches its own origin distinct from one that also contains the latest canonical upstream, while preserving fork-only commits whenever canonical is already their ancestor.
-Fork/canonical divergence or an unavailable source stops the update before any target moves, and dirty, locally diverged, offline, and off-default targets are reported and left untouched.
-For a remote route, the configured code root applies the same comparison on that host before the persistent home fast-forwards to the code-root commit.
-Local homes share the guarded fast-forward helper, and a standalone clone imports the exact selected commit from the primary code root before applying those same guards.
+`/updatefirstmate` fast-forwards the running firstmate repo and registered secondmate homes from `origin`, then re-reads updated instructions and nudges updated secondmates without touching project clones.
+For a remote route, the configured code root updates from its own origin on that host before the persistent home fast-forwards to the code-root commit.
+The update is fast-forward only: dirty, diverged, offline, and off-default targets are reported and left untouched.
+Local homes share the guarded fast-forward helper, while remote updates delegate the same safety decision to the configured host through the generic transport.
 The mechanics are owned by the `/updatefirstmate` skill and firstmate's operating manual in [`AGENTS.md`](../AGENTS.md) (self-update).
 
 ## Restart-proof

--- a/docs/consumed-domain-review.md
+++ b/docs/consumed-domain-review.md
@@ -1,0 +1,64 @@
+# Consumed domain reviews
+
+The agent-runtime policy for deciding whether a prior domain review may replace delivery's duplicate independent review is owned by [`consumed-domain-review`](../.agents/skills/consumed-domain-review/SKILL.md).
+This page owns the neutral extension protocol and maintainer-facing integration boundaries without copying that decision procedure.
+
+## Ownership
+
+A provider-specific consumer owns its handoff schemas, artifact integrity, evidence requirements, exact head and diff rules, modes, finding disposition, and invalidation state.
+Provider adapters, private product names, provider allowlists, and operational evidence remain with that producer or under Firstmate's gitignored home-local `config/` and `data/` surfaces.
+Tracked Firstmate core does not discover a consumer from handoff bytes or carry provider-specific semantics.
+
+[`bin/fm-domain-review-consume.sh`](../bin/fm-domain-review-consume.sh) invokes one explicitly selected external consumer and preserves its nonzero result.
+It adds Firstmate-side checks for a clean exact repository root, current product head, and the repository identity Firstmate resolved independently at intake.
+On acceptance it emits only allowlisted neutral fields, so extra provider data cannot cross into delivery by accident.
+Its header and `--help` output own the exact command and exit mechanics.
+It neither reviews code nor runs delivery.
+
+`AGENTS.md` owns the always-loaded trigger and the invariant that consumption replaces only an independent review.
+[`bin/fm-brief.sh`](../bin/fm-brief.sh) reinforces that a no-mistakes worker may omit exactly its review step only after Firstmate supplies an accepted result under the policy.
+The installed no-mistakes skill and current `axi` help remain authoritative for skip syntax, fixes, tests, documentation, lint, push, pull request creation, CI, and branch custody.
+
+## Consumer protocol
+
+Firstmate invokes the trusted executable as `<consumer> consume <handoff> --repo <exact-root> --repository <expected-identity>`.
+The handoff remains opaque to core.
+A successful consumer prints exactly one JSON object whose provider-independent fields are:
+
+```json
+{
+  "ok": true,
+  "schema_version": "firstmate-domain-review-consumption.v1",
+  "status": "accepted",
+  "repository": "independently-comparable-identity",
+  "receipt_sha256": "64 lowercase hexadecimal characters",
+  "product_head_sha": "the exact 40- or 64-character Git object id",
+  "diff_sha256": "64 lowercase hexadecimal characters",
+  "review_mode": "provider-owned nonempty label",
+  "quality_label": "provider-owned nonempty label",
+  "review_strategy": "consume-existing-exact-head-domain-review",
+  "independent_review_required": false
+}
+```
+
+The adapter rejects every other protocol version, status, strategy, repository identity, head, or digest shape.
+It allows provider-defined review and quality labels because their semantics and acceptance belong to the selected consumer, then preserves those labels visibly in the normalized result.
+Fields beyond the listed normalized result are discarded after validation rather than forwarded to the delivery worker.
+A provider that cannot emit this contract needs a provider-local adapter instead of a new core branch.
+
+The consumer executable and handoff must each be regular non-symlink files.
+Firstmate selects the consumer independently of untrusted artifact content.
+The exact worktree must be clean before provider code runs, and the accepted head must still equal that worktree's current `HEAD` after the consumer returns.
+
+## Runtime and delivery applicability
+
+The admission decision and adapter use data, process exit, Git, and JSON rather than rendered runtime output, hooks, trust dialogs, or runtime-specific skill commands.
+The same protocol therefore applies across supported primary and worker runtimes.
+The provider's review mode describes the review that produced the handoff and need not equal either runtime.
+
+Which delivery paths an accepted result affects, and what it may never change, is owned by [`consumed-domain-review`](../.agents/skills/consumed-domain-review/SKILL.md).
+
+## Verification
+
+Behavioral coverage lives in [`tests/fm-domain-review-consume.test.sh`](../tests/fm-domain-review-consume.test.sh), and active extension-contract evidence lives in [`docs/verification/consumed-domain-review.md`](verification/consumed-domain-review.md).
+Run the documentation classification check after changing any of these owner pointers.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -55,6 +55,14 @@
       "target": "docs/documentation-audiences.json"
     },
     {
+      "source": "docs/architecture.md",
+      "target": "docs/consumed-domain-review.md"
+    },
+    {
+      "source": "docs/consumed-domain-review.md",
+      "target": "docs/verification/consumed-domain-review.md"
+    },
+    {
       "source": "docs/calm.md",
       "target": "docs/calm-mode-feasibility.md"
     },
@@ -126,6 +134,10 @@
     },
     {
       "path": ".agents/skills/bootstrap-diagnostics/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
+      "path": ".agents/skills/consumed-domain-review/SKILL.md",
       "audience": "agent-runtime"
     },
     {
@@ -241,6 +253,10 @@
       "audience": "operator-current"
     },
     {
+      "path": "docs/consumed-domain-review.md",
+      "audience": "maintainer-architecture"
+    },
+    {
       "path": "docs/decision-hold-lifecycle.md",
       "audience": "maintainer-architecture"
     },
@@ -327,6 +343,10 @@
     {
       "path": "docs/turnend-guard.md",
       "audience": "operator-current"
+    },
+    {
+      "path": "docs/verification/consumed-domain-review.md",
+      "audience": "maintainer-verification"
     },
     {
       "path": "docs/verification/dispatch-auth.md",

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -62,7 +62,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-config-push.sh`      | Push declared inherited local material to live local or remote secondmates and send the placement-specific config reread when changed |
 | `fm-project-mode.sh`     | Resolve a project's registered delivery posture from `data/projects.md` for fleet sync and home seeding |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval            |
-| `fm-domain-review-consume.sh` | Delegate exact-head receipt validation to its domain producer and enforce Firstmate's independently resolved repository identity |
+| `fm-domain-review-consume.sh` | Delegate an exact-head domain-review handoff to the selected external consumer and enforce Firstmate's clean exact head and independently resolved repository identity |
 | `fm-review-diff.sh`      | Review a crewmate branch or resolved PR head against the authoritative base          |
 | `fm-marker-lib.sh`       | Compatibility entry point for the from-firstmate carrier owned by `fm-operational-input.sh` |
 | `fm-pending-reply-lib.sh` | Parent-owned secondmate pending-reply expectations, recovery, and keyed escalation lifecycle |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -17,7 +17,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-fleet-snapshot.sh`   | Print the read-only structured fleet snapshot JSON (schema `fm-fleet-snapshot.v1`)   |
 | `fm-fleet-view.sh`       | Render the fleet snapshot as a human Markdown view                                   |
 | `fm-bearings-snapshot.sh` | Project the fleet snapshot to the compact TOON bearings view; local-only unless `--include-prs` |
-| `fm-update.sh`           | Fast-forward-only self-update of firstmate and local or remote secondmate homes       |
+| `fm-update.sh`           | Compare fork and canonical sources, then fast-forward firstmate and secondmate homes only to their shared descendant |
 | `fm-on.sh`               | Execute one tracked Firstmate command in a configured remote secondmate home, using its job worker except for the doctor bootstrap |
 | `fm-remote-job-lib.sh`   | Shared bounded remote job queue, worker readiness, LaunchAgent contract, and filesystem-composed PATH |
 | `fm-remote-job-worker.sh` | Long-lived remote queue worker for tracked `fm-*.sh` commands in the account runtime |
@@ -49,6 +49,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-remote-home-seed.sh` | Register and provision a whole secondmate home on an SSH-reachable host              |
 | `fm-remote-readiness-lib.sh` | Shared remote second-mate readiness gate: check and, when needed, repair then re-check through `fm-remote-doctor.sh` |
 | [`fm-project-origin-lib.sh`](../bin/fm-project-origin-lib.sh) | Accepted origin-form owner shared by both remote provisioning boundaries |
+| `fm-stow-cascade.sh`     | Enumerate this home's registered secondmates for an internal `/stow` cascade: per-home budget accounting and how the sweep reaches each home |
 | `fm-spawn.sh`            | Spawn crewmates, scouts, `id=repo` batches, and secondmates on the resolved harness and runtime backend |
 | `fm-backend.sh`          | Runtime-backend selection, meta helpers, selector resolution, and operation dispatch |
 | `fm-backend-hometag-lib.sh` | Shared per-installation home-tag derivation for zellij tab and cmux workspace titles |
@@ -61,6 +62,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-config-push.sh`      | Push declared inherited local material to live local or remote secondmates and send the placement-specific config reread when changed |
 | `fm-project-mode.sh`     | Resolve a project's registered delivery posture from `data/projects.md` for fleet sync and home seeding |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval            |
+| `fm-domain-review-consume.sh` | Delegate exact-head receipt validation to its domain producer and enforce Firstmate's independently resolved repository identity |
 | `fm-review-diff.sh`      | Review a crewmate branch or resolved PR head against the authoritative base          |
 | `fm-marker-lib.sh`       | Compatibility entry point for the from-firstmate carrier owned by `fm-operational-input.sh` |
 | `fm-pending-reply-lib.sh` | Parent-owned secondmate pending-reply expectations, recovery, and keyed escalation lifecycle |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -17,7 +17,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-fleet-snapshot.sh`   | Print the read-only structured fleet snapshot JSON (schema `fm-fleet-snapshot.v1`)   |
 | `fm-fleet-view.sh`       | Render the fleet snapshot as a human Markdown view                                   |
 | `fm-bearings-snapshot.sh` | Project the fleet snapshot to the compact TOON bearings view; local-only unless `--include-prs` |
-| `fm-update.sh`           | Compare fork and canonical sources, then fast-forward firstmate and secondmate homes only to their shared descendant |
+| `fm-update.sh`           | Fast-forward-only self-update of firstmate and local or remote secondmate homes       |
 | `fm-on.sh`               | Execute one tracked Firstmate command in a configured remote secondmate home, using its job worker except for the doctor bootstrap |
 | `fm-remote-job-lib.sh`   | Shared bounded remote job queue, worker readiness, LaunchAgent contract, and filesystem-composed PATH |
 | `fm-remote-job-worker.sh` | Long-lived remote queue worker for tracked `fm-*.sh` commands in the account runtime |

--- a/docs/verification/consumed-domain-review.md
+++ b/docs/verification/consumed-domain-review.md
@@ -36,5 +36,39 @@ Expected guarantees are:
 
 ## Recorded result
 
-Refresh this section with the exact final-head output from the commands above whenever the extension contract changes.
+Recorded on Darwin 26.5.2 (arm64) with GNU bash 3.2.57, jq 1.7.1, and ShellCheck 0.11.0 (the version `bin/fm-lint.sh` pins).
+Every consumer in these cases is a fake executable, so no provider adapter, private handoff, or provider evidence is involved.
+
+```console
+$ bin/fm-test-run.sh tests/fm-domain-review-consume.test.sh
+ok - matching exact-head result is consumed without forwarding provider-private fields
+ok - matching code cannot consume a result for another repository identity
+ok - accepted results are bound to the exact current product HEAD
+ok - dirty product worktrees stop before provider code runs
+ok - the exact clean head binding is re-checked after the consumer returns
+ok - an unadopted protocol version cannot broaden policy
+ok - provider-owned review labels remain visible without private core semantics
+ok - blocked, invalidated, and error consumer outcomes remain non-consumable
+FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0
+```
+
+```console
+$ bin/fm-test-run.sh tests/fm-brief.test.sh
+ok - fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe
+ok - fm-brief.sh: faster paths use configured authority without stacked review
+FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0
+$ bin/fm-test-run.sh tests/fm-documentation-audiences.test.sh
+ok - documentation inventory classifies every maintained prose surface exactly once
+ok - classification, setup routing, and maintained-prose scope fail safely
+ok - required documentation owner pointers cannot silently disappear
+ok - local links resolve while dates, versions, commands, and incident prose remain semantically reviewed
+FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0
+$ bin/fm-doc-audience-check.sh
+fm-doc-audience-check: ok surfaces=70 local_links=251
+$ bin/fm-lint.sh
+fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
+```
+
+`tests/fm-brief.test.sh` covers the brief contract far beyond this extension, so only the two assertions this record depends on are reproduced above: the first owns the approved single-step skip wording, and the second holds direct-PR and local-only briefs free of any consumption step.
+Re-run every command above and refresh this section whenever the extension contract changes.
 The private task audit retains task chronology and provider-specific migration evidence; neither belongs in this upstream-facing maintainer record.

--- a/docs/verification/consumed-domain-review.md
+++ b/docs/verification/consumed-domain-review.md
@@ -24,7 +24,8 @@ Expected guarantees are:
 
 - a trusted external consumer receives the opaque handoff, exact clean product root, and independently resolved repository identity;
 - an accepted result passes only when its neutral protocol version, repository identity, current product head, strategy, and digest shapes match;
-- a dirty product worktree stops before external provider code runs;
+- a dirty product worktree stops before external provider code runs, and a worktree the consumer moved or dirtied stops before any accepted result is emitted;
+- an unreadable worktree state refuses instead of admitting an unverified tree;
 - a repository mismatch, stale accepted head, incompatible protocol version, malformed result, or nonaccepted outcome cannot authorize a review skip;
 - provider-owned review and quality labels remain visible without a provider-specific core allowlist;
 - provider-private fields beyond the normalized protocol are not forwarded;

--- a/docs/verification/consumed-domain-review.md
+++ b/docs/verification/consumed-domain-review.md
@@ -1,0 +1,39 @@
+# Consumed domain-review verification
+
+- **Evidence date:** 2026-08-13
+- **Extension contract:** `firstmate-domain-review-consumption.v1`
+
+## Scope
+
+This record verifies the neutral boundary between Firstmate delivery and an explicitly selected external domain-review consumer.
+Provider-specific adapters, schemas, identities, findings, and evidence remain outside tracked core and are intentionally not recorded here.
+
+## Commands
+
+Run the focused behavior and documentation checks with:
+
+```sh
+bin/fm-test-run.sh tests/fm-domain-review-consume.test.sh
+bin/fm-test-run.sh tests/fm-brief.test.sh
+bin/fm-test-run.sh tests/fm-documentation-audiences.test.sh
+bin/fm-doc-audience-check.sh
+bin/fm-lint.sh
+```
+
+Expected guarantees are:
+
+- a trusted external consumer receives the opaque handoff, exact clean product root, and independently resolved repository identity;
+- an accepted result passes only when its neutral protocol version, repository identity, current product head, strategy, and digest shapes match;
+- a dirty product worktree stops before external provider code runs;
+- a repository mismatch, stale accepted head, incompatible protocol version, malformed result, or nonaccepted outcome cannot authorize a review skip;
+- provider-owned review and quality labels remain visible without a provider-specific core allowlist;
+- provider-private fields beyond the normalized protocol are not forwarded;
+- consumer blocked, invalidated, and error exits and output remain unchanged;
+- a no-mistakes brief permits only an explicit policy-approved skip of the duplicate review step and retains every other pipeline stage;
+- direct-PR and local-only briefs gain no review or skip behavior;
+- every maintained prose surface and owner pointer remains classified.
+
+## Recorded result
+
+Refresh this section with the exact final-head output from the commands above whenever the extension contract changes.
+The private task audit retains task chronology and provider-specific migration evidence; neither belongs in this upstream-facing maintainer record.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -312,10 +312,14 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
     "local-only brief retained a personal review stacked on the selected delivery path"
   assert_no_grep "make \`--intent\` preserve all relevant content from this brief" "$home/data/$id/brief.md" \
     "local-only brief must not include the no-mistakes --intent contract"
+  assert_no_grep "consumed-domain-review" "$home/data/$id/brief.md" \
+    "local-only brief must not invent a review-consumption step"
   id="brief-direct-intent-a4"
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" direct-proj --mode direct-PR >/dev/null 2>&1
   assert_no_grep "make \`--intent\` preserve all relevant content from this brief" "$home/data/$id/brief.md" \
     "direct-PR brief must not include the no-mistakes --intent contract"
+  assert_no_grep "consumed-domain-review" "$home/data/$id/brief.md" \
+    "direct-PR brief must not invent a review-consumption step"
   pass "fm-brief.sh: faster paths use configured authority without stacked review"
 }
 
@@ -345,6 +349,12 @@ test_no_mistakes_dod_wording() {
     "no-mistakes DOD must keep direct requirements and exclude generic scaffold boilerplate from --intent"
   assert_grep "exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific" "$brief" \
     "no-mistakes DOD must exclude non-task-specific scaffold boilerplate from --intent"
+  assert_grep "Only when Firstmate explicitly supplies an accepted result under its \`consumed-domain-review\` policy" "$brief" \
+    "no-mistakes DOD must require Firstmate's accepted receipt decision"
+  assert_grep "skip exactly the duplicate \`review\` step" "$brief" \
+    "consumed review must replace only the independent review step"
+  assert_grep "never infer receipt validity or omit another step" "$brief" \
+    "consumed review wording must retain every non-review delivery step"
   # The apostrophe in "firstmate's authority check" is now structurally safe
   # (no `$(...)` wrapper around the heredoc), so it renders verbatim instead of
   # being reworded or escaped away. test_no_heredoc_in_command_substitution

--- a/tests/fm-domain-review-consume.test.sh
+++ b/tests/fm-domain-review-consume.test.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# Behavior tests for the neutral domain-review consumer extension point.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SUBJECT="$ROOT/bin/fm-domain-review-consume.sh"
+TMP_ROOT=$(fm_test_tmproot fm-domain-review-consume)
+
+make_repo() {
+  local repo=$1
+  mkdir -p "$repo"
+  git -C "$repo" init -q
+  git -C "$repo" config user.email test@example.com
+  git -C "$repo" config user.name Test
+  printf '%s\n' fixture > "$repo/file.txt"
+  git -C "$repo" add file.txt
+  git -C "$repo" commit -qm fixture
+}
+
+write_consumer() {
+  local path=$1
+  cat > "$path" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >> "${FAKE_CONSUMER_LOG:?}"
+case "${FAKE_CONSUMER_RESULT:-accepted}" in
+  accepted)
+    cat <<JSON
+{
+  "ok": true,
+  "schema_version": "${FAKE_SCHEMA:-firstmate-domain-review-consumption.v1}",
+  "status": "accepted",
+  "repository": "${FAKE_REPOSITORY:-example/product}",
+  "receipt_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "product_head_sha": "${FAKE_PRODUCT_HEAD:?}",
+  "diff_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "review_mode": "${FAKE_REVIEW_MODE:-provider-full}",
+  "quality_label": "${FAKE_QUALITY_LABEL:-full}",
+  "review_strategy": "consume-existing-exact-head-domain-review",
+  "independent_review_required": false,
+  "private_finding": "must not cross the extension boundary"
+}
+JSON
+    exit 0
+    ;;
+  blocked)
+    printf '%s\n' '{"ok":false,"status":"blocked","reason":"review-findings-unresolved"}'
+    exit 11
+    ;;
+  invalidated)
+    printf '%s\n' '{"ok":false,"status":"invalidated","reason":"product-head-changed"}'
+    exit 12
+    ;;
+  error)
+    printf '%s\n' '{"ok":false,"error":{"code":"CONTRACT_INVALID"}}'
+    exit 23
+    ;;
+esac
+SH
+  chmod +x "$path"
+}
+
+new_case() {
+  local name=$1 dir
+  dir="$TMP_ROOT/$name"
+  mkdir -p "$dir/run"
+  dir=$(CDPATH='' cd -- "$dir" && pwd -P)
+  make_repo "$dir/product"
+  printf '%s\n' opaque-provider-artifact > "$dir/run/handoff.json"
+  write_consumer "$dir/consumer"
+  : > "$dir/consumer.log"
+  printf '%s\n' "$dir"
+}
+
+run_case() {
+  local dir=$1 expected=${2:-example/product}
+  shift 2 || true
+  FAKE_CONSUMER_LOG="$dir/consumer.log" \
+    FAKE_PRODUCT_HEAD="$(git -C "$dir/product" rev-parse HEAD)" "$@" "$SUBJECT" \
+    --consumer "$dir/consumer" \
+    --handoff "$dir/run/handoff.json" \
+    --repo "$dir/product" \
+    --repository "$expected"
+}
+
+test_matching_accepted_result_is_consumed() {
+  local dir out
+  dir=$(new_case accepted)
+  out=$(run_case "$dir" example/product env)
+  assert_contains "$out" '"schema_version": "firstmate-domain-review-consumption.v1"' \
+    "matching result did not preserve the neutral protocol"
+  assert_contains "$out" '"status": "accepted"' "matching result was not accepted"
+  assert_contains "$(cat "$dir/consumer.log")" \
+    "consume $dir/run/handoff.json --repo $dir/product --repository example/product" \
+    "extension point did not pass the exact inputs to the external consumer"
+  assert_not_contains "$out" "private_finding" \
+    "provider-private fields crossed the allowlisted extension boundary"
+  pass "matching exact-head result is consumed without forwarding provider-private fields"
+}
+
+test_repository_identity_mismatch_is_refused() {
+  local dir out rc
+  dir=$(new_case repository-mismatch)
+  set +e
+  out=$(run_case "$dir" other/product env 2>&1)
+  rc=$?
+  set -e
+  expect_code 13 "$rc" "repository mismatch must use the integration-refusal exit"
+  assert_contains "$out" 'repository identity "example/product" does not match expected "other/product"' \
+    "repository mismatch did not explain both identities"
+  pass "matching code cannot consume a result for another repository identity"
+}
+
+test_changed_head_is_refused() {
+  local dir out rc stale_head
+  dir=$(new_case changed-head)
+  stale_head=$(git -C "$dir/product" rev-parse HEAD)
+  printf '%s\n' changed > "$dir/product/file.txt"
+  git -C "$dir/product" add file.txt
+  git -C "$dir/product" commit -qm changed
+  set +e
+  out=$(FAKE_CONSUMER_LOG="$dir/consumer.log" FAKE_PRODUCT_HEAD="$stale_head" "$SUBJECT" \
+    --consumer "$dir/consumer" --handoff "$dir/run/handoff.json" \
+    --repo "$dir/product" --repository example/product 2>&1)
+  rc=$?
+  set -e
+  expect_code 13 "$rc" "stale accepted head must be refused"
+  assert_contains "$out" 'accepted product HEAD does not match the exact product worktree' \
+    "stale accepted head refusal was not actionable"
+  pass "accepted results are bound to the exact current product HEAD"
+}
+
+test_dirty_worktree_is_refused_before_consumer() {
+  local dir out rc
+  dir=$(new_case dirty)
+  printf '%s\n' dirty >> "$dir/product/file.txt"
+  set +e
+  out=$(run_case "$dir" example/product env 2>&1)
+  rc=$?
+  set -e
+  expect_code 13 "$rc" "dirty worktree must be refused"
+  assert_contains "$out" 'product worktree must be clean' "dirty refusal was not actionable"
+  [ ! -s "$dir/consumer.log" ] || fail "consumer ran against a dirty product worktree"
+  pass "dirty product worktrees stop before provider code runs"
+}
+
+test_incompatible_accepted_version_is_refused() {
+  local dir out rc
+  dir=$(new_case incompatible-version)
+  set +e
+  out=$(run_case "$dir" example/product env FAKE_SCHEMA=firstmate-domain-review-consumption.v2 2>&1)
+  rc=$?
+  set -e
+  expect_code 13 "$rc" "unsupported accepted-result version must be refused"
+  assert_contains "$out" 'unsupported consumer-result version' \
+    "unsupported version refusal was not actionable"
+  pass "an unadopted protocol version cannot broaden policy"
+}
+
+test_provider_labels_remain_visible_without_core_allowlist() {
+  local dir out
+  dir=$(new_case provider-labels)
+  out=$(run_case "$dir" example/product env \
+    FAKE_REVIEW_MODE=specialized-reduced FAKE_QUALITY_LABEL=reduced-provider)
+  assert_contains "$out" '"review_mode": "specialized-reduced"' \
+    "provider review mode was not preserved"
+  assert_contains "$out" '"quality_label": "reduced-provider"' \
+    "provider quality label was not preserved"
+  pass "provider-owned review labels remain visible without private core semantics"
+}
+
+test_nonaccepted_consumer_results_are_preserved() {
+  local result expected dir out rc
+  while IFS='|' read -r result expected; do
+    dir=$(new_case "$result")
+    set +e
+    out=$(run_case "$dir" example/product env FAKE_CONSUMER_RESULT="$result" 2>&1)
+    rc=$?
+    set -e
+    expect_code "$expected" "$rc" "$result consumer result changed exit status"
+    assert_contains "$out" "\"status\":\"$result\"" "$result consumer JSON was not preserved"
+  done <<'ROWS'
+blocked|11
+invalidated|12
+ROWS
+
+  dir=$(new_case provider-error)
+  set +e
+  out=$(run_case "$dir" example/product env FAKE_CONSUMER_RESULT=error 2>&1)
+  rc=$?
+  set -e
+  expect_code 23 "$rc" "consumer contract error changed exit status"
+  assert_contains "$out" '"code":"CONTRACT_INVALID"' "consumer error JSON was not preserved"
+  pass "blocked, invalidated, and error consumer outcomes remain non-consumable"
+}
+
+test_matching_accepted_result_is_consumed
+test_repository_identity_mismatch_is_refused
+test_changed_head_is_refused
+test_dirty_worktree_is_refused_before_consumer
+test_incompatible_accepted_version_is_refused
+test_provider_labels_remain_visible_without_core_allowlist
+test_nonaccepted_consumer_results_are_preserved

--- a/tests/fm-domain-review-consume.test.sh
+++ b/tests/fm-domain-review-consume.test.sh
@@ -25,6 +25,14 @@ write_consumer() {
 #!/usr/bin/env bash
 set -u
 printf '%s\n' "$*" >> "${FAKE_CONSUMER_LOG:?}"
+case "${FAKE_CONSUMER_MUTATE:-none}" in
+  commit)
+    printf '%s\n' consumer-moved > "${FAKE_CONSUMER_REPO:?}/file.txt"
+    git -C "${FAKE_CONSUMER_REPO:?}" add file.txt
+    git -C "${FAKE_CONSUMER_REPO:?}" commit -qm consumer-moved
+    ;;
+  dirty) printf '%s\n' consumer-dirtied >> "${FAKE_CONSUMER_REPO:?}/file.txt" ;;
+esac
 case "${FAKE_CONSUMER_RESULT:-accepted}" in
   accepted)
     cat <<JSON
@@ -146,6 +154,26 @@ test_dirty_worktree_is_refused_before_consumer() {
   pass "dirty product worktrees stop before provider code runs"
 }
 
+test_worktree_moved_by_consumer_is_refused() {
+  local mutation message dir out rc
+  while IFS='|' read -r mutation message; do
+    dir=$(new_case "consumer-$mutation")
+    set +e
+    out=$(run_case "$dir" example/product env \
+      FAKE_CONSUMER_REPO="$dir/product" FAKE_CONSUMER_MUTATE="$mutation" 2>&1)
+    rc=$?
+    set -e
+    expect_code 13 "$rc" "a consumer that $mutation the product worktree must be refused"
+    assert_contains "$out" "$message" "post-consumer refusal was not actionable"
+    assert_not_contains "$out" '"status": "accepted"' \
+      "an unbound worktree still produced an accepted delivery result"
+  done <<'ROWS'
+commit|product HEAD moved during domain-review consumption
+dirty|product worktree must be clean after domain-review consumption
+ROWS
+  pass "the exact clean head binding is re-checked after the consumer returns"
+}
+
 test_incompatible_accepted_version_is_refused() {
   local dir out rc
   dir=$(new_case incompatible-version)
@@ -200,6 +228,7 @@ test_matching_accepted_result_is_consumed
 test_repository_identity_mismatch_is_refused
 test_changed_head_is_refused
 test_dirty_worktree_is_refused_before_consumer
+test_worktree_moved_by_consumer_is_refused
 test_incompatible_accepted_version_is_refused
 test_provider_labels_remain_visible_without_core_allowlist
 test_nonaccepted_consumer_results_are_preserved


### PR DESCRIPTION
api_response:
  body: "## Intent\n\nAdd a narrow provider-neutral extension point for consuming an already completed exact-head domain review as the review input to no-mistakes delivery without carrying any company, product, provider, repository, evidence, or strategy semantics in canonical Firstmate. Use one explicitly selected trusted external consumer and an opaque private handoff; enforce a clean exact repository root, independently resolved repository identity, exact current HEAD, versioned neutral JSON, digest shapes, nonaccepted exit preservation, and allowlisted output that discards extra provider-private fields. Consumption may skip exactly the duplicate no-mistakes review step and must preserve fixes, tests, documentation, lint, branch custody, push, PR creation, CI, captain decisions, red-PR prohibition, merge authority, and invalidation after any change. Keep the policy and protocol with one authoritative owner, add concise triggers and inventories, cover behavior only through public executable and generated-brief interfaces across delivery paths and provider-defined labels, follow Firstmate coding and documentation rules, and ship a green canonical Firstmate PR without merging it.\n\n## What Changed\n\n- Adds `bin/fm-domain-review-consume.sh`, which invokes one explicitly selected trusted external consumer with an opaque handoff and validates the result Firstmate-side: regular non-symlink consumer and handoff files, an exact clean repository root, independently resolved repository identity, exact current `HEAD` (re-bound after the consumer returns), the `firstmate-domain-review-consumption.v1` schema/status/strategy, and digest shapes — preserving nonaccepted exit codes and emitting only allowlisted neutral fields so provider-private data is discarded.\n- Wires the policy into the always-loaded surfaces: an `AGENTS.md` trigger plus the new `.agents/skills/consumed-domain-review/SKILL.md` owner (consumption may replace exactly the duplicate no-mistakes review step and nothing else), and `bin/fm-brief.sh` now renders that review-consumption line in generated briefs across delivery modes.\n- Documents the protocol and integration boundaries in `docs/consumed-domain-review.md`, `docs/verification/consumed-domain-review.md`, and the architecture/scripts/audience inventories; adds behavior coverage through the public executable and brief interfaces in `tests/fm-domain-review-consume.test.sh` and `tests/fm-brief.test.sh`, registered in `bin/fm-test-run.sh`.\n\nPipeline review flagged an unrelated self-update doc rewrite and a head/cleanliness rebind gap; both were auto-fixed on the branch, and the recorded verification evidence in `docs/verification/consumed-domain-review.md` was filled in from the final head. Test, lint, and document phases pass.\n\n## Risk Assessment\n\n✅ Low: All three previously accepted findings are correctly fixed with matching test and verification-doc coverage, the unrelated self-update doc rewrite is fully reverted so the change is now confined to the neutral extension point, and no new defect is present in the added helper or its call sites.\n\n## Testing\n\nRan the focused behavior suite for the new consumer plus the brief and documentation-audience suites (all green), then manually drove `bin/fm-domain-review-consume.sh` end-to-end against a real fixture git repo and a stand-in external provider consumer: the accepted path returned only the neutral allowlisted JSON with the provider's private findings and evidence paths stripped, while repository mismatch, dirty worktree, post-review HEAD movement, and a non-accepted status each refused with exit 13, and a consumer exiting 12 had its output and exit code preserved unchanged. I also generated real briefs for all three delivery modes and confirmed the single policy-gated skip sentence appears only on the no-mistakes path with the surrounding delivery steps intact. Both CLI transcripts are saved as evidence; no linters or static analysis were run, and the temporary fixture repo was rem"
  truncated: true
  original_length: 17390
