### PR TITLE
fix(herdr): keep watcher event-wait failures visible

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -3135,8 +3135,8 @@ fm_backend_herdr_events_capable() {  # <session>
   case "$protocol" in ''|*[!0-9]*) return 1 ;; esac
   [ "$protocol" -ge "$FM_BACKEND_HERDR_MIN_EVENTS_PROTOCOL" ] || return 1
   schema=$(herdr api schema --json 2>/dev/null) || return 1
-  printf '%s' "$schema" | grep -Fq 'events.subscribe' || return 1
-  printf '%s' "$schema" | grep -Fq 'pane.agent_status_changed' || return 1
+  case "$schema" in *events.subscribe*) ;; *) return 1 ;; esac
+  case "$schema" in *pane.agent_status_changed*) ;; *) return 1 ;; esac
   return 0
 }
 

--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -2,11 +2,12 @@
 # Safe, home-scoped (re-)arm of the firstmate watcher, with honest verification.
 #
 # The watcher (bin/fm-watch.sh) blocks until it has an actionable wake to
-# surface, then prints one reason line and exits. While state/.afk exists the
-# daemon owns triage and the watcher exits on every wake for the daemon to
-# classify. Reliability depends on arming through a mechanism that SURVIVES the
-# call and NOTIFIES on exit, so firstmate must run this script as the harness's
-# own tracked background task (e.g. run_in_background), or - for a Claude
+# surface, then prints one reason line and exits. An unexpected native event-wait
+# failure instead prints one typed `watcher: FAILED - <reason>` line and exits
+# nonzero. While state/.afk exists the daemon owns triage and the watcher exits on
+# every wake for the daemon to classify. Reliability depends on arming through a
+# mechanism that SURVIVES the call and NOTIFIES on exit, so firstmate must run
+# this script as the harness's own tracked background task (e.g. run_in_background), or - for a Claude
 # primary - inside the Stop asyncRewake hook's foreground process tree
 # (bin/fm-claude-stop-autoarm.sh), where the harness owns the process group and
 # the hook's exit-2 rewake is the notification. Run it as its own standalone
@@ -32,13 +33,16 @@
 #   watcher: FAILED - cycle ended without an actionable reason
 #                                                        - a clean cycle ended with no wake and no
 #                                                          verified healthy successor
+#   watcher: FAILED - <concrete reason>
+#                                                        - the child supplied its own terminal failure
 # It NEVER reports started/attached/healthy off a stale beacon or a dead/reused pid: a
 # stale-beacon or dead-pid holder either self-heals (the fresh child steals the
 # dead lock per the singleton self-eviction/steal path and is confirmed) or this
-# returns the FAILED line. On started it waits the child and propagates the wake
-# reason; on attached it stays live across identity-matched successors. A cycle
-# that ends with no reason line and no healthy successor is resolved against the
-# watcher's identity-bound delivery record: a matching record reports that wake
+# returns the FAILED line. On started it waits the child and propagates either
+# the actionable reason or the concrete typed failure; on attached it stays live
+# across identity-matched successors. A cycle that ends with no reason line and
+# no healthy successor is resolved against the watcher's identity-bound delivery
+# record: a matching record reports that wake
 # and exits 0, and only a cycle that delivered nothing is the typed nonzero
 # failure. Neither is ever a clean empty completion. On FAILED it exits non-zero
 # so the failure is loud. A live cycle already present means re-arm attaches - do

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -686,8 +686,11 @@ event_wait_or_sleep() {
     return
   fi
 
-  rec=$(FM_BACKEND_EVENTS_CAPABILITY_CONFIRMED=1 fm_backend_wait_transition "$first_backend" "$first_session" "$POLL" "$STATE" "${windows[@]}")
-  rc=$?
+  if rec=$(FM_BACKEND_EVENTS_CAPABILITY_CONFIRMED=1 fm_backend_wait_transition "$first_backend" "$first_session" "$POLL" "$STATE" "${windows[@]}"); then
+    rc=0
+  else
+    rc=$?
+  fi
   case "$rc" in
     0)
       _event_cap_fails=0
@@ -701,10 +704,14 @@ event_wait_or_sleep() {
       [ "$_event_cap_fails" -ge "$EVENT_CAP_FAIL_MAX" ] && _event_cap_ok=0
       sleep "$POLL"
       ;;
-    *)
+    1)
       # 1: a clean full-budget wait with no actionable edge - the reader already
       # blocked ~POLL, so just continue; the next cycle re-scans.
       _event_cap_fails=0
+      ;;
+    *)
+      echo "watcher: FAILED - $first_backend event wait exited $rc" >&2
+      return 1
       ;;
   esac
 }
@@ -1204,4 +1211,6 @@ EOF
   # Terminal wait: a bounded native-event wait for push-capable homes (herdr),
   # else the blind poll sleep. See event_wait_or_sleep.
   event_wait_or_sleep
+  event_wait_rc=$?
+  [ "$event_wait_rc" -eq 0 ] || exit "$event_wait_rc"
 done

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -710,7 +710,7 @@ event_wait_or_sleep() {
       _event_cap_fails=0
       ;;
     *)
-      echo "watcher: FAILED - $first_backend event wait exited $rc" >&2
+      echo "watcher: FAILED - $first_backend event wait exited $rc"
       return 1
       ;;
   esac

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -10,7 +10,7 @@
 # the separate idle absorb case and re-surfaces only on its long bounded cadence,
 # although its initial no-verb status signal still surfaces in normal mode.
 # While state/.afk exists, the daemon owns triage and this watcher queues and exits
-# on every wake. Printed reason lines:
+# on every wake. Printed terminal lines:
 #   signal: <file>...      status/turn-end signals, surfaced when a listed status
 #                          has a captain-relevant verb OR a no-verb signal's crew
 #                          is not provably working, unless afk is active
@@ -56,9 +56,13 @@
 #   check: inactive-outcome bounded poll-loop reconciliation found a suspicious
 #                          inactive terminal outcome that still lacks its durable
 #                          upstream receipt
+#   watcher: FAILED - <backend> event wait exited <status>
+#                          an unexpected native-wait failure; the arm preserves
+#                          this concrete reason and returns nonzero
 # For normal supervision, resume the session-start primary-harness protocol
-# after each printed reason. Direct duplicate invocations of this script still
-# no-op through the watcher singleton lock.
+# after each printed actionable reason; a typed failure instead follows that
+# protocol's repair path. Direct duplicate invocations of this script still no-op
+# through the watcher singleton lock.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -643,6 +647,8 @@ heartbeat_scan_finds_actionable() {
 # loop is the permanent fail-closed backstop). This preserves the single live
 # supervision cycle: the reader is a short-lived subprocess of THIS watcher, not
 # a second watcher, so every guard/beacon/arm/turn-end mechanism is unchanged.
+# Only the adapter's expected clean-timeout and unavailable statuses may continue
+# or fall back; every other status is a typed terminal failure for the arm layer.
 event_wait_or_sleep() {
   local w b session first_backend="" first_session="" rec rc
   local windows=()

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -275,9 +275,10 @@ The watcher maps the pane back to the task and skips secondmate endpoints and de
 
 The push path only shortens latency.
 Polling runs every cycle and remains the permanent fallback when protocol 16, the event schema, Python, connection, subscription, or repeated reader execution is unavailable.
+An unexpected wait status outside the adapter's expected contract ends the current cycle with a typed failure instead of being treated as a timeout or fallback; the [arm-layer cycle contract](watcher-continuity.md#arm-layer-cycle-contract) owns how that reason is surfaced.
 There is still one watcher process; the event reader is a bounded child of that watcher.
 
-`tests/fm-backend-herdr-eventwait-smoke.test.sh`, `tests/fm-transition-lib.test.sh`, and `tests/fm-supervision-events.test.sh` cover capability, subscribe-then-reconcile ordering, dedupe, exemptions, and polling fallback.
+`tests/fm-backend-herdr.test.sh`, `tests/fm-backend-herdr-eventwait-smoke.test.sh`, `tests/fm-transition-lib.test.sh`, `tests/fm-supervision-events.test.sh`, and `tests/fm-watch-arm.test.sh` cover pipe-safe capability detection, subscribe-then-reconcile ordering, dedupe, exemptions, inherited-errexit status classification, polling fallback, and typed-failure propagation through the arm.
 
 ## Away-mode supervisor support
 

--- a/docs/watcher-continuity.md
+++ b/docs/watcher-continuity.md
@@ -59,11 +59,12 @@ An acknowledged episode does not freeze the generation, because the next downtim
 
 `bin/fm-watch-arm.sh` never returns a clean empty success.
 An actionable child output returns that reason normally.
+A typed child failure such as `watcher: FAILED - herdr event wait exited <status>` is passed through unchanged and remains nonzero.
 A zero/empty child return rechecks the home lock and beacon, attaches to a verified healthy successor when one exists, or resolves the close against the watcher's bounded terminal-delivery ledger.
 An attached arm follows verified identity-matched successors and resolves the same way when that chain ends without one, because it holds no handle on the watcher's stdout and cannot read the reason line itself.
 Before releasing its singleton lock after printing an actionable reason, the watcher records that reason with its PID and process identity in `state/.watch-deliveries.log`.
 A matching PID and identity lets an attached arm report the delivered reason and exit zero even after its durable wake was handled and acknowledged, while an unrelated queue producer or a recycled PID cannot satisfy the match.
-Only a cycle with no matching delivery record emits `watcher: FAILED - cycle ended without an actionable reason` and exits nonzero.
+Only a cycle with neither a typed output nor a matching delivery record receives the arm's generic `watcher: FAILED - cycle ended without an actionable reason` and exits nonzero.
 
 The arm layer appends one tab-separated record per observed cycle to `state/.watch-cycle-exits.log`.
 Each record includes arm and watcher PIDs, start and end timestamps, exit code and signal, classified reason, beacon age, lock identity before and after close, and successor disposition.
@@ -78,6 +79,7 @@ Only the watcher process touches `state/.last-watcher-beat`; no helper process c
 `tests/fm-pi-watch-extension.test.sh` checks Pi's first-cycle-or-explicit-repair tool metadata and ownership-based redundant-call no-ops, then simulates actionable and empty child closes against the actual Pi and OpenCode close handlers, blocks prompt delivery to prove the successor launches first, verifies single-flight behavior, changes the session lock before close to prove ownership is rechecked, and hangs each successor arm to prove bounded fallback delivery includes the typed restoration failure.
 The same suite covers ordinary same-process session replacement for `/new`, `/resume`, and `/fork`, same-instance shutdown-plus-start, stale prior-generation callbacks, repeated transitions with exactly one live cycle, disappearance of the shutting-down refusal after a valid replacement activates, and terminal quit still refusing late rearm.
 `tests/fm-watch-arm.test.sh` covers durable queue replay, real remote parent-replies ingestion into the authoritative status log, decision-only OPEN DECISIONS recovery, interrupted handling replay, generation-bound acknowledgement, a persistent live successor after recovery, a watcher close inside the handling window that must leave the printed acknowledgement valid, and the self-healing moved-generation acknowledgement that consumes its handled rows and names its remedy.
+The same suite proves an owned Herdr event-wait failure preserves the watcher's concrete typed reason instead of replacing it with the arm's generic exit message.
 `tests/fm-watcher-lock.test.sh` covers verified-successor attach, recovery publication before stale-lock removal, the typed self-eviction failure, bounded and successor-linked lifecycle rows, and a SIGSTOP counterfactual that distinguishes a live PID from a stale beacon before classifying termination.
 `tests/fm-subagent-pretool-check.test.sh` proves Claude retains only the non-status Bash seatbelts.
 `tests/fm-claude-stop-autoarm.test.sh` covers the auto-arm's scope, stale and live session owners, unchanged AFK and need boundaries, single-flight, bounded failure retries, benign live-watcher cycle ends, one-notice failure episodes, and exit-2 translation.

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -4031,6 +4031,9 @@ cmd=${1:-}; sub=${2:-}
 case "$cmd $sub" in
   "status --json")
     printf '{"client":{"version":"0.7.3","protocol":16},"server":{"running":true}}\n' ;;
+  "api schema")
+    printf 'events.subscribe\npane.agent_status_changed\n'
+    awk 'BEGIN { for (i = 0; i < 200000; i++) print "padding" }' ;;
   "session list")
     printf '{"sessions":[{"name":"%s","running":true,"default":false,"socket_path":"%s"}]}\n' \
       "${FM_FAKE_SESSION_NAME:-default}" "${FM_FAKE_SOCKET:-/tmp/fm-fake.sock}" ;;
@@ -4170,6 +4173,17 @@ test_wait_transition_no_panes_returns_2() {
   bash -c '. "$0/bin/backends/herdr.sh"; FM_BACKEND_HERDR_EVENTS_FORCE=1 fm_backend_herdr_wait_transition default 1 /tmp/st' "$ROOT"; rc=$?
   [ "$rc" = 2 ] || fail "wait_transition with no pane windows must return 2 (fall back to sleep), got $rc"
   pass "fm_backend_herdr_wait_transition: a home with no herdr panes falls back to polling (rc 2)"
+}
+
+test_events_capable_survives_an_early_schema_consumer_close() {
+  local dir fb rc
+  dir="$TMP_ROOT/events-capable-pipe-safe"; mkdir -p "$dir"
+  fb=$(make_herdr_eventfake "$dir")
+  PATH="$fb:$PATH" FM_FAKE_SESSION_NAME=sess \
+    bash -c 'set -o pipefail; . "$0/bin/backends/herdr.sh"; fm_backend_herdr_events_capable sess' "$ROOT"
+  rc=$?
+  [ "$rc" = 0 ] || fail "events capability must survive grep closing a large schema pipe early, got $rc"
+  pass "fm_backend_herdr_events_capable: an early schema consumer close cannot turn capability detection into SIGPIPE failure"
 }
 
 test_wait_transition_not_capable_returns_2() {
@@ -4480,6 +4494,7 @@ test_apply_transition_blocked_requires_commit_to_dedupe
 test_apply_transition_working_clears_marker
 test_clear_transition_removes_task_marker
 test_apply_transition_defer_and_fallback_are_noops
+test_events_capable_survives_an_early_schema_consumer_close
 test_wait_transition_no_panes_returns_2
 test_wait_transition_not_capable_returns_2
 test_wait_transition_reconcile_blocked_returns_record

--- a/tests/fm-supervision-events.test.sh
+++ b/tests/fm-supervision-events.test.sh
@@ -140,7 +140,7 @@ fm_write_meta "$STATE_DIR/tk3.meta" "window=default:wG:pQ" "backend=herdr" "kind
 fm_backend_events_capable() { return 0; }
 # shellcheck disable=SC2329 # Runtime override called by the isolated watcher.
 fm_backend_wait_transition() { return 7; }
-UNEXPECTED_OUT=$(event_wait_or_sleep 2>&1)
+UNEXPECTED_OUT=$(event_wait_or_sleep)
 UNEXPECTED_RC=$?
 [ "$UNEXPECTED_RC" -ne 0 ] || fail "an unexpected event-wait failure must fail the watcher cycle"
 case "$UNEXPECTED_OUT" in

--- a/tests/fm-supervision-events.test.sh
+++ b/tests/fm-supervision-events.test.sh
@@ -112,6 +112,43 @@ event_wait_or_sleep
 [ "$CAP_CALLS" = 1 ] || fail "capability probe must be memoized across waits, got $CAP_CALLS calls"
 pass "event_wait_or_sleep: one cached capability probe owns validation across bounded waits"
 
+# --- event_wait_or_sleep: inherited errexit cannot pre-empt rc classification -
+
+reset_state
+fm_write_meta "$STATE_DIR/tk3.meta" "window=default:wG:pQ" "backend=herdr" "kind=ship"
+ERREXIT_SURVIVED="$TMP/errexit-survived"
+rm -f "$ERREXIT_SURVIVED"
+FM_EVENT_TEST_ROOT="$ROOT" FM_EVENT_TEST_STATE="$STATE_DIR" FM_EVENT_TEST_SURVIVED="$ERREXIT_SURVIVED" \
+  /bin/bash -c '
+    set -e
+    export FM_ROOT_OVERRIDE="$FM_EVENT_TEST_ROOT" FM_STATE_OVERRIDE="$FM_EVENT_TEST_STATE"
+    . "$FM_EVENT_TEST_ROOT/bin/fm-watch.sh"
+    sleep() { :; }
+    fm_backend_events_capable() { return 0; }
+    fm_backend_wait_transition() { return 1; }
+    event_wait_or_sleep
+    : > "$FM_EVENT_TEST_SURVIVED"
+  '
+ERREXIT_RC=$?
+[ "$ERREXIT_RC" = 0 ] && [ -e "$ERREXIT_SURVIVED" ] \
+  || fail "an inherited errexit shell must survive a clean event-wait timeout, got rc $ERREXIT_RC"
+pass "event_wait_or_sleep: a clean event timeout is classified before inherited errexit can end the watcher"
+
+reset_state
+fm_write_meta "$STATE_DIR/tk3.meta" "window=default:wG:pQ" "backend=herdr" "kind=ship"
+# shellcheck disable=SC2329 # Runtime override called by the isolated watcher.
+fm_backend_events_capable() { return 0; }
+# shellcheck disable=SC2329 # Runtime override called by the isolated watcher.
+fm_backend_wait_transition() { return 7; }
+UNEXPECTED_OUT=$(event_wait_or_sleep 2>&1)
+UNEXPECTED_RC=$?
+[ "$UNEXPECTED_RC" -ne 0 ] || fail "an unexpected event-wait failure must fail the watcher cycle"
+case "$UNEXPECTED_OUT" in
+  *"watcher: FAILED - herdr event wait exited 7"*) : ;;
+  *) fail "an unexpected event-wait failure must emit a typed watcher failure, got '$UNEXPECTED_OUT'" ;;
+esac
+pass "event_wait_or_sleep: an unexpected event-path failure is loud and nonzero"
+
 # --- event_wait_or_sleep: a tmux-only home never runs the event path ----------
 
 reset_state

--- a/tests/fm-watch-arm.test.sh
+++ b/tests/fm-watch-arm.test.sh
@@ -241,6 +241,55 @@ test_attached_arm_still_fails_on_a_wake_it_did_not_deliver() {
   pass "watch-arm: a cycle that delivered no wake of its own still fails loudly"
 }
 
+test_owned_arm_preserves_typed_event_wait_failure() {
+  local dir state fakebin reader armout armerr status signal_number expected_rc
+  dir=$(make_case owned-typed-event-wait-failure)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  reader="$dir/failing-reader"
+  armout="$dir/arm.out"
+  armerr="$dir/arm.err"
+
+  cat > "$fakebin/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-} ${2:-}" in
+  "status --json")
+    printf '{"client":{"protocol":16},"server":{"running":true}}\n' ;;
+  "session list")
+    printf '{"sessions":[{"name":"default","socket_path":"/tmp/fm-fake.sock"}]}\n' ;;
+  "agent get")
+    exit 1 ;;
+esac
+exit 0
+SH
+  cat > "$reader" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf '@subscribed\n'
+kill -USR1 "$PPID"
+SH
+  chmod +x "$fakebin/herdr" "$reader"
+  fm_write_meta "$state/demo.meta" "window=default:wG:pQ" "backend=herdr" "kind=ship"
+
+  PATH="$fakebin:$PATH" FM_HOME="$dir" FM_STATE_OVERRIDE="$state" \
+    FM_BACKEND_HERDR_EVENTS_FORCE=1 FM_BACKEND_HERDR_EVENT_READER="$reader" \
+    FM_POLL=1 FM_SIGNAL_GRACE=0 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 \
+    FM_ARM_CONFIRM_TIMEOUT=1 "$WATCH_ARM" > "$armout" 2> "$armerr"
+  status=$?
+  signal_number=$(kill -l USR1)
+  expected_rc=$((128 + signal_number))
+
+  expect_code 1 "$status" "an unexpected event-wait failure must fail its owned arm"
+  grep -qF "watcher: FAILED - herdr event wait exited $expected_rc" "$armout" \
+    || fail "the arm lost the watcher's typed event-wait reason: $(cat "$armout")"
+  ! grep -qF 'watcher cycle exited 1' "$armout" \
+    || fail "the arm replaced the concrete event-wait reason with its generic exit-1 failure: $(cat "$armout")"
+  ! grep -qF "watcher: FAILED - herdr event wait exited $expected_rc" "$armerr" \
+    || fail "the typed event-wait reason escaped the arm's captured stdout contract"
+  pass "watch-arm: an owned failed cycle preserves its typed event-wait reason"
+}
+
 test_rearm_resurfaces_durable_queue_and_remote_open_decision() {
   local dir home state fakebin result armout drainout status watcher_pid sequence generation decision_recovery_arm decision_successor
   dir=$(make_case rearm-resurface)
@@ -800,6 +849,7 @@ test_downtime_marker_does_not_follow_symlink() {
 test_attached_arm_reports_the_delivered_wake
 test_attached_arm_reports_the_delivered_wake_after_drain
 test_attached_arm_still_fails_on_a_wake_it_did_not_deliver
+test_owned_arm_preserves_typed_event_wait_failure
 test_rearm_resurfaces_durable_queue_and_remote_open_decision
 test_marker_publish_failure_retains_recovery_evidence
 test_delivery_gap_wake_is_recovered_once


### PR DESCRIPTION
## Intent

Fix the Firstmate watcher's recurring silent death on the Herdr backend. Reproduce and eliminate the broken-pipe failure caused by an early-closing schema consumer, ensure expected Herdr event-wait statuses remain safe even when the watcher inherits errexit, and make every unexpected poll-path failure surface as a loud typed "watcher: FAILED - <reason>" through the arm layer instead of leaving a stale beacon. Preserve the documented one-shot watcher contract: one actionable stale wake intentionally ends its cycle and continuity belongs to the arm layer. Do not change other backends, beacon semantics, guard semantics, or Herdr lifecycle behavior. Keep the change surgical, add colocated regression coverage, remain ShellCheck-clean, and open a PR that waits for captain merge. The captain has explicitly approved fixing review-1 by routing the concrete poll-failure reason through the stream captured by fm-watch-arm.sh and adding arm-level regression coverage that proves the concrete reason appears instead of the generic exit-1 message.

## What Changed

- Replace piped Herdr schema probes with shell matching to prevent early consumer closure from causing SIGPIPE failures under `pipefail`.
- Safely classify event-wait statuses under inherited `errexit` and terminate unexpected failures with a concrete `watcher: FAILED - <reason>` that the arm layer preserves.
- Document the one-shot watcher contract and add regression coverage for schema probing, status handling, and arm-level failure propagation.

## Risk Assessment

✅ Low: The change is surgical, preserves the documented watcher contracts, eliminates the schema-consumer broken pipe, safely classifies expected wait statuses under errexit, and carries unexpected failures through the arm’s captured stdout.

## Testing

Inspected the base-to-target change, ran the focused regressions, and replayed the real arm path before and after the fix. Target reports `watcher: FAILED - herdr event wait exited 158` through captured stdout without the generic exit-1 replacement, preserves one-shot lifecycle behavior, and eliminates the reproduced pipefail and inherited-errexit failures.

<details>
<summary>Evidence: Herdr arm regression transcript</summary>

```text
===== target-f7cb12c =====
fixture_dir=/var/folders/s8/0_mzgfjj34v2wr0gvxxh64n80000gn/T/no-mistakes-evidence/01KZZMZPWYCB4Q09R5TH1GHQSY/target-f7cb12c.Mp4cnD
code_root=/Users/mohammedameen/.no-mistakes/worktrees/ac543050f1c8/01KZZMZPWYCB4Q09R5TH1GHQSY
arm_exit=1
arm_stdout<<EOF
watcher: started pid=74730 (beacon fresh)
watcher: FAILED - herdr event wait exited 158
EOF
arm_stderr<<EOF

EOF
pre_cleanup_state: beacon=present lock=absent watcher_down=pending:downtime:74730.1786696207.MARNxC
lifecycle_ledger<<EOF
arm_pid=74715	watcher_pid=74730	origin=started	started_at=1786696206	ended_at=1786696207	exit_code=1	signal=none	reason=nonzero-exit	beacon_age=1	lock_before=pid:74730|identity:Fri Aug 14 18:30:06 2026     bash /Users/mohammedameen/.no-mistakes/worktrees/ac543050f1c8/01KZZMZPWYCB4Q09R5TH1GHQSY/bin/fm-watch.sh	lock_after=pid:none|identity:none	successor=none
EOF
typed_failure_on_arm_stdout=yes
generic_exit1_on_arm_stdout=no
cleanup=no live fixture processes remained

===== review1-4c808b7 =====
fixture_dir=/var/folders/s8/0_mzgfjj34v2wr0gvxxh64n80000gn/T/no-mistakes-evidence/01KZZMZPWYCB4Q09R5TH1GHQSY/review1-4c808b7.FpGfls
code_root=/var/folders/s8/0_mzgfjj34v2wr0gvxxh64n80000gn/T/no-mistakes-evidence/01KZZMZPWYCB4Q09R5TH1GHQSY/review1-src
arm_exit=1
arm_stdout<<EOF
watcher: started pid=75612 (beacon fresh)
watcher: FAILED - watcher cycle exited 1 without an actionable reason
EOF
arm_stderr<<EOF
watcher: FAILED - herdr event wait exited 158
EOF
pre_cleanup_state: beacon=present lock=absent watcher_down=pending:downtime:75612.1786696210.W3jiG0
lifecycle_ledger<<EOF
arm_pid=75595	watcher_pid=75612	origin=started	started_at=1786696207	ended_at=1786696210	exit_code=1	signal=none	reason=nonzero-exit	beacon_age=2	lock_before=pid:75612|identity:Fri Aug 14 18:30:07 2026     bash /var/folders/s8/0_mzgfjj34v2wr0gvxxh64n80000gn/T/no-mistakes-evidence/01KZZMZPWYCB4Q09R5TH1GHQSY/review1-src/bin/fm-watch.sh	lock_after=pid:none|identity:none	successor=none
EOF
typed_failure_on_arm_stdout=no
generic_exit1_on_arm_stdout=yes
cleanup=no live fixture processes remained

===== base-6789876 =====
fixture_dir=/var/folders/s8/0_mzgfjj34v2wr0gvxxh64n80000gn/T/no-mistakes-evidence/01KZZMZPWYCB4Q09R5TH1GHQSY/base-6789876.ZZgvPA
code_root=/var/folders/s8/0_mzgfjj34v2wr0gvxxh64n80000gn/T/no-mistakes-evidence/01KZZMZPWYCB4Q09R5TH1GHQSY/base-src
arm_exit=0
arm_stdout<<EOF
watcher: started pid=76511 (beacon fresh)
stale: default:wG:pQ
EOF
arm_stderr<<EOF

EOF
pre_cleanup_state: beacon=present lock=absent watcher_down=pending:downtime:76511.1786696213.msCd55
lifecycle_ledger<<EOF
arm_pid=76496	watcher_pid=76511	origin=started	started_at=1786696210	ended_at=1786696213	exit_code=0	signal=none	reason=actionable-stale	beacon_age=1	lock_before=pid:76511|identity:Fri Aug 14 18:30:10 2026     bash /var/folders/s8/0_mzgfjj34v2wr0gvxxh64n80000gn/T/no-mistakes-evidence/01KZZMZPWYCB4Q09R5TH1GHQSY/base-src/bin/fm-watch.sh	lock_after=pid:none|identity:none	successor=none
EOF
typed_failure_on_arm_stdout=no
generic_exit1_on_arm_stdout=no
cleanup=no live fixture processes remained
```
</details>
<details>
<summary>Evidence: Herdr schema pipefail counterfactual</summary>

```text
target-f7cb12c: fm_backend_herdr_events_capable rc=0 (pipefail on; 200000-line schema with both capabilities at start)
base-6789876: fm_backend_herdr_events_capable rc=1 (pipefail on; 200000-line schema with both capabilities at start)
expected: target rc=0; base rc!=0 because grep -q closes before printf finishes and pipefail exposes SIGPIPE
```
</details>
<details>
<summary>Evidence: Base regression failure transcript</summary>

```text
command: target regression test file executed against base 6789876442d0fb6da9f70d86399a2930c5073ae2 source fixture
exit_status=1
stdout<<EOF
ok - handle_push_transition: a blocked crew enqueues a stale wake naming its window and wakes the supervisor
ok - handle_push_transition: enqueue failure cannot commit the Herdr dedupe marker
ok - handle_push_transition: a declared-pause crew is absorbed (no fast wake), left to the poll loop's long cadence
ok - event_wait_or_sleep: herdr windows go on the event pane list, but kind=secondmate endpoints are excluded
ok - event_wait_or_sleep: one cached capability probe owns validation across bounded waits
EOF
stderr<<EOF
not ok - an inherited errexit shell must survive a clean event-wait timeout, got rc 1
EOF
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"20dd120a6b1797bc6723bcf0ca0fff1bb2e3e45c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-watch.sh:713` - The required “routing the concrete poll-failure reason through the stream captured by fm-watch-arm.sh and adding arm-level regression coverage” is still absent. This line writes to stderr, but fm-watch-arm.sh captures only watcher stdout in child_out; it therefore misses the typed failure and emits the generic “watcher cycle exited 1” message. The added function test hides this mismatch with `2&gt;&amp;1`. Emit the typed reason through the watcher’s stdout reason contract and add a real fm-watch-arm regression proving the concrete reason replaces the generic message.

🔧 Fix: fix(watch): surface typed failures through arm
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `tests/fm-supervision-events.test.sh`
- `tests/fm-watch-arm.test.sh`
- `tests/fm-backend-herdr.test.sh`
- <code>Real `bin/fm-watch-arm.sh` early-closing Herdr-reader fixture against target `f7cb12c`, review-1 predecessor `4c808b7`, and base `6789876`</code>
- <code>200,000-line early-match Herdr schema capability probe under `pipefail` against target and base</code>
- `Target supervision regression executed against base source to confirm failure before the fix`
- <code>`git status --short --branch` and scoped watcher-process check</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
