### PR TITLE
ci: bound Herdr behavior shard with a 20-minute step timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,8 +170,10 @@ jobs:
   tests-herdr:
     name: Behavior tests (Herdr)
     runs-on: ubuntu-latest
-    # Real Herdr is slower than the portable suite; this is a hang tripwire,
-    # not the expected healthy end of the lane (estimate 15-40 min first cut).
+    # Healthy runs finish around 7 minutes. This job cap is a last-resort hang
+    # tripwire, not the expected end of the lane. The family-run step owns the
+    # tighter bound so a wedged suite fails fast with always() cleanup and
+    # timing artifacts still uploaded (docs/fm-test-portable-shards.md).
     timeout-minutes: 75
     steps:
       - uses: actions/checkout@v6
@@ -252,6 +254,9 @@ jobs:
           mkdir -p "$RUNNER_TEMP/fm-herdr"
           bin/fm-herdr-ci-cleanup.sh snapshot "$RUNNER_TEMP/fm-herdr/sessions-before.json"
       - name: Run real-Herdr family (serial, required)
+        # Comfortably above the ~7 min healthy wall and far below the 75 min
+        # job backstop. A hang must fail this step so cleanup still runs.
+        timeout-minutes: 20
         run: |
           set -eu
           mkdir -p "$RUNNER_TEMP/fm-test"

--- a/docs/fm-test-portable-shards.md
+++ b/docs/fm-test-portable-shards.md
@@ -105,10 +105,11 @@ Portable shards, each portable serial shard, and the Herdr lane upload runner-ge
 
 ## Timeouts
 
-| Job | timeout-minutes | Rationale |
-|---|---:|---|
-| portable parallel 1/2 | 10 | The measured shard sums are about three minutes and the timeout is a hang tripwire. |
-| portable serial 1-4 | 15 | Each balanced shard is about five minutes, leaving roughly 3x hang-tripwire margin. |
-| Herdr | 40 | The real-Herdr lane keeps its dedicated timeout. |
+| Lane | Bound | Rationale |
+|---|---|---|
+| portable parallel 1/2 | job `timeout-minutes: 10` | The measured shard sums are about three minutes and the timeout is a hang tripwire. |
+| portable serial 1-4 | job `timeout-minutes: 15` | Each balanced shard is about five minutes, leaving roughly 3x hang-tripwire margin. |
+| Herdr | family-run step `timeout-minutes: 20`; job `timeout-minutes: 75` backstop | Healthy runs finish around 7 minutes, so the step bound is the hang tripwire (cleanup and timing artifacts still upload) while the job cap stays a last-resort backstop. |
 
 Timeouts are hang tripwires rather than expected healthy durations.
+`.github/workflows/ci.yml` owns the exact numbers.

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -627,6 +627,40 @@ SH
   pass "jobs scheduler runs proven scripts; failure propagates; non-proven refused"
 }
 
+test_herdr_ci_family_run_has_a_step_timeout() {
+  # The required Herdr lane's hang tripwire is the family-run *step* bound, not
+  # the 75-minute job cap. Parse the workflow as YAML so nested `with.name`
+  # artifact keys cannot masquerade as the step contract.
+  command -v ruby >/dev/null 2>&1 \
+    || fail "ruby is required to parse .github/workflows/ci.yml as YAML"
+  local json job_timeout step_timeout
+  json=$(ruby -ryaml -rjson -e '
+doc = YAML.load_file(ARGV[0])
+job = doc.fetch("jobs").fetch("tests-herdr")
+step = job.fetch("steps").find { |s|
+  s.is_a?(Hash) && s["name"] == "Run real-Herdr family (serial, required)"
+}
+raise "missing family-run step" if step.nil?
+raise "family-run step has no timeout-minutes" unless step.key?("timeout-minutes")
+puts JSON.generate(
+  "job_timeout" => job.fetch("timeout-minutes"),
+  "step_timeout" => step.fetch("timeout-minutes")
+)
+' "$ROOT/.github/workflows/ci.yml") \
+    || fail "could not parse tests-herdr timeouts from ci.yml"
+  job_timeout=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["job_timeout"])' <<<"$json") \
+    || fail "could not read job timeout from parsed workflow"
+  step_timeout=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["step_timeout"])' <<<"$json") \
+    || fail "could not read step timeout from parsed workflow"
+  [ "$job_timeout" = 75 ] \
+    || fail "tests-herdr job backstop must stay 75 minutes, got $job_timeout"
+  [ "$step_timeout" = 20 ] \
+    || fail "family-run step timeout must be 20 minutes, got $step_timeout"
+  [ "$step_timeout" -lt "$job_timeout" ] \
+    || fail "family-run step timeout must be below the job backstop"
+  pass "Herdr CI family-run step times out at 20 min under a 75 min job backstop"
+}
+
 test_aggregate_json() {
   local tmp a b
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-aggjson.XXXXXX")
@@ -685,4 +719,5 @@ test_portable_serial_shards_partition_the_serial_lane
 test_portable_serial_shard_lane_refusals
 test_jobs_requires_proven_isolated
 test_jobs_parallel_scheduler_and_failure_propagation
+test_herdr_ci_family_run_has_a_step_timeout
 test_aggregate_json


### PR DESCRIPTION
## Intent

Bound firstmate's Herdr behavior CI shard with a step-level timeout so a hung suite fails fast with evidence instead of occupying a runner until the 75-minute job cap.

From the 2026-08-14 fleet CI audit (captain-approved to dispatch): firstmate's Behavior tests (Herdr) CI job relies on a 75-minute JOB cap (added in firstmate#2191) as its only stop - but healthy runs finish in ~7 min, so 75 min is a HANG TRIPWIRE, not a target: a wedged shard holds a runner for the full 75 min before cancel (e.g. run 31524483885, ~92-min wall).

Fix: add a STEP-LEVEL timeout INSIDE the Herdr behavior shard/script so a hung shard FAILS FAST with evidence instead of occupying a runner to the 75-min cap. Choose a bound comfortably above the ~7-min healthy time but far below 75 min. Keep the job cap as a backstop. Do NOT touch the 479 action_required runs - those are fork-PR approvals, not flakes, and out of scope.

This edits firstmate's shared CI / Herdr material. Ship no-mistakes +yolo; merge on green. Do not auto-fix unrelated flaky tests such as tests/fm-procevent.test.sh.

## What Changed
- Add a 20-minute `timeout-minutes` on the required Herdr family-run CI step so a hung suite fails that step (cleanup and timing artifacts still upload) instead of occupying a runner until the 75-minute job cap.
- Keep the 75-minute job timeout as a last-resort backstop and document the two-level Herdr bound in the portable-shards timeout table.
- Add a YAML-parsed regression test that asserts the family-run step timeout is 20 minutes and the job backstop stays 75.

## Risk Assessment

✅ Low: The Herdr family-run step is now bounded at 20 minutes under the kept 75-minute job backstop, which is the requested fail-fast contract and leaves always() cleanup and artifact upload intact.

## Testing

Parsed the real tests-herdr workflow as YAML, reproduced the missing step timeout on the base commit, confirmed the official contract test passes after the fix, and simulated a wedged family-run so a hang now fails at 20 minutes with cleanup and timing artifacts still uploaded while the 75-minute job cap stays the backstop.

<details>
<summary>Evidence: Reviewer-facing hang-tripwire comparison (base vs target)</summary>

Source: [Reviewer-facing hang-tripwire comparison (base vs target)](https://github.com/kunchenguid/firstmate/blob/46dcd8d65a51a334fc86d4eb7ae0db517ef13fe7/.no-mistakes/evidence/fm/fm-herdr-shard-step-timeout-r1/herdr-step-timeout-review.md)

```text
# Herdr behavior shard: step-level hang tripwire

End-user of this change: a CI operator watching a wedged `Behavior tests (Herdr)` job.

## What the runner will do

Parsed `.github/workflows/ci.yml` as YAML (Psych / the same document GitHub Actions consumes). Not a text grep.

| | Base `6789876` | Target `221aebd` |
|---|---|---|
| Job `tests-herdr` `timeout-minutes` | 75 | 75 (kept as backstop) |
| Family-run step `timeout-minutes` | **missing** | **20** |
| Cleanup `if:` | `always()` | `always()` |
| Upload timing/diagnostics `if:` | `always()` | `always()` |

GitHub Actions semantics (docs.github.com workflow syntax):

- **Step** `timeout-minutes`: "The maximum number of minutes to run the step before killing the process."
- **Job** `timeout-minutes`: "The maximum number of minutes to let a job run before GitHub automatically cancels it."

A step kill leaves the job running, so the two `if: always()` steps after the family-run still execute. A job-cap cancel is the whole job stopping — that is the 75-minute hang the audit called out (run 31524483885).

20 minutes is above the ~7-minute healthy wall and far below the 75-minute backstop.

## Contract test (official suite function)

`tests/fm-test-run.test.sh::test_herdr_ci_family_run_has_a_step_timeout`

- Against **base** workflow: `not ok - could not parse tests-herdr timeouts from ci.yml` (`family-run step has no timeout-minutes`). Exit 1.
- Against **target** workflow: `ok - Herdr CI family-run step times out at 20 min under a 75 min job backstop`. Exit 0.

The reported failure exists before the fix and is gone after it.

## Hung-suite experience (scaled clock)

1 CI minute = 80 ms wall so a 75-minute occupation is observable without burning a runner.

`` `
BASE (job cap only)
  t=    0 min  family-run starts and wedges
  t=   75 min  job timeout-minutes=75 cancels the whole job (only stop)
  t=   75 min  cleanup/upload not a reliable evidence path
  => runner occupied 75 CI minutes; evidence_uploaded=false

TARGET (this change)
  t=    0 min  family-run starts and wedges
  t=   20 min  step timeout-minutes=20 fires; hung family-run is killed
  t= 20.5 min  Cleanup job-owned Herdr lab sessions ran (if: always())
  t= 21.0 min  Upload Herdr timing and diagnostics ran (if: always())
  => runner occupied 20 CI minutes; evidence_uploaded=true
`` `

A hang now fails ~55 runner-minutes sooner, with cleanup and the timing/diagnostics artifact still uploaded. The 75-minute job cap remains the last-resort backstop.

## Scope (forbidden work)

Changed files vs base: `.github/workflows/ci.yml`, `docs/fm-test-portable-shards.md`, `tests/fm-test-run.test.sh`.

- `tests/fm-procevent.test.sh` not touched.
- Diff does not mention `action_required` (the 479 fork-PR approvals stay out of scope).
```
</details>
<details>
<summary>Evidence: Scaled hung-suite timeline: 75-minute job cancel vs 20-minute step fail-fast with evidence</summary>

Source: [Scaled hung-suite timeline: 75-minute job cancel vs 20-minute step fail-fast with evidence](https://github.com/kunchenguid/firstmate/blob/46dcd8d65a51a334fc86d4eb7ae0db517ef13fe7/.no-mistakes/evidence/fm/fm-herdr-shard-step-timeout-r1/herdr-hang-simulation.txt)

<code>BASE (job cap only)&#10;t= 0 min family-run starts and wedges&#10;t= 75 min job timeout-minutes=75 cancels the whole job (only stop)&#10;=&gt; runner occupied 75 CI minutes; evidence_uploaded=False&#10;&#10;TARGET (this change)&#10;t= 0 min family-run starts and wedges&#10;t= 20 min step timeout-minutes=20 fires; hung family-run is killed&#10;t= 20.5 min Cleanup job-owned Herdr lab sessions ran (if: always())&#10;t= 21.0 min Upload Herdr timing and diagnostics ran (if: always())&#10;=&gt; runner occupied 20 CI minutes; evidence_uploaded=True</code>

```text
Herdr hang tripwire — compressed end-user simulation
Time scale: 1 CI minute = 0.08s wall (so a 75-min occupation is observable)

BASE (before the change): tests-herdr has only timeout-minutes: 75 on the job.
A wedged family-run holds the runner until that job cap. Cleanup/upload are
not a reliable evidence path once the job itself is cancelled.

  t=    0 min  BASE (job cap only): family-run starts and wedges (suite never returns)
  t=   75 min  job timeout-minutes=75 cancels the whole job (only stop)
  t=   75 min  job cancelled at cap; cleanup/upload not a reliable evidence path
  => runner occupied 75 CI minutes; evidence_uploaded=False

TARGET (this change): family-run step timeout-minutes: 20; job stays 75.
A wedged family-run is killed at 20 minutes. The job is still running, so
if: always() cleanup and artifact upload still execute.

  t=    0 min  TARGET (step tripwire + job backstop): family-run starts and wedges (suite never returns)
  t=   20 min  step timeout-minutes=20 fires; hung family-run is killed
  t= 20.5 min  Cleanup job-owned Herdr lab sessions ran (if: always())
  t= 21.0 min  Upload Herdr timing and diagnostics ran (if: always())
  => runner occupied 20 CI minutes; evidence_uploaded=True

Saved ~55 runner-minutes on a hang. Job cap remains the last-resort backstop.
```
</details>
<details>
<summary>Evidence: Official contract test on the target workflow</summary>

Source: [Official contract test on the target workflow](https://github.com/kunchenguid/firstmate/blob/46dcd8d65a51a334fc86d4eb7ae0db517ef13fe7/.no-mistakes/evidence/fm/fm-herdr-shard-step-timeout-r1/herdr-timeout-test-target.txt)

<code>ok - Herdr CI family-run step times out at 20 min under a 75 min job backstop&#10;exit=0</code>

```text
repo=/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01M01T1AM9F508XFJAHTK1GN6S
2026-08-15T04:28:24Z
ok - Herdr CI family-run step times out at 20 min under a 75 min job backstop
exit=0
```
</details>
<details>
<summary>Evidence: Official contract test on the base workflow (must fail)</summary>

Source: [Official contract test on the base workflow (must fail)](https://github.com/kunchenguid/firstmate/blob/46dcd8d65a51a334fc86d4eb7ae0db517ef13fe7/.no-mistakes/evidence/fm/fm-herdr-shard-step-timeout-r1/herdr-timeout-test-base.txt)

<code>family-run step has no timeout-minutes (RuntimeError)&#10;not ok - could not parse tests-herdr timeouts from ci.yml&#10;exit=1</code>

```text
repo=/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/no-mistakes-evidence/01M01T1AM9F508XFJAHTK1GN6S/base-tree
2026-08-15T04:28:24Z
-e:8:in `<main>': family-run step has no timeout-minutes (RuntimeError)
not ok - could not parse tests-herdr timeouts from ci.yml
exit=1
```
</details>
<details>
<summary>Evidence: Parsed tests-herdr timeout model (target)</summary>

Source: [Parsed tests-herdr timeout model (target)](https://github.com/kunchenguid/firstmate/blob/46dcd8d65a51a334fc86d4eb7ae0db517ef13fe7/.no-mistakes/evidence/fm/fm-herdr-shard-step-timeout-r1/herdr-timeout-model-target.json)

```text
{
  "job": "tests-herdr",
  "job_timeout_minutes": 75,
  "family_run_step": {
    "name": "Run real-Herdr family (serial, required)",
    "timeout_minutes": 20,
    "has_timeout": true
  },
  "cleanup_step": {
    "name": "Cleanup job-owned Herdr lab sessions",
    "if": "always()",
    "runs_after_step_failure_or_cancel": true
  },
  "upload_step": {
    "name": "Upload Herdr timing and diagnostics",
    "if": "always()",
    "runs_after_step_failure_or_cancel": true
  },
  "contract": {
    "job_backstop_minutes": 75,
    "step_tripwire_minutes": 20,
    "step_is_tighter_than_job": true,
    "healthy_runs_about_minutes": 7,
    "step_above_healthy_runtime": true,
    "step_far_below_job_cap": true,
    "cleanup_and_upload_survive_step_timeout": true
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"221aebd29869b9f2b847cb3da7f399ec6d355fb7","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`ruby parse-herdr-timeouts.rb` semantic YAML model of `.github/workflows/ci.yml` jobs.tests-herdr (target 221aebd vs base 6789876)</code>
- <code>`bash test_herdr_ci_family_run_has_a_step_timeout.sh` against the target workflow — `ok - Herdr CI family-run step times out at 20 min under a 75 min job backstop`</code>
- <code>`bash test_herdr_ci_family_run_has_a_step_timeout.sh` against the base workflow — `not ok` / `family-run step has no timeout-minutes` (regression exists before the fix)</code>
- <code>`python3 simulate-herdr-hang.py` scaled hung-suite timeline: base holds the runner 75 CI minutes with no reliable evidence path; target kills the step at 20 minutes and still runs `if: always()` cleanup + artifact upload</code>
- <code>scope check that the diff does not touch `tests/fm-procevent.test.sh` or `action_required`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
