### PR TITLE
feat: add direct Slack captain-action notifications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ config/startup-memory-budget     primary-authoritative per-home startup-memory b
 config/herdr-presentation-spaces  optional "off" opt-out from, or "on" opt-in to, Herdr's default-on disposable single-task visual projection, which is unconfigured-default-on only at or above a Herdr version floor; LOCAL, gitignored; inherited by secondmate homes; see docs/herdr-backend.md "Presentation spaces"
 config/trace-context  optional presence flag enabling default-off native W3C trace-context propagation to spawned agents; LOCAL, gitignored; inherited by secondmate homes; see docs/configuration.md "Trace context propagation" and docs/trace-context.md
 config/cmux-socket-password  optional cmux control-socket password; LOCAL, gitignored; read fresh on every cmux CLI call and passed through without ever overriding an operator's own ambient CMUX_SOCKET_PASSWORD when absent (docs/cmux-backend.md "Setup")
+config/slack-webhook-url  optional owner-only Slack Incoming Webhook secret for direct captain-action notifications; LOCAL, gitignored, and not inherited; see bin/fm-slack-notify.sh --help
 config/wedge-alarm  optional away-mode wedge-alarm active-alert directives; LOCAL, gitignored; absent means auto (macOS Notification Center when available); see docs/wedge-alarm.md
 config/x-mode.env    generated Relay watcher cadence; LOCAL, gitignored; source before arming watcher when present
 data/                personal fleet records; LOCAL, gitignored as a whole
@@ -467,6 +468,7 @@ Reach the captain immediately for:
 - Anything destructive, irreversible, or security-sensitive.
 - A needed credential or login.
 
+When `config/slack-webhook-url` is present and one of those outcomes genuinely requires captain action, invoke `bin/fm-slack-notify.sh send` with one concise, non-sensitive plain-English notification before sending the normal trusted-channel escalation; the command's help owns setup and exact mechanics, Slack never carries approval authority, and delivery success or failure changes no work state.
 Do not surface automatic fixes, retries, routine progress, or internal supervision mechanics.
 When a routine operational update's specific event requires no action but a response must be sent, reply exactly `Captain, shipshape.` without characterizing the visible session's unrelated decisions.
 Batch non-urgent updates into the next natural reply.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Launching a supported harness inside it instantiates your first mate - and makes
 - **Optional secondmates** - opt in to persistent second mates that run from isolated firstmate homes with their own `FM_HOME`, state, projects, and session lock, either locally or as a whole home on an SSH-reachable host, with guarded updates and recovery that never turns an unavailable remote route into a local replacement.
 - **Event-driven, zero-token supervision** - a bash watcher sleeps on the fleet and wakes the first mate only when something needs you; verified primary harnesses also get a turn-end backstop that blocks or follows up on a blind stop when work is under way and supervision is not live.
 - **Optional Relay** - opt in with one local `.env` pairing token so firstmate can answer your public mentions on X and Discord alike, act on normal reversible mention requests through the same lifecycle as chat requests, acknowledge spawned work, and post up to three public-safe completion follow-ups within seven days for genuine milestones and the final outcome without changing non-Relay behavior; a final reply promised in a thread becomes durable state that is reconciled from disk, so a restart or a compacted conversation cannot lose it; dry-run preview records would-be replies and dismissals locally before go-live.
+- **Optional Slack notifications** - configure one local Incoming Webhook for direct, best-effort captain-action alerts without making Slack a command or approval channel.
 - **Strict project boundary** - the first mate is read-only over your projects except for the narrow guarded and captain-approved operations authorized by [hard rule 1](AGENTS.md#1-identity-and-prime-directives), including fleet sync's guarded safe branch pruning; crewmates make every other project change behind the configured merge authority.
 - **Restart-proof** - all state lives on disk and in the active session backend (tmux by hard default, herdr or cmux when selected or auto-detected, zellij/orca when explicitly selected); kill the session anytime and the next one reconciles, including confirmed-dead secondmate agents, and carries on.
 
@@ -199,7 +200,7 @@ Firstmate's skills live in two separate places with different audiences:
 ## Documentation
 
 - [docs/architecture.md](docs/architecture.md) - maintainer architecture for the crew, supervision, worktrees, secondmates, and project modes.
-- [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, runtime backend selection, optional Relay and its X and Discord setup steps, the files you set, and harness support.
+- [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, runtime backend selection, optional Relay and direct Slack setup, the files you set, and harness support.
 - [docs/remote-secondmates.md](docs/remote-secondmates.md) - current setup, routing, transfer, recovery, and safety behavior for whole-home remote second mates.
 - [docs/calm.md](docs/calm.md) - current Pi `/calm` behavior and supported presentation limits.
 - [docs/wedge-alarm.md](docs/wedge-alarm.md) - configure the active alert for an away-mode escalation delivery that gets stuck.

--- a/bin/fm-slack-notify.sh
+++ b/bin/fm-slack-notify.sh
@@ -76,7 +76,7 @@ setup_webhook() {
       return 1
     }
   fi
-  if [ -d "$SECRET" ] && [ ! -L "$SECRET" ]; then
+  if [ -d "$SECRET" ]; then
     diag 'webhook path must not be a directory'
     return 1
   fi
@@ -92,11 +92,20 @@ setup_webhook() {
     return 1
   }
   chmod 600 "$tmp" 2>/dev/null || { rm -f "$tmp"; return 1; }
+  if [ -d "$SECRET" ]; then
+    rm -f "$tmp"
+    diag 'webhook path must not be a directory'
+    return 1
+  fi
   if ! printf '%s\n' "$value" > "$tmp" || ! mv -f "$tmp" "$SECRET"; then
     rm -f "$tmp"
     diag 'could not store the webhook'
     return 1
   fi
+  [ -f "$SECRET" ] && [ ! -L "$SECRET" ] || {
+    diag 'could not store the webhook as a private local file'
+    return 1
+  }
   chmod 600 "$SECRET" 2>/dev/null || {
     diag 'could not secure the webhook file'
     return 1

--- a/bin/fm-slack-notify.sh
+++ b/bin/fm-slack-notify.sh
@@ -24,6 +24,7 @@
 #
 # Test-only environment:
 #   FM_SLACK_NOTIFY_ALLOW_LOOPBACK=1 permits an http://127.0.0.1:<port>/ endpoint.
+set +x
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -74,6 +75,10 @@ setup_webhook() {
       diag 'could not create the private config directory'
       return 1
     }
+  fi
+  if [ -d "$SECRET" ] && [ ! -L "$SECRET" ]; then
+    diag 'webhook path must not be a directory'
+    return 1
   fi
   printf 'Paste Slack Incoming Webhook URL: ' >&2
   IFS= read -r -s value || true

--- a/bin/fm-slack-notify.sh
+++ b/bin/fm-slack-notify.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# Send one direct, bounded Slack Incoming Webhook notification.
+#
+# Usage:
+#   fm-slack-notify.sh setup
+#   printf '%s\n' '<concise safe captain-action message>' | fm-slack-notify.sh send
+#   fm-slack-notify.sh test
+#   fm-slack-notify.sh --help
+#
+# In Slack, create an app, enable Incoming Webhooks, and add one webhook for the
+# chosen private channel. Keep its URL out of chat and run `setup` locally.
+# `setup` prompts without echo and atomically stores the webhook in the current
+# Firstmate home's gitignored config/slack-webhook-url with mode 0600.
+# `send` is best-effort: absent configuration is a silent no-op, and delivery
+# failure prints one generic local diagnostic but returns success so the normal
+# trusted-channel escalation always continues. It accepts one plain-text line,
+# adds the notification-only boundary, attempts one POST, and never retries.
+# `test` sends one fixed harmless setup message and returns nonzero on failure.
+#
+# Slack is outbound notification only. Decisions, approvals, credentials, and
+# instructions must return through the trusted Firstmate captain channel.
+# Remove config/slack-webhook-url to disable notifications. Re-run `setup` to
+# rotate locally, then revoke the old webhook in Slack.
+#
+# Test-only environment:
+#   FM_SLACK_NOTIFY_ALLOW_LOOPBACK=1 permits an http://127.0.0.1:<port>/ endpoint.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+SECRET="$CONFIG/slack-webhook-url"
+WEBHOOK=
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0"
+}
+
+diag() {
+  printf 'slack-notify: %s\n' "$1" >&2
+}
+
+file_mode() {
+  if [ "$(uname)" = Darwin ]; then
+    stat -f %Lp "$1" 2>/dev/null
+  else
+    stat -c %a "$1" 2>/dev/null
+  fi
+}
+
+webhook_valid() {
+  local value=$1 slack_re loopback_re
+  slack_re='^https://hooks\.slack\.com/services/[A-Za-z0-9_-]+/[A-Za-z0-9_-]+/[A-Za-z0-9_-]+$'
+  loopback_re='^http://127\.0\.0\.1:[0-9]+/[A-Za-z0-9._/?&%-]*$'
+  [[ "$value" =~ $slack_re ]] && return 0
+  [ "${FM_SLACK_NOTIFY_ALLOW_LOOPBACK:-}" = 1 ] \
+    && [[ "$value" =~ $loopback_re ]]
+}
+
+setup_webhook() {
+  local value tmp
+  if [ -e "$CONFIG" ] || [ -L "$CONFIG" ]; then
+    [ -d "$CONFIG" ] && [ ! -L "$CONFIG" ] || {
+      diag 'config must be a non-symlink directory'
+      return 1
+    }
+  else
+    mkdir -m 700 -p "$CONFIG" 2>/dev/null || {
+      diag 'could not create the private config directory'
+      return 1
+    }
+  fi
+  printf 'Paste Slack Incoming Webhook URL: ' >&2
+  IFS= read -r -s value || true
+  printf '\n' >&2
+  webhook_valid "$value" || {
+    diag 'the webhook URL is not an accepted Slack Incoming Webhook'
+    return 1
+  }
+  tmp=$(mktemp "$CONFIG/.slack-webhook-url.XXXXXX" 2>/dev/null) || {
+    diag 'could not create a private temporary file'
+    return 1
+  }
+  chmod 600 "$tmp" 2>/dev/null || { rm -f "$tmp"; return 1; }
+  if ! printf '%s\n' "$value" > "$tmp" || ! mv -f "$tmp" "$SECRET"; then
+    rm -f "$tmp"
+    diag 'could not store the webhook'
+    return 1
+  fi
+  chmod 600 "$SECRET" 2>/dev/null || {
+    diag 'could not secure the webhook file'
+    return 1
+  }
+  printf '%s\n' 'slack-notify: configured'
+}
+
+load_webhook() {
+  local mode extra=
+  WEBHOOK=
+  if [ ! -e "$SECRET" ] && [ ! -L "$SECRET" ]; then
+    return 2
+  fi
+  [ -d "$CONFIG" ] && [ ! -L "$CONFIG" ] \
+    && [ -f "$SECRET" ] && [ ! -L "$SECRET" ] || return 1
+  mode=$(file_mode "$SECRET") || return 1
+  [ "$mode" = 600 ] || return 1
+  IFS= read -r WEBHOOK < "$SECRET" || true
+  if IFS= read -r extra < <(tail -n +2 "$SECRET" 2>/dev/null) || [ -n "$extra" ]; then
+    return 1
+  fi
+  [ -n "$WEBHOOK" ] && webhook_valid "$WEBHOOK"
+}
+
+safe_message() {
+  local message=$1
+  [ -n "$message" ] && [ "${#message}" -le 280 ] || return 1
+  case "$message" in
+    *[$'\001'-$'\037'$'\177']*) return 1 ;;
+  esac
+  return 0
+}
+
+payload_for() {
+  local message=$1 text
+  text=$(printf '%s\n\nNotification only. Return decisions, approvals, credentials, and instructions through the trusted Firstmate captain channel.' "$message")
+  printf '%s' "$text" | jq -Rs '{text:.}'
+}
+
+post_payload() {
+  local payload=$1 response code rc body proto='=https'
+  command -v curl >/dev/null 2>&1 || return 1
+  command -v jq >/dev/null 2>&1 || return 1
+  case "$WEBHOOK" in http://127.0.0.1:*) proto='=http,https' ;; esac
+  response=$(mktemp "${TMPDIR:-/tmp}/fm-slack-notify.XXXXXX" 2>/dev/null) || return 1
+  chmod 600 "$response" 2>/dev/null || { rm -f "$response"; return 1; }
+  code=$(printf '%s' "$payload" | curl --disable \
+    --silent \
+    --request POST \
+    --header 'Content-Type: application/json; charset=utf-8' \
+    --data-binary @- \
+    --output "$response" \
+    --write-out '%{http_code}' \
+    --connect-timeout 2 \
+    --max-time 5 \
+    --max-redirs 0 \
+    --max-filesize 1024 \
+    --proto "$proto" \
+    --config /dev/fd/3 \
+    3< <(printf 'url = "%s"\n' "$WEBHOOK") \
+    2>/dev/null)
+  rc=$?
+  body=$(cat "$response" 2>/dev/null || true)
+  rm -f "$response"
+  [ "$rc" -eq 0 ] && [ "$code" = 200 ] && [ "$body" = ok ]
+}
+
+send_message() {
+  local message= payload load_rc
+  load_webhook
+  load_rc=$?
+  case "$load_rc" in
+    0) ;;
+    2) return 0 ;;
+    *) diag 'webhook configuration is unsafe or invalid; notification skipped'; return 0 ;;
+  esac
+  IFS= read -r message || true
+  safe_message "$message" || {
+    diag 'message must be one non-empty plain-text line of at most 280 characters'
+    return 0
+  }
+  command -v jq >/dev/null 2>&1 || {
+    diag 'delivery dependency unavailable; notification skipped'
+    return 0
+  }
+  payload=$(payload_for "$message") || {
+    diag 'could not prepare the notification; notification skipped'
+    return 0
+  }
+  post_payload "$payload" || diag 'delivery failed; the trusted-channel escalation still continues'
+  return 0
+}
+
+test_message() {
+  local payload load_rc
+  load_webhook
+  load_rc=$?
+  case "$load_rc" in
+    0) ;;
+    2) diag 'not configured'; return 1 ;;
+    *) diag 'webhook configuration is unsafe or invalid'; return 1 ;;
+  esac
+  command -v jq >/dev/null 2>&1 || { diag 'delivery dependency unavailable'; return 1; }
+  payload=$(payload_for 'Firstmate Slack setup test. No action is required.') || return 1
+  if post_payload "$payload"; then
+    printf '%s\n' 'slack-notify: test delivered'
+    return 0
+  fi
+  diag 'test delivery failed'
+  return 1
+}
+
+umask 077
+case "${1:-}" in
+  setup)
+    [ "$#" -eq 1 ] || { usage >&2; exit 2; }
+    setup_webhook
+    ;;
+  send)
+    [ "$#" -eq 1 ] || { usage >&2; exit 2; }
+    send_message
+    ;;
+  test)
+    [ "$#" -eq 1 ] || { usage >&2; exit 2; }
+    test_message
+    ;;
+  -h|--help)
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -141,7 +141,7 @@ family_for_basename() {
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-kimi-harness.test.sh|fm-muse-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
     fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
-    fm-send-popup-settle.test.sh|fm-send-settle.test.sh|\
+    fm-send-popup-settle.test.sh|fm-send-settle.test.sh|fm-slack-notify.test.sh|\
     fm-subagent-pretool-check.test.sh|\
     fm-supervision-instructions.test.sh|fm-task-delivery.test.sh|\
     fm-tmux-submit-busy.test.sh|fm-trace-context-lib.test.sh|\
@@ -899,6 +899,9 @@ families_for_changed_path() {
     bin/fm-startup-memory-budget.sh|bin/fm-startup-memory-budget-lib.sh)
       printf '%s\n' secondmate
       printf '%s\n' session-bootstrap
+      ;;
+    bin/fm-slack-notify.sh)
+      printf '%s\n' pure-contract-unit
       ;;
     bin/fm-secondmate*|bin/fm-remote*|bin/fm-on.sh|bin/fm-home-seed.sh|\
     bin/fm-backlog-handoff.sh|bin/fm-backlog-receive.sh|bin/fm-procevent-remote-reply.sh|\

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -106,6 +106,14 @@ That keeps a tmux pane nested inside herdr on the tmux transport, matching the r
 Target detection uses `FM_SUPERVISOR_TARGET`, then `$TMUX_PANE`, then `"${HERDR_SESSION:-default}:${HERDR_PANE_ID}"` under herdr, then the legacy `firstmate:0` tmux fallback with a warning.
 Selecting any other supervisor backend, including `zellij`, `orca`, or `cmux`, refuses at daemon startup instead of trying tmux injection primitives against a non-tmux pane.
 
+## Direct Slack notifications (config/slack-webhook-url)
+
+`bin/fm-slack-notify.sh` can send one direct, best-effort Slack Incoming Webhook notification when Firstmate is already sending a genuine captain-action escalation through the trusted channel.
+Run `bin/fm-slack-notify.sh setup`, then `bin/fm-slack-notify.sh test`; the command's `--help` owns exact setup, rotation, disabling, and notification-only boundaries.
+The owner-only webhook file is local and gitignored, is not inherited into secondmate homes, and has no effect when absent.
+This path adds no scanner, watcher hook, event identity, deduplication state, command ingestion, approval channel, or background service.
+It is an ordinary host command independent of every primary harness and runtime backend, so no adapter-specific integration applies.
+
 ## Away-mode wedge alarm channels (config/wedge-alarm)
 
 When away-mode injection wedges past `FM_MAX_DEFER_SECS`, the sub-supervisor raises a loud, rate-limited alarm.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -75,6 +75,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-afk-start.sh`        | Run the common sourceable away-mode daemon entry in the foreground                      |
 | `fm-afk-launch.sh`       | Own away-mode entry, exit, rollback, and any backend terminal lifecycle                 |
 | `fm-afk-return.sh`       | Own deterministic return shutdown, catch-up evidence, and the firstmate-actionable blocker gate |
+| `fm-slack-notify.sh`     | Configure and send one direct bounded Slack captain-action notification             |
 | `fm-supervisor-target-lib.sh` | Resolve the shared supervisor target and backend for the daemon and launcher       |
 | `fm-supervise-daemon.sh` | Presence-gated away-mode sub-supervisor: self-handle routine wakes, guard injection by the detected primary harness, escalate batched digests, alert on failed delivery |
 | `fm-crew-state.sh`       | Print one deterministic current-state line for a crew                                |

--- a/tests/fm-slack-notify.test.sh
+++ b/tests/fm-slack-notify.test.sh
@@ -119,6 +119,49 @@ test_setup_atomically_replaces_a_symlink() {
   pass "setup atomically replaces an existing symlink with one private local secret"
 }
 
+test_setup_rejects_a_directory_target() {
+  local home out rc mode
+  home=$(make_home setup-directory)
+  mkdir "$home/config/slack-webhook-url"
+  chmod 700 "$home/config/slack-webhook-url"
+  printf 'unrelated data\n' > "$home/config/slack-webhook-url/marker"
+  out=$(printf 'http://127.0.0.1:%s/directory\n' "$PORT" | \
+    FM_HOME="$home" FM_SLACK_NOTIFY_ALLOW_LOOPBACK=1 "$NOTIFY" setup 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "setup accepted a directory as the webhook target"
+  printf '%s' "$out" | grep -F 'must not be a directory' >/dev/null \
+    || fail "setup did not explain the invalid webhook target"
+  mode=$(if [ "$(uname)" = Darwin ]; then stat -f %Lp "$home/config/slack-webhook-url"; else stat -c %a "$home/config/slack-webhook-url"; fi)
+  [ "$mode" = 700 ] || fail "setup changed the directory target mode"
+  [ "$(cat "$home/config/slack-webhook-url/marker")" = 'unrelated data' ] \
+    || fail "setup changed unrelated directory contents"
+  [ "$(find "$home/config/slack-webhook-url" -mindepth 1 -maxdepth 1 | wc -l | tr -d ' ')" = 1 ] \
+    || fail "setup moved its temporary file into the directory target"
+  pass "setup rejects a directory target without mutating it"
+}
+
+test_shell_trace_does_not_expose_the_webhook() {
+  local home path webhook setup_trace send_trace before after
+  home=$(make_home trace)
+  path=/trace-secret-token
+  webhook="http://127.0.0.1:$PORT$path"
+  setup_trace=$(printf '%s\n' "$webhook" | \
+    FM_HOME="$home" FM_SLACK_NOTIFY_ALLOW_LOOPBACK=1 bash -x "$NOTIFY" setup 2>&1) \
+    || fail "setup failed under shell tracing"
+  printf '%s' "$setup_trace" | grep -F "$webhook" >/dev/null \
+    && fail "setup shell trace exposed the webhook"
+  [ "$(cat "$home/config/slack-webhook-url")" = "$webhook" ] \
+    || fail "setup under shell tracing did not persist the webhook"
+  before=$(count_path "$path")
+  send_trace=$(printf '%s\n' 'Alpha needs a release decision.' | \
+    FM_HOME="$home" FM_SLACK_NOTIFY_ALLOW_LOOPBACK=1 bash -x "$NOTIFY" send 2>&1)
+  printf '%s' "$send_trace" | grep -F "$webhook" >/dev/null \
+    && fail "send shell trace exposed the webhook"
+  after=$(count_path "$path")
+  [ "$after" -eq $((before + 1)) ] || fail "send under shell tracing did not deliver"
+  pass "shell tracing stays disabled throughout webhook handling"
+}
+
 test_direct_send_shapes_one_way_payload() {
   local home path before after text
   home=$(make_home success)
@@ -188,6 +231,8 @@ test_explicit_harmless_test() {
 
 test_absent_configuration_is_inert
 test_setup_atomically_replaces_a_symlink
+test_setup_rejects_a_directory_target
+test_shell_trace_does_not_expose_the_webhook
 test_direct_send_shapes_one_way_payload
 test_direct_send_has_no_deduplication
 test_failure_is_bounded_and_best_effort

--- a/tests/fm-slack-notify.test.sh
+++ b/tests/fm-slack-notify.test.sh
@@ -140,6 +140,31 @@ test_setup_rejects_a_directory_target() {
   pass "setup rejects a directory target without mutating it"
 }
 
+test_setup_rejects_a_symlink_to_a_directory() {
+  local home outside out rc mode
+  home=$(make_home setup-symlink-directory)
+  outside="$home/outside-directory"
+  mkdir "$outside"
+  chmod 700 "$outside"
+  printf 'unrelated data\n' > "$outside/marker"
+  ln -s "$outside" "$home/config/slack-webhook-url"
+  out=$(printf 'http://127.0.0.1:%s/symlink-directory\n' "$PORT" | \
+    FM_HOME="$home" FM_SLACK_NOTIFY_ALLOW_LOOPBACK=1 "$NOTIFY" setup 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "setup accepted a symlink resolving to a directory"
+  printf '%s' "$out" | grep -F 'must not be a directory' >/dev/null \
+    || fail "setup did not explain the symlinked directory target"
+  [ -L "$home/config/slack-webhook-url" ] \
+    || fail "setup replaced the symlinked directory target"
+  mode=$(if [ "$(uname)" = Darwin ]; then stat -f %Lp "$outside"; else stat -c %a "$outside"; fi)
+  [ "$mode" = 700 ] || fail "setup changed the symlinked directory mode"
+  [ "$(cat "$outside/marker")" = 'unrelated data' ] \
+    || fail "setup changed unrelated symlinked directory contents"
+  [ "$(find "$outside" -mindepth 1 -maxdepth 1 | wc -l | tr -d ' ')" = 1 ] \
+    || fail "setup moved its temporary file through the directory symlink"
+  pass "setup rejects a symlinked directory without mutating its target"
+}
+
 test_shell_trace_does_not_expose_the_webhook() {
   local home path webhook setup_trace send_trace before after
   home=$(make_home trace)
@@ -232,6 +257,7 @@ test_explicit_harmless_test() {
 test_absent_configuration_is_inert
 test_setup_atomically_replaces_a_symlink
 test_setup_rejects_a_directory_target
+test_setup_rejects_a_symlink_to_a_directory
 test_shell_trace_does_not_expose_the_webhook
 test_direct_send_shapes_one_way_payload
 test_direct_send_has_no_deduplication

--- a/tests/fm-slack-notify.test.sh
+++ b/tests/fm-slack-notify.test.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# Focused behavior tests for the direct, opt-in Slack notification command.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+NOTIFY="$ROOT/bin/fm-slack-notify.sh"
+TMP_ROOT=$(fm_test_tmproot fm-slack-notify)
+SERVER="$TMP_ROOT/server"
+mkdir -p "$SERVER"
+SERVER_PID=
+
+cleanup_notify_test() {
+  if [ -n "${SERVER_PID:-}" ]; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  fm_test_cleanup
+}
+trap cleanup_notify_test EXIT
+trap 'cleanup_notify_test; exit 130' INT
+trap 'cleanup_notify_test; exit 143' TERM
+
+cat > "$SERVER/server.py" <<'PY'
+import http.server
+import json
+import pathlib
+import threading
+import time
+
+root = pathlib.Path(__file__).parent
+lock = threading.Lock()
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        body = self.rfile.read(int(self.headers.get("Content-Length", "0"))).decode()
+        with lock:
+            with (root / "requests.jsonl").open("a") as out:
+                out.write(json.dumps({"path": self.path, "body": body}) + "\n")
+        if self.path == "/slow":
+            time.sleep(8)
+        response = b"bad" if self.path == "/bad" else b"ok"
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(response)))
+        self.end_headers()
+        try:
+            self.wfile.write(response)
+        except BrokenPipeError:
+            pass
+
+    def log_message(self, *args):
+        pass
+
+server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+(root / "port").write_text(str(server.server_port))
+server.serve_forever()
+PY
+python3 "$SERVER/server.py" > "$SERVER/stdout" 2> "$SERVER/stderr" &
+SERVER_PID=$!
+for _ in $(seq 1 100); do
+  [ -s "$SERVER/port" ] && break
+  kill -0 "$SERVER_PID" 2>/dev/null || fail "capture server exited during startup"
+  sleep 0.05
+done
+[ -s "$SERVER/port" ] || fail "capture server did not publish a port"
+PORT=$(cat "$SERVER/port")
+REQUESTS="$SERVER/requests.jsonl"
+
+make_home() {
+  local home="$TMP_ROOT/$1"
+  mkdir -p "$home/config" "$home/state"
+  chmod 700 "$home/config"
+  printf '%s' "$home"
+}
+
+write_webhook() {
+  local home=$1 path=$2
+  printf 'http://127.0.0.1:%s%s\n' "$PORT" "$path" > "$home/config/slack-webhook-url"
+  chmod 600 "$home/config/slack-webhook-url"
+}
+
+count_path() {
+  local path=$1
+  [ -f "$REQUESTS" ] || { printf '0'; return; }
+  jq -s --arg path "$path" '[.[] | select(.path == $path)] | length' "$REQUESTS"
+}
+
+last_text() {
+  local path=$1
+  jq -rs --arg path "$path" '[.[] | select(.path == $path)] | last | .body | fromjson | .text' "$REQUESTS"
+}
+
+test_absent_configuration_is_inert() {
+  local home out before after
+  home=$(make_home absent)
+  before=$(count_path /ok)
+  out=$(printf '%s\n' 'Alpha needs a release decision.' | FM_HOME="$home" "$NOTIFY" send 2>&1)
+  after=$(count_path /ok)
+  [ -z "$out" ] || fail "absent configuration produced output: $out"
+  [ "$before" = "$after" ] || fail "absent configuration sent a request"
+  [ ! -e "$home/state/slack-alerts" ] || fail "direct notifier created deduplication state"
+  pass "absent configuration is a silent no-op with no notification state"
+}
+
+test_setup_atomically_replaces_a_symlink() {
+  local home outside mode
+  home=$(make_home setup)
+  outside="$home/outside-secret"
+  printf 'outside unchanged\n' > "$outside"
+  ln -s "$outside" "$home/config/slack-webhook-url"
+  printf 'http://127.0.0.1:%s/setup\n' "$PORT" | \
+    FM_HOME="$home" FM_SLACK_NOTIFY_ALLOW_LOOPBACK=1 "$NOTIFY" setup >/dev/null 2>&1 \
+    || fail "setup rejected the local fake webhook"
+  [ ! -L "$home/config/slack-webhook-url" ] || fail "setup retained the webhook symlink"
+  [ "$(cat "$outside")" = 'outside unchanged' ] || fail "setup followed and overwrote the symlink target"
+  mode=$(if [ "$(uname)" = Darwin ]; then stat -f %Lp "$home/config/slack-webhook-url"; else stat -c %a "$home/config/slack-webhook-url"; fi)
+  [ "$mode" = 600 ] || fail "setup did not store the webhook with mode 0600"
+  pass "setup atomically replaces an existing symlink with one private local secret"
+}
+
+test_direct_send_shapes_one_way_payload() {
+  local home path before after text
+  home=$(make_home success)
+  path=/success
+  write_webhook "$home" "$path"
+  before=$(count_path "$path")
+  printf '%s\n' 'Alpha is ready for your release approval.' | \
+    FM_HOME="$home" FM_SLACK_NOTIFY_ALLOW_LOOPBACK=1 "$NOTIFY" send >/dev/null 2>&1
+  after=$(count_path "$path")
+  [ "$after" -eq $((before + 1)) ] || fail "direct send did not make exactly one request"
+  text=$(last_text "$path")
+  printf '%s' "$text" | grep -F 'Alpha is ready for your release approval.' >/dev/null \
+    || fail "payload omitted the supplied concise captain-action message"
+  printf '%s' "$text" | grep -F 'Notification only.' >/dev/null \
+    || fail "payload omitted the notification-only boundary"
+  printf '%s' "$text" | grep -F 'decisions, approvals, credentials, and instructions' >/dev/null \
+    || fail "payload omitted trusted-channel return categories"
+  pass "direct send posts one concise notification-only payload"
+}
+
+test_direct_send_has_no_deduplication() {
+  local home path before after
+  home=$(make_home duplicates)
+  path=/duplicates
+  write_webhook "$home" "$path"
+  before=$(count_path "$path")
+  for _ in 1 2; do
+    printf '%s\n' 'Alpha still needs your decision.' | \
+      FM_HOME="$home" FM_SLACK_NOTIFY_ALLOW_LOOPBACK=1 "$NOTIFY" send >/dev/null 2>&1
+  done
+  after=$(count_path "$path")
+  [ "$after" -eq $((before + 2)) ] || fail "direct notifier unexpectedly added deduplication or event state"
+  [ ! -e "$home/state/slack-alerts" ] || fail "direct notifier persisted event identity"
+  pass "each explicit invocation is one attempt with no scanner or deduplication infrastructure"
+}
+
+test_failure_is_bounded_and_best_effort() {
+  local home start elapsed out rc
+  home=$(make_home timeout)
+  write_webhook "$home" /slow
+  start=$SECONDS
+  out=$(printf '%s\n' 'Alpha needs your decision.' | \
+    FM_HOME="$home" FM_SLACK_NOTIFY_ALLOW_LOOPBACK=1 "$NOTIFY" send 2>&1)
+  rc=$?
+  elapsed=$((SECONDS - start))
+  [ "$rc" -eq 0 ] || fail "delivery failure blocked the normal escalation"
+  [ "$elapsed" -lt 7 ] || fail "delivery exceeded its short bound (${elapsed}s)"
+  printf '%s' "$out" | grep -F 'trusted-channel escalation still continues' >/dev/null \
+    || fail "delivery failure lacked the generic local diagnostic"
+  printf '%s' "$out" | grep -F "127.0.0.1:$PORT" >/dev/null \
+    && fail "delivery diagnostic exposed the webhook"
+  pass "delivery failure is bounded, generic, and best-effort"
+}
+
+test_explicit_harmless_test() {
+  local home out text
+  home=$(make_home test)
+  write_webhook "$home" /test
+  out=$(FM_HOME="$home" FM_SLACK_NOTIFY_ALLOW_LOOPBACK=1 "$NOTIFY" test 2>&1) \
+    || fail "explicit setup test failed: $out"
+  printf '%s' "$out" | grep -F 'test delivered' >/dev/null || fail "test did not report success"
+  text=$(last_text /test)
+  printf '%s' "$text" | grep -F 'No action is required.' >/dev/null \
+    || fail "test message could be mistaken for a real escalation"
+  pass "explicit setup test uses the local fake endpoint and requires no Slack credential"
+}
+
+test_absent_configuration_is_inert
+test_setup_atomically_replaces_a_symlink
+test_direct_send_shapes_one_way_payload
+test_direct_send_has_no_deduplication
+test_failure_is_bounded_and_best_effort
+test_explicit_harmless_test


### PR DESCRIPTION
## Intent

Implement only the simple direct Slack notifier: one local gitignored Slack Incoming Webhook secret; one bounded best-effort setup/test/send command invoked explicitly by Firstmate when Firstmate is already sending a genuine captain-action escalation; concise operator documentation; and focused fake-endpoint behavior tests requiring no real Slack credential. Slack is outbound notification-only; decisions, approvals, credentials, and instructions must return through the trusted captain channel. Keep the feature inert when unconfigured, keep the secret owner-only where supported, do not expose it in command arguments, logs, errors, status, commits, secondmate homes, or workers, and ensure delivery failure cannot block or crash supervision or erase the original trusted-channel escalation. Explicitly do not add background scanning, durable event identity, cursor/index state, automatic wake hooks, generalized notification categories, primary/task event plumbing, deduplication infrastructure, services, callback servers, OAuth, Slack command ingestion, approvals from Slack, or generalized notification architecture. Occasional duplicate direct alerts are acceptable. Treat every prior automatic Slack design requirement and finding as obsolete. Preserve the captain-approved proportional fixes that disable xtrace before secret handling, reject directory and symlink-directory secret targets, and verify the final secret is a regular non-symlink file. The captain explicitly accepted the remaining concurrent target-substitution race to preserve the simple local setup and rejected adding broader atomic-publication infrastructure. This run validates the current fixed head, pushes it to the captain-approved public benleivian/firstmate fork, and opens a PR against kunchenguid/firstmate. Rebase, documentation, and lint are skipped because the base/docs are unchanged and the prior local lint dependency remains unavailable; review and behavior tests must validate the changed head.

## What Changed

- Add an explicit `setup`, `test`, and `send` command for local, owner-only Slack Incoming Webhook notifications that remains inert when unconfigured.
- Deliver bounded, best-effort captain-action alerts while keeping Slack notification-only and preserving trusted-channel escalation on failure.
- Document the Slack workflow and add fake-endpoint tests covering secret safety, payloads, duplicate sends, and failure behavior.

## Risk Assessment

✅ Low: Captain, the notifier is narrowly scoped, inert when unconfigured, bounded and best-effort, and its secret-handling safeguards and behavior tests conform to the stated intent.

## Testing

The focused behavior test passed, and an independent fake-endpoint journey demonstrated private setup, harmless testing, genuine captain-action delivery, outbound-only copy, inert unconfigured behavior, and bounded non-blocking failure; reviewer-visible CLI and JSON evidence were captured.

<details>
<summary>Evidence: End-to-end CLI transcript</summary>

Source: [End-to-end CLI transcript](https://github.com/benleivian/firstmate/blob/4e25a496fda5d04f27e78e6c7beaa2578930b190/.no-mistakes/evidence/fm/slack-captain-alerts-simple-s3/slack-notifier-e2e.txt)

```text
Direct Slack notifier end-to-end verification

SETUP
exit=0
stdout: slack-notify: configured
stderr: Paste Slack Incoming Webhook URL:
stored secret: regular non-symlink file, mode 0o600

EXPLICIT TEST
exit=0
stdout: slack-notify: test delivered
received payload: {"text": "Firstmate Slack setup test. No action is required.\n\nNotification only. Return decisions, approvals, credentials, and instructions through the trusted Firstmate captain channel."}

GENUINE CAPTAIN-ACTION SEND
exit=0
stdout: <silent success>
stderr: <silent>
received payload: {"text": "Alpha is ready for your release approval.\n\nNotification only. Return decisions, approvals, credentials, and instructions through the trusted Firstmate captain channel."}

UNCONFIGURED SEND
exit=0
output: <silent>
requests made: 0

FAILED DELIVERY
exit=0
elapsed=5.19s
stderr: slack-notify: delivery failed; the trusted-channel escalation still continues
```
</details>
<details>
<summary>Evidence: Structured fake-endpoint evidence</summary>

Source: [Structured fake-endpoint evidence](https://github.com/benleivian/firstmate/blob/4e25a496fda5d04f27e78e6c7beaa2578930b190/.no-mistakes/evidence/fm/slack-captain-alerts-simple-s3/slack-notifier-e2e.json)

```text
{
  "scenario": "Firstmate direct Slack notifier against a local fake Incoming Webhook endpoint",
  "setup": {
    "exit_code": 0,
    "stdout": "slack-notify: configured\n",
    "stderr": "Paste Slack Incoming Webhook URL: \n",
    "elapsed_seconds": 0.02
  },
  "stored_secret_contract": {
    "kind": "regular non-symlink file",
    "mode": "0o600"
  },
  "explicit_test": {
    "exit_code": 0,
    "stdout": "slack-notify: test delivered\n",
    "stderr": "",
    "elapsed_seconds": 0.04
  },
  "direct_send": {
    "exit_code": 0,
    "stdout": "",
    "stderr": "",
    "elapsed_seconds": 0.04
  },
  "fake_endpoint_received": [
    {
      "path": "/notify",
      "content_type": "application/json; charset=utf-8",
      "payload": {
        "text": "Firstmate Slack setup test. No action is required.\n\nNotification only. Return decisions, approvals, credentials, and instructions through the trusted Firstmate captain channel."
      }
    },
    {
      "path": "/notify",
      "content_type": "application/json; charset=utf-8",
      "payload": {
        "text": "Alpha is ready for your release approval.\n\nNotification only. Return decisions, approvals, credentials, and instructions through the trusted Firstmate captain channel."
      }
    },
    {
      "path": "/slow",
      "content_type": "application/json; charset=utf-8",
      "payload": {
        "text": "Alpha needs your decision.\n\nNotification only. Return decisions, approvals, credentials, and instructions through the trusted Firstmate captain channel."
      }
    }
  ],
  "unconfigured_send": {
    "exit_code": 0,
    "stdout": "",
    "stderr": "",
    "elapsed_seconds": 0.01,
    "requests_made": 0
  },
  "delivery_timeout": {
    "exit_code": 0,
    "stdout": "",
    "stderr": "slack-notify: delivery failed; the trusted-channel escalation still continues\n",
    "elapsed_seconds": 5.19
  },
  "interpretation": "Setup created a 0600 regular local secret; test and send delivered outbound-only payloads; absent config made no request; timeout returned success with a generic trusted-channel-continuation diagnostic."
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"3cf692529bcd2bdf45a661242dc2fb63a55226f8","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"skipped"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"skipped"},{"step":"lint","status":"skipped"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Rebase** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `tests/fm-slack-notify.test.sh`
- <code>Manual end-to-end execution of `fm-slack-notify.sh setup`, `test`, and `send` against a local fake Incoming Webhook endpoint</code>
- <code>Manual unconfigured `send` verification: silent success with zero HTTP requests</code>
- `Manual slow-endpoint verification: delivery stopped after about 5.2 seconds, returned success, and preserved the trusted-channel escalation diagnostic`
- <code>Verified setup produced a regular non-symlink secret file with mode `0600` and captured the actual outbound notification-only JSON payload</code>

</details>

<details>
<summary>⏭️ **Document** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
