### PR TITLE
Store no-mistakes test evidence in the repo

### DIFF
--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -36,7 +36,7 @@ document:
 commands:
   lint: 'bin/fm-lint.sh'
 
-# Keep test evidence out of this repo; it stays in a temp dir instead.
+# Store test evidence in this repo rather than a temp dir.
 test:
   evidence:
-    store_in_repo: false
+    store_in_repo: true


### PR DESCRIPTION
## Summary
- Flip `test.evidence.store_in_repo` from `false` to `true` so no-mistakes test evidence is stored in the repo rather than a temp dir.
- Update the adjacent comment to match that behavior.

## Test plan
- [ ] Confirm `.no-mistakes.yaml` has `store_in_repo: true` and the comment above the `test:` block describes in-repo storage.
- [ ] No other files or keys changed.