### PR TITLE
fix(bin): reconcile decision holds whose routed work completed out of band

### DIFF
--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -43,7 +43,12 @@
 # include a `Resolution mode:` naming their path; older routed records remain valid.
 #
 # `resolve` is the routed path. It requires every --routed-to task to exist and to
-# be blocked by the hold. It writes the captain decision and routed identities into
+# be blocked by the hold, with one reconciliation exception: a routed task that
+# already completed out of band (a direct tasks-axi done) is accepted when its own
+# durable blocked-by edge still names the hold, which is the surviving proof the
+# work really was routed behind this decision; a done task without that edge is
+# refused, and decline likewise keeps refusing it, so neither path can close the
+# hold from a guess. It writes the captain decision and routed identities into
 # the hold body, clears those dependency edges, and only then marks the hold Done.
 # A failure before the final step leaves the captain hold open.
 #
@@ -534,9 +539,16 @@ command_resolve() {
   for dep in $routed; do
     show=$(task_show "$dep") || fail "routed task $dep does not exist in the active home"
     state=$(show_field "$show" state)
-    [ "$state" != "done" ] || [ "$resolution_recorded" = 1 ] \
-      || fail "routed task $dep is already done"
     blocked=$(normalized_blocked_by "$show")
+    # A routed task completed out of band (a direct tasks-axi done) is
+    # reconcilable only while its own durable blocked-by edge still names this
+    # hold: that edge is the surviving evidence the work was routed behind this
+    # decision. Without it, a done task proves nothing and the close is refused
+    # rather than recorded from a guess.
+    if [ "$state" = "done" ] && [ "$resolution_recorded" != 1 ] \
+      && ! list_has_key "$blocked" "$id"; then
+      fail "routed task $dep is already done and no durable blocked-by edge to $id survives"
+    fi
     if ! list_has_key "$blocked" "$id"; then
       case "$hold_body" in
         *"Resolution recorded by fm-decision-hold."*"- $dep"*) : ;;

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -30,6 +30,7 @@ An exact retry is idempotent, while a changed decision or, for `resolve`, a chan
 The `resolve` subcommand is the routed path and additionally requires at least one existing dependent task whose structured `blocked-by` edge points to the hold.
 It clears each dependency edge through tasks-axi and marks the hold Done only after those writes succeed.
 An exact retry can finish a partial routing operation, and a failed intermediate step leaves the hold open.
+A dependent that already completed out of band (a direct `tasks-axi done`) is reconciled when its own `blocked-by` edge still names the hold, which is the surviving evidence the work was routed behind the decision; a done dependent without that edge is refused, so neither close path records a routing from a guess.
 
 The `decline` subcommand closes a hold whose captain answer routes no follow-up work, recording `(none)` as the routed identities.
 It refuses while any task in the same backlog is still blocked by the hold, because releasing routed work without recording it is `resolve`'s job.
@@ -55,6 +56,7 @@ Verification date: 2026-07-14.
 Additional quoted `blocked_by` regression verification date: 2026-07-17.
 Plural blocker-readiness and mixed-home projection verification date: 2026-07-22.
 Unrouted close-path verification date: 2026-08-13.
+Out-of-band routed completion reconciliation verification date: 2026-08-16.
 
 The focused end-to-end regression uses only synthetic `sample` identities and decision text.
 It begins with a completed investigation and visual review whose genuine unresolved choice exists only in the report.
@@ -67,6 +69,9 @@ A hold closed by a direct `tasks-axi done` reproduces the shape that fails `veri
 An unanswered decision still blocks completion and teardown, and neither `decline` nor `repair` can close a hold that is still actively held or supply an answer with a missing or empty decision file.
 `repair` also refuses a closed captain-kind task that was never held for the captain.
 
+A further regression covers the answered-but-unclosable deadlock: routed work completed by a direct `tasks-axi done` before the decision close kept its `blocked-by` edge, so `resolve` refused the done task, `decline` refused the surviving edge, `repair` refused the still-open hold, and the answered decision stayed permanently open.
+`resolve` now reconciles that done dependent from its surviving edge, records the routed resolution, clears the stale edge, and stays idempotent, while a done dependent with no surviving edge is still refused.
+
 The final verification commands and their exact summarized outputs follow.
 
 ```text
@@ -75,6 +80,7 @@ ok - report-only unresolved decision is reproduced and completion refuses before
 ok - non-forced scout teardown always requires durable inventory verification
 ok - a declined decision closes with a recorded answer and no routed work
 ok - a decision closed outside the script is repairable and then clears teardown
+ok - done routed work is reconcilable from its surviving edge and evidence-less done work still refuses
 ok - an unanswered decision still blocks completion and resists both unrouted close paths
 ok - captain holds are idempotent, distinct, teardown-safe, Bearings-visible, and durably routed before close
 ok - completion and verification validate origins before constructing paths

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -703,6 +703,102 @@ test_out_of_band_close_is_repairable_before_teardown() {
   pass "a decision closed outside the script is repairable and then clears teardown"
 }
 
+# The deadlock: the captain answered, but the routed work was completed out of
+# band with a direct tasks-axi done before the decision close ran, and its
+# durable blocked-by edge survived. The routed close refused the done task, the
+# unrouted close refused the surviving edge, and repair refused the still-open
+# hold, so the answered decision stayed permanently open. resolve now reconciles
+# from that surviving edge as evidence, while a done task without its edge still
+# cannot close the hold from a guess.
+test_done_routed_work_is_reconcilable_from_its_surviving_edge() {
+  local home id hold dep show json
+  home=$(make_home done-routed-work)
+  id=sample-launch-review
+  mkdir -p "$home/data/$id"
+  tasks_in "$home" add "$id" "Investigate the sample launch" --kind scout --repo sample --start >/dev/null \
+    || fail "could not create done-routed origin"
+  write_origin_meta "$home" "$id"
+  printf 'done: report complete\n' > "$home/state/$id.status"
+  printf '# Sample launch review\n\nOne captain choice remains.\n' > "$home/data/$id/report.md"
+  hold=$(run_decisions "$home" hold "$id" launch-window \
+    --title "Choose the sample launch window" --reason "captain launch window choice pending" --repo sample) \
+    || fail "could not register the done-routed hold"
+  run_decisions "$home" complete "$id" launch-window >/dev/null \
+    || fail "completion failed for the done-routed hold"
+  dep=sample-launch-work
+  tasks_in "$home" add "$dep" "Apply the sample launch window" \
+    --kind ship --repo sample --blocked-by "$hold" >/dev/null \
+    || fail "could not route work behind the done-routed hold"
+
+  # The routed work completes out of band before the decision close runs; its
+  # durable blocked-by edge survives the direct done.
+  tasks_in "$home" "done" "$dep" >/dev/null || fail "could not reproduce the out-of-band routed completion"
+  show=$(tasks_in "$home" show "$dep" --full)
+  assert_contains "$show" "state: done" "out-of-band routed completion fixture did not close the work"
+  assert_contains "$show" "blocked_by: $hold" "out-of-band completion must keep the durable routing edge"
+  printf 'Launch the sample in the morning window.\n' > "$home/launch-decision.txt"
+  if run_decisions "$home" decline "$id" launch-window --decision-file "$home/launch-decision.txt" \
+    > "$home/deadlocked-decline.out" 2> "$home/deadlocked-decline.err"; then
+    fail "decline closed a hold whose routed work survives"
+  fi
+  if run_decisions "$home" repair "$id" launch-window --decision-file "$home/launch-decision.txt" \
+    > "$home/deadlocked-repair.out" 2> "$home/deadlocked-repair.err"; then
+    fail "repair closed a hold that is still actively held"
+  fi
+  json=$(run_bearings "$home") || fail "Bearings failed for the deadlocked hold"
+  printf '%s' "$json" | jq -e --arg hold "$hold" '
+    .decisions_open | any(.id == $hold and .verb == "captain-hold")
+  ' >/dev/null || fail "the answered-but-unclosable hold was not reproduced as open: $json"
+
+  run_decisions "$home" resolve "$id" launch-window --decision-file "$home/launch-decision.txt" \
+    --routed-to "$dep" >/dev/null \
+    || fail "resolve could not reconcile a done routed task from its surviving edge"
+  show=$(tasks_in "$home" show "$hold" --full)
+  assert_contains "$show" "state: done" "reconciled hold did not close"
+  assert_contains "$show" "Resolution recorded by fm-decision-hold" "reconciled hold lost the decision record"
+  assert_contains "$show" "Resolution mode: routed" "reconciled hold did not record the routed close path"
+  assert_contains "$show" "Launch the sample in the morning window." \
+    "reconciled hold did not record the captain decision text"
+  assert_contains "$show" "- $dep" "reconciled hold did not record the done routed work"
+  show=$(tasks_in "$home" show "$dep" --full)
+  assert_contains "$show" "blocked: no" "reconciliation did not clear the stale edge from the done work"
+  run_decisions "$home" verify "$id" >/dev/null \
+    || fail "the reconciled decision did not satisfy the completion gate"
+  run_decisions "$home" resolve "$id" launch-window --decision-file "$home/launch-decision.txt" \
+    --routed-to "$dep" >/dev/null || fail "identical reconciliation retry was not idempotent"
+  printf 'Launch the sample in the evening window.\n' > "$home/drifted-launch-decision.txt"
+  if run_decisions "$home" resolve "$id" launch-window --decision-file "$home/drifted-launch-decision.txt" \
+    --routed-to "$dep" > "$home/drifted-reconcile.out" 2> "$home/drifted-reconcile.err"; then
+    fail "reconciliation retry accepted a different captain decision"
+  fi
+  json=$(run_bearings "$home") || fail "Bearings failed after reconciliation"
+  printf '%s' "$json" | jq -e --arg hold "$hold" '
+    .decisions_open | any(.id == $hold) | not
+  ' >/dev/null || fail "a reconciled decision remained an open Captain's Call: $json"
+
+  # A done task with no surviving edge still cannot close the hold: nothing
+  # proves it was ever routed behind this decision.
+  hold=$(run_decisions "$home" hold "$id" launch-cadence \
+    --title "Choose the sample launch cadence" --reason "captain launch cadence choice pending" --repo sample) \
+    || fail "could not register the evidence-less hold"
+  run_decisions "$home" complete "$id" launch-window launch-cadence >/dev/null \
+    || fail "completion failed for the evidence-less hold"
+  dep=sample-unrouted-done-work
+  tasks_in "$home" add "$dep" "Sample work that was never routed" --kind ship --repo sample >/dev/null \
+    || fail "could not create the never-routed fixture"
+  tasks_in "$home" "done" "$dep" >/dev/null || fail "could not close the never-routed fixture"
+  if run_decisions "$home" resolve "$id" launch-cadence --decision-file "$home/launch-decision.txt" \
+    --routed-to "$dep" > "$home/evidence-less.out" 2> "$home/evidence-less.err"; then
+    fail "resolve closed a hold from a done task with no routing evidence"
+  fi
+  assert_grep "no durable blocked-by edge" "$home/evidence-less.err" \
+    "resolve must say why a done task without its edge cannot close the hold"
+  show=$(tasks_in "$home" show "$hold" --full)
+  assert_contains "$show" "state: queued" "refused evidence-less reconciliation closed the hold"
+  assert_contains "$show" "held: yes" "refused evidence-less reconciliation released the hold"
+  pass "done routed work is reconcilable from its surviving edge and evidence-less done work still refuses"
+}
+
 # The unrouted close paths must not become a way past the gate. An unanswered
 # decision keeps blocking cleanup, and neither new path can manufacture an answer.
 test_unanswered_decision_still_blocks_completion_and_teardown() {
@@ -775,6 +871,7 @@ test_uninventoried_report_decision_refuses_completion
 test_scout_teardown_always_requires_inventory_verification
 test_declined_decision_closes_without_routed_work
 test_out_of_band_close_is_repairable_before_teardown
+test_done_routed_work_is_reconcilable_from_its_surviving_edge
 test_unanswered_decision_still_blocks_completion_and_teardown
 test_structured_holds_survive_teardown_and_route_resolution
 test_origin_slug_validation_precedes_path_construction


### PR DESCRIPTION
## Intent

Fix a deadlock in the decision-hold lifecycle: a captain hold whose routed work was completed out of band (a direct `tasks-axi done`) before the decision close ran became permanently unclosable, so the answered decision stayed open in the durable record forever.

## Root cause

In `bin/fm-decision-hold.sh`, the three close paths each refused this state for a locally-correct reason:

- `resolve` refused because the routed task was already done (a guard meant to keep an exact retry from recording a false routing).
- `decline` refused because the done task's durable `blocked-by` edge to the hold survived the out-of-band close, so the hold still "blocked routed work".
- `repair` refused because the hold was still actively held.

With all three refusing, the hold stayed queued+held permanently even though the captain had answered: Bearings' Captain's Call listed it forever, and no firstmate path could close or re-verify it from evidence.

## Fix

`resolve` now reconciles a done routed task when that task's own durable `blocked-by` edge still names the hold. The surviving edge is the evidence that the work really was routed behind this decision, so the close is recorded from proof rather than a guess: the decision and routed identities are written to the hold body, the stale edge is cleared through tasks-axi, and the hold closes Done with the usual idempotent retry identity.

A done task without that surviving edge is still refused, and `decline` keeps refusing while any edge survives, so neither unrouted path can manufacture a routing.

## Regression coverage

`tests/fm-decision-hold-lifecycle.test.sh` gains an end-to-end regression that reproduces the deadlock shape exactly (synthetic `sample` identities), then asserts:

- the deadlocked hold is unclosable by `decline` and `repair` and still surfaces as an open captain-hold in Bearings;
- `resolve` reconciles it from the surviving edge, records `Resolution mode: routed` with the captain decision text and the done routed work, clears the stale edge, satisfies `verify`, and leaves Bearings' Captain's Call;
- an identical retry is idempotent and a retry with a changed captain decision is rejected;
- a done task with no surviving edge is still refused, leaving the hold queued and held.

## Verification

- `bash tests/fm-decision-hold-lifecycle.test.sh` - 13/13 ok, including the new regression
- `bash tests/fm-fleet-snapshot-view.test.sh`, `bash tests/fm-bearings-snapshot.test.sh`, `bash tests/fm-brief.test.sh`, `bash tests/fm-teardown.test.sh` - all ok
- `bin/fm-lint.sh` - ShellCheck 0.11.0 (pinned), clean
- `bin/fm-doc-audience-check.sh` - ok surfaces=68 local_links=253

The mechanism owner `docs/decision-hold-lifecycle.md` records the reconciliation rule and the 2026-08-16 verification date.
