### PR TITLE
fix(bin): attribute run state to a task's current run, not a superseded one

### DIFF
--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -24,10 +24,16 @@
 #      active or terminal (from `axi status`, or the coarse `no-mistakes runs`
 #      fallback)? Branch name alone is not enough: a historical run on a reused
 #      branch whose head was rewritten or diverged must not be attributed.
-#      A run matches when its head equals the worktree HEAD, or the worktree HEAD
-#      is an ancestor of the run head (pipeline fix commits advanced the run on
-#      the same line of history). Local work that advanced past the run head, or
-#      diverged from it, invalidates attribution.
+#      A run matches when one of its heads equals the worktree HEAD, or the
+#      worktree HEAD is an ancestor of it (pipeline fix commits advanced the run
+#      on the same line of history). Local work that advanced past the run head,
+#      or diverged from it, invalidates attribution.
+#      Which heads count is owned by fm_nm_run_binds_worktree in
+#      bin/fm-nm-run-lib.sh: a run's top-level head is the PIPELINE's head and is
+#      routinely unresolvable here, so submitted_head carries the binding.
+#      When only a SUPERSEDED run for this branch binds - the branch's newest run
+#      cannot be bound while an older one can - the answer is unknown, never the
+#      superseded run's state and never a pane/log answer standing in for it.
 #      The run-step is AUTHORITATIVE: running/fixing -> working, ci -> working,
 #      awaiting_approval/fix_review -> parked (with gate findings), terminal
 #      passed/checks-passed -> done, failed/cancelled -> failed. EXCEPT: while
@@ -81,6 +87,12 @@ case "$NM_TIMEOUT" in ''|*[!0-9]*) NM_TIMEOUT=10 ;; esac
 FM_CREW_STATE_RUNS_LIMIT=${FM_CREW_STATE_RUNS_LIMIT:-200}
 case "$FM_CREW_STATE_RUNS_LIMIT" in ''|*[!0-9]*) FM_CREW_STATE_RUNS_LIMIT=200 ;; esac
 SEP=' · '
+# Reserved COARSE_STATUS value meaning "the branch's current run could not be
+# bound to this worktree's code while an older, superseded run could" - the
+# ambiguity that must report unknown rather than a guess. It contains spaces, and
+# a runs-list status is parsed as one whitespace-delimited word, so no real status
+# can ever collide with it.
+FM_COARSE_SUPERSEDED='superseded by an unmatched newer run'
 
 # Emit the one canonical line and exit 0. Detail is optional.
 emit() {  # <state> <source> [detail]
@@ -331,11 +343,24 @@ nm_ci_checks_state() {
 # "<status> <branch> <short-sha> <date> [<pr-url>]" separated by runs of
 # spaces (verified: no quoting, so splitting on the first two whitespace runs
 # is exact) - but branch + coarse status is exactly what this predicate needs:
-# is a run for THIS branch active right now. Echoes the first (most recent)
-# matching row's status word (running/completed/cancelled/failed), or empty
-# when the branch has no run within FM_CREW_STATE_RUNS_LIMIT rows.
+# is a run for THIS branch active right now.
+#
+# The list is newest-first, so for one branch ONLY its topmost row can be the
+# current run; every older row for that branch is superseded by definition.
+# Echoes that newest row's status word (running/completed/cancelled/failed) when
+# it binds to this worktree's code, $FM_COARSE_SUPERSEDED when it does not bind
+# while an older row for the same branch does, and empty when the branch has no
+# row within FM_CREW_STATE_RUNS_LIMIT rows or no row binds at all.
+#
+# Walking PAST a non-binding newest row to an older one was the 2026-08-14
+# false-failure defect: a live run's short sha is a pipeline commit absent from
+# the crew worktree, so the newest row could not bind, and the abandoned earlier
+# run one row down still sat exactly on the worktree HEAD - so an actively
+# validating crew was reported `failed`. A superseded row must never supply the
+# state, and preferring the older row over an honest `unknown` is what turned a
+# missing answer into a confidently wrong one.
 nm_runs_status_for_branch() {  # <branch>
-  local branch=$1 out row st rest br sha
+  local branch=$1 out row st rest br sha newest_seen=0 older_binds=0
   out=$(nm_run runs --limit "$FM_CREW_STATE_RUNS_LIMIT")
   [ -n "$out" ] || return 0
   while IFS= read -r row; do
@@ -348,16 +373,25 @@ nm_runs_status_for_branch() {  # <branch>
     rest=${rest#* }
     rest=$(trim "$rest")
     sha=${rest%% *}
-    if [ "$br" = "$branch" ]; then
-      # Same code-identity rule as axi status: skip a same-branch row whose
-      # short-sha does not match this worktree (rewritten or advanced tip).
-      if ! nm_coarse_head_matches_worktree "$sha"; then
-        continue
+    [ "$br" = "$branch" ] || continue
+    if [ "$newest_seen" = 0 ]; then
+      # The branch's current run. Same code-identity rule as axi status.
+      newest_seen=1
+      if nm_coarse_head_matches_worktree "$sha"; then
+        printf '%s' "$st"
+        return 0
       fi
-      printf '%s' "$st"
-      return 0
+      continue
+    fi
+    # An older row for the same branch: only ever consulted to tell an honest
+    # ambiguity ("a bindable answer exists but it is superseded") apart from
+    # having no answer at all. Its status is deliberately never reported.
+    if nm_coarse_head_matches_worktree "$sha"; then
+      older_binds=1
+      break
     fi
   done <<< "$out"
+  [ "$older_binds" = 1 ] && printf '%s' "$FM_COARSE_SUPERSEDED"
   return 0
 }
 
@@ -365,13 +399,13 @@ nm_runs_status_for_branch() {  # <branch>
 # scratch worktree); with no branch there is no run to attribute to this crew.
 CREW_BRANCH=$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
 
-# 0 if the active axi-status run's head field matches this worktree's code
-# identity. Branch match is a precondition (caller). Rule owned by
-# fm_nm_head_matches_worktree in bin/fm-nm-run-lib.sh.
-nm_run_head_matches_worktree() {
-  local run_head
-  run_head=$(strip_quotes "$(nm_field head)")
-  fm_nm_head_matches_worktree "$WT" "$run_head"
+# 0 if the active axi-status run binds to this worktree's code identity. Branch
+# match is a precondition (caller). Rule owned by fm_nm_run_binds_worktree in
+# bin/fm-nm-run-lib.sh, which reads the run's submitted_head as well as its
+# top-level head - a fixing run's top-level head is a pipeline commit this
+# worktree cannot resolve, so head alone would reject the crew's own live run.
+nm_run_binds_worktree() {
+  fm_nm_run_binds_worktree "$WT" "$RUN_OUT"
 }
 
 # Coarse runs-list rows are "<status> <branch> <short-sha> ...". 0 if the short
@@ -394,7 +428,7 @@ if [ "$KIND" = ship ] && [ -n "$CREW_BRANCH" ] && command -v no-mistakes >/dev/n
   RUN_OUT=$(nm_run axi status)
   if [ -n "$RUN_OUT" ]; then
     run_branch=$(strip_quotes "$(nm_field branch)")
-    if [ -n "$run_branch" ] && [ "$run_branch" = "$CREW_BRANCH" ] && nm_run_head_matches_worktree; then
+    if [ -n "$run_branch" ] && [ "$run_branch" = "$CREW_BRANCH" ] && nm_run_binds_worktree; then
       HAVE_RUN=1
     else
       # The active-or-most-recent run is for another branch, or same branch with
@@ -434,6 +468,16 @@ if [ "$HAVE_RUN" = 1 ]; then
       completed) RUN_STATE="done";  RUN_DETAIL="run completed" ;;
       failed)    RUN_STATE=failed;  RUN_DETAIL="run failed" ;;
       cancelled) RUN_STATE=failed;  RUN_DETAIL="run cancelled" ;;
+      # Ambiguous by construction: the only run this crew's code binds to is one
+      # a newer run already superseded, and that newer run cannot be bound here.
+      # Emitted right here as unknown/none - no source established a state.
+      # Falling through to the pane/log fallback instead would be just as much a
+      # guess: the crew pane of a validating crew is legitimately idle, so the
+      # fallback would report whatever terminal line the log last happened to
+      # carry, and a confident wrong verdict is the expensive failure mode.
+      "$FM_COARSE_SUPERSEDED")
+        emit unknown none "cannot match this code to the branch's current run; not reporting a superseded one"
+        ;;
       *)         RUN_STATE=unknown; RUN_DETAIL="runs list status: $COARSE_STATUS" ;;
     esac
   else
@@ -516,9 +560,12 @@ if [ "$HAVE_RUN" = 1 ]; then
   # Reconcile the status log. A needs-decision/blocked log line that the run-step
   # has moved past (anything but a genuinely parked run) is deterministically
   # stale: the gate resolved and the run resumed or finished.
+  # An unknown run state is deliberately excluded: it establishes nothing the log
+  # could have been superseded BY, so claiming supersession there would be the
+  # same unevidenced confidence this reader exists to avoid.
   case "$LOG_VERB" in
     needs-decision|blocked)
-      if [ "$RUN_STATE" != parked ]; then
+      if [ "$RUN_STATE" != parked ] && [ "$RUN_STATE" != unknown ]; then
         if [ "$RUN_STATE" = working ]; then
           RUN_DETAIL="$RUN_DETAIL${SEP}status-log superseded by active run"
         else

--- a/bin/fm-nm-run-lib.sh
+++ b/bin/fm-nm-run-lib.sh
@@ -7,6 +7,9 @@
 # abort, see its "Fix 1" header comment). Getting this wrong in either
 # direction is unsafe: a false negative hides a genuinely parked run, and a
 # false positive lets teardown act on a run it does not own.
+# fm_nm_run_binds_worktree is the entry point callers want for a whole `axi
+# status` run object; fm_nm_head_matches_worktree is the single-head primitive
+# it and the coarse runs-list path are both built on.
 #
 # Bounded call to `no-mistakes "$@"` in dir $1, timeout $2 seconds. The bounded
 # form preserves stdout, stderr, and exit status; the checked form discards
@@ -58,6 +61,7 @@ fm_nm_field() {  # <toon-output> <key>
 # 0 if run head $2 matches worktree $1's code identity, per the same rule
 # everywhere this attribution is needed:
 #   - missing/empty head: cannot bind; reject
+#   - unresolvable commit (not in this worktree's object store): cannot bind; reject
 #   - equal commits (short or full SHA): match
 #   - worktree HEAD is an ancestor of run head: match (pipeline fix commits on
 #     the same history advanced the run tip past local HEAD)
@@ -70,4 +74,32 @@ fm_nm_head_matches_worktree() {  # <worktree> <run_head>
   run_full=$(git -C "$wt" rev-parse --verify "${run_head}^{commit}" 2>/dev/null) || return 1
   [ "$run_full" = "$local_full" ] && return 0
   git -C "$wt" merge-base --is-ancestor "$local_full" "$run_full" 2>/dev/null
+}
+
+# 0 if the run described by `axi status` output $2 binds to worktree $1's code
+# identity. Reads TWO independent heads and lets either carry a positive verdict,
+# because the run's own top-level head alone is not a reliable binding:
+#
+#   - branch_sync.pipeline.submitted_head - the worktree commit the run was
+#     SUBMITTED from. This is the field that actually answers "is this run mine",
+#     and it does not move while the pipeline works.
+#   - the top-level head field - the PIPELINE's current head. It advances with
+#     every pipeline fix commit, and those commits live in no-mistakes' own repo,
+#     never in the crew worktree, so once a run starts fixing this head is
+#     routinely UNRESOLVABLE here and binds nothing. Kept as the fallback signal
+#     for a run object that carries no branch_sync block.
+#
+# Trying both is what stops a live run from silently failing attribution and
+# letting a caller fall back onto an older, superseded run for the same branch.
+# Verified against no-mistakes v1.46.0 - see the "Run attribution heads" section
+# of docs/verification/supervision.md for the captured output.
+fm_nm_run_binds_worktree() {  # <worktree> <axi-status-output>
+  local wt=$1 out=$2 submitted head
+  [ -n "$out" ] || return 1
+  submitted=$(fm_nm_strip_quotes "$(fm_nm_field "$out" submitted_head)")
+  if [ -n "$submitted" ] && fm_nm_head_matches_worktree "$wt" "$submitted"; then
+    return 0
+  fi
+  head=$(fm_nm_strip_quotes "$(fm_nm_field "$out" head)")
+  fm_nm_head_matches_worktree "$wt" "$head"
 }

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -104,7 +104,7 @@
 #     crew's worktree, so they are not orphaned by removing the worktree.
 #     conclude_task_no_mistakes_run attributes the active-or-most-recent run to
 #     THIS task only when its branch AND code identity (bin/fm-nm-run-lib.sh's
-#     fm_nm_head_matches_worktree, the same rule bin/fm-crew-state.sh uses) both
+#     fm_nm_run_binds_worktree, the same rule bin/fm-crew-state.sh uses) both
 #     match this worktree, then runs `no-mistakes axi abort --run <id>` for
 #     that verified run instance. A run already terminal
 #     (an outcome is set) or not parked at a gate is left untouched. Idempotent:
@@ -1208,7 +1208,7 @@ NM_TEARDOWN_TIMEOUT=${FM_TEARDOWN_NM_TIMEOUT:-10}
 case "$NM_TEARDOWN_TIMEOUT" in ''|*[!0-9]*) NM_TEARDOWN_TIMEOUT=10 ;; esac
 TASK_RUN_ID=
 task_status_is_own_parked_run() {  # <worktree> <axi-status-output>
-  local wt=$1 out=$2 branch run_id run_branch run_head status outcome awaiting has_gate
+  local wt=$1 out=$2 branch run_id run_branch status outcome awaiting has_gate
   TASK_RUN_ID=
   branch=$(git -C "$wt" symbolic-ref --quiet --short HEAD 2>/dev/null) || return 1
   [ -n "$branch" ] || return 1
@@ -1217,8 +1217,10 @@ task_status_is_own_parked_run() {  # <worktree> <axi-status-output>
   [ -n "$run_id" ] || return 1
   run_branch=$(fm_nm_strip_quotes "$(fm_nm_field "$out" branch)")
   [ -n "$run_branch" ] && [ "$run_branch" = "$branch" ] || return 1
-  run_head=$(fm_nm_strip_quotes "$(fm_nm_field "$out" head)")
-  fm_nm_head_matches_worktree "$wt" "$run_head" || return 1
+  # Binds on submitted_head as well as the top-level head: a run that has already
+  # made pipeline fix commits reports a head this worktree cannot resolve, and
+  # rejecting it there would leave the task's own parked run orphaned.
+  fm_nm_run_binds_worktree "$wt" "$out" || return 1
   outcome=$(fm_nm_strip_quotes "$(fm_nm_field "$out" outcome)")
   [ -z "$outcome" ] || return 1
   status=$(fm_nm_strip_quotes "$(fm_nm_field "$out" status)")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,10 +42,11 @@ This home's answerer close, pending-reply escalation close, and captain-held tra
 A turn-ended-only queue row omits its historical status annotation when that status file exactly matches the same seen marker.
 Any direct or remaining historical annotation prints every status line unread at the presentation cursor instead of replaying only the latest line.
 `bin/fm-crew-state.sh <id>` is the cheap current-state read for an actionable heartbeat review: it attributes a no-mistakes run, active or terminal, only when it matches the crew's branch and current code identity, then keeps that run-step authoritative even if the pane has closed.
-The script header owns the exact run-head ancestry rules.
+The script header owns the exact run-head ancestry rules, and `bin/fm-nm-run-lib.sh` owns which of a run's heads can carry that binding.
 During no-mistakes' `ci` monitor phase, it also reads the ci step log tail because `axi status` reports both "still waiting on checks" and "checks green, waiting on merge" as `ci,running`.
 The most recent recognized ci log marker wins, so checks-green monitoring reports done while a later re-arm, failed-check, or issue marker returns the crew to working.
-Only when no matching run exists does it consult semantic busy state; exact busy reports working, exact idle permits fallback to a status-log event whose verb maps to a recognized run-state, and unknown or a dead pane stays unknown instead of trusting a stale log.
+Only when no run for this crew resolves at all does it consult semantic busy state; exact busy reports working, exact idle permits fallback to a status-log event whose verb maps to a recognized run-state, and unknown or a dead pane stays unknown instead of trusting a stale log.
+An ambiguous attribution is the one case that skips that fallback: when the branch's newest run cannot be bound to this code while an older superseded run can, the read is unknown with source none, because the superseded run's state and the legitimately idle pane of a validating crew are both guesses.
 Decision-only events such as `resolved` never become current state or leak their prose into the current-state detail.
 In that status-log fallback, a declared external wait reports the distinct `paused` state with its reason.
 The semantic branch reports working only on an exact busy verdict and names the source that produced it; an unknown verdict never becomes working, never permits the status-log fallback, and never becomes a silent idle.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -205,6 +205,55 @@ tests/fm-busy-adapter-wiring.test.sh
 tests/fm-crew-state.test.sh
 ```
 
+## Run attribution heads
+
+[`bin/fm-nm-run-lib.sh`](../../bin/fm-nm-run-lib.sh) binds a no-mistakes run to a worktree on two independent heads and lets either carry a positive verdict.
+This section records the no-mistakes output that makes the second head necessary, captured on 2026-08-14 against `no-mistakes version v1.46.0 (20892e6)`.
+
+A branch carrying a live run and an older superseded one reports both:
+
+```sh
+no-mistakes runs --limit 60
+```
+
+```
+  running      fm/spawn-noremote-g2 bb41ea9b  2026-08-14 12:33
+  failed       fm/spawn-noremote-g2 de91af51  2026-08-14 10:38
+```
+
+The crew worktree's HEAD was the head of the older row, and the live run's head did not exist in that worktree at all:
+
+```sh
+git rev-parse HEAD                          # de91af5179f296f12a6f99f0c082bdca9db59fb7
+git rev-parse --verify 'bb41ea9b^{commit}'  # fatal: Needed a single revision
+```
+
+A run's top-level `head` is the pipeline's own head, and it advances with every pipeline fix commit.
+Those commits live in no-mistakes' repository rather than the crew worktree, so once a run reaches its fixing steps that head is routinely unresolvable in the worktree and can bind nothing.
+`no-mistakes axi status` in the same worktree returned the live run alongside the field that does bind:
+
+```
+run:
+  id: "01M00473HD3KXXT1B3RPVVTVDC"
+  branch: fm/spawn-noremote-g2
+  status: running
+  head: bb41ea9b
+branch_sync:
+  pipeline:
+    submitted_head: de91af5179f296f12a6f99f0c082bdca9db59fb7
+    current_head: bb41ea9b
+```
+
+`branch_sync.pipeline.submitted_head` is the worktree commit the run was submitted from, and it does not move while the pipeline works, so it answers whether a run belongs to this worktree for the whole life of that run.
+Binding on the top-level head alone rejected the crew's own live run, which is what allowed a reader to walk past it to the superseded `failed` row for the same branch and report dead work as the crew's current state.
+
+Deterministic entry points:
+
+```sh
+tests/fm-crew-state.test.sh
+tests/fm-teardown.test.sh
+```
+
 ## Turn-end guard
 
 The blocking and bounded-follow-up mechanisms were validated across six harnesses on 2026-07-08 through 2026-08-13, with Claude's replacement Stop-owned path revalidated on 2026-07-24 and Cursor's stop-hook park validated on 2026-08-13.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -2,7 +2,7 @@
 
 Audience: maintainer verification.
 
-This record supports current session-start, turn-end, watcher-continuity, and wedge-alarm guarantees.
+This record supports current session-start, semantic busy state, run attribution, turn-end, watcher-continuity, and wedge-alarm guarantees.
 Operator behavior and active limits remain in the linked current guides.
 Task-specific chronology, temporary paths, run identifiers, and delivery transcripts remain in private reports or PR evidence.
 

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -170,8 +170,9 @@ reset_fakes() {
   FM_FAKE_HERDR_MISSING=0
   FM_FAKE_HERDR_AGENT_STATUS=""
   FM_FAKE_CI_LOGS=""
+  FM_FAKE_PIPELINE_HEAD=""
   export FM_FAKE_AXI_STATUS FM_FAKE_AXI_STATUS_RUN FM_FAKE_RUNS_LIST FM_FAKE_BUSY FM_FAKE_BUSY_TEXT FM_FAKE_TMUX_MISSING
-  export FM_FAKE_HERDR_BUSY FM_FAKE_HERDR_MISSING FM_FAKE_HERDR_AGENT_STATUS FM_FAKE_CI_LOGS
+  export FM_FAKE_HERDR_BUSY FM_FAKE_HERDR_MISSING FM_FAKE_HERDR_AGENT_STATUS FM_FAKE_CI_LOGS FM_FAKE_PIPELINE_HEAD
 }
 
 # --- run-object fixtures (TOON, as `no-mistakes axi status` emits) -----------
@@ -200,6 +201,42 @@ run:
   head: "${FM_FAKE_RUN_HEAD:-abc1234}"
   pr: ""
   findings: none
+EOF
+}
+
+# A live run that has already made pipeline fix commits, in the shape no-mistakes
+# actually emits for one (captured from a live v1.46.0 run - see the "Run
+# attribution heads" section of docs/verification/supervision.md). The
+# distinguishing property, and the whole reason this fixture exists: the
+# top-level `head` is the PIPELINE's
+# head, which lives only in no-mistakes' own repo and CANNOT be resolved in the
+# crew worktree, while branch_sync.pipeline.submitted_head is the crew commit the
+# run was submitted from. Binding on head alone rejects the crew's own live run.
+run_fixing_pipeline_head_unresolvable() {  # <branch>
+  cat <<EOF
+run:
+  id: "01RUN"
+  branch: $1
+  status: fixing
+  head: ${FM_FAKE_PIPELINE_HEAD:-bb41ea9b}
+  findings: "1 awaiting, 1 info"
+  steps[3]{step,status,findings,duration_ms}:
+    intent,completed,0,4
+    rebase,completed,0,705
+    review,fixing,2,1178291
+branch_sync:
+  state: pipeline_owned
+  changed: false
+  local:
+    branch: $1
+    head: ${FM_FAKE_RUN_HEAD:-abc1234}
+    clean: true
+  pipeline:
+    run: "01RUN"
+    status: running
+    phase: pre_push
+    submitted_head: ${FM_FAKE_RUN_HEAD:-abc1234}
+    current_head: ${FM_FAKE_PIPELINE_HEAD:-bb41ea9b}
 EOF
 }
 
@@ -1290,6 +1327,132 @@ test_local_advanced_past_run_head_invalidates() {
   pass "local work advanced past run head invalidates attribution"
 }
 
+# --- superseded-vs-current run resolution (2026-08-14 false-failure defect) ---
+#
+# Observed live: branch fm/spawn-noremote-g2 had TWO runs - a live one at 12:33
+# and one abandoned at 10:38 after a push failure. The live run's head was a
+# pipeline commit absent from the crew worktree so it could not be bound, and the
+# abandoned run still sat exactly on the worktree HEAD, so the reader walked past
+# the live run and reported `state: failed` for an actively validating crew.
+# fm-inactive-reconcile.sh then reported the same failure, not independently but
+# because fm-crew-state.sh is its sole current-state source.
+#
+# (1) the live run must win over the superseded one.
+test_live_run_wins_over_superseded_failed_run() {
+  reset_fakes
+  local d head short out
+  d=$(new_case live-vs-superseded)
+  make_repo_on_branch "$d/wt" fm/spawn-noremote-g2
+  head=$(git -C "$d/wt" rev-parse HEAD)
+  short=$(git -C "$d/wt" rev-parse --short=8 HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/g2.meta" "window=fm:fm-g2" "worktree=$d/wt" "kind=ship" "harness=claude"
+  # The pipeline head is unresolvable here, exactly as the live one was.
+  FM_FAKE_PIPELINE_HEAD=bb41ea9b
+  export FM_FAKE_PIPELINE_HEAD
+  git -C "$d/wt" rev-parse --verify "$FM_FAKE_PIPELINE_HEAD^{commit}" >/dev/null 2>&1 \
+    && fail "fixture invalid: the pipeline head must be unresolvable in the crew worktree"
+  FM_FAKE_RUN_HEAD="$head"
+  FM_FAKE_AXI_STATUS="$(run_fixing_pipeline_head_unresolvable fm/spawn-noremote-g2)"
+  # Both runs, newest-first, as `no-mistakes runs` listed them.
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  running    fm/spawn-noremote-g2 ${FM_FAKE_PIPELINE_HEAD}  2026-08-14 12:33
+  failed     fm/spawn-noremote-g2 ${short}  2026-08-14 10:38
+EOF
+)"
+  FM_FAKE_BUSY=0
+  arm_idle_record "$d/state" g2
+  out=$(run_crew_state "$d" g2)
+  assert_contains "$out" "state: working" "the live run must supply the state"
+  assert_contains "$out" "source: run-step" "the live run is attributed via submitted_head"
+  assert_not_contains "$out" "state: failed" "the superseded failed run must never be reported"
+  pass "a live run whose pipeline head is unresolvable wins over a superseded failed run"
+}
+
+# (2) a branch whose ONLY run failed still reports failed. The distinction being
+# fixed is superseded versus current, never failed versus running, so the coarse
+# path must keep reporting a genuine lone failure.
+test_branch_with_only_failed_run_still_reports_failed() {
+  reset_fakes
+  local d short out
+  d=$(new_case only-failed-run)
+  make_repo_on_branch "$d/wt" fm/feat-onlyfailed
+  short=$(git -C "$d/wt" rev-parse --short=8 HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/onlyfailed.meta" "window=fm:fm-onlyfailed" "worktree=$d/wt" "kind=ship" "harness=claude"
+  # Repo-wide answer is another crew's run, so resolution goes through the list.
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  running    fm/other-crew aaaaaaa  2026-08-14 12:41
+  failed     fm/feat-onlyfailed ${short}  2026-08-14 10:38
+EOF
+)"
+  FM_FAKE_BUSY=0
+  arm_idle_record "$d/state" onlyfailed
+  out=$(run_crew_state "$d" onlyfailed)
+  assert_contains "$out" "state: failed" "a genuine lone failed run must still report failed"
+  assert_contains "$out" "source: run-step" "a genuine lone failed run stays run-step sourced"
+  pass "a branch whose only run failed still reports failed"
+}
+
+# (3) genuine ambiguity reports unknown. The branch's current run cannot be bound
+# to this code, while a superseded older run can. Reporting the older run's state
+# is the defect; falling through to the pane/log is equally a guess, because a
+# validating crew's own pane is legitimately idle and its log still carries a
+# pre-validation line. Only unknown is honest.
+test_superseded_bindable_run_reports_unknown() {
+  reset_fakes
+  local d short out
+  d=$(new_case superseded-ambiguous)
+  make_repo_on_branch "$d/wt" fm/feat-ambig
+  short=$(git -C "$d/wt" rev-parse --short=8 HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/ambig.meta" "window=fm:fm-ambig" "worktree=$d/wt" "kind=ship" "harness=claude"
+  # A stale pre-validation terminal line, the kind a fall-through would trust.
+  printf 'done: implemented, ready to validate\n' > "$d/state/ambig.status"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  running    fm/feat-ambig cafed00d  2026-08-14 12:33
+  failed     fm/feat-ambig ${short}  2026-08-14 10:38
+EOF
+)"
+  git -C "$d/wt" rev-parse --verify 'cafed00d^{commit}' >/dev/null 2>&1 \
+    && fail "fixture invalid: the newer run's head must be unresolvable here"
+  FM_FAKE_BUSY=0
+  arm_idle_record "$d/state" ambig
+  out=$(run_crew_state "$d" ambig)
+  assert_contains "$out" "state: unknown" "unbindable current run over a bindable superseded one -> unknown"
+  assert_not_contains "$out" "state: failed" "the superseded run must not supply the state"
+  assert_not_contains "$out" "state: done" "the stale status log must not stand in for the run either"
+  assert_not_contains "$out" "source: run-step" "no run step was resolved, so the source must not claim one"
+  pass "a superseded-only match reports unknown rather than guessing"
+}
+
+# The complement: a newest row that cannot be bound and NO older row that can is
+# not ambiguous, it is simply no attributable run - the existing pane/log
+# fall-through must survive, so the fix does not turn every unbound row into unknown.
+test_unbindable_newest_row_without_older_match_falls_back() {
+  reset_fakes
+  local d out
+  d=$(new_case unbindable-only)
+  make_repo_on_branch "$d/wt" fm/feat-unbound
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/unbound.meta" "window=fm:fm-unbound" "worktree=$d/wt" "kind=ship" "harness=claude"
+  printf 'working: stage 2 implementation in progress\n' > "$d/state/unbound.status"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_RUNS_LIST="$(cat <<'EOF'
+  running    fm/feat-unbound cafed00d  2026-08-14 12:33
+EOF
+)"
+  FM_FAKE_BUSY=0
+  arm_idle_record "$d/state" unbound
+  out=$(run_crew_state "$d" unbound)
+  assert_not_contains "$out" "source: run-step" "an unbindable row must not be attributed"
+  assert_contains "$out" "source: status-log" "no bindable run at all still falls through"
+  assert_contains "$out" "state: working" "the fall-through answer is unchanged"
+  pass "an unbindable newest row with no older match still falls through to pane/log"
+}
+
 test_missing_run_head_falls_back_to_current_state() {
   reset_fakes
   local d out
@@ -1358,5 +1521,9 @@ test_historical_same_branch_rewritten_head_not_current
 test_active_run_descendant_fix_head_remains_current
 test_local_advanced_past_run_head_invalidates
 test_missing_run_head_falls_back_to_current_state
+test_live_run_wins_over_superseded_failed_run
+test_branch_with_only_failed_run_still_reports_failed
+test_superseded_bindable_run_reports_unknown
+test_unbindable_newest_row_without_older_match_falls_back
 
 echo "all fm-crew-state tests passed"

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -2024,6 +2024,37 @@ gate: review
 EOF
 }
 
+# The same parked payload as above, but in the shape no-mistakes emits once a run
+# has already made pipeline fix commits: the top-level `head` is the PIPELINE's
+# head, which lives only in no-mistakes' own repo and cannot be resolved in the
+# crew worktree, while branch_sync.pipeline.submitted_head is the crew commit the
+# run was submitted from. Binding on the top-level head alone would refuse to
+# recognise the task's OWN parked run here and orphan it. See the "Run attribution
+# heads" section of docs/verification/supervision.md for the captured output.
+parked_axi_status_pipeline_head_toon() {  # <branch> <submitted-head> <pipeline-head> [run-id]
+  cat <<EOF
+run:
+  id: "${4:-01RUN}"
+  branch: $1
+  status: awaiting_approval
+  awaiting_agent: parked 2m10s
+  head: "$3"
+  pr: ""
+  findings: none
+gate: review
+branch_sync:
+  state: pipeline_owned
+  local:
+    branch: $1
+    head: "$2"
+    clean: true
+  pipeline:
+    run: "${4:-01RUN}"
+    submitted_head: "$2"
+    current_head: "$3"
+EOF
+}
+
 running_axi_status_toon() {  # <branch> <head> [run-id]
   cat <<EOF
 run:
@@ -2068,6 +2099,57 @@ test_parked_own_run_is_aborted_before_teardown() {
   assert_grep "parked at a gate; aborting" "$case_dir/stderr" \
     "parked-run-abort: teardown did not report aborting the parked run before removing the worker"
   pass "a task's own parked no-mistakes run is aborted, not orphaned, before the worker is removed"
+}
+
+# The false-negative half of the 2026-08-14 attribution defect. fm-crew-state.sh
+# lost a live run and reported a superseded one; teardown loses the SAME run in the
+# other direction, silently declining to abort a parked run it does own and leaving
+# it holding a gate slot with no worker left to answer it. One rule owner
+# (fm_nm_run_binds_worktree), so both callers are constrained by both cases.
+test_parked_own_run_with_unresolvable_pipeline_head_is_aborted() {
+  local case_dir rc head
+  case_dir=$(make_case parked-run-pipeline-head)
+  write_meta "$case_dir" no-mistakes ship
+  land_shippable_commit "$case_dir"
+  head=$(git -C "$case_dir/wt" rev-parse HEAD)
+
+  # Fixture validity: the top-level head this run reports must genuinely not
+  # resolve here, or the case would pass for the wrong reason.
+  if git -C "$case_dir/wt" rev-parse --verify 'bb41ea9b^{commit}' >/dev/null 2>&1; then
+    fail "parked-run-pipeline-head: fixture pipeline head unexpectedly resolves in the worktree"
+  fi
+
+  rc=0
+  FM_FAKE_AXI_STATUS="$(parked_axi_status_pipeline_head_toon fm/task-x1 "$head" bb41ea9b)" \
+  FM_FAKE_NM_ABORT_LOG="$case_dir/nm-abort.log" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+
+  expect_code 0 "$rc" "parked-run-pipeline-head: teardown should still succeed"
+  assert_present "$case_dir/nm-abort.log" \
+    "parked-run-pipeline-head: teardown left its own parked run orphaned because the pipeline head did not resolve"
+  assert_grep "abort --run 01RUN" "$case_dir/nm-abort.log" \
+    "parked-run-pipeline-head: teardown did not target the task's own run id"
+  pass "a task's own parked run is still aborted when only its submitted head resolves here"
+}
+
+# The complement, guarding against fixing the above by binding on the branch
+# alone: a parked run on OUR branch whose neither head belongs to this worktree
+# (a rewritten or foreign tip) is still not ours to abort.
+test_parked_run_on_own_branch_with_foreign_code_is_never_aborted() {
+  local case_dir rc
+  case_dir=$(make_case parked-run-foreign-code)
+  write_meta "$case_dir" no-mistakes ship
+  land_shippable_commit "$case_dir"
+
+  rc=0
+  FM_FAKE_AXI_STATUS="$(parked_axi_status_pipeline_head_toon fm/task-x1 cafed00d bb41ea9b)" \
+  FM_FAKE_NM_ABORT_LOG="$case_dir/nm-abort.log" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+
+  expect_code 0 "$rc" "parked-run-foreign-code: teardown should still succeed"
+  assert_absent "$case_dir/nm-abort.log" \
+    "parked-run-foreign-code: teardown aborted a run whose code identity is not this worktree's"
+  pass "a same-branch parked run with no matching head is still not aborted (branch alone never binds)"
 }
 
 test_mismatched_run_after_abort_refuses_unconfirmed() {
@@ -2633,6 +2715,8 @@ test_persistent_index_lock_exhausts_retries_and_refuses_loudly
 test_empty_retry_wait_uses_default_without_aborting
 test_fractional_legacy_retry_wait_refuses_without_arithmetic_error
 test_parked_own_run_is_aborted_before_teardown
+test_parked_own_run_with_unresolvable_pipeline_head_is_aborted
+test_parked_run_on_own_branch_with_foreign_code_is_never_aborted
 test_parked_own_run_refuses_when_abort_is_unconfirmed
 test_mismatched_run_after_abort_refuses_unconfirmed
 test_empty_status_after_abort_refuses_unconfirmed


### PR DESCRIPTION
## Intent

Stop firstmate reporting a worker as failed when its work is actually alive.

The defect, with the evidence it was found by. A task whose branch has more than one validation run was reported using the wrong run. Observed live on 2026-08-14 on task spawn-noremote-g2, branch fm/spawn-noremote-g2: `no-mistakes runs` listed two runs for that branch, "running ... 1df684df 12:33" and "failed ... de91af51 10:38", where the 10:38 run had been abandoned after a push failure and superseded. `bin/fm-crew-state.sh spawn-noremote-g2` reported "state: failed - source: run-step - run failed", and the inactive-outcome check reported "child=spawn-noremote-g2 state=failed", while the worker itself was alive and parked at a review gate awaiting a decision. Firstmate nearly reported dead work twice on the strength of that, and a fleet view that lies about a task's state is worse than one that says unknown. AGENTS.md already states the intended contract in its validate section: judge validation by the current-code-matched run step. The readers were not honouring it when several runs exist for one branch.

What was asked for, and is what this change must be judged against:
1. Find every place that resolves a task's run state, at least bin/fm-crew-state.sh's run-step source and whatever produces the inactive-outcome check, by searching rather than assuming those are the only two, and record the search in the PR.
2. Make resolution pick the run that matches the task's current work, not merely a run whose branch name matches. Prefer the live or current-head-matched run; a superseded run must never supply the reported state.
3. When resolution is genuinely ambiguous, report unknown rather than guessing. unknown is honest and the fleet contract already tolerates it; a confident wrong answer is the actual harm.

An explicit constraint from the requester, deliberately shaping the design: do NOT paper over this by filtering out failed runs in general. A genuinely failed live run must still report failed. The distinction being enforced is superseded versus current, NOT failed versus running. Anything that reads as "ignore failed runs" is the wrong fix.

Required regression coverage, all three of which had to fail before the change: a branch with a superseded failed run plus a live running run reports the live one; a branch whose only run failed still reports failed; an ambiguous case reports unknown rather than picking one.

Acceptance criteria: a parked or running task is never reported as failed because of a superseded run; a genuinely failed run is still reported as failed; ambiguity reports unknown; every resolution site found and fixed with the search recorded in the PR; tests cover all three cases and fail without the change. Standing instruction from the requester: no em-dashes anywhere in code, comments, documentation, commits or PR text.

Root cause found, which explains why the diff looks the way it does. Attribution bound only on a run's top-level `head` field, which is the PIPELINE's head, not the crew's. It advances with every pipeline fix commit, and those commits live in no-mistakes' own repository rather than the crew worktree, so a fixing run reports a head the crew worktree cannot resolve at all. Verified live against no-mistakes v1.46.0: the worktree HEAD was de91af5179f296f12a6f99f0c082bdca9db59fb7, `git rev-parse --verify bb41ea9b^{commit}` returned "fatal: Needed a single revision", and `no-mistakes axi status` returned the live run carrying branch_sync.pipeline.submitted_head equal to the worktree HEAD exactly. So the crew's own live run failed to bind, resolution fell to the coarse `no-mistakes runs` fallback, whose newest row carried the same unresolvable sha and failed the same check, and the loop then `continue`d to the older abandoned row, which sat exactly on the worktree HEAD and bound. That produced "failed" for a crew parked at a review gate.

Decisions and tradeoffs made while doing the work, which a reviewer reading only the diff would not know:
- The rule has ONE owner, fm_nm_run_binds_worktree in bin/fm-nm-run-lib.sh, shared by both real resolution sites. It reads branch_sync.pipeline.submitted_head as well as the top-level head and lets EITHER carry a positive verdict. submitted_head is the worktree commit the run was submitted from and does not move while the pipeline works, so it answers ownership for the whole life of a run; the top-level head is kept as the fallback for a run object with no branch_sync block. Deliberately not replaced, because two independent signals mean no single vendor field is load-bearing.
- bin/fm-crew-state.sh's coarse path no longer walks past a non-binding newest row to an older one. Because the runs list is newest-first, only a branch's topmost row can be the current run and every older row is superseded by definition. An older row is now consulted ONLY to distinguish honest ambiguity from having no answer at all, and its status is never reported.
- The ambiguous case emits unknown/none directly rather than falling through to the existing pane/status-log fallback. That was a deliberate choice: a validating crew's own pane is legitimately idle and its status log still carries the pre-validation line, so falling through would report whatever terminal line the log last happened to carry. That is just as much a guess as reporting the superseded run, and a confident wrong verdict is the expensive failure mode here.
- The ambiguity is signalled with a reserved sentinel string containing spaces, because the function runs inside command substitution so a global variable cannot propagate out of the subshell, and a runs-list status is parsed as a single whitespace-delimited word so no real status can collide with it.
- The status-log reconciliation now excludes an unknown run state from claiming supersession, since unknown establishes nothing the log could have been superseded by.
- Two corrections to the original problem statement, both worth a reviewer's attention. First, the request described "two separate readers" resolving the superseded run, but bin/fm-inactive-reconcile.sh is NOT an independent resolver: bin/fm-crew-state.sh is its sole current-state source, so its inactive-outcome report was the same single wrong answer relayed, and it is fixed transitively with no change of its own. Second, there IS a second genuine resolution site the request did not name, bin/fm-teardown.sh, which had the identical defect in the opposite direction: a task's own parked run whose pipeline head had advanced failed to bind, so teardown silently declined to abort it and left it orphaned holding a gate slot with no worker left to answer it. Both sites now go through the shared owner, so both directions of the defect are constrained by both sets of tests.
- Search performed to justify the completeness claim: greps across bin, tests, .agents, docs and AGENTS.md for `axi status`, `runs --limit`, `no-mistakes runs`, the run status vocabulary (checks-passed, awaiting_approval, fix_review, submitted_head, branch_sync), `outcome`, sourcers of fm-nm-run-lib, callers of fm-crew-state.sh, and non-shell resolvers (.mjs, .js, .ts, .py; no hits). Exactly two files issue a no-mistakes run query and resolve a run to a task: bin/fm-crew-state.sh and bin/fm-teardown.sh. Every other reader (fm-backend.sh, fm-inactive-reconcile.sh, fm-classify-lib.sh, fm-fleet-snapshot.sh, fm-session-start.sh, fm-watch.sh, fm-supervise-daemon.sh, backends/herdr.sh) consumes fm-crew-state.sh output and resolves nothing itself.
- Test placement follows the repo rule that behavior is exercised through executable interfaces, never by asserting implementation source bytes. Every case drives the real bin/fm-crew-state.sh or bin/fm-teardown.sh with faked no-mistakes output in the shape the real v1.46.0 CLI emits, and each fixture carries a validity guard asserting that the pipeline head genuinely does not resolve in the test worktree, so the case cannot pass for the wrong reason or go quietly vacuous.
- Beyond the three required cases, three anti-regression guards were added that pass both before and after the change: a lone failed run still reports failed, an unbindable newest row with no older match still falls through to the existing sources rather than becoming unknown, and a same-branch parked run whose neither head belongs to the worktree is still not aborted by teardown. Those guards are what prove the fix is superseded-versus-current and not failed-versus-running, and that branch name alone still never binds.
- Durable evidence went to the existing classified maintainer-verification record, a new "Run attribution heads" section in docs/verification/supervision.md, rather than a new verification file, following the repo's knowledge-placement rule that a fact belongs to its most specific existing owner. It records the date, the no-mistakes version, the exact commands, and the captured output that makes the second head necessary. AGENTS.md and docs/architecture.md were deliberately left unchanged: they already state the current-code-matched contract as one-line pointers that remain accurate, and restating which heads count there would duplicate the rule owner.

Verification already run locally: tests/fm-crew-state.test.sh 53 ok, tests/fm-teardown.test.sh 60 ok, tests/fm-inactive-reconcile.test.sh 16 ok, tests/fm-gotmp.test.sh 3 ok; bin/fm-test-run.sh --changed selected 35 suites and 34 pass; bin/fm-lint.sh clean on pinned ShellCheck 0.11.0; bin/fm-doc-audience-check.sh ok; bin/fm-test-run.sh --check-coverage ok. Each of the three required cases was confirmed to fail with bin/ reverted to HEAD and the test files as written. One pre-existing environmental failure is NOT a regression from this change: tests/fm-decision-hold-lifecycle.test.sh fails at setup with "mise ERROR No version is set for shim: tasks-axi", reproduced identically on a pristine `git archive HEAD` tree containing none of these changes.

## What Changed

- `bin/fm-nm-run-lib.sh` gains `fm_nm_run_binds_worktree`, now the single owner of run-to-task attribution. It accepts a match on `branch_sync.pipeline.submitted_head` (the worktree commit a run was submitted from, which does not move while the pipeline works) as well as on the top-level `head` (the pipeline's own head, which advances onto no-mistakes repo commits the crew worktree cannot resolve, so it binds nothing once a run starts fixing). Both real resolution sites now call it: `bin/fm-crew-state.sh`'s `axi status` path, and `bin/fm-teardown.sh`'s own-parked-run check, which carried the same defect in the opposite direction and silently declined to abort a task's own parked run. Sites were enumerated by grepping `bin`, `tests`, `.agents`, `docs` and `AGENTS.md` for `axi status`, `runs --limit`, `no-mistakes runs`, the run status vocabulary (`checks-passed`, `awaiting_approval`, `fix_review`, `submitted_head`, `branch_sync`), `outcome`, sourcers of `fm-nm-run-lib`, callers of `fm-crew-state.sh`, and non-shell resolvers (`.mjs`, `.js`, `.ts`, `.py`; no hits); exactly those two files query a run and resolve it to a task, and `bin/fm-inactive-reconcile.sh` is not an independent resolver (`fm-crew-state.sh` is its sole current-state source), so it is corrected transitively with no change of its own.
- `bin/fm-crew-state.sh`'s coarse `no-mistakes runs` path no longer walks past a non-binding newest row to an older one. The list is newest-first, so only a branch's topmost row can be its current run and every older row is superseded by definition; an older bindable row is now consulted only to tell honest ambiguity apart from having no answer, and its status is never reported. That ambiguity emits `state: unknown` with `source: none` directly, instead of the superseded run's status or a pane/status-log answer standing in for it. Status-log reconciliation also stops letting an `unknown` run state claim supersession, while a branch whose only run failed still reports `failed`, keeping the distinction superseded-versus-current rather than failed-versus-running.
- `tests/fm-crew-state.test.sh` adds four cases (live run with an unresolvable pipeline head wins over a superseded failed run; a lone failed run still reports failed; a superseded-only match reports unknown and does not fall through to a stale status log; an unbindable newest row with no older match still falls through as before) and `tests/fm-teardown.test.sh` adds two (a parked run binding only on `submitted_head` is aborted; a same-branch parked run with no matching head is still never aborted). Each drives the real script with faked v1.46.0-shaped CLI output and guards that the fixture's pipeline head genuinely does not resolve in the test worktree. `docs/verification/supervision.md` records the captured live commands and output in a new "Run attribution heads" section, and `docs/architecture.md` now points at the rule owner and states the unknown-on-ambiguity behavior in its resolution order.

## Risk Assessment

✅ Low: The change is well bounded to one evidence-backed rule owner with both real resolution sites routed through it, the superseded-supplies-state invariant is closed on both the axi-status and coarse paths, the widened teardown binding stays constrained by the same-branch precondition, the new unknown verdict is safe for every downstream consumer, and the only findings are two mechanical comment/doc nits plus two recorded tradeoffs.

## Testing

I read the change, ran the four directly affected suites (fm-crew-state 53 ok, fm-teardown 60 ok, fm-inactive-reconcile 16 ok, fm-gotmp 3 ok, all exit 0), then built the evidence the intent actually asks for by replaying the live 2026-08-14 incident end to end. With a real git worktree on `fm/spawn-noremote-g2` and a fake `no-mistakes` emitting the recorded v1.46.0 shapes, the pre-fix tree reproduces the reported symptom exactly: `bin/fm-crew-state.sh` says `state: failed · source: run-step · run failed`, the rendered `bin/fm-fleet-view.sh` table shows `failed / run-step` for a crew parked at a review gate, and `bin/fm-inactive-reconcile.sh` writes a durable terminal-outcome record announcing `child=spawn-noremote-g2 state=failed`. The post-fix tree reports `state: parked · source: run-step · parked at review`, renders `parked / run-step`, and writes no outcome record at all. I then proved the distinction is superseded-versus-current and not failed-versus-running: over the same product surfaces, a genuinely failed live run and a branch whose only run failed both still report `failed` and still reconcile as terminal, identically before and after, and the only behavior that changed is the ambiguous case, from a confident `failed` to `state: unknown · source: none · cannot match this code to the branch's current run`. Reverting only the three changed `bin/` files to the base commit makes both crew-state regression cases and the previously unnamed teardown-site case fail; the third required case (lone failed run still reports failed) passes before and after, which is the one small divergence from the intent's literal wording and is the sole finding. Visual evidence is a rendered markdown fleet-view table rather than a screenshot because this surface is a terminal CLI with no graphical renderer. Working tree left clean; all evidence is under the dedicated evidence directory.

<details>
<summary>Evidence: Before/after end-to-end incident replay (fleet view, snapshot JSON, inactive-outcome check)</summary>

```text
################ BEFORE the fix (bin/ at ef35d79, tests+docs unchanged)  (tree: /tmp/no-mistakes-evidence/01M05MGX1XAFE95ZSKNYFJXGXC/baseline-tree) ################

--- what the operator sees from no-mistakes ---
$ no-mistakes version
no-mistakes version v1.46.0 (20892e6)
$ no-mistakes runs --limit 60
  running    fm/spawn-noremote-g2 bb41ea9b  2026-08-14 12:33
  failed     fm/spawn-noremote-g2 f62bfca9  2026-08-14 10:38
$ git -C <crew worktree> rev-parse HEAD
f62bfca91a252279909615ee9b724e10dce8114c
$ git -C <crew worktree> rev-parse --verify 'bb41ea9b^{commit}'
fatal: Needed a single revision
$ no-mistakes axi status   (in the crew worktree)
run:
  id: "01M00473HD3KXXT1B3RPVVTVDC"
  branch: fm/spawn-noremote-g2
  status: awaiting_approval
  awaiting_agent: parked 2m10s
  head: bb41ea9b
  pr: ""
  findings: "1 awaiting, 1 info"
gate: review
branch_sync:
  state: pipeline_owned
  local:
    branch: fm/spawn-noremote-g2
    head: f62bfca91a252279909615ee9b724e10dce8114c
    clean: true
  pipeline:
    run: "01M00473HD3KXXT1B3RPVVTVDC"
    status: running
    phase: pre_push
    submitted_head: f62bfca91a252279909615ee9b724e10dce8114c
    current_head: bb41ea9b

--- the fleet view: bin/fm-crew-state.sh spawn-noremote-g2 ---
state: failed · source: run-step · run failed

--- the captain-facing rendered fleet view: bin/fm-fleet-view.sh ---
  # Fleet View
  
  Schema: fm-fleet-snapshot.v1
  Home: /tmp/fm-repro-Ysdjx0/home
  
  ## Under Way
  | ID | Current | Kind | Repo/Project | Backend | Endpoint | Artifact | Path | Watch / return channel |
  | --- | --- | --- | --- | --- | --- | --- | --- | --- |
  | spawn-noremote-g2 | failed / run-step | ship | - | tmux | present | - | /tmp/fm-repro-Ysdjx0/wt | bin/fm-peek.sh fm-spawn-noremote-g2 |
  
  ## Queued
  No queued backlog records found.
  
  ## Done
  No done backlog records found.
  
  ## Secondmates
  For kind=secondmate, bearings selects validated structured state from that registered home; parent events and bounded terminal evidence are fallback-only supplements and never current-state authority.

--- the captain-facing fleet snapshot row: bin/fm-fleet-snapshot.sh --json ---
{
  "id": "spawn-noremote-g2",
  "current_state": {
    "state": "failed",
    "source": "run-step",
    "detail": "run failed",
    "raw": "state: failed \u00b7 source: run-step \u00b7 run failed",
    "observed_at": "2026-08-16T16:16:26Z",
    "freshness": "fresh"
  }
}

--- the inactive-outcome check: bin/fm-inactive-reconcile.sh scan --startup ---
actionable: inactive terminal outcome awaiting captain presentation: child=spawn-noremote-g2 state=failed
(exit 0)
wake queue:
  1786896986	1	check	inactive-outcome:7ef93a57ba901c3d2e43f7de18c2c381	inactive terminal outcome awaiting captain presentation: child=spawn-noremote-g2 state=failed
durable terminal-outcome records written: 1
  7ef93a57ba901c3d2e43f7de18c2c381.pending:
    task_id=spawn-noremote-g2
    state=failed
    outcome_key=inactive-outcome-main-spawn-noremote-g2-failed

################ AFTER the fix (bin/ at 605c3e6)  (tree: /home/inthuson/.no-mistakes/worktrees/d4c7ad84348d/01M05MGX1XAFE95ZSKNYFJXGXC) ################

--- what the operator sees from no-mistakes ---
$ no-mistakes version
no-mistakes version v1.46.0 (20892e6)
$ no-mistakes runs --limit 60
  running    fm/spawn-noremote-g2 bb41ea9b  2026-08-14 12:33
  failed     fm/spawn-noremote-g2 f62bfca9  2026-08-14 10:38
$ git -C <crew worktree> rev-parse HEAD
f62bfca91a252279909615ee9b724e10dce8114c
$ git -C <crew worktree> rev-parse --verify 'bb41ea9b^{commit}'
fatal: Needed a single revision
$ no-mistakes axi status   (in the crew worktree)
run:
  id: "01M00473HD3KXXT1B3RPVVTVDC"
  branch: fm/spawn-noremote-g2
  status: awaiting_approval
  awaiting_agent: parked 2m10s
  head: bb41ea9b
  pr: ""
  findings: "1 awaiting, 1 info"
gate: review
branch_sync:
  state: pipeline_owned
  local:
    branch: fm/spawn-noremote-g2
    head: f62bfca91a252279909615ee9b724e10dce8114c
    clean: true
  pipeline:
    run: "01M00473HD3KXXT1B3RPVVTVDC"
    status: running
    phase: pre_push
    submitted_head: f62bfca91a252279909615ee9b724e10dce8114c
    current_head: bb41ea9b

--- the fleet view: bin/fm-crew-state.sh spawn-noremote-g2 ---
state: parked · source: run-step · parked at review

--- the captain-facing rendered fleet view: bin/fm-fleet-view.sh ---
  # Fleet View
  
  Schema: fm-fleet-snapshot.v1
  Home: /tmp/fm-repro-v1FWzk/home
  
  ## Under Way
  | ID | Current | Kind | Repo/Project | Backend | Endpoint | Artifact | Path | Watch / return channel |
  | --- | --- | --- | --- | --- | --- | --- | --- | --- |
  | spawn-noremote-g2 | parked / run-step | ship | - | tmux | present | - | /tmp/fm-repro-v1FWzk/wt | bin/fm-peek.sh fm-spawn-noremote-g2 |
  
  ## Queued
  No queued backlog records found.
  
  ## Done
  No done backlog records found.
  
  ## Secondmates
  For kind=secondmate, bearings selects validated structured state from that registered home; parent events and bounded terminal evidence are fallback-only supplements and never current-state authority.

--- the captain-facing fleet snapshot row: bin/fm-fleet-snapshot.sh --json ---
{
  "id": "spawn-noremote-g2",
  "current_state": {
    "state": "parked",
    "source": "run-step",
    "detail": "parked at review",
    "raw": "state: parked \u00b7 source: run-step \u00b7 parked at review",
    "observed_at": "2026-08-16T16:16:27Z",
    "freshness": "fresh"
  }
}

--- the inactive-outcome check: bin/fm-inactive-reconcile.sh scan --startup ---
(exit 0)
wake queue: empty (no terminal outcome reported for this task)
durable terminal-outcome records written: 0
```
</details>
<details>
<summary>Evidence: The captain-facing rendered fleet view row, before vs after</summary>

```text
$ bin/fm-fleet-view.sh # a crew parked at a review gate

## Under Way
| ID | Current | Kind | ... |
| --- | --- | --- | --- |
BEFORE | spawn-noremote-g2 | failed / run-step | ship | ... |
AFTER | spawn-noremote-g2 | parked / run-step | ship | ... |

$ bin/fm-crew-state.sh spawn-noremote-g2
BEFORE state: failed · source: run-step · run failed
AFTER state: parked · source: run-step · parked at review

$ bin/fm-inactive-reconcile.sh scan --startup
BEFORE actionable: inactive terminal outcome awaiting captain presentation: child=spawn-noremote-g2 state=failed
durable terminal-outcome records written: 1 (state=failed)
AFTER (no output)
durable terminal-outcome records written: 0

Fixture validity, printed by the harness in both runs:
$ git -C <crew worktree> rev-parse --verify 'bb41ea9b^{commit}'
fatal: Needed a single revision
```
</details>
<details>
<summary>Evidence: Scenario matrix before/after: genuine failure preserved, only ambiguity changed</summary>

```text
BEFORE (bin/ at ef35d79) AFTER (bin/ at 605c3e6)
genuinely failed live run state: failed · source: run-step state: failed · source: run-step (unchanged)
outcome reported: state=failed outcome reported: state=failed (unchanged)
branch whose only run failed state: failed · source: run-step state: failed · source: run-step (unchanged)
outcome reported: state=failed outcome reported: state=failed (unchanged)
ambiguous: only a superseded run binds state: failed · source: run-step state: unknown · source: none · cannot match this
outcome reported: state=failed code to the branch's current run; not reporting
a superseded one
no terminal outcome reported

This is the proof the fix is superseded-versus-current, not "ignore failed runs":
both genuine-failure rows are identical before and after.
```
</details>
<details>
<summary>Evidence: Required regression cases run against bin/ reverted to the base commit</summary>

<code>$ tests/fm-crew-state.test.sh # only test_live_run_wins_over_superseded_failed_run&#10;not ok - the live run must supply the state (missing: &#39;state: working&#39;)&#10;--- output ---&#10;state: failed · source: run-step · run failed&#10;&#10;$ tests/fm-crew-state.test.sh # only test_superseded_bindable_run_reports_unknown&#10;not ok - unbindable current run over a bindable superseded one -&gt; unknown (missing: &#39;state: unknown&#39;)&#10;--- output ---&#10;state: failed · source: run-step · run failed&#10;&#10;$ tests/fm-teardown.test.sh # only test_parked_own_run_with_unresolvable_pipeline_head_is_aborted&#10;not ok - parked-run-pipeline-head: teardown left its own parked run orphaned because the pipeline head did not resolve&#10;&#10;$ tests/fm-crew-state.test.sh # only test_branch_with_only_failed_run_still_reports_failed&#10;ok - a branch whose only run failed still reports failed &lt;-- passes pre-fix too (see finding)&#10;&#10;$ tests/fm-teardown.test.sh # only test_parked_run_on_own_branch_with_foreign_code_is_never_aborted&#10;ok - a same-branch parked run with no matching head is still not aborted (branch alone never binds)</code>

```text
### Required regression cases run against bin/ reverted to the base commit ef35d79
### (test files kept exactly as written on 605c3e6). fail() exits non-zero on first failure.

$ bash tests/fm-crew-state.test.sh  # only test_live_run_wins_over_superseded_failed_run
not ok - the live run must supply the state (missing: 'state: working')
--- output ---
state: failed · source: run-step · run failed

$ bash tests/fm-crew-state.test.sh  # only test_superseded_bindable_run_reports_unknown
not ok - unbindable current run over a bindable superseded one -> unknown (missing: 'state: unknown')
--- output ---
state: failed · source: run-step · run failed

$ bash tests/fm-crew-state.test.sh  # only test_branch_with_only_failed_run_still_reports_failed
ok - a branch whose only run failed still reports failed

$ bash tests/fm-teardown.test.sh  # only test_parked_own_run_with_unresolvable_pipeline_head_is_aborted
not ok - parked-run-pipeline-head: teardown left its own parked run orphaned because the pipeline head did not resolve

$ bash tests/fm-teardown.test.sh  # only test_parked_run_on_own_branch_with_foreign_code_is_never_aborted
ok - a same-branch parked run with no matching head is still not aborted (branch alone never binds)
```
</details>
<details>
<summary>Evidence: Scenario matrix transcript, pre-fix and post-fix</summary>

```text
################ BEFORE the fix (bin/ at ef35d79) ################

=== genuinely failed live run ===
expected: state: failed (a real failure must still be reported, and reconciled as terminal)
$ no-mistakes runs --limit 60
  failed     fm/feat-genuine bb63a0db  2026-08-14 12:33
$ bin/fm-crew-state.sh failed-live
state: failed · source: run-step · run failed
$ bin/fm-inactive-reconcile.sh scan --startup
actionable: inactive terminal outcome awaiting captain presentation: child=failed-live state=failed
  -> terminal outcome reported: inactive terminal outcome awaiting captain presentation: child=failed-live state=failed

=== branch whose only run failed ===
expected: state: failed (superseded-vs-current, never failed-vs-running)
$ no-mistakes runs --limit 60
  running    fm/other-crew deadbeef  2026-08-14 12:41
  failed     fm/feat-onlyfailed bb63a0db  2026-08-14 10:38
$ bin/fm-crew-state.sh only-failed
state: failed · source: run-step · run failed
$ bin/fm-inactive-reconcile.sh scan --startup
actionable: inactive terminal outcome awaiting captain presentation: child=only-failed state=failed
  -> terminal outcome reported: inactive terminal outcome awaiting captain presentation: child=only-failed state=failed

=== ambiguous: only a superseded run binds ===
expected: state: unknown (honest), and no terminal outcome reported
$ no-mistakes runs --limit 60
  running    fm/feat-ambig cafed00d  2026-08-14 12:33
  failed     fm/feat-ambig 8fe20077  2026-08-14 10:38
$ bin/fm-crew-state.sh ambig
state: failed · source: run-step · run failed
$ bin/fm-inactive-reconcile.sh scan --startup
actionable: inactive terminal outcome awaiting captain presentation: child=ambig state=failed
  -> terminal outcome reported: inactive terminal outcome awaiting captain presentation: child=ambig state=failed

################ AFTER the fix (bin/ at 605c3e6) ################

=== genuinely failed live run ===
expected: state: failed (a real failure must still be reported, and reconciled as terminal)
$ no-mistakes runs --limit 60
  failed     fm/feat-genuine 8fe20077  2026-08-14 12:33
$ bin/fm-crew-state.sh failed-live
state: failed · source: run-step · run failed
$ bin/fm-inactive-reconcile.sh scan --startup
actionable: inactive terminal outcome awaiting captain presentation: child=failed-live state=failed
  -> terminal outcome reported: inactive terminal outcome awaiting captain presentation: child=failed-live state=failed

=== branch whose only run failed ===
expected: state: failed (superseded-vs-current, never failed-vs-running)
$ no-mistakes runs --limit 60
  running    fm/other-crew deadbeef  2026-08-14 12:41
  failed     fm/feat-onlyfailed 6185fd5f  2026-08-14 10:38
$ bin/fm-crew-state.sh only-failed
state: failed · source: run-step · run failed
$ bin/fm-inactive-reconcile.sh scan --startup
actionable: inactive terminal outcome awaiting captain presentation: child=only-failed state=failed
  -> terminal outcome reported: inactive terminal outcome awaiting captain presentation: child=only-failed state=failed

=== ambiguous: only a superseded run binds ===
expected: state: unknown (honest), and no terminal outcome reported
$ no-mistakes runs --limit 60
  running    fm/feat-ambig cafed00d  2026-08-14 12:33
  failed     fm/feat-ambig 6185fd5f  2026-08-14 10:38
$ bin/fm-crew-state.sh ambig
state: unknown · source: none · cannot match this code to the branch's current run; not reporting a superseded one
$ bin/fm-inactive-reconcile.sh scan --startup
  -> no terminal outcome reported
```
</details>
<details>
<summary>Evidence: Reproduction harnesses and instructions (incident replay, scenario matrix, pre-fix tree rebuild)</summary>

```text
# Local test evidence: never report a superseded run as a task's current state

Change under test: `605c3e6` on `fm/stale-run-match-v6` (base `ef35d79`).

## Files

- `incident-before-after.txt` - end-to-end reproduction of the live 2026-08-14
  incident (task `spawn-noremote-g2`, branch `fm/spawn-noremote-g2`) driven
  through the real `bin/fm-crew-state.sh` and `bin/fm-inactive-reconcile.sh`,
  captured against the pre-fix `bin/` and then the post-fix `bin/`.
- `scenarios-before-after.txt` - the same product surface over the three states
  the fix must distinguish: genuinely failed live run, branch whose only run
  failed, and genuine ambiguity. Side by side, pre-fix and post-fix.
- `pre-fix-test-results.txt` - the new regression cases run with `bin/` reverted
  to the base commit and the test files left exactly as written.
- `repro-incident.sh`, `repro-scenarios.sh` - the harnesses that produced the two
  transcripts. Each takes a tree root and a label.
- `baseline-tree/` - a checkout of `605c3e6` with only the three changed `bin/`
  files reverted to `ef35d79`, so the new tests and the harnesses can be run
  against pre-fix behavior.

## Reproducing

`` `sh
EV=/tmp/no-mistakes-evidence/01M05MGX1XAFE95ZSKNYFJXGXC
bash "$EV/repro-incident.sh"  "$EV/baseline-tree" "BEFORE"
bash "$EV/repro-incident.sh"  "$PWD"              "AFTER"
bash "$EV/repro-scenarios.sh" "$EV/baseline-tree" "BEFORE"
bash "$EV/repro-scenarios.sh" "$PWD"              "AFTER"
`` `

Rebuilding `baseline-tree/` from scratch:

`` `sh
git archive 605c3e6 | tar -x -C baseline-tree
for f in bin/fm-crew-state.sh bin/fm-nm-run-lib.sh bin/fm-teardown.sh; do
  git show "ef35d79:$f" > "baseline-tree/$f"
done
chmod +x baseline-tree/bin/fm-crew-state.sh baseline-tree/bin/fm-teardown.sh
`` `

The fake `no-mistakes` in both harnesses emits the v1.46.0 shapes recorded in
`docs/verification/supervision.md`: a `runs` list carrying a live row and a
superseded row for one branch, and an `axi status` run whose top-level `head` is
a pipeline commit absent from the crew worktree while
`branch_sync.pipeline.submitted_head` is the crew commit it was submitted from.
Both harnesses print `git rev-parse --verify '<pipeline head>^{commit}'` failing
in the crew worktree, so the transcripts cannot look right for the wrong reason.
```
</details>
- Outcome: ⚠️ 1 info across 1 run (11m55s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"053df032aece01ec54e6d923b88ba9c2fcec6981","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 4 infos</summary>

- ℹ️ `bin/fm-crew-state.sh:413` - Dangling reference to a function renamed in this same commit. bin/fm-crew-state.sh:413 says the coarse row rule is &#34;the same rules as nm_run_head_matches_worktree&#34;, but the diff renamed that function to nm_run_binds_worktree, so the name no longer exists anywhere in the repo (grep confirms line 413 is the only remaining hit). The reference is also now semantically wrong: nm_coarse_head_matches_worktree wraps the single-head primitive fm_nm_head_matches_worktree, not the two-head binder, and the whole point of the fix is that those two rules differ. In a file where header comments are the documented rule-ownership pointers, a comment naming a nonexistent function sends the next reader to the wrong owner. Point it at fm_nm_head_matches_worktree.
- ℹ️ `docs/verification/supervision.md:237` - The new &#34;Run attribution heads&#34; section records a one-off run identifier (id: &#34;01M00473HD3KXXT1B3RPVVTVDC&#34;) and the task branch name fm/spawn-noremote-g2 in a tracked doc. That contradicts the same file&#39;s own header at docs/verification/supervision.md:7 (&#34;Task-specific chronology, temporary paths, run identifiers, and delivery transcripts remain in private reports or PR evidence&#34;) and docs/documentation-audiences.md:17 (&#34;branches ... and one-off process identifiers stay in private task reports or PR evidence by default&#34;); it is the only run identifier in docs/, and docs/codex-app-backend.md:57 shows the repo&#39;s practice of keeping verification records free of task-specific ids. The load-bearing evidence is the two head SHAs and the fact that one does not resolve in the worktree, neither of which needs the run id or the branch name, so redacting them (id: &#34;&lt;run id&gt;&#34;, a generic branch placeholder) keeps the section&#39;s full evidentiary value.
- ℹ️ `bin/fm-crew-state.sh:478` - Recorded tradeoff, no action needed. The ambiguity branch emits unknown/none directly, which skips the pane busy verdict as well as the status log. The intent justifies skipping the fallback because &#34;a validating crew&#39;s own pane is legitimately idle and its status log still carries the pre-validation line&#34;, which is exactly right for the status log, but a positive busy verdict from fm_busy_classify is live evidence rather than a stale tail, and it is now discarded too. Effect: a crew in the ambiguous state whose harness is actively busy reports unknown, so crew_absorb_class returns none and its no-verb turn-end and stale wakes surface to the captain instead of being absorbed. This is not a regression (pre-change a non-empty coarse status also set HAVE_RUN=1 and never reached the pane), and it fails safe toward surfacing rather than toward reporting dead work, so it is strictly better than the defect. Noting it only so the boundary is on record: admitting an exact busy verdict here would preserve the honesty property while recovering the absorb.
- ℹ️ `tests/fm-crew-state.test.sh:1375` - The acceptance criteria say &#34;tests cover all three cases and fail without the change&#34;, and one of the three named cases is &#34;a branch whose only run failed still reports failed&#34;. test_branch_with_only_failed_run_still_reports_failed cannot fail before the change: the pre-change coarse path already reported failed for a lone bindable failed row, so a correct test of that behavior necessarily passes in both directions. The criterion is unsatisfiable for that case rather than unmet by the author, the behavior itself is covered, and both the intent (&#34;three anti-regression guards ... that pass both before and after&#34;) and the commit message (which lists it under guards, not under &#34;all failing before the change&#34;) disclose this accurately. Raising it only so the acceptance record is explicit; the other two required cases do fail without the change, since the pre-change loop walked past the unbindable newest row to the superseded one in both.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `tests/fm-crew-state.test.sh:1367` - Acceptance criteria says &#34;tests cover all three cases and fail without the change&#34;, but one of the three required cases cannot fail without the change and does not: `test_branch_with_only_failed_run_still_reports_failed` passes identically against `bin/` reverted to ef35d79 (verified, see pre-fix-test-results.txt). The pre-fix code already reported `failed` for a branch whose only run failed, so requiring that case to fail beforehand would require a second, different pre-existing bug. The author documented this same reclassification (&#34;anti-regression guards that pass both before and after&#34;). The other two required cases plus the previously unnamed teardown site case all do fail before the change. No test action needed; noting only because the intent states the criterion literally.
- <code>`bash tests/fm-crew-state.test.sh` (53 ok, exit 0) - includes the four new attribution cases</code>
- <code>`bash tests/fm-teardown.test.sh` (60 ok, exit 0) - includes the two new second-resolution-site cases</code>
- <code>`bash tests/fm-inactive-reconcile.test.sh` (16 ok, exit 0) - the transitively fixed consumer</code>
- <code>`bash tests/fm-gotmp.test.sh` (3 ok, exit 0) - symlinks the changed `bin/fm-nm-run-lib.sh`</code>
- <code>Pre-fix reproduction: rebuilt a tree at 605c3e6 with only `bin/fm-crew-state.sh`, `bin/fm-nm-run-lib.sh`, `bin/fm-teardown.sh` reverted to ef35d79, then ran each required case in isolation. `test_live_run_wins_over_superseded_failed_run` and `test_superseded_bindable_run_reports_unknown` both fail with `state: failed · source: run-step · run failed`; `test_parked_own_run_with_unresolvable_pipeline_head_is_aborted` fails with the run left orphaned. `test_branch_with_only_failed_run_still_reports_failed` and `test_parked_run_on_own_branch_with_foreign_code_is_never_aborted` pass both ways.</code>
- <code>Manual end-to-end incident replay (`/tmp/no-mistakes-evidence/01M05MGX1XAFE95ZSKNYFJXGXC/repro-incident.sh`): real git worktree on `fm/spawn-noremote-g2`, fake `no-mistakes` emitting the v1.46.0 shapes from docs/verification/supervision.md (two runs for one branch; `axi status` whose top-level `head` is the unresolvable pipeline commit and whose `branch_sync.pipeline.submitted_head` is the worktree HEAD), driven through `bin/fm-crew-state.sh spawn-noremote-g2`, `bin/fm-fleet-view.sh`, `bin/fm-fleet-snapshot.sh --json`, and `bin/fm-inactive-reconcile.sh scan --startup`, against the pre-fix and post-fix trees</code>
- <code>Manual scenario matrix (`repro-scenarios.sh`) over the same surfaces for three states: genuinely failed live run, branch whose only run failed, and superseded-only-binds ambiguity - captured pre-fix and post-fix side by side</code>
- <code>Fixture validity guard inside both harnesses: `git rev-parse --verify &#39;bb41ea9b^{commit}&#39;` prints `fatal: Needed a single revision` in the crew worktree, so the transcripts cannot read correctly for the wrong reason</code>
- <code>`git diff ef35d79 605c3e6 | grep &#39;—&#39;` and `git log -1 --format=%B 605c3e6 | grep &#39;—&#39;` - no em-dash in the change or its commit message</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `.agents/skills/stuck-crewmate-recovery/SKILL.md:33` - Judgment call, not fixed: `bin/fm-crew-state.sh` can now report `unknown · none · cannot match this code to the branch&#39;s current run; not reporting a superseded one` while a validation run for that branch is genuinely live. `.agents/skills/stuck-crewmate-recovery/SKILL.md` is the nameable-situation owner for acting on a crew whose state cannot be resolved, and its existing guidance already fails safe (line 33 routes an unaccounted run to backend/worktree inspection, lines 37-40 require proving no live agent owns the task before relaunch and preserving state when ownership cannot be reconciled), so nothing there is factually stale. I left it unchanged rather than adding a clause about the new detail string, which would restate the rule owner in always-loaded agent guidance. Confirm that reading if you want the skill to name this case explicitly.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
