### PR TITLE
fix(bin): exclude the untracked CLAUDE.md pointer so it never blocks teardown

### DIFF
--- a/bin/fm-ensure-agents-md.sh
+++ b/bin/fm-ensure-agents-md.sh
@@ -18,6 +18,10 @@
 # filesystem (issue #389). The real-file pointer also eliminates the old
 # uppercase-literal-target dangling-symlink hazard that a CLAUDE.md -> AGENTS.md
 # link would have carried for that same mismatch.
+# In a git repo whose index does not track CLAUDE.md, the canonical pointer it
+# writes (or finds) is best-effort added to the repo's info/exclude so the
+# untracked pointer never blocks fm-teardown's dirty check or leaks into a
+# commit; a tracked CLAUDE.md is never excluded (see exclude_untracked_pointer).
 # This is a worktree utility for crewmates, not a supervision script, so it does
 # not call fm-guard.sh.
 # Usage: fm-ensure-agents-md.sh [repo-or-worktree-dir]
@@ -114,20 +118,53 @@ is_canonical_claude_pointer() {
   claude_pointer_content | cmp -s - "$CLAUDE"
 }
 
+# Keep the untracked canonical pointer out of git's view so it never blocks
+# fm-teardown's dirty check or leaks into a commit - the same requirement and
+# tolerant shape as fm-spawn.sh's exclude_path for worktree-resident hooks.
+# Verified empirically (git 2.50.1): inside a linked worktree,
+# `git rev-parse --git-path info/exclude` resolves to the SHARED common-dir
+# exclude (git treats info/ as a common path), and a per-worktree
+# $GIT_DIR/info/exclude is NOT honored by git at all, so a per-worktree
+# mechanism does not exist short of extensions.worktreeConfig. The shared
+# exclude is deliberate and acceptable here: the line is written only for
+# this fixed firstmate-owned filename, only while the repo does not track
+# CLAUDE.md, and only when the file present is the canonical pointer this
+# script owns; and `git add CLAUDE.md` on an excluded path refuses loudly
+# with a hint naming the exclude, so tracking it later stays discoverable.
+# Excluding is best-effort housekeeping: outside a git work tree, off the
+# repo's top level, or on any write failure, do nothing and never fail.
+exclude_untracked_pointer() {
+  local top excl
+  is_canonical_claude_pointer || return 0
+  git rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+  # The exclude pattern is anchored to the repo root, so only write it when
+  # the pointer actually lives there.
+  top=$(git rev-parse --show-toplevel 2>/dev/null) || return 0
+  [ "$top" = "$DIR" ] || return 0
+  # Never exclude a tracked path.
+  if git ls-files --error-unmatch -- "$CLAUDE" >/dev/null 2>&1; then
+    return 0
+  fi
+  excl=$(git rev-parse --git-path info/exclude 2>/dev/null) || return 0
+  [ -n "$excl" ] || return 0
+  mkdir -p "$(dirname "$excl")" 2>/dev/null || return 0
+  grep -qxF "/$CLAUDE" "$excl" 2>/dev/null || echo "/$CLAUDE" >> "$excl" || return 0
+}
+
 # Write the canonical pointer as a regular file. Unlink a symlink first so the
 # write cannot follow it and destroy AGENTS.md. Never overwrite a distinct real
 # file; callers classify that as a conflict before invoking this.
 install_claude_pointer() {
-  if is_canonical_claude_pointer; then
-    return 0
+  if ! is_canonical_claude_pointer; then
+    if [ -L "$CLAUDE" ]; then
+      rm -- "$CLAUDE"
+    elif [ -e "$CLAUDE" ]; then
+      echo "error: internal: refuse to overwrite existing CLAUDE.md" >&2
+      exit 1
+    fi
+    claude_pointer_content > "$CLAUDE"
   fi
-  if [ -L "$CLAUDE" ]; then
-    rm -- "$CLAUDE"
-  elif [ -e "$CLAUDE" ]; then
-    echo "error: internal: refuse to overwrite existing CLAUDE.md" >&2
-    exit 1
-  fi
-  claude_pointer_content > "$CLAUDE"
+  exclude_untracked_pointer
 }
 
 is_correct_claude_symlink() {
@@ -206,6 +243,7 @@ if [ -e "$AGENTS" ]; then
   if [ -f "$CLAUDE" ]; then
     if is_canonical_claude_pointer; then
       ensure_maintenance_section
+      exclude_untracked_pointer
       if [ "$MAINT_INJECTED" -eq 1 ]; then
         echo "updated: added ## Maintaining this file to AGENTS.md in $DIR"
       else
@@ -235,6 +273,7 @@ if [ -e "$CLAUDE" ]; then
   if [ -f "$CLAUDE" ]; then
     if is_canonical_claude_pointer; then
       write_skeleton
+      exclude_untracked_pointer
       echo "created: AGENTS.md and kept CLAUDE.md @AGENTS.md pointer in $DIR"
       exit 0
     fi

--- a/tests/fm-ensure-agents-md.test.sh
+++ b/tests/fm-ensure-agents-md.test.sh
@@ -353,6 +353,123 @@ test_lowercase_agents_md_refuses_case_fragile_pointer() {
   pass "fm-ensure-agents-md.sh: refuses a case-variant lowercase agents.md (issue #389)"
 }
 
+# Initialize a git repo fixture with a tracked AGENTS.md (and optionally more),
+# committing whatever is staged. Mirrors the shape that reproduced the teardown
+# refusal: a project tracking AGENTS.md but not CLAUDE.md.
+git_fixture() {
+  local repo=$1
+  mkdir -p "$repo"
+  git -C "$repo" init -q -b main || fail "git init failed for fixture $repo"
+  git -C "$repo" -c user.email=t@test -c user.name=t commit -q --allow-empty -m init \
+    || fail "git initial commit failed for fixture $repo"
+}
+
+git_fixture_commit() {
+  local repo=$1
+  shift
+  git -C "$repo" add -- "$@" || fail "git add failed in fixture $repo"
+  git -C "$repo" -c user.email=t@test -c user.name=t commit -q -m fixture \
+    || fail "git commit failed in fixture $repo"
+}
+
+exclude_file_of() {
+  local p
+  p=$(git -C "$1" rev-parse --git-path info/exclude) || fail "could not resolve info/exclude for $1"
+  case "$p" in
+    /*) printf '%s\n' "$p" ;;
+    *) printf '%s/%s\n' "$1" "$p" ;;
+  esac
+}
+
+test_untracked_pointer_is_excluded_and_status_clean() {
+  local repo out excl
+  repo="$TMP_ROOT/git-tracked-agents-project"
+  git_fixture "$repo"
+  printf '# Existing agent memory\n\n## Maintaining this file\n\nKeep this file for knowledge useful to almost every future agent session in this project.\nDo not repeat what the codebase already shows; point to the authoritative file or command instead.\nPrefer rewriting or pruning existing entries over appending new ones.\nWhen updating this file, preserve this bar for all agents and keep entries concise.\n' > "$repo/AGENTS.md"
+  git_fixture_commit "$repo" AGENTS.md
+  "$ROOT/bin/fm-ensure-agents-md.sh" "$repo" >/dev/null 2>&1 \
+    || fail "fm-ensure-agents-md.sh failed in a git repo tracking only AGENTS.md"
+  assert_claude_pointer "$repo/CLAUDE.md"
+  excl=$(exclude_file_of "$repo")
+  grep -qxF "/CLAUDE.md" "$excl" || fail "untracked pointer was not added to info/exclude"
+  out=$(git -C "$repo" status --porcelain)
+  [ -z "$out" ] || fail "git status is not clean after writing the pointer (got: $out)"
+  pass "fm-ensure-agents-md.sh: untracked pointer is excluded and git status stays clean"
+}
+
+test_exclude_is_idempotent_across_reruns() {
+  local repo excl count
+  repo="$TMP_ROOT/git-idempotent-exclude-project"
+  git_fixture "$repo"
+  printf '# memory\n' > "$repo/AGENTS.md"
+  git_fixture_commit "$repo" AGENTS.md
+  "$ROOT/bin/fm-ensure-agents-md.sh" "$repo" >/dev/null 2>&1 \
+    || fail "fm-ensure-agents-md.sh failed on the first git-repo run"
+  "$ROOT/bin/fm-ensure-agents-md.sh" "$repo" >/dev/null 2>&1 \
+    || fail "fm-ensure-agents-md.sh failed on the second git-repo run"
+  excl=$(exclude_file_of "$repo")
+  count=$(grep -cxF "/CLAUDE.md" "$excl")
+  [ "$count" -eq 1 ] || fail "expected exactly one /CLAUDE.md exclude line, got $count"
+  pass "fm-ensure-agents-md.sh: re-run appends no duplicate exclude line"
+}
+
+test_tracked_claude_pointer_is_never_excluded() {
+  local repo out excl
+  repo="$TMP_ROOT/git-tracked-claude-project"
+  git_fixture "$repo"
+  printf '# Existing agent memory\n\n## Maintaining this file\n\nKeep this file for knowledge useful to almost every future agent session in this project.\nDo not repeat what the codebase already shows; point to the authoritative file or command instead.\nPrefer rewriting or pruning existing entries over appending new ones.\nWhen updating this file, preserve this bar for all agents and keep entries concise.\n' > "$repo/AGENTS.md"
+  write_fixture_claude_pointer "$repo"
+  git_fixture_commit "$repo" AGENTS.md CLAUDE.md
+  "$ROOT/bin/fm-ensure-agents-md.sh" "$repo" >/dev/null 2>&1 \
+    || fail "fm-ensure-agents-md.sh failed in a git repo tracking CLAUDE.md"
+  excl=$(exclude_file_of "$repo")
+  if [ -e "$excl" ] && grep -qxF "/CLAUDE.md" "$excl"; then
+    fail "a tracked CLAUDE.md was added to info/exclude"
+  fi
+  out=$(git -C "$repo" status --porcelain)
+  [ -z "$out" ] || fail "tracked-CLAUDE.md repo is no longer clean (got: $out)"
+  pass "fm-ensure-agents-md.sh: a tracked CLAUDE.md is never excluded"
+}
+
+test_real_distinct_claude_file_is_never_excluded() {
+  local repo excl
+  repo="$TMP_ROOT/git-real-claude-project"
+  git_fixture "$repo"
+  printf '# Agents memory\n' > "$repo/AGENTS.md"
+  git_fixture_commit "$repo" AGENTS.md
+  printf '# A real captain-authored CLAUDE.md\n' > "$repo/CLAUDE.md"
+  "$ROOT/bin/fm-ensure-agents-md.sh" "$repo" >/dev/null 2>&1 \
+    && fail "expected a conflict for a distinct real CLAUDE.md"
+  excl=$(exclude_file_of "$repo")
+  if [ -e "$excl" ] && grep -qxF "/CLAUDE.md" "$excl"; then
+    fail "a real non-pointer CLAUDE.md was added to info/exclude"
+  fi
+  printf '# A real captain-authored CLAUDE.md\n' | cmp -s - "$repo/CLAUDE.md" \
+    || fail "the real CLAUDE.md file was modified"
+  pass "fm-ensure-agents-md.sh: a real non-pointer CLAUDE.md is refused and never excluded"
+}
+
+test_linked_worktree_pointer_leaves_status_clean() {
+  local repo wt out excl
+  repo="$TMP_ROOT/git-worktree-main"
+  wt="$TMP_ROOT/git-worktree-task"
+  git_fixture "$repo"
+  printf '# Existing agent memory\n\n## Maintaining this file\n\nKeep this file for knowledge useful to almost every future agent session in this project.\nDo not repeat what the codebase already shows; point to the authoritative file or command instead.\nPrefer rewriting or pruning existing entries over appending new ones.\nWhen updating this file, preserve this bar for all agents and keep entries concise.\n' > "$repo/AGENTS.md"
+  git_fixture_commit "$repo" AGENTS.md
+  git -C "$repo" worktree add -q "$wt" HEAD \
+    || fail "could not add a linked worktree fixture"
+  "$ROOT/bin/fm-ensure-agents-md.sh" "$wt" >/dev/null 2>&1 \
+    || fail "fm-ensure-agents-md.sh failed inside a linked worktree"
+  assert_claude_pointer "$wt/CLAUDE.md"
+  out=$(git -C "$wt" status --porcelain)
+  [ -z "$out" ] || fail "linked worktree is not clean after writing the pointer (got: $out)"
+  # The exclude lands in the shared common-dir file by design; assert the
+  # observable contract rather than the byte location: the worktree is clean.
+  excl=$(exclude_file_of "$wt")
+  grep -qxF "/CLAUDE.md" "$excl" || fail "linked worktree run did not record the exclude"
+  pass "fm-ensure-agents-md.sh: linked-worktree pointer no longer dirties git status"
+}
+
 test_created_agents_md_includes_self_governance
 test_fresh_setup_writes_real_claude_pointer
 test_promoted_claude_md_includes_self_governance
@@ -369,3 +486,8 @@ test_agents_md_symlink_is_refused
 test_wrong_target_symlink_is_refused
 test_non_regular_claude_md_is_refused
 test_lowercase_agents_md_refuses_case_fragile_pointer
+test_untracked_pointer_is_excluded_and_status_clean
+test_exclude_is_idempotent_across_reruns
+test_tracked_claude_pointer_is_never_excluded
+test_real_distinct_claude_file_is_never_excluded
+test_linked_worktree_pointer_leaves_status_clean


### PR DESCRIPTION
## What

`bin/fm-ensure-agents-md.sh` now best-effort adds an anchored `/CLAUDE.md` line to the repo's `info/exclude` whenever the canonical `@AGENTS.md` pointer it owns is present but untracked, so the pointer never shows up as an uncommitted change.

## Why

In a project that tracks `AGENTS.md` but not `CLAUDE.md`, every ship brief's "Project memory" step leaves the pointer untracked in the task worktree, and `bin/fm-teardown.sh` then refuses the task over a file containing no work. Hit twice on 2026-08-17 (`subs-skip-offer-unbilled-cycle`, `subs-ci-actions`), each costing a manual discard decision after the PR was already merged.

The fix lives in the script that creates the artifact, following the existing precedent in `bin/fm-spawn.sh`'s `exclude_path()` ("Worktree-resident hooks and token pointers stay out of git's view so they never block teardown's dirty check or leak into a commit"). `fm-teardown.sh` is untouched.

## Guards

- Excludes only when the file present is byte-identical to the canonical pointer this script owns, `CLAUDE.md` is untracked, the script runs at the repo top level, and the directory is a git work tree. A tracked `CLAUDE.md` is never excluded; a real captain-authored `CLAUDE.md` is refused as before and never excluded.
- Best-effort throughout (`|| return 0`): non-git and installer/human runs are untouched, and a failed exclude write never fails the script.
- Idempotent via `grep -qxF`, same as `exclude_path()`.
- Pattern is anchored (`/CLAUDE.md`), so nested `CLAUDE.md` files elsewhere in a repo are unaffected.

## Where the exclude lands (requirement 2, verified empirically)

With git 2.50.1, inside a linked worktree `git rev-parse --git-path info/exclude` resolves to the **shared** common-dir `.git/info/exclude` — git treats `info/` as a common path — and a per-worktree `$GIT_DIR/info/exclude` (`.git/worktrees/<name>/info/exclude`) is **not honored by git at all** (verified: an untracked file stayed `??` with only the per-worktree file written, and disappeared from status only via the shared file). So a per-worktree mechanism does not exist short of `extensions.worktreeConfig` + a per-worktree `core.excludesFile`, which mutates shared repo config and is far more invasive.

The shared exclude is a deliberate choice, documented in the code comment: it is written only for this fixed firstmate-owned filename, only while the repo does not track `CLAUDE.md`, and only when the canonical pointer is what exists; `fm-spawn.sh`'s existing excludes already land in this same shared file. It is not silent for the captain: `git add CLAUDE.md` on an excluded path refuses loudly with a hint naming the exclude file, so deciding to track it later stays discoverable.

## End-to-end proof

Scratch repo tracking `AGENTS.md` only, linked worktree, real script runs:

```
== before fix (script from main):
?? CLAUDE.md
(dirty -> would be REFUSED by fm-teardown)
== after fix (this branch):
wrote: CLAUDE.md @AGENTS.md pointer in .../e2e/task-wt
git status --porcelain exit-empty: CLEAN
```

## Tests

New cases in `tests/fm-ensure-agents-md.test.sh`: untracked pointer excluded + status clean; re-run appends no duplicate line; tracked `CLAUDE.md` never excluded and repo stays clean; real non-pointer `CLAUDE.md` refused and never excluded; linked-worktree end-to-end status-clean. Full run (all 21 pass):

```
ok - fm-ensure-agents-md.sh: created AGENTS.md includes self-governance section
ok - fm-ensure-agents-md.sh: fresh setup writes a real @AGENTS.md pointer
ok - fm-ensure-agents-md.sh: promoted CLAUDE.md includes self-governance section
ok - fm-ensure-agents-md.sh: newline-less promotion keeps a blank separator line
ok - fm-ensure-agents-md.sh: existing symlinked AGENTS.md gains the section idempotently
ok - fm-ensure-agents-md.sh: correct symlink migrates to pointer without clobbering AGENTS.md
ok - fm-ensure-agents-md.sh: existing AGENTS.md without CLAUDE.md gains section and pointer
ok - fm-ensure-agents-md.sh: AGENTS.md that already has the section stays unchanged
ok - fm-ensure-agents-md.sh: CRLF AGENTS.md with the section stays unchanged
ok - fm-ensure-agents-md.sh: CRLF injection preserves line endings idempotently
ok - fm-ensure-agents-md.sh: canonical real CLAUDE.md pointer is not a conflict
ok - fm-ensure-agents-md.sh: refuses distinct real AGENTS.md and CLAUDE.md
ok - fm-ensure-agents-md.sh: refuses AGENTS.md when it is a symlink
ok - fm-ensure-agents-md.sh: refuses a CLAUDE.md symlink that does not point to AGENTS.md
ok - fm-ensure-agents-md.sh: refuses a non-regular CLAUDE.md
ok - fm-ensure-agents-md.sh: refuses a case-variant lowercase agents.md (issue #389)
ok - fm-ensure-agents-md.sh: untracked pointer is excluded and git status stays clean
ok - fm-ensure-agents-md.sh: re-run appends no duplicate exclude line
ok - fm-ensure-agents-md.sh: a tracked CLAUDE.md is never excluded
ok - fm-ensure-agents-md.sh: a real non-pointer CLAUDE.md is refused and never excluded
ok - fm-ensure-agents-md.sh: linked-worktree pointer no longer dirties git status
```

## Lint

```
$ bin/fm-lint.sh
fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)   (exit 0)
$ shellcheck -x bin/fm-ensure-agents-md.sh tests/fm-ensure-agents-md.test.sh
shellcheck -x: clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
