### PR TITLE
Fix Phase 0 Pi session evidence parity and privacy

### DIFF
--- a/bin/fm-session-usage.sh
+++ b/bin/fm-session-usage.sh
@@ -1,404 +1,222 @@
 #!/usr/bin/env bash
 # fm-session-usage.sh - read-only JSON report for an observed-stable Pi session.
 #
-# Usage:
-#   fm-session-usage.sh [--run-label <label>] [--role <role>]
-#     [--task <task>] [--attempt <number>] [--settle-ms <number>] <session.jsonl>
+# Usage: fm-session-usage.sh [--run-label <label>] [--role <role>]
+#   [--task <task>] [--attempt <number>] [--settle-ms <number>] <session.jsonl>
 #
-# The input must be a regular Pi JSONL session file. The report is final only
-# when the file has a session header, every non-blank line is valid JSON, and
-# the file identity and size stay unchanged while it is read and during the
-# settle check. A growing or replaced file is reported as non-final.
-#
-# Only top-level usage-bearing entries are measured. Compaction retained tails,
-# details, prompts, tool output, credentials, authenticated content, and source
-# paths are never emitted. Caller-supplied metadata is content-free only when it
-# uses the accepted tag syntax; primary versus worker identity is never guessed.
-# This phase does not create a correlation sidecar or add runtime instrumentation.
-# Provider usage and model-rate cost estimates are separate and neither is
+# Reads only a regular Pi JSONL artifact. final is true only for one header,
+# valid records, and an unchanged identity and size during read and settle.
+# Measures only top-level usage entries and emits no prompts, tool output,
+# credentials, authenticated content, or paths. Caller metadata is tag-only;
+# identity and correlation are never inferred or sidecar-backed.
+# Provider usage and model-rate estimates remain separate and neither means
 # subscription or quota consumption.
-set -euo pipefail
+set -eu
+command -v python3 >/dev/null 2>&1 || { printf 'fm-session-usage: python3 is required\n' >&2; exit 2; }
+exec python3 - "$@" <<'PY'
+import json, math, os, re, stat, sys, time
 
-usage() {
-  awk '
-    NR == 1 { next }
-    /^#/ { sub(/^# ?/, ""); print; next }
-    { exit }
-  ' "$0" >&2
-}
+TAG = re.compile(r"[A-Za-z0-9._:+,@-]{1,128}\Z")
+SESSION_ID = re.compile(r"[A-Za-z0-9._:-]{1,128}\Z")
+TOKENS = dict(input="input", cache_read="cacheRead", cache_write="cacheWrite",
+              output="output", reasoning="reasoning", provider_total="totalTokens")
+REQUIRED = {k: v for k, v in TOKENS.items() if k != "reasoning"}
+COSTS = dict(input="input", cache_read="cacheRead", cache_write="cacheWrite", output="output", total="total")
+HELP = """fm-session-usage.sh - read-only JSON report for an observed-stable Pi session.
 
-die() {
-  printf 'fm-session-usage: %s\n' "$*" >&2
-  exit 2
-}
+Usage: fm-session-usage.sh [--run-label <label>] [--role <role>]
+  [--task <task>] [--attempt <number>] [--settle-ms <number>] <session.jsonl>
+"""
 
-command -v jq >/dev/null 2>&1 || die 'jq is required'
 
-RUN_LABEL=
-ROLE=
-TASK=
-ATTEMPT=
-SETTLE_MS=10
-RUN_LABEL_SET=0
-ROLE_SET=0
-TASK_SET=0
-ATTEMPT_SET=0
+def fail(message):
+    print(f"fm-session-usage: {message}", file=sys.stderr)
+    raise SystemExit(2)
 
-validate_tag() {
-  local name=$1 value=$2
-  [ -n "$value" ] || die "$name must not be empty"
-  [ "${#value}" -le 128 ] || die "$name is too long"
-  case "$value" in
-    *[!A-Za-z0-9._:+,@-]*) die "$name must be a content-free tag" ;;
-  esac
-}
 
-validate_milliseconds() {
-  case "$1" in
-    ''|*[!0-9]*) die 'settle milliseconds must be a non-negative integer' ;;
-  esac
-  [ "$1" -le 60000 ] || die 'settle milliseconds must be at most 60000'
-}
+def parse(argv):
+    values = dict(run_label=None, role=None, task=None, attempt=None, settle_ms="10")
+    positional, options = [], {"--run-label", "--role", "--task", "--attempt", "--settle-ms"}
+    while argv:
+        arg = argv.pop(0)
+        if arg in ("-h", "--help"):
+            print(HELP, end="", file=sys.stderr); raise SystemExit(0)
+        if arg == "--":
+            positional.extend(argv); break
+        if arg in options:
+            if not argv: fail(f"{arg} requires a value")
+            values[arg[2:].replace("-", "_")] = argv.pop(0)
+        elif arg.startswith("-"):
+            fail("unknown option")
+        else:
+            positional.append(arg)
+    if len(positional) != 1 or positional[0].startswith("-"):
+        fail("one session JSONL path is required")
+    for key in ("run_label", "role", "task"):
+        if values[key] is not None and not TAG.fullmatch(values[key]):
+            fail(f"{key.replace('_', '-')} must be a content-free tag")
+    if values["attempt"] is not None and not re.fullmatch(r"[0-9]+", values["attempt"]):
+        fail("attempt must be a non-negative integer")
+    if not re.fullmatch(r"[0-9]+", values["settle_ms"]):
+        fail("settle milliseconds must be a non-negative integer")
+    values["settle_ms"] = int(values["settle_ms"])
+    if values["settle_ms"] > 60000:
+        fail("settle milliseconds must be between 0 and 60000")
+    return values, positional[0]
 
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    --run-label)
-      [ "$#" -ge 2 ] || die '--run-label requires a value'
-      RUN_LABEL=$2
-      validate_tag run-label "$RUN_LABEL"
-      RUN_LABEL_SET=1
-      shift 2
-      ;;
-    --role)
-      [ "$#" -ge 2 ] || die '--role requires a value'
-      ROLE=$2
-      validate_tag role "$ROLE"
-      ROLE_SET=1
-      shift 2
-      ;;
-    --task)
-      [ "$#" -ge 2 ] || die '--task requires a value'
-      TASK=$2
-      validate_tag task "$TASK"
-      TASK_SET=1
-      shift 2
-      ;;
-    --attempt)
-      [ "$#" -ge 2 ] || die '--attempt requires a value'
-      case "$2" in
-        ''|*[!0-9]*) die 'attempt must be a non-negative integer' ;;
-      esac
-      ATTEMPT=$2
-      ATTEMPT_SET=1
-      shift 2
-      ;;
-    --settle-ms)
-      [ "$#" -ge 2 ] || die '--settle-ms requires a value'
-      SETTLE_MS=$2
-      validate_milliseconds "$SETTLE_MS"
-      shift 2
-      ;;
-    --help|-h)
-      usage
-      exit 0
-      ;;
-    --)
-      shift
-      break
-      ;;
-    -*)
-      die "unknown option: $1"
-      ;;
-    *)
-      break
-      ;;
-  esac
-done
 
-[ "$#" -eq 1 ] || die 'one session JSONL path is required'
-SESSION_FILE=$1
-case "$SESSION_FILE" in
-  -*) die 'session path must not start with a dash' ;;
-esac
-[ -f "$SESSION_FILE" ] || die 'session path is not a readable regular file'
-[ -r "$SESSION_FILE" ] || die 'session path is not a readable regular file'
+def signature(path):
+    try:
+        info = os.stat(path)
+        return (info.st_dev, info.st_ino, info.st_size, info.st_mtime_ns, info.st_ctime_ns) \
+            if stat.S_ISREG(info.st_mode) else None
+    except OSError:
+        return None
 
-stat_signature() {
-  local path=$1 result
-  if result=$(stat -c '%d:%i:%s:%Y:%Z' "$path" 2>/dev/null); then
-    printf '%s\n' "$result"
-    return 0
-  fi
-  stat -f '%d:%i:%z:%m' "$path" 2>/dev/null
-}
 
-sleep_milliseconds() {
-  local milliseconds=$1 seconds fraction
-  [ "$milliseconds" -gt 0 ] || return 0
-  seconds=$((milliseconds / 1000))
-  fraction=$((milliseconds % 1000))
-  if [ "$seconds" -gt 0 ]; then
-    sleep "${seconds}.$(printf '%03d' "$fraction")"
-  else
-    sleep "0.$(printf '%03d' "$fraction")"
-  fi
-}
+def number(value):
+    try:
+        return None if isinstance(value, bool) or not isinstance(value, (int, float)) \
+            or not math.isfinite(value) or value < 0 else value
+    except (OverflowError, TypeError):
+        return None
 
-BEFORE_SIGNATURE=$(stat_signature "$SESSION_FILE") || die 'could not inspect session file'
-TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/fm-session-usage.XXXXXX") || die 'could not create a private temporary directory'
-RECORDS_FILE=$TMP_DIR/records.jsonl
-WARNINGS_FILE=$TMP_DIR/warnings.jsonl
-: >"$RECORDS_FILE"
-: >"$WARNINGS_FILE"
-cleanup() {
-  rm -rf "$TMP_DIR"
-}
-trap cleanup EXIT
 
-append_warning() {
-  printf '%s\n' "$1" >>"$WARNINGS_FILE"
-}
+def text(value):
+    return value if isinstance(value, str) and value else None
 
-exec 3<"$SESSION_FILE" || die 'could not open session file'
-LINE_NUMBER=0
-MALFORMED_COUNT=0
-while IFS= read -r line <&3 || [ -n "$line" ]; do
-  LINE_NUMBER=$((LINE_NUMBER + 1))
-  [ -n "$line" ] || continue
 
-  if ! json=$(printf '%s\n' "$line" | jq -c . 2>/dev/null); then
-    append_warning "{\"code\":\"malformed_json\",\"line\":$LINE_NUMBER}"
-    MALFORMED_COUNT=$((MALFORMED_COUNT + 1))
-    continue
-  fi
-  if ! printf '%s\n' "$json" | jq -e 'type == "object"' >/dev/null 2>&1; then
-    append_warning "{\"code\":\"record_not_object\",\"line\":$LINE_NUMBER}"
-    MALFORMED_COUNT=$((MALFORMED_COUNT + 1))
-    continue
-  fi
-  if ! printf '%s\n' "$json" | jq -c --argjson line "$LINE_NUMBER" '. + {"_fm_line": $line}' \
-    >>"$RECORDS_FILE" 2>/dev/null; then
-    append_warning "{\"code\":\"record_unreadable\",\"line\":$LINE_NUMBER}"
-    MALFORMED_COUNT=$((MALFORMED_COUNT + 1))
-  fi
-done
-exec 3<&-
+def provider_values(usage):
+    return {key: number(usage.get(source)) for key, source in TOKENS.items()} \
+        if isinstance(usage, dict) else None
 
-AFTER_READ_SIGNATURE=$(stat_signature "$SESSION_FILE" 2>/dev/null || true)
-sleep_milliseconds "$SETTLE_MS"
-AFTER_SETTLE_SIGNATURE=$(stat_signature "$SESSION_FILE" 2>/dev/null || true)
 
-STABILITY=stable
-STABLE_BOOL=true
-if [ -z "$AFTER_READ_SIGNATURE" ] || [ -z "$AFTER_SETTLE_SIGNATURE" ] || \
-  [ "$BEFORE_SIGNATURE" != "$AFTER_READ_SIGNATURE" ] || \
-  [ "$BEFORE_SIGNATURE" != "$AFTER_SETTLE_SIGNATURE" ]; then
-  STABILITY=unstable
-  STABLE_BOOL=false
-fi
+def cost_values(usage):
+    cost = usage.get("cost") if isinstance(usage, dict) else None
+    return {key: number(cost.get(source)) for key, source in COSTS.items()} \
+        if isinstance(cost, dict) else None
 
-jq -s \
-  --slurpfile input_warnings "$WARNINGS_FILE" \
-  --arg stability "$STABILITY" \
-  --argjson stable "$STABLE_BOOL" \
-  --argjson malformed "$MALFORMED_COUNT" \
-  --arg run_label "$RUN_LABEL" \
-  --arg role "$ROLE" \
-  --arg task "$TASK" \
-  --arg attempt "$ATTEMPT" \
-  --argjson run_label_set "$RUN_LABEL_SET" \
-  --argjson role_set "$ROLE_SET" \
-  --argjson task_set "$TASK_SET" \
-  --argjson attempt_set "$ATTEMPT_SET" \
-  '
-  def string_or_null($value):
-    if ($value | type) == "string" and ($value | length) > 0 then $value else null end;
 
-  def session_id_or_null($value):
-    if ($value | type) == "string" and ($value | test("^[A-Za-z0-9._:-]{1,128}$")) then $value else null end;
+def measurement(entry, entry_class, parent, provider=None, model=None):
+    usage = parent.get("usage")
+    state = "missing" if "usage" not in parent else "present" if isinstance(usage, dict) else "invalid"
+    return dict(entry_class=entry_class, line=entry["_line"], provider=text(provider), model=text(model),
+                usage_state=state, has_usage=state == "present", provider_usage=provider_values(usage),
+                model_rate_cost_estimate=cost_values(usage))
 
-  def nonnegative_number($value):
-    if ($value | type) == "number" and $value >= 0 then $value else null end;
 
-  def usage_object($value):
-    if ($value | type) == "object" then $value else null end;
+def measurements(entries):
+    result = []
+    for entry in entries:
+        message = entry.get("message")
+        if entry.get("type") == "message" and isinstance(message, dict):
+            role = message.get("role")
+            if role == "assistant":
+                result.append(measurement(entry, "assistant", message, message.get("provider"), message.get("model")))
+            elif role == "toolResult":
+                result.append(measurement(entry, "tool_result", message))
+        elif entry.get("type") in ("compaction", "branch_summary"):
+            result.append(measurement(entry, entry["type"], entry))
+    return result
 
-  def token_value($usage; $key):
-    nonnegative_number(($usage[$key] // null));
 
-  def cost_value($usage; $key):
-    nonnegative_number(($usage.cost[$key] // null));
+def usage_warnings(record):
+    if record["usage_state"] != "present":
+        return [dict(code=f"{record['usage_state']}_usage", entry_class=record["entry_class"], line=record["line"])]
+    warnings = [dict(code="unknown_usage_field", entry_class=record["entry_class"], field=field, line=record["line"])
+                for key, field in REQUIRED.items() if record["provider_usage"][key] is None]
+    if record["model_rate_cost_estimate"] is None:
+        warnings.append(dict(code="unknown_model_rate_cost", entry_class=record["entry_class"], line=record["line"]))
+    return warnings
 
-  def provider_usage($usage):
-    (usage_object($usage)) as $u |
-    if $u == null then null
-    else {
-      input: token_value($u; "input"),
-      cache_read: token_value($u; "cacheRead"),
-      cache_write: token_value($u; "cacheWrite"),
-      output: token_value($u; "output"),
-      reasoning: token_value($u; "reasoning"),
-      provider_total: token_value($u; "totalTokens")
-    }
-    end;
 
-  def model_rate_cost($usage):
-    (usage_object($usage)) as $u |
-    if $u == null or (($u.cost | type) != "object") then null
-    else {
-      input: cost_value($u; "input"),
-      cache_read: cost_value($u; "cacheRead"),
-      cache_write: cost_value($u; "cacheWrite"),
-      output: cost_value($u; "output"),
-      total: cost_value($u; "total")
-    }
-    end;
+def aggregate(records, section, key, zero_if_empty):
+    if not records:
+        return 0 if zero_if_empty else None
+    if any(not record["has_usage"] for record in records):
+        return None
+    values = [record[section][key] for record in records]
+    return sum(values) if all(value is not None for value in values) else None
 
-  def usage_state($parent):
-    if ($parent | type) != "object" or ($parent | has("usage") | not) then "missing"
-    elif (($parent.usage | type) != "object") then "invalid"
-    else "present"
-    end;
 
-  def measurement($entry; $entry_class; $parent; $provider; $model):
-    {
-      entry_class: $entry_class,
-      line: ($entry._fm_line // null),
-      provider: string_or_null($provider),
-      model: string_or_null($model),
-      usage_state: usage_state($parent),
-      has_usage: (usage_state($parent) == "present"),
-      provider_usage: provider_usage($parent.usage?),
-      model_rate_cost_estimate: model_rate_cost($parent.usage?)
-    };
+def report(values, path):
+    before = signature(path)
+    if before is None:
+        fail("session path is not a readable regular file")
+    entries, warnings, malformed = [], [], 0
 
-  def measurements($entries):
-    [
-      $entries[] as $entry |
-      if $entry.type == "message" and ($entry.message | type) == "object" and $entry.message.role == "assistant" then
-        measurement($entry; "assistant"; $entry.message; $entry.message.provider?; $entry.message.model?)
-      elif $entry.type == "message" and ($entry.message | type) == "object" and $entry.message.role == "toolResult" then
-        measurement($entry; "tool_result"; $entry.message; null; null)
-      elif $entry.type == "compaction" then
-        measurement($entry; "compaction"; $entry; null; null)
-      elif $entry.type == "branch_summary" then
-        measurement($entry; "branch_summary"; $entry; null; null)
-      else empty
-      end
-    ];
+    def reject_constant(value):
+        raise ValueError(value)
 
-  def usage_warnings($measurement):
-    if $measurement.usage_state == "missing" then
-      [{code: "missing_usage", entry_class: $measurement.entry_class, line: $measurement.line}]
-    elif $measurement.usage_state == "invalid" then
-      [{code: "invalid_usage", entry_class: $measurement.entry_class, line: $measurement.line}]
-    else
-      (
-        [
-          {key: "input", field: "input"},
-          {key: "cache_read", field: "cacheRead"},
-          {key: "cache_write", field: "cacheWrite"},
-          {key: "output", field: "output"},
-          {key: "provider_total", field: "totalTokens"}
-        ]
-        | map(select($measurement.provider_usage[.key] == null) |
-          {code: "unknown_usage_field", entry_class: $measurement.entry_class,
-           field: .field, line: $measurement.line})
-      ) +
-      if $measurement.model_rate_cost_estimate == null then
-        [{code: "unknown_model_rate_cost", entry_class: $measurement.entry_class, line: $measurement.line}]
-      else []
-      end
-    end;
+    try:
+        with open(path, encoding="utf-8", errors="replace") as source:
+            for line_no, line in enumerate(source, 1):
+                if not line.strip():
+                    continue
+                try:
+                    entry = json.loads(line, parse_constant=reject_constant)
+                except (TypeError, ValueError):
+                    warnings.append(dict(code="malformed_json", line=line_no)); malformed += 1; continue
+                if not isinstance(entry, dict):
+                    warnings.append(dict(code="record_not_object", line=line_no)); malformed += 1; continue
+                entry["_line"] = line_no; entries.append(entry)
+    except OSError:
+        fail("could not read session file")
 
-  def aggregate($measurements; $section; $key; $zero_if_empty):
-    if ($measurements | length) == 0 then
-      if $zero_if_empty then 0 else null end
-    elif any($measurements[]; .has_usage == false) then null
-    else
-      ($measurements | map(.[$section][$key])) as $values |
-      if any($values[]; . == null) then null
-      else reduce $values[] as $value (0; . + $value)
-      end
-    end;
+    after_read = signature(path)
+    if values["settle_ms"]:
+        time.sleep(values["settle_ms"] / 1000)
+    stable = before == after_read == signature(path)
+    records = measurements(entries)
+    headers = [entry for entry in entries if entry.get("type") == "session"]
+    header = headers[0] if headers else {}
+    for record in records:
+        warnings.extend(usage_warnings(record))
+    if not headers:
+        warnings.append(dict(code="missing_session_header"))
+    elif len(headers) > 1:
+        warnings.append(dict(code="multiple_session_headers"))
+    warnings.extend(dict(code="embedded_history_ignored", entry_class="compaction", line=entry["_line"])
+                    for entry in entries if entry.get("type") == "compaction" and isinstance(entry.get("retainedTail"), list))
+    if not stable:
+        warnings.append(dict(code="unstable_file"))
 
-  def aggregate_section($measurements; $section; $zero_if_empty):
-    {
-      input: aggregate($measurements; $section; "input"; $zero_if_empty),
-      cache_read: aggregate($measurements; $section; "cache_read"; $zero_if_empty),
-      cache_write: aggregate($measurements; $section; "cache_write"; $zero_if_empty),
-      output: aggregate($measurements; $section; "output"; $zero_if_empty),
-      reasoning: aggregate($measurements; $section; "reasoning"; false),
-      provider_total: aggregate($measurements; $section; "provider_total"; false)
-    };
+    def type_count(kind):
+        return sum(entry.get("type") == kind for entry in entries)
 
-  . as $entries |
-  (measurements($entries)) as $measurements |
-  ($entries | map(select(.type == "session"))) as $headers |
-  ($headers[0] // {}) as $header |
-  (
-    $input_warnings +
-    ([$measurements[] | usage_warnings(.)[]]) +
-    (if ($headers | length) == 0 then [{code: "missing_session_header"}]
-     elif ($headers | length) > 1 then [{code: "multiple_session_headers"}]
-     else [] end) +
-    ([$entries[] | select(.type == "compaction" and (.retainedTail | type) == "array") |
-      {code: "embedded_history_ignored", entry_class: "compaction", line: ._fm_line}]) +
-    (if $stable then [] else [{code: "unstable_file"}] end)
-  ) as $warnings |
-  {
-    schema: 1,
-    artifact: {
-      format: "pi-session-jsonl",
-      stability: $stability,
-      final: ($stable and ($malformed == 0) and (($headers | length) == 1))
-    },
-    session: {
-      id: session_id_or_null($header.id?),
-      version: if ($header.version | type) == "number" then $header.version else null end
-    },
-    metadata: {
-      run_label: if $run_label_set == 1 then $run_label else null end,
-      role: if $role_set == 1 then $role else null end,
-      task: if $task_set == 1 then $task else null end,
-      attempt: if $attempt_set == 1 then ($attempt | tonumber) else null end
-    },
-    entry_counts: {
-      parsed: ($entries | length),
-      malformed: $malformed,
-      session: ($entries | map(select(.type == "session")) | length),
-      message: ($entries | map(select(.type == "message")) | length),
-      user_message: ($entries | map(select(.type == "message" and (.message.role? // null) == "user")) | length),
-      assistant_message: ($entries | map(select(.type == "message" and (.message.role? // null) == "assistant")) | length),
-      tool_result_message: ($entries | map(select(.type == "message" and (.message.role? // null) == "toolResult")) | length),
-      compaction: ($entries | map(select(.type == "compaction")) | length),
-      branch_summary: ($entries | map(select(.type == "branch_summary")) | length),
-      other: ($entries | map(select(.type != "session" and .type != "message" and .type != "compaction" and .type != "branch_summary")) | length)
-    },
-    calls: {
-      assistant: ($entries | map(select(.type == "message" and (.message.role? // null) == "assistant")) | length),
-      tool: ([$entries[] | select(.type == "message") | .message.content? // [] | .[]? | select(type == "object" and .type == "toolCall")] | length),
-      tool_result: ($entries | map(select(.type == "message" and (.message.role? // null) == "toolResult")) | length),
-      compaction: ($entries | map(select(.type == "compaction")) | length),
-      branch_summary: ($entries | map(select(.type == "branch_summary")) | length),
-      measured: ($measurements | map(select(.has_usage)) | length)
-    },
-    records: $measurements,
-    totals: {
-      provider_usage: aggregate_section($measurements; "provider_usage"; true),
-      model_rate_cost_estimate: {
-        input: aggregate($measurements; "model_rate_cost_estimate"; "input"; true),
-        cache_read: aggregate($measurements; "model_rate_cost_estimate"; "cache_read"; true),
-        cache_write: aggregate($measurements; "model_rate_cost_estimate"; "cache_write"; true),
-        output: aggregate($measurements; "model_rate_cost_estimate"; "output"; true),
-        total: aggregate($measurements; "model_rate_cost_estimate"; "total"; true)
-      }
-    },
-    warnings: $warnings,
-    limitations: [
-      "final means the regular file stayed unchanged during this read and settle check; Pi JSONL has no closed marker.",
-      "Provider usage is not subscription or quota consumption, and model-rate cost is an estimate rather than a billing record.",
-      "Worker identity and run correlation are caller-supplied only; this parser does not infer primary versus worker or create a sidecar."
-    ]
-  }
-' "$RECORDS_FILE"
+    def role_count(role):
+        return sum(entry.get("type") == "message" and isinstance(entry.get("message"), dict)
+                   and entry["message"].get("role") == role for entry in entries)
+
+    tool_calls = sum(isinstance(block, dict) and block.get("type") == "toolCall"
+                     for entry in entries if entry.get("type") == "message" and isinstance(entry.get("message"), dict)
+                     for block in (entry["message"].get("content") if isinstance(entry["message"].get("content"), list) else []))
+    known = {"session", "message", "compaction", "branch_summary"}
+    counts = dict(parsed=len(entries), malformed=malformed, session=type_count("session"), message=type_count("message"),
+                  user_message=role_count("user"), assistant_message=role_count("assistant"),
+                  tool_result_message=role_count("toolResult"), compaction=type_count("compaction"),
+                  branch_summary=type_count("branch_summary"), other=sum(entry.get("type") not in known for entry in entries))
+    calls = dict(assistant=role_count("assistant"), tool=tool_calls, tool_result=role_count("toolResult"),
+                 compaction=type_count("compaction"), branch_summary=type_count("branch_summary"),
+                 measured=sum(record["has_usage"] for record in records))
+    provider = {key: aggregate(records, "provider_usage", key, key not in ("reasoning", "provider_total")) for key in TOKENS}
+    model_cost = {key: aggregate(records, "model_rate_cost_estimate", key, True) for key in COSTS}
+    session_id = text(header.get("id"))
+    report_data = dict(schema=1,
+        artifact=dict(format="pi-session-jsonl", stability="stable" if stable else "unstable",
+                      final=stable and malformed == 0 and len(headers) == 1),
+        session=dict(id=session_id if session_id and SESSION_ID.fullmatch(session_id) else None,
+                     version=header.get("version") if isinstance(header.get("version"), (int, float)) and not isinstance(header.get("version"), bool) else None),
+        metadata=dict(run_label=values["run_label"], role=values["role"], task=values["task"],
+                      attempt=int(values["attempt"]) if values["attempt"] is not None else None),
+        entry_counts=counts, calls=calls, records=records,
+        totals=dict(provider_usage=provider, model_rate_cost_estimate=model_cost), warnings=warnings,
+        limitations=["final means the regular file stayed unchanged during this read and settle check; Pi JSONL has no closed marker.",
+                     "Provider usage is not subscription or quota consumption, and model-rate cost is an estimate rather than a billing record.",
+                     "Worker identity and run correlation are caller-supplied only; this parser does not infer primary versus worker or create a sidecar."])
+    json.dump(report_data, sys.stdout, indent=2); print()
+
+
+values, session_path = parse(sys.argv[1:])
+report(values, session_path)
+PY

--- a/bin/fm-session-usage.sh
+++ b/bin/fm-session-usage.sh
@@ -134,6 +134,11 @@ def usage_warnings(record):
                 for key, field in REQUIRED.items() if record["provider_usage"][key] is None]
     if record["model_rate_cost_estimate"] is None:
         warnings.append(dict(code="unknown_model_rate_cost", entry_class=record["entry_class"], line=record["line"]))
+    else:
+        warnings.extend(dict(code="unknown_model_rate_cost_field", entry_class=record["entry_class"],
+                             field=field, line=record["line"])
+                        for key, field in COSTS.items()
+                        if record["model_rate_cost_estimate"][key] is None)
     return warnings
 
 
@@ -142,7 +147,8 @@ def aggregate(records, section, key, zero_if_empty):
         return 0 if zero_if_empty else None
     if any(not record["has_usage"] for record in records):
         return None
-    values = [record[section][key] for record in records]
+    values = [record[section].get(key) if isinstance(record[section], dict) else None
+              for record in records]
     return sum(values) if all(value is not None for value in values) else None
 
 

--- a/bin/fm-session-usage.sh
+++ b/bin/fm-session-usage.sh
@@ -1,0 +1,404 @@
+#!/usr/bin/env bash
+# fm-session-usage.sh - read-only JSON report for an observed-stable Pi session.
+#
+# Usage:
+#   fm-session-usage.sh [--run-label <label>] [--role <role>]
+#     [--task <task>] [--attempt <number>] [--settle-ms <number>] <session.jsonl>
+#
+# The input must be a regular Pi JSONL session file. The report is final only
+# when the file has a session header, every non-blank line is valid JSON, and
+# the file identity and size stay unchanged while it is read and during the
+# settle check. A growing or replaced file is reported as non-final.
+#
+# Only top-level usage-bearing entries are measured. Compaction retained tails,
+# details, prompts, tool output, credentials, authenticated content, and source
+# paths are never emitted. Caller-supplied metadata is content-free only when it
+# uses the accepted tag syntax; primary versus worker identity is never guessed.
+# This phase does not create a correlation sidecar or add runtime instrumentation.
+# Provider usage and model-rate cost estimates are separate and neither is
+# subscription or quota consumption.
+set -euo pipefail
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0" >&2
+}
+
+die() {
+  printf 'fm-session-usage: %s\n' "$*" >&2
+  exit 2
+}
+
+command -v jq >/dev/null 2>&1 || die 'jq is required'
+
+RUN_LABEL=
+ROLE=
+TASK=
+ATTEMPT=
+SETTLE_MS=10
+RUN_LABEL_SET=0
+ROLE_SET=0
+TASK_SET=0
+ATTEMPT_SET=0
+
+validate_tag() {
+  local name=$1 value=$2
+  [ -n "$value" ] || die "$name must not be empty"
+  [ "${#value}" -le 128 ] || die "$name is too long"
+  case "$value" in
+    *[!A-Za-z0-9._:+,@-]*) die "$name must be a content-free tag" ;;
+  esac
+}
+
+validate_milliseconds() {
+  case "$1" in
+    ''|*[!0-9]*) die 'settle milliseconds must be a non-negative integer' ;;
+  esac
+  [ "$1" -le 60000 ] || die 'settle milliseconds must be at most 60000'
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --run-label)
+      [ "$#" -ge 2 ] || die '--run-label requires a value'
+      RUN_LABEL=$2
+      validate_tag run-label "$RUN_LABEL"
+      RUN_LABEL_SET=1
+      shift 2
+      ;;
+    --role)
+      [ "$#" -ge 2 ] || die '--role requires a value'
+      ROLE=$2
+      validate_tag role "$ROLE"
+      ROLE_SET=1
+      shift 2
+      ;;
+    --task)
+      [ "$#" -ge 2 ] || die '--task requires a value'
+      TASK=$2
+      validate_tag task "$TASK"
+      TASK_SET=1
+      shift 2
+      ;;
+    --attempt)
+      [ "$#" -ge 2 ] || die '--attempt requires a value'
+      case "$2" in
+        ''|*[!0-9]*) die 'attempt must be a non-negative integer' ;;
+      esac
+      ATTEMPT=$2
+      ATTEMPT_SET=1
+      shift 2
+      ;;
+    --settle-ms)
+      [ "$#" -ge 2 ] || die '--settle-ms requires a value'
+      SETTLE_MS=$2
+      validate_milliseconds "$SETTLE_MS"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      die "unknown option: $1"
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+[ "$#" -eq 1 ] || die 'one session JSONL path is required'
+SESSION_FILE=$1
+case "$SESSION_FILE" in
+  -*) die 'session path must not start with a dash' ;;
+esac
+[ -f "$SESSION_FILE" ] || die 'session path is not a readable regular file'
+[ -r "$SESSION_FILE" ] || die 'session path is not a readable regular file'
+
+stat_signature() {
+  local path=$1 result
+  if result=$(stat -c '%d:%i:%s:%Y:%Z' "$path" 2>/dev/null); then
+    printf '%s\n' "$result"
+    return 0
+  fi
+  stat -f '%d:%i:%z:%m' "$path" 2>/dev/null
+}
+
+sleep_milliseconds() {
+  local milliseconds=$1 seconds fraction
+  [ "$milliseconds" -gt 0 ] || return 0
+  seconds=$((milliseconds / 1000))
+  fraction=$((milliseconds % 1000))
+  if [ "$seconds" -gt 0 ]; then
+    sleep "${seconds}.$(printf '%03d' "$fraction")"
+  else
+    sleep "0.$(printf '%03d' "$fraction")"
+  fi
+}
+
+BEFORE_SIGNATURE=$(stat_signature "$SESSION_FILE") || die 'could not inspect session file'
+TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/fm-session-usage.XXXXXX") || die 'could not create a private temporary directory'
+RECORDS_FILE=$TMP_DIR/records.jsonl
+WARNINGS_FILE=$TMP_DIR/warnings.jsonl
+: >"$RECORDS_FILE"
+: >"$WARNINGS_FILE"
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+append_warning() {
+  printf '%s\n' "$1" >>"$WARNINGS_FILE"
+}
+
+exec 3<"$SESSION_FILE" || die 'could not open session file'
+LINE_NUMBER=0
+MALFORMED_COUNT=0
+while IFS= read -r line <&3 || [ -n "$line" ]; do
+  LINE_NUMBER=$((LINE_NUMBER + 1))
+  [ -n "$line" ] || continue
+
+  if ! json=$(printf '%s\n' "$line" | jq -c . 2>/dev/null); then
+    append_warning "{\"code\":\"malformed_json\",\"line\":$LINE_NUMBER}"
+    MALFORMED_COUNT=$((MALFORMED_COUNT + 1))
+    continue
+  fi
+  if ! printf '%s\n' "$json" | jq -e 'type == "object"' >/dev/null 2>&1; then
+    append_warning "{\"code\":\"record_not_object\",\"line\":$LINE_NUMBER}"
+    MALFORMED_COUNT=$((MALFORMED_COUNT + 1))
+    continue
+  fi
+  if ! printf '%s\n' "$json" | jq -c --argjson line "$LINE_NUMBER" '. + {"_fm_line": $line}' \
+    >>"$RECORDS_FILE" 2>/dev/null; then
+    append_warning "{\"code\":\"record_unreadable\",\"line\":$LINE_NUMBER}"
+    MALFORMED_COUNT=$((MALFORMED_COUNT + 1))
+  fi
+done
+exec 3<&-
+
+AFTER_READ_SIGNATURE=$(stat_signature "$SESSION_FILE" 2>/dev/null || true)
+sleep_milliseconds "$SETTLE_MS"
+AFTER_SETTLE_SIGNATURE=$(stat_signature "$SESSION_FILE" 2>/dev/null || true)
+
+STABILITY=stable
+STABLE_BOOL=true
+if [ -z "$AFTER_READ_SIGNATURE" ] || [ -z "$AFTER_SETTLE_SIGNATURE" ] || \
+  [ "$BEFORE_SIGNATURE" != "$AFTER_READ_SIGNATURE" ] || \
+  [ "$BEFORE_SIGNATURE" != "$AFTER_SETTLE_SIGNATURE" ]; then
+  STABILITY=unstable
+  STABLE_BOOL=false
+fi
+
+jq -s \
+  --slurpfile input_warnings "$WARNINGS_FILE" \
+  --arg stability "$STABILITY" \
+  --argjson stable "$STABLE_BOOL" \
+  --argjson malformed "$MALFORMED_COUNT" \
+  --arg run_label "$RUN_LABEL" \
+  --arg role "$ROLE" \
+  --arg task "$TASK" \
+  --arg attempt "$ATTEMPT" \
+  --argjson run_label_set "$RUN_LABEL_SET" \
+  --argjson role_set "$ROLE_SET" \
+  --argjson task_set "$TASK_SET" \
+  --argjson attempt_set "$ATTEMPT_SET" \
+  '
+  def string_or_null($value):
+    if ($value | type) == "string" and ($value | length) > 0 then $value else null end;
+
+  def session_id_or_null($value):
+    if ($value | type) == "string" and ($value | test("^[A-Za-z0-9._:-]{1,128}$")) then $value else null end;
+
+  def nonnegative_number($value):
+    if ($value | type) == "number" and $value >= 0 then $value else null end;
+
+  def usage_object($value):
+    if ($value | type) == "object" then $value else null end;
+
+  def token_value($usage; $key):
+    nonnegative_number(($usage[$key] // null));
+
+  def cost_value($usage; $key):
+    nonnegative_number(($usage.cost[$key] // null));
+
+  def provider_usage($usage):
+    (usage_object($usage)) as $u |
+    if $u == null then null
+    else {
+      input: token_value($u; "input"),
+      cache_read: token_value($u; "cacheRead"),
+      cache_write: token_value($u; "cacheWrite"),
+      output: token_value($u; "output"),
+      reasoning: token_value($u; "reasoning"),
+      provider_total: token_value($u; "totalTokens")
+    }
+    end;
+
+  def model_rate_cost($usage):
+    (usage_object($usage)) as $u |
+    if $u == null or (($u.cost | type) != "object") then null
+    else {
+      input: cost_value($u; "input"),
+      cache_read: cost_value($u; "cacheRead"),
+      cache_write: cost_value($u; "cacheWrite"),
+      output: cost_value($u; "output"),
+      total: cost_value($u; "total")
+    }
+    end;
+
+  def usage_state($parent):
+    if ($parent | type) != "object" or ($parent | has("usage") | not) then "missing"
+    elif (($parent.usage | type) != "object") then "invalid"
+    else "present"
+    end;
+
+  def measurement($entry; $entry_class; $parent; $provider; $model):
+    {
+      entry_class: $entry_class,
+      line: ($entry._fm_line // null),
+      provider: string_or_null($provider),
+      model: string_or_null($model),
+      usage_state: usage_state($parent),
+      has_usage: (usage_state($parent) == "present"),
+      provider_usage: provider_usage($parent.usage?),
+      model_rate_cost_estimate: model_rate_cost($parent.usage?)
+    };
+
+  def measurements($entries):
+    [
+      $entries[] as $entry |
+      if $entry.type == "message" and ($entry.message | type) == "object" and $entry.message.role == "assistant" then
+        measurement($entry; "assistant"; $entry.message; $entry.message.provider?; $entry.message.model?)
+      elif $entry.type == "message" and ($entry.message | type) == "object" and $entry.message.role == "toolResult" then
+        measurement($entry; "tool_result"; $entry.message; null; null)
+      elif $entry.type == "compaction" then
+        measurement($entry; "compaction"; $entry; null; null)
+      elif $entry.type == "branch_summary" then
+        measurement($entry; "branch_summary"; $entry; null; null)
+      else empty
+      end
+    ];
+
+  def usage_warnings($measurement):
+    if $measurement.usage_state == "missing" then
+      [{code: "missing_usage", entry_class: $measurement.entry_class, line: $measurement.line}]
+    elif $measurement.usage_state == "invalid" then
+      [{code: "invalid_usage", entry_class: $measurement.entry_class, line: $measurement.line}]
+    else
+      (
+        [
+          {key: "input", field: "input"},
+          {key: "cache_read", field: "cacheRead"},
+          {key: "cache_write", field: "cacheWrite"},
+          {key: "output", field: "output"},
+          {key: "provider_total", field: "totalTokens"}
+        ]
+        | map(select($measurement.provider_usage[.key] == null) |
+          {code: "unknown_usage_field", entry_class: $measurement.entry_class,
+           field: .field, line: $measurement.line})
+      ) +
+      if $measurement.model_rate_cost_estimate == null then
+        [{code: "unknown_model_rate_cost", entry_class: $measurement.entry_class, line: $measurement.line}]
+      else []
+      end
+    end;
+
+  def aggregate($measurements; $section; $key; $zero_if_empty):
+    if ($measurements | length) == 0 then
+      if $zero_if_empty then 0 else null end
+    elif any($measurements[]; .has_usage == false) then null
+    else
+      ($measurements | map(.[$section][$key])) as $values |
+      if any($values[]; . == null) then null
+      else reduce $values[] as $value (0; . + $value)
+      end
+    end;
+
+  def aggregate_section($measurements; $section; $zero_if_empty):
+    {
+      input: aggregate($measurements; $section; "input"; $zero_if_empty),
+      cache_read: aggregate($measurements; $section; "cache_read"; $zero_if_empty),
+      cache_write: aggregate($measurements; $section; "cache_write"; $zero_if_empty),
+      output: aggregate($measurements; $section; "output"; $zero_if_empty),
+      reasoning: aggregate($measurements; $section; "reasoning"; false),
+      provider_total: aggregate($measurements; $section; "provider_total"; false)
+    };
+
+  . as $entries |
+  (measurements($entries)) as $measurements |
+  ($entries | map(select(.type == "session"))) as $headers |
+  ($headers[0] // {}) as $header |
+  (
+    $input_warnings +
+    ([$measurements[] | usage_warnings(.)[]]) +
+    (if ($headers | length) == 0 then [{code: "missing_session_header"}]
+     elif ($headers | length) > 1 then [{code: "multiple_session_headers"}]
+     else [] end) +
+    ([$entries[] | select(.type == "compaction" and (.retainedTail | type) == "array") |
+      {code: "embedded_history_ignored", entry_class: "compaction", line: ._fm_line}]) +
+    (if $stable then [] else [{code: "unstable_file"}] end)
+  ) as $warnings |
+  {
+    schema: 1,
+    artifact: {
+      format: "pi-session-jsonl",
+      stability: $stability,
+      final: ($stable and ($malformed == 0) and (($headers | length) == 1))
+    },
+    session: {
+      id: session_id_or_null($header.id?),
+      version: if ($header.version | type) == "number" then $header.version else null end
+    },
+    metadata: {
+      run_label: if $run_label_set == 1 then $run_label else null end,
+      role: if $role_set == 1 then $role else null end,
+      task: if $task_set == 1 then $task else null end,
+      attempt: if $attempt_set == 1 then ($attempt | tonumber) else null end
+    },
+    entry_counts: {
+      parsed: ($entries | length),
+      malformed: $malformed,
+      session: ($entries | map(select(.type == "session")) | length),
+      message: ($entries | map(select(.type == "message")) | length),
+      user_message: ($entries | map(select(.type == "message" and (.message.role? // null) == "user")) | length),
+      assistant_message: ($entries | map(select(.type == "message" and (.message.role? // null) == "assistant")) | length),
+      tool_result_message: ($entries | map(select(.type == "message" and (.message.role? // null) == "toolResult")) | length),
+      compaction: ($entries | map(select(.type == "compaction")) | length),
+      branch_summary: ($entries | map(select(.type == "branch_summary")) | length),
+      other: ($entries | map(select(.type != "session" and .type != "message" and .type != "compaction" and .type != "branch_summary")) | length)
+    },
+    calls: {
+      assistant: ($entries | map(select(.type == "message" and (.message.role? // null) == "assistant")) | length),
+      tool: ([$entries[] | select(.type == "message") | .message.content? // [] | .[]? | select(type == "object" and .type == "toolCall")] | length),
+      tool_result: ($entries | map(select(.type == "message" and (.message.role? // null) == "toolResult")) | length),
+      compaction: ($entries | map(select(.type == "compaction")) | length),
+      branch_summary: ($entries | map(select(.type == "branch_summary")) | length),
+      measured: ($measurements | map(select(.has_usage)) | length)
+    },
+    records: $measurements,
+    totals: {
+      provider_usage: aggregate_section($measurements; "provider_usage"; true),
+      model_rate_cost_estimate: {
+        input: aggregate($measurements; "model_rate_cost_estimate"; "input"; true),
+        cache_read: aggregate($measurements; "model_rate_cost_estimate"; "cache_read"; true),
+        cache_write: aggregate($measurements; "model_rate_cost_estimate"; "cache_write"; true),
+        output: aggregate($measurements; "model_rate_cost_estimate"; "output"; true),
+        total: aggregate($measurements; "model_rate_cost_estimate"; "total"; true)
+      }
+    },
+    warnings: $warnings,
+    limitations: [
+      "final means the regular file stayed unchanged during this read and settle check; Pi JSONL has no closed marker.",
+      "Provider usage is not subscription or quota consumption, and model-rate cost is an estimate rather than a billing record.",
+      "Worker identity and run correlation are caller-supplied only; this parser does not infer primary versus worker or create a sidecar."
+    ]
+  }
+' "$RECORDS_FILE"

--- a/bin/fm-session-usage.sh
+++ b/bin/fm-session-usage.sh
@@ -4,8 +4,9 @@
 # Usage: fm-session-usage.sh [--run-label <label>] [--role <role>]
 #   [--task <task>] [--attempt <number>] [--settle-ms <number>] <session.jsonl>
 #
-# Reads only a regular Pi JSONL artifact. final is true only for one header,
-# valid records, and an unchanged identity and size during read and settle.
+# Reads only a regular Pi JSONL artifact. final means observed-stable: one
+# first header, valid records, and unchanged identity and size during read and settle.
+# It does not prove permanent closure because Pi JSONL has no closed marker.
 # Measures only top-level usage entries and emits no prompts, tool output,
 # credentials, authenticated content, or paths. Caller metadata is tag-only;
 # identity and correlation are never inferred or sidecar-backed.
@@ -14,7 +15,7 @@
 set -eu
 command -v python3 >/dev/null 2>&1 || { printf 'fm-session-usage: python3 is required\n' >&2; exit 2; }
 exec python3 - "$@" <<'PY'
-import json, math, os, re, stat, sys, time
+import hashlib, json, math, os, re, stat, sys, time
 
 TAG = re.compile(r"[A-Za-z0-9._:+,@-]{1,128}\Z")
 SESSION_ID = re.compile(r"[A-Za-z0-9._:-]{1,128}\Z")
@@ -86,6 +87,11 @@ def text(value):
     return value if isinstance(value, str) and value else None
 
 
+def session_id_digest(value):
+    value = text(value)
+    return hashlib.sha256(value.encode()).hexdigest() if value and SESSION_ID.fullmatch(value) else None
+
+
 def provider_values(usage):
     return {key: number(usage.get(source)) for key, source in TOKENS.items()} \
         if isinstance(usage, dict) else None
@@ -112,10 +118,11 @@ def measurements(entries):
         if entry.get("type") == "message" and isinstance(message, dict):
             role = message.get("role")
             if role == "assistant":
-                result.append(measurement(entry, "assistant", message, message.get("provider"), message.get("model")))
-            elif role == "toolResult":
+                model = text(message.get("responseModel")) or text(message.get("model"))
+                result.append(measurement(entry, "assistant", message, message.get("provider"), model))
+            elif role == "toolResult" and "usage" in message:
                 result.append(measurement(entry, "tool_result", message))
-        elif entry.get("type") in ("compaction", "branch_summary"):
+        elif entry.get("type") in ("compaction", "branch_summary") and "usage" in entry:
             result.append(measurement(entry, entry["type"], entry))
     return result
 
@@ -170,12 +177,15 @@ def report(values, path):
     records = measurements(entries)
     headers = [entry for entry in entries if entry.get("type") == "session"]
     header = headers[0] if headers else {}
+    first_is_header = bool(entries and entries[0].get("type") == "session")
     for record in records:
         warnings.extend(usage_warnings(record))
     if not headers:
         warnings.append(dict(code="missing_session_header"))
     elif len(headers) > 1:
         warnings.append(dict(code="multiple_session_headers"))
+    if headers and not first_is_header:
+        warnings.append(dict(code="session_header_not_first", line=headers[0]["_line"]))
     warnings.extend(dict(code="embedded_history_ignored", entry_class="compaction", line=entry["_line"])
                     for entry in entries if entry.get("type") == "compaction" and isinstance(entry.get("retainedTail"), list))
     if not stable:
@@ -201,17 +211,17 @@ def report(values, path):
                  measured=sum(record["has_usage"] for record in records))
     provider = {key: aggregate(records, "provider_usage", key, key not in ("reasoning", "provider_total")) for key in TOKENS}
     model_cost = {key: aggregate(records, "model_rate_cost_estimate", key, True) for key in COSTS}
-    session_id = text(header.get("id"))
     report_data = dict(schema=1,
         artifact=dict(format="pi-session-jsonl", stability="stable" if stable else "unstable",
-                      final=stable and malformed == 0 and len(headers) == 1),
-        session=dict(id=session_id if session_id and SESSION_ID.fullmatch(session_id) else None,
+                      final=stable and malformed == 0 and len(headers) == 1 and first_is_header),
+        session=dict(id=session_id_digest(header.get("id")),
                      version=header.get("version") if isinstance(header.get("version"), (int, float)) and not isinstance(header.get("version"), bool) else None),
         metadata=dict(run_label=values["run_label"], role=values["role"], task=values["task"],
                       attempt=int(values["attempt"]) if values["attempt"] is not None else None),
         entry_counts=counts, calls=calls, records=records,
         totals=dict(provider_usage=provider, model_rate_cost_estimate=model_cost), warnings=warnings,
-        limitations=["final means the regular file stayed unchanged during this read and settle check; Pi JSONL has no closed marker.",
+        limitations=["final means observed-stable: the first record is the only session header, all records are valid, and the regular file stayed unchanged during this read and settle check. It does not prove permanent closure because Pi JSONL has no closed marker.",
+                     "Session IDs are emitted only as SHA-256 digests; source paths and session content are never emitted.",
                      "Provider usage is not subscription or quota consumption, and model-rate cost is an estimate rather than a billing record.",
                      "Worker identity and run correlation are caller-supplied only; this parser does not infer primary versus worker or create a sidecar."])
     json.dump(report_data, sys.stdout, indent=2); print()

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1123,9 +1123,9 @@ launch_template() {
     pi|pi-signed)
       printf '%s' '__PIBIN____PITUIMODE__'
       if [ "$kind" = secondmate ]; then
-        printf '%s' ' __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' ' __PIRESOURCEFLAGS____MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       else
-        printf '%s' ' __MODELFLAG____EFFORTFLAG__-e __PIEXT__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' ' __PIRESOURCEFLAGS____MODELFLAG____EFFORTFLAG__-e __PIEXT__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       fi
       ;;
     # grok (Grok Build TUI): a positional prompt starts the supervised interactive
@@ -2714,6 +2714,35 @@ sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
 sq_worktree=$(shell_quote "$WT")
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
+PIRESOURCEFLAGS=
+if [ "$HARNESS" = pi ] || [ "$HARNESS" = pi-signed ]; then
+  PI_AGENT_HOME=${PI_CODING_AGENT_DIR:-${HOME:-}/.pi/agent}
+  [ -n "$PI_AGENT_HOME" ] || { echo "error: cannot resolve Pi agent home for the local extension allowlist" >&2; exit 1; }
+  PIRESOURCEFLAGS='-ne '
+  if [ "$KIND" != secondmate ]; then
+    PI_FFF_EXTENSION="$PI_AGENT_HOME/npm/node_modules/@ff-labs/pi-fff/src/index.ts"
+    [ -f "$PI_FFF_EXTENSION" ] || { echo "error: required Pi worker extension missing: $PI_FFF_EXTENSION" >&2; exit 1; }
+    PIRESOURCEFLAGS="${PIRESOURCEFLAGS}-e $(shell_quote "$PI_FFF_EXTENSION") "
+  fi
+  if [ "$KIND" = scout ]; then
+    PI_WEB_EXTENSION="$PI_AGENT_HOME/extensions/pi-web-access/index.ts"
+    [ -f "$PI_WEB_EXTENSION" ] || { echo "error: required Pi scout extension missing: $PI_WEB_EXTENSION" >&2; exit 1; }
+    PIRESOURCEFLAGS="${PIRESOURCEFLAGS}-e $(shell_quote "$PI_WEB_EXTENSION") "
+  fi
+  if [ "$BACKEND" = herdr ]; then
+    PI_HERDR_EXTENSION="$PI_AGENT_HOME/extensions/herdr-agent-state.ts"
+    [ -f "$PI_HERDR_EXTENSION" ] || { echo "error: required Herdr Pi extension missing: $PI_HERDR_EXTENSION" >&2; exit 1; }
+    PIRESOURCEFLAGS="${PIRESOURCEFLAGS}-e $(shell_quote "$PI_HERDR_EXTENSION") "
+  fi
+  case "$MODEL" in
+    openai/*|openai-codex/*|openai-codex-fast/*)
+      PI_COMPACTION_EXTENSION="$PI_AGENT_HOME/extensions/pi-openai-server-compaction/src/index.ts"
+      [ -f "$PI_COMPACTION_EXTENSION" ] || { echo "error: required OpenAI Pi extension missing: $PI_COMPACTION_EXTENSION" >&2; exit 1; }
+      PIRESOURCEFLAGS="${PIRESOURCEFLAGS}-e $(shell_quote "$PI_COMPACTION_EXTENSION") "
+      ;;
+  esac
+fi
+LAUNCH=${LAUNCH//__PIRESOURCEFLAGS__/$PIRESOURCEFLAGS}
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
 LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -3505,8 +3505,17 @@ JS
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/export $export_file"
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
-  wait_for_text "$export_snapshot" "Session exported to: $export_file" \
-    || fail "/export did not complete while calm mode was on"
+  # Pi writes the export artifact reliably, but its pane status wording is not a
+  # stable contract across Pi releases. The file is the export completion signal;
+  # the HTML/session assertions below validate its contents.
+  active_wait=0
+  while [ ! -s "$export_file" ] && [ "$active_wait" -lt 120 ]; do
+    tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S -600 >"$export_snapshot" 2>/dev/null || true
+    sleep 0.05
+    active_wait=$((active_wait + 1))
+  done
+  tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S -600 >"$export_snapshot" 2>/dev/null || true
+  [ -s "$export_file" ] || fail "/export did not create the HTML session artifact while calm mode was on"
   node - "$export_file" <<'JS' || fail "calm-mode HTML export lost tool data or persisted synthetic provenance"
 const html = require("node:fs").readFileSync(process.argv[2], "utf8");
 const match = html.match(/<script id="session-data" type="application\/json">([^<]+)<\/script>/);

--- a/tests/fm-session-usage.test.sh
+++ b/tests/fm-session-usage.test.sh
@@ -7,7 +7,7 @@ set -u
 
 PARSER="$ROOT/bin/fm-session-usage.sh"
 TMP_ROOT=$(fm_test_tmproot fm-session-usage)
-FULL="$TMP_ROOT/full.jsonl"; MISSING="$TMP_ROOT/missing.jsonl"; MALFORMED="$TMP_ROOT/malformed.jsonl"; UNSTABLE="$TMP_ROOT/unstable.jsonl"; OPTIONAL="$TMP_ROOT/optional.jsonl"; LATE="$TMP_ROOT/late.jsonl"
+FULL="$TMP_ROOT/full.jsonl"; MISSING="$TMP_ROOT/missing.jsonl"; MALFORMED="$TMP_ROOT/malformed.jsonl"; UNSTABLE="$TMP_ROOT/unstable.jsonl"; OPTIONAL="$TMP_ROOT/optional.jsonl"; LATE="$TMP_ROOT/late.jsonl"; COST_INVALID="$TMP_ROOT/cost-invalid.jsonl"; COST_PARTIAL="$TMP_ROOT/cost-partial.jsonl"
 cat >"$FULL" <<'EOF'
 {"type":"session","version":3,"id":"session-phase0","timestamp":"2026-01-01T00:00:00.000Z","cwd":"/secret/project","parentSession":"/secret/parent.jsonl"}
 {"type":"message","id":"user-1","message":{"role":"user","content":"PROMPT_SECRET_DO_NOT_PRINT"}}
@@ -37,6 +37,15 @@ cat >"$LATE" <<'EOF'
 {"type":"message","id":"user-late","message":{"role":"user","content":"late"}}
 {"type":"session","version":3,"id":"late-header","cwd":"/tmp/phase0"}
 EOF
+cat >"$COST_INVALID" <<'EOF'
+{"type":"session","version":3,"id":"cost-invalid","cwd":"/tmp/phase0"}
+{"type":"message","message":{"role":"assistant","provider":"test-provider","model":"test-model","usage":{"input":1,"output":2,"cacheRead":3,"cacheWrite":4,"totalTokens":10}}}
+{"type":"message","message":{"role":"assistant","provider":"test-provider","model":"test-model","usage":{"input":1,"output":2,"cacheRead":3,"cacheWrite":4,"totalTokens":10,"cost":"not-an-object"}}}
+EOF
+cat >"$COST_PARTIAL" <<'EOF'
+{"type":"session","version":3,"id":"cost-partial","cwd":"/tmp/phase0"}
+{"type":"message","message":{"role":"assistant","provider":"test-provider","model":"test-model","usage":{"input":1,"output":2,"cacheRead":3,"cacheWrite":4,"totalTokens":10,"cost":{"input":0.1,"output":"invalid","cacheRead":0.2,"total":0.3}}}}
+EOF
 
 check() { local input=$1 filter=$2 message=$3; shift 3; printf '%s\n' "$input" | jq -e "$@" "$filter" >/dev/null || fail "$message"; }
 report=$("$PARSER" --run-label phase0-measurement --role worker --task token-minimization --attempt 0 --settle-ms 0 "$FULL") || fail 'complete fixture must parse'
@@ -52,6 +61,12 @@ check "$late_report" '.artifact.final==false and .session.id == "932756903434134
 missing_report=$("$PARSER" --settle-ms 0 "$MISSING") || fail 'missing-usage fixture must parse'
 check "$missing_report" '.artifact.final and .calls.assistant==1 and .calls.measured==0 and .records[0].usage_state=="missing" and .records[0].provider_usage==null and .records[0].model_rate_cost_estimate==null and .totals.provider_usage.input==null and .totals.provider_usage.output==null and any(.warnings[];.code=="missing_usage")' 'missing usage remains unknown instead of zero'
 pass 'missing usage is warned and represented as unknown'
+cost_invalid_report=$("$PARSER" --settle-ms 0 "$COST_INVALID") || fail 'missing and non-object cost fixture must parse'
+check "$cost_invalid_report" '.artifact.final and (.records|length)==2 and .calls.measured==2 and all(.records[];.model_rate_cost_estimate==null) and .totals.model_rate_cost_estimate == {input:null,cache_read:null,cache_write:null,output:null,total:null} and ([.warnings[]|select(.code=="unknown_model_rate_cost")]|length)==2 and ([.warnings[]|select(.code=="unknown_model_rate_cost_field")]|length)==0' 'missing and non-object costs remain unknown with section warnings'
+pass 'missing and non-object model-rate costs are warned without aborting'
+cost_partial_report=$("$PARSER" --settle-ms 0 "$COST_PARTIAL") || fail 'partially invalid cost fixture must parse'
+check "$cost_partial_report" '.artifact.final and .totals.model_rate_cost_estimate.input==0.1 and .totals.model_rate_cost_estimate.cache_read==0.2 and .totals.model_rate_cost_estimate.output==null and .totals.model_rate_cost_estimate.cache_write==null and .totals.model_rate_cost_estimate.total==0.3 and ([.warnings[]|select(.code=="unknown_model_rate_cost_field" and .field=="output")]|length)==1 and ([.warnings[]|select(.code=="unknown_model_rate_cost_field" and .field=="cacheWrite")]|length)==1 and ([.warnings[]]|length)==2' 'partial model-rate costs preserve valid values and warn on invalid fields'
+pass 'partial model-rate costs warn on missing and invalid scalars'
 malformed_report=$("$PARSER" --settle-ms 0 "$MALFORMED") || fail 'malformed fixture must parse'
 check "$malformed_report" '.artifact.final==false and .entry_counts.parsed==2 and .entry_counts.malformed==2 and .totals.provider_usage.input==1 and any(.warnings[];.code=="malformed_json" and .line==3) and any(.warnings[];.code=="record_not_object" and .line==4)' 'malformed records remain measurable without becoming final'
 pass 'malformed records are warned and make the report non-final'

--- a/tests/fm-session-usage.test.sh
+++ b/tests/fm-session-usage.test.sh
@@ -1,213 +1,62 @@
 #!/usr/bin/env bash
-# tests/fm-session-usage.test.sh - focused executable coverage for the read-only
-# Pi 0.83.0 session usage parser and its closed-artifact stability boundary.
+# tests/fm-session-usage.test.sh - executable Phase 0 parser coverage.
+# shellcheck disable=SC2016
 set -u
-
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 PARSER="$ROOT/bin/fm-session-usage.sh"
 TMP_ROOT=$(fm_test_tmproot fm-session-usage)
-FULL="$TMP_ROOT/full.jsonl"
-MISSING="$TMP_ROOT/missing.jsonl"
-MALFORMED="$TMP_ROOT/malformed.jsonl"
-UNSTABLE="$TMP_ROOT/unstable.jsonl"
-
+FULL="$TMP_ROOT/full.jsonl"; MISSING="$TMP_ROOT/missing.jsonl"; MALFORMED="$TMP_ROOT/malformed.jsonl"; UNSTABLE="$TMP_ROOT/unstable.jsonl"
 cat >"$FULL" <<'EOF'
 {"type":"session","version":3,"id":"session-phase0","timestamp":"2026-01-01T00:00:00.000Z","cwd":"/secret/project","parentSession":"/secret/parent.jsonl"}
-{"type":"message","id":"user-1","parentId":null,"timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"user","content":"PROMPT_SECRET_DO_NOT_PRINT","timestamp":1}}
-{"type":"message","id":"assistant-1","parentId":"user-1","timestamp":"2026-01-01T00:00:02.000Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"REASONING_SECRET_DO_NOT_PRINT"},{"type":"toolCall","id":"tool-1","name":"read","arguments":{"path":"/secret/input"}},{"type":"toolCall","id":"tool-2","name":"bash","arguments":{"command":"printf TOOL_ARGUMENT_SECRET"}}],"api":"anthropic-messages","provider":"anthropic","model":"claude-sonnet-test","usage":{"input":100,"output":30,"cacheRead":20,"cacheWrite":5,"reasoning":10,"totalTokens":155,"cost":{"input":0.10,"output":0.30,"cacheRead":0.02,"cacheWrite":0.01,"total":0.43}},"stopReason":"toolUse","timestamp":2}}
-{"type":"message","id":"tool-result-1","parentId":"assistant-1","timestamp":"2026-01-01T00:00:03.000Z","message":{"role":"toolResult","toolCallId":"tool-1","toolName":"read","content":[{"type":"text","text":"TOOL_RESULT_SECRET_DO_NOT_PRINT"}],"details":{"path":"/secret/output"},"usage":{"input":2,"output":3,"cacheRead":0,"cacheWrite":0,"totalTokens":5,"cost":{"input":0.02,"output":0.03,"cacheRead":0,"cacheWrite":0,"total":0.05}},"isError":false,"timestamp":3}}
-{"type":"message","id":"assistant-2","parentId":"tool-result-1","timestamp":"2026-01-01T00:00:04.000Z","message":{"role":"assistant","content":[{"type":"text","text":"visible reply"}],"api":"openai-responses","provider":"openai","model":"gpt-test","usage":{"input":7,"output":13,"cacheRead":11,"cacheWrite":0,"totalTokens":31,"cost":{"input":0.07,"output":0.13,"cacheRead":0,"cacheWrite":0,"total":0.20}},"stopReason":"stop","timestamp":4}}
-{"type":"compaction","id":"compact-1","parentId":"assistant-2","timestamp":"2026-01-01T00:00:05.000Z","summary":"COMPACTION_SECRET_DO_NOT_PRINT","firstKeptEntryId":"assistant-2","tokensBefore":500,"usage":{"input":4,"output":6,"cacheRead":1,"cacheWrite":0,"reasoning":2,"totalTokens":11,"cost":{"input":0.04,"output":0.06,"cacheRead":0.01,"cacheWrite":0,"total":0.11}},"retainedTail":[{"role":"assistant","provider":"anthropic","model":"claude-sonnet-test","usage":{"input":9000,"output":9000,"cacheRead":9000,"cacheWrite":9000,"reasoning":9000,"totalTokens":36000,"cost":{"input":9000,"output":9000,"cacheRead":9000,"cacheWrite":9000,"total":36000}},"content":"RETAINED_TAIL_SECRET_DO_NOT_PRINT"}]}
-{"type":"branch_summary","id":"branch-1","parentId":"compact-1","timestamp":"2026-01-01T00:00:06.000Z","fromId":"assistant-1","summary":"BRANCH_SUMMARY_SECRET_DO_NOT_PRINT","usage":{"input":3,"output":4,"cacheRead":0,"cacheWrite":0,"totalTokens":7,"cost":{"input":0.03,"output":0.04,"cacheRead":0,"cacheWrite":0,"total":0.07}}}
-{"type":"model_change","id":"model-1","parentId":"branch-1","timestamp":"2026-01-01T00:00:07.000Z","provider":"google","modelId":"gemini-test"}
+{"type":"message","id":"user-1","message":{"role":"user","content":"PROMPT_SECRET_DO_NOT_PRINT"}}
+{"type":"message","id":"assistant-1","message":{"role":"assistant","content":[{"type":"thinking","thinking":"REASONING_SECRET_DO_NOT_PRINT"},{"type":"toolCall","id":"tool-1","name":"read","arguments":{"path":"/secret/input"}},{"type":"toolCall","id":"tool-2","name":"bash","arguments":{"command":"printf TOOL_ARGUMENT_SECRET"}}],"provider":"anthropic","model":"claude-sonnet-test","usage":{"input":100,"output":30,"cacheRead":20,"cacheWrite":5,"reasoning":10,"totalTokens":155,"cost":{"input":0.10,"output":0.30,"cacheRead":0.02,"cacheWrite":0.01,"total":0.43}}}}
+{"type":"message","id":"tool-result-1","message":{"role":"toolResult","toolCallId":"tool-1","content":[{"type":"text","text":"TOOL_RESULT_SECRET_DO_NOT_PRINT"}],"usage":{"input":2,"output":3,"cacheRead":0,"cacheWrite":0,"totalTokens":5,"cost":{"input":0.02,"output":0.03,"cacheRead":0,"cacheWrite":0,"total":0.05}}}}
+{"type":"message","id":"assistant-2","message":{"role":"assistant","content":[{"type":"text","text":"visible reply"}],"provider":"openai","model":"gpt-test","usage":{"input":7,"output":13,"cacheRead":11,"cacheWrite":0,"totalTokens":31,"cost":{"input":0.07,"output":0.13,"cacheRead":0,"cacheWrite":0,"total":0.20}}}}
+{"type":"compaction","id":"compact-1","usage":{"input":4,"output":6,"cacheRead":1,"cacheWrite":0,"reasoning":2,"totalTokens":11,"cost":{"input":0.04,"output":0.06,"cacheRead":0.01,"cacheWrite":0,"total":0.11}},"retainedTail":[{"role":"assistant","provider":"anthropic","usage":{"input":9000,"output":9000,"cacheRead":9000,"cacheWrite":9000,"reasoning":9000,"totalTokens":36000,"cost":{"input":9000,"output":9000,"cacheRead":9000,"cacheWrite":9000,"total":36000}},"content":"RETAINED_TAIL_SECRET_DO_NOT_PRINT"}]}
+{"type":"branch_summary","id":"branch-1","usage":{"input":3,"output":4,"cacheRead":0,"cacheWrite":0,"totalTokens":7,"cost":{"input":0.03,"output":0.04,"cacheRead":0,"cacheWrite":0,"total":0.07}},"summary":"BRANCH_SUMMARY_SECRET_DO_NOT_PRINT"}
+{"type":"model_change","provider":"google","modelId":"gemini-test"}
 EOF
+printf '%s\n' \
+ '{"type":"session","version":3,"id":"session-missing","cwd":"/redacted"}' \
+ '{"type":"message","message":{"role":"assistant","content":[],"provider":"anthropic","model":"unknown-usage-model"}}' >"$MISSING"
+printf '%s\n' \
+ '{"type":"session","version":3,"id":"session-malformed","cwd":"/redacted"}' \
+ '{"type":"message","message":{"role":"assistant","provider":"anthropic","model":"valid-model","usage":{"input":1,"output":2,"cacheRead":0,"cacheWrite":0,"totalTokens":3,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}}}}' \
+ 'not-json' '42' >"$MALFORMED"
+printf '%s\n' '{"type":"session","version":3,"id":"session-unstable","cwd":"/redacted"}' >"$UNSTABLE"
 
-cat >"$MISSING" <<'EOF'
-{"type":"session","version":3,"id":"session-missing","timestamp":"2026-01-01T00:00:00.000Z","cwd":"/redacted"}
-{"type":"message","id":"assistant-missing","parentId":null,"timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"assistant","content":[],"provider":"anthropic","model":"unknown-usage-model","stopReason":"error"}}
-EOF
-
-cat >"$MALFORMED" <<'EOF'
-{"type":"session","version":3,"id":"session-malformed","timestamp":"2026-01-01T00:00:00.000Z","cwd":"/redacted"}
-{"type":"message","id":"assistant-valid","parentId":null,"timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"assistant","content":[],"provider":"anthropic","model":"valid-model","usage":{"input":1,"output":2,"cacheRead":0,"cacheWrite":0,"totalTokens":3,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop"}}
-not-json
-42
-EOF
-
-cat >"$UNSTABLE" <<'EOF'
-{"type":"session","version":3,"id":"session-unstable","timestamp":"2026-01-01T00:00:00.000Z","cwd":"/redacted"}
-EOF
-
-report=$(
-  "$PARSER" --run-label phase0-measurement --role worker --task token-minimization \
-    --attempt 0 --settle-ms 0 "$FULL"
-) || fail 'the complete closed fixture must parse'
-
-printf '%s\n' "$report" | jq -e '
-  .artifact.format == "pi-session-jsonl" and
-  .artifact.stability == "stable" and
-  .artifact.final == true and
-  .session.id == "session-phase0" and
-  .metadata.run_label == "phase0-measurement" and
-  .metadata.role == "worker" and
-  .metadata.task == "token-minimization" and
-  .metadata.attempt == 0 and
-  .entry_counts.parsed == 8 and
-  .entry_counts.malformed == 0 and
-  .entry_counts.message == 4 and
-  .entry_counts.assistant_message == 2 and
-  .entry_counts.tool_result_message == 1 and
-  .entry_counts.compaction == 1 and
-  .entry_counts.branch_summary == 1 and
-  .calls.assistant == 2 and
-  .calls.tool == 2 and
-  .calls.tool_result == 1 and
-  .calls.compaction == 1 and
-  .calls.branch_summary == 1 and
-  .calls.measured == 5 and
-  .totals.provider_usage.input == 116 and
-  .totals.provider_usage.cache_read == 32 and
-  .totals.provider_usage.cache_write == 5 and
-  .totals.provider_usage.output == 56 and
-  .totals.provider_usage.provider_total == 209 and
-  .totals.provider_usage.reasoning == null and
-  (.totals.model_rate_cost_estimate.total - 0.86 | fabs) < 0.0000001
-' >/dev/null || fail 'complete fixture totals, counts, and metadata are reported'
-pass 'closed fixture reports entry classes, calls, totals, and explicit metadata'
-
-printf '%s\n' "$report" | jq -e '
-  ([.records[] | select(.entry_class == "assistant" and .provider == "anthropic")][0]) as $anthropic |
-  ([.records[] | select(.entry_class == "assistant" and .provider == "openai")][0]) as $openai |
-  ([.records[] | select(.entry_class == "tool_result")][0]) as $tool |
-  ([.records[] | select(.entry_class == "compaction")][0]) as $compaction |
-  ([.records[] | select(.entry_class == "branch_summary")][0]) as $branch |
-  $anthropic.provider_usage.input == 100 and
-  $anthropic.provider_usage.output == 30 and
-  $anthropic.provider_usage.reasoning == 10 and
-  $anthropic.provider_usage.provider_total == 155 and
-  ($anthropic.model_rate_cost_estimate.total - 0.43 | fabs) < 0.0000001 and
-  $openai.provider_usage.cache_read == 11 and
-  $openai.provider_usage.cache_write == 0 and
-  $openai.provider_usage.reasoning == null and
-  $tool.provider == null and
-  $tool.model == null and
-  $tool.provider_usage.provider_total == 5 and
-  $compaction.provider == null and
-  $compaction.provider_usage.reasoning == 2 and
-  $branch.provider_usage.provider_total == 7 and
-  $anthropic.provider_usage.output != ($anthropic.provider_usage.output + $anthropic.provider_usage.reasoning)
-' >/dev/null || fail 'provider fields, cached input, optional reasoning, and separate cost stay distinct'
-pass 'provider-native records keep reasoning as an output subset and do not guess summary providers'
-
-assert_not_contains "$report" 'PROMPT_SECRET_DO_NOT_PRINT' 'report must not expose prompts'
-assert_not_contains "$report" 'TOOL_RESULT_SECRET_DO_NOT_PRINT' 'report must not expose tool results'
-assert_not_contains "$report" 'REASONING_SECRET_DO_NOT_PRINT' 'report must not expose thinking content'
-assert_not_contains "$report" 'RETAINED_TAIL_SECRET_DO_NOT_PRINT' 'report must not expose retained history'
-assert_not_contains "$report" '/secret/project' 'report must not expose session cwd paths'
-assert_not_contains "$report" '/secret/parent.jsonl' 'report must not expose parent session paths'
-assert_not_contains "$report" "$FULL" 'report must not expose the source path'
-pass 'report is content-free and omits authenticated content and secret-bearing paths'
-
-missing_report=$("$PARSER" --settle-ms 0 "$MISSING") || fail 'missing-usage fixture must still produce a report'
-printf '%s\n' "$missing_report" | jq -e '
-  .artifact.final == true and
-  .calls.assistant == 1 and
-  .calls.measured == 0 and
-  .records[0].usage_state == "missing" and
-  .records[0].provider_usage == null and
-  .records[0].model_rate_cost_estimate == null and
-  .totals.provider_usage.input == null and
-  .totals.provider_usage.output == null and
-  any(.warnings[]; .code == "missing_usage")
-' >/dev/null || fail 'missing usage remains unknown instead of becoming zero'
+check() { local input=$1 filter=$2 message=$3; shift 3; printf '%s\n' "$input" | jq -e "$@" "$filter" >/dev/null || fail "$message"; }
+report=$("$PARSER" --run-label phase0-measurement --role worker --task token-minimization --attempt 0 --settle-ms 0 "$FULL") || fail 'complete fixture must parse'
+check "$report" '.artifact.format == "pi-session-jsonl" and .artifact.stability == "stable" and .artifact.final and .session.id == "session-phase0" and .metadata == {run_label:"phase0-measurement",role:"worker",task:"token-minimization",attempt:0} and .entry_counts == {parsed:8,malformed:0,session:1,message:4,user_message:1,assistant_message:2,tool_result_message:1,compaction:1,branch_summary:1,other:1} and .calls == {assistant:2,tool:2,tool_result:1,compaction:1,branch_summary:1,measured:5} and .totals.provider_usage == {input:116,cache_read:32,cache_write:5,output:56,reasoning:null,provider_total:209} and ((.totals.model_rate_cost_estimate.total - .86)|fabs) < 0.0000001' 'complete fixture totals and counts are reported'
+check "$report" '([.records[]|select(.entry_class=="assistant" and .provider=="anthropic")][0]) as $a | ([.records[]|select(.entry_class=="assistant" and .provider=="openai")][0]) as $o | ([.records[]|select(.entry_class=="tool_result")][0]) as $t | ([.records[]|select(.entry_class=="compaction")][0]) as $c | ([.records[]|select(.entry_class=="branch_summary")][0]) as $b | $a.provider_usage == {input:100,cache_read:20,cache_write:5,output:30,reasoning:10,provider_total:155} and ($a.model_rate_cost_estimate.total-.43|fabs)<.0000001 and $o.provider_usage.cache_read==11 and $o.provider_usage.reasoning==null and $t.provider==null and $t.model==null and $t.provider_usage.provider_total==5 and $c.provider_usage.reasoning==2 and $b.provider_usage.provider_total==7' 'provider, cached input, reasoning, and cost stay distinct'
+for secret in PROMPT_SECRET_DO_NOT_PRINT TOOL_RESULT_SECRET_DO_NOT_PRINT REASONING_SECRET_DO_NOT_PRINT RETAINED_TAIL_SECRET_DO_NOT_PRINT /secret/project /secret/parent.jsonl "$FULL"; do assert_not_contains "$report" "$secret" 'report must be content-free'; done
+pass 'closed records remain privacy-safe and top-level retained-tail usage is not counted twice'
+missing_report=$("$PARSER" --settle-ms 0 "$MISSING") || fail 'missing-usage fixture must parse'
+check "$missing_report" '.artifact.final and .calls.assistant==1 and .calls.measured==0 and .records[0].usage_state=="missing" and .records[0].provider_usage==null and .records[0].model_rate_cost_estimate==null and .totals.provider_usage.input==null and .totals.provider_usage.output==null and any(.warnings[];.code=="missing_usage")' 'missing usage remains unknown instead of zero'
 pass 'missing usage is warned and represented as unknown'
-
-malformed_report=$("$PARSER" --settle-ms 0 "$MALFORMED") || fail 'malformed fixture must produce a partial report'
-printf '%s\n' "$malformed_report" | jq -e '
-  .artifact.final == false and
-  .entry_counts.parsed == 2 and
-  .entry_counts.malformed == 2 and
-  .totals.provider_usage.input == 1 and
-  any(.warnings[]; .code == "malformed_json" and .line == 3) and
-  any(.warnings[]; .code == "record_not_object" and .line == 4)
-' >/dev/null || fail 'malformed records are warned without leaking their contents'
-pass 'malformed records make the report non-final while valid records remain measurable'
-
+malformed_report=$("$PARSER" --settle-ms 0 "$MALFORMED") || fail 'malformed fixture must parse'
+check "$malformed_report" '.artifact.final==false and .entry_counts.parsed==2 and .entry_counts.malformed==2 and .totals.provider_usage.input==1 and any(.warnings[];.code=="malformed_json" and .line==3) and any(.warnings[];.code=="record_not_object" and .line==4)' 'malformed records remain measurable without becoming final'
+pass 'malformed records are warned and make the report non-final'
 (
-  i=0
-  while [ "$i" -lt 30 ]; do
-    sleep 0.01
-    printf '%s\n' '{"type":"message","message":{"role":"user","content":"GROWING_SECRET"}}' >>"$UNSTABLE"
-    i=$((i + 1))
-  done
-) &
-MUTATOR=$!
-unstable_report=$("$PARSER" --settle-ms 100 "$UNSTABLE") || fail 'unstable fixture must still produce a report'
-wait "$MUTATOR" || fail 'unstable fixture mutator failed'
-printf '%s\n' "$unstable_report" | jq -e '
-  .artifact.final == false and
-  .artifact.stability == "unstable" and
-  any(.warnings[]; .code == "unstable_file")
-' >/dev/null || fail 'a growing file is explicitly marked non-final'
-pass 'growing session files are detected without mutating or recursively rereading them'
-
-resolve_pi_root() {
-  local pi_bin=$1 link entry
-  if [ -L "$pi_bin" ]; then
-    link=$(readlink "$pi_bin") || return 1
-    case "$link" in
-      /*) entry=$link ;;
-      *) entry=$(dirname "$pi_bin")/$link ;;
-    esac
-  else
-    entry=$pi_bin
-  fi
-  entry=$(cd "$(dirname "$entry")" && pwd)/$(basename "$entry") || return 1
-  cd "$(dirname "$entry")/.." && pwd
-}
-
-if command -v pi >/dev/null 2>&1 && [ "$(pi --version 2>/dev/null | head -n 1)" = "0.83.0" ] &&
-  command -v node >/dev/null 2>&1; then
-  PI_ROOT=$(resolve_pi_root "$(command -v pi)") || fail 'installed Pi path could not be resolved'
-  PI_CWD="$TMP_ROOT/pi-cwd"
-  mkdir -p "$PI_CWD"
-  pi_stats=$(PI_ROOT="$PI_ROOT" node --input-type=module - "$FULL" "$PI_CWD" 2>"$TMP_ROOT/pi-stats.stderr" <<'NODE'
+  i=0; while [ "$i" -lt 30 ]; do sleep 0.01; printf '%s\n' '{"type":"message","message":{"role":"user","content":"GROWING_SECRET"}}' >>"$UNSTABLE"; i=$((i + 1)); done
+) & MUTATOR=$!
+unstable_report=$("$PARSER" --settle-ms 100 "$UNSTABLE") || fail 'unstable fixture must parse'; wait "$MUTATOR" || fail 'unstable fixture mutator failed'
+check "$unstable_report" '.artifact.final==false and .artifact.stability=="unstable" and any(.warnings[];.code=="unstable_file")' 'growing files are non-final'
+pass 'growing session files are detected'
+if command -v pi >/dev/null 2>&1 && [ "$(pi --version 2>/dev/null | head -n1)" = 0.83.0 ] && command -v node >/dev/null 2>&1; then
+  PI_ROOT=$(node -p 'const fs=require("fs"),p=require("path"),x=fs.realpathSync(process.argv[1]);p.resolve(p.dirname(x),"..")' "$(command -v pi)") || fail 'installed Pi path could not be resolved'; PI_CWD="$TMP_ROOT/pi-cwd"; mkdir -p "$PI_CWD"
+  pi_stats=$(PI_ROOT="$PI_ROOT" node --input-type=module - "$FULL" "$PI_CWD" <<'NODE'
 import { pathToFileURL } from "node:url";
-
-const [file, cwd] = process.argv.slice(2);
-const root = process.env.PI_ROOT;
-if (!root) throw new Error("missing Pi root");
-const { createAgentSession, SessionManager } = await import(
-  pathToFileURL(`${root}/dist/index.js`).href,
-);
-const manager = SessionManager.open(file, undefined, cwd);
-const { session } = await createAgentSession({
-  cwd,
-  agentDir: `${cwd}/agent`,
-  sessionManager: manager,
-  noTools: "all",
-});
+const [file,cwd]=process.argv.slice(2),root=process.env.PI_ROOT;
+const {createAgentSession,SessionManager}=await import(pathToFileURL(`${root}/dist/index.js`).href);
+const {session}=await createAgentSession({cwd,agentDir:`${cwd}/agent`,sessionManager:SessionManager.open(file,undefined,cwd),noTools:"all"});
 process.stdout.write(JSON.stringify(session.getSessionStats()));
 NODE
-  ) || {
-    cat "$TMP_ROOT/pi-stats.stderr" >&2
-    fail 'Pi 0.83.0 session-stat comparison failed'
-  }
-  printf '%s\n' "$report" | jq -e --argjson stats "$pi_stats" '
-    .entry_counts.message == $stats.totalMessages and
-    .calls.assistant == $stats.assistantMessages and
-    .calls.tool == $stats.toolCalls and
-    .calls.tool_result == $stats.toolResults and
-    .totals.provider_usage.input == $stats.tokens.input and
-    .totals.provider_usage.output == $stats.tokens.output and
-    .totals.provider_usage.cache_read == $stats.tokens.cacheRead and
-    .totals.provider_usage.cache_write == $stats.tokens.cacheWrite and
-    ((.totals.provider_usage.input + .totals.provider_usage.output + .totals.provider_usage.cache_read + .totals.provider_usage.cache_write) == $stats.tokens.total) and
-    ((.totals.model_rate_cost_estimate.total - $stats.cost) | fabs) < 0.0000001
-  ' >/dev/null || fail 'parser totals must match installed Pi 0.83.0 session statistics'
-  pass 'parser totals match installed Pi 0.83.0 session-stat behavior'
+  ) || fail 'Pi 0.83.0 session-stat comparison failed'
+  check "$report" '.entry_counts.message==$stats.totalMessages and .calls.assistant==$stats.assistantMessages and .calls.tool==$stats.toolCalls and .calls.tool_result==$stats.toolResults and .totals.provider_usage.input==$stats.tokens.input and .totals.provider_usage.output==$stats.tokens.output and .totals.provider_usage.cache_read==$stats.tokens.cacheRead and .totals.provider_usage.cache_write==$stats.tokens.cacheWrite and ((.totals.provider_usage.input+.totals.provider_usage.output+.totals.provider_usage.cache_read+.totals.provider_usage.cache_write)==$stats.tokens.total) and ((.totals.model_rate_cost_estimate.total-$stats.cost)|fabs)<0.0000001' 'parser totals must match installed Pi 0.83.0 statistics' --argjson stats "$pi_stats"
+  pass 'parser totals match installed Pi 0.83.0 session statistics'
 else
-  pass 'Pi 0.83.0 session-stat comparison skipped because the installed interface is unavailable'
+  pass 'Pi 0.83.0 comparison skipped because the installed interface is unavailable'
 fi

--- a/tests/fm-session-usage.test.sh
+++ b/tests/fm-session-usage.test.sh
@@ -7,7 +7,7 @@ set -u
 
 PARSER="$ROOT/bin/fm-session-usage.sh"
 TMP_ROOT=$(fm_test_tmproot fm-session-usage)
-FULL="$TMP_ROOT/full.jsonl"; MISSING="$TMP_ROOT/missing.jsonl"; MALFORMED="$TMP_ROOT/malformed.jsonl"; UNSTABLE="$TMP_ROOT/unstable.jsonl"
+FULL="$TMP_ROOT/full.jsonl"; MISSING="$TMP_ROOT/missing.jsonl"; MALFORMED="$TMP_ROOT/malformed.jsonl"; UNSTABLE="$TMP_ROOT/unstable.jsonl"; OPTIONAL="$TMP_ROOT/optional.jsonl"; LATE="$TMP_ROOT/late.jsonl"
 cat >"$FULL" <<'EOF'
 {"type":"session","version":3,"id":"session-phase0","timestamp":"2026-01-01T00:00:00.000Z","cwd":"/secret/project","parentSession":"/secret/parent.jsonl"}
 {"type":"message","id":"user-1","message":{"role":"user","content":"PROMPT_SECRET_DO_NOT_PRINT"}}
@@ -26,13 +26,29 @@ printf '%s\n' \
  '{"type":"message","message":{"role":"assistant","provider":"anthropic","model":"valid-model","usage":{"input":1,"output":2,"cacheRead":0,"cacheWrite":0,"totalTokens":3,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}}}}' \
  'not-json' '42' >"$MALFORMED"
 printf '%s\n' '{"type":"session","version":3,"id":"session-unstable","cwd":"/redacted"}' >"$UNSTABLE"
+cat >"$OPTIONAL" <<'EOF'
+{"type":"session","version":3,"id":"optional-parity","cwd":"/tmp/phase0"}
+{"type":"message","id":"assistant-optional","message":{"role":"assistant","content":[{"type":"toolCall","id":"tool-optional","name":"read","arguments":{}}],"provider":"proxy","model":"requested-model","responseModel":"served-model","usage":{"input":1,"output":2,"cacheRead":3,"cacheWrite":4,"totalTokens":10,"cost":{"input":0.1,"output":0.2,"cacheRead":0.3,"cacheWrite":0.4,"total":1.0}},"stopReason":"toolUse"}}
+{"type":"message","id":"tool-optional","message":{"role":"toolResult","toolCallId":"tool-optional","toolName":"read","content":[],"isError":false}}
+{"type":"compaction","id":"compact-optional","summary":"summary","tokensBefore":10}
+{"type":"branch_summary","id":"branch-optional","summary":"branch","fromId":"assistant-optional"}
+EOF
+cat >"$LATE" <<'EOF'
+{"type":"message","id":"user-late","message":{"role":"user","content":"late"}}
+{"type":"session","version":3,"id":"late-header","cwd":"/tmp/phase0"}
+EOF
 
 check() { local input=$1 filter=$2 message=$3; shift 3; printf '%s\n' "$input" | jq -e "$@" "$filter" >/dev/null || fail "$message"; }
 report=$("$PARSER" --run-label phase0-measurement --role worker --task token-minimization --attempt 0 --settle-ms 0 "$FULL") || fail 'complete fixture must parse'
-check "$report" '.artifact.format == "pi-session-jsonl" and .artifact.stability == "stable" and .artifact.final and .session.id == "session-phase0" and .metadata == {run_label:"phase0-measurement",role:"worker",task:"token-minimization",attempt:0} and .entry_counts == {parsed:8,malformed:0,session:1,message:4,user_message:1,assistant_message:2,tool_result_message:1,compaction:1,branch_summary:1,other:1} and .calls == {assistant:2,tool:2,tool_result:1,compaction:1,branch_summary:1,measured:5} and .totals.provider_usage == {input:116,cache_read:32,cache_write:5,output:56,reasoning:null,provider_total:209} and ((.totals.model_rate_cost_estimate.total - .86)|fabs) < 0.0000001' 'complete fixture totals and counts are reported'
-check "$report" '([.records[]|select(.entry_class=="assistant" and .provider=="anthropic")][0]) as $a | ([.records[]|select(.entry_class=="assistant" and .provider=="openai")][0]) as $o | ([.records[]|select(.entry_class=="tool_result")][0]) as $t | ([.records[]|select(.entry_class=="compaction")][0]) as $c | ([.records[]|select(.entry_class=="branch_summary")][0]) as $b | $a.provider_usage == {input:100,cache_read:20,cache_write:5,output:30,reasoning:10,provider_total:155} and ($a.model_rate_cost_estimate.total-.43|fabs)<.0000001 and $o.provider_usage.cache_read==11 and $o.provider_usage.reasoning==null and $t.provider==null and $t.model==null and $t.provider_usage.provider_total==5 and $c.provider_usage.reasoning==2 and $b.provider_usage.provider_total==7' 'provider, cached input, reasoning, and cost stay distinct'
-for secret in PROMPT_SECRET_DO_NOT_PRINT TOOL_RESULT_SECRET_DO_NOT_PRINT REASONING_SECRET_DO_NOT_PRINT RETAINED_TAIL_SECRET_DO_NOT_PRINT /secret/project /secret/parent.jsonl "$FULL"; do assert_not_contains "$report" "$secret" 'report must be content-free'; done
-pass 'closed records remain privacy-safe and top-level retained-tail usage is not counted twice'
+check "$report" '.artifact.format == "pi-session-jsonl" and .artifact.stability == "stable" and .artifact.final and .session.id == "4d5604d79a794d1662d745d204d09fcc6cc19f76ce42018b7fc42442693e7d5c" and .metadata == {run_label:"phase0-measurement",role:"worker",task:"token-minimization",attempt:0} and .entry_counts == {parsed:8,malformed:0,session:1,message:4,user_message:1,assistant_message:2,tool_result_message:1,compaction:1,branch_summary:1,other:1} and .calls == {assistant:2,tool:2,tool_result:1,compaction:1,branch_summary:1,measured:5} and .totals.provider_usage == {input:116,cache_read:32,cache_write:5,output:56,reasoning:null,provider_total:209} and ((.totals.model_rate_cost_estimate.total - .86)|fabs) < 0.0000001 and (.limitations[0] | contains("observed-stable"))' 'complete fixture totals and counts are reported'
+check "$report" '([.records[]|select(.entry_class=="assistant" and .provider=="anthropic")][0]) as $a | ([.records[]|select(.entry_class=="assistant" and .provider=="openai")][0]) as $o | ([.records[]|select(.entry_class=="tool_result")][0]) as $t | ([.records[]|select(.entry_class=="compaction")][0]) as $c | ([.records[]|select(.entry_class=="branch_summary")][0]) as $b | $a.model == "claude-sonnet-test" and $a.provider_usage == {input:100,cache_read:20,cache_write:5,output:30,reasoning:10,provider_total:155} and ($a.model_rate_cost_estimate.total-.43|fabs)<.0000001 and $o.provider_usage.cache_read==11 and $o.provider_usage.reasoning==null and $t.provider==null and $t.model==null and $t.provider_usage.provider_total==5 and $c.provider_usage.reasoning==2 and $b.provider_usage.provider_total==7' 'provider, cached input, reasoning, and cost stay distinct'
+for secret in PROMPT_SECRET_DO_NOT_PRINT TOOL_RESULT_SECRET_DO_NOT_PRINT REASONING_SECRET_DO_NOT_PRINT RETAINED_TAIL_SECRET_DO_NOT_PRINT /secret/project /secret/parent.jsonl session-phase0 "$FULL"; do assert_not_contains "$report" "$secret" 'report must be content-free'; done
+pass 'observed-stable records remain privacy-safe and top-level retained-tail usage is not counted twice'
+optional_report=$("$PARSER" --settle-ms 0 "$OPTIONAL") || fail 'optional-usage parity fixture must parse'
+check "$optional_report" '.artifact.final and .session.id == "997d7cf59c4a95139ff7e7aebb9f009c4e9252fa227a8ab026ede7e5e35b6843" and (.records|length)==1 and .records[0].model=="served-model" and .calls == {assistant:1,tool:1,tool_result:1,compaction:1,branch_summary:1,measured:1} and .totals.provider_usage == {input:1,cache_read:3,cache_write:4,output:2,reasoning:null,provider_total:10} and .totals.model_rate_cost_estimate.total==1 and (all(.warnings[];.code!="missing_usage"))' 'optional no-usage records are omitted, responseModel wins, and native totals stay exact'
+assert_not_contains "$optional_report" optional-parity 'aggregate session IDs must be digests'
+late_report=$("$PARSER" --settle-ms 0 "$LATE") || fail 'late-header fixture must parse'
+check "$late_report" '.artifact.final==false and .session.id == "9327569034341341751ad3db62e5a74554cd479dddfd0a7208ea91744615a4d3" and any(.warnings[];.code=="session_header_not_first" and .line==2)' 'a late session header is not final'
 missing_report=$("$PARSER" --settle-ms 0 "$MISSING") || fail 'missing-usage fixture must parse'
 check "$missing_report" '.artifact.final and .calls.assistant==1 and .calls.measured==0 and .records[0].usage_state=="missing" and .records[0].provider_usage==null and .records[0].model_rate_cost_estimate==null and .totals.provider_usage.input==null and .totals.provider_usage.output==null and any(.warnings[];.code=="missing_usage")' 'missing usage remains unknown instead of zero'
 pass 'missing usage is warned and represented as unknown'
@@ -47,16 +63,17 @@ check "$unstable_report" '.artifact.final==false and .artifact.stability=="unsta
 pass 'growing session files are detected'
 if command -v pi >/dev/null 2>&1 && [ "$(pi --version 2>/dev/null | head -n1)" = 0.83.0 ] && command -v node >/dev/null 2>&1; then
   PI_ROOT=$(node -p 'const fs=require("fs"),p=require("path"),x=fs.realpathSync(process.argv[1]);p.resolve(p.dirname(x),"..")' "$(command -v pi)") || fail 'installed Pi path could not be resolved'; PI_CWD="$TMP_ROOT/pi-cwd"; mkdir -p "$PI_CWD"
-  pi_stats=$(PI_ROOT="$PI_ROOT" node --input-type=module - "$FULL" "$PI_CWD" <<'NODE'
+  pi_stats=$(PI_ROOT="$PI_ROOT" node --input-type=module - "$FULL" "$OPTIONAL" "$PI_CWD" <<'NODE'
 import { pathToFileURL } from "node:url";
-const [file,cwd]=process.argv.slice(2),root=process.env.PI_ROOT;
+const [file,optionalFile,cwd]=process.argv.slice(2),root=process.env.PI_ROOT;
 const {createAgentSession,SessionManager}=await import(pathToFileURL(`${root}/dist/index.js`).href);
-const {session}=await createAgentSession({cwd,agentDir:`${cwd}/agent`,sessionManager:SessionManager.open(file,undefined,cwd),noTools:"all"});
-process.stdout.write(JSON.stringify(session.getSessionStats()));
+const stats=async (path)=>{const {session}=await createAgentSession({cwd,agentDir:`${cwd}/agent`,sessionManager:SessionManager.open(path,undefined,cwd),noTools:"all"});return session.getSessionStats();};
+process.stdout.write(JSON.stringify({full:await stats(file),optional:await stats(optionalFile)}));
 NODE
   ) || fail 'Pi 0.83.0 session-stat comparison failed'
-  check "$report" '.entry_counts.message==$stats.totalMessages and .calls.assistant==$stats.assistantMessages and .calls.tool==$stats.toolCalls and .calls.tool_result==$stats.toolResults and .totals.provider_usage.input==$stats.tokens.input and .totals.provider_usage.output==$stats.tokens.output and .totals.provider_usage.cache_read==$stats.tokens.cacheRead and .totals.provider_usage.cache_write==$stats.tokens.cacheWrite and ((.totals.provider_usage.input+.totals.provider_usage.output+.totals.provider_usage.cache_read+.totals.provider_usage.cache_write)==$stats.tokens.total) and ((.totals.model_rate_cost_estimate.total-$stats.cost)|fabs)<0.0000001' 'parser totals must match installed Pi 0.83.0 statistics' --argjson stats "$pi_stats"
-  pass 'parser totals match installed Pi 0.83.0 session statistics'
+  check "$report" '.entry_counts.message==$stats.full.totalMessages and .calls.assistant==$stats.full.assistantMessages and .calls.tool==$stats.full.toolCalls and .calls.tool_result==$stats.full.toolResults and .totals.provider_usage.input==$stats.full.tokens.input and .totals.provider_usage.output==$stats.full.tokens.output and .totals.provider_usage.cache_read==$stats.full.tokens.cacheRead and .totals.provider_usage.cache_write==$stats.full.tokens.cacheWrite and ((.totals.provider_usage.input+.totals.provider_usage.output+.totals.provider_usage.cache_read+.totals.provider_usage.cache_write)==$stats.full.tokens.total) and ((.totals.model_rate_cost_estimate.total-$stats.full.cost)|fabs)<0.0000001' 'parser totals must match installed Pi 0.83.0 session statistics' --argjson stats "$pi_stats"
+  check "$optional_report" '.entry_counts.message==$stats.optional.totalMessages and .calls.assistant==$stats.optional.assistantMessages and .calls.tool==$stats.optional.toolCalls and .calls.tool_result==$stats.optional.toolResults and .totals.provider_usage.input==$stats.optional.tokens.input and .totals.provider_usage.output==$stats.optional.tokens.output and .totals.provider_usage.cache_read==$stats.optional.tokens.cacheRead and .totals.provider_usage.cache_write==$stats.optional.tokens.cacheWrite and ((.totals.provider_usage.input+.totals.provider_usage.output+.totals.provider_usage.cache_read+.totals.provider_usage.cache_write)==$stats.optional.tokens.total) and ((.totals.model_rate_cost_estimate.total-$stats.optional.cost)|fabs)<0.0000001' 'optional parser totals must match installed Pi 0.83.0 statistics' --argjson stats "$pi_stats"
+  pass 'parser totals match installed Pi 0.83.0 session statistics for full and optional-usage fixtures'
 else
   pass 'Pi 0.83.0 comparison skipped because the installed interface is unavailable'
 fi

--- a/tests/fm-session-usage.test.sh
+++ b/tests/fm-session-usage.test.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# tests/fm-session-usage.test.sh - focused executable coverage for the read-only
+# Pi 0.83.0 session usage parser and its closed-artifact stability boundary.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+PARSER="$ROOT/bin/fm-session-usage.sh"
+TMP_ROOT=$(fm_test_tmproot fm-session-usage)
+FULL="$TMP_ROOT/full.jsonl"
+MISSING="$TMP_ROOT/missing.jsonl"
+MALFORMED="$TMP_ROOT/malformed.jsonl"
+UNSTABLE="$TMP_ROOT/unstable.jsonl"
+
+cat >"$FULL" <<'EOF'
+{"type":"session","version":3,"id":"session-phase0","timestamp":"2026-01-01T00:00:00.000Z","cwd":"/secret/project","parentSession":"/secret/parent.jsonl"}
+{"type":"message","id":"user-1","parentId":null,"timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"user","content":"PROMPT_SECRET_DO_NOT_PRINT","timestamp":1}}
+{"type":"message","id":"assistant-1","parentId":"user-1","timestamp":"2026-01-01T00:00:02.000Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"REASONING_SECRET_DO_NOT_PRINT"},{"type":"toolCall","id":"tool-1","name":"read","arguments":{"path":"/secret/input"}},{"type":"toolCall","id":"tool-2","name":"bash","arguments":{"command":"printf TOOL_ARGUMENT_SECRET"}}],"api":"anthropic-messages","provider":"anthropic","model":"claude-sonnet-test","usage":{"input":100,"output":30,"cacheRead":20,"cacheWrite":5,"reasoning":10,"totalTokens":155,"cost":{"input":0.10,"output":0.30,"cacheRead":0.02,"cacheWrite":0.01,"total":0.43}},"stopReason":"toolUse","timestamp":2}}
+{"type":"message","id":"tool-result-1","parentId":"assistant-1","timestamp":"2026-01-01T00:00:03.000Z","message":{"role":"toolResult","toolCallId":"tool-1","toolName":"read","content":[{"type":"text","text":"TOOL_RESULT_SECRET_DO_NOT_PRINT"}],"details":{"path":"/secret/output"},"usage":{"input":2,"output":3,"cacheRead":0,"cacheWrite":0,"totalTokens":5,"cost":{"input":0.02,"output":0.03,"cacheRead":0,"cacheWrite":0,"total":0.05}},"isError":false,"timestamp":3}}
+{"type":"message","id":"assistant-2","parentId":"tool-result-1","timestamp":"2026-01-01T00:00:04.000Z","message":{"role":"assistant","content":[{"type":"text","text":"visible reply"}],"api":"openai-responses","provider":"openai","model":"gpt-test","usage":{"input":7,"output":13,"cacheRead":11,"cacheWrite":0,"totalTokens":31,"cost":{"input":0.07,"output":0.13,"cacheRead":0,"cacheWrite":0,"total":0.20}},"stopReason":"stop","timestamp":4}}
+{"type":"compaction","id":"compact-1","parentId":"assistant-2","timestamp":"2026-01-01T00:00:05.000Z","summary":"COMPACTION_SECRET_DO_NOT_PRINT","firstKeptEntryId":"assistant-2","tokensBefore":500,"usage":{"input":4,"output":6,"cacheRead":1,"cacheWrite":0,"reasoning":2,"totalTokens":11,"cost":{"input":0.04,"output":0.06,"cacheRead":0.01,"cacheWrite":0,"total":0.11}},"retainedTail":[{"role":"assistant","provider":"anthropic","model":"claude-sonnet-test","usage":{"input":9000,"output":9000,"cacheRead":9000,"cacheWrite":9000,"reasoning":9000,"totalTokens":36000,"cost":{"input":9000,"output":9000,"cacheRead":9000,"cacheWrite":9000,"total":36000}},"content":"RETAINED_TAIL_SECRET_DO_NOT_PRINT"}]}
+{"type":"branch_summary","id":"branch-1","parentId":"compact-1","timestamp":"2026-01-01T00:00:06.000Z","fromId":"assistant-1","summary":"BRANCH_SUMMARY_SECRET_DO_NOT_PRINT","usage":{"input":3,"output":4,"cacheRead":0,"cacheWrite":0,"totalTokens":7,"cost":{"input":0.03,"output":0.04,"cacheRead":0,"cacheWrite":0,"total":0.07}}}
+{"type":"model_change","id":"model-1","parentId":"branch-1","timestamp":"2026-01-01T00:00:07.000Z","provider":"google","modelId":"gemini-test"}
+EOF
+
+cat >"$MISSING" <<'EOF'
+{"type":"session","version":3,"id":"session-missing","timestamp":"2026-01-01T00:00:00.000Z","cwd":"/redacted"}
+{"type":"message","id":"assistant-missing","parentId":null,"timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"assistant","content":[],"provider":"anthropic","model":"unknown-usage-model","stopReason":"error"}}
+EOF
+
+cat >"$MALFORMED" <<'EOF'
+{"type":"session","version":3,"id":"session-malformed","timestamp":"2026-01-01T00:00:00.000Z","cwd":"/redacted"}
+{"type":"message","id":"assistant-valid","parentId":null,"timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"assistant","content":[],"provider":"anthropic","model":"valid-model","usage":{"input":1,"output":2,"cacheRead":0,"cacheWrite":0,"totalTokens":3,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop"}}
+not-json
+42
+EOF
+
+cat >"$UNSTABLE" <<'EOF'
+{"type":"session","version":3,"id":"session-unstable","timestamp":"2026-01-01T00:00:00.000Z","cwd":"/redacted"}
+EOF
+
+report=$(
+  "$PARSER" --run-label phase0-measurement --role worker --task token-minimization \
+    --attempt 0 --settle-ms 0 "$FULL"
+) || fail 'the complete closed fixture must parse'
+
+printf '%s\n' "$report" | jq -e '
+  .artifact.format == "pi-session-jsonl" and
+  .artifact.stability == "stable" and
+  .artifact.final == true and
+  .session.id == "session-phase0" and
+  .metadata.run_label == "phase0-measurement" and
+  .metadata.role == "worker" and
+  .metadata.task == "token-minimization" and
+  .metadata.attempt == 0 and
+  .entry_counts.parsed == 8 and
+  .entry_counts.malformed == 0 and
+  .entry_counts.message == 4 and
+  .entry_counts.assistant_message == 2 and
+  .entry_counts.tool_result_message == 1 and
+  .entry_counts.compaction == 1 and
+  .entry_counts.branch_summary == 1 and
+  .calls.assistant == 2 and
+  .calls.tool == 2 and
+  .calls.tool_result == 1 and
+  .calls.compaction == 1 and
+  .calls.branch_summary == 1 and
+  .calls.measured == 5 and
+  .totals.provider_usage.input == 116 and
+  .totals.provider_usage.cache_read == 32 and
+  .totals.provider_usage.cache_write == 5 and
+  .totals.provider_usage.output == 56 and
+  .totals.provider_usage.provider_total == 209 and
+  .totals.provider_usage.reasoning == null and
+  (.totals.model_rate_cost_estimate.total - 0.86 | fabs) < 0.0000001
+' >/dev/null || fail 'complete fixture totals, counts, and metadata are reported'
+pass 'closed fixture reports entry classes, calls, totals, and explicit metadata'
+
+printf '%s\n' "$report" | jq -e '
+  ([.records[] | select(.entry_class == "assistant" and .provider == "anthropic")][0]) as $anthropic |
+  ([.records[] | select(.entry_class == "assistant" and .provider == "openai")][0]) as $openai |
+  ([.records[] | select(.entry_class == "tool_result")][0]) as $tool |
+  ([.records[] | select(.entry_class == "compaction")][0]) as $compaction |
+  ([.records[] | select(.entry_class == "branch_summary")][0]) as $branch |
+  $anthropic.provider_usage.input == 100 and
+  $anthropic.provider_usage.output == 30 and
+  $anthropic.provider_usage.reasoning == 10 and
+  $anthropic.provider_usage.provider_total == 155 and
+  ($anthropic.model_rate_cost_estimate.total - 0.43 | fabs) < 0.0000001 and
+  $openai.provider_usage.cache_read == 11 and
+  $openai.provider_usage.cache_write == 0 and
+  $openai.provider_usage.reasoning == null and
+  $tool.provider == null and
+  $tool.model == null and
+  $tool.provider_usage.provider_total == 5 and
+  $compaction.provider == null and
+  $compaction.provider_usage.reasoning == 2 and
+  $branch.provider_usage.provider_total == 7 and
+  $anthropic.provider_usage.output != ($anthropic.provider_usage.output + $anthropic.provider_usage.reasoning)
+' >/dev/null || fail 'provider fields, cached input, optional reasoning, and separate cost stay distinct'
+pass 'provider-native records keep reasoning as an output subset and do not guess summary providers'
+
+assert_not_contains "$report" 'PROMPT_SECRET_DO_NOT_PRINT' 'report must not expose prompts'
+assert_not_contains "$report" 'TOOL_RESULT_SECRET_DO_NOT_PRINT' 'report must not expose tool results'
+assert_not_contains "$report" 'REASONING_SECRET_DO_NOT_PRINT' 'report must not expose thinking content'
+assert_not_contains "$report" 'RETAINED_TAIL_SECRET_DO_NOT_PRINT' 'report must not expose retained history'
+assert_not_contains "$report" '/secret/project' 'report must not expose session cwd paths'
+assert_not_contains "$report" '/secret/parent.jsonl' 'report must not expose parent session paths'
+assert_not_contains "$report" "$FULL" 'report must not expose the source path'
+pass 'report is content-free and omits authenticated content and secret-bearing paths'
+
+missing_report=$("$PARSER" --settle-ms 0 "$MISSING") || fail 'missing-usage fixture must still produce a report'
+printf '%s\n' "$missing_report" | jq -e '
+  .artifact.final == true and
+  .calls.assistant == 1 and
+  .calls.measured == 0 and
+  .records[0].usage_state == "missing" and
+  .records[0].provider_usage == null and
+  .records[0].model_rate_cost_estimate == null and
+  .totals.provider_usage.input == null and
+  .totals.provider_usage.output == null and
+  any(.warnings[]; .code == "missing_usage")
+' >/dev/null || fail 'missing usage remains unknown instead of becoming zero'
+pass 'missing usage is warned and represented as unknown'
+
+malformed_report=$("$PARSER" --settle-ms 0 "$MALFORMED") || fail 'malformed fixture must produce a partial report'
+printf '%s\n' "$malformed_report" | jq -e '
+  .artifact.final == false and
+  .entry_counts.parsed == 2 and
+  .entry_counts.malformed == 2 and
+  .totals.provider_usage.input == 1 and
+  any(.warnings[]; .code == "malformed_json" and .line == 3) and
+  any(.warnings[]; .code == "record_not_object" and .line == 4)
+' >/dev/null || fail 'malformed records are warned without leaking their contents'
+pass 'malformed records make the report non-final while valid records remain measurable'
+
+(
+  i=0
+  while [ "$i" -lt 30 ]; do
+    sleep 0.01
+    printf '%s\n' '{"type":"message","message":{"role":"user","content":"GROWING_SECRET"}}' >>"$UNSTABLE"
+    i=$((i + 1))
+  done
+) &
+MUTATOR=$!
+unstable_report=$("$PARSER" --settle-ms 100 "$UNSTABLE") || fail 'unstable fixture must still produce a report'
+wait "$MUTATOR" || fail 'unstable fixture mutator failed'
+printf '%s\n' "$unstable_report" | jq -e '
+  .artifact.final == false and
+  .artifact.stability == "unstable" and
+  any(.warnings[]; .code == "unstable_file")
+' >/dev/null || fail 'a growing file is explicitly marked non-final'
+pass 'growing session files are detected without mutating or recursively rereading them'
+
+resolve_pi_root() {
+  local pi_bin=$1 link entry
+  if [ -L "$pi_bin" ]; then
+    link=$(readlink "$pi_bin") || return 1
+    case "$link" in
+      /*) entry=$link ;;
+      *) entry=$(dirname "$pi_bin")/$link ;;
+    esac
+  else
+    entry=$pi_bin
+  fi
+  entry=$(cd "$(dirname "$entry")" && pwd)/$(basename "$entry") || return 1
+  cd "$(dirname "$entry")/.." && pwd
+}
+
+if command -v pi >/dev/null 2>&1 && [ "$(pi --version 2>/dev/null | head -n 1)" = "0.83.0" ] &&
+  command -v node >/dev/null 2>&1; then
+  PI_ROOT=$(resolve_pi_root "$(command -v pi)") || fail 'installed Pi path could not be resolved'
+  PI_CWD="$TMP_ROOT/pi-cwd"
+  mkdir -p "$PI_CWD"
+  pi_stats=$(PI_ROOT="$PI_ROOT" node --input-type=module - "$FULL" "$PI_CWD" 2>"$TMP_ROOT/pi-stats.stderr" <<'NODE'
+import { pathToFileURL } from "node:url";
+
+const [file, cwd] = process.argv.slice(2);
+const root = process.env.PI_ROOT;
+if (!root) throw new Error("missing Pi root");
+const { createAgentSession, SessionManager } = await import(
+  pathToFileURL(`${root}/dist/index.js`).href,
+);
+const manager = SessionManager.open(file, undefined, cwd);
+const { session } = await createAgentSession({
+  cwd,
+  agentDir: `${cwd}/agent`,
+  sessionManager: manager,
+  noTools: "all",
+});
+process.stdout.write(JSON.stringify(session.getSessionStats()));
+NODE
+  ) || {
+    cat "$TMP_ROOT/pi-stats.stderr" >&2
+    fail 'Pi 0.83.0 session-stat comparison failed'
+  }
+  printf '%s\n' "$report" | jq -e --argjson stats "$pi_stats" '
+    .entry_counts.message == $stats.totalMessages and
+    .calls.assistant == $stats.assistantMessages and
+    .calls.tool == $stats.toolCalls and
+    .calls.tool_result == $stats.toolResults and
+    .totals.provider_usage.input == $stats.tokens.input and
+    .totals.provider_usage.output == $stats.tokens.output and
+    .totals.provider_usage.cache_read == $stats.tokens.cacheRead and
+    .totals.provider_usage.cache_write == $stats.tokens.cacheWrite and
+    ((.totals.provider_usage.input + .totals.provider_usage.output + .totals.provider_usage.cache_read + .totals.provider_usage.cache_write) == $stats.tokens.total) and
+    ((.totals.model_rate_cost_estimate.total - $stats.cost) | fabs) < 0.0000001
+  ' >/dev/null || fail 'parser totals must match installed Pi 0.83.0 session statistics'
+  pass 'parser totals match installed Pi 0.83.0 session-stat behavior'
+else
+  pass 'Pi 0.83.0 session-stat comparison skipped because the installed interface is unavailable'
+fi

--- a/tests/fm-spawn-batch.test.sh
+++ b/tests/fm-spawn-batch.test.sh
@@ -14,6 +14,7 @@ set -u
 
 SPAWN="$ROOT/bin/fm-spawn.sh"
 TMP_ROOT=$(fm_test_tmproot fm-spawn-batch)
+mkdir -p "$TMP_ROOT/config"
 export FM_BACKEND=tmux
 
 # Clear ambient firstmate overrides so the behavior test owns its environment.
@@ -23,7 +24,7 @@ run_spawn() {
     FM_STATE_OVERRIDE='' \
     FM_DATA_OVERRIDE='' \
     FM_PROJECTS_OVERRIDE='' \
-    FM_CONFIG_OVERRIDE='' \
+    FM_CONFIG_OVERRIDE="$TMP_ROOT/config" \
     FM_SPAWN_NO_GUARD=1 \
     "$SPAWN" "$@" 2>&1
 }

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -88,7 +88,15 @@ make_spawn_case() {
   wt="$case_dir/wt"
   launchlog="$case_dir/launch.log"
   fakebin=$(make_spawn_fakebin "$case_dir/fake")
-  mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
+  mkdir -p \
+    "$home/data" "$home/projects" "$home/state" "$home/config" \
+    "$home/config/npm/node_modules/@ff-labs/pi-fff/src" \
+    "$home/config/extensions/pi-web-access" \
+    "$home/config/extensions/pi-openai-server-compaction/src"
+  : > "$home/config/npm/node_modules/@ff-labs/pi-fff/src/index.ts"
+  : > "$home/config/extensions/pi-web-access/index.ts"
+  : > "$home/config/extensions/herdr-agent-state.ts"
+  : > "$home/config/extensions/pi-openai-server-compaction/src/index.ts"
   printf '%s\n' "$harness" > "$home/config/crew-harness"
   fm_git_worktree "$proj" "$wt" "wt-$name"
   touch "$home/state/.last-watcher-beat"
@@ -124,6 +132,7 @@ run_spawn() {
   FM_ROOT_OVERRIDE='' FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    PI_CODING_AGENT_DIR="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
     CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
     FM_FAKE_LAUNCH_LOG="$launchlog" FM_FAKE_PI_VERSION="${FM_TEST_PI_VERSION:-0.84.0}" \
@@ -143,6 +152,7 @@ read_case_record() {
   IFS='|' read -r CASE_DIR HOME_DIR PROJ_DIR WT_DIR FAKEBIN_DIR LAUNCH_LOG <<EOF
 $1
 EOF
+  export PI_CODING_AGENT_DIR="$HOME_DIR/config"
 }
 
 assert_meta_profile() {
@@ -623,8 +633,14 @@ test_pi_threads_model_and_max_effort() {
   expect_code 0 "$status" "pi spawn with max effort should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" pi openai-codex/gpt-5.6-sol max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "FM_PI_HARNESS=pi '$FAKEBIN_DIR/pi' --tui-mode regular --model 'openai-codex/gpt-5.6-sol' --thinking 'max' -e" \
-    "pi launch did not force the regular TUI while threading the requested model and max thinking level"
+  assert_contains "$launch" "FM_PI_HARNESS=pi '$FAKEBIN_DIR/pi' --tui-mode regular -ne -e" \
+    "pi launch did not force the regular TUI and explicit resource allowlist"
+  assert_contains "$launch" "'$HOME_DIR/config/npm/node_modules/@ff-labs/pi-fff/src/index.ts'" \
+    "pi launch did not load the required worker resource extension"
+  assert_contains "$launch" "'$HOME_DIR/config/extensions/pi-openai-server-compaction/src/index.ts'" \
+    "pi launch did not load the required OpenAI compaction extension"
+  assert_contains "$launch" "--model 'openai-codex/gpt-5.6-sol' --thinking 'max' -e" \
+    "pi launch did not thread the requested model and max thinking level"
   assert_not_contains "$launch" "FM_FIRSTMATE_PI_LAUNCH_BRIEF=" \
     "pi launch still exports the removed Calm input-reroute binding"
   assert_contains "$launch" "fm-operational-input.sh' encode launch-brief" \
@@ -645,8 +661,14 @@ test_pi_signed_threads_shared_pi_profile_and_preserves_identity() {
   assert_contains "$out" "spawned $id harness=pi-signed" "pi-signed spawn did not preserve its visible identity"
   assert_meta_profile "$HOME_DIR/state/$id.meta" pi-signed openai-codex/gpt-5.6-sol max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "FM_PI_HARNESS=pi-signed '$FAKEBIN_DIR/pi-signed' --tui-mode regular --model 'openai-codex/gpt-5.6-sol' --thinking 'max' -e" \
-    "pi-signed launch did not force the regular TUI with Pi's model, thinking, and extension semantics"
+  assert_contains "$launch" "FM_PI_HARNESS=pi-signed '$FAKEBIN_DIR/pi-signed' --tui-mode regular -ne -e" \
+    "pi-signed launch did not force the regular TUI and explicit resource allowlist"
+  assert_contains "$launch" "'$HOME_DIR/config/npm/node_modules/@ff-labs/pi-fff/src/index.ts'" \
+    "pi-signed launch did not load the required worker resource extension"
+  assert_contains "$launch" "'$HOME_DIR/config/extensions/pi-openai-server-compaction/src/index.ts'" \
+    "pi-signed launch did not load the required OpenAI compaction extension"
+  assert_contains "$launch" "--model 'openai-codex/gpt-5.6-sol' --thinking 'max' -e" \
+    "pi-signed launch did not thread Pi's model and max thinking level"
   assert_contains "$launch" "fm-operational-input.sh' encode launch-brief" \
     "pi-signed launch lost the canonical typed launch-brief envelope"
   assert_present "$HOME_DIR/state/$id.pi-ext.ts" "pi-signed launch did not install Pi's turn-end extension"
@@ -735,7 +757,7 @@ test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity() {
     "pi-signed secondmate spawn did not preserve its runtime identity"
   assert_meta_profile "$HOME_DIR/state/$id.meta" pi-signed default default
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "FM_PI_HARNESS=pi-signed '$FAKEBIN_DIR/pi-signed' --tui-mode regular -e '$sm/.pi/extensions/fm-primary-turnend-guard.ts' -e '$sm/.pi/extensions/fm-primary-pi-watch.ts'" \
+  assert_contains "$launch" "FM_PI_HARNESS=pi-signed '$FAKEBIN_DIR/pi-signed' --tui-mode regular -ne -e '$sm/.pi/extensions/fm-primary-turnend-guard.ts' -e '$sm/.pi/extensions/fm-primary-pi-watch.ts'" \
     "pi-signed secondmate did not force the regular TUI with Pi's primary extension launch shape"
   pass "pi-signed is a distinct persistent secondmate runtime with shared Pi supervision semantics"
 }


### PR DESCRIPTION
## Summary
- Align optional tool-result and summary usage selection with Pi 0.83.0 native totals.
- Attribute assistant usage to responseModel when present and sanitize persisted session IDs.
- Reject late session headers as final and clarify observed-stable evidence semantics.

## Evidence
- Three representative primary sessions were regenerated as sanitized private aggregates.
- Pi 0.83.0 SessionManager/getSessionStats parity passed for all three captured sessions.
- Focused parser tests cover optional usage parity, responseModel attribution, late headers, privacy, malformed and unstable files.
- Full Firstmate lint, diff checks, privacy, schema, identity, and permission scans passed.

## Scope
- Phase 0 only. No Phase 1, no no-mistakes run, no Seatbelt work, no browser grants, and no merge.