### PR TITLE
feat(herdr): add passive no-mistakes observer panes

### DIFF
--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -25,8 +25,8 @@
 # stays bounded by new appends instead of re-reading each task's whole lifetime
 # log every time.
 
-# Directory of this library, used to locate the sibling fm-crew-state.sh reader.
-# Resolved at source time from BASH_SOURCE so it works whether sourced by a
+# Directory of this library, used to locate sibling current-state and optional
+# Herdr visual-observer helpers. Resolved at source time from BASH_SOURCE so it works whether sourced by a
 # bin/ script (which sets its own SCRIPT_DIR) or directly by a test.
 _FM_CLASSIFY_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null)" || _FM_CLASSIFY_LIB_DIR="."
 
@@ -674,14 +674,21 @@ signal_reason_is_actionable() {  # <file> ...
 # run it only on no-verb signal and first-sighting stale paths, never every wake.
 # FM_CREW_STATE_BIN lets tests stub the verdict.
 crew_absorb_class() {  # <id>
-  local id=$1 line state src
+  local id=$1 line state src observer_bin
   [ -n "$id" ] || { printf 'none'; return; }
   line=$("$FM_CREW_STATE_BIN" "$id" 2>/dev/null) || true
   case "$line" in state:*) ;; *) printf 'none'; return ;; esac
   state=${line#state: }; state=${state%% *}
+  src=${line#*source: }; src=${src%% *}
+  # The watcher already obtained a current, branch-and-head-attributed run-step.
+  # Reconcile the optional Herdr observer only on that path, keeping all Herdr
+  # lifecycle operations in its focused helper rather than in watcher logic.
+  if [ "$src" = run-step ]; then
+    observer_bin=${FM_HERDR_NM_OBSERVER_BIN:-$_FM_CLASSIFY_LIB_DIR/fm-herdr-no-mistakes-observer.sh}
+    [ -x "$observer_bin" ] && "$observer_bin" reconcile "$id" >/dev/null 2>&1 || true
+  fi
   if [ "$state" = paused ]; then printf 'paused'; return; fi
   if [ "$state" = working ]; then
-    src=${line#*source: }; src=${src%% *}
     case "$src" in run-step|pane) printf 'working'; return ;; esac
   fi
   printf 'none'

--- a/bin/fm-herdr-no-mistakes-observer.sh
+++ b/bin/fm-herdr-no-mistakes-observer.sh
@@ -46,24 +46,31 @@ observer_enabled() {
 }
 
 # Parse exactly one version-1 sidecar.  Values are held in OBS_* globals.
-sidecar_snapshot() { # <path> <task-id>
-  local path=$1 id=$2 version task_id run_id session task_pane observer_pane worktree
-  OBS_VERSION= OBS_TASK_ID= OBS_RUN_ID= OBS_SESSION= OBS_TASK_PANE= OBS_PANE= OBS_WORKTREE=
+sidecar_snapshot_for_state() { # <path> <task-id> <state>
+  local path=$1 id=$2 expected_state=$3 version state attach_state task_id run_id session task_pane observer_pane worktree
+  OBS_VERSION= OBS_STATE= OBS_ATTACH_STATE= OBS_TASK_ID= OBS_RUN_ID= OBS_SESSION= OBS_TASK_PANE= OBS_PANE= OBS_WORKTREE=
   [ -f "$path" ] && [ ! -L "$path" ] || return 1
   version=$(meta_exact "$path" version) || return 1
+  state=$(meta_exact "$path" state) || return 1
+  attach_state=$(meta_exact "$path" attach_state) || return 1
   task_id=$(meta_exact "$path" task_id) || return 1
   run_id=$(meta_exact "$path" run_id) || return 1
   session=$(meta_exact "$path" session) || return 1
   task_pane=$(meta_exact "$path" task_pane) || return 1
   observer_pane=$(meta_exact "$path" observer_pane) || return 1
   worktree=$(meta_exact "$path" worktree) || return 1
-  [ "$version" = 1 ] && [ "$task_id" = "$id" ] || return 1
+  [ "$version" = 1 ] && [ "$state" = "$expected_state" ] && [ "$task_id" = "$id" ] || return 1
+  case "$state:$attach_state" in bound:pending|bound:ready|quarantined:quarantined) ;; *) return 1 ;; esac
   case "$run_id$session$task_pane$observer_pane" in *$'\n'*|*$'\r'*|*$'\t'*) return 1 ;; esac
   [ "$task_pane" != "$observer_pane" ] || return 1
   [ -d "$worktree" ] && [ ! -L "$worktree" ] || return 1
-  OBS_VERSION=$version OBS_TASK_ID=$task_id OBS_RUN_ID=$run_id OBS_SESSION=$session
+  OBS_VERSION=$version OBS_STATE=$state OBS_ATTACH_STATE=$attach_state OBS_TASK_ID=$task_id OBS_RUN_ID=$run_id OBS_SESSION=$session
   OBS_TASK_PANE=$task_pane OBS_PANE=$observer_pane OBS_WORKTREE=$(cd "$worktree" && pwd -P)
 }
+
+sidecar_snapshot() { sidecar_snapshot_for_state "$1" "$2" bound; }
+
+sidecar_reservation_snapshot() { sidecar_snapshot_for_state "$1" "$2" quarantined; }
 
 # Confirm current Herdr identities, including the exact task pane's tab/workspace.
 task_binding() { # <meta> <id>
@@ -144,12 +151,18 @@ observer_close_safe() { # <session> <observer-pane> <task-pane>
   ' >/dev/null 2>&1
 }
 
-sidecar_write() { # <path> <task-id> <run-id> <session> <task-pane> <observer-pane> <worktree>
-  local path=$1 id=$2 run_id=$3 session=$4 task_pane=$5 observer_pane=$6 worktree=$7 tmp
+sidecar_publish() { # <path> <task-id> <run-id> <session> <task-pane> <observer-pane> <worktree> <state> <attach-state> <replace-state>
+  local path=$1 id=$2 run_id=$3 session=$4 task_pane=$5 observer_pane=$6 worktree=$7 state=$8 attach_state=$9 replace_state=${10} tmp
+  case "$state:$attach_state:$replace_state" in
+    bound:pending:reservation|bound:ready:bound|quarantined:quarantined:absent) ;;
+    *) return 1 ;;
+  esac
   tmp=$(umask 077; mktemp "$STATE/.${id}.herdr-no-mistakes-observer.XXXXXX") || return 1
   chmod 0600 "$tmp" || { rm -f -- "$tmp"; return 1; }
   if ! {
     printf 'version=1\n'
+    printf 'state=%s\n' "$state"
+    printf 'attach_state=%s\n' "$attach_state"
     printf 'task_id=%s\n' "$id"
     printf 'run_id=%s\n' "$run_id"
     printf 'session=%s\n' "$session"
@@ -157,10 +170,51 @@ sidecar_write() { # <path> <task-id> <run-id> <session> <task-pane> <observer-pa
     printf 'observer_pane=%s\n' "$observer_pane"
     printf 'worktree=%s\n' "$worktree"
   } > "$tmp"; then rm -f -- "$tmp"; return 1; fi
-  # The caller holds the task lock.  Refuse rather than replacing any sidecar
-  # that appeared before publication.
-  if [ -e "$path" ] || [ -L "$path" ]; then rm -f -- "$tmp"; return 1; fi
+  case "$replace_state" in
+    absent) [ ! -e "$path" ] && [ ! -L "$path" ] || { rm -f -- "$tmp"; return 1; } ;;
+    reservation) sidecar_reservation_snapshot "$path" "$id" || { rm -f -- "$tmp"; return 1; } ;;
+    bound) sidecar_snapshot "$path" "$id" || { rm -f -- "$tmp"; return 1; } ;;
+  esac
   mv -f -- "$tmp" "$path"
+}
+
+sidecar_reserve() { # <path> <task-id> <run-id> <session> <task-pane> <worktree>
+  sidecar_publish "$1" "$2" "$3" "$4" "$5" unresolved "$6" quarantined quarantined absent
+}
+
+sidecar_bind_reservation() { # <path> <task-id> <run-id> <session> <task-pane> <observer-pane> <worktree>
+  local path=$1 id=$2 run_id=$3 session=$4 task_pane=$5 observer_pane=$6 worktree=$7
+  sidecar_reservation_snapshot "$path" "$id" \
+    && [ "$OBS_RUN_ID" = "$run_id" ] \
+    && [ "$OBS_SESSION" = "$session" ] \
+    && [ "$OBS_TASK_PANE" = "$task_pane" ] \
+    && [ "$OBS_WORKTREE" = "$worktree" ] \
+    || return 1
+  sidecar_publish "$path" "$id" "$run_id" "$session" "$task_pane" "$observer_pane" "$worktree" bound pending reservation
+}
+
+sidecar_mark_ready() { # <path> <task-id> <run-id> <session> <task-pane> <observer-pane> <worktree>
+  local path=$1 id=$2 run_id=$3 session=$4 task_pane=$5 observer_pane=$6 worktree=$7
+  sidecar_snapshot "$path" "$id" \
+    && [ "$OBS_ATTACH_STATE" = pending ] \
+    && [ "$OBS_RUN_ID" = "$run_id" ] \
+    && [ "$OBS_SESSION" = "$session" ] \
+    && [ "$OBS_TASK_PANE" = "$task_pane" ] \
+    && [ "$OBS_PANE" = "$observer_pane" ] \
+    && [ "$OBS_WORKTREE" = "$worktree" ] \
+    || return 1
+  sidecar_publish "$path" "$id" "$run_id" "$session" "$task_pane" "$observer_pane" "$worktree" bound ready bound
+}
+
+observer_attach() { # <sidecar> <task-id>
+  local sidecar=$1 id=$2
+  sidecar_snapshot "$sidecar" "$id" && [ "$OBS_ATTACH_STATE" = pending ] || return 1
+  if fm_backend_herdr_cli "$OBS_SESSION" pane run "$OBS_PANE" no-mistakes attach --run "$OBS_RUN_ID" >/dev/null 2>&1; then
+    sidecar_mark_ready "$sidecar" "$id" "$OBS_RUN_ID" "$OBS_SESSION" "$OBS_TASK_PANE" "$OBS_PANE" "$OBS_WORKTREE" \
+      || warn "$id observer attach started but its ready state could not be recorded"
+  else
+    warn "$id observer attach command could not start; retaining its exact sidecar for retry"
+  fi
 }
 
 retire_exact() { # <sidecar> <task-id> [<metadata-present>]
@@ -254,6 +308,7 @@ reconcile() { # <task-id>
       && [ "$OBS_TASK_PANE" = "$TASK_PANE" ] \
       && [ "$OBS_WORKTREE" = "$TASK_WORKTREE" ] \
       && observer_pane_matches "$OBS_SESSION" "$OBS_PANE" "$TASK_WORKSPACE" "$TASK_TAB"; then
+      [ "$OBS_ATTACH_STATE" = ready ] || observer_attach "$sidecar" "$id"
       fm_lock_release "$session_lock" || true
       return 0
     fi
@@ -263,21 +318,22 @@ reconcile() { # <task-id>
   fi
   observer_enabled || { fm_lock_release "$session_lock" || true; return 0; }
 
+  sidecar_reserve "$sidecar" "$id" "$ACTIVE_RUN_ID" "$TASK_SESSION" "$TASK_PANE" "$TASK_WORKTREE" || {
+    warn "$id observer reservation could not be published; refusing a split"; fm_lock_release "$session_lock" || true; return 0;
+  }
+
   split=$(fm_backend_herdr_cli "$TASK_SESSION" pane split "$TASK_PANE" --direction right --ratio 0.30 --cwd "$TASK_WORKTREE" --no-focus 2>/dev/null) || {
-    warn "$id split failed"; fm_lock_release "$session_lock" || true; return 0;
+    warn "$id split failed; preserving its quarantine reservation"; fm_lock_release "$session_lock" || true; return 0;
   }
   observer=$(printf '%s' "$split" | jq -r '.result.pane.pane_id // empty' 2>/dev/null)
   [ -n "$observer" ] && [ "$observer" != "$TASK_PANE" ] \
     && observer_pane_matches "$TASK_SESSION" "$observer" "$TASK_WORKSPACE" "$TASK_TAB" || {
-      warn "$id split response was ambiguous; refusing sidecar publication"; fm_lock_release "$session_lock" || true; return 0;
+      warn "$id split response was ambiguous; preserving its quarantine reservation"; fm_lock_release "$session_lock" || true; return 0;
     }
-  sidecar_write "$sidecar" "$id" "$ACTIVE_RUN_ID" "$TASK_SESSION" "$TASK_PANE" "$observer" "$TASK_WORKTREE" || {
-    warn "$id observer sidecar could not be published; refusing another viewer"; fm_lock_release "$session_lock" || true; return 0;
+  sidecar_bind_reservation "$sidecar" "$id" "$ACTIVE_RUN_ID" "$TASK_SESSION" "$TASK_PANE" "$observer" "$TASK_WORKTREE" || {
+    warn "$id observer sidecar could not be bound; preserving its quarantine reservation"; fm_lock_release "$session_lock" || true; return 0;
   }
-  # pane run only starts the passive attach display in the already-bound pane.
-  # It cannot start or steer a validation run.
-  fm_backend_herdr_cli "$TASK_SESSION" pane run "$observer" no-mistakes attach --run "$ACTIVE_RUN_ID" >/dev/null 2>&1 \
-    || warn "$id observer attach command could not start; retaining its exact sidecar for safe cleanup"
+  observer_attach "$sidecar" "$id"
   fm_lock_release "$session_lock" || true
 }
 

--- a/bin/fm-herdr-no-mistakes-observer.sh
+++ b/bin/fm-herdr-no-mistakes-observer.sh
@@ -250,24 +250,34 @@ retire_exact() { # <sidecar> <task-id> [<metadata-present>]
   sidecar_snapshot "$sidecar" "$id" && rm -f -- "$sidecar"
 }
 
-retire() { # <task-id>
-  local id=$1 sidecar="$STATE/$1$FM_HERDR_NM_OBSERVER_SUFFIX" task_lock session_lock meta_present=0
+retire() { # <task-id> [<held-task-lock-pid> <held-task-lock-identity>]
+  local id=$1 sidecar="$STATE/$1$FM_HERDR_NM_OBSERVER_SUFFIX" task_lock session_lock meta_present=0 lock_pid=${2:-} lock_identity=${3:-} acquired_task_lock=0
   fm_task_id_creation_valid "$id" || return 0
   [ -f "$sidecar" ] && [ ! -L "$sidecar" ] || return 0
   sidecar_snapshot "$sidecar" "$id" || { warn "$id sidecar is unreadable; preserving it"; return 0; }
   task_lock="$STATE/.spawn-$id.lock"
-  fm_lock_try_acquire "$task_lock" || return 0
+  if [ -n "$lock_pid$lock_identity" ]; then
+    case "$lock_pid" in ''|*[!0-9]*) return 0 ;; esac
+    [ -n "$lock_identity" ] \
+      && [ "$(cat "$task_lock/pid" 2>/dev/null || true)" = "$lock_pid" ] \
+      && [ "$(cat "$task_lock/pid-identity" 2>/dev/null || true)" = "$lock_identity" ] \
+      && [ "$(fm_pid_identity "$lock_pid" 2>/dev/null || true)" = "$lock_identity" ] \
+      || return 0
+  else
+    fm_lock_try_acquire "$task_lock" || return 0
+    acquired_task_lock=1
+  fi
   session_lock=$(fm_backend_herdr_presentation_session_lock_path "$OBS_SESSION" 2>/dev/null) || {
-    fm_lock_release "$task_lock" || true; return 0;
+    [ "$acquired_task_lock" = 1 ] && fm_lock_release "$task_lock" || true; return 0;
   }
   if ! fm_lock_try_acquire "$session_lock"; then
-    fm_lock_release "$task_lock" || true
+    [ "$acquired_task_lock" = 1 ] && fm_lock_release "$task_lock" || true
     return 0
   fi
   [ -f "$STATE/$id.meta" ] && meta_present=1
   retire_exact "$sidecar" "$id" "$meta_present"
   fm_lock_release "$session_lock" || true
-  fm_lock_release "$task_lock" || true
+  [ "$acquired_task_lock" = 1 ] && fm_lock_release "$task_lock" || true
 }
 
 reconcile() { # <task-id>
@@ -285,6 +295,10 @@ reconcile() { # <task-id>
     # Metadata disappearance may be part of normal cleanup.  The sidecar alone
     # is enough to identify its observer, but never to close a malformed one.
     [ -e "$sidecar" ] || [ -L "$sidecar" ] || return 0
+    if [ -e "$meta" ] || [ -L "$meta" ]; then
+      warn "$id task metadata is unreadable or conflicting; preserving sidecar"
+      return 0
+    fi
     sidecar_snapshot "$sidecar" "$id" || { warn "$id sidecar is unreadable; preserving it"; return 0; }
     session_lock=$(fm_backend_herdr_presentation_session_lock_path "$OBS_SESSION" 2>/dev/null) || return 0
     fm_lock_try_acquire "$session_lock" || return 0
@@ -340,5 +354,6 @@ reconcile() { # <task-id>
 case "${1:-}" in
   reconcile) [ -n "${2:-}" ] || { usage; exit 2; }; reconcile "$2" ;;
   retire)    [ -n "${2:-}" ] || { usage; exit 2; }; retire "$2" ;;
+  retire-locked) [ -n "${2:-}" ] && [ -n "${3:-}" ] && [ -n "${4:-}" ] || { usage; exit 2; }; retire "$2" "$3" "$4" ;;
   *) usage; exit 2 ;;
 esac

--- a/bin/fm-herdr-no-mistakes-observer.sh
+++ b/bin/fm-herdr-no-mistakes-observer.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# fm-herdr-no-mistakes-observer.sh - own the optional Herdr validation viewer.
+#
+# Usage: fm-herdr-no-mistakes-observer.sh reconcile <task-id>
+#
+# This is deliberately a visual-only lifecycle.  It never invokes a pipeline
+# command other than the read-only `no-mistakes axi status`, and it never makes
+# a sidecar authoritative for a task endpoint, recovery, or delivery.
+#
+# With local config/herdr-no-mistakes-observer-panes present, reconcile creates
+# one unfocused right split beside an ordinary Herdr ship task whose own branch
+# has a non-terminal no-mistakes run.  The private sidecar is the exact binding
+# required to reuse or close that split.  Any malformed, stale, or conflicting
+# sidecar is quarantined in place: it never licenses a duplicate viewer or a
+# close.  Normal task teardown calls `retire`, so an exact viewer is retired
+# before the task pane is removed.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+NM_TIMEOUT=${FM_HERDR_NM_OBSERVER_TIMEOUT:-10}
+FM_HERDR_NM_OBSERVER_CONFIG="herdr-no-mistakes-observer-panes"
+FM_HERDR_NM_OBSERVER_SUFFIX=".herdr-no-mistakes-observer"
+
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-backend.sh
+. "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-nm-run-lib.sh
+. "$SCRIPT_DIR/fm-nm-run-lib.sh"
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+fm_backend_source herdr
+
+warn() { printf 'warning: herdr no-mistakes observer: %s\n' "$*" >&2; }
+
+usage() { echo "usage: fm-herdr-no-mistakes-observer.sh reconcile|retire <task-id>" >&2; }
+
+meta_exact() { fm_backend_meta_exact_value "$1" "$2"; }
+
+observer_enabled() {
+  [ -f "$CONFIG/$FM_HERDR_NM_OBSERVER_CONFIG" ] && [ ! -L "$CONFIG/$FM_HERDR_NM_OBSERVER_CONFIG" ]
+}
+
+# Parse exactly one version-1 sidecar.  Values are held in OBS_* globals.
+sidecar_snapshot() { # <path> <task-id>
+  local path=$1 id=$2 version task_id run_id session task_pane observer_pane worktree
+  OBS_VERSION= OBS_TASK_ID= OBS_RUN_ID= OBS_SESSION= OBS_TASK_PANE= OBS_PANE= OBS_WORKTREE=
+  [ -f "$path" ] && [ ! -L "$path" ] || return 1
+  version=$(meta_exact "$path" version) || return 1
+  task_id=$(meta_exact "$path" task_id) || return 1
+  run_id=$(meta_exact "$path" run_id) || return 1
+  session=$(meta_exact "$path" session) || return 1
+  task_pane=$(meta_exact "$path" task_pane) || return 1
+  observer_pane=$(meta_exact "$path" observer_pane) || return 1
+  worktree=$(meta_exact "$path" worktree) || return 1
+  [ "$version" = 1 ] && [ "$task_id" = "$id" ] || return 1
+  case "$run_id$session$task_pane$observer_pane" in *$'\n'*|*$'\r'*|*$'\t'*) return 1 ;; esac
+  [ "$task_pane" != "$observer_pane" ] || return 1
+  [ -d "$worktree" ] && [ ! -L "$worktree" ] || return 1
+  OBS_VERSION=$version OBS_TASK_ID=$task_id OBS_RUN_ID=$run_id OBS_SESSION=$session
+  OBS_TASK_PANE=$task_pane OBS_PANE=$observer_pane OBS_WORKTREE=$(cd "$worktree" && pwd -P)
+}
+
+# Confirm current Herdr identities, including the exact task pane's tab/workspace.
+task_binding() { # <meta> <id>
+  local meta=$1 id=$2 kind session task_pane workspace tab worktree pane_json
+  TASK_SESSION= TASK_PANE= TASK_WORKSPACE= TASK_TAB= TASK_WORKTREE=
+  [ -f "$meta" ] && [ ! -L "$meta" ] || return 1
+  fm_backend_validate_task_endpoint "$meta" "$id" >/dev/null 2>&1 || return 1
+  [ "$FM_BACKEND_VALIDATED_BACKEND" = herdr ] || return 1
+  kind=$(meta_exact "$meta" kind) || return 1
+  [ "$kind" = ship ] || return 1
+  session=$(meta_exact "$meta" herdr_session) || return 1
+  task_pane=$(meta_exact "$meta" herdr_pane_id) || return 1
+  workspace=$(meta_exact "$meta" herdr_workspace_id) || return 1
+  tab=$(meta_exact "$meta" herdr_tab_id) || return 1
+  worktree=$(meta_exact "$meta" worktree) || return 1
+  [ "$FM_BACKEND_VALIDATED_TARGET" = "$session:$task_pane" ] || return 1
+  [ -d "$worktree" ] && [ ! -L "$worktree" ] || return 1
+  worktree=$(cd "$worktree" && pwd -P) || return 1
+  pane_json=$(fm_backend_herdr_cli "$session" pane get "$task_pane" 2>/dev/null) || return 1
+  printf '%s' "$pane_json" | jq -e --arg pane "$task_pane" --arg workspace "$workspace" --arg tab "$tab" '
+    .result.pane.pane_id == $pane
+    and .result.pane.workspace_id == $workspace
+    and .result.pane.tab_id == $tab
+  ' >/dev/null 2>&1 || return 1
+  TASK_SESSION=$session TASK_PANE=$task_pane TASK_WORKSPACE=$workspace TASK_TAB=$tab TASK_WORKTREE=$worktree
+}
+
+# Bind the current run to a worktree by its branch and code identity.  This is
+# read-only. MATCH_RUN_ACTIVE distinguishes a live validation from a terminal
+# result so terminal cleanup can still prove that its sidecar belongs to this
+# task rather than an old run on a reused branch.
+matching_run() { # <worktree>
+  local wt=$1 out branch run_id run_branch run_head outcome status
+  MATCH_RUN_ID= MATCH_RUN_ACTIVE=0
+  branch=$(git -C "$wt" symbolic-ref --quiet --short HEAD 2>/dev/null) || return 1
+  out=$(fm_nm_run "$wt" "$NM_TIMEOUT" axi status)
+  [ -n "$out" ] || return 1
+  run_id=$(fm_nm_strip_quotes "$(fm_nm_field "$out" id)")
+  run_branch=$(fm_nm_strip_quotes "$(fm_nm_field "$out" branch)")
+  run_head=$(fm_nm_strip_quotes "$(fm_nm_field "$out" head)")
+  outcome=$(fm_nm_strip_quotes "$(fm_nm_field "$out" outcome)")
+  status=$(fm_nm_strip_quotes "$(fm_nm_field "$out" status)")
+  [ -n "$run_id" ] && [ "$run_branch" = "$branch" ] || return 1
+  fm_nm_head_matches_worktree "$wt" "$run_head" || return 1
+  MATCH_RUN_ID=$run_id
+  [ -n "$outcome" ] && return 0
+  case "$status" in completed|failed|cancelled) return 0 ;; esac
+  MATCH_RUN_ACTIVE=1
+}
+
+active_run() { # <worktree>
+  ACTIVE_RUN_ID=
+  matching_run "$1" || return 1
+  [ "$MATCH_RUN_ACTIVE" = 1 ] || return 1
+  ACTIVE_RUN_ID=$MATCH_RUN_ID
+}
+
+observer_pane_matches() { # <session> <observer-pane> <workspace> <tab>
+  local session=$1 pane=$2 workspace=$3 tab=$4 out
+  out=$(fm_backend_herdr_cli "$session" pane get "$pane" 2>/dev/null) || return 1
+  printf '%s' "$out" | jq -e --arg pane "$pane" --arg workspace "$workspace" --arg tab "$tab" '
+    .result.pane.pane_id == $pane
+    and .result.pane.workspace_id == $workspace
+    and .result.pane.tab_id == $tab
+  ' >/dev/null 2>&1
+}
+
+# A split can share the task tab, so tab focus is not captain-pane authority.
+# Closing the observer is safe only when this exact pane response says it is not
+# focused.  The task pane is separately bound and must always differ.
+observer_close_safe() { # <session> <observer-pane> <task-pane>
+  local session=$1 pane=$2 task_pane=$3 out
+  [ "$pane" != "$task_pane" ] || return 1
+  out=$(fm_backend_herdr_cli "$session" pane get "$pane" 2>/dev/null) || return 1
+  printf '%s' "$out" | jq -e --arg pane "$pane" '
+    .result.pane.pane_id == $pane
+    and .result.pane.focused != true
+  ' >/dev/null 2>&1
+}
+
+sidecar_write() { # <path> <task-id> <run-id> <session> <task-pane> <observer-pane> <worktree>
+  local path=$1 id=$2 run_id=$3 session=$4 task_pane=$5 observer_pane=$6 worktree=$7 tmp
+  tmp=$(umask 077; mktemp "$STATE/.${id}.herdr-no-mistakes-observer.XXXXXX") || return 1
+  chmod 0600 "$tmp" || { rm -f -- "$tmp"; return 1; }
+  if ! {
+    printf 'version=1\n'
+    printf 'task_id=%s\n' "$id"
+    printf 'run_id=%s\n' "$run_id"
+    printf 'session=%s\n' "$session"
+    printf 'task_pane=%s\n' "$task_pane"
+    printf 'observer_pane=%s\n' "$observer_pane"
+    printf 'worktree=%s\n' "$worktree"
+  } > "$tmp"; then rm -f -- "$tmp"; return 1; fi
+  # The caller holds the task lock.  Refuse rather than replacing any sidecar
+  # that appeared before publication.
+  if [ -e "$path" ] || [ -L "$path" ]; then rm -f -- "$tmp"; return 1; fi
+  mv -f -- "$tmp" "$path"
+}
+
+retire_exact() { # <sidecar> <task-id> [<metadata-present>]
+  local sidecar=$1 id=$2 meta_present=${3:-0} session pane task_pane
+  sidecar_snapshot "$sidecar" "$id" || { warn "$id sidecar is unreadable; preserving it"; return 0; }
+  session=$OBS_SESSION pane=$OBS_PANE task_pane=$OBS_TASK_PANE
+  if [ "$meta_present" = 1 ]; then
+    task_binding "$STATE/$id.meta" "$id" || { warn "$id sidecar does not agree with current task metadata; preserving it"; return 0; }
+    [ "$TASK_SESSION" = "$session" ] && [ "$TASK_PANE" = "$task_pane" ] && [ "$TASK_WORKTREE" = "$OBS_WORKTREE" ] || {
+      warn "$id sidecar conflicts with current task binding; preserving it"; return 0;
+    }
+    matching_run "$TASK_WORKTREE" && [ "$MATCH_RUN_ID" = "$OBS_RUN_ID" ] || {
+      warn "$id sidecar run binding is stale or unreadable; preserving it"; return 0;
+    }
+  fi
+  [ "$pane" != "$task_pane" ] || { warn "$id sidecar names the task pane as observer; preserving it"; return 0; }
+  observer_pane_matches "$session" "$pane" "${TASK_WORKSPACE:-$(fm_backend_herdr_cli "$session" pane get "$pane" 2>/dev/null | jq -r '.result.pane.workspace_id // empty')}" "${TASK_TAB:-$(fm_backend_herdr_cli "$session" pane get "$pane" 2>/dev/null | jq -r '.result.pane.tab_id // empty')}" || {
+    # A stale/missing observer is not a closure authority.  Retire only a
+    # sidecar whose exact pane is positively gone, never an unreadable one.
+    [ "$(fm_backend_herdr_pane_presence_state "$session" "$pane")" = dead ] || { warn "$id observer pane is unreadable or mismatched; preserving sidecar"; return 0; }
+  }
+  if [ "$(fm_backend_herdr_pane_presence_state "$session" "$pane")" = dead ]; then
+    sidecar_snapshot "$sidecar" "$id" && rm -f -- "$sidecar"
+    return 0
+  fi
+  observer_close_safe "$session" "$pane" "$task_pane" || {
+    warn "$id observer is the captain pane or has an ambiguous identity; preserving sidecar"; return 0;
+  }
+  fm_backend_herdr_explicit_close_pane_confirmed "$session" "$pane" || {
+    warn "$id observer close was refused or unconfirmed; preserving sidecar"; return 0;
+  }
+  [ "$(fm_backend_herdr_pane_presence_state "$session" "$pane")" = dead ] || { warn "$id observer close was not confirmed; preserving sidecar"; return 0; }
+  sidecar_snapshot "$sidecar" "$id" && rm -f -- "$sidecar"
+}
+
+retire() { # <task-id>
+  local id=$1 sidecar="$STATE/$1$FM_HERDR_NM_OBSERVER_SUFFIX" task_lock session_lock meta_present=0
+  fm_task_id_creation_valid "$id" || return 0
+  [ -f "$sidecar" ] && [ ! -L "$sidecar" ] || return 0
+  sidecar_snapshot "$sidecar" "$id" || { warn "$id sidecar is unreadable; preserving it"; return 0; }
+  task_lock="$STATE/.spawn-$id.lock"
+  fm_lock_try_acquire "$task_lock" || return 0
+  session_lock=$(fm_backend_herdr_presentation_session_lock_path "$OBS_SESSION" 2>/dev/null) || {
+    fm_lock_release "$task_lock" || true; return 0;
+  }
+  if ! fm_lock_try_acquire "$session_lock"; then
+    fm_lock_release "$task_lock" || true
+    return 0
+  fi
+  [ -f "$STATE/$id.meta" ] && meta_present=1
+  retire_exact "$sidecar" "$id" "$meta_present"
+  fm_lock_release "$session_lock" || true
+  fm_lock_release "$task_lock" || true
+}
+
+reconcile() { # <task-id>
+  local id=$1 meta="$STATE/$1.meta" sidecar="$STATE/$1$FM_HERDR_NM_OBSERVER_SUFFIX" task_lock session_lock split observer
+  fm_task_id_creation_valid "$id" || return 0
+  [ -d "$STATE" ] && [ ! -L "$STATE" ] || return 0
+  # A disabled home has no observer lifecycle unless it already owns a sidecar
+  # that needs conservative retirement.
+  { [ -e "$sidecar" ] || [ -L "$sidecar" ]; } || observer_enabled || return 0
+  task_lock="$STATE/.spawn-$id.lock"
+  fm_lock_try_acquire "$task_lock" || return 0
+  trap 'fm_lock_release "$task_lock" >/dev/null 2>&1 || true' RETURN
+
+  if ! task_binding "$meta" "$id"; then
+    # Metadata disappearance may be part of normal cleanup.  The sidecar alone
+    # is enough to identify its observer, but never to close a malformed one.
+    [ -e "$sidecar" ] || [ -L "$sidecar" ] || return 0
+    sidecar_snapshot "$sidecar" "$id" || { warn "$id sidecar is unreadable; preserving it"; return 0; }
+    session_lock=$(fm_backend_herdr_presentation_session_lock_path "$OBS_SESSION" 2>/dev/null) || return 0
+    fm_lock_try_acquire "$session_lock" || return 0
+    retire_exact "$sidecar" "$id" 0
+    fm_lock_release "$session_lock" || true
+    return 0
+  fi
+
+  session_lock=$(fm_backend_herdr_presentation_session_lock_path "$TASK_SESSION" 2>/dev/null) || return 0
+  fm_lock_try_acquire "$session_lock" || return 0
+  if ! active_run "$TASK_WORKTREE"; then
+    if [ -e "$sidecar" ] || [ -L "$sidecar" ]; then retire_exact "$sidecar" "$id" 1; fi
+    fm_lock_release "$session_lock" || true
+    return 0
+  fi
+
+  if [ -e "$sidecar" ] || [ -L "$sidecar" ]; then
+    if sidecar_snapshot "$sidecar" "$id" \
+      && [ "$OBS_RUN_ID" = "$ACTIVE_RUN_ID" ] \
+      && [ "$OBS_SESSION" = "$TASK_SESSION" ] \
+      && [ "$OBS_TASK_PANE" = "$TASK_PANE" ] \
+      && [ "$OBS_WORKTREE" = "$TASK_WORKTREE" ] \
+      && observer_pane_matches "$OBS_SESSION" "$OBS_PANE" "$TASK_WORKSPACE" "$TASK_TAB"; then
+      fm_lock_release "$session_lock" || true
+      return 0
+    fi
+    warn "$id observer sidecar is stale or conflicting; refusing a duplicate viewer"
+    fm_lock_release "$session_lock" || true
+    return 0
+  fi
+  observer_enabled || { fm_lock_release "$session_lock" || true; return 0; }
+
+  split=$(fm_backend_herdr_cli "$TASK_SESSION" pane split "$TASK_PANE" --direction right --ratio 0.30 --cwd "$TASK_WORKTREE" --no-focus 2>/dev/null) || {
+    warn "$id split failed"; fm_lock_release "$session_lock" || true; return 0;
+  }
+  observer=$(printf '%s' "$split" | jq -r '.result.pane.pane_id // empty' 2>/dev/null)
+  [ -n "$observer" ] && [ "$observer" != "$TASK_PANE" ] \
+    && observer_pane_matches "$TASK_SESSION" "$observer" "$TASK_WORKSPACE" "$TASK_TAB" || {
+      warn "$id split response was ambiguous; refusing sidecar publication"; fm_lock_release "$session_lock" || true; return 0;
+    }
+  sidecar_write "$sidecar" "$id" "$ACTIVE_RUN_ID" "$TASK_SESSION" "$TASK_PANE" "$observer" "$TASK_WORKTREE" || {
+    warn "$id observer sidecar could not be published; refusing another viewer"; fm_lock_release "$session_lock" || true; return 0;
+  }
+  # pane run only starts the passive attach display in the already-bound pane.
+  # It cannot start or steer a validation run.
+  fm_backend_herdr_cli "$TASK_SESSION" pane run "$observer" no-mistakes attach --run "$ACTIVE_RUN_ID" >/dev/null 2>&1 \
+    || warn "$id observer attach command could not start; retaining its exact sidecar for safe cleanup"
+  fm_lock_release "$session_lock" || true
+}
+
+case "${1:-}" in
+  reconcile) [ -n "${2:-}" ] || { usage; exit 2; }; reconcile "$2" ;;
+  retire)    [ -n "${2:-}" ] || { usage; exit 2; }; retire "$2" ;;
+  *) usage; exit 2 ;;
+esac

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -178,6 +178,9 @@ CONTROL_LOCK="$STATE/.control-$ID.lock"
 CONTROL_LOCK_HELD=0
 META_LOCK=
 META_LOCK_HELD=0
+OBSERVER_TASK_LOCK=
+OBSERVER_TASK_LOCK_HELD=0
+OBSERVER_TASK_LOCK_IDENTITY=
 DESCENDANT_LOCK_PATHS=()
 DESCENDANT_TASK_STATES=()
 DESCENDANT_TASK_IDS=()
@@ -195,6 +198,10 @@ teardown_release_locks() {
   if [ "$META_LOCK_HELD" = 1 ]; then
     fm_lock_release "$META_LOCK" || true
     META_LOCK_HELD=0
+  fi
+  if [ "$OBSERVER_TASK_LOCK_HELD" = 1 ]; then
+    fm_lock_release "$OBSERVER_TASK_LOCK" || true
+    OBSERVER_TASK_LOCK_HELD=0
   fi
   if [ "$CONTROL_LOCK_HELD" = 1 ]; then
     fm_lock_release "$CONTROL_LOCK" || true
@@ -2380,12 +2387,24 @@ fi
 # dedicated process-event and firstmate-home removal machinery further below,
 # not by task-worktree cleanup.
 if [ "$KIND" != secondmate ]; then
+  if [ "$BACKEND" = herdr ]; then
+    OBSERVER_TASK_LOCK="$STATE/.spawn-$ID.lock"
+    fm_lock_try_acquire "$OBSERVER_TASK_LOCK" || {
+      echo "error: observer lifecycle is already running for task $ID; nothing was changed" >&2
+      exit 1
+    }
+    OBSERVER_TASK_LOCK_HELD=1
+    OBSERVER_TASK_LOCK_IDENTITY=$(fm_pid_identity "${BASHPID:-$$}" 2>/dev/null) || {
+      echo "error: observer lifecycle lock identity could not be verified for task $ID; nothing was changed" >&2
+      exit 1
+    }
+  fi
   conclude_task_no_mistakes_run "$WT"
   # The optional Herdr validation viewer is a visual child only. Retire it
   # through its focused helper before returning the worktree or closing the
   # authoritative task pane; missing or ambiguous sidecars are preserved.
   if [ "$BACKEND" = herdr ]; then
-    "$SCRIPT_DIR/fm-herdr-no-mistakes-observer.sh" retire "$ID" || true
+    "$SCRIPT_DIR/fm-herdr-no-mistakes-observer.sh" retire-locked "$ID" "${BASHPID:-$$}" "$OBSERVER_TASK_LOCK_IDENTITY" || true
   fi
   reap_task_worktree_processes worktree "$WT" "$TASK_TMP"
 fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2381,6 +2381,12 @@ fi
 # not by task-worktree cleanup.
 if [ "$KIND" != secondmate ]; then
   conclude_task_no_mistakes_run "$WT"
+  # The optional Herdr validation viewer is a visual child only. Retire it
+  # through its focused helper before returning the worktree or closing the
+  # authoritative task pane; missing or ambiguous sidecars are preserved.
+  if [ "$BACKEND" = herdr ]; then
+    "$SCRIPT_DIR/fm-herdr-no-mistakes-observer.sh" retire "$ID" || true
+  fi
   reap_task_worktree_processes worktree "$WT" "$TASK_TMP"
 fi
 

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -264,6 +264,13 @@ recorded_windows() {
   done
 }
 
+reconcile_no_mistakes_observer() {  # <task-id>
+  local task=$1 observer_bin
+  [ -n "$task" ] || return 0
+  observer_bin=${FM_HERDR_NM_OBSERVER_BIN:-$SCRIPT_DIR/fm-herdr-no-mistakes-observer.sh}
+  [ -x "$observer_bin" ] && "$observer_bin" reconcile "$task" >/dev/null 2>&1 || true
+}
+
 # Consecutive wedge-escalation count for a window past FM_WEDGE_DEMAND_INSPECT_COUNT
 # (default 3): a pane that keeps re-wedging on the SAME stale hash - each
 # escalation gets absorbed again as "still validating" one poll later, since the
@@ -1007,6 +1014,7 @@ EOF
   while IFS= read -r w; do
     kind=$(window_kind "$w")
     task=$(window_to_task "$w" "$STATE")
+    reconcile_no_mistakes_observer "$task"
     key=${w//:/_}
     key=${key//\//_}
     key=${key//./_}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,6 +85,9 @@ Legacy tmux metadata remains cleanup-compatible when its exact window name is `f
 [`herdr-backend.md`](herdr-backend.md#watching-and-task-containers) owns launcher-bound workspace placement, the label-only fallback, collision handling, and recovery behavior.
 The local `config/herdr-presentation-spaces` file instead opts a home out of, or explicitly in to, Herdr's default-on disposable single-task visual projection; [Presentation spaces](herdr-backend.md#presentation-spaces) owns its accepted values, default, Herdr version floor, migration, behavior, safety limits, recovery contract, and narrow locked session-start cleanup of exact restored idle-shell children.
 The setting is inherited into secondmate homes under the primary-authoritative contract owned by [`secondmate-provisioning`](../.agents/skills/secondmate-provisioning/SKILL.md).
+The separate local presence file `config/herdr-no-mistakes-observer-panes` explicitly enables an adjacent passive `no-mistakes attach` viewer for matching active validation runs in ordinary Herdr ship panes.
+It is disabled when absent, is not inherited into secondmate homes, and is inert on every non-Herdr backend.
+[`herdr-backend.md`](herdr-backend.md#live-no-mistakes-observer) owns its exact binding, cleanup, and safety contract.
 For normal herdr operations, `HERDR_SESSION` selects the named session, but destructive test cleanup must not rely on `HERDR_SESSION` alone.
 Use the explicit guarded cleanup path described in [`docs/herdr-backend.md`](herdr-backend.md) instead of `herdr server stop`.
 For normal zellij operations, `FM_ZELLIJ_SESSION` selects the named session and defaults to `firstmate`.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -308,6 +308,21 @@ Its before/after tripwire requires the live default-session snapshot to remain b
 The helper's header and `--help` own exact commands.
 Tests use thin compatibility wrappers in `tests/herdr-test-safety.sh` and never duplicate the destructive policy.
 
+## Live no-mistakes observer
+
+Create local `config/herdr-no-mistakes-observer-panes` to opt in to one passive observer beside an ordinary Herdr ship pane during its matching active validation run.
+`bin/fm-herdr-no-mistakes-observer.sh` verifies the task's authoritative Herdr metadata, live task pane, current worktree branch and code identity, and a non-terminal `no-mistakes axi status` result before splitting that exact pane to the right without focus.
+The new pane runs only `no-mistakes attach --run <run-id>` from the task's isolated worktree.
+It cannot start, restart, cancel, answer, approve, fix, or otherwise drive the pipeline.
+
+The helper writes an atomic private sidecar binding task id, run id, session, task pane, observer pane, and worktree.
+A sidecar is reusable only while its complete live binding agrees.
+A missing, unreadable, stale, or conflicting sidecar refuses both duplicate creation and pane closure.
+When the run is terminal, the task pane has disappeared, or normal task cleanup begins, the helper closes only its exact verified observer pane after confirming it differs from the task pane and is not the captain's active tab.
+It retires the sidecar only after structured pane absence confirms that close.
+The observer never contributes endpoint authority, recovery, delivery, or presentation-journal behavior.
+It is disabled by default, local to one home, and unsupported on non-Herdr backends.
+
 ## Active limits
 
 - Herdr remains experimental.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -318,7 +318,7 @@ It cannot start, restart, cancel, answer, approve, fix, or otherwise drive the p
 The helper writes an atomic private sidecar binding task id, run id, session, task pane, observer pane, and worktree.
 A sidecar is reusable only while its complete live binding agrees.
 A missing, unreadable, stale, or conflicting sidecar refuses both duplicate creation and pane closure.
-When the run is terminal, the task pane has disappeared, or normal task cleanup begins, the helper closes only its exact verified observer pane after confirming it differs from the task pane and is not the captain's active tab.
+When the run is terminal, the task pane has disappeared, or normal task cleanup begins, the helper closes only its exact verified observer pane after confirming it differs from the task pane and is not the captain's active pane.
 It retires the sidecar only after structured pane absence confirms that close.
 The observer never contributes endpoint authority, recovery, delivery, or presentation-journal behavior.
 It is disabled by default, local to one home, and unsupported on non-Herdr backends.

--- a/tests/fm-herdr-no-mistakes-observer.test.sh
+++ b/tests/fm-herdr-no-mistakes-observer.test.sh
@@ -19,6 +19,9 @@ CONFIG="$TMP_ROOT/home/config"
 FAKEBIN="$TMP_ROOT/fakebin"
 NM_STATUS="$TMP_ROOT/nm-status"
 NM_LOG="$TMP_ROOT/nm.log"
+HERDR_LOG="$TMP_ROOT/herdr.log"
+TASK_WORKTREE="$TMP_ROOT/task-worktree"
+REAL_HERDR=$(command -v herdr)
 mkdir -p "$STATE" "$CONFIG" "$FAKEBIN"
 
 cleanup() {
@@ -38,14 +41,37 @@ esac
 SH
 chmod +x "$FAKEBIN/no-mistakes"
 
-PATH="$FAKEBIN:$PATH" "$HERDR_LAB_HELPER" provision "$HERDR_LAB_SESSION" || fail 'could not provision isolated Herdr lab'
+cat > "$FAKEBIN/herdr" <<'SH'
+#!/usr/bin/env bash
+case "${FM_FAKE_HERDR_FAULT_MODE:-}" in
+  ambiguous-split)
+    if [ "${1:-}" = pane ] && [ "${2:-}" = split ]; then
+      "$FM_REAL_HERDR" "$@" >/dev/null || exit $?
+      printf '%s\n' '{"result":{"pane":{"pane_id":"ambiguous"}}}'
+      exit 0
+    fi
+    ;;
+  attach-failure)
+    if [ "${1:-}" = pane ] && [ "${2:-}" = run ]; then exit 1; fi
+    ;;
+esac
+if [ "${1:-}" = pane ] && [ "${2:-}" = run ]; then
+  printf '%s\n' "$*" >> "${FM_FAKE_HERDR_LOG:?}"
+fi
+exec "$FM_REAL_HERDR" "$@"
+SH
+chmod +x "$FAKEBIN/herdr"
+
+PATH="$FAKEBIN:$PATH" FM_REAL_HERDR="$REAL_HERDR" "$HERDR_LAB_HELPER" provision "$HERDR_LAB_SESSION" || fail 'could not provision isolated Herdr lab'
 workspace=$("$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" workspace create --label observer-test --no-focus | jq -r '.result.workspace.workspace_id')
 tab=$("$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" tab list --workspace "$workspace" | jq -r '.result.tabs[0].tab_id')
 task_pane=$("$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" pane list --workspace "$workspace" | jq -r '.result.panes[0].pane_id')
 [ -n "$workspace" ] && [ -n "$tab" ] && [ -n "$task_pane" ] || fail 'could not create task pane in isolated lab'
 
-branch=$(git -C "$ROOT" symbolic-ref --quiet --short HEAD) || fail 'test requires a branch worktree'
 head=$(git -C "$ROOT" rev-parse HEAD) || fail 'could not read test worktree head'
+git clone -q --no-checkout "$ROOT" "$TASK_WORKTREE" || fail 'could not create isolated task worktree'
+git -C "$TASK_WORKTREE" switch --quiet --create observer-test "$head" || fail 'could not create task worktree branch'
+branch=$(git -C "$TASK_WORKTREE" symbolic-ref --quiet --short HEAD) || fail 'could not read task worktree branch'
 cat > "$NM_STATUS" <<EOF
 run:
   id: "run-live"
@@ -58,7 +84,7 @@ write_meta() { # <id> <backend>
   local id=$1 backend=$2
   cat > "$STATE/$id.meta" <<EOF
 window=$HERDR_LAB_SESSION:$task_pane
-worktree=$ROOT
+worktree=$TASK_WORKTREE
 project=$ROOT
 kind=ship
 endpoint_task_id=$id
@@ -70,10 +96,12 @@ herdr_pane_id=$task_pane
 EOF
 }
 
-run_observer() { # <action> <id>
+run_observer() { # <action> <id> [<fault-mode>]
+  local action=$1 id=$2 fault_mode=${3:-}
   PATH="$FAKEBIN:$PATH" FM_STATE_OVERRIDE="$STATE" FM_CONFIG_OVERRIDE="$CONFIG" \
     FM_ROOT_OVERRIDE="$ROOT" FM_FAKE_NM_STATUS="$NM_STATUS" FM_FAKE_NM_LOG="$NM_LOG" \
-    "$ROOT/bin/fm-herdr-no-mistakes-observer.sh" "$1" "$2"
+    FM_REAL_HERDR="$REAL_HERDR" FM_FAKE_HERDR_FAULT_MODE="$fault_mode" FM_FAKE_HERDR_LOG="$HERDR_LOG" \
+    "$ROOT/bin/fm-herdr-no-mistakes-observer.sh" "$action" "$id"
 }
 
 pane_count() {
@@ -126,6 +154,23 @@ if "$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" pane get "$observer_pane" >/dev/
 [ "$($HERDR_LAB_HELPER run "$HERDR_LAB_SESSION" pane get "$task_pane" | jq -r '.result.pane.pane_id')" = "$task_pane" ] || fail 'terminal cleanup resized or closed the task pane'
 pass 'terminal matching run closes only the exact observer pane and preserves the task pane'
 
+cat > "$NM_STATUS" <<EOF
+run:
+  id: "run-mismatched"
+  branch: unmatched-$branch
+  status: running
+  head: "$head"
+EOF
+run_observer reconcile task || fail 'mismatched observer reconcile failed'
+[ "$(pane_count)" = 1 ] || fail 'mismatched run created an observer pane'
+[ ! -e "$sidecar" ] || fail 'mismatched run created an observer sidecar'
+pass 'mismatched branch is inert'
+
+write_meta nonherdr tmux
+run_observer reconcile nonherdr || fail 'non-Herdr observer reconcile failed'
+[ ! -e "$STATE/nonherdr.herdr-no-mistakes-observer" ] || fail 'non-Herdr metadata created an observer sidecar'
+pass 'enabled preference remains inert for non-Herdr tasks'
+
 rm -f "$CONFIG/herdr-no-mistakes-observer-panes"
 cat > "$NM_STATUS" <<EOF
 run:
@@ -136,9 +181,51 @@ run:
 EOF
 run_observer reconcile task || fail 'disabled observer reconcile failed'
 [ "$(pane_count)" = 1 ] || fail 'disabled preference created an observer pane'
-write_meta nonherdr tmux
-run_observer reconcile nonherdr || fail 'non-Herdr observer reconcile failed'
-[ ! -e "$STATE/nonherdr.herdr-no-mistakes-observer" ] || fail 'non-Herdr metadata created an observer sidecar'
-pass 'disabled preference and non-Herdr task are inert'
+pass 'disabled preference is inert'
+
+: > "$CONFIG/herdr-no-mistakes-observer-panes"
+: > "$HERDR_LOG"
+cat > "$NM_STATUS" <<EOF
+run:
+  id: "run-retry"
+  branch: $branch
+  status: running
+  head: "$head"
+EOF
+run_observer reconcile task attach-failure || fail 'attach-failure observer reconcile failed'
+[ "$(pane_count)" = 2 ] || fail 'attach failure did not leave one bound observer pane'
+[ -f "$sidecar" ] || fail 'attach failure did not retain its bound sidecar'
+[ "$(sed -n 's/^attach_state=//p' "$sidecar")" = pending ] || fail 'attach failure was not recorded as pending'
+run_observer reconcile task || fail 'attach-retry observer reconcile failed'
+[ "$(pane_count)" = 2 ] || fail 'attach retry created a duplicate observer pane'
+grep -F 'no-mistakes attach --run run-retry' "$HERDR_LOG" >/dev/null || fail 'attach retry did not display the active run'
+pass 'pending attach retries in its exact bound pane without a duplicate'
+
+cat > "$NM_STATUS" <<EOF
+run:
+  id: "run-retry"
+  branch: $branch
+  status: completed
+  head: "$head"
+  outcome: checks-passed
+EOF
+run_observer reconcile task || fail 'attach-retry terminal cleanup failed'
+[ "$(pane_count)" = 1 ] || fail 'attach-retry terminal cleanup did not retire its observer'
+[ ! -e "$sidecar" ] || fail 'attach-retry terminal cleanup retained its sidecar'
+
+cat > "$NM_STATUS" <<EOF
+run:
+  id: "run-ambiguous"
+  branch: $branch
+  status: running
+  head: "$head"
+EOF
+run_observer reconcile task ambiguous-split || fail 'ambiguous-split observer reconcile failed'
+[ "$(pane_count)" = 2 ] || fail 'ambiguous split did not create its simulated unbound pane'
+[ -f "$sidecar" ] || fail 'ambiguous split did not persist its quarantine reservation'
+[ "$(sed -n 's/^state=//p' "$sidecar")" = quarantined ] || fail 'ambiguous split did not quarantine its reservation'
+run_observer reconcile task || fail 'quarantined observer reconcile failed'
+[ "$(pane_count)" = 2 ] || fail 'quarantined split response authorized a duplicate observer pane'
+pass 'ambiguous split responses remain quarantined without duplicate panes'
 
 echo 'all fm-herdr-no-mistakes-observer tests passed'

--- a/tests/fm-herdr-no-mistakes-observer.test.sh
+++ b/tests/fm-herdr-no-mistakes-observer.test.sh
@@ -127,6 +127,13 @@ run_observer reconcile task || fail 'repeat observer reconcile failed'
 [ "$(pane_count)" = 2 ] || fail 'repeat ensure created a duplicate observer'
 pass 'observer creation is idempotent for the complete live binding'
 
+sed -i.bak 's/^backend=.*/backend=tmux/' "$STATE/task.meta" && rm -f "$STATE/task.meta.bak"
+run_observer reconcile task || fail 'conflicting metadata observer reconcile failed'
+[ "$(pane_count)" = 2 ] || fail 'conflicting metadata authorized observer closure'
+[ -f "$sidecar" ] || fail 'conflicting metadata retired the observer sidecar'
+sed -i.bak 's/^backend=.*/backend=herdr/' "$STATE/task.meta" && rm -f "$STATE/task.meta.bak"
+pass 'conflicting metadata preserves the exact observer sidecar and pane'
+
 sed -i.bak 's/^run_id=.*/run_id=old-run/' "$sidecar" && rm -f "$sidecar.bak"
 run_observer reconcile task || fail 'stale observer reconcile failed'
 [ "$(pane_count)" = 2 ] || fail 'stale sidecar authorized a duplicate observer'

--- a/tests/fm-herdr-no-mistakes-observer.test.sh
+++ b/tests/fm-herdr-no-mistakes-observer.test.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Real-Herdr behavioral coverage for the optional passive validation observer.
+# Every Herdr operation uses the guarded named lab helper, never default.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+command -v herdr >/dev/null 2>&1 || { echo 'skip: herdr not found'; exit 0; }
+command -v jq >/dev/null 2>&1 || { echo 'skip: jq not found'; exit 0; }
+
+TMP_ROOT=$(fm_test_tmproot fm-herdr-no-mistakes-observer)
+FM_TEST_CLEANUP_DIRS+=("$TMP_ROOT")
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HERDR_LAB_HELPER="$ROOT/bin/fm-herdr-lab.sh"
+HERDR_LAB_SESSION=$("$HERDR_LAB_HELPER" name nm-observer-layout-n4) || exit 1
+STATE="$TMP_ROOT/home/state"
+CONFIG="$TMP_ROOT/home/config"
+FAKEBIN="$TMP_ROOT/fakebin"
+NM_STATUS="$TMP_ROOT/nm-status"
+NM_LOG="$TMP_ROOT/nm.log"
+mkdir -p "$STATE" "$CONFIG" "$FAKEBIN"
+
+cleanup() {
+  local status=0
+  "$HERDR_LAB_HELPER" teardown "$HERDR_LAB_SESSION" || status=1
+  fm_test_cleanup
+  return "$status"
+}
+trap cleanup EXIT
+
+cat > "$FAKEBIN/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+  axi) [ "${2:-}" = status ] && cat "${FM_FAKE_NM_STATUS:?}" ;;
+  attach) printf '%s\n' "$*" >> "${FM_FAKE_NM_LOG:?}"; sleep 30 ;;
+esac
+SH
+chmod +x "$FAKEBIN/no-mistakes"
+
+PATH="$FAKEBIN:$PATH" "$HERDR_LAB_HELPER" provision "$HERDR_LAB_SESSION" || fail 'could not provision isolated Herdr lab'
+workspace=$("$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" workspace create --label observer-test --no-focus | jq -r '.result.workspace.workspace_id')
+tab=$("$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" tab list --workspace "$workspace" | jq -r '.result.tabs[0].tab_id')
+task_pane=$("$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" pane list --workspace "$workspace" | jq -r '.result.panes[0].pane_id')
+[ -n "$workspace" ] && [ -n "$tab" ] && [ -n "$task_pane" ] || fail 'could not create task pane in isolated lab'
+
+branch=$(git -C "$ROOT" symbolic-ref --quiet --short HEAD) || fail 'test requires a branch worktree'
+head=$(git -C "$ROOT" rev-parse HEAD) || fail 'could not read test worktree head'
+cat > "$NM_STATUS" <<EOF
+run:
+  id: "run-live"
+  branch: $branch
+  status: running
+  head: "$head"
+EOF
+
+write_meta() { # <id> <backend>
+  local id=$1 backend=$2
+  cat > "$STATE/$id.meta" <<EOF
+window=$HERDR_LAB_SESSION:$task_pane
+worktree=$ROOT
+project=$ROOT
+kind=ship
+endpoint_task_id=$id
+backend=$backend
+herdr_session=$HERDR_LAB_SESSION
+herdr_workspace_id=$workspace
+herdr_tab_id=$tab
+herdr_pane_id=$task_pane
+EOF
+}
+
+run_observer() { # <action> <id>
+  PATH="$FAKEBIN:$PATH" FM_STATE_OVERRIDE="$STATE" FM_CONFIG_OVERRIDE="$CONFIG" \
+    FM_ROOT_OVERRIDE="$ROOT" FM_FAKE_NM_STATUS="$NM_STATUS" FM_FAKE_NM_LOG="$NM_LOG" \
+    "$ROOT/bin/fm-herdr-no-mistakes-observer.sh" "$1" "$2"
+}
+
+pane_count() {
+  "$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" pane list --workspace "$workspace" | jq '.result.panes | length'
+}
+
+write_meta task herdr
+before_focus=$("$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" workspace list | jq -r '[.result.workspaces[] | select(.focused == true) | .workspace_id, .active_tab_id] | @tsv')
+: > "$CONFIG/herdr-no-mistakes-observer-panes"
+run_observer reconcile task || fail 'enabled observer reconcile failed'
+sidecar="$STATE/task.herdr-no-mistakes-observer"
+[ -f "$sidecar" ] || fail 'enabled matching run did not publish its observer sidecar'
+observer_pane=$(sed -n 's/^observer_pane=//p' "$sidecar")
+[ -n "$observer_pane" ] && [ "$observer_pane" != "$task_pane" ] || fail 'sidecar did not bind a distinct observer pane'
+[ "$(pane_count)" = 2 ] || fail 'enabled matching run did not create exactly one adjacent pane'
+[ "$("$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" pane get "$observer_pane" | jq -r '.result.pane.focused')" = false ] || fail 'observer pane was focused after no-focus split'
+after_focus=$("$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" workspace list | jq -r '[.result.workspaces[] | select(.focused == true) | .workspace_id, .active_tab_id] | @tsv')
+[ "$before_focus" = "$after_focus" ] || fail 'observer split changed focus'
+sleep 0.2
+pass 'enabled matching Herdr run creates one unfocused passive observer with an exact sidecar'
+
+run_observer reconcile task || fail 'repeat observer reconcile failed'
+[ "$(pane_count)" = 2 ] || fail 'repeat ensure created a duplicate observer'
+pass 'observer creation is idempotent for the complete live binding'
+
+sed -i.bak 's/^run_id=.*/run_id=old-run/' "$sidecar" && rm -f "$sidecar.bak"
+run_observer reconcile task || fail 'stale observer reconcile failed'
+[ "$(pane_count)" = 2 ] || fail 'stale sidecar authorized a duplicate observer'
+[ -f "$sidecar" ] || fail 'stale sidecar was unexpectedly retired while run remains active'
+pass 'stale sidecar refuses duplicate creation and remains quarantined'
+
+run_observer retire task || fail 'stale observer retire failed'
+[ "$(pane_count)" = 2 ] || fail 'stale sidecar authorized observer closure'
+[ -f "$sidecar" ] || fail 'stale sidecar was retired by cleanup'
+[ "$($HERDR_LAB_HELPER run "$HERDR_LAB_SESSION" pane get "$task_pane" | jq -r '.result.pane.pane_id')" = "$task_pane" ] || fail 'stale cleanup touched the task pane'
+pass 'stale cleanup never closes the task or observer pane'
+
+sed -i.bak 's/^run_id=.*/run_id=run-live/' "$sidecar" && rm -f "$sidecar.bak"
+cat > "$NM_STATUS" <<EOF
+run:
+  id: "run-live"
+  branch: $branch
+  status: completed
+  head: "$head"
+  outcome: checks-passed
+EOF
+run_observer reconcile task || fail 'terminal observer reconcile failed'
+if "$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" pane get "$observer_pane" >/dev/null 2>&1; then fail 'terminal run did not close the exact observer pane'; fi
+[ ! -e "$sidecar" ] || fail 'terminal run did not retire a confirmed observer sidecar'
+[ "$($HERDR_LAB_HELPER run "$HERDR_LAB_SESSION" pane get "$task_pane" | jq -r '.result.pane.pane_id')" = "$task_pane" ] || fail 'terminal cleanup resized or closed the task pane'
+pass 'terminal matching run closes only the exact observer pane and preserves the task pane'
+
+rm -f "$CONFIG/herdr-no-mistakes-observer-panes"
+cat > "$NM_STATUS" <<EOF
+run:
+  id: "run-disabled"
+  branch: $branch
+  status: running
+  head: "$head"
+EOF
+run_observer reconcile task || fail 'disabled observer reconcile failed'
+[ "$(pane_count)" = 1 ] || fail 'disabled preference created an observer pane'
+write_meta nonherdr tmux
+run_observer reconcile nonherdr || fail 'non-Herdr observer reconcile failed'
+[ ! -e "$STATE/nonherdr.herdr-no-mistakes-observer" ] || fail 'non-Herdr metadata created an observer sidecar'
+pass 'disabled preference and non-Herdr task are inert'
+
+echo 'all fm-herdr-no-mistakes-observer tests passed'

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -1925,6 +1925,33 @@ test_afk_paused_changed_pane_hands_off_plain_stale() {
   pass "AFK changed paused panes hand off plain stale identities for daemon-owned pause triage"
 }
 
+test_busy_task_reconciles_observer_without_staleness() {
+  local dir state fakebin out capture_file observer_bin observer_log window pid i=0
+  dir=$(make_case observer-busy); state="$dir/state"; fakebin="$dir/fakebin"; out="$dir/watch.out"
+  capture_file="$dir/pane.txt"; observer_bin="$fakebin/observer"; observer_log="$dir/observer.log"
+  window="test:fm-observer-busy"
+  printf 'working\n' > "$capture_file"
+  printf 'window=%s\nbackend=tmux\nkind=ship\n' "$window" > "$state/observer-busy.meta"
+  cat > "$observer_bin" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${FM_FAKE_OBSERVER_LOG:?}"
+SH
+  chmod +x "$observer_bin"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_HERDR_NM_OBSERVER_BIN="$observer_bin" \
+    FM_FAKE_OBSERVER_LOG="$observer_log" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  while [ ! -s "$observer_log" ] && [ "$i" -lt 30 ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ -s "$observer_log" ] || { reap "$pid"; fail 'watcher did not reconcile a busy observer task'; }
+  grep -Fx 'reconcile observer-busy' "$observer_log" >/dev/null || { reap "$pid"; fail 'watcher reconciled the wrong observer task'; }
+  kill -0 "$pid" 2>/dev/null || { reap "$pid"; fail 'watcher exited before a busy task could remain supervised'; }
+  reap "$pid"
+  pass 'a busy task reconciles its observer without waiting for staleness'
+}
+
 test_signal_reason_is_actionable_classifier
 test_stale_is_terminal_classifier
 test_scan_captain_relevant_statuses_classifier
@@ -1974,3 +2001,4 @@ test_heartbeat_backstop_surfaces_unsurfaced_status
 test_beacon_stays_fresh_while_absorbing
 test_afk_present_reverts_watcher_to_one_shot
 test_afk_paused_changed_pane_hands_off_plain_stale
+test_busy_task_reconciles_observer_without_staleness


### PR DESCRIPTION
## Intent

Implement the captain-approved live no-mistakes observer for Firstmate Herdr tasks. Only when explicit local config/herdr-no-mistakes-observer-panes is present, automatically create exactly one adjacent unfocused right-hand Herdr pane for an ordinary ship task with a live task pane and a matching active no-mistakes run for that task branch and current code identity. The pane displays no-mistakes attach --run <run-id> in the task isolated worktree. It is visual-only and must never start, restart, cancel, answer, approve, fix, or run a validation pipeline. Keep lifecycle in one focused helper, atomically bind task id, run id, session, task pane, observer pane, and worktree in a private sidecar, reuse only a fully agreeing live sidecar, and refuse ambiguity without duplicates. Remain inert and unsupported on non-Herdr backends. On terminal runs, disappeared task endpoints, and normal cleanup, close only the exact verified observer pane after proving it is neither the task pane nor the active captain pane, then retire the sidecar only after confirmation. Missing, stale, conflicting, or unreadable sidecars never authorize closure. Do not alter presentation journals or task ownership, recovery, or delivery. Cover executable behavior for idempotence, disabled/non-Herdr no-op, terminal and mismatched runs, stale sidecar refusal, safe cleanup, and task-pane preservation. Use only isolated Herdr labs for tests and never touch the default session or active project pipelines.

## What Changed

- Adds an opt-in Herdr helper that creates one unfocused right-hand `no-mistakes attach` observer pane only for a matching active task run, with an atomic sidecar binding its task, run, pane, session, and worktree identities.
- Reconciles observers while tasks are actively validating and retires only verified observer panes on terminal runs, vanished endpoints, or teardown while preserving ambiguous, stale, or conflicting sidecars.
- Documents the local configuration flag and adds isolated Herdr and watcher coverage for idempotence, no-op paths, retries, and safe cleanup.

## Risk Assessment

✅ Low: The observer lifecycle is conservatively bound, serialized through teardown, and the changed executable coverage addresses the previously identified ambiguity, attach-retry, non-Herdr, mismatch, and busy-watcher paths.

## Testing

Real isolated-Herdr lifecycle testing passed: one unfocused adjacent observer, idempotence, disabled/non-Herdr/mismatched no-ops, stale-sidecar refusal, terminal cleanup, task-pane preservation, attach retry, and ambiguous-split quarantine. The focused watcher reconciliation scenario also passed. The disposable headless Herdr lab has no screenshot endpoint, so saved runtime transcripts provide the reviewer-visible evidence; the worktree remains clean.

<details>
<summary>Evidence: Real Herdr observer lifecycle</summary>

```text
ok - enabled matching Herdr run creates one unfocused passive observer with an exact sidecar
ok - observer creation is idempotent for the complete live binding
warning: herdr no-mistakes observer: task task metadata is unreadable or conflicting; preserving sidecar
ok - conflicting metadata preserves the exact observer sidecar and pane
warning: herdr no-mistakes observer: task observer sidecar is stale or conflicting; refusing a duplicate viewer
ok - stale sidecar refuses duplicate creation and remains quarantined
warning: herdr no-mistakes observer: task sidecar run binding is stale or unreadable; preserving it
ok - stale cleanup never closes the task or observer pane
ok - terminal matching run closes only the exact observer pane and preserves the task pane
ok - mismatched branch is inert
ok - enabled preference remains inert for non-Herdr tasks
ok - disabled preference is inert
warning: herdr no-mistakes observer: task observer attach command could not start; retaining its exact sidecar for retry
ok - pending attach retries in its exact bound pane without a duplicate
warning: herdr no-mistakes observer: task split response was ambiguous; preserving its quarantine reservation
warning: herdr no-mistakes observer: task observer sidecar is stale or conflicting; refusing a duplicate viewer
ok - ambiguous split responses remain quarantined without duplicate panes
all fm-herdr-no-mistakes-observer tests passed
```
</details>
<details>
<summary>Evidence: Watcher observer reconciliation</summary>

```text
ok - a busy task reconciles its observer without waiting for staleness
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-herdr-no-mistakes-observer.sh:271` - A successful split with an ambiguous/mismatched pane response is left unbound; the next reconcile sees no sidecar and splits again, so duplicates remain reachable. This contradicts the required “refuse ambiguity without duplicates” behavior. Persist a non-closure-authorizing quarantine/reservation before a split can be retried.
- 🚨 `bin/fm-herdr-no-mistakes-observer.sh:279` - If `pane run` fails after sidecar publication, the code retains a fully reusable sidecar. Every later reconcile returns through the reuse path and never attempts to display `no-mistakes attach`, leaving the only observer pane blank for the live run. This contradicts the required “pane displays no-mistakes attach --run &lt;run-id&gt;” behavior; the recovery state needs an explicit, safe policy.
- 🚨 `tests/fm-herdr-no-mistakes-observer.test.sh:136` - The required executable coverage for “disabled/non-Herdr no-op” is incomplete: the test removes the opt-in file before invoking the non-Herdr case, so the result is explained by disabled configuration and never proves the non-Herdr guard while explicitly enabled.
- 🚨 `tests/fm-herdr-no-mistakes-observer.test.sh:84` - The required executable coverage for mismatched runs is absent. The test exercises a stale sidecar run id, but never supplies an `axi status` for a different branch or code identity and proves that no observer is created.

🔧 Fix: Hardened observer reservations and attach recovery
3 errors still open:
- 🚨 `bin/fm-classify-lib.sh:686` - The required &#34;automatically create exactly one&#34; observer is not reached for every matching live run. Production wiring invokes reconcile only from `crew_absorb_class` after a stale/idle watcher path asks for current state; while the task pane is busy, no reconcile occurs, so a short live run can finish without any observer. Add a lifecycle-aware reconcile trigger independent of stale-pane triage.
- 🚨 `bin/fm-herdr-no-mistakes-observer.sh:284` - An existing but malformed or re-bound task metadata file is treated exactly like a disappeared endpoint. For example, changing its backend or Herdr pane makes `task_binding` fail, then this branch calls `retire_exact` with metadata disabled and can close the sidecar pane. This contradicts &#34;Missing, stale, conflicting, or unreadable sidecars never authorize closure.&#34; Distinguish an actually absent metadata record from an unreadable/conflicting one and preserve the sidecar in the latter case.
- 🚨 `bin/fm-teardown.sh:2388` - Normal teardown releases the observer&#39;s per-task and session locks when `retire` returns, before teardown destroys the task endpoint. A watcher can then reconcile a still-active run, create a new observer, and leave that new pane and sidecar behind after teardown removes the task. This violates the required normal-cleanup retirement invariant. Serialize teardown and reconcile through the endpoint-removal boundary.

🔧 Fix: Serialize observer lifecycle through teardown
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-herdr-no-mistakes-observer.test.sh`
- <code>`test_busy_task_reconciles_observer_without_staleness` from `tests/fm-watch-triage.test.sh`, executed with its isolated watcher harness</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
