### PR TITLE
fix(herdr): make the presentation lock namespace per account

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -649,14 +649,25 @@ fm_backend_herdr_projection_workspace_label() {  # <task-id> <projection-id>
   printf '└ %s · p:%s' "$(fm_backend_herdr_projection_concise_task_label "$1")" "$2"
 }
 
-# fm_backend_herdr_presentation_session_lock_path: one machine-private lock
-# path per live named Herdr session/socket, shared across every Firstmate home
-# that uses that session.
-# The path is never under any one home's state/ and secondmates never write the
-# primary home. Returns non-zero when the named session's socket cannot be
-# resolved unambiguously.
+# fm_backend_herdr_presentation_lock_namespace: the lock namespace root, whose
+# name carries this account's numeric uid.
+# The uid suffix is what makes the ownership and mode assertions below
+# enforceable: an unsuffixed shared name is claimable by whichever account on
+# the machine creates it first, and every other account's ownership assertion
+# then refuses permanently, with no remedy short of a privileged removal. That
+# refusal blocks teardown, so a task whose work has already landed stays
+# recorded as in flight and its cleanup runs late against a stale target.
+# Per-uid naming removes the collision by construction rather than relaxing the
+# assertions, which remain correct on a name no other account can claim.
+# The directory holds only lock files, so an older unsuffixed directory is left
+# untouched and nothing is migrated out of it.
 fm_backend_herdr_presentation_lock_namespace() {
-  printf '%s' '/tmp/firstmate-herdr-presentation'
+  local uid
+  uid=$(id -u 2>/dev/null) || return 1
+  case "$uid" in
+    '' | *[!0-9]*) return 1 ;;
+  esac
+  printf '/tmp/firstmate-herdr-presentation-%s' "$uid"
 }
 
 fm_backend_herdr_presentation_lock_namespace_mode() {
@@ -682,6 +693,55 @@ fm_backend_herdr_presentation_lock_namespace_valid() {
   owner=$(fm_backend_herdr_presentation_lock_namespace_uid "$dir") || return 1
   mode=$(fm_backend_herdr_presentation_lock_namespace_mode "$dir") || return 1
   [ "$owner" = "$expected_uid" ] && [ "$mode" = 700 ]
+}
+
+# fm_backend_herdr_presentation_lock_namespace_fault: tell a PERMANENT lock
+# namespace fault apart from an ordinary session-resolution failure.
+# fm_backend_herdr_presentation_session_lock_path refuses for two unrelated
+# reasons: the named session could not be resolved unambiguously, which a later
+# attempt may clear on its own, or the lock namespace itself cannot validate,
+# which no later attempt ever clears. Reporting only the first sends a
+# supervisor into an unbounded retry loop against a condition that cannot
+# change, so every caller that reports such a refusal consults this first.
+# Prints one self-contained fragment naming the exact path, the exact fault,
+# and the remedy that actually clears it, and returns 0 ONLY when a permanent
+# fault exists. A usable or absent namespace prints nothing and returns 1,
+# which is the caller's signal to report the ordinary session-resolution
+# failure instead.
+fm_backend_herdr_presentation_lock_namespace_fault() {
+  local dir expected_uid owner mode
+  expected_uid=$(id -u 2>/dev/null) || expected_uid=
+  dir=$(fm_backend_herdr_presentation_lock_namespace) || dir=
+  if [ -z "$dir" ]; then
+    printf 'this account has no readable numeric user id, so the presentation lock namespace cannot be named; restore a working id command and rerun'
+    return 0
+  fi
+  if [ -L "$dir" ]; then
+    printf 'the presentation lock namespace %s is a symlink, which is never accepted, and no later attempt will clear it; remove that link (the namespace holds only lock files) and rerun' "$dir"
+    return 0
+  fi
+  [ -e "$dir" ] || return 1
+  if [ ! -d "$dir" ]; then
+    printf 'the presentation lock namespace %s exists but is not a directory, and no later attempt will clear it; remove it (the namespace holds only lock files) and rerun' "$dir"
+    return 0
+  fi
+  owner=$(fm_backend_herdr_presentation_lock_namespace_uid "$dir")
+  if [ -z "$owner" ]; then
+    printf 'the presentation lock namespace %s exists but its ownership could not be read, and no later attempt will clear it; restore access to it (the namespace holds only lock files) and rerun' "$dir"
+    return 0
+  fi
+  if [ "$owner" != "$expected_uid" ]; then
+    printf 'the presentation lock namespace %s is owned by uid %s but this account is uid %s, so its ownership check can never pass and no later attempt will clear it; have uid %s or an administrator remove that directory (it holds only lock files) and rerun' \
+      "$dir" "$owner" "$expected_uid" "$owner"
+    return 0
+  fi
+  mode=$(fm_backend_herdr_presentation_lock_namespace_mode "$dir")
+  if [ "$mode" != 700 ]; then
+    printf 'the presentation lock namespace %s has mode %s rather than the required 700, and no later attempt will clear it; run chmod 700 %s and rerun' \
+      "$dir" "${mode:-unreadable}" "$dir"
+    return 0
+  fi
+  return 1
 }
 
 # Resolve the one verified running named-session socket path as an absolute
@@ -728,6 +788,14 @@ fm_backend_herdr_presentation_session_socket_path() {  # <session>
   fm_backend_herdr_canonical_socket_path "$socket"
 }
 
+# fm_backend_herdr_presentation_session_lock_path: one machine-private lock
+# path per live named Herdr session/socket, shared across every Firstmate home
+# that this account uses with that session.
+# The path is never under any one home's state/ and secondmates never write the
+# primary home. Returns non-zero when the named session's socket cannot be
+# resolved unambiguously, or when the lock namespace itself cannot be used;
+# fm_backend_herdr_presentation_lock_namespace_fault tells those two apart for
+# any caller that reports the refusal.
 fm_backend_herdr_presentation_session_lock_path() {  # <session>
   local session=$1 socket key dir hash
   [ -n "$session" ] || return 1
@@ -2861,7 +2929,7 @@ fm_backend_herdr_kill_serialized() {  # <session> <pane>
 fm_backend_herdr_kill() {  # <target>
   fm_backend_herdr_target_ready "$1" || return 0
   local session=$FM_BACKEND_HERDR_SESSION pane=$FM_BACKEND_HERDR_PANE
-  local lock_path attempt=0 lock_held=0
+  local lock_path attempt=0 lock_held=0 namespace_fault
   if ! declare -F fm_lock_try_acquire >/dev/null 2>&1; then
     # shellcheck source=bin/fm-wake-lib.sh
     . "$FM_BACKEND_HERDR_ROOT/bin/fm-wake-lib.sh"
@@ -2879,6 +2947,8 @@ fm_backend_herdr_kill() {  # <target>
   if [ "$lock_held" = 1 ]; then
     fm_backend_herdr_kill_serialized "$session" "$pane"
     fm_lock_release "$lock_path" || true
+  elif namespace_fault=$(fm_backend_herdr_presentation_lock_namespace_fault); then
+    echo "warning: herdr task kill could not acquire its session presentation lock; refusing an unlocked pane close - $namespace_fault" >&2
   else
     echo "warning: herdr task kill could not acquire its session presentation lock; refusing an unlocked pane close" >&2
   fi

--- a/bin/fm-herdr-session-cleanup.sh
+++ b/bin/fm-herdr-session-cleanup.sh
@@ -202,7 +202,7 @@ fm_herdr_cleanup_revalidate() { # <session> <workspace> <tab> <pane> <title> <to
 fm_herdr_cleanup_one() { # <session> <workspace> <title> <home-real>
   local session=$1 workspace=$2 title=$3 home_real=$4 token journal id task_lock
   local version bound_workspace bound_tab bound_pane presentation_lock snapshot
-  local tab pane state close_status=0
+  local tab pane state close_status=0 namespace_fault
   token=$(fm_herdr_cleanup_title_token "$title") || return 0
   if ! fm_herdr_cleanup_unique_match "$title" "$session" "$home_real"; then
     return 0
@@ -221,7 +221,11 @@ fm_herdr_cleanup_one() { # <session> <workspace> <title> <home-real>
   fi
   presentation_lock=$(fm_backend_herdr_presentation_session_lock_path "$session" 2>/dev/null) || {
     fm_lock_release "$task_lock" || true
-    fm_herdr_cleanup_warn "$id skipped because the shared presentation lock is unavailable"
+    if namespace_fault=$(fm_backend_herdr_presentation_lock_namespace_fault); then
+      fm_herdr_cleanup_warn "$id skipped because the shared presentation lock is unavailable - $namespace_fault"
+    else
+      fm_herdr_cleanup_warn "$id skipped because the shared presentation lock is unavailable"
+    fi
     return 0
   }
   if ! fm_lock_try_acquire "$presentation_lock"; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -691,7 +691,7 @@ parse_orca_worktree_result() {
 }
 
 spawn_abort_cleanup() {
-  local status=$?
+  local status=$? namespace_fault
   if [ "$RELAUNCH_REPLACEMENT_PENDING" = 1 ] \
      && [ "$SPAWN_META_PUBLISH_STARTED" = 1 ] \
      && [ -n "$SPAWN_META_TMP" ] \
@@ -719,7 +719,11 @@ spawn_abort_cleanup() {
   if [ "$HERDR_PROJECTION_ABORT_CLEANUP" = 1 ] \
      && [ "$HERDR_PRESENTATION_ORDER_LOCK_HELD" != 1 ]; then
     if ! spawn_herdr_presentation_order_lock_acquire "${HERDR_PROJECTION_ABORT_SESSION:-}"; then
-      echo "warning: herdr presentation focus lock unavailable; retaining the projection journal and refusing concurrent abort cleanup" >&2
+      if namespace_fault=$(fm_backend_herdr_presentation_lock_namespace_fault); then
+        echo "warning: herdr presentation focus lock unavailable; retaining the projection journal and refusing concurrent abort cleanup - $namespace_fault" >&2
+      else
+        echo "warning: herdr presentation focus lock unavailable; retaining the projection journal and refusing concurrent abort cleanup" >&2
+      fi
       HERDR_PROJECTION_ABORT_CLEANUP=0
     fi
   fi
@@ -2017,7 +2021,11 @@ case "$BACKEND" in
             fi
           fi
         else
-          echo "warning: herdr presentation focus lock unavailable; using the ordinary flat layout without projection" >&2
+          if HERDR_NAMESPACE_FAULT=$(fm_backend_herdr_presentation_lock_namespace_fault); then
+            echo "warning: herdr presentation focus lock unavailable; using the ordinary flat layout without projection - $HERDR_NAMESPACE_FAULT" >&2
+          else
+            echo "warning: herdr presentation focus lock unavailable; using the ordinary flat layout without projection" >&2
+          fi
         fi
       fi
     fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1907,7 +1907,13 @@ case "$BACKEND" in
           exit 1
         }
         spawn_herdr_presentation_order_lock_acquire "$HERDR_SES" || {
-          echo "error: herdr presentation recovery could not acquire its session lock; refusing a concurrent resume" >&2
+          # A contended lock clears on its own; an unusable lock namespace never
+          # does, so this refusal names which one it hit.
+          if HERDR_NAMESPACE_FAULT=$(fm_backend_herdr_presentation_lock_namespace_fault); then
+            echo "error: herdr presentation recovery could not acquire its session lock; refusing a concurrent resume - $HERDR_NAMESPACE_FAULT" >&2
+          else
+            echo "error: herdr presentation recovery could not acquire its session lock; refusing a concurrent resume" >&2
+          fi
           exit 1
         }
         if [ -e "$STATE/$ID.meta" ] || [ -L "$STATE/$ID.meta" ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -791,7 +791,8 @@ spawn_abort_cleanup() {
 }
 trap spawn_abort_cleanup EXIT
 
-# One bounded lock per live Herdr session/socket, shared across all homes.
+# One bounded lock per live Herdr session/socket, shared across all of this
+# account's homes; the namespace is per-uid, so another account never shares it.
 # <session> is required so secondmate and primary spawns serialize against the
 # same session without writing any other home's state directory.
 spawn_herdr_presentation_order_lock_acquire() {

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2074,7 +2074,8 @@ teardown_herdr_require_prerequisites() {  # <task-id>
     fm_backend_herdr_workspace_presence_state \
     fm_backend_herdr_endpoint_confirmed_gone \
     fm_backend_herdr_explicit_close_pane_confirmed \
-    fm_backend_herdr_presentation_session_lock_path; do
+    fm_backend_herdr_presentation_session_lock_path \
+    fm_backend_herdr_presentation_lock_namespace_fault; do
     if ! declare -F "$prerequisite" >/dev/null 2>&1; then
       echo "error: herdr teardown prerequisites are unavailable for $task_id; nothing was changed - restore the adapter and rerun teardown" >&2
       return 1
@@ -2092,7 +2093,7 @@ teardown_herdr_require_prerequisites() {  # <task-id>
 }
 
 teardown_herdr_preflight_target() {  # <target> <task-id>
-  local target=$1 task_id=$2 session pane presence lock_path verified_lock_path lock_session held_path attempt
+  local target=$1 task_id=$2 session pane presence lock_path verified_lock_path lock_session held_path attempt namespace_fault
   teardown_herdr_require_prerequisites "$task_id" || return 1
   if ! fm_backend_herdr_parse_target "$target"; then
     echo "error: herdr endpoint $target for $task_id could not be parsed exactly; nothing was changed - repair the endpoint metadata and rerun teardown" >&2
@@ -2109,7 +2110,14 @@ teardown_herdr_preflight_target() {  # <target> <task-id>
       ;;
   esac
   if ! lock_path=$(fm_backend_herdr_presentation_session_lock_path "$session"); then
-    echo "error: herdr session presentation lock could not be resolved for $task_id; nothing was changed - rerun teardown once the session is reachable and unambiguous" >&2
+    # Two unrelated faults refuse here, and only one of them can clear on a
+    # rerun; reporting the wrong one is what turned this refusal into an
+    # unbounded retry loop that held cleanup open indefinitely.
+    if namespace_fault=$(fm_backend_herdr_presentation_lock_namespace_fault); then
+      echo "error: herdr session presentation lock could not be resolved for $task_id; nothing was changed - $namespace_fault" >&2
+    else
+      echo "error: herdr session presentation lock could not be resolved for $task_id; nothing was changed - rerun teardown once the session is reachable and unambiguous" >&2
+    fi
     return 1
   fi
   if [ -n "$TEARDOWN_HERDR_LOCK_RECORDS" ]; then

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -108,7 +108,7 @@ Protocol 16 exposes `workspace.move` over the named session socket but no CLI su
 Projected children are placed in one contiguous block immediately after their owning home when the session layout, protocol, socket, `python3`, and machine-private per-session lock are all verifiable.
 That lock lives in a namespace whose name carries the account's own numeric user id, so it is shared by every Firstmate home of one account, and no other account's Firstmate ever creates or uses that name because each account only ever resolves and creates its own uid-suffixed one.
 A second local account can still deliberately create that name, and the refusal then names the owning user id and the remedy instead of misdirecting a retry.
-When the namespace exists but cannot be used, every refusal that mentions it names the owning user id and the remedy, and says plainly that rerunning will not clear it, because that fault is permanent while an unreachable session is not.
+When the namespace exists but cannot be used for any other reason, every refusal that mentions it names the exact fault and the remedy that clears it, and says plainly that rerunning will not clear it, because that fault is permanent while an unreachable session is not.
 Existing legacy child labels may extend an already adjacent block read-only but are never renamed or migrated.
 A foreign, ambiguous, detached, or manually interleaved child makes ordering skip with a warning rather than rewriting the layout.
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -106,7 +106,8 @@ An ambiguous response grants no mutation or cleanup authority.
 Protocol 16 exposes `workspace.move` over the named session socket but no CLI subcommand.
 `bin/backends/herdr-workspace-move.py` sends only that whitelisted method and verifies the complete returned workspace order.
 Projected children are placed in one contiguous block immediately after their owning home when the session layout, protocol, socket, `python3`, and machine-private per-session lock are all verifiable.
-That lock lives in a namespace whose name carries the account's own numeric user id, so it is shared by every Firstmate home of one account and can never be claimed by a second account on the same machine.
+That lock lives in a namespace whose name carries the account's own numeric user id, so it is shared by every Firstmate home of one account, and no other account's Firstmate ever creates or uses that name because each account only ever resolves and creates its own uid-suffixed one.
+A second local account can still deliberately create that name, and the refusal then names the owning user id and the remedy instead of misdirecting a retry.
 When the namespace exists but cannot be used, every refusal that mentions it names the owning user id and the remedy, and says plainly that rerunning will not clear it, because that fault is permanent while an unreachable session is not.
 Existing legacy child labels may extend an already adjacent block read-only but are never renamed or migrated.
 A foreign, ambiguous, detached, or manually interleaved child makes ordering skip with a warning rather than rewriting the layout.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -106,6 +106,8 @@ An ambiguous response grants no mutation or cleanup authority.
 Protocol 16 exposes `workspace.move` over the named session socket but no CLI subcommand.
 `bin/backends/herdr-workspace-move.py` sends only that whitelisted method and verifies the complete returned workspace order.
 Projected children are placed in one contiguous block immediately after their owning home when the session layout, protocol, socket, `python3`, and machine-private per-session lock are all verifiable.
+That lock lives in a namespace whose name carries the account's own numeric user id, so it is shared by every Firstmate home of one account and can never be claimed by a second account on the same machine.
+When the namespace exists but cannot be used, every refusal that mentions it names the owning user id and the remedy, and says plainly that rerunning will not clear it, because that fault is permanent while an unreachable session is not.
 Existing legacy child labels may extend an already adjacent block read-only but are never renamed or migrated.
 A foreign, ambiguous, detached, or manually interleaved child makes ordering skip with a warning rather than rewriting the layout.
 

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -712,6 +712,8 @@ LOCK_CONTENTION_OWNER_PID=
   || fail "bounded presentation lock contention did not fall back to a successful flat spawn: $(cat "$TMP_ROOT/lock-contended.err")"
 grep -F "presentation focus lock unavailable; using the ordinary flat layout without projection" "$TMP_ROOT/lock-contended.err" >/dev/null 2>&1 \
   || fail "bounded presentation lock contention did not warn about flat fallback"
+! grep -F "presentation lock namespace" "$TMP_ROOT/lock-contended.err" >/dev/null 2>&1 \
+  || fail "bounded presentation lock contention reported a namespace fault"
 LOCK_CONTENTION_META="$HOME_DIR/state/lock-contended.meta"
 remember_meta_worktree "$LOCK_CONTENTION_META" >/dev/null
 LOCK_CONTENTION_WSID=$(grep '^herdr_workspace_id=' "$LOCK_CONTENTION_META" | cut -d= -f2-)
@@ -1134,6 +1136,8 @@ wait "$CROSS_LOCK_PID" || fail "cross-home session lock owner failed"
   || fail "cross-home lock contention did not fall back flat: $(cat "$TMP_ROOT/aflat.err")"
 grep -F "presentation focus lock unavailable; using the ordinary flat layout without projection" "$TMP_ROOT/aflat.err" >/dev/null 2>&1 \
   || fail "cross-home lock contention did not warn about flat fallback"
+! grep -F "presentation lock namespace" "$TMP_ROOT/aflat.err" >/dev/null 2>&1 \
+  || fail "cross-home lock contention reported a namespace fault"
 remember_meta_worktree "$SECOND_HOME_A/state/aflat.meta" >/dev/null
 AFLAT_WSID=$(grep '^herdr_workspace_id=' "$SECOND_HOME_A/state/aflat.meta" | cut -d= -f2-)
 AFLAT_LABEL=$(lab workspace get "$AFLAT_WSID" | jq -r '.result.workspace.label')

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -2529,9 +2529,6 @@ test_presentation_session_lock_path_is_shared_across_homes() {
     *) fail "session lock path must use this account's machine namespace: $path_a" ;;
   esac
   case "$path_a" in
-    /tmp/firstmate-herdr-presentation/*) fail "session lock path must not use a namespace name another account can claim: $path_a" ;;
-  esac
-  case "$path_a" in
     */state/*) fail "session lock path must not live under a home state directory: $path_a" ;;
   esac
   path_other=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -2525,8 +2525,11 @@ test_presentation_session_lock_path_is_shared_across_homes() {
     || fail "session lock path resolution failed for home B"
   [ "$path_a" = "$path_b" ] || fail "same session/socket must resolve one shared lock path"
   case "$path_a" in
-    /tmp/firstmate-herdr-presentation/order-*.lock) ;;
-    *) fail "session lock path must use the shared machine namespace: $path_a" ;;
+    "/tmp/firstmate-herdr-presentation-$(id -u)/order-"*.lock) ;;
+    *) fail "session lock path must use this account's machine namespace: $path_a" ;;
+  esac
+  case "$path_a" in
+    /tmp/firstmate-herdr-presentation/*) fail "session lock path must not use a namespace name another account can claim: $path_a" ;;
   esac
   case "$path_a" in
     */state/*) fail "session lock path must not live under a home state directory: $path_a" ;;
@@ -2551,6 +2554,109 @@ test_presentation_session_lock_path_is_shared_across_homes() {
       || fail "symlink parent socket paths must resolve one lock: $path_tmp vs $path_private"
   fi
   pass "herdr presentation lock: one path per session/socket across homes"
+}
+
+# A second account on the machine must not be able to claim the lock namespace
+# name and lock this account out of it permanently. The uid is driven apart with
+# a fake `id` rather than a real second account, so the divergence is real for
+# every function that reads it while the case stays unprivileged.
+make_uid_fakebin() {  # <dir> <fakebin> <uid> -> echoes fakebin dir
+  local dir=$1 fb=$2 uid=$3
+  mkdir -p "$fb"
+  cat > "$fb/id" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = -u ] && [ \$# -eq 1 ]; then printf '%s\n' '$uid'; exit 0; fi
+exec /usr/bin/id "\$@"
+SH
+  chmod +x "$fb/id"
+  cp "$dir/fakebin/herdr" "$fb/herdr"
+  printf '%s\n' "$fb"
+}
+
+test_presentation_lock_namespace_is_per_account() {
+  local dir log resp fb fb_a fb_b path_real path_a path_b resolved resolved_rc n staged
+  dir="$TMP_ROOT/presentation-namespace-per-account"; mkdir -p "$dir/responses" "$dir/sockdir"
+  log="$dir/log"; resp="$dir/responses"; : > "$log"
+  : > "$dir/sockdir/fmtest.sock"
+  for n in 1 2 3; do
+    printf '%s\n' "{\"sessions\":[{\"name\":\"fmtest\",\"running\":true,\"socket_path\":\"$dir/sockdir/fmtest.sock\"}]}" > "$resp/$n.out"
+  done
+  fb=$(make_herdr_fakebin "$dir")
+  fb_a=$(make_uid_fakebin "$dir" "$dir/fakebin-a" 424241)
+  fb_b=$(make_uid_fakebin "$dir" "$dir/fakebin-b" 424242)
+  path_real=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace' "$ROOT") \
+    || fail "the lock namespace must resolve for this account"
+  path_a=$(PATH="$fb_a:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace' "$ROOT") \
+    || fail "the lock namespace must resolve for account A"
+  path_b=$(PATH="$fb_b:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace' "$ROOT") \
+    || fail "the lock namespace must resolve for account B"
+  [ "$path_a" != "$path_b" ] \
+    || fail "two accounts resolved one lock namespace, so either can lock the other out: $path_a"
+  [ "$path_a" != "$path_real" ] && [ "$path_b" != "$path_real" ] \
+    || fail "a foreign account resolved this account's lock namespace: $path_a $path_b"
+  case "$path_real" in
+    /tmp/firstmate-herdr-presentation) fail "the namespace name is still claimable by any account: $path_real" ;;
+  esac
+  # Another account's namespace present on the machine, at the same mode the
+  # ownership check demands, must be inert for this account rather than
+  # blocking it.
+  for staged in "$path_a" "$path_b"; do
+    mkdir -m 700 "$staged" 2>/dev/null || chmod 700 "$staged" \
+      || fail "could not stage another account's namespace at $staged"
+  done
+  resolved=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path fmtest' "$ROOT")
+  resolved_rc=$?
+  rmdir "$path_a" "$path_b" 2>/dev/null || true
+  [ "$resolved_rc" -eq 0 ] \
+    || fail "another account's namespace blocked this account's lock resolution"
+  case "$resolved" in "$path_real"/*) ;; *) fail "the resolved lock left this account's namespace: $resolved" ;; esac
+  pass "herdr presentation lock: the namespace name is per account, so no account can claim another's"
+}
+
+test_presentation_lock_namespace_foreign_owner_is_diagnosed() {
+  local dir log resp fb fb_foreign out status fault fault_status owner
+  dir="$TMP_ROOT/presentation-namespace-foreign-owner"; mkdir -p "$dir/responses" "$dir/sockdir"
+  log="$dir/log"; resp="$dir/responses"; : > "$log"
+  : > "$dir/sockdir/fmtest.sock"
+  printf '%s\n' "{\"sessions\":[{\"name\":\"fmtest\",\"running\":true,\"socket_path\":\"$dir/sockdir/fmtest.sock\"}]}" > "$resp/1.out"
+  fb=$(make_herdr_fakebin "$dir")
+  # 424243 never owns anything here, so the namespace it resolves is created by
+  # and owned by the real account: exactly the cross-account collision, without
+  # needing a second real account.
+  fb_foreign=$(make_uid_fakebin "$dir" "$dir/fakebin-foreign" 424243)
+  owner=$(id -u)
+  out=$(PATH="$fb_foreign:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path fmtest' "$ROOT" 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "a foreign-owned lock namespace must refuse rather than return a path: $out"
+  fault=$(PATH="$fb_foreign:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace_fault' "$ROOT" 2>&1)
+  fault_status=$?
+  [ "$fault_status" -eq 0 ] \
+    || fail "a foreign-owned lock namespace must be reported as a permanent fault, not a retryable one"
+  assert_contains "$fault" "owned by uid $owner" "the fault did not name the owning account: $fault"
+  assert_contains "$fault" "this account is uid 424243" "the fault did not name this account: $fault"
+  assert_contains "$fault" "remove that directory" "the fault did not name the remedy: $fault"
+  rmdir "/tmp/firstmate-herdr-presentation-424243" 2>/dev/null || true
+  pass "herdr presentation lock: a foreign-owned namespace is diagnosed as permanent and names its remedy"
+}
+
+test_presentation_lock_namespace_usable_reports_no_fault() {
+  local dir log resp fb fault status
+  dir="$TMP_ROOT/presentation-namespace-no-fault"; mkdir -p "$dir/responses" "$dir/sockdir"
+  log="$dir/log"; resp="$dir/responses"; : > "$log"
+  fb=$(make_herdr_fakebin "$dir")
+  fault=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_lock_namespace_fault' "$ROOT" 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] \
+    || fail "this account's own namespace must not be reported as a permanent fault: $fault"
+  [ -z "$fault" ] || fail "a usable namespace must print no diagnosis: $fault"
+  pass "herdr presentation lock: a usable namespace reports no permanent fault"
 }
 
 test_presentation_session_lock_path_rejects_malformed_socket() {
@@ -4410,6 +4516,9 @@ test_projection_order_anchors_the_parent_by_exact_id
 test_projection_order_foreign_new_child_before_parent_is_read_only
 test_projection_order_missing_parent_is_read_only
 test_presentation_session_lock_path_is_shared_across_homes
+test_presentation_lock_namespace_is_per_account
+test_presentation_lock_namespace_foreign_owner_is_diagnosed
+test_presentation_lock_namespace_usable_reports_no_fault
 test_presentation_session_lock_path_rejects_malformed_socket
 test_projection_order_rejects_malformed_socket
 test_projection_reclaim_refusal_matrix_is_non_mutating

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -1498,6 +1498,86 @@ SH
   pass "herdr flat teardown refuses before returning the isolated copy under lock contention and the retry completes cleanly"
 }
 
+# A lock namespace another account owns can never validate here, so retrying is
+# futile: teardown must say that rather than blaming the session, which is what
+# held cleanup open indefinitely and let it later act on a reassigned copy.
+# The account is driven apart with a fake `id -u` rather than a second real
+# account, so the ownership divergence is real without needing privileges.
+install_foreign_uid_fake() {  # <case-dir> <uid>
+  local case_dir=$1 uid=$2
+  cat > "$case_dir/fakebin/id" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = -u ] && [ \$# -eq 1 ]; then printf '%s\n' '$uid'; exit 0; fi
+exec /usr/bin/id "\$@"
+SH
+  chmod +x "$case_dir/fakebin/id"
+}
+
+test_herdr_teardown_diagnoses_a_foreign_owned_lock_namespace() {
+  local case_dir log closed rc owner
+  case_dir=$(make_case herdr-foreign-lock-namespace)
+  write_meta "$case_dir" local-only ship
+  configure_flat_herdr_teardown_case "$case_dir"
+  log="$case_dir/herdr.log"; : > "$log"
+  closed="$case_dir/closed"
+  : > "$case_dir/state/task-x1.status"
+  install_foreign_uid_fake "$case_dir" 424246
+  owner=$(id -u)
+  rc=0
+  FM_FAKE_HERDR_LOG="$log" FM_FAKE_HERDR_CLOSED="$closed" \
+    FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+    run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+  rmdir "/tmp/firstmate-herdr-presentation-424246" 2>/dev/null || true
+  [ "$rc" -ne 0 ] \
+    || fail "herdr-foreign-lock-namespace: teardown proceeded without its presentation lock"
+  [ -e "$case_dir/state/task-x1.meta" ] \
+    || fail "herdr-foreign-lock-namespace: the refusal erased the durable endpoint metadata"
+  [ ! -e "$closed" ] \
+    || fail "herdr-foreign-lock-namespace: the refusal still closed the pane unlocked"
+  assert_grep "owned by uid $owner" "$case_dir/stderr" \
+    "herdr-foreign-lock-namespace: the refusal did not name the owning account"
+  assert_grep "no later attempt will clear it" "$case_dir/stderr" \
+    "herdr-foreign-lock-namespace: the refusal did not say that retrying cannot help"
+  assert_grep "remove that directory" "$case_dir/stderr" \
+    "herdr-foreign-lock-namespace: the refusal did not name the remedy"
+  if grep -q "rerun teardown once the session is reachable" "$case_dir/stderr"; then
+    fail "herdr-foreign-lock-namespace: the refusal blamed the session instead of the namespace"
+  fi
+  pass "herdr teardown separates an unusable lock namespace from an unreachable session"
+}
+
+test_herdr_teardown_ignores_another_accounts_lock_namespace() {
+  local case_dir log closed lock foreign
+  case_dir=$(make_case herdr-other-account-namespace)
+  write_meta "$case_dir" local-only ship
+  configure_flat_herdr_teardown_case "$case_dir"
+  log="$case_dir/herdr.log"; : > "$log"
+  closed="$case_dir/closed"
+  : > "$case_dir/state/task-x1.status"
+  foreign=/tmp/firstmate-herdr-presentation-424247
+  mkdir -m 700 "$foreign" 2>/dev/null || chmod 700 "$foreign" \
+    || fail "herdr-other-account-namespace: could not stage another account's namespace"
+  lock=$(FM_FAKE_HERDR_LOG="$log" FM_FAKE_HERDR_CLOSED="$closed" PATH="$case_dir/fakebin:$PATH" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path default' "$ROOT") \
+    || { rmdir "$foreign" 2>/dev/null || true; fail "herdr-other-account-namespace: the presentation lock path did not resolve"; }
+  case "$lock" in
+    /tmp/firstmate-herdr-presentation/*)
+      rmdir "$foreign" 2>/dev/null || true
+      fail "herdr-other-account-namespace: the lock still uses a namespace name any account can claim: $lock"
+      ;;
+  esac
+  FM_FAKE_HERDR_LOG="$log" FM_FAKE_HERDR_CLOSED="$closed" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+    run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr" \
+    || { rmdir "$foreign" 2>/dev/null || true; fail "herdr-other-account-namespace: teardown failed: $(cat "$case_dir/stderr")"; }
+  rmdir "$foreign" 2>/dev/null || true
+  [ -e "$closed" ] || fail "herdr-other-account-namespace: teardown never closed the pane under its lock"
+  [ ! -e "$case_dir/state/task-x1.meta" ] \
+    || fail "herdr-other-account-namespace: teardown left the durable endpoint metadata behind"
+  grep -q "teardown task-x1 complete" "$case_dir/stdout" \
+    || fail "herdr-other-account-namespace: teardown did not report completion"
+  pass "herdr teardown completes while another account's presentation lock namespace exists"
+}
+
 test_herdr_flat_teardown_refuses_records_on_unparseable_presence() {
   local case_dir log closed rc
   case_dir=$(make_case herdr-garbage-presence)
@@ -2603,6 +2683,8 @@ test_teardown_missing_busy_sidecar_completes
 test_herdr_teardown_clears_escalation_marker
 test_herdr_flat_teardown_refuses_orphaning_records_then_retry_completes
 test_herdr_flat_teardown_refuses_records_on_unparseable_presence
+test_herdr_teardown_diagnoses_a_foreign_owned_lock_namespace
+test_herdr_teardown_ignores_another_accounts_lock_namespace
 test_herdr_flat_teardown_preflight_refuses_before_changes
 test_forced_secondmate_herdr_child_preflight_refuses_before_changes
 test_forced_secondmate_teardown_holds_descendant_lifecycle_locks


### PR DESCRIPTION
## The defect

`fm_backend_herdr_presentation_lock_namespace()` returned the fixed path `/tmp/firstmate-herdr-presentation`, and resolving a lock asserted that the directory is owned by the current uid at mode 700.

On a machine with more than one account, whichever account created the directory first owned it.
Every other account's ownership assertion then refused permanently, because the directory is mode 700 and cannot even be inspected, and the only remedy was a privileged removal by a human.

Observed live on 2026-08-14: uid 502 created the directory, and every operation in the uid 501 home that resolved the lock failed with `herdr session presentation lock could not be resolved for <task>`.

## Why it matters

The refusal blocks teardown outright, so a task whose work has already landed stays recorded as in flight and keeps raising stale-endpoint alarms.
That trains a supervisor to ignore the same alarms that catch a genuinely wedged worker.

It also delays cleanup unboundedly, and a delayed cleanup can act on a stale target.
That happened: by the time a blocked cleanup was finally allowed to run, the local copy it had recorded had been reassigned to a different live task, and running it cleared that task's working copy and killed its agent mid-run.
Nothing was lost because the commits were already in the object store, but the hazard is real and it is a direct consequence of this bug holding cleanup open.

## The fix

Name the namespace `/tmp/firstmate-herdr-presentation-<uid>` so the collision is impossible by construction.

The ownership and mode assertions are kept unchanged.
They are correct and worth having; they simply must not be applied to a name another account can claim first, and they are now applied to a name no other account can claim.
The directory holds only lock files, so the old path is left alone and nothing is migrated.

## Separated diagnostics

The two faults folded into the old message have different remedies, and conflating them sent a supervisor into an infinite retry loop against a condition that could never clear.

- An unresolvable named session may clear on a later attempt.
- An unusable lock namespace never does.

`fm_backend_herdr_presentation_lock_namespace_fault` classifies the second and prints the exact path, the fault, the owning uid, and the remedy.
Teardown, spawn recovery, task kill, and session cleanup now report that fault instead of blaming the session.

## Tests

Regression coverage added through the real executable interface, never by asserting source bytes:

- The namespace name is per account, and another account's namespace is inert.
- A foreign-owned namespace is diagnosed as permanent and names its remedy.
- Teardown reports that fault rather than the session, and completes while another account's namespace exists.
- Ordinary lock contention still reports no namespace fault, so the new classification does not swallow the transient case.

## Survey of the same exposure elsewhere

The brief asked whether any other fixed shared-`/tmp` path in `bin/` carries the same collision exposure.
It does not, and no separate follow-up task is needed:

- Every other `/tmp` use in `bin/` goes through `mktemp`, so the names are unique per invocation.
- `bin/fm-herdr-lab.sh` already scopes its state directory by `${UID}`.
- No other runtime backend (`tmux`, `cmux`, `zellij`, `orca`) uses a fixed shared path at all, so the axis is checked and not applicable there.

## Validation

Reviewed, tested, documented, and linted through the no-mistakes pipeline at head `be1e9bf`, with zero findings at every gate.
