### PR TITLE
feat(skills): add safe BWS and SOPS age workflows

### DIFF
--- a/.agents/skills/bws/SKILL.md
+++ b/.agents/skills/bws/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: bws
+description: >-
+  Agent-only load stub for the Bitwarden Secrets Manager CLI skill.
+  Use before any work with `bws` (not `bw`): authentication checks, project or secret listing, secret reads, creates, updates, rotations, or deletes.
+  The procedure lives in skills/bws/SKILL.md; read and follow that file completely after loading this stub.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# bws
+
+This stub exists because firstmate loads skills from `.agents/skills/`, while the authoritative procedure lives in the public installer skill at [`skills/bws/SKILL.md`](../../../skills/bws/SKILL.md).
+
+After this stub loads, read and follow that file completely.
+Never treat this stub as the procedure owner.

--- a/.agents/skills/sops-age/SKILL.md
+++ b/.agents/skills/sops-age/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: sops-age
+description: >-
+  Agent-only load stub for the Mozilla SOPS and age encryption skill.
+  Use before any work with `sops`, `age`, or `age-keygen`: encrypting or decrypting files, editing encrypted manifests, rotating age recipients or data keys, or resolving an age private key from bws.
+  The procedure lives in skills/sops-age/SKILL.md; read and follow that file completely after loading this stub.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# sops-age
+
+This stub exists because firstmate loads skills from `.agents/skills/`, while the authoritative procedure lives in the public installer skill at [`skills/sops-age/SKILL.md`](../../../skills/sops-age/SKILL.md).
+
+After this stub loads, read and follow that file completely.
+Never treat this stub as the procedure owner.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -536,6 +536,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the Relay configuration blocker, on a `public-followup ...` `check:` wake or a startup-surfaced public commitment, and on any milestone or terminal wake for a Relay-linked task before posting its completion follow-up; relevant only when Relay is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
+- `bws` - load before any work with Bitwarden Secrets Manager CLI (`bws`, not `bw`): authentication checks, listing projects or secrets, reading secret values, creating, updating, rotating, or deleting secrets.
 
 ## 14. Relay
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -537,6 +537,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
 - `bws` - load before any work with Bitwarden Secrets Manager CLI (`bws`, not `bw`): authentication checks, listing projects or secrets, reading secret values, creating, updating, rotating, or deleting secrets.
+- `sops-age` - load before any work with `sops`, `age`, or `age-keygen`: encrypting or decrypting files, editing encrypted manifests, rotating age recipients or data keys, or resolving an age private key from bws.
 
 ## 14. Relay
 

--- a/README.md
+++ b/README.md
@@ -193,9 +193,10 @@ Firstmate's skills live in two separate places with different audiences:
 - `.agents/skills/` - agent-loaded skills (this section's table, plus firstmate's agent-only reference skills). Every one of these assumes a live firstmate home and is meaningless, or actively misleading, installed anywhere else, so each carries `metadata.internal: true` in its frontmatter. That flag hides them from installer discovery (tools like the [skills.sh](https://skills.sh) `npx skills add` installer) without affecting how firstmate itself loads them - frontmatter metadata is inert to the agent's own skill loader.
 - `skills/` - public, installer-facing skills meant to be installed standalone into any project, independent of firstmate.
   Each one is a self-contained skill with no dependency on firstmate's paths, tools, or vocabulary.
-  Today that includes `skills/stow`, a generic session-knowledge-sweep skill that routes findings by explicit instruction first, then existing local conventions, then a private `.stow-notes.md` fallback, and curates tiered entries through decay, local archival, and user-approved on-demand offload proposals, and `skills/bws`, a safe Bitwarden Secrets Manager CLI (`bws`, not `bw`) skill with a bundled redaction helper.
+  Today that includes `skills/stow`, a generic session-knowledge-sweep skill that routes findings by explicit instruction first, then existing local conventions, then a private `.stow-notes.md` fallback, and curates tiered entries through decay, local archival, and user-approved on-demand offload proposals, `skills/bws`, a safe Bitwarden Secrets Manager CLI (`bws`, not `bw`) skill with a bundled redaction helper, and `skills/sops-age`, a safe Mozilla SOPS and age workflow with guarded private-key injection.
   `skills/stow` intentionally shares no code with the firstmate-internal `.agents/skills/stow` it is named after, so the two can evolve independently.
   `skills/bws` is the single procedure owner; firstmate's `.agents/skills/bws` stub only routes loaders to it.
+  `skills/sops-age` is likewise the single procedure owner; firstmate's `.agents/skills/sops-age` stub only routes loaders to it.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -193,8 +193,9 @@ Firstmate's skills live in two separate places with different audiences:
 - `.agents/skills/` - agent-loaded skills (this section's table, plus firstmate's agent-only reference skills). Every one of these assumes a live firstmate home and is meaningless, or actively misleading, installed anywhere else, so each carries `metadata.internal: true` in its frontmatter. That flag hides them from installer discovery (tools like the [skills.sh](https://skills.sh) `npx skills add` installer) without affecting how firstmate itself loads them - frontmatter metadata is inert to the agent's own skill loader.
 - `skills/` - public, installer-facing skills meant to be installed standalone into any project, independent of firstmate.
   Each one is a self-contained skill with no dependency on firstmate's paths, tools, or vocabulary.
-  Today that is `skills/stow`, a generic session-knowledge-sweep skill that routes findings by explicit instruction first, then existing local conventions, then a private `.stow-notes.md` fallback, and curates tiered entries through decay, local archival, and user-approved on-demand offload proposals.
-  It intentionally shares no code with the firstmate-internal `.agents/skills/stow` it is named after, so the two can evolve independently.
+  Today that includes `skills/stow`, a generic session-knowledge-sweep skill that routes findings by explicit instruction first, then existing local conventions, then a private `.stow-notes.md` fallback, and curates tiered entries through decay, local archival, and user-approved on-demand offload proposals, and `skills/bws`, a safe Bitwarden Secrets Manager CLI (`bws`, not `bw`) skill with a bundled redaction helper.
+  `skills/stow` intentionally shares no code with the firstmate-internal `.agents/skills/stow` it is named after, so the two can evolve independently.
+  `skills/bws` is the single procedure owner; firstmate's `.agents/skills/bws` stub only routes loaders to it.
 
 ## Documentation
 

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -379,6 +379,14 @@
     {
       "path": "skills/stow/SKILL.md",
       "audience": "public-product"
+    },
+    {
+      "path": "skills/bws/SKILL.md",
+      "audience": "public-product"
+    },
+    {
+      "path": ".agents/skills/bws/SKILL.md",
+      "audience": "agent-runtime"
     }
   ]
 }

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -387,6 +387,14 @@
     {
       "path": ".agents/skills/bws/SKILL.md",
       "audience": "agent-runtime"
+    },
+    {
+      "path": "skills/sops-age/SKILL.md",
+      "audience": "public-product"
+    },
+    {
+      "path": ".agents/skills/sops-age/SKILL.md",
+      "audience": "agent-runtime"
     }
   ]
 }

--- a/skills/bws/SKILL.md
+++ b/skills/bws/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: bws
+description: >-
+  Safe work with Bitwarden Secrets Manager CLI (`bws`, not password-manager `bw`).
+  Use before authentication checks, listing projects or secrets, reading secret values, creating, updating, rotating, or deleting Secrets Manager secrets.
+---
+
+<!-- maintainers: public installer-facing skill. Procedure owner for both firstmate and project workers. Firstmate loads `.agents/skills/bws/SKILL.md`, a stub that points here. -->
+
+# bws
+
+Bitwarden Secrets Manager CLI is `bws`.
+The password-manager CLI is `bw` and is a different product.
+Regular vault logins and personal passwords belong to `bw` or the Bitwarden application, not `bws`.
+
+## Current-source discovery
+
+Never memorize flags or claim subcommands this install does not support.
+Before operations, consult the installed CLI:
+
+```sh
+bws --version
+bws --help
+bws secret --help
+bws project --help
+bws run --help
+```
+
+Subcommand help is authoritative for the current version.
+
+## Installation
+
+Copy or link this directory into a project worker's skill discovery path:
+
+- `.agents/skills/bws/` (recommended)
+- `.claude/skills/bws/` (Claude Code)
+
+From the firstmate repository, the source path is `skills/bws/`.
+Installers such as [skills.sh](https://skills.sh) can add the same directory from the published firstmate repo.
+
+The bundled helper is `scripts/bws-safe.sh` relative to this skill directory.
+
+## Project AGENTS.md trigger
+
+Add this exact line to the project's always-loaded agent instructions (for example `AGENTS.md`):
+
+```md
+- `bws` - load before any work with Bitwarden Secrets Manager CLI (`bws`, not `bw`): authentication checks, listing projects or secrets, reading secret values, creating, updating, rotating, or deleting secrets.
+```
+
+## Bundled helper
+
+Use `scripts/bws-safe.sh` for probes, metadata listing, duplicate-safe ID resolution, and JSON redaction.
+It never prints access tokens or secret values.
+
+```sh
+HELPER="<skill-dir>/scripts/bws-safe.sh"
+"$HELPER" probe
+"$HELPER" list-metadata <PROJECT_ID>
+"$HELPER" resolve-id <PROJECT_ID> <KEY>
+bws secret get <SECRET_ID> -o json | "$HELPER" redact-json
+```
+
+`probe` prints `status=`, `version=`, and `token_present=` only.
+Treat `token_present=yes` as "a token or profile may exist", never as proof the token is valid.
+Only `status=authenticated` means the project-list authentication probe succeeded.
+It does not prove access to any particular project or permission to write.
+`status=no_token`, `invalid_token`, `forbidden`, `unavailable`, and `indeterminate` are not success.
+
+## Authentication without exposure
+
+Detect install and authentication without exposing the access token.
+
+1. Run `"$HELPER" probe` or `command -v bws` plus `bws --version`.
+2. Never print `BWS_ACCESS_TOKEN`, `--access-token`, config file contents, or token-shaped strings.
+3. Never ask the captain or user to paste a token or secret into chat.
+4. Never commit tokens, secret values, rendered credentials, or CLI output that contains values.
+
+If `probe` reports `no_token` or `invalid_token`, stop and ask the operator to configure `BWS_ACCESS_TOKEN` or a `bws` profile outside chat.
+Do not troubleshoot by echoing token material.
+
+## Distinguish failures
+
+| Evidence | Meaning |
+| --- | --- |
+| `command -v bws` fails | CLI absent |
+| `status=no_token` | No usable access token |
+| `status=invalid_token` | Token present but rejected |
+| `status=authenticated` | The project-list probe succeeded; project-specific access and writes remain unverified |
+| `status=forbidden` on list | Token valid but lacks project access or is read-only beyond list |
+| `resolve-id` exit 1 | Secret key absent in that project |
+| `resolve-id` exit 2 | Duplicate secret names; do not mutate by name alone |
+| Write command non-zero after explicit authority | Write denied, wrong project, or target mismatch; never report success |
+
+Read-only service accounts can succeed at `project list` and `secret list` for accessible projects while create, edit, and delete fail.
+Verify writes by exit code and post-change metadata, never by echoing values.
+
+## Safe listing and inspection
+
+List projects and inspect secret metadata without printing values.
+
+```sh
+bws project list -o table
+"$HELPER" list-metadata <PROJECT_ID>
+bws project get <PROJECT_ID> -o json
+```
+
+Prefer `-o table` or `list-metadata` for human review.
+Secret JSON includes values; pipe it through `redact-json` before logging or chat.
+
+Preserve identities separately:
+
+- `PROJECT_ID` identifies a project.
+- `SECRET_ID` identifies a secret.
+- `key` is a human label and may duplicate within a project.
+
+Resolve targets with `"$HELPER" resolve-id <PROJECT_ID> <KEY>` before create, edit, or delete when the key name is known.
+When duplicates exist, stop and ask for the exact `SECRET_ID`.
+
+## Reading secret values
+
+Read a secret value only when the task genuinely requires it.
+
+1. Resolve `SECRET_ID` when starting from a key name.
+2. Prefer `bws run --project-id <PROJECT_ID> -- <trusted-command>` so the value stays in the child process environment instead of chat or files.
+3. If you must call `bws secret get`, never paste the value into chat, logs, command arguments visible to tools, or tracked files.
+4. Verify success with redacted metadata (`revisionDate`, `id`, `key`) rather than re-printing the value.
+
+## Creating and updating secrets
+
+Create or update only with current explicit authority naming the project and secret.
+
+1. Confirm `probe` shows `authenticated`.
+2. Confirm the service account can write to the named `PROJECT_ID`.
+3. Resolve duplicates before create; prefer `secret edit <SECRET_ID>` over ambiguous name-only updates.
+4. Create: `bws secret create <KEY> <VALUE> <PROJECT_ID> [--note <NOTE>]`
+5. Update: `bws secret edit <SECRET_ID> [--key <KEY>] [--value <VALUE>] [--note <NOTE>] [--project-id <PROJECT_ID>]`
+6. The current CLI takes secret values as command arguments, so keep the value in a preconfigured environment variable and invoke the command only through a trusted shell or wrapper that does not record expanded arguments.
+7. Never place the value itself in chat, a tool-call command, a transcript, or a committed file.
+8. Verify with `"$HELPER" list-metadata <PROJECT_ID>` or `bws secret get <SECRET_ID> -o json | "$HELPER" redact-json`.
+9. A non-zero exit code is failure even when partial output appeared; never report success without verification.
+
+Rotation is an edit of `SECRET_ID` with a new value, then the same redacted verification.
+
+## Deleting secrets
+
+Delete only with explicit, concrete captain or operator authority that names the exact `SECRET_ID` (and project context).
+
+1. Refuse delete requests that name only a key when duplicates may exist.
+2. Re-verify identity with `bws secret get <SECRET_ID> -o json | "$HELPER" redact-json` and `projectId`.
+3. Run `bws secret delete <SECRET_ID>`.
+4. Confirm absence with `resolve-id` exit 1 or metadata listing without that `id`.
+5. Never delete to "clean up" without named authority.
+
+## Write-access and scope failures
+
+Handle service-account scope and write-access failures safely.
+
+- Stop on non-zero exit codes from create, edit, or delete.
+- Report the concrete failure (forbidden, not found, duplicate) without secret values.
+- Do not retry writes with guessed project IDs or names.
+- Do not fall back to storing secrets in repo files, `.env` commits, or chat.
+
+## Never commit secrets
+
+Never commit tokens, secret values, rendered credentials, or captured CLI output that contains values.
+Redact before saving command transcripts or diagnostics.

--- a/skills/bws/scripts/bws-safe.sh
+++ b/skills/bws/scripts/bws-safe.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# bws-safe.sh - safe helper for Bitwarden Secrets Manager CLI (bws).
+#
+# Owned by skills/bws/SKILL.md. Never prints access tokens or secret values.
+# Consult `bws --help` and subcommand help for flags; this script does not
+# memorize CLI syntax beyond what it needs for safe probes and redaction.
+#
+# Usage:
+#   bws-safe.sh probe
+#   bws-safe.sh redact-json
+#   bws-safe.sh list-metadata [PROJECT_ID]
+#   bws-safe.sh resolve-id <PROJECT_ID> <KEY>
+#
+# probe prints one sanitized key=value line per fact on stdout:
+#   status= unavailable | no_token | invalid_token | authenticated | forbidden | indeterminate
+#   version=  bws version or none
+#   token_present= yes | no
+#
+# resolve-id prints exactly one secret UUID on stdout when the key is unique in
+# the project; exit 0. Exit 1 when absent, 2 when duplicate names exist, 3 on
+# probe or CLI failure. Never prints secret values.
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+usage() {
+  cat <<'EOF'
+bws-safe.sh - safe helper for Bitwarden Secrets Manager CLI (bws)
+
+Usage:
+  bws-safe.sh probe
+  bws-safe.sh redact-json
+  bws-safe.sh list-metadata [PROJECT_ID]
+  bws-safe.sh resolve-id <PROJECT_ID> <KEY>
+
+Never prints access tokens or secret values.
+EOF
+}
+
+die_usage() {
+  printf 'bws-safe: %s\n' "$1" >&2
+  usage >&2
+  exit 2
+}
+
+require_jq() {
+  command -v jq >/dev/null 2>&1 || die_usage "jq is required"
+}
+
+bws_version() {
+  local output version
+  if ! command -v bws >/dev/null 2>&1; then
+    printf 'none\n'
+    return 0
+  fi
+  if ! output=$(bws --version 2>/dev/null); then
+    printf 'none\n'
+    return 0
+  fi
+  version=$(awk 'NF >= 2 {print $2; exit}' <<<"$output")
+  if [ -n "$version" ]; then
+    printf '%s\n' "$version"
+  else
+    printf 'none\n'
+  fi
+}
+
+token_present() {
+  if [ -n "${BWS_ACCESS_TOKEN:-}" ]; then
+    printf 'yes\n'
+    return 0
+  fi
+  if [ -n "${BWS_PROFILE:-}" ] || [ -f "${BWS_CONFIG_FILE:-$HOME/.config/bws/config}" ]; then
+    printf 'yes\n'
+    return 0
+  fi
+  printf 'no\n'
+}
+
+classify_bws_stderr() {
+  local err=$1
+  case "$err" in
+    *"Missing access token"*) printf 'no_token\n' ;;
+    *"Doesn't contain a decryption key"*|*"401"*) printf 'invalid_token\n' ;;
+    *"403"*|*"Forbidden"*|*"forbidden"*)
+      printf 'forbidden\n'
+      ;;
+    *) printf 'indeterminate\n' ;;
+  esac
+}
+
+run_bws() {
+  # shellcheck disable=SC2068
+  bws "$@" 2>/dev/null
+}
+
+cmd_probe() {
+  local version status token stderr
+  version=$(bws_version)
+  token=$(token_present)
+  if [ "$version" = none ]; then
+    status=unavailable
+    printf 'status=%s version=%s token_present=%s\n' "$status" "$version" "$token"
+    exit 0
+  fi
+  if [ "$token" = no ]; then
+    status=no_token
+    printf 'status=%s version=%s token_present=%s\n' "$status" "$version" "$token"
+    exit 0
+  fi
+  stderr=$(mktemp)
+  chmod 600 "$stderr"
+  if bws project list -o none > /dev/null 2>"$stderr"; then
+    status=authenticated
+  else
+    status=$(classify_bws_stderr "$(<"$stderr")")
+  fi
+  rm -f "$stderr"
+  printf 'status=%s version=%s token_present=%s\n' "$status" "$version" "$token"
+  exit 0
+}
+
+cmd_redact_json() {
+  require_jq
+  jq '
+    walk(
+      if type == "object" then
+        (if has("value") then .value = "[REDACTED]" else . end)
+        | (if has("note") then .note = "[REDACTED]" else . end)
+      else
+        .
+      end
+    )
+  '
+}
+
+cmd_list_metadata() {
+  local project_id=${1:-} json
+  require_jq
+  if [ -n "$project_id" ]; then
+    json=$(run_bws secret list "$project_id" -o json) || exit 3
+  else
+    json=$(run_bws secret list -o json) || exit 3
+  fi
+  printf '%s\n' "$json" | cmd_redact_json
+}
+
+cmd_resolve_id() {
+  local project_id=$1 key=$2 json matches count id list_stderr list_error
+  [ -n "$project_id" ] && [ -n "$key" ] || die_usage "resolve-id requires PROJECT_ID and KEY"
+  require_jq
+  list_stderr=$(mktemp)
+  chmod 600 "$list_stderr"
+  if ! json=$(bws secret list "$project_id" -o json 2>"$list_stderr"); then
+    list_error=$(<"$list_stderr")
+    rm -f "$list_stderr"
+    case "$list_error" in
+      *"404"*) ;;
+      *) exit 3 ;;
+    esac
+    run_bws project get "$project_id" -o none >/dev/null || exit 3
+    exit 1
+  fi
+  rm -f "$list_stderr"
+  matches=$(jq -r --arg key "$key" '
+    [.[] | select(.key == $key)] as $items
+    | if any($items[]; ((.id | type) != "string") or (.id == "")) then
+        error("matching secret has an invalid id")
+      else
+        [$items[].id] | @json
+      end
+  ' <<<"$json") || exit 3
+  count=$(jq 'length' <<<"$matches") || exit 3
+  case "$count" in
+    0) exit 1 ;;
+    1)
+      id=$(jq -r '.[0]' <<<"$matches")
+      printf '%s\n' "$id"
+      exit 0
+      ;;
+    *)
+      printf 'bws-safe: duplicate secret key %s in project %s (%s matches)\n' \
+        "$key" "$project_id" "$count" >&2
+      jq -r '.[]' <<<"$matches" >&2
+      exit 2
+      ;;
+  esac
+}
+
+CMD=${1:-}
+shift || true
+
+case "$CMD" in
+  -h|--help|'')
+    usage
+    [ -n "$CMD" ] || exit 2
+    exit 0
+    ;;
+  probe)
+    [ $# -eq 0 ] || die_usage "probe takes no arguments"
+    cmd_probe
+    ;;
+  redact-json)
+    [ $# -eq 0 ] || die_usage "redact-json reads stdin and takes no arguments"
+    cmd_redact_json
+    ;;
+  list-metadata)
+    [ $# -le 1 ] || die_usage "list-metadata accepts an optional PROJECT_ID"
+    cmd_list_metadata "${1:-}"
+    ;;
+  resolve-id)
+    [ $# -eq 2 ] || die_usage "resolve-id requires PROJECT_ID and KEY"
+    cmd_resolve_id "$1" "$2"
+    ;;
+  *)
+    die_usage "unknown command: $CMD"
+    ;;
+esac

--- a/skills/sops-age/SKILL.md
+++ b/skills/sops-age/SKILL.md
@@ -73,13 +73,14 @@ Exit 0 means an identity is available to the current process; exit 1 means none.
 Decrypted output has no generally safe field allowlist and must never be relayed to chat, logs, or saved diagnostics.
 For verification, discard decrypted stdout and use only the command exit status.
 
-`with-age-key` runs a child command with age identity available only inside that child.
+`with-age-key` runs a supported direct SOPS command with age identity available only inside that child.
 Modes:
 
-- `bws <PROJECT_ID> -- <command...>` runs `bws run --project-id <PROJECT_ID> -- <command...>` so the age key stays in the trusted child environment.
-- `file <KEY_FILE> -- <command...>` sets `SOPS_AGE_KEY_FILE` for the child only when the operator provides a readable key file outside chat.
+- `bws <PROJECT_ID> -- <sops-command...>` runs `bws run --project-id <PROJECT_ID> -- <sops-command...>` so the age key stays in the trusted child environment.
+- `file <KEY_FILE> -- <sops-command...>` sets `SOPS_AGE_KEY_FILE` for the child only when the operator provides a readable key file outside chat.
 
-The wrapper refuses commands whose arguments contain `AGE-SECRET-KEY-...`, suppresses stdout from direct `sops -d`, `sops --decrypt`, and `sops decrypt` commands, and unsets `SOPS_AGE_KEY` and `SOPS_AGE_KEY_FILE` after the child exits.
+The wrapper accepts only direct SOPS decrypt, encrypt, edit, updatekeys, and rotate operations, refuses commands whose arguments contain `AGE-SECRET-KEY-...`, suppresses decrypt stdout, and unsets `SOPS_AGE_KEY` and `SOPS_AGE_KEY_FILE` after the child exits.
+It rejects intermediary executables such as `env` and shells because their eventual output cannot be classified safely.
 
 ## Environment separation
 

--- a/skills/sops-age/SKILL.md
+++ b/skills/sops-age/SKILL.md
@@ -80,6 +80,7 @@ Modes:
 - `file <KEY_FILE> -- <sops-command...>` sets `SOPS_AGE_KEY_FILE` for the child only when the operator provides a readable key file outside chat.
 
 The wrapper accepts only direct SOPS decrypt, encrypt, edit, updatekeys, and rotate operations, refuses commands whose arguments contain `AGE-SECRET-KEY-...`, suppresses decrypt stdout, and unsets `SOPS_AGE_KEY` and `SOPS_AGE_KEY_FILE` after the child exits.
+The operation token must immediately follow the `sops` executable, and any second operation token makes the command invalid.
 It rejects intermediary executables such as `env` and shells because their eventual output cannot be classified safely.
 
 ## Environment separation

--- a/skills/sops-age/SKILL.md
+++ b/skills/sops-age/SKILL.md
@@ -69,6 +69,7 @@ HELPER="<skill-dir>/scripts/sops-safe.sh"
 `detect-age-identity` prints `age_identity_present=` and `source=` only.
 It never prints `AGE-SECRET-KEY-...` or file contents.
 Exit 0 means an identity is available to the current process; exit 1 means none.
+Treat `source=env` as an inherited unsafe state to clear, not as approval to use the key from the parent environment.
 
 Decrypted output has no generally safe field allowlist and must never be relayed to chat, logs, or saved diagnostics.
 For verification, discard decrypted stdout and use only the command exit status.
@@ -105,7 +106,7 @@ Never paste `AGE-SECRET-KEY-...` into chat, tool arguments, logs, commits, or st
 Never pass a private key as a visible command-line argument to `sops`, `age`, or any wrapper.
 Never write a private key into a tracked file.
 
-Prefer `with-age-key bws` over exporting `SOPS_AGE_KEY` in the parent shell.
+Do not export `SOPS_AGE_KEY` in the parent shell; use `with-age-key bws` so the key exists only in the trusted child process.
 When the operator supplies a key file, reference only the file path and keep permissions tight.
 
 ## Authority for mutating work
@@ -191,7 +192,7 @@ After encrypt, edit, `updatekeys`, or `rotate`:
 ## Cleanup
 
 Remove gitignored plaintext staging files, temp decrypt outputs, and editor swap files before reporting completion.
-Unset any manual `SOPS_AGE_KEY` or `SOPS_AGE_KEY_FILE` exports in the current shell.
+Unset any inherited or pre-existing `SOPS_AGE_KEY` export before continuing, and clear temporary `SOPS_AGE_KEY_FILE` exports after use.
 Do not leave decrypted content in the worktree.
 
 ## Failure handling

--- a/skills/sops-age/SKILL.md
+++ b/skills/sops-age/SKILL.md
@@ -52,15 +52,14 @@ Add this exact line to the project's always-loaded agent instructions (for examp
 
 ## Bundled helper
 
-Use `scripts/sops-safe.sh` for probes, age-identity detection without printing keys, transcript-safe redaction, and trusted age-key injection.
+Use `scripts/sops-safe.sh` for probes, age-identity detection without printing keys, and trusted age-key injection.
 
 ```sh
 HELPER="<skill-dir>/scripts/sops-safe.sh"
 "$HELPER" probe
 "$HELPER" detect-age-identity
-sops --decrypt file.enc.yaml 2>/dev/null | "$HELPER" redact-output
-"$HELPER" with-age-key bws <PROJECT_ID> -- sops --decrypt file.enc.yaml
-"$HELPER" with-age-key file /path/to/key.txt -- sops --decrypt file.enc.yaml
+"$HELPER" with-age-key bws <PROJECT_ID> -- sops --decrypt file.enc.yaml >/dev/null
+"$HELPER" with-age-key file /path/to/key.txt -- sops --decrypt file.enc.yaml >/dev/null
 ```
 
 `probe` prints `status=`, `sops_version=`, and `age_version=` only.
@@ -71,8 +70,8 @@ sops --decrypt file.enc.yaml 2>/dev/null | "$HELPER" redact-output
 It never prints `AGE-SECRET-KEY-...` or file contents.
 Exit 0 means an identity is available to the current process; exit 1 means none.
 
-`redact-output` reads stdin and replaces age private keys and common secret field values with `[REDACTED]` markers.
-Pipe decrypted or edited output through it before chat, logs, or saved diagnostics.
+Decrypted output has no generally safe field allowlist and must never be relayed to chat, logs, or saved diagnostics.
+For verification, discard decrypted stdout and use only the command exit status.
 
 `with-age-key` runs a child command with age identity available only inside that child.
 Modes:
@@ -109,7 +108,7 @@ When the operator supplies a key file, reference only the file path and keep per
 
 ## Authority for mutating work
 
-Read-only operations (probe, metadata inspection, decrypt-for-verification with redacted output) need no extra authority beyond the task itself.
+Read-only operations that do not create files (probe, encrypted metadata inspection, and decrypt-for-verification with stdout discarded) need no extra authority beyond the task itself.
 
 Require current explicit authority naming the target file and environment before:
 
@@ -119,6 +118,7 @@ Require current explicit authority naming the target file and environment before
 - `sops rotate` (data-key rotation)
 - creating or changing `.sops.yaml` creation rules
 - creating, rotating, or deleting age keys or Secrets Manager secrets that hold private keys
+- creating or deleting files containing decrypted values, including temporary files
 
 Refuse mutating requests that name only a directory, only a key alias without environment context, or only a recipient fingerprint without the file set.
 
@@ -137,18 +137,18 @@ Encrypt only with explicit authority naming the plaintext path, output path if d
 2. Never place plaintext secret values in chat or command arguments visible to tools.
 3. Prefer encrypting from a gitignored staging copy when the plaintext must not remain on disk.
 4. Run `sops --encrypt --in-place <file>` or the equivalent your `sops --help` documents for the installed version.
-5. Verify by decrypting inside `with-age-key` and piping through `redact-output`; confirm structure and keys without printing values.
+5. Verify by decrypting inside `with-age-key` with stdout discarded; use the exit status to confirm integrity without printing values.
 6. Remove plaintext staging copies after verification when the workflow created them.
 
 ## Decrypting and inspecting
 
 Decrypt only when the task requires reading content.
-Prefer metadata inspection (`sops --extract`, `sops -d` into a gitignored temp file) over pasting output into chat.
+Prefer encrypted metadata inspection over decrypting values.
 
 1. Run decrypt inside `with-age-key bws` or `with-age-key file`, never with a key in parent arguments.
-2. Pipe stdout through `"$HELPER" redact-output` before logging or relaying.
-3. Write decrypted output only to gitignored temp files with restrictive permissions when a file is required.
-4. Delete temp files in a `trap` or explicit cleanup step before finishing.
+2. Discard stdout when only the decryption result is needed for verification.
+3. Require explicit authority naming the file and environment before writing decrypted output to a restrictive, gitignored temporary file.
+4. Require the same authority to delete that temporary file, and clean it up in a `trap` or explicit cleanup step before finishing.
 
 ## Editing encrypted files
 
@@ -156,7 +156,7 @@ Prefer metadata inspection (`sops --extract`, `sops -d` into a gitignored temp f
 
 1. Confirm the age identity for that environment is available through an approved path.
 2. Run edit inside `with-age-key`.
-3. After edit, verify MAC and decrypt with `redact-output` without printing values.
+3. After edit, verify MAC and decrypt with stdout discarded.
 4. Commit only the encrypted file, never editor backups that might hold plaintext.
 
 ## Recipient update and data-key rotation
@@ -182,7 +182,7 @@ Data-key rotation (`rotate`):
 After encrypt, edit, `updatekeys`, or `rotate`:
 
 1. Confirm `sops` exits 0.
-2. Decrypt inside `with-age-key` and pipe through `redact-output`; check field names and structure only.
+2. Decrypt inside `with-age-key` with stdout discarded and confirm the exit status only.
 3. For GitOps repos, confirm only encrypted blobs changed in the diff.
 4. Never attach decrypted content to PR descriptions, status lines, or chat.
 
@@ -208,5 +208,5 @@ Never retry mutating commands with guessed recipient lists, guessed key files, o
 ## Never commit secrets
 
 Never commit age private keys, plaintext secret files, decrypted output, or command transcripts that contain values.
-Redact before saving diagnostics.
+Do not save diagnostics containing decrypted output.
 Encrypted SOPS files belong in Git; plaintext secrets do not.

--- a/skills/sops-age/SKILL.md
+++ b/skills/sops-age/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: sops-age
+description: >-
+  Safe work with Mozilla SOPS and age for GitOps-managed secrets.
+  Use before encrypting or decrypting files, editing encrypted manifests, rotating age recipients or data keys, or resolving an age private key from Bitwarden Secrets Manager.
+---
+
+<!-- maintainers: public installer-facing skill. Procedure owner for both firstmate and project workers. Firstmate loads `.agents/skills/sops-age/SKILL.md`, a stub that points here. -->
+
+# sops-age
+
+Mozilla SOPS encrypts structured files in place.
+age provides the recipient and identity format SOPS uses for file encryption.
+This skill owns safe probe, encrypt, decrypt, edit, recipient update, data-key rotation, verification, cleanup, and failure handling.
+
+Load the `bws` skill before resolving age private keys from Bitwarden Secrets Manager.
+
+## Current-source discovery
+
+Never memorize flags or claim subcommands this install does not support.
+Before operations, consult the installed tools:
+
+```sh
+sops --version
+sops --help
+age --version
+age --help
+age-keygen --help
+```
+
+Subcommand help is authoritative for the current version.
+
+## Installation
+
+Copy or link this directory into a project worker's skill discovery path:
+
+- `.agents/skills/sops-age/` (recommended)
+- `.claude/skills/sops-age/` (Claude Code)
+
+From the firstmate repository, the source path is `skills/sops-age/`.
+Installers such as [skills.sh](https://skills.sh) can add the same directory from the published firstmate repo.
+
+The bundled helper is `scripts/sops-safe.sh` relative to this skill directory.
+
+## Project AGENTS.md trigger
+
+Add this exact line to the project's always-loaded agent instructions (for example `AGENTS.md`):
+
+```md
+- `sops-age` - load before any work with `sops`, `age`, or `age-keygen`: encrypting or decrypting files, editing encrypted manifests, rotating age recipients or data keys, or resolving an age private key from bws.
+```
+
+## Bundled helper
+
+Use `scripts/sops-safe.sh` for probes, age-identity detection without printing keys, transcript-safe redaction, and trusted age-key injection.
+
+```sh
+HELPER="<skill-dir>/scripts/sops-safe.sh"
+"$HELPER" probe
+"$HELPER" detect-age-identity
+sops --decrypt file.enc.yaml 2>/dev/null | "$HELPER" redact-output
+"$HELPER" with-age-key bws <PROJECT_ID> -- sops --decrypt file.enc.yaml
+"$HELPER" with-age-key file /path/to/key.txt -- sops --decrypt file.enc.yaml
+```
+
+`probe` prints `status=`, `sops_version=`, and `age_version=` only.
+`status=ready` means both `sops` and `age` are present.
+`sops_absent`, `age_absent`, and `unavailable` are not success.
+
+`detect-age-identity` prints `age_identity_present=` and `source=` only.
+It never prints `AGE-SECRET-KEY-...` or file contents.
+Exit 0 means an identity is available to the current process; exit 1 means none.
+
+`redact-output` reads stdin and replaces age private keys and common secret field values with `[REDACTED]` markers.
+Pipe decrypted or edited output through it before chat, logs, or saved diagnostics.
+
+`with-age-key` runs a child command with age identity available only inside that child.
+Modes:
+
+- `bws <PROJECT_ID> -- <command...>` runs `bws run --project-id <PROJECT_ID> -- <command...>` so the age key stays in the trusted child environment.
+- `file <KEY_FILE> -- <command...>` sets `SOPS_AGE_KEY_FILE` for the child only when the operator provides a readable key file outside chat.
+
+The wrapper refuses commands whose arguments contain `AGE-SECRET-KEY-...` and unsets `SOPS_AGE_KEY` and `SOPS_AGE_KEY_FILE` after the child exits.
+
+## Environment separation
+
+Each deployment environment must use its own age recipient set and its own private key.
+Configure separate `.sops.yaml` creation rules per environment so path patterns bind to the correct recipients.
+Never reuse one environment's private key to decrypt another environment's files.
+Verify recipient lists in file metadata match the intended environment before any mutating work.
+
+Name environments in task authority and commands with the operator's labels (for example `staging` and `production`).
+Do not assume project-specific key or secret names; resolve them from the operator's secret manager or documented runbook.
+
+## Age private key boundary
+
+An age private key may enter a session only through one of these paths:
+
+1. `bws run --project-id <PROJECT_ID> -- <trusted-command>` with the key stored as a Secrets Manager secret in that project.
+2. An operator-managed key file on disk that never passes through chat, transcripts, or tracked files.
+3. `with-age-key` wrapping either path above.
+
+Never paste `AGE-SECRET-KEY-...` into chat, tool arguments, logs, commits, or status lines.
+Never pass a private key as a visible command-line argument to `sops`, `age`, or any wrapper.
+Never write a private key into a tracked file.
+
+Prefer `with-age-key bws` over exporting `SOPS_AGE_KEY` in the parent shell.
+When the operator supplies a key file, reference only the file path and keep permissions tight.
+
+## Authority for mutating work
+
+Read-only operations (probe, metadata inspection, decrypt-for-verification with redacted output) need no extra authority beyond the task itself.
+
+Require current explicit authority naming the target file and environment before:
+
+- encrypting a new or plaintext file
+- `sops edit` or any in-place change to encrypted content
+- `sops updatekeys` (recipient rotation)
+- `sops rotate` (data-key rotation)
+- creating or changing `.sops.yaml` creation rules
+- creating, rotating, or deleting age keys or Secrets Manager secrets that hold private keys
+
+Refuse mutating requests that name only a directory, only a key alias without environment context, or only a recipient fingerprint without the file set.
+
+## Safe probe and prerequisites
+
+1. Run `"$HELPER" probe` or `command -v sops age` plus version checks.
+2. Confirm `.sops.yaml` exists when the repository uses creation rules.
+3. For decrypt or edit, confirm an age identity is available via `detect-age-identity` or a planned `with-age-key` invocation.
+4. Stop when `probe` reports anything other than `status=ready`.
+
+## Encrypting files
+
+Encrypt only with explicit authority naming the plaintext path, output path if different, and environment.
+
+1. Confirm recipients in `.sops.yaml` match the named environment.
+2. Never place plaintext secret values in chat or command arguments visible to tools.
+3. Prefer encrypting from a gitignored staging copy when the plaintext must not remain on disk.
+4. Run `sops --encrypt --in-place <file>` or the equivalent your `sops --help` documents for the installed version.
+5. Verify by decrypting inside `with-age-key` and piping through `redact-output`; confirm structure and keys without printing values.
+6. Remove plaintext staging copies after verification when the workflow created them.
+
+## Decrypting and inspecting
+
+Decrypt only when the task requires reading content.
+Prefer metadata inspection (`sops --extract`, `sops -d` into a gitignored temp file) over pasting output into chat.
+
+1. Run decrypt inside `with-age-key bws` or `with-age-key file`, never with a key in parent arguments.
+2. Pipe stdout through `"$HELPER" redact-output` before logging or relaying.
+3. Write decrypted output only to gitignored temp files with restrictive permissions when a file is required.
+4. Delete temp files in a `trap` or explicit cleanup step before finishing.
+
+## Editing encrypted files
+
+`sops edit` is mutating and needs explicit authority naming file and environment.
+
+1. Confirm the age identity for that environment is available through an approved path.
+2. Run edit inside `with-age-key`.
+3. After edit, verify MAC and decrypt with `redact-output` without printing values.
+4. Commit only the encrypted file, never editor backups that might hold plaintext.
+
+## Recipient update and data-key rotation
+
+`sops updatekeys` changes who can decrypt; `sops rotate` changes the data key.
+Both are mutating and need explicit authority naming the files and environment.
+
+Recipient update (`updatekeys`):
+
+1. Confirm the new recipient public keys belong to the named environment only.
+2. Update `.sops.yaml` creation rules when new files should use the new recipient set.
+3. Run `sops updatekeys <file>` inside `with-age-key` using a key that already decrypts the file.
+4. Verify every listed file decrypts under the expected identity after the update.
+
+Data-key rotation (`rotate`):
+
+1. Run `sops rotate --in-place <file>` inside `with-age-key`.
+2. Verify decrypt after rotation.
+3. Re-encrypt or update keys for every copy that must stay in sync.
+
+## Verification
+
+After encrypt, edit, `updatekeys`, or `rotate`:
+
+1. Confirm `sops` exits 0.
+2. Decrypt inside `with-age-key` and pipe through `redact-output`; check field names and structure only.
+3. For GitOps repos, confirm only encrypted blobs changed in the diff.
+4. Never attach decrypted content to PR descriptions, status lines, or chat.
+
+## Cleanup
+
+Remove gitignored plaintext staging files, temp decrypt outputs, and editor swap files before reporting completion.
+Unset any manual `SOPS_AGE_KEY` or `SOPS_AGE_KEY_FILE` exports in the current shell.
+Do not leave decrypted content in the worktree.
+
+## Failure handling
+
+| Evidence | Meaning | Action |
+| --- | --- | --- |
+| `status=sops_absent` or `status=age_absent` | Required CLI missing | Stop; ask operator to install |
+| `detect-age-identity` exit 1 | No usable private key in process | Use `with-age-key` or stop |
+| MAC mismatch / decryption error | Wrong key or corrupted file | Stop; do not retry with another environment's key |
+| `with-age-key` refuses arguments | Key material in argv | Remove key from command; use approved injection |
+| `bws run` non-zero | Secret or project access failure | Report without secret values; load `bws` skill |
+| `updatekeys` / `rotate` non-zero | Incomplete rotation | Stop; do not commit partial state |
+
+Never retry mutating commands with guessed recipient lists, guessed key files, or a different environment's key.
+
+## Never commit secrets
+
+Never commit age private keys, plaintext secret files, decrypted output, or command transcripts that contain values.
+Redact before saving diagnostics.
+Encrypted SOPS files belong in Git; plaintext secrets do not.

--- a/skills/sops-age/SKILL.md
+++ b/skills/sops-age/SKILL.md
@@ -58,8 +58,8 @@ Use `scripts/sops-safe.sh` for probes, age-identity detection without printing k
 HELPER="<skill-dir>/scripts/sops-safe.sh"
 "$HELPER" probe
 "$HELPER" detect-age-identity
-"$HELPER" with-age-key bws <PROJECT_ID> -- sops --decrypt file.enc.yaml >/dev/null
-"$HELPER" with-age-key file /path/to/key.txt -- sops --decrypt file.enc.yaml >/dev/null
+"$HELPER" with-age-key bws <PROJECT_ID> -- sops --decrypt file.enc.yaml
+"$HELPER" with-age-key file /path/to/key.txt -- sops --decrypt file.enc.yaml
 ```
 
 `probe` prints `status=`, `sops_version=`, and `age_version=` only.
@@ -79,7 +79,7 @@ Modes:
 - `bws <PROJECT_ID> -- <command...>` runs `bws run --project-id <PROJECT_ID> -- <command...>` so the age key stays in the trusted child environment.
 - `file <KEY_FILE> -- <command...>` sets `SOPS_AGE_KEY_FILE` for the child only when the operator provides a readable key file outside chat.
 
-The wrapper refuses commands whose arguments contain `AGE-SECRET-KEY-...` and unsets `SOPS_AGE_KEY` and `SOPS_AGE_KEY_FILE` after the child exits.
+The wrapper refuses commands whose arguments contain `AGE-SECRET-KEY-...`, suppresses stdout from direct `sops -d`, `sops --decrypt`, and `sops decrypt` commands, and unsets `SOPS_AGE_KEY` and `SOPS_AGE_KEY_FILE` after the child exits.
 
 ## Environment separation
 

--- a/skills/sops-age/scripts/sops-safe.sh
+++ b/skills/sops-age/scripts/sops-safe.sh
@@ -130,37 +130,39 @@ assert_no_key_in_args() {
 }
 
 classify_sops_command() {
-  local executable=${1:-} arg
+  local executable=${1:-} operation_token operation arg
   shift || true
   [ "${executable##*/}" = sops ] || return 1
+  operation_token=${1:-}
+  shift || true
+  case "$operation_token" in
+    -d|--decrypt|decrypt)
+      operation=decrypt
+      ;;
+    -e|--encrypt|encrypt)
+      operation=encrypt
+      ;;
+    edit)
+      operation=edit
+      ;;
+    updatekeys)
+      operation=updatekeys
+      ;;
+    -r|--rotate|rotate)
+      operation=rotate
+      ;;
+    *)
+      return 1
+      ;;
+  esac
   for arg in "$@"; do
     case "$arg" in
-      -d|--decrypt|decrypt)
-        printf 'decrypt\n'
-        return 0
-        ;;
-      -e|--encrypt|encrypt)
-        printf 'encrypt\n'
-        return 0
-        ;;
-      edit)
-        printf 'edit\n'
-        return 0
-        ;;
-      updatekeys)
-        printf 'updatekeys\n'
-        return 0
-        ;;
-      -r|--rotate|rotate)
-        printf 'rotate\n'
-        return 0
-        ;;
-      --)
+      -d|--decrypt|decrypt|-e|--encrypt|encrypt|edit|updatekeys|-r|--rotate|rotate)
         return 1
         ;;
     esac
   done
-  return 1
+  printf '%s\n' "$operation"
 }
 
 cmd_with_age_key() {

--- a/skills/sops-age/scripts/sops-safe.sh
+++ b/skills/sops-age/scripts/sops-safe.sh
@@ -8,8 +8,8 @@
 # Usage:
 #   sops-safe.sh probe
 #   sops-safe.sh detect-age-identity
-#   sops-safe.sh with-age-key bws <PROJECT_ID> -- <command...>
-#   sops-safe.sh with-age-key file <KEY_FILE> -- <command...>
+#   sops-safe.sh with-age-key bws <PROJECT_ID> -- <sops-command...>
+#   sops-safe.sh with-age-key file <KEY_FILE> -- <sops-command...>
 #
 # probe prints one sanitized key=value line per fact on stdout:
 #   status= ready | sops_absent | age_absent | unavailable
@@ -18,8 +18,8 @@
 #
 # detect-age-identity never prints key material; exit 0 when present, 1 when absent.
 #
-# with-age-key runs the child with SOPS age identity available only inside the
-# child process, suppresses direct SOPS decrypt stdout, then unsets
+# with-age-key runs a supported direct SOPS operation with age identity
+# available only inside the child process, suppresses decrypt stdout, then unsets
 # SOPS_AGE_KEY and SOPS_AGE_KEY_FILE before exit.
 set -u
 
@@ -34,8 +34,8 @@ sops-safe.sh - safe helper for Mozilla SOPS and age
 Usage:
   sops-safe.sh probe
   sops-safe.sh detect-age-identity
-  sops-safe.sh with-age-key bws <PROJECT_ID> -- <command...>
-  sops-safe.sh with-age-key file <KEY_FILE> -- <command...>
+  sops-safe.sh with-age-key bws <PROJECT_ID> -- <sops-command...>
+  sops-safe.sh with-age-key file <KEY_FILE> -- <sops-command...>
 
 Never prints age private keys or decrypted secret values.
 EOF
@@ -129,13 +129,30 @@ assert_no_key_in_args() {
   done
 }
 
-is_sops_decrypt() {
+classify_sops_command() {
   local executable=${1:-} arg
   shift || true
   [ "${executable##*/}" = sops ] || return 1
   for arg in "$@"; do
     case "$arg" in
       -d|--decrypt|decrypt)
+        printf 'decrypt\n'
+        return 0
+        ;;
+      -e|--encrypt|encrypt)
+        printf 'encrypt\n'
+        return 0
+        ;;
+      edit)
+        printf 'edit\n'
+        return 0
+        ;;
+      updatekeys)
+        printf 'updatekeys\n'
+        return 0
+        ;;
+      -r|--rotate|rotate)
+        printf 'rotate\n'
         return 0
         ;;
       --)
@@ -147,7 +164,7 @@ is_sops_decrypt() {
 }
 
 cmd_with_age_key() {
-  local mode=${1:-}
+  local mode=${1:-} operation
   shift || true
   case "$mode" in
     bws)
@@ -158,9 +175,10 @@ cmd_with_age_key() {
       shift
       [ $# -gt 0 ] || die_usage "with-age-key bws requires a command after --"
       assert_no_key_in_args "$project_id" "$@"
+      operation=$(classify_sops_command "$@") || die_usage "with-age-key accepts direct sops decrypt, encrypt, edit, updatekeys, or rotate commands only"
       command -v bws >/dev/null 2>&1 || die_usage "bws is required for with-age-key bws"
       unset_age_identity
-      if is_sops_decrypt "$@"; then
+      if [ "$operation" = decrypt ]; then
         bws run --project-id "$project_id" -- "$@" >/dev/null
       else
         bws run --project-id "$project_id" -- "$@"
@@ -177,9 +195,10 @@ cmd_with_age_key() {
       shift
       [ $# -gt 0 ] || die_usage "with-age-key file requires a command after --"
       assert_no_key_in_args "$key_file" "$@"
+      operation=$(classify_sops_command "$@") || die_usage "with-age-key accepts direct sops decrypt, encrypt, edit, updatekeys, or rotate commands only"
       [ -r "$key_file" ] || die_usage "KEY_FILE is not readable"
       unset_age_identity
-      if is_sops_decrypt "$@"; then
+      if [ "$operation" = decrypt ]; then
         SOPS_AGE_KEY_FILE=$key_file "$@" >/dev/null
       else
         SOPS_AGE_KEY_FILE=$key_file "$@"

--- a/skills/sops-age/scripts/sops-safe.sh
+++ b/skills/sops-age/scripts/sops-safe.sh
@@ -19,7 +19,8 @@
 # detect-age-identity never prints key material; exit 0 when present, 1 when absent.
 #
 # with-age-key runs the child with SOPS age identity available only inside the
-# child process, then unsets SOPS_AGE_KEY and SOPS_AGE_KEY_FILE before exit.
+# child process, suppresses direct SOPS decrypt stdout, then unsets
+# SOPS_AGE_KEY and SOPS_AGE_KEY_FILE before exit.
 set -u
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -128,6 +129,23 @@ assert_no_key_in_args() {
   done
 }
 
+is_sops_decrypt() {
+  local executable=${1:-} arg
+  shift || true
+  [ "${executable##*/}" = sops ] || return 1
+  for arg in "$@"; do
+    case "$arg" in
+      -d|--decrypt|decrypt)
+        return 0
+        ;;
+      --)
+        return 1
+        ;;
+    esac
+  done
+  return 1
+}
+
 cmd_with_age_key() {
   local mode=${1:-}
   shift || true
@@ -142,7 +160,11 @@ cmd_with_age_key() {
       assert_no_key_in_args "$project_id" "$@"
       command -v bws >/dev/null 2>&1 || die_usage "bws is required for with-age-key bws"
       unset_age_identity
-      bws run --project-id "$project_id" -- "$@"
+      if is_sops_decrypt "$@"; then
+        bws run --project-id "$project_id" -- "$@" >/dev/null
+      else
+        bws run --project-id "$project_id" -- "$@"
+      fi
       local rc=$?
       unset_age_identity
       return "$rc"
@@ -157,7 +179,11 @@ cmd_with_age_key() {
       assert_no_key_in_args "$key_file" "$@"
       [ -r "$key_file" ] || die_usage "KEY_FILE is not readable"
       unset_age_identity
-      SOPS_AGE_KEY_FILE=$key_file "$@"
+      if is_sops_decrypt "$@"; then
+        SOPS_AGE_KEY_FILE=$key_file "$@" >/dev/null
+      else
+        SOPS_AGE_KEY_FILE=$key_file "$@"
+      fi
       local rc=$?
       unset_age_identity
       return "$rc"

--- a/skills/sops-age/scripts/sops-safe.sh
+++ b/skills/sops-age/scripts/sops-safe.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# sops-safe.sh - safe helper for Mozilla SOPS and age.
+#
+# Owned by skills/sops-age/SKILL.md. Never prints age private keys or decrypted
+# secret values. Consult `sops --help` and `age --help` for flags; this script
+# does not memorize CLI syntax beyond probes, redaction, and key injection.
+#
+# Usage:
+#   sops-safe.sh probe
+#   sops-safe.sh detect-age-identity
+#   sops-safe.sh redact-output
+#   sops-safe.sh with-age-key bws <PROJECT_ID> -- <command...>
+#   sops-safe.sh with-age-key file <KEY_FILE> -- <command...>
+#
+# probe prints one sanitized key=value line per fact on stdout:
+#   status= ready | sops_absent | age_absent | unavailable
+#   sops_version= version or none
+#   age_version= version or none
+#
+# detect-age-identity never prints key material; exit 0 when present, 1 when absent.
+#
+# with-age-key runs the child with SOPS age identity available only inside the
+# child process, then unsets SOPS_AGE_KEY and SOPS_AGE_KEY_FILE before exit.
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+AGE_KEY_PATTERN='AGE-SECRET-KEY-[A-Z0-9]+'
+
+usage() {
+  cat <<'EOF'
+sops-safe.sh - safe helper for Mozilla SOPS and age
+
+Usage:
+  sops-safe.sh probe
+  sops-safe.sh detect-age-identity
+  sops-safe.sh redact-output
+  sops-safe.sh with-age-key bws <PROJECT_ID> -- <command...>
+  sops-safe.sh with-age-key file <KEY_FILE> -- <command...>
+
+Never prints age private keys or decrypted secret values.
+EOF
+}
+
+die_usage() {
+  printf 'sops-safe: %s\n' "$1" >&2
+  usage >&2
+  exit 2
+}
+
+tool_version() {
+  local tool=$1
+  local output version
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    printf 'none\n'
+    return 0
+  fi
+  if ! output=$("$tool" --version 2>/dev/null); then
+    printf 'none\n'
+    return 0
+  fi
+  version=$(awk 'NF >= 2 {print $2; exit}' <<<"$output")
+  if [ -n "$version" ]; then
+    printf '%s\n' "$version"
+  else
+    printf 'none\n'
+  fi
+}
+
+cmd_probe() {
+  local sops_version age_version status
+  sops_version=$(tool_version sops)
+  age_version=$(tool_version age)
+  if [ "$sops_version" = none ]; then
+    status=sops_absent
+  elif [ "$age_version" = none ]; then
+    status=age_absent
+  else
+    status=ready
+  fi
+  printf 'status=%s sops_version=%s age_version=%s\n' "$status" "$sops_version" "$age_version"
+  exit 0
+}
+
+age_identity_present() {
+  if [ -n "${SOPS_AGE_KEY:-}" ]; then
+    printf 'yes\n'
+    return 0
+  fi
+  if [ -n "${SOPS_AGE_KEY_FILE:-}" ] && [ -r "${SOPS_AGE_KEY_FILE}" ]; then
+    printf 'yes\n'
+    return 0
+  fi
+  printf 'no\n'
+}
+
+age_identity_source() {
+  if [ -n "${SOPS_AGE_KEY:-}" ]; then
+    printf 'env\n'
+    return 0
+  fi
+  if [ -n "${SOPS_AGE_KEY_FILE:-}" ] && [ -r "${SOPS_AGE_KEY_FILE}" ]; then
+    printf 'file\n'
+    return 0
+  fi
+  printf 'none\n'
+}
+
+cmd_detect_age_identity() {
+  local present source
+  present=$(age_identity_present)
+  source=$(age_identity_source)
+  printf 'age_identity_present=%s source=%s\n' "$present" "$source"
+  if [ "$present" = yes ]; then
+    exit 0
+  fi
+  exit 1
+}
+
+redact_line() {
+  local line=$1
+  if [[ "$line" =~ $AGE_KEY_PATTERN ]]; then
+    printf '%s\n' "${line//$BASH_REMATCH/[REDACTED_AGE_KEY]}"
+    return 0
+  fi
+  if [[ "$line" =~ ^[[:space:]]*([A-Za-z0-9_.-]+):[[:space:]]*(.+)$ ]]; then
+    local key=${BASH_REMATCH[1]} value=${BASH_REMATCH[2]}
+    case "$key" in
+      value|stringData|password|token|secret|apiKey|api_key|private_key|client_secret)
+        printf '%s: [REDACTED]\n' "$key"
+        return 0
+        ;;
+    esac
+  fi
+  printf '%s\n' "$line"
+}
+
+cmd_redact_output() {
+  local line
+  while IFS= read -r line || [ -n "$line" ]; do
+    redact_line "$line"
+  done
+}
+
+unset_age_identity() {
+  unset SOPS_AGE_KEY SOPS_AGE_KEY_FILE
+}
+
+assert_no_key_in_args() {
+  local arg
+  for arg in "$@"; do
+    if [[ "$arg" =~ $AGE_KEY_PATTERN ]]; then
+      die_usage "refusing command with age private key in arguments"
+    fi
+  done
+}
+
+cmd_with_age_key() {
+  local mode=${1:-}
+  shift || true
+  case "$mode" in
+    bws)
+      local project_id=${1:-}
+      shift || true
+      [ -n "$project_id" ] || die_usage "with-age-key bws requires PROJECT_ID"
+      [ "${1:-}" = -- ] || die_usage "with-age-key bws requires -- before command"
+      shift
+      [ $# -gt 0 ] || die_usage "with-age-key bws requires a command after --"
+      assert_no_key_in_args "$project_id" "$@"
+      command -v bws >/dev/null 2>&1 || die_usage "bws is required for with-age-key bws"
+      unset_age_identity
+      bws run --project-id "$project_id" -- "$@"
+      local rc=$?
+      unset_age_identity
+      return "$rc"
+      ;;
+    file)
+      local key_file=${1:-}
+      shift || true
+      [ -n "$key_file" ] || die_usage "with-age-key file requires KEY_FILE"
+      [ "${1:-}" = -- ] || die_usage "with-age-key file requires -- before command"
+      shift
+      [ $# -gt 0 ] || die_usage "with-age-key file requires a command after --"
+      assert_no_key_in_args "$key_file" "$@"
+      [ -r "$key_file" ] || die_usage "KEY_FILE is not readable"
+      unset_age_identity
+      SOPS_AGE_KEY_FILE=$key_file "$@"
+      local rc=$?
+      unset_age_identity
+      return "$rc"
+      ;;
+    *)
+      die_usage "with-age-key mode must be bws or file"
+      ;;
+  esac
+}
+
+CMD=${1:-}
+shift || true
+
+case "$CMD" in
+  -h|--help|'')
+    usage
+    [ -n "$CMD" ] || exit 2
+    exit 0
+    ;;
+  probe)
+    [ $# -eq 0 ] || die_usage "probe takes no arguments"
+    cmd_probe
+    ;;
+  detect-age-identity)
+    [ $# -eq 0 ] || die_usage "detect-age-identity takes no arguments"
+    cmd_detect_age_identity
+    ;;
+  redact-output)
+    [ $# -eq 0 ] || die_usage "redact-output reads stdin and takes no arguments"
+    cmd_redact_output
+    ;;
+  with-age-key)
+    cmd_with_age_key "$@"
+    ;;
+  *)
+    die_usage "unknown command: $CMD"
+    ;;
+esac

--- a/skills/sops-age/scripts/sops-safe.sh
+++ b/skills/sops-age/scripts/sops-safe.sh
@@ -3,12 +3,11 @@
 #
 # Owned by skills/sops-age/SKILL.md. Never prints age private keys or decrypted
 # secret values. Consult `sops --help` and `age --help` for flags; this script
-# does not memorize CLI syntax beyond probes, redaction, and key injection.
+# does not memorize CLI syntax beyond probes and key injection.
 #
 # Usage:
 #   sops-safe.sh probe
 #   sops-safe.sh detect-age-identity
-#   sops-safe.sh redact-output
 #   sops-safe.sh with-age-key bws <PROJECT_ID> -- <command...>
 #   sops-safe.sh with-age-key file <KEY_FILE> -- <command...>
 #
@@ -34,7 +33,6 @@ sops-safe.sh - safe helper for Mozilla SOPS and age
 Usage:
   sops-safe.sh probe
   sops-safe.sh detect-age-identity
-  sops-safe.sh redact-output
   sops-safe.sh with-age-key bws <PROJECT_ID> -- <command...>
   sops-safe.sh with-age-key file <KEY_FILE> -- <command...>
 
@@ -117,31 +115,6 @@ cmd_detect_age_identity() {
   exit 1
 }
 
-redact_line() {
-  local line=$1
-  if [[ "$line" =~ $AGE_KEY_PATTERN ]]; then
-    printf '%s\n' "${line//$BASH_REMATCH/[REDACTED_AGE_KEY]}"
-    return 0
-  fi
-  if [[ "$line" =~ ^[[:space:]]*([A-Za-z0-9_.-]+):[[:space:]]*(.+)$ ]]; then
-    local key=${BASH_REMATCH[1]} value=${BASH_REMATCH[2]}
-    case "$key" in
-      value|stringData|password|token|secret|apiKey|api_key|private_key|client_secret)
-        printf '%s: [REDACTED]\n' "$key"
-        return 0
-        ;;
-    esac
-  fi
-  printf '%s\n' "$line"
-}
-
-cmd_redact_output() {
-  local line
-  while IFS= read -r line || [ -n "$line" ]; do
-    redact_line "$line"
-  done
-}
-
 unset_age_identity() {
   unset SOPS_AGE_KEY SOPS_AGE_KEY_FILE
 }
@@ -211,10 +184,6 @@ case "$CMD" in
   detect-age-identity)
     [ $# -eq 0 ] || die_usage "detect-age-identity takes no arguments"
     cmd_detect_age_identity
-    ;;
-  redact-output)
-    [ $# -eq 0 ] || die_usage "redact-output reads stdin and takes no arguments"
-    cmd_redact_output
     ;;
   with-age-key)
     cmd_with_age_key "$@"

--- a/tests/bws-safe.test.sh
+++ b/tests/bws-safe.test.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# Behavior tests for skills/bws/scripts/bws-safe.sh using synthetic bws fixtures.
+set -u
+
+# shellcheck source=tests/lib.sh disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+HELPER="$ROOT/skills/bws/scripts/bws-safe.sh"
+TMP_ROOT=$(fm_test_tmproot bws-safe-tests)
+
+make_fake_bws() {
+  local dir=$1 mode=${2:-authenticated}
+  local fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/bws" <<'SH'
+#!/usr/bin/env bash
+MODE="${FM_FAKE_BWS_MODE:-authenticated}"
+case "${1:-}" in
+  --version)
+    if [ "$MODE" = broken_version ]; then
+      exit 1
+    fi
+    printf 'bws 9.9.9\n'
+    exit 0
+    ;;
+  project)
+  case "${2:-}" in
+    list)
+      case "$MODE" in
+        authenticated|read_only) exit 0 ;;
+        no_token) printf "Error:\n   0: Missing access token\n" >&2; exit 1 ;;
+        invalid_token) printf "Error:\n   0: Doesn't contain a decryption key\n" >&2; exit 1 ;;
+        unauthorized) printf "Error:\n   0: 401 Unauthorized\n" >&2; exit 1 ;;
+        forbidden) printf "Error:\n   0: 403 Forbidden\n" >&2; exit 1 ;;
+        not_found) printf "Error:\n   0: 404 Not Found\n" >&2; exit 1 ;;
+        local_permission) printf "Error: Permission denied reading config\n" >&2; exit 1 ;;
+        absent) exit 127 ;;
+        *) printf "Error: unknown mode %s\n" "$MODE" >&2; exit 1 ;;
+      esac
+      ;;
+    get)
+      case "$MODE" in
+        empty_project|transient_list) exit 0 ;;
+        *) exit 1 ;;
+      esac
+      ;;
+  esac
+  ;;
+  secret)
+  case "${2:-}" in
+    list)
+      case "$MODE" in
+        duplicate)
+          printf '%s\n' '[{"id":"id-a","key":"dup","value":"one","projectId":"proj-1"},{"id":"id-b","key":"dup","value":"two","projectId":"proj-1"}]'
+          ;;
+        malformed)
+          printf '%s\n' '{invalid json'
+          ;;
+        invalid_id)
+          printf '%s\n' '[{"id":null,"key":"ONLY","projectId":"proj-1"}]'
+          ;;
+        empty_project)
+          printf "Error:\n   0: 404 Not Found\n" >&2
+          exit 1
+          ;;
+        transient_list)
+          printf "Error: request timed out\n" >&2
+          exit 1
+          ;;
+        authenticated|read_only)
+          printf '%s\n' '[{"id":"only-id","key":"ONLY","value":"secret-value","note":"sensitive-note","projectId":"proj-1"}]'
+          ;;
+        write_fail)
+          printf '%s\n' '[]'
+          ;;
+        *)
+          printf '%s\n' '[]'
+          ;;
+      esac
+      exit 0
+      ;;
+    create)
+      if [ "$MODE" = read_only ]; then
+        printf "Error:\n   0: 403 Forbidden\n" >&2
+        exit 1
+      fi
+      exit 0
+      ;;
+  esac
+  ;;
+esac
+printf 'unhandled bws fake: %s\n' "$*" >&2
+exit 1
+SH
+  chmod +x "$fakebin/bws"
+  printf '%s\n' "$fakebin"
+}
+
+run_with_fake() {
+  local mode=$1
+  shift
+  local fakebin case_dir isolated_home
+  case_dir="$TMP_ROOT/$mode-${RANDOM}"
+  isolated_home="$case_dir/home"
+  mkdir -p "$isolated_home"
+  fakebin=$(make_fake_bws "$case_dir" "$mode")
+  env -u BWS_ACCESS_TOKEN -u BWS_PROFILE -u BWS_CONFIG_FILE \
+    HOME="$isolated_home" FM_FAKE_BWS_MODE="$mode" PATH="$fakebin:$PATH" "$@"
+}
+
+test_probe_absent() {
+  local out fakebin isolated_home
+  fakebin="$TMP_ROOT/absent-only/bin"
+  isolated_home="$TMP_ROOT/absent-only/home"
+  mkdir -p "$fakebin" "$isolated_home"
+  out=$(env -u BWS_ACCESS_TOKEN -u BWS_PROFILE -u BWS_CONFIG_FILE \
+    HOME="$isolated_home" PATH="$fakebin:/usr/bin:/bin" "$HELPER" probe)
+  assert_contains "$out" 'status=unavailable' 'absent bws should report unavailable'
+  assert_contains "$out" 'version=none' 'absent bws should report version none'
+  pass 'probe classifies absent bws'
+}
+
+test_probe_broken_version() {
+  local out
+  out=$(run_with_fake broken_version env BWS_ACCESS_TOKEN=set "$HELPER" probe)
+  assert_contains "$out" 'status=unavailable' 'failed version command should report unavailable'
+  assert_contains "$out" 'version=none' 'failed version command should report version none'
+  pass 'probe classifies broken bws installation'
+}
+
+test_probe_no_token() {
+  local out
+  out=$(run_with_fake no_token env -u BWS_ACCESS_TOKEN "$HELPER" probe)
+  assert_contains "$out" 'status=no_token' 'missing token should report no_token'
+  assert_contains "$out" 'token_present=no' 'missing token should report token_present=no'
+  pass 'probe classifies missing BWS_ACCESS_TOKEN'
+}
+
+test_probe_invalid_token() {
+  local out
+  out=$(run_with_fake invalid_token env BWS_ACCESS_TOKEN=bad "$HELPER" probe)
+  assert_contains "$out" 'status=invalid_token' 'bad token should report invalid_token'
+  pass 'probe classifies invalid token'
+}
+
+test_probe_unauthorized_token() {
+  local out
+  out=$(run_with_fake unauthorized env BWS_ACCESS_TOKEN=bad "$HELPER" probe)
+  assert_contains "$out" 'status=invalid_token' '401 response should report invalid_token'
+  pass 'probe classifies rejected token'
+}
+
+test_probe_authenticated_read_only() {
+  local out
+  out=$(run_with_fake read_only env BWS_ACCESS_TOKEN=readonly "$HELPER" probe)
+  assert_contains "$out" 'status=authenticated' 'read-only token should still list projects'
+  pass 'probe treats read-only list success as authenticated'
+}
+
+test_probe_not_found() {
+  local out
+  out=$(run_with_fake not_found env BWS_ACCESS_TOKEN=set "$HELPER" probe)
+  assert_contains "$out" 'status=indeterminate' '404 response should report indeterminate'
+  pass 'probe leaves ambiguous not-found response indeterminate'
+}
+
+test_probe_local_permission_failure() {
+  local out
+  out=$(run_with_fake local_permission env BWS_ACCESS_TOKEN=set "$HELPER" probe)
+  assert_contains "$out" 'status=indeterminate' 'local permission failure should report indeterminate'
+  pass 'probe leaves local permission failures indeterminate'
+}
+
+test_redact_metadata() {
+  local out
+  out=$(printf '%s\n' '{"id":"x","key":"k","value":"secret","note":"credential note"}' | "$HELPER" redact-json)
+  assert_contains "$out" '[REDACTED]' 'redact-json should replace value'
+  assert_not_contains "$out" 'secret' 'redact-json must not leak original value'
+  assert_not_contains "$out" 'credential note' 'redact-json must not leak notes'
+  pass 'redact-json redacts secret values and notes'
+}
+
+test_list_metadata_redacts() {
+  local out
+  out=$(run_with_fake authenticated env BWS_ACCESS_TOKEN=ok "$HELPER" list-metadata proj-1)
+  assert_contains "$out" '[REDACTED]' 'list-metadata should redact values'
+  assert_contains "$out" '"key": "ONLY"' 'list-metadata should keep metadata'
+  assert_not_contains "$out" 'secret-value' 'list-metadata must not leak values'
+  assert_not_contains "$out" 'sensitive-note' 'list-metadata must not leak notes'
+  pass 'list-metadata returns redacted secret metadata'
+}
+
+test_resolve_duplicate_names() {
+  local rc=0
+  set +e
+  run_with_fake duplicate env BWS_ACCESS_TOKEN=ok "$HELPER" resolve-id proj-1 dup >/dev/null 2>"$TMP_ROOT/dup.err"
+  rc=$?
+  set -e
+  [ "$rc" -eq 2 ] || fail "duplicate key should exit 2, got $rc"
+  assert_contains "$(<"$TMP_ROOT/dup.err")" 'duplicate secret key' 'duplicate should explain ambiguity'
+  pass 'resolve-id refuses duplicate secret names'
+}
+
+test_resolve_malformed_json() {
+  local rc=0
+  set +e
+  run_with_fake malformed env BWS_ACCESS_TOKEN=ok "$HELPER" resolve-id proj-1 ONLY >/dev/null 2>"$TMP_ROOT/malformed.err"
+  rc=$?
+  set -e
+  [ "$rc" -eq 3 ] || fail "malformed JSON should exit 3, got $rc"
+  assert_not_contains "$(<"$TMP_ROOT/malformed.err")" 'duplicate secret key' 'malformed JSON must not report duplicates'
+  pass 'resolve-id rejects malformed CLI JSON'
+}
+
+test_resolve_invalid_id() {
+  local rc=0 out
+  set +e
+  out=$(run_with_fake invalid_id env BWS_ACCESS_TOKEN=ok "$HELPER" resolve-id proj-1 ONLY 2>"$TMP_ROOT/invalid-id.err")
+  rc=$?
+  set -e
+  [ "$rc" -eq 3 ] || fail "invalid secret ID should exit 3, got $rc"
+  [ -z "$out" ] || fail "invalid secret ID must not produce output, got $out"
+  pass 'resolve-id rejects invalid secret IDs'
+}
+
+test_resolve_empty_project() {
+  local rc=0 out
+  set +e
+  out=$(run_with_fake empty_project env BWS_ACCESS_TOKEN=ok "$HELPER" resolve-id proj-1 ONLY)
+  rc=$?
+  set -e
+  [ "$rc" -eq 1 ] || fail "empty project should report absent key with exit 1, got $rc"
+  [ -z "$out" ] || fail "empty project must not produce output, got $out"
+  pass 'resolve-id handles empty projects as absent keys'
+}
+
+test_resolve_transient_list_failure() {
+  local rc=0 out
+  set +e
+  out=$(run_with_fake transient_list env BWS_ACCESS_TOKEN=ok "$HELPER" resolve-id proj-1 ONLY)
+  rc=$?
+  set -e
+  [ "$rc" -eq 3 ] || fail "transient list failure should exit 3, got $rc"
+  [ -z "$out" ] || fail "transient list failure must not produce output, got $out"
+  pass 'resolve-id preserves transient list failures'
+}
+
+test_probe_absent
+test_probe_broken_version
+test_probe_no_token
+test_probe_invalid_token
+test_probe_unauthorized_token
+test_probe_authenticated_read_only
+test_probe_not_found
+test_probe_local_permission_failure
+test_redact_metadata
+test_list_metadata_redacts
+test_resolve_duplicate_names
+test_resolve_malformed_json
+test_resolve_invalid_id
+test_resolve_empty_project
+test_resolve_transient_list_failure

--- a/tests/sops-safe.test.sh
+++ b/tests/sops-safe.test.sh
@@ -27,6 +27,9 @@ case "${1:-}" in
     ;;
   --decrypt)
     if [ -n "${SOPS_AGE_KEY:-}${SOPS_AGE_KEY_FILE:-}" ] || [ -n "${FM_FAKE_BWS_INJECTED:-}" ]; then
+      if [ -n "${FM_FAKE_DECRYPT_MARKER:-}" ]; then
+        : > "$FM_FAKE_DECRYPT_MARKER"
+      fi
       printf 'password: super-secret-value\n'
       exit 0
     fi
@@ -164,20 +167,6 @@ test_detect_age_identity_file() {
   pass 'detect-age-identity detects SOPS_AGE_KEY_FILE without echoing it'
 }
 
-test_redact_output_scrubs_keys_and_values() {
-  local out
-  out=$(printf '%s\n' \
-    'AGE-SECRET-KEY-ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AB' \
-    'password: plain-text-secret' \
-    'username: admin' | "$HELPER" redact-output)
-  assert_contains "$out" '[REDACTED_AGE_KEY]' 'redact should scrub age private keys'
-  assert_not_contains "$out" 'AGE-SECRET-KEY-' 'redact must not leave key prefix'
-  assert_contains "$out" 'password: [REDACTED]' 'redact should scrub password values'
-  assert_contains "$out" 'username: admin' 'redact should keep non-secret fields'
-  assert_not_contains "$out" 'plain-text-secret' 'redact must not leak secret values'
-  pass 'redact-output scrubs keys and sensitive field values'
-}
-
 test_with_age_key_refuses_key_in_args() {
   local key_file rc=0
   key_file="$TMP_ROOT/refuse-key-args.txt"
@@ -195,29 +184,30 @@ test_with_age_key_refuses_key_in_args() {
 }
 
 test_with_age_key_file_mode() {
-  local key_file out redacted case_dir fakebin
+  local key_file marker case_dir fakebin
   key_file="$TMP_ROOT/with-key-file.txt"
   printf 'AGE-SECRET-KEY-TESTKEYTESTKEYTESTKEYTESTKEYTESTKEYTEST\n' > "$key_file"
   chmod 600 "$key_file"
   case_dir="$TMP_ROOT/with-file-mode"
+  marker="$case_dir/decrypted"
   fakebin=$(make_fake_sops_age "$case_dir" ready ready)
-  out=$(env -u SOPS_AGE_KEY -u SOPS_AGE_KEY_FILE SOPS_AGE_KEY_FILE=should-be-cleared \
-    PATH="$fakebin:/usr/bin:/bin" "$HELPER" with-age-key file "$key_file" -- sops --decrypt secret.enc.yaml)
-  assert_contains "$out" 'password:' 'with-age-key file should run child with identity'
-  redacted=$(printf '%s\n' "$out" | "$HELPER" redact-output)
-  assert_not_contains "$redacted" 'super-secret-value' 'redact-output should scrub decrypted values'
+  env -u SOPS_AGE_KEY -u SOPS_AGE_KEY_FILE SOPS_AGE_KEY_FILE=should-be-cleared \
+    FM_FAKE_DECRYPT_MARKER="$marker" PATH="$fakebin:/usr/bin:/bin" \
+    "$HELPER" with-age-key file "$key_file" -- sops --decrypt secret.enc.yaml >/dev/null
+  [ -f "$marker" ] || fail 'with-age-key file should run child with identity'
   pass 'with-age-key file mode injects identity for child command'
 }
 
 test_with_age_key_bws_mode() {
-  local out case_dir fakebin bwsbin
+  local marker case_dir fakebin bwsbin
   case_dir="$TMP_ROOT/with-bws-mode"
+  marker="$case_dir/decrypted"
   fakebin=$(make_fake_sops_age "$case_dir" ready ready)
   bwsbin=$(make_fake_bws_run "$case_dir")
-  out=$(env -u SOPS_AGE_KEY -u SOPS_AGE_KEY_FILE \
+  env -u SOPS_AGE_KEY -u SOPS_AGE_KEY_FILE FM_FAKE_DECRYPT_MARKER="$marker" \
     PATH="$bwsbin:$case_dir/fakebin:/usr/bin:/bin" \
-    "$HELPER" with-age-key bws proj-1 -- sops --decrypt secret.enc.yaml)
-  assert_contains "$out" 'password:' 'with-age-key bws should run child through bws run'
+    "$HELPER" with-age-key bws proj-1 -- sops --decrypt secret.enc.yaml >/dev/null
+  [ -f "$marker" ] || fail 'with-age-key bws should run child through bws run'
   pass 'with-age-key bws mode delegates to bws run'
 }
 
@@ -244,7 +234,6 @@ test_probe_age_absent
 test_detect_age_identity_absent
 test_detect_age_identity_env
 test_detect_age_identity_file
-test_redact_output_scrubs_keys_and_values
 test_with_age_key_refuses_key_in_args
 test_with_age_key_file_mode
 test_with_age_key_bws_mode

--- a/tests/sops-safe.test.sh
+++ b/tests/sops-safe.test.sh
@@ -25,7 +25,7 @@ case "${1:-}" in
       *) printf 'sops 3.9.0\n'; exit 0 ;;
     esac
     ;;
-  --decrypt)
+  -d|--decrypt|decrypt)
     if [ -n "${SOPS_AGE_KEY:-}${SOPS_AGE_KEY_FILE:-}" ] || [ -n "${FM_FAKE_BWS_INJECTED:-}" ]; then
       if [ -n "${FM_FAKE_DECRYPT_MARKER:-}" ]; then
         : > "$FM_FAKE_DECRYPT_MARKER"
@@ -184,30 +184,32 @@ test_with_age_key_refuses_key_in_args() {
 }
 
 test_with_age_key_file_mode() {
-  local key_file marker case_dir fakebin
+  local key_file marker case_dir fakebin out
   key_file="$TMP_ROOT/with-key-file.txt"
   printf 'AGE-SECRET-KEY-TESTKEYTESTKEYTESTKEYTESTKEYTESTKEYTEST\n' > "$key_file"
   chmod 600 "$key_file"
   case_dir="$TMP_ROOT/with-file-mode"
   marker="$case_dir/decrypted"
   fakebin=$(make_fake_sops_age "$case_dir" ready ready)
-  env -u SOPS_AGE_KEY -u SOPS_AGE_KEY_FILE SOPS_AGE_KEY_FILE=should-be-cleared \
+  out=$(env -u SOPS_AGE_KEY -u SOPS_AGE_KEY_FILE SOPS_AGE_KEY_FILE=should-be-cleared \
     FM_FAKE_DECRYPT_MARKER="$marker" PATH="$fakebin:/usr/bin:/bin" \
-    "$HELPER" with-age-key file "$key_file" -- sops --decrypt secret.enc.yaml >/dev/null
+    "$HELPER" with-age-key file "$key_file" -- sops --decrypt secret.enc.yaml)
   [ -f "$marker" ] || fail 'with-age-key file should run child with identity'
+  [ -z "$out" ] || fail 'with-age-key file must suppress decrypted stdout'
   pass 'with-age-key file mode injects identity for child command'
 }
 
 test_with_age_key_bws_mode() {
-  local marker case_dir fakebin bwsbin
+  local marker case_dir fakebin bwsbin out
   case_dir="$TMP_ROOT/with-bws-mode"
   marker="$case_dir/decrypted"
   fakebin=$(make_fake_sops_age "$case_dir" ready ready)
   bwsbin=$(make_fake_bws_run "$case_dir")
-  env -u SOPS_AGE_KEY -u SOPS_AGE_KEY_FILE FM_FAKE_DECRYPT_MARKER="$marker" \
+  out=$(env -u SOPS_AGE_KEY -u SOPS_AGE_KEY_FILE FM_FAKE_DECRYPT_MARKER="$marker" \
     PATH="$bwsbin:$case_dir/fakebin:/usr/bin:/bin" \
-    "$HELPER" with-age-key bws proj-1 -- sops --decrypt secret.enc.yaml >/dev/null
+    "$HELPER" with-age-key bws proj-1 -- sops -d secret.enc.yaml)
   [ -f "$marker" ] || fail 'with-age-key bws should run child through bws run'
+  [ -z "$out" ] || fail 'with-age-key bws must suppress decrypted stdout'
   pass 'with-age-key bws mode delegates to bws run'
 }
 

--- a/tests/sops-safe.test.sh
+++ b/tests/sops-safe.test.sh
@@ -17,6 +17,23 @@ make_fake_sops_age() {
   cat > "$fakebin/sops" <<'SH'
 #!/usr/bin/env bash
 MODE="${FM_FAKE_SOPS_MODE:-ready}"
+DECRYPT_REQUESTED=0
+for ARG in "$@"; do
+  case "$ARG" in
+    -d|--decrypt|decrypt) DECRYPT_REQUESTED=1 ;;
+  esac
+done
+if [ "$DECRYPT_REQUESTED" -eq 1 ]; then
+  if [ -n "${SOPS_AGE_KEY:-}${SOPS_AGE_KEY_FILE:-}" ] || [ -n "${FM_FAKE_BWS_INJECTED:-}" ]; then
+    if [ -n "${FM_FAKE_DECRYPT_MARKER:-}" ]; then
+      : > "$FM_FAKE_DECRYPT_MARKER"
+    fi
+    printf 'password: super-secret-value\n'
+    exit 0
+  fi
+  printf 'sops: failed to decrypt\n' >&2
+  exit 1
+fi
 case "${1:-}" in
   --version)
     case "$MODE" in
@@ -24,17 +41,6 @@ case "${1:-}" in
       broken) exit 1 ;;
       *) printf 'sops 3.9.0\n'; exit 0 ;;
     esac
-    ;;
-  -d|--decrypt|decrypt)
-    if [ -n "${SOPS_AGE_KEY:-}${SOPS_AGE_KEY_FILE:-}" ] || [ -n "${FM_FAKE_BWS_INJECTED:-}" ]; then
-      if [ -n "${FM_FAKE_DECRYPT_MARKER:-}" ]; then
-        : > "$FM_FAKE_DECRYPT_MARKER"
-      fi
-      printf 'password: super-secret-value\n'
-      exit 0
-    fi
-    printf 'sops: failed to decrypt\n' >&2
-    exit 1
     ;;
   edit)
     exit 0
@@ -234,6 +240,23 @@ test_with_age_key_refuses_indirect_commands() {
   pass 'with-age-key refuses indirect decrypt commands'
 }
 
+test_with_age_key_refuses_conflicting_operations() {
+  local key_file case_dir fakebin rc=0 out
+  key_file="$TMP_ROOT/refuse-conflicting.txt"
+  printf 'AGE-SECRET-KEY-TESTKEYTESTKEYTESTKEYTESTKEYTESTKEYTEST\n' > "$key_file"
+  chmod 600 "$key_file"
+  case_dir="$TMP_ROOT/refuse-conflicting"
+  fakebin=$(make_fake_sops_age "$case_dir" ready ready)
+  set +e
+  out=$(env -u SOPS_AGE_KEY -u SOPS_AGE_KEY_FILE PATH="$fakebin:/usr/bin:/bin" \
+    "$HELPER" with-age-key file "$key_file" -- sops encrypt --decrypt 2>&1)
+  rc=$?
+  set -e
+  [ "$rc" -eq 2 ] || fail "conflicting operations should exit 2, got $rc"
+  assert_not_contains "$out" 'super-secret-value' 'refused conflicting operations must not print plaintext'
+  pass 'with-age-key refuses conflicting operation tokens'
+}
+
 test_with_age_key_unsets_identity_after() {
   local key_file rc=0
   key_file="$TMP_ROOT/unset-after.txt"
@@ -261,4 +284,5 @@ test_with_age_key_refuses_key_in_args
 test_with_age_key_file_mode
 test_with_age_key_bws_mode
 test_with_age_key_refuses_indirect_commands
+test_with_age_key_refuses_conflicting_operations
 test_with_age_key_unsets_identity_after

--- a/tests/sops-safe.test.sh
+++ b/tests/sops-safe.test.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# Behavior tests for skills/sops-age/scripts/sops-safe.sh using synthetic fixtures.
+set -u
+
+# shellcheck source=tests/lib.sh disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+HELPER="$ROOT/skills/sops-age/scripts/sops-safe.sh"
+TMP_ROOT=$(fm_test_tmproot sops-safe-tests)
+
+chmod +x "$HELPER"
+
+make_fake_sops_age() {
+  local dir=$1 sops_mode=${2:-ready} age_mode=${3:-ready}
+  local fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/sops" <<'SH'
+#!/usr/bin/env bash
+MODE="${FM_FAKE_SOPS_MODE:-ready}"
+case "${1:-}" in
+  --version)
+    case "$MODE" in
+      absent) exit 127 ;;
+      broken) exit 1 ;;
+      *) printf 'sops 3.9.0\n'; exit 0 ;;
+    esac
+    ;;
+  --decrypt)
+    if [ -n "${SOPS_AGE_KEY:-}${SOPS_AGE_KEY_FILE:-}" ] || [ -n "${FM_FAKE_BWS_INJECTED:-}" ]; then
+      printf 'password: super-secret-value\n'
+      exit 0
+    fi
+    printf 'sops: failed to decrypt\n' >&2
+    exit 1
+    ;;
+esac
+printf 'unhandled sops fake: %s\n' "$*" >&2
+exit 1
+SH
+  cat > "$fakebin/age" <<'SH'
+#!/usr/bin/env bash
+MODE="${FM_FAKE_AGE_MODE:-ready}"
+case "${1:-}" in
+  --version)
+    case "$MODE" in
+      absent) exit 127 ;;
+      broken) exit 1 ;;
+      *) printf 'age 1.2.0\n'; exit 0 ;;
+    esac
+    ;;
+esac
+printf 'unhandled age fake: %s\n' "$*" >&2
+exit 1
+SH
+  chmod +x "$fakebin/sops" "$fakebin/age"
+  printf '%s\n' "$fakebin"
+}
+
+make_fake_bws_run() {
+  local dir=$1
+  local fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/bws" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+  run)
+    shift
+    [ "${1:-}" = --project-id ] || exit 1
+    shift 2
+    [ "${1:-}" = -- ] || exit 1
+    shift
+    FM_FAKE_BWS_INJECTED=1 SOPS_AGE_KEY_FILE=/dev/null "$@"
+    ;;
+  *)
+    printf 'unhandled bws fake: %s\n' "$*" >&2
+    exit 1
+    ;;
+esac
+SH
+  chmod +x "$fakebin/bws"
+  printf '%s\n' "$fakebin"
+}
+
+run_with_fake_tools() {
+  local sops_mode=$1 age_mode=$2
+  shift 2
+  local case_dir isolated_home fakebin
+  case_dir="$TMP_ROOT/tools-${sops_mode}-${age_mode}-${RANDOM}"
+  isolated_home="$case_dir/home"
+  mkdir -p "$isolated_home"
+  fakebin=$(make_fake_sops_age "$case_dir" "$sops_mode" "$age_mode")
+  env -u SOPS_AGE_KEY -u SOPS_AGE_KEY_FILE -u FM_FAKE_BWS_INJECTED \
+    HOME="$isolated_home" FM_FAKE_SOPS_MODE="$sops_mode" FM_FAKE_AGE_MODE="$age_mode" \
+    PATH="$fakebin:/usr/bin:/bin" "$@"
+}
+
+test_probe_ready() {
+  local out
+  out=$(run_with_fake_tools ready ready "$HELPER" probe)
+  assert_contains "$out" 'status=ready' 'ready install should report ready'
+  assert_contains "$out" 'sops_version=3.9.0' 'ready install should report sops version'
+  assert_contains "$out" 'age_version=1.2.0' 'ready install should report age version'
+  pass 'probe reports ready when both tools are present'
+}
+
+test_probe_sops_absent() {
+  local case_dir out
+  case_dir="$TMP_ROOT/sops-missing"
+  make_fake_sops_age "$case_dir" absent ready >/dev/null
+  rm -f "$case_dir/fakebin/sops"
+  out=$(env -u SOPS_AGE_KEY -u SOPS_AGE_KEY_FILE PATH="$case_dir/fakebin:/usr/bin:/bin" "$HELPER" probe)
+  assert_contains "$out" 'status=sops_absent' 'missing sops should report sops_absent'
+  pass 'probe classifies absent sops'
+}
+
+test_probe_age_absent() {
+  local case_dir out
+  case_dir="$TMP_ROOT/age-missing"
+  make_fake_sops_age "$case_dir" ready absent >/dev/null
+  rm -f "$case_dir/fakebin/age"
+  out=$(env HOME="$TMP_ROOT/age-missing/home" PATH="$case_dir/fakebin:/usr/bin:/bin" "$HELPER" probe)
+  assert_contains "$out" 'status=age_absent' 'missing age should report age_absent'
+  pass 'probe classifies absent age'
+}
+
+test_detect_age_identity_absent() {
+  local rc=0 out
+  set +e
+  out=$(env -u SOPS_AGE_KEY -u SOPS_AGE_KEY_FILE "$HELPER" detect-age-identity)
+  rc=$?
+  set -e
+  [ "$rc" -eq 1 ] || fail "absent identity should exit 1, got $rc"
+  assert_contains "$out" 'age_identity_present=no' 'absent identity should report no'
+  assert_not_contains "$out" 'AGE-SECRET-KEY' 'detect must never print keys'
+  pass 'detect-age-identity reports absent without leaking keys'
+}
+
+test_detect_age_identity_env() {
+  local out rc=0
+  set +e
+  out=$(env SOPS_AGE_KEY='AGE-SECRET-KEY-TESTKEYTESTKEYTESTKEYTESTKEYTESTKEYTEST' \
+    "$HELPER" detect-age-identity)
+  rc=$?
+  set -e
+  [ "$rc" -eq 0 ] || fail "env identity should exit 0, got $rc"
+  assert_contains "$out" 'age_identity_present=yes' 'env identity should report yes'
+  assert_contains "$out" 'source=env' 'env identity should report source env'
+  assert_not_contains "$out" 'TESTKEY' 'detect must never print key material'
+  pass 'detect-age-identity detects SOPS_AGE_KEY without echoing it'
+}
+
+test_detect_age_identity_file() {
+  local key_file out rc=0
+  key_file="$TMP_ROOT/test-age-key.txt"
+  printf 'AGE-SECRET-KEY-TESTKEYTESTKEYTESTKEYTESTKEYTESTKEYTEST\n' > "$key_file"
+  chmod 600 "$key_file"
+  set +e
+  out=$(env -u SOPS_AGE_KEY SOPS_AGE_KEY_FILE="$key_file" "$HELPER" detect-age-identity)
+  rc=$?
+  set -e
+  [ "$rc" -eq 0 ] || fail "file identity should exit 0, got $rc"
+  assert_contains "$out" 'source=file' 'file identity should report source file'
+  assert_not_contains "$out" 'TESTKEY' 'detect must never print key material'
+  pass 'detect-age-identity detects SOPS_AGE_KEY_FILE without echoing it'
+}
+
+test_redact_output_scrubs_keys_and_values() {
+  local out
+  out=$(printf '%s\n' \
+    'AGE-SECRET-KEY-ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AB' \
+    'password: plain-text-secret' \
+    'username: admin' | "$HELPER" redact-output)
+  assert_contains "$out" '[REDACTED_AGE_KEY]' 'redact should scrub age private keys'
+  assert_not_contains "$out" 'AGE-SECRET-KEY-' 'redact must not leave key prefix'
+  assert_contains "$out" 'password: [REDACTED]' 'redact should scrub password values'
+  assert_contains "$out" 'username: admin' 'redact should keep non-secret fields'
+  assert_not_contains "$out" 'plain-text-secret' 'redact must not leak secret values'
+  pass 'redact-output scrubs keys and sensitive field values'
+}
+
+test_with_age_key_refuses_key_in_args() {
+  local key_file rc=0
+  key_file="$TMP_ROOT/refuse-key-args.txt"
+  printf 'AGE-SECRET-KEY-TESTKEYTESTKEYTESTKEYTESTKEYTESTKEYTEST\n' > "$key_file"
+  chmod 600 "$key_file"
+  set +e
+  "$HELPER" with-age-key file "$key_file" -- sops --decrypt \
+    'AGE-SECRET-KEY-ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AB' >/dev/null 2>"$TMP_ROOT/key-arg.err"
+  rc=$?
+  set -e
+  [ "$rc" -eq 2 ] || fail "key in args should exit 2, got $rc"
+  assert_contains "$(<"$TMP_ROOT/key-arg.err")" 'refusing command with age private key' \
+    'with-age-key should refuse key material in arguments'
+  pass 'with-age-key refuses age private keys in command arguments'
+}
+
+test_with_age_key_file_mode() {
+  local key_file out redacted case_dir fakebin
+  key_file="$TMP_ROOT/with-key-file.txt"
+  printf 'AGE-SECRET-KEY-TESTKEYTESTKEYTESTKEYTESTKEYTESTKEYTEST\n' > "$key_file"
+  chmod 600 "$key_file"
+  case_dir="$TMP_ROOT/with-file-mode"
+  fakebin=$(make_fake_sops_age "$case_dir" ready ready)
+  out=$(env -u SOPS_AGE_KEY -u SOPS_AGE_KEY_FILE SOPS_AGE_KEY_FILE=should-be-cleared \
+    PATH="$fakebin:/usr/bin:/bin" "$HELPER" with-age-key file "$key_file" -- sops --decrypt secret.enc.yaml)
+  assert_contains "$out" 'password:' 'with-age-key file should run child with identity'
+  redacted=$(printf '%s\n' "$out" | "$HELPER" redact-output)
+  assert_not_contains "$redacted" 'super-secret-value' 'redact-output should scrub decrypted values'
+  pass 'with-age-key file mode injects identity for child command'
+}
+
+test_with_age_key_bws_mode() {
+  local out case_dir fakebin bwsbin
+  case_dir="$TMP_ROOT/with-bws-mode"
+  fakebin=$(make_fake_sops_age "$case_dir" ready ready)
+  bwsbin=$(make_fake_bws_run "$case_dir")
+  out=$(env -u SOPS_AGE_KEY -u SOPS_AGE_KEY_FILE \
+    PATH="$bwsbin:$case_dir/fakebin:/usr/bin:/bin" \
+    "$HELPER" with-age-key bws proj-1 -- sops --decrypt secret.enc.yaml)
+  assert_contains "$out" 'password:' 'with-age-key bws should run child through bws run'
+  pass 'with-age-key bws mode delegates to bws run'
+}
+
+test_with_age_key_unsets_identity_after() {
+  local key_file rc=0
+  key_file="$TMP_ROOT/unset-after.txt"
+  printf 'AGE-SECRET-KEY-TESTKEYTESTKEYTESTKEYTESTKEYTESTKEYTEST\n' > "$key_file"
+  chmod 600 "$key_file"
+  case_dir="$TMP_ROOT/unset-after"
+  make_fake_sops_age "$case_dir" ready ready >/dev/null
+  env -u SOPS_AGE_KEY -u SOPS_AGE_KEY_FILE PATH="$case_dir/fakebin:/usr/bin:/bin" \
+    "$HELPER" with-age-key file "$key_file" -- true
+  set +e
+  env -u SOPS_AGE_KEY -u SOPS_AGE_KEY_FILE "$HELPER" detect-age-identity >/dev/null
+  rc=$?
+  set -e
+  [ "$rc" -eq 1 ] || fail 'parent shell should have no age identity after with-age-key completes'
+  pass 'with-age-key does not leave age identity in the parent shell'
+}
+
+test_probe_ready
+test_probe_sops_absent
+test_probe_age_absent
+test_detect_age_identity_absent
+test_detect_age_identity_env
+test_detect_age_identity_file
+test_redact_output_scrubs_keys_and_values
+test_with_age_key_refuses_key_in_args
+test_with_age_key_file_mode
+test_with_age_key_bws_mode
+test_with_age_key_unsets_identity_after

--- a/tests/sops-safe.test.sh
+++ b/tests/sops-safe.test.sh
@@ -36,6 +36,9 @@ case "${1:-}" in
     printf 'sops: failed to decrypt\n' >&2
     exit 1
     ;;
+  edit)
+    exit 0
+    ;;
 esac
 printf 'unhandled sops fake: %s\n' "$*" >&2
 exit 1
@@ -213,6 +216,24 @@ test_with_age_key_bws_mode() {
   pass 'with-age-key bws mode delegates to bws run'
 }
 
+test_with_age_key_refuses_indirect_commands() {
+  local key_file case_dir fakebin rc=0 out
+  key_file="$TMP_ROOT/refuse-indirect.txt"
+  printf 'AGE-SECRET-KEY-TESTKEYTESTKEYTESTKEYTESTKEYTESTKEYTEST\n' > "$key_file"
+  chmod 600 "$key_file"
+  case_dir="$TMP_ROOT/refuse-indirect"
+  fakebin=$(make_fake_sops_age "$case_dir" ready ready)
+  set +e
+  out=$(env -u SOPS_AGE_KEY -u SOPS_AGE_KEY_FILE PATH="$fakebin:/usr/bin:/bin" \
+    "$HELPER" with-age-key file "$key_file" -- env sops --decrypt secret.enc.yaml 2>&1)
+  rc=$?
+  set -e
+  [ "$rc" -eq 2 ] || fail "indirect decrypt should exit 2, got $rc"
+  assert_not_contains "$out" 'super-secret-value' 'refused indirect decrypt must not print plaintext'
+  assert_contains "$out" 'accepts direct sops' 'indirect decrypt should explain the direct-command boundary'
+  pass 'with-age-key refuses indirect decrypt commands'
+}
+
 test_with_age_key_unsets_identity_after() {
   local key_file rc=0
   key_file="$TMP_ROOT/unset-after.txt"
@@ -221,7 +242,7 @@ test_with_age_key_unsets_identity_after() {
   case_dir="$TMP_ROOT/unset-after"
   make_fake_sops_age "$case_dir" ready ready >/dev/null
   env -u SOPS_AGE_KEY -u SOPS_AGE_KEY_FILE PATH="$case_dir/fakebin:/usr/bin:/bin" \
-    "$HELPER" with-age-key file "$key_file" -- true
+    "$HELPER" with-age-key file "$key_file" -- sops edit secret.enc.yaml
   set +e
   env -u SOPS_AGE_KEY -u SOPS_AGE_KEY_FILE "$HELPER" detect-age-identity >/dev/null
   rc=$?
@@ -239,4 +260,5 @@ test_detect_age_identity_file
 test_with_age_key_refuses_key_in_args
 test_with_age_key_file_mode
 test_with_age_key_bws_mode
+test_with_age_key_refuses_indirect_commands
 test_with_age_key_unsets_identity_after


### PR DESCRIPTION
## Intent

Create the Firstmate-owned public sops-age skill approved in firstmate-iafk-tool-skills-plan report. Follow the established bws ownership pattern: authoritative public procedure under skills/sops-age/ and concise internal stub under .agents/skills/sops-age/. Add one precise trigger to AGENTS.md section 13. Cover safe SOPS and age probe, encrypt, decrypt, edit, recipient update, data-key rotation, verification, cleanup, and failure handling. Enforce separate environment recipients without embedding IAFK-specific names. Permit age private-key use only inside a trusted bws run child process or through an operator-managed file outside chat. Never print, log, commit, or place private keys or decrypted values in visible command arguments. Require explicit authority for encryption, edit, rotation, and any operation that changes files, keys, or Secrets. Add a minimal helper only where deterministic enforcement provides value. Add executable behavior tests with fake tools and no real credentials or network. Use one sentence per Markdown line, plain dashes, and no agent co-author.

## What Changed

- Add public `bws` and `sops-age` skills covering safe secrets access, encryption workflows, authorization boundaries, failure handling, and verification.
- Add guarded helpers for redacted BWS inspection and private-key-safe SOPS/age execution through operator-managed files or trusted `bws run` children.
- Register internal loader stubs and documentation audiences, and add fake-tool behavior tests for both helpers without real credentials or network access.

## Risk Assessment

✅ Low: The security-sensitive helper is narrowly scoped, prior plaintext-output bypasses are closed at the wrapper boundary, and the executable tests cover the concrete regression paths without source-content-only assertions.

## Testing

Targeted fake-tool tests and an end-user CLI workflow exercised safe probing, sanitized identity detection, file- and bws-child key injection, plaintext suppression, unsafe-command refusal, and parent-shell cleanup; all passed without credentials or network, with a CLI transcript captured as evidence.

<details>
<summary>Evidence: End-user sops-age safety workflow</summary>

Source: [End-user sops-age safety workflow](https://github.com/prandelicious/firstmate/blob/117f93122f95fba401360e44494e659f895726c4/.no-mistakes/evidence/fm/firstmate-sops-age-skill/sops-age-cli-transcript.txt)

`Shows ready tool discovery, source-only identity detection, successful file- and bws-backed decrypts emitting zero plaintext bytes, and rejection of an indirect command.`

```text
$ sops-safe.sh probe
status=ready sops_version=3.9.0 age_version=1.2.0

$ sops-safe.sh detect-age-identity (operator-managed file)
age_identity_present=yes source=file

$ sops-safe.sh with-age-key file ... -- sops --decrypt secret.enc.yaml
exit=0 decrypted_stdout_bytes=0

$ sops-safe.sh with-age-key bws project-fixture -- sops --decrypt secret.enc.yaml
exit=0 decrypted_stdout_bytes=0

$ sops-safe.sh with-age-key file ... -- env sops --decrypt secret.enc.yaml
exit=2
sops-safe: with-age-key accepts direct sops decrypt, encrypt, edit, updatekeys, or rotate commands only
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c14ef15797a77e14544e6c34c1e9ff47c62c6848","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Rebase** - 1 warning</summary>

- ⚠️ `.agents/skills/bws/SKILL.md` - branch carries 1 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (34 file(s)) into the PR:
- f15b59e Add public bws skill with firstmate stub for dual-surface loading (#1)

Push main to origin, or rebase your branch onto origin/main, before gating.

🔧 Fix applied.
1 warning still open:
- ⚠️ `.agents/skills/bws/SKILL.md` - branch carries 1 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (34 file(s)) into the PR:
- f15b59e Add public bws skill with firstmate stub for dual-surface loading (#1)

Push main to origin, or rebase your branch onto origin/main, before gating.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (4) ✅</summary>

- 🚨 `skills/sops-age/scripts/sops-safe.sh:120` - Intent requires “Never print, log…decrypted values,” but the advertised `redact-output` workflow passes through ordinary secret fields such as `database_url: plaintext`, JSON values, and nested `stringData` entries unchanged. Replace this unsafe allowlist-style redaction at the earliest shared output boundary, or prohibit relaying decrypted output entirely and expose only structurally derived metadata.
- 🚨 `skills/sops-age/SKILL.md:112` - Intent requires “explicit authority for…any operation that changes files,” but this section classifies decrypt-for-verification as needing no extra authority while lines 146–151 permit creating and deleting decrypted temporary files. Distinguish stdout-only verification from file-writing decrypts and require explicit authority for the latter.
- 🚨 `docs/documentation-audiences.json:383` - The repository&#39;s machine-checked documentation inventory was updated for `bws` but omits both new SOPS Markdown surfaces. The existing audience checker enumerates every tracked Markdown file, so it will reject `.agents/skills/sops-age/SKILL.md` and `skills/sops-age/SKILL.md` as unclassified; add agent-runtime and public-product entries respectively.

🔧 Fix: Harden SOPS output and mutation safety
1 error still open:
- 🚨 `skills/sops-age/scripts/sops-safe.sh:145` - The required “Never print, log…decrypted values” invariant remains reachable: `with-age-key` forwards the child’s stdout unchanged, so an otherwise authorized `with-age-key … -- sops --decrypt file` invocation prints plaintext unless every caller remembers `&gt;/dev/null`. This also contradicts the helper’s own `Never prints … decrypted secret values` contract. Enforce suppression at the shared wrapper boundary for decrypt commands, or narrow the helper’s contract and remove the claim that it prevents such output.

🔧 Fix: Suppress decrypted output at wrapper boundary
1 error still open:
- 🚨 `skills/sops-age/scripts/sops-safe.sh:163` - The required “Never print, log…decrypted values” invariant remains bypassable because suppression only recognizes commands whose first executable is `sops`. Supported invocations such as `with-age-key file KEY -- env sops --decrypt secret.yaml` or a trusted shell child still relay plaintext stdout. Enforce suppression at the wrapper’s shared child-output boundary, or restrict `with-age-key` to direct commands that can be classified safely.

🔧 Fix: Restrict age-key wrapper to safe direct operations
1 error still open:
- 🚨 `skills/sops-age/scripts/sops-safe.sh:140` - The required “Never print, log…decrypted values” invariant remains bypassable because classification returns on the first operation-looking argument anywhere in argv. For example, `with-age-key file KEY -- sops encrypt --decrypt` classifies the positional filename `encrypt` as encryption and forwards stdout, while SOPS can interpret `--decrypt` as the operation and emit plaintext. Accept only an unambiguous canonical command shape and reject conflicting or later operation markers before deciding whether stdout may be forwarded.

🔧 Fix: Reject ambiguous SOPS operation ordering
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/sops-safe.test.sh`
- <code>Manual synthetic-tool workflow via `/tmp/no-mistakes-evidence/01M0A714XXG7RFM022JCH9NHHC/verify-sops-age.sh`</code>
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
