### PR TITLE
fix(fm-lock): match harness via args for versioned/symlinked binaries

### DIFF
--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -25,10 +25,11 @@ harness_pid() {
     if printf '%s' "$(basename "$comm")" | grep -qE "$HARNESS_RE"; then
       echo "$pid"; return 0
     fi
-    # Bare interpreter (e.g. node): match the harness name in its script path.
-    case "$comm" in
-      *node*|*python*) printf '%s' "$args" | grep -qE "$HARNESS_RE" && { echo "$pid"; return 0; } ;;
-    esac
+    # comm alone can miss a harness invoked via a versioned/symlinked binary
+    # (e.g. comm "2.1.233" for a Claude build at .../claude/versions/2.1.233)
+    # or a bare interpreter (e.g. node, python) wrapping the harness script.
+    # args reliably carries the harness name in its path either way.
+    printf '%s' "$args" | grep -qE "$HARNESS_RE" && { echo "$pid"; return 0; }
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
     [ -n "$pid" ] && [ "$pid" -gt 1 ] || return 1
   done


### PR DESCRIPTION
## Summary
- `ps -o comm=` reports a version string (e.g. `2.1.233`) instead of `claude` for a Claude Code harness launched from a versioned binary path (`.../claude/versions/2.1.233`).
- `harness_pid()` only fell back to matching `HARNESS_RE` against `args` when `comm` looked like a bare interpreter (`node`/`python`), so a versioned Claude binary's own harness process could never be found while walking process ancestry.
- This made `bin/fm-lock.sh` always fail with "cannot locate harness process in ancestry", forcing every session-start digest into false read-only mode even when the recorded lock PID was dead.
- Fix: always fall back to checking `args` against `HARNESS_RE`, matching the same comm+args check `holder_alive()` already does a few lines below.

## Test plan
- [x] `bin/fm-lock.sh status` before the fix showed the true state (stale lock, dead PID)
- [x] `bin/fm-lock.sh` (acquire) failed before the fix with the ancestry error
- [x] After the fix, `bin/fm-lock.sh` acquires cleanly and `bin/fm-session-start.sh` runs its full locked digest instead of falling back to read-only