### PR TITLE
ci: fix invalid YAML in CLAUDE.md pointer check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,10 +377,12 @@ jobs:
         run: |
           set -eu
           [ ! -L CLAUDE.md ] || { echo "::error::CLAUDE.md must be a real @AGENTS.md pointer file, not a symlink"; exit 1; }
-          cmp -s CLAUDE.md - <<'EOF' || { echo "::error::CLAUDE.md must be the canonical @AGENTS.md pointer"; exit 1; }
-<!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
-@AGENTS.md
-EOF
+          tmp=$(mktemp)
+          trap 'rm -f "$tmp"' EXIT
+          printf '%s\n' \
+            '<!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->' \
+            '@AGENTS.md' >"$tmp"
+          cmp -s CLAUDE.md "$tmp" || { echo "::error::CLAUDE.md must be the canonical @AGENTS.md pointer"; exit 1; }
           [ "$(readlink .claude/skills)" = "../.agents/skills" ] || { echo "::error::.claude/skills must be a symlink to ../.agents/skills"; exit 1; }
       - name: Personal fleet paths must not be tracked
         run: |


### PR DESCRIPTION
## Intent

Fix firstmate CI: the CLAUDE.md-pointer check added in #2512 currently embeds a column-0 heredoc body inside a run: | YAML block scalar in .github/workflows/ci.yml, making the workflow invalid and causing recent CI runs, including main, to fail or parse as zero jobs. Reproduce the malformed YAML and recent main CI failures, then rework only this check so the workflow is valid while it still rejects a CLAUDE.md symlink and any wrong or non-canonical pointer, and still asserts the exact canonical CLAUDE.md bytes: <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. --> followed by @AGENTS.md. Keep the adjacent .claude/skills symlink assertion working and do not change unrelated CI behavior. Validate and ship the fix through the no-mistakes pipeline, and require the PR CI run to go green as regression proof; do not merge the PR because the captain owns the merge.

## What Changed

- Reworked the CLAUDE.md-pointer verification step in `.github/workflows/ci.yml` so the canonical bytes are built with `mktemp` + `printf` and compared via `cmp`, replacing the column-0 heredoc body that broke out of the `run: |` block scalar and made the workflow parse as invalid.
- Preserved the check's behavior: it still rejects a `CLAUDE.md` symlink, asserts the exact canonical pointer bytes (`<!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->` followed by `@AGENTS.md`), and keeps the adjacent `.claude/skills` symlink assertion intact.

## Risk Assessment

✅ Low: A minimal, well-bounded CI fix that makes the workflow valid YAML (verified: base fails to parse, target parses with all 9 jobs) while preserving the symlink rejection, exact canonical-bytes assertion (verified byte-for-byte against the real CLAUDE.md), and the .claude/skills symlink check, with no unrelated behavior changed.

## Testing

Reproduced the reported bug by parsing the base ci.yml with a real YAML parser (fails at the column-0 heredoc body inside the run:| block scalar, yielding zero parseable jobs), confirmed the target ci.yml parses cleanly into all 9 jobs including invariants, then extracted the actual fixed check step from the parsed workflow and executed it against symlink / wrong-bytes / wrong-pointer / broken-skills fixtures plus the real repo files - every case behaves as intended, the canonical CLAUDE.md bytes (100644, exact) and .claude/skills symlink (120000) assertions hold, and the worktree is clean; the PR-CI-green regression proof named in the intent is owned by the remote pipeline outside this test phase.

<details>
<summary>Evidence: CI check test evidence</summary>

Source: [CI check test evidence](https://github.com/kunchenguid/firstmate/blob/291685f7cb2298f4854aaff182441e160ee7d6e9/.no-mistakes/evidence/fm/fm-ci-yaml-claudemd-check-fix-r1/ci-yaml-check.md)

```text
# CI CLAUDE.md-pointer check fix - test evidence

## 1. Reproduce malformed YAML (bug) vs valid YAML (fix)
Parsed both ci.yml revisions with a real YAML parser (Ruby Psych).

BASE (4913723, before fix):
  PARSE: FAILED
  ERROR: Psych::SyntaxError: could not find expected ':' while scanning a simple key at line 381 column 1
  -> the column-0 heredoc body (`@AGENTS.md`, `EOF`) terminates the `run: |`
     block scalar and breaks the workflow; it parses as zero jobs.

TARGET (b62f5f9, after fix):
  PARSE: OK
  JOBS: 9 -> lint, test-coverage, tests-portable-parallel-1, tests-portable-parallel-2,
             tests-portable-serial, tests-herdr, tests-timing-aggregate,
             macos-stock-bash, invariants

## 2. Behavior of the fixed check (extracted the real step body from parsed YAML, executed under bash)
  [canonical_ok]     exit=0  (correct pointer + correct skills symlink -> pass)
  [claudemd_symlink] exit=1  ::error::CLAUDE.md must be a real @AGENTS.md pointer file, not a symlink
  [wrong_bytes]      exit=1  ::error::CLAUDE.md must be the canonical @AGENTS.md pointer
  [wrong_pointer]    exit=1  ::error::CLAUDE.md must be the canonical @AGENTS.md pointer  (@CLAUDE.md rejected)
  [skills_broken]    exit=1  ::error::.claude/skills must be a symlink to ../.agents/skills

## 3. Real repo
  - extracted check runs clean (exit 0) against the actual worktree files
  - CLAUDE.md tracked mode 100644 (regular file), .claude/skills mode 120000 (symlink)
  - CLAUDE.md bytes exactly:
      <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->\n@AGENTS.md\n
```
</details>
<details>
<summary>Evidence: YAML parse: base fails, target 9 jobs</summary>

```text
=== BASE (4913723, before fix) ===
PARSE: FAILED
ERROR: Psych::SyntaxError: could not find expected ':' while scanning a simple key at line 381 column 1

=== TARGET (b62f5f9, after fix) ===
PARSE: OK
JOBS: 9 -> lint, test-coverage, tests-portable-parallel-1, tests-portable-parallel-2, tests-portable-serial, tests-herdr, tests-timing-aggregate, macos-stock-bash, invariants
```
</details>
<details>
<summary>Evidence: Extracted check run against fixtures</summary>

```text
[canonical_ok] exit=0 <no output>
[claudemd_symlink] exit=1 ::error::CLAUDE.md must be a real @AGENTS.md pointer file, not a symlink
[wrong_bytes] exit=1 ::error::CLAUDE.md must be the canonical @AGENTS.md pointer
[wrong_pointer] exit=1 ::error::CLAUDE.md must be the canonical @AGENTS.md pointer
[skills_broken] exit=1 ::error::.claude/skills must be a symlink to ../.agents/skills
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b62f5f9f41be943fde0c99ec1aeac5426842fc8d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`ruby -ryaml` parse of base ci.yml (4913723) -&gt; Psych::SyntaxError at line 381 col 1 (malformed)</code>
- <code>`ruby -ryaml` parse of target ci.yml (b62f5f9) -&gt; OK, 9 jobs incl invariants</code>
- `Extracted real invariants step body from parsed YAML, ran under bash against 5 fixtures: canonical_ok pass; claudemd_symlink/wrong_bytes/wrong_pointer/skills_broken fail with correct ::error:: messages`
- `Ran extracted check against real worktree -> exit 0`
- <code>`git ls-files -s CLAUDE.md .claude/skills` and `xxd CLAUDE.md` confirm 100644 regular file, 120000 symlink, exact canonical bytes</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
