### PR TITLE
fix(supervision): stop turn-end guard from raising false blind alarms under away mode

### DIFF
--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -81,33 +81,17 @@ daemon_lock_owner() {
   printf '%s\n' "$FM_AFK_LOCK"
 }
 
-daemon_pid_matches() {
-  local pid=$1 owner=$2 identity current command
-  identity=$(cat "$owner/pid-identity" 2>/dev/null || true)
-  if [ -n "$identity" ]; then
-    current=$(fm_pid_identity "$pid") || return 1
-    [ "$current" = "$identity" ]
-    return
-  fi
-  command=$(ps -p "$pid" -o command= 2>/dev/null || true)
-  case "$command" in
-    *"$FM_AFK_DAEMON"*|*"fm-supervise-daemon.sh"*) return 0 ;;
-  esac
-  return 1
-}
-
 daemon_lock_pid() {
   local owner
   owner=$(daemon_lock_owner) || return 1
   cat "$owner/pid" 2>/dev/null || true
 }
 
+# "A live away daemon holds this home" has exactly one definition, in
+# bin/fm-wake-lib.sh, shared with the supervision guards that must agree with this
+# script about whether away supervision is running.
 daemon_lock_held_by_live_daemon() {
-  local owner pid
-  owner=$(daemon_lock_owner) || return 1
-  pid=$(cat "$owner/pid" 2>/dev/null || true)
-  fm_pid_alive "$pid" || return 1
-  daemon_pid_matches "$pid" "$owner"
+  fm_away_daemon_lock_alive "$FM_AFK_STATE"
 }
 
 fm_afk_flag_write() {  # <state-dir>

--- a/bin/fm-guard.sh
+++ b/bin/fm-guard.sh
@@ -10,16 +10,18 @@
 # healthy, prints a loud, clearly delimited banner so the agent cannot skim past
 # it in the tool output of whatever it was doing - the one channel every harness
 # has. Supervision health is MODEL-AWARE (fm_watcher_supervision_verdict in
-# bin/fm-wake-lib.sh): under the Claude Stop auto-arm model the watcher runs only
-# between turns, so mid-turn a fresh beacon with no live watcher is healthy and
-# only a stale beacon (beyond FM_GUARD_GRACE) is a genuine lapse; under the Pi
-# extension model the extension tears the watcher down and respawns it on every
-# actionable wake, so a fresh beacon with a genuinely unheld lock is healthy
-# while that live Pi session provably owns continuity; any held but unhealthy
-# lock is down; under every
+# bin/fm-wake-lib.sh): while away mode is active its daemon owns supervision for
+# every harness and runs the watcher one cycle at a time, so the daemon's own
+# liveness and tick are the health signal and no long-lived watcher is expected;
+# under the Claude Stop auto-arm model the watcher runs only between turns, so
+# mid-turn a fresh beacon with no live watcher is healthy and only a stale beacon
+# (beyond FM_GUARD_GRACE) is a genuine lapse; under the Pi extension model the
+# extension tears the watcher down and respawns it on every actionable wake, so a
+# fresh beacon with a genuinely unheld lock is healthy while that live Pi session
+# provably owns continuity; any held but unhealthy lock is down; under every
 # persistent-watcher harness a live identity-matched watcher with a fresh beacon
-# is required. The banner names the true failing condition (a missing live
-# watcher process vs a genuinely stale beacon). The full banner is emitted once
+# is required. The banner names the true failing condition (a stopped away
+# daemon vs a missing live watcher process vs a genuinely stale beacon). The full banner is emitted once
 # per distinct down-episode in this FM_HOME (keyed to the failing condition, not
 # the beacon mtime, which a healthy between-turns watcher advances every poll);
 # later guarded commands in the same episode print a one-line reminder instead.
@@ -198,7 +200,11 @@ if [ "$watcher_healthy" = false ]; then
     {
       printf '●%s\n' "$rule"
       printf '●  WATCHER DOWN - SUPERVISION IS OFF\n'
-      if [ "$watcher_down_reason" = no-watcher ]; then
+      if [ "$watcher_down_reason" = away-daemon-down ]; then
+        away_tick=$(fm_away_daemon_tick_age "$STATE")
+        [ "$away_tick" -lt 999999 ] && away_tick="${away_tick}s ago" || away_tick=never
+        watcher_cause=$(printf 'away mode owns supervision but its daemon is not running or has stopped ticking (last supervision tick: %s)' "$away_tick")
+      elif [ "$watcher_down_reason" = no-watcher ]; then
         watcher_cause=$(printf 'no live watcher process holds this home lock (last beat: %s)' "$beacon_desc")
       else
         watcher_cause=$(printf 'no watcher has a fresh beacon (last beat: %s, grace %ss)' "$beacon_desc" "$GRACE")

--- a/bin/fm-supervision-lib.sh
+++ b/bin/fm-supervision-lib.sh
@@ -6,10 +6,12 @@
 # work (a state/<id>.meta exists) or an X-mode relay poll
 # (state/x-watch.check.sh), and whether its watcher has a fresh liveness beacon
 # (state/.last-watcher-beat, touched every poll cycle, within the grace window).
-# bin/fm-turnend-guard.sh uses the PID-strict fm_watcher_healthy from
-# bin/fm-wake-lib.sh for its block decision. bin/fm-guard.sh uses the model-aware
-# fm_watcher_supervision_verdict (also in bin/fm-wake-lib.sh), which owns what a
-# live watcher process means per supervision model. The status fields here retain
+# bin/fm-turnend-guard.sh uses fm_turnend_supervision_healthy from
+# bin/fm-wake-lib.sh for its block decision (the PID-strict fm_watcher_healthy
+# everywhere except away mode, where the away daemon is the supervisor).
+# bin/fm-guard.sh uses the model-aware fm_watcher_supervision_verdict (also in
+# bin/fm-wake-lib.sh), which owns what a live watcher process means per
+# supervision model. The status fields here retain
 # the beacon-age details used in their messages.
 
 # Portable mtime; Linux stat lacks -f, macOS stat lacks -c.

--- a/bin/fm-turnend-guard.sh
+++ b/bin/fm-turnend-guard.sh
@@ -42,6 +42,15 @@
 # never a wedged, un-endable session - while still nagging again on a later turn
 # if the problem persists.
 #
+# Away mode: while state/.afk exists the away daemon (bin/fm-supervise-daemon.sh)
+# owns supervision for EVERY primary harness and runs the watcher as its own child
+# one cycle at a time, so between cycles this home has no watcher process by
+# design and the PID-strict check would call a perfectly supervised fleet blind.
+# The predicate is model-aware (fm_turnend_supervision_healthy in
+# bin/fm-wake-lib.sh): under away mode it requires a live identity-matched daemon
+# with a turning loop instead, so a dead, stale-pid or wedged daemon still blocks
+# with a banner naming the daemon. Outside away mode nothing here changes.
+#
 # Loop-guard, --claude mode (Stop-owned auto-arm cooperation): Claude Code
 # marks EVERY stop after ANY stop-hook-driven continuation stop_hook_active=true,
 # including turns started by the asyncRewake auto-arm, so the one-shot allow
@@ -158,37 +167,56 @@ budget_reset() {
   fm_lock_release "$BUDGET_LOCK"
 }
 
+# Away mode replaces the primary harness's own supervision: the away daemon owns
+# the watcher and runs it one cycle at a time, so between cycles this home has no
+# watcher process BY DESIGN. fm_turnend_supervision_healthy asks the daemon
+# question there and the unchanged PID-strict question everywhere else.
+AWAY_MODE=0
+fm_supervision_away "$STATE" && AWAY_MODE=1
+
 fm_supervision_status "$STATE" "$GRACE"
 if [ "$FM_SUP_NEEDED" = false ]; then
   [ -e "$FAILURE_NOTICE" ] || budget_reset
   exit 0
 fi
-if fm_watcher_healthy "$STATE" "$WATCH" "$GRACE" "$FM_HOME"; then
+if fm_turnend_supervision_healthy "$STATE" "$WATCH" "$GRACE" "$FM_HOME"; then
   [ "$CLAUDE_MODE" -eq 1 ] || exit 0
   fm_failure_episode_reset "$STATE" && exit 0
   exit 2
 fi
 
 block_stop() {
-  local afk x_mode reason rule
-  afk=0
-  [ -e "$STATE/.afk" ] && afk=1
+  local afk x_mode reason rule cause tick
+  afk=$AWAY_MODE
   x_mode=0
   [ -f "$CONFIG/x-mode.env" ] && x_mode=1
   reason=$("$SCRIPT_DIR/fm-supervision-instructions.sh" --afk "$afk" --x-mode "$x_mode" --repair-line 2>/dev/null \
     || printf '%s\n' 'tasks in flight, no live watcher - repair missing watcher supervision according to the session-start operating block before ending the turn')
+  # Under away mode the missing thing is the daemon, never a watcher to arm: name
+  # what actually stopped, and which of its two failure shapes this is.
+  if [ "$afk" -eq 1 ]; then
+    tick=$(fm_away_daemon_tick_age "$STATE")
+    [ "$tick" -lt 999999 ] && tick="${tick}s ago" || tick=never
+    if fm_away_daemon_lock_alive "$STATE"; then
+      cause=$(printf 'the away-mode supervision daemon is alive but has stopped ticking (last supervision tick: %s, grace %ss)' "$tick" "$FM_AWAY_TICK_GRACE")
+    else
+      cause=$(printf 'no live away-mode supervision daemon holds this home (last supervision tick: %s)' "$tick")
+    fi
+  else
+    cause=$(printf 'no live watcher holds this home lock (last beat: %s)' "$FM_SUP_BEACON_DESC")
+  fi
   rule='━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
   {
     printf '●%s\n' "$rule"
     printf '●  TURN WOULD END BLIND - SUPERVISION IS OFF\n'
     if [ "$FM_SUP_IN_FLIGHT" -gt 0 ]; then
-      printf '●  %s task(s) in flight, but no live watcher holds this home lock (last beat: %s).\n' "$FM_SUP_IN_FLIGHT" "$FM_SUP_BEACON_DESC"
+      printf '●  %s task(s) in flight, but %s.\n' "$FM_SUP_IN_FLIGHT" "$cause"
     elif [ "$FM_SUP_SOURCES" -gt 0 ]; then
-      printf '●  %s process-event source(s) registered, but no live watcher holds this home lock (last beat: %s).\n' "$FM_SUP_SOURCES" "$FM_SUP_BEACON_DESC"
+      printf '●  %s process-event source(s) registered, but %s.\n' "$FM_SUP_SOURCES" "$cause"
     else
-      printf '●  X-mode relay polling needs supervision, but no live watcher holds this home lock (last beat: %s).\n' "$FM_SUP_BEACON_DESC"
+      printf '●  X-mode relay polling needs supervision, but %s.\n' "$cause"
     fi
-    if [ "$CLAUDE_MODE" -eq 1 ]; then
+    if [ "$CLAUDE_MODE" -eq 1 ] && [ "$afk" -eq 0 ]; then
       printf '●  The Stop-owned auto-arm did not claim this home either, so recovery is NOT already under way.\n'
     fi
     printf '●  %s\n' "$reason"
@@ -197,7 +225,10 @@ block_stop() {
   exit 2
 }
 
-if [ "$CLAUDE_MODE" -eq 0 ]; then
+# The Stop-owned auto-arm stands down entirely while state/.afk exists
+# (bin/fm-claude-stop-autoarm.sh), so under away mode there is no claim to wait
+# for and no bounded continuation worth spending: block on the daemon directly.
+if [ "$CLAUDE_MODE" -eq 0 ] || [ "$AWAY_MODE" -eq 1 ]; then
   block_stop
 fi
 

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -132,14 +132,22 @@ fm_watcher_healthy() {
 # identity-matched watcher PROCESS holds this home's lock with a fresh beacon. The
 # arm layer (bin/fm-watch-arm.sh, bin/fm-claude-stop-autoarm.sh) needs exactly
 # that - it decides whether to start, attach to, or replace a real watcher
-# process, so a leftover beacon must never satisfy it. bin/fm-turnend-guard.sh
-# also keeps this strict check because it fires at the turn boundary where the
-# auto-arm brings a fresh watcher up. The pull warning (bin/fm-guard.sh) fires
-# mid-turn, where the auto-arm model runs no watcher at all, so it wants a
-# different, model-aware question:
+# process, so a leftover beacon must never satisfy it. Outside away mode
+# bin/fm-turnend-guard.sh also keeps this strict check, because it fires at the
+# turn boundary where the auto-arm brings a fresh watcher up. The pull warning
+# (bin/fm-guard.sh) fires mid-turn, where the auto-arm model runs no watcher at
+# all, so it wants a different, model-aware question:
 
-# fm_supervision_model
-# Print the supervision model of this home's PRIMARY harness:
+# fm_supervision_model [state]
+# Print the supervision model in force for this home:
+#   away        state/.afk exists: the away-mode daemon
+#               (bin/fm-supervise-daemon.sh) owns supervision for EVERY primary
+#               harness, and runs the watcher as its own child that exits on each
+#               wake so the daemon can handle it. Between those cycles the
+#               singleton lock is genuinely unheld BY DESIGN, so no watcher
+#               process is the healthy state and the daemon itself is what must be
+#               tested (fm_away_daemon_healthy). Checked before the harness because
+#               away mode replaces the harness's own supervision, whatever it is.
 #   autoarm     Claude's Stop-hook auto-arm and Cursor's stop-hook park: the
 #               watcher is armed at each turn end and exits on its wake, so it
 #               runs only BETWEEN turns. Mid-turn a fresh beacon with no live
@@ -152,11 +160,19 @@ fm_watcher_healthy() {
 #   persistent  every other harness (codex foreground checkpoint, opencode/grok
 #               background arm, tmux, unknown): the watcher runs as a tracked live
 #               process, so a live identity-matched pid is the real liveness signal.
-# FM_SUPERVISION_MODEL overrides detection (tests, and callers that already know
-# the harness). Otherwise bin/fm-harness.sh is the single detection owner, so this
-# stays consistent with the harness-specific repair line the guards already emit.
+# state defaults to $STATE. FM_SUPERVISION_MODEL overrides HARNESS detection (tests,
+# and callers that already know the harness, such as the pinned model bin/fm-spawn.sh
+# bakes into a secondmate launch); otherwise bin/fm-harness.sh is the single
+# detection owner, so this stays consistent with the harness-specific repair line
+# the guards already emit. Away mode outranks that override because it is a runtime
+# state of the home rather than a harness fact: knowing the harness does not tell a
+# caller whether the away daemon has taken supervision over.
 fm_supervision_model() {
-  local harness
+  local state=${1:-$STATE} harness
+  if fm_supervision_away "$state"; then
+    printf 'away\n'
+    return 0
+  fi
   case "${FM_SUPERVISION_MODEL:-}" in
     autoarm|extension|persistent) printf '%s\n' "$FM_SUPERVISION_MODEL"; return 0 ;;
   esac
@@ -166,6 +182,115 @@ fm_supervision_model() {
     pi|pi-signed) printf 'extension\n' ;;
     *) printf 'persistent\n' ;;
   esac
+}
+
+# fm_supervision_away [state]
+# True when the away model is in force for this home. This is the ONE test for it:
+# fm_supervision_model reports it as the model, and the hot turn-end path calls it
+# directly so the non-away path never pays a harness-detection fork. Only an
+# explicit FM_SUPERVISION_MODEL=away forces it on; a pinned harness model never
+# forces it off.
+fm_supervision_away() {
+  local state=${1:-$STATE}
+  [ "${FM_SUPERVISION_MODEL:-}" = away ] && return 0
+  [ -e "$state/.afk" ]
+}
+
+# Away-mode supervision evidence. Under the away model the question "is this home
+# supervised" is answered by the DAEMON, not by a watcher process: a live daemon
+# plus a turning loop, i.e. exactly the two ways away supervision can stop (the
+# daemon exited, or it is wedged and no longer ticking).
+#
+# FM_AWAY_TICK_GRACE is how stale that loop may get before away supervision counts
+# as stopped, taken from the daemon's own cadence rather than guessed: its main
+# loop sleeps 1s per pass and runs housekeeping every FM_HOUSEKEEPING_TICK seconds
+# (default 15), and the longest quiet stretch a HEALTHY loop can take is the
+# crash-spin backoff (FM_CRASH_BACKOFF, default 60) plus the following
+# housekeeping gate, about 75s. 180s clears that worst case with margin for one
+# slow wake-handling pass, while still catching a stopped daemon well inside the
+# 300s watcher-beacon grace, so away supervision is held to a STRICTER freshness
+# bound than an ordinary watcher. A home that raises FM_HOUSEKEEPING_TICK or
+# FM_CRASH_BACKOFF far above their defaults must raise this with them; the failure
+# direction is a loud false alarm, never silence.
+FM_AWAY_TICK_GRACE="${FM_AWAY_TICK_GRACE:-180}"
+
+# fm_away_daemon_lock_alive <state>
+# True when this home's away-daemon lock is held by a LIVE, identity-matched
+# bin/fm-supervise-daemon.sh process. Identity comes from the pid-identity the
+# daemon writes into its own lock at startup, so a recycled pid is a mismatch. A
+# lock written by an older daemon that recorded no identity falls back to matching
+# the process command. Single owner of "a live away daemon holds this home":
+# bin/fm-afk-start.sh's already-running check calls this too.
+fm_away_daemon_lock_alive() {
+  local state=$1 lock pid identity current command
+  lock="$state/.supervise-daemon.lock"
+  pid=$(cat "$lock/pid" 2>/dev/null || true)
+  fm_pid_alive "$pid" || return 1
+  identity=$(cat "$lock/pid-identity" 2>/dev/null || true)
+  if [ -n "$identity" ]; then
+    current=$(fm_pid_identity "$pid") || return 1
+    [ "$current" = "$identity" ]
+    return
+  fi
+  command=$(ps -p "$pid" -o command= 2>/dev/null || true)
+  case "$command" in
+    *fm-supervise-daemon.sh*) return 0 ;;
+  esac
+  return 1
+}
+
+# fm_away_daemon_tick_age <state>
+# Seconds since the freshest evidence that the away daemon's loop is turning:
+#   state/.subsuper-last-housekeep  its own housekeeping tick
+#   state/.last-watcher-beat        the beat of the watcher child it runs
+#   state/.supervise-daemon.pid     its startup stamp, which covers the window
+#                                   before a just-started daemon's first tick
+# 999999 when none of them is readable. The FRESHEST of the three is the correct
+# reading: the watcher is deliberately down while the daemon handles a wake, and
+# housekeeping is skipped while the daemon backs off, so requiring them together
+# would re-create the very false alarm this exists to prevent.
+fm_away_daemon_tick_age() {
+  local state=$1 best=999999 path age
+  for path in \
+    "$state/.subsuper-last-housekeep" \
+    "$state/.last-watcher-beat" \
+    "$state/.supervise-daemon.pid"
+  do
+    [ -e "$path" ] || continue
+    age=$(fm_path_age "$path")
+    case "$age" in
+      ''|*[!0-9]*) continue ;;
+    esac
+    [ "$age" -lt "$best" ] && best=$age
+  done
+  printf '%s\n' "$best"
+}
+
+# fm_away_daemon_healthy <state> [tick-grace]
+# True when away supervision is genuinely running: a live identity-matched daemon
+# AND a tick inside the grace window. A stale pid file, a pid whose process is
+# gone, a recycled pid, or a daemon that stopped ticking all stay false, so a dead
+# away daemon still raises every alarm a missing watcher would.
+fm_away_daemon_healthy() {
+  local state=$1 grace=${2:-$FM_AWAY_TICK_GRACE} age
+  fm_away_daemon_lock_alive "$state" || return 1
+  age=$(fm_away_daemon_tick_age "$state")
+  [ "$age" -lt "$grace" ]
+}
+
+# fm_turnend_supervision_healthy <state> <watch-path> [grace] [home]
+# The turn-end guard's model-aware "is this home supervised right now" test. Away
+# mode is the only model whose healthy shape differs AT THE TURN BOUNDARY: the
+# auto-arm and Pi extension models both bring a real watcher up as the turn ends,
+# so the PID-strict primitive stays exactly right for them, while away mode
+# deliberately runs no long-lived watcher at all.
+fm_turnend_supervision_healthy() {
+  local state=$1 watch=$2 grace=${3:-${FM_GUARD_GRACE:-300}} home=${4:-$FM_HOME}
+  if fm_supervision_away "$state"; then
+    fm_away_daemon_healthy "$state"
+    return
+  fi
+  fm_watcher_healthy "$state" "$watch" "$grace" "$home"
 }
 
 # Pi primary supervision evidence. The Pi extensions record, in their state
@@ -236,6 +361,13 @@ fm_pi_extension_owns_supervision() {
 #                                             the lock (the beacon is still fresh)
 #                              stale-beacon - the beacon is stale beyond grace or
 #                                             absent (a genuine supervision lapse)
+#                              away-daemon-down - away mode owns supervision but
+#                                             its daemon is not running or has
+#                                             stopped ticking
+# away: the away daemon owns supervision, so the watcher lock and the beacon say
+# nothing about health; only a live identity-matched daemon with a turning loop
+# (fm_away_daemon_healthy) is healthy, and this is checked first because away mode
+# replaces whatever the primary harness would otherwise do.
 # autoarm: a fresh beacon within grace is healthy even with no live watcher,
 # because the watcher only runs between turns; only a stale beacon is a lapse.
 # extension: a live identity-matched watcher is the ordinary healthy state, but a
@@ -264,7 +396,17 @@ fm_watcher_supervision_verdict() {
     ''|*[!0-9]*) ;;
     *) [ "$age" -lt "$grace" ] && fresh=true ;;
   esac
-  model=$(fm_supervision_model)
+  if fm_supervision_away "$state"; then
+    if fm_away_daemon_healthy "$state"; then
+      # shellcheck disable=SC2034 # Read by callers after the function returns.
+      FM_WATCHER_VERDICT_OK=true
+    else
+      # shellcheck disable=SC2034 # Read by callers after the function returns.
+      FM_WATCHER_VERDICT_REASON=away-daemon-down
+    fi
+    return 0
+  fi
+  model=$(fm_supervision_model "$state")
   if [ "$model" = autoarm ]; then
     [ "$fresh" = true ] && FM_WATCHER_VERDICT_OK=true
     return 0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -568,6 +568,7 @@ FMX_FOLLOWUP_MAX_COUNT=3   # local cap on Relay completion follow-ups per linked
 FM_PF_RETRY_BACKOFF_SECS=900   # seconds before the next attempt after a retryable promised-public-reply delivery error
 FM_LOCK_STALE_AFTER=2   # seconds before dead-pid lock records can be reclaimed; mid-acquire locks keep at least 2s grace
 FM_GUARD_GRACE=300      # seconds before guard warnings, arm health checks, and the primary turn-end guard treat a watcher beacon as stale
+FM_AWAY_TICK_GRACE=180  # seconds the away-mode daemon's own tick may age before the supervision guards treat away supervision as stopped; derived from the daemon's housekeeping cadence and crash backoff, so raise it with FM_HOUSEKEEPING_TICK or FM_CRASH_BACKOFF
 FM_CLAUDE_AUTOARM_ATTEMPTS=2   # bounded Stop-owned arm attempts per Claude auto-arm cycle; accepted values are 1, 2, or 3
 FM_CLAUDE_AUTOARM_SYNC_WAIT_MS=800   # milliseconds the --claude turn-end guard waits for watcher health, a role-verified Stop auto-arm claim, or a fresh epoch before deciding recovery ownership or failure progression
 FM_CLAUDE_AUTOARM_EPOCH_FRESH=15   # seconds a recorded auto-arm outcome remains eligible for the current event epoch's recovery or failure decision

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -14,7 +14,7 @@ Do not infer this guard's scope, loop safety, or compatibility tradeoffs for tho
 `bin/fm-guard.sh` is a pull-based warning that runs only when another supervision command invokes it.
 The turn-end guard closes the remaining gap at the primary's own turn boundary.
 When work, a process-event source, or Relay polling needs supervision at that boundary and no identity-matched watcher has a fresh beacon, the harness integration must either block the turn end or force one bounded follow-up that uses the recovery instruction from the emitted session-start protocol.
-The mid-turn pull warning uses the model-aware supervision verdict described below, while the turn-end guard keeps the PID-strict watcher predicate.
+Both guards use the model-aware supervision vocabulary described below; outside away mode the turn-end guard's model still resolves to the PID-strict watcher predicate.
 The guard remains a backstop; [`watcher-continuity.md`](watcher-continuity.md) owns normal continuity.
 
 ## Guard predicates
@@ -30,9 +30,24 @@ For an in-scope primary, the guard counts in-flight work from `state/*.meta`.
 Registered `state/procevent/*.source` records also require supervision even though they have no task metadata.
 The default cross-harness mode exits silently with no supervision need.
 Every mode treats `state/x-watch.check.sh` as supervision need, so Relay polling remains guarded without an in-flight task.
-Otherwise it calls `fm_watcher_healthy <state-dir> <watch-path> [grace-seconds] [home]` from `bin/fm-wake-lib.sh`, the same PID-strict identity-matched lock and fresh-beacon check used by `bin/fm-watch-arm.sh`: a stale beacon blocks even when a watcher pid is live, and a fresh leftover beacon blocks when the lock is missing, dead, or identity-mismatched.
+Otherwise it calls `fm_turnend_supervision_healthy <state-dir> <watch-path> [grace-seconds] [home]` from `bin/fm-wake-lib.sh`.
+Outside away mode that resolves to `fm_watcher_healthy`, the same PID-strict identity-matched lock and fresh-beacon check used by `bin/fm-watch-arm.sh`: a stale beacon blocks even when a watcher pid is live, and a fresh leftover beacon blocks when the lock is missing, dead, or identity-mismatched.
 The turn-end guard needs that strict check because it fires at the turn boundary, where the auto-arm is bringing a fresh watcher up for the upcoming idle period, and it cooperates with that arm rather than trusting a beacon left by the cycle that just ended.
+
+Away mode is the one model whose healthy shape differs at that boundary.
+While `state/.afk` exists the away daemon owns supervision for every primary harness and runs the watcher as its own child, which exits on each wake so the daemon can handle it and is restarted afterwards, so between cycles the singleton lock is genuinely unheld by design and the PID-strict check would report a perfectly supervised fleet as blind.
+Under that model the guard tests the daemon instead, through `fm_away_daemon_healthy`: this home's `state/.supervise-daemon.lock` must be held by a live process whose identity matches the `pid-identity` the daemon recorded there at startup, so a stale pid file or a recycled pid is a mismatch, and the daemon's loop must still be turning.
+A lock written by an older daemon that recorded no identity falls back to matching the process command.
+The turning-loop evidence is the freshest of the daemon's own housekeeping tick (`state/.subsuper-last-housekeep`), the beat of the watcher child it runs (`state/.last-watcher-beat`), and its startup stamp (`state/.supervise-daemon.pid`), which covers the window before a just-started daemon's first tick.
+Taking the freshest of the three is what keeps the check quiet through a normal cycle, because the watcher is deliberately down while a wake is handled and housekeeping is skipped while the daemon backs off.
+`FM_AWAY_TICK_GRACE` bounds that freshness and defaults to 180 seconds, taken from the daemon's own cadence rather than guessed: its loop runs housekeeping every `FM_HOUSEKEEPING_TICK` seconds (default 15) and its longest healthy quiet stretch is the crash-spin backoff `FM_CRASH_BACKOFF` (default 60) plus the following housekeeping gate, about 75 seconds.
+A home that raises either daemon tunable far above its default must raise `FM_AWAY_TICK_GRACE` with it; the failure direction is a loud false alarm, never silence.
+A dead, exited, recycled-pid, or wedged daemon therefore still blocks the turn end, with a banner that names the daemon and distinguishes "no live daemon" from "alive but stopped ticking" instead of telling the session to arm a watcher.
+The Stop-owned auto-arm stands down entirely while `state/.afk` exists, so under away mode `--claude` blocks directly rather than waiting for a claim that can never come or spending a bounded continuation.
+`bin/fm-afk-start.sh`'s already-running check calls the same `fm_away_daemon_lock_alive`, so entering away mode and guarding it cannot disagree about whether a daemon is live.
+Away mode outranks an explicit `FM_SUPERVISION_MODEL` harness pin, because it is a runtime state of the home rather than a harness fact, and `bin/fm-spawn.sh` bakes such a pin into every secondmate launch.
 `bin/fm-guard.sh`, the pull warning, instead uses the model-aware `fm_watcher_supervision_verdict` from the same library, because it fires mid-turn when the auto-arm model runs no watcher at all.
+It answers the away model the same way the turn-end guard does, because away mode replaces whatever the primary harness would otherwise run.
 Under the Claude Stop auto-arm model a beacon fresh within grace is healthy even with no live watcher process, and only a beacon stale beyond grace (or absent) alarms.
 Under the Pi extension model a live identity-matched watcher is the ordinary healthy state, but a genuinely unheld lock with a beacon fresh within grace is also healthy while a live Pi session provably owns continuity, because `.pi/extensions/fm-primary-pi-watch.ts` tears the watcher down on every actionable wake and spawns the replacement itself.
 A lock is genuinely unheld only when the lock directory or its symlinked owner directory is absent, or when the existing lock records no pid at all.
@@ -41,10 +56,10 @@ That ownership proof is `fm_pi_extension_owns_supervision` in `bin/fm-wake-lib.s
 Requiring the turn-end guard extension as well as the watch extension is deliberate, because a home without that structural backstop has no benign hand-off to tolerate.
 Without that proof an unheld lock alarms exactly as it did before, so an unloaded, version-drifted, or exited Pi session is loud immediately, and a cycle the extension never restores is loud once the beacon passes grace.
 Under every persistent-watcher harness a live identity-matched watcher with a fresh beacon is still required, so the pull guard keeps the same strict semantics there.
-Its banner names the true failing condition, either a missing live watcher process or a genuinely stale beacon with its real age, and keys the once-per-episode dedup on that condition rather than the beacon mtime.
+Its banner names the true failing condition, either a stopped away daemon, a missing live watcher process, or a genuinely stale beacon with its real age, and keys the once-per-episode dedup on that condition rather than the beacon mtime.
 
 `FM_STATE_OVERRIDE` wins over `FM_HOME/state`, and `FM_HOME` wins over repository-root `state/`.
-`FM_GUARD_GRACE` controls beacon freshness and defaults to 300 seconds.
+`FM_GUARD_GRACE` controls beacon freshness and defaults to 300 seconds, and `FM_AWAY_TICK_GRACE` controls away-daemon tick freshness and defaults to 180 seconds.
 If `jq` is missing or hook stdin is empty, the guard exits 0 because it cannot safely read loop-guard fields.
 
 ## Harness integrations
@@ -146,8 +161,8 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 
 ## Regression coverage
 
-`tests/fm-turnend-guard.test.sh` covers the predicate, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the live-lock and fresh-beacon guard predicate, the cooperative `--claude` claim wait, monotonic failed-epoch progression, bounded attended fail-open, post-alarm continuation suppression, positive recovery reset, Pi logical-run latching, missing-`jq` behavior, all five primary registrations, Grok native and legacy selection, typed field precedence, malformed input, and exactly-one-path safety.
-`tests/fm-guard-stale-banner.test.sh` covers the pull-guard predicate, including the persistent-model fresh-leftover-beacon negative control, the auto-arm model's healthy fresh-beacon-without-a-watcher case and stale-beacon alarm, and the extension model's live-watcher path, ownership-qualified fresh hand-off, held-lock failures, independently broken ownership signals, stale-beacon alarm, queued-wake warning, and Pi and pi-signed harness routing.
+`tests/fm-turnend-guard.test.sh` covers the predicate, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the live-lock and fresh-beacon guard predicate, the away model in both directions (a live ticking daemon with no watcher stays silent in default and `--claude` mode, while a dead pid, a recycled pid, and a daemon that stopped ticking each still block with daemon-specific wording, and a live daemon without `state/.afk` changes nothing), the cooperative `--claude` claim wait, monotonic failed-epoch progression, bounded attended fail-open, post-alarm continuation suppression, positive recovery reset, Pi logical-run latching, missing-`jq` behavior, all five primary registrations, Grok native and legacy selection, typed field precedence, malformed input, and exactly-one-path safety.
+`tests/fm-guard-stale-banner.test.sh` covers the pull-guard predicate, including the away model's live-daemon healthy case, its dead-daemon alarm wording, and its precedence over a pinned harness model, the persistent-model fresh-leftover-beacon negative control, the auto-arm model's healthy fresh-beacon-without-a-watcher case and stale-beacon alarm, and the extension model's live-watcher path, ownership-qualified fresh hand-off, held-lock failures, independently broken ownership signals, stale-beacon alarm, queued-wake warning, and Pi and pi-signed harness routing.
 It also covers true-reason banner wording and reason-keyed episode dedup surviving a beacon mtime change.
 `tests/fm-cursor-primary.test.sh` covers the Cursor park end to end over real processes with no harness installed: each tracked Claude-shaped entrypoint standing down on a Cursor payload, both follow-up sources, the bounded repair nag and its reset, the nested loop bounds, supersession, away-mode and lock-ownership inertness, child-worktree exclusion, and that the adapter never exits 2.
 `FM_CURSOR_PRIMARY_LIVE_E2E=1 tests/fm-cursor-primary-live-e2e.test.sh` is the opt-in guard that proves the same behavior against the installed cursor-agent and fails naming the harness and version.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -387,6 +387,36 @@ Observed output, before and after the model correction, then with the recorded P
 ●  1 task(s) in flight, but no live watcher process holds this home lock (last beat: 0s ago).
 ```
 
+The away-model turn-end correction (`bin/fm-turnend-guard.sh` no longer reports a false blind turn end while away mode is active, where the away daemon owns supervision and runs the watcher one cycle at a time) was verified on 2026-08-18 against a real `bin/fm-supervise-daemon.sh` in a throwaway `FM_HOME` with its own tmux socket, never the live home.
+The fixture ran one in-flight task with a status line appended every 4 seconds so the daemon handled wakes throughout, and sampled `bin/fm-turnend-guard.sh --claude` 200 times at 0.4-second intervals.
+Before the correction, 3 of 200 samples blocked with the blind banner while the daemon was alive and its housekeeping tick was 1 to 4 seconds old; every one of those samples fell in a window where the watcher child had exited between cycles.
+After the correction the same construction blocked 0 of 200 times, with the watcher lock genuinely absent in 10 of those samples, and the two genuine-failure directions still blocked: the daemon killed with `SIGKILL` (leaving its pid file and a 7-second-old tick behind) and the daemon left alive but stopped with `SIGSTOP` and its tick evidence aged out.
+
+```text
+before: === blind=3 quiet=197 (daemon alive: yes) ===
+after:  A: blocked=0 quiet=200  (watcher-lock genuinely absent in 10 of 200 samples)
+after, daemon SIGKILLed:
+●  1 task(s) in flight, but no live away-mode supervision daemon holds this home (last supervision tick: 7s ago).
+after, daemon alive but wedged:
+●  1 task(s) in flight, but the away-mode supervision daemon is alive but has stopped ticking (last supervision tick: 3601s ago, grace 180s).
+```
+
+The portable suites are the enforcing evidence, since the predicate reads only state files and process liveness.
+
+```sh
+bin/fm-lint.sh
+bin/fm-doc-audience-check.sh
+bin/fm-test-run.sh tests/fm-guard-stale-banner.test.sh tests/fm-turnend-guard.test.sh tests/fm-claude-stop-autoarm.test.sh tests/fm-afk-launch.test.sh tests/fm-afk-return.test.sh
+```
+
+Observed output:
+
+```text
+fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
+fm-doc-audience-check: ok surfaces=68 local_links=252
+FM_TEST_SUMMARY total=5 failed=0 skipped_gate=0 duration_ms=174265
+```
+
 The broader relevant regression pass was rerun on 2026-08-02 without live-home or daemon mutation.
 
 ```sh

--- a/tests/fm-guard-stale-banner.test.sh
+++ b/tests/fm-guard-stale-banner.test.sh
@@ -383,6 +383,87 @@ test_autoarm_stale_episode_is_stable() {
   pass "fm-guard stale banner: auto-arm stale episode stays one episode across calls"
 }
 
+# The away model: while state/.afk exists the away daemon owns supervision for
+# every harness and runs the watcher one cycle at a time, so the daemon's own
+# liveness and tick answer this question and no long-lived watcher is expected.
+# The harness model is deliberately left unpinned here: away mode must win over
+# whatever primary harness the host runner looks like.
+run_guard_case_away() {
+  local dir=$1
+  FM_ROOT_OVERRIDE="$(case_root "$dir")" \
+    FM_HOME="$(case_home "$dir")" \
+    FM_GUARD_GRACE=999 \
+    "$ROOT/bin/fm-guard.sh" 2>&1
+}
+
+# Record a live, identity-matched away daemon and a fresh tick for it.
+record_live_away_daemon() {
+  local dir=$1 pid=$2 home identity
+  home=$(case_home "$dir")
+  identity=$(FM_STATE_OVERRIDE="$home/state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$ROOT/bin/fm-wake-lib.sh" "$pid") || return 1
+  mkdir -p "$home/state/.supervise-daemon.lock"
+  printf '%s\n' "$pid" > "$home/state/.supervise-daemon.lock/pid"
+  printf '%s\n' "$identity" > "$home/state/.supervise-daemon.lock/pid-identity"
+  printf '%s\n' "$pid" > "$home/state/.supervise-daemon.pid"
+  touch "$home/state/.subsuper-last-housekeep"
+}
+
+test_away_model_live_daemon_without_watcher_is_healthy() {
+  local dir out pid
+  dir=$(make_guard_case away-live-daemon)
+  : > "$(case_home "$dir")/state/.afk"
+  sleep 60 &
+  pid=$!
+  record_live_away_daemon "$dir" "$pid" || {
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    fail "could not record the live away daemon"
+  }
+  out=$(run_guard_case_away "$dir")
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  [ -z "$out" ] \
+    || fail "away mode with a live ticking daemon and no watcher must stay silent, got: $out"
+  pass "fm-guard stale banner: away mode with a live daemon and no watcher is healthy"
+}
+
+test_away_model_outranks_a_pinned_harness_model() {
+  local dir out home
+  dir=$(make_guard_case away-outranks-pin)
+  home=$(case_home "$dir")
+  : > "$home/state/.afk"
+  touch "$home/state/.last-watcher-beat"
+  touch "$home/state/.subsuper-last-housekeep"
+  # bin/fm-spawn.sh bakes a pinned harness model into every secondmate launch, so
+  # away mode must not be suppressed by one: the pinned autoarm model would call
+  # this fresh beacon healthy while away supervision is genuinely dead.
+  out=$(FM_ROOT_OVERRIDE="$(case_root "$dir")" \
+    FM_HOME="$home" \
+    FM_GUARD_GRACE=999 \
+    FM_SUPERVISION_MODEL=autoarm \
+    "$ROOT/bin/fm-guard.sh" 2>&1)
+  assert_contains "$out" "away mode owns supervision but its daemon is not running" \
+    "a pinned harness model must not suppress away-mode detection"
+  pass "fm-guard stale banner: away mode outranks a pinned harness supervision model"
+}
+
+test_away_model_dead_daemon_alarms_with_daemon_reason() {
+  local dir out home
+  dir=$(make_guard_case away-dead-daemon)
+  home=$(case_home "$dir")
+  : > "$home/state/.afk"
+  # A fresh watcher beacon and a fresh daemon tick, but no daemon process at all:
+  # away supervision is genuinely off and must still alarm.
+  touch "$home/state/.last-watcher-beat"
+  touch "$home/state/.subsuper-last-housekeep"
+  out=$(run_guard_case_away "$dir")
+  [ "$(count_text "$out" "WATCHER DOWN - SUPERVISION IS OFF")" -eq 1 ] \
+    || fail "away mode with no daemon must alarm: $out"
+  assert_contains "$out" "away mode owns supervision but its daemon is not running or has stopped ticking" \
+    "the away banner must name the daemon as the failing condition"
+  pass "fm-guard stale banner: away mode alarms on a dead daemon and names it"
+}
+
 test_persistent_no_watcher_banner_names_missing_process() {
   local dir out
   dir=$(make_guard_case persistent-no-watcher-reason)
@@ -695,6 +776,9 @@ test_extension_live_watcher_is_healthy_without_ownership_evidence
 test_autoarm_fresh_beacon_without_watcher_is_healthy
 test_autoarm_stale_beacon_alarms_with_correct_reason
 test_autoarm_stale_episode_is_stable
+test_away_model_live_daemon_without_watcher_is_healthy
+test_away_model_dead_daemon_alarms_with_daemon_reason
+test_away_model_outranks_a_pinned_harness_model
 test_persistent_no_watcher_banner_names_missing_process
 test_persistent_no_watcher_episode_survives_beacon_touch
 test_fresh_beacon_without_live_watcher_stays_alarm

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -1531,6 +1531,246 @@ test_hook_claude_mode_away_mode_never_uses_stop_autoarm_fail_open() {
   pass "fm-turnend-guard --claude: away ownership excludes the Stop-autoarm fail-open"
 }
 
+# --- away mode: the away daemon, not a watcher process, is the supervisor ----
+#
+# While state/.afk exists bin/fm-supervise-daemon.sh owns supervision and runs the
+# watcher one cycle at a time, so an unheld state/.watch.lock is the HEALTHY state
+# between cycles. These fixtures therefore never record a watcher lock at all: the
+# only supervision evidence is the daemon lock, its identity, and its tick.
+
+# Record an away-daemon lock exactly as bin/fm-supervise-daemon.sh does at
+# startup: the portable lock dir with its pid, the pid-identity it writes itself,
+# and the startup pid file.
+record_daemon_lock() {
+  local dir=$1 pid=$2 identity=$3
+  mkdir -p "$dir/state/.supervise-daemon.lock"
+  printf '%s\n' "$pid" > "$dir/state/.supervise-daemon.lock/pid"
+  [ -z "$identity" ] || printf '%s\n' "$identity" > "$dir/state/.supervise-daemon.lock/pid-identity"
+  printf '%s\n' "$pid" > "$dir/state/.supervise-daemon.pid"
+}
+
+# A live stand-in for the away daemon, with the daemon's own identity recorded.
+# Sets AWAY_DAEMON_PID rather than printing it: a command substitution would run
+# the suite's EXIT cleanup trap in its subshell and reap the process.
+AWAY_DAEMON_PID=
+start_away_daemon_stand_in() {
+  local dir=$1 identity
+  sleep 60 &
+  AWAY_DAEMON_PID=$!
+  identity=$(watcher_identity "$dir" "$AWAY_DAEMON_PID") || {
+    kill "$AWAY_DAEMON_PID" 2>/dev/null || true
+    wait "$AWAY_DAEMON_PID" 2>/dev/null || true
+    fail "could not identify the away daemon stand-in"
+  }
+  record_daemon_lock "$dir" "$AWAY_DAEMON_PID" "$identity"
+}
+
+stop_away_daemon_stand_in() {
+  local pid=$1
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+}
+
+# The daemon ticks two ways and either one proves the loop is turning: its own
+# housekeeping pass, and the beat of the watcher child it runs.
+touch_daemon_tick() {
+  local dir=$1
+  touch "$dir/state/.subsuper-last-housekeep"
+}
+
+test_hook_away_mode_silent_with_live_daemon_and_no_watcher() {
+  local dir pid out status
+  dir=$(make_primary_dir "$TMP_ROOT/hook-afk-healthy")
+  : > "$dir/state/task1.meta"
+  : > "$dir/state/.afk"
+  start_away_daemon_stand_in "$dir"
+  pid=$AWAY_DAEMON_PID
+  touch_daemon_tick "$dir"
+  out=$(run_hook "$dir" false); status=$?
+  stop_away_daemon_stand_in "$pid"
+  expect_code 0 "$status" "away mode with a live ticking daemon and no watcher must not block"
+  [ -z "$out" ] || fail "away mode with a live ticking daemon produced output: $out"
+  [ ! -e "$dir/state/.watch.lock" ] || fail "fixture must not record a watcher lock"
+  pass "fm-turnend-guard: away mode is quiet with a live daemon and no watcher process"
+}
+
+test_hook_claude_mode_away_mode_silent_with_live_daemon() {
+  local dir pid out status
+  dir=$(make_primary_dir "$TMP_ROOT/hook-afk-healthy-claude")
+  : > "$dir/state/task1.meta"
+  : > "$dir/state/.afk"
+  start_away_daemon_stand_in "$dir"
+  pid=$AWAY_DAEMON_PID
+  touch_daemon_tick "$dir"
+  out=$(FM_CLAUDE_AUTOARM_SYNC_WAIT_MS=100 run_hook_claude "$dir" false); status=$?
+  stop_away_daemon_stand_in "$pid"
+  expect_code 0 "$status" "--claude away mode with a live ticking daemon must not block"
+  [ -z "$out" ] || fail "--claude away mode with a live ticking daemon produced output: $out"
+  [ ! -f "$dir/state/.turnend-claude-blocks" ] || fail "a quiet away turn must not consume the Claude block budget"
+  pass "fm-turnend-guard --claude: away mode is quiet with a live daemon and no watcher process"
+}
+
+test_hook_away_mode_silent_on_watcher_beat_alone() {
+  local dir pid out status
+  dir=$(make_primary_dir "$TMP_ROOT/hook-afk-beat-only")
+  : > "$dir/state/task1.meta"
+  : > "$dir/state/.afk"
+  start_away_daemon_stand_in "$dir"
+  pid=$AWAY_DAEMON_PID
+  # No housekeeping tick at all: the watcher child's beat alone still proves the
+  # daemon's loop is turning (housekeeping is skipped while it backs off), so
+  # requiring both signals together would re-create the false alarm.
+  rm -f "$dir/state/.subsuper-last-housekeep"
+  touch -t 202001010000 "$dir/state/.supervise-daemon.pid"
+  touch "$dir/state/.last-watcher-beat"
+  out=$(run_hook "$dir" false); status=$?
+  stop_away_daemon_stand_in "$pid"
+  expect_code 0 "$status" "the watcher child's beat alone must satisfy the away tick"
+  [ -z "$out" ] || fail "away mode blocked on a fresh watcher beat: $out"
+  pass "fm-turnend-guard: away mode accepts the watcher beat as the daemon's tick"
+}
+
+test_hook_away_mode_silent_before_first_tick() {
+  local dir pid out status
+  dir=$(make_primary_dir "$TMP_ROOT/hook-afk-just-started")
+  : > "$dir/state/task1.meta"
+  : > "$dir/state/.afk"
+  start_away_daemon_stand_in "$dir"
+  pid=$AWAY_DAEMON_PID
+  # A daemon that started seconds ago has not run housekeeping yet and its
+  # watcher child has not beaten yet; its startup stamp is the tick.
+  rm -f "$dir/state/.subsuper-last-housekeep" "$dir/state/.last-watcher-beat"
+  out=$(run_hook "$dir" false); status=$?
+  stop_away_daemon_stand_in "$pid"
+  expect_code 0 "$status" "a just-started away daemon must not read as dead before its first tick"
+  [ -z "$out" ] || fail "away mode blocked a just-started daemon: $out"
+  pass "fm-turnend-guard: away mode tolerates the window before the daemon's first tick"
+}
+
+test_hook_away_mode_blocks_when_daemon_pid_is_dead() {
+  local dir dead out status
+  dir=$(make_primary_dir "$TMP_ROOT/hook-afk-dead-daemon")
+  dead=$(nonexistent_pid)
+  : > "$dir/state/task1.meta"
+  : > "$dir/state/.afk"
+  record_daemon_lock "$dir" "$dead" "dead daemon identity"
+  # Every freshness signal is fresh: only the dead PROCESS makes this unhealthy,
+  # which is exactly the case a freshness-only check would miss.
+  touch_daemon_tick "$dir"
+  touch "$dir/state/.last-watcher-beat"
+  out=$(run_hook "$dir" false); status=$?
+  expect_code 2 "$status" "a dead away daemon must still block even with fresh ticks"
+  assert_contains "$out" "TURN WOULD END BLIND" "a dead away daemon must raise the blind alarm"
+  assert_contains "$out" "no live away-mode supervision daemon holds this home" \
+    "the away banner must name the daemon, not a missing watcher"
+  assert_contains "$out" 'Away mode owns watcher supervision' "the away block must point at the daemon repair path"
+  pass "fm-turnend-guard: away mode still blocks when the daemon pid is dead"
+}
+
+test_hook_away_mode_blocks_on_recycled_daemon_pid() {
+  local dir pid out status
+  dir=$(make_primary_dir "$TMP_ROOT/hook-afk-recycled-pid")
+  : > "$dir/state/task1.meta"
+  : > "$dir/state/.afk"
+  sleep 60 &
+  pid=$!
+  # A live pid whose recorded identity belongs to the daemon that held that pid
+  # before it was recycled: liveness alone must not satisfy the check.
+  record_daemon_lock "$dir" "$pid" "some other process identity"
+  touch_daemon_tick "$dir"
+  out=$(run_hook "$dir" false); status=$?
+  stop_away_daemon_stand_in "$pid"
+  expect_code 2 "$status" "a recycled daemon pid must still block"
+  assert_contains "$out" "no live away-mode supervision daemon holds this home" \
+    "a recycled pid must read as no daemon at all"
+  pass "fm-turnend-guard: away mode blocks when the daemon pid was recycled"
+}
+
+test_hook_away_mode_blocks_when_daemon_stopped_ticking() {
+  local dir pid out status
+  dir=$(make_primary_dir "$TMP_ROOT/hook-afk-stalled-daemon")
+  : > "$dir/state/task1.meta"
+  : > "$dir/state/.afk"
+  start_away_daemon_stand_in "$dir"
+  pid=$AWAY_DAEMON_PID
+  # The process is alive and identity-matched, but nothing in its loop has moved
+  # for an hour: a wedged daemon supervises nothing.
+  touch -t 202001010000 "$dir/state/.subsuper-last-housekeep"
+  touch -t 202001010000 "$dir/state/.last-watcher-beat"
+  touch -t 202001010000 "$dir/state/.supervise-daemon.pid"
+  out=$(run_hook "$dir" false); status=$?
+  stop_away_daemon_stand_in "$pid"
+  expect_code 2 "$status" "a live but wedged away daemon must still block"
+  assert_contains "$out" "is alive but has stopped ticking" \
+    "the stalled-daemon banner must distinguish itself from a missing daemon"
+  pass "fm-turnend-guard: away mode still blocks when the daemon stopped ticking"
+}
+
+test_hook_claude_mode_away_mode_blocks_dead_daemon() {
+  local dir dead out status
+  dir=$(make_primary_dir "$TMP_ROOT/hook-afk-dead-daemon-claude")
+  dead=$(nonexistent_pid)
+  : > "$dir/state/task1.meta"
+  : > "$dir/state/.afk"
+  record_daemon_lock "$dir" "$dead" "dead daemon identity"
+  touch_daemon_tick "$dir"
+  out=$(FM_CLAUDE_AUTOARM_SYNC_WAIT_MS=100 run_hook_claude "$dir" true); status=$?
+  expect_code 2 "$status" "--claude away mode must block a dead daemon even after a prior continuation"
+  assert_contains "$out" "no live away-mode supervision daemon holds this home" \
+    "the --claude away banner must name the daemon"
+  case "$out" in
+    *"Stop-owned auto-arm did not claim"*)
+      fail "the away banner must not blame the Stop-owned auto-arm, which stands down under away mode" ;;
+  esac
+  pass "fm-turnend-guard --claude: away mode blocks a dead daemon and never blames the auto-arm"
+}
+
+test_hook_away_mode_daemon_lock_without_identity_matches_command() {
+  local dir out status fake pid
+  dir=$(make_primary_dir "$TMP_ROOT/hook-afk-no-identity")
+  : > "$dir/state/task1.meta"
+  : > "$dir/state/.afk"
+  # A lock written by an older daemon records no pid-identity; the fallback must
+  # accept a real fm-supervise-daemon.sh process and nothing else.
+  fake="$dir/bin/fm-supervise-daemon.sh"
+  printf '#!/usr/bin/env bash\nsleep 60\n' > "$fake"
+  chmod +x "$fake"
+  "$fake" &
+  pid=$!
+  record_daemon_lock "$dir" "$pid" ""
+  touch_daemon_tick "$dir"
+  out=$(run_hook "$dir" false); status=$?
+  stop_away_daemon_stand_in "$pid"
+  expect_code 0 "$status" "an identity-less lock held by a real daemon process must stay healthy"
+  [ -z "$out" ] || fail "identity-less daemon lock produced output: $out"
+
+  sleep 60 &
+  pid=$!
+  record_daemon_lock "$dir" "$pid" ""
+  out=$(run_hook "$dir" false); status=$?
+  stop_away_daemon_stand_in "$pid"
+  expect_code 2 "$status" "an identity-less lock held by an unrelated process must still block"
+  pass "fm-turnend-guard: away mode's identity-less fallback matches the daemon command only"
+}
+
+test_hook_non_away_behaviour_is_unchanged_by_daemon_state() {
+  local dir pid out status
+  dir=$(make_primary_dir "$TMP_ROOT/hook-no-afk-daemon-ignored")
+  : > "$dir/state/task1.meta"
+  # A live, ticking away daemon with NO state/.afk must not rescue a home whose
+  # watcher is genuinely gone: outside away mode the watcher is still the answer.
+  start_away_daemon_stand_in "$dir"
+  pid=$AWAY_DAEMON_PID
+  touch_daemon_tick "$dir"
+  touch "$dir/state/.last-watcher-beat"
+  out=$(run_hook "$dir" false); status=$?
+  stop_away_daemon_stand_in "$pid"
+  expect_code 2 "$status" "without state/.afk a daemon must not satisfy the watcher requirement"
+  assert_contains "$out" "no live watcher holds this home lock" \
+    "the non-away banner must keep its watcher wording"
+  pass "fm-turnend-guard: a live daemon outside away mode changes nothing"
+}
+
 test_hook_claude_mode_allow_resets_budget() {
   local dir pid identity out status
   dir=$(make_primary_dir "$TMP_ROOT/hook-claude-reset")
@@ -1662,6 +1902,16 @@ test_hook_claude_mode_budget_without_verified_failure_keeps_blocking
 test_hook_claude_mode_verified_failure_alarm_is_loud_and_once
 test_hook_claude_mode_fail_open_requires_notice_and_failure_epoch
 test_hook_claude_mode_away_mode_never_uses_stop_autoarm_fail_open
+test_hook_away_mode_silent_with_live_daemon_and_no_watcher
+test_hook_claude_mode_away_mode_silent_with_live_daemon
+test_hook_away_mode_silent_on_watcher_beat_alone
+test_hook_away_mode_silent_before_first_tick
+test_hook_away_mode_blocks_when_daemon_pid_is_dead
+test_hook_away_mode_blocks_on_recycled_daemon_pid
+test_hook_away_mode_blocks_when_daemon_stopped_ticking
+test_hook_claude_mode_away_mode_blocks_dead_daemon
+test_hook_away_mode_daemon_lock_without_identity_matches_command
+test_hook_non_away_behaviour_is_unchanged_by_daemon_state
 test_hook_claude_mode_allow_resets_budget
 test_hook_claude_mode_waits_for_late_claim
 test_hook_claude_mode_secondmate_reblocks_like_primary


### PR DESCRIPTION
## Intent

Fix the firstmate turn-end supervision guard so it stops raising its loudest alarm - TURN WOULD END BLIND - SUPERVISION IS OFF - on a fleet whose supervision is healthy, whenever away mode (state/.afk) is active. Under away mode the away daemon (bin/fm-supervise-daemon.sh) owns supervision and runs the watcher one cycle at a time, so between cycles no long-lived watcher process holds state/.watch.lock; the guard's PID-strict fm_watcher_healthy check read that designed state as 'supervision is off'.

Requirements, in priority order:
1. Under state/.afk the guard must test the away daemon plus its freshness (a live daemon whose process is actually alive, together with a recent housekeeping tick state/.subsuper-last-housekeep and/or a fresh state/.last-watcher-beat), not a long-lived watcher. The signal set must be chosen deliberately and justified, and the freshness bound taken from the daemon's own real tick cadence rather than a guessed number.
2. It must still catch a genuinely dead away daemon: a stale pid file, a pid whose process is gone, or a daemon that stopped ticking must still raise the BLIND alarm. Trading a false positive for a false negative would make this change worse than the bug, because this guard is the last backstop before an unattended night with nobody watching. Both directions must be shown: healthy afk stops quietly, dead-daemon afk still blocks.
3. Keep the predicate where the concept already lives: extend the shared supervision-model vocabulary in bin/fm-wake-lib.sh (fm_supervision_model's autoarm/extension/persistent set) rather than bolting an 'if [ -e .afk ]' onto the guard script, so bin/fm-guard.sh and any future caller get the same answer.
4. Do not change non-afk behaviour at all: with no state/.afk, the PID-strict healthy check, the Claude auto-arm cooperative window, the bounded block budget, and the one-time attended fail-open must behave exactly as they do today.
5. The wording when the alarm does fire under afk must point at the daemon, not at arming a watcher.

Acceptance: the reproduction must stop blocking, demonstrated by running the command rather than by inference; a dead or stalled away daemon under state/.afk must still block, demonstrated the same way; tests must cover both directions and extend the repository's existing test surface for the guard and for bin/fm-wake-lib.sh rather than inventing a parallel one; shellcheck clean on every file touched; and non-afk behaviour unchanged with concrete evidence.

This changes firstmate's own shared tracked material, so the firstmate coding guidelines apply: one owner per contract, knowledge routed to its most specific owner, one sentence per line in tracked Markdown, plain dash never an em dash, no agent commit co-author, bin/*.sh shellcheck clean through bin/fm-lint.sh, tests colocated in tests/ named <subject>.test.sh extending existing scripts, and dated maintainer-verification evidence under docs/verification/ for the current guarantee.

Out of scope by explicit instruction: the three pre-existing suite failures in this environment (tests/fm-watch-arm.test.sh, tests/fm-session-start.test.sh, tests/fm-secondmate-harness.test.sh), which fail identically on a clean checkout at commit 64d61ae and are being filed separately. Do not fix them on this branch.

## What Changed

- Extended the shared supervision model in `bin/fm-wake-lib.sh` with away mode support (`fm_supervision_away`, `fm_away_daemon_healthy`), evaluating away daemon liveness and tick freshness (`FM_AWAY_TICK_GRACE`) when `state/.afk` exists.
- Updated `bin/fm-turnend-guard.sh` and `bin/fm-guard.sh` to use `fm_turnend_supervision_healthy`, eliminating false BLIND alarms under healthy away mode while ensuring dead or stalled away daemons still trigger blocks with daemon-specific alarm messaging.
- Deduplicated daemon PID identity matching into shared `fm_daemon_pid_matches` helper across `bin/fm-afk-start.sh` and supervision libraries, and updated documentation and tests covering both healthy and dead/stalled away daemon scenarios.

## Risk Assessment

✅ Low: The change cleanly implements model-aware away-mode supervision with well-justified freshness bounds, clear error banners, and thorough test coverage for both healthy and failing daemon scenarios.

## Testing

Exercised targeted guard unit test suites (tests/fm-turnend-guard.test.sh and tests/fm-guard-stale-banner.test.sh) and executed end-to-end CLI reproductions covering healthy away-mode daemon execution (quiet exit status 0), dead and stalled away-mode daemon blocking (exit status 2 with away daemon alarm banner), and non-AFK behavior (exit status 2 when watcher is missing and exit status 0 when watcher is present). All targeted tests passed without issues.

<details>
<summary>Evidence: Away Mode Healthy Ticking Daemon Execution Transcript</summary>

Source: [Away Mode Healthy Ticking Daemon Execution Transcript](https://github.com/BohnBawerick/firstmate/blob/d42881faa5eaec017c031ccd425e8e0a8468da8c/.no-mistakes/evidence/fm/fm-turnend-guard-afk-false-blind/away-mode-healthy-quiet.txt)

<code># Demonstration A: Away Mode Active (state/.afk) with Live Ticking Away Daemon&#10;$ FM_HOME=/tmp/fm-evid-TayXdq/home_a bin/fm-turnend-guard.sh --claude&#10;Exit Status: 0&#10;Output:&#10;(Quiet exit - zero output produced, turn end proceeds safely)</code>

```text
# Demonstration A: Away Mode Active (state/.afk) with Live Ticking Away Daemon
$ FM_HOME=/tmp/fm-evid-TayXdq/home_a bin/fm-turnend-guard.sh --claude
Exit Status: 0
Output:
(Quiet exit - zero output produced, turn end proceeds safely)
```
</details>
<details>
<summary>Evidence: Away Mode Dead Daemon Process Execution Transcript</summary>

Source: [Away Mode Dead Daemon Process Execution Transcript](https://github.com/BohnBawerick/firstmate/blob/d42881faa5eaec017c031ccd425e8e0a8468da8c/.no-mistakes/evidence/fm/fm-turnend-guard-afk-false-blind/away-mode-dead-daemon-blocks.txt)

<code># Demonstration B: Away Mode Active (state/.afk) with Dead Away Daemon Process&#10;$ FM_HOME=/tmp/fm-evid-TayXdq/home_b bin/fm-turnend-guard.sh --claude&#10;Exit Status: 2&#10;Output:&#10;●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━&#10;● TURN WOULD END BLIND - SUPERVISION IS OFF&#10;● 1 task(s) in flight, but no live away-mode supervision daemon holds this home (last supervision tick: 0s ago).&#10;● Away mode owns watcher supervision; load /afk and ensure the daemon is running instead of starting normal supervision directly.&#10;●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</code>

```text
# Demonstration B: Away Mode Active (state/.afk) with Dead Away Daemon Process
$ FM_HOME=/tmp/fm-evid-TayXdq/home_b bin/fm-turnend-guard.sh --claude
Exit Status: 2
Output:
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  TURN WOULD END BLIND - SUPERVISION IS OFF
●  1 task(s) in flight, but no live away-mode supervision daemon holds this home (last supervision tick: 0s ago).
●  Away mode owns watcher supervision; load /afk and ensure the daemon is running instead of starting normal supervision directly.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```
</details>
<details>
<summary>Evidence: Away Mode Stalled Daemon Process Execution Transcript</summary>

Source: [Away Mode Stalled Daemon Process Execution Transcript](https://github.com/BohnBawerick/firstmate/blob/d42881faa5eaec017c031ccd425e8e0a8468da8c/.no-mistakes/evidence/fm/fm-turnend-guard-afk-false-blind/away-mode-stalled-daemon-blocks.txt)

<code># Demonstration C: Away Mode Active (state/.afk) with Stalled/Un-ticking Away Daemon&#10;$ FM_HOME=/tmp/fm-evid-TayXdq/home_c bin/fm-turnend-guard.sh --claude&#10;Exit Status: 2&#10;Output:&#10;●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━&#10;● TURN WOULD END BLIND - SUPERVISION IS OFF&#10;● 1 task(s) in flight, but the away-mode supervision daemon is alive but has stopped ticking (last supervision tick: 300s ago, grace 180s).&#10;● Away mode owns watcher supervision; load /afk and ensure the daemon is running instead of starting normal supervision directly.&#10;●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</code>

```text
# Demonstration C: Away Mode Active (state/.afk) with Stalled/Un-ticking Away Daemon
$ FM_HOME=/tmp/fm-evid-TayXdq/home_c bin/fm-turnend-guard.sh --claude
Exit Status: 2
Output:
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  TURN WOULD END BLIND - SUPERVISION IS OFF
●  1 task(s) in flight, but the away-mode supervision daemon is alive but has stopped ticking (last supervision tick: 300s ago, grace 180s).
●  Away mode owns watcher supervision; load /afk and ensure the daemon is running instead of starting normal supervision directly.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```
</details>
<details>
<summary>Evidence: Non-AFK Supervision Guard Execution Transcript</summary>

Source: [Non-AFK Supervision Guard Execution Transcript](https://github.com/BohnBawerick/firstmate/blob/d42881faa5eaec017c031ccd425e8e0a8468da8c/.no-mistakes/evidence/fm/fm-turnend-guard-afk-false-blind/non-afk-behavior-unchanged.txt)

<code># Demonstration D: Non-AFK Home (No state/.afk) - Missing Watcher vs Healthy Watcher&#10;&#10;--- Subcase D1: Missing Watcher Process ---&#10;$ FM_HOME=/tmp/fm-evid-TayXdq/home_d bin/fm-turnend-guard.sh --claude&#10;Exit Status: 2&#10;Output:&#10;●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━&#10;● TURN WOULD END BLIND - SUPERVISION IS OFF&#10;● 1 task(s) in flight, but no live watcher holds this home lock (last beat: never).&#10;● watcher supervision needs Stop-owned automatic recovery; inspect the hook registration and startup status before ending the turn.&#10;●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━&#10;&#10;--- Subcase D2: Healthy Live Watcher Process ---&#10;$ FM_HOME=/tmp/fm-evid-TayXdq/home_d bin/fm-turnend-guard.sh --claude&#10;Exit Status: 0&#10;Output:&#10;(Quiet exit - zero output produced, turn end proceeds safely)</code>

```text
# Demonstration D: Non-AFK Home (No state/.afk) - Missing Watcher vs Healthy Watcher

--- Subcase D1: Missing Watcher Process ---
$ FM_HOME=/tmp/fm-evid-TayXdq/home_d bin/fm-turnend-guard.sh --claude
Exit Status: 2
Output:
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  TURN WOULD END BLIND - SUPERVISION IS OFF
●  1 task(s) in flight, but no live watcher holds this home lock (last beat: never).
●  watcher supervision needs Stop-owned automatic recovery; inspect the hook registration and startup status before ending the turn.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- Subcase D2: Healthy Live Watcher Process ---
$ FM_HOME=/tmp/fm-evid-TayXdq/home_d bin/fm-turnend-guard.sh --claude
Exit Status: 0
Output:
(Quiet exit - zero output produced, turn end proceeds safely)
```
</details>
<details>
<summary>Evidence: Targeted Test Suite Log</summary>

Source: [Targeted Test Suite Log](https://github.com/BohnBawerick/firstmate/blob/d42881faa5eaec017c031ccd425e8e0a8468da8c/.no-mistakes/evidence/fm/fm-turnend-guard-afk-false-blind/targeted-test-suite.txt)

```text
# Targeted Automated Test Suite Verification
Running tests/fm-turnend-guard.test.sh...
ok - fm_supervision_unhealthy: false with no state/*.meta at all
ok - fm_supervision_unhealthy: true with in-flight task and no beacon ever
ok - fm_supervision_unhealthy: true with in-flight task and a beacon far outside the grace window
ok - fm_supervision_unhealthy: false with in-flight task and a fresh beacon
ok - fm_supervision_status: FM_SUP_QUEUE_PENDING tracks state/.wake-queue
ok - fm_supervision_needed: X-mode relay poll needs supervision
ok - fm_supervision_unhealthy: source-only home needs supervision
ok - fm-turnend-guard: silent no-op with nothing in flight
ok - fm-turnend-guard: blocks when a fresh beacon has no live watcher lock
ok - fm-turnend-guard: non-Claude path blocks a source-only home
ok - fm-turnend-guard: blocks on a dead watcher lock even when the beacon is fresh
ok - fm-turnend-guard: silent no-op with a live watcher lock and fresh beacon
ok - fm-turnend-guard: healthy non-Claude harness paths ignore Claude episode contention
ok - fm-turnend-guard: blocks on a live watcher lock with an ancient beacon
ok - fm-turnend-guard: blocks with the exact required reason in the primary when unhealthy
ok - fm-turnend-guard: blocks from active FM_HOME state, not only repo-root state
ok - fm-turnend-guard: X-mode repair reason sources the cadence config
ok - fm-turnend-guard: X-mode-only supervision remains guarded in default mode
ok - fm-turnend-guard: ignores stale repo-root state when FM_HOME is set
ok - fm-turnend-guard: uses FM_STATE_OVERRIDE ahead of FM_HOME/state
ok - fm-turnend-guard: stop_hook_active=true always allows the stop (never blocks twice in one turn)
ok - fm-turnend-guard: blocks a blind turn end in a secondmate's own home (.fm-secondmate-home no longer excludes it)
ok - fm-turnend-guard: idle-by-default - silent in a secondmate home with nothing in flight
ok - fm-turnend-guard: stop_hook_active=true allows the stop in a secondmate home (never blocks twice in one turn)
ok - fm-turnend-guard: secondmate deferred-death recovery - silent while watched, forces re-arm once the watcher exits
ok - fm-turnend-guard: inert in a secondmate's own child worktree (linked git worktree) even when unhealthy
ok - fm-turnend-guard: blocks a blind turn end in a treehouse-leased LINKED secondmate home (marker force-include)
ok - fm-turnend-guard: an invalid (empty) marker cannot spoof inclusion; linked worktree stays exempt
ok - fm-turnend-guard: a non-ASCII marker cannot spoof inclusion; linked worktree stays exempt
ok - fm-turnend-guard: inert in a crewmate/scout task worktree (linked git worktree) even when unhealthy
ok - fm-turnend-guard: fails open (never blocks) when jq is missing
ok - fm-turnend-guard: silent no-op on empty stdin
ok - fm-turnend-guard: runs well under the generous timing margin (0s)
ok - fm-turnend-guard-grok: forces one explicitly marked same-session resume when the shared predicate blocks
ok - fm-turnend-guard-grok: legacy environment loop guard prevents a nested resume loop
ok - fm-turnend-guard-grok: native false delegates blocking feedback with zero resume processes
ok - fm-turnend-guard-grok: native true remains bounded and starts no resume process
ok - fm-turnend-guard-grok: both spellings are typed and camelCase has deterministic precedence
ok - fm-turnend-guard-grok: malformed, invalidly typed, and missing-prerequisite payloads start neither path
ok - fm-turnend-guard-grok: missing jq and no-supervision-needed stops stay silent and bounded
ok - tracked .claude/settings.json entries: 5 inert under grok, the documented subagent exception still armed, all live under Claude
ok - .codex/hooks.json: Stop hook uses hook process root when payload cwd is outside
ok - .codex/hooks.json: Stop hook ignores nested git root guard scripts
ok - .opencode primary plugin: guard path is anchored to worktree, not directory
ok - .pi primary extension: no-tool and multi-tool runs each inject exactly one guard follow-up
ok - .pi primary extension: delivery failure resets the logical-run latch
ok - fm-turnend-guard --claude: re-blocks a loop-guarded stop while unhealthy and unclaimed (incident regression)
ok - fm-turnend-guard --claude: X-mode-only homes re-block when auto-arm recovery is absent
ok - fm-turnend-guard --claude: a live arming epoch advances once and repeated observation is idempotent
ok - fm-turnend-guard --claude: repeated failed-to-arming races make bounded monotonic progress
ok - fm-turnend-guard --claude: terminal owner boundary excludes a concurrent start without deadlock
ok - fm-turnend-guard --claude: fresh rewake epoch prevents a duplicate continuation for the same event
ok - fm-turnend-guard --claude: fresh failed epochs preserve and advance monotonic fail-open progression
ok - fm-turnend-guard --claude: integrated fresh failures reach one bounded fail-open, stop continuation, and reset on recovery
ok - fm-turnend-guard --claude: reset contention preserves all episode state until retry
ok - fm-turnend-guard --claude: concurrent auto-arm and guard resets are idempotent and deadlock-free
ok - fm-turnend-guard --claude: stale rewake epoch does not allow a blind stop
ok - fm-turnend-guard --claude: budget exhaustion alone cannot permit a blind stop
ok - fm-turnend-guard --claude: verified fail-open is loud, bounded, attended, and non-repeating
ok - fm-turnend-guard --claude: fail-open requires both exhausted retries and consumed notice
ok - fm-turnend-guard --claude: away ownership excludes the Stop-autoarm fail-open
ok - fm-turnend-guard: away mode is quiet with a live daemon and no watcher process
ok - fm-turnend-guard --claude: away mode is quiet with a live daemon and no watcher process
ok - fm-turnend-guard: away mode accepts the watcher beat as the daemon's tick
ok - fm-turnend-guard: away mode tolerates the window before the daemon's first tick
ok - fm-turnend-guard: away mode still blocks when the daemon pid is dead
ok - fm-turnend-guard: away mode blocks when the daemon pid was recycled
ok - fm-turnend-guard: away mode still blocks when the daemon stopped ticking
ok - fm-turnend-guard --claude: away mode blocks a dead daemon and never blames the auto-arm
ok - fm-turnend-guard: away mode's identity-less fallback matches the daemon command only
ok - fm-turnend-guard: a live daemon outside away mode changes nothing
ok - fm-turnend-guard --claude: positive watcher recovery resets failure episode state
ok - fm-turnend-guard --claude: bounded claim wait avoids a token-consuming forced continuation
ok - fm-turnend-guard --claude: secondmate home re-blocks unclaimed and allows auto-arm-claimed stops

Running tests/fm-guard-stale-banner.test.sh...
ok - fm-guard stale banner: first stale call prints the full actionable banner
ok - fm-guard stale banner: repeated same-episode calls print a concise reminder only
ok - fm-guard stale banner: Pi and pi-signed primaries route themselves to the extension model
ok - fm-guard stale banner: extension-owned hand-off with a live session is healthy
ok - fm-guard stale banner: extension-owned empty lock is genuinely unheld
ok - fm-guard stale banner: held unhealthy extension locks stay loud
ok - fm-guard stale banner: extension model without ownership evidence stays loud
ok - fm-guard stale banner: every extension-ownership signal is load-bearing
ok - fm-guard stale banner: extension model still alarms on a genuinely stale beacon
ok - fm-guard stale banner: queued-wake warning survives the extension hand-off tolerance
ok - fm-guard stale banner: persistent primaries ignore Pi extension evidence
ok - fm-guard stale banner: extension model stays silent for a live watcher
ok - fm-guard stale banner: auto-arm fresh beacon without a live watcher is healthy
ok - fm-guard stale banner: auto-arm stale beacon alarms with the true reason
ok - fm-guard stale banner: auto-arm stale episode stays one episode across calls
ok - fm-guard stale banner: away mode with a live daemon and no watcher is healthy
ok - fm-guard stale banner: away mode alarms on a dead daemon and names it
ok - fm-guard stale banner: away mode outranks a pinned harness supervision model
ok - fm-guard stale banner: persistent no-watcher banner names the true reason
ok - fm-guard stale banner: a no-watcher episode survives a beacon mtime change
ok - fm-guard stale banner: a fresh beacon without a live watcher remains unhealthy
ok - fm-guard stale banner: X-mode polling without a live watcher remains unhealthy
ok - fm-guard stale banner: healthy recovery rearms the next stale episode
ok - fm-guard stale banner: concurrent same-episode calls claim exactly one full banner
ok - fm-guard stale banner: deduplication is isolated per FM_HOME
ok - fm-guard stale banner: queued-wake warning remains independent
ok - fm-guard stale banner: read-only before writable does not consume full banner
ok - fm-guard stale banner: read-only during episode observes without mutating marker
ok - fm-guard stale banner: healthy read-only does not clear marker
ok - fm-guard stale banner: read-only never mutates stale-banner state files
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"416c0d30abd12d835d463c46cc5fc60483877afc","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `./tests/fm-turnend-guard.test.sh`
- `./tests/fm-guard-stale-banner.test.sh`
- `./tests/fm-tangle-guard.test.sh`
- `./tests/fm-claude-stop-autoarm.test.sh`
- `./tests/fm-supervision-events.test.sh`
- `./tests/fm-supervision-instructions.test.sh`
- <code>CLI execution of `bin/fm-turnend-guard.sh --claude` under away mode (`state/.afk`) with live ticking daemon (quiet exit 0)</code>
- <code>CLI execution of `bin/fm-turnend-guard.sh --claude` under away mode (`state/.afk`) with dead daemon process (exit 2 with daemon banner)</code>
- <code>CLI execution of `bin/fm-turnend-guard.sh --claude` under away mode (`state/.afk`) with stalled daemon process (exit 2 with tick age banner)</code>
- <code>CLI execution of `bin/fm-turnend-guard.sh --claude` without away mode (`state/.afk`) verifying unchanged non-AFK watcher guard behavior</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
