### PR TITLE
fix(herdr): stop events-capability probe spamming broken-pipe under ignored SIGPIPE

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -3135,8 +3135,16 @@ fm_backend_herdr_events_capable() {  # <session>
   case "$protocol" in ''|*[!0-9]*) return 1 ;; esac
   [ "$protocol" -ge "$FM_BACKEND_HERDR_MIN_EVENTS_PROTOCOL" ] || return 1
   schema=$(herdr api schema --json 2>/dev/null) || return 1
-  printf '%s' "$schema" | grep -Fq 'events.subscribe' || return 1
-  printf '%s' "$schema" | grep -Fq 'pane.agent_status_changed' || return 1
+  # Match the ~220KB schema with pure Bash glob `case`, NOT `printf '%s' "$schema"
+  # | grep -Fq`. grep -Fq exits on the first match while printf is still writing
+  # the rest of the schema down the pipe; if the watcher inherited an ignored
+  # SIGPIPE from its launcher, that write returns EPIPE instead of dying
+  # silently, and Bash's printf builtin then spams `printf: write error: Broken
+  # pipe` to the watcher's stderr every time this probe runs. `case` is a single
+  # in-process pass with no subprocess and no pipe, so it cannot break a pipe and
+  # is immune to the caller's SIGPIPE disposition.
+  case "$schema" in *events.subscribe*) : ;; *) return 1 ;; esac
+  case "$schema" in *pane.agent_status_changed*) : ;; *) return 1 ;; esac
   return 0
 }
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -278,6 +278,7 @@ Polling runs every cycle and remains the permanent fallback when protocol 16, th
 There is still one watcher process; the event reader is a bounded child of that watcher.
 
 `tests/fm-backend-herdr-eventwait-smoke.test.sh`, `tests/fm-transition-lib.test.sh`, and `tests/fm-supervision-events.test.sh` cover capability, subscribe-then-reconcile ordering, dedupe, exemptions, and polling fallback.
+The capability probe matches the large `herdr api schema` in-process rather than through a pipe, so a watcher that inherited an ignored SIGPIPE cannot spam broken-pipe write errors; `tests/fm-backend-herdr.test.sh` pins this.
 
 ## Away-mode supervisor support
 

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -4312,9 +4312,94 @@ test_wait_transition_clean_timeout_returns_1() {
   pass "fm_backend_herdr_wait_transition: stock macOS Bash clean timeout closes fd 9 and returns 1"
 }
 
+# make_herdr_schema_fakebin: a `herdr` stub whose `api schema --json` emits a
+# large (~300KB) multi-line schema, with the two capability tokens near the top,
+# so a first-match consumer stops reading long before the payload is drained.
+# `$FM_FAKE_SCHEMA_DROP` (events.subscribe | pane.agent_status_changed) omits one
+# token so the incapable path can be exercised. Only the two calls
+# events_capable makes are modeled.
+make_herdr_schema_fakebin() {  # <dir> -> echoes fakebin dir
+  local dir=$1 fb="$1/fakebin"
+  mkdir -p "$fb"
+  cat > "$fb/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-} ${2:-}" in
+  "status --json")
+    printf '{"client":{"version":"0.7.5","protocol":16},"server":{"running":true}}\n' ;;
+  "api schema")
+    printf '{\n'
+    [ "${FM_FAKE_SCHEMA_DROP:-}" = events.subscribe ] || printf '  "methods": ["events.subscribe"],\n'
+    [ "${FM_FAKE_SCHEMA_DROP:-}" = pane.agent_status_changed ] || printf '  "events": ["pane.agent_status_changed"],\n'
+    i=0
+    while [ "$i" -lt 8000 ]; do
+      printf '  "pad_%d": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",\n' "$i"
+      i=$((i + 1))
+    done
+    printf '  "end": true\n}\n' ;;
+  *) : ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/herdr"
+  printf '%s\n' "$fb"
+}
+
+# A watcher can inherit an ignored SIGPIPE from its launcher. Under that
+# disposition a Bash builtin `printf` piped into a first-match consumer
+# (grep -Fq) does not die silently on the reader's early close - its write
+# returns EPIPE and the builtin spams `printf: write error: Broken pipe` to
+# stderr. fm_backend_herdr_events_capable reads the ~220KB `herdr api schema`,
+# so it must match the schema without a broken-pipe-prone pipe. This case fixes
+# the environment (SIGPIPE ignored, large schema, early tokens), proves that
+# environment really can break a pipe (the control), and asserts the real probe
+# stays quiet while still returning the right verdict.
+test_events_capable_sigpipe_ignored_no_broken_pipe() {
+  local dir fb err rc control
+  dir="$TMP_ROOT/events-capable-sigpipe"; mkdir -p "$dir"
+  fb=$(make_herdr_schema_fakebin "$dir")
+  err="$dir/probe.err"
+
+  # Control: the classic broken-pipe pattern under the same ignored SIGPIPE must
+  # actually emit the message here, or the assertion below would be vacuous.
+  control=$(PATH="$fb:$PATH" /bin/bash -c '
+    trap "" PIPE
+    schema=$(herdr api schema --json 2>/dev/null)
+    printf "%s" "$schema" | grep -Fq "events.subscribe"
+  ' 2>&1 >/dev/null)
+  case "$control" in
+    *[Bb]"roken pipe"*) : ;;
+    *) fail "test harness cannot trigger a broken pipe under ignored SIGPIPE; case is vacuous (control='$control')" ;;
+  esac
+
+  # The real probe, same ignored SIGPIPE, must return capable AND print nothing.
+  PATH="$fb:$PATH" FM_BACKEND_HERDR_EVENT_READER=stub /bin/bash -c '
+    trap "" PIPE
+    . "$0/bin/backends/herdr.sh"
+    fm_backend_herdr_events_capable sess
+  ' "$ROOT" 2>"$err"; rc=$?
+  [ "$rc" = 0 ] || fail "events_capable must return capable when both tokens are present, got $rc"
+  if grep -qiE 'broken pipe|write error' "$err"; then
+    fail "events_capable spammed a broken-pipe write error under ignored SIGPIPE: $(cat "$err")"
+  fi
+
+  # A missing token still fails closed to incapable, and still stays quiet.
+  PATH="$fb:$PATH" FM_BACKEND_HERDR_EVENT_READER=stub FM_FAKE_SCHEMA_DROP=pane.agent_status_changed /bin/bash -c '
+    trap "" PIPE
+    . "$0/bin/backends/herdr.sh"
+    fm_backend_herdr_events_capable sess
+  ' "$ROOT" 2>"$err"; rc=$?
+  [ "$rc" = 1 ] || fail "events_capable must return incapable when a token is absent, got $rc"
+  if grep -qiE 'broken pipe|write error' "$err"; then
+    fail "events_capable spammed a broken-pipe write error on the incapable path: $(cat "$err")"
+  fi
+  pass "fm_backend_herdr_events_capable: matches the large schema without a broken pipe under ignored SIGPIPE"
+}
+
 # shellcheck source=bin/fm-backend.sh
 . "$ROOT/bin/fm-backend.sh"
 
+test_events_capable_sigpipe_ignored_no_broken_pipe
 test_version_check_accepts_current_protocol
 test_version_check_refuses_old_protocol
 test_version_check_refuses_missing_herdr


### PR DESCRIPTION
## Problem

On herdr homes with parked panes, the watcher's push-capability probe
(`fm_backend_herdr_events_capable` in `bin/backends/herdr.sh`) spammed
`printf: write error: Broken pipe` to the watcher's stderr, alongside repeated
watcher restarts.

## Root cause (reproduced end-to-end)

The probe matched the ~220KB `herdr api schema` output with
`printf '%s' "$schema" | grep -Fq TOKEN`. `grep -Fq` exits on the first match
while the Bash `printf` builtin is still writing the rest of the schema down the
pipe. When the watcher inherits an **ignored SIGPIPE** from its launcher, that
write returns `EPIPE` instead of dying silently, so `printf` reports
`write error: Broken pipe` on every probe.

Reproduced in a throwaway home (8 parked herdr panes, ignored SIGPIPE): exactly
two broken-pipe lines at the two `grep -Fq` calls, while the watcher cycle
itself stayed healthy - confirming the message was noise co-occurring with the
restarts, not the killer.

## Fix

Match the schema with pure-Bash glob `case` (no subprocess, no pipe), which
cannot break a pipe and is immune to the caller's SIGPIPE disposition. The
capability verdict is unchanged and was reverified against real herdr 0.7.5 via
`tests/fm-backend-herdr-eventwait-smoke.test.sh`.

The watcher read path was separately verified end-to-end to already survive
transient/malformed/failed herdr reads (reader dying mid-stream, failing pane
reads) without killing the cycle, so no behavioral change was made there. The
`cycle ended without an actionable reason` string is intentionally untouched: it
is a typed sentinel the Stop-hook re-arm/guard contract parses, and it is not
driven by the herdr read path.

## Tests

New colocated regression case in `tests/fm-backend-herdr.test.sh` that fixes the
triggering environment (ignored SIGPIPE, large fake api schema, early tokens),
proves via a control that the environment really can break a pipe, then asserts
the probe stays quiet while returning the correct capable/incapable verdict.
Confirmed the test fails against the pre-fix `grep` pattern and passes against
the fix. Full herdr suite green.

Validated through the no-mistakes pipeline (review, test, document, lint all
green; findings info/no-op only). The `document` step added the one-line
invariant note in `docs/herdr-backend.md`.
