### PR TITLE
feat(bin): automate honest task metrics emission

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ data/                personal fleet records; LOCAL, gitignored as a whole
   learnings.md       fleet-local operational facts and gotchas; LOCAL, gitignored; dated, evidence-backed, curated, and updated with inspect-then-update - rewrite and prune rather than append forever, the same contract as captain.md; created lazily, absent until this home has a learning to store
   projects.md        thin fleet navigation registry recording each project's standing delivery posture; firstmate-private, parsed for mechanical sync and seeding by fm-project-mode.sh (section 6)
   secondmates.md      local and remote secondmate routing table; firstmate-private, maintained by the secondmate seed helpers (section 6)
+  task-metrics.jsonl  one durable mechanically-derived row per completed ordinary task; see docs/task-metrics.md
   <id>/brief.md      per-task crewmate brief, or per-secondmate charter brief when kind=secondmate
   <id>/report.md     scout task deliverable, written by the crewmate; survives teardown
 projects/            cloned repos; gitignored; read-only except under hard rule 1's concrete captain-approved project operation exception
@@ -94,6 +95,7 @@ state/               runtime records and signals; gitignored
   <id>.muse-session  muse busy-source binding (sessions root plus task worktree) written by fm-spawn; removed by teardown
   <id>.cursor-session  cursor busy-source binding (projects root, task worktree, prior conversations) written by fm-spawn; removed by teardown
   <id>.meta          task metadata; each producer script's header owns its exact fields and mutation contract, with docs/configuration.md routing operator-facing backend and trace-context details
+  <id>.task-metrics-row  private retry receipt prepared before cleanup and committed after cleanup succeeds; see docs/task-metrics.md
   <id>.herdr-presentation  quarantinable attempt and restart-binding journal for Herdr's optional visual projection; never task or endpoint authority; see docs/herdr-backend.md "Presentation spaces"
   <id>.check.sh      authenticated slow poll; the watcher dispatches validated PR data and the byte-identified Relay shim through trusted repository scripts, runs registered custom checks from hash-validated private snapshots, and rejects every other state check without execution
   <id>.check-trust   private content binding created by fm-check-register.sh for an intentional custom check

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2621,6 +2621,10 @@ fi
 META_WINDOW=$T
 [ "$BACKEND" = orca ] && META_WINDOW=$W
 SPAWN_GEN="s$(date +%s).${BASHPID:-$$}.$RANDOM"
+SPAWN_DISPATCHED_AT=
+if [ "$RELAUNCH" -eq 0 ]; then
+  SPAWN_DISPATCHED_AT=$(LC_ALL=C date -u '+%Y-%m-%dT%H:%M:%SZ') || exit 1
+fi
 SPAWN_META_PATH="$STATE/$ID.meta"
 if [ "$RELAUNCH" -eq 1 ]; then
   SPAWN_META_LOCK=$(fm_meta_lock_path "$STATE/$ID.meta") || exit 1
@@ -2638,6 +2642,7 @@ preserve_relaunch_meta() {
     !($1 in owned)
   ' "$RELAUNCH_META"
 }
+SPAWN_META_WRITE_STATUS=0
 {
   echo "window=$META_WINDOW"
   echo "endpoint_task_id=$ID"
@@ -2652,6 +2657,7 @@ preserve_relaunch_meta() {
   echo "effort=${EFFORT:-default}"
   [ -z "${BUSY_GEN:-}" ] || echo "busy_gen=$BUSY_GEN"
   echo "spawn_gen=$SPAWN_GEN"
+  [ -z "$SPAWN_DISPATCHED_AT" ] || echo "dispatched_at=$SPAWN_DISPATCHED_AT"
   # Default-off writes no traceparent= line.
   # backend= is written only for a non-default (non-tmux) backend, so the
   # default path's meta stays byte-identical (absent backend= means tmux;
@@ -2686,7 +2692,11 @@ preserve_relaunch_meta() {
   if [ "$SPAWN_CONTROL_PARENT" = 1 ] && [ -n "${FM_CONTROL_RELAUNCH_TX:-}" ]; then
     echo "control_relaunch_tx=$FM_CONTROL_RELAUNCH_TX"
   fi
-} > "$SPAWN_META_PATH"
+} > "$SPAWN_META_PATH" || SPAWN_META_WRITE_STATUS=$?
+if [ "$SPAWN_META_WRITE_STATUS" -ne 0 ]; then
+  echo "error: could not publish task metadata at $SPAWN_META_PATH" >&2
+  exit 1
+fi
 if [ "$RELAUNCH" -eq 1 ]; then
   SPAWN_META_PUBLISH_STARTED=1
   mv -f "$SPAWN_META_TMP" "$STATE/$ID.meta"

--- a/bin/fm-task-metrics.sh
+++ b/bin/fm-task-metrics.sh
@@ -28,9 +28,8 @@
 #   fix_rounds: no-mistakes auto_fix rounds in review or test steps only.
 #   decisions_raised: status lines whose classified verb is needs-decision or
 #     blocked.
-#   ci_green_first_push: all GitHub workflow runs for the first durable pushed
-#     SHA completed successfully/skipped/neutral; false on any other completed
-#     conclusion, null when no complete observation exists.
+#   ci_green_first_push: null until durable records identify the first pushed
+#     SHA and support a complete workflow-run observation for that SHA.
 #   merged/outcome: the recorded PR's current forge state, or the last durable
 #     terminal status when there is no PR.
 #
@@ -161,7 +160,6 @@ task_metrics_pipeline_info() {
   [ -f "$db" ] && [ ! -L "$db" ] && [ -n "$project" ] && [ -n "$branch" ] || return 1
   fm_run_timed 10 python3 - "$db" "$project" "$branch" <<'PY'
 import os
-import re
 import sqlite3
 import sys
 
@@ -183,7 +181,7 @@ if not repo_ids:
 marks = ",".join("?" for _ in repo_ids)
 run_rows = list(
     con.execute(
-        f"SELECT id, last_pushed_sha FROM runs "
+        f"SELECT id FROM runs "
         f"WHERE repo_id IN ({marks}) AND branch = ? ORDER BY created_at, id",
         (*repo_ids, branch),
     )
@@ -200,21 +198,15 @@ if run_ids:
         "AND rd.trigger_type = 'auto_fix'",
         run_ids,
     ).fetchone()[0]
-first_sha = ""
-for _, candidate in run_rows:
-    if isinstance(candidate, str) and re.fullmatch(r"[0-9a-f]{40}|[0-9a-f]{64}", candidate):
-        first_sha = candidate
-        break
 print(len(run_rows))
 print(fix_rounds)
-print(first_sha)
 PY
 }
 
 task_metrics_prepare() {
   local state_device worktree project mode pr_url branch prior_branch repo_slug=''
-  local pipeline_info='' pipeline_runs=null fix_rounds=null first_push_sha=''
-  local pr_provider='' pr_number='' pr_out='' ci_out='' pr_tmp='' ci_tmp=''
+  local pipeline_info='' pipeline_runs=null fix_rounds=null
+  local pr_provider='' pr_number='' pr_out='' pr_tmp=''
   local decisions=0 terminal_verb='' verb line receipt_tmp
 
   command -v python3 >/dev/null 2>&1 || { echo "error: task metrics requires python3" >&2; return 1; }
@@ -254,32 +246,24 @@ task_metrics_prepare() {
   if pipeline_info=$(task_metrics_pipeline_info "$mode" "$project" "$branch" 2>/dev/null); then
     pipeline_runs=$(printf '%s\n' "$pipeline_info" | sed -n '1p')
     fix_rounds=$(printf '%s\n' "$pipeline_info" | sed -n '2p')
-    first_push_sha=$(printf '%s\n' "$pipeline_info" | sed -n '3p')
     case "$pipeline_runs" in ''|*[!0-9]*) pipeline_runs=null ;; esac
     case "$fix_rounds" in ''|*[!0-9]*) fix_rounds=null ;; esac
   fi
 
   pr_tmp=$(mktemp "$STATE/.task-metrics-pr.XXXXXX") || return 1
-  ci_tmp=$(mktemp "$STATE/.task-metrics-ci.XXXXXX") || { rm -f "$pr_tmp"; return 1; }
   if [ "$pr_provider" = github ] && [ -n "$repo_slug" ] && command -v gh-axi >/dev/null 2>&1; then
     if fm_run_timed "$GH_TIMEOUT" gh-axi pr view "$pr_number" --repo "$repo_slug" > "$pr_tmp" 2>/dev/null; then
       pr_out=$pr_tmp
     fi
-    if [ -n "$first_push_sha" ] \
-      && fm_run_timed "$GH_TIMEOUT" gh-axi run list --repo "$repo_slug" \
-        --commit "$first_push_sha" --limit 100 > "$ci_tmp" 2>/dev/null; then
-      ci_out=$ci_tmp
-    fi
   fi
 
-  state_device=$(task_metrics_file_device "$STATE") || { rm -f "$pr_tmp" "$ci_tmp"; return 1; }
-  receipt_tmp=$(mktemp "$STATE/.task-metrics-row.XXXXXX") || { rm -f "$pr_tmp" "$ci_tmp"; return 1; }
+  state_device=$(task_metrics_file_device "$STATE") || { rm -f "$pr_tmp"; return 1; }
+  receipt_tmp=$(mktemp "$STATE/.task-metrics-row.XXXXXX") || { rm -f "$pr_tmp"; return 1; }
   if ! FM_METRICS_BRANCH="$branch" FM_METRICS_REPO="$repo_slug" \
       FM_METRICS_PIPELINE_RUNS="$pipeline_runs" FM_METRICS_FIX_ROUNDS="$fix_rounds" \
       FM_METRICS_DECISIONS="$decisions" FM_METRICS_TERMINAL_VERB="$terminal_verb" \
-      FM_METRICS_PR_OUT="$pr_out" FM_METRICS_CI_OUT="$ci_out" \
+      FM_METRICS_PR_OUT="$pr_out" \
       fm_run_timed 10 python3 - "$META" "$receipt_tmp" <<'PY'; then
-import csv
 import datetime
 import json
 import os
@@ -327,22 +311,6 @@ def parse_pr(path):
         return False, "pr_open"
     return False, None
 
-def parse_ci(path):
-    if not path:
-        return None
-    observations = []
-    with open(path, encoding="utf-8") as source:
-        for raw in source:
-            if not re.match(r"^  [0-9]", raw):
-                continue
-            row = next(csv.reader([raw.strip()]))
-            if len(row) >= 4:
-                observations.append((row[2], row[3]))
-    if not observations or any(status != "completed" for status, _ in observations):
-        return None
-    good = {"success", "skipped", "neutral"}
-    return all(conclusion in good for _, conclusion in observations)
-
 pr_url = nullable_text(meta.get("pr"))
 merged, outcome = parse_pr(os.environ.get("FM_METRICS_PR_OUT")) if pr_url else (None, None)
 terminal = os.environ.get("FM_METRICS_TERMINAL_VERB")
@@ -382,7 +350,7 @@ row = {
     "nudges_to_validate": None,
     "agent_deaths": None,
     "rebases_required": None,
-    "ci_green_first_push": parse_ci(os.environ.get("FM_METRICS_CI_OUT")),
+    "ci_green_first_push": None,
     "vacuous_tests_caught": None,
     "vacuous_tests_shipped": None,
     "tokens_consumed": None,
@@ -401,10 +369,10 @@ with open(output_path, "w", encoding="utf-8") as destination:
     json.dump(envelope, destination, ensure_ascii=False, separators=(",", ":"))
     destination.write("\n")
 PY
-    rm -f "$receipt_tmp" "$pr_tmp" "$ci_tmp"
+    rm -f "$receipt_tmp" "$pr_tmp"
     return 1
   fi
-  rm -f "$pr_tmp" "$ci_tmp"
+  rm -f "$pr_tmp"
   chmod 0600 "$receipt_tmp" || { rm -f "$receipt_tmp"; return 1; }
   task_metrics_private_file_valid "$receipt_tmp" 600 "$state_device" \
     || { rm -f "$receipt_tmp"; echo "error: task metrics receipt is unsafe" >&2; return 1; }

--- a/bin/fm-task-metrics.sh
+++ b/bin/fm-task-metrics.sh
@@ -1,0 +1,500 @@
+#!/usr/bin/env bash
+# Prepare and commit one honest per-task metrics row from durable task records.
+#
+# Teardown uses two phases so destructive cleanup cannot erase the inputs before
+# the row exists, while a later cleanup refusal cannot create a duplicate row:
+#
+#   fm-task-metrics.sh prepare <task-id>
+#     Reads state/<id>.meta, state/<id>.status, the task branch's durable
+#     no-mistakes records, and the recorded PR. It atomically writes the private
+#     recovery receipt state/<id>.task-metrics-row but does not append metrics.
+#
+#   fm-task-metrics.sh commit <task-id>
+#     Under the data/task-metrics lock, validates the complete JSONL destination,
+#     appends the prepared row exactly once, fsyncs it, and retires the receipt.
+#     A corrupt or unsafe destination refuses without losing the receipt.
+#
+#   fm-task-metrics.sh emit <task-id>
+#     Runs prepare then commit. This is the standalone convenience interface;
+#     guarded teardown prepares before cleanup and commits after cleanup has
+#     succeeded but before it retires the metadata and status inputs.
+#
+# Only mechanically attributable values are populated. Judgment-only fields,
+# timing without a durable terminal timestamp, and unattributable token usage
+# remain JSON null. Missing optional no-mistakes or forge evidence also yields
+# null for the affected fields rather than a guessed value. The exact formulas:
+#   pipeline_runs: distinct no-mistakes runs for the metadata project and exact
+#     current task branch.
+#   fix_rounds: no-mistakes auto_fix rounds in review or test steps only.
+#   decisions_raised: status lines whose classified verb is needs-decision or
+#     blocked.
+#   ci_green_first_push: all GitHub workflow runs for the first durable pushed
+#     SHA completed successfully/skipped/neutral; false on any other completed
+#     conclusion, null when no complete observation exists.
+#   merged/outcome: the recorded PR's current forge state, or the last durable
+#     terminal status when there is no PR.
+#
+# The no-mistakes SQLite path defaults to
+# ${NO_MISTAKES_HOME:-$HOME/.no-mistakes}/state.sqlite. Tests and specialized
+# homes may set FM_NM_STATE_DB_OVERRIDE. External forge reads are bounded by
+# FM_TASK_METRICS_GH_TIMEOUT seconds (default 15).
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+
+# shellcheck source=bin/fm-backend.sh
+. "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-classify-lib.sh
+. "$SCRIPT_DIR/fm-classify-lib.sh"
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-timeout-lib.sh
+. "$SCRIPT_DIR/fm-timeout-lib.sh"
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+
+usage() {
+  sed -n '2,${/^#/!q;p;}' "$0" | sed 's/^# \{0,1\}//'
+}
+
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+  prepare|commit|emit) ACTION=$1 ;;
+  *) echo "error: usage: fm-task-metrics.sh <prepare|commit|emit> <task-id>" >&2; exit 2 ;;
+esac
+ID=${2:-}
+if [ "$#" -ne 2 ] || ! fm_task_id_path_safe "$ID"; then
+  echo "error: invalid task metrics request" >&2
+  exit 2
+fi
+
+META="$STATE/$ID.meta"
+STATUS="$STATE/$ID.status"
+RECEIPT="$STATE/$ID.task-metrics-row"
+METRICS="$DATA/task-metrics.jsonl"
+METRICS_LOCK="$DATA/.task-metrics.lock"
+GH_TIMEOUT=${FM_TASK_METRICS_GH_TIMEOUT:-15}
+case "$GH_TIMEOUT" in ''|*[!0-9]*|0) echo "error: invalid FM_TASK_METRICS_GH_TIMEOUT" >&2; exit 2 ;; esac
+
+task_metrics_prior_branch() {
+  [ -f "$RECEIPT" ] && [ ! -L "$RECEIPT" ] || return 0
+  python3 - "$RECEIPT" <<'PY' 2>/dev/null || true
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as source:
+    value = json.load(source).get("branch")
+if isinstance(value, str):
+    print(value)
+PY
+}
+
+task_metrics_repo_slug() {
+  local project=$1 pr_url=$2 remote slug
+  if [ -n "$pr_url" ]; then
+    fm_pr_url_parse "$pr_url" || return 1
+    printf '%s\n' "$FM_PR_PATH"
+    return 0
+  fi
+  remote=$(git -C "$project" remote get-url origin 2>/dev/null) || return 1
+  case "$remote" in
+    https://github.com/*) slug=${remote#https://github.com/} ;;
+    git@github.com:*) slug=${remote#git@github.com:} ;;
+    *) return 1 ;;
+  esac
+  slug=${slug%.git}
+  case "$slug" in
+    */*) printf '%s\n' "$slug" ;;
+    *) return 1 ;;
+  esac
+}
+
+task_metrics_file_device() {  # <path>
+  python3 - "$1" <<'PY' 2>/dev/null
+import os
+import sys
+
+print(os.lstat(sys.argv[1]).st_dev)
+PY
+}
+
+task_metrics_regular_single_link() {  # <path>
+  python3 - "$1" <<'PY' >/dev/null 2>&1
+import os
+import stat
+import sys
+
+info = os.lstat(sys.argv[1])
+raise SystemExit(0 if stat.S_ISREG(info.st_mode) and info.st_nlink == 1 else 1)
+PY
+}
+
+task_metrics_private_file_valid() {  # <path> <octal-mode> <device>
+  python3 - "$1" "$2" "$3" <<'PY' >/dev/null 2>&1
+import os
+import stat
+import sys
+
+path, expected_mode, expected_device = sys.argv[1:]
+info = os.lstat(path)
+valid = (
+    stat.S_ISREG(info.st_mode)
+    and info.st_nlink == 1
+    and stat.S_IMODE(info.st_mode) == int(expected_mode, 8)
+    and info.st_dev == int(expected_device)
+)
+raise SystemExit(0 if valid else 1)
+PY
+}
+
+task_metrics_pipeline_info() {
+  local mode=$1 project=$2 branch=$3 db
+  if [ "$mode" != no-mistakes ]; then
+    printf '0\n0\n\n'
+    return 0
+  fi
+  db=${FM_NM_STATE_DB_OVERRIDE:-${NO_MISTAKES_HOME:-${HOME}/.no-mistakes}/state.sqlite}
+  [ -f "$db" ] && [ ! -L "$db" ] && [ -n "$project" ] && [ -n "$branch" ] || return 1
+  fm_run_timed 10 python3 - "$db" "$project" "$branch" <<'PY'
+import os
+import re
+import sqlite3
+import sys
+
+db, project, branch = sys.argv[1:]
+uri = "file:" + os.path.abspath(db) + "?mode=ro"
+con = sqlite3.connect(uri, uri=True, timeout=0.25)
+con.execute("PRAGMA query_only = ON")
+project_real = os.path.realpath(project)
+repo_ids = [
+    row[0]
+    for row in con.execute(
+        "SELECT id FROM repos WHERE working_path IN (?, ?)",
+        (project, project_real),
+    )
+]
+if not repo_ids:
+    print("0\n0\n")
+    raise SystemExit(0)
+marks = ",".join("?" for _ in repo_ids)
+run_rows = list(
+    con.execute(
+        f"SELECT id, last_pushed_sha FROM runs "
+        f"WHERE repo_id IN ({marks}) AND branch = ? ORDER BY created_at, id",
+        (*repo_ids, branch),
+    )
+)
+run_ids = [row[0] for row in run_rows]
+fix_rounds = 0
+if run_ids:
+    run_marks = ",".join("?" for _ in run_ids)
+    fix_rounds = con.execute(
+        f"SELECT COUNT(*) FROM step_rounds rd "
+        f"JOIN step_results sr ON sr.id = rd.step_result_id "
+        f"WHERE sr.run_id IN ({run_marks}) "
+        "AND sr.step_name IN ('review', 'test') "
+        "AND rd.trigger_type = 'auto_fix'",
+        run_ids,
+    ).fetchone()[0]
+first_sha = ""
+for _, candidate in run_rows:
+    if isinstance(candidate, str) and re.fullmatch(r"[0-9a-f]{40}|[0-9a-f]{64}", candidate):
+        first_sha = candidate
+        break
+print(len(run_rows))
+print(fix_rounds)
+print(first_sha)
+PY
+}
+
+task_metrics_prepare() {
+  local state_device worktree project mode pr_url branch prior_branch repo_slug=''
+  local pipeline_info='' pipeline_runs=null fix_rounds=null first_push_sha=''
+  local pr_provider='' pr_number='' pr_out='' ci_out='' pr_tmp='' ci_tmp=''
+  local decisions=0 terminal_verb='' verb line receipt_tmp
+
+  command -v python3 >/dev/null 2>&1 || { echo "error: task metrics requires python3" >&2; return 1; }
+  [ -d "$STATE" ] && [ ! -L "$STATE" ] || { echo "error: task metrics state directory is unsafe" >&2; return 1; }
+  task_metrics_regular_single_link "$META" \
+    || { echo "error: task metrics metadata is unavailable" >&2; return 1; }
+  if [ -e "$STATUS" ] || [ -L "$STATUS" ]; then
+    task_metrics_regular_single_link "$STATUS" \
+      || { echo "error: task metrics status record is unsafe" >&2; return 1; }
+    while IFS= read -r line || [ -n "$line" ]; do
+      verb=$(status_line_verb "$line")
+      case "$verb" in
+        needs-decision|blocked) decisions=$((decisions + 1)) ;;
+      esac
+      case "$verb" in
+        done|failed) terminal_verb=$verb ;;
+      esac
+    done < "$STATUS"
+  fi
+
+  worktree=$(fm_meta_get "$META" worktree)
+  project=$(fm_meta_get "$META" project)
+  mode=$(fm_meta_get "$META" mode)
+  pr_url=$(fm_meta_get "$META" pr)
+  if [ -n "$pr_url" ]; then
+    fm_pr_url_parse "$pr_url" || { echo "error: task metrics metadata has an invalid PR URL" >&2; return 1; }
+    pr_provider=$FM_PR_PROVIDER
+    pr_number=$FM_PR_NUMBER
+  fi
+  branch=$(git -C "$worktree" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+  if [ -z "$branch" ]; then
+    prior_branch=$(task_metrics_prior_branch)
+    branch=$prior_branch
+  fi
+  repo_slug=$(task_metrics_repo_slug "$project" "$pr_url" 2>/dev/null || true)
+
+  if pipeline_info=$(task_metrics_pipeline_info "$mode" "$project" "$branch" 2>/dev/null); then
+    pipeline_runs=$(printf '%s\n' "$pipeline_info" | sed -n '1p')
+    fix_rounds=$(printf '%s\n' "$pipeline_info" | sed -n '2p')
+    first_push_sha=$(printf '%s\n' "$pipeline_info" | sed -n '3p')
+    case "$pipeline_runs" in ''|*[!0-9]*) pipeline_runs=null ;; esac
+    case "$fix_rounds" in ''|*[!0-9]*) fix_rounds=null ;; esac
+  fi
+
+  pr_tmp=$(mktemp "$STATE/.task-metrics-pr.XXXXXX") || return 1
+  ci_tmp=$(mktemp "$STATE/.task-metrics-ci.XXXXXX") || { rm -f "$pr_tmp"; return 1; }
+  if [ "$pr_provider" = github ] && [ -n "$repo_slug" ] && command -v gh-axi >/dev/null 2>&1; then
+    if fm_run_timed "$GH_TIMEOUT" gh-axi pr view "$pr_number" --repo "$repo_slug" > "$pr_tmp" 2>/dev/null; then
+      pr_out=$pr_tmp
+    fi
+    if [ -n "$first_push_sha" ] \
+      && fm_run_timed "$GH_TIMEOUT" gh-axi run list --repo "$repo_slug" \
+        --commit "$first_push_sha" --limit 100 > "$ci_tmp" 2>/dev/null; then
+      ci_out=$ci_tmp
+    fi
+  fi
+
+  state_device=$(task_metrics_file_device "$STATE") || { rm -f "$pr_tmp" "$ci_tmp"; return 1; }
+  receipt_tmp=$(mktemp "$STATE/.task-metrics-row.XXXXXX") || { rm -f "$pr_tmp" "$ci_tmp"; return 1; }
+  if ! FM_METRICS_BRANCH="$branch" FM_METRICS_REPO="$repo_slug" \
+      FM_METRICS_PIPELINE_RUNS="$pipeline_runs" FM_METRICS_FIX_ROUNDS="$fix_rounds" \
+      FM_METRICS_DECISIONS="$decisions" FM_METRICS_TERMINAL_VERB="$terminal_verb" \
+      FM_METRICS_PR_OUT="$pr_out" FM_METRICS_CI_OUT="$ci_out" \
+      fm_run_timed 10 python3 - "$META" "$receipt_tmp" <<'PY'; then
+import csv
+import datetime
+import json
+import os
+import re
+import sys
+
+meta_path, output_path = sys.argv[1:]
+meta = {}
+with open(meta_path, encoding="utf-8") as source:
+    for raw in source:
+        key, sep, value = raw.rstrip("\n").partition("=")
+        if sep:
+            meta[key] = value
+
+def nullable_text(value):
+    return value if isinstance(value, str) and value else None
+
+def nullable_int(value):
+    return int(value) if re.fullmatch(r"[0-9]+", value or "") else None
+
+def yolo_value(value):
+    if value in ("on", "true"):
+        return True
+    if value in ("off", "false"):
+        return False
+    return None
+
+def parse_pr(path):
+    if not path:
+        return None, None
+    text = open(path, encoding="utf-8").read()
+    state_match = re.search(r"^  state: (open|closed|merged)$", text, re.MULTILINE)
+    merged_match = re.search(r"^  merged: (yes|no)$", text, re.MULTILINE)
+    checks_match = re.search(r'^  checks: "([0-9]+) passed, ([0-9]+) failed, ([0-9]+) total"$', text, re.MULTILINE)
+    if not merged_match:
+        return None, None
+    if merged_match.group(1) == "yes":
+        return True, "merged"
+    state = state_match.group(1) if state_match else None
+    if state == "closed":
+        return False, "pr_closed"
+    if state == "open":
+        if checks_match and int(checks_match.group(2)) == 0 and int(checks_match.group(3)) > 0:
+            return False, "green_pr"
+        return False, "pr_open"
+    return False, None
+
+def parse_ci(path):
+    if not path:
+        return None
+    observations = []
+    with open(path, encoding="utf-8") as source:
+        for raw in source:
+            if not re.match(r"^  [0-9]", raw):
+                continue
+            row = next(csv.reader([raw.strip()]))
+            if len(row) >= 4:
+                observations.append((row[2], row[3]))
+    if not observations or any(status != "completed" for status, _ in observations):
+        return None
+    good = {"success", "skipped", "neutral"}
+    return all(conclusion in good for _, conclusion in observations)
+
+pr_url = nullable_text(meta.get("pr"))
+merged, outcome = parse_pr(os.environ.get("FM_METRICS_PR_OUT")) if pr_url else (None, None)
+terminal = os.environ.get("FM_METRICS_TERMINAL_VERB")
+if not pr_url:
+    if terminal == "done":
+        outcome = "completed"
+    elif terminal == "failed":
+        outcome = "failed"
+
+dispatched_at = nullable_text(meta.get("dispatched_at"))
+if dispatched_at and not re.fullmatch(r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z", dispatched_at):
+    dispatched_at = None
+date = dispatched_at[:10] if dispatched_at else None
+row = {
+    "task": meta.get("endpoint_task_id") or os.path.basename(meta_path).removesuffix(".meta"),
+    "title": None,
+    "repo": nullable_text(os.environ.get("FM_METRICS_REPO")),
+    "kind": nullable_text(meta.get("kind")),
+    "mode": nullable_text(meta.get("mode")),
+    "yolo": yolo_value(meta.get("yolo")),
+    "harness": nullable_text(meta.get("harness")),
+    "model": nullable_text(meta.get("model")),
+    "effort": nullable_text(meta.get("effort")),
+    "attribution": None,
+    "date": date,
+    "dispatched_at": dispatched_at,
+    "done_at": None,
+    "wall_clock_min": None,
+    "blocked_min": None,
+    "pipeline_runs": nullable_int(os.environ.get("FM_METRICS_PIPELINE_RUNS")),
+    "fix_rounds": nullable_int(os.environ.get("FM_METRICS_FIX_ROUNDS")),
+    "decisions_raised": nullable_int(os.environ.get("FM_METRICS_DECISIONS")),
+    "firstmate_interventions": None,
+    "captain_interventions": None,
+    "corrections_required": None,
+    "self_corrections": None,
+    "nudges_to_validate": None,
+    "agent_deaths": None,
+    "rebases_required": None,
+    "ci_green_first_push": parse_ci(os.environ.get("FM_METRICS_CI_OUT")),
+    "vacuous_tests_caught": None,
+    "vacuous_tests_shipped": None,
+    "tokens_consumed": None,
+    "token_note": "not attributable from per-task durable records",
+    "outcome": outcome,
+    "pr": pr_url,
+    "merged": merged,
+    "notes": None,
+}
+envelope = {
+    "schema": "firstmate.task-metrics.prepare.v1",
+    "branch": nullable_text(os.environ.get("FM_METRICS_BRANCH")),
+    "row": row,
+}
+with open(output_path, "w", encoding="utf-8") as destination:
+    json.dump(envelope, destination, ensure_ascii=False, separators=(",", ":"))
+    destination.write("\n")
+PY
+    rm -f "$receipt_tmp" "$pr_tmp" "$ci_tmp"
+    return 1
+  fi
+  rm -f "$pr_tmp" "$ci_tmp"
+  chmod 0600 "$receipt_tmp" || { rm -f "$receipt_tmp"; return 1; }
+  task_metrics_private_file_valid "$receipt_tmp" 600 "$state_device" \
+    || { rm -f "$receipt_tmp"; echo "error: task metrics receipt is unsafe" >&2; return 1; }
+  if [ -e "$RECEIPT" ] || [ -L "$RECEIPT" ]; then
+    task_metrics_regular_single_link "$RECEIPT" \
+      || { rm -f "$receipt_tmp"; echo "error: task metrics receipt destination is unsafe" >&2; return 1; }
+  fi
+  mv -f -- "$receipt_tmp" "$RECEIPT"
+  echo "prepared: state/$ID.task-metrics-row"
+}
+
+task_metrics_commit() {
+  local state_device data_device lock_held=0 rc=0
+  command -v python3 >/dev/null 2>&1 || { echo "error: task metrics requires python3" >&2; return 1; }
+  task_metrics_regular_single_link "$RECEIPT" || { echo "error: task metrics receipt is unavailable" >&2; return 1; }
+  state_device=$(task_metrics_file_device "$STATE") || return 1
+  task_metrics_private_file_valid "$RECEIPT" 600 "$state_device" \
+    || { echo "error: task metrics receipt is unsafe" >&2; return 1; }
+  if [ ! -e "$DATA" ]; then
+    mkdir -p "$DATA" || return 1
+    chmod 0700 "$DATA" || return 1
+  fi
+  [ -d "$DATA" ] && [ ! -L "$DATA" ] || { echo "error: task metrics data directory is unsafe" >&2; return 1; }
+  data_device=$(task_metrics_file_device "$DATA") || return 1
+  if [ -e "$METRICS" ] || [ -L "$METRICS" ]; then
+    task_metrics_regular_single_link "$METRICS" \
+      && [ "$(task_metrics_file_device "$METRICS")" = "$data_device" ] \
+      || { echo "error: task metrics destination is unsafe" >&2; return 1; }
+  fi
+  fm_lock_acquire_wait "$METRICS_LOCK" || return 1
+  lock_held=1
+  if python3 - "$RECEIPT" "$METRICS" "$ID" <<'PY'
+import json
+import os
+import stat
+import sys
+
+receipt_path, metrics_path, expected_id = sys.argv[1:]
+with open(receipt_path, encoding="utf-8") as source:
+    envelope = json.load(source)
+if envelope.get("schema") != "firstmate.task-metrics.prepare.v1":
+    raise SystemExit("invalid task metrics receipt schema")
+row = envelope.get("row")
+if not isinstance(row, dict) or row.get("task") != expected_id:
+    raise SystemExit("task metrics receipt identity mismatch")
+
+seen = False
+if os.path.exists(metrics_path):
+    with open(metrics_path, encoding="utf-8") as source:
+        for line_number, raw in enumerate(source, 1):
+            if not raw.strip():
+                continue
+            try:
+                existing = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                raise SystemExit(f"invalid task metrics JSONL at line {line_number}: {exc}")
+            if isinstance(existing, dict) and existing.get("task") == expected_id:
+                seen = True
+if not seen:
+    encoded = (json.dumps(row, ensure_ascii=False, separators=(",", ":")) + "\n").encode("utf-8")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(metrics_path, flags, 0o600)
+    try:
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode) or info.st_nlink != 1:
+            raise SystemExit("task metrics destination changed while appending")
+        written = os.write(fd, encoded)
+        if written != len(encoded):
+            raise SystemExit("short task metrics append")
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+PY
+  then
+    rc=0
+  else
+    rc=$?
+  fi
+  if [ "$lock_held" -eq 1 ]; then
+    fm_lock_release "$METRICS_LOCK" || rc=1
+  fi
+  [ "$rc" -eq 0 ] || return "$rc"
+  rm -f -- "$RECEIPT"
+  echo "emitted: data/task-metrics.jsonl task=$ID"
+}
+
+case "$ACTION" in
+  prepare) task_metrics_prepare ;;
+  commit) task_metrics_commit ;;
+  emit) task_metrics_prepare >/dev/null && task_metrics_commit ;;
+esac

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2063,7 +2063,12 @@ FMEOF
 }
 
 teardown_herdr_require_prerequisites() {  # <task-id>
-  local task_id=$1 prerequisite
+  local task_id=$1 prerequisite adapter
+  adapter="$FM_BACKEND_LIB_DIR/backends/herdr.sh"
+  if [ ! -f "$adapter" ] || [ -L "$adapter" ]; then
+    echo "error: herdr teardown prerequisites are unavailable for $task_id; nothing was changed - restore the adapter and rerun teardown" >&2
+    return 1
+  fi
   if ! fm_backend_source herdr; then
     echo "error: herdr teardown prerequisites are unavailable for $task_id; nothing was changed - restore the adapter and rerun teardown" >&2
     return 1
@@ -2375,6 +2380,15 @@ if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
   fi
 fi
 
+# Prepare every ordinary task's durable metrics row before cleanup can destroy
+# its worktree or other derivation inputs. The row is committed only after the
+# cleanup succeeds, while metadata and status still make a failed append
+# retryable on a later teardown attempt.
+if [ "$KIND" != secondmate ]; then
+  FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
+    "$SCRIPT_DIR/fm-task-metrics.sh" prepare "$ID" >/dev/null
+fi
+
 # Every landed/discard-work refusal above has now passed (or --force skipped
 # them). Fix 1 and Fix 2 (see script header) run here, unconditionally on
 # --force, and before ANY destructive step below - a still-parked run or a
@@ -2393,11 +2407,10 @@ fi
 
 # A Herdr close may reposition shared workspace order, so the whole
 # destructive sequence below (worktree return, pane close, record removal)
-# runs under the named-session presentation lock, acquired BEFORE anything is
-# returned or erased: a contended lock refuses here while the isolated copy,
-# every durable record, and the endpoint are all still intact for a plain
-# rerun. An unresolvable lock path (for example an unreachable server) also
-# refuses before any destructive step.
+# runs under the named-session presentation lock, acquired before anything is
+# returned or erased. Metrics preparation above is read-only and deliberately
+# remains outside this focus-critical section so concurrent teardowns do not
+# hold the shared presentation lock during durable derivation.
 TEARDOWN_HERDR_SESSION=
 TEARDOWN_HERDR_PANE=
 if [ "$BACKEND" = herdr ]; then
@@ -2538,6 +2551,10 @@ fm_backend_clear_transition "$BACKEND" "$STATE" "$T" || true
 remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
 retire_busy_state "$STATE" "$ID" "$BUSY_GEN" || exit 1
 status_retire_presentation_task "$STATE" "$ID" || exit 1
+if [ "$KIND" != secondmate ]; then
+  FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
+    "$SCRIPT_DIR/fm-task-metrics.sh" commit "$ID" >/dev/null
+fi
 rm -f "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
   "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
   "$STATE/$ID.kimi-turnend-token" "$STATE/$ID.muse-session" \

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,13 +10,14 @@ The shared orchestrator behavior lives in [`AGENTS.md`](../AGENTS.md) - edit it 
 
 This section is the single owner of the top-level operational-home layout; producer script headers and their help own exact child-file fields and mutation contracts.
 The tracked code root contains the shared instruction, skill, documentation, workflow, and `bin/` surfaces, while each effective `FM_HOME` contains private operational directories.
-`data/` holds durable private fleet records such as the project and secondmate registries, captain preferences, optional shared captain preferences, learnings, backlog, briefs, and scout reports.
-`state/` holds runtime records such as task metadata, append-only status events, endpoint signals, watcher and wake-queue coordination, inactive terminal-outcome receipts under `state/terminal-outcomes/`, away-mode state, generated Relay artifacts, private secondmate config-reread generations with their retry and quarantine state, and parent-owned secondmate pending-reply records under `state/pending-replies/` (`bin/fm-pending-reply-lib.sh`).
+`data/` holds durable private fleet records such as the project and secondmate registries, captain preferences, optional shared captain preferences, learnings, backlog, briefs, scout reports, and completed task metrics.
+`state/` holds runtime records such as task metadata, append-only status events, retryable task-metrics receipts, endpoint signals, watcher and wake-queue coordination, inactive terminal-outcome receipts under `state/terminal-outcomes/`, away-mode state, generated Relay artifacts, private secondmate config-reread generations with their retry and quarantine state, and parent-owned secondmate pending-reply records under `state/pending-replies/` (`bin/fm-pending-reply-lib.sh`).
 `config/` holds local gitignored operating choices, and `projects/` holds the local project clones that Firstmate reads but changes only through the narrow guarded and concrete captain-approved exceptions in `AGENTS.md`.
 
 `bin/fm-spawn.sh` owns the base task-metadata fields it emits, while the runtime-backend section below owns backend-specific fields and selector interpretation.
 The producing PR and Relay helpers own the fields they append, `bin/fm-classify-lib.sh` owns status-event vocabulary, and `bin/fm-crew-state.sh` owns current-state reconciliation.
 Wake, watcher, away-mode, and Relay-specific state mechanics remain with their named scripts and reference sections rather than being duplicated into one exhaustive state tree here.
+[`docs/task-metrics.md`](task-metrics.md) owns task-metrics formulas, null rules, and teardown recovery behavior.
 
 `bin/fm-session-start.sh`'s header is the single owner of session-start ordering, composed commands, digest contents, and the digest's startup mechanism.
 `bin/fm-startup-network.sh`'s header owns the deferred network stage that keeps every external-network call off that digest's blocking path, including its state files and the safety argument for running them later.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -321,6 +321,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": "docs/task-metrics.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/tmux-backend.md",
       "audience": "operator-current"
     },

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -108,6 +108,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-pr-merge.sh`         | Record PR metadata, then merge a task's canonical full GitHub URL                    |
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task with an explicit delivery mode |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |
+| `fm-task-metrics.sh`     | Prepare and commit one durable-only per-task metrics row during guarded teardown |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |
 | `fm-lock.sh`             | Per-home firstmate session lock                                                      |
 | `fm-x-lib.sh`            | Shared Relay config, relay, and reply-threading helpers                              |

--- a/docs/task-metrics.md
+++ b/docs/task-metrics.md
@@ -21,7 +21,7 @@ The mechanically derived counters and outcomes are:
 - `pipeline_runs` counts no-mistakes runs whose durable repository path and branch match the task exactly.
 - `fix_rounds` counts durable no-mistakes `auto_fix` rounds for review and test steps only.
 - `decisions_raised` counts status events classified as `needs-decision` or `blocked` by `bin/fm-classify-lib.sh`.
-- `ci_green_first_push` inspects workflow runs for the first durable pushed SHA, returns true only when every observed run completed with `success`, `skipped`, or `neutral`, returns false for another completed conclusion, and remains null for missing or incomplete evidence.
+- `ci_green_first_push` remains null because current durable no-mistakes records retain only each run's latest pushed SHA, not the first pushed SHA or a complete workflow-run history for it.
 - `merged` and `outcome` use the recorded PR's current forge state, or the last durable `done` or `failed` status when no PR is recorded.
 
 Tasks outside no-mistakes mode have zero no-mistakes pipeline runs and fix rounds by definition.

--- a/docs/task-metrics.md
+++ b/docs/task-metrics.md
@@ -1,0 +1,51 @@
+# Task metrics
+
+Firstmate emits one JSON object per completed ordinary task to the home-local, gitignored `data/task-metrics.jsonl` file.
+Secondmate runtime records are excluded because they are persistent homes rather than backlog tasks.
+
+`bin/fm-teardown.sh` prepares the row only after every non-destructive refusal gate has passed.
+The private `state/<id>.task-metrics-row` receipt preserves the prepared row while worktree and endpoint cleanup runs.
+Teardown commits the row after that cleanup succeeds and before it retires task metadata and status.
+If cleanup fails, the receipt remains but the JSONL row is not emitted.
+If the append fails, teardown retains the receipt and task metadata for a safe retry.
+The commit path validates the existing JSONL file, serializes appends with a home-local lock, and treats an existing row for the same task id as success.
+
+## Derivation rules
+
+The helper populates identity and routing fields directly from `state/<id>.meta`.
+Fresh spawns record `dispatched_at` once in UTC, and relaunches preserve that original value.
+`date` is derived only from a valid recorded dispatch timestamp.
+
+The mechanically derived counters and outcomes are:
+
+- `pipeline_runs` counts no-mistakes runs whose durable repository path and branch match the task exactly.
+- `fix_rounds` counts durable no-mistakes `auto_fix` rounds for review and test steps only.
+- `decisions_raised` counts status events classified as `needs-decision` or `blocked` by `bin/fm-classify-lib.sh`.
+- `ci_green_first_push` inspects workflow runs for the first durable pushed SHA, returns true only when every observed run completed with `success`, `skipped`, or `neutral`, returns false for another completed conclusion, and remains null for missing or incomplete evidence.
+- `merged` and `outcome` use the recorded PR's current forge state, or the last durable `done` or `failed` status when no PR is recorded.
+
+Tasks outside no-mistakes mode have zero no-mistakes pipeline runs and fix rounds by definition.
+When no-mistakes records or forge observations are unavailable, affected fields remain null instead of becoming zero or false.
+
+## Fields that remain null
+
+Judgment-only fields remain null because durable records do not distinguish correction from escalation or reliably attribute human and agent intervention.
+This includes attribution, intervention counts, correction counts, self-corrections, validation nudges, agent deaths, rebases, vacuous-test judgments, and blocked duration.
+`title` and free-form `notes` also remain null because the selected durable inputs do not own them.
+
+`tokens_consumed` is always null and `token_note` explains that per-task durable records cannot attribute shared-session token use.
+No process total, conversation estimate, or concurrent-lane aggregate is assigned to one task.
+
+`done_at`, `wall_clock_min`, and `blocked_min` remain null until status events carry durable timestamps with lifecycle semantics sufficient for mechanical derivation.
+File mtimes and conversation timestamps are not substitutes for that dependency.
+
+## Manual use
+
+Run the complete operation with:
+
+```bash
+bin/fm-task-metrics.sh emit <task-id>
+```
+
+The `prepare` and `commit` actions are lifecycle primitives for guarded teardown and recovery.
+Read the script header before invoking either phase separately.

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -428,6 +428,7 @@ normalize_meta() {  # <meta>
     -e 's|^herdr_tab_id=.*$|herdr_tab_id=<herdr-container-id>|' \
     -e 's|^herdr_pane_id=.*$|herdr_pane_id=<herdr-container-id>|' \
     -e 's|^spawn_gen=.*$|spawn_gen=<spawn-incarnation>|' \
+    -e 's|^dispatched_at=.*$|dispatched_at=<dispatch-time>|' \
     "$1"
 }
 
@@ -507,7 +508,7 @@ FIRSTMATE_WSID=$(grep '^herdr_workspace_id=' "$ANCHOR_META" | cut -d= -f2-)
 
 # The same task id and project run once opted out and once projected, so
 # Treehouse commands and metadata can be compared after normalizing endpoint
-# IDs and the deliberately fresh per-spawn incarnation.
+# IDs, the deliberately fresh per-spawn incarnation, and its dispatch time.
 : > "$TREEHOUSE_CALL_LOG"
 OFF_HERDR_START=$(log_line_count)
 OFF_MOVE_START=$(wc -l < "$MOVE_CALL_LOG" | tr -d '[:space:]')
@@ -886,8 +887,10 @@ teardown_task order-a "$HOME_DIR" > "$TMP_ROOT/order-a-teardown.out" 2> "$TMP_RO
 ORDER_A_TEARDOWN_PID=$!
 teardown_task order-b "$HOME_DIR" > "$TMP_ROOT/order-b-teardown.out" 2> "$TMP_ROOT/order-b-teardown.err" &
 ORDER_B_TEARDOWN_PID=$!
-wait "$ORDER_A_TEARDOWN_PID" || fail "projected ordering fixture A teardown failed"
-wait "$ORDER_B_TEARDOWN_PID" || fail "projected ordering fixture B teardown failed"
+wait "$ORDER_A_TEARDOWN_PID" \
+  || fail "projected ordering fixture A teardown failed: $(cat "$TMP_ROOT/order-a-teardown.err")"
+wait "$ORDER_B_TEARDOWN_PID" \
+  || fail "projected ordering fixture B teardown failed: $(cat "$TMP_ROOT/order-b-teardown.err")"
 assert_focus_is "$CAPTAIN_FOCUS" "concurrent projected teardowns"
 teardown_task order-fail "$HOME_DIR" > "$TMP_ROOT/order-fail-teardown.out" 2> "$TMP_ROOT/order-fail-teardown.err" \
   || fail "projected ordering failure fixture teardown failed"

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -271,17 +271,17 @@ test_matrix_herdr_halfblock_rule_bounds_bare_wrap() {
   # footer, whose real content turns an idle pane into a false `pending`.
   # Captured live from a herdr cursor pane.
   local screen plain out
-  plain=$'transcript\n \u2584\u2584\u2584\u2584\u2584\u2584\u2584\u2584\n  \u2192 Add a follow-up\n \u2580\u2580\u2580\u2580\u2580\u2580\u2580\u2580\n  Cursor Grok 4.5 High \u00b7 6.7%   Run Everything\n  ~/wt \u00b7 64cdd3a'
+  plain=$'transcript\n ▄▄▄▄▄▄▄▄\n  → Add a follow-up\n ▀▀▀▀▀▀▀▀\n  Cursor Grok 4.5 High · 6.7%   Run Everything\n  ~/wt · 64cdd3a'
   # The closing rule must bound the region, so the footer below is not input.
-  fm_composer_row_has_edge " $(printf '\u2580\u2580\u2580')" \
+  fm_composer_row_has_edge " ▀▀▀" \
     || fail "a half-block rule row must count as a structural edge"
-  fm_composer_row_has_edge " $(printf '\u2584\u2584\u2584')" \
+  fm_composer_row_has_edge " ▄▄▄" \
     || fail "the upper half-block rule must count as a structural edge"
   # Non-vacuousness: the footer rows really are non-blank content that would be
   # swallowed if the rule did not bound the region.
   case "$plain" in *"Run Everything"*) : ;; *) fail "fixture lost its footer content" ;; esac
   ESC_LOCAL=$(printf '\033')
-  screen=$'transcript\n \u2584\u2584\u2584\u2584\u2584\u2584\u2584\u2584\n'"  ${ESC_LOCAL}[2m\u2192 ${ESC_LOCAL}[0;7mA${ESC_LOCAL}[0;2mdd a follow-up${ESC_LOCAL}[0m"$'\n \u2580\u2580\u2580\u2580\u2580\u2580\u2580\u2580\n  Cursor Grok 4.5 High \u00b7 6.7%   Run Everything\n  ~/wt \u00b7 64cdd3a'
+  screen=$'transcript\n ▄▄▄▄▄▄▄▄\n'"  ${ESC_LOCAL}[2m→ ${ESC_LOCAL}[0;7mA${ESC_LOCAL}[0;2mdd a follow-up${ESC_LOCAL}[0m"$'\n ▀▀▀▀▀▀▀▀\n  Cursor Grok 4.5 High · 6.7%   Run Everything\n  ~/wt · 64cdd3a'
   out=$(fm_composer_classify_screen "$CAPS_STYLED" "$(printf '%b' "$screen")")
   [ "$out" = empty ] \
     || fail "an idle cursor composer inside herdr half-block rules must read empty, got '$out'"

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -278,6 +278,7 @@ test_relaunch_preserves_durable_task_metadata() {
   dir=$(new_case durable-meta rl19)
   add_ship_task "$dir" rl19 claude
   {
+    printf '%s\n' 'dispatched_at=2026-08-13T20:00:00Z'
     printf '%s\n' 'pr=https://github.com/example/repo/pull/19'
     printf '%s\n' 'pr_head=feature/relaunch'
     printf '%s\n' 'x_request=request-19'
@@ -294,6 +295,8 @@ test_relaunch_preserves_durable_task_metadata() {
     || fail "the task X request must survive relaunch"
   [ "$(meta_field "$dir" rl19 decisions_reviewed)" = 1 ] \
     || fail "the task decision state must survive relaunch"
+  [ "$(meta_field "$dir" rl19 dispatched_at)" = "2026-08-13T20:00:00Z" ] \
+    || fail "the original dispatch timestamp must survive relaunch"
   pass "fm-control relaunch: durable task metadata survives replacement launch publication"
 }
 

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -150,6 +150,8 @@ assert_meta_profile() {
   assert_grep "harness=$harness" "$meta" "meta missing harness=$harness"
   assert_grep "model=$model" "$meta" "meta missing model=$model"
   assert_grep "effort=$effort" "$meta" "meta missing effort=$effort"
+  grep -Eq '^dispatched_at=[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$' "$meta" \
+    || fail "meta missing its durable UTC dispatch timestamp"
 }
 
 test_no_profile_keeps_claude_profile_defaults() {

--- a/tests/fm-task-metrics.test.sh
+++ b/tests/fm-task-metrics.test.sh
@@ -111,12 +111,7 @@ pull_request:
 OUT
     ;;
   "run list")
-    cat <<'OUT'
-count: 2
-runs[2]{id,title,status,conclusion,workflow,branch,event,created}:
-  101,"portable tests",completed,success,CI,fm/metric-task,pull_request,1m ago
-  102,"lint",completed,success,CI,fm/metric-task,pull_request,1m ago
-OUT
+    exit 97
     ;;
   *) exit 1 ;;
 esac
@@ -148,7 +143,7 @@ assert row["blocked_min"] is None, row
 assert row["pipeline_runs"] == 2, row
 assert row["fix_rounds"] == 2, row
 assert row["decisions_raised"] == 3, row
-assert row["ci_green_first_push"] is True, row
+assert row["ci_green_first_push"] is None, row
 assert row["outcome"] == "merged", row
 assert row["pr"] == "https://github.com/example/widgets/pull/17", row
 assert row["merged"] is True, row

--- a/tests/fm-task-metrics.test.sh
+++ b/tests/fm-task-metrics.test.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# Behavioral contract for durable, honest task-metrics emission.
+#
+# The helper prepares a private recovery row before teardown destroys task
+# inputs, commits that row exactly once afterward, and leaves fields null when
+# the durable sources cannot attribute them mechanically.
+set -u
+
+# shellcheck source=tests/lib.sh disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+fm_git_identity fmtest fmtest@example.invalid
+
+METRICS="$ROOT/bin/fm-task-metrics.sh"
+TMP_ROOT=$(fm_test_tmproot fm-task-metrics-tests)
+
+make_case() {
+  local name=$1 dir="$TMP_ROOT/$1" fakebin
+  fakebin="$dir/fakebin"
+  mkdir -p "$dir/home/state" "$dir/home/data" "$dir/project" "$fakebin"
+  git -C "$dir/project" init -q
+  git -C "$dir/project" checkout -q -b fm/metric-task
+  git -C "$dir/project" remote add origin https://github.com/example/widgets.git
+  git -C "$dir/project" commit -q --allow-empty -m baseline
+  printf '%s\n' "$dir"
+}
+
+write_meta() {
+  local dir=$1 mode=${2:-no-mistakes}
+  fm_write_meta "$dir/home/state/metric-task.meta" \
+    "window=fleet:metric-task" \
+    "endpoint_task_id=metric-task" \
+    "worktree=$dir/project" \
+    "project=$dir/project" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=$mode" \
+    "yolo=off" \
+    "model=gpt-test" \
+    "effort=high" \
+    "dispatched_at=2026-08-13T20:00:00Z" \
+    "pr=https://github.com/example/widgets/pull/17"
+}
+
+write_no_mistakes_db() {
+  local dir=$1 db="$dir/no-mistakes.sqlite" sha
+  sha=$(git -C "$dir/project" rev-parse HEAD)
+  python3 - "$db" "$dir/project" "$sha" <<'PY'
+import sqlite3
+import sys
+
+db, project, sha = sys.argv[1:]
+con = sqlite3.connect(db)
+con.executescript("""
+CREATE TABLE repos (id TEXT PRIMARY KEY, working_path TEXT NOT NULL, upstream_url TEXT);
+CREATE TABLE runs (
+  id TEXT PRIMARY KEY, repo_id TEXT NOT NULL, branch TEXT NOT NULL,
+  status TEXT NOT NULL, pr_url TEXT, last_pushed_sha TEXT, created_at INTEGER NOT NULL
+);
+CREATE TABLE step_results (
+  id TEXT PRIMARY KEY, run_id TEXT NOT NULL, step_name TEXT NOT NULL, status TEXT NOT NULL
+);
+CREATE TABLE step_rounds (
+  id TEXT PRIMARY KEY, step_result_id TEXT NOT NULL, round INTEGER NOT NULL,
+  trigger_type TEXT NOT NULL
+);
+""")
+con.execute("INSERT INTO repos VALUES (?, ?, ?)", ("repo-1", project, "https://github.com/example/widgets.git"))
+con.executemany(
+    "INSERT INTO runs VALUES (?, 'repo-1', 'fm/metric-task', ?, ?, ?, ?)",
+    [
+        ("run-1", "failed", None, sha, 10),
+        ("run-2", "completed", "https://github.com/example/widgets/pull/17", sha, 20),
+    ],
+)
+con.executemany(
+    "INSERT INTO step_results VALUES (?, ?, ?, 'completed')",
+    [
+        ("review-1", "run-1", "review"),
+        ("test-2", "run-2", "test"),
+        ("document-2", "run-2", "document"),
+    ],
+)
+con.executemany(
+    "INSERT INTO step_rounds VALUES (?, ?, 2, 'auto_fix')",
+    [
+        ("round-review", "review-1"),
+        ("round-test", "test-2"),
+        ("round-doc", "document-2"),
+    ],
+)
+con.commit()
+PY
+  printf '%s\n' "$db"
+}
+
+write_gh_axi() {
+  local dir=$1
+  cat > "$dir/fakebin/gh-axi" <<'SH'
+#!/usr/bin/env bash
+case "${1:-} ${2:-}" in
+  "pr view")
+    cat <<'OUT'
+pull_request:
+  number: 17
+  title: "Metrics fixture"
+  state: closed
+  author: example
+  draft: no
+  merged: yes
+  checks: "2 passed, 0 failed, 2 total"
+OUT
+    ;;
+  "run list")
+    cat <<'OUT'
+count: 2
+runs[2]{id,title,status,conclusion,workflow,branch,event,created}:
+  101,"portable tests",completed,success,CI,fm/metric-task,pull_request,1m ago
+  102,"lint",completed,success,CI,fm/metric-task,pull_request,1m ago
+OUT
+    ;;
+  *) exit 1 ;;
+esac
+SH
+  chmod +x "$dir/fakebin/gh-axi"
+}
+
+assert_row_contract() {
+  local file=$1
+  python3 - "$file" <<'PY'
+import json
+import sys
+
+rows = [json.loads(line) for line in open(sys.argv[1], encoding="utf-8") if line.strip()]
+assert len(rows) == 1, rows
+row = rows[0]
+assert row["task"] == "metric-task", row
+assert row["repo"] == "example/widgets", row
+assert row["kind"] == "ship", row
+assert row["mode"] == "no-mistakes", row
+assert row["yolo"] is False, row
+assert row["harness"] == "codex", row
+assert row["model"] == "gpt-test", row
+assert row["effort"] == "high", row
+assert row["dispatched_at"] == "2026-08-13T20:00:00Z", row
+assert row["done_at"] is None, row
+assert row["wall_clock_min"] is None, row
+assert row["blocked_min"] is None, row
+assert row["pipeline_runs"] == 2, row
+assert row["fix_rounds"] == 2, row
+assert row["decisions_raised"] == 3, row
+assert row["ci_green_first_push"] is True, row
+assert row["outcome"] == "merged", row
+assert row["pr"] == "https://github.com/example/widgets/pull/17", row
+assert row["merged"] is True, row
+for key in (
+    "attribution", "corrections_required", "self_corrections",
+    "tokens_consumed", "firstmate_interventions", "captain_interventions",
+):
+    assert row[key] is None, (key, row)
+PY
+}
+
+test_prepare_commit_and_idempotency() {
+  local dir db metrics receipt
+  dir=$(make_case prepare-commit)
+  write_meta "$dir"
+  printf '%s\n' \
+    'working: implementation started' \
+    'needs-decision [key=one]: pick one' \
+    'blocked [key=two]: credentials needed' \
+    'resolved [key=two]: supplied' \
+    'needs-decision: pick three' \
+    'done: PR ready' > "$dir/home/state/metric-task.status"
+  db=$(write_no_mistakes_db "$dir")
+  write_gh_axi "$dir"
+  metrics="$dir/home/data/task-metrics.jsonl"
+  receipt="$dir/home/state/metric-task.task-metrics-row"
+
+  PATH="$dir/fakebin:$PATH" FM_HOME="$dir/home" \
+    FM_NM_STATE_DB_OVERRIDE="$db" "$METRICS" prepare metric-task \
+    || fail "prepare failed"
+  assert_present "$receipt" "prepare did not publish the recovery row"
+  assert_absent "$metrics" "prepare appended before teardown reached its commit point"
+
+  PATH="$dir/fakebin:$PATH" FM_HOME="$dir/home" \
+    FM_NM_STATE_DB_OVERRIDE="$db" "$METRICS" commit metric-task \
+    || fail "commit failed"
+  assert_absent "$receipt" "commit left the recovery row behind"
+  assert_row_contract "$metrics"
+
+  PATH="$dir/fakebin:$PATH" FM_HOME="$dir/home" \
+    FM_NM_STATE_DB_OVERRIDE="$db" "$METRICS" emit metric-task \
+    || fail "idempotent emit failed"
+  assert_row_contract "$metrics"
+  pass "task metrics: prepares before destruction, commits exactly once, and derives only durable fields"
+}
+
+test_missing_pipeline_records_stay_null() {
+  local dir metrics
+  dir=$(make_case missing-pipeline)
+  write_meta "$dir"
+  printf 'done: complete\n' > "$dir/home/state/metric-task.status"
+  write_gh_axi "$dir"
+  metrics="$dir/home/data/task-metrics.jsonl"
+
+  PATH="$dir/fakebin:$PATH" FM_HOME="$dir/home" \
+    FM_NM_STATE_DB_OVERRIDE="$dir/absent.sqlite" "$METRICS" emit metric-task \
+    || fail "emit should preserve unknown pipeline fields as null"
+  python3 - "$metrics" <<'PY'
+import json
+import sys
+row = json.loads(open(sys.argv[1], encoding="utf-8").readline())
+assert row["pipeline_runs"] is None, row
+assert row["fix_rounds"] is None, row
+assert row["ci_green_first_push"] is None, row
+assert row["tokens_consumed"] is None, row
+PY
+  pass "task metrics: unavailable pipeline attribution stays null instead of becoming a guess"
+}
+
+test_corrupt_destination_refuses_without_losing_receipt() {
+  local dir receipt metrics
+  dir=$(make_case corrupt-destination)
+  write_meta "$dir" direct-PR
+  printf 'done: PR ready\n' > "$dir/home/state/metric-task.status"
+  write_gh_axi "$dir"
+  receipt="$dir/home/state/metric-task.task-metrics-row"
+  metrics="$dir/home/data/task-metrics.jsonl"
+
+  PATH="$dir/fakebin:$PATH" FM_HOME="$dir/home" "$METRICS" prepare metric-task \
+    || fail "prepare failed"
+  printf 'not-json\n' > "$metrics"
+  if PATH="$dir/fakebin:$PATH" FM_HOME="$dir/home" "$METRICS" commit metric-task \
+      > "$dir/stdout" 2> "$dir/stderr"; then
+    fail "commit accepted a corrupt append-only destination"
+  fi
+  assert_present "$receipt" "failed commit discarded its retryable receipt"
+  [ "$(cat "$metrics")" = not-json ] || fail "failed commit changed the corrupt destination"
+  pass "task metrics: corrupt output blocks completion and preserves the retry receipt"
+}
+
+test_prepare_commit_and_idempotency
+test_missing_pipeline_records_stay_null
+test_corrupt_destination_refuses_without_losing_receipt

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -58,6 +58,8 @@ fm_git_identity fmtest fmtest@example.invalid
 TEARDOWN="$ROOT/bin/fm-teardown.sh"
 PR_CHECK="$ROOT/bin/fm-pr-check.sh"
 TMP_ROOT=$(fm_test_tmproot fm-teardown-tests)
+mkdir -p "$TMP_ROOT/data"
+export FM_DATA_OVERRIDE="$TMP_ROOT/data"
 REAL_GIT_FOR_TEST=$(command -v git)
 export REAL_GIT_FOR_TEST
 REAL_PS_FOR_TEST=$(command -v ps)
@@ -76,7 +78,7 @@ make_case() {
   local name=$1 case_dir fakebin
   case_dir="$TMP_ROOT/$name"
   fakebin="$case_dir/fakebin"
-  mkdir -p "$case_dir/state" "$case_dir/config" "$fakebin"
+  mkdir -p "$case_dir/state" "$case_dir/data" "$case_dir/config" "$fakebin"
 
   # Mocks for the post-check teardown steps. Refuse logic exits before these
   # run; the ALLOW cases need them so the script can complete cleanly.
@@ -544,6 +546,7 @@ run_teardown() {
   local case_dir=$1; shift
   FM_ROOT_OVERRIDE="$ROOT" \
   FM_STATE_OVERRIDE="$case_dir/state" \
+  FM_DATA_OVERRIDE="$case_dir/data" \
   FM_CONFIG_OVERRIDE="$case_dir/config" \
   PATH="$case_dir/fakebin:${FM_TEARDOWN_TEST_PATH:-$PATH}" \
     "$TEARDOWN" task-x1 "$@"
@@ -555,7 +558,7 @@ make_path_without_lsof() {  # <case-dir>
   local case_dir=$1 path_dir="$1/path-without-lsof" cmd resolved
   mkdir -p "$path_dir"
   for cmd in awk bash basename cat chmod cp cut date dirname env find git grep head hostname id ln \
-    mkdir mktemp mv perl ps readlink realpath rm sed sh sleep sort stat tail timeout tr uname wc xargs; do
+    mkdir mktemp mv perl ps python3 readlink realpath rm sed sh sleep sort stat tail timeout tr uname wc xargs; do
     resolved=$(command -v "$cmd" 2>/dev/null) || continue
     case "$resolved" in /*) ln -sf "$resolved" "$path_dir/$cmd" ;; esac
   done
@@ -1218,6 +1221,10 @@ test_persistent_index_lock_exhausts_retries_and_refuses_loudly() {
   [ -e "$lock" ] || fail "persistent-index-lock: lock file was removed"
   [ -f "$case_dir/state/task-x1.meta" ] \
     || fail "persistent-index-lock: teardown completed despite persistent lock"
+  assert_present "$case_dir/state/task-x1.task-metrics-row" \
+    "persistent-index-lock: failed cleanup lost the retryable metrics receipt"
+  assert_absent "$case_dir/data/task-metrics.jsonl" \
+    "persistent-index-lock: failed cleanup committed a completion metrics row"
   pass "persistent index.lock exhausts retries and refuses without force-removing the lock"
 }
 
@@ -2591,6 +2598,37 @@ EOF
   pass "the run abort and the leaked-process reap both complete before the destructive worktree return"
 }
 
+test_successful_teardown_emits_one_metrics_row() {
+  local case_dir metrics
+  case_dir=$(make_case task-metrics-emission)
+  write_meta "$case_dir" local-only ship
+  printf 'done: local work complete\n' > "$case_dir/state/task-x1.status"
+  wt_commit "$case_dir"
+
+  run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr" \
+    || fail "task-metrics-emission: teardown should succeed"
+  metrics="$case_dir/data/task-metrics.jsonl"
+  assert_present "$metrics" "task-metrics-emission: teardown emitted no metrics file"
+  assert_absent "$case_dir/state/task-x1.task-metrics-row" \
+    "task-metrics-emission: successful teardown retained the recovery receipt"
+  python3 - "$metrics" <<'PY'
+import json
+import sys
+
+rows = [json.loads(line) for line in open(sys.argv[1], encoding="utf-8") if line.strip()]
+assert len(rows) == 1, rows
+row = rows[0]
+assert row["task"] == "task-x1", row
+assert row["mode"] == "local-only", row
+assert row["pipeline_runs"] == 0, row
+assert row["fix_rounds"] == 0, row
+assert row["outcome"] == "completed", row
+assert row["merged"] is None, row
+assert row["tokens_consumed"] is None, row
+PY
+  pass "successful teardown emits one honest metrics row before retiring task records"
+}
+
 test_local_only_fork_remote_allows
 test_teardown_prompts_tasks_axi_done_when_compatible
 test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
@@ -2649,3 +2687,4 @@ test_process_spawned_during_grace_is_reaped_on_later_pass
 test_persistent_scan_refuses_after_bounded_retries
 test_process_exit_during_identity_lookup_does_not_refuse
 test_run_abort_precedes_process_reap_precedes_worktree_removal
+test_successful_teardown_emits_one_metrics_row


### PR DESCRIPTION
## Intent

Implement backlog task fm-task-metrics-automate completely for Firstmate issue #2342. Automate one honest per-task metrics row during guarded teardown, deriving only mechanically attributable fields from durable task metadata, status events, exact no-mistakes repository/branch records, and the recorded PR/CI state. Keep judgment-only fields, unavailable timing, and unattributable token consumption null; never guess. Add only the durable dispatch timestamp needed for future honest speed derivation, preserve it across relaunch, and leave done/wall-clock/blocked timing null until timestamped status semantics exist. Preserve teardown safety and retryability, exclude persistent secondmate runtime records, add focused tests and operator-current docs, run the full validation path, push a PR, and never merge. Do not add Overwhelmed label conventions.

## What Changed

- Emit one mechanically derived metrics row for each ordinary task during guarded teardown, excluding persistent secondmate records.
- Preserve the initial dispatch timestamp across relaunches and use retry-safe prepare/commit receipts so failed cleanup or appends can be retried.
- Derive pipeline, fix-round, decision, PR, and outcome fields only from durable evidence; leave unavailable timing, token, judgment, and first-push CI fields null.

## Risk Assessment

✅ Low: The follow-up cleanly removes both unsupported first-push derivations, keeps the field honestly null, and introduces no new material source risks.

## Testing

Focused helper, spawn, relaunch, and guarded-teardown tests passed end-to-end: one honest row is emitted exactly once, unknown and judgment-only values remain null, dispatch time survives relaunch, cleanup failures preserve a retryable receipt, and persistent secondmate teardown remains excluded and safe. A reviewer-visible CLI transcript was captured; no UI evidence applies because this is a shell/JSONL lifecycle change.

<details>
<summary>Evidence: Task metrics CLI transcript</summary>

`Shows receipt preparation, exactly-once emission, null handling, retry preservation, secondmate safety, and successful guarded teardown.`

```text
$ bash tests/fm-task-metrics.test.sh
prepared: state/metric-task.task-metrics-row
emitted: data/task-metrics.jsonl task=metric-task
emitted: data/task-metrics.jsonl task=metric-task
ok - task metrics: prepares before destruction, commits exactly once, and derives only durable fields
emitted: data/task-metrics.jsonl task=metric-task
ok - task metrics: unavailable pipeline attribution stays null instead of becoming a guess
prepared: state/metric-task.task-metrics-row
ok - task metrics: corrupt output blocks completion and preserves the retry receipt

$ bash tests/fm-teardown.test.sh  # focused teardown contract; final behavior excerpt
ok - persistent index.lock exhausts retries and refuses without force-removing the lock
ok - forced secondmate teardown preflights every Herdr child before cleanup mutation
ok - successful teardown emits one honest metrics row before retiring task records
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- 🚨 `bin/fm-task-metrics.sh:254` - The intent requires metrics from “exact no-mistakes repository/branch records,” but preparation queries the database using metadata `project`, while Firstmate runs no-mistakes from the distinct task `worktree`. In normal pooled-worktree tasks this finds no repository row and falsely records zero pipeline runs/fix rounds. Pass `worktree` to the repository lookup and retain the prepared receipt for retries.
- 🚨 `bin/fm-task-metrics.sh:186` - The intent says to “never guess,” but `last_pushed_sha` is the latest push recorded for a run, not necessarily its first push. If a run pushes SHA A, applies a fix, then pushes SHA B, this code labels B&#39;s CI result as `ci_green_first_push`. Leave the field null unless durable history identifies the actual first pushed SHA.
- 🚨 `bin/fm-task-metrics.sh:269` - The documented invariant says every workflow run for the first push must be green, but the query fetches at most 100 runs and `parse_ci` treats that bounded subset as complete. A failed run outside the first 100 therefore produces a dishonest `true`. Detect truncation/paginate fully, or leave the field null when completeness cannot be proven.

🔧 Fix: Keep first-push CI null without durable evidence
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-task-metrics.test.sh`
- `bash tests/fm-spawn-dispatch-profile.test.sh`
- `bash tests/fm-control-relaunch.test.sh`
- `bash tests/fm-teardown.test.sh`
- `Captured the end-user CLI lifecycle transcript in the dedicated evidence directory.`
- <code>Verified `git status --short` after testing showed no transient worktree artifacts.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
