### PR TITLE
fix: bind turn-end notifications to live task incarnations

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -355,7 +355,7 @@ grok loads PROJECT hooks (`<worktree>/.grok/hooks/`, `<worktree>/.claude/setting
 GLOBAL hooks in `~/.grok/hooks/` are always trusted and load on first launch.
 So `fm-spawn` installs ONE firstmate-owned global hook, `~/.grok/hooks/fm-turn-end.json`, plus the companion `~/.grok/hooks/fm-turn-end.sh`, guarded as a no-op for every non-firstmate grok session.
 Its `Stop` command fires only when the current workspace holds a `.fm-grok-turnend` token pointer that matches the firstmate-owned hook registry under `~/.grok/hooks/fm-turn-end.d/`.
-`fm-spawn` writes that per-task pointer (`<worktree>/.fm-grok-turnend`, gitignored via git info/exclude like the other harnesses' worktree hook files) and a matching registry entry naming this task's `state/<id>.turn-ended`.
+`fm-spawn` writes that per-task pointer (`<worktree>/.fm-grok-turnend`, gitignored via git info/exclude like the other harnesses' worktree hook files) and a matching registry entry consumed through the generation-bound task notification contract owned by [`docs/configuration.md`](../../../docs/configuration.md) "Harness support".
 The hook reads `$GROK_WORKSPACE_ROOT`, which is always set for hooks and equals the worktree.
 This keeps the hook outside the worktree, needs no trust grant, and writes only firstmate-owned files.
 `fm-teardown` removes the worktree pointer before returning a pooled worktree.
@@ -474,7 +474,7 @@ The delivery-only spinner match covers the full moon-phase glyph set rather than
 
 [`docs/turnend-guard.md`](../../../docs/turnend-guard.md) owns Kimi's verified global hook surface and captain-approved crew wake integration.
 `fm-spawn.sh` installs one marker-delimited Firstmate entry in `$HOME/.kimi-code/config.toml`, one silent always-zero hook script, and one private token registry under `$HOME/.kimi-code/fm-turn-end.d/`.
-Each Kimi crew worktree receives a gitignored `.fm-kimi-turnend` token pointer, and the global hook touches that task's `state/<id>.turn-ended` only when the Stop payload's `cwd`, pointer, and registry entry all agree.
+Each Kimi crew worktree receives a gitignored `.fm-kimi-turnend` token pointer, and the global hook publishes only when the Stop payload's `cwd`, pointer, registry entry, and generation-bound task metadata all agree under the contract owned by [`docs/configuration.md`](../../../docs/configuration.md) "Harness support".
 A guarded silent hook cannot be verified from absence of effect, so prove invocation with an unguarded probe before concluding that the hook did not fire.
 The guarded turn-end signal remains a wake notification; standalone Kimi has no busy-state source until one is live-verified.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ data/                personal fleet records; LOCAL, gitignored as a whole
 projects/            cloned repos; gitignored; read-only except under hard rule 1's concrete captain-approved project operation exception
 state/               runtime records and signals; gitignored
   <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth
-  <id>.turn-ended    touched by turn-end hooks
+  <id>.turn-ended    turn-end wake notification published only for the task's live spawn incarnation
   <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
   <id>.kimi-turnend-token   firstmate-owned Kimi hook registry token for the task; removed by teardown
   <id>.muse-session  muse busy-source binding (sessions root plus task worktree) written by fm-spawn; removed by teardown

--- a/bin/fm-kimi-turnend-hook.sh
+++ b/bin/fm-kimi-turnend-hook.sh
@@ -89,9 +89,20 @@ case "$token" in fm.????????????) : ;; *) exit 0 ;; esac
 case "$token" in *[!A-Za-z0-9._-]*) exit 0 ;; esac
 auth_dir=${HOME:-}/.kimi-code/fm-turn-end.d
 [ -n "${HOME:-}" ] || exit 0
-target=$(cat "$auth_dir/$token" 2>/dev/null) || exit 0
-case "$target" in /*.turn-ended) : ;; *) exit 0 ;; esac
-touch -- "$target" 2>/dev/null || true
+registry="$auth_dir/$token"
+target= spawn_gen= signal= extra=
+IFS= read -r target < "$registry" 2>/dev/null || exit 0
+IFS= read -r spawn_gen < <(sed -n '2p' "$registry") || exit 0
+IFS= read -r signal < <(sed -n '3p' "$registry") || exit 0
+IFS= read -r extra < <(sed -n '4p' "$registry") || true
+case "$target" in target=/*.turn-ended) target=${target#target=} ;; *) exit 0 ;; esac
+case "$spawn_gen" in spawn_gen=*) spawn_gen=${spawn_gen#spawn_gen=} ;; *) exit 0 ;; esac
+case "$signal" in signal=/*/bin/fm-turnend-signal.sh) signal=${signal#signal=} ;; *) exit 0 ;; esac
+[ -z "$extra" ] || exit 0
+state=${target%/*}
+name=${target##*/}
+id=${name%.turn-ended}
+"$signal" "$state" "$id" "$spawn_gen" >/dev/null 2>&1 || true
 exit 0
 '''
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -152,8 +152,10 @@
 #     __BRIEF__    absolute path to data/<task-id>/brief.md
 #     __PIBIN__    quoted concrete Pi-family executable path resolved from PATH
 #     __PITUIMODE__ optional --tui-mode regular when that executable advertises it
-#     __TURNEND__  absolute path to state/<task-id>.turn-ended (for harnesses whose
-#                  turn-end signal rides the launch command, e.g. codex -c notify=[...])
+#     __TURNEND_SIGNAL__ absolute path to bin/fm-turnend-signal.sh
+#     __STATE__     absolute path to the task's state directory
+#     __TASK_ID__   canonical task id
+#     __SPAWN_GEN__ per-launch incarnation bound to the task's metadata
 #     __PIEXT__    absolute path to state/<task-id>.pi-ext.ts (pi turn-end extension,
 #                  written by this script; outside the worktree to avoid pi's trust gate)
 #     __PITURNEND__ absolute path to .pi/extensions/fm-primary-turnend-guard.ts in a pi secondmate home
@@ -1116,7 +1118,7 @@ launch_template() {
       if [ "$kind" = secondmate ]; then
         printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       else
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"__TURNEND_SIGNAL__ __STATE__ __TASK_ID__ __SPAWN_GEN__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       fi
       ;;
     opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
@@ -2279,6 +2281,8 @@ mkdir -p "$TASK_TMP/gotmp"
 mkdir -p "$STATE"
 STATE_REAL=$(cd "$STATE" && pwd -P)
 TURNEND="$STATE_REAL/$ID.turn-ended"
+TURNEND_SIGNAL="$FM_ROOT/bin/fm-turnend-signal.sh"
+SPAWN_GEN="s$(date +%s).${BASHPID:-$$}.$RANDOM"
 exclude_path() {
   local rel=$1 EXCL
   EXCL=$(git -C "$WT" rev-parse --git-path info/exclude 2>/dev/null || true)
@@ -2352,7 +2356,8 @@ if [ "$KIND" != secondmate ]; then
       busy_cmd_prefix="$(shell_quote "$FM_ROOT/bin/fm-busy-event.sh") apply $(shell_quote "$STATE_REAL") $(shell_quote "$ID")"
       busy_suffix="--gen $(shell_quote "$BUSY_GEN") --source claude-hook"
       j_submit=$(json_escape "$busy_cmd_prefix busy $busy_suffix --event user-prompt-submit 2>/dev/null || true")
-      j_stop=$(json_escape "touch $(shell_quote "$TURNEND"); $busy_cmd_prefix idle $busy_suffix --event stop 2>/dev/null || true")
+      turnend_cmd="$(shell_quote "$TURNEND_SIGNAL") $(shell_quote "$STATE_REAL") $(shell_quote "$ID") $(shell_quote "$SPAWN_GEN")"
+      j_stop=$(json_escape "$turnend_cmd; $busy_cmd_prefix idle $busy_suffix --event stop 2>/dev/null || true")
       j_stopfail=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event stop-failure 2>/dev/null || true")
       j_sessionend=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event session-end 2>/dev/null || true")
       cat > "$WT/.claude/settings.local.json" <<EOF
@@ -2404,7 +2409,7 @@ export const FmBusyState = async () => {
           await busyEvent("idle", "session-idle");
         }
         await new Promise((resolve) => {
-          execFile("touch", ["$TURNEND"], () => resolve());
+          execFile("$TURNEND_SIGNAL", ["$STATE_REAL", "$ID", "$SPAWN_GEN"], () => resolve());
         });
       }
     },
@@ -2442,7 +2447,7 @@ export default function (pi: any) {
     if (ctx && typeof ctx.isIdle === "function" && !ctx.isIdle()) return;
     return busyEvent("idle", "agent-settled");
   });
-  pi.on("turn_end", () => execFile("touch", ["$TURNEND"]));
+  pi.on("turn_end", () => execFile("$TURNEND_SIGNAL", ["$STATE_REAL", "$ID", "$SPAWN_GEN"]));
 }
 EOF
       ;;
@@ -2454,7 +2459,8 @@ EOF
       # firstmate-launched worker. Codex therefore classifies unknown with
       # an explicit reason rather than falling back to idle, and no busy
       # wiring is installed. The turn-end NOTIFICATION marker still rides
-      # the launch command via -c notify=[...] and __TURNEND__.
+      # the launch command via -c notify=[...] and the generation-bound
+      # fm-turnend-signal.sh command.
       ;;
     grok*)
       # grok fires a Stop hook at every turn boundary (verified, grok 0.2.73), the
@@ -2478,7 +2484,8 @@ EOF
       umask 077
       auth_file=$(mktemp "$GROK_AUTH_DIR/fm.XXXXXXXXXXXX")
       umask "$old_umask"
-      printf '%s\n' "$TURNEND" > "$auth_file"
+      printf 'target=%s\nspawn_gen=%s\nsignal=%s\n' \
+        "$TURNEND" "$SPAWN_GEN" "$TURNEND_SIGNAL" > "$auth_file"
       printf '%s\n' "${auth_file##*/}" > "$STATE/$ID.grok-turnend-token"
       sq_grok_auth_dir=$(shell_quote "$GROK_AUTH_DIR")
       cat > "$GROK_HOOKS_DIR/fm-turn-end.sh" <<EOF
@@ -2494,9 +2501,20 @@ IFS= read -r -n 256 first < "\$p" 2>/dev/null || [ -n "\$first" ] || exit 0
 case "\$first" in token=*) token=\${first#token=} ;; *) exit 0 ;; esac
 case "\$token" in fm.????????????) : ;; *) exit 0 ;; esac
 case "\$token" in *[!A-Za-z0-9._-]*) exit 0 ;; esac
-t=\$(cat "\$auth_dir/\$token" 2>/dev/null) || exit 0
-case "\$t" in /*.turn-ended) : ;; *) exit 0 ;; esac
-touch "\$t" 2>/dev/null || true
+registry="\$auth_dir/\$token"
+target= spawn_gen= signal= extra=
+IFS= read -r target < "\$registry" 2>/dev/null || exit 0
+IFS= read -r spawn_gen < <(sed -n '2p' "\$registry") || exit 0
+IFS= read -r signal < <(sed -n '3p' "\$registry") || exit 0
+IFS= read -r extra < <(sed -n '4p' "\$registry") || true
+case "\$target" in target=/*.turn-ended) target=\${target#target=} ;; *) exit 0 ;; esac
+case "\$spawn_gen" in spawn_gen=*) spawn_gen=\${spawn_gen#spawn_gen=} ;; *) exit 0 ;; esac
+case "\$signal" in signal=/*/bin/fm-turnend-signal.sh) signal=\${signal#signal=} ;; *) exit 0 ;; esac
+[ -z "\$extra" ] || exit 0
+state=\${target%/*}
+name=\${target##*/}
+id=\${name%.turn-ended}
+"\$signal" "\$state" "\$id" "\$spawn_gen" >/dev/null 2>&1 || true
 exit 0
 EOF
       chmod +x "$GROK_HOOKS_DIR/fm-turn-end.sh"
@@ -2566,7 +2584,8 @@ EOF
       umask 077
       auth_file=$(mktemp "$KIMI_AUTH_DIR/fm.XXXXXXXXXXXX")
       umask "$old_umask"
-      printf '%s\n' "$TURNEND" > "$auth_file"
+      printf 'target=%s\nspawn_gen=%s\nsignal=%s\n' \
+        "$TURNEND" "$SPAWN_GEN" "$TURNEND_SIGNAL" > "$auth_file"
       printf '%s\n' "${auth_file##*/}" > "$STATE/$ID.kimi-turnend-token"
       printf 'token=%s\n' "${auth_file##*/}" > "$WT/.fm-kimi-turnend"
       exclude_path '.fm-kimi-turnend'
@@ -2620,7 +2639,6 @@ fi
 
 META_WINDOW=$T
 [ "$BACKEND" = orca ] && META_WINDOW=$W
-SPAWN_GEN="s$(date +%s).${BASHPID:-$$}.$RANDOM"
 SPAWN_META_PATH="$STATE/$ID.meta"
 if [ "$RELAUNCH" -eq 1 ]; then
   SPAWN_META_LOCK=$(fm_meta_lock_path "$STATE/$ID.meta") || exit 1
@@ -2706,7 +2724,10 @@ fi
 [ "$BACKEND" = orca ] && ORCA_ABORT_CLEANUP=0
 
 sq_brief=$(shell_quote "$BRIEF")
-sq_turnend=$(shell_quote "$TURNEND")
+sq_turnend_signal=$(shell_quote "$TURNEND_SIGNAL")
+sq_state=$(shell_quote "$STATE_REAL")
+sq_task_id=$(shell_quote "$ID")
+sq_spawn_gen=$(shell_quote "$SPAWN_GEN")
 sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
 sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts")
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
@@ -2717,7 +2738,10 @@ EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
 LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}
-LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
+LAUNCH=${LAUNCH//__TURNEND_SIGNAL__/$sq_turnend_signal}
+LAUNCH=${LAUNCH//__STATE__/$sq_state}
+LAUNCH=${LAUNCH//__TASK_ID__/$sq_task_id}
+LAUNCH=${LAUNCH//__SPAWN_GEN__/$sq_spawn_gen}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2274,7 +2274,7 @@ fi
 TASK_TMP="/tmp/fm-$ID"
 mkdir -p "$TASK_TMP/gotmp"
 
-# Per-harness turn-end hook where enabled: a file that touches
+# Per-harness turn-end hook where enabled: a generation-bound publisher creates
 # state/<id>.turn-ended when the agent finishes a turn. Worktree-resident hooks
 # and token pointers stay out of git's view so they never block teardown's dirty
 # check or leak into a commit.
@@ -2349,7 +2349,7 @@ if [ "$KIND" != secondmate ]; then
       # never leave a stale busy record. Claude fires no hook for a manual
       # interrupt: fm-control preserves the adapter-owned state, while the
       # legacy fm-send --key Escape path records idle/fm-interrupt. Stop keeps
-      # the turn-ended NOTIFICATION touch for the watcher. Every
+      # the generation-bound turn-ended NOTIFICATION for the watcher. Every
       # hook command tolerates a refused event (|| true) so a stale-gen writer
       # can never break Claude's own lifecycle.
       mkdir -p "$WT/.claude"
@@ -2375,7 +2375,7 @@ EOF
 // reports activity (the worker's main session - a subagent child session can
 // only start while the main session is already busy) and ignores other
 // sessions' status until the latched session settles, so a child's idle can
-// never clear the worker's busy state. The session.idle touch stays the
+// never clear the worker's busy state. The session.idle publication stays the
 // watcher's wake NOTIFICATION, never current-state truth.
 import { execFile } from "node:child_process";
 const busyEvent = (state, event) =>
@@ -2431,7 +2431,7 @@ EOF
 // loops, and queued continuations all keep the run un-settled, and a settle
 // that raced another extension's fresh run keeps state busy via isIdle().
 // "turn_end" fires at every inner turn boundary (one LLM response plus its
-// tool calls) and stays a wake NOTIFICATION touch for the watcher, never
+// tool calls) and stays a wake NOTIFICATION publication for the watcher, never
 // current-state truth.
 import { execFile } from "node:child_process";
 const busyEvent = (state: string, event: string) =>

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -196,6 +196,7 @@ family_for_basename() {
       printf '%s\n' live-harness-optin
       ;;
     fm-backend-herdr.test.sh|fm-backend-tmux-smoke.test.sh|fm-backend.test.sh|\
+    fm-busy-adapter-wiring.test.sh|\
     fm-tmux-agent-liveness.test.sh|\
     fm-control.test.sh|fm-control-relaunch.test.sh|\
     fm-herdr-session-cleanup.test.sh|fm-send-resolve-key.test.sh|fm-send-strict.test.sh|fm-spawn-batch.test.sh|\
@@ -947,9 +948,12 @@ families_for_changed_path() {
       printf '%s\n' pure-contract-unit
       printf '%s\n' live-harness-optin
       ;;
-    bin/fm-spawn.sh|bin/fm-send.sh|bin/fm-harness.sh|\
+    bin/fm-spawn.sh|bin/fm-send.sh|bin/fm-harness.sh|bin/fm-turnend-signal.sh|\
     bin/fm-peek.sh|bin/fm-composer*)
       printf '%s\n' backend-dispatch
+      printf '%s\n' pure-contract-unit
+      ;;
+    bin/fm-kimi-turnend-hook.sh)
       printf '%s\n' pure-contract-unit
       ;;
     bin/fm-bearings-snapshot.sh|bin/fm-fleet-snapshot.sh|bin/fm-fleet-view.sh)

--- a/bin/fm-turnend-signal.sh
+++ b/bin/fm-turnend-signal.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Publish one task turn-end notification only while the exact spawning
+# incarnation still owns that task's metadata.
+#
+# Usage:
+#   fm-turnend-signal.sh <state-dir> <task-id> <spawn-gen>
+#
+# Every per-task harness hook embeds the spawn_gen minted by fm-spawn.sh.
+# This writer takes the task metadata lock without waiting, verifies both the
+# task identity and that generation, then touches state/<id>.turn-ended.
+# A hook retained in harness memory after teardown, or one from an older worker
+# after a same-id relaunch, is therefore a silent no-op. Contention is also a
+# silent no-op so a notification hook can never delay or break harness shutdown.
+set -u
+
+STATE_DIR=${1:-}
+ID=${2:-}
+SPAWN_GEN=${3:-}
+
+case "$ID" in
+  ''|*[!A-Za-z0-9._-]*) exit 0 ;;
+esac
+case "$SPAWN_GEN" in
+  ''|*[!A-Za-z0-9._-]*) exit 0 ;;
+esac
+[ -d "$STATE_DIR" ] && [ ! -L "$STATE_DIR" ] || exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_STATE_OVERRIDE=$STATE_DIR
+export FM_STATE_OVERRIDE
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-backend.sh
+. "$SCRIPT_DIR/fm-backend.sh"
+
+META="$STATE_DIR/$ID.meta"
+LOCK=$(fm_meta_lock_path "$META") || exit 0
+fm_lock_try_acquire "$LOCK" || exit 0
+trap 'fm_lock_release "$LOCK"' EXIT
+
+[ -f "$META" ] && [ ! -L "$META" ] || exit 0
+META_ID=$(fm_meta_get "$META" endpoint_task_id)
+META_GEN=$(fm_meta_get "$META" spawn_gen)
+[ "$META_ID" = "$ID" ] && [ "$META_GEN" = "$SPAWN_GEN" ] || exit 0
+
+touch -- "$STATE_DIR/$ID.turn-ended" 2>/dev/null || true
+exit 0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -242,6 +242,7 @@ Those inherited values are defaults and rules only; `fm-spawn` still permits a c
 `config/secondmate-harness` is not inherited because secondmates do not launch secondmates.
 For grok, `fm-spawn.sh` installs one firstmate-owned global turn-end hook under `$GROK_HOME/hooks/`, or `~/.grok/hooks/` when `GROK_HOME` is unset, and drops a per-task `.fm-grok-turnend` pointer in the worktree, with teardown removing the task token and pointer.
 For Kimi crews, `fm-spawn.sh` runs `fm-kimi-turnend-hook.sh install`, drops a per-task `.fm-kimi-turnend` pointer in the worktree, and records the matching private registry token for teardown.
+Every task turn-end notification is bound to the `spawn_gen` in that task's locked metadata, so an old in-memory hook, a recycled-worktree hook, or a persistent global token becomes inert as soon as teardown retires the task or relaunch replaces its incarnation.
 Kimi continues to use the captain's normal Kimi home, including the existing config, skills, and memory; Firstmate does not create an isolated Kimi home.
 The Kimi installer requires an existing regular non-symlink `~/.kimi-code/config.toml`, `python3` with `tomllib`, and `jq`; it validates but never serializes the captain's TOML and refuses before writing when the config is missing, malformed, or surprising or when either tool requirement is unavailable.
 Its `remove` action excises only the marker-delimited Firstmate region and removes Firstmate's hook files.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -39,6 +39,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-session-lock-lib.sh` | Shared session-lock harness identity (ancestry walk and holder liveness) for fm-lock.sh and the Claude Stop auto-arm |
 | `fm-claude-stop-autoarm.sh` | Claude Stop `asyncRewake` hook owning tokenless watcher continuity with single-flight exit-2 rewake (docs/watcher-continuity.md) |
 | `fm-turnend-guard.sh`    | Shared primary turn-end guard predicate so no turn ends blind (docs/turnend-guard.md) |
+| `fm-turnend-signal.sh`   | Spawn-incarnation-bound publisher for task turn-end notification markers             |
 | `fm-turnend-guard-grok.sh` | Grok Stop-hook adapter for the primary turn-end guard                              |
 | `fm-kimi-turnend-hook.sh` | Surgically install or remove Kimi's guarded global crew turn-end hook                |
 | `fm-arm-pretool-check.sh` | Stable PreToolUse transport for the watcher-arm command policy (docs/arm-pretool-check.md) |

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -151,7 +151,7 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 It also covers true-reason banner wording and reason-keyed episode dedup surviving a beacon mtime change.
 `tests/fm-cursor-primary.test.sh` covers the Cursor park end to end over real processes with no harness installed: each tracked Claude-shaped entrypoint standing down on a Cursor payload, both follow-up sources, the bounded repair nag and its reset, the nested loop bounds, supersession, away-mode and lock-ownership inertness, child-worktree exclusion, and that the adapter never exits 2.
 `FM_CURSOR_PRIMARY_LIVE_E2E=1 tests/fm-cursor-primary-live-e2e.test.sh` is the opt-in guard that proves the same behavior against the installed cursor-agent and fails naming the harness and version.
-`tests/fm-kimi-harness.test.sh` covers the separate Kimi crew hook's format preservation, idempotence, refusal cases, token guard, spawn registration, and teardown cleanup.
+`tests/fm-kimi-harness.test.sh` covers the separate Kimi crew hook's format preservation, idempotence, refusal cases, token guard, spawn registration, generation-bound publication, legacy-registry inertness, and teardown cleanup.
 `tests/fm-supervision-instructions.test.sh` covers recovery-line ownership and pi-signed's identity-preserving reuse of Pi's protocol.
 `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` is the opt-in isolated Pi path.
 [`verification/supervision.md`](verification/supervision.md#turn-end-guard) records the active cross-harness empirical evidence, including the 2026-07-24 Claude `asyncRewake` revalidation.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -138,7 +138,7 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 - Kimi Code CLI 0.29.1 exposes only global `[[hooks]]` configuration in `~/.kimi-code/config.toml`, including a `Stop` event with snake_case payload fields `hook_event_name`, `session_id`, `cwd`, and `stop_hook_active`.
 - Kimi has no project-level hook configuration and remains outside the primary guard integrations above.
 - Captain-approved Kimi crew wake support uses `bin/fm-kimi-turnend-hook.sh` to edit only one marker-delimited Firstmate region in that global config and install a silent always-zero hook.
-- The hook remains inert unless the payload `cwd` contains a per-task token pointer that resolves through Firstmate's private registry to one `state/<id>.turn-ended` marker.
+- The hook remains inert unless the payload `cwd` contains a per-task token pointer that resolves through Firstmate's private registry and the generation-bound task notification publisher described in [`configuration.md`](configuration.md#harness-support) accepts it.
 - Installation refuses before writing unless `python3` with `tomllib` and `jq` are available.
 - If `jq` is removed after installation, the hook remains silent and exits 0, turn-end wakes stop, and Kimi crews fall back to idle detection.
 - Unreadable hook input remains fail-open.

--- a/tests/fm-busy-adapter-wiring.test.sh
+++ b/tests/fm-busy-adapter-wiring.test.sh
@@ -30,7 +30,18 @@ esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;
-  has-session|new-session|new-window|kill-window|send-keys) exit 0 ;;
+  send-keys)
+    prev=
+    for arg in "$@"; do
+      if [ "$prev" = -l ]; then
+        [ -z "${FM_FAKE_LITERAL_LOG:-}" ] || printf '%s\n' "$arg" >> "$FM_FAKE_LITERAL_LOG"
+        break
+      fi
+      prev=$arg
+    done
+    exit 0
+    ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
 esac
 exit 0
 SH
@@ -66,6 +77,7 @@ run_spawn() {  # <home> <wt> <fakebin> <spawn-args...>
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    FM_FAKE_LITERAL_LOG="$home/tmux-literals.log" \
     GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
     "$SPAWN" "$@" 2>&1
 }
@@ -79,6 +91,26 @@ EOF
 
 classify() {  # <harness> <id> <state-dir>
   fm_busy_classify tmux fake:w "$1" "$2" "$3"
+}
+
+test_turnend_signal_requires_live_spawn_incarnation() {
+  local state="$TMP_ROOT/turnend-signal" id=turnend-x1 marker meta
+  marker="$state/$id.turn-ended"
+  meta="$state/$id.meta"
+  mkdir -p "$state"
+  printf 'endpoint_task_id=%s\nspawn_gen=spawn-one\n' "$id" > "$meta"
+
+  "$ROOT/bin/fm-turnend-signal.sh" "$state" "$id" spawn-one
+  assert_present "$marker" "the live spawn incarnation did not publish its turn-end marker"
+
+  rm -f "$marker"
+  "$ROOT/bin/fm-turnend-signal.sh" "$state" "$id" spawn-old
+  assert_absent "$marker" "a mismatched spawn incarnation published a turn-end marker"
+
+  rm -f "$meta"
+  "$ROOT/bin/fm-turnend-signal.sh" "$state" "$id" spawn-one
+  assert_absent "$marker" "a retired task's turn-end writer recreated its marker"
+  pass "turn-end marker publication requires the exact live task spawn incarnation"
 }
 
 # drive_pi_ext <ext-path> <mode>: load the generated Pi extension in a plain
@@ -142,6 +174,10 @@ test_pi_extension_semantic_lifecycle() {
   out=$(drive_pi_ext "$ext" settle-idle) || fail "final settle drive failed: $out"
   out=$(classify pi "$id" "$state")
   [ "$out" = "idle pi-ext" ] || fail "the final settle must classify idle, got '$out'"
+
+  rm -f "$state/$id.turn-ended" "$state/$id.meta"
+  out=$(drive_pi_ext "$ext" turn-end) || fail "retired turn_end drive failed: $out"
+  assert_absent "$state/$id.turn-ended" "a retired Pi extension recreated its task marker"
   pass "pi extension reports agent_start busy, settles idle only via ctx.isIdle(), and keeps turn_end a notification"
 }
 
@@ -246,6 +282,10 @@ test_opencode_plugin_semantic_lifecycle() {
   [ -f "$state/$id.turn-ended" ] || fail "the marker touch must stay a notification for every session.idle"
   out=$(classify opencode "$id" "$state")
   [ "$out" = "busy opencode-plugin" ] || fail "another session's idle must not clear the latched busy, got '$out'"
+
+  rm -f "$state/$id.turn-ended" "$state/$id.meta"
+  out=$(drive_oc_plugin "$plugin" "$(oc_idle ses2)") || fail "retired session.idle drive failed: $out"
+  assert_absent "$state/$id.turn-ended" "a retired OpenCode plugin recreated its task marker"
   pass "opencode plugin classifies from session.status, scoped to the latched worker session"
 }
 
@@ -295,7 +335,7 @@ test_claude_hooks_semantic_lifecycle() {
 }
 
 test_claude_hooks_stale_incarnation_harmless() {
-  local rec id=busy-cl-2 out state settings
+  local rec id=busy-cl-2 out state settings meta tmp
   rec=$(make_spawn_case claude-stale claude "$id")
   read_case_record "$rec"
   out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" "$PROJ_DIR")
@@ -303,6 +343,14 @@ test_claude_hooks_stale_incarnation_harmless() {
   state="$HOME_DIR/state"
   settings="$WT_DIR/.claude/settings.local.json"
   "$ROOT/bin/fm-busy-event.sh" arm "$state" "$id" >/dev/null
+  meta="$state/$id.meta"
+  tmp="$meta.tmp"
+  awk '{ if ($0 ~ /^spawn_gen=/) print "spawn_gen=replacement"; else print }' "$meta" > "$tmp"
+  mv -f "$tmp" "$meta"
+  rm -f "$state/$id.turn-ended"
+  run_claude_hook "$settings" Stop \
+    || fail "a stale-incarnation Stop hook must still exit 0 so Claude can stop"
+  assert_absent "$state/$id.turn-ended" "a stale Claude hook recreated its task marker"
   run_claude_hook "$settings" UserPromptSubmit \
     || fail "a stale-gen hook must still exit 0 so Claude's lifecycle is never broken"
   out=$(classify claude "$id" "$state")
@@ -311,7 +359,7 @@ test_claude_hooks_stale_incarnation_harmless() {
 }
 
 test_codex_unverified_until_a_semantic_source_exists() {
-  local rec id=busy-cx-1 out state
+  local rec id=busy-cx-1 out state launch notify_cmd
   rec=$(make_spawn_case codex-unverified codex "$id")
   read_case_record "$rec"
   out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" "$PROJ_DIR")
@@ -324,6 +372,18 @@ test_codex_unverified_until_a_semantic_source_exists() {
   [ "$out" = "unknown codex-unverified" ] || fail "codex must classify 'unknown codex-unverified', got '$out'"
   out=$(fm_busy_classify tmux fake:w codex "$id" "$state" '• Working (6s • esc to interrupt)')
   [ "$out" = "unknown codex-unverified" ] || fail "codex must not fall back to footer text, got '$out'"
+
+  launch=$(tail -1 "$HOME_DIR/tmux-literals.log")
+  notify_cmd=$(printf '%s\n' "$launch" \
+    | sed -n 's/.*notify=\[\\"bash\\",\\"-c\\",\\"\(.*\)\\"\].*/\1/p')
+  [ -n "$notify_cmd" ] || fail "codex launch did not carry an executable turn-end notification"
+  rm -f "$state/$id.turn-ended"
+  sh -c "$notify_cmd"
+  assert_present "$state/$id.turn-ended" "codex notification did not publish for its live spawn"
+
+  rm -f "$state/$id.turn-ended" "$state/$id.meta"
+  sh -c "$notify_cmd"
+  assert_absent "$state/$id.turn-ended" "a retired Codex notification recreated its task marker"
   pass "codex classifies unknown until a semantic source is verified, never idle or footer-matched"
 }
 
@@ -342,6 +402,7 @@ test_kimi_and_grok_install_no_unverified_wiring() {
   pass "kimi and grok install no unverified semantic wiring and classify through their own gates"
 }
 
+test_turnend_signal_requires_live_spawn_incarnation
 test_pi_extension_semantic_lifecycle
 test_pi_extension_serializes_settle_before_next_start
 test_pi_extension_stale_incarnation_rejected

--- a/tests/fm-grok-harness.test.sh
+++ b/tests/fm-grok-harness.test.sh
@@ -57,7 +57,7 @@ run_grok_spawn() {
 }
 
 test_grok_hook_requires_registered_token() {
-  local rec case_dir home proj wt fakebin grok_home id out status hook token target evil evil_target
+  local rec case_dir home proj wt fakebin grok_home id out status hook token target registry registry_content evil evil_target
   rec=$(make_spawn_case hook-auth)
   IFS='|' read -r case_dir home proj wt fakebin grok_home id <<EOF
 $rec
@@ -73,7 +73,8 @@ EOF
   target="$home/state/$id.turn-ended"
   assert_no_grep "$target" "$wt/.fm-grok-turnend" "grok pointer exposed the turn-end path"
   token=$(sed -n 's/^token=//p' "$wt/.fm-grok-turnend")
-  assert_present "$grok_home/hooks/fm-turn-end.d/$token" "grok auth registry entry was not written"
+  registry="$grok_home/hooks/fm-turn-end.d/$token"
+  assert_present "$registry" "grok auth registry entry was not written"
 
   evil="$case_dir/evil"
   evil_target="$case_dir/evil-target.turn-ended"
@@ -92,6 +93,17 @@ EOF
   printf 'token=%s\n' "$token" > "$wt/.fm-grok-turnend"
   GROK_WORKSPACE_ROOT="$wt" bash "$hook"
   assert_present "$target" "registered grok pointer did not touch the task turn-end file"
+
+  rm -f "$target"
+  registry_content=$(cat "$registry")
+  printf '%s\n' "$target" > "$registry"
+  GROK_WORKSPACE_ROOT="$wt" bash "$hook"
+  assert_absent "$target" "a legacy one-line grok registry entry remained active"
+  printf '%s\n' "$registry_content" > "$registry"
+
+  rm -f "$target" "$home/state/$id.meta"
+  GROK_WORKSPACE_ROOT="$wt" bash "$hook"
+  assert_absent "$target" "a retired task's grok token recreated its turn-end marker"
   pass "grok global hook requires a firstmate registry token"
 }
 

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -196,7 +196,7 @@ test_kimi_launch_then_send_is_verified() {
     || fail "kimi launch did not use the absolute binary, model, and --auto only: $launch"
   assert_not_contains "$launch" "--effort" "kimi launch emitted a nonexistent effort flag"
   assert_not_contains "$launch" "turn-ended" "kimi launch embedded a turn-end path"
-  assert_not_contains "$launch" "__TURNEND__" "kimi launch retained a turn-end placeholder"
+  assert_not_contains "$launch" "__TURNEND_SIGNAL__" "kimi launch retained a turn-end placeholder"
 
   brief_real="$(cd "$HOME_DIR/data/$id" && pwd -P)/brief.md"
   pointer=$(cat "$CASE_DIR/pointer.log")
@@ -355,7 +355,7 @@ test_kimi_hook_install_refuses_without_jq() {
 }
 
 test_kimi_hook_is_silent_and_requires_registered_workspace_token() {
-  local id rec out rc hook target token no_token snapshot_before snapshot_after fakebin
+  local id rec out rc hook target token registry registry_content no_token snapshot_before snapshot_after fakebin
   id=kimi-hook-auth-z6
   rec=$(make_spawn_case hook-auth "$id")
   read_spawn_record "$rec"
@@ -365,7 +365,8 @@ test_kimi_hook_is_silent_and_requires_registered_workspace_token() {
   hook="$HOME_DIR/.kimi-code/fm-turn-end.sh"
   target="$HOME_DIR/state/$id.turn-ended"
   token=$(sed -n 's/^token=//p' "$WT_DIR/.fm-kimi-turnend")
-  assert_present "$HOME_DIR/.kimi-code/fm-turn-end.d/$token" "Kimi registry token is missing"
+  registry="$HOME_DIR/.kimi-code/fm-turn-end.d/$token"
+  assert_present "$registry" "Kimi registry token is missing"
 
   no_token="$CASE_DIR/no-token-workspace"
   mkdir -p "$no_token"
@@ -387,7 +388,25 @@ test_kimi_hook_is_silent_and_requires_registered_workspace_token() {
   [ -z "$out" ] || fail "registered Kimi hook invocation printed output: $out"
   assert_present "$target" "registered Kimi hook invocation did not touch the turn-end marker"
 
-  rm "$target"
+  rm -f "$target"
+  registry_content=$(cat "$registry")
+  printf '%s\n' "$target" > "$registry"
+  out=$(printf '{"hook_event_name":"Stop","session_id":"legacy","cwd":"%s","stop_hook_active":false}\n' "$WT_DIR" \
+    | HOME="$HOME_DIR" bash "$hook" 2>&1)
+  rc=$?
+  expect_code 0 "$rc" "legacy-registry Kimi hook invocation did not exit zero"
+  [ -z "$out" ] || fail "legacy-registry Kimi hook invocation printed output: $out"
+  assert_absent "$target" "a legacy one-line Kimi registry entry remained active"
+  printf '%s\n' "$registry_content" > "$registry"
+
+  rm -f "$target" "$HOME_DIR/state/$id.meta"
+  out=$(printf '{"hook_event_name":"Stop","session_id":"retired","cwd":"%s","stop_hook_active":false}\n' "$WT_DIR" \
+    | HOME="$HOME_DIR" bash "$hook" 2>&1)
+  rc=$?
+  expect_code 0 "$rc" "retired Kimi hook invocation did not exit zero"
+  [ -z "$out" ] || fail "retired Kimi hook invocation printed output: $out"
+  assert_absent "$target" "a retired task's Kimi token recreated its turn-end marker"
+
   fakebin=$(fm_fakebin "$CASE_DIR/no-jq")
   ln -s "$(command -v bash)" "$fakebin/bash"
   out=$(printf '{"hook_event_name":"Stop","session_id":"crew","cwd":"%s","stop_hook_active":false}\n' "$WT_DIR" \


### PR DESCRIPTION
## Intent

Find and fix firstmate's stray state/eslint-config.turn-ended recreation after task teardown. Instrument and investigate the writer, and inspect every registered turn-end surface across Claude project and user settings, Codex hooks and notify configuration, Kimi config.toml and its HOME token registry, Grok's HOME global hook registry, OpenCode plugins, and Pi extensions, treating the persistent Kimi and Grok registries as prime suspects. Remove any stale registration through its owner's documented mechanism, add executable regression protection so a torn-down task's turn-end registration cannot outlive that task, preserve live turn-end notification behavior across every supported harness, and document the root cause in the PR. The historical writer had already stopped and native macOS fs_usage required root, so rely on captured hook behavior and historical session and marker evidence without adding a tracing dependency. The discovered root-cause class is unguarded raw marker touches retained in harness memory after teardown or superseding relaunch; bind every notification to the task's live spawn incarnation and make legacy global registry records inert. Follow the firstmate coding guidelines.

## What Changed

- Route Claude, Codex, OpenCode, Pi, Kimi, and Grok turn-end notifications through a publisher that verifies the task’s locked `spawn_gen` metadata before recreating its marker.
- Store generation-bound Kimi and Grok registry records and make legacy one-line records inert, preventing retained hooks from writing after teardown or superseding relaunches.
- Add regression coverage for live, stale, legacy, and retired notification paths and document the spawn-incarnation contract.

## Risk Assessment

✅ Low: The change consistently routes task turn-end writers through a metadata-locked spawn-incarnation check, makes legacy global registry entries inert, and adds behavior-level regression coverage for live, superseded, and torn-down tasks across the affected harness paths.

## Testing

Focused generated-hook and plugin lifecycle tests exercised live delivery, teardown, same-ID superseding relaunch, and legacy registry behavior across all supported harnesses. Claude, Codex, OpenCode, Pi, Grok, and the generation publisher passed initially; Kimi initially encountered macOS `/usr/bin/python3` lacking `tomllib`, then passed completely using the available Python 3.14 interpreter. Reviewer-visible CLI transcripts were captured, and testing left the worktree unchanged.

<details>
<summary>Evidence: Multi-harness turn-end regression transcript</summary>

Source: [Multi-harness turn-end regression transcript](https://github.com/pm-justinm/firstmate/blob/30b407cbef16226b7209286e0c0323922685c818/.no-mistakes/evidence/fm/stray-turnend-marker/turnend-harness-regression.txt)

```text
FM_TEST_BEGIN 2026-08-18T01:42:21Z tests/fm-busy-adapter-wiring.test.sh family=backend-dispatch expected_gate_skip=none
ok - turn-end marker publication requires the exact live task spawn incarnation
ok - pi extension reports agent_start busy, settles idle only via ctx.isIdle(), and keeps turn_end a notification
ok - pi extension awaits agent_settled before the next agent_start without a test delay
ok - pi extension events from a superseded incarnation are rejected as stale
ok - kimi and grok install no unverified semantic wiring and classify through their own gates
ok - opencode plugin classifies from session.status, scoped to the latched worker session
ok - claude hooks open on UserPromptSubmit and close on Stop, StopFailure, and SessionEnd
ok - claude hook events from a superseded incarnation are rejected without breaking the hook
ok - codex classifies unknown until a semantic source is verified, never idle or footer-matched
all fm-busy-adapter-wiring tests passed
FM_TEST_END 2026-08-18T01:42:58Z tests/fm-busy-adapter-wiring.test.sh exit=0 duration_ms=36203 gate_skip=false
FM_TEST_BEGIN 2026-08-18T01:42:58Z tests/fm-kimi-harness.test.sh family=pure-contract-unit expected_gate_skip=none
fm-kimi-turnend-hook: refused: python3 with tomllib is required to validate config.toml.
not ok - Kimi hook install refused a realistic config
FM_TEST_END 2026-08-18T01:42:59Z tests/fm-kimi-harness.test.sh exit=1 duration_ms=869 gate_skip=false
FM_TEST_BEGIN 2026-08-18T01:42:59Z tests/fm-grok-harness.test.sh family=pure-contract-unit expected_gate_skip=none
ok - grok global hook requires a firstmate registry token
ok - grok teardown removes pointer and token state
ok - fm-lock recognizes grok harness processes
FM_TEST_END 2026-08-18T01:43:14Z tests/fm-grok-harness.test.sh exit=0 duration_ms=15659 gate_skip=false
FM_TEST_SUMMARY total=3 failed=1 skipped_gate=0 duration_ms=52974
FM_TEST_SUMMARY_FAMILY family=backend-dispatch count=1 duration_ms=36203 failed=0
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=2 duration_ms=16528 failed=1
FM_TEST_SLOWEST rank=1 script=tests/fm-busy-adapter-wiring.test.sh duration_ms=36203
FM_TEST_SLOWEST rank=2 script=tests/fm-grok-harness.test.sh duration_ms=15659
FM_TEST_SLOWEST rank=3 script=tests/fm-kimi-harness.test.sh duration_ms=869
```
</details>
<details>
<summary>Evidence: Kimi turn-end regression retry transcript</summary>

Source: [Kimi turn-end regression retry transcript](https://github.com/pm-justinm/firstmate/blob/30b407cbef16226b7209286e0c0323922685c818/.no-mistakes/evidence/fm/stray-turnend-marker/kimi-turnend-regression.txt)

```text
FM_TEST_BEGIN 2026-08-18T01:43:37Z tests/fm-kimi-harness.test.sh family=pure-contract-unit expected_gate_skip=none
ok - Kimi hook install is idempotent and removal restores every foreign config byte
ok - Kimi hook removal preserves owned newline boundaries and pristine bytes
ok - Kimi hook install refuses missing, malformed, and surprising config without writing
ok - Kimi hook install refuses without jq before any config write
ok - fm-spawn: kimi launches, delivers its brief, and registers a guarded turn-end token
ok - Kimi hook stays silent and inert without a Firstmate registry token
ok - fm-spawn: unsafe Kimi global config refuses before pane creation
ok - fm-teardown: Kimi task pointer and registry token are removed
ok - fm-spawn: Kimi fallback expands the active HOME
ok - fm-spawn: missing Kimi executable refuses before pane creation
ok - fm-spawn: kimi treats a silent pointer drop as a failed spawn
ok - fm-spawn: kimi never sends the brief pointer before an observable ready signal
ok - fm-harness: markerless kimi is detected by ancestry after env-marker precedence
lock acquired: harness pid 75956
ok - fm-lock recognizes Kimi ancestry and live lock holders
ok - busy detection: real Kimi moon-plus-middot captures require its harness while idle labels stay idle
ok - fm-watch classifies Kimi as unknown rather than from its spinner, and Grok's fallback stays isolated
ok - composer classifier: kimi's existing bordered > shape is already safe without an override
FM_TEST_END 2026-08-18T01:44:11Z tests/fm-kimi-harness.test.sh exit=0 duration_ms=33807 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=33928
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=1 duration_ms=33807 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-kimi-harness.test.sh duration_ms=33807
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"07e37493d5287538c384a203604a4f12a16b60dc","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 64d61aed84373e02b1a28c4e6b262908ed8128d5 dc76f6af6e780b216007a9423fc9e3a9dd2d0568` to map the intent to executable behavior.</code>
- `bin/fm-test-run.sh tests/fm-busy-adapter-wiring.test.sh tests/fm-kimi-harness.test.sh tests/fm-grok-harness.test.sh`
- `PATH=/opt/homebrew/opt/python@3.14/bin:$PATH bin/fm-test-run.sh tests/fm-kimi-harness.test.sh`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
