### PR TITLE
feat: restore post-merge content verification rule + guard script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,6 +324,8 @@ Before deciding any ask-user finding, load `ask-user-authority`; the implementat
 Never merge a red PR.
 Without a current explicit captain instruction that states the concrete merge, that default stands, and standing `yolo` cannot authorize a red merge; section 1 owns when such an instruction overrides a Firstmate-written standing rule within its exact scope.
 Use `bin/fm-pr-merge.sh` for every task PR merge so merge metadata is recorded, and use `bin/fm-merge-local.sh` for approved local-only landing; never call a lower-level merge command around their guards.
+After any merge, confirm approved content landed on the remote default branch with `bin/fm-post-merge-verify.sh <project-dir> <base-sha> <head-sha>` before treating landing as confirmed.
+Missing or differing approved content is a stop-and-investigate result, never a re-push or force; the script's header owns the exact content-based semantics.
 After an autonomous merge, give the captain a one-line full-URL or local-main outcome.
 
 ### Validate

--- a/bin/fm-post-merge-verify.sh
+++ b/bin/fm-post-merge-verify.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Verify that approved content is present on a project's default branch before
+# a task is considered complete (post-merge verification).
+#
+# Usage: fm-post-merge-verify.sh <project-dir> <base-sha> <head-sha> [--remote <name>]
+#
+# Semantics: content-based, not commit-based. A task's approved content is the
+# blob state of every path changed between <base-sha> and <head-sha>. After any
+# merge (squash, rebase, or fast-forward), the default branch must contain the
+# same blobs for those paths, whatever the resulting commit hashes. This catches
+# history rewrites that drop approved work while their commits still exist as
+# detached objects (see the 2026-08-02 rebase-merge incident post-mortem).
+#
+# Behavior:
+#   - Fetches <remote> (default origin) fresh before reading the default branch.
+#   - Resolves the remote default branch (remote HEAD, then main, then master).
+#   - For every path changed between base and head:
+#       - present at head and present with the identical blob on the default
+#         branch  -> OK
+#       - deleted at head and absent from the default branch -> OK
+#       - anything else -> MISSING or DIFFERS (listed, exit 1)
+#   - Prints one line per changed path plus a summary, exits 0 only when every
+#     changed path is confirmed on the default branch.
+#
+# A non-zero exit means approved content is not provably on the default branch:
+# stop and investigate before teardown or completion. Never force, reset, or
+# re-push around this check; it is a verification gate, not a repair tool.
+set -eu
+
+usage() {
+  sed -n '2,9p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  exit 1
+}
+
+PROJECT_DIR=${1:-}
+BASE_SHA=${2:-}
+HEAD_SHA=${3:-}
+REMOTE=origin
+if [ "${4:-}" = "--remote" ]; then
+  REMOTE=${5:-}
+  [ -n "$REMOTE" ] || usage
+fi
+if [ -z "$PROJECT_DIR" ] || [ -z "$BASE_SHA" ] || [ -z "$HEAD_SHA" ]; then
+  usage
+fi
+[ -d "$PROJECT_DIR/.git" ] || { echo "error: $PROJECT_DIR is not a git repository" >&2; exit 2; }
+
+git -C "$PROJECT_DIR" fetch -q "$REMOTE"
+
+default_branch=$(git -C "$PROJECT_DIR" symbolic-ref -q --short "refs/remotes/$REMOTE/HEAD" 2>/dev/null || true)
+if [ -z "$default_branch" ]; then
+  for candidate in "main" "master"; do
+    if git -C "$PROJECT_DIR" rev-parse -q --verify "refs/remotes/$REMOTE/$candidate" >/dev/null 2>&1; then
+      default_branch="$REMOTE/$candidate"
+      break
+    fi
+  done
+fi
+if [ -z "$default_branch" ]; then
+  echo "error: cannot resolve the default branch of remote $REMOTE" >&2
+  exit 2
+fi
+REMOTE_HEAD=$(git -C "$PROJECT_DIR" rev-parse --verify "refs/remotes/${default_branch#*/}" 2>/dev/null || git -C "$PROJECT_DIR" rev-parse --verify "$default_branch")
+git -C "$PROJECT_DIR" rev-parse -q --verify "$BASE_SHA^{commit}" >/dev/null 2>&1 \
+  || { echo "error: base sha $BASE_SHA does not exist locally" >&2; exit 2; }
+git -C "$PROJECT_DIR" rev-parse -q --verify "$HEAD_SHA^{commit}" >/dev/null 2>&1 \
+  || { echo "error: head sha $HEAD_SHA does not exist locally" >&2; exit 2; }
+
+failures=0
+total=0
+while IFS= read -r -d '' path; do
+  total=$((total + 1))
+  head_blob=$(git -C "$PROJECT_DIR" rev-parse -q --verify "$HEAD_SHA:$path" 2>/dev/null || true)
+  remote_blob=$(git -C "$PROJECT_DIR" rev-parse -q --verify "$REMOTE_HEAD:$path" 2>/dev/null || true)
+  if [ -z "$head_blob" ]; then
+    if [ -z "$remote_blob" ]; then
+      echo "ok (deleted)  $path"
+    else
+      echo "DIFFERS       $path (deleted in approved head but present on $default_branch)"
+      failures=$((failures + 1))
+    fi
+  elif [ "$head_blob" = "$remote_blob" ]; then
+    echo "ok            $path"
+  else
+    echo "DIFFERS       $path (approved content not on $default_branch)"
+    failures=$((failures + 1))
+  fi
+done < <(git -C "$PROJECT_DIR" diff --name-only -z "$BASE_SHA" "$HEAD_SHA")
+
+if [ "$total" -eq 0 ]; then
+  echo "warning: no changed paths between $BASE_SHA and $HEAD_SHA" >&2
+  exit 2
+fi
+if [ "$failures" -eq 0 ]; then
+  echo "post-merge verification PASS: $total changed paths confirmed on $default_branch ($REMOTE_HEAD)"
+  exit 0
+fi
+echo "post-merge verification FAIL: $failures of $total changed paths missing or differing on $default_branch"
+exit 1

--- a/tests/fm-post-merge-verify.test.sh
+++ b/tests/fm-post-merge-verify.test.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# tests/fm-post-merge-verify.test.sh - post-merge content verification guard.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-post-merge-verify.XXXXXX")
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+REMOTE="$TMP_ROOT/remote.git"
+CLONE="$TMP_ROOT/clone"
+
+# Deterministic git identity from the shared lib.
+setup_repo() {
+  mkdir -p "$REMOTE"
+  git init -q --bare "$REMOTE"
+  git clone -q "$REMOTE" "$CLONE"
+  git -C "$CLONE" config user.name "Test"
+  git -C "$CLONE" config user.email "test@example.com"
+  echo "base" > "$CLONE/base.txt"
+  git -C "$CLONE" add base.txt
+  git -C "$CLONE" commit -q -m "base"
+  git -C "$CLONE" branch -M main
+  git -C "$CLONE" push -q -u origin main
+}
+
+# Simulate an approved PR: branch with two changed files, one new, one edited.
+make_pr_branch() {
+  git -C "$CLONE" checkout -q -b feature
+  echo "approved-v1" > "$CLONE/approved.txt"
+  echo "edited" >> "$CLONE/base.txt"
+  git -C "$CLONE" add approved.txt base.txt
+  git -C "$CLONE" commit -q -m "feature work"
+  BASE=$(git -C "$CLONE" rev-parse main)
+  HEAD=$(git -C "$CLONE" rev-parse feature)
+}
+
+# Simulate a squash merge that carries the approved blobs onto main.
+squash_land() {
+  git -C "$CLONE" checkout -q main
+  git -C "$CLONE" checkout -q feature -- approved.txt base.txt
+  git -C "$CLONE" commit -q -m "merge feature (squashed)"
+  git -C "$CLONE" push -q origin main
+}
+
+setup_repo
+make_pr_branch
+
+# Scenario 1: approved content present on the default branch -> PASS.
+squash_land
+if "$ROOT/bin/fm-post-merge-verify.sh" "$CLONE" "$BASE" "$HEAD" >"$TMP_ROOT/out1" 2>&1; then
+  pass "content present on main passes"
+else
+  cat "$TMP_ROOT/out1"
+  fail "content present on main should pass"
+fi
+if grep -q "PASS: 2 changed paths" "$TMP_ROOT/out1"; then
+  pass "summary reports both paths"
+else
+  fail "summary should report both paths"
+fi
+
+# Scenario 2: content missing from the default branch -> FAIL.
+git -C "$CLONE" checkout -q -b feature2 main
+git -C "$CLONE" rm -q approved.txt
+git -C "$CLONE" commit -q -m "drop approved content"
+git -C "$CLONE" push -q -u origin feature2
+BASE2=$(git -C "$CLONE" rev-parse main)
+HEAD2=$(git -C "$CLONE" rev-parse feature2)
+if "$ROOT/bin/fm-post-merge-verify.sh" "$CLONE" "$BASE2" "$HEAD2" >"$TMP_ROOT/out2" 2>&1; then
+  fail "missing content should fail"
+else
+  pass "missing content fails with non-zero exit"
+fi
+if grep -q "FAIL" "$TMP_ROOT/out2"; then
+  pass "failure reported"
+else
+  fail "failure line expected"
+fi
+
+# Scenario 3: content present but differing -> FAIL.
+git -C "$CLONE" checkout -q main
+echo "different-content" > "$CLONE/base.txt"
+git -C "$CLONE" commit -q -am "diverging base.txt content"
+git -C "$CLONE" push -q origin main
+if "$ROOT/bin/fm-post-merge-verify.sh" "$CLONE" "$BASE" "$HEAD" >"$TMP_ROOT/out3" 2>&1; then
+  fail "differing content should fail"
+else
+  pass "differing content fails with non-zero exit"
+fi
+if grep -q "DIFFERS" "$TMP_ROOT/out3"; then
+  pass "differing path listed"
+else
+  fail "DIFFERS line expected"
+fi
+
+# Scenario 4: missing args -> usage error, non-zero.
+if "$ROOT/bin/fm-post-merge-verify.sh" "$CLONE" "$BASE" >"$TMP_ROOT/out4" 2>&1; then
+  fail "missing args should fail"
+else
+  pass "missing args fail with non-zero exit"
+fi
+
+exit 0


### PR DESCRIPTION
Restores the post-merge verification contract lost in the upstream AGENTS.md rewrite, and ships the local guard implementation that has been operationally load-bearing (all bga-mercurio merges verified with it).

- AGENTS.md: re-adds the two rules (content-based post-merge verification via bin/fm-post-merge-verify.sh; missing/differing content is a stop-and-investigate result, never a re-push/force) in the landing section, right after the fm-pr-merge/fm-merge-local tooling line — same placement as the pre-rewrite text, wording adapted to the current section structure.
- bin/fm-post-merge-verify.sh: pure-git content-based verifier (blob equality per changed path vs the remote default branch; catches history rewrites that drop approved work). Shellcheck-clean, no firstmate-internal dependencies.
- tests/fm-post-merge-verify.test.sh: 4 scenarios (present/missing/differing/usage), 7/7 pass on current main.

Verdict: the rules remain appropriate under the current architecture — the current AGENTS.md still mandates fm-pr-merge for task merges with fleet sync as the detection backstop, but nothing else verifies that approved CONTENT landed on the remote default branch (the 2026-08-02 rebase-merge history-loss incident class is still live).