### PR TITLE
docs(agents): compact section 4 dispatch procedure and one section 2 duplicate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,6 @@ state/               runtime records and signals; gitignored
 ```
 
 A `state/<id>.status` line is a wake event, not current-state truth; `bin/fm-crew-state.sh` owns current-state reconciliation.
-Treat `data/captain.md` as the domain-local record of captain preferences, optional `data/captain-shared.md` as the main-authoritative shared captain-preference file for secondmate inheritance, and `data/learnings.md` as curated home-local knowledge, regardless of harness memory.
 
 ## 3. Session start (run once at every session start)
 
@@ -188,18 +187,15 @@ If static `config/crew-harness` or `config/secondmate-harness` names an unverifi
 `docs/configuration.md` owns dispatch-profile and runtime-backend schemas, `bin/fm-harness.sh` owns static resolution, and `bin/fm-spawn.sh` owns launch flags and fail-closed validation.
 When dispatch profiles exist, consult them at every crewmate or scout intake and pass the resolved concrete profile required by `fm-spawn`.
 Routing precedence is an explicit per-task captain override, then the best-fit configured rule, then the configured default, then the static crewmate harness.
-Firstmate alone resolves a matched profile array: run `quota-axi --json` at that intake, evaluate every configured candidate against that current output, and choose with inspectable effective headroom and usable runway, using pace and reserve only later when needed.
+Firstmate alone resolves a matched profile array: run `quota-axi --json` at that intake and evaluate every configured candidate against that current output.
 Account for every candidate with the catalog evidence, provider relationship, applicable quota and authentication facts, remaining uncertainty, fit and reasoning class, and the headroom, runway, and later pace or reserve evidence used in selection; never omit a candidate, guess, fall back silently, or call the result quota-informed without them.
-Establish model support and provider family from that harness's own authoritative catalog, then read `quota-axi` at the granularity the vendor actually supplies: provider-level or all-model evidence applies to every model established in that family, and a named-model window bounds only that model.
 Missing model-level quota, a missing authentication source, unmeasurable headroom, or unmodeled authentication is disclosed uncertainty that keeps a candidate eligible, never a credential or login escalation.
 Only concrete contradictory evidence blocks a candidate, such as an authoritative catalog proving the model unsupported or proof that the credential selected for that surface is unusable; never infer a credential store, provider family, or quota mapping from a harness, model, or source name, and never launch another harness's CLI to judge a candidate.
 Preserve malformed profile configuration as an actionable error rather than selecting around it.
 When every candidate is tight, preserve the captain's strongest-reasoning class rather than silently downgrading it solely to conserve quota; stop and report the tight choice if that class cannot proceed.
 Break genuine evidence ties without array-order or harness bias.
-`quota-axi` owns how model or product windows relate to bounding account windows and remains data-only.
-Load `quota-array-dispatch` before choosing among a matched profile array; that skill is the single owner of the completion-aware selection procedure.
-The generic effort fallback and its precedence are owned by `harness-adapters`: explicit captain and standing configured effort win; otherwise use low for well-understood explicit work, xhigh for ambiguous investigation or design, intermediate levels proportionally, and never max without explicit captain preference.
-Do not add model-specific versions of that policy.
+Load `quota-array-dispatch` before choosing among a matched profile array; that skill is the single owner of the completion-aware selection procedure, including how to establish the provider relation and read `quota-axi` at the granularity the vendor supplies, and `quota-axi` itself stays data-only.
+The generic effort fallback and its precedence are owned by `harness-adapters`; never select max from that fallback without explicit captain preference, and do not add model-specific versions of that policy.
 
 `secondmate-provisioning` owns secondmate harness pins and inherited local material, while `harness-adapters` owns the harness consequences.
 Dispatch only on a backend that `fm-spawn` validates as spawn-capable; pass an explicit per-spawn `--backend` only under that exact task's own authority, never as later-task precedent (selection contract: [`docs/configuration.md`](docs/configuration.md) "Runtime backend").


### PR DESCRIPTION
## What and why

`AGENTS.md` auto-loads into **every** firstmate and secondmate session (section 12: only `AGENTS.md`, `bin/`, `.agents/skills/` are loaded by a running firstmate), so its token cost is paid on every turn of every fleet member. This is a conservative `/pochisti` pass: it removes **only** content whose owning skill or a sibling section already states in full, and preserves every safety boundary.

This file is a safety contract, so the target was correctness, not a percentage. Realistic savings here are modest by design.

**Before → after:** 67064 → 66259 chars · 9110 → 9009 words · ~16766 → ~16565 est tokens (chars/4) · **−805 chars / −201 est tokens (−1.20%)**. No section heading renumbered (headings are cross-referenced by scripts/tests, e.g. `bin/fm-bootstrap.sh`, `tests/fm-task-delivery.test.sh`).

## Per-section classification (every section gets exactly one verdict)

| # | KB | heading | verdict | evidence / owner |
|---|----|---------|---------|------------------|
| 0 | 0.9 | # Firstmate | keep | address/identity behavioral rules used every turn |
| 1 | 3.5 | 1. Identity and prime directives | keep | hard rules 1–5, all safety |
| 2 | 12.7 | 2. Layout and state | **compact** | removed 1 summary line duplicating the state listing (owner: same section, lines 81–83) |
| 3 | 7.4 | 3. Session start | keep | actionable digest + recovery contract read every session |
| 4 | 4.0 | 4. Harness and runtime dispatch | **compact** | duplicated selection procedure — owners: `quota-array-dispatch` + `harness-adapters` (see below) |
| 5 | 1.3 | 5. Recovery | keep | recovery safety contract |
| 6 | 2.6 | 6. Project and knowledge management | keep | skill triggers + knowledge-routing rules |
| 7 | 14.1 | 7. Task lifecycle | keep | load-bearing delivery/merge/validate/teardown decision contract |
| 8 | 5.3 | 8. Supervision protocol | keep | supervision safety + away-mode stub (already a model inline-stub) |
| 9 | 4.0 | 9. Escalation and captain etiquette | keep | captain-facing translation table, used on every message |
| 10 | 1.8 | 10. Backlog contract | keep | queue safety + note-hygiene rules |
| 11 | 1.4 | 11. Crewmate briefs | keep | brief safety contract |
| 12 | 0.5 | 12. Self-update | keep | update surface + load-order fact |
| 13 | 3.3 | 13. Agent-only reference skills | keep | each row is a skill load trigger |
| 14 | 1.5 | 14. Relay | keep | public-reply consent boundary |
| 15 | 0.9 | Captain instruction precedence | keep | override safety, entire |
| 16 | 0.4 | Maintaining this file | keep | self-governance |

15 of 17 sections are `keep`. Only 2 were touched.

## What was cut, by class

**Class: duplicated (section 4).** `.agents/skills/quota-array-dispatch/SKILL.md:15` *explicitly declares the ownership split*: AGENTS.md section 4 owns the intake boundary, load trigger, malformed-config refusal, every-candidate accounting, and strongest-reasoning/tie safety rules — while the **skill** owns the completion-aware selection procedure and **`harness-adapters`** owns model/provider discovery and the effort fallback. Both owner skills load at the exact decision point (`harness-adapters` before every spawn per section 4; `quota-array-dispatch` before choosing among an array per the same section + section 13), so the restated procedure is a pure duplicate available whenever it applies. Collapsed to pointers:
- provider-relation establishment + quota-granularity rule (was "Establish model support and provider family…") → owned by `quota-array-dispatch` "Establish the provider relation" §, signposted in the retained load-trigger line.
- `quota-axi … remains data-only` → owned by `quota-array-dispatch:17`, signposted in the same line.
- the `191` selection-procedure tail ("choose with inspectable effective headroom and usable runway…") → owned by the skill's Selection order.
- effort fallback enumeration ("low for well-understood…, xhigh for ambiguous…, intermediate levels proportionally…") → owned **verbatim** by `harness-adapters:116-121`.

**Class: duplicated (section 2).** Removed one summary sentence restating the `captain.md` / `captain-shared.md` / `learnings.md` roles (incl. the harness-memory-canonical fact) already spelled out in the state-directory listing directly above it (lines 81–83; `learnings.md` line 83 states "the same contract as captain.md").

No `false-now` and no `historical` content was found; this file is current contract.

## What I deliberately KEPT despite length or apparent duplication

- **Every `never do X` / eligibility line in section 4**, incl. "disclosed uncertainty keeps a candidate eligible, never a credential or login escalation" and "never launch another harness's CLI to judge a candidate." These carry safety flavor and were treated as ambiguous → kept.
- **The never-max guard** ("never select max from that fallback without explicit captain preference") — `bin/fm-spawn.sh:1408` cross-references "AGENTS.md section 4 forbids selecting max without captain preference," so it must stay in section 4. Kept.
- **The verified-harness list and unverified-adapter fallback** (section 4) — `bin/fm-control-lib.sh:62` cross-references "section 4's verified-adapter list." Kept.
- **The full section 2 state listing incl. every `never touch` marker** — it is the agent's navigation map for `state/`; the "never touch" annotations are load-bearing safety. Kept whole (only the one duplicated *summary* line was removed).
- **Section 3's 7-step digest enumeration** — although `bin/fm-session-start.sh`'s header owns the mechanics, the steps are actionable behavioral contract the agent interprets every session (lock-refused mode, OPEN DECISIONS / UNREAD STATUS semantics). Kept.
- **`line 132`** (wake-event-vs-current-state + `fm-crew-state.sh` owner) — a permitted one-line reinforcement at a genuine risk point; kept while removing the adjacent duplicated summary.

## Verification

- Grepped the repo for every removed rule's wording: each surviving copy lives only in its owner (`harness-adapters:119-120`, `quota-array-dispatch:17,47-48`, state listing line 81); no orphaned AGENTS.md fragment remains, and the never-max cross-ref (`fm-spawn.sh:1408`) still resolves.
- All 17 section headings intact; no renumbering.
- `bin/fm-doc-audience-check.sh` → **ok** (68 surfaces, 253 local links).
- `bin/fm-lint.sh` → clean (no script changed).
- `.no-mistakes.yaml` defines no local `commands.test` (it explicitly reserves the full behavior suite for CI); this change is prose-only and touches no script, so no script behavior can change.

## Guard note

`AGENTS.md` size discipline already has an owner: `.agents/skills/firstmate-coding-guidelines/SKILL.md` ("Size discipline" + the knowledge-placement decision tree). No new guard file added — the existing skill is the standing check against regrowth, and this PR does not change it.
