### PR TITLE
docs(agents): collapse §2/§3 restated mechanics to their SSOT owners

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,25 +64,25 @@ README.md            public overview and development notes
 skills/              standalone public installer-facing skills, committed; not loaded by firstmate
 bin/                 helper scripts, committed; read each script's header before first use
 .env                 optional Relay pairing token; LOCAL, gitignored; presence-gates section 14
-config/crew-harness  crewmate harness override; LOCAL, gitignored; absent or "default" = same as firstmate. Inherited as the literal file: a concrete primary adapter value also controls a secondmate home's own crewmates (section 4)
-config/crew-dispatch.json  optional crewmate dispatch profiles; LOCAL, gitignored; firstmate-maintained but human-editable natural-language rules that choose a per-task harness/model/effort profile (section 4). Inherited by secondmate homes
-config/secondmate-harness  harness the PRIMARY uses to launch SECONDMATE agents, optionally followed by a model and effort token on the same line ("<harness> [<model>] [<effort>]"; section 4); LOCAL, gitignored; absent or "default" harness falls back to config/crew-harness then firstmate's own. The primary's own setting; NOT inherited into secondmate homes (secondmates do not spawn secondmates)
-config/backlog-backend  backlog backend override; LOCAL, gitignored; absent or "tasks-axi" = default tasks-axi backend, "manual" = force routine backlog updates to hand-editing; inherited by secondmate homes (section 10)
-config/backend  runtime session-provider backend override for new tasks; LOCAL, gitignored; absent = falls through to runtime auto-detection (the runtime firstmate itself is executing inside), then tmux; tmux is the verified reference backend (docs/tmux-backend.md), while herdr, zellij, orca, and cmux are experimental spawn backends (docs/herdr-backend.md, docs/zellij-backend.md, docs/orca-backend.md, docs/cmux-backend.md) - herdr and cmux can also be selected by runtime auto-detection, zellij and orca never are (always explicit), and codex-app is not accepted; see docs/codex-app-backend.md; inherited by secondmate homes under the primary-authoritative contract in secondmate-provisioning
-config/calm     Pi Calm presentation preference; LOCAL, gitignored, and not inherited; see docs/configuration.md "Pi Calm preference"
-config/startup-memory-budget     primary-authoritative per-home startup-memory budget; LOCAL, gitignored, materialized as 7,500 estimated tokens by locked primary bootstrap and inherited into secondmate homes; see docs/configuration.md "Startup memory budget"
-config/herdr-presentation-spaces  optional "off" opt-out from, or "on" opt-in to, Herdr's default-on disposable single-task visual projection, which is unconfigured-default-on only at or above a Herdr version floor; LOCAL, gitignored; inherited by secondmate homes; see docs/herdr-backend.md "Presentation spaces"
-config/trace-context  optional presence flag enabling default-off native W3C trace-context propagation to spawned agents; LOCAL, gitignored; inherited by secondmate homes; see docs/configuration.md "Trace context propagation" and docs/trace-context.md
-config/cmux-socket-password  optional cmux control-socket password; LOCAL, gitignored; read fresh on every cmux CLI call and passed through without ever overriding an operator's own ambient CMUX_SOCKET_PASSWORD when absent (docs/cmux-backend.md "Setup")
-config/wedge-alarm  optional away-mode wedge-alarm active-alert directives; LOCAL, gitignored; absent means auto (macOS Notification Center when available); see docs/wedge-alarm.md
+config/crew-harness  crewmate/scout harness override; LOCAL, gitignored; absent or "default" = same as firstmate; inherited by secondmate homes (section 4; docs/configuration.md "Harness support" owns the mechanics)
+config/crew-dispatch.json  optional per-task harness/model/effort dispatch rules; LOCAL, gitignored; inherited by secondmate homes (section 4; docs/configuration.md "Crew dispatch profiles")
+config/secondmate-harness  harness (plus optional model/effort) the primary uses to launch secondmates; LOCAL, gitignored; NOT inherited; absent/"default" falls back to config/crew-harness then firstmate's own (section 4; docs/configuration.md "Harness support")
+config/backlog-backend  backlog backend override; LOCAL, gitignored; absent or "tasks-axi" = default, "manual" = force hand-editing; inherited by secondmate homes (section 10; docs/configuration.md "Backlog backend")
+config/backend  runtime session-provider backend for new tasks; LOCAL, gitignored; absent = auto-detect then tmux (the verified reference backend); inherited by secondmate homes (docs/configuration.md "Runtime backend" owns selection and accepted values)
+config/calm     Pi Calm presentation preference; LOCAL, gitignored, not inherited (docs/configuration.md "Pi Calm preference")
+config/startup-memory-budget     per-home startup-memory budget; LOCAL, gitignored; primary-authoritative, inherited by secondmate homes (docs/configuration.md "Startup memory budget")
+config/herdr-presentation-spaces  optional "off"/"on" override for Herdr's default-on single-task visual projection; LOCAL, gitignored; inherited by secondmate homes (docs/herdr-backend.md "Presentation spaces")
+config/trace-context  presence flag enabling default-off trace-context propagation to spawned agents; LOCAL, gitignored; inherited by secondmate homes (docs/configuration.md "Trace context propagation"; docs/trace-context.md)
+config/cmux-socket-password  optional cmux control-socket password; LOCAL, gitignored; never overrides an ambient CMUX_SOCKET_PASSWORD (docs/cmux-backend.md "Setup")
+config/wedge-alarm  optional away-mode wedge-alarm active-alert directives; LOCAL, gitignored; absent means auto (docs/wedge-alarm.md)
 config/x-mode.env    generated Relay watcher cadence; LOCAL, gitignored; source before arming watcher when present
 data/                personal fleet records; LOCAL, gitignored as a whole
   backlog.md         task queue, dependencies, history
   captain.md         this home's domain-local captain preferences and working style; LOCAL, gitignored, canonical even if harness memory mirrors it, and updated with inspect-then-update
   captain-shared.md  main-authoritative shared captain preferences propagated read-only to secondmate homes; LOCAL, gitignored, owned by secondmate-provisioning
   learnings.md       fleet-local operational facts and gotchas; LOCAL, gitignored; dated, evidence-backed, curated, and updated with inspect-then-update - rewrite and prune rather than append forever, the same contract as captain.md; created lazily, absent until this home has a learning to store
-  projects.md        thin fleet navigation registry recording each project's standing delivery posture; firstmate-private, parsed for mechanical sync and seeding by fm-project-mode.sh (section 6)
-  secondmates.md      local and remote secondmate routing table; firstmate-private, maintained by the secondmate seed helpers (section 6)
+  projects.md        thin fleet navigation registry of each project's standing delivery posture; firstmate-private (section 6)
+  secondmates.md      local and remote secondmate routing table; firstmate-private (section 6)
   <id>/brief.md      per-task crewmate brief, or per-secondmate charter brief when kind=secondmate
   <id>/report.md     scout task deliverable, written by the crewmate; survives teardown
 projects/            cloned repos; gitignored; read-only except under hard rule 1's concrete captain-approved project operation exception
@@ -104,7 +104,7 @@ state/               runtime records and signals; gitignored
   .pr-check-migration.log  private per-task outcomes distinguishing rebuilt or canonically registered replacement polls, quarantined unarmed polls, and incomplete migrations
   .pr-check-migration-scan-v1  private marker proving the non-executing scan disabled every unsafe legacy check; .pr-check-migration-v1 separately records completed private repairs
   x-watch.check.sh   generated Relay poll shim; present only when opted in (section 14)
-  pending-replies/   parent-owned secondmate pending-reply records (correlation id, delivery vs reply, recovery, escalation); fm-pending-reply-lib.sh
+  pending-replies/   parent-owned secondmate pending-reply records; fm-pending-reply-lib.sh
   procevent/         registered process-to-event sources, one private record per canonical source id; written only by bin/fm-procevent.sh, and their presence alone keeps supervision required (section 13)
   procevent-inbox/   private captured results and their durable handled-acknowledgement markers; source output lives here and never in an event line
   when/              private condition->action watch specs, their trust bindings, and single-fire markers; written only by bin/fm-procevent-when.sh (section 13's process-event-sources trigger)
@@ -113,7 +113,7 @@ state/               runtime records and signals; gitignored
   x-outbox/          generated Relay dry-run reply and dismiss previews; inspect it when FMX_DRY_RUN is set (section 14)
   public-followup/   generated private transport for promised public replies: commitment registrations, typed terminal-result inbox, accepted/rejected ledgers (section 14; bin/fm-public-followup.sh)
   x-poll.error x-poll.claim-error  generated Relay and offer-claim diagnostic dedupe markers
-  .startup-network.*  status, report, per-step elapsed timings, inline-print claim, and lock for the deferred network stage session start runs off its blocking path; bin/fm-startup-network.sh
+  .startup-network.*  deferred network-stage state kept off the session-start blocking path; bin/fm-startup-network.sh
   .wake-queue        durable queued wakes retained until post-handling acknowledgement: epoch<TAB>seq<TAB>kind<TAB>key<TAB>payload
   .watcher-down      private generation-bound recovery state coupling watcher downtime, durable wake presentation, and post-handling acknowledgement; never touch
   .<id>.open-decisions-cursor  per-task byte cursor and folded open-decision set bounding the OPEN DECISIONS scan's cost to new status-log appends; written only by fm-classify-lib.sh's status_open_decisions_incremental, removed by teardown, safe to delete (forces one full re-fold)
@@ -152,25 +152,13 @@ The digest itself makes no external-network call and never waits for one.
 Every network check a session start owes - GitHub auth, dead-secondmate relaunch, secondmate convergence, pending handoff delivery, and project clone refresh - runs concurrently in a bounded worker owned by `bin/fm-startup-network.sh` and is reported in the digest's own `NETWORK CHECKS` section.
 When that section reports its checks still in progress it names exactly what is unconfirmed; treat none of those as passed until the result lands, either from `bin/fm-startup-network.sh report` or as a `check: startup-network` wake.
 
-1. **Lock** - acquires the per-home session lock first, before anything mutates shared state, then starts the deferred network stage above.
-2. **Bootstrap** - detect-only checks (tool/version problems, the worktree-tangle check, harness override, dispatch-profile validation, backlog-backend status) always run, but routine confirmations stay silent by default.
-   When the lock could not be acquired, the worktree-tangle check uses read-only advisory wording without a checkout repair command.
-   Home-local stale Herdr projection cleanup and the six bootstrap MUTATING sweeps - non-executing legacy PR-check migration, fleet sync, secondmate convergence, secondmate liveness, pending remote handoff retry, and Relay artifact writes - run only when this session actually holds the lock from step 1; the four network ones among them run in the deferred stage rather than in this section.
-   The secondmate liveness sweep deterministically accounts for every registered secondmate: it relaunches only from the recovery-grade `dead` or `missing` states, preserves ambiguous, unreadable, or unreachable remote targets, and reports skipped or failed guarantees as `SECONDMATE_LIVENESS:` lines (`bin/fm-bootstrap.sh`; `bin/fm-backend.sh`'s `fm_backend_agent_state`; `docs/remote-secondmates.md`).
-3. **Wake queue** - when locked, presents the durable wake queue and prints the raw records prominently as this turn's first work queue; a clearly labeled status-event annotation may follow a valid `signal` record and includes every status line still unread at the presentation cursor, but never replaces the raw record or current-state reconciliation, and a lapsed watcher chain still surfaces here via the same guard alarm.
-   Presented records remain durable until the handling turn runs the generation-bound acknowledgement printed by the drain.
-   Every locked drain also prints a bounded fleet-wide `OPEN DECISIONS` section when durable decision records remain open, including when the queue itself is empty; reconcile those entries before continuing.
-   The same drain prints every still-unread `note:` line and pending-reply resolution since the last presentation in an unbounded `UNREAD STATUS` section, so an answer buried under a later routine line is not dropped; those lines are not re-printed after that presentation.
-   When the lock could not be acquired and verified, the queue is left untouched because no session mutation is authorized, and the guard's tangle/watcher-liveness alarms still print in read-only advisory mode without drain, supervision repair, or checkout repair commands.
-4. **Supervision operating instructions** - after the wake queue and before both digests, the digest emits exactly one operating block for the detected primary harness, followed by the read-once contract that governs them.
-   The script itself never starts supervision; the emitted harness protocol owns the exact wait or wake mechanism.
-5. **Fleet-state digest** - after that read-once contract and ahead of the context digest, the compact backlog listing owned by `bin/fm-session-start.sh`; every `state/<id>.meta`; a bounded tail of each task's `state/<id>.status` (labeled as wake-EVENT history, not current state, with the full log path printed for a deeper read); the `state/.afk` flag; and one cheap alive/dead read of each task's recorded backend endpoint.
-   That liveness line is a fast presence check only, not a full state read - when you need a crew's actual current state (a run-step, not just "is the pane there"), read it with `bin/fm-crew-state.sh <id>` as before; the digest deliberately skips that deeper, slower read for every task so it stays fast and bounded.
-6. **Network checks** - after the fleet-state digest, the deferred stage's result, or an explicit statement of what it has not confirmed yet.
-   A read-only session runs no network checks at all and says so.
-7. **Context digest and next step** - last of the bulk sections, the full contents of `data/projects.md`, `data/secondmates.md`, `data/captain.md`, `data/captain-shared.md`, and `data/learnings.md`, each clearly delimited, followed by the closing reminder.
-   A file that does not exist prints an explicit `ABSENT` marker, never confused with an empty-but-present file: absence is meaningful (`captain.md` absent means use the firstmate repo's built-in defaults, `projects.md` absent means rebuild it from the clones under `projects/`, etc.).
-   The closing reminder points back to the emitted supervision block and preserves only the lock, afk, Relay, and read-once reminders.
+`bin/fm-session-start.sh`'s header owns the exact stage ordering and every digest section's contents; the operator invariants that must survive that pointer are these.
+The session lock is acquired first, before any mutating step: bootstrap's detect-only diagnostics always run, but its mutating sweeps and every network check run only when this session holds the lock, and a lock-refused session stays read-only per the rule above.
+When locked, the digest presents the durable wake queue once as this turn's first work queue, together with any `OPEN DECISIONS` and `UNREAD STATUS` sections; when lock-refused it leaves the queue untouched.
+Section 8 owns handling, reconciling, and acknowledging those sections and their durability.
+The digest emits exactly one supervision operating block for the detected primary harness; that emitted protocol owns the wait or wake mechanism, and the script never starts supervision itself.
+The fleet-state digest's endpoint line is a fast presence check only; read `bin/fm-crew-state.sh <id>` when a task's actual current state matters.
+A missing source prints an explicit `ABSENT` marker whose meaning is defined above, and a read-only session runs no network checks and says so.
 
 Bootstrap detects first, asks for consent, and installs only after the captain approves in the current session.
 Do not dispatch until the required tools are present and GitHub authentication is good.


### PR DESCRIPTION
## What

SSOT pointer-collapse of the restated mechanics in **AGENTS.md §2 (Layout and state)** and **§3 (Session start)** only. Every other section is byte-for-byte unchanged (`git diff` touches lines 67-78, 84-85, 107, 116 in §2 and 155-173 in §3).

## Before → after

| Section | Before | After | Δ |
|---|---|---|---|
| §2 Layout and state | 13,049 B (~3,260 tok) | 11,815 B (~2,950 tok) | −1,234 B (~−9.5%) |
| §3 Session start | 7,627 B (~1,910 tok) | 4,279 B (~1,070 tok) | −3,348 B (~−44%) |
| whole file | 568 lines | 556 lines | −12 lines |

## The lever

§2's own intro already names the owner ("`docs/configuration.md` is the single owner … each producing script's header and help own exact child fields and mutation mechanics") and §3's intro already names "`bin/fm-session-start.sh` … the single owner of composed commands, ordering, and digest contents." The per-entry field-lists and the 7-step digest enumeration were duplicating those owners. This collapses that duplication to a pointer while keeping the map usable and every safety note.

## Pointers introduced (each verified to contain the moved content)

§2 config/data/state entries — each keeps its one-line purpose + every safety flag; mechanics point to:

- `config/crew-harness`, `config/secondmate-harness` → `docs/configuration.md` "Harness support" (owns default-mirroring, the secondmate-crewmate inheritance, the fallback chain, and "not inherited because secondmates do not launch secondmates").
- `config/crew-dispatch.json` → `docs/configuration.md` "Crew dispatch profiles".
- `config/backlog-backend` → `docs/configuration.md` "Backlog backend".
- `config/backend` → `docs/configuration.md` "Runtime backend" (owns selection order and accepted/rejected values incl. codex-app rejection).
- `config/calm`, `config/startup-memory-budget`, `config/trace-context` → `docs/configuration.md` "Pi Calm preference" / "Startup memory budget" / "Trace context propagation".
- `config/herdr-presentation-spaces` → `docs/herdr-backend.md` "Presentation spaces"; `config/cmux-socket-password` → `docs/cmux-backend.md` "Setup"; `config/wedge-alarm` → `docs/wedge-alarm.md`.
- `data/projects.md`, `data/secondmates.md` → section 6 (dropped "parsed/maintained by <script>" provenance).
- `state/pending-replies/` → `fm-pending-reply-lib.sh` + `docs/configuration.md` (dropped the field list); `state/.startup-network.*` → `fm-startup-network.sh` (dropped the field list).

§3 — the 7-step digest enumeration → `bin/fm-session-start.sh`'s header, which owns the exact ordering and each section's contents (its header even states it "Collapses AGENTS.md sections 3 and 5 into ONE script"). The step narration duplicated the wake-queue handling contract, which **section 8** owns (drain, OPEN DECISIONS, UNREAD STATUS, `--ack-through` durability).

## Invariants preserved (not dropped)

- Lock acquired first; mutating sweeps and network checks run only when locked; a lock-refused session stays read-only (also §3 line 149) and runs no network checks.
- The digest presents the durable wake queue once; section 8 owns handling and acknowledgement.
- Exactly one supervision block is emitted; the script never starts supervision itself.
- Endpoint liveness is a presence check only — use `bin/fm-crew-state.sh` for real state.
- `ABSENT` marker semantics kept above (§3 line 146).

## Safety confirmation

Safety-token counts across the changed §2/§3 region are unchanged: `LOCAL, gitignored` 17→17, `never touch` 5→5, `NOT inherited`/`not inherited` preserved, `firstmate-private` 2→2, and the `bin/fm-send.sh` **fails closed** note is intact. The only two removed safety-token occurrences are guard-output UX ("read-only advisory" wording) and sweep mechanics ("skipped or failed guarantees" for `SECONDMATE_LIVENESS`), both owned by `bin/fm-bootstrap.sh` and routed via `bootstrap-diagnostics`; the lock-refused read-only invariant they described is fully retained at §3 line 149. Every "never touch" / security / trust / quarantine / provenance line in the `state/` tree (check.sh, procevent, pr-poll-*, autoarm/cursor internals) is verbatim.

## Verification

- `git diff` confined to §2/§3; all other sections identical.
- Every retired phrase grep-confirmed present in its named owner.
- `bin/fm-doc-audience-check.sh` → ok (68 surfaces, 253 local links).
- `bin/fm-lint.sh` → clean (no changed lint targets).
- No test asserts the changed prose (tests use those config files as runtime inputs only, never as AGENTS.md text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEwdqRzwcC2Zmrk6SrbST1
