### PR TITLE
feat: let live scouts host Lavish review loops

### DIFF
--- a/.agents/skills/process-event-sources/SKILL.md
+++ b/.agents/skills/process-event-sources/SKILL.md
@@ -25,7 +25,7 @@ Firstmate registers a source, keeps working, and is woken when that process comp
 ## Arming a source
 
 Use the adapter, not the generic runner, for a real source.
-For a Lavish review artifact:
+For a Lavish review artifact firstmate owns (a live investigating scout should host its own loop):
 
 ```sh
 bin/fm-procevent-lavish.sh arm <artifact.html>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,6 +372,7 @@ Retire one only on an explicit captain or main-firstmate decision, after loading
 A completed scout must leave a self-contained report before its scratch worktree can be discarded; read and relay its findings, record the report as the Done artifact, and re-evaluate the queue.
 A report may recommend implementation but does not authorize it.
 Before treating the investigation or any visual review as complete, load `decision-hold-lifecycle`; teardown enforces that shared completion gate.
+When a scout's deliverable is a visual artifact the captain will iterate on, prefer keeping that scout alive to host its own Lavish loop rather than tearing it down and mediating from firstmate, so the scout keeps its investigation context and the captain iterates in one continuous session.
 When implementation is separately authorized, promote the existing scout through `bin/fm-promote.sh` rather than creating a duplicate task.
 The promoted worker must inventory scratch state, return to a clean default-branch base, carry over only intended fix changes, create the ship branch, and follow the project's selected delivery path while leaving scratch commits and debug edits behind and turning a reproduced bug into the regression test.
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -339,6 +339,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
 The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
+If your deliverable is a visual artifact the captain will review and iterate on, you may host the Lavish review loop yourself (poll, revise, re-serve, staying alive) instead of handing it back to firstmate.
 Before reporting done, read and follow \`$FM_ROOT/.agents/skills/decision-hold-lifecycle/SKILL.md\` and pass its shared completion gate for the report and any visual review.
 When the report is complete, append \`done: {one-line conclusion}\` to the status file and stop.
 If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -699,6 +699,8 @@ test_scout_and_secondmate_scaffold() {
   assert_present "$brief" "scout brief was not scaffolded"
   assert_grep "SCOUT task" "$brief" "scout brief must declare itself a scout task"
   assert_grep "report.md" "$brief" "scout brief must point at the report deliverable"
+  assert_grep "you may host the Lavish review loop yourself" "$brief" \
+    "scout brief must mention the option to host a Lavish review loop"
 
   FM_SECONDMATE_CHARTER='Supervise the alpha domain.' \
     FM_HOME="$BRIEF_HOME" "$ROOT/bin/fm-brief.sh" brief-sm-q6 --secondmate alpha >/dev/null 2>&1 \


### PR DESCRIPTION
## Intent

Add SMALL, ADDITIVE hints so firstmate treats "a live scout hosting its own Lavish review loop" as a first-class OPTION, instead of defaulting to open-Lavish-itself + mediate + tear the scout down between iteration rounds. This is firstmate's SHARED, TRACKED, ALWAYS-LOADED instruction surface (AGENTS.md + bin/ + maybe a skill). Follow firstmate-coding-guidelines: AGENTS.md size discipline (add minimal), one-owner rule, one-sentence-per-line Markdown, plain dash, preserve every safety boundary, shellcheck + bin/fm-lint.sh for the script.

Why: process-event-sources only teaches fm-procevent-lavish.sh arm (firstmate as host/poller). Nothing tells firstmate that a LIVE scout which produced a visual artifact can host its OWN review loop. Combined with the scout lifecycle (tear down after report), firstmate defaults to mediating and tearing the scout down between rounds. The captain wants a continuous scout that hosts the artifact and iterates with him in one session. These are LIGHT hints that make it a first-class option - do NOT force the pattern, do NOT restructure anything.

Required changes, each SMALL and additive:
1. AGENTS.md - in section 7's scout-outcome / visual-review area, right around the existing line: "Before treating the investigation or any visual review as complete, load `decision-hold-lifecycle`; teardown enforces that shared completion gate." Add ONE sentence (fit AGENTS.md's voice and one-sentence-per-line style) to the effect of: when a scout's deliverable is a visual artifact the captain will iterate on, prefer keeping that scout alive to host its own Lavish loop (serve, poll, iterate) rather than tearing it down and mediating from firstmate, so the scout keeps its investigation context and the captain iterates in one continuous session. Preserve every existing safety boundary and the surrounding sentences.
2. bin/fm-brief.sh scout scaffold - the KIND=scout generated scout contract. Add ONE line to the generated scout contract so every scout sees the option, roughly: "If your deliverable is a visual artifact the captain will review and iterate on, you may host the Lavish review loop yourself (poll, revise, re-serve, staying alive) instead of handing it back to firstmate." Match the scaffold's existing wording/format.
3. OPTIONAL, ONLY if it stays a half-sentence - in the process-event-sources skill, a short caveat that fm-procevent-lavish.sh arm is for firstmate-OWNED artifacts, while a live investigating scout should host its own loop. Skip it if it cannot be a clean half-sentence; do not expand the skill.

Hard limits (do NOT cross):
- Additive HINTS only. Do NOT restructure AGENTS.md, the scout lifecycle, or the scaffold.
- Do NOT weaken decision-hold-lifecycle's completion gate, the teardown-only-after-landing rules, or any supervision / turn-end / wake contract. The scout still must leave its self-contained report and pass the shared completion gate before any teardown; hosting a Lavish loop does not exempt it from those.
- Keep AGENTS.md's token cost minimal (it loads every session) - one sentence, not a paragraph.
- No agent co-author trailer.

Tests: instruction-surface prose + a scaffold string; no behavioral unit test is expected. If bin/fm-brief.sh is touched, a scout scaffold still generates cleanly (exercise the real fm-brief.sh --scout and confirm the hint appears in the generated contract via the executable, not by asserting source bytes). Run bin/fm-lint.sh, bin/fm-doc-audience-check.sh, and shellcheck as applicable.

Delivery: mode=no-mistakes, yolo OFF - the captain owns the merge. Escalate any ask-user finding; do not answer them as the implementation worker. This changes firstmate's ALWAYS-LOADED instruction surface (AGENTS.md, the scaffold, maybe a skill), so the PR must note that running homes pick it up after merge plus a firstmate self-update and that landing timing is coordinated with the main firstmate. Drive to a green PR; do not merge.

Implementation already committed: one AGENTS.md sentence, one generated scout-contract line, a half-sentence process-event-sources caveat, and an existing fm-brief.test.sh assertion that greps the generated brief (executable output), not source bytes.

## What Changed
- Add guidance allowing live scouts with visual artifacts to host their own Lavish review loop while retaining investigation context.
- Include the option in generated scout contracts and clarify that the existing Lavish event-source flow is for Firstmate-owned artifacts.
- Verify the hint through the generated scaffold output; running homes pick it up after merge and a coordinated Firstmate self-update.

## Risk Assessment

✅ Low: The change is small, additive, preserves lifecycle and teardown safety gates, and tests the emitted scout brief through the executable interface.

## Testing

The focused scaffold tests and documentation audience check passed, and a real `fm-brief.sh --scout` invocation produced a clean contract offering the self-hosted Lavish loop immediately before the unchanged shared completion gate; reviewer-visible generated output was captured. Lint and static-analysis commands were left to their dedicated gate phases as required by this test-phase boundary.

<details>
<summary>Evidence: Scout scaffold generation transcript and Definition of done</summary>

Source: [Scout scaffold generation transcript and Definition of done](https://github.com/kunchenguid/firstmate/blob/478fff51c83310acb5b3b68bed3ef7ae92827caa/.no-mistakes/evidence/fm/fm-scout-lavish-host-hints-r1/scout-scaffold-transcript.txt)

```text
$ FM_HOME=/Users/kunchen/.no-mistakes/evidence/01M09CK35FWS278645KDKK0GMK/home FM_ROOT_OVERRIDE=/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01M09CK35FWS278645KDKK0GMK bin/fm-brief.sh lavish-scout demo-project --scout
scaffolded: /Users/kunchen/.no-mistakes/evidence/01M09CK35FWS278645KDKK0GMK/home/data/lavish-scout/brief.md (scout; replace {TASK})

$ generated Definition of done
# Definition of done
Write your findings to `/Users/kunchen/.no-mistakes/evidence/01M09CK35FWS278645KDKK0GMK/home/data/lavish-scout/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
If your deliverable is a visual artifact the captain will review and iterate on, you may host the Lavish review loop yourself (poll, revise, re-serve, staying alive) instead of handing it back to firstmate.
Before reporting done, read and follow `/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01M09CK35FWS278645KDKK0GMK/.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
```
</details>
<details>
<summary>Evidence: Generated scout contract</summary>

Source: [Generated scout contract](https://github.com/kunchenguid/firstmate/blob/478fff51c83310acb5b3b68bed3ef7ae92827caa/.no-mistakes/evidence/fm/fm-scout-lavish-host-hints-r1/home/data/lavish-scout/brief.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of demo-project, at a detached HEAD on a clean default branch.
This is a SCOUT task: the deliverable is a written report, not a PR.
The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
The report is the only thing that survives, so anything worth keeping must be in it.

# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/Users/kunchen/.no-mistakes/evidence/01M09CK35FWS278645KDKK0GMK/home/state/lavish-scout.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
   FYI progress lines; firstmate reads your pane for that.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
   firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
   treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Definition of done
Write your findings to `/Users/kunchen/.no-mistakes/evidence/01M09CK35FWS278645KDKK0GMK/home/data/lavish-scout/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
If your deliverable is a visual artifact the captain will review and iterate on, you may host the Lavish review loop yourself (poll, revise, re-serve, staying alive) instead of handing it back to firstmate.
Before reporting done, read and follow `/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01M09CK35FWS278645KDKK0GMK/.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2638aa562dd368b18875f1406e98b99c8ca92713","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-brief.test.sh`
- `bin/fm-doc-audience-check.sh`
- <code>Real scaffold generation: `FM_HOME=&#34;$EVIDENCE/home&#34; FM_ROOT_OVERRIDE=&#34;$PWD&#34; bin/fm-brief.sh lavish-scout demo-project --scout`</code>
- `Manually inspected the commit diff to confirm the AGENTS.md and process-event-sources hints remain additive and preserve the adjacent completion gate and teardown boundaries.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
