### PR TITLE
feat(skills): add safe Bitwarden Secrets Manager workflow

### DIFF
--- a/.agents/skills/bws/SKILL.md
+++ b/.agents/skills/bws/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: bws
+description: >-
+  Agent-only load stub for the Bitwarden Secrets Manager CLI skill.
+  Use before any work with `bws` (not `bw`): authentication checks, project or secret listing, secret reads, creates, updates, rotations, or deletes.
+  The procedure lives in skills/bws/SKILL.md; read and follow that file completely after loading this stub.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# bws
+
+This stub exists because firstmate loads skills from `.agents/skills/`, while the authoritative procedure lives in the public installer skill at [`skills/bws/SKILL.md`](../../../skills/bws/SKILL.md).
+
+After this stub loads, read and follow that file completely.
+Never treat this stub as the procedure owner.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -536,6 +536,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the Relay configuration blocker, on a `public-followup ...` `check:` wake or a startup-surfaced public commitment, and on any milestone or terminal wake for a Relay-linked task before posting its completion follow-up; relevant only when Relay is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
+- `bws` - load before any work with Bitwarden Secrets Manager CLI (`bws`, not `bw`): authentication checks, listing projects or secrets, reading secret values, creating, updating, rotating, or deleting secrets.
 
 ## 14. Relay
 

--- a/README.md
+++ b/README.md
@@ -193,8 +193,9 @@ Firstmate's skills live in two separate places with different audiences:
 - `.agents/skills/` - agent-loaded skills (this section's table, plus firstmate's agent-only reference skills). Every one of these assumes a live firstmate home and is meaningless, or actively misleading, installed anywhere else, so each carries `metadata.internal: true` in its frontmatter. That flag hides them from installer discovery (tools like the [skills.sh](https://skills.sh) `npx skills add` installer) without affecting how firstmate itself loads them - frontmatter metadata is inert to the agent's own skill loader.
 - `skills/` - public, installer-facing skills meant to be installed standalone into any project, independent of firstmate.
   Each one is a self-contained skill with no dependency on firstmate's paths, tools, or vocabulary.
-  Today that is `skills/stow`, a generic session-knowledge-sweep skill that routes findings by explicit instruction first, then existing local conventions, then a private `.stow-notes.md` fallback, and curates tiered entries through decay, local archival, and user-approved on-demand offload proposals.
-  It intentionally shares no code with the firstmate-internal `.agents/skills/stow` it is named after, so the two can evolve independently.
+  Today that includes `skills/stow`, a generic session-knowledge-sweep skill that routes findings by explicit instruction first, then existing local conventions, then a private `.stow-notes.md` fallback, and curates tiered entries through decay, local archival, and user-approved on-demand offload proposals, and `skills/bws`, a safe Bitwarden Secrets Manager CLI (`bws`, not `bw`) skill with a bundled redaction helper.
+  `skills/stow` intentionally shares no code with the firstmate-internal `.agents/skills/stow` it is named after, so the two can evolve independently.
+  `skills/bws` is the single procedure owner; firstmate's `.agents/skills/bws` stub only routes loaders to it.
 
 ## Documentation
 

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -379,6 +379,14 @@
     {
       "path": "skills/stow/SKILL.md",
       "audience": "public-product"
+    },
+    {
+      "path": "skills/bws/SKILL.md",
+      "audience": "public-product"
+    },
+    {
+      "path": ".agents/skills/bws/SKILL.md",
+      "audience": "agent-runtime"
     }
   ]
 }

--- a/skills/bws/SKILL.md
+++ b/skills/bws/SKILL.md
@@ -133,7 +133,7 @@ Create or update only with current explicit authority naming the project and sec
 4. Create: `bws secret create <KEY> <VALUE> <PROJECT_ID> [--note <NOTE>]`
 5. Update: `bws secret edit <SECRET_ID> [--key <KEY>] [--value <VALUE>] [--note <NOTE>] [--project-id <PROJECT_ID>]`
 6. Pass values through env vars or stdin wrappers, never through chat or committed files.
-7. Verify with `"$HELPER" list-metadata <PROJECT_ID>` or `bws secret get <SECRET_ID> -o json | redact-json`.
+7. Verify with `"$HELPER" list-metadata <PROJECT_ID>` or `bws secret get <SECRET_ID> -o json | "$HELPER" redact-json`.
 8. A non-zero exit code is failure even when partial output appeared; never report success without verification.
 
 Rotation is an edit of `SECRET_ID` with a new value, then the same redacted verification.
@@ -143,7 +143,7 @@ Rotation is an edit of `SECRET_ID` with a new value, then the same redacted veri
 Delete only with explicit, concrete captain or operator authority that names the exact `SECRET_ID` (and project context).
 
 1. Refuse delete requests that name only a key when duplicates may exist.
-2. Re-verify identity with `bws secret get <SECRET_ID> -o json | redact-json` and `projectId`.
+2. Re-verify identity with `bws secret get <SECRET_ID> -o json | "$HELPER" redact-json` and `projectId`.
 3. Run `bws secret delete <SECRET_ID>`.
 4. Confirm absence with `resolve-id` exit 1 or metadata listing without that `id`.
 5. Never delete to "clean up" without named authority.

--- a/skills/bws/SKILL.md
+++ b/skills/bws/SKILL.md
@@ -44,7 +44,9 @@ The bundled helper is `scripts/bws-safe.sh` relative to this skill directory.
 
 Add this exact line to the project's always-loaded agent instructions (for example `AGENTS.md`):
 
-`- `bws` - load before any work with Bitwarden Secrets Manager CLI (`bws`, not `bw`): authentication checks, listing projects or secrets, reading secret values, creating, updating, rotating, or deleting secrets.`
+```md
+- `bws` - load before any work with Bitwarden Secrets Manager CLI (`bws`, not `bw`): authentication checks, listing projects or secrets, reading secret values, creating, updating, rotating, or deleting secrets.
+```
 
 ## Bundled helper
 

--- a/skills/bws/SKILL.md
+++ b/skills/bws/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: bws
+description: >-
+  Safe work with Bitwarden Secrets Manager CLI (`bws`, not password-manager `bw`).
+  Use before authentication checks, listing projects or secrets, reading secret values, creating, updating, rotating, or deleting Secrets Manager secrets.
+---
+
+<!-- maintainers: public installer-facing skill. Procedure owner for both firstmate and project workers. Firstmate loads `.agents/skills/bws/SKILL.md`, a stub that points here. -->
+
+# bws
+
+Bitwarden Secrets Manager CLI is `bws`.
+The password-manager CLI is `bw` and is a different product.
+Regular vault logins and personal passwords belong to `bw` or the Bitwarden application, not `bws`.
+
+## Current-source discovery
+
+Never memorize flags or claim subcommands this install does not support.
+Before operations, consult the installed CLI:
+
+```sh
+bws --version
+bws --help
+bws secret --help
+bws project --help
+bws run --help
+```
+
+Subcommand help is authoritative for the current version.
+
+## Installation
+
+Copy or link this directory into a project worker's skill discovery path:
+
+- `.agents/skills/bws/` (recommended)
+- `.claude/skills/bws/` (Claude Code)
+
+From the firstmate repository, the source path is `skills/bws/`.
+Installers such as [skills.sh](https://skills.sh) can add the same directory from the published firstmate repo.
+
+The bundled helper is `scripts/bws-safe.sh` relative to this skill directory.
+
+## Project AGENTS.md trigger
+
+Add this exact line to the project's always-loaded agent instructions (for example `AGENTS.md`):
+
+`- `bws` - load before any work with Bitwarden Secrets Manager CLI (`bws`, not `bw`): authentication checks, listing projects or secrets, reading secret values, creating, updating, rotating, or deleting secrets.`
+
+## Bundled helper
+
+Use `scripts/bws-safe.sh` for probes, metadata listing, duplicate-safe ID resolution, and JSON redaction.
+It never prints access tokens or secret values.
+
+```sh
+HELPER="<skill-dir>/scripts/bws-safe.sh"
+"$HELPER" probe
+"$HELPER" list-metadata <PROJECT_ID>
+"$HELPER" resolve-id <PROJECT_ID> <KEY>
+bws secret get <SECRET_ID> -o json | "$HELPER" redact-json
+```
+
+`probe` prints `status=`, `version=`, and `token_present=` only.
+Treat `token_present=yes` as "a token or profile may exist", never as proof the token is valid.
+Only `status=authenticated` means read access succeeded.
+`status=no_token`, `invalid_token`, `forbidden`, `unavailable`, and `indeterminate` are not success.
+
+## Authentication without exposure
+
+Detect install and authentication without exposing the access token.
+
+1. Run `"$HELPER" probe` or `command -v bws` plus `bws --version`.
+2. Never print `BWS_ACCESS_TOKEN`, `--access-token`, config file contents, or token-shaped strings.
+3. Never ask the captain or user to paste a token or secret into chat.
+4. Never commit tokens, secret values, rendered credentials, or CLI output that contains values.
+
+If `probe` reports `no_token` or `invalid_token`, stop and ask the operator to configure `BWS_ACCESS_TOKEN` or a `bws` profile outside chat.
+Do not troubleshoot by echoing token material.
+
+## Distinguish failures
+
+| Evidence | Meaning |
+| --- | --- |
+| `command -v bws` fails | CLI absent |
+| `status=no_token` | No usable access token |
+| `status=invalid_token` | Token present but rejected |
+| `status=authenticated` and read commands succeed | Read access OK for at least one project |
+| `status=forbidden` on list | Token valid but lacks project access or is read-only beyond list |
+| `resolve-id` exit 1 | Secret key absent in that project |
+| `resolve-id` exit 2 | Duplicate secret names; do not mutate by name alone |
+| Write command non-zero after explicit authority | Write denied, wrong project, or target mismatch; never report success |
+
+Read-only service accounts succeed at `project list` and `secret list` but fail create, edit, or delete.
+Verify writes by exit code and post-change metadata, never by echoing values.
+
+## Safe listing and inspection
+
+List projects and inspect secret metadata without printing values.
+
+```sh
+bws project list -o table
+"$HELPER" list-metadata <PROJECT_ID>
+bws project get <PROJECT_ID> -o json
+```
+
+Prefer `-o table` or `list-metadata` for human review.
+Default JSON includes values; pipe through `redact-json` before logging or chat.
+
+Preserve identities separately:
+
+- `PROJECT_ID` identifies a project.
+- `SECRET_ID` identifies a secret.
+- `key` is a human label and may duplicate within a project.
+
+Resolve targets with `"$HELPER" resolve-id <PROJECT_ID> <KEY>` before create, edit, or delete when the key name is known.
+When duplicates exist, stop and ask for the exact `SECRET_ID`.
+
+## Reading secret values
+
+Read a secret value only when the task genuinely requires it.
+
+1. Resolve `SECRET_ID` when starting from a key name.
+2. Prefer `bws run --project-id <PROJECT_ID> -- <trusted-command>` so the value stays in the child process environment instead of chat or files.
+3. If you must call `bws secret get`, never paste the value into chat, logs, command arguments visible to tools, or tracked files.
+4. Verify success with redacted metadata (`revisionDate`, `id`, `key`) rather than re-printing the value.
+
+## Creating and updating secrets
+
+Create or update only with current explicit authority naming the project and secret.
+
+1. Confirm `probe` shows `authenticated`.
+2. Confirm the service account can write to the named `PROJECT_ID`.
+3. Resolve duplicates before create; prefer `secret edit <SECRET_ID>` over ambiguous name-only updates.
+4. Create: `bws secret create <KEY> <VALUE> <PROJECT_ID> [--note <NOTE>]`
+5. Update: `bws secret edit <SECRET_ID> [--key <KEY>] [--value <VALUE>] [--note <NOTE>] [--project-id <PROJECT_ID>]`
+6. Pass values through env vars or stdin wrappers, never through chat or committed files.
+7. Verify with `"$HELPER" list-metadata <PROJECT_ID>` or `bws secret get <SECRET_ID> -o json | redact-json`.
+8. A non-zero exit code is failure even when partial output appeared; never report success without verification.
+
+Rotation is an edit of `SECRET_ID` with a new value, then the same redacted verification.
+
+## Deleting secrets
+
+Delete only with explicit, concrete captain or operator authority that names the exact `SECRET_ID` (and project context).
+
+1. Refuse delete requests that name only a key when duplicates may exist.
+2. Re-verify identity with `bws secret get <SECRET_ID> -o json | redact-json` and `projectId`.
+3. Run `bws secret delete <SECRET_ID>`.
+4. Confirm absence with `resolve-id` exit 1 or metadata listing without that `id`.
+5. Never delete to "clean up" without named authority.
+
+## Write-access and scope failures
+
+Handle service-account scope and write-access failures safely.
+
+- Stop on non-zero exit codes from create, edit, or delete.
+- Report the concrete failure (forbidden, not found, duplicate) without secret values.
+- Do not retry writes with guessed project IDs or names.
+- Do not fall back to storing secrets in repo files, `.env` commits, or chat.
+
+## Never commit secrets
+
+Never commit tokens, secret values, rendered credentials, or captured CLI output that contains values.
+Redact before saving command transcripts or diagnostics.

--- a/skills/bws/SKILL.md
+++ b/skills/bws/SKILL.md
@@ -63,7 +63,8 @@ bws secret get <SECRET_ID> -o json | "$HELPER" redact-json
 
 `probe` prints `status=`, `version=`, and `token_present=` only.
 Treat `token_present=yes` as "a token or profile may exist", never as proof the token is valid.
-Only `status=authenticated` means read access succeeded.
+Only `status=authenticated` means the project-list authentication probe succeeded.
+It does not prove access to any particular project or permission to write.
 `status=no_token`, `invalid_token`, `forbidden`, `unavailable`, and `indeterminate` are not success.
 
 ## Authentication without exposure
@@ -85,13 +86,13 @@ Do not troubleshoot by echoing token material.
 | `command -v bws` fails | CLI absent |
 | `status=no_token` | No usable access token |
 | `status=invalid_token` | Token present but rejected |
-| `status=authenticated` and read commands succeed | Read access OK for at least one project |
+| `status=authenticated` | The project-list probe succeeded; project-specific access and writes remain unverified |
 | `status=forbidden` on list | Token valid but lacks project access or is read-only beyond list |
 | `resolve-id` exit 1 | Secret key absent in that project |
 | `resolve-id` exit 2 | Duplicate secret names; do not mutate by name alone |
 | Write command non-zero after explicit authority | Write denied, wrong project, or target mismatch; never report success |
 
-Read-only service accounts succeed at `project list` and `secret list` but fail create, edit, or delete.
+Read-only service accounts can succeed at `project list` and `secret list` for accessible projects while create, edit, and delete fail.
 Verify writes by exit code and post-change metadata, never by echoing values.
 
 ## Safe listing and inspection
@@ -105,7 +106,7 @@ bws project get <PROJECT_ID> -o json
 ```
 
 Prefer `-o table` or `list-metadata` for human review.
-Default JSON includes values; pipe through `redact-json` before logging or chat.
+Secret JSON includes values; pipe it through `redact-json` before logging or chat.
 
 Preserve identities separately:
 
@@ -134,9 +135,10 @@ Create or update only with current explicit authority naming the project and sec
 3. Resolve duplicates before create; prefer `secret edit <SECRET_ID>` over ambiguous name-only updates.
 4. Create: `bws secret create <KEY> <VALUE> <PROJECT_ID> [--note <NOTE>]`
 5. Update: `bws secret edit <SECRET_ID> [--key <KEY>] [--value <VALUE>] [--note <NOTE>] [--project-id <PROJECT_ID>]`
-6. Pass values through env vars or stdin wrappers, never through chat or committed files.
-7. Verify with `"$HELPER" list-metadata <PROJECT_ID>` or `bws secret get <SECRET_ID> -o json | "$HELPER" redact-json`.
-8. A non-zero exit code is failure even when partial output appeared; never report success without verification.
+6. The current CLI takes secret values as command arguments, so keep the value in a preconfigured environment variable and invoke the command only through a trusted shell or wrapper that does not record expanded arguments.
+7. Never place the value itself in chat, a tool-call command, a transcript, or a committed file.
+8. Verify with `"$HELPER" list-metadata <PROJECT_ID>` or `bws secret get <SECRET_ID> -o json | "$HELPER" redact-json`.
+9. A non-zero exit code is failure even when partial output appeared; never report success without verification.
 
 Rotation is an edit of `SECRET_ID` with a new value, then the same redacted verification.
 

--- a/skills/bws/scripts/bws-safe.sh
+++ b/skills/bws/scripts/bws-safe.sh
@@ -150,7 +150,14 @@ cmd_resolve_id() {
   [ -n "$project_id" ] && [ -n "$key" ] || die_usage "resolve-id requires PROJECT_ID and KEY"
   require_jq
   json=$(run_bws secret list "$project_id" -o json) || exit 3
-  matches=$(jq -r --arg key "$key" '[.[] | select(.key == $key) | .id] | @json' <<<"$json") || exit 3
+  matches=$(jq -r --arg key "$key" '
+    [.[] | select(.key == $key)] as $items
+    | if any($items[]; ((.id | type) != "string") or (.id == "")) then
+        error("matching secret has an invalid id")
+      else
+        [$items[].id] | @json
+      end
+  ' <<<"$json") || exit 3
   count=$(jq 'length' <<<"$matches") || exit 3
   case "$count" in
     0) exit 1 ;;

--- a/skills/bws/scripts/bws-safe.sh
+++ b/skills/bws/scripts/bws-safe.sh
@@ -75,9 +75,6 @@ classify_bws_stderr() {
     *"403"*|*"Forbidden"*|*"forbidden"*|*"permission"*|*"Permission"*)
       printf 'forbidden\n'
       ;;
-    *"404"*|*"Not Found"*|*"not found"*)
-      printf 'forbidden\n'
-      ;;
     *) printf 'indeterminate\n' ;;
   esac
 }
@@ -117,8 +114,9 @@ cmd_redact_json() {
   require_jq
   jq '
     walk(
-      if type == "object" and has("value") then
-        .value = "[REDACTED]"
+      if type == "object" then
+        (if has("value") then .value = "[REDACTED]" else . end)
+        | (if has("note") then .note = "[REDACTED]" else . end)
       else
         .
       end

--- a/skills/bws/scripts/bws-safe.sh
+++ b/skills/bws/scripts/bws-safe.sh
@@ -72,7 +72,7 @@ classify_bws_stderr() {
   case "$err" in
     *"Missing access token"*) printf 'no_token\n' ;;
     *"Doesn't contain a decryption key"*|*"401"*) printf 'invalid_token\n' ;;
-    *"403"*|*"Forbidden"*|*"forbidden"*|*"permission"*|*"Permission"*)
+    *"403"*|*"Forbidden"*|*"forbidden"*)
       printf 'forbidden\n'
       ;;
     *) printf 'indeterminate\n' ;;

--- a/skills/bws/scripts/bws-safe.sh
+++ b/skills/bws/scripts/bws-safe.sh
@@ -48,11 +48,21 @@ require_jq() {
 }
 
 bws_version() {
+  local output version
   if ! command -v bws >/dev/null 2>&1; then
     printf 'none\n'
     return 0
   fi
-  bws --version 2>/dev/null | awk '{print $2; exit}' || printf 'none\n'
+  if ! output=$(bws --version 2>/dev/null); then
+    printf 'none\n'
+    return 0
+  fi
+  version=$(awk 'NF >= 2 {print $2; exit}' <<<"$output")
+  if [ -n "$version" ]; then
+    printf '%s\n' "$version"
+  else
+    printf 'none\n'
+  fi
 }
 
 token_present() {

--- a/skills/bws/scripts/bws-safe.sh
+++ b/skills/bws/scripts/bws-safe.sh
@@ -149,7 +149,10 @@ cmd_resolve_id() {
   local project_id=$1 key=$2 json matches count id
   [ -n "$project_id" ] && [ -n "$key" ] || die_usage "resolve-id requires PROJECT_ID and KEY"
   require_jq
-  json=$(run_bws secret list "$project_id" -o json) || exit 3
+  if ! json=$(run_bws secret list "$project_id" -o json); then
+    run_bws project get "$project_id" -o none >/dev/null || exit 3
+    exit 1
+  fi
   matches=$(jq -r --arg key "$key" '
     [.[] | select(.key == $key)] as $items
     | if any($items[]; ((.id | type) != "string") or (.id == "")) then

--- a/skills/bws/scripts/bws-safe.sh
+++ b/skills/bws/scripts/bws-safe.sh
@@ -146,13 +146,22 @@ cmd_list_metadata() {
 }
 
 cmd_resolve_id() {
-  local project_id=$1 key=$2 json matches count id
+  local project_id=$1 key=$2 json matches count id list_stderr list_error
   [ -n "$project_id" ] && [ -n "$key" ] || die_usage "resolve-id requires PROJECT_ID and KEY"
   require_jq
-  if ! json=$(run_bws secret list "$project_id" -o json); then
+  list_stderr=$(mktemp)
+  chmod 600 "$list_stderr"
+  if ! json=$(bws secret list "$project_id" -o json 2>"$list_stderr"); then
+    list_error=$(<"$list_stderr")
+    rm -f "$list_stderr"
+    case "$list_error" in
+      *"404"*) ;;
+      *) exit 3 ;;
+    esac
     run_bws project get "$project_id" -o none >/dev/null || exit 3
     exit 1
   fi
+  rm -f "$list_stderr"
   matches=$(jq -r --arg key "$key" '
     [.[] | select(.key == $key)] as $items
     | if any($items[]; ((.id | type) != "string") or (.id == "")) then

--- a/skills/bws/scripts/bws-safe.sh
+++ b/skills/bws/scripts/bws-safe.sh
@@ -150,8 +150,8 @@ cmd_resolve_id() {
   [ -n "$project_id" ] && [ -n "$key" ] || die_usage "resolve-id requires PROJECT_ID and KEY"
   require_jq
   json=$(run_bws secret list "$project_id" -o json) || exit 3
-  matches=$(jq -r --arg key "$key" '[.[] | select(.key == $key) | .id] | @json' <<<"$json")
-  count=$(jq 'length' <<<"$matches")
+  matches=$(jq -r --arg key "$key" '[.[] | select(.key == $key) | .id] | @json' <<<"$json") || exit 3
+  count=$(jq 'length' <<<"$matches") || exit 3
   case "$count" in
     0) exit 1 ;;
     1)

--- a/skills/bws/scripts/bws-safe.sh
+++ b/skills/bws/scripts/bws-safe.sh
@@ -71,8 +71,8 @@ classify_bws_stderr() {
   local err=$1
   case "$err" in
     *"Missing access token"*) printf 'no_token\n' ;;
-    *"Doesn't contain a decryption key"*) printf 'invalid_token\n' ;;
-    *"401"*|*"403"*|*"Forbidden"*|*"forbidden"*|*"permission"*|*"Permission"*)
+    *"Doesn't contain a decryption key"*|*"401"*) printf 'invalid_token\n' ;;
+    *"403"*|*"Forbidden"*|*"forbidden"*|*"permission"*|*"Permission"*)
       printf 'forbidden\n'
       ;;
     *"404"*|*"Not Found"*|*"not found"*)

--- a/skills/bws/scripts/bws-safe.sh
+++ b/skills/bws/scripts/bws-safe.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# bws-safe.sh - safe helper for Bitwarden Secrets Manager CLI (bws).
+#
+# Owned by skills/bws/SKILL.md. Never prints access tokens or secret values.
+# Consult `bws --help` and subcommand help for flags; this script does not
+# memorize CLI syntax beyond what it needs for safe probes and redaction.
+#
+# Usage:
+#   bws-safe.sh probe
+#   bws-safe.sh redact-json
+#   bws-safe.sh list-metadata [PROJECT_ID]
+#   bws-safe.sh resolve-id <PROJECT_ID> <KEY>
+#
+# probe prints one sanitized key=value line per fact on stdout:
+#   status= unavailable | no_token | invalid_token | authenticated | forbidden | indeterminate
+#   version=  bws version or none
+#   token_present= yes | no
+#
+# resolve-id prints exactly one secret UUID on stdout when the key is unique in
+# the project; exit 0. Exit 1 when absent, 2 when duplicate names exist, 3 on
+# probe or CLI failure. Never prints secret values.
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+usage() {
+  cat <<'EOF'
+bws-safe.sh - safe helper for Bitwarden Secrets Manager CLI (bws)
+
+Usage:
+  bws-safe.sh probe
+  bws-safe.sh redact-json
+  bws-safe.sh list-metadata [PROJECT_ID]
+  bws-safe.sh resolve-id <PROJECT_ID> <KEY>
+
+Never prints access tokens or secret values.
+EOF
+}
+
+die_usage() {
+  printf 'bws-safe: %s\n' "$1" >&2
+  usage >&2
+  exit 2
+}
+
+require_jq() {
+  command -v jq >/dev/null 2>&1 || die_usage "jq is required"
+}
+
+bws_version() {
+  if ! command -v bws >/dev/null 2>&1; then
+    printf 'none\n'
+    return 0
+  fi
+  bws --version 2>/dev/null | awk '{print $2; exit}' || printf 'none\n'
+}
+
+token_present() {
+  if [ -n "${BWS_ACCESS_TOKEN:-}" ]; then
+    printf 'yes\n'
+    return 0
+  fi
+  if [ -n "${BWS_PROFILE:-}" ] || [ -f "${BWS_CONFIG_FILE:-$HOME/.config/bws/config}" ]; then
+    printf 'yes\n'
+    return 0
+  fi
+  printf 'no\n'
+}
+
+classify_bws_stderr() {
+  local err=$1
+  case "$err" in
+    *"Missing access token"*) printf 'no_token\n' ;;
+    *"Doesn't contain a decryption key"*) printf 'invalid_token\n' ;;
+    *"401"*|*"403"*|*"Forbidden"*|*"forbidden"*|*"permission"*|*"Permission"*)
+      printf 'forbidden\n'
+      ;;
+    *"404"*|*"Not Found"*|*"not found"*)
+      printf 'forbidden\n'
+      ;;
+    *) printf 'indeterminate\n' ;;
+  esac
+}
+
+run_bws() {
+  # shellcheck disable=SC2068
+  bws "$@" 2>/dev/null
+}
+
+cmd_probe() {
+  local version status token stderr
+  version=$(bws_version)
+  token=$(token_present)
+  if [ "$version" = none ]; then
+    status=unavailable
+    printf 'status=%s version=%s token_present=%s\n' "$status" "$version" "$token"
+    exit 0
+  fi
+  if [ "$token" = no ]; then
+    status=no_token
+    printf 'status=%s version=%s token_present=%s\n' "$status" "$version" "$token"
+    exit 0
+  fi
+  stderr=$(mktemp)
+  chmod 600 "$stderr"
+  if bws project list -o none > /dev/null 2>"$stderr"; then
+    status=authenticated
+  else
+    status=$(classify_bws_stderr "$(<"$stderr")")
+  fi
+  rm -f "$stderr"
+  printf 'status=%s version=%s token_present=%s\n' "$status" "$version" "$token"
+  exit 0
+}
+
+cmd_redact_json() {
+  require_jq
+  jq '
+    walk(
+      if type == "object" and has("value") then
+        .value = "[REDACTED]"
+      else
+        .
+      end
+    )
+  '
+}
+
+cmd_list_metadata() {
+  local project_id=${1:-} json
+  require_jq
+  if [ -n "$project_id" ]; then
+    json=$(run_bws secret list "$project_id" -o json) || exit 3
+  else
+    json=$(run_bws secret list -o json) || exit 3
+  fi
+  printf '%s\n' "$json" | cmd_redact_json
+}
+
+cmd_resolve_id() {
+  local project_id=$1 key=$2 json matches count id
+  [ -n "$project_id" ] && [ -n "$key" ] || die_usage "resolve-id requires PROJECT_ID and KEY"
+  require_jq
+  json=$(run_bws secret list "$project_id" -o json) || exit 3
+  matches=$(jq -r --arg key "$key" '[.[] | select(.key == $key) | .id] | @json' <<<"$json")
+  count=$(jq 'length' <<<"$matches")
+  case "$count" in
+    0) exit 1 ;;
+    1)
+      id=$(jq -r '.[0]' <<<"$matches")
+      printf '%s\n' "$id"
+      exit 0
+      ;;
+    *)
+      printf 'bws-safe: duplicate secret key %s in project %s (%s matches)\n' \
+        "$key" "$project_id" "$count" >&2
+      jq -r '.[]' <<<"$matches" >&2
+      exit 2
+      ;;
+  esac
+}
+
+CMD=${1:-}
+shift || true
+
+case "$CMD" in
+  -h|--help|'')
+    usage
+    [ -n "$CMD" ] || exit 2
+    exit 0
+    ;;
+  probe)
+    [ $# -eq 0 ] || die_usage "probe takes no arguments"
+    cmd_probe
+    ;;
+  redact-json)
+    [ $# -eq 0 ] || die_usage "redact-json reads stdin and takes no arguments"
+    cmd_redact_json
+    ;;
+  list-metadata)
+    [ $# -le 1 ] || die_usage "list-metadata accepts an optional PROJECT_ID"
+    cmd_list_metadata "${1:-}"
+    ;;
+  resolve-id)
+    [ $# -eq 2 ] || die_usage "resolve-id requires PROJECT_ID and KEY"
+    cmd_resolve_id "$1" "$2"
+    ;;
+  *)
+    die_usage "unknown command: $CMD"
+    ;;
+esac

--- a/tests/bws-safe.test.sh
+++ b/tests/bws-safe.test.sh
@@ -50,6 +50,9 @@ case "${1:-}" in
         malformed)
           printf '%s\n' '{invalid json'
           ;;
+        invalid_id)
+          printf '%s\n' '[{"id":null,"key":"ONLY","projectId":"proj-1"}]'
+          ;;
         authenticated|read_only)
           printf '%s\n' '[{"id":"only-id","key":"ONLY","value":"secret-value","note":"sensitive-note","projectId":"proj-1"}]'
           ;;
@@ -195,6 +198,17 @@ test_resolve_malformed_json() {
   pass 'resolve-id rejects malformed CLI JSON'
 }
 
+test_resolve_invalid_id() {
+  local rc=0 out
+  set +e
+  out=$(run_with_fake invalid_id env BWS_ACCESS_TOKEN=ok "$HELPER" resolve-id proj-1 ONLY 2>"$TMP_ROOT/invalid-id.err")
+  rc=$?
+  set -e
+  [ "$rc" -eq 3 ] || fail "invalid secret ID should exit 3, got $rc"
+  [ -z "$out" ] || fail "invalid secret ID must not produce output, got $out"
+  pass 'resolve-id rejects invalid secret IDs'
+}
+
 test_probe_absent
 test_probe_broken_version
 test_probe_no_token
@@ -207,3 +221,4 @@ test_redact_metadata
 test_list_metadata_redacts
 test_resolve_duplicate_names
 test_resolve_malformed_json
+test_resolve_invalid_id

--- a/tests/bws-safe.test.sh
+++ b/tests/bws-safe.test.sh
@@ -27,6 +27,7 @@ case "${1:-}" in
         authenticated|read_only) exit 0 ;;
         no_token) printf "Error:\n   0: Missing access token\n" >&2; exit 1 ;;
         invalid_token) printf "Error:\n   0: Doesn't contain a decryption key\n" >&2; exit 1 ;;
+        unauthorized) printf "Error:\n   0: 401 Unauthorized\n" >&2; exit 1 ;;
         forbidden) printf "Error:\n   0: 403 Forbidden\n" >&2; exit 1 ;;
         absent) exit 127 ;;
         *) printf "Error: unknown mode %s\n" "$MODE" >&2; exit 1 ;;
@@ -73,18 +74,22 @@ SH
 run_with_fake() {
   local mode=$1
   shift
-  local fakebin case_dir
+  local fakebin case_dir isolated_home
   case_dir="$TMP_ROOT/$mode-${RANDOM}"
-  mkdir -p "$case_dir"
+  isolated_home="$case_dir/home"
+  mkdir -p "$isolated_home"
   fakebin=$(make_fake_bws "$case_dir" "$mode")
-  env FM_FAKE_BWS_MODE="$mode" PATH="$fakebin:$PATH" "$@"
+  env -u BWS_ACCESS_TOKEN -u BWS_PROFILE -u BWS_CONFIG_FILE \
+    HOME="$isolated_home" FM_FAKE_BWS_MODE="$mode" PATH="$fakebin:$PATH" "$@"
 }
 
 test_probe_absent() {
-  local out fakebin
+  local out fakebin isolated_home
   fakebin="$TMP_ROOT/absent-only/bin"
-  mkdir -p "$fakebin"
-  out=$(PATH="$fakebin:/usr/bin:/bin" env -u BWS_ACCESS_TOKEN "$HELPER" probe)
+  isolated_home="$TMP_ROOT/absent-only/home"
+  mkdir -p "$fakebin" "$isolated_home"
+  out=$(env -u BWS_ACCESS_TOKEN -u BWS_PROFILE -u BWS_CONFIG_FILE \
+    HOME="$isolated_home" PATH="$fakebin:/usr/bin:/bin" "$HELPER" probe)
   assert_contains "$out" 'status=unavailable' 'absent bws should report unavailable'
   assert_contains "$out" 'version=none' 'absent bws should report version none'
   pass 'probe classifies absent bws'
@@ -103,6 +108,13 @@ test_probe_invalid_token() {
   out=$(run_with_fake invalid_token env BWS_ACCESS_TOKEN=bad "$HELPER" probe)
   assert_contains "$out" 'status=invalid_token' 'bad token should report invalid_token'
   pass 'probe classifies invalid token'
+}
+
+test_probe_unauthorized_token() {
+  local out
+  out=$(run_with_fake unauthorized env BWS_ACCESS_TOKEN=bad "$HELPER" probe)
+  assert_contains "$out" 'status=invalid_token' '401 response should report invalid_token'
+  pass 'probe classifies rejected token'
 }
 
 test_probe_authenticated_read_only() {
@@ -150,18 +162,12 @@ test_write_failure_not_success() {
   pass 'read-only write attempt fails with non-zero exit'
 }
 
-test_delete_without_authority_is_skill_policy() {
-  grep -Fq 'explicit, concrete captain or operator authority' "$ROOT/skills/bws/SKILL.md" \
-    || fail 'skill must require explicit authority for delete'
-  pass 'skill documents delete authority requirement'
-}
-
 test_probe_absent
 test_probe_no_token
 test_probe_invalid_token
+test_probe_unauthorized_token
 test_probe_authenticated_read_only
 test_redact_metadata
 test_list_metadata_redacts
 test_resolve_duplicate_names
 test_write_failure_not_success
-test_delete_without_authority_is_skill_policy

--- a/tests/bws-safe.test.sh
+++ b/tests/bws-safe.test.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Behavior tests for skills/bws/scripts/bws-safe.sh using synthetic bws fixtures.
+set -u
+
+# shellcheck source=tests/lib.sh disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+HELPER="$ROOT/skills/bws/scripts/bws-safe.sh"
+TMP_ROOT=$(fm_test_tmproot bws-safe-tests)
+
+make_fake_bws() {
+  local dir=$1 mode=${2:-authenticated}
+  local fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/bws" <<'SH'
+#!/usr/bin/env bash
+MODE="${FM_FAKE_BWS_MODE:-authenticated}"
+case "${1:-}" in
+  --version)
+    printf 'bws 9.9.9\n'
+    exit 0
+    ;;
+  project)
+  case "${2:-}" in
+    list)
+      case "$MODE" in
+        authenticated|read_only) exit 0 ;;
+        no_token) printf "Error:\n   0: Missing access token\n" >&2; exit 1 ;;
+        invalid_token) printf "Error:\n   0: Doesn't contain a decryption key\n" >&2; exit 1 ;;
+        forbidden) printf "Error:\n   0: 403 Forbidden\n" >&2; exit 1 ;;
+        absent) exit 127 ;;
+        *) printf "Error: unknown mode %s\n" "$MODE" >&2; exit 1 ;;
+      esac
+      ;;
+  esac
+  ;;
+  secret)
+  case "${2:-}" in
+    list)
+      case "$MODE" in
+        duplicate)
+          printf '%s\n' '[{"id":"id-a","key":"dup","value":"one","projectId":"proj-1"},{"id":"id-b","key":"dup","value":"two","projectId":"proj-1"}]'
+          ;;
+        authenticated|read_only)
+          printf '%s\n' '[{"id":"only-id","key":"ONLY","value":"secret-value","projectId":"proj-1"}]'
+          ;;
+        write_fail)
+          printf '%s\n' '[]'
+          ;;
+        *)
+          printf '%s\n' '[]'
+          ;;
+      esac
+      exit 0
+      ;;
+    create)
+      if [ "$MODE" = read_only ]; then
+        printf "Error:\n   0: 403 Forbidden\n" >&2
+        exit 1
+      fi
+      exit 0
+      ;;
+  esac
+  ;;
+esac
+printf 'unhandled bws fake: %s\n' "$*" >&2
+exit 1
+SH
+  chmod +x "$fakebin/bws"
+  printf '%s\n' "$fakebin"
+}
+
+run_with_fake() {
+  local mode=$1
+  shift
+  local fakebin case_dir
+  case_dir="$TMP_ROOT/$mode-${RANDOM}"
+  mkdir -p "$case_dir"
+  fakebin=$(make_fake_bws "$case_dir" "$mode")
+  env FM_FAKE_BWS_MODE="$mode" PATH="$fakebin:$PATH" "$@"
+}
+
+test_probe_absent() {
+  local out fakebin
+  fakebin="$TMP_ROOT/absent-only/bin"
+  mkdir -p "$fakebin"
+  out=$(PATH="$fakebin:/usr/bin:/bin" env -u BWS_ACCESS_TOKEN "$HELPER" probe)
+  assert_contains "$out" 'status=unavailable' 'absent bws should report unavailable'
+  assert_contains "$out" 'version=none' 'absent bws should report version none'
+  pass 'probe classifies absent bws'
+}
+
+test_probe_no_token() {
+  local out
+  out=$(run_with_fake no_token env -u BWS_ACCESS_TOKEN "$HELPER" probe)
+  assert_contains "$out" 'status=no_token' 'missing token should report no_token'
+  assert_contains "$out" 'token_present=no' 'missing token should report token_present=no'
+  pass 'probe classifies missing BWS_ACCESS_TOKEN'
+}
+
+test_probe_invalid_token() {
+  local out
+  out=$(run_with_fake invalid_token env BWS_ACCESS_TOKEN=bad "$HELPER" probe)
+  assert_contains "$out" 'status=invalid_token' 'bad token should report invalid_token'
+  pass 'probe classifies invalid token'
+}
+
+test_probe_authenticated_read_only() {
+  local out
+  out=$(run_with_fake read_only env BWS_ACCESS_TOKEN=readonly "$HELPER" probe)
+  assert_contains "$out" 'status=authenticated' 'read-only token should still list projects'
+  pass 'probe treats read-only list success as authenticated'
+}
+
+test_redact_metadata() {
+  local out
+  out=$(printf '%s\n' '{"id":"x","key":"k","value":"secret"}' | "$HELPER" redact-json)
+  assert_contains "$out" '[REDACTED]' 'redact-json should replace value'
+  assert_not_contains "$out" 'secret' 'redact-json must not leak original value'
+  pass 'redact-json redacts secret values'
+}
+
+test_list_metadata_redacts() {
+  local out
+  out=$(run_with_fake authenticated env BWS_ACCESS_TOKEN=ok "$HELPER" list-metadata proj-1)
+  assert_contains "$out" '[REDACTED]' 'list-metadata should redact values'
+  assert_contains "$out" '"key": "ONLY"' 'list-metadata should keep metadata'
+  assert_not_contains "$out" 'secret-value' 'list-metadata must not leak values'
+  pass 'list-metadata returns redacted secret metadata'
+}
+
+test_resolve_duplicate_names() {
+  local rc=0
+  set +e
+  run_with_fake duplicate env BWS_ACCESS_TOKEN=ok "$HELPER" resolve-id proj-1 dup >/dev/null 2>"$TMP_ROOT/dup.err"
+  rc=$?
+  set -e
+  [ "$rc" -eq 2 ] || fail "duplicate key should exit 2, got $rc"
+  assert_contains "$(<"$TMP_ROOT/dup.err")" 'duplicate secret key' 'duplicate should explain ambiguity'
+  pass 'resolve-id refuses duplicate secret names'
+}
+
+test_write_failure_not_success() {
+  local rc=0
+  set +e
+  run_with_fake read_only env BWS_ACCESS_TOKEN=ro bws secret create KEY VALUE proj-1 -o none >/dev/null 2>&1
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail 'read-only create should fail'
+  pass 'read-only write attempt fails with non-zero exit'
+}
+
+test_delete_without_authority_is_skill_policy() {
+  grep -Fq 'explicit, concrete captain or operator authority' "$ROOT/skills/bws/SKILL.md" \
+    || fail 'skill must require explicit authority for delete'
+  pass 'skill documents delete authority requirement'
+}
+
+test_probe_absent
+test_probe_no_token
+test_probe_invalid_token
+test_probe_authenticated_read_only
+test_redact_metadata
+test_list_metadata_redacts
+test_resolve_duplicate_names
+test_write_failure_not_success
+test_delete_without_authority_is_skill_policy

--- a/tests/bws-safe.test.sh
+++ b/tests/bws-safe.test.sh
@@ -30,6 +30,7 @@ case "${1:-}" in
         unauthorized) printf "Error:\n   0: 401 Unauthorized\n" >&2; exit 1 ;;
         forbidden) printf "Error:\n   0: 403 Forbidden\n" >&2; exit 1 ;;
         not_found) printf "Error:\n   0: 404 Not Found\n" >&2; exit 1 ;;
+        local_permission) printf "Error: Permission denied reading config\n" >&2; exit 1 ;;
         absent) exit 127 ;;
         *) printf "Error: unknown mode %s\n" "$MODE" >&2; exit 1 ;;
       esac
@@ -132,6 +133,13 @@ test_probe_not_found() {
   pass 'probe leaves ambiguous not-found response indeterminate'
 }
 
+test_probe_local_permission_failure() {
+  local out
+  out=$(run_with_fake local_permission env BWS_ACCESS_TOKEN=set "$HELPER" probe)
+  assert_contains "$out" 'status=indeterminate' 'local permission failure should report indeterminate'
+  pass 'probe leaves local permission failures indeterminate'
+}
+
 test_redact_metadata() {
   local out
   out=$(printf '%s\n' '{"id":"x","key":"k","value":"secret","note":"credential note"}' | "$HELPER" redact-json)
@@ -168,6 +176,7 @@ test_probe_invalid_token
 test_probe_unauthorized_token
 test_probe_authenticated_read_only
 test_probe_not_found
+test_probe_local_permission_failure
 test_redact_metadata
 test_list_metadata_redacts
 test_resolve_duplicate_names

--- a/tests/bws-safe.test.sh
+++ b/tests/bws-safe.test.sh
@@ -17,6 +17,9 @@ make_fake_bws() {
 MODE="${FM_FAKE_BWS_MODE:-authenticated}"
 case "${1:-}" in
   --version)
+    if [ "$MODE" = broken_version ]; then
+      exit 1
+    fi
     printf 'bws 9.9.9\n'
     exit 0
     ;;
@@ -97,6 +100,14 @@ test_probe_absent() {
   pass 'probe classifies absent bws'
 }
 
+test_probe_broken_version() {
+  local out
+  out=$(run_with_fake broken_version env BWS_ACCESS_TOKEN=set "$HELPER" probe)
+  assert_contains "$out" 'status=unavailable' 'failed version command should report unavailable'
+  assert_contains "$out" 'version=none' 'failed version command should report version none'
+  pass 'probe classifies broken bws installation'
+}
+
 test_probe_no_token() {
   local out
   out=$(run_with_fake no_token env -u BWS_ACCESS_TOKEN "$HELPER" probe)
@@ -171,6 +182,7 @@ test_resolve_duplicate_names() {
 }
 
 test_probe_absent
+test_probe_broken_version
 test_probe_no_token
 test_probe_invalid_token
 test_probe_unauthorized_token

--- a/tests/bws-safe.test.sh
+++ b/tests/bws-safe.test.sh
@@ -29,6 +29,7 @@ case "${1:-}" in
         invalid_token) printf "Error:\n   0: Doesn't contain a decryption key\n" >&2; exit 1 ;;
         unauthorized) printf "Error:\n   0: 401 Unauthorized\n" >&2; exit 1 ;;
         forbidden) printf "Error:\n   0: 403 Forbidden\n" >&2; exit 1 ;;
+        not_found) printf "Error:\n   0: 404 Not Found\n" >&2; exit 1 ;;
         absent) exit 127 ;;
         *) printf "Error: unknown mode %s\n" "$MODE" >&2; exit 1 ;;
       esac
@@ -43,7 +44,7 @@ case "${1:-}" in
           printf '%s\n' '[{"id":"id-a","key":"dup","value":"one","projectId":"proj-1"},{"id":"id-b","key":"dup","value":"two","projectId":"proj-1"}]'
           ;;
         authenticated|read_only)
-          printf '%s\n' '[{"id":"only-id","key":"ONLY","value":"secret-value","projectId":"proj-1"}]'
+          printf '%s\n' '[{"id":"only-id","key":"ONLY","value":"secret-value","note":"sensitive-note","projectId":"proj-1"}]'
           ;;
         write_fail)
           printf '%s\n' '[]'
@@ -124,12 +125,20 @@ test_probe_authenticated_read_only() {
   pass 'probe treats read-only list success as authenticated'
 }
 
+test_probe_not_found() {
+  local out
+  out=$(run_with_fake not_found env BWS_ACCESS_TOKEN=set "$HELPER" probe)
+  assert_contains "$out" 'status=indeterminate' '404 response should report indeterminate'
+  pass 'probe leaves ambiguous not-found response indeterminate'
+}
+
 test_redact_metadata() {
   local out
-  out=$(printf '%s\n' '{"id":"x","key":"k","value":"secret"}' | "$HELPER" redact-json)
+  out=$(printf '%s\n' '{"id":"x","key":"k","value":"secret","note":"credential note"}' | "$HELPER" redact-json)
   assert_contains "$out" '[REDACTED]' 'redact-json should replace value'
   assert_not_contains "$out" 'secret' 'redact-json must not leak original value'
-  pass 'redact-json redacts secret values'
+  assert_not_contains "$out" 'credential note' 'redact-json must not leak notes'
+  pass 'redact-json redacts secret values and notes'
 }
 
 test_list_metadata_redacts() {
@@ -138,6 +147,7 @@ test_list_metadata_redacts() {
   assert_contains "$out" '[REDACTED]' 'list-metadata should redact values'
   assert_contains "$out" '"key": "ONLY"' 'list-metadata should keep metadata'
   assert_not_contains "$out" 'secret-value' 'list-metadata must not leak values'
+  assert_not_contains "$out" 'sensitive-note' 'list-metadata must not leak notes'
   pass 'list-metadata returns redacted secret metadata'
 }
 
@@ -152,22 +162,12 @@ test_resolve_duplicate_names() {
   pass 'resolve-id refuses duplicate secret names'
 }
 
-test_write_failure_not_success() {
-  local rc=0
-  set +e
-  run_with_fake read_only env BWS_ACCESS_TOKEN=ro bws secret create KEY VALUE proj-1 -o none >/dev/null 2>&1
-  rc=$?
-  set -e
-  [ "$rc" -ne 0 ] || fail 'read-only create should fail'
-  pass 'read-only write attempt fails with non-zero exit'
-}
-
 test_probe_absent
 test_probe_no_token
 test_probe_invalid_token
 test_probe_unauthorized_token
 test_probe_authenticated_read_only
+test_probe_not_found
 test_redact_metadata
 test_list_metadata_redacts
 test_resolve_duplicate_names
-test_write_failure_not_success

--- a/tests/bws-safe.test.sh
+++ b/tests/bws-safe.test.sh
@@ -47,6 +47,9 @@ case "${1:-}" in
         duplicate)
           printf '%s\n' '[{"id":"id-a","key":"dup","value":"one","projectId":"proj-1"},{"id":"id-b","key":"dup","value":"two","projectId":"proj-1"}]'
           ;;
+        malformed)
+          printf '%s\n' '{invalid json'
+          ;;
         authenticated|read_only)
           printf '%s\n' '[{"id":"only-id","key":"ONLY","value":"secret-value","note":"sensitive-note","projectId":"proj-1"}]'
           ;;
@@ -181,6 +184,17 @@ test_resolve_duplicate_names() {
   pass 'resolve-id refuses duplicate secret names'
 }
 
+test_resolve_malformed_json() {
+  local rc=0
+  set +e
+  run_with_fake malformed env BWS_ACCESS_TOKEN=ok "$HELPER" resolve-id proj-1 ONLY >/dev/null 2>"$TMP_ROOT/malformed.err"
+  rc=$?
+  set -e
+  [ "$rc" -eq 3 ] || fail "malformed JSON should exit 3, got $rc"
+  assert_not_contains "$(<"$TMP_ROOT/malformed.err")" 'duplicate secret key' 'malformed JSON must not report duplicates'
+  pass 'resolve-id rejects malformed CLI JSON'
+}
+
 test_probe_absent
 test_probe_broken_version
 test_probe_no_token
@@ -192,3 +206,4 @@ test_probe_local_permission_failure
 test_redact_metadata
 test_list_metadata_redacts
 test_resolve_duplicate_names
+test_resolve_malformed_json

--- a/tests/bws-safe.test.sh
+++ b/tests/bws-safe.test.sh
@@ -38,6 +38,10 @@ case "${1:-}" in
         *) printf "Error: unknown mode %s\n" "$MODE" >&2; exit 1 ;;
       esac
       ;;
+    get)
+      [ "$MODE" = empty_project ] && exit 0
+      exit 1
+      ;;
   esac
   ;;
   secret)
@@ -52,6 +56,10 @@ case "${1:-}" in
           ;;
         invalid_id)
           printf '%s\n' '[{"id":null,"key":"ONLY","projectId":"proj-1"}]'
+          ;;
+        empty_project)
+          printf "Error:\n   0: 404 Not Found\n" >&2
+          exit 1
           ;;
         authenticated|read_only)
           printf '%s\n' '[{"id":"only-id","key":"ONLY","value":"secret-value","note":"sensitive-note","projectId":"proj-1"}]'
@@ -209,6 +217,17 @@ test_resolve_invalid_id() {
   pass 'resolve-id rejects invalid secret IDs'
 }
 
+test_resolve_empty_project() {
+  local rc=0 out
+  set +e
+  out=$(run_with_fake empty_project env BWS_ACCESS_TOKEN=ok "$HELPER" resolve-id proj-1 ONLY)
+  rc=$?
+  set -e
+  [ "$rc" -eq 1 ] || fail "empty project should report absent key with exit 1, got $rc"
+  [ -z "$out" ] || fail "empty project must not produce output, got $out"
+  pass 'resolve-id handles empty projects as absent keys'
+}
+
 test_probe_absent
 test_probe_broken_version
 test_probe_no_token
@@ -222,3 +241,4 @@ test_list_metadata_redacts
 test_resolve_duplicate_names
 test_resolve_malformed_json
 test_resolve_invalid_id
+test_resolve_empty_project

--- a/tests/bws-safe.test.sh
+++ b/tests/bws-safe.test.sh
@@ -39,8 +39,10 @@ case "${1:-}" in
       esac
       ;;
     get)
-      [ "$MODE" = empty_project ] && exit 0
-      exit 1
+      case "$MODE" in
+        empty_project|transient_list) exit 0 ;;
+        *) exit 1 ;;
+      esac
       ;;
   esac
   ;;
@@ -59,6 +61,10 @@ case "${1:-}" in
           ;;
         empty_project)
           printf "Error:\n   0: 404 Not Found\n" >&2
+          exit 1
+          ;;
+        transient_list)
+          printf "Error: request timed out\n" >&2
           exit 1
           ;;
         authenticated|read_only)
@@ -228,6 +234,17 @@ test_resolve_empty_project() {
   pass 'resolve-id handles empty projects as absent keys'
 }
 
+test_resolve_transient_list_failure() {
+  local rc=0 out
+  set +e
+  out=$(run_with_fake transient_list env BWS_ACCESS_TOKEN=ok "$HELPER" resolve-id proj-1 ONLY)
+  rc=$?
+  set -e
+  [ "$rc" -eq 3 ] || fail "transient list failure should exit 3, got $rc"
+  [ -z "$out" ] || fail "transient list failure must not produce output, got $out"
+  pass 'resolve-id preserves transient list failures'
+}
+
 test_probe_absent
 test_probe_broken_version
 test_probe_no_token
@@ -242,3 +259,4 @@ test_resolve_duplicate_names
 test_resolve_malformed_json
 test_resolve_invalid_id
 test_resolve_empty_project
+test_resolve_transient_list_failure


### PR DESCRIPTION
## Intent

Create bws Bitwarden Secrets Manager CLI skill with dual firstmate/project loading via skills/bws owner and .agents/skills/bws stub, bws-safe helper, tests, doc checks; open PR to kunchenguid/firstmate, do not merge.

## What Changed

- Add a public Bitwarden Secrets Manager CLI skill and a Firstmate agent-only stub that routes to the shared procedure.
- Add a safe helper for authentication probing, JSON redaction, metadata listing, and unambiguous secret ID resolution.
- Document the dual-surface skill layout and add fixture-based coverage for redaction, authentication states, duplicate keys, and CLI failure handling.

## Risk Assessment

✅ Low: The change is well-bounded, satisfies the dual-loading and safe-helper intent, and the behavior-oriented tests cover the material authentication, redaction, resolution, and failure-classification paths without introducing source-content-only assertions.

## Testing

Focused behavior and documentation tests passed, and a reviewer-visible CLI transcript demonstrates the helper’s public commands, safe unavailable-state probe, and value/note redaction; no screenshot was captured because this change has no rendered UI.

<details>
<summary>Evidence: Sanitized bws-safe end-user CLI transcript</summary>

Source: [Sanitized bws-safe end-user CLI transcript](https://github.com/prandelicious/firstmate/blob/fb15da567bcf54a4a1345f7d51050ba90283c251/.no-mistakes/evidence/fm/firstmate-bws-skill/bws-safe-cli-transcript.txt)

```text
$ skills/bws/scripts/bws-safe.sh --help
bws-safe.sh - safe helper for Bitwarden Secrets Manager CLI (bws)

Usage:
  bws-safe.sh probe
  bws-safe.sh redact-json
  bws-safe.sh list-metadata [PROJECT_ID]
  bws-safe.sh resolve-id <PROJECT_ID> <KEY>

Never prints access tokens or secret values.

$ env -u BWS_ACCESS_TOKEN -u BWS_PROFILE -u BWS_CONFIG_FILE HOME=/tmp/bws-evidence-empty-home PATH=/usr/bin:/bin skills/bws/scripts/bws-safe.sh probe
status=unavailable version=none token_present=no

$ printf <sample-secret-json> | skills/bws/scripts/bws-safe.sh redact-json
{
  "id": "secret-id",
  "key": "DATABASE_URL",
  "value": "[REDACTED]",
  "note": "[REDACTED]",
  "projectId": "project-id"
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ebb58017d467fd09ce517fc5dd63c90d7a31f833","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `tests/bws-safe.test.sh`
- `tests/fm-documentation-audiences.test.sh`
- `skills/bws/scripts/bws-safe.sh --help`
- <code>Unauthenticated isolated-environment probe using `skills/bws/scripts/bws-safe.sh probe`</code>
- <code>Piped representative secret JSON through `skills/bws/scripts/bws-safe.sh redact-json` and captured the sanitized output</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
