### PR TITLE
Trim generated brief scaffolds

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -25,8 +25,7 @@
 #   --herdr-lab is mandatory when the task will issue Herdr lifecycle commands.
 #   It adds the hard isolation contract backed by bin/fm-herdr-lab.sh.
 #   The flag must be explicit because {TASK} is filled after scaffolding and the
-#   caller-supplied repo string cannot reliably identify this repo. Briefs made
-#   without it carry a loud declaration so an omitted contract cannot be silent.
+#   caller-supplied repo string cannot reliably identify this repo.
 # For ship tasks, --mode is REQUIRED and shapes the definition of done. Firstmate
 # resolves it per task at intake (AGENTS.md section 7); data/projects.md holds the
 # captain's standing posture as context, and this script never reads it:
@@ -51,9 +50,8 @@
 # blocked when firstmate must act.
 # Ship tasks include a project-memory section so durable project-intrinsic
 # learnings can be committed to AGENTS.md through the project's delivery path;
-# it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
-# over copied detail) and has the crewmate add the fm-ensure-agents-md.sh
-# self-governance section when a touched project AGENTS.md lacks it.
+# it has the crewmate add the fm-ensure-agents-md.sh self-governance section when
+# a touched project AGENTS.md lacks it.
 # Refuses to overwrite an existing brief.
 set -eu
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -289,13 +289,7 @@ HERDR_SECTION=$(printf '%s\n' \
 'Never bypass the helper, even for a read-only lifecycle probe or cleanup after failure.' \
 'The captain fleet uses the running `default` session.')
 else
-IFS= read -r -d '' HERDR_SECTION <<'EOF' || true
-# Herdr lifecycle declaration - NOT ENABLED
-**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
-If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
-Do not add Herdr lifecycle commands to this unguarded brief by hand.
-EOF
-HERDR_SECTION=${HERDR_SECTION%$'\n'}
+HERDR_SECTION=""
 fi
 
 if [ "$KIND" = scout ]; then
@@ -304,9 +298,9 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 
 # Task
 {TASK}
-
+${HERDR_SECTION:+
 $HERDR_SECTION
-
+}
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
 This is a SCOUT task: the deliverable is a written report, not a PR.
@@ -332,10 +326,6 @@ The report is the only thing that survives, so anything worth keeping must be in
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
    Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
-7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
-   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
-   daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
-
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
 The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
@@ -351,6 +341,7 @@ fi
 # delivery mode, validated above. The generated DOD opens with the fixed
 # "Delivery contract: mode=<mode>" line that bin/fm-spawn.sh checks against its own
 # explicit --mode before launching.
+DAEMON_RULE=""
 case "$MODE" in
   direct-PR)
     SETUP2=""
@@ -401,6 +392,12 @@ Two firstmate-specific rules layer on top of that guidance:
 
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
+    IFS= read -r -d '' DAEMON_RULE <<'EOF' || true
+7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
+   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
+   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.
+EOF
+    DAEMON_RULE=${DAEMON_RULE%$'\n'}
     ;;
 esac
 
@@ -414,9 +411,9 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 
 # Task
 {TASK}
-
+${HERDR_SECTION:+
 $HERDR_SECTION
-
+}
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
 
@@ -443,19 +440,17 @@ $RULE1
    known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
    a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
    cadence instead of treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
+   When you enter a deliberate wait, declare it in one \`$PAUSED_VERB:\` line naming your current head, exactly what you await, and what voids the wait.
+   The moment you push, your next status line names the new head before anything else - never advertise a head you have moved past.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
    Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
-7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
-   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
-   daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
-
+${DAEMON_RULE:+$DAEMON_RULE
+}
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.
-Record only project knowledge useful to almost every future session.
-For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
 If you touch a project \`AGENTS.md\` that lacks \`## Maintaining this file\`, add that short self-governance section from \`$FM_ROOT/bin/fm-ensure-agents-md.sh\` in the same pass.
 Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -354,7 +354,7 @@ test_no_mistakes_dod_wording() {
   pass "fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe"
 }
 
-test_ship_project_memory_wording() {
+test_ship_project_memory_wording_is_trimmed() {
   local home id brief
   home="$TMP_ROOT/project-memory-home"
   mkdir -p "$home/data"
@@ -362,13 +362,64 @@ test_ship_project_memory_wording() {
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
   brief="$home/data/$id/brief.md"
   assert_present "$brief" "brief was not scaffolded"
-  assert_grep "Record only project knowledge useful to almost every future session." "$brief" \
-    "project-memory contract lost the durable-knowledge bar"
-  assert_grep "prefer a pointer to the authoritative file, command, or doc over copying the detail" "$brief" \
-    "project-memory contract lost pointer-over-copy guidance"
+  assert_grep "If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge" "$brief" \
+    "project-memory trim lost the trigger sentence"
+  assert_no_grep "Record only project knowledge useful to almost every future session." "$brief" \
+    "project-memory trim retained the removed durable-knowledge sentence"
+  assert_no_grep "prefer a pointer to the authoritative file, command, or doc over copying the detail" "$brief" \
+    "project-memory trim retained the removed pointer-over-copy sentence"
   assert_grep "lacks \`## Maintaining this file\`, add that short self-governance section" "$brief" \
     "project-memory contract lost the self-governance add-in-same-pass rule"
-  pass "fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar"
+  assert_grep "Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks" "$brief" \
+    "project-memory trim lost the proportionality sentence"
+  pass "fm-brief.sh: ship project-memory wording keeps the trigger and proportionality only"
+}
+
+test_no_mistakes_daemon_rule_is_mode_scoped() {
+  local home id brief shape
+  home="$TMP_ROOT/daemon-rule-home"
+  mkdir -p "$home/data"
+
+  for shape in direct local scout; do
+    id="brief-daemon-$shape"
+    case "$shape" in
+      direct)
+        FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode direct-PR >/dev/null 2>&1
+        ;;
+      local)
+        FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode local-only >/dev/null 2>&1
+        ;;
+      scout)
+        FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --scout >/dev/null 2>&1
+        ;;
+    esac
+    brief="$home/data/$id/brief.md"
+    assert_no_grep "Never stop, restart, or update the shared \`no-mistakes\` daemon" "$brief" \
+      "$shape brief retained the no-mistakes-only daemon rule"
+  done
+
+  id="brief-daemon-no-mistakes"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep "7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving" "$brief" \
+    "no-mistakes brief lost the daemon rule"
+  assert_grep "daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon." "$brief" \
+    "no-mistakes brief changed the daemon rule"
+  pass "fm-brief.sh: daemon rule appears only in no-mistakes mode"
+}
+
+test_ship_status_protocol_tracks_wait_and_pushed_head() {
+  local home id brief
+  home="$TMP_ROOT/status-protocol-home"
+  mkdir -p "$home/data"
+  id="brief-status-protocol-c2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode direct-PR >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep "When you enter a deliberate wait, declare it in one \`paused:\` line naming your current head, exactly what you await, and what voids the wait." "$brief" \
+    "ship status protocol omitted the deliberate-wait declaration"
+  assert_grep "The moment you push, your next status line names the new head before anything else - never advertise a head you have moved past." "$brief" \
+    "ship status protocol omitted the pushed-head declaration"
+  pass "fm-brief.sh: ship status protocol declares deliberate waits and pushed heads"
 }
 
 test_herdr_lab_contract_is_explicit_and_complete() {
@@ -419,7 +470,7 @@ test_herdr_lab_contract_quotes_foreign_firstmate_path() {
   pass "fm-brief.sh: --herdr-lab uses its quoted Firstmate-owned helper path"
 }
 
-test_herdr_lab_omission_is_loud_for_ship_and_scout() {
+test_unguarded_briefs_omit_herdr_gate() {
   local home id brief
   home="$TMP_ROOT/herdr-gate-home"
   mkdir -p "$home/data"
@@ -431,12 +482,12 @@ test_herdr_lab_omission_is_loud_for_ship_and_scout() {
       FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --mode no-mistakes >/dev/null 2>&1
     fi
     brief="$home/data/$id/brief.md"
-    assert_grep "# Herdr lifecycle declaration - NOT ENABLED" "$brief" \
-      "$kind brief silently omitted the Herdr declaration"
-    assert_grep "regenerate the brief with \`--herdr-lab\` before dispatch" "$brief" \
-      "$kind brief missing the fail-visible regeneration instruction"
+    assert_no_grep "Herdr lifecycle declaration - NOT ENABLED" "$brief" \
+      "$kind brief retained the removed Herdr declaration"
+    assert_no_grep "regenerate the brief with \`--herdr-lab\` before dispatch" "$brief" \
+      "$kind brief retained the removed Herdr gate"
   done
-  pass "fm-brief.sh: ship and scout scaffolds make omitted Herdr intent fail-visible"
+  pass "fm-brief.sh: unguarded ship and scout scaffolds omit the Herdr gate"
 }
 
 test_secondmate_no_projects_charter() {
@@ -719,10 +770,12 @@ test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
-test_ship_project_memory_wording
+test_ship_project_memory_wording_is_trimmed
+test_no_mistakes_daemon_rule_is_mode_scoped
+test_ship_status_protocol_tracks_wait_and_pushed_head
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path
-test_herdr_lab_omission_is_loud_for_ship_and_scout
+test_unguarded_briefs_omit_herdr_gate
 test_herdr_lab_contract_applies_to_scouts_but_not_secondmates
 test_secondmate_no_projects_charter
 test_secondmate_marked_request_reporting_contract


### PR DESCRIPTION
## What changed

- Remove the no-mistakes daemon rule outside no-mistakes mode while preserving it verbatim where the daemon is in play.
- Remove the Herdr NOT ENABLED gate from unguarded briefs while leaving the --herdr-lab contract untouched.
- Remove the two redundant Project-memory sentences while preserving its trigger and proportionality guidance.
- Add deliberate-wait and post-push head-reporting lines to the status protocol.
- Update only the two stale fm-brief --help claims so the help describes the trimmed scaffold.

## Why

The audit found that the removed scaffold text fails blunt removal on the measured project, so this applies the captain-adopted trim with no compressed remnant. The two status-protocol lines retire nightly steers by making deliberate waits and newly pushed heads self-reporting.

## Generated brief evidence

### --mode direct-PR

```diff
--- before/direct-PR.md
+++ after/direct-PR.md
@@ -3,11 +3,6 @@
 # Task
 {TASK}
 
-# Herdr lifecycle declaration - NOT ENABLED
-**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
-If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
-Do not add Herdr lifecycle commands to this unguarded brief by hand.
-
 # Setup
 You are in a disposable git worktree of firstmate, at a detached HEAD on a clean default branch.
 
@@ -34,19 +29,16 @@
    known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
    a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
    cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
+   When you enter a deliberate wait, declare it in one `paused:` line naming your current head, exactly what you await, and what voids the wait.
+   The moment you push, your next status line names the new head before anything else - never advertise a head you have moved past.
 5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
 6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
    append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
    A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
    Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
-7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
-   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
-   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.
 
 # Project memory
 If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/tiago/.treehouse/firstmate-ed7b19/2/firstmate/bin/fm-ensure-agents-md.sh .` in the worktree.
-Record only project knowledge useful to almost every future session.
-For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
 If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/tiago/.treehouse/firstmate-ed7b19/2/firstmate/bin/fm-ensure-agents-md.sh` in the same pass.
 Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.
 
```

### --mode no-mistakes

```diff
--- before/no-mistakes.md
+++ after/no-mistakes.md
@@ -3,11 +3,6 @@
 # Task
 {TASK}
 
-# Herdr lifecycle declaration - NOT ENABLED
-**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
-If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
-Do not add Herdr lifecycle commands to this unguarded brief by hand.
-
 # Setup
 You are in a disposable git worktree of firstmate, at a detached HEAD on a clean default branch.
 
@@ -35,6 +30,8 @@
    known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
    a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
    cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
+   When you enter a deliberate wait, declare it in one `paused:` line naming your current head, exactly what you await, and what voids the wait.
+   The moment you push, your next status line names the new head before anything else - never advertise a head you have moved past.
 5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
 6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
    append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
@@ -46,8 +43,6 @@
 
 # Project memory
 If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/tiago/.treehouse/firstmate-ed7b19/2/firstmate/bin/fm-ensure-agents-md.sh .` in the worktree.
-Record only project knowledge useful to almost every future session.
-For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
 If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/tiago/.treehouse/firstmate-ed7b19/2/firstmate/bin/fm-ensure-agents-md.sh` in the same pass.
 Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.
 
```

### --scout

```diff
--- before/scout.md
+++ after/scout.md
@@ -3,11 +3,6 @@
 # Task
 {TASK}
 
-# Herdr lifecycle declaration - NOT ENABLED
-**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
-If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
-Do not add Herdr lifecycle commands to this unguarded brief by hand.
-
 # Setup
 You are in a disposable git worktree of firstmate, at a detached HEAD on a clean default branch.
 This is a SCOUT task: the deliverable is a written report, not a PR.
@@ -33,10 +28,6 @@
    append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
    A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
    Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
-7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
-   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
-   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.
-
 # Definition of done
 Write your findings to `/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/firstmate-brief-scaffold-trim.3G3ZW2/rendered/evidence-scout/report.md`.
 The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
```

### --herdr-lab variant

```diff
--- before/herdr-lab.md
+++ after/herdr-lab.md
@@ -48,19 +48,16 @@
    known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
    a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
    cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
+   When you enter a deliberate wait, declare it in one `paused:` line naming your current head, exactly what you await, and what voids the wait.
+   The moment you push, your next status line names the new head before anything else - never advertise a head you have moved past.
 5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
 6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
    append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
    A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
    Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
-7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
-   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
-   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.
 
 # Project memory
 If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/tiago/.treehouse/firstmate-ed7b19/2/firstmate/bin/fm-ensure-agents-md.sh .` in the worktree.
-Record only project knowledge useful to almost every future session.
-For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
 If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/tiago/.treehouse/firstmate-ed7b19/2/firstmate/bin/fm-ensure-agents-md.sh` in the same pass.
 Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.
 
```

## Testing

- bin/fm-test-run.sh tests/fm-brief.test.sh (22 output checks passed)
- bin/fm-lint.sh (passed with ShellCheck 0.11.0)
- git diff upstream/main...HEAD --check
- no-mistakes review, test, document, and lint stages passed at 0218ab36

No benchmark artifacts are included.