### PR TITLE
feat(bin): safely retire task records without teardown

### DIFF
--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -35,7 +35,7 @@ if [ -r "$_FM_CLASSIFY_LIB_DIR/fm-record-retire-lib.sh" ]; then
 else
   # A partial-bin recovery copy has no retirement-marker authority.
   # Treat every marker as inert so status remains visible.
-  fm_record_retire_marker_valid() { return 1; }
+  fm_record_retire_marker_active() { return 1; }
 fi
 
 # The crew current-state reader used for the "provably working" decision.
@@ -371,7 +371,7 @@ scan_open_decisions() {  # <state>
   for f in "$state"/*.status; do
     [ -e "$f" ] || continue
     task=$(basename "$f"); task="${task%.status}"
-    fm_record_retire_marker_valid "$state" "$task" && continue
+    fm_record_retire_marker_active "$state" "$task" && continue
     open=$(status_open_decisions "$f") || continue
     [ -n "$open" ] || continue
     while IFS= read -r line; do
@@ -610,7 +610,7 @@ scan_open_decisions_incremental() {  # <state>
   for f in "$state"/*.status; do
     [ -e "$f" ] || continue
     task=$(basename "$f"); task="${task%.status}"
-    fm_record_retire_marker_valid "$state" "$task" && continue
+    fm_record_retire_marker_active "$state" "$task" && continue
     open=$(status_open_decisions_incremental "$f") || continue
     [ -n "$open" ] || continue
     while IFS= read -r line; do
@@ -629,7 +629,7 @@ status_presentation_snapshot() {  # <state>
     [ -e "$f" ] || continue
     [ -f "$f" ] && [ -r "$f" ] && [ ! -L "$f" ] || continue
     task=$(basename "$f"); task="${task%.status}"
-    fm_record_retire_marker_valid "$state" "$task" && continue
+    fm_record_retire_marker_active "$state" "$task" && continue
     size=$(_fm_status_file_size "$f") || return 1
     size=${size//[[:space:]]/}
     ident=$(_fm_open_decisions_file_ident "$f") || return 1
@@ -1202,7 +1202,7 @@ scan_captain_relevant_statuses() {  # <state>
   for f in "$state"/*.status; do
     [ -e "$f" ] || continue
     task=$(basename "$f"); task="${task%.status}"
-    fm_record_retire_marker_valid "$state" "$task" && continue
+    fm_record_retire_marker_active "$state" "$task" && continue
     last=$(last_status_line "$f")
     status_is_captain_relevant "$last" || continue
     printf '%s\t%s\t%s\n' "$f" "$task" "$last"

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -29,6 +29,8 @@
 # Resolved at source time from BASH_SOURCE so it works whether sourced by a
 # bin/ script (which sets its own SCRIPT_DIR) or directly by a test.
 _FM_CLASSIFY_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null)" || _FM_CLASSIFY_LIB_DIR="."
+# shellcheck source=bin/fm-record-retire-lib.sh
+. "$_FM_CLASSIFY_LIB_DIR/fm-record-retire-lib.sh"
 
 # The crew current-state reader used for the "provably working" decision.
 # Overridable so tests can stub the run-step/pane verdict without a real worktree
@@ -363,6 +365,7 @@ scan_open_decisions() {  # <state>
   for f in "$state"/*.status; do
     [ -e "$f" ] || continue
     task=$(basename "$f"); task="${task%.status}"
+    fm_record_retire_marker_valid "$state" "$task" && continue
     open=$(status_open_decisions "$f") || continue
     [ -n "$open" ] || continue
     while IFS= read -r line; do
@@ -601,6 +604,7 @@ scan_open_decisions_incremental() {  # <state>
   for f in "$state"/*.status; do
     [ -e "$f" ] || continue
     task=$(basename "$f"); task="${task%.status}"
+    fm_record_retire_marker_valid "$state" "$task" && continue
     open=$(status_open_decisions_incremental "$f") || continue
     [ -n "$open" ] || continue
     while IFS= read -r line; do
@@ -619,6 +623,7 @@ status_presentation_snapshot() {  # <state>
     [ -e "$f" ] || continue
     [ -f "$f" ] && [ -r "$f" ] && [ ! -L "$f" ] || continue
     task=$(basename "$f"); task="${task%.status}"
+    fm_record_retire_marker_valid "$state" "$task" && continue
     size=$(_fm_status_file_size "$f") || return 1
     size=${size//[[:space:]]/}
     ident=$(_fm_open_decisions_file_ident "$f") || return 1
@@ -1190,9 +1195,10 @@ scan_captain_relevant_statuses() {  # <state>
   local state=$1 f last task
   for f in "$state"/*.status; do
     [ -e "$f" ] || continue
+    task=$(basename "$f"); task="${task%.status}"
+    fm_record_retire_marker_valid "$state" "$task" && continue
     last=$(last_status_line "$f")
     status_is_captain_relevant "$last" || continue
-    task=$(basename "$f"); task="${task%.status}"
     printf '%s\t%s\t%s\n' "$f" "$task" "$last"
   done
   return 0

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -30,7 +30,13 @@
 # bin/ script (which sets its own SCRIPT_DIR) or directly by a test.
 _FM_CLASSIFY_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null)" || _FM_CLASSIFY_LIB_DIR="."
 # shellcheck source=bin/fm-record-retire-lib.sh
-. "$_FM_CLASSIFY_LIB_DIR/fm-record-retire-lib.sh"
+if [ -r "$_FM_CLASSIFY_LIB_DIR/fm-record-retire-lib.sh" ]; then
+  . "$_FM_CLASSIFY_LIB_DIR/fm-record-retire-lib.sh"
+else
+  # A partial-bin recovery copy has no retirement-marker authority.
+  # Treat every marker as inert so status remains visible.
+  fm_record_retire_marker_valid() { return 1; }
+fi
 
 # The crew current-state reader used for the "provably working" decision.
 # Overridable so tests can stub the run-step/pane verdict without a real worktree

--- a/bin/fm-push-transition-lib.sh
+++ b/bin/fm-push-transition-lib.sh
@@ -108,10 +108,6 @@ wake() {
   exit 0
 }
 
-_hb_surfaced_path() {
-  printf '%s/.hb-surfaced-%s' "$STATE" "$(printf '%s' "$1" | tr ':/.' '___')"
-}
-
 # Record a captain-relevant status after its durable wake has been enqueued.
 mark_surfaced() {  # <status-file>
   local f=$1 task last
@@ -119,7 +115,7 @@ mark_surfaced() {  # <status-file>
   last=$(last_status_line "$f")
   [ -n "$last" ] || return 0
   status_is_captain_relevant "$last" || return 0
-  printf '%s' "$last" > "$(_hb_surfaced_path "$task")"
+  printf '%s' "$last" > "$(fm_wake_hb_surfaced_path "$STATE" "$task")"
 }
 
 # Act on a fresh actionable transition from a push-capable backend.

--- a/bin/fm-record-retire-lib.sh
+++ b/bin/fm-record-retire-lib.sh
@@ -75,6 +75,14 @@ fm_record_retire_marker_active() {  # <state-dir> <task-id>
   [ ! -e "$meta" ] && [ ! -L "$meta" ]
 }
 
+fm_record_retire_watcher_state_key() {  # <window>
+  local key=$1
+  key=${key//:/_}
+  key=${key//\//_}
+  key=${key//./_}
+  printf '%s' "$key"
+}
+
 fm_record_retire_marker_publish() {  # <state-dir> <task-id> <window> <meta-sha256>
   local state=$1 id=$2 window=$3 digest=$4 marker tmp old_umask
   fm_record_retire_id_valid "$id" || return 1

--- a/bin/fm-record-retire-lib.sh
+++ b/bin/fm-record-retire-lib.sh
@@ -83,6 +83,49 @@ fm_record_retire_watcher_state_key() {  # <window>
   printf '%s' "$key"
 }
 
+fm_record_retire_window_collision() {  # <target-window> <other-window>
+  local target=$1 other=$2 target_key other_key
+  if [ "$other" = "$target" ]; then
+    printf 'raw'
+    return 0
+  fi
+  target_key=$(fm_record_retire_watcher_state_key "$target")
+  other_key=$(fm_record_retire_watcher_state_key "$other")
+  [ "$other_key" = "$target_key" ] || return 1
+  printf 'collapsed'
+}
+
+fm_record_retire_artifact_paths() {  # <state-dir> <task-id> <window>
+  local state=$1 id=$2 window=$3 key prefix
+  printf '%s\n' \
+    "$state/$id.status" \
+    "$state/$id.turn-ended" \
+    "$state/$id.pi-ext.ts" \
+    "$state/$id.grok-turnend-token" \
+    "$state/$id.kimi-turnend-token" \
+    "$state/$id.muse-session" \
+    "$state/$id.muse-session-current" \
+    "$state/$id.cursor-session" \
+    "$state/$id.control-relaunch" \
+    "$state/$id.control-relaunch.meta-prior" \
+    "$state/$id.control-relaunch.brief-prior" \
+    "$state/$id.control-relaunch.note" \
+    "$state/$id.herdr-presentation" \
+    "$state/$id.busy-gen" \
+    "$state/$id.busy-state" \
+    "$state/$id.check.sh" \
+    "$state/$id.check-trust" \
+    "$state/$id.pr-poll" \
+    "$state/$id.pr-poll-registration" \
+    "$state/$id.pr-poll-retirement" \
+    "$state/.$id.open-decisions-cursor"
+  fm_wake_task_surface_paths "$state" "$id"
+  key=$(fm_record_retire_watcher_state_key "$window")
+  for prefix in hash count stale stale-since paused paused-rechecked paused-resurfaced wedge-escalations; do
+    printf '%s/.%s-%s\n' "$state" "$prefix" "$key"
+  done
+}
+
 fm_record_retire_marker_publish() {  # <state-dir> <task-id> <window> <meta-sha256>
   local state=$1 id=$2 window=$3 digest=$4 marker tmp old_umask
   fm_record_retire_id_valid "$id" || return 1

--- a/bin/fm-record-retire-lib.sh
+++ b/bin/fm-record-retire-lib.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Shared record-retirement marker contract.
+#
+# A successful state-only retirement leaves one fixed-path marker at
+# state/.record-retired-<task-id> so a still-live, deliberately untouched agent
+# cannot recreate supervision by writing its old status or turn-end path.
+# The marker is not task metadata and does not authorize endpoint, process,
+# branch, project, or working-copy access.
+#
+# Format (exactly four lines):
+#   schema=fm-record-retired.v1
+#   task_id=<privacy-safe task id>
+#   window=<recorded runtime target>
+#   meta_sha256=<lowercase sha256 of the retired metadata bytes>
+#
+# The watcher suppresses only a regular, non-symlink marker with this exact
+# shape and task binding.
+# An invalid marker is inert, so corruption fails toward surfacing work.
+
+FM_RECORD_RETIRED_SCHEMA=fm-record-retired.v1
+
+fm_record_retire_id_valid() {
+  local id=${1:-}
+  case "$id" in
+    ''|.*|*[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+}
+
+fm_record_retire_marker_path() {  # <state-dir> <task-id>
+  printf '%s/.record-retired-%s\n' "$1" "$2"
+}
+
+fm_record_retire_sha256_file() {  # <file>
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    return 1
+  fi
+}
+
+fm_record_retire_marker_valid() {  # <state-dir> <task-id>
+  local state=$1 id=$2 marker schema task window digest lines
+  fm_record_retire_id_valid "$id" || return 1
+  marker=$(fm_record_retire_marker_path "$state" "$id")
+  [ -f "$marker" ] && [ -r "$marker" ] && [ ! -L "$marker" ] || return 1
+  lines=$(LC_ALL=C wc -l < "$marker" 2>/dev/null) || return 1
+  lines=${lines//[[:space:]]/}
+  [ "$lines" = 4 ] || return 1
+  schema=$(sed -n '1s/^schema=//p' "$marker")
+  task=$(sed -n '2s/^task_id=//p' "$marker")
+  window=$(sed -n '3s/^window=//p' "$marker")
+  digest=$(sed -n '4s/^meta_sha256=//p' "$marker")
+  [ "$schema" = "$FM_RECORD_RETIRED_SCHEMA" ] || return 1
+  [ "$task" = "$id" ] || return 1
+  [ -n "$window" ] || return 1
+  case "$window" in *$'\t'*|*$'\r'*|*$'\n'*) return 1 ;; esac
+  [[ "$digest" =~ ^[0-9a-f]{64}$ ]] || return 1
+}
+
+fm_record_retire_marker_window() {  # <state-dir> <task-id>
+  local marker
+  fm_record_retire_marker_valid "$1" "$2" || return 1
+  marker=$(fm_record_retire_marker_path "$1" "$2")
+  sed -n '3s/^window=//p' "$marker"
+}
+
+fm_record_retire_marker_publish() {  # <state-dir> <task-id> <window> <meta-sha256>
+  local state=$1 id=$2 window=$3 digest=$4 marker tmp old_umask
+  fm_record_retire_id_valid "$id" || return 1
+  [ -n "$window" ] || return 1
+  case "$window" in *$'\t'*|*$'\r'*|*$'\n'*) return 1 ;; esac
+  [[ "$digest" =~ ^[0-9a-f]{64}$ ]] || return 1
+  marker=$(fm_record_retire_marker_path "$state" "$id")
+  tmp="$marker.tmp.${BASHPID:-$$}"
+  if [ -e "$marker" ] || [ -L "$marker" ]; then
+    fm_record_retire_marker_valid "$state" "$id" || return 1
+    [ "$(fm_record_retire_marker_window "$state" "$id")" = "$window" ] || return 1
+    [ "$(sed -n '4s/^meta_sha256=//p' "$marker")" = "$digest" ] || return 1
+    return 0
+  fi
+  old_umask=$(umask)
+  umask 077
+  {
+    printf 'schema=%s\n' "$FM_RECORD_RETIRED_SCHEMA"
+    printf 'task_id=%s\n' "$id"
+    printf 'window=%s\n' "$window"
+    printf 'meta_sha256=%s\n' "$digest"
+  } > "$tmp" || { rm -f -- "$tmp"; umask "$old_umask"; return 1; }
+  chmod 0600 "$tmp" || { rm -f -- "$tmp"; umask "$old_umask"; return 1; }
+  mv -f -- "$tmp" "$marker" || { rm -f -- "$tmp"; umask "$old_umask"; return 1; }
+  umask "$old_umask"
+  fm_record_retire_marker_valid "$state" "$id"
+}
+
+fm_record_retire_marker_clear_for_spawn() {  # <state-dir> <task-id>
+  local marker
+  marker=$(fm_record_retire_marker_path "$1" "$2")
+  [ -e "$marker" ] || [ -L "$marker" ] || return 0
+  fm_record_retire_marker_valid "$1" "$2" || {
+    printf 'error: invalid record-retirement marker for task %s; refusing spawn\n' "$2" >&2
+    return 1
+  }
+  rm -f -- "$marker"
+}
+
+fm_record_retire_wake_muted() {  # <state-dir> <kind> <key>
+  local state=$1 kind=$2 key=$3 id marker window
+  case "$kind" in
+    signal)
+      case "$key" in
+        *.status) id=${key%.status} ;;
+        *.turn-ended) id=${key%.turn-ended} ;;
+        *) return 1 ;;
+      esac
+      fm_record_retire_marker_valid "$state" "$id"
+      ;;
+    check)
+      case "$key" in
+        "$state"/*.check.sh) id=${key##*/}; id=${id%.check.sh} ;;
+        *) return 1 ;;
+      esac
+      fm_record_retire_marker_valid "$state" "$id"
+      ;;
+    stale)
+      for marker in "$state"/.record-retired-*; do
+        [ -e "$marker" ] || continue
+        id=${marker##*/.record-retired-}
+        fm_record_retire_marker_valid "$state" "$id" || continue
+        window=$(fm_record_retire_marker_window "$state" "$id") || continue
+        [ "$window" = "$key" ] && return 0
+      done
+      return 1
+      ;;
+    *) return 1 ;;
+  esac
+}

--- a/bin/fm-record-retire-lib.sh
+++ b/bin/fm-record-retire-lib.sh
@@ -13,8 +13,9 @@
 #   window=<recorded runtime target>
 #   meta_sha256=<lowercase sha256 of the retired metadata bytes>
 #
-# The watcher suppresses only a regular, non-symlink marker with this exact
-# shape and task binding.
+# The watcher suppresses only id-keyed signal and check wakes for a regular,
+# non-symlink marker with this exact shape and task binding.
+# Slot-keyed stale wakes are never marker-muted because they carry no task id.
 # An invalid marker is inert, so corruption fails toward surfacing work.
 
 FM_RECORD_RETIRED_SCHEMA=fm-record-retired.v1
@@ -106,7 +107,7 @@ fm_record_retire_marker_clear_for_spawn() {  # <state-dir> <task-id>
 }
 
 fm_record_retire_wake_muted() {  # <state-dir> <kind> <key>
-  local state=$1 kind=$2 key=$3 id marker window
+  local state=$1 kind=$2 key=$3 id
   case "$kind" in
     signal)
       case "$key" in
@@ -123,16 +124,10 @@ fm_record_retire_wake_muted() {  # <state-dir> <kind> <key>
       esac
       fm_record_retire_marker_valid "$state" "$id"
       ;;
-    stale)
-      for marker in "$state"/.record-retired-*; do
-        [ -e "$marker" ] || continue
-        id=${marker##*/.record-retired-}
-        fm_record_retire_marker_valid "$state" "$id" || continue
-        window=$(fm_record_retire_marker_window "$state" "$id") || continue
-        [ "$window" = "$key" ] && return 0
-      done
-      return 1
-      ;;
+    # A stale wake is keyed only by a runtime slot and carries no task id.
+    # It can never be attributed safely to one retired record, so markers do
+    # not mute it.
+    stale) return 1 ;;
     *) return 1 ;;
   esac
 }

--- a/bin/fm-record-retire-lib.sh
+++ b/bin/fm-record-retire-lib.sh
@@ -13,8 +13,9 @@
 #   window=<recorded runtime target>
 #   meta_sha256=<lowercase sha256 of the retired metadata bytes>
 #
-# The watcher suppresses only id-keyed signal and check wakes for a regular,
-# non-symlink marker with this exact shape and task binding.
+# Consumers suppress only after canonical metadata is absent and an id-keyed
+# signal or check wake has a regular, non-symlink marker with this exact shape
+# and task binding.
 # Slot-keyed stale wakes are never marker-muted because they carry no task id.
 # An invalid marker is inert, so corruption fails toward surfacing work.
 
@@ -67,6 +68,13 @@ fm_record_retire_marker_window() {  # <state-dir> <task-id>
   sed -n '3s/^window=//p' "$marker"
 }
 
+fm_record_retire_marker_active() {  # <state-dir> <task-id>
+  local state=$1 id=$2 meta
+  fm_record_retire_marker_valid "$state" "$id" || return 1
+  meta="$state/$id.meta"
+  [ ! -e "$meta" ] && [ ! -L "$meta" ]
+}
+
 fm_record_retire_marker_publish() {  # <state-dir> <task-id> <window> <meta-sha256>
   local state=$1 id=$2 window=$3 digest=$4 marker tmp old_umask
   fm_record_retire_id_valid "$id" || return 1
@@ -115,14 +123,14 @@ fm_record_retire_wake_muted() {  # <state-dir> <kind> <key>
         *.turn-ended) id=${key%.turn-ended} ;;
         *) return 1 ;;
       esac
-      fm_record_retire_marker_valid "$state" "$id"
+      fm_record_retire_marker_active "$state" "$id"
       ;;
     check)
       case "$key" in
         "$state"/*.check.sh) id=${key##*/}; id=${id%.check.sh} ;;
         *) return 1 ;;
       esac
-      fm_record_retire_marker_valid "$state" "$id"
+      fm_record_retire_marker_active "$state" "$id"
       ;;
     # A stale wake is keyed only by a runtime slot and carries no task id.
     # It can never be attributed safely to one retired record, so markers do

--- a/bin/fm-record-retire-lib.sh
+++ b/bin/fm-record-retire-lib.sh
@@ -154,7 +154,7 @@ fm_record_retire_marker_publish() {  # <state-dir> <task-id> <window> <meta-sha2
   fm_record_retire_marker_valid "$state" "$id"
 }
 
-fm_record_retire_marker_clear_for_spawn() {  # <state-dir> <task-id>
+fm_record_retire_marker_validate_for_spawn() {  # <state-dir> <task-id>
   local marker
   marker=$(fm_record_retire_marker_path "$1" "$2")
   [ -e "$marker" ] || [ -L "$marker" ] || return 0
@@ -162,6 +162,13 @@ fm_record_retire_marker_clear_for_spawn() {  # <state-dir> <task-id>
     printf 'error: invalid record-retirement marker for task %s; refusing spawn\n' "$2" >&2
     return 1
   }
+}
+
+fm_record_retire_marker_clear_for_spawn() {  # <state-dir> <task-id>
+  local marker
+  fm_record_retire_marker_validate_for_spawn "$1" "$2" || return 1
+  marker=$(fm_record_retire_marker_path "$1" "$2")
+  [ -e "$marker" ] || [ -L "$marker" ] || return 0
   rm -f -- "$marker"
 }
 

--- a/bin/fm-record-retire.sh
+++ b/bin/fm-record-retire.sh
@@ -196,14 +196,6 @@ meta_file_exact() {  # <metadata-path> <key>
   printf '%s' "$value"
 }
 
-watcher_state_key() {  # <window>
-  local key=$1
-  key=${key//:/_}
-  key=${key//\//_}
-  key=${key//./_}
-  printf '%s' "$key"
-}
-
 STATE_DEVICE=$(fm_pr_file_device "$STATE") || refuse "state device cannot be established"
 DATA_DEVICE=$(fm_pr_file_device "$DATA") || refuse "data device cannot be established"
 
@@ -238,7 +230,7 @@ esac
 
 lock_and_verify_runtime_slot_exclusive() {
   local other other_id other_window other_key other_lock target_key
-  target_key=$(watcher_state_key "$WINDOW")
+  target_key=$(fm_record_retire_watcher_state_key "$WINDOW")
   for other in "$STATE"/*.meta; do
     [ -e "$other" ] || [ -L "$other" ] || continue
     [ "$other" != "$META" ] || continue
@@ -260,7 +252,7 @@ lock_and_verify_runtime_slot_exclusive() {
     if [ "$other_window" = "$WINDOW" ]; then
       refuse "runtime slot is also recorded by $other_id; no record state was retired"
     fi
-    other_key=$(watcher_state_key "$other_window")
+    other_key=$(fm_record_retire_watcher_state_key "$other_window")
     if [ "$other_key" = "$target_key" ]; then
       refuse "watcher state key is also recorded by $other_id; no record state was retired"
     fi
@@ -363,11 +355,11 @@ ARTIFACTS=(
   "$STATE/$ID.pr-poll-registration"
   "$STATE/$ID.pr-poll-retirement"
   "$STATE/.$ID.open-decisions-cursor"
-  "$STATE/.seen-${ID}_status"
-  "$STATE/.seen-${ID}_turn-ended"
-  "$STATE/.hb-surfaced-$ID"
 )
-WINDOW_KEY=$(watcher_state_key "$WINDOW")
+while IFS= read -r artifact; do
+  [ -n "$artifact" ] && ARTIFACTS+=("$artifact")
+done < <(fm_wake_task_surface_paths "$STATE" "$ID")
+WINDOW_KEY=$(fm_record_retire_watcher_state_key "$WINDOW")
 for prefix in hash count stale stale-since paused paused-rechecked paused-resurfaced wedge-escalations; do
   ARTIFACTS+=("$STATE/.$prefix-$WINDOW_KEY")
 done

--- a/bin/fm-record-retire.sh
+++ b/bin/fm-record-retire.sh
@@ -34,9 +34,10 @@
 # record, then refuses any raw runtime-slot or collapsed watcher-key collision.
 #
 # A successful retirement leaves state/.record-retired-<task-id>, whose format
-# is owned by fm-record-retire-lib.sh.
-# That marker mutes late status and turn-end writes from the intentionally
-# untouched agent until a later fresh spawn of the same id clears it.
+# and activation contract are owned by fm-record-retire-lib.sh.
+# Once active, that marker keeps late status and turn-end writes from the
+# intentionally untouched agent out of supervision until a later fresh spawn
+# of the same id publishes new metadata and clears it.
 # It never mutes slot-keyed stale wakes because those carry no task identity.
 set -eu
 

--- a/bin/fm-record-retire.sh
+++ b/bin/fm-record-retire.sh
@@ -1,0 +1,390 @@
+#!/usr/bin/env bash
+# Retire one ordinary task's runtime record and supervision footprint without
+# resolving or touching any project, working copy, branch, or runtime endpoint.
+# This is deliberately separate from fm-teardown.sh and never calls it.
+#
+# Usage:
+#   fm-record-retire.sh <task-id> --work-safety scout-report
+#   fm-record-retire.sh <task-id> --work-safety remote-ref \
+#     --remote-url <url> --remote-ref <full-ref>
+#
+# No work-safety mode is inferred.
+# `scout-report` requires kind=scout, a regular single-link
+# data/<task-id>/report.md, and the existing unresolved-decision completion gate.
+# This is sound because Firstmate's scout contract declares that report to be the
+# complete durable work product and treats the disposable copy as scratch.
+#
+# `remote-ref` requires kind=ship and two exact metadata attestations recorded by
+# an operator while the task's own copy identity was independently established:
+#   record_retire_work_head=<40-or-64-hex commit>
+#   record_retire_worktree_clean=1
+# It then requires the caller-named GitHub remote ref to advertise that exact
+# commit now.
+# The clean attestation excludes uncommitted work, and the remote-tip equality
+# proves every committed byte at that head is held outside the local copy.
+# Missing attestations, remote access, the ref, or exact equality all refuse.
+#
+# The command reads task metadata, task state, the scout report when selected,
+# and a caller-named remote ref when selected.
+# It does not read worktree= or project= values from metadata and does not run
+# git against any local repository.
+# It never calls a backend, signals a process, removes tasktmp, runs treehouse,
+# changes a branch, refreshes a clone, or deletes a working copy.
+#
+# A successful retirement leaves state/.record-retired-<task-id>, whose format
+# is owned by fm-record-retire-lib.sh.
+# That marker mutes late status and turn-end writes from the intentionally
+# untouched agent until a later fresh spawn of the same id clears it.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-classify-lib.sh
+. "$SCRIPT_DIR/fm-classify-lib.sh"
+# shellcheck source=bin/fm-control-lib.sh
+. "$SCRIPT_DIR/fm-control-lib.sh"
+# shellcheck source=bin/fm-gate-refuse-lib.sh
+. "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-public-followup-lib.sh
+. "$SCRIPT_DIR/fm-public-followup-lib.sh"
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0"
+}
+
+refuse() {
+  printf 'REFUSED: %s\n' "$*" >&2
+  exit 1
+}
+
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+esac
+
+ID=${1:-}
+fm_record_retire_id_valid "$ID" || { usage >&2; exit 2; }
+shift
+
+WORK_SAFETY=
+REMOTE_URL=
+REMOTE_REF=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --work-safety)
+      [ "$#" -ge 2 ] || { usage >&2; exit 2; }
+      WORK_SAFETY=$2
+      shift 2
+      ;;
+    --remote-url)
+      [ "$#" -ge 2 ] || { usage >&2; exit 2; }
+      REMOTE_URL=$2
+      shift 2
+      ;;
+    --remote-ref)
+      [ "$#" -ge 2 ] || { usage >&2; exit 2; }
+      REMOTE_REF=$2
+      shift 2
+      ;;
+    *) usage >&2; exit 2 ;;
+  esac
+done
+
+case "$WORK_SAFETY" in
+  scout-report|remote-ref) ;;
+  '') refuse "--work-safety is required; no unlanded-work proof is inferred" ;;
+  *) refuse "unsupported --work-safety value '$WORK_SAFETY'" ;;
+esac
+case "$WORK_SAFETY" in
+  scout-report)
+    [ -z "$REMOTE_URL" ] && [ -z "$REMOTE_REF" ] \
+      || refuse "scout-report safety does not accept remote-ref arguments"
+    ;;
+  remote-ref)
+    [ -n "$REMOTE_URL" ] || refuse "remote-ref safety requires --remote-url"
+    [ -n "$REMOTE_REF" ] || refuse "remote-ref safety requires --remote-ref"
+    ;;
+esac
+
+[ -d "$STATE" ] && [ ! -L "$STATE" ] || refuse "state directory is absent or unsafe at $STATE"
+[ -d "$DATA" ] && [ ! -L "$DATA" ] || refuse "data directory is absent or unsafe at $DATA"
+fm_refuse_if_gate_agent
+
+META="$STATE/$ID.meta"
+CONTROL_LOCK="$STATE/.control-$ID.lock"
+META_LOCK=
+CONTROL_LOCK_HELD=0
+META_LOCK_HELD=0
+QUEUE_LOCK_HELD=0
+
+release_locks() {
+  local status=$?
+  if [ "$QUEUE_LOCK_HELD" = 1 ]; then
+    fm_lock_release "$FM_WAKE_QUEUE_LOCK" || true
+    QUEUE_LOCK_HELD=0
+  fi
+  if [ "$META_LOCK_HELD" = 1 ]; then
+    fm_lock_release "$META_LOCK" || true
+    META_LOCK_HELD=0
+  fi
+  if [ "$CONTROL_LOCK_HELD" = 1 ]; then
+    fm_lock_release "$CONTROL_LOCK" || true
+    CONTROL_LOCK_HELD=0
+  fi
+  return "$status"
+}
+trap release_locks EXIT
+
+fm_lock_try_acquire "$CONTROL_LOCK" \
+  || refuse "another lifecycle action is already running for task $ID; nothing was changed"
+CONTROL_LOCK_HELD=1
+[ -f "$META" ] && [ ! -L "$META" ] || refuse "task $ID has no regular metadata at $META"
+META_LOCK=$(fm_meta_lock_path "$META") || refuse "task $ID metadata lock cannot be resolved"
+fm_lock_acquire_wait "$META_LOCK" || refuse "task $ID metadata lock cannot be acquired"
+META_LOCK_HELD=1
+[ -f "$META" ] && [ ! -L "$META" ] || refuse "task $ID metadata disappeared before retirement"
+
+meta_exact() {  # <key>
+  local key=$1 count value
+  count=$(grep -c "^$key=" "$META" 2>/dev/null || true)
+  [ "$count" = 1 ] || return 1
+  value=$(grep "^$key=" "$META" | cut -d= -f2-)
+  [ -n "$value" ] || return 1
+  printf '%s' "$value"
+}
+
+STATE_DEVICE=$(fm_pr_file_device "$STATE") || refuse "state device cannot be established"
+DATA_DEVICE=$(fm_pr_file_device "$DATA") || refuse "data device cannot be established"
+
+regular_single_link() {  # <path> <device>
+  local path=$1 device=$2
+  [ -f "$path" ] && [ ! -L "$path" ] || return 1
+  [ "$(fm_pr_file_link_count "$path")" = 1 ] || return 1
+  [ "$(fm_pr_file_device "$path")" = "$device" ]
+}
+
+regular_state_artifact_if_present() {  # <path>
+  local path=$1
+  [ -e "$path" ] || [ -L "$path" ] || return 0
+  regular_single_link "$path" "$STATE_DEVICE" \
+    || refuse "unsafe task-state artifact at $path; no task state was retired"
+}
+
+regular_single_link "$META" "$STATE_DEVICE" \
+  || refuse "task metadata is not a regular single-link file on the state device"
+ENDPOINT_TASK_ID=$(meta_exact endpoint_task_id) \
+  || refuse "metadata must contain exactly one nonempty endpoint_task_id"
+[ "$ENDPOINT_TASK_ID" = "$ID" ] \
+  || refuse "metadata belongs to task $ENDPOINT_TASK_ID, not $ID"
+KIND=$(meta_exact kind) || refuse "metadata must contain exactly one nonempty kind"
+WINDOW=$(meta_exact window) || refuse "metadata must contain exactly one nonempty window"
+case "$WINDOW" in *$'\t'*|*$'\r'*|*$'\n'*) refuse "metadata window contains a control character" ;; esac
+case "$KIND" in
+  scout|ship) ;;
+  secondmate) refuse "secondmate homes require the dedicated teardown path" ;;
+  *) refuse "unsupported task kind '$KIND'" ;;
+esac
+
+validate_report_safety() {
+  local report
+  [ "$KIND" = scout ] || refuse "scout-report safety requires kind=scout"
+  report="$DATA/$ID/report.md"
+  regular_single_link "$report" "$DATA_DEVICE" \
+    || refuse "scout report is absent or not a regular single-link file at $report"
+  FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
+    FM_CONFIG_OVERRIDE="$CONFIG" "$SCRIPT_DIR/fm-decision-hold.sh" verify "$ID" >/dev/null \
+    || refuse "scout unresolved-decision completion gate cannot be verified"
+}
+
+remote_url_valid() {
+  case "$1" in
+    https://github.com/*/*|ssh://git@github.com/*/*|git@github.com:*/*) ;;
+    *) return 1 ;;
+  esac
+  case "$1" in -*|*[[:space:]]*) return 1 ;; esac
+}
+
+validate_remote_ref_safety() {
+  local work_head clean ls_output matches advertised
+  [ "$KIND" = ship ] || refuse "remote-ref safety requires kind=ship"
+  work_head=$(meta_exact record_retire_work_head) \
+    || refuse "metadata must contain exactly one record_retire_work_head attestation"
+  [[ "$work_head" =~ ^[0-9a-f]{40}$|^[0-9a-f]{64}$ ]] \
+    || refuse "record_retire_work_head is not a full lowercase commit id"
+  clean=$(meta_exact record_retire_worktree_clean) \
+    || refuse "metadata must contain exactly one record_retire_worktree_clean attestation"
+  [ "$clean" = 1 ] \
+    || refuse "record_retire_worktree_clean must equal 1"
+  remote_url_valid "$REMOTE_URL" \
+    || refuse "--remote-url must name an explicit GitHub HTTPS or SSH repository"
+  case "$REMOTE_REF" in refs/*) ;; *) refuse "--remote-ref must be a full refs/... name" ;; esac
+  git check-ref-format "$REMOTE_REF" >/dev/null 2>&1 \
+    || refuse "--remote-ref is not a valid full ref name"
+  ls_output=$(git ls-remote --exit-code "$REMOTE_URL" "$REMOTE_REF" 2>/dev/null) \
+    || refuse "remote ref cannot be read at $REMOTE_URL $REMOTE_REF"
+  matches=$(printf '%s\n' "$ls_output" | awk -v ref="$REMOTE_REF" '$2 == ref { print $1 }')
+  [ "$(printf '%s\n' "$matches" | sed '/^$/d' | LC_ALL=C wc -l | tr -d ' ')" = 1 ] \
+    || refuse "remote did not return exactly one match for $REMOTE_REF"
+  advertised=$(printf '%s\n' "$matches" | sed -n '1p')
+  [ "$advertised" = "$work_head" ] \
+    || refuse "remote ref advertises $advertised, not attested work head $work_head"
+}
+
+case "$WORK_SAFETY" in
+  scout-report) validate_report_safety ;;
+  remote-ref) validate_remote_ref_safety ;;
+esac
+
+if fm_pf_relay_active "$FM_HOME" && fm_pf_has_registrations "$STATE"; then
+  refuse "public-followup registrations exist; settle or remove them before record retirement"
+fi
+
+refuse_bound_records() {  # <directory> <field>
+  local dir=$1 field=$2 record
+  [ -e "$dir" ] || [ -L "$dir" ] || return 0
+  [ -d "$dir" ] && [ ! -L "$dir" ] \
+    || refuse "runtime binding directory is unsafe at $dir"
+  for record in "$dir"/*; do
+    [ -e "$record" ] || [ -L "$record" ] || continue
+    [ -f "$record" ] && [ ! -L "$record" ] \
+      || refuse "runtime binding record is unsafe at $record"
+    if grep -qxF "$field=$ID" "$record" 2>/dev/null; then
+      refuse "task $ID still owns runtime binding $record"
+    fi
+  done
+}
+refuse_bound_records "$STATE/terminal-outcomes" task_id
+refuse_bound_records "$STATE/procevent" task_id
+refuse_bound_records "$STATE/pending-replies" task_id
+
+ARTIFACTS=(
+  "$STATE/$ID.status"
+  "$STATE/$ID.turn-ended"
+  "$STATE/$ID.pi-ext.ts"
+  "$STATE/$ID.grok-turnend-token"
+  "$STATE/$ID.kimi-turnend-token"
+  "$STATE/$ID.muse-session"
+  "$STATE/$ID.muse-session-current"
+  "$STATE/$ID.cursor-session"
+  "$STATE/$ID.control-relaunch"
+  "$STATE/$ID.control-relaunch.meta-prior"
+  "$STATE/$ID.control-relaunch.brief-prior"
+  "$STATE/$ID.control-relaunch.note"
+  "$STATE/$ID.herdr-presentation"
+  "$STATE/$ID.busy-gen"
+  "$STATE/$ID.busy-state"
+  "$STATE/$ID.check.sh"
+  "$STATE/$ID.check-trust"
+  "$STATE/$ID.pr-poll"
+  "$STATE/$ID.pr-poll-registration"
+  "$STATE/$ID.pr-poll-retirement"
+  "$STATE/.$ID.open-decisions-cursor"
+  "$STATE/.seen-${ID}_status"
+  "$STATE/.seen-${ID}_turn-ended"
+  "$STATE/.hb-surfaced-$ID"
+)
+WINDOW_KEY=${WINDOW//:/_}
+WINDOW_KEY=${WINDOW_KEY//\//_}
+WINDOW_KEY=${WINDOW_KEY//./_}
+for prefix in hash count stale stale-since paused paused-rechecked paused-resurfaced wedge-escalations; do
+  ARTIFACTS+=("$STATE/.$prefix-$WINDOW_KEY")
+done
+for artifact in "${ARTIFACTS[@]}"; do
+  regular_state_artifact_if_present "$artifact"
+done
+if [ -e "$STATE/$ID.busy-state.lock" ] || [ -L "$STATE/$ID.busy-state.lock" ]; then
+  refuse "busy-state writer lock exists for task $ID"
+fi
+
+QUARANTINE="$STATE/.pr-check-quarantine"
+if [ -e "$QUARANTINE" ] || [ -L "$QUARANTINE" ]; then
+  [ -d "$QUARANTINE" ] && [ ! -L "$QUARANTINE" ] \
+    || refuse "PR-check quarantine path is unsafe at $QUARANTINE"
+  for artifact in "$QUARANTINE/$ID."*; do
+    [ -e "$artifact" ] || [ -L "$artifact" ] || continue
+    regular_single_link "$artifact" "$STATE_DEVICE" \
+      || refuse "unsafe task quarantine entry at $artifact"
+  done
+fi
+
+BUSY_GEN=$(meta_exact busy_gen 2>/dev/null || true)
+if { [ -e "$STATE/$ID.busy-gen" ] || [ -e "$STATE/$ID.busy-state" ]; } && [ -z "$BUSY_GEN" ]; then
+  refuse "busy-state exists but metadata has no exact busy_gen; incarnation safety is unprovable"
+fi
+META_SHA256=$(fm_record_retire_sha256_file "$META") \
+  || refuse "SHA-256 support is required to bind the retirement marker"
+RETIREMENT_MARKER=$(fm_record_retire_marker_path "$STATE" "$ID")
+if [ -e "$RETIREMENT_MARKER" ] || [ -L "$RETIREMENT_MARKER" ]; then
+  regular_single_link "$RETIREMENT_MARKER" "$STATE_DEVICE" \
+    || refuse "existing record-retirement marker is unsafe at $RETIREMENT_MARKER"
+  fm_record_retire_marker_valid "$STATE" "$ID" \
+    || refuse "existing record-retirement marker is invalid at $RETIREMENT_MARKER"
+  [ "$(fm_record_retire_marker_window "$STATE" "$ID")" = "$WINDOW" ] \
+    || refuse "existing record-retirement marker names a different runtime target"
+  [ "$(sed -n '4s/^meta_sha256=//p' "$RETIREMENT_MARKER")" = "$META_SHA256" ] \
+    || refuse "existing record-retirement marker names a different metadata generation"
+fi
+
+# Retire status presentation first through its existing serialized owner.
+# All safety checks above have passed, and a failure here leaves metadata intact.
+status_retire_presentation_task "$STATE" "$ID" \
+  || refuse "status presentation state could not be retired safely"
+if [ -n "$BUSY_GEN" ]; then
+  "$SCRIPT_DIR/fm-busy-event.sh" retire "$STATE" "$ID" --gen "$BUSY_GEN" \
+    || refuse "busy-state incarnation could not be retired safely"
+fi
+
+fm_lock_acquire_wait "$FM_WAKE_QUEUE_LOCK" || refuse "wake-queue lock cannot be acquired"
+QUEUE_LOCK_HELD=1
+fm_record_retire_marker_publish "$STATE" "$ID" "$WINDOW" "$META_SHA256" \
+  || refuse "record-retirement marker could not be published safely"
+
+retire_queue_rows_locked() {
+  local queue=$FM_WAKE_QUEUE tmp
+  [ -e "$queue" ] || [ -L "$queue" ] || return 0
+  regular_single_link "$queue" "$STATE_DEVICE" || return 1
+  tmp="$queue.retire.${BASHPID:-$$}"
+  awk -F '\t' -v id="$ID" -v window="$WINDOW" -v check="$STATE/$ID.check.sh" '
+    NF < 5 { print; next }
+    $3 == "signal" && ($4 == id ".status" || $4 == id ".turn-ended") { next }
+    $3 == "stale" && $4 == window { next }
+    $3 == "check" && $4 == check { next }
+    { print }
+  ' "$queue" > "$tmp" || { rm -f -- "$tmp"; return 1; }
+  chmod 0600 "$tmp" || { rm -f -- "$tmp"; return 1; }
+  mv -f -- "$tmp" "$queue" || { rm -f -- "$tmp"; return 1; }
+}
+retire_queue_rows_locked || refuse "task wake rows could not be retired safely"
+
+fm_pr_poll_retirement_recover_one "$STATE" "$ID" "$SCRIPT_DIR/fm-pr-poll.sh" \
+  || refuse "PR-poll retirement state could not be reconciled safely"
+rm -f -- "$STATE/$ID.check.sh" "$STATE/$ID.check-trust" \
+  "$STATE/$ID.pr-poll" "$STATE/$ID.pr-poll-registration" \
+  "$STATE/$ID.pr-poll-retirement"
+if [ -d "$QUARANTINE" ] && [ ! -L "$QUARANTINE" ]; then
+  for artifact in "$QUARANTINE/$ID."*; do
+    [ -e "$artifact" ] || [ -L "$artifact" ] || continue
+    rm -f -- "$artifact"
+  done
+  rmdir "$QUARANTINE" 2>/dev/null || true
+fi
+
+rm -f -- "${ARTIFACTS[@]}" "$META"
+fm_lock_release "$FM_WAKE_QUEUE_LOCK"
+QUEUE_LOCK_HELD=0
+fm_lock_release "$META_LOCK"
+META_LOCK_HELD=0
+
+printf 'record retirement %s complete; no endpoint, process, branch, project, or working copy was touched\n' "$ID"

--- a/bin/fm-record-retire.sh
+++ b/bin/fm-record-retire.sh
@@ -30,11 +30,14 @@
 # git against any local repository.
 # It never calls a backend, signals a process, removes tasktmp, runs treehouse,
 # changes a branch, refreshes a clone, or deletes a working copy.
+# Before mutating state it locks the home task set and every other metadata
+# record, then refuses any raw runtime-slot or collapsed watcher-key collision.
 #
 # A successful retirement leaves state/.record-retired-<task-id>, whose format
 # is owned by fm-record-retire-lib.sh.
 # That marker mutes late status and turn-end writes from the intentionally
 # untouched agent until a later fresh spawn of the same id clears it.
+# It never mutes slot-keyed stale wakes because those carry no task identity.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -124,10 +127,13 @@ fm_refuse_if_gate_agent
 
 META="$STATE/$ID.meta"
 CONTROL_LOCK="$STATE/.control-$ID.lock"
+TASK_SET_LOCK=
 META_LOCK=
 CONTROL_LOCK_HELD=0
+TASK_SET_LOCK_HELD=0
 META_LOCK_HELD=0
 QUEUE_LOCK_HELD=0
+OTHER_META_LOCKS=()
 
 release_locks() {
   local status=$?
@@ -135,6 +141,13 @@ release_locks() {
     fm_lock_release "$FM_WAKE_QUEUE_LOCK" || true
     QUEUE_LOCK_HELD=0
   fi
+  local index
+  index=${#OTHER_META_LOCKS[@]}
+  while [ "$index" -gt 0 ]; do
+    index=$((index - 1))
+    fm_lock_release "${OTHER_META_LOCKS[$index]}" || true
+  done
+  OTHER_META_LOCKS=()
   if [ "$META_LOCK_HELD" = 1 ]; then
     fm_lock_release "$META_LOCK" || true
     META_LOCK_HELD=0
@@ -143,10 +156,19 @@ release_locks() {
     fm_lock_release "$CONTROL_LOCK" || true
     CONTROL_LOCK_HELD=0
   fi
+  if [ "$TASK_SET_LOCK_HELD" = 1 ]; then
+    fm_lock_release "$TASK_SET_LOCK" || true
+    TASK_SET_LOCK_HELD=0
+  fi
   return "$status"
 }
 trap release_locks EXIT
 
+TASK_SET_LOCK=$(fm_task_set_lock_path "$STATE") \
+  || refuse "task-set lock cannot be resolved for $STATE"
+fm_lock_try_acquire "$TASK_SET_LOCK" \
+  || refuse "the task set is changing; runtime-slot exclusivity cannot be established"
+TASK_SET_LOCK_HELD=1
 fm_lock_try_acquire "$CONTROL_LOCK" \
   || refuse "another lifecycle action is already running for task $ID; nothing was changed"
 CONTROL_LOCK_HELD=1
@@ -163,6 +185,23 @@ meta_exact() {  # <key>
   value=$(grep "^$key=" "$META" | cut -d= -f2-)
   [ -n "$value" ] || return 1
   printf '%s' "$value"
+}
+
+meta_file_exact() {  # <metadata-path> <key>
+  local file=$1 key=$2 count value
+  count=$(grep -c "^$key=" "$file" 2>/dev/null || true)
+  [ "$count" = 1 ] || return 1
+  value=$(grep "^$key=" "$file" | cut -d= -f2-)
+  [ -n "$value" ] || return 1
+  printf '%s' "$value"
+}
+
+watcher_state_key() {  # <window>
+  local key=$1
+  key=${key//:/_}
+  key=${key//\//_}
+  key=${key//./_}
+  printf '%s' "$key"
 }
 
 STATE_DEVICE=$(fm_pr_file_device "$STATE") || refuse "state device cannot be established"
@@ -196,6 +235,39 @@ case "$KIND" in
   secondmate) refuse "secondmate homes require the dedicated teardown path" ;;
   *) refuse "unsupported task kind '$KIND'" ;;
 esac
+
+lock_and_verify_runtime_slot_exclusive() {
+  local other other_id other_window other_key other_lock target_key
+  target_key=$(watcher_state_key "$WINDOW")
+  for other in "$STATE"/*.meta; do
+    [ -e "$other" ] || [ -L "$other" ] || continue
+    [ "$other" != "$META" ] || continue
+    regular_single_link "$other" "$STATE_DEVICE" \
+      || refuse "runtime-slot exclusivity is unprovable because metadata is unsafe at $other"
+    other_lock=$(fm_meta_lock_path "$other") \
+      || refuse "runtime-slot exclusivity is unprovable because a metadata lock cannot be resolved for $other"
+    fm_lock_try_acquire "$other_lock" \
+      || refuse "runtime-slot exclusivity is unprovable because metadata is changing at $other"
+    OTHER_META_LOCKS+=("$other_lock")
+    regular_single_link "$other" "$STATE_DEVICE" \
+      || refuse "runtime-slot exclusivity is unprovable because metadata changed at $other"
+    other_id=$(meta_file_exact "$other" endpoint_task_id) \
+      || refuse "runtime-slot exclusivity requires one exact endpoint_task_id in $other"
+    [ "${other##*/}" = "$other_id.meta" ] \
+      || refuse "runtime-slot exclusivity found a mismatched task binding in $other"
+    other_window=$(meta_file_exact "$other" window) \
+      || refuse "runtime-slot exclusivity requires one exact window in $other"
+    if [ "$other_window" = "$WINDOW" ]; then
+      refuse "runtime slot is also recorded by $other_id; no record state was retired"
+    fi
+    other_key=$(watcher_state_key "$other_window")
+    if [ "$other_key" = "$target_key" ]; then
+      refuse "watcher state key is also recorded by $other_id; no record state was retired"
+    fi
+  done
+}
+
+lock_and_verify_runtime_slot_exclusive
 
 validate_report_safety() {
   local report
@@ -295,9 +367,7 @@ ARTIFACTS=(
   "$STATE/.seen-${ID}_turn-ended"
   "$STATE/.hb-surfaced-$ID"
 )
-WINDOW_KEY=${WINDOW//:/_}
-WINDOW_KEY=${WINDOW_KEY//\//_}
-WINDOW_KEY=${WINDOW_KEY//./_}
+WINDOW_KEY=$(watcher_state_key "$WINDOW")
 for prefix in hash count stale stale-since paused paused-rechecked paused-resurfaced wedge-escalations; do
   ARTIFACTS+=("$STATE/.$prefix-$WINDOW_KEY")
 done

--- a/bin/fm-record-retire.sh
+++ b/bin/fm-record-retire.sh
@@ -229,8 +229,7 @@ case "$KIND" in
 esac
 
 lock_and_verify_runtime_slot_exclusive() {
-  local other other_id other_window other_key other_lock target_key
-  target_key=$(fm_record_retire_watcher_state_key "$WINDOW")
+  local other other_id other_window other_lock collision
   for other in "$STATE"/*.meta; do
     [ -e "$other" ] || [ -L "$other" ] || continue
     [ "$other" != "$META" ] || continue
@@ -249,12 +248,12 @@ lock_and_verify_runtime_slot_exclusive() {
       || refuse "runtime-slot exclusivity found a mismatched task binding in $other"
     other_window=$(meta_file_exact "$other" window) \
       || refuse "runtime-slot exclusivity requires one exact window in $other"
-    if [ "$other_window" = "$WINDOW" ]; then
-      refuse "runtime slot is also recorded by $other_id; no record state was retired"
-    fi
-    other_key=$(fm_record_retire_watcher_state_key "$other_window")
-    if [ "$other_key" = "$target_key" ]; then
-      refuse "watcher state key is also recorded by $other_id; no record state was retired"
+    if collision=$(fm_record_retire_window_collision "$WINDOW" "$other_window"); then
+      case "$collision" in
+        raw) refuse "runtime slot is also recorded by $other_id; no record state was retired" ;;
+        collapsed) refuse "watcher state key is also recorded by $other_id; no record state was retired" ;;
+        *) refuse "runtime-slot collision classification failed for $other_id" ;;
+      esac
     fi
   done
 }
@@ -333,36 +332,10 @@ refuse_bound_records "$STATE/terminal-outcomes" task_id
 refuse_bound_records "$STATE/procevent" task_id
 refuse_bound_records "$STATE/pending-replies" task_id
 
-ARTIFACTS=(
-  "$STATE/$ID.status"
-  "$STATE/$ID.turn-ended"
-  "$STATE/$ID.pi-ext.ts"
-  "$STATE/$ID.grok-turnend-token"
-  "$STATE/$ID.kimi-turnend-token"
-  "$STATE/$ID.muse-session"
-  "$STATE/$ID.muse-session-current"
-  "$STATE/$ID.cursor-session"
-  "$STATE/$ID.control-relaunch"
-  "$STATE/$ID.control-relaunch.meta-prior"
-  "$STATE/$ID.control-relaunch.brief-prior"
-  "$STATE/$ID.control-relaunch.note"
-  "$STATE/$ID.herdr-presentation"
-  "$STATE/$ID.busy-gen"
-  "$STATE/$ID.busy-state"
-  "$STATE/$ID.check.sh"
-  "$STATE/$ID.check-trust"
-  "$STATE/$ID.pr-poll"
-  "$STATE/$ID.pr-poll-registration"
-  "$STATE/$ID.pr-poll-retirement"
-  "$STATE/.$ID.open-decisions-cursor"
-)
+ARTIFACTS=()
 while IFS= read -r artifact; do
   [ -n "$artifact" ] && ARTIFACTS+=("$artifact")
-done < <(fm_wake_task_surface_paths "$STATE" "$ID")
-WINDOW_KEY=$(fm_record_retire_watcher_state_key "$WINDOW")
-for prefix in hash count stale stale-since paused paused-rechecked paused-resurfaced wedge-escalations; do
-  ARTIFACTS+=("$STATE/.$prefix-$WINDOW_KEY")
-done
+done < <(fm_record_retire_artifact_paths "$STATE" "$ID" "$WINDOW")
 for artifact in "${ARTIFACTS[@]}"; do
   regular_state_artifact_if_present "$artifact"
 done

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -824,6 +824,7 @@ for status in "$STATE"/*.status; do
   [ -f "$status" ] || continue
   id=$(basename "$status" .status)
   [ -f "$STATE/$id.meta" ] && continue
+  fm_record_retire_marker_valid "$STATE" "$id" && continue
   ORPHAN_STATUS_FOUND=1
   printf '\n--- %s ---\n' "$id"
   print_status_tail "$status"

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -824,7 +824,7 @@ for status in "$STATE"/*.status; do
   [ -f "$status" ] || continue
   id=$(basename "$status" .status)
   [ -f "$STATE/$id.meta" ] && continue
-  fm_record_retire_marker_valid "$STATE" "$id" && continue
+  fm_record_retire_marker_active "$STATE" "$id" && continue
   ORPHAN_STATUS_FOUND=1
   printf '\n--- %s ---\n' "$id"
   print_status_tail "$status"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2622,6 +2622,10 @@ META_WINDOW=$T
 [ "$BACKEND" = orca ] && META_WINDOW=$W
 SPAWN_GEN="s$(date +%s).${BASHPID:-$$}.$RANDOM"
 SPAWN_META_PATH="$STATE/$ID.meta"
+# A fresh incarnation must not inherit an older state-only retirement mute.
+# The task lifecycle locks are already held here, so a validated marker can be
+# removed without racing another spawn or retirement for the same id.
+fm_record_retire_marker_clear_for_spawn "$STATE" "$ID" || exit 1
 if [ "$RELAUNCH" -eq 1 ]; then
   SPAWN_META_LOCK=$(fm_meta_lock_path "$STATE/$ID.meta") || exit 1
   fm_lock_acquire_wait "$SPAWN_META_LOCK"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1894,7 +1894,7 @@ case "$BACKEND" in
     HERDR_LAUNCHER_RELATIONSHIP=launcher-home
     if [ "$KIND" = secondmate ]; then
       HERDR_LABEL_HOME=$PROJ_ABS
-      HERDR_LAUNCHER_RELATIONSHIP=other-home
+      HERDR_LAUNCHER_RELATIONSHIP='other-home'
     fi
     HERDR_PRESENTATION_JOURNAL=$(fm_backend_herdr_projection_journal_path "$STATE" "$ID")
     HERDR_PROJECTED=0

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -663,6 +663,7 @@ SPAWN_META_TMP=
 SPAWN_META_LOCK=
 SPAWN_META_LOCK_HELD=0
 SPAWN_META_PUBLISH_STARTED=0
+SPAWN_RETIREMENT_MARKER_INHERITED=0
 SPAWN_TASK_SET_LOCK=
 SPAWN_TASK_SET_LOCK_HELD=0
 RELAUNCH_REPLACEMENT_PENDING=0
@@ -2621,17 +2622,17 @@ fi
 META_WINDOW=$T
 [ "$BACKEND" = orca ] && META_WINDOW=$W
 SPAWN_GEN="s$(date +%s).${BASHPID:-$$}.$RANDOM"
-SPAWN_META_PATH="$STATE/$ID.meta"
-# A fresh incarnation must not inherit an older state-only retirement mute.
-# The task lifecycle locks are already held here, so a validated marker can be
-# removed without racing another spawn or retirement for the same id.
-fm_record_retire_marker_clear_for_spawn "$STATE" "$ID" || exit 1
+SPAWN_META_TMP="$STATE/.$ID.meta.spawn.${BASHPID:-$$}"
+SPAWN_META_PATH=$SPAWN_META_TMP
+SPAWN_RETIREMENT_MARKER=$(fm_record_retire_marker_path "$STATE" "$ID")
+if [ -e "$SPAWN_RETIREMENT_MARKER" ] || [ -L "$SPAWN_RETIREMENT_MARKER" ]; then
+  fm_record_retire_marker_validate_for_spawn "$STATE" "$ID" || exit 1
+  SPAWN_RETIREMENT_MARKER_INHERITED=1
+fi
 if [ "$RELAUNCH" -eq 1 ]; then
   SPAWN_META_LOCK=$(fm_meta_lock_path "$STATE/$ID.meta") || exit 1
   fm_lock_acquire_wait "$SPAWN_META_LOCK"
   SPAWN_META_LOCK_HELD=1
-  SPAWN_META_TMP="$STATE/.$ID.meta.relaunch.${BASHPID:-$$}"
-  SPAWN_META_PATH=$SPAWN_META_TMP
 fi
 preserve_relaunch_meta() {
   awk -F= '
@@ -2691,12 +2692,18 @@ preserve_relaunch_meta() {
     echo "control_relaunch_tx=$FM_CONTROL_RELAUNCH_TX"
   fi
 } > "$SPAWN_META_PATH"
+SPAWN_META_PUBLISH_STARTED=1
+mv -f -- "$SPAWN_META_TMP" "$STATE/$ID.meta"
 if [ "$RELAUNCH" -eq 1 ]; then
-  SPAWN_META_PUBLISH_STARTED=1
-  mv -f "$SPAWN_META_TMP" "$STATE/$ID.meta"
   RELAUNCH_REPLACEMENT_PENDING=0
-  SPAWN_META_PUBLISH_STARTED=0
-  SPAWN_META_TMP=
+fi
+SPAWN_META_PUBLISH_STARTED=0
+SPAWN_META_TMP=
+if [ "$SPAWN_RETIREMENT_MARKER_INHERITED" = 1 ]; then
+  fm_record_retire_marker_clear_for_spawn "$STATE" "$ID" || exit 1
+  SPAWN_RETIREMENT_MARKER_INHERITED=0
+fi
+if [ "$RELAUNCH" -eq 1 ]; then
   fm_lock_release "$SPAWN_META_LOCK"
   SPAWN_META_LOCK_HELD=0
 fi

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -17,12 +17,19 @@ else
   # Missing marker support must fail toward surfacing work, never abort every
   # consumer of this core library or leave a fresh incarnation muted.
   fm_record_retire_wake_muted() { return 1; }
-  fm_record_retire_marker_clear_for_spawn() {
-    local marker="$1/.record-retired-$2"
+  fm_record_retire_marker_path() {
+    printf '%s/.record-retired-%s\n' "$1" "$2"
+  }
+  fm_record_retire_marker_validate_for_spawn() {
+    local marker
+    marker=$(fm_record_retire_marker_path "$1" "$2")
     [ ! -e "$marker" ] && [ ! -L "$marker" ] || {
       printf 'error: record-retirement support is unavailable for task %s; refusing spawn\n' "$2" >&2
       return 1
     }
+  }
+  fm_record_retire_marker_clear_for_spawn() {
+    fm_record_retire_marker_validate_for_spawn "$1" "$2"
   }
 fi
 # Resolved once at source time: fm_pid_identity and fm_path_mtime run inside 0.2s

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -1057,6 +1057,20 @@ fm_wake_signal_seen_path() {  # <state> <file>
   printf '%s/.seen-%s' "$1" "$(basename "$2" | tr '.' '_')"
 }
 
+fm_wake_hb_surfaced_path() {  # <state> <task-id>
+  printf '%s/.hb-surfaced-%s' "$1" "$(printf '%s' "$2" | tr ':/.' '___')"
+}
+
+fm_wake_task_surface_paths() {  # <state> <task-id>
+  local state=$1 task=$2
+  fm_wake_signal_seen_path "$state" "$state/$task.status"
+  printf '\n'
+  fm_wake_signal_seen_path "$state" "$state/$task.turn-ended"
+  printf '\n'
+  fm_wake_hb_surfaced_path "$state" "$task"
+  printf '\n'
+}
+
 # 0 when <file>'s current signature exactly matches its recorded seen marker,
 # meaning every byte in it was already surfaced or deliberately absorbed.
 # A missing marker or unreadable signature is NOT a match, so uncertainty reads

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -1047,10 +1047,10 @@ fm_wake_print_deduped() {
 # status or turn-ended change by comparing a size:mtime signature against a
 # persisted state/.seen-* marker, and advances that marker only after the change
 # has been surfaced to firstmate or deliberately absorbed by the signal triage.
-# These three helpers plus the guarded append below are the ONE owner of that
-# signature and marker format, shared by the scan itself, by the drain-time
-# historical-annotation staleness check, and by this home's own bookkeeping
-# writers.
+# These producer functions plus the guarded append below are the ONE owner of
+# the signature and every task surface-marker path, shared by signal and
+# heartbeat producers, retirement, the drain-time historical-annotation
+# staleness check, and this home's own bookkeeping writers.
 
 fm_wake_signal_sig() {  # <file> -> "size:mtime"
   if [ "$_FM_UNAME" = Darwin ]; then

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -10,7 +10,21 @@ FM_WAKE_QUEUE="${FM_WAKE_QUEUE:-$STATE/.wake-queue}"
 FM_WAKE_QUEUE_LOCK="${FM_WAKE_QUEUE_LOCK:-$STATE/.wake-queue.lock}"
 FM_LOCK_STALE_AFTER="${FM_LOCK_STALE_AFTER:-2}"
 # shellcheck source=bin/fm-record-retire-lib.sh
-. "$FM_WAKE_LIB_DIR/fm-record-retire-lib.sh"
+if [ -r "$FM_WAKE_LIB_DIR/fm-record-retire-lib.sh" ]; then
+  . "$FM_WAKE_LIB_DIR/fm-record-retire-lib.sh"
+else
+  # Partial-bin fixtures and recovery copies predate record retirement.
+  # Missing marker support must fail toward surfacing work, never abort every
+  # consumer of this core library or leave a fresh incarnation muted.
+  fm_record_retire_wake_muted() { return 1; }
+  fm_record_retire_marker_clear_for_spawn() {
+    local marker="$1/.record-retired-$2"
+    [ ! -e "$marker" ] && [ ! -L "$marker" ] || {
+      printf 'error: record-retirement support is unavailable for task %s; refusing spawn\n' "$2" >&2
+      return 1
+    }
+  }
+fi
 # Resolved once at source time: fm_pid_identity and fm_path_mtime run inside 0.2s
 # confirm and 0.5s attach polls, and forking uname per call is a measurable cost on
 # the platform (Git Bash/MSYS) that already pays the highest fork price.

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -9,6 +9,8 @@ STATE="${FM_STATE_OVERRIDE:-${STATE:-$FM_HOME/state}}"
 FM_WAKE_QUEUE="${FM_WAKE_QUEUE:-$STATE/.wake-queue}"
 FM_WAKE_QUEUE_LOCK="${FM_WAKE_QUEUE_LOCK:-$STATE/.wake-queue.lock}"
 FM_LOCK_STALE_AFTER="${FM_LOCK_STALE_AFTER:-2}"
+# shellcheck source=bin/fm-record-retire-lib.sh
+. "$FM_WAKE_LIB_DIR/fm-record-retire-lib.sh"
 # Resolved once at source time: fm_pid_identity and fm_path_mtime run inside 0.2s
 # confirm and 0.5s attach polls, and forking uname per call is a measurable cost on
 # the platform (Git Bash/MSYS) that already pays the highest fork price.
@@ -943,6 +945,10 @@ fm_wake_append() {
   status=0
 
   fm_lock_acquire_wait "$FM_WAKE_QUEUE_LOCK"
+  if fm_record_retire_wake_muted "$STATE" "$kind" "$clean_key"; then
+    fm_lock_release "$FM_WAKE_QUEUE_LOCK"
+    return 0
+  fi
   _fm_recovery_marker_publish "$recovery_marker" downtime || status=$?
   if [ "$status" -eq 0 ]; then
     seq=$(cat "$seq_file" 2>/dev/null || echo 0)

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -462,7 +462,7 @@ scan_signals() {
     task=$(basename "$f")
     task=${task%.status}
     task=${task%.turn-ended}
-    fm_record_retire_marker_valid "$STATE" "$task" && continue
+    fm_record_retire_marker_active "$STATE" "$task" && continue
     sig=$(fm_wake_signal_sig "$f") || continue
     [ -n "$sig" ] || continue
     sf=$(fm_wake_signal_seen_path "$STATE" "$f")

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -456,9 +456,13 @@ age_of() {  # seconds since file mtime; "due immediately" if missing
 # surfaced or intentionally absorbed, so a watcher killed mid-cycle never
 # swallows a signal.
 scan_signals() {
-  local f sig sf
+  local f sig sf task
   for f in "$STATE"/*.status "$STATE"/*.turn-ended; do
     [ -e "$f" ] || continue
+    task=$(basename "$f")
+    task=${task%.status}
+    task=${task%.turn-ended}
+    fm_record_retire_marker_valid "$STATE" "$task" && continue
     sig=$(fm_wake_signal_sig "$f") || continue
     [ -n "$sig" ] || continue
     sf=$(fm_wake_signal_seen_path "$STATE" "$f")

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -613,7 +613,7 @@ mark_all_captain_relevant_surfaced() {
   local f task last
   while IFS=$(printf '\t') read -r f task last; do
     [ -n "$f" ] || continue
-    printf '%s' "$last" > "$(_hb_surfaced_path "$task")"
+    printf '%s' "$last" > "$(fm_wake_hb_surfaced_path "$STATE" "$task")"
   done < <(scan_captain_relevant_statuses "$STATE")
 }
 
@@ -629,7 +629,7 @@ heartbeat_scan_finds_actionable() {
   local f task last surfaced
   while IFS=$(printf '\t') read -r f task last; do
     [ -n "$f" ] || continue
-    surfaced=$(cat "$(_hb_surfaced_path "$task")" 2>/dev/null || true)
+    surfaced=$(cat "$(fm_wake_hb_surfaced_path "$STATE" "$task")" 2>/dev/null || true)
     [ "$surfaced" = "$last" ] && continue
     return 0
   done < <(scan_captain_relevant_statuses "$STATE")

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -604,8 +604,8 @@ run_check_capture() {
   fm_check_output_cleanup
 }
 
-# Surfaced-marker bookkeeping for the heartbeat backstop is owned by
-# fm-push-transition-lib.sh because push and poll paths must write one format.
+# The heartbeat surfaced-marker path and task-id normalization are owned by
+# fm-wake-lib.sh so push, poll, and retirement use one format.
 # Mark every current captain-relevant status as surfaced. Called after the
 # heartbeat backstop enqueues its wake, so the same statuses are not re-surfaced
 # by the next heartbeat.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -107,6 +107,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-pr-check.sh`         | Record validated `pr=` and `pr_head=` values, then atomically arm a static merge poll |
 | `fm-pr-merge.sh`         | Record PR metadata, then merge a task's canonical full GitHub URL                    |
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task with an explicit delivery mode |
+| `fm-record-retire.sh`    | Retire an ordinary task's state and supervision without touching its endpoint or working copy |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |
 | `fm-lock.sh`             | Per-home firstmate session lock                                                      |

--- a/tests/fm-record-retire.test.sh
+++ b/tests/fm-record-retire.test.sh
@@ -1887,7 +1887,7 @@ test_wake_queue_must_be_regular() {
 }
 
 test_wake_queue_rewrite_failure_refuses() {
-  local home id rc
+  local home id rc output
   home=$(make_home wake-queue-rewrite-failure)
   id=scout-wake-queue-rewrite-failure
   write_scout "$home" "$id" "$home/copies/missing"
@@ -1908,9 +1908,25 @@ test_wake_queue_rewrite_failure_refuses() {
   assert_grep "task wake rows could not be retired safely" "$home/err" \
     "wake-queue rewrite refusal was not concrete"
   assert_present "$home/state/$id.meta" "wake-queue rewrite refusal removed metadata"
+  assert_present "$home/state/.record-retired-$id" \
+    "wake-queue rewrite failure did not exercise post-publication recovery"
   assert_content "$home/state/.wake-queue" $'1\t1\theartbeat\theartbeat\theartbeat' \
     "failed wake-queue rewrite changed the queue"
-  pass "record retirement refuses when wake-queue rewriting fails"
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    bash -c '. "$1"; fm_wake_append signal "$2.status" "signal: still live"' _ \
+    "$ROOT/bin/fm-wake-lib.sh" "$id" \
+    || fail "post-publication refusal could not queue the still-live task wake"
+  [ "$(wc -l < "$home/state/.wake-queue" | tr -d ' ')" -eq 2 ] \
+    || fail "post-publication marker suppressed a task whose metadata remains"
+  printf 'failed: still-live task reported after retirement refusal\n' \
+    > "$home/state/$id.status"
+  output=$(FM_STATE_OVERRIDE="$home/state" bash -c \
+    '. "$1"; scan_captain_relevant_statuses "$2"' _ \
+    "$ROOT/bin/fm-classify-lib.sh" "$home/state") \
+    || fail "post-publication refusal could not scan captain-relevant status"
+  printf '%s\n' "$output" | grep -q "$id" \
+    || fail "post-publication marker hid status while canonical metadata remains"
+  pass "post-publication failure keeps the live task visible while metadata remains"
 }
 
 test_pr_poll_recovery_failure_refuses() {

--- a/tests/fm-record-retire.test.sh
+++ b/tests/fm-record-retire.test.sh
@@ -1,0 +1,428 @@
+#!/usr/bin/env bash
+# Behavioral coverage for state-only task-record retirement.
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+RETIRE="$ROOT/bin/fm-record-retire.sh"
+TMP_ROOT=$(fm_test_tmproot fm-record-retire)
+
+assert_content() {  # <file> <expected> <message>
+  local file=$1 expected=$2 message=$3 actual
+  actual=$(cat "$file" 2>/dev/null) || fail "$message"
+  [ "$actual" = "$expected" ] || fail "$message: got '$actual'"
+}
+
+write_fake_tools() {  # <home>
+  local home=$1 fakebin tool
+  fakebin=$(fm_fakebin "$home")
+  # shellcheck disable=SC2016
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'case "${1:-} ${2:-}" in' \
+    '  "hold --help") printf "%s\n" "--kind captain"; exit 0 ;;' \
+    'esac' \
+    'exit 97' > "$fakebin/tasks-axi"
+  # shellcheck disable=SC2016
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'printf "git %s\n" "$*" >> "${FM_COMMAND_LOG:?}"' \
+    'case "${1:-}" in' \
+    '  check-ref-format) exit 0 ;;' \
+    '  ls-remote)' \
+    '    [ -n "${FM_FAKE_REMOTE_SHA:-}" ] || exit 97' \
+    '    printf "%s\t%s\n" "$FM_FAKE_REMOTE_SHA" "$FM_FAKE_REMOTE_REF"' \
+    '    exit 0 ;;' \
+    'esac' \
+    'exit 97' > "$fakebin/git"
+  for tool in treehouse tmux gh gh-axi no-mistakes lsof; do
+    printf '%s\n' \
+      '#!/usr/bin/env bash' \
+      "printf '$tool %s\\n' \"\$*\" >> \"\${FM_COMMAND_LOG:?}\"" \
+      'exit 97' > "$fakebin/$tool"
+  done
+  chmod +x "$fakebin"/*
+}
+
+make_home() {  # <name>
+  local home="$TMP_ROOT/$1"
+  mkdir -p "$home/state" "$home/data" "$home/config" "$home/copies"
+  : > "$home/commands.log"
+  write_fake_tools "$home"
+  printf '%s\n' "$home"
+}
+
+write_scout() {  # <home> <id> <worktree>
+  local home=$1 id=$2 worktree=$3
+  mkdir -p "$home/data/$id"
+  fm_write_meta "$home/state/$id.meta" \
+    "window=firstmate:fm-$id" \
+    "endpoint_task_id=$id" \
+    "worktree=$worktree" \
+    "project=$home/projects/sample" \
+    "harness=codex" \
+    "kind=scout" \
+    "decisions_reviewed=1" \
+    "decision_keys="
+  printf '# %s report\n\nThe durable scout result is complete.\n' "$id" \
+    > "$home/data/$id/report.md"
+  printf 'done: report complete\n' > "$home/state/$id.status"
+  : > "$home/state/$id.turn-ended"
+}
+
+run_retire() {  # <home> <args...>
+  local home=$1
+  shift
+  PATH="$home/fakebin:$PATH" FM_TASKS_AXI_COMPATIBLE=1 \
+    FM_COMMAND_LOG="$home/commands.log" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_CONFIG_OVERRIDE="$home/config" "$RETIRE" "$@"
+}
+
+assert_retired() {  # <home> <id>
+  local home=$1 id=$2
+  assert_absent "$home/state/$id.meta" "retirement left task metadata"
+  assert_absent "$home/state/$id.status" "retirement left task status"
+  assert_absent "$home/state/$id.turn-ended" "retirement left task turn-end state"
+  assert_present "$home/state/.record-retired-$id" "retirement marker is absent"
+  assert_present "$home/data/$id/report.md" "retirement removed the durable report"
+}
+
+test_ordinary_retire() {
+  local home id queue_before queue_after
+  home=$(make_home ordinary)
+  id=scout-ordinary
+  mkdir -p "$home/copies/task"
+  printf 'copy bytes remain\n' > "$home/copies/task/sentinel"
+  write_scout "$home" "$id" "$home/copies/task"
+  printf '1\t1\tsignal\t%s.status\tsignal: task\n' "$id" > "$home/state/.wake-queue"
+  printf '1\t2\theartbeat\theartbeat\theartbeat\n' >> "$home/state/.wake-queue"
+
+  run_retire "$home" "$id" --work-safety scout-report >/dev/null \
+    || fail "ordinary record retirement refused"
+  assert_retired "$home" "$id"
+  assert_content "$home/copies/task/sentinel" "copy bytes remain" \
+    "ordinary retirement touched the recorded copy"
+  assert_content "$home/state/.wake-queue" $'1\t2\theartbeat\theartbeat\theartbeat' \
+    "ordinary retirement did not remove only this task's queued wake"
+  [ ! -s "$home/commands.log" ] \
+    || fail "ordinary retirement invoked a copy, process, backend, or forge command: $(cat "$home/commands.log")"
+
+  printf 'failed: late old-agent write\n' > "$home/state/$id.status"
+  queue_before=$(sha256sum "$home/state/.wake-queue" 2>/dev/null || shasum -a 256 "$home/state/.wake-queue")
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    bash -c '. "$1"; fm_wake_append signal "$2.status" "late"' _ \
+    "$ROOT/bin/fm-wake-lib.sh" "$id" || fail "late-wake mute call failed"
+  queue_after=$(sha256sum "$home/state/.wake-queue" 2>/dev/null || shasum -a 256 "$home/state/.wake-queue")
+  [ "$queue_before" = "$queue_after" ] || fail "late old-agent write recreated a queued wake"
+  late=$(FM_STATE_OVERRIDE="$home/state" bash -c '. "$1"; scan_captain_relevant_statuses "$2"' _ \
+    "$ROOT/bin/fm-classify-lib.sh" "$home/state")
+  [ -z "$late" ] || fail "late old-agent status re-entered captain-relevant supervision"
+  pass "record retirement removes ordinary state and permanently mutes the untouched old agent"
+}
+
+test_aliased_copy_is_safe() {
+  local home stale live shared
+  home=$(make_home alias)
+  stale=scout-stale
+  live=scout-live
+  shared="$home/copies/recycled-slot"
+  mkdir -p "$shared"
+  printf 'live lane owns these bytes\n' > "$shared/live-sentinel"
+  write_scout "$home" "$stale" "$shared"
+  fm_write_meta "$home/state/$live.meta" \
+    "window=firstmate:fm-$live" \
+    "endpoint_task_id=$live" \
+    "worktree=$shared" \
+    "project=$home/projects/sample" \
+    "harness=codex" \
+    "kind=ship"
+
+  run_retire "$home" "$stale" --work-safety scout-report >/dev/null \
+    || fail "aliased-copy record retirement refused"
+  assert_retired "$home" "$stale"
+  assert_present "$home/state/$live.meta" "aliased-copy retirement removed the live lane's record"
+  assert_content "$shared/live-sentinel" "live lane owns these bytes" \
+    "aliased-copy retirement touched the recycled live copy"
+  [ ! -s "$home/commands.log" ] \
+    || fail "aliased-copy retirement invoked an external lifecycle command"
+  pass "record retirement is safe when the recorded copy is aliased by another live lane"
+}
+
+test_unprovable_safety_refuses_without_mutation() {
+  local home id rc before
+  home=$(make_home unprovable)
+  id=scout-no-report
+  mkdir -p "$home/copies/task"
+  write_scout "$home" "$id" "$home/copies/task"
+  rm -f "$home/data/$id/report.md"
+  before=$(shasum -a 256 "$home/state/$id.meta" "$home/state/$id.status")
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report \
+    > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "unprovable scout safety was accepted"
+  assert_grep "scout report is absent" "$home/err" "unprovable refusal did not name the missing report"
+  [ "$before" = "$(shasum -a 256 "$home/state/$id.meta" "$home/state/$id.status")" ] \
+    || fail "unprovable refusal changed task state"
+  assert_absent "$home/state/.record-retired-$id" "unprovable refusal published a retirement marker"
+  pass "record retirement refuses when off-copy work safety cannot be proved"
+}
+
+test_no_copy_touched_even_when_copy_is_hostile() {
+  local home id rc
+  home=$(make_home hostile-copy)
+  id=scout-hostile-copy
+  write_scout "$home" "$id" "$home/copies/does-not-exist/and-must-not-be-resolved"
+  run_retire "$home" "$id" --work-safety scout-report >/dev/null \
+    || fail "retirement tried to require or resolve the recorded copy"
+  assert_retired "$home" "$id"
+  [ ! -e "$home/copies/does-not-exist" ] \
+    || fail "retirement created or opened the hostile recorded-copy path"
+  [ ! -s "$home/commands.log" ] \
+    || fail "retirement invoked a forbidden external command: $(cat "$home/commands.log")"
+  pass "record retirement never resolves or touches the recorded copy"
+}
+
+test_ship_requires_clean_remote_tip_proof() {
+  local home id sha rc
+  home=$(make_home remote-proof)
+  id=ship-custodied
+  sha=0123456789abcdef0123456789abcdef01234567
+  fm_write_meta "$home/state/$id.meta" \
+    "window=firstmate:fm-$id" \
+    "endpoint_task_id=$id" \
+    "worktree=$home/copies/missing" \
+    "project=$home/projects/sample" \
+    "harness=codex" \
+    "kind=ship" \
+    "record_retire_work_head=$sha" \
+    "record_retire_worktree_clean=1"
+  FM_FAKE_REMOTE_SHA=$sha FM_FAKE_REMOTE_REF=refs/pull/18/head \
+    run_retire "$home" "$id" --work-safety remote-ref \
+      --remote-url https://github.com/example/sample.git --remote-ref refs/pull/18/head >/dev/null \
+    || fail "exact remote-tip custody proof was refused"
+  assert_absent "$home/state/$id.meta" "remote-ref retirement left ship metadata"
+  assert_present "$home/state/.record-retired-$id" "remote-ref retirement marker is absent"
+
+  home=$(make_home remote-mismatch)
+  id=ship-not-custodied
+  fm_write_meta "$home/state/$id.meta" \
+    "window=firstmate:fm-$id" \
+    "endpoint_task_id=$id" \
+    "worktree=$home/copies/missing" \
+    "project=$home/projects/sample" \
+    "harness=codex" \
+    "kind=ship" \
+    "record_retire_work_head=$sha" \
+    "record_retire_worktree_clean=1"
+  set +e
+  FM_FAKE_REMOTE_SHA=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+    FM_FAKE_REMOTE_REF=refs/heads/main \
+    run_retire "$home" "$id" --work-safety remote-ref \
+      --remote-url https://github.com/example/sample.git --remote-ref refs/heads/main \
+      > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "mismatched remote tip was accepted"
+  assert_grep "not attested work head" "$home/err" "remote mismatch refusal did not name exact inequality"
+  assert_present "$home/state/$id.meta" "remote mismatch removed ship metadata"
+
+  home=$(make_home local-remote)
+  id=ship-local-only
+  fm_write_meta "$home/state/$id.meta" \
+    "window=firstmate:fm-$id" \
+    "endpoint_task_id=$id" \
+    "worktree=$home/copies/missing" \
+    "project=$home/projects/sample" \
+    "harness=codex" \
+    "kind=ship" \
+    "record_retire_work_head=$sha" \
+    "record_retire_worktree_clean=1"
+  set +e
+  FM_FAKE_REMOTE_SHA=$sha FM_FAKE_REMOTE_REF=refs/heads/main \
+    run_retire "$home" "$id" --work-safety remote-ref \
+      --remote-url https://localhost/sample.git --remote-ref refs/heads/main \
+      > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "local remote was accepted as off-disk custody"
+  assert_grep "explicit GitHub" "$home/err" "local remote refusal did not name the custody boundary"
+  [ ! -s "$home/commands.log" ] || fail "local remote refusal contacted git"
+  assert_present "$home/state/$id.meta" "local remote refusal removed ship metadata"
+  pass "ship retirement requires a clean attested head at the exact remote tip"
+}
+
+test_unsafe_state_artifact_refuses() {
+  local home id outside rc
+  home=$(make_home unsafe-artifact)
+  id=scout-unsafe-state
+  write_scout "$home" "$id" "$home/copies/missing"
+  outside="$home/outside-runtime-state"
+  printf 'outside bytes\n' > "$outside"
+  ln -s "$outside" "$home/state/$id.pi-ext.ts"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report \
+    > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "unsafe task-state symlink was accepted"
+  assert_grep "unsafe task-state artifact" "$home/err" "unsafe artifact refusal was not concrete"
+  assert_content "$outside" "outside bytes" "unsafe artifact refusal touched the symlink target"
+  assert_present "$home/state/$id.meta" "unsafe artifact refusal removed metadata"
+  pass "record retirement refuses unsafe state paths before removal"
+}
+
+test_explicit_safety_mode_is_mandatory() {
+  local home id rc
+  home=$(make_home explicit-mode)
+  id=scout-explicit
+  write_scout "$home" "$id" "$home/copies/missing"
+  set +e
+  run_retire "$home" "$id" > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "missing work-safety mode silently defaulted"
+  assert_grep "--work-safety is required" "$home/err" "missing-mode refusal was not concrete"
+  assert_present "$home/state/$id.meta" "missing-mode refusal removed metadata"
+  pass "record retirement never defaults the unlanded-work proof"
+}
+
+test_task_binding_is_exact() {
+  local home id rc
+  home=$(make_home binding)
+  id=scout-binding
+  write_scout "$home" "$id" "$home/copies/missing"
+  printf 'endpoint_task_id=another-lane\n' >> "$home/state/$id.meta"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "ambiguous task binding was accepted"
+  assert_grep "exactly one nonempty endpoint_task_id" "$home/err" \
+    "task-binding refusal did not name the exact requirement"
+  assert_present "$home/state/$id.meta" "task-binding refusal removed metadata"
+  pass "record retirement requires one exact task binding"
+}
+
+test_decision_gate_is_mandatory_for_scouts() {
+  local home id rc filtered
+  home=$(make_home decision-gate)
+  id=scout-unreviewed
+  write_scout "$home" "$id" "$home/copies/missing"
+  filtered="$home/state/$id.meta.filtered"
+  awk '$0 != "decisions_reviewed=1"' "$home/state/$id.meta" > "$filtered"
+  mv -f "$filtered" "$home/state/$id.meta"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "unreviewed scout decision inventory was accepted"
+  assert_grep "unresolved-decision completion gate" "$home/err" \
+    "decision-gate refusal did not name the missing requirement"
+  assert_present "$home/state/$id.meta" "decision-gate refusal removed metadata"
+  pass "record retirement preserves the scout decision-hold completion gate"
+}
+
+test_busy_incarnation_must_be_bound() {
+  local home id rc
+  home=$(make_home busy-binding)
+  id=scout-busy-unbound
+  write_scout "$home" "$id" "$home/copies/missing"
+  printf 'v1 gen=g1 seq=1 state=idle source=test event=test ts=1\n' \
+    > "$home/state/$id.busy-state"
+  printf 'g1\n' > "$home/state/$id.busy-gen"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "unbound busy incarnation was retired"
+  assert_grep "busy-state exists but metadata has no exact busy_gen" "$home/err" \
+    "busy-incarnation refusal did not name the missing binding"
+  assert_present "$home/state/$id.busy-state" "busy-incarnation refusal removed busy state"
+  assert_present "$home/state/$id.meta" "busy-incarnation refusal removed metadata"
+  pass "record retirement refuses an unbound busy-state incarnation"
+}
+
+test_runtime_binding_must_be_settled() {
+  local home id rc
+  home=$(make_home runtime-binding)
+  id=scout-runtime-bound
+  write_scout "$home" "$id" "$home/copies/missing"
+  mkdir -p "$home/state/terminal-outcomes"
+  printf 'schema=fm-terminal-outcome.v1\ntask_id=%s\n' "$id" \
+    > "$home/state/terminal-outcomes/exact.pending"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "task-owned runtime binding was silently orphaned"
+  assert_grep "still owns runtime binding" "$home/err" \
+    "runtime-binding refusal did not name the exact record"
+  assert_present "$home/state/$id.meta" "runtime-binding refusal removed metadata"
+  pass "record retirement refuses task-owned runtime bindings"
+}
+
+test_public_followup_presence_refuses() {
+  local home id rc
+  home=$(make_home public-followup)
+  id=scout-public-bound
+  write_scout "$home" "$id" "$home/copies/missing"
+  mkdir -p "$home/state/public-followup/registry"
+  printf 'obligation_id=other\n' > "$home/state/public-followup/registry/other"
+  set +e
+  FMX_PAIRING_TOKEN=test-token \
+    run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "active public-followup registrations were ignored"
+  assert_grep "public-followup registrations exist" "$home/err" \
+    "public-followup refusal did not name the unsettled subsystem"
+  assert_present "$home/state/$id.meta" "public-followup refusal removed metadata"
+  pass "record retirement refuses while public-followup state is active"
+}
+
+test_invalid_retirement_marker_refuses_before_mutation() {
+  local home id outside rc
+  home=$(make_home invalid-marker)
+  id=scout-invalid-marker
+  write_scout "$home" "$id" "$home/copies/missing"
+  outside="$home/outside-marker"
+  printf 'not a retirement marker\n' > "$outside"
+  ln -s "$outside" "$home/state/.record-retired-$id"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "unsafe preexisting retirement marker was accepted"
+  assert_grep "existing record-retirement marker is unsafe" "$home/err" \
+    "marker refusal did not name the unsafe record"
+  assert_present "$home/state/$id.status" "marker refusal removed status before refusing"
+  assert_present "$home/state/$id.meta" "marker refusal removed metadata"
+  assert_content "$outside" "not a retirement marker" "marker refusal touched the symlink target"
+  pass "record retirement validates its mute marker before any retirement mutation"
+}
+
+run_test() {  # <test-function>
+  [ -z "${FM_RECORD_RETIRE_TEST_ONLY:-}" ] \
+    || [ "$FM_RECORD_RETIRE_TEST_ONLY" = "$1" ] \
+    || return 0
+  "$1"
+}
+
+run_test test_ordinary_retire
+run_test test_aliased_copy_is_safe
+run_test test_unprovable_safety_refuses_without_mutation
+run_test test_no_copy_touched_even_when_copy_is_hostile
+run_test test_ship_requires_clean_remote_tip_proof
+run_test test_unsafe_state_artifact_refuses
+run_test test_explicit_safety_mode_is_mandatory
+run_test test_task_binding_is_exact
+run_test test_decision_gate_is_mandatory_for_scouts
+run_test test_busy_incarnation_must_be_bound
+run_test test_runtime_binding_must_be_settled
+run_test test_public_followup_presence_refuses
+run_test test_invalid_retirement_marker_refuses_before_mutation

--- a/tests/fm-record-retire.test.sh
+++ b/tests/fm-record-retire.test.sh
@@ -1173,12 +1173,13 @@ test_live_metadata_keeps_marker_consumers_audible() {
 }
 
 test_surface_artifact_paths_are_producer_owned() {
-  local home id actual expected
+  local home id window actual expected expected_path
   home=$(make_home producer-owned-surface-paths)
   id=task.a_b
+  window='a:b:c/d/e.f.g'
   actual=$(FM_STATE_OVERRIDE="$home/state" bash -c \
-    '. "$1"; fm_wake_task_surface_paths "$2" "$3"' _ \
-    "$ROOT/bin/fm-wake-lib.sh" "$home/state" "$id")
+    '. "$1"; fm_record_retire_artifact_paths "$2" "$3" "$4"' _ \
+    "$ROOT/bin/fm-wake-lib.sh" "$home/state" "$id" "$window")
   expected=$(FM_STATE_OVERRIDE="$home/state" bash -c '
     . "$1"
     fm_wake_signal_seen_path "$2" "$2/$3.status"
@@ -1187,24 +1188,51 @@ test_surface_artifact_paths_are_producer_owned() {
     printf "\n"
     fm_wake_hb_surfaced_path "$2" "$3"
   ' _ "$ROOT/bin/fm-wake-lib.sh" "$home/state" "$id")
-  [ "$actual" = "$expected" ] \
-    || fail "retirement surface-artifact inventory diverged from its producers"
+  while IFS= read -r expected_path; do
+    [ -n "$expected_path" ] || continue
+    printf '%s\n' "$actual" | grep -Fqx "$expected_path" \
+      || fail "retirement surface-artifact inventory omitted producer path $expected_path"
+  done <<EOF
+$expected
+EOF
   printf '%s\n' "$actual" | grep -q '/.seen-task_a_b_status$' \
     || fail "producer-owned status marker path did not collapse the dotted id"
   printf '%s\n' "$actual" | grep -q '/.seen-task_a_b_turn-ended$' \
     || fail "producer-owned turn-end marker path did not collapse the dotted id"
   printf '%s\n' "$actual" | grep -q '/.hb-surfaced-task_a_b$' \
     || fail "producer-owned heartbeat marker path did not collapse the dotted id"
+  printf '%s\n' "$actual" | grep -q '/.hash-a_b_c_d_e_f_g$' \
+    || fail "artifact inventory did not use the fully collapsed watcher key"
+  printf '%s\n' "$actual" | grep -q '/.seen-task\.a_b_status$' \
+    && fail "artifact inventory re-derived the raw dotted task id"
   pass "retirement obtains seen and heartbeat surface paths from their producers"
 }
 
 test_watcher_key_collapses_every_occurrence() {
-  local actual
+  local actual collision
   actual=$(bash -c '. "$1"; fm_record_retire_watcher_state_key "$2"' _ \
     "$RETIRE_LIB" 'a:b:c/d/e.f.g')
   [ "$actual" = 'a_b_c_d_e_f_g' ] \
     || fail "watcher state key did not collapse every punctuation occurrence: $actual"
-  pass "watcher state keys collapse every colon, slash, and dot"
+  collision=$(bash -c '. "$1"; fm_record_retire_window_collision "$2" "$3"' _ \
+    "$RETIRE_LIB" 'a:b:c/d/e.f.g' 'a_b_c_d_e_f_g') \
+    || fail "collapsed watcher-key collision was not detected"
+  [ "$collision" = collapsed ] \
+    || fail "collapsed watcher-key collision was misclassified: $collision"
+  collision=$(bash -c '. "$1"; fm_record_retire_window_collision "$2" "$3"' _ \
+    "$RETIRE_LIB" 'a_b_c_d_e_f_g' 'a:b:c/d/e.f.g') \
+    || fail "reverse-direction collapsed watcher-key collision was not detected"
+  [ "$collision" = collapsed ] \
+    || fail "reverse-direction watcher-key collision was misclassified: $collision"
+  collision=$(bash -c '. "$1"; fm_record_retire_window_collision "$2" "$3"' _ \
+    "$RETIRE_LIB" 'same:window' 'same:window') \
+    || fail "raw runtime-slot collision was not detected"
+  [ "$collision" = raw ] || fail "raw runtime-slot collision was misclassified: $collision"
+  if bash -c '. "$1"; fm_record_retire_window_collision "$2" "$3"' _ \
+    "$RETIRE_LIB" 'different:one' 'different:two'; then
+    fail "noncolliding runtime windows were classified as a collision"
+  fi
+  pass "watcher keys fully collapse and classify raw and collapsed runtime-slot collisions"
 }
 
 test_muted_wake_releases_queue_lock() {

--- a/tests/fm-record-retire.test.sh
+++ b/tests/fm-record-retire.test.sh
@@ -1138,6 +1138,91 @@ test_retired_marker_hides_status_snapshot() {
   pass "status presentation snapshots omit validly retired tasks"
 }
 
+test_live_metadata_keeps_marker_consumers_audible() {
+  local home id digest decisions snapshot queue
+  home=$(make_home marker-with-live-metadata)
+  id='live-after-marker-publication'
+  digest=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  printf 'window=firstmate:fm-%s\nkind=ship\n' "$id" > "$home/state/$id.meta"
+  printf 'needs-decision: [key=still-live] captain review remains open\n' \
+    > "$home/state/$id.status"
+  write_retirement_marker "$home/state" "$id" "firstmate:fm-$id" "$digest"
+  : > "$home/state/.wake-queue"
+
+  if bash -c '. "$1"; fm_record_retire_marker_active "$2" "$3"' _ \
+    "$RETIRE_LIB" "$home/state" "$id"; then
+    fail "a retirement marker became active while canonical metadata still existed"
+  fi
+  decisions=$(FM_STATE_OVERRIDE="$home/state" bash -c \
+    '. "$1"; scan_open_decisions "$2"' _ "$ROOT/bin/fm-classify-lib.sh" "$home/state")
+  printf '%s\n' "$decisions" | grep -q "$id" \
+    || fail "full decision scan hid a live task after marker publication"
+  snapshot=$(FM_STATE_OVERRIDE="$home/state" bash -c \
+    '. "$1"; status_presentation_snapshot "$2"' _ \
+    "$ROOT/bin/fm-classify-lib.sh" "$home/state")
+  printf '%s\n' "$snapshot" | grep -q "$id" \
+    || fail "status snapshot hid a live task after marker publication"
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    bash -c '. "$1"; fm_wake_append check "$2" "check: still live"' _ \
+    "$ROOT/bin/fm-wake-lib.sh" "$home/state/$id.check.sh" \
+    || fail "live task check wake could not be appended"
+  queue=$(cat "$home/state/.wake-queue")
+  printf '%s\n' "$queue" | grep -q "$id.check.sh" \
+    || fail "check wake was muted while canonical metadata still existed"
+  pass "live metadata keeps full decisions, snapshots, and check wakes audible after marker publication"
+}
+
+test_surface_artifact_paths_are_producer_owned() {
+  local home id actual expected
+  home=$(make_home producer-owned-surface-paths)
+  id=task.a_b
+  actual=$(FM_STATE_OVERRIDE="$home/state" bash -c \
+    '. "$1"; fm_wake_task_surface_paths "$2" "$3"' _ \
+    "$ROOT/bin/fm-wake-lib.sh" "$home/state" "$id")
+  expected=$(FM_STATE_OVERRIDE="$home/state" bash -c '
+    . "$1"
+    fm_wake_signal_seen_path "$2" "$2/$3.status"
+    printf "\n"
+    fm_wake_signal_seen_path "$2" "$2/$3.turn-ended"
+    printf "\n"
+    fm_wake_hb_surfaced_path "$2" "$3"
+  ' _ "$ROOT/bin/fm-wake-lib.sh" "$home/state" "$id")
+  [ "$actual" = "$expected" ] \
+    || fail "retirement surface-artifact inventory diverged from its producers"
+  printf '%s\n' "$actual" | grep -q '/.seen-task_a_b_status$' \
+    || fail "producer-owned status marker path did not collapse the dotted id"
+  printf '%s\n' "$actual" | grep -q '/.seen-task_a_b_turn-ended$' \
+    || fail "producer-owned turn-end marker path did not collapse the dotted id"
+  printf '%s\n' "$actual" | grep -q '/.hb-surfaced-task_a_b$' \
+    || fail "producer-owned heartbeat marker path did not collapse the dotted id"
+  pass "retirement obtains seen and heartbeat surface paths from their producers"
+}
+
+test_watcher_key_collapses_every_occurrence() {
+  local actual
+  actual=$(bash -c '. "$1"; fm_record_retire_watcher_state_key "$2"' _ \
+    "$RETIRE_LIB" 'a:b:c/d/e.f.g')
+  [ "$actual" = 'a_b_c_d_e_f_g' ] \
+    || fail "watcher state key did not collapse every punctuation occurrence: $actual"
+  pass "watcher state keys collapse every colon, slash, and dot"
+}
+
+test_muted_wake_releases_queue_lock() {
+  local home id digest
+  home=$(make_home muted-wake-lock-release)
+  id=retired-lock-release
+  digest=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  write_retirement_marker "$home/state" "$id" "firstmate:fm-$id" "$digest"
+  : > "$home/state/.wake-queue"
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    bash -c '. "$1"; fm_wake_append signal "$2.status" "signal: late"' _ \
+    "$ROOT/bin/fm-wake-lib.sh" "$id" || fail "muted wake append failed"
+  [ ! -e "$home/state/.wake-queue.lock" ] && [ ! -L "$home/state/.wake-queue.lock" ] \
+    || fail "muted wake returned while still owning the queue lock"
+  [ ! -s "$home/state/.wake-queue" ] || fail "muted wake was appended to the queue"
+  pass "muted wakes release the queue lock before returning"
+}
+
 test_partial_wake_library_fails_open() {
   local home id rc
   home=$(make_home partial-wake-library)
@@ -1999,6 +2084,10 @@ run_test test_marker_does_not_mute_unknown_wake_kind
 run_test test_retired_marker_hides_full_open_decision_scan
 run_test test_retired_marker_hides_incremental_open_decision_scan
 run_test test_retired_marker_hides_status_snapshot
+run_test test_live_metadata_keeps_marker_consumers_audible
+run_test test_surface_artifact_paths_are_producer_owned
+run_test test_watcher_key_collapses_every_occurrence
+run_test test_muted_wake_releases_queue_lock
 run_test test_partial_wake_library_fails_open
 run_test test_partial_classify_library_fails_open
 run_test test_watcher_key_collision_refuses

--- a/tests/fm-record-retire.test.sh
+++ b/tests/fm-record-retire.test.sh
@@ -30,10 +30,11 @@ write_fake_tools() {  # <home>
     '#!/usr/bin/env bash' \
     'printf "git %s\n" "$*" >> "${FM_COMMAND_LOG:?}"' \
     'case "${1:-}" in' \
-    '  check-ref-format) exit 0 ;;' \
+    '  check-ref-format) [ "${2:-}" != "refs/heads/bad..name" ]; exit ;;' \
     '  ls-remote)' \
     '    [ -n "${FM_FAKE_REMOTE_SHA:-}" ] || exit 97' \
     '    printf "%s\t%s\n" "$FM_FAKE_REMOTE_SHA" "$FM_FAKE_REMOTE_REF"' \
+    '    [ "${FM_FAKE_REMOTE_DUPLICATE:-0}" != 1 ] || printf "%s\t%s\n" "$FM_FAKE_REMOTE_SHA" "$FM_FAKE_REMOTE_REF"' \
     '    exit 0 ;;' \
     'esac' \
     'exit 97' > "$fakebin/git"
@@ -149,6 +150,115 @@ test_aliased_copy_is_safe() {
   [ ! -s "$home/commands.log" ] \
     || fail "aliased-copy retirement invoked an external lifecycle command"
   pass "record retirement is safe when the recorded copy is aliased by another live lane"
+}
+
+test_recycled_runtime_slot_refuses() {  # <backend>
+  local backend=$1 home stale live shared window key prefix rc queue_before queue_after
+  home=$(make_home "runtime-alias-$backend")
+  stale="scout-stale-$backend"
+  live="ship-live-$backend"
+  shared="$home/copies/recycled-slot"
+  window="${backend}-session:%17"
+  key=${window//:/_}
+  key=${key//\//_}
+  key=${key//./_}
+  mkdir -p "$shared"
+  printf 'live lane owns these bytes\n' > "$shared/live-sentinel"
+  write_scout "$home" "$stale" "$shared"
+  printf 'backend=%s\n' "$backend" >> "$home/state/$stale.meta"
+  awk -v window="$window" '
+    /^window=/ { print "window=" window; next }
+    { print }
+  ' "$home/state/$stale.meta" > "$home/state/$stale.meta.next"
+  mv -f "$home/state/$stale.meta.next" "$home/state/$stale.meta"
+  fm_write_meta "$home/state/$live.meta" \
+    "window=$window" \
+    "endpoint_task_id=$live" \
+    "worktree=$shared" \
+    "project=$home/projects/sample" \
+    "harness=codex" \
+    "kind=ship" \
+    "backend=$backend"
+  for prefix in hash count stale stale-since paused wedge-escalations; do
+    printf 'live %s state\n' "$prefix" > "$home/state/.$prefix-$key"
+  done
+  printf '1\t1\tstale\t%s\tstale: live lane wedged\n' "$window" > "$home/state/.wake-queue"
+
+  set +e
+  run_retire "$home" "$stale" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "$backend recycled runtime slot was accepted"
+  assert_grep "runtime slot is also recorded by $live" "$home/err" \
+    "$backend refusal did not name the live lane sharing the runtime slot"
+  assert_present "$home/state/$stale.meta" "$backend refusal removed the stale record"
+  assert_present "$home/state/$live.meta" "$backend refusal removed the live record"
+  for prefix in hash count stale stale-since paused wedge-escalations; do
+    assert_content "$home/state/.$prefix-$key" "live $prefix state" \
+      "$backend refusal changed the live lane's $prefix state"
+  done
+  assert_content "$home/copies/recycled-slot/live-sentinel" "live lane owns these bytes" \
+    "$backend refusal touched the aliased live copy"
+  queue_before=$(wc -l < "$home/state/.wake-queue" | tr -d ' ')
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    bash -c '. "$1"; fm_wake_append stale "$2" "stale: live lane still wedged"' _ \
+    "$ROOT/bin/fm-wake-lib.sh" "$window" \
+    || fail "$backend live lane could not append a future wedge notification"
+  queue_after=$(wc -l < "$home/state/.wake-queue" | tr -d ' ')
+  [ "$queue_after" -eq $((queue_before + 1)) ] \
+    || fail "$backend live lane's future wedge notification was muted"
+  pass "$backend retirement refuses a recycled runtime slot and preserves live wedge detection"
+}
+
+test_recycled_runtime_slot_refuses_herdr() {
+  test_recycled_runtime_slot_refuses herdr
+}
+
+test_recycled_runtime_slot_refuses_zellij() {
+  test_recycled_runtime_slot_refuses zellij
+}
+
+test_recycled_runtime_slot_refuses_cmux() {
+  test_recycled_runtime_slot_refuses cmux
+}
+
+test_retired_runtime_slot_can_be_reused() {  # <backend>
+  local backend=$1 home stale live window
+  home=$(make_home "runtime-reuse-$backend")
+  stale="scout-retired-$backend"
+  live="ship-reusing-$backend"
+  window="${backend}-session:%23"
+  write_scout "$home" "$stale" "$home/copies/missing"
+  printf 'backend=%s\n' "$backend" >> "$home/state/$stale.meta"
+  awk -v window="$window" '
+    /^window=/ { print "window=" window; next }
+    { print }
+  ' "$home/state/$stale.meta" > "$home/state/$stale.meta.next"
+  mv -f "$home/state/$stale.meta.next" "$home/state/$stale.meta"
+  run_retire "$home" "$stale" --work-safety scout-report >/dev/null \
+    || fail "$backend record could not retire before later slot reuse"
+  fm_write_meta "$home/state/$live.meta" \
+    "window=$window" "endpoint_task_id=$live" "kind=ship" "backend=$backend"
+  : > "$home/state/.wake-queue"
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    bash -c '. "$1"; fm_wake_append stale "$2" "stale: reused live slot wedged"' _ \
+    "$ROOT/bin/fm-wake-lib.sh" "$window" \
+    || fail "$backend reused live slot could not append a wedge notification"
+  [ "$(wc -l < "$home/state/.wake-queue" | tr -d ' ')" -eq 1 ] \
+    || fail "$backend retirement marker permanently muted a later live slot occupant"
+  pass "$backend retired slot can be reused later without muting the new live lane"
+}
+
+test_retired_runtime_slot_can_be_reused_herdr() {
+  test_retired_runtime_slot_can_be_reused herdr
+}
+
+test_retired_runtime_slot_can_be_reused_zellij() {
+  test_retired_runtime_slot_can_be_reused zellij
+}
+
+test_retired_runtime_slot_can_be_reused_cmux() {
+  test_retired_runtime_slot_can_be_reused cmux
 }
 
 test_unprovable_safety_refuses_without_mutation() {
@@ -406,6 +516,392 @@ test_invalid_retirement_marker_refuses_before_mutation() {
   pass "record retirement validates its mute marker before any retirement mutation"
 }
 
+test_kind_and_remote_attestation_guards() {
+  local home id sha rc filtered
+  sha=0123456789abcdef0123456789abcdef01234567
+
+  home=$(make_home scout-kind)
+  id=ship-with-report
+  write_scout "$home" "$id" "$home/copies/missing"
+  filtered="$home/state/$id.meta.filtered"
+  awk '{ sub(/^kind=scout$/, "kind=ship"); print }' "$home/state/$id.meta" > "$filtered"
+  mv -f "$filtered" "$home/state/$id.meta"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "scout-report accepted a ship record"
+  assert_grep "scout-report safety requires kind=scout" "$home/err" \
+    "scout kind refusal was not concrete"
+
+  home=$(make_home remote-kind)
+  id=scout-with-remote-proof
+  write_scout "$home" "$id" "$home/copies/missing"
+  printf 'record_retire_work_head=%s\nrecord_retire_worktree_clean=1\n' "$sha" \
+    >> "$home/state/$id.meta"
+  set +e
+  FM_FAKE_REMOTE_SHA=$sha FM_FAKE_REMOTE_REF=refs/heads/main \
+    run_retire "$home" "$id" --work-safety remote-ref \
+      --remote-url https://github.com/example/sample.git --remote-ref refs/heads/main \
+      > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "remote-ref accepted a scout record"
+  assert_grep "remote-ref safety requires kind=ship" "$home/err" \
+    "remote kind refusal was not concrete"
+
+  home=$(make_home malformed-head)
+  id=ship-malformed-head
+  fm_write_meta "$home/state/$id.meta" \
+    "window=firstmate:fm-$id" "endpoint_task_id=$id" "kind=ship" \
+    "record_retire_work_head=0123456" "record_retire_worktree_clean=1"
+  set +e
+  run_retire "$home" "$id" --work-safety remote-ref \
+    --remote-url https://github.com/example/sample.git --remote-ref refs/heads/main \
+    > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "abbreviated work head was accepted"
+  assert_grep "not a full lowercase commit id" "$home/err" \
+    "work-head format refusal was not concrete"
+
+  home=$(make_home dirty-attestation)
+  id=ship-dirty-attestation
+  fm_write_meta "$home/state/$id.meta" \
+    "window=firstmate:fm-$id" "endpoint_task_id=$id" "kind=ship" \
+    "record_retire_work_head=$sha" "record_retire_worktree_clean=0"
+  set +e
+  run_retire "$home" "$id" --work-safety remote-ref \
+    --remote-url https://github.com/example/sample.git --remote-ref refs/heads/main \
+    > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "dirty worktree attestation was accepted"
+  assert_grep "record_retire_worktree_clean must equal 1" "$home/err" \
+    "clean-attestation refusal was not concrete"
+
+  pass "work-safety modes enforce record kind, full head, and clean attestation"
+}
+
+test_remote_ref_shape_and_cardinality_guards() {
+  local home id sha rc
+  sha=0123456789abcdef0123456789abcdef01234567
+  home=$(make_home bad-ref)
+  id=ship-bad-ref
+  fm_write_meta "$home/state/$id.meta" \
+    "window=firstmate:fm-$id" "endpoint_task_id=$id" "kind=ship" \
+    "record_retire_work_head=$sha" "record_retire_worktree_clean=1"
+  set +e
+  run_retire "$home" "$id" --work-safety remote-ref \
+    --remote-url https://github.com/example/sample.git --remote-ref refs/heads/bad..name \
+    > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "invalid full ref name was accepted"
+  assert_grep "not a valid full ref name" "$home/err" "invalid-ref refusal was not concrete"
+
+  home=$(make_home duplicate-ref)
+  id=ship-duplicate-ref
+  fm_write_meta "$home/state/$id.meta" \
+    "window=firstmate:fm-$id" "endpoint_task_id=$id" "kind=ship" \
+    "record_retire_work_head=$sha" "record_retire_worktree_clean=1"
+  set +e
+  FM_FAKE_REMOTE_SHA=$sha FM_FAKE_REMOTE_REF=refs/heads/main FM_FAKE_REMOTE_DUPLICATE=1 \
+    run_retire "$home" "$id" --work-safety remote-ref \
+      --remote-url https://github.com/example/sample.git --remote-ref refs/heads/main \
+      > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "duplicate remote matches were accepted"
+  assert_grep "exactly one match" "$home/err" "remote-cardinality refusal was not concrete"
+  pass "remote custody requires a valid full ref and exactly one advertised match"
+}
+
+test_identity_and_task_kind_guards() {
+  local home id rc
+  home=$(make_home mismatched-binding)
+  id=scout-mismatched-binding
+  write_scout "$home" "$id" "$home/copies/missing"
+  awk '{ sub(/^endpoint_task_id=.*/, "endpoint_task_id=another-task"); print }' \
+    "$home/state/$id.meta" > "$home/state/$id.meta.next"
+  mv -f "$home/state/$id.meta.next" "$home/state/$id.meta"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "single mismatched task binding was accepted"
+  assert_grep "metadata belongs to task another-task" "$home/err" \
+    "mismatched task-binding refusal was not concrete"
+
+  home=$(make_home secondmate-kind)
+  id=secondmate-record
+  write_scout "$home" "$id" "$home/copies/missing"
+  awk '{ sub(/^kind=scout$/, "kind=secondmate"); print }' \
+    "$home/state/$id.meta" > "$home/state/$id.meta.next"
+  mv -f "$home/state/$id.meta.next" "$home/state/$id.meta"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "secondmate record was accepted"
+  assert_grep "secondmate homes require the dedicated teardown path" "$home/err" \
+    "secondmate refusal was not concrete"
+  pass "record retirement enforces exact task identity and excludes secondmates"
+}
+
+test_metadata_busy_and_quarantine_guards() {
+  local home id outside rc
+  home=$(make_home hardlinked-meta)
+  id=scout-hardlinked-meta
+  write_scout "$home" "$id" "$home/copies/missing"
+  ln "$home/state/$id.meta" "$home/outside-meta-link"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "hardlinked metadata was accepted"
+  assert_grep "metadata is not a regular single-link" "$home/err" \
+    "metadata-link refusal was not concrete"
+
+  home=$(make_home busy-writer-lock)
+  id=scout-busy-writer
+  write_scout "$home" "$id" "$home/copies/missing"
+  mkdir "$home/state/$id.busy-state.lock"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "busy-state writer lock was ignored"
+  assert_grep "busy-state writer lock exists" "$home/err" \
+    "busy-writer refusal was not concrete"
+
+  home=$(make_home unsafe-quarantine)
+  id=scout-unsafe-quarantine
+  write_scout "$home" "$id" "$home/copies/missing"
+  outside="$home/outside-quarantine"
+  printf 'outside bytes\n' > "$outside"
+  mkdir -p "$home/state/.pr-check-quarantine"
+  ln -s "$outside" "$home/state/.pr-check-quarantine/$id.legacy"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "unsafe quarantine entry was accepted"
+  assert_grep "unsafe task quarantine entry" "$home/err" \
+    "quarantine refusal was not concrete"
+  assert_content "$outside" "outside bytes" "quarantine refusal touched the symlink target"
+  pass "metadata, busy-writer, and quarantine artifacts fail closed"
+}
+
+test_task_set_and_directory_guards() {
+  local home id rc real_state
+  home=$(make_home task-set-lock)
+  id=scout-task-set-lock
+  write_scout "$home" "$id" "$home/copies/missing"
+  set +e
+  PATH="$home/fakebin:$PATH" FM_TASKS_AXI_COMPATIBLE=1 \
+    FM_COMMAND_LOG="$home/commands.log" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_CONFIG_OVERRIDE="$home/config" bash -c '
+      . "$1"
+      lock=$(fm_task_set_lock_path "$FM_STATE_OVERRIDE") || exit 80
+      fm_lock_acquire_wait "$lock" || exit 81
+      "$2" "$3" --work-safety scout-report
+      rc=$?
+      fm_lock_release "$lock"
+      exit "$rc"
+    ' _ "$ROOT/bin/fm-wake-lib.sh" "$RETIRE" "$id" > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "task-set lifecycle lock was ignored"
+  assert_grep "task set is changing" "$home/err" "task-set lock refusal was not concrete"
+  assert_present "$home/state/$id.meta" "task-set lock refusal removed metadata"
+
+  home=$(make_home control-lock)
+  id=scout-control-lock
+  write_scout "$home" "$id" "$home/copies/missing"
+  set +e
+  PATH="$home/fakebin:$PATH" FM_TASKS_AXI_COMPATIBLE=1 \
+    FM_COMMAND_LOG="$home/commands.log" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_CONFIG_OVERRIDE="$home/config" bash -c '
+      . "$1"
+      lock="$FM_STATE_OVERRIDE/.control-$3.lock"
+      fm_lock_acquire_wait "$lock" || exit 80
+      "$2" "$3" --work-safety scout-report
+      rc=$?
+      fm_lock_release "$lock"
+      exit "$rc"
+    ' _ "$ROOT/bin/fm-wake-lib.sh" "$RETIRE" "$id" > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "task lifecycle control lock was ignored"
+  assert_grep "another lifecycle action is already running" "$home/err" \
+    "control-lock refusal was not concrete"
+  assert_present "$home/state/$id.meta" "control-lock refusal removed metadata"
+
+  home=$(make_home unsafe-state-dir)
+  id=scout-unsafe-state-dir
+  write_scout "$home" "$id" "$home/copies/missing"
+  real_state="$home/state-real"
+  mv "$home/state" "$real_state"
+  ln -s "$real_state" "$home/state"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "symlinked state directory was accepted"
+  assert_grep "state directory is absent or unsafe" "$home/err" \
+    "state-directory refusal was not concrete"
+  assert_present "$real_state/$id.meta" "state-directory refusal removed metadata"
+  pass "task-set and state-directory boundaries refuse before mutation"
+}
+
+test_task_id_guard() {
+  local home rc
+  home=$(make_home invalid-task-id)
+  set +e
+  run_retire "$home" ../escape --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -eq 2 ] || fail "invalid task id did not stop at usage validation (rc=$rc)"
+  assert_absent "$home/state/.record-retired-../escape" "invalid task id published a marker"
+  pass "task ids must be privacy-safe slugs before any path is composed"
+}
+
+test_marker_integrity_and_fail_open_guards() {
+  local home id digest rc before after outside
+  digest=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+  home=$(make_home invalid-regular-marker)
+  id=scout-invalid-regular-marker
+  write_scout "$home" "$id" "$home/copies/missing"
+  printf 'schema=fm-record-retired.v1\ntask_id=%s\nwindow=firstmate:fm-%s\nmeta_sha256=bad\n' \
+    "$id" "$id" > "$home/state/.record-retired-$id"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "invalid regular retirement marker was accepted"
+  assert_grep "existing record-retirement marker is invalid" "$home/err" \
+    "regular marker refusal was not concrete"
+
+  home=$(make_home symlink-marker-mute)
+  id='live-symlink-marker'
+  outside="$home/outside-valid-marker"
+  printf 'schema=fm-record-retired.v1\ntask_id=%s\nwindow=firstmate:fm-%s\nmeta_sha256=%s\n' \
+    "$id" "$id" "$digest" > "$outside"
+  ln -s "$outside" "$home/state/.record-retired-$id"
+  : > "$home/state/.wake-queue"
+  before=$(wc -l < "$home/state/.wake-queue" | tr -d ' ')
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    bash -c '. "$1"; fm_wake_append signal "$2.status" "signal: live"' _ \
+    "$ROOT/bin/fm-wake-lib.sh" "$id" || fail "symlink-marker wake append failed"
+  after=$(wc -l < "$home/state/.wake-queue" | tr -d ' ')
+  [ "$after" -eq $((before + 1)) ] || fail "symlink marker muted a live task"
+
+  home=$(make_home foreign-marker-mute)
+  id='live-foreign-marker'
+  printf 'schema=fm-record-retired.v1\ntask_id=another-task\nwindow=firstmate:fm-%s\nmeta_sha256=%s\n' \
+    "$id" "$digest" > "$home/state/.record-retired-$id"
+  : > "$home/state/.wake-queue"
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    bash -c '. "$1"; fm_wake_append signal "$2.status" "signal: live"' _ \
+    "$ROOT/bin/fm-wake-lib.sh" "$id" || fail "foreign-marker wake append failed"
+  [ "$(wc -l < "$home/state/.wake-queue" | tr -d ' ')" -eq 1 ] \
+    || fail "foreign task marker muted a live task"
+
+  home=$(make_home spawn-invalid-marker)
+  id=fresh-incarnation
+  printf 'not a marker\n' > "$home/state/.record-retired-$id"
+  set +e
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    bash -c '. "$1"; fm_record_retire_marker_clear_for_spawn "$2" "$3"' _ \
+    "$ROOT/bin/fm-wake-lib.sh" "$home/state" "$id" > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "fresh incarnation accepted an invalid inherited marker"
+  assert_grep "invalid record-retirement marker" "$home/err" \
+    "fresh-incarnation marker refusal was not concrete"
+  assert_present "$home/state/.record-retired-$id" "spawn guard removed an invalid marker"
+  pass "marker format, link identity, task binding, and fresh-spawn validation fail open or refuse"
+}
+
+test_partial_wake_library_fails_open() {
+  local home id rc
+  home=$(make_home partial-wake-library)
+  id='live-with-partial-bin'
+  mkdir -p "$home/partial-bin"
+  cp "$ROOT/bin/fm-wake-lib.sh" "$home/partial-bin/fm-wake-lib.sh"
+  : > "$home/state/.wake-queue"
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    bash -c '. "$1"; fm_wake_append signal "$2.status" "signal: live"' _ \
+    "$home/partial-bin/fm-wake-lib.sh" "$id" 2> "$home/partial.err" \
+    || fail "partial wake library aborted without retirement support"
+  [ ! -s "$home/partial.err" ] \
+    || fail "partial wake library emitted a missing-dependency error: $(cat "$home/partial.err")"
+  [ "$(wc -l < "$home/state/.wake-queue" | tr -d ' ')" -eq 1 ] \
+    || fail "partial wake library muted a live task"
+  printf 'not a marker\n' > "$home/state/.record-retired-fresh-task"
+  set +e
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    bash -c '. "$1"; fm_record_retire_marker_clear_for_spawn "$2" fresh-task' _ \
+    "$home/partial-bin/fm-wake-lib.sh" "$home/state" > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "partial wake library cleared a marker without validation support"
+  assert_present "$home/state/.record-retired-fresh-task" \
+    "partial wake library removed an unvalidated marker"
+  pass "a partial wake-library copy surfaces work and refuses unvalidated marker clearing"
+}
+
+test_partial_classify_library_fails_open() {
+  local home id digest output
+  home=$(make_home partial-classify-library)
+  id='live-with-partial-classify'
+  digest=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  mkdir -p "$home/partial-bin"
+  cp "$ROOT/bin/fm-classify-lib.sh" "$home/partial-bin/fm-classify-lib.sh"
+  printf 'needs-decision: live task needs review\n' > "$home/state/$id.status"
+  printf 'schema=fm-record-retired.v1\ntask_id=%s\nwindow=firstmate:fm-%s\nmeta_sha256=%s\n' \
+    "$id" "$id" "$digest" > "$home/state/.record-retired-$id"
+  output=$(FM_STATE_OVERRIDE="$home/state" bash -c \
+    '. "$1"; scan_captain_relevant_statuses "$2"' _ \
+    "$home/partial-bin/fm-classify-lib.sh" "$home/state" 2> "$home/partial.err") \
+    || fail "partial classify library aborted without retirement support"
+  [ ! -s "$home/partial.err" ] \
+    || fail "partial classify library emitted a missing-dependency error: $(cat "$home/partial.err")"
+  printf '%s\n' "$output" | grep -q "$id" \
+    || fail "partial classify library trusted a marker it could not validate"
+  pass "a partial classify-library copy fails toward surfacing without marker support"
+}
+
+test_watcher_key_collision_refuses() {
+  local home stale live shared rc
+  home=$(make_home watcher-key-collision)
+  stale=scout-a-dot-b
+  live=ship-a-underscore-b
+  shared="$home/copies/recycled-slot"
+  mkdir -p "$shared"
+  write_scout "$home" "$stale" "$shared"
+  awk '{ sub(/^window=.*/, "window=firstmate:fm-a.b"); print }' \
+    "$home/state/$stale.meta" > "$home/state/$stale.meta.next"
+  mv -f "$home/state/$stale.meta.next" "$home/state/$stale.meta"
+  fm_write_meta "$home/state/$live.meta" \
+    "window=firstmate:fm-a_b" "endpoint_task_id=$live" "kind=ship"
+  printf 'live watcher state\n' > "$home/state/.hash-firstmate_fm-a_b"
+  set +e
+  run_retire "$home" "$stale" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "colliding watcher-state key was accepted"
+  assert_grep "watcher state key is also recorded by $live" "$home/err" \
+    "watcher-key collision refusal was not concrete"
+  assert_content "$home/state/.hash-firstmate_fm-a_b" "live watcher state" \
+    "watcher-key collision changed live state"
+  pass "nonidentical windows that collapse to one watcher key refuse safely"
+}
+
 run_test() {  # <test-function>
   [ -z "${FM_RECORD_RETIRE_TEST_ONLY:-}" ] \
     || [ "$FM_RECORD_RETIRE_TEST_ONLY" = "$1" ] \
@@ -415,6 +911,12 @@ run_test() {  # <test-function>
 
 run_test test_ordinary_retire
 run_test test_aliased_copy_is_safe
+run_test test_recycled_runtime_slot_refuses_herdr
+run_test test_recycled_runtime_slot_refuses_zellij
+run_test test_recycled_runtime_slot_refuses_cmux
+run_test test_retired_runtime_slot_can_be_reused_herdr
+run_test test_retired_runtime_slot_can_be_reused_zellij
+run_test test_retired_runtime_slot_can_be_reused_cmux
 run_test test_unprovable_safety_refuses_without_mutation
 run_test test_no_copy_touched_even_when_copy_is_hostile
 run_test test_ship_requires_clean_remote_tip_proof
@@ -426,3 +928,13 @@ run_test test_busy_incarnation_must_be_bound
 run_test test_runtime_binding_must_be_settled
 run_test test_public_followup_presence_refuses
 run_test test_invalid_retirement_marker_refuses_before_mutation
+run_test test_kind_and_remote_attestation_guards
+run_test test_remote_ref_shape_and_cardinality_guards
+run_test test_identity_and_task_kind_guards
+run_test test_metadata_busy_and_quarantine_guards
+run_test test_task_set_and_directory_guards
+run_test test_task_id_guard
+run_test test_marker_integrity_and_fail_open_guards
+run_test test_partial_wake_library_fails_open
+run_test test_partial_classify_library_fails_open
+run_test test_watcher_key_collision_refuses

--- a/tests/fm-record-retire.test.sh
+++ b/tests/fm-record-retire.test.sh
@@ -7,6 +7,7 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 RETIRE="$ROOT/bin/fm-record-retire.sh"
+RETIRE_LIB="$ROOT/bin/fm-record-retire-lib.sh"
 TMP_ROOT=$(fm_test_tmproot fm-record-retire)
 
 assert_content() {  # <file> <expected> <message>
@@ -73,6 +74,12 @@ write_scout() {  # <home> <id> <worktree>
   : > "$home/state/$id.turn-ended"
 }
 
+write_retirement_marker() {  # <state> <id> <window> <digest> [<schema>]
+  local state=$1 id=$2 window=$3 digest=$4 schema=${5:-fm-record-retired.v1}
+  printf 'schema=%s\ntask_id=%s\nwindow=%s\nmeta_sha256=%s\n' \
+    "$schema" "$id" "$window" "$digest" > "$state/.record-retired-$id"
+}
+
 run_retire() {  # <home> <args...>
   local home=$1
   shift
@@ -92,22 +99,39 @@ assert_retired() {  # <home> <id>
 }
 
 test_ordinary_retire() {
-  local home id queue_before queue_after
+  local home id window key prefix queue_before queue_after
   home=$(make_home ordinary)
   id=scout-ordinary
+  window="firstmate:fm-$id"
+  key=${window//:/_}
+  key=${key//\//_}
+  key=${key//./_}
   mkdir -p "$home/copies/task"
   printf 'copy bytes remain\n' > "$home/copies/task/sentinel"
   write_scout "$home" "$id" "$home/copies/task"
-  printf '1\t1\tsignal\t%s.status\tsignal: task\n' "$id" > "$home/state/.wake-queue"
-  printf '1\t2\theartbeat\theartbeat\theartbeat\n' >> "$home/state/.wake-queue"
+  {
+    printf '1\t1\tsignal\t%s.status\tsignal: task\n' "$id"
+    printf '1\t2\tstale\t%s\tstale: task\n' "$window"
+    printf '1\t3\tcheck\t%s/%s.check.sh\tcheck: task\n' "$home/state" "$id"
+    printf '1\t4\tsignal\t%s.status\n' "$id"
+    printf '1\t5\theartbeat\theartbeat\theartbeat\n'
+  } > "$home/state/.wake-queue"
+  for prefix in hash count stale stale-since paused paused-rechecked paused-resurfaced wedge-escalations; do
+    printf 'retired %s state\n' "$prefix" > "$home/state/.$prefix-$key"
+  done
 
   run_retire "$home" "$id" --work-safety scout-report >/dev/null \
     || fail "ordinary record retirement refused"
   assert_retired "$home" "$id"
   assert_content "$home/copies/task/sentinel" "copy bytes remain" \
     "ordinary retirement touched the recorded copy"
-  assert_content "$home/state/.wake-queue" $'1\t2\theartbeat\theartbeat\theartbeat' \
+  assert_content "$home/state/.wake-queue" \
+    $'1\t4\tsignal\tscout-ordinary.status\n1\t5\theartbeat\theartbeat\theartbeat' \
     "ordinary retirement did not remove only this task's queued wake"
+  for prefix in hash count stale stale-since paused paused-rechecked paused-resurfaced wedge-escalations; do
+    assert_absent "$home/state/.$prefix-$key" \
+      "ordinary retirement left collapsed runtime-slot state for $prefix"
+  done
   [ ! -s "$home/commands.log" ] \
     || fail "ordinary retirement invoked a copy, process, backend, or forge command: $(cat "$home/commands.log")"
 
@@ -827,6 +851,293 @@ test_marker_integrity_and_fail_open_guards() {
   pass "marker format, link identity, task binding, and fresh-spawn validation fail open or refuse"
 }
 
+test_marker_requires_exact_line_count() {
+  local home id digest
+  home=$(make_home marker-line-count)
+  id=retired-extra-line
+  digest=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  write_retirement_marker "$home/state" "$id" "firstmate:fm-$id" "$digest"
+  printf 'unexpected=fifth-line\n' >> "$home/state/.record-retired-$id"
+  if bash -c '. "$1"; fm_record_retire_marker_valid "$2" "$3"' _ \
+    "$RETIRE_LIB" "$home/state" "$id"; then
+    fail "five-line retirement marker was accepted"
+  fi
+  pass "retirement markers require exactly four lines"
+}
+
+test_marker_requires_exact_schema() {
+  local home id digest
+  home=$(make_home marker-schema)
+  id=retired-wrong-schema
+  digest=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  write_retirement_marker "$home/state" "$id" "firstmate:fm-$id" "$digest" wrong-schema
+  if bash -c '. "$1"; fm_record_retire_marker_valid "$2" "$3"' _ \
+    "$RETIRE_LIB" "$home/state" "$id"; then
+    fail "wrong-schema retirement marker was accepted"
+  fi
+  pass "retirement markers require the exact schema"
+}
+
+test_marker_requires_nonempty_window() {
+  local home id digest
+  home=$(make_home marker-empty-window)
+  id=retired-empty-window
+  digest=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  write_retirement_marker "$home/state" "$id" '' "$digest"
+  if bash -c '. "$1"; fm_record_retire_marker_valid "$2" "$3"' _ \
+    "$RETIRE_LIB" "$home/state" "$id"; then
+    fail "empty-window retirement marker was accepted"
+  fi
+  pass "retirement markers require a nonempty runtime window"
+}
+
+test_marker_rejects_control_window() {
+  local home id digest
+  home=$(make_home marker-control-window)
+  id=retired-control-window
+  digest=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  write_retirement_marker "$home/state" "$id" $'firstmate:\tfm-task' "$digest"
+  if bash -c '. "$1"; fm_record_retire_marker_valid "$2" "$3"' _ \
+    "$RETIRE_LIB" "$home/state" "$id"; then
+    fail "control-character retirement window was accepted"
+  fi
+  pass "retirement markers reject control characters in runtime windows"
+}
+
+test_marker_publish_rejects_invalid_id() {
+  local home digest
+  home=$(make_home publish-invalid-id)
+  digest=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  if bash -c '. "$1"; fm_record_retire_marker_publish "$2" .hidden window "$3"' _ \
+    "$RETIRE_LIB" "$home/state" "$digest"; then
+    fail "marker publication accepted an invalid task id"
+  fi
+  assert_absent "$home/state/.record-retired-.hidden" \
+    "invalid task id published a retirement marker"
+  pass "marker publication validates the task id"
+}
+
+test_marker_publish_rejects_empty_window() {
+  local home id digest
+  home=$(make_home publish-empty-window)
+  id=retired-publish-empty-window
+  digest=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  if bash -c '. "$1"; fm_record_retire_marker_publish "$2" "$3" "" "$4"' _ \
+    "$RETIRE_LIB" "$home/state" "$id" "$digest"; then
+    fail "marker publication accepted an empty runtime window"
+  fi
+  assert_absent "$home/state/.record-retired-$id" \
+    "empty runtime window published a retirement marker"
+  pass "marker publication requires a nonempty runtime window"
+}
+
+test_marker_publish_rejects_control_window() {
+  local home id digest window
+  home=$(make_home publish-control-window)
+  id=retired-publish-control-window
+  digest=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  window=$'firstmate:\tfm-task'
+  if bash -c '. "$1"; fm_record_retire_marker_publish "$2" "$3" "$4" "$5"' _ \
+    "$RETIRE_LIB" "$home/state" "$id" "$window" "$digest"; then
+    fail "marker publication accepted a control-character runtime window"
+  fi
+  assert_absent "$home/state/.record-retired-$id" \
+    "control-character runtime window published a retirement marker"
+  pass "marker publication rejects control characters in runtime windows"
+}
+
+test_marker_publish_rejects_invalid_digest() {
+  local home id
+  home=$(make_home publish-invalid-digest)
+  id=retired-publish-invalid-digest
+  if bash -c '. "$1"; fm_record_retire_marker_publish "$2" "$3" window bad' _ \
+    "$RETIRE_LIB" "$home/state" "$id"; then
+    fail "marker publication accepted a malformed metadata digest"
+  fi
+  assert_absent "$home/state/.record-retired-$id" \
+    "malformed metadata digest published a retirement marker"
+  pass "marker publication requires a full lowercase SHA-256 digest"
+}
+
+test_marker_republish_requires_same_window() {
+  local home id digest marker_before
+  home=$(make_home republish-window)
+  id=retired-republish-window
+  digest=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  write_retirement_marker "$home/state" "$id" original-window "$digest"
+  marker_before=$(shasum -a 256 "$home/state/.record-retired-$id")
+  if bash -c '. "$1"; fm_record_retire_marker_publish "$2" "$3" changed-window "$4"' _ \
+    "$RETIRE_LIB" "$home/state" "$id" "$digest"; then
+    fail "marker republish accepted a different runtime window"
+  fi
+  [ "$marker_before" = "$(shasum -a 256 "$home/state/.record-retired-$id")" ] \
+    || fail "different-window republish changed the existing marker"
+  pass "marker republish requires the same runtime window"
+}
+
+test_marker_republish_requires_same_digest() {
+  local home id original changed marker_before
+  home=$(make_home republish-digest)
+  id=retired-republish-digest
+  original=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  changed=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  write_retirement_marker "$home/state" "$id" original-window "$original"
+  marker_before=$(shasum -a 256 "$home/state/.record-retired-$id")
+  if bash -c '. "$1"; fm_record_retire_marker_publish "$2" "$3" original-window "$4"' _ \
+    "$RETIRE_LIB" "$home/state" "$id" "$changed"; then
+    fail "marker republish accepted a different metadata digest"
+  fi
+  [ "$marker_before" = "$(shasum -a 256 "$home/state/.record-retired-$id")" ] \
+    || fail "different-digest republish changed the existing marker"
+  pass "marker republish requires the same metadata generation"
+}
+
+test_marker_publish_verifies_the_published_file() {
+  local home id digest fakebin rc
+  home=$(make_home publish-postverify)
+  id=retired-publish-postverify
+  digest=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  fakebin="$home/noop-mv"
+  mkdir -p "$fakebin"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$fakebin/mv"
+  chmod +x "$fakebin/mv"
+  set +e
+  PATH="$fakebin:$PATH" bash -c \
+    '. "$1"; fm_record_retire_marker_publish "$2" "$3" window "$4"' _ \
+    "$RETIRE_LIB" "$home/state" "$id" "$digest"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "marker publication trusted a false-successful atomic move"
+  assert_absent "$home/state/.record-retired-$id" \
+    "false-successful atomic move unexpectedly published a marker"
+  pass "marker publication verifies the exact file after atomic publication"
+}
+
+test_marker_clear_accepts_absent_marker() {
+  local home
+  home=$(make_home clear-absent-marker)
+  bash -c '. "$1"; fm_record_retire_marker_clear_for_spawn "$2" fresh-task' _ \
+    "$RETIRE_LIB" "$home/state" \
+    || fail "fresh spawn refused when no retirement marker existed"
+  pass "fresh spawn treats an absent retirement marker as already clear"
+}
+
+test_marker_clear_removes_valid_marker_and_restores_wakes() {
+  local home id digest
+  home=$(make_home clear-valid-marker)
+  id=fresh-reused-task
+  digest=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  write_retirement_marker "$home/state" "$id" "firstmate:fm-$id" "$digest"
+  bash -c '. "$1"; fm_record_retire_marker_clear_for_spawn "$2" "$3"' _ \
+    "$ROOT/bin/fm-wake-lib.sh" "$home/state" "$id" \
+    || fail "fresh spawn could not clear a valid inherited retirement marker"
+  assert_absent "$home/state/.record-retired-$id" \
+    "fresh spawn left a valid retirement marker in place"
+  : > "$home/state/.wake-queue"
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    bash -c '. "$1"; fm_wake_append signal "$2.status" "signal: fresh"' _ \
+    "$ROOT/bin/fm-wake-lib.sh" "$id" \
+    || fail "fresh incarnation could not append a wake after marker clearing"
+  [ "$(wc -l < "$home/state/.wake-queue" | tr -d ' ')" -eq 1 ] \
+    || fail "fresh incarnation remained muted after valid marker clearing"
+  pass "fresh spawn removes a valid marker and restores the new incarnation's wakes"
+}
+
+test_marker_does_not_mute_unrecognized_signal_key() {
+  local home id digest
+  home=$(make_home signal-key-scope)
+  id=retired-plain-key
+  digest=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  write_retirement_marker "$home/state" "$id" window "$digest"
+  if bash -c '. "$1"; fm_record_retire_wake_muted "$2" signal "$3"' _ \
+    "$RETIRE_LIB" "$home/state" "$id"; then
+    fail "retirement marker muted an unrecognized signal key"
+  fi
+  pass "retirement markers mute only status and turn-end signal keys"
+}
+
+test_marker_does_not_mute_foreign_check_path() {
+  local home id digest foreign
+  home=$(make_home foreign-check-path)
+  id=retired-foreign-check
+  digest=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  foreign="$home/foreign/$id.check.sh"
+  mkdir -p "${foreign%/*}"
+  write_retirement_marker "$home/state" "$id" window "$digest"
+  if bash -c '. "$1"; fm_record_retire_wake_muted "$2" check "$3"' _ \
+    "$RETIRE_LIB" "$home/state" "$foreign"; then
+    fail "retirement marker muted a check path outside its state home"
+  fi
+  pass "retirement markers mute only state-home check paths"
+}
+
+test_marker_never_mutes_stale_wake() {
+  local home id digest
+  home=$(make_home stale-key-scope)
+  id=retired-slot
+  digest=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  write_retirement_marker "$home/state" "$id" "$id:window" "$digest"
+  if bash -c '. "$1"; fm_record_retire_wake_muted "$2" stale "$3:window"' _ \
+    "$RETIRE_LIB" "$home/state" "$id"; then
+    fail "retirement marker muted a slot-keyed stale wake"
+  fi
+  pass "retirement markers never mute slot-keyed stale wakes"
+}
+
+test_marker_does_not_mute_unknown_wake_kind() {
+  local home id digest
+  home=$(make_home unknown-wake-kind)
+  id=retired-unknown-kind
+  digest=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  write_retirement_marker "$home/state" "$id" window "$digest"
+  if bash -c '. "$1"; fm_record_retire_wake_muted "$2" heartbeat "$3.status"' _ \
+    "$RETIRE_LIB" "$home/state" "$id"; then
+    fail "retirement marker muted an unknown wake kind"
+  fi
+  pass "retirement markers fail open for unknown wake kinds"
+}
+
+test_retired_marker_hides_full_open_decision_scan() {
+  local home id digest output
+  home=$(make_home classify-full-retired)
+  id=retired-full-scan
+  digest=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  printf 'needs-decision: held work\n' > "$home/state/$id.status"
+  write_retirement_marker "$home/state" "$id" window "$digest"
+  output=$(FM_STATE_OVERRIDE="$home/state" bash -c \
+    '. "$1"; scan_open_decisions "$2"' _ "$ROOT/bin/fm-classify-lib.sh" "$home/state")
+  [ -z "$output" ] || fail "full decision scan resurfaced a retired task"
+  pass "full open-decision scans omit validly retired tasks"
+}
+
+test_retired_marker_hides_incremental_open_decision_scan() {
+  local home id digest output
+  home=$(make_home classify-incremental-retired)
+  id=retired-incremental-scan
+  digest=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  printf 'needs-decision: held work\n' > "$home/state/$id.status"
+  write_retirement_marker "$home/state" "$id" window "$digest"
+  output=$(FM_STATE_OVERRIDE="$home/state" bash -c \
+    '. "$1"; scan_open_decisions_incremental "$2"' _ \
+    "$ROOT/bin/fm-classify-lib.sh" "$home/state")
+  [ -z "$output" ] || fail "incremental decision scan resurfaced a retired task"
+  pass "incremental open-decision scans omit validly retired tasks"
+}
+
+test_retired_marker_hides_status_snapshot() {
+  local home id digest output
+  home=$(make_home classify-snapshot-retired)
+  id=retired-status-snapshot
+  digest=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  printf 'blocked: held work\n' > "$home/state/$id.status"
+  write_retirement_marker "$home/state" "$id" window "$digest"
+  output=$(FM_STATE_OVERRIDE="$home/state" bash -c \
+    '. "$1"; status_presentation_snapshot "$2"' _ \
+    "$ROOT/bin/fm-classify-lib.sh" "$home/state")
+  [ -z "$output" ] || fail "status snapshot resurfaced a retired task"
+  pass "status presentation snapshots omit validly retired tasks"
+}
+
 test_partial_wake_library_fails_open() {
   local home id rc
   home=$(make_home partial-wake-library)
@@ -902,6 +1213,723 @@ test_watcher_key_collision_refuses() {
   pass "nonidentical windows that collapse to one watcher key refuse safely"
 }
 
+test_unsupported_safety_mode_refuses() {
+  local home id rc
+  home=$(make_home unsupported-safety)
+  id=scout-unsupported-safety
+  write_scout "$home" "$id" "$home/copies/missing"
+  set +e
+  run_retire "$home" "$id" --work-safety guessed-safe > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "unsupported work-safety mode was accepted"
+  assert_grep "unsupported --work-safety value" "$home/err" \
+    "unsupported work-safety refusal was not concrete"
+  assert_present "$home/state/$id.meta" "unsupported work-safety mode removed metadata"
+  pass "record retirement rejects unsupported work-safety modes"
+}
+
+test_scout_report_rejects_remote_arguments() {
+  local home id rc
+  home=$(make_home scout-remote-args)
+  id=scout-with-remote-args
+  write_scout "$home" "$id" "$home/copies/missing"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report \
+    --remote-url https://github.com/example/sample.git --remote-ref refs/heads/main \
+    > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "scout-report accepted remote custody arguments"
+  assert_grep "scout-report safety does not accept remote-ref arguments" "$home/err" \
+    "scout remote-argument refusal was not concrete"
+  assert_present "$home/state/$id.meta" "scout remote-argument refusal removed metadata"
+  pass "scout-report safety rejects remote custody arguments"
+}
+
+test_remote_ref_requires_both_arguments() {
+  local home id sha rc
+  sha=0123456789abcdef0123456789abcdef01234567
+
+  home=$(make_home remote-missing-url)
+  id=ship-missing-url
+  fm_write_meta "$home/state/$id.meta" \
+    "window=firstmate:fm-$id" "endpoint_task_id=$id" "kind=ship" \
+    "record_retire_work_head=$sha" "record_retire_worktree_clean=1"
+  set +e
+  run_retire "$home" "$id" --work-safety remote-ref --remote-ref refs/heads/main \
+    > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "remote-ref safety accepted a missing remote URL"
+  assert_grep "requires --remote-url" "$home/err" \
+    "missing remote URL refusal was not concrete"
+
+  home=$(make_home remote-missing-ref)
+  id=ship-missing-ref
+  fm_write_meta "$home/state/$id.meta" \
+    "window=firstmate:fm-$id" "endpoint_task_id=$id" "kind=ship" \
+    "record_retire_work_head=$sha" "record_retire_worktree_clean=1"
+  set +e
+  run_retire "$home" "$id" --work-safety remote-ref \
+    --remote-url https://github.com/example/sample.git > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "remote-ref safety accepted a missing full ref"
+  assert_grep "requires --remote-ref" "$home/err" \
+    "missing remote ref refusal was not concrete"
+  pass "remote-ref safety requires both explicit custody arguments"
+}
+
+test_symlinked_data_directory_refuses() {
+  local home id real_data rc
+  home=$(make_home unsafe-data-dir)
+  id=scout-unsafe-data-dir
+  write_scout "$home" "$id" "$home/copies/missing"
+  real_data="$home/data-real"
+  mv "$home/data" "$real_data"
+  ln -s "$real_data" "$home/data"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "symlinked data directory was accepted"
+  assert_grep "data directory is absent or unsafe" "$home/err" \
+    "data-directory refusal was not concrete"
+  assert_present "$home/state/$id.meta" "data-directory refusal removed metadata"
+  pass "record retirement refuses a symlinked data directory"
+}
+
+test_gate_agent_refuses_before_retirement() {
+  local home id rc
+  home=$(make_home gate-agent)
+  id=scout-gate-agent
+  write_scout "$home" "$id" "$home/copies/missing"
+  set +e
+  NO_MISTAKES_GATE=1 FM_GATE_REFUSE_BYPASS='' \
+    run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -eq 3 ] || fail "gate-agent retirement did not refuse with exit 3 (rc=$rc)"
+  assert_grep "NO_MISTAKES_GATE set" "$home/err" \
+    "gate-agent refusal did not name its authority boundary"
+  assert_present "$home/state/$id.meta" "gate-agent refusal removed metadata"
+  pass "no-mistakes gate agents cannot drive record retirement"
+}
+
+test_task_set_lock_path_must_resolve() {
+  local home id rc
+  home=$(make_home $'task-set-path\tcontrol')
+  id=scout-task-set-path
+  write_scout "$home" "$id" "$home/copies/missing"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "unresolvable task-set lock path was accepted"
+  assert_grep "task-set lock cannot be resolved" "$home/err" \
+    "task-set lock path refusal was not concrete"
+  assert_present "$home/state/$id.meta" "task-set lock path refusal removed metadata"
+  pass "record retirement requires a resolvable task-set lock path"
+}
+
+test_symlinked_metadata_refuses_before_locking() {
+  local home id outside rc
+  home=$(make_home symlinked-metadata)
+  id=scout-symlinked-metadata
+  write_scout "$home" "$id" "$home/copies/missing"
+  outside="$home/outside-meta"
+  mv "$home/state/$id.meta" "$outside"
+  ln -s "$outside" "$home/state/$id.meta"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "symlinked metadata was accepted"
+  assert_grep "has no regular metadata" "$home/err" \
+    "pre-lock metadata refusal was not concrete"
+  assert_present "$outside" "symlinked metadata refusal removed its target"
+  pass "record retirement rejects symlinked metadata before taking its lock"
+}
+
+test_metadata_is_rechecked_after_lock_wait() {
+  local home id rc
+  home=$(make_home metadata-lock-recheck)
+  id=scout-metadata-lock-recheck
+  write_scout "$home" "$id" "$home/copies/missing"
+  set +e
+  PATH="$home/fakebin:$PATH" FM_TASKS_AXI_COMPATIBLE=1 \
+    FM_COMMAND_LOG="$home/commands.log" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_CONFIG_OVERRIDE="$home/config" bash -c '
+      . "$1"
+      lock=$(fm_meta_lock_path "$FM_STATE_OVERRIDE/$3.meta") || exit 80
+      fm_lock_acquire_wait "$lock" || exit 81
+      "$2" "$3" --work-safety scout-report > "$4/out" 2> "$4/err" &
+      child=$!
+      ready=0
+      attempts=0
+      while [ "$attempts" -lt 100 ]; do
+        if [ -e "$FM_STATE_OVERRIDE/.control-$3.lock" ] \
+          || [ -L "$FM_STATE_OVERRIDE/.control-$3.lock" ]; then
+          ready=1
+          break
+        fi
+        attempts=$((attempts + 1))
+        sleep 0.01
+      done
+      [ "$ready" -eq 1 ] || { kill "$child"; wait "$child"; exit 82; }
+      sleep 0.1
+      mv "$FM_STATE_OVERRIDE/$3.meta" "$FM_STATE_OVERRIDE/$3.meta.removed"
+      fm_lock_release "$lock"
+      wait "$child"
+    ' _ "$ROOT/bin/fm-wake-lib.sh" "$RETIRE" "$id" "$home"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "metadata disappearance during lock wait was accepted"
+  assert_grep "metadata disappeared before retirement" "$home/err" \
+    "post-lock metadata refusal was not concrete"
+  assert_present "$home/state/$id.meta.removed" \
+    "post-lock metadata refusal changed the removed record bytes"
+  pass "record retirement rechecks metadata after waiting for its lifecycle lock"
+}
+
+test_metadata_window_rejects_control_characters() {
+  local home id rc
+  home=$(make_home metadata-control-window)
+  id=scout-metadata-control-window
+  write_scout "$home" "$id" "$home/copies/missing"
+  awk -v window=$'firstmate:\tfm-task' '
+    /^window=/ { print "window=" window; next }
+    { print }
+  ' "$home/state/$id.meta" > "$home/state/$id.meta.next"
+  mv -f "$home/state/$id.meta.next" "$home/state/$id.meta"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "metadata accepted a control-character runtime window"
+  assert_grep "metadata window contains a control character" "$home/err" \
+    "metadata control-character refusal was not concrete"
+  assert_present "$home/state/$id.meta" "metadata control-character refusal removed metadata"
+  pass "record retirement rejects control characters in metadata windows"
+}
+
+test_state_artifact_device_boundary_refuses() {
+  local home id artifact rc
+  home=$(make_home artifact-device)
+  id=scout-foreign-device-artifact
+  artifact="$home/state/$id.pi-ext.ts"
+  write_scout "$home" "$id" "$home/copies/missing"
+  printf 'regular artifact bytes\n' > "$artifact"
+  # shellcheck disable=SC2016
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'if [ "$*" = "-f %d $FM_FOREIGN_DEVICE_ARTIFACT" ]; then' \
+    '  printf "999999999\n"' \
+    '  exit 0' \
+    'fi' \
+    'exec /usr/bin/stat "$@"' > "$home/fakebin/stat"
+  chmod +x "$home/fakebin/stat"
+  set +e
+  FM_FOREIGN_DEVICE_ARTIFACT="$artifact" \
+    run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "regular task artifact from another device was accepted"
+  assert_grep "unsafe task-state artifact" "$home/err" \
+    "cross-device task-artifact refusal was not concrete"
+  assert_present "$artifact" "cross-device task-artifact refusal removed the artifact"
+  assert_present "$home/state/$id.meta" "cross-device task-artifact refusal removed metadata"
+  pass "record retirement rejects regular task artifacts from another device"
+}
+
+test_unsupported_task_kind_refuses() {
+  local home id rc
+  home=$(make_home unsupported-kind)
+  id=unsupported-kind-record
+  write_scout "$home" "$id" "$home/copies/missing"
+  awk '{ sub(/^kind=scout$/, "kind=crew"); print }' \
+    "$home/state/$id.meta" > "$home/state/$id.meta.next"
+  mv -f "$home/state/$id.meta.next" "$home/state/$id.meta"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "unsupported task kind was accepted"
+  assert_grep "unsupported task kind" "$home/err" \
+    "unsupported task-kind refusal was not concrete"
+  assert_present "$home/state/$id.meta" "unsupported task-kind refusal removed metadata"
+  pass "record retirement rejects unsupported task kinds"
+}
+
+test_unsafe_other_metadata_refuses() {
+  local home id other outside rc
+  home=$(make_home unsafe-other-metadata)
+  id=scout-target-safe
+  other=ship-other-unsafe
+  write_scout "$home" "$id" "$home/copies/missing"
+  fm_write_meta "$home/state/$other.meta" \
+    "window=firstmate:fm-$other" "endpoint_task_id=$other" "kind=ship"
+  outside="$home/outside-other-meta-link"
+  ln "$home/state/$other.meta" "$outside"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "hardlinked foreign metadata was accepted"
+  assert_grep "metadata is unsafe" "$home/err" \
+    "unsafe foreign metadata refusal was not concrete"
+  assert_present "$home/state/$id.meta" "unsafe foreign metadata refusal removed target metadata"
+  pass "runtime-slot proof rejects unsafe foreign metadata"
+}
+
+test_locked_other_metadata_refuses() {
+  local home id other rc
+  home=$(make_home locked-other-metadata)
+  id=scout-target-locked-other
+  other=ship-changing-other
+  write_scout "$home" "$id" "$home/copies/missing"
+  fm_write_meta "$home/state/$other.meta" \
+    "window=firstmate:fm-$other" "endpoint_task_id=$other" "kind=ship"
+  set +e
+  PATH="$home/fakebin:$PATH" FM_TASKS_AXI_COMPATIBLE=1 \
+    FM_COMMAND_LOG="$home/commands.log" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_CONFIG_OVERRIDE="$home/config" bash -c '
+      . "$1"
+      lock=$(fm_meta_lock_path "$FM_STATE_OVERRIDE/$4.meta") || exit 80
+      fm_lock_acquire_wait "$lock" || exit 81
+      set +e
+      "$2" "$3" --work-safety scout-report > "$5/out" 2> "$5/err"
+      rc=$?
+      set -e
+      fm_lock_release "$lock"
+      exit "$rc"
+    ' _ "$ROOT/bin/fm-wake-lib.sh" "$RETIRE" "$id" "$other" "$home"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "changing foreign metadata was accepted"
+  assert_grep "metadata is changing" "$home/err" \
+    "changing foreign metadata refusal was not concrete"
+  assert_present "$home/state/$id.meta" "changing foreign metadata refusal removed target metadata"
+  pass "runtime-slot proof refuses while foreign metadata is locked"
+}
+
+test_other_metadata_is_rechecked_after_lock() {
+  local home id other target fakebin rc
+  home=$(make_home other-metadata-recheck)
+  id=scout-target-other-recheck
+  other=ship-other-recheck
+  write_scout "$home" "$id" "$home/copies/missing"
+  fm_write_meta "$home/state/$other.meta" \
+    "window=firstmate:fm-$other" "endpoint_task_id=$other" "kind=ship"
+  target="$home/other-meta-target"
+  fm_write_meta "$target" \
+    "window=firstmate:fm-$other" "endpoint_task_id=$other" "kind=ship"
+  fakebin="$home/swap-bin"
+  mkdir -p "$fakebin"
+  # shellcheck disable=SC2016
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'set -u' \
+    '/bin/ln "$@"' \
+    'rc=$?' \
+    'for arg in "$@"; do' \
+    '  if [ "$arg" = "$FM_SWAP_LOCK" ]; then' \
+    '    /bin/mv "$FM_SWAP_META" "$FM_SWAP_META.regular"' \
+    '    /bin/ln -s "$FM_SWAP_TARGET" "$FM_SWAP_META"' \
+    '  fi' \
+    'done' \
+    'exit "$rc"' > "$fakebin/ln"
+  chmod +x "$fakebin/ln"
+  set +e
+  FM_SWAP_LOCK="$home/state/.meta-$other.lock" \
+    FM_SWAP_META="$home/state/$other.meta" FM_SWAP_TARGET="$target" \
+    PATH="$fakebin:$home/fakebin:$PATH" FM_TASKS_AXI_COMPATIBLE=1 \
+    FM_COMMAND_LOG="$home/commands.log" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_CONFIG_OVERRIDE="$home/config" "$RETIRE" "$id" --work-safety scout-report \
+    > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "foreign metadata replacement after locking was accepted"
+  assert_grep "metadata changed" "$home/err" \
+    "foreign metadata post-lock refusal was not concrete"
+  assert_present "$home/state/$id.meta" "foreign metadata post-lock refusal removed target metadata"
+  pass "runtime-slot proof rechecks foreign metadata after taking its lock"
+}
+
+test_other_metadata_requires_exact_task_binding() {
+  local home id other rc
+  home=$(make_home other-binding)
+  id=scout-target-other-binding
+  other=ship-other-binding
+  write_scout "$home" "$id" "$home/copies/missing"
+  fm_write_meta "$home/state/$other.meta" "window=firstmate:fm-$other" "kind=ship"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "foreign metadata without an exact task binding was accepted"
+  assert_grep "requires one exact endpoint_task_id" "$home/err" \
+    "foreign task-binding refusal was not concrete"
+  assert_present "$home/state/$id.meta" "foreign task-binding refusal removed target metadata"
+  pass "runtime-slot proof requires exact foreign task bindings"
+}
+
+test_other_metadata_filename_must_match_binding() {
+  local home id other rc
+  home=$(make_home other-filename-binding)
+  id=scout-target-filename-binding
+  other=ship-other-filename
+  write_scout "$home" "$id" "$home/copies/missing"
+  fm_write_meta "$home/state/$other.meta" \
+    "window=firstmate:fm-$other" "endpoint_task_id=different-task" "kind=ship"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "foreign metadata with a mismatched filename binding was accepted"
+  assert_grep "mismatched task binding" "$home/err" \
+    "foreign filename-binding refusal was not concrete"
+  assert_present "$home/state/$id.meta" "foreign filename-binding refusal removed target metadata"
+  pass "runtime-slot proof binds every foreign record to its filename"
+}
+
+test_other_metadata_requires_exact_window() {
+  local home id other rc
+  home=$(make_home other-window)
+  id=scout-target-other-window
+  other=ship-other-window
+  write_scout "$home" "$id" "$home/copies/missing"
+  fm_write_meta "$home/state/$other.meta" "endpoint_task_id=$other" "kind=ship"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "foreign metadata without an exact runtime window was accepted"
+  assert_grep "requires one exact window" "$home/err" \
+    "foreign window refusal was not concrete"
+  assert_present "$home/state/$id.meta" "foreign window refusal removed target metadata"
+  pass "runtime-slot proof requires an exact window for every foreign record"
+}
+
+test_remote_ref_requires_full_namespace() {
+  local home id sha rc
+  home=$(make_home remote-short-ref)
+  id=ship-short-ref
+  sha=0123456789abcdef0123456789abcdef01234567
+  fm_write_meta "$home/state/$id.meta" \
+    "window=firstmate:fm-$id" "endpoint_task_id=$id" "kind=ship" \
+    "record_retire_work_head=$sha" "record_retire_worktree_clean=1"
+  set +e
+  FM_FAKE_REMOTE_SHA=$sha FM_FAKE_REMOTE_REF=main \
+    run_retire "$home" "$id" --work-safety remote-ref \
+      --remote-url https://github.com/example/sample.git --remote-ref main \
+      > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "short remote ref was accepted"
+  assert_grep "must be a full refs/... name" "$home/err" \
+    "short remote-ref refusal was not concrete"
+  assert_present "$home/state/$id.meta" "short remote-ref refusal removed metadata"
+  pass "remote custody requires a full refs namespace"
+}
+
+test_runtime_binding_directory_must_be_safe() {
+  local home id outside rc
+  home=$(make_home runtime-binding-dir)
+  id=scout-runtime-binding-dir
+  write_scout "$home" "$id" "$home/copies/missing"
+  outside="$home/outside-terminal-outcomes"
+  mkdir -p "$outside"
+  ln -s "$outside" "$home/state/terminal-outcomes"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "symlinked runtime-binding directory was accepted"
+  assert_grep "runtime binding directory is unsafe" "$home/err" \
+    "runtime-binding directory refusal was not concrete"
+  assert_present "$home/state/$id.meta" "runtime-binding directory refusal removed metadata"
+  pass "record retirement rejects unsafe runtime-binding directories"
+}
+
+test_runtime_binding_record_must_be_safe() {
+  local home id outside rc
+  home=$(make_home runtime-binding-record)
+  id=scout-runtime-binding-record
+  write_scout "$home" "$id" "$home/copies/missing"
+  mkdir -p "$home/state/terminal-outcomes"
+  outside="$home/outside-terminal-record"
+  printf 'task_id=another-task\n' > "$outside"
+  ln -s "$outside" "$home/state/terminal-outcomes/foreign.pending"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "symlinked runtime-binding record was accepted"
+  assert_grep "runtime binding record is unsafe" "$home/err" \
+    "runtime-binding record refusal was not concrete"
+  assert_present "$home/state/$id.meta" "runtime-binding record refusal removed metadata"
+  pass "record retirement rejects unsafe runtime-binding records"
+}
+
+test_procevent_binding_must_be_settled() {
+  local home id rc
+  home=$(make_home procevent-binding)
+  id=scout-procevent-bound
+  write_scout "$home" "$id" "$home/copies/missing"
+  mkdir -p "$home/state/procevent"
+  printf 'task_id=%s\n' "$id" > "$home/state/procevent/exact.source"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "task-owned process-event binding was orphaned"
+  assert_grep "still owns runtime binding" "$home/err" \
+    "process-event binding refusal was not concrete"
+  assert_present "$home/state/$id.meta" "process-event binding refusal removed metadata"
+  pass "record retirement refuses task-owned process-event bindings"
+}
+
+test_pending_reply_binding_must_be_settled() {
+  local home id rc
+  home=$(make_home pending-reply-binding)
+  id=scout-pending-reply-bound
+  write_scout "$home" "$id" "$home/copies/missing"
+  mkdir -p "$home/state/pending-replies"
+  printf 'task_id=%s\n' "$id" > "$home/state/pending-replies/exact.pending"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "task-owned pending-reply binding was orphaned"
+  assert_grep "still owns runtime binding" "$home/err" \
+    "pending-reply binding refusal was not concrete"
+  assert_present "$home/state/$id.meta" "pending-reply binding refusal removed metadata"
+  pass "record retirement refuses task-owned pending-reply bindings"
+}
+
+test_quarantine_directory_must_be_safe() {
+  local home id outside rc
+  home=$(make_home quarantine-directory)
+  id=scout-quarantine-directory
+  write_scout "$home" "$id" "$home/copies/missing"
+  outside="$home/outside-quarantine-directory"
+  mkdir -p "$outside"
+  ln -s "$outside" "$home/state/.pr-check-quarantine"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "symlinked PR-check quarantine was accepted"
+  assert_grep "PR-check quarantine path is unsafe" "$home/err" \
+    "quarantine-directory refusal was not concrete"
+  assert_present "$home/state/$id.meta" "quarantine-directory refusal removed metadata"
+  pass "record retirement rejects an unsafe PR-check quarantine directory"
+}
+
+test_marker_digest_requires_sha256_support() {
+  local home id work_head nohash tool rc
+  home=$(make_home missing-sha256)
+  id=ship-missing-sha256
+  work_head=0123456789abcdef0123456789abcdef01234567
+  fm_write_meta "$home/state/$id.meta" \
+    "window=firstmate:fm-$id" "endpoint_task_id=$id" "kind=ship" \
+    "record_retire_work_head=$work_head" "record_retire_worktree_clean=1"
+  nohash="$home/nohash-bin"
+  mkdir -p "$nohash"
+  for tool in awk basename bash cat chmod cut date dirname grep head ln mkdir mktemp mv od ps \
+    readlink rm rmdir sed sleep stat touch tr uname wc; do
+    ln -s "$(command -v "$tool")" "$nohash/$tool"
+  done
+  set +e
+  PATH="$nohash" FM_FAKE_REMOTE_SHA=$work_head FM_FAKE_REMOTE_REF=refs/heads/main \
+    run_retire "$home" "$id" --work-safety remote-ref \
+      --remote-url https://github.com/example/sample.git --remote-ref refs/heads/main \
+      > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "retirement proceeded without a metadata SHA-256 digest"
+  assert_grep "SHA-256 support is required" "$home/err" \
+    "missing SHA-256 refusal was not concrete: $(cat "$home/err")"
+  assert_present "$home/state/$id.meta" "missing SHA-256 refusal removed metadata"
+  assert_absent "$home/state/.record-retired-$id" \
+    "missing SHA-256 refusal published a marker"
+  pass "record retirement requires a verified metadata SHA-256 digest"
+}
+
+test_existing_marker_requires_same_window() {
+  local home id digest rc
+  home=$(make_home existing-marker-window)
+  id=scout-existing-marker-window
+  write_scout "$home" "$id" "$home/copies/missing"
+  digest=$(shasum -a 256 "$home/state/$id.meta" | awk '{print $1}')
+  write_retirement_marker "$home/state" "$id" different-window "$digest"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "existing marker for a different runtime target was accepted"
+  assert_grep "names a different runtime target" "$home/err" \
+    "existing-marker window refusal was not concrete"
+  assert_present "$home/state/$id.meta" "existing-marker window refusal removed metadata"
+  pass "record retirement binds an existing marker to the same runtime target"
+}
+
+test_existing_marker_requires_same_metadata_generation() {
+  local home id digest rc
+  home=$(make_home existing-marker-generation)
+  id=scout-existing-marker-generation
+  write_scout "$home" "$id" "$home/copies/missing"
+  digest=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  write_retirement_marker "$home/state" "$id" "firstmate:fm-$id" "$digest"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "existing marker for a different metadata generation was accepted"
+  assert_grep "names a different metadata generation" "$home/err" \
+    "existing-marker generation refusal was not concrete"
+  assert_present "$home/state/$id.meta" "existing-marker generation refusal removed metadata"
+  pass "record retirement binds an existing marker to the same metadata generation"
+}
+
+test_status_presentation_failure_refuses_before_marker() {
+  local home id outside rc
+  home=$(make_home status-presentation-failure)
+  id=scout-status-presentation-failure
+  write_scout "$home" "$id" "$home/copies/missing"
+  outside="$home/outside-status-cursor"
+  printf 'other\tident\t0\n' > "$outside"
+  ln -s "$outside" "$home/state/.status-presentation-cursor"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "unsafe status-presentation state was ignored"
+  assert_grep "status presentation state could not be retired safely" "$home/err" \
+    "status-presentation refusal was not concrete"
+  assert_present "$home/state/$id.meta" "status-presentation refusal removed metadata"
+  assert_absent "$home/state/.record-retired-$id" \
+    "status-presentation refusal published a retirement marker"
+  pass "status-presentation retirement must succeed before marker publication"
+}
+
+test_busy_generation_mismatch_refuses() {
+  local home id rc
+  home=$(make_home busy-generation-mismatch)
+  id=scout-busy-generation-mismatch
+  write_scout "$home" "$id" "$home/copies/missing"
+  printf 'busy_gen=metadata-gen\n' >> "$home/state/$id.meta"
+  printf 'sidecar-gen\n' > "$home/state/$id.busy-gen"
+  printf 'v1 gen=sidecar-gen seq=1 state=idle source=test event=test ts=1\n' \
+    > "$home/state/$id.busy-state"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "mismatched busy-state incarnation was retired"
+  assert_grep "busy-state incarnation could not be retired safely" "$home/err" \
+    "busy-generation refusal was not concrete"
+  assert_present "$home/state/$id.meta" "busy-generation refusal removed metadata"
+  assert_present "$home/state/$id.busy-state" "busy-generation refusal removed busy state"
+  pass "record retirement refuses a mismatched busy-state incarnation"
+}
+
+test_marker_publication_failure_refuses() {
+  local home id rc
+  home=$(make_home marker-publication-failure)
+  id=scout-marker-publication-failure
+  write_scout "$home" "$id" "$home/copies/missing"
+  # shellcheck disable=SC2016
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'for arg in "$@"; do' \
+    '  case "$arg" in *.record-retired-*) exit 75 ;; esac' \
+    'done' \
+    'exec /bin/mv "$@"' > "$home/fakebin/mv"
+  chmod +x "$home/fakebin/mv"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "failed retirement-marker publication was ignored"
+  assert_grep "record-retirement marker could not be published safely" "$home/err" \
+    "marker-publication refusal was not concrete"
+  assert_present "$home/state/$id.meta" "marker-publication refusal removed metadata"
+  assert_absent "$home/state/.record-retired-$id" \
+    "failed marker publication left a retirement marker"
+  pass "record retirement refuses when its marker cannot be published"
+}
+
+test_wake_queue_must_be_regular() {
+  local home id outside rc
+  home=$(make_home unsafe-wake-queue)
+  id=scout-unsafe-wake-queue
+  write_scout "$home" "$id" "$home/copies/missing"
+  outside="$home/outside-wake-queue"
+  printf '1\t1\theartbeat\theartbeat\theartbeat\n' > "$outside"
+  ln -s "$outside" "$home/state/.wake-queue"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "symlinked wake queue was accepted"
+  assert_grep "task wake rows could not be retired safely" "$home/err" \
+    "wake-queue identity refusal was not concrete"
+  assert_present "$home/state/$id.meta" "wake-queue identity refusal removed metadata"
+  assert_content "$outside" $'1\t1\theartbeat\theartbeat\theartbeat' \
+    "wake-queue identity refusal changed the symlink target"
+  pass "record retirement requires a regular single-link wake queue"
+}
+
+test_wake_queue_rewrite_failure_refuses() {
+  local home id rc
+  home=$(make_home wake-queue-rewrite-failure)
+  id=scout-wake-queue-rewrite-failure
+  write_scout "$home" "$id" "$home/copies/missing"
+  printf '1\t1\theartbeat\theartbeat\theartbeat\n' > "$home/state/.wake-queue"
+  # shellcheck disable=SC2016
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'last=' \
+    'for arg in "$@"; do last=$arg; done' \
+    'case "$last" in */.wake-queue) exit 75 ;; esac' \
+    'exec /usr/bin/awk "$@"' > "$home/fakebin/awk"
+  chmod +x "$home/fakebin/awk"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "failed wake-queue rewrite was ignored"
+  assert_grep "task wake rows could not be retired safely" "$home/err" \
+    "wake-queue rewrite refusal was not concrete"
+  assert_present "$home/state/$id.meta" "wake-queue rewrite refusal removed metadata"
+  assert_content "$home/state/.wake-queue" $'1\t1\theartbeat\theartbeat\theartbeat' \
+    "failed wake-queue rewrite changed the queue"
+  pass "record retirement refuses when wake-queue rewriting fails"
+}
+
+test_pr_poll_recovery_failure_refuses() {
+  local home id rc
+  home=$(make_home pr-poll-recovery-failure)
+  id=scout-pr-poll-recovery-failure
+  write_scout "$home" "$id" "$home/copies/missing"
+  printf 'invalid retirement receipt\n' > "$home/state/$id.pr-poll-retirement"
+  set +e
+  run_retire "$home" "$id" --work-safety scout-report > "$home/out" 2> "$home/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "unreconciled PR-poll retirement state was ignored"
+  assert_grep "PR-poll retirement state could not be reconciled safely" "$home/err" \
+    "PR-poll recovery refusal was not concrete"
+  assert_present "$home/state/$id.meta" "PR-poll recovery refusal removed metadata"
+  pass "record retirement refuses unreconciled PR-poll retirement state"
+}
+
 run_test() {  # <test-function>
   [ -z "${FM_RECORD_RETIRE_TEST_ONLY:-}" ] \
     || [ "$FM_RECORD_RETIRE_TEST_ONLY" = "$1" ] \
@@ -935,6 +1963,58 @@ run_test test_metadata_busy_and_quarantine_guards
 run_test test_task_set_and_directory_guards
 run_test test_task_id_guard
 run_test test_marker_integrity_and_fail_open_guards
+run_test test_marker_requires_exact_line_count
+run_test test_marker_requires_exact_schema
+run_test test_marker_requires_nonempty_window
+run_test test_marker_rejects_control_window
+run_test test_marker_publish_rejects_invalid_id
+run_test test_marker_publish_rejects_empty_window
+run_test test_marker_publish_rejects_control_window
+run_test test_marker_publish_rejects_invalid_digest
+run_test test_marker_republish_requires_same_window
+run_test test_marker_republish_requires_same_digest
+run_test test_marker_publish_verifies_the_published_file
+run_test test_marker_clear_accepts_absent_marker
+run_test test_marker_clear_removes_valid_marker_and_restores_wakes
+run_test test_marker_does_not_mute_unrecognized_signal_key
+run_test test_marker_does_not_mute_foreign_check_path
+run_test test_marker_never_mutes_stale_wake
+run_test test_marker_does_not_mute_unknown_wake_kind
+run_test test_retired_marker_hides_full_open_decision_scan
+run_test test_retired_marker_hides_incremental_open_decision_scan
+run_test test_retired_marker_hides_status_snapshot
 run_test test_partial_wake_library_fails_open
 run_test test_partial_classify_library_fails_open
 run_test test_watcher_key_collision_refuses
+run_test test_unsupported_safety_mode_refuses
+run_test test_scout_report_rejects_remote_arguments
+run_test test_remote_ref_requires_both_arguments
+run_test test_symlinked_data_directory_refuses
+run_test test_gate_agent_refuses_before_retirement
+run_test test_task_set_lock_path_must_resolve
+run_test test_symlinked_metadata_refuses_before_locking
+run_test test_metadata_is_rechecked_after_lock_wait
+run_test test_metadata_window_rejects_control_characters
+run_test test_state_artifact_device_boundary_refuses
+run_test test_unsupported_task_kind_refuses
+run_test test_unsafe_other_metadata_refuses
+run_test test_locked_other_metadata_refuses
+run_test test_other_metadata_is_rechecked_after_lock
+run_test test_other_metadata_requires_exact_task_binding
+run_test test_other_metadata_filename_must_match_binding
+run_test test_other_metadata_requires_exact_window
+run_test test_remote_ref_requires_full_namespace
+run_test test_runtime_binding_directory_must_be_safe
+run_test test_runtime_binding_record_must_be_safe
+run_test test_procevent_binding_must_be_settled
+run_test test_pending_reply_binding_must_be_settled
+run_test test_quarantine_directory_must_be_safe
+run_test test_marker_digest_requires_sha256_support
+run_test test_existing_marker_requires_same_window
+run_test test_existing_marker_requires_same_metadata_generation
+run_test test_status_presentation_failure_refuses_before_marker
+run_test test_busy_generation_mismatch_refuses
+run_test test_marker_publication_failure_refuses
+run_test test_wake_queue_must_be_regular
+run_test test_wake_queue_rewrite_failure_refuses
+run_test test_pr_poll_recovery_failure_refuses

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -1162,6 +1162,31 @@ EOF
   pass "orphan status logs are printed once with bounded tails"
 }
 
+test_marker_cannot_hide_orphan_with_broken_metadata_link() {
+  local rec root home fakebin out id digest
+  rec=$(new_world orphan-broken-meta-link)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_toolchain "$fakebin"
+  make_fake_ps_claude "$fakebin"
+
+  id=task-orphan-broken-meta
+  digest=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  printf 'blocked: metadata link needs investigation\n' > "$home/state/$id.status"
+  ln -s "$home/state/missing-meta-target" "$home/state/$id.meta"
+  printf 'schema=fm-record-retired.v1\ntask_id=%s\nwindow=firstmate:fm-%s\nmeta_sha256=%s\n' \
+    "$id" "$id" "$digest" > "$home/state/.record-retired-$id"
+
+  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+
+  assert_contains "$out" "--- $id ---" \
+    "valid marker hid an orphan whose canonical metadata path was still a symlink"
+  assert_contains "$out" "blocked: metadata link needs investigation" \
+    "orphan digest omitted the status behind a broken metadata link"
+  pass "session start keeps marker-bearing orphan status visible while a metadata symlink remains"
+}
+
 # --- session-start secondmate recovery boundary -----------------------------
 
 test_session_start_relaunches_missing_pi_secondmate() {
@@ -2418,6 +2443,7 @@ test_session_start_relaunches_herdr_husk_secondmate
 test_status_tail_bounding
 test_status_tail_line_cap
 test_orphan_status_logs_are_printed
+test_marker_cannot_hide_orphan_with_broken_metadata_link
 test_endpoint_liveness_tmux
 test_endpoint_liveness_herdr
 test_composition_invokes_real_scripts

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -826,6 +826,41 @@ test_active_dispatch_profile_does_not_block_secondmate_launch() {
   pass "active crew-dispatch profile does not block secondmate launches"
 }
 
+write_spawn_retirement_marker() {  # <state> <task-id>
+  printf 'schema=fm-record-retired.v1\ntask_id=%s\nwindow=firstmate:fm-%s\nmeta_sha256=%064d\n' \
+    "$2" "$2" 0 > "$1/.record-retired-$2"
+}
+
+test_spawn_clears_only_a_valid_inherited_retirement_marker() {
+  local rec id out status marker
+  id=profile-retired-valid-z20
+  rec=$(make_spawn_case profile-retired-valid claude "$id")
+  read_case_record "$rec"
+  marker="$HOME_DIR/state/.record-retired-$id"
+  write_spawn_retirement_marker "$HOME_DIR/state" "$id"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "spawn with a valid inherited retirement marker should succeed"
+  assert_absent "$marker" "fresh spawn left the old retirement marker active"
+  assert_present "$HOME_DIR/state/$id.meta" "fresh spawn did not publish canonical metadata"
+
+  id=profile-retired-invalid-z21
+  rec=$(make_spawn_case profile-retired-invalid claude "$id")
+  read_case_record "$rec"
+  marker="$HOME_DIR/state/.record-retired-$id"
+  printf 'invalid marker\n' > "$marker"
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn ignored an invalid inherited retirement marker"
+  assert_contains "$out" "invalid record-retirement marker" \
+    "spawn refusal did not explain the invalid inherited marker"
+  assert_present "$marker" "spawn removed an inherited marker it could not validate"
+  assert_absent "$HOME_DIR/state/$id.meta" \
+    "spawn published metadata after retirement-marker validation failed"
+  pass "fresh spawn clears a valid retirement marker and refuses an invalid one"
+}
+
 test_no_profile_keeps_claude_profile_defaults
 test_non_cursor_launch_clears_inherited_cursor_markers
 test_relative_home_overrides_launch_with_absolute_cross_process_paths
@@ -857,5 +892,6 @@ test_claude_forwards_firstmate_config_dir_when_set
 test_claude_omits_config_dir_prefix_when_unset
 test_non_claude_harness_ignores_config_dir
 test_active_dispatch_profile_does_not_block_secondmate_launch
+test_spawn_clears_only_a_valid_inherited_retirement_marker
 
 echo "# all fm-spawn-dispatch-profile tests passed"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -861,6 +861,63 @@ write_spawn_retirement_marker() {  # <state> <task-id>
     "$2" "$2" 0 > "$1/.record-retired-$2"
 }
 
+test_partial_bin_spawn_preserves_marker_compatibility_contract() {
+  local partial_root rec id out status marker target
+  partial_root="$TMP_ROOT/partial-spawn-root"
+  mkdir -p "$partial_root"
+  cp -R "$ROOT/bin" "$partial_root/bin"
+  rm -f "$partial_root/bin/fm-record-retire-lib.sh"
+
+  id=profile-partial-no-marker-z19a
+  rec=$(make_spawn_case profile-partial-no-marker claude "$id")
+  read_case_record "$rec"
+  out=$(SPAWN="$partial_root/bin/fm-spawn.sh" \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "partial-bin spawn without a retirement marker should succeed"
+  assert_not_contains "$out" "command not found" \
+    "partial-bin marker-free spawn called an unavailable marker interface"
+  assert_present "$HOME_DIR/state/$id.meta" \
+    "partial-bin marker-free spawn did not publish canonical metadata"
+
+  id=profile-partial-regular-marker-z19b
+  rec=$(make_spawn_case profile-partial-regular-marker claude "$id")
+  read_case_record "$rec"
+  marker="$HOME_DIR/state/.record-retired-$id"
+  write_spawn_retirement_marker "$HOME_DIR/state" "$id"
+  out=$(SPAWN="$partial_root/bin/fm-spawn.sh" \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  [ "$status" -ne 0 ] || fail "partial-bin spawn accepted an existing regular retirement marker"
+  assert_contains "$out" "record-retirement support is unavailable" \
+    "partial-bin regular-marker refusal did not name unavailable retirement support"
+  assert_not_contains "$out" "command not found" \
+    "partial-bin regular-marker refusal called an unavailable marker interface"
+  assert_present "$marker" "partial-bin spawn removed an existing regular retirement marker"
+  assert_absent "$HOME_DIR/state/$id.meta" \
+    "partial-bin regular-marker refusal published canonical metadata"
+
+  id=profile-partial-symlink-marker-z19c
+  rec=$(make_spawn_case profile-partial-symlink-marker claude "$id")
+  read_case_record "$rec"
+  marker="$HOME_DIR/state/.record-retired-$id"
+  target="$HOME_DIR/state/partial-marker-target"
+  printf 'unsupported marker\n' > "$target"
+  ln -s "$target" "$marker"
+  out=$(SPAWN="$partial_root/bin/fm-spawn.sh" \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  [ "$status" -ne 0 ] || fail "partial-bin spawn accepted an existing symlink retirement marker"
+  assert_contains "$out" "record-retirement support is unavailable" \
+    "partial-bin symlink-marker refusal did not name unavailable retirement support"
+  assert_not_contains "$out" "command not found" \
+    "partial-bin symlink-marker refusal called an unavailable marker interface"
+  [ -L "$marker" ] || fail "partial-bin spawn removed an existing symlink retirement marker"
+  assert_absent "$HOME_DIR/state/$id.meta" \
+    "partial-bin symlink-marker refusal published canonical metadata"
+  pass "partial-bin spawns permit no marker and preserve regular or symlink markers"
+}
+
 test_spawn_clears_only_a_valid_inherited_retirement_marker() {
   local rec id out status marker order_log
   id=profile-retired-valid-z20
@@ -941,6 +998,7 @@ test_claude_forwards_firstmate_config_dir_when_set
 test_claude_omits_config_dir_prefix_when_unset
 test_non_claude_harness_ignores_config_dir
 test_active_dispatch_profile_does_not_block_secondmate_launch
+test_partial_bin_spawn_preserves_marker_compatibility_contract
 test_spawn_clears_only_a_valid_inherited_retirement_marker
 
 echo "# all fm-spawn-dispatch-profile tests passed"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -12,6 +12,9 @@ set -u
 
 SPAWN="$ROOT/bin/fm-spawn.sh"
 TMP_ROOT=$(fm_test_tmproot fm-spawn-dispatch-profile)
+TEST_REAL_MV=$(command -v mv)
+TEST_REAL_RM=$(command -v rm)
+export FM_TEST_REAL_MV="$TEST_REAL_MV" FM_TEST_REAL_RM="$TEST_REAL_RM"
 
 make_spawn_pi_probe() {
   local fakebin=$1 tool=$2
@@ -74,6 +77,32 @@ fi
 exit 0
 SH
   chmod +x "$fakebin/timeout" "$fakebin/cursor-agent"
+  cat > "$fakebin/mv" <<'SH'
+#!/usr/bin/env bash
+set -u
+target=${!#}
+if [ -n "${FM_FAKE_RETIRE_META:-}" ] && [ "$target" = "$FM_FAKE_RETIRE_META" ]; then
+  [ "${FM_FAKE_RETIRE_META_FAIL:-0}" = 0 ] || exit 73
+  "$FM_TEST_REAL_MV" "$@"
+  status=$?
+  [ "$status" -eq 0 ] || exit "$status"
+  [ -z "${FM_FAKE_RETIRE_ORDER_LOG:-}" ] || printf 'publish\n' >> "$FM_FAKE_RETIRE_ORDER_LOG"
+  exit 0
+fi
+exec "$FM_TEST_REAL_MV" "$@"
+SH
+  cat > "$fakebin/rm" <<'SH'
+#!/usr/bin/env bash
+set -u
+for target in "$@"; do
+  if [ -n "${FM_FAKE_RETIRE_MARKER:-}" ] && [ "$target" = "$FM_FAKE_RETIRE_MARKER" ]; then
+    [ -f "${FM_FAKE_RETIRE_META:-}" ] || exit 74
+    [ -z "${FM_FAKE_RETIRE_ORDER_LOG:-}" ] || printf 'clear\n' >> "$FM_FAKE_RETIRE_ORDER_LOG"
+  fi
+done
+exec "$FM_TEST_REAL_RM" "$@"
+SH
+  chmod +x "$fakebin/mv" "$fakebin/rm"
   make_spawn_pi_probe "$fakebin" pi
   make_spawn_pi_probe "$fakebin" pi-signed
   printf '%s\n' "$fakebin"
@@ -126,6 +155,7 @@ run_spawn() {
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
     CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
+    FM_TEST_REAL_MV="$TEST_REAL_MV" FM_TEST_REAL_RM="$TEST_REAL_RM" \
     FM_FAKE_LAUNCH_LOG="$launchlog" FM_FAKE_PI_VERSION="${FM_TEST_PI_VERSION:-0.84.0}" \
     FM_FAKE_CURSOR_MODELS="${FM_TEST_CURSOR_MODELS:-}" \
     FM_FAKE_CURSOR_LIST_STATUS="${FM_TEST_CURSOR_LIST_STATUS:-0}" \
@@ -832,18 +862,37 @@ write_spawn_retirement_marker() {  # <state> <task-id>
 }
 
 test_spawn_clears_only_a_valid_inherited_retirement_marker() {
-  local rec id out status marker
+  local rec id out status marker order_log
   id=profile-retired-valid-z20
   rec=$(make_spawn_case profile-retired-valid claude "$id")
   read_case_record "$rec"
   marker="$HOME_DIR/state/.record-retired-$id"
+  order_log="$CASE_DIR/retirement-order.log"
   write_spawn_retirement_marker "$HOME_DIR/state" "$id"
 
-  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  out=$(FM_FAKE_RETIRE_META="$HOME_DIR/state/$id.meta" \
+    FM_FAKE_RETIRE_MARKER="$marker" FM_FAKE_RETIRE_ORDER_LOG="$order_log" \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
   status=$?
   expect_code 0 "$status" "spawn with a valid inherited retirement marker should succeed"
   assert_absent "$marker" "fresh spawn left the old retirement marker active"
   assert_present "$HOME_DIR/state/$id.meta" "fresh spawn did not publish canonical metadata"
+  [ "$(cat "$order_log")" = $'publish\nclear' ] \
+    || fail "fresh spawn did not publish metadata before clearing its inherited retirement marker"
+
+  id=profile-retired-publish-failure-z20b
+  rec=$(make_spawn_case profile-retired-publish-failure claude "$id")
+  read_case_record "$rec"
+  marker="$HOME_DIR/state/.record-retired-$id"
+  write_spawn_retirement_marker "$HOME_DIR/state" "$id"
+  out=$(FM_FAKE_RETIRE_META="$HOME_DIR/state/$id.meta" \
+    FM_FAKE_RETIRE_MARKER="$marker" FM_FAKE_RETIRE_META_FAIL=1 \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn succeeded after metadata publication failed"
+  assert_present "$marker" "metadata-publication failure removed the inherited retirement marker"
+  assert_absent "$HOME_DIR/state/$id.meta" \
+    "metadata-publication failure left canonical metadata behind"
 
   id=profile-retired-invalid-z21
   rec=$(make_spawn_case profile-retired-invalid claude "$id")

--- a/tests/fm-supervision-events.test.sh
+++ b/tests/fm-supervision-events.test.sh
@@ -34,7 +34,9 @@ sleep() { printf 'SLEEP\n' >> "$SLEEP_LOG"; }
 reset_state() {
   rm -f "$STATE_DIR"/*.meta "$STATE_DIR"/*.status "$STATE_DIR"/.wake-queue \
     "$STATE_DIR"/.wake-queue.seq "$STATE_DIR"/.watch-triage.log \
-    "$STATE_DIR"/.herdr-escalated-* "$TMP"/panes "$TMP"/wtcalls "$TMP"/wtcalled 2>/dev/null || true
+    "$STATE_DIR"/.herdr-escalated-* "$STATE_DIR"/.record-retired-* \
+    "$STATE_DIR"/.seen-* "$STATE_DIR"/.hb-surfaced-* \
+    "$TMP"/panes "$TMP"/wtcalls "$TMP"/wtcalled 2>/dev/null || true
   : > "$WAKE_LOG"
   : > "$SLEEP_LOG"
   _event_cap_key=""
@@ -45,6 +47,45 @@ reset_state() {
 mkrec() {  # <pane_id> <status>
   fm_transition_record "$1" "wG" "" "$2" claude
 }
+
+# A published marker is inert until canonical metadata disappears. The watcher
+# must therefore keep scanning the status file during a post-publication
+# refusal, when both marker and metadata are durably reachable together.
+reset_state
+LIVE_ID=watch-live-after-marker
+printf 'window=default:wG:pQ\nkind=ship\n' > "$STATE_DIR/$LIVE_ID.meta"
+printf 'blocked: still live\n' > "$STATE_DIR/$LIVE_ID.status"
+printf 'schema=fm-record-retired.v1\ntask_id=%s\nwindow=default:wG:pQ\nmeta_sha256=%064d\n' \
+  "$LIVE_ID" 0 > "$STATE_DIR/.record-retired-$LIVE_ID"
+SIGNALS=$(scan_signals)
+printf '%s\n' "$SIGNALS" | grep -q "$LIVE_ID.status" \
+  || fail "scan_signals hid a live task after marker publication"
+pass "scan_signals keeps a marker-bearing task audible while canonical metadata exists"
+
+# Push and poll writers share the same heartbeat surfaced-path producer that
+# retirement consumes, including its punctuation collapse.
+reset_state
+SURFACE_ID=surface.task
+printf 'blocked: needs captain\n' > "$STATE_DIR/$SURFACE_ID.status"
+mark_surfaced "$STATE_DIR/$SURFACE_ID.status"
+SURFACE_PATH=$(fm_wake_hb_surfaced_path "$STATE_DIR" "$SURFACE_ID")
+[ "$(cat "$SURFACE_PATH" 2>/dev/null)" = 'blocked: needs captain' ] \
+  || fail "mark_surfaced did not write through the shared heartbeat path producer"
+[ ! -e "$STATE_DIR/.hb-surfaced-$SURFACE_ID" ] \
+  || fail "mark_surfaced re-derived the raw dotted task id"
+pass "heartbeat surfacing writes through the shared punctuation-collapsing path producer"
+
+reset_state
+SURFACE_ID=watch.surface.task
+printf 'blocked: needs captain\n' > "$STATE_DIR/$SURFACE_ID.status"
+mark_all_captain_relevant_surfaced
+SURFACE_PATH=$(fm_wake_hb_surfaced_path "$STATE_DIR" "$SURFACE_ID")
+[ "$(cat "$SURFACE_PATH" 2>/dev/null)" = 'blocked: needs captain' ] \
+  || fail "watcher heartbeat writer did not use the shared surfaced-path producer"
+if heartbeat_scan_finds_actionable; then
+  fail "watcher heartbeat reader did not find the producer-owned surfaced marker"
+fi
+pass "watcher heartbeat reader and writer share the punctuation-collapsing path producer"
 
 # --- handle_push_transition: enqueue + wake for a non-paused blocked crew -----
 


### PR DESCRIPTION
## Intent

Close F1 and F2 from the independent record-retirement enforcement gate on top of PR #2458, and add focused behavioral coverage for F3, F4, and F5. Prove all five previously uncovered marker_active call sites discriminate by reverting each guard and observing RED, then restore GREEN. Stop re-deriving seen and heartbeat surfaced paths by making the producer-owned path functions the single spelling used by retirement. Individually close the four initially surviving planning mutants: F2-08 producer-path omission, F4-04 target-window normalization bypass, F4-05 competing-record normalization bypass, and F4-06 artifact-window normalization bypass; all four must be named in the PR body with their one-substitution RED verdicts and zero harness-class exits. Preserve the hard boundary: never execute fm-record-retire.sh, never run any test that invokes retirement, and touch no real state record or pooled worktree copy; safe focused library, watcher, spawn, and session-start fixtures are allowed only in scratch homes. Never weaken a property. Publish an open HTTPS pull request to kunchenguid/firstmate without merging. Upstream has zero configured checks, so treat the completed local pipeline gate as delivery evidence and do not wait for maintainer-controlled checks.

## What Changed

- Add state-only task-record retirement with explicit scout-report or remote-ref safety proofs, runtime-slot collision checks, durable markers, and no endpoint or working-copy teardown.
- Make marker-aware decisions, status presentation, wakes, watchers, session start, and fresh spawns preserve live supervision; replacement metadata is published atomically before valid inherited markers are cleared, including fail-closed partial-bin compatibility.
- Centralize producer-owned seen, heartbeat, and watcher paths and add focused F1–F5 regression coverage. F2-08 producer-path omission, F4-04 target-window normalization bypass, F4-05 competing-record normalization bypass, and F4-06 artifact-window normalization bypass each reached RED with one substitution and 0 harness-class exits.

## Risk Assessment

✅ Low: Captain, both prior defects are closed at their shared boundaries: metadata publication is atomic and marker-safe, while partial-bin spawns preserve marker-free compatibility and fail closed on existing markers.

## Testing

Repository and safety preflight, focused library fixtures, watcher/spawn/session-start behavioral suites, a direct live-versus-retired CLI demonstration, and six counterfactual RED substitutions all succeeded; evidence is transcript-based because this is shell/CLI behavior with no rendered UI, and the prohibited retirement executable and real fleet state were never touched.

<details>
<summary>Evidence: Live, retired, and counterfactual RED behavior demo</summary>

```text
LIVE MARKER PLUS META
demo.record	demo	needs-decision	captain action remains visible
snapshot: demo.record	58	16777231:136754275
captain scan: /var/folders/cq/xf4qcb9j0qzc2dbh173mflbm0000gn/T/no-mistakes-evidence/01M04NGZ6P9JEWX6C3N5SF6SB1/demo-state/state/demo.record.status	demo.record	needs-decision: [key=demo] captain action remains visible
queued wake: 1786865088	1	check	/var/folders/cq/xf4qcb9j0qzc2dbh173mflbm0000gn/T/no-mistakes-evidence/01M04NGZ6P9JEWX6C3N5SF6SB1/demo-state/state/demo.record.check.sh	check: demo

RETIRED MARKER AFTER META REMOVAL
open decisions: <>
snapshot: <>
captain scan: <>
queued wake bytes: 0

COUNTERFACTUAL REVERT TO marker_valid WHILE META EXISTS
full with reverted guard: <> (RED: live surface hidden)
incremental with reverted guard: <> (RED: live surface hidden)
snapshot with reverted guard: <> (RED: live surface hidden)
captain with reverted guard: <> (RED: live surface hidden)
wake append with reverted guard bytes: 0 (RED: live wake hidden)
watcher signal scan with reverted guard: <> (RED: live signal hidden)
```
</details>
<details>
<summary>Evidence: Focused marker-library transcript</summary>

```text
CASE test_retired_marker_hides_full_open_decision_scan
ok - full open-decision scans omit validly retired tasks
CASE test_retired_marker_hides_incremental_open_decision_scan
ok - incremental open-decision scans omit validly retired tasks
CASE test_retired_marker_hides_status_snapshot
ok - status presentation snapshots omit validly retired tasks
CASE test_live_metadata_keeps_marker_consumers_audible
ok - live metadata keeps full decisions, snapshots, and check wakes audible after marker publication
CASE test_surface_artifact_paths_are_producer_owned
ok - retirement obtains seen and heartbeat surface paths from their producers
CASE test_watcher_key_collapses_every_occurrence
ok - watcher keys fully collapse and classify raw and collapsed runtime-slot collisions
CASE test_muted_wake_releases_queue_lock
ok - muted wakes release the queue lock before returning
```
</details>
<details>
<summary>Evidence: Watcher and heartbeat transcript</summary>

```text
ok - scan_signals keeps a marker-bearing task audible while canonical metadata exists
ok - heartbeat surfacing writes through the shared punctuation-collapsing path producer
ok - watcher heartbeat reader and writer share the punctuation-collapsing path producer
ok - handle_push_transition: a blocked crew enqueues a stale wake naming its window and wakes the supervisor
ok - handle_push_transition: enqueue failure cannot commit the Herdr dedupe marker
ok - handle_push_transition: a declared-pause crew is absorbed (no fast wake), left to the poll loop's long cadence
ok - event_wait_or_sleep: herdr windows go on the event pane list, but kind=secondmate endpoints are excluded
ok - event_wait_or_sleep: one cached capability probe owns validation across bounded waits
ok - event_wait_or_sleep: a home with no push-capable window is inert (sleeps POLL, never touches the event path)
ok - event_wait_or_sleep: consecutive event-path failures disable the fast-path and revert to pure polling (fail-closed)
# fm-supervision-events.test.sh: all assertions passed
```
</details>
<details>
<summary>Evidence: Spawn marker lifecycle transcript</summary>

```text
ok - no --model/--effort records defaults and types the claude launch instructions
ok - non-cursor launches clear inherited Cursor identity markers
ok - relative home overrides ignore CDPATH and become absolute before spawn launch construction
ok - FM_HOME defaults resolve relative paths and preserve absolute spellings
ok - absolute override spellings are preserved in spawn launch paths
ok - unresolvable relative spawn overrides fail with named diagnostics
ok - active crew-dispatch profile requires an explicit harness for ship spawns
ok - active crew-dispatch profile requires an explicit harness for scout spawns
ok - active crew-dispatch profile allows an explicit resolved harness
ok - active crew-dispatch profile allows the legacy positional harness form
ok - active crew-dispatch profile allows the raw launch-command escape hatch
ok - claude receives --model and --effort profile flags
ok - codex receives --model and model_reasoning_effort profile flags
ok - codex omits unsupported max effort instead of passing a bad config value
ok - grok receives --model and --reasoning-effort profile flags
ok - grok omits unsupported max reasoning effort
ok - grok omits unsupported xhigh reasoning effort
ok - cursor receives its model-qualified reasoning class and exact task workspace
ok - cursor refuses model ids absent from its resolved binary's live catalog
ok - cursor preserves the requested model when its live catalog is unreachable
ok - opencode receives --model and omits the unsupported effort axis
ok - pi receives --model and --thinking max profile flags
ok - Pi launch probing omits --tui-mode on older Pi and preserves it on supporting Pi
ok - pi-signed shares Pi launch semantics while preserving its configured and recorded identity
ok - pi-signed refuses safely and actionably when the selected executable is unavailable
ok - pi-signed is a distinct persistent secondmate runtime with shared Pi supervision semantics
ok - batch dispatch forwards shared --harness, --model, and --effort to every pair
ok - claude forwards firstmate's CLAUDE_CONFIG_DIR so the crewmate uses the same credential store
ok - claude omits the config-dir prefix when firstmate runs with the single-store default
ok - non-claude harnesses do not receive the claude CLAUDE_CONFIG_DIR prefix
ok - active crew-dispatch profile does not block secondmate launches
ok - partial-bin spawns permit no marker and preserve regular or symlink markers
ok - fresh spawn clears a valid retirement marker and refuses an invalid one
# all fm-spawn-dispatch-profile tests passed
```
</details>
<details>
<summary>Evidence: Session-start orphan visibility transcript</summary>

```text
ok - context digest distinguishes ABSENT, empty-but-present, and populated files
ok - a lock refusal prints a loud read-only banner, skips every mutating step, and still completes the digest
ok - session start stays read-only when lock ownership cannot be published
ok - locked session start freezes trace context and lock refusal leaves it unchanged
ok - concurrent session-lock acquisition admits exactly one live harness
ok - digest sections are ordered safety-preamble first, live fleet state before curated memory
ok - the read-once contract is stated once, ahead of the sources it governs
ok - session start: configured and auto-detected Herdr homes never require tmux
ok - session start: an absent recorded tmux window relaunches its Pi secondmate exactly once, off the blocking path
ok - session start: a deferred relaunch is always reported, so the digest's stale endpoint record cannot stand
ok - session start: an unreachable host delays a reported check, not the digest
ok - session start: a deferred result the digest outran still reaches the agent as a wake
ok - session start: a read-only session declares its skipped network checks rather than dropping them
ok - session start: the tasks-axi compatibility verdict is computed once and reused
ok - session start: an existing ambiguous Pi process prevents duplicate recovery
ok - session start: transient tmux unreadability never licenses a relaunch
ok - session start: the proven bare-shell recovery path remains intact
ok - session start: a confirmed Herdr husk is closed and relaunched
ok - status tail is bounded to the configured line count, with the full log path always printed
ok - status tail lines are capped with a truncation marker while the full log stays reachable
ok - orphan status logs are printed once with bounded tails
ok - session start keeps marker-bearing orphan status visible while a metadata symlink remains
ok - tmux endpoint liveness is reported per task: alive for a live window, dead for a gone one
ok - herdr endpoint liveness is reported per task: alive for a live pane, dead for a gone one
ok - fm-session-start.sh composes the real fm-lock.sh, fm-bootstrap.sh, and fm-wake-drain.sh output verbatim
ok - compatible tasks-axi backlog rendering drops done rows and keeps every in-flight, held, and blocked row
ok - the startup backlog bound cuts only dispatchable queued rows and discloses the remainder exactly
ok - manual backlog rendering drops done rows, keeps every held or blocked title line, and bounds the rest
ok - unavailable or incompatible tasks-axi falls back to compact manual backlog rendering
ok - an empty fleet reports (none) for in-flight tasks and an absent AFK flag
ok - session start emits X-mode cadence guidance in the harness supervision block
ok - next step delegates watcher ownership to the AFK daemon
ok - session start emits exactly one detected harness block and reports Pi extension load state
ok - session start preserves pi-signed primary identity while applying Pi extension guarantees
ok - session start rejects stale Pi loaded markers
ok - session start accepts current Pi markers written before lock acquisition
ok - session start rejects Pi sessions missing the turn-end guard marker
ok - session start rejects Pi loaded markers from previous sessions
ok - the pure-Bash watchdog bounds session start, kills its hung grandchild, and emits the truncation contract
ok - the portable timeout path force-kills a command that ignores TERM
ok - a session start inside its budget prints no truncation banner
ok - the runtime bound leaves enough ancestry headroom for a deeply nested session to take the lock
ok - --reemit reprints the digest without repeating startup's mutating sweeps and still drains queued wakes
ok - true-start AGENTS baselines stay immutable while every drifted Pi compact re-emits the current contract
ok - read-only Pi compact refreshes against the rebuilding session identity without mutation
ok - Codex reset sources do not claim an unavailable instruction-refresh channel
ok - instruction baselines require SHA-256 and successful startup completion
ok - --reemit re-verifies lock ownership and keeps repair ownership with whoever holds it
# fm-session-start.test.sh: all assertions passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-spawn.sh:2628` - The fresh-spawn path removes the retirement marker before replacement metadata is safely published. If the process is interrupted or the metadata write at line 2693 fails, no metadata and no marker remain, so late writes from the deliberately untouched retired agent become actionable again. Keep the validated marker through an atomic metadata publication, then clear it under the existing lifecycle locks only after the complete canonical record exists.

🔧 Fix: Captain, preserve retirement markers through atomic metadata publication
1 error still open:
- 🚨 `bin/fm-spawn.sh:2627` - The atomic-publication fix now calls `fm_record_retire_marker_path` and `fm_record_retire_marker_validate_for_spawn` directly, but `fm-wake-lib.sh`&#39;s supported partial-bin fallback defines neither. A recovery copy without `fm-record-retire-lib.sh` therefore aborts every spawn here with `command not found`, even when no marker exists. Extend the shared fallback with path resolution and fail-closed prevalidation, preserving its rule that absent support permits marker-free spawns but refuses any existing marker.

🔧 Fix: Captain, complete partial-bin retirement marker compatibility
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat ef35d799a846d676c2fd30b1d1e3ed47b0fb2c22..252ceef80ac9310ba4421613de31c913496fe845` and targeted call-site/diff inspection</code>
- <code>`FM_RECORD_RETIRE_TEST_ONLY=&lt;marker-safe selector&gt; bash tests/fm-record-retire.test.sh` for full and incremental decision scans, status snapshots, live-metadata audibility, producer-owned paths, normalization collisions, and queue-lock release</code>
- `bash tests/fm-supervision-events.test.sh`
- `bash tests/fm-spawn-dispatch-profile.test.sh`
- `bash tests/fm-session-start.test.sh`
- `Manual scratch-home CLI probe comparing marker-plus-live-metadata behavior against post-metadata-removal retirement behavior`
- <code>Counterfactual `marker_active -&gt; marker_valid` substitutions for full, incremental, snapshot, captain-scan, wake-append, and watcher-signal surfaces; each produced the expected RED hidden-live-state verdict</code>
- <code>`git status --short` after testing</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
