### PR TITLE
fix(backend): stop reading every dead tmux endpoint as alive

### DIFF
--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -828,14 +828,23 @@ fm_backend_composer_state() {  # <backend> <target> [expected-label] -> empty|pe
 # probe). A gone tmux window or an unqueryable herdr pane (server down, pane
 # closed), missing zellij pane, or unreadable Orca terminal simply fails, which
 # IS "does not exist" for this purpose.
-# Mirrors fm-crew-state.sh's pane_readable check; exists here as one shared
-# primitive so callers that only need a fast alive/dead read (recovery
-# digests, the session-start fleet digest) do not re-derive it inline.
+# The one owner of that probe: fm-crew-state.sh's pane_readable calls straight
+# into this for tmux rather than keeping its own copy, so callers that need a
+# fast alive/dead read (recovery digests, the session-start fleet digest) never
+# re-derive it inline and the two can never drift apart again.
 fm_backend_target_exists() {  # <backend> <target> [expected-label]
   local backend=$1 target=$2 expected_label=${3:-} session pane
   case "$backend" in
     tmux)
-      tmux display-message -p -t "$target" '#{pane_id}' >/dev/null 2>&1
+      # list-panes, NOT display-message: display-message is an informational
+      # command that falls back to the CALLER'S OWN pane and exits 0 when the
+      # target does not resolve, so it answers "yes" for a missing window, a
+      # missing session, and a bogus window id alike (verified on tmux 3.7b).
+      # That made every dead endpoint read alive after a tmux server crash,
+      # because a restarted firstmate recreates the `firstmate` session the
+      # recorded targets name. list-panes asks the question this check actually
+      # means - is there a pane there - and fails when there is not.
+      tmux list-panes -t "$target" >/dev/null 2>&1
       ;;
     herdr)
       fm_backend_source herdr || return 1

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -144,12 +144,15 @@ LOG_VERB=$(status_line_verb "$LOG_LINE")
 # state (e.g. done) instead of being masked as unknown. Backend-aware
 # (fm_backend_of_meta defaults absent backend= to tmux, the P1 contract): a
 # herdr task is read through fm_backend_capture instead of a bare tmux probe.
+# The tmux probe itself is NOT restated here - it delegates to the one owner,
+# fm_backend_target_exists (bin/fm-backend.sh), which explains why that probe
+# cannot be `tmux display-message`.
 TASK_BACKEND=$(fm_backend_of_meta "$META")
 BACKEND_TARGET=$(fm_backend_target_of_meta "$META")
 EXPECTED_LABEL="fm-$ID"
 pane_readable() {  # <target>
   case "$TASK_BACKEND" in
-    tmux) tmux display-message -p -t "$1" '#{pane_id}' >/dev/null 2>&1 ;;
+    tmux) fm_backend_target_exists tmux "$1" ;;
     *) fm_backend_capture "$TASK_BACKEND" "$1" 1 "$EXPECTED_LABEL" >/dev/null 2>&1 ;;
   esac
 }

--- a/tests/fm-backend-tmux-smoke.test.sh
+++ b/tests/fm-backend-tmux-smoke.test.sh
@@ -73,6 +73,34 @@ if fm_backend_tmux_create_task "$SESSION" "$WINDOW" "$HOME" 2>/dev/null; then
 fi
 pass "real tmux: fm_backend_tmux_create_task creates a window and refuses a duplicate"
 
+# --- target_exists must DISCRIMINATE -----------------------------------------
+# The regression this pins: fm_backend_target_exists (and, through it,
+# fm-crew-state.sh's pane_readable) once probed with
+# `tmux display-message -p -t "$target" '#{pane_id}'`. display-message is an
+# informational command that falls back to the CALLER'S OWN pane and exits 0
+# when the target does not resolve, making the predicate very nearly
+# unconditionally true. A tmux server crash therefore left every dead crew
+# reading `endpoint: alive`, because the restarted firstmate recreates the
+# session its recorded targets name.
+#
+# Both directions matter, and the negative one is the whole bug: a window that
+# does NOT exist INSIDE A SESSION THAT DOES must not read as existing. Assert
+# it here with a real server so no future refactor can quietly reintroduce a
+# probe that answers yes to everything.
+fm_backend_target_exists tmux "$TARGET" \
+  || fail "fm_backend_target_exists must find the live window '$TARGET'"
+pass "real tmux: fm_backend_target_exists finds a window that exists"
+
+if fm_backend_target_exists tmux "$SESSION:fm-does-not-exist"; then
+  fail "fm_backend_target_exists reported a missing window inside the live session '$SESSION' as existing"
+fi
+pass "real tmux: fm_backend_target_exists rejects a missing window inside a session that DOES exist"
+
+if fm_backend_target_exists tmux "no-such-session-xyz:$WINDOW"; then
+  fail "fm_backend_target_exists reported a window in a wholly missing session as existing"
+fi
+pass "real tmux: fm_backend_target_exists rejects a window in a session that does not exist"
+
 # --- send text + Enter -------------------------------------------------------
 
 # A newly-created interactive shell can exist before its startup files and line
@@ -161,6 +189,9 @@ pass "real tmux: fm_backend_tmux_resolve_bare_selector fails for a window that d
 fm_backend_tmux_kill "$TARGET"
 if tmux list-windows -t "$SESSION" -F '#{window_name}' 2>/dev/null | grep -qx "$WINDOW"; then
   fail "fm_backend_tmux_kill did not remove the window"
+fi
+if fm_backend_target_exists tmux "$TARGET"; then
+  fail "fm_backend_target_exists still reports the killed window '$TARGET' as existing"
 fi
 state=$(fm_backend_agent_state tmux "$TARGET")
 [ "$state" = missing ] \

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -83,6 +83,13 @@ SH
 #!/usr/bin/env bash
 set -u
 case "${1:-}" in
+  list-panes)
+    # The endpoint-liveness primitive (fm_backend_target_exists, which
+    # fm-crew-state.sh's pane_readable calls for tmux). Honors the same
+    # missing-endpoint switch as display-message: a fake that succeeded for
+    # every target could only ever confirm the alive case.
+    [ "${FM_FAKE_TMUX_MISSING:-0}" = 1 ] && exit 1
+    printf '0: [80x24] [history 0/2000, 0 bytes] %%1 (active)\n' ;;
   display-message)
     [ "${FM_FAKE_TMUX_MISSING:-0}" = 1 ] && exit 1
     printf '%%1\n' ;;

--- a/tests/fm-send-strict.test.sh
+++ b/tests/fm-send-strict.test.sh
@@ -40,6 +40,22 @@ case "${1:-}" in
       exit 1
     fi
     exit 0 ;;
+  list-panes)
+    # The endpoint-liveness primitive (fm_backend_target_exists). Honors the
+    # same dead-target switch as display-message below: a fake that answered
+    # yes for every target could only ever confirm the alive case.
+    target=
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        -t) target=$2; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    if [ -n "${FM_FAKE_TMUX_DEAD_TARGET:-}" ] && [ "$target" = "$FM_FAKE_TMUX_DEAD_TARGET" ]; then
+      exit 1
+    fi
+    printf '0: [80x24] [history 0/2000, 0 bytes] %%1 (active)\n'
+    exit 0 ;;
   display-message)
     target=
     cursor=0

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -290,16 +290,18 @@ SH
   chmod +x "$fakebin/ps"
 }
 
-# make_fake_tmux <fakebin> <live-target>: display-message succeeds only for
-# the given "session:window" target - the exact primitive
+# make_fake_tmux <fakebin> <live-target>: list-panes succeeds only for the
+# given "session:window" target - the exact primitive
 # fm_backend_target_exists uses for a tmux endpoint liveness read.
+# display-message keeps the same rule so the fixture stays coherent, but the
+# liveness verdict is read from list-panes.
 make_fake_tmux() {
   local fakebin=$1 live=$2
   cat > "$fakebin/tmux" <<SH
 #!/usr/bin/env bash
 set -u
 case "\${1:-}" in
-  display-message)
+  list-panes|display-message)
     target=""
     prev=""
     for a in "\$@"; do
@@ -332,6 +334,17 @@ mate_home=${FM_FAKE_SECOND_MATE_HOME:?}
 mate_id=${FM_FAKE_SECOND_MATE_ID:?}
 mate_window="fm-$mate_id"
 case "${1:-}" in
+  list-panes)
+    # The endpoint-liveness primitive (fm_backend_target_exists). Its presence
+    # answer mirrors the list-windows inventory below rather than
+    # display-message's active-window fallback, so a recorded window that is
+    # genuinely absent reads as absent.
+    [ -e "$spawned" ] && exit 0
+    if [ ! -e "$killed" ] && { [ "$mode" = ambiguous ] || [ "$mode" = shell ]; }; then
+      exit 0
+    fi
+    exit 1
+    ;;
   display-message)
     target=
     format=


### PR DESCRIPTION
## The defect

The tmux endpoint-liveness probe was `tmux display-message -p -t "$target" '#{pane_id}'`.

`display-message` is an informational command, not a query.
When its target does not resolve it falls back to the **caller's own current pane** and still exits 0:

```
$ tmux display-message -p -t "=firstmate:=fm-does-not-exist" '#{pane_id}'
%0            <- exit 0, and %0 is the asking pane
```

Measured on tmux 3.7b, it succeeds for a missing window, for a window in a session that does not exist at all, and for a bogus window id.
As a predicate it is very nearly unconditionally true.

The consequence is silent and only surfaces after a crash.
A tmux server crash takes every crewmate with it; the restarted firstmate then recreates a session named `firstmate`, so every recorded `firstmate:fm-<task>` target resolves to the new session's own pane.
Observed live: the session-start fleet digest reported all six dead workers as `endpoint: alive`, `bin/fm-crew-state.sh` reported three of them as actively `working`, and nothing was routed into recovery.

## The fix

Probe with `tmux list-panes -t "$target"` instead.

| Predicate | Missing window | Real window |
|---|---|---|
| `display-message -p -t` | **wrongly succeeds** | succeeds |
| `has-session -t` | correctly fails | succeeds |
| `list-panes -t` | correctly fails | succeeds |

`list-panes` was chosen over `has-session` because it asks the question the caller actually means - is there a pane there - and it discriminates correctly on every target form firstmate records, including bare window ids (`@N`) and wholly missing sessions, where a session-existence check is the wrong question.
The existing exact-match target construction is unchanged; the target string is still passed through verbatim.

The defect had two call sites, kept in agreement only by a `Mirrors fm-backend.sh's ...` comment.
`bin/fm-crew-state.sh`'s `pane_readable` now calls `fm_backend_target_exists` directly for tmux instead of holding a second copy, so the two cannot drift apart again.

## Coverage

`tests/fm-backend-tmux-smoke.test.sh` - the repo's one suite that talks to a real tmux server, isolated on a private socket - now asserts both directions:

- a window that exists reads as existing,
- a window that does **not** exist **inside a session that does** reads as not existing,
- a window in a wholly missing session reads as not existing,
- a window that was real and has been killed reads as not existing.

The second case is the whole defect and is what a future refactor must not regress.
Verified the test genuinely catches it: reverting only the probe to `display-message` fails on
`fm_backend_target_exists reported a missing window inside the live session 'smoke' as existing`.

Three fake `tmux` fixtures (`fm-send-strict`, `fm-crew-state`, `fm-session-start`) modelled only `display-message` and fell through to `exit 0` for every other subcommand, so under a correct probe they answered "alive" for targets their own tests intended to be dead.
They now model `list-panes` with the same liveness rule each fixture already applied to `display-message`.

`fm_backend_agent_state` was already correct and stays correct, confirmed by hand on a throwaway server and asserted in the smoke test:

```
live window       -> agent_state=dead    target_exists=yes
never existed     -> agent_state=missing target_exists=no
killed window     -> agent_state=missing target_exists=no
```

## Validation

- `bin/fm-lint.sh` clean (ShellCheck 0.11.0, the pinned version).
- `bin/fm-test-run.sh --changed --base main`: 57 suites, 1 failure - `tests/fm-test-run.test.sh`, which fails identically on unmodified `main` in this environment (a `comm: input is not in sorted order` locale issue, unrelated to this change and left untouched).
