### PR TITLE
fix(spawn): preserve user-installed worker PATH

### DIFF
--- a/bin/fm-remote-job-lib.sh
+++ b/bin/fm-remote-job-lib.sh
@@ -29,8 +29,9 @@
 # its configured FM_ROOT/bin. Every child receives env -i with the composed
 # PATH, HOME, FM_HOME, FM_ROOT_OVERRIDE, and FM_REMOTE_JOB_ACTIVE=1. The PATH
 # is intentionally filesystem-discovered rather than login-shell-derived:
-# ~/.local/bin; nvm, asdf, and mise shims/install bins; Nix; Homebrew; and the
-# system tail. No shell startup files are evaluated.
+# ~/.local/bin; nvm, asdf, and mise shims/install bins; Nix; linked Homebrew;
+# the system tail; and last of all Homebrew's keg-only versioned formula bins.
+# No shell startup files are evaluated.
 #
 # On macOS the worker is Firstmate's Aqua LaunchAgent
 # dev.firstmate.remote-job at ~/Library/LaunchAgents/dev.firstmate.remote-job.plist
@@ -135,6 +136,39 @@ fm_remote_job_append_glob_dirs() { # <glob whose matches are directories>
   done < <(compgen -G "$pattern" || true)
 }
 
+# The Homebrew prefixes this composer inspects, in order. Apple Silicon uses
+# /opt/homebrew and Intel uses /usr/local; a host with only one of them simply
+# contributes nothing for the other. The override exists for isolated tests,
+# which cannot install a real Homebrew prefix.
+fm_remote_job_homebrew_prefixes() {
+  local raw=${FM_REMOTE_JOB_HOMEBREW_PREFIXES_OVERRIDE:-/opt/homebrew:/usr/local} prefix old_ifs
+  old_ifs=$IFS
+  IFS=:
+  for prefix in $raw; do
+    [ -z "$prefix" ] || printf '%s\n' "$prefix"
+  done
+  IFS=$old_ifs
+}
+
+# Homebrew deliberately leaves keg-only formulae - which includes every
+# versioned formula such as node@24 or python@3.13 - unlinked from <prefix>/bin,
+# so a PATH that stops at the linked bin cannot resolve them at all and
+# /usr/bin/env node fails even though the operator installed Node. Their stable
+# launcher directory is <prefix>/opt/<formula>/bin, which survives the formula's
+# own patch upgrades because the versioned name is a symlink into the Cellar.
+#
+# Only <name>@<version> kegs are admitted, and only after the system tail, so
+# this recovers the operator's intent without letting an unlinked formula shadow
+# a system or linked-Homebrew executable - the exact shadowing Homebrew unlinks
+# them to prevent. Several versions of one formula are ordered highest-name
+# first so the choice is deterministic rather than glob-arbitrary.
+fm_remote_job_append_keg_only_bins() { # <homebrew-prefix>
+  local prefix=$1 directory
+  while IFS= read -r directory; do
+    [ -z "$directory" ] || fm_remote_job_path_append_if_dir "$directory"
+  done < <(compgen -G "$prefix/opt/*@*/bin" 2>/dev/null | LC_ALL=C sort -r || true)
+}
+
 fm_remote_job_nvm_default_selector() { # <account-home>
   local account_home=$1 alias_root selector alias_file next depth=0 suffix
   alias_root="$account_home/.nvm/alias"
@@ -209,7 +243,7 @@ fm_remote_job_nvm_selected_bin() { # <account-home>
 }
 
 fm_remote_job_compose_operator_path() { # <account-home>
-  local account_home=$1 account_user nvm_bin
+  local account_home=$1 account_user nvm_bin brew_prefix
   FM_REMOTE_JOB_OPERATOR_PATH=
   fm_remote_job_path_append_if_dir "$account_home/.local/bin"
   nvm_bin=$(fm_remote_job_nvm_selected_bin "$account_home" 2>/dev/null || true)
@@ -226,12 +260,16 @@ fm_remote_job_compose_operator_path() { # <account-home>
     fm_remote_job_path_append_resolved_dir "/etc/profiles/per-user/$account_user/bin"
   fi
   fm_remote_job_path_append_resolved_dir /run/current-system/sw/bin
-  fm_remote_job_path_append_if_dir /opt/homebrew/bin
-  fm_remote_job_path_append_if_dir /usr/local/bin
+  while IFS= read -r brew_prefix; do
+    fm_remote_job_path_append_if_dir "$brew_prefix/bin"
+  done < <(fm_remote_job_homebrew_prefixes)
   fm_remote_job_path_append /usr/bin
   fm_remote_job_path_append /bin
   fm_remote_job_path_append /usr/sbin
   fm_remote_job_path_append /sbin
+  while IFS= read -r brew_prefix; do
+    fm_remote_job_append_keg_only_bins "$brew_prefix"
+  done < <(fm_remote_job_homebrew_prefixes)
   printf '%s\n' "$FM_REMOTE_JOB_OPERATOR_PATH"
 }
 

--- a/bin/fm-remote-job-lib.sh
+++ b/bin/fm-remote-job-lib.sh
@@ -160,13 +160,27 @@ fm_remote_job_homebrew_prefixes() {
 # Only <name>@<version> kegs are admitted, and only after the system tail, so
 # this recovers the operator's intent without letting an unlinked formula shadow
 # a system or linked-Homebrew executable - the exact shadowing Homebrew unlinks
-# them to prevent. Several versions of one formula are ordered highest-name
-# first so the choice is deterministic rather than glob-arbitrary.
+# them to prevent. Several versions of one formula are ordered highest version
+# first, by version sort rather than by name, so python@3.13 outranks python@3.9
+# and node@24 outranks node@8. Plain byte ordering would silently hand every
+# remote worker the older keg whenever the versions differ in digit count.
+fm_remote_job_sort_versions_desc() { # <newline-separated paths>
+  local lines=$1 sorted
+  [ -n "$lines" ] || return 0
+  # Both BSD and GNU sort implement -V; an implementation without it falls back
+  # to byte order rather than dropping every discovered directory.
+  sorted=$(printf '%s\n' "$lines" | LC_ALL=C sort -rV 2>/dev/null) || sorted=
+  [ -n "$sorted" ] || sorted=$(printf '%s\n' "$lines" | LC_ALL=C sort -r)
+  printf '%s\n' "$sorted"
+}
+
 fm_remote_job_append_keg_only_bins() { # <homebrew-prefix>
-  local prefix=$1 directory
+  local prefix=$1 directory matches
+  matches=$(compgen -G "$prefix/opt/*@*/bin" 2>/dev/null || true)
+  [ -n "$matches" ] || return 0
   while IFS= read -r directory; do
     [ -z "$directory" ] || fm_remote_job_path_append_if_dir "$directory"
-  done < <(compgen -G "$prefix/opt/*@*/bin" 2>/dev/null | LC_ALL=C sort -r || true)
+  done < <(fm_remote_job_sort_versions_desc "$matches")
 }
 
 fm_remote_job_nvm_default_selector() { # <account-home>

--- a/bin/fm-remote-job-lib.sh
+++ b/bin/fm-remote-job-lib.sh
@@ -164,7 +164,12 @@ fm_remote_job_homebrew_prefixes() {
 # first, by version sort rather than by name, so python@3.13 outranks python@3.9
 # and node@24 outranks node@8. Plain byte ordering would silently hand every
 # remote worker the older keg whenever the versions differ in digit count.
-fm_remote_job_sort_versions_desc() { # <newline-separated paths>
+#
+# The sort key is the keg directory <name>@<version>, never the discovered
+# <keg>/bin path. A trailing component inverts every strict-prefix version pair:
+# after the shared text of openssl@3 and openssl@3.6, version comparison would
+# weigh `/` against `.` and rank the bare openssl@3 higher.
+fm_remote_job_sort_versions_desc() { # <newline-separated names>
   local lines=$1 sorted
   [ -n "$lines" ] || return 0
   # Both BSD and GNU sort implement -V; an implementation without it falls back
@@ -175,12 +180,15 @@ fm_remote_job_sort_versions_desc() { # <newline-separated paths>
 }
 
 fm_remote_job_append_keg_only_bins() { # <homebrew-prefix>
-  local prefix=$1 directory matches
-  matches=$(compgen -G "$prefix/opt/*@*/bin" 2>/dev/null || true)
-  [ -n "$matches" ] || return 0
+  local prefix=$1 directory kegs=''
   while IFS= read -r directory; do
-    [ -z "$directory" ] || fm_remote_job_path_append_if_dir "$directory"
-  done < <(fm_remote_job_sort_versions_desc "$matches")
+    [ -n "$directory" ] || continue
+    kegs="${kegs}${directory%/bin}"$'\n'
+  done < <(compgen -G "$prefix/opt/*@*/bin" 2>/dev/null || true)
+  [ -n "$kegs" ] || return 0
+  while IFS= read -r directory; do
+    [ -z "$directory" ] || fm_remote_job_path_append_if_dir "$directory/bin"
+  done < <(fm_remote_job_sort_versions_desc "$kegs")
 }
 
 fm_remote_job_nvm_default_selector() { # <account-home>

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -161,6 +161,15 @@
 #     __OPINPUT__   absolute path to the canonical operational-input encoder
 #     __WORKTREE__  absolute path to the task worktree
 #     __CURSORBIN__ resolved, cursor-verified executable for a cursor launch
+#   Before any harness launches, fm-spawn prefixes the submitted launch line
+#   with an export of the caller's exact PATH. Long-lived tmux, Herdr, Zellij,
+#   Orca, and cmux providers can otherwise create a fresh shell from an older or
+#   app-owned environment that omits an operator's current user-installed command
+#   directories. The snapshot is one non-empty control-byte-free value,
+#   shell-quoted as data; no other ambient variable is copied by this contract.
+#   Fresh spawns and relaunches both replace, rather than append to, the task
+#   PATH in the same atomic launch submission, so repeated delivery is
+#   deterministic and idempotent and no prompt hook can reset it between steps.
 # Verified per-harness turn-end hooks are installed automatically where enabled; some live outside the worktree.
 # Kimi uses one surgically installed Firstmate region in $HOME/.kimi-code/config.toml,
 # a firstmate-owned global hook and registry, and a gitignored per-task pointer.
@@ -194,6 +203,27 @@
 #   pane export happens on the remote host (bin/fm-remote-secondmate-control.sh).
 #   Local spawns never pass it and resolve their own carrier exactly as before.
 set -eu
+
+# Snapshot and validate the launcher's command search path before resolving any
+# helper or mutating any task state. Session providers are long-lived processes
+# (or GUI apps), so the shell they create can carry an older, app-owned, or
+# otherwise reduced PATH even though every command fm-spawn itself resolves from
+# this value is available now. PATH is the one general ambient variable this
+# boundary deliberately preserves. Reject an empty value and every control byte
+# rather than putting unsafe multi-line or terminal-control input into the
+# one-line launch command; ordinary spaces, quotes, shell metacharacters, and
+# non-ASCII path bytes remain data and are protected later by shell_quote.
+SPAWN_WORKER_PATH=${PATH:-}
+if [ -z "$SPAWN_WORKER_PATH" ]; then
+  echo "error: caller PATH is empty; refusing to launch a worker without a deterministic command search path" >&2
+  exit 1
+fi
+case "$SPAWN_WORKER_PATH" in
+  *[[:cntrl:]]*)
+    echo "error: caller PATH contains a control byte; refusing to place it in the worker command channel" >&2
+    exit 1
+    ;;
+esac
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -2775,6 +2805,10 @@ fi
 if [ -z "$SPAWN_TRACEPARENT" ] && [ "$RELAUNCH" -eq 1 ]; then
   LAUNCH="unset TRACEPARENT; $LAUNCH"
 fi
+# Keep the environment handoff and harness launch in one submitted shell line.
+# This makes the worker independent of the long-lived provider's environment
+# without a second command/prompt cycle that a shell hook could rewrite.
+LAUNCH="export PATH=$(shell_quote "$SPAWN_WORKER_PATH"); $LAUNCH"
 
 spawn_record_traceparent() {
   local meta="$STATE/$ID.meta" tmp status=0

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -196,7 +196,7 @@ family_for_basename() {
     fm-tmux-agent-liveness.test.sh|\
     fm-control.test.sh|fm-control-relaunch.test.sh|\
     fm-herdr-session-cleanup.test.sh|fm-send-resolve-key.test.sh|fm-send-strict.test.sh|fm-spawn-batch.test.sh|\
-    fm-spawn-dispatch-profile.test.sh|\
+    fm-spawn-dispatch-profile.test.sh|fm-spawn-worker-path.test.sh|\
     fm-trace-context-spawn.test.sh|fm-spawn-worktree-settle.test.sh|\
     fm-teardown-endpoint-safety.test.sh)
       printf '%s\n' backend-dispatch

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -216,6 +216,9 @@ New harnesses get verified through a supervised trial task before joining the se
 The verified adapter evidence - each harness's busy-state source, interrupt and exit behavior, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 The executable interrupt and exit mechanics live in [`bin/fm-control-lib.sh`](../bin/fm-control-lib.sh), and [`docs/agent-control.md`](agent-control.md) owns their lifecycle-control architecture.
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
+Before any harness starts, each `fm-spawn.sh` process exports its exact caller `PATH` into the task shell so a long-lived or GUI-owned session provider cannot replace current user-installed command directories with its older environment.
+The value must be non-empty and control-byte-free, is shell-quoted as one data value, and is the only general ambient environment variable copied by this contract.
+The same replacement applies to fresh spawns and relaunches across tmux, Herdr, Zellij, Orca, and cmux, while each harness's narrower explicit environment handling remains layered on top.
 Pi-family launches adapt the regular-TUI safeguard to the installed CLI's capabilities; [`fm-spawn.sh --help`](../bin/fm-spawn.sh) owns the exact version-safe launch mechanics.
 Enabled primary-session turn-end guard integrations are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).
 Kimi remains outside the primary turn-end guard integrations; [`docs/turnend-guard.md`](turnend-guard.md#compatibility-limits) owns its separate captain-approved crew wake hook.

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -42,8 +42,9 @@ The origin URL named for each project must be reachable from the remote account 
 ## Non-interactive tool contract
 
 No login or interactive shell ever runs on the remote host, so `~/.profile`, `~/.bashrc`, and `~/.zshrc` never contribute to the runtime `PATH`.
-`bin/fm-remote-job-lib.sh` is the single owner of the worker `PATH` and builds it by filesystem discovery rather than by evaluating shell startup files.
+`bin/fm-remote-job-lib.sh` is the single owner of the remote job child's `PATH` and builds it by filesystem discovery rather than by evaluating shell startup files.
 The authorized child sees `<remote-root>/bin` first, then a genuine account `~/.local/bin`, the nvm default version bin, asdf shims and install bins, mise shims and install bins, Nix directories, Homebrew directories, and the system tail `/usr/bin:/bin:/usr/sbin:/sbin`.
+When that child runs `fm-spawn.sh`, the ordinary launch contract in [`configuration.md`](configuration.md#harness-support) exports this same explicit value into the remote Herdr pane rather than inheriting the Herdr server's environment.
 Nvm selection follows the filesystem `alias/default` chain and chooses the highest matching installed semantic version, falling back to the highest installed semantic version when the alias is absent or has no installed match.
 An nvm `system` default adds no nvm version bin, so the later system directories provide Node.
 The Nix and package-manager order after version-manager discovery is `~/.nix-profile/bin`, `/etc/profiles/per-user/<account>/bin`, `/run/current-system/sw/bin`, `/opt/homebrew/bin`, and `/usr/local/bin`.

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -43,11 +43,13 @@ The origin URL named for each project must be reachable from the remote account 
 
 No login or interactive shell ever runs on the remote host, so `~/.profile`, `~/.bashrc`, and `~/.zshrc` never contribute to the runtime `PATH`.
 `bin/fm-remote-job-lib.sh` is the single owner of the remote job child's `PATH` and builds it by filesystem discovery rather than by evaluating shell startup files.
-The authorized child sees `<remote-root>/bin` first, then a genuine account `~/.local/bin`, the nvm default version bin, asdf shims and install bins, mise shims and install bins, Nix directories, Homebrew directories, and the system tail `/usr/bin:/bin:/usr/sbin:/sbin`.
+The authorized child sees `<remote-root>/bin` first, then a genuine account `~/.local/bin`, the nvm default version bin, asdf shims and install bins, mise shims and install bins, Nix directories, linked Homebrew directories, the system tail `/usr/bin:/bin:/usr/sbin:/sbin`, and finally Homebrew's keg-only versioned formula bins.
 When that child runs `fm-spawn.sh`, the ordinary launch contract in [`configuration.md`](configuration.md#harness-support) exports this same explicit value into the remote Herdr pane rather than inheriting the Herdr server's environment.
 Nvm selection follows the filesystem `alias/default` chain and chooses the highest matching installed semantic version, falling back to the highest installed semantic version when the alias is absent or has no installed match.
 An nvm `system` default adds no nvm version bin, so the later system directories provide Node.
 The Nix and package-manager order after version-manager discovery is `~/.nix-profile/bin`, `/etc/profiles/per-user/<account>/bin`, `/run/current-system/sw/bin`, `/opt/homebrew/bin`, and `/usr/local/bin`.
+Homebrew unlinks keg-only formulae - which includes every versioned formula such as `node@24` - from `<prefix>/bin`, so `<prefix>/opt/<name>@<version>/bin` is appended after the system tail for both the `/opt/homebrew` and `/usr/local` prefixes.
+That position makes an otherwise unresolvable `node`, `npx`, or `#!/usr/bin/env node` executable work without letting an unlinked formula shadow a system or linked-Homebrew command, and several versions of one formula are ordered highest-name first.
 Exact repeated entries are omitted.
 For the three Nix locations, a final `bin` symlink is resolved to its physical directory, while a path reached through symlinked ancestors remains in its documented position.
 Other final-component symlink directories, including `~/.local/bin`, are excluded.

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -49,7 +49,7 @@ Nvm selection follows the filesystem `alias/default` chain and chooses the highe
 An nvm `system` default adds no nvm version bin, so the later system directories provide Node.
 The Nix and package-manager order after version-manager discovery is `~/.nix-profile/bin`, `/etc/profiles/per-user/<account>/bin`, `/run/current-system/sw/bin`, `/opt/homebrew/bin`, and `/usr/local/bin`.
 Homebrew unlinks keg-only formulae - which includes every versioned formula such as `node@24` - from `<prefix>/bin`, so `<prefix>/opt/<name>@<version>/bin` is appended after the system tail for both the `/opt/homebrew` and `/usr/local` prefixes.
-That position makes an otherwise unresolvable `node`, `npx`, or `#!/usr/bin/env node` executable work without letting an unlinked formula shadow a system or linked-Homebrew command, and several versions of one formula are ordered highest-name first.
+That position makes an otherwise unresolvable `node`, `npx`, or `#!/usr/bin/env node` executable work without letting an unlinked formula shadow a system or linked-Homebrew command, and several versions of one formula are ordered highest version first by version sort, so `python@3.13` outranks `python@3.9`.
 Exact repeated entries are omitted.
 For the three Nix locations, a final `bin` symlink is resolved to its physical directory, while a path reached through symlinked ancestors remains in its documented position.
 Other final-component symlink directories, including `~/.local/bin`, are excluded.

--- a/docs/trace-context.md
+++ b/docs/trace-context.md
@@ -88,9 +88,10 @@ This is a deliberate, source-owned choice:
 ## Safety
 
 - **Default-off.**
-  With no `config/trace-context` and no `FM_TRACE_CONTEXT`, a fresh spawn or actual relaunch injects nothing and writes no `traceparent=` line, so the generated meta and the launch environment are unchanged.
+  With no `config/trace-context` and no `FM_TRACE_CONTEXT`, a fresh spawn or actual relaunch injects no `TRACEPARENT` value and writes no `traceparent=` line, so trace context adds no launch-environment or metadata change.
+  Independent always-on launch contracts, including the caller `PATH` handoff owned by `fm-spawn.sh`, still apply.
   Reusing an already-alive remote endpoint records any carrier that endpoint reports without injecting a new one.
-  A locked session start makes the one config-file check, and each spawn sources one extra library and reads the frozen effective-state file, so the process is not literally byte-for-byte identical, but nothing an agent, an observer, or the task meta can see differs.
+  A locked session start makes the one config-file check, and each spawn sources one extra library and reads the frozen effective-state file, but nothing trace-visible to an agent, observer, or task record differs while the capability is off.
 - **What is and is not exposed.**
   A Firstmate-*minted* root uses a random id and reads no prompt, path, task prose, credential, or arbitrary environment key, so Firstmate never *originates* sensitive data in the carrier.
   Every carrier Firstmate injects is either such a mint or the same task's previously recorded carrier reused verbatim; ambient `TRACEPARENT` is never read, so no caller-controlled bytes enter a new carrier.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -6,6 +6,66 @@ This record contains reusable version-scoped evidence for active runtime guarant
 The backend guides own current setup, safety boundaries, and limitations.
 Exact task chronology, branch names, temporary homes, local paths, process ids, thread ids, and delivery transcripts remain in private reports or PR evidence.
 
+## Worker launch PATH
+
+The shared worker environment handoff was verified on 2026-08-12 with Herdr 0.8.0 protocol 19 on macOS arm64 and with the portable real-`fm-spawn.sh` regression.
+The expected behavior is that the worker receives the exact non-empty, control-byte-free `PATH` of the `fm-spawn.sh` process before its harness starts, rather than the unrelated environment of a long-lived session provider.
+
+The live Herdr reproduction provisioned only a guarded named non-default lab and created a fresh pane from a server process whose `PATH` lacked the keg-only Node prefix.
+The probe printed only `PATH` and command-resolution results, never the rest of the environment.
+
+```sh
+HERDR_LAB_HELPER=bin/fm-herdr-lab.sh
+LAB=$("$HERDR_LAB_HELPER" name worker-path)
+trap '"$HERDR_LAB_HELPER" teardown "$LAB"' EXIT
+"$HERDR_LAB_HELPER" provision "$LAB"
+"$HERDR_LAB_HELPER" run "$LAB" workspace create --cwd "$probe_dir" --label worker-path --no-focus
+"$HERDR_LAB_HELPER" run "$LAB" pane run "$pane" \
+  "sh -c 'printf \"path=%s\\n\" \"\$PATH\"; command -v node || printf \"node=MISSING\\n\"; command -v npx || printf \"npx=MISSING\\n\"'"
+```
+
+Bounded failing shape before the spawn handoff:
+
+```text
+path=/opt/homebrew/bin:/opt/homebrew/sbin:...:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+node=MISSING
+npx=MISSING
+```
+
+Provisioning a second guarded lab from a process whose `PATH` included `/opt/homebrew/opt/node@24/bin` made a fresh pane inherit that directory and execute `npx --version` successfully.
+The final counterfactual also used the same literal-send-then-Enter shape as `fm-spawn.sh`, with the `PATH` export and executable probe in one submitted line, and resolved both commands.
+This is disconfirming evidence against Herdr stripping versioned Homebrew paths or the Node installation itself being defective.
+
+```text
+node=/opt/homebrew/opt/node@24/bin/node
+npx=/opt/homebrew/opt/node@24/bin/npx
+11.12.1
+```
+
+The portable regression drives the real `bin/fm-spawn.sh` interface against a stateful provider-shell fixture whose baseline cannot resolve Node.
+It supplies a temporary `homebrew/opt/node@24/bin`, runs both its `node` executable and an executable carrying `#!/usr/bin/env node`, proves an entry containing spaces, a single quote, a dollar expression, and a semicolon remains quoted data, refuses an empty `PATH` before helper resolution, and refuses a control-byte `PATH` before endpoint creation.
+
+```sh
+tests/fm-spawn-worker-path.test.sh
+```
+
+Observed output:
+
+```text
+ok - fm-spawn: a provider shell missing node receives the exact caller PATH, resolves a versioned formula's node/npx, runs env-node, and preserves quoted entries
+ok - fm-spawn: fresh spawn and public relaunch both replace provider PATH with one deterministic caller snapshot
+ok - fm-spawn: an empty PATH refuses before helper resolution or task mutation
+ok - fm-spawn: a control byte in PATH refuses before endpoint creation and never reaches the worker command channel
+# all fm-spawn worker PATH tests passed
+```
+
+Applicability was inspected across every supported axis.
+All verified worker harnesses - Claude, Codex, OpenCode, Pi, pi-signed, Grok, Kimi, and Muse - launch after the one shared export, and their existing narrower launch prefixes do not clear `PATH`.
+Tmux, Herdr, Zellij, Orca, and cmux all submit that export in the existing backend-neutral literal launch line immediately before the harness command, so no provider-specific environment mutation was added.
+Fresh spawns and recovery relaunches converge by replacing the shell value with the current caller snapshot instead of appending directories.
+A remote secondmate's host-local `fm-spawn.sh` receives the filesystem-composed remote job `PATH` and now forwards that same explicit value into its Herdr pane; the parent-side remote transport remains not applicable because it never creates the remote pane itself.
+Orca and cmux secondmate launches remain not applicable because those backend-kind combinations are still unsupported, while their ordinary worker launches use the shared handoff.
+
 ## tmux
 
 Foreground-process behavior was verified on 2026-07-07 with tmux 3.6a on macOS.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -53,6 +53,7 @@ Observed output:
 
 ```text
 ok - fm-spawn: a provider shell missing node receives the exact caller PATH, resolves a versioned formula's node/npx, runs env-node, and preserves quoted entries
+ok - fm-spawn: the cursor launch template's own env prefix keeps the caller PATH handoff intact
 ok - fm-spawn: fresh spawn and public relaunch both replace provider PATH with one deterministic caller snapshot
 ok - fm-spawn: an empty PATH refuses before helper resolution or task mutation
 ok - fm-spawn: a control byte in PATH refuses before endpoint creation and never reaches the worker command channel
@@ -60,11 +61,27 @@ ok - fm-spawn: a control byte in PATH refuses before endpoint creation and never
 ```
 
 Applicability was inspected across every supported axis.
-All verified worker harnesses - Claude, Codex, OpenCode, Pi, pi-signed, Grok, Kimi, and Muse - launch after the one shared export, and their existing narrower launch prefixes do not clear `PATH`.
+All verified worker harnesses - Claude, Codex, OpenCode, Pi, pi-signed, Grok, Kimi, Cursor, and Muse - launch after the one shared export, and their existing narrower launch prefixes do not clear `PATH`.
+Cursor is the only one whose template already carried an `env` prefix of its own; it unsets four foreign primary markers and never touches `PATH`, and Cursor is crewmate/scout only, so no Cursor secondmate axis exists to inspect.
 Tmux, Herdr, Zellij, Orca, and cmux all submit that export in the existing backend-neutral literal launch line immediately before the harness command, so no provider-specific environment mutation was added.
 Fresh spawns and recovery relaunches converge by replacing the shell value with the current caller snapshot instead of appending directories.
-A remote secondmate's host-local `fm-spawn.sh` receives the filesystem-composed remote job `PATH` and now forwards that same explicit value into its Herdr pane; the parent-side remote transport remains not applicable because it never creates the remote pane itself.
 Orca and cmux secondmate launches remain not applicable because those backend-kind combinations are still unsupported, while their ordinary worker launches use the shared handoff.
+
+A remote secondmate's host-local `fm-spawn.sh` runs as a remote job child, so its caller `PATH` is the filesystem-composed operator `PATH` rather than an interactive one, and it forwards that same explicit value into its Herdr pane.
+That composition previously stopped at the linked `<prefix>/bin`, which by construction cannot contain a keg-only versioned formula, so the remote axis reproduced the original `node=MISSING` / `npx=MISSING` symptom on any host whose Node came from `brew install node@24`.
+`bin/fm-remote-job-lib.sh` is the earliest shared owner of that value, so the fix lands there: `<prefix>/opt/<name>@<version>/bin` is appended after the system tail for both Homebrew prefixes.
+Appending only adds directories, so no richer inherited value is replaced and no linked or system command can be shadowed by an unlinked formula.
+The parent-side remote transport remains not applicable because it never creates the remote pane itself.
+
+```sh
+tests/fm-remote-job.test.sh
+```
+
+Observed output:
+
+```text
+ok - operator PATH resolves a keg-only versioned formula only behind the system tail
+```
 
 ## tmux
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -62,7 +62,10 @@ ok - fm-spawn: a control byte in PATH refuses before endpoint creation and never
 
 Applicability was inspected across every supported axis.
 All verified worker harnesses - Claude, Codex, OpenCode, Pi, pi-signed, Grok, Kimi, Cursor, and Muse - launch after the one shared export, and their existing narrower launch prefixes do not clear `PATH`.
-Cursor is the only one whose template already carried an `env` prefix of its own; it unsets four foreign primary markers and never touches `PATH`, and Cursor is crewmate/scout only, so no Cursor secondmate axis exists to inspect.
+Two templates carry an `env` prefix of their own: Cursor unsets five foreign primary markers, and Muse unsets four and sets `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, and one Muse privacy variable.
+Every harness except Cursor is additionally wrapped in the shared `env -u CURSOR_AGENT -u CURSOR_INVOKED_AS`, so a Muse launch runs through two stacked `env` invocations.
+None of those invocations clears or replaces `PATH` - each only unsets named markers or sets unrelated variables - so the shared export survives every one.
+Cursor's is the only template-level `env` prefix with no shared wrapper behind it, which is why the regression drives Cursor's real template; Cursor is also crewmate/scout only, so no Cursor secondmate axis exists to inspect.
 Tmux, Herdr, Zellij, Orca, and cmux all submit that export in the existing backend-neutral literal launch line immediately before the harness command, so no provider-specific environment mutation was added.
 Fresh spawns and recovery relaunches converge by replacing the shell value with the current caller snapshot instead of appending directories.
 Orca and cmux secondmate launches remain not applicable because those backend-kind combinations are still unsupported, while their ordinary worker launches use the shared handoff.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -69,7 +69,7 @@ Orca and cmux secondmate launches remain not applicable because those backend-ki
 
 A remote secondmate's host-local `fm-spawn.sh` runs as a remote job child, so its caller `PATH` is the filesystem-composed operator `PATH` rather than an interactive one, and it forwards that same explicit value into its Herdr pane.
 That composition previously stopped at the linked `<prefix>/bin`, which by construction cannot contain a keg-only versioned formula, so the remote axis reproduced the original `node=MISSING` / `npx=MISSING` symptom on any host whose Node came from `brew install node@24`.
-`bin/fm-remote-job-lib.sh` is the earliest shared owner of that value, so the fix lands there: `<prefix>/opt/<name>@<version>/bin` is appended after the system tail for both Homebrew prefixes.
+`bin/fm-remote-job-lib.sh` is the earliest shared owner of that value, so the fix lands there: `<prefix>/opt/<name>@<version>/bin` is appended after the system tail for both Homebrew prefixes, highest version first by version sort.
 Appending only adds directories, so no richer inherited value is replaced and no linked or system command can be shadowed by an unlinked formula.
 The parent-side remote transport remains not applicable because it never creates the remote pane itself.
 
@@ -80,7 +80,19 @@ tests/fm-remote-job.test.sh
 Observed output:
 
 ```text
-ok - operator PATH resolves a keg-only versioned formula only behind the system tail
+ok - operator PATH resolves the highest keg-only formula version only behind the system tail
+```
+
+The byte-exact child-`PATH` contract in `tests/fm-on.test.sh` rebuilds the same discovered keg-only tail from the documented contract, so a host with a versioned formula, a host with only unversioned kegs, and a host with no Homebrew each assert a real direction.
+
+```sh
+tests/fm-on.test.sh
+```
+
+Observed output on a macOS arm64 host carrying versioned Homebrew formulae:
+
+```text
+ok - the entrypoint composes a deduplicated discovered child PATH (kept 4 existing, omitted 7 absent)
 ```
 
 ## tmux

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -371,8 +371,8 @@ test_disabled_relaunch_clears_prior_trace_context() {
   expect_code 0 "$rc" "disabled relaunch should succeed"$'\n'"$out"
   [ -z "$(meta_field "$dir" rl33 traceparent)" ] \
     || fail "disabled relaunch must remove the prior trace carrier from metadata"
-  grep -q '^unset TRACEPARENT; .*claude' "$dir/fake/literal" \
-    || fail "disabled relaunch must clear the pane carrier before replacement launch"
+  grep -q '^export PATH=.*; unset TRACEPARENT; .*claude' "$dir/fake/literal" \
+    || fail "disabled relaunch must export worker PATH and clear the pane carrier before replacement launch"
   ! grep -q '^export TRACEPARENT=' "$dir/fake/literal" \
     || fail "disabled relaunch must not export a replacement trace carrier"
   pass "fm-control relaunch: disabling tracing clears metadata and pane context"

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -424,7 +424,8 @@ test_harness_switch_moves_the_record_and_clears_prior_wiring() {
   [ "$(meta_field "$dir" rl4 harness)" = codex ] || fail "the record should follow the switch"
   [ ! -e "$dir/wt/.claude/settings.local.json" ] \
     || fail "the previous harness's per-task wiring must be cleared on a switch"
-  assert_grep "codex" "$dir/fake/literal" "the replacement launch should be the new harness"
+  grep -q '; env -u CURSOR_AGENT -u CURSOR_INVOKED_AS codex .*encode launch-brief' "$dir/fake/literal" \
+    || fail "the replacement launch should execute the new harness after the PATH handoff"
   [ "$(journal_field "$dir" rl4 from_harness)" = claude ] || fail "the journal should record the origin harness"
   [ "$(journal_field "$dir" rl4 to_harness)" = codex ] || fail "the journal should record the target harness"
   pass "fm-control relaunch: switching harness is one ordinary relaunch, and the old wiring goes with the old agent"

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -15,6 +15,12 @@ PYTHON_BIN_DIR=$(dirname "$PYTHON_BIN")
 JQ_BIN=$(command -v jq) || fail "test needs jq"
 BASE_PATH=${FM_TEST_BASE_PATH:-$PYTHON_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin}
 
+test_shell_quote() {
+  printf "'"
+  printf '%s' "$1" | sed "s/'/'\\\\''/g"
+  printf "'"
+}
+
 cleanup_kimi_harness() {
   [ -z "$KIMI_RUNTIME_TASK_TMP" ] || rm -rf "$KIMI_RUNTIME_TASK_TMP"
   rm -rf "$TMP_ROOT"
@@ -177,7 +183,7 @@ EOF
 }
 
 test_kimi_launch_then_send_is_verified() {
-  local id rec out rc launch pointer brief_real meta task_tmp
+  local id rec out rc launch expected pointer brief_real meta task_tmp
   id="kimi-success-z1-$$"
   task_tmp="/tmp/fm-$id"
   KIMI_RUNTIME_TASK_TMP=$task_tmp
@@ -192,8 +198,9 @@ test_kimi_launch_then_send_is_verified() {
   assert_contains "$out" "spawned $id harness=kimi" "kimi spawn did not report success"
 
   launch=$(cat "$CASE_DIR/launch.log")
-  [ "$launch" = "env -u CURSOR_AGENT -u CURSOR_INVOKED_AS '$FAKEBIN_DIR/kimi' --model 'kimi-code/k3' --auto" ] \
-    || fail "kimi launch did not use the absolute binary, model, and --auto only: $launch"
+  expected="export PATH=$(test_shell_quote "$FAKEBIN_DIR:$BASE_PATH"); env -u CURSOR_AGENT -u CURSOR_INVOKED_AS $(test_shell_quote "$FAKEBIN_DIR/kimi") --model 'kimi-code/k3' --auto"
+  [ "$launch" = "$expected" ] \
+    || fail "kimi launch did not use the caller PATH, absolute binary, model, and --auto only: $launch"
   assert_not_contains "$launch" "--effort" "kimi launch emitted a nonexistent effort flag"
   assert_not_contains "$launch" "turn-ended" "kimi launch embedded a turn-end path"
   assert_not_contains "$launch" "__TURNEND__" "kimi launch retained a turn-end placeholder"
@@ -437,7 +444,7 @@ test_kimi_teardown_removes_pointer_and_registry_token() {
 }
 
 test_kimi_falls_back_to_expanded_home_binary() {
-  local id rec out rc launch fallback
+  local id rec out rc launch expected fallback
   id=kimi-fallback-z4
   rec=$(make_spawn_case fallback "$id")
   read_spawn_record "$rec"
@@ -449,8 +456,9 @@ test_kimi_falls_back_to_expanded_home_binary() {
   rc=$?
   expect_code 0 "$rc" "Kimi HOME fallback spawn should succeed"
   launch=$(cat "$CASE_DIR/launch.log")
-  [ "$launch" = "env -u CURSOR_AGENT -u CURSOR_INVOKED_AS '$fallback' --auto" ] \
-    || fail "Kimi fallback did not expand HOME into an absolute executable: $launch"
+  expected="export PATH=$(test_shell_quote "$FAKEBIN_DIR:$BASE_PATH"); env -u CURSOR_AGENT -u CURSOR_INVOKED_AS $(test_shell_quote "$fallback") --auto"
+  [ "$launch" = "$expected" ] \
+    || fail "Kimi fallback did not preserve caller PATH and expand HOME into an absolute executable: $launch"
   pass "fm-spawn: Kimi fallback expands the active HOME"
 }
 

--- a/tests/fm-on.test.sh
+++ b/tests/fm-on.test.sh
@@ -214,12 +214,16 @@ OPTIONAL_DIRS=(
 # this expectation, so a host with such a formula, a host with only unversioned
 # kegs, and a host with no Homebrew each exercise a real direction.
 BREW_PREFIXES=(/opt/homebrew /usr/local)
+# Sorted on the <name>@<version> keg directory, not on the discovered
+# <keg>/bin path, because a trailing component inverts strict-prefix version
+# pairs such as openssl@3 and openssl@3.6.
 keg_dirs_for_prefix() { # <homebrew-prefix>
-  local matches
-  matches=$(compgen -G "$1/opt/*@*/bin" 2>/dev/null || true)
-  [ -n "$matches" ] || return 0
-  printf '%s\n' "$matches" | LC_ALL=C sort -rV 2>/dev/null \
-    || printf '%s\n' "$matches" | LC_ALL=C sort -r
+  local kegs sorted
+  kegs=$(compgen -G "$1/opt/*@*/bin" 2>/dev/null | sed 's|/bin$||' || true)
+  [ -n "$kegs" ] || return 0
+  sorted=$(printf '%s\n' "$kegs" | LC_ALL=C sort -rV 2>/dev/null) || sorted=
+  [ -n "$sorted" ] || sorted=$(printf '%s\n' "$kegs" | LC_ALL=C sort -r)
+  printf '%s\n' "$sorted" | sed 's|$|/bin|'
 }
 KEG_DIRS=()
 for prefix in "${BREW_PREFIXES[@]}"; do

--- a/tests/fm-on.test.sh
+++ b/tests/fm-on.test.sh
@@ -208,6 +208,31 @@ OPTIONAL_DIRS=(
   /opt/homebrew/bin
   /usr/local/bin
 )
+# Homebrew unlinks keg-only versioned formulae from <prefix>/bin, so the
+# contract appends <prefix>/opt/<name>@<version>/bin after the fixed tail,
+# highest version first per prefix. Rebuilt here the same way as the rest of
+# this expectation, so a host with such a formula, a host with only unversioned
+# kegs, and a host with no Homebrew each exercise a real direction.
+BREW_PREFIXES=(/opt/homebrew /usr/local)
+keg_dirs_for_prefix() { # <homebrew-prefix>
+  local matches
+  matches=$(compgen -G "$1/opt/*@*/bin" 2>/dev/null || true)
+  [ -n "$matches" ] || return 0
+  printf '%s\n' "$matches" | LC_ALL=C sort -rV 2>/dev/null \
+    || printf '%s\n' "$matches" | LC_ALL=C sort -r
+}
+KEG_DIRS=()
+for prefix in "${BREW_PREFIXES[@]}"; do
+  while IFS= read -r candidate; do
+    [ -z "$candidate" ] || KEG_DIRS+=("$candidate")
+  done < <(keg_dirs_for_prefix "$prefix")
+done
+UNVERSIONED_KEG_DIRS=()
+for prefix in "${BREW_PREFIXES[@]}"; do
+  while IFS= read -r candidate; do
+    [ -z "$candidate" ] || UNVERSIONED_KEG_DIRS+=("$candidate")
+  done < <(compgen -G "$prefix/opt/*/bin" 2>/dev/null | grep -v '@' || true)
+done
 EXPECTED_PATH=
 expect_dir() {
   case ":$EXPECTED_PATH:" in *":$1:"*) return 0 ;; esac
@@ -232,6 +257,9 @@ for candidate in "${OPTIONAL_DIRS[@]}"; do
   [ -d "$candidate" ] && [ ! -L "$candidate" ] && expect_dir "$candidate"
 done
 for fixed in /usr/bin /bin /usr/sbin /sbin; do expect_dir "$fixed"; done
+for candidate in "${KEG_DIRS[@]}"; do
+  [ -d "$candidate" ] && [ ! -L "$candidate" ] && expect_dir "$candidate"
+done
 
 [ "$CHILD_PATH" = "$EXPECTED_PATH" ] \
   || fail "composed child PATH did not match the portable contract"$'\n'"expected: $EXPECTED_PATH"$'\n'"actual:   $CHILD_PATH"
@@ -243,7 +271,23 @@ else
   path_has "$CHILD_PATH" "$ACCOUNT_HOME/.local/bin" \
     && fail "the account's absent or symlinked ~/.local/bin was added to the child PATH"
 fi
-case "$CHILD_PATH" in *:/usr/bin:/bin:/usr/sbin:/sbin) ;; *) fail "the child PATH did not end with the portable system tail" ;; esac
+case "$CHILD_PATH" in
+  *:/usr/bin:/bin:/usr/sbin:/sbin|*:/usr/bin:/bin:/usr/sbin:/sbin:*) ;;
+  *) fail "the child PATH did not carry the portable system tail as one contiguous run" ;;
+esac
+CHILD_BEFORE_TAIL=${CHILD_PATH%%:/usr/bin:/bin:/usr/sbin:/sbin*}
+CHILD_AFTER_TAIL=${CHILD_PATH#*:/usr/bin:/bin:/usr/sbin:/sbin}
+for candidate in "${KEG_DIRS[@]}"; do
+  [ -d "$candidate" ] && [ ! -L "$candidate" ] || continue
+  path_has "$CHILD_AFTER_TAIL" "$candidate" \
+    || fail "a keg-only versioned formula bin was dropped from the child PATH: $candidate"
+  path_has "$CHILD_BEFORE_TAIL" "$candidate" \
+    && fail "a keg-only versioned formula bin was placed ahead of the system tail: $candidate"
+done
+for candidate in "${UNVERSIONED_KEG_DIRS[@]}"; do
+  path_has "$CHILD_PATH" "$candidate" \
+    && fail "an unversioned keg-only formula bin was added to the child PATH: $candidate"
+done
 DUPES=$(printf '%s\n' "$CHILD_PATH" | tr ':' '\n' | sort | uniq -d)
 [ -z "$DUPES" ] || fail "the child PATH repeated entries: $DUPES"
 PRESENT_CHECKED=0

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -152,6 +152,49 @@ esac
 printf '20\n' > "$NVM_ROOT/alias/default"
 pass "operator PATH honors nvm defaults with a deterministic fallback"
 
+# Homebrew leaves keg-only formulae - every versioned formula included - out of
+# <prefix>/bin, so a remote worker on a host whose Node came from
+# `brew install node@24` could resolve neither node nor a #!/usr/bin/env node
+# executable. The keg bin therefore has to be discovered, but only behind the
+# system tail so an unlinked formula can never shadow a real system command.
+# A dedicated empty account home keeps the nvm fixture above out of this case.
+KEG_HOME="$TMP_ROOT/keg-account"
+KEG_PREFIX="$TMP_ROOT/brew-prefix"
+KEG_LINKED="$KEG_PREFIX/bin"
+KEG_NEW="$KEG_PREFIX/Cellar/node@24/24.14.1/bin"
+KEG_OLD="$KEG_PREFIX/Cellar/node@22/22.9.0/bin"
+KEG_UNVERSIONED="$KEG_PREFIX/opt/libpq/bin"
+mkdir -p "$KEG_HOME" "$KEG_LINKED" "$KEG_NEW" "$KEG_OLD" "$KEG_UNVERSIONED" "$KEG_PREFIX/opt"
+ln -s ../Cellar/node@24/24.14.1 "$KEG_PREFIX/opt/node@24"
+ln -s ../Cellar/node@22/22.9.0 "$KEG_PREFIX/opt/node@22"
+printf '#!/bin/bash\ncase "${1:-}" in */npx) printf "keg-npx-ok\\n" ;; *) printf "keg-node-24\\n" ;; esac\n' > "$KEG_NEW/node"
+printf '#!/usr/bin/env node\n' > "$KEG_NEW/npx"
+printf '#!/bin/bash\nprintf "keg-shadow\\n"\n' > "$KEG_NEW/ls"
+printf '#!/bin/bash\nprintf "keg-node-22\\n"\n' > "$KEG_OLD/node"
+printf '#!/bin/bash\nprintf "keg-psql\\n"\n' > "$KEG_UNVERSIONED/psql"
+chmod +x "$KEG_NEW/node" "$KEG_NEW/npx" "$KEG_NEW/ls" "$KEG_OLD/node" "$KEG_UNVERSIONED/psql"
+FM_REMOTE_JOB_HOMEBREW_PREFIXES_OVERRIDE="$KEG_PREFIX"
+fm_remote_job_compose_operator_path "$KEG_HOME" >/dev/null
+KEG_NODE=$(PATH="$FM_REMOTE_JOB_OPERATOR_PATH" node 2>/dev/null || printf 'MISSING\n')
+[ "$KEG_NODE" = keg-node-24 ] \
+  || fail "the composed PATH did not resolve the highest keg-only versioned formula's node (got '$KEG_NODE')"
+KEG_NPX=$(PATH="$FM_REMOTE_JOB_OPERATOR_PATH" npx 2>/dev/null || printf 'MISSING\n')
+[ "$KEG_NPX" = keg-npx-ok ] \
+  || fail "a keg-only #!/usr/bin/env node executable did not run through the composed PATH (got '$KEG_NPX')"
+KEG_SHADOW=$(PATH="$FM_REMOTE_JOB_OPERATOR_PATH" ls -d "$TMP_ROOT" 2>/dev/null || printf 'MISSING\n')
+[ "$KEG_SHADOW" != keg-shadow ] || fail "a keg-only formula bin shadowed the system tail"
+PATH="$FM_REMOTE_JOB_OPERATOR_PATH" command -v psql >/dev/null 2>&1 \
+  && fail "the composed PATH admitted an unversioned keg-only formula bin"
+printf '#!/bin/bash\nprintf "linked-node\\n"\n' > "$KEG_LINKED/node"
+chmod +x "$KEG_LINKED/node"
+fm_remote_job_compose_operator_path "$KEG_HOME" >/dev/null
+KEG_NODE=$(PATH="$FM_REMOTE_JOB_OPERATOR_PATH" node 2>/dev/null || printf 'MISSING\n')
+[ "$KEG_NODE" = linked-node ] \
+  || fail "a linked Homebrew bin lost precedence to a keg-only formula (got '$KEG_NODE')"
+unset FM_REMOTE_JOB_HOMEBREW_PREFIXES_OVERRIDE
+fm_remote_job_compose_operator_path "$ACCOUNT_HOME" >/dev/null
+pass "operator PATH resolves a keg-only versioned formula only behind the system tail"
+
 NIX_PROFILE="$ACCOUNT_HOME/.nix-profile"
 NIX_BIN="$TMP_ROOT/nix-profile-bin"
 mkdir -p "$NIX_PROFILE" "$NIX_BIN"

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -188,7 +188,13 @@ printf '#!/bin/bash\nprintf "keg-openssl-3.6\\n"\n' > "$KEG_SSL_NEW/fm-keg-opens
 printf '#!/bin/bash\nprintf "keg-openssl-3\\n"\n' > "$KEG_SSL_OLD/fm-keg-openssl"
 chmod +x "$KEG_PY_NEW/fm-keg-python" "$KEG_PY_OLD/fm-keg-python" \
   "$KEG_SSL_NEW/fm-keg-openssl" "$KEG_SSL_OLD/fm-keg-openssl"
-printf '#!/bin/bash\ncase "${1:-}" in */npx) printf "keg-npx-ok\\n" ;; *) printf "keg-node-24\\n" ;; esac\n' > "$KEG_NEW/node"
+cat > "$KEG_NEW/node" <<'SH'
+#!/bin/bash
+case "${1:-}" in
+  */npx) printf 'keg-npx-ok\n' ;;
+  *) printf 'keg-node-24\n' ;;
+esac
+SH
 printf '#!/usr/bin/env node\n' > "$KEG_NEW/npx"
 printf '#!/bin/bash\nprintf "keg-shadow\\n"\n' > "$KEG_NEW/ls"
 printf '#!/bin/bash\nprintf "keg-node-22\\n"\n' > "$KEG_OLD/node"

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -164,9 +164,21 @@ KEG_LINKED="$KEG_PREFIX/bin"
 KEG_NEW="$KEG_PREFIX/Cellar/node@24/24.14.1/bin"
 KEG_OLD="$KEG_PREFIX/Cellar/node@22/22.9.0/bin"
 KEG_UNVERSIONED="$KEG_PREFIX/opt/libpq/bin"
-mkdir -p "$KEG_HOME" "$KEG_LINKED" "$KEG_NEW" "$KEG_OLD" "$KEG_UNVERSIONED" "$KEG_PREFIX/opt"
+# python@3.9 sorts AHEAD of python@3.13 in byte order, so this pair fails
+# whenever the ordering rule is not a version sort.
+KEG_PY_NEW="$KEG_PREFIX/Cellar/python@3.13/3.13.2/bin"
+KEG_PY_OLD="$KEG_PREFIX/Cellar/python@3.9/3.9.21/bin"
+mkdir -p "$KEG_HOME" "$KEG_LINKED" "$KEG_NEW" "$KEG_OLD" "$KEG_UNVERSIONED" \
+  "$KEG_PY_NEW" "$KEG_PY_OLD" "$KEG_PREFIX/opt"
 ln -s ../Cellar/node@24/24.14.1 "$KEG_PREFIX/opt/node@24"
 ln -s ../Cellar/node@22/22.9.0 "$KEG_PREFIX/opt/node@22"
+ln -s ../Cellar/python@3.13/3.13.2 "$KEG_PREFIX/opt/python@3.13"
+ln -s ../Cellar/python@3.9/3.9.21 "$KEG_PREFIX/opt/python@3.9"
+# A name no system directory provides, so the assertion observes the keg
+# ordering itself rather than the system tail that deliberately outranks it.
+printf '#!/bin/bash\nprintf "keg-python-3.13\\n"\n' > "$KEG_PY_NEW/fm-keg-python"
+printf '#!/bin/bash\nprintf "keg-python-3.9\\n"\n' > "$KEG_PY_OLD/fm-keg-python"
+chmod +x "$KEG_PY_NEW/fm-keg-python" "$KEG_PY_OLD/fm-keg-python"
 printf '#!/bin/bash\ncase "${1:-}" in */npx) printf "keg-npx-ok\\n" ;; *) printf "keg-node-24\\n" ;; esac\n' > "$KEG_NEW/node"
 printf '#!/usr/bin/env node\n' > "$KEG_NEW/npx"
 printf '#!/bin/bash\nprintf "keg-shadow\\n"\n' > "$KEG_NEW/ls"
@@ -175,12 +187,27 @@ printf '#!/bin/bash\nprintf "keg-psql\\n"\n' > "$KEG_UNVERSIONED/psql"
 chmod +x "$KEG_NEW/node" "$KEG_NEW/npx" "$KEG_NEW/ls" "$KEG_OLD/node" "$KEG_UNVERSIONED/psql"
 FM_REMOTE_JOB_HOMEBREW_PREFIXES_OVERRIDE="$KEG_PREFIX"
 fm_remote_job_compose_operator_path "$KEG_HOME" >/dev/null
-KEG_NODE=$(PATH="$FM_REMOTE_JOB_OPERATOR_PATH" node 2>/dev/null || printf 'MISSING\n')
-[ "$KEG_NODE" = keg-node-24 ] \
-  || fail "the composed PATH did not resolve the highest keg-only versioned formula's node (got '$KEG_NODE')"
-KEG_NPX=$(PATH="$FM_REMOTE_JOB_OPERATOR_PATH" npx 2>/dev/null || printf 'MISSING\n')
-[ "$KEG_NPX" = keg-npx-ok ] \
-  || fail "a keg-only #!/usr/bin/env node executable did not run through the composed PATH (got '$KEG_NPX')"
+KEG_PYTHON=$(PATH="$FM_REMOTE_JOB_OPERATOR_PATH" fm-keg-python 2>/dev/null || printf 'MISSING\n')
+[ "$KEG_PYTHON" = keg-python-3.13 ] \
+  || fail "keg-only formula versions were not ordered by version (got '$KEG_PYTHON')"
+# A distribution that ships /usr/bin/node keeps that system copy ahead of an
+# unlinked keg on purpose, so the executable node/npx proof only runs where the
+# system tail is silent. The always-portable proof that a worker resolves node
+# and a #!/usr/bin/env node executable lives in
+# tests/fm-spawn-worker-path.test.sh, where the whole caller PATH is controlled.
+if PATH=/usr/bin:/bin:/usr/sbin:/sbin command -v node >/dev/null 2>&1; then
+  case ":$FM_REMOTE_JOB_OPERATOR_PATH:" in
+    *":$KEG_PREFIX/opt/node@24/bin:"*) ;;
+    *) fail "the composed PATH omitted the keg-only node@24 bin" ;;
+  esac
+else
+  KEG_NODE=$(PATH="$FM_REMOTE_JOB_OPERATOR_PATH" node 2>/dev/null || printf 'MISSING\n')
+  [ "$KEG_NODE" = keg-node-24 ] \
+    || fail "the composed PATH did not resolve the highest keg-only versioned formula's node (got '$KEG_NODE')"
+  KEG_NPX=$(PATH="$FM_REMOTE_JOB_OPERATOR_PATH" npx 2>/dev/null || printf 'MISSING\n')
+  [ "$KEG_NPX" = keg-npx-ok ] \
+    || fail "a keg-only #!/usr/bin/env node executable did not run through the composed PATH (got '$KEG_NPX')"
+fi
 KEG_SHADOW=$(PATH="$FM_REMOTE_JOB_OPERATOR_PATH" ls -d "$TMP_ROOT" 2>/dev/null || printf 'MISSING\n')
 [ "$KEG_SHADOW" != keg-shadow ] || fail "a keg-only formula bin shadowed the system tail"
 PATH="$FM_REMOTE_JOB_OPERATOR_PATH" command -v psql >/dev/null 2>&1 \
@@ -193,7 +220,7 @@ KEG_NODE=$(PATH="$FM_REMOTE_JOB_OPERATOR_PATH" node 2>/dev/null || printf 'MISSI
   || fail "a linked Homebrew bin lost precedence to a keg-only formula (got '$KEG_NODE')"
 unset FM_REMOTE_JOB_HOMEBREW_PREFIXES_OVERRIDE
 fm_remote_job_compose_operator_path "$ACCOUNT_HOME" >/dev/null
-pass "operator PATH resolves a keg-only versioned formula only behind the system tail"
+pass "operator PATH resolves the highest keg-only formula version only behind the system tail"
 
 NIX_PROFILE="$ACCOUNT_HOME/.nix-profile"
 NIX_BIN="$TMP_ROOT/nix-profile-bin"

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -164,21 +164,30 @@ KEG_LINKED="$KEG_PREFIX/bin"
 KEG_NEW="$KEG_PREFIX/Cellar/node@24/24.14.1/bin"
 KEG_OLD="$KEG_PREFIX/Cellar/node@22/22.9.0/bin"
 KEG_UNVERSIONED="$KEG_PREFIX/opt/libpq/bin"
-# python@3.9 sorts AHEAD of python@3.13 in byte order, so this pair fails
-# whenever the ordering rule is not a version sort.
+# Two ordering shapes that byte order and path-suffixed version sort each get
+# wrong. python@3.9 sorts AHEAD of python@3.13 in byte order. openssl@3.6 sorts
+# BELOW openssl@3 whenever the trailing /bin rides along in the sort key,
+# because version comparison then weighs `/` against `.` after the shared text.
 KEG_PY_NEW="$KEG_PREFIX/Cellar/python@3.13/3.13.2/bin"
 KEG_PY_OLD="$KEG_PREFIX/Cellar/python@3.9/3.9.21/bin"
+KEG_SSL_NEW="$KEG_PREFIX/Cellar/openssl@3.6/3.6.1/bin"
+KEG_SSL_OLD="$KEG_PREFIX/Cellar/openssl@3/3.0.18/bin"
 mkdir -p "$KEG_HOME" "$KEG_LINKED" "$KEG_NEW" "$KEG_OLD" "$KEG_UNVERSIONED" \
-  "$KEG_PY_NEW" "$KEG_PY_OLD" "$KEG_PREFIX/opt"
+  "$KEG_PY_NEW" "$KEG_PY_OLD" "$KEG_SSL_NEW" "$KEG_SSL_OLD" "$KEG_PREFIX/opt"
 ln -s ../Cellar/node@24/24.14.1 "$KEG_PREFIX/opt/node@24"
 ln -s ../Cellar/node@22/22.9.0 "$KEG_PREFIX/opt/node@22"
 ln -s ../Cellar/python@3.13/3.13.2 "$KEG_PREFIX/opt/python@3.13"
 ln -s ../Cellar/python@3.9/3.9.21 "$KEG_PREFIX/opt/python@3.9"
-# A name no system directory provides, so the assertion observes the keg
+ln -s ../Cellar/openssl@3.6/3.6.1 "$KEG_PREFIX/opt/openssl@3.6"
+ln -s ../Cellar/openssl@3/3.0.18 "$KEG_PREFIX/opt/openssl@3"
+# Names no system directory provides, so the assertions observe the keg
 # ordering itself rather than the system tail that deliberately outranks it.
 printf '#!/bin/bash\nprintf "keg-python-3.13\\n"\n' > "$KEG_PY_NEW/fm-keg-python"
 printf '#!/bin/bash\nprintf "keg-python-3.9\\n"\n' > "$KEG_PY_OLD/fm-keg-python"
-chmod +x "$KEG_PY_NEW/fm-keg-python" "$KEG_PY_OLD/fm-keg-python"
+printf '#!/bin/bash\nprintf "keg-openssl-3.6\\n"\n' > "$KEG_SSL_NEW/fm-keg-openssl"
+printf '#!/bin/bash\nprintf "keg-openssl-3\\n"\n' > "$KEG_SSL_OLD/fm-keg-openssl"
+chmod +x "$KEG_PY_NEW/fm-keg-python" "$KEG_PY_OLD/fm-keg-python" \
+  "$KEG_SSL_NEW/fm-keg-openssl" "$KEG_SSL_OLD/fm-keg-openssl"
 printf '#!/bin/bash\ncase "${1:-}" in */npx) printf "keg-npx-ok\\n" ;; *) printf "keg-node-24\\n" ;; esac\n' > "$KEG_NEW/node"
 printf '#!/usr/bin/env node\n' > "$KEG_NEW/npx"
 printf '#!/bin/bash\nprintf "keg-shadow\\n"\n' > "$KEG_NEW/ls"
@@ -190,6 +199,9 @@ fm_remote_job_compose_operator_path "$KEG_HOME" >/dev/null
 KEG_PYTHON=$(PATH="$FM_REMOTE_JOB_OPERATOR_PATH" fm-keg-python 2>/dev/null || printf 'MISSING\n')
 [ "$KEG_PYTHON" = keg-python-3.13 ] \
   || fail "keg-only formula versions were not ordered by version (got '$KEG_PYTHON')"
+KEG_OPENSSL=$(PATH="$FM_REMOTE_JOB_OPERATOR_PATH" fm-keg-openssl 2>/dev/null || printf 'MISSING\n')
+[ "$KEG_OPENSSL" = keg-openssl-3.6 ] \
+  || fail "a strict-prefix keg version pair was ordered by path rather than by version (got '$KEG_OPENSSL')"
 # A distribution that ships /usr/bin/node keeps that system copy ahead of an
 # unlinked keg on purpose, so the executable node/npx proof only runs where the
 # system tail is silent. The always-portable proof that a worker resolves node

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -152,6 +152,13 @@ assert_meta_profile() {
   assert_grep "effort=$effort" "$meta" "meta missing effort=$effort"
 }
 
+assert_worker_path_then_launch() { # <actual> <expected command> <message>
+  case "$1" in
+    "export PATH="*"; $2") return 0 ;;
+  esac
+  fail "$3"$'\n'"expected suffix after PATH export: $2"$'\n'"actual: $1"
+}
+
 test_no_profile_keeps_claude_profile_defaults() {
   local rec id out status expected launch
   id=profile-off-z1
@@ -166,7 +173,8 @@ test_no_profile_keeps_claude_profile_defaults() {
 
   launch=$(cat "$LAUNCH_LOG")
   expected="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
-  [ "$launch" = "$expected" ] || fail "no-profile claude launch did not use the canonical launch kind"$'\n'"expected: $expected"$'\n'"actual:   $launch"
+  assert_worker_path_then_launch "$launch" "$expected" \
+    "no-profile claude launch did not export worker PATH before the canonical launch kind"
   pass "no --model/--effort records defaults and types the claude launch instructions"
 }
 
@@ -414,7 +422,8 @@ test_active_dispatch_profile_allows_raw_launch_command() {
   assert_contains "$out" "spawned $id harness=custom-agent" "spawn did not report raw command harness"
   assert_meta_profile "$HOME_DIR/state/$id.meta" custom-agent default default
   launch=$(cat "$LAUNCH_LOG")
-  [ "$launch" = "custom-agent --flag" ] || fail "raw launch command changed"$'\n'"actual: $launch"
+  assert_worker_path_then_launch "$launch" "custom-agent --flag" \
+    "raw launch command changed beyond the required worker PATH prefix"
   pass "active crew-dispatch profile allows the raw launch-command escape hatch"
 }
 

--- a/tests/fm-spawn-worker-path.test.sh
+++ b/tests/fm-spawn-worker-path.test.sh
@@ -68,18 +68,6 @@ case "${1:-}" in
       printf '%s' "$payload" > "$FM_FAKE_PANE_LAUNCH"
       exit 0
     fi
-    case "$payload" in
-      'export PATH='*)
-        pane_path=$(cat "$FM_FAKE_PANE_PATH_FILE")
-        next=$(PANE_PATH="$pane_path" PAYLOAD="$payload" /bin/sh -c '
-          PATH=$PANE_PATH
-          export PATH
-          eval "$PAYLOAD"
-          printf "%s" "$PATH"
-        ') || exit 1
-        printf '%s' "$next" > "$FM_FAKE_PANE_PATH_FILE"
-        ;;
-    esac
     if [ "$enter" -eq 1 ] && [ -z "$payload" ] && [ -s "$FM_FAKE_PANE_LAUNCH" ]; then
       pane_path=$(cat "$FM_FAKE_PANE_PATH_FILE")
       launch=$(cat "$FM_FAKE_PANE_LAUNCH")
@@ -94,12 +82,16 @@ SH
 }
 
 make_spawn_case() { # <name> [provider-path]
-  local name=$1 provider_path=${2:-/usr/bin:/bin:/usr/sbin:/sbin} base home project worktree fakebin id
+  local name=$1 provider_path=${2:-} base home project worktree fakebin id
   base="$TMP_ROOT/$name"
   home="$base/home"
   project="$base/project"
   worktree="$base/worktree"
   fakebin=$(fm_fakebin "$base/controller")
+  if [ -z "$provider_path" ]; then
+    provider_path="$base/provider-empty"
+    mkdir -p "$provider_path"
+  fi
   id="$name-z1"
   mkdir -p "$home/data/$id" "$home/state" "$home/config" "$home/projects" "$base/pane-home"
   printf 'Delivery contract: mode=no-mistakes\n' > "$home/data/$id/brief.md"
@@ -163,8 +155,8 @@ SH
 SH
   chmod +x "$CASE_BASE/probe.sh"
 
-  if PATH='/usr/bin:/bin:/usr/sbin:/sbin' command -v node >/dev/null 2>&1 \
-     || PATH='/usr/bin:/bin:/usr/sbin:/sbin' command -v npx >/dev/null 2>&1; then
+  if PATH=$(cat "$CASE_BASE/pane.path") command -v node >/dev/null 2>&1 \
+     || PATH=$(cat "$CASE_BASE/pane.path") command -v npx >/dev/null 2>&1; then
     fail "the fake provider baseline unexpectedly resolves node or npx"
   fi
   caller_path="$versioned:$quoted:$FAKEBIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin"

--- a/tests/fm-spawn-worker-path.test.sh
+++ b/tests/fm-spawn-worker-path.test.sh
@@ -110,6 +110,9 @@ read_spawn_case() {
   IFS='|' read -r CASE_BASE HOME_DIR PROJECT_DIR WORKTREE_DIR FAKEBIN_DIR CASE_ID <<EOF_CASE
 $1
 EOF_CASE
+  # The third spawn positional: a raw launch command by default, or a bare
+  # adapter name for a case that must exercise a real harness template.
+  SPAWN_ARG3="sh '$CASE_BASE/probe.sh'"
 }
 
 run_spawn() { # <caller-path> [extra env NAME=value ...]
@@ -125,7 +128,7 @@ run_spawn() { # <caller-path> [extra env NAME=value ...]
     FM_FAKE_PANE_LAUNCH="$CASE_BASE/pane.launch" \
     FM_FAKE_TMUX_LOG="$CASE_BASE/tmux.log" \
     PATH="$caller_path" \
-    "$SPAWN" "$CASE_ID" "$PROJECT_DIR" "sh '$CASE_BASE/probe.sh'" \
+    "$SPAWN" "$CASE_ID" "$PROJECT_DIR" "$SPAWN_ARG3" \
       --backend tmux --mode no-mistakes --yolo off 2>&1
 }
 
@@ -173,6 +176,44 @@ SH
   assert_contains "$result" "quoted-path-ok" "a quoted/metacharacter PATH entry was not preserved as data"
   [ ! -e "$CASE_BASE/literal" ] || fail "PATH shell metacharacters executed instead of remaining quoted data"
   pass "fm-spawn: a provider shell missing node receives the exact caller PATH, resolves a versioned formula's node/npx, runs env-node, and preserves quoted entries"
+}
+
+# Cursor is the only verified worker adapter whose launch template already
+# carries an `env` prefix of its own, so it is the one runtime where a later
+# change could plausibly clear the shared handoff. Drive its real template.
+test_cursor_template_env_prefix_preserves_the_caller_path() {
+  local record versioned caller_path out status result
+  record=$(make_spawn_case cursor-harness)
+  read_spawn_case "$record"
+  versioned="$CASE_BASE/homebrew/opt/node@24/bin"
+  make_fake_node_install "$versioned"
+  cat > "$FAKEBIN_DIR/cursor-agent" <<SH
+#!/bin/sh
+{
+  printf 'path=%s\\n' "\$PATH"
+  printf 'node=%s\\n' "\$(command -v node 2>/dev/null || printf MISSING)"
+  npx
+} > '$CASE_BASE/result'
+SH
+  chmod +x "$FAKEBIN_DIR/cursor-agent"
+  SPAWN_ARG3=cursor
+
+  if PATH=$(cat "$CASE_BASE/pane.path") command -v node >/dev/null 2>&1; then
+    fail "the fake provider baseline unexpectedly resolves node"
+  fi
+  caller_path="$versioned:$FAKEBIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin"
+  out=$(run_spawn "$caller_path" CURSOR_PROJECTS_ROOT_OVERRIDE="$CASE_BASE/cursor-projects")
+  status=$?
+  expect_code 0 "$status" "a cursor spawn should succeed: $out"
+  assert_contains "$out" "spawned $CASE_ID" "the cursor spawn did not report success"
+  result=$(cat "$CASE_BASE/result" 2>/dev/null || true)
+  assert_contains "$result" "path=$caller_path" \
+    "cursor's own env prefix did not preserve the caller PATH"
+  assert_contains "$result" "node=$versioned/node" \
+    "the cursor worker did not resolve node from the versioned formula bin"
+  assert_contains "$result" "npx-env-node-ok" \
+    "the cursor worker could not run a #!/usr/bin/env node executable"
+  pass "fm-spawn: the cursor launch template's own env prefix keeps the caller PATH handoff intact"
 }
 
 test_fresh_spawn_and_relaunch_replace_provider_path_idempotently() {
@@ -258,6 +299,7 @@ SH
 }
 
 test_versioned_homebrew_path_reaches_worker_and_env_shebang
+test_cursor_template_env_prefix_preserves_the_caller_path
 test_fresh_spawn_and_relaunch_replace_provider_path_idempotently
 test_empty_path_refuses_before_helper_resolution
 test_control_byte_path_refuses_before_endpoint_creation

--- a/tests/fm-spawn-worker-path.test.sh
+++ b/tests/fm-spawn-worker-path.test.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# tests/fm-spawn-worker-path.test.sh - worker PATH handoff regressions through
+# the real fm-spawn interface and a stateful fake tmux task shell.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-worker-path)
+
+make_fake_node_install() { # <versioned-bin>
+  local bin=$1
+  mkdir -p "$bin"
+  cat > "$bin/node" <<'SH'
+#!/bin/sh
+case "${1:-}" in
+  */npx) printf 'npx-env-node-ok\n' ;;
+  '') printf 'node-direct-ok\n' ;;
+  *) printf 'node-args-ok:%s\n' "$1" ;;
+esac
+SH
+  cat > "$bin/npx" <<'JS'
+#!/usr/bin/env node
+// The fake node executable reports this script's path as npx-env-node-ok.
+JS
+  chmod +x "$bin/node" "$bin/npx"
+}
+
+make_fake_tmux() { # <fakebin>
+  local fakebin=$1
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >> "$FM_FAKE_TMUX_LOG"
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "$FM_FAKE_PANE_CWD"; exit 0 ;;
+  *"#{pane_current_command}"*) printf 'sh\n'; exit 0 ;;
+  *"#{pane_tty}"*) exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows)
+    if [ "${FM_FAKE_ENDPOINT_EXISTS:-0}" = 1 ]; then
+      case "$*" in *'#{window_name}'*) printf 'fm-%s\n' "$FM_FAKE_TASK_ID" ;; esac
+    fi
+    exit 0
+    ;;
+  has-session|new-session|set-window-option|kill-window) exit 0 ;;
+  new-window) printf '@1\n'; exit 0 ;;
+  send-keys)
+    shift
+    literal=0
+    payload=
+    enter=0
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -t) shift 2; continue ;;
+        -l) literal=1; shift; continue ;;
+        Enter|C-m) enter=1; shift; continue ;;
+        *)
+          if [ -z "$payload" ]; then payload=$1; else payload="$payload $1"; fi
+          shift
+          ;;
+      esac
+    done
+    if [ "$literal" -eq 1 ]; then
+      printf '%s' "$payload" > "$FM_FAKE_PANE_LAUNCH"
+      exit 0
+    fi
+    case "$payload" in
+      'export PATH='*)
+        pane_path=$(cat "$FM_FAKE_PANE_PATH_FILE")
+        next=$(PANE_PATH="$pane_path" PAYLOAD="$payload" /bin/sh -c '
+          PATH=$PANE_PATH
+          export PATH
+          eval "$PAYLOAD"
+          printf "%s" "$PATH"
+        ') || exit 1
+        printf '%s' "$next" > "$FM_FAKE_PANE_PATH_FILE"
+        ;;
+    esac
+    if [ "$enter" -eq 1 ] && [ -z "$payload" ] && [ -s "$FM_FAKE_PANE_LAUNCH" ]; then
+      pane_path=$(cat "$FM_FAKE_PANE_PATH_FILE")
+      launch=$(cat "$FM_FAKE_PANE_LAUNCH")
+      env -i HOME="$FM_FAKE_PANE_HOME" PATH="$pane_path" /bin/sh -c "$launch"
+    fi
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+}
+
+make_spawn_case() { # <name> [provider-path]
+  local name=$1 provider_path=${2:-/usr/bin:/bin:/usr/sbin:/sbin} base home project worktree fakebin id
+  base="$TMP_ROOT/$name"
+  home="$base/home"
+  project="$base/project"
+  worktree="$base/worktree"
+  fakebin=$(fm_fakebin "$base/controller")
+  id="$name-z1"
+  mkdir -p "$home/data/$id" "$home/state" "$home/config" "$home/projects" "$base/pane-home"
+  printf 'Delivery contract: mode=no-mistakes\n' > "$home/data/$id/brief.md"
+  printf '%s\n' "$$" > "$home/state/.lock"
+  printf '%s off\n' "$$" > "$home/state/.trace-context-effective"
+  touch "$home/state/.last-watcher-beat"
+  fm_git_worktree "$project" "$worktree" "wt-$name"
+  : > "$base/tmux.log"
+  : > "$base/pane.launch"
+  printf '%s' "$provider_path" > "$base/pane.path"
+  make_fake_tmux "$fakebin"
+  printf '%s\n' "$base|$home|$project|$worktree|$fakebin|$id"
+}
+
+read_spawn_case() {
+  IFS='|' read -r CASE_BASE HOME_DIR PROJECT_DIR WORKTREE_DIR FAKEBIN_DIR CASE_ID <<EOF_CASE
+$1
+EOF_CASE
+}
+
+run_spawn() { # <caller-path> [extra env NAME=value ...]
+  local caller_path=$1
+  shift
+  env "$@" \
+    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_CWD="$WORKTREE_DIR" \
+    FM_FAKE_PANE_HOME="$CASE_BASE/pane-home" FM_FAKE_TASK_ID="$CASE_ID" FM_FAKE_ENDPOINT_EXISTS=0 \
+    FM_FAKE_PANE_PATH_FILE="$CASE_BASE/pane.path" \
+    FM_FAKE_PANE_LAUNCH="$CASE_BASE/pane.launch" \
+    FM_FAKE_TMUX_LOG="$CASE_BASE/tmux.log" \
+    PATH="$caller_path" \
+    "$SPAWN" "$CASE_ID" "$PROJECT_DIR" "sh '$CASE_BASE/probe.sh'" \
+      --backend tmux --mode no-mistakes --yolo off 2>&1
+}
+
+test_versioned_homebrew_path_reaches_worker_and_env_shebang() {
+  local record versioned quoted caller_path out status result
+  record=$(make_spawn_case versioned-homebrew)
+  read_spawn_case "$record"
+  versioned="$CASE_BASE/homebrew/opt/node@24/bin"
+  quoted="$CASE_BASE/user path 'quoted' \$(literal);still-data/bin"
+  make_fake_node_install "$versioned"
+  mkdir -p "$quoted"
+  cat > "$quoted/quoted-tool" <<'SH'
+#!/bin/sh
+printf 'quoted-path-ok\n'
+SH
+  chmod +x "$quoted/quoted-tool"
+  cat > "$CASE_BASE/probe.sh" <<SH
+#!/bin/sh
+{
+  printf 'path=%s\\n' "\$PATH"
+  printf 'node=%s\\n' "\$(command -v node 2>/dev/null || printf MISSING)"
+  node
+  printf 'npx=%s\\n' "\$(command -v npx 2>/dev/null || printf MISSING)"
+  npx
+  quoted-tool
+} > '$CASE_BASE/result'
+SH
+  chmod +x "$CASE_BASE/probe.sh"
+
+  if PATH='/usr/bin:/bin:/usr/sbin:/sbin' command -v node >/dev/null 2>&1 \
+     || PATH='/usr/bin:/bin:/usr/sbin:/sbin' command -v npx >/dev/null 2>&1; then
+    fail "the fake provider baseline unexpectedly resolves node or npx"
+  fi
+  caller_path="$versioned:$quoted:$FAKEBIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin"
+  out=$(run_spawn "$caller_path")
+  status=$?
+  expect_code 0 "$status" "spawn with a versioned Homebrew-style caller PATH should succeed: $out"
+  assert_contains "$out" "spawned $CASE_ID" "spawn did not report success"
+  result=$(cat "$CASE_BASE/result" 2>/dev/null || true)
+  assert_contains "$result" "path=$caller_path" "worker did not receive the caller PATH byte-for-byte"
+  assert_contains "$result" "node=$versioned/node" "worker did not resolve node from the versioned formula bin"
+  assert_contains "$result" "node-direct-ok" "resolved node executable did not run"
+  assert_contains "$result" "npx=$versioned/npx" "worker did not resolve npx from the versioned formula bin"
+  assert_contains "$result" "npx-env-node-ok" "the #!/usr/bin/env node npx executable did not run through worker PATH"
+  assert_contains "$result" "quoted-path-ok" "a quoted/metacharacter PATH entry was not preserved as data"
+  [ ! -e "$CASE_BASE/literal" ] || fail "PATH shell metacharacters executed instead of remaining quoted data"
+  pass "fm-spawn: a provider shell missing node receives the exact caller PATH, resolves a versioned formula's node/npx, runs env-node, and preserves quoted entries"
+}
+
+test_fresh_spawn_and_relaunch_replace_provider_path_idempotently() {
+  local record caller_path out status result
+  caller_path="$TMP_ROOT/relaunch-command-bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  mkdir -p "${caller_path%%:*}"
+  record=$(make_spawn_case relaunch-idempotent "/provider/old:/usr/bin:/bin")
+  read_spawn_case "$record"
+  cat > "$CASE_BASE/probe.sh" <<SH
+#!/bin/sh
+printf '%s\\n' "\$PATH" > '$CASE_BASE/result'
+SH
+  chmod +x "$CASE_BASE/probe.sh"
+
+  cat > "$CASE_BASE/fake-harness" <<SH
+#!/bin/sh
+sh '$CASE_BASE/probe.sh'
+SH
+  chmod +x "$CASE_BASE/fake-harness"
+  out=$(run_spawn "$FAKEBIN_DIR:$caller_path")
+  status=$?
+  expect_code 0 "$status" "fresh spawn PATH handoff should succeed"
+  result=$(cat "$CASE_BASE/result" 2>/dev/null || true)
+  [ "$result" = "$FAKEBIN_DIR:$caller_path" ] \
+    || fail "fresh spawn did not replace the provider PATH exactly (got '$result')"
+  case "$result" in *'/provider/old'*) fail "fresh spawn appended to the provider PATH instead of replacing it" ;; esac
+
+  # Recreate a provider-shaped path before driving the public relaunch path.
+  # The task record and worktree come from the successful fresh spawn above.
+  printf '/provider/relaunch:/usr/bin:/bin' > "$CASE_BASE/pane.path"
+  : > "$CASE_BASE/result"
+  : > "$CASE_BASE/pane.launch"
+  : > "$CASE_BASE/tmux.log"
+  out=$(env \
+    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_CWD="$WORKTREE_DIR" \
+    FM_FAKE_PANE_HOME="$CASE_BASE/pane-home" FM_FAKE_TASK_ID="$CASE_ID" FM_FAKE_ENDPOINT_EXISTS=1 FM_FAKE_PANE_PATH_FILE="$CASE_BASE/pane.path" \
+    FM_FAKE_PANE_LAUNCH="$CASE_BASE/pane.launch" FM_FAKE_TMUX_LOG="$CASE_BASE/tmux.log" \
+    PATH="$FAKEBIN_DIR:$caller_path" "$SPAWN" "$CASE_ID" --relaunch --harness "sh '$CASE_BASE/fake-harness'" 2>&1)
+  status=$?
+  expect_code 0 "$status" "relaunch PATH handoff should succeed: $out"
+  assert_contains "$out" "spawned $CASE_ID" "relaunch did not report success"
+  result=$(cat "$CASE_BASE/result" 2>/dev/null || true)
+  [ "$result" = "$FAKEBIN_DIR:$caller_path" ] \
+    || fail "relaunch did not replace the provider PATH with the same snapshot (got '$result')"
+  case "$result" in
+    *'/provider/relaunch'*) fail "relaunch appended to the provider PATH instead of replacing it" ;;
+    *"$FAKEBIN_DIR:$FAKEBIN_DIR"*) fail "relaunch duplicated the caller PATH instead of replacing it idempotently" ;;
+  esac
+  pass "fm-spawn: fresh spawn and public relaunch both replace provider PATH with one deterministic caller snapshot"
+}
+
+test_empty_path_refuses_before_helper_resolution() {
+  local out status
+  out=$(env -i PATH= HOME="${HOME:-/tmp}" /bin/bash "$SPAWN" empty-path-z1 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "an empty caller PATH must be refused"
+  assert_contains "$out" "caller PATH is empty" "empty PATH refusal was not actionable"
+  assert_not_contains "$out" "command not found" "empty PATH reached helper resolution before its validation"
+  pass "fm-spawn: an empty PATH refuses before helper resolution or task mutation"
+}
+
+test_control_byte_path_refuses_before_endpoint_creation() {
+  local record caller_path out status
+  record=$(make_spawn_case control-byte)
+  read_spawn_case "$record"
+  cat > "$CASE_BASE/probe.sh" <<SH
+#!/bin/sh
+: > '$CASE_BASE/result'
+SH
+  chmod +x "$CASE_BASE/probe.sh"
+  caller_path="$FAKEBIN_DIR:/usr/bin:/bin:"$'\n'"$CASE_BASE/injected"
+  out=$(run_spawn "$caller_path")
+  status=$?
+  [ "$status" -ne 0 ] || fail "a control-byte PATH must be refused"
+  assert_contains "$out" "caller PATH contains a control byte" "control-byte refusal was not actionable"
+  ! grep -q '^new-window ' "$CASE_BASE/tmux.log" \
+    || fail "control-byte PATH refusal occurred after a task endpoint was created"
+  [ ! -e "$CASE_BASE/result" ] || fail "control-byte PATH reached the worker launch"
+  pass "fm-spawn: a control byte in PATH refuses before endpoint creation and never reaches the worker command channel"
+}
+
+test_versioned_homebrew_path_reaches_worker_and_env_shebang
+test_fresh_spawn_and_relaunch_replace_provider_path_idempotently
+test_empty_path_refuses_before_helper_resolution
+test_control_byte_path_refuses_before_endpoint_creation
+
+echo "# all fm-spawn worker PATH tests passed"

--- a/tests/fm-spawn-worker-path.test.sh
+++ b/tests/fm-spawn-worker-path.test.sh
@@ -178,9 +178,12 @@ SH
   pass "fm-spawn: a provider shell missing node receives the exact caller PATH, resolves a versioned formula's node/npx, runs env-node, and preserves quoted entries"
 }
 
-# Cursor is the only verified worker adapter whose launch template already
-# carries an `env` prefix of its own, so it is the one runtime where a later
-# change could plausibly clear the shared handoff. Drive its real template.
+# Two launch templates carry an `env` prefix of their own - cursor and muse -
+# and every harness except cursor is additionally wrapped in the shared
+# `env -u CURSOR_AGENT -u CURSOR_INVOKED_AS`. Cursor is therefore the one
+# adapter whose `env` prefix is its own template's alone, with no shared wrapper
+# behind it, so it is the launch shape where a later change could most easily
+# clear the handoff unnoticed. Drive its real template.
 test_cursor_template_env_prefix_preserves_the_caller_path() {
   local record versioned caller_path out status result
   record=$(make_spawn_case cursor-harness)

--- a/tests/fm-trace-context-spawn.test.sh
+++ b/tests/fm-trace-context-spawn.test.sh
@@ -159,6 +159,7 @@ EOF
 
 meta_traceparent() { sed -n 's/^traceparent=//p' "$1"; }
 injected_traceparent() { sed -n 's/^export TRACEPARENT=//p' "$1"; }
+launch_line() { grep 'export PATH=.*; .*CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude ' "$1" | tail -1; }
 
 # Two-level primary -> secondmate -> worker regression for the FM_TRACE_CONTEXT
 # effective override. Drives bin/fm-spawn.sh TWICE against real homes and a real
@@ -255,7 +256,7 @@ test_enabled_records_and_injects_identical_carrier_before_launch() {
 
   gl=$(grep -n '^export GOTMPDIR=' "$LAUNCH_LOG" | tail -1 | cut -d: -f1)
   tl=$(grep -n '^export TRACEPARENT=' "$LAUNCH_LOG" | tail -1 | cut -d: -f1)
-  ll=$(grep -n 'claude' "$LAUNCH_LOG" | tail -1 | cut -d: -f1)
+  ll=$(grep -n 'export PATH=.*; .*CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude ' "$LAUNCH_LOG" | tail -1 | cut -d: -f1)
   [ -n "$gl" ] && [ -n "$tl" ] && [ -n "$ll" ] || fail "launch log missing GOTMPDIR/TRACEPARENT/launch lines"
   [ "$tl" -gt "$gl" ] || fail "TRACEPARENT export must ride the GOTMPDIR pre-launch site (gotmp=$gl tp=$tl)"
   [ "$tl" -lt "$ll" ] || fail "TRACEPARENT export must be sent before the launch literal (tp=$tl launch=$ll)"
@@ -299,7 +300,8 @@ test_failed_delivery_omits_metadata_and_still_launches() {
     || fail "failed traceparent delivery must not leave a traceparent= claim in meta"
   ! grep -q '^export TRACEPARENT=' "$LAUNCH_LOG" \
     || fail "the failed TRACEPARENT export must not be recorded as delivered"
-  grep -q 'claude' "$LAUNCH_LOG" || fail "the source task must still launch"
+  grep -q 'export PATH=.*; .*CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude ' "$LAUNCH_LOG" \
+    || fail "the source task must still launch"
   pass "failed TRACEPARENT delivery omits metadata while the source task still launches"
 }
 
@@ -316,7 +318,7 @@ test_unsafe_delivery_refuses_to_append_launch() {
   [ "$status" -ne 0 ] || fail "uncleared traceparent input must stop spawn"
   assert_contains "$out" "refusing to append the launch command" \
     "unsafe traceparent delivery should report why spawn stopped"
-  ! grep -q 'claude' "$LAUNCH_LOG" \
+  [ -z "$(launch_line "$LAUNCH_LOG")" ] \
     || fail "unsafe traceparent delivery must not append the launch command"
   pass "uncleared TRACEPARENT input stops before the launch command is appended"
 }
@@ -337,7 +339,7 @@ test_failed_metadata_append_unsets_carrier_and_still_launches() {
 
   ! grep -q '^traceparent=' "$meta" \
     || fail "failed metadata append must not leave a traceparent= claim in meta"
-  grep -q '^unset TRACEPARENT; .*claude' "$LAUNCH_LOG" \
+  grep -q '^unset TRACEPARENT; export PATH=.*; .*CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude ' "$LAUNCH_LOG" \
     || fail "failed metadata append must unset TRACEPARENT in the launch command"
   pass "failed traceparent metadata append removes the carrier from the launched task"
 }


### PR DESCRIPTION
## Summary

- Preserve the invoking Firstmate process PATH across the shared worker spawn boundary by shell-quoting one validated snapshot into the same submitted launch line as the harness command.
- Repair remote worker PATH composition for versioned, keg-only Homebrew formulae under the Apple Silicon and Intel prefixes, with deterministic semantic version ordering behind linked Homebrew and system directories.
- Cover fresh spawn, relaunch, Cursor, env-node executables, remote child PATH construction, quoting, control-byte rejection, and non-shadowing behavior.

## Proven cause

- **Trigger:** a long-lived session provider or sanitized remote worker starts from a stale or narrower environment than the Firstmate process that launches the worker.
- **Mask:** the provider was started after PATH enrichment, Node is linked into a generic Homebrew bin directory, or another manager already supplies Node.
- **Symptom:** the harness starts, but node, npx, and tools using `#!/usr/bin/env node` fail inside the worker.
- **Earliest divergence:** the shared spawn owner submitted the harness command without explicitly handing off caller PATH; the remote child path composer also omitted versioned keg-only formula bins.

## Runtime and provider scope

The shared spawn launch applies to tmux, Herdr, Zellij, Orca, and cmux and to the supported worker harnesses routed through it. Fresh spawn and relaunch replace PATH deterministically rather than appending it. Remote jobs add discovered versioned Homebrew formula bins only after richer linked and system paths, so they do not shadow them.

## Verification

- `tests/fm-spawn-worker-path.test.sh`
- `tests/fm-remote-job.test.sh`
- `tests/fm-on.test.sh`
- `tests/fm-spawn-dispatch-profile.test.sh`
- `bin/fm-lint.sh`
- `bin/fm-doc-audience-check.sh`
- `git diff --check origin/main...HEAD`
- Earlier focused backend, relaunch, trace-context, remote, Muse, Grok, and test-runner suites passed before the final review fixes.
- Guarded live Herdr reproduction and counterfactual evidence are recorded in `docs/verification/runtime-backends.md`; the default Herdr session was not changed.

## Unvalidated review concerns

The captain stopped the token-consuming validation run and ordered direct PR delivery. Two late review concerns remain intentionally unaddressed for review or follow-up:

1. Remote discovery does not yet include the standard Linuxbrew prefix `/home/linuxbrew/.linuxbrew`, so versioned Linuxbrew formulae can remain absent on Linux remote workers.
2. The verification record says Cursor has no secondmate axis, while current project documentation and tests indicate Cursor secondmates are supported; that inventory statement and matching secondmate evidence need correction.

No agent co-author was added.
