### PR TITLE
feat(bin): add deliverable inventory instruction to ship briefs

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -54,11 +54,6 @@
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
 # over copied detail) and has the crewmate add the fm-ensure-agents-md.sh
 # self-governance section when a touched project AGENTS.md lacks it.
-# Ship briefs also carry a deliverable-inventory section before the definition
-# of done, worded identically in all three modes: before reporting done the
-# crewmate accounts for every task-named surface it implemented or deliberately
-# skipped, in its pane rather than the one-line status file. Scout and secondmate
-# scaffolds omit it.
 # Refuses to overwrite an existing brief.
 set -eu
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -54,6 +54,11 @@
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
 # over copied detail) and has the crewmate add the fm-ensure-agents-md.sh
 # self-governance section when a touched project AGENTS.md lacks it.
+# Ship briefs also carry a deliverable-inventory section before the definition
+# of done, worded identically in all three modes: before reporting done the
+# crewmate accounts for every task-named surface it implemented or deliberately
+# skipped, in its pane rather than the one-line status file. Scout and secondmate
+# scaffolds omit it.
 # Refuses to overwrite an existing brief.
 set -eu
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -410,7 +410,8 @@ IFS= read -r -d '' DELIVERABLE_INVENTORY <<'EOF' || true
 Before reporting done, list every distinct surface named by the task - files, components, screens, endpoints, config, and documentation.
 For each surface, state where you implemented it.
 Explicitly identify every surface you deliberately skipped and why.
-If you cannot complete this inventory, say so in your completion report rather than blocking the report.
+Report the inventory in your final message in your pane, never in the status file - status lines stay one line.
+If you cannot complete this inventory, say so there rather than blocking the report.
 EOF
 DELIVERABLE_INVENTORY=${DELIVERABLE_INVENTORY%$'\n'}
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -404,6 +404,16 @@ EOF
     ;;
 esac
 
+# Keep this shared across every ship mode so the completion prompt cannot drift.
+IFS= read -r -d '' DELIVERABLE_INVENTORY <<'EOF' || true
+# Deliverable inventory
+Before reporting done, list every distinct surface named by the task - files, components, screens, endpoints, config, and documentation.
+For each surface, state where you implemented it.
+Explicitly identify every surface you deliberately skipped and why.
+If you cannot complete this inventory, say so in your completion report rather than blocking the report.
+EOF
+DELIVERABLE_INVENTORY=${DELIVERABLE_INVENTORY%$'\n'}
+
 # read -r -d '' preserves the heredoc's trailing newline that the removed
 # $(...) command substitution used to strip. Drop that one newline so generated
 # briefs stay byte-identical to the historical Bash 5 output.
@@ -458,6 +468,8 @@ Record only project knowledge useful to almost every future session.
 For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
 If you touch a project \`AGENTS.md\` that lacks \`## Maintaining this file\`, add that short self-governance section from \`$FM_ROOT/bin/fm-ensure-agents-md.sh\` in the same pass.
 Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
+
+$DELIVERABLE_INVENTORY
 
 $DOD
 EOF

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -235,7 +235,9 @@ test_deliverable_inventory_is_ship_only() {
       "$mode brief did not require implementation locations"
     assert_grep "Explicitly identify every surface you deliberately skipped and why." "$brief" \
       "$mode brief did not require deliberate omissions"
-    assert_grep "If you cannot complete this inventory, say so in your completion report rather than blocking the report." "$brief" \
+    assert_grep "Report the inventory in your final message in your pane, never in the status file - status lines stay one line." "$brief" \
+      "$mode brief did not keep the inventory out of the one-line status protocol"
+    assert_grep "If you cannot complete this inventory, say so there rather than blocking the report." "$brief" \
       "$mode brief turned the inventory prompt into a hard gate"
     inventory_line=$(grep -nFx "# Deliverable inventory" "$brief" | cut -d: -f1)
     dod_line=$(grep -nFx "# Definition of done" "$brief" | cut -d: -f1)

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -217,6 +217,49 @@ test_ship_modes_generate_clean_briefs() {
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"
 }
 
+test_deliverable_inventory_is_ship_only() {
+  local home id mode brief inventory_line dod_line
+  home="$TMP_ROOT/deliverable-inventory-home"
+  mkdir -p "$home/data"
+
+  for mode in no-mistakes direct-PR local-only; do
+    id="brief-inventory-$mode"
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1 \
+      || fail "$mode brief should scaffold with the deliverable inventory"
+    brief="$home/data/$id/brief.md"
+    assert_grep "# Deliverable inventory" "$brief" \
+      "$mode brief missing the deliverable inventory"
+    assert_grep "list every distinct surface named by the task - files, components, screens, endpoints, config, and documentation" "$brief" \
+      "$mode brief did not inventory every named surface"
+    assert_grep "For each surface, state where you implemented it." "$brief" \
+      "$mode brief did not require implementation locations"
+    assert_grep "Explicitly identify every surface you deliberately skipped and why." "$brief" \
+      "$mode brief did not require deliberate omissions"
+    assert_grep "If you cannot complete this inventory, say so in your completion report rather than blocking the report." "$brief" \
+      "$mode brief turned the inventory prompt into a hard gate"
+    inventory_line=$(grep -nFx "# Deliverable inventory" "$brief" | cut -d: -f1)
+    dod_line=$(grep -nFx "# Definition of done" "$brief" | cut -d: -f1)
+    [ "$inventory_line" -lt "$dod_line" ] \
+      || fail "$mode brief placed the deliverable inventory after Definition of done"
+  done
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-inventory-scout some-proj --scout >/dev/null 2>&1 \
+    || fail "scout brief should scaffold"
+  assert_no_grep "# Deliverable inventory" "$home/data/brief-inventory-scout/brief.md" \
+    "scout brief must not carry the ship deliverable inventory"
+  assert_no_grep "list every distinct surface named by the task" "$home/data/brief-inventory-scout/brief.md" \
+    "scout brief must not carry the ship deliverable inventory instruction"
+
+  FM_HOME="$home" FM_SECONDMATE_CHARTER='Supervise routed work.' \
+    "$ROOT/bin/fm-brief.sh" brief-inventory-secondmate --secondmate --no-projects >/dev/null 2>&1 \
+    || fail "secondmate charter should scaffold"
+  assert_no_grep "# Deliverable inventory" "$home/data/brief-inventory-secondmate/brief.md" \
+    "secondmate charter must not carry the ship deliverable inventory"
+  assert_no_grep "list every distinct surface named by the task" "$home/data/brief-inventory-secondmate/brief.md" \
+    "secondmate charter must not carry the ship deliverable inventory instruction"
+  pass "fm-brief.sh: deliverable inventory appears in every ship mode only"
+}
+
 # A ship task's delivery mode is firstmate's per-task decision, so a missing or
 # unusable value must stop the scaffold instead of silently defaulting. The
 # no-mistakes-prod-only row is the conditional registry policy: it is never a task
@@ -714,6 +757,7 @@ test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
+test_deliverable_inventory_is_ship_only
 test_ship_mode_is_required_and_closed_set
 test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply


### PR DESCRIPTION
## Intent

Add a short deliverable inventory instruction to ship briefs generated by bin/fm-brief.sh for all three delivery modes: no-mistakes, direct-PR, and local-only. Before reporting done, workers must list every distinct task-named surface including files, components, screens, endpoints, config, and documentation; state where each was implemented; identify any deliberately skipped surface and why; and explicitly report if they cannot complete the inventory rather than being blocked from reporting. Define this wording once in the script and share it across all three modes, positioned before the append-done-and-stop instruction and preferably before Definition of done. Scout briefs and secondmate charters must not receive it. Do not change AGENTS.md. Update --help only if caller-facing knowledge changes. Extend the existing tests/fm-brief.test.sh runner, exercising generated briefs through the real script rather than inspecting source bytes, and cover all three ship modes plus scout and secondmate exclusions. Completion requires bin/fm-lint.sh clean, tests/fm-brief.test.sh passing, and generated briefs for all three modes eyeballed for natural placement.

## What Changed

- `bin/fm-brief.sh` defines a shared `DELIVERABLE_INVENTORY` heredoc and interpolates it once into the common ship-brief tail, so the no-mistakes, direct-PR, and local-only modes emit byte-identical wording. The block tells workers to list every task-named surface (files, components, screens, endpoints, config, documentation), state where each was implemented, name any deliberately skipped surface and why, and say so rather than block if the inventory can't be completed.
- The section lands immediately before `# Definition of done` — and therefore before the append-`done`-and-stop instruction — and routes the multi-line inventory to the worker's pane rather than the one-line status file, keeping the status protocol intact.
- `tests/fm-brief.test.sh` gains `test_deliverable_inventory_is_ship_only`, which scaffolds real briefs through the script to assert the block's content and its placement ahead of Definition of done in all three ship modes, and asserts its absence from scout briefs and secondmate charters.

Scout briefs, secondmate charters, `--help` output, and `AGENTS.md` are unchanged.

## Risk Assessment

✅ Low: The follow-up is a two-line prose correction inside an already-shared quoted heredoc plus the matching test assertions, leaving the change purely additive scaffolding text with no code-path behavior change, correct placement in all three ship modes, and structural exclusion from scout and secondmate briefs.

## Testing

I exercised the change through the real `bin/fm-brief.sh` rather than by reading source: generated briefs for all three ship modes plus scout and secondmate, and diffed each against the same scaffolds produced by the base-commit script. The only content change in each ship brief is the new `# Deliverable inventory` block, sitting between Project memory and Definition of done and ahead of every append-done-and-stop instruction; the block hashes identically across all three modes (single shared definition), and the scout and secondmate briefs are byte-for-byte unchanged. `--help` output and `AGENTS.md` are unchanged. `tests/fm-brief.test.sh` passes at the target commit, and the same test file fails at the base commit, so the new coverage is a genuine guard rather than a tautology; the two adjacent suites that assert brief prose also pass. This change has no rendered UI surface — the end-user artifact is the generated `brief.md` a worker agent reads, so the evidence is the verbatim generated briefs and their base-vs-target diff. Lint was not run: linters are excluded from this phase and `bin/fm-lint.sh` is owned by the lint phase. Transient scaffolding was removed and the worktree is clean.

<details>
<summary>Evidence: Base-vs-target diff of generated ship briefs (all three modes, real script output)</summary>

<code>### mode=no-mistakes base 64d61ae -&gt; target 4753406 (real fm-brief.sh output)&#10;@@ -51,6 +51,13 @@&#10;Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.&#10;&#10;+# Deliverable inventory&#10;+Before reporting done, list every distinct surface named by the task - files, components, screens, endpoints, config, and documentation.&#10;+For each surface, state where you implemented it.&#10;+Explicitly identify every surface you deliberately skipped and why.&#10;+Report the inventory in your final message in your pane, never in the status file - status lines stay one line.&#10;+If you cannot complete this inventory, say so there rather than blocking the report.&#10;+&#10;# Definition of done&#10;Delivery contract: mode=no-mistakes&#10;&#10;(identical added block in mode=direct-PR and mode=local-only; the only other hunk in each is the temp home path in the status-file line)</code>

```text
### mode=no-mistakes   base 64d61ae  ->  target 4753406   (real fm-brief.sh output)
--- BASE/data/evid-no-mistakes/brief.md	2026-08-18 11:28:50
+++ TARGET/data/evid-no-mistakes/brief.md	2026-08-18 11:28:17
@@ -23,7 +23,7 @@
 2. Stay inside this worktree; modify nothing outside it.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
-   `echo "{state}: {one short line}" >> '/var/folders/xn/rpz7khvj25zdhw1rrx8q8sh80000gn/T//fm-brief-base.siZUoh/home/state/evid-no-mistakes.status'`
+   `echo "{state}: {one short line}" >> '/var/folders/xn/rpz7khvj25zdhw1rrx8q8sh80000gn/T//fm-brief-evid.GuZTHV/state/evid-no-mistakes.status'`
    States: working, needs-decision, blocked, paused, done, failed.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
    would act on (setup done, bug reproduced, fix implemented, validation passed) and the
@@ -51,6 +51,13 @@
 If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/kad/.no-mistakes/worktrees/a65af6729e3c/01M096K6KEPF1YRW9J0ZD0PK7Y/bin/fm-ensure-agents-md.sh` in the same pass.
 Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.
 
+# Deliverable inventory
+Before reporting done, list every distinct surface named by the task - files, components, screens, endpoints, config, and documentation.
+For each surface, state where you implemented it.
+Explicitly identify every surface you deliberately skipped and why.
+Report the inventory in your final message in your pane, never in the status file - status lines stay one line.
+If you cannot complete this inventory, say so there rather than blocking the report.
+
 # Definition of done
 Delivery contract: mode=no-mistakes
 The task is complete only when committed on your branch.

### mode=direct-PR   base 64d61ae  ->  target 4753406   (real fm-brief.sh output)
--- BASE/data/evid-direct-PR/brief.md	2026-08-18 11:28:50
+++ TARGET/data/evid-direct-PR/brief.md	2026-08-18 11:28:17
@@ -22,7 +22,7 @@
 2. Stay inside this worktree; modify nothing outside it.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
-   `echo "{state}: {one short line}" >> '/var/folders/xn/rpz7khvj25zdhw1rrx8q8sh80000gn/T//fm-brief-base.siZUoh/home/state/evid-direct-PR.status'`
+   `echo "{state}: {one short line}" >> '/var/folders/xn/rpz7khvj25zdhw1rrx8q8sh80000gn/T//fm-brief-evid.GuZTHV/state/evid-direct-PR.status'`
    States: working, needs-decision, blocked, paused, done, failed.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
    would act on (setup done, bug reproduced, fix implemented, validation passed) and the
@@ -50,6 +50,13 @@
 If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/kad/.no-mistakes/worktrees/a65af6729e3c/01M096K6KEPF1YRW9J0ZD0PK7Y/bin/fm-ensure-agents-md.sh` in the same pass.
 Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.
 
+# Deliverable inventory
+Before reporting done, list every distinct surface named by the task - files, components, screens, endpoints, config, and documentation.
+For each surface, state where you implemented it.
+Explicitly identify every surface you deliberately skipped and why.
+Report the inventory in your final message in your pane, never in the status file - status lines stay one line.
+If you cannot complete this inventory, say so there rather than blocking the report.
+
 # Definition of done
 Delivery contract: mode=direct-PR
 This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.

### mode=local-only   base 64d61ae  ->  target 4753406   (real fm-brief.sh output)
--- BASE/data/evid-local-only/brief.md	2026-08-18 11:28:50
+++ TARGET/data/evid-local-only/brief.md	2026-08-18 11:28:17
@@ -22,7 +22,7 @@
 2. Stay inside this worktree; modify nothing outside it.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
-   `echo "{state}: {one short line}" >> '/var/folders/xn/rpz7khvj25zdhw1rrx8q8sh80000gn/T//fm-brief-base.siZUoh/home/state/evid-local-only.status'`
+   `echo "{state}: {one short line}" >> '/var/folders/xn/rpz7khvj25zdhw1rrx8q8sh80000gn/T//fm-brief-evid.GuZTHV/state/evid-local-only.status'`
    States: working, needs-decision, blocked, paused, done, failed.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
    would act on (setup done, bug reproduced, fix implemented, validation passed) and the
@@ -50,6 +50,13 @@
 If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/kad/.no-mistakes/worktrees/a65af6729e3c/01M096K6KEPF1YRW9J0ZD0PK7Y/bin/fm-ensure-agents-md.sh` in the same pass.
 Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.
 
+# Deliverable inventory
+Before reporting done, list every distinct surface named by the task - files, components, screens, endpoints, config, and documentation.
+For each surface, state where you implemented it.
+Explicitly identify every surface you deliberately skipped and why.
+Report the inventory in your final message in your pane, never in the status file - status lines stay one line.
+If you cannot complete this inventory, say so there rather than blocking the report.
+
 # Definition of done
 Delivery contract: mode=local-only
 This task ships **local-only**: no remote, no PR, no pipeline.
```
</details>
<details>
<summary>Evidence: Shared-wording, placement, and exclusion checks against generated briefs</summary>

<code>== 1. shared wording: inventory block byte-identical across all three ship modes? ==&#10;8ab9f9e9c64b2aa5630c80bbee18cf48ea27b95f mode=no-mistakes&#10;8ab9f9e9c64b2aa5630c80bbee18cf48ea27b95f mode=direct-PR&#10;8ab9f9e9c64b2aa5630c80bbee18cf48ea27b95f mode=local-only&#10;&#10;== 2. placement: inventory vs Definition of done vs every &#39;append done ... and stop&#39; ==&#10;--- mode=no-mistakes&#10;54:# Deliverable inventory&#10;61:# Definition of done&#10;64:When you believe it is complete, append `done: {summary}` to the status file and stop.&#10;78:After /no-mistakes reports CI green ... append `done: PR {url} checks green` and stop.&#10;--- mode=direct-PR&#10;53:# Deliverable inventory&#10;60:# Definition of done&#10;64:When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` ... and stop.&#10;--- mode=local-only&#10;53:# Deliverable inventory&#10;60:# Definition of done&#10;65:When it is implemented and committed, append `done: ready in branch fm/evid-local-only` to the status file and stop.&#10;&#10;== 3. exclusions ==&#10;scout brief: identical to base (no deliverable inventory) grep count -&gt; 0&#10;secondmate brief: identical to base (no deliverable inventory) grep count -&gt; 0&#10;&#10;== 4. caller-facing surface ==&#10;--help output: identical to base&#10;AGENTS.md: untouched by this change</code>

```text
== 1. shared wording: is the inventory block byte-identical across all three ship modes? ==
8ab9f9e9c64b2aa5630c80bbee18cf48ea27b95f  mode=no-mistakes
8ab9f9e9c64b2aa5630c80bbee18cf48ea27b95f  mode=direct-PR
8ab9f9e9c64b2aa5630c80bbee18cf48ea27b95f  mode=local-only

== 2. placement: line numbers of inventory vs Definition of done vs every 'append done ... and stop' ==
--- mode=no-mistakes
54:# Deliverable inventory
61:# Definition of done
64:When you believe it is complete, append `done: {summary}` to the status file and stop.
78:After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), ap
--- mode=direct-PR
53:# Deliverable inventory
60:# Definition of done
64:When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and s
--- mode=local-only
53:# Deliverable inventory
60:# Definition of done
65:When it is implemented and committed, append `done: ready in branch fm/evid-local-only` to the status file and stop.

== 3. exclusions: scout + secondmate scaffolds are unchanged from base (empty diff = no inventory added) ==
scout brief: identical to base (no deliverable inventory)
  grep 'Deliverable inventory' -> 0
secondmate brief: identical to base (no deliverable inventory)
  grep 'Deliverable inventory' -> 0

== 4. caller-facing surface: fm-brief.sh --help unchanged, AGENTS.md unchanged ==
--help output: identical to base
AGENTS.md: untouched by this change
```
</details>
<details>
<summary>Evidence: fm-brief.test.sh run at target + negative control at base</summary>

<code>$ bash tests/fm-brief.test.sh # at target 4753406&#10;ok - fm-brief.sh: bash -n succeeds&#10;ok - fm-brief.sh: no heredoc is nested inside a command substitution (Bash 3.2 parse-safe)&#10;ok - fm-brief.sh: --help renders the complete header&#10;ok - fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly&#10;ok - fm-brief.sh: deliverable inventory appears in every ship mode only&#10;... (21 ok total)&#10;EXIT=0&#10;&#10;--- negative control: same test file, bin/fm-brief.sh reverted to base 64d61ae ---&#10;ok - fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly&#10;not ok - no-mistakes brief missing the deliverable inventory&#10;EXIT=1 (new test fails without the change, so it is a real guard)</code>

```text
$ bash tests/fm-brief.test.sh    # at target 4753406
ok - fm-brief.sh: bash -n succeeds
/var/folders/xn/rpz7khvj25zdhw1rrx8q8sh80000gn/T//fm-brief.KXHObm/heredoc-in-substitution.sh:2
ok - fm-brief.sh: no heredoc is nested inside a command substitution (Bash 3.2 parse-safe)
ok - fm-brief.sh: --help renders the complete header
ok - fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly
ok - fm-brief.sh: deliverable inventory appears in every ship mode only
ok - fm-brief.sh: ship --mode is required and closed-set validated
ok - fm-brief.sh: the explicit ship mode wins over the registered posture
ok - fm-brief.sh: --yolo and scout/secondmate --mode are refused, never silently dropped
ok - fm-brief.sh: faster paths use configured authority without stacked review
ok - fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe
ok - fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar
ok - fm-brief.sh: --herdr-lab emits the complete hard safety contract
ok - fm-brief.sh: --herdr-lab uses its quoted Firstmate-owned helper path
ok - fm-brief.sh: ship and scout scaffolds make omitted Herdr intent fail-visible
ok - fm-brief.sh: Herdr lab contract covers scouts and rejects secondmate misuse
ok - fm-brief.sh: --no-projects scaffolds a project-less charter and guards misuse
ok - fm-brief.sh: marked requests avoid generic acknowledgements and preserve material reporting
ok - fm-brief.sh: relative directory inputs ignore CDPATH, render stable absolute charter paths, or fail loudly
ok - fm-brief.sh: custom pause verb renders in every scaffold
ok - fm-brief.sh: investigation and visual-review completions load the shared decision policy
ok - fm-brief: scout and secondmate code paths still scaffold well-formed briefs

EXIT=0

--- negative control: same test file, bin/fm-brief.sh reverted to base 64d61ae ---
ok - fm-brief.sh: bash -n succeeds
/var/folders/xn/rpz7khvj25zdhw1rrx8q8sh80000gn/T//fm-brief.4cXfJU/heredoc-in-substitution.sh:2
ok - fm-brief.sh: no heredoc is nested inside a command substitution (Bash 3.2 parse-safe)
ok - fm-brief.sh: --help renders the complete header
ok - fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly
not ok - no-mistakes brief missing the deliverable inventory
EXIT=1  (new test fails without the change, so it is a real guard)
```
</details>
<details>
<summary>Evidence: Generated ship brief, no-mistakes mode (end-user surface a worker reads)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of acme-app, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/evid-no-mistakes`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/xn/rpz7khvj25zdhw1rrx8q8sh80000gn/T//fm-brief-evid.GuZTHV/state/evid-no-mistakes.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/kad/.no-mistakes/worktrees/a65af6729e3c/01M096K6KEPF1YRW9J0ZD0PK7Y/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/kad/.no-mistakes/worktrees/a65af6729e3c/01M096K6KEPF1YRW9J0ZD0PK7Y/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Deliverable inventory
Before reporting done, list every distinct surface named by the task - files, components, screens, endpoints, config, and documentation.
For each surface, state where you implemented it.
Explicitly identify every surface you deliberately skipped and why.
Report the inventory in your final message in your pane, never in the status file - status lines stay one line.
If you cannot complete this inventory, say so there rather than blocking the report.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Generated ship brief, direct-PR mode</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of acme-app, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/evid-direct-PR`

# Rules
1. Never push to the default branch (push only your `fm/evid-direct-PR` branch). Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/xn/rpz7khvj25zdhw1rrx8q8sh80000gn/T//fm-brief-evid.GuZTHV/state/evid-direct-PR.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/kad/.no-mistakes/worktrees/a65af6729e3c/01M096K6KEPF1YRW9J0ZD0PK7Y/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/kad/.no-mistakes/worktrees/a65af6729e3c/01M096K6KEPF1YRW9J0ZD0PK7Y/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Deliverable inventory
Before reporting done, list every distinct surface named by the task - files, components, screens, endpoints, config, and documentation.
For each surface, state where you implemented it.
Explicitly identify every surface you deliberately skipped and why.
Report the inventory in your final message in your pane, never in the status file - status lines stay one line.
If you cannot complete this inventory, say so there rather than blocking the report.

# Definition of done
Delivery contract: mode=direct-PR
This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
```
</details>
<details>
<summary>Evidence: Generated ship brief, local-only mode</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of acme-app, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/evid-local-only`

# Rules
1. Never push to any remote and never open a PR. Work only on your `fm/evid-local-only` branch; firstmate handles the merge into local `main`.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/xn/rpz7khvj25zdhw1rrx8q8sh80000gn/T//fm-brief-evid.GuZTHV/state/evid-local-only.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/kad/.no-mistakes/worktrees/a65af6729e3c/01M096K6KEPF1YRW9J0ZD0PK7Y/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/kad/.no-mistakes/worktrees/a65af6729e3c/01M096K6KEPF1YRW9J0ZD0PK7Y/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Deliverable inventory
Before reporting done, list every distinct surface named by the task - files, components, screens, endpoints, config, and documentation.
For each surface, state where you implemented it.
Explicitly identify every surface you deliberately skipped and why.
Report the inventory in your final message in your pane, never in the status file - status lines stay one line.
If you cannot complete this inventory, say so there rather than blocking the report.

# Definition of done
Delivery contract: mode=local-only
This task ships **local-only**: no remote, no PR, no pipeline.
The task is complete only when committed on your branch `fm/evid-local-only`. Do NOT push, do NOT open a PR, do NOT merge.
Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
When it is implemented and committed, append `done: ready in branch fm/evid-local-only` to the status file and stop.
The configured merge authority approves the ready branch, then firstmate merges it into local `main` through the guarded fast-forward path.
```
</details>
<details>
<summary>Evidence: Generated scout brief (must not carry the inventory)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of acme-app, at a detached HEAD on a clean default branch.
This is a SCOUT task: the deliverable is a written report, not a PR.
The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
The report is the only thing that survives, so anything worth keeping must be in it.

# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/xn/rpz7khvj25zdhw1rrx8q8sh80000gn/T//fm-brief-evid.GuZTHV/state/evid-scout.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
   FYI progress lines; firstmate reads your pane for that.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
   firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
   treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Definition of done
Write your findings to `/var/folders/xn/rpz7khvj25zdhw1rrx8q8sh80000gn/T//fm-brief-evid.GuZTHV/data/evid-scout/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
Before reporting done, read and follow `/Users/kad/.no-mistakes/worktrees/a65af6729e3c/01M096K6KEPF1YRW9J0ZD0PK7Y/.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
```
</details>
- Evidence: Generated secondmate charter (must not carry the inventory) (local file: <code>/var/folders/xn/rpz7khvj25zdhw1rrx8q8sh80000gn/T/no-mistakes-evidence/01M096K6KEPF1YRW9J0ZD0PK7Y/brief-secondmate.md</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ℹ️ `bin/fm-brief.sh:56` - The script header (which is verbatim `--help` output via `usage()`) documents each generated ship-brief section for the caller — e.g. lines 52-56 explain the project-memory section, line 45 the worktree-isolation assertion — but gains no line for the new `# Deliverable inventory` section that now appears in every ship brief. Firstmate is the caller and is told it &#34;may adjust other sections when the task genuinely deviates&#34;, so the section&#39;s existence is arguably caller-facing knowledge by this file&#39;s own convention. The intent explicitly makes this discretionary (&#34;Update --help only if caller-facing knowledge changes&#34;), so this is a judgment call for the author, not a defect.
- ℹ️ `bin/fm-brief.sh:413` - &#34;say so in your completion report&#34; introduces a term that ship briefs never define. Scout briefs have a concrete artifact (`data/&lt;id&gt;/report.md`, line 341), but ship briefs have only the status file — whose protocol is a strict `{state}: {one short line}` with &#34;No step-by-step FYI progress lines&#34; (rules at lines 444-455) — and the worker&#39;s pane. The inventory itself is multi-line, so a worker could plausibly append it to the status file, producing spurious firstmate wakes and off-protocol lines. Naming the destination (e.g. &#34;in your final message&#34; or &#34;in the pane, not the status file&#34;) would close the ambiguity. This is worker-facing prose the intent deliberately worded, so it is the author&#39;s call.

🔧 Fix: Name pane as deliverable inventory destination
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-brief.test.sh` — 21 checks pass, exit 0, including the new `test_deliverable_inventory_is_ship_only`</code>
- <code>Negative control: ran the same `tests/fm-brief.test.sh` against `bin/fm-brief.sh` reverted to base `64d61ae` (temp dir with libs symlinked) — exits 1 with `not ok - no-mistakes brief missing the deliverable inventory`, proving the new test is a real guard</code>
- <code>Generated real briefs via `FM_HOME=&lt;tmp&gt; bin/fm-brief.sh evid-&lt;mode&gt; acme-app --mode &lt;no-mistakes|direct-PR|local-only&gt;`, `--scout`, and `FM_SECONDMATE_CHARTER=... --secondmate --no-projects`, then diffed each against base-script output</code>
- <code>Confirmed the inventory block is byte-identical across all three ship modes by hashing the extracted section from each generated brief (`awk &#39;/^# Deliverable inventory$/,/^$/&#39; | shasum`)</code>
- <code>Confirmed placement: `grep -n` shows `# Deliverable inventory` before `# Definition of done` and before every `append \`done: …\` … and stop` line in all three ship modes</code>
- <code>Confirmed exclusions: scout and secondmate generated briefs are byte-identical to base output and contain zero `Deliverable inventory` matches</code>
- <code>Confirmed no caller-facing drift: `diff` of `bin/fm-brief.sh --help` between base and target is empty; `git diff --stat 64d61ae 4753406 -- AGENTS.md` is empty</code>
- <code>`bash tests/fm-ask-user-authority.test.sh` and `bash tests/fm-tangle-guard.test.sh` — the two adjacent suites that assert generated brief prose, both pass</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `bin/fm-brief.sh:57` - Judgment call on the intent&#39;s conditional &#34;Update --help only if caller-facing knowledge changes&#34;: I judged yes and added a four-line summary to the bin/fm-brief.sh header (rendered verbatim by --help). Rationale: AGENTS.md section 11 names the script and its help as the owner of generated variants and the status protocol, the header already enumerates every other ship-only generated section (worktree-isolation assertion, project-memory section), and the new section constrains the status protocol by routing the inventory to the pane rather than the one-line status file. The addition is a one-sentence-plus summary, not a restatement of the five-line brief contract, so the brief template remains the single owner of the exact wording. If the reviewer reads the inventory as worker-only knowledge with no caller-facing consequence, this header addition can be dropped with no other documentation becoming stale.

🔧 Fix: Drop fm-brief help note on deliverable inventory
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

🔧 Fix: Install pinned actionlint to clear lint exit 127
1 warning still open:
- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
