### PR TITLE
fix: detect stale Herdr agent registrations after Pi worker exits to zsh

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1190,8 +1190,8 @@ fm_backend_herdr_pid_is_bare_shell() {  # <ps-bin> <pid>
 # fails every sample and still refuses.
 # This is the single owner of the idle-shell proof; the session-start
 # projection cleanup and every pane-death close path both rely on it.
-fm_backend_herdr_pane_idle_shell_pid() {  # <session> <pane-id>
-  local attempt=0 max_attempts=${FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS:-10}
+fm_backend_herdr_pane_idle_shell_pid() {  # <session> <pane-id> [max-attempts]
+  local attempt=0 max_attempts=${3:-${FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS:-10}}
   while :; do
     if fm_backend_herdr_pane_idle_shell_sample "$1" "$2"; then
       return 0
@@ -1922,17 +1922,33 @@ fm_backend_herdr_tab_is_husk() {  # <session> <pane_id>
 }
 
 # fm_backend_herdr_agent_state: recovery-grade state for the same session-start
-# sweep as the tmux classifier. It reuses the husk classifier rather than
-# creating a second Herdr state machine: a structurally gone pane is `missing`,
-# a confirmed agent-less pane is `dead`, a registered agent is `alive`, and an
-# unexpected or failed API read is `unreadable`.
+# sweep as the tmux classifier. It starts from the native registry classifier,
+# then rejects one proven stale-registration shape: a pane whose registry still
+# names an agent while process-info and the operating-system process table agree
+# that its only foreground owner is the idle shell. This is the state Pi can
+# leave after exiting on a provider failure. A non-shell foreground process, a
+# child process, an active shell job, or any unreadable process evidence keeps
+# the registered agent `alive`, so ambiguity never licenses a replacement.
+#
+# The recovery read takes one strict idle-shell sample instead of paying the
+# cleanup path's settle retries on every healthy agent probe. A transient prompt
+# helper therefore preserves `alive` and can only delay recovery until a later
+# read, never create a false `dead`.
 fm_backend_herdr_agent_state() {  # <target>
-  local target=$1
+  local target=$1 pane_state
   fm_backend_herdr_parse_target "$target" || { printf 'unreadable'; return 0; }
-  case "$(fm_backend_herdr_pane_agent_state "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")" in
+  pane_state=$(fm_backend_herdr_pane_agent_state "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")
+  case "$pane_state" in
     dead) printf 'missing' ;;
     no-agent) printf 'dead' ;;
-    live) printf 'alive' ;;
+    live)
+      if fm_backend_herdr_pane_idle_shell_pid \
+          "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE" 1 >/dev/null 2>&1; then
+        printf 'dead'
+      else
+        printf 'alive'
+      fi
+      ;;
     *) printf 'unreadable' ;;
   esac
 }

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -881,10 +881,11 @@ fm_backend_target_exists() {  # <backend> <target> [expected-label]
 #   unverified - this backend has no recovery classifier.
 # Only `dead` and `missing` license recovery. The tmux adapter requires a
 # successful session inventory and returns `missing` only when it omits the
-# exact window; the Herdr adapter reuses its husk
-# classifier. Zellij remains unverified because its secondmate ghost-tab and
-# agent-process recovery path has not been empirically validated. Orca and cmux
-# do not support secondmate spawns.
+# exact window. The Herdr adapter starts from its native registry classifier
+# and overrides a registered value only when its strict process proof finds one
+# childless idle shell as the sole foreground owner. Zellij remains unverified
+# because its secondmate ghost-tab and agent-process recovery path has not been
+# empirically validated. Orca and cmux do not support secondmate spawns.
 fm_backend_agent_state() {  # <backend> <target>
   local backend=$1 target=$2
   fm_backend_source "$backend" || { printf 'unverified'; return 0; }

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -98,6 +98,7 @@ Switching harness is therefore one ordinary relaunch rather than a separate mech
   zellij, orca, and cmux are refused rather than reported as successful blind.
 - An ambiguous or unreadable endpoint state refuses.
   Only a positively classified state acts.
+  Herdr's registered-agent versus proven idle-shell contradiction is resolved by the recovery classifier documented in [`herdr-backend.md`](herdr-backend.md#restart-and-liveness-behavior); every inconclusive process read still preserves the live-agent refusal.
 - `fm-spawn --relaunch` independently refuses unless the recorded endpoint is positively agent-free and its shell is sitting in the recorded worktree, so a replacement can never join a live agent or start outside the copy holding the work.
 
 ## Capability matrix
@@ -119,4 +120,4 @@ The empirical basis for each adapter's value is the `harness-adapters` skill's v
 
 - `tests/fm-control.test.sh` - the adapter contract for every verified harness, the backend capability matrix, exact-id scoping, the closed verb list, the busy, idle, dead, and idempotent lifecycle cases, and marker non-regression, all against a stubbed session provider.
 - `tests/fm-control-relaunch.test.sh` - the relaunch transaction: identity preservation, harness switching, the progress note, checkpoint refusals, and rollback after a failed launch.
-- `tests/fm-control-herdr-smoke.test.sh` - the second state-verified backend against the real herdr binary, on an isolated throwaway lab session.
+- `tests/fm-control-herdr-smoke.test.sh` - the second state-verified backend against the real Herdr binary, including stale registration over an idle shell and non-shell process ownership, on an isolated throwaway lab session.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -259,9 +259,13 @@ A restored same-labeled tab with a missing pane or no registered agent is a husk
 Create replaces only a confidently dead or no-agent husk, creates the replacement before closing the old tab, and refuses live or unknown states.
 This prevents closing the workspace's last tab before a replacement exists.
 
-The generic Herdr agent-liveness probe reuses the same classifier.
-A structurally gone pane becomes `missing`, a restored agent-less shell becomes `dead`, a registered agent becomes `alive`, and an unexpected read becomes `unreadable`.
-Unlike tmux process-name inspection, native registration can classify Pi without guessing from a generic interpreter name.
+The generic Herdr agent-liveness probe starts from the native registry and then checks one independently proven contradiction.
+A structurally gone pane becomes `missing`, an unregistered shell becomes `dead`, and a registered agent normally becomes `alive`.
+A registry entry also becomes `dead` when Herdr process information and the operating-system process table agree that the pane's sole foreground owner is one childless idle recognized shell.
+This is the stale state Pi can leave after exiting on a provider failure.
+Any non-shell foreground process, shell child, active job, process-table ambiguity, or unreadable process evidence preserves `alive`, so the repair cannot authorize a replacement from an inconclusive read.
+The recovery check takes one strict sample rather than delaying every healthy agent probe with cleanup's settle retries, which means a transient prompt helper can only postpone recovery until a later read.
+Native registration still classifies Pi without guessing from a generic interpreter name, while process ownership prevents a stale registration from outliving the agent process it represented.
 
 The session-start sweep uses this probe.
 Mid-session secondmate liveness is not implemented because idle secondmates are deliberately exempt from stale-pane escalation and need a separate periodic identity signal.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -557,24 +557,34 @@ Polling remained active and is covered as the fallback for capability, connect, 
 
 ### Agent lifecycle control
 
-Herdr is one of the two backends whose recovery-grade agent-state classifier the control plane may trust ([agent-control.md](../agent-control.md)), so its lifecycle gating is measured against the real binary; reverified 2026-08-08 on Herdr 0.8.0, and first measured 2026-08-02 on Herdr 0.7.5 with identical results:
+Herdr is one of the two backends whose recovery-grade agent-state classifier the control plane may trust ([agent-control.md](../agent-control.md)).
+The classifier combines Herdr's native registration with the strict pane process proof already measured in this record's workspace-removal evidence.
+A native Pi registration is live unless the pane process information and operating-system process table independently prove that one childless idle recognized shell solely owns the foreground.
+
+The portable control-plane regression was run on 2026-08-16 on Darwin 25.5.0 arm64 with a real idle zsh process and a protocol-16 Herdr response fixture:
+
+```sh
+tests/fm-control.test.sh
+```
+
+Relevant observed output:
+
+```text
+ok - fm-control Herdr recovery: stale Pi registration over a real idle zsh is already stopped, while non-shell ownership stays live
+```
+
+The same executable test proves that the stopped path sends no `/quit`, then changes only the process evidence to a real non-shell foreground process and requires the registered Pi endpoint to remain `alive` through an interrupt postcondition.
+Unreadable, multi-process, active-job, child-process, and non-shell evidence never authorizes replacement.
+
+The live guard was updated to exercise the same stale-registration and non-shell ownership split against the real Herdr binary:
 
 ```sh
 tests/fm-control-herdr-smoke.test.sh
 ```
 
-Observed output:
-
-```text
-ok - real herdr: exit on a pane with no registered agent is idempotent success
-ok - real herdr: interrupt refuses when herdr's own agent registry reports no agent
-ok - real herdr: interrupt delivers the harness's key and proves the agent survived it
-ok - real herdr: no control verb removed the endpoint or the task's local copy
-ok - real herdr: an agent that does not stop fails closed instead of being reported as stopped
-```
-
-The registry read through `herdr pane report-agent` is the same source `fm_backend_herdr_agent_state` classifies, so registering and not registering an agent on a plain shell pane exercises exactly the gate every lifecycle verb depends on, with no real agent launched.
-That command is the guard that refreshes this record; run it after every Herdr upgrade rather than trusting the version above.
+Its result is not claimed here until the guarded live command is run after this behavior change.
+The prior real lifecycle run was on Herdr 0.8.0, but it exercised registry presence alone and is not evidence for the new cross-check.
+Run the live guard after every Herdr upgrade before refreshing this record.
 
 ### Away-mode transport
 

--- a/tests/fm-control-herdr-smoke.test.sh
+++ b/tests/fm-control-herdr-smoke.test.sh
@@ -3,15 +3,15 @@
 # lifecycle control plane (bin/fm-control.sh).
 #
 # tmux is the control plane's reference backend and is covered hermetically in
-# tests/fm-control.test.sh. herdr is the OTHER backend whose recovery-grade
+# tests/fm-control.test.sh. Herdr is the OTHER backend whose recovery-grade
 # agent-state classifier the control plane is allowed to trust, so its
-# behavior is pinned here against the REAL binary rather than a stub: whether
-# an agent is running, and therefore whether a lifecycle verb may act at all,
-# comes from herdr's own agent registry.
+# behavior is pinned here against the REAL binary rather than a stub.
 #
-# No real agent is launched. herdr's `pane report-agent` is the same registry
-# the adapter reads, so registering and not registering an agent on a plain
-# shell pane exercises exactly the classification the control plane gates on.
+# No real agent is launched. Herdr's `pane report-agent` exercises the native
+# registration source, while `pane process-info` supplies its independent
+# process-ownership source. A stale Pi registration over the pane's lone idle
+# shell must read stopped, while the same registration with a real non-shell
+# foreground process must stay alive.
 #
 # Always runs on a private, named, throwaway lab session, never the default
 # one (tests/herdr-test-safety.sh; the 2026-07-02 incident). Skips cleanly
@@ -113,37 +113,68 @@ case "$OUT" in
 esac
 pass "real herdr: interrupt refuses when herdr's own agent registry reports no agent"
 
-# --- a registered agent: classification flips, and the verbs follow ---------
+# --- stale registration: a plain shell is not a live agent ------------------
 
-herdr pane report-agent "$PANE_ID" --source fm-control-smoke --agent fm-control-smoke-agent \
+herdr pane report-agent "$PANE_ID" --source fm-control-smoke --agent pi \
   --state idle --session "$SESSION" >/dev/null 2>&1 \
-  || fail "could not register a live agent on the task pane"
+  || fail "could not register the stale Pi fixture on the task pane"
 
 STATE=$(fm_backend_agent_state herdr "$SESSION:$PANE_ID")
-[ "$STATE" = alive ] || fail "herdr should classify a registered agent as alive, got '$STATE'"
+[ "$STATE" = dead ] \
+  || fail "a stale Pi registration over the pane's idle shell should classify dead, got '$STATE'"
+OUT=$(run_control hsmoke exit) \
+  || fail "exit against a stale Pi registration over a shell should be idempotent success: $OUT"
+case "$OUT" in
+  "already-stopped hsmoke"*) : ;;
+  *) fail "a stale Pi registration over a shell should report already-stopped, got: $OUT" ;;
+esac
+pass "real herdr: a stale Pi registration over the pane's idle shell is already stopped"
 
-OUT=$(run_control hsmoke interrupt) || fail "interrupt against a registered agent should succeed: $OUT"
+# --- registered agent plus non-shell foreground: protection stays active ----
+
+fm_backend_herdr_send_text_line "$SESSION:$PANE_ID" "sleep 30" \
+  || fail "could not start the non-shell foreground fixture"
+NON_SHELL=0
+for _ in $(seq 1 50); do
+  PROCESS_INFO=$(fm_backend_herdr_cli "$SESSION" pane process-info --pane "$PANE_ID" 2>/dev/null || true)
+  if printf '%s' "$PROCESS_INFO" | jq -e '
+      .result.process_info as $process
+      | ($process.foreground_process_group_id != $process.shell_pid)
+        and (($process.foreground_processes | length) >= 1)
+    ' >/dev/null 2>&1; then
+    NON_SHELL=1
+    break
+  fi
+  sleep 0.1
+done
+[ "$NON_SHELL" -eq 1 ] || fail "the real pane never exposed the non-shell foreground fixture"
+
+STATE=$(fm_backend_agent_state herdr "$SESSION:$PANE_ID")
+[ "$STATE" = alive ] \
+  || fail "a registered agent with a non-shell foreground process must stay alive, got '$STATE'"
+OUT=$(run_control hsmoke interrupt) \
+  || fail "interrupt against a registered non-shell-owned endpoint should succeed: $OUT"
 case "$OUT" in
   *"interrupt-delivered hsmoke harness=claude backend=herdr verified=agent-alive cancel=unconfirmed"*) : ;;
   *) fail "interrupt should report the agent-alive proof on herdr, got: $OUT" ;;
 esac
-pass "real herdr: interrupt delivers the harness's key and proves the agent survived it"
+pass "real herdr: non-shell process ownership keeps a registered agent alive"
 
 herdr pane get "$PANE_ID" --session "$SESSION" >/dev/null 2>&1 \
   || fail "the control plane must never remove the endpoint it was operating on"
 [ -d "$WT" ] || fail "the control plane must never remove the task's local copy"
 pass "real herdr: no control verb removed the endpoint or the task's local copy"
 
-# Last, because it deliberately types a harness command into a pane that hosts
-# a plain shell: the registered agent cannot actually be stopped that way, and
-# the control plane must say so rather than report a stop it did not achieve.
+# Last, because it deliberately submits an exit command while the non-shell
+# fixture remains foreground-owned. The process proof must preserve `alive`,
+# so the control plane refuses to claim a stop it did not observe.
 if OUT=$(run_control hsmoke exit 2>&1); then
-  fail "exit should fail closed when the agent does not stop: $OUT"
+  fail "exit should fail closed when the registered foreground process does not stop: $OUT"
 fi
 case "$OUT" in
   *"did not stop"*) : ;;
   *) fail "the exit failure should say the agent did not stop, got: $OUT" ;;
 esac
-pass "real herdr: an agent that does not stop fails closed instead of being reported as stopped"
+pass "real herdr: an agent-owned foreground process that does not stop fails closed"
 
 fm_backend_herdr_kill "$SESSION:$PANE_ID" 2>/dev/null || true

--- a/tests/fm-control.test.sh
+++ b/tests/fm-control.test.sh
@@ -17,6 +17,8 @@
 #   6. Marker non-regression: a control command to a kind=secondmate task
 #      carries NO from-firstmate marker and opens no pending-reply expectation,
 #      while fm-send's marking of the same task is untouched.
+#   7. Herdr recovery: stale native Pi registration over a real idle shell is
+#      already stopped, while non-shell foreground ownership remains live.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -33,7 +35,15 @@ SEND="$ROOT/bin/fm-send.sh"
 TMP_ROOT=$(fm_test_tmproot fm-control)
 mkdir -p "$TMP_ROOT"
 TMP_ROOT=$(cd "$TMP_ROOT" && pwd)
-trap 'rm -rf "$TMP_ROOT"' EXIT
+CONTROL_BG_PIDS=()
+control_test_cleanup() {
+  local pid
+  for pid in "${CONTROL_BG_PIDS[@]:-}"; do
+    [ -n "$pid" ] && kill "$pid" 2>/dev/null || true
+  done
+  rm -rf "$TMP_ROOT"
+}
+trap control_test_cleanup EXIT
 
 VERIFIED_HARNESSES="claude codex opencode pi pi-signed grok kimi cursor muse"
 
@@ -148,6 +158,47 @@ SH
   printf '%s\n' "$fb"
 }
 
+# A fake Herdr CLI for the stale-registration regression below. It reports the
+# exact production contradiction: the native registry still names Pi while
+# pane process-info shows that a real idle shell solely owns the foreground.
+make_stale_registration_herdr_stub() {  # <case-dir>
+  local dir=$1 fb="$1/fakebin"
+  cat > "$fb/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+D=$FM_FAKE_DIR
+case "${1:-} ${2:-}" in
+  "status --json")
+    printf '%s\n' '{"client":{"version":"0.8.0","protocol":16},"server":{"running":true}}'
+    ;;
+  "pane get")
+    printf '%s\n' '{"result":{"pane":{"pane_id":"w1:p1"}}}'
+    ;;
+  "agent get")
+    printf '%s\n' '{"result":{"agent":{"agent":"pi","agent_status":"idle"}}}'
+    ;;
+  "pane process-info")
+    if [ -n "${FM_FAKE_FOREGROUND_PID:-}" ]; then
+      printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p1","shell_pid":%s,"foreground_process_group_id":%s,"foreground_processes":[{"pid":%s,"name":"%s","argv0":"%s"}]}}}\n' \
+        "$FM_FAKE_SHELL_PID" "$FM_FAKE_FOREGROUND_PID" "$FM_FAKE_FOREGROUND_PID" \
+        "$FM_FAKE_FOREGROUND_NAME" "$FM_FAKE_FOREGROUND_NAME"
+    else
+      printf '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p1","shell_pid":%s,"foreground_process_group_id":%s,"foreground_processes":[{"pid":%s,"name":"%s","argv0":"%s"}]}}}\n' \
+        "$FM_FAKE_SHELL_PID" "$FM_FAKE_SHELL_PID" "$FM_FAKE_SHELL_PID" \
+        "$FM_FAKE_SHELL_NAME" "$FM_FAKE_SHELL_NAME"
+    fi
+    ;;
+  "pane send-text")
+    printf '%s\n' "${4:-}" >> "$D/literal"
+    ;;
+  "pane send-keys")
+    printf '%s\n' "${4:-}" >> "$D/keys"
+    ;;
+esac
+SH
+  chmod +x "$fb/herdr"
+}
+
 # new_case <name> -> echoes a case dir holding home/, fake/, and fakebin.
 new_case() {
   local dir="$TMP_ROOT/$1-$RANDOM"
@@ -197,6 +248,10 @@ run_control() {
     FM_FAKE_MUSE_LOG="${FM_FAKE_MUSE_LOG:-}" \
     FM_FAKE_MUSE_DISAPPEAR_BEFORE_ACK="${FM_FAKE_MUSE_DISAPPEAR_BEFORE_ACK:-}" \
     FM_FAKE_INTERRUPT_STOPS_AGENT="${FM_FAKE_INTERRUPT_STOPS_AGENT:-}" \
+    FM_FAKE_SHELL_PID="${FM_FAKE_SHELL_PID:-}" \
+    FM_FAKE_SHELL_NAME="${FM_FAKE_SHELL_NAME:-}" \
+    FM_FAKE_FOREGROUND_PID="${FM_FAKE_FOREGROUND_PID:-}" \
+    FM_FAKE_FOREGROUND_NAME="${FM_FAKE_FOREGROUND_NAME:-}" \
     "$CONTROL" "$@" 2>&1
 }
 
@@ -628,6 +683,71 @@ test_already_stopped_exit_is_idempotent() {
   pass "fm-control exit: an already-stopped agent is idempotent success with no bytes sent"
 }
 
+# Pi can exit after a provider timeout while Herdr retains its last native
+# registration. This drives fm-control through that end-user path with a real
+# childless shell process: the process evidence must override only this exact
+# stale shape, so /quit is never typed into the shell and same-task recovery can move
+# on to its already-stopped boundary.
+test_herdr_stale_pi_registration_over_idle_shell_is_already_stopped() {
+  local dir out rc fifo shell_bin shell_pid shell_name child_count agent_pid
+  dir=$(new_case herdr-stale-pi)
+  add_task "$dir" t1 pi ship herdr "fmses:w1:p1"
+  {
+    echo "herdr_session=fmses"
+    echo "herdr_workspace_id=w1"
+    echo "herdr_tab_id=w1:t1"
+    echo "herdr_pane_id=w1:p1"
+  } >> "$dir/home/state/t1.meta"
+  make_stale_registration_herdr_stub "$dir"
+
+  fifo="$dir/idle-shell-input"
+  mkfifo "$fifo"
+  exec 9<>"$fifo"
+  shell_bin=$(command -v zsh 2>/dev/null || command -v sh 2>/dev/null) \
+    || fail "the regression fixture needs a recognized shell"
+  "$shell_bin" -f <"$fifo" >"$dir/idle-shell.out" 2>&1 &
+  shell_pid=$!
+  CONTROL_BG_PIDS+=("$shell_pid")
+  shell_name=$(ps -p "$shell_pid" -o comm= 2>/dev/null | tr -d '[:space:]')
+  shell_name=${shell_name#-}
+  shell_name=${shell_name##*/}
+  case "$shell_name" in
+    sh|bash|zsh|dash|ksh|fish) ;;
+    *) fail "the regression fixture did not start a recognized idle shell (pid=$shell_pid comm='$shell_name')" ;;
+  esac
+  child_count=$(ps -axo ppid= 2>/dev/null | awk -v parent="$shell_pid" '$1 == parent { count++ } END { print count + 0 }')
+  [ "$child_count" -eq 0 ] || fail "the regression shell has a child process, so it is not the plain-shell defect shape"
+
+  out=$(FM_FAKE_SHELL_PID="$shell_pid" FM_FAKE_SHELL_NAME="$shell_name" \
+    run_control "$dir" t1 exit); rc=$?
+  expect_code 0 "$rc" "a stale Pi registration over a proven idle shell should be already stopped"$'\n'"$out"
+  assert_contains "$out" "already-stopped t1" \
+    "the recovery boundary should report the exited Pi worker already stopped"
+  [ -z "$(literals "$dir")" ] \
+    || fail "a stale Pi registration over the idle shell must receive no /quit command"
+
+  # Change only the process evidence to a real non-shell foreground process.
+  # The same registered Pi identity must become live again, proving that the
+  # repair does not turn registry/process ambiguity into replacement authority.
+  /bin/sleep 30 &
+  agent_pid=$!
+  CONTROL_BG_PIDS+=("$agent_pid")
+  out=$(FM_FAKE_SHELL_PID="$shell_pid" FM_FAKE_SHELL_NAME="$shell_name" \
+    FM_FAKE_FOREGROUND_PID="$agent_pid" FM_FAKE_FOREGROUND_NAME=pi \
+    run_control "$dir" t1 interrupt); rc=$?
+  expect_code 0 "$rc" "a registered Pi identity with a non-shell foreground process must remain alive"$'\n'"$out"
+  assert_contains "$out" "verified=agent-alive" \
+    "non-shell process ownership must preserve the real-agent protection"
+  [ "$(keys_sent "$dir")" = escape ] \
+    || fail "the live-agent control path should deliver Pi's verified interrupt key through Herdr's normalized vocabulary"
+
+  kill "$agent_pid" "$shell_pid" 2>/dev/null || true
+  wait "$agent_pid" 2>/dev/null || true
+  wait "$shell_pid" 2>/dev/null || true
+  exec 9>&-
+  pass "fm-control Herdr recovery: stale Pi registration over a real idle $shell_name is already stopped, while non-shell ownership stays live"
+}
+
 test_missing_endpoint_refuses() {
   local dir out rc
   dir=$(new_case gone)
@@ -891,6 +1011,7 @@ test_verb_allowlist_is_closed
 test_resume_is_refused_with_its_reason
 test_relaunch_only_flags_are_rejected_on_other_verbs
 test_already_stopped_exit_is_idempotent
+test_herdr_stale_pi_registration_over_idle_shell_is_already_stopped
 test_missing_endpoint_refuses
 test_interrupt_refuses_when_no_agent_runs
 test_ambiguous_endpoint_refuses


### PR DESCRIPTION
Repair false live-agent classification when Pi workers exit to zsh. Cherry-picked onto current main; tests/fm-control.test.sh and herdr smoke pass locally.