### PR TITLE
fix(bin): keep armed pr-merge polls authorized across metadata appends

### DIFF
--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -77,6 +77,9 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 # shellcheck source=bin/fm-wake-lib.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-pr-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-pr-lib.sh"
 
 DECISION_META_LOCK=
 DECISION_META_LOCK_HELD=0
@@ -436,8 +439,13 @@ $open
 EOF
 
   if [ "$has_meta" = 1 ]; then
+    # The attestation is appended, so on a task whose pull request is already
+    # armed it lands after that record. bin/fm-pr-lib.sh's guarded append is what
+    # keeps these two keys declared alongside the poll's parser rather than
+    # quietly invalidating it.
     if [ "$(meta_value "$meta" decisions_reviewed)" != 1 ] || [ "$previous" != "$keys" ]; then
-      printf 'decisions_reviewed=1\ndecision_keys=%s\n' "$keys" >> "$meta"
+      fm_pr_meta_append_records "$meta" decisions_reviewed=1 "decision_keys=$keys" \
+        || fail "could not record the completion attestation in $meta"
     fi
     fm_lock_release "$DECISION_META_LOCK"
     DECISION_META_LOCK_HELD=0

--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -16,6 +16,14 @@
 # after its durable wake is appended.
 # The receipt binds the terminal observation to the canonical registration and
 # lets a restart finish fixed-path removal without executing state-file bytes.
+#
+# bin/fm-pr-check.sh rewrites task metadata with pr= and any pr_head= last, so
+# every later append to that file lands after the armed pull request record.
+# fm_pr_meta_key_appendable is therefore the single owner of which keys any
+# subsystem may add to state/<id>.meta once a poll is armed, and
+# fm_pr_meta_append_records is the write path that enforces it: an appending
+# writer whose key is not declared there is refused at its own write instead of
+# silently disarming the poll it never knew about.
 
 FM_PR_PROVIDER=
 FM_PR_URL=
@@ -285,6 +293,47 @@ fm_pr_regular_destination_on_device_or_absent() {
   [ ! -e "$path" ] || [ "$(fm_pr_file_device "$path")" = "$device" ]
 }
 
+# The keys a subsystem may append to state/<id>.meta after a poll is armed. A
+# key is declared here only because some writer records it after bin/fm-pr-check.sh
+# has moved pr= to the end: pr_head= is the arming owner's own second record,
+# the x_ keys are bin/fm-x-lib.sh's relay link, decisions_reviewed= and
+# decision_keys= are bin/fm-decision-hold.sh's completion attestation, and
+# traceparent= is bin/fm-spawn.sh's relaunch carrier. pr= is deliberately absent:
+# the arming owner rewrites that record and never appends it, so an appended pr=
+# is exactly the ambiguity the parser refuses.
+fm_pr_meta_key_appendable() {
+  case "${1-}" in
+    pr_head|x_request|x_request_ts|x_followups|x_platform|x_reply_max_chars) ;;
+    decisions_reviewed|decision_keys|traceparent) ;;
+    *) return 1 ;;
+  esac
+}
+
+# fm_pr_meta_append_records <meta> <key=value>...: append the given records to an
+# existing task metadata file, refusing the whole write when any key is not
+# declared appendable above. Appending is the one write shape that can land after
+# an armed pr= record, so a writer that wants a new key extends
+# fm_pr_meta_key_appendable in the same change or is refused here. Every record is
+# validated before any is written, so a refusal leaves the file untouched. The
+# caller owns the metadata lock (fm_meta_lock_path) across its read-modify-write.
+fm_pr_meta_append_records() {
+  local meta=$1 record
+  shift
+  [ -f "$meta" ] && [ ! -L "$meta" ] || return 1
+  [ "$#" -gt 0 ] || return 1
+  for record in "$@"; do
+    case "$record" in
+      *$'\n'*|*$'\r'*) return 1 ;;
+      ?*=*) ;;
+      *) return 1 ;;
+    esac
+    fm_pr_meta_key_appendable "${record%%=*}" || return 1
+  done
+  for record in "$@"; do
+    printf '%s\n' "$record" >> "$meta" || return 1
+  done
+}
+
 fm_pr_metadata_identity_parse() {
   local file=$1 line value pr_count=0 seen_pr=0 post_pr_invalid=0
   FM_PR_META_PROVIDER=
@@ -315,10 +364,13 @@ fm_pr_metadata_identity_parse() {
           fm_pr_head_valid "$value" || post_pr_invalid=1
         fi
         ;;
-      x_request=*|x_request_ts=*|x_followups=*|x_platform=*|x_reply_max_chars=*)
-        ;;
       *)
-        [ "$seen_pr" -eq 0 ] || post_pr_invalid=1
+        if [ "$seen_pr" -eq 1 ]; then
+          case "$line" in
+            ?*=*) fm_pr_meta_key_appendable "${line%%=*}" || post_pr_invalid=1 ;;
+            *) post_pr_invalid=1 ;;
+          esac
+        fi
         ;;
     esac
   done < "$file"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2771,9 +2771,12 @@ spawn_record_traceparent() {
   fm_lock_acquire_wait "$SPAWN_META_LOCK"
   SPAWN_META_LOCK_HELD=1
   SPAWN_META_TMP="$STATE/.$ID.meta.trace.${BASHPID:-$$}"
+  # The carrier is re-appended last, so on a task whose pull request is already
+  # armed it lands after that record; bin/fm-pr-lib.sh's guarded append keeps this
+  # key declared alongside the poll's parser rather than quietly invalidating it.
   if [ ! -f "$meta" ] || [ ! -w "$meta" ] \
      || ! awk -F= '$1 != "traceparent"' "$meta" > "$SPAWN_META_TMP" \
-     || ! printf 'traceparent=%s\n' "$SPAWN_TRACEPARENT" >> "$SPAWN_META_TMP" \
+     || ! fm_pr_meta_append_records "$SPAWN_META_TMP" "traceparent=$SPAWN_TRACEPARENT" \
      || ! mv -f "$SPAWN_META_TMP" "$meta"; then
     status=1
     rm -f "$SPAWN_META_TMP" 2>/dev/null || true

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -101,7 +101,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-peek.sh`             | Print a bounded tail of a crewmate endpoint                                          |
 | `fm-check-register.sh`   | Bind an intentional custom watcher check to its current bytes                       |
 | `fm-check-lib.sh`        | Validate custom-check registrations and prepare private execution snapshots          |
-| `fm-pr-lib.sh`           | Own canonical task and PR validation plus private atomic PR-poll publication and identity-bound retirement |
+| `fm-pr-lib.sh`           | Own canonical task and PR validation, the keys a subsystem may append to an armed task's metadata, plus private atomic PR-poll publication and identity-bound retirement |
 | `fm-pr-poll.sh`          | Provide the byte-static watcher program for validated PR/MR-poll sidecars           |
 | `fm-pr-check-migrate.sh` | Quarantine older task polls without execution and rebuild only canonical polls       |
 | `fm-pr-check.sh`         | Record validated `pr=` and `pr_head=` values, then atomically arm a static merge poll |

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -11,6 +11,9 @@ TEARDOWN="$ROOT/bin/fm-teardown.sh"
 BEARINGS="$ROOT/bin/fm-bearings-snapshot.sh"
 TMP_ROOT=$(fm_test_tmproot fm-decision-hold)
 TASKS_AXI_BIN=$(command -v tasks-axi || true)
+# shellcheck source=bin/fm-pr-lib.sh
+# shellcheck disable=SC1091
+. "$ROOT/bin/fm-pr-lib.sh"
 
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
 command -v tasks-axi >/dev/null 2>&1 || { echo "skip: tasks-axi not found"; exit 0; }
@@ -420,6 +423,44 @@ test_terminal_single_owner_status_decision_does_not_block_empty_inventory() {
   pass "terminal single-owner stale status decisions do not block empty inventory"
 }
 
+# The live sequence that lost merge notifications: a ship task's pull request is
+# armed, its decision inventory is completed afterwards, and the completion
+# attestation is appended to the same metadata the merge poll authorizes against.
+# The poll must survive that append, because the watcher stops executing a poll it
+# cannot authorize and the merged pull request then never wakes supervision.
+test_completion_attestation_keeps_an_armed_merge_poll_authorized() {
+  local home id url state
+  home=$(make_home armed-poll-completion)
+  id=sample-armed-ship
+  url=https://github.com/sample-org/sample-repo/pull/10
+  state="$home/state"
+  mkdir -p "$home/data/$id"
+  tasks_in "$home" add "$id" "Ship a sample change" --kind ship --repo sample --start >/dev/null \
+    || fail "could not create the armed-poll backlog fixture"
+  write_origin_meta "$home" "$id" ship
+  printf 'done: change implemented and reviewed\n' > "$state/$id.status"
+
+  PATH="$home/fakebin:$PATH" FM_HOME="$home" FM_STATE_OVERRIDE="$state" \
+    "$ROOT/bin/fm-pr-check.sh" "$id" "$url" >/dev/null 2> "$home/arm.err" \
+    || fail "could not arm the merge poll: $(cat "$home/arm.err")"
+  fm_pr_poll_snapshot_capture "$state" "$id" "$ROOT/bin/fm-pr-poll.sh" \
+    || fail "the freshly armed merge poll did not authorize"
+
+  run_decisions "$home" complete "$id" --none >/dev/null 2> "$home/complete.err" \
+    || fail "completion failed on a task with an armed merge poll: $(cat "$home/complete.err")"
+  assert_grep "decisions_reviewed=1" "$state/$id.meta" "completion attestation missing"
+  assert_grep "pr=$url" "$state/$id.meta" "completion attestation displaced the pull request record"
+  fm_pr_poll_snapshot_capture "$state" "$id" "$ROOT/bin/fm-pr-poll.sh" \
+    || fail "recording a decision inventory disarmed the task's merge poll"
+
+  # A second completion re-appends the attestation when the inventory changes.
+  run_decisions "$home" complete "$id" --none >/dev/null 2> "$home/complete-again.err" \
+    || fail "repeat completion failed: $(cat "$home/complete-again.err")"
+  fm_pr_poll_snapshot_capture "$state" "$id" "$ROOT/bin/fm-pr-poll.sh" \
+    || fail "a repeated decision inventory disarmed the task's merge poll"
+  pass "recording a decision inventory leaves an armed merge poll authorized"
+}
+
 test_secondmate_hold_stays_in_authoritative_home() {
   local parent mate origin hold json
   parent=$(make_home main-routing)
@@ -782,4 +823,5 @@ test_visual_review_uses_shared_completion_owner
 test_none_inventory_and_resolved_prose_do_not_create_holds
 test_terminal_single_owner_status_decision_does_not_block_empty_inventory
 test_secondmate_hold_stays_in_authoritative_home
+test_completion_attestation_keeps_an_armed_merge_poll_authorized
 test_resolve_matches_quoted_blocked_by_edges

--- a/tests/fm-pr-check-security.test.sh
+++ b/tests/fm-pr-check-security.test.sh
@@ -2616,6 +2616,62 @@ SH
   pass "returned custom check descendants are drained on installed and fallback timeout paths"
 }
 
+# bin/fm-pr-check.sh moves pr= to the end of the metadata, so every later append
+# by another subsystem lands after the armed record. Each declared appendable key
+# must therefore leave the poll authorized, and an undeclared one must be refused
+# at the write rather than silently disarming the poll it never knew about.
+test_armed_metadata_appends_keep_the_poll_authorized() {
+  local dir state meta record before
+  dir=$(make_case armed-metadata-appends)
+  state="$dir/home/state"
+  meta="$state/task-a.meta"
+  write_task_meta "$dir"
+  run_check_entry "$dir" task-a https://github.com/o/r/pull/10 >/dev/null 2>/dev/null \
+    || fail "could not arm the merge poll fixture"
+  fm_pr_poll_artifacts_valid "$state" task-a "$POLL" || fail "freshly armed poll did not authorize"
+
+  # Every key some subsystem records after arming: bin/fm-decision-hold.sh's
+  # completion attestation, bin/fm-spawn.sh's relaunch carrier, and
+  # bin/fm-x-lib.sh's relay link.
+  for record in decisions_reviewed=1 decision_keys= decision_keys=access,route \
+    traceparent=00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01 \
+    x_request=r1 x_request_ts=1750000000 x_followups=0 x_platform=x x_reply_max_chars=280; do
+    fm_pr_meta_append_records "$meta" "$record" \
+      || fail "guarded append refused a declared appendable record: $record"
+    fm_pr_poll_artifacts_valid "$state" task-a "$POLL" \
+      || fail "an armed poll was disarmed by a declared appendable record: $record"
+  done
+
+  # An undeclared key is the second-writer case: it must be refused before the
+  # file changes, so the poll cannot be disarmed by a writer that never extended
+  # the parser's declared set.
+  before=$(shasum -a 256 "$meta" | awk '{print $1}')
+  for record in future_subsystem=1 window=unexpected-after-pr pr=https://github.com/o/r/pull/11 \
+    x_requests=1 decision_keysx=1 pr_headx=1 'decision_keys=a
+future_subsystem=1' bare-line =novalue; do
+    ! fm_pr_meta_append_records "$meta" "$record" \
+      || fail "guarded append accepted an undeclared or malformed record: $record"
+    [ "$(shasum -a 256 "$meta" | awk '{print $1}')" = "$before" ] \
+      || fail "a refused append still changed task metadata: $record"
+  done
+  ! fm_pr_meta_append_records "$meta" decisions_reviewed=1 future_subsystem=1 \
+    || fail "guarded append accepted a batch carrying an undeclared record"
+  [ "$(shasum -a 256 "$meta" | awk '{print $1}')" = "$before" ] \
+    || fail "a refused batch append still changed task metadata"
+  fm_pr_poll_artifacts_valid "$state" task-a "$POLL" \
+    || fail "refused appends disarmed the poll"
+
+  # A writer that bypasses the guarded append must still not be tolerated: the
+  # parser's strictness about unknown records after pr= is what stops an appended
+  # record being read as part of the pull request identity.
+  printf 'future_subsystem=1\n' >> "$meta"
+  ! fm_pr_metadata_identity_parse "$meta" \
+    || fail "parser tolerated an undeclared record appended after the pull request"
+  ! fm_pr_poll_artifacts_valid "$state" task-a "$POLL" \
+    || fail "poll authorization tolerated an undeclared record after the pull request"
+  pass "declared metadata appends keep an armed poll authorized and undeclared ones are refused"
+}
+
 test_teardown_removes_poll_artifacts() {
   local dir fakebin kind artifact counterpart rc
   dir=$(make_case teardown-cleanup)
@@ -3391,4 +3447,5 @@ test_bootstrap_migrates_before_other_mutations
 test_bootstrap_isolates_incomplete_poll_migration
 test_custom_snapshot_cleanup_on_signal
 test_returned_custom_check_descendants_are_drained
+test_armed_metadata_appends_keep_the_poll_authorized
 test_teardown_removes_poll_artifacts


### PR DESCRIPTION
## Intent

Fix a confirmed supervision-integrity defect in firstmate: an armed pull-request merge poll is silently and permanently disarmed by a later append to the same task's metadata file, so a merged PR never wakes supervision. fm_pr_metadata_identity_parse in bin/fm-pr-lib.sh only accepted pr_head= and five x_* keys after the pr= line and rejected the whole record otherwise; bin/fm-decision-hold.sh appends decisions_reviewed= and decision_keys= to that same file when a decision-hold completion is recorded, which disarms the poll. Observed live on 2026-08-16.

The user required: reproduce it first as a failing test before changing anything; choose between two candidate fixes (extend the allowlist, or move the decision-hold fields to a separate sidecar file), implement the one that can be defended, and say in the PR why the other was rejected; and explicitly NOT weaken the parser by making it tolerate arbitrary unknown keys after pr= - that strictness is deliberate, it is what stops a tampered or appended metadata record redirecting a poll at a different pull request, and relaxing it would trade a missed notification for a security property. The user also required that a second writer adding a new post-pr= key cannot silently reintroduce the defect, and that this property be testable and tested.

Decisions made while doing the work, all approved by the user:
- Option 1 (extend the allowlist) was implemented; the sidecar option was rejected because state/<id>.meta already has several appending writers (pr_head, five x_* keys, decision-hold's two keys, and traceparent), so a sidecar removes one instance of the class rather than the class, would have left the traceparent instance live, and would have changed the decision-hold record contract and every reader of those two keys.
- While reproducing, a second live instance of the same defect was found and deliberately pulled into scope: bin/fm-spawn.sh's spawn_record_traceparent re-appends traceparent= on relaunch and disarms an armed poll identically. The user confirmed this was in scope because it is the same defect.
- Rather than documenting the allowlist, the requirement is enforced: the allowlist moved into fm_pr_meta_key_appendable as its single owner, and fm_pr_meta_append_records validates every record against that one declaration before writing any of them. Both appending writers now go through it, so a writer adding a key without declaring it is refused at its own write, and a writer bypassing the helper still cannot make the parser tolerate the record. The parser's strictness itself is unchanged and pr= is deliberately not appendable.
- No behavior change to what a poll actually targets or reports.

Both new tests drive real behavior through the executables and public interfaces, never implementation source bytes, and extend existing colocated tests/<subject>.test.sh scripts. The live cross-subsystem sequence test was verified to fail on base commit 7a3259e with exactly the assertion it is meant to pin.

Known pre-existing flake, explicitly not addressed here and explicitly not to be "fixed" by changing timing: tests/fm-pr-check-security.test.sh's bounded watcher cases (perl ... alarm 10) are load-sensitive. On unmodified base commit 7a3259e, two consecutive runs on this machine (2 CPUs, load average 4.89) both aborted with "not ok - merged retirement watcher failed:" and empty stderr, and a separate run failed the same way with "not ok - receipt recovery watcher failed:". The new assertions in that file pass in isolation. The user instructed that this flake be recorded in the PR body with that base-commit evidence, and that if the gate itself trips on the flake the run stop and report the exact failure rather than retry blind or widen the timing - that call is the user's, not the agent's. It is recorded in the commit message for that reason.

Repo conventions that apply: one sentence per line in tracked Markdown, plain dash never an em dash, one owner per contract (patch the owner's existing language rather than appending a parallel clause), bin/fm-lint.sh must pass, and no agent name as a commit co-author.

## What Changed

- Add `fm_pr_meta_key_appendable` in `bin/fm-pr-lib.sh` as the single owner of which keys may be appended to `state/<id>.meta` after a poll is armed (the existing `pr_head=` and `x_*` keys, plus `decisions_reviewed=`, `decision_keys=`, and `traceparent=`), and `fm_pr_meta_append_records` as the enforced write path: it validates every record against that allowlist before writing any of them, refusing the whole write on an undeclared key.
- Route `bin/fm-decision-hold.sh`'s completion-attestation append and `bin/fm-spawn.sh`'s `spawn_record_traceparent` relaunch-carrier append through `fm_pr_meta_append_records`, replacing their direct `>>` writes; `fm_pr_metadata_identity_parse`'s post-`pr=` line handling now defers to `fm_pr_meta_key_appendable` instead of a hardcoded case list, with `pr=` itself deliberately excluded from the allowlist.
- Add regression tests: `tests/fm-decision-hold-lifecycle.test.sh` gains a test that a completion attestation keeps an armed merge poll authorized, and `tests/fm-pr-check-security.test.sh` gains `test_armed_metadata_appends_keep_the_poll_authorized`, which was verified to fail on base commit 7a3259e with the exact assertion it pins.
- Update `docs/scripts.md`'s description of `fm-pr-lib.sh` to mention its new role owning the appendable-key allowlist.

Two fix candidates were considered: extending the allowlist (implemented) versus moving decision-hold's fields to a separate sidecar file. The sidecar was rejected because `state/<id>.meta` already has several appending writers beyond decision-hold (`pr_head=`, five `x_*` keys, and `traceparent=`), so a sidecar would remove only one instance of the defect class, leave the `traceparent=` instance live, and change the decision-hold record contract along with every reader of those two keys. A second live instance of the same defect, in `bin/fm-spawn.sh`'s traceparent relaunch carrier, was found during reproduction and pulled into this fix as the same defect. The parser's post-`pr=` strictness is otherwise unchanged: `pr=` remains non-appendable, so a tampered or appended `pr=` record is still refused.

Known pre-existing flake, not addressed here: `tests/fm-pr-check-security.test.sh`'s bounded watcher cases (`perl ... alarm 10`) are load-sensitive. On unmodified base commit 7a3259e, two consecutive runs on this machine (2 CPUs, load average 4.89) both aborted with `not ok - merged retirement watcher failed:` and empty stderr, and a separate run failed the same way with `not ok - receipt recovery watcher failed:`. The new assertions in that file pass in isolation.

## Risk Assessment

✅ Low: The fix correctly moves the appendable-key allowlist into a single-owner function (fm_pr_meta_key_appendable) enforced by a validate-before-write helper (fm_pr_meta_append_records); both new appending writers (decision-hold, spawn) now go through it, the parser's strictness against unknown post-pr= keys is unchanged, and the two new tests exercise real behavior through the public executables/functions and cover the declared-key, undeclared-key, batch-refusal, and bypass-still-rejected cases as required.

## Testing

Ran the two colocated tests added for this fix against the target commit: the full fm-decision-hold-lifecycle suite (end-to-end through real fm-pr-check.sh/fm-decision-hold.sh executables) and a targeted single-test extraction from fm-pr-check-security.test.sh (to avoid the documented pre-existing unrelated watcher flake in that file); both new tests pass, demonstrating an armed merge poll survives appends from every real writer (decision-hold attestation, spawn traceparent, x-lib relay keys) while an undeclared key is refused at the write and the parser still rejects an appended unknown key that bypasses the guard, satisfying both the required fix and the required non-weakening constraint. No product-level defects found; the pre-existing bounded-watcher flake in fm-pr-check-security.test.sh was intentionally avoided by extracting only the new test rather than running the whole file, per the user's own note that it is a known, unaddressed, load-sensitive flake unrelated to this change.

<details>
<summary>Evidence: fm-decision-hold-lifecycle.test.sh full run (target commit adbd32c)</summary>

```text
ok - report-only unresolved decision is reproduced and completion refuses before loss
ok - non-forced scout teardown always requires durable inventory verification
ok - a declined decision closes with a recorded answer and no routed work
ok - a decision closed outside the script is repairable and then clears teardown
ok - an unanswered decision still blocks completion and resists both unrouted close paths
ok - captain holds are idempotent, distinct, teardown-safe, Bearings-visible, and durably routed before close
ok - completion and verification validate origins before constructing paths
ok - ended visual review follows the same decision-hold completion owner
ok - resolved findings and decision-like prose do not create false holds
ok - terminal single-owner stale status decisions do not block empty inventory
ok - main-home and secondmate-home captain holds remain correctly routed
ok - recording a decision inventory leaves an armed merge poll authorized
ok - resolve matches first/middle/last in quoted blocked_by and rejects a genuinely absent id
```
</details>
<details>
<summary>Evidence: Targeted run of test_armed_metadata_appends_keep_the_poll_authorized</summary>

```text
ok - declared metadata appends keep an armed poll authorized and undeclared ones are refused
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `tests/fm-decision-hold-lifecycle.test.sh:462` - The comment above the second `run_decisions ... complete ... --none` call claims it &#39;re-appends the attestation when the inventory changes,&#39; but both calls pass --none so `keys` is empty both times and `previous == keys` with `decisions_reviewed` already 1 - the guard at bin/fm-decision-hold.sh:439 skips the write entirely on the second call. The test still validates a legitimate case (a repeated completion doesn&#39;t disarm the poll), but does not exercise an actual re-append with changed decision_keys as the comment implies.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-decision-hold-lifecycle.test.sh` at target commit adbd32c — all 13 tests pass, including `test_completion_attestation_keeps_an_armed_merge_poll_authorized`</code>
- <code>Targeted extraction of `tests/fm-pr-check-security.test.sh` (function defs + single call to `test_armed_metadata_appends_keep_the_poll_authorized`), run via `bash /tmp/.../fm-pr-check-security.targeted.test.sh` — passes</code>
- `Reviewed diff of bin/fm-pr-lib.sh, bin/fm-decision-hold.sh, bin/fm-spawn.sh, docs/scripts.md to confirm both appending writers route through the new fm_pr_meta_append_records/fm_pr_meta_key_appendable single-owner allowlist, and that fm_pr_metadata_identity_parse's post-pr= strictness is otherwise unchanged`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
