### PR TITLE
fix(bin): refuse duplicate worktree ownership and bound uncreatable-lock recovery

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1727,6 +1727,26 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   fi
 }
 
+assert_spawn_worktree_unowned() {
+  local wt_real meta owner owner_wt owner_real
+  wt_real=$(cd "$WT" 2>/dev/null && pwd -P) || {
+    echo "error: could not canonicalize candidate worktree '$WT' before ownership validation" >&2
+    exit 1
+  }
+  for meta in "$STATE"/*.meta; do
+    [ -f "$meta" ] && [ ! -L "$meta" ] || continue
+    owner=$(basename "$meta" .meta)
+    [ "$owner" = "$ID" ] && continue
+    owner_wt=$(sed -n 's/^worktree=//p' "$meta" | head -n 1)
+    [ -n "$owner_wt" ] || continue
+    owner_real=$(cd "$owner_wt" 2>/dev/null && pwd -P) || continue
+    if [ "$owner_real" = "$wt_real" ]; then
+      echo "error: candidate worktree '$wt_real' is already owned by task '$owner'; refusing to launch '$ID' in a shared copy" >&2
+      exit 1
+    fi
+  done
+}
+
 freshen_spawn_worktree_base() {  # <worktree>
   local worktree=$1 default target expected actual status
   if ! git -C "$worktree" fetch --quiet origin; then
@@ -2259,6 +2279,9 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   fi
 
   validate_spawn_worktree "treehouse get" "$T"
+fi
+if [ "$KIND" != secondmate ]; then
+  assert_spawn_worktree_unowned
 fi
 if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
   freshen_spawn_worktree_base "$WT" || exit 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -134,6 +134,12 @@
 #   default-branch commit when safe; skipped syncs warn and launch unchanged.
 #   Ship/scout spawns refuse to launch unless the resolved task path is a real
 #   git worktree root distinct from the primary project checkout.
+#   Every non-secondmate spawn additionally refuses, before branch prep, launch,
+#   or metadata publication, a candidate worktree whose canonical path already
+#   matches another task's recorded worktree= in state/*.meta (plain files only;
+#   symlinked meta is ignored and endpoint liveness is never an ownership
+#   bypass), so two tasks never share one isolated copy. A same-task relaunch
+#   into its own recorded worktree is exempt.
 #   Before a fresh ship or scout worker starts, its clean task worktree fetches
 #   origin, resolves the current remote default branch, and resets to its tip.
 #   An unreachable origin, unresolved default branch, or non-clean worktree

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -406,7 +406,13 @@ fm_lock_claim() {
 fm_lock_try_create() {
   local lockdir=$1 allowed_steal_owner=${2:-} ownerdir
   FM_LOCK_OWNER_DIR=
-  ownerdir=$(fm_lock_owner_dir "$lockdir") || return 1
+  FM_LOCK_CREATE_ERROR=
+  if ! ownerdir=$(fm_lock_owner_dir "$lockdir"); then
+    if [ ! -e "$lockdir" ] && [ ! -L "$lockdir" ]; then
+      FM_LOCK_CREATE_ERROR=uncreatable
+    fi
+    return 1
+  fi
   if [ -e "$lockdir" ] || [ -L "$lockdir" ]; then
     fm_lock_discard_owner "$ownerdir"
     return 1
@@ -728,9 +734,15 @@ fm_lock_try_acquire() {
   FM_LOCK_HELD_PID=
   FM_LOCK_OWNER_DIR=
   FM_LOCK_RECOVERED_PID=
+  FM_LOCK_ERROR=
 
   if fm_lock_try_create "$lockdir"; then
     return 0
+  fi
+  if [ "${FM_LOCK_CREATE_ERROR:-}" = uncreatable ] \
+     && [ ! -e "$lockdir" ] && [ ! -L "$lockdir" ]; then
+    FM_LOCK_ERROR=uncreatable-path
+    return 1
   fi
 
   # Compare against ${BASHPID:-$$} inline, never via a command substitution:
@@ -827,6 +839,7 @@ fm_lock_try_acquire() {
 fm_lock_acquire_wait() {
   local lockdir=$1
   while ! fm_lock_try_acquire "$lockdir"; do
+    [ "${FM_LOCK_ERROR:-}" = uncreatable-path ] && return 1
     sleep 0.1
   done
 }

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -1146,6 +1146,18 @@ teardown_task aflat "$SECOND_HOME_A" > "$TMP_ROOT/aflat-teardown.out" 2> "$TMP_R
   || fail "flat cross-home contention fixture teardown failed"
 pass "real Herdr lab: session lock contention from a secondmate home falls back flat with no journal"
 
+# The projection anchor above is deliberately never torn down so every earlier
+# projection could nest under its persistent firstmate workspace; its assertions
+# are complete by here. Its pooled worktree can be recycled to a later task, so
+# release the anchor's now-stale ownership record (and return the copy) before
+# the same-identity restarts below - otherwise a restart landing on a worktree
+# still recorded to 'anchor' is refused as a shared copy.
+ANCHOR_WT=$(grep '^worktree=' "$ANCHOR_META" | cut -d= -f2-)
+rm -f "$ANCHOR_META"
+if [ -n "$ANCHOR_WT" ]; then
+  "$REAL_TREEHOUSE" return --force "$ANCHOR_WT" >/dev/null 2>&1 || true
+fi
+
 # Same-identity recovery replaces only one exact agent-free husk in its
 # original projected workspace.
 # Exercise both the leading fm- identity style seen in Hi Bit work and the

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -37,12 +37,34 @@ make_spawn_fakebin() {
 #!/usr/bin/env bash
 set -u
 case "$*" in
-  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+  *"#{pane_current_path}"*)
+    # A real batch hands every task its own pooled worktree. When
+    # FM_FAKE_PANE_MAP_DIR is set, route each window's pane to a distinct
+    # worktree keyed by its window id (@<window-name>) so co-spawned tasks do
+    # not resolve to one shared copy; otherwise fall back to one fixed path.
+    if [ -n "${FM_FAKE_PANE_MAP_DIR:-}" ]; then
+      target= prev=
+      for a in "$@"; do [ "$prev" = "-t" ] && target=$a; prev=$a; done
+      key=${target#@}
+      if [ -n "$key" ] && [ -d "$FM_FAKE_PANE_MAP_DIR/$key" ]; then
+        printf '%s\n' "$FM_FAKE_PANE_MAP_DIR/$key"; exit 0
+      fi
+    fi
+    printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
 esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;
-  has-session|new-session|new-window|kill-window) exit 0 ;;
+  new-window)
+    # Echo a stable window id only when per-window routing is requested, so the
+    # pane query above can map it back to that task's worktree.
+    if [ -n "${FM_FAKE_PANE_MAP_DIR:-}" ]; then
+      name= prev=
+      for a in "$@"; do [ "$prev" = "-n" ] && name=$a; prev=$a; done
+      [ -n "$name" ] && printf '@%s\n' "$name"
+    fi
+    exit 0 ;;
+  has-session|new-session|kill-window) exit 0 ;;
   send-keys)
     if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
       prev=
@@ -244,6 +266,10 @@ test_home_defaults_preserve_absolute_or_resolve_relative_paths() {
 
   linked_home="$CASE_DIR/home-link"
   ln -s "$HOME_DIR" "$linked_home"
+  # The two spawns deliberately reuse one worktree to compare home-path
+  # spellings, not to co-own it. Release the first task's recorded ownership so
+  # the second spawn is not refused as a duplicate owner of the shared copy.
+  rm -f "$HOME_DIR/state/$relative_id.meta"
   : > "$LAUNCH_LOG"
   out=$(
     FM_ROOT_OVERRIDE='' FM_HOME="$linked_home" \
@@ -741,14 +767,21 @@ test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity() {
 }
 
 test_batch_forwards_shared_profile_flags() {
-  local rec id1 id2 out status
+  local rec id1 id2 out status map
   id1=profile-batch-a-z9
   id2=profile-batch-b-z10
   rec=$(make_spawn_case profile-batch claude "$id1" "$id2")
   read_case_record "$rec"
   enable_dispatch_profile "$HOME_DIR"
 
-  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+  # Each batch task gets its own real worktree, keyed by its fm-<id> window, so
+  # the pair is not refused for co-owning a single copy (as a real pool would).
+  map="$CASE_DIR/panes"
+  mkdir -p "$map"
+  git -C "$PROJ_DIR" worktree add --quiet -b "batch-$id1" "$map/fm-$id1"
+  git -C "$PROJ_DIR" worktree add --quiet -b "batch-$id2" "$map/fm-$id2"
+  out=$(FM_FAKE_PANE_MAP_DIR="$map" \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
     "$id1=$PROJ_DIR" "$id2=$PROJ_DIR" --harness codex --model gpt-5 --effort high)
   status=$?
   expect_code 0 "$status" "batch spawn with shared profile flags should succeed"

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -104,6 +104,10 @@ test_stale_pool_base_refreshes_before_branching() {
       "$branch_head" "$current" "$(cat "$POOL_DIR/advanced-main.txt")"
   fi
 
+  # The repeat exercises a fresh task reusing the same pooled base after the
+  # first owner released it; drop the prior owner's record so the reuse is not
+  # refused as a duplicate owner of the shared copy.
+  rm -f "$HOME_DIR/state/pool-current-base-r1.meta"
   id='pool-current-base-repeat-r1'
   mkdir -p "$HOME_DIR/data/$id"
   printf 'brief for %s\n' "$id" > "$HOME_DIR/data/$id/brief.md"

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -141,7 +141,30 @@ test_already_settled_pane_costs_one_confirm_sleep() {
   pass "an already-settled pane confirms via the existing inter-poll sleep, not an extra full cycle"
 }
 
+test_duplicate_worktree_owner_is_refused() {
+  local rec id out status owner wt_real
+  id=settle-duplicate-owner-z3
+  owner=ship-existing-z3
+  rec=$(make_settle_case settle-duplicate-owner "$id" 0)
+  read_settle_record "$rec"
+  printf 'window=test:existing\nworktree=%s\nkind=ship\n' "$WT_DIR" \
+    > "$HOME_DIR/state/$owner.meta"
+
+  out=$(run_settle_spawn "$id")
+  status=$?
+  expect_code 1 "$status" "spawn must refuse a worktree already owned by another task"
+  assert_contains "$out" "already owned by task '$owner'" \
+    "duplicate-worktree refusal did not name the existing owner"
+  wt_real=$(cd "$WT_DIR" && pwd -P)
+  assert_contains "$out" "$wt_real" \
+    "duplicate-worktree refusal did not name the canonical worktree"
+  [ ! -e "$HOME_DIR/state/$id.meta" ] \
+    || fail "duplicate-worktree refusal published metadata for the new task"
+  pass "spawn refuses a canonical worktree already owned by another task record"
+}
+
 test_single_stale_first_read_is_not_accepted
 test_already_settled_pane_costs_one_confirm_sleep
+test_duplicate_worktree_owner_is_refused
 
 echo "# all fm-spawn-worktree-settle tests passed"

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -743,6 +743,54 @@ test_self_held_lock_reclaims_instead_of_deadlocking() {
   pass "an abandoned same-process lock hold is reclaimed; a parent's live hold is not"
 }
 
+test_uncreatable_lock_path_fails_without_recursive_steal() {
+  local dir state missing out pid rc lock stale_lock
+  dir=$(make_case uncreatable-lock)
+  state="$dir/state"
+  missing="$dir/missing/.fixture.lock"
+  out="$dir/missing.out"
+
+  FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    if fm_lock_acquire_wait "$2"; then
+      exit 10
+    fi
+    printf "error=%s\n" "${FM_LOCK_ERROR:-}"
+  ' _ "$ROOT/bin/fm-wake-lib.sh" "$missing" > "$out" 2>&1 &
+  pid=$!
+  rc=0
+  wait_for_exit "$pid" 30 || rc=$?
+  [ "$rc" -eq 0 ] || fail "an uncreatable lock path did not fail within three seconds (rc=$rc)"
+  assert_grep 'error=uncreatable-path' "$out" \
+    "uncreatable lock path did not expose its bounded failure reason"
+  if find "$dir" -name '*.steal*' -print | grep . >/dev/null; then
+    fail "uncreatable lock path created recursive steal artifacts"
+  fi
+
+  lock="$dir/present/.fixture.lock"
+  mkdir -p "$dir/present"
+  rc=0
+  FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    fm_lock_acquire_wait "$2" || exit 11
+    fm_lock_release "$2"
+  ' _ "$ROOT/bin/fm-wake-lib.sh" "$lock" || rc=$?
+  [ "$rc" -eq 0 ] || fail "an absent lock with a valid parent no longer acquires (rc=$rc)"
+
+  stale_lock="$dir/present/.stale.lock"
+  mkdir "$stale_lock"
+  printf '999999\n' > "$stale_lock/pid"
+  rc=0
+  FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    fm_lock_acquire_wait "$2" || exit 12
+    [ "$FM_LOCK_RECOVERED_PID" = 999999 ] || exit 13
+    fm_lock_release "$2"
+  ' _ "$ROOT/bin/fm-wake-lib.sh" "$stale_lock" || rc=$?
+  [ "$rc" -eq 0 ] || fail "a stale dead-pid lock no longer recovers (rc=$rc)"
+  pass "an uncreatable lock fails boundedly while valid and stale lock paths still acquire"
+}
+
 # Drain-time historical annotation staleness: a turn-ended-only wake row must
 # not present an already-announced status line as a new update, while a status
 # file with unannounced bytes keeps its annotation and a direct status row is
@@ -792,6 +840,7 @@ test_historical_annotation_skips_announced_status() {
   pass "historical annotations replay nothing already announced and keep everything new"
 }
 
+test_uncreatable_lock_path_fails_without_recursive_steal
 test_self_held_lock_reclaims_instead_of_deadlocking
 test_self_announced_append_guards
 test_historical_annotation_skips_announced_status


### PR DESCRIPTION
## Intent

Prevent Firstmate from ever assigning one isolated project copy to two different tasks, and stop wake-queue lock recovery from recursively appending .steal when the lock path cannot be created. The captain explicitly authorized both safety fixes directly after two reproduced incidents. Preserve same-task relaunch reuse, existing stale-owner recovery and cross-platform lock semantics; refuse duplicate ownership before branch preparation, launch text, or metadata publication; ignore symlink metadata and never use endpoint liveness as an ownership bypass. Add executable public-interface regressions and positive controls. Do not merge without the captain's already explicit authorization for this concrete fix after checks are green.

## What Changed

- `fm-spawn.sh` gains `assert_spawn_worktree_unowned`, invoked for every non-secondmate spawn before branch prep, launch, or metadata publication: it canonicalizes the candidate worktree and refuses to launch if another task's `state/*.meta` already records the same canonical `worktree=` path, reading plain meta files only (symlinked meta is skipped) and never treating endpoint liveness as an ownership bypass; a same-task relaunch into its own recorded worktree stays exempt.
- `fm-wake-lib.sh` now flags an uncreatable lock path in `fm_lock_try_create` (`FM_LOCK_CREATE_ERROR=uncreatable`) and surfaces it through `fm_lock_try_acquire` as `FM_LOCK_ERROR=uncreatable-path`, so `fm_lock_acquire_wait` returns failure immediately instead of looping and recursively appending `.steal`; existing stale dead-pid recovery and cross-platform lock semantics are unchanged.
- Adds executable regressions: `fm-spawn-worktree-settle.test.sh` asserts a duplicate-owner worktree is refused (naming the owner and canonical path, publishing no new metadata), and `fm-wake-queue.test.sh` asserts an uncreatable lock path fails boundedly with no `.steal` artifacts while valid and stale lock paths still acquire.

## Risk Assessment

✅ Low: Two targeted, well-bounded safety fixes that preserve existing lock-recovery and relaunch semantics, gate ownership before branch prep/launch/metadata publication exactly as the intent requires, and ship executable regressions plus positive controls; the only finding is a latent, non-reachable call-site asymmetry.

## Testing

Exercised both fixes through their public shell interfaces (fm-spawn.sh spawn path and fm-wake-lib.sh fm_lock_acquire_wait) using the change's own regression tests, and proved each is a genuine regression by running the new tests against the pre-fix base sources (both fail: duplicate-owner spawns into the shared copy with exit 0; uncreatable lock path hangs to a timeout) versus the fixed sources (both pass, with positive controls confirming same-task/absent/stale lock and normal spawn paths still work). The only failure observed was an unrelated, pre-existing test ('oversized unread status line') that dies with 'grep: out of memory' due to host swap pressure — it is untouched by this change and environmental, not a product regression. This is a CLI/shell change with no UI surface, so evidence is a captured before/after test transcript rather than a screenshot.

<details>
<summary>Evidence: Before/after regression transcript (both fixes)</summary>

Source: [Before/after regression transcript (both fixes)](https://github.com/AbdullahPesteli/firstmate/blob/8a6f6e6626e035a7e1ceac0ca5c8b21e1e7e2490/.no-mistakes/evidence/fix/lock-and-worktree-ownership/regression-before-after.txt)

```text
Firstmate lock/worktree-ownership safety fixes — regression before/after evidence
branch: fix/lock-and-worktree-ownership
base (pre-fix):   6789876
target (fixed):   b13148c

Each regression test reproduces a real reported incident: it must FAIL on the
pre-fix bin/ sources and PASS on the fixed sources. Positive controls in the
same tests confirm normal behavior is preserved.

================================================================================
FIX 1 — spawn refuses a worktree already owned by another task
  (bin/fm-spawn.sh: assert_spawn_worktree_unowned)
  Test: tests/fm-spawn-worktree-settle.test.sh :: test_duplicate_worktree_owner_is_refused
================================================================================

>>> PRE-FIX (base bin) — expect FAILURE (spawn wrongly launches into the shared copy):
ok - a single transient stale pane_current_path read is not accepted as the worktree
ok - an already-settled pane confirms via the existing inter-poll sleep, not an extra full cycle
not ok - spawn must refuse a worktree already owned by another task: expected exit 1, got 0

>>> FIXED (target bin) — expect PASS (spawn refuses, names owner + canonical worktree, publishes no metadata):
ok - a single transient stale pane_current_path read is not accepted as the worktree
ok - an already-settled pane confirms via the existing inter-poll sleep, not an extra full cycle
ok - spawn refuses a canonical worktree already owned by another task record
# all fm-spawn-worktree-settle tests passed

================================================================================
FIX 2 — wake-queue lock recovery fails boundedly on an uncreatable lock path
  (bin/fm-wake-lib.sh: FM_LOCK_CREATE_ERROR=uncreatable / uncreatable-path)
  Test: tests/fm-wake-queue.test.sh :: test_uncreatable_lock_path_fails_without_recursive_steal
  (isolated to avoid an unrelated pre-existing test that OOMs greps under host swap pressure)
================================================================================

>>> PRE-FIX (base bin) — expect FAILURE (unbounded: hangs past timeout, rc=124):
not ok - an uncreatable lock path did not fail within three seconds (rc=124)

>>> FIXED (target bin) — expect PASS (bounded failure via uncreatable-path; no .steal artifacts; positive controls: a valid absent lock still acquires and a stale dead-pid lock still recovers):
ok - an uncreatable lock fails boundedly while valid and stale lock paths still acquire
# uncreatable-lock isolated test passed

================================================================================
NOTE — unrelated pre-existing failure in the FULL fm-wake-queue.test.sh suite:
  test 'the oversized unread status line was truncated or omitted' fails with
  'grep: out of memory'. This test is untouched by this change (it exercises
  status-line enrichment, not locks/worktree ownership) and fails only because
  the host is under heavy swap pressure (11.7/12.0GB swap at session start).
  It is an environmental/infra condition, not a product regression from this fix.
================================================================================
```
</details>
<details>
<summary>Evidence: Duplicate-owner refusal: base FAILS, fix PASSES</summary>

```text
PRE-FIX base bin: not ok - spawn must refuse a worktree already owned by another task: expected exit 1, got 0
FIXED target bin: ok - spawn refuses a canonical worktree already owned by another task record
# all fm-spawn-worktree-settle tests passed
```
</details>
<details>
<summary>Evidence: Uncreatable lock bounded: base HANGS (rc=124), fix PASSES</summary>

```text
PRE-FIX base bin: not ok - an uncreatable lock path did not fail within three seconds (rc=124)
FIXED target bin: ok - an uncreatable lock fails boundedly while valid and stale lock paths still acquire
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"1e83eaee1c2eaf061b7bca024778231451fafee5","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-wake-lib.sh:958` - This change makes fm_lock_acquire_wait able to return non-zero (uncreatable-path), but two of the nine call sites — fm_wake_append (bin/fm-wake-lib.sh:958) and fm_wake_queued_keys (bin/fm-wake-lib.sh:987) — call it without a `|| return` guard, unlike the other seven sites (526/553/582/591/617/618/699). If it ever returned 1 there, the code would run its wake-queue critical section unlocked and then call fm_lock_release on a lock it never held. This is currently latent, not concretely reachable: FM_WAKE_QUEUE_LOCK lives under $STATE, whose parent always exists in production, so uncreatable-path cannot fire for it; and fm_lock_release safely no-ops on an unheld lock. A defensive `|| return`/status propagation would restore the pattern used at the other call sites.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-spawn-worktree-settle.test.sh` — full settle suite passes on fixed bin (3/3, incl. test_duplicate_worktree_owner_is_refused)</code>
- <code>`bash tests/fm-wake-queue.test.sh :: test_uncreatable_lock_path_fails_without_recursive_steal` — passes on fixed bin (bounded failure, no .steal, positive controls acquire/recover)</code>
- `Regression proof: ran the NEW tests against BASE (6789876) bin/ sources — duplicate-owner test FAILS (spawn returns 0 instead of refusing), uncreatable-lock test FAILS (hangs, rc=124 timeout)`
- `Regression proof: ran the same isolated tests against FIXED (b13148c) bin/ sources — both PASS`
- <code>Confirmed worktree remained clean (`git status --porcelain` empty); all scratch trees isolated under /tmp</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
