### PR TITLE
feat(bin): add detect-only project layout preflight for shared-object-cache readiness

### DIFF
--- a/bin/fm-project-layout-lib.sh
+++ b/bin/fm-project-layout-lib.sh
@@ -55,15 +55,17 @@ fmp_path_has_symlink_component() {
 }
 
 fmp_existing_path_physical() {
-  local path=$1 parent base
+  local path=$1 parent base resolved
   [ -e "$path" ] || [ -L "$path" ] || return 1
   if [ -d "$path" ]; then
-    (cd "$path" 2>/dev/null && pwd -P)
-    return
+    resolved=$(cd "$path" 2>/dev/null && pwd -P)
+  else
+    parent=$(dirname "$path")
+    base=$(basename "$path")
+    resolved=$(cd "$parent" 2>/dev/null && printf '%s/%s' "$(pwd -P)" "$base")
   fi
-  parent=$(dirname "$path")
-  base=$(basename "$path")
-  (cd "$parent" 2>/dev/null && printf '%s/%s\n' "$(pwd -P)" "$base")
+  [ -n "$resolved" ] || return 1
+  printf '%s\n' "$resolved"
 }
 
 fmp_nearest_existing_ancestor() {

--- a/bin/fm-project-layout-lib.sh
+++ b/bin/fm-project-layout-lib.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# Read-only helpers for fm-project-layout-preflight.sh.
+#
+# This library owns path canonicalization, portable ownership/mode inspection,
+# local-filesystem classification, Git topology reads, credential redaction,
+# JSON encoding, and the evidence fingerprint used by the preflight command.
+# Sourcing it has no side effects.
+
+fmp_json_escape() {
+  local value=$1
+  value=${value//\\/\\\\}
+  value=${value//\"/\\\"}
+  value=${value//$'\b'/\\b}
+  value=${value//$'\f'/\\f}
+  value=${value//$'\n'/\\n}
+  value=${value//$'\r'/\\r}
+  value=${value//$'\t'/\\t}
+  printf '%s' "$value"
+}
+
+fmp_has_control() {
+  case "$1" in
+    *$'\n'*|*$'\r'*|*$'\t'*) return 0 ;;
+  esac
+  return 1
+}
+
+fmp_absolute_path_is_lexically_safe() {
+  local path=$1
+  case "$path" in
+    /*) ;;
+    *) return 1 ;;
+  esac
+  fmp_has_control "$path" && return 1
+  case "/$path/" in
+    *'/../'*|*'/./'*) return 1 ;;
+  esac
+  return 0
+}
+
+fmp_path_has_symlink_component() {
+  local path=$1 rest component current=
+  fmp_absolute_path_is_lexically_safe "$path" || return 0
+  rest=${path#/}
+  while [ -n "$rest" ]; do
+    case "$rest" in
+      */*) component=${rest%%/*}; rest=${rest#*/} ;;
+      *) component=$rest; rest= ;;
+    esac
+    [ -n "$component" ] || continue
+    current="$current/$component"
+    [ -L "$current" ] && return 0
+  done
+  return 1
+}
+
+fmp_existing_path_physical() {
+  local path=$1 parent base
+  [ -e "$path" ] || [ -L "$path" ] || return 1
+  if [ -d "$path" ]; then
+    (cd "$path" 2>/dev/null && pwd -P)
+    return
+  fi
+  parent=$(dirname "$path")
+  base=$(basename "$path")
+  (cd "$parent" 2>/dev/null && printf '%s/%s\n' "$(pwd -P)" "$base")
+}
+
+fmp_nearest_existing_ancestor() {
+  local path=$1
+  fmp_absolute_path_is_lexically_safe "$path" || return 1
+  while [ ! -e "$path" ] && [ ! -L "$path" ]; do
+    [ "$path" != / ] || break
+    path=$(dirname "$path")
+  done
+  [ -e "$path" ] || [ -L "$path" ] || return 1
+  fmp_existing_path_physical "$path"
+}
+
+fmp_path_is_within() {
+  local parent=$1 child=$2
+  [ "$parent" != "$child" ] || return 1
+  case "$child/" in
+    "$parent/"*) return 0 ;;
+  esac
+  return 1
+}
+
+fmp_stat_uid() {
+  if [ "$(uname -s)" = Darwin ]; then
+    stat -f %u "$1" 2>/dev/null
+  else
+    stat -c %u "$1" 2>/dev/null
+  fi
+}
+
+fmp_stat_mode() {
+  if [ "$(uname -s)" = Darwin ]; then
+    stat -f %Lp "$1" 2>/dev/null
+  else
+    stat -c %a "$1" 2>/dev/null
+  fi
+}
+
+fmp_mode_group_or_world_writable() {
+  local mode=$1 group world
+  case "$mode" in
+    *[!0-7]*|'') return 0 ;;
+  esac
+  mode=${mode#"${mode%???}"}
+  group=${mode%?}
+  group=${group#?}
+  world=${mode#??}
+  case "$group$world" in
+    *2*|*3*|*6*|*7*) return 0 ;;
+  esac
+  return 1
+}
+
+fmp_filesystem_source() {
+  LC_ALL=C df -P "$1" 2>/dev/null | awk 'NF { line=$0 } END { split(line, f, /[[:space:]]+/); print f[1] }'
+}
+
+fmp_filesystem_locality() {
+  local source=$1
+  case "$source" in
+    /dev/*|overlay|overlayfs|tmpfs|devtmpfs|ramfs) printf '%s\n' local ;;
+    *:*|//*) printf '%s\n' network ;;
+    *) printf '%s\n' unknown ;;
+  esac
+}
+
+fmp_git_absolute_dir() {
+  local repo=$1 kind=$2 value
+  case "$kind" in
+    git) value=$(git -C "$repo" rev-parse --absolute-git-dir 2>/dev/null) || return 1 ;;
+    common) value=$(git -C "$repo" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1 ;;
+    *) return 1 ;;
+  esac
+  fmp_existing_path_physical "$value"
+}
+
+fmp_git_object_format() {
+  local repo=$1 format
+  format=$(git -C "$repo" rev-parse --show-object-format 2>/dev/null) || format=
+  if [ -z "$format" ]; then
+    format=$(git -C "$repo" config --get extensions.objectFormat 2>/dev/null) || format=
+  fi
+  printf '%s\n' "${format:-sha1}"
+}
+
+fmp_git_default_branch() {
+  local repo=$1 ref
+  ref=$(git -C "$repo" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null) || ref=
+  case "$ref" in
+    origin/*) printf '%s\n' "${ref#origin/}"; return 0 ;;
+  esac
+  for ref in main master; do
+    if git -C "$repo" rev-parse --verify --quiet "refs/remotes/origin/$ref^{commit}" >/dev/null; then
+      printf '%s\n' "$ref"
+      return 0
+    fi
+  done
+  return 1
+}
+
+fmp_meta_value() {
+  local file=$1 key=$2
+  awk -v wanted="$key" '
+    index($0, wanted "=") == 1 {
+      print substr($0, length(wanted) + 2)
+      exit
+    }
+  ' "$file" 2>/dev/null
+}
+
+fmp_redact_origin() {
+  local origin=$1 scheme rest authority
+  case "$origin" in
+    *://*)
+      scheme=${origin%%://*}
+      rest=${origin#*://}
+      rest=${rest%%\?*}
+      rest=${rest%%\#*}
+      authority=${rest%%/*}
+      case "$authority" in
+        *@*)
+          rest=${rest#*@}
+          printf '%s://<redacted>@%s\n' "$scheme" "$rest"
+          return 0
+          ;;
+      esac
+      printf '%s://%s\n' "$scheme" "$rest"
+      return 0
+      ;;
+  esac
+  printf '%s\n' "$origin"
+}
+
+fmp_origin_has_http_credentials() {
+  local origin=$1 rest authority
+  case "$origin" in
+    http://*|https://*)
+      rest=${origin#*://}
+      authority=${rest%%/*}
+      case "$authority" in *@*) return 0 ;; esac
+      case "$origin" in *\?*|*\#*) return 0 ;; esac
+      ;;
+  esac
+  return 1
+}
+
+fmp_fingerprint() {
+  local output sum bytes
+  output=$(LC_ALL=C cksum) || output="0 0"
+  sum=${output%% *}
+  output=${output#* }
+  bytes=${output%% *}
+  printf 'posix-cksum:%s:%s\n' "$sum" "$bytes"
+}
+
+fmp_csv_contains() {
+  local rest=$1 wanted=$2 item
+  while :; do
+    case "$rest" in
+      *,*) item=${rest%%,*}; rest=${rest#*,} ;;
+      *) item=$rest; rest= ;;
+    esac
+    item=$(printf '%s' "$item" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    [ "$item" = "$wanted" ] && return 0
+    [ -n "$rest" ] || break
+  done
+  return 1
+}

--- a/bin/fm-project-layout-preflight.sh
+++ b/bin/fm-project-layout-preflight.sh
@@ -24,6 +24,11 @@ FM_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # Prevent `git status` and other read-only porcelain from refreshing the index.
 export GIT_OPTIONAL_LOCKS=0
 
+AMBIENT_GIT_ALTERNATES=${GIT_ALTERNATE_OBJECT_DIRECTORIES:-}
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY \
+  GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR GIT_NAMESPACE \
+  GIT_GRAFT_FILE GIT_CEILING_DIRECTORIES GIT_DISCOVERY_ACROSS_FILESYSTEM
+
 # shellcheck source=bin/fm-project-layout-lib.sh
 . "$SCRIPT_DIR/fm-project-layout-lib.sh"
 
@@ -136,13 +141,15 @@ if fmp_path_has_symlink_component "$HOME_ARG"; then
 fi
 
 CURRENT_UID=$(id -u)
-HOME_UID=$(fmp_stat_uid "$HOME_PHYSICAL" 2>/dev/null) || HOME_UID=unknown
-HOME_MODE=$(fmp_stat_mode "$HOME_PHYSICAL" 2>/dev/null) || HOME_MODE=unknown
-if [ "$HOME_UID" != unknown ] && [ "$HOME_UID" != "$CURRENT_UID" ]; then
-  add_blocker home_owner_mismatch "Firstmate home is not owned by the current user"
+HOME_UID=$(fmp_stat_uid "$HOME_PHYSICAL" 2>/dev/null) || HOME_UID=
+HOME_MODE=$(fmp_stat_mode "$HOME_PHYSICAL" 2>/dev/null) || HOME_MODE=
+[ -n "$HOME_UID" ] || HOME_UID=unknown
+[ -n "$HOME_MODE" ] || HOME_MODE=unknown
+if [ "$HOME_UID" != "$CURRENT_UID" ]; then
+  add_blocker home_owner_mismatch "Firstmate home is not verifiably owned by the current user"
 fi
-if [ "$HOME_MODE" != unknown ] && fmp_mode_group_or_world_writable "$HOME_MODE"; then
-  add_blocker home_writable_by_others "Firstmate home is group- or world-writable"
+if [ "$HOME_MODE" = unknown ] || fmp_mode_group_or_world_writable "$HOME_MODE"; then
+  add_blocker home_writable_by_others "Firstmate home is not verifiably owner-only"
 fi
 
 case "$PROJECT_ARG" in
@@ -215,13 +222,15 @@ else
     if [ -z "$PROJECTS_PHYSICAL" ] || ! fmp_path_is_within "$PROJECTS_PHYSICAL" "$PROJECT_PHYSICAL"; then
       add_blocker project_path_escape "Project does not resolve beneath the supplied home's projects directory"
     fi
-    PROJECT_UID=$(fmp_stat_uid "$PROJECT_PHYSICAL" 2>/dev/null) || PROJECT_UID=unknown
-    PROJECT_MODE=$(fmp_stat_mode "$PROJECT_PHYSICAL" 2>/dev/null) || PROJECT_MODE=unknown
-    if [ "$PROJECT_UID" != unknown ] && [ "$PROJECT_UID" != "$CURRENT_UID" ]; then
-      add_blocker project_owner_mismatch "Project is not owned by the current user"
+    PROJECT_UID=$(fmp_stat_uid "$PROJECT_PHYSICAL" 2>/dev/null) || PROJECT_UID=
+    PROJECT_MODE=$(fmp_stat_mode "$PROJECT_PHYSICAL" 2>/dev/null) || PROJECT_MODE=
+    [ -n "$PROJECT_UID" ] || PROJECT_UID=unknown
+    [ -n "$PROJECT_MODE" ] || PROJECT_MODE=unknown
+    if [ "$PROJECT_UID" != "$CURRENT_UID" ]; then
+      add_blocker project_owner_mismatch "Project is not verifiably owned by the current user"
     fi
-    if [ "$PROJECT_MODE" != unknown ] && fmp_mode_group_or_world_writable "$PROJECT_MODE"; then
-      add_blocker project_writable_by_others "Project is group- or world-writable"
+    if [ "$PROJECT_MODE" = unknown ] || fmp_mode_group_or_world_writable "$PROJECT_MODE"; then
+      add_blocker project_writable_by_others "Project is not verifiably owner-only"
     fi
 
     if ! git -C "$PROJECT_PHYSICAL" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
@@ -311,7 +320,7 @@ else
         ALTERNATE=true
         add_blocker unexpected_alternate "Project already borrows from an alternate object store"
       fi
-      if [ -n "${GIT_ALTERNATE_OBJECT_DIRECTORIES:-}" ]; then
+      if [ -n "$AMBIENT_GIT_ALTERNATES" ]; then
         ALTERNATE=true
         add_blocker ambient_alternate "GIT_ALTERNATE_OBJECT_DIRECTORIES is set in the preflight environment"
       fi

--- a/bin/fm-project-layout-preflight.sh
+++ b/bin/fm-project-layout-preflight.sh
@@ -506,49 +506,51 @@ if [ -n "$CACHE_ARG" ]; then
     fi
   else
     CACHE_PHYSICAL=$(fmp_existing_path_physical "$CACHE_ARG") || CACHE_PHYSICAL=
-    CACHE_UID=$(fmp_stat_uid "$CACHE_PHYSICAL" 2>/dev/null) || CACHE_UID=unknown
-    CACHE_MODE=$(fmp_stat_mode "$CACHE_PHYSICAL" 2>/dev/null) || CACHE_MODE=unknown
-    if [ "$CACHE_UID" != "$CURRENT_UID" ]; then
-      add_blocker cache_owner_mismatch "Proposed cache is not owned by the current user"
-    fi
-    if [ "$CACHE_MODE" = unknown ] || fmp_mode_group_or_world_writable "$CACHE_MODE"; then
-      add_blocker cache_permissions "Proposed cache is not verifiably owner-only"
-    fi
-    CACHE_FILESYSTEM_SOURCE=$(fmp_filesystem_source "$CACHE_PHYSICAL")
-    CACHE_FILESYSTEM_LOCALITY=$(fmp_filesystem_locality "$CACHE_FILESYSTEM_SOURCE")
-    case "$CACHE_FILESYSTEM_LOCALITY" in
-      local) ;;
-      network) add_blocker cache_network_filesystem "Proposed cache is on a network filesystem" ;;
-      *) add_blocker cache_filesystem_unknown "Proposed cache filesystem locality cannot be proved" ;;
-    esac
     if [ -z "$CACHE_PHYSICAL" ]; then
       add_blocker cache_unresolved "Proposed cache path could not be resolved to a readable physical directory"
-    elif git -C "$CACHE_PHYSICAL" rev-parse --git-dir >/dev/null 2>&1; then
-      CACHE_IS_GIT=true
-      if [ "$(git -C "$CACHE_PHYSICAL" rev-parse --is-bare-repository 2>/dev/null || echo false)" = true ]; then
-        CACHE_IS_BARE=true
-      else
-        add_blocker cache_not_bare "Proposed per-project cache is not a bare repository"
-      fi
-      CACHE_OBJECT_FORMAT=$(fmp_git_object_format "$CACHE_PHYSICAL")
-      CACHE_ORIGIN_RAW=$(git -C "$CACHE_PHYSICAL" remote get-url origin 2>/dev/null) || CACHE_ORIGIN_RAW=
-      CACHE_ORIGIN_REDACTED=$(fmp_redact_origin "$CACHE_ORIGIN_RAW")
-      if [ -z "$CACHE_ORIGIN_RAW" ]; then
-        add_blocker cache_no_origin "Proposed cache has no origin remote"
-      elif fmp_origin_has_http_credentials "$CACHE_ORIGIN_RAW"; then
-        add_blocker cache_embedded_credentials "Proposed cache origin contains embedded HTTP credentials or query/fragment material; sensitive text was redacted"
-      elif [ -n "$ORIGIN_RAW" ] && [ "$CACHE_ORIGIN_RAW" != "$ORIGIN_RAW" ]; then
-        add_blocker cache_origin_mismatch "Proposed cache origin differs from the control checkout origin"
-      fi
-      if [ "$OBJECT_FORMAT" != unknown ] && [ "$CACHE_OBJECT_FORMAT" != "$OBJECT_FORMAT" ]; then
-        add_blocker cache_object_format_mismatch "Proposed cache and control checkout use different object formats"
-      fi
-      CACHE_ALTERNATES=$(git -C "$CACHE_PHYSICAL" rev-parse --path-format=absolute --git-path objects/info/alternates 2>/dev/null) || CACHE_ALTERNATES=
-      if [ -n "$CACHE_ALTERNATES" ] && [ -s "$CACHE_ALTERNATES" ]; then
-        add_blocker cache_has_alternate "Proposed cache itself borrows objects from another store"
-      fi
     else
-      add_blocker cache_not_git "Proposed cache is not a Git repository"
+      CACHE_UID=$(fmp_stat_uid "$CACHE_PHYSICAL" 2>/dev/null) || CACHE_UID=unknown
+      CACHE_MODE=$(fmp_stat_mode "$CACHE_PHYSICAL" 2>/dev/null) || CACHE_MODE=unknown
+      if [ "$CACHE_UID" != "$CURRENT_UID" ]; then
+        add_blocker cache_owner_mismatch "Proposed cache is not owned by the current user"
+      fi
+      if [ "$CACHE_MODE" = unknown ] || fmp_mode_group_or_world_writable "$CACHE_MODE"; then
+        add_blocker cache_permissions "Proposed cache is not verifiably owner-only"
+      fi
+      CACHE_FILESYSTEM_SOURCE=$(fmp_filesystem_source "$CACHE_PHYSICAL")
+      CACHE_FILESYSTEM_LOCALITY=$(fmp_filesystem_locality "$CACHE_FILESYSTEM_SOURCE")
+      case "$CACHE_FILESYSTEM_LOCALITY" in
+        local) ;;
+        network) add_blocker cache_network_filesystem "Proposed cache is on a network filesystem" ;;
+        *) add_blocker cache_filesystem_unknown "Proposed cache filesystem locality cannot be proved" ;;
+      esac
+      if git -C "$CACHE_PHYSICAL" rev-parse --git-dir >/dev/null 2>&1; then
+        CACHE_IS_GIT=true
+        if [ "$(git -C "$CACHE_PHYSICAL" rev-parse --is-bare-repository 2>/dev/null || echo false)" = true ]; then
+          CACHE_IS_BARE=true
+        else
+          add_blocker cache_not_bare "Proposed per-project cache is not a bare repository"
+        fi
+        CACHE_OBJECT_FORMAT=$(fmp_git_object_format "$CACHE_PHYSICAL")
+        CACHE_ORIGIN_RAW=$(git -C "$CACHE_PHYSICAL" remote get-url origin 2>/dev/null) || CACHE_ORIGIN_RAW=
+        CACHE_ORIGIN_REDACTED=$(fmp_redact_origin "$CACHE_ORIGIN_RAW")
+        if [ -z "$CACHE_ORIGIN_RAW" ]; then
+          add_blocker cache_no_origin "Proposed cache has no origin remote"
+        elif fmp_origin_has_http_credentials "$CACHE_ORIGIN_RAW"; then
+          add_blocker cache_embedded_credentials "Proposed cache origin contains embedded HTTP credentials or query/fragment material; sensitive text was redacted"
+        elif [ -n "$ORIGIN_RAW" ] && [ "$CACHE_ORIGIN_RAW" != "$ORIGIN_RAW" ]; then
+          add_blocker cache_origin_mismatch "Proposed cache origin differs from the control checkout origin"
+        fi
+        if [ "$OBJECT_FORMAT" != unknown ] && [ "$CACHE_OBJECT_FORMAT" != "$OBJECT_FORMAT" ]; then
+          add_blocker cache_object_format_mismatch "Proposed cache and control checkout use different object formats"
+        fi
+        CACHE_ALTERNATES=$(git -C "$CACHE_PHYSICAL" rev-parse --path-format=absolute --git-path objects/info/alternates 2>/dev/null) || CACHE_ALTERNATES=
+        if [ -n "$CACHE_ALTERNATES" ] && [ -s "$CACHE_ALTERNATES" ]; then
+          add_blocker cache_has_alternate "Proposed cache itself borrows objects from another store"
+        fi
+      else
+        add_blocker cache_not_git "Proposed cache is not a Git repository"
+      fi
     fi
   fi
 fi

--- a/bin/fm-project-layout-preflight.sh
+++ b/bin/fm-project-layout-preflight.sh
@@ -40,6 +40,7 @@ while [ "$AMBIENT_CONFIG_INDEX" -lt "$AMBIENT_GIT_CONFIG_COUNT" ]; do
   AMBIENT_CONFIG_INDEX=$((AMBIENT_CONFIG_INDEX + 1))
 done
 unset AMBIENT_CONFIG_INDEX AMBIENT_GIT_CONFIG_COUNT
+unset FM_DATA_OVERRIDE FM_ROOT_OVERRIDE
 
 # shellcheck source=bin/fm-project-layout-lib.sh
 . "$SCRIPT_DIR/fm-project-layout-lib.sh"

--- a/bin/fm-project-layout-preflight.sh
+++ b/bin/fm-project-layout-preflight.sh
@@ -221,7 +221,9 @@ else
     add_blocker project_writable_by_others "Project is group- or world-writable"
   fi
 
-  if ! git -C "$PROJECT_PHYSICAL" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  if [ -z "$PROJECT_PHYSICAL" ]; then
+    add_blocker project_unresolved "Project path could not be resolved to a readable physical directory"
+  elif ! git -C "$PROJECT_PHYSICAL" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     add_blocker project_not_worktree "Project is not an ordinary Git working tree"
   else
     PROJECT_GIT_DIR=$(fmp_git_absolute_dir "$PROJECT_PHYSICAL" git 2>/dev/null) || PROJECT_GIT_DIR=
@@ -392,6 +394,7 @@ if [ -d "$STATE_DIR" ] && [ -n "$PROJECT_PHYSICAL" ]; then
       REPLY_PHASE=$(fmp_meta_value "$REPLY" phase)
       [ "$REPLY_PHASE" != resolved ] || continue
       REPLY_TASK=$(fmp_meta_value "$REPLY" task_id)
+      [ -n "$REPLY_TASK" ] || continue
       if array_contains "$REPLY_TASK" "${LIVE_TASK_IDS[@]:-}"; then
         PENDING_REPLY_COUNT=$((PENDING_REPLY_COUNT + 1))
       fi
@@ -460,7 +463,9 @@ if [ -n "$CANONICAL_ARG" ]; then
     if [ -n "$PROJECT_PHYSICAL" ] && [ "$CANONICAL_PHYSICAL" = "$PROJECT_PHYSICAL" ]; then
       add_blocker canonical_is_control "Canonical human checkout is the Firstmate control checkout"
     fi
-    if git -C "$CANONICAL_PHYSICAL" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if [ -z "$CANONICAL_PHYSICAL" ]; then
+      add_blocker canonical_unresolved "Canonical navigation path could not be resolved to a readable physical directory"
+    elif git -C "$CANONICAL_PHYSICAL" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
       CANONICAL_GIT_DIR=$(fmp_git_absolute_dir "$CANONICAL_PHYSICAL" git 2>/dev/null) || CANONICAL_GIT_DIR=
       CANONICAL_COMMON_DIR=$(fmp_git_absolute_dir "$CANONICAL_PHYSICAL" common 2>/dev/null) || CANONICAL_COMMON_DIR=
       if [ -n "$PROJECT_COMMON_DIR" ] && [ "$CANONICAL_COMMON_DIR" = "$PROJECT_COMMON_DIR" ]; then
@@ -516,7 +521,9 @@ if [ -n "$CACHE_ARG" ]; then
       network) add_blocker cache_network_filesystem "Proposed cache is on a network filesystem" ;;
       *) add_blocker cache_filesystem_unknown "Proposed cache filesystem locality cannot be proved" ;;
     esac
-    if git -C "$CACHE_PHYSICAL" rev-parse --git-dir >/dev/null 2>&1; then
+    if [ -z "$CACHE_PHYSICAL" ]; then
+      add_blocker cache_unresolved "Proposed cache path could not be resolved to a readable physical directory"
+    elif git -C "$CACHE_PHYSICAL" rev-parse --git-dir >/dev/null 2>&1; then
       CACHE_IS_GIT=true
       if [ "$(git -C "$CACHE_PHYSICAL" rev-parse --is-bare-repository 2>/dev/null || echo false)" = true ]; then
         CACHE_IS_BARE=true

--- a/bin/fm-project-layout-preflight.sh
+++ b/bin/fm-project-layout-preflight.sh
@@ -208,139 +208,141 @@ else
   if fmp_path_has_symlink_component "$PROJECT_REQUESTED"; then
     add_blocker project_symlink "Project path has a symlink component"
   fi
-  PROJECTS_PHYSICAL=$(fmp_existing_path_physical "$HOME_PHYSICAL/projects" 2>/dev/null) || PROJECTS_PHYSICAL=
-  if [ -z "$PROJECTS_PHYSICAL" ] || [ -z "$PROJECT_PHYSICAL" ] || ! fmp_path_is_within "$PROJECTS_PHYSICAL" "$PROJECT_PHYSICAL"; then
-    add_blocker project_path_escape "Project does not resolve beneath the supplied home's projects directory"
-  fi
-  PROJECT_UID=$(fmp_stat_uid "$PROJECT_PHYSICAL" 2>/dev/null) || PROJECT_UID=unknown
-  PROJECT_MODE=$(fmp_stat_mode "$PROJECT_PHYSICAL" 2>/dev/null) || PROJECT_MODE=unknown
-  if [ "$PROJECT_UID" != unknown ] && [ "$PROJECT_UID" != "$CURRENT_UID" ]; then
-    add_blocker project_owner_mismatch "Project is not owned by the current user"
-  fi
-  if [ "$PROJECT_MODE" != unknown ] && fmp_mode_group_or_world_writable "$PROJECT_MODE"; then
-    add_blocker project_writable_by_others "Project is group- or world-writable"
-  fi
-
   if [ -z "$PROJECT_PHYSICAL" ]; then
     add_blocker project_unresolved "Project path could not be resolved to a readable physical directory"
-  elif ! git -C "$PROJECT_PHYSICAL" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    add_blocker project_not_worktree "Project is not an ordinary Git working tree"
   else
-    PROJECT_GIT_DIR=$(fmp_git_absolute_dir "$PROJECT_PHYSICAL" git 2>/dev/null) || PROJECT_GIT_DIR=
-    PROJECT_COMMON_DIR=$(fmp_git_absolute_dir "$PROJECT_PHYSICAL" common 2>/dev/null) || PROJECT_COMMON_DIR=
-    [ -n "$PROJECT_GIT_DIR" ] || add_blocker git_dir_unreadable "Project Git directory cannot be resolved"
-    [ -n "$PROJECT_COMMON_DIR" ] || add_blocker common_dir_unreadable "Project common Git directory cannot be resolved"
-    OBJECT_FORMAT=$(fmp_git_object_format "$PROJECT_PHYSICAL")
+    PROJECTS_PHYSICAL=$(fmp_existing_path_physical "$HOME_PHYSICAL/projects" 2>/dev/null) || PROJECTS_PHYSICAL=
+    if [ -z "$PROJECTS_PHYSICAL" ] || ! fmp_path_is_within "$PROJECTS_PHYSICAL" "$PROJECT_PHYSICAL"; then
+      add_blocker project_path_escape "Project does not resolve beneath the supplied home's projects directory"
+    fi
+    PROJECT_UID=$(fmp_stat_uid "$PROJECT_PHYSICAL" 2>/dev/null) || PROJECT_UID=unknown
+    PROJECT_MODE=$(fmp_stat_mode "$PROJECT_PHYSICAL" 2>/dev/null) || PROJECT_MODE=unknown
+    if [ "$PROJECT_UID" != unknown ] && [ "$PROJECT_UID" != "$CURRENT_UID" ]; then
+      add_blocker project_owner_mismatch "Project is not owned by the current user"
+    fi
+    if [ "$PROJECT_MODE" != unknown ] && fmp_mode_group_or_world_writable "$PROJECT_MODE"; then
+      add_blocker project_writable_by_others "Project is group- or world-writable"
+    fi
 
-    ORIGIN_RAW=$(git -C "$PROJECT_PHYSICAL" remote get-url origin 2>/dev/null) || ORIGIN_RAW=
-    if [ -n "$ORIGIN_RAW" ]; then
-      ORIGIN_PRESENT=true
-      ORIGIN_REDACTED=$(fmp_redact_origin "$ORIGIN_RAW")
-      ORIGIN_IDENTITY=$(printf '%s' "$ORIGIN_REDACTED" | fmp_fingerprint)
-      if fmp_origin_has_http_credentials "$ORIGIN_RAW"; then
-        add_blocker origin_embedded_credentials "Origin contains embedded HTTP credentials or query/fragment material; sensitive text was redacted"
-      fi
+    if ! git -C "$PROJECT_PHYSICAL" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      add_blocker project_not_worktree "Project is not an ordinary Git working tree"
     else
-      add_blocker no_origin "Project has no origin remote"
-    fi
+      PROJECT_GIT_DIR=$(fmp_git_absolute_dir "$PROJECT_PHYSICAL" git 2>/dev/null) || PROJECT_GIT_DIR=
+      PROJECT_COMMON_DIR=$(fmp_git_absolute_dir "$PROJECT_PHYSICAL" common 2>/dev/null) || PROJECT_COMMON_DIR=
+      [ -n "$PROJECT_GIT_DIR" ] || add_blocker git_dir_unreadable "Project Git directory cannot be resolved"
+      [ -n "$PROJECT_COMMON_DIR" ] || add_blocker common_dir_unreadable "Project common Git directory cannot be resolved"
+      OBJECT_FORMAT=$(fmp_git_object_format "$PROJECT_PHYSICAL")
 
-    DEFAULT_BRANCH=$(fmp_git_default_branch "$PROJECT_PHYSICAL" 2>/dev/null) || DEFAULT_BRANCH=
-    if [ -z "$DEFAULT_BRANCH" ]; then
-      add_blocker default_branch_unknown "Remote default branch cannot be determined from local refs"
-    fi
-    CURRENT_BRANCH=$(git -C "$PROJECT_PHYSICAL" symbolic-ref --quiet --short HEAD 2>/dev/null) || CURRENT_BRANCH=DETACHED
-    if [ -n "$DEFAULT_BRANCH" ] && [ "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]; then
-      OFF_DEFAULT=true
-      add_blocker off_default "Project checkout is not on its remote default branch"
-    fi
+      ORIGIN_RAW=$(git -C "$PROJECT_PHYSICAL" remote get-url origin 2>/dev/null) || ORIGIN_RAW=
+      if [ -n "$ORIGIN_RAW" ]; then
+        ORIGIN_PRESENT=true
+        ORIGIN_REDACTED=$(fmp_redact_origin "$ORIGIN_RAW")
+        ORIGIN_IDENTITY=$(printf '%s' "$ORIGIN_REDACTED" | fmp_fingerprint)
+        if fmp_origin_has_http_credentials "$ORIGIN_RAW"; then
+          add_blocker origin_embedded_credentials "Origin contains embedded HTTP credentials or query/fragment material; sensitive text was redacted"
+        fi
+      else
+        add_blocker no_origin "Project has no origin remote"
+      fi
 
-    if [ -n "$(git -C "$PROJECT_PHYSICAL" status --porcelain=v1 --untracked-files=normal 2>/dev/null)" ]; then
-      DIRTY=true
-      add_blocker dirty_worktree "Project checkout has uncommitted or untracked changes"
-    fi
+      DEFAULT_BRANCH=$(fmp_git_default_branch "$PROJECT_PHYSICAL" 2>/dev/null) || DEFAULT_BRANCH=
+      if [ -z "$DEFAULT_BRANCH" ]; then
+        add_blocker default_branch_unknown "Remote default branch cannot be determined from local refs"
+      fi
+      CURRENT_BRANCH=$(git -C "$PROJECT_PHYSICAL" symbolic-ref --quiet --short HEAD 2>/dev/null) || CURRENT_BRANCH=DETACHED
+      if [ -n "$DEFAULT_BRANCH" ] && [ "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]; then
+        OFF_DEFAULT=true
+        add_blocker off_default "Project checkout is not on its remote default branch"
+      fi
 
-    if [ -n "$DEFAULT_BRANCH" ] \
-      && git -C "$PROJECT_PHYSICAL" rev-parse --verify --quiet "refs/heads/$DEFAULT_BRANCH^{commit}" >/dev/null 2>&1 \
-      && git -C "$PROJECT_PHYSICAL" rev-parse --verify --quiet "refs/remotes/origin/$DEFAULT_BRANCH^{commit}" >/dev/null 2>&1; then
-      COUNTS=$(git -C "$PROJECT_PHYSICAL" rev-list --left-right --count "$DEFAULT_BRANCH...origin/$DEFAULT_BRANCH" 2>/dev/null) || COUNTS=
-      if [ -n "$COUNTS" ]; then
-        DEFAULT_AHEAD=${COUNTS%%[[:space:]]*}
-        DEFAULT_BEHIND=${COUNTS##*[[:space:]]}
-        if [ "$DEFAULT_AHEAD" -gt 0 ] && [ "$DEFAULT_BEHIND" -gt 0 ]; then
-          DIVERGED=true
-          add_blocker default_diverged "Local and remote default branches have diverged"
-        elif [ "$DEFAULT_AHEAD" -gt 0 ]; then
-          add_blocker default_ahead "Local default branch is ahead of its origin default ref"
-        elif [ "$DEFAULT_BEHIND" -gt 0 ]; then
-          add_warning default_behind "Local default branch is behind its cached origin ref"
+      if [ -n "$(git -C "$PROJECT_PHYSICAL" status --porcelain=v1 --untracked-files=normal 2>/dev/null)" ]; then
+        DIRTY=true
+        add_blocker dirty_worktree "Project checkout has uncommitted or untracked changes"
+      fi
+
+      if [ -n "$DEFAULT_BRANCH" ] \
+        && git -C "$PROJECT_PHYSICAL" rev-parse --verify --quiet "refs/heads/$DEFAULT_BRANCH^{commit}" >/dev/null 2>&1 \
+        && git -C "$PROJECT_PHYSICAL" rev-parse --verify --quiet "refs/remotes/origin/$DEFAULT_BRANCH^{commit}" >/dev/null 2>&1; then
+        COUNTS=$(git -C "$PROJECT_PHYSICAL" rev-list --left-right --count "$DEFAULT_BRANCH...origin/$DEFAULT_BRANCH" 2>/dev/null) || COUNTS=
+        if [ -n "$COUNTS" ]; then
+          DEFAULT_AHEAD=${COUNTS%%[[:space:]]*}
+          DEFAULT_BEHIND=${COUNTS##*[[:space:]]}
+          if [ "$DEFAULT_AHEAD" -gt 0 ] && [ "$DEFAULT_BEHIND" -gt 0 ]; then
+            DIVERGED=true
+            add_blocker default_diverged "Local and remote default branches have diverged"
+          elif [ "$DEFAULT_AHEAD" -gt 0 ]; then
+            add_blocker default_ahead "Local default branch is ahead of its origin default ref"
+          elif [ "$DEFAULT_BEHIND" -gt 0 ]; then
+            add_warning default_behind "Local default branch is behind its cached origin ref"
+          fi
         fi
       fi
-    fi
 
-    UNPUSHED_COUNT=$(git -C "$PROJECT_PHYSICAL" rev-list --count --branches --not --remotes 2>/dev/null) || UNPUSHED_COUNT=0
-    case "$UNPUSHED_COUNT" in ''|*[!0-9]*) UNPUSHED_COUNT=0 ;; esac
-    if [ "$UNPUSHED_COUNT" -gt 0 ]; then
-      add_blocker unpushed_commits "Local branches contain commits not reachable from any remote ref"
-    fi
+      UNPUSHED_COUNT=$(git -C "$PROJECT_PHYSICAL" rev-list --count --branches --not --remotes 2>/dev/null) || UNPUSHED_COUNT=0
+      case "$UNPUSHED_COUNT" in ''|*[!0-9]*) UNPUSHED_COUNT=0 ;; esac
+      if [ "$UNPUSHED_COUNT" -gt 0 ]; then
+        add_blocker unpushed_commits "Local branches contain commits not reachable from any remote ref"
+      fi
 
-    if [ "$(git -C "$PROJECT_PHYSICAL" rev-parse --is-shallow-repository 2>/dev/null || echo false)" = true ]; then
-      SHALLOW=true
-      add_blocker shallow_repository "Project is shallow"
-    fi
-    if git -C "$PROJECT_PHYSICAL" config --get extensions.partialClone >/dev/null 2>&1 \
-      || git -C "$PROJECT_PHYSICAL" config --get-regexp '^remote\..*\.partialclonefilter$' >/dev/null 2>&1; then
-      PARTIAL=true
-      add_blocker partial_clone "Project uses partial-clone configuration"
-    fi
-    if git -C "$PROJECT_PHYSICAL" config --get-regexp '^remote\..*\.promisor$' 2>/dev/null \
-      | awk '$NF == "true" { found=1 } END { exit found ? 0 : 1 }'; then
-      PROMISOR=true
-      add_blocker promisor_remote "Project has a promisor remote"
-    fi
-    REPLACE_REF_COUNT=$(git -C "$PROJECT_PHYSICAL" for-each-ref --format='%(refname)' refs/replace 2>/dev/null | awk 'NF { n++ } END { print n+0 }')
-    if [ "$REPLACE_REF_COUNT" -gt 0 ]; then
-      add_blocker replace_refs "Project has replace refs"
-    fi
-    if [ -n "$PROJECT_COMMON_DIR" ] && [ -s "$PROJECT_COMMON_DIR/info/grafts" ]; then
-      GRAFTS=true
-      add_blocker grafts "Project has legacy grafts"
-    fi
-    ALTERNATES_PATH=$(git -C "$PROJECT_PHYSICAL" rev-parse --path-format=absolute --git-path objects/info/alternates 2>/dev/null) || ALTERNATES_PATH=
-    if [ -n "$ALTERNATES_PATH" ] && [ -s "$ALTERNATES_PATH" ]; then
-      ALTERNATE=true
-      add_blocker unexpected_alternate "Project already borrows from an alternate object store"
-    fi
-    if [ -n "${GIT_ALTERNATE_OBJECT_DIRECTORIES:-}" ]; then
-      ALTERNATE=true
-      add_blocker ambient_alternate "GIT_ALTERNATE_OBJECT_DIRECTORIES is set in the preflight environment"
-    fi
-    if git -C "$PROJECT_PHYSICAL" remote get-url no-mistakes >/dev/null 2>&1; then
-      NO_MISTAKES_REMOTE=true
-    fi
+      if [ "$(git -C "$PROJECT_PHYSICAL" rev-parse --is-shallow-repository 2>/dev/null || echo false)" = true ]; then
+        SHALLOW=true
+        add_blocker shallow_repository "Project is shallow"
+      fi
+      if git -C "$PROJECT_PHYSICAL" config --get extensions.partialClone >/dev/null 2>&1 \
+        || git -C "$PROJECT_PHYSICAL" config --get-regexp '^remote\..*\.partialclonefilter$' >/dev/null 2>&1; then
+        PARTIAL=true
+        add_blocker partial_clone "Project uses partial-clone configuration"
+      fi
+      if git -C "$PROJECT_PHYSICAL" config --get-regexp '^remote\..*\.promisor$' 2>/dev/null \
+        | awk '$NF == "true" { found=1 } END { exit found ? 0 : 1 }'; then
+        PROMISOR=true
+        add_blocker promisor_remote "Project has a promisor remote"
+      fi
+      REPLACE_REF_COUNT=$(git -C "$PROJECT_PHYSICAL" for-each-ref --format='%(refname)' refs/replace 2>/dev/null | awk 'NF { n++ } END { print n+0 }')
+      if [ "$REPLACE_REF_COUNT" -gt 0 ]; then
+        add_blocker replace_refs "Project has replace refs"
+      fi
+      if [ -n "$PROJECT_COMMON_DIR" ] && [ -s "$PROJECT_COMMON_DIR/info/grafts" ]; then
+        GRAFTS=true
+        add_blocker grafts "Project has legacy grafts"
+      fi
+      ALTERNATES_PATH=$(git -C "$PROJECT_PHYSICAL" rev-parse --path-format=absolute --git-path objects/info/alternates 2>/dev/null) || ALTERNATES_PATH=
+      if [ -n "$ALTERNATES_PATH" ] && [ -s "$ALTERNATES_PATH" ]; then
+        ALTERNATE=true
+        add_blocker unexpected_alternate "Project already borrows from an alternate object store"
+      fi
+      if [ -n "${GIT_ALTERNATE_OBJECT_DIRECTORIES:-}" ]; then
+        ALTERNATE=true
+        add_blocker ambient_alternate "GIT_ALTERNATE_OBJECT_DIRECTORIES is set in the preflight environment"
+      fi
+      if git -C "$PROJECT_PHYSICAL" remote get-url no-mistakes >/dev/null 2>&1; then
+        NO_MISTAKES_REMOTE=true
+      fi
 
-    WORKTREE_DATA=$(git -C "$PROJECT_PHYSICAL" -c core.quotePath=false worktree list --porcelain 2>/dev/null) || WORKTREE_DATA=
-    while IFS= read -r line || [ -n "$line" ]; do
-      case "$line" in
-        worktree\ *)
-          WORKTREE_PATH=${line#worktree }
-          WORKTREE_COUNT=$((WORKTREE_COUNT + 1))
-          if ! paths_match "$WORKTREE_PATH" "$PROJECT_PHYSICAL"; then
-            EXTRA_WORKTREE_COUNT=$((EXTRA_WORKTREE_COUNT + 1))
-            EXTRA_WORKTREES+=("$WORKTREE_PATH")
-            case "$WORKTREE_PATH" in
-              */.no-mistakes/*) NO_MISTAKES_WORKTREE_COUNT=$((NO_MISTAKES_WORKTREE_COUNT + 1)) ;;
-            esac
-          fi
-          ;;
-      esac
-    done <<EOF
+      WORKTREE_DATA=$(git -C "$PROJECT_PHYSICAL" -c core.quotePath=false worktree list --porcelain 2>/dev/null) || WORKTREE_DATA=
+      while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+          worktree\ *)
+            WORKTREE_PATH=${line#worktree }
+            WORKTREE_COUNT=$((WORKTREE_COUNT + 1))
+            if ! paths_match "$WORKTREE_PATH" "$PROJECT_PHYSICAL"; then
+              EXTRA_WORKTREE_COUNT=$((EXTRA_WORKTREE_COUNT + 1))
+              EXTRA_WORKTREES+=("$WORKTREE_PATH")
+              case "$WORKTREE_PATH" in
+                */.no-mistakes/*) NO_MISTAKES_WORKTREE_COUNT=$((NO_MISTAKES_WORKTREE_COUNT + 1)) ;;
+              esac
+            fi
+            ;;
+        esac
+      done <<EOF
 $WORKTREE_DATA
 EOF
-    if [ "$EXTRA_WORKTREE_COUNT" -gt 0 ]; then
-      add_blocker linked_worktrees "Project has linked worktrees beyond its control checkout"
-    fi
-    if [ "$NO_MISTAKES_WORKTREE_COUNT" -gt 0 ]; then
-      add_blocker no_mistakes_run_worktree "Project has a linked no-mistakes worktree"
+      if [ "$EXTRA_WORKTREE_COUNT" -gt 0 ]; then
+        add_blocker linked_worktrees "Project has linked worktrees beyond its control checkout"
+      fi
+      if [ "$NO_MISTAKES_WORKTREE_COUNT" -gt 0 ]; then
+        add_blocker no_mistakes_run_worktree "Project has a linked no-mistakes worktree"
+      fi
     fi
   fi
 fi
@@ -420,7 +422,7 @@ if [ -f "$HOME_PHYSICAL/data/secondmates.md" ] && [ ! -L "$HOME_PHYSICAL/data/se
       fi
       continue
     fi
-    [ "$SECONDMATE_REGISTRY_HOME" != "$HOME_PHYSICAL" ] || continue
+    ! paths_match "$SECONDMATE_REGISTRY_HOME" "$HOME_PHYSICAL" || continue
     SIBLING_PROJECT="$SECONDMATE_REGISTRY_HOME/projects/$PROJECT_NAME"
     [ -d "$SIBLING_PROJECT" ] || continue
     SIBLING_ORIGIN=$(git -C "$SIBLING_PROJECT" remote get-url origin 2>/dev/null) || SIBLING_ORIGIN=
@@ -496,8 +498,7 @@ if [ -n "$CACHE_ARG" ]; then
     add_blocker cache_path_unsafe "Proposed cache path is not a traversal-free absolute path"
   elif fmp_path_has_symlink_component "$CACHE_ARG"; then
     add_blocker cache_symlink "Proposed cache path has a symlink component"
-  fi
-  if [ ! -d "$CACHE_ARG" ]; then
+  elif [ ! -d "$CACHE_ARG" ]; then
     add_blocker cache_missing "Proposed cache repository does not exist; preflight will not create it"
     CACHE_ANCESTOR=$(fmp_nearest_existing_ancestor "$CACHE_ARG" 2>/dev/null) || CACHE_ANCESTOR=
     if [ -n "$CACHE_ANCESTOR" ]; then

--- a/bin/fm-project-layout-preflight.sh
+++ b/bin/fm-project-layout-preflight.sh
@@ -28,6 +28,18 @@ AMBIENT_GIT_ALTERNATES=${GIT_ALTERNATE_OBJECT_DIRECTORIES:-}
 unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY \
   GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR GIT_NAMESPACE \
   GIT_GRAFT_FILE GIT_CEILING_DIRECTORIES GIT_DISCOVERY_ACROSS_FILESYSTEM
+AMBIENT_GIT_CONFIG_COUNT=${GIT_CONFIG_COUNT:-}
+unset GIT_CONFIG_COUNT GIT_CONFIG_PARAMETERS GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM GIT_CONFIG
+case "$AMBIENT_GIT_CONFIG_COUNT" in
+  ''|*[!0-9]*) AMBIENT_GIT_CONFIG_COUNT=0 ;;
+esac
+[ "$AMBIENT_GIT_CONFIG_COUNT" -le 1024 ] || AMBIENT_GIT_CONFIG_COUNT=1024
+AMBIENT_CONFIG_INDEX=0
+while [ "$AMBIENT_CONFIG_INDEX" -lt "$AMBIENT_GIT_CONFIG_COUNT" ]; do
+  unset "GIT_CONFIG_KEY_$AMBIENT_CONFIG_INDEX" "GIT_CONFIG_VALUE_$AMBIENT_CONFIG_INDEX"
+  AMBIENT_CONFIG_INDEX=$((AMBIENT_CONFIG_INDEX + 1))
+done
+unset AMBIENT_CONFIG_INDEX AMBIENT_GIT_CONFIG_COUNT
 
 # shellcheck source=bin/fm-project-layout-lib.sh
 . "$SCRIPT_DIR/fm-project-layout-lib.sh"
@@ -233,7 +245,12 @@ else
       add_blocker project_writable_by_others "Project is not verifiably owner-only"
     fi
 
-    if ! git -C "$PROJECT_PHYSICAL" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    PROJECT_TOPLEVEL=$(git -C "$PROJECT_PHYSICAL" rev-parse --show-toplevel 2>/dev/null) || PROJECT_TOPLEVEL=
+    if [ -n "$PROJECT_TOPLEVEL" ]; then
+      PROJECT_TOPLEVEL=$(fmp_existing_path_physical "$PROJECT_TOPLEVEL" 2>/dev/null) || PROJECT_TOPLEVEL=
+    fi
+    if ! git -C "$PROJECT_PHYSICAL" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+      || [ "$PROJECT_TOPLEVEL" != "$PROJECT_PHYSICAL" ]; then
       add_blocker project_not_worktree "Project is not an ordinary Git working tree"
     else
       PROJECT_GIT_DIR=$(fmp_git_absolute_dir "$PROJECT_PHYSICAL" git 2>/dev/null) || PROJECT_GIT_DIR=

--- a/bin/fm-project-layout-preflight.sh
+++ b/bin/fm-project-layout-preflight.sh
@@ -1,0 +1,690 @@
+#!/usr/bin/env bash
+# Inspect whether one explicit Firstmate home/project is safe input to a future
+# shared-object-cache design. This command is detect-only: it never fetches,
+# clones, creates a cache or ref, writes an alternate, edits registry/config,
+# initializes no-mistakes, scans a development tree, touches state, or performs
+# migration/cutover. Its fingerprint identifies the evidence printed by this
+# run; it is not cutover authority and must be rechecked by any future tool.
+#
+# Exit status:
+#   0  inspection completed with no blockers found
+#   1  inspection completed and found one or more blockers
+#   2  invalid arguments or the explicit home cannot be inspected
+#
+# JSON schema fm-project-layout-preflight.v1 is owned by emit_json below.
+# Usage:
+#   fm-project-layout-preflight.sh --home <absolute-fm-home> --project <name|absolute-path>
+#     [--cache-root <absolute-project-cache-repo>]
+#     [--canonical-path <absolute-navigation-only-human-checkout>] [--json]
+set -u
+
+unset CDPATH
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# Prevent `git status` and other read-only porcelain from refreshing the index.
+export GIT_OPTIONAL_LOCKS=0
+
+# shellcheck source=bin/fm-project-layout-lib.sh
+. "$SCRIPT_DIR/fm-project-layout-lib.sh"
+
+usage() {
+  cat <<'EOF'
+Usage: fm-project-layout-preflight.sh --home <absolute-fm-home> --project <name|absolute-path> [options]
+
+Read-only options:
+  --cache-root <path>      Inspect one exact proposed per-project cache repository.
+  --canonical-path <path> Inspect one navigation-only human checkout; never use it as Git control state.
+  --json                   Emit schema fm-project-layout-preflight.v1 instead of text.
+  -h, --help               Show this help.
+
+The command performs no migration or cutover and never creates a missing path.
+Exit 0 means no blocker was visible in the supplied local evidence, not that a
+future cutover is authorized. Exit 1 means blockers were found. Exit 2 means
+the explicit inputs could not be inspected safely.
+EOF
+}
+
+HOME_ARG=
+PROJECT_ARG=
+CACHE_ARG=
+CANONICAL_ARG=
+JSON=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --home)
+      [ "$#" -ge 2 ] || { echo "error: --home requires a path" >&2; exit 2; }
+      HOME_ARG=$2
+      shift 2
+      ;;
+    --home=*) HOME_ARG=${1#--home=}; shift ;;
+    --project)
+      [ "$#" -ge 2 ] || { echo "error: --project requires a name or path" >&2; exit 2; }
+      PROJECT_ARG=$2
+      shift 2
+      ;;
+    --project=*) PROJECT_ARG=${1#--project=}; shift ;;
+    --cache-root)
+      [ "$#" -ge 2 ] || { echo "error: --cache-root requires a path" >&2; exit 2; }
+      CACHE_ARG=$2
+      shift 2
+      ;;
+    --cache-root=*) CACHE_ARG=${1#--cache-root=}; shift ;;
+    --canonical-path)
+      [ "$#" -ge 2 ] || { echo "error: --canonical-path requires a path" >&2; exit 2; }
+      CANONICAL_ARG=$2
+      shift 2
+      ;;
+    --canonical-path=*) CANONICAL_ARG=${1#--canonical-path=}; shift ;;
+    --json) JSON=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    --) shift; [ "$#" -eq 0 ] || { echo "error: positional arguments are not accepted" >&2; exit 2; } ;;
+    *) echo "error: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$HOME_ARG" ] || { echo "error: --home is required" >&2; exit 2; }
+[ -n "$PROJECT_ARG" ] || { echo "error: --project is required" >&2; exit 2; }
+if fmp_has_control "$HOME_ARG$PROJECT_ARG$CACHE_ARG$CANONICAL_ARG"; then
+  echo "error: paths and project names must not contain tabs or newlines" >&2
+  exit 2
+fi
+fmp_absolute_path_is_lexically_safe "$HOME_ARG" || {
+  echo "error: --home must be a traversal-free absolute path" >&2
+  exit 2
+}
+[ -d "$HOME_ARG" ] || { echo "error: Firstmate home is not a directory: $HOME_ARG" >&2; exit 2; }
+
+BLOCKER_CODES=()
+BLOCKER_DETAILS=()
+WARNING_CODES=()
+WARNING_DETAILS=()
+
+add_blocker() {
+  BLOCKER_CODES+=("$1")
+  BLOCKER_DETAILS+=("$2")
+}
+
+add_warning() {
+  WARNING_CODES+=("$1")
+  WARNING_DETAILS+=("$2")
+}
+
+array_contains() {
+  local wanted=$1 value
+  shift
+  for value in "$@"; do
+    [ "$value" = "$wanted" ] && return 0
+  done
+  return 1
+}
+
+paths_match() {
+  local left=$1 right=$2 left_physical right_physical
+  [ "$left" = "$right" ] && return 0
+  left_physical=$(fmp_existing_path_physical "$left" 2>/dev/null) || return 1
+  right_physical=$(fmp_existing_path_physical "$right" 2>/dev/null) || return 1
+  [ "$left_physical" = "$right_physical" ]
+}
+
+HOME_PHYSICAL=$(fmp_existing_path_physical "$HOME_ARG") || {
+  echo "error: cannot resolve Firstmate home: $HOME_ARG" >&2
+  exit 2
+}
+if fmp_path_has_symlink_component "$HOME_ARG"; then
+  add_blocker home_symlink "Firstmate home has a symlink component"
+fi
+
+CURRENT_UID=$(id -u)
+HOME_UID=$(fmp_stat_uid "$HOME_PHYSICAL" 2>/dev/null) || HOME_UID=unknown
+HOME_MODE=$(fmp_stat_mode "$HOME_PHYSICAL" 2>/dev/null) || HOME_MODE=unknown
+if [ "$HOME_UID" != unknown ] && [ "$HOME_UID" != "$CURRENT_UID" ]; then
+  add_blocker home_owner_mismatch "Firstmate home is not owned by the current user"
+fi
+if [ "$HOME_MODE" != unknown ] && fmp_mode_group_or_world_writable "$HOME_MODE"; then
+  add_blocker home_writable_by_others "Firstmate home is group- or world-writable"
+fi
+
+case "$PROJECT_ARG" in
+  /*)
+    PROJECT_REQUESTED=$PROJECT_ARG
+    PROJECT_NAME=$(basename "$PROJECT_ARG")
+    ;;
+  *)
+    PROJECT_REQUESTED="$HOME_PHYSICAL/projects/$PROJECT_ARG"
+    PROJECT_NAME=$PROJECT_ARG
+    case "$PROJECT_ARG" in
+      */*) add_blocker project_not_flat "Relative project names must be one flat projects/ entry" ;;
+    esac
+    ;;
+esac
+
+PROJECT_PHYSICAL=
+PROJECT_GIT_DIR=
+PROJECT_COMMON_DIR=
+PROJECT_UID=unknown
+PROJECT_MODE=unknown
+REGISTERED=false
+REGISTERED_MODE=unknown
+REGISTERED_YOLO=unknown
+ORIGIN_PRESENT=false
+ORIGIN_RAW=
+ORIGIN_REDACTED=
+ORIGIN_IDENTITY=
+DEFAULT_BRANCH=
+CURRENT_BRANCH=
+OBJECT_FORMAT=unknown
+DIRTY=false
+OFF_DEFAULT=false
+DIVERGED=false
+DEFAULT_AHEAD=0
+DEFAULT_BEHIND=0
+UNPUSHED_COUNT=0
+SHALLOW=false
+PARTIAL=false
+PROMISOR=false
+REPLACE_REF_COUNT=0
+GRAFTS=false
+ALTERNATE=false
+NO_MISTAKES_REMOTE=false
+WORKTREE_COUNT=0
+EXTRA_WORKTREE_COUNT=0
+NO_MISTAKES_WORKTREE_COUNT=0
+EXTRA_WORKTREES=()
+LIVE_TASK_IDS=()
+ENDPOINT_COUNT=0
+ORCA_COUNT=0
+PENDING_REPLY_COUNT=0
+SIBLING_BORROWER_COUNT=0
+REMOTE_BORROWER_COUNT=0
+DUPLICATE_BRANCH_IDS=()
+
+if ! fmp_absolute_path_is_lexically_safe "$PROJECT_REQUESTED"; then
+  add_blocker project_path_unsafe "Project path is not a traversal-free absolute path"
+elif [ ! -d "$PROJECT_REQUESTED" ]; then
+  add_blocker project_missing "Project directory does not exist"
+else
+  PROJECT_PHYSICAL=$(fmp_existing_path_physical "$PROJECT_REQUESTED") || PROJECT_PHYSICAL=
+  if fmp_path_has_symlink_component "$PROJECT_REQUESTED"; then
+    add_blocker project_symlink "Project path has a symlink component"
+  fi
+  PROJECTS_PHYSICAL=$(fmp_existing_path_physical "$HOME_PHYSICAL/projects" 2>/dev/null) || PROJECTS_PHYSICAL=
+  if [ -z "$PROJECTS_PHYSICAL" ] || [ -z "$PROJECT_PHYSICAL" ] || ! fmp_path_is_within "$PROJECTS_PHYSICAL" "$PROJECT_PHYSICAL"; then
+    add_blocker project_path_escape "Project does not resolve beneath the supplied home's projects directory"
+  fi
+  PROJECT_UID=$(fmp_stat_uid "$PROJECT_PHYSICAL" 2>/dev/null) || PROJECT_UID=unknown
+  PROJECT_MODE=$(fmp_stat_mode "$PROJECT_PHYSICAL" 2>/dev/null) || PROJECT_MODE=unknown
+  if [ "$PROJECT_UID" != unknown ] && [ "$PROJECT_UID" != "$CURRENT_UID" ]; then
+    add_blocker project_owner_mismatch "Project is not owned by the current user"
+  fi
+  if [ "$PROJECT_MODE" != unknown ] && fmp_mode_group_or_world_writable "$PROJECT_MODE"; then
+    add_blocker project_writable_by_others "Project is group- or world-writable"
+  fi
+
+  if ! git -C "$PROJECT_PHYSICAL" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    add_blocker project_not_worktree "Project is not an ordinary Git working tree"
+  else
+    PROJECT_GIT_DIR=$(fmp_git_absolute_dir "$PROJECT_PHYSICAL" git 2>/dev/null) || PROJECT_GIT_DIR=
+    PROJECT_COMMON_DIR=$(fmp_git_absolute_dir "$PROJECT_PHYSICAL" common 2>/dev/null) || PROJECT_COMMON_DIR=
+    [ -n "$PROJECT_GIT_DIR" ] || add_blocker git_dir_unreadable "Project Git directory cannot be resolved"
+    [ -n "$PROJECT_COMMON_DIR" ] || add_blocker common_dir_unreadable "Project common Git directory cannot be resolved"
+    OBJECT_FORMAT=$(fmp_git_object_format "$PROJECT_PHYSICAL")
+
+    ORIGIN_RAW=$(git -C "$PROJECT_PHYSICAL" remote get-url origin 2>/dev/null) || ORIGIN_RAW=
+    if [ -n "$ORIGIN_RAW" ]; then
+      ORIGIN_PRESENT=true
+      ORIGIN_REDACTED=$(fmp_redact_origin "$ORIGIN_RAW")
+      ORIGIN_IDENTITY=$(printf '%s' "$ORIGIN_REDACTED" | fmp_fingerprint)
+      if fmp_origin_has_http_credentials "$ORIGIN_RAW"; then
+        add_blocker origin_embedded_credentials "Origin contains embedded HTTP credentials or query/fragment material; sensitive text was redacted"
+      fi
+    else
+      add_blocker no_origin "Project has no origin remote"
+    fi
+
+    DEFAULT_BRANCH=$(fmp_git_default_branch "$PROJECT_PHYSICAL" 2>/dev/null) || DEFAULT_BRANCH=
+    if [ -z "$DEFAULT_BRANCH" ]; then
+      add_blocker default_branch_unknown "Remote default branch cannot be determined from local refs"
+    fi
+    CURRENT_BRANCH=$(git -C "$PROJECT_PHYSICAL" symbolic-ref --quiet --short HEAD 2>/dev/null) || CURRENT_BRANCH=DETACHED
+    if [ -n "$DEFAULT_BRANCH" ] && [ "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]; then
+      OFF_DEFAULT=true
+      add_blocker off_default "Project checkout is not on its remote default branch"
+    fi
+
+    if [ -n "$(git -C "$PROJECT_PHYSICAL" status --porcelain=v1 --untracked-files=normal 2>/dev/null)" ]; then
+      DIRTY=true
+      add_blocker dirty_worktree "Project checkout has uncommitted or untracked changes"
+    fi
+
+    if [ -n "$DEFAULT_BRANCH" ] \
+      && git -C "$PROJECT_PHYSICAL" rev-parse --verify --quiet "refs/heads/$DEFAULT_BRANCH^{commit}" >/dev/null 2>&1 \
+      && git -C "$PROJECT_PHYSICAL" rev-parse --verify --quiet "refs/remotes/origin/$DEFAULT_BRANCH^{commit}" >/dev/null 2>&1; then
+      COUNTS=$(git -C "$PROJECT_PHYSICAL" rev-list --left-right --count "$DEFAULT_BRANCH...origin/$DEFAULT_BRANCH" 2>/dev/null) || COUNTS=
+      if [ -n "$COUNTS" ]; then
+        DEFAULT_AHEAD=${COUNTS%%[[:space:]]*}
+        DEFAULT_BEHIND=${COUNTS##*[[:space:]]}
+        if [ "$DEFAULT_AHEAD" -gt 0 ] && [ "$DEFAULT_BEHIND" -gt 0 ]; then
+          DIVERGED=true
+          add_blocker default_diverged "Local and remote default branches have diverged"
+        elif [ "$DEFAULT_AHEAD" -gt 0 ]; then
+          add_blocker default_ahead "Local default branch is ahead of its origin default ref"
+        elif [ "$DEFAULT_BEHIND" -gt 0 ]; then
+          add_warning default_behind "Local default branch is behind its cached origin ref"
+        fi
+      fi
+    fi
+
+    UNPUSHED_COUNT=$(git -C "$PROJECT_PHYSICAL" rev-list --count --branches --not --remotes 2>/dev/null) || UNPUSHED_COUNT=0
+    case "$UNPUSHED_COUNT" in ''|*[!0-9]*) UNPUSHED_COUNT=0 ;; esac
+    if [ "$UNPUSHED_COUNT" -gt 0 ]; then
+      add_blocker unpushed_commits "Local branches contain commits not reachable from any remote ref"
+    fi
+
+    if [ "$(git -C "$PROJECT_PHYSICAL" rev-parse --is-shallow-repository 2>/dev/null || echo false)" = true ]; then
+      SHALLOW=true
+      add_blocker shallow_repository "Project is shallow"
+    fi
+    if git -C "$PROJECT_PHYSICAL" config --get extensions.partialClone >/dev/null 2>&1 \
+      || git -C "$PROJECT_PHYSICAL" config --get-regexp '^remote\..*\.partialclonefilter$' >/dev/null 2>&1; then
+      PARTIAL=true
+      add_blocker partial_clone "Project uses partial-clone configuration"
+    fi
+    if git -C "$PROJECT_PHYSICAL" config --get-regexp '^remote\..*\.promisor$' 2>/dev/null \
+      | awk '$NF == "true" { found=1 } END { exit found ? 0 : 1 }'; then
+      PROMISOR=true
+      add_blocker promisor_remote "Project has a promisor remote"
+    fi
+    REPLACE_REF_COUNT=$(git -C "$PROJECT_PHYSICAL" for-each-ref --format='%(refname)' refs/replace 2>/dev/null | awk 'NF { n++ } END { print n+0 }')
+    if [ "$REPLACE_REF_COUNT" -gt 0 ]; then
+      add_blocker replace_refs "Project has replace refs"
+    fi
+    if [ -n "$PROJECT_COMMON_DIR" ] && [ -s "$PROJECT_COMMON_DIR/info/grafts" ]; then
+      GRAFTS=true
+      add_blocker grafts "Project has legacy grafts"
+    fi
+    ALTERNATES_PATH=$(git -C "$PROJECT_PHYSICAL" rev-parse --path-format=absolute --git-path objects/info/alternates 2>/dev/null) || ALTERNATES_PATH=
+    if [ -n "$ALTERNATES_PATH" ] && [ -s "$ALTERNATES_PATH" ]; then
+      ALTERNATE=true
+      add_blocker unexpected_alternate "Project already borrows from an alternate object store"
+    fi
+    if [ -n "${GIT_ALTERNATE_OBJECT_DIRECTORIES:-}" ]; then
+      ALTERNATE=true
+      add_blocker ambient_alternate "GIT_ALTERNATE_OBJECT_DIRECTORIES is set in the preflight environment"
+    fi
+    if git -C "$PROJECT_PHYSICAL" remote get-url no-mistakes >/dev/null 2>&1; then
+      NO_MISTAKES_REMOTE=true
+    fi
+
+    WORKTREE_DATA=$(git -C "$PROJECT_PHYSICAL" -c core.quotePath=false worktree list --porcelain 2>/dev/null) || WORKTREE_DATA=
+    while IFS= read -r line || [ -n "$line" ]; do
+      case "$line" in
+        worktree\ *)
+          WORKTREE_PATH=${line#worktree }
+          WORKTREE_COUNT=$((WORKTREE_COUNT + 1))
+          if ! paths_match "$WORKTREE_PATH" "$PROJECT_PHYSICAL"; then
+            EXTRA_WORKTREE_COUNT=$((EXTRA_WORKTREE_COUNT + 1))
+            EXTRA_WORKTREES+=("$WORKTREE_PATH")
+            case "$WORKTREE_PATH" in
+              */.no-mistakes/*) NO_MISTAKES_WORKTREE_COUNT=$((NO_MISTAKES_WORKTREE_COUNT + 1)) ;;
+            esac
+          fi
+          ;;
+      esac
+    done <<EOF
+$WORKTREE_DATA
+EOF
+    if [ "$EXTRA_WORKTREE_COUNT" -gt 0 ]; then
+      add_blocker linked_worktrees "Project has linked worktrees beyond its control checkout"
+    fi
+    if [ "$NO_MISTAKES_WORKTREE_COUNT" -gt 0 ]; then
+      add_blocker no_mistakes_run_worktree "Project has a linked no-mistakes worktree"
+    fi
+  fi
+fi
+
+REGISTRY="$HOME_PHYSICAL/data/projects.md"
+if [ -f "$REGISTRY" ] && [ ! -L "$REGISTRY" ] \
+  && awk -v n="$PROJECT_NAME" '$1 == "-" && $2 == n { found=1 } END { exit found ? 0 : 1 }' "$REGISTRY"; then
+  REGISTERED=true
+  MODE_LINE=$(FM_HOME="$HOME_PHYSICAL" "$FM_ROOT/bin/fm-project-mode.sh" "$PROJECT_NAME" 2>/dev/null) || MODE_LINE="unknown unknown"
+  REGISTERED_MODE=${MODE_LINE%% *}
+  REGISTERED_YOLO=${MODE_LINE##* }
+else
+  add_blocker unregistered_project "Project is not present in the supplied home's registry"
+fi
+
+STATE_DIR="$HOME_PHYSICAL/state"
+if [ -d "$STATE_DIR" ] && [ -n "$PROJECT_PHYSICAL" ]; then
+  for META in "$STATE_DIR"/*.meta; do
+    [ -f "$META" ] && [ ! -L "$META" ] || continue
+    META_PROJECT=$(fmp_meta_value "$META" project)
+    [ -n "$META_PROJECT" ] || continue
+    if paths_match "$META_PROJECT" "$PROJECT_PHYSICAL"; then
+      TASK_ID=$(basename "$META" .meta)
+      LIVE_TASK_IDS+=("$TASK_ID")
+      META_WINDOW=$(fmp_meta_value "$META" window)
+      META_ENDPOINT_ID=$(fmp_meta_value "$META" endpoint_task_id)
+      if [ -n "$META_WINDOW$META_ENDPOINT_ID" ]; then
+        ENDPOINT_COUNT=$((ENDPOINT_COUNT + 1))
+      fi
+      META_BACKEND=$(fmp_meta_value "$META" backend)
+      META_ORCA_ID=$(fmp_meta_value "$META" orca_worktree_id)
+      if [ "$META_BACKEND" = orca ] || [ -n "$META_ORCA_ID" ]; then
+        ORCA_COUNT=$((ORCA_COUNT + 1))
+      fi
+    fi
+  done
+  if [ "${#LIVE_TASK_IDS[@]}" -gt 0 ]; then
+    add_blocker live_task_metadata "Home has live task metadata naming this project"
+  fi
+  if [ "$ENDPOINT_COUNT" -gt 0 ]; then
+    add_blocker live_endpoint "Live task metadata carries endpoint identity"
+  fi
+  if [ "$ORCA_COUNT" -gt 0 ]; then
+    add_blocker live_orca "Live task metadata carries Orca identity"
+  fi
+
+  if [ -d "$STATE_DIR/pending-replies" ]; then
+    for REPLY in "$STATE_DIR/pending-replies"/*; do
+      [ -f "$REPLY" ] && [ ! -L "$REPLY" ] || continue
+      [ "$(fmp_meta_value "$REPLY" schema)" = fm-pending-reply.v1 ] || continue
+      REPLY_PHASE=$(fmp_meta_value "$REPLY" phase)
+      [ "$REPLY_PHASE" != resolved ] || continue
+      REPLY_TASK=$(fmp_meta_value "$REPLY" task_id)
+      if array_contains "$REPLY_TASK" "${LIVE_TASK_IDS[@]:-}"; then
+        PENDING_REPLY_COUNT=$((PENDING_REPLY_COUNT + 1))
+      fi
+    done
+    if [ "$PENDING_REPLY_COUNT" -gt 0 ]; then
+      add_blocker pending_reply "An unresolved pending reply is tied to live project work"
+    fi
+  fi
+fi
+
+# Inspect only explicitly registered local sibling homes. Remote paths are never
+# resolved or combined with this host's cache proposal.
+if [ -f "$HOME_PHYSICAL/data/secondmates.md" ] && [ ! -L "$HOME_PHYSICAL/data/secondmates.md" ] \
+  && [ -n "$ORIGIN_RAW" ]; then
+  # shellcheck source=bin/fm-secondmate-registry-lib.sh
+  . "$FM_ROOT/bin/fm-secondmate-registry-lib.sh"
+  while IFS= read -r REGISTRY_LINE || [ -n "$REGISTRY_LINE" ]; do
+    case "$REGISTRY_LINE" in "- "*) ;; *) continue ;; esac
+    secondmate_registry_parse_line "$REGISTRY_LINE" || continue
+    if [ "$SECONDMATE_REGISTRY_REMOTE" -eq 1 ]; then
+      if fmp_csv_contains "$SECONDMATE_REGISTRY_PROJECTS" "$PROJECT_NAME"; then
+        REMOTE_BORROWER_COUNT=$((REMOTE_BORROWER_COUNT + 1))
+      fi
+      continue
+    fi
+    [ "$SECONDMATE_REGISTRY_HOME" != "$HOME_PHYSICAL" ] || continue
+    SIBLING_PROJECT="$SECONDMATE_REGISTRY_HOME/projects/$PROJECT_NAME"
+    [ -d "$SIBLING_PROJECT" ] || continue
+    SIBLING_ORIGIN=$(git -C "$SIBLING_PROJECT" remote get-url origin 2>/dev/null) || SIBLING_ORIGIN=
+    [ "$SIBLING_ORIGIN" = "$ORIGIN_RAW" ] || continue
+    SIBLING_BORROWER_COUNT=$((SIBLING_BORROWER_COUNT + 1))
+    for SIBLING_META in "$SECONDMATE_REGISTRY_HOME/state"/*.meta; do
+      [ -f "$SIBLING_META" ] && [ ! -L "$SIBLING_META" ] || continue
+      SIBLING_META_PROJECT=$(fmp_meta_value "$SIBLING_META" project)
+      [ -n "$SIBLING_META_PROJECT" ] || continue
+      paths_match "$SIBLING_META_PROJECT" "$SIBLING_PROJECT" || continue
+      SIBLING_ID=$(basename "$SIBLING_META" .meta)
+      if array_contains "$SIBLING_ID" "${LIVE_TASK_IDS[@]:-}" \
+        && ! array_contains "$SIBLING_ID" "${DUPLICATE_BRANCH_IDS[@]:-}"; then
+        DUPLICATE_BRANCH_IDS+=("$SIBLING_ID")
+      fi
+    done
+  done < "$HOME_PHYSICAL/data/secondmates.md"
+  if [ "${#DUPLICATE_BRANCH_IDS[@]}" -gt 0 ]; then
+    add_blocker duplicate_cross_home_branch "Two local homes have live work that maps to the same fm/<id> branch"
+  fi
+  if [ "$REMOTE_BORROWER_COUNT" -gt 0 ]; then
+    add_warning remote_home_unverified "Registered remote homes are out of local inspection scope and receive no local cache path"
+  fi
+fi
+
+CANONICAL_PHYSICAL=
+CANONICAL_GIT_DIR=
+CANONICAL_COMMON_DIR=
+CANONICAL_ORIGIN_REDACTED=
+if [ -n "$CANONICAL_ARG" ]; then
+  if ! fmp_absolute_path_is_lexically_safe "$CANONICAL_ARG"; then
+    add_blocker canonical_path_unsafe "Canonical navigation path is not a traversal-free absolute path"
+  elif [ ! -d "$CANONICAL_ARG" ]; then
+    add_blocker canonical_path_missing "Canonical navigation path does not exist"
+  else
+    CANONICAL_PHYSICAL=$(fmp_existing_path_physical "$CANONICAL_ARG") || CANONICAL_PHYSICAL=
+    if fmp_path_has_symlink_component "$CANONICAL_ARG"; then
+      add_blocker canonical_path_symlink "Canonical navigation path has a symlink component"
+    fi
+    if [ -n "$PROJECT_PHYSICAL" ] && [ "$CANONICAL_PHYSICAL" = "$PROJECT_PHYSICAL" ]; then
+      add_blocker canonical_is_control "Canonical human checkout is the Firstmate control checkout"
+    fi
+    if git -C "$CANONICAL_PHYSICAL" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      CANONICAL_GIT_DIR=$(fmp_git_absolute_dir "$CANONICAL_PHYSICAL" git 2>/dev/null) || CANONICAL_GIT_DIR=
+      CANONICAL_COMMON_DIR=$(fmp_git_absolute_dir "$CANONICAL_PHYSICAL" common 2>/dev/null) || CANONICAL_COMMON_DIR=
+      if [ -n "$PROJECT_COMMON_DIR" ] && [ "$CANONICAL_COMMON_DIR" = "$PROJECT_COMMON_DIR" ]; then
+        add_blocker canonical_shares_common_dir "Canonical human checkout shares Firstmate's common Git directory"
+      fi
+      CANONICAL_ORIGIN_RAW=$(git -C "$CANONICAL_PHYSICAL" remote get-url origin 2>/dev/null) || CANONICAL_ORIGIN_RAW=
+      CANONICAL_ORIGIN_REDACTED=$(fmp_redact_origin "$CANONICAL_ORIGIN_RAW")
+      if [ -n "$ORIGIN_RAW" ] && [ -n "$CANONICAL_ORIGIN_RAW" ] && [ "$CANONICAL_ORIGIN_RAW" != "$ORIGIN_RAW" ]; then
+        add_blocker canonical_origin_mismatch "Canonical checkout origin differs from the control checkout origin"
+      fi
+    else
+      add_warning canonical_not_git "Canonical navigation path is not a Git working tree"
+    fi
+  fi
+fi
+
+CACHE_PHYSICAL=
+CACHE_UID=unknown
+CACHE_MODE=unknown
+CACHE_FILESYSTEM_SOURCE=
+CACHE_FILESYSTEM_LOCALITY=not-supplied
+CACHE_IS_GIT=false
+CACHE_IS_BARE=false
+CACHE_ORIGIN_REDACTED=
+CACHE_OBJECT_FORMAT=unknown
+if [ -n "$CACHE_ARG" ]; then
+  if ! fmp_absolute_path_is_lexically_safe "$CACHE_ARG"; then
+    add_blocker cache_path_unsafe "Proposed cache path is not a traversal-free absolute path"
+  elif fmp_path_has_symlink_component "$CACHE_ARG"; then
+    add_blocker cache_symlink "Proposed cache path has a symlink component"
+  fi
+  if [ ! -d "$CACHE_ARG" ]; then
+    add_blocker cache_missing "Proposed cache repository does not exist; preflight will not create it"
+    CACHE_ANCESTOR=$(fmp_nearest_existing_ancestor "$CACHE_ARG" 2>/dev/null) || CACHE_ANCESTOR=
+    if [ -n "$CACHE_ANCESTOR" ]; then
+      CACHE_FILESYSTEM_SOURCE=$(fmp_filesystem_source "$CACHE_ANCESTOR")
+      CACHE_FILESYSTEM_LOCALITY=$(fmp_filesystem_locality "$CACHE_FILESYSTEM_SOURCE")
+    fi
+  else
+    CACHE_PHYSICAL=$(fmp_existing_path_physical "$CACHE_ARG") || CACHE_PHYSICAL=
+    CACHE_UID=$(fmp_stat_uid "$CACHE_PHYSICAL" 2>/dev/null) || CACHE_UID=unknown
+    CACHE_MODE=$(fmp_stat_mode "$CACHE_PHYSICAL" 2>/dev/null) || CACHE_MODE=unknown
+    if [ "$CACHE_UID" != "$CURRENT_UID" ]; then
+      add_blocker cache_owner_mismatch "Proposed cache is not owned by the current user"
+    fi
+    if [ "$CACHE_MODE" = unknown ] || fmp_mode_group_or_world_writable "$CACHE_MODE"; then
+      add_blocker cache_permissions "Proposed cache is not verifiably owner-only"
+    fi
+    CACHE_FILESYSTEM_SOURCE=$(fmp_filesystem_source "$CACHE_PHYSICAL")
+    CACHE_FILESYSTEM_LOCALITY=$(fmp_filesystem_locality "$CACHE_FILESYSTEM_SOURCE")
+    case "$CACHE_FILESYSTEM_LOCALITY" in
+      local) ;;
+      network) add_blocker cache_network_filesystem "Proposed cache is on a network filesystem" ;;
+      *) add_blocker cache_filesystem_unknown "Proposed cache filesystem locality cannot be proved" ;;
+    esac
+    if git -C "$CACHE_PHYSICAL" rev-parse --git-dir >/dev/null 2>&1; then
+      CACHE_IS_GIT=true
+      if [ "$(git -C "$CACHE_PHYSICAL" rev-parse --is-bare-repository 2>/dev/null || echo false)" = true ]; then
+        CACHE_IS_BARE=true
+      else
+        add_blocker cache_not_bare "Proposed per-project cache is not a bare repository"
+      fi
+      CACHE_OBJECT_FORMAT=$(fmp_git_object_format "$CACHE_PHYSICAL")
+      CACHE_ORIGIN_RAW=$(git -C "$CACHE_PHYSICAL" remote get-url origin 2>/dev/null) || CACHE_ORIGIN_RAW=
+      CACHE_ORIGIN_REDACTED=$(fmp_redact_origin "$CACHE_ORIGIN_RAW")
+      if [ -z "$CACHE_ORIGIN_RAW" ]; then
+        add_blocker cache_no_origin "Proposed cache has no origin remote"
+      elif fmp_origin_has_http_credentials "$CACHE_ORIGIN_RAW"; then
+        add_blocker cache_embedded_credentials "Proposed cache origin contains embedded HTTP credentials or query/fragment material; sensitive text was redacted"
+      elif [ -n "$ORIGIN_RAW" ] && [ "$CACHE_ORIGIN_RAW" != "$ORIGIN_RAW" ]; then
+        add_blocker cache_origin_mismatch "Proposed cache origin differs from the control checkout origin"
+      fi
+      if [ "$OBJECT_FORMAT" != unknown ] && [ "$CACHE_OBJECT_FORMAT" != "$OBJECT_FORMAT" ]; then
+        add_blocker cache_object_format_mismatch "Proposed cache and control checkout use different object formats"
+      fi
+      CACHE_ALTERNATES=$(git -C "$CACHE_PHYSICAL" rev-parse --path-format=absolute --git-path objects/info/alternates 2>/dev/null) || CACHE_ALTERNATES=
+      if [ -n "$CACHE_ALTERNATES" ] && [ -s "$CACHE_ALTERNATES" ]; then
+        add_blocker cache_has_alternate "Proposed cache itself borrows objects from another store"
+      fi
+    else
+      add_blocker cache_not_git "Proposed cache is not a Git repository"
+    fi
+  fi
+fi
+
+STATUS=ready
+[ "${#BLOCKER_CODES[@]}" -eq 0 ] || STATUS=blocked
+
+FINGERPRINT=$({
+  printf 'schema=fm-project-layout-preflight.v1\n'
+  printf 'home=%s\nproject=%s\nname=%s\n' "$HOME_PHYSICAL" "$PROJECT_PHYSICAL" "$PROJECT_NAME"
+  printf 'registered=%s\nmode=%s\nyolo=%s\n' "$REGISTERED" "$REGISTERED_MODE" "$REGISTERED_YOLO"
+  printf 'origin=%s\nobject-format=%s\ndefault=%s\nbranch=%s\n' "$ORIGIN_REDACTED" "$OBJECT_FORMAT" "$DEFAULT_BRANCH" "$CURRENT_BRANCH"
+  printf 'dirty=%s\noff-default=%s\ndiverged=%s\nunpushed=%s\n' "$DIRTY" "$OFF_DEFAULT" "$DIVERGED" "$UNPUSHED_COUNT"
+  printf 'shallow=%s\npartial=%s\npromisor=%s\nreplace=%s\ngrafts=%s\nalternate=%s\n' \
+    "$SHALLOW" "$PARTIAL" "$PROMISOR" "$REPLACE_REF_COUNT" "$GRAFTS" "$ALTERNATE"
+  printf 'worktrees=%s\ntasks=%s\nendpoints=%s\nfixed-orca=%s\npending=%s\n' \
+    "$WORKTREE_COUNT" "${#LIVE_TASK_IDS[@]}" "$ENDPOINT_COUNT" "$ORCA_COUNT" "$PENDING_REPLY_COUNT"
+  printf 'task-ids='
+  printf '%s,' "${LIVE_TASK_IDS[@]:-}"
+  printf '\nextra-worktrees='
+  printf '%s,' "${EXTRA_WORKTREES[@]:-}"
+  printf '\nduplicate-branch-ids='
+  printf '%s,' "${DUPLICATE_BRANCH_IDS[@]:-}"
+  printf '\n'
+  printf 'cache-requested=%s\ncache=%s\ncache-origin=%s\ncache-format=%s\ncache-locality=%s\n' \
+    "$CACHE_ARG" "$CACHE_PHYSICAL" "$CACHE_ORIGIN_REDACTED" "$CACHE_OBJECT_FORMAT" "$CACHE_FILESYSTEM_LOCALITY"
+  printf 'canonical-requested=%s\ncanonical=%s\nsibling-borrowers=%s\nremote-borrowers=%s\n' \
+    "$CANONICAL_ARG" "$CANONICAL_PHYSICAL" "$SIBLING_BORROWER_COUNT" "$REMOTE_BORROWER_COUNT"
+  printf 'blockers='
+  printf '%s,' "${BLOCKER_CODES[@]:-}"
+  printf '\nwarnings='
+  printf '%s,' "${WARNING_CODES[@]:-}"
+  printf '\n'
+} | fmp_fingerprint)
+
+emit_json_string_array() {
+  local first=1 value
+  printf '['
+  for value in "$@"; do
+    [ -n "$value" ] || continue
+    [ "$first" -eq 1 ] || printf ','
+    printf '"%s"' "$(fmp_json_escape "$value")"
+    first=0
+  done
+  printf ']'
+}
+
+emit_json_findings() {
+  local kind=$1 i count
+  if [ "$kind" = blockers ]; then
+    count=${#BLOCKER_CODES[@]}
+  else
+    count=${#WARNING_CODES[@]}
+  fi
+  printf '['
+  i=0
+  while [ "$i" -lt "$count" ]; do
+    [ "$i" -eq 0 ] || printf ','
+    if [ "$kind" = blockers ]; then
+      printf '{"code":"%s","detail":"%s"}' \
+        "$(fmp_json_escape "${BLOCKER_CODES[$i]}")" "$(fmp_json_escape "${BLOCKER_DETAILS[$i]}")"
+    else
+      printf '{"code":"%s","detail":"%s"}' \
+        "$(fmp_json_escape "${WARNING_CODES[$i]}")" "$(fmp_json_escape "${WARNING_DETAILS[$i]}")"
+    fi
+    i=$((i + 1))
+  done
+  printf ']'
+}
+
+emit_json() {
+  printf '{'
+  printf '"schema":"fm-project-layout-preflight.v1",'
+  printf '"status":"%s","read_only":true,' "$STATUS"
+  printf '"home":{"requested":"%s","physical":"%s","uid":"%s","mode":"%s"},' \
+    "$(fmp_json_escape "$HOME_ARG")" "$(fmp_json_escape "$HOME_PHYSICAL")" "$HOME_UID" "$HOME_MODE"
+  printf '"project":{"name":"%s","requested":"%s","physical":"%s","git_dir":"%s","common_dir":"%s","uid":"%s","mode":"%s"},' \
+    "$(fmp_json_escape "$PROJECT_NAME")" "$(fmp_json_escape "$PROJECT_REQUESTED")" \
+    "$(fmp_json_escape "$PROJECT_PHYSICAL")" "$(fmp_json_escape "$PROJECT_GIT_DIR")" \
+    "$(fmp_json_escape "$PROJECT_COMMON_DIR")" "$PROJECT_UID" "$PROJECT_MODE"
+  printf '"registration":{"registered":%s,"mode":"%s","yolo":"%s"},' \
+    "$REGISTERED" "$(fmp_json_escape "$REGISTERED_MODE")" "$(fmp_json_escape "$REGISTERED_YOLO")"
+  printf '"repository":{"origin_present":%s,"origin":"%s","origin_identity":"%s","default_branch":"%s","current_branch":"%s","object_format":"%s","dirty":%s,"off_default":%s,"diverged":%s,"ahead":%s,"behind":%s,"unpushed_commits":%s,"shallow":%s,"partial":%s,"promisor":%s,"replace_refs":%s,"grafts":%s,"alternate":%s,"no_mistakes_remote":%s},' \
+    "$ORIGIN_PRESENT" "$(fmp_json_escape "$ORIGIN_REDACTED")" "$(fmp_json_escape "$ORIGIN_IDENTITY")" \
+    "$(fmp_json_escape "$DEFAULT_BRANCH")" "$(fmp_json_escape "$CURRENT_BRANCH")" "$(fmp_json_escape "$OBJECT_FORMAT")" \
+    "$DIRTY" "$OFF_DEFAULT" "$DIVERGED" "$DEFAULT_AHEAD" "$DEFAULT_BEHIND" "$UNPUSHED_COUNT" \
+    "$SHALLOW" "$PARTIAL" "$PROMISOR" "$REPLACE_REF_COUNT" "$GRAFTS" "$ALTERNATE" "$NO_MISTAKES_REMOTE"
+  printf '"live":{"worktree_count":%s,"extra_worktree_count":%s,"no_mistakes_worktree_count":%s,"task_ids":' \
+    "$WORKTREE_COUNT" "$EXTRA_WORKTREE_COUNT" "$NO_MISTAKES_WORKTREE_COUNT"
+  emit_json_string_array "${LIVE_TASK_IDS[@]:-}"
+  printf ',"endpoint_count":%s,"orca_count":%s,"pending_reply_count":%s,"sibling_borrower_count":%s,"remote_borrower_count":%s,"duplicate_branch_ids":' \
+    "$ENDPOINT_COUNT" "$ORCA_COUNT" "$PENDING_REPLY_COUNT" "$SIBLING_BORROWER_COUNT" "$REMOTE_BORROWER_COUNT"
+  emit_json_string_array "${DUPLICATE_BRANCH_IDS[@]:-}"
+  printf '},'
+  printf '"proposal":{"cache_root":"%s","cache_physical":"%s","cache_uid":"%s","cache_mode":"%s","cache_filesystem":"%s","cache_locality":"%s","cache_is_git":%s,"cache_is_bare":%s,"cache_origin":"%s","cache_object_format":"%s","canonical_path":"%s","canonical_physical":"%s","canonical_git_dir":"%s","canonical_common_dir":"%s","canonical_origin":"%s"},' \
+    "$(fmp_json_escape "$CACHE_ARG")" "$(fmp_json_escape "$CACHE_PHYSICAL")" "$CACHE_UID" "$CACHE_MODE" \
+    "$(fmp_json_escape "$CACHE_FILESYSTEM_SOURCE")" "$CACHE_FILESYSTEM_LOCALITY" "$CACHE_IS_GIT" "$CACHE_IS_BARE" \
+    "$(fmp_json_escape "$CACHE_ORIGIN_REDACTED")" "$CACHE_OBJECT_FORMAT" \
+    "$(fmp_json_escape "$CANONICAL_ARG")" "$(fmp_json_escape "$CANONICAL_PHYSICAL")" \
+    "$(fmp_json_escape "$CANONICAL_GIT_DIR")" "$(fmp_json_escape "$CANONICAL_COMMON_DIR")" \
+    "$(fmp_json_escape "$CANONICAL_ORIGIN_REDACTED")"
+  printf '"blockers":'; emit_json_findings blockers
+  printf ',"warnings":'; emit_json_findings warnings
+  printf ',"fingerprint":{"algorithm":"posix-cksum","value":"%s","cutover_authority":false}' "$(fmp_json_escape "$FINGERPRINT")"
+  printf '}\n'
+}
+
+emit_text() {
+  local i
+  printf 'project layout preflight: %s\n' "$STATUS"
+  printf 'schema: fm-project-layout-preflight.v1\n'
+  printf 'read-only: true\n'
+  printf 'home: %s\n' "$HOME_PHYSICAL"
+  printf 'project: %s\n' "$PROJECT_PHYSICAL"
+  printf 'registered posture: %s yolo=%s\n' "$REGISTERED_MODE" "$REGISTERED_YOLO"
+  printf 'origin: %s\n' "${ORIGIN_REDACTED:-none}"
+  printf 'git dirs: git=%s common=%s\n' "$PROJECT_GIT_DIR" "$PROJECT_COMMON_DIR"
+  printf 'branch: current=%s default=%s ahead=%s behind=%s\n' "$CURRENT_BRANCH" "$DEFAULT_BRANCH" "$DEFAULT_AHEAD" "$DEFAULT_BEHIND"
+  printf 'object format: %s\n' "$OBJECT_FORMAT"
+  printf 'live evidence: worktrees=%s extra=%s tasks=%s endpoints=%s orca=%s pending-replies=%s\n' \
+    "$WORKTREE_COUNT" "$EXTRA_WORKTREE_COUNT" "${#LIVE_TASK_IDS[@]}" "$ENDPOINT_COUNT" "$ORCA_COUNT" "$PENDING_REPLY_COUNT"
+  printf 'cache proposal: %s locality=%s format=%s\n' "${CACHE_PHYSICAL:-${CACHE_ARG:-not-supplied}}" "$CACHE_FILESYSTEM_LOCALITY" "$CACHE_OBJECT_FORMAT"
+  printf 'canonical navigation path: %s\n' "${CANONICAL_PHYSICAL:-${CANONICAL_ARG:-not-supplied}}"
+  printf 'blockers: %s\n' "${#BLOCKER_CODES[@]}"
+  i=0
+  while [ "$i" -lt "${#BLOCKER_CODES[@]}" ]; do
+    printf -- '- %s: %s\n' "${BLOCKER_CODES[$i]}" "${BLOCKER_DETAILS[$i]}"
+    i=$((i + 1))
+  done
+  printf 'warnings: %s\n' "${#WARNING_CODES[@]}"
+  i=0
+  while [ "$i" -lt "${#WARNING_CODES[@]}" ]; do
+    printf -- '- %s: %s\n' "${WARNING_CODES[$i]}" "${WARNING_DETAILS[$i]}"
+    i=$((i + 1))
+  done
+  printf 'evidence fingerprint: %s\n' "$FINGERPRINT"
+  printf 'cutover authority: false (a future mutating tool must re-check every fact)\n'
+}
+
+if [ "$JSON" -eq 1 ]; then
+  emit_json
+else
+  emit_text
+fi
+
+[ "$STATUS" = ready ]

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -142,6 +142,7 @@ family_for_basename() {
     fm-kimi-harness.test.sh|fm-muse-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
     fm-lint-workflows.test.sh|\
     fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
+    fm-project-layout-preflight.test.sh|\
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|\
     fm-subagent-pretool-check.test.sh|\
     fm-supervision-instructions.test.sh|fm-task-delivery.test.sh|\
@@ -967,7 +968,7 @@ families_for_changed_path() {
     bin/fm-decision-hold.sh|bin/fm-supervision*|bin/fm-transition-lib.sh|\
     bin/fm-tmux-lib.sh|bin/fm-marker-lib.sh|bin/fm-operational-input.sh|bin/fm-tasks-axi-lib.sh|\
     bin/fm-vendor-auth-probe.sh|\
-    bin/fm-primary-scope-lib.sh|bin/fm-project-mode.sh|bin/fm-promote.sh|\
+    bin/fm-primary-scope-lib.sh|bin/fm-project-mode.sh|bin/fm-project-layout-*.sh|bin/fm-promote.sh|\
     bin/fm-ff-lib.sh|bin/fm-gotmp*|bin/*pretool*)
       printf '%s\n' pure-contract-unit
       ;;

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -49,6 +49,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-remote-home-seed.sh` | Register and provision a whole secondmate home on an SSH-reachable host              |
 | `fm-remote-readiness-lib.sh` | Shared remote second-mate readiness gate: check and, when needed, repair then re-check through `fm-remote-doctor.sh` |
 | [`fm-project-origin-lib.sh`](../bin/fm-project-origin-lib.sh) | Accepted origin-form owner shared by both remote provisioning boundaries |
+| `fm-project-layout-preflight.sh` | Emit deterministic read-only cache-layout evidence for one explicit home/project without migration or cutover |
 | `fm-spawn.sh`            | Spawn crewmates, scouts, `id=repo` batches, and secondmates on the resolved harness and runtime backend |
 | `fm-backend.sh`          | Runtime-backend selection, meta helpers, selector resolution, and operation dispatch |
 | `fm-backend-hometag-lib.sh` | Shared per-installation home-tag derivation for zellij tab and cmux workspace titles |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -50,6 +50,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-remote-readiness-lib.sh` | Shared remote second-mate readiness gate: check and, when needed, repair then re-check through `fm-remote-doctor.sh` |
 | [`fm-project-origin-lib.sh`](../bin/fm-project-origin-lib.sh) | Accepted origin-form owner shared by both remote provisioning boundaries |
 | `fm-project-layout-preflight.sh` | Emit deterministic read-only cache-layout evidence for one explicit home/project without migration or cutover |
+| `fm-project-layout-lib.sh` | Side-effect-free path, ownership, Git-topology, redaction, and evidence-fingerprint helpers for the layout preflight |
 | `fm-spawn.sh`            | Spawn crewmates, scouts, `id=repo` batches, and secondmates on the resolved harness and runtime backend |
 | `fm-backend.sh`          | Runtime-backend selection, meta helpers, selector resolution, and operation dispatch |
 | `fm-backend-hometag-lib.sh` | Shared per-installation home-tag derivation for zellij tab and cmux workspace titles |

--- a/tests/fm-project-layout-preflight.test.sh
+++ b/tests/fm-project-layout-preflight.test.sh
@@ -321,6 +321,33 @@ test_live_work_endpoint_orca_pending_and_no_mistakes_worktree() {
   pass "linked run worktree, live metadata, endpoint, Orca, and pending reply all block"
 }
 
+test_unreadable_cache_and_taskless_pending_reply() {
+  local home="$TMP_ROOT/unreadable" cache="$TMP_ROOT/unreadable-cache.git" out rc
+
+  setup_home "$home" sample
+  mkdir -p "$home/state/pending-replies"
+  fm_write_meta "$home/state/pending-replies/0123456789abcdef" \
+    "schema=fm-pending-reply.v1" "phase=awaiting_report"
+  out=$(run_json "$home" sample)
+  rc=$?
+  expect_code 0 "$rc" "taskless pending reply preflight"
+  assert_no_json_code "$out" blockers pending_reply
+  [ "$(json_value "$out" 'd["live"]["pending_reply_count"]')" = 0 ] \
+    || fail "taskless pending reply was counted as live"
+
+  mkdir -p "$cache"
+  chmod 0600 "$cache"
+  out=$(run_json "$home" sample --cache-root "$cache")
+  rc=$?
+  chmod 0700 "$cache"
+  expect_code 1 "$rc" "unreadable cache preflight"
+  assert_json_code "$out" blockers cache_unresolved
+  assert_no_json_code "$out" blockers cache_not_bare
+  [ "$(json_value "$out" 'json.dumps(d["proposal"]["cache_is_git"])')" = false ] \
+    || fail "unreadable cache borrowed Git evidence from another repository"
+  pass "unreadable cache paths never yield foreign Git evidence and taskless pending replies are ignored"
+}
+
 test_duplicate_cross_home_branch_and_remote_isolation() {
   local home="$TMP_ROOT/parent" child="$TMP_ROOT/child" project child_project out rc remote_path=/remote/private/home
   setup_home "$home" sample
@@ -388,6 +415,7 @@ test_alternate_shallow_partial_promisor_and_replace
 test_no_origin_and_diverged_default
 test_cache_identity_and_format_mismatch
 test_live_work_endpoint_orca_pending_and_no_mistakes_worktree
+test_unreadable_cache_and_taskless_pending_reply
 test_duplicate_cross_home_branch_and_remote_isolation
 test_canonical_checkout_is_navigation_only
 test_spaces_and_metacharacters_are_literal

--- a/tests/fm-project-layout-preflight.test.sh
+++ b/tests/fm-project-layout-preflight.test.sh
@@ -335,6 +335,39 @@ test_unreadable_cache_and_taskless_pending_reply() {
   [ "$(json_value "$out" 'd["live"]["pending_reply_count"]')" = 0 ] \
     || fail "taskless pending reply was counted as live"
 
+  out=$(run_json "$home" sample --cache-root "$TMP_ROOT/cache/../escape.git")
+  rc=$?
+  expect_code 1 "$rc" "lexically unsafe cache preflight"
+  assert_json_code "$out" blockers cache_path_unsafe
+  assert_no_json_code "$out" blockers cache_missing
+  assert_no_json_code "$out" blockers cache_not_git
+  assert_no_json_code "$out" blockers cache_filesystem_unknown
+  [ "$(json_value "$out" 'd["proposal"]["cache_locality"]')" = not-supplied ] \
+    || fail "unsafe cache path was probed for filesystem locality"
+  [ "$(json_value "$out" 'json.dumps(d["proposal"]["cache_is_git"])')" = false ] \
+    || fail "unsafe cache path was probed with Git"
+
+  if [ "$(id -u)" -eq 0 ]; then
+    pass "taskless pending replies are ignored (unreadable-path coverage needs a non-root user)"
+    return 0
+  fi
+
+  mkdir -p "$home/projects/unreadable"
+  chmod 0600 "$home/projects/unreadable"
+  out=$(run_json "$home" unreadable)
+  rc=$?
+  chmod 0700 "$home/projects/unreadable"
+  expect_code 1 "$rc" "unreadable project preflight"
+  assert_json_code "$out" blockers project_unresolved
+  assert_no_json_code "$out" blockers project_path_escape
+  assert_no_json_code "$out" blockers project_not_worktree
+  assert_no_json_code "$out" blockers dirty_worktree
+  assert_no_json_code "$out" blockers off_default
+  [ "$(json_value "$out" 'd["repository"]["origin"]')" = "" ] \
+    || fail "unresolved project borrowed an origin from the caller repository"
+  [ "$(json_value "$out" 'd["repository"]["object_format"]')" = unknown ] \
+    || fail "unresolved project borrowed an object format from the caller repository"
+
   mkdir -p "$cache"
   chmod 0600 "$cache"
   out=$(run_json "$home" sample --cache-root "$cache")

--- a/tests/fm-project-layout-preflight.test.sh
+++ b/tests/fm-project-layout-preflight.test.sh
@@ -1,0 +1,395 @@
+#!/usr/bin/env bash
+# Behavior tests for the detect-only project-layout preflight.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+PREFLIGHT="$ROOT/bin/fm-project-layout-preflight.sh"
+TMP_ROOT=$(fm_test_tmproot fm-project-layout-preflight)
+TMP_ROOT=$(cd "$TMP_ROOT" && pwd -P)
+SOURCE="$TMP_ROOT/source"
+REMOTE="$TMP_ROOT/source.git"
+
+git -C "$TMP_ROOT" init -q -b main "$SOURCE" || fail "could not initialize source fixture"
+printf '# fixture\n' > "$SOURCE/README.md"
+git -C "$SOURCE" add README.md
+git -C "$SOURCE" -c user.name=fixture -c user.email=fixture@example.invalid commit -qm initial \
+  || fail "could not commit source fixture"
+printf 'second\n' >> "$SOURCE/README.md"
+git -C "$SOURCE" add README.md
+git -C "$SOURCE" -c user.name=fixture -c user.email=fixture@example.invalid commit -qm second \
+  || fail "could not add second source commit"
+git clone --quiet --bare "$SOURCE" "$REMOTE" || fail "could not create source bare remote"
+ORIGIN_URL="file://$REMOTE"
+
+setup_home() { # <home> <project-name>
+  local home=$1 name=$2 project
+  mkdir -p "$home/data" "$home/state" "$home/projects"
+  project="$home/projects/$name"
+  git clone --quiet "$ORIGIN_URL" "$project" || fail "could not clone $name fixture"
+  git -C "$project" remote set-head origin --auto >/dev/null 2>&1 \
+    || fail "could not set cached origin HEAD for $name"
+  printf -- '- %s [direct-PR] - fixture project (added 2026-08-17)\n' "$name" > "$home/data/projects.md"
+}
+
+run_json() { # <home> <project> [extra args...]
+  local home=$1 project=$2
+  shift 2
+  "$PREFLIGHT" --home "$home" --project "$project" --json "$@"
+}
+
+json_valid() {
+  printf '%s' "$1" | python3 -c 'import json,sys; json.load(sys.stdin)' \
+    || fail "preflight did not emit valid JSON"
+}
+
+json_value() { # <json> <python-expression over d>
+  printf '%s' "$1" | python3 -c "import json,sys; d=json.load(sys.stdin); print($2)"
+}
+
+assert_json_code() { # <json> <blockers|warnings> <code>
+  local json=$1 kind=$2 code=$3
+  printf '%s' "$json" | python3 -c '
+import json,sys
+doc=json.load(sys.stdin)
+kind, code=sys.argv[1:]
+raise SystemExit(0 if code in [item["code"] for item in doc[kind]] else 1)
+' "$kind" "$code" || fail "missing $kind code $code"
+}
+
+assert_no_json_code() { # <json> <blockers|warnings> <code>
+  local json=$1 kind=$2 code=$3
+  if printf '%s' "$json" | python3 -c '
+import json,sys
+doc=json.load(sys.stdin)
+kind, code=sys.argv[1:]
+raise SystemExit(0 if code in [item["code"] for item in doc[kind]] else 1)
+' "$kind" "$code"; then
+    fail "unexpected $kind code $code"
+  fi
+}
+
+snapshot_fixture() { # <home> <project>
+  local home=$1 project=$2 git_dir
+  git_dir=$(git -C "$project" rev-parse --absolute-git-dir)
+  {
+    cksum "$home/data/projects.md"
+    if [ -d "$home/state" ]; then
+      find "$home/state" -type f -print | LC_ALL=C sort | while IFS= read -r file; do
+        cksum "$file"
+      done
+    fi
+    GIT_OPTIONAL_LOCKS=0 git -C "$project" status --porcelain=v1
+    GIT_OPTIONAL_LOCKS=0 git -C "$project" show-ref
+    GIT_OPTIONAL_LOCKS=0 git -C "$project" config --local --list --show-origin
+    GIT_OPTIONAL_LOCKS=0 git -C "$project" worktree list --porcelain
+    find "$git_dir" -type f -print | LC_ALL=C sort | while IFS= read -r file; do
+      cksum "$file"
+    done
+  } | LC_ALL=C sort
+}
+
+snapshot_git_admin() { # <worktree-or-bare-repo>
+  local repo=$1 git_dir
+  git_dir=$(git -C "$repo" rev-parse --absolute-git-dir) || return 1
+  {
+    GIT_OPTIONAL_LOCKS=0 git -C "$repo" show-ref
+    GIT_OPTIONAL_LOCKS=0 git -C "$repo" config --local --list --show-origin
+    find "$git_dir" -type f -print | LC_ALL=C sort | while IFS= read -r file; do
+      cksum "$file"
+    done
+  } | LC_ALL=C sort
+}
+
+test_help_and_ready_json() {
+  local home="$TMP_ROOT/ready home" cache="$TMP_ROOT/ready-cache.git" out rc cache_before cache_after
+  setup_home "$home" sample
+  git clone --quiet --bare "$ORIGIN_URL" "$cache"
+  chmod 0700 "$cache"
+  cache_before=$(snapshot_git_admin "$cache")
+  out=$($PREFLIGHT --help) || fail "--help failed"
+  assert_contains "$out" "performs no migration or cutover" "help omitted the detect-only boundary"
+  out=$(run_json "$home" sample --cache-root "$cache")
+  rc=$?
+  expect_code 0 "$rc" "ready preflight"
+  json_valid "$out"
+  [ "$(json_value "$out" 'd["schema"]')" = fm-project-layout-preflight.v1 ] \
+    || fail "wrong JSON schema"
+  [ "$(json_value "$out" 'd["status"]')" = ready ] || fail "clean fixture was not ready"
+  [ "$(json_value "$out" 'd["read_only"]')" = True ] || fail "read_only was not true"
+  [ "$(json_value "$out" 'd["fingerprint"]["cutover_authority"]')" = False ] \
+    || fail "fingerprint was represented as cutover authority"
+  cache_after=$(snapshot_git_admin "$cache")
+  [ "$cache_before" = "$cache_after" ] || fail "preflight changed cache refs, config, hooks, or objects"
+  pass "clean managed clone produces deterministic ready evidence, not cutover authority"
+}
+
+test_idempotence_and_byte_invariance() {
+  local home="$TMP_ROOT/invariant" project before between after one two
+  setup_home "$home" sample
+  project="$home/projects/sample"
+  before=$(snapshot_fixture "$home" "$project")
+  one=$(run_json "$home" sample) || fail "first invariant preflight blocked"
+  between=$(snapshot_fixture "$home" "$project")
+  two=$(run_json "$home" sample) || fail "second invariant preflight blocked"
+  after=$(snapshot_fixture "$home" "$project")
+  [ "$one" = "$two" ] || fail "repeat preflights emitted different evidence"
+  [ "$before" = "$between" ] || fail "first preflight changed repository, registry, refs, config, index, or state bytes"
+  [ "$between" = "$after" ] || fail "second preflight changed repository, registry, refs, config, index, or state bytes"
+  pass "repeat preflight is byte-for-byte deterministic and leaves repository/state/config/refs unchanged"
+}
+
+test_dirty_off_default_and_unpushed() {
+  local home="$TMP_ROOT/repository blockers" project out rc
+  setup_home "$home" sample
+  project="$home/projects/sample"
+  git -C "$project" switch -q -c feature
+  printf 'uncommitted\n' >> "$project/README.md"
+  git -C "$project" add README.md
+  git -C "$project" -c user.name=fixture -c user.email=fixture@example.invalid commit -qm local
+  printf 'dirty\n' >> "$project/README.md"
+  out=$(run_json "$home" sample)
+  rc=$?
+  expect_code 1 "$rc" "repository blocker preflight"
+  assert_json_code "$out" blockers off_default
+  assert_json_code "$out" blockers dirty_worktree
+  assert_json_code "$out" blockers unpushed_commits
+  pass "dirty, off-default, and unpushed repository state fails closed"
+}
+
+test_secret_redaction() {
+  local home="$TMP_ROOT/credential" project out rc secret=supersecret query=moresecret
+  setup_home "$home" sample
+  project="$home/projects/sample"
+  git -C "$project" remote set-url origin "https://user:$secret@example.invalid/team/app.git?token=$query"
+  out=$(run_json "$home" sample)
+  rc=$?
+  expect_code 1 "$rc" "credential preflight"
+  json_valid "$out"
+  assert_json_code "$out" blockers origin_embedded_credentials
+  assert_not_contains "$out" "$secret" "credential leaked into preflight output"
+  assert_not_contains "$out" "$query" "query credential leaked into preflight output"
+  assert_contains "$out" '<redacted>@example.invalid/team/app.git' "redacted origin identity was not reported"
+  git -C "$project" remote set-url origin "https://example.invalid/team/app.git?token=$query"
+  out=$(run_json "$home" sample)
+  rc=$?
+  expect_code 1 "$rc" "query credential preflight"
+  assert_json_code "$out" blockers origin_embedded_credentials
+  assert_not_contains "$out" "$query" "credential-only query leaked without URL userinfo"
+  pass "credential-bearing origins are blocked and secrets never enter output or fingerprint"
+}
+
+test_symlink_and_cache_permission_hazards() {
+  local home="$TMP_ROOT/symlink" outside="$TMP_ROOT/outside" cache="$TMP_ROOT/cache.git" missing="$TMP_ROOT/missing-cache.git" out rc
+  setup_home "$home" sample
+  mkdir -p "$outside"
+  ln -s "$outside" "$home/projects/escape"
+  out=$(run_json "$home" escape)
+  rc=$?
+  expect_code 1 "$rc" "symlink preflight"
+  assert_json_code "$out" blockers project_symlink
+  assert_json_code "$out" blockers project_path_escape
+
+  out=$(run_json "$home" sample --cache-root "$missing")
+  rc=$?
+  expect_code 1 "$rc" "missing cache preflight"
+  assert_json_code "$out" blockers cache_missing
+  assert_absent "$missing" "detect-only preflight created the proposed cache path"
+
+  git clone --quiet --bare "$ORIGIN_URL" "$cache"
+  chmod 0777 "$cache"
+  out=$(run_json "$home" sample --cache-root "$cache")
+  rc=$?
+  expect_code 1 "$rc" "cache permission preflight"
+  assert_json_code "$out" blockers cache_permissions
+  pass "symlink escape and non-owner-only cache permissions fail closed"
+}
+
+test_alternate_shallow_partial_promisor_and_replace() {
+  local alternate_home="$TMP_ROOT/alternate" shallow_home="$TMP_ROOT/shallow" project out rc head parent
+  setup_home "$alternate_home" sample
+  project="$alternate_home/projects/sample"
+  printf '%s/objects\n' "$REMOTE" > "$project/.git/objects/info/alternates"
+  git -C "$project" config extensions.partialClone origin
+  git -C "$project" config remote.origin.promisor true
+  git -C "$project" config remote.origin.partialclonefilter blob:none
+  head=$(git -C "$project" rev-parse HEAD)
+  parent=$(git -C "$project" rev-parse HEAD^)
+  git -C "$project" update-ref "refs/replace/$head" "$parent"
+  printf '%s %s\n' "$head" "$parent" > "$project/.git/info/grafts"
+  out=$(run_json "$alternate_home" sample)
+  rc=$?
+  expect_code 1 "$rc" "alternate feature preflight"
+  assert_json_code "$out" blockers unexpected_alternate
+  assert_json_code "$out" blockers partial_clone
+  assert_json_code "$out" blockers promisor_remote
+  assert_json_code "$out" blockers replace_refs
+  assert_json_code "$out" blockers grafts
+
+  mkdir -p "$shallow_home/data" "$shallow_home/state" "$shallow_home/projects"
+  git clone --quiet --depth 1 "$ORIGIN_URL" "$shallow_home/projects/sample"
+  git -C "$shallow_home/projects/sample" remote set-head origin --auto >/dev/null 2>&1
+  printf -- '- sample [direct-PR] - fixture project (added 2026-08-17)\n' > "$shallow_home/data/projects.md"
+  out=$(run_json "$shallow_home" sample)
+  rc=$?
+  expect_code 1 "$rc" "shallow preflight"
+  assert_json_code "$out" blockers shallow_repository
+  pass "alternate, shallow, partial, promisor, replace, and graft states are observable blockers"
+}
+
+test_no_origin_and_diverged_default() {
+  local no_origin_home="$TMP_ROOT/no-origin" diverged_home="$TMP_ROOT/diverged"
+  local project divergent_remote="$TMP_ROOT/divergent.git" publisher="$TMP_ROOT/publisher" out rc
+  setup_home "$no_origin_home" sample
+  git -C "$no_origin_home/projects/sample" remote remove origin
+  out=$(run_json "$no_origin_home" sample)
+  rc=$?
+  expect_code 1 "$rc" "no-origin preflight"
+  assert_json_code "$out" blockers no_origin
+  assert_json_code "$out" blockers default_branch_unknown
+
+  git clone --quiet --bare "$ORIGIN_URL" "$divergent_remote"
+  setup_home "$diverged_home" sample
+  project="$diverged_home/projects/sample"
+  git -C "$project" remote set-url origin "file://$divergent_remote"
+  git -C "$project" fetch -q origin
+  git -C "$project" remote set-head origin --auto >/dev/null 2>&1
+  printf 'local\n' >> "$project/README.md"
+  git -C "$project" add README.md
+  git -C "$project" -c user.name=fixture -c user.email=fixture@example.invalid commit -qm local
+  git clone --quiet "file://$divergent_remote" "$publisher"
+  printf 'remote\n' > "$publisher/remote.txt"
+  git -C "$publisher" add remote.txt
+  git -C "$publisher" -c user.name=fixture -c user.email=fixture@example.invalid commit -qm remote
+  git -C "$publisher" push -q origin main
+  git -C "$project" fetch -q origin
+  out=$(run_json "$diverged_home" sample)
+  rc=$?
+  expect_code 1 "$rc" "diverged preflight"
+  assert_json_code "$out" blockers default_diverged
+  assert_json_code "$out" blockers unpushed_commits
+  pass "no-origin and diverged default states fail closed from local evidence"
+}
+
+test_cache_identity_and_format_mismatch() {
+  local home="$TMP_ROOT/cache identity" other="$TMP_ROOT/other" other_remote="$TMP_ROOT/other.git"
+  local cache="$TMP_ROOT/mismatch-cache.git" sha_cache="$TMP_ROOT/sha-cache.git" out rc
+  setup_home "$home" sample
+  fm_git_init_commit "$other"
+  git clone --quiet --bare "$other" "$other_remote"
+  git clone --quiet --bare "file://$other_remote" "$cache"
+  chmod 0700 "$cache"
+  out=$(run_json "$home" sample --cache-root "$cache")
+  rc=$?
+  expect_code 1 "$rc" "cache origin mismatch preflight"
+  assert_json_code "$out" blockers cache_origin_mismatch
+
+  if git init -q --bare --object-format=sha256 "$sha_cache" 2>/dev/null; then
+    git -C "$sha_cache" remote add origin "$ORIGIN_URL"
+    chmod 0700 "$sha_cache"
+    out=$(run_json "$home" sample --cache-root "$sha_cache")
+    rc=$?
+    expect_code 1 "$rc" "cache object format mismatch preflight"
+    assert_json_code "$out" blockers cache_object_format_mismatch
+  fi
+  pass "cache origin and supported object-format mismatches fail closed"
+}
+
+test_live_work_endpoint_orca_pending_and_no_mistakes_worktree() {
+  local home="$TMP_ROOT/live" project gate_wt out rc
+  gate_wt="$home/.no-mistakes/runs/run-1"
+  setup_home "$home" sample
+  project="$home/projects/sample"
+  mkdir -p "$(dirname "$gate_wt")"
+  git -C "$project" worktree add -q --detach "$gate_wt" HEAD
+  fm_write_meta "$home/state/same-id.meta" \
+    "project=$project" "worktree=$gate_wt" "window=terminal-1" \
+    "endpoint_task_id=same-id" "backend=orca" "orca_worktree_id=orca-1"
+  mkdir -p "$home/state/pending-replies"
+  fm_write_meta "$home/state/pending-replies/0123456789abcdef" \
+    "schema=fm-pending-reply.v1" "task_id=same-id" "phase=awaiting_report"
+  out=$(run_json "$home" sample)
+  rc=$?
+  expect_code 1 "$rc" "live work preflight"
+  assert_json_code "$out" blockers linked_worktrees
+  assert_json_code "$out" blockers no_mistakes_run_worktree
+  assert_json_code "$out" blockers live_task_metadata
+  assert_json_code "$out" blockers live_endpoint
+  assert_json_code "$out" blockers live_orca
+  assert_json_code "$out" blockers pending_reply
+  pass "linked run worktree, live metadata, endpoint, Orca, and pending reply all block"
+}
+
+test_duplicate_cross_home_branch_and_remote_isolation() {
+  local home="$TMP_ROOT/parent" child="$TMP_ROOT/child" project child_project out rc remote_path=/remote/private/home
+  setup_home "$home" sample
+  setup_home "$child" sample
+  project="$home/projects/sample"
+  child_project="$child/projects/sample"
+  fm_write_meta "$home/state/collision.meta" "project=$project" "worktree=$project" "endpoint_task_id=collision"
+  fm_write_meta "$child/state/collision.meta" "project=$child_project" "worktree=$child_project" "endpoint_task_id=collision"
+  {
+    printf -- '- local-mate - fixture (home: %s; scope: sample; projects: sample; added 2026-08-17)\n' "$child"
+    printf -- '- remote-mate - fixture (host: build-host; root: /remote/code; home: %s; scope: sample; projects: sample; added 2026-08-17)\n' "$remote_path"
+  } > "$home/data/secondmates.md"
+  out=$(run_json "$home" sample)
+  rc=$?
+  expect_code 1 "$rc" "duplicate branch preflight"
+  assert_json_code "$out" blockers duplicate_cross_home_branch
+  assert_json_code "$out" warnings remote_home_unverified
+  assert_not_contains "$out" "$remote_path" "remote home path leaked into local preflight evidence"
+  [ "$(json_value "$out" 'd["live"]["remote_borrower_count"]')" = 1 ] \
+    || fail "remote borrower was not counted without resolving its path"
+  pass "duplicate cross-home fm/id is blocked and remote placement never receives a local path"
+}
+
+test_canonical_checkout_is_navigation_only() {
+  local home="$TMP_ROOT/canonical" project human="$TMP_ROOT/human checkout" linked="$TMP_ROOT/linked human" out rc human_before human_after
+  setup_home "$home" sample
+  project="$home/projects/sample"
+  git clone --quiet "$ORIGIN_URL" "$human"
+  human_before=$(snapshot_git_admin "$human")
+  out=$(run_json "$home" sample --canonical-path "$human") \
+    || fail "independent canonical checkout should remain navigation-only evidence"
+  assert_no_json_code "$out" blockers canonical_shares_common_dir
+  human_after=$(snapshot_git_admin "$human")
+  [ "$human_before" = "$human_after" ] || fail "preflight changed the human checkout's refs, config, hooks, index, or objects"
+  git -C "$project" worktree add -q --detach "$linked" HEAD
+  out=$(run_json "$home" sample --canonical-path "$linked")
+  rc=$?
+  expect_code 1 "$rc" "linked canonical preflight"
+  assert_json_code "$out" blockers canonical_shares_common_dir
+  pass "independent human checkout is navigation-only while a shared common dir is refused"
+}
+
+test_spaces_and_metacharacters_are_literal() {
+  local home="$TMP_ROOT/metachar home" name="project \$(touch SHOULD_NOT_EXIST) [x]" project out rc sentinel="$PWD/SHOULD_NOT_EXIST"
+  mkdir -p "$home/data" "$home/state" "$home/projects"
+  project="$home/projects/$name"
+  git clone --quiet "$ORIGIN_URL" "$project"
+  git -C "$project" remote set-head origin --auto >/dev/null 2>&1
+  out=$(run_json "$home" "$name")
+  rc=$?
+  expect_code 1 "$rc" "metacharacter preflight"
+  json_valid "$out"
+  assert_json_code "$out" blockers unregistered_project
+  assert_absent "$sentinel" "project name metacharacters were executed"
+  assert_contains "$out" "$name" "literal project name was not preserved"
+  pass "spaces and shell metacharacters remain literal and deterministic"
+}
+
+test_help_and_ready_json
+test_idempotence_and_byte_invariance
+test_dirty_off_default_and_unpushed
+test_secret_redaction
+test_symlink_and_cache_permission_hazards
+test_alternate_shallow_partial_promisor_and_replace
+test_no_origin_and_diverged_default
+test_cache_identity_and_format_mismatch
+test_live_work_endpoint_orca_pending_and_no_mistakes_worktree
+test_duplicate_cross_home_branch_and_remote_isolation
+test_canonical_checkout_is_navigation_only
+test_spaces_and_metacharacters_are_literal
+
+echo "ALL TESTS PASSED"

--- a/tests/fm-project-layout-preflight.test.sh
+++ b/tests/fm-project-layout-preflight.test.sh
@@ -492,8 +492,44 @@ test_unverifiable_ownership_fails_closed() {
   pass "unverifiable ownership and permissions fail closed"
 }
 
+test_ambient_git_config_injection_cannot_alter_evidence() {
+  local home="$TMP_ROOT/ambient config" clean injected rc
+  setup_home "$home" sample
+  clean=$(run_json "$home" sample) || fail "ambient config baseline preflight blocked"
+  injected=$(GIT_CONFIG_COUNT=3 \
+    GIT_CONFIG_KEY_0=remote.evil.promisor GIT_CONFIG_VALUE_0=true \
+    GIT_CONFIG_KEY_1=extensions.partialclone GIT_CONFIG_VALUE_1=evil \
+    GIT_CONFIG_KEY_2=extensions.objectformat GIT_CONFIG_VALUE_2=sha256 \
+    GIT_CONFIG_PARAMETERS="'extensions.objectformat=sha256'" \
+    GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null \
+    run_json "$home" sample)
+  rc=$?
+  expect_code 0 "$rc" "ambient git config injection preflight"
+  [ "$injected" = "$clean" ] \
+    || fail "ambient GIT_CONFIG_* injection changed reported repository evidence"
+  pass "ambient Git config injection cannot alter reported repository evidence"
+}
+
+test_nested_directory_cannot_borrow_ancestor_repository() {
+  local home="$TMP_ROOT/nested" out rc
+  mkdir -p "$home/data" "$home/state"
+  git clone --quiet "$ORIGIN_URL" "$home/outer" || fail "could not clone nested ancestor"
+  git -C "$home/outer" remote set-url origin https://ancestor.invalid/team/outer.git
+  mkdir -p "$home/outer/projects/sample"
+  printf -- '- sample [direct-PR] - fixture project (added 2026-08-17)\n' > "$home/data/projects.md"
+  out=$(run_json "$home/outer" sample)
+  rc=$?
+  expect_code 1 "$rc" "nested ancestor preflight"
+  json_valid "$out"
+  assert_json_code "$out" blockers project_not_worktree
+  assert_not_contains "$out" "ancestor.invalid" "ancestor repository origin leaked into project evidence"
+  pass "plain nested directory cannot borrow an ancestor repository identity"
+}
+
 test_help_and_ready_json
 test_ambient_git_environment_cannot_substitute_another_repository
+test_ambient_git_config_injection_cannot_alter_evidence
+test_nested_directory_cannot_borrow_ancestor_repository
 test_unverifiable_ownership_fails_closed
 test_idempotence_and_byte_invariance
 test_dirty_off_default_and_unpushed

--- a/tests/fm-project-layout-preflight.test.sh
+++ b/tests/fm-project-layout-preflight.test.sh
@@ -343,6 +343,19 @@ test_unreadable_cache_and_taskless_pending_reply() {
   expect_code 1 "$rc" "unreadable cache preflight"
   assert_json_code "$out" blockers cache_unresolved
   assert_no_json_code "$out" blockers cache_not_bare
+  assert_no_json_code "$out" blockers cache_not_git
+  assert_no_json_code "$out" blockers cache_owner_mismatch
+  assert_no_json_code "$out" blockers cache_permissions
+  assert_no_json_code "$out" blockers cache_filesystem_unknown
+  assert_no_json_code "$out" blockers cache_network_filesystem
+  [ "$(json_value "$out" 'd["proposal"]["cache_uid"]')" = unknown ] \
+    || fail "unresolved cache reported an ownership claim"
+  [ "$(json_value "$out" 'd["proposal"]["cache_mode"]')" = unknown ] \
+    || fail "unresolved cache reported a mode claim"
+  [ "$(json_value "$out" 'd["proposal"]["cache_object_format"]')" = unknown ] \
+    || fail "unresolved cache borrowed an object format from another repository"
+  [ "$(json_value "$out" 'd["proposal"]["cache_origin"]')" = "" ] \
+    || fail "unresolved cache borrowed an origin from another repository"
   [ "$(json_value "$out" 'json.dumps(d["proposal"]["cache_is_git"])')" = false ] \
     || fail "unreadable cache borrowed Git evidence from another repository"
   pass "unreadable cache paths never yield foreign Git evidence and taskless pending replies are ignored"

--- a/tests/fm-project-layout-preflight.test.sh
+++ b/tests/fm-project-layout-preflight.test.sh
@@ -510,6 +510,25 @@ test_ambient_git_config_injection_cannot_alter_evidence() {
   pass "ambient Git config injection cannot alter reported repository evidence"
 }
 
+test_ambient_home_overrides_cannot_substitute_another_home() {
+  local home="$TMP_ROOT/ambient overrides" decoy clean injected rc
+  setup_home "$home" sample
+  decoy="$TMP_ROOT/ambient-overrides-decoy"
+  mkdir -p "$decoy/data" "$decoy/bin"
+  printf -- '- sample [local-only +yolo] - decoy project (added 2026-08-17)\n' > "$decoy/data/projects.md"
+  printf '#!/bin/sh\necho "local-only on"\n' > "$decoy/bin/fm-project-mode.sh"
+  chmod 0755 "$decoy/bin/fm-project-mode.sh"
+  clean=$(run_json "$home" sample) || fail "ambient override baseline preflight blocked"
+  injected=$(FM_DATA_OVERRIDE="$decoy/data" FM_ROOT_OVERRIDE="$decoy" run_json "$home" sample)
+  rc=$?
+  expect_code 0 "$rc" "ambient home override preflight"
+  [ "$injected" = "$clean" ] \
+    || fail "ambient FM_DATA_OVERRIDE/FM_ROOT_OVERRIDE changed reported home posture"
+  assert_not_contains "$injected" "local-only" "decoy home mode leaked into the report"
+  assert_not_contains "$injected" "\"yolo\":\"on\"" "decoy home yolo posture leaked into the report"
+  pass "ambient home overrides cannot substitute another home's posture"
+}
+
 test_nested_directory_cannot_borrow_ancestor_repository() {
   local home="$TMP_ROOT/nested" out rc
   mkdir -p "$home/data" "$home/state"
@@ -529,6 +548,7 @@ test_nested_directory_cannot_borrow_ancestor_repository() {
 test_help_and_ready_json
 test_ambient_git_environment_cannot_substitute_another_repository
 test_ambient_git_config_injection_cannot_alter_evidence
+test_ambient_home_overrides_cannot_substitute_another_home
 test_nested_directory_cannot_borrow_ancestor_repository
 test_unverifiable_ownership_fails_closed
 test_idempotence_and_byte_invariance

--- a/tests/fm-project-layout-preflight.test.sh
+++ b/tests/fm-project-layout-preflight.test.sh
@@ -452,7 +452,49 @@ test_spaces_and_metacharacters_are_literal() {
   pass "spaces and shell metacharacters remain literal and deterministic"
 }
 
+test_ambient_git_environment_cannot_substitute_another_repository() {
+  local home="$TMP_ROOT/ambient" project decoy clean ambient rc
+  setup_home "$home" sample
+  project="$home/projects/sample"
+  decoy="$TMP_ROOT/ambient-decoy"
+  git clone --quiet "$ORIGIN_URL" "$decoy" || fail "could not clone ambient decoy"
+  git -C "$decoy" remote set-url origin https://decoy.invalid/team/decoy.git
+  git -C "$decoy" switch -q -c decoy-branch
+  printf 'decoy\n' >> "$decoy/README.md"
+  clean=$(run_json "$home" sample) || fail "ambient baseline preflight blocked"
+  ambient=$(GIT_DIR="$decoy/.git" GIT_WORK_TREE="$decoy" \
+    GIT_INDEX_FILE="$decoy/.git/index" GIT_OBJECT_DIRECTORY="$decoy/.git/objects" \
+    run_json "$home" sample)
+  rc=$?
+  expect_code 0 "$rc" "ambient git environment preflight"
+  [ "$ambient" = "$clean" ] \
+    || fail "ambient GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE/GIT_OBJECT_DIRECTORY changed reported repository facts"
+  assert_not_contains "$ambient" "decoy.invalid" "ambient repository origin leaked into the report"
+  assert_not_contains "$ambient" "decoy-branch" "ambient repository branch leaked into the report"
+  pass "hostile ambient Git environment cannot substitute another repository"
+}
+
+test_unverifiable_ownership_fails_closed() {
+  local home="$TMP_ROOT/unverifiable" stub="$TMP_ROOT/stat-stub" out rc
+  setup_home "$home" sample
+  mkdir -p "$stub"
+  printf '#!/bin/sh\nexit 1\n' > "$stub/stat"
+  chmod 0755 "$stub/stat"
+  out=$(PATH="$stub:$PATH" run_json "$home" sample)
+  rc=$?
+  expect_code 1 "$rc" "unverifiable ownership preflight"
+  json_valid "$out"
+  assert_json_code "$out" blockers home_owner_mismatch
+  assert_json_code "$out" blockers home_writable_by_others
+  assert_json_code "$out" blockers project_owner_mismatch
+  assert_json_code "$out" blockers project_writable_by_others
+  [ "$(json_value "$out" 'd["status"]')" != ready ] || fail "unverifiable ownership reported ready"
+  pass "unverifiable ownership and permissions fail closed"
+}
+
 test_help_and_ready_json
+test_ambient_git_environment_cannot_substitute_another_repository
+test_unverifiable_ownership_fails_closed
 test_idempotence_and_byte_invariance
 test_dirty_off_default_and_unpushed
 test_secret_redaction


### PR DESCRIPTION
## Intent

Implement only the safest prerequisite approved after reviewing Mr Allen’s development-folder architecture: a deterministic, detect-only preflight for isolated per-home ordinary control checkouts backed in the future by a host-local per-origin shared Git object cache, while disposable task worktrees and canonical human development checkouts remain untouched. The tool must accept an explicit Firstmate home/project plus optional exact proposed cache repository and navigation-only canonical human path; it must never migrate or cut over, create/fetch/clone a cache, write alternates or refs, edit registry/config/hooks/excludes, initialize no-mistakes, scan a development-directory tree, touch state, move/replace checkouts, or mutate human repositories. It must conservatively report registered posture, Git/common directories, redacted origin identity, default/object format and delivery state; blockers for dirty/off-default/diverged/unpushed/no-origin/shallow/partial/promisor/replace/graft/alternate/symlink/path/ownership/permissions/cache mismatch/live worktree or task/run/endpoint/Orca/pending reply/duplicate cross-home fm task identity where local evidence is authoritative; remote-home paths must remain isolated. Emit deterministic text and JSON plus a stable non-secret evidence fingerprint that explicitly is not cutover authority. Keep Bash 3.2/Linux portability, public-behavior tests with repeated byte-for-byte control/state/config/ref and human/cache invariance, and the exact five-surface scope: two new project-layout scripts, one new test, minimal test routing, and minimal scripts documentation. Do not add descriptors, cache lifecycle, leases, pruning, borrower registration, migration, rollback, pilot selection, or deletion. Future pilot selection, cutover, and old-clone deletion remain separate approvals. Reconcile concurrent shared-repository work without reverting or overwriting it, validate through CI, open a PR, and never merge.

## What Changed

- Added `bin/fm-project-layout-preflight.sh`, a read-only command that inspects one explicit Firstmate home/project (plus optional exact `--cache-root` and navigation-only `--canonical-path`) and reports registered posture, Git/common directories, redacted origin identity, default branch, object format, and delivery state, together with blockers for dirty/off-default/diverged/unpushed/no-origin/shallow/partial/promisor/replace/graft/alternate/symlink/path/ownership/permission/cache-mismatch/live-worktree and task/run/endpoint/Orca/pending-reply/duplicate-identity conditions. It emits deterministic text or `fm-project-layout-preflight.v1` JSON with a non-secret evidence fingerprint that is explicitly not cutover authority, and exits 0/1/2 for clean/blocked/invalid. It never fetches, clones, creates a cache, writes alternates or refs, edits registry/config, initializes no-mistakes, scans a development tree, or mutates any checkout.
- Added `bin/fm-project-layout-lib.sh` with side-effect-free helpers for path resolution, ownership and permission checks, Git topology probing, origin redaction, and evidence fingerprinting; the entrypoint also scrubs ambient `GIT_*`, `GIT_CONFIG_*`, and Firstmate home/root override environment before any inspection.
- Added `tests/fm-project-layout-preflight.test.sh` covering public behavior, including repeated byte-for-byte output stability and control/state/config/ref plus human-checkout and cache invariance, and routed it into the `pure-contract-unit` family in `bin/fm-test-run.sh`; documented both new scripts in `docs/scripts.md`.

## Risk Assessment

✅ Low: Detect-only, read-only new tool confined to the five approved surfaces, with the prior round's ambient FM_HOME override gap now closed at the same env-scrub boundary and covered by a behavioral test that genuinely fails without the fix.

## Testing

Targeted validation of the detect-only layout preflight: the new suite passes, and a manual end-to-end CLI transcript on a real temporary home/project/cache demonstrates the ready path, the blocked path with the intended blocker codes, credential redaction with no secret in output or fingerprint, repeated-run byte-for-byte determinism, and byte-level invariance of home state, git config, refs and the proposed cache. No UI surface is involved (Bash CLI tool), so evidence is CLI transcripts rather than screenshots. Temporary fixtures removed; worktree clean.

<details>
<summary>Evidence: Ready-posture preflight transcript (text + JSON)</summary>

Source: [Ready-posture preflight transcript (text + JSON)](https://github.com/MikeyB03/firstmate/blob/1c11d085f0910ecbb0f61d9464e6e6e5ec4a729c/.no-mistakes/evidence/fm/dev-layout-architecture-review/preflight-ready.txt)

```text
=== 1. ready posture (text) ===
project layout preflight: ready
schema: fm-project-layout-preflight.v1
read-only: true
home: <TMP>/fm-home
project: <TMP>/fm-home/projects/demo
registered posture: direct-PR yolo=off
origin: file://<TMP>/src.git
git dirs: git=<TMP>/fm-home/projects/demo/.git common=<TMP>/fm-home/projects/demo/.git
branch: current=main default=main ahead=0 behind=0
object format: sha1
live evidence: worktrees=1 extra=0 tasks=0 endpoints=0 orca=0 pending-replies=0
cache proposal: <TMP>/demo-cache.git locality=local format=sha1
canonical navigation path: not-supplied
blockers: 0
warnings: 0
evidence fingerprint: posix-cksum:4260972489:816
cutover authority: false (a future mutating tool must re-check every fact)
exit=0

=== 2. same run, JSON ===
{"schema":"fm-project-layout-preflight.v1","status":"ready","read_only":true,"home":{"requested":"<TMP>/fm-home","physical":"<TMP>/fm-home","uid":"501","mode":"755"},"project":{"name":"demo","requested":"<TMP>/fm-home/projects/demo","physical":"<TMP>/fm-home/projects/demo","git_dir":"<TMP>/fm-home/projects/demo/.git","common_dir":"<TMP>/fm-home/projects/demo/.git","uid":"501","mode":"755"},"registration":{"registered":true,"mode":"direct-PR","yolo":"off"},"repository":{"origin_present":true,"origin":"file://<TMP>/src.git","origin_identity":"posix-cksum:2156380555:41","default_branch":"main","current_branch":"main","object_format":"sha1","dirty":false,"off_default":false,"diverged":false,"ahead":0,"behind":0,"unpushed_commits":0,"shallow":false,"partial":false,"promisor":false,"replace_refs":0,"grafts":false,"alternate":false,"no_mistakes_remote":false},"live":{"worktree_count":1,"extra_worktree_count":0,"no_mistakes_worktree_count":0,"task_ids":[],"endpoint_count":0,"orca_count":0,"pending_reply_count":0,"sibling_borrower_count":0,"remote_borrower_count":0,"duplicate_branch_ids":[]},"proposal":{"cache_root":"<TMP>/demo-cache.git","cache_physical":"<TMP>/demo-cache.git","cache_uid":"501","cache_mode":"700","cache_filesystem":"/dev/disk3s5","cache_locality":"local","cache_is_git":true,"cache_is_bare":true,"cache_origin":"file://<TMP>/src.git","cache_object_format":"sha1","canonical_path":"","canonical_physical":"","canonical_git_dir":"","canonical_common_dir":"","canonical_origin":""},"blockers":[],"warnings":[],"fingerprint":{"algorithm":"posix-cksum","value":"posix-cksum:4260972489:816","cutover_authority":false}}
exit=0
```
</details>
<details>
<summary>Evidence: Determinism, blocker codes, and credential-redaction transcript</summary>

Source: [Determinism, blocker codes, and credential-redaction transcript](https://github.com/MikeyB03/firstmate/blob/1c11d085f0910ecbb0f61d9464e6e6e5ec4a729c/.no-mistakes/evidence/fm/dev-layout-architecture-review/preflight-blockers.txt)

```text
=== 3. determinism: two consecutive JSON runs diffed ===
byte-for-byte identical: yes

=== 4. blockers: dirty tree + unpushed commit + wrong-origin cache ===
project layout preflight: blocked
schema: fm-project-layout-preflight.v1
read-only: true
home: <TMP>/fm-home
project: <TMP>/fm-home/projects/demo
registered posture: direct-PR yolo=off
origin: file://<TMP>/src.git
git dirs: git=<TMP>/fm-home/projects/demo/.git common=<TMP>/fm-home/projects/demo/.git
branch: current=main default=main ahead=1 behind=0
object format: sha1
live evidence: worktrees=1 extra=0 tasks=0 endpoints=0 orca=0 pending-replies=0
cache proposal: <TMP>/wrong-cache.git locality=local format=sha1
canonical navigation path: not-supplied
blockers: 4
- dirty_worktree: Project checkout has uncommitted or untracked changes
- default_ahead: Local default branch is ahead of its origin default ref
- unpushed_commits: Local branches contain commits not reachable from any remote ref
- cache_origin_mismatch: Proposed cache origin differs from the control checkout origin
warnings: 0
evidence fingerprint: posix-cksum:2097231762:875
cutover authority: false (a future mutating tool must re-check every fact)
exit=1

=== 5. secret redaction: credential-bearing origin ===
project layout preflight: blocked
origin: https://<redacted>@example.invalid/x.git
blockers: 4
- origin_embedded_credentials: Origin contains embedded HTTP credentials or query/fragment material; sensitive text was redacted
- default_ahead: Local default branch is ahead of its origin default ref
exit=
```
</details>
<details>
<summary>Evidence: Repository/state/config/ref invariance across runs</summary>

Source: [Repository/state/config/ref invariance across runs](https://github.com/MikeyB03/firstmate/blob/1c11d085f0910ecbb0f61d9464e6e6e5ec4a729c/.no-mistakes/evidence/fm/dev-layout-architecture-review/preflight-invariance.txt)

<code>unchanged: yes (0 differing lines)&#10;cache repo untouched: 3a750b78... refs/heads/main</code>

```text
=== 6. invariance: home/state/config/refs/git-dir checksums before vs after two preflight runs ===
unchanged: yes (0 differing lines)
cache repo untouched:
3a750b7800fdb0f9de0906ab02197e2bf71df3e0 refs/heads/main
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"16766c84ed64ff4be88a53c3cc2cacd5e76d261c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-project-layout-preflight.sh:380` - Ambient FM_DATA_OVERRIDE (and FM_ROOT_OVERRIDE) are not scrubbed, so registered posture can come from a home other than the explicit --home. The script unsets every GIT_* variable at lines 27-42 to guarantee the report describes only the supplied home, but bin/fm-project-mode.sh resolves DATA=&#34;${FM_DATA_OVERRIDE:-$FM_HOME/data}&#34;, i.e. FM_DATA_OVERRIDE wins over the explicitly exported FM_HOME. Failure sequence: FM_DATA_OVERRIDE=/other/home/data fm-project-layout-preflight.sh --home /h --project p -- membership is read from /h/data/projects.md (registered=true) while mode/yolo come from /other/home/data/projects.md, and those foreign values enter both the JSON registration block and the evidence fingerprint (line 591), breaking determinism and per-home isolation for a field the intent requires be conservatively reported. Fix at the same env-scrub boundary: unset FM_DATA_OVERRIDE FM_ROOT_OVERRIDE alongside the GIT_* scrub, or pass FM_DATA_OVERRIDE=&#34;$HOME_PHYSICAL/data&#34; explicitly on the fm-project-mode.sh call.

🔧 Fix: scrub ambient FM home overrides in layout preflight
1 info still open:
- ℹ️ `bin/fm-project-layout-lib.sh:9` - fmp_json_escape handles only \\, &#34;, \b, \f, \n, \r, \t. Other C0 control characters (e.g. 0x01) pass through raw, which JSON forbids. The four CLI arguments are pre-rejected for tab/CR/NL at bin/fm-project-layout-preflight.sh:106, but task IDs (basename of $HOME/state/*.meta) and branch/origin strings are not argument-derived, so a state filename containing a raw 0x01 would make emit_json produce output a strict parser rejects. The home is owner-only, so this is robustness rather than a reachable trust-boundary defect; a \u00XX fallback in the escaper would close it.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-project-layout-preflight.test.sh` — 18 behavior tests, ALL TESTS PASSED</code>
- <code>Manual CLI run: `bin/fm-project-layout-preflight.sh --home &lt;tmp home&gt; --project demo --cache-root &lt;tmp&gt;/demo-cache.git` (text + `--json`) → status ready, exit 0</code>
- <code>Manual blocker run against dirty/unpushed checkout with wrong-origin cache → status blocked, exit 1, codes `dirty_worktree`, `default_ahead`, `unpushed_commits`, `cache_origin_mismatch`</code>
- <code>Manual redaction check: origin set to `https://user:sup3rsecret@example.invalid/x.git` → `origin_embedded_credentials` blocker, origin printed as `https://&lt;redacted&gt;@...`; `grep -c sup3rsecret` over all evidence files = 0</code>
- <code>Determinism: two consecutive `--json` runs compared byte-for-byte → identical</code>
- <code>Invariance: cksum snapshot of home data/state, project `.git` tree, `git config --local -l`, `show-ref`, plus cache repo refs, before vs after two preflight runs → unchanged</code>
- <code>`bin/fm-test-run.sh` routing diff reviewed: new test mapped into `pure-contract-unit` family and `bin/fm-project-layout-*.sh` routed to it</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
