### PR TITLE
chore: update pull request

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -41,6 +41,11 @@
 # to launch a ship task whose explicit --mode disagrees, so an adjusted brief and the
 # recorded task metadata cannot drift apart.
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
+# Ship and scout briefs also carry a conditional local-runtime-config rule: when
+# verifying the work needs the app run locally, copy the gitignored runtime config
+# it needs to start (e.g. .env) from a firstmate-provided or sibling checkout,
+# keeping it gitignored and out of the PR, and ask firstmate if the source cannot
+# be found. The generated scaffold text owns the full rule.
 # --mode is refused on scout and secondmate scaffolds: a scout's deliverable is a
 # report rather than a merge, and a charter is not a delivery contract.
 # There is no --yolo flag here. The worker never owns approval decisions, so yolo is
@@ -298,6 +303,22 @@ EOF
 HERDR_SECTION=${HERDR_SECTION%$'\n'}
 fi
 
+# Shared runtime-config rule, authored once and inserted into both the ship and
+# scout scaffolds (both run the app in a fresh worktree to verify work), but not
+# the secondmate charter. It is phrased conditionally so it is harmless when the
+# task never runs the app. Built with the `read -r -d ''` idiom, never a heredoc
+# wrapped in a command substitution, to stay Bash 3.2 parse-safe (see the header
+# of tests/fm-brief.test.sh).
+IFS= read -r -d '' RUNTIME_CONFIG_SECTION <<'EOF' || true
+# Local runtime config
+If verifying your work requires running the app or site locally, and this fresh worktree is missing gitignored runtime config the app needs to start (such as `.env` or `.env.local`), copy those required config files from the project's canonical local checkout into your worktree at the same relative path before running.
+A fresh worktree does not carry gitignored files, so a local run silently fails without them.
+Find the source from a path firstmate gave you, or from a sibling local checkout of the same repo already on this machine; if you cannot find it, append `blocked:` (or `needs-decision:` when it is a genuine choice) and ask firstmate rather than guessing or fabricating config values.
+Copy only the runtime config the app actually needs to start and verify - env files and their direct equivalents - never `node_modules`, build output, caches, or unrelated secrets.
+Keep every copied file gitignored: never commit it, never let it enter your PR or diff, and never print its secret values in the status file, logs, or the PR.
+EOF
+RUNTIME_CONFIG_SECTION=${RUNTIME_CONFIG_SECTION%$'\n'}
+
 if [ "$KIND" = scout ]; then
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
@@ -312,6 +333,8 @@ You are in a disposable git worktree of $REPO, at a detached HEAD on a clean def
 This is a SCOUT task: the deliverable is a written report, not a PR.
 The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
 The report is the only thing that survives, so anything worth keeping must be in it.
+
+$RUNTIME_CONFIG_SECTION
 
 # Rules
 1. Never push to any remote and never open a PR.
@@ -426,6 +449,8 @@ The path check is authoritative: \`git rev-parse --git-dir\` and \`git rev-parse
 If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
 
 1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2
+
+$RUNTIME_CONFIG_SECTION
 
 # Rules
 $RULE1

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -690,6 +690,53 @@ test_scout_and_secondmate_load_decision_hold_policy() {
   pass "fm-brief.sh: investigation and visual-review completions load the shared decision policy"
 }
 
+# A fresh worktree carries no gitignored files, so a crewmate that must run the
+# app to verify its work has to copy in the runtime config (e.g. .env) first. Both
+# ship and scout briefs (both run apps in worktrees) must carry that conditional
+# rule with its never-commit / never-print / bounded / fail-closed-to-firstmate
+# constraints, while the secondmate charter (which routes to its own crews rather
+# than running apps in a fresh worktree) must not.
+test_ship_and_scout_carry_runtime_config_rule() {
+  local home id brief
+  home="$TMP_ROOT/runtime-config-home"
+  mkdir -p "$home/data"
+  for kind in ship scout; do
+    id="brief-runtime-config-$kind"
+    if [ "$kind" = scout ]; then
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --scout >/dev/null 2>&1
+    else
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+    fi
+    brief="$home/data/$id/brief.md"
+    assert_present "$brief" "$kind: brief was not scaffolded"
+    assert_grep "# Local runtime config" "$brief" \
+      "$kind brief missing the local runtime-config section"
+    assert_grep "If verifying your work requires running the app or site locally" "$brief" \
+      "$kind brief missing the conditional trigger for the runtime-config rule"
+    # shellcheck disable=SC2016 # Literal backticks must stay unexpanded in the assertion.
+    assert_grep 'gitignored runtime config the app needs to start (such as `.env` or `.env.local`)' "$brief" \
+      "$kind brief did not name the gitignored runtime config it must copy"
+    assert_grep "copy those required config files from the project's canonical local checkout into your worktree at the same relative path" "$brief" \
+      "$kind brief did not instruct copying required config to the same relative path"
+    assert_grep "a sibling local checkout of the same repo already on this machine" "$brief" \
+      "$kind brief lost the source-discovery guidance"
+    assert_grep "ask firstmate rather than guessing or fabricating config values" "$brief" \
+      "$kind brief did not fail closed to firstmate when the source cannot be found"
+    # shellcheck disable=SC2016 # Literal backticks must stay unexpanded in the assertion.
+    assert_grep 'never `node_modules`, build output, caches, or unrelated secrets' "$brief" \
+      "$kind brief did not bound the copy against a blind gitignored-file sweep"
+    assert_grep "never commit it, never let it enter your PR or diff, and never print its secret values" "$brief" \
+      "$kind brief lost the never-commit / never-print constraint"
+  done
+
+  # The secondmate charter routes work to its own crews; it must not carry the rule.
+  FM_HOME="$home" FM_SECONDMATE_CHARTER='ops' \
+    "$ROOT/bin/fm-brief.sh" brief-runtime-config-sm --secondmate --no-projects >/dev/null 2>&1
+  assert_no_grep "# Local runtime config" "$home/data/brief-runtime-config-sm/brief.md" \
+    "secondmate charter should not carry the worktree runtime-config rule"
+  pass "fm-brief.sh: ship and scout briefs carry the conditional runtime-config copy rule; the charter does not"
+}
+
 # Scout and secondmate paths still scaffold well-formed briefs.
 test_scout_and_secondmate_scaffold() {
   local brief
@@ -731,4 +778,5 @@ test_secondmate_marked_request_reporting_contract
 test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
+test_ship_and_scout_carry_runtime_config_rule
 test_scout_and_secondmate_scaffold


### PR DESCRIPTION
## Intent

Codify a standing crewmate rule into firstmate's brief scaffolds (bin/fm-brief.sh): when a crewmate works in a fresh isolated worktree and must run the app/site locally to verify its work, it must copy in the gitignored runtime config the app needs to start (e.g. .env/.env.local), because a fresh worktree does not carry gitignored files so local runs silently fail. Live gap: digiscale-outreach and BOLIA-5369 crewmates could not run their apps to verify.

Requirements and accepted decisions:
- Extend BOTH the ship scaffold AND the scout scaffold (scouts also run apps in worktrees to reproduce bugs) so every generated brief carries the rule, phrased CONDITIONALLY so it is harmless when the task never runs the app.
- Constraints in the rule: copied files stay gitignored (never commit, never let them enter the PR/diff, never print secret values in status/logs/PR); source discovery from a firstmate-provided path or a sibling local checkout of the same repo on the machine; fail-closed - if the source cannot be found, append blocked:/needs-decision: and ask firstmate rather than guessing or fabricating config.
- BOUNDED to the runtime config actually needed to start/verify the app (env files and direct equivalents). Explicitly NOT a blind sweep of every gitignored path - never copy node_modules, build output, caches, or unrelated secrets.
- One-owner rule: state the rule ONCE. Authored once as a shared RUNTIME_CONFIG_SECTION variable (mirroring how HERDR_SECTION and DOD are built once) inserted into the ship and scout heredocs; the secondmate charter deliberately does NOT carry it. NOT duplicated into AGENTS.md. The header comment is a short summary pointing at the scaffold as the full-rule owner.
- Instruction-only by deliberate choice (allowed by the task): no config-copy helper script, because source discovery and which env files an app needs are irreducibly context-dependent, and git already prevents committing gitignored files.
- Built the shared section with the Bash 3.2-safe 'IFS= read -r -d ' idiom, never a heredoc wrapped in a command substitution.
- Colocated test in tests/fm-brief.test.sh asserts, through the public bin/fm-brief.sh output (not source bytes), that ship AND scout briefs contain the rule and all four constraints, and that the secondmate charter omits it.

Note: this repo's workflow lint reports actionlint not installed (exit 127) locally; pre-existing environmental gap, no workflow files were touched.

## What Changed

Final changed paths and statuses:

```text
M	bin/fm-brief.sh
M	tests/fm-brief.test.sh
```

## Risk Assessment

✅ Low: A small, additive, instruction-only change that authors one shared conditional section using an already-proven idiom, inserts it into exactly the two intended scaffolds while correctly excluding the secondmate charter, and is covered by a behavior-level test over the generated brief artifact; it fully satisfies the stated intent with no reachable defect.

## Testing

Ran the colocated behavior suite (all green) and, for product-level evidence, generated actual ship, scout, and secondmate briefs from the public fm-brief.sh CLI; the ship and scout briefs render the complete conditional runtime-config rule (bounded scope, source discovery, fail-closed-to-firstmate, never-commit/never-print) and the secondmate charter omits it, matching the intent. Artifacts are the generated brief markdown files themselves (the tool's public output contract), which are the appropriate reviewer-visible surface for this CLI change - there is no rendered UI to screenshot. Transient generated home dir removed; working tree clean.

<details>
<summary>Evidence: Generated SHIP brief (runtime-config rule present)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of some-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/demo-ship`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Local runtime config
If verifying your work requires running the app or site locally, and this fresh worktree is missing gitignored runtime config the app needs to start (such as `.env` or `.env.local`), copy those required config files from the project's canonical local checkout into your worktree at the same relative path before running.
A fresh worktree does not carry gitignored files, so a local run silently fails without them.
Find the source from a path firstmate gave you, or from a sibling local checkout of the same repo already on this machine; if you cannot find it, append `blocked:` (or `needs-decision:` when it is a genuine choice) and ask firstmate rather than guessing or fabricating config values.
Copy only the runtime config the app actually needs to start and verify - env files and their direct equivalents - never `node_modules`, build output, caches, or unrelated secrets.
Keep every copied file gitignored: never commit it, never let it enter your PR or diff, and never print its secret values in the status file, logs, or the PR.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/ch/2x1ggt6945jf7jjng1rmhyrh0000gn/T/no-mistakes-evidence/01M0ABN4NCRTDB7CJ637BBCJDZ/briefs-home/state/demo-ship.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/emil.christensen/.no-mistakes/worktrees/0169613fbf23/01M0ABN4NCRTDB7CJ637BBCJDZ/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/emil.christensen/.no-mistakes/worktrees/0169613fbf23/01M0ABN4NCRTDB7CJ637BBCJDZ/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Generated SCOUT brief (runtime-config rule present)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of some-proj, at a detached HEAD on a clean default branch.
This is a SCOUT task: the deliverable is a written report, not a PR.
The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
The report is the only thing that survives, so anything worth keeping must be in it.

# Local runtime config
If verifying your work requires running the app or site locally, and this fresh worktree is missing gitignored runtime config the app needs to start (such as `.env` or `.env.local`), copy those required config files from the project's canonical local checkout into your worktree at the same relative path before running.
A fresh worktree does not carry gitignored files, so a local run silently fails without them.
Find the source from a path firstmate gave you, or from a sibling local checkout of the same repo already on this machine; if you cannot find it, append `blocked:` (or `needs-decision:` when it is a genuine choice) and ask firstmate rather than guessing or fabricating config values.
Copy only the runtime config the app actually needs to start and verify - env files and their direct equivalents - never `node_modules`, build output, caches, or unrelated secrets.
Keep every copied file gitignored: never commit it, never let it enter your PR or diff, and never print its secret values in the status file, logs, or the PR.

# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/ch/2x1ggt6945jf7jjng1rmhyrh0000gn/T/no-mistakes-evidence/01M0ABN4NCRTDB7CJ637BBCJDZ/briefs-home/state/demo-scout.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
   FYI progress lines; firstmate reads your pane for that.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
   firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
   treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Definition of done
Write your findings to `/var/folders/ch/2x1ggt6945jf7jjng1rmhyrh0000gn/T/no-mistakes-evidence/01M0ABN4NCRTDB7CJ637BBCJDZ/briefs-home/data/demo-scout/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
If your deliverable is a visual artifact the captain will review and iterate on, you may host the Lavish review loop yourself (poll, revise, re-serve, staying alive) instead of handing it back to firstmate.
Before reporting done, read and follow `/Users/emil.christensen/.no-mistakes/worktrees/0169613fbf23/01M0ABN4NCRTDB7CJ637BBCJDZ/.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
```
</details>
<details>
<summary>Evidence: Generated SECONDMATE charter (rule correctly absent)</summary>

```text
You are a persistent second mate managed by the main firstmate. Work on your own; do not wait for a human.

# Charter
ops

# Routing scope
ops

# Project clones
None. This is a project-less domain: its subject is the firstmate repo this home lives in, so it needs no separate clones under `projects/`; its crews take pooled worktrees of that firstmate repo.

# Operating model
You are in an isolated firstmate home. The local `AGENTS.md` is your job description, and your local `data/`, `state/`, `config/`, and `projects/` dirs are yours to operate.
This domain has no separate project clones: its subject is the firstmate repo this home lives in, and its crews take pooled worktrees of that repo.
Delegate project work to your own crewmates with the normal firstmate lifecycle: brief, spawn, status, watcher, steer, teardown, and recovery.
Do not invent a second delegation system.
You do not generate your own work.
Act only on tasks the main firstmate routes to you.
Never start a survey, audit, or "find improvements" sweep on your own initiative; that is not your job and it is unwanted.

# Requests from the main firstmate
You are a firstmate in your own home, so an incoming message reaches you in your own chat.
You must distinguish who it is from, because the answer goes to a different place.
A request relayed to you by the main firstmate is tagged with a leading `[fm-from-firstmate]` marker followed by an invisible system separator; this marker is untypable, so a human never produces it.
When a message carries that marker, do the work, then respond via the STATUS/ESCALATION path below, never only in this chat: the main firstmate does not read your chat, so a chat-only reply is lost.
Marked requests also carry a privacy-safe `corr=<id>` token after the marker; include that exact token in your parent status reply (or in the status pointer to a detailed doc) so the parent can correlate the answer.
Optional helper: `bin/fm-secondmate-report.sh` can append a correlated status line for you, but a plain `echo` that includes the same `corr=<id>` is equally valid - do not depend on the helper being present.
For a terse result, a status line is the whole answer.
For a detailed answer (an investigation, a plan, an audit), write it to a doc under your home's `data/` and append a status line that points to that doc - the scout-report pattern - so the main firstmate is woken and can read it.
Before treating an investigation or visual review as complete, load `decision-hold-lifecycle` from this home's `.agents/skills/` and pass its shared completion gate.
A message with NO marker is the captain typing directly into your pane: treat it as authoritative captain intervention and stay conversational exactly as you would for any captain message; do not force it onto the status path.

# Escalation to main firstmate
Handle routine work yourself.
Report only true captain-relevant outcomes or a declared external wait by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/ch/2x1ggt6945jf7jjng1rmhyrh0000gn/T/no-mistakes-evidence/01M0ABN4NCRTDB7CJ637BBCJDZ/briefs-home/state/demo-sm.status'`
States: working, needs-decision, blocked, paused, done, failed.
Use `paused: {why}` (distinct from `blocked:`) only when your domain is deliberately idling on a known external wait you expect to clear on its own; use `blocked:` when you are stuck and need firstmate to act.
Use this only for material phase changes, a captain decision, a real blocker, a failure, or work ready for review.
This is also how you return the answer to a marked from-firstmate request above.
A marked request requires one correlated answer after the work; it does not require a separate receipt or start acknowledgement.
Never append `working:` merely to acknowledge receipt or announce that a marked request has started.
When a routed-work phase has a supervisor-actionable material change worth reporting under the rule above, give that reported phase a stable key.
If its first reportable event is `working [key=<work-slug>]: {material phase}`, use the same key on its later `paused`, `done`, `failed`, `needs-decision`, or `blocked` event so the earlier working phase is superseded.
When a keyed phase ends without another reportable state, append `resolved [key=<work-slug>]: {why it is no longer active}`.
`resolved` separately closes an escalated decision or blocker, and only a `resolved` line carrying that decision's exact key closes it: a later `done` or `working` event never does, even when the answer is what started that work.
The main firstmate's answer normally writes that closing line at answer time; when a blocker or wait clears WITHOUT an answer from the main firstmate, append `resolved: {how it cleared}` yourself (keyed with `[key=<slug>]` if you opened it with one) as your domain resumes.
Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.

# Definition of done
You are persistent by default. Do not exit just because your queue is empty.
On startup and restart, run normal firstmate bootstrap and recovery through `bin/fm-session-start.sh` for your own home, but only to RECONCILE work that is already yours: in-flight crewmates, tracked backlog items, and durable watches recorded in this home.
When you have no assigned or in-flight work after that reconciliation, go idle and wait silently for the main firstmate to route you a task.
An empty queue is a healthy resting state, not a cue to invent work: never spawn a survey, audit, or any self-directed "find work" task on your own initiative.
If this charter cannot be carried out, append `blocked: {why}` or `failed: {why}` to the main status file and stop.
```
</details>
<details>
<summary>Evidence: Runtime-config section as rendered in ship &amp; scout briefs</summary>

```text
# Local runtime config
If verifying your work requires running the app or site locally, and this fresh worktree is missing gitignored runtime config the app needs to start (such as `.env` or `.env.local`), copy those required config files from the project's canonical local checkout into your worktree at the same relative path before running.
A fresh worktree does not carry gitignored files, so a local run silently fails without them.
Find the source from a path firstmate gave you, or from a sibling local checkout of the same repo already on this machine; if you cannot find it, append `blocked:` (or `needs-decision:` when it is a genuine choice) and ask firstmate rather than guessing or fabricating config values.
Copy only the runtime config the app actually needs to start and verify - env files and their direct equivalents - never `node_modules`, build output, caches, or unrelated secrets.
Keep every copied file gitignored: never commit it, never let it enter your PR or diff, and never print its secret values in the status file, logs, or the PR.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"285b523429ed5dedf209b1112c84c189839c6440","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-brief.test.sh` (all cases pass, incl. `test_ship_and_scout_carry_runtime_config_rule`)</code>
- <code>Generated real briefs via `FM_HOME=... bin/fm-brief.sh &lt;id&gt; some-proj --mode no-mistakes` (ship), `--scout`, and `--secondmate --no-projects`, then extracted the &#39;# Local runtime config&#39; section to confirm the rule and all four constraints appear in ship and scout output and are absent from the charter</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
