### PR TITLE
feat(session): emit Claude Code session name at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,11 @@ Then launch one of the co-primary harnesses; AGENTS.md takes over from there:
 **Claude Code**
 
 ```sh
-claude
+claude --name firstmate
 ```
+
+The `--name` flag sets the session's display title in the picker and terminal.
+Default is `firstmate`; override per home by writing the desired name to a single line in `config/session-name` (gitignored, captain-private), then launch with `claude --name "$(cat config/session-name)"`.
 
 **Grok**
 

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -616,6 +616,11 @@ if [ "$REEMIT" -eq 1 ]; then
 else
   section "SESSION START - $FM_HOME"
 fi
+# --- session name -------------------------------------------------------
+SESSION_NAME=$(head -1 "$FM_HOME/config/session-name" 2>/dev/null | tr -d '[:space:]')
+[ -n "$SESSION_NAME" ] || SESSION_NAME=firstmate
+printf 'session name: %s\n' "$SESSION_NAME"
+printf "  Claude Code UI: \`/rename %s\` for this session, or relaunch with \`claude --name %s\` next time.\n" "$SESSION_NAME" "$SESSION_NAME"
 # --- 1. lock -----------------------------------------------------------
 stage lock
 subsection "LOCK"


### PR DESCRIPTION
Print the configured session name near the top of the digest so the captain sees which name this session is set to use, and update README to launch with `claude --name firstmate` so future sessions pick the name up automatically.

The name is read from $FM_HOME/config/session-name (default: firstmate), so each firstmate home can declare its own title without touching the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)