### PR TITLE
fix(herdr): recover stale idle shell occupancy

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1895,14 +1895,15 @@ fm_backend_herdr_explicit_close_pane_confirmed() {  # <session> <pane_id>
 # live agent for recovery, relaunch, husk replace, or liveness. When agent
 # get reports idle or done (never working or blocked) and
 # fm_backend_herdr_pane_idle_shell_pid holds, this classifier returns
-# no-agent. If agent_session.source is present, it also calls
-# `pane release-agent --source <source> --agent <agent>` once with only the
-# identity Herdr itself returned; it never invents `herdr:pi`. Missing source
-# still classifies no-agent for recovery. Send and inject keep using raw
-# `agent get` via fm_backend_herdr_busy_state and stay fail-closed.
-# FM_HERDR_STALE_SHELL_RELEASE=0 restores the registry-only classifier.
+# no-agent. When the confirmed record includes agent_session.source, agent,
+# and state_change_seq, it releases only that exact revision through
+# `pane release-agent --source <source> --agent <agent> --seq <seq>`.
+# Missing source or sequence still classifies no-agent for recovery. Send and
+# inject keep using raw `agent get` via fm_backend_herdr_busy_state and stay
+# fail-closed. FM_HERDR_STALE_SHELL_RELEASE=0 restores the registry-only
+# classifier.
 fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
-  local session=$1 pane_id=$2 out code presence status source agent
+  local session=$1 pane_id=$2 out code presence status source agent seq
   presence=$(fm_backend_herdr_pane_presence_state "$session" "$pane_id")
   if [ "$presence" != present ]; then
     case "$presence" in
@@ -1924,13 +1925,29 @@ fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
       if [ "${FM_HERDR_STALE_SHELL_RELEASE:-1}" != 0 ] \
         && fm_backend_herdr_pane_idle_shell_pid "$session" "$pane_id" >/dev/null
       then
-        source=$(printf '%s' "$out" | jq -r '.result.agent.agent_session.source // empty' 2>/dev/null)
-        agent=$(printf '%s' "$out" | jq -r '.result.agent.agent // empty' 2>/dev/null)
-        if [ -n "$source" ] && [ -n "$agent" ]; then
-          fm_backend_herdr_cli "$session" pane release-agent \
-            --source "$source" --agent "$agent" "$pane_id" >/dev/null 2>&1 || true
+        out=$(fm_backend_herdr_cli "$session" agent get "$pane_id" 2>&1)
+        code=$(printf '%s' "$out" | jq -r '.error.code // empty' 2>/dev/null)
+        if [ -n "$code" ]; then
+          [ "$code" = "agent_not_found" ] && printf 'no-agent' || printf 'unknown'
+          return 0
         fi
-        printf 'no-agent'
+        status=$(printf '%s' "$out" | jq -r '.result.agent.agent_status // empty' 2>/dev/null)
+        case "$status" in
+          idle|done)
+            source=$(printf '%s' "$out" | jq -r '(.result.agent.agent_session.source // empty) | select(type == "string")' 2>/dev/null)
+            agent=$(printf '%s' "$out" | jq -r '(.result.agent.agent // empty) | select(type == "string")' 2>/dev/null)
+            seq=$(printf '%s' "$out" | jq -r '(.result.agent.state_change_seq // empty) | select(type == "number" and floor == . and . >= 0)' 2>/dev/null)
+            case "$seq" in ''|*[!0-9]*) seq= ;; esac
+            if [ -n "$source" ] && [ -n "$agent" ] && [ -n "$seq" ]; then
+              fm_backend_herdr_cli "$session" pane release-agent \
+                --source "$source" --agent "$agent" --seq "$seq" "$pane_id" >/dev/null 2>&1 \
+                || { printf 'unknown'; return 0; }
+            fi
+            printf 'no-agent'
+            ;;
+          working|blocked) printf 'live' ;;
+          *) printf 'unknown' ;;
+        esac
       else
         printf 'live'
       fi
@@ -2021,7 +2038,7 @@ fm_backend_herdr_agent_alive() {  # <target>
 # 4th arg, so this function never even queries for a prune candidate in that
 # case. Echoes "<tab_id> <pane_id>" on success.
 fm_backend_herdr_create_task() {  # <container> <label> <cwd> <seeded_default_tab_id>
-  local container=$1 label=$2 cwd=$3 seeded_tab_id=${4:-} session wsid list dup_tabs dup dup_pane dup_tab_ids out tab_id pane_id remaining_dup_tabs
+  local container=$1 label=$2 cwd=$3 seeded_tab_id=${4:-} session wsid list dup_tabs dup dup_pane dup_state dup_tab_ids out tab_id pane_id remaining_dup_tabs
   session=${container%%:*}
   wsid=${container#*:}
   list=$(fm_backend_herdr_cli "$session" tab list --workspace "$wsid" 2>/dev/null) || return 1
@@ -2034,11 +2051,19 @@ fm_backend_herdr_create_task() {  # <container> <label> <cwd> <seeded_default_ta
     while IFS= read -r dup; do
       [ -n "$dup" ] || continue
       dup_pane=$(fm_backend_herdr_pane_for_tab "$session" "$wsid" "$dup")
-      if [ -z "$dup_pane" ] || ! fm_backend_herdr_tab_is_husk "$session" "$dup_pane"; then
+      [ -n "$dup_pane" ] || {
         echo "error: herdr tab '$label' already exists in workspace $wsid (session $session)" >&2
         return 1
-      fi
-      dup_tab_ids="${dup_tab_ids}${dup}"$'\n'
+      }
+      dup_state=$(fm_backend_herdr_pane_agent_state "$session" "$dup_pane")
+      case "$dup_state" in
+        dead|no-agent) ;;
+        *)
+          echo "error: herdr tab '$label' already exists in workspace $wsid (session $session)" >&2
+          return 1
+          ;;
+      esac
+      dup_tab_ids="${dup_tab_ids}${dup}"$'\t'"${dup_state}"$'\n'
     done <<EOF
 $dup_tabs
 EOF
@@ -2052,8 +2077,15 @@ EOF
   fi
   [ -z "$seeded_tab_id" ] || fm_backend_herdr_workspace_prune_seeded_default_tab "$session" "$wsid" "$seeded_tab_id"
   if [ -n "$dup_tab_ids" ]; then
-    while IFS= read -r dup; do
+    while IFS=$'\t' read -r dup dup_state; do
       [ -n "$dup" ] || continue
+      if [ "$dup_state" = no-agent ]; then
+        dup_pane=$(fm_backend_herdr_pane_for_tab "$session" "$wsid" "$dup")
+        if [ -z "$dup_pane" ] || ! fm_backend_herdr_tab_is_husk "$session" "$dup_pane"; then
+          echo "error: herdr tab '$label' changed before stale-husk closure in workspace $wsid (session $session)" >&2
+          return 1
+        fi
+      fi
       fm_backend_herdr_cli "$session" tab close "$dup" >/dev/null 2>&1 || true
     done <<EOF
 $dup_tab_ids

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1856,38 +1856,53 @@ fm_backend_herdr_explicit_close_pane_confirmed() {  # <session> <pane_id>
 }
 
 # fm_backend_herdr_pane_agent_state: classify <pane_id> in <session> as one of
-# dead|no-agent|live|unknown, purely from the JSON body of two read-only
-# calls - never from process exit status, since a business-logic "not found"
-# response is a normal, expected outcome here, not a call failure (real herdr
-# 0.7.1 exits 1 for it; the canned-response test fakes exit 0; parsing only
-# the JSON keeps this function correct against either).
+# dead|no-agent|live|unknown. The pane and agent reads are classified from
+# JSON bodies rather than process exit status, because a business-logic
+# "not found" response is a normal, expected outcome here, not a call
+# failure (real herdr 0.7.1 exits 1 for it; the canned-response test fakes
+# exit 0; parsing only the JSON keeps this function correct against either).
 #
 #   dead     - `pane get` responds with error code pane_not_found: the pane
 #              itself is gone (closed, or its process died and herdr already
 #              reaped it - verified empirically: killing a pane's shell pid
 #              on a live server makes herdr immediately drop both the pane
 #              and its tab from `pane get`/`tab list`).
-#   no-agent - `pane get` succeeds (the pane structurally exists) but `agent
-#              get` responds with error code agent_not_found: nothing is
-#              registered in it - exactly what a herdr session-layout restore
-#              produces (verified empirically: `session stop` + fresh `herdr
-#              server` restart leaves the pane alive, agent_status "unknown",
-#              agent get -> agent_not_found - docs/herdr-backend.md "ID
-#              stability across a server restart"), and what a future
-#              `resume_agents_on_restore = false` restore would produce too
-#              (a plain shell, never an agent).
-#   live     - `agent get` succeeds and reports a real agent_status (working,
-#              idle, done, or blocked - any registered value). An idle or
-#              blocked agent is still a genuine, still-registered agent, not
-#              a restored husk, so it is never a close-and-replace candidate.
+#   no-agent - the pane structurally exists (`pane get` succeeds) and either
+#              `agent get` responds with error code agent_not_found, or idle
+#              or done occupancy is process-proven to be a leftover on a lone
+#              idle shell (see below). agent_not_found is what a herdr
+#              session-layout restore produces (verified empirically:
+#              `session stop` + fresh `herdr server` restart leaves the pane
+#              alive, agent_status "unknown", agent get -> agent_not_found -
+#              docs/herdr-backend.md "ID stability across a server restart"),
+#              and what a future `resume_agents_on_restore = false` restore
+#              would produce too (a plain shell, never an agent).
+#   live     - `agent get` succeeds with working or blocked occupancy, or
+#              with idle or done occupancy that the idle-shell proof cannot
+#              confirm. A working or blocked agent, and an idle agent whose
+#              process is not a proven lone idle shell, is still a genuine
+#              registered agent, not a restored husk, so it is never a
+#              close-and-replace candidate.
 #   unknown  - anything else: an unparseable/unexpected response from either
 #              call, or a `pane get` success whose own echoed pane_id does not
 #              round-trip (guards against misreading a herdr response shape
 #              change as "the pane exists"). The caller must fail safe toward
 #              refusal here, never toward closing - this is the conservative
 #              backstop the husk check depends on.
+#
+# Stale occupancy: Herdr can retain idle or done lifecycle occupancy on a
+# pane whose process is already a lone idle shell. That occupancy is not a
+# live agent for recovery, relaunch, husk replace, or liveness. When agent
+# get reports idle or done (never working or blocked) and
+# fm_backend_herdr_pane_idle_shell_pid holds, this classifier returns
+# no-agent. If agent_session.source is present, it also calls
+# `pane release-agent --source <source> --agent <agent>` once with only the
+# identity Herdr itself returned; it never invents `herdr:pi`. Missing source
+# still classifies no-agent for recovery. Send and inject keep using raw
+# `agent get` via fm_backend_herdr_busy_state and stay fail-closed.
+# FM_HERDR_STALE_SHELL_RELEASE=0 restores the registry-only classifier.
 fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
-  local session=$1 pane_id=$2 out code presence status
+  local session=$1 pane_id=$2 out code presence status source agent
   presence=$(fm_backend_herdr_pane_presence_state "$session" "$pane_id")
   if [ "$presence" != present ]; then
     case "$presence" in
@@ -1904,7 +1919,22 @@ fm_backend_herdr_pane_agent_state() {  # <session> <pane_id>
   fi
   status=$(printf '%s' "$out" | jq -r '.result.agent.agent_status // empty' 2>/dev/null)
   case "$status" in
-    working|idle|done|blocked) printf 'live' ;;
+    working|blocked) printf 'live' ;;
+    idle|done)
+      if [ "${FM_HERDR_STALE_SHELL_RELEASE:-1}" != 0 ] \
+        && fm_backend_herdr_pane_idle_shell_pid "$session" "$pane_id" >/dev/null
+      then
+        source=$(printf '%s' "$out" | jq -r '.result.agent.agent_session.source // empty' 2>/dev/null)
+        agent=$(printf '%s' "$out" | jq -r '.result.agent.agent // empty' 2>/dev/null)
+        if [ -n "$source" ] && [ -n "$agent" ]; then
+          fm_backend_herdr_cli "$session" pane release-agent \
+            --source "$source" --agent "$agent" "$pane_id" >/dev/null 2>&1 || true
+        fi
+        printf 'no-agent'
+      else
+        printf 'live'
+      fi
+      ;;
     *) printf 'unknown' ;;
   esac
 }

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -255,13 +255,13 @@ No Herdr-specific copy of that protocol exists.
 ## Restart and liveness behavior
 
 Stopping and restarting a named Herdr server preserves workspace, tab, pane, and label ids, but the underlying harness processes and live agent registrations do not survive.
-A restored same-labeled tab with a missing pane or no registered agent is a husk.
+A restored same-labeled tab with a missing pane, no registered agent, or retained `idle` or `done` occupancy on a proven lone idle shell is a husk.
 Create replaces only a confidently dead or no-agent husk, creates the replacement before closing the old tab, and refuses live or unknown states.
 This prevents closing the workspace's last tab before a replacement exists.
 
 The generic Herdr agent-liveness probe reuses the same classifier.
-A structurally gone pane becomes `missing`, a restored agent-less shell becomes `dead`, a registered agent becomes `alive`, and an unexpected read becomes `unreadable`.
-Idle or done occupancy on a proven lone idle shell is `no-agent` / `dead` for recovery; `fm_backend_herdr_pane_agent_state` owns that contract.
+A structurally gone pane becomes `missing`; an agent-less pane or retained `idle` or `done` occupancy on a proven lone idle shell becomes `dead`; working or blocked occupancy and `idle` or `done` occupancy without that proof remain `alive`; and an unexpected read becomes `unreadable`.
+`fm_backend_herdr_pane_agent_state` owns the exact recovery-classification contract.
 Unlike tmux process-name inspection, native registration can classify Pi without guessing from a generic interpreter name.
 
 The session-start sweep uses this probe.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -261,6 +261,7 @@ This prevents closing the workspace's last tab before a replacement exists.
 
 The generic Herdr agent-liveness probe reuses the same classifier.
 A structurally gone pane becomes `missing`, a restored agent-less shell becomes `dead`, a registered agent becomes `alive`, and an unexpected read becomes `unreadable`.
+Idle or done occupancy on a proven lone idle shell is `no-agent` / `dead` for recovery; `fm_backend_herdr_pane_agent_state` owns that contract.
 Unlike tmux process-name inspection, native registration can classify Pi without guessing from a generic interpreter name.
 
 The session-start sweep uses this probe.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -574,8 +574,9 @@ ok - real herdr: no control verb removed the endpoint or the task's local copy
 ok - real herdr: an agent that does not stop fails closed instead of being reported as stopped
 ```
 
-Working occupancy on a plain shell pane still classifies as alive, so interrupt and fail-closed exit keep their live-agent guarantees.
-Idle occupancy on a proven idle shell classifies as already-stopped.
+The direct no-agent control and idle-occupancy control exercise the registry path and its strict idle-shell exception without launching a real agent.
+Working occupancy on that same plain shell remains alive, so interrupt and fail-closed exit keep their live-agent guarantees.
+The exact recovery-classification contract, including the unproven `idle` or `done` fail-closed case, is owned by `fm_backend_herdr_pane_agent_state`.
 That command is the guard that refreshes this record; run it after every Herdr upgrade rather than trusting the version above.
 
 ### Away-mode transport

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -557,7 +557,7 @@ Polling remained active and is covered as the fallback for capability, connect, 
 
 ### Agent lifecycle control
 
-Herdr is one of the two backends whose recovery-grade agent-state classifier the control plane may trust ([agent-control.md](../agent-control.md)), so its lifecycle gating is measured against the real binary; reverified 2026-08-08 on Herdr 0.8.0, and first measured 2026-08-02 on Herdr 0.7.5 with identical results:
+Herdr is one of the two backends whose recovery-grade agent-state classifier the control plane may trust ([agent-control.md](../agent-control.md)), so its lifecycle gating is measured against the real binary; reverified 2026-08-14 on Herdr 0.8.0 after the stale-occupancy classifier change, and first measured 2026-08-02 on Herdr 0.7.5:
 
 ```sh
 tests/fm-control-herdr-smoke.test.sh
@@ -568,12 +568,14 @@ Observed output:
 ```text
 ok - real herdr: exit on a pane with no registered agent is idempotent success
 ok - real herdr: interrupt refuses when herdr's own agent registry reports no agent
+ok - real herdr: idle occupancy on a proven idle shell is already-stopped
 ok - real herdr: interrupt delivers the harness's key and proves the agent survived it
 ok - real herdr: no control verb removed the endpoint or the task's local copy
 ok - real herdr: an agent that does not stop fails closed instead of being reported as stopped
 ```
 
-The registry read through `herdr pane report-agent` is the same source `fm_backend_herdr_agent_state` classifies, so registering and not registering an agent on a plain shell pane exercises exactly the gate every lifecycle verb depends on, with no real agent launched.
+Working occupancy on a plain shell pane still classifies as alive, so interrupt and fail-closed exit keep their live-agent guarantees.
+Idle occupancy on a proven idle shell classifies as already-stopped.
 That command is the guard that refreshes this record; run it after every Herdr upgrade rather than trusting the version above.
 
 ### Away-mode transport

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -1388,7 +1388,7 @@ assert_no_projection_mutation_since "$START" "agent-free duplicate-token recover
 lab workspace get "$DUP1_WSID" >/dev/null 2>&1 || fail "duplicate-token recovery removed the first quarantined workspace"
 lab workspace get "$DUP2_WSID" >/dev/null 2>&1 || fail "duplicate-token recovery removed the second quarantined workspace"
 
-lab pane report-agent "$DUP1_PANE" --source fm-projection-e2e --agent test-agent --state idle >/dev/null \
+lab pane report-agent "$DUP1_PANE" --source fm-projection-e2e --agent test-agent --state working >/dev/null \
   || fail "could not register the duplicate-live-agent risk fixture"
 START=$(log_line_count)
 if fm_backend_herdr_projection_recovery_allows_flat "$HERDR_LAB_SESSION" "$DUP_JOURNAL" duplicate1; then

--- a/tests/fm-backend-herdr-respawn-idem-e2e.test.sh
+++ b/tests/fm-backend-herdr-respawn-idem-e2e.test.sh
@@ -164,7 +164,7 @@ pass "fixed: the workspace holds exactly the 2 replacement tabs after both respa
 # attempt refuses exactly as before - the husk fix must never touch a pane
 # that actually has something registered in it.
 
-herdr pane report-agent "$NEW_CREW_PANE_ID" --source fm-respawn-e2e --agent fm-respawn-live-agent --state idle --session "$SESSION" >/dev/null 2>&1 \
+herdr pane report-agent "$NEW_CREW_PANE_ID" --source fm-respawn-e2e --agent fm-respawn-live-agent --state working --session "$SESSION" >/dev/null 2>&1 \
   || fail "could not register a live agent on the respawned crewmate-shaped pane"
 
 if fm_backend_herdr_create_task "$CONTAINER" "$CREW_LABEL" "$PROJ_CWD" >/dev/null 2>&1; then

--- a/tests/fm-backend-herdr-smoke.test.sh
+++ b/tests/fm-backend-herdr-smoke.test.sh
@@ -119,8 +119,9 @@ pass "real herdr: create_task prunes the freshly-created workspace's seeded defa
 # $PANE_ID/$TARGET (this suite's primary task, which the rest of the file
 # still depends on) so neither scenario disturbs it.
 
-# 1. A genuinely LIVE duplicate (a real registered agent, via herdr's own
-#    `pane report-agent`) must still refuse exactly as before.
+# 1. A genuinely LIVE duplicate (working occupancy, via herdr's own
+#    `pane report-agent`) must still refuse. Idle occupancy on a proven idle
+#    shell is a husk and is covered next.
 LIVE_DUP_LABEL="fm-smoke-livedup"
 LIVE_DUP_IDS=$(fm_backend_herdr_create_task "$CONTAINER" "$LIVE_DUP_LABEL" /tmp) || fail "could not create the live-duplicate scenario's tab"
 read -r LIVE_DUP_TAB_ID LIVE_DUP_PANE_ID <<EOF
@@ -129,15 +130,36 @@ EOF
 if [ -z "$LIVE_DUP_TAB_ID" ] || [ -z "$LIVE_DUP_PANE_ID" ]; then
   fail "live-duplicate scenario tab creation did not return ids"
 fi
-herdr pane report-agent "$LIVE_DUP_PANE_ID" --source fm-smoke-test --agent fm-smoke-live-agent --state idle --session "$SESSION" >/dev/null 2>&1 \
+herdr pane report-agent "$LIVE_DUP_PANE_ID" --source fm-smoke-test --agent fm-smoke-live-agent --state working --session "$SESSION" >/dev/null 2>&1 \
   || fail "could not register a live agent on the live-duplicate scenario's pane"
 if fm_backend_herdr_create_task "$CONTAINER" "$LIVE_DUP_LABEL" /tmp >/dev/null 2>&1; then
-  fail "REGRESSION: create_task should refuse a duplicate label whose pane hosts a genuinely live registered agent (idle counts as live)"
+  fail "REGRESSION: create_task should refuse a duplicate label whose pane hosts a genuinely live registered agent"
 fi
 herdr pane get "$LIVE_DUP_PANE_ID" --session "$SESSION" >/dev/null 2>&1 \
   || fail "REGRESSION: the live-duplicate scenario's pane should have survived the refused create_task call untouched"
 pass "real herdr: create_task refuses a same-labeled tab whose pane hosts a genuinely live registered agent (unchanged behavior)"
 fm_backend_herdr_kill "$SESSION:$LIVE_DUP_PANE_ID"
+
+# 1b. Idle occupancy on a proven idle shell is a replaceable husk.
+STALE_DUP_LABEL="fm-smoke-staledup"
+STALE_DUP_IDS=$(fm_backend_herdr_create_task "$CONTAINER" "$STALE_DUP_LABEL" /tmp) || fail "could not create the stale-occupancy scenario's tab"
+read -r STALE_DUP_TAB_ID STALE_DUP_PANE_ID <<EOF
+$STALE_DUP_IDS
+EOF
+if [ -z "$STALE_DUP_TAB_ID" ] || [ -z "$STALE_DUP_PANE_ID" ]; then
+  fail "stale-occupancy scenario tab creation did not return ids"
+fi
+herdr pane report-agent "$STALE_DUP_PANE_ID" --source fm-smoke-test --agent fm-smoke-stale-agent --state idle --session "$SESSION" >/dev/null 2>&1 \
+  || fail "could not register idle occupancy on the stale-occupancy scenario's pane"
+REPLACED_STALE_IDS=$(fm_backend_herdr_create_task "$CONTAINER" "$STALE_DUP_LABEL" /tmp) \
+  || fail "REGRESSION: create_task should close-and-replace idle occupancy on a proven idle shell"
+read -r NEW_STALE_TAB_ID NEW_STALE_PANE_ID <<EOF
+$REPLACED_STALE_IDS
+EOF
+[ -n "$NEW_STALE_TAB_ID" ] && [ -n "$NEW_STALE_PANE_ID" ] || fail "stale-occupancy close-and-replace did not return new ids"
+[ "$NEW_STALE_PANE_ID" != "$STALE_DUP_PANE_ID" ] || fail "stale-occupancy close-and-replace returned the SAME pane id"
+pass "real herdr: create_task replaces idle occupancy on a proven idle shell"
+fm_backend_herdr_kill "$SESSION:$NEW_STALE_PANE_ID"
 
 # 2. A husk (no registered agent at all - the restored-plain-shell shape)
 #    must be CLOSED AND REPLACED instead of refused.

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -766,6 +766,166 @@ test_create_task_husk_replacement_creates_before_closing() {
   pass "fm_backend_herdr_create_task: creates the replacement tab BEFORE closing the husk tab, never the reverse"
 }
 
+# --- stale idle/done occupancy on a proven idle shell ---------------------
+#
+# Herdr can retain idle or done occupancy on a pane whose process is already
+# a lone idle shell. Recovery classifies that as no-agent; working, blocked,
+# and a failed idle-shell proof stay live. These cases drive the public
+# classifier and the create_task husk path.
+
+make_stale_occupancy_ps() {  # <dir> <pid>
+  local dir=$1 pid=$2
+  mkdir -p "$dir"
+  cat > "$dir/ps" <<SH
+#!/usr/bin/env bash
+case "\$*" in
+  "-axo pid=,ppid=") printf '1 0\n$pid 1\n' ;;
+  "-p $pid -o stat=") printf 'Ss\n' ;;
+  *) exit 1 ;;
+esac
+SH
+  chmod +x "$dir/ps"
+}
+
+run_stale_occupancy_classifier() {  # uses dir, log, resp, fb, ROOT
+  PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_pane_agent_state fmtest w1:p2' "$ROOT"
+}
+
+setup_stale_occupancy_responses() {  # <resp> <status> [agent-json-extra]
+  local resp=$1 status=$2 extra=${3:-}
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent":"fm-lab-agent","agent_status":"%s"%s}}}\n' "$status" "$extra" > "$resp/2.out"
+}
+
+test_pane_agent_state_idle_proven_shell_is_no_agent() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/stale-idle"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  setup_stale_occupancy_responses "$resp" idle
+  death_process_info_fixture w1:p2 67 > "$resp/3.out"
+  make_stale_occupancy_ps "$dir" 67
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(run_stale_occupancy_classifier)
+  [ "$out" = "no-agent" ] || fail "idle occupancy on a proven idle shell should classify no-agent, got '$out'"
+  assert_not_contains "$(cat "$log")" $'pane\x1frelease-agent' \
+    "missing agent_session.source must not invent a release-agent identity"
+  pass "fm_backend_herdr_pane_agent_state: idle occupancy plus a proven idle shell is no-agent"
+}
+
+test_pane_agent_state_done_proven_shell_is_no_agent() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/stale-done"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  setup_stale_occupancy_responses "$resp" "done"
+  death_process_info_fixture w1:p2 67 > "$resp/3.out"
+  make_stale_occupancy_ps "$dir" 67
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(run_stale_occupancy_classifier)
+  [ "$out" = "no-agent" ] || fail "done occupancy on a proven idle shell should classify no-agent, got '$out'"
+  pass "fm_backend_herdr_pane_agent_state: done occupancy plus a proven idle shell is no-agent"
+}
+
+test_pane_agent_state_working_proven_shell_stays_live() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/stale-working"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  setup_stale_occupancy_responses "$resp" working
+  death_process_info_fixture w1:p2 67 > "$resp/3.out"
+  make_stale_occupancy_ps "$dir" 67
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(run_stale_occupancy_classifier)
+  [ "$out" = "live" ] || fail "working occupancy must stay live even when the pane looks like an idle shell, got '$out'"
+  assert_not_contains "$(cat "$log")" $'pane\x1fprocess-info' \
+    "working occupancy must not run the idle-shell proof"
+  assert_not_contains "$(cat "$log")" $'pane\x1frelease-agent' \
+    "working occupancy must not call release-agent"
+  pass "fm_backend_herdr_pane_agent_state: working occupancy stays live even with an idle-shell process table"
+}
+
+test_pane_agent_state_blocked_proven_shell_stays_live() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/stale-blocked"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  setup_stale_occupancy_responses "$resp" blocked
+  death_process_info_fixture w1:p2 67 > "$resp/3.out"
+  make_stale_occupancy_ps "$dir" 67
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(run_stale_occupancy_classifier)
+  [ "$out" = "live" ] || fail "blocked occupancy must stay live even when the pane looks like an idle shell, got '$out'"
+  assert_not_contains "$(cat "$log")" $'pane\x1fprocess-info' \
+    "blocked occupancy must not run the idle-shell proof"
+  pass "fm_backend_herdr_pane_agent_state: blocked occupancy stays live even with an idle-shell process table"
+}
+
+test_pane_agent_state_idle_without_shell_proof_stays_live() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/stale-idle-unproven"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  setup_stale_occupancy_responses "$resp" idle
+  printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":67,"foreground_process_group_id":67,"foreground_processes":[{"pid":67,"name":"zsh","argv0":"zsh"},{"pid":68,"name":"pi","argv0":"pi"}]}}}\n' > "$resp/3.out"
+  make_stale_occupancy_ps "$dir" 67
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(run_stale_occupancy_classifier)
+  [ "$out" = "live" ] || fail "idle occupancy without a lone idle shell must stay live, got '$out'"
+  assert_not_contains "$(cat "$log")" $'pane\x1frelease-agent' \
+    "unproven idle occupancy must not call release-agent"
+  pass "fm_backend_herdr_pane_agent_state: idle occupancy with an extra foreground process stays live"
+}
+
+test_pane_agent_state_rollback_flag_keeps_idle_live() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/stale-rollback"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  setup_stale_occupancy_responses "$resp" idle
+  death_process_info_fixture w1:p2 67 > "$resp/3.out"
+  make_stale_occupancy_ps "$dir" 67
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(FM_HERDR_STALE_SHELL_RELEASE=0 run_stale_occupancy_classifier)
+  [ "$out" = "live" ] || fail "FM_HERDR_STALE_SHELL_RELEASE=0 must restore registry-only live classification, got '$out'"
+  assert_not_contains "$(cat "$log")" $'pane\x1fprocess-info' \
+    "the rollback flag must not run the idle-shell proof"
+  pass "fm_backend_herdr_pane_agent_state: FM_HERDR_STALE_SHELL_RELEASE=0 keeps idle occupancy live"
+}
+
+test_pane_agent_state_releases_only_returned_source() {
+  local dir log resp fb out calls
+  dir="$TMP_ROOT/stale-release"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  setup_stale_occupancy_responses "$resp" idle ',"agent_session":{"source":"herdr:pi"}'
+  death_process_info_fixture w1:p2 67 > "$resp/3.out"
+  make_stale_occupancy_ps "$dir" 67
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(run_stale_occupancy_classifier)
+  [ "$out" = "no-agent" ] || fail "idle occupancy with a returned source should still classify no-agent, got '$out'"
+  calls=$(cat "$log")
+  assert_contains "$calls" $'pane\x1frelease-agent' "matching source must call release-agent"
+  assert_contains "$calls" $'--source\x1fherdr:pi' "release-agent must use the source Herdr returned"
+  assert_contains "$calls" $'--agent\x1ffm-lab-agent' "release-agent must use the agent Herdr returned"
+  pass "fm_backend_herdr_pane_agent_state: matching release-agent uses only the source Herdr returned"
+}
+
+test_create_task_replaces_idle_occupancy_on_proven_shell() {
+  local dir log resp fb out tab pane
+  dir="$TMP_ROOT/husk-stale-idle"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"fm-stale-idle","workspace_id":"w1"}]}}\n' > "$resp/1.out"
+  printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}\n' > "$resp/2.out"
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/3.out"
+  printf '{"result":{"agent":{"agent":"fm-lab-agent","agent_status":"idle"}}}\n' > "$resp/4.out"
+  death_process_info_fixture w1:p2 67 > "$resp/5.out"
+  printf '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}\n' > "$resp/6.out"
+  printf '{"result":{"tabs":[{"tab_id":"w1:t3","label":"fm-stale-idle","workspace_id":"w1"}]}}\n' > "$resp/8.out"
+  make_stale_occupancy_ps "$dir" 67
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-stale-idle /tmp/proj' "$ROOT") \
+    || fail "create_task should close-and-replace idle occupancy on a proven idle shell"
+  read -r tab pane <<EOF
+$out
+EOF
+  if [ "$tab" != "w1:t3" ] || [ "$pane" != "w1:p3" ]; then
+    fail "create_task should echo the NEW tab/pane ids, got '$out'"
+  fi
+  assert_contains "$(cat "$log")" $'\x1f''tab'$'\x1f''create' "create_task did not create the replacement tab"
+  assert_contains "$(cat "$log")" $'\x1f''tab'$'\x1f''close'$'\x1f''w1:t2' "create_task did not close the stale-occupancy husk"
+  pass "fm_backend_herdr_create_task: idle occupancy on a proven idle shell is a replaceable husk"
+}
+
 test_create_task_creates_and_parses_ids() {
   local dir log resp fb out
   dir="$TMP_ROOT/create-task"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
@@ -4355,6 +4515,14 @@ test_create_task_closes_all_duplicate_husks_after_replacement
 test_create_task_refuses_when_preexisting_husk_tab_remains
 test_create_task_refuses_when_agent_state_ambiguous
 test_create_task_husk_replacement_creates_before_closing
+test_pane_agent_state_idle_proven_shell_is_no_agent
+test_pane_agent_state_done_proven_shell_is_no_agent
+test_pane_agent_state_working_proven_shell_stays_live
+test_pane_agent_state_blocked_proven_shell_stays_live
+test_pane_agent_state_idle_without_shell_proof_stays_live
+test_pane_agent_state_rollback_flag_keeps_idle_live
+test_pane_agent_state_releases_only_returned_source
+test_create_task_replaces_idle_occupancy_on_proven_shell
 test_create_task_creates_and_parses_ids
 test_create_task_creates_with_no_focus_flag
 test_presentation_defaults_on_at_or_above_the_floor

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -645,7 +645,10 @@ test_create_task_closes_and_replaces_no_agent_husk() {
   printf '{"error":{"code":"agent_not_found","message":"agent target w1:p2 not found"}}\n' > "$resp/4.out"
   # 5: tab create -> the replacement tab (created BEFORE the husk is closed)
   printf '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}\n' > "$resp/5.out"
-  printf '{"result":{"tabs":[{"tab_id":"w1:t3","label":"fm-husk2","workspace_id":"w1"}]}}\n' > "$resp/7.out"
+  printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}\n' > "$resp/6.out"
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/7.out"
+  printf '{"error":{"code":"agent_not_found","message":"agent target w1:p2 not found"}}\n' > "$resp/8.out"
+  printf '{"result":{"tabs":[{"tab_id":"w1:t3","label":"fm-husk2","workspace_id":"w1"}]}}\n' > "$resp/10.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-husk2 /tmp/proj' "$ROOT" ) \
@@ -673,7 +676,13 @@ test_create_task_closes_all_duplicate_husks_after_replacement() {
   printf '{"result":{"pane":{"pane_id":"w1:p3"}}}\n' > "$resp/6.out"
   printf '{"error":{"code":"agent_not_found","message":"agent target w1:p3 not found"}}\n' > "$resp/7.out"
   printf '{"result":{"tab":{"tab_id":"w1:t4"},"root_pane":{"pane_id":"w1:p4"}}}\n' > "$resp/8.out"
-  printf '{"result":{"tabs":[{"tab_id":"w1:t4","label":"fm-husk-many","workspace_id":"w1"}]}}\n' > "$resp/11.out"
+  printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"},{"pane_id":"w1:p3","tab_id":"w1:t3"}]}}\n' > "$resp/9.out"
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/10.out"
+  printf '{"error":{"code":"agent_not_found","message":"agent target w1:p2 not found"}}\n' > "$resp/11.out"
+  printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"},{"pane_id":"w1:p3","tab_id":"w1:t3"}]}}\n' > "$resp/13.out"
+  printf '{"result":{"pane":{"pane_id":"w1:p3"}}}\n' > "$resp/14.out"
+  printf '{"error":{"code":"agent_not_found","message":"agent target w1:p3 not found"}}\n' > "$resp/15.out"
+  printf '{"result":{"tabs":[{"tab_id":"w1:t4","label":"fm-husk-many","workspace_id":"w1"}]}}\n' > "$resp/17.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-husk-many /tmp/proj' "$ROOT" ) \
@@ -704,8 +713,11 @@ test_create_task_refuses_when_preexisting_husk_tab_remains() {
   printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/3.out"
   printf '{"error":{"code":"agent_not_found","message":"agent target w1:p2 not found"}}\n' > "$resp/4.out"
   printf '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}\n' > "$resp/5.out"
-  printf '1\n' > "$resp/6.exit"
-  printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"fm-stale-husk","workspace_id":"w1"},{"tab_id":"w1:t3","label":"fm-stale-husk","workspace_id":"w1"}]}}\n' > "$resp/7.out"
+  printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}\n' > "$resp/6.out"
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/7.out"
+  printf '{"error":{"code":"agent_not_found","message":"agent target w1:p2 not found"}}\n' > "$resp/8.out"
+  printf '1\n' > "$resp/9.exit"
+  printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"fm-stale-husk","workspace_id":"w1"},{"tab_id":"w1:t3","label":"fm-stale-husk","workspace_id":"w1"}]}}\n' > "$resp/10.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-stale-husk /tmp/proj' "$ROOT" 2>&1 )
@@ -797,6 +809,7 @@ setup_stale_occupancy_responses() {  # <resp> <status> [agent-json-extra]
   local resp=$1 status=$2 extra=${3:-}
   printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/1.out"
   printf '{"result":{"agent":{"agent":"fm-lab-agent","agent_status":"%s"%s}}}\n' "$status" "$extra" > "$resp/2.out"
+  printf '{"result":{"agent":{"agent":"fm-lab-agent","agent_status":"%s"%s}}}\n' "$status" "$extra" > "$resp/4.out"
 }
 
 test_pane_agent_state_idle_proven_shell_is_no_agent() {
@@ -883,20 +896,36 @@ test_pane_agent_state_rollback_flag_keeps_idle_live() {
   pass "fm_backend_herdr_pane_agent_state: FM_HERDR_STALE_SHELL_RELEASE=0 keeps idle occupancy live"
 }
 
-test_pane_agent_state_releases_only_returned_source() {
+test_pane_agent_state_stale_recheck_preserves_working_agent() {
+  local dir log resp fb out calls
+  dir="$TMP_ROOT/stale-working-recheck"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  setup_stale_occupancy_responses "$resp" idle ',"agent_session":{"source":"herdr:pi"}'
+  death_process_info_fixture w1:p2 67 > "$resp/3.out"
+  printf '{"result":{"agent":{"agent":"fm-lab-agent","agent_status":"working","agent_session":{"source":"herdr:pi"}}}}\n' > "$resp/4.out"
+  make_stale_occupancy_ps "$dir" 67
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(run_stale_occupancy_classifier)
+  [ "$out" = "live" ] || fail "a newly working agent must stay live after the stale-shell proof, got '$out'"
+  calls=$(cat "$log")
+  assert_not_contains "$calls" $'pane\x1frelease-agent' "the liveness classifier must not release a newly working agent"
+  pass "fm_backend_herdr_pane_agent_state: a working transition after the stale-shell proof stays live"
+}
+
+test_pane_agent_state_releases_current_stale_identity() {
   local dir log resp fb out calls
   dir="$TMP_ROOT/stale-release"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
-  setup_stale_occupancy_responses "$resp" idle ',"agent_session":{"source":"herdr:pi"}'
+  setup_stale_occupancy_responses "$resp" idle ',"agent_session":{"source":"herdr:pi"},"state_change_seq":42'
   death_process_info_fixture w1:p2 67 > "$resp/3.out"
   make_stale_occupancy_ps "$dir" 67
   fb=$(make_herdr_fakebin "$dir")
   out=$(run_stale_occupancy_classifier)
-  [ "$out" = "no-agent" ] || fail "idle occupancy with a returned source should still classify no-agent, got '$out'"
+  [ "$out" = "no-agent" ] || fail "a revalidated stale occupancy should classify no-agent, got '$out'"
   calls=$(cat "$log")
-  assert_contains "$calls" $'pane\x1frelease-agent' "matching source must call release-agent"
+  assert_contains "$calls" $'pane\x1frelease-agent' "a current stale identity must release its lifecycle authority"
   assert_contains "$calls" $'--source\x1fherdr:pi' "release-agent must use the source Herdr returned"
   assert_contains "$calls" $'--agent\x1ffm-lab-agent' "release-agent must use the agent Herdr returned"
-  pass "fm_backend_herdr_pane_agent_state: matching release-agent uses only the source Herdr returned"
+  assert_contains "$calls" $'--seq\x1f42' "release-agent must condition on the current lifecycle sequence"
+  pass "fm_backend_herdr_pane_agent_state: releases a revalidated stale identity at its exact lifecycle sequence"
 }
 
 test_create_task_replaces_idle_occupancy_on_proven_shell() {
@@ -907,8 +936,14 @@ test_create_task_replaces_idle_occupancy_on_proven_shell() {
   printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/3.out"
   printf '{"result":{"agent":{"agent":"fm-lab-agent","agent_status":"idle"}}}\n' > "$resp/4.out"
   death_process_info_fixture w1:p2 67 > "$resp/5.out"
-  printf '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}\n' > "$resp/6.out"
-  printf '{"result":{"tabs":[{"tab_id":"w1:t3","label":"fm-stale-idle","workspace_id":"w1"}]}}\n' > "$resp/8.out"
+  printf '{"result":{"agent":{"agent":"fm-lab-agent","agent_status":"idle"}}}\n' > "$resp/6.out"
+  printf '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}\n' > "$resp/7.out"
+  printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}\n' > "$resp/8.out"
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/9.out"
+  printf '{"result":{"agent":{"agent":"fm-lab-agent","agent_status":"idle"}}}\n' > "$resp/10.out"
+  death_process_info_fixture w1:p2 67 > "$resp/11.out"
+  printf '{"result":{"agent":{"agent":"fm-lab-agent","agent_status":"idle"}}}\n' > "$resp/12.out"
+  printf '{"result":{"tabs":[{"tab_id":"w1:t3","label":"fm-stale-idle","workspace_id":"w1"}]}}\n' > "$resp/14.out"
   make_stale_occupancy_ps "$dir" 67
   fb=$(make_herdr_fakebin "$dir")
   out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
@@ -924,6 +959,32 @@ EOF
   assert_contains "$(cat "$log")" $'\x1f''tab'$'\x1f''create' "create_task did not create the replacement tab"
   assert_contains "$(cat "$log")" $'\x1f''tab'$'\x1f''close'$'\x1f''w1:t2' "create_task did not close the stale-occupancy husk"
   pass "fm_backend_herdr_create_task: idle occupancy on a proven idle shell is a replaceable husk"
+}
+
+test_create_task_refuses_stale_husk_that_becomes_working_before_close() {
+  local dir log resp fb calls
+  dir="$TMP_ROOT/husk-stale-working-before-close"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"fm-stale-working","workspace_id":"w1"}]}}\n' > "$resp/1.out"
+  printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}\n' > "$resp/2.out"
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/3.out"
+  printf '{"result":{"agent":{"agent":"fm-lab-agent","agent_status":"idle"}}}\n' > "$resp/4.out"
+  death_process_info_fixture w1:p2 67 > "$resp/5.out"
+  printf '{"result":{"agent":{"agent":"fm-lab-agent","agent_status":"idle"}}}\n' > "$resp/6.out"
+  printf '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}\n' > "$resp/7.out"
+  printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}\n' > "$resp/8.out"
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/9.out"
+  printf '{"result":{"agent":{"agent":"fm-lab-agent","agent_status":"working"}}}\n' > "$resp/10.out"
+  make_stale_occupancy_ps "$dir" 67
+  fb=$(make_herdr_fakebin "$dir")
+  if PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_HERDR_PS_BIN="$dir/ps" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-stale-working /tmp/proj' "$ROOT" >/dev/null 2>&1; then
+    fail "create_task must refuse a stale husk that becomes working before closure"
+  fi
+  calls=$(cat "$log")
+  assert_contains "$calls" $'\x1f''tab'$'\x1f''create' "create_task should create the replacement before the closure recheck"
+  assert_not_contains "$calls" $'\x1f''tab'$'\x1f''close'$'\x1f''w1:t2' "create_task must not close a duplicate that became working"
+  pass "fm_backend_herdr_create_task: a stale husk that becomes working before closure is preserved"
 }
 
 test_create_task_creates_and_parses_ids() {
@@ -4521,8 +4582,10 @@ test_pane_agent_state_working_proven_shell_stays_live
 test_pane_agent_state_blocked_proven_shell_stays_live
 test_pane_agent_state_idle_without_shell_proof_stays_live
 test_pane_agent_state_rollback_flag_keeps_idle_live
-test_pane_agent_state_releases_only_returned_source
+test_pane_agent_state_stale_recheck_preserves_working_agent
+test_pane_agent_state_releases_current_stale_identity
 test_create_task_replaces_idle_occupancy_on_proven_shell
+test_create_task_refuses_stale_husk_that_becomes_working_before_close
 test_create_task_creates_and_parses_ids
 test_create_task_creates_with_no_focus_flag
 test_presentation_defaults_on_at_or_above_the_floor

--- a/tests/fm-control-herdr-smoke.test.sh
+++ b/tests/fm-control-herdr-smoke.test.sh
@@ -10,8 +10,8 @@
 # comes from herdr's own agent registry.
 #
 # No real agent is launched. herdr's `pane report-agent` is the same registry
-# the adapter reads, so registering and not registering an agent on a plain
-# shell pane exercises exactly the classification the control plane gates on.
+# the adapter reads. Working occupancy on a plain shell pane still classifies
+# as alive. Idle occupancy on a proven idle shell classifies as already-stopped.
 #
 # Always runs on a private, named, throwaway lab session, never the default
 # one (tests/herdr-test-safety.sh; the 2026-07-02 incident). Skips cleanly
@@ -113,16 +113,32 @@ case "$OUT" in
 esac
 pass "real herdr: interrupt refuses when herdr's own agent registry reports no agent"
 
-# --- a registered agent: classification flips, and the verbs follow ---------
+# --- idle occupancy on a proven idle shell is already-stopped -------------
 
 herdr pane report-agent "$PANE_ID" --source fm-control-smoke --agent fm-control-smoke-agent \
   --state idle --session "$SESSION" >/dev/null 2>&1 \
-  || fail "could not register a live agent on the task pane"
+  || fail "could not register idle occupancy on the task pane"
 
 STATE=$(fm_backend_agent_state herdr "$SESSION:$PANE_ID")
-[ "$STATE" = alive ] || fail "herdr should classify a registered agent as alive, got '$STATE'"
+[ "$STATE" = dead ] || fail "idle occupancy on a proven idle shell should classify as dead, got '$STATE'"
 
-OUT=$(run_control hsmoke interrupt) || fail "interrupt against a registered agent should succeed: $OUT"
+OUT=$(run_control hsmoke exit) || fail "exit against proven idle-shell occupancy should be already-stopped: $OUT"
+case "$OUT" in
+  "already-stopped hsmoke"*) : ;;
+  *) fail "idle occupancy on a proven idle shell should report already-stopped, got: $OUT" ;;
+esac
+pass "real herdr: idle occupancy on a proven idle shell is already-stopped"
+
+# --- working occupancy on a shell pane stays live --------------------------
+
+herdr pane report-agent "$PANE_ID" --source fm-control-smoke --agent fm-control-smoke-agent \
+  --state working --session "$SESSION" >/dev/null 2>&1 \
+  || fail "could not register a working agent on the task pane"
+
+STATE=$(fm_backend_agent_state herdr "$SESSION:$PANE_ID")
+[ "$STATE" = alive ] || fail "herdr should classify working occupancy as alive, got '$STATE'"
+
+OUT=$(run_control hsmoke interrupt) || fail "interrupt against a registered working agent should succeed: $OUT"
 case "$OUT" in
   *"interrupt-delivered hsmoke harness=claude backend=herdr verified=agent-alive cancel=unconfirmed"*) : ;;
   *) fail "interrupt should report the agent-alive proof on herdr, got: $OUT" ;;
@@ -135,7 +151,7 @@ herdr pane get "$PANE_ID" --session "$SESSION" >/dev/null 2>&1 \
 pass "real herdr: no control verb removed the endpoint or the task's local copy"
 
 # Last, because it deliberately types a harness command into a pane that hosts
-# a plain shell: the registered agent cannot actually be stopped that way, and
+# a plain shell: working occupancy cannot actually be stopped that way, and
 # the control plane must say so rather than report a stop it did not achieve.
 if OUT=$(run_control hsmoke exit 2>&1); then
   fail "exit should fail closed when the agent does not stop: $OUT"

--- a/tests/fm-herdr-session-cleanup.test.sh
+++ b/tests/fm-herdr-session-cleanup.test.sh
@@ -164,7 +164,7 @@ fm_backend_herdr_cli() {
     "agent get")
       case "$(cat "$FIXTURE_DIR/agent")" in
         absent) printf '%s\n' '{"error":{"code":"agent_not_found"}}' >&2; return 1 ;;
-        live) printf '%s\n' '{"result":{"agent":{"agent_status":"idle"}}}' ;;
+        live) printf '%s\n' '{"result":{"agent":{"agent_status":"working"}}}' ;;
         unknown) printf '%s\n' '{"error":{"code":"internal_error"}}' >&2; return 1 ;;
       esac
       ;;


### PR DESCRIPTION
## Intent

Unblock Firstmate recovery when Herdr leftover occupancy sits on a proven idle shell, without treating a live working agent as gone.

## What Changed

- Treated Herdr idle or done registry occupancy on a process-proven lone idle shell as recoverable, while retaining live classification for working, blocked, and unproven cases.
- Enabled stale duplicate task tabs to be replaced with a final liveness recheck before closure, preserving panes that become working.
- Documented the lifecycle semantics and expanded hermetic and real-Herdr coverage for stale occupancy, release safety, and control behavior.

## Risk Assessment

🚨 High: The live-agent safety guarantee remains bypassable for stale records lacking the atomic identity/version fields, so this should not merge without explicit approval or correction.

## Testing

Ran the real Herdr control-plane flow and the focused backend lifecycle regression suite. They demonstrate stale idle occupancy is recoverable, a working agent remains live through classification and close-boundary rechecks, and the recovery path creates a replacement before closing the stale pane. CLI/backend behavior has no rendered UI surface, so command transcripts are the appropriate reviewer-visible evidence. The worktree was clean after testing.

<details>
<summary>Evidence: Real Herdr control-plane lifecycle transcript</summary>

<code>ok - real herdr: idle occupancy on a proven idle shell is already-stopped&#10;ok - real herdr: interrupt delivers the harness&#39;s key and proves the agent survived it&#10;ok - real herdr: an agent that does not stop fails closed instead of being reported as stopped</code>

```text
ok - real herdr: exit on a pane with no registered agent is idempotent success
ok - real herdr: interrupt refuses when herdr's own agent registry reports no agent
ok - real herdr: idle occupancy on a proven idle shell is already-stopped
ok - real herdr: interrupt delivers the harness's key and proves the agent survived it
ok - real herdr: no control verb removed the endpoint or the task's local copy
ok - real herdr: an agent that does not stop fails closed instead of being reported as stopped
```
</details>
<details>
<summary>Evidence: Herdr backend lifecycle regression transcript</summary>

`Focused adapter regression transcript covering stale idle/done recovery, live-working preservation, exact lifecycle release identity, replacement creation, and pre-close race refusal.`

```text
ok - fm_backend_herdr_version_check: accepts the current protocol (14)
ok - fm_backend_herdr_version_check: refuses an old protocol loudly
ok - fm_backend_herdr_version_check: refuses loudly when herdr is not installed
ok - fm_backend_herdr_workspace_label: a primary home (no marker) resolves to 'firstmate'
ok - fm_backend_herdr_workspace_label: a secondmate home (.fm-secondmate-home) resolves to '2ndmate-<id>'
ok - fm_backend_herdr_workspace_label: trims whitespace around the marker's secondmate id
ok - fm_backend_herdr_workspace_label: an empty marker file falls back to the primary label 'firstmate'
ok - fm_backend_herdr_workspace_label: two different secondmate homes get two different, non-colliding labels
ok - fm_backend_herdr_cli: sets HERDR_SESSION AND appends a trailing --session flag on every call
ok - fm_backend_herdr_launcher_identity: a firstmate not running inside herdr has no launcher workspace to inherit
ok - fm_backend_herdr_launcher_identity: HERDR_ENV=1 without a pane id selects the backend but binds no parent
ok - fm_backend_herdr_launcher_identity: resolves the launcher's exact workspace even when a same-labeled workspace sorts first
ok - fm_backend_herdr_launcher_identity: refuses a launcher pane that names a different herdr session
ok - fm_backend_herdr_launcher_identity: refuses a claimed pane without exact server identity
ok - fm_backend_herdr_launcher_identity: refuses a launcher pane whose injected socket belongs to another herdr server
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's own pane no longer resolves
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's pane and tab disagree about their workspace
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's workspace is gone from its own session
ok - fm_backend_herdr_workspace_ensure: places a worker in the launcher's exact workspace, not the first same-labeled one
ok - fm_backend_herdr_workspace_ensure: refuses to guess between two same-labeled home workspaces
ok - fm_backend_herdr_workspace_ensure: a --secondmate container resolves that home's own workspace, not the launcher's
ok - fm_backend_herdr_container_ensure: surfaces the exact ambiguous-placement refusal instead of a generic failure
ok - fm_backend_herdr_container_ensure: version-gates, starts the server, ensures the firstmate workspace, echoes session:workspace_id + the seeded default tab id
ok - fm_backend_herdr_container_ensure: reuses an existing firstmate workspace without recreating it, and reports no seeded default tab (adopted, not created)
ok - fm_backend_herdr_container_ensure: workspace create passes --no-focus
ok - fm_backend_herdr_container_ensure: creates the workspace under the SECONDMATE home's own label, not 'firstmate'
ok - fm_backend_herdr_create_task: prunes exactly the seeded default tab container_ensure identified, once the first real task tab exists
ok - herdr repeated spawn/teardown: one persistent firstmate workspace reused, zero orphans, default tab pruned, create ran once
ok - fm_backend_herdr_create_task: an ADOPTED workspace's pre-existing tab is never pruned (the created-vs-adopted gate)
ok - fm_backend_herdr_create_task: the label-collision startup-workspace scenario (2026-07-02 incident) leaves the captain's live tab untouched
ok - fm_backend_herdr_workspace_prune_seeded_default_tab: refuses to close the seeded default tab when its pane reports a working agent (defense in depth)
ok - fm_backend_herdr_create_task: refuses a duplicate tab label (herdr's own tab create has no uniqueness check)
ok - fm_backend_herdr_create_task: a same-labeled tab with a live (even idle) registered agent still refuses exactly as before
ok - fm_backend_herdr_create_task: scans every same-labeled tab and refuses if any duplicate is live
ok - fm_backend_herdr_create_task: closes and replaces a same-labeled tab whose pane is dead (pane_not_found)
ok - fm_backend_herdr_create_task: closes and replaces a same-labeled tab whose pane is alive but hosts no registered agent (a restored plain shell)
ok - fm_backend_herdr_create_task: closes every confirmed same-labeled husk only after creating the replacement
ok - fm_backend_herdr_create_task: refuses success when a preexisting husk tab remains after replacement
ok - fm_backend_herdr_create_task: refuses (fail-safe) rather than guessing when the duplicate's agent state cannot be classified confidently
ok - fm_backend_herdr_create_task: creates the replacement tab BEFORE closing the husk tab, never the reverse
ok - fm_backend_herdr_pane_agent_state: idle occupancy plus a proven idle shell is no-agent
ok - fm_backend_herdr_pane_agent_state: done occupancy plus a proven idle shell is no-agent
ok - fm_backend_herdr_pane_agent_state: working occupancy stays live even with an idle-shell process table
ok - fm_backend_herdr_pane_agent_state: blocked occupancy stays live even with an idle-shell process table
ok - fm_backend_herdr_pane_agent_state: idle occupancy with an extra foreground process stays live
ok - fm_backend_herdr_pane_agent_state: FM_HERDR_STALE_SHELL_RELEASE=0 keeps idle occupancy live
ok - fm_backend_herdr_pane_agent_state: a working transition after the stale-shell proof stays live
ok - fm_backend_herdr_pane_agent_state: releases a revalidated stale identity at its exact lifecycle sequence
ok - fm_backend_herdr_create_task: idle occupancy on a proven idle shell is a replaceable husk
ok - fm_backend_herdr_create_task: a stale husk that becomes working before closure is preserved
ok - fm_backend_herdr_create_task: creates a tab and parses tab_id/pane_id from the JSON response, prunes nothing when no seeded tab id is given
ok - fm_backend_herdr_create_task: tab create passes --no-focus
ok - herdr presentation: a home that set nothing gets the projection by default at or above the floor
ok - herdr presentation: an unconfigured home below the floor falls back flat with one naming warning
ok - herdr presentation: an unreadable client release falls back flat instead of guessing
ok - herdr presentation: a deliberate opt-in is never silently downgraded below the floor
ok - herdr presentation: an explicit off opts the home out
ok - herdr presentation: an unrecognized value warns and follows the default instead of failing a spawn
ok - herdr presentation: the below-floor warning is one per home per release, not one per spawn
ok - herdr presentation: warning marker publication is atomic, symlink-safe, and fails visible
ok - herdr presentation: client and selected server floors compose conservatively without overriding explicit opt-in
ok - herdr presentation floor: every measured release, and each signal alone, classifies correctly
ok - herdr presentation floor: either signal alone can carry an above verdict, and each divergence is real
ok - herdr presentation: config parsing separates a deliberate choice from an unconfigured default
ok - herdr presentation journal: atomically publishes one non-authoritative 128-bit correlator and refuses overwrite
ok - herdr presentation journal: version 2 binds exact home/endpoint/parent identities and advances atomically
ok - herdr presentation create: exact response IDs yield one normal task pane with no workspace-close authority
ok - herdr presentation create: concurrent same-label tabs are never prune targets
ok - herdr presentation focus: snapshot requires one exact active workspace and tab
ok - herdr presentation focus: exact pane close restores the exact prior workspace and tab
ok - herdr presentation focus: cleanup refuses rather than close the captain's active tab
ok - herdr presentation focus: pane close fails when exact focus restoration fails
ok - herdr presentation reclaim: live agent state at the close boundary refuses mutation
ok - herdr presentation cleanup: emptying close behind focus ends the exact shell without a move or focus change
ok - herdr presentation cleanup: emptying close before focus moves the doomed workspace to the end and ends its exact shell
ok - herdr presentation cleanup: emptying close with the focused workspace last skips the move
ok - herdr presentation cleanup: emptying close of the last workspace skips the move
ok - herdr presenta

... [4065 bytes truncated] ...

ibling home's
ok - fm_backend_herdr_parse_target: splits '<session>:<pane_id>' on the FIRST colon (pane_id itself contains one)
ok - fm_backend_herdr_normalize_key: Enter/Escape/C-c map to herdr's verified enter/escape/ctrl+c
ok - fm_backend_herdr_capture: calls 'pane read <pane> --source recent --lines N' with the session set
ok - fm_backend_herdr_capture: works around the verified small-N '--lines' bug by over-fetching and trimming locally
ok - fm_backend_herdr_capture: ensures the session and preserves pane read failure
ok - fm_backend_herdr_send_key: normalizes the key and targets the right pane
ok - fm_backend_herdr_kill: calls pane close and stays best-effort on failure
ok - fm_backend_herdr_current_path: reads pane foreground_cwd (the live running process), not the frozen creation-time cwd
ok - fm_backend_herdr_busy_state: working -> busy
ok - fm_backend_herdr_busy_state: done -> idle, blocked -> idle (surfaced like a stale pane, not suppressed as busy)
ok - fm_backend_herdr_busy_state: unparseable/absent agent state reports unknown, the regex-fallback cue
ok - fm_backend_herdr_composer_state: a bare '❯' composer row reads empty
ok - fm_backend_herdr_composer_state: bright placeholder-like text stays pending rather than being mistaken for an idle ghost
ok - fm_backend_herdr_composer_state: real composer text reads pending
ok - fm_backend_herdr_composer_state: a slash-command popup's argument-hint placeholder still reads pending (the incident fix)
ok - fm_backend_herdr_composer_state: reports unknown when the pane cannot be captured
ok - fm_backend_herdr_composer_state: reports unknown for bare shell prompts with no composer row
ok - fm_backend_herdr_composer_state: a native idle Pi separator composer reads empty
ok - fm_backend_herdr_composer_state: real Pi composer text remains pending
ok - fm_backend_herdr_composer_state: an incomplete lower Pi separator cannot inherit a stale empty row
ok - fm_backend_herdr_composer_state: Pi separators never authorize working, non-Pi, unreadable, or over-tall targets
ok - fm_backend_herdr_composer_state: a real-claude unbordered '❯' prompt row (no border box in view) reads empty
ok - fm_backend_herdr_composer_state: a real-claude unbordered '❯ <text>' prompt row reads pending
ok - fm_backend_herdr_composer_state: a live unbordered prompt row below a stale bordered decorative box still wins (not misread as the box's own row)
ok - fm_backend_herdr_composer_state: claude's dim prompt-suggestion ghost (the overnight wedge shape) reads empty
ok - fm_backend_herdr_composer_state: real typed text on the same claude prompt row still reads pending
ok - fm_backend_herdr_composer_state: grok's dark-truecolor placeholder (the TRUECOLOR gap) reads empty
ok - fm_backend_herdr_composer_state: grok's real bright typed input still reads pending
ok - fm_backend_herdr_composer_state: a real-codex unbordered '›' prompt row reads empty
ok - fm_backend_herdr_composer_state: a faint real-codex ghost suggestion reads empty
ok - fm_backend_herdr_composer_state: non-faint codex prompt text still reads pending
ok - fm_backend_herdr_wait_for_working: reports 'busy' immediately on the first poll, without spending the rest of the budget
ok - fm_backend_herdr_wait_for_working: a slow transition landing on a later sample within one window is still caught (robust against the 'slow transition' failure direction)
ok - fm_backend_herdr_wait_for_working: spreads six samples across the full budget endpoint without a final trailing sleep
ok - fm_backend_herdr_send_text_submit: applies the herdr minimum confirmation budget before polling agent-state
ok - fm_backend_herdr_wait_for_working: reports 'idle' (readable, genuinely not yet working) when 'busy' never appears
ok - fm_backend_herdr_wait_for_working: reports 'unknown' (a hard read failure, not a timing race) only when EVERY poll in the window fails
ok - fm_backend_herdr_wait_for_working: treats blocked as submit-active for confirmation without changing watcher busy-state semantics
ok - fm_backend_herdr_send_text_submit: reports 'empty' once agent_status reports working after one Enter, without ever reading the composer
ok - fm_backend_herdr_send_text_submit: reports 'pending' when agent_status never reports working after retried Enters (swallowed)
ok - fm_backend_herdr_send_text_submit: a slash-command popup's placeholder fill on Enter #1 never flips agent_status to working, so it does not short-circuit as submitted; Enter #2 is retried and lands it
ok - fm_backend_herdr_send_text_submit: a post-Enter blocked state confirms delivery without retrying into the prompt
ok - fm_backend_herdr_send_text_submit: preexisting working is not accepted as submit proof when the composer still holds the message
ok - fm_backend_herdr_composer_state: cursor's mid-turn placeholder-plus-busy-token row reads pending (why delivery needs a separate signal)
ok - fm_backend_herdr_rendered_busy_state: busy/idle/unknown from the rendered footer, with an unreadable pane never reading idle
ok - fm_backend_herdr_send_text_submit: a rendered-footer idle-to-busy transition confirms delivery when native agent-state never reports idle
ok - fm_backend_herdr_send_text_submit: an already-busy footer baseline is never accepted as proof that this Enter landed
ok - fm_backend_herdr_send_text_submit: confirms submission via native agent-state alone, immune to a codex-style dynamic idle-tip composer that would have misread as 'pending' under the old composer-based confirmation
ok - fm_backend_herdr_composer_state: a faint real-codex dynamic idle-tip composer row reads empty
ok - fm_backend_composer_state (herdr): the pre-injection empty-box guard still refuses a genuinely non-empty composer, unaffected by the submit-confirmation change
ok - fm_backend_herdr_send_text_submit: a slow transition landing on a later sample within one Enter's budget is confirmed WITHOUT sending a needless extra Enter
ok - fm_backend_herdr_send_text_submit: reports 'send-failed' when the literal send-text call itself errors
ok - fm_backend_herdr_send_text_submit: reports 'unknown' when the post-Enter agent-get read fails (never retries past an unreadable target)
ok - fm_backend_validate: herdr is a known backend (P2)
ok - fm_backend_busy_state: tmux (no native primitive) always reports unknown, preserving the P1 regex-only path
error: unknown backend 'bogus' (known: tmux herdr zellij orca cmux)
ok - fm_backend_composer_state dispatches every backend to its named thin classifier, unknown for unrecognized backends
ok - fm-peek/fm-send: explicit stale targets matching metadata use the recorded backend
ok - fm_backend_herdr_normalize_event routes through the shared record with an empty from_status
ok - fm_backend_herdr_escalation_marker keys the dedupe marker exactly like the watcher's .stale-<key>
ok - fm_backend_herdr_apply_transition: blocked dedupe starts only after explicit commit
ok - fm_backend_herdr_apply_transition: a working edge clears the marker so the next ->blocked re-escalates
ok - fm_backend_herdr_clear_transition removes task-owned dedupe state
ok - fm_backend_herdr_apply_transition: idle/done (defer) and unknown/empty (fallback) take no fast action
ok - fm_backend_herdr_wait_transition: a home with no herdr panes falls back to polling (rc 2)
ok - fm_backend_herdr_wait_transition: below-capability protocol/schema falls back to polling (rc 2)
ok - fm_backend_herdr_wait_transition: reconnect level-reconcile returns an uncommitted blocked pane
ok - fm_backend_herdr_wait_transition: subscribes before reconnect level-reconcile
ok - fm_backend_herdr_wait_transition: a still-blocked, already-escalated pane is not re-delivered on reconnect
ok - fm_backend_herdr_wait_transition: a streamed ->blocked edge returns the record sub-poll
ok - fm_backend_herdr_wait_transition: streamed working clears the marker, idle/done are deferred (clean timeout)
ok - fm_backend_herdr_wait_transition: a reader/subscribe failure falls back to polling (rc 2)
ok - fm_backend_herdr_wait_transition: Bash 3.2-safe bad-ack path closes fd 9 and removes its FIFO
ok - fm_backend_herdr_wait_transition: stock macOS Bash clean timeout closes fd 9 and returns 1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- 🚨 `bin/backends/herdr.sh:1925` - The required guarantee, “without treating a live working agent as gone,” is not preserved across the new stale-occupancy transition. After `agent get` returns idle/done and the shell proof succeeds, that same agent can report working before this code calls `release-agent`; the stale identity is then released and `no-agent` is returned. `fm_backend_herdr_agent_state` maps this to dead, so `fm-control exit` can report an active agent already stopped, and relaunch paths can close its tab. Revalidate the current agent identity and status at the release/close boundary, or use an atomic conditional Herdr operation, before authorizing recovery.

🔧 Fix: Harden Herdr stale-agent recovery
1 error still open:
- 🚨 `bin/backends/herdr.sh:1946` - When `source`, `agent`, or `state_change_seq` is absent, the branch skips the conditional `release-agent` yet still returns `no-agent`. A worker can report working immediately after that final idle read, leaving no atomic guard before `fm_backend_herdr_agent_state` maps it to dead and `fm-control exit` reports `already-stopped`; the duplicate-tab path can likewise authorize closure. This contradicts the required criterion, “without treating a live working agent as gone.” Return `unknown` and refuse recovery unless `release-agent --source --agent --seq` succeeds, or use an equivalent atomic boundary.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-control-herdr-smoke.test.sh` against local Herdr 0.8.0, protocol 19</code>
- `bash tests/fm-backend-herdr.test.sh`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
