### PR TITLE
fix(bin): refuse teardown while a task's recorded PR is still open

### DIFF
--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -22,6 +22,15 @@
 # A gh lookup error falls back to the content check; if that is also inconclusive,
 # teardown refuses rather than risk discarding unlanded work.
 # Uncommitted changes are never landed.
+# Once the dirty/unpushed/landed checks above pass, teardown separately REFUSES if
+# the task's recorded pr= is still open on GitHub: a fully pushed, git-history-landed
+# branch can still have its own PR sitting open, and teardown deletes
+# state/<id>.meta - the record bin/fm-pr-merge.sh resolves that PR through - so
+# tearing down now would strand a mergeable PR with no guarded path to land it. A gh
+# lookup error here refuses loudly too (naming the PR firstmate could not confirm)
+# rather than tearing down blind, because "unreachable" and "confirmed closed" are
+# not the same fact. This check only fires when a pr= is actually recorded, so scout,
+# local-only, and secondmate teardowns (none of which ever record one) are unaffected.
 # local-only projects additionally accept work merged into the local default
 # branch (firstmate performs that merge after configured approval) as a fallback
 # for the common case where there is no remote at all.
@@ -55,9 +64,11 @@
 # never left leased forever. If the treehouse return fails, teardown leaves the
 # leased home and state in place instead of hiding a still-held lease.
 # Usage: fm-teardown.sh <task-id> [--force]
-#   --force skips ordinary-task dirty and landed-work checks, skips scout report
-#   checks, and discards secondmate child work for kind=secondmate. Only use it
-#   when the captain has explicitly said to discard the work.
+#   --force skips ordinary-task dirty, landed-work, and open-PR checks, skips scout
+#   report checks, and discards secondmate child work for kind=secondmate. Only use
+#   it when the captain has explicitly said to discard the work (for the open-PR
+#   check specifically, that means accepting the PR will need to be merged or closed
+#   by hand, outside fm-pr-merge.sh's guarded path).
 #
 # Transient / stale worktree git lock recovery (teardown-lock-race): a crew process
 # killed mid-git-operation can leave a .git/worktrees/<wt>/index.lock (or, for a
@@ -856,6 +867,24 @@ pr_is_merged() {
   unpushed_patches_are_in_pr_head "$head"
 }
 
+# Is the task's recorded PR ($PR_URL) still open? Only called when PR_URL is
+# non-empty - a task with no recorded PR has nothing for this check to guard.
+# Uses the same gh query shape as pr_is_merged so a single GitHub call answers
+# both. Returns 0 when GitHub confirms OPEN, 1 when GitHub confirms a
+# non-open state (MERGED or CLOSED), and 2 when the state could not be
+# confirmed at all (gh/network error, or a malformed response) - the caller
+# refuses loudly on that uncertainty rather than guess it is safe.
+pr_open_state() {
+  local view state
+  view=$(cd "$WT" && gh pr view "$PR_URL" --json state,headRefOid -q '.state + "\t" + .headRefOid' 2>/dev/null) || return 2
+  state=${view%%$'\t'*}
+  [ -n "$state" ] && [ "$state" != "$view" ] || return 2
+  case "$state" in
+    OPEN|open) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # Is the branch's content already present in the up-to-date default branch? Fetches
 # first, then 3-way merges the default branch with HEAD: when HEAD introduces nothing
 # the default branch does not already contain (e.g. its change landed via squash) the
@@ -1197,6 +1226,29 @@ validate_worktree_teardown_safety() {
       echo "Push the branch, land its PR, or get the captain's explicit OK to discard, then --force." >&2
       return 1
     fi
+  fi
+
+  # Local git state is clean (or already refused above), so now check the higher-level
+  # question the dirty/unpushed/landed checks above cannot answer: is this task's own
+  # PR actually done? A pushed, fully-landed-by-git-history branch can still have its
+  # PR sitting open - teardown deletes state/<id>.meta, which is what fm-pr-merge.sh
+  # resolves that PR through, so tearing down now would strand a mergeable PR with no
+  # guarded path to land it.
+  if [ -n "$PR_URL" ]; then
+    pr_open_state
+    case $? in
+      0)
+        echo "REFUSED: worktree $WT belongs to task $ID, whose recorded PR is still open: $PR_URL" >&2
+        echo "Tearing down now deletes the metadata bin/fm-pr-merge.sh needs, stranding a PR with no guarded path to land it." >&2
+        echo "Get the PR merged with bin/fm-pr-merge.sh once it is green and merge is authorized, or close it on GitHub, then retry teardown." >&2
+        return 1
+        ;;
+      2)
+        echo "REFUSED: cannot confirm whether task $ID's recorded PR ($PR_URL) is still open; GitHub was unreachable or returned an error." >&2
+        echo "Retry once GitHub is reachable, confirm the PR's state directly on GitHub, or get the captain's explicit OK to discard, then --force." >&2
+        return 1
+        ;;
+    esac
   fi
 }
 

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -284,6 +284,45 @@ SH
   chmod +x "$case_dir/fakebin/gh-axi" "$case_dir/fakebin/gh"
 }
 
+# Override `gh pr view` to report the recorded PR as OPEN, regardless of target.
+add_gh_pr_open() {
+  local case_dir=$1
+  cat > "$case_dir/fakebin/gh" <<'SH'
+#!/usr/bin/env bash
+case "${1:-} ${2:-}" in
+  "pr view")
+    case " $* " in
+      *"state,headRefOid"*) printf '%s\t%s\n' 'OPEN' '' ; exit 0 ;;
+    esac
+    ;;
+esac
+echo "error: pull request not found" >&2
+exit 1
+SH
+  chmod +x "$case_dir/fakebin/gh"
+}
+
+# Override `gh pr view` to report the recorded PR as CLOSED (not merged, not open),
+# regardless of target. Used both by the closed-PR-allows case and by tests that
+# record a pr= only incidentally and do not care about its state, so they are not
+# newly refused by the open-PR guard's default-stub "not found" error.
+add_gh_pr_closed() {
+  local case_dir=$1
+  cat > "$case_dir/fakebin/gh" <<'SH'
+#!/usr/bin/env bash
+case "${1:-} ${2:-}" in
+  "pr view")
+    case " $* " in
+      *"state,headRefOid"*) printf '%s\t%s\n' 'CLOSED' '' ; exit 0 ;;
+    esac
+    ;;
+esac
+echo "error: pull request not found" >&2
+exit 1
+SH
+  chmod +x "$case_dir/fakebin/gh"
+}
+
 append_pr_meta_for_current_head() {
   local case_dir=$1 head
   head=$(git -C "$case_dir/wt" rev-parse HEAD)
@@ -584,6 +623,7 @@ test_teardown_prompts_tasks_axi_done_when_compatible() {
   case_dir=$(make_case tasks-axi-reminder)
   write_meta "$case_dir" no-mistakes ship
   printf '%s\n' 'pr=https://github.com/example/repo/pull/7' >> "$case_dir/state/task-x1.meta"
+  add_gh_pr_closed "$case_dir"
   add_compatible_tasks_axi "$case_dir"
 
   out=$(run_teardown "$case_dir") || fail "teardown failed with compatible tasks-axi"
@@ -604,6 +644,7 @@ test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present() {
   write_meta "$case_dir" no-mistakes ship
   printf '%s\n' 'pr=https://github.com/example/repo/pull/7' >> "$case_dir/state/task-x1.meta"
   printf '%s\n' manual > "$case_dir/config/backlog-backend"
+  add_gh_pr_closed "$case_dir"
   add_compatible_tasks_axi "$case_dir"
 
   out=$(run_teardown "$case_dir") || fail "teardown failed with manual backlog backend"
@@ -949,6 +990,87 @@ test_gh_error_and_content_absent_refuses() {
   expect_code 1 "$rc" "gh-error: teardown should refuse when the PR lookup errors and content is not landed"
   grep -q REFUSED "$case_dir/stderr" || fail "gh-error: no REFUSED line in stderr"
   pass "gh lookup error with content not in default refuses (fail-safe)"
+}
+
+# Open-PR guard: teardown deletes state/<id>.meta, which is what fm-pr-merge.sh
+# resolves the recorded PR through. A branch can be fully pushed and reachable from
+# a remote-tracking branch (so the dirty/unpushed/landed checks above find nothing
+# to refuse) while its own PR still sits open - exactly tonight's incident. No
+# wt_commit is needed to set these cases up: make_case's worktree branch starts at
+# the same commit already pushed as origin/main, so it is dirty=empty,
+# unpushed=empty by construction, isolating the open-PR check from the checks above.
+#   (z1) recorded PR confirmed OPEN                    -> REFUSE (the fix)
+#   (z2) recorded PR confirmed OPEN + --force           -> ALLOW  (escape hatch)
+#   (z3) recorded PR lookup errors (forge unreachable)  -> REFUSE (fail-safe)
+#   (z4) recorded PR confirmed CLOSED (not merged)       -> ALLOW  (not open, not blocking)
+test_open_pr_on_clean_pushed_branch_refuses() {
+  local case_dir rc
+  case_dir=$(make_case open-pr-clean)
+  write_meta "$case_dir" no-mistakes ship
+  printf '%s\n' 'pr=https://github.com/example/repo/pull/7' >> "$case_dir/state/task-x1.meta"
+  add_gh_pr_open "$case_dir"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "open-pr-clean: teardown should refuse a still-open recorded PR"
+  grep -q REFUSED "$case_dir/stderr" || fail "open-pr-clean: no REFUSED line in stderr"
+  grep -q "pull/7" "$case_dir/stderr" || fail "open-pr-clean: refusal did not name the open PR"
+  grep -q "fm-pr-merge.sh" "$case_dir/stderr" || fail "open-pr-clean: refusal did not point at the guarded merge path"
+  pass "teardown refuses a task whose recorded PR is still open, even on an otherwise clean pushed branch"
+}
+
+test_open_pr_force_overrides() {
+  local case_dir rc
+  case_dir=$(make_case open-pr-force)
+  write_meta "$case_dir" no-mistakes ship
+  printf '%s\n' 'pr=https://github.com/example/repo/pull/7' >> "$case_dir/state/task-x1.meta"
+  add_gh_pr_open "$case_dir"
+
+  set +e
+  run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "open-pr-force: --force should bypass the open-PR check"
+  pass "task with an open recorded PR is torn down under --force (escape hatch)"
+}
+
+test_open_pr_lookup_error_refuses() {
+  local case_dir rc
+  case_dir=$(make_case open-pr-gh-error)
+  write_meta "$case_dir" no-mistakes ship
+  printf '%s\n' 'pr=https://github.com/example/repo/pull/7' >> "$case_dir/state/task-x1.meta"
+  add_gh_axi_error "$case_dir"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "open-pr-gh-error: teardown should refuse when it cannot confirm the recorded PR is closed"
+  grep -q REFUSED "$case_dir/stderr" || fail "open-pr-gh-error: no REFUSED line in stderr"
+  grep -q "cannot confirm" "$case_dir/stderr" || fail "open-pr-gh-error: refusal did not say it could not confirm the PR state"
+  pass "teardown refuses rather than guess when it cannot confirm a recorded PR's open/closed state"
+}
+
+test_closed_pr_on_clean_pushed_branch_allows() {
+  local case_dir rc
+  case_dir=$(make_case closed-pr-clean)
+  write_meta "$case_dir" no-mistakes ship
+  printf '%s\n' 'pr=https://github.com/example/repo/pull/7' >> "$case_dir/state/task-x1.meta"
+  add_gh_pr_closed "$case_dir"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "closed-pr-clean: teardown should allow a confirmed-closed (not open) recorded PR"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "closed-pr-clean: teardown printed a REFUSED line"
+  pass "a recorded PR that is confirmed closed (not merged, not open) does not block teardown"
 }
 
 test_stale_index_lock_cleared_and_teardown_succeeds() {
@@ -2622,6 +2744,10 @@ test_content_in_default_fallback_allows
 test_content_fallback_refreshes_stale_origin_ref
 test_dirty_worktree_refuses
 test_gh_error_and_content_absent_refuses
+test_open_pr_on_clean_pushed_branch_refuses
+test_open_pr_force_overrides
+test_open_pr_lookup_error_refuses
+test_closed_pr_on_clean_pushed_branch_allows
 test_stale_index_lock_cleared_and_teardown_succeeds
 test_live_index_lock_is_never_removed_and_teardown_refuses
 test_lsof_error_never_clears_index_lock


### PR DESCRIPTION
## Summary

Tearing down a task deletes `state/<id>.meta`, which is what `bin/fm-pr-merge.sh` resolves the task's PR through. Two incidents an hour apart showed that a task can be torn down while its PR is still open, stranding a proven, mergeable PR with no guarded path to land it.

The existing landed-work check in `validate_worktree_teardown_safety` only inspects local git state (dirty, unpushed, or unreachable-but-landed commits). A branch that is fully pushed and reachable from a remote-tracking branch passes that check cleanly even while its own PR is still open - exactly what happened tonight.

## What changed

- Added `pr_open_state()` next to `pr_is_merged()` in `bin/fm-teardown.sh`, reusing the same `gh pr view --json state,headRefOid` query shape so both share one call pattern (and existing test stubs).
- Added a new refusal at the end of `validate_worktree_teardown_safety`, gated on a non-empty recorded `pr=`, so it never runs for scout/local-only/secondmate teardowns (none of which ever record one).

## Decisions

- **Placement**: the new check runs *after* the existing dirty/unpushed/landed checks, as an independent final gate, not nested inside the unpushed branch (it must fire even when nothing is unpushed - that's the actual incident shape). This keeps messages from contradicting: only one refusal fires per invocation, and the more urgent local-state refusals (uncommitted changes, unlanded commits) take precedence over the higher-level "is this task's PR actually done" question.
- **Forge unreachable**: refuses loudly, naming the PR it could not confirm, rather than tearing down blind - "unreachable" and "confirmed closed" are different facts, and guessing safe on the former defeats the point of the guard.
- **`--force`**: covers this check too, explicitly documented in the header and usage comment (not incidental - it falls out of the same `[ "$FORCE" != "--force" ] || return 0` early return the existing checks already use). `--force` already means "the captain explicitly authorized discarding this," and bypassing the open-PR guard means accepting the PR now needs to be merged or closed by hand, outside `fm-pr-merge.sh`'s guarded path.
- **Refusal text**: tells the operator to merge with `fm-pr-merge.sh` (once green and authorized) or close the PR on GitHub, then retry teardown.

## Test plan

- [x] `bin/fm-lint.sh bin/fm-teardown.sh tests/fm-teardown.test.sh` - clean (ShellCheck 0.11.0)
- [x] `bash tests/fm-teardown.test.sh` - all 62 cases pass, including 4 new ones covering: open PR refuses, `--force` overrides, gh lookup error refuses (fail-safe), and confirmed-closed PR does not block
- [x] `bash tests/fm-teardown-endpoint-safety.test.sh` - all 7 cases still pass (no regression)
- [x] Fixed two pre-existing tests (`test_teardown_prompts_tasks_axi_done_when_compatible`, `test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present`) that incidentally recorded a `pr=` without caring about its state; they now pin it to a confirmed-closed stub so they stay decoupled from this new check