### PR TITLE
feat(brief): make ship-brief Project memory section opt-out via config knob

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ config/crew-harness  crewmate harness override; LOCAL, gitignored; absent or "de
 config/crew-dispatch.json  optional crewmate dispatch profiles; LOCAL, gitignored; firstmate-maintained but human-editable natural-language rules that choose a per-task harness/model/effort profile (section 4). Inherited by secondmate homes
 config/secondmate-harness  harness the PRIMARY uses to launch SECONDMATE agents, optionally followed by a model and effort token on the same line ("<harness> [<model>] [<effort>]"; section 4); LOCAL, gitignored; absent or "default" harness falls back to config/crew-harness then firstmate's own. The primary's own setting; NOT inherited into secondmate homes (secondmates do not spawn secondmates)
 config/backlog-backend  backlog backend override; LOCAL, gitignored; absent or "tasks-axi" = default tasks-axi backend, "manual" = force routine backlog updates to hand-editing; inherited by secondmate homes (section 10)
+config/project-memory  opts a home out of the ship-brief "Project memory" section; LOCAL, gitignored; absent or "on" keeps it, "off" omits it and makes fm-ensure-agents-md.sh refuse; not inherited by secondmate homes (docs/configuration.md "Project memory")
 config/backend  runtime session-provider backend override for new tasks; LOCAL, gitignored; absent = falls through to runtime auto-detection (the runtime firstmate itself is executing inside), then tmux; tmux is the verified reference backend (docs/tmux-backend.md), while herdr, zellij, orca, and cmux are experimental spawn backends (docs/herdr-backend.md, docs/zellij-backend.md, docs/orca-backend.md, docs/cmux-backend.md) - herdr and cmux can also be selected by runtime auto-detection, zellij and orca never are (always explicit), and codex-app is not accepted; see docs/codex-app-backend.md; inherited by secondmate homes under the primary-authoritative contract in secondmate-provisioning
 config/calm     Pi Calm presentation preference; LOCAL, gitignored, and not inherited; see docs/configuration.md "Pi Calm preference"
 config/startup-memory-budget     primary-authoritative per-home startup-memory budget; LOCAL, gitignored, materialized as 7,500 estimated tokens by locked primary bootstrap and inherited into secondmate homes; see docs/configuration.md "Startup memory budget"
@@ -246,7 +247,7 @@ Route durable knowledge to its most specific owner:
 - Knowledge general to every firstmate user belongs in this repo's shared tracked surface.
 
 Firstmate never writes a project's `AGENTS.md` directly.
-A crewmate creates or updates it lazily through the project's selected delivery path, using `bin/fm-ensure-agents-md.sh` and preferring pointers to authoritative sources over copied detail.
+A crewmate creates or updates it lazily through the project's selected delivery path, using `bin/fm-ensure-agents-md.sh` and preferring pointers to authoritative sources over copied detail, unless the local `config/project-memory` knob is off (section 2).
 Keep fleet delivery posture and captain-private strategy out of project memory.
 When the captain invokes `/stow`, load the `stow` skill for its memory curation, knowledge routing, and persistence of the open work records this session is holding; it files and corrects only the open work that session is holding, and never reconciles the backlog against repository or PR reality.
 
@@ -499,6 +500,7 @@ Preserve durable structured identifiers, dependencies, and completion artifact l
 `bin/fm-brief.sh` and its help own scaffold syntax, generated variants, status protocol, delivery-mode definitions of done, and exact safety mechanics.
 Use its scaffold as the contract, then replace every `{TASK}` placeholder with a clear task description, acceptance criteria, constraints, and necessary context before dispatch or seeding.
 Keep additions task-specific rather than repeating lifecycle instructions, and alter generated sections only when the task genuinely differs from the standard shape.
+A generated ship brief's standard shape itself can vary by home: its "Project memory" section is conditional on the local `config/project-memory` knob (section 2), never a task-specific edit.
 
 Every ship brief must retain the worktree-isolation assertion and stop if launched in the primary checkout.
 If a ship task touches firstmate's shared tracked material, explicitly require `firstmate-coding-guidelines` before editing.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -54,6 +54,9 @@
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
 # over copied detail) and has the crewmate add the fm-ensure-agents-md.sh
 # self-governance section when a touched project AGENTS.md lacks it.
+# The local, gitignored config/project-memory knob (bin/fm-project-memory-lib.sh;
+# docs/configuration.md "Project memory") opts a home out of that section
+# entirely: absent or "on" keeps the section, "off" omits it with no stub.
 # Refuses to overwrite an existing brief.
 set -eu
 
@@ -75,6 +78,8 @@ esac
 . "$SCRIPT_DIR/fm-marker-lib.sh"
 # shellcheck source=bin/fm-classify-lib.sh
 . "$SCRIPT_DIR/fm-classify-lib.sh"
+# shellcheck source=bin/fm-project-memory-lib.sh
+. "$SCRIPT_DIR/fm-project-memory-lib.sh"
 PAUSED_VERB=${FM_CLASSIFY_PAUSED_VERB:-$FM_CLASSIFY_PAUSED_VERB_DEFAULT}
 
 resolve_directory_input() {
@@ -100,6 +105,11 @@ if [ -n "${FM_STATE_OVERRIDE:-}" ]; then
   STATE=$(resolve_directory_input FM_STATE_OVERRIDE "$FM_STATE_OVERRIDE") || exit 1
 else
   STATE="$FM_HOME/state"
+fi
+if [ -n "${FM_CONFIG_OVERRIDE:-}" ]; then
+  CONFIG=$(resolve_directory_input FM_CONFIG_OVERRIDE "$FM_CONFIG_OVERRIDE") || exit 1
+else
+  CONFIG="$FM_HOME/config"
 fi
 KIND=ship
 HERDR_LAB=0
@@ -409,6 +419,25 @@ esac
 # briefs stay byte-identical to the historical Bash 5 output.
 DOD=${DOD%$'\n'}
 
+# config/project-memory off omits the whole section below rather than leaving a
+# weakened stub, per bin/fm-project-memory-lib.sh. PROJECT_MEMORY_SECTION
+# already carries its own leading/trailing blank-line separators when on, and
+# is the empty string when off so the surrounding heredoc collapses to one
+# blank line, not several.
+if fm_project_memory_enabled "$CONFIG"; then
+  IFS= read -r -d '' PROJECT_MEMORY_SECTION <<EOF || true
+
+# Project memory
+If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.
+Record only project knowledge useful to almost every future session.
+For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
+If you touch a project \`AGENTS.md\` that lacks \`## Maintaining this file\`, add that short self-governance section from \`$FM_ROOT/bin/fm-ensure-agents-md.sh\` in the same pass.
+Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
+EOF
+else
+  PROJECT_MEMORY_SECTION=
+fi
+
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
 
@@ -451,14 +480,7 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
-
-# Project memory
-If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.
-Record only project knowledge useful to almost every future session.
-For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
-If you touch a project \`AGENTS.md\` that lacks \`## Maintaining this file\`, add that short self-governance section from \`$FM_ROOT/bin/fm-ensure-agents-md.sh\` in the same pass.
-Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
-
+$PROJECT_MEMORY_SECTION
 $DOD
 EOF
 echo "scaffolded: $BRIEF (ship, mode=$MODE; replace {TASK})"

--- a/bin/fm-ensure-agents-md.sh
+++ b/bin/fm-ensure-agents-md.sh
@@ -20,8 +20,22 @@
 # link would have carried for that same mismatch.
 # This is a worktree utility for crewmates, not a supervision script, so it does
 # not call fm-guard.sh.
+# Refuses outright when the local config/project-memory knob (bin/fm-project-memory-lib.sh;
+# docs/configuration.md "Project memory") is "off", making the opt-out structural
+# rather than only a matter of bin/fm-brief.sh omitting the instruction to run this
+# script. A crewmate normally has no FM_HOME in its environment (bin/fm-spawn.sh
+# injects it only for a secondmate launch), so this check resolves the config
+# directory from FM_HOME/FM_CONFIG_OVERRIDE when set, else from this script's own
+# tracked-code-root location - correct for the common case of an ordinary
+# crewmate invoking the exact path baked into its brief at scaffold time, but it
+# cannot see a secondmate home's own distinct knob value when that secondmate
+# shares the primary's tracked checkout.
 # Usage: fm-ensure-agents-md.sh [repo-or-worktree-dir]
 set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/fm-project-memory-lib.sh
+. "$SCRIPT_DIR/fm-project-memory-lib.sh"
 
 usage() {
   echo "usage: fm-ensure-agents-md.sh [repo-or-worktree-dir]" >&2
@@ -34,6 +48,12 @@ case "${1:-}" in
     ;;
 esac
 [ "$#" -le 1 ] || { usage; exit 1; }
+
+PROJECT_MEMORY_CONFIG="${FM_CONFIG_OVERRIDE:-${FM_HOME:-$(cd "$SCRIPT_DIR/.." && pwd)}/config}"
+if ! fm_project_memory_enabled "$PROJECT_MEMORY_CONFIG"; then
+  echo "error: config/project-memory is off; this firstmate home does not commit project AGENTS.md/CLAUDE.md files (docs/configuration.md \"Project memory\")" >&2
+  exit 1
+fi
 
 DIR=${1:-.}
 [ -d "$DIR" ] || { echo "error: not a directory: $DIR" >&2; exit 1; }

--- a/bin/fm-project-memory-lib.sh
+++ b/bin/fm-project-memory-lib.sh
@@ -1,0 +1,35 @@
+# shellcheck shell=bash
+# Local opt-out knob for the ship-brief "Project memory" contract
+# (config/project-memory; see docs/configuration.md "Project memory").
+#
+# Some captains forbid committing AGENTS.md/CLAUDE.md into project repos (agent
+# rules live in a machine-level CLAUDE.md instead), so bin/fm-brief.sh and
+# bin/fm-ensure-agents-md.sh both consult this file rather than assuming every
+# fleet wants a project-committed memory file.
+#
+# Usage: . bin/fm-project-memory-lib.sh
+#
+# fm_project_memory_value <config-dir>
+#   Echoes the trimmed content of <config-dir>/project-memory, or "on" when the
+#   file is absent or empty. Any content other than the exact literal "off" is
+#   treated as "on" so an unrecognized value fails open to the pre-existing
+#   default rather than silently disabling the contract.
+# fm_project_memory_enabled <config-dir>
+#   True (exit 0) unless fm_project_memory_value is exactly "off".
+
+fm_project_memory_value() {
+  local config_dir=$1 knob_file value
+  knob_file="$config_dir/project-memory"
+  if [ -f "$knob_file" ]; then
+    value=$(tr -d '[:space:]' < "$knob_file" 2>/dev/null || true)
+    [ -n "$value" ] || value=on
+    printf '%s\n' "$value"
+    return 0
+  fi
+  printf '%s\n' on
+}
+
+fm_project_memory_enabled() {
+  local config_dir=$1
+  [ "$(fm_project_memory_value "$config_dir")" != off ]
+}

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -594,8 +594,8 @@ run_coverage_guard() {
     return 1
   fi
   cat "$tmp/s1" "$tmp/s2" | LC_ALL=C sort -u >"$tmp/shards_union"
-  missing=$(comm -23 "$tmp/proven" "$tmp/shards_union" || true)
-  extra=$(comm -13 "$tmp/proven" "$tmp/shards_union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/proven" "$tmp/shards_union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/proven" "$tmp/shards_union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable shards must equal the proven-isolated set"
     [ -z "$missing" ] || { log "missing from shards:"; printf '%s\n' "$missing" >&2; }
@@ -639,8 +639,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/serial_shards_raw" >"$tmp/serial_shards"
-  missing=$(comm -23 "$tmp/serial" "$tmp/serial_shards" || true)
-  extra=$(comm -13 "$tmp/serial" "$tmp/serial_shards" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/serial" "$tmp/serial_shards" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/serial" "$tmp/serial_shards" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable serial shards must equal the portable serial lane"
     [ -z "$missing" ] || { log "missing from serial shards:"; printf '%s\n' "$missing" >&2; }
@@ -652,7 +652,7 @@ run_coverage_guard() {
   for pair in "shards_union:serial" "shards_union:herdr" "serial:herdr"; do
     a=${pair%%:*}
     b=${pair#*:}
-    comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
+    LC_ALL=C comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
     if [ -s "$tmp/overlap" ]; then
       log "coverage guard: overlap between $a and $b:"
       cat "$tmp/overlap" >&2
@@ -670,8 +670,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/union_raw" >"$tmp/union"
-  missing=$(comm -23 "$tmp/all" "$tmp/union" || true)
-  extra=$(comm -13 "$tmp/all" "$tmp/union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/all" "$tmp/union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/all" "$tmp/union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: union of portable shards + portable serial + Herdr must equal tests/*.test.sh"
     [ -z "$missing" ] || { log "missing from union:"; printf '%s\n' "$missing" >&2; }
@@ -684,7 +684,7 @@ run_coverage_guard() {
     "$ROOT/bin/fm-test-isolation-proof.sh" --list | LC_ALL=C sort -u >"$tmp/proof_list"
     if ! cmp -s "$tmp/proven" "$tmp/proof_list"; then
       log "coverage guard: embedded proven-isolated set diverges from bin/fm-test-isolation-proof.sh --list"
-      comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
+      LC_ALL=C comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
       rm -rf "$tmp"
       return 1
     fi
@@ -966,6 +966,7 @@ families_for_changed_path() {
     bin/fm-tmux-lib.sh|bin/fm-marker-lib.sh|bin/fm-operational-input.sh|bin/fm-tasks-axi-lib.sh|\
     bin/fm-vendor-auth-probe.sh|\
     bin/fm-primary-scope-lib.sh|bin/fm-project-mode.sh|bin/fm-promote.sh|\
+    bin/fm-project-memory-lib.sh|\
     bin/fm-ff-lib.sh|bin/fm-gotmp*|bin/*pretool*)
       printf '%s\n' pure-contract-unit
       ;;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,6 +47,17 @@ Set the local, gitignored `config/backlog-backend` file to `manual` to force man
 Absent or `tasks-axi` selects the default tasks-axi backend.
 The file format is unchanged in both modes; tasks-axi and manual edits produce the same `## In flight`, `## Queued`, and `## Done` sections.
 
+## Project memory (config/project-memory)
+
+`bin/fm-brief.sh` includes a "Project memory" section in every generated ship brief, instructing the crewmate to record durable project-intrinsic knowledge in the project's own `AGENTS.md` via `bin/fm-ensure-agents-md.sh` (AGENTS.md section 6, "Route durable knowledge to its most specific owner").
+Some captains forbid committing `AGENTS.md`/`CLAUDE.md` into a project repo at all, for example because agent rules live in a machine-level `CLAUDE.md` instead.
+The local, gitignored `config/project-memory` file opts a firstmate home out of that contract.
+Absent or `on` keeps the section in every generated ship brief, unchanged from the pre-existing default.
+`off` omits the section entirely rather than leaving a weakened stub, and also makes `bin/fm-ensure-agents-md.sh` itself refuse to run rather than only relying on the brief never mentioning it.
+That refusal resolves its own config directory from `FM_HOME` (or `FM_CONFIG_OVERRIDE`) when set, else from the script's own tracked-code-root location, so it reliably sees the knob for an ordinary crewmate invoking the exact path baked into its brief, but not necessarily a secondmate home's own distinct value when that secondmate shares the primary's tracked checkout.
+Any file content other than the exact literal `off` is treated as `on`, so an unrecognized value fails open to the pre-existing default rather than silently disabling the contract.
+This preference is local to each firstmate home and is not part of secondmate inherited configuration.
+
 ## Runtime backend (config/backend / FM_BACKEND)
 
 For spawn-capable adapters, the runtime session-provider backend controls where task windows/endpoints are created, captured, sent to, watched, and killed.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -362,6 +362,8 @@ test_ship_project_memory_wording() {
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
   brief="$home/data/$id/brief.md"
   assert_present "$brief" "brief was not scaffolded"
+  assert_grep "# Project memory" "$brief" \
+    "project-memory section missing with config/project-memory absent (default on)"
   assert_grep "Record only project knowledge useful to almost every future session." "$brief" \
     "project-memory contract lost the durable-knowledge bar"
   assert_grep "prefer a pointer to the authoritative file, command, or doc over copying the detail" "$brief" \
@@ -369,6 +371,38 @@ test_ship_project_memory_wording() {
   assert_grep "lacks \`## Maintaining this file\`, add that short self-governance section" "$brief" \
     "project-memory contract lost the self-governance add-in-same-pass rule"
   pass "fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar"
+}
+
+test_ship_project_memory_knob_on_explicit() {
+  local home id brief
+  home="$TMP_ROOT/project-memory-home-on"
+  mkdir -p "$home/data" "$home/config"
+  printf 'on\n' > "$home/config/project-memory"
+  id="brief-memory-c2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "brief was not scaffolded"
+  assert_grep "# Project memory" "$brief" \
+    "project-memory section missing with config/project-memory explicitly on"
+  pass "fm-brief.sh: explicit config/project-memory=on keeps the section"
+}
+
+test_ship_project_memory_knob_off_omits_section() {
+  local home id brief
+  home="$TMP_ROOT/project-memory-home-off"
+  mkdir -p "$home/data" "$home/config"
+  printf 'off\n' > "$home/config/project-memory"
+  id="brief-memory-c3"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "brief was not scaffolded"
+  assert_no_grep "Project memory" "$brief" \
+    "project-memory section (or a stub of it) leaked into the brief with config/project-memory=off"
+  assert_no_grep "fm-ensure-agents-md.sh" "$brief" \
+    "brief still tells the crewmate to run fm-ensure-agents-md.sh with config/project-memory=off"
+  assert_grep "# Definition of done" "$brief" \
+    "brief lost the Definition of done section entirely"
+  pass "fm-brief.sh: config/project-memory=off omits the Project memory section with no stub"
 }
 
 test_herdr_lab_contract_is_explicit_and_complete() {
@@ -720,6 +754,8 @@ test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording
+test_ship_project_memory_knob_on_explicit
+test_ship_project_memory_knob_off_omits_section
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path
 test_herdr_lab_omission_is_loud_for_ship_and_scout

--- a/tests/fm-ensure-agents-md.test.sh
+++ b/tests/fm-ensure-agents-md.test.sh
@@ -353,6 +353,41 @@ test_lowercase_agents_md_refuses_case_fragile_pointer() {
   pass "fm-ensure-agents-md.sh: refuses a case-variant lowercase agents.md (issue #389)"
 }
 
+test_project_memory_knob_off_refuses_loudly() {
+  local repo home out rc
+  repo="$TMP_ROOT/project-memory-off-project"
+  home="$TMP_ROOT/project-memory-off-home"
+  mkdir -p "$repo" "$home/config"
+  printf 'off\n' > "$home/config/project-memory"
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-ensure-agents-md.sh" "$repo" 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit when config/project-memory is off"
+  assert_contains "$out" "project-memory" "refusal did not name the config/project-memory knob"
+  assert_contains "$out" "off" "refusal did not explain the knob is off"
+  assert_absent "$repo/AGENTS.md" "AGENTS.md was created despite config/project-memory=off"
+  assert_absent "$repo/CLAUDE.md" "CLAUDE.md was created despite config/project-memory=off"
+  pass "fm-ensure-agents-md.sh: refuses loudly when config/project-memory is off"
+}
+
+test_project_memory_knob_on_and_absent_still_write() {
+  local repo home
+  repo="$TMP_ROOT/project-memory-on-project"
+  home="$TMP_ROOT/project-memory-on-home"
+  mkdir -p "$repo" "$home/config"
+  printf 'on\n' > "$home/config/project-memory"
+  FM_HOME="$home" "$ROOT/bin/fm-ensure-agents-md.sh" "$repo" >/dev/null 2>&1 \
+    || fail "fm-ensure-agents-md.sh failed with config/project-memory=on"
+  assert_present "$repo/AGENTS.md" "AGENTS.md was not created with config/project-memory=on"
+
+  repo="$TMP_ROOT/project-memory-absent-project"
+  home="$TMP_ROOT/project-memory-absent-home"
+  mkdir -p "$repo" "$home/config"
+  FM_HOME="$home" "$ROOT/bin/fm-ensure-agents-md.sh" "$repo" >/dev/null 2>&1 \
+    || fail "fm-ensure-agents-md.sh failed with config/project-memory absent"
+  assert_present "$repo/AGENTS.md" "AGENTS.md was not created with config/project-memory absent (default on)"
+  pass "fm-ensure-agents-md.sh: config/project-memory=on and absent both keep the default write-enabled behavior"
+}
+
 test_created_agents_md_includes_self_governance
 test_fresh_setup_writes_real_claude_pointer
 test_promoted_claude_md_includes_self_governance
@@ -369,3 +404,5 @@ test_agents_md_symlink_is_refused
 test_wrong_target_symlink_is_refused
 test_non_regular_claude_md_is_refused
 test_lowercase_agents_md_refuses_case_fragile_pointer
+test_project_memory_knob_off_refuses_loudly
+test_project_memory_knob_on_and_absent_still_write

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -25,8 +25,8 @@ test_list_all_exact_suite_coverage() {
     done | LC_ALL=C sort
   )
   [ -n "$listed" ] || fail "--list --all printed nothing"
-  missing=$(comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
-  extra=$(comm -13 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
+  missing=$(LC_ALL=C comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
+  extra=$(LC_ALL=C comm -13 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
   [ -z "$missing" ] || fail "--list --all missing scripts: $missing"
   [ -z "$extra" ] || fail "--list --all unexpected scripts: $extra"
   # No duplicates.
@@ -359,7 +359,7 @@ test_portable_shard_union_and_coverage_guard() {
   herdr=$("$RUNNER" --list --family real-herdr-gated)
   [ -n "$s1" ] && [ -n "$s2" ] || fail "portable parallel shards must be non-empty"
   # Shards disjoint.
-  overlap=$(comm -12 <(printf '%s\n' "$s1" | LC_ALL=C sort) <(printf '%s\n' "$s2" | LC_ALL=C sort) || true)
+  overlap=$(LC_ALL=C comm -12 <(printf '%s\n' "$s1" | LC_ALL=C sort) <(printf '%s\n' "$s2" | LC_ALL=C sort) || true)
   [ -z "$overlap" ] || fail "portable parallel shards overlap: $overlap"
   # Union of shards equals proven-isolated.
   [ "$(printf '%s\n' "$s1" "$s2" | LC_ALL=C sort -u)" = \


### PR DESCRIPTION
## Make the ship-brief Project memory section opt-out

`bin/fm-brief.sh` unconditionally told every ship crewmate to commit knowledge into a project's `AGENTS.md`/`CLAUDE.md`, which conflicts with a captain preference that those files must never be committed into a project repo. This adds a local, gitignored `config/project-memory` knob so a fleet can opt out without changing the tracked default for every other firstmate user.

### Changes
- Add `bin/fm-project-memory-lib.sh`: `fm_project_memory_value`/`fm_project_memory_enabled` read `config/project-memory` (absent or `on` = enabled, `off` = disabled, anything else fails open to `on`).
- `bin/fm-brief.sh` omits the whole "Project memory" section (no stub) from generated ship briefs when the knob is off; unchanged byte-for-byte when on/absent.
- `bin/fm-ensure-agents-md.sh` refuses loudly when the knob is off, so the opt-out is structural, not only a matter of the brief never mentioning it. It resolves its config directory from `FM_HOME`/`FM_CONFIG_OVERRIDE` when set, else from its own tracked-code-root location - this reliably covers an ordinary crewmate (which has no `FM_HOME` in its pane per `bin/fm-spawn.sh`) invoking the exact path baked into its brief, but not a secondmate home's own distinct value when that secondmate shares the primary's tracked checkout. Documented as a known limitation rather than silently assumed complete.
- Docs: `AGENTS.md` section 2 gets a one-line config entry, sections 6 and 11 get a one-line cross-reference to the new conditional behavior, and `docs/configuration.md` gets the full "Project memory" writeup.
- Tests: extended `tests/fm-brief.test.sh` and `tests/fm-ensure-agents-md.test.sh` (colocated, no new runner) to cover on/off/absent for both scripts.
- Unrelated fix found while validating: `bin/fm-test-run.sh`'s `--check-coverage` guard compared `LC_ALL=C`-sorted files with plain `comm`, which spuriously fails under a non-C collation locale; pinned every `comm` call (and the matching one in `tests/fm-test-run.test.sh`) to `LC_ALL=C` to match the existing `sort` calls.

Deliberately **not** inherited into secondmate homes (like `config/calm`) and **not** added to `FM_INHERITABLE_CONFIG`, since this is a per-captain preference not requested for secondmate propagation and secondmates may legitimately work on projects with a different convention.
