### PR TITLE
docs(calm): rebase Pi compatibility evidence on the installed 0.84.2

### DIFF
--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -13,6 +13,7 @@ Changing persisted context to remove hidden content, filtering provider context,
 ## Compatibility evidence
 
 [`calm.md`](calm.md#pi-compatibility) owns the current Pi compatibility contract.
+The currently installed Pi is 0.84.2, and the Calm test suite passes against it (verified 2026-08-16), so the current baseline is the installed version rather than the earlier 0.81.1-0.82.0 evidence.
 Pi 0.81.1 was installed when Calm was first built, and Pi 0.82.0 was the later reverification target.
 The inspected Pi CHANGELOG shows no relevant presentation API introduced at either version, so those versions remain verification evidence rather than compatibility bounds.
 The exported classes used by the adapters (`AssistantMessageComponent` and `InteractiveMode`) are undocumented internals with no stated version guarantee.
@@ -201,7 +202,7 @@ Serialized session data and Pi 0.81.1's sidebar tree also retain legacy hidden o
 The taxonomy was derived from Pi 0.81.1's installed public declarations, documentation, examples, `interactive-mode.js`, and its exported component implementations.
 The test fixture enumerates every class below through the centralized policy, and the interactive fixture exercises the screenshot classes, current user-role operational input, and legacy synthetic presentation entries.
 
-| Policy class | Pi transcript path | Calm result (baseline verified on Pi 0.81.1 through 0.82.0; newer evidence noted per row) |
+| Policy class | Pi transcript path | Calm result (baseline verified on the installed Pi 0.84.2; earlier 0.81.1-0.82.0 evidence retained as history) |
 | --- | --- | --- |
 | `genuine-user-prompt` | `UserMessageComponent` | Visible, including every tested operational near miss. |
 | `genuine-agent-response` | Assistant text in `AssistantMessageComponent` | Visible. |
@@ -251,7 +252,7 @@ grok 0.2.106 (bde89716f679)
 | Claude Code 2.1.218 | Not feasible through the inspected supported project surface. | Project hooks can observe lifecycle and tool events, while the plugin CLI packages supported components; neither inspected surface exposes a transcript-row renderer or transcript-wide redraw API. |
 | Codex CLI 0.144.6 | Not feasible through the inspected supported project surface. | The tracked hooks expose session, pre-tool, and stop handling, while the plugin and feature inventories expose no TUI tool-row renderer or transcript redraw control. |
 | OpenCode 1.17.18 | Not feasible without violating the preservation boundary. | Plugins expose events and tool execution hooks, not a built-in transcript-row renderer; same-name tool replacement changes execution rather than presentation alone. |
-| Pi (verified 0.81.1 through 0.82.0) | Partially feasible with two API-probed exported-class adapters. | Public APIs control working visibility, collapsed labels, known tool slots, custom entries, and expansion redraws; exported assistant and interactive-mode classes provide the collapsed-thinking and operational-user layout boundaries, gated on the exact method's presence rather than a version number, while generic user, tool, and status filtering remains unavailable. |
+| Pi (verified on the installed 0.84.2) | Partially feasible with two API-probed exported-class adapters. | Public APIs control working visibility, collapsed labels, known tool slots, custom entries, and expansion redraws; exported assistant and interactive-mode classes provide the collapsed-thinking and operational-user layout boundaries, gated on the exact method's presence rather than a version number, while generic user, tool, and status filtering remains unavailable. |
 | Grok CLI 0.2.106 | Not feasible through the inspected supported project surface. | Project hooks expose lifecycle and tool interception, while the plugin CLI exposes no row-renderer contract; `--minimal` changes the whole screen mode rather than selected transcript rows. |
 
 These conclusions are deliberately limited to the named versions and supported surfaces.
@@ -269,7 +270,7 @@ The operational provider path covers Calm loaded on, loaded off, default prefere
 It asserts one persisted and rendered captain answer, exact user-role operational envelopes in order, no replacement custom messages, one processing result, zero operational transcript rows, and the two-row neighboring-assistant geometry for live, adjacent, and restart paths.
 Quoted current markers, ASCII-only labels, ordinary text before a marker, unrelated U+2063 placement, and image-bearing input remain visible in component and native transcript checks.
 `tests/fm-pi-primary-live-e2e.test.sh` also proves the working ship replaces the built-in `Working...` row while Calm is active on the credentialed provider path, and that it clears when the run settles, before continuing its ordinary watcher lifecycle.
-`tests/fm-pi-primary-types.test.sh` performs strict no-emit TypeScript checking against the installed Pi declarations, currently package version 0.81.1.
+`tests/fm-pi-primary-types.test.sh` performs strict no-emit TypeScript checking against the installed Pi declarations, currently package version 0.84.2.
 
 The relevant commands are:
 
@@ -500,3 +501,29 @@ FM_TEST_SUMMARY total=46 failed=0 skipped_gate=16 duration_ms=279390
 FM_TEST_SUMMARY_FAMILY family=live-harness-optin count=16 duration_ms=431 failed=0
 FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=30 duration_ms=277700 failed=0
 ```
+
+## 2026-08-16 Pi 0.84.2 installed-version verification
+
+The currently installed Pi is 0.84.2, and the Calm test suite passes against it, so the current compatibility baseline is the installed version rather than the earlier 0.81.1-0.82.0 evidence.
+The 0.84.1 export-confirmation fix and every earlier Calm guarantee hold on 0.84.2.
+
+```text
+$ pi --version
+0.84.2
+
+$ tests/fm-calm-pi-extension.test.sh
+ok - Pi calm resolves its persistent home independently of Pi's launch directory
+ok - Pi calm compatibility evidence never rejects a Pi version for being newer than 0.82.0, and still fails closed on a missing or malformed version
+ok - a missing collapsed-thinking presentation API degrades only that Calm adapter with a clear skip reason, while the rest of Calm still registers
+ok - missing Pi presentation class exports reach the independent adapter degradation path
+ok - Calm registers none of its 7 built-in tool wrappers at load while config/calm is off, and all 7 synchronously at load while config/calm is on
+ok - Calm's first same-session /calm activation claims every uncontested built-in, leaves a foreign bash tool fully intact and callable, warns prominently and logs the contested name, and only rows constructed before that activation - the documented bound - fail to retroactively collapse
+ok - Pi calm centralizes transcript visibility, preserves execution/export data, keeps Pi's stock working row visible while no run is active, and persists its choice across session starts
+ok - Pi calm on collapses mid-turn assistant working notes to zero height while Calm off keeps them, leaves streaming, truncated-final, and genuine final replies untouched, never mutates the messages, ignores every /calm argument, and restores a legacy persisted max as ordinary Calm on
+ok - Pi operational follow-up E2E processes exact user-role notifications once while Calm hides current and adjacent rows, Calm off and absent render them, and restart preserves semantics
+ok - Pi Calm native /skill:ahoy geometry keeps every collapsed thinking and tool block at zero height while preserving expansion, history, restart, and Calm-off rendering
+ok - Pi Calm working ship moves on a slow independent cadence over faster fixed-cell blue water, paints the complete boat standard yellow with balanced resets, keeps ANSI-stripped width exact, flips the directional sail on the exact bounce at both edges and every width, clamps visible and hidden resizes, falls back deterministically when narrow, freezes and resumes column/direction across settle/start without hidden-time jumps or duplicate timers, resets only on a fresh session, and installs and removes one scheduler-owning widget across starts, settle, abort, failure, shutdown, reload, replacement, and Calm toggles while leaving Calm-off visibility untouched
+ok - Pi calm native E2E replaces the stock working row with a moving, resize-clamped working ship that freezes and resumes across two working periods in one Pi session, clears on abort, keeps captain turns visible, hides exact operational user rows without changing persistence, restores stock rendering Calm-off, survives restart, and preserves export plus Ctrl+O behavior
+```
+
+The follow-up adjacent case intermittently fails a pane-capture timing race (`Pi follow-up adjacent case rendered a duplicate captain answer`) that is a pre-existing test-harness race, not a Calm behavior break; the suite passes when the run completes.

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -32,7 +32,9 @@ The exported classes used by the adapters (`AssistantMessageComponent` and `Inte
 ### Built-in tool override constraints
 
 [`calm.md`](calm.md#pi-compatibility) owns the current user-facing collision behavior and limitation.
-Inspection of Pi 0.80.10 and 0.82.0 established that extensions override a built-in tool by registering the same name, the first registered extension wins the complete `ToolDefinition` without merging, and Pi exposes no unregister operation.
+Inspection of Pi 0.80.10 and 0.82.0, recorded on 2026-08-04, established that extensions override a built-in tool by registering the same name, the first registered extension wins the complete `ToolDefinition` without merging, and Pi exposes no unregister operation.
+That inspection has not been redone on 0.84.2, so the Pi registration behavior described here is unverified there.
+0.84.2's new `defaultTools` setting selects which built-ins Pi starts with and was not tested against Calm; the [2026-08-16 verification record](#2026-08-16-pi-0842-installed-version-verification) owns that gap.
 Pi loads project-local extensions before global or CLI-configured extensions, so Firstmate's tracked Calm extension previously won those collisions even when its persisted preference was off.
 The losing definition's execution and render functions are both discarded, so unconditionally registering Calm's wrappers would replace another extension's same-named tool rather than changing presentation alone.
 

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -89,7 +89,7 @@ The single-thinking, tool-call-only, tool-result, Calm-off, and `clearOnShrink` 
 PR 927 made Calm persistent and described controlled rows as gapless while retaining a documented unsupported boundary for collapsed-thinking spacing.
 PR 936 removed the unsafe operational-input reroute and preserved legacy zero-height entries but did not change assistant-message layout.
 
-The fix installs one idempotent presentation adapter, verified on Pi 0.81.1 through 0.82.0, on the exported `AssistantMessageComponent.updateContent` method.
+The fix installs one idempotent presentation adapter on the exported `AssistantMessageComponent.updateContent` method, verified on Pi 0.81.1 on 2026-07-23 and on Pi 0.82.0 on 2026-07-26; no release between or after those two was tested for this adapter beyond what the dated entries below record.
 The adapter probes for that exact method and, per the [compatibility contract](calm.md#pi-compatibility), degrades independently with a diagnostic rather than gating on a version number.
 Only while Calm is active and Pi has collapsed thinking does the adapter pass a shallow thinking-free presentation copy into Pi's ordinary layout calculation, then retain the original message on the component for invalidation and thinking expansion.
 The persisted assistant message, provider context, tool execution, export data, and expansion history remain unchanged.
@@ -147,7 +147,7 @@ The real Pi viewport moved the unchanged assistant text from row 7 to row 2, ren
 The leading cause would have been falsified if the row or height remained, the provider lost or duplicated the message, or the persisted role or bytes changed.
 None occurred.
 
-The fix installs a separate idempotent presentation adapter, verified on Pi 0.81.1 through 0.82.0, on the exported `InteractiveMode.addMessageToChat` method.
+The fix installs a separate idempotent presentation adapter on the exported `InteractiveMode.addMessageToChat` method, verified on Pi 0.81.1 on 2026-07-23 and on Pi 0.82.0 on 2026-07-26; no release between or after those two was tested for this adapter beyond what the dated entries below record.
 The adapter probes for that exact method and, per the [compatibility contract](calm.md#pi-compatibility), degrades independently with a diagnostic rather than gating on a version number.
 It delegates current recognition to `bin/fm-operational-input.sh`, adds only the evidence-backed bare-U+2063 `Supervisor escalate (` presentation compatibility shape, mounts a `UserMessageComponent` subclass that preserves Pi's stock row plus leading spacer while Calm is off, and returns zero rendered lines while Calm is on.
 It never intercepts the input event, rewrites the message, changes its role, filters model context, or changes session data.

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -13,7 +13,9 @@ Changing persisted context to remove hidden content, filtering provider context,
 ## Compatibility evidence
 
 [`calm.md`](calm.md#pi-compatibility) owns the current Pi compatibility contract.
-The currently installed Pi is 0.84.2, and the Calm test suite passes against it (verified 2026-08-16), so the current baseline is the installed version rather than the earlier 0.81.1-0.82.0 evidence.
+The currently installed Pi is 0.84.2, and the Calm test suite completed a clean run against it on 2026-08-16, so the current baseline is the installed version rather than the earlier 0.81.1-0.82.0 evidence.
+That run is not a uniformly reproducible pass: the follow-up adjacent case intermittently fails a known test-harness race, recorded with its measurement and fix reference in the [2026-08-16 verification record](#2026-08-16-pi-0842-installed-version-verification).
+Every claim below states the version it was verified on, or says that it is unverified there.
 Pi 0.81.1 was installed when Calm was first built, and Pi 0.82.0 was the later reverification target.
 The inspected Pi CHANGELOG shows no relevant presentation API introduced at either version, so those versions remain verification evidence rather than compatibility bounds.
 The exported classes used by the adapters (`AssistantMessageComponent` and `InteractiveMode`) are undocumented internals with no stated version guarantee.
@@ -199,10 +201,10 @@ Serialized session data and Pi 0.81.1's sidebar tree also retain legacy hidden o
 
 ## Complete currently reachable Pi transcript taxonomy
 
-The taxonomy was derived from Pi 0.81.1's installed public declarations, documentation, examples, `interactive-mode.js`, and its exported component implementations.
+The taxonomy was derived from Pi 0.81.1's installed public declarations, documentation, examples, `interactive-mode.js`, and its exported component implementations; the class list itself has not been re-derived against 0.84.2, so the `Pi transcript path` column remains 0.81.1 evidence.
 The test fixture enumerates every class below through the centralized policy, and the interactive fixture exercises the screenshot classes, current user-role operational input, and legacy synthetic presentation entries.
 
-| Policy class | Pi transcript path | Calm result (baseline verified on the installed Pi 0.84.2; earlier 0.81.1-0.82.0 evidence retained as history) |
+| Policy class | Pi transcript path | Calm result (exercised by the fixture run recorded on 2026-08-16 against the installed Pi 0.84.2, with that record's intermittent failure included; earlier 0.81.1-0.82.0 evidence retained as history, and per-version evidence noted per row) |
 | --- | --- | --- |
 | `genuine-user-prompt` | `UserMessageComponent` | Visible, including every tested operational near miss. |
 | `genuine-agent-response` | Assistant text in `AssistantMessageComponent` | Visible. |
@@ -222,12 +224,12 @@ The test fixture enumerates every class below through the centralized policy, an
 | `system-notice` | `showStatus`, `showError`, compaction, retry, and startup warning rows | Unsupported boundary; remains visible. |
 | `cache-notice` | Non-persisted cache-miss `Text` row | Unsupported boundary; remains visible. |
 | `project-trust-warning` | Non-persisted startup `Text` row | Unsupported boundary; remains visible. |
-| `synthetic-user` | Firstmate extension `sendUserMessage`, terminal-injected input, Firstmate-generated Pi positional brief, or the already non-displayed session-start nudge | Canonically classified text-only operational user messages stay ordinary semantic user messages but render through the zero-height adapter (verified on Pi 0.81.1 through 0.82.0) under Calm; legacy entries stay gaplessly controllable, and the session-start nudge retains its existing non-displayed custom-message path. |
+| `synthetic-user` | Firstmate extension `sendUserMessage`, terminal-injected input, Firstmate-generated Pi positional brief, or the already non-displayed session-start nudge | Canonically classified text-only operational user messages stay ordinary semantic user messages but render through the zero-height adapter (verified on Pi 0.81.1 through 0.82.0, and re-exercised on 0.84.2 by the 2026-08-16 fixture run, whose follow-up adjacent case is the intermittently failing one recorded there) under Calm; legacy entries stay gaplessly controllable, and the session-start nudge retains its existing non-displayed custom-message path. |
 | `synthetic-assistant` | No authoritative Firstmate source found | Policy-hidden, but Pi exposes no generic assistant-role renderer. |
 | `unknown` | Future or unclassified transcript component | Policy-hidden, but no generic renderer exists; never claimed as covered. |
 
 The installed extension API has no supported global transcript filter, user-message renderer, assistant-message renderer, chat-container API, or generic custom-tool wrapper.
-Pi 0.81.1 through 0.82.0 export `AssistantMessageComponent` and `InteractiveMode`, so Calm uses separate idempotent, API-probed adapters for assistant thinking layout and the complete operational-user transcript row while leaving all message data and non-Calm rendering unchanged; see the [compatibility contract](calm.md#pi-compatibility) for how a future Pi lacking one of those exports is handled.
+Pi 0.81.1 through 0.82.0 and the installed 0.84.2 export `AssistantMessageComponent` and `InteractiveMode`, the latter re-inspected on 2026-08-16 in the installed package's `dist/index.d.ts` with both patched hooks still declared (`updateContent` in `assistant-message.d.ts`, `addMessageToChat` in `interactive-mode.d.ts`), so Calm uses separate idempotent, API-probed adapters for assistant thinking layout and the complete operational-user transcript row while leaving all message data and non-Calm rendering unchanged; see the [compatibility contract](calm.md#pi-compatibility) for how a future Pi lacking one of those exports is handled.
 General component replacement, ANSI cursor erasure, provider-context mutation, and installed-file patching remain rejected as unsupported or preservation-breaking workarounds.
 
 ## Cross-harness verification record
@@ -247,12 +249,15 @@ $ grok --version
 grok 0.2.106 (bde89716f679)
 ```
 
+Only Pi has been rechecked since that inspection: it was reverified on the installed 0.84.2 on 2026-08-16, recorded in the [2026-08-16 verification record](#2026-08-16-pi-0842-installed-version-verification).
+Claude Code, Codex CLI, OpenCode, and Grok CLI remain inspected only at the versions printed above and are unverified on any newer release.
+
 | Harness | Conclusion | Evidence |
 | --- | --- | --- |
 | Claude Code 2.1.218 | Not feasible through the inspected supported project surface. | Project hooks can observe lifecycle and tool events, while the plugin CLI packages supported components; neither inspected surface exposes a transcript-row renderer or transcript-wide redraw API. |
 | Codex CLI 0.144.6 | Not feasible through the inspected supported project surface. | The tracked hooks expose session, pre-tool, and stop handling, while the plugin and feature inventories expose no TUI tool-row renderer or transcript redraw control. |
 | OpenCode 1.17.18 | Not feasible without violating the preservation boundary. | Plugins expose events and tool execution hooks, not a built-in transcript-row renderer; same-name tool replacement changes execution rather than presentation alone. |
-| Pi (verified on the installed 0.84.2) | Partially feasible with two API-probed exported-class adapters. | Public APIs control working visibility, collapsed labels, known tool slots, custom entries, and expansion redraws; exported assistant and interactive-mode classes provide the collapsed-thinking and operational-user layout boundaries, gated on the exact method's presence rather than a version number, while generic user, tool, and status filtering remains unavailable. |
+| Pi (verified on the installed 0.84.2 on 2026-08-16; 0.81.1 through 0.82.0 retained as history) | Partially feasible with two API-probed exported-class adapters. | Public APIs control working visibility, collapsed labels, known tool slots, custom entries, and expansion redraws; exported assistant and interactive-mode classes provide the collapsed-thinking and operational-user layout boundaries, gated on the exact method's presence rather than a version number, while generic user, tool, and status filtering remains unavailable. |
 | Grok CLI 0.2.106 | Not feasible through the inspected supported project surface. | Project hooks expose lifecycle and tool interception, while the plugin CLI exposes no row-renderer contract; `--minimal` changes the whole screen mode rather than selected transcript rows. |
 
 These conclusions are deliberately limited to the named versions and supported surfaces.
@@ -270,7 +275,8 @@ The operational provider path covers Calm loaded on, loaded off, default prefere
 It asserts one persisted and rendered captain answer, exact user-role operational envelopes in order, no replacement custom messages, one processing result, zero operational transcript rows, and the two-row neighboring-assistant geometry for live, adjacent, and restart paths.
 Quoted current markers, ASCII-only labels, ordinary text before a marker, unrelated U+2063 placement, and image-bearing input remain visible in component and native transcript checks.
 `tests/fm-pi-primary-live-e2e.test.sh` also proves the working ship replaces the built-in `Working...` row while Calm is active on the credentialed provider path, and that it clears when the run settles, before continuing its ordinary watcher lifecycle.
-`tests/fm-pi-primary-types.test.sh` performs strict no-emit TypeScript checking against the installed Pi declarations, currently package version 0.84.2.
+`tests/fm-pi-primary-types.test.sh` performs strict no-emit TypeScript checking against the installed Pi declarations, currently package version 0.84.2 as read from the installed package manifest on 2026-08-16.
+That package version is independent of the `pi` binary version: the last recorded run of this test typechecked against Pi 0.80.10 on 2026-08-15, and the typecheck has not been rerun since, so it is unverified against 0.84.2.
 
 The relevant commands are:
 
@@ -505,11 +511,18 @@ FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=30 duration_ms=277700 fai
 ## 2026-08-16 Pi 0.84.2 installed-version verification
 
 The currently installed Pi is 0.84.2, and the Calm test suite passes against it, so the current compatibility baseline is the installed version rather than the earlier 0.81.1-0.82.0 evidence.
-The 0.84.1 export-confirmation fix and every earlier Calm guarantee hold on 0.84.2.
+This run exercises the 0.84.1 export-confirmation fix and the Calm guarantees the suite covers; it does not establish that every earlier Calm guarantee holds on 0.84.2.
+Two 0.84.2 changes fall outside what the suite exercises and are therefore unverified against Calm: the new `defaultTools` setting, which selects the initial built-in tool set globally or per project while Calm still registers all seven built-in wrappers unconditionally at load (see [Built-in tool override constraints](#built-in-tool-override-constraints)), and the changed fallback rendering for extension tool results, which now collapses long output and honors tool expansion.
 
 ```text
 $ pi --version
 0.84.2
+
+$ jq -r .version "$(npm root -g)/@earendil-works/pi-coding-agent/package.json"
+0.84.2
+
+$ tests/fm-pi-primary-types.test.sh
+skip: tsc not found for Pi extension typecheck
 
 $ tests/fm-calm-pi-extension.test.sh
 ok - Pi calm resolves its persistent home independently of Pi's launch directory
@@ -526,4 +539,6 @@ ok - Pi Calm working ship moves on a slow independent cadence over faster fixed-
 ok - Pi calm native E2E replaces the stock working row with a moving, resize-clamped working ship that freezes and resumes across two working periods in one Pi session, clears on abort, keeps captain turns visible, hides exact operational user rows without changing persistence, restores stock rendering Calm-off, survives restart, and preserves export plus Ctrl+O behavior
 ```
 
-The follow-up adjacent case intermittently fails a pane-capture timing race (`Pi follow-up adjacent case rendered a duplicate captain answer`) that is a pre-existing test-harness race, not a Calm behavior break; the suite passes when the run completes.
+The follow-up adjacent case intermittently fails a pane-capture timing race (`Pi follow-up adjacent case rendered a duplicate captain answer`), so the run above is a clean run rather than a uniformly reproducible pass.
+That race was measured on 2026-08-16 at 9 failures in 24 executions, at the same rate under both interpreters, and diagnosed there as a test-harness race rather than a Calm behavior break, then fixed in PR #2477 (branch `fm/fm-calm-bash5-regression`, head `adce327`).
+That fix is not in this branch's history, so the failure remains reachable here; the diagnosis rests on that measurement and is unverified from this branch alone.

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -16,10 +16,13 @@ Changing persisted context to remove hidden content, filtering provider context,
 
 [`calm.md`](calm.md#pi-compatibility) owns the current Pi compatibility contract.
 The Pi installed on 2026-08-16 is 0.84.2.
-Two things were observed against it that day and nothing else: one clean run of `tests/fm-calm-pi-extension.test.sh`, and a declarations recheck of the two exported classes the adapters patch, both in the [2026-08-16 verification record](#2026-08-16-pi-0842-installed-version-verification).
+What was observed against it that day is what the [2026-08-16 verification record](#2026-08-16-pi-0842-installed-version-verification) shows and nothing more: the `pi` and installed-package versions, one clean run of `tests/fm-calm-pi-extension.test.sh`, a declarations recheck of the two exported classes the adapters patch, and a typecheck run that produced no typecheck because `tsc` was absent.
 That run is not a uniformly reproducible pass: the follow-up adjacent case intermittently fails a known test-harness race, measured and referenced in the same entry.
 No survey in this document has been redone on 0.84.2.
-The API surveys, the transcript taxonomy, and the cross-harness inspection date from Pi 0.81.1 on 2026-07-22 and Pi 0.82.0 on 2026-07-30, and the sections below repeat that where it matters.
+The extension-API survey and the transcript taxonomy were made against Pi 0.81.1 on 2026-07-22.
+The cross-harness inspection was made on 2026-07-22, with its Pi row reverified at 0.81.1 on 2026-07-23.
+The working-presentation observations were made against the Pi 0.82.0 CLI on 2026-07-30.
+Each section below repeats its own date and version.
 Pi 0.81.1 was installed when Calm was first built, and Pi 0.82.0 was the later reverification target.
 The Pi CHANGELOG read at those two versions showed no relevant presentation API introduced at either, so they were recorded as verification evidence rather than compatibility bounds.
 That reading was not repeated release by release afterwards; the later CHANGELOG entries that did touch Calm were found when they broke or changed it and are written up in the dated entries below.
@@ -157,6 +160,9 @@ The current exact marker and the narrow bare-U+2063 `Supervisor escalate (` comp
 
 ## Calm working presentation
 
+The Pi behaviors this section relies on - the documented custom working-indicator frames, the `agent_settled` emission point, widget disposal under a repeated key, and the above-editor spacer row - were observed against the Pi 0.82.0 CLI on 2026-07-30, recorded in the [2026-07-30 revision verification](#2026-07-30-calm-working-presentation-revision-verification).
+They have not been re-observed on 0.83.x or 0.84.2 and are unverified there; everything else below describes Calm's own implementation.
+
 Calm replaces Pi's stock working row with a small animated boat while Calm is on and one logical agent run is active.
 This path uses only public extension API and patches nothing: `ExtensionUIContext.setWorkingVisible(false)` hides the stock row, and `setWidget()` installs a temporary component factory above the editor.
 Pi's documented custom working-indicator frames are static and width-blind, so they cannot own responsive geometry; a widget component receives `render(width)` and can.
@@ -207,11 +213,11 @@ Serialized session data and Pi 0.81.1's sidebar tree also retain legacy hidden o
 ## Pi transcript taxonomy surveyed on Pi 0.81.1
 
 Surveyed on 2026-07-22 against Pi 0.81.1's installed public declarations, documentation, examples, `interactive-mode.js`, and its exported component implementations.
-That survey has not been redone on 0.82.0 or 0.84.2, so the class list, the transcript-path column, and every `unsupported boundary` conclusion below are 0.81.1 observations and are unverified on later Pi releases.
+That survey has not been redone on 0.82.0 or 0.84.2, so its transcript paths and every `unsupported boundary` conclusion are 0.81.1 observations and are unverified on later Pi releases.
+Two rows postdate it and carry their own dates instead: the Calm working-ship widget named in `working-status` was added on 2026-07-30 against the Pi 0.82.0 CLI, and the whole `assistant-working-note` row, transcript path included, was added on 2026-08-13 with its zero-height result observed on Pi 0.84.1.
 What the fixtures exercise against whichever Pi is installed is narrower than the table: `tests/fm-calm-pi-extension.test.sh` walks `CALM_TRANSCRIPT_CLASSES` and asserts only the visible-or-hidden policy classification, while the interactive fixture renders the screenshot classes, current user-role operational input, and legacy synthetic presentation entries.
-Rows carrying their own version note were observed on that version; the rest carry the 0.81.1 survey date above.
 
-| Policy class | Pi transcript path (Pi 0.81.1 survey, 2026-07-22) | Calm result |
+| Policy class | Pi transcript path | Calm result |
 | --- | --- | --- |
 | `genuine-user-prompt` | `UserMessageComponent` | Visible, including every tested operational near miss. |
 | `genuine-agent-response` | Assistant text in `AssistantMessageComponent` | Visible. |
@@ -286,7 +292,8 @@ It asserts one persisted and rendered captain answer, exact user-role operationa
 Quoted current markers, ASCII-only labels, ordinary text before a marker, unrelated U+2063 placement, and image-bearing input remain visible in component and native transcript checks.
 `tests/fm-pi-primary-live-e2e.test.sh` also proves the working ship replaces the built-in `Working...` row while Calm is active on the credentialed provider path, and that it clears when the run settles, before continuing its ordinary watcher lifecycle.
 `tests/fm-pi-primary-types.test.sh` performs strict no-emit TypeScript checking against the installed Pi declarations, currently package version 0.84.2 as read from the installed package manifest on 2026-08-16.
-That package version is independent of the `pi` binary version: the last recorded run of this test typechecked against Pi 0.80.10 on 2026-08-15, and the typecheck has not been rerun since, so it is unverified against 0.84.2.
+That package version is independent of the `pi` binary version: the last recorded typecheck ran against Pi 0.80.10 on 2026-08-15.
+The test was rerun on 2026-08-16 but performed no typecheck, because `tsc` was absent from that machine and the script skips with `skip: tsc not found for Pi extension typecheck`, so the declarations are unverified against 0.84.2.
 
 The relevant commands are:
 
@@ -523,7 +530,9 @@ FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=30 duration_ms=277700 fai
 Observed on 2026-08-16: the installed Pi is 0.84.2, `tests/fm-calm-pi-extension.test.sh` completed one clean run against it, and the two exported classes the adapters patch are still declared with their patched hooks.
 That is what this entry records.
 The run exercises the 0.84.1 export-confirmation fix and the guarantees the suite covers, and nothing beyond them.
-Two 0.84.2 changes fall outside what the suite exercises and were not tested against Calm: the new `defaultTools` setting, which selects the initial built-in tool set globally or per project, while Calm registers its seven built-in wrappers synchronously at load only when the persisted preference is already on and none while Calm is off (see [Built-in tool override constraints](#built-in-tool-override-constraints)); and the changed fallback rendering for extension tool results, which now collapses long output and honors tool expansion.
+Several 0.84.2 changes fall outside what the suite exercises and were not tested against Calm.
+Reading the 0.84.2 CHANGELOG surfaced three that touch Calm's surface: the new `defaultTools` setting, which selects the initial built-in tool set globally or per project, while Calm registers its seven built-in wrappers synchronously at load only when the persisted preference is already on and none while Calm is off (see [Built-in tool override constraints](#built-in-tool-override-constraints)); the changed fallback rendering for extension tool results, which now collapses long output and honors tool expansion; and the experimental strict JSON-schema constrained sampling for the default `read`, `bash`, `edit`, and `write` tools under `PI_EXPERIMENTAL=1`, which covers four of the seven built-ins Calm re-registers under the same names.
+That is what one CHANGELOG reading found, not an exhaustive audit of the release.
 
 ```text
 $ pi --version
@@ -561,5 +570,6 @@ ok - Pi calm native E2E replaces the stock working row with a moving, resize-cla
 ```
 
 The follow-up adjacent case intermittently fails a pane-capture timing race (`Pi follow-up adjacent case rendered a duplicate captain answer`), so the run above is a clean run rather than a uniformly reproducible pass.
-That race was measured on 2026-08-16 at 9 failures in 24 executions, at the same rate under both interpreters, and diagnosed there as a test-harness race rather than a Calm behavior break, then fixed in PR #2477 (branch `fm/fm-calm-bash5-regression`, head `adce327`).
-That fix is not in this branch's history, so the failure remains reachable here; the diagnosis rests on that measurement and is unverified from this branch alone.
+That race was measured on 2026-08-16 at 9 failures in 24 executions, at the same rate under both interpreters, and diagnosed there as a test-harness race rather than a Calm behavior break.
+A fix for it was written the same day in PR #2477 (branch `fm/fm-calm-bash5-regression`, head `adce327`), which was still open and unmerged on 2026-08-16.
+That fix is therefore in no branch of this repository, `main` included: the failure is reachable wherever this suite runs today, and the diagnosis rests on that measurement rather than on anything in the code this document describes.

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -1,6 +1,8 @@
 # Calm-mode harness feasibility
 
-This document owns the version-scoped feasibility evidence, Pi transcript taxonomy, and supported-API boundaries for Firstmate calm mode.
+This document is a dated journal of Calm-mode observations: harness surveys, the Pi transcript taxonomy, and supported-API boundaries for Firstmate calm mode.
+Each entry records when an observation was made, which harness version it was made against, and what was actually seen.
+An observation is not carried to a version it was not made on; where a survey has not been redone, the gap is stated instead of filled by deduction.
 [`calm.md`](calm.md) owns the current user-facing `/calm` usage and limitation contract.
 
 ## Required extension surface
@@ -13,11 +15,14 @@ Changing persisted context to remove hidden content, filtering provider context,
 ## Compatibility evidence
 
 [`calm.md`](calm.md#pi-compatibility) owns the current Pi compatibility contract.
-The currently installed Pi is 0.84.2, and the Calm test suite completed a clean run against it on 2026-08-16, so the current baseline is the installed version rather than the earlier 0.81.1-0.82.0 evidence.
-That run is not a uniformly reproducible pass: the follow-up adjacent case intermittently fails a known test-harness race, recorded with its measurement and fix reference in the [2026-08-16 verification record](#2026-08-16-pi-0842-installed-version-verification).
-Every claim below states the version it was verified on, or says that it is unverified there.
+The Pi installed on 2026-08-16 is 0.84.2.
+Two things were observed against it that day and nothing else: one clean run of `tests/fm-calm-pi-extension.test.sh`, and a declarations recheck of the two exported classes the adapters patch, both in the [2026-08-16 verification record](#2026-08-16-pi-0842-installed-version-verification).
+That run is not a uniformly reproducible pass: the follow-up adjacent case intermittently fails a known test-harness race, measured and referenced in the same entry.
+No survey in this document has been redone on 0.84.2.
+The API surveys, the transcript taxonomy, and the cross-harness inspection date from Pi 0.81.1 on 2026-07-22 and Pi 0.82.0 on 2026-07-30, and the sections below repeat that where it matters.
 Pi 0.81.1 was installed when Calm was first built, and Pi 0.82.0 was the later reverification target.
-The inspected Pi CHANGELOG shows no relevant presentation API introduced at either version, so those versions remain verification evidence rather than compatibility bounds.
+The Pi CHANGELOG read at those two versions showed no relevant presentation API introduced at either, so they were recorded as verification evidence rather than compatibility bounds.
+That reading was not repeated release by release afterwards; the later CHANGELOG entries that did touch Calm were found when they broke or changed it and are written up in the dated entries below.
 The exported classes used by the adapters (`AssistantMessageComponent` and `InteractiveMode`) are undocumented internals with no stated version guarantee.
 `tests/fm-calm-pi-extension.test.sh` records the installed Pi version as evidence without gating on it and covers both newer synthetic versions and an unavailable adapter seam.
 
@@ -199,12 +204,14 @@ Returning from stock export rendering instead invalidates only the tool rows Cal
 Exported and shared HTML retain genuine user prompts, genuine assistant responses, current operational user messages, ordinary tool rendering, and the complete session artifact.
 Serialized session data and Pi 0.81.1's sidebar tree also retain legacy hidden operational custom messages.
 
-## Complete currently reachable Pi transcript taxonomy
+## Pi transcript taxonomy surveyed on Pi 0.81.1
 
-The taxonomy was derived from Pi 0.81.1's installed public declarations, documentation, examples, `interactive-mode.js`, and its exported component implementations; the class list itself has not been re-derived against 0.84.2, so the `Pi transcript path` column remains 0.81.1 evidence.
-The test fixture enumerates every class below through the centralized policy, and the interactive fixture exercises the screenshot classes, current user-role operational input, and legacy synthetic presentation entries.
+Surveyed on 2026-07-22 against Pi 0.81.1's installed public declarations, documentation, examples, `interactive-mode.js`, and its exported component implementations.
+That survey has not been redone on 0.82.0 or 0.84.2, so the class list, the transcript-path column, and every `unsupported boundary` conclusion below are 0.81.1 observations and are unverified on later Pi releases.
+What the fixtures exercise against whichever Pi is installed is narrower than the table: `tests/fm-calm-pi-extension.test.sh` walks `CALM_TRANSCRIPT_CLASSES` and asserts only the visible-or-hidden policy classification, while the interactive fixture renders the screenshot classes, current user-role operational input, and legacy synthetic presentation entries.
+Rows carrying their own version note were observed on that version; the rest carry the 0.81.1 survey date above.
 
-| Policy class | Pi transcript path | Calm result (exercised by the fixture run recorded on 2026-08-16 against the installed Pi 0.84.2, with that record's intermittent failure included; earlier 0.81.1-0.82.0 evidence retained as history, and per-version evidence noted per row) |
+| Policy class | Pi transcript path (Pi 0.81.1 survey, 2026-07-22) | Calm result |
 | --- | --- | --- |
 | `genuine-user-prompt` | `UserMessageComponent` | Visible, including every tested operational near miss. |
 | `genuine-agent-response` | Assistant text in `AssistantMessageComponent` | Visible. |
@@ -224,12 +231,14 @@ The test fixture enumerates every class below through the centralized policy, an
 | `system-notice` | `showStatus`, `showError`, compaction, retry, and startup warning rows | Unsupported boundary; remains visible. |
 | `cache-notice` | Non-persisted cache-miss `Text` row | Unsupported boundary; remains visible. |
 | `project-trust-warning` | Non-persisted startup `Text` row | Unsupported boundary; remains visible. |
-| `synthetic-user` | Firstmate extension `sendUserMessage`, terminal-injected input, Firstmate-generated Pi positional brief, or the already non-displayed session-start nudge | Canonically classified text-only operational user messages stay ordinary semantic user messages but render through the zero-height adapter (verified on Pi 0.81.1 through 0.82.0, and re-exercised on 0.84.2 by the 2026-08-16 fixture run, whose follow-up adjacent case is the intermittently failing one recorded there) under Calm; legacy entries stay gaplessly controllable, and the session-start nudge retains its existing non-displayed custom-message path. |
+| `synthetic-user` | Firstmate extension `sendUserMessage`, terminal-injected input, Firstmate-generated Pi positional brief, or the already non-displayed session-start nudge | Canonically classified text-only operational user messages stay ordinary semantic user messages but render through the zero-height adapter (observed on Pi 0.81.1 and on 0.82.0; re-exercised on the installed 0.84.2 by the 2026-08-16 run, whose follow-up adjacent case is the intermittently failing one recorded there) under Calm; legacy entries stay gaplessly controllable, and the session-start nudge retains its existing non-displayed custom-message path. |
 | `synthetic-assistant` | No authoritative Firstmate source found | Policy-hidden, but Pi exposes no generic assistant-role renderer. |
 | `unknown` | Future or unclassified transcript component | Policy-hidden, but no generic renderer exists; never claimed as covered. |
 
-The installed extension API has no supported global transcript filter, user-message renderer, assistant-message renderer, chat-container API, or generic custom-tool wrapper.
-Pi 0.81.1 through 0.82.0 and the installed 0.84.2 export `AssistantMessageComponent` and `InteractiveMode`, the latter re-inspected on 2026-08-16 in the installed package's `dist/index.d.ts` with both patched hooks still declared (`updateContent` in `assistant-message.d.ts`, `addMessageToChat` in `interactive-mode.d.ts`), so Calm uses separate idempotent, API-probed adapters for assistant thinking layout and the complete operational-user transcript row while leaving all message data and non-Calm rendering unchanged; see the [compatibility contract](calm.md#pi-compatibility) for how a future Pi lacking one of those exports is handled.
+The Pi 0.81.1 API survey found no supported global transcript filter, user-message renderer, assistant-message renderer, chat-container API, or generic custom-tool wrapper.
+That survey has not been redone since, and the extension API did move afterwards - 0.84.2 adds an `expandPromptTemplates` option to `pi.sendUserMessage()` and a `defaultTools` setting - so the negative finding is unverified on 0.84.2.
+`AssistantMessageComponent` and `InteractiveMode` were observed exported on Pi 0.81.1, on 0.82.0, and again on the installed 0.84.2 on 2026-08-16, where both patched hooks are still declared (`updateContent` in `assistant-message.d.ts`, `addMessageToChat` in `interactive-mode.d.ts`); that recheck read the declarations only and exercised nothing else.
+Calm uses separate idempotent, API-probed adapters for assistant thinking layout and the complete operational-user transcript row while leaving all message data and non-Calm rendering unchanged; see the [compatibility contract](calm.md#pi-compatibility) for how a future Pi lacking one of those exports is handled.
 General component replacement, ANSI cursor erasure, provider-context mutation, and installed-file patching remain rejected as unsupported or preservation-breaking workarounds.
 
 ## Cross-harness verification record
@@ -249,15 +258,16 @@ $ grok --version
 grok 0.2.106 (bde89716f679)
 ```
 
-Only Pi has been rechecked since that inspection: it was reverified on the installed 0.84.2 on 2026-08-16, recorded in the [2026-08-16 verification record](#2026-08-16-pi-0842-installed-version-verification).
-Claude Code, Codex CLI, OpenCode, and Grok CLI remain inspected only at the versions printed above and are unverified on any newer release.
+Only Pi has been looked at since: on 2026-08-16 the Calm adapters were re-exercised end to end against the installed 0.84.2, recorded in the [2026-08-16 verification record](#2026-08-16-pi-0842-installed-version-verification).
+The harness API survey behind the conclusions below was not redone on that version.
+Claude Code, Codex CLI, OpenCode, and Grok CLI have not been reinspected since 2026-07-22 and are unverified on any later release.
 
 | Harness | Conclusion | Evidence |
 | --- | --- | --- |
 | Claude Code 2.1.218 | Not feasible through the inspected supported project surface. | Project hooks can observe lifecycle and tool events, while the plugin CLI packages supported components; neither inspected surface exposes a transcript-row renderer or transcript-wide redraw API. |
 | Codex CLI 0.144.6 | Not feasible through the inspected supported project surface. | The tracked hooks expose session, pre-tool, and stop handling, while the plugin and feature inventories expose no TUI tool-row renderer or transcript redraw control. |
 | OpenCode 1.17.18 | Not feasible without violating the preservation boundary. | Plugins expose events and tool execution hooks, not a built-in transcript-row renderer; same-name tool replacement changes execution rather than presentation alone. |
-| Pi (verified on the installed 0.84.2 on 2026-08-16; 0.81.1 through 0.82.0 retained as history) | Partially feasible with two API-probed exported-class adapters. | Public APIs control working visibility, collapsed labels, known tool slots, custom entries, and expansion redraws; exported assistant and interactive-mode classes provide the collapsed-thinking and operational-user layout boundaries, gated on the exact method's presence rather than a version number, while generic user, tool, and status filtering remains unavailable. |
+| Pi 0.81.1 | Partially feasible with two API-probed exported-class adapters. | Surveyed 2026-07-22 and reverified at 0.81.1 on 2026-07-23: public APIs control working visibility, collapsed labels, known tool slots, custom entries, and expansion redraws; exported assistant and interactive-mode classes provide the collapsed-thinking and operational-user layout boundaries, gated on the exact method's presence rather than a version number, while generic user, tool, and status filtering remains unavailable. The adapter path was re-exercised end to end against the installed 0.84.2 on 2026-08-16; this row's API survey was not redone there. |
 | Grok CLI 0.2.106 | Not feasible through the inspected supported project surface. | Project hooks expose lifecycle and tool interception, while the plugin CLI exposes no row-renderer contract; `--minimal` changes the whole screen mode rather than selected transcript rows. |
 
 These conclusions are deliberately limited to the named versions and supported surfaces.
@@ -510,9 +520,10 @@ FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=30 duration_ms=277700 fai
 
 ## 2026-08-16 Pi 0.84.2 installed-version verification
 
-The currently installed Pi is 0.84.2, and the Calm test suite passes against it, so the current compatibility baseline is the installed version rather than the earlier 0.81.1-0.82.0 evidence.
-This run exercises the 0.84.1 export-confirmation fix and the Calm guarantees the suite covers; it does not establish that every earlier Calm guarantee holds on 0.84.2.
-Two 0.84.2 changes fall outside what the suite exercises and are therefore unverified against Calm: the new `defaultTools` setting, which selects the initial built-in tool set globally or per project while Calm still registers all seven built-in wrappers unconditionally at load (see [Built-in tool override constraints](#built-in-tool-override-constraints)), and the changed fallback rendering for extension tool results, which now collapses long output and honors tool expansion.
+Observed on 2026-08-16: the installed Pi is 0.84.2, `tests/fm-calm-pi-extension.test.sh` completed one clean run against it, and the two exported classes the adapters patch are still declared with their patched hooks.
+That is what this entry records.
+The run exercises the 0.84.1 export-confirmation fix and the guarantees the suite covers, and nothing beyond them.
+Two 0.84.2 changes fall outside what the suite exercises and were not tested against Calm: the new `defaultTools` setting, which selects the initial built-in tool set globally or per project, while Calm registers its seven built-in wrappers synchronously at load only when the persisted preference is already on and none while Calm is off (see [Built-in tool override constraints](#built-in-tool-override-constraints)); and the changed fallback rendering for extension tool results, which now collapses long output and honors tool expansion.
 
 ```text
 $ pi --version
@@ -520,6 +531,16 @@ $ pi --version
 
 $ jq -r .version "$(npm root -g)/@earendil-works/pi-coding-agent/package.json"
 0.84.2
+
+$ cd "$(npm root -g)/@earendil-works/pi-coding-agent"
+
+$ grep -oE 'AssistantMessageComponent|InteractiveMode' dist/index.d.ts | sort -u
+AssistantMessageComponent
+InteractiveMode
+
+$ grep -oE 'updateContent|addMessageToChat' dist/modes/interactive/components/assistant-message.d.ts dist/modes/interactive/interactive-mode.d.ts | sort -u
+dist/modes/interactive/components/assistant-message.d.ts:updateContent
+dist/modes/interactive/interactive-mode.d.ts:addMessageToChat
 
 $ tests/fm-pi-primary-types.test.sh
 skip: tsc not found for Pi extension typecheck

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -17,7 +17,8 @@ PI_OPERATIONAL_INPUT="$ROOT/.pi/extensions/lib/fm-operational-input.ts"
 PI_PACKAGE_DIR=${FM_PI_PACKAGE_DIR:-"$(npm root -g 2>/dev/null)/@earendil-works/pi-coding-agent"}
 TMUX_SOCKET="fm-calm-$$"
 TMUX_SESSION="fm-calm-e2e"
-# Verified against Pi 0.81.1 and 0.82.0 (docs/calm-mode-feasibility.md). This is
+# Current recorded evidence is the installed Pi 0.84.2, with 0.81.1 and 0.82.0 retained
+# as history (docs/calm-mode-feasibility.md). This is
 # known-good evidence, not a support ceiling: the fixtures below run against whatever
 # Pi is actually installed, and record_pi_version_evidence never rejects a newer
 # version. The tracked presentation adapters probe the exact API they patch (see


### PR DESCRIPTION
## Intent

Update docs/calm-mode-feasibility.md so it no longer asserts a Pi compatibility baseline (verified on Pi 0.81.1 through 0.82.0) that is contradicted by its own more recent sections and by the actually-installed Pi 0.84.2. The document must describe the behavior of the installed version and say so explicitly, mark each compatibility claim as verified or unverified, and must not widen the announced version range without proof. The installed Pi is 0.84.2 and the Calm test suite passes against it; the earlier 0.81.1-0.82.0 evidence is retained as history.

## What Changed

- Restructured `docs/calm-mode-feasibility.md` from a version-range baseline into a dated journal: the intro now states the installed Pi is 0.84.2, each survey carries its own observation date and Pi version, and the former "verified on Pi 0.81.1 through 0.82.0" claims on both presentation adapters, the transcript taxonomy table, and the cross-harness Pi row are narrowed to the individual dated observations that back them.
- Marked the claims that were never rechecked on 0.84.2 as unverified - the extension-API negative findings, the built-in tool override inspection, the working-presentation observations, and the transcript taxonomy - and noted the 0.84.2 API movement (`defaultTools`, `expandPromptTemplates`) plus the Pi package version now read as 0.84.2 by `tests/fm-pi-primary-types.test.sh` while its last real typecheck ran against 0.80.10.
- Added a "2026-08-16 Pi 0.84.2 installed-version verification" section recording the version commands, the exported-class declarations recheck, the skipped `tsc` typecheck, one clean `tests/fm-calm-pi-extension.test.sh` run, and the intermittent follow-up-adjacent pane-capture race (9/24) whose fix sits in unmerged PR #2477; the header comment in `tests/fm-calm-pi-extension.test.sh` now names 0.84.2 as current evidence with 0.81.1/0.82.0 retained as history.

## Risk Assessment

✅ Low: Changement purement documentaire (la seule modification hors documentation est un commentaire dans un test, sans effet exécutable) : le critère nommé par l'intent est vérifiablement satisfait, plus aucune plage de compatibilité n'est annoncée, et toutes les affirmations factuelles contrôlables - version Pi installée, entrées du CHANGELOG 0.84.2, logique d'enregistrement des sept outils, dates de vérification des deux adaptateurs, état de la PR #2477, mesure 9/24, ancres internes - se vérifient contre les sources ; il ne reste que deux imprécisions de provenance de niveau info.

## Testing

J'ai validé le document comme surface lue par un relecteur et comme registre de preuves reproductibles. Les commandes que la nouvelle section 2026-08-16 enregistre ont été rejouées sur cette machine : Pi binaire et paquet en 0.84.2, déclarations des deux classes exportées présentes (confirmées en plus par une sonde runtime des méthodes patchées), typecheck sauté faute de `tsc`, et suite `tests/fm-calm-pi-extension.test.sh` dont les 12 lignes `ok -` sont strictement identiques au transcript publié. Les affirmations 0.84.2 du document ont été recoupées avec le CHANGELOG du paquet installé, l'absence de plage élargie vérifiée sur tout le dépôt, et les 11 liens internes validés par un parsing sémantique des titres selon les règles de slug GitHub, le renommage de titre ne cassant aucune référence externe. Les rendus HTML avant/après et leurs captures montrent la bascule de « Pi (verified 0.81.1 through 0.82.0) » vers des observations datées et explicitement marquées vérifiées ou non. Sur 4 exécutions de la suite, une a échoué sur la course de capture de pane déjà documentée, mais sur le cas `loaded_off` et non sur le cas `adjacent` nommé par le document ; ce défaut est préexistant et son correctif vit dans une PR non fusionnée. Arbre de travail laissé propre.

- Evidence: [AVANT (base ef35d79) - la ligne cross-harness affirme « Pi (verified 0.81.1 through 0.82.0) »](https://github.com/Kallas95/firstmate/blob/e087938d2d91170c721032b8f008b832401d3634/.no-mistakes/evidence/fm/fm-calm-doc-pi-versions/03-before-crossharness-pi-row.png)
- Evidence: [APRÈS - section Compatibility evidence : version installée annoncée (0.84.2) et absence de survey redone marquée non vérifiée](https://github.com/Kallas95/firstmate/blob/e087938d2d91170c721032b8f008b832401d3634/.no-mistakes/evidence/fm/fm-calm-doc-pi-versions/04-after-compatibility-evidence.png)
- Evidence: [APRÈS - la ligne cross-harness redevient « Pi 0.81.1 » avec ses dates et le rappel que le survey d&#39;API n&#39;a pas été refait sur 0.84.2](https://github.com/Kallas95/firstmate/blob/e087938d2d91170c721032b8f008b832401d3634/.no-mistakes/evidence/fm/fm-calm-doc-pi-versions/05-after-crossharness-pi-row.png)
- Evidence: [AVANT/APRÈS - en-tête de la taxonomie : plage « baseline verified on Pi 0.81.1 through 0.82.0 » remplacée par une portée datée sur 0.81.1](https://github.com/Kallas95/firstmate/blob/e087938d2d91170c721032b8f008b832401d3634/.no-mistakes/evidence/fm/fm-calm-doc-pi-versions/06-after-taxonomy-scoped-header.png)
- Evidence: [APRÈS - clic réel sur la nouvelle référence « 2026-08-16 verification record » : la navigation atterrit sur la section ajoutée](https://github.com/Kallas95/firstmate/blob/e087938d2d91170c721032b8f008b832401d3634/.no-mistakes/evidence/fm/fm-calm-doc-pi-versions/07-after-anchor-jump-2026-08-16-record.png)
<details>
<summary>Evidence: Rendus HTML du document (base et cible), ouvrables directement</summary>

Source: [Rendus HTML du document (base et cible), ouvrables directement](https://github.com/Kallas95/firstmate/blob/e087938d2d91170c721032b8f008b832401d3634/.no-mistakes/evidence/fm/fm-calm-doc-pi-versions/doc-after-change.html)

```text
<!doctype html>
<html lang="en"><head><meta charset="utf-8">
<title>AFTER (0692b6b)</title>
<script src="marked.min.js"></script>
<style>
  :root { color-scheme: light; }
  body { margin:0; background:#f6f8fa; font: 16px/1.6 -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; color:#1f2328; }
  .bar { position:sticky; top:0; background:#24292f; color:#fff; padding:10px 24px; font-size:14px; display:flex; gap:12px; align-items:center; z-index:5; }
  .bar .badge { background:#1a7f37; color:#fff; border-radius:12px; padding:2px 10px; font-weight:600; font-size:12px; letter-spacing:.03em; }
  .bar code { color:#c9d1d9; }
  main { max-width:1000px; margin:24px auto 80px; background:#fff; border:1px solid #d0d7de; border-radius:6px; padding:32px 40px; }
  h1,h2,h3 { border-bottom:1px solid #d8dee4; padding-bottom:.3em; margin-top:1.6em; scroll-margin-top:60px; }
  h1 { font-size:2em } h2 { font-size:1.5em } h3 { font-size:1.2em; border:0 }
  table { border-collapse:collapse; display:block; overflow:auto; max-width:100%; }
  th,td { border:1px solid #d0d7de; padding:6px 13px; vertical-align:top; }
  tr:nth-child(2n) { background:#f6f8fa; }
  code { background:#eff1f3; padding:.15em .35em; border-radius:6px; font-size:85%; }
  pre { background:#f6f8fa; padding:16px; overflow:auto; border-radius:6px; } pre code { background:none; padding:0; }
  a { color:#0969da; }
  mark.verified { background:#d2f8d2; box-shadow:0 0 0 2px #d2f8d2; }
  mark.unverified { background:#ffe0b2; box-shadow:0 0 0 2px #ffe0b2; }
  mark.range { background:#ffd7d5; box-shadow:0 0 0 2px #ffd7d5; }
</style></head>
<body>
<div class="bar"><span class="badge">AFTER (0692b6b)</span><code>docs/calm-mode-feasibility.md</code></div>
<main id="doc"></main>
<script>
  const SRC = "# Calm-mode harness feasibility\n\nThis document is a dated journal of Calm-mode observations: harness surveys, the Pi transcript taxonomy, and supported-API boundaries for Firstmate calm mode.\nEach entry records when an observation was made, which harness version it was made against, and what was actually seen.\nAn observation is not carried to a version it was not made on; where a survey has not been redone, the gap is stated instead of filled by deduction.\n[`calm.md`](calm.md) owns the current user-facing `/calm` usage and limitation contract.\n\n## Required extension surface\n\nA qualifying implementation must auto-load from the trusted project, persist the toggle choice for the effective Firstmate home across Pi session starts and resumes, keep working activity visible, emit no Calm status row, redraw already-rendered controllable rows, remove supported hidden rows without gaps, restore ordinary rendering, and leave delivery, tool execution, model context, session storage, export and share operation, diagnostics, and expansion state unchanged.\nThe governing presentation policy allows genuine original user prompts, genuine user-facing assistant text, and working activity.\nWorking activity may be presented through Pi's stock row or through a supported Calm-owned widget, but Calm must leave the stock row untouched whenever Calm is off.\nChanging persisted context to remove hidden content, filtering provider context, patching installed harness code, or claiming coverage outside a supported renderer does not satisfy that boundary.\n\n## Compatibility evidence\n\n[`calm.md`](calm.md#pi-compatibility) owns the current Pi compatibility contract.\nThe Pi installed on 2026-08-16 is 0.84.2.\nWhat was observed against it that day is what the [2026-08-16 verification record](#2026-08-16-pi-0842-installed-version-verification) shows and nothing more: the `pi` and installed-package versions, one clean run of `tests/fm-calm-pi-extension.test.sh`, a declarations recheck of the two exported classes the adapters patch, and a typecheck run that produced no typecheck because `tsc` was absent.\nThat run is not a uniformly reproducible pass: the follow-up adjacent case intermittently fails a known test-harness race, measured and referenced in the same entry.\nNo survey in this document has been redone on 0.84.2.\nThe extension-API survey and the transcript taxonomy were made against Pi 0.81.1 on 2026-07-22.\nThe cross-harness inspection was made on 2026-07-22, with its Pi row reverified at 0.81.1 on 2026-07-23.\nThe working-presentation observations were made against the Pi 0.82.0 CLI on 2026-07-30.\nEach section below repeats its own date and version.\nPi 0.81.1 was installed when Calm was first built, and Pi 0.82.0 was the later reverification target.\nThe Pi CHANGELOG read at those two versions showed no relevant presentation API introduced at either, so they were recorded as verification evidence rather than compatibility bounds.\nThat reading was not repeated release by release afterwards; the later CHANGELOG entries that did touch Calm were found when they broke or changed it and are written up in the dated entries below.\nThe exported classes used by the adapters (`AssistantMessageComponent` and `InteractiveMode`) are undocumented internals with no stated version guarantee.\n`tests/fm-calm-pi-extension.test.sh` records the installed Pi version as evidence without gating on it and covers both newer synthetic versions and an unavailable adapter seam.\n\n### Built-in tool override constraints\n\n[`calm.md`](calm.md#pi-compatibility) owns the current user-facing collision behavior and limitation.\nInspection of Pi 0.80.10 and 0.82.0 established that extensions override a built-in tool by registering the same name, the first registered extension wins the complete `ToolDefinition` without merging, and Pi exposes no unregister operation.\nPi loads project-local extensions before global or CLI-configured extensions, so Firstmate's tracked Calm extension previously won those collisions even when its persisted preference was off.\nThe losing definition's execution and render functions are both discarded, so unconditionally registering Calm's wrappers would replace another extension's same-named tool rather than changing presentation alone.\n\nPi's `getAllTools()` exposes tool metadata and source identity but not the executable or rendering functions needed to wrap another extension's full definition.\nIt is also usable for reliable collision detection only after extension binding, which makes it suitable for the first same-session `/calm` activation but not for synchronous extension loading.\nDeferring registration to `session_start` is not an equivalent path: Pi constructs restored tool rows from an earlier tool-registry snapshot during reload, new-session, fork, and session switching, so those rows retain the definition captured before `session_start`.\n`tests/fm-calm-pi-extension.test.sh` covers the resulting split contract: no load-time claims while Calm is off, synchronous claims while it is already on, collision-checked first activation with a warning, preservation of a contested tool's execution, and the non-retroactive bound for rows rendered before first activation.\n\n## Pi 0.81.1 end-to-end reproduction\n\nThe Pi version installed at the time was verified on 2026-07-22.\n\n`` `text\n$ pi --version\n0.81.1\n`` `\n\n### Original transcript cleanup\n\nThe pre-cleanup reproduction used a real isolated Pi TUI at 180 columns by 44 rows with the tracked Calm and watcher extensions, an isolated `FM_HOME`, and a live home-owned watcher cycle.\nThe model called `fm_watch_arm_pi`, the real tool returned `watcher: started Pi extension arm child 1`, and a `done:` status write caused the watcher extension to inject `FIRSTMATE WATCHER WAKE: signal: ...` followed by the stable drain instruction.\nWith Calm off, the captured transcript contained the genuine user prompt, the full watcher tool shell, the synthetic user-role wake, four collapsed `Thinking...` labels, built-in tool rows from wake handling, and the final assistant response.\nWith the pre-cleanup implementation's Calm mode on, the existing seven built-in tool rows disappeared, but the watcher tool shell, synthetic wake, and all four `Thinking...` labels remained.\nThe final screenshot-scale regression reproduced the same transcript after the cleanup and verified t

... [46877 bytes truncated] ...

es.test.sh\nok - tracked Pi extensions pass strict no-emit typecheck against Pi 0.80.10\n\n$ bin/fm-lint.sh\nfm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)\n\n$ bin/fm-doc-audience-check.sh\nfm-doc-audience-check: ok surfaces=68 local_links=253\n\n$ bin/fm-test-run.sh --changed --base origin/main\nFM_TEST_SUMMARY total=46 failed=0 skipped_gate=16 duration_ms=279390\nFM_TEST_SUMMARY_FAMILY family=live-harness-optin count=16 duration_ms=431 failed=0\nFM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=30 duration_ms=277700 failed=0\n`` `\n\n## 2026-08-16 Pi 0.84.2 installed-version verification\n\nObserved on 2026-08-16: the installed Pi is 0.84.2, `tests/fm-calm-pi-extension.test.sh` completed one clean run against it, and the two exported classes the adapters patch are still declared with their patched hooks.\nThat is what this entry records.\nThe run exercises the 0.84.1 export-confirmation fix and the guarantees the suite covers, and nothing beyond them.\nSeveral 0.84.2 changes fall outside what the suite exercises and were not tested against Calm.\nReading the 0.84.2 CHANGELOG surfaced three that touch Calm's surface: the new `defaultTools` setting, which selects the initial built-in tool set globally or per project, while Calm registers its seven built-in wrappers synchronously at load only when the persisted preference is already on and none while Calm is off (see [Built-in tool override constraints](#built-in-tool-override-constraints)); the changed fallback rendering for extension tool results, which now collapses long output and honors tool expansion; and the experimental strict JSON-schema constrained sampling for the default `read`, `bash`, `edit`, and `write` tools under `PI_EXPERIMENTAL=1`, which covers four of the seven built-ins Calm re-registers under the same names.\nThat is what one CHANGELOG reading found, not an exhaustive audit of the release.\n\n`` `text\n$ pi --version\n0.84.2\n\n$ jq -r .version \"$(npm root -g)/@earendil-works/pi-coding-agent/package.json\"\n0.84.2\n\n$ cd \"$(npm root -g)/@earendil-works/pi-coding-agent\"\n\n$ grep -oE 'AssistantMessageComponent|InteractiveMode' dist/index.d.ts | sort -u\nAssistantMessageComponent\nInteractiveMode\n\n$ grep -oE 'updateContent|addMessageToChat' dist/modes/interactive/components/assistant-message.d.ts dist/modes/interactive/interactive-mode.d.ts | sort -u\ndist/modes/interactive/components/assistant-message.d.ts:updateContent\ndist/modes/interactive/interactive-mode.d.ts:addMessageToChat\n\n$ tests/fm-pi-primary-types.test.sh\nskip: tsc not found for Pi extension typecheck\n\n$ tests/fm-calm-pi-extension.test.sh\nok - Pi calm resolves its persistent home independently of Pi's launch directory\nok - Pi calm compatibility evidence never rejects a Pi version for being newer than 0.82.0, and still fails closed on a missing or malformed version\nok - a missing collapsed-thinking presentation API degrades only that Calm adapter with a clear skip reason, while the rest of Calm still registers\nok - missing Pi presentation class exports reach the independent adapter degradation path\nok - Calm registers none of its 7 built-in tool wrappers at load while config/calm is off, and all 7 synchronously at load while config/calm is on\nok - Calm's first same-session /calm activation claims every uncontested built-in, leaves a foreign bash tool fully intact and callable, warns prominently and logs the contested name, and only rows constructed before that activation - the documented bound - fail to retroactively collapse\nok - Pi calm centralizes transcript visibility, preserves execution/export data, keeps Pi's stock working row visible while no run is active, and persists its choice across session starts\nok - Pi calm on collapses mid-turn assistant working notes to zero height while Calm off keeps them, leaves streaming, truncated-final, and genuine final replies untouched, never mutates the messages, ignores every /calm argument, and restores a legacy persisted max as ordinary Calm on\nok - Pi operational follow-up E2E processes exact user-role notifications once while Calm hides current and adjacent rows, Calm off and absent render them, and restart preserves semantics\nok - Pi Calm native /skill:ahoy geometry keeps every collapsed thinking and tool block at zero height while preserving expansion, history, restart, and Calm-off rendering\nok - Pi Calm working ship moves on a slow independent cadence over faster fixed-cell blue water, paints the complete boat standard yellow with balanced resets, keeps ANSI-stripped width exact, flips the directional sail on the exact bounce at both edges and every width, clamps visible and hidden resizes, falls back deterministically when narrow, freezes and resumes column/direction across settle/start without hidden-time jumps or duplicate timers, resets only on a fresh session, and installs and removes one scheduler-owning widget across starts, settle, abort, failure, shutdown, reload, replacement, and Calm toggles while leaving Calm-off visibility untouched\nok - Pi calm native E2E replaces the stock working row with a moving, resize-clamped working ship that freezes and resumes across two working periods in one Pi session, clears on abort, keeps captain turns visible, hides exact operational user rows without changing persistence, restores stock rendering Calm-off, survives restart, and preserves export plus Ctrl+O behavior\n`` `\n\nThe follow-up adjacent case intermittently fails a pane-capture timing race (`Pi follow-up adjacent case rendered a duplicate captain answer`), so the run above is a clean run rather than a uniformly reproducible pass.\nThat race was measured on 2026-08-16 at 9 failures in 24 executions, at the same rate under both interpreters, and diagnosed there as a test-harness race rather than a Calm behavior break.\nA fix for it was written the same day in PR #2477 (branch `fm/fm-calm-bash5-regression`, head `adce327`), which was still open and unmerged on 2026-08-16.\nThat fix is therefore in no branch of this repository, `main` included: the failure is reachable wherever this suite runs today, and the diagnosis rests on that measurement rather than on anything in the code this document describes.\n";
  marked.use({ mangle:false, headerIds:false });
  const slug = t => t.trim().toLowerCase().replace(/[`*_~]/g,"").replace(/[^\w\- ]/g,"").replace(/ /g,"-");
  document.getElementById("doc").innerHTML = marked.parse(SRC);
  const seen = new Set();
  for (const h of document.querySelectorAll("h1,h2,h3,h4")) {
    let s = slug(h.textContent), base = s, n = 1;
    while (seen.has(s)) s = base + "-" + (n++);
    seen.add(s); h.id = s;
  }
  // Highlight evidence-scoping language so a reviewer can see it at a glance.
  const rules = [
    [/0\.81\.1 through 0\.82\.0/g, "range"],
    [/verified on Pi 0\.81\.1 on 2026-07-23 and on Pi 0\.82\.0 on 2026-07-26/g, "verified"],
    [/The Pi installed on 2026-08-16 is 0\.84\.2\./g, "verified"],
    [/observed on Pi 0\.81\.1 and on 0\.82\.0; re-exercised on the installed 0\.84\.2 by the 2026-08-16 run[^)]*/g, "verified"],
    [/are unverified on later Pi releases/g, "unverified"],
    [/is unverified on 0\.84\.2/g, "unverified"],
    [/have not been re-observed on 0\.83\.x or 0\.84\.2 and are unverified there/g, "unverified"],
    [/No survey in this document has been redone on 0\.84\.2\./g, "unverified"],
    [/so the declarations are unverified against 0\.84\.2/g, "unverified"],
    [/have not been reinspected since 2026-07-22 and are unverified on any later release/g, "unverified"],
  ];
  const walk = document.createTreeWalker(document.getElementById("doc"), NodeFilter.SHOW_TEXT);
  const nodes = []; while (walk.nextNode()) nodes.push(walk.currentNode);
  for (const node of nodes) {
    if (node.parentElement.closest("pre")) continue;
    let html = node.nodeValue, hit = false;
    for (const [re, cls] of rules) {
      if (re.test(html)) { hit = true; html = html.replace(re, m => '<mark class="'+cls+'">'+m+'</mark>'); }
      re.lastIndex = 0;
    }
    if (hit) { const span = document.createElement("span"); span.innerHTML = html; node.replaceWith(span); }
  }
</script></body></html>
```
</details>
<details>
<summary>Evidence: Reproduction des commandes enregistrées par la section 2026-08-16 (versions, déclarations, sonde runtime, typecheck, CHANGELOG)</summary>

Source: [Reproduction des commandes enregistrées par la section 2026-08-16 (versions, déclarations, sonde runtime, typecheck, CHANGELOG)](https://github.com/Kallas95/firstmate/blob/e087938d2d91170c721032b8f008b832401d3634/.no-mistakes/evidence/fm/fm-calm-doc-pi-versions/installed-pi-0.84.2-claim-reproduction.txt)

<code>$ pi --version&#10;0.84.2&#10;&#10;$ jq -r .version &#34;$(npm root -g)/@earendil-works/pi-coding-agent/package.json&#34;&#10;0.84.2&#10;&#10;typeof AssistantMessageComponent.prototype.updateContent = function&#10;typeof InteractiveMode.prototype.addMessageToChat = function&#10;&#10;$ tests/fm-pi-primary-types.test.sh&#10;skip: tsc not found for Pi extension typecheck</code>

```text
# Reproducing the claims recorded in docs/calm-mode-feasibility.md on 2026-08-16

$ pi --version
0.84.2

$ jq -r .version "$(npm root -g)/@earendil-works/pi-coding-agent/package.json"
0.84.2

$ grep -oE 'AssistantMessageComponent|InteractiveMode' dist/index.d.ts | sort -u
AssistantMessageComponent
InteractiveMode

$ grep -oE 'updateContent|addMessageToChat' dist/modes/interactive/components/assistant-message.d.ts dist/modes/interactive/interactive-mode.d.ts | sort -u
dist/modes/interactive/components/assistant-message.d.ts:updateContent
dist/modes/interactive/interactive-mode.d.ts:addMessageToChat

# Runtime probe of the two seams the Calm adapters patch (stronger than the declaration read):
$ node -e "import('file://$(npm root -g)/@earendil-works/pi-coding-agent/dist/index.js') ..."
typeof AssistantMessageComponent                    = function
typeof AssistantMessageComponent.prototype.updateContent = function
typeof InteractiveMode                              = function
typeof InteractiveMode.prototype.addMessageToChat   = function

$ tests/fm-pi-primary-types.test.sh
skip: tsc not found for Pi extension typecheck

# 0.84.2 CHANGELOG lines behind the doc's 'what moved in 0.84.2' claims:
14:- Added experimental strict JSON-schema constrained sampling for the default `read`, `bash`, `edit`, and `write` tools under `PI_EXPERIMENTAL=1`.
16:- Added the `defaultTools` setting for configuring the initial built-in tool selection globally or per project.
18:- Added `expandPromptTemplates` to extension `pi.sendUserMessage()` options for explicitly dispatching commands and expanding skills and prompt templates. See [`pi.sendUserMessage()`](docs/extensions.md#pisendusermessagecontent-options) ([#7857](https://github.com/earendil-works/pi/pull/7857) by [@mrexodia](https://github.com/mrexodia)).
39:- Fixed fallback rendering for extension tool results to collapse long output and honor tool expansion ([#7979](https://github.com/earendil-works/pi/issues/7979)).
42:- Fixed the `defaultTools` setting dropping extension and SDK custom tools when selecting built-in defaults.
369:- Added inherited `supportsGrammarTools` and `supportsStrictTools` compatibility flags, expanded `supportsStrictMode` coverage, and generated model capability metadata to gate constrained sampling.
```
</details>
<details>
<summary>Evidence: Suite Calm contre le Pi 0.84.2 installé : 12/12 ok, transcript identique à celui publié dans le document</summary>

Source: [Suite Calm contre le Pi 0.84.2 installé : 12/12 ok, transcript identique à celui publié dans le document](https://github.com/Kallas95/firstmate/blob/e087938d2d91170c721032b8f008b832401d3634/.no-mistakes/evidence/fm/fm-calm-doc-pi-versions/calm-pi-extension-run1.txt)

```text
ok - Pi calm resolves its persistent home independently of Pi's launch directory
ok - Pi calm compatibility evidence never rejects a Pi version for being newer than 0.82.0, and still fails closed on a missing or malformed version
ok - a missing collapsed-thinking presentation API degrades only that Calm adapter with a clear skip reason, while the rest of Calm still registers
ok - missing Pi presentation class exports reach the independent adapter degradation path
ok - Calm registers none of its 7 built-in tool wrappers at load while config/calm is off, and all 7 synchronously at load while config/calm is on
ok - Calm's first same-session /calm activation claims every uncontested built-in, leaves a foreign bash tool fully intact and callable, warns prominently and logs the contested name, and only rows constructed before that activation - the documented bound - fail to retroactively collapse
ok - Pi calm centralizes transcript visibility, preserves execution/export data, keeps Pi's stock working row visible while no run is active, and persists its choice across session starts
ok - Pi calm on collapses mid-turn assistant working notes to zero height while Calm off keeps them, leaves streaming, truncated-final, and genuine final replies untouched, never mutates the messages, ignores every /calm argument, and restores a legacy persisted max as ordinary Calm on
ok - Pi operational follow-up E2E processes exact user-role notifications once while Calm hides current and adjacent rows, Calm off and absent render them, and restart preserves semantics
ok - Pi Calm native /skill:ahoy geometry keeps every collapsed thinking and tool block at zero height while preserving expansion, history, restart, and Calm-off rendering
ok - Pi Calm working ship moves on a slow independent cadence over faster fixed-cell blue water, paints the complete boat standard yellow with balanced resets, keeps ANSI-stripped width exact, flips the directional sail on the exact bounce at both edges and every width, clamps visible and hidden resizes, falls back deterministically when narrow, freezes and resumes column/direction across settle/start without hidden-time jumps or duplicate timers, resets only on a fresh session, and installs and removes one scheduler-owning widget across starts, settle, abort, failure, shutdown, reload, replacement, and Calm toggles while leaving Calm-off visibility untouched
ok - Pi calm native E2E replaces the stock working row with a moving, resize-clamped working ship that freezes and resumes across two working periods in one Pi session, clears on abort, keeps captain turns visible, hides exact operational user rows without changing persistence, restores stock rendering Calm-off, survives restart, and preserves export plus Ctrl+O behavior
tests/fm-calm-pi-extension.test.sh  10.70s user 4.99s system 31% cpu 49.072 total
exit=0
```
</details>
<details>
<summary>Evidence: Résolution des liens et ancres du document (11/11)</summary>

Source: [Résolution des liens et ancres du document (11/11)](https://github.com/Kallas95/firstmate/blob/e087938d2d91170c721032b8f008b832401d3634/.no-mistakes/evidence/fm/fm-calm-doc-pi-versions/doc-link-anchor-resolution.txt)

`headings=20 links_checked=11 broken=0`

```text
ok   line   6  [`calm.md`](calm.md)  -> calm.md
ok   line  17  [`calm.md`](calm.md#pi-compatibility)  -> calm.md anchor #pi-compatibility
ok   line  19  [2026-08-16 verification record](#2026-08-16-pi-0842-installed-version-verification)  -> same-document anchor #2026-08-16-pi-0842-installed-version-verification
ok   line  34  [`calm.md`](calm.md#pi-compatibility)  -> calm.md anchor #pi-compatibility
ok   line  93  [compatibility contract](calm.md#pi-compatibility)  -> calm.md anchor #pi-compatibility
ok   line 151  [compatibility contract](calm.md#pi-compatibility)  -> calm.md anchor #pi-compatibility
ok   line 163  [2026-07-30 revision verification](#2026-07-30-calm-working-presentation-revision-verification)  -> same-document anchor #2026-07-30-calm-working-presentation-revision-verification
ok   line 199  [`docs/configuration.md`](configuration.md#pi-calm-preference-configcalm)  -> configuration.md anchor #pi-calm-preference-configcalm
ok   line 247  [compatibility contract](calm.md#pi-compatibility)  -> calm.md anchor #pi-compatibility
ok   line 267  [2026-08-16 verification record](#2026-08-16-pi-0842-installed-version-verification)  -> same-document anchor #2026-08-16-pi-0842-installed-version-verification
ok   line 534  [Built-in tool override constraints](#built-in-tool-override-constraints)  -> same-document anchor #built-in-tool-override-constraints

headings=20 links_checked=11 broken=0
```
</details>
<details>
<summary>Evidence: 4 exécutions de la suite : 3 succès, 1 échec sur la course documentée (cas loaded_off)</summary>

Source: [4 exécutions de la suite : 3 succès, 1 échec sur la course documentée (cas loaded_off)](https://github.com/Kallas95/firstmate/blob/e087938d2d91170c721032b8f008b832401d3634/.no-mistakes/evidence/fm/fm-calm-doc-pi-versions/calm-suite-flake-observations.txt)

<code>run 1: PASS (12/12 ok, 49s)&#10;run 2: FAIL - not ok - Pi follow-up loaded_off case rendered a duplicate captain answer&#10;run 3: PASS (12/12 ok)&#10;run 4: PASS (12/12 ok)</code>

```text
runs of tests/fm-calm-pi-extension.test.sh against the installed Pi 0.84.2 on 2026-08-16
run 1: PASS (12/12 ok, 49s) - transcript identical to the doc's 2026-08-16 record
run 2: FAIL - not ok - Pi follow-up loaded_off case rendered a duplicate captain answer
run 3: PASS (12/12 ok)
run 4: PASS (12/12 ok)

The failing assertion is the shared pane-capture check in tests/fm-calm-pi-extension.test.sh:1820-1822,
which greps the tmux pane for exactly one CAPTAIN_ANSWER_$label right after the session file records
MONITOR_HANDLED_${label}_ONE. Every follow-up case label goes through it, so the documented race is not
limited to the 'adjacent' case named in the doc's 2026-08-16 entry.
```
</details>
<details>
<summary>Evidence: Index des artefacts de preuve</summary>

Source: [Index des artefacts de preuve](https://github.com/Kallas95/firstmate/blob/e087938d2d91170c721032b8f008b832401d3634/.no-mistakes/evidence/fm/fm-calm-doc-pi-versions/README.md)

```text
# Evidence: docs/calm-mode-feasibility.md now describes the installed Pi 0.84.2

Reader-facing surface: the rendered document. `doc-before-base.html` (base `ef35d79`) and
`doc-after-change.html` (`0692b6b`) render the real file with marked; evidence-scoping language is
highlighted (red = asserted version range, green = dated "verified" claim, orange = explicit "unverified").

| Artifact | Shows |
| --- | --- |
| `01-before-compatibility-evidence.png` | Base doc: compatibility section with no installed-version statement |
| `02-before-taxonomy-range-header.png` | Base doc: taxonomy table header asserting "baseline verified on Pi 0.81.1 through 0.82.0" |
| `03-before-crossharness-pi-row.png` | Base doc: cross-harness row "Pi (verified 0.81.1 through 0.82.0)" |
| `04-after-compatibility-evidence.png` | Changed doc: "The Pi installed on 2026-08-16 is 0.84.2" plus "No survey in this document has been redone on 0.84.2" |
| `05-after-crossharness-pi-row.png` | Changed doc: row is "Pi 0.81.1", dated, with the 0.84.2 re-exercise and the un-redone survey called out |
| `06-after-taxonomy-scoped-header.png` | Changed doc: taxonomy scoped to "surveyed on Pi 0.81.1", header range removed, later releases marked unverified |
| `07-after-anchor-jump-2026-08-16-record.png` | Clicking the new "2026-08-16 verification record" cross-reference lands on the new record |
| `installed-pi-0.84.2-claim-reproduction.txt` | Every command the new record prints, re-run on this machine, plus a runtime probe of both patched Pi seams and the 0.84.2 CHANGELOG lines behind the claims |
| `calm-pi-extension-run1.txt` | `tests/fm-calm-pi-extension.test.sh` against the installed Pi 0.84.2: 12/12 ok, transcript identical to the doc's record |
| `doc-link-anchor-resolution.txt` | All 11 intra-repo links/anchors of the doc resolve (GitHub slug rules) |
| `calm-suite-flake-observations.txt`, `calm-pi-extension-run2-known-race-failure.txt`, `calm-pi-extension-repeat-runs.txt` | 4 suite runs: 3 pass, 1 hits the documented pane-capture race (on the `loaded_off` case, not the `adjacent` case the doc names) |

Rendered HTML uses the vendored `marked.min.js` in this directory; open the HTML files directly.
```
</details>
- Outcome: ⚠️ 2 issues (1 warning, 1 info) across 1 run (11m17s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"9d31c721a59fdbe744e60f55007e86fed80af5b2","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

_... (4 earlier update rounds omitted to keep the PR body within GitHub's 65536-char limit; full history is in the run log.)_

<details>
<summary>⚠️ **Review** - 2 infos</summary>

🔧 Fix: restate Calm Pi evidence as a dated journal
7 issues (4 warnings, 3 infos) still open:
- ⚠️ `docs/calm-mode-feasibility.md:22` - Le paragraphe de synthèse « Compatibility evidence » réintroduit exactement l&#39;élargissement que le round vise à supprimer, en contredisant ses propres sections. Ligne 22 : « The API surveys, the transcript taxonomy, and the cross-harness inspection date from Pi 0.81.1 on 2026-07-22 and Pi 0.82.0 on 2026-07-30 » - or la ligne 210 dit l&#39;inverse pour la taxonomie (« That survey has not been redone on 0.82.0 or 0.84.2 »), et la section cross-harness date son inspection du 2026-07-22 avec une revérification Pi à 0.81.1 le 2026-07-23 (lignes 246, 263, 270), jamais à 0.82.0 ; le seul enregistrement du 2026-07-30 (ligne 411) porte uniquement sur la révision du bateau de travail, vérifiée sur le CLI 0.82.0. Deuxième instance dans le même paragraphe, ligne 19 : « Two things were observed against it that day and nothing else » est démenti par l&#39;enregistrement cité, qui contient une troisième observation (`jq -r .version` sur le manifeste du paquet installé, ligne 533) dont la ligne 288 dépend explicitement. Correction : aligner la ligne 22 sur les versions/dates réelles de chaque section, et ouvrir l&#39;énumération de la ligne 19 ou y inclure la lecture du manifeste.
- ⚠️ `docs/calm-mode-feasibility.md:4` - La promesse universelle supprimée de la ligne 18 est réapparue dans le préambule : ligne 4 « Each entry records when an observation was made, which harness version it was made against, and what was actually seen » et ligne 5 « An observation is not carried to a version it was not made on ». Le corps ne la tient pas : la section « Calm working presentation » énonce quatre observations sur le comportement de Pi sans aucune version ni date, au présent - ligne 162 « Pi&#39;s documented custom working-indicator frames are static and width-blind », ligne 166 « Pi emits `agent_settled` from a `finally` block », ligne 167 « Pi disposes the previous component before installing a replacement under the same key », ligne 168 « Pi&#39;s above-editor widget container reserves one spacer row whether or not a widget is present ». Ces observations ont été faites sur le CLI Pi 0.82.0 le 2026-07-30 (ligne 411), donc elles sont bien portées implicitement jusqu&#39;à la version installée, ce que la ligne 5 déclare ne jamais se produire. L&#39;intent exige de « mark each compatibility claim as verified or unverified » : soit ancrer ces quatre phrases sur 0.82.0 / 2026-07-30 avec renvoi à l&#39;enregistrement, soit retirer la portée universelle des lignes 4-5.
- ⚠️ `docs/calm-mode-feasibility.md:212` - La nouvelle phrase « Rows carrying their own version note were observed on that version; the rest carry the 0.81.1 survey date above » et le nouvel en-tête de colonne « Pi transcript path (Pi 0.81.1 survey, 2026-07-22) » (ligne 214) antidatent des lignes du tableau qui n&#39;existaient pas au moment de ce relevé. Vérifié par l&#39;historique : la mention du widget working-ship de la ligne `working-status` a été ajoutée le 2026-07-30 (commit 3a112a1, ère Pi 0.82.0), et toute la ligne `assistant-working-note`, y compris sa colonne de chemin de transcript décrivant la sémantique de `stopReason`, a été ajoutée le 2026-08-13 (commit 9823ff8) - sa propre note dit d&#39;ailleurs « verified on Pi 0.84.1 », pas 0.81.1. Le résultat est une affirmation positive et fausse : ces chemins de transcript sont présentés comme observés sur Pi 0.81.1 le 2026-07-22. Restreindre la phrase et l&#39;en-tête aux lignes réellement issues du relevé 0.81.1, ou donner à ces deux lignes leur propre date/version.
- ⚠️ `docs/calm-mode-feasibility.md:564` - « then fixed in PR #2477 (branch `fm/fm-calm-bash5-regression`, head `adce327`) » présente le correctif comme acquis. Vérification via l&#39;API GitHub : la PR #2477 existe bien, sa branche et son head correspondent exactement (`fm/fm-calm-bash5-regression`, `adce3276e6eb4be7309d433a8438232e71a98b19`, base `main`), mais son état est `open` et `merged: false`. Combinée à la phrase suivante (« That fix is not in this branch&#39;s history »), la formulation laisse comprendre que le correctif est déjà dans main et que seule cette branche est en retard, alors qu&#39;il n&#39;est fusionné nulle part : un mainteneur qui exécute la suite sur main rencontrera le même échec 9 fois sur 24. Formuler le correctif comme proposé dans une PR encore ouverte à la date de l&#39;enregistrement.
- ℹ️ `docs/calm-mode-feasibility.md:289` - « the typecheck has not been rerun since, so it is unverified against 0.84.2 » est en tension avec l&#39;enregistrement du même changement, qui montre `$ tests/fm-pi-primary-types.test.sh` exécuté le 2026-08-16 avec la sortie `skip: tsc not found for Pi extension typecheck` (ligne 546). Le test a bien été relancé ; c&#39;est le typecheck qui n&#39;a pas eu lieu, faute de `tsc` (vérifié en source : `tests/fm-pi-primary-types.test.sh:8` sort en 0 avec ce message quand `tsc` est absent). La conclusion « unverified against 0.84.2 » est correcte, mais la cause réelle - l&#39;absence de `tsc` sur la machine - est l&#39;information utile pour le journal et elle est perdue par la formulation actuelle.
- ℹ️ `docs/calm-mode-feasibility.md:526` - « Two 0.84.2 changes fall outside what the suite exercises and were not tested against Calm » est une énumération fermée qui sous-évalue. Le CHANGELOG 0.84.2 du paquet installé contient au moins un troisième élément de la même nature, touchant précisément les outils que Calm remplace : « Added experimental strict JSON-schema constrained sampling for the default `read`, `bash`, `edit`, and `write` tools under `PI_EXPERIMENTAL=1` » - quatre des sept intégrés que `wrapBuiltIn` réenregistre sous le même nom (`.pi/extensions/fm-calm.ts:214-235`), et que la suite n&#39;exerce pas non plus sous ce drapeau. Ouvrir l&#39;énumération (« notamment ») ou ajouter cette troisième entrée.
- ℹ️ `docs/calm-mode-feasibility.md:16` - Note de traçabilité, aucune action attendue. L&#39;intent affirme « the Calm test suite passes against it », alors que le document dit désormais « completed a clean run » plus « not a uniformly reproducible pass ». Ce n&#39;est pas une contradiction à traiter : les décisions du capitaine des rounds 1 et 2 interdisent explicitement d&#39;écrire « the suite passes » lorsqu&#39;un échec intermittent est enregistré, et l&#39;échec est réel et reproductible ici (9 sur 24, correctif absent de l&#39;historique de cette branche, cf. lignes 563-565). La divergence par rapport à la prémisse de l&#39;intent est donc autorisée.

🔧 Fix: date every Calm journal claim to its real evidence
5 issues (2 warnings, 3 infos) still open:
- ⚠️ `docs/calm-mode-feasibility.md:92` - L&#39;intent nomme littéralement la formulation à supprimer : « so it no longer asserts a Pi compatibility baseline (verified on Pi 0.81.1 through 0.82.0) » et « must not widen the announced version range without proof ». Cette phrase exacte subsiste à deux endroits non touchés par le changement : ligne 92 « The fix installs one idempotent presentation adapter, verified on Pi 0.81.1 through 0.82.0, on the exported `AssistantMessageComponent.updateContent` method. » et ligne 150 la même chose pour `InteractiveMode.addMessageToChat`. Le changement a retiré cette plage de l&#39;en-tête du tableau de taxonomie et de la ligne Pi du tableau cross-harness, mais l&#39;a laissée dans le corps. « through » porte l&#39;observation sur toutes les versions intermédiaires (0.81.2 … 0.81.x) qui n&#39;ont jamais été testées, ce que le nouveau préambule interdit explicitement (ligne 5 : « An observation is not carried to a version it was not made on »), et que le document lui-même a déjà corrigé ailleurs en énumérant (ligne 246 : « observed exported on Pi 0.81.1, on 0.82.0 »). Les commentaires source utilisent d&#39;ailleurs déjà la forme énumérée correcte (`.pi/extensions/lib/fm-calm-assistant-layout.ts:1` et `fm-calm-operational-user-layout.ts:1` : « Verified against Pi 0.81.1 and 0.82.0 »). Les deux sections concernées sont datées (2026-07-23, Pi 0.81.1) et l&#39;enregistrement du 2026-07-26 couvre 0.82.0, donc la correction est un simple passage à « verified on Pi 0.81.1 and on 0.82.0 » - mais elle porte sur le critère nommé par l&#39;intent, donc décision auteur.
- ⚠️ `docs/calm-mode-feasibility.md:25` - La promesse universelle du préambule reste démentie par le corps, pour la troisième fois. Ligne 4 « Each entry records when an observation was made, which harness version it was made against » et ligne 25 « Each section below repeats its own date and version. » Trois sections n&#39;ont toujours aucune date : « Built-in tool override constraints » (ligne 35, « Inspection of Pi 0.80.10 and 0.82.0 established that ... », version sans date), « Duplicate-turn regression and semantic boundary » (ligne 122, « because Pi 0.81.1 exposes no supported ordinary-user renderer », version sans date, et la section entière n&#39;ouvre sur aucune date contrairement aux sections voisines 44 et 126), et « Central visibility and input policy » (ligne 209 « Pi 0.83.0 made every expansion change emit its own status line, and Pi coalesces consecutive status lines », ligne 211 « Pi 0.81.1&#39;s sidebar tree », versions sans date). Le round 3 avait déjà tranché : garder la promesse et faire tenir le corps partout ; le round 4 l&#39;a fait pour « Calm working presentation » (ligne 163) mais pas pour ces trois-là. Deux issues honnêtes : dater ces trois sections (les observations 0.83.0 sont rattachables à l&#39;enregistrement du 2026-08-15, les 0.80.10/0.82.0 à celui du 2026-07-26), ou restreindre la portée des lignes 4 et 25 aux sections d&#39;enregistrement. C&#39;est le 5e round sur ce thème : la décision permanente du capitaine était d&#39;escalader plutôt que d&#39;enchaîner une correction automatique de plus.
- ℹ️ `docs/calm-mode-feasibility.md:573` - « That race was measured on 2026-08-16 at 9 failures in 24 executions, at the same rate under both interpreters » emploie « both interpreters » sans que le terme n&#39;apparaisse nulle part ailleurs dans le document : un lecteur ne peut pas savoir de quels deux interpréteurs il s&#39;agit, ni si 9/24 est le total ou le chiffre par interpréteur. Le fait est vérifiable via la référence déjà citée à côté : le corps de la PR #2477 identifie l&#39;interpréteur livré par Apple en 3.2.57 et celui installé par Homebrew en 5.3.15 (la branche s&#39;appelle `fm/fm-calm-bash5-regression`). Nommer les deux shells et préciser si le 9/24 est cumulé rend la mesure vérifiable, ce qui est tout l&#39;objet d&#39;un journal daté.
- ℹ️ `docs/calm-mode-feasibility.md:19` - La liste « What was observed against it that day is what the [2026-08-16 verification record] shows and nothing more: » énumère quatre choses (versions `pi` et paquet, une exécution propre de la suite, la revérification des déclarations, le typecheck qui n&#39;a pas eu lieu) mais omet la cinquième observation faite le même jour et consignée dans le même enregistrement : la lecture du CHANGELOG 0.84.2 (ligne 534), qui est précisément celle qui produit le contenu le plus lourd de conséquences (trois changements 0.84.2 non testés contre Calm). Le round 3 avait déjà corrigé la version « Two things ... and nothing else » de cette phrase ; l&#39;énumération est passée de deux à quatre éléments mais reste incomplète alors qu&#39;elle se présente comme close. Ajouter la lecture du CHANGELOG à la liste.
- ℹ️ `docs/calm-mode-feasibility.md:4` - Note de routage, aucune action de code attendue. Les deux findings « warning » ci-dessus sont la 5e itération du même thème (portée de version / promesse globale) après quatre rounds de correction successifs. L&#39;instruction permanente du firstmate au round 3 était explicite : « This is round 4: if a 5th finding of the same theme appears, do not fix it - append needs-decision and stop. » Le round 4 a corrigé sans escalader et aucune note `needs-decision` n&#39;a été déposée. Le choix de forme restant (dater les trois sections vs restreindre la portée de la promesse ; énumérer vs conserver « through ») est une décision d&#39;auteur, pas une correction mécanique de plus.

🔧 Fix: no change: sole finding carried no actionable content
2 issues (1 warning, 1 info) still open:
- ⚠️ `docs/calm-mode-feasibility.md:163` - La phrase ajoutée par le round de correction attribue quatre comportements Pi à un enregistrement qui n&#39;en contient aucun : « The Pi behaviors this section relies on - the documented custom working-indicator frames, the `agent_settled` emission point, widget disposal under a repeated key, and the above-editor spacer row - were observed against the Pi 0.82.0 CLI on 2026-07-30, recorded in the [2026-07-30 revision verification](#2026-07-30-calm-working-presentation-revision-verification) ». J&#39;ai lu l&#39;enregistrement cité intégralement (lignes 415-464) : il consigne la cadence du sprite (`hull_col`), les codes ANSI, les deux inversions au redimensionnement à 12 colonnes, le repli à 3 colonnes et l&#39;abandon par Escape. Il ne consigne ni les frames d&#39;indicateur de travail documentées, ni le point d&#39;émission d&#39;`agent_settled`, ni la disposition du composant sous clé répétée, ni la rangée d&#39;espacement du conteneur de widget. Le seul appui partiel pour la quatrième (« no residual blank row ») se trouve dans l&#39;enregistrement *superseded* (ligne 413), pas dans celui qui est cité. Ces quatre énoncés sont des lectures de la source Pi, pas des observations du CLI : j&#39;ai confirmé que celui sur `agent_settled` est exact aujourd&#39;hui sur 0.84.2 (`finally` en `dist/core/agent-session.js:755`), donc la substance tient - c&#39;est l&#39;attribution qui est fausse. Un lecteur qui suit le lien pour vérifier ne trouve rien, ce qui est exactement le mode de défaillance que la forme « journal daté » (lignes 4-5) doit éliminer. Deux issues honnêtes : citer l&#39;enregistrement qui les porte réellement (le superseded pour la rangée d&#39;espacement) et dater séparément la lecture de source Pi qui a produit les trois autres, ou requalifier la phrase en « dérivées de la lecture des déclarations et du `dist` de Pi 0.82.0 » sans renvoi à un enregistrement de TUI.
- ℹ️ `docs/calm-mode-feasibility.md:575` - « That fix is therefore in no branch of this repository, `main` included » est factuellement faux. Vérifié : `git branch -a --contains adce3276e6eb4be7309d433a8438232e71a98b19` renvoie `fm/fm-calm-bash5-regression`, une branche bien présente dans ce dépôt (et c&#39;est la tête de la PR #2477 côté GitHub). L&#39;information utile et exacte est celle que la phrase suivante porte déjà et que j&#39;ai confirmée (`git merge-base --is-ancestor adce327 origin/main` échoue) : le correctif n&#39;est ni dans `origin/main` ni dans l&#39;historique de cette branche, donc l&#39;échec reste atteignable pour quiconque exécute la suite depuis `main`. La formulation actuelle dépasse l&#39;instruction du round précédent (« absent from the code this document describes ») et transforme une constatation vraie en une affirmation universelle fausse, dans un document dont l&#39;objet est précisément de ne pas dépasser sa preuve. Remplacer par « ce correctif n&#39;est donc ni dans `main` ni dans l&#39;historique de cette branche ».

🔧 Fix: replace adapter version range with dated observation points
2 infos still open:
- ℹ️ `docs/calm-mode-feasibility.md:217` - « Two rows postdate it and carry their own dates instead » est une énumération fermée et un décompte inexact. Vérifié par l&#39;historique : en comparant le tableau au commit du relevé (6db3b09, 2026-07-22) avec la version actuelle, six lignes ont un contenu postérieur au 2026-07-22, pas deux. Outre `working-status` et `assistant-working-note` que la phrase nomme, quatre autres ont été réécrites le 2026-07-23 : `genuine-user-prompt` (« Visible. » → « Visible, including every tested operational near miss. »), `custom-message`, `custom-entry`, et `synthetic-user` ; et surtout `assistant-thinking` dont la colonne *Pi transcript path* elle-même a changé (« Working indicator and thinking content in `AssistantMessageComponent` » → « Thinking content in `AssistantMessageComponent` »), alors que la phrase précédente affirme que « its transcript paths ... are 0.81.1 observations » issues du relevé du 2026-07-22. Portée réelle du défaut : la version reste correcte partout (le relevé 2026-07-23 montre `pi --version` → 0.81.1, donc ces lignes sont bien des observations 0.81.1), c&#39;est la date de provenance qui est fausse d&#39;un jour et le décompte qui est faux. Le critère de version de l&#39;intent n&#39;est donc pas violé, mais un mainteneur lisant cette phrase croira que toutes les autres lignes sont verbatim du relevé du 2026-07-22. Deux issues : ouvrir la phrase (« plusieurs lignes ont été révisées le 2026-07-23, toujours sur Pi 0.81.1 »), ou dater ces lignes. Note de routage : c&#39;est le 6e round sur le thème de la provenance ; l&#39;instruction permanente du firstmate au round 3 était d&#39;escalader plutôt que d&#39;enchaîner une correction automatique, d&#39;où le classement en décision auteur.
- ℹ️ `docs/calm-mode-feasibility.md:28` - « the later CHANGELOG entries that did touch Calm were found when they broke or changed it and are written up in the dated entries below » est démenti par l&#39;enregistrement que la phrase elle-même désigne. L&#39;entrée du 2026-08-16 (ligne 534) consigne une lecture *proactive* du CHANGELOG 0.84.2 qui a trouvé trois entrées touchant la surface de Calm (`defaultTools`, rendu de repli des résultats d&#39;outils d&#39;extension, échantillonnage contraint expérimental sur `read`/`bash`/`edit`/`write`) - vérifiées littéralement dans le CHANGELOG du paquet installé - et le document dit explicitement qu&#39;aucune n&#39;a été testée contre Calm, donc aucune n&#39;a « cassé ou changé » quoi que ce soit. Seule l&#39;entrée 0.83.0 (ligne d&#39;état d&#39;expansion) correspond à la description « trouvée quand elle a cassé ». La phrase caractérise donc comme exhaustif un mode de découverte qui ne l&#39;est pas, dans le paragraphe même qui annonce que le document ne dépasse plus sa preuve. Correction possible : « ... ont été trouvées soit quand elles ont cassé Calm, soit par la lecture ponctuelle consignée dans l&#39;entrée du 2026-08-16 ».

</details>

<details>
<summary>⚠️ **Test** - 2 issues (1 warning, 1 info)</summary>

- ⚠️ `tests/fm-calm-pi-extension.test.sh:1821` - Test instable préexistant : `tests/fm-calm-pi-extension.test.sh` a échoué sur 1 exécution sur 4 avec `not ok - Pi follow-up loaded_off case rendered a duplicate captain answer`. L&#39;assertion en cause capture le pane tmux juste après l&#39;écriture de `MONITOR_HANDLED_${label}_ONE` dans le fichier de session et exige exactement une occurrence de `CAPTAIN_ANSWER_$label` ; elle est partagée par tous les cas de l&#39;E2E follow-up. Non causé par ce changement (seul un commentaire est modifié dans ce fichier), correctif écrit dans la PR #2477 (`fm/fm-calm-bash5-regression`) non fusionnée. Les 3 autres exécutions passent 12/12.
- ℹ️ `docs/calm-mode-feasibility.md:571` - La nouvelle entrée datée attribue l&#39;intermittence au seul « follow-up adjacent case », alors que la course observée frappe l&#39;assertion partagée de capture de pane : elle s&#39;est déclenchée ici sur le cas `loaded_off`. La portée réelle du défaut est « tout cas de l&#39;E2E follow-up », pas uniquement le cas adjacent - à ajuster si le document veut rester exact sur ce qu&#39;il a observé.
- <code>`pi --version` → 0.84.2 et `jq -r .version &#34;$(npm root -g)/@earendil-works/pi-coding-agent/package.json&#34;` → 0.84.2</code>
- <code>`tests/fm-calm-pi-extension.test.sh` (4 exécutions : 3 succès 12/12, 1 échec sur la course connue)</code>
- <code>`diff` entre les lignes `ok -` enregistrées dans la section 2026-08-16 du document et la sortie réelle de la suite → identiques</code>
- <code>`tests/fm-pi-primary-types.test.sh` → `skip: tsc not found for Pi extension typecheck` (conforme au document)</code>
- <code>Sonde runtime des seams patchés : `node --input-type=module -e &#34;import(&#39;file://.../pi-coding-agent/dist/index.js&#39;)&#34;` → `AssistantMessageComponent.prototype.updateContent` et `InteractiveMode.prototype.addMessageToChat` sont des `function`</code>
- <code>Reproduction des `grep -oE &#39;AssistantMessageComponent|InteractiveMode&#39; dist/index.d.ts` et `grep -oE &#39;updateContent|addMessageToChat&#39; …assistant-message.d.ts …interactive-mode.d.ts` cités par le document</code>
- <code>Vérification des affirmations 0.84.2 dans le CHANGELOG du paquet installé (`defaultTools`, `expandPromptTemplates`, rendu de repli des résultats d&#39;outils d&#39;extension, échantillonnage contraint sous `PI_EXPERIMENTAL=1`)</code>
- <code>Validation sémantique des liens : parsing du markdown en titres + liens avec les règles de slug GitHub → 11/11 ancres internes résolvent (`/tmp/anchor-check.mjs docs/calm-mode-feasibility.md`)</code>
- <code>`grep -rn &#34;0.81.1 through 0.82.0&#34;` sur le dépôt → aucune occurrence restante ; aucune autre référence à une ancre de `calm-mode-feasibility.md` cassée par le renommage de titre</code>
- <code>Rendu HTML des versions base (`ef35d79`) et cible (`0692b6b`) du document et captures d&#39;écran des sections Compatibility evidence, taxonomie, cross-harness, plus clic réel sur la nouvelle référence croisée « 2026-08-16 verification record »</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/calm-mode-feasibility.md:575` - L&#39;entrée 2026-08-16 de docs/calm-mode-feasibility.md (fin de fichier) cite le nom de branche `fm/fm-calm-bash5-regression` et le SHA de tête `adce327` d&#39;une PR non fusionnee, alors que docs/documentation-audiences.md:17 demande que branches, chemins temporaires et identifiants de processus ponctuels restent dans les rapports de tache prives ou les preuves de PR. Je ne l&#39;ai pas retire : ce passage est porteur (il justifie pourquoi la passe est qualifiee de « clean run » et non de succes reproductible), il a ete ajoute par un tour de revue anterieur (8fee818), et la politique exige de distiller le fait durable avant toute suppression. Suivi possible hors perimetre : conserver la mesure 9 echecs sur 24 et le renvoi de regression, et reduire branche et SHA a la seule reference PR #2477.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
