### PR TITLE
fix: ignore home-root scratchpad directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 projects/
 state/
 data/
+scratchpad/
 .no-mistakes/
 .lavish/
 .fm-secondmate-home


### PR DESCRIPTION
## Intent

Add a 'scratchpad/' entry to the firstmate repo's root .gitignore, matching the existing trailing-slash directory-pattern style already used there (projects/, state/, data/, config/), placed sensibly among the existing directory ignores.

Why: agents sometimes write temp files into a scratchpad/ directory at a firstmate home root. Because it is untracked, a stray home-root scratchpad/ makes git status show the home as not-clean, which blocks the guarded tracked-file instruction syncs (fleet-sync / secondmate convergence) that only fast-forward a clean home. Ignoring scratchpad/ prevents that class of false not-clean state.

Precondition confirmed before the change: 'git ls-files | grep -i scratchpad' returned nothing, so no legitimately tracked path is being untracked by this ignore.

Deliberate constraints accepted for this task:
- One-line addition only. No other line in .gitignore changed, reordered, or reformatted, and no other file touched. git diff was verified to contain exactly the one added line.
- No unit test is expected or required: this is a .gitignore pattern change with no executable interface of its own. Do NOT add a test that asserts .gitignore file bytes or greps its contents - that is an explicitly ruled-out anti-pattern here. The behavioral proof, already performed manually, is that creating a scratchpad/ directory in the clean checkout leaves 'git status --porcelain' unaffected because git ignores it.
- Commit message carries no agent co-author trailer (firstmate repo rule).

## What Changed

- Add `scratchpad/` to the root `.gitignore` so temporary scratchpad files do not affect repository status.

## Risk Assessment

✅ Low: The change is a well-bounded, intent-conforming one-line .gitignore addition with no other files modified and no agent co-author trailer.

## Testing

Verified the one-line-only diff and commit constraints, then exercised Git’s real ignore behavior end-to-end: a file created under root `scratchpad/` was ignored and left the clean checkout’s porcelain status unchanged. No unit tests were run, as explicitly intended for this declarative change.

<details>
<summary>Evidence: Scratchpad ignore behavior transcript</summary>

Source: [Scratchpad ignore behavior transcript](https://github.com/kunchenguid/firstmate/blob/3829ae7eabd7966abb06f997358cebe554e405c2/.no-mistakes/evidence/fm/fm-gitignore-scratchpad-r1/scratchpad-git-status-transcript.txt)

```text
$ git status --porcelain --untracked-files=all  # before creating scratchpad/probe.txt
<no output: clean>

$ mkdir scratchpad && printf "temporary agent note\n" > scratchpad/probe.txt

$ git check-ignore -v scratchpad/probe.txt
.gitignore:4:scratchpad/	scratchpad/probe.txt

$ git status --porcelain --untracked-files=all  # after creating scratchpad/probe.txt
<no output: still clean>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"94717337f9ef08905795b99ea44db2ad6de25ff3","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff --name-status` and the `.gitignore` diff between base and target; confirmed exactly one added line and no other files changed.</code>
- <code>Ran `git ls-files | grep -i scratchpad`; confirmed no tracked scratchpad paths.</code>
- <code>Inspected `git show -s --format=&#39;%H%n%B&#39; 94717337f9ef08905795b99ea44db2ad6de25ff3`; confirmed no co-author trailer.</code>
- <code>Created `scratchpad/probe.txt`, ran `git check-ignore -v scratchpad/probe.txt`, and verified `git status --porcelain --untracked-files=all` remained clean before and after creation; then removed the transient directory.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
