### PR TITLE
feat(crew): add completion, process-exit, and shadow receipts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,9 @@ state/               runtime records and signals; gitignored
   <id>.pr-poll       private validated data sidecar for the byte-static PR merge poll
   <id>.pr-poll-registration  private transactional provenance record binding the task, canonical metadata identity, sidecar, and static poll publication
   <id>.pr-poll-retirement  private identity-bound crash-recovery receipt for one exact validated merged result; removed after its poll artifacts retire
+  <id>.completion-receipt  atomic completion receipt published by fm-complete.sh, bound to spawn_gen, kind, mode, outcome, worktree HEAD, and optional PR URL; stale incarnations are rejected (fm-completion-lib.sh)
+  <id>.process-exit-receipt  atomic process-exit receipt published by fm-harness-run.sh, bound to spawn_gen, harness, backend, the exact child PID, and its kernel-derived process identity; persistent secondmates are excluded
+  <id>.completion-shadow  per-harness, per-backend shadow comparison log between receipt conclusions and the unchanged current crew state, written by fm-completion-shadow.sh
   .pr-check-quarantine/  private non-runnable storage for checks neutralized by the non-executing migration
   .pr-check-migration.log  private per-task outcomes distinguishing rebuilt or canonically registered replacement polls, quarantined unarmed polls, and incomplete migrations
   .pr-check-migration-scan-v1  private marker proving the non-executing scan disabled every unsafe legacy check; .pr-check-migration-v1 separately records completed private repairs

--- a/bin/fm-complete.sh
+++ b/bin/fm-complete.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Publish a current-incarnation completion receipt without changing lifecycle.
+#
+# Usage:
+#   fm-complete.sh <task-id> --spawn-gen <gen> --outcome <done|failed>
+#     --summary <legacy-status-note> [--artifact <path>] [--pr <canonical-url>]
+#
+# FM_SPAWN_GEN may supply --spawn-gen for a process launched by fm-spawn.sh.
+# The receipt is atomically published only while the supplied generation still
+# matches state/<id>.meta. During migration this helper also appends the same
+# done:/failed: status event existing readers consume. It never calls a control,
+# merge, park, teardown, cleanup, or forge command.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-backend.sh
+. "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-completion-lib.sh
+. "$SCRIPT_DIR/fm-completion-lib.sh"
+
+usage() {
+  sed -n '2,${/^#/!q;p;}' "$0" | sed 's/^# \{0,1\}//' >&2
+  exit 2
+}
+
+die() { printf 'error: %s\n' "$1" >&2; exit 1; }
+
+ID=${1:-}
+[ -n "$ID" ] || usage
+shift
+fm_pr_task_id_valid "$ID" || die "invalid task id"
+SPAWN_GEN=${FM_SPAWN_GEN:-}
+OUTCOME=
+SUMMARY=
+ARTIFACT=
+PR_URL=
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --spawn-gen) SPAWN_GEN=${2-}; shift 2 || usage ;;
+    --outcome) OUTCOME=${2-}; shift 2 || usage ;;
+    --summary) SUMMARY=${2-}; shift 2 || usage ;;
+    --artifact) ARTIFACT=${2-}; shift 2 || usage ;;
+    --pr) PR_URL=${2-}; shift 2 || usage ;;
+    -h|--help) usage ;;
+    *) usage ;;
+  esac
+done
+fm_completion_token_valid "$SPAWN_GEN" || die "--spawn-gen is required and must be a safe token"
+case "$OUTCOME" in done|failed) : ;; *) die "--outcome must be done or failed" ;; esac
+[ -n "$SUMMARY" ] || die "--summary is required"
+case "$SUMMARY" in *$'\n'*|*$'\r'*) die "--summary must be one line" ;; esac
+
+META="$STATE/$ID.meta"
+[ -f "$META" ] || die "no task metadata for $ID"
+KIND=$(fm_backend_meta_exact_value "$META" kind) || die "task $ID has no exact kind"
+[ "$KIND" != secondmate ] || die "persistent secondmates are outside the completion-receipt lifecycle"
+case "$KIND" in
+  scout) MODE=scout ;;
+  ship) MODE=$(fm_backend_meta_exact_value "$META" mode) || die "ship task $ID has no exact mode" ;;
+  *) die "unsupported task kind '$KIND'" ;;
+esac
+case "$MODE" in scout|no-mistakes|direct-PR|local-only) : ;; *) die "unsupported task mode '$MODE'" ;; esac
+WT=$(fm_backend_meta_exact_value "$META" worktree) || die "task $ID has no exact worktree"
+[ -d "$WT" ] || die "task $ID worktree is missing"
+HEAD=$(git -C "$WT" rev-parse HEAD 2>/dev/null) || die "cannot resolve worktree HEAD for $ID"
+fm_pr_head_valid "$HEAD" || die "worktree HEAD for $ID is not a full object id"
+
+if [ "$KIND" = scout ]; then
+  [ -n "$ARTIFACT" ] || die "investigation completion requires --artifact with its report path"
+  [ -f "$ARTIFACT" ] || die "investigation report path is not a file: $ARTIFACT"
+fi
+if [ -n "$ARTIFACT" ]; then
+  case "$ARTIFACT" in *$'\n'*|*$'\r'*) die "artifact path must be one line" ;; esac
+  ARTIFACT_DIR=$(CDPATH='' cd -- "$(dirname "$ARTIFACT")" 2>/dev/null && pwd -P) \
+    || die "cannot resolve artifact path: $ARTIFACT"
+  ARTIFACT="$ARTIFACT_DIR/$(basename "$ARTIFACT")"
+fi
+if [ "$MODE" = local-only ]; then
+  [ -z "$(git -C "$WT" status --porcelain 2>/dev/null)" ] \
+    || die "local-only completion requires a clean worktree"
+  BRANCH=$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null) \
+    || die "local-only completion requires task branch fm/$ID, not detached HEAD"
+  [ "$BRANCH" = "fm/$ID" ] || die "local-only completion requires task branch fm/$ID, found $BRANCH"
+fi
+if [ -n "$PR_URL" ]; then
+  fm_pr_url_parse "$PR_URL" || die "--pr must be a canonical supported PR or MR URL"
+  PR_URL=$FM_PR_URL
+fi
+
+LOCK=$(fm_meta_lock_path "$META") || die "cannot resolve metadata lock for $ID"
+fm_lock_acquire_wait "$LOCK"
+LOCK_HELD=1
+cleanup() {
+  local rc=$?
+  [ "${LOCK_HELD:-0}" -eq 0 ] || fm_lock_release "$LOCK"
+  [ -z "${TMP:-}" ] || rm -f "$TMP" 2>/dev/null || true
+  exit "$rc"
+}
+trap cleanup EXIT INT TERM
+CURRENT_GEN=$(fm_backend_meta_exact_value "$META" spawn_gen) || die "task $ID has no exact spawn generation"
+[ "$CURRENT_GEN" = "$SPAWN_GEN" ] || die "stale spawn generation for $ID (receipt rejected)"
+
+DEST="$STATE/$ID.completion-receipt"
+TMP="$STATE/.$ID.completion-receipt.${BASHPID:-$$}"
+OLD_UMASK=$(umask)
+umask 077
+{
+  printf 'schema=%s\n' "$FM_COMPLETION_SCHEMA"
+  printf 'task_id=%s\n' "$ID"
+  printf 'spawn_gen=%s\n' "$SPAWN_GEN"
+  printf 'kind=%s\n' "$KIND"
+  printf 'mode=%s\n' "$MODE"
+  printf 'outcome=%s\n' "$OUTCOME"
+  printf 'artifact_path=%s\n' "$ARTIFACT"
+  printf 'worktree_head=%s\n' "$HEAD"
+  printf 'created_epoch=%s\n' "$(date +%s)"
+  [ -z "$PR_URL" ] || printf 'pr_url=%s\n' "$PR_URL"
+} > "$TMP" || die "could not write completion receipt temporary file"
+umask "$OLD_UMASK"
+fm_completion_receipt_load "$TMP" "$ID" "$SPAWN_GEN" || die "generated completion receipt failed schema validation"
+if [ -e "$DEST" ] || [ -L "$DEST" ]; then
+  fm_completion_receipt_load "$DEST" || die "existing completion receipt is malformed; refusing to replace it"
+  if [ "$FM_COMPLETION_SPAWN_GEN" = "$SPAWN_GEN" ]; then
+    cmp -s <(grep -v '^created_epoch=' "$DEST") <(grep -v '^created_epoch=' "$TMP") \
+      || die "current incarnation already has a different completion receipt"
+    rm -f "$TMP"
+    TMP=
+  fi
+fi
+if [ -n "$TMP" ]; then
+  mv -f "$TMP" "$DEST" || die "could not atomically publish completion receipt"
+  TMP=
+fi
+fm_lock_release "$LOCK"
+LOCK_HELD=0
+trap - EXIT INT TERM
+
+STATUS_LINE="$OUTCOME: $SUMMARY"
+if [ "$(tail -n 1 "$STATE/$ID.status" 2>/dev/null || true)" != "$STATUS_LINE" ]; then
+  printf '%s\n' "$STATUS_LINE" >> "$STATE/$ID.status" || die "receipt published but legacy status append failed"
+fi
+FM_SHADOW_TRIGGER=completion "$SCRIPT_DIR/fm-completion-shadow.sh" record "$ID" >/dev/null 2>&1 || true
+printf '%s\n' "$DEST"

--- a/bin/fm-completion-lib.sh
+++ b/bin/fm-completion-lib.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Shared schema and identity helpers for observation-only crew completion data.
+#
+# The two fixed-path receipts are independent signals:
+#
+#   state/<id>.completion-receipt
+#   state/<id>.process-exit-receipt
+#
+# A completion receipt records worker intent and observable artifact identity.
+# A process-exit receipt records only the exact harness child's lifetime result.
+# Neither receipt is landing proof, merge authority, cleanup eligibility, or
+# permission to call fm-teardown.sh. Git cleanliness, forge state, and teardown's
+# landed-work proof remain separate contracts owned by their existing scripts.
+#
+# Both schemas are strict line-oriented key/value records. Writers publish with
+# a private temporary file plus rename while holding the task metadata lock.
+# Readers must validate the schema and compare spawn_gen with current metadata;
+# a syntactically valid receipt from another incarnation is stale, not current.
+
+FM_COMPLETION_SCHEMA=fm-completion-receipt.v1
+FM_PROCESS_EXIT_SCHEMA=fm-process-exit-receipt.v1
+
+fm_completion_token_valid() {
+  local value=${1-}
+  case "$value" in
+    ''|*[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+}
+
+fm_completion_field() {  # <file> <key>
+  local file=$1 key=$2
+  grep "^$key=" "$file" 2>/dev/null | cut -d= -f2-
+}
+
+fm_completion_schema_shape_valid() {  # <file> <type>
+  local file=$1 type=$2
+  [ -f "$file" ] && [ ! -L "$file" ] || return 1
+  case "$type" in
+    completion)
+      awk -F= '
+        BEGIN {
+          split("schema task_id spawn_gen kind mode outcome artifact_path worktree_head created_epoch pr_url", allowed, " ")
+          for (i in allowed) known[allowed[i]] = 1
+        }
+        !($1 in known) { bad = 1 }
+        { count[$1]++ }
+        END {
+          required = "schema task_id spawn_gen kind mode outcome artifact_path worktree_head created_epoch"
+          n = split(required, keys, " ")
+          for (i = 1; i <= n; i++) if (count[keys[i]] != 1) bad = 1
+          if (count["pr_url"] > 1) bad = 1
+          exit bad
+        }
+      ' "$file"
+      ;;
+    process-exit)
+      awk -F= '
+        BEGIN {
+          required = "schema task_id spawn_gen harness backend process_pid process_identity exit_epoch wait_status"
+          n = split(required, keys, " ")
+          for (i = 1; i <= n; i++) known[keys[i]] = 1
+        }
+        !($1 in known) { bad = 1 }
+        { count[$1]++ }
+        END {
+          for (i = 1; i <= n; i++) if (count[keys[i]] != 1) bad = 1
+          exit bad
+        }
+      ' "$file"
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+fm_completion_receipt_load() {  # <file> [expected-task] [expected-spawn-gen]
+  local file=$1 expected_task=${2-} expected_spawn=${3-}
+  fm_completion_schema_shape_valid "$file" completion || return 1
+  FM_COMPLETION_TASK_ID=$(fm_completion_field "$file" task_id) || return 1
+  FM_COMPLETION_SPAWN_GEN=$(fm_completion_field "$file" spawn_gen) || return 1
+  FM_COMPLETION_KIND=$(fm_completion_field "$file" kind) || return 1
+  FM_COMPLETION_MODE=$(fm_completion_field "$file" mode) || return 1
+  FM_COMPLETION_OUTCOME=$(fm_completion_field "$file" outcome) || return 1
+  FM_COMPLETION_ARTIFACT_PATH=$(fm_completion_field "$file" artifact_path) || return 1
+  FM_COMPLETION_WORKTREE_HEAD=$(fm_completion_field "$file" worktree_head) || return 1
+  FM_COMPLETION_CREATED_EPOCH=$(fm_completion_field "$file" created_epoch) || return 1
+  FM_COMPLETION_PR_URL=$(fm_completion_field "$file" pr_url 2>/dev/null || true)
+  [ "$(fm_completion_field "$file" schema)" = "$FM_COMPLETION_SCHEMA" ] || return 1
+  fm_completion_token_valid "$FM_COMPLETION_TASK_ID" || return 1
+  fm_completion_token_valid "$FM_COMPLETION_SPAWN_GEN" || return 1
+  case "$FM_COMPLETION_KIND:$FM_COMPLETION_MODE" in
+    scout:scout|ship:no-mistakes|ship:direct-PR|ship:local-only) : ;;
+    *) return 1 ;;
+  esac
+  case "$FM_COMPLETION_OUTCOME" in done|failed) : ;; *) return 1 ;; esac
+  case "$FM_COMPLETION_CREATED_EPOCH" in ''|*[!0-9]*) return 1 ;; esac
+  fm_pr_head_valid "$FM_COMPLETION_WORKTREE_HEAD" || return 1
+  if [ "$FM_COMPLETION_KIND" = scout ]; then
+    [ -n "$FM_COMPLETION_ARTIFACT_PATH" ] || return 1
+  fi
+  case "$FM_COMPLETION_ARTIFACT_PATH" in *$'\n'*|*$'\r'*) return 1 ;; esac
+  if [ -n "$FM_COMPLETION_PR_URL" ]; then
+    fm_pr_url_parse "$FM_COMPLETION_PR_URL" || return 1
+    [ "$FM_PR_URL" = "$FM_COMPLETION_PR_URL" ] || return 1
+  fi
+  [ -z "$expected_task" ] || [ "$FM_COMPLETION_TASK_ID" = "$expected_task" ] || return 1
+  [ -z "$expected_spawn" ] || [ "$FM_COMPLETION_SPAWN_GEN" = "$expected_spawn" ] || return 1
+}
+
+fm_process_exit_receipt_load() {  # <file> [expected-task] [expected-spawn-gen]
+  local file=$1 expected_task=${2-} expected_spawn=${3-}
+  fm_completion_schema_shape_valid "$file" process-exit || return 1
+  FM_PROCESS_EXIT_TASK_ID=$(fm_completion_field "$file" task_id) || return 1
+  FM_PROCESS_EXIT_SPAWN_GEN=$(fm_completion_field "$file" spawn_gen) || return 1
+  FM_PROCESS_EXIT_HARNESS=$(fm_completion_field "$file" harness) || return 1
+  FM_PROCESS_EXIT_BACKEND=$(fm_completion_field "$file" backend) || return 1
+  FM_PROCESS_EXIT_PID=$(fm_completion_field "$file" process_pid) || return 1
+  FM_PROCESS_EXIT_IDENTITY=$(fm_completion_field "$file" process_identity) || return 1
+  FM_PROCESS_EXIT_EPOCH=$(fm_completion_field "$file" exit_epoch) || return 1
+  FM_PROCESS_EXIT_WAIT_STATUS=$(fm_completion_field "$file" wait_status) || return 1
+  [ "$(fm_completion_field "$file" schema)" = "$FM_PROCESS_EXIT_SCHEMA" ] || return 1
+  fm_completion_token_valid "$FM_PROCESS_EXIT_TASK_ID" || return 1
+  fm_completion_token_valid "$FM_PROCESS_EXIT_SPAWN_GEN" || return 1
+  case "$FM_PROCESS_EXIT_HARNESS" in claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse) : ;; *) return 1 ;; esac
+  case "$FM_PROCESS_EXIT_BACKEND" in tmux|herdr|zellij|orca|cmux) : ;; *) return 1 ;; esac
+  case "$FM_PROCESS_EXIT_PID" in ''|*[!0-9]*) return 1 ;; esac
+  case "$FM_PROCESS_EXIT_IDENTITY" in ''|*[!0-9a-f]*) return 1 ;; esac
+  [ $(( ${#FM_PROCESS_EXIT_IDENTITY} % 2 )) -eq 0 ] || return 1
+  case "$FM_PROCESS_EXIT_EPOCH" in ''|*[!0-9]*) return 1 ;; esac
+  case "$FM_PROCESS_EXIT_WAIT_STATUS" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$FM_PROCESS_EXIT_WAIT_STATUS" -le 255 ] || return 1
+  [ -z "$expected_task" ] || [ "$FM_PROCESS_EXIT_TASK_ID" = "$expected_task" ] || return 1
+  [ -z "$expected_spawn" ] || [ "$FM_PROCESS_EXIT_SPAWN_GEN" = "$expected_spawn" ] || return 1
+}
+
+fm_completion_process_identity() {  # <pid>
+  local pid=$1 proc_root stat_line starttime value raw
+  local -a stat_fields
+  case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+  proc_root=${FM_PROC_ROOT_OVERRIDE:-/proc}
+  if [ -r "$proc_root/$pid/stat" ]; then
+    stat_line=$(cat "$proc_root/$pid/stat" 2>/dev/null) || return 1
+    read -r -a stat_fields <<< "${stat_line##*)}"
+    [ "${#stat_fields[@]}" -ge 20 ] || return 1
+    starttime=${stat_fields[19]}
+    case "$starttime" in ''|*[!0-9]*) return 1 ;; esac
+    raw="starttime=$starttime"
+  else
+    value=$(LC_ALL=C ps -p "$pid" -o lstart= 2>/dev/null) || return 1
+    value=$(printf '%s' "$value" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    [ -n "$value" ] || return 1
+    raw="lstart=$value"
+  fi
+  printf '%s' "$raw" | od -An -v -tx1 | tr -d '[:space:]'
+}

--- a/bin/fm-completion-shadow.sh
+++ b/bin/fm-completion-shadow.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Record and read observation-only comparisons between current crew state and
+# completion/process-exit receipts.
+#
+# Usage:
+#   fm-completion-shadow.sh record <task-id>
+#   fm-completion-shadow.sh read [<task-id>] [--disagreements]
+#
+# `read` is the documented inspection path. Each ledger row names the harness,
+# backend, trigger, independently validated completion and process observations,
+# shadow verdict, current fm-crew-state verdict, and match/different result.
+# Recording and reading are inert: this script never invokes lifecycle control,
+# forge mutation, merge, teardown, or cleanup.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-backend.sh
+. "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-completion-lib.sh
+. "$SCRIPT_DIR/fm-completion-lib.sh"
+
+usage() { sed -n '2,${/^#/!q;p;}' "$0" | sed 's/^# \{0,1\}//' >&2; exit 2; }
+
+CMD=${1:-}
+case "$CMD" in record|read) shift ;; *) usage ;; esac
+
+if [ "$CMD" = read ]; then
+  ID=
+  DISAGREEMENTS=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --disagreements) DISAGREEMENTS=1 ;;
+      -h|--help) usage ;;
+      *) [ -z "$ID" ] || usage; ID=$1 ;;
+    esac
+    shift
+  done
+  if [ -n "$ID" ]; then
+    fm_pr_task_id_valid "$ID" || usage
+    FILES=("$STATE/$ID.completion-shadow")
+  else
+    FILES=("$STATE"/*.completion-shadow)
+  fi
+  for file in "${FILES[@]}"; do
+    [ -f "$file" ] || continue
+    if [ "$DISAGREEMENTS" -eq 1 ]; then
+      grep ' comparison=different$' "$file" 2>/dev/null || true
+    else
+      cat "$file"
+    fi
+  done
+  exit 0
+fi
+
+ID=${1:-}
+[ $# -eq 1 ] || usage
+fm_pr_task_id_valid "$ID" || usage
+META="$STATE/$ID.meta"
+[ -f "$META" ] || exit 1
+KIND=$(fm_meta_get "$META" kind)
+[ "$KIND" != secondmate ] || exit 0
+SPAWN_GEN=$(fm_backend_meta_exact_value "$META" spawn_gen) || exit 1
+HARNESS=$(fm_meta_get "$META" harness)
+BACKEND=$(fm_backend_of_meta "$META")
+case "$HARNESS" in claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse) : ;; *) HARNESS=unknown ;; esac
+case "$BACKEND" in tmux|herdr|zellij|orca|cmux) : ;; *) BACKEND=unknown ;; esac
+
+COMPLETION=absent
+COMPLETION_OUTCOME=
+if [ -e "$STATE/$ID.completion-receipt" ] || [ -L "$STATE/$ID.completion-receipt" ]; then
+  if fm_completion_receipt_load "$STATE/$ID.completion-receipt" "$ID" "$SPAWN_GEN"; then
+    COMPLETION=$FM_COMPLETION_OUTCOME
+    COMPLETION_OUTCOME=$FM_COMPLETION_OUTCOME
+  else
+    COMPLETION=invalid-or-stale
+  fi
+fi
+PROCESS=absent
+if [ -e "$STATE/$ID.process-exit-receipt" ] || [ -L "$STATE/$ID.process-exit-receipt" ]; then
+  if fm_process_exit_receipt_load "$STATE/$ID.process-exit-receipt" "$ID" "$SPAWN_GEN"; then
+    if [ "$FM_PROCESS_EXIT_WAIT_STATUS" -eq 0 ]; then PROCESS=exited-zero; else PROCESS=exited-nonzero; fi
+  else
+    PROCESS=invalid-or-stale
+  fi
+fi
+
+if [ "$PROCESS" = exited-zero ] || [ "$PROCESS" = exited-nonzero ]; then
+  if [ "$COMPLETION" = done ] || [ "$COMPLETION" = failed ]; then
+    SHADOW=worker-stopped
+  else
+    SHADOW=abnormal-exit
+  fi
+elif [ "$COMPLETION" = done ] || [ "$COMPLETION" = failed ]; then
+  SHADOW=ready
+else
+  SHADOW=running
+fi
+
+CREW_STATE_BIN=${FM_SHADOW_CREW_STATE_BIN:-$SCRIPT_DIR/fm-crew-state.sh}
+CURRENT_OUT=$(FM_CREW_STATE_NM_TIMEOUT=${FM_SHADOW_NM_TIMEOUT:-1} "$CREW_STATE_BIN" "$ID" 2>/dev/null || true)
+CURRENT=$(printf '%s\n' "$CURRENT_OUT" | sed -n 's/^state: \([^ ·][^ ·]*\).*/\1/p' | head -n 1)
+case "$CURRENT" in working|parked|done|blocked|paused|failed|unknown) : ;; *) CURRENT=unavailable ;; esac
+COMPARISON=no-comparison
+if [ -n "$COMPLETION_OUTCOME" ]; then
+  if [ "$CURRENT" = "$COMPLETION_OUTCOME" ]; then COMPARISON=match; else COMPARISON=different; fi
+elif [ "$SHADOW" = abnormal-exit ]; then
+  COMPARISON=different
+fi
+
+TRIGGER=${FM_SHADOW_TRIGGER:-manual}
+case "$TRIGGER" in completion|process-exit|manual) : ;; *) TRIGGER=manual ;; esac
+LINE="v1 epoch=$(date +%s) task=$ID spawn_gen=$SPAWN_GEN harness=$HARNESS backend=$BACKEND trigger=$TRIGGER completion=$COMPLETION process=$PROCESS shadow=$SHADOW current=$CURRENT comparison=$COMPARISON"
+DEST="$STATE/$ID.completion-shadow"
+LOCK="$DEST.lock"
+fm_lock_acquire_wait "$LOCK"
+OLD_UMASK=$(umask)
+umask 077
+printf '%s\n' "$LINE" >> "$DEST"
+umask "$OLD_UMASK"
+fm_lock_release "$LOCK"

--- a/bin/fm-completion-shadow.sh
+++ b/bin/fm-completion-shadow.sh
@@ -93,12 +93,12 @@ if [ -e "$STATE/$ID.process-exit-receipt" ] || [ -L "$STATE/$ID.process-exit-rec
 fi
 
 if [ "$PROCESS" = exited-zero ] || [ "$PROCESS" = exited-nonzero ]; then
-  if [ "$COMPLETION" = done ] || [ "$COMPLETION" = failed ]; then
+  if [ "$COMPLETION" = "done" ] || [ "$COMPLETION" = "failed" ]; then
     SHADOW=worker-stopped
   else
     SHADOW=abnormal-exit
   fi
-elif [ "$COMPLETION" = done ] || [ "$COMPLETION" = failed ]; then
+elif [ "$COMPLETION" = "done" ] || [ "$COMPLETION" = "failed" ]; then
   SHADOW=ready
 else
   SHADOW=running

--- a/bin/fm-harness-run.sh
+++ b/bin/fm-harness-run.sh
@@ -54,16 +54,16 @@ case "$BACKEND" in tmux|herdr|zellij|orca|cmux) : ;; *) usage ;; esac
 META="$STATE/$ID.meta"
 START_RECORD="$STATE/.$ID.process-start.${BASHPID:-$$}"
 rm -f "$START_RECORD" 2>/dev/null || true
-OLD_UMASK=$(umask)
-umask 077
 (
+  SUB_OLD_UMASK=$(umask)
+  umask 077
   CHILD_SELF=${BASHPID:-$$}
   CHILD_IDENTITY=$(fm_completion_process_identity "$CHILD_SELF" 2>/dev/null || true)
   printf 'pid=%s\nidentity=%s\n' "$CHILD_SELF" "$CHILD_IDENTITY" > "$START_RECORD"
+  umask "$SUB_OLD_UMASK"
   exec "$@"
 ) <&0 &
 CHILD_PID=$!
-umask "$OLD_UMASK"
 
 i=0
 while [ ! -f "$START_RECORD" ] && [ "$i" -lt 100 ]; do

--- a/bin/fm-harness-run.sh
+++ b/bin/fm-harness-run.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Run one supported ordinary harness as the exact child of an observation-only
+# wait wrapper, then atomically publish the kernel-derived shell wait status.
+#
+# Usage:
+#   fm-harness-run.sh --task <id> --spawn-gen <gen> --harness <name>
+#     --backend <name> -- <harness-command> [args...]
+#
+# fm-spawn.sh places this wrapper immediately around the real harness executable
+# for ordinary ship/scout workers on every backend. The child keeps the pane's
+# stdin, stdout, stderr, process group, and terminal. The wrapper never interprets
+# exit as task completion and never calls control, merge, teardown, or cleanup.
+# Receipt publication failure is a warning only and never changes the child's
+# exit status, preserving the pre-observation launch behavior.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-backend.sh
+. "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-completion-lib.sh
+. "$SCRIPT_DIR/fm-completion-lib.sh"
+
+usage() { sed -n '2,${/^#/!q;p;}' "$0" | sed 's/^# \{0,1\}//' >&2; exit 2; }
+
+ID=
+SPAWN_GEN=
+HARNESS=
+BACKEND=
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --task) ID=${2-}; shift 2 || usage ;;
+    --spawn-gen) SPAWN_GEN=${2-}; shift 2 || usage ;;
+    --harness) HARNESS=${2-}; shift 2 || usage ;;
+    --backend) BACKEND=${2-}; shift 2 || usage ;;
+    --) shift; break ;;
+    -h|--help) usage ;;
+    *) usage ;;
+  esac
+done
+[ $# -gt 0 ] || usage
+fm_pr_task_id_valid "$ID" || usage
+fm_completion_token_valid "$SPAWN_GEN" || usage
+case "$HARNESS" in claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse) : ;; *) usage ;; esac
+case "$BACKEND" in tmux|herdr|zellij|orca|cmux) : ;; *) usage ;; esac
+
+META="$STATE/$ID.meta"
+START_RECORD="$STATE/.$ID.process-start.${BASHPID:-$$}"
+rm -f "$START_RECORD" 2>/dev/null || true
+OLD_UMASK=$(umask)
+umask 077
+(
+  CHILD_SELF=${BASHPID:-$$}
+  CHILD_IDENTITY=$(fm_completion_process_identity "$CHILD_SELF" 2>/dev/null || true)
+  printf 'pid=%s\nidentity=%s\n' "$CHILD_SELF" "$CHILD_IDENTITY" > "$START_RECORD"
+  exec "$@"
+) <&0 &
+CHILD_PID=$!
+umask "$OLD_UMASK"
+
+i=0
+while [ ! -f "$START_RECORD" ] && [ "$i" -lt 100 ]; do
+  kill -0 "$CHILD_PID" 2>/dev/null || break
+  sleep 0.01
+  i=$((i + 1))
+done
+PROCESS_IDENTITY=$(sed -n 's/^identity=//p' "$START_RECORD" 2>/dev/null | head -n 1 || true)
+
+set +e
+wait "$CHILD_PID"
+WAIT_STATUS=$?
+set -e
+EXIT_EPOCH=$(date +%s)
+rm -f "$START_RECORD" 2>/dev/null || true
+
+publish_exit_receipt() {
+  local lock current dest tmp old_umask
+  [ -n "$PROCESS_IDENTITY" ] || return 1
+  [ -f "$META" ] || return 1
+  [ "$(fm_backend_meta_exact_value "$META" kind 2>/dev/null)" != secondmate ] || return 1
+  lock=$(fm_meta_lock_path "$META") || return 1
+  fm_lock_acquire_wait "$lock"
+  current=$(fm_backend_meta_exact_value "$META" spawn_gen 2>/dev/null) || {
+    fm_lock_release "$lock"
+    return 1
+  }
+  if [ "$current" != "$SPAWN_GEN" ]; then
+    fm_lock_release "$lock"
+    return 1
+  fi
+  dest="$STATE/$ID.process-exit-receipt"
+  tmp="$STATE/.$ID.process-exit-receipt.${BASHPID:-$$}"
+  old_umask=$(umask)
+  umask 077
+  {
+    printf 'schema=%s\n' "$FM_PROCESS_EXIT_SCHEMA"
+    printf 'task_id=%s\n' "$ID"
+    printf 'spawn_gen=%s\n' "$SPAWN_GEN"
+    printf 'harness=%s\n' "$HARNESS"
+    printf 'backend=%s\n' "$BACKEND"
+    printf 'process_pid=%s\n' "$CHILD_PID"
+    printf 'process_identity=%s\n' "$PROCESS_IDENTITY"
+    printf 'exit_epoch=%s\n' "$EXIT_EPOCH"
+    printf 'wait_status=%s\n' "$WAIT_STATUS"
+  } > "$tmp" || {
+    umask "$old_umask"
+    rm -f "$tmp"
+    fm_lock_release "$lock"
+    return 1
+  }
+  umask "$old_umask"
+  fm_process_exit_receipt_load "$tmp" "$ID" "$SPAWN_GEN" || {
+    rm -f "$tmp"
+    fm_lock_release "$lock"
+    return 1
+  }
+  if [ -e "$dest" ] || [ -L "$dest" ]; then
+    if ! fm_process_exit_receipt_load "$dest"; then
+      rm -f "$tmp"
+      fm_lock_release "$lock"
+      return 1
+    fi
+    if [ "$FM_PROCESS_EXIT_SPAWN_GEN" = "$SPAWN_GEN" ]; then
+      if ! cmp -s "$dest" "$tmp"; then
+        rm -f "$tmp"
+        fm_lock_release "$lock"
+        return 1
+      fi
+      rm -f "$tmp"
+      fm_lock_release "$lock"
+      return 0
+    fi
+  fi
+  mv -f "$tmp" "$dest" || {
+    rm -f "$tmp"
+    fm_lock_release "$lock"
+    return 1
+  }
+  fm_lock_release "$lock"
+}
+
+if ! publish_exit_receipt; then
+  printf 'warning: process-exit receipt was not published for %s spawn %s\n' "$ID" "$SPAWN_GEN" >&2
+else
+  FM_SHADOW_TRIGGER=process-exit "$SCRIPT_DIR/fm-completion-shadow.sh" record "$ID" >/dev/null 2>&1 || true
+fi
+exit "$WAIT_STATUS"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -161,6 +161,8 @@
 #     __OPINPUT__   absolute path to the canonical operational-input encoder
 #     __WORKTREE__  absolute path to the task worktree
 #     __CURSORBIN__ resolved, cursor-verified executable for a cursor launch
+#     __RUNNER__    observation-only exact-child wait wrapper for ordinary
+#                   supported harnesses; empty for persistent secondmates
 # Verified per-harness turn-end hooks are installed automatically where enabled; some live outside the worktree.
 # Kimi uses one surgically installed Firstmate region in $HOME/.kimi-code/config.toml,
 # a firstmate-owned global hook and registry, and a gitignored per-task pointer.
@@ -1111,17 +1113,17 @@ launch_template() {
     # does NOT suppress the interactive ghost text (verified empirically), so the env
     # var is the correct control. The dim-aware composer reader in fm-tmux-lib.sh is
     # the defense-in-depth backstop for any pane this flag cannot reach.
-    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false __RUNNER__claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     codex)
       if [ "$kind" = secondmate ]; then
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' '__RUNNER__codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       else
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' '__RUNNER__codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       fi
       ;;
-    opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' __RUNNER__opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     pi|pi-signed)
-      printf '%s' '__PIBIN____PITUIMODE__'
+      printf '%s' '__RUNNER____PIBIN____PITUIMODE__'
       if [ "$kind" = secondmate ]; then
         printf '%s' ' __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       else
@@ -1135,7 +1137,7 @@ launch_template() {
     # --dangerously-skip-permissions. grok's turn-end signal does NOT ride the
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
-    grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    grok) printf '%s' '__RUNNER__grok --always-approve __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     # Cursor Agent CLI. --trust suppresses the workspace-trust prompt, which
     # --yolo does NOT cover and which would otherwise block every spawn, since
     # each task gets a fresh worktree path cursor has never seen. --yolo is the
@@ -1148,12 +1150,12 @@ launch_template() {
     # inherited CLAUDECODE cannot outrank cursor's own marker in a process that
     # only reads the environment. Cursor exposes no effort flag, so the shared
     # effort axis is deliberately omitted and stays in task metadata only.
-    cursor) printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS -u CURSOR_INVOKED_AS __CURSORBIN__ --trust --yolo __MODELFLAG__--workspace __WORKTREE__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    cursor) printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS -u CURSOR_INVOKED_AS __RUNNER____CURSORBIN__ --trust --yolo __MODELFLAG__--workspace __WORKTREE__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     # Kimi Code rejects a positional prompt, so it launches bare and receives
     # only an absolute brief pointer after the TUI readiness gate below.
     # Its turn-end signal is a globally configured Stop hook plus a guarded
     # per-task worktree token, so no launch placeholder belongs here.
-    kimi) printf '%s' '__KIMIBIN__ __MODELFLAG__--auto' ;;
+    kimi) printf '%s' '__RUNNER____KIMIBIN__ __MODELFLAG__--auto' ;;
     # muse (Muse Code): a positional prompt starts the supervised interactive
     # session. --yolo is the single flag that makes a crewmate pane viable: muse
     # ships approval prompts AND a filesystem/network sandbox ON by default
@@ -1175,7 +1177,7 @@ launch_template() {
     # session event log instead (bin/fm-busy-lib.sh), bound by the sidecar
     # written below. Nothing to place in the template for it.
     # codex, opencode, and kimi are also markerless and share this inherited-marker hazard; changing their verified launch boundaries belongs in follow-up work.
-    muse) printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS XDG_CONFIG_HOME=__MUSECONFIG__ XDG_DATA_HOME=__MUSEDATA__ MUSE_EXPERIMENTAL_FOREIGN_PERSONAL_CONTEXT_KILL=on __MUSEBIN__ --yolo __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    muse) printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS XDG_CONFIG_HOME=__MUSECONFIG__ XDG_DATA_HOME=__MUSEDATA__ MUSE_EXPERIMENTAL_FOREIGN_PERSONAL_CONTEXT_KILL=on __RUNNER____MUSEBIN__ --yolo __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     *) return 1 ;;
   esac
 }
@@ -2712,10 +2714,19 @@ sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
 sq_worktree=$(shell_quote "$WT")
+RUNNER=
+if [ "$KIND" != secondmate ]; then
+  case "$HARNESS" in
+    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse)
+      RUNNER="FM_HOME=$(shell_quote "$FM_HOME") FM_STATE_OVERRIDE=$(shell_quote "$STATE") FM_TASK_ID=$(shell_quote "$ID") FM_SPAWN_GEN=$(shell_quote "$SPAWN_GEN") $(shell_quote "$FM_ROOT/bin/fm-harness-run.sh") --task $(shell_quote "$ID") --spawn-gen $(shell_quote "$SPAWN_GEN") --harness $(shell_quote "$HARNESS") --backend $(shell_quote "$BACKEND") -- "
+      ;;
+  esac
+fi
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
 LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
+LAUNCH=${LAUNCH//__RUNNER__/$RUNNER}
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}
 LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}

--- a/bin/fm-test-isolation-proof.sh
+++ b/bin/fm-test-isolation-proof.sh
@@ -99,6 +99,9 @@ exclusion_reason() {
     fm-spawn-dispatch-profile.test.sh|fm-spawn-worktree-settle.test.sh|fm-trace-context-spawn.test.sh)
       printf '%s\n' 'real isolated git worktrees plus spawn settle loops; gray zone until dedicated proof'
       ;;
+    fm-completion-receipt.test.sh)
+      printf '%s\n' 'real process-signal waits plus isolated git fixtures; keep serial until dedicated proof'
+      ;;
     fm-pr-check-security.test.sh)
       printf '%s\n' 'watcher lock / migration / poll security surface; intentional shared-lock class'
       ;;
@@ -189,6 +192,7 @@ list_exclusions_for_report() {
 fm-test-isolation-proof.test.sh
 fm-backend-tmux-smoke.test.sh
 fm-backend.test.sh
+fm-completion-receipt.test.sh
 fm-spawn-dispatch-profile.test.sh
 fm-spawn-worktree-settle.test.sh
 fm-trace-context-spawn.test.sh

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -197,6 +197,7 @@ family_for_basename() {
     fm-backend-herdr.test.sh|fm-backend-tmux-smoke.test.sh|fm-backend.test.sh|\
     fm-tmux-agent-liveness.test.sh|\
     fm-control.test.sh|fm-control-relaunch.test.sh|\
+    fm-completion-receipt.test.sh|\
     fm-herdr-session-cleanup.test.sh|fm-send-resolve-key.test.sh|fm-send-strict.test.sh|fm-spawn-batch.test.sh|\
     fm-spawn-dispatch-profile.test.sh|\
     fm-trace-context-spawn.test.sh|fm-spawn-worktree-settle.test.sh|\
@@ -409,6 +410,7 @@ tests/fm-grok-stop-live-e2e.test.sh 19
 tests/fm-guard-stale-banner.test.sh 2917
 tests/fm-herdr-session-cleanup.test.sh 4802
 tests/fm-kimi-harness.test.sh 12590
+tests/fm-completion-receipt.test.sh 16000
 tests/fm-opencode-primary-live-e2e.test.sh 18
 tests/fm-operational-input.test.sh 184
 tests/fm-pending-reply.test.sh 7328
@@ -881,6 +883,9 @@ families_for_changed_path() {
     bin/fm-backend.sh|bin/fm-backend-hometag-lib.sh)
       printf '%s\n' backend-dispatch
       printf '%s\n' real-herdr-gated
+      ;;
+    bin/fm-complete.sh|bin/fm-completion-lib.sh|bin/fm-completion-shadow.sh|bin/fm-harness-run.sh)
+      printf '%s\n' backend-dispatch
       ;;
     bin/fm-watch*|bin/fm-wake*|bin/fm-inactive-reconcile.sh|\
     bin/fm-classify-lib.sh|bin/fm-daemon*|bin/fm-turnend-guard*|bin/fm-guard.sh)

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -50,6 +50,10 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-remote-readiness-lib.sh` | Shared remote second-mate readiness gate: check and, when needed, repair then re-check through `fm-remote-doctor.sh` |
 | [`fm-project-origin-lib.sh`](../bin/fm-project-origin-lib.sh) | Accepted origin-form owner shared by both remote provisioning boundaries |
 | `fm-spawn.sh`            | Spawn crewmates, scouts, `id=repo` batches, and secondmates on the resolved harness and runtime backend |
+| `fm-harness-run.sh`      | Wait for one exact ordinary harness child and publish its observation-only process-exit receipt |
+| `fm-complete.sh`         | Publish a current-incarnation completion receipt and its migration-compatible status event |
+| `fm-completion-lib.sh`   | Validate completion and process-exit receipt schemas and process identities |
+| `fm-completion-shadow.sh` | Record and read per-harness, per-backend comparisons between receipts and current crew state |
 | `fm-backend.sh`          | Runtime-backend selection, meta helpers, selector resolution, and operation dispatch |
 | `fm-backend-hometag-lib.sh` | Shared per-installation home-tag derivation for zellij tab and cmux workspace titles |
 | `fm-composer-lib.sh`     | Single fleet-wide owner of composer shapes, capability-aware screen classification, and verdicts |

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -520,8 +520,10 @@ test_spawn_writes_orca_metadata_and_launches_harness() {
     "spawn should reuse the implicit terminal returned by Orca worktree creation"
   assert_contains "$(cat "$log")" $'orca\x1f''terminal'$'\x1f''send'$'\x1f''--terminal'$'\x1f''term-spawn'$'\x1f''--text'$'\x1f''export GOTMPDIR=/tmp/fm-orcaspawnz1/gotmp'$'\x1f''--enter'$'\x1f''--json' \
     "spawn did not export GOTMPDIR through the Orca terminal"
-  assert_contains "$(cat "$log")" "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions" \
-    "spawn did not send the selected harness launch command through Orca"
+  assert_contains "$(cat "$log")" "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false" \
+    "spawn did not disable the claude prompt-suggestion through Orca"
+  assert_contains "$(cat "$log")" "--harness 'claude' --backend 'orca' -- claude --dangerously-skip-permissions" \
+    "spawn did not place the selected harness behind the exit-receipt wrapper"
   rm -rf "/tmp/fm-$id"
   pass "fm-spawn.sh --backend orca: reuses implicit terminal, records metadata, launches harness"
 }

--- a/tests/fm-completion-receipt.test.sh
+++ b/tests/fm-completion-receipt.test.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+# Behavioral coverage for observation-only completion and exact-child exit receipts.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+COMPLETE="$ROOT/bin/fm-complete.sh"
+RUNNER="$ROOT/bin/fm-harness-run.sh"
+SHADOW="$ROOT/bin/fm-completion-shadow.sh"
+TMP_ROOT=$(fm_test_tmproot fm-completion-receipt)
+
+make_world() {  # <name> <id> <kind> <mode> [harness] [backend]
+  local name=$1 id=$2 kind=$3 mode=$4 harness=${5:-codex} backend=${6:-tmux}
+  WORLD="$TMP_ROOT/$name"
+  HOME_DIR="$WORLD/home"
+  WT="$WORLD/worktree"
+  mkdir -p "$HOME_DIR"/{state,data,config} "$HOME_DIR/data/$id"
+  fm_git_init_commit "$WT"
+  git -C "$WT" checkout -qb "fm/$id"
+  GEN="s-test-$name"
+  if [ "$backend" = tmux ]; then
+    fm_write_meta "$HOME_DIR/state/$id.meta" \
+      "window=firstmate:fm-$id" "endpoint_task_id=$id" "worktree=$WT" "project=$WT" \
+      "harness=$harness" "kind=$kind" "mode=$mode" "spawn_gen=$GEN"
+  else
+    fm_write_meta "$HOME_DIR/state/$id.meta" \
+      "window=opaque-$id" "endpoint_task_id=$id" "worktree=$WT" "project=$WT" \
+      "harness=$harness" "kind=$kind" "mode=$mode" "spawn_gen=$GEN" "backend=$backend"
+  fi
+  : > "$HOME_DIR/state/$id.status"
+  cat > "$WORLD/crew-state" <<'SH'
+#!/usr/bin/env bash
+printf 'state: %s · source: fake\n' "${FM_FAKE_CURRENT_STATE:-unknown}"
+SH
+  chmod +x "$WORLD/crew-state"
+}
+
+run_complete() {  # <id> <gen> <outcome> <summary> [extra...]
+  local id=$1 gen=$2 outcome=$3 summary=$4
+  shift 4
+  FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" \
+    FM_SHADOW_CREW_STATE_BIN="$WORLD/crew-state" \
+    "$COMPLETE" "$id" --spawn-gen "$gen" --outcome "$outcome" --summary "$summary" "$@"
+}
+
+run_runner() {  # <id> <gen> <harness> <backend> -- <command...>
+  FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" \
+    FM_SHADOW_CREW_STATE_BIN="$WORLD/crew-state" "$RUNNER" "$@"
+}
+
+test_completion_schema_and_dual_status() {
+  local id=receipt-schema-r1 receipt shadow
+  make_world schema "$id" ship no-mistakes
+  receipt=$(FM_FAKE_CURRENT_STATE=working run_complete "$id" "$GEN" done 'PR ready' --pr https://github.com/example/repo/pull/12)
+  [ "$receipt" = "$HOME_DIR/state/$id.completion-receipt" ] || fail "completion helper did not print its receipt path"
+  assert_grep 'schema=fm-completion-receipt.v1' "$receipt" "completion schema version missing"
+  assert_grep "task_id=$id" "$receipt" "completion receipt lost task identity"
+  assert_grep "spawn_gen=$GEN" "$receipt" "completion receipt lost incarnation identity"
+  assert_grep 'kind=ship' "$receipt" "completion receipt lost task kind"
+  assert_grep 'mode=no-mistakes' "$receipt" "completion receipt lost delivery mode"
+  assert_grep 'outcome=done' "$receipt" "completion receipt lost outcome"
+  assert_grep 'artifact_path=' "$receipt" "completion receipt did not retain an explicit empty artifact binding"
+  assert_grep "worktree_head=$(git -C "$WT" rev-parse HEAD)" "$receipt" "completion receipt lost exact HEAD"
+  assert_grep 'pr_url=https://github.com/example/repo/pull/12' "$receipt" "completion receipt lost canonical PR identity"
+  [ "$(cat "$HOME_DIR/state/$id.status")" = 'done: PR ready' ] || fail "completion helper did not dual-write the legacy status event"
+  shadow=$(cat "$HOME_DIR/state/$id.completion-shadow")
+  assert_contains "$shadow" "harness=codex backend=tmux trigger=completion completion=done" \
+    "completion shadow row did not carry harness/backend and receipt verdict"
+  assert_contains "$shadow" "shadow=ready current=working comparison=different" \
+    "completion shadow row did not preserve the current-system disagreement"
+  find "$HOME_DIR/state" -name ".$id.completion-receipt.*" -print | grep -q . \
+    && fail "completion publication left a temporary file"
+  pass "completion receipt is versioned, identity-bound, atomic, and status-compatible"
+}
+
+test_schema_validation_rejects_malformed_receipt() {
+  local id=receipt-invalid-r2
+  make_world invalid "$id" ship direct-PR
+  FM_FAKE_CURRENT_STATE=done run_complete "$id" "$GEN" done 'ready' >/dev/null
+  printf 'unknown_field=1\n' >> "$HOME_DIR/state/$id.completion-receipt"
+  FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" \
+    FM_SHADOW_CREW_STATE_BIN="$WORLD/crew-state" "$SHADOW" record "$id"
+  assert_contains "$(tail -n 1 "$HOME_DIR/state/$id.completion-shadow")" 'completion=invalid-or-stale' \
+    "shadow reader accepted a receipt outside the strict schema"
+  pass "completion reader rejects malformed schema instead of trusting it"
+}
+
+test_incarnation_binding_and_stale_rejection() {
+  local id=receipt-stale-r3 before out status
+  make_world stale "$id" ship direct-PR
+  run_complete "$id" "$GEN" done 'first incarnation' >/dev/null
+  before=$(cat "$HOME_DIR/state/$id.completion-receipt")
+  sed "s/^spawn_gen=.*/spawn_gen=s-new-incarnation/" "$HOME_DIR/state/$id.meta" > "$HOME_DIR/state/$id.meta.new"
+  mv "$HOME_DIR/state/$id.meta.new" "$HOME_DIR/state/$id.meta"
+  out=$(run_complete "$id" "$GEN" failed 'stale writer' 2>&1)
+  status=$?
+  expect_code 1 "$status" "stale completion writer must be refused"
+  assert_contains "$out" 'stale spawn generation' "stale completion refusal did not name the incarnation mismatch"
+  [ "$(cat "$HOME_DIR/state/$id.completion-receipt")" = "$before" ] || fail "stale writer replaced the prior receipt"
+
+  out=$(run_runner --task "$id" --spawn-gen "$GEN" --harness codex --backend tmux -- /bin/sh -c 'exit 0' 2>&1)
+  status=$?
+  expect_code 0 "$status" "receipt observation failure must not change a successful harness exit"
+  assert_contains "$out" 'process-exit receipt was not published' "stale process exit was not visibly rejected"
+  assert_absent "$HOME_DIR/state/$id.process-exit-receipt" "stale process exit published a receipt"
+  pass "both receipt writers reject a stale spawn incarnation"
+}
+
+test_investigation_requires_report_path() {
+  local id=receipt-scout-r4 out status report
+  make_world scout "$id" scout scout
+  out=$(run_complete "$id" "$GEN" done 'investigation complete' 2>&1)
+  status=$?
+  expect_code 1 "$status" "investigation completion without a report path must fail"
+  assert_contains "$out" 'investigation completion requires --artifact' "missing report refusal was not actionable"
+  assert_absent "$HOME_DIR/state/$id.completion-receipt" "report-less investigation published a receipt"
+  report="$HOME_DIR/data/$id/report.md"
+  printf '# report\n' > "$report"
+  run_complete "$id" "$GEN" done 'investigation complete' --artifact "$report" >/dev/null
+  report="$(cd "$(dirname "$report")" && pwd -P)/$(basename "$report")"
+  assert_grep "artifact_path=$report" "$HOME_DIR/state/$id.completion-receipt" \
+    "investigation receipt did not bind the report path"
+  pass "investigation receipts refuse a missing report path"
+}
+
+test_local_only_requires_clean_task_branch() {
+  local id=receipt-local-r5 out status
+  make_world local "$id" ship local-only
+  printf 'dirty\n' >> "$WT/README.md"
+  out=$(run_complete "$id" "$GEN" done 'ready in branch' 2>&1)
+  status=$?
+  expect_code 1 "$status" "dirty local-only worktree must be refused"
+  assert_contains "$out" 'requires a clean worktree' "dirty local-only refusal was not actionable"
+  git -C "$WT" checkout -- README.md
+  git -C "$WT" checkout -qb wrong-branch
+  out=$(run_complete "$id" "$GEN" done 'ready in branch' 2>&1)
+  status=$?
+  expect_code 1 "$status" "wrong local-only branch must be refused"
+  assert_contains "$out" "requires task branch fm/$id" "wrong-branch refusal did not name the task branch"
+  assert_absent "$HOME_DIR/state/$id.completion-receipt" "unsafe local-only state published a receipt"
+  pass "local-only receipt refuses dirty and wrong-branch worktrees"
+}
+
+test_process_exit_normal_and_killed() {
+  local id=receipt-exit-r6 status pidfile child wrapper i
+  make_world exit-normal "$id" ship direct-PR claude herdr
+  run_runner --task "$id" --spawn-gen "$GEN" --harness claude --backend herdr -- /bin/sh -c 'exit 0'
+  status=$?
+  expect_code 0 "$status" "normal harness exit status changed"
+  assert_grep 'schema=fm-process-exit-receipt.v1' "$HOME_DIR/state/$id.process-exit-receipt" \
+    "normal exit did not publish the process receipt schema"
+  assert_grep 'wait_status=0' "$HOME_DIR/state/$id.process-exit-receipt" \
+    "normal exit did not retain the kernel-derived wait status"
+  grep -Eq '^process_identity=[0-9a-f]+$' "$HOME_DIR/state/$id.process-exit-receipt" \
+    || fail "normal exit did not retain process incarnation identity"
+
+  id=receipt-killed-r7
+  make_world exit-killed "$id" ship direct-PR muse cmux
+  pidfile="$WORLD/child.pid"
+  run_runner --task "$id" --spawn-gen "$GEN" --harness muse --backend cmux -- \
+    /bin/sh -c 'printf "%s\n" "$$" > "$1"; while :; do sleep 1; done' _ "$pidfile" &
+  wrapper=$!
+  i=0
+  while [ ! -s "$pidfile" ] && [ "$i" -lt 100 ]; do sleep 0.02; i=$((i + 1)); done
+  [ -s "$pidfile" ] || fail "killed-process fixture did not publish its child pid"
+  child=$(cat "$pidfile")
+  kill -KILL "$child"
+  set +e
+  wait "$wrapper"
+  status=$?
+  set -e
+  expect_code 137 "$status" "killed harness wait status was not preserved"
+  assert_grep 'wait_status=137' "$HOME_DIR/state/$id.process-exit-receipt" \
+    "killed process receipt did not retain the wait status"
+  assert_grep "process_pid=$child" "$HOME_DIR/state/$id.process-exit-receipt" \
+    "killed process receipt did not name the exact harness child"
+  assert_contains "$(tail -n 1 "$HOME_DIR/state/$id.completion-shadow")" \
+    'harness=muse backend=cmux trigger=process-exit completion=absent process=exited-nonzero shadow=abnormal-exit' \
+    "killed child did not produce an inspectable abnormal-exit comparison"
+  find "$HOME_DIR/state" -name ".$id.process-exit-receipt.*" -print | grep -q . \
+    && fail "process-exit publication left a temporary file"
+  pass "exact-child exit receipts capture normal and killed wait statuses"
+}
+
+test_process_wrapper_preserves_child_io_and_status() {
+  local id=receipt-io-r7b out status
+  make_world process-io "$id" ship direct-PR opencode zellij
+  out=$(printf 'hello\n' | run_runner --task "$id" --spawn-gen "$GEN" --harness opencode --backend zellij -- \
+    /bin/sh -c 'IFS= read -r line; [ "$line" = hello ]; printf "child-output\n"')
+  status=$?
+  expect_code 0 "$status" "process wrapper changed child stdin or success status"
+  [ "$out" = child-output ] || fail "process wrapper changed child stdout"
+  assert_grep 'wait_status=0' "$HOME_DIR/state/$id.process-exit-receipt" \
+    "process wrapper did not publish the successful child status"
+  pass "process wrapper preserves the harness child I/O and exit status"
+}
+
+test_shadow_records_every_harness_and_backend_axis() {
+  local harness backend id rows
+  rows="$TMP_ROOT/shadow-axis.rows"
+  : > "$rows"
+  for harness in claude codex opencode pi pi-signed grok kimi cursor muse; do
+    for backend in tmux herdr zellij orca cmux; do
+      id="axis-${harness//[^A-Za-z0-9]/-}-$backend"
+      make_world "axis-$id" "$id" ship direct-PR "$harness" "$backend"
+      FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" \
+        FM_SHADOW_CREW_STATE_BIN="$WORLD/crew-state" "$SHADOW" record "$id"
+      tail -n 1 "$HOME_DIR/state/$id.completion-shadow" >> "$rows"
+    done
+  done
+  [ "$(wc -l < "$rows" | tr -d ' ')" -eq 45 ] || fail "shadow matrix did not record every harness/backend pair"
+  for harness in claude codex opencode pi pi-signed grok kimi cursor muse; do
+    assert_contains "$(cat "$rows")" "harness=$harness " "shadow matrix omitted harness $harness"
+  done
+  for backend in tmux herdr zellij orca cmux; do
+    assert_contains "$(cat "$rows")" "backend=$backend " "shadow matrix omitted backend $backend"
+  done
+  pass "shadow ledger records comparisons per supported harness and backend"
+}
+
+test_receipts_cannot_reach_cleanup() {
+  local id=receipt-no-cleanup-r8 trapbin
+  make_world no-cleanup "$id" ship direct-PR
+  trapbin="$WORLD/trapbin"
+  mkdir -p "$trapbin"
+  cat > "$trapbin/fm-teardown.sh" <<'SH'
+#!/usr/bin/env bash
+touch "${FM_CLEANUP_TRIPWIRE:?}"
+exit 99
+SH
+  chmod +x "$trapbin/fm-teardown.sh"
+  FM_CLEANUP_TRIPWIRE="$WORLD/cleanup-called" PATH="$trapbin:$PATH" \
+    FM_TEARDOWN_BIN="$trapbin/fm-teardown.sh" run_complete "$id" "$GEN" done 'ready' >/dev/null
+  FM_CLEANUP_TRIPWIRE="$WORLD/cleanup-called" PATH="$trapbin:$PATH" \
+    FM_TEARDOWN_BIN="$trapbin/fm-teardown.sh" \
+    run_runner --task "$id" --spawn-gen "$GEN" --harness codex --backend tmux -- /bin/sh -c 'exit 0'
+  assert_absent "$WORLD/cleanup-called" "a receipt path invoked teardown"
+  assert_present "$HOME_DIR/state/$id.meta" "receipt path removed task metadata"
+  [ -d "$WT" ] || fail "receipt path removed the worktree"
+  pass "completion and process-exit receipts expose no cleanup path"
+}
+
+test_shadow_read_interface_documents_disagreements() {
+  local id=receipt-read-r9 help out
+  make_world read "$id" ship direct-PR
+  FM_FAKE_CURRENT_STATE=working run_complete "$id" "$GEN" done 'ready' >/dev/null
+  out=$(FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" "$SHADOW" read "$id" --disagreements)
+  assert_contains "$out" 'comparison=different' "shadow read did not expose the disagreement"
+  help=$($SHADOW --help 2>&1 || true)
+  assert_contains "$help" 'fm-completion-shadow.sh read' "shadow helper help did not document the read interface"
+  pass "shadow comparisons have a documented disagreement reader"
+}
+
+test_completion_schema_and_dual_status
+test_schema_validation_rejects_malformed_receipt
+test_incarnation_binding_and_stale_rejection
+test_investigation_requires_report_path
+test_local_only_requires_clean_task_branch
+test_process_exit_normal_and_killed
+test_process_wrapper_preserves_child_io_and_status
+test_shadow_records_every_harness_and_backend_axis
+test_receipts_cannot_reach_cleanup
+test_shadow_read_interface_documents_disagreements
+
+echo "# all fm-completion-receipt tests passed"

--- a/tests/fm-completion-receipt.test.sh
+++ b/tests/fm-completion-receipt.test.sh
@@ -52,7 +52,7 @@ run_runner() {  # <id> <gen> <harness> <backend> -- <command...>
 test_completion_schema_and_dual_status() {
   local id=receipt-schema-r1 receipt shadow
   make_world schema "$id" ship no-mistakes
-  receipt=$(FM_FAKE_CURRENT_STATE=working run_complete "$id" "$GEN" done 'PR ready' --pr https://github.com/example/repo/pull/12)
+  receipt=$(FM_FAKE_CURRENT_STATE=working run_complete "$id" "$GEN" "done" 'PR ready' --pr https://github.com/example/repo/pull/12)
   [ "$receipt" = "$HOME_DIR/state/$id.completion-receipt" ] || fail "completion helper did not print its receipt path"
   assert_grep 'schema=fm-completion-receipt.v1' "$receipt" "completion schema version missing"
   assert_grep "task_id=$id" "$receipt" "completion receipt lost task identity"
@@ -77,7 +77,7 @@ test_completion_schema_and_dual_status() {
 test_schema_validation_rejects_malformed_receipt() {
   local id=receipt-invalid-r2
   make_world invalid "$id" ship direct-PR
-  FM_FAKE_CURRENT_STATE=done run_complete "$id" "$GEN" done 'ready' >/dev/null
+  FM_FAKE_CURRENT_STATE="done" run_complete "$id" "$GEN" "done" 'ready' >/dev/null
   printf 'unknown_field=1\n' >> "$HOME_DIR/state/$id.completion-receipt"
   FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" \
     FM_SHADOW_CREW_STATE_BIN="$WORLD/crew-state" "$SHADOW" record "$id"
@@ -89,7 +89,7 @@ test_schema_validation_rejects_malformed_receipt() {
 test_incarnation_binding_and_stale_rejection() {
   local id=receipt-stale-r3 before out status
   make_world stale "$id" ship direct-PR
-  run_complete "$id" "$GEN" done 'first incarnation' >/dev/null
+  run_complete "$id" "$GEN" "done" 'first incarnation' >/dev/null
   before=$(cat "$HOME_DIR/state/$id.completion-receipt")
   sed "s/^spawn_gen=.*/spawn_gen=s-new-incarnation/" "$HOME_DIR/state/$id.meta" > "$HOME_DIR/state/$id.meta.new"
   mv "$HOME_DIR/state/$id.meta.new" "$HOME_DIR/state/$id.meta"
@@ -110,14 +110,14 @@ test_incarnation_binding_and_stale_rejection() {
 test_investigation_requires_report_path() {
   local id=receipt-scout-r4 out status report
   make_world scout "$id" scout scout
-  out=$(run_complete "$id" "$GEN" done 'investigation complete' 2>&1)
+  out=$(run_complete "$id" "$GEN" "done" 'investigation complete' 2>&1)
   status=$?
   expect_code 1 "$status" "investigation completion without a report path must fail"
   assert_contains "$out" 'investigation completion requires --artifact' "missing report refusal was not actionable"
   assert_absent "$HOME_DIR/state/$id.completion-receipt" "report-less investigation published a receipt"
   report="$HOME_DIR/data/$id/report.md"
   printf '# report\n' > "$report"
-  run_complete "$id" "$GEN" done 'investigation complete' --artifact "$report" >/dev/null
+  run_complete "$id" "$GEN" "done" 'investigation complete' --artifact "$report" >/dev/null
   report="$(cd "$(dirname "$report")" && pwd -P)/$(basename "$report")"
   assert_grep "artifact_path=$report" "$HOME_DIR/state/$id.completion-receipt" \
     "investigation receipt did not bind the report path"
@@ -128,13 +128,13 @@ test_local_only_requires_clean_task_branch() {
   local id=receipt-local-r5 out status
   make_world local "$id" ship local-only
   printf 'dirty\n' >> "$WT/README.md"
-  out=$(run_complete "$id" "$GEN" done 'ready in branch' 2>&1)
+  out=$(run_complete "$id" "$GEN" "done" 'ready in branch' 2>&1)
   status=$?
   expect_code 1 "$status" "dirty local-only worktree must be refused"
   assert_contains "$out" 'requires a clean worktree' "dirty local-only refusal was not actionable"
   git -C "$WT" checkout -- README.md
   git -C "$WT" checkout -qb wrong-branch
-  out=$(run_complete "$id" "$GEN" done 'ready in branch' 2>&1)
+  out=$(run_complete "$id" "$GEN" "done" 'ready in branch' 2>&1)
   status=$?
   expect_code 1 "$status" "wrong local-only branch must be refused"
   assert_contains "$out" "requires task branch fm/$id" "wrong-branch refusal did not name the task branch"
@@ -155,9 +155,11 @@ test_process_exit_normal_and_killed() {
   grep -Eq '^process_identity=[0-9a-f]+$' "$HOME_DIR/state/$id.process-exit-receipt" \
     || fail "normal exit did not retain process incarnation identity"
 
+  # shellcheck disable=SC2100 # id is a literal task-id suffix, not arithmetic.
   id=receipt-killed-r7
   make_world exit-killed "$id" ship direct-PR muse cmux
   pidfile="$WORLD/child.pid"
+  # shellcheck disable=SC2016 # child shell must expand $$ and $1 inside the literal script.
   run_runner --task "$id" --spawn-gen "$GEN" --harness muse --backend cmux -- \
     /bin/sh -c 'printf "%s\n" "$$" > "$1"; while :; do sleep 1; done' _ "$pidfile" &
   wrapper=$!
@@ -186,6 +188,7 @@ test_process_exit_normal_and_killed() {
 test_process_wrapper_preserves_child_io_and_status() {
   local id=receipt-io-r7b out status
   make_world process-io "$id" ship direct-PR opencode zellij
+  # shellcheck disable=SC2016 # child shell must expand $line inside the literal script.
   out=$(printf 'hello\n' | run_runner --task "$id" --spawn-gen "$GEN" --harness opencode --backend zellij -- \
     /bin/sh -c 'IFS= read -r line; [ "$line" = hello ]; printf "child-output\n"')
   status=$?
@@ -231,7 +234,7 @@ exit 99
 SH
   chmod +x "$trapbin/fm-teardown.sh"
   FM_CLEANUP_TRIPWIRE="$WORLD/cleanup-called" PATH="$trapbin:$PATH" \
-    FM_TEARDOWN_BIN="$trapbin/fm-teardown.sh" run_complete "$id" "$GEN" done 'ready' >/dev/null
+    FM_TEARDOWN_BIN="$trapbin/fm-teardown.sh" run_complete "$id" "$GEN" "done" 'ready' >/dev/null
   FM_CLEANUP_TRIPWIRE="$WORLD/cleanup-called" PATH="$trapbin:$PATH" \
     FM_TEARDOWN_BIN="$trapbin/fm-teardown.sh" \
     run_runner --task "$id" --spawn-gen "$GEN" --harness codex --backend tmux -- /bin/sh -c 'exit 0'
@@ -244,7 +247,7 @@ SH
 test_shadow_read_interface_documents_disagreements() {
   local id=receipt-read-r9 help out
   make_world read "$id" ship direct-PR
-  FM_FAKE_CURRENT_STATE=working run_complete "$id" "$GEN" done 'ready' >/dev/null
+  FM_FAKE_CURRENT_STATE=working run_complete "$id" "$GEN" "done" 'ready' >/dev/null
   out=$(FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" "$SHADOW" read "$id" --disagreements)
   assert_contains "$out" 'comparison=different' "shadow read did not expose the disagreement"
   help=$($SHADOW --help 2>&1 || true)

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -192,8 +192,10 @@ test_kimi_launch_then_send_is_verified() {
   assert_contains "$out" "spawned $id harness=kimi" "kimi spawn did not report success"
 
   launch=$(cat "$CASE_DIR/launch.log")
-  [ "$launch" = "env -u CURSOR_AGENT -u CURSOR_INVOKED_AS '$FAKEBIN_DIR/kimi' --model 'kimi-code/k3' --auto" ] \
-    || fail "kimi launch did not use the absolute binary, model, and --auto only: $launch"
+  assert_contains "$launch" "'$FAKEBIN_DIR/kimi' --model 'kimi-code/k3' --auto" \
+    "kimi launch did not use the absolute binary, model, and --auto only: $launch"
+  assert_contains "$launch" "--harness 'kimi' --backend 'tmux' -- " \
+    "kimi launch did not place the selected harness behind the exit-receipt wrapper: $launch"
   assert_not_contains "$launch" "--effort" "kimi launch emitted a nonexistent effort flag"
   assert_not_contains "$launch" "turn-ended" "kimi launch embedded a turn-end path"
   assert_not_contains "$launch" "__TURNEND__" "kimi launch retained a turn-end placeholder"
@@ -449,8 +451,10 @@ test_kimi_falls_back_to_expanded_home_binary() {
   rc=$?
   expect_code 0 "$rc" "Kimi HOME fallback spawn should succeed"
   launch=$(cat "$CASE_DIR/launch.log")
-  [ "$launch" = "env -u CURSOR_AGENT -u CURSOR_INVOKED_AS '$fallback' --auto" ] \
-    || fail "Kimi fallback did not expand HOME into an absolute executable: $launch"
+  assert_contains "$launch" "'$fallback' --auto" \
+    "Kimi fallback did not expand HOME into an absolute executable: $launch"
+  assert_contains "$launch" "--harness 'kimi' --backend 'tmux' -- " \
+    "Kimi fallback did not place the selected harness behind the exit-receipt wrapper: $launch"
   pass "fm-spawn: Kimi fallback expands the active HOME"
 }
 

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -153,7 +153,7 @@ assert_meta_profile() {
 }
 
 test_no_profile_keeps_claude_profile_defaults() {
-  local rec id out status expected launch
+  local rec id out status expected launch gen runner
   id=profile-off-z1
   rec=$(make_spawn_case profile-off claude "$id")
   read_case_record "$rec"
@@ -165,7 +165,9 @@ test_no_profile_keeps_claude_profile_defaults() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
+  gen=$(sed -n 's/^spawn_gen=//p' "$HOME_DIR/state/$id.meta")
+  runner="FM_HOME='$HOME_DIR' FM_STATE_OVERRIDE='$HOME_DIR/state' FM_TASK_ID='$id' FM_SPAWN_GEN='$gen' '$ROOT/bin/fm-harness-run.sh' --task '$id' --spawn-gen '$gen' --harness 'claude' --backend 'tmux' -- "
+  expected="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false ${runner}claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch did not use the canonical launch kind"$'\n'"expected: $expected"$'\n'"actual:   $launch"
   pass "no --model/--effort records defaults and types the claude launch instructions"
 }
@@ -623,7 +625,7 @@ test_pi_threads_model_and_max_effort() {
   expect_code 0 "$status" "pi spawn with max effort should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" pi openai-codex/gpt-5.6-sol max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "FM_PI_HARNESS=pi '$FAKEBIN_DIR/pi' --tui-mode regular --model 'openai-codex/gpt-5.6-sol' --thinking 'max' -e" \
+  assert_contains "$launch" "--harness 'pi' --backend 'tmux' -- '$FAKEBIN_DIR/pi' --tui-mode regular --model 'openai-codex/gpt-5.6-sol' --thinking 'max' -e" \
     "pi launch did not force the regular TUI while threading the requested model and max thinking level"
   assert_not_contains "$launch" "FM_FIRSTMATE_PI_LAUNCH_BRIEF=" \
     "pi launch still exports the removed Calm input-reroute binding"
@@ -645,7 +647,7 @@ test_pi_signed_threads_shared_pi_profile_and_preserves_identity() {
   assert_contains "$out" "spawned $id harness=pi-signed" "pi-signed spawn did not preserve its visible identity"
   assert_meta_profile "$HOME_DIR/state/$id.meta" pi-signed openai-codex/gpt-5.6-sol max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "FM_PI_HARNESS=pi-signed '$FAKEBIN_DIR/pi-signed' --tui-mode regular --model 'openai-codex/gpt-5.6-sol' --thinking 'max' -e" \
+  assert_contains "$launch" "--harness 'pi-signed' --backend 'tmux' -- '$FAKEBIN_DIR/pi-signed' --tui-mode regular --model 'openai-codex/gpt-5.6-sol' --thinking 'max' -e" \
     "pi-signed launch did not force the regular TUI with Pi's model, thinking, and extension semantics"
   assert_contains "$launch" "fm-operational-input.sh' encode launch-brief" \
     "pi-signed launch lost the canonical typed launch-brief envelope"
@@ -737,6 +739,8 @@ test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity() {
   launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "FM_PI_HARNESS=pi-signed '$FAKEBIN_DIR/pi-signed' --tui-mode regular -e '$sm/.pi/extensions/fm-primary-turnend-guard.ts' -e '$sm/.pi/extensions/fm-primary-pi-watch.ts'" \
     "pi-signed secondmate did not force the regular TUI with Pi's primary extension launch shape"
+  assert_not_contains "$launch" 'fm-harness-run.sh' \
+    "persistent secondmate entered the ordinary completion-receipt lifecycle"
   pass "pi-signed is a distinct persistent secondmate runtime with shared Pi supervision semantics"
 }
 
@@ -770,8 +774,10 @@ test_claude_forwards_firstmate_config_dir_when_set() {
   status=$?
   expect_code 0 "$status" "claude spawn with CLAUDE_CONFIG_DIR set should succeed"
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "CLAUDE_CONFIG_DIR='/opt/test/claude-work' env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude" \
+  assert_contains "$launch" "CLAUDE_CONFIG_DIR='/opt/test/claude-work' env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false FM_HOME=" \
     "claude launch did not forward firstmate's CLAUDE_CONFIG_DIR to the crewmate pane"
+  assert_contains "$launch" "--harness 'claude' --backend 'tmux' -- claude" \
+    "claude launch did not place the configured child behind the exit-receipt wrapper"
   pass "claude forwards firstmate's CLAUDE_CONFIG_DIR so the crewmate uses the same credential store"
 }
 


### PR DESCRIPTION
## Intent

Phase 1 of the captain-approved deterministic finished-crew closing design: add a versioned atomic completion receipt bound to task id, current spawn generation, kind, mode, outcome, artifact path, worktree HEAD, and optional PR URL; reject stale incarnations, investigation completion without a report path, and local-only completion when HEAD is dirty or not on the task branch; during migration also emit the existing status line. Add an observation-only process-exit receipt sourced from the real kernel wait status for the exact supported harness child, bound to spawn generation, process identity, exit epoch, harness, and backend, covering normal and killed exits. Add inspectable per-harness and per-backend shadow comparisons between receipt conclusions and the unchanged current system conclusion. Change no behavior: do not close, park, stop, or clean up workers; add no caller of fm-teardown; preserve every hook, semantic busy source, status append, watcher behavior, manual cleanup path, fm-crew-state result, busy generation and sequence binding, source trust, unknown-never-idle semantics, teardown unlanded-work protection, and merge authority. Keep receipt, process exit, forge state, and worktree cleanliness as separate signals with separate tests; exclude persistent secondmates entirely. Add colocated tests for receipt schemas, incarnation binding and stale rejection, investigation-without-report refusal, dirty and wrong-branch local-only refusals, normal and killed exit capture, and an explicit proof that no cleanup path is reachable from either receipt. Document how to read shadow comparisons. Confirm but do not fix the pre-existing fm-teardown herdr-preflight-missing-adapter failure. Deliver through a PR with green CI and do not merge.

## What Changed

- Add `bin/fm-complete.sh`, `bin/fm-completion-lib.sh`, and `bin/fm-completion-shadow.sh` to publish a versioned atomic completion receipt bound to task id, current spawn generation, kind, mode, outcome, artifact path, worktree HEAD, and optional PR URL, with refusals for stale incarnations, investigation completion without a report path, and local-only completion when HEAD is dirty or off-branch.
- Add `bin/fm-harness-run.sh` and wire it through `bin/fm-spawn.sh` so ordinary ship/scout children are wrapped by an observation-only wait that publishes a kernel-derived process-exit receipt, and per-harness/per-backend shadow comparisons let inspectors diff receipt conclusions against the unchanged current-system conclusion.
- Add `tests/fm-completion-receipt.test.sh` covering schema, incarnation binding and stale rejection, investigation-without-report refusal, dirty and wrong-branch local-only refusals, normal and killed exit capture, and an explicit proof that no cleanup path is reachable from either receipt; document the new state files in `AGENTS.md` and `docs/scripts.md`, and update the test-runner shims.

## Risk Assessment

✅ Low: The change is a well-bounded observation-only wrapper: the umask leak is fixed without behavior change, the receipts are independent signals with no caller of fm-teardown, the secondmate exclusion is preserved, and the tests assert observable behavior via the public CLI interfaces.

## Testing

Ran the new tests/fm-completion-receipt.test.sh (all 10 cases pass) and the dispatch-profile test modified to expect the new __RUNNER__ wrapper (all cases pass). Then exercised each public helper end-to-end against a real fixture: fm-complete.sh published a versioned, schema-bound, atomic receipt and dual-wrote the legacy status line; fm-harness-run.sh preserved child stdin/stdout and the kernel wait status for both a normal-exit child (wait_status=0) and a killable child (wait_status=137) while emitting an observation-only process-exit receipt; fm-completion-shadow.sh record produced a per-harness/per-backend ledger row and read --disagreements correctly filtered to comparison=different rows. The pre-existing herdr-preflight-missing-adapter failure is reproduced unchanged (the change does not touch fm-teardown or herdr.sh) and is therefore not actionable here.

<details>
<summary>Evidence: fm-complete.sh end-to-end run</summary>

Source: [fm-complete.sh end-to-end run](https://github.com/abhishekdubey331/firstmate/blob/9f6b5618e4b0be2bdfbcecbf4ca2668d6ab5a7ba/.no-mistakes/evidence/fm/fm-completion-receipt-r1/completion-receipt-evidence.txt)

`Produced: state/a1.completion-receipt (schema=fm-completion-receipt.v1, task_id=a1, spawn_gen=s-evidence-1, kind=ship, mode=no-mistakes, outcome=done, worktree_head=<SHA>, created_epoch=<epoch>, pr_url=https://github.com/example/repo/pull/55). Legacy status file contains 'done: PR ready'. Shadow row: v1 epoch=... task=a1 spawn_gen=s-evidence-1 harness=codex backend=tmux trigger=completion completion=done process=absent shadow=ready current=working comparison=different.`

```text
## Step 1: prepare a real report artifact
## Step 2: invoke fm-complete.sh for kind=ship mode=no-mistakes
/var/folders/2f/t93tm4q16tgfszs6_l1mvxpm0000gn/T/fm-completion-evidence-XXXXXX.l6dCM7fPFq/home/state/a1.completion-receipt
## Produced: /var/folders/2f/t93tm4q16tgfszs6_l1mvxpm0000gn/T/fm-completion-evidence-XXXXXX.l6dCM7fPFq/home/state/a1.completion-receipt
schema=fm-completion-receipt.v1
task_id=a1
spawn_gen=s-evidence-1
kind=ship
mode=no-mistakes
outcome=done
artifact_path=
worktree_head=2cb324bee35a98c1243aed0305404d8699ef1f7c
created_epoch=1786994577
pr_url=https://github.com/example/repo/pull/55

## Status file (legacy dual-write):
done: PR ready

## Shadow comparison:
v1 epoch=1786994578 task=a1 spawn_gen=s-evidence-1 harness=codex backend=tmux trigger=completion completion=done process=absent shadow=ready current=working comparison=different

## Step 3: invoke fm-completion-shadow.sh read --disagreements
v1 epoch=1786994578 task=a1 spawn_gen=s-evidence-1 harness=codex backend=tmux trigger=completion completion=done process=absent shadow=ready current=working comparison=different

## Step 4: read full ledger
v1 epoch=1786994578 task=a1 spawn_gen=s-evidence-1 harness=codex backend=tmux trigger=completion completion=done process=absent shadow=ready current=working comparison=different
```
</details>
<details>
<summary>Evidence: fm-harness-run.sh end-to-end run</summary>

Source: [fm-harness-run.sh end-to-end run](https://github.com/abhishekdubey331/firstmate/blob/9f6b5618e4b0be2bdfbcecbf4ca2668d6ab5a7ba/.no-mistakes/evidence/fm/fm-completion-receipt-r1/runner-evidence.txt)

`Normal-exit child: wrapper exit 0, child stdout preserved as 'child-stdout', receipt wait_status=0 with hex process_identity. Killed child: wrapper exit 137, receipt wait_status=137 with the exact child pid, shadow row: harness=muse backend=cmux trigger=process-exit completion=absent process=exited-nonzero shadow=abnormal-exit current=unknown comparison=different.`

```text
## Test 1: normal exit (child exits 0)
wrapper stdout: child-stdout
wrapper exit code: 0
process-exit receipt:
schema=fm-process-exit-receipt.v1
task_id=run1
spawn_gen=s-evidence-runner
harness=claude
backend=tmux
process_pid=80909
process_identity=6c73746172743d547565204175672031382030303a35373a31312032303236
exit_epoch=1786994832
wait_status=0


## Test 2: killed exit (child receives SIGKILL, expect wait_status=137)
child pid: 81195
/Users/aibuilders/.no-mistakes/worktrees/8decc6a0d3a4/01M08HYB7CJMVQB4SMD2J54D5D/bin/fm-harness-run.sh: line 75: 81195 Killed: 9               ( SUB_OLD_UMASK=$(umask); umask 077; CHILD_SELF=${BASHPID:-$$}; CHILD_IDENTITY=$(fm_completion_process_identity "$CHILD_SELF" 2>/dev/null || true); printf 'pid=%s\nidentity=%s\n' "$CHILD_SELF" "$CHILD_IDENTITY" > "$START_RECORD"; umask "$SUB_OLD_UMASK"; exec "$@" ) 0<&0
wrapper exit code: 137
process-exit receipt:
schema=fm-process-exit-receipt.v1
task_id=run2
spawn_gen=s-evidence-runner
harness=muse
backend=cmux
process_pid=81195
process_identity=6c73746172743d547565204175672031382030303a35373a31322032303236
exit_epoch=1786994832
wait_status=137


## Test 3: invoke fm-completion-shadow.sh read for the killed task
v1 epoch=1786994833 task=run2 spawn_gen=s-evidence-runner harness=muse backend=cmux trigger=process-exit completion=absent process=exited-nonzero shadow=abnormal-exit current=unknown comparison=different
```
</details>
<details>
<summary>Evidence: Shadow ledger end-to-end run</summary>

Source: [Shadow ledger end-to-end run](https://github.com/abhishekdubey331/firstmate/blob/9f6b5618e4b0be2bdfbcecbf4ca2668d6ab5a7ba/.no-mistakes/evidence/fm/fm-completion-receipt-r1/shadow-evidence.txt)

`Built a 9-harness x 5-backend matrix (claude/codex/opencode/pi/pi-signed/grok/kimi/cursor/muse x tmux/herdr/zellij/orca/cmux) and recorded shadow rows for each. Sample row: 'v1 epoch=... task=ax-claude-tmux spawn_gen=s-ax-claude-tmux harness=claude backend=tmux trigger=completion completion=done process=absent shadow=ready current=working comparison=different'. read --disagreements correctly returned only that row.`

```text
## Build one task per harness x backend pair and record shadow rows

## Per-task shadow sample (one example)
v1 epoch=1786994843 task=ax-claude-tmux spawn_gen=s-ax-claude-tmux harness=claude backend=tmux trigger=manual completion=absent process=absent shadow=running current=unknown comparison=no-comparison

## Verify disagreements read for the example (current=unknown vs no completion=absent -> comparison=no-comparison)

## Same but with FM_FAKE_CURRENT_STATE=done to make a disagreement
v1 epoch=1786994848 task=ax-claude-tmux spawn_gen=s-ax-claude-tmux harness=claude backend=tmux trigger=completion completion=done process=absent shadow=ready current=working comparison=different
```
</details>
<details>
<summary>Evidence: fm-teardown preflight missing-adapter pre-existing failure</summary>

Source: [fm-teardown preflight missing-adapter pre-existing failure](https://github.com/abhishekdubey331/firstmate/blob/9f6b5618e4b0be2bdfbcecbf4ca2668d6ab5a7ba/.no-mistakes/evidence/fm/fm-completion-receipt-r1/teardown-preflight-evidence.txt)

`not ok - herdr-preflight-missing-adapter: teardown continued without its required preflight (pre-existing failure, not introduced by this change; per user intent, confirm but do not fix).`

```text
not ok - herdr-preflight-missing-adapter: teardown continued without its required preflight
```
</details>
- Outcome: ⚠️ 1 info across 1 run (10m28s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"6721d6aa83f469f36cebf5ff105d3d0e297f0d96","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-harness-run.sh:57` - Wrapper sets umask 077 in the parent before forking the subshell that execs the harness, so the umask leaks through fork+exec into the wrapped harness child. The parent restores its own umask after $!, but the harness keeps 077 for its entire lifetime, changing file creation modes from inherited 022 (644/755) to 077 (600/700). The user intent forbids behavior changes; the fix is to save/restore umask inside the subshell and restore before exec &#34;$@&#34;, mirroring fm-complete.sh and the wrapper&#39;s own publish_exit_receipt.
- ℹ️ `bin/fm-completion-shadow.sh:9` - Documentation for reading shadow comparisons is minimal: the script header names the columns and scripts.md has a one-liner, but neither shows an example row nor explains the shadow=ready|running|worker-stopped|abnormal-exit verdict semantics. The intent calls documentation out as required; the current doc is functional but light.

🔧 Fix: fix(fm-harness-run): restore umask inside subshell before exec
1 info still open:
- ℹ️ `bin/fm-harness-run.sh:131` - publish_exit_receipt cmp -s includes the entire receipt bytes (including exit_epoch and wait_status), so a second invocation of the wrapper for the exact same spawn_gen would fail the strict comparison and refuse to publish. fm-complete.sh excludes created_epoch from the same comparison to allow repeatable calls for the same incarnation. The wrapper is only invoked once per spawn so this is unreachable in practice, but the inconsistency between the two receipt writers is worth noting.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `tests/fm-teardown.test.sh:1582` - fm-teardown pre-existing failure `herdr-preflight-missing-adapter: teardown continued without its required preflight` is reproduced on this branch but is OUTSIDE the scope of this change. The change does not touch bin/fm-teardown.sh or bin/backends/herdr.sh, and the user intent explicitly says to &#34;confirm but do not fix&#34; this pre-existing failure.
- `bash tests/fm-completion-receipt.test.sh`
- `bash tests/fm-spawn-dispatch-profile.test.sh`
- `bash tests/fm-teardown.test.sh (full pass; preflight-missing-adapter case fails)`
- `end-to-end driver: invoke fm-complete.sh for kind=ship/mode=no-mistakes, assert receipt contents and dual status line`
- `end-to-end driver: invoke fm-harness-run.sh with a normal-exit child, assert receipt schema and wait_status=0`
- `end-to-end driver: invoke fm-harness-run.sh with a killable child, assert wrapper preserves wait_status=137 and receipt carries process_pid/exit_epoch`
- `end-to-end driver: invoke fm-completion-shadow.sh record for 9 harnesses x 5 backends and confirm read --disagreements filters to comparison=different rows`
- `grep verification that bin/fm-complete.sh, bin/fm-completion-lib.sh, bin/fm-completion-shadow.sh, bin/fm-harness-run.sh contain no fm-teardown/merge/cleanup invocations and explicitly exclude kind=secondmate`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: fix(lint): clear shellcheck SC1010/SC2100/SC2016 findings
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
