### PR TITLE
fix(teardown): skip worktree steps on rerun when the pool slot was returned or reissued

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,7 @@ state/               runtime records and signals; gitignored
   <id>.kimi-turnend-token   firstmate-owned Kimi hook registry token for the task; removed by teardown
   <id>.muse-session  muse busy-source binding (sessions root plus task worktree) written by fm-spawn; removed by teardown
   <id>.cursor-session  cursor busy-source binding (projects root, task worktree, prior conversations) written by fm-spawn; removed by teardown
+  <id>.worktree-returned  touched by fm-teardown right after this task's own pool-worktree return succeeds so a rerun skips every worktree step instead of resetting a possibly reissued slot; removed by teardown
   <id>.meta          task metadata; each producer script's header owns its exact fields and mutation contract, with docs/configuration.md routing operator-facing backend and trace-context details
   <id>.herdr-presentation  quarantinable attempt and restart-binding journal for Herdr's optional visual projection; never task or endpoint authority; see docs/herdr-backend.md "Presentation spaces"
   <id>.check.sh      authenticated slow poll; the watcher dispatches validated PR data and the byte-identified Relay shim through trusted repository scripts, runs registered custom checks from hash-validated private snapshots, and rejects every other state check without execution

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -63,10 +63,13 @@
 # state/<id>.worktree-returned marker, touched immediately after this task's
 # own successful return, and the current fleet bindings - another task's meta
 # recording the same worktree path proves the slot was reissued even when the
-# marker is lost. When either shows the worktree is no longer this task's, the
-# safety inspection, run-abort, worktree process reap, branch delete, hook
-# removal, and the return itself are all skipped with one line, while tasktmp
-# reaping, the pane close retry, and durable-record cleanup continue unchanged.
+# marker is lost. A binding whose task carries its own worktree-returned
+# marker is ignored: that task provably gave the slot back already, so its
+# meta records a past tenancy, not a live claim. When either signal shows the
+# worktree is no longer this task's, the safety inspection, run-abort,
+# worktree process reap, branch delete, hook removal, and the return itself
+# are all skipped with one line, while tasktmp reaping, the pane close retry,
+# and durable-record cleanup continue unchanged.
 # The marker is removed with the rest of the volatile state once teardown
 # completes.
 # Usage: fm-teardown.sh <task-id> [--force]
@@ -2300,11 +2303,13 @@ WORKTREE_RETURN_MARKER="$STATE/$ID.worktree-returned"
 WORKTREE_OWNED_BY_TASK=1
 WORKTREE_SKIP_REASON=
 
-# Echoes the id of another task whose meta records the same worktree path,
-# proving the pool slot was reissued; returns non-zero when no other task
-# binds it.
+# Echoes the id of another task whose meta records the same worktree path
+# without its own worktree-returned marker, proving the pool slot was
+# reissued; a marker-bearing binding is a stale record of an already-returned
+# tenancy and is skipped. Returns non-zero when no other task holds a live
+# binding.
 worktree_reissued_to_other_task() {
-  local meta other_id other_wt abs_wt abs_other
+  local meta other_id other_wt abs_wt abs_other other_marker
   [ -n "$WT" ] || return 1
   abs_wt=$(canonical_existing_dir "$WT") || abs_wt=$WT
   for meta in "$STATE"/*.meta; do
@@ -2315,6 +2320,10 @@ worktree_reissued_to_other_task() {
     [ -n "$other_wt" ] || continue
     abs_other=$(canonical_existing_dir "$other_wt") || abs_other=$other_wt
     [ "$abs_other" = "$abs_wt" ] || continue
+    other_marker="$STATE/$other_id.worktree-returned"
+    if [ -e "$other_marker" ] || [ -L "$other_marker" ]; then
+      continue
+    fi
     printf '%s\n' "$other_id"
     return 0
   done

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -54,6 +54,21 @@
 # the retired home. Removing a leased home releases its durable treehouse lease so the pool slot is freed,
 # never left leased forever. If the treehouse return fails, teardown leaves the
 # leased home and state in place instead of hiding a still-held lease.
+# Rerun tenant safety (teardown-rerun-reissue, observed 2026-08-08): a teardown
+# that returned this task's pool worktree and then failed on a later step (for
+# example a refused focus-unsafe pane close) is rerun by design - but by then
+# the pool may have reissued the SAME slot to a newer task, so re-running any
+# worktree-scoped step would reset the worktree under the live tenant and kill
+# its session. Ownership is decided from two provable signals: the durable
+# state/<id>.worktree-returned marker, touched immediately after this task's
+# own successful return, and the current fleet bindings - another task's meta
+# recording the same worktree path proves the slot was reissued even when the
+# marker is lost. When either shows the worktree is no longer this task's, the
+# safety inspection, run-abort, worktree process reap, branch delete, hook
+# removal, and the return itself are all skipped with one line, while tasktmp
+# reaping, the pane close retry, and durable-record cleanup continue unchanged.
+# The marker is removed with the rest of the volatile state once teardown
+# completes.
 # Usage: fm-teardown.sh <task-id> [--force]
 #   --force skips ordinary-task dirty and landed-work checks, skips scout report
 #   checks, and discards secondmate child work for kind=secondmate. Only use it
@@ -2278,7 +2293,53 @@ remove_secondmate_registry_entry() {
   return "$rc"
 }
 
+# Rerun tenant-safety guard (see the script header). WORKTREE_OWNED_BY_TASK=0
+# means the recorded worktree is provably no longer this task's and every
+# worktree-scoped step below must be skipped.
+WORKTREE_RETURN_MARKER="$STATE/$ID.worktree-returned"
+WORKTREE_OWNED_BY_TASK=1
+WORKTREE_SKIP_REASON=
+
+# Echoes the id of another task whose meta records the same worktree path,
+# proving the pool slot was reissued; returns non-zero when no other task
+# binds it.
+worktree_reissued_to_other_task() {
+  local meta other_id other_wt abs_wt abs_other
+  [ -n "$WT" ] || return 1
+  abs_wt=$(canonical_existing_dir "$WT") || abs_wt=$WT
+  for meta in "$STATE"/*.meta; do
+    [ -f "$meta" ] && [ ! -L "$meta" ] || continue
+    other_id=$(basename "$meta" .meta)
+    [ "$other_id" != "$ID" ] || continue
+    other_wt=$(fm_meta_get "$meta" worktree)
+    [ -n "$other_wt" ] || continue
+    abs_other=$(canonical_existing_dir "$other_wt") || abs_other=$other_wt
+    [ "$abs_other" = "$abs_wt" ] || continue
+    printf '%s\n' "$other_id"
+    return 0
+  done
+  return 1
+}
+
+resolve_worktree_ownership() {
+  local tenant
+  [ "$KIND" != secondmate ] || return 0
+  [ -n "$WT" ] || return 0
+  if [ -e "$WORKTREE_RETURN_MARKER" ] || [ -L "$WORKTREE_RETURN_MARKER" ]; then
+    WORKTREE_OWNED_BY_TASK=0
+    WORKTREE_SKIP_REASON="this task's return already succeeded on a previous attempt"
+  elif tenant=$(worktree_reissued_to_other_task); then
+    WORKTREE_OWNED_BY_TASK=0
+    WORKTREE_SKIP_REASON="the pool slot is now recorded for task $tenant"
+  fi
+  if [ "$WORKTREE_OWNED_BY_TASK" -ne 1 ]; then
+    echo "teardown: skipping worktree return and every other worktree step for $ID: $WORKTREE_SKIP_REASON"
+  fi
+}
+
 validate_pr_poll_cleanup "$STATE" "$ID" || exit 1
+
+resolve_worktree_ownership
 
 if [ "$KIND" = secondmate ]; then
   [ -n "$HOME_PATH" ] || HOME_PATH=$WT
@@ -2361,7 +2422,7 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != scout ] && [ "$KIND" != secondmate ] &&
   ORCA_PATH_MATCH_VERIFIED=1
 fi
 
-if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
+if [ -d "$WT" ] && [ "$FORCE" != "--force" ] && [ "$WORKTREE_OWNED_BY_TASK" = 1 ]; then
   if validate_worktree_teardown_safety; then
     :
   else
@@ -2383,8 +2444,14 @@ fi
 # dedicated process-event and firstmate-home removal machinery further below,
 # not by task-worktree cleanup.
 if [ "$KIND" != secondmate ]; then
-  conclude_task_no_mistakes_run "$WT"
-  reap_task_worktree_processes worktree "$WT" "$TASK_TMP"
+  if [ "$WORKTREE_OWNED_BY_TASK" = 1 ]; then
+    conclude_task_no_mistakes_run "$WT"
+    reap_task_worktree_processes worktree "$WT" "$TASK_TMP"
+  else
+    # The worktree now belongs to another tenant, but the per-task tasktmp root
+    # is still uniquely this task's and is removed below, so still reap it.
+    reap_task_worktree_processes tasktmp "$TASK_TMP"
+  fi
 fi
 
 # Fix 3 (see script header): sweep remote job workers abandoned by an already
@@ -2426,7 +2493,7 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
   fi
   [ -z "$T_ORCA" ] || fm_backend_kill "$BACKEND" "$T" "$(meta_value "$META" zellij_tab_id)" "fm-$ID" 2>/dev/null || true
   fm_backend_remove_worktree "$BACKEND" "$ORCA_WORKTREE_ID"
-elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
+elif [ -d "$WT" ] && [ "$KIND" != secondmate ] && [ "$WORKTREE_OWNED_BY_TASK" = 1 ]; then
   branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
   if [ "$branch" != "HEAD" ]; then
     if git -C "$WT" checkout --detach -q 2>/dev/null; then
@@ -2448,6 +2515,10 @@ elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
     echo "error: treehouse return failed for worktree $WT; teardown aborted" >&2
     exit 1
   }
+  # Record the completed return durably BEFORE any later step can fail, so a
+  # sanctioned rerun never re-returns a slot the pool may reissue meanwhile.
+  touch "$WORKTREE_RETURN_MARKER" 2>/dev/null \
+    || echo "warning: could not record the completed worktree return for $ID at $WORKTREE_RETURN_MARKER; a rerun will rely on live fleet bindings to skip the return" >&2
 fi
 
 HERDR_PRESENTATION_JOURNAL="$STATE/$ID.herdr-presentation"
@@ -2542,6 +2613,7 @@ rm -f "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
   "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
   "$STATE/$ID.kimi-turnend-token" "$STATE/$ID.muse-session" \
   "$STATE/$ID.muse-session-current" "$STATE/$ID.cursor-session" \
+  "$STATE/$ID.worktree-returned" \
   "$STATE/$ID.control-relaunch" "$STATE/$ID.control-relaunch.meta-prior" \
   "$STATE/$ID.control-relaunch.brief-prior" "$STATE/$ID.control-relaunch.note"
 fm_lock_release "$META_LOCK"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -249,7 +249,8 @@ The firstmate repo itself is the exception: its `.no-mistakes/` directory is loc
 PR-based task merges go through `bin/fm-pr-merge.sh`, which records `pr=` and any available `pr_head=` through `bin/fm-pr-check.sh` before calling `gh-axi pr merge`.
 The helper requires a full `https://github.com/<owner>/<repo>/pull/<n>` URL, invokes `gh-axi pr merge <n> --repo <owner>/<repo>`, defaults to `--squash`, preserves explicit merge-method flags, and rejects malformed URLs or repo override flags before recording merge state; a well-formed GitLab merge request URL (see [docs/gitlab-merge-watch.md](gitlab-merge-watch.md)) is refused too, explicitly, rather than sent to the wrong forge.
 Teardown is fail-closed for ship worktrees: dirty worktrees refuse, and committed work must be landed before the worktree is returned.
-[`bin/fm-teardown.sh`](../bin/fm-teardown.sh)'s header owns the landed-work proofs, PR-discovery fallback, and stale-lock recovery procedure.
+Those worktree-scoped checks and the return itself apply only while the pool slot is still provably this task's: a sanctioned teardown rerun that finds the slot already returned or reissued to a newer task skips them instead of resetting the live tenant's worktree.
+[`bin/fm-teardown.sh`](../bin/fm-teardown.sh)'s header owns the landed-work proofs, PR-discovery fallback, stale-lock recovery procedure, and the rerun tenant-safety ownership signals.
 
 ## Optional Relay
 

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -2591,6 +2591,177 @@ EOF
   pass "the run abort and the leaked-process reap both complete before the destructive worktree return"
 }
 
+# Replace the treehouse mock with one that logs every invocation to
+# $case_dir/treehouse.log and succeeds. Args: case_dir
+add_logging_treehouse() {
+  local case_dir=$1
+  : > "$case_dir/treehouse.log"
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$case_dir/treehouse.log"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+}
+
+# Fast-forward the project's local main to the worktree HEAD so the local-only
+# landed-work safety check passes. Args: case_dir
+merge_wt_into_local_main() {
+  local case_dir=$1 wt_head
+  wt_head=$(git -C "$case_dir/wt" rev-parse HEAD)
+  git -C "$case_dir/project" update-ref refs/heads/main "$wt_head"
+}
+
+# The 2026-08-08 incident end to end (teardown-rerun-reissue): attempt 1 returns
+# the pool worktree, then fails on the refused pane close; the freed slot is
+# reissued to a NEWER task; the sanctioned rerun must close the stale pane and
+# finish cleanup WITHOUT re-returning the slot under the live tenant.
+test_rerun_after_return_and_reissue_never_rereturns() {
+  local case_dir log closed rc
+  case_dir=$(make_case rerun-reissue)
+  write_meta "$case_dir" local-only ship
+  wt_commit "$case_dir" "landed work"
+  merge_wt_into_local_main "$case_dir"
+  configure_flat_herdr_teardown_case "$case_dir"
+  add_logging_treehouse "$case_dir"
+  log="$case_dir/herdr.log"; : > "$log"
+  closed="$case_dir/closed"
+  : > "$case_dir/state/task-x1.status"
+
+  # Attempt 1: the pane close cannot record success (FM_FAKE_HERDR_CLOSED points
+  # into a missing dir), so the pane stays present and teardown fails AFTER the
+  # worktree return - the incident's exact failure point.
+  rc=0
+  FM_FAKE_HERDR_LOG="$log" FM_FAKE_HERDR_CLOSED="$case_dir/noexist/closed" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+  [ "$rc" -ne 0 ] || fail "rerun-reissue: attempt 1 reported success although the pane was never closed"
+  [ "$(wc -l < "$case_dir/treehouse.log")" -eq 1 ] \
+    || fail "rerun-reissue: attempt 1 did not return the worktree exactly once: $(cat "$case_dir/treehouse.log")"
+  [ -e "$case_dir/state/task-x1.worktree-returned" ] \
+    || fail "rerun-reissue: the completed return left no durable marker for the rerun"
+  [ -e "$case_dir/state/task-x1.meta" ] || fail "rerun-reissue: attempt 1 erased the durable metadata"
+
+  # The pool reissues the same slot to a newer task: its meta binds the same
+  # worktree path and its session occupies the worktree on its own branch with
+  # uncommitted work.
+  fm_write_meta "$case_dir/state/task-x2.meta" \
+    "window=default:wZ:pZ" \
+    "endpoint_task_id=task-x2" \
+    "worktree=$case_dir/wt" \
+    "project=$case_dir/project" \
+    "kind=scout" \
+    "mode=no-mistakes" \
+    "backend=herdr"
+  git -C "$case_dir/wt" checkout -q -b fm/task-x2
+  printf '%s\n' "tenant work in flight" > "$case_dir/wt/tenant.txt"
+
+  # Attempt 2 (the sanctioned rerun): the pane close now works.
+  FM_FAKE_HERDR_LOG="$log" FM_FAKE_HERDR_CLOSED="$closed" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+    run_teardown "$case_dir" > "$case_dir/stdout2" 2> "$case_dir/stderr2" \
+    || fail "rerun-reissue: the rerun failed: $(cat "$case_dir/stderr2")"
+  [ "$(wc -l < "$case_dir/treehouse.log")" -eq 1 ] \
+    || fail "rerun-reissue: the rerun re-returned the reissued slot: $(cat "$case_dir/treehouse.log")"
+  assert_grep "skipping worktree return" "$case_dir/stdout2" \
+    "rerun-reissue: the rerun did not say it skipped the return"
+  [ -e "$closed" ] || fail "rerun-reissue: the rerun never closed the stale pane"
+  [ "$(git -C "$case_dir/wt" rev-parse --abbrev-ref HEAD)" = "fm/task-x2" ] \
+    || fail "rerun-reissue: the rerun moved the tenant's branch"
+  [ -f "$case_dir/wt/tenant.txt" ] || fail "rerun-reissue: the rerun destroyed the tenant's uncommitted work"
+  [ -e "$case_dir/state/task-x2.meta" ] || fail "rerun-reissue: the rerun removed the tenant's metadata"
+  [ ! -e "$case_dir/state/task-x1.meta" ] || fail "rerun-reissue: the rerun left the old metadata behind"
+  [ ! -e "$case_dir/state/task-x1.worktree-returned" ] \
+    || fail "rerun-reissue: the rerun left the return marker behind"
+  grep -q "teardown task-x1 complete" "$case_dir/stdout2" \
+    || fail "rerun-reissue: the rerun did not report completion"
+  pass "a rerun after a completed return and a reissued slot closes the pane and cleans records without re-returning"
+}
+
+# A plain first-run teardown of a task that still owns its worktree must return
+# it exactly as before the guard existed.
+test_first_run_still_returns_worktree() {
+  local case_dir
+  case_dir=$(make_case first-run-return)
+  write_meta "$case_dir" local-only ship
+  wt_commit "$case_dir" "landed work"
+  merge_wt_into_local_main "$case_dir"
+  add_logging_treehouse "$case_dir"
+
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" \
+    || fail "first-run-return: teardown failed: $(cat "$case_dir/stderr")"
+  grep -q "return --force $case_dir/wt" "$case_dir/treehouse.log" \
+    || fail "first-run-return: the worktree was never returned: $(cat "$case_dir/treehouse.log")"
+  grep -q "skipping worktree return" "$case_dir/stdout" \
+    && fail "first-run-return: a first run wrongly skipped the return"
+  [ ! -e "$case_dir/state/task-x1.worktree-returned" ] \
+    || fail "first-run-return: the return marker survived a completed teardown"
+  pass "a first-run teardown of an owned worktree still returns it to the pool"
+}
+
+# A rerun whose worktree is still bound to this task and un-returned (the first
+# attempt failed BEFORE or AT the return) must perform the return.
+test_rerun_still_bound_unreturned_returns() {
+  local case_dir rc
+  case_dir=$(make_case rerun-unreturned)
+  write_meta "$case_dir" local-only ship
+  wt_commit "$case_dir" "landed work"
+  merge_wt_into_local_main "$case_dir"
+
+  # Attempt 1: the return itself fails with a non-lock error, so no marker may
+  # be written and the rerun must retry the return.
+  cat > "$case_dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+echo "error: pool server unavailable" >&2
+exit 1
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+  rc=0
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+  [ "$rc" -ne 0 ] || fail "rerun-unreturned: attempt 1 reported success although the return failed"
+  [ ! -e "$case_dir/state/task-x1.worktree-returned" ] \
+    || fail "rerun-unreturned: a failed return still wrote the returned marker"
+
+  add_logging_treehouse "$case_dir"
+  run_teardown "$case_dir" > "$case_dir/stdout2" 2> "$case_dir/stderr2" \
+    || fail "rerun-unreturned: the rerun failed: $(cat "$case_dir/stderr2")"
+  grep -q "return --force $case_dir/wt" "$case_dir/treehouse.log" \
+    || fail "rerun-unreturned: the rerun never returned the still-bound worktree"
+  grep -q "teardown task-x1 complete" "$case_dir/stdout2" \
+    || fail "rerun-unreturned: the rerun did not report completion"
+  pass "a rerun with the worktree still bound to this task and un-returned performs the return"
+}
+
+# Second signal: even with the durable marker lost, another task's meta binding
+# the same worktree path proves reissue and must skip every worktree step.
+test_reissued_slot_without_marker_skips_return() {
+  local case_dir
+  case_dir=$(make_case reissue-no-marker)
+  write_meta "$case_dir" local-only ship
+  wt_commit "$case_dir" "landed work"
+  merge_wt_into_local_main "$case_dir"
+  add_logging_treehouse "$case_dir"
+  fm_write_meta "$case_dir/state/task-x2.meta" \
+    "window=firstmate:fm-task-x2" \
+    "endpoint_task_id=task-x2" \
+    "worktree=$case_dir/wt" \
+    "project=$case_dir/project" \
+    "kind=ship" \
+    "mode=no-mistakes"
+
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" \
+    || fail "reissue-no-marker: teardown failed: $(cat "$case_dir/stderr")"
+  [ ! -s "$case_dir/treehouse.log" ] \
+    || fail "reissue-no-marker: the reissued slot was still returned: $(cat "$case_dir/treehouse.log")"
+  grep -q "recorded for task task-x2" "$case_dir/stdout" \
+    || fail "reissue-no-marker: the skip line did not name the tenant"
+  [ "$(git -C "$case_dir/wt" rev-parse --abbrev-ref HEAD)" = "fm/task-x1" ] \
+    || fail "reissue-no-marker: the tenant's checked-out branch was dropped"
+  [ -e "$case_dir/state/task-x2.meta" ] || fail "reissue-no-marker: the tenant's metadata was removed"
+  [ ! -e "$case_dir/state/task-x1.meta" ] || fail "reissue-no-marker: the old metadata survived"
+  grep -q "teardown task-x1 complete" "$case_dir/stdout" \
+    || fail "reissue-no-marker: teardown did not report completion"
+  pass "a reissued slot is never re-returned even when the durable marker is lost"
+}
+
 test_local_only_fork_remote_allows
 test_teardown_prompts_tasks_axi_done_when_compatible
 test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
@@ -2649,3 +2820,7 @@ test_process_spawned_during_grace_is_reaped_on_later_pass
 test_persistent_scan_refuses_after_bounded_retries
 test_process_exit_during_identity_lookup_does_not_refuse
 test_run_abort_precedes_process_reap_precedes_worktree_removal
+test_rerun_after_return_and_reissue_never_rereturns
+test_first_run_still_returns_worktree
+test_rerun_still_bound_unreturned_returns
+test_reissued_slot_without_marker_skips_return

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -2762,6 +2762,44 @@ test_reissued_slot_without_marker_skips_return() {
   pass "a reissued slot is never re-returned even when the durable marker is lost"
 }
 
+# Mirror of the incident window: a PREDECESSOR of this slot already returned it
+# (its own worktree-returned marker proves that) but awaits its sanctioned
+# rerun, so its stale meta still binds the same worktree path. The CURRENT
+# tenant's teardown must ignore that past-tenancy binding and still perform
+# its own return.
+test_returned_predecessor_binding_does_not_skip_current_return() {
+  local case_dir
+  case_dir=$(make_case predecessor-returned)
+  write_meta "$case_dir" local-only ship
+  wt_commit "$case_dir" "landed work"
+  merge_wt_into_local_main "$case_dir"
+  add_logging_treehouse "$case_dir"
+  fm_write_meta "$case_dir/state/task-x0.meta" \
+    "window=firstmate:fm-task-x0" \
+    "endpoint_task_id=task-x0" \
+    "worktree=$case_dir/wt" \
+    "project=$case_dir/project" \
+    "kind=ship" \
+    "mode=no-mistakes"
+  : > "$case_dir/state/task-x0.worktree-returned"
+
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" \
+    || fail "predecessor-returned: teardown failed: $(cat "$case_dir/stderr")"
+  grep -q "return --force $case_dir/wt" "$case_dir/treehouse.log" \
+    || fail "predecessor-returned: the owned slot was never returned: $(cat "$case_dir/treehouse.log")"
+  grep -q "skipping worktree return" "$case_dir/stdout" \
+    && fail "predecessor-returned: the predecessor's stale binding wrongly skipped the return"
+  [ -e "$case_dir/state/task-x0.worktree-returned" ] \
+    || fail "predecessor-returned: the predecessor's own return marker was removed"
+  [ -e "$case_dir/state/task-x0.meta" ] \
+    || fail "predecessor-returned: the predecessor's metadata was removed"
+  [ ! -e "$case_dir/state/task-x1.worktree-returned" ] \
+    || fail "predecessor-returned: the return marker survived a completed teardown"
+  grep -q "teardown task-x1 complete" "$case_dir/stdout" \
+    || fail "predecessor-returned: teardown did not report completion"
+  pass "a returned predecessor's stale binding does not block the current tenant's own return"
+}
+
 test_local_only_fork_remote_allows
 test_teardown_prompts_tasks_axi_done_when_compatible
 test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
@@ -2824,3 +2862,4 @@ test_rerun_after_return_and_reissue_never_rereturns
 test_first_run_still_returns_worktree
 test_rerun_still_bound_unreturned_returns
 test_reissued_slot_without_marker_skips_return
+test_returned_predecessor_binding_does_not_skip_current_return


### PR DESCRIPTION
## Intent

Port the local-only teardown ownership guard onto the current upstream head and ship it as an upstream PR against kunchenguid/firstmate:main.

Background: commit f603232 existed only on this firstmate home's local main and never reached upstream. Upstream has since heavily reworked bin/fm-teardown.sh and both teardown test suites. Verified that upstream does NOT already carry this guard, so it is not redundant. Because a cherry-pick was unavailable in this environment, the guard's intent was RE-FITTED into the current upstream structure of bin/fm-teardown.sh rather than forcing the old hunks in; f603232's commit message body is the deliberate basis for the new commit message.

Behavior contract to preserve exactly: a teardown rerun after a post-return failure must never reset or reap a pool worktree slot that (a) this task already returned - proven by a durable state/<id>.worktree-returned marker touched right after its own successful return and removed by teardown's final cleanup - or (b) another task's meta now records, which proves reissue even when the marker is lost. When either signal shows the slot is no longer this task's, teardown skips the safety inspection, run-abort, worktree process reap, branch delete, hook removal, and the return itself, while tasktmp reaping, the pane close retry, and durable-record cleanup continue unchanged.

Deliberate decisions a reviewer reading only the diff would not know:
- The guard is deliberately scoped to the treehouse pool-return branch and to non-secondmate tasks, exactly as in the original fix. The Orca branch removes its worktree through its own backend call rather than returning a shared pool slot, so it is intentionally out of scope.
- The marker is touched immediately AFTER a successful return and BEFORE any later step can fail; a failed return must NOT write it, so a rerun still performs the return.
- A failure to write the marker warns but does not fail teardown, because live fleet bindings remain as the second signal.
- The AGENTS.md state-layout line for <id>.worktree-returned was re-added and worded consistently with upstream's current AGENTS.md text.
- Four ported test cases were added to tests/fm-teardown.test.sh: an end-to-end replay of the 2026-08-08 incident, a plain first-run return, a rerun with the worktree still bound and un-returned, and the lost-marker reissue caught by fleet bindings alone. All four were verified to FAIL against the unpatched script, so they pin the guard rather than passing vacuously.
- tests/fm-teardown-endpoint-safety.test.sh is deliberately untouched and passes 7/7.
- Known pre-existing, unrelated local-environment failure: herdr-preflight-missing-adapter reproduces identically at origin/main on this host and is NOT caused by this change. It was temporarily disabled only to let the rest of the suite run locally; that temporary edit was reverted and is not in the commit.

Constraints: this changes firstmate's shared tracked material, so .agents/skills/firstmate-coding-guidelines/SKILL.md applies - one sentence per line in Markdown, plain dash never an em dash, no agent co-author, shellcheck-clean bin scripts under the pinned version, and colocated tests extending the existing suite. Delivery route: no write access to origin, so the branch fm/fm-main-rebase-amont must go to the fork Kallas95/firstmate and the PR must open against kunchenguid/firstmate:main. Terminal state is local validation green plus the upstream PR open.

## What Changed

- `bin/fm-teardown.sh` adds a rerun tenant-safety guard: a durable `state/<id>.worktree-returned` marker is touched immediately after this task's own successful pool-worktree return (removed by teardown's final cleanup), and ownership is re-checked on rerun from that marker plus live fleet bindings — another task's meta recording the same worktree path proves reissue even when the marker is lost, while bindings whose task carries its own returned marker are ignored as past tenancies. When either signal shows the slot is no longer this task's, the safety inspection, run-abort, worktree process reap, branch delete, hook removal, and the return itself are skipped; tasktmp reaping, the pane close retry, and durable-record cleanup continue unchanged. A failed marker write warns instead of failing teardown, leaving fleet bindings as the fallback signal.
- `tests/fm-teardown.test.sh` gains four cases pinning the guard: an end-to-end replay of the 2026-08-08 teardown-rerun-reissue incident, a plain first-run return, a rerun whose worktree is still bound and un-returned (the return must still happen), and a lost-marker reissue caught by fleet bindings alone, including ignoring a predecessor's stale past-tenancy binding.
- `AGENTS.md` documents the new `<id>.worktree-returned` state entry, and `docs/architecture.md` qualifies the teardown worktree checks as applying only while the slot is provably still this task's.

## Risk Assessment

✅ Low: The fix round implements the captain-authorized refinement exactly as prescribed (marker-bearing bindings skipped with the same presence test, header contract updated, scan semantics otherwise untouched), adds a colocated behavior-observable regression test that is non-vacuous by inspection against the pre-fix code, leaves no test disabled, and the only remaining observation is an explicitly authorized residual corner that never harms a live tenant.

## Testing

Exercised the teardown ownership guard end-to-end via the colocated suites and swapped-script trees: the endpoint-safety suite passes 7/7, the full teardown suite passes 62/62 at the target commit once the one proven pre-existing local herdr-preflight environment failure (reproduced identically on the pure base commit) is excluded, the new tests were shown to fail against the unpatched and pre-review-fix scripts so they genuinely pin the guard, and an archived CLI transcript of the 2026-08-08 incident replay shows the rerun skipping the re-return while pane close and record cleanup complete and the reissued slot's tenant survives untouched; no UI surface is involved, so CLI transcripts are the product-level evidence.

<details>
<summary>Evidence: Incident replay CLI transcript (attempt 1 fails after the return, rerun skips every worktree step, tenant untouched)</summary>

```text
# Incident replay (teardown-rerun-reissue, 2026-08-08) - CLI transcript
# Sandbox: hermetic fixture from tests/fm-teardown.test.sh::test_rerun_after_return_and_reissue_never_rereturns
# Script under test: bin/fm-teardown.sh at target commit 7213b9b

## Attempt 1: teardown returns the pool worktree, then fails on the refused pane close (the incident's exact failure point)
### stderr:
error: herdr pane default:wG:pQ for task-x1 is not confirmed gone after its close was refused, skipped, or failed; retaining every durable task record - rerun teardown once the close can run under the session lock

### treehouse invocations so far (exactly one return):
return --force /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-teardown-tests.duhMyC/rerun-reissue/wt

### durable marker written right after the successful return:
state/task-x1.worktree-returned existed after attempt 1 (asserted by the test before the rerun)

## Between attempts: the pool reissues the SAME slot to newer task task-x2
task-x2.meta binds worktree=/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-teardown-tests.duhMyC/rerun-reissue/wt ; its session sits on branch fm/task-x2 with uncommitted tenant.txt

## Attempt 2 (sanctioned rerun): stdout
teardown: skipping worktree return and every other worktree step for task-x1: this task's return already succeeded on a previous attempt
teardown task-x1 complete (window default:wG:pQ, worktree /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-teardown-tests.duhMyC/rerun-reissue/wt)
Backlog: task-x1 just finished. Run tasks-axi done task-x1 --note "local main", then run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due.

## After the rerun:
### treehouse invocations in total (STILL exactly one - the reissued slot was never re-returned):
return --force /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-teardown-tests.duhMyC/rerun-reissue/wt

### tenant worktree untouched:
branch: fm/task-x2
uncommitted tenant file: tenant work in flight

### state dir: task-x1 records (meta + worktree-returned marker) cleaned, tenant task-x2.meta preserved:
task-x2.meta
```
</details>
<details>
<summary>Evidence: Fail-before/pass-after regression-pinning matrix (base 6789876, mid 1097082, target 7213b9b)</summary>

```text
# Regression pinning: fail-before / pass-after matrix for the teardown ownership guard
# Trees are pristine 'git archive' extracts; only bin/fm-teardown.sh is swapped per column.
# base   = 6789876 (upstream head, no guard)
# mid    = 1097082 (guard ported, before the review fix)
# target = 7213b9b (guard + review fix: ignore returned predecessors)

## New tests vs base script (no guard):
--- test_rerun_after_return_and_reissue_never_rereturns:
not ok - rerun-reissue: the completed return left no durable marker for the rerun
--- test_first_run_still_returns_worktree:
ok - a first-run teardown of an owned worktree still returns it to the pool
--- test_rerun_still_bound_unreturned_returns:
ok - a rerun with the worktree still bound to this task and un-returned performs the return
--- test_reissued_slot_without_marker_skips_return:
not ok - reissue-no-marker: the reissued slot was still returned: return --force /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-teardown-tests.3jBoAz/reissue-no-marker/wt
--- test_returned_predecessor_binding_does_not_skip_current_return:
ok - a returned predecessor's stale binding does not block the current tenant's own return

## New tests vs mid script (1097082, before the review fix):
--- test_returned_predecessor_binding_does_not_skip_current_return:
not ok - predecessor-returned: the owned slot was never returned: 
--- test_rerun_after_return_and_reissue_never_rereturns:
ok - a rerun after a completed return and a reissued slot closes the pane and cleans records without re-returning

## Reading:
- The incident replay and the lost-marker reissue case FAIL without the guard: they pin the guard itself.
- The first-run and still-bound-rerun cases pass with and without the guard: they pin the non-skip side (the guard must not over-trigger); they fail only if the guard wrongly skips an owned return.
- The returned-predecessor case FAILS at 1097082 and passes at target: it pins the review fix that ignores marker-bearing stale bindings.

## Known pre-existing local failure (not caused by this change):
test_herdr_flat_teardown_preflight_refuses_before_changes (herdr-preflight-missing-adapter) fails identically on the pure base commit on this host:
not ok - herdr-preflight-missing-adapter: teardown continued without its required preflight
```
</details>
<details>
<summary>Evidence: Rerun stdout (the guard&#39;s one-line skip followed by clean completion)</summary>

```text
teardown: skipping worktree return and every other worktree step for task-x1: this task's return already succeeded on a previous attempt
teardown task-x1 complete (window default:wG:pQ, worktree .../rerun-reissue/wt)
```
</details>
- Outcome: ⚠️ 2 infos across 1 run (9m6s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-teardown.sh:2310` - Signal (b) of the tenant-ownership guard can false-positive on a PREDECESSOR&#39;s stale meta: worktree_reissued_to_other_task (loop at bin/fm-teardown.sh:2310) treats any other task&#39;s meta binding the same worktree path as proof of reissue, without excluding a task that has provably relinquished the slot via its own state/&lt;id&gt;.worktree-returned marker. Concrete reachable sequence, the mirror image of the pinned 2026-08-08 incident: task C returns slot S, touches C&#39;s marker, fails on the refused pane close and awaits its sanctioned rerun (C&#39;s meta and marker persist by design); the pool reissues S to task A; A finishes and its FIRST teardown runs before C&#39;s rerun converges; the scan finds C&#39;s meta binding S and sets WORKTREE_OWNED_BY_TASK=0, so A&#39;s teardown skips its own safety inspection (the unlanded/dirty-work refusal is silently bypassed), run-abort, worktree reap, branch delete, hook removal, and the pool return itself, then reports complete and erases A&#39;s durable records - leaking A&#39;s pool lease until manual intervention and leaving A&#39;s branch and hook files in the slot for the next tenant. The failure direction is fail-safe (nothing is destroyed, and the skip line names C), but the window is exactly the operational state this fix targets, so every new tenant of an incident slot that tears down before the old rerun converges hits it. A contract-compatible refinement: in the scan, skip any other task whose own &lt;other_id&gt;.worktree-returned marker exists, since that marker proves its binding is a stale record of an already-returned tenancy rather than a live claim; the intent&#39;s clause (b) (&#39;another task&#39;s meta now records&#39;) still holds for marker-less bindings, and the accepted marker-lost fallback is unchanged. Classified ask-user because the two-signal semantics were deliberately ported &#39;exactly as in the original fix&#39;.

🔧 Fix: ignore returned predecessors when detecting pool slot reissue
1 info still open:
- ℹ️ `bin/fm-teardown.sh:2324` - Residual authorized corner of the captain-approved refinement (documentation only, no action needed): a marker-lost rerun whose successor has ALSO already returned the slot (successor&#39;s own worktree-returned marker present while it awaits its sanctioned rerun) no longer sees that marker-bearing binding as proof of reissue, so the rerunning task re-executes the full worktree path and re-returns an idle pool slot. This requires two overlapping degraded states (this task&#39;s marker lost - a warn-only failure mode - plus the successor inside the post-return-failure window), never touches a live occupant (any marker-bearing binding provably returned the slot; any live tenant&#39;s marker-less meta is still detected), matches the pre-guard baseline behavior for idle slots, and stays behind the safety inspection which re-runs on that path. It is exactly the semantics the captain&#39;s fix instruction authorized (&#39;only a task binding the same worktree path WITHOUT its own return marker proves the slot was reissued&#39;), so it is an accepted tradeoff, not a defect.

</details>

<details>
<summary>⚠️ **Test** - 2 infos</summary>

- ℹ️ `tests/fm-teardown.test.sh` - The intent states all four ported tests were verified to FAIL against the unpatched script, but empirically only two do against the upstream base script (the incident replay and the lost-marker reissue case). test_first_run_still_returns_worktree and test_rerun_still_bound_unreturned_returns pass both before and after the patch: they pin the non-skip side of the contract (the guard must not over-trigger), which only the patched script could violate. The guard is still non-vacuously pinned; only the narrative claim is imprecise.
- ℹ️ `tests/fm-teardown.test.sh` - tests/fm-teardown.test.sh aborts locally at test_herdr_flat_teardown_preflight_refuses_before_changes (herdr-preflight-missing-adapter) before reaching the new tests. I reproduced the identical failure on the pure base commit 6789876 on this host, confirming it is a pre-existing local-environment issue not caused by this change, exactly as the intent discloses. The targeted run excluded only this case; remote CI remains the authority for it.
- <code>`bin/fm-test-run.sh tests/fm-teardown.test.sh tests/fm-teardown-endpoint-safety.test.sh` at target (endpoint-safety 7/7 ok; main suite aborted at the known herdr-preflight-missing-adapter environment failure before reaching the new tests)</code>
- <code>single-test run of `test_herdr_flat_teardown_preflight_refuses_before_changes` on a pristine base-commit (6789876) tree, reproducing the identical failure and proving it pre-existing on this host</code>
- <code>full `tests/fm-teardown.test.sh` at target with only the known-bad preflight case excluded: 62/62 ok including all five new guard tests</code>
- <code>each of the five new tests individually against the unpatched base `bin/fm-teardown.sh` (6789876): incident replay and bindings-only reissue FAIL as designed; first-run, still-bound-rerun, and returned-predecessor pass (they pin the non-skip side)</code>
- <code>`test_returned_predecessor_binding_does_not_skip_current_return` against the pre-review-fix script (1097082): FAILS, pinning the review fix; the incident replay passes there, confirming the ported guard itself</code>
- `manual evidence capture: re-ran the incident replay with fixture cleanup disabled and archived the real fm-teardown.sh transcripts (attempt-1 stderr, rerun stdout, treehouse return log, tenant worktree state, state-dir contents)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
