### PR TITLE
feat(briefs): inject relevant project learnings into worker briefs

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -266,13 +266,10 @@ fi
 
 REPO=${POS[1]}
 
-# Launch-time gstack learnings: ship and scout workers never see the gstack
-# SessionStart hooks that surface learnings in the captain's own sessions, so
-# surface the searcher's top hits directly in the written brief. The helper is
-# fail-soft - a missing searcher, empty results, or a searcher error all print
-# nothing - so the scaffold is unchanged when no learnings are available.
-# Secondmate charters are excluded: they are roles rather than tasks and exit
-# above. The helper, not this block, owns the search mechanics.
+# Ship and scout workers do not receive the captain's gstack SessionStart hooks,
+# so their written briefs may carry relevant learnings. Secondmate charters exit
+# above because they are roles rather than tasks. The helper owns lookup behavior;
+# this block derives brief tokens and conditionally formats its hits.
 LEARNINGS_BLOCK=
 learnings_tokens() {  # <id> <repo> -> one derived token per line, capped at 5
   local id=$1 repo=$2

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -266,6 +266,55 @@ fi
 
 REPO=${POS[1]}
 
+# Launch-time gstack learnings: ship and scout workers never see the gstack
+# SessionStart hooks that surface learnings in the captain's own sessions, so
+# surface the searcher's top hits directly in the written brief. The helper is
+# fail-soft - a missing searcher, empty results, or a searcher error all print
+# nothing - so the scaffold is unchanged when no learnings are available.
+# Secondmate charters are excluded: they are roles rather than tasks and exit
+# above. The helper, not this block, owns the search mechanics.
+LEARNINGS_BLOCK=
+learnings_tokens() {  # <id> <repo> -> one derived token per line, capped at 5
+  local id=$1 repo=$2
+  local -a words=() seen=() tokens=()
+  local src tok i j n
+  for src in "$id" "$repo"; do
+    while IFS= read -r tok; do
+      [ -n "$tok" ] || continue
+      words+=("$tok")
+    done < <(printf '%s\n' "$src" | tr '[:upper:]' '[:lower:]' | grep -oE '[a-z0-9]+' || true)
+  done
+  n=${#words[@]}
+  for ((i = 0; i < n; i++)); do
+    tok=${words[$i]}
+    [ "${#tok}" -ge 2 ] || continue
+    case "$tok" in
+      feat|fix|chore|docs|v0|issue) continue ;;
+    esac
+    j=0
+    while [ "$j" -lt "${#seen[@]}" ]; do
+      [ "${seen[$j]}" = "$tok" ] && continue 2
+      j=$((j + 1))
+    done
+    seen+=("$tok")
+    tokens+=("$tok")
+    [ "${#tokens[@]}" -ge 5 ] && break
+  done
+  if [ "${#tokens[@]}" -gt 0 ]; then
+    printf '%s\n' "${tokens[@]}"
+  fi
+}
+LEARNINGS_TOKENS=()
+while IFS= read -r tok; do
+  LEARNINGS_TOKENS+=("$tok")
+done < <(learnings_tokens "$ID" "$REPO")
+if [ "${#LEARNINGS_TOKENS[@]}" -gt 0 ]; then
+  learnings_output=$("$SCRIPT_DIR/fm-learnings-search.sh" --limit 5 "${LEARNINGS_TOKENS[@]}") || learnings_output=
+  if [ -n "$learnings_output" ]; then
+    LEARNINGS_BLOCK=$'\n\n# Relevant project learnings\n\n'"$learnings_output"
+  fi
+fi
+
 if [ "$HERDR_LAB" -eq 1 ]; then
 HERDR_LAB_HELPER=$(shell_quote "$FM_ROOT/bin/fm-herdr-lab.sh")
 # shellcheck disable=SC2016  # single quotes are deliberate: these lines are literal brief text whose backtick-wrapped $(...) and "$HERDR_LAB_SESSION" snippets must reach the reading agent verbatim, not expand at scaffold time; only the '"$VAR"' break-outs interpolate.
@@ -303,7 +352,7 @@ cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
 
 # Task
-{TASK}
+{TASK}$LEARNINGS_BLOCK
 
 $HERDR_SECTION
 
@@ -413,7 +462,7 @@ cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
 
 # Task
-{TASK}
+{TASK}$LEARNINGS_BLOCK
 
 $HERDR_SECTION
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -265,6 +265,7 @@ exit 0
 fi
 
 REPO=${POS[1]}
+LEARNINGS_PROJECT_SLUG=$(printf '%s' "$REPO" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9._-')
 
 # Ship and scout workers do not receive the captain's gstack SessionStart hooks,
 # so their written briefs may carry relevant learnings. Secondmate charters exit
@@ -306,7 +307,7 @@ while IFS= read -r tok; do
   LEARNINGS_TOKENS+=("$tok")
 done < <(learnings_tokens "$ID" "$REPO")
 if [ "${#LEARNINGS_TOKENS[@]}" -gt 0 ]; then
-  learnings_output=$("$SCRIPT_DIR/fm-learnings-search.sh" --limit 5 "${LEARNINGS_TOKENS[@]}") || learnings_output=
+  learnings_output=$(GSTACK_PROJECT_SLUG="$LEARNINGS_PROJECT_SLUG" "$SCRIPT_DIR/fm-learnings-search.sh" --limit 5 "${LEARNINGS_TOKENS[@]}") || learnings_output=
   if [ -n "$learnings_output" ]; then
     LEARNINGS_BLOCK=$'\n\n# Relevant project learnings\n\n'"$learnings_output"
   fi

--- a/bin/fm-learnings-search.sh
+++ b/bin/fm-learnings-search.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# fm-learnings-search.sh - surface the captain's gstack learnings for a task.
+#
+# Crewmate workers run in isolated worktrees and never see the gstack
+# SessionStart hooks that surface relevant learnings in the captain's own
+# sessions, so the start half of that feature belongs in the written brief.
+# This helper is that start half: bin/fm-brief.sh derives topic tokens from
+# the task id and repo name, passes each token as its own argument, and embeds
+# the top hits as a short "Relevant project learnings" section.
+#
+# The search runs the gstack CLI's learnings searcher at
+# $HOME/.claude/skills/gstack/bin/gstack-learnings-search (override with
+# FM_GSTACK_SEARCH_BIN). That script resolves its project scope from the cwd
+# slug and honors GSTACK_PROJECT_SLUG and GSTACK_HOME, matches any query token
+# (token-OR) against learning keys, insights, and file paths, and caps results
+# at --limit.
+#
+# Fail-soft contract: a missing or non-executable searcher, an empty token
+# list, no matching learnings, or a searcher error all print nothing and exit
+# 0, so a missing or broken learnings store never fails a brief scaffold.
+# Usage: fm-learnings-search.sh [--limit <n>] <token>...
+#   --limit <n>  cap the number of learnings returned (default 5)
+#   <token>...   search tokens, one per argument; joined into one
+#                whitespace-separated query for the searcher
+#   --help       print this header
+set -eu
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0"
+}
+
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+esac
+
+LIMIT=5
+TOKENS=()
+want=
+for a in "$@"; do
+  if [ -n "$want" ]; then
+    LIMIT=$a
+    want=
+    continue
+  fi
+  case "$a" in
+    --limit) want=1 ;;
+    --limit=*) LIMIT=${a#--limit=} ;;
+    -h|--help) usage; exit 0 ;;
+    --*) echo "error: unknown option: $a" >&2; exit 2 ;;
+    *) TOKENS+=("$a") ;;
+  esac
+done
+[ -z "$want" ] || { echo "error: --limit requires a value" >&2; exit 2; }
+case "$LIMIT" in
+  ''|*[!0-9]*) echo "error: --limit must be a positive integer: $LIMIT" >&2; exit 2 ;;
+esac
+[ "$LIMIT" -gt 0 ] || { echo "error: --limit must be a positive integer: $LIMIT" >&2; exit 2; }
+
+# No tokens means no query: print nothing and let the brief omit the section.
+[ "${#TOKENS[@]}" -gt 0 ] || exit 0
+
+SEARCHER=${FM_GSTACK_SEARCH_BIN:-"$HOME/.claude/skills/gstack/bin/gstack-learnings-search"}
+[ -x "$SEARCHER" ] || exit 0
+
+# The searcher takes one --query value and token-ORs its whitespace-separated
+# words, so join the caller's argv tokens into a single query string.
+QUERY=
+for t in "${TOKENS[@]}"; do
+  QUERY="${QUERY:+$QUERY }$t"
+done
+
+# A non-zero searcher exit is absorbed, never propagated: the brief must not
+# fail because the learnings store errored.
+OUTPUT=$("$SEARCHER" --query "$QUERY" --limit "$LIMIT" 2>/dev/null) || OUTPUT=
+[ -n "$OUTPUT" ] || exit 0
+printf '%s\n' "$OUTPUT"

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -133,7 +133,7 @@ now_ms() {
 family_for_basename() {
   case "$1" in
     fm-arm-pretool-check.test.sh|fm-ask-user-authority.test.sh|\
-    fm-brief.test.sh|fm-vendor-auth-probe.test.sh|\
+    fm-brief.test.sh|fm-learnings-search.test.sh|fm-vendor-auth-probe.test.sh|\
     fm-calm-pi-extension.test.sh|fm-cd-pretool-check.test.sh|\
     fm-classify-decision-key.test.sh|\
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
@@ -961,7 +961,7 @@ families_for_changed_path() {
       printf '%s\n' real-herdr-gated
       ;;
     bin/fm-lint.sh|bin/fm-install-shellcheck.sh|\
-    bin/fm-brief.sh|bin/fm-ensure-agents-md.sh|bin/fm-crew-state.sh|\
+    bin/fm-brief.sh|bin/fm-learnings-search.sh|bin/fm-ensure-agents-md.sh|bin/fm-crew-state.sh|\
     bin/fm-decision-hold.sh|bin/fm-supervision*|bin/fm-transition-lib.sh|\
     bin/fm-tmux-lib.sh|bin/fm-marker-lib.sh|bin/fm-operational-input.sh|bin/fm-tasks-axi-lib.sh|\
     bin/fm-vendor-auth-probe.sh|\

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -27,7 +27,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-backlog-receive.sh`  | Idempotently ingest one confined remote handoff outbox through tasks-axi             |
 | `fm-decision-hold.sh`    | Create, verify, complete, close, and repair durable captain-held decisions       |
 | `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs   |
-| `fm-learnings-search.sh` | Provide relevant gstack learnings for crewmate briefs |
+| `fm-learnings-search.sh` | Provide fail-soft relevant gstack learnings for ship and scout briefs |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |
 | `fm-install-treehouse.sh`| Install CI's exact-version Treehouse pin for real-Herdr E2E that needs spawn worktrees |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -27,7 +27,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-backlog-receive.sh`  | Idempotently ingest one confined remote handoff outbox through tasks-axi             |
 | `fm-decision-hold.sh`    | Create, verify, complete, close, and repair durable captain-held decisions       |
 | `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs   |
-| `fm-learnings-search.sh` | Search the gstack learnings store for a task's topic tokens, fail-soft, for briefs' relevant-learnings section |
+| `fm-learnings-search.sh` | Provide relevant gstack learnings for crewmate briefs |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |
 | `fm-install-treehouse.sh`| Install CI's exact-version Treehouse pin for real-Herdr E2E that needs spawn worktrees |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -27,6 +27,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-backlog-receive.sh`  | Idempotently ingest one confined remote handoff outbox through tasks-axi             |
 | `fm-decision-hold.sh`    | Create, verify, complete, close, and repair durable captain-held decisions       |
 | `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs   |
+| `fm-learnings-search.sh` | Search the gstack learnings store for a task's topic tokens, fail-soft, for briefs' relevant-learnings section |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |
 | `fm-install-treehouse.sh`| Install CI's exact-version Treehouse pin for real-Herdr E2E that needs spawn worktrees |

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -22,6 +22,11 @@ TMP_ROOT=$(fm_test_tmproot fm-brief)
 BRIEF_HOME="$TMP_ROOT/home"
 mkdir -p "$BRIEF_HOME/data"
 
+# Hermeticity: pin the gstack learnings searcher to a missing path so every
+# scaffold in this file stays byte-stable and never reads the host's real
+# learnings store. The learnings-wiring tests below override it with fixtures.
+export FM_GSTACK_SEARCH_BIN="$TMP_ROOT/missing-gstack-learnings-search"
+
 # The script itself must always parse under the ambient bash. That is Bash 5 in
 # CI and locally, where the issue #958/#1069 parser bug does not fire, so this
 # is a weak guard on its own; test_no_heredoc_in_command_substitution and the
@@ -710,6 +715,170 @@ test_scout_and_secondmate_scaffold() {
   pass "fm-brief: scout and secondmate code paths still scaffold well-formed briefs"
 }
 
+# Launch-time gstack learnings: ship and scout briefs embed the searcher's top
+# hits under "Relevant project learnings" when the helper returns them, capped
+# at five; the section is omitted and the scaffold unchanged when the searcher
+# is missing, returns nothing, or errors; secondmate charters never get it.
+
+write_brief_fake_searcher() {  # <dir> <name> <mode: ok|empty|fail>
+  local dir=$1 name=$2 mode=$3
+  mkdir -p "$dir"
+  case "$mode" in
+    empty) printf '#!/usr/bin/env bash\nexit 0\n' > "$dir/$name" ;;
+    fail) printf '#!/usr/bin/env bash\nexit 3\n' > "$dir/$name" ;;
+    *)
+      cat > "$dir/$name" <<'SH'
+#!/usr/bin/env bash
+query=""
+limit="5"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --query) query=$2; shift 2 ;;
+    --limit) limit=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -n "$query" ] || exit 0
+printf 'LEARNINGS: %s loaded (2 pitfalls)\n\n## Pitfalls\n- [fixture] (confidence: 9/10, observed, 2026-01-01)\n  insight for: %s\n' "$limit" "$query"
+SH
+      ;;
+  esac
+  chmod +x "$dir/$name"
+}
+
+test_learnings_embedded_when_searcher_present() {
+  local home fake brief
+  home="$TMP_ROOT/learnings-present-home"
+  mkdir -p "$home/data"
+  fake="$TMP_ROOT/learnings-fakebin/gstack-learnings-search"
+  write_brief_fake_searcher "$TMP_ROOT/learnings-fakebin" gstack-learnings-search ok
+  FM_HOME="$home" FM_GSTACK_SEARCH_BIN="$fake" \
+    "$ROOT/bin/fm-brief.sh" tinas-second-brain-fix-issue-698 tinas-second-brain --mode no-mistakes >/dev/null 2>&1 \
+    || fail "ship brief with a present searcher should scaffold"
+  brief="$home/data/tinas-second-brain-fix-issue-698/brief.md"
+  assert_grep "# Relevant project learnings" "$brief" "ship brief did not embed the learnings heading"
+  assert_grep "LEARNINGS: 5 loaded (2 pitfalls)" "$brief" "ship brief did not embed the searcher summary"
+  assert_grep "insight for: tinas second brain 698" "$brief" \
+    "ship brief did not derive tokens from the title and repo (noise stripped, issue number kept)"
+  assert_grep "{TASK}" "$brief" "learnings insertion broke the task placeholder"
+  assert_grep "# Setup" "$brief" "learnings insertion broke the setup section"
+  assert_no_grep "insight for: fix" "$brief" "noise token fix leaked into the learnings query"
+  assert_no_grep "insight for: issue" "$brief" "noise token issue leaked into the learnings query"
+  pass "fm-brief.sh: ship brief embeds top-five learnings from a present searcher"
+}
+
+test_scout_brief_embeds_learnings() {
+  local home fake brief
+  home="$TMP_ROOT/learnings-scout-home"
+  mkdir -p "$home/data"
+  fake="$TMP_ROOT/learnings-scout-fakebin/gstack-learnings-search"
+  write_brief_fake_searcher "$TMP_ROOT/learnings-scout-fakebin" gstack-learnings-search ok
+  FM_HOME="$home" FM_GSTACK_SEARCH_BIN="$fake" \
+    "$ROOT/bin/fm-brief.sh" investigate-698 alpha --scout >/dev/null 2>&1 \
+    || fail "scout brief with a present searcher should scaffold"
+  brief="$home/data/investigate-698/brief.md"
+  assert_grep "# Relevant project learnings" "$brief" "scout brief did not embed the learnings heading"
+  assert_grep "insight for: investigate 698 alpha" "$brief" "scout brief did not derive tokens"
+  assert_grep "SCOUT task" "$brief" "learnings insertion broke the scout contract"
+  pass "fm-brief.sh: scout brief embeds learnings like a ship brief"
+}
+
+test_learnings_omitted_when_searcher_missing() {
+  local home brief
+  home="$TMP_ROOT/learnings-missing-home"
+  mkdir -p "$home/data"
+  FM_HOME="$home" FM_GSTACK_SEARCH_BIN="$TMP_ROOT/no-such-searcher" \
+    "$ROOT/bin/fm-brief.sh" brief-missing-l1 some-proj --mode no-mistakes >/dev/null 2>&1 \
+    || fail "a missing searcher must not fail the ship scaffold"
+  brief="$home/data/brief-missing-l1/brief.md"
+  assert_present "$brief" "missing searcher scaffold produced no brief"
+  assert_no_grep "# Relevant project learnings" "$brief" "missing searcher left a learnings section"
+  assert_grep "# Setup" "$brief" "missing searcher brief lost its setup section"
+  assert_grep "{TASK}" "$brief" "missing searcher brief lost the task placeholder"
+  pass "fm-brief.sh: a missing searcher leaves the brief unchanged"
+}
+
+test_learnings_omitted_when_searcher_errors() {
+  local home fake brief
+  home="$TMP_ROOT/learnings-err-home"
+  mkdir -p "$home/data"
+  fake="$TMP_ROOT/learnings-err-fakebin/gstack-learnings-search"
+  write_brief_fake_searcher "$TMP_ROOT/learnings-err-fakebin" gstack-learnings-search fail
+  FM_HOME="$home" FM_GSTACK_SEARCH_BIN="$fake" \
+    "$ROOT/bin/fm-brief.sh" brief-err-l2 some-proj --mode no-mistakes >/dev/null 2>&1 \
+    || fail "a failing searcher must not fail the ship scaffold"
+  brief="$home/data/brief-err-l2/brief.md"
+  assert_no_grep "# Relevant project learnings" "$brief" "a failing searcher left a learnings section"
+  assert_grep "# Setup" "$brief" "a failing searcher broke the scaffold"
+  pass "fm-brief.sh: a failing searcher never fails fm-brief"
+}
+
+test_learnings_omitted_when_no_hits() {
+  local home fake brief
+  home="$TMP_ROOT/learnings-nohits-home"
+  mkdir -p "$home/data"
+  fake="$TMP_ROOT/learnings-nohits-fakebin/gstack-learnings-search"
+  write_brief_fake_searcher "$TMP_ROOT/learnings-nohits-fakebin" gstack-learnings-search empty
+  FM_HOME="$home" FM_GSTACK_SEARCH_BIN="$fake" \
+    "$ROOT/bin/fm-brief.sh" brief-nohits-l3 some-proj --mode no-mistakes >/dev/null 2>&1 \
+    || fail "an empty-results searcher must not fail the ship scaffold"
+  brief="$home/data/brief-nohits-l3/brief.md"
+  assert_no_grep "# Relevant project learnings" "$brief" "no-hits searcher left a learnings section"
+  assert_grep "# Setup" "$brief" "no-hits searcher broke the scaffold"
+  pass "fm-brief.sh: no learnings hits means no section"
+}
+
+test_secondmate_charter_never_embeds_learnings() {
+  local home fake brief
+  home="$TMP_ROOT/learnings-sm-home"
+  mkdir -p "$home/data"
+  fake="$TMP_ROOT/learnings-sm-fakebin/gstack-learnings-search"
+  write_brief_fake_searcher "$TMP_ROOT/learnings-sm-fakebin" gstack-learnings-search ok
+  FM_HOME="$home" FM_GSTACK_SEARCH_BIN="$fake" FM_SECONDMATE_CHARTER='ops' \
+    "$ROOT/bin/fm-brief.sh" learnings-mate --secondmate --no-projects >/dev/null 2>&1 \
+    || fail "a secondmate charter should scaffold even with a present searcher"
+  brief="$home/data/learnings-mate/brief.md"
+  assert_no_grep "# Relevant project learnings" "$brief" "secondmate charter got a learnings section"
+  assert_grep "# Charter" "$brief" "secondmate charter lost its charter section"
+  pass "fm-brief.sh: secondmate charters never embed learnings"
+}
+
+test_learnings_tokens_capped_at_five() {
+  local home fake brief
+  home="$TMP_ROOT/learnings-cap-home"
+  mkdir -p "$home/data"
+  fake="$TMP_ROOT/learnings-cap-fakebin/gstack-learnings-search"
+  write_brief_fake_searcher "$TMP_ROOT/learnings-cap-fakebin" gstack-learnings-search ok
+  FM_HOME="$home" FM_GSTACK_SEARCH_BIN="$fake" \
+    "$ROOT/bin/fm-brief.sh" alpha-beta-gamma-delta-epsilon-zeta omega --mode no-mistakes >/dev/null 2>&1 \
+    || fail "capped-token brief should scaffold"
+  brief="$home/data/alpha-beta-gamma-delta-epsilon-zeta/brief.md"
+  assert_grep "insight for: alpha beta gamma delta epsilon" "$brief" \
+    "token derivation did not cap the query at five tokens"
+  assert_no_grep "insight for: zeta" "$brief" "sixth token leaked past the cap"
+  pass "fm-brief.sh: learnings search tokens are capped at five"
+}
+
+test_learnings_dollar_text_renders_literally() {
+  local home fake brief
+  home="$TMP_ROOT/learnings-dollar-home"
+  mkdir -p "$home/data" "$TMP_ROOT/learnings-dollar-fakebin"
+  fake="$TMP_ROOT/learnings-dollar-fakebin/gstack-learnings-search"
+  cat > "$fake" <<'SH'
+#!/usr/bin/env bash
+printf 'LEARNINGS: 1 loaded (1 pitfall)\n\n## Pitfalls\n- [k] (confidence: 9/10)\n  run $D extract and $(echo SHOULD-NOT-RUN)\n'
+SH
+  chmod +x "$fake"
+  FM_HOME="$home" FM_GSTACK_SEARCH_BIN="$fake" \
+    "$ROOT/bin/fm-brief.sh" brief-dollar-l4 some-proj --mode no-mistakes >/dev/null 2>&1 \
+    || fail "dollar-laden learnings must not fail the scaffold"
+  brief="$home/data/brief-dollar-l4/brief.md"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the fixture's literal $D/$(...) text must be asserted verbatim
+  assert_grep 'run $D extract and $(echo SHOULD-NOT-RUN)' "$brief" \
+    "learnings text lost its literal dollar and command-substitution content"
+  pass "fm-brief.sh: learnings text renders literally through the scaffold heredoc"
+}
+
 test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
@@ -730,3 +899,11 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
 test_scout_and_secondmate_scaffold
+test_learnings_embedded_when_searcher_present
+test_scout_brief_embeds_learnings
+test_learnings_omitted_when_searcher_missing
+test_learnings_omitted_when_searcher_errors
+test_learnings_omitted_when_no_hits
+test_secondmate_charter_never_embeds_learnings
+test_learnings_tokens_capped_at_five
+test_learnings_dollar_text_renders_literally

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -739,7 +739,7 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 [ -n "$query" ] || exit 0
-printf 'LEARNINGS: %s loaded (2 pitfalls)\n\n## Pitfalls\n- [fixture] (confidence: 9/10, observed, 2026-01-01)\n  insight for: %s\n' "$limit" "$query"
+printf 'LEARNINGS: %s loaded (2 pitfalls)\n\n## Pitfalls\n- [fixture] (confidence: 9/10, observed, 2026-01-01)\n  scope: %s\n  insight for: %s\n' "$limit" "${GSTACK_PROJECT_SLUG:-}" "$query"
 SH
       ;;
   esac
@@ -758,6 +758,7 @@ test_learnings_embedded_when_searcher_present() {
   brief="$home/data/tinas-second-brain-fix-issue-698/brief.md"
   assert_grep "# Relevant project learnings" "$brief" "ship brief did not embed the learnings heading"
   assert_grep "LEARNINGS: 5 loaded (2 pitfalls)" "$brief" "ship brief did not embed the searcher summary"
+  assert_grep "scope: tinas-second-brain" "$brief" "ship brief did not scope the search to the target repository"
   assert_grep "insight for: tinas second brain 698" "$brief" \
     "ship brief did not derive tokens from the title and repo (noise stripped, issue number kept)"
   assert_grep "{TASK}" "$brief" "learnings insertion broke the task placeholder"

--- a/tests/fm-learnings-search.test.sh
+++ b/tests/fm-learnings-search.test.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-learnings-search.sh.
+#
+# The helper is the start half of the gstack-learnings feature: it calls the
+# gstack learnings searcher for task tokens and is fail-soft, printing nothing
+# and exiting 0 when the searcher is missing, the token list is empty, the
+# search returns no hits, or the searcher errors. All of that refuse-fail
+# behavior is what lets bin/fm-brief.sh embed a "Relevant project learnings"
+# section without ever failing a scaffold.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-learnings-search)
+
+# write_fake_searcher <dir> <name> <mode: ok|empty|fail>
+# A fixture that honors the real gstack-learnings-search contract: --query
+# carries one whitespace-joined token list, --limit caps the count. The ok mode
+# echoes the query and limit back so tests can assert token derivation and limit
+# forwarding through the helper's public interface; empty and fail modes model a
+# no-hits searcher and a broken searcher respectively.
+write_fake_searcher() {
+  local dir=$1 name=$2 mode=$3
+  mkdir -p "$dir"
+  case "$mode" in
+    empty) printf '#!/usr/bin/env bash\nexit 0\n' > "$dir/$name" ;;
+    fail) printf '#!/usr/bin/env bash\nexit 3\n' > "$dir/$name" ;;
+    *)
+      cat > "$dir/$name" <<'SH'
+#!/usr/bin/env bash
+query=""
+limit="5"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --query) query=$2; shift 2 ;;
+    --limit) limit=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -n "$query" ] || exit 0
+printf 'LEARNINGS: %s loaded (2 pitfalls)\n\n## Pitfalls\n- [fixture] (confidence: 9/10, observed, 2026-01-01)\n  insight for: %s\n' "$limit" "$query"
+SH
+      ;;
+  esac
+  chmod +x "$dir/$name"
+}
+
+test_help_renders_complete_header() {
+  local help
+  help=$("$ROOT/bin/fm-learnings-search.sh" --help)
+  assert_contains "$help" "fm-learnings-search.sh" "help did not name the helper"
+  assert_contains "$help" "Fail-soft contract" "help did not own the fail-soft mechanics"
+  assert_contains "$help" "--limit <n>" "help did not document the limit flag"
+  assert_contains "$help" "never fails a brief scaffold" "help did not own the never-fail guarantee"
+  pass "fm-learnings-search.sh: --help renders the complete header"
+}
+
+test_missing_searcher_is_silent_noop() {
+  local out status
+  out=$(FM_GSTACK_SEARCH_BIN="$TMP_ROOT/no-such-searcher" \
+    "$ROOT/bin/fm-learnings-search.sh" alpha beta 2>/dev/null); status=$?
+  expect_code 0 "$status" "missing searcher must exit 0"
+  [ -z "$out" ] || fail "missing searcher printed output: $out"
+  pass "fm-learnings-search.sh: a missing searcher prints nothing and exits 0"
+}
+
+test_no_tokens_is_silent_noop() {
+  local fake out status
+  fake="$TMP_ROOT/fakebin/gstack-learnings-search"
+  write_fake_searcher "$TMP_ROOT/fakebin" gstack-learnings-search ok
+  out=$(FM_GSTACK_SEARCH_BIN="$fake" "$ROOT/bin/fm-learnings-search.sh" 2>/dev/null); status=$?
+  expect_code 0 "$status" "empty token list must exit 0"
+  [ -z "$out" ] || fail "empty token list printed output: $out"
+  pass "fm-learnings-search.sh: an empty token list prints nothing and exits 0"
+}
+
+test_hits_are_printed_and_tokens_joined() {
+  local fake out
+  fake="$TMP_ROOT/fakebin-hits/gstack-learnings-search"
+  write_fake_searcher "$TMP_ROOT/fakebin-hits" gstack-learnings-search ok
+  out=$(FM_GSTACK_SEARCH_BIN="$fake" "$ROOT/bin/fm-learnings-search.sh" alpha beta)
+  expect_code 0 "$?" "searcher present with hits must exit 0"
+  assert_contains "$out" "LEARNINGS: 5 loaded (2 pitfalls)" "helper lost the searcher summary"
+  assert_contains "$out" "insight for: alpha beta" "helper did not join the tokens into one query"
+  pass "fm-learnings-search.sh: prints the searcher hits and joins tokens"
+}
+
+test_limit_flag_is_forwarded() {
+  local fake out
+  fake="$TMP_ROOT/fakebin-limit/gstack-learnings-search"
+  write_fake_searcher "$TMP_ROOT/fakebin-limit" gstack-learnings-search ok
+  out=$(FM_GSTACK_SEARCH_BIN="$fake" "$ROOT/bin/fm-learnings-search.sh" --limit 2 alpha)
+  assert_contains "$out" "LEARNINGS: 2 loaded (2 pitfalls)" "helper did not forward --limit 2"
+  pass "fm-learnings-search.sh: the --limit flag is forwarded to the searcher"
+}
+
+test_bad_limit_is_refused() {
+  local fake out status
+  fake="$TMP_ROOT/fakebin-badlimit/gstack-learnings-search"
+  write_fake_searcher "$TMP_ROOT/fakebin-badlimit" gstack-learnings-search ok
+  out=$(FM_GSTACK_SEARCH_BIN="$fake" "$ROOT/bin/fm-learnings-search.sh" --limit nope alpha 2>&1); status=$?
+  expect_code 2 "$status" "a non-numeric --limit must be refused"
+  assert_contains "$out" "--limit" "bad --limit refusal did not name the flag"
+  pass "fm-learnings-search.sh: a non-numeric --limit is refused loudly"
+}
+
+test_empty_results_are_silent() {
+  local fake out status
+  fake="$TMP_ROOT/fakebin-empty/gstack-learnings-search"
+  write_fake_searcher "$TMP_ROOT/fakebin-empty" gstack-learnings-search empty
+  out=$(FM_GSTACK_SEARCH_BIN="$fake" "$ROOT/bin/fm-learnings-search.sh" alpha 2>/dev/null); status=$?
+  expect_code 0 "$status" "an empty-results searcher must exit 0"
+  [ -z "$out" ] || fail "empty-results searcher printed output: $out"
+  pass "fm-learnings-search.sh: no hits prints nothing and exits 0"
+}
+
+test_searcher_failure_is_silent() {
+  local fake out status
+  fake="$TMP_ROOT/fakebin-fail/gstack-learnings-search"
+  write_fake_searcher "$TMP_ROOT/fakebin-fail" gstack-learnings-search fail
+  out=$(FM_GSTACK_SEARCH_BIN="$fake" "$ROOT/bin/fm-learnings-search.sh" alpha 2>/dev/null); status=$?
+  expect_code 0 "$status" "a failing searcher must not propagate its exit"
+  [ -z "$out" ] || fail "a failing searcher printed output: $out"
+  pass "fm-learnings-search.sh: a searcher error prints nothing and exits 0"
+}
+
+test_help_renders_complete_header
+test_missing_searcher_is_silent_noop
+test_no_tokens_is_silent_noop
+test_hits_are_printed_and_tokens_joined
+test_limit_flag_is_forwarded
+test_bad_limit_is_refused
+test_empty_results_are_silent
+test_searcher_failure_is_silent


### PR DESCRIPTION
## Intent

Wire launch-time injection of relevant gstack learnings into firstmate worker instructions, mirroring the captain's Claude SessionStart hooks in tinas-second-brain (cfeddersen/show-current-context) that surface the top 5 gstack pitfalls from the branch/task name; firstmate workers do not run those hooks reliably, so the start half belongs in the written instructions every worker reads. Requirements: (1) add a small fail-soft helper bin/fm-learnings-search.sh whose header and --help own the mechanics (search, limit, fail-soft); it calls ~/.claude/skills/gstack/bin/gstack-learnings-search when that executable exists, otherwise prints nothing and exits 0; a missing, empty, or erroring searcher must never fail a brief. (2) Derive search tokens from the task id (slugged title) and repo name only, per accepted decision A: the filled-in brief task text never reaches the searcher because {TASK} is filled after scaffolding, so do not pass it and do not change the brief-fill flow; pass each token as its own quoted argv, cap at 5, strip noise tokens (feat, fix, chore, docs, v0, issue). (3) Wire the helper into bin/fm-brief.sh so every ship and scout brief gets a short 'Relevant project learnings' section when the searcher returns hits, and omit the section when there are no hits; never inject into secondmate charters. (4) Keep the section tight: a heading plus the searcher output; do not copy firstmate data/learnings.md; do not implement SessionEnd / auto-checkpoint / post-ship nudge. (5) Tests in tests/ through the public helper/brief interface: missing searcher is a silent no-op, hits appear in the scaffolded brief, searcher failures do not fail fm-brief. (6) AGENTS.md: at most a one-line pointer if a trigger is required; do not restate the helper. (7) bin/fm-lint.sh clean; no agent co-author. Acceptance: fm-brief on a tinas-second-brain-like title produces at most five learnings when the searcher is present; without the searcher the brief is unchanged except for the usual scaffold. PR body: short What / Why / How to try bullets, no wall of intent text.

## What Changed

- Added a fail-soft `fm-learnings-search.sh` helper that invokes the configured gstack learnings searcher and returns no output when unavailable or failing.
- Added capped, noise-filtered task/repository token lookup to inject matching learnings into ship and scout brief scaffolds; secondmate charters remain unchanged.
- Added helper and brief coverage, registered the new test in the portable test family, and documented the helper in the script reference.

## Risk Assessment

✅ Low: The change is well-bounded, correctly scopes lookup to the target repository via the gstack override, and preserves fail-soft scaffolding behavior.

## Testing

Exercised the fail-soft public helper and generated ship/scout brief flows, including missing, empty, and failing searchers, token filtering/capping, secondmate exclusion, and literal output rendering. A deterministic end-to-end ship scaffold produced the expected five-learning section; no UI surface applies because this is a CLI-generated Markdown brief.

<details>
<summary>Evidence: Generated ship-brief learning section</summary>

<code># Relevant project learnings&#10;&#10;LEARNINGS: 5 loaded (fixture)&#10;&#10;- Keep SessionStart-only context in worker briefs.&#10;- Make optional learning lookup fail soft.&#10;- Derive the query from stable task and repository identifiers.</code>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Relevant project learnings

LEARNINGS: 5 loaded (fixture)

- Keep SessionStart-only context in worker briefs.
- Make optional learning lookup fail soft.
- Derive the query from stable task and repository identifiers.

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of tinas-second-brain, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/tinas-second-brain-fix-issue-698`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/_3/klqsxx153k94qb8tvbb5f5g40000gn/T/no-mistakes-evidence/01M07TDM4XK5SSRRQN91MB90SS/home/state/tinas-second-brain-fix-issue-698.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/christoph/.no-mistakes/worktrees/04015cb0c3e3/01M07TDM4XK5SSRRQN91MB90SS/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/christoph/.no-mistakes/worktrees/04015cb0c3e3/01M07TDM4XK5SSRRQN91MB90SS/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"1117eb54b061bbd7ea8436cd0d0466579514d1f0","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-brief.sh:309` - The lookup is scoped to the firstmate process’s current directory, not the target repo. For example, running `fm-brief ... tinas-second-brain` from the firstmate home calls the helper without `GSTACK_PROJECT_SLUG`; the installed searcher therefore reads the firstmate slug’s learnings, so tinas-second-brain learnings are omitted (or unrelated firstmate hits are injected). Pass an explicit target project slug derived from `$REPO` at this call boundary and cover the selected scope with the fake searcher.

🔧 Fix: Scope learnings to target repository
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-learnings-search.test.sh`
- `bash tests/fm-brief.test.sh`
- `FM_HOME=/var/folders/_3/klqsxx153k94qb8tvbb5f5g40000gn/T/no-mistakes-evidence/01M07TDM4XK5SSRRQN91MB90SS/home FM_GSTACK_SEARCH_BIN=/var/folders/_3/klqsxx153k94qb8tvbb5f5g40000gn/T/no-mistakes-evidence/01M07TDM4XK5SSRRQN91MB90SS/gstack-learnings-search bin/fm-brief.sh tinas-second-brain-fix-issue-698 tinas-second-brain --mode no-mistakes`
- `sed -n '/# Relevant project learnings/,/# Setup/p' <generated brief>`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
