### PR TITLE
fix(bin): stop reporting live validation runs as failed

### DIFF
--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -24,10 +24,18 @@
 #      active or terminal (from `axi status`, or the coarse `no-mistakes runs`
 #      fallback)? Branch name alone is not enough: a historical run on a reused
 #      branch whose head was rewritten or diverged must not be attributed.
-#      A run matches when its head equals the worktree HEAD, or the worktree HEAD
-#      is an ancestor of the run head (pipeline fix commits advanced the run on
-#      the same line of history). Local work that advanced past the run head, or
-#      diverged from it, invalidates attribution.
+#      Code identity is TERNARY (bin/fm-nm-run-lib.sh's fm_nm_head_identity):
+#      a run matches when its head equals the worktree HEAD or the worktree HEAD
+#      is an ancestor of it; local work that advanced past the run head, or
+#      diverged from it, is a mismatch and invalidates attribution; and a run
+#      head this worktree cannot resolve AT ALL is `unverified` - the routine
+#      shape of a live run, whose pipeline-side fix commits were pushed but
+#      never fetched here. An unverified run is attributed (it is this branch's
+#      current run) but may only carry an IN-FLIGHT reading: any terminal
+#      verdict it would produce becomes `unknown`, because `failed` routes
+#      firstmate into recovery and `done` into teardown. The coarse runs list is
+#      newest-first and the first row for this branch is its current run, so the
+#      walk never falls through to an older, superseded row.
 #      The run-step is AUTHORITATIVE: running/fixing -> working, ci -> working,
 #      awaiting_approval/fix_review -> parked (with gate findings), terminal
 #      passed/checks-passed -> done, failed/cancelled -> failed. EXCEPT: while
@@ -331,11 +339,13 @@ nm_ci_checks_state() {
 # "<status> <branch> <short-sha> <date> [<pr-url>]" separated by runs of
 # spaces (verified: no quoting, so splitting on the first two whitespace runs
 # is exact) - but branch + coarse status is exactly what this predicate needs:
-# is a run for THIS branch active right now. Echoes the first (most recent)
-# matching row's status word (running/completed/cancelled/failed), or empty
-# when the branch has no run within FM_CREW_STATE_RUNS_LIMIT rows.
-nm_runs_status_for_branch() {  # <branch>
-  local branch=$1 out row st rest br sha
+# is a run for THIS branch active right now. Echoes that row's status word
+# (running/completed/cancelled/failed) and how its head bound to this worktree,
+# as "<status>|<identity>"; empty when the branch has no run within
+# FM_CREW_STATE_RUNS_LIMIT rows, or when its current row is provably not this
+# worktree's code.
+nm_runs_status_for_branch() {  # <branch> -> "<status>|<identity>", or empty
+  local branch=$1 out row st rest br sha identity
   out=$(nm_run runs --limit "$FM_CREW_STATE_RUNS_LIMIT")
   [ -n "$out" ] || return 0
   while IFS= read -r row; do
@@ -349,12 +359,18 @@ nm_runs_status_for_branch() {  # <branch>
     rest=$(trim "$rest")
     sha=${rest%% *}
     if [ "$br" = "$branch" ]; then
-      # Same code-identity rule as axi status: skip a same-branch row whose
-      # short-sha does not match this worktree (rewritten or advanced tip).
-      if ! nm_coarse_head_matches_worktree "$sha"; then
-        continue
-      fi
-      printf '%s' "$st"
+      # NEWEST ROW WINS: the list is newest-first, so the first row for this
+      # branch is its current run and the walk stops here either way. A run
+      # superseded by a newer run on the same branch is never current, so
+      # continuing past this row to an older one can only ever answer with a
+      # stale verdict - which is exactly how a live run came to be reported as
+      # failed: its own row was rejected on a head this worktree does not hold,
+      # and the newest STALE row underneath it (failed at the very head the
+      # worktree still had) matched instead.
+      identity=$(nm_coarse_head_identity "$sha")
+      case "$identity" in
+        match|unverified) printf '%s|%s' "$st" "$identity" ;;
+      esac
       return 0
     fi
   done <<< "$out"
@@ -365,20 +381,39 @@ nm_runs_status_for_branch() {  # <branch>
 # scratch worktree); with no branch there is no run to attribute to this crew.
 CREW_BRANCH=$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
 
-# 0 if the active axi-status run's head field matches this worktree's code
-# identity. Branch match is a precondition (caller). Rule owned by
-# fm_nm_head_matches_worktree in bin/fm-nm-run-lib.sh.
-nm_run_head_matches_worktree() {
-  local run_head
-  run_head=$(strip_quotes "$(nm_field head)")
-  fm_nm_head_matches_worktree "$WT" "$run_head"
+# The run's launch anchor (submitted head), read at most once per invocation and
+# only when the cheap local rule could not decide - the probe is a bounded CLI
+# call, so it is never paid on the ordinary path where the run head resolves
+# here. Owner of the command and its no-answer contract: fm_nm_submitted_head.
+NM_SUBMITTED_HEAD=""
+NM_SUBMITTED_HEAD_PROBED=0
+nm_submitted_head() {
+  if [ "$NM_SUBMITTED_HEAD_PROBED" = 0 ]; then
+    NM_SUBMITTED_HEAD_PROBED=1
+    NM_SUBMITTED_HEAD=$(fm_nm_submitted_head "$WT" "$NM_TIMEOUT")
+  fi
+  printf '%s' "$NM_SUBMITTED_HEAD"
 }
 
-# Coarse runs-list rows are "<status> <branch> <short-sha> ...". 0 if the short
-# sha for this branch row matches the worktree head under the same rules as
-# nm_run_head_matches_worktree (equal, or local is ancestor of run tip).
-nm_coarse_head_matches_worktree() {  # <short-sha>
-  fm_nm_head_matches_worktree "$WT" "$1"
+# Ternary code identity (match|mismatch|unverified|unbound) of a run head
+# against this worktree. Branch match is a precondition (caller). Rule owned by
+# fm_nm_head_identity in bin/fm-nm-run-lib.sh; the submitted-head anchor is only
+# consulted for a run head this worktree cannot resolve at all.
+nm_head_identity() {  # <run-head>
+  local identity
+  identity=$(fm_nm_head_identity "$WT" "$1")
+  [ "$identity" = unverified ] || { printf '%s' "$identity"; return; }
+  fm_nm_head_identity "$WT" "$1" "$(nm_submitted_head)"
+}
+
+# Identity of the active axi-status run's head field.
+nm_run_head_identity() {
+  nm_head_identity "$(strip_quotes "$(nm_field head)")"
+}
+
+# Coarse runs-list rows are "<status> <branch> <short-sha> ...".
+nm_coarse_head_identity() {  # <short-sha>
+  nm_head_identity "$1"
 }
 
 HAVE_RUN=0
@@ -388,15 +423,25 @@ HAVE_RUN=0
 # run-step block below skips the TOON field parsing entirely for this crew.
 RUN_SOURCE=full
 COARSE_STATUS=""
+# HEAD_IDENTITY records how the attributed run was bound to this worktree's code:
+# `match` is a verified binding, `unverified` means a real run head that this
+# worktree cannot resolve and no launch anchor confirmed. An unverified run may
+# report an in-flight state but never a terminal verdict (see the gate below the
+# run-step block).
+HEAD_IDENTITY=match
 # Scouts and secondmates never drive a no-mistakes validation of their own
 # worktree, so skip the lookup for them and read state from pane/log directly.
 if [ "$KIND" = ship ] && [ -n "$CREW_BRANCH" ] && command -v no-mistakes >/dev/null 2>&1; then
   RUN_OUT=$(nm_run axi status)
   if [ -n "$RUN_OUT" ]; then
     run_branch=$(strip_quotes "$(nm_field branch)")
-    if [ -n "$run_branch" ] && [ "$run_branch" = "$CREW_BRANCH" ] && nm_run_head_matches_worktree; then
-      HAVE_RUN=1
-    else
+    if [ -n "$run_branch" ] && [ "$run_branch" = "$CREW_BRANCH" ]; then
+      case "$(nm_run_head_identity)" in
+        match)      HAVE_RUN=1 ;;
+        unverified) HAVE_RUN=1; HEAD_IDENTITY=unverified ;;
+      esac
+    fi
+    if [ "$HAVE_RUN" = 0 ]; then
       # The active-or-most-recent run is for another branch, or same branch with
       # a rewritten/diverged head (the CLI is alive and answered; only the
       # attribution missed) - try the coarse fallback.
@@ -404,8 +449,10 @@ if [ "$KIND" = ship ] && [ -n "$CREW_BRANCH" ] && command -v no-mistakes >/dev/n
       # primary call means the CLI itself did not respond, so retrying it
       # immediately with a second bounded call would just double the wait
       # for no better answer.
-      COARSE_STATUS=$(nm_runs_status_for_branch "$CREW_BRANCH")
-      if [ -n "$COARSE_STATUS" ]; then
+      coarse_row=$(nm_runs_status_for_branch "$CREW_BRANCH")
+      if [ -n "$coarse_row" ]; then
+        COARSE_STATUS=${coarse_row%%|*}
+        HEAD_IDENTITY=${coarse_row#*|}
         HAVE_RUN=1
         RUN_SOURCE=coarse
       fi
@@ -494,6 +541,23 @@ if [ "$HAVE_RUN" = 1 ]; then
         esac
       fi
     fi
+  fi
+
+  # A run whose code identity could not be established may carry an in-flight
+  # reading, but never a terminal verdict. `failed` routes firstmate straight
+  # into recovery (AGENTS.md section 8) and `done` into teardown, so a confident
+  # wrong answer in either direction costs far more than saying it is unknown -
+  # and unlike `failed`, `unknown` is not itself an instruction to act.
+  if [ "$HEAD_IDENTITY" = unverified ]; then
+    case "$RUN_STATE" in
+      "done"|failed)
+        RUN_DETAIL="$RUN_DETAIL${SEP}run head unverifiable against this copy"
+        RUN_STATE=unknown
+        ;;
+      *)
+        RUN_DETAIL="$RUN_DETAIL (unverified run head)"
+        ;;
+    esac
   fi
 
   if [ "$RUN_STATE" = working ] && log_reports_ci_ready; then

--- a/bin/fm-nm-run-lib.sh
+++ b/bin/fm-nm-run-lib.sh
@@ -6,7 +6,11 @@
 # (read-only current-state reporting) and fm-teardown.sh (pre-teardown run
 # abort, see its "Fix 1" header comment). Getting this wrong in either
 # direction is unsafe: a false negative hides a genuinely parked run, and a
-# false positive lets teardown act on a run it does not own.
+# false positive lets teardown act on a run it does not own. The rule is ternary
+# (fm_nm_head_identity) because "cannot tell" is a third answer that must not be
+# collapsed into either: a caller that acts on a run needs the strict predicate,
+# while a caller that only REPORTS state needs to say unknown instead of a
+# confident wrong verdict.
 #
 # Bounded call to `no-mistakes "$@"` in dir $1, timeout $2 seconds. The bounded
 # form preserves stdout, stderr, and exit status; the checked form discards
@@ -55,19 +59,73 @@ fm_nm_field() {  # <toon-output> <key>
   printf '%s\n' "$1" | sed -n "s/^[[:space:]]*$2:[[:space:]]*\(.*\)/\1/p" | head -1
 }
 
-# 0 if run head $2 matches worktree $1's code identity, per the same rule
-# everywhere this attribution is needed:
-#   - missing/empty head: cannot bind; reject
+# Ternary code-identity verdict for run head $2 against worktree $1, printing
+# exactly one token:
+#   unbound    - no run head was reported, or the worktree has no readable HEAD;
+#                there is nothing to bind, so there is no run to attribute
+#   match      - the run's code identity is this worktree's current code
+#   mismatch   - the run ran on code this worktree no longer holds
+#   unverified - a real run head was reported, but identity can be neither
+#                confirmed nor refuted from here
+#
+# The local rule answers first because it is free:
 #   - equal commits (short or full SHA): match
-#   - worktree HEAD is an ancestor of run head: match (pipeline fix commits on
-#     the same history advanced the run tip past local HEAD)
-#   - run head is a strict ancestor of worktree HEAD, or diverged: no match
+#   - worktree HEAD is an ancestor of the run head: match (pipeline fix commits
+#     on the same history advanced the run tip past local HEAD)
+#   - run head is a strict ancestor of worktree HEAD, or diverged: mismatch
 #     (local work advanced outside the run, or the branch tip was rewritten)
+#
+# A run head that does not resolve in this worktree's object database at all is
+# the ROUTINE shape of a healthy in-flight run, not evidence against it: the
+# pipeline commits its own fixes and pushes them to the configured target, so
+# its tip is a real commit that was never fetched here. Treating that as a
+# mismatch is a false negative that gets MORE likely the longer and harder a run
+# works, which is why it is reported as `unverified` rather than folded into
+# `mismatch` - callers must be able to tell "provably not mine" from "cannot
+# tell". Optional $3 is the run's launch anchor (its submitted head, from
+# fm_nm_submitted_head): the head the run was STARTED against, which is the head
+# the worktree still holds while the pipeline advances its own. When it is
+# supplied and resolves, it decides identity outright.
+fm_nm_head_identity() {  # <worktree> <run_head> [<submitted_head>]
+  local wt=$1 run_head=$2 anchor=${3:-} local_full run_full anchor_full
+  [ -n "$run_head" ] || { printf 'unbound'; return 0; }
+  local_full=$(git -C "$wt" rev-parse HEAD 2>/dev/null) || { printf 'unbound'; return 0; }
+  if run_full=$(git -C "$wt" rev-parse --verify "${run_head}^{commit}" 2>/dev/null); then
+    if [ "$run_full" = "$local_full" ] \
+      || git -C "$wt" merge-base --is-ancestor "$local_full" "$run_full" 2>/dev/null; then
+      printf 'match'
+    else
+      printf 'mismatch'
+    fi
+    return 0
+  fi
+  [ -n "$anchor" ] || { printf 'unverified'; return 0; }
+  anchor_full=$(git -C "$wt" rev-parse --verify "${anchor}^{commit}" 2>/dev/null) \
+    || { printf 'unverified'; return 0; }
+  if [ "$anchor_full" = "$local_full" ]; then printf 'match'; else printf 'mismatch'; fi
+}
+
+# The run's submitted head for worktree $1's current branch, read through the one
+# read-only CLI surface that reports it. `no-mistakes axi sync --check` freshly
+# verifies and returns the plan without changing HEAD, and its pipeline block
+# carries submitted_head alongside current_head; `axi status` reports only the
+# CURRENT head, and `no-mistakes runs` only the current head's short SHA, so
+# neither can anchor identity on its own (verified against the installed
+# v1.48.0). Echoes empty for every no-answer case - no CLI, no pipeline binding
+# for this branch, or a bounded-out call - because none of them is a refutation.
+fm_nm_submitted_head() {  # <worktree> <timeout_secs>
+  local out
+  command -v no-mistakes >/dev/null 2>&1 || return 0
+  out=$(fm_nm_run "$1" "$2" axi sync --check) || return 0
+  [ -n "$out" ] || return 0
+  fm_nm_strip_quotes "$(fm_nm_field "$out" submitted_head)"
+}
+
+# 0 if run head $2 is provably worktree $1's own code identity. The strict
+# predicate: only a verified `match` passes, so a caller that acts on a run
+# (fm-teardown.sh's pre-teardown abort) never acts on one it cannot bind.
+# Callers that must distinguish "cannot tell" from "not mine" read
+# fm_nm_head_identity directly instead.
 fm_nm_head_matches_worktree() {  # <worktree> <run_head>
-  local wt=$1 run_head=$2 local_full run_full
-  [ -n "$run_head" ] || return 1
-  local_full=$(git -C "$wt" rev-parse HEAD 2>/dev/null) || return 1
-  run_full=$(git -C "$wt" rev-parse --verify "${run_head}^{commit}" 2>/dev/null) || return 1
-  [ "$run_full" = "$local_full" ] && return 0
-  git -C "$wt" merge-base --is-ancestor "$local_full" "$run_full" 2>/dev/null
+  [ "$(fm_nm_head_identity "$1" "$2")" = match ]
 }

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -104,7 +104,8 @@
 #     crew's worktree, so they are not orphaned by removing the worktree.
 #     conclude_task_no_mistakes_run attributes the active-or-most-recent run to
 #     THIS task only when its branch AND code identity (bin/fm-nm-run-lib.sh's
-#     fm_nm_head_matches_worktree, the same rule bin/fm-crew-state.sh uses) both
+#     fm_nm_head_matches_worktree, the strict matching predicate from
+#     fm_nm_head_identity) both
 #     match this worktree, then runs `no-mistakes axi abort --run <id>` for
 #     that verified run instance. A run already terminal
 #     (an outcome is set) or not parked at a gate is left untouched. Idempotent:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,6 +42,7 @@ This home's answerer close, pending-reply escalation close, and captain-held tra
 A turn-ended-only queue row omits its historical status annotation when that status file exactly matches the same seen marker.
 Any direct or remaining historical annotation prints every status line unread at the presentation cursor instead of replaying only the latest line.
 `bin/fm-crew-state.sh <id>` is the cheap current-state read for an actionable heartbeat review: it attributes a no-mistakes run, active or terminal, only when it matches the crew's branch and current code identity, then keeps that run-step authoritative even if the pane has closed.
+Code identity is ternary, so a run head this copy cannot resolve at all - the ordinary shape of a live run whose pipeline-side commits were never fetched here - is reported as unverified rather than treated as another crew's: such a run may report that work is still under way, but never a terminal passed or failed verdict.
 The script header owns the exact run-head ancestry rules.
 During no-mistakes' `ci` monitor phase, it also reads the ci step log tail because `axi status` reports both "still waiting on checks" and "checks green, waiting on merge" as `ci,running`.
 The most recent recognized ci log marker wins, so checks-green monitoring reports done while a later re-arm, failed-check, or issue marker returns the crew to working.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -341,6 +341,10 @@
       "audience": "maintainer-verification"
     },
     {
+      "path": "docs/verification/nm-run-attribution.md",
+      "audience": "maintainer-verification"
+    },
+    {
       "path": "docs/verification/process-event-sources.md",
       "audience": "maintainer-verification"
     },

--- a/docs/verification/nm-run-attribution.md
+++ b/docs/verification/nm-run-attribution.md
@@ -1,0 +1,71 @@
+# no-mistakes run attribution verification
+
+Repeatable evidence for the code-identity rule that decides whether a no-mistakes run belongs to a crew's worktree.
+The rule itself is owned by [`../../bin/fm-nm-run-lib.sh`](../../bin/fm-nm-run-lib.sh) (`fm_nm_head_identity`) and its consumer contract by [`../../bin/fm-crew-state.sh`](../../bin/fm-crew-state.sh); this page records evidence only.
+
+Date: 2026-08-18.
+Installed CLI: `no-mistakes version v1.48.0 (2ac3769) 2026-08-08T06:39:01Z`.
+
+## The pipeline head is not the worktree head during a run
+
+A live run's recorded head is the head the PIPELINE has advanced to as it applies its own fix commits, and those commits are pushed to the configured target rather than fetched into the crew's worktree.
+The head a run was launched against is a separate value.
+Both were read from one in-flight run while its crew's worktree still sat at the launch head:
+
+```console
+$ no-mistakes runs --limit 4
+  running      fm/fm-turnend-guard-afk-false-blind 416c0d30  2026-08-18 09:10  https://github.com/kunchenguid/firstmate/pull/2557
+  running      fm/fm-wedge-aging-ignores-busy e4370ecc  2026-08-18 08:24  https://github.com/kunchenguid/firstmate/pull/2554
+  running      fm/fm-brief-no-mistakes-cli 2e878030  2026-08-18 02:22  https://github.com/kunchenguid/firstmate/pull/2566
+  failed       fm/fm-brief-no-mistakes-cli a5bc06b6  2026-08-18 02:13
+
+$ git -C <crew worktree> rev-parse HEAD
+a5bc06b6ee6829997c6bcc498b1e3d40a99bf1b7
+
+$ git -C <crew worktree> rev-parse --verify 2e878030^{commit}
+fatal: Needed a single revision
+```
+
+The pipeline head is not merely different from the worktree head; it does not resolve in that repository at all, so no ancestry comparison can be made against it.
+This is the ordinary shape of a healthy run, and it grows more likely the more fix rounds a run performs, which is why `fm_nm_head_identity` reports it as `unverified` rather than folding it into `mismatch`.
+
+## Which surfaces report which head
+
+`no-mistakes runs` prints the current head's short SHA only, and `axi status` prints a single `head` field that is likewise the CURRENT head - shown here on a run whose launch head and current head differ:
+
+```console
+$ no-mistakes axi status --run 01M09420FAAJ8WRT6BTY29A38R
+run:
+  id: "01M09420FAAJ8WRT6BTY29A38R"
+  branch: fm/fm-wedge-aging-ignores-busy
+  status: running
+  head: e4370ecc
+  ...
+```
+
+`no-mistakes axi status --help` lists no output-format flag, and no `--json` surface exists on it.
+The only read-only surface that reports the launch head is `axi sync --check`, documented as "freshly verify and return the plan without changing HEAD":
+
+```console
+$ no-mistakes axi sync --check
+branch_sync:
+  ...
+  pipeline:
+    run: ""
+    status: ""
+    phase: ""
+    submitted_head: ""
+    current_head: ""
+```
+
+`submitted_head` is therefore the identity anchor the attribution rule falls back to, and every empty or blocked answer from that command is treated as "no answer" rather than as a refutation.
+
+## Regression coverage
+
+`tests/fm-crew-state.test.sh` pins both directions over throwaway git repos and a fake CLI serving the exact shapes above.
+Seven assertions cover the case: a live run at an unresolvable head reported through `axi status` and through the coarse runs list; a terminal verdict preserved when `submitted_head` binds the run; a terminal verdict withheld as `unknown` on both paths when nothing binds it; a genuine failure at the current head still reported `failed`; and a provably diverged newest row blocking attribution instead of falling through to an older row.
+
+```console
+$ bash tests/fm-crew-state.test.sh | tail -1
+all fm-crew-state tests passed
+```

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -14,6 +14,8 @@
 #   (c) genuine parked run + needs-decision log = NOT superseded  -> run-step
 #   (d) terminal run-step (passed/failed) is authoritative        -> run-step
 #   (e) cross-branch attribution: this branch's own run found via list lookup
+#   (e2) an in-flight run whose pipeline head is absent from this object
+#        database is never answered with a stale same-branch failed run
 #   (f) no run + semantic busy                                    -> pane
 #   (g) no run + semantic idle falls to the status-log verb       -> status-log
 #   (h) dead pane: no run -> unknown/none; with a run -> run-step (not the shell)
@@ -55,7 +57,10 @@ make_repo_on_branch() {  # <dir> <branch>
 # `axi` surface - no runs-listing subcommand exists under it, verified against
 # the real CLI), and the actual top-level run-listing command, `no-mistakes
 # runs --limit N`, which is plain text - no run id, no quoting - serving
-# FM_FAKE_RUNS_LIST verbatim.
+# FM_FAKE_RUNS_LIST verbatim. `axi sync --check` serves FM_FAKE_AXI_SYNC: the
+# one read-only surface that reports the run's submitted_head (its launch
+# anchor), used to bind a run whose pipeline-advanced head is absent from the
+# worktree's object database.
 make_fakebin() {  # <dir> -> echoes fakebin path
   local dir=$1 fb="$1/fakebin"
   mkdir -p "$fb"
@@ -72,6 +77,8 @@ case "${1:-}" in
         else printf '%s\n' "${FM_FAKE_AXI_STATUS:-}"; fi ;;
       logs)
         printf '%s\n' "${FM_FAKE_CI_LOGS:-}" ;;
+      sync)
+        printf '%s\n' "${FM_FAKE_AXI_SYNC:-}" ;;
     esac
     ;;
   runs)
@@ -162,6 +169,7 @@ arm_idle_record() {  # <state-dir> <id>
 reset_fakes() {
   FM_FAKE_AXI_STATUS=""
   FM_FAKE_AXI_STATUS_RUN=""
+  FM_FAKE_AXI_SYNC=""
   FM_FAKE_RUNS_LIST=""
   FM_FAKE_BUSY=0
   FM_FAKE_BUSY_TEXT=
@@ -170,7 +178,7 @@ reset_fakes() {
   FM_FAKE_HERDR_MISSING=0
   FM_FAKE_HERDR_AGENT_STATUS=""
   FM_FAKE_CI_LOGS=""
-  export FM_FAKE_AXI_STATUS FM_FAKE_AXI_STATUS_RUN FM_FAKE_RUNS_LIST FM_FAKE_BUSY FM_FAKE_BUSY_TEXT FM_FAKE_TMUX_MISSING
+  export FM_FAKE_AXI_STATUS FM_FAKE_AXI_STATUS_RUN FM_FAKE_AXI_SYNC FM_FAKE_RUNS_LIST FM_FAKE_BUSY FM_FAKE_BUSY_TEXT FM_FAKE_TMUX_MISSING
   export FM_FAKE_HERDR_BUSY FM_FAKE_HERDR_MISSING FM_FAKE_HERDR_AGENT_STATUS FM_FAKE_CI_LOGS
 }
 
@@ -1290,6 +1298,216 @@ test_local_advanced_past_run_head_invalidates() {
   pass "local work advanced past run head invalidates attribution"
 }
 
+# --- pipeline-advanced run heads -------------------------------------------
+# The pipeline commits its own fixes and pushes them to the configured target,
+# so an in-flight run's head is a REAL commit that this worktree never fetched:
+# `git rev-parse` cannot resolve it at all. That is not evidence against the run,
+# and the shape below is the exact live condition (2026-08-18) in which it was
+# read as the opposite of the truth - a healthy running validation reported as
+# `failed`, which routes firstmate into recovery and can restart a run that is
+# working. The branch's own newest row was rejected on the unresolvable head, and
+# the newest STALE row underneath it - failed, recorded at the very head the
+# worktree still holds, because those runs died before advancing it - answered
+# instead. An unresolvable run head is UNKNOWN identity, never a mismatch.
+
+# `no-mistakes axi sync --check` shape (the one read-only surface reporting the
+# run's launch anchor), trimmed to the fields the helper reads.
+sync_pipeline() {  # <submitted-head> <current-head>
+  cat <<EOF
+branch_sync:
+  state: pipeline_owned
+  changed: false
+  local:
+    branch: ${FM_FAKE_SYNC_BRANCH:-fm/feat-sync}
+    head: $1
+    clean: true
+  pipeline:
+    run: "01RUN"
+    status: running
+    phase: ci
+    submitted_head: $1
+    current_head: $2
+    pushed_head: $2
+  relation: pipeline_ahead
+  safety: ok
+EOF
+}
+
+# A 40-hex commit-shaped SHA that is absent from any throwaway fixture repo, so
+# `git rev-parse --verify` fails on it exactly as it does for a real
+# pipeline-side head that was pushed but never fetched here.
+UNFETCHED_HEAD=dead1eafdead1eafdead1eafdead1eafdead1eaf
+
+# (e2) The live reproduction, primary path: this branch's own running run,
+# reported at a head this worktree cannot resolve, with older failed runs of the
+# same branch still sitting at the worktree head.
+test_advanced_pipeline_head_is_not_reported_failed() {
+  reset_fakes
+  local d short out
+  d=$(new_case advanced-head-running)
+  make_repo_on_branch "$d/wt" fm/feat-advhead
+  short=$(git -C "$d/wt" rev-parse --short=8 HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/advhead.meta" "window=fm:fm-advhead" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_RUN_HEAD="$UNFETCHED_HEAD"
+  FM_FAKE_AXI_STATUS="$(run_running fm/feat-advhead)"
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  running    fm/feat-advhead ${UNFETCHED_HEAD:0:8}  2026-08-18 02:22  https://github.com/o/r/pull/9
+  failed     fm/feat-advhead ${short}  2026-08-18 02:13
+  failed     fm/feat-advhead ${short}  2026-08-18 02:05
+  failed     fm/feat-advhead ${short}  2026-08-18 01:45
+EOF
+)"
+  out=$(run_crew_state "$d" advhead)
+  assert_not_contains "$out" "state: failed" "a live run must never be answered by a stale failed run"
+  assert_contains "$out" "state: working" "the branch's own in-flight run is current"
+  assert_contains "$out" "source: run-step" "the in-flight run remains the authoritative source"
+  assert_contains "$out" "unverified run head" "an unbindable head is disclosed, not hidden"
+  pass "pipeline-advanced run head is not reported as a stale failure"
+}
+
+# (e2) Same shape reached through the coarse runs list, when the repo-wide
+# `axi status` answer belongs to another crew's branch.
+test_coarse_advanced_pipeline_head_is_not_reported_failed() {
+  reset_fakes
+  local d short out
+  d=$(new_case advanced-head-coarse)
+  make_repo_on_branch "$d/wt" fm/feat-advcoarse
+  short=$(git -C "$d/wt" rev-parse --short=8 HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/advcoarse.meta" "window=fm:fm-advcoarse" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  running    fm/other-crew aaaaaaa  2026-08-18 02:30
+  running    fm/feat-advcoarse ${UNFETCHED_HEAD:0:8}  2026-08-18 02:22
+  failed     fm/feat-advcoarse ${short}  2026-08-18 02:13
+EOF
+)"
+  out=$(run_crew_state "$d" advcoarse)
+  assert_not_contains "$out" "state: failed" "the coarse walk must not fall through to a superseded failed row"
+  assert_contains "$out" "state: working" "the branch's newest row is its current run"
+  assert_contains "$out" "source: run-step" "coarse-resolved run remains run-step sourced"
+  pass "coarse walk stops at the branch's newest row instead of a stale failure"
+}
+
+# The run's submitted head - the head it was LAUNCHED against, which is what the
+# worktree still holds while the pipeline advances its own - establishes identity
+# outright, so a genuine failure reported at an advanced head is still `failed`.
+test_advanced_head_bound_by_submitted_head_reports_failed() {
+  reset_fakes
+  local d head out
+  d=$(new_case advanced-head-submitted)
+  make_repo_on_branch "$d/wt" fm/feat-submitted
+  head=$(git -C "$d/wt" rev-parse HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/submitted.meta" "window=fm:fm-submitted" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_RUN_HEAD="$UNFETCHED_HEAD"
+  FM_FAKE_AXI_STATUS="$(run_failed fm/feat-submitted)"
+  FM_FAKE_SYNC_BRANCH=fm/feat-submitted
+  FM_FAKE_AXI_SYNC="$(sync_pipeline "$head" "$UNFETCHED_HEAD")"
+  export FM_FAKE_SYNC_BRANCH
+  out=$(run_crew_state "$d" submitted)
+  assert_contains "$out" "state: failed" "an identity-bound terminal failure is still reported failed"
+  assert_contains "$out" "source: run-step" "identity-bound run remains run-step sourced"
+  assert_not_contains "$out" "unverified" "a bound run head is not reported as unverified"
+  pass "submitted head binds an advanced-head run and preserves its terminal verdict"
+}
+
+# With no way to bind the run to this code, a terminal verdict is withheld:
+# `unknown` is a distinct and safer answer than a confident wrong `failed`.
+test_unbindable_terminal_run_reports_unknown_not_failed() {
+  reset_fakes
+  local d out
+  d=$(new_case unbindable-terminal)
+  make_repo_on_branch "$d/wt" fm/feat-unbindable
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/unbindable.meta" "window=fm:fm-unbindable" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_RUN_HEAD="$UNFETCHED_HEAD"
+  FM_FAKE_AXI_STATUS="$(run_failed fm/feat-unbindable)"
+  FM_FAKE_AXI_SYNC=""
+  out=$(run_crew_state "$d" unbindable)
+  assert_not_contains "$out" "state: failed" "an unbindable run must not produce a confident failure"
+  assert_contains "$out" "state: unknown" "an unbindable terminal run is unknown"
+  assert_contains "$out" "run head unverifiable" "the reason the verdict was withheld is stated"
+  pass "terminal verdict is withheld when run identity cannot be established"
+}
+
+# The same withholding on the coarse path, and proof the walk does not rescue the
+# verdict from an older row underneath.
+test_coarse_unbindable_terminal_row_reports_unknown() {
+  reset_fakes
+  local d short out
+  d=$(new_case unbindable-coarse)
+  make_repo_on_branch "$d/wt" fm/feat-unbcoarse
+  short=$(git -C "$d/wt" rev-parse --short=8 HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/unbcoarse.meta" "window=fm:fm-unbcoarse" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  failed     fm/feat-unbcoarse ${UNFETCHED_HEAD:0:8}  2026-08-18 02:22
+  running    fm/feat-unbcoarse ${short}  2026-08-18 01:40
+EOF
+)"
+  out=$(run_crew_state "$d" unbcoarse)
+  assert_not_contains "$out" "state: failed" "an unbindable coarse failure is not a confident failure"
+  assert_not_contains "$out" "state: working" "nor is it rescued by an older superseded row"
+  assert_contains "$out" "state: unknown" "an unbindable coarse terminal row is unknown"
+  pass "coarse terminal verdict is withheld when identity cannot be established"
+}
+
+# A genuine failure recorded at the worktree's current head is still `failed`
+# through the coarse path - the direction the newest-row-wins change must keep.
+test_coarse_failed_run_at_current_head_still_reports_failed() {
+  reset_fakes
+  local d short out
+  d=$(new_case coarse-genuine-failed)
+  make_repo_on_branch "$d/wt" fm/feat-genfail
+  short=$(git -C "$d/wt" rev-parse --short=8 HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/genfail.meta" "window=fm:fm-genfail" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  failed     fm/feat-genfail ${short}  2026-08-18 02:13
+EOF
+)"
+  out=$(run_crew_state "$d" genfail)
+  assert_contains "$out" "state: failed" "a genuine failure at the current head is still failed"
+  assert_contains "$out" "source: run-step" "genuine coarse failure remains run-step sourced"
+  pass "genuine failed run at the current head is still reported failed"
+}
+
+# A newest row whose head is RESOLVABLE and diverged is still a provable
+# mismatch, and the walk must not reach past it to an older row that happens to
+# sit at the worktree head.
+test_coarse_diverged_newest_row_blocks_older_row() {
+  reset_fakes
+  local d short diverged out
+  d=$(new_case coarse-diverged-newest)
+  make_repo_on_branch "$d/wt" fm/feat-divnewest
+  short=$(git -C "$d/wt" rev-parse --short=8 HEAD)
+  git -C "$d/wt" checkout -q --orphan tmp-diverged
+  git -C "$d/wt" commit -q --allow-empty -m 'diverged line of history'
+  diverged=$(git -C "$d/wt" rev-parse --short=8 HEAD)
+  git -C "$d/wt" checkout -q fm/feat-divnewest
+  [ "$short" != "$diverged" ] || fail "diverged fixture did not produce a second head"
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/divnewest.meta" "window=fm:fm-divnewest" "worktree=$d/wt" "kind=ship" "harness=claude"
+  printf 'working: implementation in progress\n' > "$d/state/divnewest.status"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  running    fm/feat-divnewest ${diverged}  2026-08-18 02:22
+  failed     fm/feat-divnewest ${short}  2026-08-18 01:40
+EOF
+)"
+  FM_FAKE_BUSY=0
+  arm_idle_record "$d/state" divnewest
+  out=$(run_crew_state "$d" divnewest)
+  assert_not_contains "$out" "source: run-step" "a provably diverged newest row is not attributed"
+  assert_not_contains "$out" "state: failed" "nor is an older superseded row used instead"
+  assert_contains "$out" "source: status-log" "falls back to current-state sources"
+  pass "provably diverged newest row blocks attribution instead of falling through"
+}
+
 test_missing_run_head_falls_back_to_current_state() {
   reset_fakes
   local d out
@@ -1358,5 +1576,12 @@ test_historical_same_branch_rewritten_head_not_current
 test_active_run_descendant_fix_head_remains_current
 test_local_advanced_past_run_head_invalidates
 test_missing_run_head_falls_back_to_current_state
+test_advanced_pipeline_head_is_not_reported_failed
+test_coarse_advanced_pipeline_head_is_not_reported_failed
+test_advanced_head_bound_by_submitted_head_reports_failed
+test_unbindable_terminal_run_reports_unknown_not_failed
+test_coarse_unbindable_terminal_row_reports_unknown
+test_coarse_failed_run_at_current_head_still_reports_failed
+test_coarse_diverged_newest_row_blocks_older_row
 
 echo "all fm-crew-state tests passed"


### PR DESCRIPTION
## Intent

Fix bin/fm-crew-state.sh reporting a healthy no-mistakes validation run as `failed`. Firstmate acts on that reading, so a false `failed` can tear down or restart a run that is working, and restarting duplicates pipeline ownership - the exact hazard the supersession sequence exists to prevent. The misreading is self-concealing: the more fix rounds a run performs, the further the pipeline head advances from the worktree head, so it gets MORE likely the longer and harder a run works, and it only bites when prior failed runs sit at the worktree head - exactly the situation on a task that has already been through trouble, where a false `failed` is most likely to be believed.

The bug had to be reproduced end to end as firstmate experiences it before being fixed, not fixed from reasoning alone. Root cause: nm_runs_status_for_branch() walked `no-mistakes runs` newest-first and applied a coarse short-sha head check that assumed the pipeline head equals the worktree head. It does not during a run - the pipeline advances its own head as it applies fix commits while the worktree stays at the submitted head, and those commits are pushed to the configured target rather than fetched into the crew's copy, so the run head does not resolve in that repository at all. The branch's own live row was rejected on that unresolvable head and the newest stale row underneath it - failed, recorded at the very head the worktree still held - matched instead.

Requirements, in priority order:

1. Do not simply delete the sha check. Its intent is correct: a rewritten or advanced tip must not be attributed to this crew. Removing it would trade this false negative for a false positive, which is worse - firstmate would believe a stale run belongs to the current code.

2. Prefer run identity over coarse head comparison. Treat the run's submitted head, not its current head, as the code-identity anchor: it is the head the run was launched against and it is what the worktree still holds. Establish the current contract from the installed no-mistakes binary's own help and output rather than assuming it.

3. A run whose identity cannot be established must not be reported as `failed`. Unknown is a distinct and safer answer than a confident wrong one, because AGENTS.md section 8 routes a `failed` reading into recovery while an `unknown` reading does not.

4. Preserve every existing behaviour for the cases that work today, including correct attribution when the branch genuinely has no run, and correct rejection of another crew's branch.

Acceptance:

- The reproduction stops misreporting, demonstrated by running the command against a fixture rather than by inference.
- A genuinely failed run at the current head is still reported `failed`, demonstrated the same way. Both directions must be shown.
- A run that cannot be attributed reports something other than `failed`.
- Tests extend the existing tests/fm-crew-state.test.sh surface rather than inventing a parallel one.
- shellcheck clean on every file touched.

Constraints: this changes firstmate's shared tracked material, which every home in the fleet loads, so firstmate's coding guidelines apply - one owner per contract, knowledge routed to its most specific owner, one sentence per line in tracked Markdown, plain dash rather than em dash, no agent name as commit co-author, and bin/*.sh passing the repo's pinned lint.

Out of scope and deliberately not addressed here: run-record retirement for runs that still show as `running`. That was investigated and the original concern turned out to be unfounded - the two runs in question are legitimately in their CI-monitoring phase on open PRs, which is documented no-mistakes behaviour, so there is nothing to fix.

## What Changed

- Introduced a ternary code-identity model (`match`, `mismatch`, `unverified`, `unbound`) in `bin/fm-nm-run-lib.sh` (`fm_nm_head_identity`), using launch anchors from `no-mistakes axi sync --check` when a pipeline head cannot be resolved locally.
- Updated `bin/fm-crew-state.sh` to evaluate run identity on a branch's newest row and withhold terminal verdicts as `unknown` when a run head is unverified.
- Added regression test cases in `tests/fm-crew-state.test.sh` covering pipeline-advanced runs and documented attribution rules in `docs/verification/nm-run-attribution.md`.

## Risk Assessment

✅ Low: The change cleanly resolves false-failed attribution by introducing ternary head identity and submitted-head anchors with comprehensive unit test coverage.

## Testing

Ran targeted automated test suite `./tests/fm-crew-state.test.sh` (all 57 tests passed) and executed `bin/fm-crew-state.sh` against end-to-end fixture scenarios demonstrating that pipeline-advanced in-flight runs report working instead of false failed, genuine failures at worktree HEAD report failed, and unbindable terminal runs report unknown.

<details>
<summary>Evidence: Firstmate crew state attribution verification transcript</summary>

Source: [Firstmate crew state attribution verification transcript](https://github.com/BohnBawerick/firstmate/blob/6093b82656de18ad13673207b23fd4013f5b83df/.no-mistakes/evidence/fm/fm-crewstate-false-failed/fm-crew-state-verification.txt)

```text
===============================================================================
FIRSTMATE CREW STATE ATTRIBUTION VERIFICATION TRANSCRIPT
===============================================================================

Date: 2026-08-18
Target CLI: bin/fm-crew-state.sh
Test Suite: tests/fm-crew-state.test.sh

-------------------------------------------------------------------------------
1. Automated Test Suite Execution
-------------------------------------------------------------------------------
Command: ./tests/fm-crew-state.test.sh

Output:
ok - active run-step is authoritative
ok - stale needs-decision over active run is superseded
ok - stale blocked over active run is superseded
ok - genuine parked run is not flagged superseded
ok - scalar gate parked run is not flagged superseded
ok - gate block parked run is not flagged superseded
ok - ci-ready status log beats monitoring run
ok - ci-monitoring run with checks already green surfaces done
ok - top-level ci status uses ci log green marker
ok - terminal no-checks ci-monitor marker surfaces done
ok - base-advance rearm after green stays working
ok - pending no-checks ci-monitor marker stays working
ok - ci-monitoring run with checks not yet green stays working
ok - a fresh issue after an earlier green reading is not masked
ok - stale checks-green status log does not mask CI relapse
ok - ci fixing is not overridden by an earlier green marker
ok - top-level fixing is not overridden by a stale ci running row
ok - top-level fixing is not overridden by a stale done log
ok - terminal passed run is authoritative
ok - terminal failed run is authoritative
ok - cross-branch run is attributed via the real runs list
ok - cross-branch attribution picks the branch's most recent row
ok - coarse run does not probe another branch's ci log
ok - another branch's run is ignored, falls back
ok - no run + a busy semantic record reads working, attributed to its source
ok - a converted adapter never reads working from rendered footer text
ok - grok still reads working through its isolated rendered-tail fallback
ok - herdr's native busy verdict reads working with no record present
ok - a mid-tool-call crew stays working because its record outranks herdr's generation state
ok - an idle record with idle agent_status stays not-busy (no regression for a human-blocked agent)
ok - no run + idle pane uses the status-log verb
ok - no run + idle pane parses keyed status syntax
ok - no run + idle pane on a paused: status reports state: paused with its reason
ok - no run + idle pane honors the configured paused verb
ok - a trailing resolved: event does not corrupt state render (idle stays idle)
ok - dead window ignores stale status log
ok - closed pane still reports a terminal run-step
ok - closed pane still reports an active run-step
ok - no timeout command uses perl bound
ok - scout skips the run lookup
ok - torn-down worktree is handled gracefully
ok - missing meta is handled gracefully
ok - crew_is_provably_working absorbs a validating crew found only via the runs-list fallback
ok - crew_is_provably_working still surfaces a genuinely stopped crew (safety property preserved)
ok - usage error exits 2
ok - historical same-branch rewritten head is not attributed as current
ok - active run with valid descendant fix head remains current
ok - local work advanced past run head invalidates attribution
ok - missing run head falls back instead of matching by branch
ok - pipeline-advanced run head is not reported as a stale failure
ok - coarse walk stops at the branch's newest row instead of a stale failure
ok - submitted head binds an advanced-head run and preserves its terminal verdict
ok - terminal verdict is withheld when run identity cannot be established
ok - coarse terminal verdict is withheld when identity cannot be established
ok - genuine failed run at the current head is still reported failed
ok - provably diverged newest row blocks attribution instead of falling through
all fm-crew-state tests passed

-------------------------------------------------------------------------------
2. End-to-End Fixture Demonstration
-------------------------------------------------------------------------------

Scenario A: In-flight run with pipeline-advanced head (Reproduction case)
- Setup: Branch fm/repro-pipeline-advanced has an in-flight running run at an unfetched pipeline SHA dead1eaf..., while older failed runs sit at worktree HEAD.
- Command: bin/fm-crew-state.sh repro-pipeline-advanced
- Result: state: working · source: run-step · validating (running) (unverified run head)
- Verification: The healthy running state is correctly reported as 'working' instead of false 'failed'.

Scenario B: Genuine failed run at worktree HEAD
- Setup: Branch fm/genuine-failed has a failed run recorded at the exact commit corresponding to worktree HEAD.
- Command: bin/fm-crew-state.sh genuine-failed
- Result: state: failed · source: run-step · run failed
- Verification: Genuinely failed run is still reported as 'failed'.

Scenario C: Unbindable terminal run (unfetched head without launch anchor)
- Setup: Branch fm/unbindable-terminal has a failed run at unfetched head dead1eaf..., with no sync launch anchor to bind it.
- Command: bin/fm-crew-state.sh unbindable-terminal
- Result: state: unknown · source: run-step · run failed · run head unverifiable against this copy
- Verification: Unattributable terminal run is reported as 'unknown' rather than a confident wrong 'failed'.

Scenario D: Submitted-head bound failed run
- Setup: Branch fm/submitted-head-bound-failed has a failed run at unfetched head dead1eaf..., but axi sync --check confirms submitted_head matches worktree HEAD.
- Command: bin/fm-crew-state.sh submitted-head-bound-failed
- Result: state: failed · source: run-step · run failed
- Verification: Submitted-head binding establishes identity and correctly reports terminal 'failed'.
===============================================================================
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"85cbede7d225566901b5ee856b32694adb1de424","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `./tests/fm-crew-state.test.sh`
- `bin/fm-crew-state.sh repro-pipeline-advanced`
- `bin/fm-crew-state.sh genuine-failed`
- `bin/fm-crew-state.sh unbindable-terminal`
- `bin/fm-crew-state.sh submitted-head-bound-failed`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
