### PR TITLE
feat: add local fleet dashboard

### DIFF
--- a/bin/fm-dashboard.sh
+++ b/bin/fm-dashboard.sh
@@ -509,11 +509,15 @@ def pr_checks(url):
         cached = SERVER.gh_cache.get(url)
         if cached and (now - cached[0]) < GH_TTL:
             return cached[1]
-        p = subprocess.run([SCRIPT, "--pr-check", url], capture_output=True, text=True, timeout=30)
         try:
-            checks = json.loads(p.stdout or "{}")
-        except json.JSONDecodeError:
-            checks = {"url": url, "error": "pr-check returned invalid JSON"}
+            p = subprocess.run([SCRIPT, "--pr-check", url], capture_output=True, text=True, timeout=30)
+            try:
+                checks = json.loads(p.stdout or "{}")
+            except json.JSONDecodeError:
+                checks = {"url": url, "error": "pr-check returned invalid JSON"}
+        except subprocess.TimeoutExpired:
+            checks = {"url": url, "pr_state": None, "verdict": "unknown", "items": [],
+                      "error": "pr-check timed out after 30 seconds"}
         SERVER.gh_cache[url] = (time.monotonic(), checks)
         return checks
 

--- a/bin/fm-dashboard.sh
+++ b/bin/fm-dashboard.sh
@@ -142,19 +142,6 @@ pane_tail_json() {  # <backend> <target> <lines> <id>
   jq -n --argjson lines "$lines_json" '{lines:$lines, error:null}'
 }
 
-remote_pane_tail_json() {  # <id> <lines>
-  local id=$1 lines=$2 capture rc text lines_json
-  capture=$("$SCRIPT_DIR/fm-on.sh" "$id" fm-remote-secondmate-control.sh capture "$id" "$lines" 2>/dev/null)
-  rc=$?
-  if [ "$rc" -ne 0 ]; then
-    jq -n --arg e "remote pane capture failed (exit $rc)" '{lines:[], error:$e}'
-    return 0
-  fi
-  text=$(printf '%s\n' "$capture" | sed '/^[[:space:]]*$/d' | tail -n "$lines")
-  lines_json=$(printf '%s\n' "$text" | jq -Rn '[inputs]')
-  jq -n --argjson lines "$lines_json" '{lines:$lines, error:null}'
-}
-
 # pr_check_json <url> - read-only PR checks for one github.com PR via gh.
 # Non-github URLs are answered with an explicit error rather than a fake pass.
 pr_check_json() {  # <url>
@@ -225,7 +212,7 @@ dashboard_snapshot() {
     target=$(printf '%s' "$task" | jq -r '.endpoint.target // ""')
     model=$(printf '%s' "$task" | jq -r '.model // ""')
     if [ "$(printf '%s' "$task" | jq -r '.remote.host // ""')" != "" ]; then
-      pane=$(remote_pane_tail_json "$id" "$PANE_LINES")
+      pane=$(jq -n '{lines:[], error:"remote worker - live view not available from the dashboard; open its remote session"}')
     else
       pane=$(pane_tail_json "$backend" "$target" "$PANE_LINES" "$id")
     fi

--- a/bin/fm-dashboard.sh
+++ b/bin/fm-dashboard.sh
@@ -460,6 +460,7 @@ dashboard_serve() {
   python3 - "$SELF" "$PORT" "$HOST" "$REFRESH" "$GH_CACHE_TTL" <<'PY'
 import http.server
 import json
+import socket
 import subprocess
 import sys
 import time
@@ -469,6 +470,17 @@ PORT = int(sys.argv[2])
 HOST = sys.argv[3]
 REFRESH = int(sys.argv[4])
 GH_TTL = int(sys.argv[5])
+
+try:
+    ADDRESS_FAMILY = socket.getaddrinfo(
+        HOST, PORT, proto=socket.IPPROTO_TCP, flags=socket.AI_NUMERICHOST
+    )[0][0]
+except socket.gaierror:
+    try:
+        ADDRESS_FAMILY = socket.getaddrinfo(HOST, PORT, proto=socket.IPPROTO_TCP)[0][0]
+    except socket.gaierror as e:
+        print("fm-dashboard: cannot resolve --host %r: %s" % (HOST, e), file=sys.stderr)
+        sys.exit(1)
 
 
 def snapshot_json():
@@ -507,6 +519,7 @@ def pr_checks(url):
 
 class Server(http.server.ThreadingHTTPServer):
     daemon_threads = True
+    address_family = ADDRESS_FAMILY
 
     def __init__(self, *a, **kw):
         super().__init__(*a, **kw)

--- a/bin/fm-dashboard.sh
+++ b/bin/fm-dashboard.sh
@@ -381,11 +381,11 @@ function checksHtml(pr) {
 }
 function tailHtml(t) {
   var p = t.pane_tail || {};
-  if (t.remote_host) return '<span class="badge">remote: ' + esc(t.remote_host) + '</span>';
-  if (p.error) return '<span class="errline">' + esc(p.error) + '</span>';
+  var out = t.remote_host ? '<span class="badge">remote: ' + esc(t.remote_host) + '</span> ' : '';
+  if (p.error) return out + '<span class="errline">' + esc(p.error) + '</span>';
   var lines = p.lines || [];
-  if (!lines.length) return '<span class="badge">no output</span>';
-  return '<details class="pane"><summary>tail (' + lines.length + ')</summary>' +
+  if (!lines.length) return out + '<span class="badge">no output</span>';
+  return out + '<details class="pane"><summary>tail (' + lines.length + ')</summary>' +
     '<pre class="tail">' + esc(lines.join('\n')) + '</pre></details>';
 }
 function activityHtml(t) {

--- a/bin/fm-dashboard.sh
+++ b/bin/fm-dashboard.sh
@@ -1,0 +1,557 @@
+#!/usr/bin/env bash
+# fm-dashboard.sh - always-on, READ-ONLY local fleet dashboard.
+#
+# Serves a single self-contained dark-theme web page on localhost that
+# auto-refreshes and shows each in-flight worker's task id, kind, harness/model,
+# project, current state, latest activity, live pane tail, no-mistakes
+# validation step, and PR link plus checks status.
+#
+# Data sources are structured readers, never hand-parsed state files:
+#   - bin/fm-fleet-snapshot.sh --json    (task identity, current state, PR url)
+#   - bin/fm-crew-state.sh <id>          (run-step / validation step, embedded in
+#                                         the snapshot's current_state)
+#   - bin/fm-backend.sh fm_backend_capture (pane tail, last N lines, read-only;
+#                                           tmux uses `capture-pane -p`)
+#   - gh pr view <url> --json            (PR checks, read-only, cached 60s)
+#
+# READ-ONLY CONTRACT: this script never writes to state/, data/, config/, or any
+# worktree, and shells out only to read-only commands. The only filesystem
+# activity is the loopback socket the Python stdlib http.server opens in serve
+# mode; every fleet read is a read-only command (snapshot, pane capture, gh).
+#
+# Usage:
+#   fm-dashboard.sh                       serve the dashboard (default)
+#   fm-dashboard.sh --port 8790           serve on a specific loopback port
+#   fm-dashboard.sh --refresh 15          page auto-refresh interval (seconds)
+#   fm-dashboard.sh --gh-cache 120        PR checks cache TTL (seconds)
+#   fm-dashboard.sh --pane-lines 25       pane tail line count
+#   fm-dashboard.sh --snapshot            print the dashboard JSON and exit
+#   fm-dashboard.sh --pr-check <url>      print one PR's checks JSON and exit
+#   fm-dashboard.sh --html                print the HTML page and exit
+#
+# Flags:
+#   --port N       loopback port (default 8790)
+#   --host HOST    loopback bind address: 127.0.0.1, ::1, or localhost
+#                  (default 127.0.0.1; non-loopback is refused)
+#   --refresh N    page auto-refresh interval in seconds (default 10)
+#   --gh-cache N   PR checks cache TTL in seconds (default 60)
+#   --pane-lines N pane tail line count (default 15)
+#
+# Output contract: `--snapshot` prints one JSON object with schema
+# `fm-dashboard.v1`; `--pr-check` prints one JSON object per URL. Both always
+# exit 0 and carry failures in an `error` field so a data-source error is shown
+# loudly instead of rendering as an empty row.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SELF="$SCRIPT_DIR/fm-dashboard.sh"
+
+# shellcheck source=bin/fm-backend.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-backend.sh"
+
+usage() {
+  cat <<'EOF'
+usage: fm-dashboard.sh [--port N] [--host HOST] [--refresh N] [--gh-cache N]
+                      [--pane-lines N]
+       fm-dashboard.sh --snapshot
+       fm-dashboard.sh --pr-check <url>
+       fm-dashboard.sh --html
+
+Serve an always-on, read-only local fleet dashboard on localhost.
+With no mode flag the dashboard serves. --snapshot prints the dashboard JSON,
+--pr-check prints one PR's checks JSON, and --html prints the page HTML.
+EOF
+}
+
+MODE=serve
+PORT=8790
+HOST=127.0.0.1
+REFRESH=10
+GH_CACHE_TTL=60
+PANE_LINES=15
+PR_URL=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --snapshot) MODE=snapshot ;;
+    --html) MODE=html ;;
+    --pr-check)
+      MODE=pr-check
+      [ "$#" -ge 2 ] || { echo "fm-dashboard: --pr-check requires a URL" >&2; exit 2; }
+      PR_URL=$2
+      shift
+      ;;
+    --port) [ "$#" -ge 2 ] || { echo "fm-dashboard: --port requires a value" >&2; exit 2; }; PORT=$2; shift ;;
+    --port=*) PORT=${1#*=} ;;
+    --host) [ "$#" -ge 2 ] || { echo "fm-dashboard: --host requires a value" >&2; exit 2; }; HOST=$2; shift ;;
+    --host=*) HOST=${1#*=} ;;
+    --refresh) [ "$#" -ge 2 ] || { echo "fm-dashboard: --refresh requires a value" >&2; exit 2; }; REFRESH=$2; shift ;;
+    --refresh=*) REFRESH=${1#*=} ;;
+    --gh-cache) [ "$#" -ge 2 ] || { echo "fm-dashboard: --gh-cache requires a value" >&2; exit 2; }; GH_CACHE_TTL=$2; shift ;;
+    --gh-cache=*) GH_CACHE_TTL=${1#*=} ;;
+    --pane-lines) [ "$#" -ge 2 ] || { echo "fm-dashboard: --pane-lines requires a value" >&2; exit 2; }; PANE_LINES=$2; shift ;;
+    --pane-lines=*) PANE_LINES=${1#*=} ;;
+    *) usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+fail_usage() {  # <message>
+  echo "fm-dashboard: $1" >&2
+  exit 2
+}
+
+case "$PORT" in ''|*[!0-9]*) fail_usage "--port must be a positive integer" ;; esac
+[ "$PORT" -ge 1 ] && [ "$PORT" -le 65535 ] || fail_usage "--port must be 1-65535"
+case "$HOST" in
+  127.0.0.1|::1|localhost) ;;
+  *) fail_usage "--host must be a loopback address (127.0.0.1, ::1, or localhost)" ;;
+esac
+case "$REFRESH" in ''|*[!0-9]*|0) fail_usage "--refresh must be a positive integer" ;; esac
+case "$GH_CACHE_TTL" in ''|*[!0-9]*|0) fail_usage "--gh-cache must be a positive integer" ;; esac
+case "$PANE_LINES" in ''|*[!0-9]*|0) fail_usage "--pane-lines must be a positive integer" ;; esac
+
+# pane_tail_json <backend> <target> <lines> <id> - read the last <lines> lines
+# of a recorded endpoint through the backend-aware read-only capture primitive,
+# and emit a JSON object `{lines:[...], error:null|string}`. The id supplies the
+# expected `fm-<id>` label bin/fm-peek.sh passes, which the zellij/cmux adapters
+# use to verify they capture the intended task's pane and not a stranger's.
+#
+# The capture runs in-process rather than under fm_run_timed: the timed runner
+# can only exec an external command, so bounding the shell function would force
+# a child bash to re-source the backend adapter chain on every capture (~2s each
+# for the tmux adapter's session-lock and cursor libs). Calling it directly
+# sources each adapter once per snapshot process and matches bin/fm-crew-state.sh's
+# own unbounded cheap pane reads (tmux capture-pane -p is a fast read-only call).
+pane_tail_json() {  # <backend> <target> <lines> <id>
+  local backend=$1 target=$2 lines=$3 id=$4 capture rc text lines_json
+  if [ -z "$target" ]; then
+    jq -n '{lines:[], error:"no recorded endpoint"}'
+    return 0
+  fi
+  capture=$(fm_backend_capture "$backend" "$target" "$lines" "fm-$id" 2>/dev/null)
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    jq -n --arg e "pane capture failed (exit $rc)" '{lines:[], error:$e}'
+    return 0
+  fi
+  text=$(printf '%s\n' "$capture" | sed '/^[[:space:]]*$/d' | tail -n "$lines")
+  lines_json=$(printf '%s\n' "$text" | jq -Rn '[inputs]')
+  jq -n --argjson lines "$lines_json" '{lines:$lines, error:null}'
+}
+
+# pr_check_json <url> - read-only PR checks for one github.com PR via gh.
+# Non-github URLs are answered with an explicit error rather than a fake pass.
+pr_check_json() {  # <url>
+  local url=$1 gh_json
+  case "$url" in
+    https://github.com/*) ;;
+    *)
+      jq -n --arg url "$url" --arg e "PR checks support github.com only" \
+        '{url:$url, pr_state:null, verdict:"unknown", items:[], error:$e}'
+      return 0
+      ;;
+  esac
+  if ! command -v gh >/dev/null 2>&1; then
+    jq -n --arg url "$url" --arg e "gh not found" \
+      '{url:$url, pr_state:null, verdict:"unknown", items:[], error:$e}'
+    return 0
+  fi
+  if ! gh_json=$(gh pr view "$url" --json state,statusCheckRollup 2>/dev/null); then
+    jq -n --arg url "$url" --arg e "gh pr view failed" \
+      '{url:$url, pr_state:null, verdict:"unknown", items:[], error:$e}'
+    return 0
+  fi
+  printf '%s' "$gh_json" | jq -c --arg url "$url" '
+    def bad: . == "FAILURE" or . == "CANCELLED" or . == "TIMED_OUT"
+      or . == "ACTION_REQUIRED" or . == "STARTUP_FAILURE";
+    def in_progress: . == "EXPECTED" or . == "PENDING" or . == "STARTED"
+      or . == "IN_PROGRESS" or . == "QUEUED";
+    def ok: . == "SUCCESS" or . == "NEUTRAL" or . == "SKIPPED";
+    def verdict($rs):
+      if ($rs | length) == 0 then "no_checks"
+      elif any($rs[]; (.conclusion // "") | bad) then "failure"
+      elif any($rs[]; (.status // "") | in_progress) then "pending"
+      elif all($rs[]; ((.conclusion // "") | ok)) then "success"
+      else "unknown" end;
+    {url:$url,
+     pr_state:(.state // null),
+     verdict:verdict(.statusCheckRollup // []),
+     items:[ (.statusCheckRollup // [])[]
+             | {name:(.name // ""), status:(.status // ""), conclusion:(.conclusion // "")} ][0:20],
+     error:null}'
+}
+
+# dashboard_snapshot - emit the fm-dashboard.v1 JSON. Always exits 0 and carries
+# failures in `error`/`errors` fields so the UI renders them loudly.
+dashboard_snapshot() {
+  local snapshot now fm_home task id backend target meta_path model pane
+  local enriched tasks
+  now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  if ! command -v jq >/dev/null 2>&1; then
+    printf '%s\n' '{"schema":"fm-dashboard.v1","generated":"","fm_home":null,"refresh_seconds":0,"error":"jq not found","tasks":[],"errors":["jq not found"]}'
+    return 0
+  fi
+  if ! snapshot=$("$SCRIPT_DIR/fm-fleet-snapshot.sh" --json 2>&1); then
+    snapshot=""
+  fi
+  if ! printf '%s' "$snapshot" | jq -e '.schema == "fm-fleet-snapshot.v1"' >/dev/null 2>&1; then
+    jq -n --arg now "$now" --arg e "fleet snapshot unavailable: $(printf '%s' "$snapshot" | head -c 300)" \
+      '{schema:"fm-dashboard.v1", generated:$now, fm_home:null, refresh_seconds:0, error:$e, tasks:[], errors:[$e]}'
+    return 0
+  fi
+
+  fm_home=$(printf '%s' "$snapshot" | jq -r '.fm_home // ""')
+  enriched=""
+  while IFS= read -r task; do
+    [ -n "$task" ] || continue
+    id=$(printf '%s' "$task" | jq -r '.id // ""')
+    backend=$(printf '%s' "$task" | jq -r '.backend // "tmux"')
+    target=$(printf '%s' "$task" | jq -r '.endpoint.target // ""')
+    meta_path=$(printf '%s' "$task" | jq -r '.paths.meta.path // ""')
+    model=""
+    if [ -n "$meta_path" ]; then
+      model=$(fm_meta_get "$meta_path" model)
+    fi
+    if [ "$(printf '%s' "$task" | jq -r '.remote.host // ""')" != "" ]; then
+      pane=$(jq -n '{lines:[], error:null}')
+    else
+      pane=$(pane_tail_json "$backend" "$target" "$PANE_LINES" "$id")
+    fi
+    enriched="$enriched$(printf '%s' "$task" | jq -c \
+      --arg model "$model" \
+      --argjson pane "$pane" \
+      '{
+        id: .id,
+        kind: .kind,
+        harness: (.harness // ""),
+        model: $model,
+        project: (.project // ""),
+        backend: (.backend // "tmux"),
+        mode: (.mode // ""),
+        state: .current_state.state,
+        state_source: .current_state.source,
+        state_detail: (.current_state.detail // ""),
+        latest_activity: (.hints.last_event_text // ""),
+        pending_decision: .hints.pending_decision,
+        blocked: .hints.blocked_event,
+        remote_host: (.remote.host // ""),
+        endpoint_present: .endpoint.exists,
+        endpoint_target: (.endpoint.target // null),
+        pane_tail: $pane,
+        validation: {active: (.current_state.source == "run-step"), detail: (.current_state.detail // "")},
+        pr: {url: (.pr.url // null)}
+      }')"$'\n'
+  done < <(printf '%s' "$snapshot" | jq -c '.tasks[]')
+
+  tasks=$(printf '%s' "$enriched" | jq -s '.')
+  jq -n --arg now "$now" --arg home "$fm_home" --arg refresh "$REFRESH" --argjson tasks "$tasks" \
+    '{schema:"fm-dashboard.v1",
+      generated:$now,
+      fm_home:$home,
+      refresh_seconds:($refresh | tonumber),
+      error:null,
+      tasks:$tasks,
+      errors:[]}'
+}
+
+# dashboard_html - print the self-contained dark-theme HTML page with the
+# refresh interval baked into the JS auto-refresh.
+#
+# The page is streamed straight through sed rather than captured in a command
+# substitution: bash mis-parses a quoted heredoc nested inside $(...) when the
+# body carries an unbalanced quote (the JS HTML-escape regex below), so the
+# substitution happens on sed's output instead of on a shell variable.
+dashboard_html() {
+  sed "s/__REFRESH__/$REFRESH/g" <<'HTML'
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>firstmate fleet</title>
+<style>
+:root { --bg:#0d1117; --panel:#161b22; --border:#30363d; --fg:#c9d1d9;
+  --muted:#8b949e; --accent:#58a6ff; --green:#3fb950; --yellow:#d29922;
+  --red:#f85149; --purple:#bc8cff; }
+* { box-sizing:border-box; }
+html, body { margin:0; background:var(--bg); color:var(--fg);
+  font:13px/1.5 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; }
+header { padding:12px 16px; border-bottom:1px solid var(--border);
+  display:flex; align-items:baseline; gap:14px; flex-wrap:wrap; }
+h1 { font-size:15px; margin:0; color:var(--accent); font-weight:600; }
+#meta { color:var(--muted); font-size:12px; }
+.banner { background:var(--red); color:#fff; padding:8px 16px; font-weight:700; }
+.hidden { display:none; }
+main { padding:12px 16px; }
+table { width:100%; border-collapse:collapse; }
+th, td { text-align:left; padding:6px 8px; border-bottom:1px solid var(--border);
+  vertical-align:top; }
+th { color:var(--muted); font-weight:400; white-space:nowrap; }
+tr:hover td { background:var(--panel); }
+.mono { white-space:nowrap; }
+.state { font-weight:700; }
+.state.working { color:var(--green); }
+.state.done { color:var(--green); }
+.state.parked { color:var(--yellow); }
+.state.paused { color:var(--yellow); }
+.state.blocked { color:var(--red); }
+.state.failed { color:var(--red); }
+.state.unknown { color:var(--muted); }
+.badge { border:1px solid var(--border); border-radius:3px; padding:0 4px;
+  margin-left:4px; color:var(--muted); font-size:11px; }
+.badge.warn { color:var(--yellow); border-color:var(--yellow); }
+.badge.err { color:var(--red); border-color:var(--red); }
+.badge.val { color:var(--purple); border-color:var(--purple); }
+.checks.success { color:var(--green); }
+.checks.failure { color:var(--red); }
+.checks.pending { color:var(--yellow); }
+.checks.no_checks, .checks.unknown { color:var(--muted); }
+a { color:var(--accent); text-decoration:none; }
+a:hover { text-decoration:underline; }
+details.pane { margin:0; }
+summary { cursor:pointer; color:var(--accent); user-select:none; }
+pre.tail { background:var(--panel); border:1px solid var(--border); padding:6px 8px;
+  margin:4px 0 0; white-space:pre-wrap; word-break:break-word; max-height:220px;
+  overflow:auto; color:var(--fg); font-size:12px; }
+.errline { color:var(--red); }
+#empty { color:var(--muted); padding:28px; text-align:center;
+  border:1px dashed var(--border); }
+footer { color:var(--muted); padding:8px 16px; font-size:11px; }
+</style>
+</head>
+<body>
+<header>
+  <h1>firstmate fleet</h1>
+  <span id="meta"></span>
+</header>
+<div id="banner" class="banner hidden"></div>
+<main>
+  <div id="empty" class="hidden">No live workers. The fleet is empty.</div>
+  <table id="fleet">
+    <thead><tr>
+      <th>Task</th><th>Kind</th><th>Harness / Model</th><th>Project</th>
+      <th>State</th><th>Validation / Activity</th><th>PR / Checks</th><th>Tail</th>
+    </tr></thead>
+    <tbody id="rows"></tbody>
+  </table>
+</main>
+<footer id="footer"></footer>
+<script>
+var REFRESH = __REFRESH__;
+function esc(s) {
+  return String(s == null ? '' : s).replace(/[&<>"']/g, function (c) {
+    return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+  });
+}
+function stateClass(s) {
+  var cls = { working: 'working', done: 'done', parked: 'parked', paused: 'paused',
+    blocked: 'blocked', failed: 'failed', unknown: 'unknown' }[s] || 'unknown';
+  return cls;
+}
+function checksHtml(pr) {
+  if (!pr || !pr.url) return '<span class="errline">no PR</span>';
+  var out = '<a href="' + esc(pr.url) + '" target="_blank" rel="noopener">PR</a>';
+  var c = pr.checks;
+  if (!c) return out;
+  if (c.error) return out + ' <span class="badge err">' + esc(c.error) + '</span>';
+  out += ' <span class="checks ' + esc(c.verdict) + '">' + esc(c.verdict) + '</span>';
+  if (c.pr_state) out += ' <span class="badge">' + esc(c.pr_state) + '</span>';
+  var items = c.items || [];
+  if (items.length) {
+    out += '<details class="pane"><summary>checks</summary><pre class="tail">';
+    out += items.map(function (i) {
+      return esc(i.name || '?') + ' ' + esc(i.status || '') +
+        (i.conclusion ? ' / ' + esc(i.conclusion) : '');
+    }).join('\n');
+    out += '</pre></details>';
+  }
+  return out;
+}
+function tailHtml(t) {
+  var p = t.pane_tail || {};
+  if (t.remote_host) return '<span class="badge">remote: ' + esc(t.remote_host) + '</span>';
+  if (p.error) return '<span class="errline">' + esc(p.error) + '</span>';
+  var lines = p.lines || [];
+  if (!lines.length) return '<span class="badge">no output</span>';
+  return '<details class="pane"><summary>tail (' + lines.length + ')</summary>' +
+    '<pre class="tail">' + esc(lines.join('\n')) + '</pre></details>';
+}
+function activityHtml(t) {
+  if (t.validation && t.validation.active) {
+    return '<span class="badge val">validation</span> ' + esc(t.validation.detail || t.state_detail || '');
+  }
+  // Prefer the last wake-event note (the meaningful activity) over a pane
+  // busy-state detail, which the State column already conveys.
+  var d = t.latest_activity || t.state_detail || '';
+  return d ? esc(d) : '<span class="badge">-</span>';
+}
+function flagsHtml(t) {
+  var out = '';
+  if (t.pending_decision) out += '<span class="badge warn">decision</span>';
+  if (t.blocked) out += '<span class="badge err">blocked</span>';
+  return out;
+}
+function rowHtml(t) {
+  var harness = t.harness || '';
+  if (t.model) harness += ' / ' + t.model;
+  return '<tr>' +
+    '<td class="mono">' + esc(t.id) + '</td>' +
+    '<td class="mono">' + esc(t.kind) + '</td>' +
+    '<td class="mono">' + esc(harness) + '</td>' +
+    '<td>' + esc(t.project) + '</td>' +
+    '<td><span class="state ' + stateClass(t.state) + '">' + esc(t.state) + '</span>' +
+      ' <span class="badge">' + esc(t.state_source) + '</span>' + flagsHtml(t) + '</td>' +
+    '<td>' + activityHtml(t) + '</td>' +
+    '<td>' + checksHtml(t.pr) + '</td>' +
+    '<td>' + tailHtml(t) + '</td>' +
+    '</tr>';
+}
+function render(data) {
+  var meta = document.getElementById('meta');
+  var banner = document.getElementById('banner');
+  var empty = document.getElementById('empty');
+  var tbody = document.getElementById('rows');
+  var footer = document.getElementById('footer');
+  banner.classList.add('hidden');
+  banner.textContent = '';
+  if (data.error) { banner.textContent = 'error: ' + data.error; banner.classList.remove('hidden'); }
+  var tasks = data.tasks || [];
+  meta.textContent = 'home: ' + (data.fm_home || '?') + ' · generated: ' +
+    (data.generated || '?') + ' · refresh: ' + (data.refresh_seconds || REFRESH) + 's';
+  if (!tasks.length) {
+    empty.classList.remove('hidden');
+    tbody.innerHTML = '';
+  } else {
+    empty.classList.add('hidden');
+    tbody.innerHTML = tasks.map(rowHtml).join('');
+  }
+  footer.textContent = tasks.length + ' worker(s) · auto-refresh ' +
+    (data.refresh_seconds || REFRESH) + 's · rendered ' + new Date().toISOString();
+}
+function tick() {
+  fetch('/snapshot').then(function (r) {
+    if (!r.ok) throw new Error('HTTP ' + r.status);
+    return r.json();
+  }).then(render).catch(function (e) {
+    var banner = document.getElementById('banner');
+    banner.textContent = 'snapshot failed: ' + e.message;
+    banner.classList.remove('hidden');
+  });
+}
+setInterval(tick, REFRESH * 1000);
+tick();
+</script>
+</body>
+</html>
+HTML
+}
+
+# dashboard_serve - run the stdlib http.server loop. The bash script stays the
+# single data owner: the server shells back into `--snapshot` for fleet data and
+# `--pr-check` for PR checks, holding the 60s PR-check cache in memory.
+dashboard_serve() {
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "fm-dashboard: python3 is required to serve the dashboard" >&2
+    exit 1
+  fi
+  python3 - "$SELF" "$PORT" "$HOST" "$REFRESH" "$GH_CACHE_TTL" <<'PY'
+import http.server
+import json
+import subprocess
+import sys
+import time
+
+SCRIPT = sys.argv[1]
+PORT = int(sys.argv[2])
+HOST = sys.argv[3]
+REFRESH = int(sys.argv[4])
+GH_TTL = int(sys.argv[5])
+
+
+def snapshot_json():
+    p = subprocess.run([SCRIPT, "--snapshot"], capture_output=True, text=True, timeout=180)
+    try:
+        data = json.loads(p.stdout or "{}")
+    except json.JSONDecodeError:
+        return {"schema": "fm-dashboard.v1", "error": "snapshot returned invalid JSON",
+                "tasks": [], "errors": ["snapshot returned invalid JSON"]}
+    if p.returncode != 0:
+        data["error"] = data.get("error") or ("snapshot failed: " + (p.stderr or "")[:200])
+    for task in data.get("tasks", []):
+        pr = task.get("pr") or {}
+        url = pr.get("url")
+        if url:
+            pr["checks"] = pr_checks(url)
+        else:
+            pr["checks"] = None
+        task["pr"] = pr
+    return data
+
+
+def pr_checks(url):
+    now = time.monotonic()
+    cached = SERVER.gh_cache.get(url)
+    if cached and (now - cached[0]) < GH_TTL:
+        return cached[1]
+    p = subprocess.run([SCRIPT, "--pr-check", url], capture_output=True, text=True, timeout=30)
+    try:
+        checks = json.loads(p.stdout or "{}")
+    except json.JSONDecodeError:
+        checks = {"url": url, "error": "pr-check returned invalid JSON"}
+    SERVER.gh_cache[url] = (now, checks)
+    return checks
+
+
+class Server(http.server.ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(self, *a, **kw):
+        super().__init__(*a, **kw)
+        self.gh_cache = {}
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def _text(self, code, body, ctype):
+        payload = body.encode()
+        self.send_response(code)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_GET(self):
+        if self.path in ("/", "/index.html"):
+            p = subprocess.run([SCRIPT, "--html", "--refresh", str(REFRESH)],
+                               capture_output=True, text=True, timeout=15)
+            self._text(200, p.stdout or "", "text/html; charset=utf-8")
+        elif self.path == "/snapshot":
+            self._text(200, json.dumps(snapshot_json()), "application/json; charset=utf-8")
+        elif self.path == "/health":
+            self._text(200, "ok", "text/plain; charset=utf-8")
+        else:
+            self._text(404, "not found", "text/plain; charset=utf-8")
+
+
+SERVER = Server((HOST, PORT), Handler)
+print("fm-dashboard: serving on http://%s:%s" % (HOST, SERVER.server_address[1]),
+      file=sys.stderr, flush=True)
+try:
+    SERVER.serve_forever()
+except KeyboardInterrupt:
+    pass
+PY
+}
+
+case "$MODE" in
+  snapshot) dashboard_snapshot ;;
+  pr-check) pr_check_json "$PR_URL" ;;
+  html) dashboard_html ;;
+  serve) dashboard_serve ;;
+  *) usage >&2; exit 2 ;;
+esac

--- a/bin/fm-dashboard.sh
+++ b/bin/fm-dashboard.sh
@@ -34,7 +34,7 @@
 #   --host HOST    loopback bind address: 127.0.0.1, ::1, or localhost
 #                  (default 127.0.0.1; non-loopback is refused)
 #   --refresh N    page auto-refresh interval in seconds (default 10)
-#   --gh-cache N   PR checks cache TTL in seconds (default 60)
+#   --gh-cache N   PR checks cache TTL in seconds, minimum 60 (default 60)
 #   --pane-lines N pane tail line count (default 15)
 #
 # Output contract: `--snapshot` prints one JSON object with schema
@@ -61,6 +61,7 @@ usage: fm-dashboard.sh [--port N] [--host HOST] [--refresh N] [--gh-cache N]
 Serve an always-on, read-only local fleet dashboard on localhost.
 With no mode flag the dashboard serves. --snapshot prints the dashboard JSON,
 --pr-check prints one PR's checks JSON, and --html prints the page HTML.
+--gh-cache accepts a minimum of 60 seconds.
 EOF
 }
 
@@ -111,6 +112,7 @@ case "$HOST" in
 esac
 case "$REFRESH" in ''|*[!0-9]*|0) fail_usage "--refresh must be a positive integer" ;; esac
 case "$GH_CACHE_TTL" in ''|*[!0-9]*|0) fail_usage "--gh-cache must be a positive integer" ;; esac
+[ "$GH_CACHE_TTL" -ge 60 ] || fail_usage "--gh-cache must be at least 60 seconds"
 case "$PANE_LINES" in ''|*[!0-9]*|0) fail_usage "--pane-lines must be a positive integer" ;; esac
 
 # pane_tail_json <backend> <target> <lines> <id> - read the last <lines> lines

--- a/bin/fm-dashboard.sh
+++ b/bin/fm-dashboard.sh
@@ -460,6 +460,7 @@ import json
 import socket
 import subprocess
 import sys
+import threading
 import time
 
 SCRIPT = sys.argv[1]
@@ -501,17 +502,20 @@ def snapshot_json():
 
 
 def pr_checks(url):
-    now = time.monotonic()
-    cached = SERVER.gh_cache.get(url)
-    if cached and (now - cached[0]) < GH_TTL:
-        return cached[1]
-    p = subprocess.run([SCRIPT, "--pr-check", url], capture_output=True, text=True, timeout=30)
-    try:
-        checks = json.loads(p.stdout or "{}")
-    except json.JSONDecodeError:
-        checks = {"url": url, "error": "pr-check returned invalid JSON"}
-    SERVER.gh_cache[url] = (now, checks)
-    return checks
+    with SERVER.gh_locks_guard:
+        lock = SERVER.gh_locks.setdefault(url, threading.Lock())
+    with lock:
+        now = time.monotonic()
+        cached = SERVER.gh_cache.get(url)
+        if cached and (now - cached[0]) < GH_TTL:
+            return cached[1]
+        p = subprocess.run([SCRIPT, "--pr-check", url], capture_output=True, text=True, timeout=30)
+        try:
+            checks = json.loads(p.stdout or "{}")
+        except json.JSONDecodeError:
+            checks = {"url": url, "error": "pr-check returned invalid JSON"}
+        SERVER.gh_cache[url] = (time.monotonic(), checks)
+        return checks
 
 
 class Server(http.server.ThreadingHTTPServer):
@@ -521,6 +525,8 @@ class Server(http.server.ThreadingHTTPServer):
     def __init__(self, *a, **kw):
         super().__init__(*a, **kw)
         self.gh_cache = {}
+        self.gh_locks = {}
+        self.gh_locks_guard = threading.Lock()
 
 
 class Handler(http.server.BaseHTTPRequestHandler):

--- a/bin/fm-dashboard.sh
+++ b/bin/fm-dashboard.sh
@@ -142,6 +142,19 @@ pane_tail_json() {  # <backend> <target> <lines> <id>
   jq -n --argjson lines "$lines_json" '{lines:$lines, error:null}'
 }
 
+remote_pane_tail_json() {  # <id> <lines>
+  local id=$1 lines=$2 capture rc text lines_json
+  capture=$("$SCRIPT_DIR/fm-on.sh" "$id" fm-remote-secondmate-control.sh capture "$id" "$lines" 2>/dev/null)
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    jq -n --arg e "remote pane capture failed (exit $rc)" '{lines:[], error:$e}'
+    return 0
+  fi
+  text=$(printf '%s\n' "$capture" | sed '/^[[:space:]]*$/d' | tail -n "$lines")
+  lines_json=$(printf '%s\n' "$text" | jq -Rn '[inputs]')
+  jq -n --argjson lines "$lines_json" '{lines:$lines, error:null}'
+}
+
 # pr_check_json <url> - read-only PR checks for one github.com PR via gh.
 # Non-github URLs are answered with an explicit error rather than a fake pass.
 pr_check_json() {  # <url>
@@ -187,7 +200,7 @@ pr_check_json() {  # <url>
 # dashboard_snapshot - emit the fm-dashboard.v1 JSON. Always exits 0 and carries
 # failures in `error`/`errors` fields so the UI renders them loudly.
 dashboard_snapshot() {
-  local snapshot now fm_home task id backend target meta_path model pane
+  local snapshot now fm_home task id backend target model pane
   local enriched tasks
   now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   if ! command -v jq >/dev/null 2>&1; then
@@ -210,13 +223,9 @@ dashboard_snapshot() {
     id=$(printf '%s' "$task" | jq -r '.id // ""')
     backend=$(printf '%s' "$task" | jq -r '.backend // "tmux"')
     target=$(printf '%s' "$task" | jq -r '.endpoint.target // ""')
-    meta_path=$(printf '%s' "$task" | jq -r '.paths.meta.path // ""')
-    model=""
-    if [ -n "$meta_path" ]; then
-      model=$(fm_meta_get "$meta_path" model)
-    fi
+    model=$(printf '%s' "$task" | jq -r '.model // ""')
     if [ "$(printf '%s' "$task" | jq -r '.remote.host // ""')" != "" ]; then
-      pane=$(jq -n '{lines:[], error:null}')
+      pane=$(remote_pane_tail_json "$id" "$PANE_LINES")
     else
       pane=$(pane_tail_json "$backend" "$target" "$PANE_LINES" "$id")
     fi

--- a/bin/fm-dashboard.sh
+++ b/bin/fm-dashboard.sh
@@ -435,9 +435,10 @@ function tick() {
     var banner = document.getElementById('banner');
     banner.textContent = 'snapshot failed: ' + e.message;
     banner.classList.remove('hidden');
+  }).then(function () {
+    setTimeout(tick, REFRESH * 1000);
   });
 }
-setInterval(tick, REFRESH * 1000);
 tick();
 </script>
 </body>

--- a/bin/fm-dashboard.sh
+++ b/bin/fm-dashboard.sh
@@ -194,7 +194,7 @@ dashboard_snapshot() {
     printf '%s\n' '{"schema":"fm-dashboard.v1","generated":"","fm_home":null,"refresh_seconds":0,"error":"jq not found","tasks":[],"errors":["jq not found"]}'
     return 0
   fi
-  if ! snapshot=$("$SCRIPT_DIR/fm-fleet-snapshot.sh" --json 2>&1); then
+  if ! snapshot=$("$SCRIPT_DIR/fm-fleet-snapshot.sh" --json --no-remote-probe 2>&1); then
     snapshot=""
   fi
   if ! printf '%s' "$snapshot" | jq -e '.schema == "fm-fleet-snapshot.v1"' >/dev/null 2>&1; then

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -140,11 +140,12 @@ validate_positive_bound FM_SNAPSHOT_REGISTRY_TIMEOUT "$FM_SNAPSHOT_REGISTRY_TIME
 
 usage() {
   cat <<'EOF'
-usage: fm-fleet-snapshot.sh --json
+usage: fm-fleet-snapshot.sh --json [--no-remote-probe]
        fm-fleet-snapshot.sh --secondmate-home-summary
 
 Print a read-only structured snapshot of the firstmate fleet.
 JSON is the stable machine-readable output contract.
+--no-remote-probe keeps --json local-only and reports remote state as unknown.
 
 --secondmate-home-summary emits the bounded structured summary used after a
 validated registered-home handoff. It is local-only, skips nested secondmate
@@ -168,12 +169,19 @@ EOF
 }
 
 OUTPUT_MODE=json
-case "${1:---json}" in
-  --json) ;;
-  --secondmate-home-summary) OUTPUT_MODE=secondmate-home-summary ;;
-  -h|--help) usage; exit 0 ;;
-  *) usage >&2; exit 2 ;;
-esac
+REMOTE_PROBE=1
+[ "$#" -gt 0 ] || set -- --json
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --json) OUTPUT_MODE=json ;;
+    --no-remote-probe) REMOTE_PROBE=0 ;;
+    --secondmate-home-summary) OUTPUT_MODE=secondmate-home-summary ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage >&2; exit 2 ;;
+  esac
+  shift
+done
+[ "$OUTPUT_MODE" = json ] || [ "$REMOTE_PROBE" -eq 1 ] || { usage >&2; exit 2; }
 
 command -v jq >/dev/null 2>&1 || { echo "fm-fleet-snapshot: jq not found" >&2; exit 1; }
 
@@ -483,7 +491,7 @@ task_json_lines() {
 
     endpoint_exists=null
     agent_alive=not_checked
-    if [ -n "$remote_host" ]; then
+    if [ -n "$remote_host" ] && [ "$REMOTE_PROBE" -eq 1 ]; then
       if remote_state=$(fm_run_timed "$FM_SNAPSHOT_SECONDMATE_TIMEOUT" \
         "$SCRIPT_DIR/fm-on.sh" "$id" fm-remote-secondmate-control.sh state "$id" < /dev/null 2>/dev/null); then
         remote_rc=0
@@ -1173,7 +1181,9 @@ secondmate_current_json() {  # <parent-tasks-json>
       esac
     fi
     if [ -z "$reason" ]; then
-      if [ "$remote" = true ]; then
+      if [ "$remote" = true ] && [ "$REMOTE_PROBE" -eq 0 ]; then
+        reason="remote probe disabled"
+      elif [ "$remote" = true ]; then
         [ -n "$host" ] || reason="invalid remote route: missing SSH host"
         case " $seen_homes " in
           *" $host:$home "*) reason="invalid home: duplicate resolved remote route" ;;

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -20,16 +20,20 @@
 #     requires_child_metadata, blocked_by_ids, unresolved_blocker_ids, and
 #     captain_actionable fields. Repeated blocker tokens remain ordered; a blocker
 #     resolves only when its structured record is Done, and missing ids stay open.
-#   tasks[]: one row per state/<id>.meta, sorted by id.
+#   tasks[]: one row per state/<id>.meta, sorted by id, including recorded
+#     harness and model identity.
 #     current_state is parsed from bin/fm-crew-state.sh <id> and preserves
-#     state, source, detail, and raw line separately.
+#     state, source, detail, and raw line separately. With --no-remote-probe,
+#     remote rows use their local status history and explicitly report unknown
+#     when that history does not establish current state.
 #     paths.status_log.last_event is historical wake-event data only, never
 #     current state.
 #     hints.open_decisions is the keyed open-decision set returned by
 #     fm-classify-lib.sh's authoritative status_open_decisions fold and reconciled
 #     against current_state; hints.pending_decision and hints.blocked_event are
 #     booleans derived from that set.
-#     endpoint.exists is the cheap backend endpoint-presence read.
+#     endpoint.exists is the cheap backend endpoint-presence read; it is unknown
+#     for remote rows when --no-remote-probe is set.
 #     endpoint.agent_alive is populated for secondmates only, where it is useful
 #     return-channel supervision data; other tasks use "not_checked".
 #   scout_reports[]: present data/<id>/report.md pointers.

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -268,7 +268,7 @@ status_current_json() {  # <status-event-json>
       working) state=working; source=status-log; detail=$note ;;
       needs-decision) state=parked; source=status-log; detail=$note ;;
       blocked) state=blocked; source=status-log; detail=$note ;;
-      done) state=done; source=status-log; detail=$note ;;
+      done) state='done'; source=status-log; detail=$note ;;
       failed) state=failed; source=status-log; detail=$note ;;
     esac
   fi

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -253,6 +253,29 @@ status_event_json() {  # <status-log>
     '{path:$path,present:$present,kind:"event_history",last_event:{state:$verb,note:$note,raw:$raw}}'
 }
 
+status_current_json() {  # <status-event-json>
+  local event=$1 raw verb note state=unknown source=none detail
+  raw=$(printf '%s' "$event" | jq -r '.last_event.raw // ""')
+  verb=$(printf '%s' "$event" | jq -r '.last_event.state // ""')
+  note=$(printf '%s' "$event" | jq -r '.last_event.note // ""')
+  detail="remote live state unavailable without probe"
+  if status_is_paused "$raw"; then
+    state=paused
+    source=status-log
+    detail=$note
+  else
+    case "$verb" in
+      working) state=working; source=status-log; detail=$note ;;
+      needs-decision) state=parked; source=status-log; detail=$note ;;
+      blocked) state=blocked; source=status-log; detail=$note ;;
+      done) state=done; source=status-log; detail=$note ;;
+      failed) state=failed; source=status-log; detail=$note ;;
+    esac
+  fi
+  jq -n --arg raw "$raw" --arg state "$state" --arg source "$source" --arg detail "$detail" \
+    '{state:$state,source:$source,detail:$detail,raw:$raw}'
+}
+
 first_pr_url_in_file() {  # <file>
   [ -f "$1" ] || return 1
   grep -Eo 'https?://[^[:space:])"]+/pull/[0-9]+' "$1" 2>/dev/null | head -1
@@ -452,8 +475,12 @@ task_json_lines() {
       pr_source=absent
     fi
 
-    current_json=$(crew_state_json "$id")
     event_json=$(status_event_json "$status_log")
+    if [ -n "$remote_host" ] && [ "$REMOTE_PROBE" -eq 0 ]; then
+      current_json=$(status_current_json "$event_json")
+    else
+      current_json=$(crew_state_json "$id")
+    fi
     last_event_raw=$(printf '%s' "$event_json" | jq -r '.last_event.raw // ""')
     current_state=$(printf '%s' "$current_json" | jq -r '.state // ""')
     current_source=$(printf '%s' "$current_json" | jq -r '.source // ""')

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -401,7 +401,7 @@ backlog_json() {  # [<backlog-path>] - defaults to this home's $BACKLOG
 }
 
 task_json_lines() {
-  local meta id kind harness mode yolo project worktree home projects backend target status_log report_path
+  local meta id kind harness model mode yolo project worktree home projects backend target status_log report_path
   local remote_host remote_root remote_state remote_rc remote_home_present
   local pr pr_source event_json current_json endpoint_exists agent_alive meta_json status_json report_json worktree_json home_json
   local last_event_raw current_state current_source pending_decision blocked_event report_present=0 pr_from_status
@@ -413,6 +413,7 @@ task_json_lines() {
     kind=$(meta_value "$meta" kind)
     [ -n "$kind" ] || kind=ship
     harness=$(meta_value "$meta" harness)
+    model=$(meta_value "$meta" model)
     mode=$(meta_value "$meta" mode)
     yolo=$(meta_value "$meta" yolo)
     project=$(meta_value "$meta" project)
@@ -532,6 +533,7 @@ task_json_lines() {
       --arg id "$id" \
       --arg kind "$kind" \
       --arg harness "$harness" \
+      --arg model "$model" \
       --arg mode "$mode" \
       --arg yolo "$yolo" \
       --arg project "$project" \
@@ -562,6 +564,7 @@ task_json_lines() {
         id:$id,
         kind:$kind,
         harness:($harness // ""),
+        model:($model // ""),
         mode:($mode // ""),
         yolo:($yolo // ""),
         project:($project // ""),

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -491,25 +491,27 @@ task_json_lines() {
 
     endpoint_exists=null
     agent_alive=not_checked
-    if [ -n "$remote_host" ] && [ "$REMOTE_PROBE" -eq 1 ]; then
-      if remote_state=$(fm_run_timed "$FM_SNAPSHOT_SECONDMATE_TIMEOUT" \
-        "$SCRIPT_DIR/fm-on.sh" "$id" fm-remote-secondmate-control.sh state "$id" < /dev/null 2>/dev/null); then
-        remote_rc=0
-      else
-        remote_rc=$?
-      fi
-      if [ "$remote_rc" -eq 0 ]; then
-        remote_home_present=true
-        remote_state=$(printf '%s\n' "$remote_state" | tail -1)
-        case "$remote_state" in
-          alive) endpoint_exists=true; agent_alive=alive ;;
-          dead) endpoint_exists=true; agent_alive=dead ;;
-          missing) endpoint_exists=false; agent_alive=dead ;;
-          *) endpoint_exists=null; agent_alive=unknown ;;
-        esac
-      else
-        endpoint_exists=null
-        agent_alive=unknown
+    if [ -n "$remote_host" ]; then
+      if [ "$REMOTE_PROBE" -eq 1 ]; then
+        if remote_state=$(fm_run_timed "$FM_SNAPSHOT_SECONDMATE_TIMEOUT" \
+          "$SCRIPT_DIR/fm-on.sh" "$id" fm-remote-secondmate-control.sh state "$id" < /dev/null 2>/dev/null); then
+          remote_rc=0
+        else
+          remote_rc=$?
+        fi
+        if [ "$remote_rc" -eq 0 ]; then
+          remote_home_present=true
+          remote_state=$(printf '%s\n' "$remote_state" | tail -1)
+          case "$remote_state" in
+            alive) endpoint_exists=true; agent_alive=alive ;;
+            dead) endpoint_exists=true; agent_alive=dead ;;
+            missing) endpoint_exists=false; agent_alive=dead ;;
+            *) endpoint_exists=null; agent_alive=unknown ;;
+          esac
+        else
+          endpoint_exists=null
+          agent_alive=unknown
+        fi
       fi
     else
       if [ -n "$target" ]; then

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -211,7 +211,7 @@ family_for_basename() {
     fm-afk-inject-e2e.test.sh|fm-afk-return.test.sh)
       printf '%s\n' afk
       ;;
-    fm-bearings-snapshot.test.sh|fm-fleet-snapshot-view.test.sh)
+    fm-bearings-snapshot.test.sh|fm-dashboard.test.sh|fm-fleet-snapshot-view.test.sh)
       printf '%s\n' snapshot-bearings
       ;;
     fm-backend-cmux.test.sh|fm-backend-cmux-smoke.test.sh)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,7 +50,7 @@ Decision-only events such as `resolved` never become current state or leak their
 In that status-log fallback, a declared external wait reports the distinct `paused` state with its reason.
 The semantic branch reports working only on an exact busy verdict and names the source that produced it; an unknown verdict never becomes working, never permits the status-log fallback, and never becomes a silent idle.
 For whole-fleet read-only review, `bin/fm-fleet-snapshot.sh --json` emits schema `fm-fleet-snapshot.v1` from the backlog, task metadata, current crew state, endpoint probes, PR/report pointers, scout reports, bounded current summaries from registered secondmate homes, and secondmate return-channel guidance.
-`bin/fm-fleet-view.sh` renders that snapshot as Markdown for humans, while `bin/fm-bearings-snapshot.sh` provides the bounded bearings projection, so both views consume one structured contract instead of reparsing raw fleet files.
+`bin/fm-fleet-view.sh` renders that snapshot as Markdown for humans, `bin/fm-bearings-snapshot.sh` provides the bounded bearings projection, and `bin/fm-dashboard.sh` serves it as a live localhost dashboard, so all three consume one structured contract instead of reparsing raw fleet files.
 The script header owns the exact JSON schema.
 
 ### Registered secondmate current state

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -16,6 +16,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-fleet-sync.sh`       | Refresh project clones with safe fast-forwards, self-heals, `STUCK:` reports, branch pruning, and bounded recovery from an orphaned `.git/packed-refs.lock` |
 | `fm-fleet-snapshot.sh`   | Print the read-only structured fleet snapshot JSON (schema `fm-fleet-snapshot.v1`)   |
 | `fm-fleet-view.sh`       | Render the fleet snapshot as a human Markdown view                                   |
+| `fm-dashboard.sh`        | Serve a read-only localhost fleet dashboard (state, tails, validation, PR checks)    |
 | `fm-bearings-snapshot.sh` | Project the fleet snapshot to the compact TOON bearings view; local-only unless `--include-prs` |
 | `fm-update.sh`           | Fast-forward-only self-update of firstmate and local or remote secondmate homes       |
 | `fm-on.sh`               | Execute one tracked Firstmate command in a configured remote secondmate home, using its job worker except for the doctor bootstrap |

--- a/tests/fm-dashboard.test.sh
+++ b/tests/fm-dashboard.test.sh
@@ -225,6 +225,39 @@ SH
   pass "dashboard surfaces a pane capture failure loudly"
 }
 
+test_remote_pane_capture() {
+  local home fakebin fake_ssh out
+  home=$(make_home remote)
+  fm_write_meta "$home/state/remote-task.meta" \
+    "home=/remote/home" \
+    "project=alpha" \
+    "harness=claude" \
+    "model=opus-4" \
+    "kind=secondmate" \
+    "mode=secondmate" \
+    "remote_host=remote-mac" \
+    "remote_root=/remote/root" \
+    "remote_backend=herdr" \
+    "remote_target=fm-remote:remote-task:pane"
+  printf '%s\n' '- remote-task - remote delivery (host: remote-mac; root: /remote/root; home: /remote/home; scope: remote work; projects: alpha; added 2026-08-17)' > "$home/data/secondmates.md"
+  fakebin=$(make_fakebin "$home")
+  fake_ssh="$fakebin/ssh"
+  cat > "$fake_ssh" <<'SH'
+#!/usr/bin/env bash
+printf 'remote worker output\nremote validation active\n'
+SH
+  chmod +x "$fake_ssh"
+  out=$(PATH="$fakebin:$PATH" FM_SSH_BIN="$fake_ssh" FM_HOME="$home" "$DASH" --snapshot)
+  printf '%s' "$out" | jq -e '
+    .tasks[0].model == "opus-4"
+      and .tasks[0].remote_host == "remote-mac"
+      and .tasks[0].pane_tail.error == null
+      and (.tasks[0].pane_tail.lines | index("remote worker output") != null)
+      and (.tasks[0].pane_tail.lines | index("remote validation active") != null)
+  ' >/dev/null || fail "remote pane capture must be displayed through the remote reader: $out"
+  pass "dashboard captures remote worker pane tails through the supported reader"
+}
+
 test_run_step_validation_active() {
   local home fakebin out repo wt
   home=$(make_home runstep)
@@ -439,6 +472,7 @@ test_usage_and_validation() {
 test_empty_fleet_snapshot
 test_pane_source_task_enrichment
 test_pane_capture_error_is_loud
+test_remote_pane_capture
 test_run_step_validation_active
 test_pr_check_verdicts
 test_html_page

--- a/tests/fm-dashboard.test.sh
+++ b/tests/fm-dashboard.test.sh
@@ -480,6 +480,70 @@ test_concurrent_serve_cache_single_flight() {
   pass "concurrent snapshot requests single-flight PR check refreshes"
 }
 
+test_concurrent_serve_cache_timeout() {
+  serve_tools_available || { pass "cache timeout test skipped (python3 or curl absent)"; return 0; }
+  local home fakebin port pid gh_count out_dir curl_pid i ready
+  home=$(make_home servetimeout)
+  mkdir -p "$home/projects/wt"
+  fm_write_meta "$home/state/ship-task.meta" \
+    "window=firstmate:fm-ship-task" \
+    "worktree=$home/projects/wt" \
+    "project=alpha" \
+    "harness=claude" \
+    "kind=ship" \
+    "mode=ship" \
+    "pr=https://github.com/o/r/pull/9"
+  printf 'working: building\n' > "$home/state/ship-task.status"
+  record_busy "$home/state" ship-task
+  fakebin=$(make_fakebin "$home")
+  fake_gh "$fakebin" '{"state":"OPEN","statusCheckRollup":[]}'
+  GH_COUNT_FILE=$TMP_ROOT/gh-timeout-count
+  : > "$GH_COUNT_FILE"
+  out_dir=$TMP_ROOT/timeout-responses
+  mkdir -p "$out_dir"
+  port=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
+
+  GH_COUNT_FILE="$GH_COUNT_FILE" GH_DELAY=31 PATH="$fakebin:$PATH" FM_HOME="$home" \
+    "$DASH" --port "$port" --gh-cache 60 >"$TMP_ROOT/serve-timeout.log" 2>&1 &
+  pid=$!
+  i=0
+  ready=0
+  while [ "$i" -lt 50 ]; do
+    if curl -fsS "http://127.0.0.1:$port/health" >/dev/null 2>&1; then ready=1; break; fi
+    sleep 0.1
+    i=$((i + 1))
+  done
+  if [ "$ready" -ne 1 ]; then
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    fail "timeout-cache dashboard server did not come up: $(cat "$TMP_ROOT/serve-timeout.log")"
+  fi
+
+  curl_pid=""
+  i=1
+  while [ "$i" -le 3 ]; do
+    curl -fsS --max-time 40 "http://127.0.0.1:$port/snapshot" > "$out_dir/$i.json" &
+    curl_pid="$curl_pid $!"
+    i=$((i + 1))
+  done
+  for i in $curl_pid; do
+    wait "$i" || fail "concurrent timeout snapshot request failed"
+  done
+  for i in "$out_dir"/*.json; do
+    jq -e '
+      .tasks[0].pr.checks.verdict == "unknown"
+        and .tasks[0].pr.checks.items == []
+        and (.tasks[0].pr.checks.error | test("timed out"))
+    ' "$i" >/dev/null || fail "PR timeout must remain visible in valid snapshot JSON: $(cat "$i")"
+  done
+  gh_count=$(wc -l < "$GH_COUNT_FILE" | tr -d ' ')
+  [ "$gh_count" = "1" ] || fail "timed-out concurrent cache misses must call gh once, got $gh_count calls"
+
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  pass "timed-out PR checks return and cache a visible error"
+}
+
 # Empty fleet served over HTTP must render the explicit empty state.
 test_serve_empty_fleet() {
   serve_tools_available || { pass "empty serve test skipped (python3 or curl absent)"; return 0; }
@@ -562,6 +626,7 @@ test_pr_check_verdicts
 test_html_page
 test_serve_and_cache
 test_concurrent_serve_cache_single_flight
+test_concurrent_serve_cache_timeout
 test_serve_empty_fleet
 test_serve_ipv6_host
 test_usage_and_validation

--- a/tests/fm-dashboard.test.sh
+++ b/tests/fm-dashboard.test.sh
@@ -117,6 +117,7 @@ fake_gh() {  # <fakebin> <json>
   cat > "$fb/gh" <<SH
 #!/usr/bin/env bash
 [ -n "\${GH_COUNT_FILE:-}" ] && printf 'x\n' >> "\$GH_COUNT_FILE"
+[ -z "\${GH_DELAY:-}" ] || sleep "\$GH_DELAY"
 cat <<'JSON'
 $json
 JSON
@@ -418,6 +419,67 @@ test_serve_and_cache() {
   pass "dashboard serves localhost snapshot and HTML, caching PR checks across refreshes"
 }
 
+test_concurrent_serve_cache_single_flight() {
+  serve_tools_available || { pass "concurrent cache test skipped (python3 or curl absent)"; return 0; }
+  local home fakebin port pid gh_count out_dir curl_pid i ready
+  home=$(make_home serveconcurrent)
+  mkdir -p "$home/projects/wt"
+  fm_write_meta "$home/state/ship-task.meta" \
+    "window=firstmate:fm-ship-task" \
+    "worktree=$home/projects/wt" \
+    "project=alpha" \
+    "harness=claude" \
+    "kind=ship" \
+    "mode=ship" \
+    "pr=https://github.com/o/r/pull/8"
+  printf 'working: building\n' > "$home/state/ship-task.status"
+  record_busy "$home/state" ship-task
+  fakebin=$(make_fakebin "$home")
+  fake_gh "$fakebin" '{"state":"OPEN","statusCheckRollup":[{"name":"ci","status":"COMPLETED","conclusion":"SUCCESS"}]}'
+  GH_COUNT_FILE=$TMP_ROOT/gh-concurrent-count
+  : > "$GH_COUNT_FILE"
+  out_dir=$TMP_ROOT/concurrent-responses
+  mkdir -p "$out_dir"
+  port=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
+
+  GH_COUNT_FILE="$GH_COUNT_FILE" GH_DELAY=1 PATH="$fakebin:$PATH" FM_HOME="$home" \
+    "$DASH" --port "$port" --gh-cache 60 >"$TMP_ROOT/serve-concurrent.log" 2>&1 &
+  pid=$!
+  i=0
+  ready=0
+  while [ "$i" -lt 50 ]; do
+    if curl -fsS "http://127.0.0.1:$port/health" >/dev/null 2>&1; then ready=1; break; fi
+    sleep 0.1
+    i=$((i + 1))
+  done
+  if [ "$ready" -ne 1 ]; then
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    fail "concurrent-cache dashboard server did not come up: $(cat "$TMP_ROOT/serve-concurrent.log")"
+  fi
+
+  curl_pid=""
+  i=1
+  while [ "$i" -le 6 ]; do
+    curl -fsS "http://127.0.0.1:$port/snapshot" > "$out_dir/$i.json" &
+    curl_pid="$curl_pid $!"
+    i=$((i + 1))
+  done
+  for i in $curl_pid; do
+    wait "$i" || fail "concurrent snapshot request failed"
+  done
+  for i in "$out_dir"/*.json; do
+    jq -e '.tasks[0].pr.checks.verdict == "success"' "$i" >/dev/null \
+      || fail "concurrent snapshot omitted successful checks: $(cat "$i")"
+  done
+  gh_count=$(wc -l < "$GH_COUNT_FILE" | tr -d ' ')
+  [ "$gh_count" = "1" ] || fail "concurrent cache misses must single-flight gh, got $gh_count calls"
+
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  pass "concurrent snapshot requests single-flight PR check refreshes"
+}
+
 # Empty fleet served over HTTP must render the explicit empty state.
 test_serve_empty_fleet() {
   serve_tools_available || { pass "empty serve test skipped (python3 or curl absent)"; return 0; }
@@ -499,6 +561,7 @@ test_run_step_validation_active
 test_pr_check_verdicts
 test_html_page
 test_serve_and_cache
+test_concurrent_serve_cache_single_flight
 test_serve_empty_fleet
 test_serve_ipv6_host
 test_usage_and_validation

--- a/tests/fm-dashboard.test.sh
+++ b/tests/fm-dashboard.test.sh
@@ -391,6 +391,37 @@ test_serve_empty_fleet() {
   pass "dashboard serves an explicit empty state for an empty fleet"
 }
 
+# --host ::1 is a documented, validated loopback address; the server must
+# actually bind and serve on it instead of crashing with an AF_INET/IPv6
+# socket.gaierror.
+test_serve_ipv6_host() {
+  serve_tools_available || { pass "ipv6 host serve test skipped (python3 or curl absent)"; return 0; }
+  local home fakebin port pid out
+  home=$(make_home serveipv6)
+  fakebin=$(make_fakebin "$home")
+  port=$(python3 -c 'import socket; s=socket.socket(socket.AF_INET6); s.bind(("::1",0)); print(s.getsockname()[1]); s.close()')
+  PATH="$fakebin:$PATH" FM_HOME="$home" "$DASH" --host ::1 --port "$port" >"$TMP_ROOT/serve-ipv6.log" 2>&1 &
+  pid=$!
+  local i=0 ready=0
+  while [ "$i" -lt 50 ]; do
+    if curl -fsS "http://[::1]:$port/health" >/dev/null 2>&1; then ready=1; break; fi
+    if ! kill -0 "$pid" 2>/dev/null; then break; fi
+    sleep 0.1
+    i=$((i + 1))
+  done
+  if [ "$ready" -ne 1 ]; then
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    fail "--host ::1 dashboard server did not come up: $(cat "$TMP_ROOT/serve-ipv6.log")"
+  fi
+  out=$(curl -fsS "http://[::1]:$port/snapshot")
+  printf '%s' "$out" | jq -e '(.tasks | length) == 0 and .error == null' >/dev/null \
+    || fail "ipv6 host snapshot must be empty with no error: $out"
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  pass "dashboard serves on --host ::1 instead of crashing on AF_INET bind"
+}
+
 test_usage_and_validation() {
   local out rc
   out=$("$DASH" --help)
@@ -413,4 +444,5 @@ test_pr_check_verdicts
 test_html_page
 test_serve_and_cache
 test_serve_empty_fleet
+test_serve_ipv6_host
 test_usage_and_validation

--- a/tests/fm-dashboard.test.sh
+++ b/tests/fm-dashboard.test.sh
@@ -614,6 +614,10 @@ test_usage_and_validation() {
   expect_code 2 "$rc" "non-loopback host must be refused"
   "$DASH" --refresh 0 >/dev/null 2>&1; rc=$?
   expect_code 2 "$rc" "refresh 0 must be refused"
+  out=$("$DASH" --gh-cache 59 2>&1); rc=$?
+  expect_code 2 "$rc" "GitHub cache TTL below 60 seconds must be refused"
+  assert_contains "$out" "--gh-cache must be at least 60 seconds" \
+    "low GitHub cache TTL must fail with its minimum"
   pass "usage documents flags and argument validation refuses bad values"
 }
 

--- a/tests/fm-dashboard.test.sh
+++ b/tests/fm-dashboard.test.sh
@@ -226,7 +226,7 @@ SH
 }
 
 test_remote_pane_notice_without_capture() {
-  local home fakebin fake_ssh ssh_log out
+  local home fakebin fake_ssh fake_herdr ssh_log backend_log out
   home=$(make_home remote)
   fm_write_meta "$home/state/remote-task.meta" \
     "home=/remote/home" \
@@ -242,21 +242,30 @@ test_remote_pane_notice_without_capture() {
   printf '%s\n' '- remote-task - remote delivery (host: remote-mac; root: /remote/root; home: /remote/home; scope: remote work; projects: alpha; added 2026-08-17)' > "$home/data/secondmates.md"
   fakebin=$(make_fakebin "$home")
   fake_ssh="$fakebin/ssh"
+  fake_herdr="$fakebin/herdr"
   ssh_log="$home/ssh.log"
+  backend_log="$home/backend.log"
   cat > "$fake_ssh" <<'SH'
 #!/usr/bin/env bash
 printf 'invoked\n' >> "${SSH_LOG:?}"
 exit 1
 SH
-  chmod +x "$fake_ssh"
-  out=$(PATH="$fakebin:$PATH" FM_SSH_BIN="$fake_ssh" SSH_LOG="$ssh_log" FM_HOME="$home" "$DASH" --snapshot)
+  cat > "$fake_herdr" <<'SH'
+#!/usr/bin/env bash
+printf 'invoked\n' >> "${BACKEND_LOG:?}"
+exit 1
+SH
+  chmod +x "$fake_ssh" "$fake_herdr"
+  out=$(PATH="$fakebin:$PATH" FM_SSH_BIN="$fake_ssh" SSH_LOG="$ssh_log" BACKEND_LOG="$backend_log" FM_HOME="$home" "$DASH" --snapshot)
   printf '%s' "$out" | jq -e '
     .tasks[0].model == "opus-4"
       and .tasks[0].remote_host == "remote-mac"
+      and .tasks[0].endpoint_present == null
       and .tasks[0].pane_tail.error == "remote worker - live view not available from the dashboard; open its remote session"
       and (.tasks[0].pane_tail.lines | length) == 0
   ' >/dev/null || fail "remote workers must carry an explicit unavailable live-view notice: $out"
   [ ! -e "$ssh_log" ] || fail "dashboard must not invoke remote transport: $(cat "$ssh_log")"
+  [ ! -e "$backend_log" ] || fail "dashboard must not probe a remote task through the local backend: $(cat "$backend_log")"
   pass "dashboard reports remote live view unavailable without remote probes"
 }
 

--- a/tests/fm-dashboard.test.sh
+++ b/tests/fm-dashboard.test.sh
@@ -225,8 +225,8 @@ SH
   pass "dashboard surfaces a pane capture failure loudly"
 }
 
-test_remote_pane_capture() {
-  local home fakebin fake_ssh out
+test_remote_pane_notice_without_capture() {
+  local home fakebin fake_ssh ssh_log out
   home=$(make_home remote)
   fm_write_meta "$home/state/remote-task.meta" \
     "home=/remote/home" \
@@ -242,20 +242,30 @@ test_remote_pane_capture() {
   printf '%s\n' '- remote-task - remote delivery (host: remote-mac; root: /remote/root; home: /remote/home; scope: remote work; projects: alpha; added 2026-08-17)' > "$home/data/secondmates.md"
   fakebin=$(make_fakebin "$home")
   fake_ssh="$fakebin/ssh"
+  ssh_log="$home/ssh.log"
   cat > "$fake_ssh" <<'SH'
 #!/usr/bin/env bash
-printf 'remote worker output\nremote validation active\n'
+argv_b64=${@: -1}
+if [ "$(uname)" = Darwin ]; then
+  printf '%s' "$argv_b64" | base64 -D
+else
+  printf '%s' "$argv_b64" | base64 --decode
+fi | tr '\0' ' ' >> "${SSH_LOG:?}"
+printf '\n' >> "$SSH_LOG"
+printf 'alive\n'
 SH
   chmod +x "$fake_ssh"
-  out=$(PATH="$fakebin:$PATH" FM_SSH_BIN="$fake_ssh" FM_HOME="$home" "$DASH" --snapshot)
+  out=$(PATH="$fakebin:$PATH" FM_SSH_BIN="$fake_ssh" SSH_LOG="$ssh_log" FM_HOME="$home" "$DASH" --snapshot)
   printf '%s' "$out" | jq -e '
     .tasks[0].model == "opus-4"
       and .tasks[0].remote_host == "remote-mac"
-      and .tasks[0].pane_tail.error == null
-      and (.tasks[0].pane_tail.lines | index("remote worker output") != null)
-      and (.tasks[0].pane_tail.lines | index("remote validation active") != null)
-  ' >/dev/null || fail "remote pane capture must be displayed through the remote reader: $out"
-  pass "dashboard captures remote worker pane tails through the supported reader"
+      and .tasks[0].pane_tail.error == "remote worker - live view not available from the dashboard; open its remote session"
+      and (.tasks[0].pane_tail.lines | length) == 0
+  ' >/dev/null || fail "remote workers must carry an explicit unavailable live-view notice: $out"
+  if grep -q ' capture ' "$ssh_log"; then
+    fail "dashboard must not transport remote pane capture: $(cat "$ssh_log")"
+  fi
+  pass "dashboard reports remote live view unavailable without remote capture"
 }
 
 test_run_step_validation_active() {
@@ -472,7 +482,7 @@ test_usage_and_validation() {
 test_empty_fleet_snapshot
 test_pane_source_task_enrichment
 test_pane_capture_error_is_loud
-test_remote_pane_capture
+test_remote_pane_notice_without_capture
 test_run_step_validation_active
 test_pr_check_verdicts
 test_html_page

--- a/tests/fm-dashboard.test.sh
+++ b/tests/fm-dashboard.test.sh
@@ -245,14 +245,8 @@ test_remote_pane_notice_without_capture() {
   ssh_log="$home/ssh.log"
   cat > "$fake_ssh" <<'SH'
 #!/usr/bin/env bash
-argv_b64=${@: -1}
-if [ "$(uname)" = Darwin ]; then
-  printf '%s' "$argv_b64" | base64 -D
-else
-  printf '%s' "$argv_b64" | base64 --decode
-fi | tr '\0' ' ' >> "${SSH_LOG:?}"
-printf '\n' >> "$SSH_LOG"
-printf 'alive\n'
+printf 'invoked\n' >> "${SSH_LOG:?}"
+exit 1
 SH
   chmod +x "$fake_ssh"
   out=$(PATH="$fakebin:$PATH" FM_SSH_BIN="$fake_ssh" SSH_LOG="$ssh_log" FM_HOME="$home" "$DASH" --snapshot)
@@ -262,10 +256,8 @@ SH
       and .tasks[0].pane_tail.error == "remote worker - live view not available from the dashboard; open its remote session"
       and (.tasks[0].pane_tail.lines | length) == 0
   ' >/dev/null || fail "remote workers must carry an explicit unavailable live-view notice: $out"
-  if grep -q ' capture ' "$ssh_log"; then
-    fail "dashboard must not transport remote pane capture: $(cat "$ssh_log")"
-  fi
-  pass "dashboard reports remote live view unavailable without remote capture"
+  [ ! -e "$ssh_log" ] || fail "dashboard must not invoke remote transport: $(cat "$ssh_log")"
+  pass "dashboard reports remote live view unavailable without remote probes"
 }
 
 test_run_step_validation_active() {

--- a/tests/fm-dashboard.test.sh
+++ b/tests/fm-dashboard.test.sh
@@ -226,7 +226,7 @@ SH
 }
 
 test_remote_pane_notice_without_capture() {
-  local home fakebin fake_ssh fake_herdr ssh_log backend_log out
+  local home fakebin fake_ssh fake_herdr ssh_log backend_log tmux_log out
   home=$(make_home remote)
   fm_write_meta "$home/state/remote-task.meta" \
     "home=/remote/home" \
@@ -235,19 +235,27 @@ test_remote_pane_notice_without_capture() {
     "model=opus-4" \
     "kind=secondmate" \
     "mode=secondmate" \
+    "window=remote:remote-task" \
     "remote_host=remote-mac" \
     "remote_root=/remote/root" \
     "remote_backend=herdr" \
     "remote_target=fm-remote:remote-task:pane"
   printf '%s\n' '- remote-task - remote delivery (host: remote-mac; root: /remote/root; home: /remote/home; scope: remote work; projects: alpha; added 2026-08-17)' > "$home/data/secondmates.md"
+  printf 'blocked: waiting for remote operator\n' > "$home/state/remote-task.status"
   fakebin=$(make_fakebin "$home")
   fake_ssh="$fakebin/ssh"
   fake_herdr="$fakebin/herdr"
   ssh_log="$home/ssh.log"
   backend_log="$home/backend.log"
+  tmux_log="$home/tmux.log"
   cat > "$fake_ssh" <<'SH'
 #!/usr/bin/env bash
 printf 'invoked\n' >> "${SSH_LOG:?}"
+exit 1
+SH
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+printf 'invoked\n' >> "${TMUX_LOG:?}"
 exit 1
 SH
   cat > "$fake_herdr" <<'SH'
@@ -256,16 +264,19 @@ printf 'invoked\n' >> "${BACKEND_LOG:?}"
 exit 1
 SH
   chmod +x "$fake_ssh" "$fake_herdr"
-  out=$(PATH="$fakebin:$PATH" FM_SSH_BIN="$fake_ssh" SSH_LOG="$ssh_log" BACKEND_LOG="$backend_log" FM_HOME="$home" "$DASH" --snapshot)
+  out=$(PATH="$fakebin:$PATH" FM_SSH_BIN="$fake_ssh" SSH_LOG="$ssh_log" BACKEND_LOG="$backend_log" TMUX_LOG="$tmux_log" FM_HOME="$home" "$DASH" --snapshot)
   printf '%s' "$out" | jq -e '
     .tasks[0].model == "opus-4"
       and .tasks[0].remote_host == "remote-mac"
+      and .tasks[0].state == "blocked"
+      and .tasks[0].state_source == "status-log"
       and .tasks[0].endpoint_present == null
       and .tasks[0].pane_tail.error == "remote worker - live view not available from the dashboard; open its remote session"
       and (.tasks[0].pane_tail.lines | length) == 0
   ' >/dev/null || fail "remote workers must carry an explicit unavailable live-view notice: $out"
   [ ! -e "$ssh_log" ] || fail "dashboard must not invoke remote transport: $(cat "$ssh_log")"
   [ ! -e "$backend_log" ] || fail "dashboard must not probe a remote task through the local backend: $(cat "$backend_log")"
+  [ ! -e "$tmux_log" ] || fail "dashboard must not probe a remote task through local tmux: $(cat "$tmux_log")"
   pass "dashboard reports remote live view unavailable without remote probes"
 }
 

--- a/tests/fm-dashboard.test.sh
+++ b/tests/fm-dashboard.test.sh
@@ -1,0 +1,416 @@
+#!/usr/bin/env bash
+# Behavior tests for the read-only local fleet dashboard (bin/fm-dashboard.sh).
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+DASH="$ROOT/bin/fm-dashboard.sh"
+TMP_ROOT=$(fm_test_tmproot fm-dashboard)
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+
+# make_fakebin builds a fakebin whose tmux answers the probes the fleet
+# snapshot and crew-state readers make, and whose no-mistakes is a no-op.
+make_fakebin() {  # <dir>
+  local fb
+  fb=$(fm_fakebin "$1")
+  cat > "$fb/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  cat > "$fb/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+target=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "-t" ]; then target=$arg; fi
+  prev=$arg
+done
+case "${1:-}" in
+  list-windows)
+    sed -n 's/^window=[^:]*://p' "${FM_HOME:?}"/state/*.meta
+    ;;
+  display-message)
+    case "$*" in
+      *pane_current_command*)
+        case "$target" in
+          *) printf 'codex\n' ;;
+        esac
+        ;;
+      *) printf '%%1\n' ;;
+    esac
+    ;;
+  capture-pane)
+    printf 'compiling module alpha\n'
+    printf 'tests: 12 passed\n'
+    printf '> \n'
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/no-mistakes" "$fb/tmux"
+  printf '%s\n' "$fb"
+}
+
+# make_run_fakebin adds a no-mistakes that attributes an active run to the
+# current worktree branch+head, so a ship task reads as a run-step source.
+make_run_fakebin() {  # <dir>
+  local fb
+  fb=$(fm_fakebin "$1")
+  cat > "$fb/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+target=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "-t" ]; then target=$arg; fi
+  prev=$arg
+done
+case "${1:-}" in
+  list-windows)
+    sed -n 's/^window=[^:]*://p' "${FM_HOME:?}"/state/*.meta
+    ;;
+  display-message)
+    case "$*" in
+      *pane_current_command*) printf 'codex\n' ;;
+      *) printf '%%1\n' ;;
+    esac
+    ;;
+  capture-pane)
+    printf 'validating review step\n'
+    ;;
+esac
+exit 0
+SH
+  cat > "$fb/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  axi)
+    case "${2:-}" in
+      status)
+        branch=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+        head=$(git rev-parse HEAD 2>/dev/null || true)
+        printf 'status: running\n'
+        printf 'outcome:\n'
+        printf 'branch: %s\n' "$branch"
+        printf 'head: %s\n' "$head"
+        ;;
+      *) exit 0 ;;
+    esac
+    ;;
+  *) exit 0 ;;
+esac
+SH
+  chmod +x "$fb/tmux" "$fb/no-mistakes"
+  printf '%s\n' "$fb"
+}
+
+# fake_gh writes a fake gh into <fakebin> that echoes <json> for any call and,
+# when GH_COUNT_FILE is set, appends one line per invocation so a test can count
+# how many times the server actually called gh.
+fake_gh() {  # <fakebin> <json>
+  local fb=$1 json=$2
+  cat > "$fb/gh" <<SH
+#!/usr/bin/env bash
+[ -n "\${GH_COUNT_FILE:-}" ] && printf 'x\n' >> "\$GH_COUNT_FILE"
+cat <<'JSON'
+$json
+JSON
+SH
+  chmod +x "$fb/gh"
+}
+
+make_home() {  # <name>
+  local home=$TMP_ROOT/$1
+  mkdir -p "$home/state" "$home/data" "$home/projects" "$home/config"
+  printf '%s\n' "$home"
+}
+
+record_busy() {  # <state-dir> <id>
+  local state=$1 id=$2 gen
+  gen=$("$ROOT/bin/fm-busy-event.sh" arm "$state" "$id")
+  "$ROOT/bin/fm-busy-event.sh" apply "$state" "$id" busy --gen "$gen" \
+    --source claude-hook --event user-prompt-submit
+}
+
+test_empty_fleet_snapshot() {
+  local home out
+  home=$(make_home empty)
+  out=$(FM_HOME="$home" "$DASH" --snapshot)
+  printf '%s' "$out" | jq -e '
+    .schema == "fm-dashboard.v1"
+      and .error == null
+      and (.tasks | length == 0)
+  ' >/dev/null || fail "empty snapshot must have no tasks and no error: $out"
+  pass "empty fleet snapshot reports an explicit empty task list"
+}
+
+test_pane_source_task_enrichment() {
+  local home fakebin out
+  home=$(make_home pane)
+  mkdir -p "$home/projects/wt"
+  fm_write_meta "$home/state/ship-task.meta" \
+    "window=firstmate:fm-ship-task" \
+    "worktree=$home/projects/wt" \
+    "project=alpha" \
+    "harness=claude" \
+    "model=opus-4" \
+    "kind=ship" \
+    "mode=ship" \
+    "pr=https://github.com/kunchenguid/firstmate/pull/9"
+  printf 'working: implementing the fix\n' > "$home/state/ship-task.status"
+  record_busy "$home/state" ship-task
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$DASH" --snapshot)
+  printf '%s' "$out" | jq -e '
+    (.tasks | length) == 1
+      and .tasks[0].id == "ship-task"
+      and .tasks[0].kind == "ship"
+      and .tasks[0].harness == "claude"
+      and .tasks[0].model == "opus-4"
+      and .tasks[0].project == "alpha"
+      and .tasks[0].state == "working"
+      and .tasks[0].state_source == "pane"
+      and .tasks[0].pr.url == "https://github.com/kunchenguid/firstmate/pull/9"
+      and .tasks[0].validation.active == false
+      and ((.tasks[0].pane_tail.lines | length) > 0)
+      and .tasks[0].pane_tail.error == null
+  ' >/dev/null || fail "pane task enrichment wrong: $out"
+  pass "dashboard enriches a live pane worker with state, model, tail, and PR"
+}
+
+test_pane_capture_error_is_loud() {
+  local home fakebin out
+  home=$(make_home paneerr)
+  mkdir -p "$home/projects/wt"
+  fm_write_meta "$home/state/ship-task.meta" \
+    "window=firstmate:fm-ship-task" \
+    "worktree=$home/projects/wt" \
+    "project=alpha" \
+    "harness=claude" \
+    "kind=ship" \
+    "mode=ship"
+  printf 'working: x\n' > "$home/state/ship-task.status"
+  record_busy "$home/state" ship-task
+  fakebin=$(make_fakebin "$home")
+  # Break the fake tmux's capture-pane so the pane tail must surface an error.
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+target=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "-t" ]; then target=$arg; fi
+  prev=$arg
+done
+case "${1:-}" in
+  list-windows) sed -n 's/^window=[^:]*://p' "${FM_HOME:?}"/state/*.meta ;;
+  display-message)
+    case "$*" in
+      *pane_current_command*) printf 'codex\n' ;;
+      *) printf '%%1\n' ;;
+    esac ;;
+  capture-pane) exit 1 ;;
+esac
+exit 0
+SH
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$DASH" --snapshot)
+  printf '%s' "$out" | jq -e '
+    .tasks[0].pane_tail.error != null and (.tasks[0].pane_tail.lines | length == 0)
+  ' >/dev/null || fail "a pane capture failure must surface an error, not an empty tail: $out"
+  pass "dashboard surfaces a pane capture failure loudly"
+}
+
+test_run_step_validation_active() {
+  local home fakebin out repo wt
+  home=$(make_home runstep)
+  repo=$home/repo
+  wt=$home/projects/wt
+  mkdir -p "$home/projects"
+  fm_git_worktree "$repo" "$wt" dashboard-branch
+  fm_write_meta "$home/state/run-task.meta" \
+    "window=firstmate:fm-run-task" \
+    "worktree=$wt" \
+    "project=alpha" \
+    "harness=claude" \
+    "kind=ship" \
+    "mode=ship"
+  printf 'working: validating\n' > "$home/state/run-task.status"
+  fakebin=$(make_run_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$DASH" --snapshot)
+  printf '%s' "$out" | jq -e '
+    (.tasks | length) == 1
+      and .tasks[0].id == "run-task"
+      and .tasks[0].state_source == "run-step"
+      and .tasks[0].validation.active == true
+      and (.tasks[0].validation.detail | test("validating"))
+  ' >/dev/null || fail "a ship task with an active run must read validation.active: $out"
+  pass "dashboard surfaces the no-mistakes validation step for an active run"
+}
+
+test_pr_check_verdicts() {
+  local fb success failure pending empty nongithub
+  fb=$(fm_fakebin "$TMP_ROOT/prchecks")
+  fake_gh "$fb" '{"state":"OPEN","statusCheckRollup":[{"name":"ci","status":"COMPLETED","conclusion":"SUCCESS"}]}'
+  success=$(PATH="$fb:$PATH" "$DASH" --pr-check "https://github.com/o/r/pull/1")
+  printf '%s' "$success" | jq -e '.verdict == "success" and .pr_state == "OPEN" and .error == null' >/dev/null \
+    || fail "success verdict wrong: $success"
+
+  fake_gh "$fb" '{"state":"OPEN","statusCheckRollup":[{"name":"ci","status":"COMPLETED","conclusion":"SUCCESS"},{"name":"lint","status":"COMPLETED","conclusion":"FAILURE"}]}'
+  failure=$(PATH="$fb:$PATH" "$DASH" --pr-check "https://github.com/o/r/pull/1")
+  printf '%s' "$failure" | jq -e '.verdict == "failure"' >/dev/null \
+    || fail "failure verdict wrong: $failure"
+
+  fake_gh "$fb" '{"state":"OPEN","statusCheckRollup":[{"name":"ci","status":"IN_PROGRESS","conclusion":null}]}'
+  pending=$(PATH="$fb:$PATH" "$DASH" --pr-check "https://github.com/o/r/pull/1")
+  printf '%s' "$pending" | jq -e '.verdict == "pending"' >/dev/null \
+    || fail "pending verdict wrong: $pending"
+
+  fake_gh "$fb" '{"state":"OPEN","statusCheckRollup":[]}'
+  empty=$(PATH="$fb:$PATH" "$DASH" --pr-check "https://github.com/o/r/pull/1")
+  printf '%s' "$empty" | jq -e '.verdict == "no_checks"' >/dev/null \
+    || fail "no_checks verdict wrong: $empty"
+
+  nongithub=$("$DASH" --pr-check "https://gitlab.com/o/r/-/merge_requests/1")
+  printf '%s' "$nongithub" | jq -e '.error == "PR checks support github.com only"' >/dev/null \
+    || fail "non-github PR must fail loud: $nongithub"
+  pass "pr-check maps gh rollups to success/failure/pending/no_checks and refuses non-github"
+}
+
+test_html_page() {
+  local html
+  html=$("$DASH" --html --refresh 7)
+  assert_contains "$html" "var REFRESH = 7;" "html must bake in the refresh interval"
+  assert_contains "$html" "firstmate fleet" "html must carry the title"
+  assert_contains "$html" "No live workers. The fleet is empty." "html must carry the explicit empty state"
+  assert_contains "$html" "Harness / Model" "html must carry the harness/model column"
+  assert_contains "$html" "Validation / Activity" "html must carry the validation column"
+  assert_contains "$html" "--bg:#0d1117" "html must use a dark terminal theme"
+  pass "html page carries refresh, empty state, columns, and dark theme"
+}
+
+# The serve-mode tests need a real HTTP server and client; skip them cleanly on
+# a host without either, matching the snapshot-bearings optional-binary gate.
+serve_tools_available() {
+  command -v python3 >/dev/null 2>&1 && command -v curl >/dev/null 2>&1
+}
+
+# Serve mode: start the server against a fixture fleet, verify it binds
+# loopback, serves the HTML and snapshot, and caches PR checks for the TTL.
+test_serve_and_cache() {
+  serve_tools_available || { pass "serve test skipped (python3 or curl absent)"; return 0; }
+  local home fakebin port pid out1 out2 count_html gh_count
+  home=$(make_home serve)
+  mkdir -p "$home/projects/wt"
+  fm_write_meta "$home/state/ship-task.meta" \
+    "window=firstmate:fm-ship-task" \
+    "worktree=$home/projects/wt" \
+    "project=alpha" \
+    "harness=claude" \
+    "kind=ship" \
+    "mode=ship" \
+    "pr=https://github.com/o/r/pull/7"
+  printf 'working: building\n' > "$home/state/ship-task.status"
+  record_busy "$home/state" ship-task
+  fakebin=$(make_fakebin "$home")
+  fake_gh "$fakebin" '{"state":"OPEN","statusCheckRollup":[{"name":"ci","status":"COMPLETED","conclusion":"SUCCESS"}]}'
+  GH_COUNT_FILE=$TMP_ROOT/gh-count
+  : > "$GH_COUNT_FILE"
+  port=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
+
+  GH_COUNT_FILE="$GH_COUNT_FILE" PATH="$fakebin:$PATH" FM_HOME="$home" \
+    "$DASH" --port "$port" --gh-cache 60 >"$TMP_ROOT/serve.log" 2>&1 &
+  pid=$!
+
+  local i=0 ready=0
+  while [ "$i" -lt 50 ]; do
+    if curl -fsS "http://127.0.0.1:$port/health" >/dev/null 2>&1; then ready=1; break; fi
+    sleep 0.1
+    i=$((i + 1))
+  done
+  if [ "$ready" -ne 1 ]; then
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    fail "dashboard server did not come up: $(cat "$TMP_ROOT/serve.log")"
+  fi
+
+  out1=$(curl -fsS "http://127.0.0.1:$port/snapshot")
+  out2=$(curl -fsS "http://127.0.0.1:$port/snapshot")
+  count_html=$(curl -fsS "http://127.0.0.1:$port/")
+
+  printf '%s' "$out1" | jq -e '
+    (.tasks | length) == 1
+      and .tasks[0].id == "ship-task"
+      and .tasks[0].pr.url == "https://github.com/o/r/pull/7"
+      and .tasks[0].pr.checks.verdict == "success"
+      and .tasks[0].pr.checks.pr_state == "OPEN"
+  ' >/dev/null || fail "served snapshot must include cached PR checks: $out1"
+  printf '%s' "$out2" | jq -e '.tasks[0].pr.checks.verdict == "success"' >/dev/null \
+    || fail "second snapshot must serve the same cached checks: $out2"
+  gh_count=$(wc -l < "$GH_COUNT_FILE" | tr -d ' ')
+  [ "$gh_count" = "1" ] || fail "gh must be called once across two refreshes (cache), got $gh_count"
+  case "$count_html" in
+    *"firstmate fleet"*) : ;;
+    *) fail "root path must serve the dashboard HTML, got: $count_html" ;;
+  esac
+
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  pass "dashboard serves localhost snapshot and HTML, caching PR checks across refreshes"
+}
+
+# Empty fleet served over HTTP must render the explicit empty state.
+test_serve_empty_fleet() {
+  serve_tools_available || { pass "empty serve test skipped (python3 or curl absent)"; return 0; }
+  local home fakebin port pid out
+  home=$(make_home serveempty)
+  fakebin=$(make_fakebin "$home")
+  port=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
+  PATH="$fakebin:$PATH" FM_HOME="$home" "$DASH" --port "$port" >"$TMP_ROOT/serve-empty.log" 2>&1 &
+  pid=$!
+  local i=0 ready=0
+  while [ "$i" -lt 50 ]; do
+    if curl -fsS "http://127.0.0.1:$port/health" >/dev/null 2>&1; then ready=1; break; fi
+    sleep 0.1
+    i=$((i + 1))
+  done
+  if [ "$ready" -ne 1 ]; then
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    fail "empty-fleet dashboard server did not come up: $(cat "$TMP_ROOT/serve-empty.log")"
+  fi
+  out=$(curl -fsS "http://127.0.0.1:$port/snapshot")
+  printf '%s' "$out" | jq -e '(.tasks | length) == 0 and .error == null' >/dev/null \
+    || fail "empty fleet snapshot must be empty with no error: $out"
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  pass "dashboard serves an explicit empty state for an empty fleet"
+}
+
+test_usage_and_validation() {
+  local out rc
+  out=$("$DASH" --help)
+  assert_contains "$out" "--port" "usage must document --port"
+  assert_contains "$out" "--refresh" "usage must document --refresh"
+  "$DASH" --port 0 >/dev/null 2>&1; rc=$?
+  expect_code 2 "$rc" "port 0 must be refused"
+  "$DASH" --host 0.0.0.0 >/dev/null 2>&1; rc=$?
+  expect_code 2 "$rc" "non-loopback host must be refused"
+  "$DASH" --refresh 0 >/dev/null 2>&1; rc=$?
+  expect_code 2 "$rc" "refresh 0 must be refused"
+  pass "usage documents flags and argument validation refuses bad values"
+}
+
+test_empty_fleet_snapshot
+test_pane_source_task_enrichment
+test_pane_capture_error_is_loud
+test_run_step_validation_active
+test_pr_check_verdicts
+test_html_page
+test_serve_and_cache
+test_serve_empty_fleet
+test_usage_and_validation


### PR DESCRIPTION
## Intent

Build an always-on local fleet dashboard for firstmate as a single self-contained web page served on localhost by one new bin script, auto-refreshing about every 10 seconds. For each in-flight worker show task id, kind, harness/model, project, current state and latest activity from bin/fm-fleet-snapshot.sh --json plus run-step from bin/fm-crew-state.sh, an expandable read-only tmux capture-pane tail of about 15 lines from the recorded window, active no-mistakes validation step from read-only status, and a recorded PR link with cached read-only GitHub checks refreshed no more often than every 60 seconds. The dashboard must be strictly read-only, never write state, data, or worktrees, shell out only to read-only commands, add no dependencies beyond Python 3 stdlib and shell, bind localhost only, fail loudly on source errors, show an explicit empty-fleet state, use a dark terminal-themed scannable table-first UI, include repository-convention behavioral tests, keep bin scripts ShellCheck-clean, and document port and flags in the script header or maintained docs. Preserve all accepted prior review fixes and captain decisions. Delivery was re-homed from fm/fleet-dashboard at exact preserved head 7f5eea90 to fm/fleet-dashboard-v2 because the old branch has an unrecoverable stale no-mistakes custody record; no commits were discarded and the old branch remains untouched. State this branch re-home and reason in the PR body.

## What Changed

- Add a localhost-only, read-only fleet dashboard with a dark table-first UI, automatic refresh, worker state and activity, expandable pane tails, validation status, and cached GitHub PR checks.
- Extend fleet snapshots with model metadata and a local-only `--no-remote-probe` mode, with dashboard behavioral coverage and script documentation.
- Re-home delivery from `fm/fleet-dashboard` at preserved head `7f5eea90` because its no-mistakes custody record is unrecoverably stale; no commits were discarded and the old branch remains untouched.

## Risk Assessment

✅ Low: The dashboard is well-bounded and the successive fixes now enforce single-flight GitHub check refreshes, cache timeout errors visibly, and reject cache TTLs below 60 seconds without introducing a substantiated source defect.

## Testing

Inspected the focused delta, passed the complete dashboard behavioral suite—including enrichment, loud failures, validation state, PR-check caching/concurrency/timeout, and IPv4/IPv6 serving—then manually served the real localhost UI, verified its JSON response, and captured a reviewer-visible screenshot confirming the dark table-first layout, 10-second refresh, and explicit empty-fleet state; the worktree remained clean.

- Evidence: [Rendered localhost dashboard showing dark table-first UI, 10-second refresh, and explicit empty-fleet state](https://github.com/pm-justinm/firstmate/blob/b1c013ade3b5be0a4574486d44a264a580cfd69c/.no-mistakes/evidence/fm/fleet-dashboard-v2/fleet-dashboard-empty-state.png)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e1dae1a43a51e9518996835dd042758b4e3896e1","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (3) ✅</summary>

- 🚨 `bin/fm-dashboard.sh:505` - The required “cached read-only GitHub checks refreshed no more often than every 60 seconds” invariant is not enforced across concurrent requests. `ThreadingHTTPServer` allows two `/snapshot` requests to reach this cache lookup before either stores a result, so both miss and invoke `gh pr view` simultaneously. Add per-URL synchronization or single-flight caching at `pr_checks()` so only one refresh can occur within the TTL.

🔧 Fix: Single-flight concurrent GitHub check cache refreshes
1 error still open:
- 🚨 `bin/fm-dashboard.sh:512` - The required “GitHub checks refreshed no more often than every 60 seconds” invariant still fails when `--pr-check` exceeds the 30-second timeout. `subprocess.run` raises `TimeoutExpired` before any cache entry is stored; queued concurrent requests then acquire the lock one by one and immediately invoke the same check again, while the HTTP response also closes without the required visible JSON error. Catch the timeout inside the per-URL lock and cache an explicit error result with the normal TTL.

🔧 Fix: Cache timed-out GitHub checks with visible errors
1 error still open:
- 🚨 `bin/fm-dashboard.sh:108` - The required “GitHub checks refreshed no more often than every 60 seconds” invariant remains user-configurably bypassable: `--gh-cache 1` is accepted because validation only requires a positive integer, causing a PR to refresh every second. Enforce a minimum TTL of 60 seconds (or remove values below 60 from the supported flag contract).

🔧 Fix: Enforce minimum GitHub checks cache TTL
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat 64d61aed84373e02b1a28c4e6b262908ed8128d5..47316ad567eac52fac8172747ec927b0cd58ef32` and focused change/test inspection</code>
- `bash tests/fm-dashboard.test.sh`
- <code>`bin/fm-dashboard.sh --port 48790` with `curl -fsS http://127.0.0.1:48790/snapshot`</code>
- `playwright screenshot --viewport-size=1440,900 --wait-for-timeout=1500 http://127.0.0.1:48790/ .../fleet-dashboard-empty-state.png`
- `Visual inspection of the captured 1440×900 dashboard screenshot`
- <code>`git status --short` after cleanup</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 127)

🔧 Fix: Captain, confirm configured lint commands pass
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
