### PR TITLE
feat(spawn): add --linear-issue for Orca worktree creation

### DIFF
--- a/bin/backends/orca.sh
+++ b/bin/backends/orca.sh
@@ -128,10 +128,13 @@ fm_backend_orca_repo_ensure() {  # <project-path>
   printf '%s' "$repo_id"
 }
 
-fm_backend_orca_worktree_create() {  # <project-path> <name>
-  local project=$1 name=$2 repo_id out wt_id wt_path terminal
+fm_backend_orca_worktree_create() {  # <project-path> <name> [linear-issue]
+  local project=$1 name=$2 linear_issue=${3:-} repo_id out wt_id wt_path terminal
+  local create_args=()
   repo_id=$(fm_backend_orca_repo_ensure "$project") || return 1
-  out=$(orca worktree create --repo "id:$repo_id" --name "$name" --no-parent --setup skip --json) || return 1
+  create_args=(worktree create --repo "id:$repo_id" --name "$name" --no-parent --setup skip)
+  [ -z "$linear_issue" ] || create_args+=(--linear-issue "$linear_issue")
+  out=$(orca "${create_args[@]}" --json) || return 1
   wt_id=$(printf '%s' "$out" | fm_backend_orca_json_get worktree-id) || {
     echo "error: orca worktree create did not return a worktree id for $name" >&2
     return 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Spawn a direct report: a crewmate in a treehouse or Orca worktree, or a
 # secondmate in its isolated firstmate home.
-# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
-#        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
+# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--linear-issue <identifier-or-url>]
+#        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--linear-issue <identifier-or-url>]
 #        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] --secondmate
 #   --mode and --yolo are this task's delivery contract, REQUIRED for every ship
 #   spawn and refused on --scout and --secondmate spawns. Firstmate resolves both
@@ -58,6 +58,9 @@
 #   A backend spawn refusal (missing dependency, version gate, unauthenticated
 #   socket, or unsupported secondmate mode) is terminal for that selected backend;
 #   callers must surface it instead of silently retrying another backend.
+#   --linear-issue <identifier-or-url> links a fresh Orca ship/scout worktree to
+#   one Linear issue during creation. It is refused for every other backend,
+#   batch dispatch, --secondmate, and --relaunch instead of being ignored.
 #   A herdr crewmate or scout is placed in the exact workspace of the firstmate
 #   or secondmate process launching it, resolved from that process's own herdr
 #   pane rather than from a workspace label (herdr enforces no label uniqueness,
@@ -272,6 +275,7 @@ HARNESS_ARG=
 MODEL=
 EFFORT=
 BACKEND_ARG=
+LINEAR_ISSUE=
 MODE=
 YOLO=
 TRACEPARENT_ARG=
@@ -279,6 +283,7 @@ HARNESS_SET=0
 MODEL_SET=0
 EFFORT_SET=0
 BACKEND_SET=0
+LINEAR_ISSUE_SET=0
 MODE_SET=0
 YOLO_SET=0
 TRACEPARENT_SET=0
@@ -295,6 +300,7 @@ for a in "$@"; do
       model) MODEL=$a; MODEL_SET=1 ;;
       effort) EFFORT=$a; EFFORT_SET=1 ;;
       backend) BACKEND_ARG=$a; BACKEND_SET=1 ;;
+      linear-issue) LINEAR_ISSUE=$a; LINEAR_ISSUE_SET=1 ;;
       mode) MODE=$a; MODE_SET=1 ;;
       yolo) YOLO=$a; YOLO_SET=1 ;;
       traceparent) TRACEPARENT_ARG=$a; TRACEPARENT_SET=1 ;;
@@ -315,6 +321,8 @@ for a in "$@"; do
     --effort=*) EFFORT=${a#--effort=}; EFFORT_SET=1 ;;
     --backend) want_value=backend ;;
     --backend=*) BACKEND_ARG=${a#--backend=}; BACKEND_SET=1 ;;
+    --linear-issue) want_value=linear-issue ;;
+    --linear-issue=*) LINEAR_ISSUE=${a#--linear-issue=}; LINEAR_ISSUE_SET=1 ;;
     --mode) want_value=mode ;;
     --mode=*) MODE=${a#--mode=}; MODE_SET=1 ;;
     --yolo) want_value=yolo ;;
@@ -329,6 +337,7 @@ done
 [ "$MODEL_SET" -eq 0 ] || [ -n "$MODEL" ] || { echo "error: --model requires a non-empty value" >&2; exit 1; }
 [ "$EFFORT_SET" -eq 0 ] || [ -n "$EFFORT" ] || { echo "error: --effort requires a non-empty value" >&2; exit 1; }
 [ "$BACKEND_SET" -eq 0 ] || [ -n "$BACKEND_ARG" ] || { echo "error: --backend requires a non-empty value" >&2; exit 1; }
+[ "$LINEAR_ISSUE_SET" -eq 0 ] || [ -n "$LINEAR_ISSUE" ] || { echo "error: --linear-issue requires a non-empty value" >&2; exit 1; }
 [ "$MODE_SET" -eq 0 ] || [ -n "$MODE" ] || { echo "error: --mode requires a non-empty value" >&2; exit 1; }
 [ "$YOLO_SET" -eq 0 ] || [ -n "$YOLO" ] || { echo "error: --yolo requires a non-empty value" >&2; exit 1; }
 [ "$TRACEPARENT_SET" -eq 0 ] || [ -n "$TRACEPARENT_ARG" ] || { echo "error: --traceparent requires a non-empty value" >&2; exit 1; }
@@ -356,10 +365,15 @@ esac
 # refusal rather than a silently-ignored flag.
 if [ "$RELAUNCH" -eq 1 ]; then
   [ "$BACKEND_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded backend; --backend cannot override it" >&2; exit 1; }
+  [ "$LINEAR_ISSUE_SET" -eq 0 ] || { echo "error: --linear-issue applies only when creating a fresh Orca worktree; --relaunch reuses the existing worktree" >&2; exit 1; }
   [ "$KIND_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded kind; --scout/--secondmate cannot override it" >&2; exit 1; }
   [ "$MODE_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded delivery mode; --mode cannot override it" >&2; exit 1; }
   [ "$YOLO_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded yolo posture; --yolo cannot override it" >&2; exit 1; }
 else
+  if [ "$LINEAR_ISSUE_SET" -eq 1 ] && [ "$KIND" = secondmate ]; then
+    echo "error: --linear-issue applies only to Orca ship/scout spawns, not --secondmate" >&2
+    exit 1
+  fi
   # Delivery contract (AGENTS.md section 7). A ship task's mode and yolo are
   # firstmate's per-task decision, so they are required and closed-set validated
   # here rather than resolved from the project registry. Scouts deliver a report
@@ -853,6 +867,10 @@ if [ "$RELAUNCH" -eq 1 ] && [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart"
   exit 1
 fi
 if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in */*) false ;; *) true ;; esac; then
+  [ "$LINEAR_ISSUE_SET" -eq 0 ] || {
+    echo "error: batch dispatch does not support --linear-issue; spawn each Linear-linked task explicitly" >&2
+    exit 1
+  }
   if [ "$KIND" != secondmate ] && [ -z "$HARNESS_ARG" ] && [ -f "$CONFIG/crew-dispatch.json" ]; then
     echo "error: config/crew-dispatch.json is active - pass an explicit harness resolved from the dispatch rules (the consultation backstop, so the rules are never silently skipped)." >&2
     exit 1
@@ -954,6 +972,10 @@ if [ "$RELAUNCH" -eq 0 ]; then
   fm_backend_source "$BACKEND" || exit 1
   if [ "$BACKEND" = orca ] && [ "$KIND" = secondmate ]; then
     echo "error: backend=orca does not support --secondmate spawns yet" >&2
+    exit 1
+  fi
+  if [ "$LINEAR_ISSUE_SET" -eq 1 ] && [ "$BACKEND" != orca ]; then
+    echo "error: --linear-issue requires backend=orca; resolved backend is '$BACKEND'" >&2
     exit 1
   fi
   if [ "$BACKEND" = cmux ] && [ "$KIND" = secondmate ]; then
@@ -2064,7 +2086,7 @@ EOF
     ;;
   orca)
     set +e
-    ORCA_WT_RAW=$(fm_backend_orca_worktree_create "$PROJ_ABS" "$W")
+    ORCA_WT_RAW=$(fm_backend_orca_worktree_create "$PROJ_ABS" "$W" "$LINEAR_ISSUE")
     ORCA_WT_STATUS=$?
     set -e
     if [ "$ORCA_WT_STATUS" -ne 0 ]; then

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -46,7 +46,9 @@ worktree=<absolute Orca worktree path>
 ## Current lifecycle and safety
 
 Spawn registers the repository, creates an independent worktree, reuses only the verified `result.terminal.handle` returned by Orca or creates a terminal explicitly, installs harness hooks, records metadata, and launches the selected harness.
-Exact command flags and response parsing are owned by `bin/backends/orca.sh` and script help.
+Because Orca owns worktree creation, a fresh ship or scout worktree can also be linked to one Linear issue as Orca creates it.
+That option is Orca-only and is refused, never silently ignored, wherever it does not apply.
+Exact command flags and response parsing are owned by `bin/backends/orca.sh` and [`fm-spawn.sh --help`](../bin/fm-spawn.sh).
 
 `fm-peek.sh` reads with `orca terminal read`.
 `fm-send.sh` types and verifies composer clearance through the fleet-wide classifier in `bin/fm-composer-lib.sh`, retrying Enter without retyping when a slash popup first fills an argument placeholder.

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -516,6 +516,8 @@ test_spawn_writes_orca_metadata_and_launches_harness() {
   assert_grep "terminal=term-spawn" "$state/$id.meta" "meta missing terminal handle"
   assert_grep "orca_worktree_id=wt-spawn" "$state/$id.meta" "meta missing Orca worktree id"
   assert_grep "worktree=$wt" "$state/$id.meta" "meta missing Orca worktree path"
+  assert_not_contains "$(cat "$log")" $'\x1f''--linear-issue'$'\x1f' \
+    "spawn without --linear-issue should preserve the existing Orca create command"
   assert_not_contains "$(cat "$log")" $'orca\x1f''terminal'$'\x1f''create' \
     "spawn should reuse the implicit terminal returned by Orca worktree creation"
   assert_contains "$(cat "$log")" $'orca\x1f''terminal'$'\x1f''send'$'\x1f''--terminal'$'\x1f''term-spawn'$'\x1f''--text'$'\x1f''export GOTMPDIR=/tmp/fm-orcaspawnz1/gotmp'$'\x1f''--enter'$'\x1f''--json' \
@@ -524,6 +526,93 @@ test_spawn_writes_orca_metadata_and_launches_harness() {
     "spawn did not send the selected harness launch command through Orca"
   rm -rf "/tmp/fm-$id"
   pass "fm-spawn.sh --backend orca: reuses implicit terminal, records metadata, launches harness"
+}
+
+test_spawn_forwards_linear_issue_to_orca_worktree_create() {
+  local proj wt data state config id linear out log
+  id="orcalinearz2"
+  proj="$TMP_ROOT/linear-spawn-project"
+  wt="$TMP_ROOT/linear-spawn-wt"
+  data="$TMP_ROOT/linear-spawn-data"
+  state="$TMP_ROOT/linear-spawn-state"
+  config="$TMP_ROOT/linear-spawn-config"
+  linear="https://linear.app/acme/issue/ENG-42/link-at-create"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  mkdir -p "$data/$id" "$state" "$config"
+  printf 'brief\n' > "$data/$id/brief.md"
+  touch "$state/.last-watcher-beat"
+  orca_case linear-spawn
+  log="$LOG"
+  printf '1\n' > "$RESP/1.exit"
+  printf '{"ok":true,"result":{"repo":{"id":"repo-linear"}}}\n' > "$RESP/2.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"wt-linear","path":"%s"},"terminal":{"handle":"term-linear"}}}\n' "$wt" > "$RESP/3.out"
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
+    FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" "$id" "$proj" claude --mode no-mistakes --yolo off --backend orca \
+      --linear-issue "$linear" 2>&1 )
+  expect_code 0 $? "fm-spawn.sh --linear-issue should succeed with fake Orca"$'\n'"$out"
+  assert_contains "$(cat "$log")" $'\x1f''--linear-issue'$'\x1f'"$linear"$'\x1f''--json' \
+    "spawn did not forward the exact Linear issue URL to Orca worktree creation"
+  rm -rf "/tmp/fm-$id"
+  pass "fm-spawn.sh --linear-issue: forwards the exact value to Orca worktree creation"
+}
+
+test_spawn_refuses_linear_issue_on_non_orca_backend() {
+  local data state config id out status
+  id="lineartmuxz3"
+  data="$TMP_ROOT/linear-tmux-data"
+  state="$TMP_ROOT/linear-tmux-state"
+  config="$TMP_ROOT/linear-tmux-config"
+  mkdir -p "$data" "$state" "$config"
+  orca_case linear-tmux
+  add_tmux_fake "$FB"
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
+    FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" "$id" "$TMP_ROOT/unused-project" claude \
+      --mode no-mistakes --yolo off --backend tmux --linear-issue ENG-42 2>&1 )
+  status=$?
+  [ "$status" -ne 0 ] || fail "fm-spawn.sh should refuse --linear-issue on backend=tmux"
+  assert_contains "$out" "--linear-issue requires backend=orca; resolved backend is 'tmux'" \
+    "non-Orca refusal should name the option and resolved backend"
+  [ ! -s "$LOG" ] || fail "non-Orca --linear-issue refusal should happen before backend mutation"
+  assert_absent "$state/$id.meta" "non-Orca --linear-issue refusal should not publish metadata"
+  pass "fm-spawn.sh --linear-issue: refuses a resolved non-Orca backend before mutation"
+}
+
+test_spawn_refuses_linear_issue_without_fresh_single_worker_worktree() {
+  local data state config out status
+  data="$TMP_ROOT/linear-shape-data"
+  state="$TMP_ROOT/linear-shape-state"
+  config="$TMP_ROOT/linear-shape-config"
+  mkdir -p "$data" "$state" "$config"
+
+  out=$( FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
+    FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" linearrelaunchz4 --relaunch --linear-issue ENG-42 2>&1 )
+  status=$?
+  [ "$status" -ne 0 ] || fail "--relaunch should refuse --linear-issue"
+  assert_contains "$out" "--linear-issue applies only when creating a fresh Orca worktree" \
+    "relaunch refusal should explain that it reuses a worktree"
+
+  out=$( FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
+    FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" linearsecondmatez5 --secondmate --backend orca --linear-issue ENG-42 2>&1 )
+  status=$?
+  [ "$status" -ne 0 ] || fail "--secondmate should refuse --linear-issue"
+  assert_contains "$out" "--linear-issue applies only to Orca ship/scout spawns" \
+    "secondmate refusal should name the supported worker kinds"
+
+  out=$( FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
+    FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" linearbatchz6=projects/none --mode no-mistakes --yolo off \
+      --backend orca --linear-issue ENG-42 2>&1 )
+  status=$?
+  [ "$status" -ne 0 ] || fail "batch dispatch should refuse --linear-issue"
+  assert_contains "$out" "batch dispatch does not support --linear-issue" \
+    "batch refusal should require explicit per-task issue linkage"
+  pass "fm-spawn.sh --linear-issue: refuses relaunch, secondmate, and batch paths"
 }
 
 test_spawn_refuses_orca_secondmate_before_home_mutation() {
@@ -1325,6 +1414,9 @@ test_worktree_and_terminal_helpers_parse_json
 test_worktree_create_removes_worktree_when_path_missing
 test_spawn_preserves_orca_metadata_when_pathless_worktree_cleanup_fails
 test_spawn_writes_orca_metadata_and_launches_harness
+test_spawn_forwards_linear_issue_to_orca_worktree_create
+test_spawn_refuses_linear_issue_on_non_orca_backend
+test_spawn_refuses_linear_issue_without_fresh_single_worker_worktree
 test_spawn_refuses_orca_secondmate_before_home_mutation
 test_spawn_refuses_orca_when_runtime_not_ready
 test_spawn_refuses_orca_nonisolated_worktree


### PR DESCRIPTION
## Intent

Add first-class Linear issue linking when Firstmate creates an Orca-backed worker. The normal bin/fm-spawn.sh path must accept one optional Linear issue identifier or URL, document it in the script-owned help and header, and pass the exact value to the existing orca worktree create --linear-issue option so the worktree is linked at creation time. Preserve existing behavior when omitted. Reject use on another backend with a clear error rather than silently ignoring it. Keep backend interfaces minimal and do not add broad configuration, other issue trackers, or speculative support. Add executable regression coverage through the public spawn/backend interface for exact forwarding, omission, and unsupported-backend behavior; tests must assert behavior rather than source text. Review all supported backend and harness integration surfaces affected by this spawn option and keep unaffected paths unchanged. Update docs/orca-backend.md only if operator-facing current behavior needs it, while exact flag mechanics remain owned by fm-spawn help/header. Run focused tests, bin/fm-lint.sh, documentation checks for prose changes, and the relevant broader suite. Commit the implementation, validate it through no-mistakes to green CI, and report the full PR URL. Prefer the existing fake-Orca/backend regression harness as evidence and use a disposable real Orca smoke only if tests cannot safely prove the boundary.

## What Changed

- `fm-spawn.sh` accepts an optional `--linear-issue <identifier-or-url>` on ship and scout spawns and passes the exact value through to `fm_backend_orca_worktree_create`, which appends `--linear-issue <value>` to `orca worktree create` so the worktree is linked as Orca creates it. Omitting the option leaves the existing create command byte-identical.
- The option is refused with a specific error instead of being ignored when the resolved backend is not `orca`, and on `--relaunch`, `--secondmate`, and batch dispatch; an empty value is also rejected. Usage lines and the script header document the new flag.
- `tests/fm-backend-orca.test.sh` covers exact forwarding through the fake-Orca harness, absence of the flag when unset, refusal on `backend=tmux` before any backend mutation or metadata write, and the relaunch/secondmate/batch refusals. `docs/orca-backend.md` notes that Orca-created worktrees can be Linear-linked and points flag mechanics at `fm-spawn.sh`.

## Risk Assessment

✅ Low: Additive, tightly bounded optional flag with a single forwarding call site, byte-identical behavior when omitted, four reachable pre-mutation refusals for every path where it cannot take effect, and behavior-level regression coverage through the public spawn interface.

## Testing

<code>Ran the focused Orca backend suite (40 tests, including the change&#39;s three new spawn regressions) and the batch-spawn suite (5 tests), both green. Because passing unit tests alone don&#39;t show the operator experience, I also drove `bin/fm-spawn.sh` end-to-end against the repo&#39;s fake-Orca CLI and captured the actual command lines Firstmate issues: a ship spawn with `--linear-issue` emits `orca worktree create … --linear-issue &lt;exact-url&gt; --json` and exits 0; the same spawn without the flag emits the unchanged command; a scout spawn forwards the value identically (a surface the new tests don&#39;t cover, sharing the single call site at bin/fm-spawn.sh:2089); and `--backend tmux --linear-issue` fails with `--linear-issue requires backend=orca; resolved backend is &#39;tmux&#39;` having made zero backend calls and published no metadata. Two fixture gaps surfaced and were fixed in my evidence script rather than the product — this gate worktree exports `NO_MISTAKES_GATE` (needing the harness&#39;s `FM_GATE_REFUSE_BYPASS=1`) and the synthetic project needed a real `origin` remote to clear the stale-base check. `fm_backend_orca_worktree_create` has exactly one caller, so no other backend or harness surface is affected. Linting and documentation checks were deliberately not run; they fall outside this phase.</code>

<details>
<summary>Evidence: End-to-end CLI transcript: Firstmate --linear-issue → orca worktree create</summary>

<code>## 1. Ship spawn WITH --linear-issue&#10;$ fm-spawn.sh linearshipe1 &lt;project&gt; claude --backend orca --mode no-mistakes --yolo off --linear-issue https://linear.app/acme/issue/ENG-42/link-at-create&#10;exit status: 0&#10;-- orca CLI commands Firstmate issued --&#10;orca worktree create --repo id:repo-ship-linear --name fm-linearshipe1 --no-parent --setup skip --linear-issue https://linear.app/acme/issue/ENG-42/link-at-create --json&#10;&#10;## 2. Ship spawn WITHOUT --linear-issue (existing behavior preserved)&#10;$ fm-spawn.sh linearshipe2 &lt;project&gt; claude --backend orca --mode no-mistakes --yolo off&#10;exit status: 0&#10;-- orca CLI commands Firstmate issued --&#10;orca worktree create --repo id:repo-ship-plain --name fm-linearshipe2 --no-parent --setup skip --json&#10;&#10;## 3. Scout spawn WITH --linear-issue&#10;$ fm-spawn.sh linearscoute3 &lt;project&gt; claude --backend orca --scout --linear-issue https://linear.app/acme/issue/ENG-42/link-at-create&#10;exit status: 0&#10;-- orca CLI commands Firstmate issued --&#10;orca worktree create --repo id:repo-scout-linear --name fm-linearscoute3 --no-parent --setup skip --linear-issue https://linear.app/acme/issue/ENG-42/link-at-create --json&#10;&#10;## 4. Refused: --linear-issue on a non-Orca backend&#10;$ fm-spawn.sh linearrejecte4 &lt;project&gt; claude --mode no-mistakes --yolo off --backend tmux --linear-issue ENG-42&#10;exit status: 1&#10;-- operator-facing error --&#10;error: --linear-issue requires backend=orca; resolved backend is &#39;tmux&#39;&#10;-- backend mutation attempted? --&#10;no: refused before touching any backend&#10;-- metadata published? --&#10;no</code>

```text
# Evidence: Firstmate --linear-issue -> orca worktree create --linear-issue

Linear issue under test: https://linear.app/acme/issue/ENG-42/link-at-create

## 1. Ship spawn WITH --linear-issue
### ship + --linear-issue (exact value must reach Orca)
$ fm-spawn.sh linearshipe1 <project> claude --backend orca --mode no-mistakes --yolo off --linear-issue https://linear.app/acme/issue/ENG-42/link-at-create
exit status: 0
-- orca CLI commands Firstmate issued --
orca worktree create --repo id:repo-ship-linear --name fm-linearshipe1 --no-parent --setup skip --linear-issue https://linear.app/acme/issue/ENG-42/link-at-create --json

## 2. Ship spawn WITHOUT --linear-issue (existing behavior preserved)
### ship, no Linear issue
$ fm-spawn.sh linearshipe2 <project> claude --backend orca --mode no-mistakes --yolo off
exit status: 0
-- orca CLI commands Firstmate issued --
orca worktree create --repo id:repo-ship-plain --name fm-linearshipe2 --no-parent --setup skip --json

## 3. Scout spawn WITH --linear-issue
### scout + --linear-issue
$ fm-spawn.sh linearscoute3 <project> claude --backend orca --scout --linear-issue https://linear.app/acme/issue/ENG-42/link-at-create
exit status: 0
-- orca CLI commands Firstmate issued --
orca worktree create --repo id:repo-scout-linear --name fm-linearscoute3 --no-parent --setup skip --linear-issue https://linear.app/acme/issue/ENG-42/link-at-create --json

## 4. Refused: --linear-issue on a non-Orca backend
### backend=tmux + --linear-issue (must fail loudly, not silently ignore)
$ fm-spawn.sh linearrejecte4 <project> claude --mode no-mistakes --yolo off --backend tmux --linear-issue ENG-42
exit status: 1
-- operator-facing error --
error: --linear-issue requires backend=orca; resolved backend is 'tmux'
-- backend mutation attempted? --
no: refused before touching any backend
-- metadata published? --
no
```
</details>
<details>
<summary>Evidence: Reproducible evidence script (drives fm-spawn.sh against the fake-Orca CLI)</summary>

```text
#!/usr/bin/env bash
# End-to-end evidence: what Firstmate actually asks the Orca CLI to do when a
# worker is spawned with and without --linear-issue. The fake `orca` binary
# records every argv it receives, so the transcript below is the real command
# line that would reach a live Orca.
set -u

ROOT=${1:?usage: spawn-linear-issue-evidence.sh <firstmate-repo-root>}
# Same bypass firstmate's own test harness exports (tests/lib.sh): this runs
# inside a no-mistakes gate worktree, which fm-spawn.sh otherwise refuses.
export FM_GATE_REFUSE_BYPASS=1
EV=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-linear-evidence.XXXXXX")
LINEAR="https://linear.app/acme/issue/ENG-42/link-at-create"

fakebin() {  # <case>
  local fb="$TMP/$1/fakebin"
  mkdir -p "$fb"
  cat > "$fb/orca" <<'SH'
#!/usr/bin/env bash
set -u
LOG="${FM_ORCA_LOG:?}"; RESP="${FM_ORCA_RESPONSES:?}"
COUNT_FILE="$RESP/.count"
next=$(( $(cat "$COUNT_FILE" 2>/dev/null || echo 0) + 1 ))
{ printf 'orca'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'; } >> "$LOG"
if [ "${1:-}" = status ]; then
  printf '{"ok":true,"result":{"runtime":{"reachable":true,"state":"ready"}}}\n'; exit 0
fi
echo "$next" > "$COUNT_FILE"
[ -f "$RESP/$next.exit" ] && exit "$(cat "$RESP/$next.exit")"
[ -f "$RESP/$next.out" ] && cat "$RESP/$next.out"
exit 0
SH
  chmod +x "$fb/orca"
  printf '%s\n' "$fb"
}

# A real git worktree with a real origin, so the spawn's isolation and
# stale-base checks pass exactly as they would against a live project.
git_worktree() {  # <proj> <wt> <branch>
  local proj=$1 wt=$2 branch=$3 origin="$1.origin.git"
  mkdir -p "$proj"
  git init -q --bare "$origin" 2>/dev/null
  git -C "$proj" init -q 2>/dev/null
  git -C "$proj" -c user.email=e@x -c user.name=e commit -q --allow-empty -m init 2>/dev/null
  git -C "$proj" remote add origin "$origin" 2>/dev/null
  git -C "$proj" push -q origin HEAD 2>/dev/null
  git -C "$proj" worktree add -q -b "$branch" "$wt" >/dev/null 2>&1
}

# Runs one spawn against the fake Orca and prints the orca command transcript.
spawn_case() {  # <case> <id> <label> <extra-args...>
  local case=$1 id=$2 label=$3; shift 3
  local dir="$TMP/$case" fb log resp
  fb=$(fakebin "$case"); log="$dir/log"; resp="$dir/responses"
  mkdir -p "$resp" "$dir/data/$id" "$dir/state" "$dir/config"
  : > "$log"
  printf 'brief\n' > "$dir/data/$id/brief.md"
  touch "$dir/state/.last-watcher-beat"
  git_worktree "$dir/project" "$dir/wt" "fm/$id"
  printf '1\n' > "$resp/1.exit"
  printf '{"ok":true,"result":{"repo":{"id":"repo-%s"}}}\n' "$case" > "$resp/2.out"
  printf '{"ok":true,"result":{"worktree":{"id":"wt-%s","path":"%s"},"terminal":{"handle":"term-%s"}}}\n' \
    "$case" "$dir/wt" "$case" > "$resp/3.out"

  local out status
  out=$( PATH="$fb:$PATH" FM_ORCA_LOG="$log" FM_ORCA_RESPONSES="$resp" \
    FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$dir/state" FM_DATA_OVERRIDE="$dir/data" \
    FM_CONFIG_OVERRIDE="$dir/config" FM_PROJECTS_OVERRIDE="$dir/unused-projects" \
    FM_SPAWN_NO_GUARD=1 \
    "$ROOT/bin/fm-spawn.sh" "$id" "$dir/project" claude --backend orca "$@" 2>&1 )
  status=$?

  echo "### $label"
  echo "\$ fm-spawn.sh $id <project> claude --backend orca $*"
  echo "exit status: $status"
  echo "-- orca CLI commands Firstmate issued --"
  grep 'worktree create' "$log" || echo "(no worktree create reached the Orca CLI)"
  if [ "$status" -ne 0 ]; then
    echo "-- operator-facing error --"
    printf '%s\n' "$out" | grep -i 'error' | head -3
    echo "-- backend mutation attempted? --"
    [ -s "$log" ] && echo "yes: $(wc -l < "$log" | tr -d ' ') orca call(s)" || echo "no: refused before touching Orca"
    echo "-- metadata published? --"
    [ -e "$dir/state/$id.meta" ] && echo "yes" || echo "no"
  fi
  echo
  rm -rf "/tmp/fm-$id"
}

{
  echo "# Evidence: Firstmate --linear-issue -> orca worktree create --linear-issue"
  echo
  echo "Linear issue under test: $LINEAR"
  echo
  echo "## 1. Ship spawn WITH --linear-issue"
  spawn_case ship-linear linearshipe1 "ship + --linear-issue (exact value must reach Orca)" \
    --mode no-mistakes --yolo off --linear-issue "$LINEAR"

  echo "## 2. Ship spawn WITHOUT --linear-issue (existing behavior preserved)"
  spawn_case ship-plain linearshipe2 "ship, no Linear issue" \
    --mode no-mistakes --yolo off

  echo "## 3. Scout spawn WITH --linear-issue"
  spawn_case scout-linear linearscoute3 "scout + --linear-issue" \
    --scout --linear-issue "$LINEAR"

  echo "## 4. Refused: --linear-issue on a non-Orca backend"
  dir="$TMP/reject-tmux"; mkdir -p "$dir/data" "$dir/state" "$dir/config" "$dir/responses"
  fb=$(fakebin reject-tmux); : > "$dir/log"
  out=$( PATH="$fb:$PATH" FM_ORCA_LOG="$dir/log" FM_ORCA_RESPONSES="$dir/responses" \
    FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$dir/state" FM_DATA_OVERRIDE="$dir/data" \
    FM_CONFIG_OVERRIDE="$dir/config" FM_PROJECTS_OVERRIDE="$dir/unused-projects" \
    FM_SPAWN_NO_GUARD=1 \
    "$ROOT/bin/fm-spawn.sh" linearrejecte4 "$dir/project" claude \
      --mode no-mistakes --yolo off --backend tmux --linear-issue ENG-42 2>&1 )
  status=$?
  echo "### backend=tmux + --linear-issue (must fail loudly, not silently ignore)"
  echo "\$ fm-spawn.sh linearrejecte4 <project> claude --mode no-mistakes --yolo off --backend tmux --linear-issue ENG-42"
  echo "exit status: $status"
  echo "-- operator-facing error --"
  printf '%s\n' "$out" | grep -i 'error' | head -3
  echo "-- backend mutation attempted? --"
  [ -s "$dir/log" ] && echo "yes" || echo "no: refused before touching any backend"
  echo "-- metadata published? --"
  [ -e "$dir/state/linearrejecte4.meta" ] && echo "yes" || echo "no"
  echo
} | tee "$EV/spawn-linear-issue-transcript.md"

rm -rf "$TMP"
```
</details>
<details>
<summary>Evidence: Focused suite result: tests/fm-backend-orca.test.sh (new Linear regressions)</summary>

```text
ok - fm-spawn.sh --linear-issue: forwards the exact value to Orca worktree creation
ok - fm-spawn.sh --linear-issue: refuses a resolved non-Orca backend before mutation
ok - fm-spawn.sh --linear-issue: refuses relaunch, secondmate, and batch paths
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ec6636c2a054ba7f368366307a57f271933be7ea","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-backend-orca.test.sh` — 40 pass, including `test_spawn_forwards_linear_issue_to_orca_worktree_create`, `test_spawn_refuses_linear_issue_on_non_orca_backend`, `test_spawn_refuses_linear_issue_without_fresh_single_worker_worktree`</code>
- <code>`bash tests/fm-spawn-batch.test.sh` — 5 pass (adjacent surface, since the change adds a batch-dispatch refusal)</code>
- <code>Manual end-to-end CLI transcript against the fake-Orca binary: ship spawn `fm-spawn.sh &lt;id&gt; &lt;project&gt; claude --backend orca --mode no-mistakes --yolo off --linear-issue https://linear.app/acme/issue/ENG-42/link-at-create` → exit 0, exact value forwarded</code>
- <code>Manual: same ship spawn with the flag omitted → exit 0, Orca create command unchanged (no `--linear-issue`)</code>
- <code>Manual: scout spawn `fm-spawn.sh &lt;id&gt; &lt;project&gt; claude --backend orca --scout --linear-issue &lt;url&gt;` → exit 0, exact value forwarded (surface not covered by the new unit tests)</code>
- <code>Manual: `fm-spawn.sh &lt;id&gt; &lt;project&gt; claude --mode no-mistakes --yolo off --backend tmux --linear-issue ENG-42` → exit 1, clear error, zero orca calls, no metadata published</code>
- <code>`bash bin/fm-spawn.sh --help` — confirmed the script-owned help renders the `--linear-issue &lt;identifier-or-url&gt;` usage line and its semantics block</code>
- <code>`grep -rn worktree_create bin/` — confirmed `fm_backend_orca_worktree_create` has exactly one caller, so no other backend/harness surface changed</code>
- <code>`git status --porcelain` — worktree clean, no transient test artifacts left behind</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
