### PR TITLE
docs: clarify test evidence branch storage

### DIFF
--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -37,7 +37,8 @@ document:
 commands:
   lint: 'bin/fm-lint.sh'
 
-# Store test evidence in this repo so it is committed alongside the change instead of kept in a temp dir.
+# Publish each run's test evidence to the orphan `no-mistakes/evidence` branch, linked from the PR, instead of leaving it in a temp dir.
+# That branch shares no history with code branches, so no evidence is committed onto the change's own branch.
 test:
   evidence:
     store_in_repo: true

--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -37,8 +37,8 @@ document:
 commands:
   lint: 'bin/fm-lint.sh'
 
-# Publish each run's test evidence to the orphan `no-mistakes/evidence` branch, linked from the PR, instead of leaving it in a temp dir.
-# That branch shares no history with code branches, so no evidence is committed onto the change's own branch.
+# Publish each run's test evidence to the orphan no-mistakes/evidence branch linked from the PR.
+# The evidence is not committed to the feature or default branch.
 test:
   evidence:
     store_in_repo: true


### PR DESCRIPTION
## Intent

Fix ONE inaccurate comment in the firstmate repo's .no-mistakes.yaml (line 40). The old comment read '# Store test evidence in this repo so it is committed alongside the change instead of kept in a temp dir.' The 'committed alongside the change' framing is inaccurate: as documented in CONTRIBUTING.md / docs/configuration.md and confirmed empirically in PR #2548, test.evidence.store_in_repo: true publishes each run's test evidence to the ORPHAN no-mistakes/evidence branch (linked from the PR body), which shares no history with code branches - it is NOT committed onto the change's feature branch, and nothing tracked lands under .no-mistakes/ on main.

Scope, deliberately constrained by the captain: reword that comment ONLY so it accurately describes the behavior. Explicit exclusions: do NOT change store_in_repo: true or any other key/value - the boolean and the behavior stay exactly as they are, which is the captain's decision in issue #2355. Do NOT change any other file. This is a comment-only, one-to-two-line change; docs/configuration.md remains the one owner of the setting's full description, so the comment stays brief.

Tests: no behavioral test for a comment-accuracy fix, and per repo policy tests must never assert implementation-source bytes, so asserting the comment text of .no-mistakes.yaml is forbidden. bin/fm-lint.sh and shellcheck were run and are green. This is firstmate shared tracked material; firstmate-coding-guidelines repo style was applied (one sentence per physical line, plain dash, no agent co-author trailer).

## What Changed

- Correct the configuration comment to explain that test evidence is published to the orphan `no-mistakes/evidence` branch rather than committed to the feature branch.

## Risk Assessment

✅ Low: The change is limited to the requested two-line comment correction, preserves all configuration values, and accurately describes orphan-branch evidence publishing.

## Testing

Author-supplied lint and shellcheck baselines were green; targeted validation confirmed the sole tracked change is the corrected `.no-mistakes.yaml` comment, parsed configuration is semantically unchanged, `store_in_repo` remains true, and reviewer-visible patch evidence was captured.

<details>
<summary>Evidence: Comment-only patch and parsed YAML semantic comparison</summary>

Source: [Comment-only patch and parsed YAML semantic comparison](https://github.com/kunchenguid/firstmate/blob/05f6c48186c52b364ede4c44a0aadf039e14aa6f/.no-mistakes/evidence/fm/fm-nm-evidence-comment-orphan-branch-r1/comment-only-change.txt)

```text
Reviewer evidence: requested comment-only configuration clarification

Changed-path and patch:
M	.no-mistakes.yaml
diff --git a/.no-mistakes.yaml b/.no-mistakes.yaml
index 219c39b..bf5663d 100644
--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -37,7 +37,8 @@ document:
 commands:
   lint: 'bin/fm-lint.sh'
 
-# Store test evidence in this repo so it is committed alongside the change instead of kept in a temp dir.
+# Publish each run's test evidence to the orphan `no-mistakes/evidence` branch, linked from the PR, instead of leaving it in a temp dir.
+# That branch shares no history with code branches, so no evidence is committed onto the change's own branch.
 test:
   evidence:
     store_in_repo: true

Parsed configuration comparison (comments excluded by YAML parser):
{
  "semantic_configuration_unchanged": true,
  "store_in_repo": true
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d5556d8883ee0b2745d35c3f40fa272220d61521","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --name-status ac55d39a5bb355308f608b9ff2d033592232826c..d5556d8883ee0b2745d35c3f40fa272220d61521` and manual patch review</code>
- <code>Ruby `YAML.safe_load` comparison of base and target `.no-mistakes.yaml`, including verification that `test.evidence.store_in_repo` remains `true`</code>
- <code>`git status --short` to confirm testing left the worktree unchanged</code>

</details>

<details>
<summary>⚠️ **Document** - 1 error</summary>

- 🚨 `docs/configuration.md:132` - The authoritative configuration documentation still says evidence stays outside the repo, and CONTRIBUTING.md:70 says it remains in a temp directory; both contradict the new orphan-branch comment, but the requested scope forbids editing other files.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
