### PR TITLE
fix(remote-job): bound worker startup and shutdown waits by wall clock

### DIFF
--- a/bin/fm-remote-job-lib.sh
+++ b/bin/fm-remote-job-lib.sh
@@ -113,16 +113,22 @@ fm_remote_job_validate_settings() {
 # successful check.
 #
 # What a wait owes its caller when the clock misbehaves is deliberately narrow.
-# It must always terminate, and it must never hand back a budget it has not
-# spent: a `date` fork can fail under the very memory pressure these waits exist
-# for, and an NTP correction can step the clock backwards on a host that just
-# woke from sleep, and either one ending a wait early would produce the exact
-# "worker did not report ready" failure the deadline exists to prevent. So an
-# unreadable reading is skipped rather than counted, up to a bounded number of
-# consecutive misses that guarantees termination, and a backwards step
-# re-anchors the deadline by the size of the step. Making these waits correct
-# against a clock that is wrong in other ways is out of scope here and tracked
-# as its own item, so this stays a deadline rather than a clock subsystem.
+# It must always terminate, whatever the clock does, and it must never hand back
+# a budget it has not spent: a `date` fork can fail under the very memory
+# pressure these waits exist for, and an NTP correction can step the clock
+# backwards on a host that just woke from sleep, and either one ending a wait
+# early would produce the exact "worker did not report ready" failure the
+# deadline exists to prevent. So a backwards step re-anchors the deadline by the
+# size of the step, and two backstops make termination unconditional whether the
+# clock is unreadable, frozen, stepping backwards, or oscillating. A run of
+# consecutive readings that tell the wait nothing new, unreadable or not
+# advancing, ends it after FM_REMOTE_JOB_CLOCK_MAX_MISSES of them. Re-anchoring
+# stops once it has given back the whole budget, and a backwards reading past
+# that point ends the wait too, which caps the worst case at roughly twice the
+# budget while still absorbing the one-off correction this exists for. Making
+# these waits correct against a clock that is wrong in other ways, a forward
+# step in particular, is out of scope here and tracked as its own item, so this
+# stays a deadline rather than a clock subsystem.
 fm_remote_job_clock_now() { # epoch seconds, or nothing when the clock is unreadable
   local now
   now=$(date +%s 2>/dev/null || true)
@@ -133,22 +139,27 @@ fm_remote_job_clock_now() { # epoch seconds, or nothing when the clock is unread
 fm_remote_job_wait_until() { # <seconds> <predicate> [args...]
   local seconds=$1
   shift
-  local now deadline='' last='' misses=0
+  local now deadline='' last='' stalled=0 returned=0 step
   now=$(fm_remote_job_clock_now) || now=
   last=$now
   [ -z "$now" ] || deadline=$((now + seconds))
   while :; do
     "$@" && return 0
     now=$(fm_remote_job_clock_now) || now=
-    if [ -z "$now" ]; then
-      misses=$((misses + 1))
-      [ "$misses" -lt "$FM_REMOTE_JOB_CLOCK_MAX_MISSES" ] || return 1
+    if [ -n "$now" ] && { [ -z "$last" ] || [ "$now" -gt "$last" ]; }; then
+      stalled=0
     else
-      misses=0
+      stalled=$((stalled + 1))
+      [ "$stalled" -lt "$FM_REMOTE_JOB_CLOCK_MAX_MISSES" ] || return 1
+    fi
+    if [ -n "$now" ]; then
       if [ -z "$deadline" ]; then
         deadline=$((now + seconds))
       elif [ -n "$last" ] && [ "$now" -lt "$last" ]; then
-        deadline=$((deadline - (last - now)))
+        [ "$returned" -lt "$seconds" ] || return 1
+        step=$((last - now))
+        returned=$((returned + step))
+        deadline=$((deadline - step))
       fi
       last=$now
       [ "$now" -lt "$deadline" ] || return 1

--- a/bin/fm-remote-job-lib.sh
+++ b/bin/fm-remote-job-lib.sh
@@ -60,7 +60,7 @@ FM_REMOTE_JOB_REAP_SECONDS=${FM_REMOTE_JOB_REAP_SECONDS:-3600}
 FM_REMOTE_JOB_PROBE_WAIT_SECONDS=${FM_REMOTE_JOB_PROBE_WAIT_SECONDS:-60}
 FM_REMOTE_JOB_STOP_WAIT_SECONDS=${FM_REMOTE_JOB_STOP_WAIT_SECONDS:-15}
 FM_REMOTE_JOB_CLOCK_MAX_STALLS=${FM_REMOTE_JOB_CLOCK_MAX_STALLS:-50}
-FM_REMOTE_JOB_WAIT_MAX_POLLS_PER_SECOND=${FM_REMOTE_JOB_WAIT_MAX_POLLS_PER_SECOND:-1000}
+FM_REMOTE_JOB_WAIT_MAX_POLLS_PER_SECOND=${FM_REMOTE_JOB_WAIT_MAX_POLLS_PER_SECOND:-50}
 FM_REMOTE_JOB_OPERATOR_PATH=
 FM_REMOTE_JOB_CHILD_PATH=
 FM_REMOTE_JOB_STATE=
@@ -140,15 +140,28 @@ fm_remote_job_validate_settings() {
 # That ceiling is a liveness backstop and never a budget, which is the opposite
 # of the counted loop this file replaced. There the count WAS the budget, so a
 # check that grew more expensive under load ate the wait alive and produced the
-# CI flake. This ceiling can only ever fire late: the loop sleeps a tenth of a
-# second per poll, so a healthy wait cannot exceed ten polls per second of
-# budget and the default leaves a hundredfold margin, and an expensive check
-# means fewer polls per second, which moves the ceiling further away rather than
-# closer. It cannot shorten a budget and it cannot be reached in healthy
-# operation, so do not mistake it for a leftover and delete it. Making these
-# waits correct against a clock that is wrong in other ways, a forward step in
-# particular, is deliberately out of scope here and tracked as its own item, so
-# this stays a deadline rather than a clock subsystem.
+# CI flake. Here the count is derived from the budget rather than standing in
+# for it, in two terms. The floor is the most polls a legitimate wait can ever
+# use: the loop sleeps a tenth of a second every time round, so a budget of S
+# seconds admits at most S x 10 polls, and that is an upper bound by
+# construction rather than an estimate, because an expensive check makes each
+# poll take longer and so can only lower the count. The margin is five times
+# that floor, which also absorbs a legitimate backwards correction of up to four
+# times the budget, since such a correction lengthens a wait rather than
+# collapsing it. Ten times five is the fifty polls per second of budget the
+# default sets, and anyone changing the poll sleep or a budget has to redo that
+# arithmetic.
+#
+# So the worst case is bounded in wall time too: fifty polls per second of
+# budget at a tenth of a second each means a clock that never advances fails a
+# wait after about five times its budget, roughly five minutes for the sixty
+# second readiness wait and about seventy five seconds for each leg of the
+# fifteen second shutdown wait. The ceiling cannot shorten a budget and cannot
+# be reached in healthy operation, so do not mistake it for a leftover and
+# delete it. Making these waits correct against a clock that is wrong in other
+# ways, a forward step in particular, is deliberately out of scope here and
+# tracked as its own item, so this stays a deadline rather than a clock
+# subsystem.
 fm_remote_job_clock_now() { # epoch seconds, or nothing when the clock is unreadable
   local now
   now=$(date +%s 2>/dev/null || true)

--- a/bin/fm-remote-job-lib.sh
+++ b/bin/fm-remote-job-lib.sh
@@ -49,6 +49,11 @@
 # it to stop itself once its root is pruned, and
 # bin/fm-remote-job-reap-orphans.sh uses it to reap workers that were already
 # orphaned that way.
+#
+# Waiting for worker readiness and for a stopped worker tree spends a
+# wall-clock budget rather than an iteration count, tunable with
+# FM_REMOTE_JOB_PROBE_WAIT_SECONDS and FM_REMOTE_JOB_STOP_WAIT_SECONDS.
+# fm_remote_job_wait_until owns that contract and the reasoning behind it.
 
 FM_REMOTE_JOB_LABEL=dev.firstmate.remote-job
 FM_REMOTE_JOB_MAX_BYTES=${FM_REMOTE_JOB_MAX_BYTES:-1048576}
@@ -115,14 +120,13 @@ fm_remote_job_validate_settings() {
 # a healthy machine nothing because every wait still returns on its first
 # successful check.
 #
-# What a wait owes its caller when the clock misbehaves is deliberately narrow,
-# and narrower than several earlier attempts at it. Each of those tried to hold
-# a budget whole across a backwards clock step by re-anchoring the deadline, and
-# each shipped a fresh way to end a wait early instead: the exact "worker did
-# not report ready" failure the deadline exists to prevent. The re-anchor is
-# gone. A backwards reading now simply sits behind the deadline and is not
-# expired, so a backwards step lengthens a wait rather than collapsing its
-# budget, and no arithmetic pretends otherwise.
+# What a wait owes its caller when the clock misbehaves is deliberately narrow.
+# The deadline is anchored once and never re-anchored: a backwards reading
+# simply sits behind it and is not expired, so a backwards step lengthens a wait
+# rather than collapsing its budget, and no arithmetic pretends otherwise. Do
+# not add a re-anchor to hold a budget whole across such a step. Every form of
+# it ends some wait early instead, which is the exact "worker did not report
+# ready" failure the deadline exists to prevent.
 #
 # That leaves termination, which two backstops guarantee unconditionally.
 # FM_REMOTE_JOB_CLOCK_MAX_STALLS bounds consecutive readings that fail to
@@ -159,9 +163,8 @@ fm_remote_job_validate_settings() {
 # fifteen second shutdown wait. The ceiling cannot shorten a budget and cannot
 # be reached in healthy operation, so do not mistake it for a leftover and
 # delete it. Making these waits correct against a clock that is wrong in other
-# ways, a forward step in particular, is deliberately out of scope here and
-# tracked as its own item, so this stays a deadline rather than a clock
-# subsystem.
+# ways, a forward step in particular, is deliberately out of scope, so this
+# stays a deadline rather than a clock subsystem.
 fm_remote_job_clock_now() { # epoch seconds, or nothing when the clock is unreadable
   local now
   now=$(date +%s 2>/dev/null || true)

--- a/bin/fm-remote-job-lib.sh
+++ b/bin/fm-remote-job-lib.sh
@@ -108,12 +108,39 @@ fm_remote_job_validate_settings() {
 # are waiting for. Deadlines make each budget the duration it states, and cost
 # a healthy machine nothing because every wait still returns on its first
 # successful check.
-fm_remote_job_wait_deadline() { # <seconds>; absolute epoch bound for a wait
-  printf '%s\n' "$(($(date +%s) + $1))"
+#
+# The clock is treated as untrustworthy, because a deadline is only a bound
+# while it can be read. A `date` fork that fails under the very memory pressure
+# these waits exist for, or a clock stepped backwards by an NTP correction on a
+# host that just woke from sleep, must never turn a bounded wait into an
+# unbounded one. Every unreadable, implausible, or backwards reading therefore
+# counts as expired: a wait that cannot prove it still has budget left gives up
+# and reports failure, which callers already handle, rather than spinning.
+fm_remote_job_clock_now() { # epoch seconds, or nothing when the clock is unreadable
+  local now
+  now=$(date +%s 2>/dev/null || true)
+  case "$now" in ''|*[!0-9]*) return 1 ;; esac
+  printf '%s\n' "$now"
 }
 
-fm_remote_job_wait_expired() { # <deadline>
-  [ "$(date +%s)" -ge "$1" ]
+# The bound carries its own start, so a reading earlier than the moment the wait
+# began is provably a backwards step and is spent budget rather than fresh time.
+fm_remote_job_wait_deadline() { # <seconds>; "<start>:<deadline>" bound for a wait
+  local now
+  now=$(fm_remote_job_clock_now) || return 0
+  printf '%s:%s\n' "$now" "$((now + $1))"
+}
+
+fm_remote_job_wait_expired() { # <bound from fm_remote_job_wait_deadline>
+  local bound=$1 start deadline now
+  case "$bound" in *:*) ;; *) return 0 ;; esac
+  start=${bound%%:*}
+  deadline=${bound##*:}
+  case "$start" in ''|*[!0-9]*) return 0 ;; esac
+  case "$deadline" in ''|*[!0-9]*) return 0 ;; esac
+  now=$(fm_remote_job_clock_now) || return 0
+  [ "$now" -ge "$start" ] || return 0
+  [ "$now" -ge "$deadline" ]
 }
 
 fm_remote_job_platform() {
@@ -762,10 +789,6 @@ fm_remote_job_worker_process_group() { # <pid>
   printf '%s\n' "$pgid"
 }
 
-# Stop a worker and every descendant it leaked, TERM first and KILL only for a
-# survivor. Signals the isolated worker group when one is provable and the lone
-# process otherwise. Returns non-zero when any verified worker-group member is
-# still alive afterwards.
 # A provable worker group is signalled and tested as a group; otherwise the
 # lone process is, exactly as fm_remote_job_worker_process_group decides.
 fm_remote_job_worker_tree_alive() { # <pid> <pgid-or-empty>

--- a/bin/fm-remote-job-lib.sh
+++ b/bin/fm-remote-job-lib.sh
@@ -113,9 +113,11 @@ fm_remote_job_validate_settings() {
 # while it can be read. A `date` fork that fails under the very memory pressure
 # these waits exist for, or a clock stepped backwards by an NTP correction on a
 # host that just woke from sleep, must never turn a bounded wait into an
-# unbounded one. Every unreadable, implausible, or backwards reading therefore
-# counts as expired: a wait that cannot prove it still has budget left gives up
-# and reports failure, which callers already handle, rather than spinning.
+# unbounded one. Nor may either one silently shorten a budget: giving up at the
+# first bad reading would end a wait with the very "worker did not report ready"
+# failure these deadlines exist to prevent. So every bound carries two
+# independent measures of elapsed time, and a wait ends only when the measure
+# that can still be trusted says the budget is spent.
 fm_remote_job_clock_now() { # epoch seconds, or nothing when the clock is unreadable
   local now
   now=$(date +%s 2>/dev/null || true)
@@ -123,24 +125,45 @@ fm_remote_job_clock_now() { # epoch seconds, or nothing when the clock is unread
   printf '%s\n' "$now"
 }
 
-# The bound carries its own start, so a reading earlier than the moment the wait
-# began is provably a backwards step and is spent budget rather than fresh time.
-fm_remote_job_wait_deadline() { # <seconds>; "<start>:<deadline>" bound for a wait
-  local now
-  now=$(fm_remote_job_clock_now) || return 0
-  printf '%s:%s\n' "$now" "$((now + $1))"
+# The second measure is bash's own SECONDS, which needs no fork and so still
+# advances on a host that has run out of the resources to run `date` at all. It
+# is the safety net rather than the authority, because it is reset by anything
+# that assigns to it and cannot outlive the shell that owns the wait.
+#
+# Establishing a bound retries, because one transient fork failure must not
+# decide what a whole wait is worth. Both measures start at the same instant, so
+# a reading earlier than the start is provably a backwards step: that is spent
+# budget, not fresh time.
+fm_remote_job_wait_deadline() { # <seconds>; opaque bound token for a wait
+  local seconds=$1 now='' attempt=0
+  while :; do
+    now=$(fm_remote_job_clock_now) && break
+    attempt=$((attempt + 1))
+    [ "$attempt" -lt 5 ] || break
+    sleep 0.1
+  done
+  printf '%s:%s:%s:%s\n' "$SECONDS" "$((SECONDS + seconds))" "$now" "${now:+$((now + seconds))}"
+}
+
+# Expired, still running, or 2 for a bound this clock cannot judge at all.
+fm_remote_job_epoch_expired() { # <start> <deadline>
+  local start=$1 deadline=$2 now
+  case "$start" in ''|*[!0-9]*) return 2 ;; esac
+  case "$deadline" in ''|*[!0-9]*) return 2 ;; esac
+  now=$(fm_remote_job_clock_now) || return 2
+  [ "$now" -ge "$start" ] || return 0
+  [ "$now" -ge "$deadline" ]
 }
 
 fm_remote_job_wait_expired() { # <bound from fm_remote_job_wait_deadline>
-  local bound=$1 start deadline now
-  case "$bound" in *:*) ;; *) return 0 ;; esac
-  start=${bound%%:*}
-  deadline=${bound##*:}
-  case "$start" in ''|*[!0-9]*) return 0 ;; esac
-  case "$deadline" in ''|*[!0-9]*) return 0 ;; esac
-  now=$(fm_remote_job_clock_now) || return 0
-  [ "$now" -ge "$start" ] || return 0
-  [ "$now" -ge "$deadline" ]
+  local bound=$1 shell_start shell_deadline epoch_start epoch_deadline verdict=0
+  IFS=: read -r shell_start shell_deadline epoch_start epoch_deadline <<< "$bound"
+  fm_remote_job_epoch_expired "$epoch_start" "$epoch_deadline" || verdict=$?
+  [ "$verdict" -eq 2 ] || return "$verdict"
+  case "$shell_start" in ''|*[!0-9]*) return 0 ;; esac
+  case "$shell_deadline" in ''|*[!0-9]*) return 0 ;; esac
+  [ "$SECONDS" -ge "$shell_start" ] || return 0
+  [ "$SECONDS" -ge "$shell_deadline" ]
 }
 
 fm_remote_job_platform() {
@@ -934,7 +957,7 @@ fm_remote_job_probe() { # <account-home>; a fresh worker heartbeat or active job
   [ -f "$ready" ] && [ ! -L "$ready" ] || return 1
   mtime=$(fm_remote_job_path_mtime "$ready" 2>/dev/null || true)
   case "$mtime" in ''|*[!0-9]*) return 1 ;; esac
-  now=$(date +%s)
+  now=$(fm_remote_job_clock_now) || return 1
   [ $((now - mtime)) -le 10 ]
 }
 

--- a/bin/fm-remote-job-lib.sh
+++ b/bin/fm-remote-job-lib.sh
@@ -60,6 +60,7 @@ FM_REMOTE_JOB_REAP_SECONDS=${FM_REMOTE_JOB_REAP_SECONDS:-3600}
 FM_REMOTE_JOB_PROBE_WAIT_SECONDS=${FM_REMOTE_JOB_PROBE_WAIT_SECONDS:-60}
 FM_REMOTE_JOB_STOP_WAIT_SECONDS=${FM_REMOTE_JOB_STOP_WAIT_SECONDS:-15}
 FM_REMOTE_JOB_CLOCK_MAX_STALLS=${FM_REMOTE_JOB_CLOCK_MAX_STALLS:-50}
+FM_REMOTE_JOB_WAIT_MAX_POLLS_PER_SECOND=${FM_REMOTE_JOB_WAIT_MAX_POLLS_PER_SECOND:-1000}
 FM_REMOTE_JOB_OPERATOR_PATH=
 FM_REMOTE_JOB_CHILD_PATH=
 FM_REMOTE_JOB_STATE=
@@ -100,6 +101,8 @@ fm_remote_job_validate_settings() {
   [ "$FM_REMOTE_JOB_STOP_WAIT_SECONDS" -le 300 ] || return 1
   case "$FM_REMOTE_JOB_CLOCK_MAX_STALLS" in ''|*[!0-9]*|0) return 1 ;; esac
   [ "$FM_REMOTE_JOB_CLOCK_MAX_STALLS" -le 1000 ] || return 1
+  case "$FM_REMOTE_JOB_WAIT_MAX_POLLS_PER_SECOND" in ''|*[!0-9]*|0) return 1 ;; esac
+  [ "$FM_REMOTE_JOB_WAIT_MAX_POLLS_PER_SECOND" -le 100000 ] || return 1
   return 0
 }
 
@@ -113,27 +116,39 @@ fm_remote_job_validate_settings() {
 # successful check.
 #
 # What a wait owes its caller when the clock misbehaves is deliberately narrow,
-# and narrower than three earlier attempts at it. Each of those tried to hold a
-# budget whole across a backwards clock step by re-anchoring the deadline, and
+# and narrower than several earlier attempts at it. Each of those tried to hold
+# a budget whole across a backwards clock step by re-anchoring the deadline, and
 # each shipped a fresh way to end a wait early instead: the exact "worker did
-# not report ready" failure the deadline exists to prevent. The re-anchor was
-# never what made a wait terminate, so it is gone. What remains is one deadline
-# and one counter of consecutive readings that fail to advance the clock, and
-# the counter alone is the termination guarantee, because a clock that is
-# unreadable, frozen, or stepping backwards never advances and so spends that
-# allowance unaided.
+# not report ready" failure the deadline exists to prevent. The re-anchor is
+# gone. A backwards reading now simply sits behind the deadline and is not
+# expired, so a backwards step lengthens a wait rather than collapsing its
+# budget, and no arithmetic pretends otherwise.
 #
-# The guarantees are therefore exactly these. A wait always terminates, whatever
-# the clock does. A backwards step lengthens a wait by the size of the step
-# instead of collapsing its budget, because a reading behind the deadline is
-# simply not expired and no arithmetic pretends otherwise. The allowance is
-# FM_REMOTE_JOB_CLOCK_MAX_STALLS readings, whose headroom is relative to the
-# poll below: `date` has one second resolution, so even a healthy clock repeats
-# a reading about ten times per second of polling, and anyone shortening that
-# sleep has to revisit the bound. Making these waits correct against a clock
-# that is wrong in other ways, a forward step in particular, is deliberately out
-# of scope here and tracked as its own item, so this stays a deadline rather
-# than a clock subsystem.
+# That leaves termination, which two backstops guarantee unconditionally.
+# FM_REMOTE_JOB_CLOCK_MAX_STALLS bounds consecutive readings that fail to
+# advance the clock, unreadable, frozen, or backwards alike, and covers the
+# common broken clock. Its headroom is relative to the poll below: `date` has
+# one second resolution, so even a healthy clock repeats a reading about ten
+# times per second of polling, and anyone shortening that sleep has to revisit
+# the bound. That counter is not enough on its own, because it resets on any
+# advancing reading, so a clock that ticks forward and is corrected backwards
+# again and again never spends it and never reaches the deadline either. No
+# measure taken from the clock can settle that, so the second backstop does not
+# come from the clock: a wait may poll at most
+# FM_REMOTE_JOB_WAIT_MAX_POLLS_PER_SECOND times per second of its budget.
+#
+# That ceiling is a liveness backstop and never a budget, which is the opposite
+# of the counted loop this file replaced. There the count WAS the budget, so a
+# check that grew more expensive under load ate the wait alive and produced the
+# CI flake. This ceiling can only ever fire late: the loop sleeps a tenth of a
+# second per poll, so a healthy wait cannot exceed ten polls per second of
+# budget and the default leaves a hundredfold margin, and an expensive check
+# means fewer polls per second, which moves the ceiling further away rather than
+# closer. It cannot shorten a budget and it cannot be reached in healthy
+# operation, so do not mistake it for a leftover and delete it. Making these
+# waits correct against a clock that is wrong in other ways, a forward step in
+# particular, is deliberately out of scope here and tracked as its own item, so
+# this stays a deadline rather than a clock subsystem.
 fm_remote_job_clock_now() { # epoch seconds, or nothing when the clock is unreadable
   local now
   now=$(date +%s 2>/dev/null || true)
@@ -144,12 +159,15 @@ fm_remote_job_clock_now() { # epoch seconds, or nothing when the clock is unread
 fm_remote_job_wait_until() { # <seconds> <predicate> [args...]
   local seconds=$1
   shift
-  local now deadline='' last='' stalled=0
+  local now deadline='' last='' stalled=0 polls=0 ceiling
+  ceiling=$((seconds * FM_REMOTE_JOB_WAIT_MAX_POLLS_PER_SECOND))
   now=$(fm_remote_job_clock_now) || now=
   last=$now
   [ -z "$now" ] || deadline=$((now + seconds))
   while :; do
     "$@" && return 0
+    polls=$((polls + 1))
+    [ "$polls" -lt "$ceiling" ] || return 1
     now=$(fm_remote_job_clock_now) || now=
     if [ -n "$now" ] && { [ -z "$last" ] || [ "$now" -gt "$last" ]; }; then
       stalled=0

--- a/bin/fm-remote-job-lib.sh
+++ b/bin/fm-remote-job-lib.sh
@@ -59,7 +59,7 @@ FM_REMOTE_JOB_POLL_SECONDS=${FM_REMOTE_JOB_POLL_SECONDS:-0.05}
 FM_REMOTE_JOB_REAP_SECONDS=${FM_REMOTE_JOB_REAP_SECONDS:-3600}
 FM_REMOTE_JOB_PROBE_WAIT_SECONDS=${FM_REMOTE_JOB_PROBE_WAIT_SECONDS:-60}
 FM_REMOTE_JOB_STOP_WAIT_SECONDS=${FM_REMOTE_JOB_STOP_WAIT_SECONDS:-15}
-FM_REMOTE_JOB_CLOCK_MAX_MISSES=${FM_REMOTE_JOB_CLOCK_MAX_MISSES:-50}
+FM_REMOTE_JOB_CLOCK_MAX_STALLS=${FM_REMOTE_JOB_CLOCK_MAX_STALLS:-50}
 FM_REMOTE_JOB_OPERATOR_PATH=
 FM_REMOTE_JOB_CHILD_PATH=
 FM_REMOTE_JOB_STATE=
@@ -98,8 +98,8 @@ fm_remote_job_validate_settings() {
   [ "$FM_REMOTE_JOB_PROBE_WAIT_SECONDS" -le 300 ] || return 1
   case "$FM_REMOTE_JOB_STOP_WAIT_SECONDS" in ''|*[!0-9]*|0) return 1 ;; esac
   [ "$FM_REMOTE_JOB_STOP_WAIT_SECONDS" -le 300 ] || return 1
-  case "$FM_REMOTE_JOB_CLOCK_MAX_MISSES" in ''|*[!0-9]*|0) return 1 ;; esac
-  [ "$FM_REMOTE_JOB_CLOCK_MAX_MISSES" -le 1000 ] || return 1
+  case "$FM_REMOTE_JOB_CLOCK_MAX_STALLS" in ''|*[!0-9]*|0) return 1 ;; esac
+  [ "$FM_REMOTE_JOB_CLOCK_MAX_STALLS" -le 1000 ] || return 1
   return 0
 }
 
@@ -112,23 +112,28 @@ fm_remote_job_validate_settings() {
 # a healthy machine nothing because every wait still returns on its first
 # successful check.
 #
-# What a wait owes its caller when the clock misbehaves is deliberately narrow.
-# It must always terminate, whatever the clock does, and it must never hand back
-# a budget it has not spent: a `date` fork can fail under the very memory
-# pressure these waits exist for, and an NTP correction can step the clock
-# backwards on a host that just woke from sleep, and either one ending a wait
-# early would produce the exact "worker did not report ready" failure the
-# deadline exists to prevent. So a backwards step re-anchors the deadline by the
-# size of the step, and two backstops make termination unconditional whether the
-# clock is unreadable, frozen, stepping backwards, or oscillating. A run of
-# consecutive readings that tell the wait nothing new, unreadable or not
-# advancing, ends it after FM_REMOTE_JOB_CLOCK_MAX_MISSES of them. Re-anchoring
-# stops once it has given back the whole budget, and a backwards reading past
-# that point ends the wait too, which caps the worst case at roughly twice the
-# budget while still absorbing the one-off correction this exists for. Making
-# these waits correct against a clock that is wrong in other ways, a forward
-# step in particular, is out of scope here and tracked as its own item, so this
-# stays a deadline rather than a clock subsystem.
+# What a wait owes its caller when the clock misbehaves is deliberately narrow,
+# and narrower than three earlier attempts at it. Each of those tried to hold a
+# budget whole across a backwards clock step by re-anchoring the deadline, and
+# each shipped a fresh way to end a wait early instead: the exact "worker did
+# not report ready" failure the deadline exists to prevent. The re-anchor was
+# never what made a wait terminate, so it is gone. What remains is one deadline
+# and one counter of consecutive readings that fail to advance the clock, and
+# the counter alone is the termination guarantee, because a clock that is
+# unreadable, frozen, or stepping backwards never advances and so spends that
+# allowance unaided.
+#
+# The guarantees are therefore exactly these. A wait always terminates, whatever
+# the clock does. A backwards step lengthens a wait by the size of the step
+# instead of collapsing its budget, because a reading behind the deadline is
+# simply not expired and no arithmetic pretends otherwise. The allowance is
+# FM_REMOTE_JOB_CLOCK_MAX_STALLS readings, whose headroom is relative to the
+# poll below: `date` has one second resolution, so even a healthy clock repeats
+# a reading about ten times per second of polling, and anyone shortening that
+# sleep has to revisit the bound. Making these waits correct against a clock
+# that is wrong in other ways, a forward step in particular, is deliberately out
+# of scope here and tracked as its own item, so this stays a deadline rather
+# than a clock subsystem.
 fm_remote_job_clock_now() { # epoch seconds, or nothing when the clock is unreadable
   local now
   now=$(date +%s 2>/dev/null || true)
@@ -139,7 +144,7 @@ fm_remote_job_clock_now() { # epoch seconds, or nothing when the clock is unread
 fm_remote_job_wait_until() { # <seconds> <predicate> [args...]
   local seconds=$1
   shift
-  local now deadline='' last='' stalled=0 returned=0 step
+  local now deadline='' last='' stalled=0
   now=$(fm_remote_job_clock_now) || now=
   last=$now
   [ -z "$now" ] || deadline=$((now + seconds))
@@ -150,17 +155,10 @@ fm_remote_job_wait_until() { # <seconds> <predicate> [args...]
       stalled=0
     else
       stalled=$((stalled + 1))
-      [ "$stalled" -lt "$FM_REMOTE_JOB_CLOCK_MAX_MISSES" ] || return 1
+      [ "$stalled" -lt "$FM_REMOTE_JOB_CLOCK_MAX_STALLS" ] || return 1
     fi
     if [ -n "$now" ]; then
-      if [ -z "$deadline" ]; then
-        deadline=$((now + seconds))
-      elif [ -n "$last" ] && [ "$now" -lt "$last" ]; then
-        [ "$returned" -lt "$seconds" ] || return 1
-        step=$((last - now))
-        returned=$((returned + step))
-        deadline=$((deadline - step))
-      fi
+      [ -n "$deadline" ] || deadline=$((now + seconds))
       last=$now
       [ "$now" -lt "$deadline" ] || return 1
     fi

--- a/bin/fm-remote-job-lib.sh
+++ b/bin/fm-remote-job-lib.sh
@@ -59,6 +59,7 @@ FM_REMOTE_JOB_POLL_SECONDS=${FM_REMOTE_JOB_POLL_SECONDS:-0.05}
 FM_REMOTE_JOB_REAP_SECONDS=${FM_REMOTE_JOB_REAP_SECONDS:-3600}
 FM_REMOTE_JOB_PROBE_WAIT_SECONDS=${FM_REMOTE_JOB_PROBE_WAIT_SECONDS:-60}
 FM_REMOTE_JOB_STOP_WAIT_SECONDS=${FM_REMOTE_JOB_STOP_WAIT_SECONDS:-15}
+FM_REMOTE_JOB_CLOCK_MAX_MISSES=${FM_REMOTE_JOB_CLOCK_MAX_MISSES:-50}
 FM_REMOTE_JOB_OPERATOR_PATH=
 FM_REMOTE_JOB_CHILD_PATH=
 FM_REMOTE_JOB_STATE=
@@ -97,6 +98,8 @@ fm_remote_job_validate_settings() {
   [ "$FM_REMOTE_JOB_PROBE_WAIT_SECONDS" -le 300 ] || return 1
   case "$FM_REMOTE_JOB_STOP_WAIT_SECONDS" in ''|*[!0-9]*|0) return 1 ;; esac
   [ "$FM_REMOTE_JOB_STOP_WAIT_SECONDS" -le 300 ] || return 1
+  case "$FM_REMOTE_JOB_CLOCK_MAX_MISSES" in ''|*[!0-9]*|0) return 1 ;; esac
+  [ "$FM_REMOTE_JOB_CLOCK_MAX_MISSES" -le 1000 ] || return 1
   return 0
 }
 
@@ -109,15 +112,17 @@ fm_remote_job_validate_settings() {
 # a healthy machine nothing because every wait still returns on its first
 # successful check.
 #
-# The clock is treated as untrustworthy, because a deadline is only a bound
-# while it can be read. A `date` fork that fails under the very memory pressure
-# these waits exist for, or a clock stepped backwards by an NTP correction on a
-# host that just woke from sleep, must never turn a bounded wait into an
-# unbounded one. Nor may either one silently shorten a budget: giving up at the
-# first bad reading would end a wait with the very "worker did not report ready"
-# failure these deadlines exist to prevent. So every bound carries two
-# independent measures of elapsed time, and a wait ends only when the measure
-# that can still be trusted says the budget is spent.
+# What a wait owes its caller when the clock misbehaves is deliberately narrow.
+# It must always terminate, and it must never hand back a budget it has not
+# spent: a `date` fork can fail under the very memory pressure these waits exist
+# for, and an NTP correction can step the clock backwards on a host that just
+# woke from sleep, and either one ending a wait early would produce the exact
+# "worker did not report ready" failure the deadline exists to prevent. So an
+# unreadable reading is skipped rather than counted, up to a bounded number of
+# consecutive misses that guarantees termination, and a backwards step
+# re-anchors the deadline by the size of the step. Making these waits correct
+# against a clock that is wrong in other ways is out of scope here and tracked
+# as its own item, so this stays a deadline rather than a clock subsystem.
 fm_remote_job_clock_now() { # epoch seconds, or nothing when the clock is unreadable
   local now
   now=$(date +%s 2>/dev/null || true)
@@ -125,45 +130,31 @@ fm_remote_job_clock_now() { # epoch seconds, or nothing when the clock is unread
   printf '%s\n' "$now"
 }
 
-# The second measure is bash's own SECONDS, which needs no fork and so still
-# advances on a host that has run out of the resources to run `date` at all. It
-# is the safety net rather than the authority, because it is reset by anything
-# that assigns to it and cannot outlive the shell that owns the wait.
-#
-# Establishing a bound retries, because one transient fork failure must not
-# decide what a whole wait is worth. Both measures start at the same instant, so
-# a reading earlier than the start is provably a backwards step: that is spent
-# budget, not fresh time.
-fm_remote_job_wait_deadline() { # <seconds>; opaque bound token for a wait
-  local seconds=$1 now='' attempt=0
+fm_remote_job_wait_until() { # <seconds> <predicate> [args...]
+  local seconds=$1
+  shift
+  local now deadline='' last='' misses=0
+  now=$(fm_remote_job_clock_now) || now=
+  last=$now
+  [ -z "$now" ] || deadline=$((now + seconds))
   while :; do
-    now=$(fm_remote_job_clock_now) && break
-    attempt=$((attempt + 1))
-    [ "$attempt" -lt 5 ] || break
+    "$@" && return 0
+    now=$(fm_remote_job_clock_now) || now=
+    if [ -z "$now" ]; then
+      misses=$((misses + 1))
+      [ "$misses" -lt "$FM_REMOTE_JOB_CLOCK_MAX_MISSES" ] || return 1
+    else
+      misses=0
+      if [ -z "$deadline" ]; then
+        deadline=$((now + seconds))
+      elif [ -n "$last" ] && [ "$now" -lt "$last" ]; then
+        deadline=$((deadline - (last - now)))
+      fi
+      last=$now
+      [ "$now" -lt "$deadline" ] || return 1
+    fi
     sleep 0.1
   done
-  printf '%s:%s:%s:%s\n' "$SECONDS" "$((SECONDS + seconds))" "$now" "${now:+$((now + seconds))}"
-}
-
-# Expired, still running, or 2 for a bound this clock cannot judge at all.
-fm_remote_job_epoch_expired() { # <start> <deadline>
-  local start=$1 deadline=$2 now
-  case "$start" in ''|*[!0-9]*) return 2 ;; esac
-  case "$deadline" in ''|*[!0-9]*) return 2 ;; esac
-  now=$(fm_remote_job_clock_now) || return 2
-  [ "$now" -ge "$start" ] || return 0
-  [ "$now" -ge "$deadline" ]
-}
-
-fm_remote_job_wait_expired() { # <bound from fm_remote_job_wait_deadline>
-  local bound=$1 shell_start shell_deadline epoch_start epoch_deadline verdict=0
-  IFS=: read -r shell_start shell_deadline epoch_start epoch_deadline <<< "$bound"
-  fm_remote_job_epoch_expired "$epoch_start" "$epoch_deadline" || verdict=$?
-  [ "$verdict" -eq 2 ] || return "$verdict"
-  case "$shell_start" in ''|*[!0-9]*) return 0 ;; esac
-  case "$shell_deadline" in ''|*[!0-9]*) return 0 ;; esac
-  [ "$SECONDS" -ge "$shell_start" ] || return 0
-  [ "$SECONDS" -ge "$shell_deadline" ]
 }
 
 fm_remote_job_platform() {
@@ -828,13 +819,13 @@ fm_remote_job_signal_worker_tree() { # <signal> <pid> <pgid-or-empty>
   fi
 }
 
+fm_remote_job_worker_tree_exited() { # <pid> <pgid-or-empty>
+  ! fm_remote_job_worker_tree_alive "$1" "$2"
+}
+
 fm_remote_job_wait_for_tree_exit() { # <pid> <pgid-or-empty>
-  local pid=$1 pgid=$2 deadline
-  deadline=$(fm_remote_job_wait_deadline "$FM_REMOTE_JOB_STOP_WAIT_SECONDS")
-  while fm_remote_job_worker_tree_alive "$pid" "$pgid"; do
-    fm_remote_job_wait_expired "$deadline" && return 1
-    sleep 0.1
-  done
+  fm_remote_job_wait_until "$FM_REMOTE_JOB_STOP_WAIT_SECONDS" \
+    fm_remote_job_worker_tree_exited "$1" "$2"
 }
 
 # Stop a worker and every descendant it leaked, TERM first and KILL only for a
@@ -965,14 +956,13 @@ fm_remote_job_probe() { # <account-home>; a fresh worker heartbeat or active job
 # worker reclaiming ownership from a predecessor: that reclaim cannot finish
 # until the predecessor's readiness heartbeat and lock age past their ten
 # second staleness windows. Those windows are wall clock, so this budget is too.
+fm_remote_job_worker_ready() { # <remote-root> <account-home>
+  fm_remote_job_probe "$2" && fm_remote_job_worker_identity_matches "$1" "$2"
+}
+
 fm_remote_job_wait_for_probe() { # <remote-root> <account-home>
-  local root=$1 account_home=$2 deadline
-  deadline=$(fm_remote_job_wait_deadline "$FM_REMOTE_JOB_PROBE_WAIT_SECONDS")
-  while :; do
-    fm_remote_job_probe "$account_home" && fm_remote_job_worker_identity_matches "$root" "$account_home" && return 0
-    fm_remote_job_wait_expired "$deadline" && return 1
-    sleep 0.1
-  done
+  fm_remote_job_wait_until "$FM_REMOTE_JOB_PROBE_WAIT_SECONDS" \
+    fm_remote_job_worker_ready "$1" "$2"
 }
 
 fm_remote_job_write_launchagent() { # <remote-root> <account-home>

--- a/bin/fm-remote-job-lib.sh
+++ b/bin/fm-remote-job-lib.sh
@@ -57,6 +57,8 @@ FM_REMOTE_JOB_TIMEOUT=${FM_REMOTE_JOB_TIMEOUT:-360}
 FM_REMOTE_JOB_WAIT_GRACE=${FM_REMOTE_JOB_WAIT_GRACE:-30}
 FM_REMOTE_JOB_POLL_SECONDS=${FM_REMOTE_JOB_POLL_SECONDS:-0.05}
 FM_REMOTE_JOB_REAP_SECONDS=${FM_REMOTE_JOB_REAP_SECONDS:-3600}
+FM_REMOTE_JOB_PROBE_WAIT_SECONDS=${FM_REMOTE_JOB_PROBE_WAIT_SECONDS:-60}
+FM_REMOTE_JOB_STOP_WAIT_SECONDS=${FM_REMOTE_JOB_STOP_WAIT_SECONDS:-15}
 FM_REMOTE_JOB_OPERATOR_PATH=
 FM_REMOTE_JOB_CHILD_PATH=
 FM_REMOTE_JOB_STATE=
@@ -91,7 +93,27 @@ fm_remote_job_validate_settings() {
   case "$FM_REMOTE_JOB_WAIT_GRACE" in ''|*[!0-9]*) return 1 ;; esac
   [ "$FM_REMOTE_JOB_WAIT_GRACE" -le 300 ] || return 1
   case "$FM_REMOTE_JOB_REAP_SECONDS" in ''|*[!0-9]*|0) return 1 ;; esac
+  case "$FM_REMOTE_JOB_PROBE_WAIT_SECONDS" in ''|*[!0-9]*|0) return 1 ;; esac
+  [ "$FM_REMOTE_JOB_PROBE_WAIT_SECONDS" -le 300 ] || return 1
+  case "$FM_REMOTE_JOB_STOP_WAIT_SECONDS" in ''|*[!0-9]*|0) return 1 ;; esac
+  [ "$FM_REMOTE_JOB_STOP_WAIT_SECONDS" -le 300 ] || return 1
   return 0
+}
+
+# Bounded waits below are denominated in wall-clock seconds, never in a fixed
+# iteration count. A counted loop's real budget is count x (check cost + sleep),
+# so it is only the duration it claims to be on the machine it was tuned on:
+# the readiness wait's nominal 20 seconds measured 21s idle but 33s and 49s on
+# a loaded host, because the checks themselves slow down with the startup they
+# are waiting for. Deadlines make each budget the duration it states, and cost
+# a healthy machine nothing because every wait still returns on its first
+# successful check.
+fm_remote_job_wait_deadline() { # <seconds>; absolute epoch bound for a wait
+  printf '%s\n' "$(($(date +%s) + $1))"
+}
+
+fm_remote_job_wait_expired() { # <deadline>
+  [ "$(date +%s)" -ge "$1" ]
 }
 
 fm_remote_job_platform() {
@@ -744,34 +766,45 @@ fm_remote_job_worker_process_group() { # <pid>
 # survivor. Signals the isolated worker group when one is provable and the lone
 # process otherwise. Returns non-zero when any verified worker-group member is
 # still alive afterwards.
+# A provable worker group is signalled and tested as a group; otherwise the
+# lone process is, exactly as fm_remote_job_worker_process_group decides.
+fm_remote_job_worker_tree_alive() { # <pid> <pgid-or-empty>
+  local pid=$1 pgid=$2
+  if [ -n "$pgid" ]; then kill -0 -- "-$pgid" 2>/dev/null; else kill -0 "$pid" 2>/dev/null; fi
+}
+
+fm_remote_job_signal_worker_tree() { # <signal> <pid> <pgid-or-empty>
+  local signal=$1 pid=$2 pgid=$3
+  if [ -n "$pgid" ]; then
+    kill -"$signal" -- "-$pgid" 2>/dev/null || true
+  else
+    kill -"$signal" "$pid" 2>/dev/null || true
+  fi
+}
+
+fm_remote_job_wait_for_tree_exit() { # <pid> <pgid-or-empty>
+  local pid=$1 pgid=$2 deadline
+  deadline=$(fm_remote_job_wait_deadline "$FM_REMOTE_JOB_STOP_WAIT_SECONDS")
+  while fm_remote_job_worker_tree_alive "$pid" "$pgid"; do
+    fm_remote_job_wait_expired "$deadline" && return 1
+    sleep 0.1
+  done
+}
+
+# Stop a worker and every descendant it leaked, TERM first and KILL only for a
+# survivor. Signals the isolated worker group when one is provable and the lone
+# process otherwise. Returns non-zero when any verified worker-group member is
+# still alive afterwards. Each leg is bounded by wall clock, so a loaded host
+# cannot report a still-shutting-down worker as one that refused to stop.
 fm_remote_job_stop_worker_tree() { # <pid>
-  local pid=$1 pgid i=0
+  local pid=$1 pgid
   case "$pid" in ''|*[!0-9]*) return 1 ;; esac
   [ "$pid" -gt 1 ] || return 1
   pgid=$(fm_remote_job_worker_process_group "$pid" 2>/dev/null || true)
-  if [ -n "$pgid" ]; then kill -TERM -- "-$pgid" 2>/dev/null || true; else kill -TERM "$pid" 2>/dev/null || true; fi
-  while { [ -n "$pgid" ] && kill -0 -- "-$pgid" 2>/dev/null || [ -z "$pgid" ] && kill -0 "$pid" 2>/dev/null; } \
-    && [ "$i" -lt 50 ]; do
-    i=$((i + 1))
-    sleep 0.1
-  done
-  if [ -n "$pgid" ]; then
-    kill -0 -- "-$pgid" 2>/dev/null || return 0
-  else
-    kill -0 "$pid" 2>/dev/null || return 0
-  fi
-  if [ -n "$pgid" ]; then kill -KILL -- "-$pgid" 2>/dev/null || true; else kill -KILL "$pid" 2>/dev/null || true; fi
-  i=0
-  while { [ -n "$pgid" ] && kill -0 -- "-$pgid" 2>/dev/null || [ -z "$pgid" ] && kill -0 "$pid" 2>/dev/null; } \
-    && [ "$i" -lt 50 ]; do
-    i=$((i + 1))
-    sleep 0.1
-  done
-  if [ -n "$pgid" ]; then
-    ! kill -0 -- "-$pgid" 2>/dev/null
-  else
-    ! kill -0 "$pid" 2>/dev/null
-  fi
+  fm_remote_job_signal_worker_tree TERM "$pid" "$pgid"
+  fm_remote_job_wait_for_tree_exit "$pid" "$pgid" && return 0
+  fm_remote_job_signal_worker_tree KILL "$pid" "$pgid"
+  fm_remote_job_wait_for_tree_exit "$pid" "$pgid"
 }
 
 fm_remote_job_read_single_line() {
@@ -882,14 +915,18 @@ fm_remote_job_probe() { # <account-home>; a fresh worker heartbeat or active job
   [ $((now - mtime)) -le 10 ]
 }
 
+# Waits out the worker startup handshake, whose slowest leg is a replacement
+# worker reclaiming ownership from a predecessor: that reclaim cannot finish
+# until the predecessor's readiness heartbeat and lock age past their ten
+# second staleness windows. Those windows are wall clock, so this budget is too.
 fm_remote_job_wait_for_probe() { # <remote-root> <account-home>
-  local root=$1 account_home=$2 i=0
-  while [ "$i" -lt 200 ]; do
+  local root=$1 account_home=$2 deadline
+  deadline=$(fm_remote_job_wait_deadline "$FM_REMOTE_JOB_PROBE_WAIT_SECONDS")
+  while :; do
     fm_remote_job_probe "$account_home" && fm_remote_job_worker_identity_matches "$root" "$account_home" && return 0
-    i=$((i + 1))
+    fm_remote_job_wait_expired "$deadline" && return 1
     sleep 0.1
   done
-  return 1
 }
 
 fm_remote_job_write_launchagent() { # <remote-root> <account-home>

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -620,4 +620,74 @@ wait "$RECOVERY_WORKER_PID" 2>/dev/null || true
 RECOVERY_WORKER_PID=
 pass "quarantine clears only after recorded execution has stopped"
 
+# The readiness wait must spend a budget denominated in wall-clock seconds, so
+# that a host slow enough to delay worker startup cannot also change what the
+# budget is worth. A count-bounded wait fails this with an expensive check: its
+# real cost is count x (check + sleep), which on a loaded host stretched the
+# nominal twenty seconds to 33s and 49s across two runs of the same code.
+# Driving each check far past the loop's own sleep is what separates the two
+# designs, so the stub below makes every probe cost a second.
+BUDGET_SCRIPT="$TMP_ROOT/probe-wait-budget.sh"
+cat > "$BUDGET_SCRIPT" <<'SH'
+#!/usr/bin/env bash
+set -u
+# shellcheck source=/dev/null
+. "$1/bin/fm-remote-job-lib.sh"
+FM_REMOTE_JOB_PROBE_WAIT_SECONDS=$2
+fm_remote_job_probe() { sleep 1; return 1; }
+fm_remote_job_worker_identity_matches() { return 1; }
+start=$(date +%s)
+fm_remote_job_wait_for_probe "$1" "$1" && exit 3
+printf '%s\n' "$(($(date +%s) - start))"
+SH
+chmod 700 "$BUDGET_SCRIPT"
+# The outer bound both proves the wait terminates and keeps a count-bounded
+# regression from burning minutes of a probe-per-second loop before it reports.
+BUDGET_ELAPSED=$(timeout 40 bash "$BUDGET_SCRIPT" "$REMOTE_ROOT" 3) \
+  || fail "the readiness wait did not honor a wall-clock budget when every probe was slow"
+case "$BUDGET_ELAPSED" in ''|*[!0-9]*) fail "the readiness wait did not report its elapsed budget" ;; esac
+[ "$BUDGET_ELAPSED" -ge 3 ] || fail "the readiness wait gave up before spending its configured budget"
+[ "$BUDGET_ELAPSED" -le 15 ] || fail "the readiness wait overran its configured budget under a slow probe"
+pass "the readiness wait spends a wall-clock budget regardless of probe cost"
+
+# Same budget, a probe an order of magnitude slower: a wall-clock bound holds
+# where a counted one would scale straight up with the per-check cost.
+cat > "$BUDGET_SCRIPT" <<'SH'
+#!/usr/bin/env bash
+set -u
+# shellcheck source=/dev/null
+. "$1/bin/fm-remote-job-lib.sh"
+FM_REMOTE_JOB_PROBE_WAIT_SECONDS=$2
+fm_remote_job_probe() { sleep 10; return 1; }
+fm_remote_job_worker_identity_matches() { return 1; }
+start=$(date +%s)
+fm_remote_job_wait_for_probe "$1" "$1" && exit 3
+printf '%s\n' "$(($(date +%s) - start))"
+SH
+BUDGET_ELAPSED=$(timeout 60 bash "$BUDGET_SCRIPT" "$REMOTE_ROOT" 3) \
+  || fail "a ten-times slower probe broke the readiness wait's wall-clock budget"
+# One in-flight probe may always finish, so the bound is the budget plus a
+# single check, never a multiple of the check cost.
+[ "$BUDGET_ELAPSED" -le 25 ] || fail "the readiness wait scaled with probe cost instead of holding its budget"
+pass "the readiness wait's budget does not scale with a slower probe"
+
+# A ready worker must still be observed immediately, so the wall-clock bound
+# is a ceiling on failure and never a floor a healthy host has to sit through.
+cat > "$BUDGET_SCRIPT" <<'SH'
+#!/usr/bin/env bash
+set -u
+# shellcheck source=/dev/null
+. "$1/bin/fm-remote-job-lib.sh"
+FM_REMOTE_JOB_PROBE_WAIT_SECONDS=120
+fm_remote_job_probe() { return 0; }
+fm_remote_job_worker_identity_matches() { return 0; }
+start=$(date +%s)
+fm_remote_job_wait_for_probe "$1" "$1" || exit 3
+printf '%s\n' "$(($(date +%s) - start))"
+SH
+BUDGET_ELAPSED=$(timeout 30 bash "$BUDGET_SCRIPT" "$REMOTE_ROOT") \
+  || fail "the readiness wait did not return as soon as the worker reported ready"
+[ "$BUDGET_ELAPSED" -le 5 ] || fail "a ready worker was made to wait out the readiness budget"
+pass "the readiness wait returns immediately once the worker reports ready"
+
 echo "ALL TESTS PASSED"

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -772,7 +772,11 @@ pass "a transient clock-read failure does not shorten the readiness budget"
 # backwards once, mid-wait. None of the budget was spent by that step, so none
 # of it may be lost to it. The wait therefore has to still be waiting well after
 # the budget it was configured with would otherwise have run out, which is what
-# an outer bound the wait deliberately outlives proves.
+# an outer bound the wait deliberately outlives proves. The step is armed on the
+# reading it lands after rather than on an instant, because the wait's first
+# reading is the one that anchors the deadline: arming on the clock would race
+# that read, and a step that landed first would anchor the deadline in
+# already-stepped time and make the wait end on schedule after all.
 cat > "$CLOCK_SCRIPT" <<'SH'
 #!/usr/bin/env bash
 set -u
@@ -780,11 +784,14 @@ set -u
 . "$1/bin/fm-remote-job-lib.sh"
 FM_REMOTE_JOB_PROBE_WAIT_SECONDS=$2
 start=$(command date +%s)
-export FM_STEP_AFTER=$((start + 1))
-date() { # one hour backwards, a second in, and forwards as usual after that
-  local now
+STEP_FILE=$3
+printf '0\n' > "$STEP_FILE"
+date() { # the third reading onwards lands an hour behind the ones before it
+  local reads now
+  reads=$(($(cat "$STEP_FILE") + 1))
+  printf '%s\n' "$reads" > "$STEP_FILE"
   now=$(command date +%s)
-  if [ "$now" -ge "$FM_STEP_AFTER" ]; then now=$((now - 3600)); fi
+  [ "$reads" -lt 3 ] || now=$((now - 3600))
   printf '%s\n' "$now"
 }
 fm_remote_job_probe() { return 1; }
@@ -793,9 +800,12 @@ fm_remote_job_wait_for_probe "$1" "$1" && exit 3
 printf '%s\n' "$(($(command date +%s) - start))"
 SH
 BACKSTEP_STATUS=0
-fm_run_timed 10 bash "$CLOCK_SCRIPT" "$REMOTE_ROOT" 3 >/dev/null 2>&1 || BACKSTEP_STATUS=$?
+fm_run_timed 10 bash "$CLOCK_SCRIPT" "$REMOTE_ROOT" 3 "$TMP_ROOT/clock-backstep" >/dev/null 2>&1 \
+  || BACKSTEP_STATUS=$?
 [ "$BACKSTEP_STATUS" -eq 124 ] \
   || fail "a backwards clock step ended the readiness wait early, exit $BACKSTEP_STATUS against a budget of 3s"
+[ "$(cat "$TMP_ROOT/clock-backstep")" -gt 3 ] \
+  || fail "the readiness wait never read the clock past the backwards step"
 pass "a backwards clock step lengthens the readiness wait instead of collapsing its budget"
 
 # That leniency is only safe because it is not what makes a wait end. A clock
@@ -906,6 +916,31 @@ run_wait_script "$CLOCK_SCRIPT" 40 "the readiness wait with an oscillating clock
   "$REMOTE_ROOT" 3 "$TMP_ROOT/clock-oscillate" 20
 [ "$WAIT_ELAPSED" -le 30 ] || fail "an oscillating clock outran the readiness wait's poll ceiling"
 pass "the readiness wait ends against a clock that never moves forwards on balance"
+
+# The ceiling exists for that pathological clock and must stay out of the way of
+# every legitimate one, or it becomes a second budget and rebuilds the counted
+# loop this change removed. The loaded host is where that would bite, so this
+# drives the wait with a check as expensive as a loaded host makes it. At the
+# shipped fifty polls per second of budget the ceiling here is three hundred
+# polls, and each one costs at least the two seconds the probe sleeps, so the
+# ceiling could not end this wait before ten minutes. Finishing anywhere near
+# the budget therefore proves the deadline ended it.
+cat > "$CLOCK_SCRIPT" <<'SH'
+#!/usr/bin/env bash
+set -u
+# shellcheck source=/dev/null
+. "$1/bin/fm-remote-job-lib.sh"
+FM_REMOTE_JOB_PROBE_WAIT_SECONDS=$2
+start=$(command date +%s)
+fm_remote_job_probe() { sleep 2; return 1; }
+fm_remote_job_worker_identity_matches() { return 1; }
+fm_remote_job_wait_for_probe "$1" "$1" && exit 3
+printf '%s\n' "$(($(command date +%s) - start))"
+SH
+run_wait_script "$CLOCK_SCRIPT" 40 "the readiness wait under a two-second probe" "$REMOTE_ROOT" 6
+[ "$WAIT_ELAPSED" -ge 6 ] || fail "an expensive probe cut the readiness wait short of its budget"
+[ "$WAIT_ELAPSED" -le 20 ] || fail "an expensive probe drove the readiness wait toward its poll ceiling"
+pass "an expensive probe leaves the readiness wait ending on its deadline, nowhere near its poll ceiling"
 
 # The shutdown wait shares the mechanism, so it needs the same guarantee: a
 # worker that never exits plus a clock that cannot be read must still end in a

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -712,10 +712,10 @@ pass "the readiness wait returns immediately once the worker reports ready"
 # fail, and the readiness wait runs on the remote side of an ssh invocation that
 # has no client-side bound of its own, so an unreadable clock must still end the
 # wait rather than leave it spinning against a deadline it can never reach. It
-# must end it on time, though, and not early: collapsing the budget to nothing
-# would report the same "worker did not report ready" failure these deadlines
-# exist to prevent, so the wait has to spend what it was configured to spend
-# using whatever measure of elapsed time it has left.
+# It must not end it early either: a wait that gave up at the first unreadable
+# reading would report the same "worker did not report ready" failure these
+# deadlines exist to prevent. So a clock that can never be read ends the wait
+# only after a bounded run of consecutive misses.
 CLOCK_SCRIPT="$TMP_ROOT/probe-wait-clock.sh"
 cat > "$CLOCK_SCRIPT" <<'SH'
 #!/usr/bin/env bash
@@ -723,6 +723,7 @@ set -u
 # shellcheck source=/dev/null
 . "$1/bin/fm-remote-job-lib.sh"
 FM_REMOTE_JOB_PROBE_WAIT_SECONDS=$2
+FM_REMOTE_JOB_CLOCK_MAX_MISSES=$3
 start=$(command date +%s)
 date() { return 1; }
 fm_remote_job_probe() { return 1; }
@@ -731,10 +732,10 @@ fm_remote_job_wait_for_probe "$1" "$1" && exit 3
 printf '%s\n' "$(($(command date +%s) - start))"
 SH
 chmod 700 "$CLOCK_SCRIPT"
-run_wait_script "$CLOCK_SCRIPT" 20 "the readiness wait with an unreadable clock" "$REMOTE_ROOT" 3
+run_wait_script "$CLOCK_SCRIPT" 20 "the readiness wait with an unreadable clock" "$REMOTE_ROOT" 60 30
 [ "$WAIT_ELAPSED" -ge 2 ] || fail "an unreadable clock collapsed the readiness budget into an instant failure"
 [ "$WAIT_ELAPSED" -le 15 ] || fail "an unreadable clock let the readiness wait outlast its own budget"
-pass "the readiness wait spends its budget and still terminates when the clock cannot be read"
+pass "the readiness wait spends its miss allowance and still terminates when the clock cannot be read"
 
 # The realistic clock failure is transient: one `date` fork loses a race for
 # memory and the next one wins. Establishing the bound must survive that, or a
@@ -767,36 +768,33 @@ run_wait_script "$CLOCK_SCRIPT" 30 "the readiness wait with a briefly unreadable
 [ "$WAIT_ELAPSED" -le 20 ] || fail "a recovered clock did not resume bounding the readiness wait"
 pass "a transient clock-read failure does not shorten the readiness budget"
 
-# A clock stepped backwards - an NTP correction on a host that just woke from
-# sleep - is the same hazard in the other direction: the deadline recedes as
-# fast as the wait approaches it. A reading earlier than the moment the wait
-# began is spent budget, not fresh time.
+# An NTP correction on a host that just woke from sleep steps the clock
+# backwards once, mid-wait. None of the budget was spent by that step, so none
+# of it may be lost to it: the wait re-anchors its deadline and goes on to spend
+# the time it was configured to spend, then still ends.
 cat > "$CLOCK_SCRIPT" <<'SH'
 #!/usr/bin/env bash
 set -u
 # shellcheck source=/dev/null
 . "$1/bin/fm-remote-job-lib.sh"
-FM_REMOTE_JOB_PROBE_WAIT_SECONDS=120
+FM_REMOTE_JOB_PROBE_WAIT_SECONDS=$2
 start=$(command date +%s)
-# A stub reading is taken in a command substitution, so the step it advances
-# has to outlive that subshell to keep the clock moving between readings.
-STEP_FILE=$2
-printf '0\n' > "$STEP_FILE"
-date() { # every reading lands five minutes before the one before it
-  local step
-  step=$(($(cat "$STEP_FILE") + 1))
-  printf '%s\n' "$step" > "$STEP_FILE"
-  printf '%s\n' "$((2000000000 - step * 300))"
+export FM_STEP_AFTER=$((start + 2))
+date() { # one hour backwards, two seconds in, and forwards as usual after that
+  local now
+  now=$(command date +%s)
+  if [ "$now" -ge "$FM_STEP_AFTER" ]; then now=$((now - 3600)); fi
+  printf '%s\n' "$now"
 }
 fm_remote_job_probe() { return 1; }
 fm_remote_job_worker_identity_matches() { return 1; }
 fm_remote_job_wait_for_probe "$1" "$1" && exit 3
 printf '%s\n' "$(($(command date +%s) - start))"
 SH
-run_wait_script "$CLOCK_SCRIPT" 20 "the readiness wait with a backwards clock" \
-  "$REMOTE_ROOT" "$TMP_ROOT/clock-step"
-[ "$WAIT_ELAPSED" -le 10 ] || fail "a backwards clock stretched the readiness wait past its budget"
-pass "the readiness wait gives up rather than chase a clock stepping backwards"
+run_wait_script "$CLOCK_SCRIPT" 30 "the readiness wait with a backwards clock step" "$REMOTE_ROOT" 5
+[ "$WAIT_ELAPSED" -ge 4 ] || fail "a backwards clock step threw away readiness budget the wait had not spent"
+[ "$WAIT_ELAPSED" -le 20 ] || fail "a backwards clock step stretched the readiness wait past its budget"
+pass "the readiness wait keeps its budget across a backwards clock step and still ends"
 
 # The shutdown wait shares the mechanism, so it needs the same guarantee: a
 # worker that never exits plus a clock that cannot be read must still end in a
@@ -807,6 +805,7 @@ set -u
 # shellcheck source=/dev/null
 . "$1/bin/fm-remote-job-lib.sh"
 FM_REMOTE_JOB_STOP_WAIT_SECONDS=$2
+FM_REMOTE_JOB_CLOCK_MAX_MISSES=$3
 start=$(command date +%s)
 date() { return 1; }
 fm_remote_job_worker_process_group() { return 1; }
@@ -815,7 +814,7 @@ fm_remote_job_worker_tree_alive() { return 0; }
 fm_remote_job_stop_worker_tree 999999 && exit 3
 printf '%s\n' "$(($(command date +%s) - start))"
 SH
-run_wait_script "$CLOCK_SCRIPT" 30 "the shutdown wait with an unreadable clock" "$REMOTE_ROOT" 3
+run_wait_script "$CLOCK_SCRIPT" 30 "the shutdown wait with an unreadable clock" "$REMOTE_ROOT" 15 20
 [ "$WAIT_ELAPSED" -le 20 ] || fail "an unreadable clock let the shutdown wait outlast its own budget"
 pass "the shutdown wait reports a surviving worker rather than spin on an unreadable clock"
 

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -704,7 +704,7 @@ fm_remote_job_wait_for_probe "$1" "$1" || exit 3
 printf '%s\n' "$(($(date +%s) - start))"
 SH
 run_wait_script "$BUDGET_SCRIPT" 30 "the readiness wait for a worker already ready" "$REMOTE_ROOT"
-[ "$WAIT_ELAPSED" -le 5 ] || fail "a ready worker was made to wait out the readiness budget"
+[ "$WAIT_ELAPSED" -le 10 ] || fail "a ready worker was made to wait out the readiness budget"
 pass "the readiness wait returns immediately once the worker reports ready"
 
 # A deadline is only a bound while the clock can be read. Under the memory
@@ -732,9 +732,9 @@ fm_remote_job_wait_for_probe "$1" "$1" && exit 3
 printf '%s\n' "$(($(command date +%s) - start))"
 SH
 chmod 700 "$CLOCK_SCRIPT"
-run_wait_script "$CLOCK_SCRIPT" 20 "the readiness wait with an unreadable clock" "$REMOTE_ROOT" 60 30
+run_wait_script "$CLOCK_SCRIPT" 30 "the readiness wait with an unreadable clock" "$REMOTE_ROOT" 60 30
 [ "$WAIT_ELAPSED" -ge 2 ] || fail "an unreadable clock collapsed the readiness budget into an instant failure"
-[ "$WAIT_ELAPSED" -le 15 ] || fail "an unreadable clock let the readiness wait outlast its own budget"
+[ "$WAIT_ELAPSED" -le 25 ] || fail "an unreadable clock let the readiness wait outlast its own budget"
 pass "the readiness wait spends its miss allowance and still terminates when the clock cannot be read"
 
 # The realistic clock failure is transient: one `date` fork loses a race for
@@ -825,9 +825,9 @@ fm_remote_job_wait_for_probe "$1" "$1" && exit 3
 [ "$(cat "$STEP_FILE")" -gt 1 ] || exit 4
 printf '%s\n' "$(($(command date +%s) - start))"
 SH
-run_wait_script "$CLOCK_SCRIPT" 30 "the readiness wait with a clock that only goes backwards" \
+run_wait_script "$CLOCK_SCRIPT" 40 "the readiness wait with a clock that only goes backwards" \
   "$REMOTE_ROOT" 60 "$TMP_ROOT/clock-back"
-[ "$WAIT_ELAPSED" -le 20 ] || fail "a clock that only goes backwards outran the readiness wait's budget"
+[ "$WAIT_ELAPSED" -le 30 ] || fail "a clock that only goes backwards outran the readiness wait's budget"
 pass "the readiness wait ends against a clock that never moves forwards"
 
 # A clock stopped dead reads perfectly and never reaches any deadline, so the
@@ -845,30 +845,67 @@ fm_remote_job_worker_identity_matches() { return 1; }
 fm_remote_job_wait_for_probe "$1" "$1" && exit 3
 printf '%s\n' "$(($(command date +%s) - start))"
 SH
-run_wait_script "$CLOCK_SCRIPT" 30 "the readiness wait with a frozen clock" "$REMOTE_ROOT" 60
-[ "$WAIT_ELAPSED" -le 20 ] || fail "a frozen clock outran the readiness wait's budget"
+run_wait_script "$CLOCK_SCRIPT" 40 "the readiness wait with a frozen clock" "$REMOTE_ROOT" 60
+[ "$WAIT_ELAPSED" -le 30 ] || fail "a frozen clock outran the readiness wait's budget"
 pass "the readiness wait ends against a clock that never moves at all"
 
 # The allowance is a backstop, not a second budget, so a healthy clock must
 # reach its deadline first. `date` only resolves to a second, so a wait polling
-# ten times a second repeats each reading about ten times over, and the
-# allowance has to keep enough headroom above that to never fire here.
+# ten times a second repeats each reading about ten times over, and an allowance
+# of twenty is the tightest headroom above that worth running: were the repeats
+# to spend it, the wait would end after two seconds instead of five, and the
+# lower bound below is what catches that.
 cat > "$CLOCK_SCRIPT" <<'SH'
 #!/usr/bin/env bash
 set -u
 # shellcheck source=/dev/null
 . "$1/bin/fm-remote-job-lib.sh"
 FM_REMOTE_JOB_PROBE_WAIT_SECONDS=$2
+FM_REMOTE_JOB_CLOCK_MAX_STALLS=$3
 start=$(command date +%s)
 fm_remote_job_probe() { return 1; }
 fm_remote_job_worker_identity_matches() { return 1; }
 fm_remote_job_wait_for_probe "$1" "$1" && exit 3
 printf '%s\n' "$(($(command date +%s) - start))"
 SH
-run_wait_script "$CLOCK_SCRIPT" 20 "the readiness wait on a healthy clock" "$REMOTE_ROOT" 3
-[ "$WAIT_ELAPSED" -ge 3 ] || fail "the readiness wait ended before its deadline on a healthy clock"
-[ "$WAIT_ELAPSED" -le 4 ] || fail "a healthy clock ran the readiness wait past its deadline into the stall allowance"
+run_wait_script "$CLOCK_SCRIPT" 30 "the readiness wait on a healthy clock" "$REMOTE_ROOT" 5 20
+[ "$WAIT_ELAPSED" -ge 5 ] || fail "a healthy clock ended the readiness wait on its stall allowance instead of its deadline"
+[ "$WAIT_ELAPSED" -le 15 ] || fail "a healthy clock ran the readiness wait well past its deadline"
 pass "the readiness wait ends on its deadline, not its stall allowance, when the clock is healthy"
+
+# The stall allowance resets on any advancing reading, so it cannot end a wait
+# on a clock that ticks forward and is corrected backwards again and again: that
+# clock never advances on balance, so it never reaches the deadline either. The
+# poll ceiling is what ends this one, and it is the only bound here that does
+# not come from the clock. The stub alternates between two readings for a net
+# movement of zero, holds its position in a file because it runs inside a
+# command substitution, and refuses to pass unless it really did oscillate.
+cat > "$CLOCK_SCRIPT" <<'SH'
+#!/usr/bin/env bash
+set -u
+# shellcheck source=/dev/null
+. "$1/bin/fm-remote-job-lib.sh"
+FM_REMOTE_JOB_PROBE_WAIT_SECONDS=$2
+FM_REMOTE_JOB_WAIT_MAX_POLLS_PER_SECOND=$4
+start=$(command date +%s)
+STEP_FILE=$3
+printf '0\n' > "$STEP_FILE"
+date() { # one second forwards, one second back, for ever
+  local step
+  step=$(($(cat "$STEP_FILE") + 1))
+  printf '%s\n' "$step" > "$STEP_FILE"
+  printf '%s\n' "$((2000000000 + step % 2))"
+}
+fm_remote_job_probe() { return 1; }
+fm_remote_job_worker_identity_matches() { return 1; }
+fm_remote_job_wait_for_probe "$1" "$1" && exit 3
+[ "$(cat "$STEP_FILE")" -gt 1 ] || exit 4
+printf '%s\n' "$(($(command date +%s) - start))"
+SH
+run_wait_script "$CLOCK_SCRIPT" 40 "the readiness wait with an oscillating clock" \
+  "$REMOTE_ROOT" 3 "$TMP_ROOT/clock-oscillate" 20
+[ "$WAIT_ELAPSED" -le 30 ] || fail "an oscillating clock outran the readiness wait's poll ceiling"
+pass "the readiness wait ends against a clock that never moves forwards on balance"
 
 # The shutdown wait shares the mechanism, so it needs the same guarantee: a
 # worker that never exits plus a clock that cannot be read must still end in a
@@ -888,8 +925,8 @@ fm_remote_job_worker_tree_alive() { return 0; }
 fm_remote_job_stop_worker_tree 999999 && exit 3
 printf '%s\n' "$(($(command date +%s) - start))"
 SH
-run_wait_script "$CLOCK_SCRIPT" 30 "the shutdown wait with an unreadable clock" "$REMOTE_ROOT" 15 20
-[ "$WAIT_ELAPSED" -le 20 ] || fail "an unreadable clock let the shutdown wait outlast its own budget"
+run_wait_script "$CLOCK_SCRIPT" 40 "the shutdown wait with an unreadable clock" "$REMOTE_ROOT" 15 20
+[ "$WAIT_ELAPSED" -le 30 ] || fail "an unreadable clock let the shutdown wait outlast its own budget"
 pass "the shutdown wait reports a surviving worker rather than spin on an unreadable clock"
 
 # The shutdown budget needs the same cost asymmetry the readiness tests use, or
@@ -913,8 +950,8 @@ run_wait_script "$CLOCK_SCRIPT" 40 "the shutdown wait under a one-second livenes
   "$REMOTE_ROOT" 3
 # Two legs, TERM then KILL, each spending its own budget plus at most the one
 # check already in flight when the budget ran out.
-[ "$WAIT_ELAPSED" -ge 5 ] || fail "the shutdown wait gave up before spending its configured budget"
-[ "$WAIT_ELAPSED" -le 20 ] || fail "the shutdown wait scaled with liveness-check cost instead of holding its budget"
+[ "$WAIT_ELAPSED" -ge 4 ] || fail "the shutdown wait gave up before spending its configured budget"
+[ "$WAIT_ELAPSED" -le 25 ] || fail "the shutdown wait scaled with liveness-check cost instead of holding its budget"
 pass "the shutdown wait spends a wall-clock budget regardless of liveness-check cost"
 
 # The wait's collaborator has to fail in the same direction it does. The probe

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -711,7 +711,7 @@ pass "the readiness wait returns immediately once the worker reports ready"
 # pressure these waits exist for, the `date` fork is itself a thing that can
 # fail, and the readiness wait runs on the remote side of an ssh invocation that
 # has no client-side bound of its own, so an unreadable clock must still end the
-# wait rather than leave it spinning against a deadline it can never reach. It
+# wait rather than leave it spinning against a deadline it can never reach.
 # It must not end it early either: a wait that gave up at the first unreadable
 # reading would report the same "worker did not report ready" failure these
 # deadlines exist to prevent. So a clock that can never be read ends the wait
@@ -795,6 +795,36 @@ run_wait_script "$CLOCK_SCRIPT" 30 "the readiness wait with a backwards clock st
 [ "$WAIT_ELAPSED" -ge 4 ] || fail "a backwards clock step threw away readiness budget the wait had not spent"
 [ "$WAIT_ELAPSED" -le 20 ] || fail "a backwards clock step stretched the readiness wait past its budget"
 pass "the readiness wait keeps its budget across a backwards clock step and still ends"
+
+# Giving the budget back for a backwards step is only safe while the giving back
+# is bounded. A clock that keeps stepping backwards hands back exactly as much
+# as the wait spends, so a deadline that re-anchored every time would recede
+# forever against a clock that reads perfectly well. The wait stops re-anchoring
+# once it has given back its whole budget, and ends there.
+cat > "$CLOCK_SCRIPT" <<'SH'
+#!/usr/bin/env bash
+set -u
+# shellcheck source=/dev/null
+. "$1/bin/fm-remote-job-lib.sh"
+FM_REMOTE_JOB_PROBE_WAIT_SECONDS=$2
+start=$(command date +%s)
+STEP_FILE=$3
+printf '0\n' > "$STEP_FILE"
+date() { # every reading lands a second before the one before it
+  local step
+  step=$(($(cat "$STEP_FILE") + 1))
+  printf '%s\n' "$step" > "$STEP_FILE"
+  printf '%s\n' "$((2000000000 - step))"
+}
+fm_remote_job_probe() { return 1; }
+fm_remote_job_worker_identity_matches() { return 1; }
+fm_remote_job_wait_for_probe "$1" "$1" && exit 3
+printf '%s\n' "$(($(command date +%s) - start))"
+SH
+run_wait_script "$CLOCK_SCRIPT" 30 "the readiness wait with a clock that only goes backwards" \
+  "$REMOTE_ROOT" 5 "$TMP_ROOT/clock-back"
+[ "$WAIT_ELAPSED" -le 20 ] || fail "a clock that only goes backwards outran the readiness wait's budget"
+pass "the readiness wait ends against a clock that never moves forwards"
 
 # The shutdown wait shares the mechanism, so it needs the same guarantee: a
 # worker that never exits plus a clock that cannot be read must still end in a

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -723,7 +723,7 @@ set -u
 # shellcheck source=/dev/null
 . "$1/bin/fm-remote-job-lib.sh"
 FM_REMOTE_JOB_PROBE_WAIT_SECONDS=$2
-FM_REMOTE_JOB_CLOCK_MAX_MISSES=$3
+FM_REMOTE_JOB_CLOCK_MAX_STALLS=$3
 start=$(command date +%s)
 date() { return 1; }
 fm_remote_job_probe() { return 1; }
@@ -770,8 +770,9 @@ pass "a transient clock-read failure does not shorten the readiness budget"
 
 # An NTP correction on a host that just woke from sleep steps the clock
 # backwards once, mid-wait. None of the budget was spent by that step, so none
-# of it may be lost to it: the wait re-anchors its deadline and goes on to spend
-# the time it was configured to spend, then still ends.
+# of it may be lost to it. The wait therefore has to still be waiting well after
+# the budget it was configured with would otherwise have run out, which is what
+# an outer bound the wait deliberately outlives proves.
 cat > "$CLOCK_SCRIPT" <<'SH'
 #!/usr/bin/env bash
 set -u
@@ -779,8 +780,8 @@ set -u
 . "$1/bin/fm-remote-job-lib.sh"
 FM_REMOTE_JOB_PROBE_WAIT_SECONDS=$2
 start=$(command date +%s)
-export FM_STEP_AFTER=$((start + 2))
-date() { # one hour backwards, two seconds in, and forwards as usual after that
+export FM_STEP_AFTER=$((start + 1))
+date() { # one hour backwards, a second in, and forwards as usual after that
   local now
   now=$(command date +%s)
   if [ "$now" -ge "$FM_STEP_AFTER" ]; then now=$((now - 3600)); fi
@@ -791,16 +792,18 @@ fm_remote_job_worker_identity_matches() { return 1; }
 fm_remote_job_wait_for_probe "$1" "$1" && exit 3
 printf '%s\n' "$(($(command date +%s) - start))"
 SH
-run_wait_script "$CLOCK_SCRIPT" 30 "the readiness wait with a backwards clock step" "$REMOTE_ROOT" 5
-[ "$WAIT_ELAPSED" -ge 4 ] || fail "a backwards clock step threw away readiness budget the wait had not spent"
-[ "$WAIT_ELAPSED" -le 20 ] || fail "a backwards clock step stretched the readiness wait past its budget"
-pass "the readiness wait keeps its budget across a backwards clock step and still ends"
+BACKSTEP_STATUS=0
+fm_run_timed 10 bash "$CLOCK_SCRIPT" "$REMOTE_ROOT" 3 >/dev/null 2>&1 || BACKSTEP_STATUS=$?
+[ "$BACKSTEP_STATUS" -eq 124 ] \
+  || fail "a backwards clock step ended the readiness wait early, exit $BACKSTEP_STATUS against a budget of 3s"
+pass "a backwards clock step lengthens the readiness wait instead of collapsing its budget"
 
-# Giving the budget back for a backwards step is only safe while the giving back
-# is bounded. A clock that keeps stepping backwards hands back exactly as much
-# as the wait spends, so a deadline that re-anchored every time would recede
-# forever against a clock that reads perfectly well. The wait stops re-anchoring
-# once it has given back its whole budget, and ends there.
+# That leniency is only safe because it is not what makes a wait end. A clock
+# that steps backwards on every reading never advances, so it spends the same
+# allowance an unreadable one does and the wait ends without the deadline ever
+# being reached. The stub keeps its position in a file because it runs inside a
+# command substitution, and the script refuses to pass unless the clock really
+# did move, so this cannot go green as an accidental frozen-clock test.
 cat > "$CLOCK_SCRIPT" <<'SH'
 #!/usr/bin/env bash
 set -u
@@ -819,12 +822,53 @@ date() { # every reading lands a second before the one before it
 fm_remote_job_probe() { return 1; }
 fm_remote_job_worker_identity_matches() { return 1; }
 fm_remote_job_wait_for_probe "$1" "$1" && exit 3
+[ "$(cat "$STEP_FILE")" -gt 1 ] || exit 4
 printf '%s\n' "$(($(command date +%s) - start))"
 SH
 run_wait_script "$CLOCK_SCRIPT" 30 "the readiness wait with a clock that only goes backwards" \
-  "$REMOTE_ROOT" 5 "$TMP_ROOT/clock-back"
+  "$REMOTE_ROOT" 60 "$TMP_ROOT/clock-back"
 [ "$WAIT_ELAPSED" -le 20 ] || fail "a clock that only goes backwards outran the readiness wait's budget"
 pass "the readiness wait ends against a clock that never moves forwards"
+
+# A clock stopped dead reads perfectly and never reaches any deadline, so the
+# same allowance has to end the wait here too.
+cat > "$CLOCK_SCRIPT" <<'SH'
+#!/usr/bin/env bash
+set -u
+# shellcheck source=/dev/null
+. "$1/bin/fm-remote-job-lib.sh"
+FM_REMOTE_JOB_PROBE_WAIT_SECONDS=$2
+start=$(command date +%s)
+date() { printf '2000000000\n'; }
+fm_remote_job_probe() { return 1; }
+fm_remote_job_worker_identity_matches() { return 1; }
+fm_remote_job_wait_for_probe "$1" "$1" && exit 3
+printf '%s\n' "$(($(command date +%s) - start))"
+SH
+run_wait_script "$CLOCK_SCRIPT" 30 "the readiness wait with a frozen clock" "$REMOTE_ROOT" 60
+[ "$WAIT_ELAPSED" -le 20 ] || fail "a frozen clock outran the readiness wait's budget"
+pass "the readiness wait ends against a clock that never moves at all"
+
+# The allowance is a backstop, not a second budget, so a healthy clock must
+# reach its deadline first. `date` only resolves to a second, so a wait polling
+# ten times a second repeats each reading about ten times over, and the
+# allowance has to keep enough headroom above that to never fire here.
+cat > "$CLOCK_SCRIPT" <<'SH'
+#!/usr/bin/env bash
+set -u
+# shellcheck source=/dev/null
+. "$1/bin/fm-remote-job-lib.sh"
+FM_REMOTE_JOB_PROBE_WAIT_SECONDS=$2
+start=$(command date +%s)
+fm_remote_job_probe() { return 1; }
+fm_remote_job_worker_identity_matches() { return 1; }
+fm_remote_job_wait_for_probe "$1" "$1" && exit 3
+printf '%s\n' "$(($(command date +%s) - start))"
+SH
+run_wait_script "$CLOCK_SCRIPT" 20 "the readiness wait on a healthy clock" "$REMOTE_ROOT" 3
+[ "$WAIT_ELAPSED" -ge 3 ] || fail "the readiness wait ended before its deadline on a healthy clock"
+[ "$WAIT_ELAPSED" -le 4 ] || fail "a healthy clock ran the readiness wait past its deadline into the stall allowance"
+pass "the readiness wait ends on its deadline, not its stall allowance, when the clock is healthy"
 
 # The shutdown wait shares the mechanism, so it needs the same guarantee: a
 # worker that never exits plus a clock that cannot be read must still end in a
@@ -835,7 +879,7 @@ set -u
 # shellcheck source=/dev/null
 . "$1/bin/fm-remote-job-lib.sh"
 FM_REMOTE_JOB_STOP_WAIT_SECONDS=$2
-FM_REMOTE_JOB_CLOCK_MAX_MISSES=$3
+FM_REMOTE_JOB_CLOCK_MAX_STALLS=$3
 start=$(command date +%s)
 date() { return 1; }
 fm_remote_job_worker_process_group() { return 1; }

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -620,6 +620,29 @@ wait "$RECOVERY_WORKER_PID" 2>/dev/null || true
 RECOVERY_WORKER_PID=
 pass "quarantine clears only after recorded execution has stopped"
 
+# bin/fm-timeout-lib.sh owns bounded execution for this repo, so the outer
+# bounds below hold on a macOS host that ships no coreutils `timeout`.
+# shellcheck source=bin/fm-timeout-lib.sh
+. "$ROOT/bin/fm-timeout-lib.sh"
+
+# Each wait below runs in a child shell under an outer bound, so a regression to
+# a counted budget reports in seconds instead of burning minutes. fm_run_timed
+# reserves exit 124 for "the bound was hit", and every wait script here exits 3
+# when the wait returns the wrong result, so the three outcomes stay tellable
+# apart. WAIT_ELAPSED is the child's own measure of the wall time it spent.
+run_wait_script() { # <script> <outer bound seconds> <subject> [script args...]
+  local script=$1 bound=$2 subject=$3 status=0
+  shift 3
+  WAIT_ELAPSED=$(fm_run_timed "$bound" bash "$script" "$@") || status=$?
+  case "$status" in
+    0) ;;
+    124) fail "$subject overran its wall-clock bound of ${bound}s" ;;
+    3) fail "$subject reported the wrong outcome" ;;
+    *) fail "$subject failed with exit $status" ;;
+  esac
+  case "$WAIT_ELAPSED" in ''|*[!0-9]*) fail "$subject did not report the time it spent" ;; esac
+}
+
 # The readiness wait must spend a budget denominated in wall-clock seconds, so
 # that a host slow enough to delay worker startup cannot also change what the
 # budget is worth. A count-bounded wait fails this with an expensive check: its
@@ -641,13 +664,9 @@ fm_remote_job_wait_for_probe "$1" "$1" && exit 3
 printf '%s\n' "$(($(date +%s) - start))"
 SH
 chmod 700 "$BUDGET_SCRIPT"
-# The outer bound both proves the wait terminates and keeps a count-bounded
-# regression from burning minutes of a probe-per-second loop before it reports.
-BUDGET_ELAPSED=$(timeout 40 bash "$BUDGET_SCRIPT" "$REMOTE_ROOT" 3) \
-  || fail "the readiness wait did not honor a wall-clock budget when every probe was slow"
-case "$BUDGET_ELAPSED" in ''|*[!0-9]*) fail "the readiness wait did not report its elapsed budget" ;; esac
-[ "$BUDGET_ELAPSED" -ge 3 ] || fail "the readiness wait gave up before spending its configured budget"
-[ "$BUDGET_ELAPSED" -le 15 ] || fail "the readiness wait overran its configured budget under a slow probe"
+run_wait_script "$BUDGET_SCRIPT" 40 "the readiness wait under a one-second probe" "$REMOTE_ROOT" 3
+[ "$WAIT_ELAPSED" -ge 3 ] || fail "the readiness wait gave up before spending its configured budget"
+[ "$WAIT_ELAPSED" -le 15 ] || fail "the readiness wait overran its configured budget under a slow probe"
 pass "the readiness wait spends a wall-clock budget regardless of probe cost"
 
 # Same budget, a probe an order of magnitude slower: a wall-clock bound holds
@@ -664,11 +683,10 @@ start=$(date +%s)
 fm_remote_job_wait_for_probe "$1" "$1" && exit 3
 printf '%s\n' "$(($(date +%s) - start))"
 SH
-BUDGET_ELAPSED=$(timeout 60 bash "$BUDGET_SCRIPT" "$REMOTE_ROOT" 3) \
-  || fail "a ten-times slower probe broke the readiness wait's wall-clock budget"
+run_wait_script "$BUDGET_SCRIPT" 60 "the readiness wait under a ten-second probe" "$REMOTE_ROOT" 3
 # One in-flight probe may always finish, so the bound is the budget plus a
 # single check, never a multiple of the check cost.
-[ "$BUDGET_ELAPSED" -le 25 ] || fail "the readiness wait scaled with probe cost instead of holding its budget"
+[ "$WAIT_ELAPSED" -le 25 ] || fail "the readiness wait scaled with probe cost instead of holding its budget"
 pass "the readiness wait's budget does not scale with a slower probe"
 
 # A ready worker must still be observed immediately, so the wall-clock bound
@@ -685,9 +703,84 @@ start=$(date +%s)
 fm_remote_job_wait_for_probe "$1" "$1" || exit 3
 printf '%s\n' "$(($(date +%s) - start))"
 SH
-BUDGET_ELAPSED=$(timeout 30 bash "$BUDGET_SCRIPT" "$REMOTE_ROOT") \
-  || fail "the readiness wait did not return as soon as the worker reported ready"
-[ "$BUDGET_ELAPSED" -le 5 ] || fail "a ready worker was made to wait out the readiness budget"
+run_wait_script "$BUDGET_SCRIPT" 30 "the readiness wait for a worker already ready" "$REMOTE_ROOT"
+[ "$WAIT_ELAPSED" -le 5 ] || fail "a ready worker was made to wait out the readiness budget"
 pass "the readiness wait returns immediately once the worker reports ready"
+
+# A deadline is only a bound while the clock can be read. Under the memory
+# pressure these waits exist for, the `date` fork is itself a thing that can
+# fail, and the readiness wait runs on the remote side of an ssh invocation that
+# has no client-side bound of its own, so an unreadable clock must end the wait
+# rather than leave it spinning against a deadline it can never reach.
+CLOCK_SCRIPT="$TMP_ROOT/probe-wait-clock.sh"
+cat > "$CLOCK_SCRIPT" <<'SH'
+#!/usr/bin/env bash
+set -u
+# shellcheck source=/dev/null
+. "$1/bin/fm-remote-job-lib.sh"
+FM_REMOTE_JOB_PROBE_WAIT_SECONDS=120
+start=$(command date +%s)
+date() { return 1; }
+fm_remote_job_probe() { return 1; }
+fm_remote_job_worker_identity_matches() { return 1; }
+fm_remote_job_wait_for_probe "$1" "$1" && exit 3
+printf '%s\n' "$(($(command date +%s) - start))"
+SH
+chmod 700 "$CLOCK_SCRIPT"
+run_wait_script "$CLOCK_SCRIPT" 20 "the readiness wait with an unreadable clock" "$REMOTE_ROOT"
+[ "$WAIT_ELAPSED" -le 10 ] || fail "an unreadable clock let the readiness wait outlast its own budget"
+pass "the readiness wait gives up rather than spin when the clock cannot be read"
+
+# A clock stepped backwards - an NTP correction on a host that just woke from
+# sleep - is the same hazard in the other direction: the deadline recedes as
+# fast as the wait approaches it. A reading earlier than the moment the wait
+# began is spent budget, not fresh time.
+cat > "$CLOCK_SCRIPT" <<'SH'
+#!/usr/bin/env bash
+set -u
+# shellcheck source=/dev/null
+. "$1/bin/fm-remote-job-lib.sh"
+FM_REMOTE_JOB_PROBE_WAIT_SECONDS=120
+start=$(command date +%s)
+# A stub reading is taken in a command substitution, so the step it advances
+# has to outlive that subshell to keep the clock moving between readings.
+STEP_FILE=$2
+printf '0\n' > "$STEP_FILE"
+date() { # every reading lands five minutes before the one before it
+  local step
+  step=$(($(cat "$STEP_FILE") + 1))
+  printf '%s\n' "$step" > "$STEP_FILE"
+  printf '%s\n' "$((2000000000 - step * 300))"
+}
+fm_remote_job_probe() { return 1; }
+fm_remote_job_worker_identity_matches() { return 1; }
+fm_remote_job_wait_for_probe "$1" "$1" && exit 3
+printf '%s\n' "$(($(command date +%s) - start))"
+SH
+run_wait_script "$CLOCK_SCRIPT" 20 "the readiness wait with a backwards clock" \
+  "$REMOTE_ROOT" "$TMP_ROOT/clock-step"
+[ "$WAIT_ELAPSED" -le 10 ] || fail "a backwards clock stretched the readiness wait past its budget"
+pass "the readiness wait gives up rather than chase a clock stepping backwards"
+
+# The shutdown wait shares the mechanism, so it needs the same guarantee: a
+# worker that never exits plus a clock that cannot be read must still end in a
+# reported failure, never a hang inside teardown.
+cat > "$CLOCK_SCRIPT" <<'SH'
+#!/usr/bin/env bash
+set -u
+# shellcheck source=/dev/null
+. "$1/bin/fm-remote-job-lib.sh"
+FM_REMOTE_JOB_STOP_WAIT_SECONDS=120
+start=$(command date +%s)
+date() { return 1; }
+fm_remote_job_worker_process_group() { return 1; }
+fm_remote_job_signal_worker_tree() { return 0; }
+fm_remote_job_worker_tree_alive() { return 0; }
+fm_remote_job_stop_worker_tree 999999 && exit 3
+printf '%s\n' "$(($(command date +%s) - start))"
+SH
+run_wait_script "$CLOCK_SCRIPT" 20 "the shutdown wait with an unreadable clock" "$REMOTE_ROOT"
+[ "$WAIT_ELAPSED" -le 10 ] || fail "an unreadable clock let the shutdown wait outlast its own budget"
+pass "the shutdown wait reports a surviving worker rather than spin on an unreadable clock"
 
 echo "ALL TESTS PASSED"

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -710,15 +710,19 @@ pass "the readiness wait returns immediately once the worker reports ready"
 # A deadline is only a bound while the clock can be read. Under the memory
 # pressure these waits exist for, the `date` fork is itself a thing that can
 # fail, and the readiness wait runs on the remote side of an ssh invocation that
-# has no client-side bound of its own, so an unreadable clock must end the wait
-# rather than leave it spinning against a deadline it can never reach.
+# has no client-side bound of its own, so an unreadable clock must still end the
+# wait rather than leave it spinning against a deadline it can never reach. It
+# must end it on time, though, and not early: collapsing the budget to nothing
+# would report the same "worker did not report ready" failure these deadlines
+# exist to prevent, so the wait has to spend what it was configured to spend
+# using whatever measure of elapsed time it has left.
 CLOCK_SCRIPT="$TMP_ROOT/probe-wait-clock.sh"
 cat > "$CLOCK_SCRIPT" <<'SH'
 #!/usr/bin/env bash
 set -u
 # shellcheck source=/dev/null
 . "$1/bin/fm-remote-job-lib.sh"
-FM_REMOTE_JOB_PROBE_WAIT_SECONDS=120
+FM_REMOTE_JOB_PROBE_WAIT_SECONDS=$2
 start=$(command date +%s)
 date() { return 1; }
 fm_remote_job_probe() { return 1; }
@@ -727,9 +731,41 @@ fm_remote_job_wait_for_probe "$1" "$1" && exit 3
 printf '%s\n' "$(($(command date +%s) - start))"
 SH
 chmod 700 "$CLOCK_SCRIPT"
-run_wait_script "$CLOCK_SCRIPT" 20 "the readiness wait with an unreadable clock" "$REMOTE_ROOT"
-[ "$WAIT_ELAPSED" -le 10 ] || fail "an unreadable clock let the readiness wait outlast its own budget"
-pass "the readiness wait gives up rather than spin when the clock cannot be read"
+run_wait_script "$CLOCK_SCRIPT" 20 "the readiness wait with an unreadable clock" "$REMOTE_ROOT" 3
+[ "$WAIT_ELAPSED" -ge 2 ] || fail "an unreadable clock collapsed the readiness budget into an instant failure"
+[ "$WAIT_ELAPSED" -le 15 ] || fail "an unreadable clock let the readiness wait outlast its own budget"
+pass "the readiness wait spends its budget and still terminates when the clock cannot be read"
+
+# The realistic clock failure is transient: one `date` fork loses a race for
+# memory and the next one wins. Establishing the bound must survive that, or a
+# single unlucky fork at the start of the wait decides that the worker was never
+# going to be ready.
+cat > "$CLOCK_SCRIPT" <<'SH'
+#!/usr/bin/env bash
+set -u
+# shellcheck source=/dev/null
+. "$1/bin/fm-remote-job-lib.sh"
+FM_REMOTE_JOB_PROBE_WAIT_SECONDS=$2
+start=$(command date +%s)
+FAIL_FILE=$3
+printf '0\n' > "$FAIL_FILE"
+date() { # the first three readings fail, every reading after them succeeds
+  local taken
+  taken=$(($(cat "$FAIL_FILE") + 1))
+  printf '%s\n' "$taken" > "$FAIL_FILE"
+  [ "$taken" -gt 3 ] || return 1
+  command date "$@"
+}
+fm_remote_job_probe() { return 1; }
+fm_remote_job_worker_identity_matches() { return 1; }
+fm_remote_job_wait_for_probe "$1" "$1" && exit 3
+printf '%s\n' "$(($(command date +%s) - start))"
+SH
+run_wait_script "$CLOCK_SCRIPT" 30 "the readiness wait with a briefly unreadable clock" \
+  "$REMOTE_ROOT" 5 "$TMP_ROOT/clock-fails"
+[ "$WAIT_ELAPSED" -ge 4 ] || fail "a transient clock-read failure cut the readiness budget short"
+[ "$WAIT_ELAPSED" -le 20 ] || fail "a recovered clock did not resume bounding the readiness wait"
+pass "a transient clock-read failure does not shorten the readiness budget"
 
 # A clock stepped backwards - an NTP correction on a host that just woke from
 # sleep - is the same hazard in the other direction: the deadline recedes as
@@ -770,7 +806,7 @@ cat > "$CLOCK_SCRIPT" <<'SH'
 set -u
 # shellcheck source=/dev/null
 . "$1/bin/fm-remote-job-lib.sh"
-FM_REMOTE_JOB_STOP_WAIT_SECONDS=120
+FM_REMOTE_JOB_STOP_WAIT_SECONDS=$2
 start=$(command date +%s)
 date() { return 1; }
 fm_remote_job_worker_process_group() { return 1; }
@@ -779,8 +815,64 @@ fm_remote_job_worker_tree_alive() { return 0; }
 fm_remote_job_stop_worker_tree 999999 && exit 3
 printf '%s\n' "$(($(command date +%s) - start))"
 SH
-run_wait_script "$CLOCK_SCRIPT" 20 "the shutdown wait with an unreadable clock" "$REMOTE_ROOT"
-[ "$WAIT_ELAPSED" -le 10 ] || fail "an unreadable clock let the shutdown wait outlast its own budget"
+run_wait_script "$CLOCK_SCRIPT" 30 "the shutdown wait with an unreadable clock" "$REMOTE_ROOT" 3
+[ "$WAIT_ELAPSED" -le 20 ] || fail "an unreadable clock let the shutdown wait outlast its own budget"
 pass "the shutdown wait reports a surviving worker rather than spin on an unreadable clock"
+
+# The shutdown budget needs the same cost asymmetry the readiness tests use, or
+# a counted loop could be put back here and nothing would notice. A liveness
+# check ten times more expensive than the loop's own sleep costs a counted loop
+# fifty checks per leg and costs a deadline nothing beyond one check.
+cat > "$CLOCK_SCRIPT" <<'SH'
+#!/usr/bin/env bash
+set -u
+# shellcheck source=/dev/null
+. "$1/bin/fm-remote-job-lib.sh"
+FM_REMOTE_JOB_STOP_WAIT_SECONDS=$2
+start=$(command date +%s)
+fm_remote_job_worker_process_group() { return 1; }
+fm_remote_job_signal_worker_tree() { return 0; }
+fm_remote_job_worker_tree_alive() { sleep 1; return 0; }
+fm_remote_job_stop_worker_tree 999999 && exit 3
+printf '%s\n' "$(($(command date +%s) - start))"
+SH
+run_wait_script "$CLOCK_SCRIPT" 40 "the shutdown wait under a one-second liveness check" \
+  "$REMOTE_ROOT" 3
+# Two legs, TERM then KILL, each spending its own budget plus at most the one
+# check already in flight when the budget ran out.
+[ "$WAIT_ELAPSED" -ge 5 ] || fail "the shutdown wait gave up before spending its configured budget"
+[ "$WAIT_ELAPSED" -le 20 ] || fail "the shutdown wait scaled with liveness-check cost instead of holding its budget"
+pass "the shutdown wait spends a wall-clock budget regardless of liveness-check cost"
+
+# The wait's collaborator has to fail in the same direction it does. The probe
+# proves readiness by comparing the heartbeat's age against a ten second window,
+# so an unreadable clock leaves it unable to establish freshness at all: it must
+# report a worker that is not ready, never one that is.
+PROBE_CLOCK_SCRIPT="$TMP_ROOT/probe-clock.sh"
+mkdir -p "$TMP_ROOT/probe-clock-home"
+cat > "$PROBE_CLOCK_SCRIPT" <<'SH'
+#!/usr/bin/env bash
+set -u
+# shellcheck source=/dev/null
+. "$1/bin/fm-remote-job-lib.sh"
+unset FM_REMOTE_JOB_ACTIVE
+export FM_REMOTE_JOB_STATE_ROOT=$3
+start=$(command date +%s)
+fm_remote_job_prepare_state "$2" || exit 4
+ready=$(fm_remote_job_worker_ready_path)
+: > "$ready" || exit 4
+fm_remote_job_probe "$2" || exit 3
+touch -t 200001010000 "$ready" || exit 4
+fm_remote_job_probe "$2" && exit 3
+date() { return 1; }
+fm_remote_job_probe "$2" && exit 3
+: > "$ready" || exit 4
+fm_remote_job_probe "$2" && exit 3
+printf '%s\n' "$(($(command date +%s) - start))"
+SH
+chmod 700 "$PROBE_CLOCK_SCRIPT"
+run_wait_script "$PROBE_CLOCK_SCRIPT" 20 "the readiness probe against an unreadable clock" \
+  "$REMOTE_ROOT" "$TMP_ROOT/probe-clock-home" "$TMP_ROOT/probe-clock-state"
+pass "the readiness probe reports not ready when it cannot establish heartbeat freshness"
 
 echo "ALL TESTS PASSED"


### PR DESCRIPTION
## Intent

Fix a CI flake: tests/fm-remote-job.test.sh intermittently fails on loaded CI runners with "remote job worker did not report ready after startup", at the test "worker identity binds the canonical configured code root".

Evidence established before the work started (do not re-derive, and do not treat this as a speculative timeout bump): it failed once on a hosted runner; the same shard passed on a sibling pull request on the same runner image; the exact failing commit passed three consecutive clean local runs; and the change under test was unrelated to remote job startup. So it is runner load, not a code defect in the change that surfaced it.

Required approach, chosen deliberately: wait against a wall-clock deadline so the budget is what it claims to be. Simply raising the iteration count was explicitly ruled out, because it hides the shape of the bug, makes healthy machines wait longer for no benefit, and leaves the same failure mode one slower runner away.

Investigation result that a reviewer reading only the diff would not know: the originally suspected mechanism was wrong in direction. The suspicion was that a fixed 200-iteration loop's effective wall-clock budget SHRINKS under load. Measurement showed the opposite. A counted loop's real budget is count x (check cost + sleep), and the checks slow down along with the startup they wait for, so the nominal 20 seconds measured 21s idle and then 33s and 49s across two loaded runs. The actual defect is that the wait has no defined budget at all: it waits on a wall-clock-denominated precondition (a replacement worker cannot reclaim ownership until its predecessor's readiness heartbeat and lock age past their ten second staleness windows) using an iteration-denominated budget, so what the wait is worth varies by more than 1.5x run to run and exhausted anyway. The prescribed deadline fix is still correct, for this better reason.

The flake was reproduced locally by running the suite under 400 concurrent busy loops on 16 CPUs, which failed with the exact CI error at the exact test; every bounded loop in the startup handshake was instrumented to locate it. Under that same load the fix passes three consecutive runs.

Scope decision on sibling waits: both counted waits in bin/fm-remote-job-lib.sh share the mechanism and were both changed. fm_remote_job_wait_for_probe is the one that actually exhausted and produced the CI failure, now bounded by FM_REMOTE_JOB_PROBE_WAIT_SECONDS (60). fm_remote_job_stop_worker_tree's TERM and KILL legs are now bounded by FM_REMOTE_JOB_STOP_WAIT_SECONDS (15). Deduplicating that function's four repeated group-or-process tests into small helpers fell out of the deadline change and is intentional, not unrelated refactoring. worker_acquire_lock in bin/fm-remote-job-worker.sh has the same shape but was deliberately left alone: it is in another file and was measured at 35 of its 150 attempts under the load that broke the readiness wait, so it has real margin and no evidence behind changing it.

The 15 second shutdown budget is a deliberate, reviewed decision, not an inflated number. The previous shutdown loop was 50 iterations, so its real budget was 50 x (check cost + sleep) and never the nominal 5 seconds; under load it measured about 12 seconds. Restoring a literal 5 seconds would tighten the budget below what the code has actually been delivering all along, manufacturing a fresh flake while claiming to preserve behavior. This was raised as a judgment call and explicitly confirmed: keep 15 seconds. Do not "correct" either default back down.

Required in the PR description, explicitly requested: state the flake evidence above so a reader sees a real flake investigation rather than a speculative timeout bump; state that the previous budgets were nominal and what they actually delivered in measurement; and state that the 60 second readiness budget covers the observed 49 second worst case, so a reader sees measurement rather than a guessed timeout.

Acceptance criteria: the wait is bounded by elapsed time, not iteration count; and a test demonstrates the budget holds when each probe is artificially slow, as executable coverage rather than a comment. The three new tests in tests/fm-remote-job.test.sh deliberately stub fm_remote_job_probe to be far slower than the loop's own sleep, because that cost asymmetry is exactly what separates a wall-clock bound from a counted one. They were verified to fail against the previous counted loop and to pass with the fix. Keep them: proving the fix rather than asserting it is the point. They run the wait in a child shell under an outer timeout so a counted-loop regression reports fast instead of burning minutes.

Repository constraints: this is the firstmate repository itself, so shared tracked material follows .agents/skills/firstmate-coding-guidelines (one sentence per line in tracked Markdown, plain dash never an em dash, no agent co-author, bin/*.sh shellcheck-clean via bin/fm-lint.sh, tests colocated in tests/ extending the existing script). origin is the captain's fork TheKingJulian/firstmate; upstream kunchenguid/firstmate is READ-ONLY and must never receive a push, branch, or pull request.

## What Changed

- `bin/fm-remote-job-lib.sh` now waits against a wall-clock deadline instead of an iteration count. A new `fm_remote_job_wait_until` driver polls a predicate until a budget anchored once from `date` runs out, `fm_remote_job_wait_for_probe` spends `FM_REMOTE_JOB_PROBE_WAIT_SECONDS` (60) on the worker readiness handshake, and both the TERM and KILL legs of `fm_remote_job_stop_worker_tree` spend `FM_REMOTE_JOB_STOP_WAIT_SECONDS` (15). Two backstops keep every wait terminating on a clock that misbehaves: `FM_REMOTE_JOB_CLOCK_MAX_STALLS` bounds consecutive non-advancing readings, and `FM_REMOTE_JOB_WAIT_MAX_POLLS_PER_SECOND` derives a poll ceiling from the budget for an oscillating clock that never trips the stall counter. `fm_remote_job_probe` now fails closed when the clock cannot be read, the four repeated group-or-process tests in the stop path collapse into `fm_remote_job_worker_tree_alive` and `fm_remote_job_signal_worker_tree` helpers, and all four new settings are range-checked in `fm_remote_job_validate_settings`.
- The change is a fix for a measured flake, not a speculative timeout bump. `tests/fm-remote-job.test.sh` failed once on a hosted runner at "worker identity binds the canonical configured code root" with "remote job worker did not report ready after startup", while the same shard passed on a sibling pull request on the same runner image, the exact failing commit passed three consecutive clean local runs, and the change under test was unrelated to remote job startup. It was reproduced locally by running the suite under 400 concurrent busy loops on 16 CPUs, which failed with the same error at the same test, and the fix then passed three consecutive runs under that load. The old budgets were nominal only: a counted loop is worth count x (check cost + sleep), and because the checks slow down along with the startup they wait for, the readiness loop's nominal 20 seconds measured 21s idle and then 33s and 49s across two loaded runs. The 60 second readiness budget covers that observed 49 second worst case. The shutdown loop's nominal 5 seconds measured about 12 seconds under the same load, so 15 seconds preserves what that path has actually been delivering rather than tightening it into a fresh flake.
- `tests/fm-remote-job.test.sh` gains executable coverage for the budget rather than a comment asserting it. Each case runs the wait in a child shell under an outer `fm_run_timed` bound so a regression to a counted loop reports in seconds, and the probe and liveness stubs are deliberately far slower than the loop's own sleep because that cost asymmetry is what separates a wall-clock bound from a counted one. Covered: the readiness budget holding under one-second, two-second and ten-second probes, an immediate return once the worker reports ready, unreadable, transient, frozen, backwards-stepping and oscillating clocks, a healthy clock ending on its deadline rather than its stall allowance, the shutdown budget under an expensive liveness check and an unreadable clock, and `fm_remote_job_probe` reporting not ready when it cannot establish heartbeat freshness.

## Risk Assessment

✅ Low: The change is confined to two supervision waits plus colocated tests, the termination guarantee it claims now actually holds unconditionally via the poll ceiling, the wall-clock deadline remains the budget, and every new test genuinely discriminates against the counted loop it replaced; the two residual findings are a factually wrong sentence in a header comment and a sub-0.1% write race in one test stub, neither of which affects shipped behavior.

## Testing

I ran the targeted suite tests/fm-remote-job.test.sh at the target commit on an idle box, where all 36 tests pass including the 14 new wait tests, then went after product-level proof rather than resting on that. Measuring fm_remote_job_wait_for_probe with the same nominal 20 second budget on both commits showed the counted loop spending 31s, 60s and over 150s as the probe cost rose, against a steady 20-21s for the deadline, and driving the real fm_remote_job_ensure_worker against a worker that takes 50 seconds to start reproduced the exact CI error on base at 42 seconds while the fix saw the worker come up. The three cost-asymmetry scenarios the new tests assert were also run against the base library and all three overran their outer bounds, so those tests genuinely fail before the fix. Under 800 busy loops on 16 CPUs the base suite failed with the reported error at the reported test, worker identity binds the canonical configured code root, and the fixed tree passed the same load three times; at the 400-loop reproduction load both trees passed on this box. One honest caveat is recorded in the evidence: three fixed-tree runs started back to back without letting the previous run's load generators be reaped hit the readiness error twice, so the 60 second budget is finite somewhere above twice the reproduction load, which is a property of any deadline rather than a defect. No screenshots apply, since this change is a shell library with no rendered surface, so the reviewer-visible artifacts are CLI transcripts of the product path and of the measurements.

<details>
<summary>Evidence: Evidence index with all measurements and how to reproduce them</summary>

Source: [Evidence index with all measurements and how to reproduce them](https://github.com/TheKingJulian/firstmate/blob/583ab10ad2f9ab0fe606e14d8da34c9abef7dcc4/.no-mistakes/evidence/fm/firstmate-remote-job-probe-wait-flaky-under-load-v1/README.md)

```text
# Evidence: readiness wait bounded by wall clock, not iteration count

Base under test is ef35d79 (counted loops), fix under test is 302efff (wall-clock deadlines).
Every comparison below runs the same experiment against both, on a 16 CPU Linux box.

## What the budget is actually worth as the check gets more expensive

`probe-wait-budget-compare.txt` measures `fm_remote_job_wait_for_probe` with a nominal 20 second budget on both sides, driving it with probes of increasing cost.

`` `
probe cost | counted loop (base)              | wall-clock deadline (fix)
0.05s      | 31s                              | 20s
0.2s       | 60s                              | 20s
1.0s       | still waiting at 150s (bound hit)| 21s
`` `

The counted loop's "20 seconds" is 31s, 60s, or more than 150s depending on how expensive the check is, which is the defect the change describes.
The deadline is the duration it claims to be, and a ready worker still returns on the first successful check, which `suite-idle-fix.txt` covers as "the readiness wait returns immediately once the worker reports ready".

Reproduce with `probe-wait-budget-compare.sh <base lib> <fixed lib>`.

## The CI failure itself, end to end, deterministically

`slow-startup-e2e.txt` drives the real entry point `fm_remote_job_ensure_worker` against a worker that takes 50 seconds to publish its identity and start heartbeating, which is what a loaded runner makes of a startup that is quick when idle.

`` `
=== base ef35d79: counted 200-iteration readiness loop ===
ensure_worker: FAILED after 42s: remote job worker did not report ready after startup
=== fix 302efff: FM_REMOTE_JOB_PROBE_WAIT_SECONDS=60 wall-clock deadline ===
ensure_worker: worker ready after 50s
`` `

That failure string is the exact CI error, produced by the product path rather than by a test assertion.
The worker was healthy and came up at 50 seconds in both runs; only the budget differed.

Reproduce with `slow-startup-e2e.sh <lib> <label> 50`.

## The new tests fail against the counted loop

`fail-before-fix.txt` runs the three cost-asymmetry scenarios from `tests/fm-remote-job.test.sh` against each library, with the same outer bounds and elapsed-time windows the tests assert.

`` `
=== base ef35d79: counted loops ===
  FAIL   readiness wait, one-second probe, 3s budget: overran its wall-clock bound of 40s
  FAIL   readiness wait, ten-second probe, 3s budget: overran its wall-clock bound of 60s
  FAIL   shutdown wait, one-second liveness check, 3s budget: overran its wall-clock bound of 40s
=== fix 302efff: wall-clock deadlines ===
  PASS   readiness wait, one-second probe, 3s budget: spent 4s
  PASS   readiness wait, ten-second probe, 3s budget: spent 10s
  PASS   shutdown wait, one-second liveness check, 3s budget: spent 6s
`` `

## The suite under the reproduction load

`loaded-ab.sh` alternates the two checkouts under N busy loops, waiting for the box to go idle before each run.

- `loaded-ab.txt`, 400 loops, two rounds each: base passed twice, fix passed twice.
- `loaded-ab-800.txt`, 800 loops, round one: base failed with `remote job worker did not report ready after startup`, immediately after `ensure replaces a live worker after its code changes`, so the failing test is `worker identity binds the canonical configured code root`, exactly the reported flake at exactly the reported test. The fix passed the same load.
- `loaded-ab-800-rounds23.txt`, 800 loops, two more rounds: fix passed both. Base passed one and failed the other at `queue time consumed the second job's execution timeout`, an unrelated timing assertion in the same file that is identical in both trees.

`base-suite-at-400-loops.txt` is the first attempt at the reproduction, 400 loops on this box, which the base survived.
The flake needed 800 loops here to appear.

`uncontrolled-back-to-back-runs.txt` records three fixed-tree runs started without waiting for the previous run's load generators to be reaped, two of which hit the readiness error.
The sixty second budget is finite, and somewhere above twice the reproduction load it can still be spent.

## Full targeted suite

`suite-idle-fix.txt` is `tests/fm-remote-job.test.sh` at 302efff on an idle box: 36 tests, all passing, including the fourteen new wait tests.
```
</details>
<details>
<summary>Evidence: Exact CI error reproduced end to end through fm_remote_job_ensure_worker, base vs fix</summary>

Source: [Exact CI error reproduced end to end through fm_remote_job_ensure_worker, base vs fix](https://github.com/TheKingJulian/firstmate/blob/583ab10ad2f9ab0fe606e14d8da34c9abef7dcc4/.no-mistakes/evidence/fm/firstmate-remote-job-probe-wait-flaky-under-load-v1/slow-startup-e2e.txt)

<code>=== base ef35d79: counted 200-iteration readiness loop ===&#10;worker startup takes 50s&#10;ensure_worker: FAILED after 42s: remote job worker did not report ready after startup&#10;=== fix 302efff: FM_REMOTE_JOB_PROBE_WAIT_SECONDS=60 wall-clock deadline ===&#10;worker startup takes 50s&#10;ensure_worker: worker ready after 50s</code>

```text
=== base ef35d79: counted 200-iteration readiness loop ===
worker startup takes 50s
ensure_worker: FAILED after 42s: remote job worker did not report ready after startup
exit=1
=== fix 302efff: FM_REMOTE_JOB_PROBE_WAIT_SECONDS=60 wall-clock deadline ===
worker startup takes 50s
ensure_worker: worker ready after 50s
exit=0
```
</details>
<details>
<summary>Evidence: What a nominal 20 second budget is actually worth as the probe gets more expensive</summary>

Source: [What a nominal 20 second budget is actually worth as the probe gets more expensive](https://github.com/TheKingJulian/firstmate/blob/583ab10ad2f9ab0fe606e14d8da34c9abef7dcc4/.no-mistakes/evidence/fm/firstmate-remote-job-probe-wait-flaky-under-load-v1/probe-wait-budget-compare.txt)

<code>probe cost | counted loop (base) | wall-clock deadline (fix)&#10;0.05s | 31s | 20s&#10;0.2s | 60s | 20s&#10;1.0s | still waiting at 150s (bound hit) | 21s</code>

```text
probe cost | counted loop (base fm-remote-job-lib.sh) | wall-clock deadline (fix)
-----------+------------------------+--------------------------
0.05s      | 31s                    | 20s
0.2s       | 60s                    | 20s
1.0s       | still waiting at 150s (bound hit) | 21s
```
</details>
<details>
<summary>Evidence: The new tests&#39; cost-asymmetry scenarios fail against the counted loop and pass against the deadline</summary>

Source: [The new tests&#39; cost-asymmetry scenarios fail against the counted loop and pass against the deadline](https://github.com/TheKingJulian/firstmate/blob/583ab10ad2f9ab0fe606e14d8da34c9abef7dcc4/.no-mistakes/evidence/fm/firstmate-remote-job-probe-wait-flaky-under-load-v1/fail-before-fix.txt)

<code>=== base ef35d79: counted loops (200 readiness iterations, 50 per shutdown leg) ===&#10;FAIL readiness wait, one-second probe, 3s budget: overran its wall-clock bound of 40s&#10;FAIL readiness wait, ten-second probe, 3s budget: overran its wall-clock bound of 60s&#10;FAIL shutdown wait, one-second liveness check, 3s budget: overran its wall-clock bound of 40s&#10;3 scenario(s) failed&#10;&#10;=== fix 302efff: wall-clock deadlines ===&#10;PASS readiness wait, one-second probe, 3s budget: spent 4s, within the 3-15s its budget allows&#10;PASS readiness wait, ten-second probe, 3s budget: spent 10s, within the 0-25s its budget allows&#10;PASS shutdown wait, one-second liveness check, 3s budget: spent 6s, within the 4-25s its budget allows&#10;0 scenario(s) failed</code>

```text
=== base ef35d79: counted loops (200 readiness iterations, 50 per shutdown leg) ===
  FAIL   readiness wait, one-second probe, 3s budget: overran its wall-clock bound of 40s
  FAIL   readiness wait, ten-second probe, 3s budget: overran its wall-clock bound of 60s
  FAIL   shutdown wait, one-second liveness check, 3s budget: overran its wall-clock bound of 40s
  3 scenario(s) failed

=== fix 302efff: wall-clock deadlines ===
  PASS   readiness wait, one-second probe, 3s budget: spent 4s, within the 3-15s its budget allows
  PASS   readiness wait, ten-second probe, 3s budget: spent 10s, within the 0-25s its budget allows
  PASS   shutdown wait, one-second liveness check, 3s budget: spent 6s, within the 4-25s its budget allows
  0 scenario(s) failed
```
</details>
<details>
<summary>Evidence: Loaded A/B at 800 busy loops: base hits the reported flake at the reported test, fix passes</summary>

Source: [Loaded A/B at 800 busy loops: base hits the reported flake at the reported test, fix passes](https://github.com/TheKingJulian/firstmate/blob/583ab10ad2f9ab0fe606e14d8da34c9abef7dcc4/.no-mistakes/evidence/fm/firstmate-remote-job-probe-wait-flaky-under-load-v1/loaded-ab-800.txt)

<code>--- base, round 1: pre-run idle 90% FAIL not ok - remote job worker did not report ready after startup&#10;suite exit status: 1 after 134s&#10;last test to pass: ok - ensure replaces a live worker after its code changes&#10;--- fixed, round 1: pre-run idle 90% PASS suite exit status: 0 after 155s</code>

```text
--- base, round 1: pre-run idle 90%    FAIL  not ok - remote job worker did not report ready after startup
          suite exit status: 1 after 134s
          last test to pass: ok - ensure replaces a live worker after its code changes
--- fixed, round 1: pre-run idle 90%    PASS  suite exit status: 0 after 155s
```
</details>
<details>
<summary>Evidence: Two further loaded rounds at 800 loops</summary>

Source: [Two further loaded rounds at 800 loops](https://github.com/TheKingJulian/firstmate/blob/583ab10ad2f9ab0fe606e14d8da34c9abef7dcc4/.no-mistakes/evidence/fm/firstmate-remote-job-probe-wait-flaky-under-load-v1/loaded-ab-800-rounds23.txt)

```text
--- base, round 1: pre-run idle 86%    PASS  suite exit status: 0 after 97s
--- fixed, round 1: pre-run idle 85%    PASS  suite exit status: 0 after 161s
--- base, round 2: pre-run idle 80%    FAIL  not ok - queue time consumed the second job's execution timeout
          suite exit status: 1 after 22s
          last test to pass: ok - the worker expires queued jobs before they can mutate
--- fixed, round 2: pre-run idle 86%    PASS  suite exit status: 0 after 180s
```
</details>
<details>
<summary>Evidence: Loaded A/B at the 400-loop reproduction load</summary>

Source: [Loaded A/B at the 400-loop reproduction load](https://github.com/TheKingJulian/firstmate/blob/583ab10ad2f9ab0fe606e14d8da34c9abef7dcc4/.no-mistakes/evidence/fm/firstmate-remote-job-probe-wait-flaky-under-load-v1/loaded-ab.txt)

```text
--- base, round 1: pre-run idle 83%    PASS  suite exit status: 0 after 68s
--- fixed, round 1: pre-run idle 88%    PASS  suite exit status: 0 after 158s
--- base, round 2: pre-run idle 90%    PASS  suite exit status: 0 after 69s
--- fixed, round 2: pre-run idle 84%    PASS  suite exit status: 0 after 144s
```
</details>
<details>
<summary>Evidence: Full targeted suite at 302efff on an idle box</summary>

Source: [Full targeted suite at 302efff on an idle box](https://github.com/TheKingJulian/firstmate/blob/583ab10ad2f9ab0fe606e14d8da34c9abef7dcc4/.no-mistakes/evidence/fm/firstmate-remote-job-probe-wait-flaky-under-load-v1/suite-idle-fix.txt)

```text
ok - default queue and execution bounds independently cover long polls
ok - operator PATH excludes a symlinked local bin
ok - operator PATH honors nvm defaults with a deterministic fallback
ok - operator PATH resolves the authorized Nix profile bin link
ok - the worker preserves bounded argv and stdin in an empty environment
ok - active jobs keep the worker ready for concurrent requests
ok - ensure replaces a live worker after its code changes
ok - worker identity binds the canonical configured code root
ok - stale ownership is reclaimed without signaling a reused pid
ok - the worker enforces the job timeout and publishes its result
ok - the worker expires queued jobs before they can mutate
ok - queued jobs receive a fresh bounded execution window
ok - a queued short command preempts a running long poll instead of waiting its window
ok - a poll re-armed after preemption reads the same cursor with nothing lost
ok - sibling polls never preempt each other into a re-arm churn loop
ok - worker shutdown terminates the active command tree before replacement
ok - Linux supervision recovers crashes and stops orphaned commands
ok - pre-execution validation obeys the job timeout
ok - the worker drains bounded output without changing command results
ok - the worker refuses symlinked job fields before command execution
ok - failed shutdown quarantines ownership against replacement workers
ok - quarantine clears only after recorded execution has stopped
ok - the readiness wait spends a wall-clock budget regardless of probe cost
ok - the readiness wait's budget does not scale with a slower probe
ok - the readiness wait returns immediately once the worker reports ready
ok - the readiness wait spends its miss allowance and still terminates when the clock cannot be read
ok - a transient clock-read failure does not shorten the readiness budget
ok - a backwards clock step lengthens the readiness wait instead of collapsing its budget
ok - the readiness wait ends against a clock that never moves forwards
ok - the readiness wait ends against a clock that never moves at all
ok - the readiness wait ends on its deadline, not its stall allowance, when the clock is healthy
ok - the readiness wait ends against a clock that never moves forwards on balance
ok - an expensive probe leaves the readiness wait ending on its deadline, nowhere near its poll ceiling
ok - the shutdown wait reports a surviving worker rather than spin on an unreadable clock
ok - the shutdown wait spends a wall-clock budget regardless of liveness-check cost
ok - the readiness probe reports not ready when it cannot establish heartbeat freshness
ALL TESTS PASSED
```
</details>
<details>
<summary>Evidence: Fixed-tree runs under uncontrolled back-to-back load, with conditions noted</summary>

Source: [Fixed-tree runs under uncontrolled back-to-back load, with conditions noted](https://github.com/TheKingJulian/firstmate/blob/583ab10ad2f9ab0fe606e14d8da34c9abef7dcc4/.no-mistakes/evidence/fm/firstmate-remote-job-probe-wait-flaky-under-load-v1/uncontrolled-back-to-back-runs.txt)

```text
NOTE ON CONDITIONS: these three runs were started back to back with no wait for
the previous run's 400 busy loops to be reaped, so the effective load is above
the 400-loop reproduction and unknown. Output is also a tail of stdout and
stderr interleaved, so the ok lines below do not sit next to the not ok line
they belong with. Kept because it records that the sixty second readiness
budget is finite and can still be exhausted somewhere above twice the
reproduction load. The controlled comparison is in loaded-ab.txt,
loaded-ab-800.txt and loaded-ab-800-rounds23.txt, where each run waits for the
box to go idle first.

--- run 1 of tests/fm-remote-job.test.sh at target 302efff ---
not ok - remote job worker did not report ready after startup
ok - the worker preserves bounded argv and stdin in an empty environment
ok - active jobs keep the worker ready for concurrent requests
ok - ensure replaces a live worker after its code changes
suite exit status: 1 after 134s
--- run 2 of tests/fm-remote-job.test.sh at target 302efff ---
ok - the shutdown wait spends a wall-clock budget regardless of liveness-check cost
ok - the readiness probe reports not ready when it cannot establish heartbeat freshness
ALL TESTS PASSED
suite exit status: 0 after 147s
--- run 3 of tests/fm-remote-job.test.sh at target 302efff ---
not ok - remote job worker did not report ready after startup
ok - the worker preserves bounded argv and stdin in an empty environment
ok - active jobs keep the worker ready for concurrent requests
ok - ensure replaces a live worker after its code changes
suite exit status: 1 after 130s
```
</details>
- Outcome: ⚠️ 1 info across 1 run (1h8m16s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"447805748adcf88f58d7e146d34bef3a7d313527","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `tests/fm-remote-job.test.sh:646` - The three new budget tests invoke bare `timeout 40|60|30`, but this repo routes every bounded call through bin/fm-timeout-lib.sh precisely because macOS ships no coreutils `timeout` (that lib documents itself as &#34;the single owner of bounded command execution&#34; and selects timeout/gtimeout/perl/bash). These are the only bare `timeout` executions in tests/. On a macOS host without coreutils the command substitution fails with &#34;timeout: command not found&#34;, the `|| fail` fires, and the suite reports &#34;the readiness wait did not honor a wall-clock budget&#34; - a false failure blaming the code under test. Source bin/fm-timeout-lib.sh and use `fm_run_timed` for the three outer bounds (lines 646, 667, 688).
- ⚠️ `bin/fm-remote-job-lib.sh:115` - fm_remote_job_wait_expired does `[ &#34;$(date +%s)&#34; -ge &#34;$1&#34; ]` with no validation, and fm_remote_job_wait_for_probe is now `while :` with no iteration backstop. If `date +%s` produces an empty string (fork failure under the same memory/load pressure this fix targets) the test becomes `[ &#34;&#34; -ge N ]`, which returns 2 with &#34;integer expression expected&#34; on stderr, so the deadline never trips and the loop spins forever; a backward clock step (NTP resync after a macOS secondmate wakes from sleep) hangs it for the size of the step. That hang sits in the fm-remote-entrypoint.sh path, which has no client-side bound - fm-on.sh&#39;s ServerAliveInterval only detects a dead peer, never a live-but-hung remote command - so the user&#39;s ssh invocation blocks indefinitely. The previous 200-iteration loop always terminated. Capture `now=$(date +%s 2&gt;/dev/null || true)`, and treat a non-numeric or empty read as expired so both wait_for_probe and wait_for_tree_exit keep a hard termination guarantee.
- ℹ️ `bin/fm-remote-job-lib.sh:765` - The original fm_remote_job_stop_worker_tree header comment (&#34;Stop a worker and every descendant it leaked, TERM first and KILL only for a survivor... Returns non-zero when any verified worker-group member is still alive afterwards.&#34;) was left in place above the new fm_remote_job_worker_tree_alive helper and re-added verbatim above the real fm_remote_job_stop_worker_tree at line 794. The helper is a pure liveness predicate that signals nothing and has no TERM/KILL sequence, so the leading four lines at 765-768 describe the wrong function. Delete them and keep only the &#34;A provable worker group is signalled and tested as a group&#34; sentence there.

🔧 Fix: route test bounds through fm_run_timed, fail waits closed on bad clock
4 issues (2 warnings, 2 infos) still open:
- ⚠️ `bin/fm-remote-job-lib.sh:937` - fm_remote_job_probe reads `now=$(date +%s)` with no validation and then evaluates `[ $((now - mtime)) -le 10 ]`. This is the direct collaborator of the wait the change hardens, and it fails in the opposite direction: if the `date` fork fails, `now` is empty, bash arithmetic treats it as 0, `0 - mtime` is a large negative number, and the staleness test returns TRUE. The probe is called from fm_remote_job_wait_for_probe on the left of `&amp;&amp;`, so errexit is suppressed inside it and the empty read is not caught. Concrete path: a transient fork failure during startup makes fm_remote_job_probe report a heartbeat that is minutes stale as fresh, fm_remote_job_wait_for_probe returns 0 against a dead or wrong-identity worker, fm_remote_job_ensure_worker succeeds, and the entrypoint then queues a job that blocks until FM_REMOTE_JOB_QUEUE_TIMEOUT (360s) instead of failing fast at startup. The new block comment at line 104 states the invariant for these waits: &#34;Every unreadable, implausible, or backwards reading therefore counts as expired.&#34; That invariant does not hold one function above, even though fm_remote_job_clock_now now exists to enforce it. Route this read through fm_remote_job_clock_now and return 1 when the clock is unreadable.
- ⚠️ `bin/fm-remote-job-lib.sh:130` - fm_remote_job_wait_deadline gives up on the very first unreadable clock read and returns an empty bound, and fm_remote_job_wait_expired then reports expired on its first call. Because the deadline is established once at line 947 before the loop, a single failed `date` fork at t=0 collapses the whole 60s budget: fm_remote_job_wait_for_probe performs exactly one probe attempt and returns 1, producing &#34;remote job worker did not report ready after startup&#34; - the exact CI error this change exists to eliminate. That failure mode is new; the previous counted loop had no dependence on the clock at all, so it could not fail this way. The same applies at line 810: an unreadable clock makes fm_remote_job_wait_for_tree_exit return 1 before a single `sleep 0.1`, so stop_worker_tree escalates TERM to KILL immediately and then reports &#34;stale remote job worker did not stop safely&#34; even though the KILL almost certainly landed. Fail-closed is the right direction and was explicitly chosen, but treating one transient fork failure as &#34;the clock is unreadable&#34; is stricter than the design needs. Retrying the read a small number of times inside fm_remote_job_clock_now before declaring it unreadable keeps the wall-clock deadline as the sole budget authority while removing the one-read cliff. Flagging rather than fixing because it revisits the deliberate fail-closed decision from round 1.
- ℹ️ `bin/fm-remote-job-lib.sh:608` - fm_remote_job_wait is the third `while :` wait in this file and still uses the raw pattern the change replaced elsewhere: `if [ &#34;$(date +%s)&#34; -ge &#34;$wait_deadline&#34; ]`. It is already wall-clock denominated, so the authorized flake (an iteration-denominated budget) is not reachable here. But if `date` returns empty, `[ &#34;&#34; -ge N ]` exits 2 with &#34;integer expression expected&#34; on stderr, the `if` is false, and the loop polls forever - and this one runs on the client side of the ssh invocation, where fm-on.sh&#39;s ServerAliveInterval only detects a dead peer, never a live-but-hung command. Now that fm_remote_job_clock_now exists as the shared boundary, this is the one remaining unguarded clock read in a spin loop in this file. Out of the intent&#39;s stated scope (which covers only the two counted waits), so raising it as the author&#39;s call rather than fixing it here.
- ℹ️ `tests/fm-remote-job.test.sh:782` - The shutdown wait gets clock-failure coverage but no budget coverage. The three slow-probe tests pin that fm_remote_job_wait_for_probe&#39;s cost does not scale with per-check cost, which is what makes them fail against a counted loop; there is no equivalent for fm_remote_job_wait_for_tree_exit. A regression that restored the old `while ... &amp;&amp; [ &#34;$i&#34; -lt 50 ]` shape in the TERM/KILL legs would pass the whole suite: the shutdown test at line 782 stubs fm_remote_job_worker_tree_alive to always return 0 and only asserts stop_worker_tree returns non-zero within 10s, which a 50-iteration loop also satisfies. A stub whose aliveness check is deliberately slower than the loop&#39;s own sleep, asserting elapsed stays near FM_REMOTE_JOB_STOP_WAIT_SECONDS, would close that gap with the same shape as the probe tests.

🔧 Fix: fail probe closed on bad clock, keep wait budgets whole
2 warnings still open:
- ⚠️ `bin/fm-remote-job-lib.sh:154` - fm_remote_job_epoch_expired treats ANY backwards reading as &#34;expired&#34; (`[ &#34;$now&#34; -ge &#34;$start&#34; ] || return 0`), which propagates through fm_remote_job_wait_expired as verdict 0 and ends the wait immediately. The SECONDS measure that the same bound token carries - documented at lines 128-131 as the safety net for exactly this hazard - is never consulted, because it is only reached on verdict 2. Concrete path: a macOS secondmate wakes from sleep, ssh triggers fm-remote-entrypoint.sh, ntpd steps the clock back one second 100ms into a 60s fm_remote_job_wait_for_probe. Next wait_expired call sees now &lt; start, returns expired, the wait performs one probe and returns 1, and the entrypoint reports &#34;remote job worker did not report ready after startup&#34; - the precise CI error this change exists to eliminate. That scenario is the one the code&#39;s own comment at line 114 names (&#34;a clock stepped backwards by an NTP correction on a host that just woke from sleep&#34;). The comment at line 135 justifies this as &#34;that is spent budget, not fresh time&#34;, but it is not spent: SECONDS knows exactly how much elapsed. Returning 2 here instead of 0 defers to SECONDS, which is monotonic within the shell, so termination is still guaranteed (guarantee (a) holds) and the configured budget is honored (guarantee (b) holds). Round 1 authorized &#34;bounding elapsed time against a monotonic source, OR treating an implausible backward jump as expired&#34;; the implementation shipped both, and the weaker branch shadows the stronger one. Also note the code fires on any backward step, not only an &#34;implausible&#34; one. Flagging rather than fixing because it revisits a deliberately documented design decision.
- ⚠️ `bin/fm-remote-job-lib.sh:160` - fm_remote_job_wait_expired parses the bound token with `IFS=: read -r shell_start shell_deadline epoch_start epoch_deadline &lt;&lt;&lt; &#34;$bound&#34;`. If the here-string redirection fails, `read` never executes and the four `local` variables stay unset (bash `local x` leaves x unset, not empty). bin/fm-remote-entrypoint.sh runs `set -eu`, so the very next line, `case &#34;$shell_start&#34; in`, aborts the entire remote command with &#34;shell_start: unbound variable&#34; instead of returning a bounded-wait failure. I confirmed this directly: `bash -c &#39;set -u; f(){ local a b; IFS=: read -r a b &lt; /nonexistent; case &#34;$a&#34; in ...` exits 127 and the function never returns. Separately, on bash below 5.1 a here-string is backed by a temp file in $TMPDIR (bash 5.1 was the release that switched small here-documents and here-strings to a pipe), and macOS ships /bin/bash 3.2, so this adds a file create/unlink per poll iteration - roughly 600 in a 60s readiness wait - inside a loop whose entire stated threat model is a host too short on resources to fork `date`. Both go away by splitting the token with parameter expansion (`shell_start=${bound%%:*}`, etc.) instead of a redirect; at minimum initialize the four locals to empty so a failed read degrades to the existing fail-closed branch rather than killing the shell.

🔧 Fix: replace clock token machinery with one bounded wait driver
3 issues (1 warning, 2 infos) still open:
- ⚠️ `bin/fm-remote-job-lib.sh:151` - The backward-step re-anchor is uncapped, so `fm_remote_job_wait_until` can spin forever against a readable clock and the guarantee the header comment states at line 116 (&#34;It must always terminate&#34;) does not hold. Every backward reading does `deadline=$((deadline - (last - now)))`, which preserves `deadline - now` exactly, and every successful read resets `misses=0`, so neither backstop can fire: termination now depends on the clock making net FORWARD progress, which nothing in the loop checks. I confirmed this directly rather than inferring it - stubbing `fm_remote_job_clock_now` to advance 1s then step back 2s on each read and calling `fm_remote_job_wait_until 3 never` hung until an outer 12s bound killed it (exit 124). This is not the pathological-clock case being deliberately scoped out at line 124; unconditional termination is the one clock property the change explicitly keeps in scope, and this wait runs on the remote side of the ssh invocation where fm-on.sh&#39;s ServerAliveInterval only detects a dead peer, never a live-but-hung command. Trigger needs a clock whose backward steps outpace its forward progress (a guest repeatedly corrected by a hypervisor, chrony makestep against a flapping source), so it is narrow - hence follow-up rather than blocking. Cheapest fix consistent with every standing constraint: count consecutive or cumulative re-anchors and give up past a bound, mirroring FM_REMOTE_JOB_CLOCK_MAX_MISSES. That touches the loop shape the author prescribed verbatim, so it is the author&#39;s call, not a mechanical fix.
- ℹ️ `bin/fm-remote-job-lib.sh:152` - Clock-step handling is one-sided: a backward step re-anchors the deadline, a forward step is not compensated at all, so an NTP correction that jumps the clock forward past the deadline ends the wait on its next read and produces &#34;remote job worker did not report ready after startup&#34; - the exact failure this change exists to eliminate. That is a new failure mode relative to the counted loop, which had no clock dependency, but it is intrinsic to the wall-clock deadline the intent requires, and the comment at line 124 explicitly scopes broader clock correctness out and tracks it separately. Noting it so the tradeoff is on the record; the wake-from-sleep scenario the comment names at line 118 can step in either direction, and only one direction is covered.
- ℹ️ `tests/fm-remote-job.test.sh:714` - The comment reads &#34;...a deadline it can never reach. It&#34; / &#34;It must not end it early either&#34; - &#34;It&#34; is duplicated across the line break. Drop the trailing &#34;It&#34; on line 714.

🔧 Fix: cap backward re-anchoring so every wait terminates
2 issues (1 warning, 1 info) still open:
- ⚠️ `bin/fm-remote-job-lib.sh:159` - The re-anchor cap `[ &#34;$returned&#34; -lt &#34;$seconds&#34; ] || return 1` ends the wait on the backward reading itself, discarding whatever budget is left. Because the cap is checked BEFORE `returned` is incremented, one ordinary NTP correction saturates it in a single shot: a 3600s backwards step sets returned=3600, so any later backwards reading, even a 1s one, returns failure immediately. I reproduced this directly rather than inferring it: with a clock that steps back 3600s at t=1s and a further 5s at t=3s, `fm_remote_job_wait_until 60 never` returned 1 after 3 seconds of a 60 second budget. Through `fm_remote_job_wait_for_probe` that is exactly &#34;remote job worker did not report ready after startup&#34;, the CI failure this change exists to eliminate, and it contradicts the function&#39;s own header at line 116 (&#34;it must never hand back a budget it has not spent&#34;) and the round-4 instruction, which said to stop re-anchoring past the cap and then let &#34;the deadline stand&#34; until &#34;the next reading at or past it ends the wait&#34; - not to return on the backwards reading.

The cap is also unnecessary for termination, so the cheapest correct fix is to delete it (lines 159-161 plus `returned=0 step` at line 142) and keep only `deadline=$((deadline - (last - now)))`. Proof that termination survives: let gap = deadline - now. A backwards or equal reading leaves gap unchanged and increments `stalled`; an advancing reading decreases gap by at least 1 and resets `stalled`. So an infinite loop needs either finitely many advancing readings (then FM_REMOTE_JOB_CLOCK_MAX_MISSES consecutive non-advancing readings fires at line 153) or infinitely many advancing readings (then gap crosses zero at line 165). Either way it ends. The `stalled` arm added in the same commit is what actually fixed the round-4 hang; the cap adds nothing but this early return. Test &#34;the readiness wait ends against a clock that only goes backwards&#34; still passes after the deletion, terminating at ~5s via the stall backstop, well inside its 20s assertion.
- ℹ️ `bin/fm-remote-job-lib.sh:62` - FM_REMOTE_JOB_CLOCK_MAX_MISSES was introduced in the previous round as a bound on consecutive UNREADABLE clock readings; commit 7a7a2a0 silently widened it to also count readable-but-non-advancing readings (line 149). Two consequences worth the author&#39;s eye, neither reachable today.

First, the headroom is now coupled to the loop&#39;s hardcoded `sleep 0.1`. `date +%s` has one-second resolution, so a perfectly healthy wait already produces ~9 consecutive equal readings between each advancing one; 50 leaves about 5x margin. Anyone later shortening the poll interval (FM_REMOTE_JOB_POLL_SECONDS is already 0.05 elsewhere in this file) halves that margin, and at that point a healthy wait aborts with &#34;worker did not report ready&#34;.

Second, 50 misses x 0.1s means a clock that is unreadable or frozen caps the 60s readiness budget at roughly 5 seconds. That is the deliberate termination backstop and it is correct in kind, but it is a 12x haircut on the budget for the precise `date`-fork-fails-under-memory-pressure scenario the header comment at line 117 names as the motivation. If that scenario is considered real, 50 is on the low side; if it is not, the value is fine as is. Flagging the choice rather than changing it, since the default was left to the fixer&#39;s judgement.

🔧 Fix: delete backward re-anchor, leave stall bound as termination
3 issues (2 warnings, 1 info) still open:
- ⚠️ `bin/fm-remote-job-lib.sh:154` - `fm_remote_job_wait_until` does not terminate against a readable clock that fails to make net forward progress, contradicting the guarantee its own header states at line 126 (&#34;A wait always terminates, whatever the clock does&#34;). The stall counter only fires on CONSECUTIVE non-advancing readings: line 154 resets `stalled=0` on any strictly greater reading, and with the round-5 deletion of the re-anchor the deadline is now fixed at establishment, so a clock that advances then steps back never reaches it. Confirmed by execution rather than inference: with the shipped code, a stubbed clock alternating 2000000000/2000000001 on successive reads and `fm_remote_job_wait_until 3 never` ran until an 8s outer bound killed it (exit 124, 80 clock reads, stall counter never reached 50); the same harness on a healthy clock returns rc=1 at elapsed=3. The header&#39;s justification at line 122 (&#34;a clock that is unreadable, frozen, or stepping backwards never advances and so spends that allowance unaided&#34;) holds only for a MONOTONICALLY backwards clock, which is the exact case the new test at line 828 covers; a clock that is repeatedly corrected backwards while otherwise ticking forward advances between corrections and resets the counter every time. That is the same trigger class the round-4 finding named (a guest repeatedly corrected by a hypervisor, chrony makestep against a flapping source), which the cap deleted in round 5 used to cover. This wait runs on the remote side of the ssh invocation, where fm-on.sh&#39;s ServerAliveInterval only detects a dead peer and never a live-but-hung command, so the user&#39;s ssh blocks indefinitely. Related and already deliberate: a single large backward step extends the wait by the size of the step (the test at line 796 asserts a 3600s step outlives a 10s bound against a 3s budget), so the wait is in fact unbounded in wall-clock terms whenever the clock moves backwards at all. Two ways to resolve, and the choice is the author&#39;s given the explicit scope cut on clock machinery: either correct the header comment so it claims only what holds (termination is guaranteed for a clock that is unreadable, frozen, or monotonically backwards; a non-monotonic clock can extend a wait without bound), or add the single cheapest real backstop - a cumulative non-advancing-reading count, or a total-iteration ceiling derived from the budget and poll interval, rather than a consecutive one.
- ⚠️ `tests/fm-remote-job.test.sh:870` - `[ &#34;$WAIT_ELAPSED&#34; -le 4 ]` against a 3-second budget leaves under one second of slack and can fail on exactly the loaded runner this change targets. WAIT_ELAPSED is computed from two `date +%s` reads in the child script, so it equals 3 plus two independent second-boundary carries: one for the gap between `start=$(command date +%s)` at line 862 and the wait&#39;s first internal clock read (two forks), and one for the gap between the wait returning and the final `command date +%s` at line 866. Each carry adds 1. A third source of overshoot exists under load: the loop returns at the first READ at or past the deadline, and if an iteration stretches past 1s (the reproduction environment was 400 concurrent busy loops on 16 CPUs) the crossing read lands a full second beyond the deadline. Any two of those three push the measure to 5 and the assertion fails with &#34;a healthy clock ran the readiness wait past its deadline into the stall allowance&#34;, blaming the code under test for host load. The assertion needs to stay strictly under the stall allowance (50 x 0.1s = 5s) to pin the headroom it exists to pin, so widening the tolerance alone is not enough - raising FM_REMOTE_JOB_CLOCK_MAX_STALLS for this script only (it is already parameterised in the sibling scripts at lines 726 and 882) would let the budget and the tolerance both grow and restore real margin.
- ℹ️ `tests/fm-remote-job.test.sh:916` - `[ &#34;$WAIT_ELAPSED&#34; -ge 5 ]` can fail legitimately. Each leg reads the clock at t1, then every ~1.1s (1s liveness stub plus the loop&#39;s 0.1s sleep), and returns at the first read whose floor is at or past floor(t1)+3. When frac(t1) &gt;= 0.9 the read at t1+2.1 already qualifies, so a leg costs 2.1s instead of 3.2s. Both legs landing there gives ~4.2s total, which floors to 4 and trips &#34;the shutdown wait gave up before spending its configured budget&#34; even though the deadline behaved correctly. Roughly a 1% shape, further reduced by the floor happening to round to 5, so low - but `-ge 4` proves the same thing (a counted 50-iteration leg would cost 55s per leg and be killed by the 40s outer bound at line 912, which is what actually distinguishes the two designs here) without the edge.

🔧 Fix: bound waits with a poll ceiling, widen test tolerances
2 issues (1 warning, 1 info) still open:
- ⚠️ `tests/fm-remote-job.test.sh:783` - The backwards-step test arms its clock stub with a wall-clock instant rather than a deterministic call count, so it can report a false failure. `start=$(command date +%s)` at line 782 is followed by `export FM_STEP_AFTER=$((start + 1))`, and the stub steps back 3600s once `command date +%s` reaches that value. The wait&#39;s very first clock read happens at bin/fm-remote-job-lib.sh:164, before any predicate call, and is what anchors the deadline. If that read lands at or after `start + 1`, the deadline is anchored in already-stepped-back time, every later reading advances normally from there, and the wait ends at its 3s budget instead of outliving the 10s outer bound. The script then exits 0 and line 797 fails with &#34;a backwards clock step ended the readiness wait early, exit 0 against a budget of 3s&#34; - blaming the code under test for host timing. I reproduced this by forcing the raced case (FM_STEP_AFTER=$start): the wait returned after elapsed=3 and fm_run_timed reported status 0, not 124. The race window is the gap between the two `command date` reads, which I measured at ~0.8ms idle in this environment; it widens with fork latency under the 400-busy-loop load this whole change targets, and the author&#39;s round-6 instruction explicitly asked that no bound in these tests be able to fail for benign reasons. Fix it the way every sibling stub in this block already works (lines 753-759, 816-821, 893-898): hold a call count in a file and step back only from, say, the second or third stub invocation onward, so the first reading is always pre-step by construction.
- ℹ️ `bin/fm-remote-job-lib.sh:170` - Recording the size of the guarantee, since the ceiling is now the sole backstop for a clock that advances and is corrected backwards repeatedly (the stall counter resets on any strictly greater reading at line 172, and the deadline is fixed at establishment). The ceiling is denominated in polls, not wall time: `seconds * FM_REMOTE_JOB_WAIT_MAX_POLLS_PER_SECOND` is 60 x 1000 = 60000 polls for the shipped readiness budget, at a floor of 0.1s per poll, so the wait terminates after roughly 100 minutes - and later still when each probe is slow, which is precisely the loaded-host case, since the header at lines 143-147 correctly notes an expensive check moves the ceiling further away. The shutdown wait is 15000 polls per leg, about 25 minutes each, inside teardown. I confirmed the mechanism at defaults rather than inferring it: an oscillating stub against a 3s budget was still polling when an 8s outer bound killed it, having used 80 of its 3000 polls. Termination does hold, and the trigger is exotic (a guest repeatedly corrected by a hypervisor, chrony makestep against a flapping source). This is the author&#39;s explicitly prescribed 100x margin, documented at length and deliberately kept out of the clock-correctness item tracked separately, so I am flagging the magnitude rather than proposing a change: a wait on the remote side of an unbounded ssh that ends after 100 minutes is only nominally bounded, and a wall-clock ceiling (or a smaller multiplier) would bound it in the unit the caller cares about.

🔧 Fix: derive poll ceiling from budget, de-race backstep test
2 infos still open:
- ℹ️ `bin/fm-remote-job-lib.sh:155` - The worst-case paragraph states the ceiling&#39;s bound for the wrong clock, and overstates how tight it is. It says &#34;fifty polls per second of budget at a tenth of a second each means a clock that never advances fails a wait after about five times its budget, roughly five minutes for the sixty second readiness wait&#34;. But a clock that never advances is exactly what FM_REMOTE_JOB_CLOCK_MAX_STALLS catches, per this file&#39;s own wording at lines 128-129 (&#34;unreadable, frozen, or backwards alike&#34;): 50 stalls x 0.1s ends that wait in about five seconds, not five minutes. The clock that actually reaches the ceiling is the oscillating one described at lines 133-135, which resets the stall counter on every advancing reading. Second, the &#34;five times its budget&#34; wall-time figure only holds when each poll costs the 0.1s sleep floor. Wall time at the ceiling is ceiling x per-poll cost, and lines 146-148 correctly note an expensive check makes each poll longer - so with a one-second probe on the loaded host this file is written for, the readiness ceiling is 3000 polls x ~1.1s, roughly 55 minutes rather than 5. The mechanism is right and the code is correct; the paragraph a future reader will use to re-derive the bound is not. Rewrite it to attribute the ceiling to a clock that oscillates rather than one that never advances, and to state the wall-time worst case as ceiling x per-poll cost (five times the budget only at the 0.1s floor).
- ℹ️ `tests/fm-remote-job.test.sh:807` - The backwards-step test is the only one that reads a stub&#39;s state file from a child that fm_run_timed just killed, and the stub&#39;s write is not atomic. The clock stub does `printf &#39;%s\n&#39; &#34;$reads&#34; &gt; &#34;$STEP_FILE&#34;` (line 792) inside a command-substitution subshell; the redirection truncates before printf writes. GNU timeout TERMs the whole process group at 10s and KILLs 1s later, so a signal landing in that window leaves the file empty. Line 807 then evaluates `[ &#34;&#34; -gt 3 ]`, which bash reports as &#34;integer expression expected&#34; and returns 2, so the `|| fail` fires with &#34;the readiness wait never read the clock past the backwards step&#34; - blaming the code under test for a signal-timing accident. The window is roughly 10-20us inside a ~0.1s loop, so on the order of 0.01-0.02% per run, but it is the one benign-failure mode left in these tests and the assertion shape (assert the child is still running at the bound) makes it unavoidable without an atomic write. The sibling stubs at lines 828-829, 905-906 and 755-756 are read only after their child exits normally, so they are not affected. Fix by writing through a temp file and rename: `printf &#39;%s\n&#39; &#34;$reads&#34; &gt; &#34;$STEP_FILE.tmp&#34; &amp;&amp; mv -f &#34;$STEP_FILE.tmp&#34; &#34;$STEP_FILE&#34;`.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `tests/fm-remote-job.test.sh:336` - tests/fm-remote-job.test.sh:336 &#34;queue time consumed the second job&#39;s execution timeout&#34; is load-sensitive independently of this change. It failed twice on the base tree under 800 busy loops on 16 CPUs, where a 1.8s job plus scheduling overhead outgrows the test&#39;s 3s FM_REMOTE_JOB_TIMEOUT. The code and the test are identical in both trees, so it is not a regression from the deadline work, and it never appeared at the 400-loop reproduction load. Recorded so a reviewer knows the same file holds a second timing assumption that a slow enough runner can break.
- <code>`bash tests/fm-remote-job.test.sh` at 302efff on an idle box: 36 tests including the 14 new wait tests, all passing</code>
- <code>`probe-wait-budget-compare.sh &lt;base lib&gt; &lt;fixed lib&gt;`: same nominal 20s readiness budget on both commits, driven with 0.05s, 0.2s and 1.0s probes, measuring what the budget is actually worth</code>
- <code>`slow-startup-e2e.sh &lt;lib&gt; &lt;label&gt; 50`: real `fm_remote_job_ensure_worker` against a worker that takes 50s to publish identity and heartbeat, run against base and fix</code>
- <code>`fail-before-fix.sh &lt;lib&gt; &lt;label&gt;`: the three cost-asymmetry scenarios from the new tests (1s probe, 10s probe, 1s liveness check) with the tests&#39; own outer bounds and elapsed windows, run against base and fix</code>
- <code>`loaded-ab.sh <scratch-base> &lt;worktree&gt; 2` at 400 busy loops on 16 CPUs, alternating base and fix with an idle wait before each run</code>
- <code>`LOOPS=800 loaded-ab.sh <scratch-base> &lt;worktree&gt; 1` plus two further rounds at 800 loops, which reproduced `remote job worker did not report ready after startup` at `worker identity binds the canonical configured code root` on base while the fix passed 3 of 3</code>
- `4 further base-only runs at 800 loops attempting to recapture the readiness flake transcript, which surfaced the unrelated queue-window flake twice instead`
- <code>`git status --porcelain` in the worktree plus a sweep for leftover worker processes and fixture directories after testing</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/configuration.md:511` - Judgment call on placement: the two new operator-tunable budgets (FM_REMOTE_JOB_PROBE_WAIT_SECONDS, FM_REMOTE_JOB_STOP_WAIT_SECONDS) were documented in the bin/fm-remote-job-lib.sh script header rather than in docs/configuration.md&#39;s environment-variable block. That block lists no FM_REMOTE_JOB_* variable at all today, and the coding-guidelines decision tree routes exact mechanics to the script&#39;s own header, so adding only the two new ones to configuration.md would have created a partial second copy. If the repo later wants the whole FM_REMOTE_JOB_* family in configuration.md, that is a single follow-up consolidation, deliberately out of scope here.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

