### PR TITLE
feat: LLM-gateway budget meter for Pi and claude

### DIFF
--- a/.pi/extensions/fm-llm-budget.ts
+++ b/.pi/extensions/fm-llm-budget.ts
@@ -1,0 +1,70 @@
+// Firstmate's Pi footer meter for remaining Rippling personal LLM-gateway budget.
+//
+// Uses a dedicated setStatus key so it does not share Calm's firstmate-calm slot.
+// bin/fm-llm-budget.sh owns the cache, query, and printed line. This adapter only
+// decides whether the active Pi provider is a Rippling gateway family and then
+// calls that command. docs/llm-budget.md points here and at the command header.
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ExtensionAPI, ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+
+export const LLM_BUDGET_STATUS_KEY = "firstmate-llm-budget";
+
+const extensionDir = dirname(fileURLToPath(import.meta.url));
+const root = resolve(extensionDir, "../..");
+const budgetCommand = resolve(root, "bin/fm-llm-budget.sh");
+
+type GatewayModel = {
+  provider?: string;
+  id?: string;
+};
+
+export function isRipplingGatewayModel(
+  model: GatewayModel | null | undefined,
+): boolean {
+  const provider = (model?.provider || "").toLowerCase();
+  const id = (model?.id || "").toLowerCase();
+  if (provider === "rippling-bedrock" || provider === "rippling-openai") return true;
+  if (provider.startsWith("rippling-")) return true;
+  if (id.startsWith("rippling-")) return true;
+  return false;
+}
+
+function applyMeter(ui: ExtensionUIContext, model: GatewayModel | null | undefined): void {
+  if (!isRipplingGatewayModel(model)) {
+    ui.setStatus(LLM_BUDGET_STATUS_KEY, undefined);
+    return;
+  }
+  const result = spawnSync(
+    budgetCommand,
+    [
+      "print",
+      "--if-gateway",
+      "--kick-refresh",
+      "--provider",
+      model?.provider || "",
+      "--model",
+      model?.id || "",
+    ],
+    {
+      encoding: "utf8",
+      timeout: 1500,
+      env: process.env,
+    },
+  );
+  const line = (result.stdout || "").trim();
+  ui.setStatus(LLM_BUDGET_STATUS_KEY, line || undefined);
+}
+
+export default function (pi: ExtensionAPI): void {
+  pi.on("session_start", (_event, ctx) => {
+    applyMeter(ctx.ui, ctx.model);
+  });
+  pi.on("model_select", (event, ctx) => {
+    applyMeter(ctx.ui, event.model);
+  });
+  pi.on("turn_start", (_event, ctx) => {
+    applyMeter(ctx.ui, ctx.model);
+  });
+}

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, runtime backend selection, optional Relay and its X and Discord setup steps, the files you set, and harness support.
 - [docs/remote-secondmates.md](docs/remote-secondmates.md) - current setup, routing, transfer, recovery, and safety behavior for whole-home remote second mates.
 - [docs/calm.md](docs/calm.md) - current Pi `/calm` behavior and supported presentation limits.
+- [docs/llm-budget.md](docs/llm-budget.md) - where the Rippling LLM-gateway budget meter attaches; the command header owns the cache and query.
 - [docs/wedge-alarm.md](docs/wedge-alarm.md) - configure the active alert for an away-mode escalation delivery that gets stuck.
 - [docs/tmux-backend.md](docs/tmux-backend.md) - current setup and limits for the tmux reference backend.
 - [docs/herdr-backend.md](docs/herdr-backend.md) - current setup, safety boundaries, and limits for the experimental Herdr backend.

--- a/bin/fm-llm-budget.sh
+++ b/bin/fm-llm-budget.sh
@@ -1,0 +1,727 @@
+#!/usr/bin/env bash
+# fm-llm-budget.sh - personal Rippling LLM-gateway budget meter.
+#
+# ONE owner of the cache, query, print, and refresh contract used by Pi, Claude
+# Code, and any other adapter that shows remaining personal gateway budget.
+# Adapters call this command; they do not restate the Datadog body, cache
+# schema, or dollar arithmetic. docs/llm-budget.md is a pointer here.
+#
+# Print never blocks on the network. Refresh is a separate path with a
+# 15-minute TTL. Last-good cache is kept across refresh failures. Cache older
+# than 24 hours is marked stale in the printed line but is still shown.
+#
+# Cache (gitignored, under the effective FM_HOME):
+#   state/llm-budget-cache.json
+# Fields: version=1, source (datadog|gateway-402), email, cap, spend,
+# remaining, exhausted (bool), fetched_at_unix, month_start_unix.
+# Remaining is cap minus spend, clamped at 0. Over-cap spend is exhausted.
+# Default cap is 2000 USD unless the 402 body supplies total, FM_LLM_BUDGET_CAP
+# is set, or config/llm-budget-cap contains a positive number.
+#
+# Email resolution, in order: RIPPLING_EMAIL, config/rippling-email, Directory
+# Services, git user.email when it is @rippling.com. Tracked code never hardcodes
+# one person.
+#
+# Auth for Datadog, in order: DD_API_KEY+DD_APP_KEY (or DATADOG_API_KEY+
+# DATADOG_APP_KEY) as DD-API-KEY / DD-APPLICATION-KEY; then a Keychain session
+# at service com.rippling.firstmate.llm-budget.datadog account oauth.datadoghq.com
+# (Linux: state/llm-budget-datadog-oauth.json mode 0600). `login` runs one-shot
+# PKCE. Never print secrets. Never use com.rippling.ai-budget.datadog.
+#
+# Gateway 402 fallback: `wavecode llm-gateway get-api-key`, then
+# `~/.wavecode/config/llm_gateway.json` `llm_key` (or WAVECODE_CONFIG_PATH).
+# If wavecode reports the budget exhausted and no 402 body is available,
+# remaining is 0 at the resolved cap.
+#
+# Gateway models: provider rippling-bedrock or rippling-openai (or any
+# rippling-* provider), or a base URL containing llm-gateway. Non-gateway
+# print/statusline output is empty.
+#
+# Usage:
+#   fm-llm-budget.sh print [--if-gateway] [--kick-refresh]
+#                          [--provider <name>] [--model <id>] [--base-url <url>]
+#   fm-llm-budget.sh refresh
+#   fm-llm-budget.sh login
+#   fm-llm-budget.sh claude-statusline [--kick-refresh]
+#   fm-llm-budget.sh install-claude
+#   fm-llm-budget.sh --help
+#
+# Environment:
+#   FM_HOME / FM_ROOT_OVERRIDE / FM_STATE_OVERRIDE / FM_CONFIG_OVERRIDE
+#   RIPPLING_EMAIL   FM_LLM_BUDGET_CAP   WAVECODE_CONFIG_PATH
+#   DD_API_KEY DD_APP_KEY (or DATADOG_API_KEY DATADOG_APP_KEY)
+#   CLAUDE_CONFIG_DIR   (install-claude; default ~/.claude)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+CACHE="$STATE/llm-budget-cache.json"
+LOCKDIR="$STATE/llm-budget-refresh.lock"
+OAUTH_FILE="$STATE/llm-budget-datadog-oauth.json"
+EMAIL_FILE="$CONFIG/rippling-email"
+CAP_FILE="$CONFIG/llm-budget-cap"
+TTL_SECONDS=900
+STALE_SECONDS=86400
+DEFAULT_CAP=2000
+KEYCHAIN_SERVICE="com.rippling.firstmate.llm-budget.datadog"
+KEYCHAIN_ACCOUNT="oauth.datadoghq.com"
+GATEWAY_HEALTH_PATH="/providers/health"
+GATEWAY_HOST_NEEDLE="llm-gateway"
+
+usage() {
+  sed -n '2,/^set -euo pipefail$/p' "$0" | sed '$d' | sed 's/^# \{0,1\}//'
+}
+
+die() {
+  printf 'error: %s\n' "$1" >&2
+  exit 2
+}
+
+need_python() {
+  command -v python3 >/dev/null 2>&1 || die "python3 is required"
+}
+
+mkdir_state() {
+  mkdir -p "$STATE" "$CONFIG"
+}
+
+path_mtime() {
+  if [ ! -e "$1" ]; then
+    printf '%s\n' 0
+    return 0
+  fi
+  if [ "$(uname)" = Darwin ]; then
+    stat -f %m "$1"
+  else
+    stat -c %Y "$1"
+  fi
+}
+
+now_unix() {
+  python3 -c 'import time; print(int(time.time()))'
+}
+
+is_gateway() {
+  local provider=${1:-} model=${2:-} base=${3:-}
+  local blob
+  blob=$(printf '%s\n%s\n%s\n%s\n%s\n%s\n' \
+    "$provider" "$model" "$base" \
+    "${ANTHROPIC_BASE_URL:-}" "${OPENAI_BASE_URL:-}" "${OPENAI_API_BASE:-}")
+  printf '%s\n' "$blob" | grep -qi "$GATEWAY_HOST_NEEDLE" && return 0
+  provider=$(printf '%s' "$provider" | tr '[:upper:]' '[:lower:]')
+  case "$provider" in
+    rippling-bedrock|rippling-openai|rippling-*) return 0 ;;
+  esac
+  model=$(printf '%s' "$model" | tr '[:upper:]' '[:lower:]')
+  case "$model" in
+    rippling-bedrock*|rippling-openai*|rippling-*) return 0 ;;
+  esac
+  return 1
+}
+
+kick_refresh_if_due() {
+  local age mtime now
+  mkdir_state
+  mtime=$(path_mtime "$CACHE")
+  now=$(now_unix)
+  age=$((now - mtime))
+  if [ -f "$CACHE" ] && [ "$age" -lt "$TTL_SECONDS" ]; then
+    return 0
+  fi
+  (
+    exec >/dev/null 2>&1
+    "$SCRIPT_DIR/fm-llm-budget.sh" refresh
+  ) &
+}
+
+print_from_cache() {
+  need_python
+  if [ ! -f "$CACHE" ]; then
+    printf '%s\n' "LLM budget: …"
+    return 0
+  fi
+  python3 - "$CACHE" "$STALE_SECONDS" <<'PY'
+import json, sys, time
+path, stale_after = sys.argv[1], int(sys.argv[2])
+try:
+    data = json.load(open(path, encoding="utf-8"))
+except (OSError, json.JSONDecodeError):
+    print("LLM budget: …")
+    raise SystemExit(0)
+cap = float(data.get("cap") or 0)
+spend = float(data.get("spend") or 0)
+remaining = float(data.get("remaining") if data.get("remaining") is not None else max(0.0, cap - spend))
+if remaining < 0:
+    remaining = 0.0
+exhausted = bool(data.get("exhausted")) or remaining <= 0 < spend or spend >= cap > 0
+fetched = int(data.get("fetched_at_unix") or 0)
+stale = fetched > 0 and (time.time() - fetched) > stale_after
+
+def dollars(value):
+    return f"${value:,.0f}"
+
+line = f"LLM {dollars(remaining)} of {dollars(cap)} (mtd {dollars(spend)})"
+if exhausted:
+    line += " exhausted"
+if stale:
+    line += " stale"
+print(line)
+PY
+}
+
+cmd_print() {
+  local if_gateway=0 kick=0 provider="" model="" base_url=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --if-gateway) if_gateway=1 ;;
+      --kick-refresh) kick=1 ;;
+      --provider) provider=${2:-}; shift ;;
+      --model) model=${2:-}; shift ;;
+      --base-url) base_url=${2:-}; shift ;;
+      -h|--help) usage; exit 0 ;;
+      *) die "unknown print option: $1" ;;
+    esac
+    shift
+  done
+  if [ "$if_gateway" -eq 1 ] && ! is_gateway "$provider" "$model" "$base_url"; then
+    return 0
+  fi
+  print_from_cache
+  if [ "$kick" -eq 1 ]; then
+    kick_refresh_if_due
+  fi
+}
+
+cmd_claude_statusline() {
+  local kick=0 payload provider model
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --kick-refresh) kick=1 ;;
+      -h|--help) usage; exit 0 ;;
+      *) die "unknown claude-statusline option: $1" ;;
+    esac
+    shift
+  done
+  need_python
+  payload=$(cat || true)
+  provider=""
+  model=""
+  if [ -n "$payload" ]; then
+    provider=$(printf '%s' "$payload" | python3 -c 'import json,sys
+try:
+    data=json.load(sys.stdin)
+except json.JSONDecodeError:
+    raise SystemExit(0)
+model=data.get("model") or {}
+sys.stdout.write(str(model.get("provider") or data.get("provider") or ""))' || true)
+    model=$(printf '%s' "$payload" | python3 -c 'import json,sys
+try:
+    data=json.load(sys.stdin)
+except json.JSONDecodeError:
+    raise SystemExit(0)
+model=data.get("model") or {}
+sys.stdout.write(str(model.get("id") or model.get("display_name") or ""))' || true)
+  fi
+  if ! is_gateway "$provider" "$model" ""; then
+    return 0
+  fi
+  print_from_cache
+  if [ "$kick" -eq 1 ]; then
+    kick_refresh_if_due
+  fi
+}
+
+cmd_install_claude() {
+  local settings_dir settings
+  need_python
+  settings_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+  settings="$settings_dir/settings.json"
+  mkdir -p "$settings_dir"
+  python3 - "$settings" "$SCRIPT_DIR/fm-llm-budget.sh" <<'PY'
+import json, os, sys
+path, command = sys.argv[1], sys.argv[2]
+data = {}
+if os.path.isfile(path):
+    try:
+        data = json.load(open(path, encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise SystemExit(f"error: Claude settings are not valid JSON: {error}")
+    if not isinstance(data, dict):
+        raise SystemExit("error: Claude settings root must be an object")
+data["statusLine"] = {
+    "type": "command",
+    "command": f"{command} claude-statusline --kick-refresh",
+}
+tmp = path + f".tmp.{os.getpid()}"
+with open(tmp, "w", encoding="utf-8") as handle:
+    json.dump(data, handle, indent=2)
+    handle.write("\n")
+os.chmod(tmp, 0o600)
+os.replace(tmp, path)
+print(path)
+PY
+}
+
+cmd_refresh() {
+  need_python
+  mkdir_state
+  if mkdir "$LOCKDIR" 2>/dev/null; then
+    trap 'rmdir "$LOCKDIR" 2>/dev/null || true' EXIT
+  else
+    return 0
+  fi
+  python3 - "$CACHE" "$EMAIL_FILE" "$CAP_FILE" "$OAUTH_FILE" \
+    "$KEYCHAIN_SERVICE" "$KEYCHAIN_ACCOUNT" "$DEFAULT_CAP" \
+    "$GATEWAY_HEALTH_PATH" <<'PY'
+import json, os, re, subprocess, sys, time, urllib.error, urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+cache_path, email_file, cap_file, oauth_file, keychain_service, keychain_account, default_cap, health_path = sys.argv[1:9]
+default_cap = float(default_cap)
+
+def log(message):
+    sys.stderr.write(f"fm-llm-budget: {message}\n")
+
+def atomic_write(path, payload, mode=0o600):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}")
+    data = json.dumps(payload, separators=(",", ":"), ensure_ascii=True) + "\n"
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode)
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write(data)
+    os.replace(tmp, path)
+
+def load_json(path):
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+def rfc3339_millis(dt):
+    utc = dt.astimezone(timezone.utc)
+    millis = int(utc.microsecond / 1000)
+    return utc.strftime("%Y-%m-%dT%H:%M:%S.") + f"{millis:03d}Z"
+
+def month_window():
+    now = datetime.now().astimezone()
+    start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    return start, now
+
+def resolve_email():
+    for candidate in (
+        os.environ.get("RIPPLING_EMAIL", "").strip(),
+        Path(email_file).read_text(encoding="utf-8").strip() if Path(email_file).is_file() else "",
+    ):
+        if candidate.lower().endswith("@rippling.com") and "@" in candidate:
+            return candidate.lower()
+    user = os.environ.get("USER") or ""
+    if user:
+        try:
+            output = subprocess.check_output(
+                ["/usr/bin/dscl", ".", "-read", f"/Users/{user}",
+                 "EMailAddress", "dsAttrTypeStandard:EMailAddress"],
+                text=True, stderr=subprocess.DEVNULL,
+            )
+        except (OSError, subprocess.CalledProcessError):
+            output = ""
+        for token in output.replace(":", " ").split():
+            if token.lower().endswith("@rippling.com"):
+                return token.lower()
+    try:
+        output = subprocess.check_output(
+            ["git", "config", "--global", "user.email"],
+            text=True, stderr=subprocess.DEVNULL,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        output = ""
+    if output.lower().endswith("@rippling.com"):
+        return output.lower()
+    return ""
+
+def resolve_cap(fallback):
+    env = os.environ.get("FM_LLM_BUDGET_CAP", "").strip()
+    if env:
+        try:
+            value = float(env)
+            if value > 0:
+                return value
+        except ValueError:
+            pass
+    if Path(cap_file).is_file():
+        try:
+            value = float(Path(cap_file).read_text(encoding="utf-8").split()[0])
+            if value > 0:
+                return value
+        except (OSError, ValueError, IndexError):
+            pass
+    return fallback
+
+def save_budget(*, source, email, cap, spend, month_start):
+    remaining = cap - spend
+    exhausted = remaining <= 0
+    if remaining < 0:
+        remaining = 0.0
+    payload = {
+        "version": 1,
+        "source": source,
+        "email": email,
+        "cap": cap,
+        "spend": spend,
+        "remaining": remaining,
+        "exhausted": exhausted,
+        "fetched_at_unix": int(time.time()),
+        "month_start_unix": int(month_start.timestamp()),
+    }
+    atomic_write(cache_path, payload)
+    return payload
+
+def http_json(url, *, method="GET", headers=None, body=None, timeout=30):
+    request = urllib.request.Request(url, data=body, method=method, headers=headers or {})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            raw = response.read()
+            return response.status, raw, dict(response.headers)
+    except urllib.error.HTTPError as error:
+        return error.code, error.read() or b"", dict(error.headers or {})
+
+def api_keys():
+    api = os.environ.get("DD_API_KEY") or os.environ.get("DATADOG_API_KEY") or ""
+    app = os.environ.get("DD_APP_KEY") or os.environ.get("DATADOG_APP_KEY") or ""
+    return api.strip(), app.strip()
+
+def keychain_session():
+    if sys.platform == "darwin":
+        try:
+            raw = subprocess.check_output(
+                ["security", "find-generic-password", "-s", keychain_service,
+                 "-a", keychain_account, "-w"],
+                text=True, stderr=subprocess.DEVNULL,
+            ).strip()
+            return json.loads(raw)
+        except (OSError, subprocess.CalledProcessError, json.JSONDecodeError):
+            return None
+    return load_json(oauth_file)
+
+def datadog_headers():
+    api, app = api_keys()
+    if api and app:
+        return {"DD-API-KEY": api, "DD-APPLICATION-KEY": app, "Content-Type": "application/json"}
+    session = keychain_session()
+    if not session:
+        return None
+    tokens = session.get("tokens") or session
+    access = tokens.get("access_token") or ""
+    if not access:
+        return None
+    return {"Authorization": f"Bearer {access}", "Content-Type": "application/json"}
+
+def sum_datadog(raw):
+    data = json.loads(raw)
+    buckets = (((data.get("data") or {}).get("buckets")) or [])
+    total = 0.0
+    for bucket in buckets:
+        points = ((bucket.get("computes") or {}).get("c0")) or []
+        if points is None:
+            continue
+        for point in points:
+            value = (point or {}).get("value")
+            if value is None:
+                continue
+            total += float(value)
+    return total
+
+def fetch_datadog(email, start, now):
+    headers = datadog_headers()
+    if headers is None:
+        return None, "no-datadog-auth"
+    body = json.dumps({
+        "compute": [{
+            "aggregation": "sum",
+            "interval": "15m",
+            "metric": "@cost",
+            "type": "timeseries",
+        }],
+        "filter": {
+            "from": rfc3339_millis(start),
+            "to": rfc3339_millis(now),
+            "indexes": ["*"],
+            "query": (
+                'service:llm-gateway env:devexp @key_type:personal '
+                f'"audit trail message" @user_email:"{email}"'
+            ),
+            "storage_tier": "flex",
+        },
+    }).encode()
+    status, raw, _headers = http_json(
+        "https://api.datadoghq.com/api/v2/logs/analytics/aggregate",
+        method="POST", headers=headers, body=body,
+    )
+    if status == 401 and "Authorization" in headers:
+        return None, "datadog-unauthorized"
+    if status < 200 or status >= 300:
+        return None, f"datadog-http-{status}"
+    return sum_datadog(raw), None
+
+def wavecode_home():
+    override = (os.environ.get("WAVECODE_CONFIG_PATH") or os.environ.get("WAVECODE_HOME") or "").strip()
+    if override:
+        return Path(override)
+    return Path.home() / ".wavecode"
+
+def wavecode_key():
+    err = ""
+    try:
+        proc = subprocess.run(
+            ["wavecode", "llm-gateway", "get-api-key"],
+            capture_output=True, text=True, check=False,
+        )
+        err = proc.stderr or ""
+        key = (proc.stdout or "").strip()
+        if key:
+            key = key.splitlines()[-1].strip()
+        if proc.returncode == 0 and key:
+            return key, err, None
+    except OSError:
+        err = "no-wavecode"
+    cfg = load_json(wavecode_home() / "config" / "llm_gateway.json")
+    if isinstance(cfg, dict):
+        key = str(cfg.get("llm_key") or "").strip()
+        url = str(cfg.get("llm_gateway_url") or "").strip().rstrip("/")
+        if key:
+            return key, err, url or None
+    return "", err, None
+
+def gateway_exhausted_from_text(text):
+    return "budget is exhausted" in (text or "").lower() or "budget exhausted" in (text or "").lower()
+
+def gateway_fallback():
+    key, err, configured_url = wavecode_key()
+    base = configured_url or "https://llm-gateway.us1.ripplingdev.net/api/v2"
+    if key:
+        status, raw, _headers = http_json(
+            base + health_path,
+            headers={"Authorization": f"Bearer {key}", "Accept": "text/plain, application/json"},
+        )
+        text = raw.decode("utf-8", "replace")
+        if status == 402:
+            match = re.search(
+                r"consumed\s+([0-9.]+)\s*,\s*total\s+([0-9.]+)",
+                text, re.IGNORECASE,
+            )
+            if not match:
+                cap = resolve_cap(default_cap)
+                return {"cap": cap, "spend": cap}, None
+            spend = float(match.group(1))
+            cap = float(match.group(2))
+            return {"cap": cap, "spend": spend}, None
+        if status == 200:
+            return None, "gateway-healthy-no-dollars"
+        if gateway_exhausted_from_text(text) or gateway_exhausted_from_text(err):
+            cap = resolve_cap(default_cap)
+            return {"cap": cap, "spend": cap}, None
+        return None, f"gateway-http-{status}"
+    if gateway_exhausted_from_text(err):
+        cap = resolve_cap(default_cap)
+        return {"cap": cap, "spend": cap}, None
+    if err == "no-wavecode":
+        return None, "no-wavecode"
+    return None, "no-wavecode-key"
+
+email = resolve_email()
+start, now = month_window()
+cap = resolve_cap(default_cap)
+if not email:
+    spend, error = None, "no-email"
+else:
+    spend, error = fetch_datadog(email, start, now)
+if error is None:
+    save_budget(source="datadog", email=email, cap=cap, spend=float(spend), month_start=start)
+    raise SystemExit(0)
+
+fallback, fallback_error = gateway_fallback()
+if fallback is not None:
+    save_budget(
+        source="gateway-402",
+        email=email,
+        cap=float(fallback["cap"]),
+        spend=float(fallback["spend"]),
+        month_start=start,
+    )
+    if error != "no-datadog-auth":
+        log(error)
+    raise SystemExit(0)
+
+log(error)
+if fallback_error:
+    log(fallback_error)
+raise SystemExit(1)
+PY
+}
+
+cmd_login() {
+  need_python
+  mkdir_state
+  python3 - "$OAUTH_FILE" "$KEYCHAIN_SERVICE" "$KEYCHAIN_ACCOUNT" <<'PY'
+import hashlib, json, os, secrets, socket, subprocess, sys, time, urllib.parse, urllib.request, webbrowser
+from pathlib import Path
+
+oauth_file, keychain_service, keychain_account = sys.argv[1:4]
+CLIENT_NAME = "firstmate-llm-budget"
+REGISTER = "https://api.datadoghq.com/api/v2/oauth2/register"
+AUTHORIZE = "https://app.datadoghq.com/oauth2/v1/authorize"
+TOKEN = "https://api.datadoghq.com/oauth2/v1/token"
+SCOPES = "logs_read_data logs_read_index_data"
+PORTS = (18765, 18766, 18767, 18768)
+
+def b64url(raw: bytes) -> str:
+    import base64
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+def http_json(url, *, method="POST", headers=None, body=None):
+    request = urllib.request.Request(url, data=body, method=method, headers=headers or {})
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return response.status, json.loads(response.read().decode())
+
+listener = None
+port = None
+for candidate in PORTS:
+    sock = socket.socket()
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        sock.bind(("127.0.0.1", candidate))
+        sock.listen(1)
+        listener = sock
+        port = candidate
+        break
+    except OSError:
+        sock.close()
+if listener is None:
+    raise SystemExit("error: Datadog OAuth callback ports 18765-18768 are busy")
+
+redirect = f"http://127.0.0.1:{port}/oauth/callback"
+status, registration = http_json(
+    REGISTER,
+    headers={"Content-Type": "application/json"},
+    body=json.dumps({
+        "client_name": CLIENT_NAME,
+        "redirect_uris": [redirect],
+        "grant_types": ["authorization_code", "refresh_token"],
+    }).encode(),
+)
+if status not in (200, 201):
+    raise SystemExit(f"error: Datadog OAuth client registration failed (HTTP {status})")
+client_id = registration["client_id"]
+verifier = b64url(secrets.token_bytes(32))
+challenge = b64url(hashlib.sha256(verifier.encode()).digest())
+state = b64url(secrets.token_bytes(16))
+query = urllib.parse.urlencode({
+    "response_type": "code",
+    "client_id": client_id,
+    "redirect_uri": redirect,
+    "scope": SCOPES,
+    "state": state,
+    "code_challenge": challenge,
+    "code_challenge_method": "S256",
+})
+try:
+    webbrowser.open(f"{AUTHORIZE}?{query}")
+except Exception:
+    subprocess.run(["/usr/bin/open", f"{AUTHORIZE}?{query}"], check=False)
+
+listener.settimeout(300)
+try:
+    conn, _addr = listener.accept()
+except (TimeoutError, socket.timeout):
+    listener.close()
+    raise SystemExit("error: Datadog authorization timed out")
+conn.settimeout(5)
+request = b""
+try:
+    while b"\r\n" not in request and len(request) < 8192:
+        chunk = conn.recv(1024)
+        if not chunk:
+            break
+        request += chunk
+except OSError:
+    request = b""
+first = request.split(b"\r\n", 1)[0].decode("latin1", "replace")
+parts = first.split(" ")
+path = parts[1] if len(parts) >= 2 else ""
+params = urllib.parse.parse_qs(urllib.parse.urlparse(path).query)
+code = (params.get("code") or [""])[0]
+got_state = (params.get("state") or [""])[0]
+error = (params.get("error") or [""])[0]
+ok = bool(code) and not error and got_state == state
+body = (
+    b"<!doctype html><title>Firstmate LLM budget</title><p>Datadog connected. You can close this tab.</p>"
+    if ok else
+    b"<!doctype html><title>Firstmate LLM budget</title><p>Datadog connection failed.</p>"
+)
+try:
+    conn.sendall(
+        b"HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: "
+        + str(len(body)).encode()
+        + b"\r\nConnection: close\r\n\r\n"
+        + body
+    )
+except OSError:
+    pass
+conn.close()
+listener.close()
+if error:
+    raise SystemExit(f"error: Datadog authorization failed: {error}")
+if not ok:
+    raise SystemExit("error: Datadog OAuth callback was invalid")
+
+token_body = urllib.parse.urlencode({
+    "grant_type": "authorization_code",
+    "client_id": client_id,
+    "code": code,
+    "redirect_uri": redirect,
+    "code_verifier": verifier,
+}).encode()
+_status, tokens = http_json(
+    TOKEN,
+    headers={"Content-Type": "application/x-www-form-urlencoded"},
+    body=token_body,
+)
+session = {
+    "client": {"client_id": client_id, "client_name": CLIENT_NAME, "redirect_uris": [redirect]},
+    "tokens": {
+        "access_token": tokens["access_token"],
+        "refresh_token": tokens.get("refresh_token"),
+        "expires_in": tokens.get("expires_in"),
+        "issued_at": int(__import__("time").time()),
+    },
+}
+blob = json.dumps(session)
+if sys.platform == "darwin":
+    subprocess.run(
+        ["security", "add-generic-password", "-U", "-s", keychain_service,
+         "-a", keychain_account, "-w", blob],
+        check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+else:
+    Path(oauth_file).parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(oauth_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write(blob + "\n")
+print("datadog-oauth-saved")
+PY
+}
+
+[ "$#" -gt 0 ] || { usage; exit 2; }
+case "$1" in
+  print) shift; cmd_print "$@" ;;
+  refresh) cmd_refresh ;;
+  login) cmd_login ;;
+  claude-statusline) shift; cmd_claude_statusline "$@" ;;
+  install-claude) cmd_install_claude ;;
+  -h|--help) usage ;;
+  *) die "unknown command: $1" ;;
+esac

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -139,8 +139,9 @@ family_for_basename() {
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
     fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
-    fm-kimi-harness.test.sh|fm-muse-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
+    fm-kimi-harness.test.sh|fm-muse-harness.test.sh|    fm-herdr-lab.test.sh|fm-lint.test.sh|\
     fm-lint-workflows.test.sh|\
+    fm-llm-budget.test.sh|\
     fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|\
     fm-subagent-pretool-check.test.sh|\
@@ -967,6 +968,7 @@ families_for_changed_path() {
     bin/fm-decision-hold.sh|bin/fm-supervision*|bin/fm-transition-lib.sh|\
     bin/fm-tmux-lib.sh|bin/fm-marker-lib.sh|bin/fm-operational-input.sh|bin/fm-tasks-axi-lib.sh|\
     bin/fm-vendor-auth-probe.sh|\
+    bin/fm-llm-budget.sh|.pi/extensions/fm-llm-budget.ts|\
     bin/fm-primary-scope-lib.sh|bin/fm-project-mode.sh|bin/fm-promote.sh|\
     bin/fm-ff-lib.sh|bin/fm-gotmp*|bin/*pretool*)
       printf '%s\n' pure-contract-unit

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,13 @@ The `/calm` command replaces the file atomically before changing live presentati
 The extension reloads this preference on every Pi `session_start`, including startup, new, resume, fork, and reload reasons.
 This preference is local to each Firstmate home and is not part of secondmate inherited configuration.
 
+## LLM gateway budget meter (state/llm-budget-cache.json)
+
+The personal Rippling LLM-gateway budget meter stores its cache under gitignored `state/` of the effective Firstmate home.
+[`bin/fm-llm-budget.sh`](../bin/fm-llm-budget.sh) owns the cache fields, Datadog query, refresh TTL, and printed line.
+[`docs/llm-budget.md`](llm-budget.md) records the Pi, Claude Code, and Codex attachment points without restating that contract.
+Optional `config/rippling-email` and `config/llm-budget-cap` are home-local overrides for email and the dollar cap; they are not inherited.
+
 ## Backlog backend (.tasks.toml / config/backlog-backend)
 
 The tracked `.tasks.toml` pins the default `tasks-axi` markdown backend to `data/backlog.md`, with `done_keep = 10` and an archive at `data/done-archive.md`.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -59,6 +59,10 @@
       "target": "docs/calm-mode-feasibility.md"
     },
     {
+      "source": "docs/llm-budget.md",
+      "target": "docs/configuration.md"
+    },
+    {
       "source": "docs/calm-mode-feasibility.md",
       "target": "docs/calm.md"
     },
@@ -270,6 +274,10 @@
     },
     {
       "path": "docs/herdr-backend.md",
+      "audience": "operator-current"
+    },
+    {
+      "path": "docs/llm-budget.md",
       "audience": "operator-current"
     },
     {

--- a/docs/llm-budget.md
+++ b/docs/llm-budget.md
@@ -1,0 +1,38 @@
+# LLM gateway budget meter
+
+The printed line, cache, Datadog query, and refresh path are owned by [`bin/fm-llm-budget.sh`](../bin/fm-llm-budget.sh).
+Read that header and `--help` for flags, cache fields, email resolution, and auth.
+Home-local cache and optional email or cap files are listed in [`docs/configuration.md`](configuration.md#llm-gateway-budget-meter-statellm-budget-cachejson).
+This page only records where that command is attached.
+
+## Pi
+
+The tracked `.pi/extensions/fm-llm-budget.ts` adapter calls `ctx.ui.setStatus` with the dedicated key `firstmate-llm-budget`.
+It does not reuse Calm's `firstmate-calm` key.
+The meter is shown only while the active provider is a Rippling gateway family (`rippling-bedrock`, `rippling-openai`, or another `rippling-*` provider).
+Any other model clears that status key.
+
+## Claude Code
+
+Do not put `statusLine` in tracked `.claude/settings.json`.
+Cursor Agent CLI also loads that project file, and this meter must not appear there.
+Claude's user settings file is the Claude-only install path: `$CLAUDE_CONFIG_DIR/settings.json`, defaulting to `~/.claude/settings.json`.
+`fm-llm-budget.sh install-claude` patches only the `statusLine` key on that file and leaves every other key unchanged.
+The installed command is `fm-llm-budget.sh claude-statusline --kick-refresh`.
+On a non-gateway model or URL it prints nothing.
+
+## Codex
+
+Skipped.
+Codex CLI 0.147.0 (2026-08-18) has a real status-line surface, but it is a closed picker of built-in items (`/statusline`, persisted as `tui.status_line`), not a command hook.
+There is no supported way to render the gateway budget line without inventing a fake footer.
+
+## Cursor
+
+Forbidden for this meter.
+Cursor-served models do not consume the Rippling LLM gateway.
+
+## Cache location
+
+Cache and optional Linux OAuth bytes live under the effective `FM_HOME` gitignored `state/` directory.
+The command header owns the filenames.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -34,6 +34,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-test-run.sh`         | Behavior-test runner: selection, portable lanes, proven-isolated `--jobs`, coverage guard, timing/JSON |
 | `fm-test-isolation-proof.sh` | Concurrent isolation proof and proven-isolated candidate set owner |
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` `@AGENTS.md` pointer, and the canonical self-governance section |
+| `fm-llm-budget.sh`       | Print and refresh the personal Rippling LLM-gateway budget meter from the home-local cache |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and unhealthy supervision    |
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |
 | `fm-session-lock-lib.sh` | Shared session-lock harness identity (ancestry walk and holder liveness) for fm-lock.sh and the Claude Stop auto-arm |

--- a/tests/fm-llm-budget.test.sh
+++ b/tests/fm-llm-budget.test.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+# Behavior tests for fm-llm-budget.sh and the Pi gateway-meter adapter.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-llm-budget)
+SCRIPT="$ROOT/bin/fm-llm-budget.sh"
+EXT="$ROOT/.pi/extensions/fm-llm-budget.ts"
+NOW=$(python3 -c 'import time; print(int(time.time()))')
+
+write_cache() {
+  local home=$1
+  mkdir -p "$home/state"
+  cat > "$home/state/llm-budget-cache.json" <<EOF
+{"version":1,"source":"gateway-402","email":"tester@rippling.com","cap":2000,"spend":2000.07,"remaining":0,"exhausted":true,"fetched_at_unix":$NOW,"month_start_unix":$NOW}
+EOF
+}
+
+run_budget() {
+  local home=$1
+  shift
+  HOME="$home" WAVECODE_CONFIG_PATH="$home/.wavecode" \
+    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_CONFIG_OVERRIDE="$home/config" \
+    "$SCRIPT" "$@"
+}
+
+test_print_from_cache_includes_dollars_under_two_seconds() {
+  local home out elapsed
+  home="$TMP_ROOT/print-cache"
+  write_cache "$home"
+  elapsed=$(python3 - "$SCRIPT" "$home" <<'PY'
+import os, subprocess, sys, time
+script, home = sys.argv[1], sys.argv[2]
+env = os.environ.copy()
+env["FM_HOME"] = home
+env["FM_STATE_OVERRIDE"] = os.path.join(home, "state")
+start = time.perf_counter()
+out = subprocess.check_output([script, "print"], env=env, text=True)
+elapsed = time.perf_counter() - start
+open(os.path.join(home, "out"), "w").write(out)
+print(f"{elapsed:.4f}")
+PY
+)
+  out=$(cat "$home/out")
+  printf '%s\n' "$out" | grep -Fq '$' || fail "print did not include a dollar amount: $out"
+  printf '%s\n' "$out" | grep -Fq 'exhausted' || fail "exhausted cache should mark exhausted: $out"
+  python3 -c 'import sys; elapsed=float(sys.argv[1]); raise SystemExit(0 if elapsed < 2 else 1)' "$elapsed" \
+    || fail "print took ${elapsed}s, expected well under 2s"
+  pass "print reads cache dollars in well under 2s"
+}
+
+test_missing_cache_prints_ellipsis() {
+  local home out
+  home="$TMP_ROOT/missing-cache"
+  mkdir -p "$home/state"
+  out=$(run_budget "$home" print)
+  [ "$out" = "LLM budget: …" ] || fail "missing cache should print ellipsis, got: $out"
+  pass "missing cache prints LLM budget: …"
+}
+
+test_non_gateway_print_is_empty() {
+  local home out
+  home="$TMP_ROOT/non-gateway"
+  write_cache "$home"
+  out=$(run_budget "$home" print --if-gateway --provider anthropic --model claude-opus)
+  [ -z "$out" ] || fail "non-gateway print should be empty, got: $out"
+  pass "non-gateway print is empty"
+}
+
+test_gateway_print_shows_meter() {
+  local home out
+  home="$TMP_ROOT/gateway"
+  write_cache "$home"
+  out=$(run_budget "$home" print --if-gateway --provider rippling-openai --model gpt-5.6-sol)
+  printf '%s\n' "$out" | grep -Fq '$' || fail "gateway print missing remaining dollars: $out"
+  printf '%s\n' "$out" | grep -Fq 'exhausted' || fail "gateway print missing exhausted mark: $out"
+  pass "gateway print shows remaining dollars"
+}
+
+test_claude_statusline_empty_for_non_gateway_stdin() {
+  local home out
+  home="$TMP_ROOT/claude-empty"
+  write_cache "$home"
+  out=$(printf '%s\n' '{"model":{"id":"claude-opus","display_name":"Opus"}}' \
+    | run_budget "$home" claude-statusline)
+  [ -z "$out" ] || fail "claude-statusline should be empty off-gateway, got: $out"
+  pass "claude-statusline is empty for a non-gateway model"
+}
+
+test_claude_statusline_prints_for_rippling_provider() {
+  local home out
+  home="$TMP_ROOT/claude-gateway"
+  write_cache "$home"
+  out=$(printf '%s\n' '{"model":{"provider":"rippling-bedrock","id":"claude-sonnet"}}' \
+    | run_budget "$home" claude-statusline)
+  printf '%s\n' "$out" | grep -Fq '$' || fail "claude-statusline gateway missing dollars: $out"
+  pass "claude-statusline prints dollars for a Rippling provider"
+}
+
+test_claude_statusline_detects_gateway_url() {
+  local home out
+  home="$TMP_ROOT/claude-url"
+  write_cache "$home"
+  out=$(printf '%s\n' '{"model":{"id":"claude-sonnet"}}' \
+    | ANTHROPIC_BASE_URL='https://llm-gateway.us1.ripplingdev.net/api/v2' \
+      run_budget "$home" claude-statusline)
+  printf '%s\n' "$out" | grep -Fq '$' || fail "gateway URL should enable the meter: $out"
+  pass "claude-statusline treats an llm-gateway base URL as gateway"
+}
+
+test_install_claude_patches_only_statusline() {
+  local home
+  home="$TMP_ROOT/install-claude"
+  mkdir -p "$home/claude" "$home/state"
+  cat > "$home/claude/settings.json" <<'JSON'
+{"permissions":{"defaultMode":"auto"},"hooks":{"Stop":[]}}
+JSON
+  CLAUDE_CONFIG_DIR="$home/claude" run_budget "$home" install-claude >/dev/null
+  python3 - "$home/claude/settings.json" "$SCRIPT" <<'PY' || fail "install-claude clobbered keys or skipped statusLine"
+import json, sys
+path, script = sys.argv[1], sys.argv[2]
+data = json.load(open(path, encoding="utf-8"))
+assert data["permissions"]["defaultMode"] == "auto", data
+assert data["hooks"] == {"Stop": []}, data
+command = data["statusLine"]["command"]
+assert command.endswith("fm-llm-budget.sh claude-statusline --kick-refresh"), command
+assert script in command, command
+assert data["statusLine"]["type"] == "command"
+PY
+  pass "install-claude patches only statusLine"
+}
+
+test_refresh_keeps_last_good_cache_on_failure() {
+  local home before after
+  home="$TMP_ROOT/keep-last-good"
+  write_cache "$home"
+  before=$(cat "$home/state/llm-budget-cache.json")
+  PATH="/usr/bin:/bin" \
+    HOME="$home" WAVECODE_CONFIG_PATH="$home/.wavecode" \
+    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_CONFIG_OVERRIDE="$home/config" \
+    RIPPLING_EMAIL="tester@rippling.com" \
+    "$SCRIPT" refresh >/dev/null 2>&1 || true
+  after=$(cat "$home/state/llm-budget-cache.json")
+  [ "$before" = "$after" ] || fail "failed refresh overwrote last-good cache"
+  pass "failed refresh keeps last-good cache"
+}
+
+test_refresh_gateway_402_fallback() {
+  local home out
+  home="$TMP_ROOT/gateway-402"
+  mkdir -p "$home/state" "$home/config" "$home/bin" "$home/pypath"
+  cat > "$home/bin/wavecode" <<'SH'
+#!/usr/bin/env bash
+if [ "$1 $2" = "llm-gateway get-api-key" ]; then
+  printf '%s\n' 'lg-test-key'
+  exit 0
+fi
+exit 1
+SH
+  chmod +x "$home/bin/wavecode"
+  cat > "$home/pypath/sitecustomize.py" <<'PY'
+import urllib.error
+import urllib.request
+
+class _PaymentRequired(urllib.error.HTTPError):
+    def __init__(self, url):
+        super().__init__(url, 402, "Payment Required", {}, None)
+        self._body = b"Budget exhausted: consumed 2000.070300, total 2000.000000"
+
+    def read(self, *args, **kwargs):
+        return self._body
+
+def urlopen(req, timeout=None):
+    url = getattr(req, "full_url", str(req))
+    raise _PaymentRequired(url)
+
+urllib.request.urlopen = urlopen
+PY
+  PATH="$home/bin:$PATH" PYTHONPATH="$home/pypath${PYTHONPATH:+:$PYTHONPATH}" \
+    RIPPLING_EMAIL="tester@rippling.com" \
+    run_budget "$home" refresh >/dev/null 2>&1 || fail "402 fallback refresh should succeed"
+  out=$(run_budget "$home" print)
+  printf '%s\n' "$out" | grep -Fq '$' || fail "402 fallback print missing remaining dollars: $out"
+  printf '%s\n' "$out" | grep -Fq 'exhausted' || fail "402 fallback print missing exhausted mark: $out"
+  python3 - "$home/state/llm-budget-cache.json" <<'PY' || fail "402 fallback cache shape"
+import json, sys
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+assert data["source"] == "gateway-402", data
+assert data["exhausted"] is True, data
+assert data["remaining"] == 0, data
+PY
+  pass "refresh 402 fallback writes exhausted cache"
+}
+
+test_refresh_wavecode_exhausted_without_key_writes_zero() {
+  local home out
+  home="$TMP_ROOT/wavecode-exhausted"
+  mkdir -p "$home/state" "$home/config" "$home/bin"
+  cat > "$home/bin/wavecode" <<'SH'
+#!/usr/bin/env bash
+printf 'wavecode: error: checking API key health: your budget is exhausted, please go to #ai-dev-quotas\n' >&2
+exit 1
+SH
+  chmod +x "$home/bin/wavecode"
+  PATH="$home/bin:$PATH" HOME="$home" \
+    RIPPLING_EMAIL="tester@rippling.com" \
+    run_budget "$home" refresh >/dev/null 2>&1 || fail "exhausted wavecode refresh should succeed"
+  out=$(run_budget "$home" print)
+  printf '%s\n' "$out" | grep -Fq '$' || fail "exhausted wavecode print missing remaining dollars: $out"
+  printf '%s\n' "$out" | grep -Fq 'exhausted' || fail "exhausted wavecode print missing exhausted mark: $out"
+  python3 - "$home/state/llm-budget-cache.json" <<'PY' || fail "exhausted wavecode cache shape"
+import json, sys
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+assert data["source"] == "gateway-402", data
+assert data["exhausted"] is True, data
+assert data["remaining"] == 0, data
+assert float(data["cap"]) == 2000, data
+PY
+  pass "refresh treats wavecode exhausted stderr as remaining zero"
+}
+
+test_pi_extension_sets_dedicated_key_only_on_gateway() {
+  command -v node >/dev/null 2>&1 || { echo "skip: node not found for Pi meter adapter test"; return 0; }
+  local fixture
+  fixture="$TMP_ROOT/pi-ext"
+  mkdir -p \
+    "$fixture/project/.pi/extensions" \
+    "$fixture/project/bin" \
+    "$fixture/project/node_modules/@earendil-works/pi-coding-agent"
+  cp "$EXT" "$fixture/project/.pi/extensions/fm-llm-budget.ts"
+  cat > "$fixture/project/bin/fm-llm-budget.sh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' 'LLM $0 of $2000 (mtd $2000) exhausted'
+SH
+  chmod +x "$fixture/project/bin/fm-llm-budget.sh"
+  cat > "$fixture/project/node_modules/@earendil-works/pi-coding-agent/package.json" <<'JSON'
+{"name":"@earendil-works/pi-coding-agent","type":"module","exports":"./index.js"}
+JSON
+  cat > "$fixture/project/node_modules/@earendil-works/pi-coding-agent/index.js" <<'JS'
+export {}
+JS
+  printf '%s\n' '{"type":"module"}' > "$fixture/project/package.json"
+  node --input-type=module 2>"$fixture/err" <<JS
+import { pathToFileURL } from "node:url";
+const extension = await import(pathToFileURL("$fixture/project/.pi/extensions/fm-llm-budget.ts").href + "?t=" + Date.now());
+if (extension.LLM_BUDGET_STATUS_KEY !== "firstmate-llm-budget") {
+  throw new Error("dedicated key drifted from firstmate-llm-budget");
+}
+if (extension.isRipplingGatewayModel({ provider: "rippling-openai", id: "gpt-5.6-sol" }) !== true) {
+  throw new Error("rippling-openai should be a gateway model");
+}
+if (extension.isRipplingGatewayModel({ provider: "anthropic", id: "claude-opus" }) !== false) {
+  throw new Error("anthropic should not be a gateway model");
+}
+const statuses = new Map();
+const ctx = {
+  model: { provider: "rippling-openai", id: "gpt-5.6-sol" },
+  ui: {
+    setStatus(key, value) { statuses.set(key, value); },
+  },
+};
+const handlers = new Map();
+extension.default({
+  on(event, handler) { handlers.set(event, handler); },
+});
+handlers.get("session_start")({}, ctx);
+if (statuses.get("firstmate-llm-budget") !== "LLM \$0 of \$2000 (mtd \$2000) exhausted") {
+  throw new Error("gateway session did not set the meter: " + JSON.stringify([...statuses]));
+}
+if (statuses.has("firstmate-calm")) {
+  throw new Error("meter must not write Calm's key");
+}
+ctx.model = { provider: "anthropic", id: "claude-opus" };
+handlers.get("session_start")({}, ctx);
+if (statuses.get("firstmate-llm-budget") !== undefined) {
+  throw new Error("non-gateway session should clear the meter");
+}
+JS
+  pass "Pi adapter uses firstmate-llm-budget and hides off-gateway"
+}
+
+test_print_from_cache_includes_dollars_under_two_seconds
+test_missing_cache_prints_ellipsis
+test_non_gateway_print_is_empty
+test_gateway_print_shows_meter
+test_claude_statusline_empty_for_non_gateway_stdin
+test_claude_statusline_prints_for_rippling_provider
+test_claude_statusline_detects_gateway_url
+test_install_claude_patches_only_statusline
+test_refresh_keeps_last_good_cache_on_failure
+test_refresh_gateway_402_fallback
+test_refresh_wavecode_exhausted_without_key_writes_zero
+test_pi_extension_sets_dedicated_key_only_on_gateway

--- a/tests/fm-pi-primary-types.test.sh
+++ b/tests/fm-pi-primary-types.test.sh
@@ -27,6 +27,7 @@ trap cleanup EXIT
 
 mkdir -p "$TMP_ROOT/lib" "$TMP_ROOT/node_modules/@earendil-works" "$TMP_ROOT/node_modules/@types"
 cp "$ROOT/.pi/extensions/fm-calm.ts" "$TMP_ROOT/fm-calm.ts"
+cp "$ROOT/.pi/extensions/fm-llm-budget.ts" "$TMP_ROOT/fm-llm-budget.ts"
 cp "$ROOT/.pi/extensions/fm-primary-pi-watch.ts" "$TMP_ROOT/fm-primary-pi-watch.ts"
 cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$TMP_ROOT/fm-primary-turnend-guard.ts"
 cp "$ROOT/.pi/extensions/lib/fm-calm-assistant-layout.ts" "$TMP_ROOT/lib/fm-calm-assistant-layout.ts"


### PR DESCRIPTION
## Summary
- Add `bin/fm-llm-budget.sh` as the owner of remaining and month-to-date personal LLM-gateway budget, with a 15-minute background refresh and a last-good cache under the Firstmate home.
- Show that meter in Pi via a dedicated `firstmate-llm-budget` status key, and in Claude Code via `install-claude` writing only `statusLine` to Claude user settings (never tracked `.claude/settings.json`).
- Skip Codex: CLI 0.147.0 `tui.status_line` is a closed picker of built-in items (`/statusline`), not a command hook. Cursor is out of scope.

## Test plan
- [x] `bin/fm-test-run.sh tests/fm-llm-budget.test.sh`
- [x] `bin/fm-lint.sh bin/fm-llm-budget.sh tests/fm-llm-budget.test.sh`
- [x] `bin/fm-doc-audience-check.sh`
- [x] Live `refresh` without Datadog credentials writes remaining `$0` from gateway 402 (`consumed 2000.0703, total 2000`)
- [ ] Repo CI green