### PR TITLE
feat(bin): guard local landings against dropping local-only commits

### DIFF
--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -7,9 +7,24 @@
 # rule #1 "never run state-changing git in projects/", and it is narrow: it only
 # runs for mode=local-only tasks, only after the captain approves (or yolo=on
 # auto-approves), and only as a clean fast-forward - it refuses a diverged branch
-# and tells you to have the crewmate rebase. See AGENTS.md prime directives,
-# project management, and task lifecycle.
-# Usage: fm-merge-local.sh <task-id>
+# and names every local commit that landing it would drop. See AGENTS.md prime
+# directives, project management, and task lifecycle.
+#
+# The local-commit guard exists because a task worktree is always freshened from
+# origin's default-branch tip, never from the local default branch. On a project
+# whose local default branch carries commits origin does not have (a fork that
+# cannot merge upstream, or local adoptions of unmerged upstream work), a branch
+# cut from that fresh base does not contain them, so landing it naively would
+# erase them. The guard names those commits and the reconciliation that keeps
+# them: `git merge <default>` inside the task branch.
+#
+# --drop-local-commits is the deliberate escape hatch for the case where losing
+# them IS the intent. It is never the default and never silent: it refuses unless
+# the guard actually triggered, prints every dropped commit, records them in
+# state/<id>.local-merge-drop before touching the branch, and then resets the
+# default branch to the task branch. Dropped commits stay recoverable by the full
+# SHAs in that record. Being destructive, it needs the captain's explicit word.
+# Usage: fm-merge-local.sh [--drop-local-commits] <task-id>
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -17,7 +32,23 @@ FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 "$FM_ROOT/bin/fm-guard.sh" || true
-ID=${1:?usage: fm-merge-local.sh <task-id>}
+
+DROP_LOCAL=no
+ID=
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --drop-local-commits) DROP_LOCAL=yes ;;
+    -h|--help) sed -n '2,28p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -*) echo "error: unknown option '$1'; usage: fm-merge-local.sh [--drop-local-commits] <task-id>" >&2; exit 1 ;;
+    *)
+      [ -z "$ID" ] || { echo "error: unexpected argument '$1'; usage: fm-merge-local.sh [--drop-local-commits] <task-id>" >&2; exit 1; }
+      ID=$1
+      ;;
+  esac
+  shift
+done
+[ -n "$ID" ] || { echo "usage: fm-merge-local.sh [--drop-local-commits] <task-id>" >&2; exit 1; }
+
 META="$STATE/$ID.meta"
 [ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }
 
@@ -55,11 +86,47 @@ if [ -n "$(git -C "$PROJ" status --porcelain 2>/dev/null | head -1)" ]; then
   exit 1
 fi
 
-# Clean fast-forward only: DEFAULT must be an ancestor of BRANCH.
-if ! git -C "$PROJ" merge-base --is-ancestor "$DEFAULT" "$BRANCH"; then
-  echo "REFUSED: $BRANCH is not a fast-forward of $DEFAULT (it has diverged)." >&2
-  echo "Have the crewmate rebase $BRANCH onto $DEFAULT, then retry." >&2
-  exit 1
+# Commits on the local default branch that the task branch does not contain.
+# Empty means the merge is a clean fast-forward and nothing local is dropped;
+# non-empty is exactly the trap this guard exists for.
+DROPPED=$(git -C "$PROJ" rev-list "$BRANCH..$DEFAULT")
+
+if [ -n "$DROPPED" ]; then
+  if [ "$DROP_LOCAL" != yes ]; then
+    {
+      echo "REFUSED: landing $BRANCH would drop $(printf '%s\n' "$DROPPED" | wc -l | tr -d ' ') commit(s) that exist only on local $DEFAULT:"
+      git -C "$PROJ" log --no-decorate --format='  %h %s' "$BRANCH..$DEFAULT"
+      echo "$BRANCH was cut from origin/$DEFAULT, so it never contained them."
+      echo "Reconcile first: run 'git merge $DEFAULT' inside $BRANCH (in its own worktree), resolve any conflicts, then retry this merge."
+      echo "If dropping those commits is genuinely intended, re-run with --drop-local-commits (destructive; needs the captain's explicit word)."
+    } >&2
+    exit 1
+  fi
+
+  before=$(git -C "$PROJ" rev-parse "$DEFAULT")
+  RECORD="$STATE/$ID.local-merge-drop"
+  {
+    echo "# $(date -u '+%Y-%m-%dT%H:%M:%SZ') fm-merge-local.sh --drop-local-commits"
+    echo "task=$ID"
+    echo "project=$PROJ"
+    echo "default=$DEFAULT"
+    echo "branch=$BRANCH"
+    echo "default_before=$before"
+    git -C "$PROJ" log --no-decorate --format='dropped=%H %s' "$BRANCH..$DEFAULT"
+  } >> "$RECORD"
+
+  echo "DROPPING $(printf '%s\n' "$DROPPED" | wc -l | tr -d ' ') local-only commit(s) from $DEFAULT as explicitly authorized:"
+  git -C "$PROJ" log --no-decorate --format='  %H %s' "$BRANCH..$DEFAULT"
+  echo "recorded in $RECORD (recoverable by full SHA)"
+
+  git -C "$PROJ" reset --hard "$BRANCH" >/dev/null
+  after=$(git -C "$PROJ" rev-parse --short "$DEFAULT")
+  echo "reset local $DEFAULT to $BRANCH ($(git -C "$PROJ" rev-parse --short "$before") -> $after) in $PROJ"
+  exit 0
+fi
+
+if [ "$DROP_LOCAL" = yes ]; then
+  echo "note: --drop-local-commits was unnecessary; $BRANCH already contains every local $DEFAULT commit"
 fi
 
 before=$(git -C "$PROJ" rev-parse --short "$DEFAULT")

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -20,10 +20,19 @@
 #
 # --drop-local-commits is the deliberate escape hatch for the case where losing
 # them IS the intent. It is never the default and never silent: it refuses unless
-# the guard actually triggered, prints every dropped commit, records them in
+# the guard actually triggered, prints every dropped commit, pins the pre-reset
+# tip of the default branch under refs/fm-dropped/<id> and records them in
 # state/<id>.local-merge-drop before touching the branch, and then resets the
-# default branch to the task branch. Dropped commits stay recoverable by the full
-# SHAs in that record. Being destructive, it needs the captain's explicit word.
+# default branch to the task branch. That rescue ref is what makes the recorded
+# SHAs recoverable: after the reset the dropped commits hang off nothing else,
+# and the reflog that would otherwise hold them expires (gc.reflogExpireUnreachable,
+# 30 days by default) and is then pruned by `git gc`. A ref never expires, so the
+# commits stay in the project for as long as it does - and stay there until
+# someone releases them with `git update-ref -d refs/fm-dropped/<id>`, which is
+# the deliberate counterpart of that guarantee. The branch never moves when that
+# ref cannot be planted, including when an earlier rescue ref still holds commits
+# the new one would not. Being destructive, the whole escape hatch needs the
+# captain's explicit word.
 # Usage: fm-merge-local.sh [--drop-local-commits] <task-id>
 set -eu
 
@@ -38,7 +47,7 @@ ID=
 while [ $# -gt 0 ]; do
   case "$1" in
     --drop-local-commits) DROP_LOCAL=yes ;;
-    -h|--help) sed -n '2,28p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -h|--help) awk 'NR>1 && !/^#/{exit} NR>1' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
     -*) echo "error: unknown option '$1'; usage: fm-merge-local.sh [--drop-local-commits] <task-id>" >&2; exit 1 ;;
     *)
       [ -z "$ID" ] || { echo "error: unexpected argument '$1'; usage: fm-merge-local.sh [--drop-local-commits] <task-id>" >&2; exit 1; }
@@ -105,6 +114,22 @@ if [ -n "$DROPPED" ]; then
 
   before=$(git -C "$PROJ" rev-parse "$DEFAULT")
   RECORD="$STATE/$ID.local-merge-drop"
+  RESCUE_REF="refs/fm-dropped/$ID"
+
+  # Plant the rescue ref BEFORE the reset, and never move the branch without it:
+  # it is the only thing that keeps the dropped commits reachable once the reflog
+  # is pruned. Refuse to clobber an earlier rescue point the new one would not
+  # itself hold, which would strand exactly the commits it promised to keep.
+  held=$(git -C "$PROJ" rev-parse --verify --quiet "$RESCUE_REF^{commit}" || true)
+  if [ -n "$held" ] && ! git -C "$PROJ" merge-base --is-ancestor "$held" "$before"; then
+    echo "error: rescue ref $RESCUE_REF already holds $held from an earlier drop and $DEFAULT no longer contains it; overwriting it would strand those commits. Release it first (git -C $PROJ update-ref -d $RESCUE_REF) if they are truly unwanted, then re-run. $DEFAULT is untouched." >&2
+    exit 1
+  fi
+  git -C "$PROJ" update-ref "$RESCUE_REF" "$before" || {
+    echo "error: could not plant rescue ref $RESCUE_REF at $before in $PROJ; refusing to drop commits with no way back. $DEFAULT is untouched." >&2
+    exit 1
+  }
+
   {
     echo "# $(date -u '+%Y-%m-%dT%H:%M:%SZ') fm-merge-local.sh --drop-local-commits"
     echo "task=$ID"
@@ -112,12 +137,14 @@ if [ -n "$DROPPED" ]; then
     echo "default=$DEFAULT"
     echo "branch=$BRANCH"
     echo "default_before=$before"
+    echo "rescue_ref=$RESCUE_REF"
     git -C "$PROJ" log --no-decorate --format='dropped=%H %s' "$BRANCH..$DEFAULT"
   } >> "$RECORD"
 
   echo "DROPPING $(printf '%s\n' "$DROPPED" | wc -l | tr -d ' ') local-only commit(s) from $DEFAULT as explicitly authorized:"
   git -C "$PROJ" log --no-decorate --format='  %H %s' "$BRANCH..$DEFAULT"
-  echo "recorded in $RECORD (recoverable by full SHA)"
+  echo "recorded in $RECORD; rescue ref $RESCUE_REF now holds $DEFAULT's pre-reset tip, so those commits stay in $PROJ (not just in the reflog) and stay recoverable by full SHA"
+  echo "release them for good with: git -C $PROJ update-ref -d $RESCUE_REF"
 
   git -C "$PROJ" reset --hard "$BRANCH" >/dev/null
   after=$(git -C "$PROJ" rev-parse --short "$DEFAULT")

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -6,9 +6,10 @@
 # locally instead of via a GitHub PR). It is the one sanctioned exception to hard
 # rule #1 "never run state-changing git in projects/", and it is narrow: it only
 # runs for mode=local-only tasks, only after the captain approves (or yolo=on
-# auto-approves), and only as a clean fast-forward - it refuses a diverged branch
-# and names every local commit that landing it would drop. See AGENTS.md prime
-# directives, project management, and task lifecycle.
+# auto-approves), and only as a clean fast-forward unless the captain explicitly
+# takes the --drop-local-commits escape hatch below - otherwise it refuses any
+# landing that would drop a local commit and names every one of them. See
+# AGENTS.md prime directives, project management, and task lifecycle.
 #
 # The local-commit guard exists because a task worktree is always freshened from
 # origin's default-branch tip, never from the local default branch. On a project
@@ -19,11 +20,12 @@
 # them: `git merge <default>` inside the task branch.
 #
 # --drop-local-commits is the deliberate escape hatch for the case where losing
-# them IS the intent. It is never the default and never silent: it refuses unless
-# the guard actually triggered, prints every dropped commit, pins the pre-reset
-# tip of the default branch under refs/fm-dropped/<id>/<short-sha> and records
-# them in state/<id>.local-merge-drop before touching the branch, and then resets
-# the default branch to the task branch. That rescue ref is what makes the
+# them IS the intent. It is never the default and never silent: when the guard
+# did not trigger it drops nothing and says so rather than passing as a silent
+# no-op, and when it did it prints every dropped commit, pins the pre-reset tip
+# of the default branch under refs/fm-dropped/<id>/<short-sha> and records them
+# in state/<id>.local-merge-drop before touching the branch, and then resets the
+# default branch to the task branch. That rescue ref is what makes the
 # recorded SHAs recoverable: after the reset the dropped commits hang off nothing
 # else, and the reflog that would otherwise hold them expires
 # (gc.reflogExpireUnreachable, 30 days by default) and is then pruned by `git gc`.

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -21,18 +21,21 @@
 # --drop-local-commits is the deliberate escape hatch for the case where losing
 # them IS the intent. It is never the default and never silent: it refuses unless
 # the guard actually triggered, prints every dropped commit, pins the pre-reset
-# tip of the default branch under refs/fm-dropped/<id> and records them in
-# state/<id>.local-merge-drop before touching the branch, and then resets the
-# default branch to the task branch. That rescue ref is what makes the recorded
-# SHAs recoverable: after the reset the dropped commits hang off nothing else,
-# and the reflog that would otherwise hold them expires (gc.reflogExpireUnreachable,
-# 30 days by default) and is then pruned by `git gc`. A ref never expires, so the
-# commits stay in the project for as long as it does - and stay there until
-# someone releases them with `git update-ref -d refs/fm-dropped/<id>`, which is
-# the deliberate counterpart of that guarantee. The branch never moves when that
-# ref cannot be planted, including when an earlier rescue ref still holds commits
-# the new one would not. Being destructive, the whole escape hatch needs the
-# captain's explicit word.
+# tip of the default branch under refs/fm-dropped/<id>/<short-sha> and records
+# them in state/<id>.local-merge-drop before touching the branch, and then resets
+# the default branch to the task branch. That rescue ref is what makes the
+# recorded SHAs recoverable: after the reset the dropped commits hang off nothing
+# else, and the reflog that would otherwise hold them expires
+# (gc.reflogExpireUnreachable, 30 days by default) and is then pruned by `git gc`.
+# A ref never expires, so the commits stay in the project for as long as it does.
+# The ref is keyed by the rescued tip, not by the task, so a later drop on the
+# same task plants its own ref beside the earlier one instead of displacing it,
+# and the branch never moves when a ref cannot be planted. Each ref is released
+# on its own - `git update-ref -d refs/fm-dropped/<id>/<short-sha>` frees exactly
+# that drop's commits and leaves every other rescue alone - which is the
+# deliberate counterpart of the guarantee: until then those commits stay in the
+# project. Being destructive, the whole escape hatch needs the captain's explicit
+# word.
 # Usage: fm-merge-local.sh [--drop-local-commits] <task-id>
 set -eu
 
@@ -114,21 +117,22 @@ if [ -n "$DROPPED" ]; then
 
   before=$(git -C "$PROJ" rev-parse "$DEFAULT")
   RECORD="$STATE/$ID.local-merge-drop"
-  RESCUE_REF="refs/fm-dropped/$ID"
+  # Keyed by the rescued tip, so successive drops on one task never contend for
+  # the same name and none can displace another's commits.
+  RESCUE_REF="refs/fm-dropped/$ID/$(git -C "$PROJ" rev-parse --short "$before")"
 
-  # Plant the rescue ref BEFORE the reset, and never move the branch without it:
-  # it is the only thing that keeps the dropped commits reachable once the reflog
-  # is pruned. Refuse to clobber an earlier rescue point the new one would not
-  # itself hold, which would strand exactly the commits it promised to keep.
+  # Plant it BEFORE the reset, and never move the branch without it: it is the
+  # only thing that keeps the dropped commits reachable once the reflog is
+  # pruned. Creating it with an empty expected value makes clobbering impossible.
   held=$(git -C "$PROJ" rev-parse --verify --quiet "$RESCUE_REF^{commit}" || true)
-  if [ -n "$held" ] && ! git -C "$PROJ" merge-base --is-ancestor "$held" "$before"; then
-    echo "error: rescue ref $RESCUE_REF already holds $held from an earlier drop and $DEFAULT no longer contains it; overwriting it would strand those commits. Release it first (git -C $PROJ update-ref -d $RESCUE_REF) if they are truly unwanted, then re-run. $DEFAULT is untouched." >&2
-    exit 1
+  if [ "$held" = "$before" ]; then
+    echo "note: rescue ref $RESCUE_REF already holds $before from an earlier drop; leaving it as it is"
+  else
+    git -C "$PROJ" update-ref "$RESCUE_REF" "$before" "" || {
+      echo "error: could not plant rescue ref $RESCUE_REF at $before in $PROJ; refusing to drop commits with no way back. $DEFAULT is untouched." >&2
+      exit 1
+    }
   fi
-  git -C "$PROJ" update-ref "$RESCUE_REF" "$before" || {
-    echo "error: could not plant rescue ref $RESCUE_REF at $before in $PROJ; refusing to drop commits with no way back. $DEFAULT is untouched." >&2
-    exit 1
-  }
 
   {
     echo "# $(date -u '+%Y-%m-%dT%H:%M:%SZ') fm-merge-local.sh --drop-local-commits"
@@ -144,7 +148,7 @@ if [ -n "$DROPPED" ]; then
   echo "DROPPING $(printf '%s\n' "$DROPPED" | wc -l | tr -d ' ') local-only commit(s) from $DEFAULT as explicitly authorized:"
   git -C "$PROJ" log --no-decorate --format='  %H %s' "$BRANCH..$DEFAULT"
   echo "recorded in $RECORD; rescue ref $RESCUE_REF now holds $DEFAULT's pre-reset tip, so those commits stay in $PROJ (not just in the reflog) and stay recoverable by full SHA"
-  echo "release them for good with: git -C $PROJ update-ref -d $RESCUE_REF"
+  echo "release this drop's commits for good with: git -C $PROJ update-ref -d $RESCUE_REF (other drops keep their own ref)"
 
   git -C "$PROJ" reset --hard "$BRANCH" >/dev/null
   after=$(git -C "$PROJ" rev-parse --short "$DEFAULT")

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -138,6 +138,9 @@
 #   origin, resolves the current remote default branch, and resets to its tip.
 #   An unreachable origin, unresolved default branch, or non-clean worktree
 #   refuses the spawn rather than risking a PR based on stale history.
+#   That base stays origin's tip even when the LOCAL default branch is ahead of
+#   it, so an upstream PR never carries local-only commits; the spawn only warns
+#   about the divergence, and bin/fm-merge-local.sh guards the local landing.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -1727,6 +1730,21 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   fi
 }
 
+# Warn when the project's LOCAL default branch carries commits origin's tip does
+# not, which is normal on a fork that cannot merge upstream and on local
+# adoptions of unmerged upstream work. The base itself stays origin's tip on
+# purpose: a branch destined for an upstream PR must never carry local-only
+# commits. The cost lands later instead, when that branch is landed locally, so
+# say so at spawn. Advisory only - it never changes the base and never stops a
+# launch. bin/fm-merge-local.sh owns the refusal that actually protects them.
+warn_local_default_divergence() {  # <worktree> <default>
+  local worktree=$1 default=$2 ahead
+  git -C "$worktree" rev-parse --verify --quiet "refs/heads/$default^{commit}" >/dev/null || return 0
+  ahead=$(git -C "$worktree" rev-list --count "origin/$default..refs/heads/$default" 2>/dev/null || true)
+  case "$ahead" in ''|0) return 0 ;; esac
+  echo "warning: local $default is $ahead commit(s) ahead of origin/$default; this worker starts from origin/$default (correct for an upstream PR), so landing its branch locally will need 'git merge $default' inside the branch first" >&2
+}
+
 freshen_spawn_worktree_base() {  # <worktree>
   local worktree=$1 default target expected actual status
   if ! git -C "$worktree" fetch --quiet origin; then
@@ -1767,6 +1785,7 @@ freshen_spawn_worktree_base() {  # <worktree>
     echo "error: pooled worktree '$worktree' is at '${actual:-unknown}', not current '$target' ('$expected'); refusing to launch" >&2
     return 1
   fi
+  warn_local_default_divergence "$worktree" "$default"
 }
 
 herdr_projection_meta_field_exact() {  # <meta> <key>

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -203,6 +203,7 @@ family_for_basename() {
     fm-teardown-endpoint-safety.test.sh)
       printf '%s\n' backend-dispatch
       ;;
+    fm-merge-local.test.sh|\
     fm-pr-check-security.test.sh|fm-pr-merge.test.sh|fm-review-diff.test.sh|\
     fm-teardown.test.sh|fm-x-mode.test.sh)
       printf '%s\n' pr-forge

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -162,10 +162,9 @@ Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-fre
 That base stays origin's tip even on a project whose local default branch is ahead of it, because a branch destined for an upstream PR must never carry local-only commits; the spawn only warns about the divergence.
 The cost of that choice lands later, when such a branch is merged into the local default branch, so `bin/fm-merge-local.sh` refuses any landing that would drop a commit the local default branch has and the task branch does not, names those commits, and points at the `git merge <default>` reconciliation inside the task branch.
 Its `--drop-local-commits` escape hatch exists for the case where losing them is the intent: never the default, never silent, recorded in `state/<id>.local-merge-drop` before the branch moves, and destructive enough to need the captain's explicit word.
-Recovery does not rest on the reflog, which expires and is then pruned by `git gc`: the drop pins the pre-reset tip under `refs/fm-dropped/<id>/<short-sha>` in the project before moving the branch, and refuses to move it if that ref cannot be planted.
-Keying that ref by the rescued tip rather than by the task lets successive drops on one task coexist, each holding its own commits.
-The dropped commits therefore stay in the project for as long as their ref does, which is also why releasing them is an explicit, per-drop act: `git update-ref -d refs/fm-dropped/<id>/<short-sha>`.
-Its header owns the exact mechanics, and `tests/fm-merge-local.test.sh` owns the regression coverage.
+Recovery does not rest on the reflog, which expires and is then pruned by `git gc`: the drop pins the pre-reset tip under its own `refs/fm-dropped/<id>/` rescue ref in the project before moving the branch, and refuses to move the branch when that ref cannot be planted.
+Dropped commits therefore stay in the project for as long as their ref does, so successive drops on one task coexist and releasing one is an explicit, per-drop act that leaves every other rescue alone.
+Its header owns the exact ref naming, drop record, and release command, and `tests/fm-merge-local.test.sh` owns the regression coverage.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.
 Its operating checkout (`FM_ROOT`) and the disposable crewmate worktrees are all linked git worktrees of the same repository, so the valid discriminator is branch state, not whether the checkout is linked.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -159,6 +159,10 @@ Crewmates never intentionally touch your project clone; [treehouse](https://gith
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
 `fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
 Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
+That base stays origin's tip even on a project whose local default branch is ahead of it, because a branch destined for an upstream PR must never carry local-only commits; the spawn only warns about the divergence.
+The cost of that choice lands later, when such a branch is merged into the local default branch, so `bin/fm-merge-local.sh` refuses any landing that would drop a commit the local default branch has and the task branch does not, names those commits, and points at the `git merge <default>` reconciliation inside the task branch.
+Its `--drop-local-commits` escape hatch exists for the case where losing them is the intent: never the default, never silent, recorded in `state/<id>.local-merge-drop` before the branch moves, and destructive enough to need the captain's explicit word.
+Its header owns the exact mechanics, and `tests/fm-merge-local.test.sh` owns the regression coverage.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.
 Its operating checkout (`FM_ROOT`) and the disposable crewmate worktrees are all linked git worktrees of the same repository, so the valid discriminator is branch state, not whether the checkout is linked.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -162,6 +162,8 @@ Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-fre
 That base stays origin's tip even on a project whose local default branch is ahead of it, because a branch destined for an upstream PR must never carry local-only commits; the spawn only warns about the divergence.
 The cost of that choice lands later, when such a branch is merged into the local default branch, so `bin/fm-merge-local.sh` refuses any landing that would drop a commit the local default branch has and the task branch does not, names those commits, and points at the `git merge <default>` reconciliation inside the task branch.
 Its `--drop-local-commits` escape hatch exists for the case where losing them is the intent: never the default, never silent, recorded in `state/<id>.local-merge-drop` before the branch moves, and destructive enough to need the captain's explicit word.
+Recovery does not rest on the reflog, which expires and is then pruned by `git gc`: the drop pins the pre-reset tip under `refs/fm-dropped/<id>` in the project before moving the branch, and refuses to move it if that ref cannot be planted.
+The dropped commits therefore stay in the project for as long as that ref does, which is also why releasing them is an explicit act: `git update-ref -d refs/fm-dropped/<id>`.
 Its header owns the exact mechanics, and `tests/fm-merge-local.test.sh` owns the regression coverage.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -162,8 +162,9 @@ Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-fre
 That base stays origin's tip even on a project whose local default branch is ahead of it, because a branch destined for an upstream PR must never carry local-only commits; the spawn only warns about the divergence.
 The cost of that choice lands later, when such a branch is merged into the local default branch, so `bin/fm-merge-local.sh` refuses any landing that would drop a commit the local default branch has and the task branch does not, names those commits, and points at the `git merge <default>` reconciliation inside the task branch.
 Its `--drop-local-commits` escape hatch exists for the case where losing them is the intent: never the default, never silent, recorded in `state/<id>.local-merge-drop` before the branch moves, and destructive enough to need the captain's explicit word.
-Recovery does not rest on the reflog, which expires and is then pruned by `git gc`: the drop pins the pre-reset tip under `refs/fm-dropped/<id>` in the project before moving the branch, and refuses to move it if that ref cannot be planted.
-The dropped commits therefore stay in the project for as long as that ref does, which is also why releasing them is an explicit act: `git update-ref -d refs/fm-dropped/<id>`.
+Recovery does not rest on the reflog, which expires and is then pruned by `git gc`: the drop pins the pre-reset tip under `refs/fm-dropped/<id>/<short-sha>` in the project before moving the branch, and refuses to move it if that ref cannot be planted.
+Keying that ref by the rescued tip rather than by the task lets successive drops on one task coexist, each holding its own commits.
+The dropped commits therefore stay in the project for as long as their ref does, which is also why releasing them is an explicit, per-drop act: `git update-ref -d refs/fm-dropped/<id>/<short-sha>`.
 Its header owns the exact mechanics, and `tests/fm-merge-local.test.sh` owns the regression coverage.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -60,7 +60,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `backends/cmux.sh`       | Experimental cmux session-provider adapter                                           |
 | `fm-config-push.sh`      | Push declared inherited local material to live local or remote secondmates and send the placement-specific config reread when changed |
 | `fm-project-mode.sh`     | Resolve a project's registered delivery posture from `data/projects.md` for fleet sync and home seeding |
-| `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval            |
+| `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval, refusing a landing that would drop local-only commits |
 | `fm-review-diff.sh`      | Review a crewmate branch or resolved PR head against the authoritative base          |
 | `fm-marker-lib.sh`       | Compatibility entry point for the from-firstmate carrier owned by `fm-operational-input.sh` |
 | `fm-pending-reply-lib.sh` | Parent-owned secondmate pending-reply expectations, recovery, and keyed escalation lifecycle |

--- a/tests/fm-merge-local.test.sh
+++ b/tests/fm-merge-local.test.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Regression tests for fm-merge-local.sh's local landing.
+#
+# A task branch is always cut from origin's default-branch tip, so on a project
+# whose local default branch carries commits origin does not have, landing that
+# branch naively erases them. These tests drive the real script and prove the
+# nominal landing still fast-forwards, the trap is refused by name, and the
+# explicit escape hatch is the only way through.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+MERGE="$ROOT/bin/fm-merge-local.sh"
+TMP_ROOT=$(fm_test_tmproot fm-merge-local)
+
+git_c() { git -C "$1" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' "${@:2}"; }
+
+# make_case <name> <id> [local_only_commit=yes]: build a home plus a project
+# whose local main optionally carries an adoption commit origin never had, and a
+# task branch fm/<id> cut from origin/main. Echoes home|project.
+make_case() {
+  local name=$1 id=$2 adopt=${3:-yes} case_dir home project origin base
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  origin="$case_dir/origin.git"
+  mkdir -p "$home/state"
+
+  git init --quiet -b main "$project"
+  printf 'base\n' > "$project/README.md"
+  git_c "$project" add README.md
+  git_c "$project" commit -qm initial
+  git clone --quiet --bare "$project" "$origin"
+  git -C "$project" remote add origin "file://$origin"
+  git -C "$project" fetch --quiet origin
+  git -C "$project" remote set-head origin --auto >/dev/null 2>&1
+  base=$(git -C "$project" rev-parse HEAD)
+
+  if [ "$adopt" = yes ]; then
+    printf 'local adoption that must survive\n' > "$project/adoption.txt"
+    git_c "$project" add adoption.txt
+    git_c "$project" commit -qm 'adopt upstream PR #1234 locally'
+  fi
+
+  # The task branch starts at origin/main, exactly as a freshened pool worktree does.
+  git_c "$project" branch "fm/$id" "$base"
+  git_c "$project" checkout --quiet "fm/$id"
+  printf 'worker change\n' > "$project/worker.txt"
+  git_c "$project" add worker.txt
+  git_c "$project" commit -qm 'worker work'
+  git_c "$project" checkout --quiet main
+
+  fm_write_meta "$home/state/$id.meta" "project=$project" "mode=local-only" "yolo=off"
+  printf '%s|%s\n' "$home" "$project"
+}
+
+read_case_record() {
+  IFS='|' read -r HOME_DIR PROJECT_DIR <<EOF
+$1
+EOF
+}
+
+run_merge() {
+  FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" FM_SPAWN_NO_GUARD=1 \
+    "$MERGE" "$@" 2>&1
+}
+
+test_clean_landing_fast_forwards() {
+  local rec id out status
+  id='merge-local-clean-r1'
+  rec=$(make_case clean "$id" no)
+  read_case_record "$rec"
+
+  out=$(run_merge "$id")
+  status=$?
+  expect_code 0 "$status" "a clean landing should fast-forward without friction"
+  assert_contains "$out" "merged fm/$id into local main" "clean landing did not report the merge"
+  assert_grep 'worker change' "$PROJECT_DIR/worker.txt" "clean landing did not bring the worker's change"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed clean landing: %s\n' "$(printf '%s\n' "$out" | tail -n 1)"
+  fi
+  pass "a landing that drops nothing still fast-forwards with no added friction"
+}
+
+test_landing_that_drops_a_local_commit_is_refused() {
+  local rec id out status before
+  id='merge-local-trap-r2'
+  rec=$(make_case trap "$id")
+  read_case_record "$rec"
+  before=$(git -C "$PROJECT_DIR" rev-parse main)
+
+  out=$(run_merge "$id")
+  status=$?
+  [ "$status" -ne 0 ] || fail "a landing that erases a local commit succeeded"
+  assert_contains "$out" "would drop 1 commit(s)" "refusal did not count the dropped commits"
+  assert_contains "$out" "adopt upstream PR #1234 locally" "refusal did not name the commit that would disappear"
+  assert_contains "$out" "git merge main" "refusal did not name the reconciliation to run"
+  assert_contains "$out" "--drop-local-commits" "refusal did not name its explicit escape hatch"
+  [ "$(git -C "$PROJECT_DIR" rev-parse main)" = "$before" ] || fail "the refusal still moved main"
+  assert_grep 'local adoption that must survive' "$PROJECT_DIR/adoption.txt" \
+    "the refused landing already erased the local adoption"
+  assert_absent "$HOME_DIR/state/$id.local-merge-drop" "a refusal wrote a drop record"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed refusal:\n%s\n' "$out"
+  fi
+  pass "a landing that would erase a local commit is refused, naming the commit and the fix"
+}
+
+test_reconciled_branch_lands_cleanly() {
+  local rec id out status
+  id='merge-local-reconciled-r3'
+  rec=$(make_case reconciled "$id")
+  read_case_record "$rec"
+
+  # The documented reconciliation: merge the local default branch into the task branch.
+  git_c "$PROJECT_DIR" checkout --quiet "fm/$id"
+  git_c "$PROJECT_DIR" merge --quiet --no-edit main
+  git_c "$PROJECT_DIR" checkout --quiet main
+
+  out=$(run_merge "$id")
+  status=$?
+  expect_code 0 "$status" "a reconciled branch should land: $out"
+  assert_grep 'local adoption that must survive' "$PROJECT_DIR/adoption.txt" \
+    "the reconciled landing lost the local adoption"
+  assert_grep 'worker change' "$PROJECT_DIR/worker.txt" "the reconciled landing lost the worker's change"
+  pass "the reconciliation the refusal names makes the same landing pass"
+}
+
+test_escape_hatch_drops_explicitly_and_traceably() {
+  local rec id out status dropped_sha
+  id='merge-local-escape-r4'
+  rec=$(make_case escape "$id")
+  read_case_record "$rec"
+  dropped_sha=$(git -C "$PROJECT_DIR" rev-parse main)
+
+  out=$(run_merge --drop-local-commits "$id")
+  status=$?
+  expect_code 0 "$status" "the explicit escape hatch should land: $out"
+  assert_contains "$out" "DROPPING 1 local-only commit(s)" "the escape hatch dropped commits silently"
+  assert_contains "$out" "$dropped_sha" "the escape hatch did not print the dropped commit's full SHA"
+  assert_present "$HOME_DIR/state/$id.local-merge-drop" "the escape hatch left no trace record"
+  assert_grep "dropped=$dropped_sha" "$HOME_DIR/state/$id.local-merge-drop" \
+    "the trace record does not carry the dropped commit's recoverable SHA"
+  [ "$(git -C "$PROJECT_DIR" rev-parse main)" = "$(git -C "$PROJECT_DIR" rev-parse "fm/$id")" ] \
+    || fail "the escape hatch did not land the branch"
+  [ ! -e "$PROJECT_DIR/adoption.txt" ] || fail "the escape hatch claimed a drop it did not perform"
+  git -C "$PROJECT_DIR" cat-file -e "$dropped_sha^{commit}" \
+    || fail "the dropped commit is not recoverable by the recorded SHA"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed escape hatch:\n%s\n' "$out"
+  fi
+  pass "the escape hatch drops only when asked, prints what it dropped, and records recoverable SHAs"
+}
+
+test_escape_hatch_is_a_noop_on_a_clean_landing() {
+  local rec id out status
+  id='merge-local-escape-noop-r5'
+  rec=$(make_case escape-noop "$id" no)
+  read_case_record "$rec"
+
+  out=$(run_merge --drop-local-commits "$id")
+  status=$?
+  expect_code 0 "$status" "the escape hatch should stay harmless on a clean landing: $out"
+  assert_contains "$out" "was unnecessary" "the escape hatch did not report itself unnecessary"
+  assert_contains "$out" "merged fm/$id into local main" "the clean landing did not fast-forward"
+  assert_absent "$HOME_DIR/state/$id.local-merge-drop" "a clean landing wrote a drop record"
+  pass "the escape hatch never turns a clean landing into a reset"
+}
+
+test_clean_landing_fast_forwards
+test_landing_that_drops_a_local_commit_is_refused
+test_reconciled_branch_lands_cleanly
+test_escape_hatch_drops_explicitly_and_traceably
+test_escape_hatch_is_a_noop_on_a_clean_landing
+
+echo "# all fm-merge-local tests passed"

--- a/tests/fm-merge-local.test.sh
+++ b/tests/fm-merge-local.test.sh
@@ -170,20 +170,21 @@ test_escape_hatch_is_a_noop_on_a_clean_landing() {
 }
 
 test_dropped_commits_outlive_an_aggressive_gc() {
-  local rec id out status dropped_sha rescue
+  local rec id out status dropped_sha ref rescue
   id='merge-local-rescue-r6'
   rec=$(make_case rescue "$id")
   read_case_record "$rec"
   dropped_sha=$(git -C "$PROJECT_DIR" rev-parse main)
+  ref="refs/fm-dropped/$id/$(git -C "$PROJECT_DIR" rev-parse --short main)"
 
   out=$(run_merge --drop-local-commits "$id")
   status=$?
   expect_code 0 "$status" "the explicit escape hatch should land: $out"
-  assert_contains "$out" "refs/fm-dropped/$id" "the escape hatch did not name the rescue ref that keeps the drop recoverable"
-  assert_contains "$out" "update-ref -d refs/fm-dropped/$id" "the escape hatch did not say how to release the rescue ref"
-  assert_grep "rescue_ref=refs/fm-dropped/$id" "$HOME_DIR/state/$id.local-merge-drop" \
+  assert_contains "$out" "$ref" "the escape hatch did not name the rescue ref that keeps the drop recoverable"
+  assert_contains "$out" "update-ref -d $ref" "the escape hatch did not say how to release the rescue ref"
+  assert_grep "rescue_ref=$ref" "$HOME_DIR/state/$id.local-merge-drop" \
     "the trace record does not name the rescue ref that holds the dropped commits"
-  rescue=$(git -C "$PROJECT_DIR" rev-parse --verify --quiet "refs/fm-dropped/$id" || true)
+  rescue=$(git -C "$PROJECT_DIR" rev-parse --verify --quiet "$ref" || true)
   [ "$rescue" = "$dropped_sha" ] \
     || fail "rescue ref holds '$rescue', expected the pre-reset tip $dropped_sha"
 
@@ -196,7 +197,7 @@ test_dropped_commits_outlive_an_aggressive_gc() {
     'adopt upstream PR #1234 locally' "the rescued commit is no longer readable after gc"
 
   # And the documented release really releases: the ref is the only thing holding them.
-  git -C "$PROJECT_DIR" update-ref -d "refs/fm-dropped/$id"
+  git -C "$PROJECT_DIR" update-ref -d "$ref"
   git -C "$PROJECT_DIR" reflog expire --expire=now --expire-unreachable=now --all >/dev/null 2>&1
   git -C "$PROJECT_DIR" gc --prune=now --quiet >/dev/null 2>&1 || fail "gc failed after releasing the rescue ref"
   if git -C "$PROJECT_DIR" cat-file -e "$dropped_sha^{commit}" 2>/dev/null; then
@@ -205,33 +206,74 @@ test_dropped_commits_outlive_an_aggressive_gc() {
   pass "dropped commits are held by a rescue ref that outlives the reflog, and the documented release frees them"
 }
 
-test_a_second_drop_never_strands_an_earlier_rescue() {
-  local rec id out status first_sha before
+test_successive_drops_each_keep_their_own_rescue() {
+  local rec id out status first_sha second_sha first_ref second_ref
   id='merge-local-rescue-twice-r7'
   rec=$(make_case rescue-twice "$id")
   read_case_record "$rec"
   first_sha=$(git -C "$PROJECT_DIR" rev-parse main)
+  first_ref="refs/fm-dropped/$id/$(git -C "$PROJECT_DIR" rev-parse --short main)"
 
   out=$(run_merge --drop-local-commits "$id")
   status=$?
   expect_code 0 "$status" "the first authorized drop should land: $out"
 
-  # A later local-only commit makes the same task droppable again; the second
-  # drop must not silently reuse the rescue ref and strand the first drop.
+  # A later local-only commit makes the same task droppable again. The second
+  # drop must succeed on its own, without the operator releasing the first rescue.
   printf 'a second local adoption\n' > "$PROJECT_DIR/adoption-2.txt"
   git_c "$PROJECT_DIR" add adoption-2.txt
   git_c "$PROJECT_DIR" commit -qm 'adopt upstream PR #5678 locally'
-  before=$(git -C "$PROJECT_DIR" rev-parse main)
+  second_sha=$(git -C "$PROJECT_DIR" rev-parse main)
+  second_ref="refs/fm-dropped/$id/$(git -C "$PROJECT_DIR" rev-parse --short main)"
+  [ "$second_ref" != "$first_ref" ] || fail "both drops resolved to the same rescue ref name"
 
   out=$(run_merge --drop-local-commits "$id")
   status=$?
-  [ "$status" -ne 0 ] || fail "a second drop overwrote the rescue ref instead of refusing"
-  assert_contains "$out" "refs/fm-dropped/$id" "the refusal did not name the rescue ref it declined to overwrite"
-  assert_contains "$out" "update-ref -d refs/fm-dropped/$id" "the refusal did not say how to release the earlier rescue"
-  [ "$(git -C "$PROJECT_DIR" rev-parse main)" = "$before" ] || fail "the refused second drop still moved main"
-  [ "$(git -C "$PROJECT_DIR" rev-parse --verify --quiet "refs/fm-dropped/$id")" = "$first_sha" ] \
-    || fail "the refused second drop still moved the rescue ref off the first drop's commits"
-  pass "a second drop refuses rather than stranding the commits an earlier rescue ref holds"
+  expect_code 0 "$status" "the second authorized drop should land without releasing the first rescue: $out"
+  assert_contains "$out" "$second_ref" "the second drop did not name its own rescue ref"
+
+  [ "$(git -C "$PROJECT_DIR" rev-parse --verify --quiet "$first_ref")" = "$first_sha" ] \
+    || fail "the second drop displaced the first drop's rescue ref"
+  [ "$(git -C "$PROJECT_DIR" rev-parse --verify --quiet "$second_ref")" = "$second_sha" ] \
+    || fail "the second drop did not pin its own tip"
+
+  git -C "$PROJECT_DIR" reflog expire --expire=now --expire-unreachable=now --all >/dev/null 2>&1
+  git -C "$PROJECT_DIR" gc --prune=now --quiet >/dev/null 2>&1 || fail "gc failed in the test project"
+  git -C "$PROJECT_DIR" cat-file -e "$first_sha^{commit}" 2>/dev/null \
+    || fail "the first drop's commits died once a second drop happened"
+  git -C "$PROJECT_DIR" cat-file -e "$second_sha^{commit}" 2>/dev/null \
+    || fail "the second drop's commits are not held by their rescue ref"
+  assert_contains "$(git -C "$PROJECT_DIR" log -1 --format='%s' "$first_sha")" \
+    'adopt upstream PR #1234 locally' "the first drop's rescued commit is no longer readable"
+  assert_contains "$(git -C "$PROJECT_DIR" log -1 --format='%s' "$second_sha")" \
+    'adopt upstream PR #5678 locally' "the second drop's rescued commit is no longer readable"
+  pass "successive drops on one task each keep their own rescue ref, and neither release is forced by the other"
+}
+
+test_redropping_a_recovered_tip_reuses_its_own_rescue() {
+  local rec id out status dropped_sha ref
+  id='merge-local-rescue-redrop-r8'
+  rec=$(make_case rescue-redrop "$id")
+  read_case_record "$rec"
+  dropped_sha=$(git -C "$PROJECT_DIR" rev-parse main)
+  ref="refs/fm-dropped/$id/$(git -C "$PROJECT_DIR" rev-parse --short main)"
+
+  out=$(run_merge --drop-local-commits "$id")
+  status=$?
+  expect_code 0 "$status" "the first authorized drop should land: $out"
+
+  # The operator recovers main from the rescue ref, then decides to drop again.
+  git_c "$PROJECT_DIR" reset --hard --quiet "$ref"
+
+  out=$(run_merge --drop-local-commits "$id")
+  status=$?
+  expect_code 0 "$status" "re-dropping a recovered tip should land: $out"
+  assert_contains "$out" "already holds $dropped_sha" "the re-drop did not say the rescue ref was already in place"
+  [ "$(git -C "$PROJECT_DIR" rev-parse --verify --quiet "$ref")" = "$dropped_sha" ] \
+    || fail "the re-drop moved the rescue ref off the tip it already held"
+  [ "$(git -C "$PROJECT_DIR" rev-parse main)" = "$(git -C "$PROJECT_DIR" rev-parse "fm/$id")" ] \
+    || fail "the re-drop did not land the branch"
+  pass "re-dropping a tip a rescue ref already holds keeps that ref and says so"
 }
 
 test_clean_landing_fast_forwards
@@ -240,6 +282,7 @@ test_reconciled_branch_lands_cleanly
 test_escape_hatch_drops_explicitly_and_traceably
 test_escape_hatch_is_a_noop_on_a_clean_landing
 test_dropped_commits_outlive_an_aggressive_gc
-test_a_second_drop_never_strands_an_earlier_rescue
+test_successive_drops_each_keep_their_own_rescue
+test_redropping_a_recovered_tip_reuses_its_own_rescue
 
 echo "# all fm-merge-local tests passed"

--- a/tests/fm-merge-local.test.sh
+++ b/tests/fm-merge-local.test.sh
@@ -4,8 +4,9 @@
 # A task branch is always cut from origin's default-branch tip, so on a project
 # whose local default branch carries commits origin does not have, landing that
 # branch naively erases them. These tests drive the real script and prove the
-# nominal landing still fast-forwards, the trap is refused by name, and the
-# explicit escape hatch is the only way through.
+# nominal landing still fast-forwards, the trap is refused by name, the explicit
+# escape hatch is the only way through, and what it drops stays recoverable for
+# as long as its rescue ref lives.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -62,7 +63,7 @@ EOF
 }
 
 run_merge() {
-  FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" FM_SPAWN_NO_GUARD=1 \
+  FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" \
     "$MERGE" "$@" 2>&1
 }
 
@@ -168,10 +169,77 @@ test_escape_hatch_is_a_noop_on_a_clean_landing() {
   pass "the escape hatch never turns a clean landing into a reset"
 }
 
+test_dropped_commits_outlive_an_aggressive_gc() {
+  local rec id out status dropped_sha rescue
+  id='merge-local-rescue-r6'
+  rec=$(make_case rescue "$id")
+  read_case_record "$rec"
+  dropped_sha=$(git -C "$PROJECT_DIR" rev-parse main)
+
+  out=$(run_merge --drop-local-commits "$id")
+  status=$?
+  expect_code 0 "$status" "the explicit escape hatch should land: $out"
+  assert_contains "$out" "refs/fm-dropped/$id" "the escape hatch did not name the rescue ref that keeps the drop recoverable"
+  assert_contains "$out" "update-ref -d refs/fm-dropped/$id" "the escape hatch did not say how to release the rescue ref"
+  assert_grep "rescue_ref=refs/fm-dropped/$id" "$HOME_DIR/state/$id.local-merge-drop" \
+    "the trace record does not name the rescue ref that holds the dropped commits"
+  rescue=$(git -C "$PROJECT_DIR" rev-parse --verify --quiet "refs/fm-dropped/$id" || true)
+  [ "$rescue" = "$dropped_sha" ] \
+    || fail "rescue ref holds '$rescue', expected the pre-reset tip $dropped_sha"
+
+  # The reflog is exactly what the record used to depend on; prune it away.
+  git -C "$PROJECT_DIR" reflog expire --expire=now --expire-unreachable=now --all >/dev/null 2>&1
+  git -C "$PROJECT_DIR" gc --prune=now --quiet >/dev/null 2>&1 || fail "gc failed in the test project"
+  git -C "$PROJECT_DIR" cat-file -e "$dropped_sha^{commit}" 2>/dev/null \
+    || fail "the dropped commit died with the reflog, so the recorded SHA is dead"
+  assert_contains "$(git -C "$PROJECT_DIR" log -1 --format='%s' "$dropped_sha")" \
+    'adopt upstream PR #1234 locally' "the rescued commit is no longer readable after gc"
+
+  # And the documented release really releases: the ref is the only thing holding them.
+  git -C "$PROJECT_DIR" update-ref -d "refs/fm-dropped/$id"
+  git -C "$PROJECT_DIR" reflog expire --expire=now --expire-unreachable=now --all >/dev/null 2>&1
+  git -C "$PROJECT_DIR" gc --prune=now --quiet >/dev/null 2>&1 || fail "gc failed after releasing the rescue ref"
+  if git -C "$PROJECT_DIR" cat-file -e "$dropped_sha^{commit}" 2>/dev/null; then
+    fail "the dropped commit survived the documented release, so the rescue ref is not what was holding it"
+  fi
+  pass "dropped commits are held by a rescue ref that outlives the reflog, and the documented release frees them"
+}
+
+test_a_second_drop_never_strands_an_earlier_rescue() {
+  local rec id out status first_sha before
+  id='merge-local-rescue-twice-r7'
+  rec=$(make_case rescue-twice "$id")
+  read_case_record "$rec"
+  first_sha=$(git -C "$PROJECT_DIR" rev-parse main)
+
+  out=$(run_merge --drop-local-commits "$id")
+  status=$?
+  expect_code 0 "$status" "the first authorized drop should land: $out"
+
+  # A later local-only commit makes the same task droppable again; the second
+  # drop must not silently reuse the rescue ref and strand the first drop.
+  printf 'a second local adoption\n' > "$PROJECT_DIR/adoption-2.txt"
+  git_c "$PROJECT_DIR" add adoption-2.txt
+  git_c "$PROJECT_DIR" commit -qm 'adopt upstream PR #5678 locally'
+  before=$(git -C "$PROJECT_DIR" rev-parse main)
+
+  out=$(run_merge --drop-local-commits "$id")
+  status=$?
+  [ "$status" -ne 0 ] || fail "a second drop overwrote the rescue ref instead of refusing"
+  assert_contains "$out" "refs/fm-dropped/$id" "the refusal did not name the rescue ref it declined to overwrite"
+  assert_contains "$out" "update-ref -d refs/fm-dropped/$id" "the refusal did not say how to release the earlier rescue"
+  [ "$(git -C "$PROJECT_DIR" rev-parse main)" = "$before" ] || fail "the refused second drop still moved main"
+  [ "$(git -C "$PROJECT_DIR" rev-parse --verify --quiet "refs/fm-dropped/$id")" = "$first_sha" ] \
+    || fail "the refused second drop still moved the rescue ref off the first drop's commits"
+  pass "a second drop refuses rather than stranding the commits an earlier rescue ref holds"
+}
+
 test_clean_landing_fast_forwards
 test_landing_that_drops_a_local_commit_is_refused
 test_reconciled_branch_lands_cleanly
 test_escape_hatch_drops_explicitly_and_traceably
 test_escape_hatch_is_a_noop_on_a_clean_landing
+test_dropped_commits_outlive_an_aggressive_gc
+test_a_second_drop_never_strands_an_earlier_rescue
 
 echo "# all fm-merge-local tests passed"

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -227,11 +227,47 @@ test_unresolved_remote_default_refuses_pool() {
   pass "an unresolved remote default branch refuses the pooled worktree"
 }
 
+test_local_default_ahead_warns_without_changing_the_base() {
+  local rec id out status current adopted
+  id='pool-local-ahead-r7'
+  rec=$(make_case local-ahead "$id")
+  read_case_record "$rec"
+
+  # The project's local default branch carries an adoption origin never had -
+  # the fork-that-cannot-merge-upstream shape. The base must stay origin's tip,
+  # so the branch never carries it into an upstream PR, and the spawn must say so.
+  git -C "$PROJECT_DIR" fetch --quiet origin
+  git -C "$PROJECT_DIR" merge --quiet --ff-only "origin/$DEFAULT_BRANCH"
+  printf 'local adoption that must not reach an upstream PR\n' > "$PROJECT_DIR/adoption.txt"
+  git -C "$PROJECT_DIR" add adoption.txt
+  git -C "$PROJECT_DIR" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -qm 'adopt upstream PR locally'
+  adopted=$(git -C "$PROJECT_DIR" rev-parse "refs/heads/$DEFAULT_BRANCH")
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 0 "$status" "a diverged local default branch must not stop the spawn: $out"
+  assert_contains "$out" "ahead of origin/$DEFAULT_BRANCH" "spawn did not warn about the local divergence"
+  assert_contains "$out" "git merge $DEFAULT_BRANCH" "the warning did not name the landing reconciliation"
+  current=$(git -C "$POOL_DIR" rev-parse "origin/$DEFAULT_BRANCH")
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$current" ] \
+    || fail "the warning changed the spawn base away from origin/$DEFAULT_BRANCH"
+  [ "$current" != "$adopted" ] || fail "fixture did not prove local $DEFAULT_BRANCH is ahead of origin"
+  [ ! -e "$POOL_DIR/adoption.txt" ] \
+    || fail "the worker base carries a local-only adoption that would pollute an upstream PR"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed divergence warning: %s\n' "$(printf '%s\n' "$out" | grep 'ahead of origin')"
+  fi
+  pass "a local default branch ahead of origin warns at spawn without moving the base off origin's tip"
+}
+
+
 test_stale_pool_base_refreshes_before_branching
 test_non_main_default_branch_refreshes_before_branching
 test_direct_pr_and_scout_refresh_before_launch
 test_dirty_pool_refuses_without_discarding_work
 test_unresolved_remote_default_refuses_pool
 test_unreachable_origin_refuses_stale_pool_base
+test_local_default_ahead_warns_without_changing_the_base
 
 echo "# all fm-spawn-pool-base-freshen tests passed"


### PR DESCRIPTION
## Intent

Poser une garde a l'ATTERRISSAGE LOCAL d'une branche d'ouvrier dans firstmate, pour qu'une branche fusionnee naivement n'efface plus les adoptions locales deployees.

CONTEXTE MESURE (2026-08-15). Ce home ne peut pas fusionner les PR du depot amont (origin = kunchenguid/firstmate, aucun droit, et l'amont ne fusionne pas les contributions externes). Le main LOCAL est donc 'amont + N adoptions locales', chacune tracee par un commit qui nomme sa PR amont d'origine. Tout poste de travail neuf est cree depuis le sommet AMONT (fm-spawn.sh freshen_spawn_worktree_base fait un reset --hard sur origin/<defaut>), pas depuis le main local. Consequence: une branche qui en sort et qu'on fusionne dans le main local supprime nos adoptions sans que personne l'ait voulu. Le piege s'est declenche quatre fois en deux jours, evite chaque fois seulement par une verification manuelle de 'git diff main..<branche> --stat' (927 lignes supprimees sur un cas). Ce n'est pas une erreur d'ouvrier: c'est la maniere dont les postes de travail sont crees.

NUANCE A PRESERVER ABSOLUMENT (contrainte explicite du captain). Pour une PR AMONT, partir de l'amont est CORRECT et souhaitable: une PR ne doit pas embarquer nos adoptions locales. Le defaut n'est donc PAS la base elle-meme, c'est l'absence de garde a l'atterrissage local. Une 'correction' qui ferait partir tous les postes du main local serait un mauvais correctif car elle polluerait chaque PR amont. Cette exclusion est deliberee.

DEMANDE: instruire d'abord, coder ensuite. Trois pistes identifiees, ordre non normatif, non exclusives: (a) une garde dans bin/fm-merge-local.sh qui refuse un atterrissage dont le diff supprime des commits presents sur le main local; (b) un choix de base explicite au lancement selon la destination de la tache; (c) au minimum un avertissement au lancement quand la base choisie diverge du main local. Lire le code reel avant de trancher et expliquer dans la PR pourquoi ce qui a ete retenu l'a ete.

CRITERES D'ACCEPTATION ACCEPTES: (1) un atterrissage local qui supprimerait un commit present sur le main local est REFUSE, avec un message qui nomme concretement ce qui disparaitrait et ce qu'il faut faire, a savoir reconcilier par 'git merge main' dans la branche; (2) le refus a une echappatoire explicite et tracee pour le cas ou la suppression est voulue, jamais le chemin par defaut ni silencieuse; (3) un atterrissage sain passe sans friction ajoutee; (4) les PR vers l'amont ne sont pas affectees, aucune adoption locale ne doit se retrouver embarquee dans une branche destinee a l'amont; (5) tests colocalises couvrant au minimum le cas nominal, le cas piege (branche basee sur l'amont qui supprime une adoption) et l'echappatoire; (6) la documentation concernee mise a jour la ou ce comportement est decrit.

DECISIONS ET ARBITRAGES PRIS PENDANT LE TRAVAIL (a lire avant de signaler une surprise du diff):
- Lecture du code reel avant de trancher. Constat 1: fm-merge-local.sh refusait deja techniquement le cas via 'merge-base --is-ancestor DEFAULT BRANCH', mais son message ne nommait rien de ce qui disparaitrait et conseillait un 'git rebase' que le pare-feu de cet environnement refuse et qui, surtout, n'est pas la reconciliation demandee. Le refus existait, l'information manquait. La nouvelle garde REMPLACE cet ancien refus d'ancetre plutot que de s'y ajouter: 'rev-list BRANCH..DEFAULT' vide equivaut exactement a 'DEFAULT est ancetre de BRANCH', donc ce n'est pas un controle supplementaire mais le meme controle avec un message exploitable. C'est deliberement une substitution, pas un doublon.
- Constat 2: le veritable point de bascule est fm-spawn.sh:freshen_spawn_worktree_base, qui remet de force le poste de travail sur origin/<defaut>. Il est laisse INCHANGE dans son choix de base, exactement pour honorer la nuance ci-dessus.
- PISTES RETENUES: (a) en plein, et (c) sous forme d'avertissement consultatif au lancement.
- PISTE (b) ECARTEE, avec raison explicite: un choix de base selon la destination aurait ete inoperant ici, car dans ce depot une tache est A LA FOIS une PR amont et une adoption locale; la destination n'est donc pas connaissable au lancement, et keyer sur mode=local-only n'aurait pas couvert le cas mesure (les taches en cause sont mode=no-mistakes). L'absence de changement de base n'est pas un oubli.
- ECHAPPATOIRE: option --drop-local-commits sur fm-merge-local.sh. Jamais par defaut, jamais silencieuse: elle refuse d'etre un no-op deguise (elle signale explicitement quand elle etait inutile), imprime chaque commit lache avec son SHA complet, ecrit un enregistrement state/<id>.local-merge-drop AVANT de bouger la branche, puis fait 'git reset --hard <branche>' sur la branche par defaut. Le reset dur est le geste honnete pour 'la suppression est voulue'; les commits laches restent recuperables par les SHA complets enregistres. Etant destructive, elle exige la parole explicite du captain, ce que AGENTS.md couvre deja.
- AVERTISSEMENT AU LANCEMENT: warn_local_default_divergence, consultatif uniquement. Il ne change jamais la base, ne fait jamais echouer un lancement, et se tait quand le ref local est absent. Ecrit sur stderr.
- PORTEE VOLONTAIREMENT NON ELARGIE: la garde de contenu (detecter une adoption annulee par une reconciliation qui aurait pris le cote amont) n'a pas ete ajoutee. Sur un fast-forward avere aucun commit du main local ne peut disparaitre par definition, donc une garde de contenu par-dessus aurait ete de la friction ajoutee, ce que le critere (3) interdit.
- Le verrou de mode (mode=local-only) de fm-merge-local.sh est conserve tel quel: le relacher aurait touche a la semantique d'autorite de fusion, hors du perimetre demande.

TESTS: tests/fm-merge-local.test.sh (nouveau, cinq cas: atterrissage sain sans friction, cas piege refuse en nommant l'adoption et la reconciliation, la reconciliation annoncee fait passer le meme atterrissage, echappatoire tracee et SHA recuperables, echappatoire inoffensive sur un cas sain) et un sixieme cas ajoute a tests/fm-spawn-pool-base-freshen.test.sh prouvant que l'avertissement se declenche sans deplacer la base et sans embarquer l'adoption dans le poste de travail (critere 4). Tous passent par des interfaces executables, jamais par lecture de source. Enregistre dans la famille pr-forge de bin/fm-test-run.sh.

DOCUMENTATION: docs/architecture.md (section 'Worktrees, not branches in your checkout') et docs/scripts.md. AGENTS.md n'est deliberement pas touche: la regle un-seul-proprietaire de firstmate-coding-guidelines veut que les mecanismes exacts vivent dans l'en-tete du script, et AGENTS.md pointe deja vers fm-merge-local.sh.

CONTRAINTES D'ENVIRONNEMENT: livraison par PR vers l'amont depuis le fork Kallas95/firstmate; l'amont ne lance AUCUNE CI sur les PR de fork, donc PR ouverte + reste du pipeline vert est l'etat terminal normal ici. Un pare-feu refuse sudo, ssh, scp, rsync, chmod, git config --global, git rebase, et git push vers master/main (le bit d'execution du nouveau test a donc ete pose via 'git update-index --chmod=+x').

## What Changed

- `bin/fm-merge-local.sh` replaces the old `merge-base --is-ancestor` divergence refusal with a `rev-list <branch>..<default>` guard that names every commit the landing would drop and points at the `git merge <default>` reconciliation inside the task branch; a clean fast-forward still lands unchanged. The new `--drop-local-commits` escape hatch is the only way through: it pins the pre-reset default tip under `refs/fm-dropped/<id>/<short-sha>` and appends the full SHAs to `state/<id>.local-merge-drop` before touching the branch, refuses to move the branch if the rescue ref cannot be planted, and reports itself as unnecessary rather than passing as a silent no-op on a clean landing. Argument parsing now accepts the flag plus `-h/--help` and rejects unknown options.
- `bin/fm-spawn.sh` adds `warn_local_default_divergence`, called at the end of `freshen_spawn_worktree_base`. It is advisory only, writing to stderr when the local default branch is ahead of `origin/<default>`; the spawn base stays origin's tip so a branch destined for an upstream PR never carries local-only commits, and no launch fails or changes base because of it.
- New `tests/fm-merge-local.test.sh` (8 cases: clean fast-forward, refused trap naming the dropped commit and the reconciliation, reconciled branch landing, traceable escape hatch, escape hatch as no-op, dropped commits surviving an aggressive `gc`, successive drops keeping separate rescue refs, re-dropping a recovered tip) registered in the `pr-forge` family of `bin/fm-test-run.sh`, plus a case in `tests/fm-spawn-pool-base-freshen.test.sh` asserting the warning fires without moving the base or leaking the local adoption into the worker worktree. `docs/architecture.md` and `docs/scripts.md` describe the guard, the escape hatch, and the rescue-ref recovery path.

## Risk Assessment

✅ Low: Toutes les corrections des tours précédents sont vérifiées effectives (aide, variable morte, bit d'exécution réellement commité en 100755, ref de sauvetage désormais par abandon), la garantie de durabilité est cohérente entre code, message, enregistrement et documentation, et le seul point restant est un nommage non déterministe à conséquence marginale et sans perte de données.

## Testing

<code>J&#39;ai exécuté les deux suites colocalisées (`tests/fm-merge-local.test.sh`, `tests/fm-spawn-pool-base-freshen.test.sh`), puis construit une démonstration end-to-end qui rejoue le piège mesuré - un fork dont le `main` local porte deux adoptions et une branche ouvrier créée par `reset --hard origin/main` comme le fait `freshen_spawn_worktree_base` - et pilote le vrai `bin/fm-merge-local.sh` : le refus nomme les deux adoptions et la réconciliation `git merge main`, `main` local reste intact et sans enregistrement, la réconciliation annoncée fait passer le même atterrissage avec adoptions et livrable présents, un atterrissage sain passe sans friction, et l&#39;échappatoire imprime les SHA complets, écrit `state/&lt;id&gt;.local-merge-drop` avant de bouger la branche, pose la ref de sauvetage qui survit à un `git gc --prune=now` après purge du reflog, puis se libère explicitement. Le même transcript compare le comportement du commit de base (refus qui ne nommait rien et conseillait un rebase) à celui du commit cible, et montre qu&#39;une tâche `mode=no-mistakes` est refusée par le verrou de mode sans que la branche destinée à l&#39;amont n&#39;embarque d&#39;adoption. J&#39;ai aussi vérifié les suites voisines exposées (`fm-test-run`, `fm-spawn-batch`, `fm-spawn-worktree-settle`, `fm-documentation-audiences`) et la garde de couverture du runner. Le changement est purement CLI/shell, sans surface graphique : la preuve visible par un relecteur est donc le transcript de terminal, pas une capture d&#39;écran. Tout est vert, aucun problème actionnable, et l&#39;arbre de travail est resté propre.</code>

<details>
<summary>Evidence: Transcript end-to-end du garde d&#39;atterrissage local (7 scènes, avant/après)</summary>

Source: [Transcript end-to-end du garde d&#39;atterrissage local (7 scènes, avant/après)](https://github.com/Kallas95/firstmate/blob/53804b7be45c062969fc9ced298f95616d1a5b15/.no-mistakes/evidence/fm/fm-worktree-base-locale/local-landing-guard-transcript.txt)

```text

== SCENE 1 - the measured shape: local main = upstream + N local adoptions

$ git -C /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/trap/projects/firstmate log --oneline --decorate -3 main
331f69b (HEAD -> main) adopt upstream PR #2456 locally (secondmate recovery hint)
7b44116 adopt upstream PR #2461 locally (calm export confirmation)
d88bbe4 (origin/main, origin/HEAD) upstream: initial

$ git -C /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/trap/projects/firstmate log --oneline origin/main..main
331f69b adopt upstream PR #2456 locally (secondmate recovery hint)
7b44116 adopt upstream PR #2461 locally (calm export confirmation)

== the worker branch was cut from origin/main, so it does not contain them

$ git -C /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/trap/projects/firstmate log --oneline origin/main..fm/fix-calm-a1
f3f998a feat(bin): the work the crewmate was sent to do

== the manual check that caught this four times in two days:

$ git -C /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/trap/projects/firstmate diff main..fm/fix-calm-a1 --stat
 calm-export.txt   | 1 -
 feature.txt       | 1 +
 recovery-hint.txt | 1 -
 3 files changed, 1 insertion(+), 2 deletions(-)

== SCENE 2 - BEFORE (base commit ef35d79): refused, but names nothing

$ fm-merge-local.sh fix-calm-a1
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: never, grace 300s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  watcher supervision needs Stop-owned automatic recovery; inspect the hook registration and startup status before ending the turn.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
REFUSED: fm/fix-calm-a1 is not a fast-forward of main (it has diverged).
Have the crewmate rebase fm/fix-calm-a1 onto main, then retry.
[exit 1]

== SCENE 3 - AFTER (38bb5cd): refused, naming what would disappear and the fix

$ fm-merge-local.sh fix-calm-a1
WARNING: watcher still down (same stale episode; last beat: never, grace 300s) - full banner already printed this episode.
REFUSED: landing fm/fix-calm-a1 would drop 2 commit(s) that exist only on local main:
  331f69b adopt upstream PR #2456 locally (secondmate recovery hint)
  7b44116 adopt upstream PR #2461 locally (calm export confirmation)
fm/fix-calm-a1 was cut from origin/main, so it never contained them.
Reconcile first: run 'git merge main' inside fm/fix-calm-a1 (in its own worktree), resolve any conflicts, then retry this merge.
If dropping those commits is genuinely intended, re-run with --drop-local-commits (destructive; needs the captain's explicit word).
[exit 1]

== local main is untouched by the refusal, and no drop record was written:

$ git -C /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/trap/projects/firstmate log --oneline -1 main
331f69b adopt upstream PR #2456 locally (secondmate recovery hint)

$ ls /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/trap/state
fix-calm-a1.meta

== SCENE 4 - the reconciliation the refusal names makes the same landing pass

$ git -C /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/trap/worker merge --no-edit main
Merge made by the 'ort' strategy.
 calm-export.txt   | 1 +
 recovery-hint.txt | 1 +
 2 files changed, 2 insertions(+)
 create mode 100644 calm-export.txt
 create mode 100644 recovery-hint.txt

$ fm-merge-local.sh fix-calm-a1
WARNING: watcher still down (same stale episode; last beat: never, grace 300s) - full banner already printed this episode.
merged fm/fix-calm-a1 into local main (331f69b -> 876d6ad) in /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/trap/projects/firstmate

== both the adoptions and the worker deliverable are on local main:

$ git -C /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/trap/projects/firstmate log --oneline -5 main
876d6ad Merge branch 'main' into fm/fix-calm-a1
f3f998a feat(bin): the work the crewmate was sent to do
331f69b adopt upstream PR #2456 locally (secondmate recovery hint)
d88bbe4 upstream: initial
7b44116 adopt upstream PR #2461 locally (calm export confirmation)

$ ls /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/trap/projects/firstmate
README.md
calm-export.txt
feature.txt
recovery-hint.txt

== SCENE 5 - a healthy landing keeps passing with no added friction

$ fm-merge-local.sh ship-clean-b2
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: never, grace 300s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  watcher supervision needs Stop-owned automatic recovery; inspect the hook registration and startup status before ending the turn.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
merged fm/ship-clean-b2 into local main (43d7501 -> 63775bd) in /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/clean/projects/firstmate

== and the escape hatch cannot silently turn a healthy landing into a reset:

$ fm-merge-local.sh ship-clean-c3 --drop-local-commits
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: never, grace 300s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  watcher supervision needs Stop-owned automatic recovery; inspect the hook registration and startup status before ending the turn.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
note: --drop-local-commits was unnecessary; fm/ship-clean-c3 already contains every local main commit
merged fm/ship-clean-c3 into local main (43d7501 -> 63775bd) in /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/clean2/projects/firstmate

== SCENE 6 - the escape hatch: explicit, traced, recoverable

$ fm-merge-local.sh --drop-local-commits fix-drop-d4
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: never, grace 300s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  watcher supervision needs Stop-owned automatic recovery; inspect the hook registration and startup status before ending the turn.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
DROPPING 2 local-only commit(s) from main as explicitly authorized:
  b4b46ab861c5d12cbfc481d54d09a43611fd79f3 adopt upstream PR #2456 locally (secondmate recovery hint)
  3c1275df9fa02e3fa65eb7245fbd91123cfdfc6e adopt upstream PR #2461 locally (calm export confirmation)
recorded in /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/drop/state/fix-drop-d4.local-merge-drop; rescue ref refs/fm-dropped/fix-drop-d4/b4b46ab now holds main's pre-reset tip, so those commits stay in /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/drop/projects/firstmate (not just in the reflog) and stay recoverable by full SHA
release this drop's commits for good with: git -C /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/drop/projects/firstmate update-ref -d refs/fm-dropped/fix-drop-d4/b4b46ab (other drops keep their own ref)
reset local main to fm/fix-drop-d4 (b4b46ab -> fbb10f1) in /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/drop/projects/firstmate

== the record written before the branch moved:

$ cat /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/drop/state/fix-drop-d4.local-merge-drop
# 2026-08-16T13:16:28Z fm-merge-local.sh --drop-local-commits
task=fix-drop-d4
project=/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/drop/projects/firstmate
default=main
branch=fm/fix-drop-d4
default_before=b4b46ab861c5d12cbfc481d54d09a43611fd79f3
rescue_ref=refs/fm-dropped/fix-drop-d4/b4b46ab
dropped=b4b46ab861c5d12cbfc481d54d09a43611fd79f3 adopt upstream PR #2456 locally (secondmate recovery hint)
dropped=3c1275df9fa02e3fa65eb7245fbd91123cfdfc6e adopt upstream PR #2461 locally (calm export confirmation)

$ git -C /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/drop/projects/firstmate for-each-ref refs/fm-dropped/**
b4b46ab861c5d12cbfc481d54d09a43611fd79f3 commit	refs/fm-dropped/fix-drop-d4/b4b46ab

== the reflog is pruned away; the rescued commits survive anyway:

$ git -C /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/drop/projects/firstmate reflog expire --expire=now --expire-unreachable=now --all

$ git -C /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/drop/projects/firstmate gc --prune=now --quiet

$ git -C /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/drop/projects/firstmate log --oneline -2 b4b46ab861c5d12cbfc481d54d09a43611fd79f3
b4b46ab adopt upstream PR #2456 locally (secondmate recovery hint)
3c1275d adopt upstream PR #2461 locally (calm export confirmation)

== recovery from the recorded SHA:

$ git -C /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/drop/projects/firstmate branch rescued-adoptions b4b46ab861c5d12cbfc481d54d09a43611fd79f3

$ git -C /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/drop/projects/firstmate log --oneline -3 rescued-adoptions
b4b46ab adopt upstream PR #2456 locally (secondmate recovery hint)
3c1275d adopt upstream PR #2461 locally (calm export confirmation)
43d7501 upstream: initial

== and the documented per-drop release really frees them:

$ git -C /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/drop/projects/firstmate branch -D rescued-adoptions
Deleted branch rescued-adoptions (was b4b46ab).

$ git -C /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/drop/projects/firstmate update-ref -d refs/fm-dropped/fix-drop-d4/b4b46ab

$ git -C /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/drop/projects/firstmate reflog expire --expire=now --expire-unreachable=now --all

$ git -C /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/drop/projects/firstmate gc --prune=now --quiet

$ git cat-file -e b4b46ab861c5d12cbfc481d54d09a43611fd79f3^{commit}   # after the release
gone - released as documented

== SCENE 7 - upstream-bound work is untouched

== the guard is never even consulted for a task that ships through an upstream PR:

$ fm-merge-local.sh ship-upstream-e5
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: never, grace 300s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  watcher supervision needs Stop-owned automatic recovery; inspect the hook registration and startup status before ending the turn.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
error: task ship-upstream-e5 is mode=no-mistakes, not local-only; merge PR tasks with bin/fm-pr-merge.sh <id> <PR url> after approval
[exit 1]

== and the branch that upstream would see carries only the deliverable, no local adoption:

$ git -C /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/upstream/projects/firstmate log --oneline origin/main..fm/ship-upstream-e5
4439cec feat(bin): the work the crewmate was sent to do

$ git -C /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN/upstream/projects/firstmate diff --stat origin/main...fm/ship-upstream-e5
 feature.txt | 1 +
 1 file changed, 1 insertion(+)

lab kept at: /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-landing-demo.z8NISN
```
</details>
<details>
<summary>Evidence: Script de démonstration reproductible (fixture fork + pilotage du vrai fm-merge-local.sh)</summary>

Source: [Script de démonstration reproductible (fixture fork + pilotage du vrai fm-merge-local.sh)](https://github.com/Kallas95/firstmate/blob/53804b7be45c062969fc9ced298f95616d1a5b15/.no-mistakes/evidence/fm/fm-worktree-base-locale/demo-local-landing-guard.sh)

```text
#!/usr/bin/env bash
# End-to-end demonstration of the local-landing guard added by 9c94e91..38bb5cd,
# replaying the measured trap: a fork whose LOCAL default branch carries
# adoptions origin never had, and a worker branch cut from origin's tip (exactly
# what fm-spawn.sh:freshen_spawn_worktree_base produces).
#
# Usage: bash demo-local-landing-guard.sh <path-to-firstmate-worktree>
set -eu

REPO=$1
NEW="$REPO/bin/fm-merge-local.sh"
LAB=$(mktemp -d "${TMPDIR:-/tmp}/fm-landing-demo.XXXXXX")
# The base-commit version, extracted with its exec bit, to show what the same
# trap looked like before this change.
mkdir -p "$LAB/before"
git -C "$REPO" archive ef35d799a846d676c2fd30b1d1e3ed47b0fb2c22 bin/fm-merge-local.sh | tar -x -C "$LAB/before"
OLD="$LAB/before/bin/fm-merge-local.sh"

g() { git -C "$1" -c user.name='Captain' -c user.email='captain@example.invalid' "${@:2}"; }
say() { printf '\n== %s\n' "$*"; }
run() { printf '\n$ %s\n' "$*"; "$@" || printf '[exit %s]\n' "$?"; }

build_fixture() {  # <name> <task-id> <with-adoption yes|no> -> case dir
  local name=$1 id=$2 adopt=$3 case_dir proj origin tip
  case_dir="$LAB/$name"; proj="$case_dir/projects/firstmate"; origin="$case_dir/upstream.git"
  mkdir -p "$case_dir/state" "$case_dir/projects"
  git init --quiet -b main "$proj"
  printf 'firstmate\n' > "$proj/README.md"
  g "$proj" add README.md; g "$proj" commit -qm 'upstream: initial'
  git clone --quiet --bare "$proj" "$origin"
  git -C "$proj" remote add origin "file://$origin"
  git -C "$proj" fetch --quiet origin
  git -C "$proj" remote set-head origin --auto >/dev/null 2>&1
  tip=$(git -C "$proj" rev-parse HEAD)
  if [ "$adopt" = yes ]; then
    printf "keep Pi's export confirmation visible\n" > "$proj/calm-export.txt"
    g "$proj" add calm-export.txt
    g "$proj" commit -qm 'adopt upstream PR #2461 locally (calm export confirmation)'
    printf 'remote-secondmate recovery hint\n' > "$proj/recovery-hint.txt"
    g "$proj" add recovery-hint.txt
    g "$proj" commit -qm 'adopt upstream PR #2456 locally (secondmate recovery hint)'
  fi
  # How a worker worktree is really created: hard-reset onto origin's tip.
  git -C "$proj" worktree add --quiet --detach "$case_dir/worker" "$tip"
  git -C "$case_dir/worker" reset --hard --quiet origin/main
  g "$case_dir/worker" checkout --quiet -b "fm/$id"
  printf 'worker deliverable\n' > "$case_dir/worker/feature.txt"
  g "$case_dir/worker" add feature.txt
  g "$case_dir/worker" commit -qm 'feat(bin): the work the crewmate was sent to do'
  printf 'project=%s\nmode=local-only\nyolo=off\n' "$proj" > "$case_dir/state/$id.meta"
  printf '%s\n' "$case_dir"
}

merge_local() {  # <script> <case_dir> <args...>
  local script=$1 case_dir=$2; shift 2
  printf '\n$ fm-merge-local.sh %s\n' "$*"
  ( cd "$case_dir/projects/firstmate" \
    && FM_ROOT_OVERRIDE="$REPO" FM_HOME="$case_dir" FM_STATE_OVERRIDE="$case_dir/state" \
       "$script" "$@" ) || printf '[exit %s]\n' "$?"
}

say 'SCENE 1 - the measured shape: local main = upstream + N local adoptions'
TRAP_CASE=$(build_fixture trap fix-calm-a1 yes)
PROJ="$TRAP_CASE/projects/firstmate"
run git -C "$PROJ" log --oneline --decorate -3 main
run git -C "$PROJ" log --oneline origin/main..main
say 'the worker branch was cut from origin/main, so it does not contain them'
run git -C "$PROJ" log --oneline origin/main..fm/fix-calm-a1
say 'the manual check that caught this four times in two days:'
run git -C "$PROJ" diff main..fm/fix-calm-a1 --stat

say 'SCENE 2 - BEFORE (base commit ef35d79): refused, but names nothing'
merge_local "$OLD" "$TRAP_CASE" fix-calm-a1

say 'SCENE 3 - AFTER (38bb5cd): refused, naming what would disappear and the fix'
merge_local "$NEW" "$TRAP_CASE" fix-calm-a1
say 'local main is untouched by the refusal, and no drop record was written:'
run git -C "$PROJ" log --oneline -1 main
run ls "$TRAP_CASE/state"

say 'SCENE 4 - the reconciliation the refusal names makes the same landing pass'
run git -C "$TRAP_CASE/worker" merge --no-edit main
merge_local "$NEW" "$TRAP_CASE" fix-calm-a1
say 'both the adoptions and the worker deliverable are on local main:'
run git -C "$PROJ" log --oneline -5 main
run ls "$PROJ"

say 'SCENE 5 - a healthy landing keeps passing with no added friction'
CLEAN_CASE=$(build_fixture clean ship-clean-b2 no)
merge_local "$NEW" "$CLEAN_CASE" ship-clean-b2
say 'and the escape hatch cannot silently turn a healthy landing into a reset:'
CLEAN2=$(build_fixture clean2 ship-clean-c3 no)
merge_local "$NEW" "$CLEAN2" ship-clean-c3 --drop-local-commits

say 'SCENE 6 - the escape hatch: explicit, traced, recoverable'
DROP_CASE=$(build_fixture drop fix-drop-d4 yes)
DPROJ="$DROP_CASE/projects/firstmate"
DROPPED_TIP=$(git -C "$DPROJ" rev-parse main)
merge_local "$NEW" "$DROP_CASE" --drop-local-commits fix-drop-d4
say 'the record written before the branch moved:'
run cat "$DROP_CASE/state/fix-drop-d4.local-merge-drop"
run git -C "$DPROJ" for-each-ref 'refs/fm-dropped/**'
say 'the reflog is pruned away; the rescued commits survive anyway:'
run git -C "$DPROJ" reflog expire --expire=now --expire-unreachable=now --all
run git -C "$DPROJ" gc --prune=now --quiet
run git -C "$DPROJ" log --oneline -2 "$DROPPED_TIP"
say 'recovery from the recorded SHA:'
run git -C "$DPROJ" branch rescued-adoptions "$DROPPED_TIP"
run git -C "$DPROJ" log --oneline -3 rescued-adoptions
say 'and the documented per-drop release really frees them:'
run git -C "$DPROJ" branch -D rescued-adoptions
run git -C "$DPROJ" update-ref -d "refs/fm-dropped/fix-drop-d4/$(git -C "$DPROJ" rev-parse --short "$DROPPED_TIP")"
run git -C "$DPROJ" reflog expire --expire=now --expire-unreachable=now --all
run git -C "$DPROJ" gc --prune=now --quiet
printf '\n$ git cat-file -e %s^{commit}   # after the release\n' "$DROPPED_TIP"
if git -C "$DPROJ" cat-file -e "$DROPPED_TIP^{commit}" 2>/dev/null; then
  printf 'still present (rescue ref was not what held it)\n'
else
  printf 'gone - released as documented\n'
fi

say 'SCENE 7 - upstream-bound work is untouched'
PR_CASE=$(build_fixture upstream ship-upstream-e5 yes)
PPROJ="$PR_CASE/projects/firstmate"
printf 'project=%s\nmode=no-mistakes\nyolo=off\n' "$PPROJ" > "$PR_CASE/state/ship-upstream-e5.meta"
say 'the guard is never even consulted for a task that ships through an upstream PR:'
merge_local "$NEW" "$PR_CASE" ship-upstream-e5
say 'and the branch that upstream would see carries only the deliverable, no local adoption:'
run git -C "$PPROJ" log --oneline origin/main..fm/ship-upstream-e5
run git -C "$PPROJ" diff --stat origin/main...fm/ship-upstream-e5

printf '\nlab kept at: %s\n' "$LAB"
```
</details>
<details>
<summary>Evidence: Sorties observées des deux suites ciblées (FM_TEST_EVIDENCE=1)</summary>

Source: [Sorties observées des deux suites ciblées (FM_TEST_EVIDENCE=1)](https://github.com/Kallas95/firstmate/blob/53804b7be45c062969fc9ced298f95616d1a5b15/.no-mistakes/evidence/fm/fm-worktree-base-locale/targeted-suites-with-evidence.txt)

```text
FM_TEST_BEGIN 2026-08-16T13:15:08Z tests/fm-spawn-pool-base-freshen.test.sh family=unclassified expected_gate_skip=none
# observed spawn: spawned pool-current-base-r1 harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-pool-current-base-r1 worktree=/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-spawn-pool-base-freshen.73KGZv/current-base/pool
# observed base: HEAD=92005d19532a1b305c1cbb3d18ec701b9b358f1f origin/main=92005d19532a1b305c1cbb3d18ec701b9b358f1f advanced-main=must survive a newly spawned branch
ok - a stale pooled worktree refreshes to current origin/main before a crew branch is created
ok - a stale pooled worktree resolves and refreshes a non-main default branch
# observed direct-pr spawn: spawned pool-direct-pr-r3 harness=codex kind=ship mode=direct-PR yolo=off window=firstmate:fm-pool-direct-pr-r3 worktree=/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-spawn-pool-base-freshen.73KGZv/direct-pr/pool
# observed scout spawn: spawned pool-scout-r3 harness=codex kind=scout window=firstmate:fm-pool-scout-r3 worktree=/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-spawn-pool-base-freshen.73KGZv/scout/pool
ok - direct-PR ships and scouts both refresh stale pooled worktrees before launch
# observed dirty refusal: error: pooled worktree '/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-spawn-pool-base-freshen.73KGZv/dirty-refusal/pool' is not clean; refusing to discard uncommitted work while refreshing its base; preserved=keep this local work
ok - a dirty pooled worktree is refused without discarding its local work
# observed unresolved-default refusal: error: could not resolve origin's current default branch for pooled worktree '/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-spawn-pool-base-freshen.73KGZv/unresolved-default/pool'; refusing to launch from a potentially stale base
ok - an unresolved remote default branch refuses the pooled worktree
# observed unreachable-origin refusal: error: could not fetch origin for pooled worktree '/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-spawn-pool-base-freshen.73KGZv/unreachable-origin/pool'; refusing to launch from a potentially stale base
ok - an unreachable origin refuses a potentially stale pooled worktree
# observed divergence warning: warning: local main is 1 commit(s) ahead of origin/main; this worker starts from origin/main (correct for an upstream PR), so landing its branch locally will need 'git merge main' inside the branch first
ok - a local default branch ahead of origin warns at spawn without moving the base off origin's tip
# all fm-spawn-pool-base-freshen tests passed
FM_TEST_END 2026-08-16T13:15:28Z tests/fm-spawn-pool-base-freshen.test.sh exit=0 duration_ms=20220 gate_skip=false
FM_TEST_BEGIN 2026-08-16T13:15:28Z tests/fm-merge-local.test.sh family=pr-forge expected_gate_skip=none
# observed clean landing: merged fm/merge-local-clean-r1 into local main (3a6c8f4 -> 066c737) in /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-merge-local.0nd8eG/clean/project
ok - a landing that drops nothing still fast-forwards with no added friction
# observed refusal:
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: never, grace 300s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  watcher supervision needs Stop-owned automatic recovery; inspect the hook registration and startup status before ending the turn.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
REFUSED: landing fm/merge-local-trap-r2 would drop 1 commit(s) that exist only on local main:
  9bf84a0 adopt upstream PR #1234 locally
fm/merge-local-trap-r2 was cut from origin/main, so it never contained them.
Reconcile first: run 'git merge main' inside fm/merge-local-trap-r2 (in its own worktree), resolve any conflicts, then retry this merge.
If dropping those commits is genuinely intended, re-run with --drop-local-commits (destructive; needs the captain's explicit word).
ok - a landing that would erase a local commit is refused, naming the commit and the fix
ok - the reconciliation the refusal names makes the same landing pass
# observed escape hatch:
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: never, grace 300s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  watcher supervision needs Stop-owned automatic recovery; inspect the hook registration and startup status before ending the turn.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
DROPPING 1 local-only commit(s) from main as explicitly authorized:
  89a83847bf0987970e2d974be2615b99e8b5e432 adopt upstream PR #1234 locally
recorded in /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-merge-local.0nd8eG/escape/home/state/merge-local-escape-r4.local-merge-drop; rescue ref refs/fm-dropped/merge-local-escape-r4/89a8384 now holds main's pre-reset tip, so those commits stay in /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-merge-local.0nd8eG/escape/project (not just in the reflog) and stay recoverable by full SHA
release this drop's commits for good with: git -C /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-merge-local.0nd8eG/escape/project update-ref -d refs/fm-dropped/merge-local-escape-r4/89a8384 (other drops keep their own ref)
reset local main to fm/merge-local-escape-r4 (89a8384 -> cb6723f) in /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T//fm-merge-local.0nd8eG/escape/project
ok - the escape hatch drops only when asked, prints what it dropped, and records recoverable SHAs
ok - the escape hatch never turns a clean landing into a reset
ok - dropped commits are held by a rescue ref that outlives the reflog, and the documented release frees them
ok - successive drops on one task each keep their own rescue ref, and neither release is forced by the other
ok - re-dropping a tip a rescue ref already holds keeps that ref and says so
# all fm-merge-local tests passed
FM_TEST_END 2026-08-16T13:15:31Z tests/fm-merge-local.test.sh exit=0 duration_ms=3222 gate_skip=false
FM_TEST_SUMMARY total=2 failed=0 skipped_gate=0 duration_ms=23524
FM_TEST_SUMMARY_FAMILY family=pr-forge count=1 duration_ms=3222 failed=0
FM_TEST_SUMMARY_FAMILY family=unclassified count=1 duration_ms=20220 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-spawn-pool-base-freshen.test.sh duration_ms=20220
FM_TEST_SLOWEST rank=2 script=tests/fm-merge-local.test.sh duration_ms=3222
```
</details>
<details>
<summary>Evidence: Le même piège, avant (ef35d79) et après (38bb5cd)</summary>

```text
$ git diff main..fm/fix-calm-a1 --stat
calm-export.txt | 1 -
feature.txt | 1 +
recovery-hint.txt | 1 -
3 files changed, 1 insertion(+), 2 deletions(-)

--- AVANT (ef35d79) ---
$ fm-merge-local.sh fix-calm-a1
REFUSED: fm/fix-calm-a1 is not a fast-forward of main (it has diverged).
Have the crewmate rebase fm/fix-calm-a1 onto main, then retry.
[exit 1]

--- APRES (38bb5cd) ---
$ fm-merge-local.sh fix-calm-a1
REFUSED: landing fm/fix-calm-a1 would drop 2 commit(s) that exist only on local main:
16b1ec6 adopt upstream PR #2456 locally (secondmate recovery hint)
3668a5a adopt upstream PR #2461 locally (calm export confirmation)
fm/fix-calm-a1 was cut from origin/main, so it never contained them.
Reconcile first: run 'git merge main' inside fm/fix-calm-a1 (in its own worktree), resolve any conflicts, then retry this merge.
If dropping those commits is genuinely intended, re-run with --drop-local-commits (destructive; needs the captain's explicit word).
[exit 1]

$ git merge --no-edit main # la reconciliation nommee par le refus
$ fm-merge-local.sh fix-calm-a1
merged fm/fix-calm-a1 into local main (16b1ec6 -> d8e3bac)
```
</details>
<details>
<summary>Evidence: Échappatoire explicite, tracée et récupérable après purge du reflog</summary>

```text
$ fm-merge-local.sh --drop-local-commits fix-drop-d4
DROPPING 2 local-only commit(s) from main as explicitly authorized:
2f95b5e6cd1f320ffe25ba2898ffa3d0fe986999 adopt upstream PR #2456 locally (secondmate recovery hint)
3d1010973c96333493ba11e50b12a3191b5c821a adopt upstream PR #2461 locally (calm export confirmation)
recorded in .../state/fix-drop-d4.local-merge-drop; rescue ref refs/fm-dropped/fix-drop-d4/2f95b5e now holds main's pre-reset tip ...
release this drop's commits for good with: git -C ... update-ref -d refs/fm-dropped/fix-drop-d4/2f95b5e
reset local main to fm/fix-drop-d4 (2f95b5e -> 4e08c4e)

$ cat state/fix-drop-d4.local-merge-drop
# 2026-08-16T13:14:49Z fm-merge-local.sh --drop-local-commits
task=fix-drop-d4
default_before=2f95b5e6cd1f320ffe25ba2898ffa3d0fe986999
rescue_ref=refs/fm-dropped/fix-drop-d4/2f95b5e
dropped=2f95b5e6... adopt upstream PR #2456 locally (secondmate recovery hint)
dropped=3d10109... adopt upstream PR #2461 locally (calm export confirmation)

$ git reflog expire --expire=now --expire-unreachable=now --all && git gc --prune=now
$ git log --oneline -2 2f95b5e6cd1f320ffe25ba2898ffa3d0fe986999
2f95b5e adopt upstream PR #2456 locally (secondmate recovery hint)
3d10109 adopt upstream PR #2461 locally (calm export confirmation)

$ git update-ref -d refs/fm-dropped/fix-drop-d4/2f95b5e && git gc --prune=now
$ git cat-file -e 2f95b5e...^{commit} # apres la liberation
gone - released as documented
```
</details>
<details>
<summary>Evidence: Avertissement consultatif émis par le vrai fm-spawn.sh, base inchangée</summary>

```text
# observed divergence warning: warning: local main is 1 commit(s) ahead of origin/main; this worker starts from origin/main (correct for an upstream PR), so landing its branch locally will need 'git merge main' inside the branch first
ok - a local default branch ahead of origin warns at spawn without moving the base off origin's tip

# cote amont, la branche que verrait l'amont ne porte aucune adoption locale :
$ fm-merge-local.sh ship-upstream-e5
error: task ship-upstream-e5 is mode=no-mistakes, not local-only; merge PR tasks with bin/fm-pr-merge.sh <id> <PR url> after approval
$ git diff --stat origin/main...fm/ship-upstream-e5
feature.txt | 1 +
1 file changed, 1 insertion(+)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e179c9c0ed5012e1b4c8f73540df7a96d2ede9a0","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-merge-local.sh:41` - `-h|--help` extrait `sed -n &#39;2,28p&#39;`, mais la ligne 28 est `set -eu` (l&#39;en-tête de commentaires s&#39;arrête ligne 27). L&#39;aide affiche donc une directive shell parasite en dernière ligne, et la plage codée en dur se décalera silencieusement à chaque édition de l&#39;en-tête. Vérifié en rejouant la commande : la sortie se termine bien par `set -eu`. Corriger en s&#39;arrêtant à la première ligne non commentée (par ex. `awk &#39;NR&gt;1 &amp;&amp; /^#/&#39; &#34;$0&#34; | sed &#39;s/^# \{0,1\}//&#39;`) plutôt qu&#39;en ajustant `28` en `27`.
- ⚠️ `bin/fm-merge-local.sh:122` - L&#39;en-tête et docs/architecture.md:164 promettent sans réserve que « Dropped commits stay recoverable by the full SHAs in that record ». Après `git reset --hard`, ces commits ne sont plus atteignables que par le reflog de `refs/heads/&lt;défaut&gt;` : `gc.reflogExpireUnreachable` (30 jours par défaut) puis un `git gc` les rendent définitivement irrésolubles, et l&#39;enregistrement devient une liste de SHA morts. Une ref de sauvetage posée avant le reset (`git update-ref refs/fm-dropped/$ID $before`, mentionnée dans le message et l&#39;enregistrement) rendrait la garantie durable. Cela ajoute une ref persistante au dépôt du captain, donc c&#39;est un arbitrage à valider et non une correction mécanique.
- ℹ️ `bin/fm-merge-local.sh:57` - Le refus dur n&#39;est atteignable que pour `mode=local-only` (verrou ligne 57, conservé délibérément). Or l&#39;intent indique que les quatre incidents mesurés portaient sur des tâches `mode=no-mistakes`, dont l&#39;atterrissage local ne passe pas par ce script : pour elles, la seule couverture ajoutée reste l&#39;avertissement consultatif de `warn_local_default_divergence`, qui n&#39;empêche rien. C&#39;est un arbitrage explicitement assumé et documenté, pas un oubli - signalé ici pour que la portée réelle de la garde soit claire. Corollaire à garder en tête : la réconciliation prescrite (`git merge &lt;défaut&gt;` dans la branche) embarquerait les adoptions locales dans la branche si celle-ci était ensuite repoussée vers l&#39;amont ; le cas ne se présente pas dans le périmètre gardé, puisqu&#39;une tâche `local-only` n&#39;a pas de PR amont.
- ℹ️ `tests/fm-merge-local.test.sh:65` - `FM_SPAWN_NO_GUARD=1` n&#39;est honoré que par `bin/fm-spawn.sh:271` ; `bin/fm-merge-local.sh:34` appelle `fm-guard.sh` inconditionnellement. Le bouton est donc mort : chaque cas de test exécute le vrai garde contre le `FM_ROOT` réel (qui, dans un worktree de tâche, est sur une branche nommée et déclenche l&#39;alarme de tangle) et son bandeau se retrouve dans `$out`. Sans impact sur les assertions actuelles, qui sont toutes par sous-chaîne, mais la variable laisse croire à une isolation qui n&#39;existe pas : la retirer, ou la remplacer par une vraie neutralisation du garde.
- ℹ️ `tests/fm-merge-local.test.sh:1` - Le fichier est commité en mode 100644 alors que 145 des 147 scripts de `tests/` sont en 100755 ; l&#39;intent affirme pourtant que le bit d&#39;exécution a été posé via `git update-index --chmod=+x`. Sans conséquence fonctionnelle (`fm-test-run.sh:1440` accepte un script simplement lisible et l&#39;invoque via `bash &#34;$script&#34;`), mais l&#39;action décrite n&#39;a pas abouti dans l&#39;arbre livré.

🔧 Fix: pin dropped commits under a durable rescue ref
2 infos still open:
- ℹ️ `tests/fm-merge-local.test.sh:1` - Le bit d&#39;exécution n&#39;a toujours pas été posé, alors que le tour de correction 2 devait le faire et le vérifier. Constaté : `git ls-files -s tests/fm-merge-local.test.sh` rend `100644`, `ls -l` rend `644`, l&#39;arbre est propre, et `git log --raw` montre le fichier ajouté en `100644` par 9c94e91 puis toujours `:100644 100644` après d9d6d3a - aucun changement de mode n&#39;a été tenté. Les 145 autres scripts de `tests/` sont en `100755`. Sans conséquence fonctionnelle (`bin/fm-test-run.sh:1546` invoque `bash &#34;$script&#34;`, qui n&#39;exige pas le bit), mais l&#39;instruction du captain demandait explicitement de vérifier le mode réellement commité et, à défaut, de le dire plutôt que de réaffirmer une action non aboutie. Correction : `git update-index --chmod=+x tests/fm-merge-local.test.sh` puis re-vérifier `git ls-files -s`.
- ℹ️ `bin/fm-merge-local.sh:124` - Le garde anti-écrasement introduit au tour 2 est sûr mais bloque un second abandon autorisé sans issue non destructive documentée. Chemin concret, exactement celui couvert par `test_a_second_drop_never_strands_an_earlier_rescue` : premier `--drop-local-commits` (refs/fm-dropped/&lt;id&gt; = base+adoption1, main réinitialisé sur base+worker), puis une nouvelle adoption locale sur main, puis un second `--drop-local-commits` autorisé. `held` (base+adoption1) n&#39;est plus ancêtre de `before` (base+worker+adoption2), donc le script refuse et la seule action nommée par le message est `git update-ref -d refs/fm-dropped/&lt;id&gt;`, c&#39;est-à-dire relâcher les commits que la garantie de durabilité venait de promettre de conserver. L&#39;opérateur n&#39;a alors le choix qu&#39;entre renoncer au second abandon ou détruire le premier sauvetage (le contournement - recopier la ref sous un autre nom avant de la supprimer - n&#39;est écrit nulle part). Une clé de ref par abandon plutôt que par tâche (par ex. `refs/fm-dropped/&lt;id&gt;-&lt;short-before&gt;`, en évitant `refs/fm-dropped/&lt;id&gt;/&lt;sha&gt;` qui entrerait en conflit D/F avec la ref existante) ferait coexister les deux sauvetages et supprimerait entièrement ce chemin de refus. C&#39;est un arbitrage délibéré du tour de correction, testé comme tel : à valider par le captain plutôt qu&#39;à corriger d&#39;office. Aucune perte de données dans l&#39;état actuel : le refus intervient avant toute mutation, `main` et la ref existante restent intacts.

🔧 Fix: key rescue refs per drop and set test exec bit
1 info still open:
- ℹ️ `bin/fm-merge-local.sh:122` - Le nom de la ref de sauvetage est construit avec `git rev-parse --short`, dont la longueur n&#39;est pas stable : en mode `auto` (défaut), git choisit la plus courte abréviation non ambiguë, et cette longueur augmente à mesure que le dépôt gagne des objets. Le nom de la ref pour UN MÊME commit change donc dans le temps. Chemin d&#39;échec concret, exactement celui que couvre `test_redropping_a_recovered_tip_reuses_its_own_rescue` : abandon d&#39;un sommet T (ref `refs/fm-dropped/&lt;id&gt;/abc1234` posée), le projet grossit jusqu&#39;à franchir le seuil d&#39;abréviation, l&#39;opérateur récupère main depuis la ref puis ré-abandonne T ; `RESCUE_REF` est alors recalculé en `refs/fm-dropped/&lt;id&gt;/abc12345`, le test d&#39;idempotence de la ligne 127 (`held = before`) ne voit rien, et une SECONDE ref est posée sur le même commit. La conséquence porte sur la promesse de retrait documentée en ligne 34 et dans `docs/architecture.md:167` : `git update-ref -d &lt;la ref nommée dans le dernier enregistrement&gt;` ne libère plus ces commits, puisque l&#39;ancienne ref les retient toujours - l&#39;opérateur doit remonter tout l&#39;historique append-only de `state/&lt;id&gt;.local-merge-drop` pour les trouver. Correction mécanique : figer la largeur (`git rev-parse --short=12 &#34;$before&#34;`) ou utiliser le SHA complet, ce qui rend le nom déterministe sans changer la forme documentée `&lt;id&gt;/&lt;short-sha&gt;`. À noter au passage, sans finding séparé : `tests/fm-merge-local.test.sh:178,215,227,259` recalculent le nom avec la formule identique à celle de l&#39;implémentation, et aucun cas ne fait grossir le dépôt entre deux abandons - ces tests ne peuvent donc pas détecter cette dérive.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-test-run.sh tests/fm-merge-local.test.sh` - 8 cas, tous verts (sain, piège refusé, réconciliation, échappatoire tracée, échappatoire inoffensive, survie au gc, drops successifs, re-drop)</code>
- <code>`bin/fm-test-run.sh tests/fm-spawn-pool-base-freshen.test.sh` - 7 cas verts dont le nouveau `test_local_default_ahead_warns_without_changing_the_base`</code>
- <code>`FM_TEST_EVIDENCE=1 bin/fm-test-run.sh tests/fm-spawn-pool-base-freshen.test.sh tests/fm-merge-local.test.sh` - capture de l&#39;avertissement réellement émis par fm-spawn.sh et des transcripts observés</code>
- <code>Démonstration manuelle end-to-end `bash demo-local-landing-guard.sh &lt;worktree&gt;` : fixture fork (main local = amont + 2 adoptions), branche ouvrier créée par `git reset --hard origin/main`, puis exécution réelle de `bin/fm-merge-local.sh` sur 7 scènes</code>
- <code>Comparaison avant/après du même piège : version du commit de base `ef35d79` extraite via `git archive` puis exécutée sur la même fixture</code>
- <code>`git -C &lt;projet&gt; diff main..fm/&lt;id&gt; --stat` - la vérification manuelle qui rattrapait le piège, montrant les suppressions d&#39;adoptions</code>
- <code>Échappatoire : `fm-merge-local.sh --drop-local-commits &lt;id&gt;` puis `cat state/&lt;id&gt;.local-merge-drop`, `git for-each-ref &#39;refs/fm-dropped/**&#39;`, `git reflog expire --expire=now --expire-unreachable=now --all`, `git gc --prune=now`, récupération par SHA complet, puis `git update-ref -d refs/fm-dropped/&lt;id&gt;/&lt;short-sha&gt;` et re-gc prouvant la libération</code>
- <code>Critère PR amont : `fm-merge-local.sh` sur une tâche `mode=no-mistakes` (refus par le verrou de mode) et `git diff --stat origin/main...fm/&lt;id&gt;` ne contenant que le livrable</code>
- <code>Surface CLI de la nouvelle analyse d&#39;options : `fm-merge-local.sh --help`, option inconnue `--drop-local`, et invocation sans task-id</code>
- <code>`bin/fm-test-run.sh tests/fm-test-run.test.sh tests/fm-spawn-batch.test.sh tests/fm-spawn-worktree-settle.test.sh` - suites voisines exposées au changement, vertes</code>
- <code>`bin/fm-test-run.sh tests/fm-documentation-audiences.test.sh` - suite couvrant les surfaces de documentation modifiées, verte</code>
- <code>`bin/fm-test-run.sh --check-coverage` - `FM_TEST_COVERAGE ok total=147`, le nouveau test est bien rattaché à une famille et à une lane</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/architecture.md:165` - Les trois phrases de docs/architecture.md sur le ref de secours avaient été ajoutées par les commits de revue d9d6d3a et 38bb5cd, mais dupliquaient mot pour mot des mécanismes que le même paragraphe attribue à l&#39;en-tête de bin/fm-merge-local.sh (chemin exact du ref, commande de libération). Jugement pris : les réduire à la garantie de sûreté au niveau architecture plus le pointeur vers le propriétaire, en conservant chaque fait de sûreté (durabilité au-delà du reflog, ref planté avant le déplacement de branche, refus si le ref ne peut pas l&#39;être, libération explicite et par drop). Signalé parce que cela retouche de la prose voulue par une réponse de revue ; si le relecteur tenait à la commande littérale visible dans architecture.md, c&#39;est le seul point à rétablir.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
