### PR TITLE
Brief scaffold: forbid shared worktree and pool administration

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -45,6 +45,13 @@
 # report rather than a merge, and a charter is not a delivery contract.
 # There is no --yolo flag here. The worker never owns approval decisions, so yolo is
 # a spawn-time and firstmate-side input only (AGENTS.md section 7).
+# Every crewmate scaffold's rules keep shared infrastructure firstmate's alone.
+# The worktree pool, the repository its worktrees share, and the single
+# no-mistakes daemon each serve every lane and home at once, so administering
+# any of them from inside one lane destroys work in the others; the worker stops
+# with "blocked:" and asks instead. The rule names the act rather than one
+# provider, because the supported worktree providers and runtime backends differ
+# in their commands but not in the damage.
 # Every scaffold's status protocol distinguishes the configured
 # declared-external-wait verb (FM_CLASSIFY_PAUSED_VERB, default "paused") from
 # "blocked:": pause for a known external wait expected to clear on its own,
@@ -316,6 +323,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 # Rules
 1. Never push to any remote and never open a PR.
 2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
+   That is a rule about files; shared administration is rule 7 and is not covered by staying inside your own directory.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
@@ -332,9 +340,20 @@ The report is the only thing that survives, so anything worth keeping must be in
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
    Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
-7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
-   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
-   daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+7. Shared infrastructure is firstmate's, never yours. This worktree's contents are your laboratory;
+   the worktree itself, the pool it came from, the repository every lane's worktree shares, and the
+   \`no-mistakes\` daemon are each ONE instance serving every lane and home, so an action that looks
+   local here hits every other lane at once - and those lanes are running right now.
+   Never create, remove, return, prune, move, or reassign any worktree or pool slot: \`git worktree
+   add/remove/prune\`, \`treehouse get/return\`, \`orca worktree create/rm\`, and the equivalent on
+   whatever other worktree provider is in use are all forbidden here, including on worktrees that
+   look stale or unused, and including this one - firstmate discards yours at teardown.
+   Never delete or rewrite a branch or ref you did not create, and never stop, restart, or update
+   the \`no-mistakes\` daemon.
+   Removing worktrees from inside a lane has already destroyed other lanes' working copies mid-run,
+   so there is no safe local workaround - if you need a second checkout, a worktree or branch
+   removed, a daemon action, or anything else on that list, and on ANY no-mistakes daemon error,
+   append \`blocked: {what you need and why}\` and stop. Firstmate does it for you.
 
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
@@ -428,7 +447,8 @@ If the top-level path is the primary checkout or not the worktree you were launc
 
 # Rules
 $RULE1
-2. Stay inside this worktree; modify nothing outside it.
+2. Stay inside this worktree; modify nothing outside it. That is a rule about files;
+   shared administration is rule 7 and is not covered by staying inside your own directory.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
@@ -448,9 +468,20 @@ $RULE1
    append \`needs-decision: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
    Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
-7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
-   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
-   daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+7. Shared infrastructure is firstmate's, never yours. The contents of this worktree are yours to
+   change; the worktree itself, the pool it came from, the repository every lane's worktree shares,
+   and the \`no-mistakes\` daemon are each ONE instance serving every lane and home, so an action
+   that looks local here hits every other lane at once - and those lanes are running right now.
+   Never create, remove, return, prune, move, or reassign any worktree or pool slot: \`git worktree
+   add/remove/prune\`, \`treehouse get/return\`, \`orca worktree create/rm\`, and the equivalent on
+   whatever other worktree provider is in use are all forbidden here, including on worktrees that
+   look stale or unused, and including this one - firstmate cleans yours up when you are done.
+   Never delete or rewrite a branch or ref you did not create, and never stop, restart, or update
+   the \`no-mistakes\` daemon.
+   Removing worktrees from inside a lane has already destroyed other lanes' working copies mid-run,
+   so there is no safe local workaround - if you need a second checkout, a worktree or branch
+   removed, a daemon action, or anything else on that list, and on ANY no-mistakes daemon error,
+   append \`blocked: {what you need and why}\` and stop. Firstmate does it for you.
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -350,7 +350,7 @@ The report is the only thing that survives, so anything worth keeping must be in
    look stale or unused, and including this one - firstmate discards yours at teardown.
    Never delete or rewrite a branch or ref you did not create, and never stop, restart, or update
    the \`no-mistakes\` daemon.
-   Removing worktrees from inside a lane has already destroyed other lanes' working copies mid-run,
+   Removing a worktree from inside a lane destroys the working copy of whatever lane owns it, mid-run,
    so there is no safe local workaround - if you need a second checkout, a worktree or branch
    removed, a daemon action, or anything else on that list, and on ANY no-mistakes daemon error,
    append \`blocked: {what you need and why}\` and stop. Firstmate does it for you.
@@ -478,7 +478,7 @@ $RULE1
    look stale or unused, and including this one - firstmate cleans yours up when you are done.
    Never delete or rewrite a branch or ref you did not create, and never stop, restart, or update
    the \`no-mistakes\` daemon.
-   Removing worktrees from inside a lane has already destroyed other lanes' working copies mid-run,
+   Removing a worktree from inside a lane destroys the working copy of whatever lane owns it, mid-run,
    so there is no safe local workaround - if you need a second checkout, a worktree or branch
    removed, a daemon action, or anything else on that list, and on ANY no-mistakes daemon error,
    append \`blocked: {what you need and why}\` and stop. Firstmate does it for you.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -371,6 +371,94 @@ test_ship_project_memory_wording() {
   pass "fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar"
 }
 
+# Rule <n> of a generated brief's "# Rules" section, flattened to a single
+# whitespace-normalized line. Scoping to that section matters because a ship
+# brief's Setup steps are numbered too. The assertions below are about what the
+# rule says, not how it wraps, so a line break inside a sentence must not decide
+# whether the contract is present.
+brief_rule_text() {  # <brief> <rule-number>
+  awk -v n="$2" '
+    /^# Rules$/ { in_rules = 1; next }
+    !in_rules { next }
+    /^# / { exit }
+    $0 ~ "^" n "\\. " { in_rule = 1 }
+    in_rule && NF == 0 { exit }
+    in_rule { print }
+  ' "$1" | tr '\n' ' ' | tr -s ' '
+}
+
+# "Stay inside this worktree; modify nothing outside it" is a rule about FILES. A
+# worker can satisfy it completely and still administer the pool its own worktree
+# came from - removing a worktree is not an edit outside a directory - which
+# destroys the working copies of lanes that are running at the time. Every
+# crewmate scaffold must therefore carry the shared-infrastructure rule, and it
+# must be stated around the ACT: worktree providers differ in their commands but
+# not in the damage, so a constraint written against one provider leaves the same
+# hole open on every other one. A prohibition with no exit gets worked around, so
+# the rule must also route a genuine need for a second checkout somewhere.
+# Secondmate charters are deliberately out of scope: a secondmate operates its own
+# home and administers its own crewmates' worktrees through the normal lifecycle.
+test_shared_infrastructure_rule_covers_every_crewmate_scaffold() {
+  local home kind id brief rule file_rule providers name
+  home="$TMP_ROOT/shared-infra-home"
+  mkdir -p "$home/data"
+
+  for kind in no-mistakes direct-PR local-only scout; do
+    id="brief-shared-infra-$kind"
+    if [ "$kind" = scout ]; then
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --scout >/dev/null 2>&1
+    else
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$kind" >/dev/null 2>&1
+    fi
+    brief="$home/data/$id/brief.md"
+    assert_present "$brief" "$kind: brief was not scaffolded"
+    rule=$(brief_rule_text "$brief" 7)
+    [ -n "$rule" ] || fail "$kind: generated brief carries no shared-infrastructure rule"
+
+    # Stated around the act, and around why the act reaches other lanes.
+    assert_contains "$rule" \
+      "Never create, remove, return, prune, move, or reassign any worktree or pool slot" \
+      "$kind: rule does not forbid the act of administering a worktree or pool slot"
+    assert_contains "$rule" "serving every lane and home" \
+      "$kind: rule does not say the pool and daemon are shared across lanes"
+
+    # Concrete commands are examples. The rule must still reach a worktree
+    # provider it does not name, so switching providers cannot reopen the hole.
+    assert_contains "$rule" "whatever other worktree provider is in use" \
+      "$kind: rule does not reach an unnamed worktree provider"
+    providers=0
+    for name in 'git worktree' 'treehouse' 'orca worktree'; do
+      case "$rule" in *"$name"*) providers=$((providers + 1)) ;; esac
+    done
+    [ "$providers" -ge 2 ] || fail \
+      "$kind: rule names fewer than two providers as examples, so it reads as a single-provider rule"
+
+    # An exit, so a genuine need for a second checkout is not a workaround.
+    # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
+    assert_contains "$rule" 'append `blocked: {what you need and why}` and stop' \
+      "$kind: rule prohibits the act without telling the worker what to do instead"
+    assert_contains "$rule" "Firstmate does it for you" \
+      "$kind: rule does not say who performs the work the worker must not do"
+
+    # Same class as the shared no-mistakes daemon - one instance serving every
+    # lane - so the two are stated together and the daemon rule is not orphaned.
+    # shellcheck disable=SC2016 # Literal backticks must remain unexpanded.
+    assert_contains "$rule" 'never stop, restart, or update the `no-mistakes` daemon' \
+      "$kind: shared-daemon prohibition was lost from the shared-infrastructure rule"
+    assert_contains "$rule" "on ANY no-mistakes daemon error" \
+      "$kind: shared-daemon errors no longer route to the same exit"
+    [ "$(grep -o 'daemon' "$brief" | wc -l | tr -d ' ')" \
+      = "$(printf '%s\n' "$rule" | grep -o 'daemon' | wc -l | tr -d ' ')" ] \
+      || fail "$kind: the brief discusses the shared daemon outside the one rule that owns it"
+
+    # The file-scope rule must point here rather than reading as complete.
+    file_rule=$(brief_rule_text "$brief" 2)
+    assert_contains "$file_rule" "shared administration is rule 7" \
+      "$kind: the stay-inside-this-worktree rule still reads as if it covered shared administration"
+  done
+  pass "fm-brief.sh: every crewmate scaffold forbids shared worktree/pool administration and offers an exit"
+}
+
 test_herdr_lab_contract_is_explicit_and_complete() {
   local home id brief
   home="$TMP_ROOT/herdr-lab-home"
@@ -720,6 +808,7 @@ test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording
+test_shared_infrastructure_rule_covers_every_crewmate_scaffold
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path
 test_herdr_lab_omission_is_loud_for_ship_and_scout


### PR DESCRIPTION
## The hole

A generated crewmate brief tells the worker:

> Stay inside this worktree; modify nothing outside it.

That is a rule about **files**. A worker can satisfy it completely and still run a `git worktree remove` loop over the pool its own worktree came from. Removing a worktree is not an edit outside a directory - it is a change to administration that every lane shares - so the sentence does not reach the act at all.

When it happens, the lanes that lose their working directory are the ones still running. Commits survive, because pooled worktrees share one repository and the branch refs live in the primary clone, but the working copies do not, and nothing uncommitted is protected by that.

The worker in that situation is not disobeying. It is following a brief that asked it to do something reasonable and never said how not to, and the constraint is easy to write into an individual brief by hand afterwards. The next brief written without it has the same hole, which is why this belongs in the scaffold rather than in one brief.

## What changed

Rule 7 of the ship and scout scaffolds now covers shared infrastructure as one class: the worktree itself, the pool it came from, the repository every lane's worktree shares, and the `no-mistakes` daemon. Rule 2 points at it instead of reading as complete.

**It names the act, not a provider.** Creating, removing, returning, pruning, moving, or reassigning any worktree or pool slot is forbidden. `git worktree add/remove/prune`, `treehouse get/return`, and `orca worktree create/rm` appear as examples, followed by an explicit catch-all for whatever other worktree provider is in use. The supported worktree providers and runtime backends differ in their commands but not in the damage, so a rule written against one provider leaves the identical hole open on every other one - which is exactly the class of failure this change exists to close.

**It says what to do instead.** A prohibition that blocks the only route somebody can see gets worked around. A worker that genuinely needs a second checkout, a worktree or branch removed, or a daemon action stops and reports with `blocked: {what you need and why}`, the same exit the scaffold already uses everywhere else, and firstmate does it.

**It is stated together with the shared-daemon rule**, which the scaffold already carried. Those two are the same class: one instance serving every lane and home, an action that looks local but is global, one owner, and the same exit. Stating them apart would present them as unrelated warnings and teach the shape twice; stated together, a reader who meets one meets the reasoning behind both.

## Test

`tests/fm-brief.test.sh` gains a case that **generates** briefs - all three ship modes plus a scout - and reads the rule out of the generated brief. It does not grep the script, per this repo's rule that tests exercise behaviour through an executable interface and never assert implementation-source bytes.

It asserts the act is forbidden, that the rule reaches a provider it does not name, that at least two providers appear as mere examples rather than as the definition, that the stop-and-report exit is present, that the shared daemon is stated in that rule and mentioned nowhere else in the brief, and that the file-scope rule points at it.

Confirmed non-vacuous: against the previous scaffold it fails on the missing act, and it also fails on variants that drop the unnamed-provider clause or the rule 2 pointer.

`bin/fm-lint.sh` passes (ShellCheck 0.11.0). The brief suite is green, as are the four adjacent suites that consume the scaffold.
