### PR TITLE
fix(bin): abort runs parked on gate-fixed heads before teardown

### DIFF
--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -171,7 +171,10 @@ crew_busy_verdict() {  # <target>
 # --- no-mistakes run lookup (authoritative when a run matches this branch) --
 # trim, strip_quotes, the bounded nm_run call, nm_field's TOON parse, and the
 # branch+head attribution rule below are thin wrappers over the ONE owner in
-# bin/fm-nm-run-lib.sh, shared with fm-teardown.sh's pre-teardown run abort.
+# bin/fm-nm-run-lib.sh. This reader binds a run by strict code identity, so a
+# run head it cannot read is never attributed. fm-teardown.sh's pre-teardown
+# run abort shares the same owner but calls its custody-aware rule, which also
+# attributes an unreadable head while the pipeline still drives that run.
 
 trim() { fm_nm_trim "$@"; }
 strip_quotes() { fm_nm_strip_quotes "$@"; }

--- a/bin/fm-nm-run-lib.sh
+++ b/bin/fm-nm-run-lib.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 # Shared no-mistakes axi run attribution primitives.
 #
-# ONE owner for the branch+code-identity matching rule that decides whether a
-# no-mistakes run belongs to a given worktree, used by fm-crew-state.sh
-# (read-only current-state reporting) and fm-teardown.sh (pre-teardown run
-# abort, see its "Fix 1" header comment). Getting this wrong in either
-# direction is unsafe: a false negative hides a genuinely parked run, and a
-# false positive lets teardown act on a run it does not own.
+# ONE owner for the matching rules that decide whether a no-mistakes run
+# belongs to a given worktree, used by fm-crew-state.sh (read-only
+# current-state reporting) and fm-teardown.sh (pre-teardown run abort, see its
+# "Fix 1" header comment). Getting this wrong in either direction is unsafe: a
+# false negative hides a genuinely parked run, and a false positive lets
+# teardown act on a run it does not own.
+#
+# Two rules live here. fm_nm_head_matches_worktree is the pure code-identity
+# ancestry test. fm_nm_run_matches_worktree layers pipeline custody on top of
+# it for callers that also know the run's status word, and is the one to use
+# whenever a run the pipeline may still be driving has to be attributed.
 #
 # Bounded call to `no-mistakes "$@"` in dir $1, timeout $2 seconds. The bounded
 # form preserves stdout, stderr, and exit status; the checked form discards
@@ -58,6 +63,8 @@ fm_nm_field() {  # <toon-output> <key>
 # 0 if run head $2 matches worktree $1's code identity, per the same rule
 # everywhere this attribution is needed:
 #   - missing/empty head: cannot bind; reject
+#   - run head not in the worktree's object store: cannot bind; reject
+#     (fm_nm_run_matches_worktree below decides what an unreadable head means)
 #   - equal commits (short or full SHA): match
 #   - worktree HEAD is an ancestor of run head: match (pipeline fix commits on
 #     the same history advanced the run tip past local HEAD)
@@ -70,4 +77,54 @@ fm_nm_head_matches_worktree() {  # <worktree> <run_head>
   run_full=$(git -C "$wt" rev-parse --verify "${run_head}^{commit}" 2>/dev/null) || return 1
   [ "$run_full" = "$local_full" ] && return 0
   git -C "$wt" merge-base --is-ancestor "$local_full" "$run_full" 2>/dev/null
+}
+
+# 0 if run head $2 is a commit worktree $1 can actually read, so the ancestry
+# rules above have something to decide against.
+fm_nm_head_is_readable() {  # <worktree> <run_head>
+  local wt=$1 run_head=$2
+  [ -n "$run_head" ] || return 1
+  git -C "$wt" rev-parse --verify --quiet "${run_head}^{commit}" >/dev/null 2>&1
+}
+
+# 0 if run status word $1 names a run the pipeline is still driving, 1 once it
+# names history. `no-mistakes` carries a run as `pending` then `running` for as
+# long as it owns the branch, and as `completed`, `failed`, or `cancelled`
+# afterwards; `axi status` reports the finer in-flight step word in the same
+# field. The list is a whitelist, so an unrecognized future word reads as
+# history and leaves the strict code-identity answer standing rather than being
+# trusted as a live run on no evidence.
+fm_nm_run_status_is_live() {  # <status-word>
+  case "${1:-}" in
+    pending|running|fixing|ci|awaiting_approval|fix_review) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# 0 if the run with head $2 and status $3 is worktree $1's CURRENT run. Callers
+# must already have established that the run is on this worktree's branch; this
+# decides the code-identity half.
+#
+# Whenever the worktree can read the run head, the ancestry rules in
+# fm_nm_head_matches_worktree decide, and a rewritten or diverged tip is refused
+# exactly as before.
+#
+# An UNREADABLE run head is the case that needs deciding, because it is the
+# normal shape of a healthy in-flight run rather than a sign of trouble: the
+# pipeline commits its own gate fixes into its private gate repository
+# (~/.no-mistakes/repos/<id>.git) and does not publish them to the crew's
+# checkout at all until its push step, so from the worktree those commits simply
+# do not exist yet. A live run holds custody of this exact branch in this exact
+# repository right now, which is a stronger statement of ownership than any
+# local ancestry proof, so it is attributed. A terminal run is history, and
+# history that cannot be bound to the worktree's code is exactly what a
+# stale-run misattribution is made of, so it is refused.
+fm_nm_run_matches_worktree() {  # <worktree> <run_head> <run_status>
+  local wt=$1 run_head=$2 run_status=${3:-}
+  [ -n "$run_head" ] || return 1
+  if fm_nm_head_is_readable "$wt" "$run_head"; then
+    fm_nm_head_matches_worktree "$wt" "$run_head"
+    return
+  fi
+  fm_nm_run_status_is_live "$run_status"
 }

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1272,8 +1272,10 @@ task_status_is_run_not_found() {  # <status-error> <run-id>
 # Abort THIS task's own parked no-mistakes run before the worker that would
 # have answered its gate is removed, so no run is left orphaned holding a
 # fleet slot. Only KIND=ship drives a no-mistakes validation of its own
-# worktree (scouts and secondmates never do, mirroring bin/fm-crew-state.sh);
-# a run not attributed to this exact branch+head is left completely alone.
+# worktree (scouts and secondmates never do, mirroring bin/fm-crew-state.sh).
+# Attribution is this branch plus fm_nm_run_matches_worktree: a readable run
+# head is decided by the ancestry rules, an unreadable one by live-pipeline
+# custody. Anything else is left completely alone.
 conclude_task_no_mistakes_run() {  # <worktree>
   local wt=$1 out run_id
   [ "$KIND" = ship ] || return 0

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -103,12 +103,17 @@
 #     alone: no-mistakes drives those against its own gate-repo clone, not the
 #     crew's worktree, so they are not orphaned by removing the worktree.
 #     conclude_task_no_mistakes_run attributes the active-or-most-recent run to
-#     THIS task only when its branch AND code identity (bin/fm-nm-run-lib.sh's
-#     fm_nm_head_matches_worktree, the same rule bin/fm-crew-state.sh uses) both
-#     match this worktree, then runs `no-mistakes axi abort --run <id>` for
-#     that verified run instance. A run already terminal
-#     (an outcome is set) or not parked at a gate is left untouched. Idempotent:
-#     an already-aborted run reads back terminal and is skipped on retry.
+#     THIS task only when its branch matches this worktree's branch and
+#     bin/fm-nm-run-lib.sh's fm_nm_run_matches_worktree confirms the run is this
+#     worktree's current one, then runs `no-mistakes axi abort --run <id>` for
+#     that verified run instance. That shared rule is custody-aware on purpose:
+#     a run that has applied its own gate fixes is parked on a head the worktree
+#     cannot read at all (the pipeline keeps those commits in its private gate
+#     repository until its push step), and binding by readable head alone
+#     silently skipped exactly the parked runs this abort exists to conclude.
+#     A run already terminal (an outcome is set) or not parked at a gate is left
+#     untouched. Idempotent: an already-aborted run reads back terminal and is
+#     skipped on retry.
 #   Fix 2 - reap leaked descendant processes. A backgrounded/disowned process
 #     started under the worktree (or its per-task tasktmp) does not receive the
 #     SIGHUP/SIGTERM that closing the backend pane sends to its own foreground
@@ -1217,11 +1222,15 @@ task_status_is_own_parked_run() {  # <worktree> <axi-status-output>
   [ -n "$run_id" ] || return 1
   run_branch=$(fm_nm_strip_quotes "$(fm_nm_field "$out" branch)")
   [ -n "$run_branch" ] && [ "$run_branch" = "$branch" ] || return 1
-  run_head=$(fm_nm_strip_quotes "$(fm_nm_field "$out" head)")
-  fm_nm_head_matches_worktree "$wt" "$run_head" || return 1
   outcome=$(fm_nm_strip_quotes "$(fm_nm_field "$out" outcome)")
   [ -z "$outcome" ] || return 1
   status=$(fm_nm_strip_quotes "$(fm_nm_field "$out" status)")
+  run_head=$(fm_nm_strip_quotes "$(fm_nm_field "$out" head)")
+  # Terminal runs are already excluded above, so the status word here is only
+  # ever asked whether the pipeline still holds this branch - which is what
+  # makes a gate-fixed head the worktree cannot read attributable rather than
+  # invisible.
+  fm_nm_run_matches_worktree "$wt" "$run_head" "$status" || return 1
   awaiting=$(printf '%s\n' "$out" | grep -E '^[[:space:]]*awaiting_agent:' | head -1 || true)
   has_gate=$(printf '%s\n' "$out" | grep -Eq '^[[:space:]]*gate:[[:space:]]*' && echo 1 || echo 0)
   case "$status" in

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -78,7 +78,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-supervisor-target-lib.sh` | Resolve the shared supervisor target and backend for the daemon and launcher       |
 | `fm-supervise-daemon.sh` | Presence-gated away-mode sub-supervisor: self-handle routine wakes, guard injection by the detected primary harness, escalate batched digests, alert on failed delivery |
 | `fm-crew-state.sh`       | Print one deterministic current-state line for a crew                                |
-| `fm-nm-run-lib.sh`       | Shared branch-and-code-identity attribution for no-mistakes runs                    |
+| `fm-nm-run-lib.sh`       | Shared code-identity and pipeline-custody attribution for no-mistakes runs           |
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification          |
 | `fm-timeout-lib.sh`      | Single owner of hard-bounded command execution and its fallback watchdog |
 | `fm-timing-lib.sh`       | Single owner of the deferred network stage's per-step elapsed-time records, inert unless a run asks for them |

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -2203,6 +2203,129 @@ test_own_autonomous_run_is_left_alone() {
   pass "a task-owned autonomous running step is left alone rather than aborted"
 }
 
+# The `axi status` shape a run takes once the pipeline has applied its own gate
+# fixes: still parked at a gate with no outcome, but on a head the crew's
+# worktree cannot read, because those fix commits live in the pipeline's private
+# gate repository until its push step.
+gate_fixed_parked_axi_status_toon() {  # <branch> <head> [run-id]
+  cat <<EOF
+run:
+  id: "${3:-01RUN}"
+  branch: $1
+  status: fix_review
+  awaiting_agent: parked 41m
+  head: "$2"
+  pr: ""
+  findings[1]{id,severity,file,line,action,description}:
+    r1,error,b.go,,fix,unchecked error
+gate: review
+EOF
+}
+
+# A terminal run: history, never something teardown may abort.
+terminal_axi_status_toon() {  # <branch> <head> [run-id]
+  cat <<EOF
+run:
+  id: "${3:-01RUN}"
+  branch: $1
+  status: failed
+  head: "$2"
+  pr: ""
+  findings: none
+outcome: failed
+EOF
+}
+
+# A real commit that exists ONLY in a separate object store, the way a pipeline
+# gate-fix commit does before the run's push step: a descendant of the crew's
+# own branch head that the crew's worktree cannot read at all. Echoes its sha.
+pipeline_gate_fix_head() {  # <case-dir>
+  local case_dir=$1 gate
+  gate="$case_dir/gate-repo"
+  git clone -q "$case_dir/origin.git" "$gate"
+  git -C "$gate" checkout -q fm/task-x1
+  git -C "$gate" -c user.email=t@t -c user.name=t \
+    commit -q --allow-empty -m "pipeline gate fix"
+  git -C "$gate" rev-parse HEAD
+}
+
+# A commit the worktree CAN read that is neither its HEAD nor a descendant of
+# it: the rewritten/diverged tip the strict code-identity rule must keep
+# refusing. Made in the project checkout, which shares the worktree's object
+# store. Echoes its sha.
+diverged_readable_head() {  # <case-dir>
+  local case_dir=$1
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t \
+    commit -q --allow-empty -m "diverged tip"
+  git -C "$case_dir/project" rev-parse HEAD
+}
+
+test_gate_fixed_parked_run_is_aborted_before_teardown() {
+  local case_dir rc head
+  case_dir=$(make_case parked-run-gate-fixed)
+  write_meta "$case_dir" no-mistakes ship
+  land_shippable_commit "$case_dir"
+  head=$(pipeline_gate_fix_head "$case_dir")
+  git -C "$case_dir/wt" rev-parse --verify --quiet "$head^{commit}" >/dev/null 2>&1 \
+    && fail "parked-run-gate-fixed: fixture head is readable from the worktree, so it no longer reproduces a gate-fixed run"
+
+  rc=0
+  FM_FAKE_AXI_STATUS="$(gate_fixed_parked_axi_status_toon fm/task-x1 "$head")" \
+  FM_FAKE_NM_ABORT_LOG="$case_dir/nm-abort.log" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+
+  expect_code 0 "$rc" "parked-run-gate-fixed: teardown should still succeed"
+  assert_present "$case_dir/nm-abort.log" \
+    "parked-run-gate-fixed: a run parked after its own gate fixes was skipped, leaving it parked forever"
+  assert_grep "abort --run 01RUN" "$case_dir/nm-abort.log" \
+    "parked-run-gate-fixed: no-mistakes axi abort did not target the verified run id"
+  assert_grep "parked at a gate; aborting" "$case_dir/stderr" \
+    "parked-run-gate-fixed: teardown did not report aborting the gate-fixed parked run"
+  pass "a run parked on a gate-fixed head the worktree cannot read is still aborted, not orphaned"
+}
+
+test_diverged_readable_head_run_is_never_aborted() {
+  local case_dir rc head
+  case_dir=$(make_case parked-run-diverged-head)
+  write_meta "$case_dir" no-mistakes ship
+  land_shippable_commit "$case_dir"
+  head=$(diverged_readable_head "$case_dir")
+  git -C "$case_dir/wt" rev-parse --verify --quiet "$head^{commit}" >/dev/null 2>&1 \
+    || fail "parked-run-diverged-head: fixture head is unreadable, so it no longer exercises the code-identity rule"
+
+  rc=0
+  FM_FAKE_AXI_STATUS="$(parked_axi_status_toon fm/task-x1 "$head")" \
+  FM_FAKE_NM_ABORT_LOG="$case_dir/nm-abort.log" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+
+  expect_code 0 "$rc" "parked-run-diverged-head: teardown should still succeed"
+  assert_absent "$case_dir/nm-abort.log" \
+    "parked-run-diverged-head: teardown aborted a run whose readable head diverged from this worktree"
+  assert_not_contains "$(cat "$case_dir/stderr")" "aborting" \
+    "parked-run-diverged-head: teardown reported aborting a run it does not own"
+  pass "a same-branch run on a readable but diverged head is still never aborted"
+}
+
+test_terminal_unreadable_head_run_is_never_aborted() {
+  local case_dir rc head
+  case_dir=$(make_case terminal-run-unreadable-head)
+  write_meta "$case_dir" no-mistakes ship
+  land_shippable_commit "$case_dir"
+  head=$(pipeline_gate_fix_head "$case_dir")
+
+  rc=0
+  FM_FAKE_AXI_STATUS="$(terminal_axi_status_toon fm/task-x1 "$head")" \
+  FM_FAKE_NM_ABORT_LOG="$case_dir/nm-abort.log" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+
+  expect_code 0 "$rc" "terminal-run-unreadable-head: teardown should still succeed"
+  assert_absent "$case_dir/nm-abort.log" \
+    "terminal-run-unreadable-head: teardown aborted a terminal run it cannot bind to this worktree"
+  assert_not_contains "$(cat "$case_dir/stderr")" "aborting" \
+    "terminal-run-unreadable-head: teardown reported aborting a terminal run"
+  pass "a terminal run on an unreadable head is history, not custody, and is left alone"
+}
+
 test_leaked_worktree_process_is_reaped() {
   local case_dir rc pid
   case_dir=$(make_case leaked-process-reap)
@@ -2639,6 +2762,9 @@ test_empty_status_after_abort_refuses_unconfirmed
 test_not_found_status_after_abort_confirms_completion
 test_another_branchs_parked_run_is_never_touched
 test_own_autonomous_run_is_left_alone
+test_gate_fixed_parked_run_is_aborted_before_teardown
+test_diverged_readable_head_run_is_never_aborted
+test_terminal_unreadable_head_run_is_never_aborted
 test_leaked_worktree_process_is_reaped
 test_leaked_tasktmp_process_is_reaped
 test_lsof_absent_reaps_tmux_process_group

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -2222,17 +2222,37 @@ gate: review
 EOF
 }
 
-# A terminal run: history, never something teardown may abort.
+# A terminal run: history, never something teardown may abort. Real terminal
+# runs report `status: completed` with the verdict in `outcome:` (the shape
+# tests/fm-crew-state.test.sh's run_failed pins).
 terminal_axi_status_toon() {  # <branch> <head> [run-id]
   cat <<EOF
 run:
   id: "${3:-01RUN}"
   branch: $1
-  status: failed
+  status: completed
   head: "$2"
   pr: ""
   findings: none
 outcome: failed
+EOF
+}
+
+# A run whose status word says the pipeline is no longer driving it, but which
+# has not reported an outcome yet, still carries parked evidence, and sits on a
+# head the worktree cannot read. Nothing here binds the run to this worktree's
+# code, so the custody rule must refuse it on the status word alone.
+settled_status_parked_axi_status_toon() {  # <branch> <head> [run-id]
+  cat <<EOF
+run:
+  id: "${3:-01RUN}"
+  branch: $1
+  status: completed
+  awaiting_agent: parked 12m
+  head: "$2"
+  pr: ""
+  findings: none
+gate: review
 EOF
 }
 
@@ -2324,6 +2344,28 @@ test_terminal_unreadable_head_run_is_never_aborted() {
   assert_not_contains "$(cat "$case_dir/stderr")" "aborting" \
     "terminal-run-unreadable-head: teardown reported aborting a terminal run"
   pass "a terminal run on an unreadable head is history, not custody, and is left alone"
+}
+
+test_non_live_status_unreadable_head_run_is_never_aborted() {
+  local case_dir rc head
+  case_dir=$(make_case parked-run-non-live-status)
+  write_meta "$case_dir" no-mistakes ship
+  land_shippable_commit "$case_dir"
+  head=$(pipeline_gate_fix_head "$case_dir")
+  git -C "$case_dir/wt" rev-parse --verify --quiet "$head^{commit}" >/dev/null 2>&1 \
+    && fail "parked-run-non-live-status: fixture head is readable from the worktree, so custody is not what decides this case"
+
+  rc=0
+  FM_FAKE_AXI_STATUS="$(settled_status_parked_axi_status_toon fm/task-x1 "$head")" \
+  FM_FAKE_NM_ABORT_LOG="$case_dir/nm-abort.log" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+
+  expect_code 0 "$rc" "parked-run-non-live-status: teardown should still succeed"
+  assert_absent "$case_dir/nm-abort.log" \
+    "parked-run-non-live-status: teardown aborted a run on an unreadable head that no live pipeline holds"
+  assert_not_contains "$(cat "$case_dir/stderr")" "aborting" \
+    "parked-run-non-live-status: teardown reported aborting a run it cannot bind to this worktree"
+  pass "a parked run on an unreadable head is left alone once its status word says no pipeline drives it"
 }
 
 test_leaked_worktree_process_is_reaped() {
@@ -2765,6 +2807,7 @@ test_own_autonomous_run_is_left_alone
 test_gate_fixed_parked_run_is_aborted_before_teardown
 test_diverged_readable_head_run_is_never_aborted
 test_terminal_unreadable_head_run_is_never_aborted
+test_non_live_status_unreadable_head_run_is_never_aborted
 test_leaked_worktree_process_is_reaped
 test_leaked_tasktmp_process_is_reaped
 test_lsof_absent_reaps_tmux_process_group


### PR DESCRIPTION
Withdrawn by the author. Opened against the upstream project in error; this work belongs on the author's fork.