### PR TITLE
fix(bin): seed project-less remote homes under Bash 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,6 +363,8 @@ jobs:
             exit 1
           }
 
+          /bin/bash tests/fm-remote-home-seed.test.sh
+
   invariants:
     name: Repo invariants
     runs-on: ubuntu-latest

--- a/bin/fm-remote-home-seed.sh
+++ b/bin/fm-remote-home-seed.sh
@@ -82,6 +82,7 @@ case "$REMOTE_ROOT/" in "$REMOTE_HOME/"*) die "remote code root must not be insi
 NO_PROJECTS=0
 PROJECT_NAMES=()
 PROJECT_ORIGINS=()
+PROJECT_COUNT=0
 for arg in "$@"; do
   if [ "$arg" = --no-projects ]; then
     NO_PROJECTS=1
@@ -96,12 +97,13 @@ for arg in "$@"; do
     esac
     PROJECT_NAMES+=("$name")
     PROJECT_ORIGINS+=("$origin")
+    PROJECT_COUNT=$((PROJECT_COUNT + 1))
   fi
 done
 if [ "$NO_PROJECTS" -eq 1 ]; then
-  [ "${#PROJECT_NAMES[@]}" -eq 0 ] || die "--no-projects cannot be combined with project names"
+  [ "$PROJECT_COUNT" -eq 0 ] || die "--no-projects cannot be combined with project names"
 else
-  [ "${#PROJECT_NAMES[@]}" -gt 0 ] || die "at least one project or --no-projects is required"
+  [ "$PROJECT_COUNT" -gt 0 ] || die "at least one project or --no-projects is required"
 fi
 
 mkdir -p "$STATE" || die "cannot create parent state directory"
@@ -157,37 +159,39 @@ done < "$BRIEF" > "$TMP/charter.remote"
 PROJECTS_CSV=
 : > "$TMP/project.records"
 PROJECT_INDEX=0
-for project in "${PROJECT_NAMES[@]}"; do
-  ORIGIN=${PROJECT_ORIGINS[$PROJECT_INDEX]}
-  PROJECT_INDEX=$((PROJECT_INDEX + 1))
-  MODE_LINE=$(FM_HOME="$FM_HOME" FM_DATA_OVERRIDE="$DATA" "$SCRIPT_DIR/fm-project-mode.sh" "$project")
-  read -r MODE _ <<EOF
+if [ "$NO_PROJECTS" -eq 0 ]; then
+  for project in "${PROJECT_NAMES[@]}"; do
+    ORIGIN=${PROJECT_ORIGINS[$PROJECT_INDEX]}
+    PROJECT_INDEX=$((PROJECT_INDEX + 1))
+    MODE_LINE=$(FM_HOME="$FM_HOME" FM_DATA_OVERRIDE="$DATA" "$SCRIPT_DIR/fm-project-mode.sh" "$project")
+    read -r MODE _ <<EOF
 $MODE_LINE
 EOF
-  case "$MODE" in
-    no-mistakes|direct-PR) ;;
-    local-only) die "project $project is local-only and cannot be provisioned remotely" ;;
-    *) die "project $project has unsupported delivery mode: $MODE" ;;
-  esac
-  # An origin named on the command line is authoritative. Reading one from a
-  # clone this home happens to have is only a convenience for the already-cloned
-  # case; it is never a reason to create one.
-  if [ -z "$ORIGIN" ] && [ -d "$PROJECTS/$project/.git" ]; then
-    ORIGIN=$(git -C "$PROJECTS/$project" remote get-url origin 2>/dev/null || true)
-  fi
-  [ -n "$ORIGIN" ] \
-    || die "project $project has no origin; pass $project=<origin-url> so the remote host can clone it"
-  fm_project_origin_safe "$ORIGIN" \
-    || die "project $project origin is not an accepted clone URL: $ORIGIN"
-  REGISTRY_LINE=$(awk -v p="$project" '$1 == "-" && $2 == p { print; exit }' "$DATA/projects.md" 2>/dev/null || true)
-  [ -n "$REGISTRY_LINE" ] || die "project $project has no registry record"
-  NAME_B64=$(printf '%s' "$project" | encode)
-  ORIGIN_B64=$(printf '%s' "$ORIGIN" | encode)
-  PROJECT_REG_B64=$(printf '%s' "$REGISTRY_LINE" | encode)
-  MODE_B64=$(printf '%s' "$MODE" | encode)
-  printf 'project=%s|%s|%s|%s\n' "$NAME_B64" "$ORIGIN_B64" "$PROJECT_REG_B64" "$MODE_B64" >> "$TMP/project.records"
-  PROJECTS_CSV="${PROJECTS_CSV}${PROJECTS_CSV:+, }$project"
-done
+    case "$MODE" in
+      no-mistakes|direct-PR) ;;
+      local-only) die "project $project is local-only and cannot be provisioned remotely" ;;
+      *) die "project $project has unsupported delivery mode: $MODE" ;;
+    esac
+    # An origin named on the command line is authoritative. Reading one from a
+    # clone this home happens to have is only a convenience for the already-cloned
+    # case; it is never a reason to create one.
+    if [ -z "$ORIGIN" ] && [ -d "$PROJECTS/$project/.git" ]; then
+      ORIGIN=$(git -C "$PROJECTS/$project" remote get-url origin 2>/dev/null || true)
+    fi
+    [ -n "$ORIGIN" ] \
+      || die "project $project has no origin; pass $project=<origin-url> so the remote host can clone it"
+    fm_project_origin_safe "$ORIGIN" \
+      || die "project $project origin is not an accepted clone URL: $ORIGIN"
+    REGISTRY_LINE=$(awk -v p="$project" '$1 == "-" && $2 == p { print; exit }' "$DATA/projects.md" 2>/dev/null || true)
+    [ -n "$REGISTRY_LINE" ] || die "project $project has no registry record"
+    NAME_B64=$(printf '%s' "$project" | encode)
+    ORIGIN_B64=$(printf '%s' "$ORIGIN" | encode)
+    PROJECT_REG_B64=$(printf '%s' "$REGISTRY_LINE" | encode)
+    MODE_B64=$(printf '%s' "$MODE" | encode)
+    printf 'project=%s|%s|%s|%s\n' "$NAME_B64" "$ORIGIN_B64" "$PROJECT_REG_B64" "$MODE_B64" >> "$TMP/project.records"
+    PROJECTS_CSV="${PROJECTS_CSV}${PROJECTS_CSV:+, }$project"
+  done
+fi
 
 {
   printf 'schema=fm-remote-home-provision.v1\n'
@@ -200,7 +204,7 @@ done
   # back; the parent's real filesystem path is never sent, since it names
   # nothing on the remote filesystem.
   printf 'parent_host_b64=%s\n' "$(printf '%s' "$HOST" | encode)"
-  printf 'project_count=%s\n' "${#PROJECT_NAMES[@]}"
+  printf 'project_count=%s\n' "$PROJECT_COUNT"
   cat "$TMP/project.records"
 } > "$TMP/manifest"
 MANIFEST_BYTES=$(LC_ALL=C wc -c < "$TMP/manifest" | tr -d ' ')

--- a/bin/fm-remote-home-seed.sh
+++ b/bin/fm-remote-home-seed.sh
@@ -82,6 +82,10 @@ case "$REMOTE_ROOT/" in "$REMOTE_HOME/"*) die "remote code root must not be insi
 NO_PROJECTS=0
 PROJECT_NAMES=()
 PROJECT_ORIGINS=()
+# Count projects explicitly instead of reading ${#PROJECT_NAMES[@]}: under
+# Bash 3.2 (stock macOS) with set -u, expanding an empty array is an unbound
+# variable error, so a --no-projects seed would abort here. Every expansion of
+# these arrays stays behind a NO_PROJECTS guard for the same reason.
 PROJECT_COUNT=0
 for arg in "$@"; do
   if [ "$arg" = --no-projects ]; then

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -167,7 +167,7 @@ family_for_basename() {
       printf '%s\n' real-herdr-gated
       ;;
     fm-backlog-handoff.test.sh|fm-on.test.sh|fm-remote-backlog-handoff.test.sh|\
-    fm-remote-doctor.test.sh|fm-remote-job.test.sh|fm-remote-job-orphan-reap.test.sh|\
+    fm-remote-doctor.test.sh|fm-remote-home-seed.test.sh|fm-remote-job.test.sh|fm-remote-job-orphan-reap.test.sh|\
     fm-remote-reply.test.sh|fm-remote-secondmate-lifecycle-e2e.test.sh|\
     fm-remote-secondmate-trace-context.test.sh|\
     fm-secondmate-harness.test.sh|fm-secondmate-lifecycle-e2e.test.sh|\

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -233,12 +233,15 @@ The lifecycle test covers seeding a registered project that this machine has nev
 bin/fm-test-run.sh tests/fm-on.test.sh
 bin/fm-test-run.sh tests/fm-remote-job.test.sh
 bin/fm-test-run.sh tests/fm-remote-doctor.test.sh
+bin/fm-test-run.sh tests/fm-remote-home-seed.test.sh
 bin/fm-test-run.sh tests/fm-project-origin.test.sh
 bin/fm-test-run.sh tests/fm-remote-reply.test.sh
 bin/fm-test-run.sh tests/fm-remote-backlog-handoff.test.sh
 bin/fm-test-run.sh tests/fm-remote-secondmate-lifecycle-e2e.test.sh
 bin/fm-test-run.sh tests/fm-remote-secondmate-trace-context.test.sh
 ```
+
+The seed test drives the public seed command for a project-less `--no-projects` home and for a project-bearing control, and CI also runs it on stock macOS Bash 3.2 so the project-less path stays covered on the oldest supported shell.
 
 The account-level checks the doctor performs - a real Aqua login session, a real `launchctl` domain, and a real herdr server - are only ever exercised against fixtures here, so the readiness gate's behavior on a genuine Mac remains an operator-run smoke test.
 

--- a/tests/fm-remote-home-seed.test.sh
+++ b/tests/fm-remote-home-seed.test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# tests/fm-remote-home-seed.test.sh - public remote-home seed coverage at the
+# oldest supported Bash semantics, including project-less and project-bearing
+# manifests.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+TMP_ROOT=$(fm_test_tmproot fm-remote-home-seed)
+PARENT="$TMP_ROOT/parent"
+FAKE_SSH="$TMP_ROOT/fake-ssh"
+MANIFEST="$TMP_ROOT/manifest"
+BASH_BIN=${FM_TEST_BASH_BIN:-/bin/bash}
+mkdir -p "$PARENT/data" "$PARENT/state" "$PARENT/config" "$PARENT/projects"
+
+cat > "$FAKE_SSH" <<'SH'
+#!/bin/sh
+while [ "$#" -gt 0 ]; do
+  shift
+done
+payload=$(cat)
+if [ -n "$payload" ]; then
+  printf '%s\n' "$payload" > "$FM_TEST_MANIFEST"
+fi
+exit 0
+SH
+chmod +x "$FAKE_SSH"
+
+run_seed() {
+  FM_HOME="$PARENT" \
+  FM_ROOT_OVERRIDE="$ROOT" \
+  FM_SSH_BIN="$FAKE_SSH" \
+  FM_TEST_MANIFEST="$MANIFEST" \
+  "$BASH_BIN" "$ROOT/bin/fm-remote-home-seed.sh" "$@"
+}
+
+[ -x "$BASH_BIN" ] || { echo "skip: test Bash interpreter not found: $BASH_BIN"; exit 0; }
+
+out=$(FM_SECONDMATE_CHARTER='Project-less Bash compatibility seed' \
+  FM_SECONDMATE_SCOPE='Project-less Bash compatibility path' \
+  run_seed project-less remote-mac /tmp/remote-root /tmp/project-less-home --no-projects) \
+  || fail "--no-projects public seed interface failed under $BASH_BIN"
+assert_contains "$out" 'home=remote-mac:/tmp/project-less-home' \
+  "--no-projects seed did not report the remote home"
+assert_grep 'project_count=0' "$MANIFEST" \
+  "--no-projects seed did not publish a zero-project manifest"
+assert_no_grep 'project=' "$MANIFEST" \
+  "--no-projects seed published a project record"
+pass "remote home seed accepts --no-projects under $BASH_BIN"
+
+printf '%s\n' '- alpha [direct-PR] - alpha project (added 2026-08-13)' \
+  > "$PARENT/data/projects.md"
+out=$(FM_SECONDMATE_CHARTER='Project-bearing Bash compatibility seed' \
+  FM_SECONDMATE_SCOPE='Project-bearing Bash compatibility path' \
+  run_seed project-bearing remote-mac /tmp/remote-root /tmp/project-bearing-home \
+  alpha=https://example.com/alpha.git) \
+  || fail "project-bearing public seed interface failed under $BASH_BIN"
+assert_contains "$out" 'home=remote-mac:/tmp/project-bearing-home' \
+  "project-bearing seed did not report the remote home"
+assert_grep 'project_count=1' "$MANIFEST" \
+  "project-bearing seed did not publish a one-project manifest"
+assert_grep 'project=' "$MANIFEST" \
+  "project-bearing seed did not publish its project record"
+pass "remote home seed preserves project-bearing behavior under $BASH_BIN"


### PR DESCRIPTION
## Intent

Fix the project-less remote-home seed path on Bash 3.2. The reported end-user path is a stock macOS primary running bin/fm-remote-home-seed.sh ... --no-projects to seed a project-less remote second-mate home, reportedly exiting under set -u with PROJECT_NAMES[@]: unbound variable; diagnose rather than trusting that diagnosis. Reproduce the real --no-projects path on actual Bash 3.2/macOS when safely reachable, or document the exact empirical limitation and run the closest representative Bash 3.2 path without calling it equivalent. Compare the failing project-less path with a proven project-bearing seed path and inspect relevant history. Guard every empty PROJECT_NAMES expansion unsafe under Bash 3.2, including the project loop and manifest count, while preserving project-bearing behavior. Add regression coverage through the executable/public --no-projects interface and the project-bearing control path under the oldest supported Bash semantics available to the test. Run focused tests, bin/fm-lint.sh, and required documentation audience checks. Keep origin read-only, push the topic branch only to fork, open the pull request against kunchenguid/firstmate from hsuperman:fm/fm-noprojects-bash32, and do not merge the pull request. The implementation uses an explicit project count and skips the project-array loop when --no-projects is selected; the regression reproduces the pre-fix Bash 3.2 failure and verifies both zero-project and project-bearing manifests.

## What Changed

- `bin/fm-remote-home-seed.sh` now tracks an explicit `PROJECT_COUNT` while parsing arguments and uses it for both the `--no-projects`/at-least-one-project validation and the manifest's `project_count` line, and it skips the `"${PROJECT_NAMES[@]}"` loop entirely when `--no-projects` is set — so a project-less seed no longer expands an empty array, which aborts under `set -u` on stock macOS Bash 3.2. Project-bearing seeding is unchanged.
- Added `tests/fm-remote-home-seed.test.sh`, which drives the public seed executable through a fake ssh transport under the oldest available Bash (`FM_TEST_BASH_BIN`, default `/bin/bash`) and asserts a `--no-projects` run publishes a `project_count=0` manifest with no `project=` records, plus a project-bearing control run that publishes `project_count=1` with its record.
- Registered the new test in `bin/fm-test-run.sh`'s remote family and in the macOS Bash 3.2 CI job, and documented it in the remote second-mates test list.

## Risk Assessment

✅ Low: The change is narrowly scoped to guarding empty-array expansions on the `--no-projects` seed path, leaves project-bearing behavior byte-identical, adds real behavioral regression coverage through the public CLI on stock Bash 3.2, and I verified by reading the code that no unguarded `PROJECT_NAMES` expansion and no zero-project mismatch remains reachable through `fm-brief.sh` or `fm-remote-home-provision.sh`.

## Testing

I diagnosed the failure rather than assuming it, then exercised the real user path: using a genuine GNU bash 3.2.57 interpreter (the same upstream release as stock macOS, obtained from the bash:3.2 image and run on the host so git and the rest of the toolchain stayed available), I ran the public `bin/fm-remote-home-seed.sh ... --no-projects` command against both the base and target source trees. Pre-fix it aborts with the exact reported `PROJECT_NAMES[@]: unbound variable` at the project loop, delivers no provisioning manifest and registers nothing (and silently exits 0); post-fix the same command reports the remote home, ships a `project_count=0` manifest with no project records, and writes its registry line, while the project-bearing control produces an identical `project_count=1` manifest before and after. The new regression test fails on the base commit under Bash 3.2 and passes on the target commit, and passes under Bash 5.3 in both cases, which is why only the added stock-macOS CI job can catch this; the related seed-consuming secondmate tests all pass through the repo runner. This is a CLI/shell change with no rendered surface, so the evidence is CLI transcripts and the delivered provisioning manifest rather than screenshots. Linting and documentation-audience checks were left to their own phases. All transient test material was removed and the worktree is clean.

<details>
<summary>Evidence: Before/after end-user CLI transcript on real Bash 3.2.57 (seed command + delivered provisioning manifest + registry)</summary>

<code># BEFORE (base 88d0f2e, GNU bash 3.2.57)&#10;$ bin/fm-remote-home-seed.sh mate-noproj remote-mac /opt/fm /Users/mate/fm-home --no-projects&#10;bin/fm-remote-home-seed.sh: line 190: PROJECT_NAMES[@]: unbound variable&#10;[exit status: 0]&#10;--- provisioning manifest delivered to the remote host ---&#10;(no manifest was ever sent)&#10;&#10;# AFTER (target 46731dd, GNU bash 3.2.57)&#10;$ bin/fm-remote-home-seed.sh mate-noproj remote-mac /opt/fm /Users/mate/fm-home --no-projects&#10;home=remote-mac:/Users/mate/fm-home&#10;[exit status: 0]&#10;--- provisioning manifest delivered to the remote host ---&#10;schema=fm-remote-home-provision.v1&#10;id_b64=bWF0ZS1ub3Byb2o=&#10;charter_b64=WW91IGFyZSBhIHBlcnNpc3Rl...&#10;parent_host_b64=cmVtb3RlLW1hYw==&#10;project_count=0&#10;&#10;$ bin/fm-remote-home-seed.sh mate-alpha remote-mac /opt/fm /Users/alpha/fm-home alpha=https://example.com/alpha.git&#10;home=remote-mac:/Users/alpha/fm-home&#10;--- provisioning manifest delivered to the remote host ---&#10;schema=fm-remote-home-provision.v1&#10;id_b64=bWF0ZS1hbHBoYQ==&#10;charter_b64=WW91IGFyZSBhIHBlcnNpc3Rl...&#10;parent_host_b64=cmVtb3RlLW1hYw==&#10;project_count=1&#10;project=YWxwaGE=...&#10;&#10;--- data/secondmates.md registered on the primary ---&#10;- mate-noproj - Remote second mate with no projects (host: remote-mac; root: /opt/fm; home: /Users/mate/fm-home; scope: Project-less remote home; projects: ; added 2026-08-13)&#10;- mate-alpha - Remote second mate with no projects (host: remote-mac; root: /opt/fm; home: /Users/alpha/fm-home; scope: Project-less remote home; projects: alpha; added 2026-08-13)</code>

```text
###############################################################
# BEFORE the fix - base commit 88d0f2e, stock-macOS Bash 3.2.57
###############################################################
$ /tmp/fm-bash32.jGfPDX/bash3.2 --version
GNU bash, version 3.2.57(1)-release (x86_64-pc-linux-musl)

$ bin/fm-remote-home-seed.sh mate-noproj remote-mac /opt/fm /Users/mate/fm-home --no-projects
/tmp/fm-prefix-repo.zqaSFf/bin/fm-remote-home-seed.sh: line 190: PROJECT_NAMES[@]: unbound variable
[exit status: 0]
--- provisioning manifest delivered to the remote host ---
(no manifest was ever sent)

$ bin/fm-remote-home-seed.sh mate-alpha remote-mac /opt/fm /Users/alpha/fm-home alpha=https://example.com/alpha.git

home=remote-mac:/Users/alpha/fm-home
[exit status: 0]
--- provisioning manifest delivered to the remote host ---
schema=fm-remote-home-provision.v1
id_b64=bWF0ZS1hbHBoYQ==
charter_b64=WW91IGFyZSBhIHBlcnNpc3Rl...
parent_host_b64=cmVtb3RlLW1hYw==
project_count=1
project=YWxwaGE=...

--- data/secondmates.md registered on the primary ---
- mate-alpha - Remote second mate with no projects (host: remote-mac; root: /opt/fm; home: /Users/alpha/fm-home; scope: Project-less remote home; projects: alpha; added 2026-08-13)

###############################################################
# AFTER the fix - target commit 46731dd, stock-macOS Bash 3.2.57
###############################################################
$ /tmp/fm-bash32.jGfPDX/bash3.2 --version
GNU bash, version 3.2.57(1)-release (x86_64-pc-linux-musl)

$ bin/fm-remote-home-seed.sh mate-noproj remote-mac /opt/fm /Users/mate/fm-home --no-projects

home=remote-mac:/Users/mate/fm-home
[exit status: 0]
--- provisioning manifest delivered to the remote host ---
schema=fm-remote-home-provision.v1
id_b64=bWF0ZS1ub3Byb2o=
charter_b64=WW91IGFyZSBhIHBlcnNpc3Rl...
parent_host_b64=cmVtb3RlLW1hYw==
project_count=0

$ bin/fm-remote-home-seed.sh mate-alpha remote-mac /opt/fm /Users/alpha/fm-home alpha=https://example.com/alpha.git

home=remote-mac:/Users/alpha/fm-home
[exit status: 0]
--- provisioning manifest delivered to the remote host ---
schema=fm-remote-home-provision.v1
id_b64=bWF0ZS1hbHBoYQ==
charter_b64=WW91IGFyZSBhIHBlcnNpc3Rl...
parent_host_b64=cmVtb3RlLW1hYw==
project_count=1
project=YWxwaGE=...

--- data/secondmates.md registered on the primary ---
- mate-noproj - Remote second mate with no projects (host: remote-mac; root: /opt/fm; home: /Users/mate/fm-home; scope: Project-less remote home; projects: ; added 2026-08-13)
- mate-alpha - Remote second mate with no projects (host: remote-mac; root: /opt/fm; home: /Users/alpha/fm-home; scope: Project-less remote home; projects: alpha; added 2026-08-13)
```
</details>
<details>
<summary>Evidence: Regression matrix: new test x (pre-fix / post-fix) x (Bash 3.2.57 / Bash 5.3.9)</summary>

<code>== base 88d0f2e (pre-fix) x Bash 3.2.57 ==&#10;bin/fm-remote-home-seed.sh: line 190: PROJECT_NAMES[@]: unbound variable&#10;not ok - --no-projects seed did not report the remote home (missing: &#39;home=remote-mac:/tmp/project-less-home&#39;)&#10;exit=1&#10;&#10;== base 88d0f2e (pre-fix) x Bash 5.3.9 (why the Linux lane missed it) ==&#10;ok - remote home seed accepts --no-projects under /bin/bash&#10;ok - remote home seed preserves project-bearing behavior under /bin/bash&#10;exit=0&#10;&#10;== target 46731dd (fixed) x Bash 3.2.57 ==&#10;ok - remote home seed accepts --no-projects under $BASH32/bash3.2&#10;ok - remote home seed preserves project-bearing behavior under $BASH32/bash3.2&#10;exit=0&#10;&#10;== target 46731dd (fixed) x Bash 5.3.9 ==&#10;ok - remote home seed accepts --no-projects under /bin/bash&#10;ok - remote home seed preserves project-bearing behavior under /bin/bash&#10;exit=0</code>

```text
Regression matrix - tests/fm-remote-home-seed.test.sh
(the same new test file is run against both source trees)

== base commit 88d0f2e (pre-fix)  x  Bash 3.2.57 ==
/tmp/fm-prefix-repo.zqaSFf/bin/fm-remote-home-seed.sh: line 190: PROJECT_NAMES[@]: unbound variable
not ok - --no-projects seed did not report the remote home (missing: 'home=remote-mac:/tmp/project-less-home')
--- output ---

exit=1

== base commit 88d0f2e (pre-fix)  x  Bash 5.3.9 (why CI missed it) ==
ok - remote home seed accepts --no-projects under /bin/bash
ok - remote home seed preserves project-bearing behavior under /bin/bash
exit=0

== target commit 46731dd (fixed)  x  Bash 3.2.57 ==
ok - remote home seed accepts --no-projects under $BASH32/bash3.2
ok - remote home seed preserves project-bearing behavior under $BASH32/bash3.2
exit=0

== target commit 46731dd (fixed)  x  Bash 5.3.9 ==
ok - remote home seed accepts --no-projects under /bin/bash
ok - remote home seed preserves project-bearing behavior under /bin/bash
exit=0
```
</details>
- Outcome: ⚠️ 1 info across 1 run (6m34s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"46731dde98fc4db1b25337b02e4d8ad8f63b481e","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `bin/fm-remote-home-seed.sh:85` - `PROJECT_COUNT` is a hand-maintained duplicate of `${#PROJECT_NAMES[@]}`, and the comment at :85-88 attributes the Bash 3.2 failure to the length reference. The repo&#39;s own Bash-3.2-targeted siblings read `${#arr[@]}` on possibly-empty arrays under `set -eu` (`bin/fm-home-seed.sh:815` on its exercised `--no-projects` path; `bin/fm-remote-doctor.sh:739` and `:792`), and `bin/fm-remote-doctor.sh:783` uses `${GAPS[@]+&#34;${GAPS[@]}&#34;}` only for element expansion — indicating the actual hazard was `for project in &#34;${PROJECT_NAMES[@]}&#34;`, which the NO_PROJECTS guard at :166 now closes. The counter is correct today, but it is state that must be kept in sync with the array by hand, and it feeds `project_count` in the manifest, which the remote side cross-checks against the `project=` record count at `bin/fm-remote-home-provision.sh:119`. Since the intent explicitly selects &#34;an explicit project count&#34;, no change is requested — noting the redundancy and the overstated comment rationale.
- ℹ️ `.github/workflows/ci.yml:366` - The new stock-Bash-3.2 CI invocation is not output-count-asserted, unlike its two neighbors in the same job (which capture output and require exactly 15 and 41 `ok - ` lines). `tests/fm-remote-home-seed.test.sh:33` has an `exit 0` skip path when `$BASH_BIN` is not executable, so a run that skips entirely — or a future edit that drops one of the two `pass` lines — leaves the macOS 3.2 job green while the project-less path is no longer actually covered under the oldest supported shell, which is the sole reason this test was added to that job. Capturing the output and asserting `grep -c &#39;^ok - &#39;` equals 2, matching the job&#39;s established convention, closes that gap.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `bin/fm-remote-home-seed.sh:85` - Diagnostic nuance verified empirically on GNU bash 3.2.57: only `&#34;${arr[@]}&#34;` on an empty array is fatal under `set -u`; `${#arr[@]}` returns 0 without error. So the project loop was the single real failure site, and the PROJECT_COUNT change for the manifest count is defensive hardening rather than a second bug — the source comment in bin/fm-remote-home-seed.sh reads as if the count expansion also aborted. No behavior impact; noting it only because the change&#39;s rationale rests on it.
- <code>Real Bash 3.2.57 acquired and verified: `bash3.2 --version` -&gt; `GNU bash, version 3.2.57(1)-release`, with the empty-array divergence confirmed directly (`set -u; a=(); for x in &#34;${a[@]}&#34;` -&gt; `a[@]: unbound variable` on 3.2, clean on 5.3.9)</code>
- <code>End-user CLI repro under Bash 3.2 against base commit 88d0f2e source: `bin/fm-remote-home-seed.sh mate-noproj remote-mac /opt/fm /Users/mate/fm-home --no-projects` -&gt; `PROJECT_NAMES[@]: unbound variable`, no manifest delivered, no registry line</code>
- <code>Same CLI repro under Bash 3.2 against target commit 46731dd: `--no-projects` prints `home=remote-mac:/Users/mate/fm-home`, delivers a `project_count=0` manifest through the SSH transport, and writes its `data/secondmates.md` line</code>
- <code>Project-bearing control under Bash 3.2, both source trees: `bin/fm-remote-home-seed.sh mate-alpha remote-mac /opt/fm /Users/alpha/fm-home alpha=https://example.com/alpha.git` -&gt; identical `project_count=1` manifest plus project record</code>
- <code>Regression matrix for the new test file: `FM_TEST_BASH_BIN=&lt;bash3.2&gt; &lt;bash3.2&gt; tests/fm-remote-home-seed.test.sh` on pre-fix source (fails, exit=1) and on post-fix source (passes), plus `/bin/bash tests/fm-remote-home-seed.test.sh` on both (passes)</code>
- <code>`bin/fm-test-run.sh tests/fm-remote-home-seed.test.sh tests/fm-remote-secondmate-parent-binding.test.sh tests/fm-remote-secondmate-trace-context.test.sh` -&gt; total=3 failed=0; new test routes into the `secondmate` family per the fm-test-run.sh change</code>
- <code>`bin/fm-remote-home-seed.sh id host /a /b --no-projects extra` under Bash 3.2 and 5.3 -&gt; `error: --no-projects cannot be combined with project names`, exit 1 on both (die() paths still report failure on the old shell)</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/fm-test-portable-shards.md:71` - docs/fm-test-portable-shards.md&#39;s shard tables are stale independently of this change and this change nudges them further: the doc records portable-serial as 69 scripts split 15/18/17/19 across the four CI shards, while `bin/fm-test-run.sh --lane portable-serial --list` now reports 111 scripts split 25/30/28/28 (tests/fm-remote-home-seed.test.sh is one of them, landing in the derived remainder as the doc says it should). The drift predates this branch (the base commit 88d0f2e has the identical table), and refreshing it correctly requires re-downloading fm-test-timing-portable-serial artifacts from a green CI run and updating the weight hints in bin/fm-test-run.sh alongside the table, which is a separate change. Coverage is unaffected: bin/fm-test-run.sh --check-coverage still proves the partition is complete and disjoint, so only the balance-evidence numbers are wrong. Suggested follow-up: refresh the hints and both tables per the procedure the doc already documents.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
