### PR TITLE
docs: herdr backend reality - pi default, treehouse/tasks-axi prereqs, scout contract

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -182,6 +182,10 @@ The helper's header owns the exact signal detection, relocated-home limitation, 
 
 Ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, or `local-only`); scout tasks leave standalone investigation reports at `data/<id>/report.md` and never push.
 The intake and authority contract in `AGENTS.md` owns when separate scout research is warranted.
+A scout is itself a firstmate task spawned with `fm-spawn.sh <id> <project-dir> --scout`.
+A scout takes no `--mode` or `--yolo`: both flags are refused because a scout delivers a report, not a project change.
+A scout runs in its own scratch worktree, `data/<id>/report.md` is its only deliverable, and cleanup discards the scratch worktree.
+That bounded blast radius also makes a scout the safe first-run pattern for a fresh backend or deployment: it exercises spawn, supervision, and cleanup end to end without touching a project.
 
 ## Dispatch profiles
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -13,6 +13,11 @@ Pick Herdr when you want native busy, idle, and blocked state and accept the exp
 Prerequisites:
 
 - Herdr protocol 14 or newer, installed from [herdr.dev](https://herdr.dev).
+- `treehouse`, the worktree provider that every session-provider backend (tmux, herdr, zellij, cmux) requires.
+  Install the SHA256-pinned build with `bin/fm-install-treehouse.sh <dest>` and keep `treehouse` on `PATH`.
+  A missing or broken install stops every spawn with `treehouse get did not enter a worktree within 60s`.
+- `tasks-axi` 0.2.4 or newer (`npm install -g tasks-axi`) for the backlog backend.
+  Without a compatible `tasks-axi`, the teardown and decision-hold completion gate refuses to close a task, and the only escape is `fm-control <id> exit` followed by `fm-teardown <id> --force`.
 - `jq` for JSON responses.
 - The universal harness and toolchain requirements in [`configuration.md`](configuration.md#toolchain).
 - `python3` only for optional protocol-16 presentation-space ordering and native event subscription.
@@ -32,6 +37,28 @@ No separate first-run provisioning is required.
 The required CI lane uses the pinned installers in `bin/fm-install-herdr.sh` and `bin/fm-install-treehouse.sh`.
 Those script headers own release assets, checksums, download bounds, and post-install gates.
 Real harness credential tests remain opt-in rather than part of default CI.
+
+Verify a fresh deployment with a scout task: it exercises spawn, supervision, and cleanup end to end, touches no project, leaves only `data/<id>/report.md`, and discards its scratch worktree at cleanup, so a first run has bounded blast radius ([`architecture.md`](architecture.md#two-task-shapes)).
+
+## Crewmate harness default
+
+firstmate-bridge pins the crewmate harness to Pi: local `config/crew-harness` holds `pi`, so crewmate and scout dispatch defaults `--harness` to pi unless an explicit per-spawn harness or a `config/crew-dispatch.json` profile overrides it.
+Pi must be runnable as `/usr/local/bin/pi` or via `PATH pi`.
+Before the first spawn, Pi's worktree-folder trust must be pre-seeded in `/config/.pi/agent/trust.json` as a flat `{"/abs/path": true}` map covering `/config/.treehouse` and every project root, or the interactive `Trust project folder?` prompt stalls every spawn.
+That pre-seed is the same class of gate as Claude's `trustedDirs` in `~/.claude.json`.
+
+## Optional pane-border agent labels
+
+To label Herdr pane borders with the agent's name, set in `/config/.config/herdr/config.toml`:
+
+```toml
+[ui]
+show_agent_labels_on_pane_borders = true
+```
+
+The toggle labels the border with the agent NAME (pi / hermes), not working-state.
+Working-state lives in the Herdr sidebar's `state_icon` column, which is default-on; press `w` inside the sidebar to filter to only working agents.
+Pane-grid activity borders are not a Herdr feature; this is the closest safe, documented toggle.
 
 ## Watching and task containers
 


### PR DESCRIPTION
## Summary

Update firstmate's tracked documentation to reflect the current Herdr/firstmate operating reality, as verified by live POC work on 2026-08-17. Edits are surgical, factual, and confined to tracked docs (no `.lavish/` or `.no-mistakes/`).

### Changes

- **docs/herdr-backend.md**:
  - `## Setup` prerequisites now name the required tools with exact install commands: `treehouse` (SHA256-pinned via `bin/fm-install-treehouse.sh <dest>`, missing => spawn fails with `treehouse get did not enter a worktree within 60s`) and `tasks-axi` >= 0.2.4 (`npm install -g tasks-axi`, missing => teardown/decision-hold completion gate refuses), alongside the existing `jq` requirement.
  - New `Crewmate harness default` section: `config/crew-harness` holds `pi`, dispatch `--harness` defaults to pi for crewmates and scouts, pi must be at `/usr/local/bin/pi` or on `PATH`, and Pi's worktree-folder trust must be pre-seeded in `/config/.pi/agent/trust.json` (flat `{"/abs/path": true}` map covering `/config/.treehouse` and project roots) or every spawn stalls on the interactive `Trust project folder?` prompt (same class of gate as Claude's `trustedDirs`).
  - New `Optional pane-border agent labels` section: the captain-side toggle `[ui] show_agent_labels_on_pane_borders = true` in `/config/.config/herdr/config.toml`; labels borders with the agent NAME, not working-state (that lives in the sidebar `state_icon`, filter key `w`).
  - Setup now points at the scout task as the safe first-run verification pattern (bounded blast radius), linking `architecture.md`.
- **docs/architecture.md** (`Two task shapes`): documents the scout task contract - `fm-spawn.sh <id> <project-dir> --scout`, no `--mode`/`--yolo` (refused), scratch worktree, `data/<id>/report.md` as the only deliverable, worktree discarded at cleanup, and the safe first-run pattern.

### Verification

- All claims checked against the repo: `treehouse get did not enter a worktree within 60s` (`bin/fm-spawn.sh`), `FM_TASKS_AXI_MIN=0.2.4` (`bin/fm-tasks-axi-lib.sh`), `--mode`/`--yolo` refusal on `--scout` (`bin/fm-spawn.sh`), and against this machine (crew-harness = pi, `/config/.pi/agent/trust.json` flat map, tasks-axi 0.2.5, `herdr config check` accepts the toggle).
- `bin/fm-doc-audience-check.sh` passes; `tests/fm-documentation-audiences.test.sh` passes.

Note: proposed doc-only change; PR raised via fork (gitricko/firstmate) since the account has no direct push access to the parent.