### PR TITLE
fix(bin): preserve Codex completion notifications through deep ancestry

### DIFF
--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -27,8 +27,10 @@ FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 
-# shellcheck source=bin/fm-cursor-lib.sh
-. "$SCRIPT_DIR/fm-cursor-lib.sh"
+# Process classification and ancestry depth are owned with session-lock
+# identity so startup rendering cannot disagree with the lock it just acquired.
+# shellcheck source=bin/fm-session-lock-lib.sh
+. "$SCRIPT_DIR/fm-session-lock-lib.sh"
 
 detect_own() {
   # Layer 1: environment markers for verified harnesses.
@@ -73,43 +75,31 @@ detect_own() {
   # without verifying it reaches children AND that it cannot survive in a
   # multiplexer's stored environment, which is the precedence hazard above.
   # Layer 2: walk the parent chain and match the command name.
-  local pid=$$ comm args argv0
-  for _ in 1 2 3 4 5 6 7 8; do
+  local pid=$$ comm args argv0 name hops=0
+  while [ "$hops" -lt "$FM_HARNESS_ANCESTRY_MAX" ]; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
+    args=$(ps -o args= -p "$pid" 2>/dev/null)
     argv0=$(fm_cursor_argv0_for_pid "$pid" "$comm" 2>/dev/null || true)
-    if fm_cursor_process_matches "$comm" '' "$argv0"; then
-      echo cursor
+    if name=$(fm_harness_process_name "$comm" "$args" "$argv0"); then
+      # An unmarked Pi family keeps the historical generic identity; explicit
+      # launch selection remains the only authority for pi-signed.
+      [ "$name" = pi-signed ] && name=pi
+      printf '%s\n' "$name"
       return
     fi
     case "$(basename -- "$comm")" in
-      *claude*) echo claude; return ;;
-      *codex*) echo codex; return ;;
-      *opencode*) echo opencode; return ;;
-      *grok*) echo grok; return ;;
-      kimi) echo kimi; return ;;
       # muse's installed launcher ~/.local/bin/muse execs ~/.local/bin/muse-bin-<version>
       # (verified in the published launcher, muse 0.1.0-R708.1), so the live process
       # name carries the version and CHANGES on every auto-update. Match the stable
       # prefix rather than any exact name. Deliberately anchored, never *muse*, so
       # unrelated commands (musescore, amuse) cannot be misread as this harness.
       muse|muse-bin-*) echo muse; return ;;
-      pi-signed) echo pi; return ;;
-      pi) echo pi; return ;;
-      node*|python*)
-        # Bare interpreter: match the harness name in its script path.
-        args=$(ps -o args= -p "$pid" 2>/dev/null)
-        case "$args" in
-          *claude*) echo claude; return ;;
-          *codex*) echo codex; return ;;
-          *opencode*) echo opencode; return ;;
-          *grok*) echo grok; return ;;
-          *" pi "*|*/pi) echo pi; return ;;
-        esac ;;
     esac
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
     if [ -z "$pid" ] || [ "$pid" -le 1 ]; then
       break
     fi
+    hops=$((hops + 1))
   done
   echo unknown
 }

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -17,7 +17,7 @@ mkdir -p "$STATE" 2>/dev/null || {
   exit 1
 }
 
-# Harness identity (FM_HARNESS_RE, ancestry walk, holder liveness) is owned by
+# Harness identity (process classifier, ancestry walk, holder liveness) is owned by
 # the shared session-lock lib so the Claude Stop auto-arm applies the exact
 # same identity contract.
 # shellcheck source=bin/fm-session-lock-lib.sh

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -16,13 +16,15 @@
 # shellcheck source=bin/fm-cursor-lib.sh
 . "$(dirname -- "${BASH_SOURCE[0]}")/fm-cursor-lib.sh"
 
-# Known harness command names; extend when a new adapter is verified.
-FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$'
+# Maximum ancestry shared by lock ownership and public harness detection.
+# Hook hosts can add several shells between their command and the primary
+# harness; keeping this bound here prevents the detector and lock owner from
+# disagreeing about the same live process tree.
+FM_HARNESS_ANCESTRY_MAX=16
 
-# The same harnesses as exact executable names. Keep in sync with
-# FM_HARNESS_RE. Used only for the stricter path evidence below, where the
-# loose regex would also match ordinary firstmate paths such as
-# bin/fm-claude-stop-autoarm.sh.
+# Exact executable names used for stricter path evidence below. The loose
+# basename and interpreter matches live in fm_harness_process_name(), the same
+# classification owner used by holder liveness and public harness detection.
 FM_HARNESS_NAMES=(claude codex opencode grok kimi pi-signed pi)
 
 # Print the exact harness name carried by executable path $1 - its own basename
@@ -45,11 +47,11 @@ fm_harness_path_name() {  # <path>
   return 1
 }
 
-# True when the process described by command name $1 and full argument string $2
-# is a verified harness. Sets FM_HARNESS_IS_CLAUDE for the ancestry walk.
+# Print the verified harness name for the process described by command name $1,
+# full argument string $2, and optional argv[0] $3, or return 1.
 #
 # Evidence, in order:
-#   1. the basename of the reported command name, against FM_HARNESS_RE.
+#   1. the basename of the reported command name.
 #   2. an exact harness component in that command path or in argv[0]. Both are
 #      needed because the two platforms report different things: macOS reports
 #      argv[0] in `ps -o comm=`, while procps on Linux reports the kernel exec
@@ -57,35 +59,57 @@ fm_harness_path_name() {  # <path>
 #      is identified by its install path on macOS and by argv[0] on Linux.
 #   3. a bare interpreter (node, python) running a harness script path.
 #   4. Cursor's own structural identity, owned by bin/fm-cursor-lib.sh.
-FM_HARNESS_IS_CLAUDE=0
-fm_harness_process_matches() {  # <comm> <args>
-  local comm=$1 args=$2 base argv0 name
-  FM_HARNESS_IS_CLAUDE=0
+fm_harness_process_name() {  # <comm> <args> [argv0]
+  local comm=$1 args=$2 argv0=${3-} base name
   base=$(basename -- "$comm")
-  if printf '%s' "$base" | grep -qE "$FM_HARNESS_RE"; then
-    case "$base" in *claude*) FM_HARNESS_IS_CLAUDE=1 ;; esac
-    return 0
-  fi
-  argv0=${args%% *}
+  case "$base" in
+    *claude*) printf '%s\n' claude; return 0 ;;
+    *codex*) printf '%s\n' codex; return 0 ;;
+    *opencode*) printf '%s\n' opencode; return 0 ;;
+    *grok*) printf '%s\n' grok; return 0 ;;
+    *kimi*) printf '%s\n' kimi; return 0 ;;
+    pi-signed) printf '%s\n' pi-signed; return 0 ;;
+    pi) printf '%s\n' pi; return 0 ;;
+  esac
+  [ -n "$argv0" ] || argv0=${args%% *}
   if name=$(fm_harness_path_name "$comm") || name=$(fm_harness_path_name "$argv0"); then
-    case "$name" in claude) FM_HARNESS_IS_CLAUDE=1 ;; esac
+    printf '%s\n' "$name"
     return 0
   fi
   # Bare interpreter (e.g. node): match the harness name in its script path.
-  case "$comm" in
+  case "$base" in
     *node*|*python*)
-      if printf '%s' "$args" | grep -qE "$FM_HARNESS_RE"; then
-        case "$args" in *claude*) FM_HARNESS_IS_CLAUDE=1 ;; esac
-        return 0
-      fi
+      case "$args" in
+        *claude*) printf '%s\n' claude; return 0 ;;
+        *codex*) printf '%s\n' codex; return 0 ;;
+        *opencode*) printf '%s\n' opencode; return 0 ;;
+        *grok*) printf '%s\n' grok; return 0 ;;
+        *kimi*) printf '%s\n' kimi; return 0 ;;
+        *pi-signed*) printf '%s\n' pi-signed; return 0 ;;
+        *" pi "*|*/pi) printf '%s\n' pi; return 0 ;;
+      esac
       ;;
   esac
   # Cursor: its own owner decides, from Cursor's name or versioned install tree
   # in the command path or argv[0]. Without this a Cursor primary can never
   # locate its own harness in the ancestry, so every session start refuses the
   # fleet lock as read-only and the park can never arm.
-  fm_cursor_process_matches "$comm" "$args" "$argv0" && return 0
+  if fm_cursor_process_matches "$comm" "$args" "$argv0"; then
+    printf '%s\n' cursor
+    return 0
+  fi
   return 1
+}
+
+# True when the process is a verified harness. Sets FM_HARNESS_IS_CLAUDE for
+# the ancestry walk while delegating every classification to the name owner.
+FM_HARNESS_IS_CLAUDE=0
+fm_harness_process_matches() {  # <comm> <args> [argv0]
+  local name
+  FM_HARNESS_IS_CLAUDE=0
+  name=$(fm_harness_process_name "$@") || return 1
+  [ "$name" = claude ] && FM_HARNESS_IS_CLAUDE=1
+  return 0
 }
 
 # Walk the current process ancestry (up to 16 hops) and print this session's
@@ -107,8 +131,8 @@ fm_harness_process_matches() {  # <comm> <args>
 # session cannot be read off the ancestry at all, so the whole contiguous run is
 # reported and the callers below decide what they need from it.
 fm_harness_ancestry_pids() {
-  local pid=$$ comm args extending=0 printed=0
-  for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
+  local pid=$$ comm args extending=0 printed=0 hops=0
+  while [ "$hops" -lt "$FM_HARNESS_ANCESTRY_MAX" ]; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
     args=$(ps -o args= -p "$pid" 2>/dev/null)
     if fm_harness_process_matches "$comm" "$args"; then
@@ -121,6 +145,7 @@ fm_harness_ancestry_pids() {
     fi
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
     [ -n "$pid" ] && [ "$pid" -gt 1 ] || break
+    hops=$((hops + 1))
   done
   [ "$printed" -eq 1 ]
 }

--- a/bin/fm-sessionstart-nudge.sh
+++ b/bin/fm-sessionstart-nudge.sh
@@ -16,27 +16,13 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 . "$SCRIPT_DIR/fm-primary-scope-lib.sh"
 # shellcheck source=bin/fm-operational-input.sh
 . "$SCRIPT_DIR/fm-operational-input.sh"
+# shellcheck source=bin/fm-session-lock-lib.sh
+. "$SCRIPT_DIR/fm-session-lock-lib.sh"
 
 fm_is_gate_agent "$FM_ROOT" && exit 0
 fm_primary_scope_matches "$FM_ROOT" "$STATE" || exit 0
 
-lock_is_in_ancestry() {
-  local lock_pid pid=$$ _
-  [ -f "$STATE/.lock" ] || return 1
-  IFS= read -r lock_pid < "$STATE/.lock" 2>/dev/null || return 1
-  case "$lock_pid" in
-    ''|*[!0-9]*|1) return 1 ;;
-  esac
-  kill -0 "$lock_pid" 2>/dev/null || return 1
-  for _ in 1 2 3 4 5 6 7 8; do
-    [ "$pid" = "$lock_pid" ] && return 0
-    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
-    [ -n "$pid" ] && [ "$pid" -gt 1 ] || return 1
-  done
-  return 1
-}
-
-lock_is_in_ancestry && exit 0
+fm_session_lock_owned_by_self "$STATE" && exit 0
 nudge=
 fm_operational_input_encode session-start \
   "Run \`bin/fm-session-start.sh\` now, exactly once, before executing any other instructions." \

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -900,6 +900,12 @@ families_for_changed_path() {
       printf '%s\n' secondmate
       printf '%s\n' session-bootstrap
       ;;
+    bin/fm-session-lock-lib.sh)
+      printf '%s\n' session-bootstrap
+      printf '%s\n' watcher-wake-lock
+      printf '%s\n' pure-contract-unit
+      printf '%s\n' live-harness-optin
+      ;;
     bin/fm-secondmate*|bin/fm-remote*|bin/fm-on.sh|bin/fm-home-seed.sh|\
     bin/fm-backlog-handoff.sh|bin/fm-backlog-receive.sh|bin/fm-procevent-remote-reply.sh|\
     bin/fm-config-inherit-lib.sh|bin/fm-config-push.sh|bin/fm-shared*|\
@@ -946,7 +952,13 @@ families_for_changed_path() {
       printf '%s\n' pure-contract-unit
       printf '%s\n' live-harness-optin
       ;;
-    bin/fm-spawn.sh|bin/fm-send.sh|bin/fm-harness.sh|\
+    bin/fm-harness.sh)
+      printf '%s\n' backend-dispatch
+      printf '%s\n' pure-contract-unit
+      printf '%s\n' session-bootstrap
+      printf '%s\n' live-harness-optin
+      ;;
+    bin/fm-spawn.sh|bin/fm-send.sh|\
     bin/fm-peek.sh|bin/fm-composer*)
       printf '%s\n' backend-dispatch
       printf '%s\n' pure-contract-unit

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -36,7 +36,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and unhealthy supervision    |
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |
-| `fm-session-lock-lib.sh` | Shared session-lock harness identity (ancestry walk and holder liveness) for fm-lock.sh and the Claude Stop auto-arm |
+| `fm-session-lock-lib.sh` | Shared primary-harness process classification, bounded ancestry, session-lock ownership, and holder liveness for detection, locking, session-start nudges, and the Claude Stop auto-arm |
 | `fm-claude-stop-autoarm.sh` | Claude Stop `asyncRewake` hook owning tokenless watcher continuity with single-flight exit-2 rewake (docs/watcher-continuity.md) |
 | `fm-turnend-guard.sh`    | Shared primary turn-end guard predicate so no turn ends blind (docs/turnend-guard.md) |
 | `fm-turnend-guard-grok.sh` | Grok Stop-hook adapter for the primary turn-end guard                              |
@@ -108,7 +108,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-pr-merge.sh`         | Record PR metadata, then merge a task's canonical full GitHub URL                    |
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task with an explicit delivery mode |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |
-| `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |
+| `fm-harness.sh`          | Detect the running harness through the shared session-lock identity owner and resolve crew or secondmate harness, model, and effort |
 | `fm-lock.sh`             | Per-home firstmate session lock                                                      |
 | `fm-x-lib.sh`            | Shared Relay config, relay, and reply-threading helpers                              |
 | `fm-x-poll.sh`           | One bounded Relay poll: stash newly offered mentions and emit their once-only wake   |

--- a/docs/sessionstart-nudge.md
+++ b/docs/sessionstart-nudge.md
@@ -7,10 +7,10 @@ Firstmate ships two session-open tiers, and the tier is a property of the harnes
 
 | Tier | What the adapter does | Used by |
 | --- | --- | --- |
-| Run | Executes `bin/fm-session-start.sh` in the hook and lets its ordered digest land in model context before the first turn. | Claude, `codex exec`, Pi / pi-signed, Cursor |
+| Run | Executes `bin/fm-session-start.sh` in the hook and lets its ordered digest land in model context before the first turn. | Claude, Codex 0.147.0 (`exec` and interactive TUI), Pi / pi-signed, Cursor |
 | Nudge | Asks the agent to run the digest through the native adapter or the tracked session-start instruction. | Grok, OpenCode, and run-tier sources routed to the nudge |
 
-Codex's interactive TUI has no tracked session-open, compaction, or re-emit channel and is not covered by either tier.
+Codex's interactive TUI gained a verified tracked `SessionStart` channel in 0.147.0, while context reset and re-emit remain uncovered.
 The run tier exists because the nudge can only ask.
 An agent can defer an instruction, including when a first-command skill has its own read-only path.
 Running the digest inside the hook removes that discretion, so even a session whose first command is a skill has already taken the helm.
@@ -58,8 +58,8 @@ The Guard Predicates section of [`turnend-guard.md`](turnend-guard.md#guard-pred
 The nudge payload starts with U+2063 and the stable `FIRSTMATE_OP: ` label, carries the current `session-start` protocol kind, and retains exactly ``Run `bin/fm-session-start.sh` now, exactly once, before executing any other instructions.`` as its body.
 The Ahoy skill owns the rule that this marked operational input is never a captain-authored session boundary, including its narrow legacy compatibility cases, and its own step 0 helm check is the fallback that protects a nudge-tier harness whose first command is a skill.
 
-Before printing, the nudge wrapper reads `state/.lock` and walks at most eight parents from its own pid in its own separate, hard-coded loop, independent of `bin/fm-lock.sh`'s ancestry walk (`fm_harness_ancestry_pid()` in `bin/fm-session-lock-lib.sh`, which now walks up to sixteen parents and can extend past a claude-named match to a still-more-ancestral one) and of Pi's `lockOwnership()`.
-If the lock names a live pid in that ancestry, session start already ran in this harness session and the wrapper stays silent.
+Before printing, the nudge wrapper asks `fm_session_lock_owned_by_self()` in `bin/fm-session-lock-lib.sh`, the same process classifier and bounded ancestry owner used to acquire the lock and render the active harness protocol.
+If the live lock names this verified harness ancestry, session start already ran in this harness session and the wrapper stays silent.
 Every path in both wrappers exits 0, including malformed state and adapter errors, because a Claude SessionStart exit 2 blocks session initialization.
 A lock another session holds and a truncated digest therefore surface as digest text, while broken GitHub auth surfaces through the deferred network result inline or as a wake; none becomes a refusal to open the session.
 
@@ -68,8 +68,8 @@ A lock another session holds and a truncated digest therefore surface as digest 
 | Harness | Tier | Tracked transport | Current compatibility |
 | --- | --- | --- | --- |
 | Claude | Run | `.claude/settings.json` registers one unmatched `SessionStart` hook, invoked through `CLAUDE_PROJECT_DIR` with a 180s timeout; the wrapper reads `source` from the hook payload. | Native stdout context injection is supported. |
-| Codex exec | Run | `.codex/hooks.json` anchors to the hook process working directory, verifies a Firstmate-shaped hook-bearing root, and pipes the hook payload into the wrapper with a 180s timeout. | Native stdout context injection is supported under `codex exec`. |
-| Codex interactive TUI | Uncovered | None. | Codex 0.146.0 does not fire the tracked project `SessionStart` hook in its interactive TUI; Firstmate ships no global hook, has no tracked compaction or re-emit channel, and does not claim instruction-refresh delivery for this surface. |
+| Codex exec | Run | `.codex/hooks.json` anchors to the hook process working directory, verifies a Firstmate-shaped hook-bearing root, and pipes the hook payload into the wrapper with a 180s timeout. | Native stdout context injection is supported. |
+| Codex interactive TUI | Run | The same tracked `.codex/hooks.json` `SessionStart` registration runs before the first model turn. | Codex 0.147.0 delivered the whole digest into model context; context reset and re-emit remain uncovered because no tracked source fires for them. |
 | Pi / pi-signed | Run | `.pi/extensions/fm-primary-turnend-guard.ts` maps `session_start` reasons `startup`, `new`, `resume`, and `fork` onto wrapper sources, refines a Pi-reported `startup` to `resume` only when a continuation, resume-selection, or explicit-session flag accompanies a session header older than the current process, maps a fork flag to `fork`, handles `session_compact` as the compaction equivalent, and injects the output with `pi.sendMessage`; setup-created entries such as `--name` are not restoration evidence. | The custom message reaches model context without racing an initial positional prompt; Pi's `reload` reason is deliberately unmapped, as it always was. |
 | OpenCode | Nudge | `.opencode/plugins/fm-primary-sessionstart-nudge.js` listens for `session.created`, runs once per session id, and calls `client.session.promptAsync` only when the wrapper prints a nudge. | Interactive TUI delivery is supported; headless `opencode run` is intentionally fail-open because the process can exit before the queued turn. That early exit is also why OpenCode cannot use the run tier. |
 | Grok | Nudge | `.grok/hooks/fm-primary-sessionstart-nudge.json` registers a project `SessionStart` hook and invokes the wrapper through inline-defaulted `${GROK_WORKSPACE_ROOT:-}`. | The project hook runs when the checkout is trusted, but Grok currently discards hook stdout from model context, so this path is intentionally fail-open and cannot use the run tier. |
@@ -77,7 +77,7 @@ A lock another session holds and a truncated digest therefore surface as digest 
 | Cursor compaction | Uncovered | None. | Cursor's `preCompact` response can return only `user_message` and is absent from Cursor's `additional_context` step set, so it cannot inject a re-emit digest. Delivering one needs its own design and is deliberately deferred to a follow-up; a Cursor primary does not re-emit its digest after a compaction. |
 
 Cursor's `sessionStart` fires at every session open with no source distinction, including a resumed session, so a resume re-runs the full digest; that is redundant and idempotent rather than a lost helm.
-Cursor's compaction surface is uncovered in the same sense as Codex's interactive TUI above: Firstmate registers nothing for `preCompact`, so a compacted Cursor session keeps whatever context survived rather than receiving a fresh digest.
+Cursor's compaction surface is uncovered in the same sense as Codex's context-reset surface above: Firstmate registers nothing for `preCompact`, so a compacted Cursor session keeps whatever context survived rather than receiving a fresh digest.
 
 Pi is the only adapter that injects a message rather than hook stdout, so whatever it injects must carry operational provenance or the Ahoy skill would have to guess whether it was captain-authored.
 The extension therefore encodes an unencoded digest as `session-start` operational input before sending it, and leaves the already-encoded nudge alone.
@@ -91,7 +91,7 @@ That alternative expands trust and writes outside this repository, so Firstmate 
 
 ## Regression coverage
 
-`tests/fm-sessionstart-nudge.test.sh` proves the nudge wrapper's silence for both gate signals, an unmarked linked worktree, a missing state directory, and an already-owned lock, plus its exact U+2063 `FIRSTMATE_OP:`-prefixed, `session-start`-typed one-line output.
+`tests/fm-sessionstart-nudge.test.sh` proves the nudge wrapper's silence for both gate signals, an unmarked linked worktree, a missing state directory, and an already-owned lock through both shallow and deep hook ancestry, plus its exact U+2063 `FIRSTMATE_OP:`-prefixed, `session-start`-typed one-line output.
 It separately proves the run wrapper's silence for the gate environment and an unmarked linked worktree.
 It proves the run wrapper's source routing end to end against a real `fm-session-start.sh`, including completion-gated `--reemit` selection, resume delegation, Pi CLI continuation classification, an unrecognized source falling through to the full digest, and bounded loud delivery of an oversized Pi digest.
 `tests/fm-session-start.test.sh` proves the runtime bound through the forced pure-Bash fallback: a TERM-resistant digest that exceeds its budget is force-killed with its grandchild, still emits its completed stages, names the incomplete stage and every stage it never reached, leaves no completion proof, and exits 0.
@@ -103,5 +103,7 @@ It verifies context-preserving reopen sources for those adapters and context-res
 Cursor uses the separate primary live guard named above because its source-free `sessionStart` and stop-hook park are validated together.
 `tests/fm-sessionstart-instruction-refresh-live-e2e.test.sh` is the separate opt-in real-Pi guard for a post-start AGENTS.md update followed by compaction.
 `tests/fm-turnend-guard.test.sh`, `tests/fm-pi-watch-extension.test.sh`, and `tests/fm-daemon.test.sh` cover marked guard, monitoring, and away-mode delivery.
+`tests/fm-supervision-instructions.test.sh` runs the renderer behind a real copied Codex process and seven ordinary hook-host shells, proving the named completion-continuation protocol survives the ancestry depth that previously selected `unknown`.
+`tests/fm-session-lock-ancestry.test.sh` pins the shared process-classification matrix for every supported primary harness.
 
 [`verification/supervision.md`](verification/supervision.md#native-session-start-delivery) records the active version-scoped transport evidence.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -51,6 +51,7 @@ If `jq` is missing or hook stdin is empty, the guard exits 0 because it cannot s
 
 - Claude registers two `Stop` hooks in `.claude/settings.json`, both anchored through `CLAUDE_PROJECT_DIR`: `bin/fm-turnend-guard.sh --claude`, and `bin/fm-claude-stop-autoarm.sh` with `asyncRewake: true` and `timeout: 28800`.
 - Codex registers a `Stop` hook in `.codex/hooks.json`, anchors the executable to the hook process working directory, verifies a Firstmate-shaped hook-bearing root, and passes the original payload to the shared guard.
+  Codex 0.147.0 awaits that hook and honors exit 2, but it ignores Claude's `asyncRewake` field and cannot process queued captain input through an unbounded synchronous park, so the guard remains a bounded backstop for the foreground-checkpoint protocol rather than the watcher owner.
 - OpenCode listens for `session.idle` in `.opencode/plugins/fm-primary-turnend-guard.js`, lets the watcher coordinator act first, and calls `client.session.promptAsync` once when the guard returns 2.
 - Pi listens for `agent_settled` in `.pi/extensions/fm-primary-turnend-guard.ts`, runs once per logical agent run, and calls `pi.sendUserMessage(..., { deliverAs: "followUp" })` once when the guard returns 2.
 - Cursor registers a `stop` hook in `.cursor/hooks.json` and delegates the whole turn boundary to `bin/fm-turnend-guard-cursor.sh`, the park described below.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -237,7 +237,7 @@ A synchronous project `Stop` hook parked until released and exit 2 produced exac
 Adding Claude's `asyncRewake` field did not detach or rewake the hook, and input entered during the park could not run until the hook released.
 Those negative controls rule out an unbounded Cursor-style park or Claude-style asynchronous arm for Codex without delaying captain input indefinitely, so the supported path remains bounded foreground checkpoints with an explicit continuation after every result or timeout.
 
-The shared classifier matrix covers Claude, Codex, OpenCode, Pi, pi-signed, Grok, and Cursor, while the existing Muse-only public detection remains outside session-lock ownership.
+The shared classifier matrix covers Claude, Codex, OpenCode, Pi, pi-signed, Grok, Kimi, and Cursor, while Muse's crewmate-only public detection remains outside session-lock ownership.
 The change is above the runtime provider boundary: tmux, Herdr, Zellij, Orca, and cmux all feed the same watcher result into the selected primary-harness protocol, so no backend endpoint, event wait, or submission behavior changes.
 
 ### Cursor primary park, 2026-08-13

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -58,14 +58,14 @@ The third is recorded below.
 | Harness | Version verified | Cold open | Context reset | Context-preserving reopen |
 | --- | --- | --- | --- | --- |
 | Claude | 2.1.222 (Claude Code) | `source=startup`, token quoted back in both `-p` and the TUI | `/clear` reports `source=clear` and `/compact` reports `source=compact`; both re-injected a fresh token that the model quoted back | `claude --continue` reports `source=resume` |
-| Codex | codex-cli 0.146.0 | `source=startup` under `codex exec`, token quoted back | Not reachable from a tracked project registration; see the limit below | `codex exec resume --last` reports `source=resume` |
+| Codex | codex-cli 0.147.0 | `source=startup` under `codex exec` and the interactive TUI, with the startup digest quoted back | Not reachable from a tracked project registration | `codex exec resume --last` reports `source=resume` |
 | Pi | 0.82.0 | `source=startup`, token quoted back in both `-p` and the TUI | `/new` raises `session_start` reason `new`, which the extension maps to `clear`; `/compact` raises `session_compact`, and both freshly injected source-stamped tokens were quoted back | `pi -c` reports reason `startup`, not `resume` |
 
 Two harness-specific consequences are load-bearing rather than incidental.
 
-Codex's interactive TUI fired no project `SessionStart` hook at all in the same lab where `codex exec` fired it reliably, which matches the earlier 2026-07-28 finding for 0.145.0.
-Codex's run tier is therefore verified only for `codex exec` startup and context-preserving resume.
-The interactive TUI is a known uncovered gap: Firstmate has no tracked session-open, compaction, or re-emit channel there, ships no global hook, and does not claim instruction-refresh delivery for that surface.
+Codex 0.147.0 supersedes the earlier 0.145.0 and 0.146.0 interactive findings for session open.
+In an isolated TUI with the tracked project hook, the hook acquired the disposable home's lock, delivered the full digest into model context, and the model repeated `SUPERVISION OPERATING INSTRUCTIONS - primary harness: codex` from that context.
+Codex still exposes no tracked context-reset or re-emit source, so instruction refresh remains uncovered after compaction or clear.
 
 Pi compaction was verified on 2026-08-05 with Pi 0.82.0 in the same throwaway lab after setting `.pi/settings.json` `compaction.keepRecentTokens` to 200 and completing one substantial assistant-prose turn before issuing `/compact`.
 Pi reported `Compacted from 7,697 tokens`, the recorder observed `session_compact`, and the model quoted the freshly injected `source=compact` token back.
@@ -212,11 +212,33 @@ The blocking and bounded-follow-up mechanisms were validated across six harnesse
 | Harness | Version verified | Mechanism | Observed result |
 | --- | --- | --- | --- |
 | Claude | 2.1.219 | Cooperative blocking `Stop` guard plus `asyncRewake` auto-arm | A fresh unsupervised session ran session start first, reclaimed a stale dead-owner lock, completed two tokenless rewake cycles with no model arm command or guard continuation, and left a competing live owner unchanged. |
-| Codex | 0.142.1 | Blocking `Stop` hook | Hook process root stayed anchored to the trusted checkout and one continuation ran. |
+| Codex | 0.147.0 | Blocking `Stop` hook | A synchronous park was awaited and exit 2 produced one continuation with `stop_hook_active=true`; `asyncRewake` was ignored. |
 | OpenCode | 1.17.6 | Passive `session.idle` callback | Throwing could not block, while `promptAsync` scheduled one TUI follow-up; headless remained fail-open. |
 | Pi | 0.80.5 | Passive `agent_settled` callback | Exactly one guard follow-up ran for an unhealthy cycle, with no recursion across tool turns. |
 | Grok | 0.2.112 native and 0.2.73 pre-native | Running-payload adaptive `Stop` | Native false-to-true continuation stayed in one process with two model turns and zero resume launches; the field-absent pre-native process launched exactly one guarded resume. |
 | Cursor | 2026.08.11-e8db854 | Awaited `stop` hook park returning one `followup_message` | Exit 2 ended the turn normally, proving it cannot block; a returned follow-up ran a genuine second turn; a sleeping hook held the boundary open and the wake landed after it; `loop_limit` stopped the hook being invoked at its ceiling. |
+
+### Codex completion-delay diagnosis, 2026-08-14
+
+The visible symptom was completed worker output remaining unsurfaced until the next captain message while the turn-end guard repeatedly reported an unsupervised fleet.
+The initiating trigger was a split identity verdict inside one session start: the 16-hop session-lock owner acquired the live Codex primary, while `bin/fm-harness.sh` stopped after eight parents and rendered the `unknown` protocol.
+The Codex watcher itself remained intentionally one-shot, so each actionable worker event ended one checkpoint; without the named Codex continuation contract, the next checkpoint was not reliably started after the handling turn.
+The smallest counterfactual placed a copied Codex executable behind seven ordinary hook-host shells: the historical detector returned `unknown`, while the shared 16-hop classifier returns `codex` and renders the instruction to start the next checkpoint after handling the completion.
+
+Three observed conditions amplified or obscured the delay without initiating it.
+First, a disappeared recorded backend endpoint made `fm-crew-state.sh` correctly return unknown even while a terminal inventory still showed an orphaned worker process; the recorded endpoint remains the control authority, and an unrelated surviving process is not evidence that the endpoint can be supervised.
+Second, the repeated `turn-ended` wake had a new file signature on each checkpoint, so it was genuine repeated worker activity rather than replay of one unchanged signal; each real wake could consume another one-shot cycle after endpoint authority was lost.
+Third, Bash printed a segmentation-fault diagnostic for the guarded process-event reconciliation child, but the watcher continued past that call as designed.
+The complete process-event suite passed, and 200 reconciliations against an isolated copy of the live registration, claim, and handled inbox shape all returned `published=0 started=0 stopped=0 uncertain=0`, so neither generic reconciliation nor that state shape reproduced the crash.
+That crash remains a production-context anomaly rather than a confirmed notification defect, and the durable result path did not account for the missing worker status wakes.
+
+Codex 0.147.0 was also tested against the tempting Stop-owned replacement.
+A synchronous project `Stop` hook parked until released and exit 2 produced exactly one continuation whose second payload carried `stop_hook_active=true`.
+Adding Claude's `asyncRewake` field did not detach or rewake the hook, and input entered during the park could not run until the hook released.
+Those negative controls rule out an unbounded Cursor-style park or Claude-style asynchronous arm for Codex without delaying captain input indefinitely, so the supported path remains bounded foreground checkpoints with an explicit continuation after every result or timeout.
+
+The shared classifier matrix covers Claude, Codex, OpenCode, Pi, pi-signed, Grok, and Cursor, while the existing Muse-only public detection remains outside session-lock ownership.
+The change is above the runtime provider boundary: tmux, Herdr, Zellij, Orca, and cmux all feed the same watcher result into the selected primary-harness protocol, so no backend endpoint, event wait, or submission behavior changes.
 
 ### Cursor primary park, 2026-08-13
 
@@ -418,7 +440,7 @@ No credential material was copied into a fixture.
 
 ```text
 Claude Code 2.1.219
-codex-cli 0.144.4
+codex-cli 0.147.0
 OpenCode 1.17.18
 Pi 0.80.10
 grok 0.2.103 (89c3d36fb6f1) [stable]
@@ -427,7 +449,7 @@ grok 0.2.103 (89c3d36fb6f1) [stable]
 | Harness | Exact opt-in command | Observed guarantee |
 | --- | --- | --- |
 | Claude | `FM_CLAUDE_LIVE_E2E=1 tests/fm-claude-stop-autoarm-live-e2e.test.sh` | Session start reclaimed a stale owner before two Stop-owned cycles, and a competing live owner prevented arm, rewake, epoch write, or lock replacement. |
-| Codex | `FM_CODEX_LIVE_E2E=1 tests/fm-codex-continuity-live-e2e.test.sh` | The one-second foreground checkpoint returned without switching to the arm wrapper. |
+| Codex | `FM_CODEX_LIVE_E2E=1 tests/fm-codex-continuity-live-e2e.test.sh` | The one-second foreground checkpoint returned without switching to the unsupported arm wrapper; the deep-ancestry portable regression selected the named continuation protocol. |
 | OpenCode | `FM_OPENCODE_LIVE_E2E=1 tests/fm-opencode-primary-live-e2e.test.sh` | A verified successor existed before prompt handling, with no model re-arm or turn-end fallback. |
 | Pi | `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` | One initial tool call led to extension-owned successors and clean child retirement on exit. |
 | Grok | `FM_GROK_LIVE_E2E=1 tests/fm-grok-continuity-live-e2e.test.sh` | Native task completion surfaced the actionable close and the cycle ledger recorded `reason=actionable-signal`. |

--- a/docs/watcher-continuity.md
+++ b/docs/watcher-continuity.md
@@ -38,6 +38,7 @@ No PreToolUse hook denies fleet commands based on watcher status.
 A genuine auto-arm failure describes the automatic mechanism as broken and never directs a routine manual background arm.
 Terminal arm-output classification (`started`, `attached`, or `FAILED`) remains defense in depth for the manual recovery path.
 Codex retains its bounded foreground checkpoint protocol.
+Codex 0.147.0 awaits project `Stop` hooks but ignores Claude's `asyncRewake` field, and an unbounded awaited park prevents queued captain input from running until release, so neither automatic shape is a supported replacement.
 Grok retains its tracked background-task notification protocol.
 No adapter starts a replacement with shell `&`.
 
@@ -90,5 +91,6 @@ The goal is continuity without a Pi or OpenCode model-memory re-arm step.
 No zero-latency guarantee is claimed because lock verification, watcher startup, and bounded retry delays remain deliberate safety work.
 OpenCode support targets persistent TUI sessions rather than headless `opencode run`.
 Claude depends on the Stop `asyncRewake` rewake, Cursor depends on its awaited stop-hook park, Grok retains native background-completion notifications, and Codex retains bounded foreground checkpoints.
+Codex startup rendering and session-start nudge suppression share the session lock's process classifier and 16-hop ancestry bound, so a hook-host shell chain cannot silently select the generic fallback after the same session acquired the lock.
 
 [`verification/supervision.md`](verification/supervision.md#watcher-continuity) records the current five-harness live evidence, the 2026-07-24 Stop-owned Claude auto-arm results, and exact opt-in commands.

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -3130,6 +3130,8 @@ test_interactive_terminal_e2e() {
     "$ROOT/bin/fm-sessionstart-nudge.sh" \
     "$ROOT/bin/fm-primary-scope-lib.sh" \
     "$ROOT/bin/fm-gate-refuse-lib.sh" \
+    "$ROOT/bin/fm-session-lock-lib.sh" \
+    "$ROOT/bin/fm-cursor-lib.sh" \
     "$ROOT/bin/fm-operational-input.sh" \
     "$project/bin/"
   # The real digest is out of scope here: this lab is about how Calm RENDERS the

--- a/tests/fm-opencode-primary-live-e2e.test.sh
+++ b/tests/fm-opencode-primary-live-e2e.test.sh
@@ -161,6 +161,8 @@ run_ahoy_transcript_regressions() {
     "$ROOT/bin/fm-sessionstart-nudge.sh" \
     "$ROOT/bin/fm-primary-scope-lib.sh" \
     "$ROOT/bin/fm-gate-refuse-lib.sh" \
+    "$ROOT/bin/fm-session-lock-lib.sh" \
+    "$ROOT/bin/fm-cursor-lib.sh" \
     "$ROOT/bin/fm-operational-input.sh" \
     "$AHOY_PROJECT/bin/"
   cp "$ROOT/.agents/skills/ahoy/SKILL.md" "$AHOY_PROJECT/.agents/skills/ahoy/SKILL.md"

--- a/tests/fm-pi-primary-live-e2e.test.sh
+++ b/tests/fm-pi-primary-live-e2e.test.sh
@@ -181,6 +181,8 @@ run_native_ahoy_regressions() {
     "$ROOT/bin/fm-sessionstart-nudge.sh" \
     "$ROOT/bin/fm-primary-scope-lib.sh" \
     "$ROOT/bin/fm-gate-refuse-lib.sh" \
+    "$ROOT/bin/fm-session-lock-lib.sh" \
+    "$ROOT/bin/fm-cursor-lib.sh" \
     "$ROOT/bin/fm-operational-input.sh" \
     "$AHOY_PROJECT/bin/"
   cp "$ROOT/.agents/skills/ahoy/SKILL.md" "$AHOY_PROJECT/.agents/skills/ahoy/SKILL.md"

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -45,6 +45,28 @@ lib_eval() {  # <fakebin> <expression>
   " "$LIB"
 }
 
+test_shared_process_classifier_covers_primary_harnesses() {
+  local comm args argv0 expected got
+  while IFS='|' read -r comm args argv0 expected; do
+    [ -n "$expected" ] || continue
+    got=$(bash -c '. "$1"; fm_harness_process_name "$2" "$3" "$4"' \
+      _ "$LIB" "$comm" "$args" "$argv0") \
+      || fail "shared classifier rejected $expected process evidence"
+    [ "$got" = "$expected" ] \
+      || fail "shared classifier resolved '$got' from $comm, expected $expected"
+  done <<'EOF'
+/opt/bin/claude|claude|/opt/bin/claude|claude
+/opt/bin/codex-aarch64-apple-darwin|codex|/opt/bin/codex-aarch64-apple-darwin|codex
+/opt/bin/opencode|opencode|/opt/bin/opencode|opencode
+/opt/bin/grok-1.0.0|grok|/opt/bin/grok-1.0.0|grok
+/opt/bin/kimi|kimi|/opt/bin/kimi|kimi
+/opt/bin/pi-signed|pi-signed|/opt/bin/pi-signed|pi-signed
+/opt/bin/pi|pi|/opt/bin/pi|pi
+/opt/Cursor/bin/cursor-agent|cursor-agent|/opt/Cursor/bin/cursor-agent|cursor
+EOF
+  pass "session-lock: one process classifier covers every supported primary harness"
+}
+
 test_version_named_session_is_identified_on_both_platforms() {
   local dir fakebin shape got
   dir="$TMP_ROOT/version-named"
@@ -357,6 +379,7 @@ test_e2e_daemon_parented_version_named_session_keeps_its_lock() {
 }
 
 test_version_named_session_is_identified_on_both_platforms
+test_shared_process_classifier_covers_primary_harnesses
 test_ordinary_paths_are_never_harness_processes
 test_harness_beyond_a_gap_never_owns_the_lock
 test_competing_version_named_session_is_seen_as_live

--- a/tests/fm-sessionstart-nudge.test.sh
+++ b/tests/fm-sessionstart-nudge.test.sh
@@ -561,12 +561,18 @@ test_run_gate_and_scope_are_silent() {
 }
 
 test_run_reports_a_failed_session_start_as_digest_text() {
-  local root="$TMP_ROOT/run-unwritable" out status=0
+  local root="$TMP_ROOT/run-contended" fixture="$TMP_ROOT/run-contended-fixture"
+  local out status=0 holder
   make_run_primary "$root"
-  chmod 0500 "$root/state"
+  mkdir -p "$fixture"
+  cp /bin/bash "$fixture/codex"
+  "$fixture/codex" -c 'while :; do read -r -t 1 _ || :; done' &
+  holder=$!
+  printf '%s\n' "$holder" > "$root/state/.lock"
   out=$(run_hook "$root" --source startup </dev/null) || status=$?
-  chmod 0700 "$root/state"
-  expect_code 0 "$status" "run wrapper with an unwritable state directory"
+  kill "$holder" 2>/dev/null || true
+  wait "$holder" 2>/dev/null || true
+  expect_code 0 "$status" "run wrapper with a competing live session"
   assert_contains "$out" "READ-ONLY SESSION" "a failed lock did not reach the agent as digest text"
   pass "run wrapper: a session start that cannot take the lock still opens the session and says so"
 }

--- a/tests/fm-sessionstart-nudge.test.sh
+++ b/tests/fm-sessionstart-nudge.test.sh
@@ -124,18 +124,55 @@ test_missing_state_is_silent() {
 }
 
 test_owned_lock_is_silent() {
-  local root="$TMP_ROOT/already-ran"
+  local root="$TMP_ROOT/already-ran" lock_pid
   make_primary "$root"
-  printf '%s\n' "$$" > "$root/state/.lock"
+  lock_pid=$(bash -c '. "$1"; fm_harness_ancestry_pid' \
+    _ "$ROOT/bin/fm-session-lock-lib.sh") \
+    || fail "owned-lock fixture could not resolve its harness process"
+  printf '%s\n' "$lock_pid" > "$root/state/.lock"
   expect_silent_zero "owned lock nudge" run_nudge "$root"
-  pass "fm-sessionstart-nudge: a lock holder in process ancestry is already run"
+  pass "fm-sessionstart-nudge: the harness lock owner is already run"
+}
+
+test_deep_owned_lock_is_silent() {
+  local root="$TMP_ROOT/deep-owned" fixture="$TMP_ROOT/deep-owned-fixture"
+  local out status=0
+  make_primary "$root"
+  mkdir -p "$fixture"
+  cp /bin/bash "$fixture/codex"
+  cat > "$fixture/wrapper.sh" <<'SH'
+#!/usr/bin/env bash
+depth=$1
+shift
+if [ "$depth" -gt 0 ]; then
+  /bin/bash "$0" "$((depth - 1))" "$@"
+else
+  "$@"
+fi
+SH
+  cat > "$fixture/session.sh" <<'SH'
+#!/usr/bin/env bash
+root=$1 nudge=$2 wrapper=$3
+printf '%s\n' "$$" > "$root/state/.lock"
+env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+  FM_GATE_REFUSE_BYPASS=0 FM_ROOT_OVERRIDE="$root" FM_HOME="$root" \
+  "$wrapper" 7 "$nudge"
+SH
+  chmod +x "$fixture/codex" "$fixture/wrapper.sh" "$fixture/session.sh"
+
+  out=$("$fixture/codex" "$fixture/session.sh" "$root" "$NUDGE" "$fixture/wrapper.sh" 2>&1) \
+    || status=$?
+  expect_code 0 "$status" "deep owned-lock nudge"
+  [ -z "$out" ] || fail "deep lock-owning session was redundantly nudged: $out"
+  pass "fm-sessionstart-nudge: deep hook ancestry shares the session-lock owner"
 }
 
 test_opencode_plugin_delivers_exact_nudge_once() {
   local root="$TMP_ROOT/opencode-primary" out status=0
   make_primary "$root"
   cp "$ROOT/bin/fm-sessionstart-nudge.sh" "$ROOT/bin/fm-primary-scope-lib.sh" \
-    "$ROOT/bin/fm-gate-refuse-lib.sh" "$ROOT/bin/fm-operational-input.sh" "$root/bin/"
+    "$ROOT/bin/fm-gate-refuse-lib.sh" "$ROOT/bin/fm-operational-input.sh" \
+    "$ROOT/bin/fm-session-lock-lib.sh" "$ROOT/bin/fm-cursor-lib.sh" "$root/bin/"
   chmod +x "$root/bin/fm-sessionstart-nudge.sh"
   out=$(PLUGIN="$ROOT/.opencode/plugins/fm-primary-sessionstart-nudge.js" \
     WORKTREE="$root" EXPECTED="$NUDGE_LINE" node --input-type=module 2>&1 <<'EOF'
@@ -419,7 +456,8 @@ test_pi_large_sessionstart_digest_is_delivered_loudly() {
   cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$fixture/.pi/extensions/lib/"
   cp "$ROOT/bin/fm-sessionstart-run.sh" "$ROOT/bin/fm-sessionstart-nudge.sh" \
     "$ROOT/bin/fm-primary-scope-lib.sh" "$ROOT/bin/fm-gate-refuse-lib.sh" \
-    "$ROOT/bin/fm-hook-host-lib.sh" \
+    "$ROOT/bin/fm-hook-host-lib.sh" "$ROOT/bin/fm-session-lock-lib.sh" \
+    "$ROOT/bin/fm-cursor-lib.sh" \
     "$ROOT/bin/fm-operational-input.sh" "$fixture/bin/"
   cat > "$fixture/bin/fm-session-start.sh" <<'SH'
 #!/usr/bin/env bash
@@ -540,6 +578,7 @@ test_unmarked_linked_worktree_is_silent
 test_linked_secondmate_primary_nudges
 test_missing_state_is_silent
 test_owned_lock_is_silent
+test_deep_owned_lock_is_silent
 test_opencode_plugin_delivers_exact_nudge_once
 test_run_startup_runs_the_full_digest
 test_run_clear_and_compact_reemit

--- a/tests/fm-supervision-instructions.test.sh
+++ b/tests/fm-supervision-instructions.test.sh
@@ -27,6 +27,38 @@ test_unknown_fallback() {
   pass "renderer falls back to unknown.md for unverified harness names"
 }
 
+test_deep_codex_hook_ancestry_keeps_completion_protocol() {
+  local dir wrapper out
+  dir="$TMP_ROOT/deep-codex"
+  wrapper="$dir/wrapper.sh"
+  mkdir -p "$dir"
+  cp /bin/bash "$dir/codex"
+  cat > "$wrapper" <<'SH'
+#!/usr/bin/env bash
+set -u
+depth=$1
+shift
+if [ "$depth" -gt 0 ]; then
+  /bin/bash "$0" "$((depth - 1))" "$@"
+else
+  "$@"
+fi
+SH
+  chmod +x "$dir/codex" "$wrapper"
+
+  # Seven ordinary hook-host shells put Codex beyond the historical eight-hop
+  # detector while keeping it inside the session lock's supported ancestry.
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    "$dir/codex" "$wrapper" 7 "$RENDER")
+  assert_contains "$out" "primary harness: codex" \
+    "deep Codex hook ancestry fell through to the unknown fallback"
+  assert_contains "$out" "then start the next checkpoint" \
+    "deep Codex hook ancestry lost the post-completion continuation"
+  assert_not_contains "$out" "Mode: Unknown harness fallback." \
+    "deep Codex hook ancestry rendered the delay-causing fallback"
+  pass "deep Codex hook ancestry retains prompt completion handling and the next checkpoint"
+}
+
 test_conditional_stanzas() {
   local home config out
   home="$TMP_ROOT/conditional-home"
@@ -178,6 +210,7 @@ test_pi_snippet_uses_effective_extension_path() {
 
 test_selected_harness_block_only
 test_unknown_fallback
+test_deep_codex_hook_ancestry_keeps_completion_protocol
 test_conditional_stanzas
 test_repair_lines
 test_cross_harness_ordinary_continuation_and_repair_matrix

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -112,6 +112,8 @@ install_guard_scripts() {
   cp "$ROOT/bin/fm-operational-input.sh" "$dir/bin/fm-operational-input.sh"
   cp "$ROOT/bin/fm-supervision-instructions.sh" "$dir/bin/fm-supervision-instructions.sh"
   cp "$ROOT/bin/fm-harness.sh" "$dir/bin/fm-harness.sh"
+  cp "$ROOT/bin/fm-session-lock-lib.sh" "$dir/bin/fm-session-lock-lib.sh"
+  cp "$ROOT/bin/fm-cursor-lib.sh" "$dir/bin/fm-cursor-lib.sh"
   cp "$ROOT/bin/fm-primary-scope-lib.sh" "$dir/bin/fm-primary-scope-lib.sh"
   cp "$ROOT/bin/fm-supervision-lib.sh" "$dir/bin/fm-supervision-lib.sh"
   cp "$ROOT/bin/fm-wake-lib.sh" "$dir/bin/fm-wake-lib.sh"


### PR DESCRIPTION
## Intent

Diagnose and fix the delayed worker-completion notification path observed in the primary Firstmate home on 2026-08-14, explicitly separating the initiating trigger, masking conditions, and visible symptom; compare it with a proven supported primary-harness path, inspect relevant history, test the smallest counterfactual for the leading cause, and actively seek disconfirming evidence. Account for the primary Codex session being misdetected as unknown despite its effective Codex context, one-event bounded checkpoints, guarded process-event reconciliation segmentation diagnostics, disappeared recorded worker endpoints with surviving terminal processes, and repeated turn-ended events. Fix confirmed causal boundaries rather than strings; add executable regressions for the end-user-visible delay and every confirmed contributing defect; review all supported primary harnesses and runtime backends affected by the supervision change; update authoritative documentation and current version-scoped verification evidence while preserving the one-owner rule. Retain Codex bounded foreground checkpoints because Codex 0.147 ignores asyncRewake and an unbounded synchronous Stop park delays captain input; treat the unreproduced guarded process-event crash and genuine orphan and re-touched signals as masking evidence, not causal defects. Run focused tests, pinned lint, documentation checks, and the required no-mistakes pipeline; deliver a review-ready PR with green CI. Never merge the PR.

## What Changed

- Unify primary-harness detection, session-lock ownership, and session-start nudge suppression around one shared process classifier with a 16-hop ancestry bound.
- Preserve the Codex completion-continuation protocol through deep hook-host process chains instead of falling back to the unknown-harness instructions.
- Add regression coverage for supported harness classification and deep ancestry, and document the Codex 0.147 completion-delay diagnosis and verified supervision behavior.

## Risk Assessment

✅ Low: The change consistently moves harness detection and session-lock ownership onto the existing 16-hop shared classifier, preserves bounded Codex checkpoints, and adds executable regressions for the reproduced deep-ancestry notification path without changing runtime-backend behavior.

## Testing

Focused testing exercised deep primary-harness ancestry, end-user completion-to-checkpoint continuation, live lock contention, supported harness/runtime protocol selection, and repeated turn-end recovery; all notification-path checks passed with CLI evidence, while an unrelated Pi terminal E2E remained demonstrably flaky across two distinct assertions.

<details>
<summary>Evidence: Deep Codex ancestry and supported harness evidence</summary>

```text
ok - session-lock: a version-named Claude Code session is identified from its install path and argv[0]
ok - session-lock: one process classifier covers every supported primary harness
ok - session-lock: ordinary script paths under a harness directory are not harness processes
ok - session-lock: ownership stops at the first non-harness gap above the contiguous run
ok - session-lock: a live version-named session holding the lock is not mistaken for a stale owner
ok - session-lock e2e: a version-named session claims the home and arms supervision
ok - session-lock e2e: a session parented by a harness-named daemon claims the home and arms supervision
ok - session-lock e2e: a version-named session under a harness-named daemon keeps its own lock
```
</details>
<details>
<summary>Evidence: Completion handling and bounded checkpoint evidence</summary>

```text
ok - renderer prints exactly the selected harness block
ok - renderer falls back to unknown.md for unverified harness names
ok - deep Codex hook ancestry retains prompt completion handling and the next checkpoint
ok - renderer includes read-only, afk, and effective x-mode current-state stanzas
ok - renderer repair-line mode is harness-aware and honors conditional state
ok - renderer preserves every harness ordinary-continuation and missing-cycle repair path
ok - pi-signed keeps its identity while sharing Pi's supervision protocol
ok - grok supervision is Claude-shaped background notify with passive Stop-hook backstop
ok - grok rendered command sources the effective x-mode config
ok - pi supervision snippet renders the effective extension path
```
</details>
<details>
<summary>Evidence: Repeated turn-end and bounded continuation evidence</summary>

```text
ok - fm_supervision_unhealthy: false with no state/*.meta at all
ok - fm_supervision_unhealthy: true with in-flight task and no beacon ever
ok - fm_supervision_unhealthy: true with in-flight task and a beacon far outside the grace window
ok - fm_supervision_unhealthy: false with in-flight task and a fresh beacon
ok - fm_supervision_status: FM_SUP_QUEUE_PENDING tracks state/.wake-queue
ok - fm_supervision_needed: X-mode relay poll needs supervision
ok - fm_supervision_unhealthy: source-only home needs supervision
ok - fm-turnend-guard: silent no-op with nothing in flight
ok - fm-turnend-guard: blocks when a fresh beacon has no live watcher lock
ok - fm-turnend-guard: non-Claude path blocks a source-only home
ok - fm-turnend-guard: blocks on a dead watcher lock even when the beacon is fresh
ok - fm-turnend-guard: silent no-op with a live watcher lock and fresh beacon
ok - fm-turnend-guard: healthy non-Claude harness paths ignore Claude episode contention
ok - fm-turnend-guard: blocks on a live watcher lock with an ancient beacon
ok - fm-turnend-guard: blocks with the exact required reason in the primary when unhealthy
ok - fm-turnend-guard: blocks from active FM_HOME state, not only repo-root state
ok - fm-turnend-guard: X-mode repair reason sources the cadence config
ok - fm-turnend-guard: X-mode-only supervision remains guarded in default mode
ok - fm-turnend-guard: ignores stale repo-root state when FM_HOME is set
ok - fm-turnend-guard: uses FM_STATE_OVERRIDE ahead of FM_HOME/state
ok - fm-turnend-guard: stop_hook_active=true always allows the stop (never blocks twice in one turn)
ok - fm-turnend-guard: blocks a blind turn end in a secondmate's own home (.fm-secondmate-home no longer excludes it)
ok - fm-turnend-guard: idle-by-default - silent in a secondmate home with nothing in flight
ok - fm-turnend-guard: stop_hook_active=true allows the stop in a secondmate home (never blocks twice in one turn)
ok - fm-turnend-guard: secondmate deferred-death recovery - silent while watched, forces re-arm once the watcher exits
ok - fm-turnend-guard: inert in a secondmate's own child worktree (linked git worktree) even when unhealthy
ok - fm-turnend-guard: blocks a blind turn end in a treehouse-leased LINKED secondmate home (marker force-include)
ok - fm-turnend-guard: an invalid (empty) marker cannot spoof inclusion; linked worktree stays exempt
ok - fm-turnend-guard: a non-ASCII marker cannot spoof inclusion; linked worktree stays exempt
ok - fm-turnend-guard: inert in a crewmate/scout task worktree (linked git worktree) even when unhealthy
ok - fm-turnend-guard: fails open (never blocks) when jq is missing
ok - fm-turnend-guard: silent no-op on empty stdin
ok - fm-turnend-guard: runs well under the generous timing margin (0s)
ok - fm-turnend-guard-grok: forces one explicitly marked same-session resume when the shared predicate blocks
ok - fm-turnend-guard-grok: legacy environment loop guard prevents a nested resume loop
ok - fm-turnend-guard-grok: native false delegates blocking feedback with zero resume processes
ok - fm-turnend-guard-grok: native true remains bounded and starts no resume process
ok - fm-turnend-guard-grok: both spellings are typed and camelCase has deterministic precedence
ok - fm-turnend-guard-grok: malformed, invalidly typed, and missing-prerequisite payloads start neither path
ok - fm-turnend-guard-grok: missing jq and no-supervision-needed stops stay silent and bounded
ok - tracked .claude/settings.json entries: 5 inert under grok, the documented subagent exception still armed, all live under Claude
ok - .codex/hooks.json: Stop hook uses hook process root when payload cwd is outside
ok - .codex/hooks.json: Stop hook ignores nested git root guard scripts
ok - .opencode primary plugin: guard path is anchored to worktree, not directory
ok - .pi primary extension: no-tool and multi-tool runs each inject exactly one guard follow-up
ok - .pi primary extension: delivery failure resets the logical-run latch
ok - fm-turnend-guard --claude: re-blocks a loop-guarded stop while unhealthy and unclaimed (incident regression)
ok - fm-turnend-guard --claude: X-mode-only homes re-block when auto-arm recovery is absent
ok - fm-turnend-guard --claude: a live arming epoch advances once and repeated observation is idempotent
ok - fm-turnend-guard --claude: repeated failed-to-arming races make bounded monotonic progress
ok - fm-turnend-guard --claude: terminal owner boundary excludes a concurrent start without deadlock
ok - fm-turnend-guard --claude: fresh rewake epoch prevents a duplicate continuation for the same event
ok - fm-turnend-guard --claude: fresh failed epochs preserve and advance monotonic fail-open progression
ok - fm-turnend-guard --claude: integrated fresh failures reach one bounded fail-open, stop continuation, and reset on recovery
ok - fm-turnend-guard --claude: reset contention preserves all episode state until retry
ok - fm-turnend-guard --claude: concurrent auto-arm and guard resets are idempotent and deadlock-free
ok - fm-turnend-guard --claude: stale rewake epoch does not allow a blind stop
ok - fm-turnend-guard --claude: budget exhaustion alone cannot permit a blind stop
ok - fm-turnend-guard --claude: verified fail-open is loud, bounded, attended, and non-repeating
ok - fm-turnend-guard --claude: fail-open requires both exhausted retries and consumed notice
ok - fm-turnend-guard --claude: away ownership excludes the Stop-autoarm fail-open
ok - fm-turnend-guard --claude: positive watcher recovery resets failure episode state
ok - fm-turnend-guard --claude: bounded claim wait avoids a token-consuming forced continuation
ok - fm-turnend-guard --claude: secondmate home re-blocks unclaimed and allows auto-arm-claimed stops
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (5m41s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"8f884b4f6ed5467c6519b1e782f7a4eb72c8d97c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `tests/fm-calm-pi-extension.test.sh:1821` - The Pi terminal E2E is nondeterministic: consecutive runs failed at different unrelated assertions—duplicate captain-answer rendering and `/export` completion—after earlier scenarios passed. This does not implicate the notification-path change, but the test remains flaky.
- `git diff 9823ff899c58319e5a09846b18f2958018598b38..577752cfb4281574c5ae677bd350f19529301d26`
- `bin/fm-test-run.sh tests/fm-session-lock-ancestry.test.sh tests/fm-sessionstart-nudge.test.sh tests/fm-supervision-instructions.test.sh tests/fm-turnend-guard.test.sh tests/fm-calm-pi-extension.test.sh`
- <code>`bin/fm-test-run.sh tests/fm-calm-pi-extension.test.sh` (flake isolation; failed at a different terminal-E2E assertion)</code>
- `tests/fm-session-lock-ancestry.test.sh`
- `tests/fm-supervision-instructions.test.sh`
- `tests/fm-turnend-guard.test.sh`
- <code>`bin/fm-test-run.sh tests/fm-sessionstart-nudge.test.sh` after replacing the root-sensitive fixture</code>
- `git diff --check`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

🔧 Fix: Confirm pinned ShellCheck lint passes
1 warning still open:
- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
