### PR TITLE
test(calm): name the missing E2E tool and wait for Pi's paint

### DIFF
--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -63,6 +63,22 @@ wait_for_text() {
   return 1
 }
 
+# Pane variant of wait_for_text: leaves the last capture in the caller's `pane`
+# so the assertions right after a wait read the very screen the wait settled on,
+# and returns non-zero once the deadline passes without <needle> appearing. The
+# caller supplies its own failure message, so each wait names the state it was
+# waiting for instead of letting a later, unrelated assertion misreport it.
+wait_for_pane_text() {
+  local needle=$1 i=0
+  while [ "$i" -lt 120 ]; do
+    pane=$(tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - 2>/dev/null || true)
+    printf '%s\n' "$pane" | grep -Fq "$needle" && return 0
+    sleep 0.05
+    i=$((i + 1))
+  done
+  return 1
+}
+
 find_chrome() {
   local candidate
   if [ -n "${FM_CHROME_BIN:-}" ] && [ -x "$FM_CHROME_BIN" ]; then
@@ -1804,14 +1820,7 @@ TS
 
     tmux -L "$TMUX_SOCKET" new-session -d -s "$TMUX_SESSION" -x 160 -y 36 \
       "cd '$project' && env FM_HOME='$home' PI_CODING_AGENT_DIR='$config' FM_OPERATIONAL_INPUT_SCRIPT='$OPERATIONAL_INPUT' PI_OFFLINE=1 pi --approve --no-context-files --no-skills --no-prompt-templates --no-extensions $extensions $session_arg; rc=\$?; printf '\nPI_EXIT=%s\n' \"\$rc\"; sleep 20"
-    i=0
-    while [ "$i" -lt 120 ]; do
-      pane=$(tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - 2>/dev/null || true)
-      printf '%s\n' "$pane" | grep -Fq 'followup-e2e.ts' && break
-      sleep 0.05
-      i=$((i + 1))
-    done
-    printf '%s\n' "$pane" | grep -Fq 'followup-e2e.ts' \
+    wait_for_pane_text 'followup-e2e.ts' \
       || fail "Pi follow-up $case_name case ($label) did not reach the ready composer"
 
     tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/followup-e2e $label $shape"
@@ -1833,19 +1842,14 @@ TS
     # pane the moment that file settles can catch the screen still on its start-up
     # state and read as zero captain answers rather than one. Wait for the follow-up
     # answer, which Pi renders after the captain answer, so every assertion below
-    # sees a fully painted transcript. A genuine duplicate still fails: the count is
-    # taken after that anchor, never satisfied by it.
-    i=0
-    while [ "$i" -lt 120 ]; do
-      pane=$(tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - 2>/dev/null || true)
-      printf '%s\n' "$pane" | grep -Fq "MONITOR_HANDLED_${label}_ONE" && break
-      sleep 0.05
-      i=$((i + 1))
-    done
+    # sees a fully painted transcript. Failing here first keeps an unpainted screen
+    # from being reported as a duplicate: the count below is taken only once this
+    # anchor holds, and is never satisfied by it, so a genuine duplicate still fails.
+    wait_for_pane_text "MONITOR_HANDLED_${label}_ONE" \
+      || fail "Pi follow-up $label case never painted the follow-up answer on screen before the wait expired"
     [ "$(printf '%s\n' "$pane" | grep -Fc "CAPTAIN_ANSWER_$label" || true)" -eq 1 ] \
       || fail "Pi follow-up $label case rendered a duplicate captain answer"
     assert_contains "$pane" "CAPTAIN_PROMPT_$label" "Pi follow-up $label case hid the genuine captain prompt"
-    assert_contains "$pane" "MONITOR_HANDLED_${label}_ONE" "Pi follow-up $label case did not render the intended processing result"
     if [ "$calm_state" = on ]; then
       assert_not_contains "$pane" "MONITOR_${label}_ONE" "Pi follow-up $label case rendered a Calm-hidden operational user row"
       if [ "$label" = exact_watcher ]; then
@@ -1944,15 +1948,9 @@ JS
     printf '%s\n' on >"$home/config/calm"
     tmux -L "$TMUX_SOCKET" new-session -d -s "$TMUX_SESSION" -x 160 -y 36 \
       "cd '$project' && env FM_HOME='$home' PI_CODING_AGENT_DIR='$config' FM_OPERATIONAL_INPUT_SCRIPT='$OPERATIONAL_INPUT' PI_OFFLINE=1 pi --approve --no-context-files --no-skills --no-prompt-templates --no-extensions -e ./.pi/extensions/fm-calm.ts -e ./followup-e2e.ts --session '$exact_session'; rc=\$?; printf '\nPI_EXIT=%s\n' \"\$rc\"; sleep 20"
-    i=0
-    while [ "$i" -lt 120 ]; do
-      pane=$(tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - 2>/dev/null || true)
-      printf '%s\n' "$pane" | grep -Fq 'MONITOR_HANDLED_exact_watcher_ONE' && break
-      sleep 0.05
-      i=$((i + 1))
-    done
+    wait_for_pane_text 'MONITOR_HANDLED_exact_watcher_ONE' \
+      || fail "Pi restart lost the operational processing response"
     assert_contains "$pane" "CAPTAIN_PROMPT_exact_watcher" "Pi restart lost the genuine captain prompt"
-    assert_contains "$pane" "MONITOR_HANDLED_exact_watcher_ONE" "Pi restart lost the operational processing response"
     assert_not_contains "$pane" "FIRSTMATE WATCHER WAKE: signal: /home/fixture/github/kunchenguid/firstmate/state/oss-triage-t4.status" \
       "Pi restart replayed the Calm-hidden exact watcher row"
     captain_line=$(printf '%s\n' "$pane" | grep -Fn 'CAPTAIN_ANSWER_exact_watcher' | tail -1 | cut -d: -f1)

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -28,6 +28,19 @@ record_pi_version_evidence() {
   [ -n "$version" ] || fail "$context could not determine the installed Pi version"
 }
 
+# Names the tools that are actually absent so a skipped E2E can never read as a
+# passing one. The three E2E cases below are the only coverage of Calm's real
+# terminal behavior, and tmux is commonly installed outside a trimmed PATH while
+# pi is not, so reporting "pi or tmux" for either case hid which one was missing.
+# A run that silently skipped all three then looked like a clean pass, which is
+# exactly how a Calm export defect was once misread as a bash-version regression.
+missing_e2e_tools() {
+  local missing=""
+  command -v pi >/dev/null 2>&1 || missing="pi"
+  command -v tmux >/dev/null 2>&1 || missing="${missing:+$missing and }tmux"
+  printf '%s\n' "$missing"
+}
+
 cleanup() {
   if command -v tmux >/dev/null 2>&1; then
     tmux -L "$TMUX_SOCKET" kill-server 2>/dev/null || true
@@ -1619,7 +1632,7 @@ JS
 test_operational_followup_turn_e2e() {
   local project home config sessions version label case_name calm_state expected_notifications session_file pane i captain_line handled_line geometry_gap exact_session
   if ! command -v pi >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then
-    echo "skip: pi or tmux not found for Pi operational follow-up E2E"
+    echo "skip: $(missing_e2e_tools) not found for Pi operational follow-up E2E"
     return 0
   fi
   version=$(pi --version 2>/dev/null || true)
@@ -1816,7 +1829,19 @@ TS
       fail "Pi follow-up $label case did not process the monitoring notification"
     fi
 
-    pane=$(tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - 2>/dev/null || true)
+    # Pi writes the session file before it paints the transcript, so capturing the
+    # pane the moment that file settles can catch the screen still on its start-up
+    # state and read as zero captain answers rather than one. Wait for the follow-up
+    # answer, which Pi renders after the captain answer, so every assertion below
+    # sees a fully painted transcript. A genuine duplicate still fails: the count is
+    # taken after that anchor, never satisfied by it.
+    i=0
+    while [ "$i" -lt 120 ]; do
+      pane=$(tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - 2>/dev/null || true)
+      printf '%s\n' "$pane" | grep -Fq "MONITOR_HANDLED_${label}_ONE" && break
+      sleep 0.05
+      i=$((i + 1))
+    done
     [ "$(printf '%s\n' "$pane" | grep -Fc "CAPTAIN_ANSWER_$label" || true)" -eq 1 ] \
       || fail "Pi follow-up $label case rendered a duplicate captain answer"
     assert_contains "$pane" "CAPTAIN_PROMPT_$label" "Pi follow-up $label case hid the genuine captain prompt"
@@ -1973,7 +1998,7 @@ test_hidden_block_geometry_e2e() {
   local project home config sessions session_file snapshot expanded_snapshot calm_off_snapshot restarted_snapshot
   local version skill_line final_line gap i
   if ! command -v pi >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then
-    echo "skip: pi or tmux not found for Pi Calm hidden-block geometry E2E"
+    echo "skip: $(missing_e2e_tools) not found for Pi Calm hidden-block geometry E2E"
     return 0
   fi
   version=$(pi --version 2>/dev/null || true)
@@ -3081,7 +3106,7 @@ JS
 test_interactive_terminal_e2e() {
   local project config home session_file export_file export_dom default_snapshot expanded_snapshot hidden_snapshot active_before_snapshot active_hidden_snapshot export_snapshot export_settled_snapshot restored_snapshot working_snapshot working_response_snapshot restarted_snapshot resumed_restored_snapshot hash_before hash_after now version chrome chrome_pid chrome_wait active_wait active_screen_wait boat_frame_one boat_frame_two boat_resized_snapshot boat_focus_snapshot boat_cleared_snapshot boat_hull_line boat_sail_line boat_column_one boat_column_two boat_line boat_color_snapshot boat_color_line boat_water_snapshot boat_water_line boat_water_first boat_water_changed boat_narrow_snapshot boat_narrow_sails boat_freeze_snapshot boat_resume_snapshot boat_freeze_column boat_freeze_sail boat_resume_column boat_resume_sail
   if ! command -v pi >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then
-    echo "skip: pi or tmux not found for Pi calm interactive E2E"
+    echo "skip: $(missing_e2e_tools) not found for Pi calm interactive E2E"
     return 0
   fi
   version=$(pi --version 2>/dev/null || true)


### PR DESCRIPTION
## Intent

Les deux interpreteurs compares dans toute cette tache sont celui livre par Apple, version 3.2.57, et celui installe par Homebrew, version 5.3.15. Ils sont designes ci-dessous par "l'interpreteur 3.2.57" et "l'interpreteur 5.3.15".

Diagnostiquer et corriger l'echec de tests/fm-calm-pi-extension.test.sh, presente comme la SEULE vraie regression de la bascule d'interpreteur sur 146 suites: la suite passait sous l'interpreteur 3.2.57 et echouait sous l'interpreteur 5.3.15 avec "not ok - /export did not complete while calm mode was on".

Mesure d'origine (2026-08-15): interpreteur 3.2.57 avec Homebrew hors PATH -> exit 0, 9 verifications; interpreteur 5.3.15 -> exit 1 sur l'echec /export. Le piege methodologique annonce etait qu'installer le nouvel interpreteur change aussi ce que "env" resout dans les sous-processus, donc le controle devait forcer un PATH sans /opt/homebrew/bin.

Deux hypotheses menant a des corrections OPPOSEES etaient a departager: soit le nouvel interpreteur revelait un vrai defaut latent de l'extension calme que celui d'Apple avalait (corriger le CODE), soit le TEST dependait d'une particularite de l'interpreteur 3.2.57 (corriger le TEST). Consigne explicite: ne pas choisir par confort, charger le skill diagnostic-reasoning avant de conclure, etablir la cause par preuve et non par plausibilite. Element de contexte fourni: sous set -e, l'interpreteur 3.2.57 avale des echecs que le 5.3.15 propage (trois defauts de cette famille trouves le meme jour), ce qui rendait la premiere hypothese serieuse sans la prouver.

Demande: (1) diagnostiquer la cause reelle avec reproduction et controle propre dans les deux sens; (2) corriger la cause etablie, code ou test selon ce que le diagnostic prouve; (3) verifier que la suite passe sous LES DEUX interpreteurs.

Criteres d'acceptation: la cause est etablie par preuve et enoncee explicitement dans la PR (defaut de l'extension calme, ou dependance du test a une particularite de l'interpreteur 3.2.57); tests/fm-calm-pi-extension.test.sh passe sous l'interpreteur 5.3.15 ET sous l'interpreteur 3.2.57 avec un PATH propre; si la cause etait un vrai defaut du code, une verification de non-regression couvre le comportement reel et pas seulement la ligne de test qui echouait; aucune autre suite ne devient rouge.

Hors perimetre explicite, a ne pas corriger: tests/fm-spawn-batch.test.sh (echec identique sous les deux interpreteurs, defaut preexistant sans rapport) et tests/fm-teardown.test.sh (rouge sous les deux, restants couverts par la PR amont 2435 non adoptee localement). Les signaler s'ils changent d'etat, sans les embarquer.

RESULTAT DU DIAGNOSTIC, qui infirme la premisse de la tache: ce n'etait PAS une regression d'interpreteur, et la mesure d'origine comparait deux configurations differant sur DEUX axes au lieu d'un. tmux vit dans /opt/homebrew/bin: retirer ce repertoire du PATH ne neutralise pas seulement le nouvel interpreteur, il fait skipper les 3 tests E2E de la suite, dont precisement celui qui contient l'assertion /export. L'arithmetique le confirme: 12 verifications - 3 skippees = les "9 verifications" rapportees. Le controle dit propre n'a donc jamais execute le test en cause, et aucune preuve de regression d'interpreteur n'existait dans cette mesure.

Contrefactuel decisif: en remettant UNIQUEMENT .pi/extensions/fm-calm.ts a son etat pre-#2461 et en gardant le test de HEAD, l'echec exact "/export did not complete while calm mode was on" se reproduit 2 fois sur 2 sous l'interpreteur 3.2.57, celui cense etre sain. La cause etait donc le vrai defaut de l'extension calme corrige six heures plus tot par ef35d79 (#2461): depuis Pi 0.83.0, setToolsExpanded() emet une ligne de statut, et deux lignes de statut consecutives fusionnent, si bien que le repaint post-export de Calm ecrasait la confirmation "Session exported to: <path>". A HEAD la suite est verte: 6 runs sur 6 sous les deux interpreteurs. Note: ce fichier de test utilise set -u et non set -e, donc le mecanisme evoque dans le brief ne s'y applique pas.

Consequence sur le perimetre: le defaut d'origine etant deja corrige en amont, il n'y avait pas de correction de code a refaire, et la couverture de non-regression demandee au critere 3 existe deja via ef35d79, qui a ajoute des assertions verifiant que la confirmation reste a l'ecran une fois le redraw stabilise, au-dela de la seule ligne qui echouait. Les deux defauts reels restants ont ete corriges dans ce commit.

Correction 1 - le skip muet: les trois cas E2E annoncaient "pi or tmux not found" quel que soit l'outil reellement absent. tmux vit couramment hors d'un PATH restreint alors que pi non, si bien qu'un run ayant skippe les trois se lisait comme un succes propre a 9 verifications. C'est exactement ainsi que le defaut d'export deja corrige a ete pris pour une regression du nouvel interpreteur. Le skip nomme desormais l'outil absent (verifie: "skip: tmux not found for ...").

Correction 2 - une instabilite preexistante que la mesure d'origine masquait: Pi ecrit le fichier de session avant de peindre le transcript, donc run_followup_case capturait le pane des que ce fichier se stabilisait et pouvait lire l'ecran encore a son etat de demarrage. Le compte de CAPTAIN_ANSWER_<label> valait alors zero, jamais deux, et l'assertion annoncait pourtant un "duplicate captain answer" inexistant - message trompeur. Mesure sur le cas adjacent: 9 echecs sur 24 runs, soit 4 sur 12 sous l'interpreteur 3.2.57 et 5 sur 12 sous l'interpreteur 5.3.15, taux equivalents donc sans lien avec l'interpreteur; les 9 panes captures contenaient zero occurrence et une recapture 50 ms plus tard en montrait toujours exactement une. Le cas attend desormais la reponse de suivi, que Pi rend apres la reponse du capitaine, avant de compter. Un vrai doublon echoue toujours puisque le comptage a lieu apres cet ancrage et n'est jamais satisfait par lui.

Verification apres correction: cas concerne 24/24 verts contre 15/24 avant; suite complete 6/6 verte sous les deux interpreteurs avec 12 verifications et 0 skip; sous PATH nettoye les deux interpreteurs restent verts avec 3 skips explicitement attribues a tmux; bin/fm-lint.sh vert. Un seul fichier modifie, tests/fm-calm-pi-extension.test.sh, donc aucune autre suite touchee. Pi installe: 0.84.2, plus recent que toutes les versions documentees dans ce test (0.81.1, 0.82.0, 0.83.0).

## What Changed

- Added a `missing_e2e_tools()` helper and used it in all three E2E skip messages, which previously reported a fixed `"pi or tmux not found"` regardless of which tool was actually absent. `tmux` commonly lives outside a trimmed PATH while `pi` does not, so a run that skipped all three E2E cases read as a clean pass - which is how the already-fixed Calm export defect (`ef35d79`, #2461) was misread as a bash-version regression rather than a real extension bug.
- `run_followup_case` now waits for the follow-up answer (`MONITOR_HANDLED_<label>_ONE`) before counting `CAPTAIN_ANSWER_<label>`. Pi writes the session file before it paints the transcript, so capturing the pane as soon as that file settled could read the screen still in its start-up state: the count was zero, never two, yet the assertion reported a nonexistent "duplicate captain answer". The count is taken only after this anchor holds and is never satisfied by it, so a genuine duplicate still fails. The now-redundant `assert_contains` on that same marker was dropped.
- Extracted the duplicated pane-polling loops in the follow-up and restart cases into a shared `wait_for_pane_text` helper that leaves its last capture in the caller's `pane` and returns non-zero on timeout, so each wait fails with a message naming the state it was waiting for instead of letting a later, unrelated assertion misreport it.

## Risk Assessment

✅ Low: Le changement est confine a un seul fichier de test, ne touche aucun code produit ni helper partage, et ses deux corrections (skip nommant l'outil absent, ancrage sur la peinture du pane avant comptage) sont coherentes avec le diagnostic enonce, preservent la garantie anti-doublon et deplacent le point de capture strictement plus tard qu'avant.

## Testing

J'ai valide la suite ciblee tests/fm-calm-pi-extension.test.sh sous les deux interpreteurs concernes (3.2.57 d'Apple et 5.3.15 de Homebrew, avec Pi 0.84.2 et tmux 3.7b), en reproduisant d'abord la premisse de la tache puis en la departageant. Le run avec PATH prive de /opt/homebrew/bin sort en exit 0 avec 9 verifications et 3 skips desormais attribues nommement a tmux, ce qui confirme par mesure que le controle d'origine n'executait jamais le test E2E incrimine. En remettant le fichier de test a son etat pre-correctif, l'echec 'rendered a duplicate captain answer' se reproduit 3 fois sur 24 runs a taux comparable entre les deux interpreteurs, et une version instrumentee montre que le pane capture contenait zero reponse capitaine (ecran encore au demarrage de Pi) et une seule 50 ms plus tard, donc un message trompeur et non un vrai doublon. A HEAD la meme fonction passe 24/24 et la suite complete passe 3 fois par interpreteur avec 12 verifications et 0 skip. J'ai aussi injecte un doublon reel dans le fixture pour verifier que la nouvelle attente ne masque rien : l'assertion echoue 6 fois sur 6. La surface concernee est un TUI en terminal : j'ai capture le pane tmux reel avec ses couleurs et produit deux artefacts visuels rendus, dont une comparaison avant/apres de l'ecran au moment de l'echec. Les deux suites hors perimetre ont ete controlees sans etre modifiees et sont vertes. Le worktree est propre, les variantes de test temporaires ont ete supprimees.

- Evidence: [Comparaison visuelle : le pane capture par le test pre-correctif (0 reponse capitaine, ecran de demarrage) contre le meme pane 50 ms plus tard, avec le tableau des mesures](https://github.com/Kallas95/firstmate/blob/4d198fc0ae7209b59bee2bde22de2880199d0407/.no-mistakes/evidence/fm/fm-calm-bash5-regression/race-before-after.html.png)
<details>
<summary>Evidence: Meme comparaison en HTML rendu (source de l&#39;image ci-dessus)</summary>

Source: [Meme comparaison en HTML rendu (source de l&#39;image ci-dessus)](https://github.com/Kallas95/firstmate/blob/4d198fc0ae7209b59bee2bde22de2880199d0407/.no-mistakes/evidence/fm/fm-calm-bash5-regression/race-before-after.html)

```text
<!doctype html>
<html lang="fr"><meta charset="utf-8"><title>La course reproduite - cas adjacent</title>
<style>
 * { box-sizing:border-box; }
 body { background:#0f1319; color:#c9d1d9; font-family:-apple-system,BlinkMacSystemFont,sans-serif; margin:0; padding:26px 30px 32px; }
 h1 { font-size:19px; font-weight:650; color:#e6edf3; margin:0 0 6px; letter-spacing:-.2px; }
 p.lede { font-size:13.5px; color:#8b949e; margin:0 0 22px; max-width:1500px; line-height:1.55; }
 .grid { display:grid; grid-template-columns:minmax(0,1fr) minmax(0,1fr); gap:18px; }
 .card { min-width:0; border:1px solid #2a313c; border-radius:10px; overflow:hidden; background:#141922; }
 .card.bad { border-color:#7f2f2a; }
 .card.good { border-color:#2f6b46; }
 .hd { padding:11px 15px; font-size:13px; font-weight:600; border-bottom:1px solid #2a313c; display:flex; gap:10px; align-items:baseline; }
 .bad .hd { background:#2a1614; color:#f3b3ad; }
 .good .hd { background:#12251b; color:#a9dcc0; }
 .hd .tag { font-size:11px; font-weight:600; padding:2px 7px; border-radius:20px; }
 .bad .tag { background:#7f2f2a; color:#ffe3e0; }
 .good .tag { background:#2f6b46; color:#e2f7ea; }
 .note { padding:9px 15px; font-size:12.5px; color:#9aa4b2; border-bottom:1px solid #222833; line-height:1.5; }
 .term { background:#090c11; padding:12px 14px; overflow-x:auto; font-family:"SFMono-Regular",Menlo,Consolas,monospace;
          font-size:10.5px; line-height:1.4; white-space:pre; min-height:330px; }
 code { background:#1b212b; padding:1px 5px; border-radius:4px; font-size:12px; }
 table { border-collapse:collapse; margin-top:24px; font-size:13px; }
 th,td { text-align:left; padding:7px 16px 7px 0; border-bottom:1px solid #222833; }
 th { color:#8b949e; font-weight:600; }
 .ko { color:#f0857d; font-weight:600; } .okc { color:#7ee2a8; font-weight:600; }
</style>
<h1>La course reproduite : le pane etait vierge, pas duplique</h1>
<p class="lede">Version pre-correctif du test (<code>ef35d79</code>), cas <code>adjacent</code>, run en echec sous l'interpreteur 5.3.15.
A gauche, l'ecran exact que le test avait en main quand il a compte les reponses du capitaine et conclu a un doublon ;
a droite, le meme ecran 50 ms plus tard. Le compte relevait <strong>0</strong> occurrence, jamais 2 : Pi ecrit le fichier de session
avant de peindre le transcript, et le test capturait des que ce fichier se stabilisait. Le correctif ancre la capture sur la reponse de suivi.</p>
<div class="grid">
  <div class="card bad">
    <div class="hd"><span class="tag">avant</span> Pane capture par le test pre-correctif <span style="color:#8b949e;font-weight:400">- 0x CAPTAIN_ANSWER_adjacent</span></div>
    <div class="note">Aucune ligne de transcript : Pi en est encore a son ecran de demarrage. Le test annonce pourtant
      <em>&laquo; rendered a duplicate captain answer &raquo;</em>.</div>
    <div class="term">
 pi v0.84.2
 escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more
 Press ctrl+o to show full startup help and loaded resources.

 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.

[Extensions]
  fm-calm.ts, followup-e2e.ts


 Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf and restart tmux.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
/private/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-calm-pi-extension.uML60T/followup-project (master)
0.0%/4.1k (auto)                                                                                                                                   deterministic</div>
  </div>
  <div class="card good">
    <div class="hd"><span class="tag">50 ms plus tard</span> Le meme pane <span style="color:#8b949e;font-weight:400">- 1x CAPTAIN_ANSWER_adjacent</span></div>
    <div class="note">Le transcript est peint : prompt et reponse du capitaine une seule fois, reponse de suivi presente,
      lignes operationnelles masquees par Calm absentes.</div>
    <div class="term"><span></span>
<span> </span><span style="font-weight:600"></span><span style="color:#8abeb7;font-weight:600">pi</span><span></span><span style="color:#666666"> v0.84.2</span><span></span>
<span> </span><span style="color:#666666">escape</span><span style="color:#808080"> interrupt · </span><span style="color:#666666">ctrl+c/ctrl+d</span><span style="color:#808080"> clear/exit · </span><span style="color:#666666">/</span><span style="color:#808080"> commands · </span><span style="color:#666666">!</span><span style="color:#808080"> bash · </span><span style="color:#666666">ctrl+o</span><span style="color:#808080"> more</span><span></span>
<span> </span><span style="color:#666666">Press ctrl+o to show full startup help and loaded resources.</span><span></span>
<span></span>
<span> </span><span style="color:#666666">Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.</span><span></span>
<span></span>
<span></span><span style="color:#f0c674">[Extensions]</span><span></span>
<span></span><span style="color:#666666">  fm-calm.ts, followup-e2e.ts</span><span></span>
<span></span>
<span></span>
<span> </span><span style="color:#ffff00">Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf and restart tmux.</span><span></span>
<span></span>
<span></span><span style="background:#343541"></span>
<span> </span><span style="color:#d4d4d4">CAPTAIN_PROMPT_adjacent</span><span></span>
<span></span>
<span></span>
<span></span><span> CAPTAIN_ANSWER_adjacent</span>
<span></span>
<span> MONITOR_HANDLED_adjacent_ONE_TWO</span>
<span></span>
<span></span><span style="color:#505050">────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────</span>
<span></span><span></span><span> </span><span></span>
<span></span><span style="color:#505050">────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────</span>
<span></span><span style="color:#666666">/private/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-calm-pi-extension.uML60T/followup-project (master)</span><span></span>
<span></span><span style="color:#666666">1.1%/4.1k (auto)                                                                                                                                   deterministic</span></div>
  </div>
</div>
<table>
 <tr><th>Mesure</th><th>Interpreteur 3.2.57</th><th>Interpreteur 5.3.15</th></tr>
 <tr><td>test_operational_followup_turn_e2e, version pre-correctif</td><td class="ko">10/12 verts</td><td class="ko">11/12 verts</td></tr>
 <tr><td>test_operational_followup_turn_e2e, version corrigee (HEAD)</td><td class="okc">12/12 verts</td><td class="okc">12/12 verts</td></tr>
 <tr><td>Suite complete a HEAD</td><td class="okc">3/3 verts, 12 verifications, 0 skip</td><td class="okc">3/3 verts, 12 verifications, 0 skip</td></tr>
 <tr><td>Doublon reel injecte dans le fixture (HEAD)</td><td class="ko">3/3 echecs attendus</td><td class="ko">3/3 echecs attendus</td></tr>
</table>
</html>
```
</details>
- Evidence: [Ecran Pi reellement asserte a HEAD (cas adjacent, Calm actif) : prompt et reponse du capitaine une seule fois, reponse de suivi peinte, lignes operationnelles masquees absentes](https://github.com/Kallas95/firstmate/blob/4d198fc0ae7209b59bee2bde22de2880199d0407/.no-mistakes/evidence/fm/fm-calm-bash5-regression/pane-adjacent-calm-on.html.png)
<details>
<summary>Evidence: Diagnostic instrumente de la version pre-correctif : ce que contenait vraiment le pane quand le test annoncait un doublon</summary>

Source: [Diagnostic instrumente de la version pre-correctif : ce que contenait vraiment le pane quand le test annoncait un doublon](https://github.com/Kallas95/firstmate/blob/4d198fc0ae7209b59bee2bde22de2880199d0407/.no-mistakes/evidence/fm/fm-calm-bash5-regression/prefix-failure-diagnosis.txt)

<code>DIAG cas=adjacent | CAPTAIN_ANSWER dans le pane capture=0 | 50ms plus tard=1 | MONITOR_HANDLED dans le pane capture=0 | 50ms plus tard=1&#10;DIAG premieres lignes non vides du pane capture: pi v0.84.2| escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more| Press ctrl+o to show full startup help and loaded resources.|&#10;not ok - Pi follow-up adjacent case rendered a duplicate captain answer</code>

```text
=== Version PRE-FIX instrumentee: que contient reellement le pane quand le test annonce un 'duplicate captain answer' ? ===
--- echec 1 (bash 5.3.15(1)-release, run 6) ---
DIAG cas=adjacent | CAPTAIN_ANSWER dans le pane capture=0 | 50ms plus tard=1 | MONITOR_HANDLED dans le pane capture=0 | 50ms plus tard=1
DIAG premieres lignes non vides du pane capture:  pi v0.84.2| escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more| Press ctrl+o to show full startup help and loaded resources.| Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.|
not ok - Pi follow-up adjacent case rendered a duplicate captain answer
--- echec 2 (bash 3.2.57(1)-release, run 15) ---
DIAG cas=adjacent | CAPTAIN_ANSWER dans le pane capture=0 | 50ms plus tard=1 | MONITOR_HANDLED dans le pane capture=0 | 50ms plus tard=1
DIAG premieres lignes non vides du pane capture:  pi v0.84.2| escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more| Press ctrl+o to show full startup help and loaded resources.| Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.|
not ok - Pi follow-up adjacent case rendered a duplicate captain answer
```
</details>
<details>
<summary>Evidence: Runs repetes avant/apres correctif de test_operational_followup_turn_e2e</summary>

Source: [Runs repetes avant/apres correctif de test_operational_followup_turn_e2e](https://github.com/Kallas95/firstmate/blob/4d198fc0ae7209b59bee2bde22de2880199d0407/.no-mistakes/evidence/fm/fm-calm-bash5-regression/followup-prefix-runs.txt)

<code>=== version PRE-FIX (ef35d79) ===&#10;run 01 FAIL: not ok - Pi follow-up adjacent case rendered a duplicate captain answer&#10;run 08 FAIL: not ok - Pi follow-up adjacent case rendered a duplicate captain answer&#10;prefix (bash 3.2.57): 10/12 green, 2 red&#10;run 03 FAIL: not ok - Pi follow-up adjacent case rendered a duplicate captain answer&#10;prefix (bash 5.3.15): 11/12 green, 1 red&#10;&#10;=== version HEAD (adce327) ===&#10;head (bash 3.2.57): 12/12 green, 0 red&#10;head (bash 5.3.15): 12/12 green, 0 red</code>

```text
=== test_operational_followup_turn_e2e isole, version PRE-FIX (ef35d79) ===
  run 01 FAIL: not ok - Pi follow-up adjacent case rendered a duplicate captain answer
  run 08 FAIL: not ok - Pi follow-up adjacent case rendered a duplicate captain answer
prefix (bash 3.2.57): 10/12 green, 2 red
  run 03 FAIL: not ok - Pi follow-up adjacent case rendered a duplicate captain answer
prefix (bash 5.3.15): 11/12 green, 1 red
```
</details>
<details>
<summary>Evidence: Un doublon reellement peint fait toujours echouer l&#39;assertion malgre la nouvelle attente</summary>

Source: [Un doublon reellement peint fait toujours echouer l&#39;assertion malgre la nouvelle attente](https://github.com/Kallas95/firstmate/blob/4d198fc0ae7209b59bee2bde22de2880199d0407/.no-mistakes/evidence/fm/fm-calm-bash5-regression/duplicate-mutation.txt)

<code>bash 3.2.57 run 1 -&gt; exit 1 | not ok - Pi follow-up adjacent case rendered a duplicate captain answer&#10;bash 3.2.57 run 2 -&gt; exit 1 | not ok - Pi follow-up adjacent case rendered a duplicate captain answer&#10;bash 3.2.57 run 3 -&gt; exit 1 | not ok - Pi follow-up adjacent case rendered a duplicate captain answer&#10;bash 5.3.15 run 1 -&gt; exit 1 | not ok - Pi follow-up adjacent case rendered a duplicate captain answer&#10;bash 5.3.15 run 2 -&gt; exit 1 | not ok - Pi follow-up adjacent case rendered a duplicate captain answer&#10;bash 5.3.15 run 3 -&gt; exit 1 | not ok - Pi follow-up adjacent case rendered a duplicate captain answer</code>

```text
=== Mutation: le fixture emet une VRAIE reponse capitaine dupliquee a l'ecran ===
But: verifier que la nouvelle attente (ancre sur MONITOR_HANDLED_<label>_ONE) ne masque pas un doublon reel.
bash 3.2.57(1)-release run 1 -> exit 1 | not ok - Pi follow-up adjacent case rendered a duplicate captain answer
bash 3.2.57(1)-release run 2 -> exit 1 | not ok - Pi follow-up adjacent case rendered a duplicate captain answer
bash 3.2.57(1)-release run 3 -> exit 1 | not ok - Pi follow-up adjacent case rendered a duplicate captain answer
bash 5.3.15(1)-release run 1 -> exit 1 | not ok - Pi follow-up adjacent case rendered a duplicate captain answer
bash 5.3.15(1)-release run 2 -> exit 1 | not ok - Pi follow-up adjacent case rendered a duplicate captain answer
bash 5.3.15(1)-release run 3 -> exit 1 | not ok - Pi follow-up adjacent case rendered a duplicate captain answer
```
</details>
<details>
<summary>Evidence: Suite complete sous les deux interpreteurs, PATH normal et PATH nettoye</summary>

Source: [Suite complete sous les deux interpreteurs, PATH normal et PATH nettoye](https://github.com/Kallas95/firstmate/blob/4d198fc0ae7209b59bee2bde22de2880199d0407/.no-mistakes/evidence/fm/fm-calm-bash5-regression/full-suite-both-shells.txt)

<code>bash 3.2.57 | runs 1-3 | exit 0 | 12 verifications | 0 skip&#10;bash 5.3.15 | runs 1-3 | exit 0 | 12 verifications | 0 skip&#10;&#10;=== PATH prive de /opt/homebrew/bin (le &#39;controle propre&#39; de la mesure d&#39;origine) ===&#10;skip: tmux not found for Pi operational follow-up E2E&#10;skip: tmux not found for Pi Calm hidden-block geometry E2E&#10;skip: tmux not found for Pi calm interactive E2E&#10;verifications reellement executees: 9 (12 moins les 3 E2E skippes), exit 0 sous les deux interpreteurs</code>

```text
=== tests/fm-calm-pi-extension.test.sh, suite complete a HEAD (adce327) ===
bash 3.2.57(1)-release | run 2 | exit 0 | 12 verifications | 0 skip | 0 echec
bash 3.2.57(1)-release | run 3 | exit 0 | 12 verifications | 0 skip | 0 echec
bash 5.3.15(1)-release | run 2 | exit 0 | 12 verifications | 0 skip | 0 echec
bash 5.3.15(1)-release | run 3 | exit 0 | 12 verifications | 0 skip | 0 echec

--- run 1 (deja mesure plus haut, meme configuration) ---
bash 3.2.57 | run 1 | exit 0 | 12 verifications | 0 skip
bash 5.3.15 | run 1 | exit 0 | 12 verifications | 0 skip

=== meme suite avec un PATH prive de /opt/homebrew/bin (le 'controle propre' de la mesure d'origine) ===
tmux vit dans /opt/homebrew/bin, donc les 3 E2E sont skippes et le skip nomme desormais l'outil absent :
--- bash 3.2.57, exit 0 ---
skip: tmux not found for Pi operational follow-up E2E
skip: tmux not found for Pi Calm hidden-block geometry E2E
skip: tmux not found for Pi calm interactive E2E
verifications reellement executees: 9 (9 = les 12 de la suite moins les 3 E2E skippes)
--- bash 5.3.15, exit 0 ---
skip: tmux not found for Pi operational follow-up E2E
skip: tmux not found for Pi Calm hidden-block geometry E2E
skip: tmux not found for Pi calm interactive E2E
verifications reellement executees: 9
```
</details>
<details>
<summary>Evidence: Le skip nomme l&#39;outil E2E reellement absent dans les trois configurations</summary>

Source: [Le skip nomme l&#39;outil E2E reellement absent dans les trois configurations](https://github.com/Kallas95/firstmate/blob/4d198fc0ae7209b59bee2bde22de2880199d0407/.no-mistakes/evidence/fm/fm-calm-bash5-regression/skip-names-the-missing-tool.txt)

<code>--- tmux absent, pi present ---&#10;skip: tmux not found for Pi operational follow-up E2E&#10;--- pi absent, tmux present ---&#10;skip: pi not found for Pi operational follow-up E2E&#10;--- pi et tmux absents ---&#10;skip: pi and tmux not found for Pi operational follow-up E2E</code>

```text
=== Ce que la suite annonce selon l'outil E2E reellement absent (bash 3.2.57) ===
--- tmux absent, pi present ---
skip: tmux not found for Pi operational follow-up E2E
skip: tmux not found for Pi Calm hidden-block geometry E2E
skip: tmux not found for Pi calm interactive E2E
--- pi absent, tmux present ---
skip: pi not found for Pi operational follow-up E2E
skip: pi not found for Pi Calm hidden-block geometry E2E
skip: pi not found for Pi calm interactive E2E
--- pi et tmux absents ---
skip: pi and tmux not found for Pi operational follow-up E2E
skip: pi and tmux not found for Pi Calm hidden-block geometry E2E
skip: pi and tmux not found for Pi calm interactive E2E
```
</details>
- Outcome: ⚠️ 1 info across 1 run (37m20s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"adce3276e6eb4be7309d433a8438232e71a98b19","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `tests/fm-calm-pi-extension.test.sh:1845` - Le chemin de timeout de la nouvelle boucle d&#39;ancrage reproduit le diagnostic trompeur que le commit visait a supprimer. La boucle 1838-1844 sort aussi apres 120 iterations (6 s) sans avoir trouve MONITOR_HANDLED_&lt;label&gt;_ONE ; `pane` contient alors la derniere capture non peinte, le compte de CAPTAIN_ANSWER_&lt;label&gt; vaut 0, et la ligne 1846 echoue avec &#34;Pi follow-up &lt;label&gt; case rendered a duplicate captain answer&#34; alors qu&#39;aucun doublon n&#39;existe. Comme `fail` (tests/lib.sh:44) fait `exit 1`, l&#39;assertion exacte de la ligne 1848 (&#34;did not render the intended processing result&#34;) n&#39;est jamais atteinte. Correction : deplacer `assert_contains &#34;$pane&#34; &#34;MONITOR_HANDLED_${label}_ONE&#34;` (ligne 1848) juste apres la boucle, avant le comptage de la ligne 1845 - c&#39;est deja l&#39;ordre retenu par `replay_exact_case` (assertion ligne 1953 avant l&#39;exploitation du pane) et par la boucle du composeur pret (re-verification explicite lignes 1814-1815).
- ℹ️ `tests/fm-calm-pi-extension.test.sh:1838` - La boucle d&#39;attente sur capture-pane existe maintenant en trois exemplaires identiques dans la meme fonction : lignes 1807-1813 (composeur pret), 1838-1844 (nouvelle) et 1946-1952 (replay_exact_case) - seule la chaine recherchee change. Un helper local du type `wait_for_pane_text &lt;needle&gt;` positionnant `pane` (pendant que `wait_for_text`, ligne 52, reste la variante fichier avec -S -600) supprimerait la triple duplication et garantirait que le delai et la re-verification restent coherents entre les trois sites.

🔧 Fix: name the unpainted pane and share the wait helper
1 info still open:
- ℹ️ `tests/fm-calm-pi-extension.test.sh:1848` - Les deux `assert_contains &#34;$pane&#34; &#34;MONITOR_HANDLED_...&#34;` remplaces par `wait_for_pane_text ... || fail ...` (1848-1849 et 1951-1952) perdent le dump de l&#39;ecran. `assert_contains` (tests/lib.sh:266-271) joint &#34;--- output ---&#34; suivi du contenu complet de `$pane` au message d&#39;echec ; `fail` seul (tests/lib.sh:44) n&#39;imprime que la ligne. Scenario concret ou la difference se voit : Calm masque a tort la ligne de traitement alors que la reponse capitaine est bien unique - avant, le flux atteignait `assert_contains ... MONITOR_HANDLED_${label}_ONE` et l&#39;echec CI contenait l&#39;ecran tmux entier ; desormais l&#39;attente expire et le rapport se reduit a &#34;never painted the follow-up answer on screen before the wait expired&#34;, sans aucune trace de ce qui etait reellement affiche. Pour un E2E dont l&#39;echec est rarement reproductible en local, c&#39;est le seul element de diagnostic. Correction : passer `$pane` dans les deux messages de `fail`, par exemple `fail &#34;...&#34;$&#39;\n&#39;&#34;--- output ---&#34;$&#39;\n&#39;&#34;$pane&#34;` (le helper laisse deja la derniere capture dans `pane` sur le chemin de timeout). Cela ne touche ni l&#39;ordre ancrage-puis-comptage ni la specificite des messages exigee.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `tests/fm-spawn-batch.test.sh` - Changement d&#39;etat des deux suites explicitement hors perimetre : tests/fm-spawn-batch.test.sh (5 verifications, exit 0) et tests/fm-teardown.test.sh (58 verifications, exit 0) sont vertes localement sous les deux interpreteurs, alors que l&#39;intent les annonce rouges. Rien n&#39;a ete modifie pour elles ; simple signalement demande par le brief.
- <code>`/bin/bash tests/fm-calm-pi-extension.test.sh` et `/opt/homebrew/bin/bash tests/fm-calm-pi-extension.test.sh` : 3 runs par interpreteur, exit 0, 12 verifications, 0 skip</code>
- <code>Meme suite avec un PATH prive de /opt/homebrew/bin sous les deux interpreteurs : exit 0, 9 verifications executees, 3 skips `skip: tmux not found for ...`</code>
- <code>Nommage du skip dans les trois configurations d&#39;outils (tmux absent, pi absent, les deux absents) via des PATH construits avec shims node/npm/git : `skip: tmux not found`, `skip: pi not found`, `skip: pi and tmux not found`</code>
- <code>Reproduction pre-correctif : `test_operational_followup_turn_e2e` isole depuis `git show ef35d79:tests/fm-calm-pi-extension.test.sh`, 12 runs par interpreteur -&gt; 10/12 et 11/12 verts, echecs `not ok - Pi follow-up adjacent case rendered a duplicate captain answer`</code>
- `Meme fonction a HEAD (adce327), 12 runs par interpreteur -> 24/24 verts`
- `Version pre-correctif instrumentee : dump du pane fige au moment du comptage (0 occurrence de CAPTAIN_ANSWER_adjacent, ecran de demarrage Pi) et recapture 50 ms plus tard (1 occurrence)`
- <code>Mutation de non-regression : fixture followup-e2e.ts modifie pour peindre une vraie reponse capitaine dupliquee -&gt; `not ok - ... rendered a duplicate captain answer` 3/3 sous chaque interpreteur</code>
- <code>`timeout 300 bash tests/fm-spawn-batch.test.sh` et `timeout 420 bash tests/fm-teardown.test.sh` sous les deux interpreteurs (controle d&#39;etat des suites hors perimetre)</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/calm-mode-feasibility.md:16` - Suivi hors périmètre : docs/calm-mode-feasibility.md « Compatibility evidence » ne mentionne que Pi 0.81.1 et 0.82.0 et conclut qu&#39;aucune API de présentation pertinente n&#39;a été introduite. Depuis le commit de base ef35d79 (#2461), il est établi que Pi 0.83.0 a introduit un status line sur setToolsExpanded qui cassait la confirmation /export sous Calm. Ce fait n&#39;est découvrable que dans l&#39;enregistrement daté « 2026-08-15 Pi 0.84.1 export-confirmation verification » en fin de document. Rien n&#39;est faux au sens strict (la phrase est bornée aux deux versions nommées), et la lacune n&#39;est pas causée par ce diff, qui ne touche que tests/fm-calm-pi-extension.test.sh. Un pointeur d&#39;une ligne depuis la section « Compatibility evidence » vers cet enregistrement rendrait l&#39;évidence 0.83.0+ découvrable sans dupliquer la prose. Laissé de côté ici pour respecter la discipline de périmètre.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
