### PR TITLE
fix(watch): retain paused workers on recheck cadence

### DIFF
--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -61,12 +61,13 @@ FM_CLASSIFY_CAPTAIN_RE_DEFAULT='done:|needs-decision:|blocked:|failed:|PR ready|
 # drift between the two consumers. FM_CLASSIFY_PAUSED_VERB overrides it.
 FM_CLASSIFY_PAUSED_VERB_DEFAULT='paused'
 
-# Bounded re-surface cadence for a declared pause or a dead-agent captain hold.
+# Bounded re-surface cadence for a declared pause or a captain-held transfer.
 # Far longer than the wedge threshold (FM_STALE_ESCALATE_SECS, default 240s), it
 # avoids nagging a deliberate wait while ensuring a forgotten hold cannot rot
 # invisibly - it re-surfaces once for a recheck every window. One hour by default;
 # both consumers read FM_PAUSE_RESURFACE_SECS with this default so the cadence has
-# one owner.
+# one owner. Watcher liveness gating for that cadence is owned by pause_state_class
+# in bin/fm-watch.sh.
 # shellcheck disable=SC2034 # Read by the watcher and daemon (fm-watch.sh, fm-supervise-daemon.sh), not this lib.
 FM_PAUSE_RESURFACE_SECS_DEFAULT=3600
 
@@ -133,9 +134,8 @@ status_is_paused() {  # <status-line>
 
 # 0 if a status line declares either an external-wait pause or a verified
 # captain-held transfer.
-# Both declarations can intentionally leave an exited crew's endpoint idle, so
-# the watcher applies its bounded pause cadence when agent death confirms that
-# no live decision gate is being silenced.
+# Watcher liveness gating for the bounded pause cadence is owned by
+# pause_state_class in bin/fm-watch.sh.
 status_is_paused_or_captain_held() {  # <status-line>
   local line=$1 verb
   status_is_paused "$line" && return 0

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -166,8 +166,9 @@ STALE_ESCALATE_SECS=${FM_STALE_ESCALATE_SECS:-240}  # idle secs before a provabl
 BUSY_TURN_MAX_SECS=${FM_BUSY_TURN_MAX_SECS:-3600}
 # A crew that declared a pause is idling on a known external wait, so its stale
 # pane is absorbed rather than wedge-escalated.
-# A captain-held or paused crew whose agent has confidently exited uses the same
-# bounded cadence, while a live or ambiguously read agent still surfaces once.
+# A captain-held or paused crew with a confirmed live or exited agent uses the
+# same bounded cadence. An ambiguous or unreadable endpoint still surfaces, so
+# unverified liveness never suppresses a potentially actionable stale pane.
 # These cases re-surface once for a recheck every PAUSE_RESURFACE_SECS - far
 # longer than the wedge threshold, but finite so a forgotten hold cannot rot invisibly.
 PAUSE_RESURFACE_SECS=${FM_PAUSE_RESURFACE_SECS:-$FM_PAUSE_RESURFACE_SECS_DEFAULT}
@@ -327,7 +328,8 @@ busy_turn_over_age() {  # <task>
 }
 
 # Absorb a stale pane under a declared external-wait pause (paused:) or a
-# dead-agent captain-held transfer, and re-surface it once every
+# captain-held transfer with a confirmed live or exited agent, and re-surface
+# it once every
 # PAUSE_RESURFACE_SECS for a recheck so it cannot rot invisibly. Called on any
 # stale poll once pause_state_class permits the bounded cadence, so it must be
 # cheap: it NEVER re-reads crew state. The re-surface age is anchored on the
@@ -399,8 +401,8 @@ clear_pause_tracking() {  # <window>
 }
 
 # Reconcile a declared pause or captain-held status with authoritative crew state.
-# Only a confidently dead ordinary crew may recover paused classification after
-# fm-crew-state has fallen back to stopped or unknown.
+# A confirmed live or exited ordinary agent retains its declared pause cadence.
+# Ambiguous or unreadable endpoints surface rather than suppressing stale work.
 pause_state_class() {  # <window> <task>
   local win=$1 task=$2 key last recheck_file class agent_alive
   key=${win//:/_}
@@ -416,11 +418,10 @@ pause_state_class() {  # <window> <task>
   if [ -e "$STATE/.paused-$key" ] && [ "$(age_of "$recheck_file")" -lt "$STALE_ESCALATE_SECS" ]; then
     if [ "$(window_kind "$win")" != secondmate ]; then
       agent_alive=$(fm_backend_agent_alive "$(window_backend "$win")" "$win" 2>/dev/null) || agent_alive=unknown
-      if [ "$agent_alive" != dead ]; then
-        rm -f "$recheck_file"
-        printf 'none'
-        return
-      fi
+      case "$agent_alive" in
+        alive|dead) printf 'paused'; return ;;
+        *) rm -f "$recheck_file"; printf 'none'; return ;;
+      esac
     fi
     printf 'paused'
     return
@@ -433,13 +434,11 @@ pause_state_class() {  # <window> <task>
   fi
   if [ "$(window_kind "$win")" != secondmate ]; then
     agent_alive=$(fm_backend_agent_alive "$(window_backend "$win")" "$win" 2>/dev/null) || agent_alive=unknown
-    if [ "$agent_alive" != dead ]; then
-      rm -f "$recheck_file"
-      printf 'none'
-      return
-    fi
+    case "$agent_alive" in
+      alive|dead) class=paused ;;
+      *) rm -f "$recheck_file"; printf 'none'; return ;;
+    esac
   fi
-  [ "$class" = none ] && [ "${agent_alive:-unknown}" = dead ] && class=paused
   case "$class" in
     paused) date +%s > "$recheck_file" ;;
     *) rm -f "$recheck_file" ;;
@@ -1123,7 +1122,7 @@ EOF
           #     pane (e.g. waiting on CI), so absorb and start the wedge timer so a
           #     genuinely frozen run still escalates past STALE_ESCALATE_SECS;
           #   - paused: the crew declared an external wait, or a declared pause or
-          #     captain hold is paired with a confidently dead agent, so absorb on
+          #     captain hold is paired with a confirmed live or exited agent, so absorb on
           #     the long PAUSE_RESURFACE_SECS cadence instead of wedge-escalating;
           #   - none: no running pipeline, no exact busy verdict, no declared pause.
           #     Surface immediately so firstmate inspects the inconclusive state

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,9 +22,8 @@ A concurrent replacement remains armed, every non-merged or invalid observation 
 No-verb wakes, such as `working:` notes and bare turn-ended signals, are benign only when `bin/fm-crew-state.sh` reports positive evidence that the crew is still working: an actively running no-mistakes step attributed to that crew's current code, or an exact busy verdict from the semantic busy-state contract.
 A `kind=secondmate` task's status signal is the parent-directed reply stream and is never absorbed as provably working; only its bare turn-ended signal retains the ordinary absorb rule.
 A crew that declares `paused:` for a known external wait is separately absorbed while idle and re-surfaced only on the longer pause cadence, rather than being treated as a possible wedge.
-For an ordinary crew that has stopped, the normal-mode watcher first surfaces one stale wake, then applies that same cadence to an unchanged `paused:` or durable `captain-held` endpoint only when the backend confidently reports its agent dead.
-Live or inconclusive liveness remains fail-open at that initial surface, and the secondmate idle-endpoint exemption is unchanged.
-Its initial normal-mode status signal still surfaces through the no-verb path, while away mode self-handles that routine signal and owns the later recheck.
+Normal-mode watcher liveness gating for that cadence, including the secondmate idle-endpoint exemption, is owned by `pause_state_class` in `bin/fm-watch.sh`.
+A declared pause's initial normal-mode status signal still surfaces through the no-verb path, while away mode self-handles that routine signal and owns the later recheck.
 Fresh stale panes use the same current-state read before trusting the status log, so an active run or a proven busy worker outranks an old captain-relevant status-log line left behind before validation.
 No-change heartbeats are also benign.
 Separately from heartbeat backoff and wedge handling, the watcher poll runs `bin/fm-inactive-reconcile.sh` on its own bounded cadence, while locked session start performs the same bounded local scan immediately.

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -165,6 +165,24 @@ record_pi_busy() {  # <state-dir> <id>
 
 reap() { kill "$1" 2>/dev/null || true; wait "$1" 2>/dev/null || true; }
 
+# Drive pause_state_class through the watcher's source-guard interface.
+# Stubs fm_backend_agent_alive so the three-state contract is tested without
+# encoding any runtime's pane UI. tmux and herdr both collapse into alive/dead/
+# unknown; zellij, orca, and cmux report unverified, which that seam treats as
+# unknown and therefore fail-open.
+run_pause_state_class() {  # <state> <fakebin> <window> <task> <alive>
+  local state=$1 fakebin=$2 window=$3 task=$4
+  export FM_FAKE_AGENT_ALIVE=$5
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" \
+    FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_ROOT_OVERRIDE="$ROOT" \
+    bash -c '
+      # shellcheck source=/dev/null
+      . "$1"
+      fm_backend_agent_alive() { printf "%s\n" "${FM_FAKE_AGENT_ALIVE:-unknown}"; }
+      pause_state_class "$2" "$3"
+    ' _ "$WATCH" "$window" "$task"
+}
+
 # --- pure classifier predicates (fm-classify-lib.sh) ------------------------
 
 test_signal_reason_is_actionable_classifier() {
@@ -325,6 +343,7 @@ test_status_is_paused_classifier() {
   status_is_paused 'paused: holding for the upstream release' || fail "paused verb not recognized"
   status_is_paused '  paused:   waiting on a rate-limit reset' || fail "leading-space paused verb not recognized"
   status_is_paused 'blocked: the build is paused upstream' && fail "a blocked line mentioning paused false-matched"
+  status_is_paused 'pause: waiting for upstream' && fail "a malformed pause verb matched"
   status_is_paused 'working: paused the animation loop' && fail "a working line mentioning paused false-matched"
   status_is_paused 'done: shipped' && fail "done classified as paused"
   status_is_paused '' && fail "empty line classified as paused"
@@ -744,6 +763,265 @@ test_nonterminal_stale_not_working_surfaced() {
   pass "a not-provably-working non-terminal stale is surfaced immediately (never left to wait out the timer)"
 }
 
+# A malformed or superseded pause declaration must not suppress ordinary stale
+# detection, even when the endpoint remains live and idle.
+test_malformed_pause_evidence_surfaces() {
+  local dir state fakebin out capture_file window key pane_hash sig pid
+  dir=$(make_case malformed-pause); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; window="test:fm-malformed-pause"
+  printf 'idle agent after malformed pause\n' > "$capture_file"
+  printf 'window=%s\nkind=ship\nharness=claude\nbackend=tmux\n' "$window" > "$state/malformed-pause.meta"
+  printf 'pause: waiting for upstream\n' > "$state/malformed-pause.status"
+  sig=$(seen_sig "$state/malformed-pause.status"); printf '%s' "$sig" > "$state/.seen-malformed-pause_status"
+  key=${window//:/_}
+  key=${key//\//_}
+  key=${key//./_}
+  pane_hash=$(hash_text "idle agent after malformed pause")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=claude FM_FAKE_CREW_STATE='state: unknown · source: none · malformed pause is not a durable wait' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "malformed pause evidence suppressed an idle stale pane"
+  grep -Fx "stale: $window" "$out" >/dev/null || fail "malformed pause evidence did not surface the ordinary stale wake"
+  [ ! -e "$state/.paused-$key" ] || fail "malformed pause evidence created a pause cadence marker"
+  pass "malformed pause evidence leaves ordinary stale detection actionable"
+}
+
+# Initiating classification: pause_state_class must retain a declared pause or
+# captain-held transfer for a confirmed live or dead agent, and fail-open for
+# an unreadable endpoint. This is the three-state backend contract, not a
+# harness pane-capture heuristic.
+test_pause_state_class_retains_confirmed_agents() {
+  local dir state fakebin window class
+  dir=$(make_case pause-state-class-confirmed); state="$dir/state"; fakebin="$dir/fakebin"
+  window="test:fm-gate"
+  printf 'window=%s\nkind=ship\nharness=claude\nbackend=tmux\n' "$window" > "$state/gate.meta"
+  printf 'paused: waiting for the upstream release\n' > "$state/gate.status"
+  export FM_FAKE_CREW_STATE='state: paused · source: status-log · waiting for the upstream release'
+
+  class=$(run_pause_state_class "$state" "$fakebin" "$window" gate alive)
+  [ "$class" = paused ] || fail "confirmed-alive declared pause classified $class, not paused"
+  class=$(run_pause_state_class "$state" "$fakebin" "$window" gate dead)
+  [ "$class" = paused ] || fail "confirmed-dead declared pause classified $class, not paused"
+  class=$(run_pause_state_class "$state" "$fakebin" "$window" gate unknown)
+  [ "$class" = none ] || fail "unreadable declared pause classified $class, not none"
+
+  printf 'captain-held [key=route]: tracked by held-decision-route\n' > "$state/gate.status"
+  export FM_FAKE_CREW_STATE='state: unknown · source: none · held by captain'
+  class=$(run_pause_state_class "$state" "$fakebin" "$window" gate alive)
+  [ "$class" = paused ] || fail "confirmed-alive captain-held classified $class, not paused"
+  class=$(run_pause_state_class "$state" "$fakebin" "$window" gate dead)
+  [ "$class" = paused ] || fail "confirmed-dead captain-held classified $class, not paused"
+  class=$(run_pause_state_class "$state" "$fakebin" "$window" gate unknown)
+  [ "$class" = none ] || fail "unreadable captain-held classified $class, not none"
+
+  unset FM_FAKE_CREW_STATE FM_FAKE_AGENT_ALIVE
+  pass "pause_state_class retains confirmed live or dead agents and surfaces unreadable endpoints"
+}
+
+# Recheck-clearing mask: a live idle paused pane used to delete .paused-rechecked
+# and fall off the cadence. The marker must survive first sight and re-arm.
+# pane_current_command is the tmux process-name liveness signal, not a rendered
+# UI; two harness names prove the cadence is not grok-specific.
+test_live_paused_idle_retains_recheck_marker() {
+  local dir state fakebin out capture_file statusf window key pane_hash sig pid harness
+  for harness in claude pi; do
+    dir=$(make_case "live-pause-recheck-$harness"); state="$dir/state"; fakebin="$dir/fakebin"
+    out="$dir/watch.out"; capture_file="$dir/pane.txt"; statusf="$state/gate.status"
+    window="test:fm-gate-$harness"
+    printf 'idle parked worker\n' > "$capture_file"
+    printf 'window=%s\nkind=ship\nharness=%s\nbackend=tmux\n' "$window" "$harness" > "$state/gate.meta"
+    printf 'paused: waiting for the upstream release\n' > "$statusf"
+    sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-gate_status"
+    key=${window//:/_}
+    key=${key//\//_}
+    key=${key//./_}
+    pane_hash=$(hash_text "idle parked worker")
+    printf '%s' "$pane_hash" > "$state/.hash-$key"
+    printf '1\n' > "$state/.count-$key"
+    PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+      FM_FAKE_TMUX_CURRENT_COMMAND="$harness" \
+      FM_FAKE_CREW_STATE='state: paused · source: status-log · waiting for the upstream release' \
+      FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+      FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+    pid=$!
+    if ! wait_live "$pid" 30; then
+      reap "$pid"
+      fail "live $harness declared pause surfaced instead of absorbing: $(cat "$out")"
+    fi
+    [ -e "$state/.paused-$key" ] || { reap "$pid"; fail "live $harness declared pause did not retain its cadence marker"; }
+    [ -s "$state/.paused-rechecked-$key" ] || { reap "$pid"; fail "live $harness declared pause did not retain its recheck marker"; }
+    [ ! -e "$state/.stale-since-$key" ] || { reap "$pid"; fail "live $harness declared pause retained the wedge timer"; }
+    grep -F "stale: $window" "$out" >/dev/null && { reap "$pid"; fail "live $harness declared pause printed a stale wake during absorb"; }
+    reap "$pid"
+    ack_stopped_cycle "$state" || fail "could not acknowledge the intentional live $harness pause stop"
+
+    printf '%s\n' $(( $(date +%s) - 500 )) > "$state/.stale-since-$key"
+    : > "$out"
+    PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+      FM_FAKE_TMUX_CURRENT_COMMAND="$harness" \
+      FM_FAKE_CREW_STATE='state: paused · source: status-log · waiting for the upstream release' \
+      FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_STALE_ESCALATE_SECS=240 FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+      FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+    pid=$!
+    if ! wait_live "$pid" 30; then
+      reap "$pid"
+      fail "live $harness declared pause escalated on the wedge timer: $(cat "$out")"
+    fi
+    [ -s "$state/.paused-rechecked-$key" ] || { reap "$pid"; fail "live $harness declared pause lost its recheck marker after re-arm"; }
+    [ ! -e "$state/.stale-since-$key" ] || { reap "$pid"; fail "live $harness declared pause retained the wedge timer after re-arm"; }
+    reap "$pid"
+    ack_stopped_cycle "$state" || fail "could not acknowledge the intentional live $harness pause re-arm stop"
+  done
+  pass "a live idle declared pause retains its recheck marker across first sight and re-arm"
+}
+
+# Visible repeated notification: after the recheck marker is kept, a churny idle
+# pane (new hash) must stay on the pause cadence instead of emitting another
+# bare waiting-too-long stale wake.
+test_live_paused_idle_hash_churn_stays_on_cadence() {
+  local dir state fakebin out capture_file statusf window key pane_hash sig pid wakes
+  dir=$(make_case live-pause-hash-churn); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; statusf="$state/gate.status"
+  window="test:fm-gate"
+  printf 'idle parked worker\n' > "$capture_file"
+  printf 'window=%s\nkind=ship\nharness=claude\nbackend=tmux\n' "$window" > "$state/gate.meta"
+  printf 'paused: waiting for the upstream release\n' > "$statusf"
+  sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-gate_status"
+  key=${window//:/_}
+  key=${key//\//_}
+  key=${key//./_}
+  pane_hash=$(hash_text "idle parked worker")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=claude \
+    FM_FAKE_CREW_STATE='state: paused · source: status-log · waiting for the upstream release' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  if ! wait_live "$pid" 30; then
+    reap "$pid"
+    fail "live declared pause surfaced instead of absorbing: $(cat "$out")"
+  fi
+  reap "$pid"
+  ack_stopped_cycle "$state" || fail "could not acknowledge the intentional live pause stop"
+
+  printf 'idle parked worker (token 2)\n' > "$capture_file"
+  pane_hash=$(hash_text "idle parked worker (token 2)")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+  prime_status_seen "$state" "$statusf"
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=claude \
+    FM_FAKE_CREW_STATE='state: paused · source: status-log · waiting for the upstream release' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  if ! wait_live "$pid" 30; then
+    reap "$pid"
+    fail "live declared pause re-notified on idle hash churn: $(cat "$out")"
+  fi
+  grep -Fx "stale: $window" "$out" >/dev/null && { reap "$pid"; fail "live declared pause printed a bare stale wake on hash churn"; }
+  [ -s "$state/.paused-rechecked-$key" ] || { reap "$pid"; fail "live declared pause lost its recheck marker on hash churn"; }
+  reap "$pid"
+  wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' "$state/.wake-queue")
+  [ "$wakes" -eq 0 ] || fail "live declared pause queued $wakes stale wakes across idle hash churn"
+  pass "a live idle declared pause does not repeat a waiting-too-long wake on pane churn"
+}
+
+# Long-cadence recheck still fires for a live parked worker, both for a declared
+# external wait and a captain-held transfer, and is never a possible-wedge.
+test_live_paused_and_captain_held_resurfaces_on_long_cadence() {
+  local dir state fakebin out capture_file statusf window key pane_hash sig pid back
+  dir=$(make_case live-pause-resurface); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; statusf="$state/held.status"
+  window="test:fm-held"
+  printf 'idle, holding for upstream\n' > "$capture_file"
+  printf 'window=%s\nkind=ship\nharness=claude\nbackend=tmux\n' "$window" > "$state/held.meta"
+  printf 'paused: holding for the upstream tool release\n' > "$statusf"
+  back=$(( $(date +%s) - 500 ))
+  if [ "$(uname)" = Darwin ]; then touch -mt "$(date -r "$back" '+%Y%m%d%H%M.%S')" "$statusf"
+  else touch -m -d "@$back" "$statusf"; fi
+  sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-held_status"
+  key=${window//:/_}
+  key=${key//\//_}
+  key=${key//./_}
+  pane_hash=$(hash_text "idle, holding for upstream")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=claude \
+    FM_FAKE_CREW_STATE='state: paused · source: status-log · holding for the upstream tool release' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=240 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "live declared pause did not re-surface on the bounded cadence"
+  grep -F "stale: $window" "$out" >/dev/null || fail "live declared pause re-surface did not print a stale wake"
+  grep -F "awaiting external" "$out" >/dev/null || fail "live declared pause re-surface was not labeled a paused/awaiting-external recheck"
+  grep -F "possible wedge" "$out" >/dev/null && fail "a live declared pause was mislabeled a possible wedge"
+
+  dir=$(make_case live-captain-held-resurface); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; statusf="$state/held.status"
+  window="test:fm-held"
+  printf 'idle after captain-held transfer\n' > "$capture_file"
+  printf 'window=%s\nkind=ship\nharness=claude\nbackend=tmux\n' "$window" > "$state/held.meta"
+  printf 'captain-held [key=route]: tracked by held-decision-route\n' > "$statusf"
+  back=$(( $(date +%s) - 500 ))
+  if [ "$(uname)" = Darwin ]; then touch -mt "$(date -r "$back" '+%Y%m%d%H%M.%S')" "$statusf"
+  else touch -m -d "@$back" "$statusf"; fi
+  sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-held_status"
+  key=${window//:/_}
+  key=${key//\//_}
+  key=${key//./_}
+  pane_hash=$(hash_text "idle after captain-held transfer")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=claude \
+    FM_FAKE_CREW_STATE='state: unknown · source: none · held by captain' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=240 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "live captain-held pane did not re-surface on the bounded cadence"
+  grep -F "awaiting external" "$out" >/dev/null \
+    || fail "live captain-held pane surfaced as a stopped crew rather than a bounded recheck"
+  grep -F "possible wedge" "$out" >/dev/null && fail "a live captain-held pane was mislabeled a possible wedge"
+  pass "live declared pauses and captain-held transfers re-surface on the long cadence, never as a wedge"
+}
+
+# An unreadable live-looking endpoint must still fail-open: a non-agent,
+# non-shell process name collapses to unknown and must surface rather than
+# silencing a potentially actionable stale pane.
+test_unreadable_paused_endpoint_still_surfaces() {
+  local dir state fakebin out capture_file window key pane_hash sig pid
+  dir=$(make_case unreadable-paused); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; window="test:fm-unreadable"
+  printf 'idle unknown process\n' > "$capture_file"
+  printf 'window=%s\nkind=ship\nharness=claude\nbackend=tmux\n' "$window" > "$state/unreadable.meta"
+  printf 'paused: waiting for the upstream release\n' > "$state/unreadable.status"
+  sig=$(seen_sig "$state/unreadable.status"); printf '%s' "$sig" > "$state/.seen-unreadable_status"
+  key=${window//:/_}
+  key=${key//\//_}
+  key=${key//./_}
+  pane_hash=$(hash_text "idle unknown process")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=python \
+    FM_FAKE_CREW_STATE='state: paused · source: status-log · waiting for the upstream release' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "unreadable paused endpoint did not surface"
+  grep -Fx "stale: $window" "$out" >/dev/null || fail "unreadable paused endpoint did not print a bare stale wake"
+  pass "an unreadable paused endpoint still surfaces rather than suppressing stale work"
+}
+
 # --- non-terminal stale, crew DECLARED a pause: absorbed, re-surfaced on a long
 #     cadence, never wedge-escalated ------------------------------------------
 # The live 2026-07-09/10 case: a crew intentionally held awaiting an upstream tool
@@ -818,10 +1096,8 @@ test_nonterminal_stale_paused_absorbed_then_resurfaced() {
 # fm-crew-state then authoritatively reports stopped rather than paused, but the
 # confirmed-dead agent plus the declared wait or captain-held transfer must retain
 # bounded pause handling.
-# A still-live agent at an external-decision gate is the disconfirming case: it
-# must surface once, while the unchanged hash must not append the same wake on
-# every watcher re-arm.
-test_exited_declared_pause_is_bounded_but_live_gate_surfaces() {
+# A still-live idle agent is covered separately: it retains the same cadence.
+test_exited_declared_pause_is_bounded() {
   local dir state fakebin out capture_file statusf window key pane_hash sig pid back round wakes bare
   dir=$(make_case exited-declared-pause); state="$dir/state"; fakebin="$dir/fakebin"
   out="$dir/watch.out"; capture_file="$dir/pane.txt"; statusf="$state/held.status"
@@ -855,8 +1131,10 @@ test_exited_declared_pause_is_bounded_but_live_gate_surfaces() {
     fi
     round=$((round + 1))
   done
-  wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' "$state/.wake-queue")
-  bare=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w && $5 == "stale: " w { n++ } END { print n + 0 }' "$state/.wake-queue")
+  wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' "$state/.wake-queue" 2>/dev/null)
+  wakes=${wakes:-0}
+  bare=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w && $5 == "stale: " w { n++ } END { print n + 0 }' "$state/.wake-queue" 2>/dev/null)
+  bare=${bare:-0}
   [ "$wakes" -le 1 ] || fail "dead-agent declared pause flooded $wakes stale wakes across six unchanged polls"
   [ "$bare" -eq 0 ] || fail "dead-agent declared pause surfaced as $bare bare stopped-crew wakes"
   grep -F "awaiting external" "$state/.wake-queue" >/dev/null \
@@ -930,6 +1208,7 @@ test_exited_declared_pause_is_bounded_but_live_gate_surfaces() {
   [ "$bare" -eq 0 ] || fail "acknowledged external-decision bare stale remained queued"
   pass "exited declared-pause and captain-held panes use bounded pause cadence while a live decision gate still surfaces once"
 }
+
 
 test_secondmate_paused_resurfaces_in_normal_mode() {
   local dir state fakebin out capture_file statusf window key pane_hash sig pid back
@@ -2119,8 +2398,14 @@ test_busy_pane_repeated_escalation_reaches_demand_deep_inspection
 test_busy_pane_default_turn_age_bound_is_3600s
 test_busy_declared_pause_is_rechecked_not_wedge_escalated
 test_nonterminal_stale_not_working_surfaced
+test_malformed_pause_evidence_surfaces
+test_pause_state_class_retains_confirmed_agents
+test_live_paused_idle_retains_recheck_marker
+test_live_paused_idle_hash_churn_stays_on_cadence
+test_live_paused_and_captain_held_resurfaces_on_long_cadence
+test_unreadable_paused_endpoint_still_surfaces
 test_nonterminal_stale_paused_absorbed_then_resurfaced
-test_exited_declared_pause_is_bounded_but_live_gate_surfaces
+test_exited_declared_pause_is_bounded
 test_secondmate_paused_resurfaces_in_normal_mode
 test_secondmate_nonpaused_stale_remains_suppressed
 test_secondmate_unpause_clears_pause_tracking

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -1174,39 +1174,60 @@ test_exited_declared_pause_is_bounded() {
   pane_hash=$(hash_text "idle external-decision gate")
   printf '%s' "$pane_hash" > "$state/.hash-$key"
   printf '1\n' > "$state/.count-$key"
-
-  # First sight must surface promptly so a live external-decision gate is not
-  # hidden behind the pause cadence.
+  # A live idle agent with a durable pause is deliberately parked. Its first stale
+  # observation is absorbed, and the persisted recheck marker proves that the
+  # next poll remains on the bounded cadence instead of re-notifying immediately.
   PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
     FM_FAKE_TMUX_CURRENT_COMMAND=grok FM_FAKE_CREW_STATE='state: paused · source: status-log · waiting at an active external-decision gate' \
     FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
     FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" >> "$out" &
   pid=$!
-  wait_for_exit "$pid" 100 || fail "live external-decision gate did not surface immediately"
-  ack_stopped_cycle "$state" || fail "could not acknowledge the immediate external-decision surface"
+  if ! wait_live "$pid" 30; then
+    reap "$pid"
+    fail "live declared pause surfaced instead of absorbing: $(cat "$out")"
+  fi
+  [ -e "$state/.paused-$key" ] || { reap "$pid"; fail "live declared pause did not retain its cadence marker"; }
+  [ -s "$state/.paused-rechecked-$key" ] || { reap "$pid"; fail "live declared pause did not retain its recheck marker"; }
+  [ ! -e "$state/.stale-since-$key" ] || { reap "$pid"; fail "live declared pause retained the wedge timer"; }
+  reap "$pid"
+  ack_stopped_cycle "$state" || fail "could not acknowledge the intentional live pause stop"
 
-  # Re-arm with the stale timer already beyond the wedge threshold. This is the
-  # exact unchanged-hash fallback after the immediate surface: it must retain
-  # the pause cadence and discard any residual wedge timer instead of emitting
-  # a second possible-wedge wake.
+  # Re-arm with a stale wedge timer to prove an unchanged alive+paused pane stays
+  # paused, retains its recheck marker, and clears ordinary wedge tracking.
   printf '%s\n' $(( $(date +%s) - 500 )) > "$state/.stale-since-$key"
   PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
     FM_FAKE_TMUX_CURRENT_COMMAND=grok FM_FAKE_CREW_STATE='state: paused · source: status-log · waiting at an active external-decision gate' \
     FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_STALE_ESCALATE_SECS=240 FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
     FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" >> "$out" &
   pid=$!
-  if ! wait_poll_cycle "$state" "$pid"; then
+  if ! wait_live "$pid" 30; then
     reap "$pid"
-    fail "live external-decision gate escalated on the wedge timer after its immediate surface: $(cat "$out")"
+    fail "live declared pause escalated on the wedge timer: $(cat "$out")"
   fi
-  [ -e "$state/.paused-$key" ] || { reap "$pid"; fail "live external-decision gate lost its pause cadence marker"; }
-  [ ! -e "$state/.stale-since-$key" ] || { reap "$pid"; fail "live external-decision gate retained the wedge timer"; }
+  [ -s "$state/.paused-rechecked-$key" ] || { reap "$pid"; fail "live declared pause lost its recheck marker after re-arm"; }
+  [ ! -e "$state/.stale-since-$key" ] || { reap "$pid"; fail "live declared pause retained the wedge timer after re-arm"; }
+  reap "$pid"
+  ack_stopped_cycle "$state" || fail "could not acknowledge the intentional live pause re-arm stop"
+
+  # A captain-held decision is the same deliberate park when its endpoint remains
+  # live. It must retain the long cadence without changing keyed decision semantics.
+  printf 'needs-decision [key=route]: choose deployment route\ncaptain-held [key=route]: tracked by held-decision-route\n' > "$statusf"
+  [ -z "$(status_open_decisions "$statusf")" ] || fail "captain-held decision did not close its exact keyed decision"
+  sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-gate_status"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=grok FM_FAKE_CREW_STATE='state: unknown · source: none · held by captain' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" >> "$out" &
+  pid=$!
+  if ! wait_live "$pid" 30; then
+    reap "$pid"
+    fail "live captain-held decision surfaced instead of absorbing: $(cat "$out")"
+  fi
+  [ -s "$state/.paused-rechecked-$key" ] || { reap "$pid"; fail "live captain-held decision lost its recheck marker"; }
   reap "$pid"
   wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' "$state/.wake-queue")
-  bare=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w && $5 == "stale: " w { n++ } END { print n + 0 }' "$state/.wake-queue")
-  [ "$wakes" -eq 0 ] || fail "acknowledged external-decision surface replayed $wakes wakes"
-  [ "$bare" -eq 0 ] || fail "acknowledged external-decision bare stale remained queued"
-  pass "exited declared-pause and captain-held panes use bounded pause cadence while a live decision gate still surfaces once"
+  [ "$wakes" -eq 0 ] || fail "live declared pause or captain-held decision queued $wakes stale wakes"
+  pass "declared pauses and captain-held transfers use bounded cadence for confirmed live or exited agents"
 }
 
 


### PR DESCRIPTION
## Intent

Finish the preserved Firstmate fix that stops parked-but-alive workers from producing repeated waiting-too-long notifications. Recover the intended behavior from commit a54022da on fm/fix-paused-alive-stale-loop-g4, reconstruct it on current main, and do not copy obsolete pipeline-only commits.

Acceptance criteria that remain in force:
1. Reproduce the bug via the real waiting classification path before changing code.
2. Prove initiating classification, recheck-clearing mask, and visible repeated notification separately.
3. Keep long-cadence rechecks for declared external waits and captain-held workers; genuine wedges still escalate.
4. Review every supported runtime; do not encode one worker runtime's rendered UI as fleet-wide.
5. Extend public-script tests; run bin/fm-lint.sh, watcher/classifier suites, and doc audience checks.
6. Keep the contract in its single owner; only concise cross-refs and current verification evidence.
7. Drive no-mistakes against the current-main-based head and report the green PR.

The product fix is already committed on this branch at 5af1227 (pause_state_class retains confirmed alive or dead agents so live paused idle workers stay on pause cadence). Continue the preserved validation from this exact head. Preserve every existing commit; do not abort-and-restart in a way that drops commits. Use Codex as the pipeline review agent; do not invoke Claude.

## What Changed

- Keep declared paused and captain-held ordinary workers on the bounded recheck cadence when agent liveness is confirmed alive or dead, while unreadable endpoints still surface normally.
- Add watcher coverage for pause classification, retained recheck markers, pane churn, bounded resurfaces, malformed declarations, and unknown liveness.
- Document the watcher-owned liveness gate and configured paused-worker recheck behavior.

## Risk Assessment

✅ Low: The bounded pause-cadence fix is narrowly scoped, preserves fail-open handling for unknown liveness, and retains the existing working-state wedge escalation path.

## Testing

Targeted watcher integration scenarios passed and provide CLI-level evidence that parked live workers retain pause cadence through idle hash churn without repeat waiting-too-long notifications, while declared waits and captain holds recheck on the long cadence and active work still escalates; documentation audience checks passed. `bin/fm-lint.sh` was intentionally not run because this assigned test phase explicitly prohibits linters.

<details>
<summary>Evidence: Watcher behavior transcript</summary>

`Live paused-worker proof: classification retains confirmed live/dead agents; recheck marker survives re-arm; idle hash churn emits no repeat stale wake; long-cadence external-wait and captain-held rechecks remain non-wedges; active work still wedge-escalates.`

```text
ok - signal_reason_is_actionable: benign absorbed, captain verbs and coalesced batches surfaced
ok - stale_is_terminal: terminal status surfaces, non-terminal and no-status are benign
ok - scan_captain_relevant_statuses lists only captain-relevant statuses
ok - classifier primitives: keyed decisions and activity phases, captain relevance, window-to-task, and overrides
ok - crew_is_provably_working: only working+run-step/pane is provable; idle/finished/parked/failed/unknown surface
ok - status_is_paused: only the leading paused verb matches, and paused is not captain-relevant
ok - crew_absorb_class: working/paused/none from one read; crew_is_paused and crew_is_provably_working agree
ok - signal_crew_provably_working: benign only when every referenced crew is provably working
ok - a secondmate's status signal is never absorbed as provably working; crewmates are unaffected
ok - a no-verb signal whose crew is provably working is absorbed (no exit, no queue, suppressor advanced, beacon present)
ok - a bare turn-end whose crew is provably working (busy pane) is absorbed
ok - a bare turn-end whose crew is not provably working is surfaced (the swallowed-finish fix)
ok - a no-verb working: note whose crew is idle with no running pipeline is surfaced
ok - a secondmate's status note surfaces even while its own agent is busy
ok - a self-announced close never wakes its own home, and the next real note still does
ok - captain-relevant signal is surfaced (queue + exit) and marked surfaced
ok - a stale pane sitting on a terminal status is surfaced (queue + exit)
ok - a stale terminal-looking status is overridden and absorbed while a run is actively working, then wedge-escalated
ok - provably-working non-terminal stale is absorbed on first sight, then wedge-escalated past the threshold
ok - consecutive wedge escalations on the same pane accumulate and demand deep inspection at the threshold
ok - a pane becoming active again resets the consecutive wedge-escalation counter
ok - a busy worker below the turn-age bound remains working with no escalation
ok - a busy worker with a stable pane hash still escalates once its completed-turn age reaches the bound
ok - a busy worker whose pane hash changes every poll still escalates once its completed-turn age reaches the bound
ok - touching a busy worker's completed-turn marker resets the age and prevents an old-age escalation
ok - repeated busy turn-age escalations reuse the existing escalation counter and demand deep inspection at the threshold
ok - the production default busy-turn-age bound is 3600s (5min under does not wedge, 66min over does)
ok - a not-provably-working non-terminal stale is surfaced immediately (never left to wait out the timer)
ok - malformed pause evidence leaves ordinary stale detection actionable
ok - pause_state_class retains confirmed live or dead agents and surfaces unreadable endpoints
ok - a live idle declared pause retains its recheck marker across first sight and re-arm
ok - a live idle declared pause does not repeat a waiting-too-long wake on pane churn
ok - live declared pauses and captain-held transfers re-surface on the long cadence, never as a wedge
ok - an unreadable paused endpoint still surfaces rather than suppressing stale work
ok - a declared pause is absorbed on first sight, then re-surfaced as a recheck past the threshold, never wedge-escalated
ok - exited declared-pause and captain-held panes keep bounded pause cadence for confirmed-dead agents
ok - a declared paused secondmate re-surfaces on the bounded normal-mode cadence
ok - a non-paused secondmate retains normal stale suppression
ok - a resumed secondmate clears pause and stale tracking before stale exemption
ok - unchanged stale hashes reclassify when a crew enters or leaves pause
ok - a declared pause is periodically rechecked against authoritative active-run state
ok - a paused status overridden by authoritative working preserves its wedge timer and escalates
ok - matching non-terminal stale suppressors repair missing or corrupt stale-since timers
ok - triage log capping handles wc byte counts with leading spaces
ok - a captured process-event result wakes a healthy watcher proactively, with no manual drain
ok - an unacknowledged process-event result re-drains until handling is acknowledged
ok - complete process-event queue keys map to distinct seen markers
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 1 --recovery-generation 40958.1786628712.C9RLgT
ok - queue revalidation, proactive output, and marker commit serialize with drain
/Users/camiloslaptop/.no-mistakes/worktrees/af1f7764a4ae/01KZXMDF7V0KHMY0ZG9X7EYZGD/bin/fm-push-transition-lib.sh: line 96: echo: write error: Broken pipe
tests/wake-helpers.sh: line 281: 44318 Killed: 9                  PATH="$dir/fakebin:$PATH" FM_HOME="$dir" FM_PROCEVENT_CLAIM_ROOT="$dir/claims" FM_CREW_STATE_BIN="$dir/fakebin/fm-crew-state.sh" FM_POLL=0.2 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out"
tests/wake-helpers.sh: line 281: 46203 Killed: 9                  PATH="$dir/fakebin:$PATH" FM_HOME="$dir" FM_PROCEVENT_CLAIM_ROOT="$dir/claims" FM_CREW_STATE_BIN="$dir/fakebin/fm-crew-state.sh" FM_POLL=0.2 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out"
ok - surfacing failures replay until post-handling acknowledgement
ok - marker failure exits through the shared wake owner, releases its lock, and replays later
ok - a heartbeat with no captain-relevant change is absorbed and backs off the cadence
ok - heartbeat backstop fail-safe surfaces a captain-relevant status the per-wake path missed
ok - the liveness beacon stays fresh while the watcher absorbs benign wakes (fm-guard never false-alarms)
ok - with .afk present the watcher reverts to one-shot so the daemon owns triage (no double-triage)
ok - AFK changed paused panes hand off plain stale identities for daemon-owned pause triage
```
</details>
<details>
<summary>Evidence: Documentation audience transcript</summary>

`Documentation ownership, audience inventory, local links, and semantic review checks passed.`

```text
ok - documentation inventory classifies every maintained prose surface exactly once
ok - classification, setup routing, and maintained-prose scope fail safely
ok - required documentation owner pointers cannot silently disappear
ok - local links resolve while dates, versions, commands, and incident prose remain semantically reviewed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `tests/fm-watch-triage.test.sh`
- `tests/fm-documentation-audiences.test.sh`
- `Reviewed saved watcher transcript for initiating classification, recheck-marker retention, hash-churn notification suppression, long-cadence rechecks, unreadable-endpoint fail-open behavior, and genuine wedge escalation.`
- `Confirmed a clean worktree after testing.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 127)

🔧 Fix: Pass lint with pinned ShellCheck
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
