### PR TITLE
feat(brief): make generated crewmate briefs forge-aware

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -505,6 +505,7 @@ Every ship brief must retain the worktree-isolation assertion and stop if launch
 If a ship task touches firstmate's shared tracked material, explicitly require `firstmate-coding-guidelines` before editing.
 If a task will drive Herdr lifecycle behavior, scaffold with `--herdr-lab`; if that need appears after an unguarded scaffold, stop and regenerate rather than adding commands by hand.
 The generated Herdr contract must use a named non-`default` isolated lab and its guarded helper for every lifecycle action.
+Crewmate briefs carry forge-specific vocabulary, detected best-effort from the project clone's origin; when the scaffold warns that it could not detect the forge, re-scaffold with `--forge` rather than hand-editing the generated wording.
 
 Load `secondmate-provisioning` before creating or using a charter brief and preserve its idle-by-default and marked-return-channel contracts.
 Status appends are sparse supervisor-actionable events, not routine progress; `bin/fm-classify-lib.sh` owns keyed open and resolved semantics.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -354,6 +354,7 @@ The worker reports the PR when CI first becomes green rather than waiting for me
 ### PR ready, landing, and teardown
 
 For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
+On a GitLab-hosted project the brief scaffolds the same signals with that forge's vocabulary - `done: MR <url> checks green` and `done: MR <url>` - and firstmate's reconciliation reads either token, so the change of vocabulary never hides a CI-ready crew.
 Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the watcher's merge poll.
 Tell the captain the PR's full URL, always the complete `https://...` link rather than a bare `#number`, a concise outcome summary, and the no-mistakes risk level when applicable.
 A captain instruction to merge is explicit authority; `yolo` is the only standing routine authority.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -8,19 +8,22 @@
 # of shipping a new one).
 # Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only> [--forge <github|gitlab>] [--herdr-lab]
 #        fm-brief.sh <task-id> <repo-name> --scout [--forge <github|gitlab>] [--herdr-lab]
+#        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
+#   --scout writes the scout contract instead: the deliverable is a report at
+#   data/<task-id>/report.md (no branch, no push, no PR) and the worktree is scratch.
 #   --forge selects the forge vocabulary in generated crewmate briefs:
 #   gh-axi and "PR" on GitHub, glab and "merge request" (MR) on GitLab.
 #   It is best-effort by default: the clone's origin remote is read from
 #   $FM_HOME/projects/<repo-name> and its host decides the vocabulary.
+#   That directory must itself be the clone's root; a placeholder or partial
+#   directory inside an enclosing repo is treated as no clone at all rather
+#   than inheriting the enclosing repo's origin.
 #   github.com means GitHub, any host whose name contains "gitlab" means
 #   GitLab, and anything else - a missing clone, a local path, or a
 #   self-hosted host with no "gitlab" in its name - means unknown.
 #   Unknown scaffolds forge-neutral wording ("your forge CLI", "PR/MR") and
 #   warns loudly at scaffold time; pass --forge to choose explicitly.
 #   Secondmate charters are forge-neutral and refuse this flag.
-#        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
-#   --scout writes the scout contract instead: the deliverable is a report at
-#   data/<task-id>/report.md (no branch, no push, no PR) and the worktree is scratch.
 #   --secondmate writes a persistent secondmate charter. The project list
 #   is cloned into the secondmate home, while the natural-language scope
 #   tells the main firstmate when to route work there; routine churn stays in its own home;
@@ -169,10 +172,12 @@ elif [ "$MODE_SET" -eq 1 ]; then
   echo "error: --mode applies only to ship briefs; a scout delivers a report and a secondmate charter is not a delivery contract" >&2
   exit 1
 fi
-case "$FORGE" in
-  auto|github|gitlab) ;;
-  *) echo "error: --forge must be one of github or gitlab (got '$FORGE'); omit it to auto-detect from the project's origin remote" >&2; exit 1 ;;
-esac
+if [ "$FORGE_SET" -eq 1 ]; then
+  case "$FORGE" in
+    github|gitlab) ;;
+    *) echo "error: --forge must be one of github or gitlab (got '$FORGE'); omit it to auto-detect from the project's origin remote" >&2; exit 1 ;;
+  esac
+fi
 ID=${POS[0]}
 
 if [ "$KIND" = secondmate ] && [ "$HERDR_LAB" -eq 1 ]; then
@@ -295,11 +300,21 @@ REPO=${POS[1]}
 # unrecognized or missing origin scaffolds forge-neutral wording and warns
 # loudly at scaffold time, so a self-hosted GitLab host without "gitlab" in
 # its name is a supported outcome rather than a silent mis-flag.
+# The project directory only counts as a clone when it is that clone's own root:
+# git resolves a repository by walking upward, and FM_HOME defaults to the
+# firstmate checkout, so a placeholder or half-finished projects/<repo-name>
+# directory would otherwise report the firstmate repo's own origin.
 if [ "$FORGE" = auto ]; then
   FORGE_ORIGIN=
-  if [ -d "$FM_HOME/projects/$REPO" ] && \
-     git -C "$FM_HOME/projects/$REPO" rev-parse --git-dir >/dev/null 2>&1; then
-    FORGE_ORIGIN=$(git -C "$FM_HOME/projects/$REPO" remote get-url origin 2>/dev/null || true)
+  PROJECT_DIR=$(CDPATH='' cd -- "$FM_HOME/projects/$REPO" 2>/dev/null && pwd -P) || PROJECT_DIR=
+  if [ -n "$PROJECT_DIR" ]; then
+    PROJECT_TOPLEVEL=$(git -C "$PROJECT_DIR" rev-parse --show-toplevel 2>/dev/null || true)
+    if [ -n "$PROJECT_TOPLEVEL" ]; then
+      PROJECT_TOPLEVEL=$(CDPATH='' cd -- "$PROJECT_TOPLEVEL" 2>/dev/null && pwd -P) || PROJECT_TOPLEVEL=
+    fi
+    if [ -n "$PROJECT_TOPLEVEL" ] && [ "$PROJECT_TOPLEVEL" = "$PROJECT_DIR" ]; then
+      FORGE_ORIGIN=$(git -C "$PROJECT_DIR" remote get-url origin 2>/dev/null || true)
+    fi
   fi
   if [ -n "$FORGE_ORIGIN" ]; then
     ORIGIN_HOST=$(printf '%s\n' "$FORGE_ORIGIN" | sed -e 's#^[a-zA-Z][a-zA-Z0-9+.-]*://##' -e 's#^[^/]*@##' -e 's#[:/].*##')

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -14,7 +14,8 @@
 #   --forge selects the forge vocabulary in generated crewmate briefs:
 #   gh-axi and "PR" on GitHub, glab and "merge request" (MR) on GitLab.
 #   It is best-effort by default: the clone's origin remote is read from
-#   $FM_HOME/projects/<repo-name> and its host decides the vocabulary.
+#   <projects-dir>/<repo-name> - $FM_HOME/projects unless FM_PROJECTS_OVERRIDE
+#   moves it - and its host decides the vocabulary.
 #   That directory must itself be the clone's root; a placeholder or partial
 #   directory inside an enclosing repo is treated as no clone at all rather
 #   than inheriting the enclosing repo's origin.
@@ -114,6 +115,7 @@ if [ -n "${FM_STATE_OVERRIDE:-}" ]; then
 else
   STATE="$FM_HOME/state"
 fi
+PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
 KIND=ship
 HERDR_LAB=0
 NO_PROJECTS=0
@@ -296,7 +298,7 @@ REPO=${POS[1]}
 
 # Forge vocabulary for generated briefs: --forge is the explicit mechanism,
 # and a missing flag falls back to best-effort detection from the project's
-# clone under $FM_HOME/projects/<repo-name>. Detection never guesses: an
+# clone under $PROJECTS/<repo-name>. Detection never guesses: an
 # unrecognized or missing origin scaffolds forge-neutral wording and warns
 # loudly at scaffold time, so a self-hosted GitLab host without "gitlab" in
 # its name is a supported outcome rather than a silent mis-flag.
@@ -306,7 +308,7 @@ REPO=${POS[1]}
 # directory would otherwise report the firstmate repo's own origin.
 if [ "$FORGE" = auto ]; then
   FORGE_ORIGIN=
-  PROJECT_DIR=$(CDPATH='' cd -- "$FM_HOME/projects/$REPO" 2>/dev/null && pwd -P) || PROJECT_DIR=
+  PROJECT_DIR=$(CDPATH='' cd -- "$PROJECTS/$REPO" 2>/dev/null && pwd -P) || PROJECT_DIR=
   if [ -n "$PROJECT_DIR" ]; then
     PROJECT_TOPLEVEL=$(git -C "$PROJECT_DIR" rev-parse --show-toplevel 2>/dev/null || true)
     if [ -n "$PROJECT_TOPLEVEL" ]; then
@@ -331,7 +333,7 @@ if [ "$FORGE" = auto ]; then
     if [ -n "$FORGE_ORIGIN" ]; then
       echo "warning: could not detect forge for '$REPO' from origin '$FORGE_ORIGIN' (host '${ORIGIN_HOST:-?}'); scaffolded forge-neutral wording - pass --forge <github|gitlab> to choose" >&2
     else
-      echo "warning: no origin remote found for '$REPO' at ${FM_HOME}/projects/$REPO; scaffolded forge-neutral wording - pass --forge <github|gitlab> to choose" >&2
+      echo "warning: no origin remote found for '$REPO' at $PROJECTS/$REPO; scaffolded forge-neutral wording - pass --forge <github|gitlab> to choose" >&2
     fi
   fi
 fi

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -6,8 +6,18 @@
 # description, acceptance criteria, and context, and may adjust other sections
 # when the task genuinely deviates (e.g. working an existing external PR instead
 # of shipping a new one).
-# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only> [--herdr-lab]
-#        fm-brief.sh <task-id> <repo-name> --scout [--herdr-lab]
+# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only> [--forge <github|gitlab>] [--herdr-lab]
+#        fm-brief.sh <task-id> <repo-name> --scout [--forge <github|gitlab>] [--herdr-lab]
+#   --forge selects the forge vocabulary in generated crewmate briefs:
+#   gh-axi and "PR" on GitHub, glab and "merge request" (MR) on GitLab.
+#   It is best-effort by default: the clone's origin remote is read from
+#   $FM_HOME/projects/<repo-name> and its host decides the vocabulary.
+#   github.com means GitHub, any host whose name contains "gitlab" means
+#   GitLab, and anything else - a missing clone, a local path, or a
+#   self-hosted host with no "gitlab" in its name - means unknown.
+#   Unknown scaffolds forge-neutral wording ("your forge CLI", "PR/MR") and
+#   warns loudly at scaffold time; pass --forge to choose explicitly.
+#   Secondmate charters are forge-neutral and refuse this flag.
 #        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
 #   --scout writes the scout contract instead: the deliverable is a report at
 #   data/<task-id>/report.md (no branch, no push, no PR) and the worktree is scratch.
@@ -31,7 +41,7 @@
 # resolves it per task at intake (AGENTS.md section 7); data/projects.md holds the
 # captain's standing posture as context, and this script never reads it:
 #   no-mistakes  implement -> /no-mistakes pipeline -> PR -> configured merge authority
-#   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> configured merge authority
+#   direct-PR    implement -> push + open PR via the forge CLI (gh-axi on GitHub, glab on GitLab) (no pipeline) -> configured merge authority
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                the configured merge authority approves, firstmate merges to local main
 # no-mistakes-prod-only is a registry policy, not a task mode; resolve it to one of
@@ -106,6 +116,8 @@ HERDR_LAB=0
 NO_PROJECTS=0
 MODE=
 MODE_SET=0
+FORGE=auto
+FORGE_SET=0
 POS=()
 want_value=
 for a in "$@"; do
@@ -115,6 +127,7 @@ for a in "$@"; do
     esac
     case "$want_value" in
       mode) MODE=$a; MODE_SET=1 ;;
+      forge) FORGE=$a; FORGE_SET=1 ;;
       *) echo "error: internal parser state for --$want_value" >&2; exit 1 ;;
     esac
     want_value=
@@ -127,6 +140,8 @@ for a in "$@"; do
     --no-projects) NO_PROJECTS=1 ;;
     --mode) want_value=mode ;;
     --mode=*) MODE=${a#--mode=}; MODE_SET=1 ;;
+    --forge) want_value=forge ;;
+    --forge=*) FORGE=${a#--forge=}; FORGE_SET=1 ;;
     # yolo never reaches the worker: it is firstmate's approval authority, not a
     # brief input. Refuse it loudly so it is never silently dropped here and then
     # believed to have been recorded.
@@ -154,10 +169,18 @@ elif [ "$MODE_SET" -eq 1 ]; then
   echo "error: --mode applies only to ship briefs; a scout delivers a report and a secondmate charter is not a delivery contract" >&2
   exit 1
 fi
+case "$FORGE" in
+  auto|github|gitlab) ;;
+  *) echo "error: --forge must be one of github or gitlab (got '$FORGE'); omit it to auto-detect from the project's origin remote" >&2; exit 1 ;;
+esac
 ID=${POS[0]}
 
 if [ "$KIND" = secondmate ] && [ "$HERDR_LAB" -eq 1 ]; then
   echo "error: --herdr-lab applies only to crewmate ship or scout briefs" >&2
+  exit 1
+fi
+if [ "$KIND" = secondmate ] && [ "$FORGE_SET" -eq 1 ]; then
+  echo "error: --forge applies only to crewmate ship or scout briefs; a secondmate charter is forge-neutral" >&2
   exit 1
 fi
 
@@ -266,6 +289,58 @@ fi
 
 REPO=${POS[1]}
 
+# Forge vocabulary for generated briefs: --forge is the explicit mechanism,
+# and a missing flag falls back to best-effort detection from the project's
+# clone under $FM_HOME/projects/<repo-name>. Detection never guesses: an
+# unrecognized or missing origin scaffolds forge-neutral wording and warns
+# loudly at scaffold time, so a self-hosted GitLab host without "gitlab" in
+# its name is a supported outcome rather than a silent mis-flag.
+if [ "$FORGE" = auto ]; then
+  FORGE_ORIGIN=
+  if [ -d "$FM_HOME/projects/$REPO" ] && \
+     git -C "$FM_HOME/projects/$REPO" rev-parse --git-dir >/dev/null 2>&1; then
+    FORGE_ORIGIN=$(git -C "$FM_HOME/projects/$REPO" remote get-url origin 2>/dev/null || true)
+  fi
+  if [ -n "$FORGE_ORIGIN" ]; then
+    ORIGIN_HOST=$(printf '%s\n' "$FORGE_ORIGIN" | sed -e 's#^[a-zA-Z][a-zA-Z0-9+.-]*://##' -e 's#^[^/]*@##' -e 's#[:/].*##')
+    case "$ORIGIN_HOST" in
+      github.com) FORGE=github ;;
+      *gitlab*) FORGE=gitlab ;;
+      *) FORGE=unknown ;;
+    esac
+  else
+    ORIGIN_HOST=
+    FORGE=unknown
+  fi
+  if [ "$FORGE" = unknown ]; then
+    if [ -n "$FORGE_ORIGIN" ]; then
+      echo "warning: could not detect forge for '$REPO' from origin '$FORGE_ORIGIN' (host '${ORIGIN_HOST:-?}'); scaffolded forge-neutral wording - pass --forge <github|gitlab> to choose" >&2
+    else
+      echo "warning: no origin remote found for '$REPO' at ${FM_HOME}/projects/$REPO; scaffolded forge-neutral wording - pass --forge <github|gitlab> to choose" >&2
+    fi
+  fi
+fi
+case "$FORGE" in
+  github)
+    FORGE_CLI='gh-axi'
+    FORGE_PR='PR'
+    FORGE_PR_SHORT='PR'
+    FORGE_RULE3='Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.'
+    ;;
+  gitlab)
+    FORGE_CLI='glab'
+    FORGE_PR='merge request'
+    FORGE_PR_SHORT='MR'
+    FORGE_RULE3='Use glab for GitLab operations and chrome-devtools-axi for browser operations.'
+    ;;
+  *)
+    FORGE_CLI='your forge CLI'
+    FORGE_PR='PR/MR'
+    FORGE_PR_SHORT='PR/MR'
+    FORGE_RULE3='Use your forge CLI (gh-axi on GitHub, glab on GitLab) for forge operations and chrome-devtools-axi for browser operations.'
+    ;;
+esac
+
 if [ "$HERDR_LAB" -eq 1 ]; then
 HERDR_LAB_HELPER=$(shell_quote "$FM_ROOT/bin/fm-herdr-lab.sh")
 # shellcheck disable=SC2016  # single quotes are deliberate: these lines are literal brief text whose backtick-wrapped $(...) and "$HERDR_LAB_SESSION" snippets must reach the reading agent verbatim, not expand at scaffold time; only the '"$VAR"' break-outs interpolate.
@@ -309,14 +384,14 @@ $HERDR_SECTION
 
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
-This is a SCOUT task: the deliverable is a written report, not a PR.
+This is a SCOUT task: the deliverable is a written report, not a $FORGE_PR.
 The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
 The report is the only thing that survives, so anything worth keeping must be in it.
 
 # Rules
-1. Never push to any remote and never open a PR.
+1. Never push to any remote and never open a $FORGE_PR.
 2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
-3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+3. $FORGE_RULE3
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
@@ -354,24 +429,24 @@ fi
 case "$MODE" in
   direct-PR)
     SETUP2=""
-    RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
+    RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a '"$FORGE_PR"'.'
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 Delivery contract: mode=direct-PR
-This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
+This task ships **direct-PR**: you raise the $FORGE_PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
-When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
-Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
+When it is implemented and committed, push your branch and open a $FORGE_PR with \`$FORGE_CLI\`, then append \`done: $FORGE_PR_SHORT {url}\` to the status file and stop.
+Do NOT run /no-mistakes. The configured merge authority decides whether to merge the $FORGE_PR; firstmate relays the outcome.
 EOF
     ;;
   local-only)
     SETUP2=""
-    RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
+    RULE1="1. Never push to any remote and never open a $FORGE_PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 Delivery contract: mode=local-only
-This task ships **local-only**: no remote, no PR, no pipeline.
-The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
+This task ships **local-only**: no remote, no $FORGE_PR_SHORT, no pipeline.
+The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a $FORGE_PR, do NOT merge.
 Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
 When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
 The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
@@ -380,13 +455,13 @@ EOF
   *)  # no-mistakes
     SETUP2="
 2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
-    RULE1='1. Never push to the default branch. Never merge a PR.'
+    RULE1='1. Never push to the default branch. Never merge a '"$FORGE_PR"'.'
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 Delivery contract: mode=no-mistakes
 The task is complete only when committed on your branch.
 When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+Firstmate will then instruct you to run /no-mistakes to validate and ship a $FORGE_PR.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
@@ -399,7 +474,7 @@ Two firstmate-specific rules layer on top of that guidance:
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
 - Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
 
-After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
+After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: $FORGE_PR_SHORT {url} checks green\` and stop. You are finished.
 EOF
     ;;
 esac
@@ -429,7 +504,7 @@ If the top-level path is the primary checkout or not the worktree you were launc
 # Rules
 $RULE1
 2. Stay inside this worktree; modify nothing outside it.
-3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+3. $FORGE_RULE3
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -245,6 +245,7 @@ log_reports_ci_ready() {
   [ "$LOG_VERB" = "done" ] || return 1
   case "$(status_line_note "$LOG_LINE")" in
     *PR*"checks green"*|*"checks green"*PR*) return 0 ;;
+    *MR*"checks green"*|*"checks green"*MR*) return 0 ;;
     *) return 1 ;;
   esac
 }

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -240,7 +240,7 @@ missing --mode||ship briefs require --mode
 empty --mode value|--mode|requires a value
 unknown mode value|--mode nope|must be one of no-mistakes, direct-PR, local-only
 conditional policy is not a task mode|--mode no-mistakes-prod-only|classify this task's surface
-invalid forge value|brief-refused-b5 some-proj --mode direct-PR --forge bitbucket|--forge must be one of github or gitlab
+invalid forge value|--mode direct-PR --forge bitbucket|--forge must be one of github or gitlab
 internal auto sentinel is not a user value|--mode direct-PR --forge auto|--forge must be one of github or gitlab
 internal auto sentinel is not a user value with =|--mode direct-PR --forge=auto|--forge must be one of github or gitlab
 forge on a secondmate charter|brief-refused-b6 --secondmate --no-projects --forge github|--forge applies only to crewmate ship or scout briefs
@@ -290,6 +290,7 @@ yolo on a ship brief|brief-refused-b1 some-proj --mode direct-PR --yolo on|--yol
 yolo=value form on a ship brief|brief-refused-b2 some-proj --mode direct-PR --yolo=off|--yolo is not a brief input
 mode on a scout brief|brief-refused-b3 some-proj --scout --mode direct-PR|--mode applies only to ship briefs
 mode on a secondmate charter|brief-refused-b4 --secondmate --no-projects --mode no-mistakes|--mode applies only to ship briefs
+forge on a secondmate charter|brief-refused-b5 --secondmate --no-projects --forge github|--forge applies only to crewmate ship or scout briefs
 ROWS
   pass "fm-brief.sh: --yolo and scout/secondmate --mode are refused, never silently dropped"
 }
@@ -834,6 +835,25 @@ test_forge_auto_detection() {
     || fail "explicit --forge should override auto-detection"
   assert_grep "open a merge request with \`glab\`" "$home/data/det-flag-a5/brief.md" \
     "explicit --forge gitlab was overridden by github-host detection"
+
+  # Homes whose clones live elsewhere via FM_PROJECTS_OVERRIDE must detect from
+  # that directory, like every other script that resolves project clones.
+  local elsewhere
+  elsewhere="$TMP_ROOT/forge-elsewhere-clones"
+  mkdir -p "$elsewhere"
+  git init -q -b main "$elsewhere/gl-elsewhere"
+  git -C "$elsewhere/gl-elsewhere" remote add origin https://gitlab.example.com/team/widgets.git
+  out=$(FM_HOME="$home" FM_PROJECTS_OVERRIDE="$elsewhere" "$ROOT/bin/fm-brief.sh" det-override-a6 gl-elsewhere --mode direct-PR 2>&1); status=$?
+  expect_code 0 "$status" "overridden projects dir should scaffold"
+  assert_not_contains "$out" "no origin remote found" \
+    "overridden projects dir was ignored and warned about a missing clone"
+  assert_grep "open a merge request with \`glab\`" "$home/data/det-override-a6/brief.md" \
+    "overridden projects dir did not auto-select gitlab vocabulary"
+  # The warning must name the directory actually searched, not the default one.
+  out=$(FM_HOME="$home" FM_PROJECTS_OVERRIDE="$elsewhere" "$ROOT/bin/fm-brief.sh" det-override-a7 ghost-proj --mode direct-PR 2>&1); status=$?
+  expect_code 0 "$status" "overridden projects dir missing clone should still scaffold"
+  assert_contains "$out" "$elsewhere/ghost-proj" \
+    "missing-clone warning pointed at a directory that holds no clones"
 
   # A projects/<repo> directory that is not the clone's own root must not inherit
   # the enclosing repo's origin. FM_HOME defaults to the firstmate checkout, so a

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -241,6 +241,8 @@ empty --mode value|--mode|requires a value
 unknown mode value|--mode nope|must be one of no-mistakes, direct-PR, local-only
 conditional policy is not a task mode|--mode no-mistakes-prod-only|classify this task's surface
 invalid forge value|brief-refused-b5 some-proj --mode direct-PR --forge bitbucket|--forge must be one of github or gitlab
+internal auto sentinel is not a user value|--mode direct-PR --forge auto|--forge must be one of github or gitlab
+internal auto sentinel is not a user value with =|--mode direct-PR --forge=auto|--forge must be one of github or gitlab
 forge on a secondmate charter|brief-refused-b6 --secondmate --no-projects --forge github|--forge applies only to crewmate ship or scout briefs
 ROWS
   pass "fm-brief.sh: ship --mode is required and closed-set validated"
@@ -832,6 +834,25 @@ test_forge_auto_detection() {
     || fail "explicit --forge should override auto-detection"
   assert_grep "open a merge request with \`glab\`" "$home/data/det-flag-a5/brief.md" \
     "explicit --forge gitlab was overridden by github-host detection"
+
+  # A projects/<repo> directory that is not the clone's own root must not inherit
+  # the enclosing repo's origin. FM_HOME defaults to the firstmate checkout, so a
+  # placeholder or interrupted clone would otherwise report firstmate's own
+  # github.com origin and silently mis-flag a GitLab project as GitHub.
+  local enclosing
+  enclosing="$TMP_ROOT/forge-enclosing-home"
+  mkdir -p "$enclosing/data" "$enclosing/projects/placeholder-proj"
+  git init -q -b main "$enclosing"
+  git -C "$enclosing" remote add origin https://github.com/acme/firstmate.git
+  out=$(FM_HOME="$enclosing" "$ROOT/bin/fm-brief.sh" det-enclosing-a6 placeholder-proj --mode direct-PR 2>&1); status=$?
+  expect_code 0 "$status" "non-clone project directory should still scaffold"
+  assert_contains "$out" "no origin remote found" \
+    "non-clone project directory did not warn loudly"
+  brief="$enclosing/data/det-enclosing-a6/brief.md"
+  assert_grep "open a PR/MR with \`your forge CLI\`" "$brief" \
+    "non-clone project directory inherited the enclosing repo's forge instead of staying neutral"
+  assert_grep "3. Use your forge CLI" "$brief" \
+    "non-clone project directory neutral brief lost the neutral forge rule"
   pass "fm-brief.sh: forge auto-detection covers github, gitlab, unknown, and missing clones"
 }
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -240,6 +240,8 @@ missing --mode||ship briefs require --mode
 empty --mode value|--mode|requires a value
 unknown mode value|--mode nope|must be one of no-mistakes, direct-PR, local-only
 conditional policy is not a task mode|--mode no-mistakes-prod-only|classify this task's surface
+invalid forge value|brief-refused-b5 some-proj --mode direct-PR --forge bitbucket|--forge must be one of github or gitlab
+forge on a secondmate charter|brief-refused-b6 --secondmate --no-projects --forge github|--forge applies only to crewmate ship or scout briefs
 ROWS
   pass "fm-brief.sh: ship --mode is required and closed-set validated"
 }
@@ -295,7 +297,7 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
   home="$TMP_ROOT/configured-authority-home"
   write_registry "$home"
   id="brief-direct-authority-a4"
-  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" direct-proj --mode direct-PR >/dev/null 2>&1
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" direct-proj --mode direct-PR --forge github >/dev/null 2>&1
   brief="$home/data/$id/brief.md"
   assert_grep "The configured merge authority decides whether to merge the PR; firstmate relays the outcome." "$brief" \
     "direct-PR brief lost configured merge authority"
@@ -313,7 +315,7 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
   assert_no_grep "make \`--intent\` preserve all relevant content from this brief" "$home/data/$id/brief.md" \
     "local-only brief must not include the no-mistakes --intent contract"
   id="brief-direct-intent-a4"
-  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" direct-proj --mode direct-PR >/dev/null 2>&1
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" direct-proj --mode direct-PR --forge github >/dev/null 2>&1
   assert_no_grep "make \`--intent\` preserve all relevant content from this brief" "$home/data/$id/brief.md" \
     "direct-PR brief must not include the no-mistakes --intent contract"
   pass "fm-brief.sh: faster paths use configured authority without stacked review"
@@ -710,6 +712,129 @@ test_scout_and_secondmate_scaffold() {
   pass "fm-brief: scout and secondmate code paths still scaffold well-formed briefs"
 }
 
+# Forge-aware generated briefs: --forge selects the CLI and PR/MR vocabulary in
+# crewmate ship and scout briefs, so a GitLab-hosted project stops needing
+# per-dispatch hand-edits of the gh-axi/PR wording.
+test_forge_flag_selects_vocabulary() {
+  local home id brief
+  home="$TMP_ROOT/forge-flag-home"
+  mkdir -p "$home/data"
+
+  # --forge github renders the historical gh-axi/PR wording, with no glab.
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" forge-gh-ship gh-proj --mode direct-PR --forge github >/dev/null 2>&1 \
+    || fail "github-forge ship brief should scaffold"
+  brief="$home/data/forge-gh-ship/brief.md"
+  assert_grep "3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations." "$brief" \
+    "github-forge ship brief lost the gh-axi rule"
+  assert_grep "open a PR with \`gh-axi\`, then append \`done: PR {url}\`" "$brief" \
+    "github-forge ship brief lost the gh-axi PR-opening instruction"
+  assert_grep "Never merge a PR." "$brief" \
+    "github-forge ship brief lost the PR merge rule"
+  assert_no_grep "glab" "$brief" \
+    "github-forge ship brief leaked glab wording"
+
+  # --forge gitlab renders glab/merge-request wording and no gh-axi.
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" forge-gl-ship gl-proj --mode direct-PR --forge gitlab >/dev/null 2>&1 \
+    || fail "gitlab-forge ship brief should scaffold"
+  brief="$home/data/forge-gl-ship/brief.md"
+  assert_grep "3. Use glab for GitLab operations and chrome-devtools-axi for browser operations." "$brief" \
+    "gitlab-forge ship brief lost the glab rule"
+  assert_grep "open a merge request with \`glab\`, then append \`done: MR {url}\`" "$brief" \
+    "gitlab-forge ship brief lost the glab merge-request instruction"
+  assert_grep "Never merge a merge request." "$brief" \
+    "gitlab-forge ship brief lost the merge-request merge rule"
+  assert_no_grep "gh-axi" "$brief" \
+    "gitlab-forge ship brief leaked gh-axi wording"
+
+  # no-mistakes mode carries the same forge vocabulary.
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" forge-gl-nm gl-proj --mode no-mistakes --forge gitlab >/dev/null 2>&1 \
+    || fail "gitlab-forge no-mistakes brief should scaffold"
+  brief="$home/data/forge-gl-nm/brief.md"
+  assert_grep "validate and ship a merge request" "$brief" \
+    "gitlab-forge no-mistakes brief kept PR wording in the ship instruction"
+  assert_grep "append \`done: MR {url} checks green\`" "$brief" \
+    "gitlab-forge no-mistakes brief kept PR wording in the done gate"
+  assert_no_grep "gh-axi" "$brief" \
+    "gitlab-forge no-mistakes brief leaked gh-axi wording"
+
+  # Scout briefs adopt the same vocabulary.
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" forge-gl-scout gl-proj --scout --forge gitlab >/dev/null 2>&1 \
+    || fail "gitlab-forge scout brief should scaffold"
+  brief="$home/data/forge-gl-scout/brief.md"
+  assert_grep "never open a merge request" "$brief" \
+    "gitlab-forge scout brief lost the merge-request push rule"
+  assert_grep "written report, not a merge request" "$brief" \
+    "gitlab-forge scout brief lost the merge-request deliverable wording"
+  assert_no_grep "gh-axi" "$brief" \
+    "gitlab-forge scout brief leaked gh-axi wording"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" forge-gh-scout gh-proj --scout --forge github >/dev/null 2>&1 \
+    || fail "github-forge scout brief should scaffold"
+  assert_grep "written report, not a PR." "$home/data/forge-gh-scout/brief.md" \
+    "github-forge scout brief lost the PR deliverable wording"
+  pass "fm-brief.sh: --forge selects github or gitlab vocabulary in ship and scout briefs"
+}
+
+# Auto-detection reads the clone's origin remote when --forge is absent; the
+# explicit flag still wins, and an unrecognized or missing origin scaffolds
+# forge-neutral wording with a loud scaffold-time warning.
+test_forge_auto_detection() {
+  local home out status brief
+  home="$TMP_ROOT/forge-detect-home"
+  mkdir -p "$home/data" "$home/projects"
+
+  # github.com origin -> github vocabulary.
+  git init -q -b main "$home/projects/gh-detect"
+  git -C "$home/projects/gh-detect" remote add origin https://github.com/acme/widgets.git
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" det-gh-a1 gh-detect --mode direct-PR 2>&1); status=$?
+  expect_code 0 "$status" "github-origin auto-detect should scaffold"
+  assert_not_contains "$out" "could not detect forge" \
+    "github origin auto-detect warned despite a recognizable host"
+  brief="$home/data/det-gh-a1/brief.md"
+  assert_grep "open a PR with \`gh-axi\`" "$brief" \
+    "github origin did not auto-select github vocabulary"
+  assert_no_grep "glab" "$brief" \
+    "github origin auto-select leaked glab wording"
+
+  # gitlab.example.com origin -> gitlab vocabulary.
+  git init -q -b main "$home/projects/gl-detect"
+  git -C "$home/projects/gl-detect" remote add origin https://gitlab.example.com/team/widgets.git
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" det-gl-a2 gl-detect --mode direct-PR >/dev/null 2>&1 \
+    || fail "gitlab origin auto-detect should scaffold"
+  brief="$home/data/det-gl-a2/brief.md"
+  assert_grep "open a merge request with \`glab\`" "$brief" \
+    "gitlab origin did not auto-select gitlab vocabulary"
+  assert_no_grep "gh-axi" "$brief" \
+    "gitlab origin auto-select leaked gh-axi wording"
+
+  # Unrecognizable self-hosted host -> forge-neutral wording plus a loud note.
+  git init -q -b main "$home/projects/noc-detect"
+  git -C "$home/projects/noc-detect" remote add origin https://noc-git.orion.co.com/team/widgets.git
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" det-noc-a3 noc-detect --mode direct-PR 2>&1); status=$?
+  expect_code 0 "$status" "unrecognized host should still scaffold"
+  assert_contains "$out" "could not detect forge" "unrecognized host did not warn loudly"
+  assert_contains "$out" "--forge" "unrecognized host warning did not point at --forge"
+  brief="$home/data/det-noc-a3/brief.md"
+  assert_grep "open a PR/MR with \`your forge CLI\`" "$brief" \
+    "unrecognized host did not scaffold forge-neutral wording"
+  assert_grep "3. Use your forge CLI" "$brief" \
+    "unrecognized host neutral brief lost the neutral forge rule"
+
+  # Missing clone (no origin available) -> the same loud neutral fallback.
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" det-noclone-a4 ghost-proj --mode direct-PR 2>&1); status=$?
+  expect_code 0 "$status" "missing-clone auto-detect should still scaffold"
+  assert_contains "$out" "no origin remote found" "missing clone did not warn loudly"
+  brief="$home/data/det-noclone-a4/brief.md"
+  assert_grep "your forge CLI" "$brief" \
+    "missing clone did not scaffold forge-neutral wording"
+
+  # The explicit flag is authoritative even when detection would choose otherwise.
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" det-flag-a5 gh-detect --mode direct-PR --forge gitlab >/dev/null 2>&1 \
+    || fail "explicit --forge should override auto-detection"
+  assert_grep "open a merge request with \`glab\`" "$home/data/det-flag-a5/brief.md" \
+    "explicit --forge gitlab was overridden by github-host detection"
+  pass "fm-brief.sh: forge auto-detection covers github, gitlab, unknown, and missing clones"
+}
+
 test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
@@ -718,6 +843,8 @@ test_ship_mode_is_required_and_closed_set
 test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
+test_forge_flag_selects_vocabulary
+test_forge_auto_detection
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -457,6 +457,25 @@ test_ci_ready_done_log_beats_monitoring_run() {
   pass "ci-ready status log beats monitoring run"
 }
 
+# GitLab-hosted ship tasks report the same CI-ready signal in that forge's
+# vocabulary (`done: MR <url> checks green`, and an MR url carries no "PR"
+# substring), so reconciliation must recognize it or the finished crew stays
+# reported as working forever.
+test_ci_ready_done_log_accepts_merge_request_vocabulary() {
+  reset_fakes
+  local d; d=$(new_case ci-ready-mr)
+  make_repo_on_branch "$d/wt" fm/feat-cimr
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-cimr.meta" "window=fm:fm-feat-cimr" "worktree=$d/wt" "kind=ship"
+  printf 'done: MR https://gitlab.example.com/team/x/-/merge_requests/9 checks green\n' > "$d/state/feat-cimr.status"
+  FM_FAKE_AXI_STATUS="$(run_ci_monitoring fm/feat-cimr)"
+  local out; out=$(run_crew_state "$d" feat-cimr)
+  assert_contains "$out" "state: done" "merge-request ci-ready status log -> done"
+  assert_contains "$out" "source: status-log" "merge-request ci-ready state comes from the status log"
+  assert_not_contains "$out" "state: working" "merge-request ci-ready is not hidden by monitoring run"
+  pass "ci-ready status log accepts merge-request vocabulary"
+}
+
 # Regression for the PR #252 incident: the crew's own status log never got a
 # "done: ... checks green" line (log_reports_ci_ready above does not apply),
 # but the ci step's log tail shows CI is actually green and only waiting on
@@ -1316,6 +1335,7 @@ test_genuine_parked_not_superseded
 test_scalar_gate_parked_not_superseded
 test_gate_block_parked_not_superseded
 test_ci_ready_done_log_beats_monitoring_run
+test_ci_ready_done_log_accepts_merge_request_vocabulary
 test_ci_monitoring_checks_green_surfaces_done
 test_top_level_ci_checks_green_surfaces_done
 test_ci_monitoring_no_checks_terminal_surfaces_done


### PR DESCRIPTION
## Intent

Make bin/fm-brief.sh's generated briefs forge-aware (UPSTREAM contribution to firstmate): add optional --forge <github|gitlab> flag as the primary mechanism, with best-effort auto-detection from the project's origin remote when the flag is absent (github.com -> github; a hostname containing gitlab -> gitlab; anything else -> forge-neutral wording plus a loud scaffold-time note, because self-hosted GitLab often has no 'gitlab' in the hostname). Extend the existing tests/ pattern for the flag, auto-detection, and invalid-value refusal. Documentation updated. REDELIVERY ONLY: implementation already fully validated on this exact head; do not change implementation code, run the pipeline so its delivery step pushes the fork and raises or updates the PR with the deterministic Pipeline body.

## What Changed

- `bin/fm-brief.sh` accepts an optional `--forge <github|gitlab>` flag that drives the forge vocabulary in generated ship and scout briefs (`gh-axi`/"PR" vs `glab`/"merge request"/"MR"), refuses any other value, and refuses the flag entirely on `--secondmate` charters, which stay forge-neutral.
- When the flag is absent, the forge is detected best-effort from the origin remote of the project clone at `$FM_HOME/projects/<repo>` (honoring `FM_PROJECTS_OVERRIDE`), counting the directory only when it is the clone's own root so an enclosing repo's origin is never inherited; `github.com` maps to github, a host containing `gitlab` to gitlab, and anything else scaffolds forge-neutral wording ("your forge CLI", "PR/MR") plus a scaffold-time warning naming the origin and host.
- `bin/fm-crew-state.sh` now treats a `done: MR <url> checks green` status line as CI-ready alongside the `PR` form, so a GitLab crew's ready signal is not dropped; `tests/fm-brief.test.sh` and `tests/fm-crew-state.test.sh` cover flag vocabulary, flag-over-detection precedence, github/gitlab/unrecognized-host detection, clone-root scoping, invalid-value refusal, and the MR ready signal, and AGENTS.md documents the MR vocabulary and the re-scaffold-on-warning rule.

## Risk Assessment

✅ Low: The change is well-bounded string-vocabulary parameterization with a fail-safe detection path (unrecognized or non-root clone degrades to neutral wording plus a loud warning rather than mis-flagging), the one behavior consumer (log_reports_ci_ready) was updated, and the new tests exercise the real scripts and assert on generated output rather than source text.

## Testing

I ran the two targeted suites that own this behavior, tests/fm-brief.test.sh and tests/fm-crew-state.test.sh, and both pass in full including the newly added forge-flag, auto-detection, refusal, and merge-request CI-ready cases. On top of that I exercised the scaffolder the way a firstmate operator would: a temporary firstmate home with three real clones whose origins point at github.com, a gitlab.example.com host, and an unrecognizable self-hosted host, then scaffolded ship and scout briefs with and without --forge. GitHub auto-detection produced the historical gh-axi/PR wording silently, GitLab auto-detection produced glab and merge-request wording, the self-hosted host printed the loud scaffold-time warning and produced forge-neutral wording, the explicit flag beat detection, and both invalid-value and secondmate-charter uses were refused with exit 1. Evidence is the captured CLI transcript, the four generated brief.md files, and a unified diff of the GitHub versus GitLab briefs; this change has no rendered UI surface, so screenshots do not apply and the generated brief markdown is the actual end-user artifact. The scratch demo home was deleted afterward and the worktree is clean.

<details>
<summary>Evidence: CLI transcript: forge-aware scaffolding across GitHub, GitLab, self-hosted, explicit flag, and refusals</summary>

Source: [CLI transcript: forge-aware scaffolding across GitHub, GitLab, self-hosted, explicit flag, and refusals](https://github.com/tieptoi/firstmate/blob/d24b89f228599c8ace0943775c673bccfdc21e0b/.no-mistakes/evidence/fm/firstmate-brief-forge-awareness/forge-scaffold-transcript.txt)

<code>$ bin/fm-brief.sh gh-auto gh-widgets --mode direct-PR&#10;scaffolded: .../data/gh-auto/brief.md (ship, mode=direct-PR; replace {TASK})&#10;&#10;$ bin/fm-brief.sh gl-auto gl-widgets --mode direct-PR&#10;scaffolded: .../data/gl-auto/brief.md (ship, mode=direct-PR; replace {TASK})&#10;&#10;$ bin/fm-brief.sh selfhosted-auto selfhosted-widgets --mode direct-PR&#10;warning: could not detect forge for &#39;selfhosted-widgets&#39; from origin &#39;https://noc-git.orion.co.com/team/widgets.git&#39; (host &#39;noc-git.orion.co.com&#39;); scaffolded forge-neutral wording - pass --forge &lt;github|gitlab&gt; to choose&#10;scaffolded: .../data/selfhosted-auto/brief.md (ship, mode=direct-PR; replace {TASK})&#10;&#10;$ bin/fm-brief.sh gl-explicit gh-widgets --mode direct-PR --forge gitlab&#10;scaffolded: .../data/gl-explicit/brief.md (ship, mode=direct-PR; replace {TASK})&#10;&#10;$ bin/fm-brief.sh gl-scout gl-widgets --scout&#10;scaffolded: .../data/gl-scout/brief.md (scout; replace {TASK})&#10;&#10;$ bin/fm-brief.sh bad-forge gh-widgets --mode direct-PR --forge bitbucket&#10;error: --forge must be one of github or gitlab (got &#39;bitbucket&#39;); omit it to auto-detect from the project&#39;s origin remote&#10;exit=1&#10;&#10;$ bin/fm-brief.sh charter-x --secondmate gl-widgets --forge gitlab&#10;error: --forge applies only to crewmate ship or scout briefs; a secondmate charter is forge-neutral&#10;exit=1</code>

```text
$ bin/fm-brief.sh gh-auto gh-widgets --mode direct-PR
scaffolded: /tmp/fm-forge-demo/fm-home/data/gh-auto/brief.md (ship, mode=direct-PR; replace {TASK})

$ bin/fm-brief.sh gl-auto gl-widgets --mode direct-PR
scaffolded: /tmp/fm-forge-demo/fm-home/data/gl-auto/brief.md (ship, mode=direct-PR; replace {TASK})

$ bin/fm-brief.sh selfhosted-auto selfhosted-widgets --mode direct-PR
warning: could not detect forge for 'selfhosted-widgets' from origin 'https://noc-git.orion.co.com/team/widgets.git' (host 'noc-git.orion.co.com'); scaffolded forge-neutral wording - pass --forge <github|gitlab> to choose
scaffolded: /tmp/fm-forge-demo/fm-home/data/selfhosted-auto/brief.md (ship, mode=direct-PR; replace {TASK})

$ bin/fm-brief.sh gl-explicit gh-widgets --mode direct-PR --forge gitlab
scaffolded: /tmp/fm-forge-demo/fm-home/data/gl-explicit/brief.md (ship, mode=direct-PR; replace {TASK})

$ bin/fm-brief.sh gl-scout gl-widgets --scout
scaffolded: /tmp/fm-forge-demo/fm-home/data/gl-scout/brief.md (scout; replace {TASK})

$ bin/fm-brief.sh bad-forge gh-widgets --mode direct-PR --forge bitbucket
error: --forge must be one of github or gitlab (got 'bitbucket'); omit it to auto-detect from the project's origin remote
exit=1

$ bin/fm-brief.sh charter-x --secondmate gl-widgets --forge gitlab
error: --forge applies only to crewmate ship or scout briefs; a secondmate charter is forge-neutral
exit=1
```
</details>
<details>
<summary>Evidence: Generated brief diff: GitHub-detected vs GitLab-detected vocabulary</summary>

Source: [Generated brief diff: GitHub-detected vs GitLab-detected vocabulary](https://github.com/tieptoi/firstmate/blob/d24b89f228599c8ace0943775c673bccfdc21e0b/.no-mistakes/evidence/fm/firstmate-brief-forge-awareness/brief-github-vs-gitlab.diff)

<code>-1. Never push to the default branch (push only your `fm/gh-auto` branch). Never merge a PR.&#10;+1. Never push to the default branch (push only your `fm/gl-auto` branch). Never merge a merge request.&#10;-3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.&#10;+3. Use glab for GitLab operations and chrome-devtools-axi for browser operations.&#10;-This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.&#10;+This task ships **direct-PR**: you raise the merge request yourself, without the no-mistakes pipeline.&#10;-When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.&#10;+When it is implemented and committed, push your branch and open a merge request with `glab`, then append `done: MR {url}` to the status file and stop.</code>

```text
--- /tmp/fm-forge-demo/fm-home/data/gh-auto/brief.md	2026-08-17 22:14:07
+++ /tmp/fm-forge-demo/fm-home/data/gl-auto/brief.md	2026-08-17 22:14:08
@@ -9,20 +9,20 @@
 Do not add Herdr lifecycle commands to this unguarded brief by hand.
 
 # Setup
-You are in a disposable git worktree of gh-widgets, at a detached HEAD on a clean default branch.
+You are in a disposable git worktree of gl-widgets, at a detached HEAD on a clean default branch.
 
 **Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
 The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
 If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.
 
-1. First action: create your branch: `git checkout -b fm/gh-auto`
+1. First action: create your branch: `git checkout -b fm/gl-auto`
 
 # Rules
-1. Never push to the default branch (push only your `fm/gh-auto` branch). Never merge a PR.
+1. Never push to the default branch (push only your `fm/gl-auto` branch). Never merge a merge request.
 2. Stay inside this worktree; modify nothing outside it.
-3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+3. Use glab for GitLab operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
-   `echo "{state}: {one short line}" >> '/tmp/fm-forge-demo/fm-home/state/gh-auto.status'`
+   `echo "{state}: {one short line}" >> '/tmp/fm-forge-demo/fm-home/state/gl-auto.status'`
    States: working, needs-decision, blocked, paused, done, failed.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
    would act on (setup done, bug reproduced, fix implemented, validation passed) and the
@@ -52,7 +52,7 @@
 
 # Definition of done
 Delivery contract: mode=direct-PR
-This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
+This task ships **direct-PR**: you raise the merge request yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
-When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
-Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
+When it is implemented and committed, push your branch and open a merge request with `glab`, then append `done: MR {url}` to the status file and stop.
+Do NOT run /no-mistakes. The configured merge authority decides whether to merge the merge request; firstmate relays the outcome.
```
</details>
<details>
<summary>Evidence: Generated brief: GitHub auto-detected (ship, direct-PR)</summary>

Source: [Generated brief: GitHub auto-detected (ship, direct-PR)](https://github.com/tieptoi/firstmate/blob/d24b89f228599c8ace0943775c673bccfdc21e0b/.no-mistakes/evidence/fm/firstmate-brief-forge-awareness/brief-github-autodetected.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of gh-widgets, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/gh-auto`

# Rules
1. Never push to the default branch (push only your `fm/gh-auto` branch). Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/fm-forge-demo/fm-home/state/gh-auto.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/gary.nguyen/.no-mistakes/worktrees/a05ac19388ac/01M07Y093AD18RG8MHW2FFDZR8/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/gary.nguyen/.no-mistakes/worktrees/a05ac19388ac/01M07Y093AD18RG8MHW2FFDZR8/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=direct-PR
This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
```
</details>
<details>
<summary>Evidence: Generated brief: GitLab auto-detected (ship, direct-PR)</summary>

Source: [Generated brief: GitLab auto-detected (ship, direct-PR)](https://github.com/tieptoi/firstmate/blob/d24b89f228599c8ace0943775c673bccfdc21e0b/.no-mistakes/evidence/fm/firstmate-brief-forge-awareness/brief-gitlab-autodetected.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of gl-widgets, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/gl-auto`

# Rules
1. Never push to the default branch (push only your `fm/gl-auto` branch). Never merge a merge request.
2. Stay inside this worktree; modify nothing outside it.
3. Use glab for GitLab operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/fm-forge-demo/fm-home/state/gl-auto.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/gary.nguyen/.no-mistakes/worktrees/a05ac19388ac/01M07Y093AD18RG8MHW2FFDZR8/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/gary.nguyen/.no-mistakes/worktrees/a05ac19388ac/01M07Y093AD18RG8MHW2FFDZR8/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=direct-PR
This task ships **direct-PR**: you raise the merge request yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch and open a merge request with `glab`, then append `done: MR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the merge request; firstmate relays the outcome.
```
</details>
<details>
<summary>Evidence: Generated brief: unrecognized self-hosted host, forge-neutral wording</summary>

Source: [Generated brief: unrecognized self-hosted host, forge-neutral wording](https://github.com/tieptoi/firstmate/blob/d24b89f228599c8ace0943775c673bccfdc21e0b/.no-mistakes/evidence/fm/firstmate-brief-forge-awareness/brief-selfhosted-neutral.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of selfhosted-widgets, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/selfhosted-auto`

# Rules
1. Never push to the default branch (push only your `fm/selfhosted-auto` branch). Never merge a PR/MR.
2. Stay inside this worktree; modify nothing outside it.
3. Use your forge CLI (gh-axi on GitHub, glab on GitLab) for forge operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/fm-forge-demo/fm-home/state/selfhosted-auto.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/gary.nguyen/.no-mistakes/worktrees/a05ac19388ac/01M07Y093AD18RG8MHW2FFDZR8/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/gary.nguyen/.no-mistakes/worktrees/a05ac19388ac/01M07Y093AD18RG8MHW2FFDZR8/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=direct-PR
This task ships **direct-PR**: you raise the PR/MR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch and open a PR/MR with `your forge CLI`, then append `done: PR/MR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR/MR; firstmate relays the outcome.
```
</details>
<details>
<summary>Evidence: Generated brief: GitLab scout contract</summary>

Source: [Generated brief: GitLab scout contract](https://github.com/tieptoi/firstmate/blob/d24b89f228599c8ace0943775c673bccfdc21e0b/.no-mistakes/evidence/fm/firstmate-brief-forge-awareness/brief-gitlab-scout.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of gl-widgets, at a detached HEAD on a clean default branch.
This is a SCOUT task: the deliverable is a written report, not a merge request.
The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
The report is the only thing that survives, so anything worth keeping must be in it.

# Rules
1. Never push to any remote and never open a merge request.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use glab for GitLab operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/fm-forge-demo/fm-home/state/gl-scout.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
   FYI progress lines; firstmate reads your pane for that.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
   firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
   treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Definition of done
Write your findings to `/tmp/fm-forge-demo/fm-home/data/gl-scout/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
Before reporting done, read and follow `/Users/gary.nguyen/.no-mistakes/worktrees/a05ac19388ac/01M07Y093AD18RG8MHW2FFDZR8/.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2e75307efb7cbc9da10c7553e9788d4be3c59fc8","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-classify-lib.sh:49` - The forge vocabulary was widened in fm-crew-state.sh (MR accepted alongside PR for the CI-ready done line), but FM_CLASSIFY_CAPTAIN_RE_DEFAULT still carries only the GitHub free-text token &#39;PR ready&#39; with no &#39;MR ready&#39; counterpart. A GitLab crew that writes the legacy bare form &#39;MR ready&#39; (no leading verb) is therefore not captain-relevant, while &#39;PR ready&#39; is. Reachability is narrow: generated briefs only ever instruct verb-prefixed lines (&#39;done: MR {url} ...&#39;), which status_is_captain_relevant already matches via the done verb, so no scaffolded path hits this. Flagging it only because AGENTS.md now states broadly that firstmate&#39;s reconciliation reads either token; adding &#39;MR ready&#39; to the free-text token list would make that claim hold for the legacy form too. Intent says redelivery-only with no implementation changes, so this is for the author to decide, not to fix here.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`./tests/fm-brief.test.sh` - all cases pass, including new `test_forge_flag_selects_vocabulary` and `test_forge_auto_detection`</code>
- <code>`./tests/fm-crew-state.test.sh` - all cases pass, including new `ci-ready status log accepts merge-request vocabulary`</code>
- <code>Manual scaffold in a temp firstmate home with three real clones: `FM_HOME=... bin/fm-brief.sh gh-auto gh-widgets --mode direct-PR` (github.com origin -&gt; gh-axi/PR, no warning)</code>
- <code>`bin/fm-brief.sh gl-auto gl-widgets --mode direct-PR` (gitlab.example.com origin -&gt; glab/merge request)</code>
- <code>`bin/fm-brief.sh selfhosted-auto selfhosted-widgets --mode direct-PR` (noc-git.orion.co.com origin -&gt; loud warning plus forge-neutral `your forge CLI` / `PR/MR` wording)</code>
- <code>`bin/fm-brief.sh gl-explicit gh-widgets --mode direct-PR --forge gitlab` (explicit flag overrides github detection)</code>
- <code>`bin/fm-brief.sh gl-scout gl-widgets --scout` (scout brief adopts merge-request vocabulary)</code>
- <code>`bin/fm-brief.sh bad-forge gh-widgets --mode direct-PR --forge bitbucket` (exit 1, closed-set refusal)</code>
- <code>`bin/fm-brief.sh charter-x --secondmate gl-widgets --forge gitlab` (exit 1, charters stay forge-neutral)</code>
- <code>`diff -u` of the generated GitHub vs GitLab briefs to show the vocabulary swap in the real generated output</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/configuration.md:296` - A GitLab-vocabulary brief now instructs the crewmate to use `glab`, but `glab` appears in no operator-facing tool list: docs/configuration.md&#39;s Toolchain section declares itself &#34;the single owner of that universal toolchain list&#34; and names only gh/gh-axi for forge operations, and the only other glab mention is docs/gitlab-merge-watch.md (maintainer-verification, where `fm-pr-check.sh` errors with &#34;watching a GitLab merge request requires glab on PATH&#34;). That precedent says glab is a conditional per-project tool rather than a universal one, so nothing is factually wrong today - but an operator running a GitLab-hosted project has no documented place telling them to install it. Left unedited because stating a requirement bootstrap does not enforce would be a new, unverified claim; the right fix is either a one-sentence conditional-tool note in the Toolchain section or a bootstrap-side requirement, which is implementation scope this redelivery forbids.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

## Follow-up candidates

- `bin/fm-classify-lib.sh` (`classify-mr-freetext-token`, info): `FM_CLASSIFY_CAPTAIN_RE_DEFAULT` still carries only the GitHub free-text token `PR ready`; no `MR ready` counterpart. Not hit by any scaffolded path (briefs only instruct verb-prefixed lines, matched via the done verb), but a GitLab crew writing the legacy bare form would not be captain-relevant.
- `docs/configuration.md` (`document-1`, info): Toolchain section (self-declared single owner of the universal toolchain list) names only `gh`/`gh-axi` for forge operations; GitLab-vocabulary briefs now instruct crewmates to use `glab`, documented elsewhere only as a conditional per-project tool. Candidate: one-sentence conditional-tool note or bootstrap-side requirement.
- `.github/workflows/no-mistakes-required.yml` live-body guard: the guard currently evaluates the PR body captured in the triggering event payload, so a pipeline-raised PR whose body gains its `## Pipeline` signature only after creation can be judged on a stale marker-less snapshot. In-tree fix prepared and tested (live body read via `gh api .../pulls/<n> --jq .body` plus `pull-requests: read`; regression test in `tests/fm-test-run.test.sh`, 18/18 pass) as pipeline head `48b6b04..58c65e8`, intentionally kept off this PR's head so the PR stays implementation-only; ship separately.