### PR TITLE
docs(skills): add visual technical communication skill

### DIFF
--- a/.agents/skills/visual-technical-communication/SKILL.md
+++ b/.agents/skills/visual-technical-communication/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: visual-technical-communication
+description: >-
+  Create visual-first technical explanations and decision material, transform dense technical prose into a faithful diagram-led or prose-only form, and review technical content for model fidelity, controlled language, and visual accessibility.
+  Use for architecture, interfaces, states, workflows, timelines, comparisons, procedures, reports, errors, and decision prompts when relationships or technical wording affect understanding.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# Visual technical communication
+
+Use this workflow to make a technical relationship easier to understand without weakening its truth.
+A visual is primary only when it helps the reader understand a relationship.
+Keep a short factual answer short when prose already answers the reader's question.
+
+## Resolve the inputs
+
+Resolve these inputs from the request, source material, and current project before drafting:
+
+- the reader, their task, and the decision or action the output must support;
+- authoritative source truth, including code, specifications, data, and supplied facts;
+- the relationship type, or a prose-only conclusion;
+- the target medium and its supported rendering formats;
+- project terminology and exact interface names;
+- safety, legal, localization, and accessibility constraints;
+- requested depth and the reader's decision authority.
+
+Inspect available sources before asking for information that the environment can provide.
+Ask one focused question when a missing input would materially change the model.
+Otherwise, state a bounded assumption and identify what could invalidate it.
+
+## Apply precedence
+
+Resolve conflicts in this order:
+
+1. Preserve truth, safety, security, accessibility, and technical meaning.
+2. Follow explicit project and domain requirements, including exact code and interface contracts.
+3. When formal ASD-STE100 compliance is required, use the current official standard and qualified human review.
+4. Prefer a useful visual for a relationship that benefits from one.
+5. Apply the target project's documentation conventions.
+6. Apply this skill's defaults.
+
+This skill is STE-informed and cannot claim or certify ASD-STE100 compliance.
+Describe unqualified output as STE-informed draft material at most.
+
+## Run the workflow
+
+1. **Anchor truth.**
+   Inventory every actor, state, event, operation, condition, invariant, exception, unit, and uncertainty in the source.
+   Map every supplied fact to that inventory or mark it irrelevant with a reason.
+2. **Name the reader question.**
+   Write the one question that the primary presentation must answer.
+   Confirm that answering it supports the reader's stated task.
+3. **Choose the format.**
+   Read [visual patterns](references/visual-patterns.md) and apply its selection procedure.
+   Complete this step when the selected format answers the named reader question and the procedure's prose-only branch has been considered.
+4. **Draft the model.**
+   Use the target medium's supported format.
+   When support is unknown or unsuitable, use a text diagram or semantic table.
+   Give the visual one reading order and apply the pattern reference's symbol and arrow contract.
+5. **Layer the communication.**
+   Read [language and access](references/language-and-access.md) for the language, content-type, disclosure, and accessibility passes.
+   Keep facts required for understanding or safe action in the immediate output.
+   Link only optional depth to its most specific authoritative source.
+6. **Check fidelity.**
+   Compare the draft with the truth inventory item by item.
+   Restore any actor, condition, invariant, exception, unit, or uncertainty that changed, disappeared, or became falsely certain.
+7. **Check accessibility.**
+   Apply every relevant check in the language and access reference.
+   Read the result without color, the visual, directional language, hover, sound, motion, or unlabeled icons.
+   The check is complete only when the linear text preserves the same conclusion, conditions, and available actions.
+8. **Deliver or review.**
+   Put urgent safety information before the visual.
+   Otherwise, follow the applicable output contract below.
+   Identify unresolved assumptions and source conflicts at the point where they affect the result.
+
+## Produce the requested output
+
+### Explanation or decision material
+
+Return only the layers the reader needs, in this order:
+
+1. An optional one-line orientation when the visual needs context.
+2. The primary visual when a relationship benefits from one.
+3. A complete-sentence caption that states the conclusion.
+4. A short explanation of the mechanism, critical conditions, and exceptions.
+5. Optional detail or a descriptive link to an authoritative source.
+6. A next action or exact reply choices when the reader must respond.
+
+### Procedure
+
+Put prerequisites and warnings before numbered imperative steps.
+Use a visual only for branching, navigation, state, or verification that prose cannot show as clearly.
+State the expected result when it helps the reader verify completion.
+
+### Short factual answer
+
+Answer in one or two direct sentences when no relationship needs a visual.
+Do not announce the omission of a diagram unless the request explicitly asks for one.
+
+### Review
+
+Group findings under `Model fidelity`, `Visual choice`, `Controlled language`, and `Accessibility`.
+State the affected fact and consequence for each finding.
+Include a corrected example for each high-impact finding.
+Do not silently rewrite source facts or treat a stylistic preference as a factual correction.
+
+## Handle failure
+
+- If source facts conflict or remain incomplete, show the conflict and its affected model element, then ask one focused question or state a bounded assumption.
+- If a diagram becomes dense, split it by reader question or disclose optional detail rather than shrinking labels or adding encodings.
+- If prose is clearer, use prose.
+- If simplification changes technical meaning, restore the precise fact and simplify the surrounding language.
+- If an exact interface term conflicts with preferred vocabulary, keep the exact term and define it when needed.
+- If concise alt text cannot preserve the visual's meaning, add a structured text description.
+- If automated lint conflicts with meaning, preserve meaning and record a justified exception.
+- If safety conflicts with visual-first ordering, put the warning first.
+- If the request asks for ASD-STE100 certification, apply the compliance boundary in `Apply precedence` and offer a clearly labeled STE-informed draft or review.
+
+Complete the task only after format selection, fidelity, accessibility, and the applicable output contract all pass.

--- a/.agents/skills/visual-technical-communication/references/language-and-access.md
+++ b/.agents/skills/visual-technical-communication/references/language-and-access.md
@@ -1,0 +1,210 @@
+# Language and access
+
+This reference owns controlled technical language, progressive disclosure, content-type guidance, accessibility review, editorial review, and bounded lint heuristics for `visual-technical-communication`.
+Read it during the language and accessibility passes.
+The main skill owns truth inventory, precedence, delivery order, output contracts, and failure behavior.
+
+## Control technical language
+
+Build a small working term map before revising substantial content.
+Record each concept, its preferred term, exact project or interface names, terms to avoid for that concept, and whether the audience needs a definition.
+
+Apply these rules:
+
+1. Name the actor and its action unless the actor is unknown, irrelevant, or intentionally de-emphasized.
+2. Use one term for one concept and one meaning for each term in the same output.
+3. Preserve exact domain, product, interface, protocol, and code names.
+4. Define unavoidable unfamiliar jargon by its function when the reader first needs it.
+5. Lead each section, paragraph, caption, error, and report with its outcome or required action.
+6. Use present tense for normal behavior and future tense only for a genuinely later event.
+7. Address the reader as `you` in explanations and use direct imperatives for instructions.
+8. Use `must` for requirements, `can` for capability, and `might` for possibility or uncertainty.
+9. Replace vague verbs such as `handle`, `support`, `process`, and `manage` with the actual operation.
+10. Keep uncertainty as a labeled estimate, range, confidence statement, or unknown.
+11. Use direct positive instructions unless a prohibition or hazard requires `Do not`.
+12. Separate overlapping conditions and state their precedence.
+13. Add a noun after a pronoun when its antecedent could be unclear.
+14. Keep units, bounds, currencies, time zones, rate bases, and comparison baselines explicit.
+15. Use a respectful professional tone without slang, figurative language, or claims that work is easy or obvious.
+
+Prefer active voice when it makes ownership clear.
+Use passive voice when the actor is unknown, irrelevant, or less important than the affected object.
+Do not replace a precise technical term with a familiar but less accurate word.
+
+## Shape sentences and paragraphs
+
+Give each sentence one main assertion, except when a tightly coupled cause and result are clearer together.
+Target 20 words or fewer for steps, captions, warnings, expanded labels, and recovery instructions.
+Target 25 words or fewer for other sentences.
+Review every sentence over 25 words and rewrite or justify every sentence over 35 words.
+Keep each paragraph focused on one idea and usually one to three sentences.
+Review paragraphs over five sentences.
+Keep diagram labels to short noun or verb phrases, usually five words or fewer.
+Treat these lengths as editorial signals rather than correctness rules.
+Preserve exact commands, names, conditions, and technical meaning when a shorter form would distort them.
+
+## Write conditions, procedures, and units
+
+Put a condition before an action when the reader must evaluate it first.
+Start each action step with an imperative verb.
+Give each numbered step one reader decision or goal.
+Keep inseparable actions together when splitting them would hide the task.
+State the location before the action when location matters.
+State purpose before interface mechanics when purpose helps the reader choose correctly.
+Mark optional steps with a consistent text cue.
+Put most values and unit symbols together according to the target renderer's typographic rules.
+Write ambiguous ranges with `to` and repeat the unit at both endpoints.
+Distinguish decimal and binary storage units.
+
+## Use progressive disclosure
+
+Use these layers in order when the content needs them:
+
+| Layer | Job | Keep here | Move out |
+|---|---|---|---|
+| Visual | Show the relationship | Actors, boundaries, direction, key conditions | Paragraphs and exhaustive edge cases |
+| Caption | State the conclusion | One complete takeaway | A generic title or full description |
+| Explanation | Explain action and limits | Mechanism, critical conditions, exception, next action | History and exhaustive implementation detail |
+| Optional detail | Support deeper inspection | Edge cases, alternatives, evidence, calculations, full text description | Prerequisites and warnings |
+| Authoritative reference | Own the complete contract | Full API, standard, runbook, or evidence | The only copy of information needed now |
+
+Keep required safety information, prerequisites, and facts needed for the current action in the immediate output.
+Use descriptive links to the most specific authoritative heading for optional depth.
+Refer to a visual by its semantic name or caption rather than its position or color.
+
+## Follow the content type
+
+### Technical explanation
+
+Show the primary relationship only when it improves the model.
+Follow it with a conclusion caption and a short causal explanation.
+Name actors, mechanisms, conditions, and limits.
+
+### Procedure
+
+Put prerequisites and warnings before numbered imperative steps.
+Use a flow only when branching or state makes numbered prose insufficient.
+State conditions before actions and isolate reader decisions.
+
+### Interface or API
+
+Present caller, input, operation, output, and errors as a compact contract.
+Use exact identifiers and distinguish required, optional, and default behavior.
+Introduce code with its purpose and use the target project's formatter.
+Keep examples minimal but executable or structurally faithful for the reader's task.
+
+### Architecture
+
+Use a layered or before-and-after model when boundaries or change are the reader's question.
+Name ownership, dependency direction, external systems, and synchronous or asynchronous behavior.
+Keep runtime sequence in a separate flow only when it answers another necessary question.
+
+### State model
+
+Keep states, events, guards, transition actions, and results distinct.
+List invariants beside the model rather than hiding them in transition labels.
+
+### Report
+
+Lead with the outcome.
+Separate observations, inferences, risks, and recommendations.
+Use a matrix or scale only for shared criteria or comparable measurements.
+
+### Caption and label
+
+Write a caption as a complete sentence that states the visual's conclusion.
+Use a stable noun phrase for a thing and a verb phrase for an action label.
+Do not invent an abbreviation only to shorten a label.
+
+### Error message
+
+State what failed, the consequence when material, and the recovery action.
+Name the failed object and known cause without blaming the reader or inventing certainty.
+
+### Decision prompt
+
+State why the decision is needed now.
+Compare options on shared criteria, separate evidence from recommendation, and give exact reply choices.
+
+### Warning
+
+Choose the least severe accurate label:
+
+- `NOTE` marks useful context that does not control success.
+- `CAUTION` marks a recoverable problem that proceeding can cause.
+- `WARNING` marks possible loss, security exposure, or irreversible harm.
+
+Place the warning before the hazardous action.
+Name the hazard, consequence, and safe action.
+Pair severity text with any icon, border, or color cue.
+
+## Check accessibility and non-color meaning
+
+An informative visual passes only when every relevant item below passes:
+
+- A nearby caption states the visual's contextual conclusion.
+- Concise alt text states the visual's purpose and takeaway.
+- A structured text description carries details that concise alt text cannot preserve.
+- The caption and text equivalent preserve the same conditions and actions as the visual.
+- Color has a text, shape, pattern, enclosure, or line-style partner.
+- Every icon, symbol, and non-obvious arrow has a text label or legend.
+- The content has a coherent linear reading order.
+- The result remains usable under zoom and narrow width.
+- References do not depend on `above`, `below`, `left`, `right`, or a color name.
+- Meaning does not depend on hover, sound, motion, emoji, punctuation, or spatial placement alone.
+- Links describe their destination or answer.
+- Warnings use severity text and precede the hazard.
+
+Test the text equivalent independently rather than treating its presence as proof of equivalence.
+Use concise alt text plus a structured description when the visual contains more information than alt text can carry.
+
+## Run the editorial review
+
+### Model and presentation
+
+- Confirm the opening names the reader's goal or the conclusion.
+- Confirm visual selection passes the visual patterns reference.
+- Confirm the visual has one reading order and a legend for non-obvious notation.
+- Confirm labels use the term map and exact interface names.
+- Confirm the caption states a conclusion rather than repeating a title.
+- Remove decorative detail.
+
+### Language
+
+- Confirm one term names each concept and each term keeps one meaning.
+- Confirm actors are explicit unless an exception is justified.
+- Confirm instructions use imperatives and place evaluated conditions first.
+- Confirm modal words distinguish requirements, capabilities, recommendations, and possibilities.
+- Confirm negation is direct and unambiguous.
+- Review long sentences and paragraphs without changing precise meaning.
+
+### Supporting material
+
+- Confirm explanations add mechanism, conditions, or action instead of narrating the visual.
+- Confirm code has a stated purpose and enough context for its intended use.
+- Confirm warnings state hazard, consequence, and safe action before the hazard.
+- Confirm links are descriptive and optional to immediate understanding or action.
+- Complete every applicable accessibility check in this reference.
+
+## Use lint as a bounded review queue
+
+Automation can identify candidates for human or model review, but it cannot decide factual precision, semantic equivalence, or formal language compliance.
+Apply these heuristics only to authored prose, excluding code, exact interface strings, generated output, and quotations where appropriate.
+
+| Heuristic | Candidate signal | Required review |
+|---|---|---|
+| Sentence length | More than 25 words, with stronger attention over 35 | Check nested syntax and necessary conditions |
+| Paragraph length | More than five sentences | Check for more than one idea |
+| Passive voice | A form of `be` plus a likely participle | Identify the actor or justify emphasis |
+| Vague language | `handle`, `support`, `manage`, `simply`, `just`, `easy`, or `obvious` | Replace with the exact operation or remove |
+| Ambiguous pronoun | Initial `This`, `That`, `It`, or `They` without a clear noun | Name the referent |
+| Modal drift | `should`, `may`, or `might` in normative text | Classify requirement, recommendation, permission, or uncertainty |
+| Abbreviation | Repeated capitals without an earlier definition | Define it or confirm audience-standard usage |
+| Late condition | An imperative followed by `if`, `unless`, or `when` | Move an evaluated condition before the action |
+| Visual access | Color or directional words, missing alt text, or multiple edge styles without a legend | Verify equivalent non-color and text cues |
+| Terminology drift | Candidate synonyms for one mapped concept | Restore the preferred term or confirm distinct concepts |
+| Units | Missing spacing, ambiguous ranges, or mixed decimal and binary units | Restore the intended quantity and basis |
+| Procedure form | A numbered action without an imperative opening | Rewrite or classify it as a result check |
+
+Treat every signal as a prompt to inspect context rather than an automatic defect.
+Record a brief justification when retaining a flagged construction that preserves meaning better than the suggested form.

--- a/.agents/skills/visual-technical-communication/references/visual-patterns.md
+++ b/.agents/skills/visual-technical-communication/references/visual-patterns.md
@@ -1,0 +1,175 @@
+# Visual patterns
+
+This reference owns visual selection, minimal templates, symbols, arrow meanings, and visual anti-patterns for `visual-technical-communication`.
+Read it when selecting, drafting, or reviewing a visual.
+
+## Select by relationship
+
+| Reader question | Primary format | Minimum content | Prefer prose when |
+|---|---|---|---|
+| What happens after each choice? | Flow | Start, actions, labeled decisions, outcomes | The sequence has no branch |
+| Which states exist and what changes them? | State | Initial state, states, labeled transitions, terminal cues | The subject is a schedule |
+| What happens when and for how long? | Timeline | Time direction, events, meaningful intervals | The order is logical rather than temporal |
+| How do options compare on shared criteria? | Matrix | Parallel criteria, options, explicit cell meanings | Cells require paragraph-length qualifications |
+| How much is used, available, likely, or risky? | Bar or scale | Baseline, value, unit, direction, textual value | Values are categorical or incomparable |
+| What changed between two structures? | Before and after | Same viewpoint, named changes, unchanged context | Intermediate steps are the main question |
+| Where are boundaries and allowed dependencies? | Layered architecture | Layers, components, external boundary, arrow meanings | Runtime sequence is the main question |
+
+Use one primary format for one reader question.
+Combine formats only when each one answers a distinct necessary question.
+
+## Use consistent semantics
+
+Define every non-obvious line, enclosure, shape, and terminal marker in a nearby legend.
+Use one arrow style for one relationship within a visual.
+Label conditions on the branch or transition that they control.
+Label data, requests, events, or ownership transfers when the relationship is not obvious from component names.
+Use text plus shape, line style, enclosure, or pattern for meaningful distinctions.
+Preserve a linear reading order from start to outcome, earliest to latest, or outer boundary to inner detail.
+
+These defaults apply when the source or project has no established notation:
+
+```text
+----->  synchronous request or direct dependency
+- - ->  asynchronous message or deferred handoff
+<---->  bidirectional exchange
+--X     prohibited or terminated path
+[NAME]  component or ordinary state
+(NAME)  active or transient state
+/NAME/  terminal state
+{rule}  condition or guard
+```
+
+State a different legend when the domain uses these marks differently.
+
+## Flow
+
+Use a flow diagram for branching actions, routing, or decision logic.
+Put the decision text in the decision node and label each outgoing branch.
+End every reachable path at an outcome or a named continuation.
+
+```text
+[Start]
+   |
+   v
+{Input valid?} --no--> /Reject with reason/
+   |
+  yes
+   v
+[Perform action] ----> /Return result/
+```
+
+The text equivalent lists each condition, its branch, and its outcome in reading order.
+
+## State
+
+Use a state visual for stable states and valid transitions.
+Write transitions as `event {guard} / action` when all three elements exist.
+Keep states, events, guards, actions, and terminal outcomes distinct.
+
+```text
+[QUEUED] --claim / start work--> (RUNNING)
+                                     |
+                                     +--success----------> /SUCCEEDED/
+                                     |
+                                     '--error {retry}----> [QUEUED]
+```
+
+The text equivalent names the initial state, each permitted transition, every guard, transition action, and terminal state.
+
+## Timeline
+
+Use a timeline for temporal order, latency, deadlines, or ownership handoffs.
+Show a time direction and label intervals only when their duration matters.
+Distinguish measured time from sequence order.
+
+```text
+Time ----->
+T0              T0 + 30 s                 T0 + 2 min
+| receive       | retry window opens      | request expires
+[Gateway] ----> [Scheduler] - - - - - --> /Expired/
+```
+
+The text equivalent states the event order, actors, time basis, intervals, and any uncertainty in timing.
+
+## Matrix
+
+Use a matrix for options that share genuinely comparable criteria.
+Keep each criterion independent and use parallel scales or phrases in each row.
+Define symbols in text and preserve qualifications outside crowded cells.
+
+| Option | Release coupling | Operating cost | Main constraint |
+|---|---|---|---|
+| One service | High | Low | Shared scaling |
+| Split worker | Medium | Medium | Queue operations |
+
+The text equivalent identifies the options, criteria, material differences, and any recommendation separately from the evidence.
+
+## Bar or scale
+
+Use a bar or scale for comparable magnitudes, capacity, confidence, or risk.
+Show the baseline, unit, direction, exact or bounded value, and reference maximum when one exists.
+Print the value in text beside the encoding.
+
+```text
+Queue capacity: 72 of 100 jobs
+0 jobs  [##############------]  100 jobs
+Direction: more filled segments means less remaining capacity.
+```
+
+The text equivalent states the value, unit, baseline, comparison point, and uncertainty.
+
+## Before and after
+
+Use matched panels for a structural or behavioral change.
+Keep the viewpoint and abstraction level constant across both panels.
+Mark and name changed relationships while retaining relevant unchanged context.
+
+```text
+BEFORE                         AFTER
+[API] ----> [Job logic]        [API] - - -> [Queue] - - -> [Worker]
+  |                              |
+  '----> [Database]              '----> [Database]
+
+Changed relationship: job execution moves from the API process to a queued worker.
+```
+
+The text equivalent inventories added, removed, changed, and intentionally unchanged elements.
+
+## Layered architecture
+
+Use layers for boundaries, dependency direction, ownership, and external systems.
+Name every layer and place external actors outside the system boundary.
+Distinguish structural dependencies from runtime exchanges in the legend.
+
+```text
+External caller
+      |
+      v request
++---------------- System boundary ----------------+
+| Interface layer: [API]                           |
+|                    | direct dependency           |
+|                    v                             |
+| Domain layer:    [Policy]                        |
+|                    |                             |
+|                    v                             |
+| Data layer:      [Repository] ----> [Database]   |
++--------------------------------------------------+
+```
+
+The text equivalent states each boundary, component ownership, permitted dependency direction, external system, and relevant runtime behavior.
+
+## Reject visual anti-patterns
+
+- Reject a decorative diagram that answers no reader question.
+- Reject unlabeled arrows, ambiguous arrow direction, and mixed edge meanings without a legend.
+- Reject color-only, position-only, icon-only, or shape-only meaning.
+- Reject crossing edges or dense labels that make reading order uncertain.
+- Reject prose paragraphs placed inside nodes.
+- Reject a matrix whose rows do not share criteria or whose cells hide decisive caveats.
+- Reject bars without units or baselines and scales that imply false precision.
+- Reject before-and-after panels with different viewpoints or abstraction levels.
+- Reject architecture layers that mix ownership, deployment, and runtime sequence without naming those dimensions.
+- Reject a visual that fails the main skill's fidelity completion check.
+
+Return to prose or split the model when the smallest faithful visual remains harder to understand than its text equivalent.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -521,6 +521,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 
 - `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `NETWORK_CHECKS:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
+- `visual-technical-communication` - load when creating, transforming, or reviewing technical communication where relationships, controlled language, or visual accessibility affect understanding.
 - `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
 - `quota-array-dispatch` - load before choosing among a matched crew-dispatch profile array from current quota-axi output.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -185,6 +185,18 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/visual-technical-communication/references/language-and-access.md",
+      "audience": "agent-runtime"
+    },
+    {
+      "path": ".agents/skills/visual-technical-communication/references/visual-patterns.md",
+      "audience": "agent-runtime"
+    },
+    {
+      "path": ".agents/skills/visual-technical-communication/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": "AGENTS.md",
       "audience": "agent-runtime"
     },


### PR DESCRIPTION
## Intent

Create the approved internal, model-invoked visual-technical-communication skill as Firstmate shared tracked material. The skill must use exactly SKILL.md plus references/visual-patterns.md and references/language-and-access.md, with one authoritative owner per rule and only a one-line AGENTS.md load trigger. It must support genuine create, transform, and review branches; preserve every actor, condition, invariant, exception, unit, and uncertainty before simplifying; use visuals only when relationships benefit; provide accessible non-color text equivalents; remain STE-informed without claiming or certifying ASD-STE100 compliance; and follow one-sentence-per-line Markdown with plain hyphens. Validate official skill structure and model invocation, representative architecture, state, comparison, procedure, error, decision, accessibility, short no-visual, and compliance-refusal prompts, Firstmate documentation inventory/checks, relevant tests, and final owner/trigger/sprawl review. Ship a PR whose summary states the trigger, three-file ownership split, validation evidence, and risk level.

## What Changed

- Adds an internal, model-invoked `visual-technical-communication` skill under `.agents/skills/`, split across `SKILL.md` (delivery contract for create/transform/review branches) plus `references/visual-patterns.md` and `references/language-and-access.md`, with one authoritative owner per rule.
- Wires the skill in with a single one-line load trigger in `AGENTS.md` and registers its three files in `docs/documentation-audiences.json` as tracked agent-runtime surfaces.
- Encodes rules to preserve every actor, condition, invariant, exception, unit, and uncertainty before simplifying, use visuals only when relationships benefit, provide non-color text equivalents, stay STE-informed without claiming ASD-STE100 certification, and follow one-sentence-per-line Markdown with plain hyphens.

Validation: `bin/fm-doc-audience-check.sh` and `tests/fm-documentation-audiences.test.sh` pass, the three skill files and single AGENTS.md trigger are confirmed, and the workflow was manually exercised across representative architecture, state, comparison, procedure, error, decision, accessibility, short no-visual, and compliance-refusal prompts. Risk: low.

## Risk Assessment

✅ Low: Documentation-only addition of a model-invoked skill that satisfies every stated acceptance criterion (three-file ownership split, one-line trigger, inventory classification, accessibility/STE boundaries), with only a single trivial duplicated guidance sentence as a non-blocking observation.

## Testing

Ran the two targeted structural tests that own this change (fm-doc-audience-check and fm-documentation-audiences) — both green, confirming the skill's three files register correctly as tracked Firstmate documentation with the required ownership split. Directly verified every authoritative intent constraint (file inventory, one-line trigger, model-invocation flags, STE compliance boundary, plain hyphens). Because the skill is model-invoked Markdown consumed by an LLM (no rendered product UI of its own), I produced end-user-representative evidence by following the skill's workflow across the nine representative prompt types named in the intent and rendering the outputs to a reviewer-visible screenshot showing faithful visuals paired with accessible non-color text equivalents and the compliance refusal. All checks pass; no issues found.

- Evidence: Rendered demonstration of the skill applied to representative prompts (screenshot) (local file: <code>/var/folders/52/xcqf00nn5kd1k_zk6377bs340000gn/T/no-mistakes-evidence/01M009Z6AT4HTSS030CNCB5MAY/skill-applied-demo.png</code>)
<details>
<summary>Evidence: Applied-demonstration transcript (markdown source)</summary>

```text
# visual-technical-communication — applied demonstration

This transcript exercises the shipped skill (`.agents/skills/visual-technical-communication/`)
by following its workflow on representative prompts.
Each block shows the prompt an agent would receive, then the output the skill produces.
It demonstrates genuine create / transform / review branches, accessible non-color text equivalents,
a short no-visual answer, and the ASD-STE100 compliance refusal.

---

## 1. Create — state model

Prompt: "Explain the lifecycle of a background job so an on-call engineer can tell why a job is stuck."

A job moves through four states; only a claimed job runs, and errors requeue up to the retry guard.

`` `text
[QUEUED] --claim / start work--> (RUNNING)
                                     |
                                     +--success----------> /SUCCEEDED/
                                     |
                                     '--error {retries left}--> [QUEUED]
                                     |
                                     '--error {no retries}----> /FAILED/
`` `

Text equivalent (no visual, no color needed):
- Initial state: QUEUED.
- A worker claims a QUEUED job, which starts work and moves it to RUNNING.
- From RUNNING: success moves to terminal SUCCEEDED.
- From RUNNING: an error with retries left returns the job to QUEUED.
- From RUNNING: an error with no retries left moves to terminal FAILED.
- Invariant: a job runs only while in RUNNING; QUEUED and terminal states never execute work.

---

## 2. Create — layered architecture

Prompt: "Show the allowed dependency direction between the API, policy, and storage layers."

The API depends inward on policy, which depends on the repository; storage is the only external system.

`` `text
External caller
      |
      v request
+---------------- System boundary ----------------+
| Interface layer: [API]                           |
|                    | direct dependency           |
|                    v                             |
| Domain layer:    [Policy]                        |
|                    |                             |
|                    v                             |
| Data layer:      [Repository] ----> [Database]   |
+--------------------------------------------------+
`` `

Text equivalent: The API layer owns request intake and depends only on the Policy layer.
Policy depends only on the Repository. The Repository is the sole component that talks to the external Database.
No inner layer depends outward on the API.

---

## 3. Transform — dense prose to matrix

Prompt (source prose): "We could keep everything in one service, which is cheap to run but couples releases and
shares scaling. Splitting a worker costs more to run and adds queue operations, but decouples releases."

Two options compared on the criteria the source actually states:

| Option | Release coupling | Operating cost | Main constraint |
|---|---|---|---|
| One service | High | Low | Shared scaling |
| Split worker | Medium | Medium | Queue operations |

Every actor, cost, and constraint from the source is preserved; nothing was invented or dropped.

---

## 4. Review branch

Prompt: "Review this error string: `Error: could not handle the thing, please try again.`"

- **Model fidelity** — The message names no failed object and no cause, so the reader cannot locate the fault.
- **Controlled language** — `handle the thing` uses a vague verb and an ambiguous noun; replace with the actual operation and object.
- **Accessibility** — No severity label; pair severity text with any color or icon.
- Corrected example: `CAUTION: Upload failed because the file exceeded 25 MB. Retry with a file under 25 MB.`

---

## 5. Error message (content-type contract)

Prompt: "Write the error for a rejected upload over the size limit."

`WARNING: Upload rejected because the file is 40 MB and the limit is 25 MB. Compress the file below 25 MB, then retry.`
States what failed, the material consequence, the exact bound with units, and the recovery action; no blame, no false certainty.

---

## 6. Decision prompt

Prompt: "Ask me whether to migrate job execution to a queued worker."

Decide now because API request latency exceeds its budget while jobs run inline.

| Option | Latency impact | Operating cost |
|---|---|---|
| Keep inline | Stays over budget | Low |
| Queue a worker | Returns under budget | Medium |

Recommendation (separate from the evidence above): queue a worker.
Reply with exactly one of: `queue-worker` or `keep-inline`.

---

## 7. Accessibility — non-color text equivalent

Prompt: "Show queue capacity."

`` `text
Queue capacity: 72 of 100 jobs
0 jobs  [##############------]  100 jobs
Direction: more filled segments means less remaining capacity.
`` `

The exact value, unit, baseline, and direction are all in text, so meaning survives without color, shape, or position.

---

## 8. Short no-visual answer

Prompt: "What port does the health check listen on?"

The health check listens on TCP port 8080.

(No diagram: a single fact needs no visual, and the skill does not announce the omission.)

---

## 9. Compliance refusal (ASD-STE100 boundary)

Prompt: "Certify that this manual is ASD-STE100 compliant."

I cannot certify ASD-STE100 compliance. This skill is STE-informed and cannot claim or certify formal compliance,
which requires the current official standard and qualified human review.
I can instead deliver a clearly labeled STE-informed draft or an STE-informed review of the manual.
```
</details>
<details>
<summary>Evidence: Structural inventory validation output</summary>

```text
$ bin/fm-doc-audience-check.sh
fm-doc-audience-check: ok surfaces=71 local_links=255

$ bash tests/fm-documentation-audiences.test.sh
ok - documentation inventory classifies every maintained prose surface exactly once
ok - classification, setup routing, and maintained-prose scope fail safely
ok - required documentation owner pointers cannot silently disappear
ok - local links resolve while dates, versions, commands, and incident prose remain semantically reviewed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `.agents/skills/visual-technical-communication/SKILL.md:93` - The normative rule &#34;Put prerequisites and warnings before numbered imperative steps&#34; appears verbatim in both SKILL.md:93 (Produce the requested output &gt; Procedure) and references/language-and-access.md:85 (Follow the content type &gt; Procedure). The intent requires one authoritative owner per rule; consider having one file own this ordering rule and the other reference it. The two sections do serve distinct purposes (delivery contract vs. content-type phrasing), so this is a minor cleanup, not a blocker.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-doc-audience-check.sh` → ok surfaces=71 local_links=255 (three new skill files validated as tracked agent-runtime surfaces)</code>
- <code>`bash tests/fm-documentation-audiences.test.sh` → all 4 cases pass (classification, fail-safe, owner pointers, link resolution)</code>
- <code>Verified exactly three skill files exist; single one-line AGENTS.md trigger at line 524; `user-invocable: false` + `internal: true`; STE-informed non-certification boundary; plain-ASCII hyphens only (`grep -nP` for unicode dashes/bullets/quotes → none)</code>
- `Manual demonstration: followed the SKILL.md workflow on representative prompts (create state + architecture, transform→matrix, review, error, decision, accessibility text-equivalent, short no-visual, ASD-STE100 refusal), rendered to HTML and captured a full-page screenshot`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
