### PR TITLE
fix(bin): add CLAUDE.md symlink hygiene guard

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -461,7 +461,7 @@ If you touch a project \`AGENTS.md\` that lacks \`## Maintaining this file\`, ad
 Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
 
 # Repo hygiene check
-Before you report done, run \`$CLAUDE_SYMLINK_CHECK .\`.
+Before you report done, run \`$CLAUDE_SYMLINK_CHECK .\`. For direct-PR delivery, run this before pushing or opening the PR.
 It is silent and exits 0 in almost every project; it only speaks up when this project keeps \`CLAUDE.md\` as a symlink to \`AGENTS.md\` and your branch lost that symlink - a known git hazard where syncing a branch whose history predates the symlink against a base that already has it hits a "distinct types on each side" conflict, easy to mis-resolve by dropping the file instead of keeping the symlink.
 It checks your working tree and your branch tip, so a restore only counts once you commit it.
 If it reports an error, run the recovery command it prints, then re-run the check until it passes.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -461,7 +461,8 @@ Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced 
 
 # Repo hygiene check
 Before you report done, run \`$FM_ROOT/bin/fm-claude-symlink-check.sh .\`.
-It is silent and exits 0 in almost every project; it only speaks up when this project keeps \`CLAUDE.md\` as a symlink to \`AGENTS.md\` and your branch's working tree lost that symlink - a known git hazard where syncing a branch whose history predates the symlink against a base that already has it hits a "distinct types on each side" conflict, easy to mis-resolve by dropping the file instead of keeping the symlink.
+It is silent and exits 0 in almost every project; it only speaks up when this project keeps \`CLAUDE.md\` as a symlink to \`AGENTS.md\` and your branch lost that symlink - a known git hazard where syncing a branch whose history predates the symlink against a base that already has it hits a "distinct types on each side" conflict, easy to mis-resolve by dropping the file instead of keeping the symlink.
+It checks your working tree and your branch tip, so a restore only counts once you commit it.
 If it reports an error, run the recovery command it prints, then re-run the check until it passes.
 
 $DOD

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -177,6 +177,7 @@ shell_quote() {
 }
 
 STATUS_FILE=$(shell_quote "$STATE/$ID.status")
+CLAUDE_SYMLINK_CHECK=$(shell_quote "$FM_ROOT/bin/fm-claude-symlink-check.sh")
 
 if [ "$KIND" = secondmate ]; then
 SECONDMATE_PROJECTS=""
@@ -460,7 +461,7 @@ If you touch a project \`AGENTS.md\` that lacks \`## Maintaining this file\`, ad
 Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
 
 # Repo hygiene check
-Before you report done, run \`$FM_ROOT/bin/fm-claude-symlink-check.sh .\`.
+Before you report done, run \`$CLAUDE_SYMLINK_CHECK .\`.
 It is silent and exits 0 in almost every project; it only speaks up when this project keeps \`CLAUDE.md\` as a symlink to \`AGENTS.md\` and your branch lost that symlink - a known git hazard where syncing a branch whose history predates the symlink against a base that already has it hits a "distinct types on each side" conflict, easy to mis-resolve by dropping the file instead of keeping the symlink.
 It checks your working tree and your branch tip, so a restore only counts once you commit it.
 If it reports an error, run the recovery command it prints, then re-run the check until it passes.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -462,7 +462,7 @@ Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced 
 
 # Repo hygiene check
 Before you report done, run \`$CLAUDE_SYMLINK_CHECK .\`. For direct-PR delivery, run this before pushing or opening the PR.
-It is silent and exits 0 in almost every project; it only speaks up when this project keeps \`CLAUDE.md\` as a symlink to \`AGENTS.md\` and your branch lost that symlink - a known git hazard where syncing a branch whose history predates the symlink against a base that already has it hits a "distinct types on each side" conflict, easy to mis-resolve by dropping the file instead of keeping the symlink.
+It is silent and exits 0 in almost every project; it only speaks up when the resolved base branch manages \`CLAUDE.md\` as a symlink to its expected target and your branch lost that symlink or its target - a known git hazard where syncing a branch whose history predates the symlink against a base that already has it hits a "distinct types on each side" conflict, easy to mis-resolve by dropping the file instead of keeping the symlink.
 It checks your working tree and your branch tip, so a restore only counts once you commit it.
 If it reports an error, run the recovery command it prints, then re-run the check until it passes.
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -459,6 +459,11 @@ For anything the codebase already shows, prefer a pointer to the authoritative f
 If you touch a project \`AGENTS.md\` that lacks \`## Maintaining this file\`, add that short self-governance section from \`$FM_ROOT/bin/fm-ensure-agents-md.sh\` in the same pass.
 Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
 
+# Repo hygiene check
+Before you report done, run \`$FM_ROOT/bin/fm-claude-symlink-check.sh .\`.
+It is silent and exits 0 in almost every project; it only speaks up when this project keeps \`CLAUDE.md\` as a symlink to \`AGENTS.md\` and your branch's working tree lost that symlink - a known git hazard where syncing a branch whose history predates the symlink against a base that already has it hits a "distinct types on each side" conflict, easy to mis-resolve by dropping the file instead of keeping the symlink.
+If it reports an error, run the recovery command it prints, then re-run the check until it passes.
+
 $DOD
 EOF
 echo "scaffolded: $BRIEF (ship, mode=$MODE; replace {TASK})"

--- a/bin/fm-claude-symlink-check.sh
+++ b/bin/fm-claude-symlink-check.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Guard against a CLAUDE.md -> AGENTS.md symlink silently turning into (or being
+# replaced by) a regular file or a dangling gap during a worker's own branch
+# work, before that state ever reaches a PR.
+#
+# Root cause this guards against: when a project adopts "CLAUDE.md is a symlink
+# to AGENTS.md" as its one-source-of-truth convention, any branch whose history
+# predates that adoption still carries the old regular-file CLAUDE.md blob.
+# Syncing or merging such a branch against a base that now has the symlink hits
+# an ordinary git "distinct types on each side" conflict on that path, and
+# resolving that conflict by hand is error-prone: it is easy to `git rm` or
+# otherwise drop the file instead of keeping the symlink side. This is not a
+# bug in any one tool; it is a routine hazard of merging stale branches, so the
+# only reliable catch is a check that runs late enough to see the real result.
+#
+# Project-agnostic: skips silently (exit 0) whenever the resolved base does not
+# manage CLAUDE.md as a symlink, so it is a no-op everywhere except a project
+# that has actually made this choice.
+#
+# Usage: fm-claude-symlink-check.sh [dir] [base-ref]
+#   dir       repo or worktree to check (default: .)
+#   base-ref  git ref to compare CLAUDE.md against (default: auto-detect the
+#             remote-tracking default branch, falling back to a local one)
+set -eu
+
+usage() {
+  echo "usage: fm-claude-symlink-check.sh [dir] [base-ref]" >&2
+}
+
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+esac
+[ "$#" -le 2 ] || { usage; exit 1; }
+
+DIR=${1:-.}
+[ -d "$DIR" ] || { echo "error: not a directory: $DIR" >&2; exit 1; }
+DIR=$(cd "$DIR" && pwd -P)
+
+git -C "$DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+  echo "error: not a git working tree: $DIR" >&2
+  exit 1
+}
+
+EXPLICIT_BASE=${2:-}
+
+resolve_base() {
+  local name b
+  if [ -n "$EXPLICIT_BASE" ]; then
+    printf '%s\n' "$EXPLICIT_BASE"
+    return 0
+  fi
+  name=$(git -C "$DIR" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+  name=${name#origin/}
+  if [ -z "$name" ]; then
+    for b in main master; do
+      if git -C "$DIR" show-ref --verify --quiet "refs/remotes/origin/$b" ||
+        git -C "$DIR" show-ref --verify --quiet "refs/heads/$b"; then
+        name=$b
+        break
+      fi
+    done
+  fi
+  [ -n "$name" ] || return 1
+  if git -C "$DIR" show-ref --verify --quiet "refs/remotes/origin/$name"; then
+    printf 'origin/%s\n' "$name"
+    return 0
+  fi
+  if git -C "$DIR" show-ref --verify --quiet "refs/heads/$name"; then
+    printf '%s\n' "$name"
+    return 0
+  fi
+  return 1
+}
+
+BASE=$(resolve_base) || {
+  echo "skip: cannot determine a base branch to compare CLAUDE.md against in $DIR"
+  exit 0
+}
+
+# ls-tree output: "<mode> <type> <sha>\t<path>"; empty when the path is absent.
+BASE_ENTRY=$(git -C "$DIR" ls-tree "$BASE" -- CLAUDE.md 2>/dev/null || true)
+if [ -z "$BASE_ENTRY" ]; then
+  echo "skip: $BASE has no CLAUDE.md in $DIR; nothing to guard"
+  exit 0
+fi
+BASE_MODE=$(printf '%s\n' "$BASE_ENTRY" | awk '{print $1}')
+BASE_BLOB=$(printf '%s\n' "$BASE_ENTRY" | awk '{print $3}')
+
+if [ "$BASE_MODE" != 120000 ]; then
+  echo "skip: CLAUDE.md in $BASE is not a symlink in $DIR (mode $BASE_MODE); nothing to guard"
+  exit 0
+fi
+
+EXPECTED_TARGET=$(git -C "$DIR" cat-file -p "$BASE_BLOB")
+
+CLAUDE="$DIR/CLAUDE.md"
+if [ ! -e "$CLAUDE" ] && [ ! -L "$CLAUDE" ]; then
+  echo "error: CLAUDE.md is missing in $DIR, but $BASE manages it as a symlink -> $EXPECTED_TARGET." >&2
+  echo "Restore it: git -C '$DIR' checkout $BASE -- CLAUDE.md   (or: ln -sfn $EXPECTED_TARGET '$CLAUDE')" >&2
+  exit 1
+fi
+if [ ! -L "$CLAUDE" ]; then
+  echo "error: CLAUDE.md in $DIR is a regular file, but $BASE manages it as a symlink -> $EXPECTED_TARGET." >&2
+  echo "This is the classic 'distinct types on each side' merge fallout: a pre-conversion branch clobbered the symlink." >&2
+  echo "Restore it: git -C '$DIR' checkout $BASE -- CLAUDE.md   (or: ln -sfn $EXPECTED_TARGET '$CLAUDE')" >&2
+  exit 1
+fi
+
+ACTUAL_TARGET=$(readlink "$CLAUDE")
+if [ "$ACTUAL_TARGET" != "$EXPECTED_TARGET" ]; then
+  echo "error: CLAUDE.md in $DIR is a symlink to '$ACTUAL_TARGET', but $BASE expects '$EXPECTED_TARGET'." >&2
+  echo "Restore it: git -C '$DIR' checkout $BASE -- CLAUDE.md   (or: ln -sfn $EXPECTED_TARGET '$CLAUDE')" >&2
+  exit 1
+fi
+
+echo "ok: CLAUDE.md -> $EXPECTED_TARGET matches $BASE in $DIR"

--- a/bin/fm-claude-symlink-check.sh
+++ b/bin/fm-claude-symlink-check.sh
@@ -155,30 +155,21 @@ restore_claude_command() {
 }
 
 restore_target_command() {
-  printf 'git -C %s checkout %s -- %s' \
+  printf 'git -C %s --literal-pathspecs checkout %s -- %s' \
     "$(shell_quote "$DIR")" \
     "$(shell_quote "$BASE")" \
     "$(shell_quote "$EXPECTED_TARGET")"
 }
 
 commit_branch_tip_command() {
-  if [ "$1" = 1 ]; then
-    printf 'git -C %s add -- %s %s && git -C %s commit -m %s -- %s %s' \
-      "$(shell_quote "$DIR")" \
-      "$(shell_quote CLAUDE.md)" \
-      "$(shell_quote "$EXPECTED_TARGET")" \
-      "$(shell_quote "$DIR")" \
-      "$(shell_quote 'fix: restore the CLAUDE.md symlink')" \
-      "$(shell_quote CLAUDE.md)" \
-      "$(shell_quote "$EXPECTED_TARGET")"
-  else
-    printf 'git -C %s add -- %s && git -C %s commit -m %s -- %s' \
-      "$(shell_quote "$DIR")" \
-      "$(shell_quote CLAUDE.md)" \
-      "$(shell_quote "$DIR")" \
-      "$(shell_quote 'fix: restore the CLAUDE.md symlink')" \
-      "$(shell_quote CLAUDE.md)"
-  fi
+  printf 'git -C %s --literal-pathspecs add -- %s %s && git -C %s --literal-pathspecs commit -m %s -- %s %s' \
+    "$(shell_quote "$DIR")" \
+    "$(shell_quote CLAUDE.md)" \
+    "$(shell_quote "$EXPECTED_TARGET")" \
+    "$(shell_quote "$DIR")" \
+    "$(shell_quote 'fix: restore the CLAUDE.md symlink')" \
+    "$(shell_quote CLAUDE.md)" \
+    "$(shell_quote "$EXPECTED_TARGET")"
 }
 
 if [ ! -e "$CLAUDE" ] && [ ! -L "$CLAUDE" ]; then
@@ -204,6 +195,15 @@ if [ ! -e "$CLAUDE" ]; then
   echo "Restore the target: $(restore_target_command)" >&2
   exit 1
 fi
+case "$EXPECTED_TARGET" in
+  /*) WORKTREE_TARGET_PATH=$EXPECTED_TARGET ;;
+  *) WORKTREE_TARGET_PATH="$DIR/$EXPECTED_TARGET" ;;
+esac
+if [ ! -f "$WORKTREE_TARGET_PATH" ] || [ -L "$WORKTREE_TARGET_PATH" ]; then
+  echo "error: the expected target '$EXPECTED_TARGET' in $DIR is not a regular non-symlink file." >&2
+  echo "Restore the target: $(restore_target_command)" >&2
+  exit 1
+fi
 
 # What reaches a PR is the committed branch tip, not the working tree: a restore
 # that is left uncommitted keeps the "distinct types on each side" conflict.
@@ -213,7 +213,6 @@ if git -C "$DIR" rev-parse --verify --quiet HEAD >/dev/null; then
     exit 1
   }
   HEAD_PROBLEM=
-  HEAD_NEEDS_TARGET=0
   if [ -z "$HEAD_ENTRY" ]; then
     HEAD_PROBLEM="drops CLAUDE.md entirely"
   else
@@ -235,7 +234,6 @@ if git -C "$DIR" rev-parse --verify --quiet HEAD >/dev/null; then
         }
         if ! tree_entry_is_regular_file "$HEAD_TARGET_ENTRY"; then
           HEAD_PROBLEM="does not carry the expected target '$EXPECTED_TARGET' as a regular file"
-          HEAD_NEEDS_TARGET=1
         fi
       fi
     fi
@@ -243,7 +241,7 @@ if git -C "$DIR" rev-parse --verify --quiet HEAD >/dev/null; then
   if [ -n "$HEAD_PROBLEM" ]; then
     echo "error: the working tree is fine, but your branch tip $HEAD_PROBLEM, while $BASE manages it as a symlink -> $EXPECTED_TARGET." >&2
     echo "That is what a PR would carry, so the 'distinct types on each side' conflict would come back." >&2
-    echo "Commit the restored symlink: $(commit_branch_tip_command "$HEAD_NEEDS_TARGET")" >&2
+    echo "Commit the restored symlink: $(commit_branch_tip_command)" >&2
     exit 1
   fi
 fi

--- a/bin/fm-claude-symlink-check.sh
+++ b/bin/fm-claude-symlink-check.sh
@@ -162,14 +162,23 @@ restore_target_command() {
 }
 
 commit_branch_tip_command() {
-  printf 'git -C %s --literal-pathspecs add -- %s %s && git -C %s --literal-pathspecs commit -m %s -- %s %s' \
-    "$(shell_quote "$DIR")" \
-    "$(shell_quote CLAUDE.md)" \
-    "$(shell_quote "$EXPECTED_TARGET")" \
-    "$(shell_quote "$DIR")" \
-    "$(shell_quote 'fix: restore the CLAUDE.md symlink')" \
-    "$(shell_quote CLAUDE.md)" \
-    "$(shell_quote "$EXPECTED_TARGET")"
+  if [ "$1" = 1 ]; then
+    printf 'git -C %s --literal-pathspecs add -- %s %s && git -C %s --literal-pathspecs commit -m %s -- %s %s' \
+      "$(shell_quote "$DIR")" \
+      "$(shell_quote CLAUDE.md)" \
+      "$(shell_quote "$EXPECTED_TARGET")" \
+      "$(shell_quote "$DIR")" \
+      "$(shell_quote 'fix: restore the CLAUDE.md symlink')" \
+      "$(shell_quote CLAUDE.md)" \
+      "$(shell_quote "$EXPECTED_TARGET")"
+  else
+    printf 'git -C %s --literal-pathspecs add -- %s && git -C %s --literal-pathspecs commit -m %s -- %s' \
+      "$(shell_quote "$DIR")" \
+      "$(shell_quote CLAUDE.md)" \
+      "$(shell_quote "$DIR")" \
+      "$(shell_quote 'fix: restore the CLAUDE.md symlink')" \
+      "$(shell_quote CLAUDE.md)"
+  fi
 }
 
 if [ ! -e "$CLAUDE" ] && [ ! -L "$CLAUDE" ]; then
@@ -213,6 +222,14 @@ if git -C "$DIR" rev-parse --verify --quiet HEAD >/dev/null; then
     exit 1
   }
   HEAD_PROBLEM=
+  HEAD_NEEDS_TARGET=0
+  HEAD_TARGET_ENTRY=$(git -C "$DIR" --literal-pathspecs ls-tree --full-tree HEAD -- "$EXPECTED_TARGET") || {
+    echo "error: cannot read the expected target '$EXPECTED_TARGET' out of HEAD in $DIR" >&2
+    exit 1
+  }
+  if ! tree_entry_is_regular_file "$HEAD_TARGET_ENTRY"; then
+    HEAD_NEEDS_TARGET=1
+  fi
   if [ -z "$HEAD_ENTRY" ]; then
     HEAD_PROBLEM="drops CLAUDE.md entirely"
   else
@@ -227,21 +244,15 @@ if git -C "$DIR" rev-parse --verify --quiet HEAD >/dev/null; then
       }
       if [ "$HEAD_TARGET" != "$EXPECTED_TARGET" ]; then
         HEAD_PROBLEM="carries CLAUDE.md as a symlink to '$HEAD_TARGET'"
-      else
-        HEAD_TARGET_ENTRY=$(git -C "$DIR" --literal-pathspecs ls-tree --full-tree HEAD -- "$EXPECTED_TARGET") || {
-          echo "error: cannot read the expected target '$EXPECTED_TARGET' out of HEAD in $DIR" >&2
-          exit 1
-        }
-        if ! tree_entry_is_regular_file "$HEAD_TARGET_ENTRY"; then
-          HEAD_PROBLEM="does not carry the expected target '$EXPECTED_TARGET' as a regular file"
-        fi
+      elif [ "$HEAD_NEEDS_TARGET" -eq 1 ]; then
+        HEAD_PROBLEM="does not carry the expected target '$EXPECTED_TARGET' as a regular file"
       fi
     fi
   fi
   if [ -n "$HEAD_PROBLEM" ]; then
     echo "error: the working tree is fine, but your branch tip $HEAD_PROBLEM, while $BASE manages it as a symlink -> $EXPECTED_TARGET." >&2
     echo "That is what a PR would carry, so the 'distinct types on each side' conflict would come back." >&2
-    echo "Commit the restored symlink: $(commit_branch_tip_command)" >&2
+    echo "Commit the restored symlink: $(commit_branch_tip_command "$HEAD_NEEDS_TARGET")" >&2
     exit 1
   fi
 fi

--- a/bin/fm-claude-symlink-check.sh
+++ b/bin/fm-claude-symlink-check.sh
@@ -17,6 +17,10 @@
 # manage CLAUDE.md as a symlink, so it is a no-op everywhere except a project
 # that has actually made this choice.
 #
+# Where the base does manage it, both the working tree and the current branch
+# tip must carry the symlink: a PR ships commits, so a restore left uncommitted
+# would still hand the conflict to whoever merges the branch.
+#
 # Usage: fm-claude-symlink-check.sh [dir] [base-ref]
 #   dir       repo or worktree to check (default: .)
 #   base-ref  git ref to compare CLAUDE.md against (default: auto-detect the
@@ -40,6 +44,13 @@ git -C "$DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
   echo "error: not a git working tree: $DIR" >&2
   exit 1
 }
+
+TOPLEVEL=$(git -C "$DIR" rev-parse --show-toplevel 2>/dev/null || true)
+[ -n "$TOPLEVEL" ] || {
+  echo "error: cannot resolve the repository root of $DIR" >&2
+  exit 1
+}
+DIR=$(cd "$TOPLEVEL" && pwd -P)
 
 EXPLICIT_BASE=${2:-}
 
@@ -77,8 +88,16 @@ BASE=$(resolve_base) || {
   exit 0
 }
 
+git -C "$DIR" rev-parse --verify --quiet "$BASE^{tree}" >/dev/null || {
+  echo "error: base ref '$BASE' does not resolve to a tree in $DIR" >&2
+  exit 1
+}
+
 # ls-tree output: "<mode> <type> <sha>\t<path>"; empty when the path is absent.
-BASE_ENTRY=$(git -C "$DIR" ls-tree "$BASE" -- CLAUDE.md 2>/dev/null || true)
+BASE_ENTRY=$(git -C "$DIR" ls-tree --full-tree "$BASE" -- CLAUDE.md) || {
+  echo "error: cannot read CLAUDE.md out of '$BASE' in $DIR" >&2
+  exit 1
+}
 if [ -z "$BASE_ENTRY" ]; then
   echo "skip: $BASE has no CLAUDE.md in $DIR; nothing to guard"
   exit 0
@@ -112,5 +131,40 @@ if [ "$ACTUAL_TARGET" != "$EXPECTED_TARGET" ]; then
   echo "Restore it: git -C '$DIR' checkout $BASE -- CLAUDE.md   (or: ln -sfn $EXPECTED_TARGET '$CLAUDE')" >&2
   exit 1
 fi
+if [ ! -e "$CLAUDE" ]; then
+  echo "error: CLAUDE.md in $DIR is a dangling symlink: its target '$EXPECTED_TARGET' does not exist." >&2
+  echo "Restore the target: git -C '$DIR' checkout $BASE -- '$EXPECTED_TARGET'" >&2
+  exit 1
+fi
 
-echo "ok: CLAUDE.md -> $EXPECTED_TARGET matches $BASE in $DIR"
+# What reaches a PR is the committed branch tip, not the working tree: a restore
+# that is left uncommitted keeps the "distinct types on each side" conflict.
+if git -C "$DIR" rev-parse --verify --quiet HEAD >/dev/null; then
+  HEAD_ENTRY=$(git -C "$DIR" ls-tree --full-tree HEAD -- CLAUDE.md) || {
+    echo "error: cannot read CLAUDE.md out of HEAD in $DIR" >&2
+    exit 1
+  }
+  HEAD_PROBLEM=
+  if [ -z "$HEAD_ENTRY" ]; then
+    HEAD_PROBLEM="drops CLAUDE.md entirely"
+  else
+    HEAD_MODE=$(printf '%s\n' "$HEAD_ENTRY" | awk '{print $1}')
+    HEAD_BLOB=$(printf '%s\n' "$HEAD_ENTRY" | awk '{print $3}')
+    if [ "$HEAD_MODE" != 120000 ]; then
+      HEAD_PROBLEM="still carries CLAUDE.md as a regular file (mode $HEAD_MODE)"
+    else
+      HEAD_TARGET=$(git -C "$DIR" cat-file -p "$HEAD_BLOB")
+      if [ "$HEAD_TARGET" != "$EXPECTED_TARGET" ]; then
+        HEAD_PROBLEM="carries CLAUDE.md as a symlink to '$HEAD_TARGET'"
+      fi
+    fi
+  fi
+  if [ -n "$HEAD_PROBLEM" ]; then
+    echo "error: the working tree is fine, but your branch tip $HEAD_PROBLEM, while $BASE manages it as a symlink -> $EXPECTED_TARGET." >&2
+    echo "That is what a PR would carry, so the 'distinct types on each side' conflict would come back." >&2
+    echo "Commit the restored symlink: git -C '$DIR' add CLAUDE.md && git -C '$DIR' commit -m 'fix: restore the CLAUDE.md symlink'" >&2
+    exit 1
+  fi
+fi
+
+echo "ok: CLAUDE.md -> $EXPECTED_TARGET matches $BASE in $DIR (working tree and branch tip)"

--- a/bin/fm-claude-symlink-check.sh
+++ b/bin/fm-claude-symlink-check.sh
@@ -169,7 +169,7 @@ stage_target_command() {
 
 commit_branch_tip_command() {
   if [ "$1" = 1 ]; then
-    printf 'git -C %s --literal-pathspecs add -- %s && git -C %s --literal-pathspecs add -f -- %s && git -C %s --literal-pathspecs commit -m %s -- %s %s' \
+    printf 'git -C %s --literal-pathspecs add -f -- %s && git -C %s --literal-pathspecs add -f -- %s && git -C %s --literal-pathspecs commit -m %s -- %s %s' \
       "$(shell_quote "$DIR")" \
       "$(shell_quote CLAUDE.md)" \
       "$(shell_quote "$DIR")" \
@@ -179,7 +179,7 @@ commit_branch_tip_command() {
       "$(shell_quote CLAUDE.md)" \
       "$(shell_quote "$EXPECTED_TARGET")"
   else
-    printf 'git -C %s --literal-pathspecs add -- %s && git -C %s --literal-pathspecs commit -m %s -- %s' \
+    printf 'git -C %s --literal-pathspecs add -f -- %s && git -C %s --literal-pathspecs commit -m %s -- %s' \
       "$(shell_quote "$DIR")" \
       "$(shell_quote CLAUDE.md)" \
       "$(shell_quote "$DIR")" \
@@ -328,17 +328,12 @@ if [ "$INDEX_TARGET_LINES" -ne 1 ] || [ "$INDEX_TARGET_STAGE" != 0 ]; then
   exit 1
 fi
 
-INDEX_TREE=$(git -C "$DIR" write-tree 2>/dev/null) || {
-  echo "error: cannot materialize the index as a tree in $DIR." >&2
+INDEX_INTENT_TO_ADD=$(git -C "$DIR" --literal-pathspecs diff-files --name-only --diff-filter=A -- "$EXPECTED_TARGET") || {
+  echo "error: cannot inspect the expected target's index state in $DIR" >&2
   exit 1
 }
-INDEX_TREE_TARGET_ENTRY=$(git -C "$DIR" --literal-pathspecs ls-tree --full-tree "$INDEX_TREE" -- "$EXPECTED_TARGET") || {
-  echo "error: cannot read the expected target '$EXPECTED_TARGET' from the index tree in $DIR" >&2
-  exit 1
-}
-INDEX_TREE_TARGET_LINES=$(printf '%s\n' "$INDEX_TREE_TARGET_ENTRY" | awk 'END {print NR}')
-if [ "$INDEX_TREE_TARGET_LINES" -ne 1 ] || ! tree_entry_is_regular_file "$INDEX_TREE_TARGET_ENTRY"; then
-  echo "error: the expected target '$EXPECTED_TARGET' would not be present as a regular file in the next tree for $DIR." >&2
+if [ -n "$INDEX_INTENT_TO_ADD" ]; then
+  echo "error: the expected target '$EXPECTED_TARGET' is only intent-to-add in the index, so it would not be present in the next tree for $DIR." >&2
   echo "Stage the target in the index: $(stage_target_command)" >&2
   exit 1
 fi

--- a/bin/fm-claude-symlink-check.sh
+++ b/bin/fm-claude-symlink-check.sh
@@ -68,10 +68,6 @@ resolve_base() {
         printf 'origin/%s\n' "$name"
         return 0
       fi
-      if git -C "$DIR" show-ref --verify --quiet "refs/heads/$name"; then
-        printf '%s\n' "$name"
-        return 0
-      fi
       ;;
   esac
   for b in main master; do
@@ -79,6 +75,8 @@ resolve_base() {
       printf 'origin/%s\n' "$b"
       return 0
     fi
+  done
+  for b in main master; do
     if git -C "$DIR" show-ref --verify --quiet "refs/heads/$b"; then
       printf '%s\n' "$b"
       return 0

--- a/bin/fm-claude-symlink-check.sh
+++ b/bin/fm-claude-symlink-check.sh
@@ -162,16 +162,17 @@ restore_target_command() {
 }
 
 stage_target_command() {
-  printf 'git -C %s --literal-pathspecs add -- %s' \
+  printf 'git -C %s --literal-pathspecs add -f -- %s' \
     "$(shell_quote "$DIR")" \
     "$(shell_quote "$EXPECTED_TARGET")"
 }
 
 commit_branch_tip_command() {
   if [ "$1" = 1 ]; then
-    printf 'git -C %s --literal-pathspecs add -- %s %s && git -C %s --literal-pathspecs commit -m %s -- %s %s' \
+    printf 'git -C %s --literal-pathspecs add -- %s && git -C %s --literal-pathspecs add -f -- %s && git -C %s --literal-pathspecs commit -m %s -- %s %s' \
       "$(shell_quote "$DIR")" \
       "$(shell_quote CLAUDE.md)" \
+      "$(shell_quote "$DIR")" \
       "$(shell_quote "$EXPECTED_TARGET")" \
       "$(shell_quote "$DIR")" \
       "$(shell_quote 'fix: restore the CLAUDE.md symlink')" \
@@ -323,6 +324,21 @@ case "$INDEX_TARGET_MODE" in
 esac
 if [ "$INDEX_TARGET_LINES" -ne 1 ] || [ "$INDEX_TARGET_STAGE" != 0 ]; then
   echo "error: the expected target '$EXPECTED_TARGET' has unmerged index entries in $DIR." >&2
+  echo "Stage the target in the index: $(stage_target_command)" >&2
+  exit 1
+fi
+
+INDEX_TREE=$(git -C "$DIR" write-tree 2>/dev/null) || {
+  echo "error: cannot materialize the index as a tree in $DIR." >&2
+  exit 1
+}
+INDEX_TREE_TARGET_ENTRY=$(git -C "$DIR" --literal-pathspecs ls-tree --full-tree "$INDEX_TREE" -- "$EXPECTED_TARGET") || {
+  echo "error: cannot read the expected target '$EXPECTED_TARGET' from the index tree in $DIR" >&2
+  exit 1
+}
+INDEX_TREE_TARGET_LINES=$(printf '%s\n' "$INDEX_TREE_TARGET_ENTRY" | awk 'END {print NR}')
+if [ "$INDEX_TREE_TARGET_LINES" -ne 1 ] || ! tree_entry_is_regular_file "$INDEX_TREE_TARGET_ENTRY"; then
+  echo "error: the expected target '$EXPECTED_TARGET' would not be present as a regular file in the next tree for $DIR." >&2
   echo "Stage the target in the index: $(stage_target_command)" >&2
   exit 1
 fi

--- a/bin/fm-claude-symlink-check.sh
+++ b/bin/fm-claude-symlink-check.sh
@@ -161,6 +161,12 @@ restore_target_command() {
     "$(shell_quote "$EXPECTED_TARGET")"
 }
 
+stage_target_command() {
+  printf 'git -C %s --literal-pathspecs add -- %s' \
+    "$(shell_quote "$DIR")" \
+    "$(shell_quote "$EXPECTED_TARGET")"
+}
+
 commit_branch_tip_command() {
   if [ "$1" = 1 ]; then
     printf 'git -C %s --literal-pathspecs add -- %s %s && git -C %s --literal-pathspecs commit -m %s -- %s %s' \
@@ -301,7 +307,7 @@ INDEX_TARGET_ENTRY=$(git -C "$DIR" --literal-pathspecs ls-files --stage -- "$EXP
 }
 if [ -z "$INDEX_TARGET_ENTRY" ]; then
   echo "error: the expected target '$EXPECTED_TARGET' is missing from the index in $DIR." >&2
-  echo "Restore the target: $(restore_target_command)" >&2
+  echo "Stage the target in the index: $(stage_target_command)" >&2
   exit 1
 fi
 INDEX_TARGET_LINES=$(printf '%s\n' "$INDEX_TARGET_ENTRY" | awk 'END {print NR}')
@@ -311,13 +317,13 @@ case "$INDEX_TARGET_MODE" in
   100*) ;;
   *)
     echo "error: the expected target '$EXPECTED_TARGET' is not staged as a regular file in $DIR." >&2
-    echo "Restore the target: $(restore_target_command)" >&2
+    echo "Stage the target in the index: $(stage_target_command)" >&2
     exit 1
     ;;
 esac
 if [ "$INDEX_TARGET_LINES" -ne 1 ] || [ "$INDEX_TARGET_STAGE" != 0 ]; then
   echo "error: the expected target '$EXPECTED_TARGET' has unmerged index entries in $DIR." >&2
-  echo "Restore the target: $(restore_target_command)" >&2
+  echo "Stage the target in the index: $(stage_target_command)" >&2
   exit 1
 fi
 

--- a/bin/fm-claude-symlink-check.sh
+++ b/bin/fm-claude-symlink-check.sh
@@ -162,7 +162,7 @@ if git -C "$DIR" rev-parse --verify --quiet HEAD >/dev/null; then
   if [ -n "$HEAD_PROBLEM" ]; then
     echo "error: the working tree is fine, but your branch tip $HEAD_PROBLEM, while $BASE manages it as a symlink -> $EXPECTED_TARGET." >&2
     echo "That is what a PR would carry, so the 'distinct types on each side' conflict would come back." >&2
-    echo "Commit the restored symlink: git -C '$DIR' add CLAUDE.md && git -C '$DIR' commit -m 'fix: restore the CLAUDE.md symlink'" >&2
+    echo "Commit the restored symlink: git -C '$DIR' commit -m 'fix: restore the CLAUDE.md symlink' -- CLAUDE.md" >&2
     exit 1
   fi
 fi

--- a/bin/fm-claude-symlink-check.sh
+++ b/bin/fm-claude-symlink-check.sh
@@ -55,36 +55,39 @@ DIR=$(cd "$TOPLEVEL" && pwd -P)
 EXPLICIT_BASE=${2:-}
 
 resolve_base() {
-  local name b
+  local ref name b
   if [ -n "$EXPLICIT_BASE" ]; then
     printf '%s\n' "$EXPLICIT_BASE"
     return 0
   fi
-  name=$(git -C "$DIR" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
-  name=${name#origin/}
-  if [ -z "$name" ]; then
-    for b in main master; do
-      if git -C "$DIR" show-ref --verify --quiet "refs/remotes/origin/$b" ||
-        git -C "$DIR" show-ref --verify --quiet "refs/heads/$b"; then
-        name=$b
-        break
+  ref=$(git -C "$DIR" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+  case "$ref" in
+    origin/*)
+      name=${ref#origin/}
+      if git -C "$DIR" show-ref --verify --quiet "refs/remotes/origin/$name"; then
+        printf 'origin/%s\n' "$name"
+        return 0
       fi
-    done
-  fi
-  [ -n "$name" ] || return 1
-  if git -C "$DIR" show-ref --verify --quiet "refs/remotes/origin/$name"; then
-    printf 'origin/%s\n' "$name"
-    return 0
-  fi
-  if git -C "$DIR" show-ref --verify --quiet "refs/heads/$name"; then
-    printf '%s\n' "$name"
-    return 0
-  fi
+      if git -C "$DIR" show-ref --verify --quiet "refs/heads/$name"; then
+        printf '%s\n' "$name"
+        return 0
+      fi
+      ;;
+  esac
+  for b in main master; do
+    if git -C "$DIR" show-ref --verify --quiet "refs/remotes/origin/$b"; then
+      printf 'origin/%s\n' "$b"
+      return 0
+    fi
+    if git -C "$DIR" show-ref --verify --quiet "refs/heads/$b"; then
+      printf '%s\n' "$b"
+      return 0
+    fi
+  done
   return 1
 }
 
 BASE=$(resolve_base) || {
-  echo "skip: cannot determine a base branch to compare CLAUDE.md against in $DIR"
   exit 0
 }
 
@@ -99,41 +102,106 @@ BASE_ENTRY=$(git -C "$DIR" ls-tree --full-tree "$BASE" -- CLAUDE.md) || {
   exit 1
 }
 if [ -z "$BASE_ENTRY" ]; then
-  echo "skip: $BASE has no CLAUDE.md in $DIR; nothing to guard"
   exit 0
 fi
 BASE_MODE=$(printf '%s\n' "$BASE_ENTRY" | awk '{print $1}')
 BASE_BLOB=$(printf '%s\n' "$BASE_ENTRY" | awk '{print $3}')
 
 if [ "$BASE_MODE" != 120000 ]; then
-  echo "skip: CLAUDE.md in $BASE is not a symlink in $DIR (mode $BASE_MODE); nothing to guard"
   exit 0
 fi
 
-EXPECTED_TARGET=$(git -C "$DIR" cat-file -p "$BASE_BLOB")
+EXPECTED_TARGET=$(git -C "$DIR" cat-file -p "$BASE_BLOB") || {
+  echo "error: cannot read the CLAUDE.md symlink target out of '$BASE' in $DIR" >&2
+  exit 1
+}
+
+tree_entry_is_regular_file() {
+  local entry=$1 mode type
+  [ -n "$entry" ] || return 1
+  mode=$(printf '%s\n' "$entry" | awk '{print $1}')
+  type=$(printf '%s\n' "$entry" | awk '{print $2}')
+  [ "$type" = blob ] || return 1
+  case "$mode" in
+    100*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+BASE_TARGET_ENTRY=$(git -C "$DIR" --literal-pathspecs ls-tree --full-tree "$BASE" -- "$EXPECTED_TARGET") || {
+  echo "error: cannot read the expected target '$EXPECTED_TARGET' out of '$BASE' in $DIR" >&2
+  exit 1
+}
+if ! tree_entry_is_regular_file "$BASE_TARGET_ENTRY"; then
+  echo "error: the expected target '$EXPECTED_TARGET' is not a regular file in '$BASE' in $DIR" >&2
+  exit 1
+fi
 
 CLAUDE="$DIR/CLAUDE.md"
+
+shell_quote() {
+  local value=$1
+  value=${value//\'/\'\\\'\'}
+  printf "'%s'" "$value"
+}
+
+restore_claude_command() {
+  printf 'git -C %s checkout %s -- %s   (or: ln -sfn -- %s %s)' \
+    "$(shell_quote "$DIR")" \
+    "$(shell_quote "$BASE")" \
+    "$(shell_quote CLAUDE.md)" \
+    "$(shell_quote "$EXPECTED_TARGET")" \
+    "$(shell_quote "$CLAUDE")"
+}
+
+restore_target_command() {
+  printf 'git -C %s checkout %s -- %s' \
+    "$(shell_quote "$DIR")" \
+    "$(shell_quote "$BASE")" \
+    "$(shell_quote "$EXPECTED_TARGET")"
+}
+
+commit_branch_tip_command() {
+  if [ "$1" = 1 ]; then
+    printf 'git -C %s add -- %s %s && git -C %s commit -m %s -- %s %s' \
+      "$(shell_quote "$DIR")" \
+      "$(shell_quote CLAUDE.md)" \
+      "$(shell_quote "$EXPECTED_TARGET")" \
+      "$(shell_quote "$DIR")" \
+      "$(shell_quote 'fix: restore the CLAUDE.md symlink')" \
+      "$(shell_quote CLAUDE.md)" \
+      "$(shell_quote "$EXPECTED_TARGET")"
+  else
+    printf 'git -C %s add -- %s && git -C %s commit -m %s -- %s' \
+      "$(shell_quote "$DIR")" \
+      "$(shell_quote CLAUDE.md)" \
+      "$(shell_quote "$DIR")" \
+      "$(shell_quote 'fix: restore the CLAUDE.md symlink')" \
+      "$(shell_quote CLAUDE.md)"
+  fi
+}
+
 if [ ! -e "$CLAUDE" ] && [ ! -L "$CLAUDE" ]; then
   echo "error: CLAUDE.md is missing in $DIR, but $BASE manages it as a symlink -> $EXPECTED_TARGET." >&2
-  echo "Restore it: git -C '$DIR' checkout $BASE -- CLAUDE.md   (or: ln -sfn $EXPECTED_TARGET '$CLAUDE')" >&2
+  echo "Restore it: $(restore_claude_command)" >&2
   exit 1
 fi
 if [ ! -L "$CLAUDE" ]; then
   echo "error: CLAUDE.md in $DIR is a regular file, but $BASE manages it as a symlink -> $EXPECTED_TARGET." >&2
   echo "This is the classic 'distinct types on each side' merge fallout: a pre-conversion branch clobbered the symlink." >&2
-  echo "Restore it: git -C '$DIR' checkout $BASE -- CLAUDE.md   (or: ln -sfn $EXPECTED_TARGET '$CLAUDE')" >&2
+  echo "Restore it: $(restore_claude_command)" >&2
   exit 1
 fi
 
 ACTUAL_TARGET=$(readlink "$CLAUDE")
 if [ "$ACTUAL_TARGET" != "$EXPECTED_TARGET" ]; then
   echo "error: CLAUDE.md in $DIR is a symlink to '$ACTUAL_TARGET', but $BASE expects '$EXPECTED_TARGET'." >&2
-  echo "Restore it: git -C '$DIR' checkout $BASE -- CLAUDE.md   (or: ln -sfn $EXPECTED_TARGET '$CLAUDE')" >&2
+  echo "Restore it: $(restore_claude_command)" >&2
   exit 1
 fi
 if [ ! -e "$CLAUDE" ]; then
   echo "error: CLAUDE.md in $DIR is a dangling symlink: its target '$EXPECTED_TARGET' does not exist." >&2
-  echo "Restore the target: git -C '$DIR' checkout $BASE -- '$EXPECTED_TARGET'" >&2
+  echo "Restore the target: $(restore_target_command)" >&2
   exit 1
 fi
 
@@ -145,6 +213,7 @@ if git -C "$DIR" rev-parse --verify --quiet HEAD >/dev/null; then
     exit 1
   }
   HEAD_PROBLEM=
+  HEAD_NEEDS_TARGET=0
   if [ -z "$HEAD_ENTRY" ]; then
     HEAD_PROBLEM="drops CLAUDE.md entirely"
   else
@@ -153,18 +222,94 @@ if git -C "$DIR" rev-parse --verify --quiet HEAD >/dev/null; then
     if [ "$HEAD_MODE" != 120000 ]; then
       HEAD_PROBLEM="still carries CLAUDE.md as a regular file (mode $HEAD_MODE)"
     else
-      HEAD_TARGET=$(git -C "$DIR" cat-file -p "$HEAD_BLOB")
+      HEAD_TARGET=$(git -C "$DIR" cat-file -p "$HEAD_BLOB") || {
+        echo "error: cannot read the CLAUDE.md symlink target out of HEAD in $DIR" >&2
+        exit 1
+      }
       if [ "$HEAD_TARGET" != "$EXPECTED_TARGET" ]; then
         HEAD_PROBLEM="carries CLAUDE.md as a symlink to '$HEAD_TARGET'"
+      else
+        HEAD_TARGET_ENTRY=$(git -C "$DIR" --literal-pathspecs ls-tree --full-tree HEAD -- "$EXPECTED_TARGET") || {
+          echo "error: cannot read the expected target '$EXPECTED_TARGET' out of HEAD in $DIR" >&2
+          exit 1
+        }
+        if ! tree_entry_is_regular_file "$HEAD_TARGET_ENTRY"; then
+          HEAD_PROBLEM="does not carry the expected target '$EXPECTED_TARGET' as a regular file"
+          HEAD_NEEDS_TARGET=1
+        fi
       fi
     fi
   fi
   if [ -n "$HEAD_PROBLEM" ]; then
     echo "error: the working tree is fine, but your branch tip $HEAD_PROBLEM, while $BASE manages it as a symlink -> $EXPECTED_TARGET." >&2
     echo "That is what a PR would carry, so the 'distinct types on each side' conflict would come back." >&2
-    echo "Commit the restored symlink: git -C '$DIR' add CLAUDE.md && git -C '$DIR' commit -m 'fix: restore the CLAUDE.md symlink' -- CLAUDE.md" >&2
+    echo "Commit the restored symlink: $(commit_branch_tip_command "$HEAD_NEEDS_TARGET")" >&2
     exit 1
   fi
+fi
+
+INDEX_UNMERGED=$(git -C "$DIR" --literal-pathspecs ls-files --unmerged -- CLAUDE.md) || {
+  echo "error: cannot inspect the CLAUDE.md index entry in $DIR" >&2
+  exit 1
+}
+if [ -n "$INDEX_UNMERGED" ]; then
+  echo "error: CLAUDE.md has unmerged index entries in $DIR; resolve the index before reporting done." >&2
+  echo "Restore it: $(restore_claude_command)" >&2
+  exit 1
+fi
+
+INDEX_ENTRY=$(git -C "$DIR" --literal-pathspecs ls-files --stage -- CLAUDE.md) || {
+  echo "error: cannot read the staged CLAUDE.md entry in $DIR" >&2
+  exit 1
+}
+if [ -z "$INDEX_ENTRY" ]; then
+  echo "error: CLAUDE.md is missing from the index in $DIR, so the next commit would drop the symlink." >&2
+  echo "Restore it: $(restore_claude_command)" >&2
+  exit 1
+fi
+INDEX_ENTRY_LINES=$(printf '%s\n' "$INDEX_ENTRY" | awk 'END {print NR}')
+INDEX_MODE=$(printf '%s\n' "$INDEX_ENTRY" | awk '{print $1}')
+INDEX_BLOB=$(printf '%s\n' "$INDEX_ENTRY" | awk '{print $2}')
+INDEX_STAGE=$(printf '%s\n' "$INDEX_ENTRY" | awk '{print $3}')
+if [ "$INDEX_ENTRY_LINES" -ne 1 ] || [ "$INDEX_MODE" != 120000 ] || [ "$INDEX_STAGE" != 0 ]; then
+  echo "error: CLAUDE.md is not staged as the expected symlink in $DIR." >&2
+  echo "Restore it: $(restore_claude_command)" >&2
+  exit 1
+fi
+INDEX_TARGET=$(git -C "$DIR" cat-file -p "$INDEX_BLOB") || {
+  echo "error: cannot read the staged CLAUDE.md symlink target in $DIR" >&2
+  exit 1
+}
+if [ "$INDEX_TARGET" != "$EXPECTED_TARGET" ]; then
+  echo "error: the staged CLAUDE.md symlink in $DIR points at '$INDEX_TARGET', not '$EXPECTED_TARGET'." >&2
+  echo "Restore it: $(restore_claude_command)" >&2
+  exit 1
+fi
+
+INDEX_TARGET_ENTRY=$(git -C "$DIR" --literal-pathspecs ls-files --stage -- "$EXPECTED_TARGET") || {
+  echo "error: cannot read the staged target '$EXPECTED_TARGET' in $DIR" >&2
+  exit 1
+}
+if [ -z "$INDEX_TARGET_ENTRY" ]; then
+  echo "error: the expected target '$EXPECTED_TARGET' is missing from the index in $DIR." >&2
+  echo "Restore the target: $(restore_target_command)" >&2
+  exit 1
+fi
+INDEX_TARGET_LINES=$(printf '%s\n' "$INDEX_TARGET_ENTRY" | awk 'END {print NR}')
+INDEX_TARGET_MODE=$(printf '%s\n' "$INDEX_TARGET_ENTRY" | awk '{print $1}')
+INDEX_TARGET_STAGE=$(printf '%s\n' "$INDEX_TARGET_ENTRY" | awk '{print $3}')
+case "$INDEX_TARGET_MODE" in
+  100*) ;;
+  *)
+    echo "error: the expected target '$EXPECTED_TARGET' is not staged as a regular file in $DIR." >&2
+    echo "Restore the target: $(restore_target_command)" >&2
+    exit 1
+    ;;
+esac
+if [ "$INDEX_TARGET_LINES" -ne 1 ] || [ "$INDEX_TARGET_STAGE" != 0 ]; then
+  echo "error: the expected target '$EXPECTED_TARGET' has unmerged index entries in $DIR." >&2
+  echo "Restore the target: $(restore_target_command)" >&2
+  exit 1
 fi
 
 echo "ok: CLAUDE.md -> $EXPECTED_TARGET matches $BASE in $DIR (working tree and branch tip)"

--- a/bin/fm-claude-symlink-check.sh
+++ b/bin/fm-claude-symlink-check.sh
@@ -162,7 +162,7 @@ if git -C "$DIR" rev-parse --verify --quiet HEAD >/dev/null; then
   if [ -n "$HEAD_PROBLEM" ]; then
     echo "error: the working tree is fine, but your branch tip $HEAD_PROBLEM, while $BASE manages it as a symlink -> $EXPECTED_TARGET." >&2
     echo "That is what a PR would carry, so the 'distinct types on each side' conflict would come back." >&2
-    echo "Commit the restored symlink: git -C '$DIR' commit -m 'fix: restore the CLAUDE.md symlink' -- CLAUDE.md" >&2
+    echo "Commit the restored symlink: git -C '$DIR' add CLAUDE.md && git -C '$DIR' commit -m 'fix: restore the CLAUDE.md symlink' -- CLAUDE.md" >&2
     exit 1
   fi
 fi

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -138,6 +138,7 @@ family_for_basename() {
     fm-classify-decision-key.test.sh|\
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
     fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
+    fm-claude-symlink-check.test.sh|\
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-kimi-harness.test.sh|fm-muse-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
     fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -34,6 +34,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-test-run.sh`         | Behavior-test runner: selection, portable lanes, proven-isolated `--jobs`, coverage guard, timing/JSON |
 | `fm-test-isolation-proof.sh` | Concurrent isolation proof and proven-isolated candidate set owner |
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |
+| `fm-claude-symlink-check.sh` | Read-only guard that a worktree and its branch tip still carry the base branch's `CLAUDE.md` symlink, skipping projects without that convention |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and unhealthy supervision    |
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |
 | `fm-session-lock-lib.sh` | Shared session-lock harness identity (ancestry walk and holder liveness) for fm-lock.sh and the Claude Stop auto-arm |

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -372,18 +372,23 @@ test_ship_project_memory_wording() {
 }
 
 test_ship_repo_hygiene_check_renders_in_every_mode() {
-  local home mode id brief
+  local home mode id brief foreign_root quoted_guard
   home="$TMP_ROOT/repo-hygiene-home"
+  foreign_root="$TMP_ROOT/firstmate helper's root"
+  quoted_guard=$(printf '%s' "$foreign_root/bin/fm-claude-symlink-check.sh" | sed "s/'/'\\\\''/g")
+  quoted_guard="'$quoted_guard'"
   mkdir -p "$home/data"
   for mode in no-mistakes direct-PR local-only; do
     id="brief-hygiene-$mode"
-    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1
+    FM_HOME="$home" FM_ROOT_OVERRIDE="$foreign_root" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1
     brief="$home/data/$id/brief.md"
     assert_present "$brief" "$mode: brief was not scaffolded"
     assert_grep "# Repo hygiene check" "$brief" \
       "$mode: brief missing the repo hygiene check section"
-    assert_grep "bin/fm-claude-symlink-check.sh ." "$brief" \
+    assert_grep "fm-claude-symlink-check.sh" "$brief" \
       "$mode: brief does not tell the worker to run fm-claude-symlink-check.sh"
+    assert_grep "run \`$quoted_guard .\`" "$brief" \
+      "$mode: brief does not shell-quote the hygiene-check executable path"
     assert_grep "run the recovery command it prints, then re-run the check until it passes" "$brief" \
       "$mode: brief lost the recovery-and-recheck instruction"
     assert_grep "a restore only counts once you commit it" "$brief" \

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -393,6 +393,8 @@ test_ship_repo_hygiene_check_renders_in_every_mode() {
       "$mode: brief lost the recovery-and-recheck instruction"
     assert_grep "a restore only counts once you commit it" "$brief" \
       "$mode: brief does not say the restored symlink has to be committed"
+    assert_grep "resolved base branch manages \`CLAUDE.md\` as a symlink to its expected target" "$brief" \
+      "$mode: brief hardcodes an incorrect symlink target"
     if [ "$mode" = direct-PR ]; then
       hygiene_line=$(grep -n "For direct-PR delivery, run this before pushing or opening the PR" "$brief" | cut -d: -f1)
       push_line=$(grep -n "push your branch and open a PR" "$brief" | cut -d: -f1)

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -371,6 +371,25 @@ test_ship_project_memory_wording() {
   pass "fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar"
 }
 
+test_ship_repo_hygiene_check_renders_in_every_mode() {
+  local home mode id brief
+  home="$TMP_ROOT/repo-hygiene-home"
+  mkdir -p "$home/data"
+  for mode in no-mistakes direct-PR local-only; do
+    id="brief-hygiene-$mode"
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1
+    brief="$home/data/$id/brief.md"
+    assert_present "$brief" "$mode: brief was not scaffolded"
+    assert_grep "# Repo hygiene check" "$brief" \
+      "$mode: brief missing the repo hygiene check section"
+    assert_grep "bin/fm-claude-symlink-check.sh ." "$brief" \
+      "$mode: brief does not tell the worker to run fm-claude-symlink-check.sh"
+    assert_grep "run the recovery command it prints, then re-run the check until it passes" "$brief" \
+      "$mode: brief lost the recovery-and-recheck instruction"
+  done
+  pass "fm-brief.sh: every ship mode renders the CLAUDE.md symlink guard before Definition of done"
+}
+
 test_herdr_lab_contract_is_explicit_and_complete() {
   local home id brief
   home="$TMP_ROOT/herdr-lab-home"
@@ -720,6 +739,7 @@ test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording
+test_ship_repo_hygiene_check_renders_in_every_mode
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path
 test_herdr_lab_omission_is_loud_for_ship_and_scout

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -393,6 +393,13 @@ test_ship_repo_hygiene_check_renders_in_every_mode() {
       "$mode: brief lost the recovery-and-recheck instruction"
     assert_grep "a restore only counts once you commit it" "$brief" \
       "$mode: brief does not say the restored symlink has to be committed"
+    if [ "$mode" = direct-PR ]; then
+      hygiene_line=$(grep -n "For direct-PR delivery, run this before pushing or opening the PR" "$brief" | cut -d: -f1)
+      push_line=$(grep -n "push your branch and open a PR" "$brief" | cut -d: -f1)
+      [ -n "$hygiene_line" ] || fail "$mode: brief does not put the hygiene check before direct-PR delivery"
+      [ -n "$push_line" ] || fail "$mode: brief is missing its direct-PR push instruction"
+      [ "$hygiene_line" -lt "$push_line" ] || fail "$mode: hygiene check appears after the direct-PR push instruction"
+    fi
   done
   pass "fm-brief.sh: every ship mode renders the CLAUDE.md symlink guard before Definition of done"
 }

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -386,6 +386,8 @@ test_ship_repo_hygiene_check_renders_in_every_mode() {
       "$mode: brief does not tell the worker to run fm-claude-symlink-check.sh"
     assert_grep "run the recovery command it prints, then re-run the check until it passes" "$brief" \
       "$mode: brief lost the recovery-and-recheck instruction"
+    assert_grep "a restore only counts once you commit it" "$brief" \
+      "$mode: brief does not say the restored symlink has to be committed"
   done
   pass "fm-brief.sh: every ship mode renders the CLAUDE.md symlink guard before Definition of done"
 }

--- a/tests/fm-claude-symlink-check.test.sh
+++ b/tests/fm-claude-symlink-check.test.sh
@@ -174,6 +174,7 @@ assert_branch_tip_recovery() {
   cmd=$(printf '%s\n' "$out" | sed -n 's/^Commit the restored symlink: //p')
   [ -n "$cmd" ] || fail "$label: no branch-tip recovery command was printed: $out"
 
+  # shellcheck disable=SC2030,SC2031 # Git identity is intentionally scoped to this recovery subshell.
   (
     export GIT_AUTHOR_NAME='Firstmate Tests' GIT_AUTHOR_EMAIL='tests@example.invalid'
     export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
@@ -234,6 +235,7 @@ test_branch_tip_missing_target_fails() {
   cmd=$(printf '%s\n' "$out" | sed -n 's/^Commit the restored symlink: //p')
   [ -n "$cmd" ] || fail "missing-target branch tip did not print a recovery commit command: $out"
   assert_contains "$cmd" "'AGENTS.md'" "branch-tip recovery did not include the missing target"
+  # shellcheck disable=SC2030,SC2031 # Git identity is intentionally scoped to this recovery subshell.
   (
     export GIT_AUTHOR_NAME='Firstmate Tests' GIT_AUTHOR_EMAIL='tests@example.invalid'
     export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
@@ -265,6 +267,7 @@ test_branch_tip_recovery_force_adds_ignored_target() {
     "ignored-target recovery did not force-add the known CLAUDE.md path"
   assert_contains "$cmd" "--literal-pathspecs add -f -- 'AGENTS.md'" \
     "ignored-target recovery did not force-add the known target"
+  # shellcheck disable=SC2030,SC2031 # Git identity is intentionally scoped to this recovery subshell.
   (
     export GIT_AUTHOR_NAME='Firstmate Tests' GIT_AUTHOR_EMAIL='tests@example.invalid'
     export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
@@ -295,6 +298,7 @@ test_branch_tip_recovery_preserves_target_work() {
   cmd=$(printf '%s\n' "$out" | sed -n 's/^Commit the restored symlink: //p')
   [ -n "$cmd" ] || fail "target-work recovery did not print a commit command: $out"
   assert_not_contains "$cmd" "'AGENTS.md'" "target-work recovery would include an already committed target"
+  # shellcheck disable=SC2030,SC2031 # Git identity is intentionally scoped to this recovery subshell.
   (
     export GIT_AUTHOR_NAME='Firstmate Tests' GIT_AUTHOR_EMAIL='tests@example.invalid'
     export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
@@ -331,6 +335,7 @@ test_branch_tip_recovery_restores_missing_target_for_regular_claude() {
   cmd=$(printf '%s\n' "$out" | sed -n 's/^Commit the restored symlink: //p')
   [ -n "$cmd" ] || fail "missing-target regular-CLAUDE recovery did not print a commit command: $out"
   assert_contains "$cmd" "'AGENTS.md'" "missing-target regular-CLAUDE recovery omitted the target"
+  # shellcheck disable=SC2030,SC2031 # Git identity is intentionally scoped to this recovery subshell.
   (
     export GIT_AUTHOR_NAME='Firstmate Tests' GIT_AUTHOR_EMAIL='tests@example.invalid'
     export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
@@ -497,6 +502,7 @@ test_recovery_target_pathspecs_are_literal() {
   [ "$rc" -ne 0 ] || fail "expected a branch-tip failure for the missing wildcard target"
   cmd=$(printf '%s\n' "$out" | sed -n 's/^Commit the restored symlink: //p')
   [ -n "$cmd" ] || fail "missing wildcard target did not print a commit recovery command: $out"
+  # shellcheck disable=SC2030,SC2031 # Git identity is intentionally scoped to this recovery subshell.
   (
     export GIT_AUTHOR_NAME='Firstmate Tests' GIT_AUTHOR_EMAIL='tests@example.invalid'
     export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL

--- a/tests/fm-claude-symlink-check.test.sh
+++ b/tests/fm-claude-symlink-check.test.sh
@@ -245,6 +245,72 @@ test_branch_tip_missing_target_fails() {
   pass "fm-claude-symlink-check.sh: branch tips must retain the regular symlink target"
 }
 
+test_branch_tip_recovery_preserves_target_work() {
+  local repo out rc cmd committed staged
+  repo="$TMP_ROOT/recovery-preserves-target-work"
+  fixture_repo "$repo"
+  git -C "$repo" checkout -q -b fm/worker
+  rm "$repo/CLAUDE.md"
+  printf 'stale content\n' > "$repo/CLAUDE.md"
+  git -C "$repo" add CLAUDE.md
+  git -C "$repo" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm demote
+
+  git -C "$repo" checkout main -- CLAUDE.md
+  printf '# target work in progress\n' > "$repo/AGENTS.md"
+  git -C "$repo" add AGENTS.md
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit while the branch tip is demoted, got: $out"
+  cmd=$(printf '%s\n' "$out" | sed -n 's/^Commit the restored symlink: //p')
+  [ -n "$cmd" ] || fail "target-work recovery did not print a commit command: $out"
+  assert_not_contains "$cmd" "'AGENTS.md'" "target-work recovery would include an already committed target"
+  (
+    export GIT_AUTHOR_NAME='Firstmate Tests' GIT_AUTHOR_EMAIL='tests@example.invalid'
+    export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
+    eval "$cmd"
+  ) >/dev/null 2>&1 || fail "target-work recovery command failed: $cmd"
+  committed=$(git -C "$repo" show --name-only --format= HEAD)
+  case "$committed" in
+    *AGENTS.md*) fail "target-work recovery swept target work into its commit: $committed" ;;
+  esac
+  staged=$(git -C "$repo" diff --cached --name-only)
+  assert_contains "$staged" "AGENTS.md" "target-work recovery consumed the staged target work"
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "expected exit 0 after target-work recovery, got $rc: $out"
+  pass "fm-claude-symlink-check.sh: branch-tip recovery preserves target work"
+}
+
+test_branch_tip_recovery_restores_missing_target_for_regular_claude() {
+  local repo out rc cmd
+  repo="$TMP_ROOT/recovery-missing-target-regular-claude"
+  fixture_repo "$repo"
+  git -C "$repo" checkout -q -b fm/worker
+  git -C "$repo" rm -q -- AGENTS.md CLAUDE.md
+  printf 'stale content\n' > "$repo/CLAUDE.md"
+  git -C "$repo" add CLAUDE.md
+  git -C "$repo" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm demote-without-target
+
+  printf '# agents restored\n' > "$repo/AGENTS.md"
+  rm "$repo/CLAUDE.md"
+  ( cd "$repo" && ln -s AGENTS.md CLAUDE.md )
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit for a demoted CLAUDE.md with a missing branch-tip target"
+  cmd=$(printf '%s\n' "$out" | sed -n 's/^Commit the restored symlink: //p')
+  [ -n "$cmd" ] || fail "missing-target regular-CLAUDE recovery did not print a commit command: $out"
+  assert_contains "$cmd" "'AGENTS.md'" "missing-target regular-CLAUDE recovery omitted the target"
+  (
+    export GIT_AUTHOR_NAME='Firstmate Tests' GIT_AUTHOR_EMAIL='tests@example.invalid'
+    export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
+    eval "$cmd"
+  ) >/dev/null 2>&1 || fail "missing-target regular-CLAUDE recovery command failed: $cmd"
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "expected exit 0 after missing-target regular-CLAUDE recovery, got $rc: $out"
+  pass "fm-claude-symlink-check.sh: recovery restores a missing target with a regular branch-tip CLAUDE.md"
+}
+
 test_worktree_target_must_be_regular_file() {
   local repo out rc
   repo="$TMP_ROOT/target-directory"
@@ -452,6 +518,8 @@ test_uncommitted_restore_still_fails
 test_branch_tip_recovery_command_works_from_every_restore_path
 test_branch_tip_dropping_claude_md_fails
 test_branch_tip_missing_target_fails
+test_branch_tip_recovery_preserves_target_work
+test_branch_tip_recovery_restores_missing_target_for_regular_claude
 test_worktree_target_must_be_regular_file
 test_index_rejects_staged_claude_deletion
 test_index_rejects_staged_target_deletion

--- a/tests/fm-claude-symlink-check.test.sh
+++ b/tests/fm-claude-symlink-check.test.sh
@@ -359,6 +359,27 @@ test_index_rejects_staged_target_deletion() {
   pass "fm-claude-symlink-check.sh: staged symlink-target deletion fails"
 }
 
+test_index_target_recovery_preserves_worktree_edits() {
+  local repo out rc cmd
+  repo="$TMP_ROOT/index-target-recovery"
+  fixture_repo "$repo"
+  git -C "$repo" rm --cached -q AGENTS.md
+  printf '# edited target\n' > "$repo/AGENTS.md"
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit when the target is missing from the index"
+  cmd=$(printf '%s\n' "$out" | sed -n 's/^Stage the target in the index: //p')
+  [ -n "$cmd" ] || fail "index-target recovery did not print a staging command: $out"
+  assert_contains "$cmd" "--literal-pathspecs add -- 'AGENTS.md'" \
+    "index-target recovery did not use a literal git add"
+  eval "$cmd" >/dev/null 2>&1 || fail "index-target staging command failed: $cmd"
+  [ "$(cat "$repo/AGENTS.md")" = '# edited target' ] || fail "index-target recovery overwrote worktree edits"
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "expected exit 0 after staging the edited target, got $rc: $out"
+  pass "fm-claude-symlink-check.sh: index-target recovery preserves worktree edits"
+}
+
 test_recovery_commands_quote_repository_operands() {
   local repo base target out rc checkout_cmd ln_cmd
   repo="$TMP_ROOT/recovery-special-'dir"
@@ -523,6 +544,7 @@ test_branch_tip_recovery_restores_missing_target_for_regular_claude
 test_worktree_target_must_be_regular_file
 test_index_rejects_staged_claude_deletion
 test_index_rejects_staged_target_deletion
+test_index_target_recovery_preserves_worktree_edits
 test_recovery_commands_quote_repository_operands
 test_recovery_target_pathspecs_are_literal
 test_repo_without_symlink_policy_skips

--- a/tests/fm-claude-symlink-check.test.sh
+++ b/tests/fm-claude-symlink-check.test.sh
@@ -75,6 +75,85 @@ test_wrong_symlink_target_fails() {
   pass "fm-claude-symlink-check.sh: symlink pointing at the wrong target fails"
 }
 
+test_dangling_symlink_fails() {
+  local repo out rc
+  repo="$TMP_ROOT/dangling"
+  fixture_repo "$repo"
+  rm "$repo/AGENTS.md"
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit when CLAUDE.md dangles, got: $out"
+  assert_contains "$out" "dangling symlink" "dangling CLAUDE.md was not reported as dangling"
+  assert_contains "$out" "checkout main -- 'AGENTS.md'" "error did not include the target-restore command"
+  pass "fm-claude-symlink-check.sh: dangling CLAUDE.md symlink fails"
+}
+
+test_runs_from_a_subdirectory() {
+  local repo out rc
+  repo="$TMP_ROOT/subdir"
+  fixture_repo "$repo"
+  mkdir -p "$repo/pkg"
+  rm "$repo/CLAUDE.md"
+  printf 'stale content\n' > "$repo/CLAUDE.md"
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo/pkg" main 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit when run from a subdirectory of a broken repo, got: $out"
+  assert_contains "$out" "regular file" "subdirectory invocation did not detect the root CLAUDE.md breakage"
+  pass "fm-claude-symlink-check.sh: run from a subdirectory it still checks the repo root"
+}
+
+test_unknown_base_ref_errors() {
+  local repo out rc
+  repo="$TMP_ROOT/bogus-base"
+  fixture_repo "$repo"
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" no-such-ref 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit for an unresolvable base ref, got: $out"
+  assert_contains "$out" "error:" "unresolvable base ref did not report an error"
+  assert_contains "$out" "no-such-ref" "error did not name the unresolvable ref"
+  pass "fm-claude-symlink-check.sh: an unresolvable base ref errors instead of skipping"
+}
+
+test_uncommitted_restore_still_fails() {
+  local repo out rc
+  repo="$TMP_ROOT/uncommitted-restore"
+  fixture_repo "$repo"
+  git -C "$repo" checkout -q -b fm/worker
+  rm "$repo/CLAUDE.md"
+  printf 'stale content\n' > "$repo/CLAUDE.md"
+  git -C "$repo" add CLAUDE.md
+  git -C "$repo" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm demote
+
+  git -C "$repo" checkout main -- CLAUDE.md
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit while the branch tip still carries the broken CLAUDE.md, got: $out"
+  assert_contains "$out" "branch tip" "error did not point at the branch tip"
+  assert_contains "$out" "Commit the restored symlink" "error did not tell the worker to commit the restore"
+
+  git -C "$repo" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm restore
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "expected exit 0 once the restored symlink is committed, got $rc: $out"
+  assert_contains "$out" "ok:" "committed restore did not report ok"
+  pass "fm-claude-symlink-check.sh: a restore only passes once it is committed"
+}
+
+test_branch_tip_dropping_claude_md_fails() {
+  local repo out rc
+  repo="$TMP_ROOT/tip-drops-file"
+  fixture_repo "$repo"
+  git -C "$repo" checkout -q -b fm/worker
+  git -C "$repo" rm -q CLAUDE.md
+  git -C "$repo" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm drop
+  ( cd "$repo" && ln -s AGENTS.md CLAUDE.md )
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit when the branch tip drops CLAUDE.md, got: $out"
+  assert_contains "$out" "drops CLAUDE.md entirely" "error did not describe the dropped file"
+  pass "fm-claude-symlink-check.sh: a branch tip that dropped CLAUDE.md fails"
+}
+
 test_repo_without_symlink_policy_skips() {
   local repo out rc
   repo="$TMP_ROOT/no-policy"
@@ -124,6 +203,11 @@ test_matching_symlink_passes
 test_regular_file_fails_with_recovery_commands
 test_missing_claude_md_fails
 test_wrong_symlink_target_fails
+test_dangling_symlink_fails
+test_runs_from_a_subdirectory
+test_unknown_base_ref_errors
+test_uncommitted_restore_still_fails
+test_branch_tip_dropping_claude_md_fails
 test_repo_without_symlink_policy_skips
 test_repo_without_claude_md_at_all_skips
 test_auto_detects_origin_default_branch

--- a/tests/fm-claude-symlink-check.test.sh
+++ b/tests/fm-claude-symlink-check.test.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-claude-symlink-check.sh.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-claude-symlink-check)
+
+# fixture_repo <dir>: a repo on "main" whose CLAUDE.md is a correct symlink to
+# AGENTS.md.
+fixture_repo() {
+  local repo=$1
+  mkdir -p "$repo"
+  git -C "$repo" init -q
+  printf '# agents\n' > "$repo/AGENTS.md"
+  git -C "$repo" add AGENTS.md
+  ( cd "$repo" && ln -s AGENTS.md CLAUDE.md )
+  git -C "$repo" add CLAUDE.md
+  git -C "$repo" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+  git -C "$repo" branch -M main
+}
+
+test_matching_symlink_passes() {
+  local repo out rc
+  repo="$TMP_ROOT/matching"
+  fixture_repo "$repo"
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "expected exit 0 for a matching symlink, got $rc: $out"
+  assert_contains "$out" "ok:" "matching symlink did not report ok"
+  pass "fm-claude-symlink-check.sh: matching CLAUDE.md symlink passes"
+}
+
+test_regular_file_fails_with_recovery_commands() {
+  local repo out rc
+  repo="$TMP_ROOT/regular-file"
+  fixture_repo "$repo"
+  rm "$repo/CLAUDE.md"
+  printf 'stale content\n' > "$repo/CLAUDE.md"
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit when CLAUDE.md is a regular file"
+  assert_contains "$out" "error:" "regular-file breakage did not report an error"
+  assert_contains "$out" "regular file" "error did not name the actual problem"
+  assert_contains "$out" "checkout main -- CLAUDE.md" "error did not include the git checkout recovery command"
+  assert_contains "$out" "ln -sfn AGENTS.md" "error did not include the ln -sfn recovery command"
+  pass "fm-claude-symlink-check.sh: CLAUDE.md demoted to a regular file fails with recovery commands"
+}
+
+test_missing_claude_md_fails() {
+  local repo out rc
+  repo="$TMP_ROOT/missing"
+  fixture_repo "$repo"
+  rm "$repo/CLAUDE.md"
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit when CLAUDE.md is missing"
+  assert_contains "$out" "error:" "missing CLAUDE.md did not report an error"
+  assert_contains "$out" "missing" "error did not describe the file as missing"
+  pass "fm-claude-symlink-check.sh: missing CLAUDE.md fails"
+}
+
+test_wrong_symlink_target_fails() {
+  local repo out rc
+  repo="$TMP_ROOT/wrong-target"
+  fixture_repo "$repo"
+  rm "$repo/CLAUDE.md"
+  ( cd "$repo" && ln -s WRONG.md CLAUDE.md )
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit for a symlink pointing at the wrong target"
+  assert_contains "$out" "error:" "wrong-target symlink did not report an error"
+  assert_contains "$out" "WRONG.md" "error did not name the actual (wrong) target"
+  pass "fm-claude-symlink-check.sh: symlink pointing at the wrong target fails"
+}
+
+test_repo_without_symlink_policy_skips() {
+  local repo out rc
+  repo="$TMP_ROOT/no-policy"
+  mkdir -p "$repo"
+  git -C "$repo" init -q
+  printf '# claude\n' > "$repo/CLAUDE.md"
+  git -C "$repo" add CLAUDE.md
+  git -C "$repo" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+  git -C "$repo" branch -M main
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "expected exit 0 for a repo without a CLAUDE.md symlink policy, got $rc: $out"
+  assert_contains "$out" "skip:" "repo without a symlink policy did not report skip"
+  pass "fm-claude-symlink-check.sh: repo without a CLAUDE.md symlink policy skips silently"
+}
+
+test_repo_without_claude_md_at_all_skips() {
+  local repo out rc
+  repo="$TMP_ROOT/no-claude-file"
+  fm_git_init_commit "$repo"
+  git -C "$repo" branch -M main
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "expected exit 0 for a repo with no CLAUDE.md at all, got $rc: $out"
+  assert_contains "$out" "skip:" "repo without any CLAUDE.md did not report skip"
+  pass "fm-claude-symlink-check.sh: repo with no CLAUDE.md at all skips silently"
+}
+
+test_auto_detects_origin_default_branch() {
+  local repo bare out rc
+  repo="$TMP_ROOT/auto-detect-src"
+  bare="$TMP_ROOT/auto-detect-bare"
+  fixture_repo "$repo"
+  fm_git_add_origin "$repo" "$bare"
+  git -C "$repo" fetch --quiet origin
+  git -C "$repo" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
+  rm "$repo/CLAUDE.md"
+  printf 'stale content\n' > "$repo/CLAUDE.md"
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit with auto-detected origin/main base, got: $out"
+  assert_contains "$out" "origin/main" "auto-detected base was not origin/main"
+  pass "fm-claude-symlink-check.sh: auto-detects the origin default branch when no base-ref is given"
+}
+
+test_matching_symlink_passes
+test_regular_file_fails_with_recovery_commands
+test_missing_claude_md_fails
+test_wrong_symlink_target_fails
+test_repo_without_symlink_policy_skips
+test_repo_without_claude_md_at_all_skips
+test_auto_detects_origin_default_branch

--- a/tests/fm-claude-symlink-check.test.sh
+++ b/tests/fm-claude-symlink-check.test.sh
@@ -139,6 +139,46 @@ test_uncommitted_restore_still_fails() {
   pass "fm-claude-symlink-check.sh: a restore only passes once it is committed"
 }
 
+test_branch_tip_recovery_command_commits_only_claude_md() {
+  local repo out rc cmd committed staged
+  repo="$TMP_ROOT/recovery-command-scope"
+  fixture_repo "$repo"
+  git -C "$repo" checkout -q -b fm/worker
+  rm "$repo/CLAUDE.md"
+  printf 'stale content\n' > "$repo/CLAUDE.md"
+  git -C "$repo" add CLAUDE.md
+  git -C "$repo" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm demote
+
+  printf 'unrelated work in progress\n' > "$repo/feature.txt"
+  git -C "$repo" add feature.txt
+  git -C "$repo" checkout main -- CLAUDE.md
+
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit while the branch tip is still broken, got: $out"
+  cmd=$(printf '%s\n' "$out" | sed -n 's/^Commit the restored symlink: //p')
+  [ -n "$cmd" ] || fail "no branch-tip recovery command was printed: $out"
+
+  (
+    export GIT_AUTHOR_NAME='Firstmate Tests' GIT_AUTHOR_EMAIL='tests@example.invalid'
+    export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
+    eval "$cmd"
+  ) >/dev/null 2>&1 || fail "the printed recovery command failed: $cmd"
+
+  committed=$(git -C "$repo" show --name-only --format= HEAD)
+  assert_contains "$committed" "CLAUDE.md" "the recovery commit did not restore CLAUDE.md"
+  case "$committed" in
+    *feature.txt*) fail "the recovery command swept unrelated staged work into its commit: $committed" ;;
+  esac
+  staged=$(git -C "$repo" diff --cached --name-only)
+  assert_contains "$staged" "feature.txt" "the recovery command consumed unrelated staged work instead of leaving it staged"
+
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "expected exit 0 after running the printed recovery command, got $rc: $out"
+  pass "fm-claude-symlink-check.sh: the printed branch-tip recovery command commits only CLAUDE.md"
+}
+
 test_branch_tip_dropping_claude_md_fails() {
   local repo out rc
   repo="$TMP_ROOT/tip-drops-file"
@@ -207,6 +247,7 @@ test_dangling_symlink_fails
 test_runs_from_a_subdirectory
 test_unknown_base_ref_errors
 test_uncommitted_restore_still_fails
+test_branch_tip_recovery_command_commits_only_claude_md
 test_branch_tip_dropping_claude_md_fails
 test_repo_without_symlink_policy_skips
 test_repo_without_claude_md_at_all_skips

--- a/tests/fm-claude-symlink-check.test.sh
+++ b/tests/fm-claude-symlink-check.test.sh
@@ -233,6 +233,7 @@ test_branch_tip_missing_target_fails() {
   assert_contains "$out" "expected target" "missing branch-tip target was not named"
   cmd=$(printf '%s\n' "$out" | sed -n 's/^Commit the restored symlink: //p')
   [ -n "$cmd" ] || fail "missing-target branch tip did not print a recovery commit command: $out"
+  assert_contains "$cmd" "'AGENTS.md'" "branch-tip recovery did not include the missing target"
   (
     export GIT_AUTHOR_NAME='Firstmate Tests' GIT_AUTHOR_EMAIL='tests@example.invalid'
     export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
@@ -242,6 +243,29 @@ test_branch_tip_missing_target_fails() {
   rc=$?
   [ "$rc" -eq 0 ] || fail "expected exit 0 after restoring and committing the target, got $rc: $out"
   pass "fm-claude-symlink-check.sh: branch tips must retain the regular symlink target"
+}
+
+test_worktree_target_must_be_regular_file() {
+  local repo out rc
+  repo="$TMP_ROOT/target-directory"
+  fixture_repo "$repo"
+  rm "$repo/AGENTS.md"
+  mkdir "$repo/AGENTS.md"
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit when the symlink target is a directory"
+  assert_contains "$out" "regular non-symlink file" "directory target was not rejected"
+
+  repo="$TMP_ROOT/target-symlink"
+  fixture_repo "$repo"
+  rm "$repo/AGENTS.md"
+  printf '# other\n' > "$repo/OTHER.md"
+  ln -s OTHER.md "$repo/AGENTS.md"
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit when the symlink target is another symlink"
+  assert_contains "$out" "regular non-symlink file" "symlink target was not rejected"
+  pass "fm-claude-symlink-check.sh: the worktree target must be a regular non-symlink file"
 }
 
 test_index_rejects_staged_claude_deletion() {
@@ -305,6 +329,54 @@ test_recovery_commands_quote_repository_operands() {
   [ -L "$repo/CLAUDE.md" ] || fail "quoted ln recovery command did not restore the symlink"
   [ "$(readlink "$repo/CLAUDE.md")" = "$target" ] || fail "quoted ln recovery command changed the symlink target"
   pass "fm-claude-symlink-check.sh: recovery commands quote every repository-controlled operand"
+}
+
+test_recovery_target_pathspecs_are_literal() {
+  local repo target decoy out rc cmd committed
+  repo="$TMP_ROOT/recovery-literal-pathspec"
+  target='AGENTS*.md'
+  decoy='AGENTS-other.md'
+  mkdir -p "$repo"
+  git -C "$repo" init -q
+  printf '# agents\n' > "$repo/$target"
+  printf '# decoy\n' > "$repo/$decoy"
+  ( cd "$repo" && ln -s "$target" CLAUDE.md )
+  git -C "$repo" --literal-pathspecs add -- "$target" "$decoy" CLAUDE.md
+  git -C "$repo" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+  git -C "$repo" branch -M main
+  git -C "$repo" checkout -q -b fm/worker
+
+  git -C "$repo" --literal-pathspecs rm -q -- "$target"
+  git -C "$repo" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm drop-target
+  printf '# agents restored\n' > "$repo/$target"
+  git -C "$repo" --literal-pathspecs add -- "$target"
+  printf 'working copy\n' > "$repo/$decoy"
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a branch-tip failure for the missing wildcard target"
+  cmd=$(printf '%s\n' "$out" | sed -n 's/^Commit the restored symlink: //p')
+  [ -n "$cmd" ] || fail "missing wildcard target did not print a commit recovery command: $out"
+  (
+    export GIT_AUTHOR_NAME='Firstmate Tests' GIT_AUTHOR_EMAIL='tests@example.invalid'
+    export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
+    eval "$cmd"
+  ) >/dev/null 2>&1 || fail "literal-pathspec commit recovery command failed: $cmd"
+  committed=$(git -C "$repo" show --name-only --format= HEAD)
+  case "$committed" in
+    *"$decoy"*) fail "literal-pathspec commit recovery swept in the decoy: $committed" ;;
+  esac
+  [ "$(cat "$repo/$decoy")" = 'working copy' ] || fail "literal-pathspec commit recovery changed the decoy"
+
+  rm "$repo/$target"
+  printf 'working copy after restore\n' > "$repo/$decoy"
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a worktree failure for the missing wildcard target"
+  cmd=$(printf '%s\n' "$out" | sed -n 's/^Restore the target: //p')
+  [ -n "$cmd" ] || fail "missing wildcard target did not print a target recovery command: $out"
+  eval "$cmd" >/dev/null 2>&1 || fail "literal-pathspec checkout recovery command failed: $cmd"
+  [ "$(cat "$repo/$decoy")" = 'working copy after restore' ] || fail "literal-pathspec checkout recovery changed the decoy"
+  pass "fm-claude-symlink-check.sh: generated Git recovery commands use literal target pathspecs"
 }
 
 test_repo_without_symlink_policy_skips() {
@@ -380,9 +452,11 @@ test_uncommitted_restore_still_fails
 test_branch_tip_recovery_command_works_from_every_restore_path
 test_branch_tip_dropping_claude_md_fails
 test_branch_tip_missing_target_fails
+test_worktree_target_must_be_regular_file
 test_index_rejects_staged_claude_deletion
 test_index_rejects_staged_target_deletion
 test_recovery_commands_quote_repository_operands
+test_recovery_target_pathspecs_are_literal
 test_repo_without_symlink_policy_skips
 test_repo_without_claude_md_at_all_skips
 test_auto_detects_origin_default_branch

--- a/tests/fm-claude-symlink-check.test.sh
+++ b/tests/fm-claude-symlink-check.test.sh
@@ -139,44 +139,66 @@ test_uncommitted_restore_still_fails() {
   pass "fm-claude-symlink-check.sh: a restore only passes once it is committed"
 }
 
-test_branch_tip_recovery_command_commits_only_claude_md() {
-  local repo out rc cmd committed staged
-  repo="$TMP_ROOT/recovery-command-scope"
+# assert_branch_tip_recovery <label> <tip> <restore>: break the branch tip the way
+# <tip> says (demote = tip carries a regular file, drop = tip lost the file), fix
+# the working tree the way <restore> says (checkout = the guard's git checkout
+# hint, ln = its ln -sfn hint), then run the exact command the guard prints and
+# hold it to both invariants: it has to succeed, and it must commit CLAUDE.md
+# alone while unrelated staged work stays staged.
+assert_branch_tip_recovery() {
+  local label=$1 tip=$2 restore=$3 repo out rc cmd committed staged
+  repo="$TMP_ROOT/recovery-$label"
   fixture_repo "$repo"
   git -C "$repo" checkout -q -b fm/worker
-  rm "$repo/CLAUDE.md"
-  printf 'stale content\n' > "$repo/CLAUDE.md"
-  git -C "$repo" add CLAUDE.md
-  git -C "$repo" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm demote
+  if [ "$tip" = demote ]; then
+    rm "$repo/CLAUDE.md"
+    printf 'stale content\n' > "$repo/CLAUDE.md"
+    git -C "$repo" add CLAUDE.md
+    git -C "$repo" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm demote
+  else
+    git -C "$repo" rm -q CLAUDE.md
+    git -C "$repo" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm drop
+  fi
 
   printf 'unrelated work in progress\n' > "$repo/feature.txt"
   git -C "$repo" add feature.txt
-  git -C "$repo" checkout main -- CLAUDE.md
+  if [ "$restore" = checkout ]; then
+    git -C "$repo" checkout main -- CLAUDE.md
+  else
+    ( cd "$repo" && ln -sfn AGENTS.md CLAUDE.md )
+  fi
 
   out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
   rc=$?
-  [ "$rc" -ne 0 ] || fail "expected a non-zero exit while the branch tip is still broken, got: $out"
+  [ "$rc" -ne 0 ] || fail "$label: expected a non-zero exit while the branch tip is still broken, got: $out"
   cmd=$(printf '%s\n' "$out" | sed -n 's/^Commit the restored symlink: //p')
-  [ -n "$cmd" ] || fail "no branch-tip recovery command was printed: $out"
+  [ -n "$cmd" ] || fail "$label: no branch-tip recovery command was printed: $out"
 
   (
     export GIT_AUTHOR_NAME='Firstmate Tests' GIT_AUTHOR_EMAIL='tests@example.invalid'
     export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
     eval "$cmd"
-  ) >/dev/null 2>&1 || fail "the printed recovery command failed: $cmd"
+  ) >/dev/null 2>&1 || fail "$label: the printed recovery command failed: $cmd"
 
   committed=$(git -C "$repo" show --name-only --format= HEAD)
-  assert_contains "$committed" "CLAUDE.md" "the recovery commit did not restore CLAUDE.md"
+  assert_contains "$committed" "CLAUDE.md" "$label: the recovery commit did not restore CLAUDE.md"
   case "$committed" in
-    *feature.txt*) fail "the recovery command swept unrelated staged work into its commit: $committed" ;;
+    *feature.txt*) fail "$label: the recovery command swept unrelated staged work into its commit: $committed" ;;
   esac
   staged=$(git -C "$repo" diff --cached --name-only)
-  assert_contains "$staged" "feature.txt" "the recovery command consumed unrelated staged work instead of leaving it staged"
+  assert_contains "$staged" "feature.txt" "$label: the recovery command consumed unrelated staged work instead of leaving it staged"
 
   out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
   rc=$?
-  [ "$rc" -eq 0 ] || fail "expected exit 0 after running the printed recovery command, got $rc: $out"
-  pass "fm-claude-symlink-check.sh: the printed branch-tip recovery command commits only CLAUDE.md"
+  [ "$rc" -eq 0 ] || fail "$label: expected exit 0 after running the printed recovery command, got $rc: $out"
+}
+
+test_branch_tip_recovery_command_works_from_every_restore_path() {
+  assert_branch_tip_recovery demoted-tip-checkout-restore demote checkout
+  assert_branch_tip_recovery demoted-tip-symlink-restore demote ln
+  assert_branch_tip_recovery dropped-tip-checkout-restore drop checkout
+  assert_branch_tip_recovery dropped-tip-symlink-restore drop ln
+  pass "fm-claude-symlink-check.sh: the printed recovery command commits only CLAUDE.md from every restore path"
 }
 
 test_branch_tip_dropping_claude_md_fails() {
@@ -247,7 +269,7 @@ test_dangling_symlink_fails
 test_runs_from_a_subdirectory
 test_unknown_base_ref_errors
 test_uncommitted_restore_still_fails
-test_branch_tip_recovery_command_commits_only_claude_md
+test_branch_tip_recovery_command_works_from_every_restore_path
 test_branch_tip_dropping_claude_md_fails
 test_repo_without_symlink_policy_skips
 test_repo_without_claude_md_at_all_skips

--- a/tests/fm-claude-symlink-check.test.sh
+++ b/tests/fm-claude-symlink-check.test.sh
@@ -245,6 +245,35 @@ test_branch_tip_missing_target_fails() {
   pass "fm-claude-symlink-check.sh: branch tips must retain the regular symlink target"
 }
 
+test_branch_tip_recovery_force_adds_ignored_target() {
+  local repo out rc cmd
+  repo="$TMP_ROOT/recovery-ignored-target"
+  fixture_repo "$repo"
+  git -C "$repo" checkout -q -b fm/worker
+  printf 'AGENTS.md\n' > "$repo/.gitignore"
+  git -C "$repo" add .gitignore
+  git -C "$repo" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm ignore-target
+  git -C "$repo" rm -q AGENTS.md
+  git -C "$repo" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm drop-target
+  printf '# restored agents\n' > "$repo/AGENTS.md"
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit while the branch tip omits an ignored target"
+  cmd=$(printf '%s\n' "$out" | sed -n 's/^Commit the restored symlink: //p')
+  [ -n "$cmd" ] || fail "ignored-target recovery did not print a commit command: $out"
+  assert_contains "$cmd" "--literal-pathspecs add -f -- 'AGENTS.md'" \
+    "ignored-target recovery did not force-add the known target"
+  (
+    export GIT_AUTHOR_NAME='Firstmate Tests' GIT_AUTHOR_EMAIL='tests@example.invalid'
+    export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
+    eval "$cmd"
+  ) >/dev/null 2>&1 || fail "ignored-target recovery command failed: $cmd"
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "expected exit 0 after ignored-target recovery, got $rc: $out"
+  pass "fm-claude-symlink-check.sh: branch-tip recovery force-adds an ignored target"
+}
+
 test_branch_tip_recovery_preserves_target_work() {
   local repo out rc cmd committed staged
   repo="$TMP_ROOT/recovery-preserves-target-work"
@@ -370,7 +399,7 @@ test_index_target_recovery_preserves_worktree_edits() {
   [ "$rc" -ne 0 ] || fail "expected a non-zero exit when the target is missing from the index"
   cmd=$(printf '%s\n' "$out" | sed -n 's/^Stage the target in the index: //p')
   [ -n "$cmd" ] || fail "index-target recovery did not print a staging command: $out"
-  assert_contains "$cmd" "--literal-pathspecs add -- 'AGENTS.md'" \
+  assert_contains "$cmd" "--literal-pathspecs add -f -- 'AGENTS.md'" \
     "index-target recovery did not use a literal git add"
   eval "$cmd" >/dev/null 2>&1 || fail "index-target staging command failed: $cmd"
   [ "$(cat "$repo/AGENTS.md")" = '# edited target' ] || fail "index-target recovery overwrote worktree edits"
@@ -378,6 +407,26 @@ test_index_target_recovery_preserves_worktree_edits() {
   rc=$?
   [ "$rc" -eq 0 ] || fail "expected exit 0 after staging the edited target, got $rc: $out"
   pass "fm-claude-symlink-check.sh: index-target recovery preserves worktree edits"
+}
+
+test_index_rejects_intent_to_add_target() {
+  local repo out rc cmd
+  repo="$TMP_ROOT/index-intent-to-add"
+  fixture_repo "$repo"
+  git -C "$repo" rm --cached -q AGENTS.md
+  git -C "$repo" add -N AGENTS.md
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit for an intent-to-add target"
+  assert_contains "$out" "would not be present as a regular file in the next tree" \
+    "intent-to-add target was not rejected as absent from the next tree"
+  cmd=$(printf '%s\n' "$out" | sed -n 's/^Stage the target in the index: //p')
+  [ -n "$cmd" ] || fail "intent-to-add target did not print a staging command: $out"
+  eval "$cmd" >/dev/null 2>&1 || fail "intent-to-add recovery command failed: $cmd"
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "expected exit 0 after replacing the intent-to-add entry, got $rc: $out"
+  pass "fm-claude-symlink-check.sh: intent-to-add targets fail closed"
 }
 
 test_recovery_commands_quote_repository_operands() {
@@ -539,12 +588,14 @@ test_uncommitted_restore_still_fails
 test_branch_tip_recovery_command_works_from_every_restore_path
 test_branch_tip_dropping_claude_md_fails
 test_branch_tip_missing_target_fails
+test_branch_tip_recovery_force_adds_ignored_target
 test_branch_tip_recovery_preserves_target_work
 test_branch_tip_recovery_restores_missing_target_for_regular_claude
 test_worktree_target_must_be_regular_file
 test_index_rejects_staged_claude_deletion
 test_index_rejects_staged_target_deletion
 test_index_target_recovery_preserves_worktree_edits
+test_index_rejects_intent_to_add_target
 test_recovery_commands_quote_repository_operands
 test_recovery_target_pathspecs_are_literal
 test_repo_without_symlink_policy_skips

--- a/tests/fm-claude-symlink-check.test.sh
+++ b/tests/fm-claude-symlink-check.test.sh
@@ -250,7 +250,7 @@ test_branch_tip_recovery_force_adds_ignored_target() {
   repo="$TMP_ROOT/recovery-ignored-target"
   fixture_repo "$repo"
   git -C "$repo" checkout -q -b fm/worker
-  printf 'AGENTS.md\n' > "$repo/.gitignore"
+  printf 'AGENTS.md\nCLAUDE.md\n' > "$repo/.gitignore"
   git -C "$repo" add .gitignore
   git -C "$repo" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm ignore-target
   git -C "$repo" rm -q AGENTS.md
@@ -261,6 +261,8 @@ test_branch_tip_recovery_force_adds_ignored_target() {
   [ "$rc" -ne 0 ] || fail "expected a non-zero exit while the branch tip omits an ignored target"
   cmd=$(printf '%s\n' "$out" | sed -n 's/^Commit the restored symlink: //p')
   [ -n "$cmd" ] || fail "ignored-target recovery did not print a commit command: $out"
+  assert_contains "$cmd" "--literal-pathspecs add -f -- 'CLAUDE.md'" \
+    "ignored-target recovery did not force-add the known CLAUDE.md path"
   assert_contains "$cmd" "--literal-pathspecs add -f -- 'AGENTS.md'" \
     "ignored-target recovery did not force-add the known target"
   (
@@ -410,16 +412,19 @@ test_index_target_recovery_preserves_worktree_edits() {
 }
 
 test_index_rejects_intent_to_add_target() {
-  local repo out rc cmd
+  local repo out rc cmd objects_before objects_after
   repo="$TMP_ROOT/index-intent-to-add"
   fixture_repo "$repo"
   git -C "$repo" rm --cached -q AGENTS.md
   git -C "$repo" add -N AGENTS.md
+  objects_before=$(git -C "$repo" count-objects -v | awk -F': ' '$1 == "count" {print $2}')
   out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
   rc=$?
+  objects_after=$(git -C "$repo" count-objects -v | awk -F': ' '$1 == "count" {print $2}')
   [ "$rc" -ne 0 ] || fail "expected a non-zero exit for an intent-to-add target"
-  assert_contains "$out" "would not be present as a regular file in the next tree" \
-    "intent-to-add target was not rejected as absent from the next tree"
+  [ "$objects_before" = "$objects_after" ] || fail "intent-to-add check mutated the object database"
+  assert_contains "$out" "only intent-to-add in the index" \
+    "intent-to-add target was not rejected"
   cmd=$(printf '%s\n' "$out" | sed -n 's/^Stage the target in the index: //p')
   [ -n "$cmd" ] || fail "intent-to-add target did not print a staging command: $out"
   eval "$cmd" >/dev/null 2>&1 || fail "intent-to-add recovery command failed: $cmd"

--- a/tests/fm-claude-symlink-check.test.sh
+++ b/tests/fm-claude-symlink-check.test.sh
@@ -43,8 +43,8 @@ test_regular_file_fails_with_recovery_commands() {
   [ "$rc" -ne 0 ] || fail "expected a non-zero exit when CLAUDE.md is a regular file"
   assert_contains "$out" "error:" "regular-file breakage did not report an error"
   assert_contains "$out" "regular file" "error did not name the actual problem"
-  assert_contains "$out" "checkout main -- CLAUDE.md" "error did not include the git checkout recovery command"
-  assert_contains "$out" "ln -sfn AGENTS.md" "error did not include the ln -sfn recovery command"
+  assert_contains "$out" "checkout 'main' -- 'CLAUDE.md'" "error did not include the git checkout recovery command"
+  assert_contains "$out" "ln -sfn -- 'AGENTS.md'" "error did not include the ln -sfn recovery command"
   pass "fm-claude-symlink-check.sh: CLAUDE.md demoted to a regular file fails with recovery commands"
 }
 
@@ -84,7 +84,7 @@ test_dangling_symlink_fails() {
   rc=$?
   [ "$rc" -ne 0 ] || fail "expected a non-zero exit when CLAUDE.md dangles, got: $out"
   assert_contains "$out" "dangling symlink" "dangling CLAUDE.md was not reported as dangling"
-  assert_contains "$out" "checkout main -- 'AGENTS.md'" "error did not include the target-restore command"
+  assert_contains "$out" "checkout 'main' -- 'AGENTS.md'" "error did not include the target-restore command"
   pass "fm-claude-symlink-check.sh: dangling CLAUDE.md symlink fails"
 }
 
@@ -198,6 +198,7 @@ test_branch_tip_recovery_command_works_from_every_restore_path() {
   assert_branch_tip_recovery demoted-tip-symlink-restore demote ln
   assert_branch_tip_recovery dropped-tip-checkout-restore drop checkout
   assert_branch_tip_recovery dropped-tip-symlink-restore drop ln
+  assert_branch_tip_recovery "quoted-'dir" demote checkout
   pass "fm-claude-symlink-check.sh: the printed recovery command commits only CLAUDE.md from every restore path"
 }
 
@@ -216,6 +217,96 @@ test_branch_tip_dropping_claude_md_fails() {
   pass "fm-claude-symlink-check.sh: a branch tip that dropped CLAUDE.md fails"
 }
 
+test_branch_tip_missing_target_fails() {
+  local repo out rc cmd
+  repo="$TMP_ROOT/tip-missing-target"
+  fixture_repo "$repo"
+  git -C "$repo" checkout -q -b fm/worker
+  git -C "$repo" rm -q AGENTS.md
+  git -C "$repo" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm drop-target
+  printf '# agents\n' > "$repo/AGENTS.md"
+  git -C "$repo" add AGENTS.md
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit when the branch tip drops the symlink target, got: $out"
+  assert_contains "$out" "branch tip" "missing branch-tip target was not reported"
+  assert_contains "$out" "expected target" "missing branch-tip target was not named"
+  cmd=$(printf '%s\n' "$out" | sed -n 's/^Commit the restored symlink: //p')
+  [ -n "$cmd" ] || fail "missing-target branch tip did not print a recovery commit command: $out"
+  (
+    export GIT_AUTHOR_NAME='Firstmate Tests' GIT_AUTHOR_EMAIL='tests@example.invalid'
+    export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
+    eval "$cmd"
+  ) >/dev/null 2>&1 || fail "missing-target recovery command failed: $cmd"
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "expected exit 0 after restoring and committing the target, got $rc: $out"
+  pass "fm-claude-symlink-check.sh: branch tips must retain the regular symlink target"
+}
+
+test_index_rejects_staged_claude_deletion() {
+  local repo out rc
+  repo="$TMP_ROOT/index-claude-deletion"
+  fixture_repo "$repo"
+  git -C "$repo" rm --cached -q CLAUDE.md
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit when CLAUDE.md is deleted from the index"
+  assert_contains "$out" "index" "staged CLAUDE.md deletion was not reported as an index problem"
+  pass "fm-claude-symlink-check.sh: staged CLAUDE.md deletion fails"
+}
+
+test_index_rejects_staged_target_deletion() {
+  local repo out rc
+  repo="$TMP_ROOT/index-target-deletion"
+  fixture_repo "$repo"
+  git -C "$repo" rm --cached -q AGENTS.md
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit when the symlink target is deleted from the index"
+  assert_contains "$out" "target" "staged target deletion was not reported"
+  assert_contains "$out" "index" "staged target deletion was not reported as an index problem"
+  pass "fm-claude-symlink-check.sh: staged symlink-target deletion fails"
+}
+
+test_recovery_commands_quote_repository_operands() {
+  local repo base target out rc checkout_cmd ln_cmd
+  repo="$TMP_ROOT/recovery-special-'dir"
+  base='base;touch'
+  target='AGENTS;touch'
+  mkdir -p "$repo"
+  git -C "$repo" init -q
+  printf '# agents\n' > "$repo/$target"
+  ( cd "$repo" && ln -s "$target" CLAUDE.md )
+  git -C "$repo" add -- "$target" CLAUDE.md
+  git -C "$repo" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+  git -C "$repo" branch -M main
+  git -C "$repo" branch "$base"
+  git -C "$repo" checkout -q -b fm/worker
+
+  rm "$repo/CLAUDE.md"
+  printf 'stale content\n' > "$repo/CLAUDE.md"
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" "$base" 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit for special recovery operands"
+  checkout_cmd=$(printf '%s\n' "$out" | sed -n 's/^Restore it: //; s/   (or:.*$//p')
+  [ -n "$checkout_cmd" ] || fail "special-operand check did not print a checkout recovery command: $out"
+  eval "$checkout_cmd" >/dev/null 2>&1 || fail "quoted checkout recovery command failed: $checkout_cmd"
+  [ -L "$repo/CLAUDE.md" ] || fail "quoted checkout recovery command did not restore the symlink"
+
+  rm "$repo/CLAUDE.md"
+  printf 'stale content\n' > "$repo/CLAUDE.md"
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" "$base" 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit for special symlink recovery operands"
+  ln_cmd=$(printf '%s\n' "$out" | sed -n 's/^Restore it: .*   (or: //; s/)$//p')
+  [ -n "$ln_cmd" ] || fail "special-operand check did not print an ln recovery command: $out"
+  eval "$ln_cmd" >/dev/null 2>&1 || fail "quoted ln recovery command failed: $ln_cmd"
+  [ -L "$repo/CLAUDE.md" ] || fail "quoted ln recovery command did not restore the symlink"
+  [ "$(readlink "$repo/CLAUDE.md")" = "$target" ] || fail "quoted ln recovery command changed the symlink target"
+  pass "fm-claude-symlink-check.sh: recovery commands quote every repository-controlled operand"
+}
+
 test_repo_without_symlink_policy_skips() {
   local repo out rc
   repo="$TMP_ROOT/no-policy"
@@ -228,7 +319,7 @@ test_repo_without_symlink_policy_skips() {
   out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
   rc=$?
   [ "$rc" -eq 0 ] || fail "expected exit 0 for a repo without a CLAUDE.md symlink policy, got $rc: $out"
-  assert_contains "$out" "skip:" "repo without a symlink policy did not report skip"
+  [ -z "$out" ] || fail "repo without a symlink policy was not silent: $out"
   pass "fm-claude-symlink-check.sh: repo without a CLAUDE.md symlink policy skips silently"
 }
 
@@ -240,7 +331,7 @@ test_repo_without_claude_md_at_all_skips() {
   out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" main 2>&1)
   rc=$?
   [ "$rc" -eq 0 ] || fail "expected exit 0 for a repo with no CLAUDE.md at all, got $rc: $out"
-  assert_contains "$out" "skip:" "repo without any CLAUDE.md did not report skip"
+  [ -z "$out" ] || fail "repo without any CLAUDE.md was not silent: $out"
   pass "fm-claude-symlink-check.sh: repo with no CLAUDE.md at all skips silently"
 }
 
@@ -261,6 +352,23 @@ test_auto_detects_origin_default_branch() {
   pass "fm-claude-symlink-check.sh: auto-detects the origin default branch when no base-ref is given"
 }
 
+test_dangling_origin_head_falls_back_to_available_default() {
+  local repo bare out rc
+  repo="$TMP_ROOT/dangling-origin-head"
+  bare="$TMP_ROOT/dangling-origin-head-bare"
+  fixture_repo "$repo"
+  fm_git_add_origin "$repo" "$bare"
+  git -C "$repo" fetch --quiet origin
+  git -C "$repo" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/stale
+  rm "$repo/CLAUDE.md"
+  printf 'stale content\n' > "$repo/CLAUDE.md"
+  out=$("$ROOT/bin/fm-claude-symlink-check.sh" "$repo" 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit after falling back from a dangling origin/HEAD"
+  assert_contains "$out" "origin/main" "dangling origin/HEAD did not fall back to origin/main"
+  pass "fm-claude-symlink-check.sh: a dangling origin/HEAD falls back to an available default"
+}
+
 test_matching_symlink_passes
 test_regular_file_fails_with_recovery_commands
 test_missing_claude_md_fails
@@ -271,6 +379,11 @@ test_unknown_base_ref_errors
 test_uncommitted_restore_still_fails
 test_branch_tip_recovery_command_works_from_every_restore_path
 test_branch_tip_dropping_claude_md_fails
+test_branch_tip_missing_target_fails
+test_index_rejects_staged_claude_deletion
+test_index_rejects_staged_target_deletion
+test_recovery_commands_quote_repository_operands
 test_repo_without_symlink_policy_skips
 test_repo_without_claude_md_at_all_skips
 test_auto_detects_origin_default_branch
+test_dangling_origin_head_falls_back_to_available_default


### PR DESCRIPTION
## Intent

Investigate why jmp-hub's CLAUDE.md -> AGENTS.md symlink (a captain-decided one-source-of-truth convention; the symlink direction must never be reversed or removed) keeps turning into a plain file on fm/* worker branches, causing repeated 'distinct types on each side' merge conflicts (documented in PR #621). The leading hypothesis to test first was that no-mistakes' prompt-injection defense neutralizes AGENTS.md/CLAUDE.md by writing through the symlink before running the gate agent, which would explain why every pipeline-processed branch is affected. That hypothesis had to be confirmed or refuted with hard evidence (commit SHAs, authorship, git log -p), not argued from plausibility. Investigation in a read-only clone of jmp-hub at projects/jmp-hub (never modified) found: CLAUDE.md became a symlink only in commit 80f54e46 (PR #612, 2026-08-05 02:28, author V4f1k). Checked all 103 current origin/fm/* branches: every branch whose CLAUDE.md is a plain file provably does NOT have 80f54e46 as an ancestor (it simply predates the symlink conversion and hasn't synced since - not corruption). Every branch descended from 80f54e46 still has the correct symlink. No no-mistakes-authored commit (grep for 'no-mistakes(document/review):' commits) ever changes CLAUDE.md's file mode, and the currently-running no-mistakes worktree for jmp-hub still has an intact symlink. This refutes the leading hypothesis with direct evidence. The actual mechanism: merging/rebasing a pre-conversion branch against a post-conversion base hits git's ordinary 'distinct types on each side' conflict on CLAUDE.md (exactly reproduced in PR #621's merge commit 7166a1ec, which resolved it correctly by keeping the symlink), and that manual conflict resolution is error-prone - fm/don768-kanban-brana's merge (86204b0f) dropped CLAUDE.md entirely instead of keeping the symlink, requiring a manual restore the next day (5dd137c0). This is not a bug in firstmate's own bin/ tooling (bin/fm-ensure-agents-md.sh was already confirmed symlink-aware and ruled out first) nor in no-mistakes; it is an operational hazard of syncing stale branches, so per the task's explicit instructions the deliverable is a safety net rather than a root-cause code fix: bin/fm-claude-symlink-check.sh is a new, project-agnostic, read-only guard script. It silently skips (exit 0) any repo whose resolved base branch does not manage CLAUDE.md as a symlink, so it is a no-op everywhere except a project that has actually adopted this convention. Where the base does manage it as a symlink, it verifies the worktree's CLAUDE.md still matches (present, is a symlink, correct target) and on failure prints the exact recovery commands (git checkout <base> -- CLAUDE.md, or ln -sfn <target> CLAUDE.md) and exits 1. It auto-detects the base branch (preferring the freshest locally-available remote-tracking ref, falling back to a local branch) or accepts an explicit ref for testing, mirroring the existing default_branch() pattern already duplicated in bin/fm-ff-lib.sh and bin/fm-fleet-sync.sh (deliberately not refactored into a shared lib - that consolidation is out of scope for this fix per explicit instructions to avoid repo-wide cleanup as a side effect). It is wired into bin/fm-brief.sh's shared 'Project memory' section so every ship-mode brief (no-mistakes, direct-PR, local-only) instructs the worker to run it right before reporting done - i.e. before a PR ever exists, not just left available. Test coverage: tests/fm-claude-symlink-check.test.sh (7 scenarios: matching symlink passes, regular-file demotion fails with both recovery commands present, missing file fails, wrong-target symlink fails, a repo with no symlink policy skips silently, a repo with no CLAUDE.md at all skips silently, and auto-detection of origin's default branch works) plus a new assertion in tests/fm-brief.test.sh confirming the hygiene-check section renders in all three delivery modes. bin/fm-test-run.sh gained one line classifying the new test into the existing pure-contract-unit family (same family as the closely related fm-ensure-agents-md.test.sh). Deliberately out of scope, per explicit instruction: do not touch jmp-hub at all (read-only investigation only, verified via git log/ls-tree/diff against the local read-only clone and its fetched remote branches, never committing there), do not un-break or rewrite history on any of the 34+ affected fm/* branches (most are dead; rewriting other workers' branches is not this task's job), do not reverse or remove the CLAUDE.md -> AGENTS.md symlink direction (captain's standing decision), and no repo-wide renaming/cleanup beyond this fix's own files. Full local verification already done directly (captain's standing instruction: the full bin/fm-test-run.sh suite is CI's job via --check-coverage in ci.yml, not duplicated locally) - bin/fm-lint.sh is clean on every touched script (fm-claude-symlink-check.sh, fm-brief.sh, fm-test-run.sh), the new and touched test files pass standalone and through the real bin/fm-test-run.sh harness, and the pure-contract-unit family run is green except two pre-existing, environment-dependent failures (missing tasks-axi and the @earendil-works/pi-coding-agent npm package in this session) confirmed unrelated to this diff by isolated reruns - neither failing test file references any file this change touches.

## What Changed

- Added `bin/fm-claude-symlink-check.sh`, a project-agnostic read-only guard that detects broken `CLAUDE.md` symlinks and prints recovery commands.
- Wired the guard into all ship-mode briefs and documented it in `docs/scripts.md`.
- Added comprehensive guard and brief-rendering coverage, registering the new test in the existing test family.

## Risk Assessment

✅ Low: Captain, the change is bounded and I found no material source-verifiable regressions or intent violations.

## Testing

Fresh focused tests passed standalone and through the real harness. Manual CLI evidence confirms failure diagnostics, recovery guidance, committed-restore enforcement, and silent no-policy behavior; generated briefs contain the guard in all three delivery modes. No linters or full-suite tests were run, and the worktree is clean.

<details>
<summary>Evidence: CLI guard failure and recovery transcript</summary>

```text
$ bin/fm-claude-symlink-check.sh <broken worktree>
exit=1
error: CLAUDE.md in /private/var/folders/mz/3dbzbvkd1375djgpnq7r7hj40000gp/T/tmp.o8ktVF2HQK/symlink-policy is a regular file, but main manages it as a symlink -> AGENTS.md.
This is the classic 'distinct types on each side' merge fallout: a pre-conversion branch clobbered the symlink.
Restore it: git -C '/private/var/folders/mz/3dbzbvkd1375djgpnq7r7hj40000gp/T/tmp.o8ktVF2HQK/symlink-policy' checkout 'main' -- 'CLAUDE.md'   (or: ln -sfn -- 'AGENTS.md' '/private/var/folders/mz/3dbzbvkd1375djgpnq7r7hj40000gp/T/tmp.o8ktVF2HQK/symlink-policy/CLAUDE.md')
$ git checkout main -- CLAUDE.md; bin/fm-claude-symlink-check.sh <uncommitted restore>
exit=1
error: the working tree is fine, but your branch tip still carries CLAUDE.md as a regular file (mode 100644), while main manages it as a symlink -> AGENTS.md.
That is what a PR would carry, so the 'distinct types on each side' conflict would come back.
Commit the restored symlink: git -C '/private/var/folders/mz/3dbzbvkd1375djgpnq7r7hj40000gp/T/tmp.o8ktVF2HQK/symlink-policy' --literal-pathspecs add -f -- 'CLAUDE.md' && git -C '/private/var/folders/mz/3dbzbvkd1375djgpnq7r7hj40000gp/T/tmp.o8ktVF2HQK/symlink-policy' --literal-pathspecs commit -m 'fix: restore the CLAUDE.md symlink' -- 'CLAUDE.md'
$ bin/fm-claude-symlink-check.sh <committed restore>
exit=0
ok: CLAUDE.md -> AGENTS.md matches main in /private/var/folders/mz/3dbzbvkd1375djgpnq7r7hj40000gp/T/tmp.o8ktVF2HQK/symlink-policy (working tree and branch tip)
$ bin/fm-claude-symlink-check.sh <repo without symlink policy>
exit=0 output_bytes=0
```
</details>
<details>
<summary>Evidence: Generated hygiene sections for all delivery modes</summary>

```text
--- mode=no-mistakes ---
# Repo hygiene check
Before you report done, run `'/Users/computer/.no-mistakes/worktrees/2f3dd046dbd1/01M015H2ZEZ25CD1XYMNGYXP7M/bin/fm-claude-symlink-check.sh' .`. For direct-PR delivery, run this before pushing or opening the PR.
It is silent and exits 0 in almost every project; it only speaks up when the resolved base branch manages `CLAUDE.md` as a symlink to its expected target and your branch lost that symlink or its target - a known git hazard where syncing a branch whose history predates the symlink against a base that already has it hits a "distinct types on each side" conflict, easy to mis-resolve by dropping the file instead of keeping the symlink.
It checks your working tree and your branch tip, so a restore only counts once you commit it.
If it reports an error, run the recovery command it prints, then re-run the check until it passes.

# Definition of done
--- mode=direct-PR ---
# Repo hygiene check
Before you report done, run `'/Users/computer/.no-mistakes/worktrees/2f3dd046dbd1/01M015H2ZEZ25CD1XYMNGYXP7M/bin/fm-claude-symlink-check.sh' .`. For direct-PR delivery, run this before pushing or opening the PR.
It is silent and exits 0 in almost every project; it only speaks up when the resolved base branch manages `CLAUDE.md` as a symlink to its expected target and your branch lost that symlink or its target - a known git hazard where syncing a branch whose history predates the symlink against a base that already has it hits a "distinct types on each side" conflict, easy to mis-resolve by dropping the file instead of keeping the symlink.
It checks your working tree and your branch tip, so a restore only counts once you commit it.
If it reports an error, run the recovery command it prints, then re-run the check until it passes.

# Definition of done
--- mode=local-only ---
# Repo hygiene check
Before you report done, run `'/Users/computer/.no-mistakes/worktrees/2f3dd046dbd1/01M015H2ZEZ25CD1XYMNGYXP7M/bin/fm-claude-symlink-check.sh' .`. For direct-PR delivery, run this before pushing or opening the PR.
It is silent and exits 0 in almost every project; it only speaks up when the resolved base branch manages `CLAUDE.md` as a symlink to its expected target and your branch lost that symlink or its target - a known git hazard where syncing a branch whose history predates the symlink against a base that already has it hits a "distinct types on each side" conflict, easy to mis-resolve by dropping the file instead of keeping the symlink.
It checks your working tree and your branch tip, so a restore only counts once you commit it.
If it reports an error, run the recovery command it prints, then re-run the check until it passes.

# Definition of done
```
</details>
<details>
<summary>Evidence: Targeted harness transcript</summary>

```text
FM_TEST_BEGIN 2026-08-14T22:30:40Z tests/fm-claude-symlink-check.test.sh family=pure-contract-unit expected_gate_skip=none
ok - fm-claude-symlink-check.sh: matching CLAUDE.md symlink passes
ok - fm-claude-symlink-check.sh: CLAUDE.md demoted to a regular file fails with recovery commands
ok - fm-claude-symlink-check.sh: missing CLAUDE.md fails
ok - fm-claude-symlink-check.sh: symlink pointing at the wrong target fails
ok - fm-claude-symlink-check.sh: dangling CLAUDE.md symlink fails
ok - fm-claude-symlink-check.sh: run from a subdirectory it still checks the repo root
ok - fm-claude-symlink-check.sh: an unresolvable base ref errors instead of skipping
ok - fm-claude-symlink-check.sh: a restore only passes once it is committed
ok - fm-claude-symlink-check.sh: the printed recovery command commits only CLAUDE.md from every restore path
ok - fm-claude-symlink-check.sh: a branch tip that dropped CLAUDE.md fails
ok - fm-claude-symlink-check.sh: branch tips must retain the regular symlink target
ok - fm-claude-symlink-check.sh: branch-tip recovery force-adds an ignored target
ok - fm-claude-symlink-check.sh: branch-tip recovery preserves target work
ok - fm-claude-symlink-check.sh: recovery restores a missing target with a regular branch-tip CLAUDE.md
ok - fm-claude-symlink-check.sh: the worktree target must be a regular non-symlink file
ok - fm-claude-symlink-check.sh: staged CLAUDE.md deletion fails
ok - fm-claude-symlink-check.sh: staged symlink-target deletion fails
ok - fm-claude-symlink-check.sh: index-target recovery preserves worktree edits
ok - fm-claude-symlink-check.sh: intent-to-add targets fail closed
ok - fm-claude-symlink-check.sh: recovery commands quote every repository-controlled operand
ok - fm-claude-symlink-check.sh: generated Git recovery commands use literal target pathspecs
ok - fm-claude-symlink-check.sh: repo without a CLAUDE.md symlink policy skips silently
ok - fm-claude-symlink-check.sh: repo with no CLAUDE.md at all skips silently
ok - fm-claude-symlink-check.sh: auto-detects the origin default branch when no base-ref is given
ok - fm-claude-symlink-check.sh: a dangling origin/HEAD falls back to an available default
FM_TEST_END 2026-08-14T22:31:05Z tests/fm-claude-symlink-check.test.sh exit=0 duration_ms=24728 gate_skip=false
FM_TEST_BEGIN 2026-08-14T22:31:05Z tests/fm-brief.test.sh family=pure-contract-unit expected_gate_skip=none
ok - fm-brief.sh: bash -n succeeds
/var/folders/mz/3dbzbvkd1375djgpnq7r7hj40000gp/T//fm-brief.gUuSx1/heredoc-in-substitution.sh:2
ok - fm-brief.sh: no heredoc is nested inside a command substitution (Bash 3.2 parse-safe)
ok - fm-brief.sh: --help renders the complete header
ok - fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly
ok - fm-brief.sh: ship --mode is required and closed-set validated
ok - fm-brief.sh: the explicit ship mode wins over the registered posture
ok - fm-brief.sh: --yolo and scout/secondmate --mode are refused, never silently dropped
ok - fm-brief.sh: faster paths use configured authority without stacked review
ok - fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe
ok - fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar
ok - fm-brief.sh: every ship mode renders the CLAUDE.md symlink guard before Definition of done
ok - fm-brief.sh: --herdr-lab emits the complete hard safety contract
ok - fm-brief.sh: --herdr-lab uses its quoted Firstmate-owned helper path
ok - fm-brief.sh: ship and scout scaffolds make omitted Herdr intent fail-visible
ok - fm-brief.sh: Herdr lab contract covers scouts and rejects secondmate misuse
ok - fm-brief.sh: --no-projects scaffolds a project-less charter and guards misuse
ok - fm-brief.sh: marked requests avoid generic acknowledgements and preserve material reporting
ok - fm-brief.sh: relative directory inputs ignore CDPATH, render stable absolute charter paths, or fail loudly
ok - fm-brief.sh: custom pause verb renders in every scaffold
ok - fm-brief.sh: investigation and visual-review completions load the shared decision policy
ok - fm-brief: scout and secondmate code paths still scaffold well-formed briefs
FM_TEST_END 2026-08-14T22:31:09Z tests/fm-brief.test.sh exit=0 duration_ms=4303 gate_skip=false
FM_TEST_SUMMARY total=2 failed=0 skipped_gate=0 duration_ms=29326
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=2 duration_ms=29031 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-claude-symlink-check.test.sh duration_ms=24728
FM_TEST_SLOWEST rank=2 script=tests/fm-brief.test.sh duration_ms=4303
fm-test-run: wrote timing artifact: /var/folders/mz/3dbzbvkd1375djgpnq7r7hj40000gp/T/no-mistakes-evidence/01M015H2ZEZ25CD1XYMNGYXP7M/harness-targeted.json
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d50d6c84598c800c978fe96205576f7057f8571d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-claude-symlink-check.test.sh`
- `bash tests/fm-brief.test.sh`
- `bin/fm-test-run.sh --json .../harness-targeted.json tests/fm-claude-symlink-check.test.sh tests/fm-brief.test.sh`
- `Manual Git fixture: broken worktree, uncommitted restore, committed recovery, and no-policy skip`
- `Manual generation of no-mistakes, direct-PR, and local-only brief sections`
- `git status --porcelain=v1 --untracked-files=all`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
