### PR TITLE
feat(calm): hide internal operational turn acknowledgements from captain chat

### DIFF
--- a/.pi/extensions/lib/fm-calm-assistant-layout.ts
+++ b/.pi/extensions/lib/fm-calm-assistant-layout.ts
@@ -8,7 +8,11 @@
 // ./fm-calm-visibility.ts owns which classes Calm hides.
 import type { AssistantMessageComponent as PiAssistantMessageComponent } from "@earendil-works/pi-coding-agent";
 import * as PiCodingAgent from "@earendil-works/pi-coding-agent";
-import { calmPresentationHides } from "./fm-calm-visibility.ts";
+import {
+  calmOperationalTurnIsActive,
+  calmPresentationHides,
+  calmReplyIsBareAcknowledgement,
+} from "./fm-calm-visibility.ts";
 
 type AssistantMessage = Parameters<PiAssistantMessageComponent["updateContent"]>[0];
 
@@ -21,6 +25,7 @@ type AssistantMessagePresentationState = {
 type CalmAssistantLayoutPatch = {
   hidesThinking: () => boolean;
   hidesWorkingNote: () => boolean;
+  hidesOperationalReply: () => boolean;
 };
 
 // A mid-turn assistant message is one the model did not end its response with: Pi's
@@ -37,6 +42,19 @@ function isMidTurnAssistantMessage(message: AssistantMessage): boolean {
   );
 }
 
+// The reply that closes a turn started by a hidden operational input, and that says
+// nothing the captain needs. A mid-turn message is left to the working-note rule above,
+// so this only ever matches the message the model ended its response with.
+function isOperationalTurnAcknowledgement(message: AssistantMessage): boolean {
+  if (!calmOperationalTurnIsActive()) return false;
+  if (isMidTurnAssistantMessage(message)) return false;
+  const spoken = message.content
+    .filter((block) => block.type === "text")
+    .map((block) => (block as { text?: string }).text ?? "")
+    .join("\n");
+  return calmReplyIsBareAcknowledgement(spoken);
+}
+
 // Keep the introduction-version symbol stable so a compatible upgrade cannot
 // double-patch a live process.
 const CALM_ASSISTANT_LAYOUT_PATCH = Symbol.for(
@@ -49,14 +67,21 @@ export function installCalmAssistantLayout(): void {
   };
   const hidesThinking = (): boolean => calmPresentationHides("assistant-thinking");
   const hidesWorkingNote = (): boolean => calmPresentationHides("assistant-working-note");
+  const hidesOperationalReply = (): boolean =>
+    calmPresentationHides("operational-turn-reply");
   const installed = registry[CALM_ASSISTANT_LAYOUT_PATCH];
   if (installed) {
     installed.hidesThinking = hidesThinking;
     installed.hidesWorkingNote = hidesWorkingNote;
+    installed.hidesOperationalReply = hidesOperationalReply;
     return;
   }
 
-  const patch: CalmAssistantLayoutPatch = { hidesThinking, hidesWorkingNote };
+  const patch: CalmAssistantLayoutPatch = {
+    hidesThinking,
+    hidesWorkingNote,
+    hidesOperationalReply,
+  };
   const AssistantMessageComponent = PiCodingAgent.AssistantMessageComponent;
   if (typeof AssistantMessageComponent !== "function") {
     throw new Error("Firstmate Calm requires Pi AssistantMessageComponent");
@@ -76,14 +101,22 @@ export function installCalmAssistantLayout(): void {
       patch.hidesThinking();
     const hideWorkingNote =
       patch.hidesWorkingNote() && isMidTurnAssistantMessage(message);
+    // The captain asked not to see internal messages in chat. The operational input that
+    // started this turn is already rendered as nothing, so its bare acknowledgement is
+    // the other half of the same internal exchange and is dropped from the rendered rows
+    // too. Only a short acknowledgement qualifies - see calmReplyIsBareAcknowledgement -
+    // so a decision, blocker, finding, review-ready outcome or PR link produced by the
+    // same turn still reaches the captain.
+    const hideOperationalReply =
+      patch.hidesOperationalReply() && isOperationalTurnAcknowledgement(message);
     const presentationMessage =
-      hideThinking || hideWorkingNote
+      hideThinking || hideWorkingNote || hideOperationalReply
         ? {
             ...message,
             content: message.content.filter(
               (block) =>
                 !(hideThinking && block.type === "thinking") &&
-                !(hideWorkingNote && block.type === "text"),
+                !((hideWorkingNote || hideOperationalReply) && block.type === "text"),
             ),
           }
         : message;

--- a/.pi/extensions/lib/fm-calm-assistant-layout.ts
+++ b/.pi/extensions/lib/fm-calm-assistant-layout.ts
@@ -56,7 +56,9 @@ function isOperationalTurnAcknowledgement(message: AssistantMessage): boolean {
 }
 
 // Keep the introduction-version symbol stable so a compatible upgrade cannot
-// double-patch a live process.
+// double-patch a live process. The pin therefore no longer distinguishes later
+// behaviour changes such as operational-reply hiding: after an in-process upgrade the
+// already-installed wrapper stays in charge, so those take effect on the next restart.
 const CALM_ASSISTANT_LAYOUT_PATCH = Symbol.for(
   "firstmate:calm-assistant-layout:pi-0.81.1",
 );

--- a/.pi/extensions/lib/fm-calm-assistant-layout.ts
+++ b/.pi/extensions/lib/fm-calm-assistant-layout.ts
@@ -20,6 +20,7 @@ type AssistantMessagePresentationState = {
   hiddenThinkingLabel: string;
   hideThinkingBlock: boolean;
   lastMessage?: AssistantMessage;
+  calmOperationalTurn?: boolean;
 };
 
 type CalmAssistantLayoutPatch = {
@@ -44,9 +45,18 @@ function isMidTurnAssistantMessage(message: AssistantMessage): boolean {
 
 // The reply that closes a turn started by a hidden operational input, and that says
 // nothing the captain needs. A mid-turn message is left to the working-note rule above,
-// so this only ever matches the message the model ended its response with.
-function isOperationalTurnAcknowledgement(message: AssistantMessage): boolean {
-  if (!calmOperationalTurnIsActive()) return false;
+// so this only ever matches the message the model ended its response with. Which turn
+// this message belongs to is decided by the caller's latched value, never by the current
+// global flag, so a later internal turn cannot re-filter an already-rendered row.
+//
+// Accepted quirk: while a reply streams, the accumulated text can momentarily equal the
+// no-action phrase before the rest arrives, so such a reply flickers before it settles.
+// The final message renders correctly and latching does not change that.
+function isOperationalTurnAcknowledgement(
+  message: AssistantMessage,
+  operationalTurn: boolean,
+): boolean {
+  if (!operationalTurn) return false;
   if (isMidTurnAssistantMessage(message)) return false;
   const spoken = message.content
     .filter((block) => block.type === "text")
@@ -97,6 +107,13 @@ export function installCalmAssistantLayout(): void {
     message: AssistantMessage,
   ): void {
     const state = this as unknown as AssistantMessagePresentationState;
+    // Latch which turn this row belongs to the first time this component receives a
+    // message. A re-layout re-calls updateContent, and Pi cascades that to every chat
+    // child on a terminal resize or a screen switch, so reading the live flag here would
+    // re-judge an already-rendered row under a later turn and could drop a genuine reply
+    // the captain has already seen. Whether Calm hides at all stays live, so toggling
+    // Calm still repaints correctly.
+    state.calmOperationalTurn ??= calmOperationalTurnIsActive();
     const hideThinking =
       state.hiddenThinkingLabel === "" &&
       state.hideThinkingBlock &&
@@ -110,7 +127,8 @@ export function installCalmAssistantLayout(): void {
     // so a decision, blocker, finding, review-ready outcome or PR link produced by the
     // same turn still reaches the captain.
     const hideOperationalReply =
-      patch.hidesOperationalReply() && isOperationalTurnAcknowledgement(message);
+      patch.hidesOperationalReply() &&
+      isOperationalTurnAcknowledgement(message, state.calmOperationalTurn);
     const presentationMessage =
       hideThinking || hideWorkingNote || hideOperationalReply
         ? {

--- a/.pi/extensions/lib/fm-calm-operational-user-layout.ts
+++ b/.pi/extensions/lib/fm-calm-operational-user-layout.ts
@@ -120,7 +120,16 @@ export function installCalmOperationalUserLayout(): void {
     message: UserMessageLike,
     options?: AddMessageOptions,
   ): void {
-    if (message.role !== "user" || !contentIsTextOnly(message.content)) {
+    if (message.role !== "user") {
+      originalAddMessageToChat.call(this, message, options);
+      return;
+    }
+
+    if (!contentIsTextOnly(message.content)) {
+      // Captain input carrying an attachment or an image is still captain input, so the
+      // flag has to describe what was just rendered instead of surviving from an earlier
+      // internal turn and hiding this turn's reply.
+      setCalmOperationalTurn(false);
       originalAddMessageToChat.call(this, message, options);
       return;
     }

--- a/.pi/extensions/lib/fm-calm-operational-user-layout.ts
+++ b/.pi/extensions/lib/fm-calm-operational-user-layout.ts
@@ -121,6 +121,10 @@ export function installCalmOperationalUserLayout(): void {
     options?: AddMessageOptions,
   ): void {
     if (message.role !== "user") {
+      // Captain-run bash, compaction summaries and custom messages all arrive here, so
+      // the flag must not survive them either: it may only stay set for an operational
+      // input this layout actually hid.
+      setCalmOperationalTurn(false);
       originalAddMessageToChat.call(this, message, options);
       return;
     }

--- a/.pi/extensions/lib/fm-calm-operational-user-layout.ts
+++ b/.pi/extensions/lib/fm-calm-operational-user-layout.ts
@@ -121,10 +121,11 @@ export function installCalmOperationalUserLayout(): void {
     options?: AddMessageOptions,
   ): void {
     if (message.role !== "user") {
-      // Captain-run bash, compaction summaries and custom messages all arrive here, so
-      // the flag must not survive them either: it may only stay set for an operational
-      // input this layout actually hid.
-      setCalmOperationalTurn(false);
+      // Only a genuine captain input clears the flag. Pi replays assistant rows through
+      // this same method when it rebuilds the chat after a resume or a compaction, and
+      // the assistant component latches its verdict from its constructor, so clearing
+      // here would wipe the operational turn a moment before its own reply latched and
+      // put an already-hidden acknowledgement back on screen.
       originalAddMessageToChat.call(this, message, options);
       return;
     }
@@ -150,6 +151,11 @@ export function installCalmOperationalUserLayout(): void {
     // assistant layout can recognise that turn's bare acknowledgement as the other half
     // of the same hidden exchange. Delivery, model context and session storage are
     // untouched either way; only rendering differs.
+    //
+    // Accepted quirk: this is recorded even while Calm is off, so a reply can be hidden
+    // after Calm is toggled on mid-session although its input was visible. Only the
+    // prescribed no-action phrase is ever hidden, so nothing captain-relevant is at risk,
+    // and it is what makes a mid-session toggle repaint both halves consistently.
     setCalmOperationalTurn(true);
 
     const component = new CalmOperationalUserMessageComponent(

--- a/.pi/extensions/lib/fm-calm-operational-user-layout.ts
+++ b/.pi/extensions/lib/fm-calm-operational-user-layout.ts
@@ -5,7 +5,7 @@
 // message delivery.
 import type { UserMessageComponent as PiUserMessageComponent } from "@earendil-works/pi-coding-agent";
 import * as PiCodingAgent from "@earendil-works/pi-coding-agent";
-import { calmPresentationHides } from "./fm-calm-visibility.ts";
+import { calmPresentationHides, setCalmOperationalTurn } from "./fm-calm-visibility.ts";
 import { classifyFirstmateCurrentOperationalText } from "./fm-operational-input.ts";
 
 type UserMessageConstructorArgs = ConstructorParameters<typeof PiUserMessageComponent>;
@@ -127,9 +127,17 @@ export function installCalmOperationalUserLayout(): void {
 
     const text = this.getUserMessageText(message);
     if (!text || !patch.isOperationalInput(text)) {
+      // A genuine captain prompt: this turn and its reply belong on screen.
+      setCalmOperationalTurn(false);
       originalAddMessageToChat.call(this, message, options);
       return;
     }
+
+    // An internal operational input. Record that the turn it starts is internal so the
+    // assistant layout can recognise that turn's bare acknowledgement as the other half
+    // of the same hidden exchange. Delivery, model context and session storage are
+    // untouched either way; only rendering differs.
+    setCalmOperationalTurn(true);
 
     const component = new CalmOperationalUserMessageComponent(
       text,

--- a/.pi/extensions/lib/fm-calm-visibility.ts
+++ b/.pi/extensions/lib/fm-calm-visibility.ts
@@ -94,12 +94,13 @@ export function calmOperationalTurnIsActive(): boolean {
 // So this matches the contract phrase and nothing else, and everything unrecognised
 // stays on screen. The cost is that a reply which ignores that contract and improvises
 // its own no-action wording still shows, because presentation cannot tell such a reply
-// apart from a real outcome without reading intent that is not in the text.
+// apart from a real outcome without reading intent that is not in the text. Text with no
+// words is not that phrase either, so it does not match.
 const CALM_NO_ACTION_REPLY = "captain, shipshape";
 
 export function calmReplyIsBareAcknowledgement(text: string): boolean {
   const reply = text.trim();
-  if (!reply) return true;
+  if (!reply) return false;
   const normalised = reply.replace(/\s+/g, " ").replace(/[.!\s]+$/, "").toLowerCase();
   return normalised === CALM_NO_ACTION_REPLY;
 }

--- a/.pi/extensions/lib/fm-calm-visibility.ts
+++ b/.pi/extensions/lib/fm-calm-visibility.ts
@@ -24,6 +24,11 @@ export const CALM_TRANSCRIPT_CLASSES = [
   "project-trust-warning",
   "synthetic-user",
   "synthetic-assistant",
+  // The assistant's own reply to a turn whose input was a hidden operational message.
+  // Deliberately absent from the allowlist below: the captain asked not to see internal
+  // messages in chat, and an internal turn's bare acknowledgement is the other half of
+  // that same internal exchange.
+  "operational-turn-reply",
   "unknown",
 ] as const;
 
@@ -65,6 +70,39 @@ type FirstmateSyntheticPresentation = {
 
 let calm = false;
 let stockExportRendering = false;
+// Whether the most recent chat input was a hidden Firstmate operational message. The
+// operational-user layout sets it as it decides how to render that input, and the
+// assistant layout reads it to recognise that turn's reply. This is presentation state
+// only: it is derived from what was rendered, never consulted by delivery, and it
+// changes no message, no model context, no session entry, and no execution semantics.
+let operationalTurn = false;
+
+export function setCalmOperationalTurn(active: boolean): void {
+  operationalTurn = active;
+}
+
+export function calmOperationalTurnIsActive(): boolean {
+  return operationalTurn;
+}
+
+// The reply that says nothing the captain needs, matched against the exact wording
+// AGENTS.md prescribes for a routine no-action operational update rather than guessed at.
+//
+// An earlier revision hid any short single-line reply. A focused test caught that hiding
+// a genuine one-line escalation, which is the failure that matters here: showing the
+// captain one line of chatter is a nuisance, hiding one decision or blocker is a fault.
+// So this matches the contract phrase and nothing else, and everything unrecognised
+// stays on screen. The cost is that a reply which ignores that contract and improvises
+// its own no-action wording still shows, because presentation cannot tell such a reply
+// apart from a real outcome without reading intent that is not in the text.
+const CALM_NO_ACTION_REPLY = "captain, shipshape";
+
+export function calmReplyIsBareAcknowledgement(text: string): boolean {
+  const reply = text.trim();
+  if (!reply) return true;
+  const normalised = reply.replace(/\s+/g, " ").replace(/[.!\s]+$/, "").toLowerCase();
+  return normalised === CALM_NO_ACTION_REPLY;
+}
 
 export function calmTranscriptClassIsVisible(itemClass: CalmTranscriptClass): boolean {
   return CALM_VISIBLE_CLASSES.has(itemClass);

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ FM_PI_HARNESS=pi-signed pi-signed
 
 For Grok, `--trust` is needed once per clone so project hooks and the turn-end guard load; `/hooks-trust` inside Grok works too.
 For Pi, approve the project trust prompt once per clone on first launch so the tracked `.pi/extensions/*.ts` files auto-load.
-Pi's `/calm` toggle hides supported transcript chrome, including canonically classified Firstmate operational user rows, and uses a Calm-only animated working boat during active runs while preserving all model context and session data.
+Pi's `/calm` toggle hides supported transcript chrome, including canonically classified Firstmate operational user rows and the bare no-action acknowledgement that closes such a turn, and uses a Calm-only animated working boat during active runs while preserving all model context and session data.
 The hidden operational inputs remain ordinary user-role messages with unchanged delivery, ordering, authority, persistence, and exports.
 The preference persists for the effective Firstmate home, and toggling it off restores ordinary rendering.
 [Calm's current behavior and supported limits](docs/calm.md) are separate from its [version-scoped maintainer evidence](docs/calm-mode-feasibility.md).

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -203,7 +203,8 @@ The test fixture enumerates every class below through the centralized policy, an
 | Policy class | Pi transcript path | Calm result (baseline verified on Pi 0.81.1 through 0.82.0; newer evidence noted per row) |
 | --- | --- | --- |
 | `genuine-user-prompt` | `UserMessageComponent` | Visible, including every tested operational near miss. |
-| `genuine-agent-response` | Assistant text in `AssistantMessageComponent` | Visible. |
+| `genuine-agent-response` | Assistant text in `AssistantMessageComponent` | Visible, apart from the `operational-turn-reply` case below. |
+| `operational-turn-reply` | Assistant text in the `AssistantMessageComponent` message the model ended a turn with, when that turn was started by a hidden operational user input | The text blocks are removed from the shallow presentation copy before layout, so the turn's bare acknowledgement occupies zero rows. Matched only against the exact no-action phrase `AGENTS.md` section 9 prescribes, so any decision, blocker, finding, review-ready outcome, or PR link on the same turn stays visible; the row latches its verdict when first laid out, so a re-layout or rebuild never re-judges it. |
 | `assistant-working-note` | Assistant text in an `AssistantMessageComponent` message the model did not end its response with, identified by its own `stopReason` of `toolUse`, or of `length` with tool calls present | The text blocks are removed from the shallow presentation copy before layout, so a `toolUse` message carrying only narration occupies zero rows (verified on Pi 0.84.1); a still-streaming `pending` message is never filtered, so narration is briefly visible before the marker flips. |
 | `assistant-thinking` | Thinking content in `AssistantMessageComponent` | Collapsed reasoning is removed from the shallow presentation copy before layout and occupies zero rows; explicit expansion renders the original reasoning. |
 | `assistant-tool-call` | `ToolExecutionComponent` | Seven built-ins and `fm_watch_arm_pi` hidden; arbitrary custom tools remain an unsupported boundary. |
@@ -225,7 +226,7 @@ The test fixture enumerates every class below through the centralized policy, an
 | `unknown` | Future or unclassified transcript component | Policy-hidden, but no generic renderer exists; never claimed as covered. |
 
 The installed extension API has no supported global transcript filter, user-message renderer, assistant-message renderer, chat-container API, or generic custom-tool wrapper.
-Pi 0.81.1 through 0.82.0 export `AssistantMessageComponent` and `InteractiveMode`, so Calm uses separate idempotent, API-probed adapters for assistant thinking layout and the complete operational-user transcript row while leaving all message data and non-Calm rendering unchanged; see the [compatibility contract](calm.md#pi-compatibility) for how a future Pi lacking one of those exports is handled.
+Pi 0.81.1 through 0.82.0 export `AssistantMessageComponent` and `InteractiveMode`, so Calm uses separate idempotent, API-probed adapters for assistant message layout (thinking, mid-turn working notes, and an internal turn's bare acknowledgement) and the complete operational-user transcript row while leaving all message data and non-Calm rendering unchanged; see the [compatibility contract](calm.md#pi-compatibility) for how a future Pi lacking one of those exports is handled.
 General component replacement, ANSI cursor erasure, provider-context mutation, and installed-file patching remain rejected as unsupported or preservation-breaking workarounds.
 
 ## Cross-harness verification record
@@ -267,6 +268,7 @@ A native deterministic `/skill:ahoy` turn produces thinking, tool-call, and tool
 The operational provider path covers Calm loaded on, loaded off, default preference, extension absent, exact watcher delivery, narrow bare-marker legacy input, persisted restart replay, a genuine captain prompt, and adjacent notifications coalesced into one intended processing turn.
 It asserts one persisted and rendered captain answer, exact user-role operational envelopes in order, no replacement custom messages, one processing result, zero operational transcript rows, and the two-row neighboring-assistant geometry for live, adjacent, and restart paths.
 Quoted current markers, ASCII-only labels, ordinary text before a marker, unrelated U+2063 placement, and image-bearing input remain visible in component and native transcript checks.
+The internal-turn reply path covers Calm off, a genuine captain turn, an internal turn's bare acknowledgement, a review-ready PR link and a decision escalation produced on that same internal turn, captain input carrying an image, re-layout of an already-rendered row in both directions, a resume-style rebuild replayed through `addMessageToChat`, the empty and whitespace-only acknowledgement predicate cases, unchanged message objects, and Calm-off restoration.
 `tests/fm-pi-primary-live-e2e.test.sh` also proves the working ship replaces the built-in `Working...` row while Calm is active on the credentialed provider path, and that it clears when the run settles, before continuing its ordinary watcher lifecycle.
 `tests/fm-pi-primary-types.test.sh` performs strict no-emit TypeScript checking against the installed Pi declarations, currently package version 0.81.1.
 

--- a/docs/calm.md
+++ b/docs/calm.md
@@ -19,6 +19,10 @@ Hiding it removes the narration a model emits alongside its tool calls, while th
 Text that is still streaming is never hidden, because suppressing it would also stop a genuine reply from streaming, so a working note is briefly visible before its row collapses.
 The narration is hidden only from the live transcript presentation, and remains in the message, model context, session storage, and `/export` artifacts.
 The operational inputs remain ordinary user-role messages, while Pi's transcript layout renders their complete rows at zero height.
+The reply that closes such a turn is dropped from the rendered rows too, so an internal exchange does not leave half of itself in the captain's chat.
+That match is deliberately narrow: only the exact no-action acknowledgement `AGENTS.md` section 9 prescribes is treated as internal chatter, and every other reply stays visible so a decision, blocker, finding, review-ready outcome, or PR link can never be hidden by presentation.
+A reply that improvises its own no-action wording instead of using that phrase therefore still shows, because rendering cannot tell it apart from a real outcome.
+None of this changes delivery: the message, the model's context, the session entry, and the export all stay exactly as vanilla Firstmate produced them.
 The session-start nudge remains on its existing non-displayed custom-message path.
 
 Outside Pi's same-name built-in override collision described below, Calm changes presentation only.

--- a/docs/calm.md
+++ b/docs/calm.md
@@ -13,7 +13,7 @@ Hidden elapsed time does not advance the animation, and a resize while hidden cl
 A fresh Pi session or new Calm extension lifetime starts at the normal initial position.
 Very narrow terminals fall back to a smaller deterministic sprite.
 While Calm is off, Pi's stock working row is left exactly as Pi renders it.
-Calm hides collapsed thinking labels, mid-turn assistant working notes, the shells for the Pi built-in tool names Calm owns, the `fm_watch_arm_pi` tool shell, and canonically classified Firstmate operational user rows.
+Calm hides collapsed thinking labels, mid-turn assistant working notes, the shells for the Pi built-in tool names Calm owns, the `fm_watch_arm_pi` tool shell, canonically classified Firstmate operational user rows, and the bare no-action acknowledgement that closes a turn one of those rows started.
 A mid-turn working note is assistant text in a message the model did not end its response with, identified by that message's own `stopReason` of `toolUse`, or of `length` with tool calls present.
 Hiding it removes the narration a model emits alongside its tool calls, while the genuine reply that ends a response stays visible.
 Text that is still streaming is never hidden, because suppressing it would also stop a genuine reply from streaming, so a working note is briefly visible before its row collapses.
@@ -22,7 +22,10 @@ The operational inputs remain ordinary user-role messages, while Pi's transcript
 The reply that closes such a turn is dropped from the rendered rows too, so an internal exchange does not leave half of itself in the captain's chat.
 That match is deliberately narrow: only the exact no-action acknowledgement `AGENTS.md` section 9 prescribes is treated as internal chatter, and every other reply stays visible so a decision, blocker, finding, review-ready outcome, or PR link can never be hidden by presentation.
 A reply that improvises its own no-action wording instead of using that phrase therefore still shows, because rendering cannot tell it apart from a real outcome.
+While such a reply streams its accumulated text can momentarily equal that phrase, so it can flicker before the rest arrives; the settled message renders correctly.
 None of this changes delivery: the message, the model's context, the session entry, and the export all stay exactly as vanilla Firstmate produced them.
+Each rendered reply keeps the verdict it was first laid out with, so a terminal resize, a screen switch, a resume, or a compaction rebuild never re-judges a row the captain has already seen under a later turn.
+Which turn is internal is recorded even while Calm is off, so toggling Calm mid-session repaints both halves of an internal exchange consistently; the only reply that can newly disappear that way is the exact no-action phrase.
 The session-start nudge remains on its existing non-displayed custom-message path.
 
 Outside Pi's same-name built-in override collision described below, Calm changes presentation only.
@@ -40,6 +43,7 @@ These are supported-API boundaries rather than hidden-content failures.
 Calm has no numeric Pi version minimum or maximum and never refuses Pi solely because its version is newer than a previously verified version.
 The collapsed-thinking and operational-user-row presentation adapters probe the exact Pi API seam they patch when Calm loads.
 If Pi removes one of those seams, Calm logs a diagnostic naming the unavailable adapter and skips only that adapter; `/calm`, the other adapter, and unrelated Pi extensions remain available.
+Each adapter is pinned to the API shape it patches rather than to a Calm behaviour revision, so a compatible in-process upgrade keeps the already-installed wrapper in charge and a newer Calm's presentation changes take effect on the next restart.
 
 Calm's built-in tool presentation (`bash`, `read`, `edit`, `write`, `grep`, `find`, `ls`) shares Pi's single, unmerged override slot per name with any other extension that overrides the same tool.
 While the persisted Calm preference is off, Calm registers none of those overrides and therefore contests no built-in tool name.
@@ -51,7 +55,7 @@ If the other extension wins, a session-start console diagnostic names the tool a
 
 [`calm-mode-feasibility.md`](calm-mode-feasibility.md) owns the version-scoped renderer taxonomy, built-in override constraints, and empirical evidence.
 [`configuration.md`](configuration.md#pi-calm-preference-configcalm) owns the persisted preference file and resolution rules.
-`.pi/extensions/lib/fm-calm-visibility.ts` owns the visibility policy, `.pi/extensions/lib/fm-calm-operational-user-layout.ts` owns the zero-height operational-user row adapter, and `.pi/extensions/lib/fm-calm-working-ship.ts` owns the animated working presentation.
+`.pi/extensions/lib/fm-calm-visibility.ts` owns the visibility policy, including the internal-turn flag and the exact no-action acknowledgement phrase, `.pi/extensions/lib/fm-calm-operational-user-layout.ts` owns the zero-height operational-user row adapter and sets that flag from what it just rendered, `.pi/extensions/lib/fm-calm-assistant-layout.ts` owns thinking, working-note, and internal-acknowledgement hiding, and `.pi/extensions/lib/fm-calm-working-ship.ts` owns the animated working presentation.
 
 Regression entry points:
 

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -1369,14 +1369,18 @@ test_calm_hides_operational_turn_acknowledgement() {
   fixture="$TMP_ROOT/calm-operational-reply"
   mkdir -p "$fixture/home" "$fixture/lib" "$fixture/node_modules/@earendil-works"
   cp "$ASSISTANT_LAYOUT" "$fixture/lib/fm-calm-assistant-layout.ts"
+  cp "$OPERATIONAL_USER_LAYOUT" "$fixture/lib/fm-calm-operational-user-layout.ts"
   cp "$VISIBILITY" "$fixture/lib/fm-calm-visibility.ts"
+  cp "$PI_OPERATIONAL_INPUT" "$fixture/lib/fm-operational-input.ts"
   ln -s "$PI_PACKAGE_DIR" "$fixture/node_modules/@earendil-works/pi-coding-agent"
   ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$fixture/node_modules/@earendil-works/pi-tui"
   ln -s "$PI_PACKAGE_DIR/node_modules/typebox" "$fixture/node_modules/typebox"
   printf '{"type":"module"}\n' >"$fixture/package.json"
   output_file="$fixture/node-output"
 
-  (cd "$fixture" && PI_PACKAGE_DIR="$PI_PACKAGE_DIR" node --input-type=module) >"$output_file" 2>&1 <<'JS'
+  (cd "$fixture" && PI_PACKAGE_DIR="$PI_PACKAGE_DIR" \
+    FM_OPERATIONAL_INPUT_SCRIPT="$OPERATIONAL_INPUT" \
+    node --input-type=module) >"$output_file" 2>&1 <<'JS'
 import { pathToFileURL } from "node:url";
 
 const packageRoot = process.env.PI_PACKAGE_DIR;
@@ -1445,6 +1449,60 @@ if (!renderedText("captainRelevant").includes("pull/7")) {
 if (!renderedText("substantive").includes("needs a decision")) {
   throw new Error("a captain-relevant outcome was hidden from the captain");
 }
+
+// The internal-turn flag is set from what the user layout just rendered and from nowhere
+// else, so a captain message that is not text-only - one carrying an image - clears it and
+// its reply stays on screen even when the previous turn was internal.
+const userLayout = await import(pathToFileURL(`${process.cwd()}/lib/fm-calm-operational-user-layout.ts`).href);
+const operationalInput = await import(pathToFileURL(`${process.cwd()}/lib/fm-operational-input.ts`).href);
+const { InteractiveMode } = await import(pathToFileURL(`${packageRoot}/dist/index.js`).href);
+userLayout.installCalmOperationalUserLayout();
+const chatMode = {
+  chatContainer: { children: [], addChild(component) { this.children.push(component); } },
+  editor: { addToHistory() {} },
+  getMarkdownTransformers: () => [],
+  getMarkdownThemeWithSettings: () => undefined,
+  getUserMessageText: (message) => typeof message.content === "string"
+    ? message.content
+    : message.content.filter((item) => item.type === "text").map((item) => item.text).join(""),
+  outputPad: 1,
+};
+const operationalText = operationalInput.encodeFirstmateOperationalInput(
+  "watcher",
+  "FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status",
+);
+InteractiveMode.prototype.addMessageToChat.call(
+  chatMode,
+  { role: "user", content: [{ type: "text", text: operationalText }] },
+);
+if (!visibility.calmOperationalTurnIsActive()) {
+  throw new Error("a hidden operational input did not mark its turn internal");
+}
+if (rendered("acknowledgement").length !== 0) {
+  throw new Error("the internal turn's acknowledgement was rendered");
+}
+InteractiveMode.prototype.addMessageToChat.call(
+  chatMode,
+  { role: "user", content: [{ type: "image", data: "AAAA", mimeType: "image/png" }] },
+);
+if (visibility.calmOperationalTurnIsActive()) {
+  throw new Error("captain input that is not text-only left the previous turn marked internal");
+}
+if (!renderedText("acknowledgement").includes("shipshape")) {
+  throw new Error("a reply to captain input carrying an image was hidden from the captain");
+}
+
+// The acknowledgement predicate means the contract phrase and nothing else.
+if (visibility.calmReplyIsBareAcknowledgement("")) {
+  throw new Error("empty reply text matched the no-action acknowledgement phrase");
+}
+if (visibility.calmReplyIsBareAcknowledgement("   \n ")) {
+  throw new Error("whitespace-only reply text matched the no-action acknowledgement phrase");
+}
+if (!visibility.calmReplyIsBareAcknowledgement("Captain, shipshape.")) {
+  throw new Error("the no-action acknowledgement phrase stopped matching");
+}
+visibility.setCalmOperationalTurn(true);
 
 // Presentation only: the objects the model and the session see are untouched.
 if (JSON.stringify(messages) !== messagesBefore) {

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -1492,6 +1492,37 @@ if (!renderedText("acknowledgement").includes("shipshape")) {
   throw new Error("a reply to captain input carrying an image was hidden from the captain");
 }
 
+// A row decides its visibility from the turn it was laid out for, not from whatever turn
+// is current when it is laid out again. A re-layout - which Pi triggers on a terminal
+// resize or a screen switch - must not drop a reply the captain has already seen.
+visibility.setCalmOperationalTurn(false);
+const captainTurnRow = new AssistantMessageComponent(messages.acknowledgement);
+if (!captainTurnRow.render(100).join("\n").includes("shipshape")) {
+  throw new Error("a reply to a genuine captain prompt was hidden when first laid out");
+}
+visibility.setCalmOperationalTurn(true);
+captainTurnRow.updateContent(messages.acknowledgement);
+if (!captainTurnRow.render(100).join("\n").includes("shipshape")) {
+  throw new Error("a later internal turn hid an already-rendered reply to a captain prompt");
+}
+const internalTurnRow = new AssistantMessageComponent(messages.acknowledgement);
+visibility.setCalmOperationalTurn(false);
+internalTurnRow.updateContent(messages.acknowledgement);
+if (internalTurnRow.render(100).length !== 0) {
+  throw new Error("an internal turn's acknowledgement reappeared after a re-layout");
+}
+
+// Captain-run bash and other non-user rows are captain-side input too, so they clear the
+// internal-turn flag instead of letting it survive into the next reply.
+visibility.setCalmOperationalTurn(true);
+InteractiveMode.prototype.addMessageToChat.call(
+  chatMode,
+  { role: "bashExecution", content: [{ type: "text", text: "!git status" }] },
+);
+if (visibility.calmOperationalTurnIsActive()) {
+  throw new Error("captain-run bash left the previous turn marked internal");
+}
+
 // The acknowledgement predicate means the contract phrase and nothing else.
 if (visibility.calmReplyIsBareAcknowledgement("")) {
   throw new Error("empty reply text matched the no-action acknowledgement phrase");

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -1356,6 +1356,115 @@ JS
   pass "Pi calm centralizes transcript visibility, preserves execution/export data, keeps Pi's stock working row visible while no run is active, and persists its choice across session starts"
 }
 
+# The captain asked not to see internal messages in chat while Firstmate keeps behaving
+# exactly as before. The operational input is already rendered as nothing; this pins the
+# other half - that turn's bare acknowledgement is dropped from the rendered rows only,
+# that a captain-relevant reply on the same turn still reaches the captain, and that the
+# message objects the model and session see are never touched.
+test_calm_hides_operational_turn_acknowledgement() {
+  command -v node >/dev/null 2>&1 || { skip "node not installed"; return 0; }
+  [ -f "$PI_PACKAGE_DIR/package.json" ] || { skip "@earendil-works/pi-coding-agent not installed"; return 0; }
+
+  local fixture output_file
+  fixture="$TMP_ROOT/calm-operational-reply"
+  mkdir -p "$fixture/home" "$fixture/lib" "$fixture/node_modules/@earendil-works"
+  cp "$ASSISTANT_LAYOUT" "$fixture/lib/fm-calm-assistant-layout.ts"
+  cp "$VISIBILITY" "$fixture/lib/fm-calm-visibility.ts"
+  ln -s "$PI_PACKAGE_DIR" "$fixture/node_modules/@earendil-works/pi-coding-agent"
+  ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$fixture/node_modules/@earendil-works/pi-tui"
+  ln -s "$PI_PACKAGE_DIR/node_modules/typebox" "$fixture/node_modules/typebox"
+  printf '{"type":"module"}\n' >"$fixture/package.json"
+  output_file="$fixture/node-output"
+
+  (cd "$fixture" && PI_PACKAGE_DIR="$PI_PACKAGE_DIR" node --input-type=module) >"$output_file" 2>&1 <<'JS'
+import { pathToFileURL } from "node:url";
+
+const packageRoot = process.env.PI_PACKAGE_DIR;
+const [{ AssistantMessageComponent }, { initTheme }, { setCapabilities }] = await Promise.all([
+  import(pathToFileURL(`${packageRoot}/dist/modes/interactive/components/assistant-message.js`).href),
+  import(pathToFileURL(`${packageRoot}/dist/modes/interactive/theme/theme.js`).href),
+  import(pathToFileURL(`${packageRoot}/node_modules/@earendil-works/pi-tui/dist/index.js`).href),
+]);
+initTheme("dark");
+setCapabilities({ images: null, trueColor: true, hyperlinks: false });
+
+const visibility = await import(pathToFileURL(`${process.cwd()}/lib/fm-calm-visibility.ts`).href);
+const layout = await import(pathToFileURL(`${process.cwd()}/lib/fm-calm-assistant-layout.ts`).href);
+layout.installCalmAssistantLayout();
+
+const base = {
+  role: "assistant",
+  api: "calm-operational-reply-test",
+  provider: "calm-operational-reply-test",
+  model: "deterministic",
+  stopReason: "stop",
+  timestamp: 1,
+  usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+const messages = {
+  acknowledgement: { ...base, content: [{ type: "text", text: "Captain, shipshape." }] },
+  captainRelevant: {
+    ...base,
+    content: [{ type: "text", text: "Review-ready: https://github.com/example/repo/pull/7 checks green" }],
+  },
+  substantive: {
+    ...base,
+    content: [{ type: "text", text: "Captain, the promo ticker worker stopped and needs a decision on how to proceed." }],
+  },
+};
+const messagesBefore = JSON.stringify(messages);
+
+// The component lays out its rows when it receives the message, so each assertion builds
+// a fresh one under the presentation state being asserted rather than re-rendering a
+// component laid out under the previous state.
+const rendered = (name) => new AssistantMessageComponent(messages[name]).render(100);
+const renderedText = (name) => rendered(name).join("\n");
+
+// Calm off: nothing is ever hidden, whatever the turn was.
+visibility.setCalmPresentation(false);
+visibility.setCalmOperationalTurn(true);
+for (const name of Object.keys(messages)) {
+  if (rendered(name).length === 0) throw new Error(`Calm off hid ${name}`);
+}
+
+// Calm on, but the turn came from the captain: every reply stays on screen.
+visibility.setCalmPresentation(true);
+visibility.setCalmOperationalTurn(false);
+if (!renderedText("acknowledgement").includes("shipshape")) {
+  throw new Error("Calm hid an acknowledgement to a genuine captain prompt");
+}
+
+// Calm on and the turn was internal: only the bare acknowledgement leaves the chat.
+visibility.setCalmOperationalTurn(true);
+if (rendered("acknowledgement").length !== 0) {
+  throw new Error(`operational acknowledgement still rendered: ${JSON.stringify(rendered("acknowledgement"))}`);
+}
+if (!renderedText("captainRelevant").includes("pull/7")) {
+  throw new Error("a review-ready PR link was hidden from the captain");
+}
+if (!renderedText("substantive").includes("needs a decision")) {
+  throw new Error("a captain-relevant outcome was hidden from the captain");
+}
+
+// Presentation only: the objects the model and the session see are untouched.
+if (JSON.stringify(messages) !== messagesBefore) {
+  throw new Error("Calm mutated the assistant messages instead of only their rendering");
+}
+
+// And it is reversible, so nothing about this is sticky state.
+visibility.setCalmPresentation(false);
+if (rendered("acknowledgement").length === 0) {
+  throw new Error("turning Calm off did not restore the acknowledgement row");
+}
+console.log("OPERATIONAL_REPLY_OK");
+JS
+  local status=$?
+  if [ "$status" -ne 0 ] || ! grep -q OPERATIONAL_REPLY_OK "$output_file"; then
+    fail "Calm operational-reply presentation failed: $(cat "$output_file")"
+  fi
+  pass "Calm hides an internal turn's bare acknowledgement without touching the message or a captain-relevant reply"
+}
+
 test_calm_mid_turn_working_notes() {
   local fixture out output_file status version
   if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
@@ -3928,6 +4037,7 @@ test_builtin_gate_load_time
 test_calm_activation_collision_and_regression_bound
 test_rendering_and_session_lifecycle
 test_calm_mid_turn_working_notes
+test_calm_hides_operational_turn_acknowledgement
 test_operational_followup_turn_e2e
 test_hidden_block_geometry_e2e
 test_working_ship_geometry_and_lifecycle

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -1465,7 +1465,10 @@ const chatMode = {
   getUserMessageText: (message) => typeof message.content === "string"
     ? message.content
     : message.content.filter((item) => item.type === "text").map((item) => item.text).join(""),
+  hideThinkingBlock: false,
+  hiddenThinkingLabel: "",
   outputPad: 1,
+  toolOutputExpanded: false,
 };
 const operationalText = operationalInput.encodeFirstmateOperationalInput(
   "watcher",
@@ -1512,15 +1515,24 @@ if (internalTurnRow.render(100).length !== 0) {
   throw new Error("an internal turn's acknowledgement reappeared after a re-layout");
 }
 
-// Captain-run bash and other non-user rows are captain-side input too, so they clear the
-// internal-turn flag instead of letting it survive into the next reply.
-visibility.setCalmOperationalTurn(true);
-InteractiveMode.prototype.addMessageToChat.call(
-  chatMode,
-  { role: "bashExecution", content: [{ type: "text", text: "!git status" }] },
-);
-if (visibility.calmOperationalTurnIsActive()) {
-  throw new Error("captain-run bash left the previous turn marked internal");
+// A rebuild - what Pi does on a resume or after a compaction - replays every item back
+// through addMessageToChat in order, and each assistant row latches its verdict as it is
+// constructed. The internal turn must survive from its operational input to its own reply,
+// and a genuine captain turn replayed the same way must still reach the captain.
+const replay = (message) => {
+  InteractiveMode.prototype.addMessageToChat.call(chatMode, message);
+  return chatMode.chatContainer.children[chatMode.chatContainer.children.length - 1];
+};
+visibility.setCalmOperationalTurn(false);
+replay({ role: "user", content: [{ type: "text", text: operationalText }] });
+const replayedInternalReply = replay({ ...messages.acknowledgement, role: "assistant" });
+if (replayedInternalReply.render(100).length !== 0) {
+  throw new Error("a rebuild put the internal turn's acknowledgement back on screen");
+}
+replay({ role: "user", content: [{ type: "text", text: "Captain here, carry on." }] });
+const replayedCaptainReply = replay({ ...messages.acknowledgement, role: "assistant" });
+if (!replayedCaptainReply.render(100).join("\n").includes("shipshape")) {
+  throw new Error("a rebuild hid a reply to a genuine captain prompt");
 }
 
 // The acknowledgement predicate means the contract phrase and nothing else.


### PR DESCRIPTION
## Intent

The developer's goal was to clean up Firstmate's Pi chat so the visible captain transcript contains essentially only captain input and captain-facing outcomes, without weakening monitoring: no visible synthetic wake entries for duplicate, obsolete, or already-drained notifications, and no "no action needed" assistant replies, while every AGENTS.md section 8 safety property (durable queue ordering, one healthy supervision cycle, no blind turn end, lock and away-mode ownership, cleanup) stayed intact. They required real root-cause work separating trigger, masking condition, and symptom, a real Pi live E2E plus an isolated Herdr-backed path through the lab helper, deterministic regression coverage that fails on the old implementation, lint and strict typecheck, and explicitly forbade fixing it by disabling stale detection, cutting cadence, swallowing actionable records, or moving to another harness. They then approved shipping through no-mistakes, delegated the gate decisions (option A for the watcher startup barrier, option A for the teardown retire race) while barring --yes and any merge, and approved a public fork (doitdigital0495/firstmate) to work around read-only push access. Finally the developer completely superseded the behavior-changing implementation: abort the active run, settle branch custody, reset to the stated clean base, and reimplement as presentation-only — hiding only the rendered operational acknowledgement while leaving all model/session delivery and vanilla Firstmate behavior untouched and important outcomes visible — then validate and ship that via a cross-fork PR against kunchenguid/firstmate main driven to CI green, without merging.

## What Changed

- Calm now hides the rendered acknowledgement an internal operational turn produces: the Pi user layout marks a turn internal when it hides an operational input, and the assistant layout drops a reply that is exactly the no-action phrase from chat while leaving model and session delivery untouched.
- The internal-turn verdict is latched per assistant row on first render, so re-layout (invalidate, resume, compaction rebuild) cannot re-filter an already-rendered row under a later turn's flag; the flag is cleared only for genuinely captain-side input roles, not for replayed assistant rows.
- Added `calmReplyIsBareAcknowledgement` plus the operational-turn flag accessors in `fm-calm-visibility.ts`, a deterministic regression test in `tests/fm-calm-pi-extension.test.sh` that fails against the pre-change libs, and updated `docs/calm.md`, `docs/calm-mode-feasibility.md`, and `README.md`.

## Risk Assessment

✅ Low: Well-bounded presentation-only change confined to three Pi extension modules, filtering exactly one prescribed phrase with per-row latching and regression tests for the resize and rebuild paths; every residual edge fails toward showing more, not hiding captain-relevant output.

## Testing

Ran the Calm Pi extension suite plus a purpose-built live Pi TUI end-to-end run in tmux with a stub model provider, capturing the captain's actual chat screen at five steps: with Calm off the internal watcher wake and its "Captain, shipshape." reply are both on screen; after /calm both halves of that internal exchange are gone; a captain-typed turn answered with the exact same phrase stays visible; an internal turn answering with a review-ready PR link stays visible; and /calm off restores the whole transcript. The saved session JSONL shows every message, including the hidden ones, delivered and stored unchanged, confirming the change is presentation-only. The new deterministic test passes and fails when run against the base implementation. Two failures in the same suite reproduce at the base commit and stem from the locally installed Pi 0.84.1 versus the suite's pinned 0.81.1, so they are pre-existing rather than regressions.

- Evidence: Pi chat screen across the five e2e steps (annotated composite) (local file: <code>/tmp/no-mistakes-evidence/01M0139H212RQ7XZZ5N1J37QZS/pi-calm-operational-reply.png</code>)
<details>
<summary>Evidence: Calm off: internal wake row + acknowledgement visible</summary>

```text

 pi v0.84.1
 escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more
 Press ctrl+o to show full startup help and loaded resources.

 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.

[Extensions]
  fm-calm-live-inject.ts, fm-calm.ts, fm-primary-pi-watch.ts, fm-primary-turnend-guard.ts


 Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf
 and restart tmux.


 ⁣FIRSTMATE_OP: v1 watcher: FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status


 Captain, shipshape.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
/tmp/fm-calm-live-e2e/project
0.6%/4.1k (auto)                                                                                                     ack
```
</details>
<details>
<summary>Evidence: Calm on: internal exchange hidden</summary>

```text

 pi v0.84.1
 escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more
 Press ctrl+o to show full startup help and loaded resources.

 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.

[Extensions]
  fm-calm-live-inject.ts, fm-calm.ts, fm-primary-pi-watch.ts, fm-primary-turnend-guard.ts


 Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf
 and restart tmux.

 Tool output: collapsed

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
/tmp/fm-calm-live-e2e/project
0.6%/4.1k (auto)                                                                                                     ack
```
</details>
<details>
<summary>Evidence: Captain&#39;s own turn: same phrase still shown</summary>

```text

 pi v0.84.1
 escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more
 Press ctrl+o to show full startup help and loaded resources.

 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.

[Extensions]
  fm-calm-live-inject.ts, fm-calm.ts, fm-primary-pi-watch.ts, fm-primary-turnend-guard.ts


 Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf
 and restart tmux.

 Tool output: collapsed


 Any news, first mate?


 Captain, shipshape.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
/tmp/fm-calm-live-e2e/project
0.9%/4.1k (auto)                                                                                                     ack
```
</details>
<details>
<summary>Evidence: Internal turn with a real outcome: PR link still shown</summary>

```text

 pi v0.84.1
 escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more
 Press ctrl+o to show full startup help and loaded resources.

 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.

[Extensions]
  fm-calm-live-inject.ts, fm-calm.ts, fm-primary-pi-watch.ts, fm-primary-turnend-guard.ts


 Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf
 and restart tmux.

 Tool output: collapsed


 Any news, first mate?


 Captain, shipshape.

 Captain, the promo ticker fix is review-ready: https://github.com/example/repo/pull/7 checks green.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
/tmp/fm-calm-live-e2e/project
1.9%/4.1k (auto)                                                                                                escalate
```
</details>
<details>
<summary>Evidence: Calm off again: full transcript restored</summary>

```text

 pi v0.84.1
 escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more
 Press ctrl+o to show full startup help and loaded resources.

 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.

[Extensions]
  fm-calm-live-inject.ts, fm-calm.ts, fm-primary-pi-watch.ts, fm-primary-turnend-guard.ts


 Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf
 and restart tmux.


 ⁣FIRSTMATE_OP: v1 watcher: FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status


 Captain, shipshape.

 Tool output: collapsed


 Any news, first mate?


 Captain, shipshape.


 ⁣FIRSTMATE_OP: v1 watcher: FIRSTMATE WATCHER WAKE: signal: /tmp/pr.status


 Captain, the promo ticker fix is review-ready: https://github.com/example/repo/pull/7 checks green.

 Tool output: collapsed

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
/tmp/fm-calm-live-e2e/project
1.9%/4.1k (auto)                                                                                                escalate
```
</details>
<details>
<summary>Evidence: Pi session transcript proving hidden rows are still delivered and stored</summary>

```text
{"type":"session","version":3,"id":"22222222-2222-4222-8222-222222222222","timestamp":"2026-08-14T22:08:17.000Z","cwd":"/tmp/fm-calm-live-e2e/project"}
{"type":"model_change","id":"6c20ff93","parentId":null,"timestamp":"2026-08-14T22:08:18.017Z","provider":"calm-live","modelId":"ack"}
{"type":"thinking_level_change","id":"7b2781b7","parentId":"6c20ff93","timestamp":"2026-08-14T22:08:18.018Z","thinkingLevel":"off"}
{"type":"model_change","id":"c2114e6f","parentId":"7b2781b7","timestamp":"2026-08-14T22:08:21.538Z","provider":"calm-live","modelId":"ack"}
{"type":"message","id":"14fad03a","parentId":"c2114e6f","timestamp":"2026-08-14T22:08:21.550Z","message":{"role":"user","content":[{"type":"text","text":"⁣FIRSTMATE_OP: v1 watcher: FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status"}],"timestamp":1786745301544}}
{"type":"message","id":"f6bd06d9","parentId":"14fad03a","timestamp":"2026-08-14T22:08:21.594Z","message":{"role":"assistant","content":[{"type":"text","text":"Captain, shipshape."}],"api":"calm-live-api","provider":"calm-live","model":"ack","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1786745301553}}
{"type":"model_change","id":"b5eb58a7","parentId":"f6bd06d9","timestamp":"2026-08-14T22:08:25.265Z","provider":"calm-live","modelId":"ack"}
{"type":"message","id":"a4a28f6c","parentId":"b5eb58a7","timestamp":"2026-08-14T22:08:26.577Z","message":{"role":"user","content":[{"type":"text","text":"Any news, first mate?"}],"timestamp":1786745306574}}
{"type":"message","id":"7c985ed3","parentId":"a4a28f6c","timestamp":"2026-08-14T22:08:26.619Z","message":{"role":"assistant","content":[{"type":"text","text":"Captain, shipshape."}],"api":"calm-live-api","provider":"calm-live","model":"ack","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1786745306578}}
{"type":"model_change","id":"63b52d32","parentId":"7c985ed3","timestamp":"2026-08-14T22:08:28.993Z","provider":"calm-live","modelId":"escalate"}
{"type":"message","id":"a3cb4684","parentId":"63b52d32","timestamp":"2026-08-14T22:08:29.005Z","message":{"role":"user","content":[{"type":"text","text":"⁣FIRSTMATE_OP: v1 watcher: FIRSTMATE WATCHER WAKE: signal: /tmp/pr.status"}],"timestamp":1786745308999}}
{"type":"message","id":"caa2b014","parentId":"a3cb4684","timestamp":"2026-08-14T22:08:29.047Z","message":{"role":"assistant","content":[{"type":"text","text":"Captain, the promo ticker fix is review-ready: https://github.com/example/repo/pull/7 checks green."}],"api":"calm-live-api","provider":"calm-live","model":"escalate","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1786745309006}}
```
</details>
- Outcome: ⚠️ 1 info across 1 run (6m3s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `.pi/extensions/lib/fm-calm-operational-user-layout.ts:123` - addMessageToChat&#39;s early return for non-text-only user content skips setCalmOperationalTurn(false), so the flag stays true from the prior internal turn. If the captain sends a message with an attachment/image right after an operational input, a genuine reply of exactly &#34;Captain, shipshape.&#34; to that captain message is hidden from chat. Clear the flag (set false) on the role==&#34;user&#34; non-text-only path before delegating.
- ℹ️ `.pi/extensions/lib/fm-calm-assistant-layout.ts:63` - The install symbol is still pinned to &#34;firstmate:calm-assistant-layout:pi-0.81.1&#34;, so an in-process upgrade finds an existing patch object and returns early after only assigning hidesOperationalReply. The previously installed prototype wrapper never reads that field, so operational-reply hiding stays inert until the process restarts. Acceptable tradeoff, but worth noting the version pin no longer distinguishes this behavior change.
- ℹ️ `.pi/extensions/lib/fm-calm-visibility.ts:96` - calmReplyIsBareAcknowledgement returns true for empty/whitespace text, so a final assistant message with no text blocks classifies as a bare acknowledgement during an operational turn. Currently harmless (filtering text blocks is a no-op and non-text blocks survive), but it makes the predicate&#39;s contract broader than &#34;matches the AGENTS.md no-action phrase&#34;.

🔧 Fix: clear internal-turn flag on non-text captain input
3 issues (1 warning, 2 infos) still open:
- ⚠️ `.pi/extensions/lib/fm-calm-assistant-layout.ts:113` - hideOperationalReply is recomputed from the module-global operational-turn flag on every updateContent call, and AssistantMessageComponent.invalidate() re-calls updateContent(this.lastMessage). Pi cascades invalidate() to every chat child (pi-tui tui.js invalidate() -&gt; root.invalidate(); alt-screen implicitDocument.invalidate(); triggered on terminal cell-dimension change, screen switch, mermaid-mode change). So an already-rendered row is re-filtered under a flag belonging to a later turn: a genuine &#39;Captain, shipshape.&#39; reply to a captain prompt, rendered while the flag was false, disappears from the transcript once an internal wake sets the flag true and any invalidate fires. Fix: latch the turn state per component on the first updateContent (e.g. state.calmOperationalTurn ??= calmOperationalTurnIsActive()) so a message&#39;s visibility is decided by its own turn, not by whatever turn is current at re-layout time.
- ℹ️ `.pi/extensions/lib/fm-calm-operational-user-layout.ts:123` - The role!==&#39;user&#39; early return delegates without clearing the flag, but Pi routes captain-run bash (`!cmd`) through addMessageToChat with role &#39;bashExecution&#39;, and compaction summaries / custom messages likewise. Those are genuine captain-side inputs, so the stated invariant (&#39;the only way the flag stays set is an actually-hidden operational input&#39;) does not hold on those paths. Impact today is nil because none of them start a model turn, but clearing the flag on the non-&#39;user&#39; path would make the code match its documented contract.
- ℹ️ `.pi/extensions/lib/fm-calm-assistant-layout.ts:50` - updateContent runs on every streaming delta and stopReason is not yet &#39;toolUse&#39; mid-stream, so a reply that begins &#39;Captain, shipshape.&#39; and then continues with real content will be hidden for the frames where the accumulated text matches exactly, then reappear. Cosmetic flicker only - the final message renders correctly - and per-component latching of the turn flag would not remove it.

🔧 Fix: latch operational-turn verdict per assistant row
2 issues (1 warning, 1 info) still open:
- ⚠️ `.pi/extensions/lib/fm-calm-operational-user-layout.ts:123` - The new blanket setCalmOperationalTurn(false) on the role !== &#34;user&#34; path also fires for assistant messages. Pi&#39;s renderSessionItems (session resume and post-compaction rebuildChatFromMessages, interactive-mode.js:2908) replays assistant messages through addMessageToChat, and the assistant branch constructs AssistantMessageComponent, whose constructor calls updateContent (assistant-message.js:31). So on every rebuild the flag is cleared immediately before the operational turn&#39;s assistant component latches state.calmOperationalTurn, the latch captures false, and the acknowledgement that was hidden live reappears in chat after a resume or compaction. Same defeat happens live if any extension emits a role &#34;custom&#34; message mid-turn (interactive-mode.js:2530). Narrow the clear to the genuinely captain-side roles that were the point of the previous fix (bashExecution, custom, compactionSummary, branchSummary) and leave the flag untouched for assistant/toolResult, so replay latches the same verdict as the live render.
- ℹ️ `.pi/extensions/lib/fm-calm-operational-user-layout.ts:153` - setCalmOperationalTurn(true) runs without consulting patch.hidesOperationalInput(), so with Calm off the operational input is rendered visibly yet the turn is still marked internal. Harmless today because hideOperationalReply separately gates on calmPresentationHides, and it is what makes a mid-session Calm toggle repaint both halves consistently, but the comment&#39;s claim that the flag &#39;may only stay set for an operational input this layout actually hid&#39; is not literally true.

🔧 Fix: clear internal-turn flag only for genuine captain input
2 infos still open:
- ℹ️ `.pi/extensions/lib/fm-calm-operational-user-layout.ts:123` - The role !== &#34;user&#34; early return deliberately no longer clears the internal-turn flag (needed so a rebuild does not wipe it before the assistant row latches). Consequence: any model turn started by something other than a role &#34;user&#34; text message (captain-run bash, a custom/slash-command message) inherits the previous internal turn&#39;s flag, and a reply that is exactly the no-action phrase would be hidden. Impact is bounded to that one phrase and this is the tradeoff explicitly chosen in the prior round, so recording only.
- ℹ️ `.pi/extensions/lib/fm-calm-assistant-layout.ts:116` - The latch depends on the operational input being replayed immediately before its reply. If compaction drops the operational input but keeps the acknowledgement, the replayed assistant row latches whatever the flag happens to be and a previously hidden &#34;Captain, shipshape.&#34; reappears. Fails in the safe direction (shows more, never hides), so no action; noted because the rebuild test only covers the both-items-present ordering.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `tests/fm-calm-pi-extension.test.sh` - Two tests in tests/fm-calm-pi-extension.test.sh fail identically at the base commit 6789876 with the same libs swapped in: `test_operational_followup_turn_e2e` (&#34;Pi follow-up adjacent case rendered a duplicate captain answer&#34;) and `test_interactive_terminal_e2e` (&#34;/export did not complete while calm mode was on&#34;). Pre-existing, environment-related (locally installed Pi is 0.84.1 while the suite records 0.81.1 as known-good); not a regression from this change.
- <code>`bash tests/fm-calm-pi-extension.test.sh` (full Calm suite; new test passes, two pre-existing e2e failures)</code>
- <code>New regression test in isolation: `test_calm_hides_operational_turn_acknowledgement` -&gt; ok</code>
- `Same test run against base-commit (6789876) copies of fm-calm-{assistant-layout,operational-user-layout,visibility}.ts -> fails (setCalmOperationalTurn missing), proving it pins the new behavior`
- <code>Live Pi TUI e2e in tmux (pi 0.84.1, stub provider): inject internal watcher wake answered &#34;Captain, shipshape.&#34; with Calm off, `/calm` on, captain-typed prompt answered with the same phrase, internal wake answered with a PR link, `/calm` off again; pane captured at each step</code>
- `Inspected the resulting Pi session JSONL to confirm every hidden row is still delivered and persisted verbatim`
- `Confirmed the two failing suite tests fail identically with base-commit libs (pre-existing, not a regression)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
