### PR TITLE
fix(bin): launch root Claude workers with sandbox marker

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1111,7 +1111,10 @@ launch_template() {
     # does NOT suppress the interactive ghost text (verified empirically), so the env
     # var is the correct control. The dim-aware composer reader in fm-tmux-lib.sh is
     # the defense-in-depth backstop for any pane this flag cannot reach.
-    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    # Claude Code rejects --dangerously-skip-permissions under root unless the
+    # subprocess is explicitly marked as sandboxed. Keep the marker scoped to
+    # this Claude exec only, and add it only from the worker shell's own UID.
+    claude) printf '%s' '$(if [ "$(id -u)" -eq 0 ]; then printf %s IS_SANDBOX=1; fi) CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     codex)
       if [ "$kind" = secondmate ]; then
         printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -79,6 +79,38 @@ SH
   printf '%s\n' "$fakebin"
 }
 
+make_launch_runtime_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/id" <<'SH'
+#!/usr/bin/env bash
+set -u
+if [ "${1:-}" = -u ]; then
+  printf '%s\n' "${FM_FAKE_ID_U:?}"
+  exit 0
+fi
+exit 1
+SH
+  cat > "$fakebin/claude" <<'SH'
+#!/usr/bin/env bash
+set -u
+{
+  printf 'IS_SANDBOX=%s\n' "${IS_SANDBOX-__unset__}"
+  printf 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=%s\n' "${CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION-__unset__}"
+  printf 'CLAUDE_CONFIG_DIR=%s\n' "${CLAUDE_CONFIG_DIR-__unset__}"
+  printf 'CURSOR_AGENT=%s\n' "${CURSOR_AGENT-__unset__}"
+  printf 'CURSOR_INVOKED_AS=%s\n' "${CURSOR_INVOKED_AS-__unset__}"
+  printf 'argv:'
+  for arg in "$@"; do
+    printf '<%s>' "$arg"
+  done
+  printf '\n'
+} >> "${FM_FAKE_CLAUDE_RUN_LOG:?}"
+SH
+  chmod +x "$fakebin/id" "$fakebin/claude"
+  printf '%s\n' "$fakebin"
+}
+
 make_spawn_case() {
   local name=$1 harness=$2 case_dir home proj wt fakebin launchlog id
   shift 2
@@ -152,6 +184,14 @@ assert_meta_profile() {
   assert_grep "effort=$effort" "$meta" "meta missing effort=$effort"
 }
 
+run_captured_claude_launch() {
+  local launch=$1 uid=$2 runtime_fakebin=$3 runlog=$4
+  : > "$runlog"
+  CURSOR_AGENT=leaked CURSOR_INVOKED_AS=cursor-agent \
+    FM_FAKE_ID_U="$uid" FM_FAKE_CLAUDE_RUN_LOG="$runlog" PATH="$runtime_fakebin:$PATH" \
+    bash -c "$launch"
+}
+
 test_no_profile_keeps_claude_profile_defaults() {
   local rec id out status expected launch
   id=profile-off-z1
@@ -165,7 +205,7 @@ test_no_profile_keeps_claude_profile_defaults() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
+  expected="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS \$(if [ \"\$(id -u)\" -eq 0 ]; then printf %s IS_SANDBOX=1; fi) CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch did not use the canonical launch kind"$'\n'"expected: $expected"$'\n'"actual:   $launch"
   pass "no --model/--effort records defaults and types the claude launch instructions"
 }
@@ -770,7 +810,7 @@ test_claude_forwards_firstmate_config_dir_when_set() {
   status=$?
   expect_code 0 "$status" "claude spawn with CLAUDE_CONFIG_DIR set should succeed"
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "CLAUDE_CONFIG_DIR='/opt/test/claude-work' env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude" \
+  assert_contains "$launch" "CLAUDE_CONFIG_DIR='/opt/test/claude-work' env -u CURSOR_AGENT -u CURSOR_INVOKED_AS \$(if [ \"\$(id -u)\" -eq 0 ]; then printf %s IS_SANDBOX=1; fi) CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude" \
     "claude launch did not forward firstmate's CLAUDE_CONFIG_DIR to the crewmate pane"
   pass "claude forwards firstmate's CLAUDE_CONFIG_DIR so the crewmate uses the same credential store"
 }
@@ -790,6 +830,102 @@ test_claude_omits_config_dir_prefix_when_unset() {
   assert_not_contains "$launch" "CLAUDE_CONFIG_DIR=" \
     "claude launch must not add a config-dir prefix when firstmate has no CLAUDE_CONFIG_DIR set"
   pass "claude omits the config-dir prefix when firstmate runs with the single-store default"
+}
+
+test_claude_root_marker_is_worker_uid_conditioned_for_ship() {
+  local rec id out status launch runtime_fakebin runlog
+  id=profile-claude-root-ship-z20
+  rec=$(make_spawn_case profile-claude-root-ship claude "$id")
+  read_case_record "$rec"
+  runtime_fakebin=$(make_launch_runtime_fakebin "$CASE_DIR/runtime-fakebin")
+  runlog="$CASE_DIR/claude-run.log"
+
+  out=$(CURSOR_AGENT=1 CURSOR_INVOKED_AS=cursor-agent FM_TEST_CLAUDE_CONFIG_DIR="/opt/test/claude-work" \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+      "$id" "$PROJ_DIR" --model sonnet --effort high)
+  status=$?
+  expect_code 0 "$status" "claude ship spawn with model/effort should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "env -u CURSOR_AGENT -u CURSOR_INVOKED_AS \$(if [ \"\$(id -u)\" -eq 0 ]; then printf %s IS_SANDBOX=1; fi)" \
+    "claude launch did not compose the worker-side UID check after Cursor marker clearing"
+  assert_contains "$launch" "claude --dangerously-skip-permissions --model 'sonnet' --effort 'high'" \
+    "claude launch lost model/effort flags around the root marker"
+
+  run_captured_claude_launch "$launch" 0 "$runtime_fakebin" "$runlog" \
+    || fail "captured root claude ship launch failed"
+  assert_grep "IS_SANDBOX=1" "$runlog" "root worker launch did not set IS_SANDBOX"
+  assert_grep "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false" "$runlog" "root worker launch lost the Claude prompt-suggestion env"
+  assert_grep "CLAUDE_CONFIG_DIR=/opt/test/claude-work" "$runlog" "root worker launch lost CLAUDE_CONFIG_DIR"
+  assert_grep "CURSOR_AGENT=__unset__" "$runlog" "root worker launch did not clear CURSOR_AGENT"
+  assert_grep "CURSOR_INVOKED_AS=__unset__" "$runlog" "root worker launch did not clear CURSOR_INVOKED_AS"
+  assert_grep "argv:<--dangerously-skip-permissions><--model><sonnet><--effort><high><" "$runlog" \
+    "root worker launch did not preserve Claude argv ordering"
+
+  run_captured_claude_launch "$launch" 1000 "$runtime_fakebin" "$runlog" \
+    || fail "captured non-root claude ship launch failed"
+  assert_grep "IS_SANDBOX=__unset__" "$runlog" "non-root worker launch must not set IS_SANDBOX"
+  assert_grep "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false" "$runlog" "non-root worker launch lost the Claude prompt-suggestion env"
+  assert_grep "CLAUDE_CONFIG_DIR=/opt/test/claude-work" "$runlog" "non-root worker launch lost CLAUDE_CONFIG_DIR"
+  pass "claude ship launch scopes IS_SANDBOX to root workers while preserving env cleanup, config, model, effort, and brief argv"
+}
+
+test_claude_root_marker_is_worker_uid_conditioned_for_scout() {
+  local rec id out status launch runtime_fakebin runlog
+  id=profile-claude-root-scout-z21
+  rec=$(make_spawn_case profile-claude-root-scout claude "$id")
+  read_case_record "$rec"
+  runtime_fakebin=$(make_launch_runtime_fakebin "$CASE_DIR/runtime-fakebin")
+  runlog="$CASE_DIR/claude-run.log"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" --scout --model opus --effort low)
+  status=$?
+  expect_code 0 "$status" "claude scout spawn with model/effort should succeed"
+  assert_grep "kind=scout" "$HOME_DIR/state/$id.meta" "scout meta missing kind=scout"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "claude --dangerously-skip-permissions --model 'opus' --effort 'low'" \
+    "claude scout launch lost model/effort flags around the root marker"
+
+  run_captured_claude_launch "$launch" 0 "$runtime_fakebin" "$runlog" \
+    || fail "captured root claude scout launch failed"
+  assert_grep "IS_SANDBOX=1" "$runlog" "root scout launch did not set IS_SANDBOX"
+  run_captured_claude_launch "$launch" 1000 "$runtime_fakebin" "$runlog" \
+    || fail "captured non-root claude scout launch failed"
+  assert_grep "IS_SANDBOX=__unset__" "$runlog" "non-root scout launch must not set IS_SANDBOX"
+  pass "claude scout launch applies the same root-only sandbox marker"
+}
+
+test_claude_root_marker_is_worker_uid_conditioned_for_secondmate() {
+  local rec id sm out status launch runtime_fakebin runlog
+  id=profile-claude-root-secondmate-z22
+  rec=$(make_spawn_case profile-claude-root-secondmate codex "$id")
+  read_case_record "$rec"
+  printf '%s\n' "claude opus low" > "$HOME_DIR/config/secondmate-harness"
+  sm="$CASE_DIR/secondmate-home"
+  make_seeded_secondmate_home "$sm" "$id"
+  runtime_fakebin=$(make_launch_runtime_fakebin "$CASE_DIR/runtime-fakebin")
+  runlog="$CASE_DIR/claude-run.log"
+
+  out=$(FM_TEST_CLAUDE_CONFIG_DIR="/opt/test/claude-work" \
+    run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$sm" --secondmate)
+  status=$?
+  expect_code 0 "$status" "claude secondmate spawn with pinned model/effort should succeed"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" claude opus low
+  assert_grep "kind=secondmate" "$HOME_DIR/state/$id.meta" "secondmate meta missing kind=secondmate"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "FM_SUPERVISION_MODEL=autoarm CLAUDE_CONFIG_DIR='/opt/test/claude-work' env -u CURSOR_AGENT -u CURSOR_INVOKED_AS \$(if [ \"\$(id -u)\" -eq 0 ]; then printf %s IS_SANDBOX=1; fi)" \
+    "claude secondmate launch did not preserve secondmate/config/env/root-marker composition"
+  assert_contains "$launch" "claude --dangerously-skip-permissions --model 'opus' --effort 'low'" \
+    "claude secondmate launch lost pinned model/effort flags around the root marker"
+
+  run_captured_claude_launch "$launch" 0 "$runtime_fakebin" "$runlog" \
+    || fail "captured root claude secondmate launch failed"
+  assert_grep "IS_SANDBOX=1" "$runlog" "root secondmate launch did not set IS_SANDBOX"
+  assert_grep "CLAUDE_CONFIG_DIR=/opt/test/claude-work" "$runlog" "root secondmate launch lost CLAUDE_CONFIG_DIR"
+  run_captured_claude_launch "$launch" 1000 "$runtime_fakebin" "$runlog" \
+    || fail "captured non-root claude secondmate launch failed"
+  assert_grep "IS_SANDBOX=__unset__" "$runlog" "non-root secondmate launch must not set IS_SANDBOX"
+  pass "claude secondmate launch applies the same root-only sandbox marker with secondmate prefixes intact"
 }
 
 test_non_claude_harness_ignores_config_dir() {
@@ -855,6 +991,9 @@ test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity
 test_batch_forwards_shared_profile_flags
 test_claude_forwards_firstmate_config_dir_when_set
 test_claude_omits_config_dir_prefix_when_unset
+test_claude_root_marker_is_worker_uid_conditioned_for_ship
+test_claude_root_marker_is_worker_uid_conditioned_for_scout
+test_claude_root_marker_is_worker_uid_conditioned_for_secondmate
 test_non_claude_harness_ignores_config_dir
 test_active_dispatch_profile_does_not_block_secondmate_launch
 

--- a/tests/fm-trace-context-spawn.test.sh
+++ b/tests/fm-trace-context-spawn.test.sh
@@ -50,7 +50,9 @@ case "${1:-}" in
       for a in "$@"; do
         case "$a" in
           "export TRACEPARENT="*)
-            chmod a-w "$FM_FAKE_META_PATH"
+            # A directory at the meta path fails for root and non-root runners.
+            rm -f "$FM_FAKE_META_PATH"
+            mkdir "$FM_FAKE_META_PATH"
             ;;
         esac
       done
@@ -335,7 +337,7 @@ test_failed_metadata_append_unsets_carrier_and_still_launches() {
   assert_contains "$out" "spawned $CASE_ID" "spawn should report success after failed metadata append"
   meta="$HOME_DIR/state/$CASE_ID.meta"
 
-  ! grep -q '^traceparent=' "$meta" \
+  ! grep -q '^traceparent=' "$meta" 2>/dev/null \
     || fail "failed metadata append must not leave a traceparent= claim in meta"
   grep -q '^unset TRACEPARENT; .*claude' "$LAUNCH_LOG" \
     || fail "failed metadata append must unset TRACEPARENT in the launch command"


### PR DESCRIPTION
## Intent

Fix Firstmate's verified Claude harness so autonomous Claude workers can launch on root-operated hosts without weakening non-root behavior. Observed reproduction on this host: fm-spawn.sh emitted `CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions ...`, and Claude Code immediately exited with `--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons`. This estate's supported root launch convention is to set `IS_SANDBOX=1` for that Claude subprocess only.

Accepted requirements: in `bin/fm-spawn.sh`, make the built-in `claude` launch template set `IS_SANDBOX=1` only when the worker-side effective UID is 0, before invoking Claude; do not export it globally; do not modify other harnesses; do not alter existing model/effort/brief encoding behavior. Keep non-root Claude launches semantically unchanged. Prefer a runtime UID check in the generated launch command so behavior is determined in the actual worker shell rather than by the Firstmate caller or CI user. Add/update deterministic regression coverage proving the root marker is applied conditionally and remains correctly composed with `env -u CURSOR_AGENT -u CURSOR_INVOKED_AS`, `CLAUDE_CONFIG_DIR`, model, effort, scout/ship and secondmate launch paths as applicable, with no expectations that change according to the test runner's UID. Add a concise code comment documenting why the marker is narrowly root-scoped. Do not broaden this into a permissions redesign. Do not touch production website repositories or services. Do not merge any PR.

Scope correction: do not ship unrelated pre-existing timing-flake changes merely to make the full suite green. Keep the diff limited to the root-only Claude marker, deterministic directly relevant coverage, and only fixture changes genuinely required for root-independent validation. Record unrelated baseline flakes instead. The gate must verify the runtime shell semantics under the `env -u` prefix, root versus non-root behavior, model/effort/config composition, and whether the `tests/fm-trace-context-spawn.test.sh` fixture change is genuinely required for root-independent validation; if that trace-context fixture change is unrelated, the pipeline should remove it.

## What Changed
- Updates the verified Claude launch template to set `IS_SANDBOX=1` only when the worker shell reports UID 0, keeping the marker scoped to that Claude exec.
- Adds deterministic Claude launch coverage for root and non-root ship, scout, and secondmate paths, including Cursor marker cleanup, `CLAUDE_CONFIG_DIR`, model, and effort composition.
- Makes the trace-context metadata failure fixture root-independent by forcing the meta path to be a directory and suppressing the expected grep error.

## Risk Assessment

✅ Low: The change is narrow, source-scoped to the built-in Claude launch template plus deterministic regression coverage, and I found no material violation of the required root-only behavior.

## Testing

Exercised the focused spawn and trace-context tests, captured an end-to-end fake Claude launch showing UID 0 gets `IS_SANDBOX=1` while UID 1000 does not, and verified the trace fixture change is root-independent on this UID-0 host.

<details>
<summary>Evidence: Claude root marker launch transcript</summary>

Source: [Claude root marker launch transcript](https://github.com/alvarodecamps/firstmate/blob/321e56074b11f32999635fd20d192d51b9caf380/.no-mistakes/evidence/fm/fm-claude-root-sandbox-launch/claude-root-marker-transcript.txt)

```text
captured_launch=CLAUDE_CONFIG_DIR='/opt/test/claude-work' env -u CURSOR_AGENT -u CURSOR_INVOKED_AS $(if [ "$(id -u)" -eq 0 ]; then printf %s IS_SANDBOX=1; fi) CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions --model 'sonnet' --effort 'high' "$('/root/.no-mistakes/worktrees/5f0e0f184814/01M04AZHY60060QZAGZ8Q3ANSX/bin/fm-operational-input.sh' encode launch-brief < '/tmp/fm-claude-root-marker-evidence.LVvhMT/ship/home/data/evidence-claude-root/brief.md')"

worker_uid=0 observed_by_fake_claude
IS_SANDBOX=1
CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false
CLAUDE_CONFIG_DIR=/opt/test/claude-work
CURSOR_AGENT=__unset__
CURSOR_INVOKED_AS=__unset__
argv:<--dangerously-skip-permissions><--model><sonnet><--effort><high><⁣FIRSTMATE_OP: v1 launch-brief: root marker evidence brief>

worker_uid=1000 observed_by_fake_claude
IS_SANDBOX=__unset__
CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false
CLAUDE_CONFIG_DIR=/opt/test/claude-work
CURSOR_AGENT=__unset__
CURSOR_INVOKED_AS=__unset__
argv:<--dangerously-skip-permissions><--model><sonnet><--effort><high><⁣FIRSTMATE_OP: v1 launch-brief: root marker evidence brief>
```
</details>
<details>
<summary>Evidence: Trace-context fixture root-independence check</summary>

Source: [Trace-context fixture root-independence check](https://github.com/alvarodecamps/firstmate/blob/321e56074b11f32999635fd20d192d51b9caf380/.no-mistakes/evidence/fm/fm-claude-root-sandbox-launch/trace-context-fixture-root-independence.txt)

```text
runner_uid=0
append_after_chmod_a_w=success
append_to_directory_meta_path=failure
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"01dfa0b9b8d4b473bbd72f15d6e64420d7b29b30","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-spawn-dispatch-profile.test.sh`
- `bash tests/fm-trace-context-spawn.test.sh`
- `bash > /tmp/no-mistakes-evidence/01M04AZHY60060QZAGZ8Q3ANSX/claude-root-marker-transcript.txt <<'SH' ...`
- `bash > /tmp/no-mistakes-evidence/01M04AZHY60060QZAGZ8Q3ANSX/trace-context-fixture-root-independence.txt <<'SH' ...`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
