### PR TITLE
feat(brief): make PR bodies open with a beneficiary TLDR

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -362,6 +362,8 @@ Delivery contract: mode=direct-PR
 This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
 When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
+Open the PR body with a short bullet TLDR before any detail, each bullet naming who the change serves and what it protects or gives them: \`- We introduced a launch-time isolation check to protect the captain's own copy of the repo from a worker committing into it.\`
+Detail may follow underneath, but it may not come first and it may not be the whole body.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
     ;;
@@ -393,6 +395,8 @@ You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
 When starting no-mistakes, make \`--intent\` preserve all relevant content from this brief's \`# Task\` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
+The pipeline generates the PR body from its own template, so you cannot set that body's final shape from here; what you do control is the material you feed it.
+Write your \`--intent\` and change summary so they lead with who each change serves and what it protects or gives them ("we introduced X to protect / to give Y"), which is as far as this contract reaches.
 
 Two firstmate-specific rules layer on top of that guidance:
 - ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -319,6 +319,35 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
   pass "fm-brief.sh: faster paths use configured authority without stacked review"
 }
 
+# The captain reads PR bodies as the merge authority, so both PR-raising modes
+# must carry the TLDR contract, and local-only (which raises no PR) must not.
+test_pr_body_tldr_contract() {
+  local home id brief
+  home="$TMP_ROOT/tldr-home"
+  mkdir -p "$home/data"
+  id="brief-tldr-c1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode direct-PR >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep "Open the PR body with a short bullet TLDR before any detail" "$brief" \
+    "direct-PR brief lost the PR-body TLDR contract"
+  assert_grep "We introduced a launch-time isolation check to protect" "$brief" \
+    "direct-PR TLDR contract lost its worked example"
+  id="brief-tldr-c2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep "you cannot set that body's final shape from here" "$brief" \
+    "no-mistakes brief must state the template limitation plainly"
+  assert_grep "which is as far as this contract reaches" "$brief" \
+    "no-mistakes brief lost the honest reach of the TLDR framing"
+  assert_no_grep "Open the PR body with a short bullet TLDR" "$brief" \
+    "no-mistakes brief must not claim control of the pipeline-generated body"
+  id="brief-tldr-c3"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode local-only >/dev/null 2>&1
+  assert_no_grep "TLDR" "$home/data/$id/brief.md" \
+    "local-only raises no PR and must not carry a PR-body contract"
+  pass "fm-brief.sh: PR-raising modes carry the PR-body TLDR contract"
+}
+
 # Pin the specific line the bug lived on: the no-mistakes DOD's no-mistakes
 # reference must render as plain prose with no dangling apostrophe artifact.
 test_no_mistakes_dod_wording() {
@@ -721,6 +750,7 @@ test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
+test_pr_body_tldr_contract
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path


### PR DESCRIPTION
## TLDR

- We introduced a required TLDR at the top of every PR body to give the captain, who is the merge authority on every project, a body they will actually read before approving a merge.
- We introduced a fixed "who it serves and what it protects" shape for those bullets to protect reviewers from bodies written from the change's own point of view, which is the specific reason the current ones go unread.
- We introduced a worked one-line example rather than a paragraph of explanation to protect the brief scaffold from growing harder to read while fixing a communication problem.
- We introduced a plainly stated limit on the no-mistakes variant to protect the contract's credibility, since the pipeline owns that PR body's final shape and the brief must not imply otherwise.
- We introduced a regression test over the generated briefs to give the fleet confidence that all three delivery modes keep exactly the contract intended for each.

## Detail

`bin/fm-brief.sh` previously said only "push your branch and open a PR with `gh-axi`" and gave no guidance on the body at all. That silence is what this change fixes.

**direct-PR** is where a worker writes the body itself, so the contract lands in full: open with a short bullet TLDR before any detail, each bullet naming who the change serves and what it protects or gives them, with one concrete worked example inline. Detail may follow underneath, but it may not come first and it may not be the whole body.

**no-mistakes** is where the contract can only reach partway, and the brief now says so rather than implying a guarantee it cannot make. The pipeline generates the body from its own template (`## What Changed`, `## Risk Assessment`, `## Testing`, `## Pipeline`), which no-mistakes owns, not firstmate. What the worker does control is the `--intent` and change summary it feeds in, so the brief directs those to lead with the beneficiary framing and states that this is as far as the contract reaches. Nothing here tries to defeat or post-process the template.

**local-only** raises no PR and is deliberately untouched.

Four lines were added to the scaffold in total.

## Testing

- `tests/fm-brief.test.sh` gains `test_pr_body_tldr_contract`, asserting the contract and its worked example in direct-PR, the limitation wording in no-mistakes, that no-mistakes does not claim control of the generated body, and that local-only carries no PR-body contract at all. All 21 tests in the file pass.
- `bin/fm-lint.sh` is clean (ShellCheck 0.11.0, actionlint 1.7.12).
- This PR's own body is written to the new contract, as its first test.
