### PR TITLE
docs: require explicit repository ownership confirmation

### DIFF
--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -55,6 +55,7 @@ Default it off for every project and every posture, and enable it only on the ca
 ## Add or clone an existing project
 
 Confirm the source URL, local project name, delivery posture, and autonomy posture, stating the resolved default for each rather than asking the captain to invent one.
+Confirm true ownership of the source repo explicitly rather than inferring it from a matching org/user namespace or a repo description; a captain can be a user or contributor of a repo under an identity they do not own, and recording ownership wrong misleads every later delivery-mode and PR-content decision for that project.
 Clone into `projects/<name>` and add the registry entry only after the destination is known to be unused.
 A `no-mistakes` or `no-mistakes-prod-only` project must have an `origin` remote and must complete the initialization procedure below, because a conditional policy's product-facing work runs the pipeline while its internal-only work still takes the direct PR.
 A `direct-PR` project needs an `origin` remote but skips no-mistakes initialization.

--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -55,7 +55,7 @@ Default it off for every project and every posture, and enable it only on the ca
 ## Add or clone an existing project
 
 Confirm the source URL, local project name, delivery posture, and autonomy posture, stating the resolved default for each rather than asking the captain to invent one.
-Confirm true ownership of the source repo explicitly rather than inferring it from a matching org/user namespace or a repo description; a captain can be a user or contributor of a repo under an identity they do not own, and recording ownership wrong misleads every later delivery-mode and PR-content decision for that project.
+Confirm true ownership of the source repo explicitly rather than inferring it from a matching org/user namespace or a repo description; the captain may have access to a repo (as a member or contributor) under a familiar namespace without owning it, and recording ownership incorrectly misleads every later delivery-mode and PR-content decision for that project.
 Clone into `projects/<name>` and add the registry entry only after the destination is known to be unused.
 A `no-mistakes` or `no-mistakes-prod-only` project must have an `origin` remote and must complete the initialization procedure below, because a conditional policy's product-facing work runs the pipeline while its internal-only work still takes the direct PR.
 A `direct-PR` project needs an `origin` remote but skips no-mistakes initialization.


### PR DESCRIPTION
## What Changed

- Require explicit confirmation of source-repository ownership during project add/clone intake instead of inferring ownership from its namespace or description.

## Risk Assessment

✅ Low: The one-line policy clarification is bounded to project-add intake and accurately prevents namespace-based ownership inference without changing executable behavior.

## Testing

Inspected the one-line agent-skill change and performed a read-only end-to-end registration scenario: contributor access did not imply ownership, so the agent requested explicit true-owner confirmation and stated the resolved remote defaults. No deterministic code test applies to this agent-instruction-only change.

<details>
<summary>Evidence: Read-only project-registration ownership evaluation</summary>

Source: [Read-only project-registration ownership evaluation](https://github.com/wesleymatosdev/firstmate/blob/7db616a66b3a7e709490aeecd7236f9b5a1e7a90/.no-mistakes/evidence/fix/project-management-confirm-ownership/project-management-ownership-manual-e2e.md)

<code>Captain, I need one confirmation: who truly owns `git@github.com:acme/launchpad.git`—Acme, you personally, or another party? Contributor access alone is not ownership.&#10;&#10;Once confirmed, I’ll register it as `launchpad` using the remote-project defaults: `no-mistakes-prod-only`, `+yolo` off, and the default autonomy posture.</code>

```text
Captain, I need one confirmation: who truly owns `git@github.com:acme/launchpad.git`—Acme, you personally, or another party? Contributor access alone is not ownership.

Once confirmed, I’ll register it as `launchpad` using the remote-project defaults: `no-mistakes-prod-only`, `+yolo` off, and the default autonomy posture.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"50ba4e8a0f3bf6e5715fd16877fc95b7aaf79e74","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --stat 0fe226c93efdd12a38f1c3936d758571e40111b7 50ba4e8a0f3bf6e5715fd16877fc95b7aaf79e74`
- <code>Manual read-only skill-loading evaluation via `codex exec --ephemeral --sandbox read-only` using a request from an Acme contributor to register `acme/launchpad`</code>
- <code>`git status --short` after cleanup</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
