### PR TITLE
fix: local-only no-origin spawn and teardown while a captain wait is open

### DIFF
--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -173,10 +173,13 @@ status_is_paused_or_captain_held() {  # <status-line>
 # carry a token, the documented before-colon one wins and the note-head token
 # stays note text. A token deeper inside the note is prose, never a stated key,
 # so a summary merely MENTIONING "[key=x]" cannot open or close that decision.
-# A line with no token in either position uses the key "default", preserving
-# the historical one-open-decision-per-task behavior (a bare "resolved:" closes
-# "default"). A stated key whose slug fails the charset below is rejected (the
-# folds skip the line), never rewritten to "default".
+# A line with no token in those positions or as a trailing "[key=<slug>]" tag
+# uses the key "default", preserving the historical one-open-decision-per-task
+# behavior (a bare "resolved:" closes "default"). A trailing tag is the same
+# stated-key shape workers emit when they append "[key=...]" after the summary;
+# a token deeper inside the note remains prose. A stated key whose slug fails
+# the charset below is rejected (the folds skip the line), never rewritten to
+# "default".
 # The parsers are pure reads of a single line. Status metadata may contain any
 # number of "[name=value]" tags before the colon, in any order, so verb parsing
 # ends at the first tag rather than special-casing "[key=...]".
@@ -232,8 +235,26 @@ status_line_note() {  # <status-line> -> text after the first colon, trimmed
     && _fm_decision_slug_ok "$k"; then
     n=${n#"[key=$k]"}
     n=${n#"${n%%[![:space:]]*}"}
+  elif ! _fm_key_before_colon "$1" && ! _fm_key_at_note_head "$1" >/dev/null \
+    && k=$(_fm_key_at_note_tail "$1") && _fm_decision_slug_ok "$k"; then
+    n=${n%"[key=$k]"}
+    n=${n%"${n##*[![:space:]]}"}
   fi
   printf '%s' "$n"
+}
+# Raw slug of a complete "[key=<slug>]" token at the END of the note.
+# Mid-note mentions are not tails.
+_fm_key_at_note_tail() {  # <status-line> -> raw slug
+  local rest
+  case "$1" in
+    *:*) rest=${1#*:} ;;
+    *) return 1 ;;
+  esac
+  rest=${rest%"${rest##*[![:space:]]}"}
+  case "$rest" in
+    *\[key=*\]) rest=${rest##*\[key=}; printf '%s' "${rest%%\]*}" ;;
+    *) return 1 ;;
+  esac
 }
 _fm_decision_key() {  # <status-line> -> key slug, or "default" when no token
   local k
@@ -241,8 +262,13 @@ _fm_decision_key() {  # <status-line> -> key slug, or "default" when no token
     k=${1%%:*}
     k=${k#*\[key=}
     k=${k%%\]*}
+  elif k=$(_fm_key_at_note_head "$1"); then
+    :
+  elif k=$(_fm_key_at_note_tail "$1"); then
+    :
   else
-    k=$(_fm_key_at_note_head "$1") || { printf 'default'; return 0; }
+    printf 'default'
+    return 0
   fi
   _fm_decision_slug_ok "$k" || return 1
   printf '%s' "$k"

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -22,6 +22,7 @@
 #     --title <title> --reason <reason> [--repo <repo>]
 #   fm-decision-hold.sh complete <origin-id> (--none | <decision-key>...)
 #   fm-decision-hold.sh verify <origin-id>
+#   fm-decision-hold.sh has-active <origin-id>
 #   fm-decision-hold.sh resolve <origin-id> <decision-key> \
 #     --decision-file <path> --routed-to <task-id> [--routed-to <task-id>...]
 #   fm-decision-hold.sh decline <origin-id> <decision-key> --decision-file <path>
@@ -464,6 +465,20 @@ EOF
   printf 'complete: %s decision inventory reviewed%s\n' "$origin" "${keys:+ ($keys)}"
 }
 
+command_has_active() {
+  local origin=${1:-} prefix rows
+  [ "$#" -eq 1 ] || { usage >&2; exit 2; }
+  validate_slug origin-id "$origin"
+  require_tasks_axi
+  prefix="${origin}-decision-"
+  rows=$(tasks_axi list --state held --kind captain --fields held,hold_kind 2>/dev/null) \
+    || fail "could not list captain-held work for $origin"
+  case "$rows" in
+    *"$prefix"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 command_verify() {
   local origin=${1:-} meta reviewed keys key open
   [ "$#" -eq 1 ] || { usage >&2; exit 2; }
@@ -654,6 +669,7 @@ case "${1:-}" in
   hold) shift; command_hold "$@" ;;
   complete) shift; command_complete "$@" ;;
   verify) shift; command_verify "$@" ;;
+  has-active) shift; command_has_active "$@" ;;
   resolve) shift; command_resolve "$@" ;;
   decline) shift; command_decline "$@" ;;
   repair) shift; command_repair "$@" ;;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -134,10 +134,13 @@
 #   default-branch commit when safe; skipped syncs warn and launch unchanged.
 #   Ship/scout spawns refuse to launch unless the resolved task path is a real
 #   git worktree root distinct from the primary project checkout.
-#   Before a fresh ship or scout worker starts, its clean task worktree fetches
-#   origin, resolves the current remote default branch, and resets to its tip.
-#   An unreachable origin, unresolved default branch, or non-clean worktree
-#   refuses the spawn rather than risking a PR based on stale history.
+#   Before a fresh ship or scout worker starts, its clean task worktree refreshes
+#   to a current base tip and resets hard to that tip. When origin exists, that
+#   tip is origin's resolved default branch (fetched). When the spawn is local-only
+#   and the worktree has no origin remote, that tip is the primary local checkout's
+#   default-branch commit instead (no fetch). An unreachable origin, unresolved
+#   default branch, missing primary tip, or non-clean worktree refuses the spawn
+#   rather than risking a PR or local-only land based on stale history.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -1728,28 +1731,72 @@ validate_spawn_worktree() {  # <source> <inspect-target>
 }
 
 freshen_spawn_worktree_base() {  # <worktree>
-  local worktree=$1 default target expected actual status
-  if ! git -C "$worktree" fetch --quiet origin; then
-    echo "error: could not fetch origin for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
-    return 1
+  local worktree=$1 default target expected actual status primary_tip
+  local has_origin=0 use_local_primary=0
+
+  if git -C "$worktree" remote get-url origin >/dev/null 2>&1; then
+    has_origin=1
   fi
-  if ! git -C "$worktree" remote set-head origin --auto >/dev/null 2>&1; then
-    echo "error: could not resolve origin's current default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
-    return 1
+
+  # local-only + no origin: refresh from the project's primary local checkout
+  # rather than dying on `git fetch origin`. Any other no-origin case (and every
+  # origin-backed case) keeps the origin path so non-local-only spawns still refuse
+  # when origin is missing or unreachable.
+  if [ "$has_origin" -eq 0 ]; then
+    if [ "${MODE:-}" = local-only ]; then
+      use_local_primary=1
+    else
+      echo "error: could not fetch origin for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+      return 1
+    fi
   fi
-  default=$(default_branch "$worktree") || {
-    echo "error: could not determine origin's default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
-    return 1
-  }
-  target="origin/$default"
-  if ! git -C "$worktree" fetch --quiet origin "+refs/heads/$default:refs/remotes/origin/$default"; then
-    echo "error: could not fetch '$target' for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
-    return 1
+
+  if [ "$use_local_primary" -eq 1 ]; then
+    if [ -z "${PROJ_ABS:-}" ] || [ ! -d "$PROJ_ABS" ]; then
+      echo "error: could not resolve primary local checkout for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+      return 1
+    fi
+    default=$(default_branch "$PROJ_ABS") || {
+      echo "error: could not determine the primary local default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+      return 1
+    }
+    primary_tip=$(git -C "$PROJ_ABS" rev-parse --verify --quiet "refs/heads/$default^{commit}" 2>/dev/null) || {
+      echo "error: primary local checkout has no tip for '$default' (pooled worktree '$worktree'); refusing to launch from a potentially stale base" >&2
+      return 1
+    }
+    # Ensure the pooled worktree can see the primary tip. Linked worktrees of the
+    # same repo already share objects; a separate clone still needs the commit
+    # reachable, so refuse rather than invent a fetch path when it is not.
+    if ! git -C "$worktree" cat-file -e "$primary_tip^{commit}" 2>/dev/null; then
+      echo "error: primary local tip '$primary_tip' is not reachable from pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+      return 1
+    fi
+    target=$primary_tip
+    expected=$primary_tip
+  else
+    if ! git -C "$worktree" fetch --quiet origin; then
+      echo "error: could not fetch origin for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+      return 1
+    fi
+    if ! git -C "$worktree" remote set-head origin --auto >/dev/null 2>&1; then
+      echo "error: could not resolve origin's current default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+      return 1
+    fi
+    default=$(default_branch "$worktree") || {
+      echo "error: could not determine origin's default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+      return 1
+    }
+    target="origin/$default"
+    if ! git -C "$worktree" fetch --quiet origin "+refs/heads/$default:refs/remotes/origin/$default"; then
+      echo "error: could not fetch '$target' for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+      return 1
+    fi
+    expected=$(git -C "$worktree" rev-parse --verify --quiet "$target^{commit}" 2>/dev/null) || {
+      echo "error: '$target' is not a commit for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+      return 1
+    }
   fi
-  expected=$(git -C "$worktree" rev-parse --verify --quiet "$target^{commit}" 2>/dev/null) || {
-    echo "error: '$target' is not a commit for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
-    return 1
-  }
+
   status=$(git -C "$worktree" status --porcelain) || {
     echo "error: could not inspect pooled worktree '$worktree' before refreshing its base" >&2
     return 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1738,12 +1738,13 @@ freshen_spawn_worktree_base() {  # <worktree>
     has_origin=1
   fi
 
-  # local-only + no origin: refresh from the project's primary local checkout
-  # rather than dying on `git fetch origin`. Any other no-origin case (and every
-  # origin-backed case) keeps the origin path so non-local-only spawns still refuse
-  # when origin is missing or unreachable.
+  # local-only ships and scouts + no origin: refresh from the project's primary
+  # local checkout rather than dying on `git fetch origin`. Scouts refuse --mode,
+  # so KIND=scout must take the same path or a local-only lab cannot be scouted.
+  # Origin-backed cases and non-local-only ships keep the origin path so a
+  # no-mistakes ship still refuses when origin is missing or unreachable.
   if [ "$has_origin" -eq 0 ]; then
-    if [ "${MODE:-}" = local-only ]; then
+    if [ "${MODE:-}" = local-only ] || [ "${KIND:-}" = scout ]; then
       use_local_primary=1
     else
       echo "error: could not fetch origin for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -29,6 +29,10 @@
 # declared scratch and the report at data/<task-id>/report.md is the work
 # product. Teardown proceeds only once the report exists and the shared
 # unresolved-decision completion gate verifies its captain-held inventory.
+# Ship and scout tasks with an OPEN status decision (needs-decision/blocked
+# that has not been resolved or captain-held-transferred) also refuse, even
+# when the worktree has no commits. An unanswered captain wait is not landed
+# work and must not be reaped.
 # Before destructive cleanup, teardown validates task check artifacts and any
 # matching quarantine entries as ordinary single-link files on the state
 # device. It refuses and preserves task state when that proof fails; otherwise
@@ -2326,6 +2330,33 @@ if [ "$KIND" = scout ] && [ "$FORCE" != "--force" ]; then
     echo "REFUSED: scout task $ID has not passed the unresolved-decision completion gate." >&2
     echo "Inventory its report and any visual review through bin/fm-decision-hold.sh before teardown." >&2
     exit 1
+  fi
+fi
+
+# Unanswered captain waits block teardown for every kind. A ship that only
+# created a branch and asked a question has no unlanded commits, so the landed-
+# work check would otherwise allow cleanup and reap the waiting agent.
+if [ "$FORCE" != "--force" ] && [ "$KIND" != secondmate ]; then
+  _td_status="$STATE/$ID.status"
+  _td_open=''
+  if [ -f "$_td_status" ]; then
+    _td_open=$(status_open_decisions "$_td_status" || true)
+  fi
+  if [ -n "$_td_open" ]; then
+    echo "REFUSED: task $ID still has an open captain decision." >&2
+    echo "Answer it through bin/fm-decision-hold.sh resolve|decline, or use --force after explicit discard approval." >&2
+    exit 1
+  fi
+  if [ -f "$_td_status" ]; then
+    _td_last=$(last_status_line "$_td_status")
+    _td_verb=$(status_line_verb "$_td_last")
+    case "$_td_verb" in
+      needs-decision|blocked)
+        echo "REFUSED: task $ID last reported $_td_verb; the captain wait is still open." >&2
+        echo "Answer it through bin/fm-decision-hold.sh resolve|decline, or use --force after explicit discard approval." >&2
+        exit 1
+        ;;
+    esac
   fi
 fi
 

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2358,6 +2358,16 @@ if [ "$FORCE" != "--force" ] && [ "$KIND" != secondmate ]; then
         ;;
     esac
   fi
+  # After complete, the status fold is empty (captain-held transfer) but the
+  # backlog hold is still queued+held until resolve/decline.
+  if fm_tasks_axi_compatible; then
+    if FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
+        FM_CONFIG_OVERRIDE="$CONFIG" "$SCRIPT_DIR/fm-decision-hold.sh" has-active "$ID"; then
+      echo "REFUSED: task $ID still has an active captain-held decision." >&2
+      echo "Close it with bin/fm-decision-hold.sh resolve|decline, or use --force after explicit discard approval." >&2
+      exit 1
+    fi
+  fi
 fi
 
 # A public commitment is not kept until its final reply lands in the ORIGINAL

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -157,7 +157,7 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
-`fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
+`fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches a current base tip, and any unsafe or unverifiable base stops the spawn. That tip is origin's resolved default branch when origin exists; for a `local-only` spawn whose worktree has no origin remote, it is the primary local checkout's default-branch commit instead.
 Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.

--- a/tests/fm-classify-decision-key.test.sh
+++ b/tests/fm-classify-decision-key.test.sh
@@ -259,7 +259,17 @@ test_incremental_agrees_with_full_fold_across_appends() {
   pass "the incremental fold matches the full fold across appends in both key positions"
 }
 
+test_trailing_key_tag_is_honored() {
+  local dir expected
+  dir=$(case_dir trailing)
+  printf 'needs-decision: trial-hold payload A or B [key=trial-hold-payload]\n' > "$dir/t.status"
+  expected=$(printf 'trial-hold-payload\tneeds-decision\ttrial-hold payload A or B\n')
+  assert_fold "$dir/t.status" "$expected" "trailing [key=] tag"
+  pass "a trailing [key=X] tag opens X and is stripped from the note"
+}
+
 test_stated_key_is_honored_in_both_positions
+test_trailing_key_tag_is_honored
 test_bare_keyless_line_still_folds_to_default
 test_resolution_closes_across_positions
 test_blocked_is_position_tolerant_like_needs_decision

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -5,7 +5,8 @@
 # advanced after the worktree was allocated.
 # These tests drive the real spawn path with a fake terminal, then prove it
 # starts the worker from the fetched origin/main tip or stops when origin is
-# unreachable.
+# unreachable. A local-only project with no origin remote instead refreshes from
+# the primary local checkout's default-branch tip.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -227,11 +228,135 @@ test_unresolved_remote_default_refuses_pool() {
   pass "an unresolved remote default branch refuses the pooled worktree"
 }
 
+# local-only project whose worktree has no origin remote: refresh from the
+# primary local checkout instead of dying on `git fetch origin`.
+make_local_only_no_origin_case() {
+  local name=$1 id=$2 default=${3:-main} case_dir home project pool fakebin initial advanced
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  pool="$case_dir/pool"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'codex\n' > "$home/config/crew-harness"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  touch "$home/state/.last-watcher-beat"
+
+  git init --quiet -b "$default" "$project"
+  printf 'base\n' > "$project/README.md"
+  git -C "$project" add README.md
+  git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+  # No origin remote on purpose: this is the local-only no-origin path.
+  initial=$(git -C "$project" rev-parse HEAD)
+  git -C "$project" worktree add --quiet --detach "$pool" "$initial"
+
+  # Advance the primary local checkout after the pool was allocated so the
+  # freshen path must pull the new tip from the primary, not from origin.
+  printf 'must survive a newly spawned local-only branch\n' > "$project/advanced-main.txt"
+  git -C "$project" add advanced-main.txt
+  git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm advance-main
+  advanced=$(git -C "$project" rev-parse HEAD)
+
+  printf '%s\n' "$case_dir|$home|$project|$pool|$fakebin|$initial|$default|$advanced"
+}
+
+read_local_only_case_record() {
+  IFS='|' read -r CASE_DIR HOME_DIR PROJECT_DIR POOL_DIR FAKEBIN_DIR INITIAL_SHA DEFAULT_BRANCH ADVANCED_SHA <<EOF
+$1
+EOF
+}
+
+test_local_only_no_origin_refreshes_from_primary() {
+  local rec id out status branch_head primary_tip
+  id='pool-local-only-no-origin-r6'
+  rec=$(make_local_only_no_origin_case local-only-no-origin "$id")
+  read_local_only_case_record "$rec"
+
+  # Prove the pool starts stale relative to the primary tip.
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$INITIAL_SHA" ] \
+    || fail "fixture pool was not detached at the initial primary tip"
+  [ "$ADVANCED_SHA" != "$INITIAL_SHA" ] \
+    || fail "fixture did not advance the primary past the pool base"
+  if git -C "$POOL_DIR" remote get-url origin >/dev/null 2>&1; then
+    fail "fixture incorrectly configured an origin remote on the local-only pool"
+  fi
+  if git -C "$PROJECT_DIR" remote get-url origin >/dev/null 2>&1; then
+    fail "fixture incorrectly configured an origin remote on the primary checkout"
+  fi
+
+  out=$(run_spawn "$id" --mode local-only --yolo off)
+  status=$?
+  expect_code 0 "$status" "local-only no-origin spawn should refresh from the primary local checkout"
+  assert_contains "$out" "spawned $id" "local-only no-origin spawn did not report success"
+  assert_not_contains "$out" "could not fetch origin" \
+    "local-only no-origin spawn incorrectly attempted an origin fetch"
+
+  primary_tip=$(git -C "$PROJECT_DIR" rev-parse HEAD)
+  branch_head=$(git -C "$POOL_DIR" rev-parse HEAD)
+  [ "$primary_tip" = "$ADVANCED_SHA" ] || fail "primary tip drifted during the spawn"
+  [ "$branch_head" = "$primary_tip" ] \
+    || fail "local-only no-origin spawn left the pooled worktree off the primary tip"
+  [ "$branch_head" != "$INITIAL_SHA" ] \
+    || fail "local-only no-origin spawn did not advance past the stale pool base"
+  assert_grep 'must survive a newly spawned local-only branch' "$POOL_DIR/advanced-main.txt" \
+    "local-only no-origin spawn omitted advanced-main content from the primary"
+
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed local-only no-origin spawn: %s\n' "$(printf '%s\n' "$out" | tail -n 1)"
+    printf '# observed base: HEAD=%s primary=%s advanced=%s\n' \
+      "$branch_head" "$primary_tip" "$ADVANCED_SHA"
+  fi
+  pass "a local-only no-origin pooled worktree refreshes from the primary local checkout"
+}
+
+test_local_only_no_origin_dirty_refuses_without_discarding_work() {
+  local rec id out status before
+  id='pool-local-only-no-origin-dirty-r7'
+  rec=$(make_local_only_no_origin_case local-only-no-origin-dirty "$id")
+  read_local_only_case_record "$rec"
+  before=$(git -C "$POOL_DIR" rev-parse HEAD)
+  printf 'keep this local work\n' > "$POOL_DIR/uncommitted.txt"
+
+  out=$(run_spawn "$id" --mode local-only --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "local-only no-origin spawn succeeded despite a dirty pooled worktree"
+  assert_contains "$out" "is not clean" \
+    "local-only no-origin spawn did not clearly refuse a dirty pooled worktree"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
+    || fail "local-only no-origin spawn moved HEAD while refusing a dirty pool"
+  assert_grep 'keep this local work' "$POOL_DIR/uncommitted.txt" \
+    "local-only no-origin spawn discarded uncommitted work while refusing the pool"
+  pass "a dirty local-only no-origin pool is refused without discarding local work"
+}
+
+test_non_local_only_no_origin_still_refuses() {
+  local rec id out status before
+  id='pool-no-mistakes-no-origin-r8'
+  rec=$(make_local_only_no_origin_case no-mistakes-no-origin "$id")
+  read_local_only_case_record "$rec"
+  before=$(git -C "$POOL_DIR" rev-parse HEAD)
+
+  # no-mistakes without origin must still refuse rather than silently using the
+  # primary tip (that path is reserved for local-only).
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "no-mistakes no-origin spawn succeeded when it should refuse"
+  assert_contains "$out" "could not fetch origin" \
+    "no-mistakes no-origin spawn did not clearly refuse a missing origin"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
+    || fail "no-mistakes no-origin spawn moved HEAD after refusing"
+  pass "a no-mistakes no-origin pool still refuses rather than using the local-primary path"
+}
+
 test_stale_pool_base_refreshes_before_branching
 test_non_main_default_branch_refreshes_before_branching
 test_direct_pr_and_scout_refresh_before_launch
 test_dirty_pool_refuses_without_discarding_work
 test_unresolved_remote_default_refuses_pool
 test_unreachable_origin_refuses_stale_pool_base
+test_local_only_no_origin_refreshes_from_primary
+test_local_only_no_origin_dirty_refuses_without_discarding_work
+test_non_local_only_no_origin_still_refuses
 
 echo "# all fm-spawn-pool-base-freshen tests passed"

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -355,7 +355,28 @@ test_direct_pr_and_scout_refresh_before_launch
 test_dirty_pool_refuses_without_discarding_work
 test_unresolved_remote_default_refuses_pool
 test_unreachable_origin_refuses_stale_pool_base
+test_local_only_no_origin_scout_refreshes_from_primary() {
+  local rec id out status branch_head primary_tip
+  id='pool-local-only-no-origin-scout-r9'
+  rec=$(make_local_only_no_origin_case local-only-no-origin-scout "$id")
+  read_local_only_case_record "$rec"
+
+  out=$(run_spawn "$id" --scout)
+  status=$?
+  expect_code 0 "$status" "local-only no-origin scout should refresh from the primary local checkout"
+  assert_contains "$out" "spawned $id" "local-only no-origin scout did not report success"
+  assert_not_contains "$out" "could not fetch origin" \
+    "local-only no-origin scout incorrectly attempted an origin fetch"
+
+  primary_tip=$(git -C "$PROJECT_DIR" rev-parse HEAD)
+  branch_head=$(git -C "$POOL_DIR" rev-parse HEAD)
+  [ "$branch_head" = "$primary_tip" ] \
+    || fail "local-only no-origin scout left the pooled worktree off the primary tip"
+  pass "a local-only no-origin scout refreshes from the primary local checkout"
+}
+
 test_local_only_no_origin_refreshes_from_primary
+test_local_only_no_origin_scout_refreshes_from_primary
 test_local_only_no_origin_dirty_refuses_without_discarding_work
 test_non_local_only_no_origin_still_refuses
 

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -2591,7 +2591,45 @@ EOF
   pass "the run abort and the leaked-process reap both complete before the destructive worktree return"
 }
 
+test_ship_open_needs_decision_refuses_even_without_commits() {
+  local case_dir rc
+  case_dir=$(make_case ship-open-decision)
+  write_meta "$case_dir" direct-PR ship
+  printf 'needs-decision: trial-hold payload A or B [key=trial-hold-payload]\n' \
+    > "$case_dir/state/task-x1.status"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  [ "$rc" -ne 0 ] || fail "ship-open-decision: teardown succeeded while needs-decision is open"
+  grep -q 'open captain decision' "$case_dir/stderr" \
+    || fail "ship-open-decision: stderr lacked open-decision refusal: $(cat "$case_dir/stderr")"
+  [ -f "$case_dir/state/task-x1.meta" ] \
+    || fail "ship-open-decision: teardown removed meta despite refusal"
+  pass "ship with open needs-decision refuses teardown even with no commits"
+}
+
+test_ship_open_needs_decision_force_allows() {
+  local case_dir rc
+  case_dir=$(make_case ship-open-decision-force)
+  write_meta "$case_dir" direct-PR ship
+  printf 'needs-decision: trial-hold payload A or B [key=trial-hold-payload]\n' \
+    > "$case_dir/state/task-x1.status"
+
+  set +e
+  run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "ship-open-decision-force: --force should still teardown"
+  pass "ship with open needs-decision can be discarded with --force"
+}
+
 test_local_only_fork_remote_allows
+test_ship_open_needs_decision_refuses_even_without_commits
+test_ship_open_needs_decision_force_allows
 test_teardown_prompts_tasks_axi_done_when_compatible
 test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
 test_local_only_truly_unpushed_refuses


### PR DESCRIPTION
## Why

Two live-lab failures on a no-remote `local-only` project and a later captain-wait:

1. `fm-spawn.sh` always freshened pooled worktrees with `git fetch origin`. A local-only lab with no remotes died before the crew started (`fatal: 'origin' does not appear to be a git repository`). Scouts refuse `--mode`, so they hit the same path even after a local-only ship fix.
2. `fm-teardown.sh` treated a ship that had only created a branch and asked the captain as landed (no commits). It reaped the waiting agent. After `fm-decision-hold.sh complete`, the status fold is empty (captain-held transfer) but the backlog hold is still active — teardown still has to refuse.

## What changed

- **Spawn:** no-origin + (`--mode local-only` or `KIND=scout`) refreshes from the primary local default-branch tip. Origin-backed and no-mistakes no-origin paths unchanged.
- **Classify:** a trailing `[key=slug]` on a `needs-decision` note is a stated key (same as note-head), so `complete`/`verify` inventory the real key instead of `default`.
- **Teardown:** refuse while `status_open_decisions` is non-empty, while the last verb is `needs-decision`/`blocked`, or while `fm-decision-hold.sh has-active` sees a queued+held captain item for that origin. `--force` still discards.

## Tests

- `tests/fm-spawn-pool-base-freshen.test.sh` (incl. local-only no-origin ship + scout)
- `tests/fm-classify-decision-key.test.sh` (trailing `[key=]`)
- `tests/fm-teardown.test.sh` — `test_ship_open_needs_decision_refuses_even_without_commits` and `--force` counterpart

Live: `fm-teardown.sh firstmate-lab-teardown-gate` after `complete` printed `REFUSED: task … still has an active captain-held decision` and left meta in place.

## Out of scope

No Herdr change. No `+yolo`. Does not retire any other orchestrator.