### PR TITLE
chore: store no-mistakes test evidence in the repo

### DIFF
--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -36,7 +36,7 @@ document:
 commands:
   lint: 'bin/fm-lint.sh'
 
-# Keep test evidence out of this repo; it stays in a temp dir instead.
+# Store test evidence in this repo so it is committed alongside the change instead of kept in a temp dir.
 test:
   evidence:
-    store_in_repo: false
+    store_in_repo: true


### PR DESCRIPTION
## Intent

Flip the no-mistakes test-evidence store toggle in the firstmate repo's .no-mistakes.yaml from local temp storage to storing evidence in the repo. Exactly two things change: test.evidence.store_in_repo goes from false to true, and the one-line comment directly above the test: block is rewritten so it accurately describes the new behavior (evidence is stored/committed in the repo rather than kept in a temp dir). The captain explicitly scoped this to that single boolean plus its adjacent comment: no other key, value, comment, formatting, or file may change, no tests are to be added or modified for a config-value flip, and the CI workflow must not be touched. This supersedes closed direct PR #2353, which carried the identical change but was rejected by the repo's required no-mistakes-required gate; the captain chose to re-ship the same change through the no-mistakes pipeline on a fresh branch so it lands as a genuinely green PR. Repo style rules apply to the comment: plain dash, no em dash, one sentence per physical line.

## What Changed
- Enable repository-backed storage for no-mistakes test evidence.
- Update the adjacent comment to reflect that evidence is committed with the change.

## Risk Assessment

✅ Low: The diff is limited exactly to the requested comment and boolean toggle, with no source-verifiable defects identified.

## Testing

Validated the base-to-target patch, parsed both YAML configurations, and confirmed repository evidence storage is enabled with exactly one semantic change and one changed file; the adjacent comment also meets the required style. No tests were added or run because this is an isolated declarative config flip, and no visual artifact applies because there is no rendered UI.

<details>
<summary>Evidence: Configuration semantic and scope verification</summary>

Source: [Configuration semantic and scope verification](https://github.com/kunchenguid/firstmate/blob/6ec704f76dad3b182e948c5ee4f17246efdeeaee/.no-mistakes/evidence/fm/fm-nm-evidence-store-firstmate-r2/config-verification.txt)

```text
Firstmate no-mistakes evidence-storage configuration verification
=================================================================

Parsed effective setting: test.evidence.store_in_repo = true
Normalized semantic delta: test.evidence.store_in_repo: false -> true
Changed-file scope: .no-mistakes.yaml (1 file)
Adjacent comment contract: exact wording, directly above test:, one physical line, plain punctuation
RESULT: PASS - repository evidence storage is enabled and no other semantic config or file changed.

Exact committed patch:
diff --git a/.no-mistakes.yaml b/.no-mistakes.yaml
index 02e6128..62bb9e7 100644
--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -36,7 +36,7 @@ document:
 commands:
   lint: 'bin/fm-lint.sh'
 
-# Keep test evidence out of this repo; it stays in a temp dir instead.
+# Store test evidence in this repo so it is committed alongside the change instead of kept in a temp dir.
 test:
   evidence:
-    store_in_repo: false
+    store_in_repo: true
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d411127e812a803c87314a2c935c609885bdb723","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --name-status 9823ff899c58319e5a09846b18f2958018598b38..d411127e812a803c87314a2c935c609885bdb723` and exact patch inspection</code>
- <code>Inline `ruby` YAML verifier comparing normalized base and target configurations, asserting only `test.evidence.store_in_repo` changes from `false` to `true`</code>
- `Comment contract verification for exact wording, adjacency, single-line formatting, and plain punctuation`
- `git status --short && git rev-parse HEAD && git diff --check 9823ff899c58319e5a09846b18f2958018598b38..d411127e812a803c87314a2c935c609885bdb723`

</details>

<details>
<summary>⚠️ **Document** - 1 error</summary>

- 🚨 `docs/configuration.md:132` - The authoritative gate-default documentation still says evidence stays outside the repo; CONTRIBUTING.md:67-69, AGENTS.md:129, and docs/architecture.md:248 repeat the stale contract. These cannot be fixed because the explicit scope forbids changing any file besides .no-mistakes.yaml.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
