### PR TITLE
fix(bin): refuse on a dedicated status when the shell-lint gate checks nothing

### DIFF
--- a/bin/fm-lint.sh
+++ b/bin/fm-lint.sh
@@ -36,12 +36,17 @@
 #   0  the selected file set is clean, or there were no changed lint targets
 #   1  ShellCheck reported findings
 #   2  invalid usage
-#   3  the lint could not run and NOTHING was checked (see the refusal below)
+#   3  the lint could not run to completion, so NOTHING it reports can be
+#      trusted (see the refusal below)
 #
 # This gate refuses instead of passing when it cannot run. A missing ShellCheck,
-# a ShellCheck that is not the pin, one that will not report its version, and a
-# missing perl all print an unmissable "LINT NOT RUN" line naming the tool, the
-# exact version required, and how to get it, then exit 3.
+# a ShellCheck that is not the pin, one that will not report its version, a
+# missing perl, a repository root it cannot enter, a temporary directory it
+# cannot create, and a bounded worker whose result never arrived all print an
+# unmissable "LINT NOT RUN" line naming what is missing - plus, when ShellCheck
+# is the missing piece, the exact version required and how to get it - then exit
+# 3. EVERY path that could not check the selected files lands there, so a
+# nonzero status is never a lint failure that in fact never ran.
 # 3 is deliberately not 127: 127 is the shell's own "command not found", so a
 # caller that sees it cannot tell whether this script refused or was never found
 # at all, and a gate that reads lint output for actionable findings sees none in
@@ -50,11 +55,15 @@
 # Provisioning is opt-in and never a side effect of linting, because a gate that
 # reaches the network to validate is harder to trust and breaks on an offline
 # host. A caller that deliberately wants it passes --provision-shellcheck <dir>
-# (or sets FM_LINT_PROVISION_SHELLCHECK=<dir>); this script then installs the
-# pinned, checksum-verified build there through bin/fm-install-shellcheck.sh and
-# puts it first on PATH for that run only. A provisioning attempt that fails
-# refuses exactly like a missing tool; it never degrades into a pass. CI
-# provisions in its own step (.github/workflows/ci.yml) and never needs this.
+# (or sets FM_LINT_PROVISION_SHELLCHECK=<dir>) to ENSURE the pin is present in
+# <dir>: an existing <dir>/shellcheck that already reports the pinned version is
+# only put first on PATH, and the pinned, checksum-verified build is installed
+# through bin/fm-install-shellcheck.sh only when <dir> does not already hold it,
+# so a repeat run neither refetches nor breaks offline. Either way the version
+# enforcement below still runs on whatever ends up on PATH, so skipping the
+# download can never skip the pin. A provisioning attempt that fails refuses
+# exactly like a missing tool; it never degrades into a pass. CI provisions in
+# its own step (.github/workflows/ci.yml) and never needs this.
 #
 # --required-version and --list-files answer with no ShellCheck present at all,
 # because bin/fm-install-shellcheck.sh asks this script which version to fetch:
@@ -66,7 +75,8 @@
 #   fm-lint.sh --jobs <1|2> [path]...  override bounded worker count
 #   fm-lint.sh --telemetry <path> ...  write a quiet metrics snapshot
 #   fm-lint.sh --provision-shellcheck <dir>
-#                                      opt in to installing the pin into <dir>
+#                                      opt in to ensuring the pin is in <dir>,
+#                                      installing it only if it is not already
 #   fm-lint.sh --required-version      print the ShellCheck pin
 #   fm-lint.sh --list-files            print the file set that would be linted
 #   fm-lint.sh --help                  print this usage
@@ -80,7 +90,6 @@ REFUSED_EXIT=3
 SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SELF="$SELF_DIR/fm-lint.sh"
 ROOT="$(cd "$SELF_DIR/.." && pwd)"
-cd "$ROOT" || exit 1
 
 # fm_lint_refuse <reason> [shellcheck]: the single exit for "this gate could not
 # run". Says so unmissably rather than letting a caller read silence as a clean
@@ -88,7 +97,7 @@ cd "$ROOT" || exit 1
 # version, and both ways to get it. See the exit-status note in the header.
 fm_lint_refuse() {
   printf 'fm-lint.sh: LINT NOT RUN: %s\n' "$1" >&2
-  printf 'fm-lint.sh: nothing was checked, so this is a failed lint gate, not a clean one.\n' >&2
+  printf 'fm-lint.sh: nothing trustworthy was checked, so this is a failed lint gate, not a clean one.\n' >&2
   if [ "${2:-}" = shellcheck ]; then
     printf 'fm-lint.sh: required tool: ShellCheck, exactly version %s (pinned so local and CI cannot diverge).\n' \
       "$REQUIRED_SHELLCHECK" >&2
@@ -98,12 +107,33 @@ fm_lint_refuse() {
   exit "$REFUSED_EXIT"
 }
 
+# The repository root every relative canonical root and worker manifest path is
+# resolved against. Refuses on the same contract when it cannot be entered: the
+# selected file set would be unreachable, so nothing could be checked.
+cd "$ROOT" || fm_lint_refuse "could not enter the repository root $ROOT"
+
 # fm_lint_provision_shellcheck <dir>: opt-in only, never reached by a default
-# lint. Installs the pinned, checksum-verified build into <dir> and puts it first
-# on PATH for this run. A failed install refuses; it never falls through to a
-# lint that silently used some other ShellCheck, or to no lint at all.
+# lint. ENSURES the pinned, checksum-verified build is in <dir> and puts <dir>
+# first on PATH for this run: a <dir>/shellcheck that already reports the pin is
+# used as it stands, so a repeat run does not refetch and an offline host with
+# the right binary already on disk still lints; anything else is installed. A
+# failed install refuses; it never falls through to a lint that silently used
+# some other ShellCheck, or to no lint at all. Skipping the download never skips
+# the pin: the main flow still resolves and enforces the version on whatever
+# this leaves on PATH, so a wrong or tampered binary here still refuses.
 fm_lint_provision_shellcheck() {
-  local dir=$1 log resolved_dir
+  local dir=$1 log resolved_dir present=
+  resolved_dir=$(cd "$dir" 2>/dev/null && pwd) || resolved_dir=
+  if [ -n "$resolved_dir" ] && [ -x "$resolved_dir/shellcheck" ]; then
+    present=$("$resolved_dir/shellcheck" --version 2>/dev/null | awk '/^version:/ {print $2; exit}')
+  fi
+  if [ "$present" = "$REQUIRED_SHELLCHECK" ]; then
+    PATH="$resolved_dir:$PATH"
+    export PATH
+    printf 'fm-lint.sh: ShellCheck %s is already provisioned in %s; not fetching.\n' \
+      "$REQUIRED_SHELLCHECK" "$resolved_dir" >&2
+    return 0
+  fi
   log=$("$SELF_DIR/fm-install-shellcheck.sh" "$dir" 2>&1) || {
     printf '%s\n' "$log" >&2
     fm_lint_refuse "provisioning ShellCheck $REQUIRED_SHELLCHECK into $dir failed" shellcheck
@@ -325,10 +355,12 @@ if ! PERL_BIN=$(command -v perl); then
   fm_lint_refuse 'no perl was found on PATH, and it is required for bounded worker cleanup'
 fi
 resolved=$("$SHELLCHECK_BIN" --version | awk '/^version:/ {print $2; exit}')
-printf 'fm-lint.sh: ShellCheck %s (pinned %s)\n' "$resolved" "$REQUIRED_SHELLCHECK" >&2
+# Reported only once a version actually resolved: a banner with an empty version
+# reads like a successful resolution directly above the refusal that follows it.
 if [ -z "$resolved" ]; then
   fm_lint_refuse "the shellcheck at $SHELLCHECK_BIN did not report a version" shellcheck
 fi
+printf 'fm-lint.sh: ShellCheck %s (pinned %s)\n' "$resolved" "$REQUIRED_SHELLCHECK" >&2
 if [ "$resolved" != "$REQUIRED_SHELLCHECK" ]; then
   fm_lint_refuse "the shellcheck at $SHELLCHECK_BIN is version $resolved, not the pinned $REQUIRED_SHELLCHECK" \
     shellcheck
@@ -349,7 +381,8 @@ if [ -n "$TELEMETRY" ]; then
   }
 fi
 
-TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-lint.XXXXXX") || exit 1
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-lint.XXXXXX") \
+  || fm_lint_refuse "could not create a temporary working directory under ${TMPDIR:-/tmp}"
 ACTIVE_PIDS=()
 # shellcheck disable=SC2329 # Registered by the EXIT and signal traps below.
 fm_lint_cleanup() {
@@ -514,6 +547,7 @@ fi
 # Replay both stable shards in deterministic order and select the first nonzero
 # shard status. ShellCheck processes every root in a shard after earlier findings.
 overall_rc=0
+lost_shards=
 worker=0
 while [ "$worker" -lt "$SHARD_COUNT" ]; do
   output="$OUTPUT_DIR/shard.$worker"
@@ -521,15 +555,21 @@ while [ "$worker" -lt "$SHARD_COUNT" ]; do
   if [ -f "$output.rc" ]; then
     rc=$(cat "$output.rc" 2>/dev/null || printf '2')
     case "$rc" in ''|*[!0-9]*) rc=2 ;; esac
+    if [ "$overall_rc" -eq 0 ] && [ "$rc" -ne 0 ]; then
+      overall_rc=$rc
+    fi
   else
-    printf 'fm-lint.sh: worker produced no result for shard %s.\n' "$worker" >&2
-    rc=2
-  fi
-  if [ "$overall_rc" -eq 0 ] && [ "$rc" -ne 0 ]; then
-    overall_rc=$rc
+    lost_shards="${lost_shards:+$lost_shards, }$worker"
   fi
   worker=$((worker + 1))
 done
+
+# A shard whose result never arrived (a worker killed off, an out-of-memory host)
+# leaves its files unverified, so this run has no verdict to report even if the
+# surviving shard was clean. Refused after the replay above so whatever the other
+# shard did find is still printed for whoever has to act on it.
+[ -z "$lost_shards" ] || fm_lint_refuse \
+  "a bounded lint worker produced no result for shard $lost_shards of $SHARD_COUNT, so those files were not checked"
 
 if [ -n "$TELEMETRY" ]; then
   TELEMETRY_END_EPOCH=$(date +%s)

--- a/bin/fm-lint.sh
+++ b/bin/fm-lint.sh
@@ -141,11 +141,14 @@ fm_lint_refuse() {
 # The repository root every relative canonical root and worker manifest path is
 # resolved against. Refuses on the same contract when it cannot be resolved or
 # entered: the selected file set would be unreachable, so nothing could be
-# checked. Emptiness is tested explicitly because `cd ""` is a successful no-op in
-# bash, which would let an unresolved root run against the caller's own directory.
-if [ -z "$SELF_DIR" ] || [ -z "$ROOT" ] || ! CDPATH='' cd -- "$ROOT" 2>/dev/null; then
+# checked. Resolution is only believed when this script is actually where it came
+# out, because `cd ""` is a successful no-op in bash: an empty resolution - from a
+# dirname that failed, or one that is not on PATH at all - would otherwise pass
+# for the caller's own directory and lint a file set that is not this repository's.
+if [ -z "$SELF_DIR" ] || [ -z "$ROOT" ] || [ ! -f "$SELF" ] \
+  || ! CDPATH='' cd -- "$ROOT" 2>/dev/null; then
   fm_lint_refuse \
-    "could not resolve and enter the repository root holding this script (directory '$SELF_DIR', root '$ROOT')"
+    "could not resolve and enter the repository root holding this script (this script '$SELF', root '$ROOT')"
 fi
 
 # fm_lint_provision_shellcheck <dir>: opt-in only, never reached by a default

--- a/bin/fm-lint.sh
+++ b/bin/fm-lint.sh
@@ -19,11 +19,10 @@
 #   - Otherwise (an ordinary local branch with a real merge-base) it lints
 #     only the canonical-set files changed since that merge-base, including
 #     uncommitted local edits, via plain local `git diff` (no network, no
-#     `gh`). A branch with zero matching changed files skips ShellCheck and
-#     prints a "no changed lint targets" note, then still validates workflows -
-#     but only after re-asking git, through a call whose exit status is
-#     observable, to confirm there really was nothing to lint rather than
-#     assuming it.
+#     `gh`). That selection is verified against a second git read before it is
+#     acted on (see Selection below). A branch with zero matching changed files
+#     skips ShellCheck and prints a "no changed lint targets" note, then still
+#     validates workflows.
 # Explicit paths always bypass this file-set selection and lint exactly the
 # given paths, matching the same config, without the workflow YAML check.
 #
@@ -39,19 +38,37 @@
 #   0  the selected file set is clean, or there were no changed lint targets
 #   1  ShellCheck reported findings
 #   2  invalid usage
-#   3  the lint could not run to completion, so NOTHING it reports can be
-#      trusted (see the refusal below)
+#   3  the lint did not run to completion, so it carries no verdict at all
+#      (see the refusal below)
 #
-# This gate refuses instead of passing when it cannot run. A missing ShellCheck,
-# a ShellCheck that is not the pin, one that will not report its version, a
-# missing perl, a repository root it cannot enter, a temporary directory it
-# cannot create, shard manifests that do not account for every selected file, an
-# empty changed-file set git will not confirm, and a bounded worker whose result
-# never arrived all print an unmissable "LINT NOT RUN" line naming what is
-# missing - plus, when ShellCheck is the missing piece, the exact version
-# required and how to get it - then exit 3. EVERY path that could not check the
-# selected files lands there, so no status this script returns, zero or not, ever
-# reports a lint that in fact never ran.
+# Two integrity checks stand between this gate and a clean exit. Each answers one
+# question, and neither covers the other's:
+#   - Execution: was every file in the selected set actually handed to ShellCheck?
+#     Each worker records the number of roots it passed for its shard next to that
+#     shard's result, and the parent refuses unless those counts sum to the
+#     selected count. A shard that dropped roots, and a shard that recorded no
+#     count at all, both refuse rather than being read as zero. This is the one
+#     place that guarantee is asserted, end to end on what was really passed
+#     rather than on an intermediate proxy.
+#   - Selection, in changed-files mode only: is the selected set really the
+#     changed set? The NUL-safe read that builds it runs in a process
+#     substitution whose exit status is invisible, so a git or sort that failed
+#     or was truncated there looks exactly like a smaller diff. The selection is
+#     therefore compared against a second `git diff` whose status IS observable,
+#     and a failed read or a differing count refuses. Full-lint mode needs no
+#     such check - its set comes from a shell glob with no external command in
+#     the path - and explicit-path mode lints exactly the caller's own list.
+# A shard whose result never arrived refuses as well, because diagnostics that
+# cannot be replayed cannot be turned into a verdict; that is replay integrity,
+# not a second completeness guarantee.
+#
+# This gate refuses instead of passing when it cannot run. Both checks above, a
+# missing ShellCheck, a ShellCheck that is not the pin, one that will not report
+# its version, a missing perl, a repository root that cannot be resolved or
+# entered, and a temporary directory that cannot be created all print an
+# unmissable "LINT NOT RUN" line naming what is missing - plus, when ShellCheck
+# is the missing piece, the exact version required and how to get it - then exit
+# 3.
 # 3 is deliberately not 127: 127 is the shell's own "command not found", so a
 # caller that sees it cannot tell whether this script refused or was never found
 # at all, and a gate that reads lint output for actionable findings sees none in
@@ -97,9 +114,9 @@ REQUIRED_SHELLCHECK=0.11.0
 # and 127 (the shell's command-not-found), so no caller can confuse a refusal
 # with a clean lint, a lint failure, or this script being absent.
 REFUSED_EXIT=3
-SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SELF_DIR=$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" 2>/dev/null && pwd -P)
 SELF="$SELF_DIR/fm-lint.sh"
-ROOT="$(cd "$SELF_DIR/.." && pwd)"
+ROOT=$(CDPATH='' cd -- "$SELF_DIR/.." 2>/dev/null && pwd -P)
 
 # fm_lint_refuse <reason> [shellcheck]: the single exit for "this gate could not
 # run". Says so unmissably rather than letting a caller read silence as a clean
@@ -122,9 +139,14 @@ fm_lint_refuse() {
 }
 
 # The repository root every relative canonical root and worker manifest path is
-# resolved against. Refuses on the same contract when it cannot be entered: the
-# selected file set would be unreachable, so nothing could be checked.
-cd "$ROOT" || fm_lint_refuse "could not enter the repository root $ROOT"
+# resolved against. Refuses on the same contract when it cannot be resolved or
+# entered: the selected file set would be unreachable, so nothing could be
+# checked. Emptiness is tested explicitly because `cd ""` is a successful no-op in
+# bash, which would let an unresolved root run against the caller's own directory.
+if [ -z "$SELF_DIR" ] || [ -z "$ROOT" ] || ! CDPATH='' cd -- "$ROOT" 2>/dev/null; then
+  fm_lint_refuse \
+    "could not resolve and enter the repository root holding this script (directory '$SELF_DIR', root '$ROOT')"
+fi
 
 # fm_lint_provision_shellcheck <dir>: opt-in only, never reached by a default
 # lint. ENSURES the pin is in <dir> and puts <dir> first on PATH for this run: a
@@ -195,6 +217,7 @@ fm_lint_worker() {  # <manifest> <output-dir> <shard-index>
   else
     : > "$output.out"
   fi
+  printf '%s\n' "${#roots[@]}" > "$output.checked"
   printf '%s\n' "$rc" > "$output.rc"
   return "$rc"
 }
@@ -382,30 +405,35 @@ if [ "$resolved" != "$REQUIRED_SHELLCHECK" ]; then
     shellcheck
 fi
 
-if [ "$CHANGED_MODE" -eq 1 ] && [ "$ROOT_COUNT" -eq 0 ]; then
-  # "Nothing changed" is the one clean exit that checks no file at all, and the
-  # read above cannot report its own failure: a process substitution's status is
-  # invisible, so a git or a sort that died in that pipeline is indistinguishable
-  # from an empty diff. Prove the empty set instead of assuming it, by re-asking
-  # git through a plain substitution whose status IS observable, and refuse unless
-  # that answer agrees. Only this branch pays for it; a run with roots skips it.
-  changed_recheck=$(git diff --name-only --diff-filter=ACMR "$merge_base" -- 2>&1) || {
+if [ "$CHANGED_MODE" -eq 1 ]; then
+  # Selection integrity: the read above cannot report its own failure, because a
+  # process substitution's exit status is invisible, so a git or a sort that died
+  # or was truncated there is indistinguishable from a smaller diff - whether that
+  # leaves no roots or merely fewer. Ask git again through a plain substitution
+  # whose status IS observable, count the same canonical existing paths, and act
+  # only on a selection that answer agrees with.
+  changed_recheck=$(git -c core.quotePath=false diff --name-only --diff-filter=ACMR "$merge_base" -- 2>&1) || {
     printf '%s\n' "$changed_recheck" >&2
-    fm_lint_refuse "git could not report what changed since $merge_base, so an empty lint target set is unproven"
+    fm_lint_refuse "git could not report what changed since $merge_base, so the lint target set is unproven"
   }
+  recheck_count=0
+  changed_path=
   while IFS= read -r changed_path; do
     [ -n "$changed_path" ] || continue
     fm_lint_is_canonical_root "$changed_path" || continue
     [ -f "$changed_path" ] || continue
-    fm_lint_refuse \
-      "$changed_path is a changed lint target, but reading the changed files produced none, so nothing was checked"
+    recheck_count=$((recheck_count + 1))
   done <<CHANGED_RECHECK
 $changed_recheck
 CHANGED_RECHECK
-  printf 'fm-lint.sh: no changed lint targets\n'
-  overall_rc=0
-  fm_lint_run_workflows || overall_rc=$?
-  exit "$overall_rc"
+  [ "$recheck_count" -eq "$ROOT_COUNT" ] || fm_lint_refuse \
+    "git reports $recheck_count changed lint targets but reading them selected $ROOT_COUNT, so the selection is wrong"
+  if [ "$ROOT_COUNT" -eq 0 ]; then
+    printf 'fm-lint.sh: no changed lint targets\n'
+    overall_rc=0
+    fm_lint_run_workflows || overall_rc=$?
+    exit "$overall_rc"
+  fi
 fi
 
 if [ -n "$TELEMETRY" ]; then
@@ -491,24 +519,6 @@ while [ "$worker" -lt "$SHARD_COUNT" ]; do
   mv "$TMP_ROOT/manifest.$worker.sorted" "$TMP_ROOT/manifest.$worker"
   worker=$((worker + 1))
 done
-
-# The manifests are the only thing a worker reads, so one that does not account
-# for every selected root means files went unchecked while every shard still
-# reported clean. Counting them against the selection here is the single boundary
-# that covers a sort that is missing, failed, or truncated and a failed mv alike,
-# before any worker starts. A legitimately empty selection still matches at zero.
-manifest_total=0
-manifest_entry=
-worker=0
-while [ "$worker" -lt "$SHARD_COUNT" ]; do
-  while IFS= read -r manifest_entry || [ -n "$manifest_entry" ]; do
-    [ -n "$manifest_entry" ] || continue
-    manifest_total=$((manifest_total + 1))
-  done < "$TMP_ROOT/manifest.$worker"
-  worker=$((worker + 1))
-done
-[ "$manifest_total" -eq "$ROOT_COUNT" ] || fm_lint_refuse \
-  "the shard manifests account for $manifest_total of the $ROOT_COUNT selected files, so they were not all checked"
 
 fm_lint_shellcheck_count() {
   if command -v pgrep >/dev/null 2>&1; then
@@ -601,6 +611,8 @@ fi
 # shard status. ShellCheck processes every root in a shard after earlier findings.
 overall_rc=0
 lost_shards=
+uncounted_shards=
+checked_total=0
 worker=0
 while [ "$worker" -lt "$SHARD_COUNT" ]; do
   output="$OUTPUT_DIR/shard.$worker"
@@ -614,15 +626,31 @@ while [ "$worker" -lt "$SHARD_COUNT" ]; do
   else
     lost_shards="${lost_shards:+$lost_shards, }$worker"
   fi
+  shard_checked=
+  [ ! -f "$output.checked" ] || shard_checked=$(cat "$output.checked" 2>/dev/null)
+  case "$shard_checked" in
+    ''|*[!0-9]*) uncounted_shards="${uncounted_shards:+$uncounted_shards, }$worker" ;;
+    *) checked_total=$((checked_total + shard_checked)) ;;
+  esac
   worker=$((worker + 1))
 done
 
 # A shard whose result never arrived (a worker killed off, an out-of-memory host)
-# leaves its files unverified, so this run has no verdict to report even if the
-# surviving shard was clean. Refused after the replay above so whatever the other
-# shard did find is still printed for whoever has to act on it.
+# leaves its diagnostics unreplayable, so this run has no verdict to report even if
+# the surviving shard was clean. Refused after the replay above so whatever the
+# other shard did find is still printed for whoever has to act on it.
 [ -z "$lost_shards" ] || fm_lint_refuse \
   "a bounded lint worker produced no result for shard $lost_shards of $SHARD_COUNT, so those files were not checked"
+
+# Execution integrity, asserted once for the whole run on what the workers really
+# handed over: a shard that says nothing about what it checked cannot be counted as
+# zero, and the roots ShellCheck actually received must be the selected set. Every
+# selected path is weighted and assigned unconditionally, including one that does
+# not exist, so a healthy run always balances here.
+[ -z "$uncounted_shards" ] || fm_lint_refuse \
+  "shard $uncounted_shards of $SHARD_COUNT recorded no count of what it checked, so this run cannot account for it"
+[ "$checked_total" -eq "$ROOT_COUNT" ] || fm_lint_refuse \
+  "ShellCheck was handed $checked_total of the $ROOT_COUNT selected files, so they were not all checked"
 
 if [ -n "$TELEMETRY" ]; then
   TELEMETRY_END_EPOCH=$(date +%s)

--- a/bin/fm-lint.sh
+++ b/bin/fm-lint.sh
@@ -32,21 +32,91 @@
 # Optional quiet telemetry writes one bounded TSV snapshot of content and source
 # graph identity, wall/CPU/RSS, shard load, and competing ShellCheck processes.
 #
+# Exit status:
+#   0  the selected file set is clean, or there were no changed lint targets
+#   1  ShellCheck reported findings
+#   2  invalid usage
+#   3  the lint could not run and NOTHING was checked (see the refusal below)
+#
+# This gate refuses instead of passing when it cannot run. A missing ShellCheck,
+# a ShellCheck that is not the pin, one that will not report its version, and a
+# missing perl all print an unmissable "LINT NOT RUN" line naming the tool, the
+# exact version required, and how to get it, then exit 3.
+# 3 is deliberately not 127: 127 is the shell's own "command not found", so a
+# caller that sees it cannot tell whether this script refused or was never found
+# at all, and a gate that reads lint output for actionable findings sees none in
+# a refusal and can record a clean step that in fact checked nothing.
+#
+# Provisioning is opt-in and never a side effect of linting, because a gate that
+# reaches the network to validate is harder to trust and breaks on an offline
+# host. A caller that deliberately wants it passes --provision-shellcheck <dir>
+# (or sets FM_LINT_PROVISION_SHELLCHECK=<dir>); this script then installs the
+# pinned, checksum-verified build there through bin/fm-install-shellcheck.sh and
+# puts it first on PATH for that run only. A provisioning attempt that fails
+# refuses exactly like a missing tool; it never degrades into a pass. CI
+# provisions in its own step (.github/workflows/ci.yml) and never needs this.
+#
+# --required-version and --list-files answer with no ShellCheck present at all,
+# because bin/fm-install-shellcheck.sh asks this script which version to fetch:
+# breaking that would break the installer that repairs a missing tool.
+#
 # Usage:
 #   fm-lint.sh                         lint the context-selected file set (see above)
 #   fm-lint.sh <path>...               lint explicit roots with the same config
 #   fm-lint.sh --jobs <1|2> [path]...  override bounded worker count
 #   fm-lint.sh --telemetry <path> ...  write a quiet metrics snapshot
+#   fm-lint.sh --provision-shellcheck <dir>
+#                                      opt in to installing the pin into <dir>
 #   fm-lint.sh --required-version      print the ShellCheck pin
 #   fm-lint.sh --list-files            print the file set that would be linted
 #   fm-lint.sh --help                  print this usage
 set -u
 
 REQUIRED_SHELLCHECK=0.11.0
+# The "checked nothing" status. Distinct from 0 (clean), 1 (findings), 2 (usage),
+# and 127 (the shell's command-not-found), so no caller can confuse a refusal
+# with a clean lint, a lint failure, or this script being absent.
+REFUSED_EXIT=3
 SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SELF="$SELF_DIR/fm-lint.sh"
 ROOT="$(cd "$SELF_DIR/.." && pwd)"
 cd "$ROOT" || exit 1
+
+# fm_lint_refuse <reason> [shellcheck]: the single exit for "this gate could not
+# run". Says so unmissably rather than letting a caller read silence as a clean
+# lint, and with the second argument also names the pinned tool, its exact
+# version, and both ways to get it. See the exit-status note in the header.
+fm_lint_refuse() {
+  printf 'fm-lint.sh: LINT NOT RUN: %s\n' "$1" >&2
+  printf 'fm-lint.sh: nothing was checked, so this is a failed lint gate, not a clean one.\n' >&2
+  if [ "${2:-}" = shellcheck ]; then
+    printf 'fm-lint.sh: required tool: ShellCheck, exactly version %s (pinned so local and CI cannot diverge).\n' \
+      "$REQUIRED_SHELLCHECK" >&2
+    printf 'fm-lint.sh: install it: bin/fm-install-shellcheck.sh <dir>, then put <dir> first on PATH.\n' >&2
+    printf 'fm-lint.sh: or provision it for this run only: bin/fm-lint.sh --provision-shellcheck <dir>\n' >&2
+  fi
+  exit "$REFUSED_EXIT"
+}
+
+# fm_lint_provision_shellcheck <dir>: opt-in only, never reached by a default
+# lint. Installs the pinned, checksum-verified build into <dir> and puts it first
+# on PATH for this run. A failed install refuses; it never falls through to a
+# lint that silently used some other ShellCheck, or to no lint at all.
+fm_lint_provision_shellcheck() {
+  local dir=$1 log resolved_dir
+  log=$("$SELF_DIR/fm-install-shellcheck.sh" "$dir" 2>&1) || {
+    printf '%s\n' "$log" >&2
+    fm_lint_refuse "provisioning ShellCheck $REQUIRED_SHELLCHECK into $dir failed" shellcheck
+  }
+  resolved_dir=$(cd "$dir" 2>/dev/null && pwd) \
+    || fm_lint_refuse "provisioning reported success but $dir is not a readable directory" shellcheck
+  [ -x "$resolved_dir/shellcheck" ] \
+    || fm_lint_refuse "provisioning reported success but $resolved_dir/shellcheck is not executable" shellcheck
+  PATH="$resolved_dir:$PATH"
+  export PATH
+  printf 'fm-lint.sh: provisioned ShellCheck %s into %s on request.\n' \
+    "$REQUIRED_SHELLCHECK" "$resolved_dir" >&2
+}
 
 FM_LINT_WORKER_SHELLCHECK_PID=
 # shellcheck disable=SC2329 # Registered by the private worker's signal traps.
@@ -99,8 +169,10 @@ if [ "${1:-}" = "--required-version" ]; then
   exit 0
 fi
 
+# Prints the header block from line 2 up to the first non-comment line, so the
+# usage text cannot drift out of a hardcoded line range when the header changes.
 fm_lint_usage() {
-  sed -n '2,42{s/^# \{0,1\}//;p;}' "$SELF"
+  sed -n '2,${/^#/!q; s/^# \{0,1\}//; p;}' "$SELF"
 }
 
 # Default no-args lint also validates GitHub workflows. Explicit paths stay a
@@ -112,6 +184,7 @@ fm_lint_run_workflows() {
 
 JOBS=${FM_LINT_JOBS:-2}
 TELEMETRY=${FM_LINT_TELEMETRY:-}
+PROVISION_DIR=${FM_LINT_PROVISION_SHELLCHECK:-}
 LIST_FILES=0
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -131,6 +204,18 @@ while [ "$#" -gt 0 ]; do
       ;;
     --telemetry=*)
       TELEMETRY=${1#*=}
+      shift
+      ;;
+    --provision-shellcheck)
+      [ "$#" -ge 2 ] || {
+        printf 'fm-lint.sh: --provision-shellcheck requires a directory.\n' >&2
+        exit 2
+      }
+      PROVISION_DIR=$2
+      shift 2
+      ;;
+    --provision-shellcheck=*)
+      PROVISION_DIR=${1#*=}
       shift
       ;;
     --list-files)
@@ -229,23 +314,24 @@ if [ "$LIST_FILES" -eq 1 ]; then
   exit 0
 fi
 
+[ -z "$PROVISION_DIR" ] || fm_lint_provision_shellcheck "$PROVISION_DIR"
+
 if ! command -v shellcheck >/dev/null 2>&1; then
-  printf 'fm-lint.sh: ShellCheck not found; install ShellCheck %s for CI parity.\n' \
-    "$REQUIRED_SHELLCHECK" >&2
-  exit 127
+  fm_lint_refuse 'no shellcheck was found on PATH' shellcheck
 fi
 unset SHELLCHECK_OPTS
 SHELLCHECK_BIN=$(command -v shellcheck)
 if ! PERL_BIN=$(command -v perl); then
-  printf 'fm-lint.sh: perl is required for bounded worker cleanup.\n' >&2
-  exit 127
+  fm_lint_refuse 'no perl was found on PATH, and it is required for bounded worker cleanup'
 fi
 resolved=$("$SHELLCHECK_BIN" --version | awk '/^version:/ {print $2; exit}')
 printf 'fm-lint.sh: ShellCheck %s (pinned %s)\n' "$resolved" "$REQUIRED_SHELLCHECK" >&2
+if [ -z "$resolved" ]; then
+  fm_lint_refuse "the shellcheck at $SHELLCHECK_BIN did not report a version" shellcheck
+fi
 if [ "$resolved" != "$REQUIRED_SHELLCHECK" ]; then
-  printf 'fm-lint.sh: ShellCheck %s required for CI parity, found %s. Install %s.\n' \
-    "$REQUIRED_SHELLCHECK" "$resolved" "$REQUIRED_SHELLCHECK" >&2
-  exit 1
+  fm_lint_refuse "the shellcheck at $SHELLCHECK_BIN is version $resolved, not the pinned $REQUIRED_SHELLCHECK" \
+    shellcheck
 fi
 
 if [ "$CHANGED_MODE" -eq 1 ] && [ "$ROOT_COUNT" -eq 0 ]; then

--- a/bin/fm-lint.sh
+++ b/bin/fm-lint.sh
@@ -20,7 +20,10 @@
 #     only the canonical-set files changed since that merge-base, including
 #     uncommitted local edits, via plain local `git diff` (no network, no
 #     `gh`). A branch with zero matching changed files skips ShellCheck and
-#     prints a "no changed lint targets" note, then still validates workflows.
+#     prints a "no changed lint targets" note, then still validates workflows -
+#     but only after re-asking git, through a call whose exit status is
+#     observable, to confirm there really was nothing to lint rather than
+#     assuming it.
 # Explicit paths always bypass this file-set selection and lint exactly the
 # given paths, matching the same config, without the workflow YAML check.
 #
@@ -42,11 +45,13 @@
 # This gate refuses instead of passing when it cannot run. A missing ShellCheck,
 # a ShellCheck that is not the pin, one that will not report its version, a
 # missing perl, a repository root it cannot enter, a temporary directory it
-# cannot create, and a bounded worker whose result never arrived all print an
-# unmissable "LINT NOT RUN" line naming what is missing - plus, when ShellCheck
-# is the missing piece, the exact version required and how to get it - then exit
-# 3. EVERY path that could not check the selected files lands there, so a
-# nonzero status is never a lint failure that in fact never ran.
+# cannot create, shard manifests that do not account for every selected file, an
+# empty changed-file set git will not confirm, and a bounded worker whose result
+# never arrived all print an unmissable "LINT NOT RUN" line naming what is
+# missing - plus, when ShellCheck is the missing piece, the exact version
+# required and how to get it - then exit 3. EVERY path that could not check the
+# selected files lands there, so no status this script returns, zero or not, ever
+# reports a lint that in fact never ran.
 # 3 is deliberately not 127: 127 is the shell's own "command not found", so a
 # caller that sees it cannot tell whether this script refused or was never found
 # at all, and a gate that reads lint output for actionable findings sees none in
@@ -57,13 +62,18 @@
 # host. A caller that deliberately wants it passes --provision-shellcheck <dir>
 # (or sets FM_LINT_PROVISION_SHELLCHECK=<dir>) to ENSURE the pin is present in
 # <dir>: an existing <dir>/shellcheck that already reports the pinned version is
-# only put first on PATH, and the pinned, checksum-verified build is installed
-# through bin/fm-install-shellcheck.sh only when <dir> does not already hold it,
-# so a repeat run neither refetches nor breaks offline. Either way the version
-# enforcement below still runs on whatever ends up on PATH, so skipping the
-# download can never skip the pin. A provisioning attempt that fails refuses
-# exactly like a missing tool; it never degrades into a pass. CI provisions in
-# its own step (.github/workflows/ci.yml) and never needs this.
+# only put first on PATH, and bin/fm-install-shellcheck.sh installs the build
+# only when <dir> does not already hold the pin, so a repeat run neither
+# refetches nor breaks offline. A fresh install is checksum-verified; a binary
+# already sitting in that caller-owned directory is taken at the version it
+# reports of itself, so what holds for it is the pin, not the checksum. Either
+# way the version enforcement below runs on whatever ends up on PATH, so a build
+# that reports anything other than the pin is refused rather than used. A
+# provisioning attempt that fails refuses exactly like a missing tool; it never
+# degrades into a pass. That installer fetches the Linux x86_64 release, so on
+# any other platform install the pinned build from the upstream ShellCheck
+# release instead and put it first on PATH. CI provisions in its own step
+# (.github/workflows/ci.yml) and never needs this.
 #
 # --required-version and --list-files answer with no ShellCheck present at all,
 # because bin/fm-install-shellcheck.sh asks this script which version to fetch:
@@ -101,8 +111,12 @@ fm_lint_refuse() {
   if [ "${2:-}" = shellcheck ]; then
     printf 'fm-lint.sh: required tool: ShellCheck, exactly version %s (pinned so local and CI cannot diverge).\n' \
       "$REQUIRED_SHELLCHECK" >&2
-    printf 'fm-lint.sh: install it: bin/fm-install-shellcheck.sh <dir>, then put <dir> first on PATH.\n' >&2
-    printf 'fm-lint.sh: or provision it for this run only: bin/fm-lint.sh --provision-shellcheck <dir>\n' >&2
+    printf 'fm-lint.sh: on Linux x86_64: bin/fm-install-shellcheck.sh <dir>, then put <dir> first on PATH.\n' >&2
+    printf 'fm-lint.sh: or, same platform, for this run only: bin/fm-lint.sh --provision-shellcheck <dir>\n' >&2
+    printf 'fm-lint.sh: on macOS or any other platform that installer does not cover: install the %s build from\n' \
+      "$REQUIRED_SHELLCHECK" >&2
+    printf 'fm-lint.sh: https://github.com/koalaman/shellcheck/releases/tag/v%s and put its directory first on PATH.\n' \
+      "$REQUIRED_SHELLCHECK" >&2
   fi
   exit "$REFUSED_EXIT"
 }
@@ -113,17 +127,19 @@ fm_lint_refuse() {
 cd "$ROOT" || fm_lint_refuse "could not enter the repository root $ROOT"
 
 # fm_lint_provision_shellcheck <dir>: opt-in only, never reached by a default
-# lint. ENSURES the pinned, checksum-verified build is in <dir> and puts <dir>
-# first on PATH for this run: a <dir>/shellcheck that already reports the pin is
-# used as it stands, so a repeat run does not refetch and an offline host with
-# the right binary already on disk still lints; anything else is installed. A
+# lint. ENSURES the pin is in <dir> and puts <dir> first on PATH for this run: a
+# <dir>/shellcheck that already reports the pin is used as it stands, so a repeat
+# run does not refetch and an offline host with the right binary already on disk
+# still lints; anything else is installed, checksum-verified, by the installer. A
 # failed install refuses; it never falls through to a lint that silently used
 # some other ShellCheck, or to no lint at all. Skipping the download never skips
-# the pin: the main flow still resolves and enforces the version on whatever
-# this leaves on PATH, so a wrong or tampered binary here still refuses.
+# the pin: the main flow still resolves and enforces the version on whatever this
+# leaves on PATH, so a build here that reports any other version is refused. What
+# an already-present binary is trusted for is that reported version, though - it
+# is not re-verified against the pinned checksum the installer checks.
 fm_lint_provision_shellcheck() {
   local dir=$1 log resolved_dir present=
-  resolved_dir=$(cd "$dir" 2>/dev/null && pwd) || resolved_dir=
+  resolved_dir=$(CDPATH='' cd -- "$dir" 2>/dev/null && pwd -P) || resolved_dir=
   if [ -n "$resolved_dir" ] && [ -x "$resolved_dir/shellcheck" ]; then
     present=$("$resolved_dir/shellcheck" --version 2>/dev/null | awk '/^version:/ {print $2; exit}')
   fi
@@ -138,7 +154,7 @@ fm_lint_provision_shellcheck() {
     printf '%s\n' "$log" >&2
     fm_lint_refuse "provisioning ShellCheck $REQUIRED_SHELLCHECK into $dir failed" shellcheck
   }
-  resolved_dir=$(cd "$dir" 2>/dev/null && pwd) \
+  resolved_dir=$(CDPATH='' cd -- "$dir" 2>/dev/null && pwd -P) \
     || fm_lint_refuse "provisioning reported success but $dir is not a readable directory" shellcheck
   [ -x "$resolved_dir/shellcheck" ] \
     || fm_lint_refuse "provisioning reported success but $resolved_dir/shellcheck is not executable" shellcheck
@@ -367,6 +383,25 @@ if [ "$resolved" != "$REQUIRED_SHELLCHECK" ]; then
 fi
 
 if [ "$CHANGED_MODE" -eq 1 ] && [ "$ROOT_COUNT" -eq 0 ]; then
+  # "Nothing changed" is the one clean exit that checks no file at all, and the
+  # read above cannot report its own failure: a process substitution's status is
+  # invisible, so a git or a sort that died in that pipeline is indistinguishable
+  # from an empty diff. Prove the empty set instead of assuming it, by re-asking
+  # git through a plain substitution whose status IS observable, and refuse unless
+  # that answer agrees. Only this branch pays for it; a run with roots skips it.
+  changed_recheck=$(git diff --name-only --diff-filter=ACMR "$merge_base" -- 2>&1) || {
+    printf '%s\n' "$changed_recheck" >&2
+    fm_lint_refuse "git could not report what changed since $merge_base, so an empty lint target set is unproven"
+  }
+  while IFS= read -r changed_path; do
+    [ -n "$changed_path" ] || continue
+    fm_lint_is_canonical_root "$changed_path" || continue
+    [ -f "$changed_path" ] || continue
+    fm_lint_refuse \
+      "$changed_path is a changed lint target, but reading the changed files produced none, so nothing was checked"
+  done <<CHANGED_RECHECK
+$changed_recheck
+CHANGED_RECHECK
   printf 'fm-lint.sh: no changed lint targets\n'
   overall_rc=0
   fm_lint_run_workflows || overall_rc=$?
@@ -456,6 +491,24 @@ while [ "$worker" -lt "$SHARD_COUNT" ]; do
   mv "$TMP_ROOT/manifest.$worker.sorted" "$TMP_ROOT/manifest.$worker"
   worker=$((worker + 1))
 done
+
+# The manifests are the only thing a worker reads, so one that does not account
+# for every selected root means files went unchecked while every shard still
+# reported clean. Counting them against the selection here is the single boundary
+# that covers a sort that is missing, failed, or truncated and a failed mv alike,
+# before any worker starts. A legitimately empty selection still matches at zero.
+manifest_total=0
+manifest_entry=
+worker=0
+while [ "$worker" -lt "$SHARD_COUNT" ]; do
+  while IFS= read -r manifest_entry || [ -n "$manifest_entry" ]; do
+    [ -n "$manifest_entry" ] || continue
+    manifest_total=$((manifest_total + 1))
+  done < "$TMP_ROOT/manifest.$worker"
+  worker=$((worker + 1))
+done
+[ "$manifest_total" -eq "$ROOT_COUNT" ] || fm_lint_refuse \
+  "the shard manifests account for $manifest_total of the $ROOT_COUNT selected files, so they were not all checked"
 
 fm_lint_shellcheck_count() {
   if command -v pgrep >/dev/null 2>&1; then

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -245,7 +245,8 @@ SH
 }
 
 # fm_lint_isolated_bin <tmp> <command>...: build a directory of symlinks to the
-# named real commands and print it, for use as a COMPLETE replacement PATH.
+# named real commands and report it in FM_TEST_ISOLATED_BIN, for use as a
+# COMPLETE replacement PATH.
 #
 # The missing-tool tests need a PATH with provably no shellcheck on it. Trimming
 # the ambient PATH cannot promise that (a contributor may have shellcheck in
@@ -253,9 +254,16 @@ SH
 # worse than no test. An allowlisted PATH inverts that: shellcheck is absent
 # because nothing was linked, on every host. A command that cannot be resolved
 # fails the test rather than leaving the run to fail later for the wrong reason.
+#
+# It answers through a variable instead of stdout precisely so that promise
+# holds: called as `dir=$(fm_lint_isolated_bin ...)` its own `fail` would exit
+# only the command-substitution subshell, and the caller would keep going with an
+# empty PATH - turning a host-setup problem into a bogus refusal diagnosis, and
+# writing stubs to filesystem-root paths like /shellcheck along the way.
 fm_lint_isolated_bin() {
   local tmp=$1 dir resolved cmd
   shift
+  FM_TEST_ISOLATED_BIN=
   dir="$tmp/isolated-bin"
   mkdir -p "$dir" || fail "could not create an isolated bin directory"
   for cmd in "$@"; do
@@ -265,7 +273,7 @@ fm_lint_isolated_bin() {
   done
   PATH="$dir" command -v shellcheck >/dev/null 2>&1 \
     && fail "the isolated PATH resolved a shellcheck, so the missing-tool path would go untested"
-  printf '%s\n' "$dir"
+  FM_TEST_ISOLATED_BIN=$dir
 }
 
 # The commands fm-lint.sh itself needs before it can resolve ShellCheck at all.
@@ -305,7 +313,8 @@ test_missing_shellcheck_refuses_instead_of_passing() {
   local tmp isolated out rc
   tmp=$(fm_test_tmproot fm-lint-missing-tool)
   # shellcheck disable=SC2086 # Deliberate word splitting of the command list.
-  isolated=$(fm_lint_isolated_bin "$tmp" $FM_LINT_REFUSAL_PATH_COMMANDS)
+  fm_lint_isolated_bin "$tmp" $FM_LINT_REFUSAL_PATH_COMMANDS
+  isolated=$FM_TEST_ISOLATED_BIN
 
   rc=0
   # CI=true selects the full canonical set, so this reaches the tool check
@@ -323,7 +332,8 @@ test_wrong_version_and_unversioned_tool_share_the_refusal() {
   # The full run set: version resolution happens after the other tool checks, so
   # a thinner PATH would refuse for the wrong reason and prove nothing.
   # shellcheck disable=SC2086 # Deliberate word splitting of the command list.
-  isolated=$(fm_lint_isolated_bin "$tmp" $FM_LINT_RUN_PATH_COMMANDS)
+  fm_lint_isolated_bin "$tmp" $FM_LINT_RUN_PATH_COMMANDS
+  isolated=$FM_TEST_ISOLATED_BIN
 
   cat > "$isolated/shellcheck" <<'SH'
 #!/usr/bin/env bash
@@ -357,7 +367,8 @@ test_pin_and_inventory_answer_without_any_shellcheck() {
   local tmp isolated version listed rc
   tmp=$(fm_test_tmproot fm-lint-no-tool-queries)
   # shellcheck disable=SC2086 # Deliberate word splitting of the command list.
-  isolated=$(fm_lint_isolated_bin "$tmp" $FM_LINT_REFUSAL_PATH_COMMANDS)
+  fm_lint_isolated_bin "$tmp" $FM_LINT_REFUSAL_PATH_COMMANDS
+  isolated=$FM_TEST_ISOLATED_BIN
 
   rc=0
   version=$(PATH="$isolated" "$LINT" --required-version 2>&1) || rc=$?
@@ -381,7 +392,8 @@ test_installer_learns_the_pin_with_no_shellcheck_present() {
   local tmp isolated destination out rc installed
   tmp=$(fm_test_tmproot fm-shellcheck-install-no-tool)
   # shellcheck disable=SC2086 # Deliberate word splitting of the command list.
-  isolated=$(fm_lint_isolated_bin "$tmp" $FM_LINT_RUN_PATH_COMMANDS install)
+  fm_lint_isolated_bin "$tmp" $FM_LINT_RUN_PATH_COMMANDS install
+  isolated=$FM_TEST_ISOLATED_BIN
   destination="$tmp/provisioned"
   fm_lint_stub_download "$isolated"
 
@@ -403,7 +415,8 @@ test_ci_provisioned_shape_never_refuses() {
   local tmp isolated log out rc
   tmp=$(fm_test_tmproot fm-lint-ci-shape)
   # shellcheck disable=SC2086 # Deliberate word splitting of the command list.
-  isolated=$(fm_lint_isolated_bin "$tmp" $FM_LINT_RUN_PATH_COMMANDS)
+  fm_lint_isolated_bin "$tmp" $FM_LINT_RUN_PATH_COMMANDS
+  isolated=$FM_TEST_ISOLATED_BIN
   log="$tmp/shellcheck.log"
   fm_lint_stub_shellcheck "$isolated" "$log"
 
@@ -422,7 +435,8 @@ test_provisioning_is_opt_in_and_never_degrades_to_a_pass() {
   local tmp isolated target out rc
   tmp=$(fm_test_tmproot fm-lint-provision)
   # shellcheck disable=SC2086 # Deliberate word splitting of the command list.
-  isolated=$(fm_lint_isolated_bin "$tmp" $FM_LINT_RUN_PATH_COMMANDS install)
+  fm_lint_isolated_bin "$tmp" $FM_LINT_RUN_PATH_COMMANDS install
+  isolated=$FM_TEST_ISOLATED_BIN
   target="$tmp/good.sh"
   printf '#!/usr/bin/env bash\nset -eu\nprintf "ok\\n"\n' > "$target"
 
@@ -449,15 +463,105 @@ test_provisioning_is_opt_in_and_never_degrades_to_a_pass() {
   [ "$rc" -eq 0 ] || fail "FM_LINT_PROVISION_SHELLCHECK did not provision the pin"$'\n'"$out"
   [ -x "$tmp/provisioned-env/shellcheck" ] || fail "FM_LINT_PROVISION_SHELLCHECK installed no ShellCheck"
 
-  # A failed opt-in must refuse, never quietly lint with nothing or pass.
+  # From here the network is unreachable, exactly as on an offline host.
   printf '#!/usr/bin/env bash\nexit 22\n' > "$isolated/curl"
   printf '#!/usr/bin/env bash\nexit 0\n' > "$isolated/sleep"
   chmod +x "$isolated/curl" "$isolated/sleep"
+
+  # The opt-in ENSURES the pin rather than always fetching it: a directory that
+  # already holds the pinned build must lint without reaching the network, or the
+  # documented env-var form would refetch on every validation run and refuse
+  # offline while the correct binary sits on disk.
+  rc=0
+  out=$(PATH="$isolated" CI=true FM_LINT_JOBS=1 \
+    "$LINT" --provision-shellcheck "$tmp/provisioned" "$target" 2>&1) || rc=$?
+  [ "$rc" -eq 0 ] \
+    || fail "an already-provisioned pin refused with the network unreachable"$'\n'"$out"
+  assert_not_contains "$out" "LINT NOT RUN" "reusing an already-provisioned pin still refused"
+
+  # Skipping the download must never skip the pin: a binary in the opt-in
+  # directory that is not the pinned version refuses like any other version skew.
+  mkdir -p "$tmp/tampered"
+  cat > "$tmp/tampered/shellcheck" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = --version ]; then
+  printf 'ShellCheck - shell script analysis tool\nversion: 0.9.9\n'
+fi
+exit 0
+SH
+  chmod +x "$tmp/tampered/shellcheck"
+  rc=0
+  out=$(PATH="$isolated" CI=true \
+    "$LINT" --provision-shellcheck "$tmp/tampered" "$target" 2>&1) || rc=$?
+  fm_lint_assert_refusal "$out" "$rc" "an opt-in directory holding a ShellCheck that is not the pin"
+
+  # A failed opt-in must refuse, never quietly lint with nothing or pass.
   rc=0
   out=$(PATH="$isolated" CI=true \
     "$LINT" --provision-shellcheck "$tmp/failed" "$target" 2>&1) || rc=$?
   fm_lint_assert_refusal "$out" "$rc" "a failed opt-in provisioning"
-  pass "fm-lint.sh provisions only on request and refuses when that request fails"
+  pass "fm-lint.sh provisions only on request, reuses an existing pin, and refuses when that request fails"
+}
+
+test_unusable_temp_directory_refuses_on_the_could_not_run_status() {
+  # A host that cannot hand the gate a temp directory (a TMPDIR that does not
+  # exist, a full disk) checked nothing, so it must land on the declared
+  # could-not-run status rather than on 1, which the same contract defines as
+  # "ShellCheck reported findings". The status is the load-bearing signal: a
+  # consumer capturing neither stream still has to fail the gate on it.
+  local tmp isolated log target out rc
+  tmp=$(fm_test_tmproot fm-lint-no-tmpdir)
+  # shellcheck disable=SC2086 # Deliberate word splitting of the command list.
+  fm_lint_isolated_bin "$tmp" $FM_LINT_RUN_PATH_COMMANDS
+  isolated=$FM_TEST_ISOLATED_BIN
+  log="$tmp/shellcheck.log"
+  fm_lint_stub_shellcheck "$isolated" "$log"
+  target="$tmp/good.sh"
+  printf '#!/usr/bin/env bash\nset -eu\nprintf "ok\\n"\n' > "$target"
+
+  rc=0
+  out=$(PATH="$isolated" CI=true FM_LINT_JOBS=1 TMPDIR="$tmp/absent" \
+    "$LINT" "$target" 2>&1) || rc=$?
+  [ "$rc" -eq "$FM_LINT_REFUSED_EXIT" ] \
+    || fail "an unusable TMPDIR exited $rc, not the could-not-run status $FM_LINT_REFUSED_EXIT"$'\n'"$out"
+  assert_contains "$out" "LINT NOT RUN" "an unusable TMPDIR did not visibly mark the lint as not run"
+  [ ! -s "$log" ] \
+    || fail "a run that could not create its temp directory still claimed to check files"$'\n'"$(cat "$log")"
+  pass "fm-lint.sh refuses on the could-not-run status when it cannot create a temp directory"
+}
+
+test_lost_worker_result_refuses_on_the_could_not_run_status() {
+  # A bounded worker that dies before recording its result leaves its shard
+  # unverified. Reporting that as a findings status (1) or a usage status (2)
+  # would describe a run that never happened, so it refuses on the same
+  # could-not-run status as a missing tool.
+  local tmp isolated target out rc
+  tmp=$(fm_test_tmproot fm-lint-lost-worker)
+  # shellcheck disable=SC2086 # Deliberate word splitting of the command list.
+  fm_lint_isolated_bin "$tmp" $FM_LINT_RUN_PATH_COMMANDS
+  isolated=$FM_TEST_ISOLATED_BIN
+  # Reproduce the worker dying mid-shard (an out-of-memory kill, a hard host
+  # timeout): this stub kills the worker shell that is waiting on it, so no
+  # shard result is ever written.
+  cat > "$isolated/shellcheck" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = --version ]; then
+  printf 'ShellCheck - shell script analysis tool\nversion: 0.11.0\n'
+  exit 0
+fi
+kill -KILL "$PPID"
+exit 0
+SH
+  chmod +x "$isolated/shellcheck"
+  target="$tmp/good.sh"
+  printf '#!/usr/bin/env bash\nset -eu\nprintf "ok\\n"\n' > "$target"
+
+  rc=0
+  out=$(PATH="$isolated" CI=true FM_LINT_JOBS=1 "$LINT" "$target" 2>&1) || rc=$?
+  [ "$rc" -eq "$FM_LINT_REFUSED_EXIT" ] \
+    || fail "a lost worker result exited $rc, not the could-not-run status $FM_LINT_REFUSED_EXIT"$'\n'"$out"
+  assert_contains "$out" "LINT NOT RUN" "a lost worker result did not visibly mark the lint as not run"
+  pass "fm-lint.sh refuses on the could-not-run status when a worker result never arrives"
 }
 
 # fm_lint_stub_download <dir>: stub the network and archive tools
@@ -1113,6 +1217,8 @@ test_pin_and_inventory_answer_without_any_shellcheck
 test_installer_learns_the_pin_with_no_shellcheck_present
 test_ci_provisioned_shape_never_refuses
 test_provisioning_is_opt_in_and_never_degrades_to_a_pass
+test_unusable_temp_directory_refuses_on_the_could_not_run_status
+test_lost_worker_result_refuses_on_the_could_not_run_status
 test_catches_a_real_lint_defect
 test_ignores_ambient_shellcheck_opts
 test_clean_fixture_passes

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -244,6 +244,270 @@ SH
   chmod +x "$fakebin/shellcheck"
 }
 
+# fm_lint_isolated_bin <tmp> <command>...: build a directory of symlinks to the
+# named real commands and print it, for use as a COMPLETE replacement PATH.
+#
+# The missing-tool tests need a PATH with provably no shellcheck on it. Trimming
+# the ambient PATH cannot promise that (a contributor may have shellcheck in
+# /usr/bin), and a test that silently stops exercising the missing-tool path is
+# worse than no test. An allowlisted PATH inverts that: shellcheck is absent
+# because nothing was linked, on every host. A command that cannot be resolved
+# fails the test rather than leaving the run to fail later for the wrong reason.
+fm_lint_isolated_bin() {
+  local tmp=$1 dir resolved cmd
+  shift
+  dir="$tmp/isolated-bin"
+  mkdir -p "$dir" || fail "could not create an isolated bin directory"
+  for cmd in "$@"; do
+    resolved=$(command -v "$cmd") \
+      || fail "fm_lint_isolated_bin needs $cmd on the ambient PATH to build an isolated PATH"
+    ln -sf "$resolved" "$dir/$cmd" || fail "could not link $cmd into the isolated PATH"
+  done
+  PATH="$dir" command -v shellcheck >/dev/null 2>&1 \
+    && fail "the isolated PATH resolved a shellcheck, so the missing-tool path would go untested"
+  printf '%s\n' "$dir"
+}
+
+# The commands fm-lint.sh itself needs before it can resolve ShellCheck at all.
+# Its shebang resolves bash through PATH, so env and bash must be present.
+FM_LINT_REFUSAL_PATH_COMMANDS="env bash dirname"
+# Additionally needed to complete a real lint run once ShellCheck is available.
+FM_LINT_RUN_PATH_COMMANDS="env bash dirname mktemp wc tr sort cat mkdir rm mv perl awk"
+
+# The status fm-lint.sh exits when it could not run and checked nothing. Pinned
+# here on purpose: the whole point is that it is neither 0 (clean), nor 1
+# (findings), nor 2 (usage), nor 127 (the shell's own command-not-found, which a
+# caller cannot tell apart from fm-lint.sh being absent).
+FM_LINT_REFUSED_EXIT=3
+
+# fm_lint_assert_refusal <output> <rc> <what>: assert the shared "could not run"
+# contract - an unmissable marker, a non-passing and non-ambiguous status, and a
+# remedy naming the tool, the exact version, and how to get it.
+fm_lint_assert_refusal() {
+  local out=$1 rc=$2 what=$3
+  [ "$rc" -ne 0 ] || fail "$what reported success while checking nothing"$'\n'"$out"
+  [ "$rc" -ne 127 ] \
+    || fail "$what exited 127, which a caller cannot tell apart from fm-lint.sh being missing"$'\n'"$out"
+  [ "$rc" -eq "$FM_LINT_REFUSED_EXIT" ] \
+    || fail "$what exited $rc, not the dedicated could-not-run status $FM_LINT_REFUSED_EXIT"$'\n'"$out"
+  assert_contains "$out" "LINT NOT RUN" "$what did not visibly mark the lint as not run"
+  assert_contains "$out" "ShellCheck" "$what did not name the required tool"
+  assert_contains "$out" "$REQUIRED" "$what did not name the exact required version"
+  assert_contains "$out" "bin/fm-install-shellcheck.sh" "$what did not name how to install the pin"
+  assert_contains "$out" "--provision-shellcheck" "$what did not name the opt-in provisioning path"
+}
+
+test_missing_shellcheck_refuses_instead_of_passing() {
+  # The regression this test exists for: with no ShellCheck resolvable, the lint
+  # gate reported a clean step while having checked nothing, so a real finding
+  # (an SC2016 caught only by running the canonical set by hand) shipped through
+  # local validation. A gate that cannot run must say so, not pass.
+  local tmp isolated out rc
+  tmp=$(fm_test_tmproot fm-lint-missing-tool)
+  # shellcheck disable=SC2086 # Deliberate word splitting of the command list.
+  isolated=$(fm_lint_isolated_bin "$tmp" $FM_LINT_REFUSAL_PATH_COMMANDS)
+
+  rc=0
+  # CI=true selects the full canonical set, so this reaches the tool check
+  # without needing git on the isolated PATH.
+  out=$(PATH="$isolated" CI=true "$LINT" 2>&1) || rc=$?
+  fm_lint_assert_refusal "$out" "$rc" "a lint with no ShellCheck on PATH"
+  pass "fm-lint.sh refuses out loud when no ShellCheck is present instead of passing"
+}
+
+test_wrong_version_and_unversioned_tool_share_the_refusal() {
+  # Both skews are the same class as a missing tool: the pinned rule set was not
+  # applied, so nothing trustworthy was checked.
+  local tmp isolated out rc
+  tmp=$(fm_test_tmproot fm-lint-skew)
+  # The full run set: version resolution happens after the other tool checks, so
+  # a thinner PATH would refuse for the wrong reason and prove nothing.
+  # shellcheck disable=SC2086 # Deliberate word splitting of the command list.
+  isolated=$(fm_lint_isolated_bin "$tmp" $FM_LINT_RUN_PATH_COMMANDS)
+
+  cat > "$isolated/shellcheck" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = "--version" ]; then
+  printf 'ShellCheck - shell script analysis tool\nversion: 0.9.9\n'
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "$isolated/shellcheck"
+  rc=0
+  out=$(PATH="$isolated" CI=true "$LINT" 2>&1) || rc=$?
+  fm_lint_assert_refusal "$out" "$rc" "a lint under a non-pinned ShellCheck"
+  assert_contains "$out" "0.9.9" "the refusal did not report the version actually resolved"
+
+  # A tool that answers nothing must not be read as a matching version.
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$isolated/shellcheck"
+  chmod +x "$isolated/shellcheck"
+  rc=0
+  out=$(PATH="$isolated" CI=true "$LINT" 2>&1) || rc=$?
+  fm_lint_assert_refusal "$out" "$rc" "a lint under a ShellCheck that reports no version"
+  pass "fm-lint.sh refuses a version-skewed or unversioned ShellCheck on the same contract"
+}
+
+test_pin_and_inventory_answer_without_any_shellcheck() {
+  # bin/fm-install-shellcheck.sh asks fm-lint.sh which version to fetch, so
+  # --required-version must keep working when ShellCheck is exactly what is
+  # missing, or the refusal above would break the installer that repairs it.
+  # .github/workflows/ci.yml's stock-macOS-Bash job likewise calls --list-files
+  # on a runner where ShellCheck is never installed.
+  local tmp isolated version listed rc
+  tmp=$(fm_test_tmproot fm-lint-no-tool-queries)
+  # shellcheck disable=SC2086 # Deliberate word splitting of the command list.
+  isolated=$(fm_lint_isolated_bin "$tmp" $FM_LINT_REFUSAL_PATH_COMMANDS)
+
+  rc=0
+  version=$(PATH="$isolated" "$LINT" --required-version 2>&1) || rc=$?
+  [ "$rc" -eq 0 ] \
+    || fail "--required-version failed with no ShellCheck present, breaking the installer"$'\n'"$version"
+  [ "$version" = "$REQUIRED" ] \
+    || fail "--required-version printed '$version', not the pin '$REQUIRED', with no ShellCheck present"
+
+  rc=0
+  listed=$(PATH="$isolated" CI=true "$LINT" --list-files 2>&1) || rc=$?
+  [ "$rc" -eq 0 ] || fail "--list-files failed with no ShellCheck present"$'\n'"$listed"
+  printf '%s\n' "$listed" | grep -Fqx 'bin/fm-lint.sh' \
+    || fail "--list-files did not report the inventory with no ShellCheck present"$'\n'"$listed"
+  pass "fm-lint.sh answers --required-version and --list-files with no ShellCheck present"
+}
+
+test_installer_learns_the_pin_with_no_shellcheck_present() {
+  # End-to-end proof of the same dependency: the installer must be able to run in
+  # exactly the state it exists to repair. Network and archive handling are
+  # stubbed; the pin lookup is the real one.
+  local tmp isolated destination out rc installed
+  tmp=$(fm_test_tmproot fm-shellcheck-install-no-tool)
+  # shellcheck disable=SC2086 # Deliberate word splitting of the command list.
+  isolated=$(fm_lint_isolated_bin "$tmp" $FM_LINT_RUN_PATH_COMMANDS install)
+  destination="$tmp/provisioned"
+  fm_lint_stub_download "$isolated"
+
+  rc=0
+  out=$(PATH="$isolated" "$INSTALLER" "$destination" 2>&1) || rc=$?
+  [ "$rc" -eq 0 ] \
+    || fail "the ShellCheck installer could not run with no ShellCheck present"$'\n'"$out"
+  [ -x "$destination/shellcheck" ] || fail "the installer produced no executable"$'\n'"$out"
+  installed=$(PATH="$isolated" "$destination/shellcheck" --version | awk '/^version:/ {print $2; exit}')
+  [ "$installed" = "$REQUIRED" ] \
+    || fail "the installer fetched version '$installed' instead of the pin '$REQUIRED'"
+  pass "the ShellCheck installer still learns the pin when ShellCheck is what is missing"
+}
+
+test_ci_provisioned_shape_never_refuses() {
+  # CI installs the pin in its own step and then runs the lint owner, so the
+  # refusal must be unreachable there. Proven by reproducing that shape rather
+  # than assuming it.
+  local tmp isolated log out rc
+  tmp=$(fm_test_tmproot fm-lint-ci-shape)
+  # shellcheck disable=SC2086 # Deliberate word splitting of the command list.
+  isolated=$(fm_lint_isolated_bin "$tmp" $FM_LINT_RUN_PATH_COMMANDS)
+  log="$tmp/shellcheck.log"
+  fm_lint_stub_shellcheck "$isolated" "$log"
+
+  rc=0
+  out=$(PATH="$isolated" CI=true FM_LINT_JOBS=1 "$LINT" 2>&1) || rc=$?
+  [ "$rc" -eq 0 ] || fail "the CI shape (pin provisioned, then lint) did not pass"$'\n'"$out"
+  assert_not_contains "$out" "LINT NOT RUN" "the CI shape reached the refusal path"
+  [ -s "$log" ] || fail "the CI shape passed without asking ShellCheck to check anything"
+  pass "fm-lint.sh never refuses in CI's provision-then-lint shape"
+}
+
+test_provisioning_is_opt_in_and_never_degrades_to_a_pass() {
+  # Default behavior is refuse, not fetch: a gate that reaches the network as a
+  # side effect of validating is harder to trust and breaks offline. Opting in
+  # provisions the pin; an opt-in that FAILS still refuses rather than passing.
+  local tmp isolated target out rc
+  tmp=$(fm_test_tmproot fm-lint-provision)
+  # shellcheck disable=SC2086 # Deliberate word splitting of the command list.
+  isolated=$(fm_lint_isolated_bin "$tmp" $FM_LINT_RUN_PATH_COMMANDS install)
+  target="$tmp/good.sh"
+  printf '#!/usr/bin/env bash\nset -eu\nprintf "ok\\n"\n' > "$target"
+
+  # Without opting in, the same environment must refuse and fetch nothing.
+  fm_lint_stub_download "$isolated"
+  rc=0
+  out=$(PATH="$isolated" CI=true "$LINT" "$target" 2>&1) || rc=$?
+  fm_lint_assert_refusal "$out" "$rc" "a default lint with ShellCheck absent but installable"
+  [ ! -e "$tmp/provisioned" ] \
+    || fail "a default lint provisioned ShellCheck without being asked to"$'\n'"$out"
+
+  # Opting in provisions the pin and completes the lint.
+  rc=0
+  out=$(PATH="$isolated" CI=true FM_LINT_JOBS=1 \
+    "$LINT" --provision-shellcheck "$tmp/provisioned" "$target" 2>&1) || rc=$?
+  [ "$rc" -eq 0 ] || fail "opt-in provisioning did not produce a working lint"$'\n'"$out"
+  assert_not_contains "$out" "LINT NOT RUN" "opt-in provisioning still refused"
+  [ -x "$tmp/provisioned/shellcheck" ] || fail "opt-in provisioning installed no ShellCheck"$'\n'"$out"
+
+  # The environment variable is the same opt-in.
+  rc=0
+  out=$(PATH="$isolated" CI=true FM_LINT_JOBS=1 \
+    FM_LINT_PROVISION_SHELLCHECK="$tmp/provisioned-env" "$LINT" "$target" 2>&1) || rc=$?
+  [ "$rc" -eq 0 ] || fail "FM_LINT_PROVISION_SHELLCHECK did not provision the pin"$'\n'"$out"
+  [ -x "$tmp/provisioned-env/shellcheck" ] || fail "FM_LINT_PROVISION_SHELLCHECK installed no ShellCheck"
+
+  # A failed opt-in must refuse, never quietly lint with nothing or pass.
+  printf '#!/usr/bin/env bash\nexit 22\n' > "$isolated/curl"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$isolated/sleep"
+  chmod +x "$isolated/curl" "$isolated/sleep"
+  rc=0
+  out=$(PATH="$isolated" CI=true \
+    "$LINT" --provision-shellcheck "$tmp/failed" "$target" 2>&1) || rc=$?
+  fm_lint_assert_refusal "$out" "$rc" "a failed opt-in provisioning"
+  pass "fm-lint.sh provisions only on request and refuses when that request fails"
+}
+
+# fm_lint_stub_download <dir>: stub the network and archive tools
+# bin/fm-install-shellcheck.sh uses, so provisioning can be exercised without
+# reaching the network. The checksum the installer verifies is the real pinned
+# one, and the extracted binary answers --version with the pinned version, so a
+# provisioning path that installed the wrong thing would still be caught.
+#
+# The installer selects its archive and pinned digest from uname, so the platform
+# is fixed here rather than read from the environment: the digest below must be
+# the one the installer expects for the archive it chooses, on every host. Unlike
+# the shared tar stub, the extracted binary stays silent unless asked for its
+# version, because these tests then use it to lint real files.
+fm_lint_stub_download() {
+  local dir=$1
+  fm_install_stub_curl "$dir"
+  fm_install_stub_sleep "$dir"
+  cat > "$dir/uname" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+  -m) printf 'x86_64\n' ;;
+  *) printf 'Linux\n' ;;
+esac
+SH
+  cat > "$dir/sha256sum" <<SH
+#!/usr/bin/env bash
+printf '%s  %s\n' "$SHELLCHECK_SHA_LINUX_X86_64" "\$1"
+SH
+  cat > "$dir/tar" <<'SH'
+#!/usr/bin/env bash
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-C" ]; then
+    mkdir -p "$2/shellcheck-v0.11.0"
+    cat > "$2/shellcheck-v0.11.0/shellcheck" <<'EOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = --version ]; then
+  printf 'ShellCheck - shell script analysis tool\nversion: 0.11.0\n'
+fi
+exit 0
+EOF
+    chmod +x "$2/shellcheck-v0.11.0/shellcheck"
+    exit 0
+  fi
+  shift
+done
+exit 2
+SH
+  chmod +x "$dir/uname" "$dir/sha256sum" "$dir/tar"
+}
+
 test_changed_mode_lints_only_the_changed_file() {
   local tmp fakebin log diff_file out target
   tmp=$(fm_test_tmproot fm-lint-changed)
@@ -532,29 +796,6 @@ test_installer_rejects_unsupported_platform() {
   [ "$rc" -ne 0 ] || fail "installer accepted an unsupported architecture"$'\n'"$out"
   assert_contains "$out" "unsupported platform" "installer did not reject linux/ppc64le"
   pass "ShellCheck installer rejects an unsupported OS or architecture"
-}
-
-test_rejects_wrong_shellcheck_version() {
-  # Version-independent: a fake shellcheck reporting a different version must be
-  # refused before any lint, proving local and CI cannot silently diverge.
-  local tmp fakebin out rc
-  tmp=$(fm_test_tmproot fm-lint-ver)
-  fakebin=$(fm_fakebin "$tmp")
-  cat > "$fakebin/shellcheck" <<'SH'
-#!/usr/bin/env bash
-if [ "$1" = "--version" ]; then
-  printf 'ShellCheck - shell script analysis tool\nversion: 0.9.9\nlicense: x\nwebsite: y\n'
-  exit 0
-fi
-exit 0
-SH
-  chmod +x "$fakebin/shellcheck"
-  rc=0
-  out=$(PATH="$fakebin:$PATH" "$LINT" 2>&1) || rc=$?
-  [ "$rc" -ne 0 ] || fail "fm-lint.sh accepted a shellcheck version other than the pin"$'\n'"$out"
-  assert_contains "$out" "$REQUIRED" "fm-lint.sh did not name the required version on mismatch"
-  assert_contains "$out" "0.9.9" "fm-lint.sh did not report the resolved (wrong) version"
-  pass "fm-lint.sh refuses to lint under a non-pinned ShellCheck version"
 }
 
 test_catches_a_real_lint_defect() {
@@ -866,7 +1107,12 @@ test_installer_rejects_wrong_checksum
 test_installer_falls_back_to_shasum
 test_installer_prefers_sha256sum_over_shasum
 test_installer_rejects_unsupported_platform
-test_rejects_wrong_shellcheck_version
+test_missing_shellcheck_refuses_instead_of_passing
+test_wrong_version_and_unversioned_tool_share_the_refusal
+test_pin_and_inventory_answer_without_any_shellcheck
+test_installer_learns_the_pin_with_no_shellcheck_present
+test_ci_provisioned_shape_never_refuses
+test_provisioning_is_opt_in_and_never_degrades_to_a_pass
 test_catches_a_real_lint_defect
 test_ignores_ambient_shellcheck_opts
 test_clean_fixture_passes

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -174,6 +174,8 @@ test_list_files_reports_the_shell_inventory() {
 #   FM_TEST_GIT_MERGE_BASE_OK    1 (default) or 0
 #   FM_TEST_GIT_MERGE_BASE       merge-base value to print when OK
 #   FM_TEST_GIT_DIFF_FILE        path to a file of NUL-separated changed paths
+#   FM_TEST_GIT_DIFF_RECHECK_OK  1 (default) or 0, for the non-NUL diff form
+#                                fm-lint.sh re-asks when it selected no roots
 fm_lint_stub_git() {
   local fakebin=$1
   cat > "$fakebin/git" <<'SH'
@@ -204,6 +206,16 @@ case "$*" in
   "diff --name-only --diff-filter=ACMR -z "*)
     if [ -n "${FM_TEST_GIT_DIFF_FILE:-}" ] && [ -f "$FM_TEST_GIT_DIFF_FILE" ]; then
       cat "$FM_TEST_GIT_DIFF_FILE"
+    fi
+    exit 0
+    ;;
+  "diff --name-only --diff-filter=ACMR "*)
+    [ "${FM_TEST_GIT_DIFF_RECHECK_OK:-1}" = 1 ] || {
+      printf 'fatal: simulated git failure\n' >&2
+      exit 128
+    }
+    if [ -n "${FM_TEST_GIT_DIFF_FILE:-}" ] && [ -f "$FM_TEST_GIT_DIFF_FILE" ]; then
+      tr '\0' '\n' < "$FM_TEST_GIT_DIFF_FILE"
     fi
     exit 0
     ;;
@@ -432,7 +444,7 @@ test_provisioning_is_opt_in_and_never_degrades_to_a_pass() {
   # Default behavior is refuse, not fetch: a gate that reaches the network as a
   # side effect of validating is harder to trust and breaks offline. Opting in
   # provisions the pin; an opt-in that FAILS still refuses rather than passing.
-  local tmp isolated target out rc
+  local tmp isolated target out rc repaired
   tmp=$(fm_test_tmproot fm-lint-provision)
   # shellcheck disable=SC2086 # Deliberate word splitting of the command list.
   fm_lint_isolated_bin "$tmp" $FM_LINT_RUN_PATH_COMMANDS install
@@ -463,6 +475,22 @@ test_provisioning_is_opt_in_and_never_degrades_to_a_pass() {
   [ "$rc" -eq 0 ] || fail "FM_LINT_PROVISION_SHELLCHECK did not provision the pin"$'\n'"$out"
   [ -x "$tmp/provisioned-env/shellcheck" ] || fail "FM_LINT_PROVISION_SHELLCHECK installed no ShellCheck"
 
+  # "Ensure the pin" means a directory holding some OTHER build is repaired, not
+  # accepted and not refused: with the download working, a wrong-version binary
+  # already in the opt-in directory must be reinstalled and the lint must pass.
+  # This is the half of the skip decision that a guard keying only on "some build
+  # is already present here" would silently get wrong.
+  fm_lint_write_stale_shellcheck "$tmp/stale-repaired"
+  rc=0
+  out=$(PATH="$isolated" CI=true FM_LINT_JOBS=1 \
+    "$LINT" --provision-shellcheck "$tmp/stale-repaired" "$target" 2>&1) || rc=$?
+  [ "$rc" -eq 0 ] || fail "an opt-in directory holding an older build was not repaired"$'\n'"$out"
+  assert_not_contains "$out" "LINT NOT RUN" "repairing an older build in the opt-in directory refused instead"
+  repaired=$(PATH="$isolated" "$tmp/stale-repaired/shellcheck" --version \
+    | awk '/^version:/ {print $2; exit}')
+  [ "$repaired" = "$REQUIRED" ] \
+    || fail "the repaired opt-in directory reports '$repaired', not the pin '$REQUIRED'"
+
   # From here the network is unreachable, exactly as on an offline host.
   printf '#!/usr/bin/env bash\nexit 22\n' > "$isolated/curl"
   printf '#!/usr/bin/env bash\nexit 0\n' > "$isolated/sleep"
@@ -471,7 +499,8 @@ test_provisioning_is_opt_in_and_never_degrades_to_a_pass() {
   # The opt-in ENSURES the pin rather than always fetching it: a directory that
   # already holds the pinned build must lint without reaching the network, or the
   # documented env-var form would refetch on every validation run and refuse
-  # offline while the correct binary sits on disk.
+  # offline while the correct binary sits on disk. With the network down, a pass
+  # here can only mean the download was skipped.
   rc=0
   out=$(PATH="$isolated" CI=true FM_LINT_JOBS=1 \
     "$LINT" --provision-shellcheck "$tmp/provisioned" "$target" 2>&1) || rc=$?
@@ -479,28 +508,37 @@ test_provisioning_is_opt_in_and_never_degrades_to_a_pass() {
     || fail "an already-provisioned pin refused with the network unreachable"$'\n'"$out"
   assert_not_contains "$out" "LINT NOT RUN" "reusing an already-provisioned pin still refused"
 
-  # Skipping the download must never skip the pin: a binary in the opt-in
-  # directory that is not the pinned version refuses like any other version skew.
-  mkdir -p "$tmp/tampered"
-  cat > "$tmp/tampered/shellcheck" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" = --version ]; then
-  printf 'ShellCheck - shell script analysis tool\nversion: 0.9.9\n'
-fi
-exit 0
-SH
-  chmod +x "$tmp/tampered/shellcheck"
+  # A build that is not the pin is never simply used: when it cannot be repaired
+  # either, that is a refusal, not a pass on whatever was sitting there.
+  fm_lint_write_stale_shellcheck "$tmp/stale-offline"
   rc=0
   out=$(PATH="$isolated" CI=true \
-    "$LINT" --provision-shellcheck "$tmp/tampered" "$target" 2>&1) || rc=$?
-  fm_lint_assert_refusal "$out" "$rc" "an opt-in directory holding a ShellCheck that is not the pin"
+    "$LINT" --provision-shellcheck "$tmp/stale-offline" "$target" 2>&1) || rc=$?
+  fm_lint_assert_refusal "$out" "$rc" "an unrepairable older build in the opt-in directory"
 
   # A failed opt-in must refuse, never quietly lint with nothing or pass.
   rc=0
   out=$(PATH="$isolated" CI=true \
     "$LINT" --provision-shellcheck "$tmp/failed" "$target" 2>&1) || rc=$?
   fm_lint_assert_refusal "$out" "$rc" "a failed opt-in provisioning"
-  pass "fm-lint.sh provisions only on request, reuses an existing pin, and refuses when that request fails"
+  pass "fm-lint.sh provisions only on request, reuses a present pin, repairs another build, and refuses on failure"
+}
+
+# fm_lint_write_stale_shellcheck <dir>: put an executable in <dir> that answers
+# --version with a version other than the pin, for the ensure-semantics cases
+# above: the opt-in must repair it when it can and refuse when it cannot, and
+# must never put it on PATH as though it were the pin.
+fm_lint_write_stale_shellcheck() {
+  local dir=$1
+  mkdir -p "$dir"
+  cat > "$dir/shellcheck" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = --version ]; then
+  printf 'ShellCheck - shell script analysis tool\nversion: 0.9.9\n'
+fi
+exit 0
+SH
+  chmod +x "$dir/shellcheck"
 }
 
 test_unusable_temp_directory_refuses_on_the_could_not_run_status() {
@@ -562,6 +600,100 @@ SH
     || fail "a lost worker result exited $rc, not the could-not-run status $FM_LINT_REFUSED_EXIT"$'\n'"$out"
   assert_contains "$out" "LINT NOT RUN" "a lost worker result did not visibly mark the lint as not run"
   pass "fm-lint.sh refuses on the could-not-run status when a worker result never arrives"
+}
+
+# fm_lint_run_path_without <command>: the run-path command list with <command>
+# left out, so a test can drive "one required tool is missing" without
+# hardcoding - and later drifting from - the rest of the list.
+fm_lint_run_path_without() {
+  local drop=$1 cmd list=
+  # shellcheck disable=SC2086 # Deliberate word splitting of the command list.
+  for cmd in $FM_LINT_RUN_PATH_COMMANDS; do
+    [ "$cmd" = "$drop" ] || list="${list:+$list }$cmd"
+  done
+  printf '%s\n' "$list"
+}
+
+test_incomplete_shard_manifest_refuses_instead_of_passing_clean() {
+  # The regression: with `sort` missing, the shard manifests came out empty, each
+  # worker took its no-roots branch and recorded a clean result, and the gate
+  # exited 0 having asked ShellCheck to check nothing. A truncated or failed sort
+  # and a failed mv land in the same place: files silently unchecked, every shard
+  # reporting clean. A run that cannot hand its workers the files it selected must
+  # refuse on the could-not-run status, not report a clean lint.
+  local tmp isolated log target out rc
+  tmp=$(fm_test_tmproot fm-lint-manifest)
+  # shellcheck disable=SC2046 # Deliberate word splitting of the command list.
+  fm_lint_isolated_bin "$tmp" $(fm_lint_run_path_without sort)
+  isolated=$FM_TEST_ISOLATED_BIN
+  log="$tmp/shellcheck.log"
+  fm_lint_stub_shellcheck "$isolated" "$log"
+  target="$tmp/good.sh"
+  printf '#!/usr/bin/env bash\nset -eu\nprintf "ok\\n"\n' > "$target"
+
+  rc=0
+  out=$(PATH="$isolated" CI=true FM_LINT_JOBS=1 "$LINT" "$target" 2>&1) || rc=$?
+  [ "$rc" -eq "$FM_LINT_REFUSED_EXIT" ] \
+    || fail "an unbuildable shard manifest exited $rc, not the could-not-run status $FM_LINT_REFUSED_EXIT"$'\n'"$out"
+  assert_contains "$out" "LINT NOT RUN" "an unbuildable shard manifest did not mark the lint as not run"
+  [ ! -s "$log" ] \
+    || fail "the manifest refusal fired after ShellCheck had checked files"$'\n'"$(cat "$log")"
+  pass "fm-lint.sh refuses when its shard manifests do not account for every selected file"
+}
+
+test_changed_mode_proves_an_empty_target_set_before_passing() {
+  # "no changed lint targets" is the one clean exit that checks no file at all,
+  # and the changed-file read cannot report its own failure: it runs in a process
+  # substitution, so a git or a sort that died there is indistinguishable from an
+  # empty diff. That is this gate's own production mode - .no-mistakes.yaml pins
+  # `lint: bin/fm-lint.sh` with no arguments, which on a feature branch outside CI
+  # selects changed files - so the defect read as a clean step, twice.
+  local tmp isolated log diff_file empty_diff out rc
+  tmp=$(fm_test_tmproot fm-lint-changed-zero)
+  # shellcheck disable=SC2046 # Deliberate word splitting of the command list.
+  fm_lint_isolated_bin "$tmp" $(fm_lint_run_path_without sort)
+  isolated=$FM_TEST_ISOLATED_BIN
+  fm_lint_stub_git "$isolated"
+  log="$tmp/shellcheck.log"
+  fm_lint_stub_shellcheck "$isolated" "$log"
+  diff_file="$tmp/diff.nul"
+  empty_diff="$tmp/empty.nul"
+  : > "$empty_diff"
+  # A real canonical target plus a non-canonical file: with the read path broken,
+  # zero roots reach the lint even though bin/fm-lint.sh changed.
+  fm_lint_write_diff_file "$diff_file" "bin/fm-lint.sh" "README.md"
+
+  # Clear CI/GITHUB_ACTIONS so changed-file mode is live; a CI run forces a full
+  # lint and cannot reach this branch at all.
+  rc=0
+  out=$(PATH="$isolated" GITHUB_ACTIONS='' CI='' FM_LINT_JOBS=1 \
+    FM_TEST_GIT_BRANCH=feature FM_TEST_GIT_DIFF_FILE="$diff_file" "$LINT" 2>&1) || rc=$?
+  [ "$rc" -eq "$FM_LINT_REFUSED_EXIT" ] \
+    || fail "a changed-file read that dropped every target exited $rc, not $FM_LINT_REFUSED_EXIT"$'\n'"$out"
+  assert_contains "$out" "LINT NOT RUN" "a dropped changed-file read did not mark the lint as not run"
+  assert_not_contains "$out" "no changed lint targets" \
+    "a dropped changed-file read still reported an empty target set as clean"
+  [ ! -s "$log" ] || fail "the refusal fired after ShellCheck had checked files"$'\n'"$(cat "$log")"
+
+  # git failing while answering that question must refuse too, rather than being
+  # discarded into an unexplained empty set.
+  ln -sf "$(command -v sort)" "$isolated/sort" || fail "could not restore sort on the isolated PATH"
+  rc=0
+  out=$(PATH="$isolated" GITHUB_ACTIONS='' CI='' FM_LINT_JOBS=1 \
+    FM_TEST_GIT_BRANCH=feature FM_TEST_GIT_DIFF_FILE="$empty_diff" \
+    FM_TEST_GIT_DIFF_RECHECK_OK=0 "$LINT" 2>&1) || rc=$?
+  [ "$rc" -eq "$FM_LINT_REFUSED_EXIT" ] \
+    || fail "git failing to confirm an empty target set exited $rc, not $FM_LINT_REFUSED_EXIT"$'\n'"$out"
+  assert_contains "$out" "LINT NOT RUN" "an unconfirmable empty target set did not mark the lint as not run"
+
+  # ...and a branch that genuinely changed no lint target must still pass with its
+  # existing note, so proving the empty set never turns an empty diff into failure.
+  rc=0
+  out=$(PATH="$isolated" GITHUB_ACTIONS='' CI='' FM_LINT_JOBS=1 \
+    FM_TEST_GIT_BRANCH=feature FM_TEST_GIT_DIFF_FILE="$empty_diff" "$LINT" 2>&1) || rc=$?
+  [ "$rc" -eq 0 ] || fail "a genuinely empty changed set no longer exits 0, got $rc"$'\n'"$out"
+  assert_contains "$out" "no changed lint targets" "a genuinely empty changed set lost its note"
+  pass "fm-lint.sh proves an empty changed target set with git before reporting a clean lint"
 }
 
 # fm_lint_stub_download <dir>: stub the network and archive tools
@@ -1219,6 +1351,8 @@ test_ci_provisioned_shape_never_refuses
 test_provisioning_is_opt_in_and_never_degrades_to_a_pass
 test_unusable_temp_directory_refuses_on_the_could_not_run_status
 test_lost_worker_result_refuses_on_the_could_not_run_status
+test_incomplete_shard_manifest_refuses_instead_of_passing_clean
+test_changed_mode_proves_an_empty_target_set_before_passing
 test_catches_a_real_lint_defect
 test_ignores_ambient_shellcheck_opts
 test_clean_fixture_passes

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -175,7 +175,7 @@ test_list_files_reports_the_shell_inventory() {
 #   FM_TEST_GIT_MERGE_BASE       merge-base value to print when OK
 #   FM_TEST_GIT_DIFF_FILE        path to a file of NUL-separated changed paths
 #   FM_TEST_GIT_DIFF_RECHECK_OK  1 (default) or 0, for the non-NUL diff form
-#                                fm-lint.sh re-asks when it selected no roots
+#                                fm-lint.sh re-asks to verify its selection
 fm_lint_stub_git() {
   local fakebin=$1
   cat > "$fakebin/git" <<'SH'
@@ -203,13 +203,13 @@ case "$*" in
     fi
     exit 1
     ;;
-  "diff --name-only --diff-filter=ACMR -z "*)
+  *"diff --name-only --diff-filter=ACMR -z "*)
     if [ -n "${FM_TEST_GIT_DIFF_FILE:-}" ] && [ -f "$FM_TEST_GIT_DIFF_FILE" ]; then
       cat "$FM_TEST_GIT_DIFF_FILE"
     fi
     exit 0
     ;;
-  "diff --name-only --diff-filter=ACMR "*)
+  *"diff --name-only --diff-filter=ACMR "*)
     [ "${FM_TEST_GIT_DIFF_RECHECK_OK:-1}" = 1 ] || {
       printf 'fatal: simulated git failure\n' >&2
       exit 128
@@ -614,15 +614,15 @@ fm_lint_run_path_without() {
   printf '%s\n' "$list"
 }
 
-test_incomplete_shard_manifest_refuses_instead_of_passing_clean() {
-  # The regression: with `sort` missing, the shard manifests came out empty, each
-  # worker took its no-roots branch and recorded a clean result, and the gate
-  # exited 0 having asked ShellCheck to check nothing. A truncated or failed sort
-  # and a failed mv land in the same place: files silently unchecked, every shard
-  # reporting clean. A run that cannot hand its workers the files it selected must
-  # refuse on the could-not-run status, not report a clean lint.
-  local tmp isolated log target out rc
-  tmp=$(fm_test_tmproot fm-lint-manifest)
+test_roots_lost_before_shellcheck_refuse_instead_of_passing_clean() {
+  # Execution integrity, end to end: whatever selected the files, every one of them
+  # must reach ShellCheck or the run refuses. The regression: with `sort` missing
+  # the shard manifests came out empty, each worker took its no-roots branch and
+  # recorded a clean result, and the gate exited 0 having asked ShellCheck to check
+  # nothing. A truncated sort and a failed mv lose roots at the same place. Both
+  # worker modes are covered, because the serial and parallel paths count alike.
+  local tmp isolated log target out rc jobs
+  tmp=$(fm_test_tmproot fm-lint-lost-roots)
   # shellcheck disable=SC2046 # Deliberate word splitting of the command list.
   fm_lint_isolated_bin "$tmp" $(fm_lint_run_path_without sort)
   isolated=$FM_TEST_ISOLATED_BIN
@@ -631,24 +631,51 @@ test_incomplete_shard_manifest_refuses_instead_of_passing_clean() {
   target="$tmp/good.sh"
   printf '#!/usr/bin/env bash\nset -eu\nprintf "ok\\n"\n' > "$target"
 
-  rc=0
-  out=$(PATH="$isolated" CI=true FM_LINT_JOBS=1 "$LINT" "$target" 2>&1) || rc=$?
-  [ "$rc" -eq "$FM_LINT_REFUSED_EXIT" ] \
-    || fail "an unbuildable shard manifest exited $rc, not the could-not-run status $FM_LINT_REFUSED_EXIT"$'\n'"$out"
-  assert_contains "$out" "LINT NOT RUN" "an unbuildable shard manifest did not mark the lint as not run"
-  [ ! -s "$log" ] \
-    || fail "the manifest refusal fired after ShellCheck had checked files"$'\n'"$(cat "$log")"
-  pass "fm-lint.sh refuses when its shard manifests do not account for every selected file"
+  for jobs in 1 2; do
+    : > "$log"
+    rc=0
+    out=$(PATH="$isolated" CI=true FM_LINT_JOBS="$jobs" "$LINT" "$target" 2>&1) || rc=$?
+    [ "$rc" -eq "$FM_LINT_REFUSED_EXIT" ] \
+      || fail "jobs=$jobs lost every root and exited $rc, not $FM_LINT_REFUSED_EXIT"$'\n'"$out"
+    assert_contains "$out" "LINT NOT RUN" "jobs=$jobs did not mark a lint that lost its roots as not run"
+    [ ! -s "$log" ] \
+      || fail "jobs=$jobs refused only after ShellCheck had checked files"$'\n'"$(cat "$log")"
+  done
+  pass "fm-lint.sh refuses when selected files never reach ShellCheck, serially and in parallel"
 }
 
-test_changed_mode_proves_an_empty_target_set_before_passing() {
-  # "no changed lint targets" is the one clean exit that checks no file at all,
-  # and the changed-file read cannot report its own failure: it runs in a process
-  # substitution, so a git or a sort that died there is indistinguishable from an
-  # empty diff. That is this gate's own production mode - .no-mistakes.yaml pins
+# fm_lint_stub_truncating_sort <dir>: install a `sort` that mangles only the -z
+# form, emitting its first NUL record and dropping the rest - the shape a sort
+# killed mid-write by an OOM kill or ENOSPC leaves in the changed-file read
+# pipeline - and delegating every other invocation to the real sort. Built from
+# shell builtins alone so it works on an isolated PATH with no sort of its own.
+fm_lint_stub_truncating_sort() {
+  local dir=$1 real
+  real=$(command -v sort) || fail "fm_lint_stub_truncating_sort needs a real sort on the ambient PATH"
+  rm -f "$dir/sort"
+  cat > "$dir/sort" <<SH
+#!/usr/bin/env bash
+for arg in "\$@"; do
+  [ "\$arg" = -z ] || continue
+  IFS= read -r -d '' first || first=
+  while IFS= read -r -d '' rest; do :; done
+  [ -z "\$first" ] || printf '%s\\0' "\$first"
+  exit 0
+done
+exec "$real" "\$@"
+SH
+  chmod +x "$dir/sort"
+}
+
+test_changed_mode_verifies_its_selection_before_acting_on_it() {
+  # The changed-file read cannot report its own failure: it runs in a process
+  # substitution, so a git or a sort that died or was truncated there is
+  # indistinguishable from a smaller diff - whether that leaves no targets or
+  # merely fewer. That is this gate's own production mode - .no-mistakes.yaml pins
   # `lint: bin/fm-lint.sh` with no arguments, which on a feature branch outside CI
-  # selects changed files - so the defect read as a clean step, twice.
-  local tmp isolated log diff_file empty_diff out rc
+  # selects changed files - and CI can never exercise it, because CI forces a full
+  # lint. So every direction of that verification is covered here.
+  local tmp isolated log diff_file partial_diff empty_diff out rc
   tmp=$(fm_test_tmproot fm-lint-changed-zero)
   # shellcheck disable=SC2046 # Deliberate word splitting of the command list.
   fm_lint_isolated_bin "$tmp" $(fm_lint_run_path_without sort)
@@ -657,11 +684,15 @@ test_changed_mode_proves_an_empty_target_set_before_passing() {
   log="$tmp/shellcheck.log"
   fm_lint_stub_shellcheck "$isolated" "$log"
   diff_file="$tmp/diff.nul"
+  partial_diff="$tmp/partial.nul"
   empty_diff="$tmp/empty.nul"
   : > "$empty_diff"
   # A real canonical target plus a non-canonical file: with the read path broken,
   # zero roots reach the lint even though bin/fm-lint.sh changed.
   fm_lint_write_diff_file "$diff_file" "bin/fm-lint.sh" "README.md"
+  # Three real canonical targets, for the partial-drop case below.
+  fm_lint_write_diff_file "$partial_diff" \
+    "bin/fm-lint.sh" "bin/fm-install-shellcheck.sh" "tests/fm-lint.test.sh"
 
   # Clear CI/GITHUB_ACTIONS so changed-file mode is live; a CI run forces a full
   # lint and cannot reach this branch at all.
@@ -675,8 +706,23 @@ test_changed_mode_proves_an_empty_target_set_before_passing() {
     "a dropped changed-file read still reported an empty target set as clean"
   [ ! -s "$log" ] || fail "the refusal fired after ShellCheck had checked files"$'\n'"$(cat "$log")"
 
+  # A read that drops SOME of the changed targets is the same defect: linting a
+  # subset while reporting on the whole is exactly the silent pass this gate exists
+  # to prevent, and a count of what reached ShellCheck cannot see it - the subset is
+  # internally consistent. Only comparing the selection against git catches it.
+  fm_lint_stub_truncating_sort "$isolated"
+  rc=0
+  out=$(PATH="$isolated" GITHUB_ACTIONS='' CI='' FM_LINT_JOBS=1 \
+    FM_TEST_GIT_BRANCH=feature FM_TEST_GIT_DIFF_FILE="$partial_diff" "$LINT" 2>&1) || rc=$?
+  [ "$rc" -eq "$FM_LINT_REFUSED_EXIT" ] \
+    || fail "a changed-file read that dropped 2 of 3 targets exited $rc, not $FM_LINT_REFUSED_EXIT"$'\n'"$out"
+  assert_contains "$out" "LINT NOT RUN" "a partially dropped changed-file read did not mark the lint as not run"
+  [ ! -s "$log" ] \
+    || fail "a partially dropped selection was linted anyway"$'\n'"$(cat "$log")"
+
   # git failing while answering that question must refuse too, rather than being
   # discarded into an unexplained empty set.
+  rm -f "$isolated/sort"
   ln -sf "$(command -v sort)" "$isolated/sort" || fail "could not restore sort on the isolated PATH"
   rc=0
   out=$(PATH="$isolated" GITHUB_ACTIONS='' CI='' FM_LINT_JOBS=1 \
@@ -687,13 +733,38 @@ test_changed_mode_proves_an_empty_target_set_before_passing() {
   assert_contains "$out" "LINT NOT RUN" "an unconfirmable empty target set did not mark the lint as not run"
 
   # ...and a branch that genuinely changed no lint target must still pass with its
-  # existing note, so proving the empty set never turns an empty diff into failure.
+  # existing note, so verifying the selection never turns an empty diff into a
+  # failure. The healthy non-empty selection is covered by the changed-mode lint
+  # test below, which must keep passing for the same reason.
   rc=0
   out=$(PATH="$isolated" GITHUB_ACTIONS='' CI='' FM_LINT_JOBS=1 \
     FM_TEST_GIT_BRANCH=feature FM_TEST_GIT_DIFF_FILE="$empty_diff" "$LINT" 2>&1) || rc=$?
   [ "$rc" -eq 0 ] || fail "a genuinely empty changed set no longer exits 0, got $rc"$'\n'"$out"
   assert_contains "$out" "no changed lint targets" "a genuinely empty changed set lost its note"
-  pass "fm-lint.sh proves an empty changed target set with git before reporting a clean lint"
+  pass "fm-lint.sh verifies its changed-file selection against git before acting on it"
+}
+
+test_unresolvable_repository_root_refuses_on_the_could_not_run_status() {
+  # `cd ""` is a successful no-op in bash, so a root that failed to resolve would
+  # otherwise leave the run pointed at whatever directory the caller happened to be
+  # in, reporting on a file set that is not this repository's. With dirname
+  # answering a directory that does not exist, the script cannot locate itself and
+  # must refuse on the could-not-run status instead of proceeding.
+  local tmp isolated out rc
+  tmp=$(fm_test_tmproot fm-lint-no-root)
+  # shellcheck disable=SC2086 # Deliberate word splitting of the command list.
+  fm_lint_isolated_bin "$tmp" $FM_LINT_REFUSAL_PATH_COMMANDS
+  isolated=$FM_TEST_ISOLATED_BIN
+  rm -f "$isolated/dirname"
+  printf '#!/usr/bin/env bash\nprintf "%%s\\n" "%s/absent"\n' "$tmp" > "$isolated/dirname"
+  chmod +x "$isolated/dirname"
+
+  rc=0
+  out=$(PATH="$isolated" CI=true "$LINT" 2>&1) || rc=$?
+  [ "$rc" -eq "$FM_LINT_REFUSED_EXIT" ] \
+    || fail "an unresolvable repository root exited $rc, not $FM_LINT_REFUSED_EXIT"$'\n'"$out"
+  assert_contains "$out" "LINT NOT RUN" "an unresolvable repository root did not mark the lint as not run"
+  pass "fm-lint.sh refuses when it cannot resolve the repository root that holds it"
 }
 
 # fm_lint_stub_download <dir>: stub the network and archive tools
@@ -1351,8 +1422,9 @@ test_ci_provisioned_shape_never_refuses
 test_provisioning_is_opt_in_and_never_degrades_to_a_pass
 test_unusable_temp_directory_refuses_on_the_could_not_run_status
 test_lost_worker_result_refuses_on_the_could_not_run_status
-test_incomplete_shard_manifest_refuses_instead_of_passing_clean
-test_changed_mode_proves_an_empty_target_set_before_passing
+test_roots_lost_before_shellcheck_refuse_instead_of_passing_clean
+test_changed_mode_verifies_its_selection_before_acting_on_it
+test_unresolvable_repository_root_refuses_on_the_could_not_run_status
 test_catches_a_real_lint_defect
 test_ignores_ambient_shellcheck_opts
 test_clean_fixture_passes

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -18,9 +18,14 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 LINT="$ROOT/bin/fm-lint.sh"
+LINT_WORKFLOWS="$ROOT/bin/fm-lint-workflows.sh"
 INSTALLER="$ROOT/bin/fm-install-shellcheck.sh"
 # The pinned version, read from the single source (the one owner itself).
 REQUIRED=$("$LINT" --required-version)
+# A default (no-args) lint also hands the GitHub workflows to their own owner,
+# so the isolated-PATH runs below need that linter too. Read from that owner for
+# the same reason as above: the pin has exactly one source.
+REQUIRED_ACTIONLINT=$("$LINT_WORKFLOWS" --required-version)
 
 # Official GitHub release asset sha256 values for shellcheck v0.11.0 .tar.xz
 # archives (https://github.com/koalaman/shellcheck/releases/tag/v0.11.0). Tests
@@ -256,6 +261,26 @@ SH
   chmod +x "$fakebin/shellcheck"
 }
 
+# fm_lint_stub_actionlint <fakebin-dir>: install an actionlint stub that answers
+# -version with the pinned workflow-lint version and accepts any workflow set.
+# A default (no-args) lint also runs bin/fm-lint-workflows.sh, so a run on an
+# isolated PATH needs that linter present to reach a verdict at all; stubbing it
+# keeps these tests about fm-lint.sh's own contract rather than about actionlint
+# findings, exactly as the ShellCheck stub above does. CI installs the real
+# pinned build in its own step before invoking this owner.
+fm_lint_stub_actionlint() {
+  local fakebin=$1
+  cat > "$fakebin/actionlint" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = -version ]; then
+  printf '%s\n' "$REQUIRED_ACTIONLINT"
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "$fakebin/actionlint"
+}
+
 # fm_lint_isolated_bin <tmp> <command>...: build a directory of symlinks to the
 # named real commands and report it in FM_TEST_ISOLATED_BIN, for use as a
 # COMPLETE replacement PATH.
@@ -293,6 +318,9 @@ fm_lint_isolated_bin() {
 FM_LINT_REFUSAL_PATH_COMMANDS="env bash dirname"
 # Additionally needed to complete a real lint run once ShellCheck is available.
 FM_LINT_RUN_PATH_COMMANDS="env bash dirname mktemp wc tr sort cat mkdir rm mv perl awk"
+# Additionally needed by a default (no-args) lint, which also hands the GitHub
+# workflows to bin/fm-lint-workflows.sh: that owner collects them itself.
+FM_LINT_WORKFLOW_PATH_COMMANDS="find"
 
 # The status fm-lint.sh exits when it could not run and checked nothing. Pinned
 # here on purpose: the whole point is that it is neither 0 (clean), nor 1
@@ -421,16 +449,17 @@ test_installer_learns_the_pin_with_no_shellcheck_present() {
 }
 
 test_ci_provisioned_shape_never_refuses() {
-  # CI installs the pin in its own step and then runs the lint owner, so the
-  # refusal must be unreachable there. Proven by reproducing that shape rather
-  # than assuming it.
+  # CI installs both pinned linters in their own steps and then runs the lint
+  # owner, so the refusal must be unreachable there. Proven by reproducing that
+  # shape rather than assuming it.
   local tmp isolated log out rc
   tmp=$(fm_test_tmproot fm-lint-ci-shape)
-  # shellcheck disable=SC2086 # Deliberate word splitting of the command list.
-  fm_lint_isolated_bin "$tmp" $FM_LINT_RUN_PATH_COMMANDS
+  # shellcheck disable=SC2086 # Deliberate word splitting of the command lists.
+  fm_lint_isolated_bin "$tmp" $FM_LINT_RUN_PATH_COMMANDS $FM_LINT_WORKFLOW_PATH_COMMANDS
   isolated=$FM_TEST_ISOLATED_BIN
   log="$tmp/shellcheck.log"
   fm_lint_stub_shellcheck "$isolated" "$log"
+  fm_lint_stub_actionlint "$isolated"
 
   rc=0
   out=$(PATH="$isolated" CI=true FM_LINT_JOBS=1 "$LINT" 2>&1) || rc=$?
@@ -677,12 +706,15 @@ test_changed_mode_verifies_its_selection_before_acting_on_it() {
   # lint. So every direction of that verification is covered here.
   local tmp isolated log diff_file partial_diff empty_diff out rc
   tmp=$(fm_test_tmproot fm-lint-changed-zero)
-  # shellcheck disable=SC2046 # Deliberate word splitting of the command list.
-  fm_lint_isolated_bin "$tmp" $(fm_lint_run_path_without sort)
+  # shellcheck disable=SC2046,SC2086 # Deliberate word splitting of the command lists.
+  fm_lint_isolated_bin "$tmp" $(fm_lint_run_path_without sort) $FM_LINT_WORKFLOW_PATH_COMMANDS
   isolated=$FM_TEST_ISOLATED_BIN
   fm_lint_stub_git "$isolated"
   log="$tmp/shellcheck.log"
   fm_lint_stub_shellcheck "$isolated" "$log"
+  # The empty-selection case below completes a default lint, which also validates
+  # the workflows, so its linter has to be present for that to be a pass.
+  fm_lint_stub_actionlint "$isolated"
   diff_file="$tmp/diff.nul"
   partial_diff="$tmp/partial.nul"
   empty_diff="$tmp/empty.nul"

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -747,24 +747,49 @@ test_changed_mode_verifies_its_selection_before_acting_on_it() {
 test_unresolvable_repository_root_refuses_on_the_could_not_run_status() {
   # `cd ""` is a successful no-op in bash, so a root that failed to resolve would
   # otherwise leave the run pointed at whatever directory the caller happened to be
-  # in, reporting on a file set that is not this repository's. With dirname
-  # answering a directory that does not exist, the script cannot locate itself and
-  # must refuse on the could-not-run status instead of proceeding.
-  local tmp isolated out rc
+  # in, linting and reporting on a file set that is not this repository's. Both ways
+  # the resolution goes wrong are covered: a dirname that answers a directory which
+  # does not exist, and no dirname on PATH at all - whose empty answer resolves to
+  # the caller's own directory, so testing for emptiness alone cannot see it.
+  #
+  # A pinned ShellCheck stub is on the PATH deliberately: it carries the run past
+  # the tool checks, so accepting a wrong root would reach a real lint of the wrong
+  # tree rather than stopping on a missing tool. That, plus asserting the refusal
+  # names the repository root, is what makes this fail if the guard regresses - a
+  # refusal for any other reason no longer satisfies it.
+  local tmp isolated log out rc
   tmp=$(fm_test_tmproot fm-lint-no-root)
   # shellcheck disable=SC2086 # Deliberate word splitting of the command list.
-  fm_lint_isolated_bin "$tmp" $FM_LINT_REFUSAL_PATH_COMMANDS
+  fm_lint_isolated_bin "$tmp" $FM_LINT_RUN_PATH_COMMANDS
   isolated=$FM_TEST_ISOLATED_BIN
+  log="$tmp/shellcheck.log"
+  fm_lint_stub_shellcheck "$isolated" "$log"
   rm -f "$isolated/dirname"
   printf '#!/usr/bin/env bash\nprintf "%%s\\n" "%s/absent"\n' "$tmp" > "$isolated/dirname"
   chmod +x "$isolated/dirname"
 
   rc=0
-  out=$(PATH="$isolated" CI=true "$LINT" 2>&1) || rc=$?
+  out=$(PATH="$isolated" CI=true FM_LINT_JOBS=1 "$LINT" 2>&1) || rc=$?
   [ "$rc" -eq "$FM_LINT_REFUSED_EXIT" ] \
-    || fail "an unresolvable repository root exited $rc, not $FM_LINT_REFUSED_EXIT"$'\n'"$out"
-  assert_contains "$out" "LINT NOT RUN" "an unresolvable repository root did not mark the lint as not run"
-  pass "fm-lint.sh refuses when it cannot resolve the repository root that holds it"
+    || fail "a root that resolved nowhere exited $rc, not $FM_LINT_REFUSED_EXIT"$'\n'"$out"
+  assert_contains "$out" "LINT NOT RUN" "a root that resolved nowhere did not mark the lint as not run"
+  assert_contains "$out" "repository root" "the refusal named something other than the repository root"
+  [ ! -s "$log" ] \
+    || fail "the run linted files outside this repository"$'\n'"$(cat "$log")"
+
+  # No dirname at all: the resolution silently falls back to the caller's own
+  # directory, which is not the one holding this script, so the guard must refuse
+  # there too instead of running against a tree it only assumed was the repository.
+  rm -f "$isolated/dirname"
+  rc=0
+  out=$(PATH="$isolated" CI=true FM_LINT_JOBS=1 "$LINT" 2>&1) || rc=$?
+  [ "$rc" -eq "$FM_LINT_REFUSED_EXIT" ] \
+    || fail "a run with no dirname on PATH exited $rc, not $FM_LINT_REFUSED_EXIT"$'\n'"$out"
+  assert_contains "$out" "repository root" \
+    "with no dirname on PATH the refusal named something other than the repository root"
+  [ ! -s "$log" ] \
+    || fail "with no dirname on PATH the run linted files outside this repository"$'\n'"$(cat "$log")"
+  pass "fm-lint.sh refuses, naming the repository root, when it cannot resolve the root that holds it"
 }
 
 # fm_lint_stub_download <dir>: stub the network and archive tools

--- a/tests/fm-on.test.sh
+++ b/tests/fm-on.test.sh
@@ -11,7 +11,22 @@ TMP_ROOT=$(fm_test_tmproot fm-on)
 # and physicalize macOS's /var -> /private/var alias before transport validation.
 mkdir -p "$TMP_ROOT"
 TMP_ROOT=$(cd "$TMP_ROOT" && pwd -P)
-trap 'if [ -f "$TMP_ROOT/remote-jobs/worker.pid" ]; then kill "$(cat "$TMP_ROOT/remote-jobs/worker.pid")" 2>/dev/null || true; fi; rm -rf -- "$TMP_ROOT"' EXIT
+# shellcheck source=bin/fm-remote-job-lib.sh
+. "$ROOT/bin/fm-remote-job-lib.sh"
+# worker.pid records the serving child, not its restart supervisor, and kill
+# only signals: it returned with both processes still alive and still writing
+# into this fixture while rm -rf removed it, which surfaced as a real CI flake
+# after every assertion had already passed:
+#   rm: cannot remove '/tmp/fm-on.XXXXXX/remote-jobs': Directory not empty
+# So stop the whole worker tree and wait for it to be gone - the leak
+# tests/fm-remote-job-orphan-reap.test.sh pins - before removing the tree.
+cleanup() {
+  if [ -f "$TMP_ROOT/remote-jobs/worker.pid" ]; then
+    fm_remote_job_stop_worker_tree "$(cat "$TMP_ROOT/remote-jobs/worker.pid")" || true
+  fi
+  rm -rf -- "$TMP_ROOT"
+}
+trap cleanup EXIT
 LOCAL_HOME="$TMP_ROOT/local-home"
 REMOTE_ROOT="$TMP_ROOT/remote-root"
 REMOTE_HOME="$TMP_ROOT/remote-home"


### PR DESCRIPTION
## Intent

Goal: firstmate's shell-lint gate could report a clean step while having checked nothing, and the captain asked to make it refuse out loud when it cannot run.

Established diagnosis the captain had already verified and told me to confirm rather than redo: bin/fm-lint.sh is the single owner of the lint definition, and both CI and the no-mistakes pipeline invoke it with no arguments so the rule set and version cannot drift; .github/workflows/ci.yml is the only place that provisions ShellCheck, installing a pinned checksum-verified build via bin/fm-install-shellcheck.sh into $RUNNER_TEMP/bin and adding it to PATH; nothing else provisions it, so when the pipeline's lint step runs on a host without ShellCheck the invocation fails and the step does not fail on it. Observed twice during another task, where the worker ran the canonical set by hand and found a real SC2016 violation the pipeline could not see. So this is not a missing feature: the provisioning step exists and was only ever wired into CI.

Acceptance criteria the captain set: (1) a missing or wrong-version lint tool is reported as a concrete missing requirement, not an accepted step; (2) the failure names the tool and the exact version it needs, and how to get it; (3) if an environment genuinely cannot host ShellCheck, the step is either provisioned with the pinned version or explicitly and visibly marked as not run, and it is never marked passed; (4) a regression test that fails before the change for the missing-tool shape.

The captain's design preference, which they explicitly invited me to dispute in a needs-decision line if I disagreed: bin/fm-lint.sh should refuse loudly and print the exact provisioning command rather than silently downloading something mid-gate, because a validation step that reaches the network as a side effect is harder to trust and breaks on an offline host; an explicit opt-in provisioning path via a flag or env var a caller sets deliberately is fine and probably useful; default behaviour must be refuse, not fetch. I read the code and agreed with that position rather than escalating it, for the captain's stated reasons plus the fact that the refusal is self-documenting, so the human cost of refusing is one copy-paste.

Constraints the captain stated: do not change the lint rule set, the file set, the severity, or the pinned version, because this task is only about what happens when the tool is absent, and changing the rules would make every existing validated branch inconsistent. Watch the circular dependency: bin/fm-install-shellcheck.sh calls bin/fm-lint.sh --required-version to learn which version to fetch, so --required-version must keep working even when ShellCheck is absent, or the installer that fixes the problem breaks; test that exact path. CI must keep working unchanged, and because CI already provisions before calling the linter the refusal path must never trigger there - prove that rather than assuming it. Keep the diagnostic wording plain and actionable, so someone reading it in a pipeline log knows immediately what is missing and what to run. Every CI round on this project costs a maintainer approval we do not control, because we contribute from a fork with pull-only access, so bias towards making the failure impossible to miss rather than towards convenience.

Decisions and tradeoffs I made while doing the work, which a reviewer reading only the diff would not know:

- The script already refused: it exited 127 for a missing ShellCheck and 1 for a version skew, both added in commit 78f9cce, the same commit that pinned commands.lint. So the silent pass was not absent refusal logic but how the refusal was reported. I sharpened the diagnosis to something provable without depending on no-mistakes internals: 127 is the shell's own "command not found", so a caller receiving it cannot distinguish "fm-lint.sh ran and refused" from "fm-lint.sh does not exist or never ran", and because a refusal prints no parseable findings, a gate that hands lint output to an agent to fix sees nothing to fix and can record a clean step. That is why the new dedicated status is 3 and deliberately not 127, and why the message carries an unmissable "LINT NOT RUN" marker plus an explicit "nothing was checked, so this is a failed lint gate, not a clean one" line.
- I verified nothing depended on the old 127 before changing it: a grep across tests/, bin/, and CI found only unrelated uses.
- The refusal has one owner, fm_lint_refuse, covering four cases: missing ShellCheck, a ShellCheck that is not the pin, a ShellCheck that will not report its version (a case the old code did not handle, since an empty version simply fell into the mismatch branch), and missing perl. The perl case deliberately omits the ShellCheck remedy block, because ShellCheck is not what is missing there.
- Provisioning is opt-in through --provision-shellcheck <dir> or FM_LINT_PROVISION_SHELLCHECK, installs through the existing bin/fm-install-shellcheck.sh so the checksum pin stays in one place, and puts the directory first on PATH for that run only. A provisioning attempt that fails refuses on the same contract rather than degrading into a pass, and it also refuses when the installer claims success but the directory or binary is not actually usable.
- --required-version already short-circuits at the top of the script, before argument parsing and before any tool check, and --list-files exits before the tool check; I left both untouched. That preserves the installer circular dependency and also the macOS stock-Bash CI job, which calls bin/fm-lint.sh --list-files with a PATH that never has ShellCheck on it - a second consumer of that property the captain did not mention.
- I replaced the hardcoded usage line range sed -n '2,39{...}' with a self-terminating range that stops at the first non-comment line. The old form was already fragile and would have silently truncated --help once my header grew, so this is incidental to the stated task but a direct consequence of it.
- Tests: I extended the existing tests/fm-lint.test.sh rather than adding a new runner, per firstmate's coding guidelines, and the script was already registered in the pure-contract-unit lane, portable parallel shard 1, and the isolation proof, so no runner changes were needed. The missing-tool tests build an allowlisted PATH of symlinks to specific real commands rather than trimming the ambient PATH, because trimming cannot promise ShellCheck is absent on a contributor host that has it in /usr/bin, and a test that silently stops exercising the missing-tool path is worse than no test; the helper fails the test if the isolated PATH resolves a shellcheck. That isolated PATH must include env, bash, and dirname, because the shebang resolves bash through PATH and the script uses dirname to locate its own root.
- I removed the superseded test_rejects_wrong_shellcheck_version. It only asserted a non-zero exit plus two version strings, all of which the new, stronger version-skew test covers on an isolated PATH. A reviewer seeing a deleted test should know it was superseded, not lost.
- I refactored test_installer_retries_transient_download_failure onto a shared fm_lint_stub_download helper, keeping its own counting curl override, to avoid duplicating the curl, sha256sum, tar, and sleep stubs across the new provisioning tests.
- Before/after proof: with the pre-change script restored, the suite fails at "a lint with no ShellCheck on PATH exited 127, which a caller cannot tell apart from fm-lint.sh being missing", and the version-skew and provisioning tests also fail before. The three guard tests the captain asked for - the pin and inventory queries with no ShellCheck present, the installer running in the exact state it repairs, and CI's provision-then-lint shape never refusing - pass both before and after by design, because their job is to prove the change did not break those paths.
- The captain's brief said ShellCheck was not installed on this host and told me to install the pinned version into a directory inside my own worktree, explicitly not system-wide and not into their home. That turned out to be unnecessary: ShellCheck 0.11.0, exactly the pin, was already on my PATH through mise, so I installed nothing and made no network fetch. Their observation was presumably taken in a shell without mise shims.
- Worth flagging: my own change tripped the new gate on a genuine SC2016 (info) finding in the test code I had just written, which I fixed by writing that fixture without a literal parameter expansion. That is the same finding class the captain observed the pipeline was blind to.
- Durable knowledge about the new exit-status contract and the refuse-versus-provision rationale went into the bin/fm-lint.sh header and --help, per firstmate's knowledge-placement guidance that script mechanics belong in the script header. AGENTS.md was deliberately not touched, and bin/fm-ensure-agents-md.sh confirmed the convention is already satisfied.
- Verified clean before committing: bin/fm-lint.sh on the changed set and on the full explicit pair, all 21 tests in tests/fm-lint.test.sh, the three other suites that consume the linter (fm-arm-pretool-check, fm-cd-pretool-check, fm-test-run), bin/fm-doc-audience-check.sh, and bin/fm-test-run.sh --check-coverage. No agent co-author on the commit, per firstmate's guidelines.

## What Changed

- `bin/fm-lint.sh` now routes every "this gate could not run" condition through one `fm_lint_refuse` that prints an unmissable `LINT NOT RUN` line plus "nothing trustworthy was checked, so this is a failed lint gate, not a clean one" and exits a dedicated status `3` instead of the old `127`/`1`: no ShellCheck on PATH, a ShellCheck that reports no version, one that is not the pinned `0.11.0`, missing `perl`, a repository root that cannot be resolved or entered, and a temp directory that cannot be created. The ShellCheck cases also name the exact required version and the concrete ways to get it. `--required-version` and `--list-files` still answer with no ShellCheck present, so `bin/fm-install-shellcheck.sh` can still learn the pin.
- Added opt-in provisioning via `--provision-shellcheck <dir>` / `FM_LINT_PROVISION_SHELLCHECK`, which reuses `bin/fm-install-shellcheck.sh` (skipping the fetch when `<dir>` already holds the pin) and puts `<dir>` first on PATH for that run only; a failed install, or one that leaves no usable binary, refuses on the same contract rather than degrading into a pass. Default behaviour still never touches the network.
- Added two completeness checks on the same refusal path: each worker records how many roots it handed to ShellCheck and the parent refuses unless the per-shard counts sum to the selected count (a missing or uncounted shard refuses rather than counting as zero), and changed-files mode re-reads `git diff` through a substitution whose status is observable and refuses on a failed read or a differing count. `tests/fm-lint.test.sh` gained 11 tests covering each refusal shape on an allowlisted symlink PATH that asserts no ambient `shellcheck` leaks in, plus guards that the pin/inventory queries, the installer's lookup path, and CI's provision-then-lint shape never refuse; the superseded `test_rejects_wrong_shellcheck_version` was removed in favour of the stronger version-skew test.

## Risk Assessment

✅ Low: Well-bounded fail-closed hardening of one script plus its own test file: the pin, rule set, severity, and canonical file set are untouched, the installer's `--required-version` dependency and CI's tool-free `--list-files` job both still short-circuit ahead of every tool check, the new refusals are covered by behavior-level tests including one that fails before the change, and the only path that now runs on every local lint (the changed-file selection recheck) verifies clean on this branch by hand — leaving three informational contract/dedup nits.

## Testing

I exercised the refusal contract as an end user would see it in a pipeline log, not just through assertions. tests/fm-lint.test.sh is 26/26 green with the pinned ShellCheck 0.11.0 on PATH; the same suite run against the base bin/fm-lint.sh aborts at exactly the missing-tool shape, and a per-test matrix confirms the eight refusal tests fail before and pass after while the three guard tests pass on both by design. The product-level evidence is CLI transcripts on an allowlisted PATH with ShellCheck provably absent: the base printed one line and exited 127, the target prints an unmissable LINT NOT RUN block naming the tool, the exact pin, and two install routes, and exits a dedicated 3. On one host I showed 0 clean, 1 findings on a fixture carrying a real SC2016 (the class the pipeline could not see), and 3 not run, so no caller can read a refusal as a clean gate. I reproduced CI's provision-then-lint sequence for real, including the download and checksum verify, and it never reached the refusal; --required-version still answers with ShellCheck absent, so the installer that repairs the problem is intact. Opt-in provisioning was exercised in all four states: default fetches nothing, opt-in installs and lints, a present pin is reused with the network severed, and a fresh dir with no network exhausts its retries and still refuses. I also confirmed --help renders the whole 105-line header where the base's hardcoded range would truncate it mid-sentence. The two other suites that consume the linter and the test-inventory partition guard pass; the single failure I saw (fm-arm-pretool-check A13) is an artifact of this worktree living under a /home → /local/home symlink and is unrelated to the diff. No visual evidence applies: this change is a CLI shell gate with no rendered surface, so terminal transcripts are the actual end-user surface. Worktree left clean.

<details>
<summary>Evidence: Evidence index mapping each acceptance criterion to its artifact</summary>

```text
# Local Test evidence — `fm/lint-step-no-shellcheck-l7`

Base `bdae21ed` → target `59eec18c`. Host: Linux x86_64, ShellCheck 0.11.0 (the pin)
available via mise at `~/.local/share/mise/installs/shellcheck/0.11.0/shellcheck-v0.11.0`.

Every "no shellcheck" transcript below runs against an allowlisted PATH built from
symlinks to specific real commands, so ShellCheck is provably absent rather than
merely trimmed off the ambient PATH.

| Acceptance criterion | Artifact |
| --- | --- |
| (1) a missing/wrong-version tool is a concrete missing requirement, not an accepted step | `cli-missing-shellcheck.txt`, `cli-version-skew.txt` |
| (2) the failure names the tool, the exact version, and how to get it | `cli-missing-shellcheck.txt` |
| (3) provisioned with the pin, or visibly marked not run — never passed | `cli-ci-provision-then-lint.txt`, `cli-optin-provisioning.txt` |
| (4) a regression test that fails before the change for the missing-tool shape | `before-suite.log`, `before-after-matrix.txt` |
| constraint: `--required-version` keeps working with ShellCheck absent (installer circular dependency) | `cli-ci-provision-then-lint.txt` |
| constraint: CI's provision-then-lint shape never refuses | `cli-ci-provision-then-lint.txt` |
| default behaviour is refuse, not fetch; opt-in provisioning; offline reuse; failed opt-in still refuses | `cli-optin-provisioning.txt` |
| `--help` no longer truncates at a hardcoded line range | `cli-help-range.txt`, `cli-help.txt` |
| suite result after the change | `after-suite.log` (26/26) |

## Headline

Same invocation, same host with no ShellCheck on PATH:

`` `
BEFORE  fm-lint.sh: ShellCheck not found; install ShellCheck 0.11.0 for CI parity.   -> exit 127
AFTER   fm-lint.sh: LINT NOT RUN: no shellcheck was found on PATH
        fm-lint.sh: nothing trustworthy was checked, so this is a failed lint gate, not a clean one.
        ... required tool / pinned version / two install routes / upstream release URL
                                                                                     -> exit 3
`` `

`cli-ci-provision-then-lint.txt` shows all three statuses staying distinct on one
host: `0` clean, `1` findings (on a fixture carrying a real SC2016 — the exact
finding class the pipeline was blind to), `3` not run.

## Before/after matrix

`before-after-matrix.txt` runs each refusal-contract test against the base
`bin/fm-lint.sh` and against the target one. The eight refusal tests fail before
and pass after; the three guard tests (pin/inventory queries with no ShellCheck,
the installer running in the state it repairs, CI's provision-then-lint shape)
pass both before and after by design.
```
</details>
<details>
<summary>Evidence: CLI transcript: missing ShellCheck, base vs target (127 → 3)</summary>

<code>$ PATH=&lt;no-shellcheck&gt; CI=true bin/fm-lint.sh # BEFORE (base bdae21e)&#10;fm-lint.sh: ShellCheck not found; install ShellCheck 0.11.0 for CI parity.&#10;$ echo $?&#10;127&#10;&#10;$ PATH=&lt;no-shellcheck&gt; CI=true bin/fm-lint.sh # AFTER (59eec18)&#10;fm-lint.sh: LINT NOT RUN: no shellcheck was found on PATH&#10;fm-lint.sh: nothing trustworthy was checked, so this is a failed lint gate, not a clean one.&#10;fm-lint.sh: required tool: ShellCheck, exactly version 0.11.0 (pinned so local and CI cannot diverge).&#10;fm-lint.sh: on Linux x86_64: bin/fm-install-shellcheck.sh &lt;dir&gt;, then put &lt;dir&gt; first on PATH.&#10;fm-lint.sh: or, same platform, for this run only: bin/fm-lint.sh --provision-shellcheck &lt;dir&gt;&#10;fm-lint.sh: on macOS or any other platform that installer does not cover: install the 0.11.0 build from&#10;fm-lint.sh: https://github.com/koalaman/shellcheck/releases/tag/v0.11.0 and put its directory first on PATH.&#10;$ echo $?&#10;3</code>

```text
############################################################
# Scenario: pipeline lint step on a host with no ShellCheck #
############################################################

$ PATH=<no-shellcheck> CI=true bin/fm-lint.sh   # BEFORE (base bdae21e)
fm-lint.sh: ShellCheck not found; install ShellCheck 0.11.0 for CI parity.
$ echo $?
127

$ PATH=<no-shellcheck> CI=true bin/fm-lint.sh   # AFTER (59eec18)
fm-lint.sh: LINT NOT RUN: no shellcheck was found on PATH
fm-lint.sh: nothing trustworthy was checked, so this is a failed lint gate, not a clean one.
fm-lint.sh: required tool: ShellCheck, exactly version 0.11.0 (pinned so local and CI cannot diverge).
fm-lint.sh: on Linux x86_64: bin/fm-install-shellcheck.sh <dir>, then put <dir> first on PATH.
fm-lint.sh: or, same platform, for this run only: bin/fm-lint.sh --provision-shellcheck <dir>
fm-lint.sh: on macOS or any other platform that installer does not cover: install the 0.11.0 build from
fm-lint.sh: https://github.com/koalaman/shellcheck/releases/tag/v0.11.0 and put its directory first on PATH.
$ echo $?
3
```
</details>
<details>
<summary>Evidence: CLI transcript: version skew, base exit 1 (same status as findings) vs target exit 3</summary>

<code>$ PATH=&lt;shellcheck-0.10.0&gt; CI=true bin/fm-lint.sh # BEFORE (base bdae21e)&#10;fm-lint.sh: ShellCheck 0.10.0 (pinned 0.11.0)&#10;fm-lint.sh: ShellCheck 0.11.0 required for CI parity, found 0.10.0. Install 0.11.0.&#10;$ echo $?&#10;1 &lt;-- 1 is the same status this gate uses for &#39;ShellCheck reported findings&#39;&#10;&#10;$ PATH=&lt;shellcheck-0.10.0&gt; CI=true bin/fm-lint.sh # AFTER (59eec18)&#10;fm-lint.sh: ShellCheck 0.10.0 (pinned 0.11.0)&#10;fm-lint.sh: LINT NOT RUN: the shellcheck at .../skew-bin/shellcheck is version 0.10.0, not the pinned 0.11.0&#10;fm-lint.sh: nothing trustworthy was checked, so this is a failed lint gate, not a clean one.&#10;fm-lint.sh: required tool: ShellCheck, exactly version 0.11.0 (pinned so local and CI cannot diverge).&#10;[... same remedy block ...]&#10;$ echo $?&#10;3</code>

```text
#####################################################################
# Scenario: host has ShellCheck 0.10.0, the pin is 0.11.0 (version skew)
#####################################################################

$ PATH=<shellcheck-0.10.0> CI=true bin/fm-lint.sh   # BEFORE (base bdae21e)
fm-lint.sh: ShellCheck 0.10.0 (pinned 0.11.0)
fm-lint.sh: ShellCheck 0.11.0 required for CI parity, found 0.10.0. Install 0.11.0.
$ echo $?
1   <-- 1 is the same status this gate uses for 'ShellCheck reported findings'

$ PATH=<shellcheck-0.10.0> CI=true bin/fm-lint.sh   # AFTER (59eec18)
fm-lint.sh: ShellCheck 0.10.0 (pinned 0.11.0)
fm-lint.sh: LINT NOT RUN: the shellcheck at /tmp/no-mistakes-evidence/01M08D5S9C4EJZCFSNDKKFZV77/skew-bin/shellcheck is version 0.10.0, not the pinned 0.11.0
fm-lint.sh: nothing trustworthy was checked, so this is a failed lint gate, not a clean one.
fm-lint.sh: required tool: ShellCheck, exactly version 0.11.0 (pinned so local and CI cannot diverge).
fm-lint.sh: on Linux x86_64: bin/fm-install-shellcheck.sh <dir>, then put <dir> first on PATH.
fm-lint.sh: or, same platform, for this run only: bin/fm-lint.sh --provision-shellcheck <dir>
fm-lint.sh: on macOS or any other platform that installer does not cover: install the 0.11.0 build from
fm-lint.sh: https://github.com/koalaman/shellcheck/releases/tag/v0.11.0 and put its directory first on PATH.
$ echo $?
3
```
</details>
<details>
<summary>Evidence: CLI transcript: real CI provision-then-lint on a no-ShellCheck host, and 0/1/3 staying distinct</summary>

<code>$ PATH=&lt;no-shellcheck&gt; bin/fm-lint.sh --required-version&#10;0.11.0&#10;&#10;$ PATH=&lt;no-shellcheck&gt; bin/fm-install-shellcheck.sh &#34;$RUNNER_TEMP/bin&#34; # CI step 1, real download+checksum&#10;ShellCheck - shell script analysis tool&#10;version: 0.11.0&#10;$ echo $?&#10;0&#10;&#10;$ PATH=&#34;$RUNNER_TEMP/bin:&lt;no-shellcheck&gt;&#34; GITHUB_ACTIONS=true bin/fm-lint.sh clean-fixture.sh # CI step 2&#10;fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)&#10;$ echo $?&#10;0 &lt;-- 0 clean: the provisioned pin satisfied every tool check, no LINT NOT RUN&#10;&#10;$ ... same PATH, fixture with a real SC2016&#10;printf &#39;hello $name\n&#39;&#10;^-------------^ SC2016 (info): Expressions don&#39;t expand in single quotes, use double quotes for that.&#10;$ echo $?&#10;1 &lt;-- 1 findings&#10;&#10;$ ... SAME fixture with the provisioned directory dropped off PATH&#10;fm-lint.sh: LINT NOT RUN: no shellcheck was found on PATH&#10;$ echo $?&#10;3 &lt;-- 3 not run. Never 0, and never 1, so no caller can read it as a clean gate.&#10;&#10;$ ... GITHUB_ACTIONS=true bin/fm-lint.sh --list-files | wc -l&#10;294</code>

```text
########################################################################
# Constraint proof: the installer must run in exactly the state it repairs,
# and CI's provision-then-lint sequence must never reach the refusal.
# The isolated PATH used below contains NO shellcheck at all.
########################################################################

$ PATH=<no-shellcheck> command -v shellcheck; echo $?
1

# --- circular dependency: the installer asks fm-lint.sh for the pin, ShellCheck absent ---
$ PATH=<no-shellcheck> bin/fm-lint.sh --required-version
0.11.0

# --- CI step 1 (.github/workflows/ci.yml 'Install pinned ShellCheck'), real download+checksum ---
$ PATH=<no-shellcheck> bin/fm-install-shellcheck.sh "$RUNNER_TEMP/bin"
ShellCheck - shell script analysis tool
version: 0.11.0
license: GNU General Public License, version 3
website: https://www.shellcheck.net
$ echo $?
0

# --- CI step 2: $RUNNER_TEMP/bin first on PATH, then the lint owner runs ---
$ PATH="$RUNNER_TEMP/bin:<no-shellcheck>" GITHUB_ACTIONS=true bin/fm-lint.sh clean-fixture.sh
fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
$ echo $?
0   <-- 0 clean: the provisioned pin satisfied every tool check, no LINT NOT RUN

# --- the three statuses stay distinct. Same provisioned PATH, a fixture with a real
#     SC2016 - the very finding class the pipeline was blind to when it could not run ---
$ PATH="$RUNNER_TEMP/bin:<no-shellcheck>" GITHUB_ACTIONS=true bin/fm-lint.sh sc2016-fixture.sh
fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)

In /tmp/no-mistakes-evidence/01M08D5S9C4EJZCFSNDKKFZV77/sc2016-fixture.sh line 3:
name=world
^--^ SC2034 (warning): name appears unused. Verify use (or export if used externally).


In /tmp/no-mistakes-evidence/01M08D5S9C4EJZCFSNDKKFZV77/sc2016-fixture.sh line 4:
printf 'hello $name\n'
       ^-------------^ SC2016 (info): Expressions don't expand in single quotes, use double quotes for that.

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- name appears unused. Verify use (...
  https://www.shellcheck.net/wiki/SC2016 -- Expressions don't expand in singl...
$ echo $?
1   <-- 1 findings

# --- and the SAME fixture with the provisioned directory dropped off PATH ---
$ PATH="<no-shellcheck>" GITHUB_ACTIONS=true bin/fm-lint.sh sc2016-fixture.sh
fm-lint.sh: LINT NOT RUN: no shellcheck was found on PATH
fm-lint.sh: nothing trustworthy was checked, so this is a failed lint gate, not a clean one.
fm-lint.sh: required tool: ShellCheck, exactly version 0.11.0 (pinned so local and CI cannot diverge).
fm-lint.sh: on Linux x86_64: bin/fm-install-shellcheck.sh <dir>, then put <dir> first on PATH.
fm-lint.sh: or, same platform, for this run only: bin/fm-lint.sh --provision-shellcheck <dir>
fm-lint.sh: on macOS or any other platform that installer does not cover: install the 0.11.0 build from
fm-lint.sh: https://github.com/koalaman/shellcheck/releases/tag/v0.11.0 and put its directory first on PATH.
$ echo $?
3   <-- 3 not run. Never 0, and never 1, so no caller can read it as a clean gate.

# --- the file set CI lints with no arguments is unchanged by any of this ---
$ PATH="$RUNNER_TEMP/bin:<no-shellcheck>" GITHUB_ACTIONS=true bin/fm-lint.sh --list-files | wc -l
294
```
</details>
<details>
<summary>Evidence: CLI transcript: default refuses and fetches nothing; opt-in installs, reuses offline, refuses on failure</summary>

<code>$ PATH=&lt;no-shellcheck,network-up&gt; CI=true bin/fm-lint.sh sc2016-fixture.sh # no opt-in&#10;fm-lint.sh: LINT NOT RUN: no shellcheck was found on PATH&#10;$ echo $?&#10;3&#10;$ ls optin-dir&#10;ls: cannot access &#39;.../optin-dir&#39;: No such file or directory&#10;^ nothing was fetched: a validation step never reaches the network as a side effect&#10;&#10;$ ... bin/fm-lint.sh --provision-shellcheck optin-dir sc2016-fixture.sh # the printed remedy, verbatim&#10;fm-lint.sh: provisioned ShellCheck 0.11.0 into .../optin-dir on request.&#10;fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)&#10;... SC2016 (info): Expressions don&#39;t expand in single quotes ...&#10;$ echo $?&#10;1 &lt;-- 1 findings: the gate now has a verdict where it previously had none&#10;&#10;# network severed from here (curl exits 6)&#10;$ ... --provision-shellcheck optin-dir clean-fixture.sh&#10;fm-lint.sh: ShellCheck 0.11.0 is already provisioned in .../optin-dir; not fetching.&#10;$ echo $?&#10;0 &lt;-- already-provisioned pin reused, nothing refetched&#10;&#10;$ ... --provision-shellcheck optin-fresh clean-fixture.sh&#10;fm-install-shellcheck.sh: download attempt 1..5 failed; retrying&#10;fm-install-shellcheck.sh: download failed after 6 attempts&#10;fm-lint.sh: LINT NOT RUN: provisioning ShellCheck 0.11.0 into .../optin-fresh failed&#10;$ echo $?&#10;3 &lt;-- 3 not run, with the same unmissable marker</code>

```text
########################################################################
# Design decision under test: default behaviour is REFUSE, never fetch.
# Provisioning happens only when a caller deliberately opts in.
# The isolated PATH below has no shellcheck at all.
########################################################################

$ PATH=<no-shellcheck,network-up> CI=true bin/fm-lint.sh sc2016-fixture.sh   # no opt-in
fm-lint.sh: LINT NOT RUN: no shellcheck was found on PATH
fm-lint.sh: nothing trustworthy was checked, so this is a failed lint gate, not a clean one.
fm-lint.sh: required tool: ShellCheck, exactly version 0.11.0 (pinned so local and CI cannot diverge).
fm-lint.sh: on Linux x86_64: bin/fm-install-shellcheck.sh <dir>, then put <dir> first on PATH.
fm-lint.sh: or, same platform, for this run only: bin/fm-lint.sh --provision-shellcheck <dir>
fm-lint.sh: on macOS or any other platform that installer does not cover: install the 0.11.0 build from
fm-lint.sh: https://github.com/koalaman/shellcheck/releases/tag/v0.11.0 and put its directory first on PATH.
$ echo $?
3
$ ls optin-dir
ls: cannot access '/tmp/no-mistakes-evidence/01M08D5S9C4EJZCFSNDKKFZV77/optin-dir': No such file or directory
  ^ nothing was fetched: a validation step never reaches the network as a side effect

# --- the remedy the refusal printed, copy-pasted verbatim ---
$ PATH=<no-shellcheck,network-up> CI=true bin/fm-lint.sh --provision-shellcheck optin-dir sc2016-fixture.sh
fm-lint.sh: provisioned ShellCheck 0.11.0 into /tmp/no-mistakes-evidence/01M08D5S9C4EJZCFSNDKKFZV77/optin-dir on request.
fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)

In /tmp/no-mistakes-evidence/01M08D5S9C4EJZCFSNDKKFZV77/sc2016-fixture.sh line 3:
name=world
^--^ SC2034 (warning): name appears unused. Verify use (or export if used externally).


In /tmp/no-mistakes-evidence/01M08D5S9C4EJZCFSNDKKFZV77/sc2016-fixture.sh line 4:
printf 'hello $name\n'
       ^-------------^ SC2016 (info): Expressions don't expand in single quotes, use double quotes for that.

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- name appears unused. Verify use (...
  https://www.shellcheck.net/wiki/SC2016 -- Expressions don't expand in singl...
$ echo $?
1   <-- 1 findings: the gate now has a verdict where it previously had none

# --- now cut the network entirely, as on an offline host ---
$ curl -fsSL https://github.com/koalaman/shellcheck -o /dev/null; echo $?
curl: (6) Could not resolve host: objects.githubusercontent.com
6

$ PATH=<no-shellcheck,network-DOWN> CI=true bin/fm-lint.sh --provision-shellcheck optin-dir clean-fixture.sh
fm-lint.sh: ShellCheck 0.11.0 is already provisioned in /tmp/no-mistakes-evidence/01M08D5S9C4EJZCFSNDKKFZV77/optin-dir; not fetching.
fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
$ echo $?
0   <-- 0: the already-provisioned pin was reused, nothing refetched

# --- an opt-in that cannot be satisfied refuses; it never degrades into a pass ---
$ PATH=<no-shellcheck,network-DOWN> CI=true bin/fm-lint.sh --provision-shellcheck optin-fresh clean-fixture.sh
curl: (6) Could not resolve host: objects.githubusercontent.com
fm-install-shellcheck.sh: download attempt 1 failed; retrying
curl: (6) Could not resolve host: objects.githubusercontent.com
fm-install-shellcheck.sh: download attempt 2 failed; retrying
curl: (6) Could not resolve host: objects.githubusercontent.com
fm-install-shellcheck.sh: download attempt 3 failed; retrying
curl: (6) Could not resolve host: objects.githubusercontent.com
fm-install-shellcheck.sh: download attempt 4 failed; retrying
curl: (6) Could not resolve host: objects.githubusercontent.com
fm-install-shellcheck.sh: download attempt 5 failed; retrying
curl: (6) Could not resolve host: objects.githubusercontent.com
fm-install-shellcheck.sh: download failed after 6 attempts
fm-lint.sh: LINT NOT RUN: provisioning ShellCheck 0.11.0 into /tmp/no-mistakes-evidence/01M08D5S9C4EJZCFSNDKKFZV77/optin-fresh failed
fm-lint.sh: nothing trustworthy was checked, so this is a failed lint gate, not a clean one.
fm-lint.sh: required tool: ShellCheck, exactly version 0.11.0 (pinned so local and CI cannot diverge).
fm-lint.sh: on Linux x86_64: bin/fm-install-shellcheck.sh <dir>, then put <dir> first on PATH.
fm-lint.sh: or, same platform, for this run only: bin/fm-lint.sh --provision-shellcheck <dir>
fm-lint.sh: on macOS or any other platform that installer does not cover: install the 0.11.0 build from
fm-lint.sh: https://github.com/koalaman/shellcheck/releases/tag/v0.11.0 and put its directory first on PATH.
$ echo $?
3   <-- 3 not run, with the same unmissable marker
```
</details>
<details>
<summary>Evidence: Per-test before/after matrix (base bin/fm-lint.sh vs target)</summary>

<code>TEST BEFORE AFTER&#10;test_missing_shellcheck_refuses_instead_of_passing FAIL PASS&#10;test_wrong_version_and_unversioned_tool_share_the_refusal FAIL PASS&#10;test_provisioning_is_opt_in_and_never_degrades_to_a_pass FAIL PASS&#10;test_unusable_temp_directory_refuses_on_the_could_not_run_status FAIL PASS&#10;test_lost_worker_result_refuses_on_the_could_not_run_status FAIL PASS&#10;test_roots_lost_before_shellcheck_refuse_instead_of_passing_clean FAIL PASS&#10;test_changed_mode_verifies_its_selection_before_acting_on_it FAIL PASS&#10;test_unresolvable_repository_root_refuses_on_the_could_not_run_status FAIL PASS&#10;test_pin_and_inventory_answer_without_any_shellcheck PASS PASS&#10;test_installer_learns_the_pin_with_no_shellcheck_present PASS PASS&#10;test_ci_provisioned_shape_never_refuses PASS PASS</code>

```text
TEST                                                           BEFORE   AFTER
---                                                            ---      ---
test_missing_shellcheck_refuses_instead_of_passing             FAIL     PASS
test_wrong_version_and_unversioned_tool_share_the_refusal      FAIL     PASS
test_provisioning_is_opt_in_and_never_degrades_to_a_pass       FAIL     PASS
test_unusable_temp_directory_refuses_on_the_could_not_run_status FAIL     PASS
test_lost_worker_result_refuses_on_the_could_not_run_status    FAIL     PASS
test_roots_lost_before_shellcheck_refuse_instead_of_passing_clean FAIL     PASS
test_changed_mode_verifies_its_selection_before_acting_on_it   FAIL     PASS
test_unresolvable_repository_root_refuses_on_the_could_not_run_status FAIL     PASS
test_pin_and_inventory_answer_without_any_shellcheck           PASS     PASS
test_installer_learns_the_pin_with_no_shellcheck_present       PASS     PASS
test_ci_provisioned_shape_never_refuses                        PASS     PASS
```
</details>
<details>
<summary>Evidence: Base-script suite run: aborts at the missing-tool shape</summary>

<code>ok - fm-lint.sh --list-files reports the complete shell inventory&#10;ok - fm-lint.sh pins an explicit ShellCheck version (0.11.0)&#10;ok - ShellCheck installer retries a transient download failure&#10;not ok - a lint with no ShellCheck on PATH exited 127, which a caller cannot tell apart from fm-lint.sh being missing&#10;fm-lint.sh: ShellCheck not found; install ShellCheck 0.11.0 for CI parity.</code>

```text
ok - fm-lint.sh --list-files reports the complete shell inventory
ok - fm-lint.sh pins an explicit ShellCheck version (0.11.0)
ok - ShellCheck installer retries a transient download failure
not ok - a lint with no ShellCheck on PATH exited 127, which a caller cannot tell apart from fm-lint.sh being missing
fm-lint.sh: ShellCheck not found; install ShellCheck 0.11.0 for CI parity.
```
</details>
<details>
<summary>Evidence: --help no longer truncates at a hardcoded line range</summary>

<code>$ # the base expression, applied to the current 105-line header:&#10;$ sed -n &#39;2,39{s/^# \{0,1\}//;p;}&#39; bin/fm-lint.sh | wc -l&#10;38&#10;$ ... | tail -2&#10;3 the lint did not run to completion, so it carries no verdict at all&#10;(see the refusal below)&#10;^ cut off mid-sentence in the exit-status table; the Usage block never appears at all.&#10;&#10;$ bin/fm-lint.sh --help | wc -l # the shipped self-terminating range&#10;105&#10;$ bin/fm-lint.sh --help | tail -2&#10;fm-lint.sh --list-files print the file set that would be linted&#10;fm-lint.sh --help print this usage</code>

```text
# --help renders the script header. The base used a hardcoded range, sed -n '2,39',
# which silently truncates once the header grows. The header is now 105 comment lines.

$ # the base expression, applied to the current 105-line header:
$ sed -n '2,39{s/^# \{0,1\}//;p;}' bin/fm-lint.sh | wc -l
38
$ sed -n '2,39{s/^# \{0,1\}//;p;}' bin/fm-lint.sh | tail -2
  3  the lint did not run to completion, so it carries no verdict at all
     (see the refusal below)
   ^ cut off mid-sentence in the exit-status table; the Usage block never appears at all.

$ bin/fm-lint.sh --help | wc -l   # the shipped self-terminating range
105
$ bin/fm-lint.sh --help | tail -2
  fm-lint.sh --list-files            print the file set that would be linted
  fm-lint.sh --help                  print this usage
```
</details>
<details>
<summary>Evidence: Full --help output on the target</summary>

```text
$ bin/fm-lint.sh --help
fm-lint.sh - the single owner of firstmate's shell-lint definition.

Runs its file set with ShellCheck's default severity, extended analysis,
ambient configuration disabled, and one exact ShellCheck version. CI and
no-mistakes both invoke this script with no arguments, so the rule set,
version, bounded execution, and diagnostics ordering cannot drift.
Tests stop source analysis at imported production modules because every
production shell is already a canonical, source-aware root of this same run.

With no explicit paths, the file set depends on context:
  - In CI (GITHUB_ACTIONS=true or CI=true), on the main branch, or when no
    merge-base against origin/main (or local main) can be found, it lints
    the full canonical set: bin/*.sh bin/backends/*.sh tests/*.sh. This is
    what CI always runs, so CI coverage never depends on a local diff.
  - Otherwise (an ordinary local branch with a real merge-base) it lints
    only the canonical-set files changed since that merge-base, including
    uncommitted local edits, via plain local `git diff` (no network, no
    `gh`). That selection is verified against a second git read before it is
    acted on (see Selection below). A branch with zero matching changed files
    exits 0 and prints a "no changed lint targets" note instead of running
    ShellCheck.
Explicit paths always bypass this file-set selection and lint exactly the
given paths, matching the same config.

Canonical lint defaults to two bounded workers over two stable logical shards.
Each shard writes separate diagnostics, and the parent replays those outputs in
deterministic shard and root order after every worker finishes. FM_LINT_JOBS=1
runs the same shards serially with byte-identical diagnostics and exit selection.

Optional quiet telemetry writes one bounded TSV snapshot of content and source
graph identity, wall/CPU/RSS, shard load, and competing ShellCheck processes.

Exit status:
  0  the selected file set is clean, or there were no changed lint targets
  1  ShellCheck reported findings
  2  invalid usage
  3  the lint did not run to completion, so it carries no verdict at all
     (see the refusal below)

Two integrity checks stand between this gate and a clean exit. Each answers one
question, and neither covers the other's:
  - Execution: was every file in the selected set actually handed to ShellCheck?
    Each worker records the number of roots it passed for its shard next to that
    shard's result, and the parent refuses unless those counts sum to the
    selected count. A shard that dropped roots, and a shard that recorded no
    count at all, both refuse rather than being read as zero. This is the one
    place that guarantee is asserted, end to end on what was really passed
    rather than on an intermediate proxy.
  - Selection, in changed-files mode only: is the selected set really the
    changed set? The NUL-safe read that builds it runs in a process
    substitution whose exit status is invisible, so a git or sort that failed
    or was truncated there looks exactly like a smaller diff. The selection is
    therefore compared against a second `git diff` whose status IS observable,
    and a failed read or a differing count refuses. Full-lint mode needs no
    such check - its set comes from a shell glob with no external command in
    the path - and explicit-path mode lints exactly the caller's own list.
A shard whose result never arrived refuses as well, because diagnostics that
cannot be replayed cannot be turned into a verdict; that is replay integrity,
not a second completeness guarantee.

This gate refuses instead of passing when it cannot run. Both checks above, a
missing ShellCheck, a ShellCheck that is not the pin, one that will not report
its version, a missing perl, a repository root that cannot be resolved or
entered, and a temporary directory that cannot be created all print an
unmissable "LINT NOT RUN" line naming what is missing - plus, when ShellCheck
is the missing piece, the exact version required and how to get it - then exit
3.
3 is deliberately not 127: 127 is the shell's own "command not found", so a
caller that sees it cannot tell whether this script refused or was never found
at all, and a gate that reads lint output for actionable findings sees none in
a refusal and can record a clean step that in fact checked nothing.

Provisioning is opt-in and never a side effect of linting, because a gate that
reaches the network to validate is harder to trust and breaks on an offline
host. A caller that deliberately wants it passes --provision-shellcheck <dir>
(or sets FM_LINT_PROVISION_SHELLCHECK=<dir>) to ENSURE the pin is present in
<dir>: an existing <dir>/shellcheck that already reports the pinned version is
only put first on PATH, and bin/fm-install-shellcheck.sh installs the build
only when <dir> does not already hold the pin, so a repeat run neither
refetches nor breaks offline. A fresh install is checksum-verified; a binary
already sitting in that caller-owned directory is taken at the version it
reports of itself, so what holds for it is the pin, not the checksum. Either
way the version enforcement below runs on whatever ends up on PATH, so a build
that reports anything other than the pin is refused rather than used. A
provisioning attempt that fails refuses exactly like a missing tool; it never
degrades into a pass. That installer fetches the Linux x86_64 release, so on
any other platform install the pinned build from the upstream ShellCheck
release instead and put it first on PATH. CI provisions in its own step
(.github/workflows/ci.yml) and never needs this.

--required-version and --list-files answer with no ShellCheck present at all,
because bin/fm-install-shellcheck.sh asks this script which version to fetch:
breaking that would break the installer that repairs a missing tool.

Usage:
  fm-lint.sh                         lint the context-selected file set (see above)
  fm-lint.sh <path>...               lint explicit roots with the same config
  fm-lint.sh --jobs <1|2> [path]...  override bounded worker count
  fm-lint.sh --telemetry <path> ...  write a quiet metrics snapshot
  fm-lint.sh --provision-shellcheck <dir>
                                     opt in to ensuring the pin is in <dir>,
                                     installing it only if it is not already
  fm-lint.sh --required-version      print the ShellCheck pin
  fm-lint.sh --list-files            print the file set that would be linted
  fm-lint.sh --help                  print this usage
```
</details>
<details>
<summary>Evidence: tests/fm-lint.test.sh on the target — 26/26</summary>

```text
ok - fm-lint.sh --list-files reports the complete shell inventory
ok - fm-lint.sh pins an explicit ShellCheck version (0.11.0)
ok - ShellCheck installer retries a transient download failure
ok - fm-lint.sh refuses out loud when no ShellCheck is present instead of passing
ok - fm-lint.sh refuses a version-skewed or unversioned ShellCheck on the same contract
ok - fm-lint.sh answers --required-version and --list-files with no ShellCheck present
ok - the ShellCheck installer still learns the pin when ShellCheck is what is missing
ok - fm-lint.sh never refuses in CI's provision-then-lint shape
ok - fm-lint.sh provisions only on request, reuses a present pin, repairs another build, and refuses on failure
ok - fm-lint.sh refuses on the could-not-run status when it cannot create a temp directory
ok - fm-lint.sh refuses on the could-not-run status when a worker result never arrives
ok - fm-lint.sh refuses when selected files never reach ShellCheck, serially and in parallel
ok - fm-lint.sh verifies its changed-file selection against git before acting on it
ok - fm-lint.sh refuses, naming the repository root, when it cannot resolve the root that holds it
ok - fm-lint.sh catches a real lint defect the old no-op gate passed
ok - fm-lint.sh ignores ambient ShellCheck options
ok - fm-lint.sh passes a clean fixture
ok - jobs=1 and jobs=2 preserve deterministic diagnostics, failures, cleanup bounds, and quiet telemetry
ok - jobs=1 and jobs=2 stop complete worker trees with and without telemetry
ok - seeded dispatcher, adapter, production-owner, and test-local diagnostics preserve parity
ok - fm-lint.sh changed mode lints only the changed canonical file
ok - fm-lint.sh forces a full lint in CI even when the local diff would be empty
ok - fm-lint.sh forces a full lint when HEAD is on main
ok - fm-lint.sh explicit paths bypass changed-file mode selection
ok - fm-lint.sh exits 0 with a note when the local branch has no changed lint targets
ok - fm-lint.sh --list-files reports the would-be changed set in changed mode
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"59eec18cd330eb99f42768b4a36d5269442f0acf","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 3 infos</summary>

- ℹ️ `bin/fm-lint.sh:609` - The replay loop normalizes only non-numeric shard statuses (`case &#34;$rc&#34; in &#39;&#39;|*[!0-9]*) rc=2`), then `exit &#34;$overall_rc&#34;` (line 748) emits whatever a shard recorded verbatim. That leaves the newly declared contract at lines 110-113 and 69-72 (&#34;3 is the could-not-run status, distinct from 0/1/2 and deliberately not 127&#34;) without an enforcement point. Two concrete escapes: ShellCheck documents exit 3 for &#34;invoked with bad syntax&#34; and 4 for &#34;invoked with bad options&#34;, so a shard rc of 3 would exit 3 with no `LINT NOT RUN` marker at all — the exact ambiguity the change exists to remove; and a ShellCheck killed mid-analysis (OOM, host timeout) makes `wait` return 128+N, the worker still writes a full `.checked` count and that rc, so the run exits e.g. 137 with truncated diagnostics and a balanced count, even though it demonstrably did not run to completion. Neither is a silent pass (both are non-zero), and neither is reachable today because the invocation is fixed at `--norc --external-sources --`, so this is a hole in the documented contract rather than a live defect. Fix: in the replay loop fold any shard status outside {0,1,2} into either 2 or the refusal, so the header&#39;s status set is actually the set this script can emit.
- ℹ️ `bin/fm-lint.sh:412` - The selection recheck loop (412-419) re-implements the primary changed-file read&#39;s filter (359-363) as a second copy: same `fm_lint_is_canonical_root` call, same `[ -f &#34;$changed_path&#34; ]` existence test, same skip-empty guard, differing only in NUL-vs-newline framing and count-vs-array-append. Because the gate now hard-refuses when the two disagree, the two copies are load-bearing in a fail-closed direction: drift between them does not weaken the check, it breaks every healthy run. Extracting the predicate pair (canonical + exists) into one helper both loops call would keep them provably identical while preserving the deliberate difference in framing.
- ℹ️ `bin/fm-lint.sh:406` - The selection is proven by asking git a second time rather than by making the first read report its own status, so the two answers are separated in time by the ShellCheck resolution and version probe (379-397, one process spawn). Any canonical-set file created or deleted in that window makes the counts disagree and produces a hard refusal attributed to &#34;the selection is wrong&#34;. This is fail-closed and the diagnostic is explicit, which matches the intent&#39;s stated bias toward making failure impossible to miss over convenience, so it is a tradeoff worth knowing rather than a defect to fix. Noting it because a reviewer of the diff alone would read the check as deterministic. If it ever fires spuriously, the tighter form is to make the first read&#39;s status observable (write the diff to a temp file with an observable exit status, then read that file) instead of re-querying git.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-lint.test.sh` — 26/26 ok, with ShellCheck 0.11.0 (the pin) on PATH so the real-lint tests run instead of skipping</code>
- <code>Before/after per-test matrix: ran `test_missing_shellcheck_refuses_instead_of_passing`, `test_wrong_version_and_unversioned_tool_share_the_refusal`, `test_provisioning_is_opt_in_and_never_degrades_to_a_pass`, `test_unusable_temp_directory_refuses_on_the_could_not_run_status`, `test_lost_worker_result_refuses_on_the_could_not_run_status`, `test_roots_lost_before_shellcheck_refuse_instead_of_passing_clean`, `test_changed_mode_verifies_its_selection_before_acting_on_it`, `test_unresolvable_repository_root_refuses_on_the_could_not_run_status`, `test_pin_and_inventory_answer_without_any_shellcheck`, `test_installer_learns_the_pin_with_no_shellcheck_present`, `test_ci_provisioned_shape_never_refuses` against both the base `bin/fm-lint.sh` (from `git show bdae21ed:bin/fm-lint.sh`) and the target one</code>
- <code>`bash tests/fm-lint.test.sh` against the base `bin/fm-lint.sh` — aborts at &#34;a lint with no ShellCheck on PATH exited 127, which a caller cannot tell apart from fm-lint.sh being missing&#34;</code>
- <code>Manual CLI: `PATH=&lt;allowlisted, no shellcheck&gt; CI=true bin/fm-lint.sh` on base vs target, capturing stderr and exit status (127 vs 3)</code>
- <code>Manual CLI: `PATH=&lt;shellcheck 0.10.0 stub&gt; CI=true bin/fm-lint.sh` on base vs target (exit 1, indistinguishable from findings, vs exit 3)</code>
- <code>Manual CLI: `PATH=&lt;no shellcheck&gt; bin/fm-lint.sh --required-version` and `--list-files` — the installer&#39;s circular dependency and the macOS stock-Bash CI job&#39;s consumer</code>
- <code>Manual CLI, real CI shape: `PATH=&lt;no shellcheck&gt; RUNNER_TEMP=... bin/fm-install-shellcheck.sh &#34;$RUNNER_TEMP/bin&#34;` (real download + checksum verify), then `PATH=&#34;$RUNNER_TEMP/bin:&lt;no shellcheck&gt;&#34; GITHUB_ACTIONS=true bin/fm-lint.sh &lt;fixture&gt;` → 0 clean, and the same fixture with an SC2016 → 1 findings, and with the provisioned dir dropped → 3 not run</code>
- <code>Manual CLI, opt-in provisioning: default run fetches nothing; `bin/fm-lint.sh --provision-shellcheck &lt;dir&gt; &lt;fixture&gt;` installs the pin and lints; with `curl` replaced by a failing stub the already-provisioned dir is reused without refetching; a fresh dir exhausts all 6 retries and refuses on exit 3</code>
- <code>Manual CLI: `bin/fm-lint.sh --help | wc -l` (105 lines) vs the base&#39;s hardcoded `sed -n &#39;2,39{s/^# \{0,1\}//;p;}&#39;` expression applied to the same header (38 lines, truncated mid-sentence in the exit-status table)</code>
- <code>`bash tests/fm-cd-pretool-check.test.sh` — passes (consumer of the linter)</code>
- <code>`bash tests/fm-arm-pretool-check.test.sh` — case A13 fails in this worktree due to a `/home` → `/local/home` symlink making `$ROOT` and the policy&#39;s home path disagree; passes 146/146 with `FM_HOME=$PWD`, and the diff touches nothing that case consumes</code>
- <code>`bin/fm-test-run.sh --check-coverage` — `FM_TEST_COVERAGE ok total=146 parallel=24 serial=110 serial_shards=4 herdr=12`, so the extended test file stays registered in its lanes</code>
- <code>`git status --porcelain` after all testing — clean, no transient artifacts left in the worktree</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `bin/fm-lint.sh:34` - Judgment call, deliberately left as a no-op: the new exit-status contract (3 = lint did not run) and the --provision-shellcheck / FM_LINT_PROVISION_SHELLCHECK opt-in stay documented only in bin/fm-lint.sh&#39;s header and --help, per tier 7 of the knowledge-placement policy in .agents/skills/firstmate-coding-guidelines/SKILL.md. CONTRIBUTING.md:48-49 and SKILL.md:121 were checked and left as-is: their one-line &#34;refuses to run under any other shellcheck version&#34; cross-references remain accurate, and spelling out the flags, exit codes, or the Linux x86_64-only installer caveat there would create the second full copy the one-owner rule forbids. Raised so a reviewer can see the contributor-facing surfaces were analyzed rather than missed.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 3)

🔧 Fix: lint clean with pinned ShellCheck 0.11.0; no changes needed
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


## Field evidence: this gate has never linted anything, on any lane

The strongest argument for this change is not the reasoning above, it is the gate's own record. Every
lint step the local no-mistakes gate has ever stored for this repository, across seven runs and six
different branches, recorded the step as **completed** while ShellCheck was absent:

| run | step | status | recorded finding |
| --- | --- | --- | --- |
| `01M07VBM2K2KHCE1XCSZ9CX9VM` | lint | completed | linter found issues (exit code 127) |
| `01M05MGX1XAFE95ZSKNYFJXGXC` | lint | completed | linter found issues (exit code 127) |
| `01M05MDFW0CTN0BG3KBHK37NK5` | lint | completed | linter found issues (exit code 127) |
| `01M00A8VTWZ3694JTCH2CDNSC6` | lint | completed | linter found issues (exit code 127) |
| `01M004MQF4M9EKB5G0JGHCQZGJ` | lint | completed | linter found issues (exit code 127) |
| `01M00473HD3KXXT1B3RPVVTVDC` | lint | completed | linter found issues (exit code 127) |
| `01KZZXKC0CKXBBHRB3N0AA80VM` | lint | completed | linter found issues (exit code 127) |
| `01M08D5S9C4EJZCFSNDKKFZV77` (this change) | lint | **awaiting_approval** | linter found issues (**exit code 3**) |

Every one of those seven runs passed its lint step and went on to merge. The shell-lint gate in this
repository has never actually linted anything on any lane, and nothing surfaced it, because a silent
non-event looks exactly like a clean gate.

This also settles the choice of a dedicated status rather than reusing 127. Note the last column
against the third: exit **127** was recorded `completed` and passed, while exit **3** was recorded
`awaiting_approval` and stopped the run. The consuming gate was treating 127 as "no linter here,
carry on" - which is a reasonable reading, because 127 is the shell's own "command not found" and
carries no information about whether a linter meant to run. A status that only this script can emit
is not ambiguous in that way, and the difference between those two rows is the entire behavioural
change this PR makes.

The fix that made this run's lint step pass was environmental, not a code change: ShellCheck 0.11.0
was already installed on the host and simply was not on the PATH the step ran with. Once it was
reachable, the same script linted the canonical set and exited 0. That is the intended shape - the
refusal is not a failure mode to be worked around, it is the gate correctly declining to certify
work it could not inspect.

## Coverage note: CI cannot reach the changed-files path

`bin/fm-lint.sh` selects its file set one of three ways: an explicit path list from the caller, a
full-lint glob, or the changed-files diff against the merge base. CI can only ever exercise the
first two. Both `.github/workflows/ci.yml` and the pipeline set `GITHUB_ACTIONS=true`, and the script
forces full-lint mode whenever `GITHUB_ACTIONS` or `CI` is set, so `CHANGED_MODE` is 0 in every CI
lane without exception.

That matters because changed-files mode is this repository's own production invocation: `.no-mistakes.yaml`
pins `lint: 'bin/fm-lint.sh'` with no arguments, which on a feature branch outside CI resolves to
exactly that path. So the mode the gate actually runs in day to day is the one mode CI will never
test, and the tests in `tests/fm-lint.test.sh` are its only coverage - now and permanently, unless
that selection rule changes. The changed-files cases in this PR were written with that in mind and
cover the partial-drop, whole-read-failure, genuinely-empty, and healthy-selection shapes, each
asserting the exit status rather than message text.
