### PR TITLE
fix(bin): stop spawned workers from fetching operator credentials

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -500,6 +500,7 @@ Use its scaffold as the contract, then replace every `{TASK}` placeholder with a
 Keep additions task-specific rather than repeating lifecycle instructions, and alter generated sections only when the task genuinely differs from the standard shape.
 
 Every ship brief must retain the worktree-isolation assertion and stop if launched in the primary checkout.
+Every generated brief - ship, scout, and secondmate charter alike - must also retain its credentials hard safety contract: a worker never fetches its own credentials from the operator's password vault or any credential store, it stops and asks, because dispatch is where a credential should be deliberately supplied, never discovered.
 If a ship task touches firstmate's shared tracked material, explicitly require `firstmate-coding-guidelines` before editing.
 If a task will drive Herdr lifecycle behavior, scaffold with `--herdr-lab`; if that need appears after an unguarded scaffold, stop and regenerate rather than adding commands by hand.
 The generated Herdr contract must use a named non-`default` isolated lab and its guarded helper for every lifecycle action.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -41,6 +41,9 @@
 # to launch a ship task whose explicit --mode disagrees, so an adjusted brief and the
 # recorded task metadata cannot drift apart.
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
+# Every variant - ship, scout, and secondmate charter alike - also carries a
+# credentials hard safety contract: a worker never fetches its own credentials
+# from the operator's password vault or any credential store, it stops and asks.
 # --mode is refused on scout and secondmate scaffolds: a scout's deliverable is a
 # report rather than a merge, and a charter is not a delivery contract.
 # There is no --yolo flag here. The worker never owns approval decisions, so yolo is
@@ -76,6 +79,15 @@ esac
 # shellcheck source=bin/fm-classify-lib.sh
 . "$SCRIPT_DIR/fm-classify-lib.sh"
 PAUSED_VERB=${FM_CLASSIFY_PAUSED_VERB:-$FM_CLASSIFY_PAUSED_VERB_DEFAULT}
+
+# Every scaffold variant carries this clause verbatim (AGENTS.md section 11):
+# a worker must never go looking for its own credentials.
+IFS= read -r -d '' CREDENTIALS_SECTION <<'EOF' || true
+# Credentials - HARD SAFETY CONTRACT
+Never read from the operator's password vault or any other credential store, run its CLI, or source any helper whose purpose is to populate credentials from one - even for a task that looks local or offline.
+If this task genuinely needs a credential, stop: append `needs-decision: credential needed - {what and why}` to the status file and wait for it to be supplied, rather than going to look for it yourself.
+EOF
+CREDENTIALS_SECTION=${CREDENTIALS_SECTION%$'\n'}
 
 resolve_directory_input() {
   local name=$1 path=$2 resolved
@@ -211,6 +223,8 @@ $SECONDMATE_SCOPE
 # Project clones
 $PROJECT_CLONES_BODY
 
+$CREDENTIALS_SECTION
+
 # Operating model
 You are in an isolated firstmate home. The local \`AGENTS.md\` is your job description, and your local \`data/\`, \`state/\`, \`config/\`, and \`projects/\` dirs are yours to operate.
 $PROJECT_CLONES_NOTE
@@ -306,6 +320,8 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 {TASK}
 
 $HERDR_SECTION
+
+$CREDENTIALS_SECTION
 
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
@@ -416,6 +432,8 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 {TASK}
 
 $HERDR_SECTION
+
+$CREDENTIALS_SECTION
 
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -633,6 +633,46 @@ test_herdr_lab_contract_applies_to_scouts_but_not_secondmates() {
   pass "fm-brief.sh: Herdr lab contract covers scouts and rejects secondmate misuse"
 }
 
+# Every generated variant must carry the credentials hard safety contract
+# verbatim: a worker never fetches its own credentials, it stops and asks.
+test_credentials_contract_renders_in_every_variant() {
+  local home id brief
+  home="$TMP_ROOT/credentials-contract-home"
+  mkdir -p "$home/data"
+
+  id="brief-credentials-ship"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep "# Credentials - HARD SAFETY CONTRACT" "$brief" \
+    "ship brief missing the credentials hard safety contract"
+  assert_grep "Never read from the operator's password vault or any other credential store" "$brief" \
+    "ship brief did not forbid reading the operator's password vault"
+  # shellcheck disable=SC2016  # Literal backticks and braces must remain unexpanded.
+  assert_grep 'append `needs-decision: credential needed' "$brief" \
+    "ship brief did not require stopping to ask rather than fetching a credential"
+  assert_no_grep "EOF" "$brief" \
+    "ship brief leaked a heredoc EOF marker after adding the credentials section"
+
+  id="brief-credentials-scout"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --scout >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep "# Credentials - HARD SAFETY CONTRACT" "$brief" \
+    "scout brief missing the credentials hard safety contract"
+  assert_grep "Never read from the operator's password vault or any other credential store" "$brief" \
+    "scout brief did not forbid reading the operator's password vault"
+
+  id="brief-credentials-secondmate"
+  FM_HOME="$home" FM_SECONDMATE_CHARTER='sample domain' \
+    "$ROOT/bin/fm-brief.sh" "$id" --secondmate --no-projects >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep "# Credentials - HARD SAFETY CONTRACT" "$brief" \
+    "secondmate charter missing the credentials hard safety contract"
+  assert_grep "Never read from the operator's password vault or any other credential store" "$brief" \
+    "secondmate charter did not forbid reading the operator's password vault"
+
+  pass "fm-brief.sh: every scaffold variant carries the credentials hard safety contract"
+}
+
 test_pause_verb_override_renders_all_brief_scaffolds() {
   local home kind id brief
   home="$TMP_ROOT/pause-verb-home"
@@ -730,3 +770,4 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
 test_scout_and_secondmate_scaffold
+test_credentials_contract_renders_in_every_variant


### PR DESCRIPTION
## Intent

Stop spawned workers from reaching into the operator's password vault or any credential store. Credentials must be supplied to a worker deliberately at dispatch time, never discovered by it going looking. Concretely: (1) bin/fm-brief.sh's generated scaffold (ship, scout, and secondmate charter variants alike) now carries a standing 'Credentials - HARD SAFETY CONTRACT' clause, worded in the same hard-safety register as the existing worktree-isolation assertion (the closest precedent in that file): the worker must not read from the operator's password vault or any other credential store, must not run its CLI, and must not source any helper whose purpose is to populate credentials from one; if the task genuinely needs a credential, the worker stops and appends a needs-decision status line asking for it rather than fetching it itself. (2) AGENTS.md section 11 (Crewmate briefs) states this rule once, concisely, as a single sentence alongside the existing worktree-isolation sentence it is modeled on - no restatement of the reasoning, which stays in the scaffold. (3) Investigated whether bin/fm-spawn.sh's per-harness launch-command env scoping (its env -u / VAR= prefixes applied only to the launched worker process) could make this fail closed instead of relying on the worker following instructions. Conclusion: no reliable, clean, generic mechanism exists, and none was implemented - explicitly a documentation/instruction-only fix, not a mechanical one. Reasoning: this repo is deliberately vault-agnostic across operators (Bitwarden/rbw, 1Password, macOS Keychain, ssh-agent/gpg-agent, pass all differ), macOS Keychain access is session-based and not gated by any per-process environment variable at all, and blanket-unsetting the env vars that do gate some vaults (an SSH or GPG agent socket) would also break legitimate credential paths every worker is expected to use (gh-axi/git operations relying on agent-forwarded SSH or GPG signing) that have nothing to do with the vault-fallback failure mode being fixed. A narrower, tool-specific block would hardcode one operator's vault choice into a generic repo and risk false confidence for operators using a different vault. This finding must be stated plainly in the PR body: the constraint is enforced by instruction only, not mechanically, and that is a deliberate, investigated conclusion, not an oversight. Constraints honored: did not change how the operator's own vault, agent, or shell is configured anywhere outside this repo; did not read, print, or write any credential value; did not weaken or reword the existing worktree-isolation assertion while editing that file; comments explain why only, never restate the line below them, and never carry PR numbers; the words captain, first mate, crewmate, crew, and scout are avoided in commit messages and PR text. Verified by generating one brief of each variant (--mode no-mistakes, --scout, --secondmate --no-projects) and reading the rendered output to confirm the clause appears cleanly with no heredoc corruption in all three; added a new fm-brief.sh test (test_credentials_contract_renders_in_every_variant) covering all three variants, alongside the file's existing pattern for other safety contracts (e.g. the Herdr lab hard safety contract); ran bin/fm-lint.sh and bin/fm-doc-audience-check.sh clean; ran the full changed-tests suite and confirmed the only 4 failures are pre-existing on the unmodified base commit (unrelated environment/tooling issues: an unrelated PreToolUse hook test, a missing optional node package, a Kimi hook-install test, and a missing ruby asdf version needed by one CI-yml-parsing test), none related to fm-brief.sh, AGENTS.md, or the new test file.

## What Changed
- Added a "Credentials - HARD SAFETY CONTRACT" clause to `bin/fm-brief.sh`'s generated scaffold, worded in the same hard-safety register as the existing worktree-isolation assertion, across all three brief variants (ship/no-mistakes, scout, secondmate). The clause instructs a worker not to read from the operator's password vault or any credential store, not to run its CLI, and not to source any credential-populating helper — instead stopping and appending a needs-decision status line when a credential is genuinely required.
- Added a single concise sentence to `AGENTS.md` section 11 (Crewmate briefs) stating this rule alongside the existing worktree-isolation sentence.
- Added `test_credentials_contract_renders_in_every_variant` to `tests/fm-brief.test.sh`, verifying the clause renders cleanly in all three brief variants, following the file's existing pattern for other hard safety contracts.

Note: this is a documentation/instruction-only fix. `bin/fm-spawn.sh`'s per-harness env scoping was investigated as a possible mechanical enforcement point but was found unsuitable — this repo is deliberately vault-agnostic (Bitwarden/rbw, 1Password, macOS Keychain, ssh-agent/gpg-agent, pass all differ), macOS Keychain access isn't gated by any per-process env var, and blanket-unsetting agent-socket env vars would break legitimate SSH/GPG-agent-backed operations every worker needs. No mechanical fail-closed guard was implemented as a result.

## Risk Assessment

✅ Low: Small, well-scoped documentation/instruction-only change: a verbatim credentials clause is correctly interpolated into all three brief heredocs via an existing pattern (mirroring HERDR_SECTION), AGENTS.md gets one concise sentence without disturbing the existing worktree-isolation sentence, a new test covers all three variants using existing assertion helpers, and no mechanical enforcement (e.g. in fm-spawn.sh) was added, consistent with the explicitly stated investigated conclusion.

## Testing

Targeted testing confirms the credentials hard-safety-contract clause is correctly wired into bin/fm-brief.sh for all three scaffold variants: the existing fm-brief.sh test suite (21 assertions, including the new test_credentials_contract_renders_in_every_variant) passes cleanly, and manual generation of ship/scout/secondmate briefs shows the clause rendering verbatim and heredoc-corruption-free in each, matching the PR's stated verification steps. No findings.

<details>
<summary>Evidence: Rendered ship-variant brief showing the credentials clause</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Credentials - HARD SAFETY CONTRACT
Never read from the operator's password vault or any other credential store, run its CLI, or source any helper whose purpose is to populate credentials from one - even for a task that looks local or offline.
If this task genuinely needs a credential, stop: append `needs-decision: credential needed - {what and why}` to the status file and wait for it to be supplied, rather than going to look for it yourself.

# Setup
You are in a disposable git worktree of /Users/dimitri/.no-mistakes/worktrees/8868f3281eff/01M034BBXMFCH8JQYP9ZFXRWD5, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/manual-ship`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/pr/xnxhrbwx7lj7lw2d1ymnbprr0000gn/T/tmp.G1kRPzrvI8/state/manual-ship.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/dimitri/.no-mistakes/worktrees/8868f3281eff/01M034BBXMFCH8JQYP9ZFXRWD5/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/dimitri/.no-mistakes/worktrees/8868f3281eff/01M034BBXMFCH8JQYP9ZFXRWD5/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Rendered scout-variant brief showing the credentials clause</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Credentials - HARD SAFETY CONTRACT
Never read from the operator's password vault or any other credential store, run its CLI, or source any helper whose purpose is to populate credentials from one - even for a task that looks local or offline.
If this task genuinely needs a credential, stop: append `needs-decision: credential needed - {what and why}` to the status file and wait for it to be supplied, rather than going to look for it yourself.

# Setup
You are in a disposable git worktree of /Users/dimitri/.no-mistakes/worktrees/8868f3281eff/01M034BBXMFCH8JQYP9ZFXRWD5, at a detached HEAD on a clean default branch.
This is a SCOUT task: the deliverable is a written report, not a PR.
The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
The report is the only thing that survives, so anything worth keeping must be in it.

# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/pr/xnxhrbwx7lj7lw2d1ymnbprr0000gn/T/tmp.G1kRPzrvI8/state/manual-scout.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
   FYI progress lines; firstmate reads your pane for that.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
   firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
   treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Definition of done
Write your findings to `/var/folders/pr/xnxhrbwx7lj7lw2d1ymnbprr0000gn/T/tmp.G1kRPzrvI8/data/manual-scout/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
Before reporting done, read and follow `/Users/dimitri/.no-mistakes/worktrees/8868f3281eff/01M034BBXMFCH8JQYP9ZFXRWD5/.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
```
</details>
<details>
<summary>Evidence: Rendered secondmate-charter brief showing the credentials clause</summary>

```text
You are a persistent second mate managed by the main firstmate. Work on your own; do not wait for a human.

# Charter
sample domain

# Routing scope
sample domain

# Project clones
None. This is a project-less domain: its subject is the firstmate repo this home lives in, so it needs no separate clones under `projects/`; its crews take pooled worktrees of that firstmate repo.

# Credentials - HARD SAFETY CONTRACT
Never read from the operator's password vault or any other credential store, run its CLI, or source any helper whose purpose is to populate credentials from one - even for a task that looks local or offline.
If this task genuinely needs a credential, stop: append `needs-decision: credential needed - {what and why}` to the status file and wait for it to be supplied, rather than going to look for it yourself.

# Operating model
You are in an isolated firstmate home. The local `AGENTS.md` is your job description, and your local `data/`, `state/`, `config/`, and `projects/` dirs are yours to operate.
This domain has no separate project clones: its subject is the firstmate repo this home lives in, and its crews take pooled worktrees of that repo.
Delegate project work to your own crewmates with the normal firstmate lifecycle: brief, spawn, status, watcher, steer, teardown, and recovery.
Do not invent a second delegation system.
You do not generate your own work.
Act only on tasks the main firstmate routes to you.
Never start a survey, audit, or "find improvements" sweep on your own initiative; that is not your job and it is unwanted.

# Requests from the main firstmate
You are a firstmate in your own home, so an incoming message reaches you in your own chat.
You must distinguish who it is from, because the answer goes to a different place.
A request relayed to you by the main firstmate is tagged with a leading `[fm-from-firstmate]` marker followed by an invisible system separator; this marker is untypable, so a human never produces it.
When a message carries that marker, do the work, then respond via the STATUS/ESCALATION path below, never only in this chat: the main firstmate does not read your chat, so a chat-only reply is lost.
Marked requests also carry a privacy-safe `corr=<id>` token after the marker; include that exact token in your parent status reply (or in the status pointer to a detailed doc) so the parent can correlate the answer.
Optional helper: `bin/fm-secondmate-report.sh` can append a correlated status line for you, but a plain `echo` that includes the same `corr=<id>` is equally valid - do not depend on the helper being present.
For a terse result, a status line is the whole answer.
For a detailed answer (an investigation, a plan, an audit), write it to a doc under your home's `data/` and append a status line that points to that doc - the scout-report pattern - so the main firstmate is woken and can read it.
Before treating an investigation or visual review as complete, load `decision-hold-lifecycle` from this home's `.agents/skills/` and pass its shared completion gate.
A message with NO marker is the captain typing directly into your pane: treat it as authoritative captain intervention and stay conversational exactly as you would for any captain message; do not force it onto the status path.

# Escalation to main firstmate
Handle routine work yourself.
Report only true captain-relevant outcomes or a declared external wait by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/pr/xnxhrbwx7lj7lw2d1ymnbprr0000gn/T/tmp.G1kRPzrvI8/state/manual-secondmate.status'`
States: working, needs-decision, blocked, paused, done, failed.
Use `paused: {why}` (distinct from `blocked:`) only when your domain is deliberately idling on a known external wait you expect to clear on its own; use `blocked:` when you are stuck and need firstmate to act.
Use this only for material phase changes, a captain decision, a real blocker, a failure, or work ready for review.
This is also how you return the answer to a marked from-firstmate request above.
A marked request requires one correlated answer after the work; it does not require a separate receipt or start acknowledgement.
Never append `working:` merely to acknowledge receipt or announce that a marked request has started.
When a routed-work phase has a supervisor-actionable material change worth reporting under the rule above, give that reported phase a stable key.
If its first reportable event is `working [key=<work-slug>]: {material phase}`, use the same key on its later `paused`, `done`, `failed`, `needs-decision`, or `blocked` event so the earlier working phase is superseded.
When a keyed phase ends without another reportable state, append `resolved [key=<work-slug>]: {why it is no longer active}`.
`resolved` separately closes an escalated decision or blocker, and only a `resolved` line carrying that decision's exact key closes it: a later `done` or `working` event never does, even when the answer is what started that work.
The main firstmate's answer normally writes that closing line at answer time; when a blocker or wait clears WITHOUT an answer from the main firstmate, append `resolved: {how it cleared}` yourself (keyed with `[key=<slug>]` if you opened it with one) as your domain resumes.
Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.

# Definition of done
You are persistent by default. Do not exit just because your queue is empty.
On startup and restart, run normal firstmate bootstrap and recovery through `bin/fm-session-start.sh` for your own home, but only to RECONCILE work that is already yours: in-flight crewmates, tracked backlog items, and durable watches recorded in this home.
When you have no assigned or in-flight work after that reconciliation, go idle and wait silently for the main firstmate to route you a task.
An empty queue is a healthy resting state, not a cue to invent work: never spawn a survey, audit, or any self-directed "find work" task on your own initiative.
If this charter cannot be carried out, append `blocked: {why}` or `failed: {why}` to the main status file and stop.
```
</details>
<details>
<summary>Evidence: tests/fm-brief.test.sh full run output</summary>

```text
ok - fm-brief.sh: bash -n succeeds
ok - fm-brief.sh: no heredoc is nested inside a command substitution (Bash 3.2 parse-safe)
ok - fm-brief.sh: --help renders the complete header
ok - fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly
ok - fm-brief.sh: ship --mode is required and closed-set validated
ok - fm-brief.sh: the explicit ship mode wins over the registered posture
ok - fm-brief.sh: --yolo and scout/secondmate --mode are refused, never silently dropped
ok - fm-brief.sh: faster paths use configured authority without stacked review
ok - fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe
ok - fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar
ok - fm-brief.sh: --herdr-lab emits the complete hard safety contract
ok - fm-brief.sh: --herdr-lab uses its quoted Firstmate-owned helper path
ok - fm-brief.sh: ship and scout scaffolds make omitted Herdr intent fail-visible
ok - fm-brief.sh: Herdr lab contract covers scouts and rejects secondmate misuse
ok - fm-brief.sh: --no-projects scaffolds a project-less charter and guards misuse
ok - fm-brief.sh: marked requests avoid generic acknowledgements and preserve material reporting
ok - fm-brief.sh: relative directory inputs ignore CDPATH, render stable absolute charter paths, or fail loudly
ok - fm-brief.sh: custom pause verb renders in every scaffold
ok - fm-brief.sh: investigation and visual-review completions load the shared decision policy
ok - fm-brief: scout and secondmate code paths still scaffold well-formed briefs
ok - fm-brief.sh: every scaffold variant carries the credentials hard safety contract
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-brief.test.sh (full file, 21 checks, all pass)`
- `Manual generation: bin/fm-brief.sh <id> <repo> --mode no-mistakes (ship variant)`
- `Manual generation: bin/fm-brief.sh <id> <repo> --scout (scout variant)`
- `Manual generation: FM_SECONDMATE_CHARTER=... bin/fm-brief.sh <id> --secondmate --no-projects (secondmate variant)`
- `Visual grep confirmation of '# Credentials - HARD SAFETY CONTRACT' clause text in all three rendered briefs`
- `git status --porcelain confirming no stray artifacts left in the working tree`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
