### PR TITLE
ci: gate GitHub workflows with pinned actionlint

### DIFF
--- a/.agents/skills/firstmate-coding-guidelines/SKILL.md
+++ b/.agents/skills/firstmate-coding-guidelines/SKILL.md
@@ -118,7 +118,7 @@ Run `bin/fm-doc-audience-check.sh`; it enforces classification, README setup rou
 - Plain dash `-`, never an em dash.
 - Never add an agent name as a commit co-author.
 - `bin/*.sh` and `bin/backends/*.sh` must pass `shellcheck`.
-- Run `bin/fm-lint.sh` before treating a script change as done; it is the single owner of the lint definition (file set, config, and pinned shellcheck version) that CI and the no-mistakes pre-push gate both invoke, and it refuses to run under any other shellcheck version.
+- Run `bin/fm-lint.sh` before treating a script change as done; it is the single owner of the lint definition (file set, config, pinned shellcheck version, and GitHub workflow YAML parse) that CI and the no-mistakes pre-push gate both invoke, and it refuses to run under any other shellcheck version.
 - Colocate tests with the existing pattern in `tests/`, name them `<subject>.test.sh`, and extend an existing script rather than inventing a new runner.
 - Tests must exercise behavior through an executable or public interface and must never assert implementation-source bytes, including through parsers, regexes, snapshots, or indirect wrappers.
 - A maintainer-verification record under `docs/verification/` records active empirical facts, not assumptions or task chronology.

--- a/.agents/skills/firstmate-coding-guidelines/SKILL.md
+++ b/.agents/skills/firstmate-coding-guidelines/SKILL.md
@@ -118,7 +118,8 @@ Run `bin/fm-doc-audience-check.sh`; it enforces classification, README setup rou
 - Plain dash `-`, never an em dash.
 - Never add an agent name as a commit co-author.
 - `bin/*.sh` and `bin/backends/*.sh` must pass `shellcheck`.
-- Run `bin/fm-lint.sh` before treating a script change as done; it is the single owner of the lint definition (file set, config, pinned shellcheck version, and GitHub workflow YAML parse) that CI and the no-mistakes pre-push gate both invoke, and it refuses to run under any other shellcheck version.
+- Run `bin/fm-lint.sh` before treating a script change as done; it is the single owner of the lint definition (file set, config, pinned shellcheck version, and pinned actionlint workflow lint) that CI and the no-mistakes pre-push gate both invoke, and it refuses to run under any other shellcheck version.
+- When a task names a specific tool, implement the work with that tool, or explicitly flag the substitution and its new dependency footprint for review before shipping.
 - Colocate tests with the existing pattern in `tests/`, name them `<subject>.test.sh`, and extend an existing script rather than inventing a new runner.
 - Tests must exercise behavior through an executable or public interface and must never assert implementation-source bytes, including through parsers, regexes, snapshots, or indirect wrappers.
 - A maintainer-verification record under `docs/verification/` records active empirical facts, not assumptions or task chronology.

--- a/.agents/skills/firstmate-coding-guidelines/SKILL.md
+++ b/.agents/skills/firstmate-coding-guidelines/SKILL.md
@@ -118,7 +118,7 @@ Run `bin/fm-doc-audience-check.sh`; it enforces classification, README setup rou
 - Plain dash `-`, never an em dash.
 - Never add an agent name as a commit co-author.
 - `bin/*.sh` and `bin/backends/*.sh` must pass `shellcheck`.
-- Run `bin/fm-lint.sh` before treating a script change as done; it is the single owner of the lint definition (file set, config, pinned shellcheck version, and pinned actionlint workflow lint) that CI and the no-mistakes pre-push gate both invoke, and it refuses to run under any other shellcheck version.
+- Run `bin/fm-lint.sh` before treating a script change as done; it is the single owner of the lint definition (file set, config, pinned shellcheck version, and pinned actionlint workflow lint) that CI and the no-mistakes pre-push gate both invoke, and it refuses to run under any other version of either linter.
 - When a task names a specific tool, implement the work with that tool, or explicitly flag the substitution and its new dependency footprint for review before shipping.
 - Colocate tests with the existing pattern in `tests/`, name them `<subject>.test.sh`, and extend an existing script rather than inventing a new runner.
 - Tests must exercise behavior through an executable or public interface and must never assert implementation-source bytes, including through parsers, regexes, snapshots, or indirect wrappers.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   lint:
-    name: Lint shell scripts
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -20,8 +20,10 @@ jobs:
           set -eu
           bin/fm-install-shellcheck.sh "$RUNNER_TEMP/bin"
           echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
-      # Single owner of the lint definition (file set + config + version). Do not
-      # re-spell the shellcheck command here; keep CI and the pre-push gate on it.
+      # Single owner of the lint definition (shell file set, config, version,
+      # and GitHub workflow YAML). Do not re-spell the checks here; keep CI
+      # and the pre-push gate on this script so a self-broken ci.yml still
+      # fails locally before merge.
       - run: bin/fm-lint.sh
 
   # Deterministic proof that portable parallel shards + portable serial + Herdr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,13 @@ jobs:
           set -eu
           bin/fm-install-shellcheck.sh "$RUNNER_TEMP/bin"
           echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+      - name: Install pinned actionlint
+        run: |
+          set -eu
+          bin/fm-install-actionlint.sh "$RUNNER_TEMP/bin"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
       # Single owner of the lint definition (shell file set, config, version,
-      # and GitHub workflow YAML). Do not re-spell the checks here; keep CI
+      # and GitHub workflow lint). Do not re-spell the checks here; keep CI
       # and the pre-push gate on this script so a self-broken ci.yml still
       # fails locally before merge.
       - run: bin/fm-lint.sh
@@ -54,6 +59,11 @@ jobs:
           set -eu
           bin/fm-install-shellcheck.sh "$RUNNER_TEMP/bin"
           echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+      - name: Install pinned actionlint
+        run: |
+          set -eu
+          bin/fm-install-actionlint.sh "$RUNNER_TEMP/bin"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
       - name: Install tasks-axi
         run: |
           set -eu
@@ -85,6 +95,11 @@ jobs:
         run: |
           set -eu
           bin/fm-install-shellcheck.sh "$RUNNER_TEMP/bin"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+      - name: Install pinned actionlint
+        run: |
+          set -eu
+          bin/fm-install-actionlint.sh "$RUNNER_TEMP/bin"
           echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
       - name: Install tasks-axi
         run: |
@@ -131,6 +146,11 @@ jobs:
         run: |
           set -eu
           bin/fm-install-shellcheck.sh "$RUNNER_TEMP/bin"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+      - name: Install pinned actionlint
+        run: |
+          set -eu
+          bin/fm-install-actionlint.sh "$RUNNER_TEMP/bin"
           echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
       - name: Require tmux for e2e tests
         run: |

--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -24,9 +24,10 @@ document:
 
 # Pin lint to the same owner CI runs instead of leaving it to no-mistakes'
 # default handling, which does not invoke the repository's canonical lint gate.
-# `bin/fm-lint.sh` owns the complete lint definition and
+# `bin/fm-lint.sh` owns the complete lint definition, including GitHub workflow
+# YAML validation via `bin/fm-lint-workflows.sh`, and
 # `.github/workflows/ci.yml` invokes it directly, with parity asserted by
-# `tests/fm-lint.test.sh`.
+# `tests/fm-lint.test.sh` and `tests/fm-lint-workflows.test.sh`.
 #
 # Do not set commands.test to a complete tests/*.test.sh walk. Local no-mistakes
 # Test is intent-targeted validation of whether the change meets its brief;

--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -25,7 +25,7 @@ document:
 # Pin lint to the same owner CI runs instead of leaving it to no-mistakes'
 # default handling, which does not invoke the repository's canonical lint gate.
 # `bin/fm-lint.sh` owns the complete lint definition, including GitHub workflow
-# YAML validation via `bin/fm-lint-workflows.sh`, and
+# lint via pinned actionlint in `bin/fm-lint-workflows.sh`, and
 # `.github/workflows/ci.yml` invokes it directly, with parity asserted by
 # `tests/fm-lint.test.sh` and `tests/fm-lint-workflows.test.sh`.
 #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,8 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 - Helper scripts in `bin/` are plain bash.
   Each starts with a usage header comment; keep it accurate when you change behavior.
   Test scripts and helpers in `tests/` are plain bash too.
-  `bin/fm-lint.sh` must pass: it is the single owner of the lint definition (the shellcheck file set, config, and pinned shellcheck version), and both CI and the no-mistakes pre-push gate run it, so local and CI can never diverge.
+  `bin/fm-lint.sh` must pass: it is the single owner of the lint definition (the shellcheck file set, config, pinned shellcheck version, and GitHub workflow YAML parse), and both CI and the no-mistakes pre-push gate run it, so local and CI can never diverge.
+  A malformed `.github/workflows/*.yml`, including a self-broken `ci.yml`, fails that local lint path before merge because a broken workflow cannot report its own breakage.
   It pins one exact shellcheck version and refuses to run under any other; print it with `bin/fm-lint.sh --required-version` and install that build locally.
 - Harness-adapter ownership spans detection in `bin/fm-harness.sh`, launch and hook mechanics in `bin/fm-spawn.sh`, semantic busy sources and trust gates in `bin/fm-busy-lib.sh`, delivery-only rendered guards in `bin/fm-composer-lib.sh`, cleanup in `bin/fm-teardown.sh`, and facts in `.agents/skills/harness-adapters/SKILL.md`; the `firstmate-coding-guidelines` skill owns the validation policy for checks that depend on those harnesses.
 - Changes to runtime session backends (`bin/fm-backend.sh`, `bin/backends/`, and the scripts that dispatch through them) keep current setup and limits in the relevant backend guide and active empirical evidence in [`docs/verification/runtime-backends.md`](docs/verification/runtime-backends.md).
@@ -72,7 +73,7 @@ Check and test the toolbelt before pushing:
 
 ```sh
 while IFS= read -r script; do /bin/bash -n "$script" || exit; done < <(bin/fm-lint.sh --list-files)   # syntax-check the shell surface fm-lint.sh will cover (changed files locally, full set in CI/on main)
-bin/fm-lint.sh   # lint that same surface; the single owner CI and the no-mistakes gate both run, full set in CI
+bin/fm-lint.sh   # lint that shell surface plus GitHub workflow YAML; the single owner CI and the no-mistakes gate both run
 bin/fm-test-run.sh tests/<subject>.test.sh   # one script (primary local focus path, timed)
 bin/fm-test-run.sh --family pure-contract-unit   # ordinary family-scoped local path (serial, timed)
 bin/fm-test-run.sh --changed   # conservative changed-file-informed set (never silent full suite)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,9 +45,10 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 - Helper scripts in `bin/` are plain bash.
   Each starts with a usage header comment; keep it accurate when you change behavior.
   Test scripts and helpers in `tests/` are plain bash too.
-  `bin/fm-lint.sh` must pass: it is the single owner of the lint definition (the shellcheck file set, config, pinned shellcheck version, and GitHub workflow YAML parse), and both CI and the no-mistakes pre-push gate run it, so local and CI can never diverge.
+  `bin/fm-lint.sh` must pass: it is the single owner of the lint definition (the shellcheck file set, config, pinned shellcheck version, and pinned actionlint workflow lint), and both CI and the no-mistakes pre-push gate run it, so local and CI can never diverge.
   A malformed `.github/workflows/*.yml`, including a self-broken `ci.yml`, fails that local lint path before merge because a broken workflow cannot report its own breakage.
-  It pins one exact shellcheck version and refuses to run under any other; print it with `bin/fm-lint.sh --required-version` and install that build locally.
+  It pins one exact shellcheck version and one exact actionlint version and refuses to run under any other.
+  Print the shellcheck pin with `bin/fm-lint.sh --required-version` and the actionlint pin with `bin/fm-lint-workflows.sh --required-version`, then install those builds locally.
 - Harness-adapter ownership spans detection in `bin/fm-harness.sh`, launch and hook mechanics in `bin/fm-spawn.sh`, semantic busy sources and trust gates in `bin/fm-busy-lib.sh`, delivery-only rendered guards in `bin/fm-composer-lib.sh`, cleanup in `bin/fm-teardown.sh`, and facts in `.agents/skills/harness-adapters/SKILL.md`; the `firstmate-coding-guidelines` skill owns the validation policy for checks that depend on those harnesses.
 - Changes to runtime session backends (`bin/fm-backend.sh`, `bin/backends/`, and the scripts that dispatch through them) keep current setup and limits in the relevant backend guide and active empirical evidence in [`docs/verification/runtime-backends.md`](docs/verification/runtime-backends.md).
 - [`docs/documentation-audiences.md`](docs/documentation-audiences.md) and its machine-consumed inventory own prose classification; run `bin/fm-doc-audience-check.sh` after documentation changes.
@@ -73,7 +74,7 @@ Check and test the toolbelt before pushing:
 
 ```sh
 while IFS= read -r script; do /bin/bash -n "$script" || exit; done < <(bin/fm-lint.sh --list-files)   # syntax-check the shell surface fm-lint.sh will cover (changed files locally, full set in CI/on main)
-bin/fm-lint.sh   # lint that shell surface plus GitHub workflow YAML; the single owner CI and the no-mistakes gate both run
+bin/fm-lint.sh   # lint that shell surface plus GitHub workflows via pinned actionlint; the single owner CI and the no-mistakes gate both run
 bin/fm-test-run.sh tests/<subject>.test.sh   # one script (primary local focus path, timed)
 bin/fm-test-run.sh --family pure-contract-unit   # ordinary family-scoped local path (serial, timed)
 bin/fm-test-run.sh --changed   # conservative changed-file-informed set (never silent full suite)

--- a/bin/fm-install-actionlint.sh
+++ b/bin/fm-install-actionlint.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# fm-install-actionlint.sh - install CI's pinned, verified actionlint build.
+#
+# Usage:
+#   fm-install-actionlint.sh <destination-directory>
+set -eu
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION="$("$ROOT/bin/fm-lint-workflows.sh" --required-version)"
+SHA256=8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+ARCHIVE="actionlint_${VERSION}_linux_amd64.tar.gz"
+URL="https://github.com/rhysd/actionlint/releases/download/v${VERSION}/${ARCHIVE}"
+DESTINATION=${1:?usage: fm-install-actionlint.sh <destination-directory>}
+TMP=$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/fm-actionlint.XXXXXX")
+trap 'rm -rf "$TMP"' EXIT
+
+DOWNLOAD_ATTEMPTS=6
+download_attempt=1
+while ! curl -fsSL "$URL" -o "$TMP/$ARCHIVE"; do
+  [ "$download_attempt" -lt "$DOWNLOAD_ATTEMPTS" ] || {
+    printf 'fm-install-actionlint.sh: download failed after %s attempts\n' "$DOWNLOAD_ATTEMPTS" >&2
+    exit 1
+  }
+  printf 'fm-install-actionlint.sh: download attempt %s failed; retrying\n' "$download_attempt" >&2
+  sleep $((1 << (download_attempt - 1)))
+  download_attempt=$((download_attempt + 1))
+done
+ACTUAL_SHA256=$(sha256sum "$TMP/$ARCHIVE" | awk '{print $1}')
+[ "$ACTUAL_SHA256" = "$SHA256" ] || {
+  printf 'fm-install-actionlint.sh: checksum mismatch for %s\n' "$ARCHIVE" >&2
+  exit 1
+}
+tar -xzf "$TMP/$ARCHIVE" -C "$TMP"
+mkdir -p "$DESTINATION"
+install -m 0755 "$TMP/actionlint" "$DESTINATION/actionlint"
+"$DESTINATION/actionlint" -version

--- a/bin/fm-lint-workflows.sh
+++ b/bin/fm-lint-workflows.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# fm-lint-workflows.sh - owner of firstmate's GitHub workflow YAML validation.
+#
+# Parses every .github/workflows/*.{yml,yaml} so a malformed workflow, including
+# a self-broken ci.yml, fails in the local and no-mistakes lint lane before
+# merge. A broken ci.yml cannot report its own breakage, so this check must not
+# live only as a step inside that workflow. bin/fm-lint.sh invokes this owner
+# on its default (no explicit-path) path, which CI and commands.lint both use.
+#
+# Usage:
+#   fm-lint-workflows.sh                 lint workflows under this repo
+#   fm-lint-workflows.sh --root <dir>    lint workflows under <dir>
+#   fm-lint-workflows.sh <path>...       lint explicit workflow files
+#   fm-lint-workflows.sh --help
+set -eu
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SELF="$SELF_DIR/fm-lint-workflows.sh"
+ROOT="$(cd "$SELF_DIR/.." && pwd)"
+
+fm_lint_workflows_usage() {
+  sed -n '2,15{s/^# \{0,1\}//;p;}' "$SELF"
+}
+
+EXPLICIT_ROOT=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --root)
+      [ "$#" -ge 2 ] || {
+        printf 'fm-lint-workflows.sh: --root requires a directory.\n' >&2
+        exit 2
+      }
+      EXPLICIT_ROOT=$2
+      shift 2
+      ;;
+    --root=*)
+      EXPLICIT_ROOT=${1#*=}
+      shift
+      ;;
+    --help|-h)
+      fm_lint_workflows_usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      printf 'fm-lint-workflows.sh: unknown option: %s\n' "$1" >&2
+      exit 2
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [ -n "$EXPLICIT_ROOT" ]; then
+  [ -d "$EXPLICIT_ROOT" ] || {
+    printf 'fm-lint-workflows.sh: --root is not a directory: %s\n' "$EXPLICIT_ROOT" >&2
+    exit 2
+  }
+  ROOT="$(cd "$EXPLICIT_ROOT" && pwd)"
+fi
+
+collect_workflow_files() {
+  local dir=$1
+  [ -d "$dir" ] || return 0
+  find "$dir" -maxdepth 1 \( -name '*.yml' -o -name '*.yaml' \) -type f \
+    | LC_ALL=C sort
+}
+
+FILES=()
+if [ "$#" -gt 0 ]; then
+  for path in "$@"; do
+    case "$path" in
+      *.yml|*.yaml) ;;
+      *)
+        printf 'fm-lint-workflows.sh: not a workflow YAML file: %s\n' "$path" >&2
+        exit 2
+        ;;
+    esac
+    [ -f "$path" ] || {
+      printf 'fm-lint-workflows.sh: workflow file not found: %s\n' "$path" >&2
+      exit 2
+    }
+    FILES+=("$path")
+  done
+else
+  workflow_dir="$ROOT/.github/workflows"
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    FILES+=("$path")
+  done < <(collect_workflow_files "$workflow_dir")
+  if [ "${#FILES[@]}" -eq 0 ]; then
+    printf 'fm-lint-workflows.sh: no GitHub workflow files found under %s\n' \
+      "$workflow_dir" >&2
+    exit 1
+  fi
+fi
+
+if ! command -v ruby >/dev/null 2>&1; then
+  printf 'fm-lint-workflows.sh: ruby is required to parse GitHub workflow YAML.\n' >&2
+  exit 127
+fi
+
+set +e
+ruby - "${FILES[@]}" <<'RUBY'
+require 'psych'
+
+status = 0
+ARGV.each do |path|
+  begin
+    doc = Psych.parse_file(path)
+    root = doc && doc.root
+    unless root.is_a?(Psych::Nodes::Mapping)
+      $stderr.puts "fm-lint-workflows.sh: #{path}: workflow YAML root must be a mapping"
+      status = 1
+      next
+    end
+  rescue Psych::SyntaxError => e
+    problem = e.respond_to?(:problem) && e.problem ? e.problem : e.message
+    line = e.respond_to?(:line) ? e.line : '?'
+    column = e.respond_to?(:column) ? e.column : '?'
+    $stderr.puts "fm-lint-workflows.sh: invalid YAML in #{path}: #{problem} at line #{line} column #{column}"
+    status = 1
+  rescue StandardError => e
+    $stderr.puts "fm-lint-workflows.sh: could not parse #{path}: #{e.message}"
+    status = 1
+  end
+end
+exit status
+RUBY
+rc=$?
+set -e
+
+if [ "$rc" -ne 0 ]; then
+  exit "$rc"
+fi
+
+printf 'fm-lint-workflows.sh: %s workflow files valid\n' "${#FILES[@]}"
+exit 0

--- a/bin/fm-lint-workflows.sh
+++ b/bin/fm-lint-workflows.sh
@@ -1,25 +1,33 @@
 #!/usr/bin/env bash
-# fm-lint-workflows.sh - owner of firstmate's GitHub workflow YAML validation.
+# fm-lint-workflows.sh - owner of firstmate's GitHub workflow lint.
 #
-# Parses every .github/workflows/*.{yml,yaml} so a malformed workflow, including
-# a self-broken ci.yml, fails in the local and no-mistakes lint lane before
-# merge. A broken ci.yml cannot report its own breakage, so this check must not
-# live only as a step inside that workflow. bin/fm-lint.sh invokes this owner
-# on its default (no explicit-path) path, which CI and commands.lint both use.
+# Runs pinned actionlint on every .github/workflows/*.{yml,yaml} so a malformed
+# workflow, including a self-broken ci.yml, fails in the local and no-mistakes
+# lint lane before merge. A broken ci.yml cannot report its own breakage, so
+# this check must not live only as a step inside that workflow. bin/fm-lint.sh
+# invokes this owner on its default (no explicit-path) path, which CI and
+# commands.lint both use.
 #
 # Usage:
 #   fm-lint-workflows.sh                 lint workflows under this repo
 #   fm-lint-workflows.sh --root <dir>    lint workflows under <dir>
 #   fm-lint-workflows.sh <path>...       lint explicit workflow files
+#   fm-lint-workflows.sh --required-version
 #   fm-lint-workflows.sh --help
 set -eu
 
+REQUIRED_ACTIONLINT=1.7.12
 SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SELF="$SELF_DIR/fm-lint-workflows.sh"
 ROOT="$(cd "$SELF_DIR/.." && pwd)"
 
+if [ "${1:-}" = "--required-version" ]; then
+  printf '%s\n' "$REQUIRED_ACTIONLINT"
+  exit 0
+fi
+
 fm_lint_workflows_usage() {
-  sed -n '2,15{s/^# \{0,1\}//;p;}' "$SELF"
+  sed -n '2,16{s/^# \{0,1\}//;p;}' "$SELF"
 }
 
 EXPLICIT_ROOT=
@@ -99,38 +107,25 @@ else
   fi
 fi
 
-if ! command -v ruby >/dev/null 2>&1; then
-  printf 'fm-lint-workflows.sh: ruby is required to parse GitHub workflow YAML.\n' >&2
+if ! command -v actionlint >/dev/null 2>&1; then
+  printf 'fm-lint-workflows.sh: actionlint not found; install actionlint %s for CI parity.\n' \
+    "$REQUIRED_ACTIONLINT" >&2
   exit 127
 fi
+ACTIONLINT_BIN=$(command -v actionlint)
+resolved=$("$ACTIONLINT_BIN" -version | awk 'NR==1 {print; exit}')
+printf 'fm-lint-workflows.sh: actionlint %s (pinned %s)\n' "$resolved" "$REQUIRED_ACTIONLINT" >&2
+if [ "$resolved" != "$REQUIRED_ACTIONLINT" ]; then
+  printf 'fm-lint-workflows.sh: actionlint %s required for CI parity, found %s. Install %s.\n' \
+    "$REQUIRED_ACTIONLINT" "$resolved" "$REQUIRED_ACTIONLINT" >&2
+  exit 1
+fi
 
+# fm-lint.sh owns ShellCheck of the canonical shell set. Disable actionlint's
+# extra shell and Python subprocess linters so this gate is the named workflow
+# linter, not a second shell lint of `run:` blocks.
 set +e
-ruby - "${FILES[@]}" <<'RUBY'
-require 'psych'
-
-status = 0
-ARGV.each do |path|
-  begin
-    doc = Psych.parse_file(path)
-    root = doc && doc.root
-    unless root.is_a?(Psych::Nodes::Mapping)
-      $stderr.puts "fm-lint-workflows.sh: #{path}: workflow YAML root must be a mapping"
-      status = 1
-      next
-    end
-  rescue Psych::SyntaxError => e
-    problem = e.respond_to?(:problem) && e.problem ? e.problem : e.message
-    line = e.respond_to?(:line) ? e.line : '?'
-    column = e.respond_to?(:column) ? e.column : '?'
-    $stderr.puts "fm-lint-workflows.sh: invalid YAML in #{path}: #{problem} at line #{line} column #{column}"
-    status = 1
-  rescue StandardError => e
-    $stderr.puts "fm-lint-workflows.sh: could not parse #{path}: #{e.message}"
-    status = 1
-  end
-end
-exit status
-RUBY
+"$ACTIONLINT_BIN" -no-color -shellcheck= -pyflakes= -- "${FILES[@]}"
 rc=$?
 set -e
 

--- a/bin/fm-lint.sh
+++ b/bin/fm-lint.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# fm-lint.sh - the single owner of firstmate's shell-lint definition.
+# fm-lint.sh - the single owner of firstmate's lint definition.
 #
 # Runs its file set with ShellCheck's default severity, extended analysis,
 # ambient configuration disabled, and one exact ShellCheck version. CI and
@@ -7,6 +7,9 @@
 # version, bounded execution, and diagnostics ordering cannot drift.
 # Tests stop source analysis at imported production modules because every
 # production shell is already a canonical, source-aware root of this same run.
+# The default (no explicit-path) path also runs bin/fm-lint-workflows.sh so a
+# malformed GitHub workflow, including a self-broken ci.yml, fails locally
+# before merge instead of only failing to run as CI.
 #
 # With no explicit paths, the file set depends on context:
 #   - In CI (GITHUB_ACTIONS=true or CI=true), on the main branch, or when no
@@ -16,10 +19,10 @@
 #   - Otherwise (an ordinary local branch with a real merge-base) it lints
 #     only the canonical-set files changed since that merge-base, including
 #     uncommitted local edits, via plain local `git diff` (no network, no
-#     `gh`). A branch with zero matching changed files exits 0 and prints a
-#     "no changed lint targets" note instead of running ShellCheck.
+#     `gh`). A branch with zero matching changed files skips ShellCheck and
+#     prints a "no changed lint targets" note, then still validates workflows.
 # Explicit paths always bypass this file-set selection and lint exactly the
-# given paths, matching the same config.
+# given paths, matching the same config, without the workflow YAML check.
 #
 # Canonical lint defaults to two bounded workers over two stable logical shards.
 # Each shard writes separate diagnostics, and the parent replays those outputs in
@@ -97,7 +100,14 @@ if [ "${1:-}" = "--required-version" ]; then
 fi
 
 fm_lint_usage() {
-  sed -n '2,39{s/^# \{0,1\}//;p;}' "$SELF"
+  sed -n '2,42{s/^# \{0,1\}//;p;}' "$SELF"
+}
+
+# Default no-args lint also validates GitHub workflows. Explicit paths stay a
+# ShellCheck-only override so callers can target one shell root.
+fm_lint_run_workflows() {
+  [ "$EXPLICIT_PATHS" -eq 0 ] || return 0
+  "$SELF_DIR/fm-lint-workflows.sh"
 }
 
 JOBS=${FM_LINT_JOBS:-2}
@@ -180,7 +190,9 @@ fm_lint_is_canonical_root() {
 }
 
 CHANGED_MODE=0
+EXPLICIT_PATHS=0
 if [ "$#" -gt 0 ]; then
+  EXPLICIT_PATHS=1
   ROOTS=("$@")
 else
   full_lint=1
@@ -238,7 +250,9 @@ fi
 
 if [ "$CHANGED_MODE" -eq 1 ] && [ "$ROOT_COUNT" -eq 0 ]; then
   printf 'fm-lint.sh: no changed lint targets\n'
-  exit 0
+  overall_rc=0
+  fm_lint_run_workflows || overall_rc=$?
+  exit "$overall_rc"
 fi
 
 if [ -n "$TELEMETRY" ]; then
@@ -536,6 +550,12 @@ EOF
     printf 'fm-lint.sh: could not write telemetry to %s.\n' "$TELEMETRY" >&2
     [ "$overall_rc" -ne 0 ] || overall_rc=2
   fi
+fi
+
+if [ "$overall_rc" -eq 0 ]; then
+  fm_lint_run_workflows || overall_rc=$?
+else
+  fm_lint_run_workflows || true
 fi
 
 exit "$overall_rc"

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -140,6 +140,7 @@ family_for_basename() {
     fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-kimi-harness.test.sh|fm-muse-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
+    fm-lint-workflows.test.sh|\
     fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|\
     fm-subagent-pretool-check.test.sh|\
@@ -960,7 +961,7 @@ families_for_changed_path() {
       # lane's contract coverage re-runs.
       printf '%s\n' real-herdr-gated
       ;;
-    bin/fm-lint.sh|bin/fm-install-shellcheck.sh|\
+    bin/fm-lint.sh|bin/fm-lint-workflows.sh|bin/fm-install-shellcheck.sh|\
     bin/fm-brief.sh|bin/fm-ensure-agents-md.sh|bin/fm-crew-state.sh|\
     bin/fm-decision-hold.sh|bin/fm-supervision*|bin/fm-transition-lib.sh|\
     bin/fm-tmux-lib.sh|bin/fm-marker-lib.sh|bin/fm-operational-input.sh|bin/fm-tasks-axi-lib.sh|\

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -962,6 +962,7 @@ families_for_changed_path() {
       printf '%s\n' real-herdr-gated
       ;;
     bin/fm-lint.sh|bin/fm-lint-workflows.sh|bin/fm-install-shellcheck.sh|\
+    bin/fm-install-actionlint.sh|\
     bin/fm-brief.sh|bin/fm-ensure-agents-md.sh|bin/fm-crew-state.sh|\
     bin/fm-decision-hold.sh|bin/fm-supervision*|bin/fm-transition-lib.sh|\
     bin/fm-tmux-lib.sh|bin/fm-marker-lib.sh|bin/fm-operational-input.sh|bin/fm-tasks-axi-lib.sh|\

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,6 +130,7 @@ See [`trace-context.md`](trace-context.md) for carrier semantics, supported rout
 ## Gate defaults (.no-mistakes.yaml)
 
 The tracked `.no-mistakes.yaml` keeps test evidence outside the repo and pins `commands.lint` to `bin/fm-lint.sh` so local lint matches CI.
+That lint owner also parses every `.github/workflows/*.yml`, so a self-broken workflow fails the local no-mistakes path instead of only failing to run in CI.
 That evidence policy is specific to the firstmate repo: target projects may legitimately commit `.no-mistakes/evidence/` from their own no-mistakes pipeline, but firstmate keeps `.no-mistakes/` local and CI rejects tracked entries under that path.
 It does not set `commands.test` to a complete `tests/*.test.sh` walk.
 See [CONTRIBUTING.md](../CONTRIBUTING.md) for the firstmate-specific local test policy and entry points.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,7 +130,7 @@ See [`trace-context.md`](trace-context.md) for carrier semantics, supported rout
 ## Gate defaults (.no-mistakes.yaml)
 
 The tracked `.no-mistakes.yaml` keeps test evidence outside the repo and pins `commands.lint` to `bin/fm-lint.sh` so local lint matches CI.
-That lint owner also parses every `.github/workflows/*.yml`, so a self-broken workflow fails the local no-mistakes path instead of only failing to run in CI.
+That lint owner also lints every `.github/workflows/*.yml` with pinned actionlint, so a self-broken workflow fails the local no-mistakes path instead of only failing to run in CI.
 That evidence policy is specific to the firstmate repo: target projects may legitimately commit `.no-mistakes/evidence/` from their own no-mistakes pipeline, but firstmate keeps `.no-mistakes/` local and CI rejects tracked entries under that path.
 It does not set `commands.test` to a complete `tests/*.test.sh` walk.
 See [CONTRIBUTING.md](../CONTRIBUTING.md) for the firstmate-specific local test policy and entry points.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,7 +130,6 @@ See [`trace-context.md`](trace-context.md) for carrier semantics, supported rout
 ## Gate defaults (.no-mistakes.yaml)
 
 The tracked `.no-mistakes.yaml` keeps test evidence outside the repo and pins `commands.lint` to `bin/fm-lint.sh` so local lint matches CI.
-That lint owner also lints every `.github/workflows/*.yml` with pinned actionlint, so a self-broken workflow fails the local no-mistakes path instead of only failing to run in CI.
 That evidence policy is specific to the firstmate repo: target projects may legitimately commit `.no-mistakes/evidence/` from their own no-mistakes pipeline, but firstmate keeps `.no-mistakes/` local and CI rejects tracked entries under that path.
 It does not set `commands.test` to a complete `tests/*.test.sh` walk.
 See [CONTRIBUTING.md](../CONTRIBUTING.md) for the firstmate-specific local test policy and entry points.

--- a/tests/fm-lint-workflows.test.sh
+++ b/tests/fm-lint-workflows.test.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# GitHub workflow YAML gate owned by bin/fm-lint-workflows.sh.
+#
+# A malformed .github/workflows/*.yml, including a self-broken ci.yml, must fail
+# in the local/no-mistakes lint path before merge. Regression origin: #2512 put
+# a column-0 heredoc body inside a `run: |` block in ci.yml; there was no
+# workflow YAML lint, and the broken workflow could not report its own breakage.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+LINT_WF="$ROOT/bin/fm-lint-workflows.sh"
+LINT="$ROOT/bin/fm-lint.sh"
+
+write_valid_workflow() {
+  local path=$1
+  cat > "$path" <<'YAML'
+name: CI
+on: push
+jobs:
+  x:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          set -eu
+          echo ok
+YAML
+}
+
+# #2512-class breakage: a heredoc body at column 0 inside a `run: |` block.
+write_col0_heredoc_workflow() {
+  local path=$1
+  cat > "$path" <<'YAML'
+name: CI
+on: push
+jobs:
+  x:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compatibility pointers must stay intact
+        run: |
+          set -eu
+          cmp -s CLAUDE.md - <<'EOF' || exit 1
+<!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
+@AGENTS.md
+EOF
+          echo ok
+YAML
+}
+
+test_current_workflows_pass() {
+  local out rc
+  rc=0
+  out=$("$LINT_WF" 2>&1) || rc=$?
+  [ "$rc" -eq 0 ] || fail "current workflows must parse, got $rc"$'\n'"$out"
+  assert_contains "$out" "workflow files valid" \
+    "current-workflow lint did not report a valid count"
+  pass "current .github/workflows YAML files parse"
+}
+
+test_col0_heredoc_fails_with_clear_error() {
+  local tmp out rc
+  tmp=$(fm_test_tmproot fm-lint-wf-col0)
+  mkdir -p "$tmp/.github/workflows"
+  write_col0_heredoc_workflow "$tmp/.github/workflows/ci.yml"
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "column-0 heredoc workflow unexpectedly passed"$'\n'"$out"
+  assert_contains "$out" "invalid YAML" \
+    "column-0 heredoc failure did not name invalid YAML"
+  assert_contains "$out" "ci.yml" \
+    "column-0 heredoc failure did not name the workflow file"
+  pass "column-0 heredoc workflow fails validation with a clear error"
+}
+
+test_valid_fixture_passes() {
+  local tmp out rc
+  tmp=$(fm_test_tmproot fm-lint-wf-ok)
+  mkdir -p "$tmp/.github/workflows"
+  write_valid_workflow "$tmp/.github/workflows/ci.yml"
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -eq 0 ] || fail "valid fixture workflow failed"$'\n'"$out"
+  assert_contains "$out" "1 workflow files valid" \
+    "valid fixture did not report one valid file"
+  pass "valid fixture workflow passes"
+}
+
+test_empty_workflows_dir_fails() {
+  local tmp out rc
+  tmp=$(fm_test_tmproot fm-lint-wf-empty)
+  mkdir -p "$tmp/.github/workflows"
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "empty workflows dir unexpectedly passed"$'\n'"$out"
+  assert_contains "$out" "no GitHub workflow files found" \
+    "empty workflows dir did not report the missing files"
+  pass "empty workflows directory fails closed"
+}
+
+test_explicit_broken_path_fails() {
+  local tmp broken out rc
+  tmp=$(fm_test_tmproot fm-lint-wf-path)
+  broken="$tmp/broken.yml"
+  write_col0_heredoc_workflow "$broken"
+  rc=0
+  out=$("$LINT_WF" "$broken" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "explicit broken path unexpectedly passed"$'\n'"$out"
+  assert_contains "$out" "invalid YAML" \
+    "explicit broken path did not report invalid YAML"
+  pass "explicit malformed workflow path fails validation"
+}
+
+test_non_mapping_root_fails() {
+  local tmp out rc
+  tmp=$(fm_test_tmproot fm-lint-wf-scalar)
+  mkdir -p "$tmp/.github/workflows"
+  printf 'just-a-string\n' > "$tmp/.github/workflows/ci.yml"
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "scalar YAML root unexpectedly passed"$'\n'"$out"
+  assert_contains "$out" "root must be a mapping" \
+    "scalar YAML root did not report the mapping requirement"
+  pass "non-mapping workflow YAML root fails"
+}
+
+test_missing_ruby_fails_closed() {
+  local tmp fakebin out rc tool
+  tmp=$(fm_test_tmproot fm-lint-wf-noruby)
+  fakebin=$(fm_fakebin "$tmp")
+  mkdir -p "$tmp/.github/workflows"
+  write_valid_workflow "$tmp/.github/workflows/ci.yml"
+  for tool in bash dirname find sort; do
+    ln -s "$(command -v "$tool")" "$fakebin/$tool"
+  done
+  rc=0
+  out=$(PATH="$fakebin" "$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -eq 127 ] || fail "missing ruby expected exit 127, got $rc"$'\n'"$out"
+  assert_contains "$out" "ruby is required" \
+    "missing ruby did not name the parser requirement"
+  pass "missing ruby fails closed"
+}
+
+# Prove the no-mistakes/local owner (bin/fm-lint.sh with no paths) catches a
+# self-broken ci.yml. Copy the lint scripts into a fake repo so the default
+# workflow root is the fixture, not this worktree.
+test_fm_lint_default_path_catches_broken_ci_yml() {
+  local tmp fakebin log diff_file out rc
+  tmp=$(fm_test_tmproot fm-lint-wf-default)
+  mkdir -p "$tmp/bin" "$tmp/.github/workflows"
+  cp "$LINT" "$tmp/bin/fm-lint.sh"
+  cp "$LINT_WF" "$tmp/bin/fm-lint-workflows.sh"
+  chmod +x "$tmp/bin/fm-lint.sh" "$tmp/bin/fm-lint-workflows.sh"
+  write_col0_heredoc_workflow "$tmp/.github/workflows/ci.yml"
+
+  fakebin=$(fm_fakebin "$tmp")
+  log="$tmp/shellcheck.log"
+  cat > "$fakebin/git" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  "rev-parse --is-inside-work-tree") printf 'true\n'; exit 0 ;;
+  "rev-parse --abbrev-ref HEAD") printf 'feature\n'; exit 0 ;;
+  "rev-parse --verify -q origin/main") exit 0 ;;
+  "merge-base "*) printf 'fakebase123\n'; exit 0 ;;
+  "diff --name-only --diff-filter=ACMR -z fakebase123 --")
+    [ -n "${FM_TEST_GIT_DIFF_FILE:-}" ] && cat "${FM_TEST_GIT_DIFF_FILE}"
+    exit 0
+    ;;
+  *) exit 0 ;;
+esac
+SH
+  chmod +x "$fakebin/git"
+  : > "$log"
+  cat > "$fakebin/shellcheck" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = --version ]; then
+  printf 'ShellCheck - shell script analysis tool\nversion: 0.11.0\n'
+  exit 0
+fi
+shift 3
+printf '%s\n' "\$@" >> "$log"
+exit 0
+SH
+  chmod +x "$fakebin/shellcheck"
+  diff_file="$tmp/diff.nul"
+  : > "$diff_file"
+
+  rc=0
+  out=$(PATH="$fakebin:$PATH" GITHUB_ACTIONS='' CI='' FM_LINT_JOBS=1 \
+    FM_TEST_GIT_DIFF_FILE="$diff_file" "$tmp/bin/fm-lint.sh" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "fm-lint.sh default path missed a broken ci.yml"$'\n'"$out"
+  assert_contains "$out" "invalid YAML" \
+    "fm-lint.sh default path did not surface the workflow YAML error"
+  assert_contains "$out" "ci.yml" \
+    "fm-lint.sh default path did not name the broken workflow"
+  pass "fm-lint.sh default path catches a self-broken ci.yml"
+}
+
+test_current_workflows_pass
+test_col0_heredoc_fails_with_clear_error
+test_valid_fixture_passes
+test_empty_workflows_dir_fails
+test_explicit_broken_path_fails
+test_non_mapping_root_fails
+test_missing_ruby_fails_closed
+test_fm_lint_default_path_catches_broken_ci_yml

--- a/tests/fm-lint-workflows.test.sh
+++ b/tests/fm-lint-workflows.test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# GitHub workflow YAML gate owned by bin/fm-lint-workflows.sh.
+# GitHub workflow lint gate owned by bin/fm-lint-workflows.sh.
 #
 # A malformed .github/workflows/*.yml, including a self-broken ci.yml, must fail
 # in the local/no-mistakes lint path before merge. Regression origin: #2512 put
@@ -12,6 +12,8 @@ set -u
 
 LINT_WF="$ROOT/bin/fm-lint-workflows.sh"
 LINT="$ROOT/bin/fm-lint.sh"
+INSTALLER="$ROOT/bin/fm-install-actionlint.sh"
+REQUIRED=$("$LINT_WF" --required-version)
 
 write_valid_workflow() {
   local path=$1
@@ -67,8 +69,8 @@ test_col0_heredoc_fails_with_clear_error() {
   rc=0
   out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
   [ "$rc" -ne 0 ] || fail "column-0 heredoc workflow unexpectedly passed"$'\n'"$out"
-  assert_contains "$out" "invalid YAML" \
-    "column-0 heredoc failure did not name invalid YAML"
+  assert_contains "$out" "could not parse as YAML" \
+    "column-0 heredoc failure did not report actionlint's YAML syntax error"
   assert_contains "$out" "ci.yml" \
     "column-0 heredoc failure did not name the workflow file"
   pass "column-0 heredoc workflow fails validation with a clear error"
@@ -107,8 +109,8 @@ test_explicit_broken_path_fails() {
   rc=0
   out=$("$LINT_WF" "$broken" 2>&1) || rc=$?
   [ "$rc" -ne 0 ] || fail "explicit broken path unexpectedly passed"$'\n'"$out"
-  assert_contains "$out" "invalid YAML" \
-    "explicit broken path did not report invalid YAML"
+  assert_contains "$out" "could not parse as YAML" \
+    "explicit broken path did not report actionlint's YAML syntax error"
   pass "explicit malformed workflow path fails validation"
 }
 
@@ -120,26 +122,112 @@ test_non_mapping_root_fails() {
   rc=0
   out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
   [ "$rc" -ne 0 ] || fail "scalar YAML root unexpectedly passed"$'\n'"$out"
-  assert_contains "$out" "root must be a mapping" \
-    "scalar YAML root did not report the mapping requirement"
+  assert_contains "$out" "mapping node is expected" \
+    "scalar YAML root did not report actionlint's mapping-node error"
   pass "non-mapping workflow YAML root fails"
 }
 
-test_missing_ruby_fails_closed() {
+test_missing_actionlint_fails_closed() {
   local tmp fakebin out rc tool
-  tmp=$(fm_test_tmproot fm-lint-wf-noruby)
+  tmp=$(fm_test_tmproot fm-lint-wf-noactionlint)
   fakebin=$(fm_fakebin "$tmp")
   mkdir -p "$tmp/.github/workflows"
   write_valid_workflow "$tmp/.github/workflows/ci.yml"
-  for tool in bash dirname find sort; do
+  for tool in bash dirname find sort awk; do
     ln -s "$(command -v "$tool")" "$fakebin/$tool"
   done
   rc=0
   out=$(PATH="$fakebin" "$LINT_WF" --root "$tmp" 2>&1) || rc=$?
-  [ "$rc" -eq 127 ] || fail "missing ruby expected exit 127, got $rc"$'\n'"$out"
-  assert_contains "$out" "ruby is required" \
-    "missing ruby did not name the parser requirement"
-  pass "missing ruby fails closed"
+  [ "$rc" -eq 127 ] || fail "missing actionlint expected exit 127, got $rc"$'\n'"$out"
+  assert_contains "$out" "actionlint not found" \
+    "missing actionlint did not name the required linter"
+  assert_contains "$out" "$REQUIRED" \
+    "missing actionlint did not name the pinned version"
+  pass "missing actionlint fails closed"
+}
+
+test_pins_an_explicit_version() {
+  [ -n "$REQUIRED" ] || fail "fm-lint-workflows.sh --required-version printed nothing"
+  assert_contains "$REQUIRED" "1.7.12" "fm-lint-workflows.sh must pin actionlint 1.7.12"
+  pass "fm-lint-workflows.sh pins an explicit actionlint version ($REQUIRED)"
+}
+
+test_rejects_wrong_actionlint_version() {
+  local tmp fakebin out rc
+  tmp=$(fm_test_tmproot fm-lint-wf-ver)
+  fakebin=$(fm_fakebin "$tmp")
+  mkdir -p "$tmp/.github/workflows"
+  write_valid_workflow "$tmp/.github/workflows/ci.yml"
+  cat > "$fakebin/actionlint" <<'SH'
+#!/usr/bin/env bash
+if [ "$1" = "-version" ]; then
+  printf '0.0.0\n'
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "$fakebin/actionlint"
+  rc=0
+  out=$(PATH="$fakebin:$PATH" "$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "fm-lint-workflows.sh accepted an actionlint version other than the pin"$'\n'"$out"
+  assert_contains "$out" "$REQUIRED" "fm-lint-workflows.sh did not name the required version on mismatch"
+  assert_contains "$out" "0.0.0" "fm-lint-workflows.sh did not report the resolved (wrong) version"
+  pass "fm-lint-workflows.sh refuses to lint under a non-pinned actionlint version"
+}
+
+test_installer_retries_transient_download_failure() {
+  local tmp fakebin destination out
+  tmp=$(fm_test_tmproot fm-actionlint-download)
+  fakebin=$(fm_fakebin "$tmp")
+  destination="$tmp/bin"
+
+  cat > "$fakebin/curl" <<'SH'
+#!/usr/bin/env bash
+count=0
+[ ! -f "$CURL_COUNT" ] || count=$(cat "$CURL_COUNT")
+count=$((count + 1))
+printf '%s\n' "$count" > "$CURL_COUNT"
+[ "$count" -gt 3 ] || exit 22
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    : > "$2"
+    exit 0
+  fi
+  shift
+done
+exit 2
+SH
+  cat > "$fakebin/sha256sum" <<'SH'
+#!/usr/bin/env bash
+printf '8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  %s\n' "$1"
+SH
+  cat > "$fakebin/tar" <<'SH'
+#!/usr/bin/env bash
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-C" ]; then
+    cat > "$2/actionlint" <<'EOF'
+#!/usr/bin/env bash
+printf '1.7.12\n'
+EOF
+    chmod +x "$2/actionlint"
+    exit 0
+  fi
+  shift
+done
+exit 2
+SH
+  cat > "$fakebin/sleep" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fakebin/curl" "$fakebin/sha256sum" "$fakebin/tar" "$fakebin/sleep"
+
+  out=$(CURL_COUNT="$tmp/curl-count" PATH="$fakebin:$PATH" "$INSTALLER" "$destination" 2>&1) \
+    || fail "installer did not recover from a transient download failure"$'\n'"$out"
+  [ "$(cat "$tmp/curl-count")" -eq 4 ] || fail "installer did not recover after three failed downloads"
+  assert_contains "$out" "download attempt 3 failed; retrying" "installer did not disclose its third retry"
+  [ -x "$destination/actionlint" ] || fail "installer did not install actionlint after retrying"
+  pass "actionlint installer retries a transient download failure"
 }
 
 # Prove the no-mistakes/local owner (bin/fm-lint.sh with no paths) catches a
@@ -190,18 +278,21 @@ SH
   out=$(PATH="$fakebin:$PATH" GITHUB_ACTIONS='' CI='' FM_LINT_JOBS=1 \
     FM_TEST_GIT_DIFF_FILE="$diff_file" "$tmp/bin/fm-lint.sh" 2>&1) || rc=$?
   [ "$rc" -ne 0 ] || fail "fm-lint.sh default path missed a broken ci.yml"$'\n'"$out"
-  assert_contains "$out" "invalid YAML" \
+  assert_contains "$out" "could not parse as YAML" \
     "fm-lint.sh default path did not surface the workflow YAML error"
   assert_contains "$out" "ci.yml" \
     "fm-lint.sh default path did not name the broken workflow"
   pass "fm-lint.sh default path catches a self-broken ci.yml"
 }
 
+test_pins_an_explicit_version
 test_current_workflows_pass
 test_col0_heredoc_fails_with_clear_error
 test_valid_fixture_passes
 test_empty_workflows_dir_fails
 test_explicit_broken_path_fails
 test_non_mapping_root_fails
-test_missing_ruby_fails_closed
+test_missing_actionlint_fails_closed
+test_rejects_wrong_actionlint_version
+test_installer_retries_transient_download_failure
 test_fm_lint_default_path_catches_broken_ci_yml

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -208,6 +208,8 @@ test_zero_changed_files_exits_clean() {
   [ "$rc" -eq 0 ] || fail "zero changed lint targets must exit 0, got $rc"$'\n'"$out"
   assert_contains "$out" "ShellCheck 0.11.0" "zero-changed run did not print the ShellCheck version line"
   assert_contains "$out" "no changed lint targets" "zero-changed run did not note the empty target set"
+  assert_contains "$out" "workflow files valid" \
+    "zero-changed run skipped workflow YAML validation"
   pass "fm-lint.sh exits 0 with a note when the local branch has no changed lint targets"
 }
 


### PR DESCRIPTION
## Intent

Rework existing open PR #2517 (branch fm/fm-ci-actionlint-gate-r1) so GitHub workflow lint uses pinned actionlint instead of Ruby/Psych. This is firstmate shared tracked material (bin/, CONTRIBUTING.md, the firstmate-coding-guidelines skill, .github/workflows). Update that existing PR in place; do not open a second PR. The captain owns the merge.

Replace the Ruby/Psych implementation in bin/fm-lint-workflows.sh with a call to actionlint (the Go static binary). Install and version-pin actionlint the same way firstmate already requires shellcheck: pin one exact version and refuse any other; add bin/fm-install-actionlint.sh that fetches a pinned release and verifies the download with a checksum; install actionlint in .github/workflows/ci.yml's lint job the same way shellcheck is installed; document the actionlint pin in CONTRIBUTING.md alongside the shellcheck one.

Hard requirements that must all hold:
(a) KEY REQUIREMENT: a self-broken .github/workflows/ci.yml must be caught in the LOCAL / no-mistakes lint lane (bin/fm-lint.sh fails locally) BEFORE merge, because a self-broken ci.yml cannot report its own breakage in CI.
(b) Validate ALL .github/workflows/*.yml, not just ci.yml.
(c) Keep the #2512-class malformed-workflow regression (the column-0 heredoc inside a run: | block that produces invalid workflow YAML) in tests/fm-lint-workflows.test.sh. Keep the repro and that it FAILS the gate; the assertion may match actionlint's actual failure output instead of the old Ruby "invalid YAML" string. Tests must exercise the real bin/fm-lint.sh / bin/fm-lint-workflows.sh executable path, never source bytes.
(d) Add NO Ruby dependency and NO npm-package dependency. actionlint is a single static Go binary. bin/fm-lint-workflows.sh must no longer reference ruby/psych anywhere.

In the firstmate-coding-guidelines skill, add a short durable note (one-owner rule; patch existing language) stating: when a task names a specific tool, implement it with that tool, or explicitly flag the substitution and its new dependency footprint for review before shipping.

This changes firstmate's instruction surface (the coding-guidelines skill and CONTRIBUTING), so the PR should note that running homes pick it up after merge plus a firstmate self-update, and that landing timing is coordinated with the main firstmate.

Accepted implementation choices: pin actionlint 1.7.12; fm-lint-workflows.sh --required-version owns that pin and the installer reads it; refuse any other installed actionlint version, matching the shellcheck refuse-on-mismatch pattern; disable actionlint's extra shell and Python subprocess linters so this gate is the named workflow linter, not a second shell lint of run: blocks (bin/fm-lint.sh already owns ShellCheck of the canonical shell set).

## What Changed

- Add a checksum-verified installer for actionlint 1.7.12 and install the pinned binary in CI.
- Extend the canonical local/no-mistakes lint path to validate every GitHub workflow, reject mismatched actionlint versions, and disable its secondary shell and Python linters.
- Add executable-path regression coverage for malformed workflows, including the #2512 heredoc case, and update contributor guidance and the named-tool rule. Running homes pick up the instruction changes after merge and a firstmate self-update, coordinated with the main firstmate.

## Risk Assessment

✅ Low: The change is well-bounded, follows the existing pinned-tool pattern, validates all workflow YAML through the local canonical lint path, and introduces no substantiated source defects.

## Testing

Confirmed the pinned actionlint and ShellCheck environment, ran the two focused lint regression scripts, manually demonstrated all repository workflows passing and a self-broken `ci.yml` failing through the actual local `bin/fm-lint.sh` path, and verified that the installer rejects a tampered archive; all expected behavior succeeded.

<details>
<summary>Evidence: Pinned actionlint validation and self-broken local CI gate transcript</summary>

Source: [Pinned actionlint validation and self-broken local CI gate transcript](https://github.com/kunchenguid/firstmate/blob/49cf1712e2c98bc53d42cb6713eb3f9ae9c06f8f/.no-mistakes/evidence/fm/fm-ci-actionlint-gate-r1/actionlint-local-gate-transcript.txt)

```text
$ bin/fm-lint-workflows.sh
fm-lint-workflows.sh: actionlint 1.7.12 (pinned 1.7.12)
fm-lint-workflows.sh: 3 workflow files valid

Discovered workflow files:
.github/workflows/ci.yml
.github/workflows/no-mistakes-required.yml
.github/workflows/windows-herdr-spike.yml

$ bin/fm-lint.sh  # local/no-mistakes default lane against self-broken ci.yml
fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
fm-lint.sh: no changed lint targets
fm-lint-workflows.sh: actionlint 1.7.12 (pinned 1.7.12)
.github/workflows/ci.yml:10:0: could not parse as YAML: could not find expected ':' [syntax-check]
   |
10 | EOF
   | 
exit status: 1
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (3m25s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b6830b85cbcb618606c17554970bfd62a46cb01c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 PR #2517&#39;s description still claims the implementation uses Ruby/Psych, includes Ruby-specific test results and evidence, and omits the required note that running homes receive the instruction-surface changes after merge plus a firstmate self-update coordinated with main firstmate. Update the existing PR description in place.
- `bin/fm-test-run.sh tests/fm-lint-workflows.test.sh`
- `bin/fm-test-run.sh tests/fm-lint.test.sh`
- <code>Executed copied `bin/fm-lint.sh` and `bin/fm-lint-workflows.sh` through their no-argument public path against two valid workflows, then a #2512-class self-broken `ci.yml`, using real actionlint 1.7.12</code>
- `gh pr view 2517 --json number,headRefName,title,body,url`
- <code>`git status --short` after evidence generation</code>

🔧 Fix: PR description fix blocked by remote-write boundary
✅ Re-checked - no issues remain.
- <code>`command -v actionlint; actionlint -version; command -v shellcheck; shellcheck --version` confirmed the required local tool pins were available.</code>
- <code>`tests/fm-lint-workflows.test.sh` exercised pinned-version enforcement, all-workflow discovery, malformed YAML rejection, installer retry behavior, and the local `fm-lint.sh` regression path.</code>
- <code>`tests/fm-lint.test.sh` exercised the canonical local lint owner, including workflow validation when no shell targets changed.</code>
- <code>`bin/fm-lint-workflows.sh` validated all three repository workflow files with actionlint 1.7.12.</code>
- <code>Ran `bin/fm-lint.sh` against a fixture repository containing the #2512-class column-zero heredoc in `.github/workflows/ci.yml`; the local/default lane reported the actionlint parse error and exited 1.</code>
- <code>Ran `bin/fm-install-actionlint.sh` with a deliberately tampered downloaded archive; it rejected the checksum and did not install a binary.</code>

</details>

<details>
<summary>⚠️ **Document** - 1 warning</summary>

- ⚠️ `.no-mistakes.yaml:43` - store_in_repo: true contradicts CONTRIBUTING.md and docs/configuration.md, which require test evidence outside the repository; resolving this requires a non-documentation configuration change.
- ℹ️ PR #2517 still needs the required delivery note that running homes receive this after merge and firstmate self-update, with landing coordinated with the main firstmate.

🔧 Fix: Review actionlint docs; PR update remains
1 warning still open:
- ⚠️ PR #2517’s body still describes Ruby/Psych and lacks the required /updatefirstmate delivery note; updating external PR metadata is prohibited by this phase’s worktree boundary.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
