### PR TITLE
fix(herdr): classify native idle agent status as unknown, not idle

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2900,16 +2900,19 @@ fm_backend_herdr_endpoint_confirmed_gone() {  # <target>
 
 # fm_backend_herdr_classify_agent_status: map a raw `agent get` agent_status
 # value to the adapter's watcher busy|idle|unknown vocabulary. working ->
-# busy (actively generating); idle/done -> idle; blocked -> idle (a blocked
-# agent is stuck waiting on the human, not grinding - the watcher should
-# treat it like a stale pane needing attention, not suppress it as busy);
-# unknown/unparseable/empty -> unknown, the caller's cue to fall back to
-# pane-regex detection.
+# busy (actively generating); done -> idle (terminal); blocked -> idle (a
+# blocked agent is stuck waiting on the human, not grinding - the watcher
+# should treat it like a stale pane needing attention, not suppress it as
+# busy). Herdr's native idle is NOT positive idle evidence: `agent get`
+# reads idle while a harness waits on its own long foreground tool call, so
+# mapping it to idle would misread a busy worker as idle. idle and
+# unknown/unparseable/empty therefore map to unknown, the caller's cue to
+# defer to the task's semantic lifecycle record (bin/fm-busy-lib.sh,
+# agent_start/agent_settled), never to a rendered busy footer.
 fm_backend_herdr_classify_agent_status() {  # <raw-agent_status>
   case "$1" in
     working) printf 'busy' ;;
-    idle|done) printf 'idle' ;;
-    blocked) printf 'idle' ;;
+    done|blocked) printf 'idle' ;;
     *) printf 'unknown' ;;
   esac
 }

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -2971,6 +2971,17 @@ test_busy_state_done_and_blocked_map_to_idle() {
   pass "fm_backend_herdr_busy_state: done -> idle, blocked -> idle (surfaced like a stale pane, not suppressed as busy)"
 }
 
+test_busy_state_idle_maps_to_unknown() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/busy-idle"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/1.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_busy_state default:w1:p2' "$ROOT" )
+  [ "$out" = unknown ] || fail "agent_status=idle should map to unknown (a busy worker on a long foreground tool reads idle), got '$out'"
+  pass "fm_backend_herdr_busy_state: idle -> unknown (native idle never misreads a busy worker as idle)"
+}
+
 test_busy_state_unknown_on_no_agent() {
   local dir log resp fb out
   dir="$TMP_ROOT/busy-unknown"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
@@ -2978,8 +2989,8 @@ test_busy_state_unknown_on_no_agent() {
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_busy_state default:w1:p2' "$ROOT" )
-  [ "$out" = unknown ] || fail "a failed agent get should report unknown (the fallback-to-regex cue), got '$out'"
-  pass "fm_backend_herdr_busy_state: unparseable/absent agent state reports unknown, the regex-fallback cue"
+  [ "$out" = unknown ] || fail "a failed agent get should report unknown (the semantic-record cue), got '$out'"
+  pass "fm_backend_herdr_busy_state: unparseable/absent agent state reports unknown, the semantic-record cue"
 }
 
 # --- composer_state: structural border-row classification --------------------
@@ -4427,6 +4438,7 @@ test_kill_is_best_effort
 test_current_path_reads_cwd
 test_busy_state_working_maps_to_busy
 test_busy_state_done_and_blocked_map_to_idle
+test_busy_state_idle_maps_to_unknown
 test_busy_state_unknown_on_no_agent
 test_composer_state_bare_prompt_is_empty
 test_composer_state_styled_placeholder_draft_is_pending

--- a/tests/fm-busy-state.test.sh
+++ b/tests/fm-busy-state.test.sh
@@ -339,6 +339,21 @@ test_herdr_native_busy_only() {
   pass "herdr's native verdict is trusted for busy only, and records outrank it"
 }
 
+test_busy_pi_record_outranks_hidden_footer_idle() {
+  local state gen out
+  state=$(new_state_dir pi-hidden-footer)
+  # Simulate Calm hiding the Pi "Working..." footer: herdr's native agent
+  # status reads idle even while the Pi worker is mid-turn.
+  # shellcheck disable=SC2329 # invoked indirectly through fm_busy_classify
+  fm_backend_busy_state() { printf 'idle'; }
+  gen=$("$EV" arm "$state" t1)
+  "$EV" apply "$state" t1 busy --gen "$gen" --source pi-ext --event agent-start
+  out=$(fm_busy_classify herdr s:p pi t1 "$state")
+  [ "$out" = "busy pi-ext" ] || fail "a busy Pi record must outrank herdr's hidden-footer idle, got '$out'"
+  unset -f fm_backend_busy_state
+  pass "a busy Pi is classified busy (not stale) even when the Working footer is hidden"
+}
+
 # The record parser runs inside sourcing callers (the watcher, the daemon, the
 # crew-state reader), so it must not disturb their shell: no clobbered
 # positional parameters and no changed glob setting.
@@ -400,6 +415,7 @@ test_kimi_unverified_gate
 test_cursor_ignores_rendered_and_native_signals
 test_dead_endpoint_overrides
 test_herdr_native_busy_only
+test_busy_pi_record_outranks_hidden_footer_idle
 test_record_read_leaves_caller_shell_intact
 test_boolean_view_never_promotes_unknown
 


### PR DESCRIPTION
## Intent

Fix the stale-detection false-positive for Pi workers when Calm mode is on. Root cause: Calm hides the Pi "Working..." rendered footer, so any check that keys off the rendered pane misreads a busy Pi worker as idle; the watcher stale detection flags busy Pi workers as "idle Ns" and floods wedge escalations. Make Pi liveness derive from the extension native agent state (agent_start / agent_settled) rather than the rendered footer token, so a busy Pi worker is never misread as idle regardless of Calm. The fix maps herdr native agent_status "idle" to "unknown" (not "idle") in fm_backend_herdr_classify_agent_status, because herdr agent get reads idle while a harness waits on its own long foreground tool call; done and blocked still map to idle. Add a regression test proving a busy Pi pane is classified busy (not stale) even with the Working footer hidden.

## What Changed

- `fm_backend_herdr_classify_agent_status` now maps the herdr native `agent_status` of `idle` to `unknown` instead of `idle`, since `herdr agent get` reports idle while a harness is blocked on its own long-running foreground tool call; `done` and `blocked` continue to map to `idle`.
- This makes Pi worker liveness derive from the extension's native agent state rather than the rendered "Working…" footer token, so a busy Pi is no longer misread as idle when Calm mode hides that footer.
- Added regression coverage in `tests/fm-backend-herdr.test.sh` (the idle→unknown case) and `tests/fm-busy-state.test.sh` (a busy Pi record still classified `busy pi-ext` with the Working footer hidden).

## Risk Assessment

✅ Low: A tightly-scoped two-line classifier change that fully satisfies the stated intent, is covered by a direct unit test plus a record-precedence regression test, and does not break existing direct-stub or record-dominated tests; the only cross-cutting effect is a benign, intent-aligned delivery-confirmation degradation.

## Testing

`Ran the two targeted shell test files covering the change. The herdr backend tests confirm the corrected native agent_status mapping (idle -> unknown; done/blocked -> idle; working -> busy), and the fm-busy-state suite's new regression test demonstrates the intended end-to-end behavior: a busy Pi worker is classified busy rather than stale even when Calm hides the rendered "Working..." footer. No screenshot/visual artifact applies since this is a shell watcher/classification change with no rendered UI surface; the CLI test transcript is the reviewer-visible evidence. The full fm-backend-herdr.test.sh file is very large and exceeds a 2-minute wall clock, so I scoped it to the relevant busy_state cases (per targeted-validation boundary) — all relevant cases pass. All tests exercised pass; no findings.`

<details>
<summary>Evidence: CLI transcript: Pi stale-detection fix (native idle-&gt;unknown, busy Pi stays busy under Calm)</summary>

<code>=== herdr classify: native agent_status mapping ===&#10;ok - fm_backend_herdr_busy_state: working -&gt; busy&#10;ok - fm_backend_herdr_busy_state: done -&gt; idle, blocked -&gt; idle&#10;ok - fm_backend_herdr_busy_state: idle -&gt; unknown (native idle never misreads a busy worker as idle)&#10;ok - fm_backend_herdr_busy_state: unparseable/absent agent state reports unknown&#10;&#10;=== end-to-end regression (Calm hides Working footer) ===&#10;ok - a busy Pi is classified busy (not stale) even when the Working footer is hidden</code>

```text
Fix: Pi liveness derives from native agent state, not the (Calm-hidden) rendered footer.
herdr native agent_status "idle" now maps to "unknown" (not "idle"); done/blocked still map to idle.

=== herdr classify: native agent_status mapping (tests/fm-backend-herdr.test.sh) ===
ok - fm_backend_herdr_busy_state: working -> busy
ok - fm_backend_herdr_busy_state: done -> idle, blocked -> idle (surfaced like a stale pane, not suppressed as busy)
ok - fm_backend_herdr_busy_state: idle -> unknown (native idle never misreads a busy worker as idle)
ok - fm_backend_herdr_busy_state: unparseable/absent agent state reports unknown, the semantic-record cue

=== end-to-end regression: busy Pi stays busy even when Calm hides the Working footer (tests/fm-busy-state.test.sh) ===
ok - herdr's native verdict is trusted for busy only, and records outrank it
ok - a busy Pi is classified busy (not stale) even when the Working footer is hidden
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-pending-reply-lib.sh:650` - Mapping native idle -&gt; unknown also changes the secondmate delivery-confirmation path: fm_pending_reply_backend_observation (bin/fm-pending-reply-lib.sh:650-652) previously accepted a native &#39;idle&#39; as an immediate positive delivery signal, but now native idle degrades to &#39;unknown&#39; and the observation falls through to the rendered-footer / fallback-idle grace path. This is consistent with the fix&#39;s rationale (native idle is not reliable positive evidence) and still confirms delivery after the grace window, so it is a minor latency tradeoff rather than a regression. Noting for awareness only.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-backend-herdr.test.sh` (targeted): fm_backend_herdr_busy_state working-&gt;busy, done/blocked-&gt;idle, and the new idle-&gt;unknown case all pass</code>
- <code>`bash tests/fm-busy-state.test.sh` (full file, fast): new `test_busy_pi_record_outranks_hidden_footer_idle` proves a busy Pi is classified `busy pi-ext` even with the Working footer hidden; all 22 assertions pass</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
