### PR TITLE
fix(bin): force byte collation in the test coverage guard

### DIFF
--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -586,7 +586,7 @@ run_coverage_guard() {
   list_portable_parallel_1 | LC_ALL=C sort -u >"$tmp/s1"
   list_portable_parallel_2 | LC_ALL=C sort -u >"$tmp/s2"
 
-  cat "$tmp/s1" "$tmp/s2" | LC_ALL=C sort | uniq -d >"$tmp/shard_dups"
+  cat "$tmp/s1" "$tmp/s2" | LC_ALL=C sort | LC_ALL=C uniq -d >"$tmp/shard_dups"
   if [ -s "$tmp/shard_dups" ]; then
     log "coverage guard: portable parallel shards share scripts:"
     cat "$tmp/shard_dups" >&2
@@ -594,8 +594,8 @@ run_coverage_guard() {
     return 1
   fi
   cat "$tmp/s1" "$tmp/s2" | LC_ALL=C sort -u >"$tmp/shards_union"
-  missing=$(comm -23 "$tmp/proven" "$tmp/shards_union" || true)
-  extra=$(comm -13 "$tmp/proven" "$tmp/shards_union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/proven" "$tmp/shards_union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/proven" "$tmp/shards_union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable shards must equal the proven-isolated set"
     [ -z "$missing" ] || { log "missing from shards:"; printf '%s\n' "$missing" >&2; }
@@ -631,7 +631,7 @@ run_coverage_guard() {
 
   # Every serial script runs in exactly one CI shard: no duplicate work across
   # runners, and no script silently left out of the required lane.
-  LC_ALL=C sort "$tmp/serial_shards_raw" | uniq -d >"$tmp/serial_shard_dups"
+  LC_ALL=C sort "$tmp/serial_shards_raw" | LC_ALL=C uniq -d >"$tmp/serial_shard_dups"
   if [ -s "$tmp/serial_shard_dups" ]; then
     log "coverage guard: portable serial shards share scripts:"
     cat "$tmp/serial_shard_dups" >&2
@@ -639,8 +639,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/serial_shards_raw" >"$tmp/serial_shards"
-  missing=$(comm -23 "$tmp/serial" "$tmp/serial_shards" || true)
-  extra=$(comm -13 "$tmp/serial" "$tmp/serial_shards" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/serial" "$tmp/serial_shards" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/serial" "$tmp/serial_shards" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable serial shards must equal the portable serial lane"
     [ -z "$missing" ] || { log "missing from serial shards:"; printf '%s\n' "$missing" >&2; }
@@ -652,7 +652,7 @@ run_coverage_guard() {
   for pair in "shards_union:serial" "shards_union:herdr" "serial:herdr"; do
     a=${pair%%:*}
     b=${pair#*:}
-    comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
+    LC_ALL=C comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
     if [ -s "$tmp/overlap" ]; then
       log "coverage guard: overlap between $a and $b:"
       cat "$tmp/overlap" >&2
@@ -662,7 +662,7 @@ run_coverage_guard() {
   done
 
   cat "$tmp/shards_union" "$tmp/serial" "$tmp/herdr" | LC_ALL=C sort >"$tmp/union_raw"
-  uniq -d "$tmp/union_raw" >"$tmp/union_dups"
+  LC_ALL=C uniq -d "$tmp/union_raw" >"$tmp/union_dups"
   if [ -s "$tmp/union_dups" ]; then
     log "coverage guard: duplicate scripts across lanes:"
     cat "$tmp/union_dups" >&2
@@ -670,8 +670,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/union_raw" >"$tmp/union"
-  missing=$(comm -23 "$tmp/all" "$tmp/union" || true)
-  extra=$(comm -13 "$tmp/all" "$tmp/union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/all" "$tmp/union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/all" "$tmp/union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: union of portable shards + portable serial + Herdr must equal tests/*.test.sh"
     [ -z "$missing" ] || { log "missing from union:"; printf '%s\n' "$missing" >&2; }
@@ -684,7 +684,7 @@ run_coverage_guard() {
     "$ROOT/bin/fm-test-isolation-proof.sh" --list | LC_ALL=C sort -u >"$tmp/proof_list"
     if ! cmp -s "$tmp/proven" "$tmp/proof_list"; then
       log "coverage guard: embedded proven-isolated set diverges from bin/fm-test-isolation-proof.sh --list"
-      comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
+      LC_ALL=C comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
       rm -rf "$tmp"
       return 1
     fi

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -386,6 +386,22 @@ test_portable_shard_union_and_coverage_guard() {
   pass "portable shard union, disjointness, and coverage guard hold"
 }
 
+test_coverage_guard_is_locale_independent() {
+  local locale c_out non_c_out
+  locale=en_AU.UTF-8
+  if ! locale -a 2>/dev/null | grep -qi '^en_AU\.utf8$'; then
+    pass "coverage guard locale independence: $locale not installed, skipping"
+    return
+  fi
+  c_out=$(LC_ALL=C "$RUNNER" --check-coverage) \
+    || fail "coverage guard failed under LC_ALL=C"
+  non_c_out=$(LC_ALL="$locale" "$RUNNER" --check-coverage) \
+    || fail "coverage guard failed under LC_ALL=$locale: sorted-input tools (comm/uniq) must force byte collation, not inherit the caller's locale"
+  [ "$non_c_out" = "$c_out" ] \
+    || fail "coverage guard output differs between LC_ALL=C and LC_ALL=$locale"
+  pass "coverage guard holds under a non-C collation locale ($locale)"
+}
+
 test_portable_serial_shards_partition_the_serial_lane() {
   local lanes count serial shard listed union dups shard_lane total cap
   lanes=$("$RUNNER" --list-lanes)
@@ -715,6 +731,7 @@ test_gate_skip_accounting
 test_fail_on_gate_skip_token
 test_exclude_family
 test_portable_shard_union_and_coverage_guard
+test_coverage_guard_is_locale_independent
 test_portable_serial_shards_partition_the_serial_lane
 test_portable_serial_shard_lane_refusals
 test_jobs_requires_proven_isolated


### PR DESCRIPTION
## Summary
- `bin/fm-test-run.sh`'s coverage guard forced byte collation (`LC_ALL=C`) on every `sort` call in the coverage guard, but not on the `comm` and `uniq` calls that consume that sorted output. Under a non-C collation locale, `comm` rejected the sorted input and the guard failed even though nothing was actually wrong with the coverage.
- Prefixes every `comm` and `uniq` invocation inside `run_coverage_guard` with `LC_ALL=C`, matching the existing per-call convention already used by the guard's `sort` calls, rather than exporting the locale for the whole script.
- Adds a regression test that runs `--check-coverage` under both `LC_ALL=C` and a non-C UTF-8 locale (`en_AU.UTF-8`) and asserts identical output, skipping explicitly and visibly when that locale is not installed on the runner.

## Test plan
- [x] Reproduced the failure on the unmodified coverage guard under `LC_ALL=en_AU.UTF-8` (`comm: file 2 is not in sorted order`).
- [x] `bash tests/fm-test-run.test.sh` passes under `LC_ALL=en_AU.UTF-8` after the fix, with no `LC_ALL=C` set by the caller.
- [x] `--check-coverage` output is byte-identical between `LC_ALL=C` and `LC_ALL=en_AU.UTF-8` after the fix.
- [x] Reverting the fix while keeping the new regression test makes it fail with the expected message, demonstrating it catches the regression.
- [x] `bin/fm-lint.sh` passes.
- [x] Ran the portable parallel and serial lanes at the branch point and after the fix: the target test goes from failing to passing, and the same set of pre-existing environmental failures remains, with one flaky exception (`tests/fm-procevent.test.sh`) confirmed to fail intermittently at the unmodified branch point too (1 failure in 3 runs at the branch point vs. 0 in 3 runs on this branch), unrelated to this change.
