### PR TITLE
fix: deliver away-mode escalations through titled composers

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -111,7 +111,7 @@ If that submit cannot be confirmed, it raises a loud, rate-limited wedge alarm:
 an ERROR in the daemon log, a durable
 `state/.subsuper-inject-wedged` marker (surface it on the "while you were out"
 catch-up if present), a tmux status-line flash when applicable, and a configurable backend-independent active alert.
-`docs/wedge-alarm.md` owns the alert channel setup, and `docs/verification/supervision.md` "Wedge-alarm channels" owns active evidence.
+`docs/wedge-alarm.md` owns the marker's diagnostic contents and alert channel setup, and `docs/verification/supervision.md` "Wedge-alarm channels" owns active evidence.
 So a guard false-positive becomes a visible stall, never an unbounded silent no-op.
 
 ## Submit model

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2633,8 +2633,9 @@ fm_backend_herdr_composer_identity() {  # <target> -> "<agent>\t<status>"
   fm_backend_herdr_agent_identity_raw "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE"
 }
 
-# _fm_backend_herdr_composer_observe: thin adapter - capture plus capabilities
-# in, shared verdict out. The ANSI capture is preferred (styled=1 lets the
+# _fm_backend_herdr_composer_observe: capture one Herdr composer snapshot and
+# classify that same snapshot into FM_BACKEND_COMPOSER_SCREEN and
+# FM_BACKEND_COMPOSER_VERDICT. The ANSI capture is preferred (styled=1 lets the
 # shared classifier strip ghost/placeholder text); when it fails on an older
 # herdr, the plain capture degrades the descriptor to styled=0 rather than
 # letting ghost text be misread as typed input. Identity is fetched lazily,

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2654,6 +2654,7 @@ _fm_backend_herdr_composer_observe() {  # <target>
   else
     return 0
   fi
+  # shellcheck disable=SC2034 # Consumed by fm_backend_composer_observation in bin/fm-backend.sh.
   FM_BACKEND_COMPOSER_SCREEN=$cap
   verdict=$(fm_composer_classify_screen "$caps" "$cap")
   if [ "$verdict" = need-identity ]; then

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2633,7 +2633,7 @@ fm_backend_herdr_composer_identity() {  # <target> -> "<agent>\t<status>"
   fm_backend_herdr_agent_identity_raw "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE"
 }
 
-# fm_backend_herdr_composer_state: thin adapter - capture plus capabilities
+# _fm_backend_herdr_composer_observe: thin adapter - capture plus capabilities
 # in, shared verdict out. The ANSI capture is preferred (styled=1 lets the
 # shared classifier strip ghost/placeholder text); when it fails on an older
 # herdr, the plain capture degrades the descriptor to styled=0 rather than
@@ -2641,17 +2641,19 @@ fm_backend_herdr_composer_identity() {  # <target> -> "<agent>\t<status>"
 # only when the classifier reports the verdict depends on it (a pi separator
 # pair below every other candidate), preserving this adapter's original
 # consult-only-when-needed behavior.
-fm_backend_herdr_composer_state() {  # <target> -> empty|pending|pending-unproven|unknown
+_fm_backend_herdr_composer_observe() {  # <target>
   local target=$1 cap caps verdict identity
-  fm_backend_herdr_parse_target "$target" || { printf 'unknown'; return 0; }
+  FM_BACKEND_COMPOSER_SCREEN=
+  FM_BACKEND_COMPOSER_VERDICT=unknown
+  fm_backend_herdr_parse_target "$target" || return 0
   if cap=$(fm_backend_herdr_capture_ansi "$target" "$FM_COMPOSER_CAPTURE_LINES" 2>/dev/null); then
     caps=$(printf 'styled=1\ncursor=0\nidentity=1\nrows=%s' "$FM_COMPOSER_CAPTURE_LINES")
   elif cap=$(fm_backend_herdr_capture "$target" "$FM_COMPOSER_CAPTURE_LINES"); then
     caps=$(printf 'styled=0\ncursor=0\nidentity=1\nrows=%s' "$FM_COMPOSER_CAPTURE_LINES")
   else
-    printf 'unknown'
     return 0
   fi
+  FM_BACKEND_COMPOSER_SCREEN=$cap
   verdict=$(fm_composer_classify_screen "$caps" "$cap")
   if [ "$verdict" = need-identity ]; then
     if ! identity=$(fm_backend_herdr_composer_identity "$target" 2>/dev/null) || [ -z "$identity" ]; then
@@ -2660,7 +2662,12 @@ fm_backend_herdr_composer_state() {  # <target> -> empty|pending|pending-unprove
     verdict=$(fm_composer_classify_screen "$caps" "$cap" '' "$identity")
     [ "$verdict" != need-identity ] || verdict=unknown
   fi
-  printf '%s' "$verdict"
+  FM_BACKEND_COMPOSER_VERDICT=$verdict
+}
+
+fm_backend_herdr_composer_state() {  # <target> -> empty|pending|pending-unproven|unknown
+  _fm_backend_herdr_composer_observe "$1"
+  printf '%s' "$FM_BACKEND_COMPOSER_VERDICT"
 }
 
 # fm_backend_herdr_rendered_busy_state: busy|idle|unknown from the pane's

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -820,7 +820,7 @@ fm_backend_composer_state() {  # <backend> <target> [expected-label] -> empty|pe
 }
 
 fm_backend_composer_observation() {  # <backend> <target>
-  local backend=$1
+  local backend=$1 plain_screen
   shift
   FM_BACKEND_COMPOSER_SCREEN=
   FM_BACKEND_COMPOSER_VERDICT=unknown
@@ -833,7 +833,8 @@ fm_backend_composer_observation() {  # <backend> <target>
   printf 'composer verdict: %s\n' "$FM_BACKEND_COMPOSER_VERDICT"
   printf 'captured screen:\n'
   if [ -n "$FM_BACKEND_COMPOSER_SCREEN" ]; then
-    printf '%s\n' "$FM_BACKEND_COMPOSER_SCREEN"
+    plain_screen=$(printf '%s\n' "$FM_BACKEND_COMPOSER_SCREEN" | fm_composer_strip_ansi)
+    printf '%s\n' "$plain_screen"
   else
     printf '(capture failed)\n'
   fi

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -819,6 +819,26 @@ fm_backend_composer_state() {  # <backend> <target> [expected-label] -> empty|pe
   esac
 }
 
+fm_backend_composer_observation() {  # <backend> <target>
+  local backend=$1
+  shift
+  FM_BACKEND_COMPOSER_SCREEN=
+  FM_BACKEND_COMPOSER_VERDICT=unknown
+  fm_backend_source "$backend" || return 1
+  case "$backend" in
+    tmux) _fm_tmux_composer_observe "$@" ;;
+    herdr) _fm_backend_herdr_composer_observe "$@" ;;
+    *) return 1 ;;
+  esac
+  printf 'composer verdict: %s\n' "$FM_BACKEND_COMPOSER_VERDICT"
+  printf 'captured screen:\n'
+  if [ -n "$FM_BACKEND_COMPOSER_SCREEN" ]; then
+    printf '%s\n' "$FM_BACKEND_COMPOSER_SCREEN"
+  else
+    printf '(capture failed)\n'
+  fi
+}
+
 # fm_backend_target_exists: cheap, READ-ONLY existence check - does the
 # recorded TARGET endpoint still exist on BACKEND? Never starts a server or
 # session: for herdr this deliberately queries the pane directly instead of

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -819,6 +819,10 @@ fm_backend_composer_state() {  # <backend> <target> [expected-label] -> empty|pe
   esac
 }
 
+# fm_backend_composer_observation: capture and classify one tmux or Herdr
+# composer snapshot, then print the verdict and that same snapshot as plain
+# text. Keeping the pair on one read makes a wedge marker diagnostic even when
+# the pane changes immediately afterward. Unsupported backends return nonzero.
 fm_backend_composer_observation() {  # <backend> <target>
   local backend=$1 plain_screen
   shift

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -593,7 +593,7 @@ fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [
 # injector defers on anything that is not `empty`, so escalations buffered for
 # 9.7 hours with the supervisor pane sitting idle the whole time.
 _fm_composer_pi_separator_row() {  # <trimmed-row>
-  local row=$1 residue
+  local row=$1 residue LC_ALL=C
   [ -n "$row" ] || return 1
   case "$row" in
     *────────*) ;;
@@ -604,10 +604,9 @@ _fm_composer_pi_separator_row() {  # <trimmed-row>
     ─*─) ;;
     *) return 1 ;;
   esac
-  residue=${row//─/ }
-  residue=$(printf '%s' "$residue" | LC_ALL=C sed 's/[!-~]/ /g')
+  residue=${row//─/}
   case "$residue" in
-    *[![:space:]]*) return 1 ;;
+    *[![:print:]]*) return 1 ;;
   esac
   return 0
 }

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -588,13 +588,10 @@ fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [
 # promoted to a rule.
 #
 # Claude draws the session's agent name into the top rule of its own bare
-# composer this way (verified live on claude 2.1.232 through herdr 0.8.0). While
-# only a solid rule counted, that one titled rule left the composer's untitled
-# BOTTOM rule unpaired; an unpaired rule below the candidate is read as proof
-# that the candidate is stale, so _fm_composer_select_cursorless abandoned
-# selection and every idle claude pane classified `unknown`. The away-mode
-# injector defers on anything that is not `empty`, so escalations buffered for
-# 9.7 hours with the supervisor pane sitting idle the whole time.
+# composer this way. If only a solid rule counts, the untitled bottom rule is
+# left unpaired and cursorless selection rejects the real composer as stale.
+# The strict two-ended ASCII-printable form admits that title without admitting
+# one-ended transcript prose or non-ASCII content as a composer boundary.
 _fm_composer_pi_separator_row() {  # <trimmed-row>
   local row=$1 residue LC_ALL=C
   [ -n "$row" ] || return 1

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -61,12 +61,15 @@
 #   left-bar   - opencode: rows prefixed by a heavy left bar `┃` with no
 #                closing border, holding the idle hint, blank rows, and a
 #                mode/model footer line.
-#   separated  - pi: content rows between two solid horizontal `─` rules, no
-#                glyph and no side border. Provable only with a live agent
-#                identity reporting an idle/done/blocked pi (herdr `agent
-#                get`; the tmux foreground-process probe), because a blank
-#                region between two transcript rules is otherwise exactly the
-#                strict rule's unidentifiable blank row.
+#   separated  - pi: content rows between two horizontal `─` rules, no glyph
+#                and no side border. Provable only with a live agent identity
+#                reporting an idle/done/blocked pi (herdr `agent get`; the tmux
+#                foreground-process probe), because a blank region between two
+#                transcript rules is otherwise exactly the strict rule's
+#                unidentifiable blank row. A rule may carry a TITLE embedded in
+#                it, the same tolerance a titled bottom BORDER already gets;
+#                claude draws the session's agent name that way, and the rules
+#                it draws around its own bare composer must still pair.
 #
 # THE SAFETY RULE for glyphs: a bare shell prompt glyph (`>` `$` `%` `#`) -
 # what a pane shows once its agent has exited to a plain login shell - is a
@@ -571,17 +574,42 @@ fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [
 # exact positive proof they require (`empty`), so unrecognized future verdicts
 # fail safe by default.
 
-# _fm_composer_pi_separator_row: a solid pi separator - nothing but `─`, at
-# least 8 columns wide. The width floor is a literal substring test so it is
-# byte-exact in every locale.
+# _fm_composer_pi_separator_row: a horizontal `─` rule at least 8 columns wide,
+# either solid or carrying an embedded TITLE. The width floor is a literal
+# substring test so it is byte-exact in every locale.
+#
+# The titled form is the same bounded tolerance _fm_composer_titled_bottom_ok
+# gives a titled bottom BORDER, and for the same reason: the title is embedded
+# IN the rule rather than replacing it, so the row still starts and ends with
+# the rule glyph and everything between is ASCII-printable. Requiring both ends
+# is what keeps an ordinary transcript line from being promoted to a rule.
+#
+# Claude draws the session's agent name into the top rule of its own bare
+# composer this way (verified live on claude 2.1.232 through herdr 0.8.0). While
+# only a solid rule counted, that one titled rule left the composer's untitled
+# BOTTOM rule unpaired; an unpaired rule below the candidate is read as proof
+# that the candidate is stale, so _fm_composer_select_cursorless abandoned
+# selection and every idle claude pane classified `unknown`. The away-mode
+# injector defers on anything that is not `empty`, so escalations buffered for
+# 9.7 hours with the supervisor pane sitting idle the whole time.
 _fm_composer_pi_separator_row() {  # <trimmed-row>
-  local row=$1
+  local row=$1 residue
   [ -n "$row" ] || return 1
-  [ -z "${row//─/}" ] || return 1
   case "$row" in
-    *────────*) return 0 ;;
+    *────────*) ;;
+    *) return 1 ;;
   esac
-  return 1
+  [ -z "${row//─/}" ] && return 0
+  case "$row" in
+    ─*─) ;;
+    *) return 1 ;;
+  esac
+  residue=${row//─/ }
+  residue=$(printf '%s' "$residue" | LC_ALL=C sed 's/[!-~]/ /g')
+  case "$residue" in
+    *[![:space:]]*) return 1 ;;
+  esac
+  return 0
 }
 
 # Row-scan results are returned through FM_COMPOSER_SCAN_* globals (bash 3.2

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -67,9 +67,11 @@
 #                foreground-process probe), because a blank region between two
 #                transcript rules is otherwise exactly the strict rule's
 #                unidentifiable blank row. A rule may carry a TITLE embedded in
-#                it, the same tolerance a titled bottom BORDER already gets;
-#                claude draws the session's agent name that way, and the rules
-#                it draws around its own bare composer must still pair.
+#                it when the interior is ASCII-printable after the standard
+#                Unicode-whitespace normalization and the row retains the same
+#                two-ended shape a titled bottom BORDER gets; claude draws the
+#                session's agent name that way, and the rules around its own
+#                bare composer must still pair.
 #
 # THE SAFETY RULE for glyphs: a bare shell prompt glyph (`>` `$` `%` `#`) -
 # what a pane shows once its agent has exited to a plain login shell - is a
@@ -578,11 +580,12 @@ fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [
 # either solid or carrying an embedded TITLE. The width floor is a literal
 # substring test so it is byte-exact in every locale.
 #
-# The titled form is the same bounded tolerance _fm_composer_titled_bottom_ok
-# gives a titled bottom BORDER, and for the same reason: the title is embedded
-# IN the rule rather than replacing it, so the row still starts and ends with
-# the rule glyph and everything between is ASCII-printable. Requiring both ends
-# is what keeps an ordinary transcript line from being promoted to a rule.
+# The titled form uses the same two-ended shape _fm_composer_titled_bottom_ok
+# gives a titled bottom BORDER: the title is embedded IN the rule rather than
+# replacing it, so the row still starts and ends with the rule glyph. Everything
+# between is ASCII-printable after the standard Unicode-whitespace normalization.
+# Requiring both ends is what keeps an ordinary transcript line from being
+# promoted to a rule.
 #
 # Claude draws the session's agent name into the top rule of its own bare
 # composer this way (verified live on claude 2.1.232 through herdr 0.8.0). While

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -591,7 +591,8 @@ fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [
 # composer this way. If only a solid rule counts, the untitled bottom rule is
 # left unpaired and cursorless selection rejects the real composer as stale.
 # The strict two-ended ASCII-printable form admits that title without admitting
-# one-ended transcript prose or non-ASCII content as a composer boundary.
+# one-ended transcript prose or non-whitespace non-ASCII content as a composer
+# boundary.
 _fm_composer_pi_separator_row() {  # <trimmed-row>
   local row=$1 residue LC_ALL=C
   [ -n "$row" ] || return 1
@@ -657,9 +658,11 @@ _fm_composer_scan_screen() {  # <plain-screen> <cursor-or-empty> [extract-wrap]
       '┗'*'┛') kind=bottom; family=heavy ;;
       '+'*'+') kind=ascii; family=ascii ;;
     esac
-    # Pi separator rows: a solid `─` rule at least 8 columns wide. A separator
-    # closes the preceding candidate and immediately opens the next, so an
-    # earlier transcript rule can never outrank the live bottom composer pair.
+    # Horizontal separator rows use a `─` rule at least 8 columns wide, either
+    # solid or carrying the bounded title accepted by the owner above. A
+    # separator closes the preceding candidate and immediately opens the next,
+    # so an earlier transcript rule can never outrank the live bottom composer
+    # pair.
     if _fm_composer_pi_separator_row "$trimmed"; then
       FM_COMPOSER_SCAN_PI_LAST_SEPARATOR=$row
       if [ "$pi_open" -ge 0 ]; then

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -909,13 +909,25 @@ inject_wedge_alarm() {  # <state> <age-seconds>
     WEDGE_ALARM_LAST_EPOCH=$now
     log "ERROR: away-mode escalation undelivered ${age}s; inject could not confirm a submit (supervisor pane busy or wedged). Buffer + wake-queue preserved; alarm marker written."
   fi
+  target="${FM_SUPERVISOR_TARGET:-$FM_SUPERVISOR_TARGET_DEFAULT}"
+  backend="${FM_SUPERVISOR_BACKEND:-$FM_SUPERVISOR_BACKEND_DEFAULT}"
   {
     printf 'fm away-mode inject WEDGED: %ss undelivered as of %s\n' "$age" "$(date '+%Y-%m-%dT%H:%M:%S%z')"
     printf 'The supervisor pane could not accept an escalation. Buffered items:\n'
     cat "$state/.subsuper-escalations" 2>/dev/null
+    # The defer reason alone cannot separate "the captain half-typed a line"
+    # from "this pane's rendering is not in the shape catalogue". Record the
+    # verdict and the screen it was read from, ONCE per max-defer window, so a
+    # wedge is diagnosable from durable state instead of a live re-capture that
+    # may no longer show the wedged rendering. The verdict's meaning is owned by
+    # bin/fm-composer-lib.sh; this only reports it.
+    printf '\n--- supervisor pane %s (%s) ---\n' "$target" "$backend"
+    printf 'composer verdict: %s\n' \
+      "$(fm_backend_composer_state "$backend" "$target" 2>/dev/null || printf 'unreadable')"
+    printf 'captured screen:\n'
+    fm_backend_capture "$backend" "$target" "${FM_COMPOSER_CAPTURE_LINES:-20}" 2>/dev/null \
+      || printf '(capture failed)\n'
   } 2>/dev/null > "$marker" || true
-  target="${FM_SUPERVISOR_TARGET:-$FM_SUPERVISOR_TARGET_DEFAULT}"
-  backend="${FM_SUPERVISOR_BACKEND:-$FM_SUPERVISOR_BACKEND_DEFAULT}"
   # Best-effort status-line flash. tmux's display-message is a client-side OSD
   # with no herdr equivalent; the log line + durable marker above are already
   # the primary, backend-independent signal, so a non-tmux backend just skips

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -120,10 +120,10 @@
 #                                   daemon defaults this to "discard" so no test
 #                                   can post a real notification (wedge_alarm_emit
 #                                   and the library-mode guard at the foot).
-#          FM_WEDGE_ALARM_TIMEOUT_SECS seconds allowed for each notifier before
-#                                   its watchdog terminates it and continues to the
-#                                   next channel (default 10; invalid/zero uses the
-#                                   default).
+#          FM_WEDGE_ALARM_TIMEOUT_SECS seconds allowed for each notifier or
+#                                   composer-evidence capture before its watchdog
+#                                   terminates it and continues (default 10;
+#                                   invalid/zero uses the default).
 #          FM_INJECT_CONFIRM_RETRIES Enter-retry attempts on a swallowed Enter
 #                                   (default 3); the digest is typed once, only
 #                                   Enter is retried. Composer-empty detection is

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -915,6 +915,16 @@ inject_wedge_alarm() {  # <state> <age-seconds>
     printf 'fm away-mode inject WEDGED: %ss undelivered as of %s\n' "$age" "$(date '+%Y-%m-%dT%H:%M:%S%z')"
     printf 'The supervisor pane could not accept an escalation. Buffered items:\n'
     cat "$state/.subsuper-escalations" 2>/dev/null
+  } 2>/dev/null > "$marker" || true
+  # Backend-independent active alert. Unlike the tmux flash below (skipped on
+  # every non-tmux backend), this can reach the captain even when every pane and
+  # its backend status-line is unreadable - the gap the 2026-07-10 overnight
+  # incident fell through. Configurable and best-effort; the marker above stays
+  # the durable record whether or not any channel fires.
+  if [ "$notify" -eq 1 ]; then
+    wedge_alarm_notify "away-mode escalations WEDGED ${age}s undelivered - see $marker" "$marker"
+  fi
+  {
     # The defer reason alone cannot separate "the captain half-typed a line"
     # from "this pane's rendering is not in the shape catalogue". Record the
     # verdict and the screen it was read from, ONCE per max-defer window, so a
@@ -922,26 +932,16 @@ inject_wedge_alarm() {  # <state> <age-seconds>
     # may no longer show the wedged rendering. The verdict's meaning is owned by
     # bin/fm-composer-lib.sh; this only reports it.
     printf '\n--- supervisor pane %s (%s) ---\n' "$target" "$backend"
-    printf 'composer verdict: %s\n' \
-      "$(fm_backend_composer_state "$backend" "$target" 2>/dev/null || printf 'unreadable')"
-    printf 'captured screen:\n'
-    fm_backend_capture "$backend" "$target" "${FM_COMPOSER_CAPTURE_LINES:-20}" 2>/dev/null \
-      || printf '(capture failed)\n'
-  } 2>/dev/null > "$marker" || true
+    wedge_alarm_run_bounded composer-evidence \
+      fm_backend_composer_observation "$backend" "$target" 2>/dev/null \
+      || printf 'composer verdict: unreadable\ncaptured screen:\n(capture failed)\n'
+  } 2>/dev/null >> "$marker" || true
   # Best-effort status-line flash. tmux's display-message is a client-side OSD
   # with no herdr equivalent; the log line + durable marker above are already
   # the primary, backend-independent signal, so a non-tmux backend just skips
   # this cosmetic extra rather than attempting an unsupported call.
   if [ "$backend" = tmux ]; then
     tmux display-message -t "$target" "fm: away-mode escalations WEDGED ${age}s — see $marker" 2>/dev/null || true
-  fi
-  # Backend-independent active alert. Unlike the tmux flash above (skipped on
-  # every non-tmux backend), this can reach the captain even when every pane and
-  # its backend status-line is unreadable - the gap the 2026-07-10 overnight
-  # incident fell through. Configurable and best-effort; the marker above stays
-  # the durable record whether or not any channel fires.
-  if [ "$notify" -eq 1 ]; then
-    wedge_alarm_notify "away-mode escalations WEDGED ${age}s undelivered - see $marker" "$marker"
   fi
 }
 

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -895,7 +895,7 @@ wedge_alarm_notify() {  # <summary> <marker>
 # is lost - the buffer and the
 # wake-queue both survive - but the stall stops being invisible.
 inject_wedge_alarm() {  # <state> <age-seconds>
-  local state=$1 age=$2 marker target backend max_defer now notify=1
+  local state=$1 age=$2 marker target backend max_defer now notify=1 marker_ready=0
   marker="$state/.subsuper-inject-wedged"
   max_defer="${FM_MAX_DEFER_SECS:-$MAX_DEFER_SECS_DEFAULT}"
   # Re-alarm at most once per max-defer window so a long wedge does not spam.
@@ -911,11 +911,20 @@ inject_wedge_alarm() {  # <state> <age-seconds>
   fi
   target="${FM_SUPERVISOR_TARGET:-$FM_SUPERVISOR_TARGET_DEFAULT}"
   backend="${FM_SUPERVISOR_BACKEND:-$FM_SUPERVISOR_BACKEND_DEFAULT}"
-  {
-    printf 'fm away-mode inject WEDGED: %ss undelivered as of %s\n' "$age" "$(date '+%Y-%m-%dT%H:%M:%S%z')"
-    printf 'The supervisor pane could not accept an escalation. Buffered items:\n'
-    cat "$state/.subsuper-escalations" 2>/dev/null
-  } 2>/dev/null > "$marker" || true
+  if : > "$marker" 2>/dev/null; then
+    if chmod 0600 "$marker" 2>/dev/null; then
+      marker_ready=1
+    else
+      log "ERROR: away-mode wedge alarm marker could not be secured: $marker"
+    fi
+  fi
+  if [ "$marker_ready" -eq 1 ]; then
+    {
+      printf 'fm away-mode inject WEDGED: %ss undelivered as of %s\n' "$age" "$(date '+%Y-%m-%dT%H:%M:%S%z')"
+      printf 'The supervisor pane could not accept an escalation. Buffered items:\n'
+      cat "$state/.subsuper-escalations" 2>/dev/null
+    } 2>/dev/null > "$marker" || true
+  fi
   # Backend-independent active alert. Unlike the tmux flash below (skipped on
   # every non-tmux backend), this can reach the captain even when every pane and
   # its backend status-line is unreadable - the gap the 2026-07-10 overnight
@@ -924,18 +933,20 @@ inject_wedge_alarm() {  # <state> <age-seconds>
   if [ "$notify" -eq 1 ]; then
     wedge_alarm_notify "away-mode escalations WEDGED ${age}s undelivered - see $marker" "$marker"
   fi
-  {
-    # The defer reason alone cannot separate "the captain half-typed a line"
-    # from "this pane's rendering is not in the shape catalogue". Record the
-    # verdict and the screen it was read from, ONCE per max-defer window, so a
-    # wedge is diagnosable from durable state instead of a live re-capture that
-    # may no longer show the wedged rendering. The verdict's meaning is owned by
-    # bin/fm-composer-lib.sh; this only reports it.
-    printf '\n--- supervisor pane %s (%s) ---\n' "$target" "$backend"
-    wedge_alarm_run_bounded composer-evidence \
-      fm_backend_composer_observation "$backend" "$target" 2>/dev/null \
-      || printf 'composer verdict: unreadable\ncaptured screen:\n(capture failed)\n'
-  } 2>/dev/null >> "$marker" || true
+  if [ "$marker_ready" -eq 1 ]; then
+    {
+      # The defer reason alone cannot separate "the captain half-typed a line"
+      # from "this pane's rendering is not in the shape catalogue". Record the
+      # verdict and the screen it was read from, ONCE per max-defer window, so a
+      # wedge is diagnosable from durable state instead of a live re-capture that
+      # may no longer show the wedged rendering. The verdict's meaning is owned by
+      # bin/fm-composer-lib.sh; this only reports it.
+      printf '\n--- supervisor pane %s (%s) ---\n' "$target" "$backend"
+      wedge_alarm_run_bounded composer-evidence \
+        fm_backend_composer_observation "$backend" "$target" 2>/dev/null \
+        || printf 'composer verdict: unreadable\ncaptured screen:\n(capture failed)\n'
+    } 2>/dev/null >> "$marker" || true
+  fi
   # Best-effort status-line flash. tmux's display-message is a client-side OSD
   # with no herdr equivalent; the log line + durable marker above are already
   # the primary, backend-independent signal, so a non-tmux backend just skips

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -146,6 +146,7 @@ _fm_tmux_composer_observe() {  # <target>
   cy=$(fm_tmux_composer_cursor_row "$target") || return 0
   case "$cy" in ''|*[!0-9]*) return 0 ;; esac
   pane=$(fm_tmux_composer_capture "$target") || return 0
+  # shellcheck disable=SC2034 # Consumed by fm_backend_composer_observation in bin/fm-backend.sh.
   FM_BACKEND_COMPOSER_SCREEN=$pane
   verdict=$(fm_composer_classify_screen "$(fm_tmux_composer_caps)" "$pane" "$cy")
   if [ "$verdict" = need-identity ]; then

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -130,8 +130,10 @@ EOF
   esac
 }
 
-# _fm_tmux_composer_observe: the tmux composer verdict - a thin adapter over the
-# shared screen classifier. The verdict contract (empty | pending |
+# _fm_tmux_composer_observe: capture one tmux composer snapshot and classify
+# that same snapshot into FM_BACKEND_COMPOSER_SCREEN and
+# FM_BACKEND_COMPOSER_VERDICT. It is a thin adapter over the shared screen
+# classifier. The verdict contract (empty | pending |
 # pending-unproven | unknown, positive proof required for empty, unrecognized
 # future verdicts failing safe) is owned by bin/fm-composer-lib.sh. Identity
 # is fetched lazily, only when the classifier reports the verdict depends on

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -130,18 +130,21 @@ EOF
   esac
 }
 
-# fm_tmux_composer_state: the tmux composer verdict - a thin adapter over the
+# _fm_tmux_composer_observe: the tmux composer verdict - a thin adapter over the
 # shared screen classifier. The verdict contract (empty | pending |
 # pending-unproven | unknown, positive proof required for empty, unrecognized
 # future verdicts failing safe) is owned by bin/fm-composer-lib.sh. Identity
 # is fetched lazily, only when the classifier reports the verdict depends on
 # it (a pi separator pair under the cursor), so the common read never pays
 # for the process probe.
-fm_tmux_composer_state() {  # <target> -> empty|pending|pending-unproven|unknown
+_fm_tmux_composer_observe() {  # <target>
   local target=$1 cy pane verdict identity
-  cy=$(fm_tmux_composer_cursor_row "$target") || { printf 'unknown'; return 0; }
-  case "$cy" in ''|*[!0-9]*) printf 'unknown'; return 0 ;; esac
-  pane=$(fm_tmux_composer_capture "$target") || { printf 'unknown'; return 0; }
+  FM_BACKEND_COMPOSER_SCREEN=
+  FM_BACKEND_COMPOSER_VERDICT=unknown
+  cy=$(fm_tmux_composer_cursor_row "$target") || return 0
+  case "$cy" in ''|*[!0-9]*) return 0 ;; esac
+  pane=$(fm_tmux_composer_capture "$target") || return 0
+  FM_BACKEND_COMPOSER_SCREEN=$pane
   verdict=$(fm_composer_classify_screen "$(fm_tmux_composer_caps)" "$pane" "$cy")
   if [ "$verdict" = need-identity ]; then
     if ! identity=$(fm_tmux_composer_identity "$target") || [ -z "$identity" ]; then
@@ -162,7 +165,12 @@ fm_tmux_composer_state() {  # <target> -> empty|pending|pending-unproven|unknown
   if [ "$verdict" = unknown ] && fm_tmux_pane_is_cursor "$target"; then
     verdict=$(fm_composer_classify_screen "$(fm_tmux_composer_caps)" "$pane" '')
   fi
-  printf '%s' "$verdict"
+  FM_BACKEND_COMPOSER_VERDICT=$verdict
+}
+
+fm_tmux_composer_state() {  # <target> -> empty|pending|pending-unproven|unknown
+  _fm_tmux_composer_observe "$1"
+  printf '%s' "$FM_BACKEND_COMPOSER_VERDICT"
 }
 
 # fm_tmux_pane_is_cursor: true when the pane's FOREGROUND process group contains

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -609,7 +609,7 @@ FM_ESCALATE_BATCH_SECS=90          # buffer window for batched escalation digest
 FM_MAX_DEFER_SECS=300              # max buffered escalation age before retry plus wedge alarm; 0 disables
 FM_WEDGE_ALARM_CHANNEL=            # override config/wedge-alarm with one active-alert directive for the wedge alarm; off|auto|osascript|herdr|command:<cmd>; absent = auto (macOS -> an OS notification)
 FM_WEDGE_ALARM_EXEC=              # notifier seam: route every channel (osascript, herdr, command:) through this command as `<cmd> <channel> <summary>`; "discard" fires nothing; unset in production; the daemon defaults it to "discard" when sourced so no test posts a real notification (docs/wedge-alarm.md)
-FM_WEDGE_ALARM_TIMEOUT_SECS=10    # maximum seconds for each osascript, herdr, override, or command: notifier before its watchdog terminates it and continues to the next channel; invalid or zero values use 10
+FM_WEDGE_ALARM_TIMEOUT_SECS=10    # maximum seconds for each notifier or composer-evidence capture before its watchdog terminates it and continues; invalid or zero values use 10 (docs/wedge-alarm.md)
 FM_INJECT_FAIL_SLEEP=30            # seconds to back off when the supervisor pane is unavailable
 FM_INJECT_CONFIRM_RETRIES=3        # daemon Enter-retry attempts after typing a digest once
 FM_INJECT_CONFIRM_SLEEP=0.5        # seconds between daemon submit checks

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -235,6 +235,7 @@ A human-blocked permission dialog has no busy banner and still surfaces.
 
 Herdr has no direct cursor-row primitive.
 The adapter is a thin capture: it hands a bounded ANSI tail plus Herdr's capability facts to the fleet-wide classifier in `bin/fm-composer-lib.sh`, which owns every shape - bordered boxes, bare agent-glyph rows (including muse's `⟩`, which the adapter's retired local pattern silently omitted), opencode's left bar, and the Pi separator region this adapter pioneered, admitted only when native `agent get` identity is exactly Pi and state is idle, done, or blocked.
+A horizontal boundary may carry Claude's embedded session title only under the shared classifier's strict two-ended, normalized ASCII-printable rule; one-ended prose and non-ASCII titles remain non-boundaries.
 A working Pi, pending middle row, missing identity, incomplete separator pair, or over-tall candidate remains unknown or pending.
 Identity stays a lazy second read, consulted only when a separator pair could change the verdict.
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -235,7 +235,7 @@ A human-blocked permission dialog has no busy banner and still surfaces.
 
 Herdr has no direct cursor-row primitive.
 The adapter is a thin capture: it hands a bounded ANSI tail plus Herdr's capability facts to the fleet-wide classifier in `bin/fm-composer-lib.sh`, which owns every shape - bordered boxes, bare agent-glyph rows (including muse's `⟩`, which the adapter's retired local pattern silently omitted), opencode's left bar, and the Pi separator region this adapter pioneered, admitted only when native `agent get` identity is exactly Pi and state is idle, done, or blocked.
-A horizontal boundary may carry Claude's embedded session title only under the shared classifier's strict two-ended, normalized ASCII-printable rule; one-ended prose and non-ASCII titles remain non-boundaries.
+A horizontal boundary may carry Claude's embedded agent name only under the shared classifier's strict two-ended, normalized ASCII-printable rule; one-ended prose and non-whitespace non-ASCII titles remain non-boundaries.
 A working Pi, pending middle row, missing identity, incomplete separator pair, or over-tall candidate remains unknown or pending.
 Identity stays a lazy second read, consulted only when a separator pair could change the verdict.
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -522,11 +522,29 @@ ok - forced teardown retains a nested secondmate home and its grandchild's Herdr
 
 Real captures verified these active distinctions:
 
-- Claude and Codex use bare `❯` and `›` agent composers.
+- Claude and Codex use bare `❯` and `›` agent composers, and Claude may embed its session title in the top horizontal rule around that bare row.
 - Pi uses content between complete separator rows and requires exact native Pi identity.
 - Dim or faint suggestion text is ghost content, while normally styled text is pending input.
 - Grok dark truecolor placeholders are ghost content, while bright truecolor typed input remains pending.
 - A bare shell prompt has no safe agent-composer container and is unknown.
+
+The Claude titled-rule variant was verified on 2026-08-14 with Claude Code 2.1.232 through Herdr 0.8.0.
+The same supervisor-pane read was used before and after the classifier correction, then repeated with unsent typed text in the composer:
+
+```sh
+. bin/fm-backend.sh
+fm_backend_composer_state herdr "$FM_SUPERVISOR_TARGET"
+```
+
+Observed verdicts:
+
+```text
+before titled-rule support: unknown
+after titled-rule support: empty
+after typing unsent text: pending
+```
+
+This focused Herdr check does not replace the complete tmux-backed matrix recorded in [Composer classification matrix](#composer-classification-matrix); that opt-in guard remains the fleet-wide refresh command.
 
 `tests/fm-composer-ghost.test.sh`, `tests/fm-composer-lib.test.sh`, and the Herdr composer cases pin the exact captured ANSI bytes.
 The U+2063 operational and routed-request separators were exercised through a real Pi-on-Herdr path; the byte-exact active regression is:

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -522,7 +522,7 @@ ok - forced teardown retains a nested secondmate home and its grandchild's Herdr
 
 Real captures verified these active distinctions:
 
-- Claude and Codex use bare `❯` and `›` agent composers, and Claude may embed its session title in the top horizontal rule around that bare row.
+- Claude and Codex use bare `❯` and `›` agent composers, and Claude may embed its agent name in the top horizontal rule around that bare row.
 - Pi uses content between complete separator rows and requires exact native Pi identity.
 - Dim or faint suggestion text is ghost content, while normally styled text is pending input.
 - Grok dark truecolor placeholders are ghost content, while bright truecolor typed input remains pending.

--- a/docs/wedge-alarm.md
+++ b/docs/wedge-alarm.md
@@ -5,6 +5,17 @@ When injection cannot confirm a submit past `FM_MAX_DEFER_SECS`, `inject_wedge_a
 The active alert is pane-independent because a tmux status-line flash has no cross-backend equivalent and cannot reach an unattended captain reliably.
 The durable marker and tmux flash remain as additional signals.
 
+## Durable diagnostic evidence
+
+`state/.subsuper-inject-wedged` starts with the undelivered age and buffered escalation items.
+After the active-alert stage, the daemon appends the supervisor backend and target plus one paired composer observation: the classifier verdict and the ANSI-stripped screen from the exact capture that produced it.
+If capture or classification cannot complete, the marker says that the evidence was unreadable or the capture failed instead of guessing.
+The evidence read is bounded by `FM_WEDGE_ALARM_TIMEOUT_SECS` and occurs at most once per max-defer window, so a hung pane read cannot delay the alert or wedge the daemon itself.
+
+The captured screen can contain visible terminal text.
+The marker stays in local, gitignored state and is a session-scoped delivery artifact, so inspect it before sharing it outside the home.
+The `/afk` lifecycle clears stale artifacts on a fresh entry and removes the marker after confirmed delivery or normal exit.
+
 ## Channels
 
 `config/wedge-alarm` is local and gitignored.
@@ -23,7 +34,7 @@ This is deliberate because the alarm fires only after a genuine max-defer wedge 
 
 Each channel is best-effort.
 A missing binary or non-zero exit logs a warning and continues to the next channel without crashing the daemon loop.
-Every invocation is process-group bounded by `FM_WEDGE_ALARM_TIMEOUT_SECS`, which defaults to 10 seconds, including `command:`, `osascript`, `herdr`, and the test seam.
+Every notifier and the diagnostic evidence read are process-group bounded by `FM_WEDGE_ALARM_TIMEOUT_SECS`, which defaults to 10 seconds, including `command:`, `osascript`, `herdr`, and the test seam.
 On timeout or daemon shutdown, the notifier process group is terminated and the next configured channel may run.
 AppleScript receives the summary as an argv item rather than interpolated source, so summary text cannot alter the script.
 See [`examples/wedge-alarm`](examples/wedge-alarm) for a copyable config.
@@ -35,5 +46,5 @@ When the daemon is sourced as a library, that seam defaults to `discard`, so a t
 `tests/wake-helpers.sh` replaces it with a recorder when a suite needs to assert channel selection and summary propagation.
 Production leaves the seam unset and uses the configured real channels.
 
-`tests/fm-daemon.test.sh` covers directive parsing, rate limiting, timeout and process-group cleanup, argv-safe dispatch, channel fallback, and safe `command:` summary delivery.
+`tests/fm-daemon.test.sh` covers directive parsing, rate limiting, timeout and process-group cleanup, argv-safe dispatch, channel fallback, safe `command:` summary delivery, alert-before-capture ordering, and the single ANSI-stripped verdict/screen observation.
 [`verification/supervision.md`](verification/supervision.md#wedge-alarm-channels) records the bounded manual macOS and Herdr channel proof.

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -238,7 +238,7 @@ test_titled_rule_requires_rule_glyphs_at_both_ends() {
   # The titled-rule tolerance is bounded exactly like a titled bottom BORDER:
   # rule glyphs at both ends and an ASCII-printable interior. Anything looser
   # would promote ordinary transcript prose into a composer boundary.
-  local base tail_only lead_only wide_title
+  local base tail_only lead_only wide_title tab_title
   # A titled rule pairs with the composer's closing rule, so the bare row
   # between them is classified and reads empty.
   base=$'chatter\n──────────── orchestrator ──\n❯\n────────────────────────'
@@ -252,6 +252,8 @@ test_titled_rule_requires_rule_glyphs_at_both_ends() {
   # A non-ASCII title is outside the proven tolerance and must not qualify.
   wide_title=$'chatter\n──────────── ✻ пример ──\n❯\n────────────────────────'
   assert_screen "non-ASCII rule title is not a rule" unknown "$CAPS_STYLED" "$wide_title" '' probe-absent
+  tab_title=$'chatter\n──────────── orchestrator\t ──\n❯\n────────────────────────'
+  assert_screen "TAB-bearing rule title is not a rule" unknown "$CAPS_STYLED" "$tab_title" '' probe-absent
   pass "fm_composer_classify_screen: a titled rule needs rule glyphs at both ends and an ASCII title"
 }
 

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -188,6 +188,73 @@ test_matrix_claude_bare_nbsp_row() {
   pass "matrix: claude's ❯+NBSP row reads empty on every profile in both locales (#1988)"
 }
 
+test_matrix_claude_titled_rule_composer() {
+  # Real idle claude 2.1.232, captured live through herdr 0.8.0 (task
+  # afk-wedge). The composer is still the bare `❯`+U+00A0 row between two
+  # horizontal rules, but the TOP rule now carries the session's agent name as
+  # a reverse-video title, and a configured statusline sits below the bottom
+  # rule.
+  #
+  # While only a SOLID rule counted as a rule, that one title left the bottom
+  # rule unpaired, an unpaired rule below the candidate read as proof the
+  # candidate was stale, and every idle claude pane classified `unknown`. The
+  # away-mode injector defers on anything that is not `empty`, so escalations
+  # buffered for 9.7 hours against an idle supervisor pane.
+  local titled solid typed
+  titled=$'transcript line\n'\
+"${ESC}[0m${ESC}[38;2;136;136;136m────────────────────────${ESC}[0m${ESC}[38;2;0;0;0m${ESC}[48;2;136;136;136m orchestrator ${ESC}[0m${ESC}[38;2;136;136;136m──${ESC}[0m"$'\n'\
+"${ESC}[0m${ESC}[38;2;153;153;153m❯${NBSP}${ESC}[0m"$'\n'\
+"${ESC}[0m${ESC}[38;2;136;136;136m────────────────────────────────────────${ESC}[0m"$'\n'\
+"  ${ESC}[1m${ESC}[38;5;2mkalvira@host${ESC}[0m${ESC}[38;2;153;153;153m:${ESC}[0m${ESC}[1m${ESC}[38;5;4m/home/kalvira/firstmate${ESC}[0m${ESC}[38;2;153;153;153m (main) [ctx:15%]${ESC}[0m"$'\n'\
+"  ${ESC}[0m${ESC}[38;2;255;193;7m⏵⏵ auto mode on${ESC}[0m${ESC}[38;2;153;153;153m (shift+tab to cycle) · ← for agents${ESC}[0m"
+
+  # Non-vacuousness: the fixture must really carry an embedded title and a
+  # non-blank statusline below the closing rule, or it proves nothing.
+  case "$titled" in *' orchestrator '*) : ;; *) fail "fixture lost its embedded rule title" ;; esac
+  case "$titled" in *'kalvira@host'*) : ;; *) fail "fixture lost its statusline row" ;; esac
+
+  assert_screen "claude 2.1.232 titled rule on herdr" empty "$CAPS_STYLED" "$titled" '' probe-absent
+  assert_screen "claude 2.1.232 titled rule on tmux" empty "$CAPS_TMUX" "$titled" 2 probe-absent
+  assert_screen "claude 2.1.232 titled rule on zellij" empty "$CAPS_STYLED_NOID" "$titled"
+  assert_screen "claude 2.1.232 titled rule on cmux/orca" empty "$CAPS_PLAIN" "$titled"
+
+  # The title is the ONLY difference from the solid-rule rendering, so both
+  # must reach the same verdict; that divergence is what the fix restores.
+  solid=${titled/"${ESC}[0m${ESC}[38;2;0;0;0m${ESC}[48;2;136;136;136m orchestrator ${ESC}[0m${ESC}[38;2;136;136;136m──${ESC}[0m"/"──────────────${ESC}[0m"}
+  [ "$solid" != "$titled" ] || fail "solid-rule variant did not differ from the titled fixture"
+  assert_screen "claude 2.1.232 solid rule on herdr" empty "$CAPS_STYLED" "$solid" '' probe-absent
+
+  # A rule title must never swallow real typed text sitting in the composer.
+  typed=${titled/"❯${NBSP}"/"❯ answer the parked decision"}
+  [ "$typed" != "$titled" ] || fail "typed variant did not differ from the idle fixture"
+  assert_screen "claude 2.1.232 titled rule typed on herdr" pending "$CAPS_STYLED" "$typed" '' probe-absent
+  assert_screen "claude 2.1.232 titled rule typed on tmux" pending "$CAPS_TMUX" "$typed" 2 probe-absent
+  # Plain captures still cannot tell typed text from claude's rotating hint.
+  assert_screen "claude 2.1.232 titled rule typed on cmux/orca" unknown "$CAPS_PLAIN" "$typed"
+  pass "matrix: claude 2.1.232's titled composer rule still pairs and reads empty (afk-wedge)"
+}
+
+test_titled_rule_requires_rule_glyphs_at_both_ends() {
+  # The titled-rule tolerance is bounded exactly like a titled bottom BORDER:
+  # rule glyphs at both ends and an ASCII-printable interior. Anything looser
+  # would promote ordinary transcript prose into a composer boundary.
+  local base tail_only lead_only wide_title
+  # A titled rule pairs with the composer's closing rule, so the bare row
+  # between them is classified and reads empty.
+  base=$'chatter\n──────────── orchestrator ──\n❯\n────────────────────────'
+  assert_screen "titled rule pairs" empty "$CAPS_STYLED" "$base" '' probe-absent
+  # A row that only ENDS with the rule glyph is prose, not a rule, so the
+  # composer's own closing rule stays unpaired and the screen stays unreadable.
+  lead_only=$'chatter\nrunning the build ──────────\n❯\n────────────────────────'
+  assert_screen "prose ending in a rule is not a rule" unknown "$CAPS_STYLED" "$lead_only" '' probe-absent
+  tail_only=$'chatter\n──────────── still working\n❯\n────────────────────────'
+  assert_screen "prose after a rule is not a rule" unknown "$CAPS_STYLED" "$tail_only" '' probe-absent
+  # A non-ASCII title is outside the proven tolerance and must not qualify.
+  wide_title=$'chatter\n──────────── ✻ пример ──\n❯\n────────────────────────'
+  assert_screen "non-ASCII rule title is not a rule" unknown "$CAPS_STYLED" "$wide_title" '' probe-absent
+  pass "fm_composer_classify_screen: a titled rule needs rule glyphs at both ends and an ASCII title"
+}
+
 test_matrix_codex_dim_hint_row() {
   # Real idle codex: bold `›`, reset, then an SGR-2 dim hint. Styled captures
   # strip the ghost and prove empty; plain captures must defer as unknown -
@@ -608,6 +675,8 @@ test_idle_placeholder_is_empty
 test_idle_placeholder_case_mode_is_explicit
 test_real_text_is_pending
 test_matrix_claude_bare_nbsp_row
+test_matrix_claude_titled_rule_composer
+test_titled_rule_requires_rule_glyphs_at_both_ends
 test_matrix_codex_dim_hint_row
 test_matrix_muse_truecolor_glyph_survives_signal_loss
 test_matrix_cursor_reverse_video_placeholder_remnant

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -234,27 +234,31 @@ test_matrix_claude_titled_rule_composer() {
   pass "matrix: claude 2.1.232's titled composer rule still pairs and reads empty (afk-wedge)"
 }
 
-test_titled_rule_requires_rule_glyphs_at_both_ends() {
-  # The titled-rule tolerance is bounded exactly like a titled bottom BORDER:
-  # rule glyphs at both ends and an ASCII-printable interior. Anything looser
-  # would promote ordinary transcript prose into a composer boundary.
-  local base tail_only lead_only wide_title tab_title
+test_titled_rule_requires_normalized_ascii_printable_interior() {
+  # The titled rule uses the same two-ended shape as a titled bottom BORDER:
+  # rule glyphs at both ends and an interior that is ASCII-printable after the
+  # standard Unicode-whitespace normalization. Anything looser would promote
+  # ordinary transcript prose into a composer boundary.
+  local ascii_title nbsp_title tail_only lead_only non_ascii_title tab_title
   # A titled rule pairs with the composer's closing rule, so the bare row
   # between them is classified and reads empty.
-  base=$'chatter\n──────────── orchestrator ──\n❯\n────────────────────────'
-  assert_screen "titled rule pairs" empty "$CAPS_STYLED" "$base" '' probe-absent
+  ascii_title=$'chatter\n──────────── orchestrator title ──\n❯\n────────────────────────'
+  assert_screen "ASCII-printable titled rule pairs after normalization" empty "$CAPS_STYLED" "$ascii_title" '' probe-absent
+  nbsp_title=$'chatter\n──────────── orchestrator'"$NBSP"$'title ──\n❯\n────────────────────────'
+  [ "$nbsp_title" != "$ascii_title" ] || fail "NBSP fixture did not differ from the plain-space title"
+  assert_screen "NBSP-bearing title normalizes like a plain-space title" empty "$CAPS_STYLED" "$nbsp_title" '' probe-absent
   # A row that only ENDS with the rule glyph is prose, not a rule, so the
   # composer's own closing rule stays unpaired and the screen stays unreadable.
   lead_only=$'chatter\nrunning the build ──────────\n❯\n────────────────────────'
   assert_screen "prose ending in a rule is not a rule" unknown "$CAPS_STYLED" "$lead_only" '' probe-absent
   tail_only=$'chatter\n──────────── still working\n❯\n────────────────────────'
   assert_screen "prose after a rule is not a rule" unknown "$CAPS_STYLED" "$tail_only" '' probe-absent
-  # A non-ASCII title is outside the proven tolerance and must not qualify.
-  wide_title=$'chatter\n──────────── ✻ пример ──\n❯\n────────────────────────'
-  assert_screen "non-ASCII rule title is not a rule" unknown "$CAPS_STYLED" "$wide_title" '' probe-absent
-  tab_title=$'chatter\n──────────── orchestrator\t ──\n❯\n────────────────────────'
+  # A non-whitespace non-ASCII title is outside the proven tolerance and must not qualify.
+  non_ascii_title=$'chatter\n──────────── ✻ пример ──\n❯\n────────────────────────'
+  assert_screen "non-whitespace non-ASCII rule title is not a rule" unknown "$CAPS_STYLED" "$non_ascii_title" '' probe-absent
+  tab_title=$'chatter\n──────────── orchestrator\ttitle ──\n❯\n────────────────────────'
   assert_screen "TAB-bearing rule title is not a rule" unknown "$CAPS_STYLED" "$tab_title" '' probe-absent
-  pass "fm_composer_classify_screen: a titled rule needs rule glyphs at both ends and an ASCII title"
+  pass "fm_composer_classify_screen: a titled rule needs a normalized ASCII-printable interior and glyphs at both ends"
 }
 
 test_matrix_codex_dim_hint_row() {
@@ -678,7 +682,7 @@ test_idle_placeholder_case_mode_is_explicit
 test_real_text_is_pending
 test_matrix_claude_bare_nbsp_row
 test_matrix_claude_titled_rule_composer
-test_titled_rule_requires_rule_glyphs_at_both_ends
+test_titled_rule_requires_normalized_ascii_printable_interior
 test_matrix_codex_dim_hint_row
 test_matrix_muse_truecolor_glyph_survives_signal_loss
 test_matrix_cursor_reverse_video_placeholder_remnant

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -189,17 +189,16 @@ test_matrix_claude_bare_nbsp_row() {
 }
 
 test_matrix_claude_titled_rule_composer() {
-  # Real idle claude 2.1.232, captured live through herdr 0.8.0 (task
-  # afk-wedge). The composer is still the bare `❯`+U+00A0 row between two
+  # Real idle Claude titled-rule rendering. The active version and backend
+  # evidence is recorded in docs/verification/runtime-backends.md. The
+  # composer is still the bare `❯`+U+00A0 row between two
   # horizontal rules, but the TOP rule now carries the session's agent name as
   # a reverse-video title, and a configured statusline sits below the bottom
   # rule.
   #
   # While only a SOLID rule counted as a rule, that one title left the bottom
   # rule unpaired, an unpaired rule below the candidate read as proof the
-  # candidate was stale, and every idle claude pane classified `unknown`. The
-  # away-mode injector defers on anything that is not `empty`, so escalations
-  # buffered for 9.7 hours against an idle supervisor pane.
+  # candidate was stale, and every idle Claude pane classified `unknown`.
   local titled solid typed
   titled=$'transcript line\n'\
 "${ESC}[0m${ESC}[38;2;136;136;136m────────────────────────${ESC}[0m${ESC}[38;2;0;0;0m${ESC}[48;2;136;136;136m orchestrator ${ESC}[0m${ESC}[38;2;136;136;136m──${ESC}[0m"$'\n'\

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -1148,7 +1148,7 @@ test_max_defer_empty_swallow_types_once_and_alarms() {
     || fail "buffer lost after a failed max-defer inject (must be preserved)"
   # The marker must carry enough to tell a half-typed line apart from a
   # rendering the shape catalogue does not know: the verdict AND the screen it
-  # was read from. Diagnosing the 9.7h afk-wedge episode needed exactly this.
+  # was read from.
   grep -q '^composer verdict: ' "$state/.subsuper-inject-wedged" \
     || fail "wedge marker did not record the composer verdict"
   # A composer border row only ever comes from the CAPTURE, never from the

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -1146,7 +1146,16 @@ test_max_defer_empty_swallow_types_once_and_alarms() {
     || fail "stuck max-defer inject did not raise a wedge alarm marker"
   [ -s "$state/.subsuper-escalations" ] \
     || fail "buffer lost after a failed max-defer inject (must be preserved)"
-  pass "max-defer on an empty stuck pane types once, alarms, and preserves the buffer"
+  # The marker must carry enough to tell a half-typed line apart from a
+  # rendering the shape catalogue does not know: the verdict AND the screen it
+  # was read from. Diagnosing the 9.7h afk-wedge episode needed exactly this.
+  grep -q '^composer verdict: ' "$state/.subsuper-inject-wedged" \
+    || fail "wedge marker did not record the composer verdict"
+  # A composer border row only ever comes from the CAPTURE, never from the
+  # buffered escalation text, so it proves the screen itself was recorded.
+  grep -q '^│ >' "$state/.subsuper-inject-wedged" \
+    || fail "wedge marker did not record the captured supervisor screen"
+  pass "max-defer on an empty stuck pane types once, alarms, preserves the buffer, and records the pane"
 }
 
 test_max_defer_flushes_empty_idle_pane() {

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -1578,8 +1578,11 @@ test_inject_wedge_alarm_uses_single_composer_observation() {
   marker="$state/.subsuper-inject-wedged"
   escalate_add "$state" "needs-decision: pick A"
   (
+    # shellcheck disable=SC2329 # Runtime override is an assertion tripwire for the isolated daemon.
     fm_backend_composer_state() { fail "wedge evidence called composer_state separately"; }
+    # shellcheck disable=SC2329 # Runtime override is an assertion tripwire for the isolated daemon.
     fm_backend_capture() { fail "wedge evidence captured a second screen"; }
+    # shellcheck disable=SC2329 # Runtime override called indirectly by the isolated daemon.
     fm_backend_composer_observation() {
       printf 'x' >> "$count"
       printf 'composer verdict: pending\ncaptured screen:\nsnapshot-one\n'
@@ -1602,6 +1605,7 @@ test_inject_wedge_alarm_notifies_before_bounded_observation() {
   escalate_add "$state" "needs-decision: pick A"
   start=$SECONDS
   (
+    # shellcheck disable=SC2329 # Runtime override called indirectly by the isolated daemon.
     fm_backend_composer_observation() {
       [ -s "$log" ] || printf 'evidence started before alert\n' > "$order_error"
       sleep 30

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -1556,6 +1556,21 @@ test_inject_wedge_alarm_fires_active_alert_on_non_tmux_backend() {
   pass "inject_wedge_alarm writes the marker AND emits the active alert even with no tmux status-line (herdr backend)"
 }
 
+test_backend_composer_observation_emits_plain_screen() {
+  local dir fakebin capture esc out
+  dir=$(make_supercase composer-observation-plain)
+  fakebin="$dir/fakebin"; capture="$dir/pane.txt"; esc=$(printf '\033')
+  printf '%s[38;2;136;136;136m❯%s[0m\n' "$esc" "$esc" > "$capture"
+  out=$(PATH="$fakebin:$PATH" FM_FAKE_TMUX_CAPTURE="$capture" FM_FAKE_TMUX_CURSOR_Y=0 \
+    fm_backend_composer_observation tmux fakepane)
+  assert_contains "$out" 'composer verdict: empty' "composer observation lost its styled-capture verdict"
+  assert_contains "$out" $'captured screen:\n❯' "composer observation lost its captured screen"
+  case "$out" in
+    *"$esc"*) fail "composer observation emitted ANSI control sequences" ;;
+  esac
+  pass "fm_backend_composer_observation emits a plain screen from its styled snapshot"
+}
+
 test_inject_wedge_alarm_uses_single_composer_observation() {
   local dir state log count marker
   dir=$(make_wedge_case wedge-single-observation)
@@ -1971,6 +1986,7 @@ test_wedge_alarm_backgrounded_command_times_out_and_reaps_descendant
 test_wedge_alarm_hung_override_times_out_and_falls_through
 test_wedge_alarm_shutdown_stops_active_notifier_group
 test_inject_wedge_alarm_fires_active_alert_on_non_tmux_backend
+test_backend_composer_observation_emits_plain_screen
 test_inject_wedge_alarm_uses_single_composer_observation
 test_inject_wedge_alarm_notifies_before_bounded_observation
 test_inject_wedge_alarm_throttles_when_marker_cannot_be_written

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -1556,6 +1556,53 @@ test_inject_wedge_alarm_fires_active_alert_on_non_tmux_backend() {
   pass "inject_wedge_alarm writes the marker AND emits the active alert even with no tmux status-line (herdr backend)"
 }
 
+test_inject_wedge_alarm_uses_single_composer_observation() {
+  local dir state log count marker
+  dir=$(make_wedge_case wedge-single-observation)
+  state="$dir/state"; log="$dir/alert.log"; count="$dir/observation-count"
+  marker="$state/.subsuper-inject-wedged"
+  escalate_add "$state" "needs-decision: pick A"
+  (
+    fm_backend_composer_state() { fail "wedge evidence called composer_state separately"; }
+    fm_backend_capture() { fail "wedge evidence captured a second screen"; }
+    fm_backend_composer_observation() {
+      printf 'x' >> "$count"
+      printf 'composer verdict: pending\ncaptured screen:\nsnapshot-one\n'
+    }
+    WEDGE_ALARM_LAST_EPOCH=0
+    FM_WEDGE_ALARM_LOG="$log" FM_WEDGE_ALARM_CHANNEL=osascript \
+      FM_SUPERVISOR_BACKEND=herdr inject_wedge_alarm "$state" 30600
+  ) || fail "single-observation wedge alarm failed"
+  [ "$(cat "$count" 2>/dev/null)" = x ] || fail "wedge evidence did not use exactly one observation"
+  grep -F 'composer verdict: pending' "$marker" >/dev/null || fail "wedge marker lost the observed verdict"
+  grep -F 'snapshot-one' "$marker" >/dev/null || fail "wedge marker lost the screen paired with its verdict"
+  pass "inject_wedge_alarm records one paired composer observation"
+}
+
+test_inject_wedge_alarm_notifies_before_bounded_observation() {
+  local dir state log marker order_error daemon_log start elapsed
+  dir=$(make_wedge_case wedge-bounded-observation)
+  state="$dir/state"; log="$dir/alert.log"; marker="$state/.subsuper-inject-wedged"
+  order_error="$dir/order-error"; daemon_log="$dir/daemon.log"
+  escalate_add "$state" "needs-decision: pick A"
+  start=$SECONDS
+  (
+    fm_backend_composer_observation() {
+      [ -s "$log" ] || printf 'evidence started before alert\n' > "$order_error"
+      sleep 30
+    }
+    WEDGE_ALARM_LAST_EPOCH=0
+    LOG="$daemon_log" FM_WEDGE_ALARM_LOG="$log" FM_WEDGE_ALARM_CHANNEL=osascript \
+      FM_WEDGE_ALARM_TIMEOUT_SECS=1 FM_SUPERVISOR_BACKEND=herdr \
+      inject_wedge_alarm "$state" 30600
+  ) || fail "bounded-observation wedge alarm failed"
+  elapsed=$((SECONDS - start))
+  [ "$elapsed" -lt 5 ] || fail "hung composer observation blocked the wedge path for ${elapsed}s"
+  [ ! -e "$order_error" ] || fail "composer observation started before the active alert"
+  grep -F '(capture failed)' "$marker" >/dev/null || fail "timed-out observation did not leave a readable marker"
+  pass "inject_wedge_alarm alerts before bounded composer evidence"
+}
+
 test_inject_wedge_alarm_throttles_when_marker_cannot_be_written() {
   local dir state log daemon_log alerts errors
   dir=$(make_wedge_case wedge-unwritable-marker)
@@ -1924,6 +1971,8 @@ test_wedge_alarm_backgrounded_command_times_out_and_reaps_descendant
 test_wedge_alarm_hung_override_times_out_and_falls_through
 test_wedge_alarm_shutdown_stops_active_notifier_group
 test_inject_wedge_alarm_fires_active_alert_on_non_tmux_backend
+test_inject_wedge_alarm_uses_single_composer_observation
+test_inject_wedge_alarm_notifies_before_bounded_observation
 test_inject_wedge_alarm_throttles_when_marker_cannot_be_written
 test_fm_send_exits_nonzero_on_confirmed_swallow
 test_fm_send_exits_nonzero_on_initial_send_failure

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -1128,7 +1128,7 @@ test_submit_ack_reports_pending_on_persistent_swallow() {
 }
 
 test_max_defer_empty_swallow_types_once_and_alarms() {
-  local dir state fakebin sent
+  local dir state fakebin sent marker_mode
   dir=$(make_bordered_case maxdefer-stuck)
   state="$dir/state"; fakebin="$dir/fakebin"
   sent="$dir/sent.log"; : > "$sent"
@@ -1144,6 +1144,13 @@ test_max_defer_empty_swallow_types_once_and_alarms() {
     || fail "max-defer typed the digest more than once"
   [ -s "$state/.subsuper-inject-wedged" ] \
     || fail "stuck max-defer inject did not raise a wedge alarm marker"
+  if [ "$(uname)" = Darwin ]; then
+    marker_mode=$(stat -f %Lp "$state/.subsuper-inject-wedged")
+  else
+    marker_mode=$(stat -c %a "$state/.subsuper-inject-wedged")
+  fi
+  [ "$marker_mode" = 600 ] \
+    || fail "wedge alarm marker mode was not 0600: $marker_mode"
   [ -s "$state/.subsuper-escalations" ] \
     || fail "buffer lost after a failed max-defer inject (must be preserved)"
   # The marker must carry enough to tell a half-typed line apart from a


### PR DESCRIPTION
## Intent

Fix the away-mode escalation delivery wedge in firstmate. While the captain was away, the sub-supervisor daemon buffered captain-relevant escalations and injected them into firstmate's own pane, but every injection deferred indefinitely - one episode sat 9.7 hours (34973s) undelivered, with 2845 defers and zero successful injections - so decision gates stalled overnight and delivery only happened via the return catch-up.

ROOT CAUSE, reproduced live on the running fleet: Claude Code 2.1.232 draws the session's agent name as a reverse-video title inside the TOP rule of its own bare composer. bin/fm-composer-lib.sh's _fm_composer_pi_separator_row only counted a row consisting of nothing but the rule glyph, so the titled top rule stopped counting as a rule, which left the composer's untitled BOTTOM rule unpaired. _fm_composer_select_cursorless treats an unpaired rule below the best candidate as proof that the candidate is stale scrollback, so it abandoned selection and every idle claude pane classified `unknown`. The away-mode injector requires an affirmative `empty` before typing, so it deferred forever: correct fail-closed behaviour applied to a wrong verdict. Steers to worker panes through fm-send.sh were unaffected the whole time, because the herdr submit primitive confirms delivery from native agent-state (`agent get`) and never reads the composer; the daemon's pre-injection composer guard is the only delivery check that consults the classifier.

THE FIX accepts a rule carrying an embedded title, bounded exactly as _fm_composer_titled_bottom_ok already bounds a titled bottom BORDER: rule glyphs at both ends and an ASCII-printable interior. That bounded shape was chosen deliberately over a looser match so ordinary transcript prose can never be promoted into a composer boundary, and the new tests pin that boundary from both sides (prose ending in a rule, prose following a rule, and a non-ASCII title must all still fail to qualify). Verified live: the supervisor pane flips unknown -> empty, typed text still reads pending, and all 12 relevant suites pass.

DELIBERATE DECISIONS a reviewer reading only the diff would not know:

1. A secondary "bare-composer wrap-extension overreach" fix was in the originally accepted scope and was deliberately REMOVED after implementation disproved it. The proposed variant ("do not extend the wrap region when the pane has no cursor capability") is literally "delete the extension", because _fm_composer_select_cursorless only ever runs cursorless. Doing that turns the existing deliberate assertion in tests/fm-composer-lib.test.sh ("cursorless activity below bare row on herdr") from pending to empty - a composer holding real text classified as safe to inject into, on the exact backend the injector uses. The alternative variant required a regex over a user-configured statusLine, which cannot be built from verified evidence. The captain decided to drop it and file it as its own backlog item. Do not re-add it or any variant of it in this change.

2. The bin/fm-supervise-daemon.sh change is deliberate diagnostic hardening, not part of the classifier fix. The wedge produced thousands of identical defer lines and no evidence, and the defer reason names three possible causes it cannot separate. The wedge marker now records the composer verdict and the captured screen once per max-defer window, alongside the existing alarm. The verdict's meaning stays owned by bin/fm-composer-lib.sh; the daemon only reports it.

CONSTRAINTS AND KNOWN GAPS: ShellCheck was absent on this machine, so the repo-pinned 0.11.0 static binary was installed to ~/.local/bin and bin/fm-lint.sh now runs clean - lint is not being skipped. tests/fm-afk-inject-herdr-e2e.test.sh fails identically with and without this change ("the supervisor pane's shell did not become ready"); it needs a real spawned herdr pane, and is pre-existing and environmental, not a regression. tests/fm-composer-matrix-live-e2e.test.sh is the live guard that would have caught this regression, but it requires tmux, which this herdr-backed machine does not have; that is noted as follow-up and is deliberately out of scope here.

3. The branch already carries five pipeline fix commits from a previous run of this same change, each one a captain-directed outcome of an earlier review round. Do not re-litigate them: (a) the wedge alarm fires BEFORE the new backend evidence probes, so an unbounded probe cannot block the alarm path; (b) the diagnostic verdict and the diagnostic screen come from ONE capture via fm_backend_composer_observation, so a redraw between two reads cannot make them disagree - this is why the diff reaches into bin/fm-backend.sh, bin/backends/herdr.sh and bin/fm-tmux-lib.sh, which were not in the original scope; (c) ANSI is stripped from the captured evidence at the output boundary so the durable marker stays plain text; (d) the titled-rule interior is validated as ASCII-printable AFTER the file's standard Unicode-whitespace normalization, and the function comment, SHAPE CATALOGUE entry and test names all state that boundary in those terms - the captain explicitly chose to correct the documented wording rather than move validation to the pre-normalization row, because a pre-normalization check would be the only such check in the file and would violate the locale-safety invariant issue #1988 exists to protect; (e) the ShellCheck suppressions are per-assignment with reasons, matching the existing convention at bin/fm-backend.sh:527, bin/fm-classify-lib.sh:70, bin/fm-wake-lib.sh:124 and tests/fm-supervision-events.test.sh:65 - SC2034 on FM_BACKEND_COMPOSER_SCREEN is a false positive because it is a genuine cross-file output global, and SC2329 covers three intentional test stubs, two of which are tripwires that must stay uncalled.

DELIVERY: this account has no write access to the upstream repo, so per the captain's decision the branch pushes to the fork unhexquadium/firstmate and the PR opens against kunchenguid/firstmate, matching how every recent PR on this repo ships. The fork is a PR staging vehicle only; nothing is ever merged into the fork itself.

## What Changed

- Recognize bounded, two-ended titled composer rules so Claude's idle composer classifies as empty while one-ended prose and non-ASCII titles remain rejected.
- Record a secured, ANSI-stripped composer verdict and matching screen capture in away-mode wedge markers using bounded, alert-first evidence collection for tmux and Herdr.
- Add regression coverage and documentation for titled-rule classification, wedge evidence handling, and live backend behavior.

## Risk Assessment

✅ Low: The private-marker fix establishes mode 0600 before writing sensitive content, preserves alarm ordering and single-snapshot diagnostics, and leaves the durable classifier fix intact.

## Testing

The focused classifier, daemon, and Herdr adapter suites passed; a base-versus-target reproduction using the captured Claude 2.1.232 pane proved `unknown` became `empty`, the production away-mode guard submitted exactly once while unsafe shapes still deferred, and the durable diagnostic preserved the buffer with a mode-0600 plain-text paired verdict and screen. A live spawned-pane run was not attempted because tmux is unavailable and the supplied intent identifies the real-Herdr shell-readiness failure as environmental.

<details>
<summary>Evidence: Away-mode end-to-end transcript</summary>

<code>same_claude_capture_baseline_verdict=unknown&#10;same_claude_capture_target_adapter_verdict=empty&#10;typed_draft_target_adapter_verdict=pending&#10;one_ended_prose_target_adapter_verdict=unknown&#10;non_ascii_title_target_adapter_verdict=unknown&#10;away_mode_injection_result=delivered&#10;away_mode_submit_calls=1</code>

```text
AFK WEDGE END-TO-END EVIDENCE
base_commit=6789876442d0fb6da9f70d86399a2930c5073ae2
target_commit=4f28e5e4fff82d12559a49711db154b3ab90b9b3
same_claude_capture_baseline_verdict=unknown
same_claude_capture_target_adapter_verdict=empty
typed_draft_target_adapter_verdict=pending
one_ended_prose_target_adapter_verdict=unknown
non_ascii_title_target_adapter_verdict=unknown
away_mode_injection_result=delivered
away_mode_injection_kind=away-supervisor
away_mode_injection_body=needs-decision: choose safe option
away_mode_submit_calls=1
wedge_marker_verdict=empty
wedge_marker_contains_captured_title_and_status=yes
wedge_marker_is_plain_text=yes
wedge_marker_buffer_preserved=yes
```
</details>
<details>
<summary>Evidence: Plain-text durable wedge marker</summary>

<code>composer verdict: empty&#10;captured screen:&#10;──────────────────────── orchestrator ──&#10;❯&#10;────────────────────────────────────────</code>

```text
fm away-mode inject WEDGED: 34973s undelivered as of 2026-08-14T10:15:55-0700
The supervisor pane could not accept an escalation. Buffered items:
needs-decision: choose safe option

--- supervisor pane default:w1:p2 (herdr) ---
composer verdict: empty
captured screen:
transcript line
──────────────────────── orchestrator ──
❯ 
────────────────────────────────────────
  kalvira@host: /home/kalvira/firstmate (main) [ctx:15%]
  ⏵⏵ auto mode on
```
</details>
<details>
<summary>Evidence: Reproducible evidence harness</summary>

```text
#!/usr/bin/env bash
set -euo pipefail

ROOT=/home/kalvira/.no-mistakes/worktrees/29769f6dfb27/01M00KEYQHEKASD825G1EXZHAK
BASE=6789876442d0fb6da9f70d86399a2930c5073ae2
EVIDENCE_DIR=/tmp/no-mistakes-evidence/01M00KEYQHEKASD825G1EXZHAK
ESC=$(printf '\033')
NBSP=$(printf '\302\240')
CAPS=$'styled=1\ncursor=0\nidentity=1\nrows=20'

# Reproduces the Claude Code 2.1.232 pane shape that triggered the wedge:
# a reverse-video title embedded in the top rule, a bare idle composer,
# an untitled closing rule, and active status rows below it.
CLAUDE_CAPTURE=$'transcript line\n'\
"${ESC}[0m${ESC}[38;2;136;136;136m────────────────────────${ESC}[0m${ESC}[38;2;0;0;0m${ESC}[48;2;136;136;136m orchestrator ${ESC}[0m${ESC}[38;2;136;136;136m──${ESC}[0m"$'\n'\
"${ESC}[0m${ESC}[38;2;153;153;153m❯${NBSP}${ESC}[0m"$'\n'\
"${ESC}[0m${ESC}[38;2;136;136;136m────────────────────────────────────────${ESC}[0m"$'\n'\
"  ${ESC}[1m${ESC}[38;5;2mkalvira@host${ESC}[0m${ESC}[38;2;153;153;153m:${ESC}[0m /home/kalvira/firstmate (main) [ctx:15%]"$'\n'\
"  ${ESC}[38;2;255;193;7m⏵⏵ auto mode on${ESC}[0m"

baseline_verdict=$(
  bash -c '. "$1"; fm_composer_classify_screen "$2" "$3" "" probe-absent' _ \
    <(git -C "$ROOT" show "$BASE:bin/fm-composer-lib.sh") "$CAPS" "$CLAUDE_CAPTURE"
)

# Load the target's real classifier, backend adapter, and away-mode injector.
. "$ROOT/bin/fm-supervise-daemon.sh"
fm_backend_source herdr

ACTIVE_CAPTURE=$CLAUDE_CAPTURE
fm_backend_herdr_capture_ansi() {
  printf '%s\n' "$ACTIVE_CAPTURE"
}
fm_backend_herdr_capture() {
  return 1
}

idle_verdict=$(fm_backend_composer_state herdr default:w1:p2)

ACTIVE_CAPTURE=${CLAUDE_CAPTURE/"❯${NBSP}"/"❯ answer the parked decision"}
typed_verdict=$(fm_backend_composer_state herdr default:w1:p2)

ACTIVE_CAPTURE=$'transcript\nrunning the build ──────────\n❯\n────────────────────────'
one_ended_prose_verdict=$(fm_backend_composer_state herdr default:w1:p2)

ACTIVE_CAPTURE=$'transcript\n──────────── ✻ пример ──\n❯\n────────────────────────'
non_ascii_title_verdict=$(fm_backend_composer_state herdr default:w1:p2)

RUNTIME_DIR=$(mktemp -d "$EVIDENCE_DIR/runtime.XXXXXX")
STATE_DIR="$RUNTIME_DIR/state"
DELIVERY_FILE="$RUNTIME_DIR/delivered"
CALLS_FILE="$RUNTIME_DIR/submit-calls"
LOG="$RUNTIME_DIR/daemon.log"
mkdir -p "$STATE_DIR"
trap 'rm -rf "$RUNTIME_DIR"' EXIT
afk_enter "$STATE_DIR"

ACTIVE_CAPTURE=$CLAUDE_CAPTURE
FM_SUPERVISOR_BACKEND=herdr
FM_SUPERVISOR_TARGET=default:w1:p2
fm_backend_target_exists() {
  [ "$1" = herdr ] && [ "$2" = default:w1:p2 ]
}
pane_is_busy() {
  return 1
}
fm_backend_send_text_submit() {
  [ "$1" = herdr ] && [ "$2" = default:w1:p2 ]
  printf 'x' >> "$CALLS_FILE"
  printf '%s' "$3" > "$DELIVERY_FILE"
  printf 'empty'
}

inject_msg 'needs-decision: choose safe option' "$STATE_DIR"
delivered=$(cat "$DELIVERY_FILE")
fm_operational_input_kind "$delivered" delivered_kind
fm_operational_input_body "$delivered" delivered_body
submit_calls=$(wc -c < "$CALLS_FILE" | tr -d '[:space:]')

# Exercise the durable operator diagnostic with the same captured screen.
escalate_add "$STATE_DIR" 'needs-decision: choose safe option'
WEDGE_ALARM_LAST_EPOCH=0
FM_WEDGE_ALARM_CHANNEL=off
inject_wedge_alarm "$STATE_DIR" 34973
WEDGE_MARKER="$STATE_DIR/.subsuper-inject-wedged"
cp "$WEDGE_MARKER" "$EVIDENCE_DIR/wedge-marker.txt"
wedge_verdict=$(sed -n 's/^composer verdict: //p' "$WEDGE_MARKER")
grep -F 'orchestrator' "$WEDGE_MARKER" >/dev/null
grep -F 'kalvira@host' "$WEDGE_MARKER" >/dev/null
case "$(cat "$WEDGE_MARKER")" in
  *"$ESC"*) wedge_marker_plain=no ;;
  *) wedge_marker_plain=yes ;;
esac

printf 'AFK WEDGE END-TO-END EVIDENCE\n'
printf 'base_commit=%s\n' "$BASE"
printf 'target_commit=%s\n' "$(git -C "$ROOT" rev-parse HEAD)"
printf 'same_claude_capture_baseline_verdict=%s\n' "$baseline_verdict"
printf 'same_claude_capture_target_adapter_verdict=%s\n' "$idle_verdict"
printf 'typed_draft_target_adapter_verdict=%s\n' "$typed_verdict"
printf 'one_ended_prose_target_adapter_verdict=%s\n' "$one_ended_prose_verdict"
printf 'non_ascii_title_target_adapter_verdict=%s\n' "$non_ascii_title_verdict"
printf 'away_mode_injection_result=delivered\n'
printf 'away_mode_injection_kind=%s\n' "$delivered_kind"
printf 'away_mode_injection_body=%s\n' "$delivered_body"
printf 'away_mode_submit_calls=%s\n' "$submit_calls"
printf 'wedge_marker_verdict=%s\n' "$wedge_verdict"
printf 'wedge_marker_contains_captured_title_and_status=yes\n'
printf 'wedge_marker_is_plain_text=%s\n' "$wedge_marker_plain"
printf 'wedge_marker_buffer_preserved=%s\n' "$([ -s "$STATE_DIR/.subsuper-escalations" ] && printf yes || printf no)"

[ "$baseline_verdict" = unknown ]
[ "$idle_verdict" = empty ]
[ "$typed_verdict" = pending ]
[ "$one_ended_prose_verdict" = unknown ]
[ "$non_ascii_title_verdict" = unknown ]
[ "$delivered_kind" = away-supervisor ]
[ "$delivered_body" = 'needs-decision: choose safe option' ]
[ "$submit_calls" = 1 ]
[ "$wedge_verdict" = empty ]
[ "$wedge_marker_plain" = yes ]
[ -s "$STATE_DIR/.subsuper-escalations" ]
```
</details>
<details>
<summary>Evidence: Targeted test timing metadata</summary>

```text
{
  "families": [
    {
      "count": 1,
      "duration_ms": 11089,
      "failed": 0,
      "name": "backend-dispatch"
    },
    {
      "count": 1,
      "duration_ms": 2774,
      "failed": 0,
      "name": "pure-contract-unit"
    },
    {
      "count": 1,
      "duration_ms": 15731,
      "failed": 0,
      "name": "watcher-wake-lock"
    }
  ],
  "finished_at": "2026-08-14T17:13:29Z",
  "run_id": "fm-test-run-1786727579834-1199520",
  "scripts": [
    {
      "duration_ms": 2774,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-composer-lib.test.sh"
    },
    {
      "duration_ms": 15731,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "watcher-wake-lock",
      "gate_skip": false,
      "path": "tests/fm-daemon.test.sh"
    },
    {
      "duration_ms": 11089,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "backend-dispatch",
      "gate_skip": false,
      "path": "tests/fm-backend-herdr.test.sh"
    }
  ],
  "selection": "scripts",
  "started_at": "2026-08-14T17:12:59Z",
  "summary": {
    "duration_ms": 29650,
    "failed": 0,
    "skipped_gate": 0,
    "total": 3
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-supervise-daemon.sh:938` - The new pane capture is appended to a marker created with ordinary shell redirection and never given restrictive permissions. With umask 022 and a traversable FM_HOME, the marker is 0644, allowing other local users to read terminal contents that may include credentials. Ensure the marker is mode 0600 before appending diagnostic evidence.

🔧 Fix: Secure away-mode wedge evidence marker
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh --list --changed --base 6789876442d0fb6da9f70d86399a2930c5073ae2`
- `bin/fm-test-run.sh --json /tmp/no-mistakes-evidence/01M00KEYQHEKASD825G1EXZHAK/targeted-test-timings.json tests/fm-composer-lib.test.sh tests/fm-daemon.test.sh tests/fm-backend-herdr.test.sh`
- `bash -o pipefail -c 'bash "$1" | tee "$2"' _ /tmp/no-mistakes-evidence/01M00KEYQHEKASD825G1EXZHAK/afk-wedge-e2e.sh /tmp/no-mistakes-evidence/01M00KEYQHEKASD825G1EXZHAK/afk-wedge-e2e.txt`
- <code>Inspected `wedge-marker.txt` and verified mode `0600`, preserved buffer, paired verdict and captured screen, and absence of ANSI escape bytes.</code>
- `Verified the working tree remained clean and testing left no transient project artifacts.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


---

## Adjacent issue deliberately left out of scope

The review round that produced the `0600` fix on `state/.subsuper-inject-wedged` raised a
class of problem, not a single instance.
`state/.subsuper-escalations`, written by the same daemon, holds buffered captain escalation
text and is created the same way, so under `umask 022` it has the same world-readable
weakness.

That one is **pre-existing** - it is not introduced or worsened by this branch - so it was
deliberately not fixed here rather than widening a validated change during its own pipeline
run.
It is worth its own item.
