### PR TITLE
fix: keep paused decision keys open

### DIFF
--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -305,8 +305,8 @@ _fm_decision_key_transition_allowed() {  # <key> <note>
   return 0
 }
 
-_fm_decision_fold_line() {  # <open-set> <status-line> <resolve-verb> <held-verb>
-  local open=$1 line=$2 resolve=$3 held=$4 verb key note stripped
+_fm_decision_fold_line() {  # <open-set> <status-line> <resolve-verb> <held-verb> <pause-verb>
+  local open=$1 line=$2 resolve=$3 held=$4 pause=$5 verb key note stripped
   stripped=${line//[[:space:]]/}
   [ -n "$stripped" ] || { printf '%s' "$open"; return 0; }
   verb=$(status_line_verb "$line")
@@ -314,6 +314,11 @@ _fm_decision_fold_line() {  # <open-set> <status-line> <resolve-verb> <held-verb
   _fm_decision_key_transition_allowed "$key" "$(status_line_note "$line")" \
     || { printf '%s' "$open"; return 0; }
   case "$verb" in
+    "$pause")
+      # A pause is an activity marker, never a decision transition. Keep this
+      # branch before the configurable close verbs so even a conflicting
+      # override cannot reinterpret a keyed wait marker as an answer.
+      ;;
     needs-decision|blocked)
       note=$(status_line_note "$line")
       open=$(_fm_decision_drop "$open" "$key")
@@ -341,12 +346,13 @@ _fm_decision_fold_line() {  # <open-set> <status-line> <resolve-verb> <held-verb
 # subprocess read, which exists for that function's much narrower payload-driven
 # path resolution rather than this directory-local glob.
 status_open_decisions() {  # <status-file>
-  local f=$1 line resolve held open=''
+  local f=$1 line resolve held pause open=''
   [ -f "$f" ] && [ -r "$f" ] && [ ! -L "$f" ] || return 0
   resolve=${FM_CLASSIFY_RESOLVE_VERB:-$FM_CLASSIFY_RESOLVE_VERB_DEFAULT}
   held=${FM_CLASSIFY_CAPTAIN_HELD_VERB:-$FM_CLASSIFY_CAPTAIN_HELD_VERB_DEFAULT}
+  pause=${FM_CLASSIFY_PAUSED_VERB:-$FM_CLASSIFY_PAUSED_VERB_DEFAULT}
   while IFS= read -r line || [ -n "$line" ]; do
-    open=$(_fm_decision_fold_line "$open" "$line" "$resolve" "$held")
+    open=$(_fm_decision_fold_line "$open" "$line" "$resolve" "$held" "$pause")
   done < "$f"
   printf '%s' "$open"
 }
@@ -437,7 +443,7 @@ _fm_open_decisions_cursor_path() {  # <status-file>
   printf '%s/.%s.open-decisions-cursor' "$dir" "${base%.status}"
 }
 
-FM_OPEN_DECISIONS_FOLD_VERSION=4
+FM_OPEN_DECISIONS_FOLD_VERSION=5
 
 # Portable device:inode identity for the rotation/recreation check below.
 _fm_open_decisions_file_ident() {  # <file> -> "dev:inode", empty on I/O failure
@@ -480,7 +486,7 @@ _fm_status_read_span() {  # <status-file> <start-offset> <byte-length>
 
 status_open_decisions_incremental() {  # <status-file> [<captured-end-offset>]
   local f=$1 captured_end=${2:-} cf offset ident open='' trusted_open='' cursor_data first rest offset_line ident_line
-  local version='' size actual_size cur_ident resolve held chunk_file chunk_size line cursor_dirty=0
+  local version='' size actual_size cur_ident resolve held pause chunk_file chunk_size line cursor_dirty=0
   local target_cursor
   [ -f "$f" ] && [ -r "$f" ] && [ ! -L "$f" ] || return 0
   cf=$(_fm_open_decisions_cursor_path "$f")
@@ -571,8 +577,9 @@ status_open_decisions_incremental() {  # <status-file> [<captured-end-offset>]
       && printf '%s\t%s\n' "$f" "$chunk_size" >> "$FM_OPEN_DECISIONS_READ_PROBE"
     resolve=${FM_CLASSIFY_RESOLVE_VERB:-$FM_CLASSIFY_RESOLVE_VERB_DEFAULT}
     held=${FM_CLASSIFY_CAPTAIN_HELD_VERB:-$FM_CLASSIFY_CAPTAIN_HELD_VERB_DEFAULT}
+    pause=${FM_CLASSIFY_PAUSED_VERB:-$FM_CLASSIFY_PAUSED_VERB_DEFAULT}
     while IFS= read -r line || [ -n "$line" ]; do
-      open=$(_fm_decision_fold_line "$open" "$line" "$resolve" "$held")
+      open=$(_fm_decision_fold_line "$open" "$line" "$resolve" "$held" "$pause")
     done < "$chunk_file"
     rm -f "$chunk_file"
     offset=$size

--- a/tests/fm-classify-decision-key.test.sh
+++ b/tests/fm-classify-decision-key.test.sh
@@ -259,6 +259,30 @@ test_incremental_agrees_with_full_fold_across_appends() {
   pass "the incremental fold matches the full fold across appends in both key positions"
 }
 
+test_paused_key_mention_never_closes_a_decision() {
+  local dir f expected full incr
+  dir=$(case_dir paused-mention)
+  f="$dir/t.status"
+  printf 'needs-decision [key=review-gate-m3-recv-core]: choose the review path\n' > "$f"
+  printf 'paused: awaiting captain decision on [key=review-gate-m3-recv-core] before continuing\n' >> "$f"
+  expected=$(printf 'review-gate-m3-recv-core\tneeds-decision\tchoose the review path\n')
+  assert_fold "$f" "$expected" "a pause that mentions the key in prose"
+
+  # The closing-verb names are overridable for compatibility. Even if one
+  # consumer inherits a conflicting override, the configured pause verb must
+  # remain a no-op so its full fold cannot disagree with a normal drain fold.
+  full=$(FM_CLASSIFY_RESOLVE_VERB=paused status_open_decisions "$f")
+  [ "$full" = "$expected" ] \
+    || fail "a resolve-verb collision let the pause close the full fold: '$full'"
+  incr=$(FM_CLASSIFY_CAPTAIN_HELD_VERB=paused status_open_decisions_incremental "$f")
+  [ "$incr" = "$expected" ] \
+    || fail "a held-verb collision let the pause close the incremental fold: '$incr'"
+
+  printf 'resolved [key=review-gate-m3-recv-core]: answered: use the core path\n' >> "$f"
+  assert_fold "$f" "" "an explicit resolution after a pause"
+  pass "a paused key mention never closes a decision; an explicit resolution does"
+}
+
 test_stated_key_is_honored_in_both_positions
 test_bare_keyless_line_still_folds_to_default
 test_resolution_closes_across_positions
@@ -272,3 +296,4 @@ test_corr_only_tag_opens_as_default_like_a_bare_line
 test_key_only_before_colon_still_opens_no_regression
 test_blocked_and_resolved_are_tag_order_independent
 test_incremental_agrees_with_full_fold_across_appends
+test_paused_key_mention_never_closes_a_decision

--- a/tests/fm-classify-decision-key.test.sh
+++ b/tests/fm-classify-decision-key.test.sh
@@ -268,6 +268,9 @@ test_paused_key_mention_never_closes_a_decision() {
   expected=$(printf 'review-gate-m3-recv-core\tneeds-decision\tchoose the review path\n')
   assert_fold "$f" "$expected" "a pause that mentions the key in prose"
 
+  printf 'paused [key=review-gate-m3-recv-core]: awaiting captain decision\n' >> "$f"
+  assert_fold "$f" "$expected" "a pause that carries the open key"
+
   # The closing-verb names are overridable for compatibility. Even if one
   # consumer inherits a conflicting override, the configured pause verb must
   # remain a no-op so its full fold cannot disagree with a normal drain fold.
@@ -280,7 +283,7 @@ test_paused_key_mention_never_closes_a_decision() {
 
   printf 'resolved [key=review-gate-m3-recv-core]: answered: use the core path\n' >> "$f"
   assert_fold "$f" "" "an explicit resolution after a pause"
-  pass "a paused key mention never closes a decision; an explicit resolution does"
+  pass "paused key mentions and carried keys stay open until explicit resolution"
 }
 
 test_stated_key_is_honored_in_both_positions

--- a/tests/fm-send-resolve-key.test.sh
+++ b/tests/fm-send-resolve-key.test.sh
@@ -197,18 +197,18 @@ test_colon_first_key_position_is_answerable() {
   pass "fm-send --resolve-key: a colon-first stated key is open under that key and answerable"
 }
 
-# A firstmate wait marker may repeat an open key in its prose while the worker
+# A firstmate wait marker may carry an open key while the worker
 # is idle. A consumer environment whose configurable resolution verb collides
 # with "paused" must not make fm-send's full fold reject a key that the normal
 # wake-drain fold still lists as open.
-test_paused_key_mention_remains_answerable() {
+test_paused_carried_key_remains_answerable() {
   local dir fb log home rc out
-  dir="$TMP_ROOT/paused-mention"; mkdir -p "$dir"
+  dir="$TMP_ROOT/paused-carried-key"; mkdir -p "$dir"
   fb=$(make_stubs "$dir"); log="$dir/send.log"
-  home=$(setup_home paused-mention)
+  home=$(setup_home paused-carried-key)
   fm_write_meta "$home/state/t10.meta" "window=sess:fm-t10" "kind=ship"
   printf 'needs-decision [key=dwr395-draft-grid]: choose the draft grid\n' > "$home/state/t10.status"
-  printf 'paused: awaiting captain decision on [key=dwr395-draft-grid] before continuing\n' \
+  printf 'paused [key=dwr395-draft-grid]: awaiting captain decision before continuing\n' \
     >> "$home/state/t10.status"
 
   out=$(drain_out "$home")
@@ -228,7 +228,7 @@ test_paused_key_mention_remains_answerable() {
   if printf '%s' "$out" | grep -F 'OPEN DECISIONS' >/dev/null; then
     fail "the explicit answer did not close the paused decision: $out"
   fi
-  pass "fm-send --resolve-key: a paused key mention remains answerable across fold environments"
+  pass "fm-send --resolve-key: a paused carried key remains answerable across fold environments"
 }
 
 test_answer_starts_work_never_orphans() {
@@ -533,7 +533,7 @@ test_flag_misuse_refuses() {
 test_answer_send_closes_open_decision
 test_answer_close_is_self_announced
 test_colon_first_key_position_is_answerable
-test_paused_key_mention_remains_answerable
+test_paused_carried_key_remains_answerable
 test_answer_starts_work_never_orphans
 test_routine_steer_never_closes
 test_not_open_key_refuses_before_send

--- a/tests/fm-send-resolve-key.test.sh
+++ b/tests/fm-send-resolve-key.test.sh
@@ -197,6 +197,40 @@ test_colon_first_key_position_is_answerable() {
   pass "fm-send --resolve-key: a colon-first stated key is open under that key and answerable"
 }
 
+# A firstmate wait marker may repeat an open key in its prose while the worker
+# is idle. A consumer environment whose configurable resolution verb collides
+# with "paused" must not make fm-send's full fold reject a key that the normal
+# wake-drain fold still lists as open.
+test_paused_key_mention_remains_answerable() {
+  local dir fb log home rc out
+  dir="$TMP_ROOT/paused-mention"; mkdir -p "$dir"
+  fb=$(make_stubs "$dir"); log="$dir/send.log"
+  home=$(setup_home paused-mention)
+  fm_write_meta "$home/state/t10.meta" "window=sess:fm-t10" "kind=ship"
+  printf 'needs-decision [key=dwr395-draft-grid]: choose the draft grid\n' > "$home/state/t10.status"
+  printf 'paused: awaiting captain decision on [key=dwr395-draft-grid] before continuing\n' \
+    >> "$home/state/t10.status"
+
+  out=$(drain_out "$home")
+  printf '%s' "$out" | grep -F '[key=dwr395-draft-grid]' >/dev/null \
+    || fail "precondition: wake drain should keep the paused decision open: $out"
+
+  FM_CLASSIFY_RESOLVE_VERB=paused run_send "$fb" "$home" "$log" t10 \
+    --resolve-key dwr395-draft-grid "use the compact grid"
+  rc=$?
+  expect_code 0 "$rc" \
+    "a pause marker must not make fm-send refuse a key still listed by wake drain"
+  grep -F 'resolved [key=dwr395-draft-grid]: answered: use the compact grid' \
+    "$home/state/t10.status" >/dev/null \
+    || fail "fm-send did not append the explicit close after the paused marker"
+
+  out=$(drain_out "$home")
+  if printf '%s' "$out" | grep -F 'OPEN DECISIONS' >/dev/null; then
+    fail "the explicit answer did not close the paused decision: $out"
+  fi
+  pass "fm-send --resolve-key: a paused key mention remains answerable across fold environments"
+}
+
 test_answer_starts_work_never_orphans() {
   local dir fb log home rc out
   dir="$TMP_ROOT/starts-work"; mkdir -p "$dir"
@@ -499,6 +533,7 @@ test_flag_misuse_refuses() {
 test_answer_send_closes_open_decision
 test_answer_close_is_self_announced
 test_colon_first_key_position_is_answerable
+test_paused_key_mention_remains_answerable
 test_answer_starts_work_never_orphans
 test_routine_steer_never_closes
 test_not_open_key_refuses_before_send


### PR DESCRIPTION
## Intent

Fix firstmate's open-decision ledger divergence where bin/fm-send.sh --resolve-key can refuse a valid key that bin/fm-wake-drain.sh still lists as open. Reproduce needs-decision followed by a paused wait marker that mentions the same key, with and without a later explicit resolution; identify the divergent fold condition and make both consumers agree. A paused line that merely mentions or carries the key must never close the decision; only an explicit resolved/answered record (or the existing verified captain-held transfer contract) may close it. Add behavioral regression tests for the fold sequence and the end-to-end fm-send refusal path, keep bin scripts ShellCheck-clean, colocate tests with existing patterns, and deliver one PR by pushing the feature branch to https://github.com/pm-justinm/firstmate with the PR targeting kunchenguid/firstmate.

## What Changed

- Treat paused status records as activity markers that cannot close an open decision, even when configurable close verbs collide with `paused`.
- Apply the rule consistently to full and incremental decision folds and bump the persisted fold version.
- Add regression coverage for paused key mentions, explicit resolution, and end-to-end `fm-send --resolve-key` handling.

## Risk Assessment

✅ Low: The shared full and incremental decision fold now explicitly treats the configured pause verb as a no-op, preserves explicit resolution and verified captain-held closure, invalidates stale incremental cursors, and includes behavioral coverage for both prose-mentioned and carried keys.

## Testing

The focused decision-fold and fm-send behavioral suites passed; manual CLI verification showed wake drain listing the decision after both forms of paused marker, fm-send accepting `--resolve-key` with exit code 0 despite the formerly divergent environment, the explicit resolved record being persisted, and wake drain then reporting no open decisions.

<details>
<summary>Evidence: End-to-end CLI transcript showing the paused decision remains open, fm-send accepts the answer, and explicit resolution closes it</summary>

Source: [End-to-end CLI transcript showing the paused decision remains open, fm-send accepts the answer, and explicit resolution closes it](https://github.com/pm-justinm/firstmate/blob/fdf2971ed9302ed7117115ed080e232f91c73338/.no-mistakes/evidence/fm/fm-send-resolve-key-fold/decision-fold-cli-transcript.txt)

```text
=== Before answer: wake drain still lists the key ===
OPEN DECISIONS (still open, folded from the durable status logs - not just the latest line):
task [key=grid] needs-decision: choose compact or spacious
OPEN DECISIONS: close one by answering it: bin/fm-send.sh <task> --resolve-key <key> '<answer>'
=== Captain answers with fm-send --resolve-key ===
WARNING: watcher still down (same stale episode; last beat: never, grace 300s) - full banner already printed this episode.
fm-send exit code: 0
=== Persisted decision ledger ===
needs-decision [key=grid]: choose compact or spacious
paused: awaiting captain response mentioning [key=grid]
paused [key=grid]: still awaiting captain response
resolved [key=grid]: answered: use compact
=== After explicit answer: wake drain output ===
(no open decisions)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"7ff80c250fbb70e342e7a037ae90b70d31d64530","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `tests/fm-classify-decision-key.test.sh:267` - The regression uses `paused: ... [key=...]`, where the key is buried in prose and therefore parsed as `default`. Consequently, even the pre-fix fold cannot close the named decision when `FM_CLASSIFY_RESOLVE_VERB=paused`, so both the fold and end-to-end tests pass before the fix and do not reproduce the reported refusal. This contradicts the required behavioral regression for a paused marker that “mentions or carries the same key.” Add the carried-key form (`paused [key=...]: ...` or the note-head equivalent) to the fold and fm-send paths, asserting it remains open until an explicit resolution.

🔧 Fix: Exercise carried-key pauses in decision regressions
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-classify-decision-key.test.sh`
- `bash tests/fm-send-resolve-key.test.sh`
- <code>`decision-fold-cli-evidence.sh &#34;$PWD&#34; &lt;evidence-dir&gt;` — exercised the real wake-drain and fm-send CLI flow with both paused prose mention and keyed pause, a conflicting `FM_CLASSIFY_RESOLVE_VERB=paused`, and later explicit resolution</code>
- <code>`git status --short` — confirmed testing left no transient worktree changes</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
