### PR TITLE
fix(bin): serialize recorded special-key input with Codex effort switching

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -233,7 +233,9 @@ The session id is printed on quit.
 
 Routine effort adjustment for an idle visible crewmate uses `FM_HOME=<home> bin/fm-codex-effort.sh <task-id> <low|medium|high|xhigh>`.
 This is the Firstmate-owned public interface for Codex's installed Chat Increase Reasoning and Chat Decrease Reasoning keybindings.
-It supports the preferred Herdr runtime and the tmux reference runtime, verifies the live footer after every step, and updates `state/<id>.meta` only after final confirmation.
+It currently supports only the preferred Herdr runtime, because Herdr supplies the required native semantic idle state.
+It writes a durable recovery record before its first chord, verifies the live footer after every step, and updates `state/<id>.meta` only after final confirmation.
+After a post-send interruption or refusal, its next locked invocation verifies the unchanged endpoint and reconciles the observed footer into `state/<id>.meta` before delivering any further chord.
 The script header and `--help` output own exact validation, input, polling, and mutation mechanics.
 `docs/verification/runtime-backends.md` owns the Codex 0.146.0 empirical evidence.
 If the interface refuses because the turn is busy, the endpoint is ambiguous, the composer or footer cannot be verified, or the runtime is unsupported, do not improvise a menu sequence or edit metadata.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -234,10 +234,10 @@ The session id is printed on quit.
 Routine effort adjustment for an idle visible crewmate uses `FM_HOME=<home> bin/fm-codex-effort.sh <task-id> <low|medium|high|xhigh>`.
 This is the Firstmate-owned public interface for Codex's installed Chat Increase Reasoning and Chat Decrease Reasoning keybindings.
 It currently supports only the preferred Herdr runtime, because Herdr supplies the required native semantic idle state.
-It writes a durable recovery record before its first chord, verifies the live footer after every step, and updates `state/<id>.meta` only after final confirmation.
+It writes a durable recovery record before its first chord, serializes every chord with ordinary recorded-task `fm-send` input, verifies the live footer after every step, and updates `state/<id>.meta` only after final confirmation.
 After a post-send interruption or refusal, its next locked invocation verifies the unchanged endpoint and reconciles the observed footer into `state/<id>.meta` before delivering any further chord.
 The script header and `--help` output own exact validation, input, polling, and mutation mechanics.
-`docs/verification/runtime-backends.md` owns the Codex 0.146.0 empirical evidence.
+`docs/verification/runtime-backends.md` owns the Codex 0.146.0 keybinding and Codex 0.147.0 footer empirical evidence.
 If the interface refuses because the turn is busy, the endpoint is ambiguous, the composer or footer cannot be verified, or the runtime is unsupported, do not improvise a menu sequence or edit metadata.
 Exit with `/quit` and resume the same session only as an explicit recovery fallback after the unsafe condition is resolved or the in-session interface remains unavailable.
 

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -234,7 +234,7 @@ The session id is printed on quit.
 Routine effort adjustment for an idle visible crewmate uses `FM_HOME=<home> bin/fm-codex-effort.sh <task-id> <low|medium|high|xhigh>`.
 This is the Firstmate-owned public interface for Codex's installed Chat Increase Reasoning and Chat Decrease Reasoning keybindings.
 It currently supports only the preferred Herdr runtime, because Herdr supplies the required native semantic idle state.
-It writes a durable recovery record before its first chord, serializes every chord with ordinary recorded-task `fm-send` input, verifies the live footer after every step, and updates `state/<id>.meta` only after final confirmation.
+It writes a durable recovery record before its first chord, serializes every chord with all recorded-task `fm-send` input including `--key`, verifies the live footer after every step, and updates `state/<id>.meta` only after final confirmation.
 After a post-send interruption or refusal, its next locked invocation verifies the unchanged endpoint and reconciles the observed footer into `state/<id>.meta` before delivering any further chord.
 The script header and `--help` output own exact validation, input, polling, and mutation mechanics.
 `docs/verification/runtime-backends.md` owns the Codex 0.146.0 keybinding and Codex 0.147.0 footer empirical evidence.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -125,7 +125,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | Harness | Model flag | Effort flag | Notes |
 |---|---|---|---|
 | claude | `--model <model>` | `--effort <low\|medium\|high\|xhigh\|max>` | Verified on Claude Code 2.1.196. |
-| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'` | Verified on codex-cli 0.142.1. The installed binary schema contains `model_reasoning_effort`, the active config uses it, and the bundled model catalog advertises only low/medium/high/xhigh. `max` is omitted. |
+| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'` | Verified on codex-cli 0.146.0. The installed schema contains `model_reasoning_effort`, the active config uses it, and the model catalog advertises only low/medium/high/xhigh. `max` is omitted. |
 | grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
 | pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
@@ -209,7 +209,7 @@ A project-level `.claude/settings.json` only takes effect when Claude Code's pro
 After those settings are loaded, hook command resolution is still cwd-sensitive because Claude Code runs commands through `/bin/sh` against the session's current cwd; keep the tracked commands anchored through `"$CLAUDE_PROJECT_DIR"/bin/...` and see `docs/turnend-guard.md` for the verified Stop-hook details.
 Claude Code's primary watcher protocol is Stop-owned: the auto-arm hook fires on every Stop and foregrounds `bin/fm-watch-arm.sh` when the home is eligible and still needs supervision, and its exit-2 `asyncRewake` rewake is the wake; the model drains and handles wakes but never runs a routine re-arm command.
 
-## codex (VERIFIED 2026-06-11, codex-cli 0.139.0)
+## codex (VERIFIED 2026-08-03, codex-cli 0.146.0)
 
 | Fact | Value |
 |---|---|
@@ -230,6 +230,14 @@ The decision persists for the repo, so later worktrees of the same project skip 
 
 Resume after exit with `codex resume <session-id>`.
 The session id is printed on quit.
+
+Routine effort adjustment for an idle visible crewmate uses `FM_HOME=<home> bin/fm-codex-effort.sh <task-id> <low|medium|high|xhigh>`.
+This is the Firstmate-owned public interface for Codex's installed Chat Increase Reasoning and Chat Decrease Reasoning keybindings.
+It supports the preferred Herdr runtime and the tmux reference runtime, verifies the live footer after every step, and updates `state/<id>.meta` only after final confirmation.
+The script header and `--help` output own exact validation, input, polling, and mutation mechanics.
+`docs/verification/runtime-backends.md` owns the Codex 0.146.0 empirical evidence.
+If the interface refuses because the turn is busy, the endpoint is ambiguous, the composer or footer cannot be verified, or the runtime is unsupported, do not improvise a menu sequence or edit metadata.
+Exit with `/quit` and resume the same session only as an explicit recovery fallback after the unsafe condition is resolved or the in-session interface remains unavailable.
 
 **Primary-session guard fact (verified 2026-07-08, codex-cli 0.142.1).**
 The firstmate PRIMARY's own `.codex/hooks.json` registers a Stop hook that pipes Codex's Stop payload to `bin/fm-turnend-guard.sh`.

--- a/bin/fm-codex-effort.sh
+++ b/bin/fm-codex-effort.sh
@@ -50,9 +50,6 @@ fi
 task_id=$1
 requested_effort=$2
 
-case "$task_id" in
-  ''|*[!A-Za-z0-9._-]*) refuse "invalid task id." ;;
-esac
 case "$requested_effort" in
   low|medium|high|xhigh) ;;
   *) refuse "unsupported Codex effort '$requested_effort'; expected low, medium, high, or xhigh." ;;
@@ -65,12 +62,16 @@ esac
 STATE="$FM_HOME/state"
 meta="$STATE/$task_id.meta"
 [ -d "$STATE" ] || refuse "state directory does not exist at $STATE."
-[ -f "$meta" ] && [ ! -L "$meta" ] || refuse "task $task_id has no regular metadata at $meta."
 
 # shellcheck source=bin/fm-backend.sh
 . "$ROOT/bin/fm-backend.sh"
+# shellcheck source=bin/fm-pr-lib.sh
+. "$ROOT/bin/fm-pr-lib.sh"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$ROOT/bin/fm-wake-lib.sh"
+
+fm_task_id_creation_valid "$task_id" || refuse "invalid task id."
+[ -f "$meta" ] && [ ! -L "$meta" ] || refuse "task $task_id has no regular metadata at $meta."
 
 control_lock="$STATE/.control-$task_id.lock"
 meta_lock=$(fm_meta_lock_path "$meta") \

--- a/bin/fm-codex-effort.sh
+++ b/bin/fm-codex-effort.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# fm-codex-effort.sh - switch one idle Codex crewmate's reasoning effort in place.
+#
+# Usage:
+#   FM_HOME=/absolute/firstmate/home bin/fm-codex-effort.sh <task-id> <effort>
+#
+# Supported efforts are low, medium, high, and xhigh.
+# The task must be an idle Codex TUI recorded on Herdr or tmux.
+# Herdr is the preferred production path and receives the verified literal
+# Alt+, or Alt+. byte chord through pane send-text.
+# Tmux receives the same public Codex keybinding through tmux's M-, or M-.
+# The installed Codex 0.146.0 exposes these bindings as Chat Decrease Reasoning
+# and Chat Increase Reasoning in /keymap.
+#
+# This operation fails closed unless task identity, harness, backend endpoint,
+# live agent, worktree, empty composer, and the current model/effort footer all
+# agree before input.
+# It verifies every one-level transition from the rendered Codex footer and
+# revalidates the unchanged endpoint before atomically replacing effort= in
+# state/<id>.meta.
+# It never submits a turn, changes the model, exits or resumes Codex, changes
+# the worktree, or rewrites task ownership.
+# A swallowed chord, changed UI, busy turn, ambiguous state, or missing footer
+# leaves metadata unchanged and reports refusal.
+set -u
+
+ROOT="${FM_ROOT_OVERRIDE:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+FM_HOME=${FM_HOME:-}
+
+usage() {
+  cat <<'USAGE'
+Usage: FM_HOME=/absolute/firstmate/home bin/fm-codex-effort.sh <task-id> <low|medium|high|xhigh>
+
+Switch an idle Codex crewmate's reasoning effort without ending its session.
+Only verified Herdr and tmux task endpoints are supported.
+USAGE
+}
+
+refuse() {
+  echo "REFUSED: $*" >&2
+  exit 1
+}
+
+if [ "$#" -eq 1 ]; then
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+  esac
+fi
+[ "$#" -eq 2 ] || { usage >&2; exit 2; }
+task_id=$1
+requested_effort=$2
+
+case "$task_id" in
+  ''|*[!A-Za-z0-9._-]*) refuse "invalid task id." ;;
+esac
+case "$requested_effort" in
+  low|medium|high|xhigh) ;;
+  *) refuse "unsupported Codex effort '$requested_effort'; expected low, medium, high, or xhigh." ;;
+esac
+case "$FM_HOME" in
+  /*) ;;
+  *) refuse "FM_HOME must be an explicit absolute firstmate home." ;;
+esac
+
+STATE="$FM_HOME/state"
+meta="$STATE/$task_id.meta"
+[ -d "$STATE" ] || refuse "state directory does not exist at $STATE."
+[ -f "$meta" ] && [ ! -L "$meta" ] || refuse "task $task_id has no regular metadata at $meta."
+
+# shellcheck source=bin/fm-backend.sh
+. "$ROOT/bin/fm-backend.sh"
+# shellcheck source=bin/fm-wake-lib.sh
+. "$ROOT/bin/fm-wake-lib.sh"
+
+lock="$STATE/.codex-effort-$task_id.lock"
+if ! fm_lock_try_acquire "$lock"; then
+  refuse "another effort-switch operation already owns task $task_id."
+fi
+tmp_meta=
+cleanup() {
+  [ -z "$tmp_meta" ] || rm -f -- "$tmp_meta" 2>/dev/null || true
+  fm_lock_release "$lock"
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+fm_backend_validate_task_endpoint "$meta" "$task_id" || exit 1
+backend=$FM_BACKEND_VALIDATED_BACKEND
+target=$FM_BACKEND_VALIDATED_TARGET
+case "$backend" in
+  herdr|tmux) ;;
+  *) refuse "backend '$backend' has no verified in-session Codex effort-switch path." ;;
+esac
+
+harness=$(fm_backend_meta_exact_value "$meta" harness) \
+  || refuse "task $task_id has a missing or ambiguous harness."
+[ "$harness" = codex ] || refuse "task $task_id uses harness '$harness', not Codex."
+model=$(fm_backend_meta_exact_value "$meta" model) \
+  || refuse "task $task_id has a missing or ambiguous model."
+recorded_effort=$(fm_backend_meta_exact_value "$meta" effort) \
+  || refuse "task $task_id has a missing or ambiguous effort."
+case "$recorded_effort" in
+  low|medium|high|xhigh) ;;
+  *) refuse "task $task_id records unsupported effort '$recorded_effort'." ;;
+esac
+worktree=$(fm_backend_meta_exact_value "$meta" worktree) \
+  || refuse "task $task_id has a missing or ambiguous worktree."
+meta_fingerprint=$(cksum < "$meta") || refuse "could not fingerprint task metadata."
+
+fm_backend_source "$backend" || refuse "could not load backend '$backend'."
+
+current_path() {
+  case "$backend" in
+    herdr) fm_backend_herdr_current_path "$target" ;;
+    tmux) fm_backend_tmux_current_path "$target" ;;
+  esac
+}
+
+capture_tail() {
+  fm_backend_capture "$backend" "$target" 40 2>/dev/null | tail -n 20
+}
+
+footer_effort() {
+  local cap line effort found=
+  cap=$(capture_tail) || return 1
+  while IFS= read -r line; do
+    case "$line" in
+      *"$model low ·"*) effort=low ;;
+      *"$model medium ·"*) effort=medium ;;
+      *"$model high ·"*) effort=high ;;
+      *"$model xhigh ·"*) effort=xhigh ;;
+      *) continue ;;
+    esac
+    found=$effort
+  done <<EOF
+$cap
+EOF
+  [ -n "$found" ] || return 1
+  printf '%s' "$found"
+}
+
+endpoint_is_safe_idle() {
+  local agent path composer busy cap live_effort
+  agent=$(fm_backend_agent_state "$backend" "$target")
+  [ "$agent" = alive ] || refuse "task $task_id endpoint state is '$agent', not a verified live Codex agent."
+  path=$(current_path)
+  [ "$path" = "$worktree" ] || refuse "task $task_id live worktree does not match its recorded worktree."
+  if [ "$backend" = herdr ]; then
+    busy=$(fm_backend_busy_state "$backend" "$target")
+    [ "$busy" = idle ] || refuse "task $task_id native agent state is '$busy', not idle."
+  fi
+  cap=$(capture_tail) || refuse "task $task_id UI could not be read."
+  if printf '%s\n' "$cap" | grep -qi 'esc to interrupt'; then
+    refuse "task $task_id has a busy Codex turn."
+  fi
+  composer=$(fm_backend_composer_state "$backend" "$target")
+  [ "$composer" = empty ] || refuse "task $task_id composer state is '$composer', not verified empty."
+  live_effort=$(footer_effort) || refuse "task $task_id has no verifiable Codex model/effort footer."
+  printf '%s' "$live_effort"
+}
+
+live_effort=$(endpoint_is_safe_idle) || exit 1
+[ "$live_effort" = "$recorded_effort" ] \
+  || refuse "task $task_id live effort '$live_effort' disagrees with recorded effort '$recorded_effort'."
+
+rank_of() {
+  case "$1" in
+    low) printf 1 ;;
+    medium) printf 2 ;;
+    high) printf 3 ;;
+    xhigh) printf 4 ;;
+  esac
+}
+
+send_effort_step() {  # <up|down>
+  local direction=$1
+  case "$backend:$direction" in
+    herdr:up) fm_backend_herdr_send_literal "$target" "$(printf '\033.')" ;;
+    herdr:down) fm_backend_herdr_send_literal "$target" "$(printf '\033,')" ;;
+    tmux:up) fm_backend_tmux_send_key "$target" M-. ;;
+    tmux:down) fm_backend_tmux_send_key "$target" M-, ;;
+    *) return 1 ;;
+  esac
+}
+
+next_effort() {  # <effort> <up|down>
+  case "$1:$2" in
+    low:up) printf medium ;;
+    medium:up) printf high ;;
+    high:up) printf xhigh ;;
+    xhigh:down) printf high ;;
+    high:down) printf medium ;;
+    medium:down) printf low ;;
+    *) return 1 ;;
+  esac
+}
+
+current_rank=$(rank_of "$live_effort")
+requested_rank=$(rank_of "$requested_effort")
+while [ "$current_rank" -ne "$requested_rank" ]; do
+  if [ "$current_rank" -lt "$requested_rank" ]; then direction=up
+  else direction=down
+  fi
+  expected=$(next_effort "$live_effort" "$direction") \
+    || refuse "cannot move from effort '$live_effort' toward '$requested_effort'."
+  [ "$(cksum < "$meta")" = "$meta_fingerprint" ] \
+    || refuse "task $task_id metadata changed before the live effort switch completed."
+  send_effort_step "$direction" \
+    || refuse "backend '$backend' could not deliver the Codex reasoning keybinding."
+  confirmed=
+  attempt=0
+  while [ "$attempt" -lt 20 ]; do
+    sleep 0.05
+    confirmed=$(footer_effort 2>/dev/null || true)
+    [ "$confirmed" = "$expected" ] && break
+    attempt=$((attempt + 1))
+  done
+  [ "$confirmed" = "$expected" ] \
+    || refuse "Codex did not confirm expected effort '$expected' after input; metadata is unchanged."
+  live_effort=$confirmed
+  current_rank=$(rank_of "$live_effort")
+done
+
+final_effort=$(endpoint_is_safe_idle) || exit 1
+[ "$final_effort" = "$requested_effort" ] \
+  || refuse "final Codex footer did not confirm effort '$requested_effort'."
+[ "$(cksum < "$meta")" = "$meta_fingerprint" ] \
+  || refuse "task $task_id metadata changed before confirmation; live effort changed but metadata was preserved."
+fm_backend_validate_task_endpoint "$meta" "$task_id" >/dev/null \
+  || refuse "task $task_id endpoint identity changed before metadata update."
+[ "$FM_BACKEND_VALIDATED_BACKEND" = "$backend" ] \
+  && [ "$FM_BACKEND_VALIDATED_TARGET" = "$target" ] \
+  || refuse "task $task_id endpoint changed before metadata update."
+
+tmp_meta=$(mktemp "$STATE/.$task_id.meta.XXXXXX") \
+  || refuse "could not create a metadata update beside $meta."
+awk -v effort="$requested_effort" '
+  /^effort=/ { print "effort=" effort; next }
+  { print }
+' "$meta" > "$tmp_meta" || refuse "could not prepare metadata update."
+if mode=$(stat -c %a "$meta" 2>/dev/null); then :
+elif mode=$(stat -f %Lp "$meta" 2>/dev/null); then :
+else mode=600
+fi
+chmod "$mode" "$tmp_meta" || refuse "could not preserve metadata permissions."
+mv -f -- "$tmp_meta" "$meta" || refuse "could not atomically record the confirmed effort."
+tmp_meta=
+
+printf '%s: %s %s (%s, session preserved)\n' "$task_id" "$model" "$requested_effort" "$backend"

--- a/bin/fm-codex-effort.sh
+++ b/bin/fm-codex-effort.sh
@@ -8,12 +8,15 @@
 # The task must be an idle Codex TUI recorded on Herdr.
 # Herdr is the preferred production path and receives the verified literal
 # Alt+, or Alt+. byte chord through pane send-text.
-# The installed Codex 0.146.0 exposes these bindings as Chat Decrease Reasoning
-# and Chat Increase Reasoning in /keymap.
+# Codex 0.146.0 exposes these bindings as Chat Decrease Reasoning and Chat
+# Increase Reasoning in /keymap.
+# Codex 0.147.0 renders the verified footer with an optional home-abbreviated
+# worktree and a trailing Context percentage.
 #
 # This operation fails closed unless task identity, harness, backend endpoint,
 # live agent, worktree, empty composer, and the current model/effort footer all
 # agree before input.
+# Its per-task endpoint input lock serializes every chord with ordinary steering and repeats the semantic idle and empty-composer checks before every chord.
 # It verifies every one-level transition from the rendered Codex footer and
 # revalidates the unchanged endpoint before atomically replacing effort= in
 # state/<id>.meta.
@@ -78,6 +81,8 @@ fm_task_id_creation_valid "$task_id" || refuse "invalid task id."
 control_lock="$STATE/.control-$task_id.lock"
 meta_lock=$(fm_meta_lock_path "$meta") \
   || refuse "could not resolve the metadata lock for task $task_id."
+input_lock=$(fm_task_input_lock_path "$STATE" "$task_id") \
+  || refuse "could not resolve the endpoint input lock for task $task_id."
 if ! fm_lock_try_acquire "$control_lock"; then
   refuse "another lifecycle action is already running for task $task_id."
 fi
@@ -88,6 +93,7 @@ if ! fm_lock_try_acquire "$meta_lock"; then
   refuse "another metadata update is already running for task $task_id."
 fi
 meta_lock_held=1
+input_lock_held=0
 tmp_meta=
 tmp_recovery=
 recovery="$STATE/$task_id.codex-effort-recovery"
@@ -97,6 +103,10 @@ cleanup() {
   if [ "$meta_lock_held" = 1 ]; then
     fm_lock_release "$meta_lock"
     meta_lock_held=0
+  fi
+  if [ "$input_lock_held" = 1 ]; then
+    fm_lock_release "$input_lock"
+    input_lock_held=0
   fi
   if [ "$control_lock_held" = 1 ]; then
     fm_lock_release "$control_lock"
@@ -134,6 +144,10 @@ meta_fingerprint=$(cksum < "$meta") || refuse "could not fingerprint task metada
 
 fm_backend_source "$backend" || refuse "could not load backend '$backend'."
 
+fm_lock_acquire_wait "$input_lock" \
+  || refuse "could not acquire the endpoint input lock for task $task_id."
+input_lock_held=1
+
 current_path() {
   fm_backend_herdr_current_path "$target"
 }
@@ -143,7 +157,7 @@ capture_tail() {
 }
 
 footer_effort_from_capture() {  # <captured-screen>
-  local cap=$1 line footer=
+  local cap=$1 line footer='' effort displayed_worktree
   while IFS= read -r line; do
     line=${line#"${line%%[![:space:]]*}"}
     line=${line%"${line##*[![:space:]]}"}
@@ -151,13 +165,25 @@ footer_effort_from_capture() {  # <captured-screen>
   done <<EOF
 $cap
 EOF
-  case "$footer" in
-    "$model low · $worktree") printf low ;;
-    "$model medium · $worktree") printf medium ;;
-    "$model high · $worktree") printf high ;;
-    "$model xhigh · $worktree") printf xhigh ;;
-    *) return 1 ;;
-  esac
+  for effort in low medium high xhigh; do
+    displayed_worktree=$worktree
+    case "$footer" in
+      "$model $effort · $displayed_worktree"|"$model $effort · $displayed_worktree · Context "[0-9]*'% use…')
+        printf '%s' "$effort"
+        return 0
+        ;;
+    esac
+    if [ -n "${HOME:-}" ] && [ "${worktree#"$HOME"/}" != "$worktree" ]; then
+      displayed_worktree="~${worktree#"$HOME"}"
+      case "$footer" in
+        "$model $effort · $displayed_worktree"|"$model $effort · $displayed_worktree · Context "[0-9]*'% use…')
+          printf '%s' "$effort"
+          return 0
+          ;;
+      esac
+    fi
+  done
+  return 1
 }
 
 footer_effort() {
@@ -346,6 +372,9 @@ while [ "$current_rank" -ne "$requested_rank" ]; do
     || refuse "cannot move from effort '$live_effort' toward '$requested_effort'."
   metadata_fingerprint_matches \
     || refuse "task $task_id metadata changed before the live effort switch completed."
+  rechecked_effort=$(endpoint_is_safe_idle) || exit 1
+  [ "$rechecked_effort" = "$live_effort" ] \
+    || refuse "task $task_id live effort changed before its reasoning chord."
   send_effort_step "$direction" \
     || refuse "backend '$backend' could not deliver the Codex reasoning keybinding."
   confirmed=

--- a/bin/fm-codex-effort.sh
+++ b/bin/fm-codex-effort.sh
@@ -5,10 +5,9 @@
 #   FM_HOME=/absolute/firstmate/home bin/fm-codex-effort.sh <task-id> <effort>
 #
 # Supported efforts are low, medium, high, and xhigh.
-# The task must be an idle Codex TUI recorded on Herdr or tmux.
+# The task must be an idle Codex TUI recorded on Herdr.
 # Herdr is the preferred production path and receives the verified literal
 # Alt+, or Alt+. byte chord through pane send-text.
-# Tmux receives the same public Codex keybinding through tmux's M-, or M-.
 # The installed Codex 0.146.0 exposes these bindings as Chat Decrease Reasoning
 # and Chat Increase Reasoning in /keymap.
 #
@@ -18,10 +17,13 @@
 # It verifies every one-level transition from the rendered Codex footer and
 # revalidates the unchanged endpoint before atomically replacing effort= in
 # state/<id>.meta.
+# Before its first chord it writes a durable recovery record, so a delivered
+# chord followed by interruption, a UI failure, or metadata-write failure is
+# reconciled from the next verified live footer before any further input.
 # It never submits a turn, changes the model, exits or resumes Codex, changes
 # the worktree, or rewrites task ownership.
 # A swallowed chord, changed UI, busy turn, ambiguous state, or missing footer
-# leaves metadata unchanged and reports refusal.
+# leaves metadata unchanged and reports refusal with any recovery record intact.
 set -u
 
 ROOT="${FM_ROOT_OVERRIDE:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
@@ -32,7 +34,7 @@ usage() {
 Usage: FM_HOME=/absolute/firstmate/home bin/fm-codex-effort.sh <task-id> <low|medium|high|xhigh>
 
 Switch an idle Codex crewmate's reasoning effort without ending its session.
-Only verified Herdr and tmux task endpoints are supported.
+Only the verified Herdr task endpoint is currently supported.
 USAGE
 }
 
@@ -87,8 +89,11 @@ if ! fm_lock_try_acquire "$meta_lock"; then
 fi
 meta_lock_held=1
 tmp_meta=
+tmp_recovery=
+recovery="$STATE/$task_id.codex-effort-recovery"
 cleanup() {
   [ -z "$tmp_meta" ] || rm -f -- "$tmp_meta" 2>/dev/null || true
+  [ -z "$tmp_recovery" ] || rm -f -- "$tmp_recovery" 2>/dev/null || true
   if [ "$meta_lock_held" = 1 ]; then
     fm_lock_release "$meta_lock"
     meta_lock_held=0
@@ -107,7 +112,8 @@ fm_backend_validate_task_endpoint "$meta" "$task_id" || exit 1
 backend=$FM_BACKEND_VALIDATED_BACKEND
 target=$FM_BACKEND_VALIDATED_TARGET
 case "$backend" in
-  herdr|tmux) ;;
+  herdr) ;;
+  tmux) refuse "task $task_id has no verified semantic Codex idle source on tmux." ;;
   *) refuse "backend '$backend' has no verified in-session Codex effort-switch path." ;;
 esac
 
@@ -129,33 +135,35 @@ meta_fingerprint=$(cksum < "$meta") || refuse "could not fingerprint task metada
 fm_backend_source "$backend" || refuse "could not load backend '$backend'."
 
 current_path() {
-  case "$backend" in
-    herdr) fm_backend_herdr_current_path "$target" ;;
-    tmux) fm_backend_tmux_current_path "$target" ;;
-  esac
+  fm_backend_herdr_current_path "$target"
 }
 
 capture_tail() {
   fm_backend_capture "$backend" "$target" 40 2>/dev/null | tail -n 20
 }
 
-footer_effort() {
-  local cap line effort found=
-  cap=$(capture_tail) || return 1
+footer_effort_from_capture() {  # <captured-screen>
+  local cap=$1 line footer=
   while IFS= read -r line; do
-    case "$line" in
-      *"$model low ·"*) effort=low ;;
-      *"$model medium ·"*) effort=medium ;;
-      *"$model high ·"*) effort=high ;;
-      *"$model xhigh ·"*) effort=xhigh ;;
-      *) continue ;;
-    esac
-    found=$effort
+    line=${line#"${line%%[![:space:]]*}"}
+    line=${line%"${line##*[![:space:]]}"}
+    [ -n "$line" ] && footer=$line
   done <<EOF
 $cap
 EOF
-  [ -n "$found" ] || return 1
-  printf '%s' "$found"
+  case "$footer" in
+    "$model low · $worktree") printf low ;;
+    "$model medium · $worktree") printf medium ;;
+    "$model high · $worktree") printf high ;;
+    "$model xhigh · $worktree") printf xhigh ;;
+    *) return 1 ;;
+  esac
+}
+
+footer_effort() {
+  local cap
+  cap=$(capture_tail) || return 1
+  footer_effort_from_capture "$cap"
 }
 
 endpoint_is_safe_idle() {
@@ -164,23 +172,18 @@ endpoint_is_safe_idle() {
   [ "$agent" = alive ] || refuse "task $task_id endpoint state is '$agent', not a verified live Codex agent."
   path=$(current_path)
   [ "$path" = "$worktree" ] || refuse "task $task_id live worktree does not match its recorded worktree."
-  if [ "$backend" = herdr ]; then
-    busy=$(fm_backend_busy_state "$backend" "$target")
-    [ "$busy" = idle ] || refuse "task $task_id native agent state is '$busy', not idle."
-  fi
+  busy=$(fm_backend_busy_state "$backend" "$target")
+  [ "$busy" = idle ] || refuse "task $task_id native agent state is '$busy', not idle."
   cap=$(capture_tail) || refuse "task $task_id UI could not be read."
   if printf '%s\n' "$cap" | grep -qi 'esc to interrupt'; then
     refuse "task $task_id has a busy Codex turn."
   fi
   composer=$(fm_backend_composer_state "$backend" "$target")
   [ "$composer" = empty ] || refuse "task $task_id composer state is '$composer', not verified empty."
-  live_effort=$(footer_effort) || refuse "task $task_id has no verifiable Codex model/effort footer."
+  live_effort=$(footer_effort_from_capture "$cap") \
+    || refuse "task $task_id has no verifiable Codex model/effort footer."
   printf '%s' "$live_effort"
 }
-
-live_effort=$(endpoint_is_safe_idle) || exit 1
-[ "$live_effort" = "$recorded_effort" ] \
-  || refuse "task $task_id live effort '$live_effort' disagrees with recorded effort '$recorded_effort'."
 
 rank_of() {
   case "$1" in
@@ -196,8 +199,6 @@ send_effort_step() {  # <up|down>
   case "$backend:$direction" in
     herdr:up) fm_backend_herdr_send_literal "$target" "$(printf '\033.')" ;;
     herdr:down) fm_backend_herdr_send_literal "$target" "$(printf '\033,')" ;;
-    tmux:up) fm_backend_tmux_send_key "$target" M-. ;;
-    tmux:down) fm_backend_tmux_send_key "$target" M-, ;;
     *) return 1 ;;
   esac
 }
@@ -214,15 +215,136 @@ next_effort() {  # <effort> <up|down>
   esac
 }
 
+metadata_identity_checksum() {
+  awk '!/^effort=/' "$meta" | cksum
+}
+
+metadata_fingerprint_matches() {
+  [ "$(cksum < "$meta")" = "$meta_fingerprint" ]
+}
+
+verify_unchanged_endpoint() {
+  fm_backend_validate_task_endpoint "$meta" "$task_id" >/dev/null \
+    || refuse "task $task_id endpoint identity changed before metadata update."
+  [ "$FM_BACKEND_VALIDATED_BACKEND" = "$backend" ] \
+    && [ "$FM_BACKEND_VALIDATED_TARGET" = "$target" ] \
+    || refuse "task $task_id endpoint changed before metadata update."
+}
+
+replace_metadata_effort() {  # <effort>
+  local effort=$1 mode
+  tmp_meta=$(mktemp "$STATE/.$task_id.meta.XXXXXX") \
+    || refuse "could not create a metadata update beside $meta."
+  awk -v effort="$effort" '
+    /^effort=/ { print "effort=" effort; next }
+    { print }
+  ' "$meta" > "$tmp_meta" || refuse "could not prepare metadata update."
+  if mode=$(stat -c %a "$meta" 2>/dev/null); then :
+  elif mode=$(stat -f %Lp "$meta" 2>/dev/null); then :
+  else mode=600
+  fi
+  chmod "$mode" "$tmp_meta" || refuse "could not preserve metadata permissions."
+  mv -f -- "$tmp_meta" "$meta" || refuse "could not atomically record the confirmed effort."
+  tmp_meta=
+}
+
+begin_recovery() {
+  local identity_checksum
+  [ ! -e "$recovery" ] && [ ! -L "$recovery" ] \
+    || refuse "task $task_id already has an unresolved Codex effort recovery record."
+  identity_checksum=$(metadata_identity_checksum) \
+    || refuse "could not fingerprint task metadata identity for recovery."
+  tmp_recovery=$(mktemp "$STATE/.$task_id.codex-effort-recovery.XXXXXX") \
+    || refuse "could not prepare a Codex effort recovery record."
+  {
+    printf '%s\n' \
+      'version=1' \
+      "task_id=$task_id" \
+      "backend=$backend" \
+      "target=$target" \
+      "harness=$harness" \
+      "model=$model" \
+      "worktree=$worktree" \
+      "metadata_identity_checksum=$identity_checksum" \
+      "recorded_effort=$recorded_effort" \
+      "requested_effort=$requested_effort"
+  } > "$tmp_recovery" || refuse "could not write a Codex effort recovery record."
+  chmod 600 "$tmp_recovery" || refuse "could not secure a Codex effort recovery record."
+  mv -f -- "$tmp_recovery" "$recovery" \
+    || refuse "could not durably start Codex effort recovery."
+  tmp_recovery=
+}
+
+recovery_value() {  # <key>
+  fm_backend_meta_exact_value "$recovery" "$1"
+}
+
+validate_recovery() {
+  local value current_identity
+  [ -f "$recovery" ] && [ ! -L "$recovery" ] \
+    || refuse "task $task_id has a non-regular Codex effort recovery record."
+  value=$(recovery_value version) || refuse "task $task_id has malformed Codex effort recovery metadata."
+  [ "$value" = 1 ] || refuse "task $task_id has an unsupported Codex effort recovery record."
+  value=$(recovery_value task_id) || refuse "task $task_id has malformed Codex effort recovery metadata."
+  [ "$value" = "$task_id" ] || refuse "task $task_id recovery record belongs to another task."
+  value=$(recovery_value backend) || refuse "task $task_id has malformed Codex effort recovery metadata."
+  [ "$value" = "$backend" ] || refuse "task $task_id recovery backend no longer matches its endpoint."
+  value=$(recovery_value target) || refuse "task $task_id has malformed Codex effort recovery metadata."
+  [ "$value" = "$target" ] || refuse "task $task_id recovery target no longer matches its endpoint."
+  value=$(recovery_value harness) || refuse "task $task_id has malformed Codex effort recovery metadata."
+  [ "$value" = "$harness" ] || refuse "task $task_id recovery harness no longer matches metadata."
+  value=$(recovery_value model) || refuse "task $task_id has malformed Codex effort recovery metadata."
+  [ "$value" = "$model" ] || refuse "task $task_id recovery model no longer matches metadata."
+  value=$(recovery_value worktree) || refuse "task $task_id has malformed Codex effort recovery metadata."
+  [ "$value" = "$worktree" ] || refuse "task $task_id recovery worktree no longer matches metadata."
+  value=$(recovery_value recorded_effort) || refuse "task $task_id has malformed Codex effort recovery metadata."
+  case "$value" in low|medium|high|xhigh) ;; *) refuse "task $task_id recovery effort is invalid." ;; esac
+  value=$(recovery_value requested_effort) || refuse "task $task_id has malformed Codex effort recovery metadata."
+  case "$value" in low|medium|high|xhigh) ;; *) refuse "task $task_id recovery requested effort is invalid." ;; esac
+  current_identity=$(metadata_identity_checksum) \
+    || refuse "could not fingerprint task metadata identity during recovery."
+  value=$(recovery_value metadata_identity_checksum) \
+    || refuse "task $task_id has malformed Codex effort recovery metadata."
+  [ "$value" = "$current_identity" ] \
+    || refuse "task $task_id metadata identity changed during Codex effort recovery."
+}
+
+reconcile_recovery() {
+  local observed_effort
+  validate_recovery
+  observed_effort=$(endpoint_is_safe_idle) || exit 1
+  if [ "$observed_effort" != "$recorded_effort" ]; then
+    metadata_fingerprint_matches \
+      || refuse "task $task_id metadata changed before Codex effort recovery."
+    verify_unchanged_endpoint
+    replace_metadata_effort "$observed_effort"
+    recorded_effort=$observed_effort
+    meta_fingerprint=$(cksum < "$meta") \
+      || refuse "could not fingerprint reconciled task metadata."
+  fi
+  rm -f -- "$recovery" \
+    || refuse "task $task_id live effort was reconciled but its recovery record could not be removed."
+}
+
+if [ -e "$recovery" ] || [ -L "$recovery" ]; then
+  reconcile_recovery
+fi
+live_effort=$(endpoint_is_safe_idle) || exit 1
+[ "$live_effort" = "$recorded_effort" ] \
+  || refuse "task $task_id live effort '$live_effort' disagrees with recorded effort '$recorded_effort'."
+
 current_rank=$(rank_of "$live_effort")
 requested_rank=$(rank_of "$requested_effort")
+if [ "$current_rank" -ne "$requested_rank" ]; then
+  begin_recovery
+fi
 while [ "$current_rank" -ne "$requested_rank" ]; do
   if [ "$current_rank" -lt "$requested_rank" ]; then direction=up
   else direction=down
   fi
   expected=$(next_effort "$live_effort" "$direction") \
     || refuse "cannot move from effort '$live_effort' toward '$requested_effort'."
-  [ "$(cksum < "$meta")" = "$meta_fingerprint" ] \
+  metadata_fingerprint_matches \
     || refuse "task $task_id metadata changed before the live effort switch completed."
   send_effort_step "$direction" \
     || refuse "backend '$backend' could not deliver the Codex reasoning keybinding."
@@ -243,26 +365,14 @@ done
 final_effort=$(endpoint_is_safe_idle) || exit 1
 [ "$final_effort" = "$requested_effort" ] \
   || refuse "final Codex footer did not confirm effort '$requested_effort'."
-[ "$(cksum < "$meta")" = "$meta_fingerprint" ] \
+[ "$current_rank" = "$requested_rank" ] || refuse "Codex did not reach the requested effort."
+metadata_fingerprint_matches \
   || refuse "task $task_id metadata changed before confirmation; live effort changed but metadata was preserved."
-fm_backend_validate_task_endpoint "$meta" "$task_id" >/dev/null \
-  || refuse "task $task_id endpoint identity changed before metadata update."
-[ "$FM_BACKEND_VALIDATED_BACKEND" = "$backend" ] \
-  && [ "$FM_BACKEND_VALIDATED_TARGET" = "$target" ] \
-  || refuse "task $task_id endpoint changed before metadata update."
-
-tmp_meta=$(mktemp "$STATE/.$task_id.meta.XXXXXX") \
-  || refuse "could not create a metadata update beside $meta."
-awk -v effort="$requested_effort" '
-  /^effort=/ { print "effort=" effort; next }
-  { print }
-' "$meta" > "$tmp_meta" || refuse "could not prepare metadata update."
-if mode=$(stat -c %a "$meta" 2>/dev/null); then :
-elif mode=$(stat -f %Lp "$meta" 2>/dev/null); then :
-else mode=600
+verify_unchanged_endpoint
+replace_metadata_effort "$requested_effort"
+if [ -e "$recovery" ] || [ -L "$recovery" ]; then
+  rm -f -- "$recovery" \
+    || refuse "task $task_id switched effort but its recovery record could not be removed."
 fi
-chmod "$mode" "$tmp_meta" || refuse "could not preserve metadata permissions."
-mv -f -- "$tmp_meta" "$meta" || refuse "could not atomically record the confirmed effort."
-tmp_meta=
 
 printf '%s: %s %s (%s, session preserved)\n' "$task_id" "$model" "$requested_effort" "$backend"

--- a/bin/fm-codex-effort.sh
+++ b/bin/fm-codex-effort.sh
@@ -72,14 +72,30 @@ meta="$STATE/$task_id.meta"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$ROOT/bin/fm-wake-lib.sh"
 
-lock="$STATE/.codex-effort-$task_id.lock"
-if ! fm_lock_try_acquire "$lock"; then
-  refuse "another effort-switch operation already owns task $task_id."
+control_lock="$STATE/.control-$task_id.lock"
+meta_lock=$(fm_meta_lock_path "$meta") \
+  || refuse "could not resolve the metadata lock for task $task_id."
+if ! fm_lock_try_acquire "$control_lock"; then
+  refuse "another lifecycle action is already running for task $task_id."
 fi
+control_lock_held=1
+if ! fm_lock_try_acquire "$meta_lock"; then
+  fm_lock_release "$control_lock"
+  control_lock_held=0
+  refuse "another metadata update is already running for task $task_id."
+fi
+meta_lock_held=1
 tmp_meta=
 cleanup() {
   [ -z "$tmp_meta" ] || rm -f -- "$tmp_meta" 2>/dev/null || true
-  fm_lock_release "$lock"
+  if [ "$meta_lock_held" = 1 ]; then
+    fm_lock_release "$meta_lock"
+    meta_lock_held=0
+  fi
+  if [ "$control_lock_held" = 1 ]; then
+    fm_lock_release "$control_lock"
+    control_lock_held=0
+  fi
 }
 trap cleanup EXIT
 trap 'exit 129' HUP

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -17,6 +17,8 @@
 # instead of silently leaving an unsubmitted instruction.
 # Submission dispatches through the target's recorded backend; the tmux adapter
 # shares its composer/submit core with the away-mode daemon via bin/fm-tmux-lib.sh.
+# Every recorded-task input transaction, including --key, holds the shared
+# endpoint input lock through its backend delivery and confirmation path.
 # Tune with FM_SEND_RETRIES (default 3) / FM_SEND_SLEEP (0.4).
 # Slash commands, and codex `$...` skill invocations resolved through harness
 # meta, get a longer pre-Enter settle so completion popups do not swallow Enter.
@@ -440,6 +442,7 @@ if [ "${1:-}" = "--key" ]; then
   esac
   key=$2
   semantic_key=$(fm_send_normalize_key "$key")
+  fm_send_acquire_task_input_lock || exit 1
   if [ "$TARGET_BACKEND" = remote ]; then
     if ! "$SCRIPT_DIR/fm-on.sh" "$TARGET_REMOTE_ID" fm-remote-secondmate-control.sh key "$TARGET_REMOTE_ID" "$key" < /dev/null; then
       echo "error: key '$key' not sent to remote secondmate $TARGET_REMOTE_ID; completion may be unknown" >&2

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -338,10 +338,30 @@ MARK_FROM_FIRSTMATE=0
 PENDING_REPLY_CORR=
 PENDING_REPLY_CREATED=0
 TARGET_TASK_ID=
-if [ -n "$TARGET_SELECTOR" ] && [ -n "$TARGET_META" ] && [ "$(fm_meta_get "$TARGET_META" kind)" = secondmate ]; then
-  MARK_FROM_FIRSTMATE=1
+if [ -n "$TARGET_META" ]; then
   TARGET_TASK_ID=$(fm_send_id_from_meta "$TARGET_META")
+  if [ -n "$TARGET_SELECTOR" ] && [ "$(fm_meta_get "$TARGET_META" kind)" = secondmate ]; then
+    MARK_FROM_FIRSTMATE=1
+  fi
 fi
+
+INPUT_LOCK=
+INPUT_LOCK_HELD=0
+fm_send_release_input_lock() {
+  if [ "$INPUT_LOCK_HELD" = 1 ]; then
+    fm_lock_release "$INPUT_LOCK"
+    INPUT_LOCK_HELD=0
+  fi
+}
+fm_send_acquire_task_input_lock() {
+  [ -n "$TARGET_TASK_ID" ] || return 0
+  INPUT_LOCK=$(fm_task_input_lock_path "$STATE" "$TARGET_TASK_ID") \
+    || { echo "error: cannot resolve the endpoint input lock for task $TARGET_TASK_ID" >&2; return 1; }
+  fm_lock_acquire_wait "$INPUT_LOCK" \
+    || { echo "error: could not acquire the endpoint input lock for task $TARGET_TASK_ID; message was not sent" >&2; return 1; }
+  INPUT_LOCK_HELD=1
+}
+trap fm_send_release_input_lock EXIT
 
 # Validate the answerer-closes request before any durable mutation or send: the
 # target must have a task ledger in THIS home, the send must carry an answer
@@ -433,6 +453,7 @@ if [ "${1:-}" = "--key" ]; then
   fm_send_record_interrupt "$semantic_key" || exit 1
 else
   MESSAGE=$*
+  fm_send_acquire_task_input_lock || exit 1
   # The pre-marker answer text, kept for the closing resolved note so the
   # durable ledger records the plain answer without marker or corr bytes.
   RESOLVE_ANSWER_TEXT=$MESSAGE

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -393,7 +393,7 @@ remote_secondmate_teardown() {
   grep -vE "^- $ID( |$)" "$SECONDMATE_REG" > "$tmp" || true
   mv -f -- "$tmp" "$SECONDMATE_REG"
   rm -f -- "$STATE/$ID.status" "$STATE/$ID.meta" "$STATE/$ID.turn-ended" \
-    "$STATE/.$ID.open-decisions-cursor"
+    "$STATE/.$ID.open-decisions-cursor" "$STATE/$ID.codex-effort-recovery"
   printf 'teardown %s complete (remote %s:%s)\n' "$ID" "$remote_host" "$remote_home"
   return 0
 }
@@ -2259,7 +2259,7 @@ cleanup_firstmate_home_children() {
       "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" \
       "$sub_state/$child_id.grok-turnend-token" "$sub_state/$child_id.kimi-turnend-token" \
       "$sub_state/$child_id.muse-session" "$sub_state/$child_id.muse-session-current" \
-      "$sub_state/$child_id.cursor-session"
+      "$sub_state/$child_id.cursor-session" "$sub_state/$child_id.codex-effort-recovery"
   done
 }
 
@@ -2538,6 +2538,7 @@ rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
   "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
   "$STATE/$ID.kimi-turnend-token" "$STATE/$ID.muse-session" \
   "$STATE/$ID.muse-session-current" "$STATE/$ID.cursor-session" \
+  "$STATE/$ID.codex-effort-recovery" \
   "$STATE/.$ID.open-decisions-cursor" \
   "$STATE/$ID.control-relaunch" "$STATE/$ID.control-relaunch.meta-prior" \
   "$STATE/$ID.control-relaunch.brief-prior" "$STATE/$ID.control-relaunch.note"

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -193,6 +193,7 @@ family_for_basename() {
       printf '%s\n' live-harness-optin
       ;;
     fm-backend-herdr.test.sh|fm-backend-tmux-smoke.test.sh|fm-backend.test.sh|\
+    fm-codex-effort.test.sh|\
     fm-tmux-agent-liveness.test.sh|\
     fm-control.test.sh|fm-control-relaunch.test.sh|\
     fm-herdr-session-cleanup.test.sh|fm-send-resolve-key.test.sh|fm-send-strict.test.sh|fm-spawn-batch.test.sh|\
@@ -394,6 +395,7 @@ tests/fm-busy-state.test.sh 607
 tests/fm-calm-pi-extension.test.sh 203
 tests/fm-claude-stop-autoarm-live-e2e.test.sh 19
 tests/fm-claude-stop-autoarm.test.sh 60521
+tests/fm-codex-effort.test.sh 4000
 tests/fm-codex-continuity-live-e2e.test.sh 19
 tests/fm-daemon.test.sh 15140
 tests/fm-documentation-audiences.test.sh 572
@@ -943,7 +945,7 @@ families_for_changed_path() {
       printf '%s\n' pure-contract-unit
       printf '%s\n' live-harness-optin
       ;;
-    bin/fm-spawn.sh|bin/fm-send.sh|bin/fm-harness.sh|\
+    bin/fm-spawn.sh|bin/fm-send.sh|bin/fm-harness.sh|bin/fm-codex-effort.sh|\
     bin/fm-peek.sh|bin/fm-composer*)
       printf '%s\n' backend-dispatch
       printf '%s\n' pure-contract-unit

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -881,7 +881,7 @@ families_for_changed_path() {
       printf '%s\n' backend-dispatch
       printf '%s\n' real-herdr-gated
       ;;
-    bin/fm-watch*|bin/fm-wake*|bin/fm-inactive-reconcile.sh|\
+    bin/fm-watch*|bin/fm-wake-drain.sh|bin/fm-inactive-reconcile.sh|\
     bin/fm-classify-lib.sh|bin/fm-daemon*|bin/fm-turnend-guard*|bin/fm-guard.sh)
       printf '%s\n' watcher-wake-lock
       ;;
@@ -907,8 +907,11 @@ families_for_changed_path() {
       ;;
     bin/fm-session-start.sh|bin/fm-bootstrap.sh|bin/fm-fleet-sync.sh|\
     bin/fm-sessionstart-nudge.sh|bin/fm-startup-network.sh|bin/fm-tangle*|bin/fm-update.sh|\
-    bin/fm-gate-refuse*|bin/fm-lock*|bin/fm-quota-axi-lib.sh)
+    bin/fm-gate-refuse*|bin/fm-lock*|bin/fm-wake-lib.sh|bin/fm-quota-axi-lib.sh)
       printf '%s\n' session-bootstrap
+      printf '%s\n' watcher-wake-lock
+      printf '%s\n' backend-dispatch
+      printf '%s\n' pr-forge
       ;;
     bin/fm-sessionstart-run.sh|.claude/settings.json|.codex/hooks.json|\
     .pi/extensions/fm-primary-turnend-guard.ts)

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -771,6 +771,19 @@ fm_meta_lock_path() {
   printf '%s/.meta-%s.lock\n' "$dir" "$id"
 }
 
+# fm_task_input_lock_path serializes input transactions for one recorded task endpoint.
+# Lifecycle and metadata locks protect ownership and durable task records.
+# They intentionally do not make a read-composer/send-input sequence atomic with ordinary steering.
+# Every runtime-facing input producer for a recorded task shares this lock instead.
+fm_task_input_lock_path() {  # <state-dir> <task-id>
+  local state=$1 id=$2 state_real
+  case "$id" in
+    ''|.*|*[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+  state_real=$(CDPATH='' cd -- "$state" 2>/dev/null && pwd -P) || return 1
+  printf '%s/.input-%s.lock\n' "$state_real" "$id"
+}
+
 # fm_task_set_lock_path: the per-home lock guarding WHICH tasks exist in a home,
 # as opposed to fm_meta_lock_path, which guards one task's record.
 #

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -257,6 +257,14 @@
       "audience": "operator-example"
     },
     {
+      "path": "tests/fixtures/codex-effort/codex-0.147-absolute-footer.txt",
+      "audience": "maintainer-verification"
+    },
+    {
+      "path": "tests/fixtures/codex-effort/codex-0.147-home-abbreviated-footer.txt",
+      "audience": "maintainer-verification"
+    },
+    {
       "path": "docs/fm-test-isolation-proof.md",
       "audience": "maintainer-verification"
     },

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -8,9 +8,11 @@ Exact task chronology, branch names, temporary homes, local paths, process ids, 
 
 ## Codex in-session reasoning effort
 
-Codex CLI 0.146.0 was verified on 2026-08-03 against the current [official model guidance](https://learn.chatgpt.com/docs/models.md) and [official CLI slash-command reference](https://learn.chatgpt.com/docs/developer-commands.md?surface=cli).
+Codex CLI 0.146.0 keybindings were verified on 2026-08-03 against the current [official model guidance](https://learn.chatgpt.com/docs/models.md) and [official CLI slash-command reference](https://learn.chatgpt.com/docs/developer-commands.md?surface=cli).
 The official guidance says an interactive CLI session can use `/model` to adjust reasoning effort, and the CLI reference lists `/model` as choosing the active model and effort when available.
 The installed `/keymap` UI exposed Chat Decrease Reasoning as `alt-,` and `shift-down`, and Chat Increase Reasoning as `alt-.` and `shift-up`.
+Codex CLI 0.147.0 footer captures additionally verified the current status row as `<model> <effort> · <worktree> · Context <n>% use…`.
+The CLI abbreviates a worktree below the operator home as `~`, so the parser accepts only an exact recorded absolute path or that exact home abbreviation.
 
 The interfaces considered were:
 
@@ -49,7 +51,7 @@ The exact session was exited and killed after the bounded check.
 `bin/fm-codex-effort.sh` uses literal `ESC .` and `ESC ,` on Herdr.
 It supports only idle Herdr Codex tasks whose endpoint identity, native agent state, live agent, current worktree, empty composer, and current model and effort footer are all verified.
 It treats tmux's observed `M-.` and `M-,` behavior as compatibility evidence only, because current Codex tmux workers have no verified semantic idle source and must refuse before any chord.
-It writes a durable recovery record before its first chord, checks each adjacent transition, revalidates the endpoint, and atomically updates only `effort=` after the final footer confirmation.
+It writes a durable recovery record before its first chord, serializes its chords with ordinary recorded-task steering through a shared endpoint input lock, checks each adjacent transition, revalidates semantic idle and the empty composer under that lock immediately before every chord, and atomically updates only `effort=` after the final footer confirmation.
 If a chord is delivered before an interruption, unreadable UI, or metadata-write failure, the next locked invocation verifies the unchanged endpoint and reconciles the observed footer into metadata before it can send another chord.
 Zellij, Orca, and cmux remain refused because their current backend adapters return `unverified` from the recovery-grade agent-state interface, even though they have generic input and capture primitives.
 This is an evidence gap rather than a claim that their terminal transports cannot carry the keys.
@@ -59,9 +61,10 @@ Behavior regression coverage is owned by:
 
 ```sh
 tests/fm-codex-effort.test.sh
+tests/fm-teardown.test.sh
 ```
 
-The suite covers successful Herdr switching, tmux refusal without semantic idle evidence, session-identity preservation, metadata-after-footer ordering, invalid effort, wrong harness, busy and ambiguous state, structural footer confirmation, swallowed input, changed UI, durable post-send recovery, unsupported backends, and no false success.
+The suites cover successful Herdr switching, captured Codex 0.147 footer variants, tmux refusal without semantic idle evidence, session-identity preservation, metadata-after-footer ordering, invalid effort, wrong harness, busy and ambiguous state, structural footer confirmation, serialized ordinary steering, swallowed input, changed UI, durable post-send recovery, task-id-reuse cleanup, unsupported backends, and no false success.
 
 ## tmux
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -37,7 +37,7 @@ Sending literal `ESC .` through `pane send-text` changed Medium to High, and lit
 A second guarded lab established the complete adjacent sequence `low <-> medium <-> high <-> xhigh` and confirmed that the boundary levels do not move farther.
 The public `bin/fm-codex-effort.sh` interface then changed a fresh isolated Herdr Codex from High to Medium and updated its private fixture metadata only after the footer showed Medium.
 
-### tmux verification
+### tmux compatibility evidence
 
 The bounded reference-backend compatibility test used tmux 3.7b, one uniquely named detached session, and one scratch Git worktree.
 It did not change `config/backend`, inspect or migrate live tasks, or touch the preferred Herdr production path.
@@ -46,12 +46,14 @@ Before and after the input, the Codex thread id and rollout path matched, the fo
 The post-switch turn reproduced a context token created before the switch.
 The exact session was exited and killed after the bounded check.
 
-`bin/fm-codex-effort.sh` therefore uses literal `ESC .` and `ESC ,` on Herdr and semantic `M-.` and `M-,` keys on tmux.
-It supports only idle Codex tasks whose endpoint identity, live agent, current worktree, empty composer, and current model and effort footer are all verified.
-It checks each adjacent transition, revalidates the endpoint, and atomically updates only `effort=` after the final footer confirmation.
+`bin/fm-codex-effort.sh` uses literal `ESC .` and `ESC ,` on Herdr.
+It supports only idle Herdr Codex tasks whose endpoint identity, native agent state, live agent, current worktree, empty composer, and current model and effort footer are all verified.
+It treats tmux's observed `M-.` and `M-,` behavior as compatibility evidence only, because current Codex tmux workers have no verified semantic idle source and must refuse before any chord.
+It writes a durable recovery record before its first chord, checks each adjacent transition, revalidates the endpoint, and atomically updates only `effort=` after the final footer confirmation.
+If a chord is delivered before an interruption, unreadable UI, or metadata-write failure, the next locked invocation verifies the unchanged endpoint and reconciles the observed footer into metadata before it can send another chord.
 Zellij, Orca, and cmux remain refused because their current backend adapters return `unverified` from the recovery-grade agent-state interface, even though they have generic input and capture primitives.
 This is an evidence gap rather than a claim that their terminal transports cannot carry the keys.
-Quit and resume are no longer required for routine effort changes on the verified Herdr and tmux paths.
+Quit and resume remain the recovery fallback when the verified Herdr operation refuses.
 
 Behavior regression coverage is owned by:
 
@@ -59,7 +61,7 @@ Behavior regression coverage is owned by:
 tests/fm-codex-effort.test.sh
 ```
 
-The suite covers successful adjacent switching on Herdr and tmux, session-identity preservation, metadata-after-footer ordering, invalid effort, wrong harness, busy and ambiguous state, swallowed input, changed UI, unsupported backends, and no false success.
+The suite covers successful Herdr switching, tmux refusal without semantic idle evidence, session-identity preservation, metadata-after-footer ordering, invalid effort, wrong harness, busy and ambiguous state, structural footer confirmation, swallowed input, changed UI, durable post-send recovery, unsupported backends, and no false success.
 
 ## tmux
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -6,6 +6,61 @@ This record contains reusable version-scoped evidence for active runtime guarant
 The backend guides own current setup, safety boundaries, and limitations.
 Exact task chronology, branch names, temporary homes, local paths, process ids, thread ids, and delivery transcripts remain in private reports or PR evidence.
 
+## Codex in-session reasoning effort
+
+Codex CLI 0.146.0 was verified on 2026-08-03 against the current [official model guidance](https://learn.chatgpt.com/docs/models.md) and [official CLI slash-command reference](https://learn.chatgpt.com/docs/developer-commands.md?surface=cli).
+The official guidance says an interactive CLI session can use `/model` to adjust reasoning effort, and the CLI reference lists `/model` as choosing the active model and effort when available.
+The installed `/keymap` UI exposed Chat Decrease Reasoning as `alt-,` and `shift-down`, and Chat Increase Reasoning as `alt-.` and `shift-up`.
+
+The interfaces considered were:
+
+| Interface | Installed and documented behavior | Operational conclusion |
+| --- | --- | --- |
+| `/model` | Public interactive model and effort chooser. | Supported for a human, but automation would have to traverse two menus whose layout is not a stable task interface. |
+| `/model gpt-5.6-sol high` | Parsed as an ordinary user prompt rather than a command with arguments, and the unchanged footer disproved the model's textual claim that effort changed. | Never use command arguments or transcript prose as confirmation. |
+| Reasoning keybindings | Public actions visible in `/keymap`, with one input per adjacent effort level. | Smallest stable interactive interface when each step is confirmed from the live footer. |
+| App-server `thread/settings/update` | `codex app-server generate-json-schema` describes `effort` as an override for subsequent turns. | Valid for an app-server-owned thread, but a normal pane TUI has no supported external attachment seam, so it is not an operational interface for existing crewmates. |
+| Quit and resume | Preserves a saved session but exits the process and reloads launch behavior. | Recovery fallback only. |
+
+### Herdr verification
+
+The primary experiment ran in a guarded `bin/fm-herdr-lab.sh` session with a scratch Git worktree and Codex launched at `gpt-5.6-sol high`.
+The default-session tripwire stayed intact, and teardown used the guarded named-lab path.
+The baseline recorded one Codex process, one Codex thread and rollout path, the scratch worktree, a remembered context token, and three completed SessionStart hooks.
+
+`/model` displayed the current model first and then Low, Medium, High, and Extra high effort choices.
+Selecting Medium changed the footer and persisted the thread effort without changing the thread id, rollout path, process id, process count, or worktree.
+The same process later reproduced the pre-switch context token, and the visible completed SessionStart-hook count stayed at three.
+
+Herdr 0.7.5 did not accept named `alt-.` or `shift-up` keys through `pane send-keys` and returned `invalid_key`.
+Sending literal `ESC .` through `pane send-text` changed Medium to High, and literal `ESC ,` changed High to Medium.
+A second guarded lab established the complete adjacent sequence `low <-> medium <-> high <-> xhigh` and confirmed that the boundary levels do not move farther.
+The public `bin/fm-codex-effort.sh` interface then changed a fresh isolated Herdr Codex from High to Medium and updated its private fixture metadata only after the footer showed Medium.
+
+### tmux verification
+
+The bounded reference-backend compatibility test used tmux 3.7b, one uniquely named detached session, and one scratch Git worktree.
+It did not change `config/backend`, inspect or migrate live tasks, or touch the preferred Herdr production path.
+Tmux `send-keys M-,` changed the live Codex footer from High to Medium.
+Before and after the input, the Codex thread id and rollout path matched, the foreground Codex process id matched, the session contained exactly one Codex process, the process cwd matched the scratch worktree, and the completed SessionStart-hook count remained three.
+The post-switch turn reproduced a context token created before the switch.
+The exact session was exited and killed after the bounded check.
+
+`bin/fm-codex-effort.sh` therefore uses literal `ESC .` and `ESC ,` on Herdr and semantic `M-.` and `M-,` keys on tmux.
+It supports only idle Codex tasks whose endpoint identity, live agent, current worktree, empty composer, and current model and effort footer are all verified.
+It checks each adjacent transition, revalidates the endpoint, and atomically updates only `effort=` after the final footer confirmation.
+Zellij, Orca, and cmux remain refused because their current backend adapters return `unverified` from the recovery-grade agent-state interface, even though they have generic input and capture primitives.
+This is an evidence gap rather than a claim that their terminal transports cannot carry the keys.
+Quit and resume are no longer required for routine effort changes on the verified Herdr and tmux paths.
+
+Behavior regression coverage is owned by:
+
+```sh
+tests/fm-codex-effort.test.sh
+```
+
+The suite covers successful adjacent switching on Herdr and tmux, session-identity preservation, metadata-after-footer ordering, invalid effort, wrong harness, busy and ambiguous state, swallowed input, changed UI, unsupported backends, and no false success.
+
 ## tmux
 
 Foreground-process behavior was verified on 2026-07-07 with tmux 3.6a on macOS.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -51,7 +51,7 @@ The exact session was exited and killed after the bounded check.
 `bin/fm-codex-effort.sh` uses literal `ESC .` and `ESC ,` on Herdr.
 It supports only idle Herdr Codex tasks whose endpoint identity, native agent state, live agent, current worktree, empty composer, and current model and effort footer are all verified.
 It treats tmux's observed `M-.` and `M-,` behavior as compatibility evidence only, because current Codex tmux workers have no verified semantic idle source and must refuse before any chord.
-It writes a durable recovery record before its first chord, serializes its chords with ordinary recorded-task steering through a shared endpoint input lock, checks each adjacent transition, revalidates semantic idle and the empty composer under that lock immediately before every chord, and atomically updates only `effort=` after the final footer confirmation.
+It writes a durable recovery record before its first chord, serializes its chords with all recorded-task steering including `fm-send --key` through a shared endpoint input lock, checks each adjacent transition, revalidates semantic idle and the empty composer under that lock immediately before every chord, and atomically updates only `effort=` after the final footer confirmation.
 If a chord is delivered before an interruption, unreadable UI, or metadata-write failure, the next locked invocation verifies the unchanged endpoint and reconciles the observed footer into metadata before it can send another chord.
 Zellij, Orca, and cmux remain refused because their current backend adapters return `unverified` from the recovery-grade agent-state interface, even though they have generic input and capture primitives.
 This is an evidence gap rather than a claim that their terminal transports cannot carry the keys.
@@ -64,7 +64,7 @@ tests/fm-codex-effort.test.sh
 tests/fm-teardown.test.sh
 ```
 
-The suites cover successful Herdr switching, captured Codex 0.147 footer variants, tmux refusal without semantic idle evidence, session-identity preservation, metadata-after-footer ordering, invalid effort, wrong harness, busy and ambiguous state, structural footer confirmation, serialized ordinary steering, swallowed input, changed UI, durable post-send recovery, task-id-reuse cleanup, unsupported backends, and no false success.
+The suites cover successful Herdr switching, captured Codex 0.147 footer variants, tmux refusal without semantic idle evidence, session-identity preservation, metadata-after-footer ordering, invalid effort, wrong harness, busy and ambiguous state, structural footer confirmation, serialized text and key steering, swallowed input, changed UI, durable post-send recovery, task-id-reuse cleanup, unsupported backends, and no false success.
 
 ## tmux
 

--- a/tests/fixtures/codex-effort/codex-0.147-absolute-footer.txt
+++ b/tests/fixtures/codex-effort/codex-0.147-absolute-footer.txt
@@ -1,0 +1,3 @@
+›
+
+gpt-5.6-sol high · /home/pranay/.treehouse/firstmate-7e2c14/5/firstmate · Context 0% use…

--- a/tests/fixtures/codex-effort/codex-0.147-home-abbreviated-footer.txt
+++ b/tests/fixtures/codex-effort/codex-0.147-home-abbreviated-footer.txt
@@ -1,0 +1,3 @@
+›
+
+gpt-5.6-sol high · ~/.treehouse/firstmate-7e2c14/5/firstmate · Context 0% use…

--- a/tests/fm-codex-effort.test.sh
+++ b/tests/fm-codex-effort.test.sh
@@ -6,7 +6,9 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 SWITCH="$ROOT/bin/fm-codex-effort.sh"
+SEND="$ROOT/bin/fm-send.sh"
 TMP_ROOT=$(fm_test_tmproot fm-codex-effort)
+FIXTURE_ROOT="$ROOT/tests/fixtures/codex-effort"
 
 make_case() {  # <name> [backend]
   local name=$1 backend=${2:-herdr} id=effort-task dir
@@ -95,7 +97,11 @@ case "${1:-} ${2:-}" in
     fi
     ;;
   "agent get")
-    printf '{"result":{"agent":{"agent":"codex","agent_status":"%s"}}}\n' "${FM_FAKE_AGENT_STATUS:-idle}"
+    status=${FM_FAKE_AGENT_STATUS:-idle}
+    if [ -n "${FM_FAKE_AGENT_STATUS_FILE:-}" ] && [ -f "$FM_FAKE_AGENT_STATUS_FILE" ]; then
+      status=$(cat "$FM_FAKE_AGENT_STATUS_FILE")
+    fi
+    printf '{"result":{"agent":{"agent":"codex","agent_status":"%s"}}}\n' "$status"
     ;;
   "pane read")
     effort=$(cat "$FM_FAKE_EFFORT_FILE")
@@ -103,7 +109,9 @@ case "${1:-} ${2:-}" in
     if [ "$effort" = "$FM_FAKE_TARGET_EFFORT" ] && [ "$meta_effort" = high ]; then
       : > "$FM_FAKE_VERIFIED_BEFORE_META"
     fi
-    if [ -e "$FM_FAKE_CHANGED_FILE" ]; then
+    if [ -n "${FM_FAKE_FOOTER_FIXTURE:-}" ]; then
+      sed "s/gpt-5.6-sol high ·/gpt-5.6-sol $effort ·/" "$FM_FAKE_FOOTER_FIXTURE"
+    elif [ -e "$FM_FAKE_CHANGED_FILE" ]; then
       printf '%s\n' 'unrecognized Codex screen without a footer'
     elif [ "${FM_FAKE_UI:-footer}" = footer ]; then
       printf 'transcript\n\n› \n\n  gpt-5.6-sol %s · %s\n' "$effort" "$FM_FAKE_WORKTREE"
@@ -119,6 +127,14 @@ case "${1:-} ${2:-}" in
     ;;
   "pane send-text")
     key=${4:-}
+    if [ "${FM_FAKE_BLOCK_ORDINARY_SEND:-0}" = 1 ] \
+      && [ "$key" != "$(printf '\033.')" ] \
+      && [ "$key" != "$(printf '\033,')" ]; then
+      : > "${FM_FAKE_SEND_ENTERED:?}"
+      while [ ! -e "${FM_FAKE_ALLOW_SEND:?}" ]; do sleep 0.01; done
+      [ -z "${FM_FAKE_SENT_TEXT:-}" ] || printf '%s\n' "$key" >> "$FM_FAKE_SENT_TEXT"
+      exit 0
+    fi
     effort=$(cat "$FM_FAKE_EFFORT_FILE")
     case "$key" in
       "$(printf '\033.')")
@@ -129,7 +145,9 @@ case "${1:-} ${2:-}" in
         case "$effort" in xhigh) effort=high ;; high) effort=medium ;; medium) effort=low ;; low) : ;; esac
         printf 'decrease\n' >> "$FM_FAKE_LOG"
         ;;
-      *) exit 9 ;;
+      *)
+        [ -z "${FM_FAKE_SENT_TEXT:-}" ] || printf '%s\n' "$key" >> "$FM_FAKE_SENT_TEXT"
+        ;;
     esac
     if [ "${FM_FAKE_SWALLOW:-0}" != 1 ]; then
       printf '%s\n' "$effort" > "$FM_FAKE_EFFORT_FILE"
@@ -139,6 +157,11 @@ case "${1:-} ${2:-}" in
     fi
     if [ "${FM_FAKE_TERM_AFTER_SEND:-0}" = 1 ]; then
       kill -TERM "$PPID"
+    fi
+    ;;
+  "pane send-keys")
+    if [ "${4:-}" = enter ] && [ -n "${FM_FAKE_AGENT_STATUS_FILE:-}" ]; then
+      printf 'working\n' > "$FM_FAKE_AGENT_STATUS_FILE"
     fi
     ;;
   *) exit 8 ;;
@@ -207,7 +230,7 @@ SH
 run_case() {  # <dir> <effort>
   local dir=$1 effort=$2
   env FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" \
-    FM_FAKE_LOG="$dir/runtime.log" FM_FAKE_WORKTREE="$dir/worktree" \
+    FM_FAKE_LOG="$dir/runtime.log" FM_FAKE_WORKTREE="${FM_FAKE_WORKTREE:-$dir/worktree}" \
     FM_FAKE_EFFORT_FILE="$dir/effort" \
     FM_FAKE_META="$dir/home/state/effort-task.meta" \
     FM_FAKE_TARGET_EFFORT="$effort" \
@@ -220,9 +243,37 @@ run_case() {  # <dir> <effort>
     FM_FAKE_CHANGE_UI_AFTER_SEND="${FM_FAKE_CHANGE_UI_AFTER_SEND:-0}" \
     FM_FAKE_TERM_AFTER_SEND="${FM_FAKE_TERM_AFTER_SEND:-0}" \
     FM_FAKE_FAIL_META_MV="${FM_FAKE_FAIL_META_MV:-0}" \
+    FM_FAKE_FOOTER_FIXTURE="${FM_FAKE_FOOTER_FIXTURE:-}" \
+    FM_FAKE_AGENT_STATUS_FILE="${FM_FAKE_AGENT_STATUS_FILE:-}" \
+    FM_FAKE_BLOCK_ORDINARY_SEND="${FM_FAKE_BLOCK_ORDINARY_SEND:-0}" \
+    FM_FAKE_SEND_ENTERED="${FM_FAKE_SEND_ENTERED:-}" \
+    FM_FAKE_ALLOW_SEND="${FM_FAKE_ALLOW_SEND:-}" \
+    FM_FAKE_SENT_TEXT="${FM_FAKE_SENT_TEXT:-}" \
     FM_FAKE_REAL_MV="$(command -v mv)" \
     PATH="$dir/fakebin:$PATH" \
     "$SWITCH" effort-task "$effort"
+}
+
+run_send_case() {  # <dir> <message>
+  local dir=$1 message=$2
+  env FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_FAKE_LOG="$dir/runtime.log" FM_FAKE_WORKTREE="${FM_FAKE_WORKTREE:-$dir/worktree}" \
+    FM_FAKE_EFFORT_FILE="$dir/effort" \
+    FM_FAKE_META="$dir/home/state/effort-task.meta" \
+    FM_FAKE_TARGET_EFFORT=high \
+    FM_FAKE_CHANGED_FILE="$dir/changed-ui" \
+    FM_FAKE_AGENT_STATUS="${FM_FAKE_AGENT_STATUS:-idle}" \
+    FM_FAKE_PANE_STATE="${FM_FAKE_PANE_STATE:-present}" \
+    FM_FAKE_UI="${FM_FAKE_UI:-footer}" \
+    FM_FAKE_FOOTER_FIXTURE="${FM_FAKE_FOOTER_FIXTURE:-}" \
+    FM_FAKE_AGENT_STATUS_FILE="${FM_FAKE_AGENT_STATUS_FILE:-}" \
+    FM_FAKE_BLOCK_ORDINARY_SEND="${FM_FAKE_BLOCK_ORDINARY_SEND:-0}" \
+    FM_FAKE_SEND_ENTERED="${FM_FAKE_SEND_ENTERED:-}" \
+    FM_FAKE_ALLOW_SEND="${FM_FAKE_ALLOW_SEND:-}" \
+    FM_FAKE_SENT_TEXT="${FM_FAKE_SENT_TEXT:-}" \
+    FM_SEND_SETTLE=0 FM_SEND_SLEEP=0 \
+    PATH="$dir/fakebin:$PATH" \
+    "$SEND" effort-task "$message"
 }
 
 test_success_changes_effort_in_place_and_then_metadata() {
@@ -378,6 +429,87 @@ test_footer_requires_the_current_bottom_status_row() {
   pass "fm-codex-effort: requires a structurally current footer instead of transcript prose"
 }
 
+test_captured_real_codex_0147_footers_bind_the_recorded_worktree() {
+  local dir fixture out expected_worktree before rc
+  expected_worktree=/home/pranay/.treehouse/firstmate-7e2c14/5/firstmate
+  for fixture in "$FIXTURE_ROOT/codex-0.147-absolute-footer.txt" \
+    "$FIXTURE_ROOT/codex-0.147-home-abbreviated-footer.txt"; do
+    dir=$(make_case "captured-$(basename "$fixture" .txt)")
+    sed -i "s|^worktree=.*$|worktree=$expected_worktree|" "$dir/home/state/effort-task.meta"
+    out=$(HOME=/home/pranay FM_FAKE_WORKTREE="$expected_worktree" \
+      FM_FAKE_FOOTER_FIXTURE="$fixture" run_case "$dir" medium) \
+      || fail "captured Codex 0.147 footer was rejected: $(cat "$fixture")"
+    [ "$(cat "$dir/effort")" = medium ] \
+      || fail "captured Codex 0.147 footer did not confirm the live effort"
+  done
+
+  dir=$(make_case captured-footer-wrong-worktree)
+  sed -i 's|^worktree=.*$|worktree=/var/lib/not-pranay/firstmate|' "$dir/home/state/effort-task.meta"
+  before=$(cksum < "$dir/home/state/effort-task.meta")
+  out=$(HOME=/home/pranay FM_FAKE_WORKTREE=/var/lib/not-pranay/firstmate \
+    FM_FAKE_FOOTER_FIXTURE="$FIXTURE_ROOT/codex-0.147-home-abbreviated-footer.txt" \
+    run_case "$dir" medium 2>&1); rc=$?
+  [ "$rc" -ne 0 ] || fail "a captured Codex footer for another worktree was accepted"
+  assert_contains "$out" 'no verifiable Codex model/effort footer' \
+    "wrong-worktree captured footer refusal was unclear"
+  assert_no_grep 'increase|decrease' "$dir/runtime.log" \
+    "wrong-worktree captured footer received an effort chord"
+  [ "$(cksum < "$dir/home/state/effort-task.meta")" = "$before" ] \
+    || fail "wrong-worktree captured footer changed metadata"
+  pass "fm-codex-effort: accepts captured Codex 0.147 footers only when their displayed path binds the recorded worktree"
+}
+
+test_ordinary_send_serializes_with_effort_chords_and_forces_a_fresh_idle_check() {
+  local dir send_pid effort_pid send_rc effort_rc waited=0
+  dir=$(make_case ordinary-send-race)
+  : > "$dir/agent-status"
+  printf 'idle\n' > "$dir/agent-status"
+
+  FM_FAKE_AGENT_STATUS_FILE="$dir/agent-status" \
+  FM_FAKE_BLOCK_ORDINARY_SEND=1 \
+  FM_FAKE_SEND_ENTERED="$dir/send-entered" \
+  FM_FAKE_ALLOW_SEND="$dir/allow-send" \
+  FM_FAKE_SENT_TEXT="$dir/sent-text" \
+    run_send_case "$dir" 'ordinary steer' >"$dir/send.out" 2>"$dir/send.err" &
+  send_pid=$!
+  while [ ! -e "$dir/send-entered" ] && [ "$waited" -lt 100 ]; do
+    sleep 0.02
+    waited=$((waited + 1))
+  done
+  if [ ! -e "$dir/send-entered" ]; then
+    : > "$dir/allow-send"
+    wait "$send_pid" || true
+    fail "ordinary send did not reach its deterministic in-flight point"
+  fi
+
+  FM_FAKE_AGENT_STATUS_FILE="$dir/agent-status" \
+  FM_FAKE_BLOCK_ORDINARY_SEND=1 \
+  FM_FAKE_SEND_ENTERED="$dir/send-entered" \
+  FM_FAKE_ALLOW_SEND="$dir/allow-send" \
+  FM_FAKE_SENT_TEXT="$dir/sent-text" \
+    run_case "$dir" medium >"$dir/effort.out" 2>"$dir/effort.err" &
+  effort_pid=$!
+  sleep 0.15
+  if grep -Eq 'increase|decrease' "$dir/runtime.log"; then
+    : > "$dir/allow-send"
+    wait "$send_pid" || true
+    wait "$effort_pid" || true
+    fail "effort chord landed while ordinary send held the endpoint input transaction"
+  fi
+
+  : > "$dir/allow-send"
+  send_rc=0; wait "$send_pid" || send_rc=$?
+  effort_rc=0; wait "$effort_pid" || effort_rc=$?
+  expect_code 0 "$send_rc" "ordinary send should complete before the effort helper retries its idle check"
+  [ "$effort_rc" -ne 0 ] || fail "effort helper accepted an endpoint made busy by the serialized ordinary send"
+  assert_contains "$(cat "$dir/effort.err")" "not idle" \
+    "effort helper did not recheck native semantic idle while it held the input lock"
+  assert_no_grep 'increase|decrease' "$dir/runtime.log" \
+    "effort helper delivered a chord after the serialized send began a turn"
+  assert_grep 'ordinary steer' "$dir/sent-text" "ordinary send did not deliver its own text"
+  pass "fm-codex-effort: ordinary fm-send input serializes with chords and receives a fresh semantic idle check"
+}
+
 test_post_send_failures_leave_a_durable_recoverable_record() {
   local dir before out rc
   dir=$(make_case recover-multi-step)
@@ -437,5 +569,7 @@ test_lifecycle_and_metadata_locks_refuse_before_runtime_input
 test_busy_and_ambiguous_runtime_states_refuse
 test_swallowed_input_and_changed_ui_never_report_success
 test_footer_requires_the_current_bottom_status_row
+test_captured_real_codex_0147_footers_bind_the_recorded_worktree
+test_ordinary_send_serializes_with_effort_chords_and_forces_a_fresh_idle_check
 test_post_send_failures_leave_a_durable_recoverable_record
 test_unverified_backends_refuse_before_input

--- a/tests/fm-codex-effort.test.sh
+++ b/tests/fm-codex-effort.test.sh
@@ -255,6 +255,24 @@ test_invalid_effort_and_wrong_harness_refuse_without_runtime_input() {
   pass "fm-codex-effort: refuses invalid effort and non-Codex tasks without side effects"
 }
 
+test_task_id_uses_current_creation_contract() {
+  local dir long_id out rc
+  dir=$(make_case invalid-id)
+  out=$(env FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" \
+    "$SWITCH" .hidden medium 2>&1); rc=$?
+  [ "$rc" -ne 0 ] || fail "a leading-dot task id was accepted"
+  assert_contains "$out" "invalid task id" "leading-dot task-id refusal was unclear"
+  [ ! -s "$dir/runtime.log" ] || fail "leading-dot task-id refusal contacted the runtime"
+
+  long_id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  out=$(env FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" \
+    "$SWITCH" "$long_id" medium 2>&1); rc=$?
+  [ "$rc" -ne 0 ] || fail "an overlong task id was accepted"
+  assert_contains "$out" "invalid task id" "overlong task-id refusal was unclear"
+  [ ! -s "$dir/runtime.log" ] || fail "overlong task-id refusal contacted the runtime"
+  pass "fm-codex-effort: uses the current task-id creation boundary"
+}
+
 test_lifecycle_and_metadata_locks_refuse_before_runtime_input() {
   local dir lock out rc
   dir=$(make_case control-lock)
@@ -344,6 +362,7 @@ test_unverified_backends_refuse_before_input() {
 test_success_changes_effort_in_place_and_then_metadata
 test_tmux_reference_path_uses_semantic_reasoning_key
 test_invalid_effort_and_wrong_harness_refuse_without_runtime_input
+test_task_id_uses_current_creation_contract
 test_lifecycle_and_metadata_locks_refuse_before_runtime_input
 test_busy_and_ambiguous_runtime_states_refuse
 test_swallowed_input_and_changed_ui_never_report_success

--- a/tests/fm-codex-effort.test.sh
+++ b/tests/fm-codex-effort.test.sh
@@ -127,6 +127,20 @@ case "${1:-} ${2:-}" in
     ;;
   "pane send-text")
     key=${4:-}
+    case "$key" in
+      "$(printf '\033.')"|"$(printf '\033,')") ;;
+      *)
+        [ -z "${FM_FAKE_TEXT_ENTERED:-}" ] || : > "$FM_FAKE_TEXT_ENTERED"
+        if [ -n "${FM_FAKE_REQUIRE_CLEAR_DONE:-}" ] && [ ! -e "$FM_FAKE_REQUIRE_CLEAR_DONE" ]; then
+          [ -z "${FM_FAKE_EVENT_LOG:-}" ] || printf '%s\n' 'text-before-clear' >> "$FM_FAKE_EVENT_LOG"
+          exit 97
+        fi
+        if [ -n "${FM_FAKE_REQUIRE_BUSY_EVENT_DONE:-}" ] && [ ! -e "$FM_FAKE_REQUIRE_BUSY_EVENT_DONE" ]; then
+          [ -z "${FM_FAKE_EVENT_LOG:-}" ] || printf '%s\n' 'text-before-interrupt-record' >> "$FM_FAKE_EVENT_LOG"
+          exit 98
+        fi
+        ;;
+    esac
     if [ "${FM_FAKE_BLOCK_ORDINARY_SEND:-0}" = 1 ] \
       && [ "$key" != "$(printf '\033.')" ] \
       && [ "$key" != "$(printf '\033,')" ]; then
@@ -160,11 +174,24 @@ case "${1:-} ${2:-}" in
     fi
     ;;
   "pane send-keys")
+    key=${4:-}
     if [ "${FM_FAKE_BLOCK_KEY_SEND:-0}" = 1 ]; then
       : > "${FM_FAKE_KEY_ENTERED:?}"
       while [ ! -e "${FM_FAKE_ALLOW_KEY:?}" ]; do sleep 0.01; done
     fi
-    if [ "${4:-}" = enter ] && [ -n "${FM_FAKE_AGENT_STATUS_FILE:-}" ]; then
+    [ -z "${FM_FAKE_SENT_KEYS:-}" ] || printf '%s\n' "$key" >> "$FM_FAKE_SENT_KEYS"
+    if [ "$key" = escape ] && [ -n "${FM_FAKE_COMPOSER_FILE:-}" ]; then
+      printf '%s\n' 'restored prompt' > "$FM_FAKE_COMPOSER_FILE"
+    fi
+    if [ "$key" = ctrl+u ] && [ "${FM_FAKE_BLOCK_CLEAR_SEND:-0}" = 1 ]; then
+      : > "${FM_FAKE_CLEAR_ENTERED:?}"
+      while [ ! -e "${FM_FAKE_ALLOW_CLEAR:?}" ]; do sleep 0.01; done
+    fi
+    if [ "$key" = ctrl+u ] && [ -n "${FM_FAKE_COMPOSER_FILE:-}" ]; then
+      : > "$FM_FAKE_COMPOSER_FILE"
+      [ -z "${FM_FAKE_CLEAR_DONE:-}" ] || : > "$FM_FAKE_CLEAR_DONE"
+    fi
+    if [ "$key" = enter ] && [ -n "${FM_FAKE_AGENT_STATUS_FILE:-}" ]; then
       printf 'working\n' > "$FM_FAKE_AGENT_STATUS_FILE"
     fi
     ;;
@@ -263,7 +290,7 @@ run_case() {  # <dir> <effort>
 
 run_send_case() {  # <dir> <message>
   local dir=$1 message=$2
-  env FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" \
+  env FM_HOME="$dir/home" FM_ROOT_OVERRIDE="${FM_SEND_ROOT_OVERRIDE:-$ROOT}" \
     FM_FAKE_LOG="$dir/runtime.log" FM_FAKE_WORKTREE="${FM_FAKE_WORKTREE:-$dir/worktree}" \
     FM_FAKE_EFFORT_FILE="$dir/effort" \
     FM_FAKE_META="$dir/home/state/effort-task.meta" \
@@ -281,6 +308,7 @@ run_send_case() {  # <dir> <message>
     FM_FAKE_BLOCK_KEY_SEND="${FM_FAKE_BLOCK_KEY_SEND:-0}" \
     FM_FAKE_KEY_ENTERED="${FM_FAKE_KEY_ENTERED:-}" \
     FM_FAKE_ALLOW_KEY="${FM_FAKE_ALLOW_KEY:-}" \
+    FM_FAKE_REAL_MV="$(command -v mv)" \
     FM_SEND_SETTLE=0 FM_SEND_SLEEP=0 \
     PATH="$dir/fakebin:$PATH" \
     "$SEND" effort-task "$message"
@@ -288,7 +316,7 @@ run_send_case() {  # <dir> <message>
 
 run_key_send_case() {  # <dir> <key>
   local dir=$1 key=$2
-  env FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" \
+  env FM_HOME="$dir/home" FM_ROOT_OVERRIDE="${FM_SEND_ROOT_OVERRIDE:-$ROOT}" \
     FM_FAKE_LOG="$dir/runtime.log" FM_FAKE_WORKTREE="${FM_FAKE_WORKTREE:-$dir/worktree}" \
     FM_FAKE_EFFORT_FILE="$dir/effort" \
     FM_FAKE_META="$dir/home/state/effort-task.meta" \
@@ -306,6 +334,21 @@ run_key_send_case() {  # <dir> <key>
     FM_FAKE_BLOCK_KEY_SEND="${FM_FAKE_BLOCK_KEY_SEND:-0}" \
     FM_FAKE_KEY_ENTERED="${FM_FAKE_KEY_ENTERED:-}" \
     FM_FAKE_ALLOW_KEY="${FM_FAKE_ALLOW_KEY:-}" \
+    FM_FAKE_BLOCK_CLEAR_SEND="${FM_FAKE_BLOCK_CLEAR_SEND:-0}" \
+    FM_FAKE_CLEAR_ENTERED="${FM_FAKE_CLEAR_ENTERED:-}" \
+    FM_FAKE_ALLOW_CLEAR="${FM_FAKE_ALLOW_CLEAR:-}" \
+    FM_FAKE_COMPOSER_FILE="${FM_FAKE_COMPOSER_FILE:-}" \
+    FM_FAKE_SENT_KEYS="${FM_FAKE_SENT_KEYS:-}" \
+    FM_FAKE_CLEAR_DONE="${FM_FAKE_CLEAR_DONE:-}" \
+    FM_FAKE_TEXT_ENTERED="${FM_FAKE_TEXT_ENTERED:-}" \
+    FM_FAKE_REQUIRE_CLEAR_DONE="${FM_FAKE_REQUIRE_CLEAR_DONE:-}" \
+    FM_FAKE_REQUIRE_BUSY_EVENT_DONE="${FM_FAKE_REQUIRE_BUSY_EVENT_DONE:-}" \
+    FM_FAKE_EVENT_LOG="${FM_FAKE_EVENT_LOG:-}" \
+    FM_FAKE_REAL_BUSY_EVENT="${FM_FAKE_REAL_BUSY_EVENT:-}" \
+    FM_FAKE_BUSY_EVENT_ENTERED="${FM_FAKE_BUSY_EVENT_ENTERED:-}" \
+    FM_FAKE_ALLOW_BUSY_EVENT="${FM_FAKE_ALLOW_BUSY_EVENT:-}" \
+    FM_FAKE_BUSY_EVENT_DONE="${FM_FAKE_BUSY_EVENT_DONE:-}" \
+    FM_FAKE_REAL_MV="$(command -v mv)" \
     FM_SEND_SETTLE=0 FM_SEND_SLEEP=0 \
     PATH="$dir/fakebin:$PATH" \
     "$SEND" effort-task --key "$key"
@@ -602,6 +645,138 @@ test_key_send_serializes_with_effort_chords_and_forces_a_fresh_idle_check() {
   pass "fm-codex-effort: recorded fm-send --key input serializes with chords and receives a fresh semantic idle check"
 }
 
+test_escape_transactions_serialize_clear_and_interrupt_bookkeeping() {
+  local dir key_pid send_pid key_rc send_rc gen waited=0
+
+  dir=$(make_case escape-clear-race)
+  sed -i 's/^harness=codex$/harness=muse/' "$dir/home/state/effort-task.meta"
+  printf 'idle\n' > "$dir/agent-status"
+  FM_FAKE_AGENT_STATUS_FILE="$dir/agent-status" \
+  FM_FAKE_BLOCK_CLEAR_SEND=1 \
+  FM_FAKE_CLEAR_ENTERED="$dir/clear-entered" \
+  FM_FAKE_ALLOW_CLEAR="$dir/allow-clear" \
+  FM_FAKE_CLEAR_DONE="$dir/clear-done" \
+  FM_FAKE_COMPOSER_FILE="$dir/composer" \
+  FM_FAKE_SENT_KEYS="$dir/sent-keys" \
+    run_key_send_case "$dir" Escape >"$dir/key.out" 2>"$dir/key.err" &
+  key_pid=$!
+  while [ ! -e "$dir/clear-entered" ] && [ "$waited" -lt 100 ]; do
+    sleep 0.02
+    waited=$((waited + 1))
+  done
+  if [ ! -e "$dir/clear-entered" ]; then
+    : > "$dir/allow-clear"
+    wait "$key_pid" || true
+    fail "Muse Escape did not reach its deterministic composer-clear point"
+  fi
+  assert_grep escape "$dir/sent-keys" "Muse Escape did not deliver the interrupt key before its clear"
+  assert_grep 'restored prompt' "$dir/composer" "Muse Escape did not restore the composer fixture before its clear"
+  : > "$dir/event.log"
+
+  FM_FAKE_AGENT_STATUS_FILE="$dir/agent-status" \
+  FM_FAKE_TEXT_ENTERED="$dir/text-entered" \
+  FM_FAKE_REQUIRE_CLEAR_DONE="$dir/clear-done" \
+  FM_FAKE_EVENT_LOG="$dir/event.log" \
+  FM_FAKE_SENT_TEXT="$dir/sent-text" \
+    run_send_case "$dir" 'after Muse Escape' >"$dir/send.out" 2>"$dir/send.err" &
+  send_pid=$!
+  waited=0
+  while [ ! -e "$dir/text-entered" ] && [ "$waited" -lt 100 ]; do
+    sleep 0.02
+    waited=$((waited + 1))
+  done
+  if [ -e "$dir/text-entered" ]; then
+    : > "$dir/allow-clear"
+    wait "$key_pid" || true
+    wait "$send_pid" || true
+    fail "ordinary input entered before the serialized Muse Escape composer clear completed"
+  fi
+
+  : > "$dir/allow-clear"
+  key_rc=0; wait "$key_pid" || key_rc=$?
+  send_rc=0; wait "$send_pid" || send_rc=$?
+  expect_code 0 "$key_rc" "Muse Escape should complete its composer clear"
+  expect_code 0 "$send_rc" "ordinary input should follow the completed Muse Escape"
+  assert_grep ctrl+u "$dir/sent-keys" "Muse Escape did not clear its restored composer"
+  [ ! -s "$dir/composer" ] || fail "Muse Escape left restored input in the composer"
+  assert_grep 'after Muse Escape' "$dir/sent-text" "ordinary input did not follow the Muse Escape clear"
+  assert_no_grep text-before-clear "$dir/event.log" "ordinary input bypassed the Muse Escape composer-clear transaction"
+
+  dir=$(make_case escape-interrupt-record-race)
+  sed -i 's/^harness=codex$/harness=claude/' "$dir/home/state/effort-task.meta"
+  printf 'idle\n' > "$dir/agent-status"
+  gen=$("$ROOT/bin/fm-busy-event.sh" arm "$dir/home/state" effort-task)
+  printf 'busy_gen=%s\n' "$gen" >> "$dir/home/state/effort-task.meta"
+  mkdir -p "$dir/test-root/bin"
+  cat > "$dir/test-root/bin/fm-busy-event.sh" <<'SH'
+#!/usr/bin/env bash
+set -eu
+if [ "${1:-}" = apply ]; then
+  : > "${FM_FAKE_BUSY_EVENT_ENTERED:?}"
+  while [ ! -e "${FM_FAKE_ALLOW_BUSY_EVENT:?}" ]; do sleep 0.01; done
+fi
+"${FM_FAKE_REAL_BUSY_EVENT:?}" "$@"
+if [ "${1:-}" = apply ]; then
+  : > "${FM_FAKE_BUSY_EVENT_DONE:?}"
+fi
+SH
+  chmod +x "$dir/test-root/bin/fm-busy-event.sh"
+
+  FM_SEND_ROOT_OVERRIDE="$dir/test-root" \
+  FM_FAKE_REAL_BUSY_EVENT="$ROOT/bin/fm-busy-event.sh" \
+  FM_FAKE_BUSY_EVENT_ENTERED="$dir/busy-event-entered" \
+  FM_FAKE_ALLOW_BUSY_EVENT="$dir/allow-busy-event" \
+  FM_FAKE_BUSY_EVENT_DONE="$dir/busy-event-done" \
+  FM_FAKE_AGENT_STATUS_FILE="$dir/agent-status" \
+  FM_FAKE_SENT_KEYS="$dir/sent-keys" \
+    run_key_send_case "$dir" Escape >"$dir/key.out" 2>"$dir/key.err" &
+  key_pid=$!
+  waited=0
+  while [ ! -e "$dir/busy-event-entered" ] && [ "$waited" -lt 100 ]; do
+    sleep 0.02
+    waited=$((waited + 1))
+  done
+  if [ ! -e "$dir/busy-event-entered" ]; then
+    : > "$dir/allow-busy-event"
+    wait "$key_pid" || true
+    fail "Claude Escape did not reach its deterministic interrupt-record point"
+  fi
+  assert_grep escape "$dir/sent-keys" "Claude Escape did not deliver the interrupt key before bookkeeping"
+  : > "$dir/event.log"
+
+  FM_SEND_ROOT_OVERRIDE="$dir/test-root" \
+  FM_FAKE_AGENT_STATUS_FILE="$dir/agent-status" \
+  FM_FAKE_TEXT_ENTERED="$dir/text-entered" \
+  FM_FAKE_REQUIRE_BUSY_EVENT_DONE="$dir/busy-event-done" \
+  FM_FAKE_EVENT_LOG="$dir/event.log" \
+  FM_FAKE_SENT_TEXT="$dir/sent-text" \
+    run_send_case "$dir" 'after Claude Escape' >"$dir/send.out" 2>"$dir/send.err" &
+  send_pid=$!
+  waited=0
+  while [ ! -e "$dir/text-entered" ] && [ "$waited" -lt 100 ]; do
+    sleep 0.02
+    waited=$((waited + 1))
+  done
+  if [ -e "$dir/text-entered" ]; then
+    : > "$dir/allow-busy-event"
+    wait "$key_pid" || true
+    wait "$send_pid" || true
+    fail "ordinary input entered before the serialized Claude Escape interrupt record completed"
+  fi
+
+  : > "$dir/allow-busy-event"
+  key_rc=0; wait "$key_pid" || key_rc=$?
+  send_rc=0; wait "$send_pid" || send_rc=$?
+  expect_code 0 "$key_rc" "Claude Escape should complete its interrupt record"
+  expect_code 0 "$send_rc" "ordinary input should follow the completed Claude Escape"
+  assert_grep 'state=idle source=fm-interrupt event=interrupt' "$dir/home/state/effort-task.busy-state" \
+    "Claude Escape did not record its idle interrupt lifecycle event"
+  assert_grep 'after Claude Escape' "$dir/sent-text" "ordinary input did not follow the Claude Escape record"
+  assert_no_grep text-before-interrupt-record "$dir/event.log" \
+    "ordinary input bypassed the Claude Escape interrupt-record transaction"
+  pass "fm-send: Escape holds endpoint input serialization through Muse clearing and Claude interrupt bookkeeping"
+}
+
 test_post_send_failures_leave_a_durable_recoverable_record() {
   local dir before out rc
   dir=$(make_case recover-multi-step)
@@ -664,5 +839,6 @@ test_footer_requires_the_current_bottom_status_row
 test_captured_real_codex_0147_footers_bind_the_recorded_worktree
 test_ordinary_send_serializes_with_effort_chords_and_forces_a_fresh_idle_check
 test_key_send_serializes_with_effort_chords_and_forces_a_fresh_idle_check
+test_escape_transactions_serialize_clear_and_interrupt_bookkeeping
 test_post_send_failures_leave_a_durable_recoverable_record
 test_unverified_backends_refuse_before_input

--- a/tests/fm-codex-effort.test.sh
+++ b/tests/fm-codex-effort.test.sh
@@ -111,6 +111,8 @@ case "${1:-} ${2:-}" in
       printf 'Working (esc to interrupt)\n\n› \n\n  gpt-5.6-sol %s · %s\n' "$effort" "$FM_FAKE_WORKTREE"
     elif [ "${FM_FAKE_UI}" = misleading ]; then
       printf 'Model set to gpt-5.6-sol %s\n\n› \n\n  gpt-5.6-sol %s · %s\n' "$FM_FAKE_TARGET_EFFORT" "$effort" "$FM_FAKE_WORKTREE"
+    elif [ "${FM_FAKE_UI}" = scrollback-only ]; then
+      printf 'transcript copied from an earlier footer: gpt-5.6-sol %s · %s\n\n› \n' "$effort" "$FM_FAKE_WORKTREE"
     else
       printf '%s\n' "${FM_FAKE_UI}"
     fi
@@ -135,11 +137,24 @@ case "${1:-} ${2:-}" in
     if [ "${FM_FAKE_CHANGE_UI_AFTER_SEND:-0}" = 1 ]; then
       : > "$FM_FAKE_CHANGED_FILE"
     fi
+    if [ "${FM_FAKE_TERM_AFTER_SEND:-0}" = 1 ]; then
+      kill -TERM "$PPID"
+    fi
     ;;
   *) exit 8 ;;
 esac
 SH
   chmod +x "$dir/fakebin/herdr"
+  cat > "$dir/fakebin/mv" <<'SH'
+#!/usr/bin/env bash
+set -u
+last=${!#}
+if [ "${FM_FAKE_FAIL_META_MV:-0}" = 1 ] && [ "${last##*/}" = effort-task.meta ]; then
+  exit 1
+fi
+exec "${FM_FAKE_REAL_MV:?}" "$@"
+SH
+  chmod +x "$dir/fakebin/mv"
   cat > "$dir/fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
@@ -203,6 +218,9 @@ run_case() {  # <dir> <effort>
     FM_FAKE_UI="${FM_FAKE_UI:-footer}" \
     FM_FAKE_SWALLOW="${FM_FAKE_SWALLOW:-0}" \
     FM_FAKE_CHANGE_UI_AFTER_SEND="${FM_FAKE_CHANGE_UI_AFTER_SEND:-0}" \
+    FM_FAKE_TERM_AFTER_SEND="${FM_FAKE_TERM_AFTER_SEND:-0}" \
+    FM_FAKE_FAIL_META_MV="${FM_FAKE_FAIL_META_MV:-0}" \
+    FM_FAKE_REAL_MV="$(command -v mv)" \
     PATH="$dir/fakebin:$PATH" \
     "$SWITCH" effort-task "$effort"
 }
@@ -223,15 +241,16 @@ test_success_changes_effort_in_place_and_then_metadata() {
   pass "fm-codex-effort: changes an idle Codex effort through the public interface without quit/resume"
 }
 
-test_tmux_reference_path_uses_semantic_reasoning_key() {
-  local dir out
-  dir=$(make_case tmux-success tmux)
-  out=$(run_case "$dir" medium) || fail "tmux effort switch failed: $out"
-  assert_contains "$out" "medium (tmux, session preserved)" "tmux success was not reported"
-  assert_grep "M-\\," "$dir/runtime.log" "tmux did not send its verified semantic Alt+, key"
-  assert_no_grep "/quit" "$dir/runtime.log" "tmux success exited Codex"
-  assert_grep "session_marker=keep-me" "$dir/home/state/effort-task.meta" "tmux success changed session identity metadata"
-  pass "fm-codex-effort: supports the verified tmux reference path"
+test_tmux_refuses_without_a_verified_semantic_idle_source() {
+  local dir before out rc
+  dir=$(make_case tmux-no-semantic-idle tmux)
+  before=$(cksum < "$dir/home/state/effort-task.meta")
+  out=$(run_case "$dir" medium 2>&1); rc=$?
+  [ "$rc" -ne 0 ] || fail "tmux effort switch was accepted without semantic idle evidence"
+  assert_contains "$out" "no verified semantic Codex idle source" "tmux idle-source refusal was unclear"
+  assert_no_grep "send-keys" "$dir/runtime.log" "tmux received an effort chord without semantic idle evidence"
+  [ "$(cksum < "$dir/home/state/effort-task.meta")" = "$before" ] || fail "tmux refusal changed metadata"
+  pass "fm-codex-effort: refuses tmux until Codex has a verified semantic idle source"
 }
 
 test_invalid_effort_and_wrong_harness_refuse_without_runtime_input() {
@@ -347,6 +366,57 @@ test_swallowed_input_and_changed_ui_never_report_success() {
   pass "fm-codex-effort: reports no false success when input is swallowed or the UI changes"
 }
 
+test_footer_requires_the_current_bottom_status_row() {
+  local dir before out rc
+  dir=$(make_case scrollback-footer)
+  before=$(cksum < "$dir/home/state/effort-task.meta")
+  out=$(FM_FAKE_UI=scrollback-only run_case "$dir" medium 2>&1); rc=$?
+  [ "$rc" -ne 0 ] || fail "footer-shaped scrollback was accepted as the current status row"
+  assert_contains "$out" "no verifiable Codex model/effort footer" "scrollback-only footer refusal was unclear"
+  assert_no_grep "pane send-text" "$dir/runtime.log" "scrollback-only footer delivered an effort chord"
+  [ "$(cksum < "$dir/home/state/effort-task.meta")" = "$before" ] || fail "scrollback-only footer changed metadata"
+  pass "fm-codex-effort: requires a structurally current footer instead of transcript prose"
+}
+
+test_post_send_failures_leave_a_durable_recoverable_record() {
+  local dir before out rc
+  dir=$(make_case recover-multi-step)
+  printf 'low\n' > "$dir/effort"
+  sed -i 's/^effort=high$/effort=low/' "$dir/home/state/effort-task.meta"
+  before=$(cksum < "$dir/home/state/effort-task.meta")
+  out=$(FM_FAKE_CHANGE_UI_AFTER_SEND=1 run_case "$dir" high 2>&1); rc=$?
+  [ "$rc" -ne 0 ] || fail "unreadable UI after the first multi-step input was accepted"
+  [ "$(cat "$dir/effort")" = medium ] || fail "first multi-step effort transition was not delivered"
+  [ "$(cksum < "$dir/home/state/effort-task.meta")" = "$before" ] || fail "failed multi-step switch changed metadata"
+  assert_present "$dir/home/state/effort-task.codex-effort-recovery" "post-send failure left no durable recovery record"
+  rm -f "$dir/changed-ui"
+  out=$(run_case "$dir" high) || fail "retry did not reconcile and complete a partially delivered multi-step switch: $out"
+  [ "$(cat "$dir/effort")" = high ] || fail "retry did not reach the requested multi-step effort"
+  [ "$(grep '^effort=' "$dir/home/state/effort-task.meta")" = effort=high ] || fail "retry did not reconcile metadata to the live effort"
+  [ ! -e "$dir/home/state/effort-task.codex-effort-recovery" ] || fail "successful retry retained the recovery record"
+
+  dir=$(make_case recover-signal)
+  out=$(FM_FAKE_TERM_AFTER_SEND=1 run_case "$dir" medium 2>&1); rc=$?
+  [ "$rc" -ne 0 ] || fail "interrupted effort switch reported success"
+  [ "$(cat "$dir/effort")" = medium ] || fail "signal fixture did not deliver the live effort transition"
+  [ "$(grep '^effort=' "$dir/home/state/effort-task.meta")" = effort=high ] || fail "interrupted switch updated metadata before recovery"
+  assert_present "$dir/home/state/effort-task.codex-effort-recovery" "signal interruption left no durable recovery record"
+  out=$(run_case "$dir" medium) || fail "retry did not reconcile a signal-interrupted effort switch: $out"
+  [ "$(grep '^effort=' "$dir/home/state/effort-task.meta")" = effort=medium ] || fail "signal retry did not reconcile metadata"
+  [ ! -e "$dir/home/state/effort-task.codex-effort-recovery" ] || fail "signal retry retained the recovery record"
+
+  dir=$(make_case recover-meta-write)
+  out=$(FM_FAKE_FAIL_META_MV=1 run_case "$dir" medium 2>&1); rc=$?
+  [ "$rc" -ne 0 ] || fail "metadata-write failure reported success"
+  [ "$(cat "$dir/effort")" = medium ] || fail "metadata-write fixture did not deliver the live effort transition"
+  [ "$(grep '^effort=' "$dir/home/state/effort-task.meta")" = effort=high ] || fail "metadata-write failure changed metadata"
+  assert_present "$dir/home/state/effort-task.codex-effort-recovery" "metadata-write failure left no recovery record"
+  out=$(run_case "$dir" medium) || fail "retry did not reconcile metadata-write failure: $out"
+  [ "$(grep '^effort=' "$dir/home/state/effort-task.meta")" = effort=medium ] || fail "metadata-write retry did not reconcile metadata"
+  [ ! -e "$dir/home/state/effort-task.codex-effort-recovery" ] || fail "metadata-write retry retained the recovery record"
+  pass "fm-codex-effort: durably recovers post-send multi-step, signal, and metadata-write failures"
+}
+
 test_unverified_backends_refuse_before_input() {
   local backend dir out rc
   for backend in zellij orca cmux; do
@@ -360,10 +430,12 @@ test_unverified_backends_refuse_before_input() {
 }
 
 test_success_changes_effort_in_place_and_then_metadata
-test_tmux_reference_path_uses_semantic_reasoning_key
+test_tmux_refuses_without_a_verified_semantic_idle_source
 test_invalid_effort_and_wrong_harness_refuse_without_runtime_input
 test_task_id_uses_current_creation_contract
 test_lifecycle_and_metadata_locks_refuse_before_runtime_input
 test_busy_and_ambiguous_runtime_states_refuse
 test_swallowed_input_and_changed_ui_never_report_success
+test_footer_requires_the_current_bottom_status_row
+test_post_send_failures_leave_a_durable_recoverable_record
 test_unverified_backends_refuse_before_input

--- a/tests/fm-codex-effort.test.sh
+++ b/tests/fm-codex-effort.test.sh
@@ -255,6 +255,28 @@ test_invalid_effort_and_wrong_harness_refuse_without_runtime_input() {
   pass "fm-codex-effort: refuses invalid effort and non-Codex tasks without side effects"
 }
 
+test_lifecycle_and_metadata_locks_refuse_before_runtime_input() {
+  local dir lock out rc
+  dir=$(make_case control-lock)
+  lock="$dir/home/state/.control-effort-task.lock"
+  mkdir "$lock"
+  printf '%s\n' "$$" > "$lock/pid"
+  out=$(run_case "$dir" medium 2>&1); rc=$?
+  [ "$rc" -ne 0 ] || fail "a concurrent lifecycle action was accepted"
+  assert_contains "$out" "lifecycle action" "control-lock refusal was unclear"
+  [ ! -s "$dir/runtime.log" ] || fail "control-lock refusal contacted the runtime"
+
+  dir=$(make_case metadata-lock)
+  lock="$dir/home/state/.meta-effort-task.lock"
+  mkdir "$lock"
+  printf '%s\n' "$$" > "$lock/pid"
+  out=$(run_case "$dir" medium 2>&1); rc=$?
+  [ "$rc" -ne 0 ] || fail "a concurrent metadata update was accepted"
+  assert_contains "$out" "metadata update" "metadata-lock refusal was unclear"
+  [ ! -s "$dir/runtime.log" ] || fail "metadata-lock refusal contacted the runtime"
+  pass "fm-codex-effort: serializes with lifecycle actions and metadata writers"
+}
+
 test_busy_and_ambiguous_runtime_states_refuse() {
   local dir before out rc
   dir=$(make_case busy-agent)
@@ -322,6 +344,7 @@ test_unverified_backends_refuse_before_input() {
 test_success_changes_effort_in_place_and_then_metadata
 test_tmux_reference_path_uses_semantic_reasoning_key
 test_invalid_effort_and_wrong_harness_refuse_without_runtime_input
+test_lifecycle_and_metadata_locks_refuse_before_runtime_input
 test_busy_and_ambiguous_runtime_states_refuse
 test_swallowed_input_and_changed_ui_never_report_success
 test_unverified_backends_refuse_before_input

--- a/tests/fm-codex-effort.test.sh
+++ b/tests/fm-codex-effort.test.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+# Behavior tests for the public idle-Codex effort switch interface.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SWITCH="$ROOT/bin/fm-codex-effort.sh"
+TMP_ROOT=$(fm_test_tmproot fm-codex-effort)
+
+make_case() {  # <name> [backend]
+  local name=$1 backend=${2:-herdr} id=effort-task dir
+  dir="$TMP_ROOT/$name"
+  mkdir -p "$dir/home/state" "$dir/home/config" "$dir/worktree" "$dir/project" "$dir/fakebin"
+  printf 'high\n' > "$dir/effort"
+  : > "$dir/runtime.log"
+  if [ "$backend" = tmux ]; then
+    fm_write_meta "$dir/home/state/$id.meta" \
+      "window=lab:fm-$id" \
+      "endpoint_task_id=$id" \
+      "worktree=$dir/worktree" \
+      "project=$dir/project" \
+      "harness=codex" \
+      "model=gpt-5.6-sol" \
+      "effort=high" \
+      "session_marker=keep-me"
+  elif [ "$backend" = zellij ]; then
+    fm_write_meta "$dir/home/state/$id.meta" \
+      "window=lab:1" \
+      "endpoint_task_id=$id" \
+      "worktree=$dir/worktree" \
+      "project=$dir/project" \
+      "harness=codex" \
+      "model=gpt-5.6-sol" \
+      "effort=high" \
+      "backend=zellij" \
+      "zellij_session=lab" \
+      "zellij_tab_id=1" \
+      "zellij_pane_id=1"
+  elif [ "$backend" = orca ]; then
+    fm_write_meta "$dir/home/state/$id.meta" \
+      "window=fm-$id" \
+      "endpoint_task_id=$id" \
+      "worktree=$dir/worktree" \
+      "project=$dir/project" \
+      "harness=codex" \
+      "model=gpt-5.6-sol" \
+      "effort=high" \
+      "backend=orca" \
+      "terminal=term1" \
+      "orca_worktree_id=worktree1"
+  elif [ "$backend" = cmux ]; then
+    fm_write_meta "$dir/home/state/$id.meta" \
+      "window=workspace1:surface1" \
+      "endpoint_task_id=$id" \
+      "worktree=$dir/worktree" \
+      "project=$dir/project" \
+      "harness=codex" \
+      "model=gpt-5.6-sol" \
+      "effort=high" \
+      "backend=cmux" \
+      "cmux_workspace_id=workspace1" \
+      "cmux_surface_id=surface1"
+  else
+    fm_write_meta "$dir/home/state/$id.meta" \
+      "window=lab:w1:p1" \
+      "endpoint_task_id=$id" \
+      "worktree=$dir/worktree" \
+      "project=$dir/project" \
+      "harness=codex" \
+      "model=gpt-5.6-sol" \
+      "effort=high" \
+      "backend=$backend" \
+      "herdr_session=lab" \
+      "herdr_workspace_id=w1" \
+      "herdr_tab_id=w1:t1" \
+      "herdr_pane_id=w1:p1" \
+      "session_marker=keep-me"
+  fi
+  cat > "$dir/fakebin/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf '<' >> "${FM_FAKE_LOG:?}"
+printf '%q ' "$@" >> "$FM_FAKE_LOG"
+printf '>\n' >> "$FM_FAKE_LOG"
+case "${1:-} ${2:-}" in
+  "status --json")
+    printf '%s\n' '{"server":{"running":true}}'
+    ;;
+  "pane get")
+    if [ "${FM_FAKE_PANE_STATE:-present}" = missing ]; then
+      printf '%s\n' '{"error":{"code":"pane_not_found"}}'
+    else
+      printf '{"result":{"pane":{"pane_id":"w1:p1","foreground_cwd":"%s"}}}\n' "$FM_FAKE_WORKTREE"
+    fi
+    ;;
+  "agent get")
+    printf '{"result":{"agent":{"agent":"codex","agent_status":"%s"}}}\n' "${FM_FAKE_AGENT_STATUS:-idle}"
+    ;;
+  "pane read")
+    effort=$(cat "$FM_FAKE_EFFORT_FILE")
+    meta_effort=$(grep '^effort=' "$FM_FAKE_META" | cut -d= -f2-)
+    if [ "$effort" = "$FM_FAKE_TARGET_EFFORT" ] && [ "$meta_effort" = high ]; then
+      : > "$FM_FAKE_VERIFIED_BEFORE_META"
+    fi
+    if [ -e "$FM_FAKE_CHANGED_FILE" ]; then
+      printf '%s\n' 'unrecognized Codex screen without a footer'
+    elif [ "${FM_FAKE_UI:-footer}" = footer ]; then
+      printf 'transcript\n\n› \n\n  gpt-5.6-sol %s · %s\n' "$effort" "$FM_FAKE_WORKTREE"
+    elif [ "${FM_FAKE_UI}" = busy ]; then
+      printf 'Working (esc to interrupt)\n\n› \n\n  gpt-5.6-sol %s · %s\n' "$effort" "$FM_FAKE_WORKTREE"
+    elif [ "${FM_FAKE_UI}" = misleading ]; then
+      printf 'Model set to gpt-5.6-sol %s\n\n› \n\n  gpt-5.6-sol %s · %s\n' "$FM_FAKE_TARGET_EFFORT" "$effort" "$FM_FAKE_WORKTREE"
+    else
+      printf '%s\n' "${FM_FAKE_UI}"
+    fi
+    ;;
+  "pane send-text")
+    key=${4:-}
+    effort=$(cat "$FM_FAKE_EFFORT_FILE")
+    case "$key" in
+      "$(printf '\033.')")
+        case "$effort" in low) effort=medium ;; medium) effort=high ;; high) effort=xhigh ;; xhigh) : ;; esac
+        printf 'increase\n' >> "$FM_FAKE_LOG"
+        ;;
+      "$(printf '\033,')")
+        case "$effort" in xhigh) effort=high ;; high) effort=medium ;; medium) effort=low ;; low) : ;; esac
+        printf 'decrease\n' >> "$FM_FAKE_LOG"
+        ;;
+      *) exit 9 ;;
+    esac
+    if [ "${FM_FAKE_SWALLOW:-0}" != 1 ]; then
+      printf '%s\n' "$effort" > "$FM_FAKE_EFFORT_FILE"
+    fi
+    if [ "${FM_FAKE_CHANGE_UI_AFTER_SEND:-0}" = 1 ]; then
+      : > "$FM_FAKE_CHANGED_FILE"
+    fi
+    ;;
+  *) exit 8 ;;
+esac
+SH
+  chmod +x "$dir/fakebin/herdr"
+  cat > "$dir/fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf '<' >> "${FM_FAKE_LOG:?}"
+printf '%q ' "$@" >> "$FM_FAKE_LOG"
+printf '>\n' >> "$FM_FAKE_LOG"
+case "${1:-}" in
+  list-windows)
+    printf '%s\n' 'fm-effort-task'
+    ;;
+  display-message)
+    format=${*: -1}
+    case "$format" in
+      '#{pane_current_command}') printf '%s\n' codex ;;
+      '#{pane_current_path}') printf '%s\n' "$FM_FAKE_WORKTREE" ;;
+      '#{pane_id}') printf '%s\n' '%1' ;;
+      '#{cursor_y}') printf '%s\n' 1 ;;
+      *) exit 8 ;;
+    esac
+    ;;
+  capture-pane)
+    effort=$(cat "$FM_FAKE_EFFORT_FILE")
+    if printf '%s\n' "$*" | grep -Fq -- '-e -p'; then
+      printf '╭────╮\n│ ›  │\n╰────╯\n  gpt-5.6-sol %s · %s\n' "$effort" "$FM_FAKE_WORKTREE"
+    elif [ -e "$FM_FAKE_CHANGED_FILE" ]; then
+      printf '%s\n' 'unrecognized Codex screen without a footer'
+    elif [ "${FM_FAKE_UI:-footer}" = busy ]; then
+      printf 'Working (esc to interrupt)\n\n› \n\n  gpt-5.6-sol %s · %s\n' "$effort" "$FM_FAKE_WORKTREE"
+    else
+      printf 'transcript\n\n› \n\n  gpt-5.6-sol %s · %s\n' "$effort" "$FM_FAKE_WORKTREE"
+    fi
+    ;;
+  send-keys)
+    key=${*: -1}
+    effort=$(cat "$FM_FAKE_EFFORT_FILE")
+    case "$key" in
+      M-.) case "$effort" in low) effort=medium ;; medium) effort=high ;; high) effort=xhigh ;; esac ;;
+      M-,) case "$effort" in xhigh) effort=high ;; high) effort=medium ;; medium) effort=low ;; esac ;;
+      *) exit 9 ;;
+    esac
+    printf '%s\n' "$effort" > "$FM_FAKE_EFFORT_FILE"
+    ;;
+  *) exit 7 ;;
+esac
+SH
+  chmod +x "$dir/fakebin/tmux"
+  printf '%s\n' "$dir"
+}
+
+run_case() {  # <dir> <effort>
+  local dir=$1 effort=$2
+  env FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_FAKE_LOG="$dir/runtime.log" FM_FAKE_WORKTREE="$dir/worktree" \
+    FM_FAKE_EFFORT_FILE="$dir/effort" \
+    FM_FAKE_META="$dir/home/state/effort-task.meta" \
+    FM_FAKE_TARGET_EFFORT="$effort" \
+    FM_FAKE_VERIFIED_BEFORE_META="$dir/verified-before-meta" \
+    FM_FAKE_CHANGED_FILE="$dir/changed-ui" \
+    FM_FAKE_AGENT_STATUS="${FM_FAKE_AGENT_STATUS:-idle}" \
+    FM_FAKE_PANE_STATE="${FM_FAKE_PANE_STATE:-present}" \
+    FM_FAKE_UI="${FM_FAKE_UI:-footer}" \
+    FM_FAKE_SWALLOW="${FM_FAKE_SWALLOW:-0}" \
+    FM_FAKE_CHANGE_UI_AFTER_SEND="${FM_FAKE_CHANGE_UI_AFTER_SEND:-0}" \
+    PATH="$dir/fakebin:$PATH" \
+    "$SWITCH" effort-task "$effort"
+}
+
+test_success_changes_effort_in_place_and_then_metadata() {
+  local dir out
+  dir=$(make_case success)
+  out=$(run_case "$dir" medium) || fail "successful effort switch failed: $out"
+  assert_contains "$out" "effort-task: gpt-5.6-sol medium" "success did not report the confirmed live effort"
+  [ "$(cat "$dir/effort")" = medium ] || fail "live fake Codex effort did not change"
+  [ "$(grep '^effort=' "$dir/home/state/effort-task.meta")" = effort=medium ] \
+    || fail "metadata did not record the confirmed effort"
+  assert_grep "decrease" "$dir/runtime.log" "success did not use the dedicated decrease-reasoning input"
+  assert_no_grep "/quit" "$dir/runtime.log" "success exited Codex instead of changing effort in place"
+  assert_no_grep "pane run" "$dir/runtime.log" "success submitted a turn instead of using an idle keybinding"
+  assert_grep "session_marker=keep-me" "$dir/home/state/effort-task.meta" "success changed session identity metadata"
+  assert_present "$dir/verified-before-meta" "metadata changed before the live footer was verified"
+  pass "fm-codex-effort: changes an idle Codex effort through the public interface without quit/resume"
+}
+
+test_tmux_reference_path_uses_semantic_reasoning_key() {
+  local dir out
+  dir=$(make_case tmux-success tmux)
+  out=$(run_case "$dir" medium) || fail "tmux effort switch failed: $out"
+  assert_contains "$out" "medium (tmux, session preserved)" "tmux success was not reported"
+  assert_grep "M-\\," "$dir/runtime.log" "tmux did not send its verified semantic Alt+, key"
+  assert_no_grep "/quit" "$dir/runtime.log" "tmux success exited Codex"
+  assert_grep "session_marker=keep-me" "$dir/home/state/effort-task.meta" "tmux success changed session identity metadata"
+  pass "fm-codex-effort: supports the verified tmux reference path"
+}
+
+test_invalid_effort_and_wrong_harness_refuse_without_runtime_input() {
+  local dir before out rc
+  dir=$(make_case invalid-effort)
+  before=$(cksum < "$dir/home/state/effort-task.meta")
+  out=$(run_case "$dir" max 2>&1); rc=$?
+  [ "$rc" -ne 0 ] || fail "unsupported effort was accepted"
+  assert_contains "$out" "unsupported Codex effort" "invalid effort refusal was unclear"
+  [ ! -s "$dir/runtime.log" ] || fail "invalid effort contacted the runtime"
+  [ "$(cksum < "$dir/home/state/effort-task.meta")" = "$before" ] || fail "invalid effort changed metadata"
+
+  dir=$(make_case wrong-harness)
+  sed -i 's/^harness=codex$/harness=claude/' "$dir/home/state/effort-task.meta"
+  before=$(cksum < "$dir/home/state/effort-task.meta")
+  out=$(run_case "$dir" medium 2>&1); rc=$?
+  [ "$rc" -ne 0 ] || fail "non-Codex harness was accepted"
+  assert_contains "$out" "not Codex" "wrong-harness refusal was unclear"
+  assert_no_grep "pane send-text" "$dir/runtime.log" "wrong harness received runtime input"
+  [ "$(cksum < "$dir/home/state/effort-task.meta")" = "$before" ] || fail "wrong harness changed metadata"
+  pass "fm-codex-effort: refuses invalid effort and non-Codex tasks without side effects"
+}
+
+test_busy_and_ambiguous_runtime_states_refuse() {
+  local dir before out rc
+  dir=$(make_case busy-agent)
+  before=$(cksum < "$dir/home/state/effort-task.meta")
+  out=$(FM_FAKE_AGENT_STATUS=working run_case "$dir" medium 2>&1); rc=$?
+  [ "$rc" -ne 0 ] || fail "busy native agent state was accepted"
+  assert_contains "$out" "not idle" "busy native-state refusal was unclear"
+  assert_no_grep "pane send-text" "$dir/runtime.log" "busy agent received effort input"
+  [ "$(cksum < "$dir/home/state/effort-task.meta")" = "$before" ] || fail "busy refusal changed metadata"
+
+  dir=$(make_case ambiguous-agent)
+  before=$(cksum < "$dir/home/state/effort-task.meta")
+  out=$(FM_FAKE_AGENT_STATUS=mystery run_case "$dir" medium 2>&1); rc=$?
+  [ "$rc" -ne 0 ] || fail "ambiguous agent state was accepted"
+  assert_contains "$out" "unreadable" "ambiguous endpoint refusal was unclear"
+  assert_no_grep "pane send-text" "$dir/runtime.log" "ambiguous endpoint received effort input"
+  [ "$(cksum < "$dir/home/state/effort-task.meta")" = "$before" ] || fail "ambiguous refusal changed metadata"
+
+  dir=$(make_case dead-endpoint)
+  before=$(cksum < "$dir/home/state/effort-task.meta")
+  out=$(FM_FAKE_PANE_STATE=missing run_case "$dir" medium 2>&1); rc=$?
+  [ "$rc" -ne 0 ] || fail "dead endpoint was accepted"
+  assert_contains "$out" "missing" "dead endpoint refusal was unclear"
+  assert_no_grep "pane send-text" "$dir/runtime.log" "dead endpoint received effort input"
+  [ "$(cksum < "$dir/home/state/effort-task.meta")" = "$before" ] || fail "dead endpoint refusal changed metadata"
+
+  dir=$(make_case busy-footer)
+  out=$(FM_FAKE_UI=busy run_case "$dir" medium 2>&1); rc=$?
+  [ "$rc" -ne 0 ] || fail "busy Codex footer was accepted"
+  assert_contains "$out" "busy Codex turn" "busy footer refusal was unclear"
+  assert_no_grep "pane send-text" "$dir/runtime.log" "busy footer received effort input"
+  pass "fm-codex-effort: refuses busy, ambiguous, and dead live states"
+}
+
+test_swallowed_input_and_changed_ui_never_report_success() {
+  local dir before out rc
+  dir=$(make_case swallowed)
+  before=$(cksum < "$dir/home/state/effort-task.meta")
+  out=$(FM_FAKE_SWALLOW=1 FM_FAKE_UI=misleading run_case "$dir" medium 2>&1); rc=$?
+  [ "$rc" -ne 0 ] || fail "swallowed input with misleading transcript reported success"
+  assert_contains "$out" "did not confirm" "swallowed-input refusal was unclear"
+  [ "$(cksum < "$dir/home/state/effort-task.meta")" = "$before" ] || fail "swallowed input changed metadata"
+
+  dir=$(make_case changed-ui)
+  before=$(cksum < "$dir/home/state/effort-task.meta")
+  out=$(FM_FAKE_CHANGE_UI_AFTER_SEND=1 run_case "$dir" medium 2>&1); rc=$?
+  [ "$rc" -ne 0 ] || fail "changed UI reported false success"
+  assert_contains "$out" "did not confirm" "changed-UI refusal was unclear"
+  [ "$(cksum < "$dir/home/state/effort-task.meta")" = "$before" ] || fail "changed UI changed metadata"
+  pass "fm-codex-effort: reports no false success when input is swallowed or the UI changes"
+}
+
+test_unverified_backends_refuse_before_input() {
+  local backend dir out rc
+  for backend in zellij orca cmux; do
+    dir=$(make_case "unsupported-$backend" "$backend")
+    out=$(run_case "$dir" medium 2>&1); rc=$?
+    [ "$rc" -ne 0 ] || fail "$backend was accepted without a verified effort-switch path"
+    assert_contains "$out" "no verified in-session" "$backend refusal was unclear"
+    [ ! -s "$dir/runtime.log" ] || fail "$backend refusal contacted a runtime"
+  done
+  pass "fm-codex-effort: refuses runtime backends without verified identity and input evidence"
+}
+
+test_success_changes_effort_in_place_and_then_metadata
+test_tmux_reference_path_uses_semantic_reasoning_key
+test_invalid_effort_and_wrong_harness_refuse_without_runtime_input
+test_busy_and_ambiguous_runtime_states_refuse
+test_swallowed_input_and_changed_ui_never_report_success
+test_unverified_backends_refuse_before_input

--- a/tests/fm-codex-effort.test.sh
+++ b/tests/fm-codex-effort.test.sh
@@ -160,6 +160,10 @@ case "${1:-} ${2:-}" in
     fi
     ;;
   "pane send-keys")
+    if [ "${FM_FAKE_BLOCK_KEY_SEND:-0}" = 1 ]; then
+      : > "${FM_FAKE_KEY_ENTERED:?}"
+      while [ ! -e "${FM_FAKE_ALLOW_KEY:?}" ]; do sleep 0.01; done
+    fi
     if [ "${4:-}" = enter ] && [ -n "${FM_FAKE_AGENT_STATUS_FILE:-}" ]; then
       printf 'working\n' > "$FM_FAKE_AGENT_STATUS_FILE"
     fi
@@ -249,6 +253,9 @@ run_case() {  # <dir> <effort>
     FM_FAKE_SEND_ENTERED="${FM_FAKE_SEND_ENTERED:-}" \
     FM_FAKE_ALLOW_SEND="${FM_FAKE_ALLOW_SEND:-}" \
     FM_FAKE_SENT_TEXT="${FM_FAKE_SENT_TEXT:-}" \
+    FM_FAKE_BLOCK_KEY_SEND="${FM_FAKE_BLOCK_KEY_SEND:-0}" \
+    FM_FAKE_KEY_ENTERED="${FM_FAKE_KEY_ENTERED:-}" \
+    FM_FAKE_ALLOW_KEY="${FM_FAKE_ALLOW_KEY:-}" \
     FM_FAKE_REAL_MV="$(command -v mv)" \
     PATH="$dir/fakebin:$PATH" \
     "$SWITCH" effort-task "$effort"
@@ -271,9 +278,37 @@ run_send_case() {  # <dir> <message>
     FM_FAKE_SEND_ENTERED="${FM_FAKE_SEND_ENTERED:-}" \
     FM_FAKE_ALLOW_SEND="${FM_FAKE_ALLOW_SEND:-}" \
     FM_FAKE_SENT_TEXT="${FM_FAKE_SENT_TEXT:-}" \
+    FM_FAKE_BLOCK_KEY_SEND="${FM_FAKE_BLOCK_KEY_SEND:-0}" \
+    FM_FAKE_KEY_ENTERED="${FM_FAKE_KEY_ENTERED:-}" \
+    FM_FAKE_ALLOW_KEY="${FM_FAKE_ALLOW_KEY:-}" \
     FM_SEND_SETTLE=0 FM_SEND_SLEEP=0 \
     PATH="$dir/fakebin:$PATH" \
     "$SEND" effort-task "$message"
+}
+
+run_key_send_case() {  # <dir> <key>
+  local dir=$1 key=$2
+  env FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_FAKE_LOG="$dir/runtime.log" FM_FAKE_WORKTREE="${FM_FAKE_WORKTREE:-$dir/worktree}" \
+    FM_FAKE_EFFORT_FILE="$dir/effort" \
+    FM_FAKE_META="$dir/home/state/effort-task.meta" \
+    FM_FAKE_TARGET_EFFORT=high \
+    FM_FAKE_CHANGED_FILE="$dir/changed-ui" \
+    FM_FAKE_AGENT_STATUS="${FM_FAKE_AGENT_STATUS:-idle}" \
+    FM_FAKE_PANE_STATE="${FM_FAKE_PANE_STATE:-present}" \
+    FM_FAKE_UI="${FM_FAKE_UI:-footer}" \
+    FM_FAKE_FOOTER_FIXTURE="${FM_FAKE_FOOTER_FIXTURE:-}" \
+    FM_FAKE_AGENT_STATUS_FILE="${FM_FAKE_AGENT_STATUS_FILE:-}" \
+    FM_FAKE_BLOCK_ORDINARY_SEND="${FM_FAKE_BLOCK_ORDINARY_SEND:-0}" \
+    FM_FAKE_SEND_ENTERED="${FM_FAKE_SEND_ENTERED:-}" \
+    FM_FAKE_ALLOW_SEND="${FM_FAKE_ALLOW_SEND:-}" \
+    FM_FAKE_SENT_TEXT="${FM_FAKE_SENT_TEXT:-}" \
+    FM_FAKE_BLOCK_KEY_SEND="${FM_FAKE_BLOCK_KEY_SEND:-0}" \
+    FM_FAKE_KEY_ENTERED="${FM_FAKE_KEY_ENTERED:-}" \
+    FM_FAKE_ALLOW_KEY="${FM_FAKE_ALLOW_KEY:-}" \
+    FM_SEND_SETTLE=0 FM_SEND_SLEEP=0 \
+    PATH="$dir/fakebin:$PATH" \
+    "$SEND" effort-task --key "$key"
 }
 
 test_success_changes_effort_in_place_and_then_metadata() {
@@ -489,7 +524,11 @@ test_ordinary_send_serializes_with_effort_chords_and_forces_a_fresh_idle_check()
   FM_FAKE_SENT_TEXT="$dir/sent-text" \
     run_case "$dir" medium >"$dir/effort.out" 2>"$dir/effort.err" &
   effort_pid=$!
-  sleep 0.15
+  waited=0
+  while ! grep -Eq 'increase|decrease' "$dir/runtime.log" && [ "$waited" -lt 100 ]; do
+    sleep 0.02
+    waited=$((waited + 1))
+  done
   if grep -Eq 'increase|decrease' "$dir/runtime.log"; then
     : > "$dir/allow-send"
     wait "$send_pid" || true
@@ -508,6 +547,59 @@ test_ordinary_send_serializes_with_effort_chords_and_forces_a_fresh_idle_check()
     "effort helper delivered a chord after the serialized send began a turn"
   assert_grep 'ordinary steer' "$dir/sent-text" "ordinary send did not deliver its own text"
   pass "fm-codex-effort: ordinary fm-send input serializes with chords and receives a fresh semantic idle check"
+}
+
+test_key_send_serializes_with_effort_chords_and_forces_a_fresh_idle_check() {
+  local dir key_pid effort_pid key_rc effort_rc waited=0
+  dir=$(make_case key-send-race)
+  printf 'idle\n' > "$dir/agent-status"
+
+  FM_FAKE_AGENT_STATUS_FILE="$dir/agent-status" \
+  FM_FAKE_BLOCK_KEY_SEND=1 \
+  FM_FAKE_KEY_ENTERED="$dir/key-entered" \
+  FM_FAKE_ALLOW_KEY="$dir/allow-key" \
+    run_key_send_case "$dir" Enter >"$dir/key.out" 2>"$dir/key.err" &
+  key_pid=$!
+  while [ ! -e "$dir/key-entered" ] && [ "$waited" -lt 100 ]; do
+    sleep 0.02
+    waited=$((waited + 1))
+  done
+  if [ ! -e "$dir/key-entered" ]; then
+    : > "$dir/allow-key"
+    wait "$key_pid" || true
+    fail "key send did not reach its deterministic in-flight point"
+  fi
+
+  FM_FAKE_AGENT_STATUS_FILE="$dir/agent-status" \
+  FM_FAKE_BLOCK_KEY_SEND=1 \
+  FM_FAKE_KEY_ENTERED="$dir/key-entered" \
+  FM_FAKE_ALLOW_KEY="$dir/allow-key" \
+    run_case "$dir" medium >"$dir/effort.out" 2>"$dir/effort.err" &
+  effort_pid=$!
+  waited=0
+  while ! grep -Eq 'increase|decrease' "$dir/runtime.log" && [ "$waited" -lt 100 ]; do
+    sleep 0.02
+    waited=$((waited + 1))
+  done
+  if grep -Eq 'increase|decrease' "$dir/runtime.log"; then
+    : > "$dir/allow-key"
+    wait "$key_pid" || true
+    wait "$effort_pid" || true
+    fail "effort chord landed while key input held the endpoint input transaction"
+  fi
+
+  : > "$dir/allow-key"
+  key_rc=0; wait "$key_pid" || key_rc=$?
+  effort_rc=0; wait "$effort_pid" || effort_rc=$?
+  expect_code 0 "$key_rc" "key send should complete before the effort helper retries its idle check"
+  assert_grep 'pane send-keys w1:p1 enter' "$dir/runtime.log" \
+    "serialized key send did not deliver its recorded Enter input"
+  [ "$effort_rc" -ne 0 ] || fail "effort helper accepted an endpoint made busy by the serialized key send"
+  assert_contains "$(cat "$dir/effort.err")" "not idle" \
+    "effort helper did not recheck native semantic idle after a serialized key send"
+  assert_no_grep 'increase|decrease' "$dir/runtime.log" \
+    "effort helper delivered a chord after the serialized key send began a turn"
+  pass "fm-codex-effort: recorded fm-send --key input serializes with chords and receives a fresh semantic idle check"
 }
 
 test_post_send_failures_leave_a_durable_recoverable_record() {
@@ -571,5 +663,6 @@ test_swallowed_input_and_changed_ui_never_report_success
 test_footer_requires_the_current_bottom_status_row
 test_captured_real_codex_0147_footers_bind_the_recorded_worktree
 test_ordinary_send_serializes_with_effort_chords_and_forces_a_fresh_idle_check
+test_key_send_serializes_with_effort_chords_and_forces_a_fresh_idle_check
 test_post_send_failures_leave_a_durable_recoverable_record
 test_unverified_backends_refuse_before_input

--- a/tests/fm-documentation-audiences.test.sh
+++ b/tests/fm-documentation-audiences.test.sh
@@ -58,6 +58,21 @@ test_repository_inventory_passes() {
     "audience check did not report exact surface coverage"
   assert_contains "$out" "local_links=" \
     "audience check did not report local-link validation"
+  python3 - "$INVENTORY" <<'PY' || fail "captured Codex footer fixtures were not classified as maintainer verification evidence"
+import json
+import sys
+
+surfaces = {
+    entry["path"]: entry["audience"]
+    for entry in json.loads(open(sys.argv[1], encoding="utf-8").read())["surfaces"]
+}
+expected = {
+    "tests/fixtures/codex-effort/codex-0.147-absolute-footer.txt",
+    "tests/fixtures/codex-effort/codex-0.147-home-abbreviated-footer.txt",
+}
+if any(surfaces.get(path) != "maintainer-verification" for path in expected):
+    raise SystemExit(1)
+PY
   pass "documentation inventory classifies every maintained prose surface exactly once"
 }
 

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -57,6 +57,7 @@ fm_git_identity fmtest fmtest@example.invalid
 
 TEARDOWN="$ROOT/bin/fm-teardown.sh"
 PR_CHECK="$ROOT/bin/fm-pr-check.sh"
+CODEX_EFFORT="$ROOT/bin/fm-codex-effort.sh"
 TMP_ROOT=$(fm_test_tmproot fm-teardown-tests)
 REAL_GIT_FOR_TEST=$(command -v git)
 export REAL_GIT_FOR_TEST
@@ -1324,6 +1325,64 @@ test_teardown_missing_busy_sidecar_completes() {
   assert_absent "$case_dir/state/task-x1.meta" \
     "missing-busy-sidecar: teardown remained incomplete"
   pass "teardown completes when an exact busy-state sidecar is already absent"
+}
+
+test_teardown_retires_codex_effort_recovery_before_task_id_reuse() {
+  local case_dir rc out
+  case_dir=$(make_case codex-effort-recovery-task-id-reuse)
+  write_meta "$case_dir" local-only ship
+  printf '%s\n' \
+    'version=1' \
+    'task_id=task-x1' \
+    'backend=herdr' \
+    'target=old-lab:w0:p0' \
+    'harness=codex' \
+    'model=gpt-5.6-sol' \
+    'worktree=/retired/worktree' \
+    'metadata_identity_checksum=0 0' \
+    'recorded_effort=high' \
+    'requested_effort=medium' > "$case_dir/state/task-x1.codex-effort-recovery"
+
+  run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr" \
+    || fail "codex-effort-recovery-task-id-reuse: forced teardown failed: $(cat "$case_dir/stderr")"
+  assert_absent "$case_dir/state/task-x1.codex-effort-recovery" \
+    "codex-effort-recovery-task-id-reuse: teardown retained the retired task's recovery record"
+
+  # Recreate the same task id with a distinct Herdr endpoint.
+  # If the former task's journal survived, the public helper refuses before runtime input because its identity fields no longer match this incarnation.
+  fm_write_meta "$case_dir/state/task-x1.meta" \
+    "window=lab:w1:p1" \
+    "endpoint_task_id=task-x1" \
+    "worktree=$case_dir/wt" \
+    "project=$case_dir/project" \
+    'harness=codex' \
+    'model=gpt-5.6-sol' \
+    'effort=high' \
+    'backend=herdr' \
+    'herdr_session=lab' \
+    'herdr_workspace_id=w1' \
+    'herdr_tab_id=w1:t1' \
+    'herdr_pane_id=w1:p1'
+  printf 'high\n' > "$case_dir/effort"
+  cat > "$case_dir/fakebin/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-} ${2:-}" in
+  "status --json") printf '%s\n' '{"server":{"running":true}}' ;;
+  "pane get") printf '{"result":{"pane":{"pane_id":"w1:p1","foreground_cwd":"%s"}}}\n' "$FM_REUSE_WORKTREE" ;;
+  "agent get") printf '%s\n' '{"result":{"agent":{"agent":"codex","agent_status":"idle"}}}' ;;
+  "pane read") printf '› \n\ngpt-5.6-sol high · %s\n' "$FM_REUSE_WORKTREE" ;;
+  "pane send-text") exit 9 ;;
+  *) exit 8 ;;
+esac
+SH
+  chmod +x "$case_dir/fakebin/herdr"
+  out=$(FM_HOME="$case_dir" FM_ROOT_OVERRIDE="$ROOT" FM_REUSE_WORKTREE="$case_dir/wt" \
+    PATH="$case_dir/fakebin:$PATH" "$CODEX_EFFORT" task-x1 high) \
+    || fail "codex-effort-recovery-task-id-reuse: a new task incarnation was poisoned by old recovery state: $out"
+  assert_contains "$out" 'task-x1: gpt-5.6-sol high' \
+    "codex-effort-recovery-task-id-reuse: the recreated task did not reach the public helper"
+  pass "teardown retires Codex effort recovery state before the task id can be reused"
 }
 
 test_herdr_teardown_clears_escalation_marker() {
@@ -2600,6 +2659,7 @@ test_no_mistakes_origin_remote_allows
 test_no_mistakes_truly_unpushed_refuses
 test_local_only_force_overrides_unpushed
 test_teardown_missing_busy_sidecar_completes
+test_teardown_retires_codex_effort_recovery_before_task_id_reuse
 test_herdr_teardown_clears_escalation_marker
 test_herdr_flat_teardown_refuses_orphaning_records_then_retry_completes
 test_herdr_flat_teardown_refuses_records_on_unparseable_presence

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -145,6 +145,18 @@ test_changed_dependency_selection_and_unmapped_failure() {
   git -C "$repo" add tests/lib.sh
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm helper-change
 
+  : >"$repo/bin/fm-wake-lib.sh"
+  git -C "$repo" add bin/fm-wake-lib.sh
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm wake-helper-baseline
+  printf '\n' >>"$repo/bin/fm-wake-lib.sh"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-session-start.test.sh" "wake helper selects bootstrap coverage"
+  assert_contains "$listed" "tests/fm-backend.test.sh" "wake helper selects backend coverage"
+  assert_contains "$listed" "tests/fm-pr-merge.test.sh" "wake helper selects PR coverage"
+  assert_contains "$listed" "tests/fm-pi-watch-extension.test.sh" "wake helper selects watcher coverage"
+  git -C "$repo" add bin/fm-wake-lib.sh
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm wake-helper-change
+
   printf '\n' >>"$repo/tests/fm-backend-herdr-eventwait.test.py"
   listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
   assert_contains "$listed" "tests/fm-backend-herdr-smoke.test.sh" "eventwait test selects Herdr coverage"

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -1098,10 +1098,38 @@ test_msys_pid_identity_uses_proc() {
   pass "MSYS process identity uses compatible /proc fields"
 }
 
+test_task_input_lock_path_uses_the_task_id_safety_boundary() {
+  local dir state out
+  dir=$(make_case task-input-lock-path)
+  state="$dir/state"
+  out=$(FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    fm_task_input_lock_path "$2" task-a
+  ' _ "$LIB" "$state") \
+    || fail "task input lock path refused a valid task id"
+  [ "$out" = "$state/.input-task-a.lock" ] \
+    || fail "task input lock path was not scoped to its state/task identity: $out"
+  out=$(cd "$dir" && FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    fm_task_input_lock_path state task-a
+  ' _ "$LIB") || fail "task input lock path did not canonicalize a relative state directory"
+  [ "$out" = "$state/.input-task-a.lock" ] \
+    || fail "relative state directory did not resolve to the shared endpoint lock: $out"
+  FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    ! fm_task_input_lock_path "$2" .hidden \
+      && ! fm_task_input_lock_path "$2" "bad/id" \
+      && ! fm_task_input_lock_path "$2/absent" task-a
+  ' _ "$LIB" "$state" \
+    || fail "task input lock path accepted an unsafe task identity or absent state directory"
+  pass "task input lock path binds each safe task identity to one canonical state endpoint"
+}
+
 test_singleton_start
 test_pid_identity_is_locale_invariant
 test_proc_pid_identity_ignores_wall_clock_and_detects_pid_reuse
 test_msys_pid_identity_uses_proc
+test_task_input_lock_path_uses_the_task_id_safety_boundary
 test_stale_watch_lock_reclaimed
 test_stale_watch_reclaim_publishes_before_clear
 test_live_stale_watch_lock_is_actionable


### PR DESCRIPTION
## Intent

Advance the Codex effort-switch feature from the current fork `main` (`4930d2c`) through a fresh correction branch.
Recorded-task `bin/fm-send.sh --key` transactions now participate in the same per-task endpoint input lock as ordinary text sends and `bin/fm-codex-effort.sh`, while explicit unrecorded endpoint behavior remains unchanged.

## What changed

- Added the recorded-task input lock to the public `fm-send --key` path.
- Kept the lock held through special-key delivery and the existing Escape composer-clear and interrupt-bookkeeping transactions.
- Added deterministic public-interface regression coverage for recorded-task `Enter` racing the effort helper.
- Retained coverage for Muse `Escape` composer clearing and Claude `Escape` interrupt bookkeeping racing ordinary sends.
- Reconciled the effort-switch implementation with current fork-main code, including durable recovery, teardown cleanup, runner mapping, and current Codex 0.147 footer evidence.
- Explicit backend targets still bypass recorded-task bookkeeping and the task input lock.

## Validation evidence

Passed:

- `bash tests/fm-codex-effort.test.sh` - all effort, recorded `Enter`, Muse `Escape`, and Claude `Escape` races passed.
- Focused runner execution of send, effort, control, backend, teardown, watcher-lock, documentation, and runner suites - all behavior assertions passed except the environment limitations below.
- `bin/fm-doc-audience-check.sh` - `ok surfaces=69 local_links=243`.
- `bin/fm-test-run.sh --check-coverage` - `FM_TEST_COVERAGE ok total=144 parallel=24 serial=108 serial_shards=4 herdr=12`.
- `git diff --check main...HEAD` and `bash -n` for all changed shell files.
- Complete diff review against `main` (`4930d2c`) found no unexpected files or whitespace/syntax defects.

Environment-limited:

- `bin/fm-lint.sh` - blocked because pinned ShellCheck `0.11.0` is not installed (`ShellCheck not found`).
- `tests/fm-backend-herdr.test.sh` - blocked in its absent-Herdr fixture because this host has an absolute `/usr/sbin/herdr` (`herdr 0.8.0`).
- `tests/fm-backend-tmux-smoke.test.sh` - tmux `3.7b` starts, but its task shell did not complete setup.

Not run by instruction: no-mistakes, Herdr lifecycle operations, merge, default-branch modification, or force-push.

## Scope

- Base: `pranaypratyush/firstmate:main` at `4930d2c`.
- Branch: `fm/firstmate-pr1-special-key-lock-correction`.
- The existing `fm/firstmate-codex-effort-switch-rebase` branch was not modified.
