### PR TITLE
fix(afk): make away-mode escalation wedge alarms self-diagnosing

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -101,7 +101,7 @@ backend (tmux or herdr; see "Auto-discovered supervisor pane" below):
   `pane_input_pending` is the tested fail-closed predicate for callers that need to know whether the composer is unsafe: it treats every result except exact `empty` as pending.
 
 A busy primary pane, or any composer verdict other than `empty`, defers the injection; the buffered escalation survives in `state/.subsuper-escalations` and is retried on the next housekeeping tick.
-Once the pane is genuinely idle with an affirmatively empty composer, delivery therefore occurs within one housekeeping interval (15 seconds by default) plus the bounded submit confirmation.
+Once the pane is genuinely idle with an affirmatively empty composer, delivery therefore occurs within one housekeeping interval (`FM_HOUSEKEEPING_TICK`, default 15s) plus the bounded submit confirmation.
 In afk mode the composer guard is belt-and-suspenders (no human is typing), but it protects against the race window between the captain returning and their message landing, a dead shell, and the daemon's own previous injection sitting unsent.
 
 **Max-defer escape (the daemon must never silently wedge).**
@@ -193,14 +193,7 @@ the operational prefix lets firstmate distinguish it from a real captain message
   `FM_COMPOSER_IDLE_RE` overrides the shared idle-placeholder regex, but a match alone never bypasses the classifier's shape-specific position and ANSI de-emphasis safety gates.
   `FM_BUSY_REGEX` overrides the rendered delivery guards plus Grok's isolated task-state fallback.
   A blank or otherwise unidentified input row carries no positive container proof and defers injection, so a modal dialog or a mid-redraw pane is never an injection target.
-- **Max-defer escape** - the daemon must never silently wedge. If anything stays
-  buffered past `FM_MAX_DEFER_SECS` (default 300s), the daemon attempts one
-  normal flush, which still requires an idle pane and an affirmatively empty composer. If that
-  cannot confirm a submit, it raises a loud, rate-limited wedge alarm: ERROR log,
-  durable `state/.subsuper-inject-wedged` marker, a tmux status-line flash when
-  applicable, and a backend-independent active alert. A
-  composer false-positive surfaces as a visible stall, never an unbounded silent
-  no-op.
+- **Max-defer escape** - the daemon must never silently wedge; the full alarm contract, including the exact-blocker verdict and bounded pane evidence, is owned by "Max-defer escape" under "Busy-guard and composer guard" above.
 - **Verified type-once submit model** - the digest is typed once (`send-keys -l`
   on tmux, `pane send-text` on herdr), then submitted with Enter and verified.
   Enter is retried, Enter only and never a retype, until the backend submit

--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -101,6 +101,7 @@ backend (tmux or herdr; see "Auto-discovered supervisor pane" below):
   `pane_input_pending` is the tested fail-closed predicate for callers that need to know whether the composer is unsafe: it treats every result except exact `empty` as pending.
 
 A busy primary pane, or any composer verdict other than `empty`, defers the injection; the buffered escalation survives in `state/.subsuper-escalations` and is retried on the next housekeeping tick.
+Once the pane is genuinely idle with an affirmatively empty composer, delivery therefore occurs within one housekeeping interval (15 seconds by default) plus the bounded submit confirmation.
 In afk mode the composer guard is belt-and-suspenders (no human is typing), but it protects against the race window between the captain returning and their message landing, a dead shell, and the daemon's own previous injection sitting unsent.
 
 **Max-defer escape (the daemon must never silently wedge).**
@@ -111,6 +112,8 @@ If that submit cannot be confirmed, it raises a loud, rate-limited wedge alarm:
 an ERROR in the daemon log, a durable
 `state/.subsuper-inject-wedged` marker (surface it on the "while you were out"
 catch-up if present), a tmux status-line flash when applicable, and a configurable backend-independent active alert.
+The log, marker, status flash, and active-alert summary name the exact blocking verdict (`busy`, `pending`, `pending-unproven`, `unknown`, a target failure, or the submit verdict).
+The marker also includes the same bounded pane snapshot in readable form and as ANSI-preserving hex, so a rendered-state misclassification is diagnosable without the original pane.
 `docs/wedge-alarm.md` owns the alert channel setup, and `docs/verification/supervision.md` "Wedge-alarm channels" owns active evidence.
 So a guard false-positive becomes a visible stall, never an unbounded silent no-op.
 

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -201,6 +201,17 @@ MAX_DEFER_SECS_DEFAULT=300
 WEDGE_ALARM_TIMEOUT_SECS_DEFAULT=10
 WEDGE_ALARM_LAST_EPOCH=0
 WEDGE_ALARM_NOTIFIER_PID=
+# The most recent failed injection attempt carries its exact blocker and one
+# bounded pane snapshot into the max-defer alarm.
+# These stay process-local because the durable wedge marker is written in the
+# same housekeeping pass immediately after the failed retry.
+INJECT_EVIDENCE_LINES_DEFAULT=12
+INJECT_EVIDENCE_BYTES_DEFAULT=4096
+INJECT_LAST_BLOCKER=unknown
+INJECT_LAST_BLOCKER_DETAIL="no failed injection attempt recorded"
+INJECT_LAST_CAPTURE_STYLE=unavailable
+INJECT_LAST_PANE_CAPTURE="<capture unavailable>"
+INJECT_LAST_PANE_CAPTURE_HEX="<capture unavailable>"
 # The captain-relevant verb set and the status classifiers (last_status_line,
 # status_is_captain_relevant, window_to_task, scan_captain_relevant_statuses) now
 # live in bin/fm-classify-lib.sh, shared with the always-on watcher.
@@ -895,9 +906,11 @@ wedge_alarm_notify() {  # <summary> <marker>
 # is lost - the buffer and the
 # wake-queue both survive - but the stall stops being invisible.
 inject_wedge_alarm() {  # <state> <age-seconds>
-  local state=$1 age=$2 marker target backend max_defer now notify=1
+  local state=$1 age=$2 marker target backend max_defer now notify=1 blocker detail
   marker="$state/.subsuper-inject-wedged"
   max_defer="${FM_MAX_DEFER_SECS:-$MAX_DEFER_SECS_DEFAULT}"
+  blocker=${INJECT_LAST_BLOCKER:-unknown}
+  detail=${INJECT_LAST_BLOCKER_DETAIL:-"no failed injection attempt recorded"}
   # Re-alarm at most once per max-defer window so a long wedge does not spam.
   if [ "$(_file_age "$marker")" -lt "$max_defer" ]; then
     return 0
@@ -907,10 +920,16 @@ inject_wedge_alarm() {  # <state> <age-seconds>
     notify=0
   else
     WEDGE_ALARM_LAST_EPOCH=$now
-    log "ERROR: away-mode escalation undelivered ${age}s; inject could not confirm a submit (supervisor pane busy or wedged). Buffer + wake-queue preserved; alarm marker written."
+    log "ERROR: away-mode escalation undelivered ${age}s; inject blocked (verdict=$blocker, detail=$detail). Buffer + wake-queue preserved; alarm marker written."
   fi
   {
     printf 'fm away-mode inject WEDGED: %ss undelivered as of %s\n' "$age" "$(date '+%Y-%m-%dT%H:%M:%S%z')"
+    printf 'Blocking verdict: %s\n' "$blocker"
+    printf 'Blocking detail: %s\n' "$detail"
+    printf 'Offending pane capture (%s, ANSI stripped, bounded):\n' "${INJECT_LAST_CAPTURE_STYLE:-unavailable}"
+    printf '%s\n' "${INJECT_LAST_PANE_CAPTURE:-<capture unavailable>}"
+    printf 'Offending pane capture bytes (ANSI-preserving hex, bounded):\n'
+    printf '%s\n' "${INJECT_LAST_PANE_CAPTURE_HEX:-<capture unavailable>}"
     printf 'The supervisor pane could not accept an escalation. Buffered items:\n'
     cat "$state/.subsuper-escalations" 2>/dev/null
   } 2>/dev/null > "$marker" || true
@@ -921,7 +940,7 @@ inject_wedge_alarm() {  # <state> <age-seconds>
   # the primary, backend-independent signal, so a non-tmux backend just skips
   # this cosmetic extra rather than attempting an unsupported call.
   if [ "$backend" = tmux ]; then
-    tmux display-message -t "$target" "fm: away-mode escalations WEDGED ${age}s — see $marker" 2>/dev/null || true
+    tmux display-message -t "$target" "fm: away-mode escalations WEDGED ${age}s (blocker=$blocker) - see $marker" 2>/dev/null || true
   fi
   # Backend-independent active alert. Unlike the tmux flash above (skipped on
   # every non-tmux backend), this can reach the captain even when every pane and
@@ -929,7 +948,7 @@ inject_wedge_alarm() {  # <state> <age-seconds>
   # incident fell through. Configurable and best-effort; the marker above stays
   # the durable record whether or not any channel fires.
   if [ "$notify" -eq 1 ]; then
-    wedge_alarm_notify "away-mode escalations WEDGED ${age}s undelivered - see $marker" "$marker"
+    wedge_alarm_notify "away-mode escalations WEDGED ${age}s undelivered (blocker=$blocker) - see $marker" "$marker"
   fi
 }
 
@@ -1113,9 +1132,68 @@ window_for_task() {  # <task-key> [state]
 #     after dim/faint ghost text and borders are ignored (a human's half-typed
 #     line, or a previous injection's unsent text), defer entirely - injecting
 #     would merge with the human's text.
+inject_evidence_reset() {
+  INJECT_LAST_BLOCKER=unknown
+  INJECT_LAST_BLOCKER_DETAIL="injection attempt did not reach a classified guard"
+  INJECT_LAST_CAPTURE_STYLE=unavailable
+  INJECT_LAST_PANE_CAPTURE="<capture unavailable>"
+  INJECT_LAST_PANE_CAPTURE_HEX="<capture unavailable>"
+}
+
+# Record the exact failed guard or submit verdict and one bounded snapshot of
+# the pane at the failure point.
+# ANSI-capable captures are retained as hex for byte-level diagnosis and
+# stripped from that same snapshot for the readable marker section.
+inject_evidence_record() {  # <blocker> <detail> <backend> <target>
+  local blocker=$1 detail=$2 backend=$3 target=$4 lines bytes capture style=unavailable
+  lines=$INJECT_EVIDENCE_LINES_DEFAULT
+  bytes=$INJECT_EVIDENCE_BYTES_DEFAULT
+
+  INJECT_LAST_BLOCKER=$blocker
+  INJECT_LAST_BLOCKER_DETAIL=$detail
+  capture=
+  case "$backend" in
+    tmux)
+      if capture=$(tmux capture-pane -e -p -t "$target" -S -"$lines" 2>/dev/null); then
+        capture=$(printf '%s' "$capture" | tail -n "$lines" | dd bs="$bytes" count=1 2>/dev/null)
+        style=ansi
+      fi
+      ;;
+    herdr)
+      if type fm_backend_herdr_capture_ansi >/dev/null 2>&1 \
+         && capture=$(fm_backend_herdr_capture_ansi "$target" "$lines" 2>/dev/null); then
+        capture=$(printf '%s' "$capture" | tail -n "$lines" | dd bs="$bytes" count=1 2>/dev/null)
+        style=ansi
+      fi
+      ;;
+  esac
+  if [ "$style" = unavailable ]; then
+    if capture=$(fm_backend_capture "$backend" "$target" "$lines" 2>/dev/null); then
+      capture=$(printf '%s' "$capture" | tail -n "$lines" | dd bs="$bytes" count=1 2>/dev/null)
+      style=plain
+    else
+      capture=
+    fi
+  fi
+
+  INJECT_LAST_CAPTURE_STYLE=$style
+  if [ "$style" = unavailable ]; then
+    INJECT_LAST_PANE_CAPTURE="<capture unavailable>"
+    INJECT_LAST_PANE_CAPTURE_HEX="<capture unavailable>"
+  elif [ -z "$capture" ]; then
+    INJECT_LAST_PANE_CAPTURE="<empty capture>"
+    INJECT_LAST_PANE_CAPTURE_HEX="<empty capture>"
+  else
+    INJECT_LAST_PANE_CAPTURE=$(printf '%s' "$capture" | fm_composer_strip_ansi \
+      | LC_ALL=C tr '\001-\010\013\014\015-\037\177' '?')
+    INJECT_LAST_PANE_CAPTURE_HEX=$(printf '%s' "$capture" | od -An -tx1 -v | tr -d ' \n')
+  fi
+}
+
 inject_msg() {  # <message> [state]
-  local msg=$1 state target backend retries sleep_s verdict composer encoded
+  local msg=$1 state target backend retries sleep_s verdict composer encoded blocker
   state="${2:-$(_state_root)}"
+  inject_evidence_reset
   # (1) Presence-gate: inject ONLY when afk is active. When afk is off, the
   # daemon self-handles and stays quiet; firstmate drives the normal always-on
   # watcher triage. Escalations buffer and survive for the next catch-up flush.
@@ -1134,9 +1212,13 @@ inject_msg() {  # <message> [state]
   # when unset (sourced/test contexts that never ran fm_super_main's startup
   # discovery), matching this function's pre-existing default assumption.
   backend="${FM_SUPERVISOR_BACKEND:-tmux}"
-  fm_backend_target_exists "$backend" "$target" || return 1
+  if ! fm_backend_target_exists "$backend" "$target"; then
+    inject_evidence_record target-missing "supervisor target does not exist or is unreadable" "$backend" "$target"
+    return 1
+  fi
   # (3) Busy-guard: never inject into an in-use supervisor pane.
   if pane_is_busy "$target" "$backend"; then
+    inject_evidence_record busy "primary-pane busy guard" "$backend" "$target"
     log "inject deferred: supervisor pane busy (agent mid-turn)"
     return 1
   fi
@@ -1151,6 +1233,11 @@ inject_msg() {  # <message> [state]
   #      stays buffered for the next cycle or the catch-up flush.
   composer=$(fm_backend_composer_state "$backend" "$target" 2>/dev/null)
   if [ "$composer" != empty ]; then
+    case "$composer" in
+      pending|pending-unproven|unknown) blocker=$composer ;;
+      *) blocker=unknown ;;
+    esac
+    inject_evidence_record "$blocker" "composer-state=${composer:-<empty>}" "$backend" "$target"
     log "inject deferred: supervisor composer not confirmed-empty (state=${composer:-unknown}: pending input, dead-shell prompt, or unreadable pane)"
     return 1
   fi
@@ -1167,6 +1254,11 @@ inject_msg() {  # <message> [state]
   if [ "$verdict" = empty ]; then
     return 0  # Backend confirmed the submit.
   fi
+  case "$verdict" in
+    pending|pending-unproven|unknown) blocker="submit-$verdict" ;;
+    *) blocker=submit-unknown ;;
+  esac
+  inject_evidence_record "$blocker" "submit-verdict=${verdict:-<empty>} after $retries retries" "$backend" "$target"
   log "inject failed: submit unconfirmed after $retries retries (verdict=$verdict, text may be in composer)"
   return 1
 }

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -1155,21 +1155,21 @@ inject_evidence_record() {  # <blocker> <detail> <backend> <target>
   case "$backend" in
     tmux)
       if capture=$(tmux capture-pane -e -p -t "$target" -S -"$lines" 2>/dev/null); then
-        capture=$(printf '%s' "$capture" | tail -n "$lines" | dd bs="$bytes" count=1 2>/dev/null)
+        capture=$(printf '%s' "$capture" | tail -n "$lines" | head -c "$bytes")
         style=ansi
       fi
       ;;
     herdr)
       if type fm_backend_herdr_capture_ansi >/dev/null 2>&1 \
          && capture=$(fm_backend_herdr_capture_ansi "$target" "$lines" 2>/dev/null); then
-        capture=$(printf '%s' "$capture" | tail -n "$lines" | dd bs="$bytes" count=1 2>/dev/null)
+        capture=$(printf '%s' "$capture" | tail -n "$lines" | head -c "$bytes")
         style=ansi
       fi
       ;;
   esac
   if [ "$style" = unavailable ]; then
     if capture=$(fm_backend_capture "$backend" "$target" "$lines" 2>/dev/null); then
-      capture=$(printf '%s' "$capture" | tail -n "$lines" | dd bs="$bytes" count=1 2>/dev/null)
+      capture=$(printf '%s' "$capture" | tail -n "$lines" | head -c "$bytes")
       style=plain
     else
       capture=

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -241,6 +241,7 @@ Identity stays a lazy second read, consulted only when a separator pair could ch
 ANSI capture preserves de-emphasized placeholder style.
 `bin/fm-composer-lib.sh` is the fleet-wide owner that strips dim or faint runs and dark truecolor placeholders while retaining bright typed input.
 If the ANSI capture ever fails, the plain fallback declares itself unstyled and the classifier degrades a glyph row carrying trailing text to `unknown` instead of misreading ghost suggestions as typed input, which safely defers injection and eventually raises the wedge alarm.
+When max-defer raises that alarm, the same Herdr ANSI capture path supplies the marker's bounded readable and byte-level evidence, while a failed ANSI read is labeled as a plain fallback or unavailable rather than fabricating certainty.
 
 A bare shell prompt is never an empty agent composer.
 Away-mode injection proceeds only on an affirmative `empty` result, never on unknown.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -467,6 +467,9 @@ The tmux away-delivery failure was reproduced on 2026-08-14 against a real Claud
 Under `LC_ALL=C`, the stale pre-consolidation classifier returned `pending` for that pane while the current shared classifier returned `empty` for the same capture.
 The pane remained genuinely idle between turns, and the daemon's 15-second housekeeping cadence continued retrying, so the composer false-positive was sufficient to explain the undelivered windows without a busy-guard or cadence failure.
 
+No retained successful daemon injection evidence exists to compare against: the away-delivery mechanism was defective from its first deployment, so no prior proven injection was ever recorded.
+The stale-versus-current classifier verdict on the same capture and the production-shaped end-to-end regression below are therefore the diagnostic baseline.
+
 The portable end-to-end regression now renders that exact byte shape under `LC_ALL=C` and proves all three delivery properties: pending human text still defers, the first idle gap accepts the preserved digest, and a swallowed Enter retries submission without retyping.
 
 ```sh

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -461,6 +461,22 @@ tests/fm-turnend-guard.test.sh
 
 ## Wedge-alarm channels
 
+### Claude NBSP away-delivery regression
+
+The tmux away-delivery failure was reproduced on 2026-08-14 against a real Claude Code 2.1.226 pane whose idle composer was `❯` followed by U+00A0 NO-BREAK SPACE.
+Under `LC_ALL=C`, the stale pre-consolidation classifier returned `pending` for that pane while the current shared classifier returned `empty` for the same capture.
+The pane remained genuinely idle between turns, and the daemon's 15-second housekeeping cadence continued retrying, so the composer false-positive was sufficient to explain the undelivered windows without a busy-guard or cadence failure.
+
+The portable end-to-end regression now renders that exact byte shape under `LC_ALL=C` and proves all three delivery properties: pending human text still defers, the first idle gap accepts the preserved digest, and a swallowed Enter retries submission without retyping.
+
+```sh
+tests/fm-composer-lib.test.sh
+tests/fm-afk-inject-e2e.test.sh
+tests/fm-daemon.test.sh
+```
+
+The daemon unit suite additionally proves that max-defer preserves the buffer and emits exact `busy`, `pending`, `unknown`, and submit verdicts with bounded readable and ANSI-preserving hex pane evidence.
+
 The two real notification channels were bounded manually on 2026-07-10 on macOS 26.5.2 with Herdr 0.7.3.
 Automated suites never execute these real notification commands.
 

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -2,7 +2,7 @@
 
 Audience: maintainer verification.
 
-This record supports current session-start, turn-end, watcher-continuity, and wedge-alarm guarantees.
+This record supports current session-start, turn-end, watcher-continuity, away-mode escalation delivery, and wedge-alarm guarantees.
 Operator behavior and active limits remain in the linked current guides.
 Task-specific chronology, temporary paths, run identifiers, and delivery transcripts remain in private reports or PR evidence.
 

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -480,6 +480,8 @@ tests/fm-daemon.test.sh
 
 The daemon unit suite additionally proves that max-defer preserves the buffer and emits exact `busy`, `pending`, `unknown`, and submit verdicts with bounded readable and ANSI-preserving hex pane evidence.
 
+### Manual channel proof
+
 The two real notification channels were bounded manually on 2026-07-10 on macOS 26.5.2 with Herdr 0.7.3.
 Automated suites never execute these real notification commands.
 

--- a/docs/wedge-alarm.md
+++ b/docs/wedge-alarm.md
@@ -5,6 +5,11 @@ When injection cannot confirm a submit past `FM_MAX_DEFER_SECS`, `inject_wedge_a
 The active alert is pane-independent because a tmux status-line flash has no cross-backend equivalent and cannot reach an unattended captain reliably.
 The durable marker and tmux flash remain as additional signals.
 
+The alarm summary names the exact failed guard or submit verdict.
+`state/.subsuper-inject-wedged` also records the verdict detail and a bounded 12-line, 4096-byte snapshot from the failure point in both ANSI-stripped readable text and ANSI-preserving hex.
+This distinguishes a genuinely busy pane from `pending`, `pending-unproven`, `unknown`, an unreadable target, and an unconfirmed submit without requiring the original pane to survive.
+The marker is private operational state and can contain text visible in the captain pane.
+
 ## Channels
 
 `config/wedge-alarm` is local and gitignored.

--- a/tests/fm-afk-inject-e2e.test.sh
+++ b/tests/fm-afk-inject-e2e.test.sh
@@ -93,15 +93,19 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 _buf=
-# The drawn composer row carries a real agent prompt glyph, matching the
-# production supervisor pane this daemon injects into: under the strict
-# container-proof rule (captain decision blank-row-injection-posture) a bare
-# unidentified row is never a safe injection target, so the fixture must
-# render the shape the classifier positively proves - "❯ " when idle,
-# "❯ <buffer>" while input is pending. The glyph is rendering only; it never
-# enters the buffer, so submitted-content assertions are unchanged.
+# The drawn composer row carries Claude 2.1.226's byte-exact idle shape: the
+# agent prompt glyph followed by U+00A0 NO-BREAK SPACE.
+# This is the production shape that used to read pending under LC_ALL=C and
+# defer every away-mode injection.
+# Typed input still renders as "❯ <buffer>".
+# The glyph and spacing are rendering only; neither enters the buffer, so
+# submitted-content assertions are unchanged.
 redraw() {
-  printf '\r\033[K\xe2\x9d\xaf %s' "$_buf"
+  if [ -n "$_buf" ]; then
+    printf '\r\033[K\xe2\x9d\xaf %s' "$_buf"
+  else
+    printf '\r\033[K\xe2\x9d\xaf\xc2\xa0'
+  fi
 }
 submit_line() {
   local _line=$_buf _c _hex
@@ -163,6 +167,7 @@ chmod +x "$TMUX_SHIM_DIR/tmux"
 "$REAL_TMUX" -L "$SOCKET" new-window -d -n fm-fake-c1 -t supervisor
 
 start_daemon() {
+  LC_ALL=C \
   PATH="$TMUX_SHIM_DIR:$PATH" \
   FM_STATE_OVERRIDE="$STATE_DIR" \
   FM_SUPERVISOR_TARGET="$SUPERVISOR_PANE" \

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -1146,6 +1146,8 @@ test_max_defer_empty_swallow_types_once_and_alarms() {
     || fail "stuck max-defer inject did not raise a wedge alarm marker"
   [ -s "$state/.subsuper-escalations" ] \
     || fail "buffer lost after a failed max-defer inject (must be preserved)"
+  grep -F 'Blocking verdict: submit-pending' "$state/.subsuper-inject-wedged" >/dev/null \
+    || fail "stuck submit alarm omitted the exact submit verdict: $(cat "$state/.subsuper-inject-wedged")"
   pass "max-defer on an empty stuck pane types once, alarms, and preserves the buffer"
 }
 
@@ -1182,7 +1184,55 @@ test_max_defer_pending_composer_alarms_without_typing() {
   [ -s "$state/.subsuper-inject-wedged" ] || fail "pending composer did not raise a wedge alarm marker"
   [ -s "$state/.subsuper-escalations" ] || fail "buffer lost while composer was pending"
   grep -F 'human draft' "$dir/composer" >/dev/null || fail "pending composer content changed"
+  grep -F 'Blocking verdict: pending' "$state/.subsuper-inject-wedged" >/dev/null \
+    || fail "pending composer alarm omitted its exact verdict: $(cat "$state/.subsuper-inject-wedged")"
+  grep -F 'human draft' "$state/.subsuper-inject-wedged" >/dev/null \
+    || fail "pending composer alarm omitted its readable pane capture"
+  grep -F '68756d616e206472616674' "$state/.subsuper-inject-wedged" >/dev/null \
+    || fail "pending composer alarm omitted its ANSI-preserving hex capture"
   pass "max-defer on a pending composer alarms without typing"
+}
+
+test_max_defer_busy_guard_alarms_with_exact_evidence() {
+  local dir state fakebin sent capture
+  dir=$(make_supercase maxdefer-busy-evidence)
+  state="$dir/state"; fakebin="$dir/fakebin"
+  sent="$dir/sent.log"; : > "$sent"
+  capture="$dir/pane.txt"; printf 'esc to interrupt\n' > "$capture"
+  escalate_add "$state" "blocked: dependency unavailable"
+  echo $(( $(date +%s) - 600 )) > "$state/.subsuper-escalations.since"
+  afk_enter "$state"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_CAPTURE="$capture" FM_FAKE_TMUX_SENT="$sent" \
+    FM_ESCALATE_BATCH_SECS=99999 FM_MAX_DEFER_SECS=60 housekeeping "$state"
+  [ ! -s "$sent" ] || fail "busy-guard max-defer typed into a busy pane"
+  grep -F 'Blocking verdict: busy' "$state/.subsuper-inject-wedged" >/dev/null \
+    || fail "busy-guard alarm omitted its exact verdict: $(cat "$state/.subsuper-inject-wedged")"
+  grep -F 'esc to interrupt' "$state/.subsuper-inject-wedged" >/dev/null \
+    || fail "busy-guard alarm omitted its readable pane capture"
+  grep -F '65736320746f20696e74657272757074' "$state/.subsuper-inject-wedged" >/dev/null \
+    || fail "busy-guard alarm omitted its ANSI-preserving hex capture"
+  pass "max-defer busy guard alarms with the exact verdict and bounded pane evidence"
+}
+
+test_max_defer_unknown_composer_alarms_with_exact_evidence() {
+  local dir state fakebin sent capture
+  dir=$(make_supercase maxdefer-unknown-evidence)
+  state="$dir/state"; fakebin="$dir/fakebin"
+  sent="$dir/sent.log"; : > "$sent"
+  capture="$dir/pane.txt"; printf 'plain shell prompt $\n' > "$capture"
+  escalate_add "$state" "needs-decision: choose recovery"
+  echo $(( $(date +%s) - 600 )) > "$state/.subsuper-escalations.since"
+  afk_enter "$state"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_CAPTURE="$capture" FM_FAKE_TMUX_SENT="$sent" \
+    FM_ESCALATE_BATCH_SECS=99999 FM_MAX_DEFER_SECS=60 housekeeping "$state"
+  [ ! -s "$sent" ] || fail "unknown-composer max-defer typed into an unproven pane"
+  grep -F 'Blocking verdict: unknown' "$state/.subsuper-inject-wedged" >/dev/null \
+    || fail "unknown-composer alarm omitted its exact verdict: $(cat "$state/.subsuper-inject-wedged")"
+  grep -F 'plain shell prompt $' "$state/.subsuper-inject-wedged" >/dev/null \
+    || fail "unknown-composer alarm omitted its readable pane capture"
+  grep -F '706c61696e207368656c6c2070726f6d70742024' "$state/.subsuper-inject-wedged" >/dev/null \
+    || fail "unknown-composer alarm omitted its ANSI-preserving hex capture"
+  pass "max-defer unknown composer alarms with the exact verdict and bounded pane evidence"
 }
 
 test_normal_flush_clears_stale_wedge_marker() {
@@ -1729,6 +1779,7 @@ test_inject_msg_herdr_busy_guard_defers() {
   state="$dir/state"
   afk_enter "$state"
   (
+    fm_backend_herdr_capture_ansi() { printf 'busy fixture pane'; }
     fm_backend_target_exists() { [ "$1" = herdr ] && [ "$2" = "default:w1:p2" ] || fail "unexpected target_exists args: $1 $2"; return 0; }
     pane_is_busy() { return 0; }
     fm_backend_composer_state() { fail "composer_state should not be consulted once the busy-guard already deferred"; }
@@ -1746,6 +1797,7 @@ test_inject_msg_herdr_composer_guard_defers() {
   state="$dir/state"
   afk_enter "$state"
   (
+    fm_backend_herdr_capture_ansi() { printf 'pending fixture pane'; }
     fm_backend_target_exists() { return 0; }
     pane_is_busy() { return 1; }
     fm_backend_composer_state() { [ "$1" = herdr ] && [ "$2" = "default:w1:p2" ] || fail "unexpected composer_state args: $1 $2"; printf 'pending'; }
@@ -1763,6 +1815,7 @@ test_inject_msg_herdr_pane_gone_defers() {
   state="$dir/state"
   afk_enter "$state"
   (
+    fm_backend_herdr_capture_ansi() { printf 'gone fixture pane'; }
     fm_backend_target_exists() { return 1; }
     pane_is_busy() { fail "busy guard should not be consulted once the pane-exists check already failed"; }
     fm_backend_send_text_submit() { fail "send_text_submit should not run when the pane does not exist"; }
@@ -1804,6 +1857,7 @@ test_inject_msg_defers_on_dead_shell_unknown() {
   state="$dir/state"
   afk_enter "$state"
   (
+    fm_backend_herdr_capture_ansi() { printf 'dead shell fixture pane'; }
     fm_backend_target_exists() { return 0; }
     pane_is_busy() { return 1; }
     fm_backend_composer_state() { printf 'unknown'; }
@@ -1821,6 +1875,7 @@ test_inject_msg_defers_on_unrecognized_composer_state() {
   state="$dir/state"
   afk_enter "$state"
   (
+    fm_backend_herdr_capture_ansi() { printf 'future-state fixture pane'; }
     fm_backend_target_exists() { return 0; }
     pane_is_busy() { return 1; }
     fm_backend_composer_state() { printf 'future-state'; }
@@ -1893,6 +1948,8 @@ test_submit_ack_reports_pending_on_persistent_swallow
 test_max_defer_empty_swallow_types_once_and_alarms
 test_max_defer_flushes_empty_idle_pane
 test_max_defer_pending_composer_alarms_without_typing
+test_max_defer_busy_guard_alarms_with_exact_evidence
+test_max_defer_unknown_composer_alarms_with_exact_evidence
 test_normal_flush_clears_stale_wedge_marker
 test_below_max_defer_does_nothing
 test_max_defer_afk_inactive_does_not_flush_or_alarm


### PR DESCRIPTION
## Intent

Diagnose and durably fix the away-mode sub-supervisor escalation-delivery wedge in Firstmate shared tracked material. Three captain-confirmed tmux windows with a Claude Code primary resolved the correct captain pane, buffered captain-relevant escalations, retried without mid-window delivery, raised max-defer alarms, and recovered the queue only on return. Apply diagnostic-reasoning discipline: separate trigger, mask, and symptom; compare against a proven injection path or explicitly record that no retained successful daemon injection exists; empirically test the Claude busy guard, composer-state guard including ghost suggestions, context lines, and queued-message displays, and housekeeping retry cadence against real scratch tmux Claude panes. Preserve related issues #2270 shutdown hang and #2251 watcher-arm wedge as distinct unless directly touched. The daemon must deliver a buffered escalation within one bounded housekeeping interval after the captain pane becomes genuinely idle and empty, or its wedge alarm must identify the exact blocker such as busy, pending, pending-unproven, unknown, target failure, or submit verdict and retain bounded offending pane content in readable and ANSI or hex form so the alarm alone is diagnostic. Add behavioral regression coverage for every composer misclassification found, with the production reproduction as the end-to-end regression. Never inject into a busy turn, genuinely typed composer, dead shell, or otherwise unproven composer. Update the AFK, composer/backend, wedge-alarm, and maintained verification documentation where those contracts live. Evidence established that the affected operational checkout was stale at 833a9a2 and lacked the already-landed shared classifier fix 7f05100: Claude 2.1.226 rendered an idle prompt as the agent glyph plus U+00A0 under LC_ALL=C, which the stale classifier called pending while the current classifier calls empty; current code retries every 15 seconds and real idle gaps are eligible. Preserve that current safe classifier rather than duplicating or weakening it, turn the exact NBSP shape into daemon end-to-end coverage, and make future guard failures self-diagnosing. Captain decided that maintained verification must explicitly record that no retained successful daemon injection evidence exists because the mechanism was defective from first deployment, with the classifier comparison and production-shaped e2e as the diagnostic baseline. Ship through the repository no-mistakes pipeline to a GitHub PR with tests, lint, docs, and CI green; do not merge. Captain deploy-on-green authority is on record for this PR.

## What Changed
- `bin/fm-supervise-daemon.sh` now records the exact blocker on every failed injection attempt (`busy`, `pending`, `pending-unproven`, `unknown`, `target-missing`, or a `submit-*` verdict) together with a bounded 12-line/4096-byte pane snapshot in both ANSI-stripped readable text and ANSI-preserving hex; the max-defer wedge alarm log line, durable `.subsuper-inject-wedged` marker, tmux status flash, and active alert all name that verdict, and the marker embeds the pane evidence.
- The AFK inject e2e fixture now renders Claude Code 2.1.226's byte-exact idle composer shape (`❯` + U+00A0) under `LC_ALL=C` — the production shape the stale classifier misread as `pending` — and `tests/fm-daemon.test.sh` adds max-defer regression tests asserting the exact verdict plus readable and hex pane evidence for busy, pending, and unknown-composer blockers.
- Documentation updates: the AFK skill doc states the one-housekeeping-interval delivery bound and consolidates the max-defer contract, `docs/wedge-alarm.md` and `docs/herdr-backend.md` describe the new alarm evidence, and `docs/verification/supervision.md` records the NBSP away-delivery regression diagnosis and that no retained successful daemon injection evidence exists (the classifier comparison and e2e are the diagnostic baseline).

## Risk Assessment

✅ Low: All new daemon code executes only on already-failing injection paths and adds diagnostics without changing guard or delivery semantics; evidence propagation, marker-consumer compatibility, backend helper existence, and every source-verifiable intent requirement (classifier preserved, NBSP e2e regression, exact-blocker alarm with bounded readable+hex evidence, no-retained-injection baseline recorded, all four doc contracts updated) were verified against the source.

## Testing

Ran the three targeted suites named by the change's verification docs (composer classifier, daemon units, real-tmux injection e2e) — all pass; additionally captured product-level artifacts (the live pane surface with the NBSP idle composer and delivered digest, and a real diagnostic wedge-alarm marker) and demonstrated the new wedge-evidence assertions fail on the base commit. This is a terminal/TUI daemon with no browser UI, so the reviewer-visible surface is the tmux capture-pane transcript and marker files, which were captured as text artifacts.

<details>
<summary>Evidence: E2E Scenario A: pane surface, NBSP idle-row bytes, and verbatim submission log</summary>

<code>=== idle composer row bytes (hex of last non-empty row) ===&#10;e2 9d af c2 a0 0a &lt;- ❯ + U+00A0 (the production shape that used to read pending)&#10;&#10;=== submitted.log (hex &lt;TAB&gt; text &lt;TAB&gt; classification) ===&#10;human draft text -&gt; user&#10;⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (1 event(s)): fake-c1.status: done: PR https://example.test/pr/100 ... -&gt; injection (one clean line, never merged)</code>

```text
=== supervisor pane surface (tmux capture-pane, post-delivery) ===
bash '/tmp/fm-afk-e2e.E51veW/supervisor-loop.sh' '/tmp/fm-afk-e2e.E51veW/submitted.log'
           .-------------------------:                    johannesr@KleinKlip
          .+=========================.                    -------------------
         :++===++==================-       :++-           OS: CachyOS x86_64
        :*++====+++++=============-        .==:           Host: MS-7D73 (1.0)
       -*+++=====+***++==========:                        Kernel: Linux 7.1.6-1-cachyos
      =*++++========------------:                         Uptime: 6 days, 1 hour, 41 mins
     =*+++++=====-                     ...                Packages: 14 (flatpak), 1903 (pacman)
   .+*+++++=-===:                    .=+++=:              Shell: fish 4.8.1
  :++++=====-==:                     -*****+              DE: KDE Plasma 6.7.4
 :++========-=.                      .=+**+.              WM: KWin (Wayland)
.+==========-.                          .                 WM Theme: Breeze
 :+++++++====-                                .--==-.     Theme: Breeze (Dark) [Qt], Breeze-Dark [GTK2], Breeze [GTK3]
  :++==========.                             :+++++++:    Icons: breeze-dark [Qt], breeze-dark [GTK2/3/4]
   .-===========.                            =*****+*+    Font: Noto Sans (10pt) [Qt], Noto Sans (10pt) [GTK2/3/4]
    .-===========:                           .+*****+:    Cursor: capitaine-cursors-light (24px)
      -=======++++:::::::::::::::::::::::::-:  .---:      Terminal: tmux 3.7b
       :======++++====+++******************=.             CPU: AMD Ryzen 7 7800X3D (16) @ 5.05 GHz
        :=====+++==========++++++++++++++*-               GPU 1: NVIDIA GeForce RTX 5090 [Discrete]
         .====++==============++++++++++*-                GPU 2: AMD Raphael [Integrated]
          .===+==================+++++++:                 Memory: 12.08 GiB / 30.23 GiB (40%)
           .-=======================+++:                  Swap: 9.53 GiB / 30.23 GiB (32%)
             ..........................                   Disk (/): 838.68 GiB / 3.63 TiB (23%) - btrfs
                                                          Local IP (wlan0): 192.168.68.53/22
                                                          Locale: en_GB.UTF-8
~/.no-mistakes/worktrees/551ff26a6b1c/01M00DXJ29XKWC0W25HMNRNFSV fm/afk-inject-fix
❯ bash '/tmp/fm-afk-e2e.E51veW/supervisor-loop.sh' '/tmp/fm-afk-e2e.E51veW/submitted.log'
❯ 

=== idle composer row bytes (hex of last non-empty row) ===
 e2 9d af c2 a0 0a

=== submitted.log (hex <TAB> text <TAB> classification, verbatim) ===
68756d616e2064726166742074657874	human draft text	user
e281a346495253544d4154455f4f503a20763120617761792d73757065727669736f723a2053757065727669736f7220657363616c617465202831206576656e74287329293a2066616b652d63312e7374617475733a20646f6e653a2050522068747470733a2f2f6578616d706c652e746573742f70722f313030202863617463682d616c6c207363616e2920287072652d726561643b2072652d61726d206e6f74206e656564656420e280942077617463686572206461656d6f6e2d6d616e6167656429	⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (1 event(s)): fake-c1.status: done: PR https://example.test/pr/100 (catch-all scan) (pre-read; re-arm not needed — watcher daemon-managed)	injection

=== daemon log (delivery timeline) ===
```
</details>
<details>
<summary>Evidence: Real wedge-alarm marker from a busy-pane max-defer (diagnostic on its own)</summary>

<code>fm away-mode inject WEDGED: 600s undelivered as of 2026-08-14T17:31:59+0200&#10;Blocking verdict: busy&#10;Blocking detail: primary-pane busy guard&#10;Offending pane capture (ansi, ANSI stripped, bounded):&#10;Working on the deploy fix...&#10;esc to interrupt&#10;Offending pane capture bytes (ANSI-preserving hex, bounded):&#10;576f726b696e67206f6e20746865206465706c6f79206669782e2e2e0a65736320746f20696e74657272757074&#10;The supervisor pane could not accept an escalation. Buffered items:&#10;blocked: production deploy needs a captain decision</code>

```text
=== state/.subsuper-inject-wedged (verbatim marker) ===
fm away-mode inject WEDGED: 600s undelivered as of 2026-08-14T17:31:59+0200
Blocking verdict: busy
Blocking detail: primary-pane busy guard
Offending pane capture (ansi, ANSI stripped, bounded):
Working on the deploy fix...
esc to interrupt
Offending pane capture bytes (ANSI-preserving hex, bounded):
576f726b696e67206f6e20746865206465706c6f79206669782e2e2e0a65736320746f20696e74657272757074
The supervisor pane could not accept an escalation. Buffered items:
blocked: production deploy needs a captain decision
```
</details>
<details>
<summary>Evidence: Regression proof: new wedge-evidence assertions fail on base commit</summary>

<code>=== fail-before-fix: target tests/fm-daemon.test.sh run against BASE (6789876) daemon code ===&#10;not ok - stuck submit alarm omitted the exact submit verdict: fm away-mode inject WEDGED: 600s undelivered as of 2026-08-14T17:35:20+0200</code>

```text
=== fail-before-fix: target tests/fm-daemon.test.sh run against BASE (6789876) daemon code ===
not ok - stuck submit alarm omitted the exact submit verdict: fm away-mode inject WEDGED: 600s undelivered as of 2026-08-14T17:35:20+0200
```
</details>
<details>
<summary>Evidence: Full daemon unit-suite transcript (101 ok, incl. new max-defer evidence tests)</summary>

```text
ok - fm-afk-start.sh fails before daemon startup when the afk flag cannot be written
ok - fm-afk-start.sh ignores stale pidfile-only live pids
ok - fm-afk-start.sh reclaims stale daemon locks whose live pid identity no longer matches
ok - supervise daemon state root is scoped by FM_HOME
ok - routine signal self-handles
ok - captain-relevant status verbs escalate
ok - check + unknown escalate; heartbeat self-handles
ok - transient stale self-handles and records a persistence marker
ok - enriched stale wedges bypass status absorption without disturbing busy workers
ok - stale + terminal status escalates immediately
ok - paused reasons with captain phrases remain pause-classified
ok - handle_wake on a paused stale records a pause marker, drops the wedge marker, and does not escalate
ok - handle_wake records a declared pause from a routine signal for long-cadence rechecks
ok - a terminal signal clears pause and stale tracking across both supervisors
ok - housekeeping migrates a normal-watcher's declared pause into daemon tracking
ok - housekeeping clears an already-resumed watcher pause across both supervisors
ok - housekeeping seeds pause tracking from status without a watcher marker
ok - persistent stale escalates after threshold and clears its marker
ok - resumed (busy) stale clears its marker without escalating
ok - housekeeping re-surfaces a stale declared pause on the long cadence and resets its window
ok - housekeeping clears a paused marker whose pane became busy again, without escalating
ok - housekeeping clears a paused marker once the crew is no longer declaring the pause
ok - housekeeping moves an existing stale marker to pause before wedge escalation
ok - housekeeping clears tracking when a crew leaves pause
ok - persistent herdr stale resolves the target from metadata and escalates
ok - herdr idle busy-footer stale clears through capture corroboration
ok - resumed herdr stale clears through backend-aware busy state
ok - persistent Orca stale resolves the terminal from metadata
ok - multiple escalations flush as a single batched digest
ok - batch flush measures max-delay from the first append, not the last
ok - catch-all scan escalates a missed terminal once, not twice
ok - handle_wake routes routine->self and captain->escalate
ok - INJECT_SKIP forces self-handle, bypassing captain-relevant classification
ok - is_wake_reason distinguishes watcher wake reasons from singleton-status stdout
ok - terminal-stale escalate removes its marker so housekeeping does not re-escalate
ok - captain signal escalate marks seen so the catch-all scan does not re-fire
ok - _collapse_newlines replaces newlines with literal separator
ok - afk flag absent: daemon does not inject, buffer preserved
ok - busy-guard defers injection when supervisor pane is busy
ok - marker detection: marker -> stay afk, no marker -> exit afk
ok - /afk invocation is exempt from afk exit (no self-cancel)
ok - should_exit_afk returns false when afk is not active
ok - strip_injection_marker removes the sentinel marker cleanly
ok - pane_input_pending detects partial input on the cursor line
ok - pane_input_pending: a blank unidentified cursor row defers (strict container-proof rule)
ok - pane_input_pending: only proven empty agent prompts pass
ok - fm_tmux_composer_state: a bare shell prompt ($/%/#/>) reads unknown, never empty (dead-shell injection safety)
ok - fm_tmux_composer_state: a bordered composer box and bare agent glyphs (❯/›) still read empty
ok - fm_tmux_composer_state: only matching edge borders form a composer box
ok - pane_input_pending preserves bright placeholder-like drafts in styled captures
ok - classify_signal dedupes against the catch-all scan seen marker
ok - classify_stale dedupes against the signal path seen marker
ok - AFK nonterminal working:+merged keeps wedge aging and re-escalates at bound
ok - genuine done: and merge-check events still escalate
ok - pane_input_pending: an idle bordered composer is NOT pending (afk-invx-i5)
ok - pane_input_pending: text inside a bordered composer is still pending
ok - submit-ACK confirms a submit when the composer returns to a bordered-empty box
ok - submit-ACK reports pending on a persistently swallowed Enter (type-once)
ok - max-defer on an empty stuck pane types once, alarms, and preserves the buffer
ok - max-defer flushes and clears the buffer on an empty bordered pane
ok - max-defer on a pending composer alarms without typing
ok - max-defer busy guard alarms with the exact verdict and bounded pane evidence
ok - max-defer unknown composer alarms with the exact verdict and bounded pane evidence
ok - normal flush clears a stale wedge marker
ok - below MAX_DEFER: no inject, no alarm, buffer preserved
ok - max-defer does not flush or alarm while afk is inactive
ok - library mode: sourcing the daemon defaults FM_WEDGE_ALARM_EXEC to discard (no test can fire a real notification)
ok - wake helpers replace inherited notifier overrides with the safe recorder
ok - the discard seam suppresses every notifier, including command: (fires nothing)
ok - direct notifier helpers honor the discard seam, including command:
ok - osascript channel routes through the notifier seam with the summary (never a real notification)
ok - herdr channel routes through the notifier seam with the summary (never a real notification)
ok - command channel runs the captain command with the summary on $1 and on stdin
ok - command channel failures redact configured commands while logging their exit status
ok - unknown channel directives are redacted while the alarm keeps running
ok - off disables every active alert regardless of directive position (marker and tmux flash are unaffected)
ok - auto resolves to the macOS osascript notifier on Darwin (default-on)
ok - auto on a non-macOS platform selects no built-in OS channel (the marker or a configured command carries it)
ok - config/wedge-alarm selects every configured channel and skips comment and blank lines
ok - a failing channel logs and falls back to the next channel, never crashing the alarm
ok - a hung notifier is bounded, logged, and falls through to the next channel
ok - a backgrounded command notifier remains bounded until its process group is reaped
ok - a hung notifier override is bounded, logged, and proceeds to the next channel
ok - daemon shutdown stops and reaps the active notifier process group
ok - inject_wedge_alarm writes the marker AND emits the active alert even with no tmux status-line (herdr backend)
ok - in-process wedge throttle prevents alert spam when the marker cannot persist
ok - fm-send exits non-zero on a confirmed swallow, zero on a clean submit
ok - fm-send exits non-zero when initial text send fails
ok - fm-send exits non-zero unless delivery is proven empty
ok - discover_supervisor_backend: override > TMUX_PANE > HERDR_ENV+HERDR_PANE_ID > tmux fallback
ok - discover_supervisor_target: override > TMUX_PANE > herdr '<session>:<pane-id>' composition > firstmate:0 fallback
ok - pane_is_busy: herdr native busy_state='busy' short-circuits without a capture fallback
ok - primary busy guard isolates rendered signatures by detected harness
ok - pane_is_busy: omitted backend defaults to tmux for Grok's isolated fallback
ok - pane_input_pending: dispatches through fm_backend_composer_state for backend=herdr
ok - inject_msg: herdr busy-guard defers before ever attempting a submit
ok - inject_msg: herdr composer-guard defers before ever attempting a submit
ok - inject_msg: herdr pane-gone check defers before any busy/composer/submit call
ok - inject_msg: dispatches busy-guard/composer-guard/submit through the herdr backend and succeeds on a confirmed empty composer
ok - inject_msg: defers on a dead-shell/unreadable composer (unknown), never typing the escalation into a shell
ok - inject_msg: unrecognized composer states defer by default
```
</details>
<details>
<summary>Evidence: Composer classifier suite transcript (30 ok, incl. ❯+NBSP empty in both locales)</summary>

```text
ok - fm_composer_classify_content: a bare shell prompt glyph (>/$/%/#) reads unknown, never empty
ok - fm_composer_classify_content: stripped unbordered content is unknown except verified agent glyphs
ok - fm_composer_classify_content: a bare shell prompt carrying a command is not empty
ok - fm_composer_classify_content: a bare prompt glyph inside a bordered composer box reads empty (claude's own idle composer)
ok - fm_composer_classify_content: agent prompt glyphs (❯ claude, › codex, ⟩ muse) read empty bordered or bare
ok - fm_composer_classify_content: an empty composer reads empty
ok - fm_composer_classify_content: idle matching is limited to proven placeholder positions
ok - fm_composer_classify_content: idle matching preserves the caller's case mode
ok - fm_composer_classify_content: real unsubmitted text reads pending (including a popup argument-hint fill)
ok - matrix: claude's ❯+NBSP row reads empty on every profile in both locales (#1988)
ok - matrix: codex's dim hint is empty when styling proves it, unknown (never pending) when it cannot
ok - matrix: muse's ⟩ reads empty everywhere and survives losing the styled-glyph signal
ok - matrix: cursor's reverse-video placeholder remnant reads empty; real typed text stays pending
ok - matrix: herdr half-block rules bound a bare composer's wrap region
ok - matrix: pi's separated composer needs identity + structure; the blank row alone never proves it
ok - matrix: opencode's left-bar composer reads empty everywhere and scans the full active run
ok - matrix: grok's titled bottom border is tolerated as a title, not read as ambiguity
ok - matrix: kimi's bordered shell-glyph box reads empty through the shared owner (spawn's fourth copy retired)
ok - matrix: the real claude-in-zellij --ansi dump reads empty in both locales
ok - strict posture: blank and unidentified rows are unknown, never injectable empty
ok - fm_composer_classify_screen: the bare composer's wrap region stays identified; structure breaks it
ok - fm_composer_classify_screen: a row-leading agent glyph reanchors the live composer
ok - fm_composer_classify_screen: a lower dead shell invalidates only cursorless stale composers
ok - fm_composer_classify_screen: cursorless bare wrap regions participate in verdicts
ok - fm_composer_classify_screen: cursorless containers reject only contiguous unclaimed activity
ok - fm_composer_classify_screen: the bottom-most candidate wins; stale banners cannot
ok - fm_composer_classify_screen: incomplete lower structure invalidates stale boxes
ok - fm_composer_classify_screen: titled bottoms retain full box geometry
ok - fm_composer_classify_screen: a proven box tolerates a bottom-border cursor
ok - fm_composer_extract_selected_content: scopes user content and excludes furniture
```
</details>
<details>
<summary>Evidence: Real-tmux injection e2e transcript (Scenarios A/B/C ok)</summary>

```text
ok - Scenario A: partial input defers injection; digest arrives clean after idle
ok - Scenario B: swallowed Enter produces exactly one clean digest
ok - Scenario C: a normal captain status injects exactly one clean single-line sentinel digest
all e2e injection tests passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 3 infos</summary>

- ℹ️ `bin/fm-supervise-daemon.sh:1147` - Wedge evidence is a second pane capture taken inside inject_evidence_record, moments after the busy/composer guard&#39;s own classification capture. For the persistent-misclassification scenario the intent targets (an idle pane misread for whole windows) the re-read is equivalent, but under a racing pane the marker snapshot can differ from the content the guard actually classified, so the &#39;offending pane content&#39; is best-effort rather than the exact classified bytes. Capturing the classified screen would require widening the fm_backend_composer_state API; the current tradeoff is reasonable and documented (&#39;from the failure point&#39;).
- ℹ️ `tests/fm-daemon.test.sh:1187` - The exact-verdict assertions use unanchored grep -F, so &#39;Blocking verdict: pending&#39; also matches a &#39;Blocking verdict: pending-unproven&#39; line (and &#39;unknown&#39; would match &#39;submit-unknown&#39; if ordering changed). If the classifier verdict for a genuinely typed draft ever degraded from pending to pending-unproven, these tests would still pass despite the fail messages promising the &#39;exact verdict&#39;. Anchoring the match (e.g. grep -Fx &#39;Blocking verdict: pending&#39;) would make the assertions exact.
- ℹ️ `bin/fm-supervise-daemon.sh:926` - The wedge marker&#39;s first line (&#39;fm away-mode inject WEDGED: &lt;age&gt;s undelivered as of &lt;ts&gt;&#39;) does not include the blocker verdict, and the afk-return catch-up surfaces only head -1 of the marker (bin/fm-afk-return.sh:173), so the &#39;while you were out&#39; evidence line names the wedge but not its cause. The intent&#39;s requirement (log, marker, flash, and alert summary name the verdict) is satisfied as written; adding &#39;(blocker=...)&#39; to the marker&#39;s first printf would additionally make the catch-up evidence itself diagnostic. Optional improvement, not required by the acceptance criteria.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-composer-lib.test.sh` — 30/30 pass, including the ❯+NBSP row reading empty on every profile in both locales</code>
- <code>`bash tests/fm-afk-inject-e2e.test.sh` — Scenarios A/B/C pass against a real tmux 3.7b pane with a live daemon under LC_ALL=C and 1s housekeeping tick</code>
- <code>`bash tests/fm-daemon.test.sh` — 101/101 pass, including new `test_max_defer_busy_guard_alarms_with_exact_evidence` and `test_max_defer_unknown_composer_alarms_with_exact_evidence` plus verdict/hex assertions added to the pending-composer and stuck-submit max-defer tests</code>
- <code>Instrumented e2e Scenario A rerun preserving the post-delivery tmux pane surface, the idle composer row bytes (e2 9d af c2 a0 = ❯ + U+00A0), and the verbatim submitted-content log (human draft as `user`, digest as one clean `injection` line)</code>
- <code>Manual verification: drove `housekeeping` against a fake busy pane past FM_MAX_DEFER_SECS and captured the resulting `.subsuper-inject-wedged` marker verbatim (verdict, detail, readable + hex capture, preserved buffer)</code>
- <code>Fail-before-fix: ran the target `tests/fm-daemon.test.sh` against the base-commit (6789876) daemon code in an ephemeral tree — the new exact-verdict assertion fails there and passes on the target</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
