### PR TITLE
fix(bin): instruct using no-mistakes CLI instead of skill in brief generator

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -30,7 +30,8 @@
 # For ship tasks, --mode is REQUIRED and shapes the definition of done. Firstmate
 # resolves it per task at intake (AGENTS.md section 7); data/projects.md holds the
 # captain's standing posture as context, and this script never reads it:
-#   no-mistakes  implement -> /no-mistakes pipeline -> PR -> configured merge authority
+#   no-mistakes  implement -> no-mistakes pipeline (the `no-mistakes axi` CLI, not a
+#                skill) -> PR -> configured merge authority
 #   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> configured merge authority
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                the configured merge authority approves, firstmate merges to local main
@@ -361,7 +362,7 @@ Delivery contract: mode=direct-PR
 This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
 When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
-Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
+Do NOT run the no-mistakes pipeline. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
     ;;
   local-only)
@@ -384,12 +385,12 @@ EOF
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 Delivery contract: mode=no-mistakes
-The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+This mode is complete only when the no-mistakes pipeline has shipped a PR whose checks are green.
+When implementation is committed on your branch, append \`done: implemented and committed, not yet validated - no PR yet\` to the status file and stop.
+Firstmate then triggers validation on you. That trigger may arrive worded as a \`/no-mistakes\` skill invocation, but what you run is the \`no-mistakes\` CLI on your \`PATH\`: \`no-mistakes axi run --intent "<...>"\` to start, and \`no-mistakes axi respond\` for each gate.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
-Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
+Follow the guidance no-mistakes itself provides for the mechanics: \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
 When starting no-mistakes, make \`--intent\` preserve all relevant content from this brief's \`# Task\` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 
@@ -399,7 +400,8 @@ Two firstmate-specific rules layer on top of that guidance:
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
 - Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
 
-After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
+If you cannot start or continue the run, append \`blocked: {the exact error}\` and stop; never report \`done:\` for work that has no PR.
+After the run reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
     ;;
 esac

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -400,7 +400,7 @@ Two firstmate-specific rules layer on top of that guidance:
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
 - Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
 
-If you cannot start or continue the run, append \`blocked: {the exact error}\` and stop; never report \`done:\` for work that has no PR.
+If you cannot start or continue the run, append \`blocked: {the exact error}\` and stop, never \`done:\`.
 After the run reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
     ;;

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -406,7 +406,7 @@ test_no_scaffold_instructs_a_skill_invocation() {
     "no-mistakes DOD did not bind completion to a green PR"
   assert_grep "not yet validated - no PR yet" "$brief" \
     "no-mistakes DOD let the implementation handoff read as a shipped result"
-  assert_grep "never report \`done:\` for work that has no PR" "$brief" \
+  assert_grep "stop, never \`done:\`." "$brief" \
     "no-mistakes DOD did not route an unstartable run to blocked: instead of done:"
 
   # The faster paths must refuse the pipeline without naming a skill for it.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -256,7 +256,7 @@ test_ship_mode_is_explicit_not_registry() {
   brief="$home/data/brief-explicit-a5/brief.md"
   grep -qx "Delivery contract: mode=no-mistakes" "$brief" \
     || fail "registered direct-PR posture overrode the explicit --mode"
-  assert_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
+  assert_grep "Firstmate then triggers validation on you." "$brief" \
     "explicit no-mistakes brief did not render the pipeline definition of done"
 
   # An unregistered project is not a blocker either, because nothing is looked up.
@@ -352,6 +352,67 @@ test_no_mistakes_dod_wording() {
   assert_grep "firstmate's authority check" "$brief" \
     "no-mistakes DOD lost the apostrophe prose that the structural fix makes parse-safe"
   pass "fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe"
+}
+
+# A crewmate runs in a project worktree, not the firstmate home, so the
+# `no-mistakes` SKILL is not reachable to it while the `no-mistakes` CLI on PATH
+# always is. Briefs that told the worker to invoke the skill cost a supervisor
+# round trip at exactly the point the worker had just finished implementing, and
+# three workers instead reported `done:` for a commit with no PR. Every scaffold
+# must therefore name the CLI and no scaffold may instruct a skill invocation.
+test_no_scaffold_instructs_a_skill_invocation() {
+  local home id brief
+  home="$TMP_ROOT/cli-interface-home"
+  mkdir -p "$home/data"
+
+  for id_args in \
+    "brief-iface-nomistakes:some-proj --mode no-mistakes" \
+    "brief-iface-directpr:some-proj --mode direct-PR" \
+    "brief-iface-localonly:some-proj --mode local-only" \
+    "brief-iface-scout:some-proj --scout"; do
+    id=${id_args%%:*}
+    # shellcheck disable=SC2086  # the arg list is an intentional word split
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" ${id_args#*:} >/dev/null 2>&1 \
+      || fail "$id: scaffold exited non-zero"
+    brief="$home/data/$id/brief.md"
+    assert_no_grep "run /no-mistakes" "$brief" \
+      "$id: brief tells the worker to run a skill it cannot load"
+    assert_no_grep "invoke /no-mistakes" "$brief" \
+      "$id: brief tells the worker to invoke a skill it cannot load"
+  done
+
+  FM_HOME="$home" FM_SECONDMATE_CHARTER='Handle routed domain work.' \
+    "$ROOT/bin/fm-brief.sh" brief-iface-secondmate --secondmate --no-projects >/dev/null 2>&1 \
+    || fail "secondmate charter scaffold exited non-zero"
+  brief="$home/data/brief-iface-secondmate/brief.md"
+  assert_no_grep "run /no-mistakes" "$brief" \
+    "secondmate charter tells the worker to run a skill it cannot load"
+  assert_no_grep "invoke /no-mistakes" "$brief" \
+    "secondmate charter tells the worker to invoke a skill it cannot load"
+
+  # The no-mistakes ship brief must positively name the working interface, and
+  # must keep the PR as the only thing `done:` can mean in that mode.
+  brief="$home/data/brief-iface-nomistakes/brief.md"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
+  assert_grep 'the `no-mistakes` CLI on your `PATH`' "$brief" \
+    "no-mistakes DOD did not name the CLI as the interface the worker actually has"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
+  assert_grep '`no-mistakes axi run --intent "<...>"` to start' "$brief" \
+    "no-mistakes DOD did not give the concrete run command"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
+  assert_grep '`no-mistakes axi respond` for each gate' "$brief" \
+    "no-mistakes DOD did not give the concrete gate-response command"
+  assert_grep "This mode is complete only when the no-mistakes pipeline has shipped a PR whose checks are green." "$brief" \
+    "no-mistakes DOD did not bind completion to a green PR"
+  assert_grep "not yet validated - no PR yet" "$brief" \
+    "no-mistakes DOD let the implementation handoff read as a shipped result"
+  assert_grep "never report \`done:\` for work that has no PR" "$brief" \
+    "no-mistakes DOD did not route an unstartable run to blocked: instead of done:"
+
+  # The faster paths must refuse the pipeline without naming a skill for it.
+  assert_grep "Do NOT run the no-mistakes pipeline." "$home/data/brief-iface-directpr/brief.md" \
+    "direct-PR brief lost its pipeline refusal"
+  pass "fm-brief.sh: every scaffold names the no-mistakes CLI and none instructs a skill invocation"
 }
 
 test_ship_project_memory_wording() {
@@ -719,6 +780,7 @@ test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
+test_no_scaffold_instructs_a_skill_invocation
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path


### PR DESCRIPTION
## Intent

Fix bin/fm-brief.sh, firstmate's crewmate-brief generator, so every generated brief names the interface a crewmate actually has.

The fault: every mode=no-mistakes ship brief told the worker to invoke the /no-mistakes SKILL. A crewmate cannot: that skill lives in the firstmate home's .agents/skills/ and loads for a firstmate session in the firstmate home, while a crewmate runs in a project worktree with no .claude/skills, so Skill(no-mistakes) returns 'Error: Unknown skill: no-mistakes'. The working path is the CLI on PATH: 'no-mistakes axi run --intent "<...>"' to start and 'no-mistakes axi respond' for each gate. Three lines carried the false premise: 'Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.', '...it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` ...', and 'After /no-mistakes reports CI green ...'. The line already pointing at 'no-mistakes axi run --help' as authoritative means much of this is removing a wrong premise rather than writing new guidance.

Why it is worth fixing: overnight 2026-08-17/18 three separate workers (hz-garmin-clock-decisions, hz-settings-counts-filter, hz-session-clock-skew) each finished implementing, could not start validation, and appended a premature 'done:' line describing a commit with no pull request; each needed a supervisor round trip supplying the exact run command. The defect lands precisely where a worker has just finished implementing and is most prone to declaring victory, and a 'done:' with no PR is the single most misleading status this fleet produces because it reads as success to everything downstream. The brief should therefore also make that failure mode harder: the definition of done for a no-mistakes ship already requires a PR URL, and a worker that cannot start validation should report 'blocked:', not 'done:'. Do not bloat the scaffold - it is read by every worker on every task and its length is a cost.

Scope and constraints:
- bin/fm-brief.sh is the generator; never hand-edit a generated brief, fix the generator.
- Check every scaffold variant, not just the no-mistakes ship one: the scout contract, the direct-PR and local-only ship variants, and the secondmate charter; report which carried the same premise and which did not.
- Do NOT make the skill reachable to crewmates as the fix; that was considered and rejected. The honest fix is that the brief names the interface the worker actually has.
- This is firstmate's shared tracked material, so the firstmate-coding-guidelines skill applies (knowledge placement, one-owner rule, size discipline, one sentence per line, plain dash never an em dash, shellcheck-clean bin scripts, colocated tests in tests/ extending the existing runner, no agent commit co-author).
- Do not weaken any safety contract in the scaffold: the worktree-isolation assertion, the status protocol, the 'paused:' versus 'blocked:' distinction, the decision-key contract, and the delivery-contract line all stay exactly as strong as they are.

The bar: fm-brief.sh generates text, so prove the fix by generating. Scaffold one brief of each variant into a scratch location, show the relevant sections before and after, and confirm no variant still mentions invoking the skill. Extend the existing tests/fm-brief.test.sh coverage rather than inventing a heavyweight harness.

Delivery: this repo's own validation pipeline and pull request path; this repo enforces in CI that PRs are raised through no-mistakes, so the pipeline is the only route.

## What Changed
- Updated `bin/fm-brief.sh` to instruct workers to drive the no-mistakes pipeline using the `no-mistakes` CLI on `PATH` (`no-mistakes axi run` and `no-mistakes axi respond`) instead of invoking the `/no-mistakes` skill.
- Refined status reporting guidance for `no-mistakes` mode briefs so intermediate commits report as unvalidated, unstartable runs report `blocked:`, and `done:` is reserved for a shipped PR with green checks.
- Added `test_no_scaffold_instructs_a_skill_invocation` in `tests/fm-brief.test.sh` to verify no brief scaffold instructs a skill invocation and that CLI commands are rendered correctly.

## Risk Assessment

✅ Low: The change is cleanly bounded, updates firstmate brief generation to accurately reflect available CLI tools, and includes comprehensive test assertions for all scaffold modes.

## Testing

<code>Exercised `./tests/fm-brief.test.sh` (20 tests passed) and scaffolded all 5 brief variants into a temporary location. Confirmed that no scaffold variant instructs running or invoking the `/no-mistakes` skill, that `mode=no-mistakes` brief explicitly names the `no-mistakes` CLI on PATH (`no-mistakes axi run --intent &#34;&lt;...&gt;&#34;` and `no-mistakes axi respond`), and that unstartable runs report `blocked:` instead of `done:`.</code>

<details>
<summary>Evidence: Scaffold Variants Verification Log</summary>

Source: [Scaffold Variants Verification Log](https://github.com/BohnBawerick/firstmate/blob/1d07bdf8a61df83b612e4c46849856e9eb1c7463/.no-mistakes/evidence/fm/fm-brief-no-mistakes-cli/scaffold_verification.log)

```text
=== 1. Running Unit Test Suite tests/fm-brief.test.sh ===
ok - fm-brief.sh: bash -n succeeds
/tmp/fm-brief.BOVMTJ/heredoc-in-substitution.sh:2
ok - fm-brief.sh: no heredoc is nested inside a command substitution (Bash 3.2 parse-safe)
ok - fm-brief.sh: --help renders the complete header
ok - fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly
ok - fm-brief.sh: ship --mode is required and closed-set validated
ok - fm-brief.sh: the explicit ship mode wins over the registered posture
ok - fm-brief.sh: --yolo and scout/secondmate --mode are refused, never silently dropped
ok - fm-brief.sh: faster paths use configured authority without stacked review
ok - fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe
ok - fm-brief.sh: every scaffold names the no-mistakes CLI and none instructs a skill invocation
ok - fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar
ok - fm-brief.sh: --herdr-lab emits the complete hard safety contract
ok - fm-brief.sh: --herdr-lab uses its quoted Firstmate-owned helper path
ok - fm-brief.sh: ship and scout scaffolds make omitted Herdr intent fail-visible
ok - fm-brief.sh: Herdr lab contract covers scouts and rejects secondmate misuse
ok - fm-brief.sh: --no-projects scaffolds a project-less charter and guards misuse
ok - fm-brief.sh: marked requests avoid generic acknowledgements and preserve material reporting
ok - fm-brief.sh: relative directory inputs ignore CDPATH, render stable absolute charter paths, or fail loudly
ok - fm-brief.sh: custom pause verb renders in every scaffold
ok - fm-brief.sh: investigation and visual-review completions load the shared decision policy
ok - fm-brief: scout and secondmate code paths still scaffold well-formed briefs

=== 2. Scaffolding All 5 Scaffold Variants into Scratch Location ===
scaffolded: /tmp/scaffold-evidence-gen/data/task-nomistakes/brief.md (ship, mode=no-mistakes; replace {TASK})
scaffolded: /tmp/scaffold-evidence-gen/data/task-directpr/brief.md (ship, mode=direct-PR; replace {TASK})
scaffolded: /tmp/scaffold-evidence-gen/data/task-localonly/brief.md (ship, mode=local-only; replace {TASK})
scaffolded: /tmp/scaffold-evidence-gen/data/task-scout/brief.md (scout; replace {TASK})
scaffolded: /tmp/scaffold-evidence-gen/data/task-secondmate/brief.md (secondmate charter)

=== 3. Inspected DOD/Operating Sections Across All 5 Scaffold Variants ===
--- Variant 1: ship --mode no-mistakes ---
# Definition of done
Delivery contract: mode=no-mistakes
This mode is complete only when the no-mistakes pipeline has shipped a PR whose checks are green.
When implementation is committed on your branch, append `done: implemented and committed, not yet validated - no PR yet` to the status file and stop.
Firstmate then triggers validation on you. That trigger may arrive worded as a `/no-mistakes` skill invocation, but what you run is the `no-mistakes` CLI on your `PATH`: `no-mistakes axi run --intent "<...>"` to start, and `no-mistakes axi respond` for each gate.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

If you cannot start or continue the run, append `blocked: {the exact error}` and stop, never `done:`.
After the run reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.

--- Variant 2: ship --mode direct-PR ---
# Definition of done
Delivery contract: mode=direct-PR
This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run the no-mistakes pipeline. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.

--- Variant 3: ship --mode local-only ---
# Definition of done
Delivery contract: mode=local-only
This task ships **local-only**: no remote, no PR, no pipeline.
The task is complete only when committed on your branch `fm/task-localonly`. Do NOT push, do NOT open a PR, do NOT merge.
Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
When it is implemented and committed, append `done: ready in branch fm/task-localonly` to the status file and stop.
The configured merge authority approves the ready branch, then firstmate merges it into local `main` through the guarded fast-forward path.

--- Variant 4: --scout ---
# Definition of done
Write your findings to `/tmp/scaffold-evidence-gen/data/task-scout/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
Before reporting done, read and follow `/home/paiva/.no-mistakes/worktrees/3437026af8a8/01M08FCN24AQ6VBA2XHW6KHNX9/.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.

--- Variant 5: --secondmate --no-projects ---
You are a persistent second mate managed by the main firstmate. Work on your own; do not wait for a human.

# Charter
Charter text

# Routing scope
Charter text

# Project clones
None. This is a project-less domain: its subject is the firstmate repo this home lives in, so it needs no separate clones under `projects/`; its crews take pooled worktrees of that firstmate repo.

# Operating model
You are in an isolated firstmate home. The local `AGENTS.md` is your job description, and your local `data/`, `state/`, `config/`, and `projects/` dirs are yours to operate.
This domain has no separate project clones: its subject is the firstmate repo this home lives in, and its crews take pooled worktrees of that repo.
Delegate project work to your own crewmates with the normal firstmate lifecycle: brief, spawn, status, watcher, steer, teardown, and recovery.
Do not invent a second delegation system.
You do not generate your own work.
Act only on tasks the main firstmate routes to you.
Never start a survey, audit, or "find improvements" sweep on your own initiative; that is not your job and it is unwanted.

# Requests from the main firstmate
You are a firstmate in your own home, so an incoming message reaches you in your own chat.
You must distinguish who it is from, because the answer goes to a different place.
A request relayed to you by the main firstmate is tagged with a leading `[fm-from-firstmate]` marker followed by an invisible system separator; this marker is untypable, so a human never produces it.
When a message carries that marker, do the work, then respond via the STATUS/ESCALATION path below, never only in this chat: the main firstmate does not read your chat, so a chat-only reply is lost.

=== 4. Verification: Check that no variant instructs invoking the /no-mistakes skill ===
PASS: Zero occurrences of 'run /no-mistakes' or 'invoke /no-mistakes' across all generated scaffolds.

=== 5. Verification: Check CLI naming in no-mistakes ship mode ===
PASS: mode=no-mistakes brief explicitly instructs using the 'no-mistakes' CLI on PATH.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2e878030c39b0ed1e3c043fdf8934edc1da05d2f","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-brief.sh:386` - Line 386 instructs the worker to append &#34;done: implemented and committed, not yet validated - no PR yet&#34; to the status file upon completing implementation, which emits a &#34;done:&#34; status line before validation or PR creation. This directly contradicts line 400 (&#34;never report `done:` for work that has no PR&#34;) and contradicts the authoritative intent requirement that a worker unable to start validation should report &#34;blocked:&#34;, not &#34;done:&#34;.

🔧 Fix: Scope unstartable validation reporting rule in brief generator
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `./tests/fm-brief.test.sh`
- <code>Scaffolded brief variants with `./bin/fm-brief.sh`: `ship --mode no-mistakes`, `ship --mode direct-PR`, `ship --mode local-only`, `--scout`, and `--secondmate --no-projects` and verified CLI guidance, status reporting rules, and skill omission.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
