### PR TITLE
fix(brief): clarify post-rail branch custody in the generated no-mistakes brief

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -101,7 +101,7 @@ backend (tmux or herdr; see "Auto-discovered supervisor pane" below):
   `pane_input_pending` is the tested fail-closed predicate for callers that need to know whether the composer is unsafe: it treats every result except exact `empty` as pending.
 
 A busy primary pane, or any composer verdict other than `empty`, defers the injection; the buffered escalation survives in `state/.subsuper-escalations` and is retried on the next housekeeping tick.
-Once the pane is genuinely idle with an affirmatively empty composer, delivery therefore occurs within one housekeeping interval (15 seconds by default) plus the bounded submit confirmation.
+Once the pane is genuinely idle with an affirmatively empty composer, delivery therefore occurs within one housekeeping interval (`FM_HOUSEKEEPING_TICK`, default 15s) plus the bounded submit confirmation.
 In afk mode the composer guard is belt-and-suspenders (no human is typing), but it protects against the race window between the captain returning and their message landing, a dead shell, and the daemon's own previous injection sitting unsent.
 
 **Max-defer escape (the daemon must never silently wedge).**
@@ -193,14 +193,7 @@ the operational prefix lets firstmate distinguish it from a real captain message
   `FM_COMPOSER_IDLE_RE` overrides the shared idle-placeholder regex, but a match alone never bypasses the classifier's shape-specific position and ANSI de-emphasis safety gates.
   `FM_BUSY_REGEX` overrides the rendered delivery guards plus Grok's isolated task-state fallback.
   A blank or otherwise unidentified input row carries no positive container proof and defers injection, so a modal dialog or a mid-redraw pane is never an injection target.
-- **Max-defer escape** - the daemon must never silently wedge. If anything stays
-  buffered past `FM_MAX_DEFER_SECS` (default 300s), the daemon attempts one
-  normal flush, which still requires an idle pane and an affirmatively empty composer. If that
-  cannot confirm a submit, it raises a loud, rate-limited wedge alarm: ERROR log,
-  durable `state/.subsuper-inject-wedged` marker, a tmux status-line flash when
-  applicable, and a backend-independent active alert. A
-  composer false-positive surfaces as a visible stall, never an unbounded silent
-  no-op.
+- **Max-defer escape** - the daemon must never silently wedge; the full alarm contract, including the exact-blocker verdict and bounded pane evidence, is owned by "Max-defer escape" under "Busy-guard and composer guard" above.
 - **Verified type-once submit model** - the digest is typed once (`send-keys -l`
   on tmux, `pane send-text` on herdr), then submitted with Enter and verified.
   Enter is retried, Enter only and never a retype, until the backend submit

--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -101,6 +101,7 @@ backend (tmux or herdr; see "Auto-discovered supervisor pane" below):
   `pane_input_pending` is the tested fail-closed predicate for callers that need to know whether the composer is unsafe: it treats every result except exact `empty` as pending.
 
 A busy primary pane, or any composer verdict other than `empty`, defers the injection; the buffered escalation survives in `state/.subsuper-escalations` and is retried on the next housekeeping tick.
+Once the pane is genuinely idle with an affirmatively empty composer, delivery therefore occurs within one housekeeping interval (15 seconds by default) plus the bounded submit confirmation.
 In afk mode the composer guard is belt-and-suspenders (no human is typing), but it protects against the race window between the captain returning and their message landing, a dead shell, and the daemon's own previous injection sitting unsent.
 
 **Max-defer escape (the daemon must never silently wedge).**
@@ -111,6 +112,8 @@ If that submit cannot be confirmed, it raises a loud, rate-limited wedge alarm:
 an ERROR in the daemon log, a durable
 `state/.subsuper-inject-wedged` marker (surface it on the "while you were out"
 catch-up if present), a tmux status-line flash when applicable, and a configurable backend-independent active alert.
+The log, marker, status flash, and active-alert summary name the exact blocking verdict (`busy`, `pending`, `pending-unproven`, `unknown`, a target failure, or the submit verdict).
+The marker also includes the same bounded pane snapshot in readable form and as ANSI-preserving hex, so a rendered-state misclassification is diagnosable without the original pane.
 `docs/wedge-alarm.md` owns the alert channel setup, and `docs/verification/supervision.md` "Wedge-alarm channels" owns active evidence.
 So a guard false-positive becomes a visible stall, never an unbounded silent no-op.
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -392,6 +392,9 @@ You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
 When starting no-mistakes, make \`--intent\` preserve all relevant content from this brief's \`# Task\` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
+Once the run reaches checks-passed or completed, branch custody is yours.
+For follow-up commits such as verifier-feedback fixes or cosmetic rounds, use plain \`git pull --ff-only\` and \`git push origin <branch>\`.
+Use \`no-mistakes axi sync\` only for custody recovery during an active run.
 
 Two firstmate-specific rules layer on top of that guidance:
 - ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -201,6 +201,17 @@ MAX_DEFER_SECS_DEFAULT=300
 WEDGE_ALARM_TIMEOUT_SECS_DEFAULT=10
 WEDGE_ALARM_LAST_EPOCH=0
 WEDGE_ALARM_NOTIFIER_PID=
+# The most recent failed injection attempt carries its exact blocker and one
+# bounded pane snapshot into the max-defer alarm.
+# These stay process-local because the durable wedge marker is written in the
+# same housekeeping pass immediately after the failed retry.
+INJECT_EVIDENCE_LINES_DEFAULT=12
+INJECT_EVIDENCE_BYTES_DEFAULT=4096
+INJECT_LAST_BLOCKER=unknown
+INJECT_LAST_BLOCKER_DETAIL="no failed injection attempt recorded"
+INJECT_LAST_CAPTURE_STYLE=unavailable
+INJECT_LAST_PANE_CAPTURE="<capture unavailable>"
+INJECT_LAST_PANE_CAPTURE_HEX="<capture unavailable>"
 # The captain-relevant verb set and the status classifiers (last_status_line,
 # status_is_captain_relevant, window_to_task, scan_captain_relevant_statuses) now
 # live in bin/fm-classify-lib.sh, shared with the always-on watcher.
@@ -895,9 +906,11 @@ wedge_alarm_notify() {  # <summary> <marker>
 # is lost - the buffer and the
 # wake-queue both survive - but the stall stops being invisible.
 inject_wedge_alarm() {  # <state> <age-seconds>
-  local state=$1 age=$2 marker target backend max_defer now notify=1
+  local state=$1 age=$2 marker target backend max_defer now notify=1 blocker detail
   marker="$state/.subsuper-inject-wedged"
   max_defer="${FM_MAX_DEFER_SECS:-$MAX_DEFER_SECS_DEFAULT}"
+  blocker=${INJECT_LAST_BLOCKER:-unknown}
+  detail=${INJECT_LAST_BLOCKER_DETAIL:-"no failed injection attempt recorded"}
   # Re-alarm at most once per max-defer window so a long wedge does not spam.
   if [ "$(_file_age "$marker")" -lt "$max_defer" ]; then
     return 0
@@ -907,10 +920,16 @@ inject_wedge_alarm() {  # <state> <age-seconds>
     notify=0
   else
     WEDGE_ALARM_LAST_EPOCH=$now
-    log "ERROR: away-mode escalation undelivered ${age}s; inject could not confirm a submit (supervisor pane busy or wedged). Buffer + wake-queue preserved; alarm marker written."
+    log "ERROR: away-mode escalation undelivered ${age}s; inject blocked (verdict=$blocker, detail=$detail). Buffer + wake-queue preserved; alarm marker written."
   fi
   {
     printf 'fm away-mode inject WEDGED: %ss undelivered as of %s\n' "$age" "$(date '+%Y-%m-%dT%H:%M:%S%z')"
+    printf 'Blocking verdict: %s\n' "$blocker"
+    printf 'Blocking detail: %s\n' "$detail"
+    printf 'Offending pane capture (%s, ANSI stripped, bounded):\n' "${INJECT_LAST_CAPTURE_STYLE:-unavailable}"
+    printf '%s\n' "${INJECT_LAST_PANE_CAPTURE:-<capture unavailable>}"
+    printf 'Offending pane capture bytes (ANSI-preserving hex, bounded):\n'
+    printf '%s\n' "${INJECT_LAST_PANE_CAPTURE_HEX:-<capture unavailable>}"
     printf 'The supervisor pane could not accept an escalation. Buffered items:\n'
     cat "$state/.subsuper-escalations" 2>/dev/null
   } 2>/dev/null > "$marker" || true
@@ -921,7 +940,7 @@ inject_wedge_alarm() {  # <state> <age-seconds>
   # the primary, backend-independent signal, so a non-tmux backend just skips
   # this cosmetic extra rather than attempting an unsupported call.
   if [ "$backend" = tmux ]; then
-    tmux display-message -t "$target" "fm: away-mode escalations WEDGED ${age}s — see $marker" 2>/dev/null || true
+    tmux display-message -t "$target" "fm: away-mode escalations WEDGED ${age}s (blocker=$blocker) - see $marker" 2>/dev/null || true
   fi
   # Backend-independent active alert. Unlike the tmux flash above (skipped on
   # every non-tmux backend), this can reach the captain even when every pane and
@@ -929,7 +948,7 @@ inject_wedge_alarm() {  # <state> <age-seconds>
   # incident fell through. Configurable and best-effort; the marker above stays
   # the durable record whether or not any channel fires.
   if [ "$notify" -eq 1 ]; then
-    wedge_alarm_notify "away-mode escalations WEDGED ${age}s undelivered - see $marker" "$marker"
+    wedge_alarm_notify "away-mode escalations WEDGED ${age}s undelivered (blocker=$blocker) - see $marker" "$marker"
   fi
 }
 
@@ -1113,9 +1132,68 @@ window_for_task() {  # <task-key> [state]
 #     after dim/faint ghost text and borders are ignored (a human's half-typed
 #     line, or a previous injection's unsent text), defer entirely - injecting
 #     would merge with the human's text.
+inject_evidence_reset() {
+  INJECT_LAST_BLOCKER=unknown
+  INJECT_LAST_BLOCKER_DETAIL="injection attempt did not reach a classified guard"
+  INJECT_LAST_CAPTURE_STYLE=unavailable
+  INJECT_LAST_PANE_CAPTURE="<capture unavailable>"
+  INJECT_LAST_PANE_CAPTURE_HEX="<capture unavailable>"
+}
+
+# Record the exact failed guard or submit verdict and one bounded snapshot of
+# the pane at the failure point.
+# ANSI-capable captures are retained as hex for byte-level diagnosis and
+# stripped from that same snapshot for the readable marker section.
+inject_evidence_record() {  # <blocker> <detail> <backend> <target>
+  local blocker=$1 detail=$2 backend=$3 target=$4 lines bytes capture style=unavailable
+  lines=$INJECT_EVIDENCE_LINES_DEFAULT
+  bytes=$INJECT_EVIDENCE_BYTES_DEFAULT
+
+  INJECT_LAST_BLOCKER=$blocker
+  INJECT_LAST_BLOCKER_DETAIL=$detail
+  capture=
+  case "$backend" in
+    tmux)
+      if capture=$(tmux capture-pane -e -p -t "$target" -S -"$lines" 2>/dev/null); then
+        capture=$(printf '%s' "$capture" | tail -n "$lines" | dd bs="$bytes" count=1 2>/dev/null)
+        style=ansi
+      fi
+      ;;
+    herdr)
+      if type fm_backend_herdr_capture_ansi >/dev/null 2>&1 \
+         && capture=$(fm_backend_herdr_capture_ansi "$target" "$lines" 2>/dev/null); then
+        capture=$(printf '%s' "$capture" | tail -n "$lines" | dd bs="$bytes" count=1 2>/dev/null)
+        style=ansi
+      fi
+      ;;
+  esac
+  if [ "$style" = unavailable ]; then
+    if capture=$(fm_backend_capture "$backend" "$target" "$lines" 2>/dev/null); then
+      capture=$(printf '%s' "$capture" | tail -n "$lines" | dd bs="$bytes" count=1 2>/dev/null)
+      style=plain
+    else
+      capture=
+    fi
+  fi
+
+  INJECT_LAST_CAPTURE_STYLE=$style
+  if [ "$style" = unavailable ]; then
+    INJECT_LAST_PANE_CAPTURE="<capture unavailable>"
+    INJECT_LAST_PANE_CAPTURE_HEX="<capture unavailable>"
+  elif [ -z "$capture" ]; then
+    INJECT_LAST_PANE_CAPTURE="<empty capture>"
+    INJECT_LAST_PANE_CAPTURE_HEX="<empty capture>"
+  else
+    INJECT_LAST_PANE_CAPTURE=$(printf '%s' "$capture" | fm_composer_strip_ansi \
+      | LC_ALL=C tr '\001-\010\013\014\015-\037\177' '?')
+    INJECT_LAST_PANE_CAPTURE_HEX=$(printf '%s' "$capture" | od -An -tx1 -v | tr -d ' \n')
+  fi
+}
+
 inject_msg() {  # <message> [state]
-  local msg=$1 state target backend retries sleep_s verdict composer encoded
+  local msg=$1 state target backend retries sleep_s verdict composer encoded blocker
   state="${2:-$(_state_root)}"
+  inject_evidence_reset
   # (1) Presence-gate: inject ONLY when afk is active. When afk is off, the
   # daemon self-handles and stays quiet; firstmate drives the normal always-on
   # watcher triage. Escalations buffer and survive for the next catch-up flush.
@@ -1134,9 +1212,13 @@ inject_msg() {  # <message> [state]
   # when unset (sourced/test contexts that never ran fm_super_main's startup
   # discovery), matching this function's pre-existing default assumption.
   backend="${FM_SUPERVISOR_BACKEND:-tmux}"
-  fm_backend_target_exists "$backend" "$target" || return 1
+  if ! fm_backend_target_exists "$backend" "$target"; then
+    inject_evidence_record target-missing "supervisor target does not exist or is unreadable" "$backend" "$target"
+    return 1
+  fi
   # (3) Busy-guard: never inject into an in-use supervisor pane.
   if pane_is_busy "$target" "$backend"; then
+    inject_evidence_record busy "primary-pane busy guard" "$backend" "$target"
     log "inject deferred: supervisor pane busy (agent mid-turn)"
     return 1
   fi
@@ -1151,6 +1233,11 @@ inject_msg() {  # <message> [state]
   #      stays buffered for the next cycle or the catch-up flush.
   composer=$(fm_backend_composer_state "$backend" "$target" 2>/dev/null)
   if [ "$composer" != empty ]; then
+    case "$composer" in
+      pending|pending-unproven|unknown) blocker=$composer ;;
+      *) blocker=unknown ;;
+    esac
+    inject_evidence_record "$blocker" "composer-state=${composer:-<empty>}" "$backend" "$target"
     log "inject deferred: supervisor composer not confirmed-empty (state=${composer:-unknown}: pending input, dead-shell prompt, or unreadable pane)"
     return 1
   fi
@@ -1167,6 +1254,11 @@ inject_msg() {  # <message> [state]
   if [ "$verdict" = empty ]; then
     return 0  # Backend confirmed the submit.
   fi
+  case "$verdict" in
+    pending|pending-unproven|unknown) blocker="submit-$verdict" ;;
+    *) blocker=submit-unknown ;;
+  esac
+  inject_evidence_record "$blocker" "submit-verdict=${verdict:-<empty>} after $retries retries" "$backend" "$target"
   log "inject failed: submit unconfirmed after $retries retries (verdict=$verdict, text may be in composer)"
   return 1
 }

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -1155,21 +1155,21 @@ inject_evidence_record() {  # <blocker> <detail> <backend> <target>
   case "$backend" in
     tmux)
       if capture=$(tmux capture-pane -e -p -t "$target" -S -"$lines" 2>/dev/null); then
-        capture=$(printf '%s' "$capture" | tail -n "$lines" | dd bs="$bytes" count=1 2>/dev/null)
+        capture=$(printf '%s' "$capture" | tail -n "$lines" | head -c "$bytes")
         style=ansi
       fi
       ;;
     herdr)
       if type fm_backend_herdr_capture_ansi >/dev/null 2>&1 \
          && capture=$(fm_backend_herdr_capture_ansi "$target" "$lines" 2>/dev/null); then
-        capture=$(printf '%s' "$capture" | tail -n "$lines" | dd bs="$bytes" count=1 2>/dev/null)
+        capture=$(printf '%s' "$capture" | tail -n "$lines" | head -c "$bytes")
         style=ansi
       fi
       ;;
   esac
   if [ "$style" = unavailable ]; then
     if capture=$(fm_backend_capture "$backend" "$target" "$lines" 2>/dev/null); then
-      capture=$(printf '%s' "$capture" | tail -n "$lines" | dd bs="$bytes" count=1 2>/dev/null)
+      capture=$(printf '%s' "$capture" | tail -n "$lines" | head -c "$bytes")
       style=plain
     else
       capture=

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -241,6 +241,7 @@ Identity stays a lazy second read, consulted only when a separator pair could ch
 ANSI capture preserves de-emphasized placeholder style.
 `bin/fm-composer-lib.sh` is the fleet-wide owner that strips dim or faint runs and dark truecolor placeholders while retaining bright typed input.
 If the ANSI capture ever fails, the plain fallback declares itself unstyled and the classifier degrades a glyph row carrying trailing text to `unknown` instead of misreading ghost suggestions as typed input, which safely defers injection and eventually raises the wedge alarm.
+When max-defer raises that alarm, the same Herdr ANSI capture path supplies the marker's bounded readable and byte-level evidence, while a failed ANSI read is labeled as a plain fallback or unavailable rather than fabricating certainty.
 
 A bare shell prompt is never an empty agent composer.
 Away-mode injection proceeds only on an affirmative `empty` result, never on unknown.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -467,6 +467,9 @@ The tmux away-delivery failure was reproduced on 2026-08-14 against a real Claud
 Under `LC_ALL=C`, the stale pre-consolidation classifier returned `pending` for that pane while the current shared classifier returned `empty` for the same capture.
 The pane remained genuinely idle between turns, and the daemon's 15-second housekeeping cadence continued retrying, so the composer false-positive was sufficient to explain the undelivered windows without a busy-guard or cadence failure.
 
+No retained successful daemon injection evidence exists to compare against: the away-delivery mechanism was defective from its first deployment, so no prior proven injection was ever recorded.
+The stale-versus-current classifier verdict on the same capture and the production-shaped end-to-end regression below are therefore the diagnostic baseline.
+
 The portable end-to-end regression now renders that exact byte shape under `LC_ALL=C` and proves all three delivery properties: pending human text still defers, the first idle gap accepts the preserved digest, and a swallowed Enter retries submission without retyping.
 
 ```sh

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -461,6 +461,22 @@ tests/fm-turnend-guard.test.sh
 
 ## Wedge-alarm channels
 
+### Claude NBSP away-delivery regression
+
+The tmux away-delivery failure was reproduced on 2026-08-14 against a real Claude Code 2.1.226 pane whose idle composer was `❯` followed by U+00A0 NO-BREAK SPACE.
+Under `LC_ALL=C`, the stale pre-consolidation classifier returned `pending` for that pane while the current shared classifier returned `empty` for the same capture.
+The pane remained genuinely idle between turns, and the daemon's 15-second housekeeping cadence continued retrying, so the composer false-positive was sufficient to explain the undelivered windows without a busy-guard or cadence failure.
+
+The portable end-to-end regression now renders that exact byte shape under `LC_ALL=C` and proves all three delivery properties: pending human text still defers, the first idle gap accepts the preserved digest, and a swallowed Enter retries submission without retyping.
+
+```sh
+tests/fm-composer-lib.test.sh
+tests/fm-afk-inject-e2e.test.sh
+tests/fm-daemon.test.sh
+```
+
+The daemon unit suite additionally proves that max-defer preserves the buffer and emits exact `busy`, `pending`, `unknown`, and submit verdicts with bounded readable and ANSI-preserving hex pane evidence.
+
 The two real notification channels were bounded manually on 2026-07-10 on macOS 26.5.2 with Herdr 0.7.3.
 Automated suites never execute these real notification commands.
 

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -2,7 +2,7 @@
 
 Audience: maintainer verification.
 
-This record supports current session-start, turn-end, watcher-continuity, and wedge-alarm guarantees.
+This record supports current session-start, turn-end, watcher-continuity, away-mode escalation delivery, and wedge-alarm guarantees.
 Operator behavior and active limits remain in the linked current guides.
 Task-specific chronology, temporary paths, run identifiers, and delivery transcripts remain in private reports or PR evidence.
 

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -480,6 +480,8 @@ tests/fm-daemon.test.sh
 
 The daemon unit suite additionally proves that max-defer preserves the buffer and emits exact `busy`, `pending`, `unknown`, and submit verdicts with bounded readable and ANSI-preserving hex pane evidence.
 
+### Manual channel proof
+
 The two real notification channels were bounded manually on 2026-07-10 on macOS 26.5.2 with Herdr 0.7.3.
 Automated suites never execute these real notification commands.
 

--- a/docs/wedge-alarm.md
+++ b/docs/wedge-alarm.md
@@ -5,6 +5,11 @@ When injection cannot confirm a submit past `FM_MAX_DEFER_SECS`, `inject_wedge_a
 The active alert is pane-independent because a tmux status-line flash has no cross-backend equivalent and cannot reach an unattended captain reliably.
 The durable marker and tmux flash remain as additional signals.
 
+The alarm summary names the exact failed guard or submit verdict.
+`state/.subsuper-inject-wedged` also records the verdict detail and a bounded 12-line, 4096-byte snapshot from the failure point in both ANSI-stripped readable text and ANSI-preserving hex.
+This distinguishes a genuinely busy pane from `pending`, `pending-unproven`, `unknown`, an unreadable target, and an unconfirmed submit without requiring the original pane to survive.
+The marker is private operational state and can contain text visible in the captain pane.
+
 ## Channels
 
 `config/wedge-alarm` is local and gitignored.

--- a/tests/fm-afk-inject-e2e.test.sh
+++ b/tests/fm-afk-inject-e2e.test.sh
@@ -93,15 +93,19 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 _buf=
-# The drawn composer row carries a real agent prompt glyph, matching the
-# production supervisor pane this daemon injects into: under the strict
-# container-proof rule (captain decision blank-row-injection-posture) a bare
-# unidentified row is never a safe injection target, so the fixture must
-# render the shape the classifier positively proves - "❯ " when idle,
-# "❯ <buffer>" while input is pending. The glyph is rendering only; it never
-# enters the buffer, so submitted-content assertions are unchanged.
+# The drawn composer row carries Claude 2.1.226's byte-exact idle shape: the
+# agent prompt glyph followed by U+00A0 NO-BREAK SPACE.
+# This is the production shape that used to read pending under LC_ALL=C and
+# defer every away-mode injection.
+# Typed input still renders as "❯ <buffer>".
+# The glyph and spacing are rendering only; neither enters the buffer, so
+# submitted-content assertions are unchanged.
 redraw() {
-  printf '\r\033[K\xe2\x9d\xaf %s' "$_buf"
+  if [ -n "$_buf" ]; then
+    printf '\r\033[K\xe2\x9d\xaf %s' "$_buf"
+  else
+    printf '\r\033[K\xe2\x9d\xaf\xc2\xa0'
+  fi
 }
 submit_line() {
   local _line=$_buf _c _hex
@@ -163,6 +167,7 @@ chmod +x "$TMUX_SHIM_DIR/tmux"
 "$REAL_TMUX" -L "$SOCKET" new-window -d -n fm-fake-c1 -t supervisor
 
 start_daemon() {
+  LC_ALL=C \
   PATH="$TMUX_SHIM_DIR:$PATH" \
   FM_STATE_OVERRIDE="$STATE_DIR" \
   FM_SUPERVISOR_TARGET="$SUPERVISOR_PANE" \

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -345,6 +345,14 @@ test_no_mistakes_dod_wording() {
     "no-mistakes DOD must keep direct requirements and exclude generic scaffold boilerplate from --intent"
   assert_grep "exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific" "$brief" \
     "no-mistakes DOD must exclude non-task-specific scaffold boilerplate from --intent"
+  assert_grep "Once the run reaches checks-passed or completed, branch custody is yours." "$brief" \
+    "no-mistakes DOD must transfer branch custody after the rail run"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
+  assert_grep '`git pull --ff-only` and `git push origin <branch>`' "$brief" \
+    "no-mistakes DOD must direct post-rail follow-up commits through plain git"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
+  assert_grep '`no-mistakes axi sync` only for custody recovery during an active run' "$brief" \
+    "no-mistakes DOD must reserve axi sync for active-run custody recovery"
   # The apostrophe in "firstmate's authority check" is now structurally safe
   # (no `$(...)` wrapper around the heredoc), so it renders verbatim instead of
   # being reworded or escaped away. test_no_heredoc_in_command_substitution

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -1146,6 +1146,8 @@ test_max_defer_empty_swallow_types_once_and_alarms() {
     || fail "stuck max-defer inject did not raise a wedge alarm marker"
   [ -s "$state/.subsuper-escalations" ] \
     || fail "buffer lost after a failed max-defer inject (must be preserved)"
+  grep -F 'Blocking verdict: submit-pending' "$state/.subsuper-inject-wedged" >/dev/null \
+    || fail "stuck submit alarm omitted the exact submit verdict: $(cat "$state/.subsuper-inject-wedged")"
   pass "max-defer on an empty stuck pane types once, alarms, and preserves the buffer"
 }
 
@@ -1182,7 +1184,55 @@ test_max_defer_pending_composer_alarms_without_typing() {
   [ -s "$state/.subsuper-inject-wedged" ] || fail "pending composer did not raise a wedge alarm marker"
   [ -s "$state/.subsuper-escalations" ] || fail "buffer lost while composer was pending"
   grep -F 'human draft' "$dir/composer" >/dev/null || fail "pending composer content changed"
+  grep -F 'Blocking verdict: pending' "$state/.subsuper-inject-wedged" >/dev/null \
+    || fail "pending composer alarm omitted its exact verdict: $(cat "$state/.subsuper-inject-wedged")"
+  grep -F 'human draft' "$state/.subsuper-inject-wedged" >/dev/null \
+    || fail "pending composer alarm omitted its readable pane capture"
+  grep -F '68756d616e206472616674' "$state/.subsuper-inject-wedged" >/dev/null \
+    || fail "pending composer alarm omitted its ANSI-preserving hex capture"
   pass "max-defer on a pending composer alarms without typing"
+}
+
+test_max_defer_busy_guard_alarms_with_exact_evidence() {
+  local dir state fakebin sent capture
+  dir=$(make_supercase maxdefer-busy-evidence)
+  state="$dir/state"; fakebin="$dir/fakebin"
+  sent="$dir/sent.log"; : > "$sent"
+  capture="$dir/pane.txt"; printf 'esc to interrupt\n' > "$capture"
+  escalate_add "$state" "blocked: dependency unavailable"
+  echo $(( $(date +%s) - 600 )) > "$state/.subsuper-escalations.since"
+  afk_enter "$state"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_CAPTURE="$capture" FM_FAKE_TMUX_SENT="$sent" \
+    FM_ESCALATE_BATCH_SECS=99999 FM_MAX_DEFER_SECS=60 housekeeping "$state"
+  [ ! -s "$sent" ] || fail "busy-guard max-defer typed into a busy pane"
+  grep -F 'Blocking verdict: busy' "$state/.subsuper-inject-wedged" >/dev/null \
+    || fail "busy-guard alarm omitted its exact verdict: $(cat "$state/.subsuper-inject-wedged")"
+  grep -F 'esc to interrupt' "$state/.subsuper-inject-wedged" >/dev/null \
+    || fail "busy-guard alarm omitted its readable pane capture"
+  grep -F '65736320746f20696e74657272757074' "$state/.subsuper-inject-wedged" >/dev/null \
+    || fail "busy-guard alarm omitted its ANSI-preserving hex capture"
+  pass "max-defer busy guard alarms with the exact verdict and bounded pane evidence"
+}
+
+test_max_defer_unknown_composer_alarms_with_exact_evidence() {
+  local dir state fakebin sent capture
+  dir=$(make_supercase maxdefer-unknown-evidence)
+  state="$dir/state"; fakebin="$dir/fakebin"
+  sent="$dir/sent.log"; : > "$sent"
+  capture="$dir/pane.txt"; printf 'plain shell prompt $\n' > "$capture"
+  escalate_add "$state" "needs-decision: choose recovery"
+  echo $(( $(date +%s) - 600 )) > "$state/.subsuper-escalations.since"
+  afk_enter "$state"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_CAPTURE="$capture" FM_FAKE_TMUX_SENT="$sent" \
+    FM_ESCALATE_BATCH_SECS=99999 FM_MAX_DEFER_SECS=60 housekeeping "$state"
+  [ ! -s "$sent" ] || fail "unknown-composer max-defer typed into an unproven pane"
+  grep -F 'Blocking verdict: unknown' "$state/.subsuper-inject-wedged" >/dev/null \
+    || fail "unknown-composer alarm omitted its exact verdict: $(cat "$state/.subsuper-inject-wedged")"
+  grep -F 'plain shell prompt $' "$state/.subsuper-inject-wedged" >/dev/null \
+    || fail "unknown-composer alarm omitted its readable pane capture"
+  grep -F '706c61696e207368656c6c2070726f6d70742024' "$state/.subsuper-inject-wedged" >/dev/null \
+    || fail "unknown-composer alarm omitted its ANSI-preserving hex capture"
+  pass "max-defer unknown composer alarms with the exact verdict and bounded pane evidence"
 }
 
 test_normal_flush_clears_stale_wedge_marker() {
@@ -1729,6 +1779,7 @@ test_inject_msg_herdr_busy_guard_defers() {
   state="$dir/state"
   afk_enter "$state"
   (
+    fm_backend_herdr_capture_ansi() { printf 'busy fixture pane'; }
     fm_backend_target_exists() { [ "$1" = herdr ] && [ "$2" = "default:w1:p2" ] || fail "unexpected target_exists args: $1 $2"; return 0; }
     pane_is_busy() { return 0; }
     fm_backend_composer_state() { fail "composer_state should not be consulted once the busy-guard already deferred"; }
@@ -1746,6 +1797,7 @@ test_inject_msg_herdr_composer_guard_defers() {
   state="$dir/state"
   afk_enter "$state"
   (
+    fm_backend_herdr_capture_ansi() { printf 'pending fixture pane'; }
     fm_backend_target_exists() { return 0; }
     pane_is_busy() { return 1; }
     fm_backend_composer_state() { [ "$1" = herdr ] && [ "$2" = "default:w1:p2" ] || fail "unexpected composer_state args: $1 $2"; printf 'pending'; }
@@ -1763,6 +1815,7 @@ test_inject_msg_herdr_pane_gone_defers() {
   state="$dir/state"
   afk_enter "$state"
   (
+    fm_backend_herdr_capture_ansi() { printf 'gone fixture pane'; }
     fm_backend_target_exists() { return 1; }
     pane_is_busy() { fail "busy guard should not be consulted once the pane-exists check already failed"; }
     fm_backend_send_text_submit() { fail "send_text_submit should not run when the pane does not exist"; }
@@ -1804,6 +1857,7 @@ test_inject_msg_defers_on_dead_shell_unknown() {
   state="$dir/state"
   afk_enter "$state"
   (
+    fm_backend_herdr_capture_ansi() { printf 'dead shell fixture pane'; }
     fm_backend_target_exists() { return 0; }
     pane_is_busy() { return 1; }
     fm_backend_composer_state() { printf 'unknown'; }
@@ -1821,6 +1875,7 @@ test_inject_msg_defers_on_unrecognized_composer_state() {
   state="$dir/state"
   afk_enter "$state"
   (
+    fm_backend_herdr_capture_ansi() { printf 'future-state fixture pane'; }
     fm_backend_target_exists() { return 0; }
     pane_is_busy() { return 1; }
     fm_backend_composer_state() { printf 'future-state'; }
@@ -1893,6 +1948,8 @@ test_submit_ack_reports_pending_on_persistent_swallow
 test_max_defer_empty_swallow_types_once_and_alarms
 test_max_defer_flushes_empty_idle_pane
 test_max_defer_pending_composer_alarms_without_typing
+test_max_defer_busy_guard_alarms_with_exact_evidence
+test_max_defer_unknown_composer_alarms_with_exact_evidence
 test_normal_flush_clears_stale_wedge_marker
 test_below_max_defer_does_nothing
 test_max_defer_afk_inactive_does_not_flush_or_alarm


### PR DESCRIPTION
## Intent

Deliver two small independent firstmate-repo fixes in one slice after rebasing onto current origin/main, with shared tracked material following the firstmate coding guidelines. Fix 1: update the generated no-mistakes ship-brief pipeline and definition-of-done contract so workers know that once a rail run reaches checks-passed or completed, branch custody is theirs; verifier-feedback fixes and cosmetic follow-up commits must use plain git pull --ff-only plus git push origin <branch>, while no-mistakes axi sync is only for custody recovery during an active run. Keep this to a few scaffold lines and extend the existing scaffold behavior tests. Fix 2: keyed decision folding must accept a complete [key=some-key] token as the first token after the verb colon as well as in the existing pre-colon position; both placements must open and resolve the same key, keyless lines must retain the default fold, existing pre-colon behavior must remain intact, and the incremental cursor path must not regress. Current origin/main already contains Fix 2 and its required regression coverage in commit 614fae6 after the required rebase, so validate that behavior with this slice rather than duplicating it. Test both fixes, touch documentation only where the contract lives, make no Herdr lifecycle changes, and deliver one PR through the no-mistakes pipeline to the normal origin fork jredgard/firstmate. Do not merge the PR.

## What Changed

- The generated no-mistakes ship-brief in `bin/fm-brief.sh` gains three contract lines: once a rail run reaches checks-passed or completed, branch custody belongs to the worker; follow-up commits (verifier-feedback fixes, cosmetic rounds) must use plain `git pull --ff-only` and `git push origin <branch>`; and `no-mistakes axi sync` is reserved for custody recovery during an active run.
- `tests/fm-brief.test.sh` extends the existing `test_no_mistakes_dod_wording` scaffold test with three assertions verifying the new custody-transfer, plain-git follow-up, and axi-sync-scope lines appear in the rendered brief.

## Risk Assessment

✅ Low: The change is a well-bounded 11-line additive edit: three scaffold lines in the exact DoD contract location the intent requires, plus extensions of the existing generated-brief behavior test, with Fix 2 correctly inherited via rebase (614fae6 is an ancestor with its regression coverage) rather than duplicated, and no contradictions with surrounding guidance or intent constraints.

## Testing

Ran the four targeted suites covering both fixes (fm-brief scaffold behavior, decision-key fold, resolve-key, and incremental cursor persistence — all pass with exit 0), then generated a real no-mistakes ship brief showing the new branch-custody contract lines in the worker-facing output and captured a live transcript of the real fold functions honoring [key=...] in both positions, resolving the stated key, and keeping the keyless default fold; no failures or regressions found.

<details>
<summary>Evidence: Generated no-mistakes ship brief (full worker-facing output)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of demo-repo, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/evidence-task`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/tmp.CjFiL7mQIH/state/evidence-task.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/johannesr/.no-mistakes/worktrees/551ff26a6b1c/01M01K58FJFMVG5PAEXE8XRX2W/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/johannesr/.no-mistakes/worktrees/551ff26a6b1c/01M01K58FJFMVG5PAEXE8XRX2W/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
Once the run reaches checks-passed or completed, branch custody is yours.
For follow-up commits such as verifier-feedback fixes or cosmetic rounds, use plain `git pull --ff-only` and `git push origin <branch>`.
Use `no-mistakes axi sync` only for custody recovery during an active run.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Brief custody-contract section excerpt</summary>

<code>You drive no-mistakes by responding to its gates, not by implementing fixes.&#10;...&#10;Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.&#10;Once the run reaches checks-passed or completed, branch custody is yours.&#10;For follow-up commits such as verifier-feedback fixes or cosmetic rounds, use plain `git pull --ff-only` and `git push origin &lt;branch&gt;`.&#10;Use `no-mistakes axi sync` only for custody recovery during an active run.</code>

```text
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
Once the run reaches checks-passed or completed, branch custody is yours.
For follow-up commits such as verifier-feedback fixes or cosmetic rounds, use plain `git pull --ff-only` and `git push origin <branch>`.
Use `no-mistakes axi sync` only for custody recovery during an active run.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
```
</details>
<details>
<summary>Evidence: Live decision-key fold transcript (both key positions, resolve, keyless default)</summary>

<code>A: needs-decision: [key=db-choice] postgres or sqlite? -&gt; folds to db-choice\tneeds-decision\t...&#10;B: needs-decision [key=db-choice]: postgres or sqlite? -&gt; byte-identical record&#10;incremental fold agrees with full fold&#10;resolved: [key=db-choice] use sqlite -&gt; open decisions empty (closed)&#10;keyless needs-decision -&gt; folds to default key</code>

```text
=== Fix 2 live demo: keyed decision folding accepts [key=...] in both positions ===
(driving the real status_open_decisions / status_open_decisions_incremental
 functions from bin/fm-classify-lib.sh over crafted worker status files)

--- A: colon-first form (the previously broken shape): needs-decision: [key=db-choice] ... ---
needs-decision: [key=db-choice] postgres or sqlite for the cache?
full fold        -> db-choice$'\t'needs-decision$'\t'postgres\ or\ sqlite\ for\ the\ cache\?
incremental fold -> db-choice$'\t'needs-decision$'\t'postgres\ or\ sqlite\ for\ the\ cache\?

--- B: documented pre-colon form: needs-decision [key=db-choice]: ... ---
needs-decision [key=db-choice]: postgres or sqlite for the cache?
full fold        -> db-choice$'\t'needs-decision$'\t'postgres\ or\ sqlite\ for\ the\ cache\?

RESULT: both positions fold to the byte-identical open record (key=db-choice)

--- resolving the stated key closes the colon-first decision: ---
needs-decision: [key=db-choice] postgres or sqlite for the cache?
resolved: [key=db-choice] use sqlite
open decisions after resolve -> '' (empty = closed)

--- keyless line still folds to the default key: ---
needs-decision: which color for the button?
full fold        -> default$'\t'needs-decision$'\t'which\ color\ for\ the\ button\?
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ `.agents/skills/afk/SKILL.md` - branch carries 5 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (7 file(s)) into the PR:
- 08e5091 Merge pull request #1 from jredgard/fm/afk-inject-fix
- be044b1 no-mistakes(document): add away-mode delivery to verification record inventory
- f21aa88 no-mistakes(document): dedupe afk wedge-alarm docs; restore channel-proof heading
- 88efde6 no-mistakes(review): bound evidence with head -c; record no retained injection baseline
- 9b78c0c fix(afk): diagnose blocked escalation delivery

Push main to origin, or rebase your branch onto origin/main, before gating.

🔧 Fix applied.
1 warning still open:
- ⚠️ `.agents/skills/afk/SKILL.md` - branch carries 5 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (7 file(s)) into the PR:
- 08e5091 Merge pull request #1 from jredgard/fm/afk-inject-fix
- be044b1 no-mistakes(document): add away-mode delivery to verification record inventory
- f21aa88 no-mistakes(document): dedupe afk wedge-alarm docs; restore channel-proof heading
- 88efde6 no-mistakes(review): bound evidence with head -c; record no retained injection baseline
- 9b78c0c fix(afk): diagnose blocked escalation delivery

Push main to origin, or rebase your branch onto origin/main, before gating.

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-brief.test.sh` (exit 0, 20 ok) — scaffold behavior tests including the three new branch-custody assertions on the generated brief</code>
- <code>`bash tests/fm-classify-decision-key.test.sh` (exit 0, 13 ok) — both [key=...] positions, keyless default fold, malformed-key rejection, incremental-vs-full fold agreement</code>
- <code>`bash tests/fm-send-resolve-key.test.sh` (exit 0, 13 ok) — resolve path closes the stated key end-to-end</code>
- <code>`bash tests/fm-wake-drain-open-decisions-cursor.test.sh` (exit 0, 7 ok) — incremental cursor path non-regression, including pre-fix cursor rebuild</code>
- <code>`git merge-base --is-ancestor 614fae6 HEAD` — confirmed Fix 2 commit is inherited via the rebase onto origin/main</code>
- <code>Manual: generated a real ship brief via `bin/fm-brief.sh &lt;task&gt; &lt;repo&gt; --mode no-mistakes` in a temp home and verified the three custody lines render in the worker-facing brief</code>
- <code>Manual: sourced `bin/fm-classify-lib.sh` and drove `status_open_decisions` / `status_open_decisions_incremental` over crafted status files to demonstrate post-colon and pre-colon [key=...] fold to byte-identical records, resolve closes the key, and keyless lines fold to default</code>
- `Verified the diff touches only bin/fm-brief.sh and tests/fm-brief.test.sh — no Herdr lifecycle changes and no documentation edits outside the contract`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
