### PR TITLE
feat: add Codex service tier controls

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -110,7 +110,7 @@ When changing any primary watcher adapter, update `docs/supervision-protocols/`,
 
 ## Launch profile axes
 
-`bin/fm-spawn.sh` accepts concrete `--harness`, `--model`, `--effort`, and `--tier` values chosen by firstmate at intake.
+`bin/fm-spawn.sh` accepts concrete `--harness`, `--model`, and `--effort` values chosen by firstmate at intake, plus the optional `--tier` axis.
 Do not make the shell scripts parse or match natural-language dispatch rules.
 
 Effort precedence is an explicit per-task captain instruction first, then any applicable standing dispatch profile or secondmate pin, then the generic fallback below.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -134,6 +134,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | cursor | `--model <model>` | none | none | Verified 2026-08-11 on Cursor Agent CLI 2026.08.11-e8db854. No effort flag exists, so firstmate records the requested effort in task metadata and omits it from the launch. Validate ids against `cursor-agent --list-models` rather than assuming a low/medium/high family: the live catalog carries only `-high` Grok ids. |
 | muse | `--model <model>` | `--reasoning-effort <low\|medium\|high\|xhigh>`, and `ultra` only for an explicit `max` | none | Verified 2026-08-05 on Muse Code 0.1.0-R708.1. The flag accepts `none\|minimal\|low\|medium\|high\|xhigh\|ultra` and defaults to `high`. `ultra` is muse's max-class level, so it is reachable only through an explicit captain `max`, never from the generic fallback; `none` and `minimal` sit below the shared vocabulary and stay unreachable. |
 
+Apply the fast-tier eligibility and refusal checks owned by `bin/fm-spawn.sh --help` whenever selecting `--tier fast`.
 An explicit tier on a non-Codex harness is recorded in task metadata and omitted from the launch with a warning because no serving-tier flag is verified for that adapter.
 
 The concrete `harness` field owns adapter identity independently of the model provider: `harness=pi` with `model=xai/grok-*` is Pi using xAI, not `harness=grok`, and does not require Grok CLI login; `harness=grok` remains the standalone Grok Build CLI adapter.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -110,7 +110,7 @@ When changing any primary watcher adapter, update `docs/supervision-protocols/`,
 
 ## Launch profile axes
 
-`bin/fm-spawn.sh` accepts concrete `--harness`, `--model`, and `--effort` values chosen by firstmate at intake.
+`bin/fm-spawn.sh` accepts concrete `--harness`, `--model`, `--effort`, and `--tier` values chosen by firstmate at intake.
 Do not make the shell scripts parse or match natural-language dispatch rules.
 
 Effort precedence is an explicit per-task captain instruction first, then any applicable standing dispatch profile or secondmate pin, then the generic fallback below.
@@ -123,16 +123,18 @@ Never select `max` from this fallback; use it only when the captain has explicit
 
 The supported launch-profile flags below are verified locally; each row records its evidence.
 
-| Harness | Model flag | Effort flag | Notes |
-|---|---|---|---|
-| claude | `--model <model>` | `--effort <low\|medium\|high\|xhigh\|max>` | Verified on Claude Code 2.1.196. |
-| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'` | Verified on codex-cli 0.142.1. The installed binary schema contains `model_reasoning_effort`, the active config uses it, and the bundled model catalog advertises only low/medium/high/xhigh. `max` is omitted. |
-| grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
-| pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
-| opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
-| kimi | `--model <model>` | none | Verified 2026-07-25 on Kimi Code CLI 0.29.1. |
-| cursor | `--model <model>` | none | Verified 2026-08-11 on Cursor Agent CLI 2026.08.11-e8db854. No effort flag exists, so firstmate records the requested effort in task metadata and omits it from the launch. Validate ids against `cursor-agent --list-models` rather than assuming a low/medium/high family: the live catalog carries only `-high` Grok ids. |
-| muse | `--model <model>` | `--reasoning-effort <low\|medium\|high\|xhigh>`, and `ultra` only for an explicit `max` | Verified 2026-08-05 on Muse Code 0.1.0-R708.1. The flag accepts `none\|minimal\|low\|medium\|high\|xhigh\|ultra` and defaults to `high`. `ultra` is muse's max-class level, so it is reachable only through an explicit captain `max`, never from the generic fallback; `none` and `minimal` sit below the shared vocabulary and stay unreachable. |
+| Harness | Model flag | Effort flag | Serving-tier flag | Notes |
+|---|---|---|---|---|
+| claude | `--model <model>` | `--effort <low\|medium\|high\|xhigh\|max>` | none | Verified on Claude Code 2.1.196. |
+| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'` | `-c 'service_tier="default\|priority"'` | Verified on codex-cli 0.142.1. The installed binary schema contains `model_reasoning_effort`, the active config uses it, and the bundled model catalog advertises only low/medium/high/xhigh. `max` is omitted. Verified 2026-08-14 on codex-cli 0.147.0: `--tier standard` maps to `-c 'service_tier="default"'` and `--tier fast` maps to `-c 'service_tier="priority"'`; the live TUI rendered `default` with no `fast` under the standard override while the operator config remained untouched. |
+| grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | none | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
+| pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | none | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
+| opencode | `--model <provider/model>` | none for firstmate's interactive launch | none | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
+| kimi | `--model <model>` | none | none | Verified 2026-07-25 on Kimi Code CLI 0.29.1. |
+| cursor | `--model <model>` | none | none | Verified 2026-08-11 on Cursor Agent CLI 2026.08.11-e8db854. No effort flag exists, so firstmate records the requested effort in task metadata and omits it from the launch. Validate ids against `cursor-agent --list-models` rather than assuming a low/medium/high family: the live catalog carries only `-high` Grok ids. |
+| muse | `--model <model>` | `--reasoning-effort <low\|medium\|high\|xhigh>`, and `ultra` only for an explicit `max` | none | Verified 2026-08-05 on Muse Code 0.1.0-R708.1. The flag accepts `none\|minimal\|low\|medium\|high\|xhigh\|ultra` and defaults to `high`. `ultra` is muse's max-class level, so it is reachable only through an explicit captain `max`, never from the generic fallback; `none` and `minimal` sit below the shared vocabulary and stay unreachable. |
+
+An explicit tier on a non-Codex harness is recorded in task metadata and omitted from the launch with a warning because no serving-tier flag is verified for that adapter.
 
 The concrete `harness` field owns adapter identity independently of the model provider: `harness=pi` with `model=xai/grok-*` is Pi using xAI, not `harness=grok`, and does not require Grok CLI login; `harness=grok` remains the standalone Grok Build CLI adapter.
 Likewise, `harness=cursor` with `model=cursor-grok-4.5-*` is Cursor Agent CLI routing a Grok model, not the xAI Grok Build `grok` harness.

--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -217,6 +217,7 @@ For a remote route, the same command probes and relaunches only on the configure
 An SSH transport failure or unreadable remote endpoint remains unknown and must be reconciled on that host; never launch a local replacement.
 `stuck-crewmate-recovery`'s remote-secondmate note owns why the endpoint-dead and send-failed verdicts that seem to justify this are themselves unreliable.
 Respawn re-resolves the secondmate harness from current config, uses the same guarded pre-launch sync, and re-propagates inherited local material, so recovered secondmates converge inherited config items and shared captain preferences whenever their home validates; tracked-file sync remains guarded separately.
+When the resolved harness family is unchanged, respawn preserves the recorded serving tier; a harness-family change resets it to standard unless the caller explicitly supplies `--tier`.
 If the secondmate is already running and only inherited local material changed, prefer `bin/fm-config-push.sh` over respawning.
 To move a live LOCAL secondmate onto a newly pinned harness, model, or effort without a full recovery, set `config/secondmate-harness` and then relaunch it with `bin/fm-control.sh <id> relaunch`, which re-resolves that pin, stops the agent, and launches the replacement in the same home ([`docs/agent-control.md`](../../../docs/agent-control.md)).
 That plane refuses a remotely placed secondmate by name, because its agent runs on another host where none of the plane's postconditions can be read; use the remote route's own relaunch path for those.

--- a/.agents/skills/stuck-crewmate-recovery/SKILL.md
+++ b/.agents/skills/stuck-crewmate-recovery/SKILL.md
@@ -47,7 +47,7 @@ Escalate in order:
 2. If the crewmate is waiting on a question its brief already answers, answer in one line via `FM_HOME=<this-firstmate-home> bin/fm-send.sh` from an active firstmate session unless `FM_HOME` is already set to the active firstmate home.
 3. If the crewmate is confused or looping, interrupt with `FM_HOME=<this-firstmate-home> bin/fm-control.sh <task-id> interrupt`, then redirect with one corrective line through `fm-send`.
 4. If the crewmate is genuinely wedged after redirection, relaunch it with `FM_HOME=<this-firstmate-home> bin/fm-control.sh <task-id> relaunch --note '<progress so far>'`, which stops the agent, carries the brief plus that note into a replacement in the same local copy, and restores the prior record if the replacement cannot start.
-   Pass `--harness`, `--model`, or `--effort` on that same command when the worker should come back on a different runtime.
+   Pass `--harness`, `--model`, `--effort`, or `--tier` on that same command when the worker should come back on a different runtime profile.
    Genuine wedging means looping, unresponsive, repeating the same obstacle, or truly dead.
    A low context reading is not wedging; modern harnesses auto-compact and keep going.
    The worktree and commits persist, so relaunch is cheap.

--- a/bin/fm-codex-tier-lib.sh
+++ b/bin/fm-codex-tier-lib.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034 # Output globals are read by sourcing callers.
+# fm-codex-tier-lib.sh - read-only Codex fast-tier capability checks.
+
+fm_codex_fast_tier_runtime_resolve() {
+  local candidate dir path resolved
+  FM_CODEX_FAST_TIER_BIN=
+  FM_CODEX_FAST_TIER_HOME=
+  candidate=$(type -P -- codex 2>/dev/null) || {
+    echo "error: Codex executable not found; cannot verify --tier fast support" >&2
+    return 1
+  }
+  [ -x "$candidate" ] || {
+    echo "error: Codex executable not found; cannot verify --tier fast support" >&2
+    return 1
+  }
+  case "$candidate" in
+    /*) FM_CODEX_FAST_TIER_BIN=$candidate ;;
+    *)
+      dir=$(CDPATH='' cd -- "$(dirname "$candidate")" 2>/dev/null && pwd -P) || return 1
+      FM_CODEX_FAST_TIER_BIN="$dir/$(basename "$candidate")"
+      ;;
+  esac
+  if [ "${CODEX_HOME+x}" = x ]; then
+    path=$CODEX_HOME
+    [ -n "$path" ] || {
+      echo "error: CODEX_HOME is set but empty; cannot pin the Codex launch configuration" >&2
+      return 1
+    }
+  else
+    [ -n "${HOME:-}" ] || {
+      echo "error: HOME is unset; cannot resolve Codex's default config home" >&2
+      return 1
+    }
+    path=$HOME/.codex
+  fi
+  [ -d "$path" ] || {
+    echo "error: effective CODEX_HOME directory does not exist: $path" >&2
+    return 1
+  }
+  case "$path" in
+    /*) FM_CODEX_FAST_TIER_HOME=$path ;;
+    *)
+      resolved=$(CDPATH='' cd -- "$path" 2>/dev/null && pwd -P) || {
+        echo "error: CODEX_HOME directory cannot be resolved: $path" >&2
+        return 1
+      }
+      FM_CODEX_FAST_TIER_HOME=$resolved
+      ;;
+  esac
+}
+
+fm_codex_fast_tier_supported() {
+  local worktree=$1 model=$2 executable=$3 config_home=$4 doctor catalog
+  if [ -z "$model" ] || [ "$model" = default ]; then
+    doctor=$(cd "$worktree" && CODEX_HOME="$config_home" "$executable" doctor --json 2>/dev/null) || true
+    case "$doctor" in
+      \{*\}) ;;
+      *)
+        echo "error: could not resolve Codex's effective model; refusing --tier fast" >&2
+        return 1
+        ;;
+    esac
+    if ! model=$(printf '%s\n' "$doctor" | awk '
+      { json = json $0 }
+      END {
+        count = split(json, checks, /"id"[[:space:]]*:[[:space:]]*"/)
+        for (i = 2; i <= count; i++) {
+          id = checks[i]
+          sub(/".*/, "", id)
+          if (id != "config.load") continue
+          if (!match(checks[i], /"model"[[:space:]]*:[[:space:]]*"[^"]+"/)) exit 1
+          model = substr(checks[i], RSTART, RLENGTH)
+          sub(/^[^:]*:[[:space:]]*"/, "", model)
+          sub(/"$/, "", model)
+          print model
+          exit 0
+        }
+        exit 1
+      }
+    '); then
+      echo "error: could not resolve Codex's effective model; refusing --tier fast" >&2
+      return 1
+    fi
+  fi
+  if ! catalog=$(cd "$worktree" && CODEX_HOME="$config_home" "$executable" debug models 2>/dev/null); then
+    echo "error: could not inspect the installed Codex model catalog; refusing --tier fast" >&2
+    return 1
+  fi
+  if ! printf '%s\n' "$catalog" | awk -v wanted="$model" '
+    { json = json $0 }
+    END {
+      count = split(json, models, /"slug"[[:space:]]*:[[:space:]]*"/)
+      for (i = 2; i <= count; i++) {
+        slug = models[i]
+        sub(/".*/, "", slug)
+        if (slug == wanted && models[i] ~ /"service_tiers"[[:space:]]*:[[:space:]]*\[[^]]*"id"[[:space:]]*:[[:space:]]*"priority"/) exit 0
+      }
+      exit 1
+    }
+  '; then
+    echo "error: Codex model '$model' does not advertise the priority service tier; refusing --tier fast" >&2
+    return 1
+  fi
+}

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -620,6 +620,10 @@ resolve_relaunch_profile() {
   [ -n "$PRIOR_MODEL" ] || PRIOR_MODEL=default
   [ -n "$PRIOR_EFFORT" ] || PRIOR_EFFORT=default
   [ -n "$PRIOR_TIER" ] || PRIOR_TIER=standard
+  case "$PRIOR_TIER" in
+    standard|fast) ;;
+    *) die "task $ID has invalid recorded tier '$PRIOR_TIER'; refusing relaunch before stopping its agent" ;;
+  esac
   if [ "$HARNESS_SET" = 0 ] \
      && [ "$PRIOR_RECORDED_HARNESS" != "$PRIOR_HARNESS" ]; then
     die "task $ID records harness '$PRIOR_RECORDED_HARNESS', whose original launch command cannot be reconstructed from its recorded basename; relaunching without --harness would substitute the canonical adapter '$PRIOR_HARNESS' for the command actually running. Pass an explicit --harness to choose the replacement runtime deliberately"
@@ -691,6 +695,10 @@ resolve_relaunch_profile() {
   else
     TARGET_TIER=standard
   fi
+  case "$TARGET_TIER" in
+    standard|fast) ;;
+    *) die "task $ID resolved invalid target tier '$TARGET_TIER'; refusing relaunch before stopping its agent" ;;
+  esac
 }
 
 # safe_checkpoint: prove, before anything is stopped, that the work a relaunch
@@ -837,7 +845,7 @@ do_relaunch() {
   spawn_args=("$ID" --relaunch --harness "$TARGET_HARNESS")
   [ "$TARGET_MODEL" = default ] || spawn_args+=(--model "$TARGET_MODEL")
   [ "$TARGET_EFFORT" = default ] || spawn_args+=(--effort "$TARGET_EFFORT")
-  [ "$TARGET_TIER" = standard ] || spawn_args+=(--tier "$TARGET_TIER")
+  spawn_args+=(--tier "$TARGET_TIER")
   if FM_CONTROL_RELAUNCH_TX="$RELAUNCH_TX" \
       "$SCRIPT_DIR/fm-spawn.sh" "${spawn_args[@]}" >/dev/null; then
     RELAUNCH_META_PUBLISHED=1

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -5,7 +5,7 @@
 # Usage: fm-control.sh <task-id> interrupt
 #        fm-control.sh <task-id> exit
 #        fm-control.sh <task-id> relaunch [--harness <name>] [--model <name>]
-#                                         [--effort <level>]
+#                                         [--effort <level>] [--tier <standard|fast>]
 #                                         (--note <text> | --note-file <path>)
 #
 # Why this exists, and how it differs from fm-send.sh. bin/fm-send.sh is the
@@ -33,7 +33,7 @@
 #              Already-stopped is success (idempotent).
 #   relaunch   Transactionally replace the running agent with a new one, in the
 #              SAME endpoint and SAME worktree, on the same or a newly chosen
-#              harness/model/effort - so switching harness is one ordinary use
+#              harness/model/effort/tier - so switching harness is one ordinary use
 #              of this verb. With no explicit axis, a secondmate re-resolves its
 #              durable config/secondmate-harness pin (harness plus its optional
 #              model and effort tokens) exactly as any other respawn does, while
@@ -187,9 +187,11 @@ fi
 NEW_HARNESS=
 NEW_MODEL=
 NEW_EFFORT=
+NEW_TIER=
 HARNESS_SET=0
 MODEL_SET=0
 EFFORT_SET=0
+TIER_SET=0
 NOTE=
 NOTE_SET=0
 want_value=
@@ -202,6 +204,7 @@ for a in "$@"; do
       harness) NEW_HARNESS=$a; HARNESS_SET=1 ;;
       model) NEW_MODEL=$a; MODEL_SET=1 ;;
       effort) NEW_EFFORT=$a; EFFORT_SET=1 ;;
+      tier) NEW_TIER=$a; TIER_SET=1 ;;
       note) NOTE=$a; NOTE_SET=1 ;;
       note-file)
         [ -f "$a" ] || die "--note-file '$a' is not a readable file"
@@ -219,6 +222,8 @@ for a in "$@"; do
     --model=*) NEW_MODEL=${a#--model=}; MODEL_SET=1 ;;
     --effort) want_value=effort ;;
     --effort=*) NEW_EFFORT=${a#--effort=}; EFFORT_SET=1 ;;
+    --tier) want_value=tier ;;
+    --tier=*) NEW_TIER=${a#--tier=}; TIER_SET=1 ;;
     --note) want_value=note ;;
     --note=*) NOTE=${a#--note=}; NOTE_SET=1 ;;
     --note-file) want_value=note-file ;;
@@ -233,15 +238,20 @@ done
 [ -z "$want_value" ] || die "--$want_value requires a value"
 
 if [ "$VERB" != relaunch ]; then
-  [ "$HARNESS_SET" = 0 ] && [ "$MODEL_SET" = 0 ] && [ "$EFFORT_SET" = 0 ] && [ "$NOTE_SET" = 0 ] \
-    || die "--harness, --model, --effort, and --note apply to 'relaunch' only"
+  [ "$HARNESS_SET" = 0 ] && [ "$MODEL_SET" = 0 ] && [ "$EFFORT_SET" = 0 ] && [ "$TIER_SET" = 0 ] && [ "$NOTE_SET" = 0 ] \
+    || die "--harness, --model, --effort, --tier, and --note apply to 'relaunch' only"
 fi
 [ "$HARNESS_SET" = 0 ] || [ -n "$NEW_HARNESS" ] || die "--harness requires a non-empty value"
 [ "$MODEL_SET" = 0 ] || [ -n "$NEW_MODEL" ] || die "--model requires a non-empty value"
 [ "$EFFORT_SET" = 0 ] || [ -n "$NEW_EFFORT" ] || die "--effort requires a non-empty value"
+[ "$TIER_SET" = 0 ] || [ -n "$NEW_TIER" ] || die "--tier requires a non-empty value"
 case "$NEW_EFFORT" in
   ''|low|medium|high|xhigh|max) ;;
   *) die "--effort must be one of low, medium, high, xhigh, max" ;;
+esac
+case "$NEW_TIER" in
+  ''|standard|fast) ;;
+  *) die "--tier must be one of standard, fast" ;;
 esac
 
 # --- exact task-id resolution ----------------------------------------------
@@ -506,9 +516,11 @@ CONFIG_MODEL=
 CONFIG_EFFORT=
 PRIOR_MODEL=
 PRIOR_EFFORT=
+PRIOR_TIER=
 TARGET_HARNESS=$HARNESS
 TARGET_MODEL=
 TARGET_EFFORT=
+TARGET_TIER=
 
 journal_write() {  # <phase> [extra-line]...
   local phase=$1
@@ -525,9 +537,11 @@ journal_write() {  # <phase> [extra-line]...
     echo "from_harness=$PRIOR_RECORDED_HARNESS"
     echo "from_model=$PRIOR_MODEL"
     echo "from_effort=$PRIOR_EFFORT"
+    echo "from_tier=$PRIOR_TIER"
     echo "to_harness=$TARGET_HARNESS"
     echo "to_model=$TARGET_MODEL"
     echo "to_effort=$TARGET_EFFORT"
+    echo "to_tier=$TARGET_TIER"
     local line
     for line in "$@"; do
       echo "$line"
@@ -602,8 +616,10 @@ resolve_relaunch_profile() {
   PRIOR_RECORDED_HARNESS=$RECORDED_HARNESS
   PRIOR_MODEL=$(fm_meta_get "$META" model)
   PRIOR_EFFORT=$(fm_meta_get "$META" effort)
+  PRIOR_TIER=$(fm_meta_get "$META" tier)
   [ -n "$PRIOR_MODEL" ] || PRIOR_MODEL=default
   [ -n "$PRIOR_EFFORT" ] || PRIOR_EFFORT=default
+  [ -n "$PRIOR_TIER" ] || PRIOR_TIER=standard
   if [ "$HARNESS_SET" = 0 ] \
      && [ "$PRIOR_RECORDED_HARNESS" != "$PRIOR_HARNESS" ]; then
     die "task $ID records harness '$PRIOR_RECORDED_HARNESS', whose original launch command cannot be reconstructed from its recorded basename; relaunching without --harness would substitute the canonical adapter '$PRIOR_HARNESS' for the command actually running. Pass an explicit --harness to choose the replacement runtime deliberately"
@@ -647,8 +663,8 @@ resolve_relaunch_profile() {
   # transaction, where nothing has changed yet.
   fm_control_harness_supports_kind "$TARGET_HARNESS" "$KIND" \
     || die "'$TARGET_HARNESS' is not verified to run a $KIND task, so relaunching $ID onto it would stop the running agent for a launch that must be refused; choose an adapter verified for this kind"
-  # A model or effort chosen for the previous harness does not transfer to a
-  # different one, so an explicit harness change resets both axes unless the
+  # A model, effort, or tier chosen for the previous harness does not transfer
+  # to a different one, so an explicit harness change resets all axes unless the
   # caller names them too.
   if [ "$MODEL_SET" = 1 ]; then
     TARGET_MODEL=$NEW_MODEL
@@ -667,6 +683,13 @@ resolve_relaunch_profile() {
     TARGET_EFFORT=$PRIOR_EFFORT
   else
     TARGET_EFFORT=default
+  fi
+  if [ "$TIER_SET" = 1 ]; then
+    TARGET_TIER=$NEW_TIER
+  elif [ "$TARGET_HARNESS" = "$PRIOR_HARNESS" ]; then
+    TARGET_TIER=$PRIOR_TIER
+  else
+    TARGET_TIER=standard
   fi
 }
 
@@ -814,6 +837,7 @@ do_relaunch() {
   spawn_args=("$ID" --relaunch --harness "$TARGET_HARNESS")
   [ "$TARGET_MODEL" = default ] || spawn_args+=(--model "$TARGET_MODEL")
   [ "$TARGET_EFFORT" = default ] || spawn_args+=(--effort "$TARGET_EFFORT")
+  [ "$TARGET_TIER" = standard ] || spawn_args+=(--tier "$TARGET_TIER")
   if FM_CONTROL_RELAUNCH_TX="$RELAUNCH_TX" \
       "$SCRIPT_DIR/fm-spawn.sh" "${spawn_args[@]}" >/dev/null; then
     RELAUNCH_META_PUBLISHED=1
@@ -830,7 +854,7 @@ do_relaunch() {
 
   journal_write complete "${CHECKPOINT_LINES[@]}" "$note_line" "exit_result=$exit_result"
   RELAUNCH_ACTIVE=0
-  echo "relaunched $ID harness=$TARGET_HARNESS from=$PRIOR_RECORDED_HARNESS model=$TARGET_MODEL effort=$TARGET_EFFORT backend=$BACKEND endpoint=$T worktree=$WT"
+  echo "relaunched $ID harness=$TARGET_HARNESS from=$PRIOR_RECORDED_HARNESS model=$TARGET_MODEL effort=$TARGET_EFFORT tier=$TARGET_TIER backend=$BACKEND endpoint=$T worktree=$WT"
 }
 
 # --- verbs ------------------------------------------------------------------

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -130,6 +130,8 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 . "$SCRIPT_DIR/fm-busy-lib.sh"
 # shellcheck source=bin/fm-control-lib.sh
 . "$SCRIPT_DIR/fm-control-lib.sh"
+# shellcheck source=bin/fm-codex-tier-lib.sh
+. "$SCRIPT_DIR/fm-codex-tier-lib.sh"
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
 # shellcheck source=bin/fm-wake-lib.sh
@@ -701,6 +703,14 @@ resolve_relaunch_profile() {
   esac
 }
 
+preflight_relaunch_profile() {
+  [ "$TARGET_HARNESS" = codex ] && [ "$TARGET_TIER" = fast ] || return 0
+  fm_codex_fast_tier_runtime_resolve || return 1
+  fm_codex_fast_tier_supported \
+    "$WT" "$TARGET_MODEL" \
+    "$FM_CODEX_FAST_TIER_BIN" "$FM_CODEX_FAST_TIER_HOME"
+}
+
 # safe_checkpoint: prove, before anything is stopped, that the work a relaunch
 # must preserve is actually there and recoverable afterwards. Fills
 # CHECKPOINT_LINES with the journal lines describing what it proved, and
@@ -827,6 +837,8 @@ do_relaunch() {
     note_line="note=none"
   fi
   safe_checkpoint
+  preflight_relaunch_profile \
+    || die "Codex fast-tier capability could not be verified; refusing relaunch before stopping its agent"
   cp -p "$META" "$META_PRIOR" || die "could not preserve task $ID's durable record before relaunching"
   RELAUNCH_ACTIVE=1
   journal_write checkpoint "${CHECKPOINT_LINES[@]}" "$note_line"

--- a/bin/fm-remote-secondmate-control.sh
+++ b/bin/fm-remote-secondmate-control.sh
@@ -12,6 +12,8 @@
 #   fm-remote-secondmate-control.sh sync <id>
 #   fm-remote-secondmate-control.sh update <id>
 #   fm-remote-secondmate-control.sh retire <id> [--force]
+# Existing endpoint metadata must record tier=standard|fast; a missing legacy
+# tier refuses access instead of being guessed from current defaults.
 #
 # Remote placement ends here, but the second-mate agent always runs on the
 # Herdr backend in the dedicated fm-remote session, so launch refuses any other

--- a/bin/fm-remote-secondmate-control.sh
+++ b/bin/fm-remote-secondmate-control.sh
@@ -2,7 +2,7 @@
 # Host-local lifecycle control for the remote secondmate home selected by fm-on.
 #
 # Usage:
-#   fm-remote-secondmate-control.sh launch <id> <harness> <model|-> <effort|-> herdr [traceparent]
+#   fm-remote-secondmate-control.sh launch <id> <harness> <model|-> <effort|-> herdr [traceparent] [tier]
 #   fm-remote-secondmate-control.sh state <id>
 #   fm-remote-secondmate-control.sh route <id>
 #   fm-remote-secondmate-control.sh send <id> <message>
@@ -133,7 +133,7 @@ cmd_route() {
 }
 
 cmd_launch() {
-  local id=$1 harness=$2 model=$3 effort=$4 selected_backend=$5 traceparent=${6:-}
+  local id=$1 harness=$2 model=$3 effort=$4 selected_backend=$5 traceparent=${6:-} tier=${7:-standard}
   local current meta out herdr_session
 
   validate_id "$id"
@@ -143,6 +143,7 @@ cmd_launch() {
     *) die "unverified remote secondmate harness: $harness" ;;
   esac
   case "$effort" in -|low|medium|high|xhigh|max) ;; *) die "invalid remote secondmate effort: $effort" ;; esac
+  case "$tier" in standard|fast) ;; *) die "invalid remote secondmate tier: $tier" ;; esac
   # Herdr is required on this host, not merely preferred: its server belongs to
   # the GUI login session, so the endpoint survives every SSH disconnection that
   # a remote route depends on. bin/fm-remote-doctor.sh is the readiness owner.
@@ -168,6 +169,7 @@ cmd_launch() {
   ARGS=("$id" "$TARGET_HOME" --secondmate --harness "$harness" --backend "$selected_backend")
   [ "$model" = - ] || ARGS+=(--model "$model")
   [ "$effort" = - ] || ARGS+=(--effort "$effort")
+  [ "$tier" = standard ] || ARGS+=(--tier "$tier")
   [ -z "$traceparent" ] || ARGS+=(--traceparent "$traceparent")
   if ! out=$(HERDR_SESSION="$REMOTE_HERDR_SESSION" FM_HOME="$FM_ROOT" FM_ROOT_OVERRIDE="$FM_ROOT" \
     FM_STATE_OVERRIDE="$CONTROL_STATE" FM_DATA_OVERRIDE="$CONTROL_DATA" \
@@ -290,7 +292,7 @@ cmd_retire() {
 }
 
 case "${1:-}" in
-  launch) shift; [ "$#" -ge 5 ] && [ "$#" -le 6 ] || usage; cmd_launch "$@" ;;
+  launch) shift; [ "$#" -ge 5 ] && [ "$#" -le 7 ] || usage; cmd_launch "$@" ;;
   state) shift; [ "$#" -eq 1 ] || usage; validate_id "$1"; validate_home "$1"; state_value "$1" ;;
   route) shift; [ "$#" -eq 1 ] || usage; cmd_route "$1" ;;
   send) shift; [ "$#" -eq 2 ] || usage; cmd_send "$@" ;;

--- a/bin/fm-remote-secondmate-control.sh
+++ b/bin/fm-remote-secondmate-control.sh
@@ -83,6 +83,15 @@ remote_endpoint_load() {
     REMOTE_ENDPOINT_ERROR="remote secondmate $id endpoint is recorded in Herdr session '${herdr_session:-missing}', expected '$REMOTE_HERDR_SESSION'; refusing access until it is explicitly migrated"
     return 1
   fi
+  REMOTE_ENDPOINT_TIER=$(fm_meta_get "$REMOTE_ENDPOINT_META" tier)
+  [ -n "$REMOTE_ENDPOINT_TIER" ] || REMOTE_ENDPOINT_TIER=standard
+  case "$REMOTE_ENDPOINT_TIER" in
+    standard|fast) ;;
+    *)
+      REMOTE_ENDPOINT_ERROR="remote secondmate $id endpoint records invalid tier '$REMOTE_ENDPOINT_TIER'; refusing access until it is explicitly migrated"
+      return 1
+      ;;
+  esac
   case "$REMOTE_ENDPOINT_TARGET" in
     "$REMOTE_HERDR_SESSION":?*) ;;
     *)
@@ -118,6 +127,7 @@ print_route() { # <id>
   printf 'target=%s\n' "$REMOTE_ENDPOINT_TARGET"
   printf 'herdr_session=%s\n' "$REMOTE_HERDR_SESSION"
   printf 'harness=%s\n' "$harness"
+  printf 'tier=%s\n' "$REMOTE_ENDPOINT_TIER"
   [ -z "$traceparent" ] || printf 'traceparent=%s\n' "$traceparent"
 }
 

--- a/bin/fm-remote-secondmate-control.sh
+++ b/bin/fm-remote-secondmate-control.sh
@@ -84,9 +84,12 @@ remote_endpoint_load() {
     return 1
   fi
   REMOTE_ENDPOINT_TIER=$(fm_meta_get "$REMOTE_ENDPOINT_META" tier)
-  [ -n "$REMOTE_ENDPOINT_TIER" ] || REMOTE_ENDPOINT_TIER=standard
   case "$REMOTE_ENDPOINT_TIER" in
     standard|fast) ;;
+    '')
+      REMOTE_ENDPOINT_ERROR="remote secondmate $id endpoint has no recorded tier; refusing access until it is explicitly migrated or safely replaced"
+      return 1
+      ;;
     *)
       REMOTE_ENDPOINT_ERROR="remote secondmate $id endpoint records invalid tier '$REMOTE_ENDPOINT_TIER'; refusing access until it is explicitly migrated"
       return 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1306,6 +1306,7 @@ launch_template() {
   esac
 }
 
+CANONICAL_LAUNCH=0
 case "$ARG3" in
   *' '*)  # raw launch command (unverified-adapter escape hatch)
     LAUNCH=$ARG3
@@ -1335,12 +1336,19 @@ case "$ARG3" in
       harness_src='config/crew-harness'
     fi
     LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: no launch template for harness '$HARNESS' (from $harness_src or detection); pass a raw launch command to use an unverified adapter" >&2; exit 1; }
+    CANONICAL_LAUNCH=1
     ;;
   *)
     HARNESS=$ARG3
     LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: unknown harness '$HARNESS'; pass a raw launch command to use an unverified adapter" >&2; exit 1; }
+    CANONICAL_LAUNCH=1
     ;;
 esac
+
+if [ "$HARNESS" = codex ] && [ "$TIER" = fast ] && [ "$CANONICAL_LAUNCH" != 1 ]; then
+  echo "error: --tier fast requires Firstmate's canonical Codex launch template; raw Codex launch commands cannot be verified or rewritten safely" >&2
+  exit 1
+fi
 
 # muse is verified as a CREWMATE/SCOUT adapter only. A secondmate is a firstmate
 # instance, so it needs a primary supervision protocol; muse has none, and its

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -164,6 +164,7 @@
 #     __OPINPUT__   absolute path to the canonical operational-input encoder
 #     __WORKTREE__  absolute path to the task worktree
 #     __CURSORBIN__ resolved, cursor-verified executable for a cursor launch
+#     __CODEXCOMMAND__ resolved Codex executable with its effective config home
 #     __TIERFLAG__  quoted Codex per-spawn service-tier override
 # Verified per-harness turn-end hooks are installed automatically where enabled; some live outside the worktree.
 # Kimi uses one surgically installed Firstmate region in $HOME/.kimi-code/config.toml,
@@ -743,7 +744,6 @@ parse_orca_worktree_result() {
 
 spawn_abort_cleanup() {
   local status=$?
-  local -a treehouse_return_args
   if [ "$RELAUNCH_REPLACEMENT_PENDING" = 1 ] \
      && [ "$SPAWN_META_PUBLISH_STARTED" = 1 ] \
      && [ -n "$SPAWN_META_TMP" ] \
@@ -817,10 +817,12 @@ spawn_abort_cleanup() {
   fi
   if [ "$TREEHOUSE_ABORT_CLEANUP" = 1 ]; then
     TREEHOUSE_ABORT_CLEANUP=0
-    treehouse_return_args=(return --if-lease-holder "$ID")
-    [ "$TREEHOUSE_ABORT_FORCE" != 1 ] || treehouse_return_args+=(--force)
-    if ! (cd "$PROJ_ABS" && treehouse "${treehouse_return_args[@]}" "$TREEHOUSE_ABORT_WORKTREE" </dev/null); then
-      echo "warning: could not return pre-acquired worktree '$TREEHOUSE_ABORT_WORKTREE' after aborted spawn of $ID" >&2
+    if [ "$TREEHOUSE_ABORT_FORCE" = 1 ]; then
+      (cd "$PROJ_ABS" && treehouse return --force "$TREEHOUSE_ABORT_WORKTREE" </dev/null) \
+        || echo "warning: could not return pre-acquired worktree '$TREEHOUSE_ABORT_WORKTREE' after aborted spawn of $ID" >&2
+    else
+      (cd "$PROJ_ABS" && treehouse return "$TREEHOUSE_ABORT_WORKTREE" </dev/null) \
+        || echo "warning: could not return pre-acquired worktree '$TREEHOUSE_ABORT_WORKTREE' after aborted spawn of $ID" >&2
     fi
   fi
   if [ "$SPAWN_TASK_LOCK_HELD" = 1 ]; then
@@ -1176,6 +1178,41 @@ resolve_pi_executable() {
   esac
 }
 
+resolve_codex_executable() {
+  local candidate dir
+  candidate=$(type -P -- codex 2>/dev/null) || return 1
+  [ -x "$candidate" ] || return 1
+  case "$candidate" in
+    /*) printf '%s\n' "$candidate" ;;
+    *)
+      dir=$(cd "$(dirname "$candidate")" 2>/dev/null && pwd -P) || return 1
+      printf '%s/%s\n' "$dir" "$(basename "$candidate")"
+      ;;
+  esac
+}
+
+resolve_codex_home() {
+  local path
+  if [ "${CODEX_HOME+x}" = x ]; then
+    path=$CODEX_HOME
+    [ -n "$path" ] || {
+      echo "error: CODEX_HOME is set but empty; cannot pin the Codex launch configuration" >&2
+      return 1
+    }
+  else
+    [ -n "${HOME:-}" ] || {
+      echo "error: HOME is unset; cannot resolve Codex's default config home" >&2
+      return 1
+    }
+    path=$HOME/.codex
+  fi
+  [ -d "$path" ] || {
+    echo "error: effective CODEX_HOME directory does not exist: $path" >&2
+    return 1
+  }
+  resolve_directory_input CODEX_HOME "$path"
+}
+
 # Pi's CLI surface is version-dependent, so probe the resolved executable's help
 # before composing the optional regular-TUI flag. An absent or inconclusive probe
 # omits the flag so older Pi versions can still spawn.
@@ -1203,9 +1240,9 @@ launch_template() {
     claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     codex)
       if [ "$kind" = secondmate ]; then
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG____TIERFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' '__CODEXCOMMAND__ __MODELFLAG____EFFORTFLAG____TIERFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       else
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG____TIERFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' '__CODEXCOMMAND__ __MODELFLAG____EFFORTFLAG____TIERFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       fi
       ;;
     opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
@@ -1317,6 +1354,17 @@ if [ "$KIND" = secondmate ] && [ "$HARNESS" = muse ]; then
 fi
 
 case "$HARNESS" in
+  codex)
+    CODEX_COMMAND=codex
+    if [ "$TIER" = fast ]; then
+      CODEX_BIN=$(resolve_codex_executable) || {
+        echo "error: Codex executable not found; cannot verify --tier fast support" >&2
+        exit 1
+      }
+      CODEX_HOME_EFFECTIVE=$(resolve_codex_home) || exit 1
+      CODEX_COMMAND="CODEX_HOME=$(shell_quote "$CODEX_HOME_EFFECTIVE") $(shell_quote "$CODEX_BIN")"
+    fi
+    ;;
   pi|pi-signed)
     PI_BIN=$(resolve_pi_executable "$HARNESS") || {
       echo "error: $HARNESS executable not found on PATH; install it or select a different verified harness" >&2
@@ -1535,14 +1583,10 @@ tier_flag_for_harness() {
 }
 
 codex_fast_tier_supported() {
-  local worktree=$1 model=$2 codex_bin doctor catalog
+  local worktree=$1 model=$2 doctor catalog
   [ "$HARNESS" = codex ] && [ "$TIER" = fast ] || return 0
-  codex_bin=$(type -P -- codex 2>/dev/null) || {
-    echo "error: Codex executable not found; cannot verify --tier fast support" >&2
-    return 1
-  }
   if [ -z "$model" ] || [ "$model" = default ]; then
-    doctor=$(cd "$worktree" && "$codex_bin" doctor --json 2>/dev/null) || true
+    doctor=$(cd "$worktree" && CODEX_HOME="$CODEX_HOME_EFFECTIVE" "$CODEX_BIN" doctor --json 2>/dev/null) || true
     case "$doctor" in
       \{*\}) ;;
       *)
@@ -1572,7 +1616,7 @@ codex_fast_tier_supported() {
       return 1
     fi
   fi
-  if ! catalog=$(cd "$worktree" && "$codex_bin" debug models 2>/dev/null); then
+  if ! catalog=$(cd "$worktree" && CODEX_HOME="$CODEX_HOME_EFFECTIVE" "$CODEX_BIN" debug models 2>/dev/null); then
     echo "error: could not inspect the installed Codex model catalog; refusing --tier fast" >&2
     return 1
   fi
@@ -2025,10 +2069,6 @@ if [ "$HARNESS" = codex ] && [ "$TIER" = fast ]; then
     TREEHOUSE_GET_STATUS=0
     WT=$(cd "$PROJ_ABS" && treehouse get --lease --lease-holder "$ID") || TREEHOUSE_GET_STATUS=$?
     if [ "$TREEHOUSE_GET_STATUS" -ne 0 ]; then
-      if [ -n "$WT" ]; then
-        TREEHOUSE_ABORT_CLEANUP=1
-        TREEHOUSE_ABORT_WORKTREE=$WT
-      fi
       echo "error: treehouse get --lease failed to acquire a worktree for $ID" >&2
       exit 1
     fi
@@ -2935,6 +2975,7 @@ sq_worktree=$(shell_quote "$WT")
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
 TIERFLAG=$(tier_flag_for_harness "$HARNESS" "$TIER")
+[ "$HARNESS" != codex ] || LAUNCH=${LAUNCH//__CODEXCOMMAND__/$CODEX_COMMAND}
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
 LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
 LAUNCH=${LAUNCH//__TIERFLAG__/$TIERFLAG}

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -257,6 +257,8 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-backend.sh"
 # shellcheck source=bin/fm-control-lib.sh
 . "$SCRIPT_DIR/fm-control-lib.sh"
+# shellcheck source=bin/fm-codex-tier-lib.sh
+. "$SCRIPT_DIR/fm-codex-tier-lib.sh"
 # shellcheck source=bin/fm-gate-refuse-lib.sh
 . "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
 # shellcheck source=bin/fm-busy-lib.sh
@@ -369,6 +371,33 @@ case "$TIER" in
   *) echo "error: --tier must be one of standard, fast" >&2; exit 1 ;;
 esac
 
+resolve_secondmate_recovery_tier() {
+  local id=$1 harness=$2 meta recorded_tier recorded_harness recorded_family target_family
+  [ "$RELAUNCH" -eq 0 ] && [ "$KIND" = secondmate ] && [ "$TIER_SET" -eq 0 ] || return 0
+  meta="$STATE/$id.meta"
+  [ -f "$meta" ] && [ ! -L "$meta" ] \
+    && [ "$(fm_meta_get "$meta" kind)" = secondmate ] || return 0
+  recorded_tier=$(fm_meta_get "$meta" tier)
+  if [ -z "$recorded_tier" ] && [ -n "$(fm_meta_get "$meta" remote_host)" ]; then
+    echo "error: remote secondmate $id has no recorded tier; refusing recovery until it is explicitly migrated or safely replaced" >&2
+    return 1
+  fi
+  [ -n "$recorded_tier" ] || recorded_tier=standard
+  case "$recorded_tier" in
+    standard|fast) ;;
+    *) echo "error: secondmate $id has invalid recorded tier '$recorded_tier'; refusing recovery" >&2; return 1 ;;
+  esac
+  recorded_harness=$(fm_meta_get "$meta" harness)
+  recorded_family=$(fm_control_harness_family "$recorded_harness" 2>/dev/null || printf '%s' "$recorded_harness")
+  target_family=$(fm_control_harness_family "$harness" 2>/dev/null || printf '%s' "$harness")
+  if [ "$target_family" = "$recorded_family" ]; then
+    TIER=$recorded_tier
+  else
+    TIER=standard
+  fi
+  TIER_SET=1
+}
+
 # --relaunch reuses an existing task's endpoint, worktree, project, and kind,
 # so every axis this block resolves for a fresh spawn instead comes from that
 # task's own durable record below. Contradicting it on the command line is a
@@ -466,6 +495,11 @@ spawn_remote_secondmate() {
       return 1
       ;;
   esac
+  if ! resolve_secondmate_recovery_tier "$id" "$harness"; then
+    fm_lock_release "$registry_lock" || true
+    fm_lock_release "$SPAWN_TASK_LOCK" || true
+    return 1
+  fi
   model=${MODEL:--}
   effort=${EFFORT:--}
   tier=$TIER
@@ -955,25 +989,6 @@ if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in *
 fi
 ID=${POS[0]}
 fm_task_id_creation_valid "$ID" || { echo "error: invalid task id" >&2; exit 2; }
-if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" = secondmate ] && [ "$TIER_SET" -eq 0 ]; then
-  existing_secondmate_meta="$STATE/$ID.meta"
-  if [ -f "$existing_secondmate_meta" ] && [ ! -L "$existing_secondmate_meta" ] \
-     && [ "$(fm_meta_get "$existing_secondmate_meta" kind)" = secondmate ]; then
-    recorded_secondmate_tier=$(fm_meta_get "$existing_secondmate_meta" tier)
-    if [ -z "$recorded_secondmate_tier" ] \
-       && [ -n "$(fm_meta_get "$existing_secondmate_meta" remote_host)" ]; then
-      echo "error: remote secondmate $ID has no recorded tier; refusing recovery until it is explicitly migrated or safely replaced" >&2
-      exit 1
-    fi
-    [ -n "$recorded_secondmate_tier" ] || recorded_secondmate_tier=standard
-    case "$recorded_secondmate_tier" in
-      standard|fast) ;;
-      *) echo "error: secondmate $ID has invalid recorded tier '$recorded_secondmate_tier'; refusing recovery" >&2; exit 1 ;;
-    esac
-    TIER=$recorded_secondmate_tier
-    TIER_SET=1
-  fi
-fi
 if [ "$RELAUNCH" -eq 1 ]; then
   SPAWN_CONTROL_LOCK="$STATE/.control-$ID.lock"
   control_owner=$(cat "$SPAWN_CONTROL_LOCK/pid" 2>/dev/null || true)
@@ -1182,41 +1197,6 @@ resolve_pi_executable() {
   esac
 }
 
-resolve_codex_executable() {
-  local candidate dir
-  candidate=$(type -P -- codex 2>/dev/null) || return 1
-  [ -x "$candidate" ] || return 1
-  case "$candidate" in
-    /*) printf '%s\n' "$candidate" ;;
-    *)
-      dir=$(cd "$(dirname "$candidate")" 2>/dev/null && pwd -P) || return 1
-      printf '%s/%s\n' "$dir" "$(basename "$candidate")"
-      ;;
-  esac
-}
-
-resolve_codex_home() {
-  local path
-  if [ "${CODEX_HOME+x}" = x ]; then
-    path=$CODEX_HOME
-    [ -n "$path" ] || {
-      echo "error: CODEX_HOME is set but empty; cannot pin the Codex launch configuration" >&2
-      return 1
-    }
-  else
-    [ -n "${HOME:-}" ] || {
-      echo "error: HOME is unset; cannot resolve Codex's default config home" >&2
-      return 1
-    }
-    path=$HOME/.codex
-  fi
-  [ -d "$path" ] || {
-    echo "error: effective CODEX_HOME directory does not exist: $path" >&2
-    return 1
-  }
-  resolve_directory_input CODEX_HOME "$path"
-}
-
 # Pi's CLI surface is version-dependent, so probe the resolved executable's help
 # before composing the optional regular-TUI flag. An absent or inconclusive probe
 # omits the flag so older Pi versions can still spawn.
@@ -1349,6 +1329,8 @@ case "$ARG3" in
     ;;
 esac
 
+resolve_secondmate_recovery_tier "$ID" "$HARNESS" || exit 1
+
 if [ "$HARNESS" = codex ] && [ "$TIER" = fast ] && [ "$CANONICAL_LAUNCH" != 1 ]; then
   echo "error: --tier fast requires Firstmate's canonical Codex launch template; raw Codex launch commands cannot be verified or rewritten safely" >&2
   exit 1
@@ -1369,11 +1351,9 @@ case "$HARNESS" in
   codex)
     CODEX_COMMAND=codex
     if [ "$TIER" = fast ]; then
-      CODEX_BIN=$(resolve_codex_executable) || {
-        echo "error: Codex executable not found; cannot verify --tier fast support" >&2
-        exit 1
-      }
-      CODEX_HOME_EFFECTIVE=$(resolve_codex_home) || exit 1
+      fm_codex_fast_tier_runtime_resolve || exit 1
+      CODEX_BIN=$FM_CODEX_FAST_TIER_BIN
+      CODEX_HOME_EFFECTIVE=$FM_CODEX_FAST_TIER_HOME
       CODEX_COMMAND="CODEX_HOME=$(shell_quote "$CODEX_HOME_EFFECTIVE") $(shell_quote "$CODEX_BIN")"
     fi
     ;;
@@ -1592,61 +1572,6 @@ tier_flag_for_harness() {
       esac
       ;;
   esac
-}
-
-codex_fast_tier_supported() {
-  local worktree=$1 model=$2 doctor catalog
-  [ "$HARNESS" = codex ] && [ "$TIER" = fast ] || return 0
-  if [ -z "$model" ] || [ "$model" = default ]; then
-    doctor=$(cd "$worktree" && CODEX_HOME="$CODEX_HOME_EFFECTIVE" "$CODEX_BIN" doctor --json 2>/dev/null) || true
-    case "$doctor" in
-      \{*\}) ;;
-      *)
-        echo "error: could not resolve Codex's effective model; refusing --tier fast" >&2
-        return 1
-        ;;
-    esac
-    if ! model=$(printf '%s\n' "$doctor" | awk '
-      { json = json $0 }
-      END {
-        count = split(json, checks, /"id"[[:space:]]*:[[:space:]]*"/)
-        for (i = 2; i <= count; i++) {
-          id = checks[i]
-          sub(/".*/, "", id)
-          if (id != "config.load") continue
-          if (!match(checks[i], /"model"[[:space:]]*:[[:space:]]*"[^"]+"/)) exit 1
-          model = substr(checks[i], RSTART, RLENGTH)
-          sub(/^[^:]*:[[:space:]]*"/, "", model)
-          sub(/"$/, "", model)
-          print model
-          exit 0
-        }
-        exit 1
-      }
-    '); then
-      echo "error: could not resolve Codex's effective model; refusing --tier fast" >&2
-      return 1
-    fi
-  fi
-  if ! catalog=$(cd "$worktree" && CODEX_HOME="$CODEX_HOME_EFFECTIVE" "$CODEX_BIN" debug models 2>/dev/null); then
-    echo "error: could not inspect the installed Codex model catalog; refusing --tier fast" >&2
-    return 1
-  fi
-  if ! printf '%s\n' "$catalog" | awk -v wanted="$model" '
-    { json = json $0 }
-    END {
-      count = split(json, models, /"slug"[[:space:]]*:[[:space:]]*"/)
-      for (i = 2; i <= count; i++) {
-        slug = models[i]
-        sub(/".*/, "", slug)
-        if (slug == wanted && models[i] ~ /"service_tiers"[[:space:]]*:[[:space:]]*\[[^]]*"id"[[:space:]]*:[[:space:]]*"priority"/) exit 0
-      }
-      exit 1
-    }
-  '; then
-    echo "error: Codex model '$model' does not advertise the priority service tier; refusing --tier fast" >&2
-    return 1
-  fi
 }
 
 case "$LAUNCH" in
@@ -2074,9 +1999,9 @@ if [ "$HARNESS" = codex ] && [ "$TIER" = fast ]; then
   if [ "$RELAUNCH" -eq 1 ]; then
     CODEX_PREFLIGHT_CWD=$WT
     [ "$KIND" = secondmate ] || CODEX_PREFLIGHT_CWD=$RELAUNCH_WT
-    codex_fast_tier_supported "$CODEX_PREFLIGHT_CWD" "$MODEL" || exit 1
+    fm_codex_fast_tier_supported "$CODEX_PREFLIGHT_CWD" "$MODEL" "$CODEX_BIN" "$CODEX_HOME_EFFECTIVE" || exit 1
   elif [ "$KIND" = secondmate ]; then
-    codex_fast_tier_supported "$WT" "$MODEL" || exit 1
+    fm_codex_fast_tier_supported "$WT" "$MODEL" "$CODEX_BIN" "$CODEX_HOME_EFFECTIVE" || exit 1
   elif [ "$BACKEND" != orca ]; then
     TREEHOUSE_GET_STATUS=0
     WT=$(cd "$PROJ_ABS" && treehouse get --lease --lease-holder "$ID") || TREEHOUSE_GET_STATUS=$?
@@ -2102,7 +2027,7 @@ if [ "$HARNESS" = codex ] && [ "$TIER" = fast ]; then
     TREEHOUSE_ABORT_FORCE=1
     freshen_spawn_worktree_base "$WT" || exit 1
     WORKTREE_REFRESHED=1
-    codex_fast_tier_supported "$WT" "$MODEL" || exit 1
+    fm_codex_fast_tier_supported "$WT" "$MODEL" "$CODEX_BIN" "$CODEX_HOME_EFFECTIVE" || exit 1
     PREACQUIRED_WORKTREE=1
   fi
 fi
@@ -2350,7 +2275,7 @@ EOF
     if [ "$HARNESS" = codex ] && [ "$TIER" = fast ]; then
       freshen_spawn_worktree_base "$WT" || exit 1
       WORKTREE_REFRESHED=1
-      codex_fast_tier_supported "$WT" "$MODEL" || exit 1
+      fm_codex_fast_tier_supported "$WT" "$MODEL" "$CODEX_BIN" "$CODEX_HOME_EFFECTIVE" || exit 1
     fi
     if [ -z "$ORCA_TERMINAL" ]; then
       ORCA_TERMINAL=$(fm_backend_orca_terminal_create "$ORCA_WORKTREE_ID" "$W") || exit 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -39,6 +39,8 @@
 #   per-spawn axis that defaults to standard. The tier is only threaded into Codex,
 #   whose installed CLI was verified to support the service-tier override; an
 #   explicit tier on another harness is recorded and omitted with a warning.
+#   A fast Codex launch additionally refuses unless its resolved model advertises
+#   the priority service tier in the installed Codex model catalog.
 #   --backend <name> is the explicit runtime session-provider backend for this
 #   exact task only (docs/configuration.md "Runtime backend" owns when that flag
 #   is authorized). Without it, the script resolves FM_BACKEND, then
@@ -1518,6 +1520,40 @@ tier_flag_for_harness() {
   esac
 }
 
+codex_fast_tier_supported() {
+  local worktree=$1 model=$2 codex_bin doctor catalog
+  [ "$HARNESS" = codex ] && [ "$TIER" = fast ] || return 0
+  codex_bin=$(type -P -- codex 2>/dev/null) || {
+    echo "error: Codex executable not found; cannot verify --tier fast support" >&2
+    return 1
+  }
+  if [ -z "$model" ] || [ "$model" = default ]; then
+    if ! doctor=$(cd "$worktree" && "$codex_bin" doctor --json 2>/dev/null); then
+      echo "error: could not resolve Codex's effective model; refusing --tier fast" >&2
+      return 1
+    fi
+    if ! model=$(printf '%s\n' "$doctor" | jq -er '
+      [.checks[]? | select(.id == "config.load") | .details.model
+       | select(type == "string" and length > 0)] | last
+    ' 2>/dev/null); then
+      echo "error: could not resolve Codex's effective model; refusing --tier fast" >&2
+      return 1
+    fi
+  fi
+  if ! catalog=$(cd "$worktree" && "$codex_bin" debug models 2>/dev/null); then
+    echo "error: could not inspect the installed Codex model catalog; refusing --tier fast" >&2
+    return 1
+  fi
+  if ! printf '%s\n' "$catalog" | jq -e --arg model "$model" '
+    any(.models[]?;
+      .slug == $model
+      and any(.service_tiers[]?; .id == "priority"))
+  ' >/dev/null 2>&1; then
+    echo "error: Codex model '$model' does not advertise the priority service tier; refusing --tier fast" >&2
+    return 1
+  fi
+}
+
 case "$LAUNCH" in
   *__MUSEBIN__*)
     MUSE_BIN=$(resolve_muse_binary) || exit 1
@@ -2357,6 +2393,7 @@ fi
 if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
   freshen_spawn_worktree_base "$WT" || exit 1
 fi
+codex_fast_tier_supported "$WT" "$MODEL" || exit 1
 
 # Per-task temp root: /tmp/fm-<id>/ with Go's build temp nested at gotmp/. Go won't
 # create GOTMPDIR, so mkdir before it is used; fm-teardown removes the whole root.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Spawn a direct report: a crewmate in a treehouse or Orca worktree, or a
 # secondmate in its isolated firstmate home.
-# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
-#        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
-#        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] --secondmate
+# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--tier <standard|fast>] [--backend <name>]
+#        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--tier <standard|fast>] [--backend <name>]
+#        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--tier <standard|fast>] [--backend <name>] --secondmate
 #   --mode and --yolo are this task's delivery contract, REQUIRED for every ship
 #   spawn and refused on --scout and --secondmate spawns. Firstmate resolves both
 #   per task at intake (AGENTS.md section 7); data/projects.md holds the captain's
@@ -16,7 +16,7 @@
 #   loud one-line deviation notice is printed and the spawn continues.
 #   no-mistakes-prod-only is a registry policy rather than a task mode and is
 #   refused as a flag value.
-#        fm-spawn.sh <task-id> --relaunch [--harness <name>] [--model <name>] [--effort <level>]
+#        fm-spawn.sh <task-id> --relaunch [--harness <name>] [--model <name>] [--effort <level>] [--tier <standard|fast>]
 #   --relaunch launches a replacement agent for an EXISTING task into that
 #   task's own recorded endpoint and worktree instead of creating either. It is
 #   the launch half of the control plane (bin/fm-control.sh relaunch), which
@@ -26,7 +26,7 @@
 #   backend, kind, project or home, worktree, endpoint - comes from the task's
 #   validated state/<id>.meta, so --backend, --scout, --secondmate, a project
 #   positional, and batch pairs are all refused alongside it; only harness,
-#   model, and effort may change, which is what makes a harness switch one
+#   model, effort, and tier may change, which is what makes a harness switch one
 #   ordinary relaunch. It refuses unless the recorded endpoint is positively
 #   agent-free on a backend with a recovery-grade agent-state classifier (tmux
 #   or herdr), refuses unless the endpoint's shell is sitting in the recorded
@@ -34,10 +34,11 @@
 #   the new incarnation.
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
 #   positional harness arg still works for back-compat.
-#   --model <name> and --effort <low|medium|high|xhigh|max> are concrete profile
-#   axes chosen by firstmate at intake. They are only threaded into harnesses whose
-#   installed CLIs were verified to support that axis; unsupported axes are omitted
-#   from that harness's launch rather than guessed.
+#   --model <name>, --effort <low|medium|high|xhigh|max>, and
+#   --tier <standard|fast> are concrete profile axes chosen by firstmate at intake.
+#   The tier defaults to standard and is only threaded into Codex, whose installed
+#   CLI was verified to support the service-tier override; an explicit tier on
+#   another harness is recorded and omitted with a warning.
 #   --backend <name> is the explicit runtime session-provider backend for this
 #   exact task only (docs/configuration.md "Runtime backend" owns when that flag
 #   is authorized). Without it, the script resolves FM_BACKEND, then
@@ -141,7 +142,7 @@
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
-#   source of truth; shared --scout/--harness/--model/--effort/--backend/--mode/--yolo
+#   source of truth; shared --scout/--harness/--model/--effort/--tier/--backend/--mode/--yolo
 #   applies to every pair. A ship batch therefore carries one delivery contract, and each
 #   pair still checks it against its own brief; a batch spanning modes is two invocations.
 #   If config/crew-dispatch.json exists, shared --harness is required for crewmate
@@ -161,6 +162,7 @@
 #     __OPINPUT__   absolute path to the canonical operational-input encoder
 #     __WORKTREE__  absolute path to the task worktree
 #     __CURSORBIN__ resolved, cursor-verified executable for a cursor launch
+#     __TIERFLAG__  quoted Codex service-tier override
 # Verified per-harness turn-end hooks are installed automatically where enabled; some live outside the worktree.
 # Kimi uses one surgically installed Firstmate region in $HOME/.kimi-code/config.toml,
 # a firstmate-owned global hook and registry, and a gitignored per-task pointer.
@@ -271,6 +273,7 @@ KIND_SET=0
 HARNESS_ARG=
 MODEL=
 EFFORT=
+TIER=standard
 BACKEND_ARG=
 MODE=
 YOLO=
@@ -278,6 +281,7 @@ TRACEPARENT_ARG=
 HARNESS_SET=0
 MODEL_SET=0
 EFFORT_SET=0
+TIER_SET=0
 BACKEND_SET=0
 MODE_SET=0
 YOLO_SET=0
@@ -294,6 +298,7 @@ for a in "$@"; do
       harness) HARNESS_ARG=$a; HARNESS_SET=1 ;;
       model) MODEL=$a; MODEL_SET=1 ;;
       effort) EFFORT=$a; EFFORT_SET=1 ;;
+      tier) TIER=$a; TIER_SET=1 ;;
       backend) BACKEND_ARG=$a; BACKEND_SET=1 ;;
       mode) MODE=$a; MODE_SET=1 ;;
       yolo) YOLO=$a; YOLO_SET=1 ;;
@@ -313,6 +318,8 @@ for a in "$@"; do
     --model=*) MODEL=${a#--model=}; MODEL_SET=1 ;;
     --effort) want_value=effort ;;
     --effort=*) EFFORT=${a#--effort=}; EFFORT_SET=1 ;;
+    --tier) want_value=tier ;;
+    --tier=*) TIER=${a#--tier=}; TIER_SET=1 ;;
     --backend) want_value=backend ;;
     --backend=*) BACKEND_ARG=${a#--backend=}; BACKEND_SET=1 ;;
     --mode) want_value=mode ;;
@@ -328,6 +335,7 @@ done
 [ "$HARNESS_SET" -eq 0 ] || [ -n "$HARNESS_ARG" ] || { echo "error: --harness requires a non-empty value" >&2; exit 1; }
 [ "$MODEL_SET" -eq 0 ] || [ -n "$MODEL" ] || { echo "error: --model requires a non-empty value" >&2; exit 1; }
 [ "$EFFORT_SET" -eq 0 ] || [ -n "$EFFORT" ] || { echo "error: --effort requires a non-empty value" >&2; exit 1; }
+[ "$TIER_SET" -eq 0 ] || [ -n "$TIER" ] || { echo "error: --tier requires a non-empty value" >&2; exit 1; }
 [ "$BACKEND_SET" -eq 0 ] || [ -n "$BACKEND_ARG" ] || { echo "error: --backend requires a non-empty value" >&2; exit 1; }
 [ "$MODE_SET" -eq 0 ] || [ -n "$MODE" ] || { echo "error: --mode requires a non-empty value" >&2; exit 1; }
 [ "$YOLO_SET" -eq 0 ] || [ -n "$YOLO" ] || { echo "error: --yolo requires a non-empty value" >&2; exit 1; }
@@ -348,6 +356,10 @@ fi
 case "$EFFORT" in
   ''|low|medium|high|xhigh|max) ;;
   *) echo "error: --effort must be one of low, medium, high, xhigh, max" >&2; exit 1 ;;
+esac
+case "$TIER" in
+  standard|fast) ;;
+  *) echo "error: --tier must be one of standard, fast" >&2; exit 1 ;;
 esac
 
 # --relaunch reuses an existing task's endpoint, worktree, project, and kind,
@@ -397,7 +409,7 @@ else
 fi
 
 spawn_remote_secondmate() {
-  local id=$1 remote host root home harness positional model effort backend out rc meta tmp
+  local id=$1 remote host root home harness positional model effort tier backend out rc meta tmp
   local remote_backend remote_target remote_harness remote_herdr_session registry_lock remote_lock remote_generation
   local remote_traceparent remote_recorded_traceparent
   local -a launch_args
@@ -449,6 +461,7 @@ spawn_remote_secondmate() {
   esac
   model=${MODEL:--}
   effort=${EFFORT:--}
+  tier=$TIER
   if [ -z "$HARNESS_ARG" ] && [ -z "$positional" ]; then
     if [ "$MODEL_SET" -eq 0 ]; then
       model=$("$SCRIPT_DIR/fm-harness.sh" secondmate-model)
@@ -478,6 +491,15 @@ spawn_remote_secondmate() {
     fm_lock_release "$registry_lock" || true
     fm_lock_release "$SPAWN_TASK_LOCK" || true
       echo "error: invalid configured remote secondmate effort: $effort" >&2
+      return 1
+      ;;
+  esac
+  case "$tier" in
+    standard|fast) ;;
+    *)
+      fm_lock_release "$registry_lock" || true
+      fm_lock_release "$SPAWN_TASK_LOCK" || true
+      echo "error: invalid remote secondmate tier: $tier" >&2
       return 1
       ;;
   esac
@@ -556,7 +578,9 @@ spawn_remote_secondmate() {
     remote_traceparent=$(FM_TRACE_CONTEXT=on fm_trace_context_resolve "$CONFIG" "$meta" || true)
   fi
   launch_args=("$id" "$harness" "$model" "$effort" "$backend")
-  [ -z "$remote_traceparent" ] || launch_args+=("$remote_traceparent")
+  if [ -n "$remote_traceparent" ] || [ "$TIER_SET" -eq 1 ]; then
+    launch_args+=("$remote_traceparent" "$tier")
+  fi
   if out=$("$SCRIPT_DIR/fm-on.sh" "$id" fm-remote-secondmate-control.sh launch \
     "${launch_args[@]}" < /dev/null 2>&1); then
     rc=0
@@ -619,6 +643,7 @@ spawn_remote_secondmate() {
     echo "tasktmp="
     echo "model=${model#-}"
     echo "effort=${effort#-}"
+    echo "tier=$tier"
     echo "home=$home"
     echo "projects=$(secondmate_registry_field "$DATA/secondmates.md" "$id" projects)"
     echo "remote_host=$host"
@@ -754,6 +779,7 @@ spawn_abort_cleanup() {
             echo "tasktmp=${TASK_TMP:-}"
             echo "model=${MODEL:-default}"
             echo "effort=${EFFORT:-default}"
+            echo "tier=${TIER:-standard}"
             echo "backend=orca"
             echo "orca_worktree_id=$ORCA_WORKTREE_ID"
             [ -z "${ORCA_TERMINAL:-}" ] || echo "terminal=$ORCA_TERMINAL"
@@ -862,6 +888,7 @@ if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in *
   [ -z "$HARNESS_ARG" ] || shared_args+=(--harness "$HARNESS_ARG")
   [ -z "$MODEL" ] || shared_args+=(--model "$MODEL")
   [ -z "$EFFORT" ] || shared_args+=(--effort "$EFFORT")
+  [ "$TIER_SET" -eq 0 ] || shared_args+=(--tier "$TIER")
   [ -z "$BACKEND_ARG" ] || shared_args+=(--backend "$BACKEND_ARG")
   # One delivery contract applies to every pair in a batch, exactly like the shared
   # harness. Each pair still re-validates it against its own brief, so a batch
@@ -1008,6 +1035,14 @@ if [ "$RELAUNCH" -eq 1 ]; then
     exit 1
   }
   RELAUNCH_PRIOR_HARNESS=$(fm_meta_get "$RELAUNCH_META" harness)
+  if [ "$TIER_SET" -eq 0 ]; then
+    TIER=$(fm_meta_get "$RELAUNCH_META" tier)
+    [ -n "$TIER" ] || TIER=standard
+  fi
+  case "$TIER" in
+    standard|fast) ;;
+    *) echo "error: task $ID has invalid recorded tier '$TIER'; refusing relaunch" >&2; exit 1 ;;
+  esac
   KIND=$(fm_meta_get "$RELAUNCH_META" kind)
   [ -n "$KIND" ] || KIND=ship
   MODE=$(fm_meta_get "$RELAUNCH_META" mode)
@@ -1114,9 +1149,9 @@ launch_template() {
     claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     codex)
       if [ "$kind" = secondmate ]; then
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' 'codex __MODELFLAG____EFFORTFLAG____TIERFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       else
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' 'codex __MODELFLAG____EFFORTFLAG____TIERFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       fi
       ;;
     opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
@@ -1257,6 +1292,10 @@ case "$HARNESS" in
     fi
     ;;
 esac
+
+if [ "$TIER_SET" -eq 1 ] && [ "$HARNESS" != codex ]; then
+  echo "warning: harness '$HARNESS' has no verified serving-tier flag; recording tier=$TIER and omitting it from launch" >&2
+fi
 
 # config/secondmate-harness may carry optional model/effort tokens alongside the
 # harness ("<harness> [<model>] [<effort>]"). They apply only when this is a
@@ -1421,6 +1460,23 @@ effort_flag_for_harness() {
     # task metadata but never reaches the launch command. Cursor encodes effort
     # in model ids such as cursor-grok-4.5-high, so it also receives no separate
     # effort flag.
+  esac
+}
+
+tier_flag_for_harness() {
+  local harness=$1 tier=$2
+  [ -n "$tier" ] || return 0
+  case "$harness" in
+    codex)
+      # Codex 0.147.0 renders service_tier=default as the standard tier and
+      # service_tier=priority as Fast. Its model catalog advertises priority
+      # but no neutral tier, so default is the empirically verified override
+      # that defeats the operator's global priority setting without a warning.
+      case "$tier" in
+        standard) printf -- '-c %s ' "$(shell_quote "service_tier=\"default\"")" ;;
+        fast) printf -- '-c %s ' "$(shell_quote "service_tier=\"priority\"")" ;;
+      esac
+      ;;
   esac
 }
 
@@ -2632,7 +2688,7 @@ fi
 preserve_relaunch_meta() {
   awk -F= '
     BEGIN {
-      split("window endpoint_task_id worktree project harness kind mode yolo tasktmp model effort busy_gen spawn_gen traceparent backend herdr_session herdr_workspace_id herdr_tab_id herdr_pane_id zellij_session zellij_tab_id zellij_pane_id orca_worktree_id terminal cmux_workspace_id cmux_surface_id home projects control_relaunch_tx", keys, " ")
+      split("window endpoint_task_id worktree project harness kind mode yolo tasktmp model effort tier busy_gen spawn_gen traceparent backend herdr_session herdr_workspace_id herdr_tab_id herdr_pane_id zellij_session zellij_tab_id zellij_pane_id orca_worktree_id terminal cmux_workspace_id cmux_surface_id home projects control_relaunch_tx", keys, " ")
       for (i in keys) owned[keys[i]] = 1
     }
     !($1 in owned)
@@ -2650,6 +2706,7 @@ preserve_relaunch_meta() {
   echo "tasktmp=$TASK_TMP"
   echo "model=${MODEL:-default}"
   echo "effort=${EFFORT:-default}"
+  echo "tier=${TIER:-standard}"
   [ -z "${BUSY_GEN:-}" ] || echo "busy_gen=$BUSY_GEN"
   echo "spawn_gen=$SPAWN_GEN"
   # Default-off writes no traceparent= line.
@@ -2714,8 +2771,10 @@ sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
 sq_worktree=$(shell_quote "$WT")
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
+TIERFLAG=$(tier_flag_for_harness "$HARNESS" "$TIER")
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
 LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
+LAUNCH=${LAUNCH//__TIERFLAG__/$TIERFLAG}
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}
 LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -36,11 +36,15 @@
 #   positional harness arg still works for back-compat.
 #   --model <name> and --effort <low|medium|high|xhigh|max> are concrete profile
 #   axes chosen by firstmate at intake. --tier <standard|fast> is an optional
-#   per-spawn axis that defaults to standard. The tier is only threaded into Codex,
-#   whose installed CLI was verified to support the service-tier override; an
-#   explicit tier on another harness is recorded and omitted with a warning.
-#   A fast Codex launch additionally refuses unless its resolved model advertises
-#   the priority service tier in the installed Codex model catalog.
+#   per-spawn axis that defaults to standard. Firstmate's canonical Codex template
+#   receives the verified service-tier override; an explicit tier on another harness
+#   is recorded and omitted with a warning. A raw Codex command remains unmodified in
+#   standard mode, so its actual service tier is outside Firstmate's verified contract.
+#   Fast service requires the canonical Codex template; a raw Codex launch command is
+#   refused before task worktree or endpoint creation because its executable,
+#   configuration home, and tier override cannot be verified or rewritten safely.
+#   The canonical fast launch also refuses when its resolved model cannot be verified
+#   to advertise the priority service tier in the installed Codex model catalog.
 #   --backend <name> is the explicit runtime session-provider backend for this
 #   exact task only (docs/configuration.md "Runtime backend" owns when that flag
 #   is authorized). Without it, the script resolves FM_BACKEND, then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -34,11 +34,11 @@
 #   the new incarnation.
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
 #   positional harness arg still works for back-compat.
-#   --model <name>, --effort <low|medium|high|xhigh|max>, and
-#   --tier <standard|fast> are concrete profile axes chosen by firstmate at intake.
-#   The tier defaults to standard and is only threaded into Codex, whose installed
-#   CLI was verified to support the service-tier override; an explicit tier on
-#   another harness is recorded and omitted with a warning.
+#   --model <name> and --effort <low|medium|high|xhigh|max> are concrete profile
+#   axes chosen by firstmate at intake. --tier <standard|fast> is an optional
+#   per-spawn axis that defaults to standard. The tier is only threaded into Codex,
+#   whose installed CLI was verified to support the service-tier override; an
+#   explicit tier on another harness is recorded and omitted with a warning.
 #   --backend <name> is the explicit runtime session-provider backend for this
 #   exact task only (docs/configuration.md "Runtime backend" owns when that flag
 #   is authorized). Without it, the script resolves FM_BACKEND, then
@@ -162,7 +162,7 @@
 #     __OPINPUT__   absolute path to the canonical operational-input encoder
 #     __WORKTREE__  absolute path to the task worktree
 #     __CURSORBIN__ resolved, cursor-verified executable for a cursor launch
-#     __TIERFLAG__  quoted Codex service-tier override
+#     __TIERFLAG__  quoted Codex per-spawn service-tier override
 # Verified per-harness turn-end hooks are installed automatically where enabled; some live outside the worktree.
 # Kimi uses one surgically installed Firstmate region in $HOME/.kimi-code/config.toml,
 # a firstmate-owned global hook and registry, and a gitignored per-task pointer.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -940,6 +940,11 @@ if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" = secondmate ] && [ "$TIER_SET" -eq 0 ]; t
   if [ -f "$existing_secondmate_meta" ] && [ ! -L "$existing_secondmate_meta" ] \
      && [ "$(fm_meta_get "$existing_secondmate_meta" kind)" = secondmate ]; then
     recorded_secondmate_tier=$(fm_meta_get "$existing_secondmate_meta" tier)
+    if [ -z "$recorded_secondmate_tier" ] \
+       && [ -n "$(fm_meta_get "$existing_secondmate_meta" remote_host)" ]; then
+      echo "error: remote secondmate $ID has no recorded tier; refusing recovery until it is explicitly migrated or safely replaced" >&2
+      exit 1
+    fi
     [ -n "$recorded_secondmate_tier" ] || recorded_secondmate_tier=standard
     case "$recorded_secondmate_tier" in
       standard|fast) ;;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -410,7 +410,7 @@ fi
 
 spawn_remote_secondmate() {
   local id=$1 remote host root home harness positional model effort tier backend out rc meta tmp
-  local remote_backend remote_target remote_harness remote_herdr_session registry_lock remote_lock remote_generation
+  local remote_backend remote_target remote_harness remote_herdr_session remote_tier registry_lock remote_lock remote_generation
   local remote_traceparent remote_recorded_traceparent
   local -a launch_args
   id=${POS[0]:-}
@@ -503,6 +503,9 @@ spawn_remote_secondmate() {
       return 1
       ;;
   esac
+  if [ "$TIER_SET" -eq 1 ] && [ "$harness" != codex ]; then
+    echo "warning: harness '$harness' has no verified serving-tier flag; recording tier=$tier and omitting it from launch" >&2
+  fi
   meta="$STATE/$id.meta"
   if [ -e "$meta" ] || [ -L "$meta" ]; then
     if [ ! -f "$meta" ] || [ -L "$meta" ] \
@@ -601,6 +604,7 @@ spawn_remote_secondmate() {
   remote_target=$(printf '%s\n' "$out" | sed -n 's/^target=//p' | tail -1)
   remote_harness=$(printf '%s\n' "$out" | sed -n 's/^harness=//p' | tail -1)
   remote_herdr_session=$(printf '%s\n' "$out" | sed -n 's/^herdr_session=//p' | tail -1)
+  remote_tier=$(printf '%s\n' "$out" | sed -n 's/^tier=//p' | tail -1)
   if [ "$remote_backend" != herdr ]; then
     fm_lock_release "$remote_lock" || true
     fm_lock_release "$registry_lock" || true
@@ -620,6 +624,23 @@ spawn_remote_secondmate() {
     fm_lock_release "$registry_lock" || true
     fm_lock_release "$SPAWN_TASK_LOCK" || true
     echo "error: remote launch returned Herdr session '${remote_herdr_session:-missing}', expected 'fm-remote'; preserving the remote route for reconciliation" >&2
+    return 1
+  fi
+  case "$remote_tier" in
+    standard|fast) ;;
+    *)
+      fm_lock_release "$remote_lock" || true
+      fm_lock_release "$registry_lock" || true
+      fm_lock_release "$SPAWN_TASK_LOCK" || true
+      echo "error: remote launch returned tier '${remote_tier:-missing}', expected standard or fast; preserving the remote route for reconciliation" >&2
+      return 1
+      ;;
+  esac
+  if [ "$remote_tier" != "$tier" ]; then
+    fm_lock_release "$remote_lock" || true
+    fm_lock_release "$registry_lock" || true
+    fm_lock_release "$SPAWN_TASK_LOCK" || true
+    echo "error: remote launch returned tier '$remote_tier', expected '$tier'; preserving the remote route for reconciliation" >&2
     return 1
   fi
   # Record what the remote endpoint ACTUALLY carries, read back from its own
@@ -643,7 +664,7 @@ spawn_remote_secondmate() {
     echo "tasktmp="
     echo "model=${model#-}"
     echo "effort=${effort#-}"
-    echo "tier=$tier"
+    echo "tier=$remote_tier"
     echo "home=$home"
     echo "projects=$(secondmate_registry_field "$DATA/secondmates.md" "$id" projects)"
     echo "remote_host=$host"
@@ -914,6 +935,20 @@ if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in *
 fi
 ID=${POS[0]}
 fm_task_id_creation_valid "$ID" || { echo "error: invalid task id" >&2; exit 2; }
+if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" = secondmate ] && [ "$TIER_SET" -eq 0 ]; then
+  existing_secondmate_meta="$STATE/$ID.meta"
+  if [ -f "$existing_secondmate_meta" ] && [ ! -L "$existing_secondmate_meta" ] \
+     && [ "$(fm_meta_get "$existing_secondmate_meta" kind)" = secondmate ]; then
+    recorded_secondmate_tier=$(fm_meta_get "$existing_secondmate_meta" tier)
+    [ -n "$recorded_secondmate_tier" ] || recorded_secondmate_tier=standard
+    case "$recorded_secondmate_tier" in
+      standard|fast) ;;
+      *) echo "error: secondmate $ID has invalid recorded tier '$recorded_secondmate_tier'; refusing recovery" >&2; exit 1 ;;
+    esac
+    TIER=$recorded_secondmate_tier
+    TIER_SET=1
+  fi
+fi
 if [ "$RELAUNCH" -eq 1 ]; then
   SPAWN_CONTROL_LOCK="$STATE/.control-$ID.lock"
   control_owner=$(cat "$SPAWN_CONTROL_LOCK/pid" 2>/dev/null || true)

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -694,6 +694,11 @@ BACKEND=
 ORCA_ABORT_CLEANUP=0
 ORCA_WORKTREE_ID=
 ORCA_TERMINAL=
+PREACQUIRED_WORKTREE=0
+TREEHOUSE_ABORT_CLEANUP=0
+TREEHOUSE_ABORT_FORCE=0
+TREEHOUSE_ABORT_WORKTREE=
+WORKTREE_REFRESHED=0
 HERDR_PROJECTION_ABORT_CLEANUP=0
 HERDR_PROJECTION_ABORT_SESSION=
 HERDR_PROJECTION_ABORT_TASK_PANE=
@@ -738,6 +743,7 @@ parse_orca_worktree_result() {
 
 spawn_abort_cleanup() {
   local status=$?
+  local -a treehouse_return_args
   if [ "$RELAUNCH_REPLACEMENT_PENDING" = 1 ] \
      && [ "$SPAWN_META_PUBLISH_STARTED" = 1 ] \
      && [ -n "$SPAWN_META_TMP" ] \
@@ -807,6 +813,14 @@ spawn_abort_cleanup() {
           } > "$STATE/$ID.meta" 2>/dev/null || true
         fi
       fi
+    fi
+  fi
+  if [ "$TREEHOUSE_ABORT_CLEANUP" = 1 ]; then
+    TREEHOUSE_ABORT_CLEANUP=0
+    treehouse_return_args=(return --if-lease-holder "$ID")
+    [ "$TREEHOUSE_ABORT_FORCE" != 1 ] || treehouse_return_args+=(--force)
+    if ! (cd "$PROJ_ABS" && treehouse "${treehouse_return_args[@]}" "$TREEHOUSE_ABORT_WORKTREE" </dev/null); then
+      echo "warning: could not return pre-acquired worktree '$TREEHOUSE_ABORT_WORKTREE' after aborted spawn of $ID" >&2
     fi
   fi
   if [ "$SPAWN_TASK_LOCK_HELD" = 1 ]; then
@@ -1846,11 +1860,6 @@ BRIEF_REAL="$BRIEF_DIR_REAL/$(basename "$BRIEF")"
 # once here so every downstream comparison uses the same physical form
 # (docs/herdr-backend.md "Known gaps").
 PROJ_ABS_REAL=$(cd "$PROJ_ABS" 2>/dev/null && pwd -P) || PROJ_ABS_REAL="$PROJ_ABS"
-CODEX_PREFLIGHT_CWD=$PROJ_ABS_REAL
-if [ "$RELAUNCH" -eq 1 ] && [ "$KIND" != secondmate ]; then
-  CODEX_PREFLIGHT_CWD=$RELAUNCH_WT
-fi
-codex_fast_tier_supported "$CODEX_PREFLIGHT_CWD" "$MODEL" || exit 1
 
 real_path_or_raw() {  # <path>
   local path=$1 real
@@ -2005,6 +2014,50 @@ herdr_projection_existing_meta_allows_flat() {  # <meta>
   esac
 }
 
+if [ "$HARNESS" = codex ] && [ "$TIER" = fast ]; then
+  if [ "$RELAUNCH" -eq 1 ]; then
+    CODEX_PREFLIGHT_CWD=$WT
+    [ "$KIND" = secondmate ] || CODEX_PREFLIGHT_CWD=$RELAUNCH_WT
+    codex_fast_tier_supported "$CODEX_PREFLIGHT_CWD" "$MODEL" || exit 1
+  elif [ "$KIND" = secondmate ]; then
+    codex_fast_tier_supported "$WT" "$MODEL" || exit 1
+  elif [ "$BACKEND" != orca ]; then
+    TREEHOUSE_GET_STATUS=0
+    WT=$(cd "$PROJ_ABS" && treehouse get --lease --lease-holder "$ID") || TREEHOUSE_GET_STATUS=$?
+    if [ "$TREEHOUSE_GET_STATUS" -ne 0 ]; then
+      if [ -n "$WT" ]; then
+        TREEHOUSE_ABORT_CLEANUP=1
+        TREEHOUSE_ABORT_WORKTREE=$WT
+      fi
+      echo "error: treehouse get --lease failed to acquire a worktree for $ID" >&2
+      exit 1
+    fi
+    if [ -z "$WT" ]; then
+      echo "error: treehouse get --lease did not report a worktree for $ID" >&2
+      exit 1
+    fi
+    TREEHOUSE_ABORT_CLEANUP=1
+    TREEHOUSE_ABORT_WORKTREE=$WT
+    validate_spawn_worktree "treehouse get --lease" "$ID"
+    TREEHOUSE_WORKTREE_STATUS=$(git -C "$WT" status --porcelain) || {
+      echo "error: could not inspect pre-acquired worktree '$WT'" >&2
+      exit 1
+    }
+    if [ -n "$TREEHOUSE_WORKTREE_STATUS" ]; then
+      echo "error: pre-acquired worktree '$WT' is not clean; refusing to discard uncommitted work" >&2
+      exit 1
+    fi
+    TREEHOUSE_ABORT_FORCE=1
+    freshen_spawn_worktree_base "$WT" || exit 1
+    WORKTREE_REFRESHED=1
+    codex_fast_tier_supported "$WT" "$MODEL" || exit 1
+    PREACQUIRED_WORKTREE=1
+  fi
+fi
+
+SPAWN_INITIAL_CWD=$PROJ_ABS
+[ "$PREACQUIRED_WORKTREE" != 1 ] || SPAWN_INITIAL_CWD=$WT
+
 W="fm-$ID"
 if [ "$RELAUNCH" -eq 1 ]; then
   # Adopt the recorded endpoint instead of creating one. This is what keeps a
@@ -2028,7 +2081,7 @@ case "$BACKEND" in
     # treehouse cd's into the worktree. WT_TARGET carries that stable id for the
     # rename-critical worktree-detection steps below; the persisted window= handle
     # stays $T (the name form), which is safe now that rename is disabled.
-    WID=$(fm_backend_tmux_create_task "$SES" "$W" "$PROJ_ABS") || exit 1
+    WID=$(fm_backend_tmux_create_task "$SES" "$W" "$SPAWN_INITIAL_CWD") || exit 1
     WT_TARGET="$WID"
     ;;
   herdr)
@@ -2080,7 +2133,7 @@ case "$BACKEND" in
           FM_HOME="$HERDR_LABEL_HOME" fm_backend_herdr_projection_reclaim_task \
             "$HERDR_SES" "$HERDR_PRESENTATION_JOURNAL" "$ID" "$HERDR_LABEL_HOME" \
             "$HERDR_RECOVERY_WORKSPACE_ID" "$HERDR_RECOVERY_TAB_ID" "$HERDR_RECOVERY_PANE_ID" \
-            "$HERDR_PARENT_LABEL" "$W" "$PROJ_ABS"
+            "$HERDR_PARENT_LABEL" "$W" "$SPAWN_INITIAL_CWD"
           HERDR_RECLAIM_STATUS=$?
           set -e
           case "$HERDR_RECLAIM_STATUS" in
@@ -2134,7 +2187,7 @@ case "$BACKEND" in
             HERDR_PROJECTION_ID=$(fm_backend_herdr_projection_journal_create "$STATE" "$ID") || exit 1
             HERDR_PROJECTION_LABEL=$(fm_backend_herdr_projection_workspace_label "$ID" "$HERDR_PROJECTION_ID")
             if ! FM_HOME="$HERDR_LABEL_HOME" fm_backend_herdr_projection_create_task \
-              "$PROJ_ABS" "$HERDR_PROJECTION_LABEL" "$W"; then
+              "$SPAWN_INITIAL_CWD" "$HERDR_PROJECTION_LABEL" "$W"; then
               if [ "${FM_BACKEND_HERDR_PROJECTION_CLEANUP_SAFE:-0}" = 1 ]; then
                 HERDR_PROJECTION_ABORT_CLEANUP=1
                 HERDR_PROJECTION_ABORT_SESSION=$FM_BACKEND_HERDR_PROJECTION_SESSION
@@ -2187,7 +2240,7 @@ case "$BACKEND" in
       HERDR_SEEDED_DEFAULT_TAB_ID=${HERDR_CONTAINER_RAW#*$'\t'}
       HERDR_SES=${CONTAINER%%:*}
       HERDR_WORKSPACE_ID=${CONTAINER#*:}
-      HERDR_TASK_IDS=$(FM_HOME="$HERDR_LABEL_HOME" fm_backend_herdr_create_task "$CONTAINER" "$W" "$PROJ_ABS" "$HERDR_SEEDED_DEFAULT_TAB_ID") || exit 1
+      HERDR_TASK_IDS=$(FM_HOME="$HERDR_LABEL_HOME" fm_backend_herdr_create_task "$CONTAINER" "$W" "$SPAWN_INITIAL_CWD" "$HERDR_SEEDED_DEFAULT_TAB_ID") || exit 1
       read -r HERDR_TAB_ID HERDR_PANE_ID <<EOF
 $HERDR_TASK_IDS
 EOF
@@ -2200,7 +2253,7 @@ EOF
     ;;
   zellij)
     ZELLIJ_SES=$(fm_backend_zellij_container_ensure) || exit 1
-    ZELLIJ_TASK_IDS=$(fm_backend_zellij_create_task "$ZELLIJ_SES" "$W" "$PROJ_ABS") || exit 1
+    ZELLIJ_TASK_IDS=$(fm_backend_zellij_create_task "$ZELLIJ_SES" "$W" "$SPAWN_INITIAL_CWD") || exit 1
     read -r ZELLIJ_TAB_ID ZELLIJ_PANE_ID <<EOF
 $ZELLIJ_TASK_IDS
 EOF
@@ -2212,7 +2265,7 @@ EOF
     ;;
   cmux)
     fm_backend_cmux_container_ensure || exit 1
-    CMUX_TASK_IDS=$(fm_backend_cmux_create_task "$W" "$PROJ_ABS") || exit 1
+    CMUX_TASK_IDS=$(fm_backend_cmux_create_task "$W" "$SPAWN_INITIAL_CWD") || exit 1
     read -r CMUX_WORKSPACE_ID CMUX_SURFACE_ID <<EOF
 $CMUX_TASK_IDS
 EOF
@@ -2242,6 +2295,11 @@ EOF
       exit 1
     fi
     validate_spawn_worktree "orca worktree create" "$W"
+    if [ "$HARNESS" = codex ] && [ "$TIER" = fast ]; then
+      freshen_spawn_worktree_base "$WT" || exit 1
+      WORKTREE_REFRESHED=1
+      codex_fast_tier_supported "$WT" "$MODEL" || exit 1
+    fi
     if [ -z "$ORCA_TERMINAL" ]; then
       ORCA_TERMINAL=$(fm_backend_orca_terminal_create "$ORCA_WORKTREE_ID" "$W") || exit 1
     fi
@@ -2371,7 +2429,7 @@ if [ "$RELAUNCH" -eq 1 ]; then
     exit 1
   fi
   [ "$KIND" = secondmate ] || validate_spawn_worktree "relaunch" "$T"
-elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
+elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ] && [ "$PREACQUIRED_WORKTREE" != 1 ]; then
   spawn_send_text_line "$WT_TARGET" 'treehouse get'
 
   # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
@@ -2420,7 +2478,7 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
 
   validate_spawn_worktree "treehouse get" "$T"
 fi
-if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
+if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ] && [ "$WORKTREE_REFRESHED" != 1 ]; then
   freshen_spawn_worktree_base "$WT" || exit 1
 fi
 
@@ -2865,6 +2923,7 @@ if [ "$SPAWN_TASK_SET_LOCK_HELD" = 1 ]; then
   fm_lock_release "$SPAWN_TASK_SET_LOCK"
 fi
 [ "$BACKEND" = orca ] && ORCA_ABORT_CLEANUP=0
+[ "$PREACQUIRED_WORKTREE" != 1 ] || TREEHOUSE_ABORT_CLEANUP=0
 
 sq_brief=$(shell_quote "$BRIEF")
 sq_turnend=$(shell_quote "$TURNEND")

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1528,14 +1528,32 @@ codex_fast_tier_supported() {
     return 1
   }
   if [ -z "$model" ] || [ "$model" = default ]; then
-    if ! doctor=$(cd "$worktree" && "$codex_bin" doctor --json 2>/dev/null); then
-      echo "error: could not resolve Codex's effective model; refusing --tier fast" >&2
-      return 1
-    fi
-    if ! model=$(printf '%s\n' "$doctor" | jq -er '
-      [.checks[]? | select(.id == "config.load") | .details.model
-       | select(type == "string" and length > 0)] | last
-    ' 2>/dev/null); then
+    doctor=$(cd "$worktree" && "$codex_bin" doctor --json 2>/dev/null) || true
+    case "$doctor" in
+      \{*\}) ;;
+      *)
+        echo "error: could not resolve Codex's effective model; refusing --tier fast" >&2
+        return 1
+        ;;
+    esac
+    if ! model=$(printf '%s\n' "$doctor" | awk '
+      { json = json $0 }
+      END {
+        count = split(json, checks, /"id"[[:space:]]*:[[:space:]]*"/)
+        for (i = 2; i <= count; i++) {
+          id = checks[i]
+          sub(/".*/, "", id)
+          if (id != "config.load") continue
+          if (!match(checks[i], /"model"[[:space:]]*:[[:space:]]*"[^"]+"/)) exit 1
+          model = substr(checks[i], RSTART, RLENGTH)
+          sub(/^[^:]*:[[:space:]]*"/, "", model)
+          sub(/"$/, "", model)
+          print model
+          exit 0
+        }
+        exit 1
+      }
+    '); then
       echo "error: could not resolve Codex's effective model; refusing --tier fast" >&2
       return 1
     fi
@@ -1544,11 +1562,18 @@ codex_fast_tier_supported() {
     echo "error: could not inspect the installed Codex model catalog; refusing --tier fast" >&2
     return 1
   fi
-  if ! printf '%s\n' "$catalog" | jq -e --arg model "$model" '
-    any(.models[]?;
-      .slug == $model
-      and any(.service_tiers[]?; .id == "priority"))
-  ' >/dev/null 2>&1; then
+  if ! printf '%s\n' "$catalog" | awk -v wanted="$model" '
+    { json = json $0 }
+    END {
+      count = split(json, models, /"slug"[[:space:]]*:[[:space:]]*"/)
+      for (i = 2; i <= count; i++) {
+        slug = models[i]
+        sub(/".*/, "", slug)
+        if (slug == wanted && models[i] ~ /"service_tiers"[[:space:]]*:[[:space:]]*\[[^]]*"id"[[:space:]]*:[[:space:]]*"priority"/) exit 0
+      }
+      exit 1
+    }
+  '; then
     echo "error: Codex model '$model' does not advertise the priority service tier; refusing --tier fast" >&2
     return 1
   fi
@@ -1821,6 +1846,11 @@ BRIEF_REAL="$BRIEF_DIR_REAL/$(basename "$BRIEF")"
 # once here so every downstream comparison uses the same physical form
 # (docs/herdr-backend.md "Known gaps").
 PROJ_ABS_REAL=$(cd "$PROJ_ABS" 2>/dev/null && pwd -P) || PROJ_ABS_REAL="$PROJ_ABS"
+CODEX_PREFLIGHT_CWD=$PROJ_ABS_REAL
+if [ "$RELAUNCH" -eq 1 ] && [ "$KIND" != secondmate ]; then
+  CODEX_PREFLIGHT_CWD=$RELAUNCH_WT
+fi
+codex_fast_tier_supported "$CODEX_PREFLIGHT_CWD" "$MODEL" || exit 1
 
 real_path_or_raw() {  # <path>
   local path=$1 real
@@ -2393,7 +2423,6 @@ fi
 if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
   freshen_spawn_worktree_base "$WT" || exit 1
 fi
-codex_fast_tier_supported "$WT" "$MODEL" || exit 1
 
 # Per-task temp root: /tmp/fm-<id>/ with Go's build temp nested at gotmp/. Go won't
 # create GOTMPDIR, so mkdir before it is used; fm-teardown removes the whole root.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -574,16 +574,14 @@ spawn_remote_secondmate() {
   # carrier is resolved against THIS task's own meta (reused verbatim on
   # relaunch, freshly rooted otherwise, never adopting this process's ambient
   # TRACEPARENT) under this home's frozen decision, then handed to the remote
-  # host to export into the agent's pane. Disabled resolves to empty and the
-  # remote launch call stays byte-identical to the untraced one.
+  # host to export into the agent's pane. Disabled resolves to an empty
+  # positional carrier in the fixed tier-aware launch shape.
   remote_traceparent=
   if [ "$(fm_trace_context_session_effective "$STATE/.trace-context-effective")" = on ]; then
     remote_traceparent=$(FM_TRACE_CONTEXT=on fm_trace_context_resolve "$CONFIG" "$meta" || true)
   fi
   launch_args=("$id" "$harness" "$model" "$effort" "$backend")
-  if [ -n "$remote_traceparent" ] || [ "$TIER_SET" -eq 1 ]; then
-    launch_args+=("$remote_traceparent" "$tier")
-  fi
+  launch_args+=("$remote_traceparent" "$tier")
   if out=$("$SCRIPT_DIR/fm-on.sh" "$id" fm-remote-secondmate-control.sh launch \
     "${launch_args[@]}" < /dev/null 2>&1); then
     rc=0

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -947,6 +947,10 @@ families_for_changed_path() {
       printf '%s\n' pure-contract-unit
       printf '%s\n' live-harness-optin
       ;;
+    bin/fm-codex-tier-lib.sh)
+      printf '%s\n' backend-dispatch
+      printf '%s\n' secondmate
+      ;;
     bin/fm-spawn.sh|bin/fm-send.sh|bin/fm-harness.sh|\
     bin/fm-peek.sh|bin/fm-composer*)
       printf '%s\n' backend-dispatch

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -32,7 +32,7 @@ A recorded `harness=` is not always an exact adapter name: a task launched from 
 | --- | --- | --- |
 | `interrupt` | Deliver the harness's verified interrupt sequence while leaving the agent running. | Delivery succeeds while the endpoint still exists and the agent is still alive where the backend can classify that; cancellation is confirmed only from an adapter-owned acknowledgement and otherwise reports `cancel=unconfirmed`. |
 | `exit` | Stop the agent, preserving the endpoint, the worktree, and every uncommitted change. | The backend's recovery-grade classifier reports the agent gone. Already-stopped is idempotent success. |
-| `relaunch` | Replace the running agent with a new one in the same endpoint and worktree, on the exact recorded adapter or an explicitly chosen harness, model, and effort. | The new agent is alive on the recorded endpoint, and the durable record names the harness that is actually running. |
+| `relaunch` | Replace the running agent with a new one in the same endpoint and worktree, on the exact recorded adapter or an explicitly chosen harness, model, effort, and serving tier. | The new agent is alive on the recorded endpoint, and the durable record names the harness and serving tier that are actually selected. |
 
 An exit that delivers lifecycle input but cannot prove the agent stopped fails with `exit=unconfirmed`, reports the observed agent state and any interrupt cancellation claim, and never claims that nothing changed.
 Interrupt never rewrites busy state as proof of its own success.
@@ -56,11 +56,11 @@ It is not deterministic across the verified adapters: codex and grok resume only
 `relaunch` is the only verb that changes durable records, so it runs as a transaction with a journal at `state/<id>.control-relaunch`, the prior record preserved beside it, and a ship or scout's prior instructions preserved when a progress note is appended.
 
 1. **Resolve the profile.**
-   An explicit `--harness`, `--model`, or `--effort` wins.
+   An explicit `--harness`, `--model`, `--effort`, or `--tier` wins.
    Otherwise a `kind=secondmate` task re-resolves its durable `config/secondmate-harness` pin, including that file's optional model and effort tokens, exactly as every other respawn does - so setting the pin and relaunching is the ordinary way to move a secondmate's runtime.
    A ship or scout keeps the harness already recorded for it, because that harness comes from firstmate's dispatch-profile judgment at intake and must not be silently re-read from configuration.
    A recorded raw-command basename that differs from its resolved adapter cannot reproduce the command actually running, so relaunch refuses before the checkpoint unless the caller passes an explicit `--harness` to choose the replacement runtime deliberately.
-   A harness change resets model and effort unless they are named too, because a model chosen for one adapter does not transfer to another.
+   A harness change resets model, effort, and serving tier unless they are named too, because a profile axis chosen for one adapter does not transfer to another.
 2. **Safe checkpoint.**
    The recorded worktree must exist and be a worktree root; its head and dirty state are recorded.
    For a `kind=secondmate` task, the home's identity marker must match and its child records must be readable, so a relaunch can never strand child work behind an unreadable home.

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -32,7 +32,7 @@ A recorded `harness=` is not always an exact adapter name: a task launched from 
 | --- | --- | --- |
 | `interrupt` | Deliver the harness's verified interrupt sequence while leaving the agent running. | Delivery succeeds while the endpoint still exists and the agent is still alive where the backend can classify that; cancellation is confirmed only from an adapter-owned acknowledgement and otherwise reports `cancel=unconfirmed`. |
 | `exit` | Stop the agent, preserving the endpoint, the worktree, and every uncommitted change. | The backend's recovery-grade classifier reports the agent gone. Already-stopped is idempotent success. |
-| `relaunch` | Replace the running agent with a new one in the same endpoint and worktree, on the exact recorded adapter or an explicitly chosen harness, model, effort, and serving tier. | The new agent is alive on the recorded endpoint, and the durable record names the harness and serving tier that are actually selected. |
+| `relaunch` | Replace the running agent with a new one in the same endpoint and worktree, on the exact recorded adapter or an explicitly chosen harness, model, effort, and serving tier. | The new agent is alive on the recorded endpoint, and the durable record names the resolved launch profile. |
 
 An exit that delivers lifecycle input but cannot prove the agent stopped fails with `exit=unconfirmed`, reports the observed agent state and any interrupt cancellation claim, and never claims that nothing changed.
 Interrupt never rewrites busy state as proof of its own success.
@@ -61,6 +61,8 @@ It is not deterministic across the verified adapters: codex and grok resume only
    A ship or scout keeps the harness already recorded for it, because that harness comes from firstmate's dispatch-profile judgment at intake and must not be silently re-read from configuration.
    A recorded raw-command basename that differs from its resolved adapter cannot reproduce the command actually running, so relaunch refuses before the checkpoint unless the caller passes an explicit `--harness` to choose the replacement runtime deliberately.
    A harness change resets model, effort, and serving tier unless they are named too, because a profile axis chosen for one adapter does not transfer to another.
+   When the selected harness is unchanged and `--tier` is absent, relaunch preserves the recorded serving tier.
+   A missing tier in legacy local metadata resolves to standard, while an invalid recorded tier refuses before the safe checkpoint.
 2. **Safe checkpoint.**
    The recorded worktree must exist and be a worktree root; its head and dirty state are recorded.
    For a `kind=secondmate` task, the home's identity marker must match and its child records must be readable, so a relaunch can never strand child work behind an unreadable home.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -186,13 +186,13 @@ The intake and authority contract in `AGENTS.md` owns when separate scout resear
 ## Dispatch profiles
 
 Crewmate and scout dispatch can stay on the static crewmate harness resolved by `config/crew-harness`, or it can use local dispatch profiles in `config/crew-dispatch.json`.
-The dispatch file is intentionally judgment-based: firstmate reads the natural-language rules at intake, chooses the best matching rule, resolves profile arrays itself from current quota output under the `AGENTS.md` section 4 intake boundary and the `quota-array-dispatch` selection procedure, and passes only concrete `--harness`, `--model`, and `--effort` axes to `fm-spawn.sh`.
-Serving tier is a separate per-task intake choice and is deliberately not part of the dispatch-profile schema.
+The dispatch file is intentionally judgment-based: firstmate reads the natural-language rules at intake, chooses the best matching rule, resolves profile arrays itself from current quota output under the `AGENTS.md` section 4 intake boundary and the `quota-array-dispatch` selection procedure, and passes concrete `--harness`, `--model`, and `--effort` axes to `fm-spawn.sh`.
+Serving tier is a separate optional per-task spawn axis, defaults to standard, and is deliberately not part of the dispatch-profile schema.
 The shell scripts validate the JSON shape and verified harness/effort combinations, but they do not parse task intent, match natural-language rules, or own array selection.
 The session-start bootstrap step keeps valid dispatch configuration silent unless verbose facts are enabled and surfaces a concise invalid-config line when validation fails.
 When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
-Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
+Unsupported effort values and explicit serving tiers remain recorded in task meta when the selected harness cannot consume them, while the launch template omits unsupported flags and warns for an explicit unsupported tier.
 That keeps spawn launch compatible across claude, codex, opencode, pi, pi-signed, grok, kimi, cursor, and muse while preserving the requested profile for later audit.
 
 ## Optional secondmates

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -187,6 +187,7 @@ The intake and authority contract in `AGENTS.md` owns when separate scout resear
 
 Crewmate and scout dispatch can stay on the static crewmate harness resolved by `config/crew-harness`, or it can use local dispatch profiles in `config/crew-dispatch.json`.
 The dispatch file is intentionally judgment-based: firstmate reads the natural-language rules at intake, chooses the best matching rule, resolves profile arrays itself from current quota output under the `AGENTS.md` section 4 intake boundary and the `quota-array-dispatch` selection procedure, and passes only concrete `--harness`, `--model`, and `--effort` axes to `fm-spawn.sh`.
+Serving tier is a separate per-task intake choice and is deliberately not part of the dispatch-profile schema.
 The shell scripts validate the JSON shape and verified harness/effort combinations, but they do not parse task intent, match natural-language rules, or own array selection.
 The session-start bootstrap step keeps valid dispatch configuration silent unless verbose facts are enabled and surfaces a concise invalid-config line when validation fails.
 When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -218,8 +218,11 @@ The verified adapter evidence - each harness's busy-state source, interrupt and 
 The executable interrupt and exit mechanics live in [`bin/fm-control-lib.sh`](../bin/fm-control-lib.sh), and [`docs/agent-control.md`](agent-control.md) owns their lifecycle-control architecture.
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
 `fm-spawn.sh` records `tier=` on every task and accepts the optional `--tier standard|fast` spawn axis.
-Codex workers default to standard, and only an explicit `--tier fast` opts that spawn into fast service.
-The per-spawn override leaves the operator's global `~/.codex/config.toml` byte-identical.
+Firstmate's canonical Codex workers default to standard, and only an explicit `--tier fast` opts that spawn into fast service.
+Fast service is available only through the canonical Codex launch template, and the launch refuses before the agent starts or task metadata is published when the effective model cannot be resolved, the installed model catalog cannot be inspected, or that catalog does not advertise priority service for the model.
+Raw Codex launch commands remain unmodified in standard mode, so their actual service tier is outside Firstmate's verified contract, and they cannot request fast service because Firstmate cannot safely verify or rewrite their executable, configuration home, and tier override.
+The per-spawn override leaves the operator's effective Codex configuration, including `~/.codex/config.toml`, byte-identical.
+[`fm-spawn.sh --help`](../bin/fm-spawn.sh) owns the exact fast-tier preflight and refusal mechanics.
 An explicit tier on another harness remains recorded for relaunch but is omitted from the launch with a warning.
 Pi-family launches adapt the regular-TUI safeguard to the installed CLI's capabilities; [`fm-spawn.sh --help`](../bin/fm-spawn.sh) owns the exact version-safe launch mechanics.
 Enabled primary-session turn-end guard integrations are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -217,7 +217,10 @@ New harnesses get verified through a supervised trial task before joining the se
 The verified adapter evidence - each harness's busy-state source, interrupt and exit behavior, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 The executable interrupt and exit mechanics live in [`bin/fm-control-lib.sh`](../bin/fm-control-lib.sh), and [`docs/agent-control.md`](agent-control.md) owns their lifecycle-control architecture.
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
-The optional `--tier standard|fast` spawn axis defaults to standard, maps to Codex's verified `service_tier=default|priority` overrides, and is recorded for relaunch; other harnesses record an explicit tier and omit it from launch with a warning.
+`fm-spawn.sh` records `tier=` on every task and accepts the optional `--tier standard|fast` spawn axis.
+Codex workers default to standard, and only an explicit `--tier fast` opts that spawn into fast service.
+The per-spawn override leaves the operator's global `~/.codex/config.toml` byte-identical.
+An explicit tier on another harness remains recorded for relaunch but is omitted from the launch with a warning.
 Pi-family launches adapt the regular-TUI safeguard to the installed CLI's capabilities; [`fm-spawn.sh --help`](../bin/fm-spawn.sh) owns the exact version-safe launch mechanics.
 Enabled primary-session turn-end guard integrations are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).
 Kimi remains outside the primary turn-end guard integrations; [`docs/turnend-guard.md`](turnend-guard.md#compatibility-limits) owns its separate captain-approved crew wake hook.
@@ -251,7 +254,7 @@ For Pi and pi-signed secondmate launches, `fm-spawn.sh` starts the selected exec
 
 `config/crew-dispatch.json` is an optional local, gitignored file containing natural-language rules that firstmate reads before dispatching a crewmate or scout.
 The shell scripts do not match those rules; firstmate chooses the best matching rule with judgment, resolves its profile object or array under the operating contract in `AGENTS.md` section 4 and `quota-array-dispatch`, and passes concrete `--harness`, `--model`, and `--effort` flags to `fm-spawn.sh`.
-Serving tier is a separate per-task intake choice and is deliberately not a `config/crew-dispatch.json` field.
+Serving tier is a separate optional per-task spawn axis, defaults to standard, and is deliberately not a `config/crew-dispatch.json` field.
 When the file exists, `fm-spawn.sh` enforces that contract by refusing crewmate and scout spawns that lack an explicit harness (`--harness`, a positional adapter, or a raw launch command).
 Batch spawns satisfy the same requirement with a shared `--harness`.
 Secondmate spawns are exempt and still resolve through `config/secondmate-harness` and its optional model and effort tokens.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -217,6 +217,7 @@ New harnesses get verified through a supervised trial task before joining the se
 The verified adapter evidence - each harness's busy-state source, interrupt and exit behavior, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 The executable interrupt and exit mechanics live in [`bin/fm-control-lib.sh`](../bin/fm-control-lib.sh), and [`docs/agent-control.md`](agent-control.md) owns their lifecycle-control architecture.
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
+The optional `--tier standard|fast` spawn axis defaults to standard, maps to Codex's verified `service_tier=default|priority` overrides, and is recorded for relaunch; other harnesses record an explicit tier and omit it from launch with a warning.
 Pi-family launches adapt the regular-TUI safeguard to the installed CLI's capabilities; [`fm-spawn.sh --help`](../bin/fm-spawn.sh) owns the exact version-safe launch mechanics.
 Enabled primary-session turn-end guard integrations are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).
 Kimi remains outside the primary turn-end guard integrations; [`docs/turnend-guard.md`](turnend-guard.md#compatibility-limits) owns its separate captain-approved crew wake hook.
@@ -249,7 +250,8 @@ For Pi and pi-signed secondmate launches, `fm-spawn.sh` starts the selected exec
 ## Crew dispatch profiles (config/crew-dispatch.json)
 
 `config/crew-dispatch.json` is an optional local, gitignored file containing natural-language rules that firstmate reads before dispatching a crewmate or scout.
-The shell scripts do not match those rules; firstmate chooses the best matching rule with judgment, resolves its profile object or array under the operating contract in `AGENTS.md` section 4 and `quota-array-dispatch`, and passes only concrete `--harness`, `--model`, and `--effort` flags to `fm-spawn.sh`.
+The shell scripts do not match those rules; firstmate chooses the best matching rule with judgment, resolves its profile object or array under the operating contract in `AGENTS.md` section 4 and `quota-array-dispatch`, and passes concrete `--harness`, `--model`, and `--effort` flags to `fm-spawn.sh`.
+Serving tier is a separate per-task intake choice and is deliberately not a `config/crew-dispatch.json` field.
 When the file exists, `fm-spawn.sh` enforces that contract by refusing crewmate and scout spawns that lack an explicit harness (`--harness`, a positional adapter, or a raw launch command).
 Batch spawns satisfy the same requirement with a shared `--harness`.
 Secondmate spawns are exempt and still resolve through `config/secondmate-harness` and its optional model and effort tokens.

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -152,10 +152,13 @@ Launch or recover the remote second mate with the same command used for a local 
 bin/fm-spawn.sh <id> --secondmate
 ```
 
-The primary resolves the verified secondmate harness and optional model and effort, runs the same readiness gate the seed runs, transfers the inherited-material allowlist, and asks the remote host to launch on Herdr in `fm-remote`.
+The primary resolves the verified secondmate harness, optional model and effort, and serving tier, then runs the same readiness gate the seed runs, transfers the inherited-material allowlist, and asks the remote host to launch on Herdr in `fm-remote`.
+The recorded tier defaults to standard, an explicit `--tier fast` opts only a Codex spawn into fast service, and recovery preserves the tier recorded for the existing endpoint.
 All remote secondmates on one host share `fm-remote` and retain separate `2ndmate-<id>` workspaces inside it.
 An explicit request for any other backend is refused rather than honored, and the remote host refuses one too.
 An existing remote endpoint recorded in another Herdr session, including `default`, is classified as unverified and left untouched; launch, liveness recovery, control, and retirement refuse it until an operator explicitly migrates it instead of attempting a live cutover.
+An existing remote endpoint with missing or invalid tier metadata receives the same fail-closed treatment and is never assigned a tier by guess.
+Before publishing the primary route, launch reads back the remote endpoint's recorded tier and preserves the route without rewriting either record when that value is missing, invalid, or different from the requested tier.
 A launch after a host has drifted out of readiness fails with the doctor's own gap text instead of leaving a half-created endpoint.
 Raw launch commands are not accepted for remote secondmates.
 Backends that already refuse secondmate launch, currently Orca and cmux, remain unsupported on the remote host.

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -154,6 +154,7 @@ bin/fm-spawn.sh <id> --secondmate
 
 The primary resolves the verified secondmate harness, optional model and effort, and serving tier, then runs the same readiness gate the seed runs, transfers the inherited-material allowlist, and asks the remote host to launch on Herdr in `fm-remote`.
 The recorded tier defaults to standard, an explicit `--tier fast` opts only a Codex spawn into fast service, and recovery preserves the tier recorded for the existing endpoint.
+The primary never falls back to a pre-tier remote launch: an older remote code root refuses before mutation and must be updated before retrying.
 All remote secondmates on one host share `fm-remote` and retain separate `2ndmate-<id>` workspaces inside it.
 An explicit request for any other backend is refused rather than honored, and the remote host refuses one too.
 An existing remote endpoint recorded in another Herdr session, including `default`, is classified as unverified and left untouched; launch, liveness recovery, control, and retirement refuse it until an operator explicitly migrates it instead of attempting a live cutover.

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -153,7 +153,8 @@ bin/fm-spawn.sh <id> --secondmate
 ```
 
 The primary resolves the verified secondmate harness, optional model and effort, and serving tier, then runs the same readiness gate the seed runs, transfers the inherited-material allowlist, and asks the remote host to launch on Herdr in `fm-remote`.
-The recorded tier defaults to standard, an explicit `--tier fast` opts only a Codex spawn into fast service, and recovery preserves the tier recorded for the existing endpoint.
+The recorded tier defaults to standard, and an explicit `--tier fast` opts only a Codex spawn into fast service.
+Recovery preserves the recorded tier when the resolved harness family is unchanged; a harness-family change resets it to standard unless the caller explicitly supplies `--tier`.
 The primary never falls back to a pre-tier remote launch: an older remote code root refuses before mutation and must be updated before retrying.
 All remote secondmates on one host share `fm-remote` and retain separate `2ndmate-<id>` workspaces inside it.
 An explicit request for any other backend is refused rather than honored, and the remote host refuses one too.

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -120,12 +120,26 @@ SH
 exit 0
 SH
   chmod +x "$fb/sleep"
+  cat > "$fb/codex" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-} ${2:-}" in
+  'doctor --json')
+    printf '%s\n' '{"checks":[{"id":"config.load","details":{"model":"gpt-5.4"}}]}'
+    ;;
+  'debug models')
+    [ "${FM_FAKE_CODEX_CATALOG_STATUS:-0}" -eq 0 ] || exit "$FM_FAKE_CODEX_CATALOG_STATUS"
+    printf '%s\n' '{"models":[{"slug":"gpt-5.4","service_tiers":[{"id":"priority"}]}]}'
+    ;;
+esac
+SH
+  chmod +x "$fb/codex"
 }
 
 # new_case <name> [id] -> echoes a case dir with a live claude ship task.
 new_case() {
   local id=${2:-t1} dir="$TMP_ROOT/$1-$RANDOM"
-  mkdir -p "$dir/home/state" "$dir/home/data" "$dir/fake"
+  mkdir -p "$dir/home/state" "$dir/home/data" "$dir/fake" "$dir/codex-home"
   : > "$dir/fake/literal"
   : > "$dir/fake/keys"
   printf 'claude' > "$dir/fake/command"
@@ -165,6 +179,8 @@ run_control() {  # <case-dir> <args...>
   local dir=$1; shift
   env PATH="$dir/fakebin:$PATH" FM_HOME="$dir/home" FM_FAKE_DIR="$dir/fake" \
     FM_SPAWN_NO_GUARD=1 GROK_HOME="$dir/grokhome" \
+    CODEX_HOME="$dir/codex-home" \
+    FM_FAKE_CODEX_CATALOG_STATUS="${FM_FAKE_CODEX_CATALOG_STATUS:-0}" \
     FM_CONTROL_POLL=0.01 FM_CONTROL_EXIT_WAIT=0.05 FM_CONTROL_LAUNCH_WAIT=0.05 \
     FM_REAL_GIT="${FM_REAL_GIT:-}" FM_FAKE_GIT_FAILURE="${FM_FAKE_GIT_FAILURE:-}" \
     FM_REAL_MV="${FM_REAL_MV:-}" FM_FAKE_COMPLETE_JOURNAL_MV_FAIL="${FM_FAKE_COMPLETE_JOURNAL_MV_FAIL:-}" \
@@ -554,6 +570,31 @@ test_invalid_recorded_tier_refuses_before_stop() {
   cmp -s "$dir/meta.before" "$dir/home/state/rl37.meta" \
     || fail "an invalid recorded tier refusal must preserve metadata byte-identical"
   pass "fm-control relaunch: invalid recorded tiers fail closed before stop"
+}
+
+test_fast_codex_preflight_refuses_before_stop() {
+  local dir out rc FM_FAKE_CODEX_CATALOG_STATUS=1
+  dir=$(new_case fast-preflight rl38)
+  add_ship_task "$dir" rl38 codex
+  sed 's/^model=default$/model=gpt-5.4/; s/^tier=standard$/tier=fast/' \
+    "$dir/home/state/rl38.meta" > "$dir/home/state/rl38.meta.tmp"
+  mv "$dir/home/state/rl38.meta.tmp" "$dir/home/state/rl38.meta"
+  cp "$dir/home/state/rl38.meta" "$dir/meta.before"
+  printf 'codex' > "$dir/fake/command"
+
+  out=$(run_control "$dir" rl38 relaunch --note "keep the current worker"); rc=$?
+  expect_code 1 "$rc" "an unreadable Codex catalog should refuse before lifecycle mutation"
+  assert_contains "$out" "could not inspect the installed Codex model catalog" \
+    "the refusal should identify the unavailable capability evidence"
+  [ "$(cat "$dir/fake/command")" = codex ] \
+    || fail "a failed fast-tier preflight must leave the running Codex agent alive"
+  [ -z "$(cat "$dir/fake/literal")" ] \
+    || fail "a failed fast-tier preflight must send no lifecycle input"
+  cmp -s "$dir/meta.before" "$dir/home/state/rl38.meta" \
+    || fail "a failed fast-tier preflight must preserve metadata byte-identical"
+  [ ! -e "$dir/home/state/rl38.control-relaunch" ] \
+    || fail "a failed fast-tier preflight must not create a relaunch journal"
+  pass "fm-control relaunch: Codex fast-tier eligibility is proven before stop"
 }
 
 test_explicit_model_wins_over_the_recorded_one() {
@@ -1362,6 +1403,7 @@ test_prefixed_recorded_harness_requires_explicit_replacement
 test_same_harness_relaunch_keeps_the_profile_axes
 test_explicit_standard_tier_overrides_recorded_fast
 test_invalid_recorded_tier_refuses_before_stop
+test_fast_codex_preflight_refuses_before_stop
 test_explicit_model_wins_over_the_recorded_one
 test_relaunch_onto_an_unverified_harness_is_refused
 test_prior_harness_turnend_registry_entry_is_cleared

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -154,6 +154,7 @@ add_ship_task() {
     echo "tasktmp=/tmp/fm-$id"
     echo "model=default"
     echo "effort=default"
+    echo "tier=standard"
   } > "$home/state/$id.meta"
   printf '%s\n' "fm-$id" > "$dir/fake/windows"
   printf '%s' "$wt" > "$dir/fake/cwd"
@@ -509,13 +510,14 @@ test_same_harness_relaunch_keeps_the_profile_axes() {
   local dir out rc
   dir=$(new_case keepprofile rl6)
   add_ship_task "$dir" rl6 claude
-  sed 's/^model=default$/model=opus/; s/^effort=default$/effort=high/' \
+  sed 's/^model=default$/model=opus/; s/^effort=default$/effort=high/; s/^tier=standard$/tier=fast/' \
     "$dir/home/state/rl6.meta" > "$dir/home/state/rl6.meta.tmp"
   mv "$dir/home/state/rl6.meta.tmp" "$dir/home/state/rl6.meta"
   out=$(run_control "$dir" rl6 relaunch --note "same runtime"); rc=$?
   expect_code 0 "$rc" "a same-harness relaunch should succeed"$'\n'"$out"
   [ "$(meta_field "$dir" rl6 model)" = opus ] || fail "the model should carry across a same-harness relaunch"
   [ "$(meta_field "$dir" rl6 effort)" = high ] || fail "the effort should carry across a same-harness relaunch"
+  [ "$(meta_field "$dir" rl6 tier)" = fast ] || fail "the serving tier should carry across a same-harness relaunch"
   pass "fm-control relaunch: a same-harness relaunch keeps the profile axes it was running with"
 }
 

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -521,6 +521,41 @@ test_same_harness_relaunch_keeps_the_profile_axes() {
   pass "fm-control relaunch: a same-harness relaunch keeps the profile axes it was running with"
 }
 
+test_explicit_standard_tier_overrides_recorded_fast() {
+  local dir out rc
+  dir=$(new_case tier-override rl36)
+  add_ship_task "$dir" rl36 claude
+  sed 's/^tier=standard$/tier=fast/' "$dir/home/state/rl36.meta" > "$dir/home/state/rl36.meta.tmp"
+  mv "$dir/home/state/rl36.meta.tmp" "$dir/home/state/rl36.meta"
+  out=$(run_control "$dir" rl36 relaunch --tier standard --note "return to standard tier"); rc=$?
+  expect_code 0 "$rc" "an explicit standard tier should override the recorded fast tier"$'\n'"$out"
+  [ "$(meta_field "$dir" rl36 tier)" = standard ] \
+    || fail "the replacement metadata should record the explicit standard tier"
+  [ "$(journal_field "$dir" rl36 to_tier)" = standard ] \
+    || fail "the relaunch journal should agree with the replacement tier"
+  pass "fm-control relaunch: explicit standard tier overrides a recorded fast tier"
+}
+
+test_invalid_recorded_tier_refuses_before_stop() {
+  local dir out rc
+  dir=$(new_case invalid-tier rl37)
+  add_ship_task "$dir" rl37 claude
+  sed 's/^tier=standard$/tier=burst/' "$dir/home/state/rl37.meta" > "$dir/home/state/rl37.meta.tmp"
+  mv "$dir/home/state/rl37.meta.tmp" "$dir/home/state/rl37.meta"
+  cp "$dir/home/state/rl37.meta" "$dir/meta.before"
+  out=$(run_control "$dir" rl37 relaunch --tier standard --note "keep running"); rc=$?
+  expect_code 1 "$rc" "an invalid recorded tier should refuse before lifecycle mutation"
+  assert_contains "$out" "invalid recorded tier 'burst'" \
+    "the refusal should name the invalid durable tier"
+  [ "$(cat "$dir/fake/command")" = claude ] \
+    || fail "an invalid recorded tier must not stop the running agent"
+  [ -z "$(cat "$dir/fake/literal")" ] \
+    || fail "an invalid recorded tier must send no lifecycle input"
+  cmp -s "$dir/meta.before" "$dir/home/state/rl37.meta" \
+    || fail "an invalid recorded tier refusal must preserve metadata byte-identical"
+  pass "fm-control relaunch: invalid recorded tiers fail closed before stop"
+}
+
 test_explicit_model_wins_over_the_recorded_one() {
   local dir out rc
   dir=$(new_case explicit rl7)
@@ -1325,6 +1360,8 @@ test_harness_switch_does_not_carry_the_old_profile_axes
 test_harness_switch_resolves_a_prefixed_recorded_harness
 test_prefixed_recorded_harness_requires_explicit_replacement
 test_same_harness_relaunch_keeps_the_profile_axes
+test_explicit_standard_tier_overrides_recorded_fast
+test_invalid_recorded_tier_refuses_before_stop
 test_explicit_model_wins_over_the_recorded_one
 test_relaunch_onto_an_unverified_harness_is_refused
 test_prior_harness_turnend_registry_entry_is_cleared

--- a/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
@@ -752,6 +752,42 @@ assert_contains "$invalid_tier_out" "records invalid tier 'burst'" \
 mv -f "$TMP_ROOT/remote-ios-before-invalid-tier.meta" "$remote_route_meta"
 pass "remote endpoint serving tiers are returned, validated, and matched before parent publication"
 
+cp "$remote_route_meta" "$TMP_ROOT/remote-ios-before-missing-tier.meta"
+cp "$PARENT/state/ios.meta" "$TMP_ROOT/parent-ios-before-missing-tier.meta"
+sed '/^tier=/d' "$TMP_ROOT/remote-ios-before-missing-tier.meta" > "$remote_route_meta"
+sed '/^tier=/d' "$TMP_ROOT/parent-ios-before-missing-tier.meta" > "$PARENT/state/ios.meta"
+cp "$remote_route_meta" "$TMP_ROOT/remote-ios-missing-tier.meta"
+cp "$PARENT/state/ios.meta" "$TMP_ROOT/parent-ios-missing-tier.meta"
+cp "$HERDR_LOG" "$TMP_ROOT/herdr-before-missing-tier.log"
+[ "$(remote_env "$ROOT/bin/fm-on.sh" ios fm-remote-secondmate-control.sh state ios 2>/dev/null)" = unverified ] \
+  || fail "live remote endpoint with missing tier metadata was not classified unverified"
+if missing_tier_route_out=$(remote_env "$ROOT/bin/fm-on.sh" ios fm-remote-secondmate-control.sh route ios 2>&1); then
+  fail "remote control synthesized a tier for an endpoint with missing tier metadata"
+fi
+assert_contains "$missing_tier_route_out" "endpoint has no recorded tier" \
+  "remote missing-tier refusal did not identify the absent endpoint tier"
+if missing_tier_launch_out=$(remote_env "$ROOT/bin/fm-on.sh" ios fm-remote-secondmate-control.sh launch ios codex - - herdr 2>&1); then
+  fail "remote control reused a live endpoint with missing tier metadata"
+fi
+assert_contains "$missing_tier_launch_out" "endpoint has no recorded tier" \
+  "remote live-reuse refusal did not identify the absent endpoint tier"
+if missing_parent_tier_out=$(remote_env "$ROOT/bin/fm-spawn.sh" ios --secondmate 2>&1); then
+  fail "parent recovery synthesized a tier for a legacy remote endpoint"
+fi
+assert_contains "$missing_parent_tier_out" "remote secondmate ios has no recorded tier" \
+  "parent missing-tier refusal did not identify the absent remote tier"
+cmp -s "$TMP_ROOT/remote-ios-missing-tier.meta" "$remote_route_meta" \
+  || fail "remote missing-tier refusal changed endpoint metadata"
+cmp -s "$TMP_ROOT/parent-ios-missing-tier.meta" "$PARENT/state/ios.meta" \
+  || fail "parent missing-tier refusal changed route metadata"
+assert_no_grep '^tier=' "$remote_route_meta" "remote missing-tier refusal synthesized endpoint metadata"
+assert_no_grep '^tier=' "$PARENT/state/ios.meta" "parent missing-tier refusal synthesized route metadata"
+cmp -s "$TMP_ROOT/herdr-before-missing-tier.log" "$HERDR_LOG" \
+  || fail "remote missing-tier refusal touched the live endpoint"
+mv -f "$TMP_ROOT/remote-ios-before-missing-tier.meta" "$remote_route_meta"
+mv -f "$TMP_ROOT/parent-ios-before-missing-tier.meta" "$PARENT/state/ios.meta"
+pass "live legacy remote endpoints with missing tiers fail closed"
+
 cp "$remote_route_meta" "$TMP_ROOT/remote-ios-before-tier-warning.meta"
 cp "$PARENT/state/ios.meta" "$TMP_ROOT/parent-ios-before-tier-warning.meta"
 sed 's/^harness=codex$/harness=claude/' "$TMP_ROOT/remote-ios-before-tier-warning.meta" > "$remote_route_meta"

--- a/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
@@ -205,6 +205,18 @@ if [ "${FM_FAKE_SSH_MODE:-normal}" = doctor-fixable ] \
   printf 'unreadable\n'
   exit 0
 fi
+if [ "${FM_FAKE_SSH_MODE:-normal}" = legacy-tier-protocol ] \
+  && [ "$command_name" = fm-remote-secondmate-control.sh ] \
+  && [ "$_command_action" = launch ]; then
+  control_argc=$(perl -MMIME::Base64=decode_base64 -e '
+    my @args=split(/\0/, decode_base64($ARGV[0]));
+    print scalar(@args) - 2;
+  ' "$argv_b64")
+  case "$control_argc" in
+    5|6) touch "$FM_FAKE_LEGACY_LAUNCH"; exit 0 ;;
+    *) exit 2 ;;
+  esac
+fi
 case "${FM_FAKE_SSH_MODE:-normal}:$command_name:$command_rel" in
   launch-nonherdr-route:fm-remote-secondmate-control.sh:*)
     [ "$_command_action" = launch ] || exit 93
@@ -275,6 +287,7 @@ remote_env() {
   FM_FAKE_INHERIT_PAYLOAD="$TMP_ROOT/inherit.payload" \
   FM_FAKE_LAUNCH_ENTERED="$TMP_ROOT/launch.entered" \
   FM_FAKE_LAUNCH_RELEASE="$TMP_ROOT/launch.release" \
+  FM_FAKE_LEGACY_LAUNCH="$TMP_ROOT/legacy-launch.entered" \
   FM_SEND_SETTLE=0 FM_SEND_SLEEP=0 FM_REMOTE_REPLY_WAIT_SECONDS=10 \
   "$@"
 }
@@ -704,6 +717,17 @@ launches_after_inherit=0
 [ "$launches_before_inherit" -eq "$launches_after_inherit" ] \
   || fail "remote spawn reached launch after ambiguous partial inheritance"
 assert_absent "$PARENT/state/ios.meta" "failed remote inheritance published launch metadata"
+rm -f "$TMP_ROOT/legacy-launch.entered"
+if FM_FAKE_SSH_MODE=legacy-tier-protocol remote_env "$ROOT/bin/fm-spawn.sh" ios --secondmate \
+  > "$TMP_ROOT/spawn-legacy-tier-protocol.out" 2>&1; then
+  fail "remote spawn succeeded against a peer without tier protocol support"
+fi
+assert_absent "$TMP_ROOT/legacy-launch.entered" \
+  "legacy remote peer entered its launch handler without a tier override"
+assert_absent "$PARENT/state/ios.meta" \
+  "legacy remote protocol refusal published parent endpoint metadata"
+pass "legacy remote peers refuse tier-aware launches before mutation"
+
 out=$(remote_env "$ROOT/bin/fm-spawn.sh" ios --secondmate)
 assert_contains "$out" 'remote=remote-mac backend=herdr' "remote spawn did not report separate host and backend dimensions"
 assert_grep 'remote_host=remote-mac' "$PARENT/state/ios.meta" "parent metadata omitted the remote host"

--- a/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
@@ -714,6 +714,10 @@ assert_grep 'herdr_session=fm-remote' "$REMOTE_HOME/state/parent-route/ios.meta"
 assert_grep '--session fm-remote' "$HERDR_LOG" "remote launch did not target the fm-remote session"
 assert_no_grep '--session default' "$HERDR_LOG" "remote launch targeted the interactive default session"
 assert_grep 'window=remote:ios' "$PARENT/state/ios.meta" "parent metadata pretended the endpoint was local"
+assert_grep 'tier=standard' "$PARENT/state/ios.meta" "parent metadata omitted the remote serving tier"
+assert_grep 'tier=standard' "$REMOTE_HOME/state/parent-route/ios.meta" "remote endpoint metadata omitted its serving tier"
+assert_grep 'tier=standard' <(remote_env "$ROOT/bin/fm-on.sh" ios fm-remote-secondmate-control.sh route ios) \
+  "remote route did not report its actual serving tier"
 assert_present "$PARENT/state/procevent/remote-reply-ios.source" "remote spawn did not arm its reply source"
 publish_healthy_watcher_identity "$PARENT/state" "$PARENT" "$ROOT/bin/fm-watch.sh"
 [ "$(remote_env "$ROOT/bin/fm-on.sh" ios fm-remote-secondmate-control.sh state ios)" = alive ] \
@@ -723,6 +727,42 @@ publish_healthy_watcher_identity "$PARENT/state" "$PARENT" "$ROOT/bin/fm-watch.s
 [ "$(remote_env "$ROOT/bin/fm-on.sh" ios fm-remote-secondmate-control.sh observe ios)" = idle ] \
   || fail "remote endpoint delivery observation did not execute on its own host"
 pass "remote spawn launches on the remote-local backend and records a host-qualified route"
+
+remote_route_meta="$REMOTE_HOME/state/parent-route/ios.meta"
+cp "$remote_route_meta" "$TMP_ROOT/remote-ios-before-tier-mismatch.meta"
+cp "$PARENT/state/ios.meta" "$TMP_ROOT/parent-ios-before-tier-mismatch.meta"
+sed 's/^tier=standard$/tier=fast/' "$TMP_ROOT/remote-ios-before-tier-mismatch.meta" > "$remote_route_meta"
+if tier_mismatch_out=$(remote_env "$ROOT/bin/fm-spawn.sh" ios --secondmate 2>&1); then
+  fail "parent accepted a live remote endpoint on a different serving tier"
+fi
+assert_contains "$tier_mismatch_out" "remote launch returned tier 'fast', expected 'standard'" \
+  "remote tier mismatch refusal did not name the actual and requested tiers"
+cmp -s "$TMP_ROOT/parent-ios-before-tier-mismatch.meta" "$PARENT/state/ios.meta" \
+  || fail "remote tier mismatch rewrote the parent endpoint metadata"
+assert_grep 'tier=fast' "$remote_route_meta" "remote tier mismatch rewrote the live endpoint tier"
+mv -f "$TMP_ROOT/remote-ios-before-tier-mismatch.meta" "$remote_route_meta"
+
+cp "$remote_route_meta" "$TMP_ROOT/remote-ios-before-invalid-tier.meta"
+sed 's/^tier=standard$/tier=burst/' "$TMP_ROOT/remote-ios-before-invalid-tier.meta" > "$remote_route_meta"
+if invalid_tier_out=$(remote_env "$ROOT/bin/fm-on.sh" ios fm-remote-secondmate-control.sh route ios 2>&1); then
+  fail "remote control accepted invalid endpoint tier metadata"
+fi
+assert_contains "$invalid_tier_out" "records invalid tier 'burst'" \
+  "remote invalid-tier refusal did not name the invalid value"
+mv -f "$TMP_ROOT/remote-ios-before-invalid-tier.meta" "$remote_route_meta"
+pass "remote endpoint serving tiers are returned, validated, and matched before parent publication"
+
+cp "$remote_route_meta" "$TMP_ROOT/remote-ios-before-tier-warning.meta"
+cp "$PARENT/state/ios.meta" "$TMP_ROOT/parent-ios-before-tier-warning.meta"
+sed 's/^harness=codex$/harness=claude/' "$TMP_ROOT/remote-ios-before-tier-warning.meta" > "$remote_route_meta"
+sed 's/^harness=codex$/harness=claude/' "$TMP_ROOT/parent-ios-before-tier-warning.meta" > "$PARENT/state/ios.meta"
+tier_warning_out=$(remote_env "$ROOT/bin/fm-spawn.sh" ios --secondmate --harness claude --tier standard 2>&1) \
+  || fail "remote non-Codex standard-tier reuse failed"$'\n'"$tier_warning_out"
+assert_contains "$tier_warning_out" "harness 'claude' has no verified serving-tier flag" \
+  "remote parent path suppressed the unsupported-tier warning"
+mv -f "$TMP_ROOT/remote-ios-before-tier-warning.meta" "$remote_route_meta"
+mv -f "$TMP_ROOT/parent-ios-before-tier-warning.meta" "$PARENT/state/ios.meta"
+pass "remote parent surfaces unsupported serving-tier warnings"
 
 remote_route_meta="$REMOTE_HOME/state/parent-route/ios.meta"
 cp "$remote_route_meta" "$TMP_ROOT/remote-ios-before-default-session.meta"

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -854,7 +854,7 @@ test_spawn_explicit_harness_does_not_inherit_secondmate_harness_tokens() {
   [ "$(meta_field "$meta" model)" = default ] || fail "explicit-harness-no-tokens: meta model should stay default"
   [ "$(meta_field "$meta" effort)" = default ] || fail "explicit-harness-no-tokens: meta effort should stay default"
   launch=$(cat "$launchlog")
-  assert_contains "$launch" "codex --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "codex -c 'service_tier=\"default\"' --dangerously-bypass-approvals-and-sandbox" \
     "explicit-harness-no-tokens: launch did not use codex"
   assert_not_contains "$launch" "--model" "explicit-harness-no-tokens: launch must not carry a --model flag"
   assert_not_contains "$launch" "model_reasoning_effort" \

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -682,27 +682,28 @@ SH
 spawn_secondmate_capture() {
   local world=$1 id=$2 home=$3 launchlog=$4 fakebin
   shift 4
-  mkdir -p "$world/home/state" "$world/home/data"
+  mkdir -p "$world/home/state" "$world/home/data" "$world/codex-home"
   fakebin=$(make_launch_capturing_tmux "$world/tmux-$id")
   : > "$launchlog"
   PATH="$fakebin:$BASE_PATH" TMUX='' CLAUDECODE=1 \
     FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$world/home" \
     FM_STATE_OVERRIDE="$world/home/state" FM_DATA_OVERRIDE="$world/home/data" \
     FM_PROJECTS_OVERRIDE="$world/home/projects" FM_CONFIG_OVERRIDE="$world/home/config" \
-    FM_SPAWN_NO_GUARD=1 FM_FAKE_LAUNCH_LOG="$launchlog" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_LAUNCH_LOG="$launchlog" CODEX_HOME="$world/codex-home" \
     "$ROOT/bin/fm-spawn.sh" "$id" "$home" "$@" --secondmate
 }
 
 respawn_secondmate_capture() {
   local world=$1 id=$2 launchlog=$3 fakebin
   shift 3
+  mkdir -p "$world/codex-home"
   fakebin=$(make_launch_capturing_tmux "$world/tmux-$id-respawn")
   : > "$launchlog"
   PATH="$fakebin:$BASE_PATH" TMUX='' CLAUDECODE=1 \
     FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$world/home" \
     FM_STATE_OVERRIDE="$world/home/state" FM_DATA_OVERRIDE="$world/home/data" \
     FM_PROJECTS_OVERRIDE="$world/home/projects" FM_CONFIG_OVERRIDE="$world/home/config" \
-    FM_SPAWN_NO_GUARD=1 FM_FAKE_LAUNCH_LOG="$launchlog" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_LAUNCH_LOG="$launchlog" CODEX_HOME="$world/codex-home" \
     "$ROOT/bin/fm-spawn.sh" "$id" "$@" --secondmate
 }
 
@@ -934,6 +935,64 @@ test_secondmate_recovery_preserves_recorded_tier() {
   assert_contains "$launch" "-c 'service_tier=\"priority\"'" \
     "recovery-tier: respawn did not launch Codex on the recorded fast tier"
   pass "C9 spawn: secondmate recovery preserves its recorded serving tier"
+}
+
+test_secondmate_recovery_resets_tier_after_harness_change() {
+  local w sm meta launchlog launch out status
+  w="$TMP_ROOT/spawn-recovery-tier-harness-change"
+  sm="$w/sm"
+  launchlog="$w/launch.log"
+  mkdir -p "$w/home/config"
+  printf 'codex\n' > "$w/home/config/secondmate-harness"
+  make_seeded_home "$sm" sm
+
+  spawn_secondmate_capture "$w" sm "$sm" "$launchlog" --tier fast >/dev/null 2>&1
+  meta="$w/home/state/sm.meta"
+  printf 'claude\n' > "$w/home/config/secondmate-harness"
+  out=$(respawn_secondmate_capture "$w" sm "$launchlog" 2>&1); status=$?
+  expect_code 0 "$status" "secondmate recovery should reset tier on a harness change"$'\n'"$out"
+  [ "$(meta_field "$meta" harness)" = claude ] \
+    || fail "recovery-tier-change: respawn did not select the configured Claude harness"
+  [ "$(meta_field "$meta" tier)" = standard ] \
+    || fail "recovery-tier-change: a Codex fast tier carried onto Claude"
+  launch=$(cat "$launchlog")
+  assert_not_contains "$launch" "service_tier" \
+    "recovery-tier-change: Claude launch retained a Codex serving-tier flag"
+
+  printf 'codex\n' > "$w/home/config/secondmate-harness"
+  out=$(respawn_secondmate_capture "$w" sm "$launchlog" 2>&1); status=$?
+  expect_code 0 "$status" "secondmate recovery should keep the reset tier when returning to Codex"$'\n'"$out"
+  [ "$(meta_field "$meta" tier)" = standard ] \
+    || fail "recovery-tier-change: returning to Codex silently reactivated fast tier"
+  launch=$(cat "$launchlog")
+  assert_contains "$launch" "-c 'service_tier=\"default\"'" \
+    "recovery-tier-change: returning to Codex did not retain the reset standard tier"
+  assert_not_contains "$launch" "service_tier=\"priority\"" \
+    "recovery-tier-change: returning to Codex silently reactivated fast tier"
+  pass "C10 spawn: secondmate recovery resets tier when its harness changes"
+}
+
+test_secondmate_recovery_honors_explicit_tier_after_harness_change() {
+  local w sm meta launchlog out status
+  w="$TMP_ROOT/spawn-recovery-explicit-tier-harness-change"
+  sm="$w/sm"
+  launchlog="$w/launch.log"
+  mkdir -p "$w/home/config"
+  printf 'codex\n' > "$w/home/config/secondmate-harness"
+  make_seeded_home "$sm" sm
+
+  spawn_secondmate_capture "$w" sm "$sm" "$launchlog" --tier fast >/dev/null 2>&1
+  meta="$w/home/state/sm.meta"
+  printf 'claude\n' > "$w/home/config/secondmate-harness"
+  out=$(respawn_secondmate_capture "$w" sm "$launchlog" --tier fast 2>&1); status=$?
+  expect_code 0 "$status" "an explicit recovery tier should survive a harness change"$'\n'"$out"
+  [ "$(meta_field "$meta" harness)" = claude ] \
+    || fail "recovery-explicit-tier: respawn did not select the configured Claude harness"
+  [ "$(meta_field "$meta" tier)" = fast ] \
+    || fail "recovery-explicit-tier: the explicit fast tier was reset"
+  assert_contains "$out" "recording tier=fast and omitting it from launch" \
+    "recovery-explicit-tier: the unsupported explicit tier was not surfaced"
+  pass "C11 spawn: explicit recovery tier wins across a harness change"
 }
 
 test_spawned_secondmate_uses_its_harness_supervision_model() {
@@ -2589,6 +2648,8 @@ test_spawn_explicit_effort_overrides_secondmate_harness_token
 test_spawn_explicit_harness_does_not_inherit_secondmate_harness_tokens
 test_spawn_explicit_harness_uses_explicit_profile_axes
 test_secondmate_recovery_preserves_recorded_tier
+test_secondmate_recovery_resets_tier_after_harness_change
+test_secondmate_recovery_honors_explicit_tier_after_harness_change
 test_spawned_secondmate_uses_its_harness_supervision_model
 test_spawn_fallback_chain_and_crew_scout_unaffected
 test_bootstrap_sweep_propagates_and_reconverges

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -660,6 +660,18 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
+  cat > "$fakebin/codex" <<'SH'
+#!/usr/bin/env bash
+case "${1:-} ${2:-}" in
+  'doctor --json')
+    printf '%s\n' '{"checks":[{"id":"config.load","details":{"model":"gpt-5.4"}}]}'
+    ;;
+  'debug models')
+    printf '%s\n' '{"models":[{"slug":"gpt-5.4","service_tiers":[{"id":"priority"}]}]}'
+    ;;
+esac
+SH
+  chmod +x "$fakebin/codex"
   fm_fake_exit0 "$fakebin" pi
   printf '%s\n' "$fakebin"
 }

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -681,6 +681,19 @@ spawn_secondmate_capture() {
     "$ROOT/bin/fm-spawn.sh" "$id" "$home" "$@" --secondmate
 }
 
+respawn_secondmate_capture() {
+  local world=$1 id=$2 launchlog=$3 fakebin
+  shift 3
+  fakebin=$(make_launch_capturing_tmux "$world/tmux-$id-respawn")
+  : > "$launchlog"
+  PATH="$fakebin:$BASE_PATH" TMUX='' CLAUDECODE=1 \
+    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$world/home" \
+    FM_STATE_OVERRIDE="$world/home/state" FM_DATA_OVERRIDE="$world/home/data" \
+    FM_PROJECTS_OVERRIDE="$world/home/projects" FM_CONFIG_OVERRIDE="$world/home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_LAUNCH_LOG="$launchlog" \
+    "$ROOT/bin/fm-spawn.sh" "$id" "$@" --secondmate
+}
+
 test_spawn_backend_precedence_over_inherited_config() {
   local w sm meta launchlog out status
   w="$TMP_ROOT/spawn-backend-env-precedence"
@@ -887,6 +900,28 @@ test_spawn_explicit_harness_uses_explicit_profile_axes() {
   assert_not_contains "$launch" "model_reasoning_effort=\"high\"" \
     "explicit-harness-explicit-axes: launch leaked the file's effort token"
   pass "C8 spawn: an explicit --harness still honors explicit model/effort flags"
+}
+
+test_secondmate_recovery_preserves_recorded_tier() {
+  local w sm meta launchlog launch out status
+  w="$TMP_ROOT/spawn-recovery-tier"
+  sm="$w/sm"
+  launchlog="$w/launch.log"
+  mkdir -p "$w/home/config"
+  printf 'codex\n' > "$w/home/config/secondmate-harness"
+  make_seeded_home "$sm" sm
+
+  spawn_secondmate_capture "$w" sm "$sm" "$launchlog" --tier fast >/dev/null 2>&1
+  meta="$w/home/state/sm.meta"
+  [ "$(meta_field "$meta" tier)" = fast ] || fail "recovery-tier: initial fast tier was not recorded"
+
+  out=$(respawn_secondmate_capture "$w" sm "$launchlog" 2>&1); status=$?
+  expect_code 0 "$status" "secondmate recovery should preserve its recorded tier"$'\n'"$out"
+  [ "$(meta_field "$meta" tier)" = fast ] || fail "recovery-tier: respawn replaced fast with standard"
+  launch=$(cat "$launchlog")
+  assert_contains "$launch" "-c 'service_tier=\"priority\"'" \
+    "recovery-tier: respawn did not launch Codex on the recorded fast tier"
+  pass "C9 spawn: secondmate recovery preserves its recorded serving tier"
 }
 
 test_spawned_secondmate_uses_its_harness_supervision_model() {
@@ -2541,6 +2576,7 @@ test_spawn_explicit_model_overrides_secondmate_harness_token
 test_spawn_explicit_effort_overrides_secondmate_harness_token
 test_spawn_explicit_harness_does_not_inherit_secondmate_harness_tokens
 test_spawn_explicit_harness_uses_explicit_profile_axes
+test_secondmate_recovery_preserves_recorded_tier
 test_spawned_secondmate_uses_its_harness_supervision_model
 test_spawn_fallback_chain_and_crew_scout_unaffected
 test_bootstrap_sweep_propagates_and_reconverges

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -63,7 +63,19 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  get)
+    [ -z "${FM_FAKE_TREEHOUSE_LOG:-}" ] || printf 'get cwd=%s args=%s\n' "$PWD" "$*" >> "$FM_FAKE_TREEHOUSE_LOG"
+    printf '%s\n' "${FM_FAKE_PANE_PATH:-}"
+    ;;
+  return)
+    [ -z "${FM_FAKE_TREEHOUSE_LOG:-}" ] || printf 'return cwd=%s args=%s\n' "$PWD" "$*" >> "$FM_FAKE_TREEHOUSE_LOG"
+    ;;
+esac
+SH
   cat > "$fakebin/timeout" <<'SH'
 #!/usr/bin/env bash
 shift
@@ -82,18 +94,23 @@ SH
 set -u
 case "${1:-} ${2:-}" in
   'doctor --json')
+    effective_model=${FM_FAKE_CODEX_EFFECTIVE_MODEL:-gpt-5.4}
+    if [ -f .codex/fake-effective-model ]; then
+      IFS= read -r effective_model < .codex/fake-effective-model
+    fi
+    [ -z "${FM_FAKE_CODEX_CWD_LOG:-}" ] || printf 'doctor %s\n' "$PWD" >> "$FM_FAKE_CODEX_CWD_LOG"
     printf '{"checks":[{"id":"config.load","details":{"model":"%s"}}]}\n' \
-      "${FM_FAKE_CODEX_EFFECTIVE_MODEL:-gpt-5.4}"
+      "$effective_model"
     exit "${FM_FAKE_CODEX_DOCTOR_STATUS:-0}"
     ;;
   'debug models')
+    [ -z "${FM_FAKE_CODEX_CWD_LOG:-}" ] || printf 'models %s\n' "$PWD" >> "$FM_FAKE_CODEX_CWD_LOG"
     [ "${FM_FAKE_CODEX_CATALOG_STATUS:-0}" -eq 0 ] || exit "${FM_FAKE_CODEX_CATALOG_STATUS}"
     printf '%s\n' '{"models":[{"slug":"gpt-5.4","service_tiers":[{"id":"priority"}]},{"slug":"gpt-5.4-mini","service_tiers":[]}]}'
     ;;
 esac
 SH
-  chmod +x "$fakebin/timeout" "$fakebin/cursor-agent"
-  chmod +x "$fakebin/codex"
+  chmod +x "$fakebin/treehouse" "$fakebin/timeout" "$fakebin/cursor-agent" "$fakebin/codex"
   make_spawn_pi_probe "$fakebin" pi
   make_spawn_pi_probe "$fakebin" pi-signed
   printf '%s\n' "$fakebin"
@@ -137,6 +154,7 @@ run_spawn() {
   local home=$1 wt=$2 fakebin=$3 launchlog=$4
   shift 4
   : > "$launchlog"
+  rm -f "$launchlog.endpoint" "$launchlog.treehouse" "$launchlog.codex-cwd"
   # CLAUDE_CONFIG_DIR is forwarded onto claude launches by fm-spawn, so pin it
   # explicitly (empty by default) instead of leaking the invoking shell's value,
   # which would make launch assertions depend on the developer's environment.
@@ -148,6 +166,8 @@ run_spawn() {
     CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
     FM_FAKE_LAUNCH_LOG="$launchlog" FM_FAKE_PI_VERSION="${FM_TEST_PI_VERSION:-0.84.0}" \
     FM_FAKE_ENDPOINT_LOG="$launchlog.endpoint" \
+    FM_FAKE_TREEHOUSE_LOG="$launchlog.treehouse" \
+    FM_FAKE_CODEX_CWD_LOG="$launchlog.codex-cwd" \
     FM_FAKE_CURSOR_MODELS="${FM_TEST_CURSOR_MODELS:-}" \
     FM_FAKE_CURSOR_LIST_STATUS="${FM_TEST_CURSOR_LIST_STATUS:-0}" \
     FM_FAKE_CODEX_EFFECTIVE_MODEL="${FM_TEST_CODEX_EFFECTIVE_MODEL:-gpt-5.4}" \
@@ -525,6 +545,14 @@ SH
   assert_contains "$launch" "codex -c 'service_tier=\"priority\"' --dangerously-bypass-approvals-and-sandbox" \
     "codex fast tier was not threaded as the verified priority override"
   assert_not_contains "$launch" "service_tier=\"default\"" "fast tier launch must not contain the standard override"
+  assert_grep "doctor $WT_DIR" "$LAUNCH_LOG.codex-cwd" \
+    "Codex fast preflight did not resolve configuration from the finalized worktree"
+  assert_grep "models $WT_DIR" "$LAUNCH_LOG.codex-cwd" \
+    "Codex fast catalog inspection did not run from the finalized worktree"
+  assert_grep "get cwd=$PROJ_DIR args=get --lease --lease-holder $id" "$LAUNCH_LOG.treehouse" \
+    "Codex fast spawn did not lease its worktree before endpoint creation"
+  assert_no_grep "return " "$LAUNCH_LOG.treehouse" \
+    "successful Codex fast spawn returned its live worktree lease"
   pass "codex fast tier is an explicit opt-in"
 }
 
@@ -548,15 +576,26 @@ test_codex_fast_tier_requires_model_support() {
   id=profile-codex-fast-config-unsupported-z3c
   rec=$(make_spawn_case profile-codex-fast-config-unsupported codex "$id")
   read_case_record "$rec"
-  out=$(FM_TEST_CODEX_EFFECTIVE_MODEL=gpt-5.4-mini \
-    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
-      "$id" "$PROJ_DIR" --tier fast)
+  mkdir -p "$PROJ_DIR/.codex"
+  printf '%s\n' gpt-5.4-mini > "$PROJ_DIR/.codex/fake-effective-model"
+  git -C "$PROJ_DIR" add .codex/fake-effective-model
+  git -C "$PROJ_DIR" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm unsupported-origin-model
+  git -C "$PROJ_DIR" push --quiet origin HEAD
+  printf '%s\n' gpt-5.4 > "$PROJ_DIR/.codex/fake-effective-model"
+  git -C "$PROJ_DIR" add .codex/fake-effective-model
+  git -C "$PROJ_DIR" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm supported-primary-model
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" --tier fast)
   status=$?
   expect_code 1 "$status" "Codex fast tier should refuse an unsupported configured model"
   assert_contains "$out" "model 'gpt-5.4-mini' does not advertise the priority service tier" \
     "unsupported configured model refusal did not use Codex's effective model"
   assert_absent "$HOME_DIR/state/$id.meta" "unsupported configured fast model published metadata"
   assert_absent "$LAUNCH_LOG.endpoint" "unsupported configured fast model created an endpoint"
+  assert_grep "doctor $WT_DIR" "$LAUNCH_LOG.codex-cwd" \
+    "configured-model refusal did not inspect the refreshed launch worktree"
+  assert_grep "return cwd=$PROJ_DIR args=return --if-lease-holder $id --force $WT_DIR" "$LAUNCH_LOG.treehouse" \
+    "failed Codex fast preflight did not return its pre-acquired worktree"
   pass "Codex fast tier requires priority support from the resolved model"
 }
 

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -467,6 +467,40 @@ test_active_dispatch_profile_allows_raw_launch_command() {
   pass "active crew-dispatch profile allows the raw launch-command escape hatch"
 }
 
+test_raw_codex_fast_tier_refuses_before_mutation() {
+  local rec id out status launch
+  id=profile-raw-codex-standard-z15a
+  rec=$(make_spawn_case profile-raw-codex-standard claude "$id")
+  read_case_record "$rec"
+  enable_dispatch_profile "$HOME_DIR"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" "codex --profile custom")
+  status=$?
+  expect_code 0 "$status" "raw standard Codex launch should remain supported"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" codex default default standard
+  launch=$(cat "$LAUNCH_LOG")
+  [ "$launch" = "env -u CURSOR_AGENT -u CURSOR_INVOKED_AS codex --profile custom" ] \
+    || fail "raw standard Codex launch changed"$'\n'"actual: $launch"
+
+  id=profile-raw-codex-fast-z15b
+  rec=$(make_spawn_case profile-raw-codex-fast claude "$id")
+  read_case_record "$rec"
+  enable_dispatch_profile "$HOME_DIR"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" "codex --profile custom" --tier fast)
+  status=$?
+  expect_code 1 "$status" "raw fast Codex launch should be refused"
+  assert_contains "$out" "--tier fast requires Firstmate's canonical Codex launch template" \
+    "raw fast Codex refusal did not require the canonical template"
+  assert_absent "$HOME_DIR/state/$id.meta" "raw fast Codex refusal published metadata"
+  assert_absent "$LAUNCH_LOG.endpoint" "raw fast Codex refusal created an endpoint"
+  assert_absent "$LAUNCH_LOG.treehouse" "raw fast Codex refusal acquired a worktree"
+  [ ! -s "$LAUNCH_LOG" ] || fail "raw fast Codex refusal reached launch construction"
+  pass "raw Codex fast tier refuses before worktree or endpoint mutation"
+}
+
 test_claude_threads_model_and_effort() {
   local rec id out status launch
   id=profile-claude-z2
@@ -1033,6 +1067,7 @@ test_active_dispatch_profile_requires_explicit_harness_for_scout
 test_active_dispatch_profile_allows_explicit_harness
 test_active_dispatch_profile_allows_positional_harness
 test_active_dispatch_profile_allows_raw_launch_command
+test_raw_codex_fast_tier_refuses_before_mutation
 test_claude_threads_model_and_effort
 test_non_codex_tier_is_omitted_with_warning
 test_codex_threads_model_and_effort

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -42,7 +42,11 @@ esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;
-  has-session|new-session|new-window|kill-window) exit 0 ;;
+  has-session|new-session|kill-window) exit 0 ;;
+  new-window)
+    [ -z "${FM_FAKE_ENDPOINT_LOG:-}" ] || printf 'created\n' > "$FM_FAKE_ENDPOINT_LOG"
+    exit 0
+    ;;
   send-keys)
     if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
       prev=
@@ -80,6 +84,7 @@ case "${1:-} ${2:-}" in
   'doctor --json')
     printf '{"checks":[{"id":"config.load","details":{"model":"%s"}}]}\n' \
       "${FM_FAKE_CODEX_EFFECTIVE_MODEL:-gpt-5.4}"
+    exit "${FM_FAKE_CODEX_DOCTOR_STATUS:-0}"
     ;;
   'debug models')
     [ "${FM_FAKE_CODEX_CATALOG_STATUS:-0}" -eq 0 ] || exit "${FM_FAKE_CODEX_CATALOG_STATUS}"
@@ -142,9 +147,11 @@ run_spawn() {
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
     CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
     FM_FAKE_LAUNCH_LOG="$launchlog" FM_FAKE_PI_VERSION="${FM_TEST_PI_VERSION:-0.84.0}" \
+    FM_FAKE_ENDPOINT_LOG="$launchlog.endpoint" \
     FM_FAKE_CURSOR_MODELS="${FM_TEST_CURSOR_MODELS:-}" \
     FM_FAKE_CURSOR_LIST_STATUS="${FM_TEST_CURSOR_LIST_STATUS:-0}" \
     FM_FAKE_CODEX_EFFECTIVE_MODEL="${FM_TEST_CODEX_EFFECTIVE_MODEL:-gpt-5.4}" \
+    FM_FAKE_CODEX_DOCTOR_STATUS="${FM_TEST_CODEX_DOCTOR_STATUS:-0}" \
     FM_FAKE_CODEX_CATALOG_STATUS="${FM_TEST_CODEX_CATALOG_STATUS:-0}" \
     GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
     "$SPAWN" "$@" 2>&1
@@ -503,8 +510,14 @@ test_codex_fast_tier_opt_in() {
   id=profile-codex-fast-z3a
   rec=$(make_spawn_case profile-codex-fast codex "$id")
   read_case_record "$rec"
+  cat > "$FAKEBIN_DIR/jq" <<'SH'
+#!/usr/bin/env bash
+exit 127
+SH
+  chmod +x "$FAKEBIN_DIR/jq"
 
-  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --tier fast)
+  out=$(FM_TEST_CODEX_DOCTOR_STATUS=1 \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --tier fast)
   status=$?
   expect_code 0 "$status" "codex spawn with fast tier should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex default default fast
@@ -528,6 +541,7 @@ test_codex_fast_tier_requires_model_support() {
   assert_contains "$out" "model 'gpt-5.4-mini' does not advertise the priority service tier" \
     "unsupported explicit model refusal did not name the missing tier capability"
   assert_absent "$HOME_DIR/state/$id.meta" "unsupported fast model refusal published metadata"
+  assert_absent "$LAUNCH_LOG.endpoint" "unsupported fast model created an endpoint"
   launch=$(cat "$LAUNCH_LOG")
   assert_not_contains "$launch" "service_tier" "unsupported fast model reached Codex launch"
 
@@ -542,6 +556,7 @@ test_codex_fast_tier_requires_model_support() {
   assert_contains "$out" "model 'gpt-5.4-mini' does not advertise the priority service tier" \
     "unsupported configured model refusal did not use Codex's effective model"
   assert_absent "$HOME_DIR/state/$id.meta" "unsupported configured fast model published metadata"
+  assert_absent "$LAUNCH_LOG.endpoint" "unsupported configured fast model created an endpoint"
   pass "Codex fast tier requires priority support from the resolved model"
 }
 
@@ -559,6 +574,7 @@ test_codex_fast_tier_fails_closed_without_catalog() {
   assert_contains "$out" "could not inspect the installed Codex model catalog" \
     "catalog failure refusal did not identify the unavailable capability evidence"
   assert_absent "$HOME_DIR/state/$id.meta" "unverified fast model published metadata"
+  assert_absent "$LAUNCH_LOG.endpoint" "unverified fast model created an endpoint"
   pass "Codex fast tier refuses when model capability cannot be verified"
 }
 

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -146,10 +146,11 @@ EOF
 }
 
 assert_meta_profile() {
-  local meta=$1 harness=$2 model=$3 effort=$4
+  local meta=$1 harness=$2 model=$3 effort=$4 tier=${5:-standard}
   assert_grep "harness=$harness" "$meta" "meta missing harness=$harness"
   assert_grep "model=$model" "$meta" "meta missing model=$model"
   assert_grep "effort=$effort" "$meta" "meta missing effort=$effort"
+  assert_grep "tier=$tier" "$meta" "meta missing tier=$tier"
 }
 
 test_no_profile_keeps_claude_profile_defaults() {
@@ -379,7 +380,7 @@ test_active_dispatch_profile_allows_explicit_harness() {
   assert_contains "$out" "spawned $id harness=codex" "spawn did not report explicit codex harness"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' -c 'service_tier=\"default\"' --dangerously-bypass-approvals-and-sandbox" \
     "explicit harness launch did not thread model and effort"
   pass "active crew-dispatch profile allows an explicit resolved harness"
 }
@@ -435,6 +436,35 @@ test_claude_threads_model_and_effort() {
   pass "claude receives --model and --effort profile flags"
 }
 
+test_non_codex_tier_is_omitted_with_warning() {
+  local baseline_rec baseline_case baseline_launch rec id out status launch
+  baseline_rec=$(make_spawn_case profile-claude-tier-baseline claude profile-claude-tier-baseline-z2a)
+  read_case_record "$baseline_rec"
+  baseline_case=$CASE_DIR
+  run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    profile-claude-tier-baseline-z2a "$PROJ_DIR" >/dev/null
+  baseline_launch=$(cat "$LAUNCH_LOG")
+
+  id=profile-claude-tier-z2a
+  rec=$(make_spawn_case profile-claude-tier claude "$id")
+  read_case_record "$rec"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --tier fast)
+  status=$?
+  expect_code 0 "$status" "claude spawn with an explicit tier should succeed"
+  assert_contains "$out" "no verified serving-tier flag" \
+    "unsupported tier warning did not explain the omitted launch axis"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default fast
+  launch=$(cat "$LAUNCH_LOG")
+  baseline_launch=${baseline_launch//"$baseline_case"/CASE_ROOT}
+  launch=${launch//"$CASE_DIR"/CASE_ROOT}
+  baseline_launch=${baseline_launch//profile-claude-tier-baseline-z2a/ID}
+  launch=${launch//profile-claude-tier-z2a/ID}
+  [ "$launch" = "$baseline_launch" ] || fail "non-Codex launch changed when tier was supplied"$'\n'"baseline: $baseline_launch"$'\n'"actual: $launch"
+  assert_not_contains "$launch" "service_tier" "non-Codex launch must omit the serving-tier override"
+  pass "non-Codex tier is recorded, warned, and omitted from the launch"
+}
+
 test_codex_threads_model_and_effort() {
   local rec id out status launch
   id=profile-codex-z3
@@ -446,9 +476,26 @@ test_codex_threads_model_and_effort() {
   expect_code 0 "$status" "codex spawn with profile flags should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' -c 'service_tier=\"default\"' --dangerously-bypass-approvals-and-sandbox" \
     "codex launch did not thread model and reasoning effort config"
   pass "codex receives --model and model_reasoning_effort profile flags"
+}
+
+test_codex_fast_tier_opt_in() {
+  local rec id out status launch
+  id=profile-codex-fast-z3a
+  rec=$(make_spawn_case profile-codex-fast codex "$id")
+  read_case_record "$rec"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --tier fast)
+  status=$?
+  expect_code 0 "$status" "codex spawn with fast tier should succeed"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" codex default default fast
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "codex -c 'service_tier=\"priority\"' --dangerously-bypass-approvals-and-sandbox" \
+    "codex fast tier was not threaded as the verified priority override"
+  assert_not_contains "$launch" "service_tier=\"default\"" "fast tier launch must not contain the standard override"
+  pass "codex fast tier is an explicit opt-in"
 }
 
 test_codex_omits_invalid_max_effort() {
@@ -462,7 +509,7 @@ test_codex_omits_invalid_max_effort() {
   expect_code 0 "$status" "codex spawn with unsupported max effort should omit the effort flag"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "codex --model 'gpt-5' -c 'service_tier=\"default\"' --dangerously-bypass-approvals-and-sandbox" \
     "codex launch did not preserve the model flag when max effort was omitted"
   assert_not_contains "$launch" "model_reasoning_effort" "codex launch must omit unsupported max reasoning effort"
   pass "codex omits unsupported max effort instead of passing a bad config value"
@@ -838,7 +885,9 @@ test_active_dispatch_profile_allows_explicit_harness
 test_active_dispatch_profile_allows_positional_harness
 test_active_dispatch_profile_allows_raw_launch_command
 test_claude_threads_model_and_effort
+test_non_codex_tier_is_omitted_with_warning
 test_codex_threads_model_and_effort
+test_codex_fast_tier_opt_in
 test_codex_omits_invalid_max_effort
 test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -72,6 +72,9 @@ case "${1:-}" in
     printf '%s\n' "${FM_FAKE_PANE_PATH:-}"
     ;;
   return)
+    case " $* " in
+      *' --if-lease-holder '*) exit 64 ;;
+    esac
     [ -z "${FM_FAKE_TREEHOUSE_LOG:-}" ] || printf 'return cwd=%s args=%s\n' "$PWD" "$*" >> "$FM_FAKE_TREEHOUSE_LOG"
     ;;
 esac
@@ -98,13 +101,13 @@ case "${1:-} ${2:-}" in
     if [ -f .codex/fake-effective-model ]; then
       IFS= read -r effective_model < .codex/fake-effective-model
     fi
-    [ -z "${FM_FAKE_CODEX_CWD_LOG:-}" ] || printf 'doctor %s\n' "$PWD" >> "$FM_FAKE_CODEX_CWD_LOG"
+    [ -z "${FM_FAKE_CODEX_CWD_LOG:-}" ] || printf 'doctor %s bin=%s home=%s\n' "$PWD" "$0" "${CODEX_HOME:-}" >> "$FM_FAKE_CODEX_CWD_LOG"
     printf '{"checks":[{"id":"config.load","details":{"model":"%s"}}]}\n' \
       "$effective_model"
     exit "${FM_FAKE_CODEX_DOCTOR_STATUS:-0}"
     ;;
   'debug models')
-    [ -z "${FM_FAKE_CODEX_CWD_LOG:-}" ] || printf 'models %s\n' "$PWD" >> "$FM_FAKE_CODEX_CWD_LOG"
+    [ -z "${FM_FAKE_CODEX_CWD_LOG:-}" ] || printf 'models %s bin=%s home=%s\n' "$PWD" "$0" "${CODEX_HOME:-}" >> "$FM_FAKE_CODEX_CWD_LOG"
     [ "${FM_FAKE_CODEX_CATALOG_STATUS:-0}" -eq 0 ] || exit "${FM_FAKE_CODEX_CATALOG_STATUS}"
     printf '%s\n' '{"models":[{"slug":"gpt-5.4","service_tiers":[{"id":"priority"}]},{"slug":"gpt-5.4-mini","service_tiers":[]}]}'
     ;;
@@ -125,7 +128,7 @@ make_spawn_case() {
   wt="$case_dir/wt"
   launchlog="$case_dir/launch.log"
   fakebin=$(make_spawn_fakebin "$case_dir/fake")
-  mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
+  mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config" "$home/codex-home"
   printf '%s\n' "$harness" > "$home/config/crew-harness"
   fm_git_worktree "$proj" "$wt" "wt-$name"
   touch "$home/state/.last-watcher-beat"
@@ -163,6 +166,7 @@ run_spawn() {
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    CODEX_HOME="$home/codex-home" \
     CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
     FM_FAKE_LAUNCH_LOG="$launchlog" FM_FAKE_PI_VERSION="${FM_TEST_PI_VERSION:-0.84.0}" \
     FM_FAKE_ENDPOINT_LOG="$launchlog.endpoint" \
@@ -542,18 +546,44 @@ SH
   expect_code 0 "$status" "codex spawn with fast tier should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex default default fast
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex -c 'service_tier=\"priority\"' --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "CODEX_HOME='$HOME_DIR/codex-home' '$FAKEBIN_DIR/codex' -c 'service_tier=\"priority\"' --dangerously-bypass-approvals-and-sandbox" \
     "codex fast tier was not threaded as the verified priority override"
   assert_not_contains "$launch" "service_tier=\"default\"" "fast tier launch must not contain the standard override"
   assert_grep "doctor $WT_DIR" "$LAUNCH_LOG.codex-cwd" \
     "Codex fast preflight did not resolve configuration from the finalized worktree"
-  assert_grep "models $WT_DIR" "$LAUNCH_LOG.codex-cwd" \
-    "Codex fast catalog inspection did not run from the finalized worktree"
+  assert_grep "doctor $WT_DIR bin=$FAKEBIN_DIR/codex home=$HOME_DIR/codex-home" "$LAUNCH_LOG.codex-cwd" \
+    "Codex fast preflight did not use the pinned executable and config home"
+  assert_grep "models $WT_DIR bin=$FAKEBIN_DIR/codex home=$HOME_DIR/codex-home" "$LAUNCH_LOG.codex-cwd" \
+    "Codex fast catalog inspection did not use the pinned executable and config home"
   assert_grep "get cwd=$PROJ_DIR args=get --lease --lease-holder $id" "$LAUNCH_LOG.treehouse" \
     "Codex fast spawn did not lease its worktree before endpoint creation"
   assert_no_grep "return " "$LAUNCH_LOG.treehouse" \
     "successful Codex fast spawn returned its live worktree lease"
   pass "codex fast tier is an explicit opt-in"
+}
+
+test_codex_fast_secondmate_pins_runtime() {
+  local rec id sm out status launch
+  id=profile-codex-fast-secondmate-z3aa
+  rec=$(make_spawn_case profile-codex-fast-secondmate codex "$id")
+  read_case_record "$rec"
+  sm="$CASE_DIR/secondmate-home"
+  make_seeded_secondmate_home "$sm" "$id"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$sm" --secondmate --tier fast)
+  status=$?
+  expect_code 0 "$status" "Codex fast secondmate spawn should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "CODEX_HOME='$HOME_DIR/codex-home' '$FAKEBIN_DIR/codex' -c 'service_tier=\"priority\"' --dangerously-bypass-approvals-and-sandbox" \
+    "Codex fast secondmate launch did not pin its preflight runtime"
+  assert_not_contains "$launch" "notify=" \
+    "Codex secondmate launch gained the task turn-end hook variant"
+  assert_grep "doctor $sm bin=$FAKEBIN_DIR/codex home=$HOME_DIR/codex-home" "$LAUNCH_LOG.codex-cwd" \
+    "Codex fast secondmate preflight did not use its pinned launch runtime"
+  assert_grep "models $sm bin=$FAKEBIN_DIR/codex home=$HOME_DIR/codex-home" "$LAUNCH_LOG.codex-cwd" \
+    "Codex fast secondmate catalog inspection did not use its pinned launch runtime"
+  pass "Codex fast secondmates pin the validated executable and config home"
 }
 
 test_codex_fast_tier_requires_model_support() {
@@ -594,7 +624,7 @@ test_codex_fast_tier_requires_model_support() {
   assert_absent "$LAUNCH_LOG.endpoint" "unsupported configured fast model created an endpoint"
   assert_grep "doctor $WT_DIR" "$LAUNCH_LOG.codex-cwd" \
     "configured-model refusal did not inspect the refreshed launch worktree"
-  assert_grep "return cwd=$PROJ_DIR args=return --if-lease-holder $id --force $WT_DIR" "$LAUNCH_LOG.treehouse" \
+  assert_grep "return cwd=$PROJ_DIR args=return --force $WT_DIR" "$LAUNCH_LOG.treehouse" \
     "failed Codex fast preflight did not return its pre-acquired worktree"
   pass "Codex fast tier requires priority support from the resolved model"
 }
@@ -1007,6 +1037,7 @@ test_claude_threads_model_and_effort
 test_non_codex_tier_is_omitted_with_warning
 test_codex_threads_model_and_effort
 test_codex_fast_tier_opt_in
+test_codex_fast_secondmate_pins_runtime
 test_codex_fast_tier_requires_model_support
 test_codex_fast_tier_fails_closed_without_catalog
 test_codex_omits_invalid_max_effort

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -73,7 +73,22 @@ if [ "${1:-}" = --list-models ]; then
 fi
 exit 0
 SH
+  cat > "$fakebin/codex" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-} ${2:-}" in
+  'doctor --json')
+    printf '{"checks":[{"id":"config.load","details":{"model":"%s"}}]}\n' \
+      "${FM_FAKE_CODEX_EFFECTIVE_MODEL:-gpt-5.4}"
+    ;;
+  'debug models')
+    [ "${FM_FAKE_CODEX_CATALOG_STATUS:-0}" -eq 0 ] || exit "${FM_FAKE_CODEX_CATALOG_STATUS}"
+    printf '%s\n' '{"models":[{"slug":"gpt-5.4","service_tiers":[{"id":"priority"}]},{"slug":"gpt-5.4-mini","service_tiers":[]}]}'
+    ;;
+esac
+SH
   chmod +x "$fakebin/timeout" "$fakebin/cursor-agent"
+  chmod +x "$fakebin/codex"
   make_spawn_pi_probe "$fakebin" pi
   make_spawn_pi_probe "$fakebin" pi-signed
   printf '%s\n' "$fakebin"
@@ -129,6 +144,8 @@ run_spawn() {
     FM_FAKE_LAUNCH_LOG="$launchlog" FM_FAKE_PI_VERSION="${FM_TEST_PI_VERSION:-0.84.0}" \
     FM_FAKE_CURSOR_MODELS="${FM_TEST_CURSOR_MODELS:-}" \
     FM_FAKE_CURSOR_LIST_STATUS="${FM_TEST_CURSOR_LIST_STATUS:-0}" \
+    FM_FAKE_CODEX_EFFECTIVE_MODEL="${FM_TEST_CODEX_EFFECTIVE_MODEL:-gpt-5.4}" \
+    FM_FAKE_CODEX_CATALOG_STATUS="${FM_TEST_CODEX_CATALOG_STATUS:-0}" \
     GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
     "$SPAWN" "$@" 2>&1
 }
@@ -496,6 +513,53 @@ test_codex_fast_tier_opt_in() {
     "codex fast tier was not threaded as the verified priority override"
   assert_not_contains "$launch" "service_tier=\"default\"" "fast tier launch must not contain the standard override"
   pass "codex fast tier is an explicit opt-in"
+}
+
+test_codex_fast_tier_requires_model_support() {
+  local rec id out status launch
+  id=profile-codex-fast-unsupported-z3b
+  rec=$(make_spawn_case profile-codex-fast-unsupported codex "$id")
+  read_case_record "$rec"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" --model gpt-5.4-mini --tier fast)
+  status=$?
+  expect_code 1 "$status" "Codex fast tier should refuse an unsupported explicit model"
+  assert_contains "$out" "model 'gpt-5.4-mini' does not advertise the priority service tier" \
+    "unsupported explicit model refusal did not name the missing tier capability"
+  assert_absent "$HOME_DIR/state/$id.meta" "unsupported fast model refusal published metadata"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_not_contains "$launch" "service_tier" "unsupported fast model reached Codex launch"
+
+  id=profile-codex-fast-config-unsupported-z3c
+  rec=$(make_spawn_case profile-codex-fast-config-unsupported codex "$id")
+  read_case_record "$rec"
+  out=$(FM_TEST_CODEX_EFFECTIVE_MODEL=gpt-5.4-mini \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+      "$id" "$PROJ_DIR" --tier fast)
+  status=$?
+  expect_code 1 "$status" "Codex fast tier should refuse an unsupported configured model"
+  assert_contains "$out" "model 'gpt-5.4-mini' does not advertise the priority service tier" \
+    "unsupported configured model refusal did not use Codex's effective model"
+  assert_absent "$HOME_DIR/state/$id.meta" "unsupported configured fast model published metadata"
+  pass "Codex fast tier requires priority support from the resolved model"
+}
+
+test_codex_fast_tier_fails_closed_without_catalog() {
+  local rec id out status
+  id=profile-codex-fast-no-catalog-z3d
+  rec=$(make_spawn_case profile-codex-fast-no-catalog codex "$id")
+  read_case_record "$rec"
+
+  out=$(FM_TEST_CODEX_CATALOG_STATUS=1 \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+      "$id" "$PROJ_DIR" --model gpt-5.4 --tier fast)
+  status=$?
+  expect_code 1 "$status" "Codex fast tier should refuse an unreadable model catalog"
+  assert_contains "$out" "could not inspect the installed Codex model catalog" \
+    "catalog failure refusal did not identify the unavailable capability evidence"
+  assert_absent "$HOME_DIR/state/$id.meta" "unverified fast model published metadata"
+  pass "Codex fast tier refuses when model capability cannot be verified"
 }
 
 test_codex_omits_invalid_max_effort() {
@@ -888,6 +952,8 @@ test_claude_threads_model_and_effort
 test_non_codex_tier_is_omitted_with_warning
 test_codex_threads_model_and_effort
 test_codex_fast_tier_opt_in
+test_codex_fast_tier_requires_model_support
+test_codex_fast_tier_fails_closed_without_catalog
 test_codex_omits_invalid_max_effort
 test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -89,7 +89,8 @@ test_changed_file_selection_is_conservative() {
 }
 
 init_changed_fixture_repo() {
-  local repo=$1 script
+  local repo=$1 script codex_tier_helper
+  codex_tier_helper="fm-codex-tier""-lib.sh"
   mkdir -p "$repo/bin" "$repo/tests"
   cp "$RUNNER" "$repo/bin/fm-test-run.sh"
   chmod +x "$repo/bin/fm-test-run.sh"
@@ -115,6 +116,7 @@ init_changed_fixture_repo() {
   done
   : >"$repo/tests/lib.sh"
   : >"$repo/tests/fm-backend-herdr-eventwait.test.py"
+  : >"$repo/bin/$codex_tier_helper"
   : >"$repo/bin/fm-supervisor-target-lib.sh"
   : >"$repo/bin/unmapped-source.sh"
   printf '# .claude/settings.json\n# .pi/extensions/fm-primary-turnend-guard.ts\n' \
@@ -132,7 +134,8 @@ init_changed_fixture_repo() {
 }
 
 test_changed_dependency_selection_and_unmapped_failure() {
-  local tmp repo listed rc
+  local tmp repo listed rc codex_tier_helper
+  codex_tier_helper="fm-codex-tier""-lib.sh"
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-changed.XXXXXX")
   repo="$tmp/repo"
   init_changed_fixture_repo "$repo"
@@ -158,6 +161,13 @@ test_changed_dependency_selection_and_unmapped_failure() {
   assert_contains "$listed" "tests/fm-afk-return.test.sh" "supervisor target selects afk coverage"
   git -C "$repo" add bin/fm-supervisor-target-lib.sh
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm supervisor-change
+
+  printf '\n' >>"$repo/bin/$codex_tier_helper"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-backend.test.sh" "Codex tier helper selects backend dispatch coverage"
+  assert_contains "$listed" "tests/fm-secondmate-safety.test.sh" "Codex tier helper selects secondmate coverage"
+  git -C "$repo" add "bin/$codex_tier_helper"
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm codex-tier-helper-change
 
   printf '\n' >>"$repo/.agents/skills/example/SKILL.md"
   printf '\n' >>"$repo/.claude/settings.json"


### PR DESCRIPTION
## Summary

Makes firstmate-spawned Codex workers use the standard serving tier by default and adds an explicit `--tier fast` opt-in.
The resolved tier now persists through metadata, relaunch, and secondmate recovery, while unsupported or ambiguous fast launches fail before endpoint mutation.

## Risk assessment

🟢 Low - The behavior change is Codex-only, standard remains the default, fast mode requires verified model support, and non-Codex launch commands remain unchanged.

<details>
<summary>Implementation details</summary>

- Maps `standard` to `service_tier="default"` and `fast` to `service_tier="priority"` in both canonical Codex launch variants.
- Pins fast-tier preflight and launch to the same Codex executable and effective `CODEX_HOME`.
- Persists `tier=` beside model and effort, including relaunch and recovery paths.
- Resets stale fast state when the resolved harness changes and refuses raw Codex fast launches that cannot carry the tier override.
- Keeps the operator's global Codex configuration byte-identical.

</details>

<details>
<summary>Validation</summary>

- Fresh review completed with no remaining findings.
- Focused spawn, relaunch, local recovery, remote secondmate lifecycle, and changed-file routing coverage passed.
- CLI evidence confirmed default standard metadata and `service_tier="default"`, explicit fast metadata and `service_tier="priority"`, recovery persistence, and pre-mutation refusal for unsupported fast models.
- The operator Codex config SHA-256 was identical before and after the launch checks.
- Pinned ShellCheck 0.11.0 passed. The full local runner could not execute because Ruby and actionlint are absent from this workspace; the affected focused cases passed independently and CI provides the full parity gate.

</details>

<details>
<summary>Pipeline fixes</summary>

- Added fast-tier eligibility preflight before a relaunch stops the live worker, while retaining spawn-time validation.
- Reset recorded fast tier when recovery changes harness unless the tier was explicitly supplied.
- Added the shared Codex tier helper to the existing backend-dispatch and secondmate changed-file test families.

</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

