### PR TITLE
fix(spawn): land the crew memory guard and repair its dead crew cap

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -194,6 +194,11 @@
 #   identity is owned by the parent home that holds its task metadata, while the
 #   pane export happens on the remote host (bin/fm-remote-secondmate-control.sh).
 #   Local spawns never pass it and resolve their own carrier exactly as before.
+#
+#   The memory guard below refuses a spawn that would overcommit the machine:
+#   FM_MAX_CREWS      hard cap on concurrent crews (default 8)
+#   FM_MIN_FREE_MB    refuse to spawn below this much available memory (default 6000)
+#   FM_SPAWN_FORCE=1  override both, deliberately
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -266,6 +271,43 @@ fm_refuse_if_gate_agent
 # Skip the watcher guard when re-exec'd for one pair of a batch (FM_SPAWN_NO_GUARD is
 # set by the batch loop below), so the guard runs once for the batch, not once per pair.
 [ -n "${FM_SPAWN_NO_GUARD:-}" ] || "$FM_ROOT/bin/fm-guard.sh" || true
+
+# ── memory guard ─────────────────────────────────────────────────────────────
+# Crews are multi-gigabyte processes. On 2026-08-14 eleven of them ran at once
+# on a 30 GiB box: individual crew windows peaked at 9.4/5.3/4.8/4.6/4.5/3.2 GiB,
+# one process was OOM-killed holding 8.7 GiB, and the machine hard-locked with no
+# OOM record at all (the kernel had no memory left to write one). Scale crew
+# count against RAM, never against ambition.
+#
+# The variables that tune and override this guard are documented in the header.
+fm_memory_guard() {
+  [ -z "${FM_SPAWN_FORCE:-}" ] || return 0
+  local cap="${FM_MAX_CREWS:-8}" minfree="${FM_MIN_FREE_MB:-6000}" live avail meta
+  live=0
+  for meta in "$STATE"/*.meta; do
+    [ -f "$meta" ] || continue
+    live=$((live + 1))
+  done
+  if [ "${live:-0}" -ge "$cap" ]; then
+    printf 'refusing to spawn: %s crews already live (cap %s).
+' "$live" "$cap" >&2
+    printf '  Crews are multi-GB each; exceeding this has hard-locked the machine.
+' >&2
+    printf '  Let some finish, raise FM_MAX_CREWS deliberately, or set FM_SPAWN_FORCE=1.
+' >&2
+    return 1
+  fi
+  avail=$(awk '/^MemAvailable:/{print int($2/1024)}' /proc/meminfo 2>/dev/null || echo 99999)
+  if [ "${avail:-99999}" -lt "$minfree" ]; then
+    printf 'refusing to spawn: only %s MiB available (need %s).
+' "$avail" "$minfree" >&2
+    printf '  Wait for memory to free, or set FM_SPAWN_FORCE=1 deliberately.
+' >&2
+    return 1
+  fi
+  return 0
+}
+fm_memory_guard || exit 1
 KIND=ship
 KIND_SET=0
 HARNESS_ARG=

--- a/tests/fm-spawn-memory-guard.test.sh
+++ b/tests/fm-spawn-memory-guard.test.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Behavior tests for fm-spawn.sh's memory guard.
+#
+# The guard runs before argument parsing, so these tests drive the real
+# fm-spawn.sh with no arguments against an isolated firstmate home and read the
+# process result. A refusal prints "refusing to spawn:" and exits 1; passing the
+# guard falls through to the ordinary "--mode" argument error, so reaching that
+# message is the positive signal that the guard allowed the spawn. Neither
+# outcome starts a backend, so no endpoint or metadata is ever created.
+#
+# FM_SPAWN_NO_GUARD=1 skips the unrelated watcher guard only; the memory guard
+# has no such skip and still runs, exactly as it does for each pair of a batch.
+#
+# The crew-count cases pin FM_MIN_FREE_MB=1 and the memory cases pin a high
+# FM_MAX_CREWS so each test exercises one branch and never depends on how much
+# memory the host running the suite happens to have free.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-memory-guard)
+
+REFUSAL='refusing to spawn:'
+PASSED_GUARD='ship spawns require --mode'
+
+# make_home <name> <live-crew-count>: isolated home with N live task metas.
+make_home() {
+  local home=$TMP_ROOT/$1 count=$2 i
+  mkdir -p "$home/state"
+  for ((i = 1; i <= count; i++)); do
+    : > "$home/state/task$i.meta"
+  done
+  printf '%s\n' "$home"
+}
+
+# run_spawn <home>: run fm-spawn with the guard reachable, echo output, return code.
+run_spawn() {
+  local home=$1
+  FM_SPAWN_NO_GUARD=1 FM_HOME="$home" bash "$SPAWN" 2>&1
+}
+
+test_cap_refuses_when_live_crews_reach_the_cap() {
+  local home out rc
+  home=$(make_home cap-at 8)
+  out=$(FM_MIN_FREE_MB=1 run_spawn "$home"); rc=$?
+  expect_code 1 "$rc" 'cap at limit must refuse'
+  assert_contains "$out" "$REFUSAL" 'cap at limit must refuse the spawn'
+  assert_contains "$out" '8 crews already live (cap 8)' 'refusal must name the live count and cap'
+  pass 'cap refuses when live crews reach the cap'
+}
+
+test_cap_refuses_above_the_cap() {
+  local home out rc
+  home=$(make_home cap-above 9)
+  out=$(FM_MIN_FREE_MB=1 run_spawn "$home"); rc=$?
+  expect_code 1 "$rc" 'cap above limit must refuse'
+  assert_contains "$out" '9 crews already live (cap 8)' 'refusal must count every live crew'
+  pass 'cap refuses above the cap'
+}
+
+test_cap_allows_below_the_cap() {
+  local home out
+  home=$(make_home cap-below 7)
+  out=$(FM_MIN_FREE_MB=1 run_spawn "$home")
+  assert_not_contains "$out" "$REFUSAL" 'a normal spawn below the cap must not be refused'
+  assert_contains "$out" "$PASSED_GUARD" 'a normal spawn must reach ordinary argument handling'
+  pass 'cap allows below the cap'
+}
+
+test_empty_home_is_unaffected() {
+  local home out
+  home=$(make_home cap-empty 0)
+  out=$(FM_MIN_FREE_MB=1 run_spawn "$home")
+  assert_not_contains "$out" "$REFUSAL" 'a home with no live crews must not be refused'
+  assert_contains "$out" "$PASSED_GUARD" 'a home with no live crews must reach ordinary argument handling'
+  pass 'empty home is unaffected'
+}
+
+test_explicit_cap_is_honoured() {
+  local home out rc
+  home=$(make_home cap-explicit 2)
+  out=$(FM_MIN_FREE_MB=1 FM_MAX_CREWS=1 run_spawn "$home"); rc=$?
+  expect_code 1 "$rc" 'explicit FM_MAX_CREWS must refuse'
+  assert_contains "$out" '2 crews already live (cap 1)' 'refusal must report the explicit cap'
+  pass 'explicit FM_MAX_CREWS is honoured'
+}
+
+test_raised_cap_allows_the_spawn() {
+  local home out
+  home=$(make_home cap-raised 9)
+  out=$(FM_MIN_FREE_MB=1 FM_MAX_CREWS=50 run_spawn "$home")
+  assert_not_contains "$out" "$REFUSAL" 'a deliberately raised cap must allow the spawn'
+  assert_contains "$out" "$PASSED_GUARD" 'a raised cap must reach ordinary argument handling'
+  pass 'a raised cap allows the spawn'
+}
+
+test_memory_refusal_fires_below_the_threshold() {
+  local home out rc
+  home=$(make_home mem-low 0)
+  out=$(FM_MAX_CREWS=99 FM_MIN_FREE_MB=99999999 run_spawn "$home"); rc=$?
+  expect_code 1 "$rc" 'memory below threshold must refuse'
+  assert_contains "$out" "$REFUSAL" 'memory below threshold must refuse the spawn'
+  assert_contains "$out" 'need 99999999' 'refusal must name the required free memory'
+  pass 'memory refusal fires below the threshold'
+}
+
+test_memory_refusal_allows_above_the_threshold() {
+  local home out
+  home=$(make_home mem-ok 0)
+  out=$(FM_MAX_CREWS=99 FM_MIN_FREE_MB=1 run_spawn "$home")
+  assert_not_contains "$out" "$REFUSAL" 'ample free memory must not be refused'
+  assert_contains "$out" "$PASSED_GUARD" 'ample free memory must reach ordinary argument handling'
+  pass 'memory refusal allows above the threshold'
+}
+
+test_force_overrides_the_cap() {
+  local home out
+  home=$(make_home force-cap 9)
+  out=$(FM_MIN_FREE_MB=1 FM_SPAWN_FORCE=1 FM_MAX_CREWS=1 run_spawn "$home")
+  assert_not_contains "$out" "$REFUSAL" 'FM_SPAWN_FORCE must override the cap'
+  assert_contains "$out" "$PASSED_GUARD" 'a forced spawn must reach ordinary argument handling'
+  pass 'FM_SPAWN_FORCE overrides the cap'
+}
+
+test_force_overrides_the_memory_refusal() {
+  local home out
+  home=$(make_home force-mem 0)
+  out=$(FM_SPAWN_FORCE=1 FM_MIN_FREE_MB=99999999 run_spawn "$home")
+  assert_not_contains "$out" "$REFUSAL" 'FM_SPAWN_FORCE must override the memory refusal'
+  assert_contains "$out" "$PASSED_GUARD" 'a forced spawn must reach ordinary argument handling'
+  pass 'FM_SPAWN_FORCE overrides the memory refusal'
+}
+
+# Regression for the typo that read an undefined variable instead of the resolved
+# state directory. Under `set -u` that killed only the counting subshell, leaving
+# the count empty so the cap silently never fired while the spawn continued.
+test_crew_count_reads_the_resolved_state_directory() {
+  local home out rc
+  home=$(make_home regression 9)
+  out=$(FM_MIN_FREE_MB=1 run_spawn "$home"); rc=$?
+  assert_not_contains "$out" 'unbound variable' 'the crew count must not read an undefined variable'
+  expect_code 1 "$rc" 'the cap must fire rather than being skipped by a failed count'
+  pass 'crew count reads the resolved state directory'
+}
+
+# The state directory is overridable, so the count must follow the override
+# rather than any other location.
+test_crew_count_follows_the_state_override() {
+  local home elsewhere out rc
+  home=$(make_home override-home 0)
+  elsewhere=$(make_home override-state 9)
+  out=$(FM_MIN_FREE_MB=1 FM_STATE_OVERRIDE="$elsewhere/state" \
+    FM_SPAWN_NO_GUARD=1 FM_HOME="$home" bash "$SPAWN" 2>&1); rc=$?
+  expect_code 1 "$rc" 'the override state directory must be counted'
+  assert_contains "$out" '9 crews already live (cap 8)' 'the count must follow FM_STATE_OVERRIDE'
+  pass 'crew count follows the state override'
+}
+
+test_cap_refuses_when_live_crews_reach_the_cap
+test_cap_refuses_above_the_cap
+test_cap_allows_below_the_cap
+test_empty_home_is_unaffected
+test_explicit_cap_is_honoured
+test_raised_cap_allows_the_spawn
+test_memory_refusal_fires_below_the_threshold
+test_memory_refusal_allows_above_the_threshold
+test_force_overrides_the_cap
+test_force_overrides_the_memory_refusal
+test_crew_count_reads_the_resolved_state_directory
+test_crew_count_follows_the_state_override
+
+echo "# all fm-spawn-memory-guard tests passed"


### PR DESCRIPTION
## What this lands

The crew memory guard in `bin/fm-spawn.sh`, plus the fix that makes half of it work at all.

The guard was written after the 2026-08-14 incident (eleven crews on a 30 GiB box; one process OOM-killed holding 8.7 GiB; the machine hard-locked with no OOM record, because the kernel had no memory left to write one). **It was never committed.** It existed only as an uncommitted change in the primary working tree, so no clone and no fleet member has ever had it. That is why this lands the guard and its fix together rather than as a one-word change.

It also carried a typo that meant the crew cap could never have fired even if it had been committed: the count read `$FM_STATE`, which is defined nowhere. Under `set -u` that killed the counting subshell before it counted anything, so `${live:-0}` was always `0` and the cap never tripped — the spawn continued, printing only a stray `FM_STATE: unbound variable`. The memory refusal sat after the failed assignment and was unaffected, so that half did work; **only the crew cap was dead.**

Counting now reads the resolved `$STATE` directory using the glob-loop idiom the rest of `bin/` already uses, so it is shellcheck-clean and does not parse `ls`.

## Tests

`tests/fm-spawn-memory-guard.test.sh` — 12 cases, all passing. It drives the real `fm-spawn.sh` against isolated homes and covers the cap firing at and above the limit, an explicit and a raised cap, the memory refusal firing below the threshold, `FM_SPAWN_FORCE` overriding both, normal spawns below the cap and in an empty home reaching ordinary argument handling untouched, and the count following `FM_STATE_OVERRIDE`. Crew-count cases pin `FM_MIN_FREE_MB` and memory cases pin `FM_MAX_CREWS`, so each exercises one branch and neither depends on the host's free memory.

Reintroducing the `$FM_STATE` typo turns the suite red — verified, not assumed:

```
not ok - cap at limit must refuse the spawn (missing: 'refusing to spawn:')
--- output ---
bin/fm-spawn.sh: line 287: FM_STATE: unbound variable
```

`bin/fm-lint.sh` is clean on both changed files (ShellCheck 0.11.0, the pinned version).

---

## Known follow-ups — deliberately NOT fixed here

These were found by review and the decisions behind them are already approved. This PR is intentionally bounded to landing the guard, so they are recorded rather than fixed. **They must not be lost.**

### 1. The relaunch bug — destructive, and it bites exactly when recovery matters

`bin/fm-control.sh` runs `do_exit` **before** `fm-spawn --relaunch`. At cap, the relaunch is therefore refused *after* the old worker has already been killed, leaving a task with a recorded endpoint and no agent behind it.

**Approved fix:** skip the cap branch when `--relaunch` is present, keeping the memory branch. A relaunch replaces an existing agent rather than adding one.

### 2. The secondmate respawn

`bin/fm-bootstrap.sh` recovers a dead local secondmate with `fm-spawn.sh <id> --secondmate`, not `--relaunch`, so the cap still refuses it.

**Approved fix:** the meta-exists exemption. Same reasoning as above — a respawn replaces an already-registered agent rather than adding one.

### 3. The contract contradiction

`AGENTS.md` section 7 says to dispatch isolated work "with no concurrency cap". A default cap of 8 contradicts that as written.

**Approved resolution:** this is a **resource** limit, not a concurrency policy. It belongs named in section 7 as a reason to serialise.

### 4. The test-suite dependency — the most urgent of these

The guard makes roughly **40 existing suites** depend on the host having 6000+ MiB free. Unrelated suites therefore fail on a loaded machine — which is exactly the condition the guard exists for, and exactly the machine the pipeline runs on.

**Approved fix:** `tests/lib.sh` already has the precedent — `FM_GATE_REFUSE_BYPASS=1`.

### 5. Smaller items, same treatment

- The memory branch is **silently inert on macOS** (it reads `/proc/meminfo`, and the `|| echo 99999` fallback means absence reads as "plenty free").
- **Secondmate metas are counted as live crews**, so secondmates consume the crew cap.
- **Unvalidated `FM_MAX_CREWS` / `FM_MIN_FREE_MB` silently disable the branch** — a non-numeric or empty value is not rejected.
- **`FM_SPAWN_FORCE=0` disables the guard**, because the check is `[ -z ... ]` (presence, not truth).
- **A remote secondmate is gated on local memory**, which is not where it runs.
- A `:-0` fallback on the count would **re-arm the exact silent no-op this PR fixes**, so it must not be reintroduced as a "defensive" default.

---

## Two further findings, recorded here because they are findings in their own right

### The primary checkout is 327 commits behind `origin/main`

Verified: `git rev-list --count HEAD..origin/main` = **327**. As a direct consequence it has **no `bin/fm-lint.sh` at all** — the file does not exist there. Anything run from the primary checkout is running against a materially different tree.

### Correction to an earlier claim about `fm-lint.sh`

An earlier report stated that `fm-lint.sh` passes without checking when its tools are missing. **That was wrong, and this corrects it.** It does not pass silently — it refuses:

- `bin/fm-lint.sh` exits **127** when ShellCheck is absent (and again when `perl` is absent).
- `bin/fm-lint-workflows.sh` exits **127** when actionlint is absent.
- CI installs both, pinned, via `bin/fm-install-shellcheck.sh` and `bin/fm-install-actionlint.sh`.

One precision worth keeping: the actionlint gate lives in `fm-lint-workflows.sh`, not in `fm-lint.sh` itself.
