### PR TITLE
fix: retain Codex checkpoint supervision

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -205,7 +205,7 @@ That styled capture is internal to the boolean detector only.
 **Primary-session guard fact (verified 2026-07-04, Claude Code 2.1.201; preserved 2026-07-08, Claude Code 2.1.204; Stop-owned auto-arm revalidated 2026-07-24, Claude Code 2.1.219).**
 This is separate from the per-task crewmate turn-end hook above (that one just `touch`es a marker file in a task's own `.claude/settings.local.json`).
 The firstmate PRIMARY's own `.claude/settings.json` registers two Stop hooks: `bin/fm-turnend-guard.sh --claude` and the Stop-owned auto-arm `bin/fm-claude-stop-autoarm.sh` (`asyncRewake: true`, `timeout: 28800`), and exiting the guard with status 2 plus stderr reliably forces the model to continue.
-Claude Code's stdin payload to a Stop hook carries a `stop_hook_active` boolean that is `true` when the current stop attempt follows ANY stop-hook-driven continuation, including `asyncRewake` rewakes; the primary guard therefore ignores it in `--claude` mode and uses the cooperative claim/epoch check plus a bounded re-block budget instead, while the codex-mode default still treats it as a one-block loop guard.
+Claude Code's stdin payload to a Stop hook carries a `stop_hook_active` boolean that is `true` when the current stop attempt follows ANY stop-hook-driven continuation, including `asyncRewake` rewakes; the primary guard therefore ignores it in `--claude` mode and uses the cooperative claim/epoch check plus a bounded re-block budget instead.
 A project-level `.claude/settings.json` only takes effect when Claude Code's project root is that exact directory - it does not walk up from a subdirectory looking for one, so firstmate launches the primary from the repo root.
 After those settings are loaded, hook command resolution is still cwd-sensitive because Claude Code runs commands through `/bin/sh` against the session's current cwd; keep the tracked commands anchored through `"$CLAUDE_PROJECT_DIR"/bin/...` and see `docs/turnend-guard.md` for the verified Stop-hook details.
 Claude Code's primary watcher protocol is Stop-owned: the auto-arm hook fires on every Stop and foregrounds `bin/fm-watch-arm.sh` when the home is eligible and still needs supervision, and its exit-2 `asyncRewake` rewake is the wake; the model drains and handles wakes but never runs a routine re-arm command.
@@ -234,7 +234,8 @@ The session id is printed on quit.
 
 **Primary-session guard fact (verified 2026-07-08, codex-cli 0.142.1).**
 The firstmate PRIMARY's own `.codex/hooks.json` registers a Stop hook that pipes Codex's Stop payload to `bin/fm-turnend-guard.sh`.
-Codex Stop hooks block on exit 2 and expose `stop_hook_active` for the same one-block loop safety Claude uses.
+Codex Stop hooks block on exit 2 and expose `stop_hook_active`.
+Codex's explicit guard mode does not accept that field as watcher proof, because a foreground checkpoint releases the watcher lock before the next turn boundary.
 Codex's Stop payload includes `cwd`, but the tracked primary hook does not use it to choose the guard executable.
 Verified on 2026-07-08: Codex runs the Stop hook command with process PWD set to the hook-loaded project root, and no `CODEX_PROJECT_DIR`, `CODEX_WORKSPACE_ROOT`, or `CODEX_CWD` root variable is set.
 The tracked hook anchors to `pwd -P`, verifies that root is firstmate-shaped and hook-bearing, and then invokes `bin/fm-turnend-guard.sh` with the original payload.

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -33,7 +33,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-turnend-guard.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.Stop[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-turnend-guard.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-turnend-guard.sh\"'",
+            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-turnend-guard.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.Stop[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-turnend-guard.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-turnend-guard.sh\" --codex'",
             "timeout": 30
           }
         ]

--- a/bin/fm-turnend-guard.sh
+++ b/bin/fm-turnend-guard.sh
@@ -10,7 +10,7 @@
 # fleet-touching command itself, can sit blind for hours.
 # This script is push-based: verified harness turn-end hooks invoke it every time
 # the primary is about to end a turn.
-# Claude and codex can block directly by preserving exit status 2 and stderr.
+# Claude and Codex can block directly by preserving exit status 2 and stderr.
 # OpenCode and pi adapters use the same predicate and force one bounded
 # follow-up because their turn-end events are passive. Grok delegates native
 # blocking when its running Stop payload advertises that capability, with one
@@ -32,15 +32,17 @@
 # primary checkout - the main home or a genuinely marked secondmate home - and
 # stay a silent, fast no-op inside child task worktrees.
 #
-# Loop-guard, codex/Grok (default) mode: never block twice in the same turn.
-# Codex uses stop_hook_active and Grok uses stopHookActive; typed camel-case
-# takes precedence when both spellings are present. A true value means the
-# current stop attempt already follows a block, so this guard always allows it.
-# Passive harness adapters provide their own one-follow-up guard before calling
-# this script.
-# That bounds those harnesses to at most one forced continuation per turn -
-# never a wedged, un-endable session - while still nagging again on a later turn
-# if the problem persists.
+# Loop-guard, default/Grok mode: never block twice in the same turn.
+# Grok uses stopHookActive; typed camel-case takes precedence when both
+# spellings are present. A true value means the current stop attempt already
+# follows a block, so this mode allows it. Passive harness adapters provide
+# their own one-follow-up guard before calling this script.
+#
+# Codex is separate. Its foreground checkpoint ends before the next turn
+# boundary, so allowing a stop_hook_active=true continuation would let the
+# session end with no live watcher. Its explicit mode rechecks the strict
+# watcher lock predicate on every stop and keeps the foreground protocol alive
+# until a real watcher owns the home lock.
 #
 # Loop-guard, --claude mode (Stop-owned auto-arm cooperation): Claude Code
 # marks EVERY stop after ANY stop-hook-driven continuation stop_hook_active=true,
@@ -72,6 +74,7 @@ CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 GRACE=${FM_GUARD_GRACE:-300}
 WATCH="$SCRIPT_DIR/fm-watch.sh"
 CLAUDE_MODE=0
+CODEX_MODE=0
 CURSOR_MODE=0
 SYNC_WAIT_MS=${FM_CLAUDE_AUTOARM_SYNC_WAIT_MS:-800}
 EPOCH_FRESH=${FM_CLAUDE_AUTOARM_EPOCH_FRESH:-15}
@@ -83,8 +86,9 @@ case "$BLOCK_BUDGET" in ''|*[!0-9]*|0) BLOCK_BUDGET=3 ;; esac
 for arg in "$@"; do
   case "$arg" in
     --claude) CLAUDE_MODE=1 ;;
+    --codex) CODEX_MODE=1 ;;
     --cursor) CURSOR_MODE=1 ;;
-    *) echo "usage: $(basename "$0") [--claude|--cursor]" >&2; exit 2 ;;
+    *) echo "usage: $(basename "$0") [--claude|--codex|--cursor]" >&2; exit 2 ;;
   esac
 done
 
@@ -123,7 +127,7 @@ STOP_HOOK_ACTIVE=$(printf '%s' "$PAYLOAD" | jq -r '
   else false
   end
 ' 2>/dev/null) || exit 0
-if [ "$CLAUDE_MODE" -eq 0 ] && [ "$STOP_HOOK_ACTIVE" = "true" ]; then
+if [ "$CLAUDE_MODE" -eq 0 ] && [ "$CODEX_MODE" -eq 0 ] && [ "$STOP_HOOK_ACTIVE" = "true" ]; then
   exit 0
 fi
 

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -68,7 +68,10 @@ If `jq` is missing or hook stdin is empty, the guard exits 0 because it cannot s
 
 Claude and Codex can block a Stop directly with exit status 2 and stderr.
 Both payloads carry `stop_hook_active`.
-In the default Codex mode, a true value lets the second stop finish after one forced continuation.
+Codex registers the guard with `--codex`.
+Its bounded foreground checkpoint has released the watcher's singleton lock before the next turn boundary, so a true value cannot prove supervision.
+The Codex mode therefore rechecks the PID-strict watcher lock and beacon predicate on every stop and returns exit 2 until a real identity-matched watcher owns the home lock.
+The generic default retains its one-follow-up loop guard for adapters that provide their own continuity mechanism.
 
 Claude runs the guard with `--claude`, which ignores `stop_hook_active` and cooperates with the Stop-owned auto-arm.
 Claude Code sets `stop_hook_active=true` on every stop after any stop-hook continuation, including `asyncRewake` rewakes, which re-opened the 2026-07-21 blind window under the default one-shot behavior.

--- a/tests/fm-codex-continuity-live-e2e.test.sh
+++ b/tests/fm-codex-continuity-live-e2e.test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Opt-in credentialed Codex regression proving the continuity changes preserve
-# Codex's bounded foreground-checkpoint supervision path.
+# Opt-in credentialed Codex regression proving that an active primary cannot
+# end blind after a bounded foreground checkpoint releases its watcher lock.
 set -u
 
 if [ "${FM_CODEX_LIVE_E2E:-0}" != 1 ]; then
@@ -31,8 +31,11 @@ trap cleanup EXIT
 mkdir -p "$LAB"
 git clone -q "$ROOT" "$PROJECT"
 mkdir -p "$HOME_DIR/state" "$HOME_DIR/config"
-# shellcheck disable=SC2016 # Backticks are literal prompt markup.
-PROMPT='Run exactly `bin/fm-watch-checkpoint.sh --seconds 1` as one foreground shell call. Do not use a background task and do not run fm-watch-arm.sh. After the checkpoint returns, reply briefly.'
+printf 'synthetic active task\n' > "$HOME_DIR/state/task.meta"
+# Keep supervision needed through two Stop-hook attempts.
+# The third turn removes the synthetic task only after the second hook feedback,
+# so the run proves that a stop_hook_active=true continuation is re-blocked.
+PROMPT="Run exactly \`bin/fm-watch-checkpoint.sh --seconds 1\` as one foreground shell call. Do not use a background task and do not run fm-watch-arm.sh. Then reply with exactly FIRST_CHECKPOINT_DONE and stop. If Stop-hook feedback creates a first follow-up turn, reply with exactly SECOND_STOP_DONE and stop without running any command. If a second Stop-hook feedback creates another follow-up turn, run exactly \`rm -f '$HOME_DIR/state/task.meta'\`, reply with exactly THIRD_SUPERVISION_RELEASED, and stop."
 
 (
   cd "$PROJECT" || exit 1
@@ -51,5 +54,11 @@ grep -F 'checkpoint: no actionable wake within 1s' "$TRANSCRIPT" >/dev/null \
 if grep -F 'watcher: started pid=' "$TRANSCRIPT" >/dev/null; then
   fail "Codex switched to the background arm path"
 fi
+grep -F 'FIRST_CHECKPOINT_DONE' "$TRANSCRIPT" >/dev/null \
+  || fail "Codex did not complete the initial foreground checkpoint turn"
+grep -F 'SECOND_STOP_DONE' "$TRANSCRIPT" >/dev/null \
+  || fail "Codex did not receive the first Stop-hook continuation"
+grep -F 'THIRD_SUPERVISION_RELEASED' "$TRANSCRIPT" >/dev/null \
+  || fail "Codex let a stop_hook_active=true turn end without the required second continuation"
 
-printf 'ok - %s live E2E preserved the one-second foreground checkpoint path\n' "$CODEX_VERSION"
+printf 'ok - %s live E2E re-blocked the foreground-checkpoint continuation until supervision was released\n' "$CODEX_VERSION"

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -195,6 +195,12 @@ run_hook() {
   printf '{"stop_hook_active":%s}' "$stop_active" | CLAUDECODE=1 FM_HOME="$home" bash "$dir/bin/fm-turnend-guard.sh" 2>&1
 }
 
+run_hook_codex() {
+  local dir=$1 stop_active=$2 home
+  home=$(cd "$dir" && pwd)
+  printf '{"stop_hook_active":%s}' "$stop_active" | FM_HOME="$home" bash "$dir/bin/fm-turnend-guard.sh" --codex 2>&1
+}
+
 nonexistent_pid() {
   local pid=999999
   while kill -0 "$pid" 2>/dev/null; do
@@ -431,6 +437,22 @@ test_hook_loop_guard_allows_retry() {
   expect_code 0 "$status" "hook must allow the stop when stop_hook_active is already true"
   [ -z "$out" ] || fail "hook produced output on the loop-guarded retry: $out"
   pass "fm-turnend-guard: stop_hook_active=true always allows the stop (never blocks twice in one turn)"
+}
+
+# End-user regression: a Codex foreground checkpoint has just returned, so its
+# watcher has released the singleton lock. The first forced continuation stops
+# with stop_hook_active=true. A fresh heartbeat from that completed checkpoint
+# is not supervision and must not let the primary end blind.
+test_codex_mode_reblocks_checkpoint_continuation_without_live_watcher() {
+  local dir out status
+  dir=$(make_primary_dir "$TMP_ROOT/codex-checkpoint-continuation")
+  : > "$dir/state/task1.meta"
+  touch "$dir/state/.last-watcher-beat"
+  out=$(run_hook_codex "$dir" true); status=$?
+  expect_code 2 "$status" "Codex continuation must block when no watcher owns the home lock"
+  assert_contains "$out" "TURN WOULD END BLIND" "Codex continuation must surface the blind-turn alarm"
+  assert_contains "$out" "no live watcher holds this home lock" "a fresh heartbeat must not satisfy Codex watcher ownership"
+  pass "fm-turnend-guard --codex: re-blocks a checkpoint continuation until a live watcher owns the home lock"
 }
 
 # A secondmate's OWN home runs a primary firstmate session and must be guarded
@@ -857,9 +879,10 @@ test_codex_hook_uses_process_pwd_when_payload_cwd_is_outside_root() {
   expected_root=$(cd "$dir" && pwd -P)
   outside="$TMP_ROOT/codex-hook-outside"
   mkdir -p "$outside"
-  cat > "$dir/bin/fm-turnend-guard.sh" <<'EOF'
+cat > "$dir/bin/fm-turnend-guard.sh" <<'EOF'
 #!/usr/bin/env bash
 printf 'guard=%s\n' "$0"
+printf 'args=%s\n' "$*"
 cat
 EOF
   chmod +x "$dir/bin/fm-turnend-guard.sh"
@@ -867,6 +890,7 @@ EOF
   out=$(printf '%s' "$payload" | (cd "$dir" && bash -c "$command") 2>&1); status=$?
   expect_code 0 "$status" "codex hook must execute successfully when payload cwd is outside the firstmate root"
   assert_contains "$out" "guard=$expected_root/bin/fm-turnend-guard.sh" "codex hook must use the hook process root"
+  assert_contains "$out" "args=--codex" "codex hook must select the Codex continuity mode"
   assert_contains "$out" "$payload" "codex hook must pass the original payload to the guard"
   pass ".codex/hooks.json: Stop hook uses hook process root when payload cwd is outside"
 }
@@ -893,9 +917,10 @@ printf 'nested guard executed\n'
 exit 99
 EOF
   chmod +x "$nested/bin/fm-turnend-guard.sh"
-  cat > "$dir/bin/fm-turnend-guard.sh" <<'EOF'
+cat > "$dir/bin/fm-turnend-guard.sh" <<'EOF'
 #!/usr/bin/env bash
 printf 'guard=%s\n' "$0"
+printf 'args=%s\n' "$*"
 cat
 EOF
   chmod +x "$dir/bin/fm-turnend-guard.sh"
@@ -905,6 +930,7 @@ EOF
   out=$(printf '%s' "$payload" | (cd "$dir" && bash -c "$command") 2>&1); status=$?
   expect_code 0 "$status" "codex hook must not execute a nested project guard"
   assert_contains "$out" "guard=$expected_root/bin/fm-turnend-guard.sh" "codex hook must keep using the outer firstmate guard"
+  assert_contains "$out" "args=--codex" "codex hook must select the Codex continuity mode"
   assert_not_contains "$out" "nested guard executed" "codex hook must not execute nested project code"
   pass ".codex/hooks.json: Stop hook ignores nested git root guard scripts"
 }
@@ -1622,6 +1648,7 @@ test_hook_x_mode_only_blocks_in_default_mode
 test_hook_ignores_repo_state_when_fm_home_set
 test_hook_uses_state_override
 test_hook_loop_guard_allows_retry
+test_codex_mode_reblocks_checkpoint_continuation_without_live_watcher
 test_hook_blocks_in_secondmate_own_home
 test_hook_silent_in_idle_secondmate_home
 test_hook_secondmate_loop_guard_allows_retry


### PR DESCRIPTION
Codex foreground checkpoints release the watcher lock before the next turn boundary. The old generic stop-hook loop guard treated stop_hook_active=true as enough to let that continuation end, leaving active work without supervision.

This adds an explicit Codex guard mode that re-checks the strict watcher ownership predicate on every stop. A heartbeat from an exited checkpoint is not accepted as watcher liveness. The tracked Codex hook selects that mode.

Validation: bin/fm-lint.sh, bin/fm-doc-audience-check.sh, bin/fm-test-run.sh tests/fm-turnend-guard.test.sh, and bin/fm-test-run.sh tests/fm-watch-checkpoint.test.sh.

The credentialed Codex continuity E2E regression was added but not run because FM_CODEX_LIVE_E2E is opt-in.