### PR TITLE
feat: add max Calm presentation level

### DIFF
--- a/.pi/extensions/fm-calm.ts
+++ b/.pi/extensions/fm-calm.ts
@@ -55,8 +55,10 @@ import {
   createCalmWorkingShipWidget,
 } from "./lib/fm-calm-working-ship.ts";
 import {
+  type CalmPresentationLevel,
   calmPresentationHides,
   calmPresentationIsActive,
+  calmPresentationLevel,
   FIRSTMATE_CALM_PRESENTATION_EVENT,
   registerFirstmateSyntheticPresentation,
   setCalmPresentation,
@@ -119,6 +121,19 @@ function installCalmPresentationAdapter(name: string, install: () => void): void
   }
 }
 
+// /calm keeps its plain no-argument cycle and recognizes one argument, "max", which
+// selects the level that also hides mid-turn assistant working notes. A plain /calm
+// steps max back to ordinary Calm; any other argument keeps the existing on/off cycle
+// rather than failing a command that has always accepted whatever followed it.
+function nextCalmLevel(
+  current: CalmPresentationLevel,
+  args: string,
+): CalmPresentationLevel {
+  if (args.trim().toLowerCase() === "max") return "max";
+  if (current === "max") return "on";
+  return current === "on" ? "off" : "on";
+}
+
 export default function (pi: ExtensionAPI) {
   installCalmPresentationAdapter("collapsed-thinking", installCalmAssistantLayout);
   installCalmPresentationAdapter("operational-user-row", installCalmOperationalUserLayout);
@@ -159,18 +174,25 @@ export default function (pi: ExtensionAPI) {
   const fmHome = process.env.FM_HOME || process.env.FM_ROOT_OVERRIDE || root;
   const configDirectory = process.env.FM_CONFIG_OVERRIDE || resolve(fmHome, "config");
   const calmPreferencePath = resolve(configDirectory, "calm");
-  const loadCalmPreference = (): boolean => {
+  // Every level the command can persist round-trips through this reader, so a session
+  // start, resume, fork, or reload restores the stored level instead of dropping an
+  // unrecognized one to off. docs/configuration.md owns the persisted value schema.
+  const loadCalmPreference = (): CalmPresentationLevel => {
+    let stored: string;
     try {
-      return readFileSync(calmPreferencePath, "utf8").trim() === "on";
+      stored = readFileSync(calmPreferencePath, "utf8").trim();
     } catch {
-      return false;
+      return "off";
     }
+    if (stored === "on") return "on";
+    if (stored === "max") return "max";
+    return "off";
   };
-  const persistCalmPreference = (active: boolean): void => {
+  const persistCalmPreference = (level: CalmPresentationLevel): void => {
     mkdirSync(dirname(calmPreferencePath), { recursive: true });
     const temporaryPath = `${calmPreferencePath}.${process.pid}.${randomUUID()}.tmp`;
     try {
-      writeFileSync(temporaryPath, active ? "on\n" : "off\n", {
+      writeFileSync(temporaryPath, `${level}\n`, {
         encoding: "utf8",
         flag: "wx",
         mode: 0o600,
@@ -312,7 +334,7 @@ export default function (pi: ExtensionAPI) {
   // unconditional here (see file header): a foreign-claim check is not reachable at
   // this point, while deferral would make restored rows capture the wrong definition.
   // A Calm-off session or reload registers nothing and creates no collision exposure.
-  if (loadCalmPreference()) {
+  if (loadCalmPreference() !== "off") {
     for (const tool of wrappedBuiltIns) pi.registerTool(tool);
     builtInsRegistered = true;
   }
@@ -443,13 +465,16 @@ export default function (pi: ExtensionAPI) {
 
   pi.registerCommand("calm", {
     description: "Toggle Firstmate's supported conversation-only transcript presentation.",
-    handler: async (_args, ctx) => {
-      const active = !calmPresentationIsActive();
-      persistCalmPreference(active);
-      setCalmPresentation(active);
+    handler: async (args, ctx) => {
+      const level = nextCalmLevel(calmPresentationLevel(), args ?? "");
+      const active = level !== "off";
+      persistCalmPreference(level);
+      setCalmPresentation(level);
       if (active) activateBuiltInsIfNeeded(ctx.ui);
       publishPresentationState();
       applyWorkingPresentation(ctx.ui, true);
+      // Pi re-runs every assistant row's layout from this call even when the label is
+      // unchanged, which is what makes a level change apply to rows already on screen.
       ctx.ui.setHiddenThinkingLabel(active ? "" : undefined);
       ctx.ui.setStatus("firstmate-calm", undefined);
 

--- a/.pi/extensions/lib/fm-calm-assistant-layout.ts
+++ b/.pi/extensions/lib/fm-calm-assistant-layout.ts
@@ -2,6 +2,10 @@
 // updateContent method. installCalmAssistantLayout() probes that exact method and throws
 // if it is missing; fm-calm.ts catches that and skips only this adapter with a diagnostic
 // instead of blocking Calm or Pi.
+// This layout removes collapsed thinking, and at the "max" presentation level also the
+// mid-turn assistant text blocks classified as "assistant-working-note", from a shallow
+// presentation copy. The message itself, model context, session storage, and export
+// rendering are never touched. ./fm-calm-visibility.ts owns which classes each level hides.
 import type { AssistantMessageComponent as PiAssistantMessageComponent } from "@earendil-works/pi-coding-agent";
 import * as PiCodingAgent from "@earendil-works/pi-coding-agent";
 import { calmPresentationHides } from "./fm-calm-visibility.ts";
@@ -16,7 +20,22 @@ type AssistantMessagePresentationState = {
 
 type CalmAssistantLayoutPatch = {
   hidesThinking: () => boolean;
+  hidesWorkingNote: () => boolean;
 };
+
+// A mid-turn assistant message is one the model did not end its response with: Pi's
+// agent loop runs its tool calls and then issues another assistant message. stopReason
+// is intrinsic to each message and is already set while the message streams, so this
+// layout never has to ask whether the turn ended. It stays "pending" until the tool
+// call materializes, which is why a working note is briefly visible before it
+// collapses; suppressing pending text would also stop a genuine reply from streaming.
+function isMidTurnAssistantMessage(message: AssistantMessage): boolean {
+  if (message.stopReason === "toolUse") return true;
+  return (
+    message.stopReason === "length" &&
+    message.content.some((block) => block.type === "toolCall")
+  );
+}
 
 // Keep the introduction-version symbol stable so a compatible upgrade cannot
 // double-patch a live process.
@@ -29,13 +48,15 @@ export function installCalmAssistantLayout(): void {
     [key: symbol]: CalmAssistantLayoutPatch | undefined;
   };
   const hidesThinking = (): boolean => calmPresentationHides("assistant-thinking");
+  const hidesWorkingNote = (): boolean => calmPresentationHides("assistant-working-note");
   const installed = registry[CALM_ASSISTANT_LAYOUT_PATCH];
   if (installed) {
     installed.hidesThinking = hidesThinking;
+    installed.hidesWorkingNote = hidesWorkingNote;
     return;
   }
 
-  const patch: CalmAssistantLayoutPatch = { hidesThinking };
+  const patch: CalmAssistantLayoutPatch = { hidesThinking, hidesWorkingNote };
   const AssistantMessageComponent = PiCodingAgent.AssistantMessageComponent;
   if (typeof AssistantMessageComponent !== "function") {
     throw new Error("Firstmate Calm requires Pi AssistantMessageComponent");
@@ -53,12 +74,19 @@ export function installCalmAssistantLayout(): void {
       state.hiddenThinkingLabel === "" &&
       state.hideThinkingBlock &&
       patch.hidesThinking();
-    const presentationMessage = hideThinking
-      ? {
-          ...message,
-          content: message.content.filter((block) => block.type !== "thinking"),
-        }
-      : message;
+    const hideWorkingNote =
+      patch.hidesWorkingNote() && isMidTurnAssistantMessage(message);
+    const presentationMessage =
+      hideThinking || hideWorkingNote
+        ? {
+            ...message,
+            content: message.content.filter(
+              (block) =>
+                !(hideThinking && block.type === "thinking") &&
+                !(hideWorkingNote && block.type === "text"),
+            ),
+          }
+        : message;
 
     originalUpdateContent.call(this, presentationMessage);
     if (presentationMessage !== message) state.lastMessage = message;

--- a/.pi/extensions/lib/fm-calm-visibility.ts
+++ b/.pi/extensions/lib/fm-calm-visibility.ts
@@ -6,6 +6,7 @@ import {
 export const CALM_TRANSCRIPT_CLASSES = [
   "genuine-user-prompt",
   "genuine-agent-response",
+  "assistant-working-note",
   "assistant-thinking",
   "assistant-tool-call",
   "tool-result",
@@ -28,10 +29,22 @@ export const CALM_TRANSCRIPT_CLASSES = [
 
 export type CalmTranscriptClass = (typeof CALM_TRANSCRIPT_CLASSES)[number];
 
+// Calm's presentation is a level, not a boolean: "off" is stock Pi, "on" is Calm, and
+// "max" is Calm plus the classes in CALM_MAX_HIDDEN_CLASSES below.
+export const CALM_PRESENTATION_LEVELS = ["off", "on", "max"] as const;
+
+export type CalmPresentationLevel = (typeof CALM_PRESENTATION_LEVELS)[number];
+
 const CALM_VISIBLE_CLASSES = new Set<CalmTranscriptClass>([
   "genuine-user-prompt",
   "genuine-agent-response",
+  "assistant-working-note",
   "working-status",
+]);
+
+// Classes ordinary Calm keeps but the "max" level also hides.
+const CALM_MAX_HIDDEN_CLASSES = new Set<CalmTranscriptClass>([
+  "assistant-working-note",
 ]);
 
 // Legacy session entries from Calm versions before 2026-07-23 retain this
@@ -60,15 +73,23 @@ type FirstmateSyntheticPresentation = {
   kind: FirstmateSyntheticKind;
 };
 
-let calm = false;
+let calmLevel: CalmPresentationLevel = "off";
 let stockExportRendering = false;
 
-export function calmTranscriptClassIsVisible(itemClass: CalmTranscriptClass): boolean {
-  return CALM_VISIBLE_CLASSES.has(itemClass);
+export function calmTranscriptClassIsVisible(
+  itemClass: CalmTranscriptClass,
+  level: CalmPresentationLevel = calmLevel,
+): boolean {
+  if (!CALM_VISIBLE_CLASSES.has(itemClass)) return false;
+  return level !== "max" || !CALM_MAX_HIDDEN_CLASSES.has(itemClass);
 }
 
-export function setCalmPresentation(active: boolean): void {
-  calm = active;
+export function setCalmPresentation(level: CalmPresentationLevel): void {
+  calmLevel = level;
+}
+
+export function calmPresentationLevel(): CalmPresentationLevel {
+  return calmLevel;
 }
 
 export function setCalmStockExportRendering(active: boolean): void {
@@ -76,11 +97,15 @@ export function setCalmStockExportRendering(active: boolean): void {
 }
 
 export function calmPresentationIsActive(): boolean {
-  return calm;
+  return calmLevel !== "off";
 }
 
 export function calmPresentationHides(itemClass: CalmTranscriptClass): boolean {
-  return calm && !stockExportRendering && !calmTranscriptClassIsVisible(itemClass);
+  return (
+    calmLevel !== "off" &&
+    !stockExportRendering &&
+    !calmTranscriptClassIsVisible(itemClass, calmLevel)
+  );
 }
 
 export function registerFirstmateSyntheticPresentation(pi: ExtensionAPI): void {

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -180,7 +180,7 @@ Compaction and retry loaders remain stock because Pi exposes no supported replac
 
 `.pi/extensions/lib/fm-calm-visibility.ts` owns only the allowlist-style transcript presentation policy.
 `bin/fm-operational-input.sh` owns current cross-language operational-input construction and parsing, while the thin Pi adapter lives at `.pi/extensions/lib/fm-operational-input.ts`.
-Only `genuine-user-prompt`, `genuine-agent-response`, and `working-status` are policy-visible.
+Only `genuine-user-prompt`, `genuine-agent-response`, `assistant-working-note`, and `working-status` are policy-visible, and `assistant-working-note` is additionally policy-hidden at the `max` presentation level.
 Every other audited class is policy-hidden when Pi exposes a supported presentation boundary, but semantic input is never transformed to enforce that preference.
 The home-local persistence schema is owned by [`docs/configuration.md`](configuration.md#pi-calm-preference-configcalm).
 
@@ -204,6 +204,7 @@ The test fixture enumerates every class below through the centralized policy, an
 | --- | --- | --- |
 | `genuine-user-prompt` | `UserMessageComponent` | Visible, including every tested operational near miss. |
 | `genuine-agent-response` | Assistant text in `AssistantMessageComponent` | Visible. |
+| `assistant-working-note` | Assistant text in an `AssistantMessageComponent` message the model did not end its response with, identified by its own `stopReason` of `toolUse`, or of `length` with tool calls present | Visible at the `on` level. At the `max` level the text blocks are removed from the shallow presentation copy before layout, so a `toolUse` message carrying only narration occupies zero rows (verified on Pi 0.84.1); a still-streaming `pending` message is never filtered, so narration is briefly visible before the marker flips. |
 | `assistant-thinking` | Thinking content in `AssistantMessageComponent` | Collapsed reasoning is removed from the shallow presentation copy before layout and occupies zero rows; explicit expansion renders the original reasoning. |
 | `assistant-tool-call` | `ToolExecutionComponent` | Seven built-ins and `fm_watch_arm_pi` hidden; arbitrary custom tools remain an unsupported boundary. |
 | `tool-result` | `ToolExecutionComponent` | Text results for the controlled tools hidden; arbitrary custom results remain an unsupported boundary. |

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -200,7 +200,7 @@ Serialized session data and Pi 0.81.1's sidebar tree also retain legacy hidden o
 The taxonomy was derived from Pi 0.81.1's installed public declarations, documentation, examples, `interactive-mode.js`, and its exported component implementations.
 The test fixture enumerates every class below through the centralized policy, and the interactive fixture exercises the screenshot classes, current user-role operational input, and legacy synthetic presentation entries.
 
-| Policy class | Pi transcript path | Calm result (verified on Pi 0.81.1 through 0.82.0) |
+| Policy class | Pi transcript path | Calm result (baseline verified on Pi 0.81.1 through 0.82.0; newer evidence noted per row) |
 | --- | --- | --- |
 | `genuine-user-prompt` | `UserMessageComponent` | Visible, including every tested operational near miss. |
 | `genuine-agent-response` | Assistant text in `AssistantMessageComponent` | Visible. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,7 +27,8 @@ Ordinary dead-direct-report recovery is owned by `stuck-crewmate-recovery`, whil
 ## Pi Calm preference (config/calm)
 
 The Pi Calm extension stores the captain's home-local presentation choice in gitignored `config/calm` under the effective Firstmate home, resolved from `FM_HOME`, then `FM_ROOT_OVERRIDE`, then the tracked code root derived from the extension path, or under `FM_CONFIG_OVERRIDE` when that test and specialized-setup override is present.
-The only values it writes are `on` and `off`, each followed by one newline; an absent, unreadable, or unrecognized value defaults to off.
+The values it writes are `on`, `off`, and `max`, each followed by one newline; an absent, unreadable, or unrecognized value defaults to off.
+`max` is a recognized persisted presentation level, so a later session restores it as `max` instead of treating it as unrecognized and dropping to off.
 The `/calm` command replaces the file atomically before changing live presentation, so a failed write leaves the current choice unchanged rather than claiming persistence.
 The extension reloads this preference on every Pi `session_start`, including startup, new, resume, fork, and reload reasons.
 This preference is local to each Firstmate home and is not part of secondmate inherited configuration.

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -802,13 +802,16 @@ if (
 }
 
 for (const itemClass of visibility.CALM_TRANSCRIPT_CLASSES) {
-  const visible = visibility.calmTranscriptClassIsVisible(itemClass);
-  const expected =
-    itemClass === "genuine-user-prompt" ||
-    itemClass === "genuine-agent-response" ||
-    itemClass === "working-status";
-  if (visible !== expected) {
-    throw new Error(`Calm allowlist classified ${itemClass} as visible=${visible}`);
+  for (const level of ["on", "max"]) {
+    const visible = visibility.calmTranscriptClassIsVisible(itemClass, level);
+    const expected =
+      itemClass === "genuine-user-prompt" ||
+      itemClass === "genuine-agent-response" ||
+      itemClass === "working-status" ||
+      (itemClass === "assistant-working-note" && level === "on");
+    if (visible !== expected) {
+      throw new Error(`Calm allowlist classified ${itemClass} as visible=${visible} at level ${level}`);
+    }
   }
 }
 const watcherBody =
@@ -826,6 +829,10 @@ const operationalChat = {
 const operationalMode = {
   chatContainer: operationalChat,
   editor: { addToHistory: (value) => operationalHistory.push(value) },
+  // Pi builds user rows with the registered markdown transformers from 0.83 onward and
+  // without them before that; the stub answers both shapes with the empty list Pi and
+  // Firstmate both use today.
+  getMarkdownTransformers: () => [],
   getMarkdownThemeWithSettings: () => undefined,
   getUserMessageText: (message) => typeof message.content === "string"
     ? message.content
@@ -1350,6 +1357,273 @@ JS
   [ "$status" -eq 0 ] || fail "Pi calm renderer and lifecycle contract failed: $out"
   [ -z "$out" ] || fail "Pi calm renderer test printed output: $out"
   pass "Pi calm centralizes transcript visibility, preserves execution/export data, keeps Pi's stock working row visible while no run is active, and persists its choice across session starts"
+}
+
+test_calm_max_mid_turn_working_notes() {
+  local fixture out output_file status version
+  if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
+    echo "skip: node or npm not found for Pi calm max renderer test"
+    return 0
+  fi
+  if [ ! -f "$PI_PACKAGE_DIR/package.json" ]; then
+    echo "skip: installed @earendil-works/pi-coding-agent package not found"
+    return 0
+  fi
+  version=$(node -p "require('$PI_PACKAGE_DIR/package.json').version")
+  record_pi_version_evidence "$version" "Pi calm max mid-turn presentation"
+
+  fixture="$TMP_ROOT/calm-max"
+  mkdir -p "$fixture/home" "$fixture/lib" "$fixture/node_modules/@earendil-works"
+  cp "$EXT" "$fixture/fm-calm.ts"
+  cp "$ASSISTANT_LAYOUT" "$fixture/lib/fm-calm-assistant-layout.ts"
+  cp "$OPERATIONAL_USER_LAYOUT" "$fixture/lib/fm-calm-operational-user-layout.ts"
+  cp "$VISIBILITY" "$fixture/lib/fm-calm-visibility.ts"
+  cp "$WORKING_SHIP" "$fixture/lib/fm-calm-working-ship.ts"
+  cp "$PI_OPERATIONAL_INPUT" "$fixture/lib/fm-operational-input.ts"
+  ln -s "$PI_PACKAGE_DIR" "$fixture/node_modules/@earendil-works/pi-coding-agent"
+  ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$fixture/node_modules/@earendil-works/pi-tui"
+  ln -s "$PI_PACKAGE_DIR/node_modules/typebox" "$fixture/node_modules/typebox"
+  printf '%s\n' '{"type":"module"}' >"$fixture/package.json"
+
+  output_file="$fixture/node-output"
+  (cd "$fixture" && EXT="$fixture/fm-calm.ts" FM_HOME="$fixture/home" PI_PACKAGE_DIR="$PI_PACKAGE_DIR" node --input-type=module) >"$output_file" 2>&1 <<'JS'
+import { existsSync, readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const packageRoot = process.env.PI_PACKAGE_DIR;
+const [{ AssistantMessageComponent }, { initTheme }, { setCapabilities }] = await Promise.all([
+  import(pathToFileURL(`${packageRoot}/dist/modes/interactive/components/assistant-message.js`).href),
+  import(pathToFileURL(`${packageRoot}/dist/modes/interactive/theme/theme.js`).href),
+  import(pathToFileURL(`${packageRoot}/node_modules/@earendil-works/pi-tui/dist/index.js`).href),
+]);
+initTheme("dark");
+setCapabilities({ images: null, trueColor: true, hyperlinks: false });
+
+// Both extension instances below resolve their own relative "./lib/..." specifiers to
+// the same module URLs, so they share one live visibility policy exactly the way a
+// single Pi process does.
+const visibility = await import(pathToFileURL(`${process.cwd()}/lib/fm-calm-visibility.ts`).href);
+const calmPreferencePath = `${process.env.FM_HOME}/config/calm`;
+const components = [];
+const ui = {
+  getEditorText: () => "",
+  getToolsExpanded: () => false,
+  onTerminalInput: () => () => {},
+  setHiddenThinkingLabel(value) {
+    // Pi's own fan-out: every mounted assistant row re-runs its layout.
+    for (const component of components) component.setHiddenThinkingLabel(value ?? "Thinking...");
+  },
+  setStatus() {},
+  setToolsExpanded() {},
+  setWorkingVisible() {},
+  notify() {},
+};
+const context = { ui };
+
+async function loadCalmExtension() {
+  const registeredTools = [];
+  let sessionStart;
+  let calmCommand;
+  const pi = {
+    events: { emit() {}, on() {} },
+    on(event, handler) {
+      if (event === "session_start") sessionStart = handler;
+    },
+    registerCommand(name, command) {
+      if (name === "calm") calmCommand = command;
+    },
+    registerEntryRenderer() {},
+    registerTool(tool) {
+      registeredTools.push(tool.name);
+    },
+    getAllTools() {
+      return [];
+    },
+  };
+  const extension = await import(`${pathToFileURL(process.env.EXT).href}?max=${Date.now()}-${Math.random()}`);
+  extension.default(pi);
+  if (!calmCommand || !sessionStart) {
+    throw new Error("Calm extension did not register its command and session handler");
+  }
+  return { calmCommand, sessionStart, registeredTools };
+}
+
+const assistantBase = {
+  role: "assistant",
+  api: "calm-max-test",
+  provider: "calm-max-test",
+  model: "deterministic",
+  usage: {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  },
+  timestamp: 1,
+};
+const toolCall = { type: "toolCall", id: "calm-max-tool", name: "read", arguments: { path: "sample.txt" } };
+const messages = {
+  // The reported incident: narration emitted in the same assistant message as a tool call.
+  midTurn: {
+    ...assistantBase,
+    stopReason: "toolUse",
+    content: [{ type: "text", text: "MIDTURN_WORKING_NOTE" }, toolCall],
+  },
+  // The genuine reply that ends a response, which no level may hide.
+  finalReply: {
+    ...assistantBase,
+    stopReason: "stop",
+    content: [{ type: "text", text: "FINAL_REPLY_TEXT" }],
+  },
+  // Still streaming: finality is unknown, and hiding here would stop a real reply.
+  streaming: {
+    ...assistantBase,
+    stopReason: "pending",
+    content: [{ type: "text", text: "STREAMING_NOTE_TEXT" }],
+  },
+  // Truncated with tool calls is mid-turn; Pi's own truncation notice stays.
+  truncatedMidTurn: {
+    ...assistantBase,
+    stopReason: "length",
+    content: [{ type: "text", text: "TRUNCATED_MIDTURN_NOTE" }, toolCall],
+  },
+  // Truncated without tool calls ended the response.
+  truncatedFinal: {
+    ...assistantBase,
+    stopReason: "length",
+    content: [{ type: "text", text: "TRUNCATED_FINAL_TEXT" }],
+  },
+};
+const messagesBefore = JSON.stringify(messages);
+const rows = {};
+for (const [name, message] of Object.entries(messages)) {
+  rows[name] = new AssistantMessageComponent(message, true);
+  components.push(rows[name]);
+}
+const rendered = (name) => rows[name].render(100);
+const renderedText = (name) => rendered(name).join("\n");
+const snapshot = () => {
+  const shot = {};
+  for (const name of Object.keys(rows)) shot[name] = JSON.stringify(rendered(name));
+  return shot;
+};
+const requireVisible = (name, needle, context) => {
+  if (rendered(name).length === 0 || !renderedText(name).includes(needle)) {
+    throw new Error(`${context}: ${name} lost ${needle}`);
+  }
+};
+const requireHidden = (name, needle, context) => {
+  if (renderedText(name).includes(needle)) {
+    throw new Error(`${context}: ${name} still rendered ${needle}`);
+  }
+};
+
+let calm = await loadCalmExtension();
+if (calm.registeredTools.length !== 0) {
+  throw new Error("Calm claimed built-in tools with no persisted preference");
+}
+await calm.sessionStart({ reason: "startup" }, context);
+const stockRows = snapshot();
+for (const name of Object.keys(rows)) {
+  if (rendered(name).length === 0) throw new Error(`Calm-off rendering hid ${name}`);
+}
+requireVisible("midTurn", "MIDTURN_WORKING_NOTE", "Calm off");
+
+await calm.calmCommand.handler("", context);
+if (readFileSync(calmPreferencePath, "utf8") !== "on\n") {
+  throw new Error("plain /calm from off did not persist on");
+}
+requireVisible("midTurn", "MIDTURN_WORKING_NOTE", "ordinary Calm");
+requireVisible("finalReply", "FINAL_REPLY_TEXT", "ordinary Calm");
+
+await calm.calmCommand.handler("max", context);
+if (readFileSync(calmPreferencePath, "utf8") !== "max\n") {
+  throw new Error("/calm max did not persist max as its own literal value");
+}
+if (rendered("midTurn").length !== 0) {
+  throw new Error(`Calm max left mid-turn working-note rows: ${JSON.stringify(rendered("midTurn"))}`);
+}
+requireHidden("truncatedMidTurn", "TRUNCATED_MIDTURN_NOTE", "Calm max");
+// Pi owns the wording of its truncation notice; Calm max must leave that row's own
+// notice standing rather than collapsing an incomplete response to nothing.
+if (rendered("truncatedMidTurn").length === 0) {
+  throw new Error("Calm max removed Pi's own truncation notice with the working note");
+}
+requireVisible("streaming", "STREAMING_NOTE_TEXT", "Calm max");
+requireVisible("truncatedFinal", "TRUNCATED_FINAL_TEXT", "Calm max");
+if (JSON.stringify(rendered("finalReply")) !== stockRows.finalReply) {
+  throw new Error("Calm max changed the genuine final reply row");
+}
+if (JSON.stringify(messages) !== messagesBefore) {
+  throw new Error("Calm max mutated the assistant messages instead of a presentation copy");
+}
+
+await calm.calmCommand.handler("max", context);
+if (readFileSync(calmPreferencePath, "utf8") !== "max\n" || rendered("midTurn").length !== 0) {
+  throw new Error("repeating /calm max did not stay at max");
+}
+await calm.calmCommand.handler("  MaX  ", context);
+if (readFileSync(calmPreferencePath, "utf8") !== "max\n" || rendered("midTurn").length !== 0) {
+  throw new Error("/calm max is not accepted with surrounding space or mixed case");
+}
+
+// Restart: scramble the live level the way a fresh process starts, then let a newly
+// loaded extension restore from the persisted file alone.
+visibility.setCalmPresentation("off");
+ui.setHiddenThinkingLabel(undefined);
+requireVisible("midTurn", "MIDTURN_WORKING_NOTE", "scrambled live level");
+calm = await loadCalmExtension();
+if (calm.registeredTools.length !== 7) {
+  throw new Error(`a session restored at max claimed ${calm.registeredTools.length} built-in tools instead of 7`);
+}
+await calm.sessionStart({ reason: "resume" }, context);
+if (rendered("midTurn").length !== 0) {
+  throw new Error("a restored session treated the persisted max level as unrecognized");
+}
+for (const reason of ["startup", "new", "fork", "reload"]) {
+  await calm.sessionStart({ reason }, context);
+  if (rendered("midTurn").length !== 0) {
+    throw new Error(`a ${reason} session did not restore the persisted max level`);
+  }
+  requireVisible("finalReply", "FINAL_REPLY_TEXT", `${reason} session`);
+}
+
+await calm.calmCommand.handler("", context);
+if (readFileSync(calmPreferencePath, "utf8") !== "on\n") {
+  throw new Error("plain /calm from max did not revert to ordinary Calm");
+}
+requireVisible("midTurn", "MIDTURN_WORKING_NOTE", "reverted Calm");
+
+await calm.calmCommand.handler("", context);
+if (readFileSync(calmPreferencePath, "utf8") !== "off\n") {
+  throw new Error("plain /calm from on did not keep the existing off toggle");
+}
+const restoredRows = snapshot();
+for (const name of Object.keys(rows)) {
+  if (restoredRows[name] !== stockRows[name]) {
+    throw new Error(`turning Calm off did not restore byte-identical ${name} rendering`);
+  }
+}
+
+await calm.calmCommand.handler("max", context);
+if (readFileSync(calmPreferencePath, "utf8") !== "max\n" || rendered("midTurn").length !== 0) {
+  throw new Error("/calm max did not enter max directly from off");
+}
+await calm.calmCommand.handler("unrecognized", context);
+if (readFileSync(calmPreferencePath, "utf8") !== "on\n") {
+  throw new Error("an unrecognized /calm argument did not fall back to the plain toggle");
+}
+if (!existsSync(calmPreferencePath)) {
+  throw new Error("Calm stopped persisting its preference file");
+}
+JS
+  status=$?
+  out=$(cat "$output_file")
+  [ "$status" -eq 0 ] || fail "Pi calm max mid-turn contract failed: $out"
+  [ -z "$out" ] || fail "Pi calm max mid-turn test printed output: $out"
+  pass "Pi calm max collapses mid-turn assistant working notes to zero height while ordinary Calm keeps them, leaves streaming, truncated-final, and genuine final replies untouched, never mutates the messages, and restores the persisted max level across session starts"
 }
 
 test_operational_followup_turn_e2e() {
@@ -3659,6 +3933,7 @@ test_pi_compat_missing_adapter_exports
 test_builtin_gate_load_time
 test_calm_activation_collision_and_regression_bound
 test_rendering_and_session_lifecycle
+test_calm_max_mid_turn_working_notes
 test_operational_followup_turn_e2e
 test_hidden_block_geometry_e2e
 test_working_ship_geometry_and_lifecycle


### PR DESCRIPTION
## Intent

Captain-decided ship (option B, gated): add an UNDOCUMENTED /calm max to Firstmate's Pi Calm presentation layer, as a silent personal dogfood. Feasibility was already proven by a prior investigation; this task implements the accepted spec, it does not re-investigate.

Product: /calm becomes three-state instead of a boolean. off = stock Pi transcript (unchanged). on = today's Calm (unchanged): hides thinking labels, owned tool shells, operational rows, and KEEPS mid-turn assistant text. max = today's Calm plus hiding mid-turn assistant working notes.

Command surface: deliberately no new top-level command. '/calm max' enters max from any state and repeating it stays max. Plain '/calm' with no argument steps max -> on (the revert the captain explicitly asked for), and keeps the existing on -> off and off -> on toggle. Any other argument keeps the existing toggle rather than erroring, so the command still accepts whatever follows it as it always has.

Persistence is THE failure mode this change had to prevent: config/calm now writes 'max' as a literal third value (one trailing newline, same atomic replace as before), and session start / resume / fork / reload must restore max as max rather than treating it as unrecognized and dropping to off.

Hide rule, taken verbatim from the prior investigation and proven against the Pi the fleet actually runs (signed 0.84.1): hide assistant text blocks when the message's own stopReason is 'toolUse', and when it is 'length' with tool calls present. Deliberately do NOT hide while stopReason is 'pending' - that would also stop the real reply from streaming - so a brief on-screen flash before the marker flips is an accepted, intended tradeoff, not a defect. The hide is zero-height with no leftover blank rows and is presentation-only: it never mutates the message, model context, session storage, /export, or delivery. It extends the EXISTING installCalmAssistantLayout patch (same risk class as the shipped collapsed-thinking adapter, not a new one) and adds a new visibility class 'assistant-working-note' to fm-calm-visibility.ts so the policy stays with its single owner; ordinary Calm ('on') must NOT hide that class, only 'max' does.

Documentation is deliberately SILENT, by the captain's explicit decision: /calm max must NOT be advertised in docs/calm.md, in any user-facing usage, or in help text that would teach other users, and the /calm command description keeps today's wording. The one required documentation change is docs/configuration.md, which is the schema owner of config/calm and previously said the only written values are on/off: it now records max as a recognized persisted value, because otherwise the next session would treat max as unrecognized and drop to off. That stays a schema note, not a feature announcement. docs/calm-mode-feasibility.md is the maintainer-verification owner of the transcript-class taxonomy, so its class list and taxonomy table were corrected to stay accurate about the new class and level.

Explicitly out of scope by captain decision: no producer-side rule about when Firstmate addresses the captain; max is NOT the default; the separately known dropped-isStreaming fidelity defect in the shipped adapter is NOT shipped here because the hide does not need it.

Tests: renderer-fixture coverage in tests/fm-calm-pi-extension.test.sh asserting zero rendered lines for a toolUse message carrying text under max, non-zero for the same message under ordinary Calm on, byte-identical restoration with Calm off, plus streaming-pending text kept, truncated-without-tool-calls text kept, Pi's own truncation notice kept, messages never mutated, and the persisted max level restored across startup/new/resume/fork/reload after the live level is scrambled. The fixture is pointed at the fleet Pi via FM_PI_PACKAGE_DIR rather than the global npm install (global is 0.80.10, fleet is 0.84.1); the suite was run green against both. One pre-existing fixture stub gap was also fixed in the same file: the interactive-mode stub lacked getMarkdownTransformers, which Pi 0.83+ calls, so the existing renderer test could not run against the fleet Pi at all.

Delivery: no-mistakes, and the PR is NOT to be merged by the pipeline or by me - the captain merges. Any ask-user finding must be escalated rather than decided here.

## What Changed

- Add `/calm max` as a persistent third presentation level while preserving existing toggle behavior.
- Hide mid-turn assistant working notes at the max level without mutating messages or affecting ordinary Calm, streaming text, final replies, or exports.
- Extend renderer and lifecycle coverage for visibility, restoration, and Pi compatibility, and update persistence schema documentation.

## Risk Assessment

✅ Low: The change is well-bounded, preserves existing Calm behavior, implements the required persistence and visibility rules, and adds behavior-focused fixture coverage.

## Testing

Focused executable fixtures passed the complete `/calm max` contract on Pi 0.80.10 and fleet Pi 0.84.1, and a rendered evidence image confirms the mid-turn note is visible off/on but zero-height under max while pending, final, and truncation rows remain. The broader native fixture reached an unrelated `/export` timeout that reproduces unchanged on the base commit.

- Evidence: Pi 0.84.1 Calm off/on/max renderer comparison (local file: <code>/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/no-mistakes-evidence/01KZYARXEWXSF611V7099135TC/calm-max-render-evidence.png</code>)
<details>
<summary>Evidence: Rendered HTML evidence</summary>

```text
<!doctype html><meta charset="utf-8"><style>*{box-sizing:border-box}body{margin:0;background:#0b1020;color:#e8ecf4;font:18px system-ui;padding:44px}main{max-width:1200px;margin:auto}h1{font-size:38px;margin:0}.sub{color:#9ba8c2;margin:8px 0 30px}.card{background:#141b2d;border:1px solid #2a3550;border-radius:16px;margin:16px 0;overflow:hidden}.card header{display:flex;justify-content:space-between;align-items:center;padding:18px 22px;border-bottom:1px solid #2a3550}header span{display:block;color:#9ba8c2;font-size:14px;margin-top:4px}mark{font-size:13px;font-weight:700;padding:7px 10px;border-radius:20px;background:#203a2e;color:#80e5ad}.hidden mark{background:#43232a;color:#ff9faa}pre{margin:0;padding:22px;background:#080c16;color:#f1f4f8;font:16px ui-monospace,monospace;min-height:64px;white-space:pre-wrap}.hidden pre{color:#ff9faa}.checks{margin-top:28px}h2{font-size:22px}.grid{display:grid;grid-template-columns:1fr 1fr;gap:14px}.grid div{background:#141b2d;border:1px solid #2a3550;border-radius:12px;padding:16px}code{display:block;color:#aab8d4;margin-top:10px;font:13px ui-monospace,monospace;white-space:pre-wrap}footer{color:#7887a6;font-size:13px;margin-top:24px}</style><main><h1>/calm max — Pi 0.84.1 renderer evidence</h1><p class="sub">The same toolUse assistant message is stock-visible and ordinary-Calm-visible, but contributes zero rows under max.</p><section class="card visible"><header><div><b>Calm off</b><span>Stock Pi transcript</span></div><mark>VISIBLE</mark></header><pre>
 MIDTURN_WORKING_NOTE</pre></section><section class="card visible"><header><div><b>Calm on</b><span>Existing Calm behavior</span></div><mark>VISIBLE</mark></header><pre>
 MIDTURN_WORKING_NOTE</pre></section><section class="card hidden"><header><div><b>Calm max</b><span>Mid-turn working note</span></div><mark>ZERO HEIGHT</mark></header><pre>∅  zero rendered lines</pre></section><section class="checks"><h2>Protected behavior under max</h2><div class="grid"><div><b>Pending stream remains visible</b><code>
 STREAMING_NOTE_TEXT</code></div><div><b>Final reply remains visible</b><code>
 FINAL_REPLY_TEXT</code></div><div><b>Pi truncation notice remains</b><code>
 Response was truncated before completion.</code></div><div><b>Persistence & data</b><code>config/calm = max\n<br>messages unchanged = true</code></div></div></section><footer>Captured from AssistantMessageComponent rendering through the executable Firstmate extension fixture.</footer></main>
```
</details>
<details>
<summary>Evidence: Pi 0.84.1 focused renderer state</summary>

```text
{
  "stockMidTurnRows": [
    "",
    " MIDTURN_WORKING_NOTE                                                                               "
  ],
  "ordinaryCalmMidTurnRows": [
    "",
    " MIDTURN_WORKING_NOTE                                                                               "
  ],
  "maxMidTurnRows": [],
  "maxTruncatedToolRows": [
    "",
    " \u001b[38;5;167mResponse was truncated before completion.\u001b[39m                                                          "
  ],
  "maxStreamingRows": [
    "\u001b]133;A\u0007",
    "\u001b]133;B\u0007\u001b]133;C\u0007 STREAMING_NOTE_TEXT                                                                                "
  ],
  "maxFinalReplyRows": [
    "\u001b]133;A\u0007",
    "\u001b]133;B\u0007\u001b]133;C\u0007 FINAL_REPLY_TEXT                                                                                   "
  ],
  "persistedPreference": "max\n",
  "messagesUnchanged": true
}
```
</details>
<details>
<summary>Evidence: Pi 0.84.1 focused test transcript</summary>

```text
ok - Pi calm max collapses mid-turn assistant working notes to zero height while ordinary Calm keeps them, leaves streaming, truncated-final, and genuine final replies untouched, never mutates the messages, and restores the persisted max level across session starts
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (6m55s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"56ded136fddcfcf9569ebba4707df1d09eaf78bd","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `tests/fm-calm-pi-extension.test.sh:3516` - The native interactive fixture repeatedly timed out waiting for `/export`; the tmux-submitted command never appeared in Pi&#39;s editor. The identical failure reproduces at base commit db0280fe, so it is not introduced by `/calm max`.
- <code>`FM_PI_PACKAGE_DIR=&#34;$(npm root -g)/@earendil-works/pi-coding-agent&#34; bash tests/fm-calm-pi-extension.test.sh` against Pi package 0.80.10; all Calm max assertions passed before the later native `/export` timeout</code>
- <code>`npm pack @earendil-works/pi-coding-agent@0.84.1` followed by a local evidence-directory dependency install</code>
- <code>`CALM_MAX_RENDER_EVIDENCE=... FM_PI_PACKAGE_DIR=.../pi-0.84.1-package bash .../calm-max-evidence-test.sh` exercising off/on/max rendering, pending and truncation rules, message immutability, command cycling, literal persistence, and startup/new/resume/fork/reload restoration</code>
- `Rendered the captured Pi 0.84.1 row output as HTML and inspected the resulting PNG`
- <code>Ran `test_interactive_terminal_e2e` independently on target and base commit db0280fe; both reproduced the same `/export` timeout</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
