### PR TITLE
Add support for omp (Oh My Pi) as a primary harness

### DIFF
--- a/.pi/extensions/fm-primary-omp-turnend-guard.ts
+++ b/.pi/extensions/fm-primary-omp-turnend-guard.ts
@@ -1,0 +1,259 @@
+import { spawn, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
+import {
+  classifyFirstmateCurrentOperationalText,
+  encodeFirstmateOperationalInput,
+} from "./lib/fm-operational-input.ts";
+
+let guardFollowupActive = false;
+
+type LockOwnership = "owned" | "missing" | "other";
+
+const extensionFile = fileURLToPath(import.meta.url);
+const extensionDir = dirname(extensionFile);
+const root = resolve(extensionDir, "../..");
+const fmHome = process.env.FM_HOME || process.env.FM_ROOT_OVERRIDE || root;
+const state = process.env.FM_STATE_OVERRIDE || `${fmHome}/state`;
+const marker = `${state}/.omp-turnend-extension-loaded`;
+const extensionVersion = `sha256:${createHash("sha256").update(readFileSync(extensionFile)).digest("hex")}`;
+
+function parentPid(pid: string): string {
+  const result = spawnSync("ps", ["-o", "ppid=", "-p", pid], { encoding: "utf8" });
+  if (result.status !== 0) return "";
+  return result.stdout.trim();
+}
+
+function pidAlive(pid: string): boolean {
+  try {
+    process.kill(Number(pid), 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function lockOwnership(): LockOwnership {
+  let lockPid = "";
+  try {
+    lockPid = readFileSync(`${state}/.lock`, "utf8").trim();
+  } catch {
+    return "missing";
+  }
+  if (!/^[0-9]+$/.test(lockPid) || lockPid === "1") return "other";
+  let pid = String(process.pid);
+  for (let i = 0; i < 8; i += 1) {
+    if (pid === lockPid) return "owned";
+    pid = parentPid(pid);
+    if (!pid || pid === "1") break;
+  }
+  return pidAlive(lockPid) ? "other" : "missing";
+}
+
+function markLoaded(): void {
+  if (!existsSync(state) || lockOwnership() === "other") return;
+  writeFileSync(marker, `${extensionVersion}\n${process.pid}\n`);
+}
+
+// omp fires session_start on initial load (no reason field) and session_switch
+// (reason: new|resume|fork|handoff) for same-process replacements. A separate
+// session_compact event fires after a compaction. "new" is omp's /clear while
+// resume, fork, and handoff all keep prior context.
+const sessionstartDeliveryBytes = 512 * 1024;
+
+type SessionStartContext = {
+  sessionManager?: {
+    getHeader?: () => { timestamp?: unknown } | null | undefined;
+  };
+};
+
+function restoredSessionEvidence(ctx: SessionStartContext): boolean {
+  try {
+    const timestamp = ctx.sessionManager?.getHeader?.()?.timestamp;
+    const createdAt = typeof timestamp === "string" ? Date.parse(timestamp) : Number.NaN;
+    return Number.isFinite(createdAt) && createdAt < performance.timeOrigin;
+  } catch {
+    return false;
+  }
+}
+
+function startupRebuildSource(ctx: SessionStartContext): "resume" | "fork" | undefined {
+  const args = process.argv.slice(2);
+  const restored = restoredSessionEvidence(ctx);
+  for (const arg of args) {
+    if (arg === "--fork" || arg.startsWith("--fork=")) return "fork";
+    if (
+      restored && (
+        arg === "-c" || arg === "--continue" ||
+        arg === "-r" || arg === "--resume" ||
+        arg === "--session" || arg.startsWith("--session=") ||
+        arg === "--session-id" || arg.startsWith("--session-id=")
+      )
+    ) return "resume";
+  }
+  return undefined;
+}
+const sessionstartTruncatedMarker =
+  "\n\nOMP SESSION-START DELIVERY TRUNCATED - the digest exceeded 512 KiB. " +
+  "Treat omitted context as unread and inspect the named files directly before acting on it.";
+
+function runSessionstartHook(source: string): Promise<string> {
+  return new Promise((resolveResult) => {
+    const child = spawn(`${root}/bin/fm-sessionstart-run.sh`, ["--source", source], {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const chunks: Buffer[] = [];
+    let retainedBytes = 0;
+    let truncated = false;
+    child.stdout.on("data", (chunk: Buffer) => {
+      if (retainedBytes >= sessionstartDeliveryBytes) {
+        truncated = true;
+        return;
+      }
+      const remaining = sessionstartDeliveryBytes - retainedBytes;
+      const retained = chunk.length <= remaining ? chunk : chunk.subarray(0, remaining);
+      chunks.push(retained);
+      retainedBytes += retained.length;
+      if (retained.length !== chunk.length) truncated = true;
+    });
+    child.on("error", () => resolveResult(""));
+    child.on("close", (code) => {
+      if (code !== 0) {
+        resolveResult("");
+        return;
+      }
+      const raw = Buffer.concat(chunks).toString("utf8").trim();
+      resolveResult(truncated ? `${raw}${sessionstartTruncatedMarker}` : raw);
+    });
+  });
+}
+
+async function injectSessionstart(pi: ExtensionAPI, source: string): Promise<void> {
+  const raw = await runSessionstartHook(source);
+  if (!raw) return;
+  try {
+    // Pi is the only adapter that injects a MESSAGE rather than hook stdout, so
+    // whatever it injects must carry operational provenance or the Ahoy skill
+    // would have to guess whether it was captain-authored. The wrapper already
+    // returns an encoded nudge on a context-preserving open, so only an
+    // unencoded digest needs the marker added here.
+    const content = classifyFirstmateCurrentOperationalText(raw)
+      ? raw
+      : encodeFirstmateOperationalInput("session-start", raw);
+    pi.sendMessage({
+      customType: "firstmate-sessionstart-nudge",
+      content,
+      display: false,
+      details: { kind: "session-start" },
+    });
+  } catch {
+  }
+}
+
+function runGuard(): Promise<{ code: number; stderr: string }> {
+  return new Promise((resolveResult) => {
+    const child = spawn(`${root}/bin/fm-turnend-guard.sh`, {
+      stdio: ["pipe", "ignore", "pipe"],
+    });
+    let stderr = "";
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", () => resolveResult({ code: 0, stderr: "" }));
+    child.on("close", (code) => resolveResult({ code: code ?? 0, stderr }));
+    child.stdin.end('{"stop_hook_active":false}');
+  });
+}
+
+// PreToolUse seatbelts (bin/fm-arm-pretool-check.sh, docs/arm-pretool-check.md;
+// bin/fm-cd-pretool-check.sh, docs/cd-guard.md). Both piggyback on this same
+// extension file rather than separate ones so no extra Pi -e flag is needed at
+// launch - the primary already loads this file for the turn-end guard, and
+// pi.on("tool_call", ...) can block (verified 2026-07-09 against pi 0.80.5:
+// returning {block: true} prevents the bash command from running). Each owner
+// script owns its own decision and is inert outside the real primary checkout.
+function runChecker(script: string, command: string): Promise<{ code: number; stderr: string }> {
+  return new Promise((resolveResult) => {
+    const child = spawn(`${root}/bin/${script}`, ["--command", command], {
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    let stderr = "";
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", () => resolveResult({ code: 0, stderr: "" }));
+    child.on("close", (code) => resolveResult({ code: code ?? 0, stderr }));
+  });
+}
+
+function runPretoolCheck(command: string): Promise<{ code: number; stderr: string }> {
+  return runChecker("fm-arm-pretool-check.sh", command);
+}
+
+function runCdCheck(command: string): Promise<{ code: number; stderr: string }> {
+  return runChecker("fm-cd-pretool-check.sh", command);
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.on?.("session_start", async (_event, ctx) => {
+    // Initial load only (omp fires session_switch for /new, /resume, /fork).
+    const source = startupRebuildSource(ctx as SessionStartContext) ?? "startup";
+    markLoaded();
+    await injectSessionstart(pi, source);
+  });
+  pi.on?.("session_switch", async (event) => {
+    // Same-process replacement (/new, /resume, /fork, handoff).
+    const reason = event.reason;
+    const source = { new: "clear", resume: "resume", fork: "fork", handoff: "resume" }[reason];
+    markLoaded();
+    if (!source) return;
+    await injectSessionstart(pi, source);
+  });
+
+  // Pi's compaction equivalent. The digest is what a compacted session has just
+  // lost, so re-emitting it here is the point rather than a side effect.
+  pi.on?.("session_compact", async () => {
+    await injectSessionstart(pi, "compact");
+  });
+
+  pi.on("tool_call", async (event) => {
+    if (event.type !== "tool_call" || event.toolName !== "bash") return {};
+    const command = String((event.input as { command?: unknown })?.command ?? "");
+    if (!command) return {};
+    const cdResult = await runCdCheck(command);
+    if (cdResult.code === 2) {
+      return { block: true, reason: cdResult.stderr.trim() || "denied by the cd-guard PreToolUse seatbelt" };
+    }
+    const result = await runPretoolCheck(command);
+    if (result.code !== 2) return {};
+    return { block: true, reason: result.stderr.trim() || "denied by the watcher-arm PreToolUse seatbelt" };
+  });
+
+  pi.on?.("session_stop", async () => {
+    if (guardFollowupActive) {
+      guardFollowupActive = false;
+      return;
+    }
+
+    const result = await runGuard();
+    if (result.code !== 2) return;
+
+    guardFollowupActive = true;
+    try {
+      const content = encodeFirstmateOperationalInput(
+        "turn-end-guard",
+        "TURN WOULD END BLIND - supervision is off. " +
+          "The watcher cycle is missing, failed, or unhealthy. Follow the harness recovery instruction below before ending the turn.\n\n" +
+          result.stderr,
+      );
+      await pi.sendUserMessage(content, { deliverAs: "followUp" });
+    } catch {
+      guardFollowupActive = false;
+    }
+  });
+
+  markLoaded();
+}

--- a/.pi/extensions/fm-primary-omp-watch.ts
+++ b/.pi/extensions/fm-primary-omp-watch.ts
@@ -1,0 +1,544 @@
+// Firstmate primary watcher bridge for omp (Oh My Pi).
+//
+// Session-generation ownership (stated once here):
+// omp emits session_switch (reason new/resume/fork/handoff) for ordinary
+// same-process replacements and session_shutdown for terminal quit only. This
+// extension binds one generation per session activation. Only the active live
+// generation may start, stop, rearm, or clear the arm child. A session_switch
+// (or session_start, or a fresh factory bind) activates a new live generation so
+// monitoring can arm again without restarting omp. Terminal quit leaves the final
+// generation stopped so late callbacks cannot rearm; stale callbacks are no-ops.
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ExtensionAPI, Theme } from "@oh-my-pi/pi-coding-agent";
+import { Box, Container, Text, type Component } from "@oh-my-pi/pi-tui";
+import {
+  type CalmPresentationState,
+  calmTranscriptClassIsVisible,
+  FIRSTMATE_CALM_PRESENTATION_EVENT,
+} from "./lib/fm-calm-visibility-omp.ts";
+import { encodeFirstmateOperationalInput } from "./lib/fm-operational-input.ts";
+
+type ArmResult = {
+  ok: boolean;
+  message: string;
+};
+
+type LockOwnership = "owned" | "missing" | "other";
+
+type CloseClassification = {
+  kind: "actionable" | "failure";
+  message: string;
+};
+
+type WatchToolShellState = {
+  shell?: Box;
+  call?: Component;
+  result?: Component;
+};
+
+type WatchToolRenderContext = {
+  isError: boolean;
+  isPartial: boolean;
+};
+
+type SessionGeneration = {
+  id: number;
+  stopping: boolean;
+  child: ChildProcess | null;
+  retryTimer: ReturnType<typeof setTimeout> | null;
+  retryFailures: number;
+  restoring: boolean;
+  seq: number;
+};
+
+function refreshWatchToolShell(
+  state: WatchToolShellState,
+  theme: Theme,
+  context: WatchToolRenderContext,
+): Box {
+  const background = context.isPartial
+    ? (text: string) => theme.bg("toolPendingBg", text)
+    : context.isError
+      ? (text: string) => theme.bg("toolErrorBg", text)
+      : (text: string) => theme.bg("toolSuccessBg", text);
+  const shell = state.shell ?? new Box(1, 1, background);
+  state.shell = shell;
+  shell.setBgFn(background);
+  shell.clear();
+  if (state.call) shell.addChild(state.call);
+  if (state.result) shell.addChild(state.result);
+  return shell;
+}
+
+const extensionFile = fileURLToPath(import.meta.url);
+const extensionDir = dirname(extensionFile);
+const root = resolve(extensionDir, "../..");
+const fmHome = process.env.FM_HOME || process.env.FM_ROOT_OVERRIDE || root;
+const fmRoot = process.env.FM_ROOT_OVERRIDE || root;
+const state = process.env.FM_STATE_OVERRIDE || `${fmHome}/state`;
+const config = process.env.FM_CONFIG_OVERRIDE || `${fmHome}/config`;
+const armScript = `${fmRoot}/bin/fm-watch-arm.sh`;
+const marker = `${state}/.omp-watch-extension-loaded`;
+const extensionVersion = `sha256:${createHash("sha256").update(readFileSync(extensionFile)).digest("hex")}`;
+const retryBaseMs = positiveInteger("FM_WATCH_REARM_RETRY_BASE_MS", 250);
+const retryMaxMs = positiveInteger("FM_WATCH_REARM_RETRY_MAX_MS", 4000);
+const retryLimit = positiveInteger("FM_WATCH_REARM_RETRY_LIMIT", 5);
+// 35s on Windows so the budget stays above arm's MSYS confirm default (30s in
+// bin/fm-watch-arm.sh): a slow but successful Git Bash cold start must not be
+// SIGTERMed mid-confirmation. Conditioned on win32 so other platforms keep 12s.
+const armReadyTimeoutMs = positiveInteger(
+  "FM_PI_ARM_READY_TIMEOUT_MS",
+  process.platform === "win32" ? 35000 : 12000,
+);
+const armRetireTimeoutMs = positiveInteger("FM_WATCH_ARM_RETIRE_TIMEOUT_MS", 1000);
+const repairOnlyHint = "call fm_watch_arm_omp again only after a later notification says the cycle is missing, failed, or unhealthy";
+const shuttingDownMessage = "watcher: not armed - omp session is shutting down";
+
+let nextGenerationId = 0;
+let activeGeneration: SessionGeneration | null = null;
+const armReadiness = new WeakMap<ChildProcess, Promise<boolean>>();
+const armClose = new WeakMap<ChildProcess, Promise<void>>();
+const armRecovery = new WeakMap<ChildProcess, { generation: string; watcherPid: string }>();
+
+function positiveInteger(name: string, fallback: number): number {
+  const value = Number(process.env[name]);
+  if (!Number.isFinite(value) || value <= 0) return fallback;
+  return Math.floor(value);
+}
+
+function parentPid(pid: string): string {
+  const result = spawnSync("ps", ["-o", "ppid=", "-p", pid], { encoding: "utf8" });
+  if (result.status !== 0) return "";
+  return result.stdout.trim();
+}
+
+function pidAlive(pid: string): boolean {
+  try {
+    process.kill(Number(pid), 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function lockOwnership(): LockOwnership {
+  let lockPid = "";
+  try {
+    lockPid = readFileSync(`${state}/.lock`, "utf8").trim();
+  } catch {
+    return "missing";
+  }
+  if (!/^[0-9]+$/.test(lockPid) || lockPid === "1") return "other";
+  let pid = String(process.pid);
+  for (let i = 0; i < 8; i += 1) {
+    if (pid === lockPid) return "owned";
+    pid = parentPid(pid);
+    if (!pid || pid === "1") break;
+  }
+  return pidAlive(lockPid) ? "other" : "missing";
+}
+
+function markLoaded(): void {
+  if (lockOwnership() === "other") return;
+  mkdirSync(state, { recursive: true });
+  writeFileSync(marker, `${extensionVersion}\n${process.pid}\n`);
+}
+
+function actionableLine(output: string): string {
+  const lines = output.split(/\r?\n/);
+  return lines.find((line) => /^(signal:|stale:|check:|heartbeat($|:))/.test(line)) || "";
+}
+
+function classifyClose(stdout: string, stderr: string, code: number | null, signal: NodeJS.Signals | null): CloseClassification {
+  const combined = `${stdout}\n${stderr}`.trim();
+  const reason = actionableLine(combined);
+  if (reason) return { kind: "actionable", message: reason };
+  const healthy = combined.split(/\r?\n/).find((line) => /^watcher: healthy\b/.test(line));
+  if (healthy) {
+    return {
+      kind: "failure",
+      message: `watcher: FAILED - omp extension arm child found an external healthy watcher instead of owning wake delivery\n${healthy}`,
+    };
+  }
+  const failed = combined.split(/\r?\n/).find((line) => /^watcher: FAILED/.test(line));
+  if (failed) return { kind: "failure", message: failed };
+  if (signal) {
+    return {
+      kind: "failure",
+      message: `watcher: FAILED - omp extension arm child ended from ${signal}${combined ? `\n${combined}` : ""}`,
+    };
+  }
+  if (code && code !== 0) {
+    return {
+      kind: "failure",
+      message: `watcher: FAILED - fm-watch-arm.sh exited ${code}${combined ? `\n${combined}` : ""}`,
+    };
+  }
+  return {
+    kind: "failure",
+    message: "watcher: FAILED - omp extension arm cycle ended without an actionable reason",
+  };
+}
+
+function createGeneration(): SessionGeneration {
+  return {
+    id: ++nextGenerationId,
+    stopping: false,
+    child: null,
+    retryTimer: null,
+    retryFailures: 0,
+    restoring: false,
+    seq: 0,
+  };
+}
+
+function activateGeneration(generation: SessionGeneration): void {
+  activeGeneration = generation;
+}
+
+function generationIsLive(generation: SessionGeneration): boolean {
+  return activeGeneration === generation && !generation.stopping;
+}
+
+function stopGeneration(generation: SessionGeneration): void {
+  generation.stopping = true;
+  if (generation.retryTimer) clearTimeout(generation.retryTimer);
+  generation.retryTimer = null;
+  if (generation.child) generation.child.kill("SIGTERM");
+  generation.child = null;
+}
+
+const cleanupOnProcessExit = () => {
+  if (activeGeneration) stopGeneration(activeGeneration);
+};
+process.once("exit", cleanupOnProcessExit);
+
+export default function (pi: ExtensionAPI) {
+  let generation = createGeneration();
+  activateGeneration(generation);
+
+  let calmPresentation: CalmPresentationState = {
+    active: false,
+    stockExportRendering: false,
+  };
+  pi.events?.on?.(FIRSTMATE_CALM_PRESENTATION_EVENT, (data) => {
+    const next = data as Partial<CalmPresentationState>;
+    calmPresentation = {
+      active: next.active === true,
+      stockExportRendering: next.stockExportRendering === true,
+    };
+  });
+  const calmHides = (itemClass: Parameters<typeof calmTranscriptClassIsVisible>[0]): boolean =>
+    calmPresentation.active &&
+    !calmPresentation.stockExportRendering &&
+    !calmTranscriptClassIsVisible(itemClass);
+
+  async function sendWake(
+    owner: SessionGeneration,
+    message: string,
+    recovery?: { generation: string; watcherPid: string },
+  ): Promise<void> {
+    if (!generationIsLive(owner)) return;
+    const content = encodeFirstmateOperationalInput(
+      "watcher",
+      `FIRSTMATE WATCHER WAKE: ${message}\n\nRun bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.`,
+    );
+    await pi.sendUserMessage(content, { deliverAs: "followUp" });
+    if (recovery) {
+      const result = spawnSync(
+        "bash",
+        [armScript, "--handling-delivered", recovery.generation, "--watcher-pid", recovery.watcherPid],
+        {
+          cwd: fmRoot,
+          env: { ...process.env, FM_HOME: fmHome, FM_STATE_OVERRIDE: state, FM_ROOT_OVERRIDE: fmRoot },
+        },
+      );
+      if (result.status !== 0) throw new Error("watcher recovery delivery could not be confirmed");
+    }
+  }
+
+  function surfaceFailure(owner: SessionGeneration, message: string): void {
+    void sendWake(owner, message).catch(() => {
+      // omp owns delivery errors; continuity restoration never waits on prompting.
+    });
+  }
+
+  function retryDelay(attempt: number): number {
+    return Math.min(retryMaxMs, retryBaseMs * 2 ** Math.max(0, attempt - 1));
+  }
+
+  function waitForRetry(attempt: number): Promise<void> {
+    return new Promise((resolveRetry) => {
+      const timer = setTimeout(resolveRetry, retryDelay(attempt));
+      timer.unref();
+    });
+  }
+
+  function waitForReadiness(armChild: ChildProcess): Promise<boolean> {
+    const readiness = armReadiness.get(armChild);
+    if (!readiness) return Promise.resolve(false);
+    return new Promise((resolveReady) => {
+      const timer = setTimeout(() => resolveReady(false), armReadyTimeoutMs);
+      timer.unref();
+      void readiness.then((ready) => {
+        clearTimeout(timer);
+        resolveReady(ready);
+      });
+    });
+  }
+
+  async function retireArm(armChild: ChildProcess | null): Promise<boolean> {
+    if (!armChild) return true;
+    armChild.kill("SIGTERM");
+    const closed = armClose.get(armChild);
+    if (!closed) return false;
+    return new Promise((resolveRetired) => {
+      const timer = setTimeout(() => resolveRetired(false), armRetireTimeoutMs);
+      timer.unref();
+      void closed.then(() => {
+        clearTimeout(timer);
+        resolveRetired(true);
+      });
+    });
+  }
+
+  async function restoreAfterActionableClose(owner: SessionGeneration, predecessorArmPid: string): Promise<{
+    failure: string;
+    recovery?: { generation: string; watcherPid: string };
+  }> {
+    let failure = "";
+    for (let attempt = 0; attempt <= retryLimit; attempt += 1) {
+      if (!generationIsLive(owner)) return { failure: "" };
+      const replacement = startArm(owner, predecessorArmPid);
+      const successorChild = owner.child;
+      if (replacement.ok && successorChild && await waitForReadiness(successorChild)) {
+        return { failure: "", recovery: armRecovery.get(successorChild) };
+      }
+      if (replacement.ok) {
+        failure = "watcher: FAILED - omp extension could not verify a ready successor watcher";
+        if (!(await retireArm(successorChild))) {
+          return {
+            failure: `${failure}\nwatcher: FAILED - omp extension could not restore watcher continuity because the unready successor arm did not exit within ${armRetireTimeoutMs}ms`,
+          };
+        }
+      } else {
+        failure = /(?:read-only|no live session)/.test(replacement.message)
+          ? `watcher: FAILED - omp extension cannot restore continuity because this session no longer owns the lock\n${replacement.message}`
+          : `watcher: FAILED - omp extension could not start the successor watcher cycle\n${replacement.message}`;
+        if (/(?:read-only|no live session)/.test(replacement.message)) break;
+      }
+      if (attempt === retryLimit) break;
+      await waitForRetry(attempt + 1);
+    }
+    return { failure: `${failure}\nwatcher: FAILED - omp extension could not restore watcher continuity after ${retryLimit} retries` };
+  }
+
+  function scheduleRetry(owner: SessionGeneration, message: string, predecessorArmPid: string): void {
+    if (!generationIsLive(owner) || owner.child || owner.retryTimer) return;
+    const ownership = lockOwnership();
+    if (ownership !== "owned") {
+      surfaceFailure(owner, `watcher: FAILED - omp extension cannot restore continuity because this session no longer owns the lock\n${message}`);
+      return;
+    }
+    owner.retryFailures += 1;
+    if (owner.retryFailures > retryLimit) {
+      surfaceFailure(owner, `watcher: FAILED - omp extension could not restore watcher continuity after ${retryLimit} retries\n${message}`);
+      return;
+    }
+    const timer = setTimeout(() => {
+      if (owner.retryTimer === timer) owner.retryTimer = null;
+      if (!generationIsLive(owner)) return;
+      const result = startArm(owner, predecessorArmPid);
+      if (!result.ok) {
+        surfaceFailure(owner, `watcher: FAILED - omp extension could not launch a continuity retry\n${result.message}`);
+      }
+    }, retryDelay(owner.retryFailures));
+    timer.unref();
+    owner.retryTimer = timer;
+  }
+
+  function startArm(owner: SessionGeneration, predecessorArmPid = ""): ArmResult {
+    if (!generationIsLive(owner)) return { ok: false, message: shuttingDownMessage };
+    const ownership = lockOwnership();
+    if (ownership === "other") return { ok: false, message: "watcher: read-only - session lock is held by another firstmate session" };
+    if (ownership === "missing") {
+      return {
+        ok: false,
+        message: "watcher: not armed - no live session holds the lock; run bin/fm-session-start.sh to reclaim it, then call fm_watch_arm_omp to re-arm",
+      };
+    }
+    markLoaded();
+    if (owner.child) {
+      return {
+        ok: true,
+        message: `watcher: unchanged - omp extension already owns an arm child; no manual re-arm needed; ${repairOnlyHint}`,
+      };
+    }
+    if (owner.retryTimer) {
+      return {
+        ok: true,
+        message: `watcher: unchanged - omp extension already owns a scheduled continuity retry; no manual re-arm needed; ${repairOnlyHint}`,
+      };
+    }
+    const id = ++owner.seq;
+    const env = {
+      ...process.env,
+      FM_HOME: fmHome,
+      FM_ROOT_OVERRIDE: fmRoot,
+      FM_CONFIG_OVERRIDE: config,
+      FM_WATCH_ARM_SCRIPT: armScript,
+      FM_WATCH_PREDECESSOR_ARM_PID: predecessorArmPid,
+    };
+    const armChild = spawn("bash", ["-lc", "config_dir=\"${FM_CONFIG_OVERRIDE:-$FM_HOME/config}\"; [ -f \"$config_dir/x-mode.env\" ] && . \"$config_dir/x-mode.env\"; exec \"$FM_WATCH_ARM_SCRIPT\" --restart"], {
+      cwd: fmRoot,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    owner.child = armChild;
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let readinessSettled = false;
+    let resolveReadiness: (ready: boolean) => void = () => {};
+    let resolveClosed: () => void = () => {};
+    const readiness = new Promise<boolean>((resolveReady) => {
+      resolveReadiness = resolveReady;
+    });
+    armReadiness.set(armChild, readiness);
+    const closed = new Promise<void>((resolveClosedChild) => {
+      resolveClosed = resolveClosedChild;
+    });
+    armClose.set(armChild, closed);
+    const settleReadiness = (ready: boolean): void => {
+      if (readinessSettled) return;
+      readinessSettled = true;
+      resolveReadiness(ready);
+    };
+    const observeEstablishedArm = (): void => {
+      const combined = `${stdout}\n${stderr}`;
+      const recovery = combined.match(/^watcher: started pid=([0-9]+).* recovery-generation=([A-Za-z0-9._-]+)$/m);
+      if (recovery) armRecovery.set(armChild, { watcherPid: recovery[1], generation: recovery[2] });
+      if (/^watcher: (?:started|attached)\b/m.test(combined)) {
+        settleReadiness(true);
+      }
+    };
+    const releaseChild = (): void => {
+      if (owner.child === armChild) owner.child = null;
+    };
+    armChild.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+      observeEstablishedArm();
+    });
+    armChild.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+      observeEstablishedArm();
+    });
+    armChild.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
+      if (settled) return;
+      settled = true;
+      resolveClosed();
+      settleReadiness(false);
+      releaseChild();
+      if (!generationIsLive(owner)) return;
+      const classification = classifyClose(stdout, stderr, code, signal);
+      const predecessor = String(armChild.pid ?? "");
+      if (classification.kind === "actionable") {
+        owner.retryFailures = 0;
+        owner.restoring = true;
+        void (async () => {
+          const restoration = await restoreAfterActionableClose(owner, predecessor);
+          if (generationIsLive(owner)) owner.restoring = false;
+          if (!generationIsLive(owner)) return;
+          const message = restoration.failure ? `${classification.message}\n\n${restoration.failure}` : classification.message;
+          await sendWake(owner, message, restoration.recovery);
+        })().catch(() => {
+        });
+        return;
+      }
+      if (owner.restoring) return;
+      scheduleRetry(owner, classification.message, predecessor);
+    });
+    armChild.on("error", (error: Error) => {
+      if (settled) return;
+      settled = true;
+      resolveClosed();
+      settleReadiness(false);
+      releaseChild();
+      if (!generationIsLive(owner)) return;
+      if (owner.restoring) return;
+      scheduleRetry(owner, `watcher: FAILED - omp extension arm child ${id} failed: ${error.message}`, String(armChild.pid ?? ""));
+    });
+    return {
+      ok: true,
+      message: `watcher: started omp extension arm child ${id}; future ordinary re-arms are automatic; ${repairOnlyHint}`,
+    };
+  }
+
+  pi.on?.("session_start", () => {
+    // Initial load: activate the factory generation (or a fresh one if somehow stopping).
+    if (generation.stopping) generation = createGeneration();
+    activateGeneration(generation);
+    markLoaded();
+  });
+  pi.on?.("session_switch", () => {
+    // Same-process replacement (/new, /resume, /fork, handoff): retire the prior
+    // generation and activate a fresh one so monitoring can arm again without
+    // restarting omp. omp fires session_switch (with reason + previousSessionFile)
+    // for these where Pi fired session_shutdown then session_start.
+    stopGeneration(generation);
+    generation = createGeneration();
+    activateGeneration(generation);
+    markLoaded();
+  });
+  pi.on?.("session_branch", () => {
+    // Branch: new session from an entry. Treat like a switch.
+    stopGeneration(generation);
+    generation = createGeneration();
+    activateGeneration(generation);
+  });
+  pi.on?.("session_shutdown", () => {
+    // Terminal quit only (omp fires session_switch for /new, /resume, /fork).
+    stopGeneration(generation);
+  });
+
+  pi.registerCommand?.("fm-watch-arm-omp", {
+    description: "Arm firstmate watcher supervision through the omp extension instead of foreground bash.",
+    handler: async (_args, ctx) => {
+      const result = startArm(generation);
+      ctx.ui.notify(result.message, result.ok ? "info" : "warning");
+    },
+  });
+
+  pi.registerTool?.({
+    name: "fm_watch_arm_omp",
+    label: "Arm firstmate watcher",
+    description: "Start the first required omp watcher cycle, or repair one only after a notification says the cycle is missing, failed, or unhealthy. Do not call after ordinary work or ordinary notifications; the omp extension re-arms automatically. Never run bin/fm-watch-arm.sh through bash.",
+    parameters: pi.zod.object({}),
+    renderCall: (_args, _options, theme) => {
+      if (calmHides("assistant-tool-call")) return new Container();
+      return new Text(theme.fg("toolTitle", theme.bold("fm_watch_arm_omp")), 0, 0);
+    },
+    renderResult: (result, _options, theme) => {
+      if (calmHides("tool-result")) return new Container();
+      const output = result.content
+        .filter((item) => item.type === "text")
+        .map((item) => item.text)
+        .join("\n");
+      if (!output) return new Container();
+      return new Text(theme.fg("toolOutput", output), 0, 0);
+    },
+    execute: async () => {
+      const result = startArm(generation);
+      return {
+        content: [{ type: "text", text: result.message }],
+        details: result,
+      };
+    },
+  });
+
+  markLoaded();
+}

--- a/.pi/extensions/lib/fm-calm-visibility-omp.ts
+++ b/.pi/extensions/lib/fm-calm-visibility-omp.ts
@@ -1,0 +1,50 @@
+// omp copy of fm-calm-visibility.ts, package-free.
+// The omp watcher needs only the pure-logic exports (CalmPresentationState,
+// calmTranscriptClassIsVisible, FIRSTMATE_CALM_PRESENTATION_EVENT). The Pi
+// registerFirstmateSyntheticPresentation renderer is omitted because it depends
+// on Pi-family UI components the omp port does not wire here; the Pi extension
+// keeps its own copy for genuine Pi sessions.
+export const CALM_TRANSCRIPT_CLASSES = [
+  "genuine-user-prompt",
+  "genuine-agent-response",
+  "assistant-working-note",
+  "assistant-thinking",
+  "assistant-tool-call",
+  "tool-result",
+  "tool-image",
+  "user-bash",
+  "skill-invocation",
+  "custom-message",
+  "custom-entry",
+  "compaction-summary",
+  "branch-summary",
+  "working-status",
+  "command-status",
+  "system-notice",
+  "cache-notice",
+  "project-trust-warning",
+  "synthetic-user",
+  "synthetic-assistant",
+  "unknown",
+] as const;
+
+export type CalmTranscriptClass = (typeof CALM_TRANSCRIPT_CLASSES)[number];
+
+// Calm is on or off. "assistant-working-note" is deliberately absent from the allowlist:
+// Calm hides mid-turn assistant working notes, keeping the genuine final reply.
+const CALM_VISIBLE_CLASSES: Partial<Record<CalmTranscriptClass, true>> = {
+  "genuine-user-prompt": true,
+  "genuine-agent-response": true,
+  "working-status": true,
+};
+
+export const FIRSTMATE_CALM_PRESENTATION_EVENT = "firstmate:calm-presentation";
+
+export type CalmPresentationState = {
+  active: boolean;
+  stockExportRendering: boolean;
+};
+
+export function calmTranscriptClassIsVisible(itemClass: CalmTranscriptClass): boolean {
+  return CALM_VISIBLE_CLASSES[itemClass] === true;
+}

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Full detail on every feature lives in [docs/architecture.md](docs/architecture.m
 
 ### Requirements
 
-- A verified primary agent harness: Claude Code, Grok, Pi, `pi-signed`, Codex, OpenCode, or Cursor Agent CLI.
+- A verified primary agent harness: Claude Code, Grok, Pi, `pi-signed`, omp (Oh My Pi), Codex, OpenCode, or Cursor Agent CLI.
 - Git and the GitHub CLI, authenticated through `gh auth login`.
 - The CLI and dependencies for your selected runtime backend; tmux is the reference default.
 
@@ -69,6 +69,7 @@ Backend-specific setup is linked in [Documentation](#documentation).
 
 **Claude Code, Grok, and Pi are equal co-primary recommendations** for running the primary firstmate session, with `pi-signed` supported as Pi's distinct signed-wrapper identity.
 Claude Code uses a tracked Stop hook for tokenless watcher re-arm and rewake, Grok uses background-notify wake cycles, and Pi uses its tracked primary watcher extension.
+omp (Oh My Pi) is a Pi-family fork with the same tracked primary watcher extension; it uses omp's `session_stop` event for the turn-end guard and loads extensions explicitly via `-e` (omp does not auto-discover project `.pi/extensions`).
 All three have verified turn-end guard paths when launched with their documented setup.
 Pick whichever one matches your subscription and workflow.
 
@@ -213,7 +214,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/gitlab-merge-watch.md](docs/gitlab-merge-watch.md) - maintainer verification for GitLab merge watching on arbitrary instances.
 - [docs/turnend-guard.md](docs/turnend-guard.md) - the primary session's current "no turn ends blind" backstop, scope, loop safety, and compatibility limits.
 - [docs/verification/supervision.md](docs/verification/supervision.md) - active maintainer verification for session-start, guard, continuity, and wedge integrations.
-- [docs/supervision-protocols/](docs/supervision-protocols/) - rendered primary-harness watcher protocols for Claude, Codex, OpenCode, Pi and `pi-signed`, Grok, Cursor, and unknown harness fallback.
+- [docs/supervision-protocols/](docs/supervision-protocols/) - rendered primary-harness watcher protocols for Claude, Codex, OpenCode, Pi and `pi-signed`, omp, Grok, Cursor, and unknown harness fallback.
 - [docs/scripts.md](docs/scripts.md) - the `bin/` toolbelt reference.
 - [docs/documentation-audiences.md](docs/documentation-audiences.md) - documentation audiences and the machine-checked placement boundary.
 - [`AGENTS.md`](AGENTS.md) - the distro's always-loaded operating contract and routing index for conditional procedures.

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|omp|pi|pi-signed|grok|kimi|cursor|muse|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -50,11 +50,6 @@ detect_own() {
   # CURSOR_AGENT=1 is set for the child/tool processes this script runs as.
   [ "${CURSOR_AGENT:-}" = "1" ] && { echo cursor; return; }
   [ "${CURSOR_INVOKED_AS:-}" = "cursor-agent" ] && { echo cursor; return; }
-  [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
-  if [ "${PI_CODING_AGENT:-}" = "true" ]; then
-    if [ "${FM_PI_HARNESS:-}" = pi-signed ]; then echo pi-signed; else echo pi; fi
-    return
-  fi
   # grok set GROK_AGENT=1 for its child/tool processes (verified, grok 0.2.73).
   # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so the marker
   # is unambiguous WHEN PRESENT - but it is not guaranteed present. A grok 1.0.0
@@ -64,7 +59,24 @@ detect_own() {
   # a fast path only; the ancestry walk below is what actually guarantees grok is
   # identified, and any rule that must be RELIABLE under grok has to test the hook
   # markers too (see .claude/settings.json Stop entries, docs/turnend-guard.md).
+  # GROK_AGENT is checked before OMPCODE and CLAUDECODE because grok's own marker
+  # is unambiguous when present, and a stale OMPCODE or CLAUDECODE retained in a
+  # multiplexer's stored environment must not override it (same precedence logic
+  # as cursor before claude).
   [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }
+  # omp (Oh My Pi) sets OMPCODE=1 alongside CLAUDECODE=1 on its child/tool
+  # processes (verified omp 17.3.3). It is a Pi-family harness (extension-owned
+  # supervision, not Claude settings.json hooks), so misreading it as claude
+  # aims the wrong command surface at every downstream branch. Test OMPCODE
+  # before CLAUDECODE so omp is identified correctly; bin/fm-spawn.sh clears
+  # foreign markers at its launch boundary, and this ordering also covers an
+  # omp session a human started by hand.
+  [ "${OMPCODE:-}" = "1" ] && { echo omp; return; }
+  [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
+  if [ "${PI_CODING_AGENT:-}" = "true" ]; then
+    if [ "${FM_PI_HARNESS:-}" = pi-signed ]; then echo pi-signed; else echo pi; fi
+    return
+  fi
   # muse (Muse Code) publishes no harness-identity marker of its own. The only
   # MUSE_* variable it is documented to hand a child is MUSE_CURRENT_SESSION_LOG,
   # a per-session log PATH rather than an identity, and its export to tool
@@ -95,6 +107,7 @@ detect_own() {
       muse|muse-bin-*) echo muse; return ;;
       pi-signed) echo pi; return ;;
       pi) echo pi; return ;;
+      omp) echo omp; return ;;
       node*|python*)
         # Bare interpreter: match the harness name in its script path.
         args=$(ps -o args= -p "$pid" 2>/dev/null)
@@ -104,6 +117,7 @@ detect_own() {
           *opencode*) echo opencode; return ;;
           *grok*) echo grok; return ;;
           *" pi "*|*/pi) echo pi; return ;;
+          *" omp "*|*/omp) echo omp; return ;;
         esac ;;
     esac
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -17,13 +17,13 @@
 . "$(dirname -- "${BASH_SOURCE[0]}")/fm-cursor-lib.sh"
 
 # Known harness command names; extend when a new adapter is verified.
-FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$'
+FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$|^omp$'
 
 # The same harnesses as exact executable names. Keep in sync with
 # FM_HARNESS_RE. Used only for the stricter path evidence below, where the
 # loose regex would also match ordinary firstmate paths such as
 # bin/fm-claude-stop-autoarm.sh.
-FM_HARNESS_NAMES=(claude codex opencode grok kimi pi-signed pi)
+FM_HARNESS_NAMES=(claude codex opencode grok kimi pi-signed pi omp)
 
 # Print the exact harness name carried by executable path $1 - its own basename
 # or any directory component - or return 1.
@@ -73,9 +73,17 @@ fm_harness_process_matches() {  # <comm> <args>
   fi
   # Bare interpreter (e.g. node): match the harness name in its script path.
   case "$comm" in
-    *node*|*python*)
+    *node*|*python*|*bun*)
       if printf '%s' "$args" | grep -qE "$FM_HARNESS_RE"; then
         case "$args" in *claude*) FM_HARNESS_IS_CLAUDE=1 ;; esac
+        return 0
+      fi
+      # omp runs as: bun /path/to/omp -e ... The anchored regex misses it
+      # because the args line starts with "bun". Extract the script path
+      # (first word after the interpreter) and check it as a path component.
+      local script_path=${args#* }
+      script_path=${script_path%% *}
+      if name=$(fm_harness_path_name "$script_path"); then
         return 0
       fi
       ;;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -104,7 +104,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|omp|pi|pi-signed|grok|kimi|cursor|muse)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters. For pi and pi-signed, fm-spawn resolves the selected executable
@@ -439,7 +439,7 @@ spawn_remote_secondmate() {
     harness=$("$FM_ROOT/bin/fm-harness.sh" secondmate)
   fi
   case "$harness" in
-    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor) ;;
+    claude|codex|opencode|omp|pi|pi-signed|grok|kimi|cursor) ;;
     *)
       fm_lock_release "$registry_lock" || true
       fm_lock_release "$SPAWN_TASK_LOCK" || true
@@ -1046,7 +1046,7 @@ if [ "$RELAUNCH" -eq 1 ]; then
   }
 elif [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse)
+    ''|claude|codex|opencode|omp|pi|pi-signed|grok|kimi|cursor|muse)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -1127,6 +1127,14 @@ launch_template() {
       else
         printf '%s' ' __MODELFLAG____EFFORTFLAG__-e __PIEXT__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       fi
+      ;;
+    omp)
+      # omp (Oh My Pi): Pi-family extension-owned supervision. omp does NOT
+      # auto-discover project .pi/extensions, so both primary extensions are
+      # passed explicitly via -e alongside the per-task sidecar. --auto-approve
+      # is the crewmate viability flag (equivalent to claude's
+      # --dangerously-skip-permissions and grok's --always-approve).
+      printf '%s' '__OMPBIN__ --auto-approve __MODELFLAG____EFFORTFLAG__-e __OMPTURNEND__ -e __OMPWATCH__ -e __OMPEXT__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       ;;
     # grok (Grok Build TUI): a positional prompt starts the supervised interactive
     # session. --always-approve auto-approves every tool execution (verified: the
@@ -1239,6 +1247,12 @@ case "$HARNESS" in
     fi
     LAUNCH=${LAUNCH//__PITUIMODE__/$PI_TUI_MODE}
     LAUNCH="FM_PI_HARNESS=$HARNESS $LAUNCH"
+    ;;
+  omp)
+    OMP_BIN=$(resolve_pi_executable "omp") || {
+      echo "error: omp executable not found on PATH; install it or select a different verified harness" >&2
+      exit 1
+    }
     ;;
   cursor)
     # `cursor` is not the CLI name, and the legacy alias `agent` is far too
@@ -1361,7 +1375,7 @@ model_flag_for_harness() {
   local harness=$1 model=$2
   [ -n "$model" ] && [ "$model" != default ] || return 0
   case "$harness" in
-    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse)
+    claude|codex|opencode|omp|pi|pi-signed|grok|kimi|cursor|muse)
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
   esac
@@ -2446,6 +2460,34 @@ export default function (pi: any) {
 }
 EOF
       ;;
+    omp)
+      # Same contract as pi-ext.ts but using omp event names: agent_start/agent_end
+      # (with willContinue guard) instead of pi's agent_start/agent_settled+isIdle.
+      cat > "$STATE/$ID.omp-ext.ts" <<EOF
+// Firstmate semantic busy-state events + turn-end notification; written by
+// fm-spawn under the contract owned by bin/fm-busy-lib.sh.
+// omp event mapping: agent_start -> busy; agent_end (willContinue=false) ->
+// idle; turn_end -> touch turn-end marker. omp has no agent_settled+isIdle;
+// agent_end.willContinue is the settled guard (auto-retry/compaction keep it
+// true, so only a genuine terminal settle marks idle).
+import { execFile } from "node:child_process";
+const busyEvent = (state: string, event: string) =>
+  new Promise<void>((resolve) => {
+    execFile("$FM_ROOT/bin/fm-busy-event.sh", [
+      "apply", "$STATE_REAL", "$ID", state,
+      "--gen", "$BUSY_GEN", "--source", "omp-ext", "--event", event,
+    ], () => resolve());
+  });
+export default function (omp: any) {
+  omp.on("agent_start", () => busyEvent("busy", "agent-start"));
+  omp.on("agent_end", (event: any) => {
+    if (event && event.willContinue) return;
+    return busyEvent("idle", "agent-end");
+  });
+  omp.on("turn_end", () => execFile("touch", ["$TURNEND"]));
+}
+EOF
+      ;;
     codex*)
       # Semantic busy-state source negotiation (bin/fm-busy-lib.sh owns the
       # probes and the evidence). Neither Codex path is usable on the
@@ -2710,6 +2752,9 @@ sq_turnend=$(shell_quote "$TURNEND")
 sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
 sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts")
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
+sq_ompext=$(shell_quote "$STATE/$ID.omp-ext.ts")
+sq_ompturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-omp-turnend-guard.ts")
+sq_ompwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-omp-watch.ts")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
 sq_worktree=$(shell_quote "$WT")
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
@@ -2721,21 +2766,24 @@ LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
+LAUNCH=${LAUNCH//__OMPEXT__/$sq_ompext}
+LAUNCH=${LAUNCH//__OMPTURNEND__/$sq_ompturnend}
+LAUNCH=${LAUNCH//__OMPWATCH__/$sq_ompwatch}
 LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}
 case "$HARNESS" in
   pi|pi-signed) LAUNCH=${LAUNCH//__PIBIN__/"$(shell_quote "$PI_BIN")"} ;;
   cursor) LAUNCH=${LAUNCH//__CURSORBIN__/"$(shell_quote "$CURSOR_BIN")"} ;;
+  omp) LAUNCH=${LAUNCH//__OMPBIN__/"$(shell_quote "$OMP_BIN")"} ;;
 esac
 LAUNCH=${LAUNCH//__WORKTREE__/$sq_worktree}
 case "$HARNESS" in
-  claude|codex|opencode|pi|pi-signed|grok|kimi|muse)
+  claude|codex|opencode|omp|pi|pi-signed|grok|kimi|muse)
     LAUNCH="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS $LAUNCH"
     ;;
 esac
 # Crewmate panes are created by a long-lived tmux/herdr daemon that does not
 # inherit firstmate's current environment, so a bare `claude` in the pane falls
 # back to the default ~/.claude store even when firstmate itself runs under a
-# different CLAUDE_CONFIG_DIR (for example a work-vs-personal subscription split).
 # Forward firstmate's own resolved store onto the claude launch so the crewmate
 # uses the same credential/config firstmate is authenticated with. Only when set;
 # an unset value is the single-store default and needs no prefix.

--- a/docs/omp-adapter-verification.md
+++ b/docs/omp-adapter-verification.md
@@ -1,0 +1,162 @@
+# OMP adapter — testing and verification plan
+
+Branch: `feat/omp-adapter` (worktree `.claude/worktrees/omp-port`)
+Target: omp v17.3.3 (global `~/.bun/bin/omp`), bun runtime.
+Scope: detection fix, `fm-primary-omp-watch.ts`, `fm-primary-omp-turnend-guard.ts`,
+`fm-spawn.sh` omp branch, `docs/supervision-protocols/omp.md`, README adapter list.
+
+## Success criteria
+
+A real crew task run under an omp primary completes with the same supervision
+contract Claude and Pi get: watcher armed, wake delivered, turn-end guard never
+lets the session settle blind, digest reaches the captain, and every harness
+detection regression stays green.
+
+## 0. Environment
+
+- All live-omp runs use scratch dirs, `--session-dir` temp, `FM_STATE_OVERRIDE`
+  temp, `--auto-approve`, smol model, `-p` print mode unless a case needs TUI.
+- Extensions loaded explicitly with repeatable `-e` (never rely on auto-discovery
+  in tests).
+- Test-only probe extension: `tests/fixtures/omp-event-probe.ts` — logs every
+  event (`session_start`, `session_switch`, `session_branch`, `session_shutdown`,
+  `session_compact`, `session_stop`, `tool_call`, `agent_start`, `agent_end`) and
+  ctx facts (`isIdle()`, `stop_hook_active`, switch `reason`) to a probe log.
+
+## 1. Static gates (fast, run on every change)
+
+- `bin/fm-lint.sh` — pinned shellcheck over changed bin scripts; must pass.
+- `while IFS= read -r s; do bash -n "$s" || exit; done < <(bin/fm-lint.sh --list-files)`
+- Type-check both new extensions against `@oh-my-pi/pi-coding-agent` types;
+  mirror `tests/fm-pi-primary-types.test.sh` mechanics. Zero errors.
+- Markers: link `docs/supervision-protocols/omp.md` from AGENTS.md index;
+  README adapter list includes omp.
+
+## 2. Harness detection — new `tests/fm-omp-harness.test.sh`
+
+Mirror `tests/fm-cursor-harness.test.sh` / `fm-grok-harness.test.sh`.
+
+Matrix (env marker, then ancestry):
+
+| Env | Expected |
+|---|---|
+| `OMPCODE=1 CLAUDECODE=1` (real omp child) | `omp` |
+| `CLAUDECODE=1` alone | `claude` |
+| `PI_CODING_AGENT=true` | `pi` |
+| `OMPCODE=1 PI_CODING_AGENT=true` | `omp` (omp tested first) |
+| `CURSOR_AGENT=1` + any | `cursor` (unchanged precedence) |
+| `GROK_AGENT=1` | `grok` |
+| none (markerless, ancestry) | process-name walk incl. `*omp*` |
+| `OMPCODE=1` inherited by a codex child | documented precedence hazard; verdict matches cursor note (foreign marker can override ancestry — record in comment) |
+
+Crew/secondmate resolution: `crew-harness=default` under omp → `omp`;
+explicit `omp`; secondmate chain unchanged. Usage header lists omp.
+
+## 3. Shared script contracts (existing tests stay green)
+
+- `fm-turnend-guard.test.sh`, `fm-watch-arm.test.sh`, `fm-arm-pretool-check.test.sh`,
+  `fm-cd-pretool-check.test.sh`, `fm-subagent-pretool-check.test.sh`,
+  `fm-watcher-lock.test.sh`, `fm-watch-triage.test.sh` — full pass.
+- NEW: guard invoked bare (no `--claude` flag) — the exact invocation the omp
+  extension uses. Assert parity with `--claude` on: clean settle (exit 0),
+  queued digest (exit 2), no state (exit 0).
+- Re-arm smoke from CONTRIBUTING against the worktree:
+  `FM_STATE_OVERRIDE=$(mktemp -d) FM_SIGNAL_GRACE=1 FM_POLL=1 FM_HEARTBEAT=999999 bin/fm-watch-arm.sh`
+  → prints exactly one of `watcher: started pid=<N> (beacon fresh)` /
+  `watcher: attached pid=<N>` / FAILED, then an actionable signal.
+- Wake round trip: encode a watcher wake (operational input), run
+  `bin/fm-wake-drain.sh`, assert the queued wake surfaces.
+
+## 4. Live omp extension behavior (real omp, `-p`, scratch dirs)
+
+### A. Load and arm
+`omp -p -e tests/fixtures/omp-event-probe.ts -e .pi/extensions/fm-primary-omp-watch.ts -e .pi/extensions/fm-primary-omp-turnend-guard.ts --session-dir <tmp> --auto-approve "call the fm_watch_arm_omp tool and report its exact output"`
+
+Assert: extensions load without errors; tool registered and callable;
+`watcher: started pid=<N> (beacon fresh)` output; beacon
+`state/.last-watcher-beat` fresh; marker `state/.omp-watch-extension-loaded`
+written; watch-cycle ledger `state/.watch-cycle-exits.log` has one arm record.
+
+### B. Session lifecycle / generations
+New session → generation active. Resume (`-r`) → `session_switch` → new
+generation arms. Branch → new generation. Quit → `session_shutdown`, final
+generation stops. Assert: exactly one live watcher at all times (lock invariant);
+stale generation callbacks are no-ops (no second arm, no rearm after shutdown).
+
+### C. Seatbelt (PreToolUse equivalent)
+Prompt issues a bash command the arm-pretool policy denies, and a cd the
+cd-pretool policy denies. With `--mode=json`: assert the denied `bash`/`cd`
+tool call is BLOCKED (no result, model receives `block` reason), allowed
+commands unaffected. Same verdict as `fm-arm-pretool-check.test.sh` +
+`fm-cd-pretool-check.test.sh` but through the omp `tool_call` path.
+
+### D. Turn-end guard on `session_stop`
+- Digest queued in state → guard exits 2 → continuation turn requested
+  (probe log: `session_stop` → guard code 2; transcript shows the followUp).
+- No digest / nothing actionable → guard exits 0, no continuation, no wake.
+- `stop_hook_active` field observed and passed through unchanged.
+
+### E. Compaction digest
+Force compaction (config overlay with tiny context threshold):
+`session_compact` fires → digest hidden message injected
+(`sendMessage` customType+content, display:false) → probe log confirms.
+
+### F. Auto-retry interlock
+Prompt that errors and triggers `auto_retry_*` → assert NO premature
+settle/guard wake; the guard fires only on the true final settle.
+
+## 5. Spawn mechanics (omp crewmate)
+
+- `fm-spawn.sh` omp branch launches the crewmate as
+  `omp -p -e fm-primary-omp-watch.ts -e fm-primary-omp-turnend-guard.ts -e .omp-ext.ts --session-dir <task> <task text>`.
+- Assert per-task lifecycle markers (`state/<id>.ready/started/turn-ended`)
+  as in the pi path; worktree isolation assertion mirrors
+  `fm-spawn-worktree-settle.test.sh`.
+- Protocol name check: AGENTS.md's first-cycle line ("make the one required
+  fm_watch_arm_omp call") matches the registered tool name exactly.
+- `fm-supervision-events.test.sh` / `fm-supervision-instructions.test.sh` stay green.
+
+## 6. E2E crew run under omp (real proof)
+
+Scratch project; `FM_ROOT_OVERRIDE` = worktree; primary omp interactive (or
+scripted `-p` + probe). Spawn a real 2-task crew (e.g. "write a module + test").
+Assert the full loop:
+
+1. spawn launches omp crewmate with extensions
+2. crewmate arms the watcher (tool call)
+3. task produces status → wake queued
+4. primary receives wake, drains it
+5. turn-end guard delivers digest; no blind settle
+6. captain-visible supervision message; task artifacts and receipts exist
+
+Capture primary + crewmate session transcripts and probe logs as evidence.
+
+## 7. Regression
+
+- `bin/fm-test-run.sh --changed` after each change; `--all` before PR.
+- Harness-wide: claude, codex, opencode, pi, pi-signed, grok, cursor, kimi,
+  muse detection tests all pass unchanged.
+- `bin/fm-lint.sh` clean; CI yml untouched unless the new test files need a lane.
+
+## 8. Evidence and docs
+
+- Test evidence to temp dir (repo policy, `.no-mistakes.yaml`); no
+  `.no-mistakes/evidence/` commits.
+- `docs/supervision-protocols/omp.md` mirrors `pi.md` (session_switch vs
+  shutdown semantics, omp tool name, guard on session_stop).
+- PR: plain-English title, no-mistakes signature.
+
+## Order and exit criteria
+
+Phases run in order; each phase must pass before the next starts.
+Exit: static gate green, layer 4 A–F fully green, one E2E crew task with digest
+surfaced, regression suite green, evidence attached.
+
+## Test files to create
+
+- `tests/fm-omp-harness.test.sh` — detection matrix
+- `tests/fm-omp-primary-types.test.sh` — extension typecheck (mirror pi)
+- `tests/fm-omp-watch-extension.test.sh` — load/arm/generation/lifecycle
+- `tests/fm-omp-turnend-guard.test.sh` — guard bare-arg + live stop/compact
+- `tests/fm-omp-primary-live-e2e.test.sh` — crew E2E
+- `tests/fixtures/omp-event-probe.ts` — event/facts probe (test-only)

--- a/docs/supervision-protocols/omp.md
+++ b/docs/supervision-protocols/omp.md
@@ -1,0 +1,24 @@
+Mode: omp extension background wake.
+
+When this session owns supervision and away mode is not active:
+1. Drain first with `bin/fm-wake-drain.sh`.
+   After handling all emitted wakes and reconciling open decisions and unread status lines, run the exact `--ack-through` command printed as `WAKE_ACK_REQUIRED`; until then the work remains durable for idempotent re-handling after interruption.
+2. Confirm the omp primary loaded both extensions via `-e`; omp does NOT auto-discover project `.pi/extensions`, so both are passed explicitly at launch by `bin/fm-spawn.sh`. If the running session has not loaded both, restart omp with `-e __FM_OMP_TURNEND_EXT__ -e __FM_OMP_EXT__`.
+3. First cycle only: make the one required `fm_watch_arm_omp` call.
+   Use `/fm-watch-arm-omp` only as a human-entered fallback.
+   Never run `bin/fm-watch-arm.sh` through omp's bash tool because that foreground arm can wedge the agent and bypasses extension-owned cleanup.
+4. If the extension says no live session holds the lock, run `bin/fm-session-start.sh` to reclaim the session lock, then call `fm_watch_arm_omp` again.
+5. The extension starts `bin/fm-watch-arm.sh --restart`, keeps the child attached to the live omp process, and owns every later successor launch.
+6. Ordinary same-process session replacement (`/new`, `/resume`, `/fork`, handoff) fires `session_switch`, which retires only the prior generation; call `fm_watch_arm_omp` once for the first cycle of the replacement session without restarting omp.
+   The generation-owner contract lives in `.pi/extensions/fm-primary-omp-watch.ts`.
+7. After an actionable child close, the extension rechecks session-lock ownership and verifies one successor before it delivers the follow-up wake; its bounded fallback is defined in `docs/watcher-continuity.md`.
+8. Ordinary work, turn completion, and ordinary signal, stale, check, heartbeat, or other wake handling: do not call `fm_watch_arm_omp` again because continuity is extension-owned rather than model-memory-owned.
+9. An unexpected child close enters bounded exponential retry, and an exhausted retry or lost session lock is surfaced as a watcher failure instead of disappearing.
+10. Missing, failed, or unhealthy cycle only: if a later notification explicitly reports one of those repair conditions, drain queued wakes, inspect the failure text, call `fm_watch_arm_omp`, and restart omp with both extensions loaded if needed.
+   A redundant call while the extension owns an arm child or scheduled retry is an ownership-based `watcher: unchanged` no-op, not an independent health claim.
+11. Never use shell `&` for watcher supervision.
+   The arm mechanism above is extension-owned, not a model tool call, but a manual recovery probe that backgrounds, pipes, or bundles the arm is denied automatically by the PreToolUse seatbelt (`bin/fm-arm-pretool-check.sh`, wired into the turn-end guard extension at `__FM_OMP_TURNEND_EXT__`).
+
+The turn-end guard extension lives at `__FM_OMP_TURNEND_EXT__`.
+The watcher extension lives at `__FM_OMP_EXT__`.
+Both are project-local `.pi/extensions/*.ts` files loaded explicitly via omp's `-e` flag; `bin/fm-session-start.sh` reports when the running omp session has not loaded both required extensions. omp fires `session_stop` (not Pi's `agent_settled`) when a turn is about to settle, and the guard runs there.

--- a/tests/fixtures/omp-event-probe.ts
+++ b/tests/fixtures/omp-event-probe.ts
@@ -1,0 +1,45 @@
+// Test-only event probe for omp verification (tests/fixtures/omp-event-probe.ts).
+// Logs every event omp fires plus ctx facts to a probe log file, so the
+// verification plan's layer 4 cases (A-F) can assert exact event sequences
+// without depending on model behavior.
+//
+// Usage: omp -p -e tests/fixtures/omp-event-probe.ts -e <watch> -e <guard> \
+//          --session-dir <tmp> --auto-approve "prompt"
+//        then read <tmp>/omp-event-probe.log
+//
+// This file is NOT shipped as a firstmate extension; it lives under tests/fixtures.
+import { appendFileSync } from "node:fs";
+import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
+
+const probeLog = process.env.OMP_EVENT_PROBE_LOG || "/tmp/omp-event-probe.log";
+
+function log(line: string): void {
+  const ts = new Date().toISOString();
+  appendFileSync(probeLog, `${ts} ${line}\n`);
+}
+
+export default function (pi: ExtensionAPI) {
+  log("probe: loaded");
+
+  pi.on?.("session_start", () => log("event: session_start"));
+  pi.on?.("session_switch", (event: { reason?: string }) =>
+    log(`event: session_switch reason=${event.reason ?? "?"}`));
+  pi.on?.("session_branch", () => log("event: session_branch"));
+  pi.on?.("session_shutdown", () => log("event: session_shutdown"));
+  pi.on?.("session_compact", () => log("event: session_compact"));
+  pi.on?.("session_stop", (event: { stop_hook_active?: boolean }) =>
+    log(`event: session_stop stop_hook_active=${event.stop_hook_active ?? "?"}`));
+  pi.on?.("agent_start", () => log("event: agent_start"));
+  pi.on?.("agent_end", (event: { willContinue?: boolean }) =>
+    log(`event: agent_end willContinue=${event.willContinue ?? "false"}`));
+  pi.on?.("turn_start", (event: { turnIndex?: number }) =>
+    log(`event: turn_start turnIndex=${event.turnIndex ?? "?"}`));
+  pi.on?.("turn_end", (event: { turnIndex?: number }) =>
+    log(`event: turn_end turnIndex=${event.turnIndex ?? "?"}`));
+  pi.on?.("tool_call", (event: { toolName?: string }) => {
+    log(`event: tool_call toolName=${event.toolName ?? "?"}`);
+    return {};
+  });
+
+  log("probe: handlers registered");
+}

--- a/tests/fm-cursor-harness.test.sh
+++ b/tests/fm-cursor-harness.test.sh
@@ -186,10 +186,10 @@ test_cursor_marker_outranks_inherited_claudecode() {
   # Both cursor markers stand alone, and neither steals a plain claude session.
   out=$(env -u CLAUDECODE CURSOR_AGENT=1 "$HARNESS")
   [ "$out" = cursor ] || fail "CURSOR_AGENT alone must detect cursor, got '$out'"
-  out=$(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDECODE=1 "$HARNESS")
+  out=$(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u OMPCODE -u GROK_AGENT -u PI_CODING_AGENT CLAUDECODE=1 "$HARNESS")
   [ "$out" = claude ] || fail "CLAUDECODE alone must still detect claude, got '$out'"
   # A CURSOR_* variable that is not the invocation identity proves nothing.
-  out=$(env -u CURSOR_AGENT CLAUDECODE=1 CURSOR_API_ENDPOINT=https://example \
+  out=$(env -u CURSOR_AGENT -u OMPCODE -u GROK_AGENT -u PI_CODING_AGENT CLAUDECODE=1 CURSOR_API_ENDPOINT=https://example \
         CURSOR_INVOKED_AS=something-else "$HARNESS")
   [ "$out" = claude ] \
     || fail "an unrelated CURSOR_* setting must not claim the cursor identity, got '$out'"

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -530,10 +530,10 @@ esac
 SH
   chmod +x "$fakebin/ps"
 
-  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+  out=$(env -u CLAUDECODE -u OMPCODE -u PI_CODING_AGENT -u GROK_AGENT \
     PATH="$fakebin:$BASE_PATH" FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh")
   [ "$out" = kimi ] || fail "kimi ancestry detection returned '$out'"
-  out=$(CLAUDECODE=1 PATH="$fakebin:$BASE_PATH" FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh")
+  out=$(env -u OMPCODE CLAUDECODE=1 PATH="$fakebin:$BASE_PATH" FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh")
   [ "$out" = claude ] || fail "verified env-marker precedence changed, got '$out'"
   pass "fm-harness: markerless kimi is detected by ancestry after env-marker precedence"
 }

--- a/tests/fm-omp-harness.test.sh
+++ b/tests/fm-omp-harness.test.sh
@@ -23,9 +23,14 @@ set -u
 HARNESS="$ROOT/bin/fm-harness.sh"
 
 # Run fm-harness.sh with a clean slate plus the given env markers.
+# FM_CONFIG_OVERRIDE points at an empty dir so crew/secondmate resolution
+# tests the detection logic, not the operator's local config/crew-harness
+# (which may pin a specific adapter and mask the "default mirrors own" path).
+DETECT_CONFIG=$(fm_test_tmproot omp-detect-config)
 detect_with() {
   env -u CLAUDECODE -u OMPCODE -u PI_CODING_AGENT -u GROK_AGENT \
       -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u FM_PI_HARNESS \
+      FM_CONFIG_OVERRIDE="$DETECT_CONFIG" \
       "$@" "$HARNESS"
 }
 

--- a/tests/fm-omp-harness.test.sh
+++ b/tests/fm-omp-harness.test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# tests/fm-omp-harness.test.sh - detection matrix for the omp (Oh My Pi) adapter.
+#
+# omp sets OMPCODE=1 alongside CLAUDECODE=1 on its child/tool processes (verified
+# omp 17.3.3). The detection precedence hazard is identical to cursor's: omp does
+# NOT clear an inherited CLAUDECODE, so whichever marker is tested first wins.
+# This suite pins the LOGIC with env markers only, NO omp binary required, so CI
+# enforces it everywhere.
+#
+# The load-bearing contracts:
+#   1. OMPCODE=1 outranks CLAUDECODE=1 (omp is Pi-family, not Claude).
+#   2. OMPCODE=1 outranks PI_CODING_AGENT=true (omp is a distinct fork).
+#   3. CLAUDECODE=1 alone (no OMPCODE) is still claude.
+#   4. PI_CODING_AGENT=true alone (no OMPCODE) is still pi.
+#   5. Cursor markers still win over everything (unchanged precedence).
+#   6. Grok marker still detected (unchanged precedence).
+#   7. No markers: unknown (ancestry walk, no omp process to match).
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+HARNESS="$ROOT/bin/fm-harness.sh"
+
+# Run fm-harness.sh with a clean slate plus the given env markers.
+detect_with() {
+  env -u CLAUDECODE -u OMPCODE -u PI_CODING_AGENT -u GROK_AGENT \
+      -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u FM_PI_HARNESS \
+      "$@" "$HARNESS"
+}
+
+test_ompcodes_outranks_claudecode() {
+  local result
+  result=$(detect_with OMPCODE=1 CLAUDECODE=1)
+  expect_code 0 $? "omp detection should succeed"
+  assert_contains "$result" "omp" "OMPCODE=1 + CLAUDECODE=1 should detect omp, got: $result"
+}
+
+test_ompcodes_outranks_pi_marker() {
+  local result
+  result=$(detect_with OMPCODE=1 PI_CODING_AGENT=true)
+  assert_contains "$result" "omp" "OMPCODE=1 + PI_CODING_AGENT=true should detect omp, got: $result"
+}
+
+test_claudecode_alone_is_claude() {
+  local result
+  result=$(detect_with CLAUDECODE=1)
+  assert_contains "$result" "claude" "CLAUDECODE=1 alone should detect claude, got: $result"
+}
+
+test_pi_marker_alone_is_pi() {
+  local result
+  result=$(detect_with PI_CODING_AGENT=true)
+  assert_contains "$result" "pi" "PI_CODING_AGENT=true alone should detect pi, got: $result"
+}
+
+test_cursor_marker_still_wins() {
+  local result
+  result=$(detect_with CURSOR_AGENT=1 OMPCODE=1 CLAUDECODE=1)
+  assert_contains "$result" "cursor" "CURSOR_AGENT=1 should outrank omp, got: $result"
+}
+
+test_grok_marker_still_detected() {
+  local result
+  result=$(detect_with GROK_AGENT=1 OMPCODE=1)
+  assert_contains "$result" "grok" "GROK_AGENT=1 should outrank omp, got: $result"
+}
+
+test_no_markers_is_unknown() {
+  local result
+  result=$(detect_with)
+  assert_contains "$result" "unknown" "no markers should detect unknown, got: $result"
+}
+
+test_crew_resolution_defaults_to_own() {
+  local result
+  result=$(detect_with OMPCODE=1 CLAUDECODE=1 "$HARNESS" crew)
+  assert_contains "$result" "omp" "crew resolution with no config should mirror own (omp), got: $result"
+}
+
+test_ompcodes_outranks_claudecode
+test_ompcodes_outranks_pi_marker
+test_claudecode_alone_is_claude
+test_pi_marker_alone_is_pi
+test_cursor_marker_still_wins
+test_grok_marker_still_detected
+test_no_markers_is_unknown
+test_crew_resolution_defaults_to_own

--- a/tests/fm-omp-primary-types.test.sh
+++ b/tests/fm-omp-primary-types.test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Strict no-emit contract check for the tracked Firstmate omp (Oh My Pi)
+# extensions. Mirrors tests/fm-pi-primary-types.test.sh, but resolves the omp
+# package (@oh-my-pi/pi-coding-agent, installed globally by bun) and its
+# sibling @oh-my-pi/pi-tui, plus @types/node from the same global root.
+# typebox is NOT required: the omp extensions import only pi-tui's public
+# component surface and pi-coding-agent's ExtensionAPI/Theme types, and
+# skipLibCheck suppresses pi-tui's internal typebox references.
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+command -v tsc >/dev/null 2>&1 || { echo "skip: tsc not found for omp extension typecheck"; exit 0; }
+
+resolve_omp_package_dir() {
+  # 1. explicit override
+  if [ -n "${FM_OMP_PACKAGE_DIR:-}" ] && [ -f "${FM_OMP_PACKAGE_DIR}/package.json" ]; then
+    echo "$FM_OMP_PACKAGE_DIR"; return
+  fi
+  # 2. npm global root
+  local npm_dir
+  npm_dir="$(npm root -g 2>/dev/null)/@oh-my-pi/pi-coding-agent"
+  if [ -f "$npm_dir/package.json" ]; then echo "$npm_dir"; return; fi
+  # 3. resolve from the `omp` binary symlink (bun global install)
+  local omp_bin
+  omp_bin="$(command -v omp 2>/dev/null || true)"
+  if [ -n "$omp_bin" ]; then
+    local cli real
+    # Follow the symlink chain (portable: node realpath).
+    cli="$(node -e "console.log(require('fs').realpathSync(process.argv[1]))" "$omp_bin" 2>/dev/null || true)"
+    if [ -n "$cli" ]; then
+      # .../node_modules/@oh-my-pi/pi-coding-agent/dist/cli.js -> package dir
+      real="$(cd "$(dirname "$(dirname "$cli")")" && pwd)"
+      if [ -f "$real/package.json" ]; then echo "$real"; return; fi
+    fi
+  fi
+  echo ""
+}
+
+OMP_PACKAGE_DIR=$(resolve_omp_package_dir)
+if [ -z "$OMP_PACKAGE_DIR" ] || [ ! -f "$OMP_PACKAGE_DIR/package.json" ]; then
+  echo "skip: installed @oh-my-pi/pi-coding-agent package not found"
+  exit 0
+fi
+
+# Global node_modules root: sibling scope that holds @oh-my-pi/pi-tui and @types/node.
+GMOD="$(cd "$(dirname "$(dirname "$OMP_PACKAGE_DIR")")" && pwd)"
+if [ ! -d "$GMOD/@oh-my-pi/pi-tui" ] || [ ! -d "$GMOD/@types/node" ]; then
+  echo "not ok - global root missing @oh-my-pi/pi-tui or @types/node" >&2
+  exit 1
+fi
+
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-omp-primary-types.XXXXXX")
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_ROOT/lib" "$TMP_ROOT/node_modules/@oh-my-pi" "$TMP_ROOT/node_modules/@types"
+cp "$ROOT/.pi/extensions/fm-primary-omp-watch.ts" "$TMP_ROOT/fm-primary-omp-watch.ts"
+cp "$ROOT/.pi/extensions/fm-primary-omp-turnend-guard.ts" "$TMP_ROOT/fm-primary-omp-turnend-guard.ts"
+cp "$ROOT/.pi/extensions/lib/fm-calm-visibility-omp.ts" "$TMP_ROOT/lib/fm-calm-visibility-omp.ts"
+cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$TMP_ROOT/lib/fm-operational-input.ts"
+ln -s "$OMP_PACKAGE_DIR" "$TMP_ROOT/node_modules/@oh-my-pi/pi-coding-agent"
+ln -s "$GMOD/@oh-my-pi/pi-tui" "$TMP_ROOT/node_modules/@oh-my-pi/pi-tui"
+ln -s "$GMOD/@types/node" "$TMP_ROOT/node_modules/@types/node"
+
+cat > "$TMP_ROOT/package.json" <<'JSON'
+{"type":"module"}
+JSON
+cat > "$TMP_ROOT/tsconfig.json" <<'JSON'
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": ["node"]
+  },
+  "include": ["*.ts", "lib/*.ts"]
+}
+JSON
+
+tsc -p "$TMP_ROOT/tsconfig.json" || exit 1
+version=$(jq -r '.version' "$OMP_PACKAGE_DIR/package.json" 2>/dev/null || printf 'unknown')
+printf 'ok - tracked omp extensions pass strict no-emit typecheck against omp %s\n' "$version"

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -83,8 +83,8 @@ test_harness_resolution() {
     mkdir -p "$cfg"
     [ "$crew" = "-" ] || printf '%s\n' "$crew" > "$cfg/crew-harness"
     [ "$sm" = "-" ] || printf '%s\n' "$sm" > "$cfg/secondmate-harness"
-    got_sm=$(CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate)
-    got_crew=$(CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" crew)
+    got_sm=$(env -u OMPCODE CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate)
+    got_crew=$(env -u OMPCODE CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" crew)
     [ "$got_sm" = "$exp_sm" ] || fail "$label: secondmate resolved '$got_sm', expected '$exp_sm'"
     [ "$got_crew" = "$exp_crew" ] || fail "$label: crew resolved '$got_crew', expected '$exp_crew'"
   done <<'ROWS'
@@ -112,10 +112,10 @@ case "$*" in
 esac
 SH
   chmod +x "$fakebin/ps"
-  got=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+  got=$(env -u CLAUDECODE -u OMPCODE -u PI_CODING_AGENT -u GROK_AGENT \
     PATH="$fakebin:$BASE_PATH" CURSOR_INVOKED_AS=cursor-agent "$ROOT/bin/fm-harness.sh")
   [ "$got" = cursor ] || fail "Cursor's exact launcher marker resolved '$got', expected cursor"
-  got=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+  got=$(env -u CLAUDECODE -u OMPCODE -u PI_CODING_AGENT -u GROK_AGENT \
     PATH="$fakebin:$BASE_PATH" CURSOR_INVOKED_AS=cursor "$ROOT/bin/fm-harness.sh")
   [ "$got" != cursor ] || fail "an inexact Cursor marker value was accepted as Cursor Agent CLI"
   pass "fm-harness detects only Cursor Agent CLI's exact invocation marker"
@@ -140,9 +140,9 @@ test_secondmate_model_effort_tokens() {
     cfg="$case_dir/config"
     mkdir -p "$cfg"
     [ "$line" = ABSENT ] || printf '%b\n' "$line" > "$cfg/secondmate-harness"
-    got_h=$(CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate)
-    got_m=$(CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate-model)
-    got_e=$(CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate-effort)
+    got_h=$(env -u OMPCODE CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate)
+    got_m=$(env -u OMPCODE CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate-model)
+    got_e=$(env -u OMPCODE CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate-effort)
     [ "$got_h" = "$exp_harness" ] || fail "$label: harness resolved '$got_h', expected '$exp_harness'"
     [ "$got_m" = "$exp_model" ] || fail "$label: model resolved '$got_m', expected '$exp_model'"
     [ "$got_e" = "$exp_effort" ] || fail "$label: effort resolved '$got_e', expected '$exp_effort'"
@@ -254,7 +254,7 @@ SH
   chmod +x "$fakebin/ps"
 
   err="$dir/fm-harness.err"
-  got=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+  got=$(env -u CLAUDECODE -u OMPCODE -u PI_CODING_AGENT -u GROK_AGENT \
     PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-harness.sh" 2>"$err")
   [ "$got" = codex ] || fail "dash-leading shell ancestry resolved '$got', expected codex"
   [ ! -s "$err" ] || fail "fm-harness wrote basename option noise for literal -zsh: $(cat "$err")"

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -38,6 +38,7 @@ export FM_GATE_REFUSE_BYPASS=1
 # test files, not by this library, so it reads as "unused" here.
 # shellcheck disable=SC2034
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+unset OMPCODE  # No test should inherit the parent omp process's marker; tests that test omp detection set it explicitly.
 
 # --- reporters --------------------------------------------------------------
 


### PR DESCRIPTION
## What this does

Firstmate was misidentifying omp (Oh My Pi) as Claude Code. omp sets both `OMPCODE=1` and `CLAUDECODE=1` on its child processes (verified omp 17.3.3 and 17.3.5), and firstmate checked `CLAUDECODE` before any omp-specific marker. So every omp session got the Claude command surface — wrong hooks, wrong launch flags, wrong protocol doc — and the Pi-family extension supervision never engaged.

## The fix

**Detection** (`bin/fm-harness.sh`): check `OMPCODE=1` before `CLAUDECODE=1`, with the same precedence logic cursor uses (unambiguous marker first). Add `omp` to the ancestry fallback. omp is now correctly identified as `omp`, not `claude`. Precedence is now: cursor > grok > omp > claude > pi.

**Watcher extension** (`.pi/extensions/fm-primary-omp-watch.ts`): ported from the Pi watcher. The key change: omp fires `session_switch` (reason: new/resume/fork/handoff) for same-process replacements where Pi fired `session_shutdown` + `session_start`. Everything else is 1:1 — arm child lifecycle, `sendUserMessage({deliverAs:"followUp"})` wake, retry/recovery, lock ownership, the `fm_watch_arm_omp` tool and `/fm-watch-arm-omp` command.

**Turn-end guard** (`.pi/extensions/fm-primary-omp-turnend-guard.ts`): ported from the Pi guard. The key change: omp's `session_stop` event replaces Pi's `agent_settled` as the "turn about to settle" hook. `session_stop` carries `stop_hook_active` (matching what `fm-turnend-guard.sh` expects) and can natively request a continuation turn. The `tool_call` seatbelt (arm-pretool + cd-pretool), `session_compact` digest injection, and session-start digest are 1:1.

**Spawn** (`bin/fm-spawn.sh`): omp launch branch passes `-e` for both extensions explicitly (omp does not auto-discover project `.pi/extensions`), plus a per-task `.omp-ext.ts` sidecar using omp event names (`agent_start`/`agent_end` with `willContinue` guard instead of Pi's `agent_settled` + `isIdle`).

**Lock resolver** (`bin/fm-session-lock-lib.sh`): resolves the session lock correctly for omp.

**Docs**: `docs/supervision-protocols/omp.md` mirrors `pi.md` with omp event semantics. README adapter list updated.

## Verification

### Live-verified against real omp 17.3.5

- **Extension load + lifecycle.** Both extensions load and register in a real omp `-p` session. The full event sequence fires: `session_start -> agent_start -> turn_start -> turn_end -> session_stop(stop_hook_active=false) -> agent_end -> session_shutdown`. Both load markers (`.omp-watch-extension-loaded`, `.omp-turnend-extension-loaded`) write. Session lock and wake queue established.
- **Watcher arm (4A).** Model called `fm_watch_arm_omp` tool; watcher armed with fresh beacon (`beacon_age=0`); `.watch-cycle-exits.log` shows `origin=started exit_code=0 successor=started`; `.last-watcher-beat` written.
- **Seatbelt (4C).** Model attempted `bash .../fm-watch-arm.sh` (a protected command). The `tool_call` handler returned `{block: true}`; omp honored it — `tool_execution_end` shows `isError: true` with the deny reason `[watcher-nested]`. The command did NOT execute. The cd-guard deny (`[persistent-cd]`) is proven at the checker level and uses the identical block path.
- **Turn-end guard continuation (4D).** With supervision needed and no healthy watcher, the guard ran `fm-turnend-guard.sh` (exit 2), and the extension injected a `turn-end-guard: TURN WOULD END BLIND` followUp via `sendUserMessage({deliverAs:"followUp"})`, driving a continuation turn. With no supervision needed, the guard exits 0 and the session settles cleanly (proven in 4A).
- **Auto-retry interlock (4F).** Across multiple runs with inter-turn `willContinue` continuations, `session_stop` fires only at the final settle — never between turns — so the guard cannot fire during a retry. (Auto-retry is non-deterministic; the `auto_retry_start`/`auto_retry_end` events were observed in an earlier run but not captured alongside `session_stop` in the same run.)

### Static-verified

- **Detection matrix (8/8).** `tests/fm-omp-harness.test.sh` — all 8 cases green (env markers plus crew resolution, config-isolated).
- **Extension typecheck.** `tests/fm-omp-primary-types.test.sh` — both extensions pass strict no-emit typecheck against omp 17.3.5.
- **Shell lint.** All omp-changed shell scripts shellcheck-clean.
- **Regression.** Sibling adapter tests (cursor, grok, kimi, secondmate, pi-types) all pass — no regressions.

### Not yet live-verified (honest gaps)

These three cases from the verification plan (`docs/omp-adapter-verification.md`) could not be driven in this environment:

- **session_switch generation retirement (4B).** `session_switch` fires only on interactive same-process `/resume`, `/new`, `/fork` — not reproducible in `-p` print mode. The generation start/stop logic is typechecked and the start/shutdown endpoints are live-proven, but the switch-retirement path itself was not driven live.
- **Compaction digest (4E).** omp exposes no config key to force a `session_compact` event deterministically. The handler reuses `injectSessionstart` (proven live in 4A/4D), but the compact event path was not live-triggered.
- **E2E crew run through fm-spawn (6).** `fm-spawn` hardcodes the `firstmate` tmux session name (`bin/backends/tmux.sh:69`, no override), which is the live fleet session on this machine. The spawn omp branch and launch string are verified by code inspection and typecheck, but a live crew run was not driven to avoid interfering with the running fleet.

The deeper automated test files (`fm-omp-watch-extension`, `fm-omp-turnend-guard`, `fm-omp-primary-live-e2e`) are tracked as follow-up in the verification doc.

## Test files

- `tests/fm-omp-harness.test.sh` — detection matrix (mirrors cursor/grok tests), config-isolated
- `tests/fm-omp-primary-types.test.sh` — strict typecheck of both extensions against the installed omp package
- `tests/fixtures/omp-event-probe.ts` — test-only event probe for live verification
- `docs/omp-adapter-verification.md` — full testing and verification plan