### PR TITLE
feat(bin): pin standard tier for Codex workers

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -112,6 +112,9 @@ When changing any primary watcher adapter, update `docs/supervision-protocols/`,
 
 `bin/fm-spawn.sh` accepts concrete `--harness`, `--model`, and `--effort` values chosen by firstmate at intake.
 Do not make the shell scripts parse or match natural-language dispatch rules.
+Codex workers use the standard service tier by default.
+Pass `--fast-tier` only for a Codex spawn when speed is explicitly called for; it omits Firstmate's standard-tier pin and leaves that spawn's tier to the operator's Codex configuration.
+Never pass this flag to another harness, and see `bin/fm-spawn.sh --help` for the exact per-spawn mechanics.
 
 Effort precedence is an explicit per-task captain instruction first, then any applicable standing dispatch profile or secondmate pin, then the generic fallback below.
 Never replace an effort value supplied by either higher-precedence source.
@@ -126,7 +129,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | Harness | Model flag | Effort flag | Notes |
 |---|---|---|---|
 | claude | `--model <model>` | `--effort <low\|medium\|high\|xhigh\|max>` | Verified on Claude Code 2.1.196. |
-| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'` | Verified on codex-cli 0.142.1. The installed binary schema contains `model_reasoning_effort`, the active config uses it, and the bundled model catalog advertises only low/medium/high/xhigh. `max` is omitted. |
+| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'` | Verified on codex-cli 0.147.0. The installed `-c`/`--config key=value` path supports both `model_reasoning_effort` and `service_tier`, and the bundled model catalog identifies `priority` as the additional Fast tier. The catalog advertises only low/medium/high/xhigh reasoning effort, so `max` is omitted. |
 | grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
 | pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |

--- a/bin/fm-remote-secondmate-control.sh
+++ b/bin/fm-remote-secondmate-control.sh
@@ -134,7 +134,7 @@ cmd_route() {
 
 cmd_launch() {
   local id=$1 harness=$2 model=$3 effort=$4 selected_backend=$5
-  local current meta out herdr_session launch_arg traceparent= fast_tier=0
+  local current meta out herdr_session launch_arg traceparent='' fast_tier=0
   shift 5
   for launch_arg in "$@"; do
     case "$launch_arg" in

--- a/bin/fm-remote-secondmate-control.sh
+++ b/bin/fm-remote-secondmate-control.sh
@@ -2,7 +2,7 @@
 # Host-local lifecycle control for the remote secondmate home selected by fm-on.
 #
 # Usage:
-#   fm-remote-secondmate-control.sh launch <id> <harness> <model|-> <effort|-> herdr [traceparent]
+#   fm-remote-secondmate-control.sh launch <id> <harness> <model|-> <effort|-> herdr [--fast-tier] [traceparent]
 #   fm-remote-secondmate-control.sh state <id>
 #   fm-remote-secondmate-control.sh route <id>
 #   fm-remote-secondmate-control.sh send <id> <message>
@@ -133,8 +133,22 @@ cmd_route() {
 }
 
 cmd_launch() {
-  local id=$1 harness=$2 model=$3 effort=$4 selected_backend=$5 traceparent=${6:-}
-  local current meta out herdr_session
+  local id=$1 harness=$2 model=$3 effort=$4 selected_backend=$5
+  local current meta out herdr_session launch_arg traceparent= fast_tier=0
+  shift 5
+  for launch_arg in "$@"; do
+    case "$launch_arg" in
+      --fast-tier)
+        [ "$fast_tier" -eq 0 ] || die "duplicate remote secondmate launch option: --fast-tier"
+        fast_tier=1
+        ;;
+      --*) die "invalid remote secondmate launch option: $launch_arg" ;;
+      *)
+        [ -z "$traceparent" ] || die "multiple remote secondmate traceparent arguments"
+        traceparent=$launch_arg
+        ;;
+    esac
+  done
 
   validate_id "$id"
   validate_home "$id"
@@ -168,6 +182,7 @@ cmd_launch() {
   ARGS=("$id" "$TARGET_HOME" --secondmate --harness "$harness" --backend "$selected_backend")
   [ "$model" = - ] || ARGS+=(--model "$model")
   [ "$effort" = - ] || ARGS+=(--effort "$effort")
+  [ "$fast_tier" -eq 0 ] || ARGS+=(--fast-tier)
   [ -z "$traceparent" ] || ARGS+=(--traceparent "$traceparent")
   if ! out=$(HERDR_SESSION="$REMOTE_HERDR_SESSION" FM_HOME="$FM_ROOT" FM_ROOT_OVERRIDE="$FM_ROOT" \
     FM_STATE_OVERRIDE="$CONTROL_STATE" FM_DATA_OVERRIDE="$CONTROL_DATA" \
@@ -290,7 +305,7 @@ cmd_retire() {
 }
 
 case "${1:-}" in
-  launch) shift; [ "$#" -ge 5 ] && [ "$#" -le 6 ] || usage; cmd_launch "$@" ;;
+  launch) shift; [ "$#" -ge 5 ] && [ "$#" -le 7 ] || usage; cmd_launch "$@" ;;
   state) shift; [ "$#" -eq 1 ] || usage; validate_id "$1"; validate_home "$1"; state_value "$1" ;;
   route) shift; [ "$#" -eq 1 ] || usage; cmd_route "$1" ;;
   send) shift; [ "$#" -eq 2 ] || usage; cmd_send "$@" ;;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Spawn a direct report: a crewmate in a treehouse or Orca worktree, or a
 # secondmate in its isolated firstmate home.
-# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
-#        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
-#        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] --secondmate
+# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--fast-tier] [--backend <name>]
+#        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--fast-tier] [--backend <name>]
+#        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--fast-tier] [--backend <name>] --secondmate
 #   --mode and --yolo are this task's delivery contract, REQUIRED for every ship
 #   spawn and refused on --scout and --secondmate spawns. Firstmate resolves both
 #   per task at intake (AGENTS.md section 7); data/projects.md holds the captain's
@@ -38,6 +38,11 @@
 #   axes chosen by firstmate at intake. They are only threaded into harnesses whose
 #   installed CLIs were verified to support that axis; unsupported axes are omitted
 #   from that harness's launch rather than guessed.
+#   Codex launches use the standard service tier by default to implement the
+#   captain's standing preference. --fast-tier is a Codex-only opt-in that skips
+#   the standard-tier override and lets the operator's configured tier apply when
+#   speed is deliberately requested. The pin also protects workers from future
+#   operator configuration drift. Other harnesses receive no tier setting.
 #   --backend <name> is the explicit runtime session-provider backend for this
 #   exact task only (docs/configuration.md "Runtime backend" owns when that flag
 #   is authorized). Without it, the script resolves FM_BACKEND, then
@@ -141,7 +146,7 @@
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
-#   source of truth; shared --scout/--harness/--model/--effort/--backend/--mode/--yolo
+#   source of truth; shared --scout/--harness/--model/--effort/--fast-tier/--backend/--mode/--yolo
 #   applies to every pair. A ship batch therefore carries one delivery contract, and each
 #   pair still checks it against its own brief; a batch spanning modes is two invocations.
 #   If config/crew-dispatch.json exists, shared --harness is required for crewmate
@@ -271,6 +276,7 @@ KIND_SET=0
 HARNESS_ARG=
 MODEL=
 EFFORT=
+FAST_TIER=0
 BACKEND_ARG=
 MODE=
 YOLO=
@@ -313,6 +319,7 @@ for a in "$@"; do
     --model=*) MODEL=${a#--model=}; MODEL_SET=1 ;;
     --effort) want_value=effort ;;
     --effort=*) EFFORT=${a#--effort=}; EFFORT_SET=1 ;;
+    --fast-tier) FAST_TIER=1 ;;
     --backend) want_value=backend ;;
     --backend=*) BACKEND_ARG=${a#--backend=}; BACKEND_SET=1 ;;
     --mode) want_value=mode ;;
@@ -862,6 +869,7 @@ if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in *
   [ -z "$HARNESS_ARG" ] || shared_args+=(--harness "$HARNESS_ARG")
   [ -z "$MODEL" ] || shared_args+=(--model "$MODEL")
   [ -z "$EFFORT" ] || shared_args+=(--effort "$EFFORT")
+  [ "$FAST_TIER" -eq 0 ] || shared_args+=(--fast-tier)
   [ -z "$BACKEND_ARG" ] || shared_args+=(--backend "$BACKEND_ARG")
   # One delivery contract applies to every pair in a batch, exactly like the shared
   # harness. Each pair still re-validates it against its own brief, so a batch
@@ -1114,9 +1122,9 @@ launch_template() {
     claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     codex)
       if [ "$kind" = secondmate ]; then
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' 'codex __MODELFLAG____EFFORTFLAG____TIERFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       else
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' 'codex __MODELFLAG____EFFORTFLAG____TIERFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       fi
       ;;
     opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
@@ -1422,6 +1430,16 @@ effort_flag_for_harness() {
     # in model ids such as cursor-grok-4.5-high, so it also receives no separate
     # effort flag.
   esac
+}
+
+service_tier_flag_for_harness() {
+  local harness=$1 fast_tier=$2
+  [ "$harness" = codex ] || return 0
+  [ "$fast_tier" -eq 0 ] || return 0
+  # Codex 0.147.0's native config schema names service_tier, and its bundled
+  # model catalog identifies priority as the additional Fast tier. The explicit
+  # default service tier is the standard path that overrides a global priority.
+  printf -- '-c %s ' "$(shell_quote 'service_tier="default"')"
 }
 
 case "$LAUNCH" in
@@ -2714,8 +2732,10 @@ sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
 sq_worktree=$(shell_quote "$WT")
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
+TIERFLAG=$(service_tier_flag_for_harness "$HARNESS" "$FAST_TIER")
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
 LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
+LAUNCH=${LAUNCH//__TIERFLAG__/$TIERFLAG}
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}
 LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -16,7 +16,7 @@
 #   loud one-line deviation notice is printed and the spawn continues.
 #   no-mistakes-prod-only is a registry policy rather than a task mode and is
 #   refused as a flag value.
-#        fm-spawn.sh <task-id> --relaunch [--harness <name>] [--model <name>] [--effort <level>]
+#        fm-spawn.sh <task-id> --relaunch [--harness <name>] [--model <name>] [--effort <level>] [--fast-tier]
 #   --relaunch launches a replacement agent for an EXISTING task into that
 #   task's own recorded endpoint and worktree instead of creating either. It is
 #   the launch half of the control plane (bin/fm-control.sh relaunch), which
@@ -26,8 +26,9 @@
 #   backend, kind, project or home, worktree, endpoint - comes from the task's
 #   validated state/<id>.meta, so --backend, --scout, --secondmate, a project
 #   positional, and batch pairs are all refused alongside it; only harness,
-#   model, and effort may change, which is what makes a harness switch one
-#   ordinary relaunch. It refuses unless the recorded endpoint is positively
+#   model, effort, and the Codex-only fast-tier choice may change.
+#   This is what makes a harness switch one ordinary relaunch.
+#   It refuses unless the recorded endpoint is positively
 #   agent-free on a backend with a recovery-grade agent-state classifier (tmux
 #   or herdr), refuses unless the endpoint's shell is sitting in the recorded
 #   worktree, and clears the previous harness's per-task wiring before arming
@@ -42,7 +43,8 @@
 #   captain's standing preference. --fast-tier is a Codex-only opt-in that skips
 #   the standard-tier override and lets the operator's configured tier apply when
 #   speed is deliberately requested. The pin also protects workers from future
-#   operator configuration drift. Other harnesses receive no tier setting.
+#   operator configuration drift without changing the global Codex configuration
+#   or the captain's interactive sessions. Other harnesses receive no tier setting.
 #   --backend <name> is the explicit runtime session-provider backend for this
 #   exact task only (docs/configuration.md "Runtime backend" owns when that flag
 #   is authorized). Without it, the script resolves FM_BACKEND, then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -563,6 +563,7 @@ spawn_remote_secondmate() {
     remote_traceparent=$(FM_TRACE_CONTEXT=on fm_trace_context_resolve "$CONFIG" "$meta" || true)
   fi
   launch_args=("$id" "$harness" "$model" "$effort" "$backend")
+  [ "$FAST_TIER" -eq 0 ] || launch_args+=(--fast-tier)
   [ -z "$remote_traceparent" ] || launch_args+=("$remote_traceparent")
   if out=$("$SCRIPT_DIR/fm-on.sh" "$id" fm-remote-secondmate-control.sh launch \
     "${launch_args[@]}" < /dev/null 2>&1); then

--- a/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
@@ -713,6 +713,7 @@ assert_grep 'remote_target=fm-remote:' "$PARENT/state/ios.meta" "parent metadata
 assert_grep 'herdr_session=fm-remote' "$REMOTE_HOME/state/parent-route/ios.meta" "remote metadata did not record the pinned Herdr session"
 assert_grep '--session fm-remote' "$HERDR_LOG" "remote launch did not target the fm-remote session"
 assert_no_grep '--session default' "$HERDR_LOG" "remote launch targeted the interactive default session"
+assert_grep "-c 'service_tier=\"default\"'" "$HERDR_LOG" "remote Codex launch omitted the standard service tier override"
 assert_grep 'window=remote:ios' "$PARENT/state/ios.meta" "parent metadata pretended the endpoint was local"
 assert_present "$PARENT/state/procevent/remote-reply-ios.source" "remote spawn did not arm its reply source"
 publish_healthy_watcher_identity "$PARENT/state" "$PARENT" "$ROOT/bin/fm-watch.sh"
@@ -723,6 +724,15 @@ publish_healthy_watcher_identity "$PARENT/state" "$PARENT" "$ROOT/bin/fm-watch.s
 [ "$(remote_env "$ROOT/bin/fm-on.sh" ios fm-remote-secondmate-control.sh observe ios)" = idle ] \
   || fail "remote endpoint delivery observation did not execute on its own host"
 pass "remote spawn launches on the remote-local backend and records a host-qualified route"
+
+reset_remote_herdr_fixture "$HERDR_STATE"
+: > "$HERDR_LOG"
+out=$(remote_env "$ROOT/bin/fm-spawn.sh" ios --secondmate --fast-tier)
+assert_contains "$out" 'remote=remote-mac backend=herdr' "fast-tier remote spawn did not report its host-qualified route"
+assert_no_grep 'service_tier' "$HERDR_LOG" "remote Codex --fast-tier launch retained the standard service tier override"
+[ "$(remote_env "$ROOT/bin/fm-on.sh" ios fm-remote-secondmate-control.sh state ios)" = alive ] \
+  || fail "fast-tier remote endpoint was not projected alive from its own host"
+pass "remote Codex fast-tier opt-in omits the standard override end to end"
 
 remote_route_meta="$REMOTE_HOME/state/parent-route/ios.meta"
 cp "$remote_route_meta" "$TMP_ROOT/remote-ios-before-default-session.meta"

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -854,7 +854,7 @@ test_spawn_explicit_harness_does_not_inherit_secondmate_harness_tokens() {
   [ "$(meta_field "$meta" model)" = default ] || fail "explicit-harness-no-tokens: meta model should stay default"
   [ "$(meta_field "$meta" effort)" = default ] || fail "explicit-harness-no-tokens: meta effort should stay default"
   launch=$(cat "$launchlog")
-  assert_contains "$launch" "codex --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "codex -c 'service_tier=\"default\"' --dangerously-bypass-approvals-and-sandbox" \
     "explicit-harness-no-tokens: launch did not use codex"
   assert_not_contains "$launch" "--model" "explicit-harness-no-tokens: launch must not carry a --model flag"
   assert_not_contains "$launch" "model_reasoning_effort" \

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -379,8 +379,8 @@ test_active_dispatch_profile_allows_explicit_harness() {
   assert_contains "$out" "spawned $id harness=codex" "spawn did not report explicit codex harness"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
-    "explicit harness launch did not thread model and effort"
+  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' -c 'service_tier=\"default\"' --dangerously-bypass-approvals-and-sandbox" \
+    "explicit harness launch did not thread model, effort, and standard service tier"
   pass "active crew-dispatch profile allows an explicit resolved harness"
 }
 
@@ -446,9 +446,27 @@ test_codex_threads_model_and_effort() {
   expect_code 0 "$status" "codex spawn with profile flags should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 high
   launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' -c 'service_tier=\"default\"' --dangerously-bypass-approvals-and-sandbox" \
+    "codex launch did not thread model, reasoning effort, and standard service tier config"
+  pass "codex receives --model, model_reasoning_effort, and the standard service tier"
+}
+
+test_codex_fast_tier_skips_standard_override() {
+  local rec id out status launch
+  id=profile-codex-fast-tier-z3b
+  rec=$(make_spawn_case profile-codex-fast-tier codex "$id")
+  read_case_record "$rec"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model gpt-5 --effort high --fast-tier)
+  status=$?
+  expect_code 0 "$status" "codex spawn with --fast-tier should succeed"
+  launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
-    "codex launch did not thread model and reasoning effort config"
-  pass "codex receives --model and model_reasoning_effort profile flags"
+    "codex fast-tier launch did not preserve the model and reasoning effort config"
+  assert_not_contains "$launch" "service_tier" \
+    "codex --fast-tier launch must omit the standard service tier override"
+  pass "codex --fast-tier skips only the standard service tier override"
 }
 
 test_codex_omits_invalid_max_effort() {
@@ -462,8 +480,8 @@ test_codex_omits_invalid_max_effort() {
   expect_code 0 "$status" "codex spawn with unsupported max effort should omit the effort flag"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' --dangerously-bypass-approvals-and-sandbox" \
-    "codex launch did not preserve the model flag when max effort was omitted"
+  assert_contains "$launch" "codex --model 'gpt-5' -c 'service_tier=\"default\"' --dangerously-bypass-approvals-and-sandbox" \
+    "codex launch did not preserve the model flag and standard service tier when max effort was omitted"
   assert_not_contains "$launch" "model_reasoning_effort" "codex launch must omit unsupported max reasoning effort"
   pass "codex omits unsupported max effort instead of passing a bad config value"
 }
@@ -839,6 +857,7 @@ test_active_dispatch_profile_allows_positional_harness
 test_active_dispatch_profile_allows_raw_launch_command
 test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
+test_codex_fast_tier_skips_standard_override
 test_codex_omits_invalid_max_effort
 test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort


### PR DESCRIPTION
## Intent

Make fm-spawn pin the STANDARD serving tier for codex workers, overriding operator config drift. The captain's standing preference is that firstmate-spawned workers use the standard serving tier unless speed is explicitly called for, while the captain's own interactive sessions keep their global configuration. The operator's global ~/.codex/config.toml is currently service_tier = "standard", but the launcher must pin standard regardless of future operator configuration drift.\n\nIn bin/fm-spawn.sh, Codex worker launches must pass the installed Codex CLI's verified config override -c 'service_tier="default"' by default, using the installed Codex 0.147.0 -c/--config key=value mechanism and its bundled model catalog evidence that priority is the additional Fast tier. Add an explicit Codex-only per-spawn --fast-tier opt-in that omits the standard-tier override so a dispatcher deliberately requesting speed can use the configured priority tier. Document the flag and the standard-tier default in the usage header. Only Codex has this knob today; do not invent service-tier equivalents for other harnesses, whose launch behavior must remain byte-identical when unchanged. Extend the existing fm-spawn flag/dispatch test surface to cover the default override and --fast-tier omission. Keep the PR body concise with plain hyphens only, include a Risk assessment section with a status-color emoji and one-line rationale, and put details in dropdowns.

## What Changed

- Pin firstmate-spawned Codex workers to the standard service tier with `-c 'service_tier="default"'` while leaving other harness launch behavior unchanged.
- Add a Codex-only `--fast-tier` opt-in across direct, batch, relaunch, and remote secondmate spawns, and document the new behavior.
- Extend spawn and remote lifecycle coverage for the default standard-tier pin and fast-tier omission.

## Risk Assessment

✅ Low: Captain, the authorized fixes close both prior findings, and the remaining change is well-bounded with no source-verifiable merge risk found.

## Testing

No baseline results were supplied; targeted dispatch, local-secondmate, and remote-secondmate suites passed, installed Codex 0.147.0 accepted the standard-tier override and identified `priority` as Fast, and the captured worker-launch transcript demonstrated default pinning, deliberate `--fast-tier` omission, and no tier argument for Claude.

<details>
<summary>Evidence: fm-spawn service-tier acceptance transcript</summary>

```text
fm-spawn service-tier acceptance transcript

Usage header
Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--fast-tier] [--backend <name>]
fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--fast-tier] [--backend <name>]
fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--fast-tier] [--backend <name>] --secondmate
Codex launches use the standard service tier by default to implement the
captain's standing preference. --fast-tier is a Codex-only opt-in that skips
the standard-tier override and lets the operator's configured tier apply when
speed is deliberately requested. The pin also protects workers from future
operator configuration drift. Other harnesses receive no tier setting.

Installed Codex evidence
codex-cli 0.147.0
  -c, --config <key=value>
          Override a configuration value that would otherwise be loaded from `~/.codex/config.toml`.
          Use a dotted path (`foo.bar.baz`) to override nested values. The `value` portion is parsed
          as TOML. If it fails to parse as TOML, the raw string is used as a literal.
          
service_tier="default" strict config parse: accepted
bundled catalog fast tier: {"model":"gpt-5.6-sol","service_tier":{"id":"priority","name":"Fast","description":"1.5x speed, increased usage"}}

Default Codex worker spawn
spawned evidence-codex-default harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-evidence-codex-default worktree=/tmp/fm-spawn-tier-evidence.GYSe2d/evidence-codex-default/wt
launch argv: env -u CURSOR_AGENT -u CURSOR_INVOKED_AS codex --model 'gpt-5' -c 'model_reasoning_effort="high"' -c 'service_tier="default"' --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch '/tmp/fm-spawn-tier-evidence.GYSe2d/evidence-codex-default/home/state/evidence-codex-default.turn-ended'\"]" "$('/home/kalvira/.no-mistakes/worktrees/29769f6dfb27/01M095AZ7VGE9HWZ4C029K0Q8K/bin/fm-operational-input.sh' encode launch-brief < '/tmp/fm-spawn-tier-evidence.GYSe2d/evidence-codex-default/home/data/evidence-codex-default/brief.md')"

Codex --fast-tier worker spawn
spawned evidence-codex-fast harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-evidence-codex-fast worktree=/tmp/fm-spawn-tier-evidence.GYSe2d/evidence-codex-fast/wt
launch argv: env -u CURSOR_AGENT -u CURSOR_INVOKED_AS codex --model 'gpt-5' -c 'model_reasoning_effort="high"' --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch '/tmp/fm-spawn-tier-evidence.GYSe2d/evidence-codex-fast/home/state/evidence-codex-fast.turn-ended'\"]" "$('/home/kalvira/.no-mistakes/worktrees/29769f6dfb27/01M095AZ7VGE9HWZ4C029K0Q8K/bin/fm-operational-input.sh' encode launch-brief < '/tmp/fm-spawn-tier-evidence.GYSe2d/evidence-codex-fast/home/data/evidence-codex-fast/brief.md')"

Unchanged non-Codex worker spawn
spawned evidence-claude-unchanged harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-evidence-claude-unchanged worktree=/tmp/fm-spawn-tier-evidence.GYSe2d/evidence-claude-unchanged/wt
launch argv: env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions --model 'sonnet' --effort 'high' "$('/home/kalvira/.no-mistakes/worktrees/29769f6dfb27/01M095AZ7VGE9HWZ4C029K0Q8K/bin/fm-operational-input.sh' encode launch-brief < '/tmp/fm-spawn-tier-evidence.GYSe2d/evidence-claude-unchanged/home/data/evidence-claude-unchanged/brief.md')"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `bin/fm-spawn.sh:322` - Intent requires &#34;Add an explicit Codex-only per-spawn --fast-tier opt-in that omits the standard-tier override.&#34; The new `--fast-tier) FAST_TIER=1` parser hunk does not reach remote secondmates: `spawn_remote_secondmate` sends only id, harness, model, effort, backend, and optional traceparent, while the remote controller reconstructs the host launch without `--fast-tier`. Consequently, a remote Codex secondmate requested with `--fast-tier` still receives `service_tier=&#34;default&#34;`. Thread the opt-in through the existing remote launch boundary and cover that route.
- 🚨 `tests/fm-secondmate-harness.test.sh:857` - Default Codex secondmate commands now contain `codex -c &#39;service_tier=&#34;default&#34;&#39; --dangerously...`, but this registered test still requires the contiguous substring `codex --dangerously...`. The suite will deterministically fail. Update the expectation to include the required service-tier override while retaining the existing model and effort checks.

🔧 Fix: Propagate remote fast-tier and refresh Codex expectations
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-spawn-dispatch-profile.test.sh`
- `bash tests/fm-remote-secondmate-lifecycle-e2e.test.sh`
- `bash tests/fm-secondmate-harness.test.sh`
- <code>`codex --version` and `codex --help`</code>
- `codex -c 'service_tier="default"' --strict-config --version`
- <code>`codex -c &#39;service_tier=&#34;default&#34;&#39; debug models --bundled` with focused `jq` extraction of the `priority` / `Fast` tier</code>
- <code>End-to-end fake-tmux launches for default Codex, Codex `--fast-tier`, and unchanged Claude, captured in the evidence transcript</code>
- <code>Reviewed the official OpenAI Codex CLI and configuration references for repeatable `-c key=value` overrides and `service_tier` semantics</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Fix empty traceparent initialization
1 warning still open:
- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
