### PR TITLE
fix(spawn): allow crewmate and scout launches on projects with no origin remote

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -138,6 +138,10 @@
 #   origin, resolves the current remote default branch, and resets to its tip.
 #   An unreachable origin, unresolved default branch, or non-clean worktree
 #   refuses the spawn rather than risking a PR based on stale history.
+#   A project with no origin remote (positively detected, never inferred from a
+#   failed fetch) skips only that fetch-and-reset machinery and launches with one
+#   notice that its base was not freshened; the non-clean worktree refusal is
+#   remote-independent and still applies.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -1727,9 +1731,25 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   fi
 }
 
+# A pooled worktree carrying uncommitted work is never a safe base for a fresh
+# worker, with or without an origin to freshen against, so this guard is
+# remote-independent and every freshen path owes it.
+require_clean_spawn_worktree() {  # <worktree>
+  local worktree=$1 status
+  status=$(git -C "$worktree" status --porcelain) || {
+    echo "error: could not inspect pooled worktree '$worktree' before refreshing its base" >&2
+    return 1
+  }
+  if [ -n "$status" ]; then
+    echo "error: pooled worktree '$worktree' is not clean; refusing to discard uncommitted work while refreshing its base" >&2
+    return 1
+  fi
+}
+
 freshen_spawn_worktree_base() {  # <worktree>
-  local worktree=$1 default target expected actual status
+  local worktree=$1 default target expected actual
   if ! git -C "$worktree" remote get-url origin >/dev/null 2>&1; then
+    require_clean_spawn_worktree "$worktree" || return 1
     echo "notice: pooled worktree '$worktree' base was not freshened because the project has no remote" >&2
     return 0
   fi
@@ -1754,14 +1774,7 @@ freshen_spawn_worktree_base() {  # <worktree>
     echo "error: '$target' is not a commit for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
     return 1
   }
-  status=$(git -C "$worktree" status --porcelain) || {
-    echo "error: could not inspect pooled worktree '$worktree' before refreshing its base" >&2
-    return 1
-  }
-  if [ -n "$status" ]; then
-    echo "error: pooled worktree '$worktree' is not clean; refusing to discard uncommitted work while refreshing its base" >&2
-    return 1
-  fi
+  require_clean_spawn_worktree "$worktree" || return 1
   if ! git -C "$worktree" reset --hard "$target" >/dev/null; then
     echo "error: could not reset pooled worktree '$worktree' to '$target'; refusing to launch from a potentially stale base" >&2
     return 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1729,6 +1729,10 @@ validate_spawn_worktree() {  # <source> <inspect-target>
 
 freshen_spawn_worktree_base() {  # <worktree>
   local worktree=$1 default target expected actual status
+  if ! git -C "$worktree" remote get-url origin >/dev/null 2>&1; then
+    echo "notice: pooled worktree '$worktree' base was not freshened because the project has no remote" >&2
+    return 0
+  fi
   if ! git -C "$worktree" fetch --quiet origin; then
     echo "error: could not fetch origin for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
     return 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -138,10 +138,12 @@
 #   origin, resolves the current remote default branch, and resets to its tip.
 #   An unreachable origin, unresolved default branch, or non-clean worktree
 #   refuses the spawn rather than risking a PR based on stale history.
-#   A project with no origin remote (positively detected, never inferred from a
-#   failed fetch) skips only that fetch-and-reset machinery and launches with one
-#   notice that its base was not freshened; the non-clean worktree refusal is
-#   remote-independent and still applies.
+#   A project with no origin remote (read positively off the configured remote
+#   list, never inferred from a failed fetch, so an origin that is configured but
+#   unusable still refuses) skips only that fetch-and-reset machinery and launches
+#   with one notice that its base was not freshened; the non-clean worktree
+#   refusal is remote-independent and still applies, in its own wording that names
+#   the missing remote instead of claiming a refresh that never ran.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -1733,23 +1735,31 @@ validate_spawn_worktree() {  # <source> <inspect-target>
 
 # A pooled worktree carrying uncommitted work is never a safe base for a fresh
 # worker, with or without an origin to freshen against, so this guard is
-# remote-independent and every freshen path owes it.
-require_clean_spawn_worktree() {  # <worktree>
-  local worktree=$1 status
+# remote-independent and every freshen path owes it. Each caller supplies the
+# tail that states its own situation, because only the origin path is about to
+# refresh anything and a refusal must never claim a refresh that never ran.
+require_clean_spawn_worktree() {  # <worktree> <inspect-failure-tail> <not-clean-tail>
+  local worktree=$1 inspect_tail=$2 not_clean_tail=$3 status
   status=$(git -C "$worktree" status --porcelain) || {
-    echo "error: could not inspect pooled worktree '$worktree' before refreshing its base" >&2
+    echo "error: could not inspect pooled worktree '$worktree' $inspect_tail" >&2
     return 1
   }
   if [ -n "$status" ]; then
-    echo "error: pooled worktree '$worktree' is not clean; refusing to discard uncommitted work while refreshing its base" >&2
+    echo "error: pooled worktree '$worktree' is not clean; $not_clean_tail" >&2
     return 1
   fi
 }
 
+# Absence of origin is read positively off the configured remote list, never
+# inferred from a command that failed: an unreadable remote list, or an origin
+# that is configured but unusable, falls through to the fetch, whose refusal is
+# the real staleness guard.
 freshen_spawn_worktree_base() {  # <worktree>
-  local worktree=$1 default target expected actual
-  if ! git -C "$worktree" remote get-url origin >/dev/null 2>&1; then
-    require_clean_spawn_worktree "$worktree" || return 1
+  local worktree=$1 default target expected actual remotes
+  if remotes=$(git -C "$worktree" remote 2>/dev/null) && ! printf '%s\n' "$remotes" | grep -qx origin; then
+    require_clean_spawn_worktree "$worktree" \
+      'before launching from it; the project has no remote' \
+      'the project has no remote, so refusing to launch a worker on top of uncommitted work' || return 1
     echo "notice: pooled worktree '$worktree' base was not freshened because the project has no remote" >&2
     return 0
   fi
@@ -1774,7 +1784,9 @@ freshen_spawn_worktree_base() {  # <worktree>
     echo "error: '$target' is not a commit for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
     return 1
   }
-  require_clean_spawn_worktree "$worktree" || return 1
+  require_clean_spawn_worktree "$worktree" \
+    'before refreshing its base' \
+    'refusing to discard uncommitted work while refreshing its base' || return 1
   if ! git -C "$worktree" reset --hard "$target" >/dev/null; then
     echo "error: could not reset pooled worktree '$worktree' to '$target'; refusing to launch from a potentially stale base" >&2
     return 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1758,9 +1758,9 @@ freshen_spawn_worktree_base() {  # <worktree>
   local worktree=$1 default target expected actual remotes
   if remotes=$(git -C "$worktree" remote 2>/dev/null) && ! printf '%s\n' "$remotes" | grep -qx origin; then
     require_clean_spawn_worktree "$worktree" \
-      'before launching from it; the project has no remote' \
-      'the project has no remote, so refusing to launch a worker on top of uncommitted work' || return 1
-    echo "notice: pooled worktree '$worktree' base was not freshened because the project has no remote" >&2
+      'before launching from it; the project has no origin remote' \
+      'the project has no origin remote, so refusing to launch a worker on top of uncommitted work' || return 1
+    echo "notice: pooled worktree '$worktree' base was not freshened because the project has no origin remote" >&2
     return 0
   fi
   if ! git -C "$worktree" fetch --quiet origin; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -142,8 +142,8 @@
 #   list, never inferred from a failed fetch, so an origin that is configured but
 #   unusable still refuses) skips only that fetch-and-reset machinery and launches
 #   with one notice that its base was not freshened; the non-clean worktree
-#   refusal is remote-independent and still applies, in its own wording that names
-#   the missing remote instead of claiming a refresh that never ran.
+#   refusal is remote-independent and still applies, in its own wording that
+#   names the missing origin remote instead of claiming a refresh that never ran.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -158,7 +158,7 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
 `fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
-A project with no origin remote is the single exception: there is nothing to freshen against, so the spawn skips the fetch and reset and launches with one notice instead, while the clean-worktree requirement still holds.
+A project with no origin remote is the single exception: there is no origin to freshen against, so the spawn skips the fetch and reset and launches with one notice instead, while the clean-worktree requirement still holds.
 Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -158,6 +158,7 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
 `fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
+A project with no origin remote is the single exception: there is nothing to freshen against, so the spawn skips the fetch and reset and launches with one notice instead, while the clean-worktree requirement still holds.
 Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -206,6 +206,52 @@ test_dirty_pool_refuses_without_discarding_work() {
   pass "a dirty pooled worktree is refused without discarding its local work"
 }
 
+make_no_origin_case() {
+  local name=$1 id=$2 case_dir home project pool fakebin initial
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  pool="$case_dir/pool"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'codex\n' > "$home/config/crew-harness"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  touch "$home/state/.last-watcher-beat"
+
+  git init --quiet -b main "$project"
+  printf 'base\n' > "$project/README.md"
+  git -C "$project" add README.md
+  git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+  initial=$(git -C "$project" rev-parse HEAD)
+  git -C "$project" worktree add --quiet --detach "$pool" "$initial"
+
+  printf '%s\n' "$case_dir|$home|$project|$pool|$fakebin|$initial|main"
+}
+
+test_no_origin_remote_skips_freshen_and_succeeds() {
+  local rec id out status before
+  id='pool-no-origin-r6'
+  rec=$(make_no_origin_case no-origin "$id")
+  read_case_record "$rec"
+  git -C "$POOL_DIR" remote 2>/dev/null | grep -qx origin \
+    && fail "fixture unexpectedly configured an origin remote"
+  before=$(git -C "$POOL_DIR" rev-parse HEAD)
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 0 "$status" "spawn should succeed on a pooled worktree with no origin remote"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  assert_contains "$out" "was not freshened because the project has no remote" \
+    "spawn did not print a clear no-remote notice"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
+    || fail "spawn moved HEAD in a pooled worktree with no remote to freshen from"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed no-origin spawn: %s\n' "$(printf '%s\n' "$out" | tail -n 1)"
+  fi
+  pass "a pooled worktree with no origin remote skips the freshen and still spawns"
+}
+
 test_unresolved_remote_default_refuses_pool() {
   local rec id out status before
   id='pool-unresolved-default-r5'
@@ -233,5 +279,6 @@ test_direct_pr_and_scout_refresh_before_launch
 test_dirty_pool_refuses_without_discarding_work
 test_unresolved_remote_default_refuses_pool
 test_unreachable_origin_refuses_stale_pool_base
+test_no_origin_remote_skips_freshen_and_succeeds
 
 echo "# all fm-spawn-pool-base-freshen tests passed"

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -8,7 +8,8 @@
 # unreachable.
 # A project with no origin remote has no tip to freshen against, so these tests
 # also prove that spawn skips only the freshen there, says so once on stderr,
-# and still refuses a dirty pool.
+# and still refuses a dirty pool in wording that names the missing remote, while
+# an origin that is configured but unusable keeps the unchanged refusal.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -217,7 +218,8 @@ test_dirty_pool_refuses_without_discarding_work() {
   out=$(run_spawn "$id" --mode no-mistakes --yolo off)
   status=$?
   [ "$status" -ne 0 ] || fail "spawn succeeded despite a dirty pooled worktree"
-  assert_contains "$out" "is not clean" "spawn did not clearly refuse a dirty pooled worktree"
+  assert_contains "$out" "is not clean; refusing to discard uncommitted work while refreshing its base" \
+    "the origin path's dirty refusal no longer reads exactly as it did"
   [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
     || fail "spawn moved HEAD while refusing a dirty pooled worktree"
   assert_grep 'keep this local work' "$POOL_DIR/uncommitted.txt" \
@@ -260,9 +262,11 @@ test_no_origin_remote_skips_freshen_and_succeeds() {
 
 # The clean-pool guard is remote-independent, so skipping the freshen must not
 # skip it. A no-origin pool that came back dirty would otherwise start a worker
-# on top of foreign uncommitted work and commit it into fm/<id>.
+# on top of foreign uncommitted work and commit it into fm/<id>. Nothing is
+# fetched or reset here, so the refusal must name the missing remote rather than
+# blame a refresh that never ran.
 test_no_origin_dirty_pool_refuses_without_discarding_work() {
-  local rec id out status before
+  local rec id out status before refusals
   id='pool-no-origin-dirty-r6'
   rec=$(make_case no-origin-dirty "$id" main no-origin)
   read_case_record "$rec"
@@ -272,8 +276,12 @@ test_no_origin_dirty_pool_refuses_without_discarding_work() {
   out=$(run_spawn "$id" --mode no-mistakes --yolo off)
   status=$?
   [ "$status" -ne 0 ] || fail "spawn succeeded on a dirty pooled worktree with no origin remote"
-  assert_contains "$out" "is not clean" \
-    "spawn did not refuse a dirty pooled worktree when there was no remote to freshen from"
+  refusals=$(printf '%s\n' "$out" \
+    | grep -c "^error: .*is not clean; the project has no remote, so refusing to launch a worker on top of uncommitted work$" || true)
+  [ "$refusals" = 1 ] \
+    || fail "the no-remote dirty refusal should be exactly one complete line naming the missing remote, found $refusals"$'\n'"--- output ---"$'\n'"$out"
+  assert_not_contains "$out" "refreshing its base" \
+    "the no-remote refusal blamed a refresh that never ran"
   [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
     || fail "spawn moved HEAD while refusing a dirty no-remote pooled worktree"
   assert_grep 'keep this local work' "$POOL_DIR/uncommitted.txt" \
@@ -283,6 +291,35 @@ test_no_origin_dirty_pool_refuses_without_discarding_work() {
       "$(printf '%s\n' "$out" | tail -n 1)" "$(cat "$POOL_DIR/uncommitted.txt")"
   fi
   pass "a dirty pooled worktree with no origin remote is refused without discarding its local work"
+}
+
+# A configured origin that cannot be fetched from is not an absent origin.
+# Absence is read off the remote list, so this pool still owes the fetch and
+# still gets the unchanged staleness refusal rather than the no-remote skip.
+test_configured_but_unusable_origin_still_refuses() {
+  local rec id out status before
+  id='pool-unusable-origin-r7'
+  rec=$(make_case unusable-origin "$id")
+  read_case_record "$rec"
+  git -C "$POOL_DIR" remote set-url --push origin "file://$CASE_DIR/origin.git"
+  git -C "$POOL_DIR" config --unset remote.origin.url
+  git -C "$POOL_DIR" remote | grep -qx origin \
+    || fail "fixture no longer lists an origin remote to fetch from"
+  before=$(git -C "$POOL_DIR" rev-parse HEAD)
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn succeeded despite an origin with no fetch address"
+  assert_contains "$out" "could not fetch origin" \
+    "spawn did not refuse an origin that is configured but has no fetch address"
+  assert_not_contains "$out" "the project has no remote" \
+    "spawn mistook a configured but unusable origin for an absent one"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
+    || fail "spawn moved HEAD after failing to fetch a configured origin"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed unusable-origin refusal: %s\n' "$(printf '%s\n' "$out" | tail -n 1)"
+  fi
+  pass "an origin configured without a fetch address still refuses instead of skipping the freshen"
 }
 
 test_unresolved_remote_default_refuses_pool() {
@@ -314,5 +351,6 @@ test_unresolved_remote_default_refuses_pool
 test_unreachable_origin_refuses_stale_pool_base
 test_no_origin_remote_skips_freshen_and_succeeds
 test_no_origin_dirty_pool_refuses_without_discarding_work
+test_configured_but_unusable_origin_still_refuses
 
 echo "# all fm-spawn-pool-base-freshen tests passed"

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -7,9 +7,10 @@
 # starts the worker from the fetched origin/main tip or stops when origin is
 # unreachable.
 # A project with no origin remote has no tip to freshen against, so these tests
-# also prove that spawn skips only the freshen there, says so once on stderr,
-# and still refuses a dirty pool in wording that names the missing remote, while
-# an origin that is configured but unusable keeps the unchanged refusal.
+# also prove that spawn skips only the freshen there, says so once on stderr, and
+# still refuses a dirty pool in wording that names the missing origin remote even
+# when other remotes exist, while an origin that is configured but unusable keeps
+# the unchanged refusal.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -245,11 +246,11 @@ test_no_origin_remote_skips_freshen_and_succeeds() {
   status=$?
   expect_code 0 "$status" "spawn should succeed on a pooled worktree with no origin remote"
   assert_contains "$out" "spawned $id" "spawn did not report success"
-  notices=$(grep -c "^notice: .*was not freshened because the project has no remote$" "$errfile" || true)
+  notices=$(grep -c "^notice: .*was not freshened because the project has no origin remote$" "$errfile" || true)
   [ "$notices" = 1 ] \
-    || fail "the no-remote notice should be exactly one complete stderr line, found $notices"$'\n'"--- stderr ---"$'\n'"$(cat "$errfile")"
-  assert_not_contains "$out" "was not freshened because the project has no remote" \
-    "the no-remote notice leaked onto stdout"
+    || fail "the no-origin notice should be exactly one complete stderr line, found $notices"$'\n'"--- stderr ---"$'\n'"$(cat "$errfile")"
+  assert_not_contains "$out" "was not freshened because the project has no origin remote" \
+    "the no-origin notice leaked onto stdout"
   [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
     || fail "spawn moved HEAD in a pooled worktree with no remote to freshen from"
   if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
@@ -277,11 +278,11 @@ test_no_origin_dirty_pool_refuses_without_discarding_work() {
   status=$?
   [ "$status" -ne 0 ] || fail "spawn succeeded on a dirty pooled worktree with no origin remote"
   refusals=$(printf '%s\n' "$out" \
-    | grep -c "^error: .*is not clean; the project has no remote, so refusing to launch a worker on top of uncommitted work$" || true)
+    | grep -c "^error: .*is not clean; the project has no origin remote, so refusing to launch a worker on top of uncommitted work$" || true)
   [ "$refusals" = 1 ] \
-    || fail "the no-remote dirty refusal should be exactly one complete line naming the missing remote, found $refusals"$'\n'"--- output ---"$'\n'"$out"
+    || fail "the no-origin dirty refusal should be exactly one complete line naming the missing origin remote, found $refusals"$'\n'"--- output ---"$'\n'"$out"
   assert_not_contains "$out" "refreshing its base" \
-    "the no-remote refusal blamed a refresh that never ran"
+    "the no-origin refusal blamed a refresh that never ran"
   [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
     || fail "spawn moved HEAD while refusing a dirty no-remote pooled worktree"
   assert_grep 'keep this local work' "$POOL_DIR/uncommitted.txt" \
@@ -291,6 +292,40 @@ test_no_origin_dirty_pool_refuses_without_discarding_work() {
       "$(printf '%s\n' "$out" | tail -n 1)" "$(cat "$POOL_DIR/uncommitted.txt")"
   fi
   pass "a dirty pooled worktree with no origin remote is refused without discarding its local work"
+}
+
+# The freshen target is origin specifically, so a fork checkout carrying only
+# `upstream` has no origin to freshen against and takes the same skip. It does
+# have a remote, so the diagnostic has to name the missing origin rather than
+# claim the project has no remote at all, and nothing may be fetched from the
+# remote that is there.
+test_non_origin_remote_only_skips_freshen_and_names_origin() {
+  local rec id out status before errfile notices
+  id='pool-upstream-only-r7'
+  rec=$(make_case upstream-only "$id" main no-origin)
+  read_case_record "$rec"
+  git -C "$POOL_DIR" remote add upstream "file://$CASE_DIR/upstream-never-fetched.git"
+  before=$(git -C "$POOL_DIR" rev-parse HEAD)
+  errfile="$CASE_DIR/spawn.stderr"
+
+  out=$(spawn_env "$id" --mode no-mistakes --yolo off 2>"$errfile")
+  status=$?
+  expect_code 0 "$status" "spawn should succeed on a pool whose only remote is not origin"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  notices=$(grep -c "^notice: .*was not freshened because the project has no origin remote$" "$errfile" || true)
+  [ "$notices" = 1 ] \
+    || fail "an upstream-only pool should get exactly one complete notice naming the missing origin remote, found $notices"$'\n'"--- stderr ---"$'\n'"$(cat "$errfile")"
+  assert_not_contains "$(cat "$errfile")" "has no remote" \
+    "spawn told the operator the project has no remote while it has an upstream"
+  [ -z "$(git -C "$POOL_DIR" for-each-ref --format='%(refname)' refs/remotes/upstream)" ] \
+    || fail "spawn fetched a non-origin remote while skipping the freshen"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
+    || fail "spawn moved HEAD in a pooled worktree with no origin to freshen from"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed upstream-only notice: %s\n' "$(grep 'was not freshened' "$errfile")"
+    printf '# observed upstream-only remotes: %s\n' "$(git -C "$POOL_DIR" remote | tr '\n' ' ')"
+  fi
+  pass "a pool whose only remote is not origin skips the freshen and names the missing origin remote"
 }
 
 # A configured origin that cannot be fetched from is not an absent origin.
@@ -312,7 +347,7 @@ test_configured_but_unusable_origin_still_refuses() {
   [ "$status" -ne 0 ] || fail "spawn succeeded despite an origin with no fetch address"
   assert_contains "$out" "could not fetch origin" \
     "spawn did not refuse an origin that is configured but has no fetch address"
-  assert_not_contains "$out" "the project has no remote" \
+  assert_not_contains "$out" "the project has no origin remote" \
     "spawn mistook a configured but unusable origin for an absent one"
   [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
     || fail "spawn moved HEAD after failing to fetch a configured origin"
@@ -351,6 +386,7 @@ test_unresolved_remote_default_refuses_pool
 test_unreachable_origin_refuses_stale_pool_base
 test_no_origin_remote_skips_freshen_and_succeeds
 test_no_origin_dirty_pool_refuses_without_discarding_work
+test_non_origin_remote_only_skips_freshen_and_names_origin
 test_configured_but_unusable_origin_still_refuses
 
 echo "# all fm-spawn-pool-base-freshen tests passed"

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -6,6 +6,9 @@
 # These tests drive the real spawn path with a fake terminal, then prove it
 # starts the worker from the fetched origin/main tip or stops when origin is
 # unreachable.
+# A project with no origin remote has no tip to freshen against, so these tests
+# also prove that spawn skips only the freshen there, says so once on stderr,
+# and still refuses a dirty pool.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -34,8 +37,17 @@ SH
   printf '%s\n' "$fakebin"
 }
 
+# make_case <name> <id> [default-branch] [origin|no-origin]
+#
+# The no-origin variant is the same fixture minus the bare origin clone, the
+# `remote add origin`, and the publisher push that advances the default branch,
+# so the two shapes cannot drift apart.
 make_case() {
-  local name=$1 id=$2 default=${3:-main} case_dir home project origin pool publisher fakebin initial
+  local name=$1 id=$2 default=${3:-main} origin_mode=${4:-origin} case_dir home project origin pool publisher fakebin initial
+  case "$origin_mode" in
+    origin|no-origin) : ;;
+    *) fail "make_case: unknown origin mode '$origin_mode'" ;;
+  esac
   case_dir="$TMP_ROOT/$name"
   home="$case_dir/home"
   project="$case_dir/project"
@@ -53,16 +65,20 @@ make_case() {
   printf 'base\n' > "$project/README.md"
   git -C "$project" add README.md
   git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
-  git clone --quiet --bare "$project" "$origin"
-  git -C "$project" remote add origin "file://$origin"
+  if [ "$origin_mode" = origin ]; then
+    git clone --quiet --bare "$project" "$origin"
+    git -C "$project" remote add origin "file://$origin"
+  fi
   initial=$(git -C "$project" rev-parse HEAD)
   git -C "$project" worktree add --quiet --detach "$pool" "$initial"
 
-  git clone --quiet "file://$origin" "$publisher"
-  printf 'must survive a newly spawned branch\n' > "$publisher/advanced-main.txt"
-  git -C "$publisher" add advanced-main.txt
-  git -C "$publisher" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm advance-main
-  git -C "$publisher" push --quiet origin "$default"
+  if [ "$origin_mode" = origin ]; then
+    git clone --quiet "file://$origin" "$publisher"
+    printf 'must survive a newly spawned branch\n' > "$publisher/advanced-main.txt"
+    git -C "$publisher" add advanced-main.txt
+    git -C "$publisher" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm advance-main
+    git -C "$publisher" push --quiet origin "$default"
+  fi
 
   printf '%s\n' "$case_dir|$home|$project|$pool|$fakebin|$initial|$default"
 }
@@ -73,7 +89,10 @@ $1
 EOF
 }
 
-run_spawn() {
+# spawn_env leaves both streams alone so a caller that cares which stream a
+# message lands on can redirect them separately; run_spawn is the merged form
+# most cases want.
+spawn_env() {
   local id=$1
   shift
   FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
@@ -81,7 +100,11 @@ run_spawn() {
     FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
     FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" FM_FAKE_PANE_PATH="$POOL_DIR" \
     PATH="$FAKEBIN_DIR:$PATH" \
-    "$SPAWN" "$id" "$PROJECT_DIR" "$@" 2>&1
+    "$SPAWN" "$id" "$PROJECT_DIR" "$@"
+}
+
+run_spawn() {
+  spawn_env "$@" 2>&1
 }
 
 test_stale_pool_base_refreshes_before_branching() {
@@ -206,50 +229,60 @@ test_dirty_pool_refuses_without_discarding_work() {
   pass "a dirty pooled worktree is refused without discarding its local work"
 }
 
-make_no_origin_case() {
-  local name=$1 id=$2 case_dir home project pool fakebin initial
-  case_dir="$TMP_ROOT/$name"
-  home="$case_dir/home"
-  project="$case_dir/project"
-  pool="$case_dir/pool"
-  fakebin=$(make_spawn_fakebin "$case_dir/fake")
-
-  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
-  printf 'codex\n' > "$home/config/crew-harness"
-  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
-  touch "$home/state/.last-watcher-beat"
-
-  git init --quiet -b main "$project"
-  printf 'base\n' > "$project/README.md"
-  git -C "$project" add README.md
-  git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
-  initial=$(git -C "$project" rev-parse HEAD)
-  git -C "$project" worktree add --quiet --detach "$pool" "$initial"
-
-  printf '%s\n' "$case_dir|$home|$project|$pool|$fakebin|$initial|main"
-}
-
 test_no_origin_remote_skips_freshen_and_succeeds() {
-  local rec id out status before
+  local rec id out status before errfile notices
   id='pool-no-origin-r6'
-  rec=$(make_no_origin_case no-origin "$id")
+  rec=$(make_case no-origin "$id" main no-origin)
   read_case_record "$rec"
   git -C "$POOL_DIR" remote 2>/dev/null | grep -qx origin \
     && fail "fixture unexpectedly configured an origin remote"
   before=$(git -C "$POOL_DIR" rev-parse HEAD)
+  errfile="$CASE_DIR/spawn.stderr"
 
-  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  out=$(spawn_env "$id" --mode no-mistakes --yolo off 2>"$errfile")
   status=$?
   expect_code 0 "$status" "spawn should succeed on a pooled worktree with no origin remote"
   assert_contains "$out" "spawned $id" "spawn did not report success"
-  assert_contains "$out" "was not freshened because the project has no remote" \
-    "spawn did not print a clear no-remote notice"
+  notices=$(grep -c "^notice: .*was not freshened because the project has no remote$" "$errfile" || true)
+  [ "$notices" = 1 ] \
+    || fail "the no-remote notice should be exactly one complete stderr line, found $notices"$'\n'"--- stderr ---"$'\n'"$(cat "$errfile")"
+  assert_not_contains "$out" "was not freshened because the project has no remote" \
+    "the no-remote notice leaked onto stdout"
   [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
     || fail "spawn moved HEAD in a pooled worktree with no remote to freshen from"
   if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
     printf '# observed no-origin spawn: %s\n' "$(printf '%s\n' "$out" | tail -n 1)"
+    printf '# observed no-origin notice: %s\n' \
+      "$(grep 'was not freshened' "$errfile")"
   fi
   pass "a pooled worktree with no origin remote skips the freshen and still spawns"
+}
+
+# The clean-pool guard is remote-independent, so skipping the freshen must not
+# skip it. A no-origin pool that came back dirty would otherwise start a worker
+# on top of foreign uncommitted work and commit it into fm/<id>.
+test_no_origin_dirty_pool_refuses_without_discarding_work() {
+  local rec id out status before
+  id='pool-no-origin-dirty-r6'
+  rec=$(make_case no-origin-dirty "$id" main no-origin)
+  read_case_record "$rec"
+  before=$(git -C "$POOL_DIR" rev-parse HEAD)
+  printf 'keep this local work\n' > "$POOL_DIR/uncommitted.txt"
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn succeeded on a dirty pooled worktree with no origin remote"
+  assert_contains "$out" "is not clean" \
+    "spawn did not refuse a dirty pooled worktree when there was no remote to freshen from"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
+    || fail "spawn moved HEAD while refusing a dirty no-remote pooled worktree"
+  assert_grep 'keep this local work' "$POOL_DIR/uncommitted.txt" \
+    "spawn discarded uncommitted work while refusing a no-remote pool"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed no-origin dirty refusal: %s; preserved=%s\n' \
+      "$(printf '%s\n' "$out" | tail -n 1)" "$(cat "$POOL_DIR/uncommitted.txt")"
+  fi
+  pass "a dirty pooled worktree with no origin remote is refused without discarding its local work"
 }
 
 test_unresolved_remote_default_refuses_pool() {
@@ -280,5 +313,6 @@ test_dirty_pool_refuses_without_discarding_work
 test_unresolved_remote_default_refuses_pool
 test_unreachable_origin_refuses_stale_pool_base
 test_no_origin_remote_skips_freshen_and_succeeds
+test_no_origin_dirty_pool_refuses_without_discarding_work
 
 echo "# all fm-spawn-pool-base-freshen tests passed"


### PR DESCRIPTION
## Intent

Make firstmate able to launch workers (crewmates/scouts) on a project that has no origin remote. Currently freshen_spawn_worktree_base() in bin/fm-spawn.sh unconditionally fetches origin before every non-relaunch, non-secondmate spawn, so a project with no origin remote can never host a crewmate or scout. Required behavior: when the worktree's repository has no origin remote, skip the freshen, print one clear single-line notice to stderr saying the base was not freshened because the project has no origin remote, and let the spawn proceed. When origin exists and the fetch fails, keep refusing exactly as today with the unchanged message - that refusal is the real staleness guard and must not be weakened. Detect the absence of origin positively by checking whether origin appears in the configured remote list, never by inspecting fetch failure output or exit codes and never by treating a failure to read origin's URL as absence (a project can have an origin with only a push address configured) - inferring 'no remote' from a failed operation would turn a network problem into a silent stale-base launch. The no-remote path must not fall into remote set-head origin --auto, default-branch resolution, or the second fetch of refs/heads/... since none of those apply without a remote. Testing requirements: unit-level coverage for three cases (no origin: skips, notices, succeeds; origin present but fetch fails: still refuses, message unchanged; origin present and fetch succeeds: existing behavior byte-for-byte unchanged), added to the existing test file that covers this script (tests/fm-spawn-pool-base-freshen.test.sh). A real end-to-end crewmate spawn into a throwaway git repository with no remote, proving it succeeds and lands in an isolated worktree, was already performed and verified manually against a real Herdr-backed spawn in an isolated lab session (not part of the committed automated test suite). Acceptance criteria: a repository with no origin remote can host a crewmate spawn, proven end to end; a repository with origin whose fetch fails still refuses to launch with the current message; the passing-fetch path is byte-for-byte unchanged; tests cover all three cases; the no-remote notice is a single clear line rather than a silent skip. This is a change to firstmate's own shared tracked material (bin/fm-spawn.sh and its colocated test file). During review, three follow-up decisions were made and are already committed on this branch: (1) the no-remote early return must not skip the pre-existing dirty-pooled-worktree refusal that the origin path gets, so that refusal now applies on both paths while the no-remote path still bypasses only the fetch and reset machinery; (2) the no-remote path has its own accurate refusal wording, separate from the origin path's refresh-specific wording, since nothing is fetched or reset on that path; (3) every message on the no-remote path says the project has no origin remote specifically (not no remote at all), because the detection principle is that these messages must say exactly what the code checks and nothing broader - the code checks specifically for a remote named origin, and a project can have other remotes. No em dashes in any commit, comment, or PR text (standing captain instruction).

## What Changed

- `freshen_spawn_worktree_base()` in `bin/fm-spawn.sh` now reads the absence of origin positively off the configured remote list (`git remote` output, matched exactly against `origin`), and on that path skips the fetch, `remote set-head`, default-branch resolution, and reset entirely, printing one stderr line (`notice: pooled worktree '...' base was not freshened because the project has no origin remote`) before letting the spawn proceed. An origin that is configured but unusable (for example fetch URL unset, push URL only) still falls through to the existing fetch, whose refusal message is unchanged.
- Factored the pooled-worktree cleanliness check into `require_clean_spawn_worktree()`, so the dirty-pool refusal now guards both paths instead of only the origin path. Each caller passes its own message tail: the origin path keeps its `refreshing its base` wording byte for byte, while the no-origin path says the project has no origin remote and refuses to launch a worker on top of uncommitted work, rather than blaming a refresh that never ran.
- Added four cases to `tests/fm-spawn-pool-base-freshen.test.sh` (no-origin pool skips, notices exactly once on stderr, and spawns; dirty no-origin pool refuses without discarding work; upstream-only pool skips the freshen, names the missing origin, and fetches nothing; origin with no fetch address still refuses) via a `no-origin` mode on the shared fixture builder and a `spawn_env` helper that keeps stdout and stderr separate. The pre-existing dirty-pool test now asserts its full refusal string, and the spawn header plus `docs/architecture.md` document the no-origin exception.

## Risk Assessment

✅ Low: The change is confined to one function plus an extracted helper, leaves the origin fetch/reset path and all of its refusal messages byte-for-byte identical, detects missing origin positively so a network failure still refuses, keeps the clean-pool guard on both paths, and is covered by four behavior-level tests; the only findings are informational wording and test-strength nits.

## Testing

I ran the script's own focused test file (9 cases, all passing, with the operator-visible notice and refusal lines captured), proved the three new no-origin cases fail against the base commit's fm-spawn.sh while the unusable-origin guard passes on both sides, and then demonstrated the intent end to end: a real fm-spawn.sh crewmate launch into a throwaway no-remote git repo using real treehouse pooling and a real tmux server on an isolated socket succeeded with exactly one stderr notice naming the missing origin remote, and the worker really ran in an isolated pooled worktree distinct from the project checkout. The same lab shows the origin-present path unchanged (no notice, base freshened to the origin tip including a commit pushed after the pool worktree existed) and that an unfetchable origin still launches nothing; note that in the live treehouse path treehouse's own fetch fails before fm-spawn's does, so fm-spawn's own unchanged refusal wording is evidenced at the real-script level in the unit transcript rather than in the live lab. This change is CLI/stderr-only with no rendered UI surface, so terminal transcripts are the reviewer-visible evidence. Adjacent spawn-path tests also pass, and I left the worktree clean with all lab and scratch artifacts removed.

<details>
<summary>Evidence: End-to-end transcript: real crewmate spawn into a no-origin project, plus the two origin-present contrasts</summary>

<code>notice: pooled worktree &#39;/tmp/fm-noremote-lab-e2e/project/.treehouse/project-a2d1ad/1/project&#39; base was not freshened because the project has no origin remote&#10;spawned nr-evidence-a1 harness=bash kind=ship mode=local-only yolo=off window=firstmate:fm-nr-evidence-a1 worktree=/tmp/fm-noremote-lab-e2e/project/.treehouse/project-a2d1ad/1/project&#10;== spawn exit=0 ==&#10;&#10;-- crewmate landed in an isolated pooled worktree, not the project checkout --&#10;/tmp/fm-noremote-lab-e2e/project 8000a9a [main]&#10;/tmp/fm-noremote-lab-e2e/project/.treehouse/project-a2d1ad/1/project 8000a9a (detached HEAD)&#10;-- the crewmate process is really running in that worktree --&#10;firstmate:fm-nr-evidence-a1 cwd=/tmp/fm-noremote-lab-e2e/project/.treehouse/project-a2d1ad/1/project running=bash&#10;crewmate-worker-alive lines in pane: 1</code>

```text
############################################################
# CASE 1 (the fix): real crewmate spawn into a git project with NO origin remote
############################################################
== project remotes (expect empty) ==
== spawn ==
warning: /tmp/fm-noremote-lab-e2e/home/data/nr-evidence-a1/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode local-only - confirm its definition of done matches
notice: nr-evidence-a1 ships mode=local-only while the standing posture for project is no-mistakes - less rigor than the captain's standing posture; proceed only on a current explicit captain instruction or an intake judgment you can state
notice: pooled worktree '/tmp/fm-noremote-lab-e2e/project/.treehouse/project-a2d1ad/1/project' base was not freshened because the project has no origin remote
spawned nr-evidence-a1 harness=bash kind=ship mode=local-only yolo=off window=firstmate:fm-nr-evidence-a1 worktree=/tmp/fm-noremote-lab-e2e/project/.treehouse/project-a2d1ad/1/project
== spawn exit=0 ==

-- project remotes (the project really has no origin) --
(no output above == no remotes at all)
-- crewmate landed in an isolated pooled worktree, not the project checkout --
/tmp/fm-noremote-lab-e2e/project                                      8000a9a [main]
/tmp/fm-noremote-lab-e2e/project/.treehouse/project-a2d1ad/1/project  8000a9a (detached HEAD)
project checkout : /tmp/fm-noremote-lab-e2e/project
crewmate worktree: /tmp/fm-noremote-lab-e2e/project/.treehouse/project-a2d1ad/1/project
-- the crewmate process is really running in that worktree --
   firstmate:zsh  cwd=/local/home/inthuson/.no-mistakes/worktrees/d4c7ad84348d/01M05MDFW0CTN0BG3KBHK37NK5  running=zsh
   firstmate:fm-nr-evidence-a1  cwd=/tmp/fm-noremote-lab-e2e/project/.treehouse/project-a2d1ad/1/project  running=bash
-- what the crewmate pane printed --
   crewmate-worker-alive lines in pane: 1
-- recorded task state --
window=firstmate:fm-nr-evidence-a1
endpoint_task_id=nr-evidence-a1
worktree=/tmp/fm-noremote-lab-e2e/project/.treehouse/project-a2d1ad/1/project
project=/tmp/fm-noremote-lab-e2e/project
harness=bash
kind=ship
mode=local-only
yolo=off
tasktmp=/tmp/fm-nr-evidence-a1
model=default
effort=default
spawn_gen=s1786896602.2775119.4870

############################################################
# CASE 2 (unchanged): origin present and reachable -> still freshens to the origin tip
############################################################
== [good-origin] project remotes ==
origin	file:///tmp/fm-noremote-lab-e2e/origin-good-origin.git (fetch)
origin	file:///tmp/fm-noremote-lab-e2e/origin-good-origin.git (push)
== [good-origin] project HEAD before spawn ==
18bf3af
== [good-origin] spawn ==
warning: /tmp/fm-noremote-lab-e2e/home-good-origin/data/nr-evidence-c3/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode local-only - confirm its definition of done matches
notice: nr-evidence-c3 ships mode=local-only while the standing posture for project-good-origin is no-mistakes - less rigor than the captain's standing posture; proceed only on a current explicit captain instruction or an intake judgment you can state
spawned nr-evidence-c3 harness=bash kind=ship mode=local-only yolo=off window=firstmate:fm-nr-evidence-c3 worktree=/tmp/fm-noremote-lab-e2e/project-good-origin/.treehouse/project-good-origin-af120d/1/project-good-origin
== [good-origin] spawn exit=0 ==

-- no no-origin notice above; base was freshened to origin's tip --
crewmate worktree HEAD = 515fec95f8bd837925b292ed6d519221ed4e8470
origin/main            = 515fec95f8bd837925b292ed6d519221ed4e8470
commit pushed to origin AFTER the pool worktree existed is present in the crew worktree:
   README.md
   advanced.txt
   treehouse.toml

############################################################
# CASE 3 (unchanged): origin present but unfetchable -> nothing launches
############################################################
== [broken-origin] project remotes ==
origin	file:///tmp/fm-noremote-lab-e2e/origin-does-not-exist.git (fetch)
origin	file:///tmp/fm-noremote-lab-e2e/origin-does-not-exist.git (push)
== [broken-origin] project HEAD before spawn ==
431cab7
== [broken-origin] spawn ==
warning: /tmp/fm-noremote-lab-e2e/home-broken-origin/data/nr-evidence-b2/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode local-only - confirm its definition of done matches
notice: nr-evidence-b2 ships mode=local-only while the standing posture for project-broken-origin is no-mistakes - less rigor than the captain's standing posture; proceed only on a current explicit captain instruction or an intake judgment you can state
error: treehouse get did not enter a worktree within 60s; inspect window firstmate:fm-nr-evidence-b2
== [broken-origin] spawn exit=1 ==

-- with a live treehouse pool, treehouse's own fetch fails first, so the spawn
-- never reaches fm-spawn's fetch; either way no worker launches on a stale base.
-- fm-spawn's own refusal for that shape is exercised in the unit transcript.
🌳 Setting up worktree...
fetch failed: git fetch origin: fatal: '/tmp/fm-noremote-lab-e2e/origin-does-not
-exist.git' does not appear to be a git repository
fatal: Could not read from remote repository.
Please make sure you have the correct access rights
and the repository exists.
(26-08-16 16:10:06) <1> [/tmp/fm-noremote-lab-e2e/project-broken-origin]
dev-dsk-inthuson-1a-a07ae4cd %
```
</details>
<details>
<summary>Evidence: Fail-before-fix: the three no-origin cases against the base commit&#39;s fm-spawn.sh</summary>

<code>=== PRE-FIX test_no_origin_remote_skips_freshen_and_succeeds ===&#10;not ok - spawn should succeed on a pooled worktree with no origin remote: expected exit 0, got 1&#10;=== PRE-FIX test_no_origin_dirty_pool_refuses_without_discarding_work ===&#10;not ok - the no-origin dirty refusal should be exactly one complete line naming the missing origin remote, found 0&#10;=== PRE-FIX test_non_origin_remote_only_skips_freshen_and_names_origin ===&#10;not ok - spawn should succeed on a pool whose only remote is not origin: expected exit 0, got 1&#10;=== PRE-FIX test_configured_but_unusable_origin_still_refuses ===&#10;ok - an origin configured without a fetch address still refuses instead of skipping the freshen</code>

```text
# Fail-before-fix check: the four new cases run against bin/fm-spawn.sh as of the base
# commit ef35d79 (scratch copy of bin/ tests/ with the pre-change script), each case in isolation.
# Expectation: the three no-origin cases fail before the fix; the unchanged-origin
# guard case passes both before and after, which is what makes it a regression guard.

=== PRE-FIX test_no_origin_remote_skips_freshen_and_succeeds ===
not ok - spawn should succeed on a pooled worktree with no origin remote: expected exit 0, got 1
=== PRE-FIX test_no_origin_dirty_pool_refuses_without_discarding_work ===
not ok - the no-origin dirty refusal should be exactly one complete line naming the missing origin remote, found 0
=== PRE-FIX test_non_origin_remote_only_skips_freshen_and_names_origin ===
not ok - spawn should succeed on a pool whose only remote is not origin: expected exit 0, got 1
=== PRE-FIX test_configured_but_unusable_origin_still_refuses ===
ok - an origin configured without a fetch address still refuses instead of skipping the freshen
```
</details>
<details>
<summary>Evidence: Post-fix focused unit run with the observed spawn messages</summary>

<code># observed no-origin notice: notice: pooled worktree &#39;.../no-origin/pool&#39; base was not freshened because the project has no origin remote&#10;# observed no-origin dirty refusal: error: pooled worktree &#39;.../no-origin-dirty/pool&#39; is not clean; the project has no origin remote, so refusing to launch a worker on top of uncommitted work; preserved=keep this local work&#10;# observed upstream-only notice: notice: pooled worktree &#39;.../upstream-only/pool&#39; base was not freshened because the project has no origin remote&#10;# observed unusable-origin refusal: error: could not fetch origin for pooled worktree &#39;.../unusable-origin/pool&#39;; refusing to launch from a potentially stale base&#10;# all fm-spawn-pool-base-freshen tests passed</code>

```text
# Post-fix: focused unit run of the script's own test file (real fm-spawn.sh, real git repos, fake terminal)
# command: FM_TEST_EVIDENCE=1 bin/fm-test-run.sh tests/fm-spawn-pool-base-freshen.test.sh

FM_TEST_BEGIN 2026-08-16T16:12:13Z tests/fm-spawn-pool-base-freshen.test.sh family=unclassified expected_gate_skip=none
# observed spawn: spawned pool-current-base-r1 harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-pool-current-base-r1 worktree=/tmp/fm-spawn-pool-base-freshen.lfKguF/current-base/pool
# observed base: HEAD=c3f684a50d173e9ab1eda3b289d7dff9b857810a origin/main=c3f684a50d173e9ab1eda3b289d7dff9b857810a advanced-main=must survive a newly spawned branch
ok - a stale pooled worktree refreshes to current origin/main before a crew branch is created
ok - a stale pooled worktree resolves and refreshes a non-main default branch
# observed direct-pr spawn: spawned pool-direct-pr-r3 harness=codex kind=ship mode=direct-PR yolo=off window=firstmate:fm-pool-direct-pr-r3 worktree=/tmp/fm-spawn-pool-base-freshen.lfKguF/direct-pr/pool
# observed scout spawn: spawned pool-scout-r3 harness=codex kind=scout window=firstmate:fm-pool-scout-r3 worktree=/tmp/fm-spawn-pool-base-freshen.lfKguF/scout/pool
ok - direct-PR ships and scouts both refresh stale pooled worktrees before launch
# observed dirty refusal: error: pooled worktree '/tmp/fm-spawn-pool-base-freshen.lfKguF/dirty-refusal/pool' is not clean; refusing to discard uncommitted work while refreshing its base; preserved=keep this local work
ok - a dirty pooled worktree is refused without discarding its local work
# observed unresolved-default refusal: error: could not resolve origin's current default branch for pooled worktree '/tmp/fm-spawn-pool-base-freshen.lfKguF/unresolved-default/pool'; refusing to launch from a potentially stale base
ok - an unresolved remote default branch refuses the pooled worktree
# observed unreachable-origin refusal: error: could not fetch origin for pooled worktree '/tmp/fm-spawn-pool-base-freshen.lfKguF/unreachable-origin/pool'; refusing to launch from a potentially stale base
ok - an unreachable origin refuses a potentially stale pooled worktree
# observed no-origin spawn: spawned pool-no-origin-r6 harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-pool-no-origin-r6 worktree=/tmp/fm-spawn-pool-base-freshen.lfKguF/no-origin/pool
# observed no-origin notice: notice: pooled worktree '/tmp/fm-spawn-pool-base-freshen.lfKguF/no-origin/pool' base was not freshened because the project has no origin remote
ok - a pooled worktree with no origin remote skips the freshen and still spawns
# observed no-origin dirty refusal: error: pooled worktree '/tmp/fm-spawn-pool-base-freshen.lfKguF/no-origin-dirty/pool' is not clean; the project has no origin remote, so refusing to launch a worker on top of uncommitted work; preserved=keep this local work
ok - a dirty pooled worktree with no origin remote is refused without discarding its local work
# observed upstream-only notice: notice: pooled worktree '/tmp/fm-spawn-pool-base-freshen.lfKguF/upstream-only/pool' base was not freshened because the project has no origin remote
# observed upstream-only remotes: upstream 
ok - a pool whose only remote is not origin skips the freshen and names the missing origin remote
# observed unusable-origin refusal: error: could not fetch origin for pooled worktree '/tmp/fm-spawn-pool-base-freshen.lfKguF/unusable-origin/pool'; refusing to launch from a potentially stale base
ok - an origin configured without a fetch address still refuses instead of skipping the freshen
# all fm-spawn-pool-base-freshen tests passed
FM_TEST_END 2026-08-16T16:12:32Z tests/fm-spawn-pool-base-freshen.test.sh exit=0 duration_ms=19289 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=19343
FM_TEST_SUMMARY_FAMILY family=unclassified count=1 duration_ms=19289 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-spawn-pool-base-freshen.test.sh duration_ms=19289
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2cedd7b6a612436e249d356830c3fb6ab2ea0686","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 3 infos</summary>

- ℹ️ `bin/fm-spawn.sh:146` - The header comment still describes the no-origin refusal as wording &#34;that names the missing remote&#34;, the exact imprecision this branch went back and corrected everywhere else: eba912c changed all three runtime messages from &#34;has no remote&#34; to &#34;has no origin remote&#34;, and 676fc33 changed docs/architecture.md from &#34;there is nothing to freshen against&#34; to &#34;there is no origin to freshen against&#34;. docs/architecture.md:162 designates this header as the owner of the exact refusal mechanics, so the one surface that owns the mechanics is now the only one describing them more broadly than the code checks (the code checks for a remote named origin specifically, and the upstream-only test at tests/fm-spawn-pool-base-freshen.test.sh:302 exists precisely because other remotes can be present). Suggested fix: &#34;names the missing origin remote&#34;.
- ℹ️ `tests/fm-spawn-pool-base-freshen.test.sh:320` - The assertion &#34;spawn fetched a non-origin remote while skipping the freshen&#34; cannot fail for the reason it states. The upstream remote added at line 307 points at file://$CASE_DIR/upstream-never-fetched.git, a path that is never created, so refs/remotes/upstream stays empty whether or not a fetch was attempted. Today the case is still not vacuous overall (a failed fetch would break the expect_code 0 above it), but if a future change ever fetched non-origin remotes tolerantly, this test would pass while claiming to prove nothing was fetched. Pointing upstream at a real bare clone carrying a commit (the fixture already knows how to make one in origin mode) gives the assertion teeth without changing anything else in the case.
- ℹ️ `bin/fm-spawn.sh:1763` - Recording the accepted tradeoff, not requesting a change: on the no-origin path the worker starts from whatever commit the pooled worktree already holds, which for a treehouse pool can be behind the project&#39;s local trunk (the stale-pool premise this test file opens with). Aligning to the local default branch tip is exactly what the intent forbids on this path (&#34;must not fall into ... default-branch resolution&#34;), and the required single-line notice is the disclosure, so the behavior as written is the authorized one. No action needed; noted only so the operator-visible consequence of the notice is on the record.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`FM_TEST_EVIDENCE=1 bin/fm-test-run.sh tests/fm-spawn-pool-base-freshen.test.sh` (all 9 cases pass, including the 4 new ones; captured operator-visible notice and refusal lines)</code>
- <code>Fail-before-fix check: scratch copy of `bin/`+`tests/` with `git show ef35d79:bin/fm-spawn.sh`, each new case run in isolation - `test_no_origin_remote_skips_freshen_and_succeeds`, `test_no_origin_dirty_pool_refuses_without_discarding_work`, `test_non_origin_remote_only_skips_freshen_and_names_origin` all fail pre-fix; `test_configured_but_unusable_origin_still_refuses` passes pre- and post-fix</code>
- <code>Manual end-to-end lab (real git + real `treehouse` pool + real `tmux -L fmnoremotelab` + sandboxed FM_HOME/state/config, worker = `bash -lc &#34;echo crewmate-worker-alive; sleep 900&#34;`): `bin/fm-spawn.sh nr-evidence-a1 &lt;no-remote-project&gt; --mode local-only --yolo off --backend tmux --harness &#39;...&#39;` -&gt; exit 0, one no-origin notice, worker running in the pooled worktree</code>
- <code>Isolation proof for the no-remote spawn: `git -C &lt;project&gt; remote -v` (empty), `git -C &lt;project&gt; worktree list`, `tmux list-windows -a -F &#39;...pane_current_path...&#39;`, `tmux capture-pane -p -t firstmate:fm-nr-evidence-a1`, and the recorded `state/nr-evidence-a1.meta`</code>
- <code>Same lab with a reachable origin (`nr-evidence-c3`): no notice emitted, crew worktree `HEAD == origin/main`, and the commit pushed to origin after the pool worktree existed is present in the crew worktree</code>
- <code>Same lab with an unfetchable origin (`nr-evidence-b2`): spawn refuses and no worker launches (treehouse&#39;s own `git fetch origin` fails before fm-spawn&#39;s fetch is reached)</code>
- <code>`bin/fm-test-run.sh tests/fm-spawn-batch.test.sh tests/fm-spawn-dispatch-profile.test.sh tests/fm-spawn-worktree-settle.test.sh tests/fm-trace-context-spawn.test.sh tests/fm-control-relaunch.test.sh` (5/5 pass) - adjacent fresh-spawn paths whose sandbox projects have no origin and therefore now take the new branch</code>
- <code>`git status --porcelain` after cleanup (clean; lab, scratch copy, and per-task `/tmp/fm-*` dirs removed, isolated tmux server killed)</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/architecture.md:161` - Judgment call, no doc added: the manual end-to-end herdr crewmate spawn into a no-remote repo stays PR/task evidence rather than becoming a docs/verification record. The guard is git-based, not a harness-emitted signal, so firstmate-coding-guidelines&#39; harness-dependent live-evidence rule does not apply, and the placement policy forbids creating a new documentation surface merely to close a perceived gap. The durable facts already live in their owners: the boundary and its one exception in docs/architecture.md, the exact refusal mechanics in bin/fm-spawn.sh&#39;s header, and the portable regression coverage in tests/fm-spawn-pool-base-freshen.test.sh.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
