### PR TITLE
Relaunch meta rebuild keeps pr= lines last

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2772,8 +2772,12 @@ spawn_record_traceparent() {
   SPAWN_META_LOCK_HELD=1
   SPAWN_META_TMP="$STATE/.$ID.meta.trace.${BASHPID:-$$}"
   if [ ! -f "$meta" ] || [ ! -w "$meta" ] \
-     || ! awk -F= '$1 != "traceparent"' "$meta" > "$SPAWN_META_TMP" \
-     || ! printf 'traceparent=%s\n' "$SPAWN_TRACEPARENT" >> "$SPAWN_META_TMP" \
+     || ! awk -F= -v traceparent="$SPAWN_TRACEPARENT" '
+       $1 == "traceparent" { next }
+       $1 == "pr" && !inserted { print "traceparent=" traceparent; inserted=1 }
+       { print }
+       END { if (!inserted) print "traceparent=" traceparent }
+     ' "$meta" > "$SPAWN_META_TMP" \
      || ! mv -f "$SPAWN_META_TMP" "$meta"; then
     status=1
     rm -f "$SPAWN_META_TMP" 2>/dev/null || true

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2635,7 +2635,9 @@ preserve_relaunch_meta() {
       split("window endpoint_task_id worktree project harness kind mode yolo tasktmp model effort busy_gen spawn_gen traceparent backend herdr_session herdr_workspace_id herdr_tab_id herdr_pane_id zellij_session zellij_tab_id zellij_pane_id orca_worktree_id terminal cmux_workspace_id cmux_surface_id home projects control_relaunch_tx", keys, " ")
       for (i in keys) owned[keys[i]] = 1
     }
-    !($1 in owned)
+    $1 == "pr" || $1 == "pr_head" { pr_lines[++pr_count] = $0; next }
+    !($1 in owned) { print }
+    END { for (i = 1; i <= pr_count; i++) print pr_lines[i] }
   ' "$RELAUNCH_META"
 }
 {
@@ -2774,9 +2776,12 @@ spawn_record_traceparent() {
   if [ ! -f "$meta" ] || [ ! -w "$meta" ] \
      || ! awk -F= -v traceparent="$SPAWN_TRACEPARENT" '
        $1 == "traceparent" { next }
-       $1 == "pr" && !inserted { print "traceparent=" traceparent; inserted=1 }
+       $1 == "pr" || $1 == "pr_head" { pr_lines[++pr_count] = $0; next }
        { print }
-       END { if (!inserted) print "traceparent=" traceparent }
+       END {
+         print "traceparent=" traceparent
+         for (i = 1; i <= pr_count; i++) print pr_lines[i]
+       }
      ' "$meta" > "$SPAWN_META_TMP" \
      || ! mv -f "$SPAWN_META_TMP" "$meta"; then
     status=1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2680,11 +2680,11 @@ preserve_relaunch_meta() {
     echo "home=$PROJ_ABS"
     echo "projects=$SECONDMATE_PROJECTS"
   fi
-  if [ "$RELAUNCH" -eq 1 ]; then
-    preserve_relaunch_meta
-  fi
   if [ "$SPAWN_CONTROL_PARENT" = 1 ] && [ -n "${FM_CONTROL_RELAUNCH_TX:-}" ]; then
     echo "control_relaunch_tx=$FM_CONTROL_RELAUNCH_TX"
+  fi
+  if [ "$RELAUNCH" -eq 1 ]; then
+    preserve_relaunch_meta
   fi
 } > "$SPAWN_META_PATH"
 if [ "$RELAUNCH" -eq 1 ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -187,6 +187,9 @@
 # one W3C traceparent= carrier, the same value injected into the pane as
 # TRACEPARENT; the default-off path writes neither, leaving the generated meta
 # and launch environment unchanged.
+# On relaunch, preserved pr= and pr_head= lines are published after every other
+# durable field; a trace-enabled publication places traceparent= before those
+# PR lines so the strict PR identity record remains parseable.
 #   --traceparent <carrier> delivers a carrier that a REMOTE parent already
 #   resolved and will record, instead of resolving one from this home's frozen
 #   decision. It is accepted only for --secondmate spawns, only as a strictly

--- a/bin/fm-x-lib.sh
+++ b/bin/fm-x-lib.sh
@@ -928,6 +928,23 @@ fmx_meta_tmp() {
   mktemp "$dir/.${base}.fm-x.XXXXXX"
 }
 
+fmx_meta_pr_lines_last() {
+  local file=$1 normalized
+  normalized=$(fmx_meta_tmp "$file") || return 1
+  if ! awk -F= '
+    $1 == "pr" || $1 == "pr_head" { pr_lines[++pr_count] = $0; next }
+    { print }
+    END { for (i = 1; i <= pr_count; i++) print pr_lines[i] }
+  ' "$file" > "$normalized"; then
+    rm -f "$normalized"
+    return 1
+  fi
+  if ! mv -f "$normalized" "$file"; then
+    rm -f "$normalized"
+    return 1
+  fi
+}
+
 # fmx_meta_link_set <meta> <request_id> <epoch> [followups] [platform] [max]:
 # atomically (re)write the x_request/x_request_ts/x_followups lines plus optional
 # reply-platform context, dropping any prior link and preserving every other meta
@@ -955,6 +972,7 @@ fmx_meta_link_set() {
     ''|*[!0-9]*) ;;
     *) printf 'x_reply_max_chars=%s\n' "$reply_max" >> "$tmp" || { rm -f "$tmp"; fm_lock_release "$lock"; return 1; } ;;
   esac
+  fmx_meta_pr_lines_last "$tmp" || { rm -f "$tmp"; fm_lock_release "$lock"; return 1; }
   mv -f "$tmp" "$meta" || { rm -f "$tmp"; fm_lock_release "$lock"; return 1; }
   fm_lock_release "$lock"
 }
@@ -973,6 +991,7 @@ fmx_meta_followups_set() {
     rm -f "$tmp"; fm_lock_release "$lock"; return 1
   fi
   printf 'x_followups=%s\n' "$n" >> "$tmp" || { rm -f "$tmp"; fm_lock_release "$lock"; return 1; }
+  fmx_meta_pr_lines_last "$tmp" || { rm -f "$tmp"; fm_lock_release "$lock"; return 1; }
   mv -f "$tmp" "$meta" || { rm -f "$tmp"; fm_lock_release "$lock"; return 1; }
   fm_lock_release "$lock"
 }
@@ -991,6 +1010,7 @@ fmx_meta_link_clear() {
   if ! { grep -vE '^x_request=|^x_request_ts=|^x_followups=|^x_platform=|^x_reply_max_chars=' "$meta" || true; } > "$tmp"; then
     rm -f "$tmp"; fm_lock_release "$lock"; return 1
   fi
+  fmx_meta_pr_lines_last "$tmp" || { rm -f "$tmp"; fm_lock_release "$lock"; return 1; }
   mv -f "$tmp" "$meta" || { rm -f "$tmp"; fm_lock_release "$lock"; return 1; }
   fm_lock_release "$lock"
 }

--- a/bin/fm-x-lib.sh
+++ b/bin/fm-x-lib.sh
@@ -906,7 +906,9 @@ fmx_post_json() (
 # fm-x-followup.sh posts against that link (within the window, up to the cap),
 # then either records the incremented count or clears the link. These helpers
 # own the read/write/clear so fm-x-link.sh and fm-x-followup.sh never hand-edit
-# meta and the rewrite stays atomic and preserves every other meta line.
+# meta and the rewrite stays atomic and preserves every other meta line. Each
+# mutation also republishes pr= and pr_head= after all other fields, because
+# the strict PR identity parser allows only the whitelisted X fields after pr=.
 
 # fmx_meta_get <meta> <key>: print the value of the last "key=value" line in
 # <meta>, or nothing (and succeed) when the file or key is absent. Callers treat

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -70,6 +70,7 @@ It is not deterministic across the verified adapters: codex and grok resume only
    A secondmate relaunch does not require one and never rewrites its standing charter.
 4. **Stop the old agent** through the `exit` verb, with its postcondition.
 5. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.
+   Relaunch publication and the shared Relay metadata writers keep preserved `pr=` and `pr_head=` lines at the end of `state/<id>.meta`, so the strict PR identity parser continues to accept the record after replacement and follow-up updates.
 
 Switching harness is therefore one ordinary relaunch rather than a separate mechanism.
 

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -276,7 +276,7 @@ test_same_harness_relaunch_keeps_identity_and_reuses_the_endpoint() {
 }
 
 test_relaunch_preserves_durable_task_metadata() {
-  local dir out rc
+  local dir out rc traceparent
   dir=$(new_case durable-meta rl19)
   add_ship_task "$dir" rl19 claude
   local meta="$dir/home/state/rl19.meta"
@@ -286,6 +286,8 @@ test_relaunch_preserves_durable_task_metadata() {
     printf '%s\n' 'pr=https://github.com/example/repo/pull/19'
     printf '%s\n' 'pr_head=0123456789abcdef0123456789abcdef01234567'
   } >> "$meta"
+  printf '%s\n' "$$" > "$dir/home/state/.lock"
+  printf '%s on\n' "$$" > "$dir/home/state/.trace-context-effective"
 
   out=$(run_control "$dir" rl19 relaunch --note "continuing review work"); rc=$?
   expect_code 0 "$rc" "relaunch should preserve durable metadata"$'\n'"$out"
@@ -297,6 +299,9 @@ test_relaunch_preserves_durable_task_metadata() {
     || fail "the task X request must survive relaunch"
   [ "$(meta_field "$dir" rl19 decisions_reviewed)" = 1 ] \
     || fail "the task decision state must survive relaunch"
+  traceparent=$(meta_field "$dir" rl19 traceparent)
+  fm_trace_context_valid "$traceparent" \
+    || fail "the trace-enabled relaunch must record a valid trace carrier"
   [ "$(tail -n 2 "$meta")" = $'pr=https://github.com/example/repo/pull/19\npr_head=0123456789abcdef0123456789abcdef01234567' ] \
     || fail "PR metadata must remain the final lines after relaunch"
   fm_pr_metadata_identity_parse "$meta" \

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -25,6 +25,8 @@ set -u
 . "$ROOT/bin/fm-control-lib.sh"
 # shellcheck source=/dev/null
 . "$ROOT/bin/fm-trace-context-lib.sh"
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-pr-lib.sh"
 
 CONTROL="$ROOT/bin/fm-control.sh"
 SPAWN="$ROOT/bin/fm-spawn.sh"
@@ -277,24 +279,29 @@ test_relaunch_preserves_durable_task_metadata() {
   local dir out rc
   dir=$(new_case durable-meta rl19)
   add_ship_task "$dir" rl19 claude
+  local meta="$dir/home/state/rl19.meta"
   {
-    printf '%s\n' 'pr=https://github.com/example/repo/pull/19'
-    printf '%s\n' 'pr_head=feature/relaunch'
     printf '%s\n' 'x_request=request-19'
     printf '%s\n' 'decisions_reviewed=1'
-  } >> "$dir/home/state/rl19.meta"
+    printf '%s\n' 'pr=https://github.com/example/repo/pull/19'
+    printf '%s\n' 'pr_head=0123456789abcdef0123456789abcdef01234567'
+  } >> "$meta"
 
   out=$(run_control "$dir" rl19 relaunch --note "continuing review work"); rc=$?
   expect_code 0 "$rc" "relaunch should preserve durable metadata"$'\n'"$out"
   [ "$(meta_field "$dir" rl19 pr)" = "https://github.com/example/repo/pull/19" ] \
     || fail "the task PR must survive relaunch"
-  [ "$(meta_field "$dir" rl19 pr_head)" = "feature/relaunch" ] \
+  [ "$(meta_field "$dir" rl19 pr_head)" = "0123456789abcdef0123456789abcdef01234567" ] \
     || fail "the task PR head must survive relaunch"
   [ "$(meta_field "$dir" rl19 x_request)" = "request-19" ] \
     || fail "the task X request must survive relaunch"
   [ "$(meta_field "$dir" rl19 decisions_reviewed)" = 1 ] \
     || fail "the task decision state must survive relaunch"
-  pass "fm-control relaunch: durable task metadata survives replacement launch publication"
+  [ "$(tail -n 2 "$meta")" = $'pr=https://github.com/example/repo/pull/19\npr_head=0123456789abcdef0123456789abcdef01234567' ] \
+    || fail "PR metadata must remain the final lines after relaunch"
+  fm_pr_metadata_identity_parse "$meta" \
+    || fail "the relaunch-shaped metadata must pass PR identity parsing"
+  pass "fm-control relaunch: durable metadata survives replacement publication with PR lines last"
 }
 
 test_relaunch_serializes_concurrent_durable_metadata_publication() {

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -200,6 +200,19 @@ make_x_linked_metadata() {  # <metadata-path>
     _ "$ROOT" "$meta"
 }
 
+make_x_followups_metadata() {  # <metadata-path>
+  local meta=$1 state home
+  state=${meta%/*}
+  home=${state%/*}
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" \
+    bash -c '
+      . "$1/bin/fm-wake-lib.sh"
+      . "$1/bin/fm-x-lib.sh"
+      fmx_meta_followups_set "$2" 1
+    ' \
+    _ "$ROOT" "$meta"
+}
+
 journal_field() {  # <case-dir> <id> <key>
   grep "^$3=" "$1/home/state/$2.control-relaunch" | tail -1 | cut -d= -f2-
 }
@@ -316,6 +329,10 @@ test_relaunch_preserves_durable_task_metadata() {
   traceparent=$(meta_field "$dir" rl19 traceparent)
   fm_trace_context_valid "$traceparent" \
     || fail "the trace-enabled relaunch must record a valid trace carrier"
+  make_x_linked_metadata "$meta" \
+    || fail "the shared link writer should update metadata after trace publication"
+  make_x_followups_metadata "$meta" \
+    || fail "the shared follow-up writer should update metadata after trace publication"
   [ "$(tail -n 2 "$meta")" = $'pr=https://github.com/example/repo/pull/19\npr_head=0123456789abcdef0123456789abcdef01234567' ] \
     || fail "PR metadata must remain the final lines after relaunch"
   fm_pr_metadata_identity_parse "$meta" \

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -187,6 +187,19 @@ meta_field() {  # <case-dir> <id> <key>
   grep "^$3=" "$1/home/state/$2.meta" | tail -1 | cut -d= -f2-
 }
 
+make_x_linked_metadata() {  # <metadata-path>
+  local meta=$1 state home
+  state=${meta%/*}
+  home=${state%/*}
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" \
+    bash -c '
+      . "$1/bin/fm-wake-lib.sh"
+      . "$1/bin/fm-x-lib.sh"
+      fmx_meta_link_set "$2" request-19 1700000000 1 x 280
+    ' \
+    _ "$ROOT" "$meta"
+}
+
 journal_field() {  # <case-dir> <id> <key>
   grep "^$3=" "$1/home/state/$2.control-relaunch" | tail -1 | cut -d= -f2-
 }
@@ -281,11 +294,12 @@ test_relaunch_preserves_durable_task_metadata() {
   add_ship_task "$dir" rl19 claude
   local meta="$dir/home/state/rl19.meta"
   {
-    printf '%s\n' 'x_request=request-19'
     printf '%s\n' 'decisions_reviewed=1'
     printf '%s\n' 'pr=https://github.com/example/repo/pull/19'
     printf '%s\n' 'pr_head=0123456789abcdef0123456789abcdef01234567'
   } >> "$meta"
+  make_x_linked_metadata "$meta" \
+    || fail "the relaunch fixture should build through the X metadata writer"
   printf '%s\n' "$$" > "$dir/home/state/.lock"
   printf '%s on\n' "$$" > "$dir/home/state/.trace-context-effective"
 


### PR DESCRIPTION
## Summary

`fm-control.sh <id> relaunch` rebuilds a task's `state/<id>.meta`; the rebuild could leave `pr=`/`pr_head=` lines in the middle of the file, and the strict PR-poll identity parsers (`fm_pr_metadata_identity_parse` / `fm_pr_poll_artifacts_valid`) reject any non-whitelisted line after `pr=`. Every relaunch of a PR-armed task therefore invalidated its armed merge poll, which the watcher then quarantined as "rejected unauthenticated state checks" and woke firstmate on each cycle.

This change normalizes metadata publication so `pr=` and `pr_head=` are always the final lines after any writer:

- The relaunch rebuild emits preserved non-PR fields first, then `pr=`/`pr_head=` last.
- `traceparent=` (trace-enabled relaunches) is folded into the ordered publication instead of appended after the PR lines.
- Shared metadata writers (`fmx_meta_link_set`, `fmx_meta_followups_set` in `bin/fm-x-lib.sh`) normalize the same way, so no writer can leave `x_*` lines after `pr=`.
- Regression coverage in `tests/fm-control-relaunch.test.sh` covers the relaunch order, the parser acceptance, and the trace-enabled path.

## Verification

- Targeted relaunch and PR-security tests pass.
- Validated through the no-mistakes pipeline: review, fixes, document, and lint steps completed.
