### PR TITLE
feat(calm): hide mid-turn working notes by default

### DIFF
--- a/.pi/extensions/fm-calm.ts
+++ b/.pi/extensions/fm-calm.ts
@@ -55,10 +55,8 @@ import {
   createCalmWorkingShipWidget,
 } from "./lib/fm-calm-working-ship.ts";
 import {
-  type CalmPresentationLevel,
   calmPresentationHides,
   calmPresentationIsActive,
-  calmPresentationLevel,
   FIRSTMATE_CALM_PRESENTATION_EVENT,
   registerFirstmateSyntheticPresentation,
   setCalmPresentation,
@@ -121,19 +119,6 @@ function installCalmPresentationAdapter(name: string, install: () => void): void
   }
 }
 
-// /calm keeps its plain no-argument cycle and recognizes one argument, "max", which
-// selects the level that also hides mid-turn assistant working notes. A plain /calm
-// steps max back to ordinary Calm; any other argument keeps the existing on/off cycle
-// rather than failing a command that has always accepted whatever followed it.
-function nextCalmLevel(
-  current: CalmPresentationLevel,
-  args: string,
-): CalmPresentationLevel {
-  if (args.trim().toLowerCase() === "max") return "max";
-  if (current === "max") return "on";
-  return current === "on" ? "off" : "on";
-}
-
 export default function (pi: ExtensionAPI) {
   installCalmPresentationAdapter("collapsed-thinking", installCalmAssistantLayout);
   installCalmPresentationAdapter("operational-user-row", installCalmOperationalUserLayout);
@@ -174,25 +159,23 @@ export default function (pi: ExtensionAPI) {
   const fmHome = process.env.FM_HOME || process.env.FM_ROOT_OVERRIDE || root;
   const configDirectory = process.env.FM_CONFIG_OVERRIDE || resolve(fmHome, "config");
   const calmPreferencePath = resolve(configDirectory, "calm");
-  // Every level the command can persist round-trips through this reader, so a session
-  // start, resume, fork, or reload restores the stored level instead of dropping an
-  // unrecognized one to off. docs/configuration.md owns the persisted value schema.
-  const loadCalmPreference = (): CalmPresentationLevel => {
+  // "max" is the legacy value written by the removed third presentation level, whose
+  // behavior is now ordinary Calm; a home upgraded from it restores as on rather than
+  // dropping to off. docs/configuration.md owns the persisted value schema.
+  const loadCalmPreference = (): boolean => {
     let stored: string;
     try {
       stored = readFileSync(calmPreferencePath, "utf8").trim();
     } catch {
-      return "off";
+      return false;
     }
-    if (stored === "on") return "on";
-    if (stored === "max") return "max";
-    return "off";
+    return stored === "on" || stored === "max";
   };
-  const persistCalmPreference = (level: CalmPresentationLevel): void => {
+  const persistCalmPreference = (active: boolean): void => {
     mkdirSync(dirname(calmPreferencePath), { recursive: true });
     const temporaryPath = `${calmPreferencePath}.${process.pid}.${randomUUID()}.tmp`;
     try {
-      writeFileSync(temporaryPath, `${level}\n`, {
+      writeFileSync(temporaryPath, active ? "on\n" : "off\n", {
         encoding: "utf8",
         flag: "wx",
         mode: 0o600,
@@ -334,7 +317,7 @@ export default function (pi: ExtensionAPI) {
   // unconditional here (see file header): a foreign-claim check is not reachable at
   // this point, while deferral would make restored rows capture the wrong definition.
   // A Calm-off session or reload registers nothing and creates no collision exposure.
-  if (loadCalmPreference() !== "off") {
+  if (loadCalmPreference()) {
     for (const tool of wrappedBuiltIns) pi.registerTool(tool);
     builtInsRegistered = true;
   }
@@ -465,16 +448,15 @@ export default function (pi: ExtensionAPI) {
 
   pi.registerCommand("calm", {
     description: "Toggle Firstmate's supported conversation-only transcript presentation.",
-    handler: async (args, ctx) => {
-      const level = nextCalmLevel(calmPresentationLevel(), args ?? "");
-      const active = level !== "off";
-      persistCalmPreference(level);
-      setCalmPresentation(level);
+    handler: async (_args, ctx) => {
+      const active = !calmPresentationIsActive();
+      persistCalmPreference(active);
+      setCalmPresentation(active);
       if (active) activateBuiltInsIfNeeded(ctx.ui);
       publishPresentationState();
       applyWorkingPresentation(ctx.ui, true);
       // Pi re-runs every assistant row's layout from this call even when the label is
-      // unchanged, which is what makes a level change apply to rows already on screen.
+      // unchanged, which is what makes a toggle apply to rows already on screen.
       ctx.ui.setHiddenThinkingLabel(active ? "" : undefined);
       ctx.ui.setStatus("firstmate-calm", undefined);
 

--- a/.pi/extensions/lib/fm-calm-assistant-layout.ts
+++ b/.pi/extensions/lib/fm-calm-assistant-layout.ts
@@ -2,10 +2,10 @@
 // updateContent method. installCalmAssistantLayout() probes that exact method and throws
 // if it is missing; fm-calm.ts catches that and skips only this adapter with a diagnostic
 // instead of blocking Calm or Pi.
-// This layout removes collapsed thinking, and at the "max" presentation level also the
-// mid-turn assistant text blocks classified as "assistant-working-note", from a shallow
-// presentation copy. The message itself, model context, session storage, and export
-// rendering are never touched. ./fm-calm-visibility.ts owns which classes each level hides.
+// This layout removes collapsed thinking and the mid-turn assistant text blocks
+// classified as "assistant-working-note" from a shallow presentation copy. The message
+// itself, model context, session storage, and export rendering are never touched.
+// ./fm-calm-visibility.ts owns which classes Calm hides.
 import type { AssistantMessageComponent as PiAssistantMessageComponent } from "@earendil-works/pi-coding-agent";
 import * as PiCodingAgent from "@earendil-works/pi-coding-agent";
 import { calmPresentationHides } from "./fm-calm-visibility.ts";

--- a/.pi/extensions/lib/fm-calm-visibility.ts
+++ b/.pi/extensions/lib/fm-calm-visibility.ts
@@ -29,22 +29,12 @@ export const CALM_TRANSCRIPT_CLASSES = [
 
 export type CalmTranscriptClass = (typeof CALM_TRANSCRIPT_CLASSES)[number];
 
-// Calm's presentation is a level, not a boolean: "off" is stock Pi, "on" is Calm, and
-// "max" is Calm plus the classes in CALM_MAX_HIDDEN_CLASSES below.
-export const CALM_PRESENTATION_LEVELS = ["off", "on", "max"] as const;
-
-export type CalmPresentationLevel = (typeof CALM_PRESENTATION_LEVELS)[number];
-
+// Calm is on or off. "assistant-working-note" is deliberately absent from the allowlist:
+// Calm hides mid-turn assistant working notes, keeping the genuine final reply.
 const CALM_VISIBLE_CLASSES = new Set<CalmTranscriptClass>([
   "genuine-user-prompt",
   "genuine-agent-response",
-  "assistant-working-note",
   "working-status",
-]);
-
-// Classes ordinary Calm keeps but the "max" level also hides.
-const CALM_MAX_HIDDEN_CLASSES = new Set<CalmTranscriptClass>([
-  "assistant-working-note",
 ]);
 
 // Legacy session entries from Calm versions before 2026-07-23 retain this
@@ -73,23 +63,15 @@ type FirstmateSyntheticPresentation = {
   kind: FirstmateSyntheticKind;
 };
 
-let calmLevel: CalmPresentationLevel = "off";
+let calm = false;
 let stockExportRendering = false;
 
-export function calmTranscriptClassIsVisible(
-  itemClass: CalmTranscriptClass,
-  level: CalmPresentationLevel = calmLevel,
-): boolean {
-  if (!CALM_VISIBLE_CLASSES.has(itemClass)) return false;
-  return level !== "max" || !CALM_MAX_HIDDEN_CLASSES.has(itemClass);
+export function calmTranscriptClassIsVisible(itemClass: CalmTranscriptClass): boolean {
+  return CALM_VISIBLE_CLASSES.has(itemClass);
 }
 
-export function setCalmPresentation(level: CalmPresentationLevel): void {
-  calmLevel = level;
-}
-
-export function calmPresentationLevel(): CalmPresentationLevel {
-  return calmLevel;
+export function setCalmPresentation(active: boolean): void {
+  calm = active;
 }
 
 export function setCalmStockExportRendering(active: boolean): void {
@@ -97,15 +79,11 @@ export function setCalmStockExportRendering(active: boolean): void {
 }
 
 export function calmPresentationIsActive(): boolean {
-  return calmLevel !== "off";
+  return calm;
 }
 
 export function calmPresentationHides(itemClass: CalmTranscriptClass): boolean {
-  return (
-    calmLevel !== "off" &&
-    !stockExportRendering &&
-    !calmTranscriptClassIsVisible(itemClass, calmLevel)
-  );
+  return calm && !stockExportRendering && !calmTranscriptClassIsVisible(itemClass);
 }
 
 export function registerFirstmateSyntheticPresentation(pi: ExtensionAPI): void {

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -180,7 +180,7 @@ Compaction and retry loaders remain stock because Pi exposes no supported replac
 
 `.pi/extensions/lib/fm-calm-visibility.ts` owns only the allowlist-style transcript presentation policy.
 `bin/fm-operational-input.sh` owns current cross-language operational-input construction and parsing, while the thin Pi adapter lives at `.pi/extensions/lib/fm-operational-input.ts`.
-Only `genuine-user-prompt`, `genuine-agent-response`, `assistant-working-note`, and `working-status` are policy-visible, and `assistant-working-note` is additionally policy-hidden at the `max` presentation level.
+Only `genuine-user-prompt`, `genuine-agent-response`, and `working-status` are policy-visible.
 Every other audited class is policy-hidden when Pi exposes a supported presentation boundary, but semantic input is never transformed to enforce that preference.
 The home-local persistence schema is owned by [`docs/configuration.md`](configuration.md#pi-calm-preference-configcalm).
 
@@ -204,7 +204,7 @@ The test fixture enumerates every class below through the centralized policy, an
 | --- | --- | --- |
 | `genuine-user-prompt` | `UserMessageComponent` | Visible, including every tested operational near miss. |
 | `genuine-agent-response` | Assistant text in `AssistantMessageComponent` | Visible. |
-| `assistant-working-note` | Assistant text in an `AssistantMessageComponent` message the model did not end its response with, identified by its own `stopReason` of `toolUse`, or of `length` with tool calls present | Visible at the `on` level. At the `max` level the text blocks are removed from the shallow presentation copy before layout, so a `toolUse` message carrying only narration occupies zero rows (verified on Pi 0.84.1); a still-streaming `pending` message is never filtered, so narration is briefly visible before the marker flips. |
+| `assistant-working-note` | Assistant text in an `AssistantMessageComponent` message the model did not end its response with, identified by its own `stopReason` of `toolUse`, or of `length` with tool calls present | The text blocks are removed from the shallow presentation copy before layout, so a `toolUse` message carrying only narration occupies zero rows (verified on Pi 0.84.1); a still-streaming `pending` message is never filtered, so narration is briefly visible before the marker flips. |
 | `assistant-thinking` | Thinking content in `AssistantMessageComponent` | Collapsed reasoning is removed from the shallow presentation copy before layout and occupies zero rows; explicit expansion renders the original reasoning. |
 | `assistant-tool-call` | `ToolExecutionComponent` | Seven built-ins and `fm_watch_arm_pi` hidden; arbitrary custom tools remain an unsupported boundary. |
 | `tool-result` | `ToolExecutionComponent` | Text results for the controlled tools hidden; arbitrary custom results remain an unsupported boundary. |

--- a/docs/calm.md
+++ b/docs/calm.md
@@ -17,7 +17,7 @@ Calm hides collapsed thinking labels, mid-turn assistant working notes, the shel
 A mid-turn working note is assistant text in a message the model did not end its response with, identified by that message's own `stopReason` of `toolUse`, or of `length` with tool calls present.
 Hiding it removes the narration a model emits alongside its tool calls, while the genuine reply that ends a response stays visible.
 Text that is still streaming is never hidden, because suppressing it would also stop a genuine reply from streaming, so a working note is briefly visible before its row collapses.
-The hidden narration is removed from the transcript only, and remains in the message, model context, session storage, and exported artifacts.
+The narration is hidden only from the live transcript presentation, and remains in the message, model context, session storage, and `/export` artifacts.
 The operational inputs remain ordinary user-role messages, while Pi's transcript layout renders their complete rows at zero height.
 The session-start nudge remains on its existing non-displayed custom-message path.
 

--- a/docs/calm.md
+++ b/docs/calm.md
@@ -13,7 +13,11 @@ Hidden elapsed time does not advance the animation, and a resize while hidden cl
 A fresh Pi session or new Calm extension lifetime starts at the normal initial position.
 Very narrow terminals fall back to a smaller deterministic sprite.
 While Calm is off, Pi's stock working row is left exactly as Pi renders it.
-Calm hides collapsed thinking labels, the shells for the Pi built-in tool names Calm owns, the `fm_watch_arm_pi` tool shell, and canonically classified Firstmate operational user rows.
+Calm hides collapsed thinking labels, mid-turn assistant working notes, the shells for the Pi built-in tool names Calm owns, the `fm_watch_arm_pi` tool shell, and canonically classified Firstmate operational user rows.
+A mid-turn working note is assistant text in a message the model did not end its response with, identified by that message's own `stopReason` of `toolUse`, or of `length` with tool calls present.
+Hiding it removes the narration a model emits alongside its tool calls, while the genuine reply that ends a response stays visible.
+Text that is still streaming is never hidden, because suppressing it would also stop a genuine reply from streaming, so a working note is briefly visible before its row collapses.
+The hidden narration is removed from the transcript only, and remains in the message, model context, session storage, and exported artifacts.
 The operational inputs remain ordinary user-role messages, while Pi's transcript layout renders their complete rows at zero height.
 The session-start nudge remains on its existing non-displayed custom-message path.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,8 +27,8 @@ Ordinary dead-direct-report recovery is owned by `stuck-crewmate-recovery`, whil
 ## Pi Calm preference (config/calm)
 
 The Pi Calm extension stores the captain's home-local presentation choice in gitignored `config/calm` under the effective Firstmate home, resolved from `FM_HOME`, then `FM_ROOT_OVERRIDE`, then the tracked code root derived from the extension path, or under `FM_CONFIG_OVERRIDE` when that test and specialized-setup override is present.
-The values it writes are `on`, `off`, and `max`, each followed by one newline; an absent, unreadable, or unrecognized value defaults to off.
-`max` is a recognized persisted presentation level, so a later session restores it as `max` instead of treating it as unrecognized and dropping to off.
+The values it writes are `on` and `off`, each followed by one newline; an absent, unreadable, or unrecognized value defaults to off.
+`max` is the legacy value written by a removed third presentation level whose behavior is now ordinary Calm, and it is still read as `on`, so a home upgraded from it keeps Calm on rather than dropping to off.
 The `/calm` command replaces the file atomically before changing live presentation, so a failed write leaves the current choice unchanged rather than claiming persistence.
 The extension reloads this preference on every Pi `session_start`, including startup, new, resume, fork, and reload reasons.
 This preference is local to each Firstmate home and is not part of secondmate inherited configuration.

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -802,16 +802,13 @@ if (
 }
 
 for (const itemClass of visibility.CALM_TRANSCRIPT_CLASSES) {
-  for (const level of ["on", "max"]) {
-    const visible = visibility.calmTranscriptClassIsVisible(itemClass, level);
-    const expected =
-      itemClass === "genuine-user-prompt" ||
-      itemClass === "genuine-agent-response" ||
-      itemClass === "working-status" ||
-      (itemClass === "assistant-working-note" && level === "on");
-    if (visible !== expected) {
-      throw new Error(`Calm allowlist classified ${itemClass} as visible=${visible} at level ${level}`);
-    }
+  const visible = visibility.calmTranscriptClassIsVisible(itemClass);
+  const expected =
+    itemClass === "genuine-user-prompt" ||
+    itemClass === "genuine-agent-response" ||
+    itemClass === "working-status";
+  if (visible !== expected) {
+    throw new Error(`Calm allowlist classified ${itemClass} as visible=${visible}`);
   }
 }
 const watcherBody =
@@ -1359,10 +1356,10 @@ JS
   pass "Pi calm centralizes transcript visibility, preserves execution/export data, keeps Pi's stock working row visible while no run is active, and persists its choice across session starts"
 }
 
-test_calm_max_mid_turn_working_notes() {
+test_calm_mid_turn_working_notes() {
   local fixture out output_file status version
   if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
-    echo "skip: node or npm not found for Pi calm max renderer test"
+    echo "skip: node or npm not found for Pi calm mid-turn renderer test"
     return 0
   fi
   if [ ! -f "$PI_PACKAGE_DIR/package.json" ]; then
@@ -1370,9 +1367,9 @@ test_calm_max_mid_turn_working_notes() {
     return 0
   fi
   version=$(node -p "require('$PI_PACKAGE_DIR/package.json').version")
-  record_pi_version_evidence "$version" "Pi calm max mid-turn presentation"
+  record_pi_version_evidence "$version" "Pi calm mid-turn presentation"
 
-  fixture="$TMP_ROOT/calm-max"
+  fixture="$TMP_ROOT/calm-mid-turn"
   mkdir -p "$fixture/home" "$fixture/lib" "$fixture/node_modules/@earendil-works"
   cp "$EXT" "$fixture/fm-calm.ts"
   cp "$ASSISTANT_LAYOUT" "$fixture/lib/fm-calm-assistant-layout.ts"
@@ -1387,7 +1384,7 @@ test_calm_max_mid_turn_working_notes() {
 
   output_file="$fixture/node-output"
   (cd "$fixture" && EXT="$fixture/fm-calm.ts" FM_HOME="$fixture/home" PI_PACKAGE_DIR="$PI_PACKAGE_DIR" node --input-type=module) >"$output_file" 2>&1 <<'JS'
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 const packageRoot = process.env.PI_PACKAGE_DIR;
@@ -1440,7 +1437,7 @@ async function loadCalmExtension() {
       return [];
     },
   };
-  const extension = await import(`${pathToFileURL(process.env.EXT).href}?max=${Date.now()}-${Math.random()}`);
+  const extension = await import(`${pathToFileURL(process.env.EXT).href}?instance=${Date.now()}-${Math.random()}`);
   extension.default(pi);
   if (!calmCommand || !sessionStart) {
     throw new Error("Calm extension did not register its command and session handler");
@@ -1450,8 +1447,8 @@ async function loadCalmExtension() {
 
 const assistantBase = {
   role: "assistant",
-  api: "calm-max-test",
-  provider: "calm-max-test",
+  api: "calm-mid-turn-test",
+  provider: "calm-mid-turn-test",
   model: "deterministic",
   usage: {
     input: 0,
@@ -1463,7 +1460,7 @@ const assistantBase = {
   },
   timestamp: 1,
 };
-const toolCall = { type: "toolCall", id: "calm-max-tool", name: "read", arguments: { path: "sample.txt" } };
+const toolCall = { type: "toolCall", id: "calm-mid-turn-tool", name: "read", arguments: { path: "sample.txt" } };
 const messages = {
   // The reported incident: narration emitted in the same assistant message as a tool call.
   midTurn: {
@@ -1471,7 +1468,7 @@ const messages = {
     stopReason: "toolUse",
     content: [{ type: "text", text: "MIDTURN_WORKING_NOTE" }, toolCall],
   },
-  // The genuine reply that ends a response, which no level may hide.
+  // The genuine reply that ends a response, which Calm never hides.
   finalReply: {
     ...assistantBase,
     stopReason: "stop",
@@ -1535,85 +1532,78 @@ await calm.calmCommand.handler("", context);
 if (readFileSync(calmPreferencePath, "utf8") !== "on\n") {
   throw new Error("plain /calm from off did not persist on");
 }
-requireVisible("midTurn", "MIDTURN_WORKING_NOTE", "ordinary Calm");
-requireVisible("finalReply", "FINAL_REPLY_TEXT", "ordinary Calm");
-
-await calm.calmCommand.handler("max", context);
-if (readFileSync(calmPreferencePath, "utf8") !== "max\n") {
-  throw new Error("/calm max did not persist max as its own literal value");
-}
 if (rendered("midTurn").length !== 0) {
-  throw new Error(`Calm max left mid-turn working-note rows: ${JSON.stringify(rendered("midTurn"))}`);
+  throw new Error(`Calm on left mid-turn working-note rows: ${JSON.stringify(rendered("midTurn"))}`);
 }
-requireHidden("truncatedMidTurn", "TRUNCATED_MIDTURN_NOTE", "Calm max");
-// Pi owns the wording of its truncation notice; Calm max must leave that row's own
-// notice standing rather than collapsing an incomplete response to nothing.
+requireHidden("truncatedMidTurn", "TRUNCATED_MIDTURN_NOTE", "Calm on");
+// Pi owns the wording of its truncation notice; Calm must leave that row's own notice
+// standing rather than collapsing an incomplete response to nothing.
 if (rendered("truncatedMidTurn").length === 0) {
-  throw new Error("Calm max removed Pi's own truncation notice with the working note");
+  throw new Error("Calm on removed Pi's own truncation notice with the working note");
 }
-requireVisible("streaming", "STREAMING_NOTE_TEXT", "Calm max");
-requireVisible("truncatedFinal", "TRUNCATED_FINAL_TEXT", "Calm max");
+requireVisible("streaming", "STREAMING_NOTE_TEXT", "Calm on");
+requireVisible("truncatedFinal", "TRUNCATED_FINAL_TEXT", "Calm on");
+requireVisible("finalReply", "FINAL_REPLY_TEXT", "Calm on");
 if (JSON.stringify(rendered("finalReply")) !== stockRows.finalReply) {
-  throw new Error("Calm max changed the genuine final reply row");
+  throw new Error("Calm on changed the genuine final reply row");
 }
 if (JSON.stringify(messages) !== messagesBefore) {
-  throw new Error("Calm max mutated the assistant messages instead of a presentation copy");
+  throw new Error("Calm on mutated the assistant messages instead of a presentation copy");
 }
 
+// The removed third level: /calm parses no argument, so every invocation is the plain
+// on/off toggle and no third literal is ever persisted.
 await calm.calmCommand.handler("max", context);
-if (readFileSync(calmPreferencePath, "utf8") !== "max\n" || rendered("midTurn").length !== 0) {
-  throw new Error("repeating /calm max did not stay at max");
-}
-await calm.calmCommand.handler("  MaX  ", context);
-if (readFileSync(calmPreferencePath, "utf8") !== "max\n" || rendered("midTurn").length !== 0) {
-  throw new Error("/calm max is not accepted with surrounding space or mixed case");
-}
-
-// Restart: scramble the live level the way a fresh process starts, then let a newly
-// loaded extension restore from the persisted file alone.
-visibility.setCalmPresentation("off");
-ui.setHiddenThinkingLabel(undefined);
-requireVisible("midTurn", "MIDTURN_WORKING_NOTE", "scrambled live level");
-calm = await loadCalmExtension();
-if (calm.registeredTools.length !== 7) {
-  throw new Error(`a session restored at max claimed ${calm.registeredTools.length} built-in tools instead of 7`);
-}
-await calm.sessionStart({ reason: "resume" }, context);
-if (rendered("midTurn").length !== 0) {
-  throw new Error("a restored session treated the persisted max level as unrecognized");
-}
-for (const reason of ["startup", "new", "fork", "reload"]) {
-  await calm.sessionStart({ reason }, context);
-  if (rendered("midTurn").length !== 0) {
-    throw new Error(`a ${reason} session did not restore the persisted max level`);
-  }
-  requireVisible("finalReply", "FINAL_REPLY_TEXT", `${reason} session`);
-}
-
-await calm.calmCommand.handler("", context);
-if (readFileSync(calmPreferencePath, "utf8") !== "on\n") {
-  throw new Error("plain /calm from max did not revert to ordinary Calm");
-}
-requireVisible("midTurn", "MIDTURN_WORKING_NOTE", "reverted Calm");
-
-await calm.calmCommand.handler("", context);
 if (readFileSync(calmPreferencePath, "utf8") !== "off\n") {
-  throw new Error("plain /calm from on did not keep the existing off toggle");
+  throw new Error("/calm max was still read as a level instead of the plain toggle");
 }
+requireVisible("midTurn", "MIDTURN_WORKING_NOTE", "Calm off after /calm max");
 const restoredRows = snapshot();
 for (const name of Object.keys(rows)) {
   if (restoredRows[name] !== stockRows[name]) {
     throw new Error(`turning Calm off did not restore byte-identical ${name} rendering`);
   }
 }
-
-await calm.calmCommand.handler("max", context);
-if (readFileSync(calmPreferencePath, "utf8") !== "max\n" || rendered("midTurn").length !== 0) {
-  throw new Error("/calm max did not enter max directly from off");
+await calm.calmCommand.handler("  MaX  ", context);
+if (readFileSync(calmPreferencePath, "utf8") !== "on\n" || rendered("midTurn").length !== 0) {
+  throw new Error("a spaced, mixed-case argument did not fall through to the plain toggle");
 }
 await calm.calmCommand.handler("unrecognized", context);
-if (readFileSync(calmPreferencePath, "utf8") !== "on\n") {
+if (readFileSync(calmPreferencePath, "utf8") !== "off\n") {
   throw new Error("an unrecognized /calm argument did not fall back to the plain toggle");
+}
+
+// Restart from each persisted value, including the legacy "max" a home upgraded from
+// the removed third level still carries: every one restores ordinary Calm, never off.
+for (const persisted of ["on\n", "max\n", "max"]) {
+  writeFileSync(calmPreferencePath, persisted, "utf8");
+  // Scramble the live state the way a fresh process starts, then let a newly loaded
+  // extension restore from the persisted file alone.
+  visibility.setCalmPresentation(false);
+  ui.setHiddenThinkingLabel(undefined);
+  requireVisible("midTurn", "MIDTURN_WORKING_NOTE", "scrambled live state");
+  calm = await loadCalmExtension();
+  if (calm.registeredTools.length !== 7) {
+    throw new Error(
+      `a session restored from ${JSON.stringify(persisted)} claimed ${calm.registeredTools.length} built-in tools instead of 7`,
+    );
+  }
+  for (const reason of ["startup", "resume", "new", "fork", "reload"]) {
+    await calm.sessionStart({ reason }, context);
+    if (rendered("midTurn").length !== 0) {
+      throw new Error(
+        `a ${reason} session restored from ${JSON.stringify(persisted)} did not hide mid-turn working notes`,
+      );
+    }
+    requireVisible("finalReply", "FINAL_REPLY_TEXT", `${reason} session`);
+  }
+  // A session restored as on toggles to off; one that had wrongly dropped to off would
+  // persist "on" here instead.
+  await calm.calmCommand.handler("", context);
+  if (readFileSync(calmPreferencePath, "utf8") !== "off\n") {
+    throw new Error(`${JSON.stringify(persisted)} did not restore as ordinary Calm on`);
+  }
+  requireVisible("midTurn", "MIDTURN_WORKING_NOTE", "Calm toggled off after restore");
 }
 if (!existsSync(calmPreferencePath)) {
   throw new Error("Calm stopped persisting its preference file");
@@ -1621,9 +1611,9 @@ if (!existsSync(calmPreferencePath)) {
 JS
   status=$?
   out=$(cat "$output_file")
-  [ "$status" -eq 0 ] || fail "Pi calm max mid-turn contract failed: $out"
-  [ -z "$out" ] || fail "Pi calm max mid-turn test printed output: $out"
-  pass "Pi calm max collapses mid-turn assistant working notes to zero height while ordinary Calm keeps them, leaves streaming, truncated-final, and genuine final replies untouched, never mutates the messages, and restores the persisted max level across session starts"
+  [ "$status" -eq 0 ] || fail "Pi calm mid-turn contract failed: $out"
+  [ -z "$out" ] || fail "Pi calm mid-turn test printed output: $out"
+  pass "Pi calm on collapses mid-turn assistant working notes to zero height while Calm off keeps them, leaves streaming, truncated-final, and genuine final replies untouched, never mutates the messages, ignores every /calm argument, and restores a legacy persisted max as ordinary Calm on"
 }
 
 test_operational_followup_turn_e2e() {
@@ -3366,6 +3356,7 @@ JSON
     # on screen through this whole redraw rather than disappearing with it.
     if ! grep -Fq "Thinking..." "$hidden_snapshot" &&
       ! grep -Fq "/calm" "$hidden_snapshot" &&
+      ! grep -Fq "I will run one command." "$hidden_snapshot" &&
       grep -Fq "FIRSTMATE WATCHER WAKE: can you explain this phrase?" "$hidden_snapshot" &&
       grep -Fq "The deterministic tool example is complete." "$hidden_snapshot"; then
       break
@@ -3402,7 +3393,9 @@ JSON
   do
     assert_contains "$(cat "$hidden_snapshot")" "$near_miss" "/calm hid the genuine operational near miss $near_miss"
   done
-  assert_contains "$(cat "$hidden_snapshot")" "I will run one command." "/calm removed assistant conversation before a tool"
+  # Mid-turn narration emitted alongside the tool call is a working note, which Calm
+  # hides against the real Pi renderer; the genuine reply that ended the response stays.
+  assert_not_contains "$(cat "$hidden_snapshot")" "I will run one command." "/calm left a mid-turn assistant working note in the transcript"
   assert_contains "$(cat "$hidden_snapshot")" "The deterministic tool example is complete." "/calm removed assistant conversation after a tool"
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm-diagnostic-e2e"
@@ -3585,6 +3578,7 @@ JS
   assert_contains "$(cat "$restored_snapshot")" " Error:" "second /calm dropped the synthetic delivery diagnostic"
   assert_not_contains "$(cat "$restored_snapshot")" "Navigated to selected point" "second /calm added a navigation status row"
   assert_contains "$(cat "$restored_snapshot")" "Thinking..." "second /calm did not restore Pi's collapsed thinking labels"
+  assert_contains "$(cat "$restored_snapshot")" "I will run one command." "second /calm did not restore the mid-turn assistant working note"
   assert_contains "$(cat "$restored_snapshot")" "escape to interrupt" "/calm changed the active Ctrl+O expansion state"
 
   hash_after=$(shasum -a 256 "$session_file" | awk '{print $1}')
@@ -3933,7 +3927,7 @@ test_pi_compat_missing_adapter_exports
 test_builtin_gate_load_time
 test_calm_activation_collision_and_regression_bound
 test_rendering_and_session_lifecycle
-test_calm_max_mid_turn_working_notes
+test_calm_mid_turn_working_notes
 test_operational_followup_turn_e2e
 test_hidden_block_geometry_e2e
 test_working_ship_geometry_and_lifecycle


### PR DESCRIPTION
## Intent

Make today's `/calm max` behavior the ORDINARY Calm `on` state and REMOVE `max` entirely, collapsing the three-state presentation level added in PR #2334 back to two-state. The captain ran `/calm max` after #2334 landed, dogfooded it, and decided that mid-turn hide should be the default Calm rather than an opt-in level.

Product requirements:
- `off` is stock Pi transcript, completely unchanged.
- `on` is the previous ordinary Calm PLUS hiding mid-turn assistant working notes.
- The hide rule itself is EXACTLY #2334's `max` rule and must NOT change: hide assistant `text` blocks when the message's own `stopReason` is "toolUse", and when it is "length" with tool calls present; never hide while `stopReason` is "pending" (suppressing streaming text would also stop a genuine reply from streaming). The change moves that hide from the max-only path into the ordinary on path.
- Remove the `/calm max` command argument entirely. Plain `/calm` is the on/off toggle again, with no argument parsing for "max" and no third state.
- `config/calm` persists only `on` / `off`.

MIGRATION - the failure mode the captain explicitly flagged: a home upgraded from #2334 may already have `max` persisted in `config/calm`. After this change, reading `max` MUST restore as `on`, NEVER drop to off. The config reader stays tolerant of the legacy `max` value and maps it to on, and a test proves a `config/calm` containing `max` reads as on with the mid-turn hide active.

Docs - this deliberately ADVERTISES the behavior, reversing #2334's silent dogfood, because the mid-turn hide is now the default: docs/calm.md states that Calm on hides mid-turn assistant working notes while keeping the final reply and keeping storage, /export, and model context intact; docs/configuration.md's config/calm schema says the written values are on/off again and notes that a legacy persisted `max` is read as on for backward compatibility; docs/calm-mode-feasibility.md drops its now-stale level-scoped `max` wording.

Explicitly OUT OF SCOPE: do not change the hide RULE, do not keep a `max` command argument or a third state, do not change `off` behavior.

Implementation decisions made while doing the work, which a reviewer reading only the diff would not know:
- Rather than keeping a two-value string union, the visibility policy owner (.pi/extensions/lib/fm-calm-visibility.ts) was collapsed back to the pre-#2334 boolean shape: CALM_PRESENTATION_LEVELS, CalmPresentationLevel, calmPresentationLevel(), and CALM_MAX_HIDDEN_CLASSES were all removed, and "assistant-working-note" was simply dropped from CALM_VISIBLE_CLASSES. This deliberately keeps the one-owner rule intact - the allowlist alone decides what Calm hides - instead of layering a second level-conditional mechanism on top of it. calmTranscriptClassIsVisible() went back to a single-argument pure allowlist check, which .pi/extensions/fm-primary-pi-watch.ts also consumes.
- loadCalmPreference() returns a boolean again and reads `stored === "on" || stored === "max"`, which is the whole migration.
- The live tmux E2E assertion for the restored mid-turn message "I will run one command." was intentionally FLIPPED from assert_contains to assert_not_contains, because under the new default that narration must hide against the real Pi renderer; a matching assert_contains was added after Calm is toggled back off to prove `off` behavior is unchanged. The redraw wait loop was extended to wait for that row to disappear so the assertion is not racy.

Verification already performed locally: the renderer fixtures were run against a scratch install of Pi 0.84.1 matching the signed fleet build, pinned via FM_PI_PACKAGE_DIR, because the signed app bundle ships no importable dist/ and the global npm install is only 0.80.10. Strict no-emit typecheck passes against Pi 0.84.1, bin/fm-lint.sh and bin/fm-doc-audience-check.sh are clean, and the exported /export artifact was decoded and Chrome-rendered to confirm the newly hidden working note is still fully present in both the session JSON and the rendered DOM.

KNOWN PRE-EXISTING FAILURE, deliberately not fixed here: tests/fm-calm-pi-extension.test.sh's live tmux E2E fails at "/export did not complete while calm mode was on". This was reproduced on unmodified origin/main at the merge base, so it is NOT caused by this change. The export itself succeeds and writes a correct 292KB artifact; only the transient "Session exported to: ..." footer status line the test waits for is no longer present under Pi 0.84.1. The captain has filed it as a separate follow-up and explicitly instructed not to widen this change to fix it. If the Test or CI step hits this failure, treat it as a pre-existing merge-base failure rather than a regression in this diff.

Delivery: firstmate shared tracked material, mode no-mistakes, yolo OFF - the captain merges. This changes the running Calm default, so homes pick it up after merge plus a firstmate self-update.

## What Changed
- Make ordinary Calm `on` hide mid-turn assistant working notes while preserving streaming text, final replies, stored messages, and exports.
- Remove the `max` presentation level and return `/calm` and persisted preferences to a two-state `on`/`off` model.
- Read legacy persisted `max` preferences as `on`, with updated documentation and renderer coverage for migration and unchanged Calm-off behavior.

## Risk Assessment

✅ Low: The change cleanly collapses Calm to two states, preserves the exact hide rule and off behavior, migrates legacy max preferences to on, and adds behavior-level coverage and matching documentation.

## Testing

Targeted Pi 0.84.1 renderer, migration, persistence, toggle, tmux UI, and export checks demonstrated the two-state behavior end-to-end: ordinary Calm hides mid-turn notes, off restores stock rendering, legacy max migrates to on, and hidden content remains stored and exportable; temporary test files were cleaned and the worktree remained clean.

- Evidence: Side-by-side real Pi 0.84.1 Calm-on and Calm-off terminal rendering (local file: <code>/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/no-mistakes-evidence/01KZYGHE0E9EHVJ1Y23QHCQ13F/calm-on-off-visual.png</code>)
<details>
<summary>Evidence: Reviewer-visible side-by-side terminal evidence</summary>

```text
<!doctype html><meta charset="utf-8"><title>Calm on/off – Pi 0.84.1</title><style>*{box-sizing:border-box}body{margin:0;background:#10141c;color:#e7edf6;font-family:Inter,-apple-system,sans-serif;padding:30px}.title{font-size:30px;font-weight:750}.sub{color:#9badc5;margin:8px 0 24px}.grid{display:grid;grid-template-columns:1fr 1fr;gap:22px}.panel{background:#171d27;border:1px solid #354158;border-radius:14px;overflow:hidden}.head{padding:16px 20px;font-size:21px;font-weight:700;border-bottom:1px solid #354158}.on .head{color:#89e0ba}.off .head{color:#ffd18b}.note{font-size:14px;font-weight:400;color:#aebbd0;margin-top:4px}pre{font:12px/1.35 Menlo,monospace;white-space:pre-wrap;margin:0;padding:18px;height:1180px;overflow:hidden;color:#d8e1ed}.legend{margin-top:18px;color:#aebbd0;font-size:14px}</style><body><div class="title">Calm transcript behavior in Pi 0.84.1</div><div class="sub">The same restored session after toggling Calm on, then off.</div><div class="grid"><section class="panel on"><div class="head">Calm on<div class="note">“I will run one command.” is hidden; final reply remains.</div></div><pre>
 pi v0.84.1
 escape to interrupt
 ctrl+c to clear
 ctrl+c twice to exit
 ctrl+d to exit (empty)
 ctrl+z to suspend
 ctrl+k to delete to end
 shift+tab to cycle thinking level
 ctrl+p/shift+ctrl+p to cycle models
 ctrl+l to select model
 ctrl+o to expand tools
 ctrl+t to expand thinking
 ctrl+g for external editor
 / for commands
 ! to run bash
 !! to run bash (no context)
 option+enter to queue follow-up
 option+up to edit all queued messages
 ctrl+v to paste image (with text fallback)
 drop files to attach

 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.

[Extensions]
  project
    /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/fm-calm-pi-extension.mfbgew/e2e-project/.pi/extensions/fm-calm-e2e-inject.ts
    /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/fm-calm-pi-extension.mfbgew/e2e-project/.pi/extensions/fm-calm.ts
    /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/fm-calm-pi-extension.mfbgew/e2e-project/.pi/extensions/fm-primary-pi-watch.ts
    /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/fm-calm-pi-extension.mfbgew/e2e-project/.pi/extensions/fm-primary-turnend-guard.ts


 Show a deterministic tool example.



 $ printf 'CALM_E2E_OUTPUT
 '

 CALM_E2E_OUTPUT



 grep /CALM_EXPORT_GREP/ in .

 sample.txt:1:CALM_EXPORT_GREP



 find CALM_EXPORT_FIND* in .

 CALM_EXPORT_FIND.txt



 FIRSTMATE WATCHER WAKE: can you explain this phrase?



 Captain quote: ⁣FIRSTMATE_OP: v1 watcher: QUOTED_CURRENT_NEAR_MISS



 FIRSTMATE_OP: v1 watcher: ASCII_ONLY_NEAR_MISS



 Ordinary captain text before ⁣FIRSTMATE_OP: v1 watcher: EMBEDDED_CURRENT_NEAR_MISS



 ⁣ordinary captain text after unrelated separator


 The deterministic tool example is complete.

 Warning: Could not restore model anthropic/claude-sonnet-4-5. Using calm-e2e/delayed

 Tool output: expanded

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/fm-calm-pi-extension.mfbgew/e2e-project (main)
↑7 ↓4 0.8%/4.1k (auto)                                                                                                                                                       delayed
</pre></section><section class="panel off"><div class="head">Calm off<div class="note">Stock Pi transcript restores the working note and thinking/tool rows.</div></div><pre>
 pi v0.84.1
 escape to interrupt
 ctrl+c to clear
 ctrl+c twice to exit
 ctrl+d to exit (empty)
 ctrl+z to suspend
 ctrl+k to delete to end
 shift+tab to cycle thinking level
 ctrl+p/shift+ctrl+p to cycle models
 ctrl+l to select model
 ctrl+o to expand tools
 ctrl+t to expand thinking
 ctrl+g for external editor
 / for commands
 ! to run bash
 !! to run bash (no context)
 option+enter to queue follow-up
 option+up to edit all queued messages
 ctrl+v to paste image (with text fallback)
 drop files to attach

 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.

[Extensions]
  project
    /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/fm-calm-pi-extension.mfbgew/e2e-project/.pi/extensions/fm-calm-e2e-inject.ts
    /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/fm-calm-pi-extension.mfbgew/e2e-project/.pi/extensions/fm-calm.ts
    /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/fm-calm-pi-extension.mfbgew/e2e-project/.pi/extensions/fm-primary-pi-watch.ts
    /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/fm-calm-pi-extension.mfbgew/e2e-project/.pi/extensions/fm-primary-turnend-guard.ts


 Show a deterministic tool example.


 Thinking...

 I will run one command.


 $ printf 'CALM_E2E_OUTPUT
 '

 CALM_E2E_OUTPUT


 Thinking...


 grep /CALM_EXPORT_GREP/ in .

 sample.txt:1:CALM_EXPORT_GREP



 find CALM_EXPORT_FIND* in .

 CALM_EXPORT_FIND.txt


 Thinking...


 fm_watch_arm_pi
 watcher: started Pi extension arm child 1



 FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status

 Run bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.



 FIRSTMATE WATCHER WAKE: can you explain this phrase?



 Captain quote: ⁣FIRSTMATE_OP: v1 watcher: QUOTED_CURRENT_NEAR_MISS



 FIRSTMATE_OP: v1 watcher: ASCII_ONLY_NEAR_MISS



 Ordinary captain text before ⁣FIRSTMATE_OP: v1 watcher: EMBEDDED_CURRENT_NEAR_MISS



 ⁣ordinary captain text after unrelated separator


 The deterministic tool example is complete.

 Warning: Could not restore model anthropic/claude-sonnet-4-5. Using calm-e2e/delayed

 Tool output: expanded

 Warning: CALM_TRANSIENT_DIAGNOSTIC


 ⁣FIRSTMATE_OP: v1 watcher: CURRENT_WATCHER_E2E /tmp/active-probe.status


 Error: CALM_OPERATIONAL_E2E_ERROR


 ⁣FIRSTMATE_OP: v1 turn-end-guard: CURRENT_TURN_END_E2E


 Error: CALM_OPERATIONAL_E2E_ERROR


 ⁣FIRSTMATE_OP: v1 away-supervisor: CURRENT_AWAY_E2E


 Error: CALM_OPERATIONAL_E2E_ERROR


 [fm-from-firstmate]⁣corr=0123456789abcdef CURRENT_FROM_FIRSTMATE_E2E


 Error: CALM_OPERATIONAL_E2E_ERROR


 ⁣FIRSTMATE_OP: v1 launch-brief: CURRENT_LAUNCH_BRIEF_E2E


 Error: CALM_OPERATIONAL_E2E_ERROR

 Tool output: expanded

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/fm-calm-pi-extension.mfbgew/e2e-project (main)
↑7 ↓4 2.7%/4.1k (auto)                                                                                                                                             operational-error
</pre></section></div><div class="legend">Captured from the real tmux-driven Pi renderer; session and exported HTML artifacts accompany this image.</div></body>
```
</details>
<details>
<summary>Evidence: Raw Calm-on terminal capture</summary>

```text

 pi v0.84.1
 escape to interrupt
 ctrl+c to clear
 ctrl+c twice to exit
 ctrl+d to exit (empty)
 ctrl+z to suspend
 ctrl+k to delete to end
 shift+tab to cycle thinking level
 ctrl+p/shift+ctrl+p to cycle models
 ctrl+l to select model
 ctrl+o to expand tools
 ctrl+t to expand thinking
 ctrl+g for external editor
 / for commands
 ! to run bash
 !! to run bash (no context)
 option+enter to queue follow-up
 option+up to edit all queued messages
 ctrl+v to paste image (with text fallback)
 drop files to attach

 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.

[Extensions]
  project
    /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/fm-calm-pi-extension.mfbgew/e2e-project/.pi/extensions/fm-calm-e2e-inject.ts
    /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/fm-calm-pi-extension.mfbgew/e2e-project/.pi/extensions/fm-calm.ts
    /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/fm-calm-pi-extension.mfbgew/e2e-project/.pi/extensions/fm-primary-pi-watch.ts
    /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/fm-calm-pi-extension.mfbgew/e2e-project/.pi/extensions/fm-primary-turnend-guard.ts


 Show a deterministic tool example.



 $ printf 'CALM_E2E_OUTPUT
 '

 CALM_E2E_OUTPUT



 grep /CALM_EXPORT_GREP/ in .

 sample.txt:1:CALM_EXPORT_GREP



 find CALM_EXPORT_FIND* in .

 CALM_EXPORT_FIND.txt



 FIRSTMATE WATCHER WAKE: can you explain this phrase?



 Captain quote: ⁣FIRSTMATE_OP: v1 watcher: QUOTED_CURRENT_NEAR_MISS



 FIRSTMATE_OP: v1 watcher: ASCII_ONLY_NEAR_MISS



 Ordinary captain text before ⁣FIRSTMATE_OP: v1 watcher: EMBEDDED_CURRENT_NEAR_MISS



 ⁣ordinary captain text after unrelated separator


 The deterministic tool example is complete.

 Warning: Could not restore model anthropic/claude-sonnet-4-5. Using calm-e2e/delayed

 Tool output: expanded

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/fm-calm-pi-extension.mfbgew/e2e-project (main)
↑7 ↓4 0.8%/4.1k (auto)                                                                                                                                                       delayed
```
</details>
<details>
<summary>Evidence: Raw Calm-off terminal capture</summary>

```text

 pi v0.84.1
 escape to interrupt
 ctrl+c to clear
 ctrl+c twice to exit
 ctrl+d to exit (empty)
 ctrl+z to suspend
 ctrl+k to delete to end
 shift+tab to cycle thinking level
 ctrl+p/shift+ctrl+p to cycle models
 ctrl+l to select model
 ctrl+o to expand tools
 ctrl+t to expand thinking
 ctrl+g for external editor
 / for commands
 ! to run bash
 !! to run bash (no context)
 option+enter to queue follow-up
 option+up to edit all queued messages
 ctrl+v to paste image (with text fallback)
 drop files to attach

 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.

[Extensions]
  project
    /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/fm-calm-pi-extension.mfbgew/e2e-project/.pi/extensions/fm-calm-e2e-inject.ts
    /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/fm-calm-pi-extension.mfbgew/e2e-project/.pi/extensions/fm-calm.ts
    /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/fm-calm-pi-extension.mfbgew/e2e-project/.pi/extensions/fm-primary-pi-watch.ts
    /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/fm-calm-pi-extension.mfbgew/e2e-project/.pi/extensions/fm-primary-turnend-guard.ts


 Show a deterministic tool example.


 Thinking...

 I will run one command.


 $ printf 'CALM_E2E_OUTPUT
 '

 CALM_E2E_OUTPUT


 Thinking...


 grep /CALM_EXPORT_GREP/ in .

 sample.txt:1:CALM_EXPORT_GREP



 find CALM_EXPORT_FIND* in .

 CALM_EXPORT_FIND.txt


 Thinking...


 fm_watch_arm_pi
 watcher: started Pi extension arm child 1



 FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status

 Run bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.



 FIRSTMATE WATCHER WAKE: can you explain this phrase?



 Captain quote: ⁣FIRSTMATE_OP: v1 watcher: QUOTED_CURRENT_NEAR_MISS



 FIRSTMATE_OP: v1 watcher: ASCII_ONLY_NEAR_MISS



 Ordinary captain text before ⁣FIRSTMATE_OP: v1 watcher: EMBEDDED_CURRENT_NEAR_MISS



 ⁣ordinary captain text after unrelated separator


 The deterministic tool example is complete.

 Warning: Could not restore model anthropic/claude-sonnet-4-5. Using calm-e2e/delayed

 Tool output: expanded

 Warning: CALM_TRANSIENT_DIAGNOSTIC


 ⁣FIRSTMATE_OP: v1 watcher: CURRENT_WATCHER_E2E /tmp/active-probe.status


 Error: CALM_OPERATIONAL_E2E_ERROR


 ⁣FIRSTMATE_OP: v1 turn-end-guard: CURRENT_TURN_END_E2E


 Error: CALM_OPERATIONAL_E2E_ERROR


 ⁣FIRSTMATE_OP: v1 away-supervisor: CURRENT_AWAY_E2E


 Error: CALM_OPERATIONAL_E2E_ERROR


 [fm-from-firstmate]⁣corr=0123456789abcdef CURRENT_FROM_FIRSTMATE_E2E


 Error: CALM_OPERATIONAL_E2E_ERROR


 ⁣FIRSTMATE_OP: v1 launch-brief: CURRENT_LAUNCH_BRIEF_E2E


 Error: CALM_OPERATIONAL_E2E_ERROR

 Tool output: expanded

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/fm-calm-pi-extension.mfbgew/e2e-project (main)
↑7 ↓4 2.7%/4.1k (auto)                                                                                                                                             operational-error
```
</details>
<details>
<summary>Evidence: Chrome-rendered exported session DOM retaining the hidden working note</summary>

```text
<!DOCTYPE html>
<html lang="en"><head>
  <meta charset="UTF-8">
  <meta name="viewport" content="width=device-width, initial-scale=1.0">
  <title>Session Export</title>
  <style>
    :root {
      --accent: #8abeb7;
      --border: #5f87ff;
      --borderAccent: #00d7ff;
      --borderMuted: #505050;
      --success: #b5bd68;
      --error: #cc6666;
      --warning: #ffff00;
      --muted: #808080;
      --dim: #666666;
      --text: #d4d4d4;
      --thinkingText: #808080;
      --selectedBg: #3a3a4a;
      --scrollbarThumb: #3a3a4a;
      --userMessageBg: #343541;
      --userMessageText: #d4d4d4;
      --customMessageBg: #2d2838;
      --customMessageText: #d4d4d4;
      --customMessageLabel: #9575cd;
      --toolPendingBg: #282832;
      --toolSuccessBg: #283228;
      --toolErrorBg: #3c2828;
      --toolTitle: #d4d4d4;
      --toolOutput: #808080;
      --mdHeading: #f0c674;
      --mdLink: #81a2be;
      --mdLinkUrl: #666666;
      --mdCode: #8abeb7;
      --mdCodeBlock: #b5bd68;
      --mdCodeBlockBorder: #808080;
      --mdQuote: #808080;
      --mdQuoteBorder: #808080;
      --mdHr: #808080;
      --mdListBullet: #8abeb7;
      --toolDiffAdded: #b5bd68;
      --toolDiffRemoved: #cc6666;
      --toolDiffContext: #808080;
      --syntaxComment: #6A9955;
      --syntaxKeyword: #569CD6;
      --syntaxFunction: #DCDCAA;
      --syntaxVariable: #9CDCFE;
      --syntaxString: #CE9178;
      --syntaxNumber: #B5CEA8;
      --syntaxType: #4EC9B0;
      --syntaxOperator: #D4D4D4;
      --syntaxPunctuation: #D4D4D4;
      --thinkingOff: #505050;
      --thinkingMinimal: #6e6e6e;
      --thinkingLow: #5f87af;
      --thinkingMedium: #81a2be;
      --thinkingHigh: #b294bb;
      --thinkingXhigh: #d183e8;
      --thinkingMax: #ff5fff;
      --bashMode: #b5bd68;
      --exportPageBg: #18181e;
      --exportCardBg: #1e1e24;
      --exportInfoBg: #3c3728;
      --body-bg: #18181e;
      --container-bg: #1e1e24;
      --info-bg: #3c3728;
    }

    * { margin: 0; padding: 0; box-sizing: border-box; }

    :root {
      --line-height: 18px; /* 12px font * 1.5 */
      --sidebar-width: 400px;
      --sidebar-min-width: 240px;
      --sidebar-max-width: 840px;
      --sidebar-resizer-width: 6px;
    }

    body {
      font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
      font-size: 12px;
      line-height: var(--line-height);
      color: var(--text);
      background: var(--body-bg);
    }

    body.sidebar-resizing {
      cursor: col-resize;
      user-select: none;
    }

    #app {
      display: flex;
      min-height: 100vh;
    }

    /* Sidebar */
    #sidebar {
      width: var(--sidebar-width);
      min-width: var(--sidebar-width);
      max-width: var(--sidebar-width);
      background: var(--container-bg);
      flex-shrink: 0;
      display: flex;
      flex-direction: column;
      position: sticky;
      top: 0;
      height: 100vh;
      border-right: 1px solid var(--dim);
    }

    #sidebar-resizer {
      width: var(--sidebar-resizer-width);
      flex-shrink: 0;
      position: sticky;
      top: 0;
      height: 100vh;
      cursor: col-resize;
      touch-action: none;
      background: transparent;
      border-right: 1px solid transparent;
    }

    #sidebar-resizer:hover,
    body.sidebar-resizing #sidebar-resizer {
      background: var(--selectedBg);
      border-right-color: var(--dim);
    }

    .sidebar-header {
      padding: 8px 12px;
      flex-shrink: 0;
    }

    .sidebar-controls {
      padding: 8px 8px 4px 8px;
    }

    .sidebar-search {
      width: 100%;
      box-sizing: border-box;
      padding: 4px 8px;
      font-size: 11px;
      font-family: inherit;
      background: var(--body-bg);
      color: var(--text);
      border: 1px solid var(--dim);
      border-radius: 3px;
    }

    .sidebar-filters {
      display: flex;
      padding: 4px 8px 8px 8px;
      gap: 4px;
      align-items: center;
      flex-wrap: wrap;
    }

    .sidebar-search:focus {
      outline: none;
      border-color: var(--accent);
    }

    .sidebar-search::placeholder {
      color: var(--muted);
    }

    .filter-btn {
      padding: 3px 8px;
      font-size: 10px;
      font-family: inherit;
      background: transparent;
      color: var(--muted);
      border: 1px solid var(--dim);
      border-radius: 3px;
      cursor: pointer;
    }

    .filter-btn:hover {
      color: var(--text);
      border-color: var(--text);
    }

    .filter-btn.active {
      background: var(--accent);
      color: var(--body-bg);
      border-color: var(--accent);
    }

    .sidebar-close {
      display: none;
      padding: 3px 8px;
      font-size: 12px;
      font-family: inherit;
      background: transparent;
      color: var(--muted);
      border: 1px solid var(--dim);
      border-radius: 3px;
      cursor: pointer;
      margin-left: auto;
    }

    .sidebar-close:hover {
      color: var(--text);
      border-color: var(--text);
    }

    .tree-container {
      flex: 1;
      overflow: auto;
      padding: 4px 0;
    }

    .tree-node {
      padding: 0 8px;
      cursor: pointer;
      display: flex;
      align-items: baseline;
      font-size: 11px;
      line-height: 13px;
      white-space: nowrap;
    }

    .tree-node:hover {
      background: var(--selectedBg);
    }

    .tree-node.active {
      background: var(--selectedBg);
    }

    .tree-node.active .tree-content {
      font-weight: bold;
    }

    .tree-node.in-path {
      background: color-mix(in srgb, var(--accent) 10%, transparent);
    }

    .tree-node:not(.in-path) {
      opacity: 0.5;
    }

    .tree-node:not(.in-path):hover {
      opacity: 1;
    }

    .tree-prefix {
      color: var(--muted);
      flex-shrink: 0;
      font-family: monospace;
      white-space: pre;
    }

    .tree-marker {
      color: var(--accent);
      flex-shrink: 0;
    }

    .tree-content {
      color: var(--text);
    }

    .tree-role-user {
      color: var(--accent);
    }

    .tree-role-skill {
      color: var(--customMessageLabel);
    }

    .tree-role-assistant {
      color: var(--success);
    }

    .tree-role-tool {
      color: var(--muted);
    }

    .tree-muted {
      color: var(--muted);
    }

    .tree-error {
      color: var(--error);
    }

    .tree-compaction {
      color: var(--borderAccent);
    }

    .tree-branch-summary {
      color: var(--warning);
    }

    .tree-custom-message {
      color: var(--customMessageLabel);
    }

    .tree-status {
      padding: 4px 12px;
      font-size: 10px;
      color: var(--muted);
      flex-shrink: 0;
    }

    /* Main content */
    #content {
      flex: 1;
      min-width: 0;
      overflow-y: auto;
      padding: var(--line-height) calc(var(--line-height) * 2);
      display: flex;
      flex-direction: column;
      align-items: center;
    }

    #content > * {
      width: 100%;
      max-width: 800px;
    }

    /* Help bar */
    .help-bar {
      font-size: 11px;
      color: var(--warning);
      margin-bottom: var(--line-height);
      display: flex;
      align-items: center;
      justify-content: space-between;
      flex-wrap: wrap;
      gap: 12px;
    }

    .help-hint {
      flex: 1 1 240px;
    }

    .help-actions {
      display: flex;
      align-items: center;
      flex-wrap: wrap;
      gap: 8px;
    }

    .header-toggle-btn,
    .download-json-btn {
      font-size: 10px;
      padding: 2px 8px;
      background: var(--container-bg);
      border: 1px solid var(--border);
      border-radius: 3px;
      color: var(--text);
      cursor: pointer;
      font-family: inherit;
    }

    .header-toggle-btn:hover,
    .download-json-btn:hover {
      background: var(--hover);
      border-color: var(--borderAccent);
    }

    /* Header */
    .header {
      background: var(--container-bg);
      border-radius: 4px;
      padding: var(--line-height);
      margin-bottom: var(--line-height);
    }

    .header h1 {
      font-size: 12px;
      font-weight: bold;
      color: var(--borderAccent);
      margin-bottom: var(--line-height);
    }

    .header-info {
      display: flex;
      flex-direct

... [310011 bytes truncated] ...

ne code: escape HTML
          codespan(token) {
            return `<code>${escapeHtml(token.text)}</code>`;
          }
        }
      });

      // Simple marked parse (escaping handled in renderers)
      function safeMarkedParse(text) {
        return marked.parse(text);
      }

      // Search input
      const searchInput = document.getElementById('tree-search');
      searchInput.addEventListener('input', (e) => {
        searchQuery = e.target.value;
        forceTreeRerender();
      });

      // Filter buttons
      document.querySelectorAll('.filter-btn').forEach(btn => {
        btn.addEventListener('click', () => {
          document.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
          btn.classList.add('active');
          filterMode = btn.dataset.filter;
          forceTreeRerender();
        });
      });

      // Sidebar toggle
      const sidebar = document.getElementById('sidebar');
      const overlay = document.getElementById('sidebar-overlay');
      const hamburger = document.getElementById('hamburger');
      const sidebarResizer = document.getElementById('sidebar-resizer');
      const SIDEBAR_WIDTH_STORAGE_KEY = 'pi-share:v1:sidebar-width';
      const MIN_CONTENT_WIDTH = 320;

      function isMobileLayout() {
        return window.matchMedia('(max-width: 900px)').matches;
      }

      function getSidebarBounds() {
        const rootStyles = getComputedStyle(document.documentElement);
        const minWidth = parseFloat(rootStyles.getPropertyValue('--sidebar-min-width')) || 240;
        const maxWidth = parseFloat(rootStyles.getPropertyValue('--sidebar-max-width')) || 720;
        const viewportMaxWidth = window.innerWidth - MIN_CONTENT_WIDTH;
        return {
          minWidth,
          maxWidth: Math.max(minWidth, Math.min(maxWidth, viewportMaxWidth))
        };
      }

      function clampSidebarWidth(width) {
        const { minWidth, maxWidth } = getSidebarBounds();
        return Math.max(minWidth, Math.min(maxWidth, width));
      }

      function applySidebarWidth(width) {
        document.documentElement.style.setProperty('--sidebar-width', `${Math.round(clampSidebarWidth(width))}px`);
      }

      function loadSidebarWidth() {
        try {
          const raw = localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY);
          if (raw === null) return null;
          const width = Number(raw);
          return Number.isFinite(width) ? width : null;
        } catch {
          return null;
        }
      }

      function saveSidebarWidth(width) {
        try {
          localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(Math.round(clampSidebarWidth(width))));
        } catch {
          // Ignore storage failures (e.g. private browsing restrictions)
        }
      }

      function setupSidebarResize() {
        const savedWidth = loadSidebarWidth();
        if (savedWidth !== null) {
          applySidebarWidth(savedWidth);
        }

        if (!sidebarResizer) return;

        let cleanupDrag = null;

        const stopDrag = (pointerId) => {
          if (cleanupDrag) {
            cleanupDrag(pointerId);
            cleanupDrag = null;
          }
        };

        sidebarResizer.addEventListener('pointerdown', (e) => {
          if (isMobileLayout()) return;

          e.preventDefault();
          const startX = e.clientX;
          const startWidth = sidebar.getBoundingClientRect().width;
          document.body.classList.add('sidebar-resizing');
          sidebarResizer.setPointerCapture?.(e.pointerId);

          const onPointerMove = (event) => {
            applySidebarWidth(startWidth + (event.clientX - startX));
          };

          cleanupDrag = (pointerIdToRelease) => {
            document.body.classList.remove('sidebar-resizing');
            sidebarResizer.releasePointerCapture?.(pointerIdToRelease);
            window.removeEventListener('pointermove', onPointerMove);
            window.removeEventListener('pointerup', onPointerUp);
            window.removeEventListener('pointercancel', onPointerCancel);
            saveSidebarWidth(sidebar.getBoundingClientRect().width);
          };

          const onPointerUp = (event) => stopDrag(event.pointerId);
          const onPointerCancel = (event) => stopDrag(event.pointerId);

          window.addEventListener('pointermove', onPointerMove);
          window.addEventListener('pointerup', onPointerUp);
          window.addEventListener('pointercancel', onPointerCancel);
        });

        sidebarResizer.addEventListener('dblclick', () => {
          if (isMobileLayout()) return;
          applySidebarWidth(400);
          saveSidebarWidth(400);
        });

        window.addEventListener('resize', () => {
          if (isMobileLayout()) return;
          applySidebarWidth(sidebar.getBoundingClientRect().width);
        });
      }

      setupSidebarResize();

      hamburger.addEventListener('click', () => {
        sidebar.classList.add('open');
        overlay.classList.add('open');
        hamburger.style.display = 'none';
      });

      const closeSidebar = () => {
        sidebar.classList.remove('open');
        overlay.classList.remove('open');
        hamburger.style.display = '';
      };

      overlay.addEventListener('click', closeSidebar);
      document.getElementById('sidebar-close').addEventListener('click', closeSidebar);

      // Toggle states
      let thinkingExpanded = true;
      let toolOutputsExpanded = false;

      const toggleThinking = () => {
        thinkingExpanded = !thinkingExpanded;
        document.querySelectorAll('.thinking-text').forEach(el => {
          el.style.display = thinkingExpanded ? '' : 'none';
        });
        document.querySelectorAll('.thinking-collapsed').forEach(el => {
          el.style.display = thinkingExpanded ? 'none' : 'block';
        });
      };

      const toggleToolOutputs = () => {
        toolOutputsExpanded = !toolOutputsExpanded;
        document.querySelectorAll('.tool-output.expandable').forEach(el => {
          el.classList.toggle('expanded', toolOutputsExpanded);
        });
        document.querySelectorAll('.compaction').forEach(el => {
          el.classList.toggle('expanded', toolOutputsExpanded);
        });
        document.querySelectorAll('.skill-invocation').forEach(el => {
          el.classList.toggle('expanded', toolOutputsExpanded);
        });
      };

      const attachHeaderHandlers = () => {
        document.querySelector('[data-action="toggle-thinking"]')?.addEventListener('click', toggleThinking);
        document.querySelector('[data-action="toggle-tools"]')?.addEventListener('click', toggleToolOutputs);
      };

      const isEditableTarget = (element) => {
        if (!element) return false;
        const tagName = element.tagName;
        if (tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT' || tagName === 'BUTTON') {
          return true;
        }
        return element.isContentEditable || Boolean(element.closest?.('[contenteditable="true"]'));
      };

      // Keyboard shortcuts
      document.addEventListener('keydown', (e) => {
        if (e.key === 'Escape') {
          searchInput.value = '';
          searchQuery = '';
          navigateTo(leafId, 'bottom');
        }

        if (isEditableTarget(document.activeElement)) {
          return;
        }

        const key = e.key.toLowerCase();
        if (key === 't') {
          e.preventDefault();
          toggleThinking();
        } else if (key === 'o') {
          e.preventDefault();
          toggleToolOutputs();
        }
      });

      // Initial render
      // If URL has targetId, scroll to that specific message; otherwise stay at top
      if (leafId) {
        if (urlTargetId && byId.has(urlTargetId)) {
          // Deep link: navigate to leaf and scroll to target message
          navigateTo(leafId, 'target', urlTargetId);
        } else {
          navigateTo(leafId, 'none');
        }
      } else if (entries.length > 0) {
        // Fallback: use last entry if no leafId
        navigateTo(entries[entries.length - 1].id, 'none');
      }
    })();

  </script>


</body></html>
```
</details>
- Evidence: Persisted Pi session JSON retaining the hidden working note (local file: <code>/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/no-mistakes-evidence/01KZYGHE0E9EHVJ1Y23QHCQ13F/calm-session.jsonl</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c96c104a616236345994011fa268c808295f8300","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Installed a temporary Pi 0.84.1 package fixture, ran `test_calm_mid_turn_working_notes`, then removed the fixture.</code>
- <code>Ran `test_interactive_terminal_e2e` through the real Pi 0.84.1 tmux renderer, stopping after Calm on/off and export verification; bypassed only the documented pre-existing missing export-footer wait by waiting for the export artifact itself.</code>
- `Verified Calm on hides tool-use and length-with-tool working notes, preserves pending/truncated-final/final replies, and does not mutate messages.`
- <code>Verified `/calm` arguments, including `max`, receive no special parsing and only perform the ordinary on/off toggle, persisting solely `on` or `off`.</code>
- <code>Verified legacy `config/calm` values `max\n` and `max` restore Calm on across startup, resume, new, fork, and reload, with mid-turn hiding active.</code>
- `Compared real terminal captures: Calm on omits “I will run one command.” while retaining the final reply; Calm off restores the working note and stock rows.`
- <code>Verified the hidden note remains in persisted session JSON and Chrome-rendered `/export` DOM.</code>
- <code>Confirmed `git status --short` was clean after removing temporary test dependencies and harness files.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
