### PR TITLE
feat: preflight composers before steering

### DIFF
--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -10,7 +10,10 @@
 # Key support is backend-specific: tmux/herdr support Escape, Enter, and C-c;
 # Orca currently supports Enter and C-c only, and rejects Escape.
 #
-# Text submission is verified: the line is typed ONCE, then Enter is sent and
+# Text submission first requires an affirmatively empty composer. Pending or
+# unreadable input fails before typing, because appending to a parked stale order
+# can execute the wrong work while a later empty-composer verdict falsely appears
+# to confirm the new order. The line is then typed ONCE, then Enter is sent and
 # retried (Enter only, never retyped) until the target backend confirms a
 # submit or reports an inconclusive send. If a swallowed Enter is positively
 # confirmed, fm-send exits NON-ZERO so the caller knows the steer did not land
@@ -433,6 +436,13 @@ if [ "${1:-}" = "--key" ]; then
   fm_send_record_interrupt "$semantic_key" || exit 1
 else
   MESSAGE=$*
+  if [ "$TARGET_BACKEND" != remote ]; then
+    composer_state=$(fm_backend_composer_state "$TARGET_BACKEND" "$T" "$EXPECTED_LABEL")
+    if [ "$composer_state" != empty ]; then
+      echo "error: text not sent to $T because its composer is not affirmatively empty (verdict=${composer_state:-unknown}; backend=$TARGET_BACKEND; tried $RESOLUTION_TRIED). Preserve the pane and reconcile its pending input before retrying." >&2
+      exit 1
+    fi
+  fi
   # The pre-marker answer text, kept for the closing resolved note so the
   # durable ledger records the plain answer without marker or corr bytes.
   RESOLVE_ANSWER_TEXT=$MESSAGE

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,7 +97,7 @@ An idle pane keeps the `pending` verdict as a genuine swallow.
 The same OpenCode busy-queue case is a known gap on the herdr adapter and is recorded in `docs/herdr-backend.md` rather than patched here.
 Composer classification has one shared owner, `bin/fm-composer-lib.sh`: tmux, herdr, Zellij, Orca, and cmux contribute only a screen capture plus declarative styled, cursor, identity, and row capabilities, while the shared classifier owns every shape and the `empty`/`pending`/`pending-unproven`/`unknown` verdict.
 `fm-spawn.sh` also routes Kimi launch readiness through that classifier instead of carrying another shape copy.
-The daemon injects only into an affirmatively `empty` composer, so every other or future verdict defers; positive container proof is required, and a blank unidentified row or bare dead-shell prompt cannot receive an escalation.
+The daemon and `fm-send.sh` inject only into an affirmatively `empty` composer, so every other or future verdict defers; positive container proof is required, and a blank unidentified row or bare dead-shell prompt cannot receive an escalation.
 The current operator boundary is in [Composer and injection safety](herdr-backend.md#composer-and-injection-safety).
 Unsupported supervisor backends refuse at daemon startup.
 Stalled escalation delivery writes `state/.subsuper-inject-wedged` and attempts a configured backend-independent active alert after `FM_MAX_DEFER_SECS` instead of silently deferring forever.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,7 +97,7 @@ An idle pane keeps the `pending` verdict as a genuine swallow.
 The same OpenCode busy-queue case is a known gap on the herdr adapter and is recorded in `docs/herdr-backend.md` rather than patched here.
 Composer classification has one shared owner, `bin/fm-composer-lib.sh`: tmux, herdr, Zellij, Orca, and cmux contribute only a screen capture plus declarative styled, cursor, identity, and row capabilities, while the shared classifier owns every shape and the `empty`/`pending`/`pending-unproven`/`unknown` verdict.
 `fm-spawn.sh` also routes Kimi launch readiness through that classifier instead of carrying another shape copy.
-The daemon and `fm-send.sh` inject only into an affirmatively `empty` composer, so every other or future verdict defers; positive container proof is required, and a blank unidentified row or bare dead-shell prompt cannot receive an escalation.
+The daemon and `fm-send.sh` both consume that shared verdict before injection; positive container proof is required, and a blank unidentified row or bare dead-shell prompt cannot receive input.
 The current operator boundary is in [Composer and injection safety](herdr-backend.md#composer-and-injection-safety).
 Unsupported supervisor backends refuse at daemon startup.
 Stalled escalation delivery writes `state/.subsuper-inject-wedged` and attempts a configured backend-independent active alert after `FM_MAX_DEFER_SECS` instead of silently deferring forever.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -243,7 +243,9 @@ ANSI capture preserves de-emphasized placeholder style.
 If the ANSI capture ever fails, the plain fallback declares itself unstyled and the classifier degrades a glyph row carrying trailing text to `unknown` instead of misreading ghost suggestions as typed input, which safely defers injection and eventually raises the wedge alarm.
 
 A bare shell prompt is never an empty agent composer.
-Away-mode injection proceeds only on an affirmative `empty` result, never on unknown.
+Every `fm-send.sh` text request inspects the existing composer before typing and proceeds only on an affirmative `empty` result.
+Pending, pending-unproven, unknown (including an unreadable capture), and future verdicts refuse before either text or Enter is sent; a remote secondmate send applies the same guard through `fm-send.sh` on the remote host.
+Away-mode injection follows the same affirmative-empty boundary and defers every other verdict.
 This prevents a dead agent pane from receiving and possibly executing an escalation as shell input.
 
 The current operational envelope starts with U+2063 and `FIRSTMATE_OP: `.

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -168,6 +168,7 @@ Send routed requests normally:
 FM_HOME=<primary-home> bin/fm-send.sh fm-<id> '<request>'
 ```
 
+The remote host applies the fleet-wide pre-typing composer guard; [Composer and injection safety](herdr-backend.md#composer-and-injection-safety) owns its verdict and refusal contract.
 Marked requests keep the existing correlation contract.
 The remote charter appends replies to `state/parent-replies.status` in the remote home.
 A process-event source performs a non-destructive, cursor-anchored delta read, fetches only referenced `data/*.md` documents through the confined reader, mirrors every content-bearing line at most once into the primary status channel, and does not carry blank separators.

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -729,13 +729,14 @@ test_peek_send_and_crew_state_route_through_orca_meta() {
     FM_ROOT_OVERRIDE="$neutral" FM_STATE_OVERRIDE="$state" FM_SEND_SETTLE=0 \
     "$ROOT/bin/fm-peek.sh" "fm-$id" 10 )
   [ "$out" = ready ] || fail "fm-peek should read through Orca metadata, got '$out'"
-  printf '{"ok":true,"result":{"send":{"handle":"term-io","accepted":true}}}\n' > "$RESP/2.out"
+  printf '{"ok":true,"result":{"terminal":{"tail":["│ > │"]}}}\n' > "$RESP/2.out"
   printf '{"ok":true,"result":{"send":{"handle":"term-io","accepted":true}}}\n' > "$RESP/3.out"
-  printf '{"ok":true,"result":{"terminal":{"tail":["│ > │"]}}}\n' > "$RESP/4.out"
+  printf '{"ok":true,"result":{"send":{"handle":"term-io","accepted":true}}}\n' > "$RESP/4.out"
+  printf '{"ok":true,"result":{"terminal":{"tail":["│ > │"]}}}\n' > "$RESP/5.out"
   PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     FM_ROOT_OVERRIDE="$neutral" FM_HOME="$neutral" FM_STATE_OVERRIDE="$state" FM_SEND_SETTLE=0 \
     "$ROOT/bin/fm-send.sh" "fm-$id" "hello orca"
-  printf '{"ok":true,"result":{"terminal":{"tail":["idle prompt"]}}}\n' > "$RESP/5.out"
+  printf '{"ok":true,"result":{"terminal":{"tail":["idle prompt"]}}}\n' > "$RESP/6.out"
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" "$ROOT/bin/fm-crew-state.sh" "$id" )
   assert_contains "$out" "state: unknown" "crew-state should fall back cleanly for an idle Orca scout"

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -729,13 +729,14 @@ test_peek_send_and_crew_state_route_through_orca_meta() {
     FM_ROOT_OVERRIDE="$neutral" FM_STATE_OVERRIDE="$state" FM_SEND_SETTLE=0 \
     "$ROOT/bin/fm-peek.sh" "fm-$id" 10 )
   [ "$out" = ready ] || fail "fm-peek should read through Orca metadata, got '$out'"
-  printf '{"ok":true,"result":{"terminal":{"tail":["│ > │"]}}}\n' > "$RESP/2.out"
+  printf '{"ok":true,"result":{"terminal":{"tail":["╭───╮","│ > │","╰───╯"]}}}\n' > "$RESP/2.out"
   printf '{"ok":true,"result":{"send":{"handle":"term-io","accepted":true}}}\n' > "$RESP/3.out"
   printf '{"ok":true,"result":{"send":{"handle":"term-io","accepted":true}}}\n' > "$RESP/4.out"
-  printf '{"ok":true,"result":{"terminal":{"tail":["│ > │"]}}}\n' > "$RESP/5.out"
+  printf '{"ok":true,"result":{"terminal":{"tail":["╭───╮","│ > │","╰───╯"]}}}\n' > "$RESP/5.out"
   PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     FM_ROOT_OVERRIDE="$neutral" FM_HOME="$neutral" FM_STATE_OVERRIDE="$state" FM_SEND_SETTLE=0 \
-    "$ROOT/bin/fm-send.sh" "fm-$id" "hello orca"
+    "$ROOT/bin/fm-send.sh" "fm-$id" "hello orca" \
+    || fail "fm-send should accept the affirmatively empty Orca composer"
   printf '{"ok":true,"result":{"terminal":{"tail":["idle prompt"]}}}\n' > "$RESP/6.out"
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" "$ROOT/bin/fm-crew-state.sh" "$id" )

--- a/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
@@ -842,6 +842,8 @@ It is read-only in secondmate homes and must not be edited there.
 Changes return through a marked status document pointer.
 current post-spawn preference
 EOF
+serialized_reads_before=$(grep -c '^pane read ' "$HERDR_LOG" || true)
+serialized_sends_before=$(grep -c '^pane send-text ' "$HERDR_LOG" || true)
 remote_env "$ROOT/bin/fm-config-push.sh" > "$TMP_ROOT/spawn-concurrent-push.out" 2>&1 &
 spawn_config_push=$!
 sleep 0.2
@@ -852,7 +854,65 @@ wait "$spawn_concurrent" || fail "serialized remote spawn failed"
 wait "$spawn_config_push" || fail "config push failed after serialized remote spawn"$'\n'"$(cat "$TMP_ROOT/spawn-concurrent-push.out")"
 [ "$(tail -1 "$REMOTE_HOME/data/captain-shared.md")" = 'current post-spawn preference' ] \
   || fail "stale spawn inheritance overwrote later config convergence"
+serialized_reads_after=$(grep -c '^pane read ' "$HERDR_LOG" || true)
+serialized_sends_after=$(grep -c '^pane send-text ' "$HERDR_LOG" || true)
+[ "$serialized_reads_after" -gt "$serialized_reads_before" ] \
+  || fail "serialized config push never read the live Herdr composer before steering"
+[ "$serialized_sends_after" -gt "$serialized_sends_before" ] \
+  || fail "serialized config push did not steer after the Herdr composer classified empty"
+serialized_last_read=$(grep -n '^pane read ' "$HERDR_LOG" | tail -1 | cut -d: -f1)
+serialized_last_send=$(grep -n '^pane send-text ' "$HERDR_LOG" | tail -1 | cut -d: -f1)
+[ "$serialized_last_read" -lt "$serialized_last_send" ] \
+  || fail "serialized config push did not preflight the composer before typing"
 pass "remote spawn serializes inheritance through launch publication"
+
+# A real but unreadable Herdr composer is not the same state as the empty bare
+# Codex composer above. Force pane read itself to fail, then drive the same
+# config-push -> remote-control -> fm-send production path and prove the
+# unknown verdict refuses before either text or Enter is sent.
+composer_state_tmp="$HERDR_STATE.composer-unreadable"
+if ! jq '.composer_readable = false' "$HERDR_STATE" > "$composer_state_tmp" \
+  || ! mv -f "$composer_state_tmp" "$HERDR_STATE"; then
+  fail "could not make the Herdr composer unreadable"
+fi
+cat > "$PARENT/data/captain-shared.md" <<'EOF'
+# Shared captain preferences
+This file is main-authoritative and maintained by the main firstmate.
+It is read-only in secondmate homes and must not be edited there.
+Changes return through a marked status document pointer.
+unreadable composer must retain this reread
+EOF
+unreadable_reads_before=$(grep -c '^pane read ' "$HERDR_LOG" || true)
+unreadable_sends_before=$(grep -c '^pane send-text ' "$HERDR_LOG" || true)
+unreadable_enters_before=$(grep -c '^pane send-keys .* enter ' "$HERDR_LOG" || true)
+if remote_env "$ROOT/bin/fm-config-push.sh" > "$TMP_ROOT/config-unreadable-composer.out" 2>&1; then
+  fail "remote config push steered despite an unreadable Herdr composer"
+fi
+unreadable_reads_after=$(grep -c '^pane read ' "$HERDR_LOG" || true)
+unreadable_sends_after=$(grep -c '^pane send-text ' "$HERDR_LOG" || true)
+unreadable_enters_after=$(grep -c '^pane send-keys .* enter ' "$HERDR_LOG" || true)
+[ "$unreadable_reads_after" -gt "$unreadable_reads_before" ] \
+  || fail "unreadable-composer refusal never exercised the production preflight"
+[ "$unreadable_sends_after" -eq "$unreadable_sends_before" ] \
+  || fail "unreadable Herdr composer received text before refusal"
+[ "$unreadable_enters_after" -eq "$unreadable_enters_before" ] \
+  || fail "unreadable Herdr composer received Enter before refusal"
+assert_grep 'config-reread: send failed; retry retained' "$TMP_ROOT/config-unreadable-composer.out" \
+  "unreadable Herdr composer did not retain the failed reread"
+UNREADABLE_NUDGE_MARKER="$PARENT/state/.secondmate-nudge-pending/ios.pending"
+assert_grep 'remote=1' "$UNREADABLE_NUDGE_MARKER" \
+  "unreadable Herdr composer lost its retry marker"
+if ! jq '.composer_readable = true' "$HERDR_STATE" > "$composer_state_tmp" \
+  || ! mv -f "$composer_state_tmp" "$HERDR_STATE"; then
+  fail "could not restore the readable Herdr composer"
+fi
+remote_env "$ROOT/bin/fm-config-push.sh" > "$TMP_ROOT/config-readable-composer-retry.out" \
+  || fail "readable empty Herdr composer did not accept the retained reread"
+assert_absent "$UNREADABLE_NUDGE_MARKER" \
+  "readable Herdr composer retry left its nudge marker"
+assert_grep 'config-reread: sent' "$TMP_ROOT/config-readable-composer-retry.out" \
+  "readable Herdr composer retry was not reported"
+pass "remote config reread distinguishes an empty Herdr composer from an unreadable one"
 
 # A normal marked parent request traverses SSH, reaches the remote endpoint once,
 # and resolves only after the correlated remote log delta is ingested.

--- a/tests/fm-send-strict.test.sh
+++ b/tests/fm-send-strict.test.sh
@@ -53,11 +53,15 @@ case "${1:-}" in
     if [ -n "${FM_FAKE_TMUX_DEAD_TARGET:-}" ] && [ "$target" = "$FM_FAKE_TMUX_DEAD_TARGET" ]; then
       exit 1
     fi
-    [ "$cursor" = 1 ] && { printf '1\n'; exit 0; }
+    [ "$cursor" = 1 ] && { printf '%s\n' "${FM_FAKE_TMUX_CURSOR:-1}"; exit 0; }
     printf '%%1\n'
     exit 0 ;;
   capture-pane)
-    printf '╭────╮\n│    │\n╰────╯\n'
+    if [ -n "${FM_FAKE_TMUX_CAPTURE:-}" ]; then
+      printf '%s\n' "$FM_FAKE_TMUX_CAPTURE"
+    else
+      printf '╭────╮\n│    │\n╰────╯\n'
+    fi
     exit 0 ;;
   list-windows)
     printf 'foreign:%s\n' "${FM_FAKE_TMUX_WINDOW:-fm-lost}"
@@ -197,6 +201,48 @@ test_healthy_fm_id_send_still_works() {
   pass "fm-send strict: healthy fm-<id> sends still type once and submit"
 }
 
+test_pending_composer_refuses_before_typing() {
+  local dir fb home err log rc got
+  dir="$TMP_ROOT/pending-composer"; mkdir -p "$dir"
+  fb=$(make_stubs "$dir"); home=$(setup_home pendingcomposer); err="$dir/send.err"; log="$dir/tmux.log"; : > "$log"
+  fm_write_meta "$home/state/pending.meta" "window=sess:fm-pending" "kind=ship" "harness=codex"
+
+  rc=0
+  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" FM_TMUX_LOG="$log" \
+    FM_FAKE_TMUX_CAPTURE=$'╭──────╮\n│ › stale │\n╰──────╯' FM_SEND_SETTLE=0 \
+    "$SEND" pending "fresh order" >/dev/null 2>"$err" || rc=$?
+  [ "$rc" -ne 0 ] || fail "pending composer accepted a second instruction"
+  got=$(cat "$log")
+  assert_not_contains "$got" 'literal=1 arg=fresh order' \
+    "fm-send typed the fresh order into a composer that already held stale text"
+  assert_not_contains "$got" 'literal=0 arg=Enter' \
+    "fm-send submitted the stale composer while attempting the fresh order"
+  assert_contains "$(cat "$err")" 'composer is not affirmatively empty' \
+    "pending-composer refusal did not explain the delivery gap"
+  pass "fm-send strict: pending composer text refuses before any typing or Enter"
+}
+
+test_unknown_composer_refuses_before_typing() {
+  local dir fb home err log rc got
+  dir="$TMP_ROOT/unknown-composer"; mkdir -p "$dir"
+  fb=$(make_stubs "$dir"); home=$(setup_home unknowncomposer); err="$dir/send.err"; log="$dir/tmux.log"; : > "$log"
+  fm_write_meta "$home/state/unknown.meta" "window=sess:fm-unknown" "kind=ship" "harness=codex"
+
+  rc=0
+  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" FM_TMUX_LOG="$log" \
+    FM_FAKE_TMUX_CURSOR=unreadable FM_SEND_SETTLE=0 \
+    "$SEND" unknown "fresh order" >/dev/null 2>"$err" || rc=$?
+  [ "$rc" -ne 0 ] || fail "unknown composer verdict accepted a new instruction"
+  got=$(cat "$log")
+  assert_not_contains "$got" 'literal=1 arg=fresh order' \
+    "fm-send typed after the composer classifier returned unknown"
+  assert_not_contains "$got" 'literal=0 arg=Enter' \
+    "fm-send submitted after the composer classifier returned unknown"
+  assert_contains "$(cat "$err")" 'verdict=unknown' \
+    "unknown-composer refusal did not preserve the classifier verdict"
+  pass "fm-send strict: unknown composer state refuses before any typing or Enter"
+}
+
 # A --key send is how firstmate interrupts a worker, so its exit status is the
 # only signal that the interrupt actually landed.
 # Reporting success for a key that was never delivered would leave supervision
@@ -227,6 +273,8 @@ test_key_send_exit_status_follows_delivery() {
 
 test_exact_lane_id_send_still_works
 test_key_send_exit_status_follows_delivery
+test_pending_composer_refuses_before_typing
+test_unknown_composer_refuses_before_typing
 test_unset_fm_home_fails
 test_unresolvable_target_does_not_tmux_fallback
 test_prefixless_herdr_pane_id_fails

--- a/tests/remote-herdr-fixture.sh
+++ b/tests/remote-herdr-fixture.sh
@@ -12,10 +12,13 @@
 # tab's only pane closes the tab, and agent get reports agent_not_found for a
 # pane no agent has registered on.
 #
-# Beyond that it models the pane IO a real launch performs. A pane reports a
-# registered agent once anything has been typed into it, and submitting starts
-# one turn: the next agent read reports working and the pane settles back to
-# idle, which is the native transition the adapter confirms a submit with.
+# Beyond that it models the pane IO a real launch performs. Each pane renders a
+# bare Codex composer (`› <draft>`), send-text fills that draft, and Enter clears
+# it while starting one turn. A pane reports a registered agent once anything
+# has been typed into it; the next agent read then reports working before the
+# pane settles back to idle, which is the native transition the adapter confirms
+# a submit with. Tests may set composer_readable=false in the state file to model
+# a genuine read failure; that must remain distinct from an empty composer.
 #
 # Usage:
 #   . "$(dirname "${BASH_SOURCE[0]}")/remote-herdr-fixture.sh"
@@ -89,14 +92,22 @@ case "${1:-} ${2:-}" in
     jq_state --arg p "${3:-}" \
       '.tabs |= [.[]|select(.pane_id != $p)]
        | .typed |= with_entries(select(.key != $p))
-       | .working |= with_entries(select(.key != $p))' | save ;;
+       | .working |= with_entries(select(.key != $p))
+       | .composer |= with_entries(select(.key != $p))' | save ;;
   "pane send-text")
     [ ! -f "$SEND_FAIL" ] || exit 1
-    jq_state --arg p "${3:-}" '.typed[$p] = true' | save ;;
+    jq_state --arg p "${3:-}" --arg text "${4:-}" \
+      '.typed[$p] = true | .composer[$p] = $text' | save ;;
   "pane send-keys")
     [ ! -f "$SEND_FAIL" ] || exit 1
-    jq_state --arg p "${3:-}" '.typed[$p] = true | .working[$p] = true' | save ;;
-  "pane read") printf '\n' ;;
+    jq_state --arg p "${3:-}" \
+      '.typed[$p] = true | .working[$p] = true | .composer[$p] = ""' | save ;;
+  "pane read")
+    [ "$(jq_state -r 'if has("composer_readable") then .composer_readable else true end')" = true ] || exit 1
+    pane=${3:-}
+    draft=$(jq_state -r --arg p "$pane" '.composer[$p] // ""')
+    printf '› %s\n' "$draft"
+    ;;
   "pane process-info") printf '{"result":{"process":{"name":"codex"}}}\n' ;;
   "agent get")
     pane=${3:-}
@@ -121,5 +132,5 @@ SH
 # reset_remote_herdr_fixture <state>: return the fake host to "no workspaces,
 # tabs, or panes", which is what a test means by "the previous endpoint is gone".
 reset_remote_herdr_fixture() { # <state>
-  printf '{"next":1,"workspaces":[],"tabs":[],"typed":{},"working":{}}\n' > "$1"
+  printf '{"next":1,"workspaces":[],"tabs":[],"typed":{},"working":{},"composer":{},"composer_readable":true}\n' > "$1"
 }


### PR DESCRIPTION
## Intent

Repackage only the composer-preflight portion of upstream firstmate PR #1631 as one standalone, independently reviewable and revertable contribution on current main. Make the new production behavior explicit as a feature: fm-send must inspect the target's existing composer before typing and refuse every pending or unreadable verdict, while remote sends perform the same guard on the remote host. Preserve the truthful Orca response-sequence correction, repair the remote Herdr fixture so empty, pending, cleared, and unreadable states are modeled faithfully, retain fail-closed unknown behavior, and include RED-before-GREEN plus mutation evidence with three enforcing lines all killed. Keep Routing R2 entirely out, leave PR #1631 open and untouched for the maintainer to dispose of, do not merge, and publish this replacement through no-mistakes. The replacement PR body must state plainly that it carries the composer-preflight part of #1631 and that #1631 is being left open for the maintainer to dispose of.

## What Changed

- Require `fm-send` text deliveries to confirm an empty composer before typing, refusing pending or unreadable states locally and through the remote-host send path.
- Repair the remote Herdr fixture to model empty, pending, cleared, and unreadable composers faithfully, with strict-send, remote lifecycle, and corrected Orca response-sequence coverage.
- Carry only the composer-preflight portion of upstream PR #1631, with Routing R2 excluded; #1631 remains open and untouched for the maintainer to dispose of.

## Risk Assessment

✅ Low: The change is narrowly scoped, enforces fail-closed composer preflight for local and host-side remote sends, preserves the corrected Orca response sequence, and keeps Routing R2 out; PR #1631 remains open.

## Testing

No baseline commands were supplied. Focused local tests passed; the affected Orca path passed after its test-only repair; direct remote-host evidence showed read-before-type success only for an empty composer and fail-closed refusal without text or Enter for pending and unreadable states. The monolithic Orca and remote suites each stopped at unrelated earlier fixture failures, so their changed paths were exercised independently. RED fired on the base behavior, GREEN passed on the target, and all three distinct enforcing-line mutants were killed.

<details>
<summary>Evidence: Remote-host composer-preflight CLI transcript</summary>

```text
REMOTE HOST COMPOSER PREFLIGHT - public fm-remote-secondmate-control.sh send path
CASE 1: affirmatively empty composer
exit=0
pane get w1:p1 --session fm-remote
status --json --session fm-remote
pane read w1:p1 --source recent --lines 200 --format ansi --session fm-remote
status --json --session fm-remote
pane send-text w1:p1 fresh remote order --session fm-remote
agent get w1:p1 --session fm-remote
status --json --session fm-remote
pane send-keys w1:p1 enter --session fm-remote
agent get w1:p1 --session fm-remote
composer_after=
CASE 2: pending composer
exit=1
pane get w1:p1 --session fm-remote
status --json --session fm-remote
pane read w1:p1 --source recent --lines 200 --format ansi --session fm-remote
error: text not sent to fm-remote:w1:p1 because its composer is not affirmatively empty (verdict=pending; backend=herdr; tried meta=/var/folders/cq/xf4qcb9j0qzc2dbh173mflbm0000gn/T/no-mistakes-evidence/01M03K5XM0CEBT6NX0959ZHE6E/remote-host.jWpMxM/state/fm-remote:w1:p1.meta; metadata window/terminal lookup; backend=herdr; endpoint=verified). Preserve the pane and reconcile its pending input before retrying.
composer_after=parked stale order
CASE 3: unreadable composer
exit=1
pane get w1:p1 --session fm-remote
status --json --session fm-remote
pane read w1:p1 --source recent --lines 200 --format ansi --session fm-remote
status --json --session fm-remote
pane read w1:p1 --source recent --lines 200 --session fm-remote
error: text not sent to fm-remote:w1:p1 because its composer is not affirmatively empty (verdict=unknown; backend=herdr; tried meta=/var/folders/cq/xf4qcb9j0qzc2dbh173mflbm0000gn/T/no-mistakes-evidence/01M03K5XM0CEBT6NX0959ZHE6E/remote-host.jWpMxM/state/fm-remote:w1:p1.meta; metadata window/terminal lookup; backend=herdr; endpoint=verified). Preserve the pane and reconcile its pending input before retrying.
composer_after=
```
</details>
<details>
<summary>Evidence: RED/GREEN and three-mutant kill transcript</summary>

```text
COMPOSER PREFLIGHT RED-BEFORE-GREEN AND MUTATION SWEEP
All cases run the public fm-send executable via tests/fm-send-strict.test.sh.
Expected: base control and each exactly-one-line mutant fail; current target passes.
red_base	exit=1
not ok - fm-send typed the fresh order into a composer that already held stale text (unexpected: 'literal=1 arg=fresh order')
mutant_a_guard_condition	substitutions=1
mutant_a_guard_condition	exit=1
not ok - fm-send typed the fresh order into a composer that already held stale text (unexpected: 'literal=1 arg=fresh order')
mutant_b_classifier_call	substitutions=1
mutant_b_classifier_call	exit=1
not ok - fm-send typed the fresh order into a composer that already held stale text (unexpected: 'literal=1 arg=fresh order')
mutant_c_refusal_exit	substitutions=1
mutant_c_refusal_exit	exit=1
not ok - fm-send typed the fresh order into a composer that already held stale text (unexpected: 'literal=1 arg=fresh order')
green_target	exit=0
ok - fm-send strict: healthy fm-<id> sends still type once and submit
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-send-strict.test.sh`
- <code>`bash tests/fm-backend-orca.test.sh` (encountered the known earlier metadata-publication fixture failure before the changed scenario)</code>
- <code>Isolated `test_peek_send_and_crew_state_route_through_orca_meta` through the public `fm-send` path</code>
- <code>`bash tests/fm-remote-secondmate-lifecycle-e2e.test.sh` (encountered an earlier provisioning-fixture failure before the changed scenario)</code>
- <code>Manual `bin/fm-remote-secondmate-control.sh send` checks for empty, pending, and unreadable remote Herdr composers</code>
- <code>Base-versus-target RED/GREEN run plus three separate exactly-one-substitution mutation runs against `tests/fm-send-strict.test.sh`</code>
- <code>Read-only `gh-axi pr view 1631 --full` verification that upstream PR #1631 remains open</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
