### PR TITLE
fix(bin): stop reporting cancelled or zero-check CI as green

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,7 +350,7 @@ Require the matching `resolved` event, forbid `--yes`, and require the worker to
 Resume fleet supervision immediately after the decision lands.
 
 Judge validation by the current-code-matched run step through `bin/fm-crew-state.sh`, not by shell liveness or the last status event.
-Running, fixing, or CI states remain working; parked approval or fix-review states require the worker to follow the active gate help; passed is done; a checks-passed claim is done only when `bin/fm-crew-state.sh` scores at least one successful check and no pending, failed, cancelled, skipped, or never-run conclusions; failed or cancelled is failed.
+Running, fixing, or CI states remain working; parked approval or fix-review states require the worker to follow the active gate help; passed is done; a checks-passed claim is done only when `bin/fm-crew-state.sh` scores at least one successful check and no pending, failed, cancelled, skipped, or never-run conclusions; a run that only reports completion, with no outcome to score, is unknown rather than done; failed or cancelled is failed.
 A worker hand-editing, committing, aborting, or restarting during an active validation run duplicates pipeline ownership outside the supersession sequence above; steer it back to the gate response flow.
 The worker reports the PR when CI first becomes green rather than waiting for merge monitoring to finish.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,7 +350,7 @@ Require the matching `resolved` event, forbid `--yes`, and require the worker to
 Resume fleet supervision immediately after the decision lands.
 
 Judge validation by the current-code-matched run step through `bin/fm-crew-state.sh`, not by shell liveness or the last status event.
-Running, fixing, or CI states remain working; parked approval or fix-review states require the worker to follow the active gate help; passed or checks-passed is done; failed or cancelled is failed.
+Running, fixing, or CI states remain working; parked approval or fix-review states require the worker to follow the active gate help; passed is done; a checks-passed claim is done only when `bin/fm-crew-state.sh` scores at least one successful check and no pending, failed, cancelled, skipped, or never-run conclusions; failed or cancelled is failed.
 A worker hand-editing, committing, aborting, or restarting during an active validation run duplicates pipeline ownership outside the supersession sequence above; steer it back to the gate response flow.
 The worker reports the PR when CI first becomes green rather than waiting for merge monitoring to finish.
 

--- a/bin/fm-ci-verdict-lib.sh
+++ b/bin/fm-ci-verdict-lib.sh
@@ -31,29 +31,21 @@ fm_ci_verdict_is_success() {
 
 fm_ci_ready_verdict() {
   local raw conclusion saw_success=0
-  if [ "$#" -gt 0 ]; then
-    for raw in "$@"; do
-      conclusion=$(fm_ci_verdict_trim "$raw")
-      [ -n "$conclusion" ] || continue
-      if fm_ci_verdict_is_success "$conclusion"; then
-        saw_success=1
-        continue
-      fi
-      printf 'not-passed'
-      return 0
-    done
-  else
+  if [ "$#" -eq 0 ]; then
     while IFS= read -r raw || [ -n "$raw" ]; do
-      conclusion=$(fm_ci_verdict_trim "$raw")
-      [ -n "$conclusion" ] || continue
-      if fm_ci_verdict_is_success "$conclusion"; then
-        saw_success=1
-        continue
-      fi
-      printf 'not-passed'
-      return 0
+      set -- "$@" "$raw"
     done
   fi
+  for raw in "$@"; do
+    conclusion=$(fm_ci_verdict_trim "$raw")
+    [ -n "$conclusion" ] || continue
+    if fm_ci_verdict_is_success "$conclusion"; then
+      saw_success=1
+      continue
+    fi
+    printf 'not-passed'
+    return 0
+  done
   if [ "$saw_success" = 1 ]; then
     printf 'passed'
   else

--- a/bin/fm-ci-verdict-lib.sh
+++ b/bin/fm-ci-verdict-lib.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Shared CI-ready scoring for a set of check conclusions.
+#
+# ONE owner of the rule that a green verdict is valid only when at least one
+# check completed with success AND none are pending, failed, cancelled,
+# skipped, or never-run. Zero checks is a distinct non-success state, never
+# passed. Used by current-state reporting so a cancelled-only or empty check
+# set cannot be read as checks-passed.
+#
+# Public interface: fm_ci_ready_verdict [conclusion...]
+#   Reads conclusions from the arguments, or from stdin (one per line) when
+#   none are given. Blank lines are ignored.
+#   Prints exactly one of: passed | empty | not-passed
+# Sourced by callers; also runnable as a command so tests drive the same
+# public function through an executable interface.
+
+fm_ci_verdict_trim() {
+  local s=${1:-}
+  s="${s#"${s%%[![:space:]]*}"}"
+  s="${s%"${s##*[![:space:]]}"}"
+  printf '%s' "$s"
+}
+
+# 0 if $1 is a completed success conclusion.
+fm_ci_verdict_is_success() {
+  case "$1" in
+    SUCCESS|success) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+fm_ci_ready_verdict() {
+  local raw conclusion saw_success=0
+  if [ "$#" -gt 0 ]; then
+    for raw in "$@"; do
+      conclusion=$(fm_ci_verdict_trim "$raw")
+      [ -n "$conclusion" ] || continue
+      if fm_ci_verdict_is_success "$conclusion"; then
+        saw_success=1
+        continue
+      fi
+      printf 'not-passed'
+      return 0
+    done
+  else
+    while IFS= read -r raw || [ -n "$raw" ]; do
+      conclusion=$(fm_ci_verdict_trim "$raw")
+      [ -n "$conclusion" ] || continue
+      if fm_ci_verdict_is_success "$conclusion"; then
+        saw_success=1
+        continue
+      fi
+      printf 'not-passed'
+      return 0
+    done
+  fi
+  if [ "$saw_success" = 1 ]; then
+    printf 'passed'
+  else
+    printf 'empty'
+  fi
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  set -u
+  fm_ci_ready_verdict "$@"
+  printf '\n'
+fi

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -37,11 +37,15 @@
 #      diverged from it, invalidates attribution.
 #      The run-step is AUTHORITATIVE: running/fixing -> working, ci -> working,
 #      awaiting_approval/fix_review -> parked (with gate findings), terminal
-#      passed/checks-passed -> done, failed/cancelled -> failed. EXCEPT: while
-#      the active step is ci, `axi status` alone cannot tell "still waiting on
-#      checks" from "checks green, waiting on merge" (see nm_ci_checks_state) -
-#      a ci-step log-tail check overrides working -> done once checks read
-#      green, so a green PR is never silently read as still-validating.
+#      passed -> done, failed/cancelled -> failed. A checks-passed outcome is
+#      done only when the CI-ready scorer in bin/fm-ci-verdict-lib.sh confirms
+#      at least one successful check and no pending, failed, cancelled,
+#      skipped, or never-run conclusions; zero checks is a distinct non-success
+#      state, never done. EXCEPT: while the active step is ci, `axi status`
+#      alone cannot tell "still waiting on checks" from "checks green, waiting
+#      on merge" (see nm_ci_checks_state) - a ci-step log-tail check overrides
+#      working -> done only when that same scorer reads green, so a cancelled
+#      or empty check set is never silently read as still-validating-and-green.
 #   3. Reconcile the status log: if its last line says needs-decision/blocked but
 #      the run-step shows the run moved on, the log is deterministically stale and
 #      is flagged superseded. A genuinely parked run plus a needs-decision log
@@ -73,6 +77,8 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 . "$SCRIPT_DIR/fm-busy-lib.sh"
 # shellcheck source=bin/fm-nm-run-lib.sh
 . "$SCRIPT_DIR/fm-nm-run-lib.sh"
+# shellcheck source=bin/fm-ci-verdict-lib.sh
+. "$SCRIPT_DIR/fm-ci-verdict-lib.sh"
 
 ID=${1:-}
 [ -n "$ID" ] || { echo "usage: fm-crew-state.sh <id>" >&2; exit 2; }
@@ -330,26 +336,37 @@ nm_effective_ci_step_status() {
 # actually merged (or failed/cancelled if closed). `axi status`'s steps[] table
 # never distinguishes "still waiting on checks" from "checks green, waiting on
 # merge": both read as plain `ci,running,...`. The only place that transition is
-# recorded is the ci step's own log text, e.g. "all CI checks passed - still
-# monitoring until merged or closed" or "no CI checks reported - still
-# monitoring until merged or closed" (verified against 360+ real run logs under
-# ~/.no-mistakes/logs/*/ci.log on the installed v1.32.2 binary, including the
-# actual PR #252 run). Reads the ci step's log tail via `axi logs` and scans it
-# for the MOST RECENT recognized marker (the log is append-only/chronological,
-# so the last match is current): green with nothing red after it means CI is
-# green right now, still only waiting on merge/close.
+# recorded is the ci step's own log text. Reads the ci step's log tail via
+# `axi logs` and scores the MOST RECENT recognized marker (the log is
+# append-only/chronological, so the last match is current). Green is valid
+# only when bin/fm-ci-verdict-lib.sh sees at least one success and no
+# pending, failed, cancelled, skipped, or never-run conclusions. Zero checks
+# is a distinct non-success state, never green.
+nm_ci_marker_conclusion() {
+  case "$1" in
+    *"all CI checks passed"*) printf 'SUCCESS' ;;
+    *"CI check cancelled"*|"CI checks were cancelled"*|"cancelled without"*) printf 'CANCELLED' ;;
+    *"checks failed"*|"CI failures"*|"issues detected"*) printf 'FAILURE' ;;
+    *"CI checks running"*|"waiting for checks"*|"base branch advanced"*"re-arming CI monitor timeout"*) printf 'PENDING' ;;
+    *"no CI checks reported"*|"repository declares no CI"*) ;;
+  esac
+}
+
 nm_ci_checks_state() {
-  local run_id log_tail marker
+  local run_id log_tail marker conclusion verdict
   run_id=$(strip_quotes "$(nm_field id)")
   [ -n "$run_id" ] || { printf 'unknown'; return; }
   log_tail=$(nm_run axi logs --step ci --run "$run_id") || true
   [ -n "$log_tail" ] || { printf 'unknown'; return; }
   marker=$(printf '%s\n' "$log_tail" \
-    | grep -E 'CI checks passed|no CI checks reported - still monitoring|no CI checks reported yet|checks failed|issues detected|CI checks running|base branch advanced.*re-arming CI monitor timeout' \
+    | grep -E 'CI checks passed|no CI checks reported|repository declares no CI|checks failed|issues detected|CI checks running|base branch advanced.*re-arming CI monitor timeout|CI check cancelled|CI checks were cancelled|cancelled without' \
     | tail -1)
-  case "$marker" in
-    *"checks passed"*|*"no CI checks reported - still monitoring"*) printf 'green' ;;
-    *"no CI checks reported yet"*|*"checks failed"*|*"issues detected"*|*"CI checks running"*|*"base branch advanced"*"re-arming CI monitor timeout"*) printf 'not-ready' ;;
+  [ -n "$marker" ] || { printf 'unknown'; return; }
+  conclusion=$(nm_ci_marker_conclusion "$marker")
+  verdict=$(fm_ci_ready_verdict "$conclusion")
+  case "$verdict" in
+    passed) printf 'green' ;;
+    empty|not-passed) printf 'not-ready' ;;
     *) printf 'unknown' ;;
   esac
 }
@@ -497,7 +514,23 @@ if [ "$HAVE_RUN" = 1 ]; then
     if [ -n "$outcome" ]; then
       case "$outcome" in
         passed)        RUN_STATE="done"; RUN_DETAIL="run passed: PR merged/closed" ;;
-        checks-passed) RUN_STATE="done"; RUN_DETAIL="checks green: PR ready for review" ;;
+        checks-passed)
+          CI_LOG_STATE=$(nm_ci_checks_state)
+          case "$CI_LOG_STATE" in
+            green)
+              RUN_STATE="done"
+              RUN_DETAIL="checks green: PR ready for review"
+              ;;
+            not-ready)
+              RUN_STATE=blocked
+              RUN_DETAIL="run reported checks-passed without green check evidence"
+              ;;
+            *)
+              RUN_STATE=unknown
+              RUN_DETAIL="run reported checks-passed but CI evidence is unavailable"
+              ;;
+          esac
+          ;;
         failed)        RUN_STATE=failed; RUN_DETAIL="run failed" ;;
         cancelled)     RUN_STATE=failed; RUN_DETAIL="run cancelled" ;;
         *)             RUN_STATE=unknown; RUN_DETAIL="outcome: $outcome" ;;
@@ -545,10 +578,7 @@ if [ "$HAVE_RUN" = 1 ]; then
     fi
   fi
 
-  if [ "$RUN_STATE" = working ] && log_reports_ci_ready; then
-    if [ "$RUN_SOURCE" = coarse ]; then
-      emit "done" status-log "$(status_line_note "$LOG_LINE")${SEP}run still monitoring PR"
-    fi
+  if [ "$RUN_STATE" = working ] && log_reports_ci_ready && [ "$RUN_SOURCE" != coarse ]; then
     [ -n "$CI_STEP_STATUS" ] || CI_STEP_STATUS=$(nm_effective_ci_step_status)
     if [ "$RUN_STATUS" = fixing ]; then
       CI_LOG_STATE=not-ready
@@ -557,7 +587,7 @@ if [ "$HAVE_RUN" = 1 ]; then
     elif [ "$CI_STEP_STATUS" = fixing ]; then
       CI_LOG_STATE=not-ready
     fi
-    if [ "$CI_LOG_STATE" != not-ready ]; then
+    if [ "$CI_LOG_STATE" = green ]; then
       emit "done" status-log "$(status_line_note "$LOG_LINE")${SEP}run still monitoring PR"
     fi
   fi

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -37,7 +37,10 @@
 #      diverged from it, invalidates attribution.
 #      The run-step is AUTHORITATIVE: running/fixing -> working, ci -> working,
 #      awaiting_approval/fix_review -> parked (with gate findings), terminal
-#      passed -> done, failed/cancelled -> failed. A checks-passed outcome is
+#      passed -> done, failed/cancelled -> failed. A terminal run that carries
+#      no outcome at all (a bare `completed` status, whether from `axi status`
+#      or the coarse runs list) reads unknown, never done: there is no verdict
+#      to score. A checks-passed outcome is
 #      done only when the CI-ready scorer in bin/fm-ci-verdict-lib.sh confirms
 #      at least one successful check and no pending, failed, cancelled,
 #      skipped, or never-run conclusions; zero checks is a distinct non-success
@@ -559,7 +562,7 @@ if [ "$HAVE_RUN" = 1 ]; then
       case "$status" in
         ci)             RUN_STATE=working; RUN_DETAIL="ci running" ;;
         running|fixing) RUN_STATE=working; RUN_DETAIL="validating ($status)" ;;
-        completed)      RUN_STATE="done"; RUN_DETAIL="run completed" ;;
+        completed)      RUN_STATE=unknown; RUN_DETAIL="run completed without an outcome" ;;
         failed)         RUN_STATE=failed;  RUN_DETAIL="run failed" ;;
         cancelled)      RUN_STATE=failed;  RUN_DETAIL="run cancelled" ;;
         "")             RUN_STATE=working; RUN_DETAIL="run active" ;;

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -345,10 +345,10 @@ nm_effective_ci_step_status() {
 nm_ci_marker_conclusion() {
   case "$1" in
     *"all CI checks passed"*) printf 'SUCCESS' ;;
-    *"CI check cancelled"*|"CI checks were cancelled"*|"cancelled without"*) printf 'CANCELLED' ;;
-    *"checks failed"*|"CI failures"*|"issues detected"*) printf 'FAILURE' ;;
-    *"CI checks running"*|"waiting for checks"*|"base branch advanced"*"re-arming CI monitor timeout"*) printf 'PENDING' ;;
-    *"no CI checks reported"*|"repository declares no CI"*) ;;
+    *"CI check cancelled"*|*"CI checks were cancelled"*|*"cancelled without"*) printf 'CANCELLED' ;;
+    *"checks failed"*|*"CI failures"*|*"issues detected"*) printf 'FAILURE' ;;
+    *"CI checks running"*|*"waiting for checks"*|*"base branch advanced"*"re-arming CI monitor timeout"*) printf 'PENDING' ;;
+    *"no CI checks reported"*|*"repository declares no CI"*) ;;
   esac
 }
 
@@ -359,7 +359,7 @@ nm_ci_checks_state() {
   log_tail=$(nm_run axi logs --step ci --run "$run_id") || true
   [ -n "$log_tail" ] || { printf 'unknown'; return; }
   marker=$(printf '%s\n' "$log_tail" \
-    | grep -E 'CI checks passed|no CI checks reported|repository declares no CI|checks failed|issues detected|CI checks running|base branch advanced.*re-arming CI monitor timeout|CI check cancelled|CI checks were cancelled|cancelled without' \
+    | grep -E 'CI checks passed|no CI checks reported|repository declares no CI|checks failed|CI failures|issues detected|CI checks running|waiting for checks|base branch advanced.*re-arming CI monitor timeout|CI check cancelled|CI checks were cancelled|cancelled without' \
     | tail -1)
   [ -n "$marker" ] || { printf 'unknown'; return; }
   conclusion=$(nm_ci_marker_conclusion "$marker")
@@ -489,15 +489,20 @@ if [ "$HAVE_RUN" = 1 ]; then
   RUN_STATUS=""
   if [ "$RUN_SOURCE" = coarse ]; then
     # No step/gate detail is available from the plain runs list - only ever
-    # true/working, done, or failed. A crew genuinely parked at a gate still
+    # working, failed, or unknown. A crew genuinely parked at a gate still
     # gets full detail once `axi status` reports its own branch again (e.g.
     # once its own step is the most-recently-touched one), and its own
     # needs-decision/blocked status-log append (a captain-relevant VERB) is
     # surfaced through signal_reason_is_actionable regardless of this
     # coarse-vs-full distinction, so a real gate is never silently missed.
+    # A `completed` row carries no outcome and no check evidence, and the
+    # ci-log scorer cannot run here ($RUN_OUT holds another run's id), so it
+    # cannot distinguish a merged run from one that claimed checks-passed over
+    # cancelled or zero checks. Reporting unknown keeps the same invariant the
+    # scorer enforces on the full path: done requires scored green evidence.
     case "$COARSE_STATUS" in
       running)   RUN_STATE=working; RUN_DETAIL="validating (background run)" ;;
-      completed) RUN_STATE="done";  RUN_DETAIL="run completed" ;;
+      completed) RUN_STATE=unknown; RUN_DETAIL="run completed without check evidence" ;;
       failed)    RUN_STATE=failed;  RUN_DETAIL="run failed" ;;
       cancelled) RUN_STATE=failed;  RUN_DETAIL="run cancelled" ;;
       *)         RUN_STATE=unknown; RUN_DETAIL="runs list status: $COARSE_STATUS" ;;

--- a/bin/fm-remote-job-lib.sh
+++ b/bin/fm-remote-job-lib.sh
@@ -590,6 +590,14 @@ fm_remote_job_path_mtime() { # <path>
   if [ "$(uname -s 2>/dev/null || true)" = Darwin ]; then stat -f %m "$1" 2>/dev/null; else stat -c %Y "$1" 2>/dev/null; fi
 }
 
+# Device and inode name one filesystem entry for as long as it exists, so a
+# directory that was removed and recreated under the same path reads as a
+# different instance. That is what lets ownership reclaim tell the lock it
+# proved stale apart from a replacement's freshly created lock.
+fm_remote_job_path_instance() { # <path>
+  if [ "$(uname -s 2>/dev/null || true)" = Darwin ]; then stat -f %d:%i "$1" 2>/dev/null; else stat -c %d:%i "$1" 2>/dev/null; fi
+}
+
 fm_remote_job_reap_stale() { # <account-home>
   local account_home=$1 job id state mtime now
   fm_remote_job_prepare_state "$account_home" || return 1

--- a/bin/fm-remote-job-worker.sh
+++ b/bin/fm-remote-job-worker.sh
@@ -143,6 +143,21 @@ worker_recover_quarantine() { # <account-home>
   rm -f -- "$WORKER_LOCK/quarantine"
 }
 
+# An owner that died between mktemp and mv leaves one of its own private temp
+# entries inside the lock directory, and rmdir can never reclaim a lock that
+# still holds one. Only this worker's own temp shapes are removable, and only as
+# plain files, so a proven-stale lock stays reclaimable after any unclean death
+# without widening what reclaim may delete.
+worker_clear_lock_residue() {
+  local entry
+  for entry in "$WORKER_LOCK"/.pid.* "$WORKER_LOCK"/.start.* \
+    "$WORKER_LOCK"/.command.* "$WORKER_LOCK"/.quarantine.*; do
+    [ -e "$entry" ] || [ -L "$entry" ] || continue
+    [ ! -L "$entry" ] && [ -f "$entry" ] || return 1
+    rm -f -- "$entry" || return 1
+  done
+}
+
 worker_acquire_lock() {
   local account_home=$1 attempt=0
   while [ "$attempt" -lt 150 ]; do
@@ -164,6 +179,7 @@ worker_acquire_lock() {
     fi
     [ ! -L "$WORKER_LOCK/pid" ] && [ ! -L "$WORKER_LOCK/start" ] && [ ! -L "$WORKER_LOCK/command" ] || return 1
     rm -f -- "$WORKER_LOCK/pid" "$WORKER_LOCK/start" "$WORKER_LOCK/command" || return 1
+    worker_clear_lock_residue || return 1
     rmdir "$WORKER_LOCK" || return 1
   done
   return 1

--- a/bin/fm-remote-job-worker.sh
+++ b/bin/fm-remote-job-worker.sh
@@ -111,13 +111,17 @@ worker_publish_lock_owner() {
   mv -f -- "$pid_tmp" "$WORKER_LOCK/pid" || { rm -f -- "$pid_tmp" "$WORKER_LOCK/start" "$WORKER_LOCK/command"; return 1; }
 }
 
-worker_lock_recent() {
+# An unreadable mtime counts as recent, because reclaim may only destroy
+# ownership it can positively prove abandoned.
+worker_path_recent() { # <path>
   local mtime now
-  mtime=$(fm_remote_job_path_mtime "$WORKER_LOCK" 2>/dev/null || true)
+  mtime=$(fm_remote_job_path_mtime "$1" 2>/dev/null || true)
   case "$mtime" in ''|*[!0-9]*) return 0 ;; esac
   now=$(date +%s)
   [ $((now - mtime)) -le 10 ]
 }
+
+worker_lock_recent() { worker_path_recent "$WORKER_LOCK"; }
 
 worker_quarantined_execution_stopped() { # <account-home>
   local account_home=$1 job state kind file pid
@@ -143,23 +147,45 @@ worker_recover_quarantine() { # <account-home>
   rm -f -- "$WORKER_LOCK/quarantine"
 }
 
-# An owner that died between mktemp and mv leaves one of its own private temp
-# entries inside the lock directory, and rmdir can never reclaim a lock that
-# still holds one. Only this worker's own temp shapes are removable, and only as
-# plain files, so a proven-stale lock stays reclaimable after any unclean death
-# without widening what reclaim may delete.
-worker_clear_lock_residue() {
-  local entry
-  for entry in "$WORKER_LOCK"/.pid.* "$WORKER_LOCK"/.start.* \
+worker_lock_instance() { fm_remote_job_path_instance "$WORKER_LOCK"; }
+
+# Reclaim removes an abandoned owner's canonical files and any private temp entry
+# left behind by an owner that died between mktemp and mv, since rmdir can never
+# reclaim a lock that still holds one. Those temp names are the ones a live owner
+# publishes through, so every removal is bound to the exact lock the staleness
+# proof observed. Ownership is only ever taken by creating the lock directory, so
+# a replacement that recreated it after that proof holds a different directory
+# instance, and a changed instance is contention to wait out rather than residue
+# to delete. Each entry must additionally be older than the recency window the
+# proof already applied to the directory, which a live owner's just-published
+# canonical and temporary files never are, and which an abandoned lock's entries
+# always are because creating them is what last moved that directory's mtime.
+worker_remove_stale_lock_entry() { # <entry> <instance>; 0 removed or absent, 2 contention, 1 refused
+  local entry=$1 instance=$2
+  [ -e "$entry" ] || [ -L "$entry" ] || return 0
+  [ ! -L "$entry" ] && [ -f "$entry" ] || return 1
+  ! worker_path_recent "$entry" || return 2
+  [ "$(worker_lock_instance)" = "$instance" ] || return 2
+  rm -f -- "$entry" || return 1
+}
+
+worker_reclaim_stale_lock() { # <instance>; 0 reclaimed, 2 contention, 1 refused
+  local instance=$1 entry status
+  [ -n "$instance" ] || return 2
+  [ "$(worker_lock_instance)" = "$instance" ] || return 2
+  for entry in "$WORKER_LOCK/pid" "$WORKER_LOCK/start" "$WORKER_LOCK/command" \
+    "$WORKER_LOCK"/.pid.* "$WORKER_LOCK"/.start.* \
     "$WORKER_LOCK"/.command.* "$WORKER_LOCK"/.quarantine.*; do
-    [ -e "$entry" ] || [ -L "$entry" ] || continue
-    [ ! -L "$entry" ] && [ -f "$entry" ] || return 1
-    rm -f -- "$entry" || return 1
+    worker_remove_stale_lock_entry "$entry" "$instance"
+    status=$?
+    [ "$status" -eq 0 ] || return "$status"
   done
+  [ "$(worker_lock_instance)" = "$instance" ] || return 2
+  rmdir "$WORKER_LOCK" || return 1
 }
 
 worker_acquire_lock() {
-  local account_home=$1 attempt=0
+  local account_home=$1 attempt=0 instance status
   while [ "$attempt" -lt 150 ]; do
     if (umask 077; mkdir "$WORKER_LOCK") 2>/dev/null; then
       WORKER_LOCK_HELD=1
@@ -167,6 +193,7 @@ worker_acquire_lock() {
       return 0
     fi
     [ -d "$WORKER_LOCK" ] && [ ! -L "$WORKER_LOCK" ] || return 1
+    instance=$(worker_lock_instance)
     if [ -e "$WORKER_LOCK/quarantine" ] || [ -L "$WORKER_LOCK/quarantine" ]; then
       worker_recover_quarantine "$account_home" || return 3
       continue
@@ -177,10 +204,13 @@ worker_acquire_lock() {
       sleep 0.1
       continue
     fi
-    [ ! -L "$WORKER_LOCK/pid" ] && [ ! -L "$WORKER_LOCK/start" ] && [ ! -L "$WORKER_LOCK/command" ] || return 1
-    rm -f -- "$WORKER_LOCK/pid" "$WORKER_LOCK/start" "$WORKER_LOCK/command" || return 1
-    worker_clear_lock_residue || return 1
-    rmdir "$WORKER_LOCK" || return 1
+    worker_reclaim_stale_lock "$instance"
+    status=$?
+    [ "$status" -ne 1 ] || return 1
+    if [ "$status" -eq 2 ]; then
+      attempt=$((attempt + 1))
+      sleep 0.1
+    fi
   done
   return 1
 }

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -136,7 +136,7 @@ family_for_basename() {
     fm-bearings-board.test.sh|\
     fm-brief.test.sh|fm-vendor-auth-probe.test.sh|\
     fm-calm-pi-extension.test.sh|fm-cd-pretool-check.test.sh|\
-    fm-classify-decision-key.test.sh|\
+    fm-ci-verdict-lib.test.sh|fm-classify-decision-key.test.sh|\
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
     fm-crew-state.test.sh|fm-captain-hold-lifecycle.test.sh|\
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
@@ -989,6 +989,9 @@ families_for_changed_path() {
       # pre-teardown run abort (pr-forge).
       printf '%s\n' pure-contract-unit
       printf '%s\n' pr-forge
+      ;;
+    bin/fm-ci-verdict-lib.sh)
+      printf '%s\n' pure-contract-unit
       ;;
     bin/fm-composer-lib.sh)
       # The shared shape catalogue is vendor-rendered signal; a change to it

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,6 +52,8 @@ Any direct or remaining historical annotation prints every status line unread at
 The script header owns the exact run-head ancestry rules.
 During no-mistakes' `ci` monitor phase, it also reads the ci step log tail because `axi status` reports both "still waiting on checks" and "checks green, waiting on merge" as `ci,running`.
 The most recent recognized ci log marker wins, and `bin/fm-ci-verdict-lib.sh` scores it: only a completed success with no pending, failed, cancelled, skipped, or never-run conclusions reports done, while a cancelled, empty, or later re-arm, failed-check, or issue marker returns the crew to working.
+A terminal `checks-passed` outcome is scored through that same owner, so a claim the scorer does not read as green reports blocked, and a missing or unreadable ci log reports unknown, instead of done.
+A terminal run that carries no outcome at all, including the coarse runs-list `completed` row that has no step, gate, or check evidence to score, reads unknown rather than done.
 Only when no matching run exists does it consult semantic busy state; exact busy reports working, exact idle permits fallback to a status-log event whose verb maps to a recognized run-state, and unknown or a dead pane stays unknown instead of trusting a stale log.
 Decision-only events such as `resolved` never become current state or leak their prose into the current-state detail.
 In that status-log fallback, a declared external wait reports the distinct `paused` state with its reason.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,7 +51,7 @@ Any direct or remaining historical annotation prints every status line unread at
 `bin/fm-crew-state.sh <id>` is the cheap current-state read for an actionable heartbeat review: it attributes a no-mistakes run, active or terminal, only when it matches the crew's branch and current code identity, then keeps that run-step authoritative even if the pane has closed.
 The script header owns the exact run-head ancestry rules.
 During no-mistakes' `ci` monitor phase, it also reads the ci step log tail because `axi status` reports both "still waiting on checks" and "checks green, waiting on merge" as `ci,running`.
-The most recent recognized ci log marker wins, so checks-green monitoring reports done while a later re-arm, failed-check, or issue marker returns the crew to working.
+The most recent recognized ci log marker wins, and `bin/fm-ci-verdict-lib.sh` scores it: only a completed success with no pending, failed, cancelled, skipped, or never-run conclusions reports done, while a cancelled, empty, or later re-arm, failed-check, or issue marker returns the crew to working.
 Only when no matching run exists does it consult semantic busy state; exact busy reports working, exact idle permits fallback to a status-log event whose verb maps to a recognized run-state, and unknown or a dead pane stays unknown instead of trusting a stale log.
 Decision-only events such as `resolved` never become current state or leak their prose into the current-state detail.
 In that status-log fallback, a declared external wait reports the distinct `paused` state with its reason.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -81,6 +81,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-supervise-daemon.sh` | Presence-gated away-mode sub-supervisor: self-handle routine wakes, guard injection by the detected primary harness, escalate batched digests, alert on failed delivery |
 | `fm-crew-state.sh`       | Print one deterministic current-state line for a crew                                |
 | `fm-nm-run-lib.sh`       | Shared branch-and-code-identity attribution for no-mistakes runs                    |
+| `fm-ci-verdict-lib.sh`   | Score a CI check-conclusion set so empty or cancelled results cannot read as passed |
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification          |
 | `fm-timeout-lib.sh`      | Single owner of hard-bounded command execution and its fallback watchdog |
 | `fm-timing-lib.sh`       | Single owner of the deferred network stage's per-step elapsed-time records, inert unless a run asks for them |

--- a/tests/fm-ci-verdict-lib.test.sh
+++ b/tests/fm-ci-verdict-lib.test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-ci-verdict-lib.sh - the CI-ready scoring rule.
+#
+# A green verdict is valid only when at least one check completed with success
+# AND none are pending, failed, cancelled, skipped, or never-run. These cases
+# drive the public command, never the implementation source:
+#   (a) cancelled-only conclusions are not passed
+#   (b) zero checks is empty, not passed
+#   (c) a genuinely all-success set is passed
+#   (d) mixed success-plus-non-success is not passed
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+VERDICT="$ROOT/bin/fm-ci-verdict-lib.sh"
+
+score() {
+  "$VERDICT" "$@"
+}
+
+test_cancelled_only_is_not_passed() {
+  local out
+  out=$(score CANCELLED)
+  [ "$out" = not-passed ] || fail "cancelled-only scored as '$out', want not-passed"
+  out=$(score CANCELED)
+  [ "$out" = not-passed ] || fail "canceled-only scored as '$out', want not-passed"
+  out=$(score SUCCESS CANCELLED)
+  [ "$out" = not-passed ] || fail "success+cancelled scored as '$out', want not-passed"
+  [ "$out" != passed ] || fail "cancelled conclusions must never score as passed"
+  pass "cancelled-only and mixed-cancelled conclusions are not passed"
+}
+
+test_zero_checks_is_not_passed() {
+  local out
+  out=$(score)
+  [ "$out" = empty ] || fail "zero checks scored as '$out', want empty"
+  [ "$out" != passed ] || fail "zero checks must never score as passed"
+  out=$(printf '\n\n' | "$VERDICT")
+  [ "$out" = empty ] || fail "blank-only input scored as '$out', want empty"
+  [ "$out" != passed ] || fail "blank-only input must never score as passed"
+  pass "zero checks is empty, not passed"
+}
+
+test_all_success_is_passed() {
+  local out
+  out=$(score SUCCESS)
+  [ "$out" = passed ] || fail "one success scored as '$out', want passed"
+  out=$(score SUCCESS SUCCESS SUCCESS)
+  [ "$out" = passed ] || fail "all-success scored as '$out', want passed"
+  pass "a genuinely all-success set is passed"
+}
+
+test_skipped_pending_failed_never_run_are_not_passed() {
+  local out word
+  for word in SKIPPED NEUTRAL FAILURE ERROR TIMED_OUT ACTION_REQUIRED \
+    STARTUP_FAILURE STALE QUEUED PENDING IN_PROGRESS WAITING REQUESTED \
+    NEVER never-run; do
+    out=$(score "$word")
+    [ "$out" = not-passed ] || fail "$word scored as '$out', want not-passed"
+    [ "$out" != passed ] || fail "$word must never score as passed"
+    out=$(score SUCCESS "$word")
+    [ "$out" = not-passed ] || fail "success+$word scored as '$out', want not-passed"
+  done
+  pass "skipped, pending, failed, and never-run conclusions are not passed"
+}
+
+test_cancelled_only_is_not_passed
+test_zero_checks_is_not_passed
+test_all_success_is_passed
+test_skipped_pending_failed_never_run_are_not_passed
+
+echo "all fm-ci-verdict-lib tests passed"

--- a/tests/fm-ci-verdict-lib.test.sh
+++ b/tests/fm-ci-verdict-lib.test.sh
@@ -16,7 +16,7 @@ set -u
 VERDICT="$ROOT/bin/fm-ci-verdict-lib.sh"
 
 score() {
-  "$VERDICT" "$@"
+  "$VERDICT" "$@" < /dev/null
 }
 
 test_cancelled_only_is_not_passed() {

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -13,6 +13,8 @@
 #   (b) needs-decision/blocked log + resumed run = SUPERSEDED     -> run-step
 #   (c) genuine parked run + needs-decision log = NOT superseded  -> run-step
 #   (d) terminal run-step (passed/failed) is authoritative        -> run-step
+#       checks-passed is done only with scored green evidence; cancelled,
+#       skipped, never-run, or zero checks stay non-success
 #   (e) cross-branch attribution: this branch's own run found via list lookup
 #   (f) no run + semantic busy                                    -> pane
 #   (g) no run + semantic idle falls to the status-log verb       -> status-log
@@ -278,6 +280,19 @@ outcome: passed
 EOF
 }
 
+run_checks_passed() {  # <branch>
+  cat <<EOF
+run:
+  id: "01RUN"
+  branch: $1
+  status: completed
+  head: "${FM_FAKE_RUN_HEAD:-abc1234}"
+  pr: "https://github.com/o/r/pull/2"
+  findings: none
+outcome: checks-passed
+EOF
+}
+
 run_failed() {  # <branch>
   cat <<EOF
 run:
@@ -441,7 +456,7 @@ test_gate_block_parked_not_superseded() {
   pass "gate block parked run is not flagged superseded"
 }
 
-test_ci_ready_done_log_beats_monitoring_run() {
+test_ci_ready_done_log_without_evidence_stays_working() {
   reset_fakes
   local d; d=$(new_case ci-ready)
   make_repo_on_branch "$d/wt" fm/feat-ci
@@ -450,11 +465,10 @@ test_ci_ready_done_log_beats_monitoring_run() {
   printf 'done: PR https://github.com/o/r/pull/2 checks green\n' > "$d/state/feat-ci.status"
   FM_FAKE_AXI_STATUS="$(run_ci_monitoring fm/feat-ci)"
   local out; out=$(run_crew_state "$d" feat-ci)
-  assert_contains "$out" "state: done" "ci-ready status log -> done"
-  assert_contains "$out" "source: status-log" "ci-ready state comes from the status log"
-  assert_contains "$out" "checks green" "ci-ready detail preserves the report"
-  assert_not_contains "$out" "state: working" "ci-ready is not hidden by monitoring run"
-  pass "ci-ready status log beats monitoring run"
+  assert_contains "$out" "state: working" "uncorroborated ci-ready status log stays working"
+  assert_not_contains "$out" "state: done" "a checks-green claim without evidence must not be done"
+  assert_not_contains "$out" "checks green" "a checks-green claim without evidence must not read as checks green"
+  pass "uncorroborated ci-ready status log does not beat a monitoring run"
 }
 
 # Regression for the PR #252 incident: the crew's own status log never got a
@@ -499,7 +513,7 @@ test_top_level_ci_checks_green_surfaces_done() {
   pass "top-level ci status uses ci log green marker"
 }
 
-test_ci_monitoring_no_checks_terminal_surfaces_done() {
+test_ci_monitoring_no_checks_terminal_is_not_green() {
   reset_fakes
   local d; d=$(new_case ci-nochecks)
   make_repo_on_branch "$d/wt" fm/feat-cinochecks
@@ -508,9 +522,53 @@ test_ci_monitoring_no_checks_terminal_surfaces_done() {
   FM_FAKE_AXI_STATUS="$(run_ci_monitoring fm/feat-cinochecks)"
   FM_FAKE_CI_LOGS="no CI checks reported - still monitoring until merged or closed"
   local out; out=$(run_crew_state "$d" feat-cinochecks)
-  assert_contains "$out" "state: done" "terminal no-checks ci-monitor run -> done"
-  assert_contains "$out" "checks green" "terminal no-checks ci-monitor detail mentions checks green"
-  pass "terminal no-checks ci-monitor marker surfaces done"
+  assert_contains "$out" "state: working" "terminal no-checks ci-monitor run -> working"
+  assert_not_contains "$out" "state: done" "zero checks must not read as done"
+  assert_not_contains "$out" "checks green" "zero checks must not read as checks green"
+  pass "terminal no-checks ci-monitor marker is not green"
+}
+
+test_ci_monitoring_cancelled_only_is_not_green() {
+  reset_fakes
+  local d; d=$(new_case ci-cancelled)
+  make_repo_on_branch "$d/wt" fm/feat-cicancelled
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-cicancelled.meta" "window=fm:fm-feat-cicancelled" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_ci_monitoring fm/feat-cicancelled)"
+  FM_FAKE_CI_LOGS="CI checks were cancelled without reporting a verdict"
+  local out; out=$(run_crew_state "$d" feat-cicancelled)
+  assert_contains "$out" "state: working" "cancelled-only ci-monitor run -> working"
+  assert_not_contains "$out" "state: done" "cancelled checks must not read as done"
+  assert_not_contains "$out" "checks green" "cancelled checks must not read as checks green"
+  pass "cancelled-only ci-monitor marker is not green"
+}
+
+test_checks_passed_without_green_evidence_is_not_done() {
+  reset_fakes
+  local d; d=$(new_case checks-passed-empty)
+  make_repo_on_branch "$d/wt" fm/feat-cpassedempty
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-cpassedempty.meta" "window=fm:fm-feat-cpassedempty" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_checks_passed fm/feat-cpassedempty)"
+  FM_FAKE_CI_LOGS="no CI checks reported - still monitoring until merged or closed"
+  local out; out=$(run_crew_state "$d" feat-cpassedempty)
+  assert_not_contains "$out" "state: done" "checks-passed with zero checks must not be done"
+  assert_not_contains "$out" "checks green" "checks-passed with zero checks must not read as checks green"
+  pass "a checks-passed claim with zero check evidence is not done"
+}
+
+test_checks_passed_with_success_evidence_is_done() {
+  reset_fakes
+  local d; d=$(new_case checks-passed-green)
+  make_repo_on_branch "$d/wt" fm/feat-cpassedgreen
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-cpassedgreen.meta" "window=fm:fm-feat-cpassedgreen" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_checks_passed fm/feat-cpassedgreen)"
+  FM_FAKE_CI_LOGS="all CI checks passed - still monitoring until merged or closed"
+  local out; out=$(run_crew_state "$d" feat-cpassedgreen)
+  assert_contains "$out" "state: done" "corroborated checks-passed -> done"
+  assert_contains "$out" "checks green" "corroborated checks-passed names checks green"
+  pass "a checks-passed claim corroborated by success evidence is done"
 }
 
 test_ci_monitoring_green_then_rearm_stays_working() {
@@ -754,10 +812,9 @@ EOF
 )"
   FM_FAKE_CI_LOGS="CI checks running, waiting for results..."
   local out; out=$(run_crew_state "$d" feat-coarseready)
-  assert_contains "$out" "state: done" "coarse ready status -> done"
-  assert_contains "$out" "source: status-log" "coarse ready status remains status-log sourced"
-  assert_not_contains "$out" "state: working" "coarse ready status must not be suppressed by another branch log"
-  pass "coarse run does not probe another branch's ci log"
+  assert_contains "$out" "state: working" "coarse ready status without evidence stays working"
+  assert_not_contains "$out" "state: done" "another branch's pending log must not corroborate a checks-green claim"
+  pass "coarse run does not treat another branch's ci log as this crew's green evidence"
 }
 
 # A different-branch run with NO matching runs-list row must NOT be
@@ -1414,10 +1471,13 @@ test_stale_blocked_superseded
 test_genuine_parked_not_superseded
 test_scalar_gate_parked_not_superseded
 test_gate_block_parked_not_superseded
-test_ci_ready_done_log_beats_monitoring_run
+test_ci_ready_done_log_without_evidence_stays_working
 test_ci_monitoring_checks_green_surfaces_done
 test_top_level_ci_checks_green_surfaces_done
-test_ci_monitoring_no_checks_terminal_surfaces_done
+test_ci_monitoring_no_checks_terminal_is_not_green
+test_ci_monitoring_cancelled_only_is_not_green
+test_checks_passed_without_green_evidence_is_not_done
+test_checks_passed_with_success_evidence_is_done
 test_ci_monitoring_green_then_rearm_stays_working
 test_ci_monitoring_no_checks_yet_stays_working
 test_ci_monitoring_still_waiting_stays_working

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -306,6 +306,20 @@ outcome: failed
 EOF
 }
 
+# A completed run whose answer carries no outcome field at all: terminal status
+# word, zero verdict evidence.
+run_completed_no_outcome() {  # <branch>
+  cat <<EOF
+run:
+  id: "01RUN"
+  branch: $1
+  status: completed
+  head: "${FM_FAKE_RUN_HEAD:-abc1234}"
+  pr: "https://github.com/o/r/pull/3"
+  findings: none
+EOF
+}
+
 run_ci_monitoring() {  # <branch>
   cat <<EOF
 run:
@@ -610,6 +624,23 @@ test_checks_passed_with_success_evidence_is_done() {
   assert_contains "$out" "state: done" "corroborated checks-passed -> done"
   assert_contains "$out" "checks green" "corroborated checks-passed names checks green"
   pass "a checks-passed claim corroborated by success evidence is done"
+}
+
+# Same shape as the coarse `completed` row: a terminal status word with no
+# outcome and no scored check evidence must not reach done.
+test_completed_without_outcome_is_not_done() {
+  reset_fakes
+  local d; d=$(new_case completed-no-outcome)
+  make_repo_on_branch "$d/wt" fm/feat-cnoout
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-cnoout.meta" "window=fm:fm-feat-cnoout" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_completed_no_outcome fm/feat-cnoout)"
+  FM_FAKE_CI_LOGS="all CI checks passed - still monitoring until merged or closed"
+  local out; out=$(run_crew_state "$d" feat-cnoout)
+  assert_contains "$out" "source: run-step" "completed-without-outcome run is still attributed"
+  assert_not_contains "$out" "state: done" "a completed run with no outcome must not be done"
+  assert_contains "$out" "run completed without an outcome" "the missing outcome is named"
+  pass "a completed run with no outcome is not done"
 }
 
 test_ci_monitoring_green_then_rearm_stays_working() {
@@ -1547,6 +1578,7 @@ test_prefixed_red_marker_after_green_is_not_green
 test_ci_failures_phrase_after_green_is_not_green
 test_checks_passed_without_green_evidence_is_not_done
 test_checks_passed_with_success_evidence_is_done
+test_completed_without_outcome_is_not_done
 test_ci_monitoring_green_then_rearm_stays_working
 test_ci_monitoring_no_checks_yet_stays_working
 test_ci_monitoring_still_waiting_stays_working

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -612,6 +612,25 @@ test_checks_passed_without_green_evidence_is_not_done() {
   pass "a checks-passed claim with zero check evidence is not done"
 }
 
+# The cancelled half of the same rule. The ci-monitoring cancelled case above
+# reads working even on the old code (an unrecognized marker scored unknown, so
+# nothing overrode working), so only this terminal-outcome case actually pins
+# "a cancelled-only run cannot produce checks-passed" from behavior.
+test_checks_passed_cancelled_only_is_not_done() {
+  reset_fakes
+  local d; d=$(new_case checks-passed-cancelled)
+  make_repo_on_branch "$d/wt" fm/feat-cpassedcancel
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-cpassedcancel.meta" "window=fm:fm-feat-cpassedcancel" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_checks_passed fm/feat-cpassedcancel)"
+  FM_FAKE_CI_LOGS="[12:00:04] CI checks were cancelled without reporting a verdict"
+  local out; out=$(run_crew_state "$d" feat-cpassedcancel)
+  assert_not_contains "$out" "state: done" "checks-passed over cancelled checks must not be done"
+  assert_not_contains "$out" "checks green" "cancelled checks must not read as checks green"
+  assert_contains "$out" "without green check evidence" "the missing green evidence is named"
+  pass "a checks-passed claim over cancelled-only checks is not done"
+}
+
 test_checks_passed_with_success_evidence_is_done() {
   reset_fakes
   local d; d=$(new_case checks-passed-green)
@@ -1577,6 +1596,7 @@ test_ci_monitoring_cancelled_only_is_not_green
 test_prefixed_red_marker_after_green_is_not_green
 test_ci_failures_phrase_after_green_is_not_green
 test_checks_passed_without_green_evidence_is_not_done
+test_checks_passed_cancelled_only_is_not_done
 test_checks_passed_with_success_evidence_is_done
 test_completed_without_outcome_is_not_done
 test_ci_monitoring_green_then_rearm_stays_working

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -543,6 +543,47 @@ test_ci_monitoring_cancelled_only_is_not_green() {
   pass "cancelled-only ci-monitor marker is not green"
 }
 
+# Real ci.log lines carry a timestamp/indent prefix, and a red marker can land
+# AFTER a green one. Both the marker selector and the conclusion classifier must
+# see the prefixed later line, or the earlier green wins.
+test_prefixed_red_marker_after_green_is_not_green() {
+  reset_fakes
+  local d; d=$(new_case ci-prefixed-red)
+  make_repo_on_branch "$d/wt" fm/feat-ciprefixed
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-ciprefixed.meta" "window=fm:fm-feat-ciprefixed" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_ci_monitoring fm/feat-ciprefixed)"
+  FM_FAKE_CI_LOGS="$(cat <<'EOF'
+[12:00:03] all CI checks passed - still monitoring until merged or closed
+[12:00:04] CI checks were cancelled without reporting a verdict
+EOF
+)"
+  local out; out=$(run_crew_state "$d" feat-ciprefixed)
+  assert_contains "$out" "state: working" "a later prefixed cancelled marker overrides the earlier green"
+  assert_not_contains "$out" "state: done" "prefixed cancelled marker must not read as done"
+  pass "prefixed red marker after green is not green"
+}
+
+# "CI failures" is a red phrase the classifier recognizes; the marker selector
+# must recognize it too, or the last green line stays the selected marker.
+test_ci_failures_phrase_after_green_is_not_green() {
+  reset_fakes
+  local d; d=$(new_case ci-failures-phrase)
+  make_repo_on_branch "$d/wt" fm/feat-cifailures
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-cifailures.meta" "window=fm:fm-feat-cifailures" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_ci_monitoring fm/feat-cifailures)"
+  FM_FAKE_CI_LOGS="$(cat <<'EOF'
+all CI checks passed - still monitoring until merged or closed
+CI failures: 2 jobs red
+EOF
+)"
+  local out; out=$(run_crew_state "$d" feat-cifailures)
+  assert_contains "$out" "state: working" "a later CI failures line overrides the earlier green"
+  assert_not_contains "$out" "state: done" "CI failures must not read as done"
+  pass "CI failures marker after green is not green"
+}
+
 test_checks_passed_without_green_evidence_is_not_done() {
   reset_fakes
   local d; d=$(new_case checks-passed-empty)
@@ -810,11 +851,37 @@ test_coarse_run_does_not_probe_other_branch_ci_log_for_ready_status() {
   running    fm/feat-coarseready ${short}  2026-07-02 22:05
 EOF
 )"
-  FM_FAKE_CI_LOGS="CI checks running, waiting for results..."
+  # The other branch's log is GREEN on purpose: any code that probed it would
+  # score green and emit done, so this assertion fails on a regression. A
+  # pending fake would pass either way and guard nothing.
+  FM_FAKE_CI_LOGS="all CI checks passed - still monitoring until merged or closed"
   local out; out=$(run_crew_state "$d" feat-coarseready)
-  assert_contains "$out" "state: working" "coarse ready status without evidence stays working"
-  assert_not_contains "$out" "state: done" "another branch's pending log must not corroborate a checks-green claim"
+  assert_contains "$out" "state: working" "coarse ready status without own evidence stays working"
+  assert_not_contains "$out" "state: done" "another branch's green log must not corroborate a checks-green claim"
   pass "coarse run does not treat another branch's ci log as this crew's green evidence"
+}
+
+# A coarse `completed` row carries no outcome and no check evidence, and the
+# ci-log scorer cannot run for it, so it must not reach done.
+test_coarse_completed_row_is_not_done() {
+  reset_fakes
+  local d short; d=$(new_case coarse-completed)
+  make_repo_on_branch "$d/wt" fm/feat-coarsedone
+  short=$(git -C "$d/wt" rev-parse --short=7 HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-coarsedone.meta" "window=fm:fm-feat-coarsedone" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_ci_monitoring fm/other-crew)"
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  running    fm/other-crew aaaaaaa  2026-07-02 22:10
+  completed  fm/feat-coarsedone ${short}  2026-07-02 22:05  https://github.com/o/r/pull/9
+EOF
+)"
+  FM_FAKE_CI_LOGS="all CI checks passed - still monitoring until merged or closed"
+  local out; out=$(run_crew_state "$d" feat-coarsedone)
+  assert_contains "$out" "source: run-step" "coarse completed row is still attributed to this crew"
+  assert_not_contains "$out" "state: done" "coarse completed without check evidence must not be done"
+  assert_contains "$out" "run completed without check evidence" "coarse completed names the missing evidence"
+  pass "coarse completed row does not report done"
 }
 
 # A different-branch run with NO matching runs-list row must NOT be
@@ -1476,6 +1543,8 @@ test_ci_monitoring_checks_green_surfaces_done
 test_top_level_ci_checks_green_surfaces_done
 test_ci_monitoring_no_checks_terminal_is_not_green
 test_ci_monitoring_cancelled_only_is_not_green
+test_prefixed_red_marker_after_green_is_not_green
+test_ci_failures_phrase_after_green_is_not_green
 test_checks_passed_without_green_evidence_is_not_done
 test_checks_passed_with_success_evidence_is_done
 test_ci_monitoring_green_then_rearm_stays_working
@@ -1491,6 +1560,7 @@ test_terminal_failed
 test_cross_branch_attribution_via_runs_list
 test_cross_branch_attribution_picks_most_recent_row
 test_coarse_run_does_not_probe_other_branch_ci_log_for_ready_status
+test_coarse_completed_row_is_not_done
 test_other_branch_run_ignored
 test_no_run_busy_pane
 test_no_run_footer_text_alone_is_not_working

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -19,6 +19,7 @@ REAL_GIT=$(command -v git)
 OTHER_PID=
 RECOVERY_WORKER_PID=
 REPEAT_WORKER_PID=
+LIVE_RECLAIM_PID=
 mkdir -p "$REMOTE_ROOT/bin" "$REMOTE_HOME" "$ACCOUNT_HOME" "$RUNTIME_BIN"
 # worker.pid records the serving child, not its restart supervisor, so stopping
 # that pid alone leaves the supervisor to respawn - the leak
@@ -27,6 +28,7 @@ cleanup_remote_job_fixture() {
   [ -z "$OTHER_PID" ] || kill "$OTHER_PID" 2>/dev/null || true
   [ -z "$RECOVERY_WORKER_PID" ] || kill "$RECOVERY_WORKER_PID" 2>/dev/null || true
   [ -z "$REPEAT_WORKER_PID" ] || kill "$REPEAT_WORKER_PID" 2>/dev/null || true
+  [ -z "$LIVE_RECLAIM_PID" ] || kill "$LIVE_RECLAIM_PID" 2>/dev/null || true
   if [ -f "$STATE_ROOT/worker.pid" ]; then
     fm_remote_job_stop_worker_tree "$(cat "$STATE_ROOT/worker.pid")" || true
   fi
@@ -303,6 +305,9 @@ fm_remote_job_stop_worker_tree "$RESIDUE_WORKER_PID" \
 mkdir -p "$STATE_ROOT/worker.lock"
 LOCK_RESIDUE="$STATE_ROOT/worker.lock/.pid.aB3xY9"
 printf '%s\n' "$RESIDUE_WORKER_PID" > "$LOCK_RESIDUE"
+# Creating that entry is what last moved the lock's own mtime, so an abandoned
+# lock old enough to be proven stale can only hold entries at least as old.
+touch -t 200001010000 "$LOCK_RESIDUE"
 touch -t 200001010000 "$STATE_ROOT/worker.lock"
 fm_remote_job_ensure_worker "$REMOTE_ROOT" "$ACCOUNT_HOME" || fail "$FM_REMOTE_JOB_ERROR"
 NEW_WORKER_PID=$(cat "$STATE_ROOT/worker.pid")
@@ -311,6 +316,36 @@ assert_absent "$LOCK_RESIDUE" "reclaim left a dead owner's private lock residue 
 fm_remote_job_worker_identity_matches "$REMOTE_ROOT" "$ACCOUNT_HOME" \
   || fail "the reclaiming worker did not publish the current code identity"
 pass "a lock left with a dead owner's private residue is still reclaimed"
+
+# A live owner publishes ownership through the same private temp names a dead
+# owner leaves behind, so a reclaimer that raced a replacement's fresh
+# publication would delete a running worker's ownership and let two workers
+# serve the same queue. An entry inside the recency window is never residue, and
+# a stale directory mtime alone does not license removing it.
+LIVE_RESIDUE_WORKER_PID=$NEW_WORKER_PID
+fm_remote_job_stop_worker_tree "$LIVE_RESIDUE_WORKER_PID" \
+  || fail "the live publication fixture could not stop the worker"
+mkdir -p "$STATE_ROOT/worker.lock"
+LIVE_LOCK_RESIDUE="$STATE_ROOT/worker.lock/.pid.zQ7wV2"
+printf '%s\n' "$LIVE_RESIDUE_WORKER_PID" > "$LIVE_LOCK_RESIDUE"
+touch -t 200001010000 "$STATE_ROOT/worker.lock"
+HOME="$ACCOUNT_HOME" FM_ROOT_OVERRIDE="$REMOTE_ROOT" FM_REMOTE_JOB_STATE_ROOT="$STATE_ROOT" \
+  FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux FM_REMOTE_JOB_TIMEOUT=1 \
+  "$REMOTE_ROOT/bin/fm-remote-job-worker.sh" --serve \
+  >> "$TMP_ROOT/worker.out" 2>> "$TMP_ROOT/worker.err" &
+LIVE_RECLAIM_PID=$!
+sleep 1
+kill -0 "$LIVE_RECLAIM_PID" 2>/dev/null \
+  || fail "the reclaiming worker stopped before its reclaim decision could be observed"
+assert_present "$LIVE_LOCK_RESIDUE" "reclaim deleted a publication still inside the recency window"
+assert_present "$STATE_ROOT/worker.lock" "reclaim destroyed a lock it could not prove abandoned"
+kill -TERM "$LIVE_RECLAIM_PID" 2>/dev/null || true
+wait "$LIVE_RECLAIM_PID" 2>/dev/null || true
+LIVE_RECLAIM_PID=
+rm -rf -- "$STATE_ROOT/worker.lock"
+fm_remote_job_ensure_worker "$REMOTE_ROOT" "$ACCOUNT_HOME" || fail "$FM_REMOTE_JOB_ERROR"
+NEW_WORKER_PID=$(cat "$STATE_ROOT/worker.pid")
+pass "reclaim never removes a lock entry a live owner could still be publishing"
 
 CRASHED_WORKER_PID=$NEW_WORKER_PID
 kill -KILL "$CRASHED_WORKER_PID"

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -266,6 +266,52 @@ fm_remote_job_ensure_worker "$REMOTE_ROOT" "$ACCOUNT_HOME" || fail "$FM_REMOTE_J
 NEW_WORKER_PID=$(cat "$STATE_ROOT/worker.pid")
 pass "worker identity binds the canonical configured code root"
 
+# Every replacement stop signals the whole worker tree, and the supervisor in
+# that tree signals the serving child again, so a second delivery always lands
+# on a child that is already shutting down. A child that dies inside its own
+# shutdown leaves ownership behind, and the replacement then has to reclaim it
+# instead of serving.
+STOPPED_WORKER_PID=$NEW_WORKER_PID
+STOPPED_WORKER_PGID=$(fm_remote_job_worker_process_group "$STOPPED_WORKER_PID") \
+  || fail "the repeated-stop fixture could not resolve an isolated worker group"
+kill -TERM -- "-$STOPPED_WORKER_PGID" 2>/dev/null || true
+for _ in $(seq 1 100); do
+  kill -0 "$STOPPED_WORKER_PID" 2>/dev/null || break
+  kill -TERM "$STOPPED_WORKER_PID" 2>/dev/null || true
+  sleep 0.003
+done
+wait "$STOPPED_WORKER_PID" 2>/dev/null || true
+for _ in $(seq 1 200); do
+  kill -0 "$STOPPED_WORKER_PID" 2>/dev/null || break
+  sleep 0.05
+done
+kill -0 "$STOPPED_WORKER_PID" 2>/dev/null && fail "the repeatedly signalled worker did not stop"
+assert_absent "$STATE_ROOT/worker.lock" "a repeatedly signalled shutdown left worker ownership held"
+assert_absent "$STATE_ROOT/worker.ready" "a repeatedly signalled shutdown left a readiness heartbeat behind"
+assert_absent "$STATE_ROOT/worker.pid" "a repeatedly signalled shutdown left a worker pid behind"
+fm_remote_job_ensure_worker "$REMOTE_ROOT" "$ACCOUNT_HOME" || fail "$FM_REMOTE_JOB_ERROR"
+NEW_WORKER_PID=$(cat "$STATE_ROOT/worker.pid")
+pass "a repeated stop signal never leaves worker ownership behind"
+
+# An owner that died between mktemp and mv leaves one of its own private temp
+# entries inside the ownership lock. rmdir can never reclaim a lock that still
+# holds one, so without residue clearing every replacement worker exits and the
+# account reads as a worker that never becomes ready.
+RESIDUE_WORKER_PID=$NEW_WORKER_PID
+fm_remote_job_stop_worker_tree "$RESIDUE_WORKER_PID" \
+  || fail "the lock residue fixture could not stop the worker"
+mkdir -p "$STATE_ROOT/worker.lock"
+LOCK_RESIDUE="$STATE_ROOT/worker.lock/.pid.aB3xY9"
+printf '%s\n' "$RESIDUE_WORKER_PID" > "$LOCK_RESIDUE"
+touch -t 200001010000 "$STATE_ROOT/worker.lock"
+fm_remote_job_ensure_worker "$REMOTE_ROOT" "$ACCOUNT_HOME" || fail "$FM_REMOTE_JOB_ERROR"
+NEW_WORKER_PID=$(cat "$STATE_ROOT/worker.pid")
+kill -0 "$NEW_WORKER_PID" 2>/dev/null || fail "the reclaiming worker is not running"
+assert_absent "$LOCK_RESIDUE" "reclaim left a dead owner's private lock residue behind"
+fm_remote_job_worker_identity_matches "$REMOTE_ROOT" "$ACCOUNT_HOME" \
+  || fail "the reclaiming worker did not publish the current code identity"
+pass "a lock left with a dead owner's private residue is still reclaimed"
+
 CRASHED_WORKER_PID=$NEW_WORKER_PID
 kill -KILL "$CRASHED_WORKER_PID"
 wait "$CRASHED_WORKER_PID" 2>/dev/null || true


### PR DESCRIPTION
## Intent

Fix the no-mistakes CI-ready verdict so cancelled, skipped, never-run, or zero checks are never reported as green. A green verdict is valid only if at least one check completed with success AND none are pending, failed, cancelled, skipped, or never-run. Zero checks is a distinct non-success state, not success. Cover both cancelled-as-green and zero-checks-as-green. A cancelled-only run cannot produce checks-passed. A run with zero checks cannot produce checks-passed. A genuinely all-success run still produces checks-passed. Tests must prove those three cases from code, not from a comment. Do not weaken an unrelated assertion to make a suite pass. Shared firstmate material; do not push to the default branch; do not merge. Open the PR against the configured upstream and stop at green.

## What Changed

- Added `bin/fm-ci-verdict-lib.sh` as the single owner of the CI-ready rule: a check-conclusion set scores `passed` only when at least one check completed with success and none are pending, failed, cancelled, skipped, or never-run; zero checks scores `empty`, everything else `not-passed`. It is sourced as a library and also runnable as a command.
- Reworked `bin/fm-crew-state.sh` to route every green claim through that scorer: the ci-log marker is now classified into a conclusion (including new cancelled/`CI failures`/`waiting for checks`/`repository declares no CI` phrases) before scoring, a terminal `checks-passed` outcome reports `blocked` without scored green evidence and `unknown` when the ci log is unreadable, and a bare `completed` run with no outcome — from `axi status` or the coarse runs list — now reads `unknown` instead of `done`, which also removes the coarse early-emit that skipped scoring entirely.
- Added `tests/fm-ci-verdict-lib.test.sh` and extended `tests/fm-crew-state.test.sh` to pin the cancelled-only, zero-checks, and genuinely all-success cases (each new guard verified to fail against the base commit); registered the new test file in `bin/fm-test-run.sh` and updated `AGENTS.md`, `docs/architecture.md`, and `docs/scripts.md` to state the scored verdict and the outcomeless-run states. Review flagged two accepted boundaries (a CI-less repo now stays `working` rather than `done`, and the no-run status-log fallback still promotes a crew's own `checks green` line); the pre-existing `tests/fm-watch-triage.test.sh` flake reproduces on the base tree and is untouched by this change.

## Risk Assessment

✅ Low: Both accepted fixes are correct and covered by tests that fail on regression, no existing fixture or consumer regresses, and every run-attributed path to done now requires scored evidence or a merged outcome.

## Testing

Ran the two targeted suites (`tests/fm-ci-verdict-lib.test.sh`, `tests/fm-crew-state.test.sh`) — both pass — then produced the real evidence by driving the actual `bin/fm-crew-state.sh` CLI over throwaway git worktrees with a fake `no-mistakes` backend, side by side on base 1238402 and target 9eb7125: a `checks-passed` run over cancelled checks and one over zero checks both used to print `state: done · checks green: PR ready for review` and now print `state: blocked · run reported checks-passed without green check evidence`, while the genuinely all-success control still prints `state: done · checks green` and a terminal `completed` run with no outcome now reads `unknown` instead of `done`. To show the tests pin this from code rather than from a comment, I grafted the target test file onto the base tree and ran each new case in isolation: all of them fail on base and pass on target, and the all-success control passes on both, so no assertion was weakened. I also captured a transcript of the shared scorer's public command across success/cancelled/skipped/pending/failed/never-run/zero-check inputs, confirmed the runner coverage guard still passes, and exercised the downstream crew-state consumers — `fm-inactive-reconcile` passes, and `fm-watch-triage` fails non-deterministically with a different case each run on both base and target (it stubs the crew-state reader, so this change cannot reach it), which I recorded as a pre-existing environmental flake rather than a regression. This is a CLI-only change with no rendered UI surface, so the evidence is CLI transcripts rather than screenshots. Scratch trees were removed and the worktree is clean.

<details>
<summary>Evidence: Before/after CLI transcript: fm-crew-state.sh verdict on base vs target</summary>

<code>==== BASE 1238402 (before the fix) ====&#10;# 1. Run claims outcome: checks-passed, but every CI check was CANCELLED&#10;$ fm-crew-state.sh cancelled-only&#10;state: done · source: run-step · checks green: PR ready for review&#10;&#10;# 2. Run claims outcome: checks-passed, but ZERO checks ever ran&#10;$ fm-crew-state.sh zero-checks&#10;state: done · source: run-step · checks green: PR ready for review&#10;&#10;# 3. Genuinely all-success run (control: green must still be green)&#10;$ fm-crew-state.sh all-success&#10;state: done · source: run-step · checks green: PR ready for review&#10;&#10;# 4. Terminal `completed` run carrying no outcome at all&#10;$ fm-crew-state.sh no-outcome&#10;state: done · source: run-step · run completed&#10;&#10;==== TARGET 9eb7125 (with the fix) ====&#10;# 1. Run claims outcome: checks-passed, but every CI check was CANCELLED&#10;$ fm-crew-state.sh cancelled-only&#10;state: blocked · source: run-step · run reported checks-passed without green check evidence&#10;&#10;# 2. Run claims outcome: checks-passed, but ZERO checks ever ran&#10;$ fm-crew-state.sh zero-checks&#10;state: blocked · source: run-step · run reported checks-passed without green check evidence&#10;&#10;# 3. Genuinely all-success run (control: green must still be green)&#10;$ fm-crew-state.sh all-success&#10;state: done · source: run-step · checks green: PR ready for review&#10;&#10;# 4. Terminal `completed` run carrying no outcome at all&#10;$ fm-crew-state.sh no-outcome&#10;state: unknown · source: run-step · run completed without an outcome</code>

```text

==== BASE 1238402 (before the fix) ====
--------------------------------------------------------------------
# 1. Run claims outcome: checks-passed, but every CI check was CANCELLED
$ no-mistakes axi logs --step ci   ->  "CI checks were cancelled without reporting a verdict"
$ fm-crew-state.sh cancelled-only
state: done · source: run-step · checks green: PR ready for review
--------------------------------------------------------------------

# 2. Run claims outcome: checks-passed, but ZERO checks ever ran
$ no-mistakes axi logs --step ci   ->  "no CI checks reported - still monitoring until merged or closed"
$ fm-crew-state.sh zero-checks
state: done · source: run-step · checks green: PR ready for review
--------------------------------------------------------------------

# 3. Genuinely all-success run (control: green must still be green)
$ no-mistakes axi logs --step ci   ->  "all CI checks passed - still monitoring until merged or closed"
$ fm-crew-state.sh all-success
state: done · source: run-step · checks green: PR ready for review
--------------------------------------------------------------------

# 4. Terminal `completed` run carrying no outcome at all
$ fm-crew-state.sh no-outcome
state: done · source: run-step · run completed
--------------------------------------------------------------------

==== TARGET 9eb7125 (with the fix) ====
--------------------------------------------------------------------
# 1. Run claims outcome: checks-passed, but every CI check was CANCELLED
$ no-mistakes axi logs --step ci   ->  "CI checks were cancelled without reporting a verdict"
$ fm-crew-state.sh cancelled-only
state: blocked · source: run-step · run reported checks-passed without green check evidence
--------------------------------------------------------------------

# 2. Run claims outcome: checks-passed, but ZERO checks ever ran
$ no-mistakes axi logs --step ci   ->  "no CI checks reported - still monitoring until merged or closed"
$ fm-crew-state.sh zero-checks
state: blocked · source: run-step · run reported checks-passed without green check evidence
--------------------------------------------------------------------

# 3. Genuinely all-success run (control: green must still be green)
$ no-mistakes axi logs --step ci   ->  "all CI checks passed - still monitoring until merged or closed"
$ fm-crew-state.sh all-success
state: done · source: run-step · checks green: PR ready for review
--------------------------------------------------------------------

# 4. Terminal `completed` run carrying no outcome at all
$ fm-crew-state.sh no-outcome
state: unknown · source: run-step · run completed without an outcome
--------------------------------------------------------------------
```
</details>
<details>
<summary>Evidence: New tests fail against base code (proves the fix from behavior)</summary>

<code># Target tests/fm-crew-state.test.sh grafted onto the BASE 1238402 tree, each case run in isolation.&#10;# &#34;not ok&#34; on base + &#34;ok&#34; on target = the test pins the fix from code.&#10;&#10;vs BASE test_checks_passed_cancelled_only_is_not_done not ok - checks-passed over cancelled checks must not be done (unexpected: &#39;state: done&#39;)&#10;vs BASE test_checks_passed_without_green_evidence_is_not_done not ok - checks-passed with zero checks must not be done (unexpected: &#39;state: done&#39;)&#10;vs BASE test_checks_passed_with_success_evidence_is_done ok - a checks-passed claim corroborated by success evidence is done &lt;-- control, green not weakened&#10;vs BASE test_completed_without_outcome_is_not_done not ok - a completed run with no outcome must not be done (unexpected: &#39;state: done&#39;)&#10;vs BASE test_coarse_completed_row_is_not_done not ok - coarse completed without check evidence must not be done (unexpected: &#39;state: done&#39;)&#10;vs BASE test_ci_monitoring_no_checks_terminal_is_not_green not ok - terminal no-checks ci-monitor run -&gt; working (missing: &#39;state: working&#39;)&#10;vs BASE test_ci_ready_done_log_without_evidence_stays_working not ok - uncorroborated ci-ready status log stays working (missing: &#39;state: working&#39;)&#10;vs BASE test_prefixed_red_marker_after_green_is_not_green not ok - a later prefixed cancelled marker overrides the earlier green (missing: &#39;state: working&#39;)&#10;vs BASE test_ci_failures_phrase_after_green_is_not_green not ok - a later CI failures line overrides the earlier green (missing: &#39;state: working&#39;)</code>

```text
# Each new/changed test, run in isolation against BASE 1238402 bin/ (target test file grafted onto the base tree).
# "not ok" here + "ok" on target = the test pins the fix from code, not from a comment.

vs BASE  test_checks_passed_cancelled_only_is_not_done            not ok - checks-passed over cancelled checks must not be done (unexpected: 'state: done')
vs BASE  test_checks_passed_without_green_evidence_is_not_done    not ok - checks-passed with zero checks must not be done (unexpected: 'state: done')
vs BASE  test_checks_passed_with_success_evidence_is_done         ok - a checks-passed claim corroborated by success evidence is done
vs BASE  test_completed_without_outcome_is_not_done               not ok - a completed run with no outcome must not be done (unexpected: 'state: done')
vs BASE  test_coarse_completed_row_is_not_done                    not ok - coarse completed without check evidence must not be done (unexpected: 'state: done')
vs BASE  test_ci_monitoring_no_checks_terminal_is_not_green       not ok - terminal no-checks ci-monitor run -> working (missing: 'state: working')
vs BASE  test_ci_monitoring_cancelled_only_is_not_green           ok - cancelled-only ci-monitor marker is not green
vs BASE  test_ci_ready_done_log_without_evidence_stays_working    not ok - uncorroborated ci-ready status log stays working (missing: 'state: working')
vs BASE  test_prefixed_red_marker_after_green_is_not_green        not ok - a later prefixed cancelled marker overrides the earlier green (missing: 'state: working')
vs BASE  test_ci_failures_phrase_after_green_is_not_green         not ok - a later CI failures line overrides the earlier green (missing: 'state: working')
```
</details>
<details>
<summary>Evidence: Shared CI-ready scorer driven through its public command interface</summary>

<code># A green verdict requires &gt;=1 completed success AND zero pending/failed/cancelled/skipped/never-run.&#10;&#10;$ bin/fm-ci-verdict-lib.sh (no checks at all) -&gt; empty&#10;$ bin/fm-ci-verdict-lib.sh SUCCESS -&gt; passed&#10;$ bin/fm-ci-verdict-lib.sh SUCCESS SUCCESS SUCCESS -&gt; passed&#10;$ bin/fm-ci-verdict-lib.sh CANCELLED -&gt; not-passed&#10;$ bin/fm-ci-verdict-lib.sh SUCCESS CANCELLED -&gt; not-passed&#10;$ bin/fm-ci-verdict-lib.sh SKIPPED -&gt; not-passed&#10;$ bin/fm-ci-verdict-lib.sh SUCCESS SKIPPED -&gt; not-passed&#10;$ bin/fm-ci-verdict-lib.sh PENDING -&gt; not-passed&#10;$ bin/fm-ci-verdict-lib.sh SUCCESS QUEUED -&gt; not-passed&#10;$ bin/fm-ci-verdict-lib.sh FAILURE -&gt; not-passed&#10;$ bin/fm-ci-verdict-lib.sh never-run -&gt; not-passed&#10;$ bin/fm-ci-verdict-lib.sh SUCCESS never-run -&gt; not-passed&#10;&#10;$ printf &#34;SUCCESS\nSUCCESS\n&#34; | bin/fm-ci-verdict-lib.sh -&gt; passed&#10;$ printf &#34;SUCCESS\nCANCELLED\n&#34; | bin/fm-ci-verdict-lib.sh -&gt; not-passed&#10;$ printf &#34;\n\n&#34; | bin/fm-ci-verdict-lib.sh -&gt; empty</code>

```text
# The shared CI-ready scorer, driven through its public command interface.
# usage: bin/fm-ci-verdict-lib.sh [conclusion...]  (stdin, one per line, when no args)
# A green verdict requires >=1 completed success AND zero pending/failed/cancelled/skipped/never-run.

$ bin/fm-ci-verdict-lib.sh (no checks at all)             -> empty
$ bin/fm-ci-verdict-lib.sh SUCCESS                        -> passed
$ bin/fm-ci-verdict-lib.sh SUCCESS SUCCESS SUCCESS        -> passed
$ bin/fm-ci-verdict-lib.sh CANCELLED                      -> not-passed
$ bin/fm-ci-verdict-lib.sh SUCCESS CANCELLED              -> not-passed
$ bin/fm-ci-verdict-lib.sh SKIPPED                        -> not-passed
$ bin/fm-ci-verdict-lib.sh SUCCESS SKIPPED                -> not-passed
$ bin/fm-ci-verdict-lib.sh PENDING                        -> not-passed
$ bin/fm-ci-verdict-lib.sh SUCCESS QUEUED                 -> not-passed
$ bin/fm-ci-verdict-lib.sh FAILURE                        -> not-passed
$ bin/fm-ci-verdict-lib.sh never-run                      -> not-passed
$ bin/fm-ci-verdict-lib.sh SUCCESS never-run              -> not-passed

$ printf "SUCCESS\nSUCCESS\n" | bin/fm-ci-verdict-lib.sh   -> passed
$ printf "SUCCESS\nCANCELLED\n" | bin/fm-ci-verdict-lib.sh -> not-passed
$ printf "\n\n" | bin/fm-ci-verdict-lib.sh                  -> empty
```
</details>
<details>
<summary>Evidence: Targeted suite result</summary>

```text
$ bin/fm-test-run.sh tests/fm-ci-verdict-lib.test.sh tests/fm-crew-state.test.sh
ok - terminal no-checks ci-monitor marker is not green
ok - cancelled-only ci-monitor marker is not green
ok - prefixed red marker after green is not green
ok - CI failures marker after green is not green
ok - a checks-passed claim with zero check evidence is not done
ok - a checks-passed claim over cancelled-only checks is not done
ok - a checks-passed claim corroborated by success evidence is done
ok - a completed run with no outcome is not done
ok - coarse completed row does not report done
FM_TEST_SUMMARY total=2 failed=0 skipped_gate=0 duration_ms=106011
```
</details>
<details>
<summary>Evidence: fm-watch-triage flake characterization (fails on base and target alike)</summary>

```text
# tests/fm-watch-triage.test.sh is timing-sensitive (spawns a real background
# watcher and polls for exit/queue effects). It fails NON-DETERMINISTICALLY in
# this sandbox on BOTH the base and the target tree, with a DIFFERENT case each
# run - the signature of an environmental timing flake, not a regression.
#
# It also cannot be affected by this change: every case stubs the crew-state
# reader via FM_CREW_STATE_BIN/FM_FAKE_CREW_STATE, so the real verdict code
# under test here never runs inside it.

TARGET 9eb7125, tests/fm-watch-triage.test.sh, three separate runs:
  run 1: not ok - provably-working signal did not advance its .seen-* suppressor
  run 2: not ok - watcher did not surface a working: note whose crew has no running pipeline and an idle pane
  run 3: not ok - watcher did not surface a turn-end whose crew is not provably working

BASE 1238402, tests/fm-watch-triage.test.sh, two separate runs:
  run 1: stopped after 9 ok (different case)
  run 2: not ok - watcher did not exit for an actionable needs-decision signal

The one case that overlapped with the target failures, run in isolation on the
target 3/3 times:
  ok - a no-verb signal whose crew is provably working is absorbed (no exit, no queue, suppressor advanced, beacon present)
```
</details>
- Outcome: ⚠️ 1 warning across 2 runs (56m24s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-crew-state.sh:313` - The marker selector grep and nm_ci_marker_conclusion no longer cover the same phrases: the classifier recognizes &#34;CI failures&#34; (line 300) and &#34;waiting for checks&#34; (line 301), but neither appears in the grep -E alternation on line 313 that picks the marker. Because selection is `tail -1` of grep-matching lines, a red line using only those phrases is invisible to the selector and an EARLIER green line wins. Concrete failing sequence: ci.log tail = [&#34;all CI checks passed - still monitoring until merged or closed&#34;, &#34;CI failures: 2 jobs red&#34;] -&gt; marker = the green line -&gt; conclusion SUCCESS -&gt; fm_ci_ready_verdict passed -&gt; nm_ci_checks_state green -&gt; state: done while CI is red. This is the same false-green class the change exists to prevent, and the drift is introduced here (the pre-change grep and case lists had identical coverage). Fix: keep the two lists in sync - add &#34;CI failures&#34; and &#34;waiting for checks&#34; to the grep alternation, or drop them from the classifier if the CLI never emits them.
- ⚠️ `bin/fm-crew-state.sh:451` - The coarse attribution path maps runs-list status `completed` straight to RUN_STATE=done (&#34;run completed&#34;) without consulting the new scorer, so the authorized failure remains reachable through a sibling path in the same function. Concrete sequence: crew&#39;s own run ends with outcome=checks-passed where every check was cancelled (or there were zero checks); `axi status` answers with another crew&#39;s run (the exact condition the coarse fallback exists for, modelled by tests/fm-crew-state.test.sh:799); `no-mistakes runs` shows a head-matching row `completed  fm/&lt;branch&gt; &lt;sha&gt;` -&gt; RUN_SOURCE=coarse -&gt; state: done. That contradicts the invariant this change just documented at AGENTS.md:349 (&#34;a checks-passed claim is done only when bin/fm-crew-state.sh scores at least one successful check&#34;). The coarse path cannot score (RUN_OUT holds another run&#39;s id), so the earliest supported boundary is the coarse status mapping itself: `completed` would have to become unknown/blocked rather than done. That trades false-green for false-unknown on every legitimately merged run, so it is a product-behavior decision rather than a mechanical fix.
- ⚠️ `bin/fm-crew-state.sh:299` - Five patterns in nm_ci_marker_conclusion are missing their leading `*`: `&#34;CI checks were cancelled&#34;*` and `&#34;cancelled without&#34;*` (line 299), `&#34;CI failures&#34;*` and `&#34;issues detected&#34;*` (line 300), `&#34;waiting for checks&#34;*` (line 301), `&#34;repository declares no CI&#34;*` (line 302). They only match when the phrase starts the line, so any real log line carrying a timestamp or indent prefix (e.g. &#34;[12:00:04] CI checks were cancelled without reporting a verdict&#34;) falls through every arm to the empty conclusion. The mis-scoring is currently masked because nm_ci_checks_state collapses `empty` and `not-passed` to `not-ready`, but the lib deliberately keeps them as distinct verdicts, so the bug becomes live the moment a caller distinguishes them - and the new tests pass only because FM_FAKE_CI_LOGS fakes are unprefixed. Add the leading `*` to each.
- ⚠️ `tests/fm-crew-state.test.sh:813` - test_coarse_run_does_not_probe_other_branch_ci_log_for_ready_status still names the property &#34;coarse run does not probe another branch&#39;s ci log&#34;, but with the coarse early-emit removed the assertions no longer distinguish probing from not-probing: FM_FAKE_CI_LOGS is a pending marker, so a regression that DID probe the other branch&#39;s log would read not-ready and still emit `state: working`, and the test would pass. The guard for the original cross-branch bug is now vacuous. Restore it by setting FM_FAKE_CI_LOGS to the green marker (&#34;all CI checks passed - still monitoring until merged or closed&#34;): current code skips the block for coarse and stays working, while any code that probed the other branch&#39;s log would emit done and fail the existing assert_not_contains &#34;state: done&#34;.
- ℹ️ `bin/fm-bearings-snapshot.sh:246` - bin/fm-ci-verdict-lib.sh declares itself the &#34;ONE owner&#34; of the green-verdict rule, but fm-bearings-snapshot.sh keeps an independent jq scorer over statusCheckRollup that reaches a different answer for conclusions the intent names as never-green: a check with status COMPLETED and conclusion SKIPPED (or NEUTRAL/STALE) is not in the failing list and is not pending, so an all-skipped rollup renders as checks &#34;passing&#34; in the captain&#39;s PR snapshot. This is pre-existing and untouched by the diff, and it scores GitHub rollup data rather than a no-mistakes run verdict, so it may be deliberately outside the stated scope (&#34;the no-mistakes CI-ready verdict&#34;) - flagging it as the one immediately competing semantic owner rather than proposing a redesign.
- ℹ️ `bin/fm-ci-verdict-lib.sh:32` - fm_ci_ready_verdict duplicates the identical trim/success/short-circuit body across the args branch and the stdin branch, so the scoring rule now has two copies to keep in sync inside its own single-owner file. It collapses to one loop by normalizing the input first, e.g. `if [ &#34;$#&#34; -eq 0 ]; then set -- $(cat); fi` (or reading stdin into a positional list) and then running the single loop over &#34;$@&#34;. Non-functional cleanup; behavior is unchanged.
- ℹ️ `bin/fm-crew-state.sh:302` - Consequence worth stating explicitly, not a defect: &#34;no CI checks reported - still monitoring until merged or closed&#34; used to score green, and now scores empty -&gt; not-ready. On a repo that genuinely configures no CI, a crew therefore never reaches done from the ci-monitor path (it stays working until the PR merges, and a terminal checks-passed run reads blocked). That is exactly what the intent requires (&#34;Zero checks is a distinct non-success state, not success&#34;), so it is correct as specified - but it changes steady-state fleet surfacing for CI-less repos, since crew_absorb_class maps blocked/unknown to &#34;none&#34; and those wakes will surface to the captain instead of being absorbed.

🔧 Fix: sync CI marker patterns and fail coarse completed closed
4 issues (1 warning, 3 infos) still open:
- ⚠️ `tests/fm-ci-verdict-lib.test.sh:36` - `out=$(score)` invokes bin/fm-ci-verdict-lib.sh with zero arguments, which by contract enters the stdin branch (`while IFS= read -r raw`). Command substitution does not redirect stdin, and bin/fm-test-run.sh:1549 runs serial scripts as `bash &#34;$script&#34; 2&gt;&amp;1 | tee &#34;$out&#34;` with JOBS=1 by default, so the test inherits the invoker&#39;s stdin. Run from a terminal (or any runner whose stdin is an open pipe), `read` blocks and the whole suite hangs at this line instead of asserting. It only appears to work when stdin happens to be /dev/null or already at EOF. Fix: `out=$(score &lt; /dev/null)` - the zero-checks assertion is unchanged (empty stdin still yields `empty`) and the hang is removed. The sibling blank-line case on line 39 already pipes its input and is fine.
- ℹ️ `bin/fm-crew-state.sh:513` - Sibling path check after closing the coarse hole: on the full path, when `axi status` reports `status: completed` with NO `outcome:` field, the no-outcome case arm still maps it to RUN_STATE=done / &#34;run completed&#34; without consulting the scorer - the same shape (done with zero check evidence) that COARSE_STATUS=completed was just changed to reject at line 456. I could not prove from source that the CLI ever emits a completed run without an outcome, so I am not claiming reachability; the supporting signal is bin/fm-teardown.sh:1251, which treats the OUTCOME (cancelled|failed|passed|checks-passed), not the status word, as the terminal marker - implying a completed row lacking an outcome is a shape the codebase already guards against elsewhere. If it is reachable, mapping it to unknown would match the coarse decision; if the CLI guarantees an outcome on every completed run, this arm is dead and can stay as is. Raising it as a question rather than a fix because it is the same product-behavior tradeoff (false-green vs false-unknown) already decided once for the coarse path.
- ℹ️ `bin/fm-crew-state.sh:456` - Downstream consequence of the accepted coarse `completed` -&gt; unknown mapping, recorded rather than proposed for change: bin/fm-inactive-reconcile.sh:341-345 only creates a durable terminal-outcome record (and supervisor wake) for `state: done ` or `state: failed `, so an inactive crew whose finished run is attributed only coarsely now produces no terminal record where it previously produced a done record. The crew is still surfaced through the ordinary wake path (crew_absorb_class maps unknown to &#34;none&#34;, so its wakes are not absorbed), and the coarse fallback is transient - a later scan where `axi status` returns the crew&#39;s own run takes the full path and scores properly. Fail-closed and consistent with the invariant the user chose; noting it because it was not visible when that mapping was decided.
- ℹ️ `tests/fm-crew-state.test.sh:549` - test_prefixed_red_marker_after_green_is_not_green asserts a genuine behavior (a later prefixed cancelled line must beat an earlier green one) but cannot fail if the leading `*` globs are removed again: with the anchored patterns, &#34;[12:00:04] CI checks were cancelled without reporting a verdict&#34; matches no case arm and yields the empty conclusion -&gt; verdict `empty`, and nm_ci_checks_state collapses `empty` and `not-passed` to the same `not-ready`, so the crew reads `working` either way. No crew-state-level test can distinguish them while that collapse exists; only a direct assertion on the classifier could. The companion test_ci_failures_phrase_after_green_is_not_green does not have this problem - it fails on a regression of the grep list. No action needed unless a caller ever distinguishes empty from not-passed.

🔧 Fix: reject outcomeless completed run and unblock verdict test stdin
1 info still open:
- ℹ️ `bin/fm-crew-state.sh:606` - Boundary note on the durable fix, no action recommended. After this round every run-attributed route to done requires evidence (line 475 outcome=passed/merged, 480 checks-passed + scored green, 528 ci-step + scored green, 550 status-log + scored green, and both bare-`completed` shapes now read unknown at 456 and 516). The one remaining way an unscored &#34;checks green&#34; claim still becomes done is the no-run fallback here: when NO run is attributable at all - worktree HEAD rewritten past the run head, or the run aged out of `no-mistakes runs --limit` - and the pane is exact-idle, map_log_state promotes the crew&#39;s own `done: PR ... checks green` line to state done with source status-log. That is reachable after a cancelled-CI run whose crew already wrote that line, but crew-state has literally no run to score at that point, and step 4 of this file&#39;s header documents the fallback as intentional. There is no earlier shared boundary that would restore the invariant without removing the fallback itself, so this is the honest edge of the fix rather than a defect to patch.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `tests/fm-crew-state.test.sh:615` - The intent requires &#34;a cancelled-only run cannot produce checks-passed&#34; be proven from code, but no test pinned it. `test_ci_monitoring_cancelled_only_is_not_green` passes against the base bin too (on base, &#34;CI checks were cancelled&#34; was an unrecognized marker, so it scored `unknown` and nothing overrode `working`) — it was green for the wrong reason and guarded nothing. The `outcome: checks-passed` + cancelled-checks path, where base actually reported `state: done · checks green`, had no coverage at all. Fixed by adding `test_checks_passed_cancelled_only_is_not_done`, verified to fail against base 1238402 and pass on the target.
- <code>`bash tests/fm-ci-verdict-lib.test.sh` — 4 scoring cases (cancelled, zero-checks, all-success, skipped/pending/failed/never-run), all pass</code>
- <code>`bash tests/fm-crew-state.test.sh` — full suite passes including all CI-verdict cases and the added `test_checks_passed_cancelled_only_is_not_done`</code>
- <code>Added `test_checks_passed_cancelled_only_is_not_done` to `tests/fm-crew-state.test.sh` pinning `outcome: checks-passed` + cancelled ci.log → not done</code>
- <code>Manual end-to-end CLI drive of `bin/fm-crew-state.sh &lt;id&gt;` over 7 scenarios against a real throwaway git worktree + faked `no-mistakes axi status`/`axi logs`/`runs`, run against BOTH base 1238402 and target f7040c7 (`bash drive-crew-state.sh &lt;repo&gt; &lt;label&gt;`)</code>
- <code>Per-test regression proof: each new guard test run individually against the base bin/ (`FM_ONE_TEST=&lt;test&gt; bash tests/one.sh`) — confirmed 8 of them fail on the old behavior, which is how the untested cancelled case was found</code>
- <code>Mutation testing of `bin/fm-ci-verdict-lib.sh`: (M1) empty→passed, (M2) CANCELLED treated as success, (M3) all-success→not-passed; each mutation caught by both suites</code>
- <code>`bash drive-scorer.sh &lt;repo&gt;` — direct CLI transcript of `bin/fm-ci-verdict-lib.sh` over 25 arg/stdin conclusion sets</code>
- <code>`bin/fm-test-run.sh --list --changed --base 12384026` — confirms `tests/fm-ci-verdict-lib.test.sh` and `tests/fm-crew-state.test.sh` are auto-selected from the changed paths</code>
- <code>`bash tests/fm-test-run.test.sh` — exit 0, confirms the new test file&#39;s family registration is consistent</code>
- <code>`bash tests/fm-documentation-audiences.test.sh`, `bash tests/fm-supervision-instructions.test.sh`, `bash tests/fm-ensure-agents-md.test.sh` — doc-contract suites owning the edited AGENTS.md / docs/ files, all exit 0</code>

🔧 Fix: verify cancelled checks-passed guard; watcher flake is environmental
1 warning still open:
- ⚠️ `tests/fm-watch-triage.test.sh:393` - tests/fm-watch-triage.test.sh fails non-deterministically in this sandbox, with a DIFFERENT case each run, on both the base tree (1238402) and the target (9eb7125). Target runs failed on &#39;provably-working signal did not advance its .seen-* suppressor&#39;, then &#39;watcher did not surface a working: note whose crew has no running pipeline and an idle pane&#39;, then &#39;watcher did not surface a turn-end whose crew is not provably working&#39;; base runs failed on a fourth and fifth distinct case. The suite spawns a real background watcher and polls for exit/queue side effects, so it is timing-sensitive. It also cannot be affected by this change: every case stubs the crew-state reader through FM_CREW_STATE_BIN/FM_FAKE_CREW_STATE, so the real verdict code never runs inside it. The one overlapping case passed 3/3 when run in isolation on the target. Informational: pre-existing environmental flake, not a regression from this change, and not fixed here because it is out of this change&#39;s scope.
- <code>`bin/fm-test-run.sh tests/fm-ci-verdict-lib.test.sh tests/fm-crew-state.test.sh` — both suites pass, 0 failures</code>
- <code>Manual end-to-end CLI transcript: real `bin/fm-crew-state.sh &lt;id&gt;` driven over throwaway git repos with a fake `no-mistakes` serving `axi status` / `axi logs`, run against base 1238402 bin/ and target 9eb7125 bin/, for cancelled-only, zero-checks, all-success, and no-outcome scenarios</code>
- <code>Per-test base comparison: target `tests/fm-crew-state.test.sh` grafted onto a base 1238402 tree, each case run in isolation — `test_checks_passed_cancelled_only_is_not_done`, `test_checks_passed_without_green_evidence_is_not_done`, `test_completed_without_outcome_is_not_done`, `test_coarse_completed_row_is_not_done`, `test_ci_monitoring_no_checks_terminal_is_not_green`, `test_ci_ready_done_log_without_evidence_stays_working`, `test_prefixed_red_marker_after_green_is_not_green`, `test_ci_failures_phrase_after_green_is_not_green` all fail on base</code>
- <code>Control check: `test_checks_passed_with_success_evidence_is_done` passes on both base and target (green was not weakened)</code>
- <code>Manual scorer transcript: `bin/fm-ci-verdict-lib.sh` public command driven over success / cancelled / skipped / pending / failed / never-run / zero-check inputs, via both argv and stdin</code>
- <code>`bin/fm-test-run.sh --check-coverage` — FM_TEST_COVERAGE ok total=147 (new test file is registered in a family/lane)</code>
- <code>`bin/fm-test-run.sh tests/fm-watch-triage.test.sh tests/fm-inactive-reconcile.test.sh` — downstream crew-state consumers; inactive-reconcile passes, watch-triage flakes on base and target alike</code>
- <code>`bash tests/fm-watch-triage.test.sh` repeated on target and on the base tree to characterize the flake</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
