### PR TITLE
fix(bin): emit a real @AGENTS.md pointer instead of a CLAUDE.md symlink

### DIFF
--- a/.agents/skills/updatefirstmate/SKILL.md
+++ b/.agents/skills/updatefirstmate/SKILL.md
@@ -35,7 +35,7 @@ This touches only the firstmate repo and its own worktrees, never anything under
 
 2. **Re-read AGENTS.md if your own instructions changed.**
    When the updater printed `reread-firstmate: yes`, the tracked instruction surface (`AGENTS.md`, `bin/`, or `.agents/skills/`) just advanced under you.
-   **Read `AGENTS.md` now** (CLAUDE.md is a symlink to it) to refresh your operating instructions before doing anything else, so you are acting on the new instructions rather than the stale ones you were started with.
+   **Read `AGENTS.md` now** (CLAUDE.md is a real `@AGENTS.md` pointer to it) to refresh your operating instructions before doing anything else, so you are acting on the new instructions rather than the stale ones you were started with.
    When it printed `reread-firstmate: no`, nothing changed for you - skip the re-read.
 
 3. **Nudge each updated live secondmate.**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,10 +373,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Symlinks must stay intact
+      - name: Compatibility pointers must stay intact
         run: |
           set -eu
-          [ "$(readlink CLAUDE.md)" = "AGENTS.md" ] || { echo "::error::CLAUDE.md must be a symlink to AGENTS.md"; exit 1; }
+          [ ! -L CLAUDE.md ] || { echo "::error::CLAUDE.md must be a real @AGENTS.md pointer file, not a symlink"; exit 1; }
+          cmp -s CLAUDE.md - <<'EOF' || { echo "::error::CLAUDE.md must be the canonical @AGENTS.md pointer"; exit 1; }
+<!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
+@AGENTS.md
+EOF
           [ "$(readlink .claude/skills)" = "../.agents/skills" ] || { echo "::error::.claude/skills must be a symlink to ../.agents/skills"; exit 1; }
       - name: Personal fleet paths must not be tracked
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Each secondmate has a persistent isolated `FM_HOME`, including its own state, ba
 Tracked files hold shared instructions and tooling; `data/` holds durable private fleet records; `state/` holds runtime records and append-only status events; `config/` holds local operating choices; and `projects/` contains clones that are read-only to firstmate except under hard rule 1's concrete captain-approved project operation exception.
 
 ```
-AGENTS.md            this file (CLAUDE.md is a symlink to it)
+AGENTS.md            this file (CLAUDE.md is a real @AGENTS.md pointer to it)
 CONTRIBUTING.md      contributor workflow and repo conventions
 README.md            public overview and development notes
 .github/workflows/   shared CI and PR enforcement, committed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,2 @@
-AGENTS.md
+<!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 ## Repo conventions
 
 - This repo is a template for running a firstmate orchestrator agent.
-  `AGENTS.md` is the agent's main job description and names when to load bundled firstmate skills; `CLAUDE.md` is a symlink to it, and `.claude/skills` is a symlink to `.agents/skills`.
+  `AGENTS.md` is the agent's main job description and names when to load bundled firstmate skills; `CLAUDE.md` is a real `@AGENTS.md` pointer to it, and `.claude/skills` is a symlink to `.agents/skills`.
 - Only shared material is tracked: `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, `.agents/skills/`, and `skills/`.
   `.agents/skills/` holds agent-loaded skills that assume a live firstmate home and carry `metadata.internal: true` so installers such as [skills.sh](https://skills.sh) hide them from discovery; `skills/` holds standalone, installer-facing public skills with no firstmate dependency (see the README's "Two-tier skill layout").
   Everything personal to one captain's fleet (`.env`, `data/`, `state/`, `config/`, `projects/`, `.no-mistakes/`) is gitignored; never commit it.
@@ -83,7 +83,10 @@ bin/fm-test-run.sh --check-coverage   # prove portable shards + serial + serial 
 bin/fm-test-run.sh --all   # deliberate complete regression (optional local full walk; not no-mistakes Test)
 bin/fm-test-isolation-proof.sh --list   # proven parallel candidate set (Phase 2 owner)
 bin/fm-test-isolation-proof.sh --jobs 4 --json /tmp/fm-isolation-proof.json   # re-run concurrent isolation proof only
-[ "$(readlink CLAUDE.md)" = "AGENTS.md" ]
+[ ! -L CLAUDE.md ] && cmp -s CLAUDE.md - <<'EOF'
+<!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
+@AGENTS.md
+EOF
 [ "$(readlink .claude/skills)" = "../.agents/skills" ]
 tmp=$(mktemp -d) && printf 'done: smoke\n' > "$tmp/smoke.status" && FM_STATE_OVERRIDE="$tmp" FM_SIGNAL_GRACE=1 FM_POLL=1 FM_HEARTBEAT=999999 bin/fm-watch-arm.sh  # watcher re-arm smoke test (prints arm status, then an actionable signal)
 ```

--- a/bin/fm-ensure-agents-md.sh
+++ b/bin/fm-ensure-agents-md.sh
@@ -1,15 +1,23 @@
 #!/usr/bin/env bash
 # Ensure a project worktree follows the agent-memory file convention.
 # AGENTS.md is the real project-intrinsic knowledge file; CLAUDE.md is a
-# relative symlink to it for compatibility. Creates a minimal AGENTS.md skeleton
+# real regular file whose canonical content is the two-line @AGENTS.md pointer
+# that Claude Code inlines at load time. Creates a minimal AGENTS.md skeleton
 # when neither file exists, promotes a real CLAUDE.md file when it is the only
-# file present, and refuses to clobber distinct real files or wrong symlinks.
+# file present (unless it is already the canonical pointer), converts a correct
+# CLAUDE.md -> AGENTS.md symlink into the pointer file, and refuses to clobber
+# distinct real files or wrong symlinks.
 # Owns the canonical "## Maintaining this file" self-governance wording for
 # project AGENTS.md files, injecting it idempotently into created skeletons,
 # promoted CLAUDE.md files, and any existing AGENTS.md that still lacks it.
-# Refuses a case-variant real memory file such as a lowercase agents.md, whose
-# CLAUDE.md symlink would carry an uppercase literal target that dangles on a
-# case-sensitive filesystem (issue #389).
+# Owns the canonical CLAUDE.md pointer content (the exact two-line @AGENTS.md
+# form). A real-file pointer cannot follow a write into AGENTS.md, which is why
+# the installer never creates a CLAUDE.md symlink.
+# Refuses a case-variant real memory file such as a lowercase agents.md, so the
+# pointer's @AGENTS.md import resolves to a real AGENTS.md on a case-sensitive
+# filesystem (issue #389). The real-file pointer also eliminates the old
+# uppercase-literal-target dangling-symlink hazard that a CLAUDE.md -> AGENTS.md
+# link would have carried for that same mismatch.
 # This is a worktree utility for crewmates, not a supervision script, so it does
 # not call fm-guard.sh.
 # Usage: fm-ensure-agents-md.sh [repo-or-worktree-dir]
@@ -92,6 +100,36 @@ EOF
   ensure_maintenance_section
 }
 
+# Canonical CLAUDE.md pointer: a real file, never a symlink. Byte-identical
+# two-line form so a stray write clobbers only this recoverable pointer.
+claude_pointer_content() {
+  cat <<'EOF'
+<!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
+@AGENTS.md
+EOF
+}
+
+is_canonical_claude_pointer() {
+  [ -f "$CLAUDE" ] && [ ! -L "$CLAUDE" ] || return 1
+  claude_pointer_content | cmp -s - "$CLAUDE"
+}
+
+# Write the canonical pointer as a regular file. Unlink a symlink first so the
+# write cannot follow it and destroy AGENTS.md. Never overwrite a distinct real
+# file; callers classify that as a conflict before invoking this.
+install_claude_pointer() {
+  if is_canonical_claude_pointer; then
+    return 0
+  fi
+  if [ -L "$CLAUDE" ]; then
+    rm -- "$CLAUDE"
+  elif [ -e "$CLAUDE" ]; then
+    echo "error: internal: refuse to overwrite existing CLAUDE.md" >&2
+    exit 1
+  fi
+  claude_pointer_content > "$CLAUDE"
+}
+
 is_correct_claude_symlink() {
   [ -L "$CLAUDE" ] || return 1
   target=$(readlink "$CLAUDE")
@@ -112,10 +150,11 @@ PY
 
 # Refuse a case-variant real memory file (issue #389). On a case-insensitive
 # filesystem an existing lowercase agents.md satisfies every [ -e AGENTS.md ]
-# test below, so the script would emit a CLAUDE.md symlink whose uppercase
-# literal target dangles once the tree is checked out on a case-sensitive
-# filesystem. Reading the real directory entries catches the mismatch on both
-# filesystem kinds; surface it for manual reconciliation instead of linking blindly.
+# test below, so the script would emit a CLAUDE.md pointer whose @AGENTS.md
+# import dangles once the tree is checked out on a case-sensitive filesystem.
+# Reading the real directory entries catches the mismatch on both filesystem
+# kinds; surface it for manual reconciliation instead of writing the pointer
+# against the wrong name.
 for entry in *; do
   if [ ! -e "$entry" ] && [ ! -L "$entry" ]; then
     continue
@@ -123,7 +162,7 @@ for entry in *; do
   if [ "$entry" != "$AGENTS" ]; then
     case "$entry" in
       [Aa][Gg][Ee][Nn][Tt][Ss].[Mm][Dd])
-        echo "conflict: memory file is named $entry in $DIR but the convention is AGENTS.md; rename it to AGENTS.md so CLAUDE.md links portably" >&2
+        echo "conflict: memory file is named $entry in $DIR but the convention is AGENTS.md; rename it to AGENTS.md so CLAUDE.md's @AGENTS.md pointer resolves portably" >&2
         exit 1
         ;;
     esac
@@ -143,10 +182,11 @@ if [ -e "$AGENTS" ]; then
   if [ -L "$CLAUDE" ]; then
     if is_correct_claude_symlink; then
       ensure_maintenance_section
+      install_claude_pointer
       if [ "$MAINT_INJECTED" -eq 1 ]; then
-        echo "updated: added ## Maintaining this file to AGENTS.md in $DIR"
+        echo "updated: added ## Maintaining this file to AGENTS.md and wrote CLAUDE.md @AGENTS.md pointer in $DIR"
       else
-        echo "unchanged: AGENTS.md with CLAUDE.md -> AGENTS.md in $DIR"
+        echo "updated: replaced CLAUDE.md symlink with @AGENTS.md pointer in $DIR"
       fi
       exit 0
     fi
@@ -155,15 +195,24 @@ if [ -e "$AGENTS" ]; then
   fi
   if [ ! -e "$CLAUDE" ]; then
     ensure_maintenance_section
-    ln -s "$AGENTS" "$CLAUDE"
+    install_claude_pointer
     if [ "$MAINT_INJECTED" -eq 1 ]; then
-      echo "updated: added ## Maintaining this file to AGENTS.md and symlinked CLAUDE.md -> AGENTS.md in $DIR"
+      echo "updated: added ## Maintaining this file to AGENTS.md and wrote CLAUDE.md @AGENTS.md pointer in $DIR"
     else
-      echo "symlinked: CLAUDE.md -> AGENTS.md in $DIR"
+      echo "wrote: CLAUDE.md @AGENTS.md pointer in $DIR"
     fi
     exit 0
   fi
   if [ -f "$CLAUDE" ]; then
+    if is_canonical_claude_pointer; then
+      ensure_maintenance_section
+      if [ "$MAINT_INJECTED" -eq 1 ]; then
+        echo "updated: added ## Maintaining this file to AGENTS.md in $DIR"
+      else
+        echo "unchanged: AGENTS.md with CLAUDE.md @AGENTS.md pointer in $DIR"
+      fi
+      exit 0
+    fi
     echo "conflict: both AGENTS.md and CLAUDE.md are real files in $DIR; reconcile them manually" >&2
     exit 1
   fi
@@ -174,7 +223,8 @@ fi
 if [ -L "$CLAUDE" ]; then
   if is_correct_claude_symlink; then
     write_skeleton
-    echo "created: AGENTS.md and kept CLAUDE.md -> AGENTS.md in $DIR"
+    install_claude_pointer
+    echo "created: AGENTS.md and wrote CLAUDE.md @AGENTS.md pointer in $DIR"
     exit 0
   fi
   echo "conflict: CLAUDE.md is a symlink in $DIR but AGENTS.md is missing and the link does not point to AGENTS.md" >&2
@@ -183,10 +233,15 @@ fi
 
 if [ -e "$CLAUDE" ]; then
   if [ -f "$CLAUDE" ]; then
+    if is_canonical_claude_pointer; then
+      write_skeleton
+      echo "created: AGENTS.md and kept CLAUDE.md @AGENTS.md pointer in $DIR"
+      exit 0
+    fi
     mv "$CLAUDE" "$AGENTS"
     ensure_maintenance_section
-    ln -s "$AGENTS" "$CLAUDE"
-    echo "promoted: moved CLAUDE.md to AGENTS.md and symlinked CLAUDE.md -> AGENTS.md in $DIR"
+    install_claude_pointer
+    echo "promoted: moved CLAUDE.md to AGENTS.md and wrote CLAUDE.md @AGENTS.md pointer in $DIR"
     exit 0
   fi
   echo "conflict: CLAUDE.md exists in $DIR but is not a regular file or symlink" >&2
@@ -194,5 +249,5 @@ if [ -e "$CLAUDE" ]; then
 fi
 
 write_skeleton
-ln -s "$AGENTS" "$CLAUDE"
-echo "created: AGENTS.md and CLAUDE.md -> AGENTS.md in $DIR"
+install_claude_pointer
+echo "created: AGENTS.md and CLAUDE.md @AGENTS.md pointer in $DIR"

--- a/bin/fm-ff-lib.sh
+++ b/bin/fm-ff-lib.sh
@@ -211,7 +211,7 @@ fetch_once() {
 
 # Which watched instruction paths changed between HEAD and BASE (comma list).
 # These are the files a running agent actually reads or runs: its instructions
-# (AGENTS.md, which CLAUDE.md symlinks), its agent-loaded skills
+# (AGENTS.md, which CLAUDE.md imports via @AGENTS.md), its agent-loaded skills
 # (.agents/skills/), and its tooling (bin/). Public skills/ is installer-facing
 # and intentionally not part of this watched instruction surface.
 changed_instr() {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -294,10 +294,10 @@ The [Relay configuration reference](configuration.md#promised-public-replies-sta
 
 ## Project memory belongs to projects
 
-Durable project-intrinsic agent knowledge lives in each project's committed `AGENTS.md`, with `CLAUDE.md` as a symlink.
+Durable project-intrinsic agent knowledge lives in each project's committed `AGENTS.md`, with `CLAUDE.md` as a real `@AGENTS.md` import pointer.
 Ship briefs prompt crewmates to create or update those files through the normal delivery path; `data/projects.md` stays a thin private registry.
 Each project `AGENTS.md` carries a short `## Maintaining this file` self-governance section; `bin/fm-ensure-agents-md.sh` owns the canonical wording and injects it idempotently when creating the skeleton, promoting an existing `CLAUDE.md`, or reconciling an existing `AGENTS.md` that still lacks it.
-It refuses a case-variant real memory file such as a lowercase `agents.md`, whose `CLAUDE.md` symlink would carry an uppercase literal target that dangles on a case-sensitive filesystem, and surfaces the mismatch for manual reconciliation.
+It refuses a case-variant real memory file such as a lowercase `agents.md`, so the pointer's `@AGENTS.md` import resolves to a real `AGENTS.md` on a case-sensitive filesystem, and surfaces the mismatch for manual reconciliation.
 The full ownership rule - what is project-intrinsic versus fleet-private, and how firstmate keeps the two apart without writing into project clones - is owned by [`AGENTS.md`](../AGENTS.md) (project and knowledge management).
 
 ## Operational memory routing

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -33,7 +33,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-herdr-ci-cleanup.sh` | Snapshot and tear down only job-owned `fm-lab-*` sessions in the Herdr CI lane       |
 | `fm-test-run.sh`         | Behavior-test runner: selection, portable lanes, proven-isolated `--jobs`, coverage guard, timing/JSON |
 | `fm-test-isolation-proof.sh` | Concurrent isolation proof and proven-isolated candidate set owner |
-| `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |
+| `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` `@AGENTS.md` pointer, and the canonical self-governance section |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and unhealthy supervision    |
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |
 | `fm-session-lock-lib.sh` | Shared session-lock harness identity (ancestry walk and holder liveness) for fm-lock.sh and the Claude Stop auto-arm |

--- a/tests/fm-ensure-agents-md.test.sh
+++ b/tests/fm-ensure-agents-md.test.sh
@@ -7,6 +7,25 @@ set -u
 
 TMP_ROOT=$(fm_test_tmproot fm-ensure-agents-md)
 
+# Public contract: CLAUDE.md is this exact two-line pointer, never a symlink.
+assert_claude_pointer() {
+  local path=$1
+  [ -e "$path" ] || fail "CLAUDE.md is missing"
+  [ ! -L "$path" ] || fail "CLAUDE.md is a symlink; expected a real @AGENTS.md pointer file"
+  [ -f "$path" ] || fail "CLAUDE.md is not a regular file"
+  cmp -s "$path" - <<'EOF' || fail "CLAUDE.md is not the canonical @AGENTS.md pointer"
+<!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
+@AGENTS.md
+EOF
+}
+
+write_fixture_claude_pointer() {
+  cat > "$1/CLAUDE.md" <<'EOF'
+<!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
+@AGENTS.md
+EOF
+}
+
 test_created_agents_md_includes_self_governance() {
   local repo agents
   repo="$TMP_ROOT/new-project"
@@ -14,8 +33,7 @@ test_created_agents_md_includes_self_governance() {
   "$ROOT/bin/fm-ensure-agents-md.sh" "$repo" >/dev/null 2>&1 || fail "fm-ensure-agents-md.sh failed for empty project"
   agents="$repo/AGENTS.md"
   assert_present "$agents" "AGENTS.md was not created"
-  assert_present "$repo/CLAUDE.md" "CLAUDE.md symlink was not created"
-  [ -L "$repo/CLAUDE.md" ] || fail "CLAUDE.md is not a symlink"
+  assert_claude_pointer "$repo/CLAUDE.md"
   assert_grep "## Maintaining this file" "$agents" "self-governance section heading missing"
   assert_grep "Keep this file for knowledge useful to almost every future agent session in this project." "$agents" \
     "self-governance section lost the future-session bar"
@@ -26,6 +44,18 @@ test_created_agents_md_includes_self_governance() {
   assert_grep "When updating this file, preserve this bar for all agents and keep entries concise." "$agents" \
     "self-governance section lost all-agents maintenance guidance"
   pass "fm-ensure-agents-md.sh: created AGENTS.md includes self-governance section"
+}
+
+test_fresh_setup_writes_real_claude_pointer() {
+  local repo out
+  repo="$TMP_ROOT/fresh-pointer-project"
+  mkdir -p "$repo"
+  out=$("$ROOT/bin/fm-ensure-agents-md.sh" "$repo" 2>&1) \
+    || fail "fm-ensure-agents-md.sh failed creating a fresh pointer"
+  assert_contains "$out" "created:" "fresh setup did not report created"
+  assert_claude_pointer "$repo/CLAUDE.md"
+  [ ! -L "$repo/CLAUDE.md" ] || fail "fresh setup created a CLAUDE.md symlink"
+  pass "fm-ensure-agents-md.sh: fresh setup writes a real @AGENTS.md pointer"
 }
 
 test_promoted_claude_md_includes_self_governance() {
@@ -40,7 +70,7 @@ EOF
   "$ROOT/bin/fm-ensure-agents-md.sh" "$repo" >/dev/null 2>&1 || fail "fm-ensure-agents-md.sh failed for CLAUDE.md promotion"
   agents="$repo/AGENTS.md"
   assert_present "$agents" "AGENTS.md was not created during promotion"
-  [ -L "$repo/CLAUDE.md" ] || fail "CLAUDE.md is not a symlink after promotion"
+  assert_claude_pointer "$repo/CLAUDE.md"
   assert_grep "Run tests with \`make test\`." "$agents" \
     "promotion lost existing CLAUDE.md content"
   count=$(grep -Fc "## Maintaining this file" "$agents")
@@ -63,6 +93,7 @@ test_promoted_claude_md_without_trailing_newline_keeps_blank_separator() {
     "newline-less promotion did not append the self-governance section"
   before=$(grep -B1 -Fx '## Maintaining this file' "$agents" | head -n 1)
   [ -z "$before" ] || fail "self-governance heading not preceded by a blank line (got: $before)"
+  assert_claude_pointer "$repo/CLAUDE.md"
   pass "fm-ensure-agents-md.sh: newline-less promotion keeps a blank separator line"
 }
 
@@ -80,18 +111,49 @@ test_existing_agents_md_with_symlink_gains_self_governance() {
   assert_grep "## Maintaining this file" "$agents" "existing AGENTS.md did not gain the self-governance section"
   count=$(grep -Fc "## Maintaining this file" "$agents")
   [ "$count" -eq 1 ] || fail "injection wrote $count self-governance sections"
-  [ -L "$repo/CLAUDE.md" ] || fail "CLAUDE.md is no longer a symlink after injection"
+  assert_claude_pointer "$repo/CLAUDE.md"
   # Re-run must be a byte-exact no-op reporting unchanged.
   cp "$agents" "$repo/.after-first"
+  cp "$repo/CLAUDE.md" "$repo/.claude-after-first"
   out=$("$ROOT/bin/fm-ensure-agents-md.sh" "$repo" 2>&1) \
     || fail "fm-ensure-agents-md.sh failed on idempotent re-run"
   assert_contains "$out" "unchanged:" "idempotent re-run did not report unchanged"
   diff "$repo/.after-first" "$agents" >/dev/null \
     || fail "idempotent re-run modified AGENTS.md"
+  cmp -s "$repo/.claude-after-first" "$repo/CLAUDE.md" \
+    || fail "idempotent re-run modified CLAUDE.md"
   pass "fm-ensure-agents-md.sh: existing symlinked AGENTS.md gains the section idempotently"
 }
 
-test_existing_agents_md_without_claude_gains_section_and_symlink() {
+test_correct_symlink_migrates_to_pointer_without_clobbering_agents() {
+  local repo agents out
+  repo="$TMP_ROOT/symlink-migrate-project"
+  mkdir -p "$repo"
+  printf '# Unique agent memory\n\nDo not clobber this payload.\n\n## Maintaining this file\n\nKeep this file for knowledge useful to almost every future agent session in this project.\nDo not repeat what the codebase already shows; point to the authoritative file or command instead.\nPrefer rewriting or pruning existing entries over appending new ones.\nWhen updating this file, preserve this bar for all agents and keep entries concise.\n' > "$repo/AGENTS.md"
+  ln -s AGENTS.md "$repo/CLAUDE.md"
+  agents="$repo/AGENTS.md"
+  cp "$agents" "$repo/.before"
+  out=$("$ROOT/bin/fm-ensure-agents-md.sh" "$repo" 2>&1) \
+    || fail "fm-ensure-agents-md.sh failed migrating a correct CLAUDE.md symlink"
+  assert_contains "$out" "updated:" "symlink migration did not report an update"
+  assert_claude_pointer "$repo/CLAUDE.md"
+  cmp -s "$repo/.before" "$agents" \
+    || fail "symlink migration clobbered AGENTS.md"
+  assert_grep "Do not clobber this payload." "$agents" \
+    "symlink migration lost unique AGENTS.md content"
+  cp "$agents" "$repo/.after-first"
+  cp "$repo/CLAUDE.md" "$repo/.claude-after-first"
+  out=$("$ROOT/bin/fm-ensure-agents-md.sh" "$repo" 2>&1) \
+    || fail "fm-ensure-agents-md.sh failed on post-migration re-run"
+  assert_contains "$out" "unchanged:" "post-migration re-run did not report unchanged"
+  cmp -s "$repo/.after-first" "$agents" \
+    || fail "post-migration re-run modified AGENTS.md"
+  cmp -s "$repo/.claude-after-first" "$repo/CLAUDE.md" \
+    || fail "post-migration re-run modified CLAUDE.md"
+  pass "fm-ensure-agents-md.sh: correct symlink migrates to pointer without clobbering AGENTS.md"
+}
+
+test_existing_agents_md_without_claude_gains_section_and_pointer() {
   local repo agents out count
   repo="$TMP_ROOT/existing-bare-project"
   mkdir -p "$repo"
@@ -100,27 +162,31 @@ test_existing_agents_md_without_claude_gains_section_and_symlink() {
   out=$("$ROOT/bin/fm-ensure-agents-md.sh" "$repo" 2>&1) \
     || fail "fm-ensure-agents-md.sh failed for existing AGENTS.md without CLAUDE.md"
   assert_contains "$out" "updated:" "injection without CLAUDE.md did not report an update"
-  [ -L "$repo/CLAUDE.md" ] || fail "CLAUDE.md symlink was not created"
+  assert_claude_pointer "$repo/CLAUDE.md"
   assert_grep "Deploy with kubectl." "$agents" "injection dropped existing AGENTS.md content"
   count=$(grep -Fc "## Maintaining this file" "$agents")
   [ "$count" -eq 1 ] || fail "injection wrote $count self-governance sections"
-  pass "fm-ensure-agents-md.sh: existing AGENTS.md without CLAUDE.md gains section and symlink"
+  pass "fm-ensure-agents-md.sh: existing AGENTS.md without CLAUDE.md gains section and pointer"
 }
 
 test_existing_agents_md_with_section_reports_unchanged() {
   local repo agents out
   repo="$TMP_ROOT/fully-formed-project"
   mkdir -p "$repo"
-  # Build a fully-formed project (AGENTS.md with the section + correct symlink).
+  # Build a fully-formed project (AGENTS.md with the section + canonical pointer).
   "$ROOT/bin/fm-ensure-agents-md.sh" "$repo" >/dev/null 2>&1 \
     || fail "fm-ensure-agents-md.sh failed building the fully-formed fixture"
   agents="$repo/AGENTS.md"
+  assert_claude_pointer "$repo/CLAUDE.md"
   cp "$agents" "$repo/.before"
+  cp "$repo/CLAUDE.md" "$repo/.claude-before"
   out=$("$ROOT/bin/fm-ensure-agents-md.sh" "$repo" 2>&1) \
     || fail "fm-ensure-agents-md.sh failed on already-formed project"
   assert_contains "$out" "unchanged:" "already-formed project was not reported unchanged"
   diff "$repo/.before" "$agents" >/dev/null \
     || fail "already-formed AGENTS.md was modified"
+  cmp -s "$repo/.claude-before" "$repo/CLAUDE.md" \
+    || fail "already-formed CLAUDE.md was modified"
   pass "fm-ensure-agents-md.sh: AGENTS.md that already has the section stays unchanged"
 }
 
@@ -137,14 +203,17 @@ test_existing_crlf_agents_md_with_section_stays_unchanged() {
     'Do not repeat what the codebase already shows; point to the authoritative file or command instead.' \
     'Prefer rewriting or pruning existing entries over appending new ones.' \
     'When updating this file, preserve this bar for all agents and keep entries concise.' > "$repo/AGENTS.md"
-  ln -s AGENTS.md "$repo/CLAUDE.md"
+  write_fixture_claude_pointer "$repo"
   agents="$repo/AGENTS.md"
   cp "$agents" "$repo/.before"
+  cp "$repo/CLAUDE.md" "$repo/.claude-before"
   out=$("$ROOT/bin/fm-ensure-agents-md.sh" "$repo" 2>&1) \
     || fail "fm-ensure-agents-md.sh failed on CRLF AGENTS.md with the section"
   assert_contains "$out" "unchanged:" "complete CRLF AGENTS.md was not reported unchanged"
   cmp -s "$repo/.before" "$agents" \
     || fail "complete CRLF AGENTS.md was modified"
+  cmp -s "$repo/.claude-before" "$repo/CLAUDE.md" \
+    || fail "complete CRLF project's CLAUDE.md was modified"
   count=$(LC_ALL=C grep -a -c '## Maintaining this file' "$agents")
   [ "$count" -eq 1 ] || fail "complete CRLF AGENTS.md has $count self-governance sections"
   pass "fm-ensure-agents-md.sh: CRLF AGENTS.md with the section stays unchanged"
@@ -176,15 +245,99 @@ test_existing_crlf_agents_md_without_section_preserves_crlf() {
     'When updating this file, preserve this bar for all agents and keep entries concise.' > "$repo/.expected"
   cmp -s "$repo/.expected" "$agents" \
     || fail "CRLF AGENTS.md injection did not preserve CRLF line endings"
+  assert_claude_pointer "$repo/CLAUDE.md"
   cp "$agents" "$repo/.after-first"
+  cp "$repo/CLAUDE.md" "$repo/.claude-after-first"
   "$ROOT/bin/fm-ensure-agents-md.sh" "$repo" >/dev/null 2>&1 \
     || fail "fm-ensure-agents-md.sh failed on idempotent CRLF re-run"
   cmp -s "$repo/.after-first" "$agents" \
     || fail "idempotent CRLF re-run modified AGENTS.md"
+  cmp -s "$repo/.claude-after-first" "$repo/CLAUDE.md" \
+    || fail "idempotent CRLF re-run modified CLAUDE.md"
   pass "fm-ensure-agents-md.sh: CRLF injection preserves line endings idempotently"
 }
 
-test_lowercase_agents_md_refuses_case_fragile_symlink() {
+test_canonical_pointer_is_accepted_when_both_are_real_files() {
+  local repo out
+  repo="$TMP_ROOT/both-real-pointer-project"
+  mkdir -p "$repo"
+  printf '# Existing agent memory\n\n## Maintaining this file\n\nKeep this file for knowledge useful to almost every future agent session in this project.\nDo not repeat what the codebase already shows; point to the authoritative file or command instead.\nPrefer rewriting or pruning existing entries over appending new ones.\nWhen updating this file, preserve this bar for all agents and keep entries concise.\n' > "$repo/AGENTS.md"
+  write_fixture_claude_pointer "$repo"
+  out=$("$ROOT/bin/fm-ensure-agents-md.sh" "$repo" 2>&1) \
+    || fail "fm-ensure-agents-md.sh refused a canonical real CLAUDE.md pointer"
+  assert_contains "$out" "unchanged:" "canonical pointer plus AGENTS.md was not reported unchanged"
+  assert_claude_pointer "$repo/CLAUDE.md"
+  pass "fm-ensure-agents-md.sh: canonical real CLAUDE.md pointer is not a conflict"
+}
+
+test_distinct_real_files_are_refused() {
+  local repo out rc
+  repo="$TMP_ROOT/distinct-real-files-project"
+  mkdir -p "$repo"
+  printf '# Agents memory\n' > "$repo/AGENTS.md"
+  printf '# Claude memory\n' > "$repo/CLAUDE.md"
+  cp "$repo/AGENTS.md" "$repo/.agents-before"
+  cp "$repo/CLAUDE.md" "$repo/.claude-before"
+  out=$("$ROOT/bin/fm-ensure-agents-md.sh" "$repo" 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit for distinct real AGENTS.md and CLAUDE.md"
+  assert_contains "$out" "conflict:" "distinct real files did not report a conflict"
+  cmp -s "$repo/.agents-before" "$repo/AGENTS.md" \
+    || fail "distinct-real-files refusal modified AGENTS.md"
+  cmp -s "$repo/.claude-before" "$repo/CLAUDE.md" \
+    || fail "distinct-real-files refusal modified CLAUDE.md"
+  [ ! -L "$repo/CLAUDE.md" ] || fail "distinct-real-files refusal turned CLAUDE.md into a symlink"
+  pass "fm-ensure-agents-md.sh: refuses distinct real AGENTS.md and CLAUDE.md"
+}
+
+test_agents_md_symlink_is_refused() {
+  local repo out rc
+  repo="$TMP_ROOT/agents-symlink-project"
+  mkdir -p "$repo"
+  printf '# payload\n' > "$repo/payload.md"
+  ln -s payload.md "$repo/AGENTS.md"
+  out=$("$ROOT/bin/fm-ensure-agents-md.sh" "$repo" 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit when AGENTS.md is a symlink"
+  assert_contains "$out" "conflict:" "AGENTS.md symlink did not report a conflict"
+  [ -L "$repo/AGENTS.md" ] || fail "AGENTS.md symlink refusal disturbed the symlink"
+  assert_absent "$repo/CLAUDE.md" "AGENTS.md symlink refusal created CLAUDE.md"
+  pass "fm-ensure-agents-md.sh: refuses AGENTS.md when it is a symlink"
+}
+
+test_wrong_target_symlink_is_refused() {
+  local repo out rc
+  repo="$TMP_ROOT/wrong-target-project"
+  mkdir -p "$repo"
+  printf '# Agents memory\n' > "$repo/AGENTS.md"
+  printf '# other\n' > "$repo/OTHER.md"
+  ln -s OTHER.md "$repo/CLAUDE.md"
+  cp "$repo/AGENTS.md" "$repo/.agents-before"
+  out=$("$ROOT/bin/fm-ensure-agents-md.sh" "$repo" 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit for a CLAUDE.md symlink that does not point to AGENTS.md"
+  assert_contains "$out" "conflict:" "wrong-target CLAUDE.md symlink did not report a conflict"
+  [ -L "$repo/CLAUDE.md" ] || fail "wrong-target refusal removed the CLAUDE.md symlink"
+  [ "$(readlink "$repo/CLAUDE.md")" = "OTHER.md" ] || fail "wrong-target refusal retargeted CLAUDE.md"
+  cmp -s "$repo/.agents-before" "$repo/AGENTS.md" \
+    || fail "wrong-target refusal modified AGENTS.md"
+  pass "fm-ensure-agents-md.sh: refuses a CLAUDE.md symlink that does not point to AGENTS.md"
+}
+
+test_non_regular_claude_md_is_refused() {
+  local repo out rc
+  repo="$TMP_ROOT/non-regular-claude-project"
+  mkdir -p "$repo" "$repo/CLAUDE.md"
+  printf '# Agents memory\n' > "$repo/AGENTS.md"
+  out=$("$ROOT/bin/fm-ensure-agents-md.sh" "$repo" 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit when CLAUDE.md is a directory"
+  assert_contains "$out" "conflict:" "non-regular CLAUDE.md did not report a conflict"
+  [ -d "$repo/CLAUDE.md" ] || fail "non-regular CLAUDE.md refusal disturbed the directory"
+  pass "fm-ensure-agents-md.sh: refuses a non-regular CLAUDE.md"
+}
+
+test_lowercase_agents_md_refuses_case_fragile_pointer() {
   local repo out rc
   repo="$TMP_ROOT/lowercase-project"
   mkdir -p "$repo"
@@ -194,18 +347,25 @@ test_lowercase_agents_md_refuses_case_fragile_symlink() {
   [ "$rc" -ne 0 ] || fail "expected a non-zero exit for a lowercase agents.md"
   assert_contains "$out" "conflict:" "lowercase agents.md did not report a conflict"
   assert_contains "$out" "agents.md" "conflict message did not name the offending file"
-  assert_absent "$repo/CLAUDE.md" "a case-fragile CLAUDE.md symlink was created for lowercase agents.md"
+  assert_absent "$repo/CLAUDE.md" "a case-fragile CLAUDE.md pointer was created for lowercase agents.md"
   [ ! -L "$repo/CLAUDE.md" ] || fail "a case-fragile CLAUDE.md symlink was created for lowercase agents.md"
   assert_present "$repo/agents.md" "the real lowercase agents.md was disturbed"
   pass "fm-ensure-agents-md.sh: refuses a case-variant lowercase agents.md (issue #389)"
 }
 
 test_created_agents_md_includes_self_governance
+test_fresh_setup_writes_real_claude_pointer
 test_promoted_claude_md_includes_self_governance
 test_promoted_claude_md_without_trailing_newline_keeps_blank_separator
 test_existing_agents_md_with_symlink_gains_self_governance
-test_existing_agents_md_without_claude_gains_section_and_symlink
+test_correct_symlink_migrates_to_pointer_without_clobbering_agents
+test_existing_agents_md_without_claude_gains_section_and_pointer
 test_existing_agents_md_with_section_reports_unchanged
 test_existing_crlf_agents_md_with_section_stays_unchanged
 test_existing_crlf_agents_md_without_section_preserves_crlf
-test_lowercase_agents_md_refuses_case_fragile_symlink
+test_canonical_pointer_is_accepted_when_both_are_real_files
+test_distinct_real_files_are_refused
+test_agents_md_symlink_is_refused
+test_wrong_target_symlink_is_refused
+test_non_regular_claude_md_is_refused
+test_lowercase_agents_md_refuses_case_fragile_pointer


### PR DESCRIPTION
## Intent

Root-cause fix: make the agent-memory installer emit a real @AGENTS.md pointer, not a CLAUDE.md symlink.

Captain-approved (2026-08-16). Context: an agent Write aimed at CLAUDE.md followed the CLAUDE.md -> AGENTS.md symlink and destroyed 1488 lines of AGENTS.md. The fleet-wide decision is to replace that symlink convention with a real CLAUDE.md file that uses Claude Code's native @path import, which inlines AGENTS.md into memory at load time (zero extra read turns) while a stray write only clobbers a recoverable one-liner. A separate worker is swapping the 34 existing repos; THIS work is the root cause so the footgun never regenerates.

The canonical CLAUDE.md pointer content is the source of truth for this task and must be byte-identical to this exact two-line form (kept consistent with the fleet sweep):
<!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
@AGENTS.md

Required changes:
1. bin/fm-ensure-agents-md.sh currently ln -s's a CLAUDE.md -> AGENTS.md symlink. Change it so that everywhere it would create or correctly assert a CLAUDE.md symlink, it instead creates/asserts a real regular file whose content is exactly the canonical pointer above.
- When only AGENTS.md exists and CLAUDE.md is missing: write the canonical real CLAUDE.md.
- When CLAUDE.md is already a correct symlink to AGENTS.md: convert it to the canonical real pointer file (idempotent migration; running the script again is a no-op).
- When CLAUDE.md is already the canonical real pointer: unchanged no-op.
- Preserve every existing safety refusal (distinct real files, AGENTS.md being a symlink, wrong-target symlink, non-regular file, the uppercase-literal-target dangling concern the header describes - which the real-file pointer actually eliminates, so update that reasoning too). The "both AGENTS.md and CLAUDE.md are real files" branch must now accept the canonical pointer as correct rather than flagging conflict.
- Update the script header comment and any --help/echo strings that say "symlink" to describe the pointer file.
- The installer must never create a CLAUDE.md symlink; it must unlink an existing correct symlink before writing so a write cannot follow the symlink and destroy AGENTS.md.
2. Firstmate's own root CLAUDE.md is currently a symlink to AGENTS.md. Replace it with the canonical real pointer file (git records the symlink->file change).
3. Firstmate's own AGENTS.md text: section 2's layout line currently reads "AGENTS.md this file (CLAUDE.md is a symlink to it)". Correct it to describe the @AGENTS.md pointer instead of a symlink. Leave the unrelated .claude/skills -> .agents/skills symlink and its description untouched. Scan docs/ and any skill text for other descriptions of the CLAUDE.md symlink convention and correct them to the pointer form.
4. Tests: update/add the structural tests for fm-ensure-agents-md.sh so they assert: a fresh setup produces a real (non-symlink) CLAUDE.md equal to the canonical pointer; an existing correct symlink is migrated to the pointer; a second run is a clean no-op; and the existing conflict-refusal cases still hold. Exercise the real script (its actual executable behavior), not source-text matching. Every existing test must still pass.

Acceptance criteria:
- fm-ensure-agents-md.sh never creates a CLAUDE.md symlink; it creates/asserts the canonical real pointer file and idempotently migrates an existing correct symlink to it.
- Firstmate's own root CLAUDE.md is a real pointer file; its AGENTS.md layout text and any other symlink-convention descriptions are corrected.
- Tests assert pointer creation, symlink->pointer migration, no-op idempotency, and the preserved refusals, all by exercising the script; the suite is green.
- The canonical pointer content is byte-identical to the two-line form above.

Do not merge the PR. Report the PR URL when CI is green.

## What Changed

- Reworked `bin/fm-ensure-agents-md.sh` so it never creates a `CLAUDE.md` symlink: it now writes/asserts a canonical two-line real `@AGENTS.md` pointer file, migrates an existing correct `CLAUDE.md -> AGENTS.md` symlink to that pointer (unlinking first so a write can't follow the link and destroy `AGENTS.md`), accepts the pointer as correct in the "both real files" branch, treats a second run as a clean no-op, and preserves every existing conflict/case-variant refusal (header, help, and echo strings updated accordingly).
- Replaced firstmate's own root `CLAUDE.md` symlink with the canonical real pointer file and corrected the symlink-convention wording in `AGENTS.md`, `CONTRIBUTING.md`, `docs/architecture.md`, `docs/scripts.md`, `bin/fm-ff-lib.sh`, and the `updatefirstmate` skill; the CI "symlinks intact" check now enforces that `CLAUDE.md` is a real file byte-equal to the canonical pointer rather than a symlink.
- Expanded `tests/fm-ensure-agents-md.test.sh` to exercise the real script for pointer creation on fresh setup, symlink→pointer migration without clobbering `AGENTS.md`, no-op idempotency, and the preserved conflict refusals.

## Risk Assessment

✅ Low: The change fully satisfies every required intent constraint with byte-identical canonical content, an unlink-before-write path that closes the symlink footgun, all safety refusals preserved, consistent doc/CI updates, and behavior-exercising tests; every branch traces correctly with no reachable wrong-result path.

## Testing

`Ran the full focused test suite for the installer (16/16 passing, all exercising the real executable), then demonstrated the core intent end-to-end by contrasting the base-commit symlink installer (a stray write to CLAUDE.md destroyed AGENTS.md) against the target-commit pointer installer (the identical stray write left AGENTS.md intact), plus symlink->pointer migration, clean no-op idempotency, and byte-identical canonical pointer content; also confirmed the repo's own CLAUDE.md is now a real pointer file (git-recorded symlink->file mode change) and no lingering symlink-convention docs remain. This is a CLI/filesystem-behavior change with no rendered UI surface, so evidence is CLI transcripts and file-state inspection rather than screenshots. Overall result: green.`

<details>
<summary>Evidence: E2E footgun comparison (old symlink destroys AGENTS.md vs new pointer protects it)</summary>

Source: [E2E footgun comparison (old symlink destroys AGENTS.md vs new pointer protects it)](https://github.com/kunchenguid/firstmate/blob/2d0698c84977bedcd9a7b5e179d9b230b8a8257e/.no-mistakes/evidence/fm/fm-agentmemory-pointer-installer-r1/footgun-e2e.txt)

```text
############################################################
# E2E: agent-memory installer footgun fix
# A stray agent Write aimed at CLAUDE.md must NOT destroy AGENTS.md
############################################################

===== SCENARIO A: OLD installer (base commit) - the footgun =====
-- After OLD installer, CLAUDE.md is:
lrwxr-xr-x@ 1 kunchen  staff  9 Aug 16 20:30 <repo>/CLAUDE.md -> AGENTS.md
   => SYMLINK (dangerous)
-- An agent now does: echo 'stray note' > CLAUDE.md
-- AGENTS.md contents afterward:
stray note
   RESULT: *** AGENTS.md DESTROYED - knowledge clobbered via symlink ***

===== SCENARIO B: NEW installer (target commit) - the fix =====
-- After NEW installer, CLAUDE.md is:
-rw-r--r--@ 1 kunchen  staff  90 Aug 16 20:30 <repo>/CLAUDE.md
   => REGULAR FILE (safe pointer)
-- CLAUDE.md contents (the canonical @AGENTS.md import pointer):
<!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
@AGENTS.md
-- An agent now does the same stray: echo 'stray note' > CLAUDE.md
-- AGENTS.md contents afterward:
# Project memory

CRITICAL: 1488 lines of hard-won knowledge live here.

## Maintaining this file

Keep this file for knowledge useful to almost every future agent session in this project.
Do not repeat what the codebase already shows; point to the authoritative file or command instead.
Prefer rewriting or pruning existing entries over appending new ones.
When updating this file, preserve this bar for all agents and keep entries concise.
   RESULT: AGENTS.md INTACT - stray write only clobbered the recoverable one-liner
```
</details>
<details>
<summary>Evidence: E2E symlink-&gt;pointer migration and idempotency transcript</summary>

Source: [E2E symlink-&gt;pointer migration and idempotency transcript](https://github.com/kunchenguid/firstmate/blob/2d0698c84977bedcd9a7b5e179d9b230b8a8257e/.no-mistakes/evidence/fm/fm-agentmemory-pointer-installer-r1/migration-idempotency-e2e.txt)

```text
===== Migration: existing correct CLAUDE.md->AGENTS.md symlink -> real pointer =====
-- before: lrwxr-xr-x@ <repo>/CLAUDE.md -> AGENTS.md
-- run 1:  updated: added ## Maintaining this file to AGENTS.md and wrote CLAUDE.md @AGENTS.md pointer in /private<repo>
-- after:  REGULAR FILE ; payload preserved: YES
-- run 2:  unchanged: AGENTS.md with CLAUDE.md @AGENTS.md pointer in /private<repo>   <- clean no-op

===== Idempotency: three consecutive runs on a fresh repo =====
-- run 1: created: AGENTS.md and CLAUDE.md @AGENTS.md pointer in /private<repo>
-- run 2: unchanged: AGENTS.md with CLAUDE.md @AGENTS.md pointer in /private<repo>
-- run 3: unchanged: AGENTS.md with CLAUDE.md @AGENTS.md pointer in /private<repo>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"03fbfb0a524cfbbb9897a1bce2a8e2cc2040b8ce","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-ensure-agents-md.test.sh` (16/16 ok)</code>
- <code>E2E footgun comparison: ran base-commit vs target-commit installer, then `echo &#39;stray note&#39; &gt; CLAUDE.md` in each and inspected AGENTS.md survival</code>
- <code>E2E migration: correct CLAUDE.md-&gt;AGENTS.md symlink migrated to real pointer with AGENTS.md payload preserved, second run reports `unchanged:`</code>
- <code>E2E idempotency: three consecutive `bin/fm-ensure-agents-md.sh` runs on a fresh repo (created -&gt; unchanged -&gt; unchanged)</code>
- <code>Verified repo CLAUDE.md is a regular file byte-identical to the canonical two-line pointer via `cmp`</code>
- <code>`git diff` confirms repo CLAUDE.md changed from file mode 120000 (symlink) to 100644 (regular file)</code>
- `grep scan of docs/AGENTS.md/CONTRIBUTING.md/README.md/.agents for lingering CLAUDE.md-symlink descriptions (none)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
