### PR TITLE
fix: preserve launched worktree metadata for relative spawns

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -420,9 +420,10 @@ $HERDR_SECTION
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
 
-**Verify isolation before anything else.** Run \`pwd -P\` and \`git rev-parse --show-toplevel\`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
-The path check is authoritative: \`git rev-parse --git-dir\` and \`git rev-parse --git-common-dir\` can help inspect the repo, but they do not prove you are outside the primary checkout.
-If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
+**Verify isolation before anything else.** Run \`pwd -P\` and \`git rev-parse --show-toplevel\`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree.
+Compare the physically resolved \`git rev-parse --show-toplevel\` result with the primary clone path: only an equal path means you were launched in the primary checkout.
+A linked worktree normally has \`git rev-parse --git-dir\` under the primary clone's \`.git/worktrees/\`; that location is not evidence that your working tree is the primary checkout.
+If the top-level path equals the primary clone path or is not the disposable worktree you were launched in, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
 
 1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -265,6 +265,15 @@ exit 0
 fi
 
 REPO=${POS[1]}
+case "$REPO" in
+  /*) PRIMARY_CLONE=$REPO ;;
+  projects/*) PRIMARY_CLONE="$FM_HOME/$REPO" ;;
+  *) PRIMARY_CLONE="$FM_HOME/projects/$REPO" ;;
+esac
+if [ -d "$PRIMARY_CLONE" ]; then
+  PRIMARY_CLONE=$(cd "$PRIMARY_CLONE" && pwd -P)
+fi
+PRIMARY_CLONE_QUOTED=$(shell_quote "$PRIMARY_CLONE")
 
 if [ "$HERDR_LAB" -eq 1 ]; then
 HERDR_LAB_HELPER=$(shell_quote "$FM_ROOT/bin/fm-herdr-lab.sh")
@@ -421,7 +430,7 @@ $HERDR_SECTION
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
 
 **Verify isolation before anything else.** Run \`pwd -P\` and \`git rev-parse --show-toplevel\`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree.
-Compare the physically resolved \`git rev-parse --show-toplevel\` result with the primary clone path: only an equal path means you were launched in the primary checkout.
+Set \`primary_clone=$PRIMARY_CLONE_QUOTED\`, physically resolve both paths with \`cd -- "\$primary_clone" && pwd -P\` and \`cd -- "\$(git rev-parse --show-toplevel)" && pwd -P\`, and compare their output; equal paths mean you were launched in the primary checkout.
 A linked worktree normally has \`git rev-parse --git-dir\` under the primary clone's \`.git/worktrees/\`; that location is not evidence that your working tree is the primary checkout.
 If the top-level path equals the primary clone path or is not the disposable worktree you were launched in, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2273,7 +2273,7 @@ if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ];
   pinned=
   pin_seen=0
   for _ in $(seq 1 10); do
-    if fm_backend_capture "$BACKEND" "$T" 20 "$W" 2>/dev/null | grep -Fxq "$pin_ack"; then
+    if fm_backend_capture "$BACKEND" "$WT_TARGET" 20 "$W" 2>/dev/null | grep -Fxq "$pin_ack"; then
       pin_seen=1
     fi
     pinned=$(spawn_current_path "$WT_TARGET" || true)

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2264,11 +2264,22 @@ if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
   freshen_spawn_worktree_base "$WT" || exit 1
 fi
 
-# Freeze the endpoint-resolved path immediately after worktree acquisition and
-# validation. The caller's project argument can be the relative
-# projects/<repo> form, but metadata and launch composition must carry the live
-# pane path selected by treehouse, never reconstruct it from that input later.
-TASK_WORKTREE=$WT
+if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
+  TASK_WORKTREE=$WT
+  spawn_send_text_line "$WT_TARGET" "cd -- $(shell_quote "$TASK_WORKTREE")"
+  pinned=
+  for _ in $(seq 1 10); do
+    pinned=$(spawn_current_path "$WT_TARGET" || true)
+    [ -z "$pinned" ] || [ "$(real_path_or_raw "$pinned")" != "$(real_path_or_raw "$TASK_WORKTREE")" ] || break
+    sleep 0.5
+  done
+  if [ -z "$pinned" ] || [ "$(real_path_or_raw "$pinned")" != "$(real_path_or_raw "$TASK_WORKTREE")" ]; then
+    echo "error: task $ID's endpoint did not stay in acquired worktree '$TASK_WORKTREE' (resolved '${pinned:-unknown}'); refusing to publish metadata or launch in the primary checkout" >&2
+    exit 1
+  fi
+else
+  TASK_WORKTREE=$WT
+fi
 
 # Per-task temp root: /tmp/fm-<id>/ with Go's build temp nested at gotmp/. Go won't
 # create GOTMPDIR, so mkdir before it is used; fm-teardown removes the whole root.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2264,6 +2264,12 @@ if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
   freshen_spawn_worktree_base "$WT" || exit 1
 fi
 
+# Freeze the endpoint-resolved path immediately after worktree acquisition and
+# validation. The caller's project argument can be the relative
+# projects/<repo> form, but metadata and launch composition must carry the live
+# pane path selected by treehouse, never reconstruct it from that input later.
+TASK_WORKTREE=$WT
+
 # Per-task temp root: /tmp/fm-<id>/ with Go's build temp nested at gotmp/. Go won't
 # create GOTMPDIR, so mkdir before it is used; fm-teardown removes the whole root.
 # Nested (not a bare /tmp/fm-<id>/gotmp) so other per-task temp can live alongside
@@ -2641,7 +2647,7 @@ preserve_relaunch_meta() {
 {
   echo "window=$META_WINDOW"
   echo "endpoint_task_id=$ID"
-  echo "worktree=$WT"
+  echo "worktree=$TASK_WORKTREE"
   echo "project=$PROJ_ABS"
   echo "harness=$HARNESS"
   echo "kind=$KIND"
@@ -2711,7 +2717,7 @@ sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
 sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts")
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
-sq_worktree=$(shell_quote "$WT")
+sq_worktree=$(shell_quote "$TASK_WORKTREE")
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
@@ -2849,4 +2855,4 @@ fi
 
 SPAWN_DELIVERY=
 [ -z "$MODE" ] || SPAWN_DELIVERY=" mode=$MODE yolo=$YOLO"
-echo "spawned $ID harness=$HARNESS kind=$KIND$SPAWN_DELIVERY window=$META_WINDOW worktree=$WT"
+echo "spawned $ID harness=$HARNESS kind=$KIND$SPAWN_DELIVERY window=$META_WINDOW worktree=$TASK_WORKTREE"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2266,14 +2266,23 @@ fi
 
 if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   TASK_WORKTREE=$WT
-  spawn_send_text_line "$WT_TARGET" "cd -- $(shell_quote "$TASK_WORKTREE")"
+  pin_ack="fm-pin-$ID-${BASHPID:-$$}-$RANDOM"
+  spawn_send_text_line "$WT_TARGET" "cd -- $(shell_quote "$TASK_WORKTREE") && printf '%s\n' $(shell_quote "$pin_ack")"
   pinned=
+  pin_seen=0
   for _ in $(seq 1 10); do
+    if fm_backend_capture "$BACKEND" "$T" 20 "$W" 2>/dev/null | grep -Fxq "$pin_ack"; then
+      pin_seen=1
+    fi
     pinned=$(spawn_current_path "$WT_TARGET" || true)
-    [ -z "$pinned" ] || [ "$(real_path_or_raw "$pinned")" != "$(real_path_or_raw "$TASK_WORKTREE")" ] || break
+    if [ "$pin_seen" -eq 1 ] && [ -n "$pinned" ] \
+      && [ "$(real_path_or_raw "$pinned")" = "$(real_path_or_raw "$TASK_WORKTREE")" ]; then
+      break
+    fi
     sleep 0.5
   done
-  if [ -z "$pinned" ] || [ "$(real_path_or_raw "$pinned")" != "$(real_path_or_raw "$TASK_WORKTREE")" ]; then
+  if [ "$pin_seen" -ne 1 ] || [ -z "$pinned" ] \
+    || [ "$(real_path_or_raw "$pinned")" != "$(real_path_or_raw "$TASK_WORKTREE")" ]; then
     echo "error: task $ID's endpoint did not stay in acquired worktree '$TASK_WORKTREE' (resolved '${pinned:-unknown}'); refusing to publish metadata or launch in the primary checkout" >&2
     exit 1
   fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -134,6 +134,9 @@
 #   default-branch commit when safe; skipped syncs warn and launch unchanged.
 #   Ship/scout spawns refuse to launch unless the resolved task path is a real
 #   git worktree root distinct from the primary project checkout.
+#   Treehouse-backed spawns then pin the endpoint shell in that acquired path
+#   before publishing metadata; worktree= and the launch placeholder both use
+#   that verified endpoint cwd, never the primary project path.
 #   Before a fresh ship or scout worker starts, its clean task worktree fetches
 #   origin, resolves the current remote default branch, and resets to its tip.
 #   An unreachable origin, unresolved default branch, or non-clean worktree

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2266,8 +2266,10 @@ fi
 
 if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   TASK_WORKTREE=$WT
-  pin_ack="fm-pin-$ID-${BASHPID:-$$}-$RANDOM"
-  spawn_send_text_line "$WT_TARGET" "cd -- $(shell_quote "$TASK_WORKTREE") && printf '%s\n' $(shell_quote "$pin_ack")"
+  pin_ack_left="fm-pin-$ID-"
+  pin_ack_right="${BASHPID:-$$}-$RANDOM"
+  pin_ack="$pin_ack_left$pin_ack_right"
+  spawn_send_text_line "$WT_TARGET" "cd -- $(shell_quote "$TASK_WORKTREE") && printf '%s%s\n' $(shell_quote "$pin_ack_left") $(shell_quote "$pin_ack_right")"
   pinned=
   pin_seen=0
   for _ in $(seq 1 10); do

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -157,6 +157,7 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
+For Treehouse-backed spawns, it pins the endpoint shell in that acquired worktree before publishing metadata, and `state/<id>.meta` records that launched working directory as `worktree=` rather than the primary project path.
 `fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
 Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
 

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -775,11 +775,14 @@ make_spawn_fakebin() {  # <dir> <fake-worktree-path> -> echoes fakebin dir
   cat > "$fb/tmux" <<SH
 #!/usr/bin/env bash
 set -u
+. "$FM_FAKE_SPAWN_ACK_LIB"
 { printf 'tmux'; for a in "\$@"; do printf '\\x1f%s' "\$a"; done; printf '\\n'; } >> "\${FM_TMUX_LOG:?}"
 case "\${1:-}" in
   display-message)
     for a in "\$@"; do case "\$a" in *pane_current_path*) printf '%s\\n' "$wt"; exit 0 ;; esac; done
     printf 'firstmate\\n'; exit 0 ;;
+  capture-pane) fm_fake_spawn_ack_capture; exit 0 ;;
+  send-keys) fm_fake_spawn_ack_send "\$@"; exit 0 ;;
   list-windows) exit 0 ;;
 esac
 exit 0

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -840,6 +840,7 @@ make_spawn_symlink_fakebin() {  # <dir> <initial-project-path> <worktree-path> -
   cat > "$fb/tmux" <<SH
 #!/usr/bin/env bash
 set -u
+. "$FM_FAKE_SPAWN_ACK_LIB"
 { printf 'tmux'; for a in "\$@"; do printf '\\x1f%s' "\$a"; done; printf '\\n'; } >> "\${FM_TMUX_LOG:?}"
 case "\${1:-}" in
   display-message)
@@ -853,6 +854,8 @@ case "\${1:-}" in
       exit 0
     ;; esac; done
     printf 'firstmate\\n'; exit 0 ;;
+  capture-pane) fm_fake_spawn_ack_capture; exit 0 ;;
+  send-keys) fm_fake_spawn_ack_send "\$@"; exit 0 ;;
   list-windows) exit 0 ;;
 esac
 exit 0

--- a/tests/fm-busy-adapter-wiring.test.sh
+++ b/tests/fm-busy-adapter-wiring.test.sh
@@ -24,13 +24,16 @@ make_spawn_fakebin() {
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
+. "${FM_FAKE_SPAWN_ACK_LIB:?FM_FAKE_SPAWN_ACK_LIB unset}"
 case "$*" in
   *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
 esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
+  capture-pane) fm_fake_spawn_ack_capture; exit 0 ;;
   list-windows) exit 0 ;;
-  has-session|new-session|new-window|kill-window|send-keys) exit 0 ;;
+  send-keys) fm_fake_spawn_ack_send "$@"; exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
 esac
 exit 0
 SH

--- a/tests/fm-gate-refuse.test.sh
+++ b/tests/fm-gate-refuse.test.sh
@@ -141,13 +141,16 @@ make_spawn_fakebin() {
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
+. "${FM_FAKE_SPAWN_ACK_LIB:?FM_FAKE_SPAWN_ACK_LIB unset}"
 case "$*" in
   *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
 esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
+  capture-pane) fm_fake_spawn_ack_capture; exit 0 ;;
   list-windows) exit 0 ;;
-  has-session|new-session|new-window|send-keys|set-window-option) exit 0 ;;
+  send-keys) fm_fake_spawn_ack_send "$@"; exit 0 ;;
+  has-session|new-session|new-window|set-window-option) exit 0 ;;
 esac
 exit 0
 SH

--- a/tests/fm-grok-harness.test.sh
+++ b/tests/fm-grok-harness.test.sh
@@ -15,13 +15,16 @@ make_spawn_fakebin() {
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
+. "${FM_FAKE_SPAWN_ACK_LIB:?FM_FAKE_SPAWN_ACK_LIB unset}"
 case "$*" in
   *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
 esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
+  capture-pane) fm_fake_spawn_ack_capture; exit 0 ;;
   list-windows) exit 0 ;;
-  has-session|new-session|new-window|send-keys|kill-window) exit 0 ;;
+  send-keys) fm_fake_spawn_ack_send "$@"; exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
 esac
 exit 0
 SH

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -27,6 +27,7 @@ make_spawn_fakebin() {
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
+. "${FM_FAKE_SPAWN_ACK_LIB:?FM_FAKE_SPAWN_ACK_LIB unset}"
 printf '%s\n' "$*" >> "$FM_FAKE_TMUX_CALL_LOG"
 state=$(cat "$FM_FAKE_KIMI_STATE" 2>/dev/null || true)
 fake_screen() {
@@ -61,6 +62,7 @@ case "${1:-}" in
   list-windows) exit 0 ;;
   has-session|new-session|new-window|kill-window) exit 0 ;;
   send-keys)
+    fm_fake_spawn_ack_send "$@"
     prev=
     literal=
     for arg in "$@"; do
@@ -106,6 +108,7 @@ case "${1:-}" in
     exit 0
     ;;
   capture-pane)
+    fm_fake_spawn_ack_capture
     start= end= prev=
     for arg in "$@"; do
       case "$prev" in

--- a/tests/fm-muse-harness.test.sh
+++ b/tests/fm-muse-harness.test.sh
@@ -65,6 +65,7 @@ make_spawn_fakebin() {
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
+. "${FM_FAKE_SPAWN_ACK_LIB:?FM_FAKE_SPAWN_ACK_LIB unset}"
 case "$*" in
   *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
 esac
@@ -75,9 +76,11 @@ case "${1:-}" in
     exit 0
     ;;
   display-message) printf 'firstmate\n'; exit 0 ;;
+  capture-pane) fm_fake_spawn_ack_capture; exit 0 ;;
   list-windows) exit 0 ;;
   has-session|new-session|new-window|kill-window) exit 0 ;;
   send-keys)
+    fm_fake_spawn_ack_send "$@"
     prev=
     for arg in "$@"; do
       if [ "$prev" = -l ]; then

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -637,14 +637,17 @@ make_launch_capturing_tmux() {
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
+. "${FM_FAKE_SPAWN_ACK_LIB:?FM_FAKE_SPAWN_ACK_LIB unset}"
 case "$*" in
   *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
 esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
+  capture-pane) fm_fake_spawn_ack_capture; exit 0 ;;
   list-windows) exit 0 ;;
   has-session|new-session|new-window|kill-window) exit 0 ;;
   send-keys)
+    fm_fake_spawn_ack_send "$@"
     if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
       prev=
       for a in "$@"; do

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -18,7 +18,6 @@ make_spawn_pi_probe() {
   cat > "$fakebin/$tool" <<'SH'
 #!/usr/bin/env bash
 set -u
-. "${FM_FAKE_SPAWN_ACK_LIB:?FM_FAKE_SPAWN_ACK_LIB unset}"
 if [ "${1:-}" = --help ]; then
   if [ "${FM_FAKE_PI_VERSION:-0.84.0}" = 0.82.0 ]; then
     printf '%s\n' 'Pi 0.82.0' 'Options: --help'
@@ -37,6 +36,7 @@ make_spawn_fakebin() {
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
+. "${FM_FAKE_SPAWN_ACK_LIB:?FM_FAKE_SPAWN_ACK_LIB unset}"
 case "$*" in
   *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
 esac

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -18,6 +18,7 @@ make_spawn_pi_probe() {
   cat > "$fakebin/$tool" <<'SH'
 #!/usr/bin/env bash
 set -u
+. "${FM_FAKE_SPAWN_ACK_LIB:?FM_FAKE_SPAWN_ACK_LIB unset}"
 if [ "${1:-}" = --help ]; then
   if [ "${FM_FAKE_PI_VERSION:-0.84.0}" = 0.82.0 ]; then
     printf '%s\n' 'Pi 0.82.0' 'Options: --help'
@@ -41,9 +42,11 @@ case "$*" in
 esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
+  capture-pane) fm_fake_spawn_ack_capture; exit 0 ;;
   list-windows) exit 0 ;;
   has-session|new-session|new-window|kill-window) exit 0 ;;
   send-keys)
+    fm_fake_spawn_ack_send "$@"
     if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
       prev=
       for a in "$@"; do

--- a/tests/fm-spawn-fake-ack.sh
+++ b/tests/fm-spawn-fake-ack.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+fm_fake_spawn_ack_send() {
+  local arg left right
+  for arg in "$@"; do
+    case "$arg" in
+      *"printf '%s%s\n'"*)
+        left=$(printf '%s\n' "$arg" | sed -n "s/.*printf '%s%s\\\\n' '\([^']*\)' '\([^']*\)'.*/\1/p")
+        right=$(printf '%s\n' "$arg" | sed -n "s/.*printf '%s%s\\\\n' '\([^']*\)' '\([^']*\)'.*/\2/p")
+        [ -n "$left" ] && [ -n "$right" ] || return 0
+        printf '%s\n%s\n' "$left" "$right" > "${FM_STATE_OVERRIDE:?FM_STATE_OVERRIDE unset}/.fake-spawn-pin-pending"
+        ;;
+    esac
+  done
+}
+
+fm_fake_spawn_ack_capture() {
+  local pending="${FM_STATE_OVERRIDE:?FM_STATE_OVERRIDE unset}/.fake-spawn-pin-pending" left right
+  [ -f "$pending" ] || return 0
+  {
+    IFS= read -r left
+    IFS= read -r right
+  } < "$pending"
+  printf '%s%s\n' "$left" "$right"
+  rm -f "$pending"
+}

--- a/tests/fm-spawn-fake-ack.sh
+++ b/tests/fm-spawn-fake-ack.sh
@@ -1,21 +1,24 @@
 #!/usr/bin/env bash
 
 fm_fake_spawn_ack_send() {
-  local arg left right
+  local arg left right state_dir
+  state_dir=${FM_STATE_OVERRIDE:-${FM_HOME:?FM_HOME unset}/state}
   for arg in "$@"; do
     case "$arg" in
       *"printf '%s%s\n'"*)
         left=$(printf '%s\n' "$arg" | sed -n "s/.*printf '%s%s\\\\n' '\([^']*\)' '\([^']*\)'.*/\1/p")
         right=$(printf '%s\n' "$arg" | sed -n "s/.*printf '%s%s\\\\n' '\([^']*\)' '\([^']*\)'.*/\2/p")
         [ -n "$left" ] && [ -n "$right" ] || return 0
-        printf '%s\n%s\n' "$left" "$right" > "${FM_STATE_OVERRIDE:?FM_STATE_OVERRIDE unset}/.fake-spawn-pin-pending"
+        printf '%s\n%s\n' "$left" "$right" > "$state_dir/.fake-spawn-pin-pending"
         ;;
     esac
   done
 }
 
 fm_fake_spawn_ack_capture() {
-  local pending="${FM_STATE_OVERRIDE:?FM_STATE_OVERRIDE unset}/.fake-spawn-pin-pending" left right
+  local state_dir pending left right
+  state_dir=${FM_STATE_OVERRIDE:-${FM_HOME:?FM_HOME unset}/state}
+  pending="$state_dir/.fake-spawn-pin-pending"
   [ -f "$pending" ] || return 0
   {
     IFS= read -r left

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -20,12 +20,15 @@ make_spawn_fakebin() {
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
+. "${FM_FAKE_SPAWN_ACK_LIB:?FM_FAKE_SPAWN_ACK_LIB unset}"
 case "$*" in
   *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:?FM_FAKE_PANE_PATH unset}"; exit 0 ;;
 esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
-  list-windows|has-session|new-session|new-window|kill-window|send-keys) exit 0 ;;
+  capture-pane) fm_fake_spawn_ack_capture; exit 0 ;;
+  send-keys) fm_fake_spawn_ack_send "$@"; exit 0 ;;
+  list-windows|has-session|new-session|new-window|kill-window) exit 0 ;;
 esac
 exit 0
 SH

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -67,7 +67,7 @@ make_settle_case() {
   local name=$1 id=$2 stale_reads=$3 case_dir home proj wt stale fakebin countfile
   case_dir="$TMP_ROOT/$name"
   home="$case_dir/home"
-  proj="$case_dir/project"
+  proj="$home/projects/project"
   wt="$case_dir/wt"
   stale="$case_dir/stale-other-checkout"
   countfile="$case_dir/pane-call-count"
@@ -89,7 +89,7 @@ EOF
 }
 
 run_settle_spawn() {
-  local id=$1
+  local id=$1 project=${2:-$PROJ_DIR}
   FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
     FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
     FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
@@ -97,7 +97,7 @@ run_settle_spawn() {
     FM_FAKE_PANE_PATH="$WT_DIR" FM_FAKE_PANE_STALE="$STALE_DIR" \
     FM_FAKE_PANE_STALE_READS="$STALE_READS" FM_FAKE_PANE_COUNTFILE="$COUNTFILE" \
     PATH="$FAKEBIN_DIR:$PATH" \
-    "$SPAWN" "$id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1
+    "$SPAWN" "$id" "$project" --mode no-mistakes --yolo off 2>&1
 }
 
 # A single stale first read (the exact incident) must not be accepted: the
@@ -141,7 +141,33 @@ test_already_settled_pane_costs_one_confirm_sleep() {
   pass "an already-settled pane confirms via the existing inter-poll sleep, not an extra full cycle"
 }
 
+# The caller-facing relative form resolves `projects/<repo>` through the active
+# home's projects directory. Its metadata must still carry the pane cwd that
+# treehouse selected, not the primary project path used to create the pane.
+test_relative_project_records_launched_pane_cwd() {
+  local rec id out status meta_project meta_worktree
+  id=settle-relative-project-z3
+  rec=$(make_settle_case settle-relative-project "$id" 0)
+  read_settle_record "$rec"
+
+  out=$(run_settle_spawn "$id" projects/project)
+  status=$?
+  expect_code 0 "$status" "relative-project spawn should succeed"$'\n'"$out"
+  meta_worktree=$(sed -n 's/^worktree=//p' "$HOME_DIR/state/$id.meta")
+  meta_project=$(sed -n 's/^project=//p' "$HOME_DIR/state/$id.meta")
+  [ "$meta_worktree" = "$WT_DIR" ] \
+    || fail "relative-project meta worktree '$meta_worktree' does not equal launched pane cwd '$WT_DIR'"
+  [ "$(cd "$meta_project" && pwd -P)" = "$(cd "$PROJ_DIR" && pwd -P)" ] \
+    || fail "relative-project meta project '$meta_project' does not equal primary project '$PROJ_DIR'"
+  [ "$meta_worktree" != "$meta_project" ] \
+    || fail "relative-project meta collapsed worktree and project to '$meta_worktree'"
+  assert_contains "$out" "worktree=$WT_DIR" \
+    "relative-project success output did not report the launched pane cwd"
+  pass "a relative projects/<repo> spawn records the launched pane cwd as worktree"
+}
+
 test_single_stale_first_read_is_not_accepted
 test_already_settled_pane_costs_one_confirm_sleep
+test_relative_project_records_launched_pane_cwd
 
 echo "# all fm-spawn-worktree-settle tests passed"

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -30,6 +30,7 @@ make_settle_fakebin() {
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
+. "${FM_FAKE_SPAWN_ACK_LIB:?FM_FAKE_SPAWN_ACK_LIB unset}"
 case "$*" in
   *"#{pane_current_path}"*)
     countfile="${FM_FAKE_PANE_COUNTFILE:?FM_FAKE_PANE_COUNTFILE unset}"
@@ -52,10 +53,11 @@ esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   capture-pane)
-    if [ -f "${FM_FAKE_PIN_PENDING_FILE:-}" ]; then
-      cat "${FM_FAKE_PIN_PENDING_FILE}"
+    if [ -f "${FM_STATE_OVERRIDE:-}/.fake-spawn-pin-pending" ]; then
+      ack=$(fm_fake_spawn_ack_capture)
+      printf '%s\n' "$ack"
+      printf '%s\n' "$ack" > "${FM_FAKE_PIN_OUTPUT_FILE:?FM_FAKE_PIN_OUTPUT_FILE unset}"
       touch "${FM_FAKE_PANE_PINNED_FILE:?FM_FAKE_PANE_PINNED_FILE unset}"
-      rm -f "${FM_FAKE_PIN_PENDING_FILE}"
     fi
     exit 0
     ;;
@@ -64,7 +66,8 @@ case "${1:-}" in
   send-keys)
     case "$*" in
       *"cd -- "*)
-        printf '%s\n' "$*" | sed -n "s/.*'\(fm-pin-[^']*\)'.*/\1/p" > "${FM_FAKE_PIN_PENDING_FILE:?FM_FAKE_PIN_PENDING_FILE unset}"
+        printf '%s\n' "$*" > "${FM_FAKE_PIN_COMMAND_FILE:?FM_FAKE_PIN_COMMAND_FILE unset}"
+        fm_fake_spawn_ack_send "$@"
         ;;
       *" -l "*) [ -f "${FM_FAKE_PANE_PINNED_FILE:-}" ] && launch_cwd=${FM_FAKE_PANE_PATH:-} || launch_cwd=${FM_FAKE_PRIMARY_PATH:-}; printf '%s\n' "$launch_cwd" > "${FM_FAKE_LAUNCH_CWD_FILE:?FM_FAKE_LAUNCH_CWD_FILE unset}" ;;
     esac
@@ -84,7 +87,7 @@ SH
 # entirely, distinct from both the project and the worktree - mirroring the
 # live incident where the stale read was another real firstmate home).
 make_settle_case() {
-  local name=$1 id=$2 stale_reads=$3 case_dir home proj wt stale fakebin countfile pinned pinpending launchcwd
+  local name=$1 id=$2 stale_reads=$3 case_dir home proj wt stale fakebin countfile pinned pincommand pinoutput launchcwd
   case_dir="$TMP_ROOT/$name"
   home="$case_dir/home"
   proj="$home/projects/project"
@@ -92,7 +95,8 @@ make_settle_case() {
   stale="$case_dir/stale-other-checkout"
   countfile="$case_dir/pane-call-count"
   pinned="$case_dir/pane-pinned"
-  pinpending="$case_dir/pin-pending"
+  pincommand="$case_dir/pin-command"
+  pinoutput="$case_dir/pin-output"
   launchcwd="$case_dir/launch-cwd"
   fakebin=$(make_settle_fakebin "$case_dir/fake")
   mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
@@ -102,11 +106,11 @@ make_settle_case() {
   mkdir -p "$home/data/$id"
   printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
   touch "$home/state/.last-watcher-beat"
-  printf '%s\n' "$case_dir|$home|$proj|$wt|$stale|$fakebin|$countfile|$stale_reads|$pinned|$pinpending|$launchcwd"
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$stale|$fakebin|$countfile|$stale_reads|$pinned|$pincommand|$pinoutput|$launchcwd"
 }
 
 read_settle_record() {
-  IFS='|' read -r _ HOME_DIR PROJ_DIR WT_DIR STALE_DIR FAKEBIN_DIR COUNTFILE STALE_READS PINNED_FILE PIN_PENDING_FILE LAUNCH_CWD_FILE <<EOF
+  IFS='|' read -r _ HOME_DIR PROJ_DIR WT_DIR STALE_DIR FAKEBIN_DIR COUNTFILE STALE_READS PINNED_FILE PIN_COMMAND_FILE PIN_OUTPUT_FILE LAUNCH_CWD_FILE <<EOF
 $1
 EOF
 }
@@ -119,7 +123,7 @@ run_settle_spawn() {
     FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
     FM_FAKE_PANE_PATH="$WT_DIR" FM_FAKE_PANE_STALE="$STALE_DIR" \
     FM_FAKE_PRIMARY_PATH="$PROJ_DIR" FM_FAKE_PANE_PINNED_FILE="$PINNED_FILE" \
-    FM_FAKE_PIN_PENDING_FILE="$PIN_PENDING_FILE" \
+    FM_FAKE_PIN_COMMAND_FILE="$PIN_COMMAND_FILE" FM_FAKE_PIN_OUTPUT_FILE="$PIN_OUTPUT_FILE" \
     FM_FAKE_LAUNCH_CWD_FILE="$LAUNCH_CWD_FILE" \
     FM_FAKE_PANE_STALE_READS="$STALE_READS" FM_FAKE_PANE_COUNTFILE="$COUNTFILE" \
     PATH="$FAKEBIN_DIR:$PATH" \
@@ -189,6 +193,10 @@ test_relative_project_records_launched_pane_cwd() {
     || fail "relative-project meta collapsed worktree and project to '$meta_worktree'"
   [ "$(cat "$LAUNCH_CWD_FILE")" = "$meta_worktree" ] \
     || fail "relative-project launched pane cwd does not equal meta worktree '$meta_worktree'"
+  [ -s "$PIN_OUTPUT_FILE" ] || fail "relative-project spawn did not observe the executed pin acknowledgement"
+  if grep -Fq "$(cat "$PIN_OUTPUT_FILE")" "$PIN_COMMAND_FILE"; then
+    fail "complete pin acknowledgement appeared in echoed command input"
+  fi
   assert_contains "$out" "worktree=$WT_DIR" \
     "relative-project success output did not report the launched pane cwd"
   pass "a relative projects/<repo> spawn records the launched pane cwd as worktree"

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -116,18 +116,20 @@ EOF
 }
 
 run_settle_spawn() {
-  local id=$1 project=${2:-$PROJ_DIR}
+  local id=$1 project=${2:-$PROJ_DIR} kind_flag=${3:-}
+  local -a delivery_args=(--mode no-mistakes --yolo off)
+  [ "$kind_flag" != --scout ] || delivery_args=(--scout)
   FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
-    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
-    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
-    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
-    FM_FAKE_PANE_PATH="$WT_DIR" FM_FAKE_PANE_STALE="$STALE_DIR" \
-    FM_FAKE_PRIMARY_PATH="$PROJ_DIR" FM_FAKE_PANE_PINNED_FILE="$PINNED_FILE" \
-    FM_FAKE_PIN_COMMAND_FILE="$PIN_COMMAND_FILE" FM_FAKE_PIN_OUTPUT_FILE="$PIN_OUTPUT_FILE" \
-    FM_FAKE_LAUNCH_CWD_FILE="$LAUNCH_CWD_FILE" \
-    FM_FAKE_PANE_STALE_READS="$STALE_READS" FM_FAKE_PANE_COUNTFILE="$COUNTFILE" \
-    PATH="$FAKEBIN_DIR:$PATH" \
-    "$SPAWN" "$id" "$project" --mode no-mistakes --yolo off 2>&1
+      FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+      FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+      FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
+      FM_FAKE_PANE_PATH="$WT_DIR" FM_FAKE_PANE_STALE="$STALE_DIR" \
+      FM_FAKE_PRIMARY_PATH="$PROJ_DIR" FM_FAKE_PANE_PINNED_FILE="$PINNED_FILE" \
+      FM_FAKE_PIN_COMMAND_FILE="$PIN_COMMAND_FILE" FM_FAKE_PIN_OUTPUT_FILE="$PIN_OUTPUT_FILE" \
+      FM_FAKE_LAUNCH_CWD_FILE="$LAUNCH_CWD_FILE" \
+      FM_FAKE_PANE_STALE_READS="$STALE_READS" FM_FAKE_PANE_COUNTFILE="$COUNTFILE" \
+      PATH="$FAKEBIN_DIR:$PATH" \
+    "$SPAWN" "$id" "$project" "${delivery_args[@]}" 2>&1
 }
 
 # A single stale first read (the exact incident) must not be accepted: the
@@ -202,8 +204,35 @@ test_relative_project_records_launched_pane_cwd() {
   pass "a relative projects/<repo> spawn records the launched pane cwd as worktree"
 }
 
+test_relative_project_scout_records_launched_pane_cwd() {
+  local rec id out status meta_project meta_worktree
+  id=settle-relative-scout-z4
+  rec=$(make_settle_case settle-relative-scout "$id" 0)
+  read_settle_record "$rec"
+
+  out=$(run_settle_spawn "$id" projects/project --scout)
+  status=$?
+  expect_code 0 "$status" "relative-project scout spawn should succeed"$'\n'"$out"
+  meta_worktree=$(sed -n 's/^worktree=//p' "$HOME_DIR/state/$id.meta")
+  meta_project=$(sed -n 's/^project=//p' "$HOME_DIR/state/$id.meta")
+  [ "$meta_worktree" = "$WT_DIR" ] \
+    || fail "relative-project scout meta worktree '$meta_worktree' does not equal launched pane cwd '$WT_DIR'"
+  [ "$(cd "$meta_project" && pwd -P)" = "$(cd "$PROJ_DIR" && pwd -P)" ] \
+    || fail "relative-project scout meta project '$meta_project' does not equal primary project '$PROJ_DIR'"
+  [ "$meta_worktree" != "$meta_project" ] \
+    || fail "relative-project scout meta collapsed worktree and project to '$meta_worktree'"
+  [ "$(cat "$LAUNCH_CWD_FILE")" = "$meta_worktree" ] \
+    || fail "relative-project scout launched pane cwd does not equal meta worktree '$meta_worktree'"
+  assert_contains "$out" "kind=scout" \
+    "relative-project scout success output did not identify the scout kind"
+  assert_contains "$out" "worktree=$WT_DIR" \
+    "relative-project scout success output did not report the launched pane cwd"
+  pass "a relative projects/<repo> scout spawn records the launched pane cwd as worktree"
+}
+
 test_single_stale_first_read_is_not_accepted
 test_already_settled_pane_costs_one_confirm_sleep
 test_relative_project_records_launched_pane_cwd
+test_relative_project_scout_records_launched_pane_cwd
 
 echo "# all fm-spawn-worktree-settle tests passed"

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -22,8 +22,8 @@ TMP_ROOT=$(fm_test_tmproot fm-spawn-worktree-settle)
 
 # make_settle_fakebin <dir> builds a fake tmux whose `#{pane_current_path}`
 # query returns FM_FAKE_PANE_STALE for the first FM_FAKE_PANE_STALE_READS
-# calls, then FM_FAKE_PANE_PATH forever after - reproducing a pane that
-# transiently reports a stale cwd before settling into the real worktree.
+# calls, then briefly reports FM_FAKE_PANE_PATH before returning to the primary
+# shell cwd unless the spawn explicitly pins that shell in the acquired worktree.
 make_settle_fakebin() {
   local dir=$1 fakebin
   fakebin=$(fm_fakebin "$dir")
@@ -37,10 +37,14 @@ case "$*" in
     [ -f "$countfile" ] && n=$(cat "$countfile")
     n=$((n + 1))
     printf '%s\n' "$n" > "$countfile"
-    if [ "$n" -le "${FM_FAKE_PANE_STALE_READS:-0}" ]; then
-      printf '%s\n' "${FM_FAKE_PANE_STALE:-}"
-    else
+    if [ -f "${FM_FAKE_PANE_PINNED_FILE:-}" ]; then
       printf '%s\n' "${FM_FAKE_PANE_PATH:-}"
+    elif [ "$n" -le "${FM_FAKE_PANE_STALE_READS:-0}" ]; then
+      printf '%s\n' "${FM_FAKE_PANE_STALE:-}"
+    elif [ "$n" -le "$((FM_FAKE_PANE_STALE_READS + 2))" ]; then
+      printf '%s\n' "${FM_FAKE_PANE_PATH:-}"
+    else
+      printf '%s\n' "${FM_FAKE_PRIMARY_PATH:-}"
     fi
     exit 0
     ;;
@@ -49,7 +53,13 @@ case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;
   has-session|new-session|new-window|kill-window) exit 0 ;;
-  send-keys) exit 0 ;;
+  send-keys)
+    case "$*" in
+      *"cd -- "*) touch "${FM_FAKE_PANE_PINNED_FILE:?FM_FAKE_PANE_PINNED_FILE unset}" ;;
+      *" -l "*) [ -f "${FM_FAKE_PANE_PINNED_FILE:-}" ] && launch_cwd=${FM_FAKE_PANE_PATH:-} || launch_cwd=${FM_FAKE_PRIMARY_PATH:-}; printf '%s\n' "$launch_cwd" > "${FM_FAKE_LAUNCH_CWD_FILE:?FM_FAKE_LAUNCH_CWD_FILE unset}" ;;
+    esac
+    exit 0
+    ;;
 esac
 exit 0
 SH
@@ -64,13 +74,15 @@ SH
 # entirely, distinct from both the project and the worktree - mirroring the
 # live incident where the stale read was another real firstmate home).
 make_settle_case() {
-  local name=$1 id=$2 stale_reads=$3 case_dir home proj wt stale fakebin countfile
+  local name=$1 id=$2 stale_reads=$3 case_dir home proj wt stale fakebin countfile pinned launchcwd
   case_dir="$TMP_ROOT/$name"
   home="$case_dir/home"
   proj="$home/projects/project"
   wt="$case_dir/wt"
   stale="$case_dir/stale-other-checkout"
   countfile="$case_dir/pane-call-count"
+  pinned="$case_dir/pane-pinned"
+  launchcwd="$case_dir/launch-cwd"
   fakebin=$(make_settle_fakebin "$case_dir/fake")
   mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
   printf 'codex\n' > "$home/config/crew-harness"
@@ -79,11 +91,11 @@ make_settle_case() {
   mkdir -p "$home/data/$id"
   printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
   touch "$home/state/.last-watcher-beat"
-  printf '%s\n' "$case_dir|$home|$proj|$wt|$stale|$fakebin|$countfile|$stale_reads"
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$stale|$fakebin|$countfile|$stale_reads|$pinned|$launchcwd"
 }
 
 read_settle_record() {
-  IFS='|' read -r _ HOME_DIR PROJ_DIR WT_DIR STALE_DIR FAKEBIN_DIR COUNTFILE STALE_READS <<EOF
+  IFS='|' read -r _ HOME_DIR PROJ_DIR WT_DIR STALE_DIR FAKEBIN_DIR COUNTFILE STALE_READS PINNED_FILE LAUNCH_CWD_FILE <<EOF
 $1
 EOF
 }
@@ -95,6 +107,8 @@ run_settle_spawn() {
     FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
     FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
     FM_FAKE_PANE_PATH="$WT_DIR" FM_FAKE_PANE_STALE="$STALE_DIR" \
+    FM_FAKE_PRIMARY_PATH="$PROJ_DIR" FM_FAKE_PANE_PINNED_FILE="$PINNED_FILE" \
+    FM_FAKE_LAUNCH_CWD_FILE="$LAUNCH_CWD_FILE" \
     FM_FAKE_PANE_STALE_READS="$STALE_READS" FM_FAKE_PANE_COUNTFILE="$COUNTFILE" \
     PATH="$FAKEBIN_DIR:$PATH" \
     "$SPAWN" "$id" "$project" --mode no-mistakes --yolo off 2>&1
@@ -161,6 +175,8 @@ test_relative_project_records_launched_pane_cwd() {
     || fail "relative-project meta project '$meta_project' does not equal primary project '$PROJ_DIR'"
   [ "$meta_worktree" != "$meta_project" ] \
     || fail "relative-project meta collapsed worktree and project to '$meta_worktree'"
+  [ "$(cat "$LAUNCH_CWD_FILE")" = "$meta_worktree" ] \
+    || fail "relative-project launched pane cwd does not equal meta worktree '$meta_worktree'"
   assert_contains "$out" "worktree=$WT_DIR" \
     "relative-project success output did not report the launched pane cwd"
   pass "a relative projects/<repo> spawn records the launched pane cwd as worktree"

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -51,11 +51,21 @@ case "$*" in
 esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
+  capture-pane)
+    if [ -f "${FM_FAKE_PIN_PENDING_FILE:-}" ]; then
+      cat "${FM_FAKE_PIN_PENDING_FILE}"
+      touch "${FM_FAKE_PANE_PINNED_FILE:?FM_FAKE_PANE_PINNED_FILE unset}"
+      rm -f "${FM_FAKE_PIN_PENDING_FILE}"
+    fi
+    exit 0
+    ;;
   list-windows) exit 0 ;;
   has-session|new-session|new-window|kill-window) exit 0 ;;
   send-keys)
     case "$*" in
-      *"cd -- "*) touch "${FM_FAKE_PANE_PINNED_FILE:?FM_FAKE_PANE_PINNED_FILE unset}" ;;
+      *"cd -- "*)
+        printf '%s\n' "$*" | sed -n "s/.*'\(fm-pin-[^']*\)'.*/\1/p" > "${FM_FAKE_PIN_PENDING_FILE:?FM_FAKE_PIN_PENDING_FILE unset}"
+        ;;
       *" -l "*) [ -f "${FM_FAKE_PANE_PINNED_FILE:-}" ] && launch_cwd=${FM_FAKE_PANE_PATH:-} || launch_cwd=${FM_FAKE_PRIMARY_PATH:-}; printf '%s\n' "$launch_cwd" > "${FM_FAKE_LAUNCH_CWD_FILE:?FM_FAKE_LAUNCH_CWD_FILE unset}" ;;
     esac
     exit 0
@@ -74,7 +84,7 @@ SH
 # entirely, distinct from both the project and the worktree - mirroring the
 # live incident where the stale read was another real firstmate home).
 make_settle_case() {
-  local name=$1 id=$2 stale_reads=$3 case_dir home proj wt stale fakebin countfile pinned launchcwd
+  local name=$1 id=$2 stale_reads=$3 case_dir home proj wt stale fakebin countfile pinned pinpending launchcwd
   case_dir="$TMP_ROOT/$name"
   home="$case_dir/home"
   proj="$home/projects/project"
@@ -82,6 +92,7 @@ make_settle_case() {
   stale="$case_dir/stale-other-checkout"
   countfile="$case_dir/pane-call-count"
   pinned="$case_dir/pane-pinned"
+  pinpending="$case_dir/pin-pending"
   launchcwd="$case_dir/launch-cwd"
   fakebin=$(make_settle_fakebin "$case_dir/fake")
   mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
@@ -91,11 +102,11 @@ make_settle_case() {
   mkdir -p "$home/data/$id"
   printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
   touch "$home/state/.last-watcher-beat"
-  printf '%s\n' "$case_dir|$home|$proj|$wt|$stale|$fakebin|$countfile|$stale_reads|$pinned|$launchcwd"
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$stale|$fakebin|$countfile|$stale_reads|$pinned|$pinpending|$launchcwd"
 }
 
 read_settle_record() {
-  IFS='|' read -r _ HOME_DIR PROJ_DIR WT_DIR STALE_DIR FAKEBIN_DIR COUNTFILE STALE_READS PINNED_FILE LAUNCH_CWD_FILE <<EOF
+  IFS='|' read -r _ HOME_DIR PROJ_DIR WT_DIR STALE_DIR FAKEBIN_DIR COUNTFILE STALE_READS PINNED_FILE PIN_PENDING_FILE LAUNCH_CWD_FILE <<EOF
 $1
 EOF
 }
@@ -108,6 +119,7 @@ run_settle_spawn() {
     FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
     FM_FAKE_PANE_PATH="$WT_DIR" FM_FAKE_PANE_STALE="$STALE_DIR" \
     FM_FAKE_PRIMARY_PATH="$PROJ_DIR" FM_FAKE_PANE_PINNED_FILE="$PINNED_FILE" \
+    FM_FAKE_PIN_PENDING_FILE="$PIN_PENDING_FILE" \
     FM_FAKE_LAUNCH_CWD_FILE="$LAUNCH_CWD_FILE" \
     FM_FAKE_PANE_STALE_READS="$STALE_READS" FM_FAKE_PANE_COUNTFILE="$COUNTFILE" \
     PATH="$FAKEBIN_DIR:$PATH" \

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -164,13 +164,16 @@ make_spawn_fakebin() {
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
+. "${FM_FAKE_SPAWN_ACK_LIB:?FM_FAKE_SPAWN_ACK_LIB unset}"
 case "$*" in
   *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
 esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
+  capture-pane) fm_fake_spawn_ack_capture; exit 0 ;;
   list-windows) exit 0 ;;
-  has-session|new-session|new-window|send-keys) exit 0 ;;
+  send-keys) fm_fake_spawn_ack_send "$@"; exit 0 ;;
+  has-session|new-session|new-window) exit 0 ;;
 esac
 exit 0
 SH
@@ -241,15 +244,18 @@ make_spawn_record_fakebin() {
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
+. "${FM_FAKE_SPAWN_ACK_LIB:?FM_FAKE_SPAWN_ACK_LIB unset}"
 [ -n "${FM_TMUX_REC:-}" ] && printf 'tmux %s\n' "$*" >> "$FM_TMUX_REC"
 case "$*" in
   *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
 esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
+  capture-pane) fm_fake_spawn_ack_capture; exit 0 ;;
   new-window) printf '%s\n' "@spawnwid"; exit 0 ;;
   list-windows) exit 0 ;;
-  has-session|new-session|send-keys|set-window-option) exit 0 ;;
+  send-keys) fm_fake_spawn_ack_send "$@"; exit 0 ;;
+  has-session|new-session|set-window-option) exit 0 ;;
 esac
 exit 0
 SH

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -136,7 +136,7 @@ test_brief_assertion_precedes_branch() {
     "brief is missing the isolation blocked-status contract"
   assert_grep "primary_clone='$primary_real'" "$brief" \
     "brief must emit the resolved primary clone path"
-  assert_grep 'cd -- "$primary_clone" && pwd -P' "$brief" \
+  assert_grep "cd -- \"\$primary_clone\" && pwd -P" "$brief" \
     "brief must make the primary-clone comparison executable"
   assert_grep "A linked worktree normally has" "$brief" \
     "brief must explain that a linked worktree git-dir under the primary clone is normal"

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -309,6 +309,8 @@ test_spawn_tmux_window_construction() {
     "treehouse get must be sent to the stable window id"
   assert_grep "display-message -p -t @spawnwid #{pane_current_path}" "$rec" \
     "the worktree wait loop must query the stable window id, not the name"
+  assert_grep "capture-pane -p -t @spawnwid -S -20" "$rec" \
+    "the pin acknowledgement must be captured from the stable window id"
 
   pass "fm-spawn: appends windows by session-colon, pins the name, and targets the window id"
 }

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -125,16 +125,19 @@ test_bootstrap_line() {
 # The generated ship brief must carry the isolation assertion AHEAD of the
 # `git checkout -b` step, so the crewmate verifies its worktree before branching.
 test_brief_assertion_precedes_branch() {
-  local home brief iso br
+  local home brief iso br primary_real
   home="$TMP_ROOT/brief-home"
-  mkdir -p "$home/data"
+  mkdir -p "$home/data" "$home/projects/alpha"
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" tangle-brief-cc3 alpha --mode no-mistakes >/dev/null 2>&1
   brief="$home/data/tangle-brief-cc3/brief.md"
+  primary_real=$(cd "$home/projects/alpha" && pwd -P)
   assert_present "$brief" "brief was not scaffolded"
   assert_grep "blocked: launched in primary checkout, not an isolated worktree" "$brief" \
     "brief is missing the isolation blocked-status contract"
-  assert_grep "Compare the physically resolved" "$brief" \
-    "brief must compare the worktree top-level with the primary clone path"
+  assert_grep "primary_clone='$primary_real'" "$brief" \
+    "brief must emit the resolved primary clone path"
+  assert_grep 'cd -- "$primary_clone" && pwd -P' "$brief" \
+    "brief must make the primary-clone comparison executable"
   assert_grep "A linked worktree normally has" "$brief" \
     "brief must explain that a linked worktree git-dir under the primary clone is normal"
   assert_no_grep "A reliable test that you are in a linked worktree" "$brief" \

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -133,8 +133,10 @@ test_brief_assertion_precedes_branch() {
   assert_present "$brief" "brief was not scaffolded"
   assert_grep "blocked: launched in primary checkout, not an isolated worktree" "$brief" \
     "brief is missing the isolation blocked-status contract"
-  assert_grep "The path check is authoritative" "$brief" \
-    "brief must make the path check authoritative"
+  assert_grep "Compare the physically resolved" "$brief" \
+    "brief must compare the worktree top-level with the primary clone path"
+  assert_grep "A linked worktree normally has" "$brief" \
+    "brief must explain that a linked worktree git-dir under the primary clone is normal"
   assert_no_grep "A reliable test that you are in a linked worktree" "$brief" \
     "brief must not present git-dir/common-dir as decisive"
   assert_no_grep "they are identical in the primary checkout" "$brief" \

--- a/tests/fm-trace-context-spawn.test.sh
+++ b/tests/fm-trace-context-spawn.test.sh
@@ -21,17 +21,20 @@ make_spawn_fakebin() {
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
+. "${FM_FAKE_SPAWN_ACK_LIB:?FM_FAKE_SPAWN_ACK_LIB unset}"
 case "$*" in
   *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
 esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
+  capture-pane) fm_fake_spawn_ack_capture; exit 0 ;;
   list-windows)
     [ -z "${FM_FAKE_DUPLICATE_WINDOW:-}" ] || printf '%s\n' "$FM_FAKE_DUPLICATE_WINDOW"
     exit 0
     ;;
   has-session|new-session|new-window|kill-window) exit 0 ;;
   send-keys)
+    fm_fake_spawn_ack_send "$@"
     if [ "${FM_FAKE_TRACEPARENT_SEND_FAIL:-0}" = 1 ]; then
       for a in "$@"; do
         case "$a" in

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -38,6 +38,7 @@ export FM_GATE_REFUSE_BYPASS=1
 # test files, not by this library, so it reads as "unused" here.
 # shellcheck disable=SC2034
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export FM_FAKE_SPAWN_ACK_LIB="$ROOT/tests/fm-spawn-fake-ack.sh"
 
 # --- reporters --------------------------------------------------------------
 


### PR DESCRIPTION
## Intent

Fix two related defects in firstmate spawn tooling. First, for ship and scout spawns invoked with a relative projects/<repo> positional path, ensure state/<id>.meta records worktree=<resolved treehouse slot> and never the primary project directory; reproduce hermetically without spawning against a real project and add a regression asserting metadata worktree equals the launched pane cwd. Second, update the generated ship brief isolation assertion to compare git rev-parse --show-toplevel against the primary clone path and explicitly explain that a genuine linked worktree normally has its git-dir under the parent clone .git/worktrees directory; extend the generated-brief scaffold test. Keep bin scripts shellcheck-clean, use colocated behavioral tests, and deliver one PR through no-mistakes. Push the branch to https://github.com/pm-justinm/firstmate and open the PR against kunchenguid/firstmate, matching the fleet-dashboard routing. The repaired local stack is current, DB-migrated, and verified at http://localhost for any applicable live-evidence step.

## What Changed

- Pin Treehouse-backed ship and scout endpoints to the acquired worktree before publishing metadata or launching the harness.
- Record the verified pane working directory in `worktree=` for relative `projects/<repo>` spawns instead of the primary clone path.
- Update generated ship briefs to compare the resolved repository top level with the primary clone while explaining normal linked-worktree git-dir placement, with regression coverage for both behaviors.

## Risk Assessment

✅ Low: The change now durably pins the endpoint to the acquired worktree before metadata publication and launch, uses the stable backend target for acknowledgement capture, emits an executable primary-clone isolation check, and includes behavioral regression coverage without source-content-only assertions.

## Testing

<code>Targeted hermetic tests demonstrated that relative `projects/&lt;repo&gt;` ship and scout spawns persist the launched treehouse cwd rather than the primary clone, while the generated ship brief compares the resolved top-level path with the primary clone and correctly explains linked-worktree git-dir placement; all focused checks passed, with direct CLI and generated-contract evidence captured.</code>

<details>
<summary>Evidence: Hermetic ship and scout spawn transcript</summary>

Source: [Hermetic ship and scout spawn transcript](https://github.com/pm-justinm/firstmate/blob/780c43f14c8ff909d984d786ebb302aa946aa5bd/.no-mistakes/evidence/fm/fm-spawn-worktree-meta/relative-project-spawn-transcript.txt)

```text
+ id=settle-relative-project-z3
spawned settle-relative-project-z3 harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-settle-relative-project-z3 worktree=/var/folders/nv/q5l3qllj3nb4nf3dj9k004rm0000gp/T//fm-spawn-worktree-settle.35JRQE/settle-relative-project/wt'
spawned settle-relative-project-z3 harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-settle-relative-project-z3 worktree=/var/folders/nv/q5l3qllj3nb4nf3dj9k004rm0000gp/T//fm-spawn-worktree-settle.35JRQE/settle-relative-project/wt'
spawned settle-relative-project-z3 harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-settle-relative-project-z3 worktree=/var/folders/nv/q5l3qllj3nb4nf3dj9k004rm0000gp/T//fm-spawn-worktree-settle.35JRQE/settle-relative-project/wt'
+ meta_worktree=/var/folders/nv/q5l3qllj3nb4nf3dj9k004rm0000gp/T//fm-spawn-worktree-settle.35JRQE/settle-relative-project/wt
+ meta_project=/var/folders/nv/q5l3qllj3nb4nf3dj9k004rm0000gp/T/fm-spawn-worktree-settle.35JRQE/settle-relative-project/home/projects/project
spawned settle-relative-project-z3 harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-settle-relative-project-z3 worktree=/var/folders/nv/q5l3qllj3nb4nf3dj9k004rm0000gp/T//fm-spawn-worktree-settle.35JRQE/settle-relative-project/wt' worktree=/var/folders/nv/q5l3qllj3nb4nf3dj9k004rm0000gp/T//fm-spawn-worktree-settle.35JRQE/settle-relative-project/wt 'relative-project success output did not report the launched pane cwd'
ok - a relative projects/<repo> spawn records the launched pane cwd as worktree
+ id=settle-relative-scout-z4
spawned settle-relative-scout-z4 harness=codex kind=scout window=firstmate:fm-settle-relative-scout-z4 worktree=/var/folders/nv/q5l3qllj3nb4nf3dj9k004rm0000gp/T//fm-spawn-worktree-settle.35JRQE/settle-relative-scout/wt'
spawned settle-relative-scout-z4 harness=codex kind=scout window=firstmate:fm-settle-relative-scout-z4 worktree=/var/folders/nv/q5l3qllj3nb4nf3dj9k004rm0000gp/T//fm-spawn-worktree-settle.35JRQE/settle-relative-scout/wt'
+ meta_worktree=/var/folders/nv/q5l3qllj3nb4nf3dj9k004rm0000gp/T//fm-spawn-worktree-settle.35JRQE/settle-relative-scout/wt
+ meta_project=/var/folders/nv/q5l3qllj3nb4nf3dj9k004rm0000gp/T/fm-spawn-worktree-settle.35JRQE/settle-relative-scout/home/projects/project
ok - a relative projects/<repo> scout spawn records the launched pane cwd as worktree
```
</details>
<details>
<summary>Evidence: Generated ship-brief isolation contract</summary>

Source: [Generated ship-brief isolation contract](https://github.com/pm-justinm/firstmate/blob/780c43f14c8ff909d984d786ebb302aa946aa5bd/.no-mistakes/evidence/fm/fm-spawn-worktree-meta/generated-ship-brief-isolation.txt)

```text
Generated ship brief isolation contract:
**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree.
Set `primary_clone='/private/var/folders/nv/q5l3qllj3nb4nf3dj9k004rm0000gp/T/no-mistakes-evidence/01M093V8NHTRTX8XW2TYVWCABK/brief-fixture/home/projects/alpha'`, physically resolve both paths with `cd -- "$primary_clone" && pwd -P` and `cd -- "$(git rev-parse --show-toplevel)" && pwd -P`, and compare their output; equal paths mean you were launched in the primary checkout.
A linked worktree normally has `git rev-parse --git-dir` under the primary clone's `.git/worktrees/`; that location is not evidence that your working tree is the primary checkout.
If the top-level path equals the primary clone path or is not the disposable worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/evidence-brief`
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ff03877121d0501430af74c2297819a29b961b70","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (4) ✅</summary>

- 🚨 `bin/fm-spawn.sh:2271` - The required durable fix is absent: `TASK_WORKTREE=$WT` only aliases the existing value, and every replaced use previously read that same unchanged `WT`; there is no assignment to `WT` between worktree validation and metadata/launch/output generation. Consequently, the new regression would also pass before this commit and does not reproduce the reported relative-path failure. Identify and repair the actual transition that changes the resolved pane cwd into the primary project path, then make the regression fail at the base commit.
- 🚨 `bin/fm-brief.sh:424` - The generated brief tells the worker to compare against “the primary clone path” but never supplies or derives that path, so the required comparison cannot be performed reliably. Emit the resolved primary clone path or an executable derivation of it, and extend the generated-output test to assert that concrete comparison contract.

🔧 Fix: Pin spawned panes and emit primary clone path
1 error still open:
- 🚨 `bin/fm-spawn.sh:2272` - The pin verification can succeed before the newly sent `cd` command executes: the pane is already reporting `TASK_WORKTREE`, so the first asynchronous cwd query may immediately break the loop; the queued `cd` can then execute too late—or the prior treehouse context can return to the primary checkout before launch. The fake backend masks this race by marking the pane pinned synchronously inside `send-keys`. Send a uniquely observable acknowledgement after `cd` and require that acknowledgement plus the matching live cwd before publishing metadata and launching.

🔧 Fix: Synchronize pane pin before publishing spawn metadata
2 errors still open:
- 🚨 `bin/fm-spawn.sh:2270` - The acknowledgement token is embedded verbatim in the command sent to the interactive pane. Because pane capture returns visual terminal lines, a sufficiently long `cd` command can wrap so the unexecuted token appears alone and satisfies `grep -Fxq`; while the pane still transiently reports `TASK_WORKTREE`, the barrier can therefore pass before `cd` executes—the original race remains reachable. Construct the acknowledgement output from separately quoted fragments so the complete marker never appears in echoed input, then recognize only the assembled output marker.
- 🚨 `bin/fm-spawn.sh:2274` - Every successful non-Orca spawn now requires `fm_backend_capture` to return the acknowledgement, but existing behavioral fake endpoints generally return empty or fixed capture output. For example, both successful spawn paths in `tests/fm-tangle-guard.test.sh` can no longer cross this barrier; the same pattern exists in several other spawn suites. Update the shared/colocated spawn fakes to execute and expose the acknowledgement asynchronously, preserving the regression&#39;s requirement that `send-keys` itself cannot satisfy the barrier.

🔧 Fix: Harden pane acknowledgement and update spawn fakes
1 error still open:
- 🚨 `bin/fm-spawn.sh:2276` - The acknowledgement is sent and cwd-checked through the rename-safe `WT_TARGET`, but capture still targets `$T`, the potentially lost tmux window name. If automatic rename changes that name, tmux may capture the active client window instead, so a valid spawn cannot observe its acknowledgement and fails after five seconds. Capture from `WT_TARGET` as well; other backends already default it to `$T`.

🔧 Fix: Use stable target for pane acknowledgement capture
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 64d61aed84373e02b1a28c4e6b262908ed8128d5..0be6139d86f0473434d855c53b0fad27446f624f`.</code>
- <code>Ran `tests/fm-spawn-worktree-settle.test.sh` after extending it to exercise both ship and scout relative-path spawns.</code>
- <code>Ran `tests/fm-tangle-guard.test.sh` to validate the generated ship-brief isolation contract.</code>
- <code>Ran `bash -x tests/fm-spawn-worktree-settle.test.sh` and captured the ship/scout CLI results plus persisted metadata values.</code>
- <code>Generated a real brief with `FM_HOME=&lt;hermetic evidence fixture&gt; bin/fm-brief.sh evidence-brief alpha --mode no-mistakes` and captured its isolation section.</code>
- <code>Checked `git status --short`; only the intentional test correction modifies the worktree.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Fix literal brief assertion quoting
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
