### PR TITLE
test: make half-block composer fixture portable

### DIFF
--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -270,18 +270,29 @@ test_matrix_herdr_halfblock_rule_bounds_bare_wrap() {
   # composer's WRAP region walks through its own closing rule and swallows the
   # footer, whose real content turns an idle pane into a false `pending`.
   # Captured live from a herdr cursor pane.
-  local screen plain out
-  plain=$'transcript\n \u2584\u2584\u2584\u2584\u2584\u2584\u2584\u2584\n  \u2192 Add a follow-up\n \u2580\u2580\u2580\u2580\u2580\u2580\u2580\u2580\n  Cursor Grok 4.5 High \u00b7 6.7%   Run Everything\n  ~/wt \u00b7 64cdd3a'
+  local screen plain out top_rule bottom_rule top_rule_bytes bottom_rule_bytes
+  top_rule='▄▄▄▄▄▄▄▄'
+  bottom_rule='▀▀▀▀▀▀▀▀'
+  # The source literals make this test independent of Bash printf's optional
+  # Unicode-escape support. Verify their bytes before exercising the matcher so
+  # a runner that cannot preserve the captured input fails loudly, not vacuously.
+  top_rule_bytes=$(LC_ALL=C printf '%s' "$top_rule" | LC_ALL=C od -An -v -t x1 | LC_ALL=C tr -d '[:space:]')
+  bottom_rule_bytes=$(LC_ALL=C printf '%s' "$bottom_rule" | LC_ALL=C od -An -v -t x1 | LC_ALL=C tr -d '[:space:]')
+  [ "$top_rule_bytes" = e29684e29684e29684e29684e29684e29684e29684e29684 ] \
+    || fail "half-block fixture cannot express U+2584 eight times, got bytes '$top_rule_bytes'"
+  [ "$bottom_rule_bytes" = e29680e29680e29680e29680e29680e29680e29680e29680 ] \
+    || fail "half-block fixture cannot express U+2580 eight times, got bytes '$bottom_rule_bytes'"
+  plain=$'transcript\n '"$top_rule"$'\n  → Add a follow-up\n '"$bottom_rule"$'\n  Cursor Grok 4.5 High · 6.7%   Run Everything\n  ~/wt · 64cdd3a'
   # The closing rule must bound the region, so the footer below is not input.
-  fm_composer_row_has_edge " $(printf '\u2580\u2580\u2580')" \
+  fm_composer_row_has_edge " $bottom_rule" \
     || fail "a half-block rule row must count as a structural edge"
-  fm_composer_row_has_edge " $(printf '\u2584\u2584\u2584')" \
+  fm_composer_row_has_edge " $top_rule" \
     || fail "the upper half-block rule must count as a structural edge"
   # Non-vacuousness: the footer rows really are non-blank content that would be
   # swallowed if the rule did not bound the region.
   case "$plain" in *"Run Everything"*) : ;; *) fail "fixture lost its footer content" ;; esac
   ESC_LOCAL=$(printf '\033')
-  screen=$'transcript\n \u2584\u2584\u2584\u2584\u2584\u2584\u2584\u2584\n'"  ${ESC_LOCAL}[2m\u2192 ${ESC_LOCAL}[0;7mA${ESC_LOCAL}[0;2mdd a follow-up${ESC_LOCAL}[0m"$'\n \u2580\u2580\u2580\u2580\u2580\u2580\u2580\u2580\n  Cursor Grok 4.5 High \u00b7 6.7%   Run Everything\n  ~/wt \u00b7 64cdd3a'
+  screen=$'transcript\n '"$top_rule"$'\n'"  ${ESC_LOCAL}[2m→ ${ESC_LOCAL}[0;7mA${ESC_LOCAL}[0;2mdd a follow-up${ESC_LOCAL}[0m"$'\n '"$bottom_rule"$'\n  Cursor Grok 4.5 High · 6.7%   Run Everything\n  ~/wt · 64cdd3a'
   out=$(fm_composer_classify_screen "$CAPS_STYLED" "$(printf '%b' "$screen")")
   [ "$out" = empty ] \
     || fail "an idle cursor composer inside herdr half-block rules must read empty, got '$out'"


### PR DESCRIPTION
## Intent

Repair the pre-existing default-branch failure in tests/fm-composer-lib.test.sh without weakening the half-block structural-edge property. Determine whether production or the environment is at fault first. The production matcher already recognizes U+2580 and U+2584; host Bash 3.2 emits literal backslash-u text for printf '\u…'. Make the test construct verified UTF-8 source literals instead, fail loudly if the fixture bytes are not preserved, keep the focused test single-purpose, and prove both half-block production alternatives remain enforced.

## What Changed

- Replace Bash-dependent Unicode escapes with portable UTF-8 source literals in the half-block composer fixture.
- Verify the exact fixture bytes and fail loudly if either U+2584 or U+2580 is not preserved.
- Keep independent structural-edge assertions for both half-block alternatives while reusing the verified literals in the end-to-end fixture.

## Risk Assessment

✅ Low: Captain, the test-only change is narrowly scoped and preserves independent byte and matcher enforcement for both U+2580 and U+2584.

## Testing

Inspected the base-to-target change and production matcher, reproduced Bash 3.2’s literal backslash-u behavior, passed the focused composer test in ambient and C locales, and captured an end-to-end transcript proving both verified UTF-8 half-block alternatives prevent footer swallowing while a non-edge does not.

<details>
<summary>Evidence: Half-block end-to-end transcript</summary>

<code>Bash 3.2 emitted literal `\u2580` bytes; verified UTF-8 literals for U+2584 and U+2580 both yielded `empty`, while the non-edge counterfactual yielded `pending`. SHA-256: 26e718a0a701e7d91dae146f76e2ceaf27d8da78470ea5d1c613bf0a79ab0316</code>

```text
^Dhost_bash=3.2.57(1)-release
legacy_printf_backslash_u_bytes=5c7532353830
literal_U+2584_x8_bytes=e29684e29684e29684e29684e29684e29684e29684e29684
literal_U+2580_x8_bytes=e29680e29680e29680e29680e29680e29680e29680e29680
U+2584_structural_edge=enforced
U+2584_rule_end_to_end_verdict=empty
U+2580_structural_edge=enforced
U+2580_rule_end_to_end_verdict=empty
non_edge_counterfactual_verdict=pending
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff f1a4af426d7199c1781bc91ccd143b8e1f732d10..eb25d1f401918f50536481f5f37c6e557652339a` and the production edge matcher.</code>
- <code>Confirmed host `/bin/bash` is GNU Bash 3.2.57 and its `printf &#39;\u2580&#39;` emits literal bytes `5c7532353830`.</code>
- `/bin/bash tests/fm-composer-lib.test.sh`
- `LC_ALL=C /bin/bash tests/fm-composer-lib.test.sh`
- <code>Captured a manual public-interface transcript verifying exact fixture bytes, independent U+2584/U+2580 edge behavior, end-to-end `empty` verdicts, and the `pending` non-edge counterfactual.</code>
- <code>Verified `git status --short` remained empty after testing.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
