### PR TITLE
fix(teardown): spare deliberately detached daemons from the lane reap

### DIFF
--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -123,6 +123,17 @@
 #     roots are unique per task and never
 #     shared, so this can never reach another task's or the primary's
 #     processes. Idempotent: nothing left to find is a silent no-op.
+#     One exception is spared: a process that is BOTH already reparented to
+#     init (PPID 1) AND the leader of its own process group (PID == PGID) is a
+#     deliberately detached daemon, not a lane leak, so it survives teardown.
+#     That signature covers a long-lived service a task happened to start from
+#     its worktree - the `limactl hostagent` behind a `colima restart` inherits
+#     the launching shell's cwd and never chdirs, so an unguarded reap took the
+#     captain's Colima VM down with the lane (observed twice on 2026-08-10).
+#     An ordinary lane process, still a child of the task's shell or harness,
+#     fails at least one half of the signature and is reaped as before. Every
+#     spared process is reported once by pid and command, so a rare genuine
+#     leak wearing that signature stays diagnosable rather than silent.
 #   Fix 3 - sweep abandoned remote job workers. A remote job worker started
 #     from a worktree's own bin/ outlives that worktree's removal without
 #     being reachable by Fix 2, because its working directory is wherever it
@@ -1351,10 +1362,44 @@ task_pid_list_contains() {  # <pid-list> <pid>
   printf '%s\n' "$1" | grep -Fxq "$2"
 }
 
+# A deliberately detached daemon carries a two-part signature: it is already
+# reparented to init (PPID 1) AND leads its own process group (PID == PGID).
+# A process the task's own shell or harness left behind fails at least one of
+# those, so sparing this signature never spares an ordinary lane leak.
+# Unreadable ppid/pgid is not the signature: the process stays reapable.
+task_pid_is_detached_daemon() {  # <pid>
+  local pid=$1 fields ppid pgid
+  case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+  fields=$(LC_ALL=C ps -p "$pid" -o ppid=,pgid= 2>/dev/null) || return 1
+  # shellcheck disable=SC2086 # deliberate word splitting of the two ps fields
+  set -- $fields
+  [ "$#" -eq 2 ] || return 1
+  ppid=$1
+  pgid=$2
+  case "$ppid" in ''|*[!0-9]*) return 1 ;; esac
+  case "$pgid" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$ppid" -eq 1 ] || return 1
+  [ "$pgid" -eq "$pid" ]
+}
+
+# Report every spared daemon exactly once per teardown, so a rare genuine leak
+# that happens to wear the signature stays diagnosable instead of vanishing
+# silently from the reap.
+TASK_SPARED_DAEMON_PIDS=""
+announce_spared_detached_daemon() {  # <pid>
+  local pid=$1 cmd
+  task_pid_list_contains "$TASK_SPARED_DAEMON_PIDS" "$pid" && return 0
+  TASK_SPARED_DAEMON_PIDS="$TASK_SPARED_DAEMON_PIDS
+$pid"
+  cmd=$(LC_ALL=C ps -p "$pid" -o args= 2>/dev/null) || cmd=""
+  cmd=$(printf '%s' "$cmd" | tr '\n' ' ')
+  echo "teardown: sparing detached daemon for $ID: pid $pid (${cmd:-<unknown command>})" >&2
+}
+
 task_pids_under_roots() {  # <dir>...
   TASK_PIDS=
   TASK_PIDS_FAILED_DIR=
-  local dir dir_pids pids=""
+  local dir dir_pids pids="" pid kept=""
   for dir in "$@"; do
     [ -n "$dir" ] || continue
     if ! dir_pids=$(pids_with_cwd_under "$dir"); then
@@ -1364,7 +1409,19 @@ task_pids_under_roots() {  # <dir>...
     pids="$pids
 $dir_pids"
   done
-  TASK_PIDS=$(printf '%s\n' "$pids" | grep -E '^[0-9]+$' | sort -un || true)
+  pids=$(printf '%s\n' "$pids" | grep -E '^[0-9]+$' | sort -un || true)
+  while IFS= read -r pid; do
+    [ -n "$pid" ] || continue
+    if task_pid_is_detached_daemon "$pid"; then
+      announce_spared_detached_daemon "$pid"
+      continue
+    fi
+    kept="$kept
+$pid"
+  done <<EOF
+$pids
+EOF
+  TASK_PIDS=$(printf '%s\n' "$kept" | grep -E '^[0-9]+$' || true)
 }
 
 reap_task_backend_process_group() {  # <label>

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -2591,6 +2591,118 @@ EOF
   pass "the run abort and the leaked-process reap both complete before the destructive worktree return"
 }
 
+# --- Deliberately detached daemons survive the reap -----------------------
+# A process that is BOTH reparented to init (PPID 1) AND the leader of its own
+# process group is a daemon someone meant to outlive the lane (the observed
+# case: `limactl hostagent`, which inherits the launching shell's cwd and never
+# chdirs, so a `colima restart` run from a worktree bound the captain's VM to
+# the lane's lifetime). Teardown spares that signature and reports it; every
+# ordinary lane process is still reaped.
+
+# Start a process under <dir> whose parent exits immediately, so it is
+# reparented to init. With <own-group>=1 it also leads its own process group,
+# which completes the detached-daemon signature; with 0 it inherits this
+# shell's group and must stay reapable. Echoes nothing; writes the pid to
+# <pidfile>.
+spawn_orphan() {  # <dir> <pidfile> <own-group>
+  perl -e '
+    my ($dir, $pidfile, $own_group) = @ARGV;
+    my $pid = fork();
+    die "fork failed" unless defined $pid;
+    exit 0 if $pid;
+    setpgrp(0, 0) if $own_group;
+    chdir $dir or die "chdir failed";
+    open my $fh, ">", $pidfile or die "open failed";
+    print $fh "$$\n";
+    close $fh;
+    exec "sleep", "300" or die "exec failed";
+  ' "$1" "$2" "$3"
+  local waited=0
+  while [ ! -s "$2" ]; do
+    waited=$((waited + 1))
+    [ "$waited" -le 100 ] || fail "spawn_orphan: process under $1 never reported its pid"
+    sleep 0.05
+  done
+  sleep 0.2
+}
+
+test_detached_daemon_survives_teardown_and_is_reported() {
+  local case_dir rc daemon_pid daemon_ppid daemon_pgid lane_pid
+  case_dir=$(make_case detached-daemon-spared)
+  write_meta "$case_dir" no-mistakes ship
+  land_shippable_commit "$case_dir"
+
+  spawn_orphan "$case_dir/wt" "$case_dir/daemon.pid" 1
+  daemon_pid=$(cat "$case_dir/daemon.pid")
+  daemon_ppid=$(ps -p "$daemon_pid" -o ppid= | tr -d '[:space:]')
+  daemon_pgid=$(ps -p "$daemon_pid" -o pgid= | tr -d '[:space:]')
+  [ "$daemon_ppid" = 1 ] \
+    || fail "detached-daemon-spared: fixture daemon is not reparented to init (ppid $daemon_ppid)"
+  [ "$daemon_pgid" = "$daemon_pid" ] \
+    || fail "detached-daemon-spared: fixture daemon does not lead its own group (pgid $daemon_pgid)"
+
+  # An ordinary lane process in the same worktree: still a child of this shell,
+  # so it fails the signature and must still be reaped.
+  ( cd "$case_dir/wt" && exec sleep 300 ) &
+  lane_pid=$!
+  disown
+  sleep 0.3
+  kill -0 "$lane_pid" 2>/dev/null || fail "detached-daemon-spared: setup lane sleeper did not start"
+
+  rc=0
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+
+  expect_code 0 "$rc" "detached-daemon-spared: teardown should still succeed"
+  if ! kill -0 "$daemon_pid" 2>/dev/null; then
+    kill -KILL "$lane_pid" 2>/dev/null || true
+    fail "detached-daemon-spared: teardown killed a deliberately detached daemon"
+  fi
+  kill -KILL "$daemon_pid" 2>/dev/null || true
+  if kill -0 "$lane_pid" 2>/dev/null; then
+    kill -KILL "$lane_pid" 2>/dev/null || true
+    fail "detached-daemon-spared: an ordinary lane process survived teardown"
+  fi
+  assert_grep "sparing detached daemon for task-x1: pid $daemon_pid (" "$case_dir/stderr" \
+    "detached-daemon-spared: teardown spared the daemon silently instead of reporting its pid"
+  assert_grep "sleep" "$case_dir/stderr" \
+    "detached-daemon-spared: the sparing line did not name the spared command"
+  assert_grep "reaping leaked worktree process" "$case_dir/stderr" \
+    "detached-daemon-spared: teardown did not report reaping the ordinary lane process"
+  pass "a detached daemon survives teardown and is reported, while an ordinary lane process is still reaped"
+}
+
+test_reparented_non_group_leader_is_still_reaped() {
+  local case_dir rc pid ppid pgid
+  case_dir=$(make_case reparented-non-leader-reaped)
+  write_meta "$case_dir" no-mistakes ship
+  land_shippable_commit "$case_dir"
+
+  # Reparented to init but NOT its own group leader: only half the signature,
+  # so this is an ordinary lane leak and must still be reaped.
+  spawn_orphan "$case_dir/wt" "$case_dir/orphan.pid" 0
+  pid=$(cat "$case_dir/orphan.pid")
+  ppid=$(ps -p "$pid" -o ppid= | tr -d '[:space:]')
+  pgid=$(ps -p "$pid" -o pgid= | tr -d '[:space:]')
+  [ "$ppid" = 1 ] \
+    || fail "reparented-non-leader-reaped: fixture process is not reparented to init (ppid $ppid)"
+  [ "$pgid" != "$pid" ] \
+    || fail "reparented-non-leader-reaped: fixture process unexpectedly leads its own group"
+
+  rc=0
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+
+  expect_code 0 "$rc" "reparented-non-leader-reaped: teardown should still succeed"
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -KILL "$pid" 2>/dev/null || true
+    fail "reparented-non-leader-reaped: a reparented non-group-leader survived teardown"
+  fi
+  assert_no_grep "sparing detached daemon" "$case_dir/stderr" \
+    "reparented-non-leader-reaped: teardown spared a process that only met half the signature"
+  assert_grep "reaping leaked worktree process" "$case_dir/stderr" \
+    "reparented-non-leader-reaped: teardown did not report reaping the leaked process"
+  pass "a reparented process that does not lead its own group is still reaped"
+}
+
 test_local_only_fork_remote_allows
 test_teardown_prompts_tasks_axi_done_when_compatible
 test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
@@ -2649,3 +2761,5 @@ test_process_spawned_during_grace_is_reaped_on_later_pass
 test_persistent_scan_refuses_after_bounded_retries
 test_process_exit_during_identity_lookup_does_not_refuse
 test_run_abort_precedes_process_reap_precedes_worktree_removal
+test_detached_daemon_survives_teardown_and_is_reported
+test_reparented_non_group_leader_is_still_reaped


### PR DESCRIPTION
## Summary

Task teardown's leaked-process reap no longer kills deliberately detached daemons.

`reap_task_worktree_processes` (Fix 2 in the script header) sends TERM then KILL to every process whose current working directory is under the task's worktree or tasktmp.
A `limactl hostagent` inherits the cwd of the shell that launched it and never chdirs, so a `colima restart` run from inside a task worktree binds the Colima VM's lifetime to that lane, and teardown shuts the VM down.
Observed twice on 2026-08-10.

The reap selector now spares any process carrying **both** halves of the detached-daemon signature:

1. already reparented to init (`PPID == 1`), and
2. leader of its own process group (`PID == PGID`).

An ordinary lane process is still a child of the task's shell or harness, so it fails at least one half and is reaped exactly as before.

## Changes

- `bin/fm-teardown.sh`
  - New `task_pid_is_detached_daemon` predicate reading `ps -p <pid> -o ppid=,pgid=`.
  - The filter is applied inside the shared selector `task_pids_under_roots`, **not** at the kill sites.
    That placement is deliberate: the post-reap check that refuses teardown when processes "remain after N reap attempts" reads the same list, so filtering at the kill sites alone would have left a spared daemon tripping that refusal and blocking every teardown of that lane.
  - Unreadable or non-numeric ppid/pgid is deliberately **not** treated as the signature, so an unverifiable process stays reapable and the reap is not weakened where that read fails.
  - Every spared process is reported once, by pid and command: `teardown: sparing detached daemon for <task>: pid <pid> (<command>)`.
    Deduplicated per pid via a script-level list, because the selector runs several times per reap pass.
  - Behavior and the Colima rationale documented in the script's existing header comment (Fix 2 paragraph). No new documentation file.
- `tests/fm-teardown.test.sh` - two colocated behavioral cases driving the real teardown path:
  - a detached daemon (PPID 1 + own group leader) survives teardown, the visibility line is emitted with its pid and command, and an ordinary lane process in the same worktree is still reaped;
  - a reparented process that is **not** its own group leader (only half the signature) is still reaped, and no sparing line is emitted for it.

Nothing else in teardown's semantics changes: unlanded-work refusals, reassigned-slot protection, and the rest of the contract are untouched.

## Validation

Run through the local no-mistakes pipeline; review, test, document, and lint all completed green.
The push step could not reach the upstream repository from this machine (no write access), so the branch was pushed to a fork and this PR opened manually; no pipeline CI ran locally.

Additional local evidence:

- `bin/fm-lint.sh` clean (ShellCheck 0.11.0, the pinned version).
- The two new tests were confirmed **red without the fix** and green with it.
- `tests/fm-teardown.test.sh` otherwise passes (58 cases) and `tests/fm-teardown-endpoint-safety.test.sh` passes.

## Known limitation

`bin/fm-teardown.sh` runs `treehouse return --force` a few lines after the corrected reap, on the treehouse-managed worktree path.
`treehouse return` describes itself as "Terminate lingering processes and return a worktree" and terminates by cwd, so on a treehouse-managed lane a daemon spared by this change can still be killed seconds later by that sibling step.
`treehouse` is an external dependency outside this repository, so extending the guard there was deliberately left out of this change and is tracked as separate follow-up work.

## Pre-existing test failure (not from this change)

`tests/fm-teardown.test.sh` contains one failing case, `herdr-preflight-missing-adapter`, reproduced identically on the unmodified tree before any change here.
It passes `FM_ROOT_OVERRIDE="$ROOT"` while removing `bin/backends/herdr.sh` only from a copied tree, so the copied teardown still resolves the adapter from the real root and does not refuse.
Flagging it because it aborts the suite before later cases run; it is unrelated to this fix.
