### PR TITLE
feat(bin): add decline and repair paths for decision holds

### DIFF
--- a/.agents/skills/decision-hold-lifecycle/SKILL.md
+++ b/.agents/skills/decision-hold-lifecycle/SKILL.md
@@ -21,7 +21,7 @@ After inventorying the whole report and review surface, run `bin/fm-decision-hol
 A completed investigation and an ended visual review use this same owner and completion command; a visual tool, including Lavish, never owns a parallel completion policy.
 Run the command in the originating work's authoritative `FM_HOME`; main-home work creates main-home holds, and secondmate-owned work creates holds in that secondmate home's backlog rather than copying them into the main backlog.
 Do not close a hold merely because the originating investigation completed, its report was archived, its visual review ended, or its task was torn down.
-The hold remains the authoritative Captain's Call item until the captain's answer is durably recorded, dependent work is created in the same backlog and blocked by that hold, and `bin/fm-decision-hold.sh resolve` routes the answer by clearing those dependency edges before closing the hold.
+When the captain's answer authorizes follow-up work, the hold remains the authoritative Captain's Call item until that answer is durably recorded, dependent work is created in the same backlog and blocked by the hold, and `bin/fm-decision-hold.sh resolve` routes the answer by clearing those dependency edges before closing the hold.
 When the captain's answer routes no follow-up work at all, such as a declined proposal, `bin/fm-decision-hold.sh decline` records that answer and closes the hold; it never substitutes for routing work the captain did authorize.
 A hold closed outside this owner leaves no durable answer, so the completion gate keeps failing until `bin/fm-decision-hold.sh repair` records the decision the captain actually gave; neither unrouted path may stand in for an answer the captain has not given.
 Resolved findings, recommendations that need no captain choice, and prose that merely sounds decision-like do not create holds.
@@ -34,9 +34,9 @@ Bearings reads the resulting structured state and must never compensate by scrap
 3. For each choice, choose a stable key and use the script's `hold` command with a concise title, reason, and repository.
 4. Run the script's `complete` command with the full unresolved-key inventory for that review pass.
 5. Relay the choices to the captain as decisions from Bearings' Captain's Call section under `AGENTS.md` section 9; do not use the word hold in captain chat.
-6. After the captain decides, record dependent work with normal tasks-axi commands and block it by the hold identity.
+6. If the captain authorizes dependent work, record it with normal tasks-axi commands and block it by the hold identity.
 7. Put the captain's exact durable decision in a file and close the hold with the script's `resolve` command and every routed task, its `decline` command when the answer routes no work, or its `repair` command when the hold was already closed outside the script.
-8. Confirm Bearings no longer shows the closed hold and that routed work remains in structured backlog state.
+8. Confirm Bearings no longer shows the closed hold and that any routed work remains in structured backlog state.
 
 `bin/fm-decision-hold.sh --help` owns command syntax, identity construction, completion attestation, retry behavior, and close ordering.
 `docs/decision-hold-lifecycle.md` records the mechanism and regression evidence without restating this policy.

--- a/.agents/skills/decision-hold-lifecycle/SKILL.md
+++ b/.agents/skills/decision-hold-lifecycle/SKILL.md
@@ -22,6 +22,8 @@ A completed investigation and an ended visual review use this same owner and com
 Run the command in the originating work's authoritative `FM_HOME`; main-home work creates main-home holds, and secondmate-owned work creates holds in that secondmate home's backlog rather than copying them into the main backlog.
 Do not close a hold merely because the originating investigation completed, its report was archived, its visual review ended, or its task was torn down.
 The hold remains the authoritative Captain's Call item until the captain's answer is durably recorded, dependent work is created in the same backlog and blocked by that hold, and `bin/fm-decision-hold.sh resolve` routes the answer by clearing those dependency edges before closing the hold.
+When the captain's answer routes no follow-up work at all, such as a declined proposal, `bin/fm-decision-hold.sh decline` records that answer and closes the hold; it never substitutes for routing work the captain did authorize.
+A hold closed outside this owner leaves no durable answer, so the completion gate keeps failing until `bin/fm-decision-hold.sh repair` records the decision the captain actually gave; neither unrouted path may stand in for an answer the captain has not given.
 Resolved findings, recommendations that need no captain choice, and prose that merely sounds decision-like do not create holds.
 Bearings reads the resulting structured state and must never compensate by scraping historical reports, visual-review artifacts, terminal output, chat, or other prose.
 
@@ -33,7 +35,7 @@ Bearings reads the resulting structured state and must never compensate by scrap
 4. Run the script's `complete` command with the full unresolved-key inventory for that review pass.
 5. Relay the choices to the captain as decisions from Bearings' Captain's Call section under `AGENTS.md` section 9; do not use the word hold in captain chat.
 6. After the captain decides, record dependent work with normal tasks-axi commands and block it by the hold identity.
-7. Put the captain's exact durable decision in a file and use the script's `resolve` command with every routed task.
+7. Put the captain's exact durable decision in a file and close the hold with the script's `resolve` command and every routed task, its `decline` command when the answer routes no work, or its `repair` command when the hold was already closed outside the script.
 8. Confirm Bearings no longer shows the closed hold and that routed work remains in structured backlog state.
 
 `bin/fm-decision-hold.sh --help` owns command syntax, identity construction, completion attestation, retry behavior, and close ordering.

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -57,6 +57,8 @@
 # genuinely answered. It never reopens a hold, never clears a dependency edge, and
 # refuses a hold that is still actively held, so an unanswered decision keeps
 # blocking teardown until `resolve` or `decline` closes it with the captain's word.
+# It also refuses an identity that does not carry surviving captain-hold
+# provenance, so an ordinary captain-kind task cannot be repaired into a decision.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -610,7 +612,7 @@ command_decline() {
 }
 
 command_repair() {
-  local origin=${1:-} key=${2:-} decision_file id body show state kind hold_body
+  local origin=${1:-} key=${2:-} decision_file id body show state kind hold_kind hold_body
   [ "$#" -ge 2 ] || { usage >&2; exit 2; }
   shift 2
   decision_file=$(parse_decision_only_flags "$@") || exit 2
@@ -622,6 +624,12 @@ command_repair() {
   show=$(task_show "$id") || fail "captain decision $id is absent from $FM_HOME/data/backlog.md"
   kind=$(show_field "$show" kind)
   [ "$kind" = captain ] || fail "backlog item $id is not kind captain"
+  # tasks-axi keeps hold_kind after a close, so it is the surviving proof that
+  # this identity really was a captain hold rather than an ordinary captain-kind
+  # task that was never held for the captain at all.
+  hold_kind=$(show_field "$show" hold_kind)
+  [ "$hold_kind" = captain ] \
+    || fail "backlog item $id was never held for the captain; repair records a captain decision only on a captain hold"
   state=$(show_field "$show" state)
   hold_body=$(show_field "$show" body)
   if [ "$state" = "done" ] && body_has_resolution_record "$hold_body"; then

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -24,6 +24,8 @@
 #   fm-decision-hold.sh verify <origin-id>
 #   fm-decision-hold.sh resolve <origin-id> <decision-key> \
 #     --decision-file <path> --routed-to <task-id> [--routed-to <task-id>...]
+#   fm-decision-hold.sh decline <origin-id> <decision-key> --decision-file <path>
+#   fm-decision-hold.sh repair <origin-id> <decision-key> --decision-file <path>
 #
 # `complete` is the shared investigation and visual-review completion gate.
 # `--none` is an explicit semantic attestation that the just-reviewed surface has
@@ -33,10 +35,28 @@
 # `verify` is read-only and is called by scout teardown so teardown cannot erase a
 # source before this gate has succeeded.
 #
-# `resolve` requires every --routed-to task to exist and to be blocked by the hold.
-# It writes the captain decision and routed identities into the hold body, clears
-# those dependency edges, and only then marks the hold Done. A failure before the
-# final step leaves the captain hold open.
+# `resolve`, `decline`, and `repair` are the three close paths. Each one requires a
+# non-empty captain decision file of at most 8192 bytes, records the same durable
+# resolution block in the hold body, and stores the decision digest plus routed
+# identities so an exact retry is idempotent while a changed decision or routed set
+# is rejected. The recorded `Resolution mode:` names which path closed the hold.
+#
+# `resolve` is the routed path. It requires every --routed-to task to exist and to
+# be blocked by the hold. It writes the captain decision and routed identities into
+# the hold body, clears those dependency edges, and only then marks the hold Done.
+# A failure before the final step leaves the captain hold open.
+#
+# `decline` is the unrouted path for a decision the captain answered with no
+# follow-up work. It takes no --routed-to task, records `(none)` as the routed
+# identities, and closes an actively held hold. It refuses while any task is still
+# blocked by the hold, because releasing routed work without recording it is
+# `resolve`'s job.
+#
+# `repair` records the missing resolution block on a hold that was already closed
+# outside this script, so `verify` stops failing on an origin whose decision was
+# genuinely answered. It never reopens a hold, never clears a dependency edge, and
+# refuses a hold that is still actively held, so an unanswered decision keeps
+# blocking teardown until `resolve` or `decline` closes it with the captain's word.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -109,6 +129,25 @@ hold_id() {  # <origin-id> <decision-key>
   printf '%s-decision-%s\n' "$1" "$2"
 }
 
+# The routed-identity token recorded when a close path routes no work. Slug
+# validation rejects parentheses, so no real task identity can collide with it.
+ROUTED_NONE='(none)'
+
+DECISION_TEXT=''
+DECISION_DIGEST=''
+
+load_decision() {  # <path>; sets DECISION_TEXT and DECISION_DIGEST
+  local path=$1 decision
+  [ -n "$path" ] || fail "--decision-file is required"
+  [ -f "$path" ] || fail "decision file does not exist: $path"
+  decision=$(cat "$path")
+  [ -n "$decision" ] || fail "decision file must not be empty"
+  [ "$(printf '%s' "$decision" | LC_ALL=C wc -c | tr -d ' ')" -le 8192 ] \
+    || fail "decision file exceeds 8192 bytes"
+  DECISION_TEXT=$decision
+  DECISION_DIGEST=$(sha256_text "$decision")
+}
+
 tasks_axi() {
   (cd "$FM_HOME" && tasks-axi "$@")
 }
@@ -170,6 +209,68 @@ origin_open_decisions() {  # <origin-id>
   printf '%s' "$open"
 }
 
+body_has_resolution_record() {  # <hold-body>
+  case "$1" in
+    *"Resolution recorded by fm-decision-hold."*"Routed work:"*) return 0 ;;
+  esac
+  return 1
+}
+
+resolution_body() {  # <mode> <routed-csv> [routed-task-id...]
+  local mode=$1 routed_csv=$2 body dep
+  shift 2
+  # Command substitution strips the trailing newline, so restore it before the
+  # routed-work list to keep each entry on its own durable backlog line.
+  body=$(printf 'Resolution recorded by fm-decision-hold.\nDecision digest: %s\nRouted identities: %s\nResolution mode: %s\n\nCaptain decision:\n%s\n\nRouted work:' \
+    "$DECISION_DIGEST" "$routed_csv" "$mode" "$DECISION_TEXT")
+  body="${body}"$'\n'
+  if [ "$#" -eq 0 ]; then
+    body="${body}${ROUTED_NONE}"$'\n'
+  else
+    for dep in "$@"; do
+      body="${body}- ${dep}"$'\n'
+    done
+  fi
+  printf '%s' "$body"
+}
+
+# tasks-axi quotes multi-entry blocked_by as "a,b,c"; strip so edge ids match.
+normalized_blocked_by() {  # <show-output>
+  local blocked
+  blocked=$(show_field "$1" blocked_by | tr -d '[:space:]')
+  blocked=${blocked#\"}
+  blocked=${blocked%\"}
+  printf '%s' "$blocked"
+}
+
+# Space-separated ids of live work still blocked by <hold-id>. The listing is only
+# a cheap prefilter whose first field is always an unquoted id; every candidate is
+# confirmed against its own authoritative record before it is reported.
+tasks_blocked_by() {  # <hold-id>
+  local id=$1 rows row candidate show found=''
+  rows=$(tasks_axi list --fields blocked_by) \
+    || fail "could not read backlog work while checking what $id still blocks"
+  while IFS= read -r row; do
+    case "$row" in
+      *"$id"*) : ;;
+      *) continue ;;
+    esac
+    candidate=${row%%,*}
+    candidate=${candidate// /}
+    [ -n "$candidate" ] || continue
+    [ "$candidate" != "$id" ] || continue
+    case "$candidate" in
+      *[!A-Za-z0-9._-]*) continue ;;
+    esac
+    show=$(task_show "$candidate") || continue
+    list_has_key "$(normalized_blocked_by "$show")" "$id" || continue
+    found="${found}${found:+ }$candidate"
+  done <<EOF
+$rows
+EOF
+  printf '%s' "$found"
+}
+
 verify_hold_active() {  # <hold-id>
   local id=$1 show state held kind hold_kind
   show=$(task_show "$id") || fail "captain hold $id is absent from $FM_HOME/data/backlog.md"
@@ -191,10 +292,7 @@ verify_hold_resolved() {  # <hold-id>
   body=$(show_field "$show" body)
   [ "$state" = "done" ] || return 1
   [ "$kind" = captain ] || return 1
-  case "$body" in
-    *"Resolution recorded by fm-decision-hold."*"Routed work:"*) return 0 ;;
-  esac
-  return 1
+  body_has_resolution_record "$body"
 }
 
 verify_hold_durable() {  # <hold-id>
@@ -208,10 +306,8 @@ verify_hold_durable() {  # <hold-id>
   if [ "$state" = queued ] && [ "$held" = yes ] && [ "$kind" = captain ] && [ "$hold_kind" = captain ]; then
     return 0
   fi
-  if [ "$state" = "done" ] && [ "$kind" = captain ]; then
-    case "$body" in
-      *"Resolution recorded by fm-decision-hold."*"Routed work:"*) return 0 ;;
-    esac
+  if [ "$state" = "done" ] && [ "$kind" = captain ] && body_has_resolution_record "$body"; then
+    return 0
   fi
   fail "captain decision $id is neither actively held nor durably resolved"
 }
@@ -396,7 +492,7 @@ EOF
 }
 
 command_resolve() {
-  local origin=${1:-} key=${2:-} decision_file='' id='' decision='' decision_digest='' body='' routed='' routed_csv='' dep show blocked state hold_show hold_body resolution_recorded=0
+  local origin=${1:-} key=${2:-} decision_file='' id='' body='' routed='' routed_csv='' dep show blocked state hold_show hold_body resolution_recorded=0
   [ "$#" -ge 2 ] || { usage >&2; exit 2; }
   shift 2
   while [ "$#" -gt 0 ]; do
@@ -409,22 +505,16 @@ command_resolve() {
   done
   validate_slug origin-id "$origin"
   validate_slug decision-key "$key"
-  [ -n "$decision_file" ] || fail "--decision-file is required"
-  [ -f "$decision_file" ] || fail "decision file does not exist: $decision_file"
-  decision=$(cat "$decision_file")
-  [ -n "$decision" ] || fail "decision file must not be empty"
-  [ "$(printf '%s' "$decision" | LC_ALL=C wc -c | tr -d ' ')" -le 8192 ] \
-    || fail "decision file exceeds 8192 bytes"
-  [ -n "$routed" ] || fail "at least one --routed-to task is required"
+  load_decision "$decision_file"
+  [ -n "$routed" ] || fail "at least one --routed-to task is required; use decline when the captain's answer routes no work"
   routed=$(printf '%s\n' "$routed" | tr ' ' '\n' | sed '/^$/d' | LC_ALL=C sort -u | paste -sd' ' -)
   routed_csv=$(printf '%s\n' "$routed" | tr ' ' ',')
-  decision_digest=$(sha256_text "$decision")
   require_tasks_axi
   id=$(hold_id "$origin" "$key")
   if verify_hold_resolved "$id"; then
     hold_show=$(task_show "$id")
     hold_body=$(show_field "$hold_show" body)
-    verify_resolution_identity "$id" "$hold_body" "$decision_digest" "$routed_csv"
+    verify_resolution_identity "$id" "$hold_body" "$DECISION_DIGEST" "$routed_csv"
     printf 'resolved: %s\n' "$id"
     return 0
   fi
@@ -433,7 +523,7 @@ command_resolve() {
   hold_body=$(show_field "$hold_show" body)
   case "$hold_body" in
     *"Resolution recorded by fm-decision-hold."*)
-      verify_resolution_identity "$id" "$hold_body" "$decision_digest" "$routed_csv"
+      verify_resolution_identity "$id" "$hold_body" "$DECISION_DIGEST" "$routed_csv"
       resolution_recorded=1
       ;;
   esac
@@ -443,42 +533,111 @@ command_resolve() {
     state=$(show_field "$show" state)
     [ "$state" != "done" ] || [ "$resolution_recorded" = 1 ] \
       || fail "routed task $dep is already done"
-    # tasks-axi quotes multi-entry blocked_by as "a,b,c"; strip so edge ids match.
-    blocked=$(show_field "$show" blocked_by | tr -d '[:space:]')
-    blocked=${blocked#\"}
-    blocked=${blocked%\"}
-    case ",$blocked," in
-      *",$id,"*) : ;;
-      *)
-        case "$hold_body" in
-          *"Resolution recorded by fm-decision-hold."*"- $dep"*) : ;;
-          *) fail "routed task $dep is not durably blocked by $id" ;;
-        esac
-        ;;
-    esac
+    blocked=$(normalized_blocked_by "$show")
+    if ! list_has_key "$blocked" "$id"; then
+      case "$hold_body" in
+        *"Resolution recorded by fm-decision-hold."*"- $dep"*) : ;;
+        *) fail "routed task $dep is not durably blocked by $id" ;;
+      esac
+    fi
   done
 
-  body=$(printf 'Resolution recorded by fm-decision-hold.\nDecision digest: %s\nRouted identities: %s\n\nCaptain decision:\n%s\n\nRouted work:\n' "$decision_digest" "$routed_csv" "$decision")
-  for dep in $routed; do
-    body="${body}- ${dep}"$'\n'
-  done
+  # shellcheck disable=SC2086  # routed is a validated space-separated slug list.
+  body=$(resolution_body routed "$routed_csv" $routed)
   tasks_axi update "$id" --body "$body" >/dev/null \
     || fail "could not record the captain decision on $id"
   for dep in $routed; do
     show=$(task_show "$dep") || fail "routed task $dep disappeared before routing"
-    blocked=$(show_field "$show" blocked_by | tr -d '[:space:]')
-    blocked=${blocked#\"}
-    blocked=${blocked%\"}
-    case ",$blocked," in
-      *",$id,"*)
-        tasks_axi unblock "$dep" --by "$id" >/dev/null \
-          || fail "could not route the recorded decision to $dep"
-        ;;
-    esac
+    if list_has_key "$(normalized_blocked_by "$show")" "$id"; then
+      tasks_axi unblock "$dep" --by "$id" >/dev/null \
+        || fail "could not route the recorded decision to $dep"
+    fi
   done
   tasks_axi "done" "$id" >/dev/null || fail "could not close resolved captain hold $id"
   verify_hold_resolved "$id" || fail "captain hold $id did not retain its durable resolution record"
   printf 'resolved: %s -> %s\n' "$id" "$routed"
+}
+
+parse_decision_only_flags() {  # <args...>; prints the --decision-file value
+  local decision_file=''
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --decision-file) shift; decision_file=${1:-} ;;
+      *) usage >&2; exit 2 ;;
+    esac
+    shift
+  done
+  printf '%s' "$decision_file"
+}
+
+command_decline() {
+  local origin=${1:-} key=${2:-} decision_file id body hold_show hold_body state dependents
+  [ "$#" -ge 2 ] || { usage >&2; exit 2; }
+  shift 2
+  decision_file=$(parse_decision_only_flags "$@") || exit 2
+  validate_slug origin-id "$origin"
+  validate_slug decision-key "$key"
+  load_decision "$decision_file"
+  require_tasks_axi
+  id=$(hold_id "$origin" "$key")
+  if verify_hold_resolved "$id"; then
+    hold_show=$(task_show "$id")
+    hold_body=$(show_field "$hold_show" body)
+    verify_resolution_identity "$id" "$hold_body" "$DECISION_DIGEST" "$ROUTED_NONE"
+    printf 'declined: %s\n' "$id"
+    return 0
+  fi
+  hold_show=$(task_show "$id") || fail "captain hold $id is absent from $FM_HOME/data/backlog.md"
+  state=$(show_field "$hold_show" state)
+  [ "$state" != "done" ] \
+    || fail "captain hold $id was closed outside fm-decision-hold; use repair to record the captain decision"
+  verify_hold_active "$id"
+  hold_body=$(show_field "$hold_show" body)
+  case "$hold_body" in
+    *"Resolution recorded by fm-decision-hold."*)
+      verify_resolution_identity "$id" "$hold_body" "$DECISION_DIGEST" "$ROUTED_NONE"
+      ;;
+  esac
+  dependents=$(tasks_blocked_by "$id") || exit 1
+  [ -z "$dependents" ] \
+    || fail "captain hold $id still blocks routed work ($dependents); use resolve to record that work"
+  body=$(resolution_body declined "$ROUTED_NONE")
+  tasks_axi update "$id" --body "$body" >/dev/null \
+    || fail "could not record the captain decision on $id"
+  tasks_axi "done" "$id" >/dev/null || fail "could not close declined captain hold $id"
+  verify_hold_resolved "$id" || fail "captain hold $id did not retain its durable resolution record"
+  printf 'declined: %s\n' "$id"
+}
+
+command_repair() {
+  local origin=${1:-} key=${2:-} decision_file id body show state kind hold_body
+  [ "$#" -ge 2 ] || { usage >&2; exit 2; }
+  shift 2
+  decision_file=$(parse_decision_only_flags "$@") || exit 2
+  validate_slug origin-id "$origin"
+  validate_slug decision-key "$key"
+  load_decision "$decision_file"
+  require_tasks_axi
+  id=$(hold_id "$origin" "$key")
+  show=$(task_show "$id") || fail "captain decision $id is absent from $FM_HOME/data/backlog.md"
+  kind=$(show_field "$show" kind)
+  [ "$kind" = captain ] || fail "backlog item $id is not kind captain"
+  state=$(show_field "$show" state)
+  hold_body=$(show_field "$show" body)
+  if [ "$state" = "done" ] && body_has_resolution_record "$hold_body"; then
+    verify_resolution_identity "$id" "$hold_body" "$DECISION_DIGEST" "$ROUTED_NONE"
+    printf 'repaired: %s\n' "$id"
+    return 0
+  fi
+  [ "$state" = "done" ] \
+    || fail "captain hold $id is still open (state=$state); use resolve or decline to close it with the captain's decision"
+  body=$(resolution_body repaired "$ROUTED_NONE")
+  tasks_axi update "$id" --body "$body" >/dev/null \
+    || fail "could not record the captain decision on $id"
+  show=$(task_show "$id") || fail "captain decision $id disappeared while recording the repair"
+  [ "$(show_field "$show" state)" = "done" ] || fail "repairing $id reopened a closed captain decision"
+  verify_hold_resolved "$id" || fail "captain hold $id did not retain its durable resolution record"
+  printf 'repaired: %s\n' "$id"
 }
 
 case "${1:-}" in
@@ -487,6 +646,8 @@ case "${1:-}" in
   complete) shift; command_complete "$@" ;;
   verify) shift; command_verify "$@" ;;
   resolve) shift; command_resolve "$@" ;;
+  decline) shift; command_decline "$@" ;;
+  repair) shift; command_repair "$@" ;;
   -h|--help) usage ;;
   *) usage >&2; exit 2 ;;
 esac

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -7,8 +7,8 @@
 # The invoking agent inventories unresolved decisions, assigns stable keys, and
 # routes dependent work. This script supplies deterministic identities, creates
 # and verifies structured tasks-axi captain holds, records completion attestation
-# in the originating task's metadata, and closes a hold only after a durable
-# decision record has been linked to existing dependent work.
+# in the originating task's metadata, and requires a durable captain decision
+# record before it closes or repairs a hold.
 #
 # A hold identity is <origin-id>-decision-<decision-key>. Origin ids and decision
 # keys must already be privacy-safe slugs. Repeating `hold` with the same identity
@@ -35,11 +35,12 @@
 # `verify` is read-only and is called by scout teardown so teardown cannot erase a
 # source before this gate has succeeded.
 #
-# `resolve`, `decline`, and `repair` are the three close paths. Each one requires a
-# non-empty captain decision file of at most 8192 bytes, records the same durable
-# resolution block in the hold body, and stores the decision digest plus routed
-# identities so an exact retry is idempotent while a changed decision or routed set
-# is rejected. The recorded `Resolution mode:` names which path closed the hold.
+# `resolve` and `decline` close active holds; `repair` attests a hold already closed
+# outside this script. All three paths require a non-empty captain decision file of
+# at most 8192 bytes, record the same durable resolution block in the hold body, and
+# store the decision digest plus routed identities so an exact retry is idempotent
+# while a changed decision or, for `resolve`, routed set is rejected. New records
+# include a `Resolution mode:` naming their path; older routed records remain valid.
 #
 # `resolve` is the routed path. It requires every --routed-to task to exist and to
 # be blocked by the hold. It writes the captain decision and routed identities into

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -23,9 +23,9 @@ For an open keyed status decision, it appends a `captain-held [key=<key>]: ...` 
 Scout teardown calls the script's read-only `verify` subcommand after checking for the report and before removing any source state.
 The `--force` path remains the explicit captain-approved discard escape hatch.
 
-The `resolve`, `decline`, and `repair` subcommands are the three close paths.
-Each requires a non-empty captain decision file, records the same resolution block in the hold body, and stores the decision digest, the routed identities, and a `Resolution mode:` naming the path that closed the hold.
-An exact retry is idempotent, while a changed decision or a changed routed-task set is rejected.
+The `resolve` and `decline` subcommands close active holds, while `repair` attests a hold already closed outside the script.
+All three require a non-empty captain decision file and record the same resolution block in the hold body with the decision digest, routed identities, and a `Resolution mode:` naming the path.
+An exact retry is idempotent, while a changed decision or, for `resolve`, a changed routed-task set is rejected.
 
 The `resolve` subcommand is the routed path and additionally requires at least one existing dependent task whose structured `blocked-by` edge points to the hold.
 It clears each dependency edge through tasks-axi and marks the hold Done only after those writes succeed.

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -23,10 +23,20 @@ For an open keyed status decision, it appends a `captain-held [key=<key>]: ...` 
 Scout teardown calls the script's read-only `verify` subcommand after checking for the report and before removing any source state.
 The `--force` path remains the explicit captain-approved discard escape hatch.
 
-The `resolve` subcommand requires a decision file and at least one existing dependent task whose structured `blocked-by` edge points to the hold.
-It records the decision digest and routed task identities as a retry identity in the hold body, clears each dependency edge through tasks-axi, and marks the hold Done only after those writes succeed.
-An exact retry can finish a partial routing operation, while a changed decision or routed-task set is rejected.
-A failed intermediate step leaves the hold open.
+The `resolve`, `decline`, and `repair` subcommands are the three close paths.
+Each requires a non-empty captain decision file, records the same resolution block in the hold body, and stores the decision digest, the routed identities, and a `Resolution mode:` naming the path that closed the hold.
+An exact retry is idempotent, while a changed decision or a changed routed-task set is rejected.
+
+The `resolve` subcommand is the routed path and additionally requires at least one existing dependent task whose structured `blocked-by` edge points to the hold.
+It clears each dependency edge through tasks-axi and marks the hold Done only after those writes succeed.
+An exact retry can finish a partial routing operation, and a failed intermediate step leaves the hold open.
+
+The `decline` subcommand closes a hold whose captain answer routes no follow-up work, recording `(none)` as the routed identities.
+It refuses while any task in the same backlog is still blocked by the hold, because releasing routed work without recording it is `resolve`'s job.
+Every candidate found in the listing prefilter is confirmed against its own structured record before the refusal is reported.
+
+The `repair` subcommand records the resolution block on a hold that was already closed outside the script, such as by a direct `tasks-axi done`, so an origin whose decision was genuinely answered stops failing `verify`.
+It refuses a hold that is still actively held, never reopens a closed hold, and never clears a dependency edge, so an unanswered decision keeps blocking teardown until the captain's word closes it.
 
 ## Structured read surfaces
 
@@ -43,11 +53,17 @@ The projection remains read-only and does not inspect historical prose.
 Verification date: 2026-07-14.
 Additional quoted `blocked_by` regression verification date: 2026-07-17.
 Plural blocker-readiness and mixed-home projection verification date: 2026-07-22.
+Unrouted close-path verification date: 2026-08-13.
 
 The focused end-to-end regression uses only synthetic `sample` identities and decision text.
 It begins with a completed investigation and visual review whose genuine unresolved choice exists only in the report.
 The initial Bearings snapshot correctly has no open decision, and the new teardown gate refuses to erase the source.
 A later regression covers tasks-axi's quoted multi-entry `blocked_by` output so `resolve` matches the first, middle, and last ids and rejects a genuinely absent id.
+
+Three further regressions cover the close paths that route no work.
+A declined decision closes with a recorded answer, satisfies `verify`, leaves Bearings' Captain's Call, and is refused while the hold still blocks routed work.
+A hold closed by a direct `tasks-axi done` reproduces the shape that fails `verify` and blocks teardown, and `repair` with a captain decision file clears both.
+An unanswered decision still blocks completion and teardown, and neither `decline` nor `repair` can close a hold that is still actively held or supply an answer with a missing or empty decision file.
 
 The final verification commands and their exact summarized outputs follow.
 
@@ -55,6 +71,9 @@ The final verification commands and their exact summarized outputs follow.
 $ bash tests/fm-decision-hold-lifecycle.test.sh
 ok - report-only unresolved decision is reproduced and completion refuses before loss
 ok - non-forced scout teardown always requires durable inventory verification
+ok - a declined decision closes with a recorded answer and no routed work
+ok - a decision closed outside the script is repairable and then clears teardown
+ok - an unanswered decision still blocks completion and resists both unrouted close paths
 ok - captain holds are idempotent, distinct, teardown-safe, Bearings-visible, and durably routed before close
 ok - completion and verification validate origins before constructing paths
 ok - ended visual review follows the same decision-hold completion owner
@@ -70,22 +89,22 @@ ok - snapshot parses tasks-axi rows and respects operational overrides
 
 $ bash tests/fm-bearings-snapshot.test.sh
 ok - a completed scout with decision-like report prose is a pointer, not pending
+ok - an authoritative captain hold surfaces end-to-end
 ok - action-free items (working/done/queued/landed) do not leak into Captain's Call
-ok - mixed secondmate roles, partial state, and captain readiness project independently
 ok - main and secondmate captain actionability use the same blocker readiness
 
 $ bash tests/fm-brief.test.sh
 ok - fm-brief.sh: investigation and visual-review completions load the shared decision policy
 
 $ bash tests/fm-teardown.test.sh
-all teardown safety cases passed
+ok - the run abort and the leaked-process reap both complete before the destructive worktree return
 
 $ bin/fm-lint.sh
 fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
 
+$ bin/fm-doc-audience-check.sh
+fm-doc-audience-check: ok surfaces=67 local_links=243
+
 $ git diff --check
 (no output)
-
-$ for test_script in tests/*.test.sh; do bash "$test_script"; done
-ALL 71 TEST SCRIPTS PASSED
 ```

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -37,6 +37,7 @@ Every candidate found in the listing prefilter is confirmed against its own stru
 
 The `repair` subcommand records the resolution block on a hold that was already closed outside the script, such as by a direct `tasks-axi done`, so an origin whose decision was genuinely answered stops failing `verify`.
 It refuses a hold that is still actively held, never reopens a closed hold, and never clears a dependency edge, so an unanswered decision keeps blocking teardown until the captain's word closes it.
+It also requires the identity to carry the captain-hold provenance that tasks-axi preserves through a close, so an ordinary captain-kind task that was never held cannot be repaired into a resolved decision.
 
 ## Structured read surfaces
 
@@ -64,6 +65,7 @@ Three further regressions cover the close paths that route no work.
 A declined decision closes with a recorded answer, satisfies `verify`, leaves Bearings' Captain's Call, and is refused while the hold still blocks routed work.
 A hold closed by a direct `tasks-axi done` reproduces the shape that fails `verify` and blocks teardown, and `repair` with a captain decision file clears both.
 An unanswered decision still blocks completion and teardown, and neither `decline` nor `repair` can close a hold that is still actively held or supply an answer with a missing or empty decision file.
+`repair` also refuses a closed captain-kind task that was never held for the captain.
 
 The final verification commands and their exact summarized outputs follow.
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -25,7 +25,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-remote-doctor.sh`    | Check, and with `--fix` repair, one remote account's second-mate readiness (remote job worker, Herdr, Aqua launch agents, PATH, and required tools) |
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-backlog-receive.sh`  | Idempotently ingest one confined remote handoff outbox through tasks-axi             |
-| `fm-decision-hold.sh`    | Create, verify, complete, and close (resolve, decline, or repair) durable captain-held decisions |
+| `fm-decision-hold.sh`    | Create, verify, complete, close, and repair durable captain-held decisions       |
 | `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs   |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -25,7 +25,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-remote-doctor.sh`    | Check, and with `--fix` repair, one remote account's second-mate readiness (remote job worker, Herdr, Aqua launch agents, PATH, and required tools) |
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-backlog-receive.sh`  | Idempotently ingest one confined remote handoff outbox through tasks-axi             |
-| `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions                 |
+| `fm-decision-hold.sh`    | Create, verify, complete, and close (resolve, decline, or repair) durable captain-held decisions |
 | `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs   |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -560,9 +560,207 @@ test_resolve_matches_quoted_blocked_by_edges() {
   pass "resolve matches first/middle/last in quoted blocked_by and rejects a genuinely absent id"
 }
 
+# A captain who declines a held decision leaves no follow-up work to route, so the
+# routed close path cannot express the answer. The unrouted close path must record
+# that answer durably while still refusing to release work the hold blocks.
+test_declined_decision_closes_without_routed_work() {
+  local home id hold routed_hold json show
+  home=$(make_home declined-decision)
+  id=sample-benchmark-review
+  mkdir -p "$home/data/$id"
+  tasks_in "$home" add "$id" "Investigate sample benchmarks" --kind scout --repo sample --start >/dev/null \
+    || fail "could not create declined-decision origin"
+  write_origin_meta "$home" "$id"
+  printf 'done: report complete\n' > "$home/state/$id.status"
+  printf '# Sample benchmark review\n\nOne captain choice remains.\n' > "$home/data/$id/report.md"
+  hold=$(run_decisions "$home" hold "$id" half-run \
+    --title "Choose the sample half run" --reason "captain half-run choice pending" --repo sample) \
+    || fail "could not register the declinable hold"
+  run_decisions "$home" complete "$id" half-run >/dev/null \
+    || fail "completion failed for the declinable hold"
+
+  printf '' > "$home/empty-decision.txt"
+  if run_decisions "$home" decline "$id" half-run --decision-file "$home/empty-decision.txt" \
+    > "$home/empty-decline.out" 2> "$home/empty-decline.err"; then
+    fail "decline accepted an empty captain decision"
+  fi
+  if run_decisions "$home" decline "$id" half-run > "$home/bare-decline.out" 2> "$home/bare-decline.err"; then
+    fail "decline accepted a close with no captain decision file at all"
+  fi
+  show=$(tasks_in "$home" show "$hold" --full)
+  assert_contains "$show" "state: queued" "a refused decline closed the hold"
+  assert_contains "$show" "held: yes" "a refused decline released the hold"
+
+  printf 'Declined: do not run the sample half benchmark.\n' > "$home/half-run-decision.txt"
+  run_decisions "$home" decline "$id" half-run --decision-file "$home/half-run-decision.txt" >/dev/null \
+    || fail "decline could not close a hold that routes no work"
+  show=$(tasks_in "$home" show "$hold" --full)
+  assert_contains "$show" "state: done" "declined hold did not close"
+  assert_contains "$show" "Resolution recorded by fm-decision-hold" "declined hold lost the decision record"
+  assert_contains "$show" "Resolution mode: declined" "declined hold did not record its close path"
+  assert_contains "$show" "Declined: do not run the sample half benchmark." \
+    "declined hold did not record the captain decision text"
+  run_decisions "$home" verify "$id" >/dev/null \
+    || fail "a declined decision did not satisfy the completion gate"
+  run_decisions "$home" decline "$id" half-run --decision-file "$home/half-run-decision.txt" >/dev/null \
+    || fail "identical decline retry was not idempotent"
+  printf 'Declined for a different reason.\n' > "$home/drifted-decision.txt"
+  if run_decisions "$home" decline "$id" half-run --decision-file "$home/drifted-decision.txt" \
+    > "$home/drifted-decline.out" 2> "$home/drifted-decline.err"; then
+    fail "decline retry accepted a different captain decision"
+  fi
+  json=$(run_bearings "$home") || fail "Bearings failed after a declined decision"
+  printf '%s' "$json" | jq -e --arg hold "$hold" '
+    (.decisions_open | any(.id == $hold) | not)
+  ' >/dev/null || fail "a declined decision remained an open Captain's Call: $json"
+
+  routed_hold=$(run_decisions "$home" hold "$id" upstream \
+    --title "Choose the sample upstream target" --reason "captain upstream choice pending" --repo sample) \
+    || fail "could not register the routed-work hold"
+  tasks_in "$home" add sample-upstream-work "Apply the sample upstream choice" \
+    --kind ship --repo sample --blocked-by "$routed_hold" >/dev/null \
+    || fail "could not route work behind the second hold"
+  if run_decisions "$home" decline "$id" upstream --decision-file "$home/half-run-decision.txt" \
+    > "$home/routed-decline.out" 2> "$home/routed-decline.err"; then
+    fail "decline released work that was still routed behind the hold"
+  fi
+  assert_grep "still blocks routed work" "$home/routed-decline.err" \
+    "decline must name the routed work it refuses to release"
+  show=$(tasks_in "$home" show "$routed_hold" --full)
+  assert_contains "$show" "state: queued" "refused routed decline closed the hold"
+  show=$(tasks_in "$home" show sample-upstream-work --full)
+  assert_contains "$show" "blocked: yes" "refused routed decline released dependent work"
+  if run_decisions "$home" resolve "$id" upstream --decision-file "$home/half-run-decision.txt" \
+    > "$home/unrouted-resolve.out" 2> "$home/unrouted-resolve.err"; then
+    fail "the routed close path accepted a resolution with no routed work"
+  fi
+  pass "a declined decision closes with a recorded answer and no routed work"
+}
+
+# The exact incident: two declined captain decisions were closed with a direct
+# tasks-axi done, so the durable resolution attestation this gate reads was never
+# written and the investigation could no longer be cleaned up.
+test_out_of_band_close_is_repairable_before_teardown() {
+  local home id hold show
+  home=$(make_home out-of-band-close)
+  id=sample-fullrun-review
+  mkdir -p "$home/data/$id"
+  tasks_in "$home" add "$id" "Investigate the sample full run" --kind scout --repo sample --start >/dev/null \
+    || fail "could not create out-of-band-close origin"
+  write_origin_meta "$home" "$id"
+  printf 'done: report complete\n' > "$home/state/$id.status"
+  printf '# Sample full run review\n\nOne captain choice remains.\n' > "$home/data/$id/report.md"
+  hold=$(run_decisions "$home" hold "$id" submission \
+    --title "Choose the sample submission" --reason "captain submission choice pending" --repo sample) \
+    || fail "could not register the out-of-band hold"
+  run_decisions "$home" complete "$id" submission >/dev/null \
+    || fail "completion failed before the out-of-band close"
+
+  tasks_in "$home" "done" "$hold" >/dev/null || fail "could not reproduce the direct out-of-band close"
+  show=$(tasks_in "$home" show "$hold" --full)
+  assert_contains "$show" "state: done" "the out-of-band close shape was not reproduced"
+  assert_no_grep "Resolution recorded by fm-decision-hold" "$home/data/backlog.md" \
+    "the out-of-band close must leave no durable resolution record"
+  if run_decisions "$home" verify "$id" > "$home/broken-verify.out" 2> "$home/broken-verify.err"; then
+    fail "verification passed a captain decision closed with no recorded answer"
+  fi
+  if run_teardown "$home" "$id" > "$home/broken-teardown.out" 2> "$home/broken-teardown.err"; then
+    fail "teardown proceeded while a captain decision had no recorded answer"
+  fi
+  assert_present "$home/state/$id.meta" "refused teardown removed investigation metadata"
+
+  if run_decisions "$home" repair "$id" submission > "$home/bare-repair.out" 2> "$home/bare-repair.err"; then
+    fail "repair recorded a resolution with no captain decision file"
+  fi
+  printf '' > "$home/empty-repair.txt"
+  if run_decisions "$home" repair "$id" submission --decision-file "$home/empty-repair.txt" \
+    > "$home/empty-repair.out" 2> "$home/empty-repair.err"; then
+    fail "repair recorded a resolution from an empty captain decision file"
+  fi
+  if run_decisions "$home" verify "$id" > "$home/still-broken.out" 2> "$home/still-broken.err"; then
+    fail "a refused repair still satisfied the completion gate"
+  fi
+
+  printf 'Declined: do not submit the sample full run upstream.\n' > "$home/submission-decision.txt"
+  run_decisions "$home" repair "$id" submission --decision-file "$home/submission-decision.txt" >/dev/null \
+    || fail "repair could not record the missing durable resolution"
+  show=$(tasks_in "$home" show "$hold" --full)
+  assert_contains "$show" "state: done" "repair reopened a closed captain decision"
+  assert_contains "$show" "Resolution mode: repaired" "repair did not record its close path"
+  assert_contains "$show" "Declined: do not submit the sample full run upstream." \
+    "repair did not record the captain decision text"
+  run_decisions "$home" verify "$id" >/dev/null \
+    || fail "the repaired decision did not satisfy the completion gate"
+  run_decisions "$home" repair "$id" submission --decision-file "$home/submission-decision.txt" >/dev/null \
+    || fail "identical repair retry was not idempotent"
+  printf 'A different answer entirely.\n' > "$home/drifted-repair.txt"
+  if run_decisions "$home" repair "$id" submission --decision-file "$home/drifted-repair.txt" \
+    > "$home/drifted-repair.out" 2> "$home/drifted-repair.err"; then
+    fail "repair retry overwrote the recorded captain decision"
+  fi
+  run_teardown "$home" "$id" >/dev/null 2> "$home/teardown.err" \
+    || fail "teardown still refused after the decision was repaired: $(cat "$home/teardown.err")"
+  pass "a decision closed outside the script is repairable and then clears teardown"
+}
+
+# The unrouted close paths must not become a way past the gate. An unanswered
+# decision keeps blocking cleanup, and neither new path can manufacture an answer.
+test_unanswered_decision_still_blocks_completion_and_teardown() {
+  local home id hold show
+  home=$(make_home unanswered-decision)
+  id=sample-open-review
+  mkdir -p "$home/data/$id"
+  tasks_in "$home" add "$id" "Investigate an open sample choice" --kind scout --repo sample --start >/dev/null \
+    || fail "could not create unanswered-decision origin"
+  write_origin_meta "$home" "$id"
+  printf 'needs-decision [key=open-choice]: choose sample option A or option B\n' \
+    > "$home/state/$id.status"
+  printf '# Sample open review\n\nThe captain has not chosen yet.\n' > "$home/data/$id/report.md"
+  printf 'An answer the captain never gave.\n' > "$home/invented-decision.txt"
+
+  if run_decisions "$home" complete "$id" open-choice > "$home/open-complete.out" 2> "$home/open-complete.err"; then
+    fail "completion accepted an unresolved decision with no captain hold"
+  fi
+  if run_decisions "$home" verify "$id" > "$home/open-verify.out" 2> "$home/open-verify.err"; then
+    fail "verification accepted an unresolved decision with no captain hold"
+  fi
+  if run_teardown "$home" "$id" > "$home/open-teardown.out" 2> "$home/open-teardown.err"; then
+    fail "teardown erased an investigation whose decision was never inventoried"
+  fi
+  assert_grep "REFUSED" "$home/open-teardown.err" "teardown refusal must be explicit"
+  if run_decisions "$home" decline "$id" open-choice --decision-file "$home/invented-decision.txt" \
+    > "$home/absent-decline.out" 2> "$home/absent-decline.err"; then
+    fail "decline invented a resolution for a decision that has no hold"
+  fi
+  if run_decisions "$home" repair "$id" open-choice --decision-file "$home/invented-decision.txt" \
+    > "$home/absent-repair.out" 2> "$home/absent-repair.err"; then
+    fail "repair invented a resolution for a decision that has no hold"
+  fi
+
+  hold=$(run_decisions "$home" hold "$id" open-choice \
+    --title "Choose the sample option" --reason "captain option choice pending" --repo sample) \
+    || fail "could not register the unanswered hold"
+  if run_decisions "$home" repair "$id" open-choice --decision-file "$home/invented-decision.txt" \
+    > "$home/held-repair.out" 2> "$home/held-repair.err"; then
+    fail "repair closed a decision that is still actively held and unanswered"
+  fi
+  assert_grep "still open" "$home/held-repair.err" "repair must say the hold is still open"
+  show=$(tasks_in "$home" show "$hold" --full)
+  assert_contains "$show" "state: queued" "a refused repair closed the live hold"
+  assert_contains "$show" "held: yes" "a refused repair released the live hold"
+  assert_no_grep "Resolution recorded by fm-decision-hold" "$home/data/backlog.md" \
+    "a refused repair wrote a resolution record"
+  run_decisions "$home" complete "$id" open-choice >/dev/null \
+    || fail "an inventoried unanswered decision could not complete its review"
+  pass "an unanswered decision still blocks completion and resists both unrouted close paths"
+}
+
 test_uninventoried_report_decision_refuses_completion
 
 test_scout_teardown_always_requires_inventory_verification
+test_declined_decision_closes_without_routed_work
+test_out_of_band_close_is_repairable_before_teardown
+test_unanswered_decision_still_blocks_completion_and_teardown
 test_structured_holds_survive_teardown_and_route_resolution
 test_origin_slug_validation_precedes_path_construction
 test_visual_review_uses_shared_completion_owner

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -737,6 +737,21 @@ test_unanswered_decision_still_blocks_completion_and_teardown() {
     fail "repair invented a resolution for a decision that has no hold"
   fi
 
+  tasks_in "$home" add "$id-decision-never-held" "An ordinary captain-kind task" \
+    --kind captain --repo sample >/dev/null \
+    || fail "could not create the never-held captain-kind fixture"
+  tasks_in "$home" "done" "$id-decision-never-held" >/dev/null \
+    || fail "could not close the never-held captain-kind fixture"
+  if run_decisions "$home" repair "$id" never-held --decision-file "$home/invented-decision.txt" \
+    > "$home/never-held-repair.out" 2> "$home/never-held-repair.err"; then
+    fail "repair turned an ordinary captain-kind task into a resolved captain decision"
+  fi
+  assert_grep "never held for the captain" "$home/never-held-repair.err" \
+    "repair must say the identity carries no captain-hold provenance"
+  show=$(tasks_in "$home" show "$id-decision-never-held" --full)
+  assert_not_contains "$show" "Resolution recorded by fm-decision-hold" \
+    "a refused never-held repair wrote a resolution record"
+
   hold=$(run_decisions "$home" hold "$id" open-choice \
     --title "Choose the sample option" --reason "captain option choice pending" --repo sample) \
     || fail "could not register the unanswered hold"


### PR DESCRIPTION
## Intent

Give bin/fm-decision-hold.sh a DECLINE close path, because the captain-decision-hold gate that scout teardown depends on had no way to close a hold the captain declined.

SCOPE IS DELIBERATELY BOUNDED AND WAS EXPLICITLY RULED BY THE REQUESTER. A previous run's auto-fix rounds expanded this change into a per-hold atomic close lock, a staging-backlog 'tasks-axi mv' close transaction, a bin/fm-decision-hold-close.mjs helper, and a tasks-axi compatibility floor bump. That expansion was REVIEWED AND REJECTED by the requester and deliberately reverted. The decision, verbatim in effect: this is a low-frequency operator action that needs NO atomic close lock, NO mv transaction, and NO compatibility floor bump, and auto-fixes must not smuggle a tasks-axi floor bump. Concurrency hardening of the close boundary against other tasks-axi writers is OUT OF SCOPE for this change and belongs to separate work. Do not re-propose it, and do not treat its absence as a defect: it is the accepted design.

The confirmed gap being fixed: command_resolve requires at least one --routed-to task ('at least one --routed-to task is required'). When the captain DECLINES a held decision there is no follow-up work to route, so resolve cannot express the answer. In the real incident the captain declined two captain-held benchmark decisions (minctx-half-run, upstream-submission); with no routable work they were closed with 'tasks-axi done' DIRECTLY, outside the script. The durable-resolved attestation the script writes was therefore never recorded, so 'fm-decision-hold.sh verify nm-review-benchmark-fullrun-r1' fails with 'captain decision ... is neither actively held nor durably resolved', which BLOCKS that scout's teardown.

The three required behaviors, as specified:
1. Decline close path: close a hold with a recorded captain decision file and NO routed work, recording the captain decision into the hold body/attestation and marking the hold durably resolved exactly like resolve does, minus the dependency-edge routing. Implemented as a new 'decline' verb (the brief allowed either 'resolve --decline' or a new verb).
2. Repair path: repair a hold already CLOSED OUTSIDE the script, where the backlog item is Done but the durable-resolved attestation is missing and verify fails. It records the missing durable-resolved state with a decision file so verify passes, without reopening or re-routing. Implemented as a new 'repair' verb.
3. Do NOT weaken the gate. Only a genuinely declined/resolved/repaired hold passes; both new paths require a real captain decision file and must not let an un-decided hold slip through.

Deliberate decisions a reviewer reading only the diff would not know:

- Stated correction to one premise in the original request. It asserted that a genuinely UNANSWERED hold, still actively held with no decision recorded, must still FAIL verify and block teardown. That is not the existing design and was deliberately NOT changed: verify_hold_durable treats an ACTIVELY HELD hold as durable, because the hold itself is the durable Captain's Call record and is designed to OUTLIVE the investigation. The pre-existing regression 'captain holds are idempotent, distinct, teardown-safe, Bearings-visible, and durably routed before close' tears down an origin while both holds are still open, so making verify fail there would break the documented lifecycle. The gate property pinned instead: no path may reach the durably-resolved state without a real captain decision, and neither new verb may close or repair a hold that is still actively held. This was flagged to and accepted by the requester.
- repair requires surviving captain-hold provenance (hold_kind=captain), not just kind=captain and state=done. This was a review finding the requester explicitly decided to FIX: without it, an ordinary captain-kind task that was never held could be closed, repaired, and then pass verify. tasks-axi preserves hold_kind through a close, so it is the surviving proof of a real captain hold.
- decline REFUSES while any task in the same backlog is still blocked by the hold, and points at resolve, because tasks-axi automatically clears blocked_by edges when the blocker closes; declining a hold with routed work would silently release that work without recording it, which is what resolve exists to record. The dependency scan uses 'tasks-axi list --fields blocked_by' as a cheap prefilter (first column is always an unquoted id) and confirms every candidate against its own 'tasks-axi show --full' record, because list rows quote titles and multi-entry blocked_by values. This is a best-effort check at a low-frequency operator action, NOT a concurrency guarantee, by explicit decision above.
- repair takes NO --routed-to: once a hold is Done, tasks-axi has already cleared its edges, so any routed identity claimed at repair time could not be verified, and recording an unverifiable claim would weaken the record. Routed context belongs in the decision file text.
- Both new paths reuse resolve's existing digest-based retry identity, so an exact retry is idempotent while a changed decision is rejected. A declined or repaired hold records '(none)' as the routed identities; slug validation rejects parentheses so no real task id can collide with that token. A new 'Resolution mode:' line (routed|declined|repaired) makes the durable record self-describing; verify_resolution_identity's existing strict parse is unaffected and records written by the previous version still validate.
- Fixed a small pre-existing formatting wart in the shared body builder: command substitution stripped the newline before the routed-work list, so entries rendered as 'Routed work:- task-id' on one line in backlog.md. Each entry now gets its own durable line.
- Duplicated resolution-record matching and blocked_by normalization were factored into single helpers (body_has_resolution_record, normalized_blocked_by) per the repo's one-owner rule.
- Ownership split kept as required: bin/fm-decision-hold.sh is the single owner of the mechanics (header and --help updated for the new verb surface), .agents/skills/decision-hold-lifecycle/SKILL.md is the single owner of the policy (updated for when to decline and when to repair), docs/decision-hold-lifecycle.md records the mechanism plus refreshed verification evidence, and docs/scripts.md's one-line table entry was updated.

Regression tests, all exercising the real fm-decision-hold verbs through the executable interface in a scratch FM_HOME with synthetic 'sample' identities, never asserting implementation source text. This is harness-agnostic shell, so a portable tests/ regression is sufficient and no live-harness guard is needed. The three mandatory cases:
- 'a declined decision closes with a recorded answer and no routed work': declined through the new decline path with a decision file and no routed work, then verify PASSES and Bearings drops it from the open Captain's Call. Also covers empty/missing decision file refusal, idempotent retry, drifted-decision rejection, refusal while work is still routed, and resolve still rejecting a no-routed-to invocation.
- 'a decision closed outside the script is repairable and then clears teardown': reproduces the exact incident by closing the hold with a direct 'tasks-axi done', asserts verify FAILS and real scout teardown REFUSES while preserving state, then repair with a decision file makes verify pass and teardown succeed. Mandatory case.
- 'an unanswered decision still blocks completion and resists both unrouted close paths': an uninventoried unresolved decision still fails complete, verify, and teardown; decline and repair both refuse when no hold exists; repair refuses a still-actively-held hold, leaving it queued and held with no resolution record; and repair refuses a closed captain-kind task that was never held. Mandatory case.
- The pre-existing resolve regressions, including the routed close path and the quoted blocked_by edge cases, are unchanged and still pass (12 of 12 in the suite).
All three new gate guards were mutation-checked: removing the repair open-hold guard, the repair provenance guard, or the decline routed-work guard each makes the suite fail.

Verified locally: bash tests/fm-decision-hold-lifecycle.test.sh (12 ok), plus fm-fleet-snapshot-view, fm-bearings-snapshot, fm-brief, fm-teardown, fm-documentation-audiences, bin/fm-lint.sh (ShellCheck 0.11.0 pinned), bin/fm-doc-audience-check.sh, and git diff --check.

Out of scope, deliberately: the real repair of nm-review-benchmark-fullrun-r1's two declined holds is a main-home operation on state that does not live in this worktree and must not be attempted here; the main firstmate runs it after this merges. tests/fm-calm-pi-extension.test.sh currently fails on '/export did not complete while calm mode was on', which reproduces identically on unmodified main at 85cefa9 with Pi 0.84.1 and is unrelated to this change.

Delivery: the requester merges. Do not merge.

## What Changed

- Add `decline` to record a captain decision and close a hold without routed work, while refusing holds that still block dependent tasks.
- Add `repair` to durably attest captain holds closed outside the script, requiring a decision file and preserved captain-hold provenance.
- Document the unrouted close lifecycle and add regression coverage for decline, repair, retry safety, and gate protections.

## Risk Assessment

✅ Low: The change is well-bounded, implements the required decline and repair paths with decision and provenance guards, and introduces no substantiated material source risks.

## Testing

The focused 12-case lifecycle regression and an end-to-end operator flow confirmed decline persistence, repair of an out-of-band close, strict refusal before repair, cleared Bearings state, and successful teardown; the inspected diff also had no whitespace errors.

<details>
<summary>Evidence: End-to-end decline and repair CLI transcript with persisted task records, gate refusal/recovery, Bearings output, and teardown</summary>

```text
$ fm-decision-hold.sh hold ... half-run
sample-operator-review-decision-half-run
$ fm-decision-hold.sh hold ... submission
sample-operator-review-decision-submission
$ fm-decision-hold.sh complete sample-operator-review half-run submission
complete: sample-operator-review decision inventory reviewed (half-run,submission)
$ fm-decision-hold.sh decline ... --decision-file half-run.txt
declined: sample-operator-review-decision-half-run
$ tasks-axi show declined hold --full (observable persisted record)
task:
  id: sample-operator-review-decision-half-run
  title: Run half benchmark?
  state: done
  blocked: no
  blocked_by: none
  held: no
  hold_reason: captain answer pending
  hold_kind: captain
  hold_until: "-"
  kind: captain
  repo: sample
  priority: "-"
  created: "-"
  closed: 2026-08-13
  deps: none
  links: none
  body: "Resolution recorded by fm-decision-hold.\nDecision digest: 0b69531b4773e5ca14fac0c46abf28b58b7fe72f0030d5ae26af882003434dd2\nRouted identities: (none)\nResolution mode: declined\n\nCaptain decision:\nDeclined: do not run the half benchmark.\n\nRouted work:\n(none)"
$ tasks-axi done submission-hold  # reproduce out-of-script incident
ok: done sample-operator-review-decision-submission -> Done
help[1]:
  - Run `tasks-axi ready` to dispatch work unblocked by this
$ fm-decision-hold.sh verify sample-operator-review  # expected refusal before repair
fm-decision-hold: captain decision sample-operator-review-decision-submission is neither actively held nor durably resolved
verify exit before repair: 1
$ fm-decision-hold.sh repair ... --decision-file submission.txt
repaired: sample-operator-review-decision-submission
$ tasks-axi show repaired hold --full (observable persisted record)
task:
  id: sample-operator-review-decision-submission
  title: Submit upstream?
  state: done
  blocked: no
  blocked_by: none
  held: no
  hold_reason: captain answer pending
  hold_kind: captain
  hold_until: "-"
  kind: captain
  repo: sample
  priority: "-"
  created: "-"
  closed: 2026-08-13
  deps: none
  links: none
  body: "Resolution recorded by fm-decision-hold.\nDecision digest: 1cf77b835fbd20806387f94eac52425a4578d4b9a51da55744829890674d8c5c\nRouted identities: (none)\nResolution mode: repaired\n\nCaptain decision:\nDeclined: do not submit upstream.\n\nRouted work:\n(none)"
$ fm-decision-hold.sh verify sample-operator-review
verified: sample-operator-review unresolved-decision inventory
$ fm-bearings-snapshot.sh --json | jq decisions_open
{
  "decisions_open": []
}
$ fm-teardown.sh sample-operator-review
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: never, grace 300s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  repair a missing or failed watcher cycle with the Pi tool fm_watch_arm_pi, or restart Pi with -e /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KZY6MFBWT4GSZKT4JBAT3XX5/.pi/extensions/fm-primary-turnend-guard.ts -e /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KZY6MFBWT4GSZKT4JBAT3XX5/.pi/extensions/fm-primary-pi-watch.ts if the extensions are not loaded.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
teardown sample-operator-review complete (window firstmate:fm-sample-operator-review, worktree /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/no-mistakes-evidence/01KZY6MFBWT4GSZKT4JBAT3XX5/decision-hold-demo-home/projects/missing-scratch)
Backlog: sample-operator-review just finished. Run tasks-axi done sample-operator-review --report data/sample-operator-review/report.md, then run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due.
teardown state check: origin metadata removed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"55138befa8e8136386327b6012d7b4b1f8ee9b60","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --check 85cefa90d1a6bd35f0c3882a04feef7a37e0be75..6c5c600ca0cf1999b144e360b658f2716bd78b9f`
- `bash tests/fm-decision-hold-lifecycle.test.sh`
- <code>Manual public-interface flow: created two captain holds, declined one without routed work, reproduced an out-of-script `tasks-axi done`, observed `verify` refuse, repaired it with a decision file, observed `verify` pass, confirmed Bearings had no open decisions, and completed scout teardown.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
