### PR TITLE
fix(bin): let adapter-load guards refuse under stock macOS Bash 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,9 +368,10 @@ jobs:
             exit 1
           }
 
-          # Teardown's preflight guards refuse through `|| return 1` around a
-          # source, which stock Bash 3.2 skips entirely. Only this lane can
-          # catch that regression; every other lane runs Bash 5.
+          # Teardown's preflight guards only reach their refusal under stock
+          # Bash 3.2 because of the readability tests fm_backend_adapter_readable
+          # owns in bin/fm-backend.sh. Only this lane can catch a regression
+          # there; every other lane runs Bash 5.
           teardown_output=$(/bin/bash tests/fm-teardown.test.sh)
           printf '%s\n' "$teardown_output"
           teardown_count=$(printf '%s\n' "$teardown_output" | grep -c '^ok - ')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,7 +328,7 @@ jobs:
   macos-stock-bash:
     name: Stock macOS Bash snapshot compatibility
     runs-on: macos-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
       - name: Run snapshot consumers with stock Bash
@@ -365,6 +365,17 @@ jobs:
           bearings_count=$(printf '%s\n' "$bearings_output" | grep -c '^ok - ')
           [ "$bearings_count" -eq 41 ] || {
             echo "::error::expected 41 Bearings tests, got $bearings_count"
+            exit 1
+          }
+
+          # Teardown's preflight guards refuse through `|| return 1` around a
+          # source, which stock Bash 3.2 skips entirely. Only this lane can
+          # catch that regression; every other lane runs Bash 5.
+          teardown_output=$(/bin/bash tests/fm-teardown.test.sh)
+          printf '%s\n' "$teardown_output"
+          teardown_count=$(printf '%s\n' "$teardown_output" | grep -c '^ok - ')
+          [ "$teardown_count" -eq 58 ] || {
+            echo "::error::expected 58 teardown tests, got $teardown_count"
             exit 1
           }
 

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2862,11 +2862,16 @@ fm_backend_herdr_kill() {  # <target>
   fm_backend_herdr_target_ready "$1" || return 0
   local session=$FM_BACKEND_HERDR_SESSION pane=$FM_BACKEND_HERDR_PANE
   local lock_path attempt=0 lock_held=0
-  if ! declare -F fm_lock_try_acquire >/dev/null 2>&1; then
+  # Readability first, for the reason fm_backend_adapter_readable states in
+  # bin/fm-backend.sh: an unopenable lock library would kill this shell instead
+  # of reaching the unlocked-close refusal below.
+  if ! declare -F fm_lock_try_acquire >/dev/null 2>&1 \
+    && [ -r "$FM_BACKEND_HERDR_ROOT/bin/fm-wake-lib.sh" ]; then
     # shellcheck source=bin/fm-wake-lib.sh
     . "$FM_BACKEND_HERDR_ROOT/bin/fm-wake-lib.sh"
   fi
-  if lock_path=$(fm_backend_herdr_presentation_session_lock_path "$session"); then
+  if declare -F fm_lock_try_acquire >/dev/null 2>&1 \
+    && lock_path=$(fm_backend_herdr_presentation_session_lock_path "$session"); then
     while [ "$attempt" -lt 50 ]; do
       if fm_lock_try_acquire "$lock_path"; then
         lock_held=1

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -592,12 +592,17 @@ fm_backend_expected_label_of_selector() {  # <raw-target> <state-dir>
 # Each adapter is an independently linted canonical root. The /dev/null source
 # boundaries keep runtime dispatch from importing all five adapter ASTs into
 # every dispatcher consumer while preserving the runtime source operations.
+# Each branch proves the adapter readable before sourcing it, because bash 3.2
+# (macOS stock) under errexit exits the shell with status 0 when a source cannot
+# open its file, skipping the `|| return 1` guard entirely - the caller would then
+# read a silent success where it must read a refusal.
 fm_backend_source() {  # <name>
   local name=$1
   fm_backend_validate "$name" || return 1
   case "$name" in
     tmux)
       if [ -z "${_FM_BACKEND_TMUX_SOURCED:-}" ]; then
+        [ -r "$FM_BACKEND_LIB_DIR/backends/tmux.sh" ] || return 1
         # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/tmux.sh" || return 1
         _FM_BACKEND_TMUX_SOURCED=1
@@ -605,6 +610,7 @@ fm_backend_source() {  # <name>
       ;;
     herdr)
       if [ -z "${_FM_BACKEND_HERDR_SOURCED:-}" ]; then
+        [ -r "$FM_BACKEND_LIB_DIR/backends/herdr.sh" ] || return 1
         # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/herdr.sh" || return 1
         _FM_BACKEND_HERDR_SOURCED=1
@@ -612,6 +618,7 @@ fm_backend_source() {  # <name>
       ;;
     zellij)
       if [ -z "${_FM_BACKEND_ZELLIJ_SOURCED:-}" ]; then
+        [ -r "$FM_BACKEND_LIB_DIR/backends/zellij.sh" ] || return 1
         # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/zellij.sh" || return 1
         _FM_BACKEND_ZELLIJ_SOURCED=1
@@ -619,6 +626,7 @@ fm_backend_source() {  # <name>
       ;;
     orca)
       if [ -z "${_FM_BACKEND_ORCA_SOURCED:-}" ]; then
+        [ -r "$FM_BACKEND_LIB_DIR/backends/orca.sh" ] || return 1
         # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/orca.sh" || return 1
         _FM_BACKEND_ORCA_SOURCED=1
@@ -626,6 +634,7 @@ fm_backend_source() {  # <name>
       ;;
     cmux)
       if [ -z "${_FM_BACKEND_CMUX_SOURCED:-}" ]; then
+        [ -r "$FM_BACKEND_LIB_DIR/backends/cmux.sh" ] || return 1
         # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/cmux.sh" || return 1
         _FM_BACKEND_CMUX_SOURCED=1

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -588,21 +588,33 @@ fm_backend_expected_label_of_selector() {  # <raw-target> <state-dir>
   return 0
 }
 
+# fm_backend_adapter_readable: prove one adapter loadable before a branch of
+# fm_backend_source sources it, and own the single refusal an unloadable adapter
+# prints. bash 3.2 (macOS stock) under errexit abandons the `|| return 1` that
+# wraps a source and terminates the shell outright when the file cannot be
+# opened - status 0 whenever an EXIT trap runs and ends on a successful command,
+# as fm-teardown.sh arms one, and 1 otherwise - so a caller would read a silent
+# success where it must read a refusal. Testing readability first keeps that
+# path unreachable, and this message replaces the diagnostic bash itself printed
+# from the source that no longer runs.
+fm_backend_adapter_readable() {  # <name> <adapter-file>
+  local name=$1 file=$2
+  [ -r "$file" ] && return 0
+  echo "error: backend '$name' adapter is missing or unreadable: $file" >&2
+  return 1
+}
+
 # fm_backend_source: source the named backend's adapter file, once per shell.
 # Each adapter is an independently linted canonical root. The /dev/null source
 # boundaries keep runtime dispatch from importing all five adapter ASTs into
 # every dispatcher consumer while preserving the runtime source operations.
-# Each branch proves the adapter readable before sourcing it, because bash 3.2
-# (macOS stock) under errexit exits the shell with status 0 when a source cannot
-# open its file, skipping the `|| return 1` guard entirely - the caller would then
-# read a silent success where it must read a refusal.
 fm_backend_source() {  # <name>
   local name=$1
   fm_backend_validate "$name" || return 1
   case "$name" in
     tmux)
       if [ -z "${_FM_BACKEND_TMUX_SOURCED:-}" ]; then
-        [ -r "$FM_BACKEND_LIB_DIR/backends/tmux.sh" ] || return 1
+        fm_backend_adapter_readable tmux "$FM_BACKEND_LIB_DIR/backends/tmux.sh" || return 1
         # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/tmux.sh" || return 1
         _FM_BACKEND_TMUX_SOURCED=1
@@ -610,7 +622,7 @@ fm_backend_source() {  # <name>
       ;;
     herdr)
       if [ -z "${_FM_BACKEND_HERDR_SOURCED:-}" ]; then
-        [ -r "$FM_BACKEND_LIB_DIR/backends/herdr.sh" ] || return 1
+        fm_backend_adapter_readable herdr "$FM_BACKEND_LIB_DIR/backends/herdr.sh" || return 1
         # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/herdr.sh" || return 1
         _FM_BACKEND_HERDR_SOURCED=1
@@ -618,7 +630,7 @@ fm_backend_source() {  # <name>
       ;;
     zellij)
       if [ -z "${_FM_BACKEND_ZELLIJ_SOURCED:-}" ]; then
-        [ -r "$FM_BACKEND_LIB_DIR/backends/zellij.sh" ] || return 1
+        fm_backend_adapter_readable zellij "$FM_BACKEND_LIB_DIR/backends/zellij.sh" || return 1
         # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/zellij.sh" || return 1
         _FM_BACKEND_ZELLIJ_SOURCED=1
@@ -626,7 +638,7 @@ fm_backend_source() {  # <name>
       ;;
     orca)
       if [ -z "${_FM_BACKEND_ORCA_SOURCED:-}" ]; then
-        [ -r "$FM_BACKEND_LIB_DIR/backends/orca.sh" ] || return 1
+        fm_backend_adapter_readable orca "$FM_BACKEND_LIB_DIR/backends/orca.sh" || return 1
         # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/orca.sh" || return 1
         _FM_BACKEND_ORCA_SOURCED=1
@@ -634,7 +646,7 @@ fm_backend_source() {  # <name>
       ;;
     cmux)
       if [ -z "${_FM_BACKEND_CMUX_SOURCED:-}" ]; then
-        [ -r "$FM_BACKEND_LIB_DIR/backends/cmux.sh" ] || return 1
+        fm_backend_adapter_readable cmux "$FM_BACKEND_LIB_DIR/backends/cmux.sh" || return 1
         # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/cmux.sh" || return 1
         _FM_BACKEND_CMUX_SOURCED=1

--- a/bin/fm-remote-doctor.sh
+++ b/bin/fm-remote-doctor.sh
@@ -140,11 +140,20 @@ herdr_cli_available() {
 # either here. Sourced only when both tools resolve, so a bare host still
 # reports its gaps instead of failing to load.
 herdr_adapter_load() {
+  local dep
   [ -z "${FM_REMOTE_DOCTOR_HERDR_LOADED:-}" ] || return 0
   herdr_cli_available || return 1
-  # -r, not -f: bash 3.2 under errexit exits the shell with status 0 when a
-  # source cannot open its file, skipping the `|| return 1` below.
-  [ -r "$SCRIPT_DIR/fm-backend.sh" ] && [ -r "$SCRIPT_DIR/backends/herdr.sh" ] || return 1
+  # -r, not -f: under errexit bash 3.2 abandons the `|| return 1` below and
+  # terminates the shell outright when a source cannot open its file, which in
+  # this script - it arms no EXIT trap - would end the whole doctor run at
+  # status 1 instead of this refusal. Naming the file keeps the refusal as loud
+  # as the diagnostic the source that no longer runs would have printed.
+  for dep in "$SCRIPT_DIR/fm-backend.sh" "$SCRIPT_DIR/backends/herdr.sh"; do
+    if [ ! -r "$dep" ]; then
+      echo "error: the herdr adapter cannot be loaded: $dep is missing or unreadable" >&2
+      return 1
+    fi
+  done
   # shellcheck source=bin/fm-backend.sh
   . "$SCRIPT_DIR/fm-backend.sh" || return 1
   fm_backend_source herdr || return 1

--- a/bin/fm-remote-doctor.sh
+++ b/bin/fm-remote-doctor.sh
@@ -142,7 +142,9 @@ herdr_cli_available() {
 herdr_adapter_load() {
   [ -z "${FM_REMOTE_DOCTOR_HERDR_LOADED:-}" ] || return 0
   herdr_cli_available || return 1
-  [ -f "$SCRIPT_DIR/fm-backend.sh" ] && [ -f "$SCRIPT_DIR/backends/herdr.sh" ] || return 1
+  # -r, not -f: bash 3.2 under errexit exits the shell with status 0 when a
+  # source cannot open its file, skipping the `|| return 1` below.
+  [ -r "$SCRIPT_DIR/fm-backend.sh" ] && [ -r "$SCRIPT_DIR/backends/herdr.sh" ] || return 1
   # shellcheck source=bin/fm-backend.sh
   . "$SCRIPT_DIR/fm-backend.sh" || return 1
   fm_backend_source herdr || return 1

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2080,7 +2080,11 @@ teardown_herdr_require_prerequisites() {  # <task-id>
       return 1
     fi
   done
-  if ! declare -F fm_lock_try_acquire >/dev/null 2>&1; then
+  # Readability first, for the reason fm_backend_adapter_readable states in
+  # bin/fm-backend.sh: an unopenable lock library would kill this shell before
+  # the refusal below could run, and this teardown arms an EXIT trap.
+  if ! declare -F fm_lock_try_acquire >/dev/null 2>&1 \
+    && [ -r "$SCRIPT_DIR/fm-wake-lib.sh" ]; then
     # shellcheck source=bin/fm-wake-lib.sh
     . "$SCRIPT_DIR/fm-wake-lib.sh"
   fi

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -76,7 +76,7 @@ make_case() {
   local name=$1 case_dir fakebin
   case_dir="$TMP_ROOT/$name"
   fakebin="$case_dir/fakebin"
-  mkdir -p "$case_dir/state" "$case_dir/config" "$fakebin"
+  mkdir -p "$case_dir/state" "$case_dir/config" "$case_dir/data" "$fakebin"
 
   # Mocks for the post-check teardown steps. Refuse logic exits before these
   # run; the ALLOW cases need them so the script can complete cleanly.

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -67,6 +67,9 @@ export REAL_LSOF_FOR_TEST
 
 # Build a fresh sandbox for one test case. Sets up:
 #   $CASE/state/        - firstmate state dir (with a fresh watcher beacon)
+#   $CASE/data/         - empty fake data dir both teardown entry points pass
+#                         as FM_DATA_OVERRIDE, so no case ever reads the
+#                         running machine's own data/secondmates.md
 #   $CASE/fakebin/      - mocks for treehouse, tmux (PATH-prepended by caller)
 #   $CASE/origin.git/   - bare upstream repo (so the project clone has origin)
 #   $CASE/project/      - clone of origin; acts as the firstmate project dir

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -545,6 +545,7 @@ run_teardown() {
   FM_ROOT_OVERRIDE="$ROOT" \
   FM_STATE_OVERRIDE="$case_dir/state" \
   FM_CONFIG_OVERRIDE="$case_dir/config" \
+  FM_DATA_OVERRIDE="$case_dir/data" \
   PATH="$case_dir/fakebin:${FM_TEARDOWN_TEST_PATH:-$PATH}" \
     "$TEARDOWN" task-x1 "$@"
 }
@@ -1559,6 +1560,7 @@ SH
   esac
   rc=0
   FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$case_dir/state" FM_CONFIG_OVERRIDE="$case_dir/config" \
+    FM_DATA_OVERRIDE="$case_dir/data" \
     FM_FAKE_HERDR_LOG="$log" FM_FAKE_HERDR_CLOSED="$closed" \
     FM_FAKE_HERDR_SESSION_LIST_GARBAGE="$([ "$mode" = unresolvable-lock ] && printf 1 || printf 0)" \
     PATH="$case_dir/fakebin:$PATH" \


### PR DESCRIPTION
## Intent

Fix two upstream macOS portability defects established by a prior investigation, and deliver them upstream.

DEFECT 1 - unguarded adapter loading under bash 3.2. bash 3.2.57, the version macOS ships by default, terminates the shell IMMEDIATELY with status 0 when a `source` fails to OPEN its file under `set -e`, skipping the guard that wraps it. Measured consequence: a teardown safety guard that must refuse loudly instead goes silent and reports success. Nothing is destroyed (the shell dies before any destructive step - the investigation verified this), but the caller believes the task was cleaned up while the isolated worktree, the branch and the durable records all still exist.

Exact surface, enumerated by the investigation: the five branches of `fm_backend_source` in bin/fm-backend.sh (lines ~602, 609, 616, 623, 630) and bin/fm-remote-doctor.sh:147. The fix, ALREADY VERIFIED on bash 3.2 AND 5.3 by the investigation, is to test readability before loading so the faulty path is never taken:
[ -r "$FM_BACKEND_LIB_DIR/backends/herdr.sh" ] || return 1
. "$FM_BACKEND_LIB_DIR/backends/herdr.sh" || return 1
Apply the same pattern to all six call sites. Also verify no other guarded source/. in the repo suffers the same defect; treat any found and say so.

DEFECT 2 - the test suite is not hermetic. tests/fm-teardown.test.sh reads the REAL data/secondmates.md of the machine instead of a fake, which makes herdr-child-preflight fail from a live home. Set FM_DATA_OVERRIDE="$case_dir/data" in run_teardown (around line 543) AND in the direct $teardown_bin invocations in the same file, as roughly ten other suites already do.

REGRESSION COVERAGE. The existing test case (herdr-preflight-missing-adapter) becomes the regression test for defect 1 - but only if it runs under bash 3.2. Check whether the macos-stock-bash CI lane includes tests/fm-teardown.test.sh; if not, add it, otherwise the regression stays invisible upstream.

REQUIRED VERIFICATION. bin/fm-test-run.sh tests/fm-teardown.test.sh must pass IN FULL on this machine with the system bash - that is the decisive criterion, the suite is red today and must be green after. Also demonstrate the refusal actually happens: the missing-adapter case must exit non-zero with its message visible. Neighbouring suites touching fm-backend.sh stay green. Shellcheck-clean.

DECISIONS AND CONSTRAINTS ACCEPTED DURING THE WORK:
- Rationale comments: the bash 3.2 explanation is stated ONCE in the fm_backend_source header rather than repeated in each of the five branches, per this repo firstmate-coding-guidelines one-owner rule.
- fm-remote-doctor.sh already prefiltered with `[ -f ... ]`; that was strengthened to `[ -r ... ]` rather than adding a second separate guard line, because -r is the test that actually answers whether the source can open the file, and it avoids duplicating the check.
- The macos-stock-bash lane asserts an exact ok-count per suite; the teardown suite contributes 58. The lane timeout was raised from 10 to 20 minutes to fit the added suite (it takes ~105s locally and GitHub macOS runners are slower). The lane job key and display name were deliberately NOT renamed, even though its name says "snapshot compatibility" and its scope is now broader, because renaming a job changes required-check names and could break branch protection upstream.
- Repo-wide sweep result: the six sites named by the investigation are the ONLY guarded loads in the repo. The other source sites (fm-cd-pretool-check.sh, fm-arm-pretool-check.sh, fm-ff-lib.sh, fm-config-inherit-lib.sh, fm-vendor-auth-probe.sh) are UNGUARDED and exit 1 on both bash versions, so they are not affected. This was checked, not assumed.
- A THIRD pre-existing defect was found and DELIBERATELY EXCLUDED from this change by an explicit captain decision. It is a different mechanism, not a guarded source: on bash 3.2 under errexit a FAILED REDIRECTION does not stop execution either - it continues and exits 0 (bash 5.3 exits 1). bin/fm-spawn.sh writes its durable task metadata via `{ ... } > "$SPAWN_META_PATH"` and so continues silently when that write fails, which makes tests/fm-backend-orca.test.sh red on this machine both BEFORE and AFTER this change (verified by stashing). It is being tracked as separate work because all supervision depends on that metadata and it deserves its own analysis. Do NOT fix it here and do NOT treat the orca suite red as a regression from this change.

DELIVERY CONSTRAINTS (known, do not rediscover): origin is kunchenguid/firstmate with NO write access; the machine firewall refuses pushes to master/main and refuses git rebase. The branch fm/fm-bash32-source-guard must be pushed ONLY to the fork https://github.com/Kallas95/firstmate by explicit URL, then the upstream PR opened against kunchenguid/firstmate:main. The upstream repo runs NO CI on fork PRs, so local validation green plus an opened upstream PR is the terminal state - do not wait for checks that will never arrive.

PR WRITING: these two defects have NO upstream ticket (verified). The PR description must present them as macOS portability defects reproduced on pure origin/main, with the exact mechanism and evidence from both bash versions, and cite that macOS stock bash is the default for every macOS user of the project.

## What Changed

- `fm_backend_source` (bin/fm-backend.sh) now proves each of its five adapters readable through a new `fm_backend_adapter_readable` helper before sourcing it, and bin/fm-remote-doctor.sh prefilters its two dependencies with `-r` instead of `-f` while naming the unreadable file. Under `set -e`, Bash 3.2 — the version macOS ships by default — terminates the shell outright when a `source` cannot open its file, skipping the `|| return 1` that wraps it, so a teardown preflight guard exited 0 without printing its refusal; testing readability first keeps that path unreachable.
- The lazy `fm-wake-lib.sh` loads in bin/fm-teardown.sh and `fm_backend_herdr_kill` (bin/backends/herdr.sh) are gated on the same readability test, and the herdr kill path now requires `fm_lock_try_acquire` to be defined before taking the lock branch, so an unopenable lock library reaches the existing lock-unavailable refusal and unlocked-close warning instead of killing the shell.
- tests/fm-teardown.test.sh builds an empty `$CASE/data` and passes `FM_DATA_OVERRIDE` from both `run_teardown` and the direct `$TEARDOWN` invocation, so no case reads the running machine's `data/secondmates.md`; the stock-Bash CI lane now also runs that suite and asserts 58 `ok -` lines, with its timeout raised from 10 to 20 minutes to fit the added work.

## Risk Assessment

✅ Low: Le changement est étroitement borné (cinq gardes d'une ligne derrière un helper unique, deux gardes défensifs sur des chargements paresseux, deux variables d'environnement de test, une suite ajoutée à une lane CI existante), il satisfait chaque critère vérifiable en source de l'intent, la régression de la faille 1 est couverte par un test comportemental réel exécuté sous bash 3.2, et le seul écart sémantique introduit par le round de correction est un chemin défensif non atteignable dont j'ai vérifié qu'il n'efface aucun enregistrement durable.

## Testing

Ran the decisive check first: `bin/fm-test-run.sh tests/fm-teardown.test.sh` under the machine's stock bash 3.2.57 is green in full (58 ok, exit 0) on the target commit, while the same suite on a pristine base tree is red at `herdr-preflight-missing-adapter` — the regression fails before the fix and passes after. Because a passing suite does not show the user-visible refusal, I drove the real `bin/fm-teardown.sh task-x1 --force` with the herdr adapter removed on both trees using the suite's own fixture helpers: the base exits 0 silently while the isolated worktree, the `fm/task-x1` branch and the durable records all survive, and the fixed tree exits 1 with the named adapter error plus the `nothing was changed` refusal. I then probed all five `fm_backend_source` branches from an errexit caller (before, the shell dies before the refusal branch; after, each returns a named refusal) and the sixth site, `fm-remote-doctor.sh`, with an adapter that is present but unopenable — the case the old `[ -f ]` never caught: before, the doctor stops after two lines with zero `check` output; after, it prints the named error and completes all ten checks and the readiness verdict. Hermeticity was shown separately by planting a live-home `data/secondmates.md`: the pre-fix test file fails the herdr-child-preflight case and the fixed one passes. For the CI lane I parsed the workflow with a real YAML parser (job `macos-stock-bash`, macos-latest, 20-minute timeout, `/bin/bash` shell) and executed its newly added teardown step locally under stock bash — exit 0 with the exact-58 assertion satisfied. The four neighbouring suites touching fm-backend.sh are green, and `fm-backend-orca` fails identically on base and target, confirming it is the pre-existing, deliberately excluded defect rather than a regression. Lint and shellcheck were not run: they are outside this phase. One hunk could not be demonstrated behaviorally and is reported as informational only.

<details>
<summary>Evidence: Refusal transcript on the BASE commit (defect reproduced, bash 3.2)</summary>

<code>### bash : 3.2.57(1)-release&#10;### command : bin/fm-teardown.sh task-x1 --force (backends/herdr.sh absent)&#10;### exit status : 0&#10;### ---------- stdout the user sees ----------&#10;### ---------- stderr the user sees ----------&#10;.../bin/fm-backend.sh: line 609: .../bin/backends/herdr.sh: No such file or directory&#10;### ---------- state after the command ----------&#10;isolated worktree still present : YES&#10;task branch still checked out : fm/task-x1&#10;durable endpoint metadata kept : YES&#10;task status record kept : YES</code>

```text
### bash                        : 3.2.57(1)-release
### tree                        : /tmp/fm-base-repro-f1a4af4
### command                     : bin/fm-teardown.sh task-x1 --force   (backends/herdr.sh absent)
### exit status                 : 0
### ---------- stdout the user sees ----------
### ---------- stderr the user sees ----------
/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-teardown-tests.jvGkbI/herdr-preflight-missing-adapter-repro/test-root/bin/fm-backend.sh: line 609: /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-teardown-tests.jvGkbI/herdr-preflight-missing-adapter-repro/test-root/bin/backends/herdr.sh: No such file or directory
### ---------- state after the command ----------
isolated worktree still present : YES
task branch still checked out   : fm/task-x1
durable endpoint metadata kept  : YES
task status record kept         : YES
unlocked pane close attempted   : no
```
</details>
<details>
<summary>Evidence: Refusal transcript on the FIXED commit (loud refusal, bash 3.2)</summary>

<code>### bash : 3.2.57(1)-release&#10;### command : bin/fm-teardown.sh task-x1 --force (backends/herdr.sh absent)&#10;### exit status : 1&#10;### ---------- stderr the user sees ----------&#10;error: backend &#39;herdr&#39; adapter is missing or unreadable: .../bin/backends/herdr.sh&#10;error: herdr teardown prerequisites are unavailable for task-x1; nothing was changed - restore the adapter and rerun teardown&#10;### ---------- state after the command ----------&#10;isolated worktree still present : YES&#10;task branch still checked out : fm/task-x1&#10;durable endpoint metadata kept : YES&#10;task status record kept : YES</code>

```text
### bash                        : 3.2.57(1)-release
### tree                        : /tmp/fm-fixed-repro-47c599c
### command                     : bin/fm-teardown.sh task-x1 --force   (backends/herdr.sh absent)
### exit status                 : 1
### ---------- stdout the user sees ----------
### ---------- stderr the user sees ----------
error: backend 'herdr' adapter is missing or unreadable: /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-teardown-tests.5fFf4W/herdr-preflight-missing-adapter-repro/test-root/bin/backends/herdr.sh
error: herdr teardown prerequisites are unavailable for task-x1; nothing was changed - restore the adapter and rerun teardown
### ---------- state after the command ----------
isolated worktree still present : YES
task branch still checked out   : fm/task-x1
durable endpoint metadata kept  : YES
task status record kept         : YES
unlocked pane close attempted   : no
```
</details>
<details>
<summary>Evidence: All five fm_backend_source branches, before vs after</summary>

<code>===== BEFORE (base f1a4af4) — bash 3.2.57 =====&#10;tmux -&gt; .../fm-backend.sh: line 602: .../backends/tmux.sh: No such file or directory&#10;herdr -&gt; line 609 ... zellij -&gt; line 616 ... orca -&gt; line 623 ... cmux -&gt; line 630 ...&#10;(the caller never reaches its refusal branch)&#10;&#10;===== AFTER (fix 47c599c) — bash 3.2.57 =====&#10;tmux -&gt; error: backend &#39;tmux&#39; adapter is missing or unreadable: ...&#10;caller reached: refusal branch (fm_backend_source returned non-zero)&#10;herdr / zellij / orca / cmux -&gt; same named refusal, caller reached in every case</code>

```text
===== BEFORE (base f1a4af4) (/tmp/fm-base-repro-f1a4af4) — bash 3.2.57(1)-release =====
tmux    -> caller shell exit=1
            /tmp/fm-guard-probe.6vb6hA/bin/fm-backend.sh: line 602: /tmp/fm-guard-probe.6vb6hA/bin/backends/tmux.sh: No such file or directory
herdr   -> caller shell exit=1
            /tmp/fm-guard-probe.1yIXAd/bin/fm-backend.sh: line 609: /tmp/fm-guard-probe.1yIXAd/bin/backends/herdr.sh: No such file or directory
zellij  -> caller shell exit=1
            /tmp/fm-guard-probe.jER5aQ/bin/fm-backend.sh: line 616: /tmp/fm-guard-probe.jER5aQ/bin/backends/zellij.sh: No such file or directory
orca    -> caller shell exit=1
            /tmp/fm-guard-probe.XenJEK/bin/fm-backend.sh: line 623: /tmp/fm-guard-probe.XenJEK/bin/backends/orca.sh: No such file or directory
cmux    -> caller shell exit=1
            /tmp/fm-guard-probe.wqw8B7/bin/fm-backend.sh: line 630: /tmp/fm-guard-probe.wqw8B7/bin/backends/cmux.sh: No such file or directory

===== AFTER (fix 47c599c) (/tmp/fm-fixed-repro-47c599c) — bash 3.2.57(1)-release =====
tmux    -> caller shell exit=0
            error: backend 'tmux' adapter is missing or unreadable: /tmp/fm-guard-probe.MAczu8/bin/backends/tmux.sh
            caller reached: refusal branch (fm_backend_source returned non-zero)
herdr   -> caller shell exit=0
            error: backend 'herdr' adapter is missing or unreadable: /tmp/fm-guard-probe.Q5eHkP/bin/backends/herdr.sh
            caller reached: refusal branch (fm_backend_source returned non-zero)
zellij  -> caller shell exit=0
            error: backend 'zellij' adapter is missing or unreadable: /tmp/fm-guard-probe.mHyF59/bin/backends/zellij.sh
            caller reached: refusal branch (fm_backend_source returned non-zero)
orca    -> caller shell exit=0
            error: backend 'orca' adapter is missing or unreadable: /tmp/fm-guard-probe.Pf9QKN/bin/backends/orca.sh
            caller reached: refusal branch (fm_backend_source returned non-zero)
cmux    -> caller shell exit=0
            error: backend 'cmux' adapter is missing or unreadable: /tmp/fm-guard-probe.swVd1k/bin/backends/cmux.sh
            caller reached: refusal branch (fm_backend_source returned non-zero)
```
</details>
<details>
<summary>Evidence: fm-remote-doctor.sh with a present-but-unopenable adapter (-f vs -r)</summary>

<code>########## BEFORE (guard was [ -f ]) ##########&#10;#### &#39;check ...&#39; lines the operator still gets: 0&#10;#### readiness verdict printed: 0&#10;mode=check&#10;platform=darwin &lt;- the doctor dies here&#10;&#10;########## AFTER (guard is [ -r ]) ##########&#10;#### &#39;check ...&#39; lines the operator still gets: 10&#10;#### readiness verdict printed: 1&#10;error: the herdr adapter cannot be loaded: .../bin/backends/herdr.sh is missing or unreadable&#10;check herdr-server=fixable: the herdr server for session fm-remote is not running&#10;error: this host is not ready for a remote second mate; unresolved: remote-job-worker ... herdr-server</code>

```text
########## BEFORE (base f1a4af4): guard was [ -f ] ##########
#### bin/fm-remote-doctor.sh, backends/herdr.sh present but unopenable, bash 3.2.57(1)-release
#### tree: /tmp/fm-base-repro-f1a4af4
#### exit status: 1
#### 'check ...' lines the operator still gets: 0
#### readiness verdict printed: 0
#### ---------- operator transcript ----------
mode=check
path=/private/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-remote-doctor.Bj7cJu/case1/home/.local/bin:/private/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-remote-doctor.Bj7cJu/case1/bin:/private/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-remote-doctor.Bj7cJu/tools:/usr/bin:/bin:/usr/sbin:/sbin
entrypoint=no
note: not launched through the fixed remote entrypoint; the reported PATH is this caller environment.
platform=darwin
/private/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-remote-doctor.Bj7cJu/case1/doctor-root/bin/fm-backend.sh: line 609: /private/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-remote-doctor.Bj7cJu/case1/doctor-root/bin/backends/herdr.sh: Permission denied
#### ---------- end of transcript ----------

########## AFTER (fix 47c599c): guard is [ -r ] ##########
#### bin/fm-remote-doctor.sh, backends/herdr.sh present but unopenable, bash 3.2.57(1)-release
#### tree: /tmp/fm-fixed-repro-47c599c
#### exit status: 1
#### 'check ...' lines the operator still gets: 10
#### readiness verdict printed: 1
#### ---------- operator transcript ----------
mode=check
path=/private/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-remote-doctor.ZUgLTY/case1/home/.local/bin:/private/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-remote-doctor.ZUgLTY/case1/bin:/private/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-remote-doctor.ZUgLTY/tools:/usr/bin:/bin:/usr/sbin:/sbin
entrypoint=no
note: not launched through the fixed remote entrypoint; the reported PATH is this caller environment.
platform=darwin
error: the herdr adapter cannot be loaded: /private/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-remote-doctor.ZUgLTY/case1/doctor-root/bin/backends/herdr.sh is missing or unreadable
required git=/private/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-remote-doctor.ZUgLTY/tools/git
required jq=/private/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-remote-doctor.ZUgLTY/tools/jq
required herdr=/private/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-remote-doctor.ZUgLTY/case1/bin/herdr
required tasks-axi=/private/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-remote-doctor.ZUgLTY/case1/bin/tasks-axi
required treehouse=/private/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-remote-doctor.ZUgLTY/case1/bin/treehouse
required harness=claude:/private/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-remote-doctor.ZUgLTY/case1/bin/claude
optional tmux=absent
optional no-mistakes=absent
optional gh=absent
check herdr=ok: /private/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-remote-doctor.ZUgLTY/case1/bin/herdr
check gui-session=ok: gui/501
check remote-job-worker=fixable: /private/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-remote-doctor.ZUgLTY/case1/home/Library/LaunchAgents/dev.firstmate.remote-job.plist does not match the Firstmate-owned Aqua worker contract
check remote-job-worker-loaded=fixable: dev.firstmate.remote-job is not loaded in gui/501
check remote-job-probe=ok: the remote job worker published a fresh heartbeat
check launchagent=fixable: no Firstmate herdr launch agent at /private/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-remote-doctor.ZUgLTY/case1/home/Library/LaunchAgents/dev.firstmate.herdr.fm-remote.plist
check launchagent-scope=skip: no launch agent is installed yet
check launchagent-loaded=fixable: dev.firstmate.herdr.fm-remote is not loaded into gui/501
check herdr-server=fixable: the herdr server for session fm-remote is not running
check entrypoint-link=skip: this run did not come through the fixed remote entrypoint
action: remote-job-worker: rerun this command with --fix to write dev.firstmate.remote-job
action: remote-job-worker-loaded: rerun this command with --fix to bootstrap the worker
action: launchagent: rerun this command with --fix to install it
action: launchagent-loaded: rerun this command with --fix to bootstrap and start it
action: herdr-server: rerun this command with --fix to start it
error: this host is not ready for a remote second mate; unresolved: remote-job-worker remote-job-worker-loaded launchagent launchagent-loaded herdr-server
#### ---------- end of transcript ----------
```
</details>
<details>
<summary>Evidence: Hermeticity: child-preflight against a live-home data/secondmates.md</summary>

<code>########## PRE-FIX TEST FILE (no FM_DATA_OVERRIDE) ##########&#10;not ok - herdr-child-preflight: refusal did not explain its non-mutating boundary&#10;EXIT=1&#10;&#10;########## FIXED TEST FILE (FM_DATA_OVERRIDE set), same registry ##########&#10;ok - forced secondmate teardown preflights every Herdr child before cleanup mutation&#10;EXIT=0</code>

```text
########## PRE-FIX TEST FILE (no FM_DATA_OVERRIDE), live-home data/secondmates.md present ##########
not ok - herdr-child-preflight: refusal did not explain its non-mutating boundary
EXIT=1

########## FIXED TEST FILE (FM_DATA_OVERRIDE set), same live-home data/secondmates.md present ##########
ok - forced secondmate teardown preflights every Herdr child before cleanup mutation
EXIT=0
```
</details>
<details>
<summary>Evidence: tests/fm-teardown.test.sh on the target commit (stock bash) — green</summary>

<code>FM_TEST_END tests/fm-teardown.test.sh exit=0 duration_ms=115366 gate_skip=false&#10;FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0&#10;ok-count: 58&#10;EXIT=0</code>

```text
FM_TEST_BEGIN 2026-08-15T14:24:12Z tests/fm-teardown.test.sh family=pr-forge expected_gate_skip=none
ok - local-only worktree with HEAD on a fork remote is torn down (fix holds)
ok - teardown prompts tasks-axi backlog refresh when compatible
ok - teardown honors config/backlog-backend=manual even when tasks-axi is compatible
ok - local-only worktree with truly unpushed work is refused (safety preserved)
ok - local-only worktree with work merged into local main is torn down (no regression)
ok - no-mistakes worktree with HEAD on origin is torn down (no regression)
ok - no-mistakes worktree with genuinely unlanded work is refused (safety preserved)
ok - local-only worktree with unpushed work is torn down under --force (escape hatch)
ok - teardown completes when an exact busy-state sidecar is already absent
ok - herdr teardown removes pane-owned escalation dedupe state
ok - herdr flat teardown refuses before returning the isolated copy under lock contention and the retry completes cleanly
ok - herdr flat teardown never erases records when pane presence is unparseable
ok - herdr flat teardown preflight refuses before every destructive change
ok - forced secondmate teardown preflights every Herdr child before cleanup mutation
ok - forced secondmate teardown holds every descendant lifecycle and metadata lock
ok - forced secondmate teardown retains Herdr child identity until exact pane disappearance
ok - forced teardown retains a nested secondmate home and its grandchild's Herdr identity when the grandchild close is unconfirmed
ok - herdr projection teardown retires its journal only after confirming the exact recorded pane is gone
ok - herdr projection teardown retains every record when post-close presence is unknown
ok - herdr projection teardown surfaces failed focus restoration without turning confirmed cleanup into a hard failure
ok - squash-merged + deleted-branch worktree (PR merged) is torn down (the fix)
ok - squash-merged PR accepts a local HEAD that is an ancestor of the final PR head
ok - teardown discovers a merged PR by branch name and tears down when no pr= was ever recorded
ok - squash-merged PR accepts replayed unpushed local patches contained in the PR head
ok - merged PR does not allow teardown after a later local commit
ok - fm-pr-check does not refresh PR head after HEAD moves
ok - fm-pr-check records the remote PR head when the local worktree lags
ok - worktree whose content already landed in the default branch is torn down (content fallback)
ok - content fallback refreshes origin default before comparing trees
ok - dirty worktree is refused even when its committed work has landed (dirty always wins)
ok - gh lookup error with content not in default refuses (fail-safe)
ok - provably-stale worktree index.lock (old, no live holder) is cleared and teardown succeeds
ok - live-held worktree index.lock is never removed and teardown refuses
ok - lsof errors leave worktree index.lock in place and refuse teardown
ok - stale lock cleanup rechecks and refuses dirty worktree before return
ok - normal repo index.lock is resolved from the worktree and cleared when stale
ok - lock mtime read failures leave worktree index.lock in place and refuse teardown
ok - transient index.lock cleared after first failed return is retried successfully without force-remove
ok - persistent index.lock exhausts retries and refuses without force-removing the lock
ok - empty retry wait overrides use the default without aborting teardown
ok - fractional legacy retry wait remains supported without arithmetic
ok - a task's own parked no-mistakes run is aborted, not orphaned, before the worker is removed
ok - teardown refuses before reap or removal when a task-owned run remains parked
ok - a different run cannot confirm the targeted abort
ok - empty post-abort status is not accepted as confirmation
ok - the CLI's exact run-not-found signal confirms completion
ok - a parked run on another branch is never aborted by this task's teardown (ownership is precise)
ok - a task-owned autonomous running step is left alone rather than aborted
ok - a leaked descendant process rooted under the task's worktree is reaped by teardown, not left surviving
ok - a leaked descendant process rooted under the task's per-task tasktmp is reaped by teardown too
ok - missing lsof falls back to reaping the tmux pane process group
ok - an erroring lsof scan refuses teardown and preserves the task
ok - a reused pid with a different start time is never force-killed
ok - an exec change preserves birth identity and the process is reaped
ok - a process spawned during grace is reaped on a later pass
ok - persistent leaked processes refuse teardown after bounded retries
ok - a process exiting during identity lookup does not block teardown
ok - the run abort and the leaked-process reap both complete before the destructive worktree return
FM_TEST_END 2026-08-15T14:26:07Z tests/fm-teardown.test.sh exit=0 duration_ms=115366 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=115421
FM_TEST_SUMMARY_FAMILY family=pr-forge count=1 duration_ms=115366 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-teardown.test.sh duration_ms=115366
EXIT=0
```
</details>
<details>
<summary>Evidence: tests/fm-teardown.test.sh on the base commit (stock bash) — red</summary>

<code>not ok - herdr-preflight-missing-adapter: teardown continued without its required preflight&#10;EXIT=1</code>

```text
ok - local-only worktree with HEAD on a fork remote is torn down (fix holds)
ok - teardown prompts tasks-axi backlog refresh when compatible
ok - teardown honors config/backlog-backend=manual even when tasks-axi is compatible
ok - local-only worktree with truly unpushed work is refused (safety preserved)
ok - local-only worktree with work merged into local main is torn down (no regression)
ok - no-mistakes worktree with HEAD on origin is torn down (no regression)
ok - no-mistakes worktree with genuinely unlanded work is refused (safety preserved)
ok - local-only worktree with unpushed work is torn down under --force (escape hatch)
ok - teardown completes when an exact busy-state sidecar is already absent
ok - herdr teardown removes pane-owned escalation dedupe state
ok - herdr flat teardown refuses before returning the isolated copy under lock contention and the retry completes cleanly
ok - herdr flat teardown never erases records when pane presence is unparseable
not ok - herdr-preflight-missing-adapter: teardown continued without its required preflight
EXIT=1
```
</details>
<details>
<summary>Evidence: macos-stock-bash CI lane step, parsed from ci.yml and executed locally</summary>

<code># job runs-on: macos-latest | timeout-minutes: 20 | shell: /bin/bash {0}&#10;teardown_output=$(/bin/bash tests/fm-teardown.test.sh)&#10;teardown_count=$(printf &#39;%s\n&#39; &#34;$teardown_output&#34; | grep -c &#39;^ok - &#39;)&#10;[ &#34;$teardown_count&#34; -eq 58 ] || { echo &#34;::error::expected 58 teardown tests, got $teardown_count&#34;; exit 1; }&#10;# --- executed here under 3.2.57(1)-release ---&#10;LANE SEGMENT EXIT=0</code>

```text
# macos-stock-bash lane step, extracted from the parsed .github/workflows/ci.yml
# job runs-on: macos-latest | timeout-minutes: 20 | shell: /bin/bash {0}
# --- segment as the lane will run it ---
set -eu
teardown_output=$(/bin/bash tests/fm-teardown.test.sh)
printf '%s\n' "$teardown_output"
teardown_count=$(printf '%s\n' "$teardown_output" | grep -c '^ok - ')
[ "$teardown_count" -eq 58 ] || {
  echo "::error::expected 58 teardown tests, got $teardown_count"
  exit 1
}
# --- executed here under 3.2.57(1)-release ---
ok - local-only worktree with HEAD on a fork remote is torn down (fix holds)
ok - teardown prompts tasks-axi backlog refresh when compatible
ok - teardown honors config/backlog-backend=manual even when tasks-axi is compatible
ok - local-only worktree with truly unpushed work is refused (safety preserved)
ok - local-only worktree with work merged into local main is torn down (no regression)
ok - no-mistakes worktree with HEAD on origin is torn down (no regression)
ok - no-mistakes worktree with genuinely unlanded work is refused (safety preserved)
ok - local-only worktree with unpushed work is torn down under --force (escape hatch)
ok - teardown completes when an exact busy-state sidecar is already absent
ok - herdr teardown removes pane-owned escalation dedupe state
ok - herdr flat teardown refuses before returning the isolated copy under lock contention and the retry completes cleanly
ok - herdr flat teardown never erases records when pane presence is unparseable
ok - herdr flat teardown preflight refuses before every destructive change
ok - forced secondmate teardown preflights every Herdr child before cleanup mutation
ok - forced secondmate teardown holds every descendant lifecycle and metadata lock
ok - forced secondmate teardown retains Herdr child identity until exact pane disappearance
ok - forced teardown retains a nested secondmate home and its grandchild's Herdr identity when the grandchild close is unconfirmed
ok - herdr projection teardown retires its journal only after confirming the exact recorded pane is gone
ok - herdr projection teardown retains every record when post-close presence is unknown
ok - herdr projection teardown surfaces failed focus restoration without turning confirmed cleanup into a hard failure
ok - squash-merged + deleted-branch worktree (PR merged) is torn down (the fix)
ok - squash-merged PR accepts a local HEAD that is an ancestor of the final PR head
ok - teardown discovers a merged PR by branch name and tears down when no pr= was ever recorded
ok - squash-merged PR accepts replayed unpushed local patches contained in the PR head
ok - merged PR does not allow teardown after a later local commit
ok - fm-pr-check does not refresh PR head after HEAD moves
ok - fm-pr-check records the remote PR head when the local worktree lags
ok - worktree whose content already landed in the default branch is torn down (content fallback)
ok - content fallback refreshes origin default before comparing trees
ok - dirty worktree is refused even when its committed work has landed (dirty always wins)
ok - gh lookup error with content not in default refuses (fail-safe)
ok - provably-stale worktree index.lock (old, no live holder) is cleared and teardown succeeds
ok - live-held worktree index.lock is never removed and teardown refuses
ok - lsof errors leave worktree index.lock in place and refuse teardown
ok - stale lock cleanup rechecks and refuses dirty worktree before return
ok - normal repo index.lock is resolved from the worktree and cleared when stale
ok - lock mtime read failures leave worktree index.lock in place and refuse teardown
ok - transient index.lock cleared after first failed return is retried successfully without force-remove
ok - persistent index.lock exhausts retries and refuses without force-removing the lock
ok - empty retry wait overrides use the default without aborting teardown
ok - fractional legacy retry wait remains supported without arithmetic
ok - a task's own parked no-mistakes run is aborted, not orphaned, before the worker is removed
ok - teardown refuses before reap or removal when a task-owned run remains parked
ok - a different run cannot confirm the targeted abort
ok - empty post-abort status is not accepted as confirmation
ok - the CLI's exact run-not-found signal confirms completion
ok - a parked run on another branch is never aborted by this task's teardown (ownership is precise)
ok - a task-owned autonomous running step is left alone rather than aborted
ok - a leaked descendant process rooted under the task's worktree is reaped by teardown, not left surviving
ok - a leaked descendant process rooted under the task's per-task tasktmp is reaped by teardown too
ok - missing lsof falls back to reaping the tmux pane process group
ok - an erroring lsof scan refuses teardown and preserves the task
ok - a reused pid with a different start time is never force-killed
ok - an exec change preserves birth identity and the process is reaped
ok - a process spawned during grace is reaped on a later pass
ok - persistent leaked processes refuse teardown after bounded retries
ok - a process exiting during identity lookup does not block teardown
ok - the run abort and the leaked-process reap both complete before the destructive worktree return
LANE SEGMENT EXIT=0
```
</details>
<details>
<summary>Evidence: Neighbouring suites touching fm-backend.sh</summary>

Source: Neighbouring suites touching fm-backend.sh (local file: <code>/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/no-mistakes-evidence/01M02TS5D5NGSXN9530Y8RKVW5/neighbour-suites.txt</code>)

```text
FM_TEST_SUMMARY total=4 failed=0 skipped_gate=0 duration_ms=396956
(fm-backend, fm-backend-herdr, fm-remote-doctor, fm-teardown-endpoint-safety)
EXIT=0
```
</details>
<details>
<summary>Evidence: fm-backend-orca: identical failure before and after (pre-existing)</summary>

<code>########## BEFORE (base f1a4af4) — exit 1 ##########&#10;not ok - Orca spawn should fail when metadata cannot be written&#10;&#10;########## AFTER (target 47c599c) — exit 1 ##########&#10;not ok - Orca spawn should fail when metadata cannot be written&#10;&#10;Same pre-existing failure on both sides; bin/fm-spawn.sh is untouched by this change.</code>

```text
########## BEFORE (base f1a4af4) — exit 1 ##########
ok - fm-spawn.sh --backend orca: removes worktree when terminal creation fails
ok - fm-spawn.sh --backend orca: preserves metadata when abort cleanup fails
not ok - Orca spawn should fail when metadata cannot be written

########## AFTER (target 47c599c) — exit 1 ##########
ok - fm-spawn.sh --backend orca: removes worktree when terminal creation fails
ok - fm-spawn.sh --backend orca: preserves metadata when abort cleanup fails
not ok - Orca spawn should fail when metadata cannot be written

Same pre-existing failure on both sides; bin/fm-spawn.sh is untouched by this change.
```
</details>
- Outcome: ⚠️ 1 info across 1 run (21m34s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-backend.sh:605` - Le garde `[ -r ... ] || return 1` (lignes 605, 613, 621, 629, 637) supprime le seul diagnostic qui existait pour un adaptateur manquant ou illisible. Avant le changement, bash lui-même imprimait `.../herdr.sh: No such file or directory` sur stderr avant que `|| return 1` ne rende la main ; maintenant `fm_backend_source` renvoie 1 sans rien écrire. Les appelants qui n&#39;ont pas de message propre deviennent totalement muets : `bin/fm-spawn.sh:954` et `bin/fm-spawn.sh:997` (`fm_backend_source &#34;$BACKEND&#34; || exit 1`), ainsi que tous les `fm_backend_source &#34;$backend&#34; || return 1` internes (fm-backend.sh:707, 722, 739, 757, 771, 781, 946, 963, 974, 985). Scénario concret : sur un checkout partiellement synchronisé où `bin/backends/herdr.sh` manque, `bin/fm-spawn.sh --backend herdr ...` sortait en 1 en affichant le chemin fautif ; il sort maintenant en 1 sans une seule ligne de sortie. Correctif : émettre un diagnostic dans le garde, par ex. `[ -r &#34;$f&#34; ] || { echo &#34;error: backend adapter $f is unreadable&#34; &gt;&amp;2; return 1; }` (fm-teardown.sh:2067 reste inchangé, il a déjà son propre message).
- ℹ️ `bin/fm-teardown.sh:2085` - Chargement paresseux de même classe, oublié par le balayage annoncé dans l&#39;intent (« verify no other guarded source/. in the repo suffers the same defect »). Dans `teardown_herdr_require_prerequisites`, `. &#34;$SCRIPT_DIR/fm-wake-lib.sh&#34;` (2085) s&#39;exécute APRÈS `trap teardown_release_locks EXIT` (207) et son échec est censé être rattrapé par le refus explicite des lignes 2087-2090 (« lock machinery is unavailable ... nothing was changed »). Si ce fichier n&#39;était pas ouvrable à cet instant, bash 3.2 tuerait le shell avec le statut 0 et sauterait ce refus — exactement le défaut corrigé ici, dans la fonction même que corrige ce changement. Non atteignable aujourd&#39;hui : fm-wake-lib.sh est sourcé sans garde en 168 et 178, avant le trap, donc un fichier absent tue déjà bruyamment le script avec le statut 1. `bin/backends/herdr.sh:2867` a la même forme et la même non-atteignabilité (`FM_BACKEND_HERDR_ROOT` est dérivé de l&#39;emplacement de l&#39;adaptateur). Ajouter le même préfiltre `[ -r ... ]` fermerait la classe et rendrait le balayage exact.
- ℹ️ `tests/fm-teardown.test.sh:548` - `FM_DATA_OVERRIDE=&#34;$case_dir/data&#34;` désigne un répertoire que `make_case` ne crée jamais (ligne 79 ne crée que `state`, `config`, `fakebin`), contrairement aux ~10 suites citées comme précédent (fm-backend-cmux, fm-busy-adapter-wiring, fm-gate-refuse, fm-decision-hold-lifecycle... qui font toutes `mkdir -p .../data`). Sans effet sur les chemins exercés aujourd&#39;hui (`SECONDMATE_REG` est toujours protégé par `[ -f ]`), mais tout chemin de teardown qui écrit sous `$DATA` — la réécriture du registre secondmate en fm-teardown.sh:394-396 (`grep ... &gt; &#34;$SECONDMATE_REG.tmp.$$&#34;`) ou un rapport scout `$DATA/$ID/report.md` — heurterait un ENOENT au lieu d&#39;exercer le comportement visé. Ajouter `&#34;$case_dir/data&#34;` au `mkdir -p` de make_case.
- ℹ️ `bin/fm-remote-doctor.sh:145` - Le commentaire affirme que bash 3.2 « exits the shell with status 0 » pour justifier `-r` au lieu de `-f`. Vérifié sur bash 3.2.57 : le statut 0 dépend d&#39;un trap EXIT installé (sans trap le shell sort en 1 ; avec un trap dont la dernière commande réussit, il sort en 0). `bin/fm-remote-doctor.sh` n&#39;installe aucun trap EXIT, donc ici le shell sortirait en 1 — le garde reste justifié (il saute quand même `|| return 1`), mais le statut annoncé est faux pour ce fichier. L&#39;en-tête de `fm_backend_source` (fm-backend.sh:595-598) est exact, lui, parce que son appelant fm-teardown.sh installe le trap en ligne 207. Reformuler en « quitte le shell immédiatement en sautant le `|| return 1` (statut 0 quand un trap EXIT est armé, comme dans fm-teardown.sh) ».

🔧 Fix: make adapter-load refusals loud and guard lazy lib loads
1 info still open:
- ℹ️ `bin/backends/herdr.sh:2873` - Le round de correction ajoute `declare -F fm_lock_try_acquire &gt;/dev/null 2&gt;&amp;1 &amp;&amp;` devant la résolution du chemin de verrou, ce qui dépasse le garde de lisibilité demandé et change la sémantique du cas dégradé. Avant : si `$FM_BACKEND_HERDR_ROOT/bin/fm-wake-lib.sh` n&#39;était pas ouvrable, le `.` nu de la ligne 2871 tuait le processus (bash 5 sous errexit : statut 1 ; bash 3.2 : terminaison immédiate) ; sans errexit, la boucle 2875-2882 tournait 50 fois × 0.1s sur une commande inexistante avant d&#39;atteindre l&#39;avertissement. Après : `fm_backend_herdr_kill` saute l&#39;acquisition, prend directement la branche existante `warning: herdr task kill could not acquire its session presentation lock; refusing an unlocked pane close` (2888) et rend 0 à son appelant. Autrement dit, un cas qui avortait le processus renvoie désormais un succès. Vérifié comme sûr pour les enregistrements durables : tout chemin de teardown qui les efface re-vérifie `fm_backend_herdr_endpoint_confirmed_gone` (bin/fm-teardown.sh:2211 et 2526), qui renvoie 1 tant que le pane est présent ; et le préflight (bin/fm-teardown.sh:2091-2094) exige déjà `fm_lock_try_acquire` avant tout kill, donc ce chemin est purement défensif. Il reste non atteignable en pratique (`FM_BACKEND_HERDR_ROOT` = racine du dépôt dérivée de l&#39;emplacement de l&#39;adaptateur, donc `bin/fm-wake-lib.sh` est toujours à côté) et non couvert par un test. Aucune action requise : signalé pour que le relecteur amont sache que ce hunk n&#39;est pas qu&#39;un préfiltre `-r`.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `bin/fm-teardown.sh:2085` - The added readability guard on the lazy fm-wake-lib.sh load in bin/fm-teardown.sh (~line 2085) is defensive only: fm-teardown.sh already sources bin/fm-wake-lib.sh unconditionally at line 168, so fm_lock_try_acquire is always defined and the lazy branch is unreachable from this entrypoint. Probing with bin/fm-wake-lib.sh removed exits 1 identically before and after the change (the unguarded top-level source owns that failure). No behavior change was demonstrable for that one hunk; the equivalent guard in bin/backends/herdr.sh is reachable from callers that do not source the lock library and is covered by tests/fm-backend-herdr.test.sh, which is green.
- <code>`/bin/bash bin/fm-test-run.sh tests/fm-teardown.test.sh` on the target commit — 58 `ok -`, exit 0 under bash 3.2.57</code>
- <code>`/bin/bash tests/fm-teardown.test.sh` on a pristine `git archive` of base `f1a4af4` — red at `not ok - herdr-preflight-missing-adapter`, exit 1</code>
- <code>Manual end-user repro driving the real `bin/fm-teardown.sh task-x1 --force` with `bin/backends/herdr.sh` absent, on both base and target trees (reusing the suite&#39;s own fixture helpers) — exit 0 silent vs exit 1 with the named refusal</code>
- <code>Behavioral probe of all five `fm_backend_source` branches (tmux, herdr, zellij, orca, cmux) from an errexit caller shell, before and after</code>
- <code>Manual probe of `bin/fm-remote-doctor.sh` with `bin/backends/herdr.sh` present but unopenable (symlink to a root-only file, so `[ -f ]` passes and `[ -r ]` fails) — 0 `check` lines vs 10 plus the readiness verdict</code>
- <code>Manual probe of `bin/fm-remote-doctor.sh` with the adapter simply absent — both complete, the fix adds the named diagnostic</code>
- <code>Hermeticity check: `test_forced_secondmate_herdr_child_preflight_refuses_before_changes` run against a planted live-home `data/secondmates.md`, with the pre-fix test file (fails) and the fixed test file (passes)</code>
- <code>Semantic parse of `.github/workflows/ci.yml` with a real YAML parser (job `macos-stock-bash`, `runs-on: macos-latest`, `timeout-minutes: 20`, `shell: /bin/bash {0}`), then local execution of the extracted teardown lane step — exit 0, exact-58 assertion satisfied</code>
- <code>`/bin/bash bin/fm-test-run.sh tests/fm-backend.test.sh tests/fm-backend-herdr.test.sh tests/fm-remote-doctor.test.sh tests/fm-teardown-endpoint-safety.test.sh` — 4/4 green, 0 failures</code>
- <code>`/bin/bash tests/fm-backend-orca.test.sh` on both base and target — identical single pre-existing failure, exit 1 on both</code>
- <code>Repo-wide sweep for guarded loads (`. &#34;…&#34; || return/exit`) — exactly the six enumerated sites, all now readability-guarded</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `.agents/skills/firstmate-coding-guidelines/SKILL.md:130` - Judgment call left to the author: the bash 3.2 errexit invariant (a guarded `source` must be preceded by a readability test, otherwise stock macOS Bash kills the shell instead of refusing) is now stated once in the `fm_backend_adapter_readable` header and enforced by the macos-stock-bash CI lane, which is the correct placement for local intent. What has no owner is the repo-wide contributor rule: nothing in `firstmate-coding-guidelines`&#39;s &#34;Repo style rules&#34; tells a future author writing a NEW guarded load in a new script to apply the pattern, so the defect class can reappear outside the six sites this change swept. I deliberately did not add it, because the placement policy forbids creating a rule in always-loaded agent guidance merely to close a perceived gap, and a one-line pointer there is a scope decision rather than a stale fact. Worth a follow-up if the author wants the invariant enforced by convention as well as by the lane.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
